### PR TITLE
[v25.2.x] [CORE-15884] `storage`: Prevent use-after-modification in `disk_log_impl::disk_usage()`

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -4064,8 +4064,11 @@ ss::future<usage_report> disk_log_impl::disk_usage(gc_config cfg) {
           config::shard_local_cfg()
             .space_management_max_segment_concurrency()));
 
+        // Copy segment pointers so that concurrent modification of
+        // _segs does not invalidate the range we iterate over.
+        auto segments = _segs.copy();
         use = co_await ss::map_reduce(
-          _segs,
+          segments,
           [&limit](const segment_set::type& seg) {
               return ss::with_semaphore(
                 limit, 1, [&seg] { return seg->persistent_size(); });


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/29896
