### PR TITLE
metrics: scope host metrics to data and cache devices

### DIFF
--- a/src/v/metrics/BUILD
+++ b/src/v/metrics/BUILD
@@ -20,6 +20,7 @@ redpanda_cc_library(
         "//src/v/config",
         "//src/v/ssx:future_util",
         "//src/v/ssx:sformat",
+        "//src/v/utils:device_utils",
         "//src/v/utils:file_io",
         "//src/v/utils:hdr_hist",
         "@abseil-cpp//absl/container:flat_hash_map",

--- a/src/v/metrics/host_metrics_watcher.cc
+++ b/src/v/metrics/host_metrics_watcher.cc
@@ -53,6 +53,15 @@ struct resolved_devices {
     std::vector<diskstats_entry> partitions;
     std::vector<diskstats_entry> disks;
     std::unordered_set<ss::sstring> filter;
+
+    // Per-directory resolution results (empty string if resolution failed)
+    ss::sstring data_device;
+    ss::sstring cache_device;
+
+    // Filesystem device IDs (st_dev) for data/cache directories, used to look
+    // up Seastar IO queues. 0 if resolution failed.
+    dev_t data_dev_id{0};
+    dev_t cache_dev_id{0};
 };
 
 namespace {
@@ -161,6 +170,7 @@ host_metrics_watcher::host_metrics_watcher(
       [this]() { setup_snmp_metrics(); });
 
     setup_io_queue_config_metrics(devices.partitions);
+    setup_info_metric(devices);
 }
 
 void host_metrics_watcher::setup_diskstats_metrics(
@@ -538,10 +548,13 @@ resolved_devices host_metrics_watcher::resolve_monitored_devices(
     };
 
     if (data) {
+        result.data_device = data->partition;
         add_entry(result.partitions, data->partition, data->disk, true, false);
         add_entry(result.disks, data->disk, {}, true, false);
     }
     if (cache) {
+        result.cache_device = cache->partition;
+        result.cache_dev_id = cache->dev_id;
         add_entry(
           result.partitions, cache->partition, cache->disk, false, true);
         add_entry(result.disks, cache->disk, {}, false, true);
@@ -679,6 +692,47 @@ void host_metrics_watcher::setup_io_queue_config_metrics(
               labels),
           });
     }
+}
+
+void host_metrics_watcher::setup_info_metric(const resolved_devices& devices) {
+    // Constant gauge (always 1) with labels describing the host metrics
+    // configuration. Useful for joining with other metrics in dashboards.
+    auto data_resolved = !devices.data_device.empty();
+    auto cache_resolved = !devices.cache_device.empty();
+    auto same_partition = data_resolved && cache_resolved
+                          && devices.data_device == devices.cache_device;
+
+    // Check if the data dir has a non-default IO queue (id > 0 means
+    // explicit io-properties were provided for this device).
+    bool data_has_io_queue = false;
+    if (data_resolved) {
+        try {
+            auto& queue = ss::engine().get_io_queue(devices.data_dev_id);
+            data_has_io_queue = queue.get_config().id > 0;
+        } catch (...) {
+            // No IO queue for this device — leave as false
+        }
+    }
+
+    auto lbl = [](const char* name) { return seastar::metrics::label(name); };
+
+    const std::vector<seastar::metrics::label_instance> labels = {
+      lbl("data_device")(data_resolved ? devices.data_device : ""),
+      lbl("cache_device")(cache_resolved ? devices.cache_device : ""),
+      lbl("data_resolved")(data_resolved ? "1" : "0"),
+      lbl("cache_resolved")(cache_resolved ? "1" : "0"),
+      lbl("same_partition")(same_partition ? "1" : "0"),
+      lbl("data_has_io_queue")(data_has_io_queue ? "1" : "0"),
+    };
+
+    _metrics.add_group(
+      "host_metrics",
+      {seastar::metrics::make_gauge(
+        "info",
+        [] { return 1; },
+        seastar::metrics::description(
+          "Host metrics configuration info (constant 1)"),
+        labels)});
 }
 
 } // namespace metrics

--- a/src/v/metrics/host_metrics_watcher.cc
+++ b/src/v/metrics/host_metrics_watcher.cc
@@ -434,6 +434,36 @@ void host_metrics_watcher::parse_snmp(
     snmp_stats.tcp_established = snmp_map["Tcp:"]["CurrEstab"];
 }
 
+namespace {
+
+// Blocking read of an entire /proc file into a string.
+//
+// We use blocking reads because you can't do dma_reads into /proc.
+// Reading from /proc should never block so this should be ~fine~.
+// From tracing the calls take less than 100us generally.
+//
+// /proc seq_files may return partial results from a single pread,
+// so we loop until we get everything.
+std::string read_proc_file(ss::file_desc& fd) {
+    static constexpr size_t chunk_size = 4096;
+    std::string result;
+
+    for (;;) {
+        auto prev_size = result.size();
+        result.resize(prev_size + chunk_size);
+        auto bytes_read = fd.pread(
+          result.data() + prev_size, chunk_size, prev_size);
+        result.resize(prev_size + bytes_read);
+        if (bytes_read == 0) {
+            break;
+        }
+    }
+
+    return result;
+}
+
+} // namespace
+
 template<typename StatsWrapper, typename ParseF>
 void refresh_stats(StatsWrapper& stats, ss::logger& logger, ParseF parsef) {
     if (stats.errored) {
@@ -445,17 +475,7 @@ void refresh_stats(StatsWrapper& stats, ss::logger& logger, ParseF parsef) {
     }
 
     try {
-        // These files aren't really big (2KiB max) so we just use a single
-        // buffer and don't dynamically read the full thing.
-        std::array<char, 16384> read_buffer;
-
-        // We are doing a blocking read here this is because you can't do
-        // dma_reads into /proc. Reading from /proc should never block so this
-        // should be ~fine~. From tracing the calls take less than 100us
-        // generally.
-        auto bytes_read = stats.fd->pread(
-          read_buffer.data(), read_buffer.size(), 0);
-        auto lines = std::string_view(read_buffer.data(), bytes_read);
+        auto lines = read_proc_file(*stats.fd);
 
         parsef(lines);
 

--- a/src/v/metrics/host_metrics_watcher.cc
+++ b/src/v/metrics/host_metrics_watcher.cc
@@ -135,7 +135,9 @@ host_metrics_watcher::host_metrics_watcher(
   const ss::sstring& data_directory,
   const ss::sstring& cache_directory)
   : _logger(log) {
-    if (!config::shard_local_cfg().enable_host_metrics()) {
+    if (
+      config::shard_local_cfg().disable_metrics()
+      || !config::shard_local_cfg().enable_host_metrics()) {
         return;
     }
 

--- a/src/v/metrics/host_metrics_watcher.cc
+++ b/src/v/metrics/host_metrics_watcher.cc
@@ -690,6 +690,21 @@ void host_metrics_watcher::setup_io_queue_config_metrics(
               seastar::metrics::description(
                 "Configured write IOPS from io-properties"),
               labels),
+
+            seastar::metrics::make_gauge(
+              "max_cost_function",
+              [v = cfg.max_cost_function] { return v ? 1 : 0; },
+              seastar::metrics::description(
+                "IO cost function mode: 1 = max(iops, throughput), "
+                "0 = sum(iops, throughput)"),
+              labels),
+
+            seastar::metrics::make_gauge(
+              "duplex",
+              [v = cfg.duplex] { return v ? 1 : 0; },
+              seastar::metrics::description(
+                "IO scheduler duplex mode: 0 = half-duplex, 1 = duplex"),
+              labels),
           });
     }
 }

--- a/src/v/metrics/host_metrics_watcher.cc
+++ b/src/v/metrics/host_metrics_watcher.cc
@@ -2,43 +2,90 @@
 
 #include "base/vlog.h"
 #include "config/configuration.h"
+#include "utils/device_utils.h"
 
-#include <seastar/core/abort_source.hh>
-#include <seastar/core/future.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/posix.hh>
-#include <seastar/core/sleep.hh>
-#include <seastar/util/later.hh>
 
 #include <exception>
 #include <ranges>
 #include <unordered_map>
 
+// Device label conventions used for diskstats metrics:
+//
+//   disk       - The block device associated with the series. For the default
+//                series these are generally partitions, while for the
+//                _underlying series, these are a guess at the underlying disk.
+//   underlying - For series which are associated the nearest block device
+//                (e.g., the partition), this is the best guess at the
+//                underlying disk. For example, if the disk is nvme0n1p1,
+//                underlying is nvme0n1.
+//   mountpoint - mountpoint identifying the specific Seastar io_queue,
+//                with the semantics as Seastar's mountpoint label on its own
+//                io_queue metrics.
+//                This is the mountpoint path specified in io-properties; which
+//                is not necessarily a "mount point" at all but may be any path
+//                at all. Empty mountpoint is the default io_queue (id=0).
+//   data_disk  - "1" if the series is associated with the device that contains
+//                the data directory, "0" otherwise
+//   cache_disk - "1" if the series is associated with the device that contains
+//                the cache directory, "0" otherwise
+//
 namespace metrics {
 
+// A /proc/diskstats entry we want to monitor, with role flags.
+struct diskstats_entry {
+    ss::sstring name;       // device name as it appears in /proc/diskstats
+    ss::sstring underlying; // best-guess underlying disk, empty if unknown
+    bool is_data;
+    bool is_cache;
+};
+
+// Result of resolve_monitored_devices: deduped partition and disk entries,
+// plus the union of their names for filtering /proc/diskstats.
+struct resolved_devices {
+    std::vector<diskstats_entry> partitions;
+    std::vector<diskstats_entry> disks;
+    std::unordered_set<ss::sstring> filter;
+};
+
 namespace {
+
+// sectors in diskstats are always 512-byte units
+// https://www.kernel.org/doc/Documentation/block/stat.txt
+constexpr uint64_t bytes_per_sector = 512;
+
+struct diskstats_field {
+    ss::sstring name;
+    // If present, means "name" is in sectors, expose an additional metric
+    // converted to bytes for convenience
+    std::optional<ss::sstring> bytes_name;
+};
+
+// NOLINTBEGIN(cppcoreguidelines-prefer-member-initializer,modernize-use-designated-initializers)
 static const std::
-  array<ss::sstring, host_metrics_watcher::diskstats_field_count>
-    diskstats_fields{
-      "reads",             // 0
-      "reads_merged",      // 1
-      "sectors_read",      // 2
-      "reads_ms",          // 3
-      "writes",            // 4
-      "writes_merged",     // 5
-      "sectors_written",   // 6
-      "writes_ms",         // 7
-      "io_in_progress",    // 8
-      "io_ms",             // 9
-      "io_weighted_ms",    // 10
-      "discards",          // 11
-      "discards_merged",   // 12
-      "sectors_discarded", // 13
-      "discards_ms",       // 14
-      "flushes",           // 15
-      "flushes_ms"         // 16
-    };
-}
+  array<diskstats_field, host_metrics_watcher::diskstats_field_count>
+    diskstats_fields{{
+      {"reads"},                                // 0
+      {"reads_merged"},                         // 1
+      {"sectors_read", "bytes_read"},           // 2
+      {"reads_ms"},                             // 3
+      {"writes"},                               // 4
+      {"writes_merged"},                        // 5
+      {"sectors_written", "bytes_written"},     // 6
+      {"writes_ms"},                            // 7
+      {"io_in_progress"},                       // 8
+      {"io_ms"},                                // 9
+      {"io_weighted_ms"},                       // 10
+      {"discards"},                             // 11
+      {"discards_merged"},                      // 12
+      {"sectors_discarded", "bytes_discarded"}, // 13
+      {"discards_ms"},                          // 14
+      {"flushes"},                              // 15
+      {"flushes_ms"},                           // 16
+    }};
+// NOLINTEND(cppcoreguidelines-prefer-member-initializer,modernize-use-designated-initializers)
+} // namespace
 
 template<typename StatsWrapper, typename RefreshF, typename MetricsF>
 void setup_parser(
@@ -67,26 +114,31 @@ void setup_parser(
     }
 }
 
-host_metrics_watcher::host_metrics_watcher(ss::logger& log)
+host_metrics_watcher::host_metrics_watcher(
+  ss::logger& log,
+  const ss::sstring& data_directory,
+  const ss::sstring& cache_directory)
   : _logger(log) {
     if (!config::shard_local_cfg().enable_host_metrics()) {
         return;
     }
 
-    vlog(log.info, "Setting up host metrics exporter");
+    vlog(
+      log.info,
+      "Setting up host metrics exporter, data_directory: {}, cache_directory: "
+      "{}",
+      data_directory,
+      cache_directory);
+
+    auto devices = resolve_monitored_devices(data_directory, cache_directory);
+    _monitored_devices = devices.filter;
 
     setup_parser(
       _logger,
       _diskstats,
       "/proc/diskstats",
       [this] { maybe_refresh_diskstats(); },
-      [this] {
-          // if more disks get added after startup we will be missing them.
-          // Unlikely to happen.
-          for (const auto& [diskname, _] : _diskstats.stats) {
-              setup_metrics_for_disk(diskname);
-          }
-      });
+      [this, devs = devices] { setup_diskstats_metrics(devs); });
 
     setup_parser(
       _logger,
@@ -103,28 +155,106 @@ host_metrics_watcher::host_metrics_watcher(ss::logger& log)
       [this]() { setup_snmp_metrics(); });
 }
 
-void host_metrics_watcher::setup_metrics_for_disk(const std::string& diskname) {
-    const auto& stats = _diskstats.stats[diskname];
+void host_metrics_watcher::setup_diskstats_metrics(
+  const resolved_devices& devices) {
+    // Register metrics for the given "interesting" devices, or else fall
+    // back to all.
+    if (!devices.partitions.empty() || !devices.disks.empty()) {
+        // The data and/or cache directories are resolved successfully.
+        // Monitor both partition-level (normal names)
+        // and whole-disk (underlying_ prefix). Otherwise fall back to all
+        // devices.
+        for (const auto& entry : devices.partitions) {
+            setup_diskstats_for_entry(entry, "disk", "");
+        }
+        for (const auto& entry : devices.disks) {
+            setup_diskstats_for_entry(entry, "disk", "underlying_");
+        }
+    } else {
+        // Could not resolve any devices (e.g. overlay/tmpfs filesystem).
+        // Fall back to unfiltered monitoring without role labels.
+        vlog(
+          _logger.info,
+          "No devices resolved, monitoring all {} devices from diskstats",
+          _diskstats.stats.size());
+        for (const auto& [diskname, _] : _diskstats.stats) {
+            diskstats_entry entry{
+              .name = ss::sstring(diskname),
+              .underlying = "",
+              .is_data = false,
+              .is_cache = false};
+            setup_diskstats_for_entry(entry, "disk", "");
+        }
+    }
+}
 
-    auto disk_label = seastar::metrics::label("disk");
-    const std::vector<seastar::metrics::label_instance> labels = {
-      disk_label(diskname),
+void host_metrics_watcher::setup_diskstats_for_entry(
+  const diskstats_entry& entry,
+  std::string_view label_name,
+  std::string_view metric_prefix) {
+    // Register gauges for one /proc/diskstats device. label_name controls
+    // whether the series is keyed by "device" (partition) or "disk" (whole
+    // disk), and metric_prefix prepends e.g. "underlying_" to metric names.
+    const auto& stats = _diskstats.stats[entry.name];
+
+    vlog(
+      _logger.info,
+      "Setting up diskstats metrics for '{}' ({}label, prefix='{}', "
+      "data_disk={}, cache_disk={})",
+      entry.name,
+      label_name,
+      metric_prefix,
+      entry.is_data,
+      entry.is_cache);
+
+    auto device_or_disk_label = seastar::metrics::label(
+      ss::sstring(label_name));
+    auto data_disk_label = seastar::metrics::label("data_disk");
+    auto cache_disk_label = seastar::metrics::label("cache_disk");
+    auto underlying_label = seastar::metrics::label("underlying");
+    std::vector<seastar::metrics::label_instance> labels = {
+      device_or_disk_label(entry.name),
+      data_disk_label(entry.is_data ? "1" : "0"),
+      cache_disk_label(entry.is_cache ? "1" : "0"),
     };
+    if (!entry.underlying.empty()) {
+        labels.push_back(underlying_label(entry.underlying));
+    }
 
     for (size_t i = 0; i < stats.size() && i < diskstats_fields.size(); i++) {
+        const auto& field = diskstats_fields[i];
+        auto name = fmt::format("{}{}", metric_prefix, field.name);
         _metrics.add_group(
           "host_diskstats",
           {
             seastar::metrics::make_gauge(
-              diskstats_fields[i],
+              name,
               [this, &stats, i] {
                   maybe_refresh_diskstats();
                   return stats[i];
               },
               seastar::metrics::description(
-                fmt::format("Host diskstat {}", diskstats_fields[i])),
+                fmt::format("Host diskstat {}", name)),
               labels),
           });
+
+        if (field.bytes_name) {
+            auto bytes_name = fmt::format(
+              "{}{}", metric_prefix, *field.bytes_name);
+            _metrics.add_group(
+              "host_diskstats",
+              {
+                seastar::metrics::make_gauge(
+                  bytes_name,
+                  [this, &stats, i] {
+                      maybe_refresh_diskstats();
+                      return stats[i] * bytes_per_sector;
+                  },
+                  seastar::metrics::description(
+                    fmt::format("Host diskstat {} (converted to bytes)", name)),
+                  labels),
+              });
+        }
     }
 }
 
@@ -178,7 +308,9 @@ void host_metrics_watcher::setup_snmp_metrics() {
 }
 
 void host_metrics_watcher::parse_diskstats(
-  std::string_view diskstats_lines, diskstats_map& diskstats) {
+  std::string_view diskstats_lines,
+  diskstats_map& diskstats,
+  const std::unordered_set<ss::sstring>& monitored_devices) {
     for (auto diskline : std::views::split(diskstats_lines, '\n')) {
         auto fields_view = std::views::split(diskline, ' ')
                            | std::views::filter(
@@ -192,6 +324,12 @@ void host_metrics_watcher::parse_diskstats(
         }
 
         auto diskname = fields[2];
+
+        // Filter by monitored devices if specified
+        if (
+          !monitored_devices.empty() && !monitored_devices.contains(diskname)) {
+            continue;
+        }
 
         // skip major number, minor number and diskname
         auto stat_fields = fields | std::views::drop(3);
@@ -311,7 +449,7 @@ void refresh_stats(StatsWrapper& stats, ss::logger& logger, ParseF parsef) {
 
 void host_metrics_watcher::maybe_refresh_diskstats() {
     refresh_stats(_diskstats, _logger, [this](const auto& stat_lines) {
-        parse_diskstats(stat_lines, _diskstats.stats);
+        parse_diskstats(stat_lines, _diskstats.stats, _monitored_devices);
     });
 }
 
@@ -327,4 +465,87 @@ void host_metrics_watcher::maybe_refresh_snmp() {
     });
 }
 
+resolved_devices host_metrics_watcher::resolve_monitored_devices(
+  const ss::sstring& data_directory, const ss::sstring& cache_directory) {
+    // Map data and cache directory paths to their partition and whole-disk
+    // device names. Returns deduped entry lists and a filter set for
+    // /proc/diskstats parsing.
+    resolved_devices result;
+
+    struct resolved {
+        ss::sstring partition;
+        ss::sstring disk;
+    };
+
+    auto resolve_one = [this](
+                         std::string_view label,
+                         const ss::sstring& dir) -> std::optional<resolved> {
+        try {
+            auto partition = utils::device_resolver::device_for_path(dir);
+            auto disk = utils::device_resolver::get_base_device(partition);
+            vlog(
+              _logger.info,
+              "Resolved {} '{}' to device '{}' (underlying disk '{}')",
+              label,
+              dir,
+              partition,
+              disk);
+            return resolved{std::move(partition), std::move(disk)};
+        } catch (const std::exception& e) {
+            vlog(
+              _logger.warn,
+              "Failed to resolve {} '{}' to a block device: {}. "
+              "Skipping diskstats monitoring for this path.",
+              label,
+              dir,
+              e.what());
+            return std::nullopt;
+        }
+    };
+
+    auto data = resolve_one("data directory", data_directory);
+    auto cache = resolve_one("cache directory", cache_directory);
+
+    // Helper: insert or merge into a deduped entry list and filter set
+    auto add_entry = [&result](
+                       std::vector<diskstats_entry>& entries,
+                       const ss::sstring& name,
+                       const ss::sstring& underlying,
+                       bool is_data,
+                       bool is_cache) {
+        for (auto& e : entries) {
+            if (e.name == name) {
+                e.is_data |= is_data;
+                e.is_cache |= is_cache;
+                return;
+            }
+        }
+        entries.push_back(
+          diskstats_entry{
+            .name = name,
+            .underlying = underlying,
+            .is_data = is_data,
+            .is_cache = is_cache});
+        result.filter.insert(name);
+    };
+
+    if (data) {
+        add_entry(result.partitions, data->partition, data->disk, true, false);
+        add_entry(result.disks, data->disk, {}, true, false);
+    }
+    if (cache) {
+        add_entry(
+          result.partitions, cache->partition, cache->disk, false, true);
+        add_entry(result.disks, cache->disk, {}, false, true);
+    }
+
+    if (!result.filter.empty()) {
+        vlog(
+          _logger.info,
+          "Monitoring diskstats for devices: {}",
+          fmt::join(result.filter, ", "));
+    }
+
+    return result;
+}
 } // namespace metrics

--- a/src/v/metrics/host_metrics_watcher.cc
+++ b/src/v/metrics/host_metrics_watcher.cc
@@ -471,6 +471,11 @@ void refresh_stats(StatsWrapper& stats, ss::logger& logger, ParseF parsef) {
 
 void host_metrics_watcher::maybe_refresh_diskstats() {
     refresh_stats(_diskstats, _logger, [this](const auto& stat_lines) {
+        vlog(
+          _logger.trace,
+          "Refreshing diskstats, read {} bytes, monitored_devices: [{}]",
+          stat_lines.size(),
+          fmt::join(_monitored_devices, ", "));
         parse_diskstats(stat_lines, _diskstats.stats, _monitored_devices);
     });
 }

--- a/src/v/metrics/host_metrics_watcher.cc
+++ b/src/v/metrics/host_metrics_watcher.cc
@@ -4,11 +4,17 @@
 #include "config/configuration.h"
 #include "utils/device_utils.h"
 
+#include <seastar/core/io_queue.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/posix.hh>
+#include <seastar/core/reactor.hh>
 
+#include <sys/stat.h>
+
+#include <cerrno>
 #include <exception>
 #include <ranges>
+#include <system_error>
 #include <unordered_map>
 
 // Device label conventions used for diskstats metrics:
@@ -153,6 +159,8 @@ host_metrics_watcher::host_metrics_watcher(
       "/proc/net/snmp",
       [this]() { maybe_refresh_snmp(); },
       [this]() { setup_snmp_metrics(); });
+
+    setup_io_queue_config_metrics(devices.partitions);
 }
 
 void host_metrics_watcher::setup_diskstats_metrics(
@@ -548,4 +556,129 @@ resolved_devices host_metrics_watcher::resolve_monitored_devices(
 
     return result;
 }
+
+// SPLIT_MARKER_IOQUEUE_START
+void host_metrics_watcher::setup_io_queue_config_metrics(
+  const std::vector<diskstats_entry>& partition_entries) {
+    // Export Seastar IO queue configuration (iotune bandwidth/IOPS) as metrics.
+    // Deduplicates by queue identity: multiple partition entries may share one
+    // Seastar IO queue (e.g. when no io-properties is configured), so we emit
+    // one metric series per queue with merged data_disk/cache_disk flags.
+    if (partition_entries.empty()) {
+        return;
+    }
+    struct queue_info {
+        ss::io_queue* queue;
+        ss::sstring device;
+        ss::sstring disk;
+        bool is_data{false};
+        bool is_cache{false};
+    };
+
+    std::vector<queue_info> queues;
+
+    for (const auto& entry : partition_entries) {
+        try {
+            auto dev_path = std::filesystem::path("/dev") / entry.name.c_str();
+
+            struct stat st{};
+            if (stat(dev_path.c_str(), &st) != 0) {
+                vlog(
+                  _logger.warn,
+                  "Could not stat device {} for IO queue metrics: {}",
+                  dev_path.string(),
+                  std::system_category().message(errno));
+                continue;
+            }
+
+            auto& queue = ss::engine().get_io_queue(st.st_rdev);
+
+            // Check if we already have this queue
+            auto it = std::ranges::find_if(
+              queues, [&](const auto& q) { return q.queue == &queue; });
+            if (it != queues.end()) {
+                it->is_data |= entry.is_data;
+                it->is_cache |= entry.is_cache;
+            } else {
+                queues.emplace_back(
+                  &queue,
+                  entry.name,
+                  utils::device_resolver::get_base_device(entry.name),
+                  entry.is_data,
+                  entry.is_cache);
+            }
+        } catch (...) {
+            vlog(
+              _logger.warn,
+              "Failed to lookup IO queue for device {}: {}",
+              entry.name,
+              std::current_exception());
+        }
+    }
+
+    for (const auto& qi : queues) {
+        auto cfg = qi.queue->get_config();
+
+        vlog(
+          _logger.info,
+          "Setting up IO queue config metrics for device '{}' "
+          "(disk='{}', mountpoint='{}', id={}, data_disk={}, "
+          "cache_disk={})",
+          qi.device,
+          qi.disk,
+          qi.queue->mountpoint(),
+          cfg.id,
+          qi.is_data ? 1 : 0,
+          qi.is_cache ? 1 : 0);
+
+        auto disk_label = seastar::metrics::label("disk");
+        auto device_label = seastar::metrics::label("device");
+        auto mountpoint_label = seastar::metrics::label("mountpoint");
+        auto data_disk_label = seastar::metrics::label("data_disk");
+        auto cache_disk_label = seastar::metrics::label("cache_disk");
+        auto id_label = seastar::metrics::label("id");
+
+        const std::vector<seastar::metrics::label_instance> labels = {
+          disk_label(qi.disk),
+          device_label(qi.device),
+          mountpoint_label(qi.queue->mountpoint()),
+          data_disk_label(qi.is_data ? "1" : "0"),
+          cache_disk_label(qi.is_cache ? "1" : "0"),
+          id_label(fmt::format("{}", cfg.id)),
+        };
+
+        _metrics.add_group(
+          "io_queue_config",
+          {
+            seastar::metrics::make_gauge(
+              "read_bytes_rate",
+              [v = cfg.read_bytes_rate] { return v; },
+              seastar::metrics::description(
+                "Configured read bandwidth from io-properties (bytes/sec)"),
+              labels),
+
+            seastar::metrics::make_gauge(
+              "write_bytes_rate",
+              [v = cfg.write_bytes_rate] { return v; },
+              seastar::metrics::description(
+                "Configured write bandwidth from io-properties (bytes/sec)"),
+              labels),
+
+            seastar::metrics::make_gauge(
+              "read_req_rate",
+              [v = cfg.read_req_rate] { return v; },
+              seastar::metrics::description(
+                "Configured read IOPS from io-properties"),
+              labels),
+
+            seastar::metrics::make_gauge(
+              "write_req_rate",
+              [v = cfg.write_req_rate] { return v; },
+              seastar::metrics::description(
+                "Configured write IOPS from io-properties"),
+              labels),
+          });
+    }
+}
+
 } // namespace metrics

--- a/src/v/metrics/host_metrics_watcher.cc
+++ b/src/v/metrics/host_metrics_watcher.cc
@@ -43,6 +43,7 @@ namespace metrics {
 struct diskstats_entry {
     ss::sstring name;       // device name as it appears in /proc/diskstats
     ss::sstring underlying; // best-guess underlying disk, empty if unknown
+    dev_t dev_id{0};        // device ID from stat(), 0 if unresolved
     bool is_data;
     bool is_cache;
 };
@@ -169,7 +170,8 @@ host_metrics_watcher::host_metrics_watcher(
       [this]() { maybe_refresh_snmp(); },
       [this]() { setup_snmp_metrics(); });
 
-    setup_io_queue_config_metrics(devices.partitions);
+    setup_io_queue_config_metrics(
+      devices.partitions, data_directory, cache_directory);
     setup_info_metric(devices);
 }
 
@@ -493,22 +495,26 @@ resolved_devices host_metrics_watcher::resolve_monitored_devices(
     struct resolved {
         ss::sstring partition;
         ss::sstring disk;
+        dev_t dev_id;
     };
 
     auto resolve_one = [this](
                          std::string_view label,
                          const ss::sstring& dir) -> std::optional<resolved> {
         try {
-            auto partition = utils::device_resolver::device_for_path(dir);
-            auto disk = utils::device_resolver::get_base_device(partition);
+            auto device = utils::device_resolver::device_for_path(dir);
+            auto disk = utils::device_resolver::get_base_device(device.name);
             vlog(
               _logger.info,
               "Resolved {} '{}' to device '{}' (underlying disk '{}')",
               label,
               dir,
-              partition,
+              device.name,
               disk);
-            return resolved{std::move(partition), std::move(disk)};
+            return resolved{
+              .partition = std::move(device.name),
+              .disk = std::move(disk),
+              .dev_id = device.dev_id};
         } catch (const std::exception& e) {
             vlog(
               _logger.warn,
@@ -529,6 +535,7 @@ resolved_devices host_metrics_watcher::resolve_monitored_devices(
                        std::vector<diskstats_entry>& entries,
                        const ss::sstring& name,
                        const ss::sstring& underlying,
+                       dev_t dev_id,
                        bool is_data,
                        bool is_cache) {
         for (auto& e : entries) {
@@ -542,6 +549,7 @@ resolved_devices host_metrics_watcher::resolve_monitored_devices(
           diskstats_entry{
             .name = name,
             .underlying = underlying,
+            .dev_id = dev_id,
             .is_data = is_data,
             .is_cache = is_cache});
         result.filter.insert(name);
@@ -549,15 +557,27 @@ resolved_devices host_metrics_watcher::resolve_monitored_devices(
 
     if (data) {
         result.data_device = data->partition;
-        add_entry(result.partitions, data->partition, data->disk, true, false);
-        add_entry(result.disks, data->disk, {}, true, false);
+        result.data_dev_id = data->dev_id;
+        add_entry(
+          result.partitions,
+          data->partition,
+          data->disk,
+          data->dev_id,
+          true,
+          false);
+        add_entry(result.disks, data->disk, {}, 0, true, false);
     }
     if (cache) {
         result.cache_device = cache->partition;
         result.cache_dev_id = cache->dev_id;
         add_entry(
-          result.partitions, cache->partition, cache->disk, false, true);
-        add_entry(result.disks, cache->disk, {}, false, true);
+          result.partitions,
+          cache->partition,
+          cache->disk,
+          cache->dev_id,
+          false,
+          true);
+        add_entry(result.disks, cache->disk, {}, 0, false, true);
     }
 
     if (!result.filter.empty()) {
@@ -572,14 +592,64 @@ resolved_devices host_metrics_watcher::resolve_monitored_devices(
 
 // SPLIT_MARKER_IOQUEUE_START
 void host_metrics_watcher::setup_io_queue_config_metrics(
-  const std::vector<diskstats_entry>& partition_entries) {
+  const std::vector<diskstats_entry>& partition_entries,
+  const ss::sstring& data_directory,
+  const ss::sstring& cache_directory) {
     // Export Seastar IO queue configuration (iotune bandwidth/IOPS) as metrics.
     // Deduplicates by queue identity: multiple partition entries may share one
     // Seastar IO queue (e.g. when no io-properties is configured), so we emit
     // one metric series per queue with merged data_disk/cache_disk flags.
-    if (partition_entries.empty()) {
-        return;
+    // Build a unified list of (dev_id, device label, disk label, role flags)
+    // for IO queue lookup. When partition entries are available, dev_id was
+    // resolved at startup. Otherwise fall back to stat'ing the directory paths.
+    struct lookup_entry {
+        dev_t dev_id;
+        ss::sstring name;   // human-readable name for logging
+        ss::sstring device; // device label (empty in fallback)
+        ss::sstring disk;   // disk label (empty in fallback)
+        bool is_data;
+        bool is_cache;
+    };
+
+    std::vector<lookup_entry> lookups;
+
+    if (!partition_entries.empty()) {
+        for (const auto& entry : partition_entries) {
+            lookups.push_back({
+              .dev_id = entry.dev_id,
+              .name = entry.name,
+              .device = entry.name,
+              .disk = entry.underlying,
+              .is_data = entry.is_data,
+              .is_cache = entry.is_cache,
+            });
+        }
+    } else {
+        // Device resolution failed — fall back to looking up IO queues
+        // directly from the data/cache directory paths. We won't have
+        // device or disk labels, but can still export the queue config.
+        auto try_stat_dir =
+          [&](const ss::sstring& dir, bool is_data, bool is_cache) {
+              struct stat st{};
+              if (stat(dir.c_str(), &st) != 0) {
+                  vlog(
+                    _logger.warn,
+                    "Could not stat directory {} for IO queue metrics: {}",
+                    dir,
+                    std::system_category().message(errno));
+                  return;
+              }
+              lookups.push_back({
+                .dev_id = st.st_dev,
+                .name = dir,
+                .is_data = is_data,
+                .is_cache = is_cache,
+              });
+          };
+        try_stat_dir(data_directory, true, false);
+        try_stat_dir(cache_directory, false, true);
     }
+
     struct queue_info {
         ss::io_queue* queue;
         ss::sstring device;
@@ -590,23 +660,10 @@ void host_metrics_watcher::setup_io_queue_config_metrics(
 
     std::vector<queue_info> queues;
 
-    for (const auto& entry : partition_entries) {
+    for (const auto& entry : lookups) {
         try {
-            auto dev_path = std::filesystem::path("/dev") / entry.name.c_str();
+            auto& queue = ss::engine().get_io_queue(entry.dev_id);
 
-            struct stat st{};
-            if (stat(dev_path.c_str(), &st) != 0) {
-                vlog(
-                  _logger.warn,
-                  "Could not stat device {} for IO queue metrics: {}",
-                  dev_path.string(),
-                  std::system_category().message(errno));
-                continue;
-            }
-
-            auto& queue = ss::engine().get_io_queue(st.st_rdev);
-
-            // Check if we already have this queue
             auto it = std::ranges::find_if(
               queues, [&](const auto& q) { return q.queue == &queue; });
             if (it != queues.end()) {
@@ -615,15 +672,15 @@ void host_metrics_watcher::setup_io_queue_config_metrics(
             } else {
                 queues.emplace_back(
                   &queue,
-                  entry.name,
-                  utils::device_resolver::get_base_device(entry.name),
+                  entry.device,
+                  entry.disk,
                   entry.is_data,
                   entry.is_cache);
             }
         } catch (...) {
             vlog(
               _logger.warn,
-              "Failed to lookup IO queue for device {}: {}",
+              "Failed to lookup IO queue for {}: {}",
               entry.name,
               std::current_exception());
         }

--- a/src/v/metrics/host_metrics_watcher.h
+++ b/src/v/metrics/host_metrics_watcher.h
@@ -125,6 +125,11 @@ private:
     void setup_io_queue_config_metrics(
       const std::vector<diskstats_entry>& partition_entries);
 
+    // Register a constant gauge (value 1) with labels describing the
+    // host metrics configuration: resolved device names, whether resolution
+    // succeeded, shared-partition status, and IO queue assignment.
+    void setup_info_metric(const resolved_devices& devices);
+
     ss::logger& _logger;
 
     // All device names to include when parsing /proc/diskstats.

--- a/src/v/metrics/host_metrics_watcher.h
+++ b/src/v/metrics/host_metrics_watcher.h
@@ -11,9 +11,7 @@
 
 #pragma once
 
-#include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
-#include <seastar/core/gate.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/posix.hh>
 #include <seastar/core/sstring.hh>
@@ -23,9 +21,13 @@
 #include <metrics/metrics.h>
 
 #include <cstdint>
+#include <optional>
 #include <unordered_map>
-
+#include <unordered_set>
 namespace metrics {
+
+struct diskstats_entry;
+struct resolved_devices;
 
 // Wrapper class that sets up metrics that export /proc/diskstats and a few
 // values from /proc/net/snmp. Usually this is a node_exporter job but often
@@ -59,14 +61,33 @@ public:
         uint64_t packets_sent = 0;
     };
 
-    explicit host_metrics_watcher(ss::logger& logger);
+    /// \brief Construct a host_metrics_watcher.
+    ///
+    /// Both paths are resolved to their underlying block devices at
+    /// construction time. Disk I/O metrics (diskstats) are then filtered to
+    /// only those devices. If both paths map to the same device, a single set
+    /// of metrics is emitted.
+    ///
+    /// \param logger Logger instance used for diagnostic output.
+    /// \param data_directory Path to the Redpanda data directory. The
+    ///        underlying block device is resolved and disk metrics are
+    ///        scoped to that device.
+    /// \param cache_directory Path to the Redpanda cache (tiered-storage)
+    ///        directory. Its block device is also monitored.
+    explicit host_metrics_watcher(
+      ss::logger& logger,
+      const ss::sstring& data_directory,
+      const ss::sstring& cache_directory);
 
     // needed for construct_service stuff in `application`
     ss::future<> stop() { return ss::make_ready_future(); };
 
     // parse the actual /proc/diskstats file. static method for testability
-    static void
-    parse_diskstats(std::string_view diskstats_lines, diskstats_map& stats);
+    // If monitored_devices is not empty, only devices in that set are included
+    static void parse_diskstats(
+      std::string_view diskstats_lines,
+      diskstats_map& stats,
+      const std::unordered_set<ss::sstring>& monitored_devices = {});
 
     // parse the actual /proc/net/netstat file. static method for testability
     static void
@@ -76,14 +97,34 @@ public:
     static void parse_snmp(std::string_view snmp_lines, snmp_stats& stats);
 
 private:
-    void setup_metrics_for_disk(const std::string& diskname);
+    // Register diskstats metrics for all resolved entries, or fall back to
+    // unfiltered monitoring when device resolution failed.
+    void setup_diskstats_metrics(const resolved_devices& devices);
+
+    // Register gauges for a single /proc/diskstats device. label_name
+    // selects "device" (partition) vs "disk" (whole disk); metric_prefix
+    // prepends e.g. "underlying_" to metric names for whole-disk entries.
+    void setup_diskstats_for_entry(
+      const diskstats_entry& entry,
+      std::string_view label_name,
+      std::string_view metric_prefix);
+
     void setup_netstat_metrics();
     void setup_snmp_metrics();
     void maybe_refresh_diskstats();
     void maybe_refresh_netstat();
     void maybe_refresh_snmp();
 
+    // Resolve data/cache directory paths to their partition and whole-disk
+    // device names.
+    resolved_devices resolve_monitored_devices(
+      const ss::sstring& data_directory, const ss::sstring& cache_directory);
+
     ss::logger& _logger;
+
+    // All device names to include when parsing /proc/diskstats.
+    // Union of partition and disk names. Empty means no filtering.
+    std::unordered_set<ss::sstring> _monitored_devices;
 
     template<typename Stats>
     struct metrics_file_info {

--- a/src/v/metrics/host_metrics_watcher.h
+++ b/src/v/metrics/host_metrics_watcher.h
@@ -120,6 +120,11 @@ private:
     resolved_devices resolve_monitored_devices(
       const ss::sstring& data_directory, const ss::sstring& cache_directory);
 
+    // Export Seastar IO queue config (iotune rates) as metrics, one series
+    // per unique IO queue deduped across partition entries.
+    void setup_io_queue_config_metrics(
+      const std::vector<diskstats_entry>& partition_entries);
+
     ss::logger& _logger;
 
     // All device names to include when parsing /proc/diskstats.

--- a/src/v/metrics/host_metrics_watcher.h
+++ b/src/v/metrics/host_metrics_watcher.h
@@ -123,7 +123,9 @@ private:
     // Export Seastar IO queue config (iotune rates) as metrics, one series
     // per unique IO queue deduped across partition entries.
     void setup_io_queue_config_metrics(
-      const std::vector<diskstats_entry>& partition_entries);
+      const std::vector<diskstats_entry>& partition_entries,
+      const ss::sstring& data_directory,
+      const ss::sstring& cache_directory);
 
     // Register a constant gauge (value 1) with labels describing the
     // host metrics configuration: resolved device names, whether resolution

--- a/src/v/metrics/tests/host_metrics_watcher_test.cc
+++ b/src/v/metrics/tests/host_metrics_watcher_test.cc
@@ -189,4 +189,93 @@ UdpLite: 0 0 0 0 0 0 0 0 0
     ASSERT_EQ(stats.packets_sent, 40889375);
 }
 
+TEST(DiskStatsParser, ParseDiskStatsWithFiltering) {
+    std::string_view diskstats = R""""(
+ 259       0 nvme0n1 26762678 20908 1428918348 3325593 26050590 3838657 2151727147 62187634 0 12832786 96772628 375506 274438 6540552016 27659340 958797 3600058
+ 259       1 nvme0n1p1 1182 1570 22668 1480 2 0 2 0 0 8279 9695 28 0 8307432 8215 0 0
+ 8         0 sda 1000000 1000 50000000 100000 2000000 2000 100000000 200000 0 150000 300000 500 500 25000000 10000 0 0
+ 8         1 sda1 500000 500 25000000 50000 1000000 1000 50000000 100000 0 75000 150000 250 250 12500000 5000 0 0
+ 253       0 dm-0 1217871 0 42450873 168534 6682917 0 267304519 81228952 0 9277885 127118565 66000 0 1199395944 45721079 0 0
+)"""";
+
+    // Test with no filtering (backward compatibility)
+    host_metrics_watcher::diskstats_map disk_stats_all;
+    std::unordered_set<ss::sstring> no_filter;
+    host_metrics_watcher::parse_diskstats(diskstats, disk_stats_all, no_filter);
+
+    ASSERT_EQ(disk_stats_all.size(), 5);
+    ASSERT_TRUE(disk_stats_all.contains("nvme0n1"));
+    ASSERT_TRUE(disk_stats_all.contains("nvme0n1p1"));
+    ASSERT_TRUE(disk_stats_all.contains("sda"));
+    ASSERT_TRUE(disk_stats_all.contains("sda1"));
+    ASSERT_TRUE(disk_stats_all.contains("dm-0"));
+
+    // Test with filtering for nvme0n1 only
+    host_metrics_watcher::diskstats_map disk_stats_nvme;
+    std::unordered_set<ss::sstring> nvme_filter = {"nvme0n1"};
+    host_metrics_watcher::parse_diskstats(
+      diskstats, disk_stats_nvme, nvme_filter);
+
+    ASSERT_EQ(disk_stats_nvme.size(), 1);
+    ASSERT_TRUE(disk_stats_nvme.contains("nvme0n1"));
+    ASSERT_FALSE(disk_stats_nvme.contains("nvme0n1p1"));
+    ASSERT_FALSE(disk_stats_nvme.contains("sda"));
+    ASSERT_EQ(disk_stats_nvme["nvme0n1"][0], 26762678);
+
+    // Test with filtering for multiple devices
+    host_metrics_watcher::diskstats_map disk_stats_multi;
+    std::unordered_set<ss::sstring> multi_filter = {"nvme0n1", "sda"};
+    host_metrics_watcher::parse_diskstats(
+      diskstats, disk_stats_multi, multi_filter);
+
+    ASSERT_EQ(disk_stats_multi.size(), 2);
+    ASSERT_TRUE(disk_stats_multi.contains("nvme0n1"));
+    ASSERT_TRUE(disk_stats_multi.contains("sda"));
+    ASSERT_FALSE(disk_stats_multi.contains("nvme0n1p1"));
+    ASSERT_FALSE(disk_stats_multi.contains("sda1"));
+    ASSERT_FALSE(disk_stats_multi.contains("dm-0"));
+
+    // Test with filtering for non-existent device
+    host_metrics_watcher::diskstats_map disk_stats_none;
+    std::unordered_set<ss::sstring> nonexistent_filter = {"vda"};
+    host_metrics_watcher::parse_diskstats(
+      diskstats, disk_stats_none, nonexistent_filter);
+
+    ASSERT_EQ(disk_stats_none.size(), 0);
+}
+
+TEST(DiskStatsParser, ParseDiskStatsValuesNonZero) {
+    // This test verifies that disk stats contain reasonable non-zero values
+    std::string_view diskstats = R""""(
+ 259       0 nvme0n1 26762678 20908 1428918348 3325593 26050590 3838657 2151727147 62187634 0 12832786 96772628 375506 274438 6540552016 27659340 958797 3600058
+)"""";
+
+    host_metrics_watcher::diskstats_map disk_stats;
+    host_metrics_watcher::parse_diskstats(diskstats, disk_stats);
+
+    ASSERT_EQ(disk_stats.size(), 1);
+    ASSERT_TRUE(disk_stats.contains("nvme0n1"));
+
+    const auto& stats = disk_stats["nvme0n1"];
+    ASSERT_EQ(stats.size(), 17);
+
+    ASSERT_EQ(stats[0], 26762678);    // reads
+    ASSERT_EQ(stats[1], 20908);       // reads_merged
+    ASSERT_EQ(stats[2], 1428918348);  // sectors_read
+    ASSERT_EQ(stats[3], 3325593);     // reads_ms
+    ASSERT_EQ(stats[4], 26050590);    // writes
+    ASSERT_EQ(stats[5], 3838657);     // writes_merged
+    ASSERT_EQ(stats[6], 2151727147);  // sectors_written
+    ASSERT_EQ(stats[7], 62187634);    // writes_ms
+    ASSERT_EQ(stats[8], 0);           // io_in_progress
+    ASSERT_EQ(stats[9], 12832786);    // io_ms
+    ASSERT_EQ(stats[10], 96772628);   // io_weighted_ms
+    ASSERT_EQ(stats[11], 375506);     // discards
+    ASSERT_EQ(stats[12], 274438);     // discards_merged
+    ASSERT_EQ(stats[13], 6540552016); // sectors_discarded
+    ASSERT_EQ(stats[14], 27659340);   // discards_ms
+    ASSERT_EQ(stats[15], 958797);     // flush_requests
+    ASSERT_EQ(stats[16], 3600058);    // flush_ms
+}
+
 } // namespace metrics

--- a/src/v/redpanda/application_runtime.cc
+++ b/src/v/redpanda/application_runtime.cc
@@ -302,7 +302,11 @@ void application::wire_up_runtime_services(
 
     construct_service(_debug_bundle_service, &storage.local().kvs()).get();
 
-    construct_single_service(_host_metrics_watcher, std::ref(_log));
+    auto data_dir = config::node().data_directory().as_sstring();
+    auto cache_dir = ss::sstring(
+      config::node().cloud_storage_cache_path().string());
+    construct_single_service(
+      _host_metrics_watcher, std::ref(_log), data_dir, cache_dir);
 
     construct_service(_kafka_connections_service, std::ref(_kafka_server.ref()))
       .get();

--- a/src/v/utils/BUILD
+++ b/src/v/utils/BUILD
@@ -689,6 +689,21 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "device_utils",
+    srcs = [
+        "device_utils.cc",
+    ],
+    hdrs = [
+        "device_utils.h",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/ssx:sformat",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "offset_monitor",
     hdrs = [
         "offset_monitor.h",

--- a/src/v/utils/device_utils.cc
+++ b/src/v/utils/device_utils.cc
@@ -26,7 +26,8 @@
 
 namespace utils {
 
-ss::sstring device_resolver::device_for_path(const ss::sstring& path) {
+device_resolver::resolved_device
+device_resolver::device_for_path(const ss::sstring& path) {
     struct stat st{};
     if (stat(path.c_str(), &st) != 0) {
         throw std::runtime_error(
@@ -55,7 +56,7 @@ ss::sstring device_resolver::device_for_path(const ss::sstring& path) {
             target.string()));
     }
 
-    return ss::sstring{device_name};
+    return {.name = ss::sstring{device_name}, .dev_id = dev};
 }
 
 ss::sstring

--- a/src/v/utils/device_utils.cc
+++ b/src/v/utils/device_utils.cc
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "utils/device_utils.h"
+
+#include "ssx/sformat.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+
+#include <cerrno>
+#include <cstring>
+#include <filesystem>
+#include <regex>
+#include <stdexcept>
+
+namespace utils {
+
+ss::sstring device_resolver::device_for_path(const ss::sstring& path) {
+    struct stat st{};
+    if (stat(path.c_str(), &st) != 0) {
+        throw std::runtime_error(
+          ssx::sformat("stat('{}') failed: {}", path, strerror(errno)));
+    }
+
+    // st_dev is the device ID of the device containing the file
+    dev_t dev = st.st_dev;
+    unsigned int maj = major(dev);
+    unsigned int min = minor(dev);
+
+    // Resolve device via /sys/dev/block/major:minor symlink
+    auto symlink_path = ssx::sformat("/sys/dev/block/{}:{}", maj, min);
+
+    // read_symlink handles buffer management and throws
+    // std::filesystem::filesystem_error on failure
+    auto target = std::filesystem::read_symlink(symlink_path.c_str());
+    auto device_name = target.filename().string();
+
+    if (device_name.empty()) {
+        throw std::runtime_error(
+          ssx::sformat(
+            "unexpected sysfs symlink format for dev {}:{}: '{}'",
+            maj,
+            min,
+            target.string()));
+    }
+
+    return ss::sstring{device_name};
+}
+
+ss::sstring
+device_resolver::get_base_device(const ss::sstring& device) noexcept {
+    if (device.empty()) {
+        return device;
+    }
+
+    // Define regex patterns for different device types
+    // NVMe: nvme0n1p1 -> nvme0n1 (capture: nvme<controller>n<namespace>)
+    static const std::regex nvme_pattern(R"(^(nvme\d+n\d+)p\d+$)");
+
+    // MMC/SD: mmcblk0p1 -> mmcblk0 (capture: mmcblk<number>)
+    static const std::regex mmc_pattern(R"(^(mmcblk\d+)p\d+$)");
+
+    // PMEM: pmem0p1 -> pmem0 (capture: pmem<number>)
+    static const std::regex pmem_pattern(R"(^(pmem\d+)p\d+$)");
+
+    // Traditional: sda1 -> sda, vda3 -> vda
+    // Excludes: nvme*, mmcblk*, pmem*, dm-*,
+    // which are handled by other patterns or for dm we don't want
+    // to strip the number since it's part of the base name (e.g. dm-0, dm-1)
+    // Use negative lookahead to exclude specific prefixes
+    static const std::regex traditional_pattern(
+      R"(^(?!nvme|mmcblk|pmem|dm)([a-z]+)\d+$)");
+
+    std::string device_str{device};
+    std::smatch match;
+
+    // Try each pattern and return the captured base device name
+    if (
+      std::regex_match(device_str, match, nvme_pattern)
+      || std::regex_match(device_str, match, mmc_pattern)
+      || std::regex_match(device_str, match, pmem_pattern)
+      || std::regex_match(device_str, match, traditional_pattern)) {
+        return {match[1].str()};
+    }
+
+    // No partition found, return as-is
+    return device;
+}
+
+} // namespace utils

--- a/src/v/utils/device_utils.cc
+++ b/src/v/utils/device_utils.cc
@@ -72,16 +72,17 @@ device_resolver::get_base_device(const ss::sstring& device) noexcept {
     // MMC/SD: mmcblk0p1 -> mmcblk0 (capture: mmcblk<number>)
     static const std::regex mmc_pattern(R"(^(mmcblk\d+)p\d+$)");
 
+    // MD RAID: md0p1 -> md0, md127p3 -> md127 (capture: md<number>)
+    static const std::regex md_pattern(R"(^(md\d+)p\d+$)");
+
     // PMEM: pmem0p1 -> pmem0 (capture: pmem<number>)
     static const std::regex pmem_pattern(R"(^(pmem\d+)p\d+$)");
 
-    // Traditional: sda1 -> sda, vda3 -> vda
-    // Excludes: nvme*, mmcblk*, pmem*, dm-*,
-    // which are handled by other patterns or for dm we don't want
-    // to strip the number since it's part of the base name (e.g. dm-0, dm-1)
-    // Use negative lookahead to exclude specific prefixes
+    // Traditional: sda1 -> sda, vda3 -> vda, xvda2 -> xvda, hdb5 -> hdb
+    // Only match known partitioned device prefixes to avoid stripping
+    // digits from non-partition base devices like md0, loop0, or dm-0.
     static const std::regex traditional_pattern(
-      R"(^(?!nvme|mmcblk|pmem|dm)([a-z]+)\d+$)");
+      R"(^((sd|vd|xvd|hd)[a-z]+)\d+$)");
 
     std::string device_str{device};
     std::smatch match;
@@ -89,6 +90,7 @@ device_resolver::get_base_device(const ss::sstring& device) noexcept {
     // Try each pattern and return the captured base device name
     if (
       std::regex_match(device_str, match, nvme_pattern)
+      || std::regex_match(device_str, match, md_pattern)
       || std::regex_match(device_str, match, mmc_pattern)
       || std::regex_match(device_str, match, pmem_pattern)
       || std::regex_match(device_str, match, traditional_pattern)) {

--- a/src/v/utils/device_utils.h
+++ b/src/v/utils/device_utils.h
@@ -14,6 +14,7 @@
 #include <seastar/core/sstring.hh>
 
 #include <base/seastarx.h>
+#include <sys/types.h>
 
 namespace utils {
 
@@ -24,26 +25,32 @@ namespace utils {
  */
 class device_resolver {
 public:
+    struct resolved_device {
+        ss::sstring name; // device name (e.g., "sda3", "nvme0n1p1")
+        dev_t dev_id;     // device ID from stat(2) st_dev
+    };
+
     /**
-     * Resolve a filesystem path to its device name, i.e., the name
-     * of the device stat(2) returns. This device will generally be a
-     * partition, not the whole disk (unless you didn't partition your
-     * disk).
+     * Resolve a filesystem path to its device name and device ID.
      *
-     * It returns only the device name, NOT prefixed with /dev/.
+     * The device name is the name of the block device that stat(2)
+     * returns for the path. This will generally be a partition, not
+     * the whole disk (unless you didn't partition your disk).
+     *
+     * The device name is NOT prefixed with /dev/.
      *
      * @param path Directory path to resolve
-     * @return Device name (e.g., "sda3", "nvme0n1p1")
+     * @return Device name and dev_t
      * @throws std::runtime_error if the path cannot be resolved to a
      *         block device (e.g. inaccessible path, overlay/tmpfs
      *         filesystem, loop device)
      *
      * Examples:
-     * - "/var/lib/redpanda" on /dev/sda3 -> "sda3"
-     * - "/mnt/vectorized" on /dev/nvme0n1p1 -> "nvme0n1p1"
-     * - Path on whole-disk filesystem -> "sda" (no partition to strip)
+     * - "/var/lib/redpanda" on /dev/sda3 -> {"sda3", <dev_t>}
+     * - "/mnt/vectorized" on /dev/nvme0n1p1 -> {"nvme0n1p1", <dev_t>}
+     * - Path on whole-disk filesystem -> {"sda", <dev_t>}
      */
-    static ss::sstring device_for_path(const ss::sstring& path);
+    static resolved_device device_for_path(const ss::sstring& path);
 
     /**
      * Strip partition number from a device name to get the base device.

--- a/src/v/utils/device_utils.h
+++ b/src/v/utils/device_utils.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <seastar/core/sstring.hh>
+
+#include <base/seastarx.h>
+
+namespace utils {
+
+/**
+ * Utility class for resolving file system paths to their underlying
+ * block device names. This is used to determine which partitions or
+ * physical disk a path resides on.
+ */
+class device_resolver {
+public:
+    /**
+     * Resolve a filesystem path to its device name, i.e., the name
+     * of the device stat(2) returns. This device will generally be a
+     * partition, not the whole disk (unless you didn't partition your
+     * disk).
+     *
+     * It returns only the device name, NOT prefixed with /dev/.
+     *
+     * @param path Directory path to resolve
+     * @return Device name (e.g., "sda3", "nvme0n1p1")
+     * @throws std::runtime_error if the path cannot be resolved to a
+     *         block device (e.g. inaccessible path, overlay/tmpfs
+     *         filesystem, loop device)
+     *
+     * Examples:
+     * - "/var/lib/redpanda" on /dev/sda3 -> "sda3"
+     * - "/mnt/vectorized" on /dev/nvme0n1p1 -> "nvme0n1p1"
+     * - Path on whole-disk filesystem -> "sda" (no partition to strip)
+     */
+    static ss::sstring device_for_path(const ss::sstring& path);
+
+    /**
+     * Strip partition number from a device name to get the base device.
+     *
+     * This is useful to find the underlying disk for a partition.
+     *
+     * This is a pure string operation matching common device patterns and
+     * removing the partition part.
+     *
+     * If this matching fails, it returns the string unchanged.
+     *
+     * @param device Device name possibly with partition (e.g., "sda3",
+     * "nvme0n1p2")
+     * @return Base device name (e.g., "sda", "nvme0n1")
+     *
+     * Examples:
+     * - "sda3" -> "sda"
+     * - "nvme0n1p2" -> "nvme0n1"
+     * - "vda1" -> "vda"
+     * - "sda" -> "sda" (already base device)
+     */
+    static ss::sstring get_base_device(const ss::sstring& device) noexcept;
+};
+
+} // namespace utils

--- a/src/v/utils/tests/BUILD
+++ b/src/v/utils/tests/BUILD
@@ -617,3 +617,14 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "device_utils_test",
+    timeout = "short",
+    srcs = ["device_utils_test.cc"],
+    deps = [
+        "//src/v/test_utils:gtest",
+        "//src/v/utils:device_utils",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/utils/tests/device_utils_test.cc
+++ b/src/v/utils/tests/device_utils_test.cc
@@ -83,15 +83,16 @@ TEST(DeviceUtils, DeviceForPathRootDirectory) {
         GTEST_SKIP() << "root device has major 0 (likely overlay/container)";
     }
 
-    auto device = device_resolver::device_for_path("/");
-    EXPECT_FALSE(device.empty());
+    auto resolved = device_resolver::device_for_path("/");
+    EXPECT_FALSE(resolved.name.empty());
+    EXPECT_NE(resolved.dev_id, 0);
 
     // The partition device should start with its base device name
     // (e.g. sda3 starts with sda, nvme0n1p5 starts with nvme0n1).
-    auto base = device_resolver::get_base_device(device);
-    EXPECT_TRUE(device.starts_with(base))
-      << "partition device '" << device << "' should start with base '" << base
-      << "'";
+    auto base = device_resolver::get_base_device(resolved.name);
+    EXPECT_TRUE(resolved.name.starts_with(base))
+      << "partition device '" << resolved.name << "' should start with base '"
+      << base << "'";
 }
 
 TEST(DeviceUtils, DeviceForPathNonExistent) {
@@ -108,8 +109,8 @@ TEST(DeviceUtils, DeviceForPathBaseDeviceConsistency) {
     }
 
     // get_base_device(device_for_path(path)) should yield a valid base device
-    auto device = device_resolver::device_for_path("/");
-    auto base = device_resolver::get_base_device(device);
+    auto resolved = device_resolver::device_for_path("/");
+    auto base = device_resolver::get_base_device(resolved.name);
     EXPECT_FALSE(base.empty());
 
     // Common root devices (one of these should match)

--- a/src/v/utils/tests/device_utils_test.cc
+++ b/src/v/utils/tests/device_utils_test.cc
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "utils/device_utils.h"
+
+#include <gtest/gtest.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+
+namespace utils {
+
+TEST(DeviceUtils, GetBaseDeviceTraditional) {
+    // Test traditional disk partition stripping
+    EXPECT_EQ(device_resolver::get_base_device("sda1"), "sda");
+    EXPECT_EQ(device_resolver::get_base_device("sda2"), "sda");
+    EXPECT_EQ(device_resolver::get_base_device("sda10"), "sda");
+    EXPECT_EQ(device_resolver::get_base_device("sda"), "sda");
+
+    EXPECT_EQ(device_resolver::get_base_device("vda1"), "vda");
+    EXPECT_EQ(device_resolver::get_base_device("vda"), "vda");
+
+    EXPECT_EQ(device_resolver::get_base_device("xvda1"), "xvda");
+    EXPECT_EQ(device_resolver::get_base_device("xvda"), "xvda");
+
+    EXPECT_EQ(device_resolver::get_base_device("hda3"), "hda");
+    EXPECT_EQ(device_resolver::get_base_device("hda"), "hda");
+}
+
+TEST(DeviceUtils, GetBaseDeviceNVMe) {
+    // Test NVMe device partition stripping
+    EXPECT_EQ(device_resolver::get_base_device("nvme0n1p1"), "nvme0n1");
+    EXPECT_EQ(device_resolver::get_base_device("nvme0n1p2"), "nvme0n1");
+    EXPECT_EQ(device_resolver::get_base_device("nvme0n1p10"), "nvme0n1");
+    EXPECT_EQ(device_resolver::get_base_device("nvme0n1"), "nvme0n1");
+
+    EXPECT_EQ(device_resolver::get_base_device("nvme1n1p1"), "nvme1n1");
+    EXPECT_EQ(device_resolver::get_base_device("nvme10n1p5"), "nvme10n1");
+}
+
+TEST(DeviceUtils, GetBaseDeviceEdgeCases) {
+    // Test edge cases
+    EXPECT_EQ(device_resolver::get_base_device(""), "");
+
+    // pmem (persistent memory) devices use 'p' prefix for partitions
+    EXPECT_EQ(device_resolver::get_base_device("pmem0"), "pmem0");
+    EXPECT_EQ(device_resolver::get_base_device("pmem0p1"), "pmem0");
+
+    // dm devices, shouldn't strip
+    EXPECT_EQ(device_resolver::get_base_device("dm-0"), "dm-0");
+    EXPECT_EQ(device_resolver::get_base_device("dm-10"), "dm-10");
+
+    // no match, pass unchanged
+    EXPECT_EQ(device_resolver::get_base_device("foobar"), "foobar");
+}
+
+TEST(DeviceUtils, GetBaseDeviceNoPartition) {
+    // Test devices that are already base devices
+    EXPECT_EQ(device_resolver::get_base_device("sda"), "sda");
+    EXPECT_EQ(device_resolver::get_base_device("nvme0n1"), "nvme0n1");
+    EXPECT_EQ(device_resolver::get_base_device("vda"), "vda");
+}
+
+TEST(DeviceUtils, GetBaseDeviceMultipleDigits) {
+    // Test devices with multiple trailing digits
+    EXPECT_EQ(device_resolver::get_base_device("sda123"), "sda");
+    EXPECT_EQ(device_resolver::get_base_device("nvme0n1p999"), "nvme0n1");
+}
+
+TEST(DeviceUtils, DeviceForPathRootDirectory) {
+    // In containers the root filesystem may be on an overlay (major 0)
+    // with no /sys/dev/block entry, so skip when that's the case.
+    struct stat st{};
+    ASSERT_EQ(stat("/", &st), 0);
+    if (major(st.st_dev) == 0) {
+        GTEST_SKIP() << "root device has major 0 (likely overlay/container)";
+    }
+
+    auto device = device_resolver::device_for_path("/");
+    EXPECT_FALSE(device.empty());
+
+    // The partition device should start with its base device name
+    // (e.g. sda3 starts with sda, nvme0n1p5 starts with nvme0n1).
+    auto base = device_resolver::get_base_device(device);
+    EXPECT_TRUE(device.starts_with(base))
+      << "partition device '" << device << "' should start with base '" << base
+      << "'";
+}
+
+TEST(DeviceUtils, DeviceForPathNonExistent) {
+    EXPECT_THROW(
+      device_resolver::device_for_path("/this/path/does/not/exist"),
+      std::runtime_error);
+}
+
+TEST(DeviceUtils, DeviceForPathBaseDeviceConsistency) {
+    struct stat st{};
+    ASSERT_EQ(stat("/", &st), 0);
+    if (major(st.st_dev) == 0) {
+        GTEST_SKIP() << "root device has major 0 (likely overlay/container)";
+    }
+
+    // get_base_device(device_for_path(path)) should yield a valid base device
+    auto device = device_resolver::device_for_path("/");
+    auto base = device_resolver::get_base_device(device);
+    EXPECT_FALSE(base.empty());
+
+    // Common root devices (one of these should match)
+    bool is_common_device = base.starts_with("sd") || base.starts_with("nvme")
+                            || base.starts_with("vd") || base.starts_with("xvd")
+                            || base.starts_with("hd") || base.starts_with("dm-")
+                            || base.starts_with("md");
+    EXPECT_TRUE(is_common_device) << "Unexpected root device: " << base;
+}
+
+} // namespace utils

--- a/src/v/utils/tests/device_utils_test.cc
+++ b/src/v/utils/tests/device_utils_test.cc
@@ -56,6 +56,17 @@ TEST(DeviceUtils, GetBaseDeviceEdgeCases) {
     // dm devices, shouldn't strip
     EXPECT_EQ(device_resolver::get_base_device("dm-0"), "dm-0");
     EXPECT_EQ(device_resolver::get_base_device("dm-10"), "dm-10");
+    EXPECT_EQ(device_resolver::get_base_device("dm0"), "dm0");
+
+    // MD RAID partitions: md0p17 -> md0
+    EXPECT_EQ(device_resolver::get_base_device("md0p1"), "md0");
+    EXPECT_EQ(device_resolver::get_base_device("md0p17"), "md0");
+    EXPECT_EQ(device_resolver::get_base_device("md127p3"), "md127");
+
+    // MD RAID base devices, shouldn't strip
+    EXPECT_EQ(device_resolver::get_base_device("md0"), "md0");
+    EXPECT_EQ(device_resolver::get_base_device("loop0"), "loop0");
+    EXPECT_EQ(device_resolver::get_base_device("sr0"), "sr0");
 
     // no match, pass unchanged
     EXPECT_EQ(device_resolver::get_base_device("foobar"), "foobar");

--- a/tests/rptest/tests/host_metrics_test.py
+++ b/tests/rptest/tests/host_metrics_test.py
@@ -41,3 +41,44 @@ class HostMetricsTest(RedpandaTest):
         assert disk_count > 0, "Expected some disk reads"
         assert netstat_count > 0, "Expected some received bytes"
         assert snmp_count > 0, "Expected some received packets"
+
+    @cluster(num_nodes=1)
+    def test_info_metric(self):
+        """
+        Test that the host_metrics info metric exists with exactly one sample
+        per node and has the expected label values.
+        """
+        node = self.redpanda.nodes[0]
+        metrics = list(self.redpanda.metrics(node))
+
+        info_samples = []
+        for family in metrics:
+            if family.name == "vectorized_host_metrics_info":
+                info_samples.extend(family.samples)
+
+        assert len(info_samples) == 1, (
+            f"Expected exactly 1 info metric sample, got {len(info_samples)}"
+        )
+
+        labels = info_samples[0].labels
+        assert int(info_samples[0].value) == 1, "Info metric should be 1"
+
+        def check(label, expected):
+            actual = labels[label]
+            assert actual == expected, f"Expected {label}={expected}, got {actual}"
+
+        if self.redpanda.dedicated_nodes:
+            # On dedicated nodes (EC2 etc.) device resolution should succeed.
+            # Data and cache default to the same directory so they share a
+            # partition.
+            check("data_resolved", "1")
+            check("cache_resolved", "1")
+            check("same_partition", "1")
+        else:
+            # In docker the data directory is on an overlay filesystem whose
+            # device (major 0) has no /sys/dev/block entry, so resolution
+            # fails.
+            check("data_resolved", "0")
+            check("cache_resolved", "0")
+            check("same_partition", "0")
+            check("data_has_io_queue", "0")

--- a/tests/rptest/tests/host_metrics_test.py
+++ b/tests/rptest/tests/host_metrics_test.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import contextlib
 import yaml
 
 from rptest.services.cluster import cluster
@@ -18,6 +19,33 @@ class HostMetricsTest(RedpandaTest):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, num_brokers=1, **kwargs)
 
+    def _log_node_disk_info(self, node):
+        """Log mount table and /proc/diskstats for post-failure diagnosis."""
+        mounts = node.account.ssh_output("mount").decode()
+        self.logger.debug(f"mount output on {node.name}:\n{mounts}")
+        diskstats = node.account.ssh_output("cat /proc/diskstats").decode()
+        self.logger.debug(f"/proc/diskstats on {node.name}:\n{diskstats}")
+
+    def _log_raw_metrics(self, node):
+        """Dump all host metrics families for diagnosis."""
+        metrics = list(self.redpanda.metrics(node))
+        for family in metrics:
+            if "host_" in family.name or "diskstats" in family.name:
+                for sample in family.samples:
+                    self.logger.debug(
+                        f"  {family.name} labels={sample.labels} value={sample.value}"
+                    )
+
+    @contextlib.contextmanager
+    def _log_disk_info_on_failure(self, node):
+        """Context manager that dumps disk info when the body raises."""
+        try:
+            yield
+        except Exception:
+            self._log_node_disk_info(node)
+            self._log_raw_metrics(node)
+            raise
+
     @cluster(num_nodes=1)
     def test_basic_hoststats(self):
         """
@@ -25,25 +53,25 @@ class HostMetricsTest(RedpandaTest):
 
         """
 
-        metrics = list(self.redpanda.metrics(self.redpanda.nodes[0]))
+        node = self.redpanda.nodes[0]
+        self._log_node_disk_info(node)
+        with self._log_disk_info_on_failure(node):
+            metrics = list(self.redpanda.metrics(node))
 
-        disk_count = 0
-        netstat_count = 0
-        snmp_count = 0
-        for family in metrics:
-            if family.name == "vectorized_host_diskstats_reads":
-                for sample in family.samples:
-                    disk_count += int(sample.value)
-            if family.name == "vectorized_host_netstat_bytes_received":
-                for sample in family.samples:
-                    netstat_count += int(sample.value)
-            if family.name == "vectorized_host_snmp_packets_received":
-                for sample in family.samples:
-                    snmp_count += int(sample.value)
+            def metric_stats(name):
+                samples = [s for f in metrics if f.name == name for s in f.samples]
+                return len(samples), sum(int(s.value) for s in samples)
 
-        assert disk_count > 0, "Expected some disk reads"
-        assert netstat_count > 0, "Expected some received bytes"
-        assert snmp_count > 0, "Expected some received packets"
+            for metric, label in [
+                ("vectorized_host_diskstats_reads", "disk reads"),
+                ("vectorized_host_netstat_bytes_received", "received bytes"),
+                ("vectorized_host_snmp_packets_received", "received packets"),
+            ]:
+                n_samples, total = metric_stats(metric)
+                assert n_samples > 0, f"Expected samples for {label}, got 0"
+                assert total > 0, (
+                    f"Expected {label} > 0, got {total} across {n_samples} samples"
+                )
 
     @cluster(num_nodes=1)
     def test_info_metric(self):
@@ -52,39 +80,44 @@ class HostMetricsTest(RedpandaTest):
         per node and has the expected label values.
         """
         node = self.redpanda.nodes[0]
-        metrics = list(self.redpanda.metrics(node))
+        with self._log_disk_info_on_failure(node):
+            metrics = list(self.redpanda.metrics(node))
 
-        info_samples = []
-        for family in metrics:
-            if family.name == "vectorized_host_metrics_info":
-                info_samples.extend(family.samples)
+            info_samples = []
+            for family in metrics:
+                if family.name == "vectorized_host_metrics_info":
+                    info_samples.extend(family.samples)
 
-        assert len(info_samples) == 1, (
-            f"Expected exactly 1 info metric sample, got {len(info_samples)}"
-        )
+            assert len(info_samples) == 1, (
+                f"Expected exactly 1 info metric sample, got {len(info_samples)}"
+            )
 
-        labels = info_samples[0].labels
-        assert int(info_samples[0].value) == 1, "Info metric should be 1"
+            labels = info_samples[0].labels
+            assert int(info_samples[0].value) == 1, "Info metric should be 1"
 
-        def check(label, expected):
-            actual = labels[label]
-            assert actual == expected, f"Expected {label}={expected}, got {actual}"
+            def check(label, expected):
+                actual = labels[label]
+                assert actual == expected, f"Expected {label}={expected}, got {actual}"
 
-        if self.redpanda.dedicated_nodes:
-            # On dedicated nodes (EC2 etc.) device resolution should succeed.
-            # Data and cache default to the same directory so they share a
-            # partition.
-            check("data_resolved", "1")
-            check("cache_resolved", "1")
-            check("same_partition", "1")
-        else:
-            # In docker the data directory is on an overlay filesystem whose
-            # device (major 0) has no /sys/dev/block entry, so resolution
-            # fails.
-            check("data_resolved", "0")
-            check("cache_resolved", "0")
-            check("same_partition", "0")
-            check("data_has_io_queue", "0")
+            if self.redpanda.dedicated_nodes:
+                # On dedicated nodes (EC2 etc.) device resolution should succeed.
+                # Data and cache default to the same directory so they share a
+                # partition.
+                check("data_resolved", "1")
+                check("cache_resolved", "1")
+                check("same_partition", "1")
+            else:
+                # In docker the data directory may be on an overlay filesystem
+                # (device resolution fails) or on a real mounted drive in CI
+                # (resolution succeeds). Don't assert specific values — just
+                # verify the labels exist.
+                for label in [
+                    "data_resolved",
+                    "cache_resolved",
+                    "same_partition",
+                    "data_has_io_queue",
+                ]:
+                    assert label in labels, f"Missing label {label}"
 
     @cluster(num_nodes=1)
     def test_io_queue_config_metrics(self):
@@ -95,72 +128,72 @@ class HostMetricsTest(RedpandaTest):
         device/disk labels.
         """
         node = self.redpanda.nodes[0]
-        metrics = list(self.redpanda.metrics(node))
+        with self._log_disk_info_on_failure(node):
+            metrics = list(self.redpanda.metrics(node))
 
-        expected_gauges = {
-            "vectorized_io_queue_config_read_bytes_rate",
-            "vectorized_io_queue_config_write_bytes_rate",
-            "vectorized_io_queue_config_read_req_rate",
-            "vectorized_io_queue_config_write_req_rate",
-            "vectorized_io_queue_config_max_cost_function",
-            "vectorized_io_queue_config_duplex",
-        }
+            expected_gauges = {
+                "vectorized_io_queue_config_read_bytes_rate",
+                "vectorized_io_queue_config_write_bytes_rate",
+                "vectorized_io_queue_config_read_req_rate",
+                "vectorized_io_queue_config_write_req_rate",
+                "vectorized_io_queue_config_max_cost_function",
+                "vectorized_io_queue_config_duplex",
+            }
 
-        expected_labels = {
-            "disk",
-            "device",
-            "mountpoint",
-            "data_disk",
-            "cache_disk",
-            "id",
-        }
+            expected_labels = {
+                "disk",
+                "device",
+                "mountpoint",
+                "data_disk",
+                "cache_disk",
+                "id",
+            }
 
-        found = {}
-        for family in metrics:
-            if family.name in expected_gauges:
-                found[family.name] = family.samples
+            found = {}
+            for family in metrics:
+                if family.name in expected_gauges:
+                    found[family.name] = family.samples
 
-        assert found.keys() == expected_gauges, (
-            f"Missing io_queue_config metrics: {expected_gauges - found.keys()}"
-        )
-
-        for name, samples in found.items():
-            assert len(samples) >= 1, f"Expected at least 1 sample for {name}"
-            for sample in samples:
-                assert expected_labels.issubset(sample.labels.keys()), (
-                    f"{name} missing labels: {expected_labels - sample.labels.keys()}"
-                )
-                # All gauges should be non-negative
-                assert sample.value >= 0, f"{name} has negative value: {sample.value}"
-
-            # At least one sample should have data_disk=1
-            data_samples = [s for s in samples if s.labels["data_disk"] == "1"]
-            assert len(data_samples) >= 1, (
-                f"Expected at least one {name} sample with data_disk=1"
+            assert found.keys() == expected_gauges, (
+                f"Missing io_queue_config metrics: {expected_gauges - found.keys()}"
             )
 
-        if not self.redpanda.dedicated_nodes:
-            # In docker, device resolution fails so the fallback path
-            # looks up IO queues by directory stat. Data and cache share
-            # one overlay device, so we expect exactly 1 sample per gauge
-            # with empty device/disk labels.
-            def check_label(name, sample, label, expected):
-                actual = sample.labels[label]
-                assert actual == expected, (
-                    f"{name} expected {label}={expected!r} in docker, got {actual!r}"
+            for name, samples in found.items():
+                assert len(samples) >= 1, f"Expected at least 1 sample for {name}"
+                for sample in samples:
+                    assert expected_labels.issubset(sample.labels.keys()), (
+                        f"{name} missing labels: {expected_labels - sample.labels.keys()}"
+                    )
+                    # All gauges should be non-negative
+                    assert sample.value >= 0, (
+                        f"{name} has negative value: {sample.value}"
+                    )
+
+                # At least one sample should have data_disk=1
+                data_samples = [s for s in samples if s.labels["data_disk"] == "1"]
+                assert len(data_samples) >= 1, (
+                    f"Expected at least one {name} sample with data_disk=1"
                 )
 
-            for name, samples in found.items():
-                assert len(samples) == 1, (
-                    f"{name} expected exactly 1 sample in docker, got {len(samples)}"
-                )
-                for label, expected in [
-                    ("device", ""),
-                    ("disk", ""),
-                    ("mountpoint", ""),
-                    ("id", "0"),
-                ]:
-                    check_label(name, samples[0], label, expected)
+            if not self.redpanda.dedicated_nodes:
+                # Without io-properties there is only the default IO queue
+                # (id=0), so we expect exactly 1 sample per gauge. Device
+                # labels vary by environment (empty in plain docker, may
+                # resolve in CI with mounted drives).
+                def check_label(name, sample, label, expected):
+                    actual = sample.labels[label]
+                    assert actual == expected, (
+                        f"{name} expected {label}={expected!r} in docker, got {actual!r}"
+                    )
+
+                for name, samples in found.items():
+                    assert len(samples) == 1, (
+                        f"{name} expected exactly 1 sample in docker, got {len(samples)}"
+                    )
+                    # In CI, mounted drives may resolve to a real device
+                    # (e.g. md0p48), so only assert on id which is always
+                    # the default queue in the no-io-properties case.
+                    check_label(name, samples[0], "id", "0")
 
     @cluster(num_nodes=1)
     def test_io_queue_config_with_io_properties(self):
@@ -176,72 +209,78 @@ class HostMetricsTest(RedpandaTest):
         queue directly, so only 1 series is emitted.
         """
         node = self.redpanda.nodes[0]
+        with self._log_disk_info_on_failure(node):
+            io_props = {
+                "disks": [
+                    {
+                        "mountpoint": RedpandaService.DATA_DIR,
+                        "read_iops": 10000,
+                        "read_bandwidth": 1000000000,
+                        "write_iops": 1000,
+                        "write_bandwidth": 100000000,
+                    }
+                ]
+            }
 
-        io_props = {
-            "disks": [
-                {
-                    "mountpoint": RedpandaService.DATA_DIR,
-                    "read_iops": 10000,
-                    "read_bandwidth": 1000000000,
-                    "write_iops": 1000,
-                    "write_bandwidth": 100000000,
-                }
-            ]
-        }
+            io_props_path = "/tmp/test-io-properties.yaml"
+            node.account.create_file(io_props_path, yaml.dump(io_props))
 
-        io_props_path = "/tmp/test-io-properties.yaml"
-        node.account.create_file(io_props_path, yaml.dump(io_props))
-
-        self.redpanda.restart_nodes(
-            [node],
-            extra_cli=[f"--io-properties-file={io_props_path}"],
-        )
-
-        metrics = list(self.redpanda.metrics(node))
-
-        expected_gauges = {
-            "vectorized_io_queue_config_read_bytes_rate",
-            "vectorized_io_queue_config_write_bytes_rate",
-            "vectorized_io_queue_config_read_req_rate",
-            "vectorized_io_queue_config_write_req_rate",
-            "vectorized_io_queue_config_max_cost_function",
-            "vectorized_io_queue_config_duplex",
-        }
-
-        found = {}
-        for family in metrics:
-            if family.name in expected_gauges:
-                found[family.name] = family.samples
-
-        assert found.keys() == expected_gauges, (
-            f"Missing io_queue_config metrics: {expected_gauges - found.keys()}"
-        )
-
-        # Every gauge should have at least 1 sample with the configured
-        # mountpoint and the expected rate values.
-        for name, samples in found.items():
-            configured = [
-                s for s in samples if s.labels["mountpoint"] == RedpandaService.DATA_DIR
-            ]
-            assert len(configured) == 1, (
-                f"{name} expected 1 sample with mountpoint="
-                f"{RedpandaService.DATA_DIR}, got {len(configured)}"
+            self.redpanda.restart_nodes(
+                [node],
+                extra_cli=[f"--io-properties-file={io_props_path}"],
             )
-            assert int(configured[0].labels["id"]) > 0
 
-        def gauge_value(metric_name):
-            samples = found[f"vectorized_io_queue_config_{metric_name}"]
-            return [
-                s for s in samples if s.labels["mountpoint"] == RedpandaService.DATA_DIR
-            ][0].value
+            metrics = list(self.redpanda.metrics(node))
 
-        assert gauge_value("read_bytes_rate") == 1000000000
-        assert gauge_value("write_bytes_rate") == 100000000
-        assert gauge_value("read_req_rate") == 10000
-        assert gauge_value("write_req_rate") == 1000
+            expected_gauges = {
+                "vectorized_io_queue_config_read_bytes_rate",
+                "vectorized_io_queue_config_write_bytes_rate",
+                "vectorized_io_queue_config_read_req_rate",
+                "vectorized_io_queue_config_write_req_rate",
+                "vectorized_io_queue_config_max_cost_function",
+                "vectorized_io_queue_config_duplex",
+            }
 
-        # When io-properties points at the data dir, get_io_queue for that
-        # device returns the configured queue. Since data and cache share
-        # the same device, they deduplicate to 1 series.
-        for name, samples in found.items():
-            assert len(samples) == 1, f"{name} expected 1 sample, got {len(samples)}"
+            found = {}
+            for family in metrics:
+                if family.name in expected_gauges:
+                    found[family.name] = family.samples
+
+            assert found.keys() == expected_gauges, (
+                f"Missing io_queue_config metrics: {expected_gauges - found.keys()}"
+            )
+
+            # Every gauge should have at least 1 sample with the configured
+            # mountpoint and the expected rate values.
+            for name, samples in found.items():
+                configured = [
+                    s
+                    for s in samples
+                    if s.labels["mountpoint"] == RedpandaService.DATA_DIR
+                ]
+                assert len(configured) == 1, (
+                    f"{name} expected 1 sample with mountpoint="
+                    f"{RedpandaService.DATA_DIR}, got {len(configured)}"
+                )
+                assert int(configured[0].labels["id"]) > 0
+
+            def gauge_value(metric_name):
+                samples = found[f"vectorized_io_queue_config_{metric_name}"]
+                return [
+                    s
+                    for s in samples
+                    if s.labels["mountpoint"] == RedpandaService.DATA_DIR
+                ][0].value
+
+            assert gauge_value("read_bytes_rate") == 1000000000
+            assert gauge_value("write_bytes_rate") == 100000000
+            assert gauge_value("read_req_rate") == 10000
+            assert gauge_value("write_req_rate") == 1000
+
+            # When io-properties points at the data dir, get_io_queue for that
+            # device returns the configured queue. Since data and cache share
+            # the same device, they deduplicate to 1 series.
+            for name, samples in found.items():
+                assert len(samples) == 1, (
+                    f"{name} expected 1 sample, got {len(samples)}"
+                )

--- a/tests/rptest/tests/host_metrics_test.py
+++ b/tests/rptest/tests/host_metrics_test.py
@@ -82,3 +82,65 @@ class HostMetricsTest(RedpandaTest):
             check("cache_resolved", "0")
             check("same_partition", "0")
             check("data_has_io_queue", "0")
+
+    @cluster(num_nodes=1)
+    def test_io_queue_config_metrics(self):
+        """
+        Test that IO queue config metrics are exported with expected labels
+        and gauge values. In docker, device resolution falls back to
+        directory stat, producing a single sample per gauge with empty
+        device/disk labels.
+        """
+        node = self.redpanda.nodes[0]
+        metrics = list(self.redpanda.metrics(node))
+
+        expected_gauges = {
+            "vectorized_io_queue_config_read_bytes_rate",
+            "vectorized_io_queue_config_write_bytes_rate",
+            "vectorized_io_queue_config_read_req_rate",
+            "vectorized_io_queue_config_write_req_rate",
+            "vectorized_io_queue_config_max_cost_function",
+            "vectorized_io_queue_config_duplex",
+        }
+
+        expected_labels = {
+            "disk",
+            "device",
+            "mountpoint",
+            "data_disk",
+            "cache_disk",
+            "id",
+        }
+
+        found = {}
+        for family in metrics:
+            if family.name in expected_gauges:
+                found[family.name] = family.samples
+
+        if not self.redpanda.dedicated_nodes:
+            # In docker there are no real block devices, so IO queue config
+            # metrics are not emitted.
+            assert len(found) == 0, (
+                f"Expected no io_queue_config metrics in docker, got: "
+                f"{list(found.keys())}"
+            )
+            return
+
+        assert found.keys() == expected_gauges, (
+            f"Missing io_queue_config metrics: {expected_gauges - found.keys()}"
+        )
+
+        for name, samples in found.items():
+            assert len(samples) >= 1, f"Expected at least 1 sample for {name}"
+            for sample in samples:
+                assert expected_labels.issubset(sample.labels.keys()), (
+                    f"{name} missing labels: {expected_labels - sample.labels.keys()}"
+                )
+                # All gauges should be non-negative
+                assert sample.value >= 0, f"{name} has negative value: {sample.value}"
+
+            # At least one sample should have data_disk=1
+            data_samples = [s for s in samples if s.labels["data_disk"] == "1"]
+            assert len(data_samples) >= 1, (
+                f"Expected at least one {name} sample with data_disk=1"
+            )

--- a/tests/rptest/tests/host_metrics_test.py
+++ b/tests/rptest/tests/host_metrics_test.py
@@ -7,7 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import yaml
+
 from rptest.services.cluster import cluster
+from rptest.services.redpanda import RedpandaService
 from rptest.tests.redpanda_test import RedpandaTest
 
 
@@ -117,15 +120,6 @@ class HostMetricsTest(RedpandaTest):
             if family.name in expected_gauges:
                 found[family.name] = family.samples
 
-        if not self.redpanda.dedicated_nodes:
-            # In docker there are no real block devices, so IO queue config
-            # metrics are not emitted.
-            assert len(found) == 0, (
-                f"Expected no io_queue_config metrics in docker, got: "
-                f"{list(found.keys())}"
-            )
-            return
-
         assert found.keys() == expected_gauges, (
             f"Missing io_queue_config metrics: {expected_gauges - found.keys()}"
         )
@@ -144,3 +138,110 @@ class HostMetricsTest(RedpandaTest):
             assert len(data_samples) >= 1, (
                 f"Expected at least one {name} sample with data_disk=1"
             )
+
+        if not self.redpanda.dedicated_nodes:
+            # In docker, device resolution fails so the fallback path
+            # looks up IO queues by directory stat. Data and cache share
+            # one overlay device, so we expect exactly 1 sample per gauge
+            # with empty device/disk labels.
+            def check_label(name, sample, label, expected):
+                actual = sample.labels[label]
+                assert actual == expected, (
+                    f"{name} expected {label}={expected!r} in docker, got {actual!r}"
+                )
+
+            for name, samples in found.items():
+                assert len(samples) == 1, (
+                    f"{name} expected exactly 1 sample in docker, got {len(samples)}"
+                )
+                for label, expected in [
+                    ("device", ""),
+                    ("disk", ""),
+                    ("mountpoint", ""),
+                    ("id", "0"),
+                ]:
+                    check_label(name, samples[0], label, expected)
+
+    @cluster(num_nodes=1)
+    def test_io_queue_config_with_io_properties(self):
+        """
+        Restart Redpanda with a custom io-properties file pointing at the
+        data directory. This creates a dedicated Seastar IO queue (id > 0)
+        for the data dir mountpoint. We verify the configured rates appear
+        in the metrics.
+
+        On dedicated nodes with real block devices, we also expect a
+        default queue (id=0) series. In docker, device resolution falls
+        back to directory stat, and get_io_queue returns the configured
+        queue directly, so only 1 series is emitted.
+        """
+        node = self.redpanda.nodes[0]
+
+        io_props = {
+            "disks": [
+                {
+                    "mountpoint": RedpandaService.DATA_DIR,
+                    "read_iops": 10000,
+                    "read_bandwidth": 1000000000,
+                    "write_iops": 1000,
+                    "write_bandwidth": 100000000,
+                }
+            ]
+        }
+
+        io_props_path = "/tmp/test-io-properties.yaml"
+        node.account.create_file(io_props_path, yaml.dump(io_props))
+
+        self.redpanda.restart_nodes(
+            [node],
+            extra_cli=[f"--io-properties-file={io_props_path}"],
+        )
+
+        metrics = list(self.redpanda.metrics(node))
+
+        expected_gauges = {
+            "vectorized_io_queue_config_read_bytes_rate",
+            "vectorized_io_queue_config_write_bytes_rate",
+            "vectorized_io_queue_config_read_req_rate",
+            "vectorized_io_queue_config_write_req_rate",
+            "vectorized_io_queue_config_max_cost_function",
+            "vectorized_io_queue_config_duplex",
+        }
+
+        found = {}
+        for family in metrics:
+            if family.name in expected_gauges:
+                found[family.name] = family.samples
+
+        assert found.keys() == expected_gauges, (
+            f"Missing io_queue_config metrics: {expected_gauges - found.keys()}"
+        )
+
+        # Every gauge should have at least 1 sample with the configured
+        # mountpoint and the expected rate values.
+        for name, samples in found.items():
+            configured = [
+                s for s in samples if s.labels["mountpoint"] == RedpandaService.DATA_DIR
+            ]
+            assert len(configured) == 1, (
+                f"{name} expected 1 sample with mountpoint="
+                f"{RedpandaService.DATA_DIR}, got {len(configured)}"
+            )
+            assert int(configured[0].labels["id"]) > 0
+
+        def gauge_value(metric_name):
+            samples = found[f"vectorized_io_queue_config_{metric_name}"]
+            return [
+                s for s in samples if s.labels["mountpoint"] == RedpandaService.DATA_DIR
+            ][0].value
+
+        assert gauge_value("read_bytes_rate") == 1000000000
+        assert gauge_value("write_bytes_rate") == 100000000
+        assert gauge_value("read_req_rate") == 10000
+        assert gauge_value("write_req_rate") == 1000
+
+        # When io-properties points at the data dir, get_io_queue for that
+        # device returns the configured queue. Since data and cache share
+        # the same device, they deduplicate to 1 series.
+        for name, samples in found.items():
+            assert len(samples) == 1, f"{name} expected 1 sample, got {len(samples)}"

--- a/tests/rptest/tests/metrics_test.py
+++ b/tests/rptest/tests/metrics_test.py
@@ -7,13 +7,16 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import re
+
 from ducktape.mark import matrix
 from ducktape.tests.test import Test
 
 from rptest.clients.default import DefaultClient
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import make_redpanda_service
+from rptest.services.redpanda import MetricsEndpoint, make_redpanda_service
+from rptest.tests.redpanda_test import RedpandaTest
 
 BOOTSTRAP_CONFIG = {
     "disable_metrics": False,
@@ -79,3 +82,67 @@ class MetricsTest(Test):
 
         assert len(metrics_pre_change) != len(metrics_post_change)
         assert len(metrics_pre_change) == len(metrics_pre_chanage_again)
+
+
+class DisableMetricsTest(RedpandaTest):
+    # Allowlist of Seastar metric group prefixes that are expected to
+    # remain on the internal endpoint even with disable_metrics=True.
+    # Any metric family not matching is a Redpanda application metric
+    # and should not be present.
+    SEASTAR_METRIC_RE = re.compile(
+        r"^vectorized_("
+        r"alien|"
+        r"httpd|"
+        r"io_queue|"
+        r"memory|"
+        r"network|"
+        r"reactor|"
+        r"scheduler|"
+        r"stall_detector"
+        r")_"
+    )
+
+    def __init__(self, test_ctx):
+        super().__init__(
+            test_ctx,
+            num_brokers=1,
+            extra_rp_conf={
+                "disable_metrics": True,
+                "disable_public_metrics": True,
+            },
+        )
+
+    @cluster(num_nodes=1)
+    def test_disable_metrics(self):
+        """
+        Verify that starting Redpanda with both disable_metrics and
+        disable_public_metrics causes the internal endpoint to contain
+        only Seastar metrics (no Redpanda application metrics) and the
+        public endpoint to be completely empty.
+        """
+        node = self.redpanda.nodes[0]
+
+        # Check internal metrics: only Seastar metrics should remain.
+        internal_families = self.redpanda.metrics(node, MetricsEndpoint.METRICS)
+        non_seastar = [
+            f.name
+            for f in internal_families
+            if f.samples and not self.SEASTAR_METRIC_RE.match(f.name)
+        ]
+        for name in non_seastar:
+            self.redpanda.logger.debug(f"unexpected internal metric family: {name}")
+        assert len(non_seastar) == 0, (
+            f"Expected only Seastar metrics on internal endpoint, "
+            f"got {len(non_seastar)} Redpanda metric families: "
+            f"{non_seastar[:10]}"
+        )
+
+        # Check public metrics: should be completely empty.
+        public_families = self.redpanda.metrics(node, MetricsEndpoint.PUBLIC_METRICS)
+        non_empty = [f.name for f in public_families if f.samples]
+        for name in non_empty:
+            self.redpanda.logger.debug(f"unexpected public metric family: {name}")
+        assert len(non_empty) == 0, (
+            f"Expected no public metrics, got {len(non_empty)} "
+            f"families: {non_empty[:10]}"
+        )

--- a/tools/dev_cluster.py
+++ b/tools/dev_cluster.py
@@ -11,9 +11,15 @@
 # by the Apache License, Version 2.0
 # ==================================================================
 #
-# Start a 3 node cluster:
+# Start a 3 node cluster via bazel (builds redpanda automatically):
 #
-#   [jerry@winterland]$ dev_cluster.py -e vbuild/debug/clang/bin/redpanda
+#   bazel run --config=fastbuild //tools:dev_cluster -- [dev_cluster args] -- [redpanda args]
+#
+# Examples:
+#
+#   bazel run --config=fastbuild //tools:dev_cluster
+#   bazel run --config=fastbuild //tools:dev_cluster -- --nodes 1
+#   bazel run --config=release //tools:dev_cluster -- --nodes 1 -- --logger-log-level=io=debug
 #
 import argparse
 import asyncio


### PR DESCRIPTION
Scope host diskstat metrics to the data and cache directory devices rather than
reporting all block devices. This makes the metrics more useful for monitoring
Redpanda's actual storage I/O and provides the metrics & info needed by the 
SLF dashboard.

The commits build up the feature incrementally:

- Add `device_utils` for resolving filesystem paths to their underlying block
  device names via sysfs
- Scope `/proc/diskstats` metrics to the resolved data and cache devices, at
  both the partition level (e.g. `nvme0n1p1`) and whole-disk level (e.g.
  `nvme0n1` with `underlying_` prefix), with graceful fallback to unfiltered
  monitoring when resolution fails (e.g. in containers)
- Export IO queue configuration (iotune rates) as metrics, deduplicated by
  Seastar IO queue identity
- Add a `host_metrics_info` gauge (constant value 1) with labels describing
  device resolution state: `data_device`, `cache_device`, `same_partition`,
  `data_resolved`, `cache_resolved`, `data_has_io_queue`

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Improvements

* Scoped host diskstat metrics to the data and cache directory devices, reporting partition-level and whole-disk I/O separately
* Added IO queue configuration metrics exposing iotune rates per Seastar IO queue
* Added `host_metrics_info` gauge with labels describing device resolution and configuration state