### PR TITLE
rptest: Change new pkcs12 arguments for FIPS compatibility

### DIFF
--- a/tests/rptest/services/tls.py
+++ b/tests/rptest/services/tls.py
@@ -503,8 +503,10 @@ class TLSCertManager:
         Runs command to generate a new PKCS#12 file and returns the generated password
         """
         p12_password = self.generate_password(length=pw_length)
+        # note: -nomac required for FIPS compatibility on OpenSSL 3.0.x
+        # loses the file integrity check, but these certs are ephemeral
         self._exec(
-            f"openssl pkcs12 -export -inkey {key} -in {crt} -certfile {ca} -passout pass:{p12_password} -out {p12_file} -certpbe AES-256-CBC -keypbe AES-256-CBC -macalg SHA256"
+            f"openssl pkcs12 -export -inkey {key} -in {crt} -certfile {ca} -passout pass:{p12_password} -out {p12_file} -certpbe AES-256-CBC -keypbe AES-256-CBC -nomac"
         )
         return p12_password
 


### PR DESCRIPTION
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

### Bug Fixes

* The previous fix for DEVPROD-1907 was not FIPS compatible; this updated version should work on both FIPS and non-FIPS systems.