### PR TITLE
[CORE-15884] `storage`: Prevent use-after-modification in `disk_log_impl::disk_usage()`

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -4213,8 +4213,11 @@ ss::future<usage_report> disk_log_impl::disk_usage(gc_config cfg) {
             config::shard_local_cfg()
               .space_management_max_segment_concurrency()));
 
+        // Copy segment pointers so that concurrent modification of
+        // _segs does not invalidate the range we iterate over.
+        auto segments = _segs.copy();
         use = co_await ss::map_reduce(
-          _segs,
+          segments,
           [&limit](const segment_set::type& seg) {
               return ss::with_semaphore(
                 limit, 1, [&seg] { return seg->persistent_size(); });


### PR DESCRIPTION
There is nothing guarding `_segs` against concurrent modification within `disk_usage()`.
Make a copy of it before `co_await`'ing a `map_reduce` over the container when computing usage to prevent any undefined behavior/use-after-modification.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.3.x
- [X] v25.2.x
- [X] v25.1.x

## Release Notes

* none
