### PR TITLE
lsm: add readahead buffering for compaction I/O

### DIFF
--- a/src/v/bytes/ioarray.cc
+++ b/src/v/bytes/ioarray.cc
@@ -97,6 +97,44 @@ ioarray::string_view::operator<=>(std::string_view other) const {
     return _views[1] <=> other;
 }
 
+ioarray ioarray::concat(ioarray a, ioarray b) {
+    if (a.empty()) {
+        return b;
+    }
+    if (b.empty()) {
+        return a;
+    }
+    // Fast path: when a's data ends on a chunk boundary and b has no offset,
+    // we can move buffers directly since the indexing math is preserved.
+    bool fast = b._offset == 0 && (a._offset + a._size) % max_chunk_size == 0;
+    if (fast) {
+        ioarray out(
+          uninitialized_t{},
+          (a._buffers.size() + b._buffers.size()) * max_chunk_size);
+        out._offset = a._offset;
+        out._size = a._size + b._size;
+        size_t i = 0;
+        for (auto& buf : a._buffers) {
+            out._buffers[i++] = std::move(buf);
+        }
+        for (auto& buf : b._buffers) {
+            out._buffers[i++] = std::move(buf);
+        }
+        return out;
+    }
+    // Slow path: copy both into a fresh ioarray.
+    size_t total = a._size + b._size;
+    ioarray out(total);
+    size_t pos = 0;
+    for (auto c : a.as_range()) {
+        out[pos++] = c;
+    }
+    for (auto c : b.as_range()) {
+        out[pos++] = c;
+    }
+    return out;
+}
+
 ioarray ioarray::copy_from(const iobuf& buf) {
     ioarray c(uninitialized_t{}, buf.size_bytes());
     iobuf_const_parser parser(buf);

--- a/src/v/bytes/ioarray.h
+++ b/src/v/bytes/ioarray.h
@@ -86,6 +86,16 @@ public:
     // `max_chunk_size` and that size is a multiple of alignment.
     static ioarray aligned(size_t alignment, size_t size);
 
+    // Concatenate two ioarrays. Both inputs are consumed.
+    //
+    // Fast path (zero-copy): when a's data ends on a chunk boundary
+    // (offset + size is a multiple of max_chunk_size) and b has offset 0,
+    // the underlying buffers are moved directly.
+    //
+    // Slow path (copy): otherwise, both arrays are copied byte-by-byte into
+    // a fresh ioarray.
+    static ioarray concat(ioarray a, ioarray b);
+
     // Create the ioarray from copying out of an iobuf.
     //
     // NOTE: This intended to be used for testing.

--- a/src/v/bytes/tests/ioarray_test.cc
+++ b/src/v/bytes/tests/ioarray_test.cc
@@ -17,7 +17,33 @@
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
+#include <random>
+
 // NOLINTBEGIN(*magic-numbers*)
+
+namespace {
+
+// Build a string where byte i = (base + i) & 0xFF.
+std::string make_pattern(size_t size, size_t base = 0) {
+    std::string s(size, '\0');
+    for (size_t i = 0; i < size; ++i) {
+        s[i] = static_cast<char>((base + i) & 0xFF);
+    }
+    return s;
+}
+
+// Fill an ioarray with the default pattern (byte i = i & 0xFF).
+ioarray make_filled(size_t size) {
+    return ioarray::copy_from(iobuf::from(make_pattern(size)));
+}
+
+// Check that arr's contents equal the pattern starting at base.
+void verify_pattern(const ioarray& arr, size_t base) {
+    auto expected = make_pattern(arr.size(), base);
+    EXPECT_TRUE(std::ranges::equal(arr.as_range(), expected));
+}
+
+} // namespace
 
 TEST(IOArray, StringView) {
     iobuf b;
@@ -461,6 +487,124 @@ TEST(IOArray, FromSizedBuffers) {
         EXPECT_THROW(
           { auto arr = ioarray::from_sized_buffers(bufs); },
           std::invalid_argument);
+    }
+}
+
+// -- concat tests --
+
+TEST(IOArray, ConcatEmpty) {
+    // Both empty
+    auto r1 = ioarray::concat(ioarray{}, ioarray{});
+    EXPECT_TRUE(r1.empty());
+
+    // Empty + non-empty
+    auto r2 = ioarray::concat(ioarray{}, make_filled(1000));
+    EXPECT_EQ(1000, r2.size());
+    verify_pattern(r2, 0);
+
+    // Non-empty + empty
+    auto r3 = ioarray::concat(make_filled(128_KiB), ioarray{});
+    EXPECT_EQ(128_KiB, r3.size());
+    verify_pattern(r3, 0);
+}
+
+TEST(IOArray, ConcatFastPath) {
+    // Fast path: a ends on a chunk boundary, b has offset 0.
+    struct testcase {
+        size_t a_size;
+        size_t b_size;
+    };
+    for (auto [a_size, b_size] : std::to_array<testcase>({
+           {.a_size = 128_KiB, .b_size = 50_KiB},
+           {.a_size = 128_KiB, .b_size = 128_KiB},
+           {.a_size = 3 * 128_KiB, .b_size = 2 * 128_KiB + 64_KiB},
+         })) {
+        auto result = ioarray::concat(
+          make_filled(a_size),
+          ioarray::copy_from(iobuf::from(make_pattern(b_size, a_size))));
+        verify_pattern(result, 0);
+    }
+
+    // Verify read_fixed32 across the chunk boundary
+    auto result = ioarray::concat(
+      make_filled(128_KiB),
+      ioarray::copy_from(iobuf::from(make_pattern(128_KiB, 128_KiB))));
+    auto byte = [](size_t i) -> uint32_t { return i & 0xFF; };
+    uint32_t expected = byte(128_KiB - 2) | (byte(128_KiB - 1) << 8u)
+                        | (byte(128_KiB) << 16u) | (byte(128_KiB + 1) << 24u);
+    EXPECT_EQ(expected, result.read_fixed32(128_KiB - 2));
+}
+
+TEST(IOArray, ConcatFastPathWithNonZeroOffset) {
+    // Fast path with a._offset != 0: offset+size = 128_KiB (chunk boundary).
+    auto full = make_filled(256_KiB);
+    auto a = full.share(100, 128_KiB - 100);
+    auto b = ioarray::copy_from(iobuf::from(make_pattern(50_KiB, 128_KiB)));
+    auto result = ioarray::concat(std::move(a), std::move(b));
+
+    auto expected = make_pattern(128_KiB - 100, 100)
+                    + make_pattern(50_KiB, 128_KiB);
+    EXPECT_TRUE(std::ranges::equal(result.as_range(), expected));
+
+    // read_fixed32 across the a/b boundary
+    size_t boundary = 128_KiB - 100;
+    auto byte = [](size_t i) -> uint32_t { return i & 0xFF; };
+    uint32_t exp32 = byte(100 + boundary - 2) | (byte(100 + boundary - 1) << 8u)
+                     | (byte(128_KiB) << 16u) | (byte(128_KiB + 1) << 24u);
+    EXPECT_EQ(exp32, result.read_fixed32(boundary - 2));
+}
+
+TEST(IOArray, ConcatSlowPath) {
+    // Small strings
+    {
+        auto result = ioarray::concat(
+          ioarray::copy_from(iobuf::from("hello")),
+          ioarray::copy_from(iobuf::from("world")));
+        EXPECT_TRUE(
+          std::ranges::equal(result.as_range(), std::string("helloworld")));
+    }
+    // Both misaligned (offsets + non-chunk-multiple size)
+    {
+        auto full_a = make_filled(300_KiB);
+        auto full_b = make_filled(200_KiB);
+        auto result = ioarray::concat(
+          full_a.share(10, 100_KiB), full_b.share(20, 80_KiB));
+
+        auto expected = make_pattern(100_KiB, 10) + make_pattern(80_KiB, 20);
+        EXPECT_TRUE(std::ranges::equal(result.as_range(), expected));
+    }
+}
+
+TEST(IOArray, ConcatRandomized) {
+    std::mt19937 rng(42);
+    std::uniform_int_distribution<size_t> size_dist(0, 512_KiB);
+    std::uniform_int_distribution<size_t> off_dist(0, 1000);
+
+    for (int iter = 0; iter < 100; ++iter) {
+        size_t a_size = size_dist(rng);
+        size_t b_size = size_dist(rng);
+        bool use_shares = iter >= 50;
+
+        size_t a_off = 0, b_off = 0;
+        size_t a_len = a_size, b_len = b_size;
+        if (use_shares && a_size > 1) {
+            a_off = std::min(off_dist(rng), a_size - 1);
+            a_len = a_size - a_off;
+        }
+        if (use_shares && b_size > 1) {
+            b_off = std::min(off_dist(rng), b_size - 1);
+            b_len = b_size - b_off;
+        }
+
+        auto src_a = make_filled(a_size);
+        auto a = use_shares ? src_a.share(a_off, a_len) : std::move(src_a);
+        auto src_b = make_filled(b_size);
+        auto b = use_shares ? src_b.share(b_off, b_len) : std::move(src_b);
+
+        auto result = ioarray::concat(std::move(a), std::move(b));
+        auto expected = make_pattern(a_len, a_off) + make_pattern(b_len, b_off);
+        ASSERT_TRUE(std::ranges::equal(result.as_range(), expected))
+          << "iter=" << iter;
     }
 }
 

--- a/src/v/lsm/core/internal/iterator.h
+++ b/src/v/lsm/core/internal/iterator.h
@@ -15,6 +15,13 @@
 
 namespace lsm::internal {
 
+// Options that control the behavior of iterators over SST files.
+struct iterator_options {
+    // The amount of extra data to read ahead on each block read. Buffered
+    // data is served to subsequent sequential reads without I/O.
+    size_t readahead_size = 0;
+};
+
 // A bi-directional iterator over sorted key-value pairs.
 class iterator {
 public:

--- a/src/v/lsm/core/internal/options.h
+++ b/src/v/lsm/core/internal/options.h
@@ -172,6 +172,12 @@ struct options {
     constexpr static size_t default_sst_block_size = 16_KiB;
     size_t sst_block_size = default_sst_block_size;
 
+    // The amount of extra data to read ahead when reading SST data blocks
+    // during compaction. Buffered data is served to subsequent sequential
+    // reads without I/O. Set to 0 to disable readahead.
+    constexpr static size_t default_compaction_readahead_size = 256_KiB;
+    size_t compaction_readahead_size = default_compaction_readahead_size;
+
     // The frequency at which to generate a new bloom filter.
     //
     // If set to 0 then no bloom filters will be generated.

--- a/src/v/lsm/db/compaction_task.cc
+++ b/src/v/lsm/db/compaction_task.cc
@@ -164,7 +164,8 @@ ss::future<ss::lw_shared_ptr<version_edit>> do_run_compaction_task(
       .compression = opts->levels[output_level].compression,
     };
     try {
-        auto input = co_await versions->make_input_iterator(compaction);
+        auto input = co_await versions->make_input_iterator(
+          compaction, {.readahead_size = opts->compaction_readahead_size});
         std::optional<internal::key> current_key;
         internal::sequence_number last_seqno_for_key
           = internal::sequence_number::max();

--- a/src/v/lsm/db/table_cache.cc
+++ b/src/v/lsm/db/table_cache.cc
@@ -93,10 +93,12 @@ class table_cache::impl {
     class wrapped_iterator : public internal::iterator {
     public:
         wrapped_iterator(
-          table_cache::impl* cache, ss::lw_shared_ptr<sst::reader> reader)
+          table_cache::impl* cache,
+          ss::lw_shared_ptr<sst::reader> reader,
+          internal::iterator_options opts)
           : _cache(cache)
           , _reader(std::move(reader))
-          , _underlying(_reader->create_iterator()) {}
+          , _underlying(_reader->create_iterator(opts)) {}
         wrapped_iterator(const wrapped_iterator&) = delete;
         wrapped_iterator(wrapped_iterator&&) = delete;
         wrapped_iterator& operator=(const wrapped_iterator&) = delete;
@@ -139,10 +141,12 @@ public:
           vlog(log.error, "table_cache_cleanup_error error=\"{}\"", ex);
       }) {}
 
-    ss::future<std::unique_ptr<internal::iterator>>
-    create_iterator(internal::file_handle h, uint64_t file_size) {
+    ss::future<std::unique_ptr<internal::iterator>> create_iterator(
+      internal::file_handle h,
+      uint64_t file_size,
+      internal::iterator_options opts) {
         auto table = co_await find_reader(h, file_size);
-        co_return std::make_unique<wrapped_iterator>(this, table);
+        co_return std::make_unique<wrapped_iterator>(this, table, opts);
     }
 
     ss::future<> get(
@@ -361,9 +365,11 @@ table_cache::table_cache(
 
 table_cache::~table_cache() = default;
 
-ss::future<std::unique_ptr<internal::iterator>>
-table_cache::create_iterator(internal::file_handle h, uint64_t file_size) {
-    return _impl->create_iterator(h, file_size);
+ss::future<std::unique_ptr<internal::iterator>> table_cache::create_iterator(
+  internal::file_handle h,
+  uint64_t file_size,
+  internal::iterator_options opts) {
+    return _impl->create_iterator(h, file_size, opts);
 }
 
 ss::future<> table_cache::get(

--- a/src/v/lsm/db/table_cache.h
+++ b/src/v/lsm/db/table_cache.h
@@ -40,8 +40,10 @@ public:
 
     // Create an iterator. All iterators returned from this method must
     // be destructed before the `close` method is called.
-    ss::future<std::unique_ptr<internal::iterator>>
-    create_iterator(internal::file_handle, uint64_t file_size);
+    ss::future<std::unique_ptr<internal::iterator>> create_iterator(
+      internal::file_handle,
+      uint64_t file_size,
+      internal::iterator_options opts = {});
 
     // Calls `fn` if the seek to `key` on this table would return a valid value.
     ss::future<> get(

--- a/src/v/lsm/db/version_set.cc
+++ b/src/v/lsm/db/version_set.cc
@@ -884,7 +884,8 @@ version_set::pick_compaction() {
 }
 
 ss::future<std::unique_ptr<internal::iterator>>
-version_set::make_input_iterator(compaction* c) {
+version_set::make_input_iterator(
+  compaction* c, internal::iterator_options iter_opts) {
     // Level 0 files have to be merged together. For other levels, we will make
     // a concatenating iterator per level.
     size_t space = c->level() == 0_level
@@ -903,18 +904,19 @@ version_set::make_input_iterator(compaction* c) {
                 // rely on compaction for that.
                 list.push_back(
                   co_await _table_cache->create_iterator(
-                    file->handle, file->file_size));
+                    file->handle, file->file_size, iter_opts));
             }
         } else {
             auto index_iter = std::make_unique<level_file_num_iterator>(
               &inputs);
             list.push_back(
               internal::create_two_level_iterator(
-                std::move(index_iter), [self = c->_input_version](iobuf value) {
+                std::move(index_iter),
+                [self = c->_input_version, iter_opts](iobuf value) {
                     auto [handle, file_size]
                       = level_file_num_iterator::decode_value(value);
                     return self->_vset->_table_cache->create_iterator(
-                      handle, file_size);
+                      handle, file_size, iter_opts);
                 }));
         }
     }

--- a/src/v/lsm/db/version_set.h
+++ b/src/v/lsm/db/version_set.h
@@ -182,7 +182,7 @@ public:
 
     // Create an iterator that reads over the compaction inputs.
     ss::future<std::unique_ptr<internal::iterator>>
-    make_input_iterator(compaction*);
+    make_input_iterator(compaction*, internal::iterator_options);
 
     // Get all the files that are currently being used by any live version.
     chunked_hash_set<internal::file_handle> get_live_files();

--- a/src/v/lsm/io/BUILD
+++ b/src/v/lsm/io/BUILD
@@ -74,6 +74,17 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "readahead_file_reader",
+    srcs = ["readahead_file_reader.cc"],
+    hdrs = ["readahead_file_reader.h"],
+    deps = [
+        ":persistence",
+        "//src/v/bytes:ioarray",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "file_io",
     srcs = ["file_io.cc"],
     hdrs = ["file_io.h"],

--- a/src/v/lsm/io/readahead_file_reader.cc
+++ b/src/v/lsm/io/readahead_file_reader.cc
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "lsm/io/readahead_file_reader.h"
+
+#include <seastar/core/align.hh>
+#include <seastar/core/coroutine.hh>
+
+#include <algorithm>
+
+namespace lsm::io {
+
+namespace {
+constexpr size_t alignment = ioarray::max_chunk_size;
+
+size_t align_down(size_t v) { return ss::align_down(v, alignment); }
+
+size_t align_up(size_t v) { return ss::align_up(v, alignment); }
+} // namespace
+
+readahead_file_reader::readahead_file_reader(
+  random_access_file_reader* inner, size_t file_size, size_t readahead_size)
+  : _inner(inner)
+  , _file_size(file_size)
+  , _readahead(readahead_size) {}
+
+ss::future<ioarray> readahead_file_reader::read(size_t offset, size_t n) {
+    if (
+      _buf.size() > 0 && offset >= _file_off
+      && offset + n <= _file_off + _buf.size()) {
+        // Serve from buffer if fully contained (nothing more to read)
+    } else if (
+      _buf.size() > 0 && offset >= _file_off
+      && offset < _file_off + _buf.size()) {
+        // Partial buffer hit: request starts in the buffer but extends past it
+        size_t missing_off = _file_off + _buf.size();
+        size_t missing_end = std::min(
+          align_up(offset + n + _readahead), _file_size);
+        auto fresh = co_await _inner->read(
+          missing_off, missing_end - missing_off);
+        _buf = ioarray::concat(std::move(_buf), std::move(fresh));
+    } else {
+        // Buffer miss: issue an aligned read
+        size_t aligned_off = align_down(offset);
+        size_t read_end = std::min(
+          align_up(offset + n + _readahead), _file_size);
+        _buf = co_await _inner->read(aligned_off, read_end - aligned_off);
+        _file_off = aligned_off;
+    }
+    // We've done all the reading we need to serve the read, now we can share
+    // out the data the caller asked for.
+    auto output = _buf.share(offset - _file_off, n);
+    // Snip off the beginning of our buffer so the next read is ready
+    size_t consumed = offset + n - _file_off;
+    _buf = _buf.share(consumed, _buf.size() - consumed);
+    _file_off = offset + n;
+    co_return output;
+}
+
+ss::future<> readahead_file_reader::close() { co_return; }
+
+fmt::iterator readahead_file_reader::format_to(fmt::iterator it) const {
+    return _inner->format_to(it);
+}
+
+} // namespace lsm::io

--- a/src/v/lsm/io/readahead_file_reader.h
+++ b/src/v/lsm/io/readahead_file_reader.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "lsm/io/persistence.h"
+
+namespace lsm::io {
+
+/// A non-owning wrapper around random_access_file_reader that issues larger
+/// reads than requested and buffers the extra bytes. Subsequent sequential
+/// reads are served from the buffer without disk I/O.
+///
+/// All reads to the underlying reader are aligned to ioarray::max_chunk_size
+/// boundaries so that the buffer can be extended via ioarray::concat without
+/// copying, eliminating read amplification on partial buffer hits.
+///
+/// The caller must ensure the wrapped reader outlives this object.
+class readahead_file_reader final : public random_access_file_reader {
+public:
+    readahead_file_reader(
+      random_access_file_reader* inner,
+      size_t file_size,
+      size_t readahead_size);
+
+    ss::future<ioarray> read(size_t offset, size_t n) override;
+    ss::future<> close() override;
+    fmt::iterator format_to(fmt::iterator it) const override;
+
+private:
+    random_access_file_reader* _inner;
+    size_t _file_size;
+    size_t _readahead;
+    ioarray _buf;
+    size_t _file_off{0};
+};
+
+} // namespace lsm::io

--- a/src/v/lsm/io/tests/BUILD
+++ b/src/v/lsm/io/tests/BUILD
@@ -1,6 +1,24 @@
 load("//bazel:test.bzl", "redpanda_cc_gtest")
 
 redpanda_cc_gtest(
+    name = "readahead_file_reader_test",
+    timeout = "short",
+    srcs = [
+        "readahead_file_reader_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes:ioarray",
+        "//src/v/lsm/io:persistence",
+        "//src/v/lsm/io:readahead_file_reader",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "persistence_test",
     timeout = "short",
     srcs = [

--- a/src/v/lsm/io/tests/readahead_file_reader_test.cc
+++ b/src/v/lsm/io/tests/readahead_file_reader_test.cc
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "bytes/ioarray.h"
+#include "lsm/io/persistence.h"
+#include "lsm/io/readahead_file_reader.h"
+
+#include <seastar/core/coroutine.hh>
+
+#include <gtest/gtest.h>
+
+#include <random>
+
+// NOLINTBEGIN(*magic-numbers*)
+
+using namespace lsm::io;
+
+namespace {
+
+/// A fake file reader backed by an in-memory buffer with a known byte pattern.
+/// Tracks the number of read calls and total bytes read so tests can verify
+/// that readahead reduces I/O.
+class fake_file_reader final : public random_access_file_reader {
+public:
+    explicit fake_file_reader(size_t size)
+      : _size(size) {
+        // Fill with a deterministic pattern: byte i = i & 0xFF
+        iobuf b;
+        for (size_t i = 0; i < size; ++i) {
+            char c = static_cast<char>(i & 0xFF);
+            b.append(&c, 1);
+        }
+        _data = ioarray::copy_from(b);
+    }
+
+    ss::future<ioarray> read(size_t offset, size_t n) override {
+        ++_read_count;
+        _bytes_read += n;
+        co_return _data.share(offset, n);
+    }
+
+    ss::future<> close() override { co_return; }
+
+    fmt::iterator format_to(fmt::iterator it) const override {
+        return fmt::format_to(it, "{{fake_file_reader size={}}}", _size);
+    }
+
+    size_t file_size() const { return _size; }
+    size_t read_count() const { return _read_count; }
+    size_t bytes_read() const { return _bytes_read; }
+
+    /// Verify that the given ioarray matches the expected pattern at offset.
+    void verify(const ioarray& arr, size_t offset) const {
+        for (size_t i = 0; i < arr.size(); ++i) {
+            ASSERT_EQ(static_cast<char>((offset + i) & 0xFF), arr[i])
+              << "mismatch at file offset " << (offset + i);
+        }
+    }
+
+private:
+    size_t _size;
+    ioarray _data;
+    size_t _read_count{0};
+    size_t _bytes_read{0};
+};
+
+} // namespace
+
+TEST(ReadaheadFileReader, FullBufferHit) {
+    // A single read should populate the buffer. A subsequent read within the
+    // buffered range should not hit the underlying reader.
+    fake_file_reader inner(1_MiB);
+    readahead_file_reader ra(&inner, inner.file_size(), 256_KiB);
+
+    auto data = ra.read(0, 16_KiB).get();
+    inner.verify(data, 0);
+    EXPECT_EQ(16_KiB, data.size());
+
+    size_t reads_after_first = inner.read_count();
+
+    // This should be served entirely from the buffer.
+    auto data2 = ra.read(16_KiB, 16_KiB).get();
+    inner.verify(data2, 16_KiB);
+    EXPECT_EQ(reads_after_first, inner.read_count());
+
+    ra.close().get();
+}
+
+TEST(ReadaheadFileReader, SequentialReadsReduceIO) {
+    // Reading 16_KiB blocks sequentially with 256_KiB readahead should issue
+    // far fewer reads than one per block.
+    fake_file_reader inner(1_MiB);
+    readahead_file_reader ra(&inner, inner.file_size(), 256_KiB);
+
+    size_t block_size = 16_KiB;
+    size_t num_blocks = inner.file_size() / block_size;
+    for (size_t i = 0; i < num_blocks; ++i) {
+        auto data = ra.read(i * block_size, block_size).get();
+        inner.verify(data, i * block_size);
+    }
+
+    // With 256_KiB readahead, ~1_MiB / (256_KiB + alignment overhead) reads.
+    // Without readahead it would be 64 reads. We should be well under that.
+    EXPECT_LT(inner.read_count(), num_blocks / 2);
+
+    ra.close().get();
+}
+
+TEST(ReadaheadFileReader, PartialBufferHitExtends) {
+    // A read that starts within the buffer but extends past it should only
+    // read the missing portion (not re-read what's buffered).
+    fake_file_reader inner(1_MiB);
+    readahead_file_reader ra(&inner, inner.file_size(), 128_KiB);
+
+    // First read populates the buffer
+    auto d1 = ra.read(0, 16_KiB).get();
+    inner.verify(d1, 0);
+    size_t bytes_after_first = inner.bytes_read();
+
+    // This read should extend past the initial buffer. The readahead reader
+    // should concat rather than re-read from the start.
+    auto d2 = ra.read(0, 512_KiB).get();
+    inner.verify(d2, 0);
+
+    // The additional bytes read should be roughly 512_KiB - buffer_already_had,
+    // not a full re-read of 512_KiB + readahead from offset 0.
+    size_t additional_bytes = inner.bytes_read() - bytes_after_first;
+    EXPECT_LT(additional_bytes, 512_KiB + 256_KiB);
+
+    ra.close().get();
+}
+
+TEST(ReadaheadFileReader, BufferMissResetsBuffer) {
+    // A read that starts past the buffer should discard the old buffer and
+    // issue a fresh aligned read.
+    fake_file_reader inner(1_MiB);
+    readahead_file_reader ra(&inner, inner.file_size(), 128_KiB);
+
+    auto d1 = ra.read(0, 16_KiB).get();
+    inner.verify(d1, 0);
+
+    // Jump far ahead - this is a buffer miss.
+    auto d2 = ra.read(800_KiB, 16_KiB).get();
+    inner.verify(d2, 800_KiB);
+
+    // The old buffer at offset 0 is gone. Reading from 0 again hits disk.
+    size_t reads_before = inner.read_count();
+    auto d3 = ra.read(0, 16_KiB).get();
+    inner.verify(d3, 0);
+    EXPECT_GT(inner.read_count(), reads_before);
+
+    ra.close().get();
+}
+
+TEST(ReadaheadFileReader, ReadAtEndOfFile) {
+    // Reads near the end of file should be clamped and not overshoot.
+    size_t file_size = 500_KiB;
+    fake_file_reader inner(file_size);
+    readahead_file_reader ra(&inner, file_size, 256_KiB);
+
+    auto data = ra.read(file_size - 100, 100).get();
+    EXPECT_EQ(100, data.size());
+    inner.verify(data, file_size - 100);
+
+    ra.close().get();
+}
+
+TEST(ReadaheadFileReader, SingleByteReads) {
+    // Reading one byte at a time should still work correctly and benefit
+    // from readahead.
+    fake_file_reader inner(64_KiB);
+    readahead_file_reader ra(&inner, inner.file_size(), 64_KiB);
+
+    for (size_t i = 0; i < inner.file_size(); ++i) {
+        auto data = ra.read(i, 1).get();
+        ASSERT_EQ(1, data.size());
+        ASSERT_EQ(static_cast<char>(i & 0xFF), data[0]) << "i=" << i;
+    }
+
+    // Should need very few underlying reads for the whole file.
+    EXPECT_LE(inner.read_count(), 3);
+
+    ra.close().get();
+}
+
+TEST(ReadaheadFileReader, ExactFileSize) {
+    // Reading the entire file in one go.
+    size_t file_size = 300_KiB;
+    fake_file_reader inner(file_size);
+    readahead_file_reader ra(&inner, file_size, 128_KiB);
+
+    auto data = ra.read(0, file_size).get();
+    EXPECT_EQ(file_size, data.size());
+    inner.verify(data, 0);
+
+    ra.close().get();
+}
+
+TEST(ReadaheadFileReader, RandomAccessPattern) {
+    // Random access should always return correct data, even if the buffer
+    // is invalidated frequently.
+    size_t file_size = 1_MiB;
+    fake_file_reader inner(file_size);
+    readahead_file_reader ra(&inner, file_size, 128_KiB);
+
+    std::mt19937 rng(42);
+    std::uniform_int_distribution<size_t> off_dist(0, file_size - 1);
+
+    for (int i = 0; i < 200; ++i) {
+        size_t offset = off_dist(rng);
+        size_t max_n = file_size - offset;
+        std::uniform_int_distribution<size_t> len_dist(
+          1, std::min(max_n, 64_KiB));
+        size_t n = len_dist(rng);
+
+        auto data = ra.read(offset, n).get();
+        ASSERT_EQ(n, data.size()) << "iter=" << i;
+        inner.verify(data, offset);
+    }
+
+    ra.close().get();
+}
+
+TEST(ReadaheadFileReader, ZeroReadahead) {
+    // With readahead_size=0, reads are still aligned to max_chunk_size so
+    // some coalescing occurs. But each aligned region should be read at most
+    // once. 256_KiB / 128_KiB = 2 aligned regions.
+    fake_file_reader inner(256_KiB);
+    readahead_file_reader ra(&inner, inner.file_size(), 0);
+
+    for (size_t i = 0; i < 16; ++i) {
+        auto data = ra.read(i * 16_KiB, 16_KiB).get();
+        inner.verify(data, i * 16_KiB);
+    }
+
+    // 256_KiB file, 128_KiB alignment → 2 aligned reads
+    EXPECT_EQ(2, inner.read_count());
+
+    ra.close().get();
+}
+
+TEST(ReadaheadFileReader, SmallFile) {
+    // A file smaller than the readahead size.
+    fake_file_reader inner(100);
+    readahead_file_reader ra(&inner, inner.file_size(), 256_KiB);
+
+    auto d1 = ra.read(0, 50).get();
+    inner.verify(d1, 0);
+
+    auto d2 = ra.read(50, 50).get();
+    inner.verify(d2, 50);
+
+    // Entire file should be buffered after the first read.
+    EXPECT_EQ(1, inner.read_count());
+
+    ra.close().get();
+}
+
+TEST(ReadaheadFileReader, FullyConsumedBufferThenNewRead) {
+    // When a read fully consumes the buffer, _buf_off must be updated so
+    // the next read doesn't incorrectly match the stale buffer position.
+    fake_file_reader inner(1_MiB);
+    readahead_file_reader ra(&inner, inner.file_size(), 0);
+
+    // Read exactly one aligned chunk — this fills then fully consumes the
+    // buffer
+    auto d1 = ra.read(0, 128_KiB).get();
+    inner.verify(d1, 0);
+
+    // A second read at a different offset must get correct data, not be
+    // confused by stale _buf_off.
+    auto d2 = ra.read(256_KiB, 128_KiB).get();
+    inner.verify(d2, 256_KiB);
+
+    ra.close().get();
+}
+
+TEST(ReadaheadFileReader, BufferDoesNotGrowUnbounded) {
+    // Sequential reads should trim consumed data from the front, keeping
+    // the buffer bounded to roughly the readahead size, not the whole file.
+    size_t file_size = 4_MiB;
+    size_t readahead = 256_KiB;
+    fake_file_reader inner(file_size);
+    readahead_file_reader ra(&inner, file_size, readahead);
+
+    size_t block_size = 16_KiB;
+    for (size_t off = 0; off + block_size <= file_size; off += block_size) {
+        auto data = ra.read(off, block_size).get();
+        inner.verify(data, off);
+    }
+
+    // The total bytes read from the underlying reader should be close to the
+    // file size (each byte read ~once), not multiples of it.
+    EXPECT_LE(
+      inner.bytes_read(), file_size + readahead + ioarray::max_chunk_size);
+
+    ra.close().get();
+}
+
+// NOLINTEND(*magic-numbers*)

--- a/src/v/lsm/sst/BUILD
+++ b/src/v/lsm/sst/BUILD
@@ -69,6 +69,7 @@ redpanda_cc_library(
         "//src/v/lsm/core:compression",
         "//src/v/lsm/core:exceptions",
         "//src/v/lsm/core/internal:two_level_iterator",
+        "//src/v/lsm/io:readahead_file_reader",
     ],
     deps = [
         ":block_cache",

--- a/src/v/lsm/sst/reader.cc
+++ b/src/v/lsm/sst/reader.cc
@@ -17,6 +17,7 @@
 #include "lsm/core/exceptions.h"
 #include "lsm/core/internal/two_level_iterator.h"
 #include "lsm/io/persistence.h"
+#include "lsm/io/readahead_file_reader.h"
 #include "lsm/sst/footer.h"
 
 #include <seastar/core/coroutine.hh>
@@ -86,20 +87,33 @@ public:
       internal::file_id id,
       block::reader index_block,
       std::unique_ptr<io::random_access_file_reader> file,
+      size_t file_size,
       std::optional<block::filter_reader> filter,
       ss::lw_shared_ptr<block_cache> cache)
       : _id(id)
       , _file(std::move(file))
+      , _file_size(file_size)
       , _index_block(std::move(index_block))
       , _filter(std::move(filter))
       , _cache(std::move(cache)) {}
 
-    std::unique_ptr<internal::iterator> create_iterator() {
+    std::unique_ptr<internal::iterator>
+    create_iterator(internal::iterator_options opts) {
+        if (opts.readahead_size == 0) {
+            return internal::create_two_level_iterator(
+              _index_block.create_iterator(), [this](iobuf index_value) {
+                  return block_reader(std::move(index_value), _file.get());
+              });
+        }
+        auto ra = std::make_shared<io::readahead_file_reader>(
+          _file.get(), _file_size, opts.readahead_size);
         return internal::create_two_level_iterator(
-          _index_block.create_iterator(), [this](iobuf index_value) {
-              return block_reader(std::move(index_value));
+          _index_block.create_iterator(),
+          [this, ra = std::move(ra)](iobuf index_value) {
+              return block_reader(std::move(index_value), ra.get());
           });
     }
+
     ss::future<> internal_get(
       internal::key_view key,
       absl::FunctionRef<ss::future<>(internal::key_view, iobuf)> fn) {
@@ -116,7 +130,7 @@ public:
                 co_return;
             }
         }
-        auto block_iter = co_await block_reader(std::move(v));
+        auto block_iter = co_await block_reader(std::move(v), _file.get());
         co_await block_iter->seek(key);
         if (block_iter->valid()) {
             co_await fn(block_iter->key(), block_iter->value());
@@ -127,13 +141,13 @@ public:
 
 private:
     ss::future<std::unique_ptr<internal::iterator>>
-    block_reader(iobuf index_value) {
+    block_reader(iobuf index_value, io::random_access_file_reader* file) {
         auto block_handle = block::handle::from_iobuf(std::move(index_value));
         auto cache_handle = co_await _cache->get(_id, block_handle);
         if (auto reader = cache_handle.get()) {
             co_return reader->create_iterator();
         }
-        auto contents = co_await read_block(_file.get(), block_handle);
+        auto contents = co_await read_block(file, block_handle);
         auto rdr = block::reader(std::move(contents));
         auto it = rdr.create_iterator();
         cache_handle.insert(std::move(rdr));
@@ -142,6 +156,7 @@ private:
 
     internal::file_id _id;
     std::unique_ptr<io::random_access_file_reader> _file;
+    size_t _file_size;
     block::reader _index_block;
     std::optional<block::filter_reader> _filter;
     ss::lw_shared_ptr<block_cache> _cache;
@@ -180,6 +195,7 @@ ss::future<reader> reader::open(
             id,
             std::move(index_block),
             std::move(file),
+            file_size,
             std::move(filter),
             std::move(block_cache)));
     } catch (...) {
@@ -191,8 +207,9 @@ ss::future<reader> reader::open(
     std::rethrow_exception(ep);
 }
 
-std::unique_ptr<internal::iterator> reader::create_iterator() {
-    return _impl->create_iterator();
+std::unique_ptr<internal::iterator>
+reader::create_iterator(internal::iterator_options opts) {
+    return _impl->create_iterator(opts);
 }
 
 ss::future<> reader::internal_get(

--- a/src/v/lsm/sst/reader.h
+++ b/src/v/lsm/sst/reader.h
@@ -44,7 +44,8 @@ public:
     //
     // The result of create_iterator is initially invalid (caller must call one
     // of the seek* methods on the iterator before using it).
-    std::unique_ptr<internal::iterator> create_iterator();
+    std::unique_ptr<internal::iterator>
+    create_iterator(internal::iterator_options opts = {});
 
     // Calls the function with the key/value pair with the entry found after a
     // call to `create_iterator()->seek(key)`. May not make such a call if the


### PR DESCRIPTION
Add readahead buffering to compaction iterators to reduce per-block I/O
syscalls during sequential SST scans.

The first commit adds `ioarray::concat` which enables zero-copy buffer
extension when data is chunk-aligned. The second introduces
`readahead_file_reader`, a non-owning wrapper that issues chunk-aligned
over-reads and serves subsequent sequential reads from its buffer. The
third threads `iterator_options` through `table_cache` and `sst::reader`
so compaction uses the new `compaction_readahead_size` option (default
256KiB) while user iterators and point lookups remain unaffected.

`fillrandom` benchmark: 20K → 37K ops/sec (+84%), 148s → 80s.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none