### PR TITLE
ct: invalidate cached epoch

### DIFF
--- a/src/v/cloud_topics/cluster_services.h
+++ b/src/v/cloud_topics/cluster_services.h
@@ -40,6 +40,11 @@ public:
      */
     virtual seastar::future<cluster_epoch>
     current_epoch(seastar::abort_source*) = 0;
+
+    /*
+     * Invalidatae any epoch caching that maybe happening is below
+     */
+    virtual seastar::future<> invalidate_epoch_below(cluster_epoch) = 0;
 };
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/data_plane_api.h
+++ b/src/v/cloud_topics/data_plane_api.h
@@ -63,8 +63,7 @@ public:
     stage_write(chunked_vector<model::record_batch> batches) = 0;
 
     // Execute this write using the reservation.
-    virtual ss::future<
-      std::expected<chunked_vector<extent_meta>, std::error_code>>
+    virtual ss::future<std::expected<upload_meta, std::error_code>>
     execute_write(
       model::ntp ntp,
       cluster_epoch min_epoch,

--- a/src/v/cloud_topics/data_plane_api.h
+++ b/src/v/cloud_topics/data_plane_api.h
@@ -12,6 +12,7 @@
 
 #include "base/outcome.h"
 #include "cloud_topics/level_zero/common/extent_meta.h"
+#include "cloud_topics/types.h"
 #include "container/chunked_vector.h"
 #include "model/fundamental.h"
 #include "model/record.h"
@@ -110,6 +111,10 @@ public:
     /// Retrieve current cluster epoch
     virtual ss::future<std::optional<cloud_topics::cluster_epoch>>
     get_current_epoch(ss::abort_source* as) = 0;
+
+    /// Invalid the current epoch window if it's below this value.
+    virtual ss::future<>
+      invalidate_epoch_below(cloud_topics::cluster_epoch) = 0;
 
     /// Wait until a batch at or beyond \p offset has been added to the cache
     /// for \p tidp, or until timeout/abort. \p last_known seeds a newly

--- a/src/v/cloud_topics/data_plane_impl.cc
+++ b/src/v/cloud_topics/data_plane_impl.cc
@@ -148,8 +148,7 @@ public:
         co_return staged_write{.staged = std::move(staged)};
     }
 
-    ss::future<std::expected<chunked_vector<extent_meta>, std::error_code>>
-    execute_write(
+    ss::future<std::expected<upload_meta, std::error_code>> execute_write(
       model::ntp ntp,
       cluster_epoch min_epoch,
       staged_write reservation,

--- a/src/v/cloud_topics/data_plane_impl.cc
+++ b/src/v/cloud_topics/data_plane_impl.cc
@@ -237,6 +237,10 @@ public:
         co_return epoch_fut.get();
     }
 
+    ss::future<> invalidate_epoch_below(cluster_epoch epoch) noexcept final {
+        co_await _cluster_services.local().invalidate_epoch_below(epoch);
+    }
+
 private:
     ss::sharded<l0::cluster_services> _cluster_services;
     // Write path

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -587,6 +587,10 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
     const auto& ntp = partition->ntp();
     // The default errc that will cause the client to retry the operation
     constexpr auto default_errc = raft::errc::timeout;
+    auto timeout = opts.timeout.value_or(0ms);
+    if (timeout == 0ms) {
+        timeout = L0_upload_default_timeout;
+    }
     /*
      * L0 GC relies on a minimum epoch associated with each NTP for calculating
      * the name of an L0 object. The minimum is based on the topic revision, but
@@ -595,20 +599,42 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
      * the rest of its journey.
      */
     auto min_epoch = cluster_epoch(partition->get_topic_revision_id());
+
+    /*
+     * Sync the STM so that our min_accepted epoch is not stale.
+     */
+    if (opts.as) {
+        co_await ctp_stm_api->sync_in_term(
+          model::time_from_now(timeout), opts.as->get());
+    } else {
+        ss::abort_source as;
+        co_await ctp_stm_api->sync_in_term(model::time_from_now(timeout), as);
+    }
+
+    /*
+     * We want to prevent from uploading data we know is going to get rejected,
+     * so we want to upload and ensure the epoch doesn't get fenced. So we
+     * have two options here we can enforce either bound of our window. We
+     * choose to use the max epoch here so that if something else in-flight
+     * pushes the window we have buffer to still accept this batch.
+     */
+    auto accepted_min = ctp_stm_api->get_max_seen_epoch(partition->term());
+    if (!accepted_min) {
+        accepted_min = ctp_stm_api->get_max_epoch();
+    }
+    if (accepted_min) {
+        min_epoch = std::max(min_epoch, *accepted_min);
+    }
+
     vassert(
       min_epoch() > 0L,
       "Unexpected invalid min epoch {} for {}",
       min_epoch,
       ntp);
 
-    if (auto current_min_epoch = ctp_stm_api->get_min_accepted_epoch()) {
-        co_await api->invalidate_epoch_below(current_min_epoch.value());
-    }
+    // Invalidate the epoch if it's below some threshold.
+    co_await api->invalidate_epoch_below(min_epoch);
 
-    auto timeout = opts.timeout.value_or(0ms);
-    if (timeout == 0ms) {
-        timeout = L0_upload_default_timeout;
-    }
     auto upload_fut = co_await ss::coroutine::as_future(api->execute_write(
       ntp,
       min_epoch,

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -601,6 +601,10 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
       min_epoch,
       ntp);
 
+    if (auto current_min_epoch = ctp_stm_api->get_min_accepted_epoch()) {
+        co_await api->invalidate_epoch_below(current_min_epoch.value());
+    }
+
     auto timeout = opts.timeout.value_or(0ms);
     if (timeout == 0ms) {
         timeout = L0_upload_default_timeout;

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -630,12 +630,14 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
           upload_res.error().message());
         co_return default_errc;
     }
-    if (upload_res.value().empty()) {
+    if (upload_res.value().extents.empty()) {
         vlog(
           cd_log.warn,
           "LO object upload returned empty result, nothing to replicate");
         co_return default_errc;
     }
+
+    auto batch_epoch = upload_res.value().extents.front().id.epoch;
 
     // Wait for all previous requests from this producer to be processed
     if (opts.as) {
@@ -650,7 +652,7 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
     // (because it needs to drain current requests as the epoch is being
     // bumped).
     auto fence_fut = co_await ss::coroutine::as_future(
-      ctp_stm_api->fence_epoch(upload_res.value().front().id.epoch));
+      ctp_stm_api->fence_epoch(batch_epoch));
     if (fence_fut.failed()) {
         auto not_leader = !partition->is_leader();
         auto e = fence_fut.get_exception();
@@ -658,7 +660,7 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
             vlog(
               cd_log.debug,
               "Failed to fence epoch {} for ntp {}, not a leader",
-              upload_res.value().front().id.epoch,
+              batch_epoch,
               ntp);
         } else {
             vlogl(
@@ -666,7 +668,7 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
               ssx::is_shutdown_exception(e) ? ss::log_level::debug
                                             : ss::log_level::warn,
               "Failed to fence epoch {} for ntp {}, error: {}",
-              upload_res.value().front().id.epoch,
+              batch_epoch,
               ntp,
               e);
         }
@@ -674,6 +676,13 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
     }
     auto fence = std::move(fence_fut.get());
     if (!fence.has_value()) {
+        auto upload_shard = upload_res.value().shard;
+        // If the upload failed, then maybe just that shard is behind, we'll
+        // dispatch a request to that shard to invalidate the epoch.
+        co_await ss::smp::submit_to(
+          upload_shard, [api, e = fence.error().window_min] {
+              return api->invalidate_epoch_below(e);
+          });
         auto no_window = fence.error().window_min == fence.error().window_max;
         // NOTE: we might see the error when the partition is just created
         // or right after the leadership transfer. This is transient state
@@ -684,7 +693,7 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
           cd_log,
           no_window ? ss::log_level::debug : ss::log_level::warn,
           "Failed to fence epoch {} for ntp {}, ctp window is [{}, {}]",
-          upload_res.value().front().id.epoch,
+          batch_epoch,
           ntp,
           fence.error().window_min,
           fence.error().window_max);
@@ -694,7 +703,7 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
     chunked_vector<model::record_batch_header> headers;
     headers.push_back(header);
     auto placeholders = co_await convert_to_placeholders(
-      upload_res.value(), headers);
+      upload_res.value().extents, headers);
 
     vassert(
       placeholders.batches.size() == 1,
@@ -799,8 +808,10 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
         co_return std::unexpected(res.error());
     }
 
+    auto batch_epoch = res.value().extents.front().id.epoch;
+
     auto fence_fut = co_await ss::coroutine::as_future(
-      _ctp_stm_api->fence_epoch(res.value().front().id.epoch));
+      _ctp_stm_api->fence_epoch(batch_epoch));
     if (fence_fut.failed()) {
         auto not_leader = !_partition->is_leader();
         auto e = fence_fut.get_exception();
@@ -808,7 +819,7 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
             vlog(
               cd_log.debug,
               "Failed to fence epoch {} for ntp {}, not a leader",
-              res.value().front().id.epoch,
+              batch_epoch,
               ntp());
         } else {
             vlogl(
@@ -816,7 +827,7 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
               ssx::is_shutdown_exception(e) ? ss::log_level::debug
                                             : ss::log_level::warn,
               "Failed to fence epoch {} for ntp {}, error: {}",
-              res.value().front().id.epoch,
+              batch_epoch,
               ntp(),
               e);
         }
@@ -828,7 +839,7 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
           cd_log.warn,
           "Failed to fence epoch {} for ntp {}, ctp latest seen epoch is [{}, "
           "{}]",
-          res.value().front().id.epoch,
+          batch_epoch,
           ntp(),
           fence.error().window_min,
           fence.error().window_max);
@@ -836,7 +847,8 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
           kafka::make_error_code(kafka::error_code::request_timed_out));
     }
 
-    auto placeholders = co_await convert_to_placeholders(res.value(), headers);
+    auto placeholders = co_await convert_to_placeholders(
+      res.value().extents, headers);
 
     chunked_vector<model::record_batch> placeholder_batches;
     for (auto&& batch : placeholders.batches) {

--- a/src/v/cloud_topics/frontend/tests/frontend_test.cc
+++ b/src/v/cloud_topics/frontend/tests/frontend_test.cc
@@ -48,7 +48,7 @@ public:
       (override));
 
     MOCK_METHOD(
-      (ss::future<std::expected<chunked_vector<extent_meta>, std::error_code>>),
+      (ss::future<std::expected<upload_meta, std::error_code>>),
       execute_write,
       (model::ntp,
        cluster_epoch,
@@ -124,9 +124,8 @@ auto make_extent_fut(model::offset o, cluster_epoch epoch) {
 
     chunked_vector<extent_meta> vec;
     vec.push_back(std::move(m));
-    return ss::make_ready_future<
-      std::expected<chunked_vector<extent_meta>, std::error_code>>(
-      std::move(vec));
+    return ss::make_ready_future<std::expected<upload_meta, std::error_code>>(
+      upload_meta{.shard = ss::this_shard_id(), .extents = std::move(vec)});
 }
 
 class frontend_fixture

--- a/src/v/cloud_topics/frontend/tests/frontend_test.cc
+++ b/src/v/cloud_topics/frontend/tests/frontend_test.cc
@@ -103,6 +103,12 @@ public:
       (ss::abort_source*),
       (noexcept, override));
 
+    MOCK_METHOD(
+      ss::future<>,
+      invalidate_epoch_below,
+      (cloud_topics::cluster_epoch),
+      (noexcept, override));
+
     MOCK_METHOD(ss::future<>, start, (), (override));
 
     MOCK_METHOD(ss::future<>, stop, (), (override));
@@ -212,6 +218,60 @@ TEST_F(frontend_fixture, test_replicate_epoch) {
                      .get();
         ASSERT_FALSE(res.has_value());
     }
+}
+
+TEST_F(frontend_fixture, test_replicate_invalidates_epoch_cache) {
+    const model::topic topic_name("epoch_invalidate");
+    model::ntp ntp(model::kafka_namespace, topic_name, 0);
+
+    cluster::topic_properties props;
+    props.storage_mode = model::redpanda_storage_mode::cloud;
+    props.shadow_indexing = model::shadow_indexing_mode::disabled;
+
+    add_topic({model::kafka_namespace, topic_name}, 1, props).get();
+    wait_for_leader(ntp).get();
+
+    auto partition = app.partition_manager.local().get(ntp);
+    ASSERT_TRUE(
+      partition->raft()->stm_manager()->get<cloud_topics::ctp_stm>()
+      != nullptr);
+
+    cloud_topics::frontend frontend(std::move(partition), _data_plane.get());
+
+    // Advance epoch twice to establish previous_applied_epoch = 5.
+    auto r1 = frontend.advance_epoch(cluster_epoch(5), model::no_timeout).get();
+    ASSERT_TRUE(r1.has_value());
+    auto r2
+      = frontend.advance_epoch(cluster_epoch(10), model::no_timeout).get();
+    ASSERT_TRUE(r2.has_value());
+
+    using stage_result = std::expected<staged_write, std::error_code>;
+    EXPECT_CALL(*_data_plane, stage_write(_))
+      .WillOnce(Return(ss::as_ready_future(stage_result{})));
+    EXPECT_CALL(*_data_plane, execute_write(_, _, _, _))
+      .WillOnce(Return(make_extent_fut(model::offset(0), cluster_epoch(7))));
+    EXPECT_CALL(*_data_plane, invalidate_epoch_below(cluster_epoch(5)))
+      .WillOnce(Return(ss::now()));
+    ON_CALL(*_data_plane, cache_put_ordered(_, _))
+      .WillByDefault([](const auto&, auto) {});
+
+    auto batch = model::test::make_random_batch(model::offset{0}, false);
+    model::batch_identity batch_id{
+      .pid = model::producer_identity{1, 0},
+      .first_seq = 0,
+      .last_seq = 0,
+      .record_count = batch.record_count(),
+      .max_timestamp = batch.header().max_timestamp,
+      .is_transactional = false,
+    };
+
+    auto stages = frontend.replicate(
+      batch_id,
+      std::move(batch),
+      raft::replicate_options(raft::consistency_level::quorum_ack));
+    stages.request_enqueued.get();
+    auto result = stages.replicate_finished.get();
+    ASSERT_TRUE(result.has_value());
 }
 
 TEST_F(frontend_fixture, test_advance_epoch) {

--- a/src/v/cloud_topics/frontend/tests/frontend_test.cc
+++ b/src/v/cloud_topics/frontend/tests/frontend_test.cc
@@ -249,7 +249,7 @@ TEST_F(frontend_fixture, test_replicate_invalidates_epoch_cache) {
       .WillOnce(Return(ss::as_ready_future(stage_result{})));
     EXPECT_CALL(*_data_plane, execute_write(_, _, _, _))
       .WillOnce(Return(make_extent_fut(model::offset(0), cluster_epoch(7))));
-    EXPECT_CALL(*_data_plane, invalidate_epoch_below(cluster_epoch(5)))
+    EXPECT_CALL(*_data_plane, invalidate_epoch_below(cluster_epoch(10)))
       .WillOnce(Return(ss::now()));
     ON_CALL(*_data_plane, cache_put_ordered(_, _))
       .WillByDefault([](const auto&, auto) {});

--- a/src/v/cloud_topics/level_zero/batcher/aggregator.cc
+++ b/src/v/cloud_topics/level_zero/batcher/aggregator.cc
@@ -114,7 +114,10 @@ void aggregator<Clock>::ack() {
     for (auto& p : _aggregated) {
         if (p->ref != nullptr) {
             try {
-                p->ref->set_value(std::move(p->extents));
+                p->ref->set_value(
+                  upload_meta{
+                    .shard = ss::this_shard_id(),
+                    .extents = std::move(p->extents)});
             } catch (const ss::broken_promise& e) {
                 std::ignore = e;
             }

--- a/src/v/cloud_topics/level_zero/batcher/tests/batcher_test.cc
+++ b/src/v/cloud_topics/level_zero/batcher/tests/batcher_test.cc
@@ -185,8 +185,8 @@ TEST_CORO(batcher_test, single_write_request) {
     // Check that uuid in the placeholder can be used to
     // access the data in S3.
     auto placeholder_batches = std::move(write_res.value());
-    ASSERT_EQ_CORO(placeholder_batches.size(), num_batches);
-    for (const cloud_topics::extent_meta& ext : placeholder_batches) {
+    ASSERT_EQ_CORO(placeholder_batches.extents.size(), num_batches);
+    for (const cloud_topics::extent_meta& ext : placeholder_batches.extents) {
         auto sid = cloud_topics::object_path_factory::level_zero_path(ext.id);
         ASSERT_EQ_CORO(sid, id);
     }
@@ -233,9 +233,8 @@ TEST_CORO(batcher_test, many_write_requests) {
 
     const auto timeout = 1s;
     auto deadline = ss::manual_clock::now() + timeout;
-    std::vector<ss::future<std::expected<
-      chunked_vector<cloud_topics::extent_meta>,
-      std::error_code>>>
+    std::vector<
+      ss::future<std::expected<cloud_topics::upload_meta, std::error_code>>>
       futures;
     futures.push_back(pipeline.write_and_debounce(
       model::controller_ntp, min_epoch, std::move(reader1), deadline));
@@ -266,8 +265,10 @@ TEST_CORO(batcher_test, many_write_requests) {
         // access the data in S3. All placeholders should share the same
         // uuid.
         auto placeholder_batches = std::move(write_res.value());
-        ASSERT_EQ_CORO(placeholder_batches.size(), expected_num_batches.at(ix));
-        for (const cloud_topics::extent_meta& ext : placeholder_batches) {
+        ASSERT_EQ_CORO(
+          placeholder_batches.extents.size(), expected_num_batches.at(ix));
+        for (const cloud_topics::extent_meta& ext :
+             placeholder_batches.extents) {
             auto sid = cloud_topics::object_path_factory::level_zero_path(
               ext.id);
             ASSERT_EQ_CORO(sid, id);
@@ -351,8 +352,8 @@ TEST_CORO(batcher_test, expired_write_request) {
     ASSERT_TRUE_CORO(pass_result.has_value());
     auto placeholder_batches = std::move(pass_result.value());
 
-    ASSERT_EQ_CORO(placeholder_batches.size(), expected_num_batches);
-    for (const cloud_topics::extent_meta& ext : placeholder_batches) {
+    ASSERT_EQ_CORO(placeholder_batches.extents.size(), expected_num_batches);
+    for (const cloud_topics::extent_meta& ext : placeholder_batches.extents) {
         auto sid = cloud_topics::object_path_factory::level_zero_path(ext.id);
         ASSERT_EQ_CORO(sid, id);
     }
@@ -383,9 +384,8 @@ TEST_CORO(batcher_test, chunk_splitting_balances_upload_sizes) {
     // (~3KB serialized), so 6 requests total ~18KB. With threshold=4096
     // this should produce multiple balanced chunks.
     const int num_requests = 6;
-    std::vector<ss::future<std::expected<
-      chunked_vector<cloud_topics::extent_meta>,
-      std::error_code>>>
+    std::vector<
+      ss::future<std::expected<cloud_topics::upload_meta, std::error_code>>>
       futures;
 
     const auto timeout = 10s;

--- a/src/v/cloud_topics/level_zero/batcher/tests/batcher_test.cc
+++ b/src/v/cloud_topics/level_zero/batcher/tests/batcher_test.cc
@@ -91,6 +91,11 @@ public:
     current_epoch(seastar::abort_source*) override {
         return seastar::make_ready_future<cloud_topics::cluster_epoch>(0);
     }
+
+    seastar::future<>
+    invalidate_epoch_below(cloud_topics::cluster_epoch) override {
+        return ss::now();
+    }
 };
 
 namespace cloud_topics::l0 {

--- a/src/v/cloud_topics/level_zero/cluster_services_impl/cluster_services.h
+++ b/src/v/cloud_topics/level_zero/cluster_services_impl/cluster_services.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cloud_topics/cluster_services.h"
+#include "cloud_topics/types.h"
 #include "cluster/cluster_epoch_service.h"
 
 #include <seastar/core/abort_source.hh>
@@ -35,6 +36,12 @@ public:
             throw std::system_error(epoch.error());
         }
         co_return cloud_topics::cluster_epoch(epoch.value());
+    }
+
+    seastar::future<>
+    invalidate_epoch_below(cloud_topics::cluster_epoch epoch) override {
+        auto prev = prev_cluster_epoch(epoch);
+        co_await _epoch_service.local().invalidate_epoch_cache(prev());
     }
 
 private:

--- a/src/v/cloud_topics/level_zero/common/extent_meta.h
+++ b/src/v/cloud_topics/level_zero/common/extent_meta.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cloud_topics/types.h"
+#include "container/chunked_vector.h"
 #include "model/fundamental.h"
 
 #include <fmt/core.h>
@@ -45,6 +46,13 @@ struct extent_meta {
     // Kafka metadata
     kafka::offset base_offset;
     kafka::offset last_offset;
+};
+
+// The result of a successful upload of data in level zero.
+struct upload_meta {
+    // The shard that uploaded the data
+    ss::shard_id shard;
+    chunked_vector<extent_meta> extents;
 };
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/pipeline/tests/event_filter_test.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/tests/event_filter_test.cc
@@ -112,7 +112,7 @@ TEST_CORO(EventFilterTest, filter_triggered_once) {
     auto pending = stage.pull_write_requests(
       std::numeric_limits<size_t>::max());
     for (auto& req : pending.requests) {
-        req.set_value(chunked_vector<extent_meta>());
+        req.set_value(upload_meta{});
     }
     std::ignore = co_await std::move(write);
 }
@@ -154,7 +154,7 @@ TEST_CORO(EventFilterTest, filter_has_memory) {
     auto pending = stage.pull_write_requests(
       std::numeric_limits<size_t>::max());
     for (auto& req : pending.requests) {
-        req.set_value(chunked_vector<extent_meta>());
+        req.set_value(upload_meta{});
     }
     std::ignore = co_await std::move(write);
     co_return;
@@ -233,7 +233,7 @@ TEST_CORO(EventFilterTest, filter_min_write_bytes) {
     auto pending = stage.pull_write_requests(
       std::numeric_limits<size_t>::max());
     for (auto& req : pending.requests) {
-        req.set_value(chunked_vector<extent_meta>());
+        req.set_value(upload_meta{});
     }
     std::ignore = co_await std::move(write1);
     std::ignore = co_await std::move(write2);

--- a/src/v/cloud_topics/level_zero/pipeline/tests/write_pipeline_test.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/tests/write_pipeline_test.cc
@@ -90,7 +90,7 @@ TEST_CORO(write_pipeline_test, single_write_request) {
     ASSERT_TRUE_CORO(res.complete);
     ASSERT_TRUE_CORO(res.requests.size() == 1);
 
-    res.requests.front().set_value(chunked_vector<cloud_topics::extent_meta>{});
+    res.requests.front().set_value(cloud_topics::upload_meta{});
 
     auto write_res = co_await std::move(fut);
     ASSERT_TRUE_CORO(write_res.has_value());
@@ -128,7 +128,7 @@ TEST_CORO(batcher_test, expired_write_request) {
 
     // One req has already expired at this point
     ASSERT_EQ_CORO(res.requests.size(), 1);
-    res.requests.back().set_value(chunked_vector<cloud_topics::extent_meta>{});
+    res.requests.back().set_value(cloud_topics::upload_meta{});
 
     auto [pass_result, fail_result] = co_await ss::when_all_succeed(
       std::move(expect_pass_fut), std::move(expect_fail_fut));
@@ -167,7 +167,7 @@ TEST_CORO(write_pipeline_test, stage_bytes_accounting) {
     auto res = stage.pull_write_requests(std::numeric_limits<size_t>::max());
     ASSERT_EQ_CORO(pipeline.stage_bytes(stage.id()), 0);
 
-    res.requests.front().set_value(chunked_vector<cloud_topics::extent_meta>{});
+    res.requests.front().set_value(cloud_topics::upload_meta{});
     auto write_res = co_await std::move(fut);
     ASSERT_TRUE_CORO(write_res.has_value());
 }
@@ -274,7 +274,7 @@ TEST_CORO(write_pipeline_test, interleaving_stages_bug) {
         // Stage should be unassigned after extraction
         ASSERT_TRUE_CORO(
           req.stage == cloud_topics::l0::unassigned_pipeline_stage);
-        req.set_value(chunked_vector<cloud_topics::extent_meta>{});
+        req.set_value(cloud_topics::upload_meta{});
     }
 
     // The remaining 3 requests should still be in the pending queue
@@ -288,7 +288,7 @@ TEST_CORO(write_pipeline_test, interleaving_stages_bug) {
     for (auto& req : result2.requests) {
         ASSERT_TRUE_CORO(
           req.stage == cloud_topics::l0::unassigned_pipeline_stage);
-        req.set_value(chunked_vector<cloud_topics::extent_meta>{});
+        req.set_value(cloud_topics::upload_meta{});
     }
 
     ASSERT_EQ_CORO(accessor.write_requests_pending(0), true);
@@ -360,8 +360,7 @@ TEST_CORO(write_pipeline_test, oversized_request) {
 
     // Should return exactly 1 request (the oversized one)
     ASSERT_EQ_CORO(result.requests.size(), 1);
-    result.requests.front().set_value(
-      chunked_vector<cloud_topics::extent_meta>{});
+    result.requests.front().set_value(cloud_topics::upload_meta{});
 
     // Second request should still be pending
     ASSERT_EQ_CORO(accessor.write_requests_pending(1), true);
@@ -370,8 +369,7 @@ TEST_CORO(write_pipeline_test, oversized_request) {
     auto result2 = stage.pull_write_requests(
       std::numeric_limits<size_t>::max());
     ASSERT_EQ_CORO(result2.requests.size(), 1);
-    result2.requests.front().set_value(
-      chunked_vector<cloud_topics::extent_meta>{});
+    result2.requests.front().set_value(cloud_topics::upload_meta{});
 
     ASSERT_EQ_CORO(accessor.write_requests_pending(0), true);
 }
@@ -439,7 +437,7 @@ TEST_CORO(write_pipeline_test, multiple_requests_within_limit) {
     ASSERT_EQ_CORO(result_all.requests.size(), 3);
 
     for (auto& req : result_all.requests) {
-        req.set_value(chunked_vector<cloud_topics::extent_meta>{});
+        req.set_value(cloud_topics::upload_meta{});
     }
 
     ASSERT_TRUE_CORO(accessor.write_requests_pending(0));
@@ -499,7 +497,7 @@ TEST_CORO(write_pipeline_test, max_requests_limit) {
     size_t first_batch_size = result.requests.size();
 
     for (auto& req : result.requests) {
-        req.set_value(chunked_vector<cloud_topics::extent_meta>{});
+        req.set_value(cloud_topics::upload_meta{});
     }
 
     // Remaining requests should still be pending
@@ -511,7 +509,7 @@ TEST_CORO(write_pipeline_test, max_requests_limit) {
     ASSERT_EQ_CORO(result2.requests.size(), 5 - first_batch_size);
 
     for (auto& req : result2.requests) {
-        req.set_value(chunked_vector<cloud_topics::extent_meta>{});
+        req.set_value(cloud_topics::upload_meta{});
     }
 
     ASSERT_TRUE_CORO(accessor.write_requests_pending(0));
@@ -555,5 +553,5 @@ TEST_CORO(write_pipeline_test, enqueue_foreign_request_accounts_bytes) {
     ASSERT_EQ_CORO(res.requests.size(), 1);
     ASSERT_EQ_CORO(pipeline.stage_bytes(stage2.id()), 0);
 
-    res.requests.front().set_value(chunked_vector<cloud_topics::extent_meta>{});
+    res.requests.front().set_value(cloud_topics::upload_meta{});
 }

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
@@ -66,7 +66,7 @@ template<class Clock>
 write_pipeline<Clock>::~write_pipeline() = default;
 
 template<class Clock>
-ss::future<std::expected<chunked_vector<extent_meta>, std::error_code>>
+ss::future<std::expected<upload_meta, std::error_code>>
 write_pipeline<Clock>::write_and_debounce(
   model::ntp ntp,
   cluster_epoch min_epoch,
@@ -103,7 +103,7 @@ auto write_pipeline<Clock>::prepare_write(
 }
 
 template<class Clock>
-ss::future<std::expected<chunked_vector<extent_meta>, std::error_code>>
+ss::future<std::expected<upload_meta, std::error_code>>
 write_pipeline<Clock>::execute_write(
   model::ntp ntp,
   cluster_epoch min_epoch,

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
@@ -55,8 +55,7 @@ public:
 
     /// Add write request to the pipeline
     /// The revision id is the topic creation revision id for the ntp.
-    ss::future<std::expected<chunked_vector<extent_meta>, std::error_code>>
-    write_and_debounce(
+    ss::future<std::expected<upload_meta, std::error_code>> write_and_debounce(
       model::ntp ntp,
       cluster_epoch min_epoch,
       chunked_vector<model::record_batch> batches,
@@ -70,8 +69,7 @@ public:
     ss::future<std::expected<prepared_data, std::error_code>>
     prepare_write(chunked_vector<model::record_batch> batches);
 
-    ss::future<std::expected<chunked_vector<extent_meta>, std::error_code>>
-    execute_write(
+    ss::future<std::expected<upload_meta, std::error_code>> execute_write(
       model::ntp ntp,
       cluster_epoch min_epoch,
       prepared_data prepped,

--- a/src/v/cloud_topics/level_zero/pipeline/write_request.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_request.cc
@@ -49,10 +49,9 @@ size_t write_request<Clock>::size_bytes() const noexcept {
 }
 
 template<class Clock>
-void write_request<Clock>::set_value(
-  chunked_vector<extent_meta> placeholders) noexcept {
+void write_request<Clock>::set_value(upload_meta meta) noexcept {
     try {
-        response.set_value(std::move(placeholders));
+        response.set_value(std::move(meta));
     } catch (const ss::broken_promise&) {
         vlog(cd_log.error, "Can't acknowledge request for {}", ntp);
     }

--- a/src/v/cloud_topics/level_zero/pipeline/write_request.h
+++ b/src/v/cloud_topics/level_zero/pipeline/write_request.h
@@ -49,7 +49,7 @@ struct write_request : ss::weakly_referencable<write_request<Clock>> {
     /// List of all write requests
     intrusive_list_hook _hook;
 
-    using response_t = std::expected<chunked_vector<extent_meta>, errc>;
+    using response_t = std::expected<upload_meta, errc>;
     /// The promise is used to signal to the caller
     /// after the upload is completed
     ss::promise<response_t> response;
@@ -73,7 +73,7 @@ struct write_request : ss::weakly_referencable<write_request<Clock>> {
 
     void set_value(errc e) noexcept;
 
-    void set_value(chunked_vector<extent_meta> placeholders) noexcept;
+    void set_value(upload_meta meta) noexcept;
 
     bool has_expired() const noexcept;
 };

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -490,12 +490,12 @@ ctp_stm::fence_epoch(cluster_epoch e) {
         // If we reach here, it means that we need to discard the batch.
         co_return std::unexpected(
           stale_cluster_epoch{
-            .window_min = _state.get_previous_seen_epoch()
+            .window_min = _state.get_previous_seen_epoch(term)
                             .or_else([this] {
                                 return _state.get_previous_applied_epoch();
                             })
                             .value_or(cluster_epoch{-1}),
-            .window_max = _state.get_max_seen_epoch()
+            .window_max = _state.get_max_seen_epoch(term)
                             .or_else(
                               [this] { return _state.get_max_applied_epoch(); })
                             .value_or(cluster_epoch{-1}),

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
@@ -309,15 +309,9 @@ std::optional<cluster_epoch> ctp_stm_api::get_max_epoch() const {
     return _stm->state().get_max_applied_epoch();
 }
 
-std::optional<cluster_epoch> ctp_stm_api::get_max_seen_epoch() const {
-    return _stm->state().get_max_seen_epoch();
-}
-
-std::optional<cluster_epoch> ctp_stm_api::get_min_accepted_epoch() const {
-    if (auto e = _stm->state().get_previous_seen_epoch()) {
-        return e;
-    }
-    return _stm->state().get_previous_applied_epoch();
+std::optional<cluster_epoch>
+ctp_stm_api::get_max_seen_epoch(model::term_id term) const {
+    return _stm->state().get_max_seen_epoch(term);
 }
 
 l0::producer_queue& ctp_stm_api::producer_queue() {

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
@@ -313,6 +313,13 @@ std::optional<cluster_epoch> ctp_stm_api::get_max_seen_epoch() const {
     return _stm->state().get_max_seen_epoch();
 }
 
+std::optional<cluster_epoch> ctp_stm_api::get_min_accepted_epoch() const {
+    if (auto e = _stm->state().get_previous_seen_epoch()) {
+        return e;
+    }
+    return _stm->state().get_previous_applied_epoch();
+}
+
 l0::producer_queue& ctp_stm_api::producer_queue() {
     return _stm->producer_queue();
 }

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.h
@@ -114,10 +114,7 @@ public:
 
     std::optional<cluster_epoch> get_max_epoch() const;
 
-    std::optional<cluster_epoch> get_max_seen_epoch() const;
-
-    // Get the minimum epoch that would be current accepted by `fence_epoch`.
-    std::optional<cluster_epoch> get_min_accepted_epoch() const;
+    std::optional<cluster_epoch> get_max_seen_epoch(model::term_id) const;
 
     l0::producer_queue& producer_queue();
 

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.h
@@ -116,6 +116,9 @@ public:
 
     std::optional<cluster_epoch> get_max_seen_epoch() const;
 
+    // Get the minimum epoch that would be current accepted by `fence_epoch`.
+    std::optional<cluster_epoch> get_min_accepted_epoch() const;
+
     l0::producer_queue& producer_queue();
 
     // Register this reader with the STM so that it's state isn't GC'd.

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
@@ -55,7 +55,10 @@ ctp_stm_state::get_previous_applied_epoch() const noexcept {
 }
 
 std::optional<cluster_epoch>
-ctp_stm_state::get_previous_seen_epoch() const noexcept {
+ctp_stm_state::get_previous_seen_epoch(model::term_id term) const noexcept {
+    if (term > _seen_window_term) {
+        return std::nullopt;
+    }
     return _previous_seen_epoch;
 }
 
@@ -137,7 +140,10 @@ ctp_stm_state::get_max_applied_epoch() const noexcept {
 }
 
 std::optional<cluster_epoch>
-ctp_stm_state::get_max_seen_epoch() const noexcept {
+ctp_stm_state::get_max_seen_epoch(model::term_id term) const noexcept {
+    if (term > _seen_window_term) {
+        return std::nullopt;
+    }
     return _max_seen_epoch;
 }
 

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
@@ -83,10 +83,12 @@ public:
     /// epoch is at least equal to the max_seen_epoch epoch.
     ///
     /// \return max_seen_epoch epoch.
-    std::optional<cluster_epoch> get_max_seen_epoch() const noexcept;
+    std::optional<cluster_epoch>
+    get_max_seen_epoch(model::term_id term) const noexcept;
 
     /// Return the previous_seen_epoch epoch.
-    std::optional<cluster_epoch> get_previous_seen_epoch() const noexcept;
+    std::optional<cluster_epoch>
+      get_previous_seen_epoch(model::term_id) const noexcept;
 
     /// Estimate the minimum epoch referenced by this ctp_stm.
     /// \note This value might be stale.

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
@@ -26,7 +26,7 @@ namespace {
 TEST(ctp_stm_state_test, initial_state) {
     ct::ctp_stm_state state;
     EXPECT_FALSE(state.get_max_applied_epoch().has_value());
-    EXPECT_FALSE(state.get_max_seen_epoch().has_value());
+    EXPECT_FALSE(state.get_max_seen_epoch(model::term_id(1)).has_value());
     EXPECT_FALSE(state.get_last_reconciled_offset().has_value());
     EXPECT_FALSE(state.get_last_reconciled_log_offset().has_value());
     EXPECT_EQ(state.get_max_collectible_offset(), model::offset::min());
@@ -40,14 +40,14 @@ TEST(ctp_stm_state_test, advance_max_seen_epoch) {
     model::term_id term(1);
 
     state.advance_max_seen_epoch(term, epoch1);
-    EXPECT_EQ(state.get_max_seen_epoch().value(), epoch1);
+    EXPECT_EQ(state.get_max_seen_epoch(term).value(), epoch1);
 
     state.advance_max_seen_epoch(term, epoch2);
-    EXPECT_EQ(state.get_max_seen_epoch().value(), epoch2);
+    EXPECT_EQ(state.get_max_seen_epoch(term).value(), epoch2);
 
     // Should not go backwards
     state.advance_max_seen_epoch(term, epoch3);
-    EXPECT_EQ(state.get_max_seen_epoch().value(), epoch2);
+    EXPECT_EQ(state.get_max_seen_epoch(term).value(), epoch2);
 }
 
 TEST(ctp_stm_state_test, advance_epoch) {
@@ -55,20 +55,21 @@ TEST(ctp_stm_state_test, advance_epoch) {
     ct::cluster_epoch epoch1(15);
     ct::cluster_epoch epoch2(25);
     ct::cluster_epoch epoch3(10);
+    model::term_id term(1);
 
     state.advance_epoch(epoch1, model::offset(1));
     EXPECT_EQ(state.get_max_applied_epoch().value(), epoch1);
     // advance_epoch does not update the seen window
-    EXPECT_FALSE(state.get_max_seen_epoch().has_value());
+    EXPECT_FALSE(state.get_max_seen_epoch(term).has_value());
 
     state.advance_epoch(epoch2, model::offset(2));
     EXPECT_EQ(state.get_max_applied_epoch().value(), epoch2);
-    EXPECT_FALSE(state.get_max_seen_epoch().has_value());
+    EXPECT_FALSE(state.get_max_seen_epoch(term).has_value());
 
     // Should not go backwards
     state.advance_epoch(epoch3, model::offset(3));
     EXPECT_EQ(state.get_max_applied_epoch().value(), epoch2);
-    EXPECT_FALSE(state.get_max_seen_epoch().has_value());
+    EXPECT_FALSE(state.get_max_seen_epoch(term).has_value());
 }
 
 TEST(ctp_stm_state_test, advance_epoch_on_a_follower) {
@@ -80,7 +81,7 @@ TEST(ctp_stm_state_test, advance_epoch_on_a_follower) {
 
     state.advance_epoch(advance_epoch, model::offset(1));
 
-    EXPECT_FALSE(state.get_max_seen_epoch().has_value());
+    EXPECT_FALSE(state.get_max_seen_epoch(model::term_id{1}).has_value());
     EXPECT_EQ(state.get_max_applied_epoch().value(), advance_epoch);
 }
 

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -564,7 +564,7 @@ TEST_F_CORO(ctp_stm_fixture, test_fence_epoch_concurrent_new_epoch) {
     ASSERT_FALSE_CORO(accessor.epoch_cv_has_waiters(*stm));
 
     // Verify epoch 2 is now established
-    auto max_seen = api(leader).get_max_seen_epoch();
+    auto max_seen = api(leader).get_max_seen_epoch(leader.raft()->term());
     ASSERT_TRUE_CORO(max_seen.has_value());
     ASSERT_EQ_CORO(max_seen.value(), ct::cluster_epoch{2});
 }
@@ -770,7 +770,7 @@ TEST_F_CORO(
     }
 
     // Verify Node 0's window
-    auto max_seen_0 = api(node0).get_max_seen_epoch();
+    auto max_seen_0 = api(node0).get_max_seen_epoch(node0.raft()->term());
     ASSERT_TRUE_CORO(max_seen_0.has_value());
     vlog(
       ct::cd_log.info,
@@ -805,7 +805,7 @@ TEST_F_CORO(
         ASSERT_TRUE_CORO(success);
     }
 
-    auto max_seen_1 = api(node1).get_max_seen_epoch();
+    auto max_seen_1 = api(node1).get_max_seen_epoch(node1.raft()->term());
     ASSERT_TRUE_CORO(max_seen_1.has_value());
     vlog(
       ct::cd_log.info,
@@ -905,7 +905,7 @@ TEST_F_CORO(
         // Let the fence guard drop without replicating.
     }
 
-    auto max_seen = api(node0).get_max_seen_epoch();
+    auto max_seen = api(node0).get_max_seen_epoch(node0.raft()->term());
     ASSERT_TRUE_CORO(max_seen.has_value());
     ASSERT_EQ_CORO(max_seen.value(), ct::cluster_epoch{100});
 

--- a/src/v/cloud_topics/level_zero/tests/l0_object_size_distribution_test.cc
+++ b/src/v/cloud_topics/level_zero/tests/l0_object_size_distribution_test.cc
@@ -104,6 +104,9 @@ public:
     current_epoch(seastar::abort_source*) override {
         return seastar::make_ready_future<cloud_topics::cluster_epoch>(0);
     }
+    seastar::future<> invalidate_epoch_below(cluster_epoch) override {
+        return ss::now();
+    }
 };
 
 class L0ObjectSizeDistFixture : public seastar_test {

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_bench.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_bench.cc
@@ -80,7 +80,7 @@ struct pipeline_sink {
             auto result = stage.pull_write_requests(
               std::numeric_limits<size_t>::max());
             for (auto& r : result.requests) {
-                r.set_value(chunked_vector<extent_meta>{});
+                r.set_value(upload_meta{});
             }
         }
     }

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_test.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_test.cc
@@ -92,7 +92,7 @@ struct pipeline_sink {
                         continue;
                     }
                 }
-                r.set_value(chunked_vector<extent_meta>{});
+                r.set_value(upload_meta{});
                 write_requests_acked++;
                 vlog(
                   test_log.debug,
@@ -187,9 +187,7 @@ static ss::future<size_t> write_until_threshold(
   write_request_balancer_fixture& fix, size_t size_threshold) {
     size_t num_requests_sent = 0;
     size_t total_size = 0;
-    std::vector<
-      ss::future<std::expected<chunked_vector<extent_meta>, std::error_code>>>
-      wd;
+    std::vector<ss::future<std::expected<upload_meta, std::error_code>>> wd;
     while (total_size < size_threshold) {
         auto buf = co_await model::test::make_random_batches();
         chunked_vector<model::record_batch> batches;

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
@@ -614,13 +614,13 @@ write_request_scheduler<Clock>::proxy_write_request(
     auto fut = proxy.response.get_future();
     _stage.enqueue_foreign_request(proxy, false);
     target_gate_holder.release();
-    auto extents_fut = co_await ss::coroutine::as_future(std::move(fut));
-    if (extents_fut.failed()) {
-        auto ex = extents_fut.get_exception();
+    auto upload_fut = co_await ss::coroutine::as_future(std::move(fut));
+    if (upload_fut.failed()) {
+        auto ex = upload_fut.get_exception();
         vlog(cd_log.error, "Proxy write request failed: {}", ex);
         co_return std::unexpected(errc::upload_failure);
     }
-    auto extents = extents_fut.get();
+    auto extents = upload_fut.get();
     if (!extents.has_value()) {
         // Normal errors (S3 upload failure or timeout)
         // are handled here
@@ -628,7 +628,7 @@ write_request_scheduler<Clock>::proxy_write_request(
         vlog(cd_log.info, "Proxy write request failed: {}", e);
         co_return std::unexpected(e);
     }
-    auto ptr = ss::make_lw_shared<chunked_vector<extent_meta>>();
+    auto ptr = ss::make_lw_shared<upload_meta>();
     *ptr = std::move(extents.value());
     foreign_ptr_t fp(ss::make_foreign(std::move(ptr)));
     co_return std::move(fp);

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.h
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.h
@@ -362,8 +362,7 @@ private:
     /// \return next wake up time
     ss::future<time_point> run_once();
 
-    using foreign_ptr_t
-      = ss::foreign_ptr<ss::lw_shared_ptr<chunked_vector<extent_meta>>>;
+    using foreign_ptr_t = ss::foreign_ptr<ss::lw_shared_ptr<upload_meta>>;
 
     using gate_holder_ptr = std::unique_ptr<ss::gate::holder>;
 

--- a/src/v/cluster/cluster_epoch_service.cc
+++ b/src/v/cluster/cluster_epoch_service.cc
@@ -17,6 +17,7 @@
 #include "cluster/controller_stm.h"
 #include "cluster/errc.h"
 #include "cluster/logger.h"
+#include "config/configuration.h"
 #include "raft/notification.h"
 #include "ssx/abort_source.h"
 #include "ssx/future-util.h"
@@ -537,6 +538,9 @@ bool cluster_epoch_service<Clock>::cache_entry_expired() const noexcept {
 }
 template<typename Clock>
 bool cluster_epoch_service<Clock>::cache_entry_needs_updated() const noexcept {
+    const auto max_same_epoch_cache_duration
+      = config::shard_local_cfg()
+          .cloud_topics_epoch_service_max_same_epoch_duration();
     return Clock::now() > (_epoch_updated_time + max_same_epoch_cache_duration)
            || Clock::now()
                 > (_cached_epoch_time + max_same_epoch_cache_duration);

--- a/src/v/cluster/cluster_epoch_service.cc
+++ b/src/v/cluster/cluster_epoch_service.cc
@@ -340,9 +340,9 @@ ss::future<> cluster_epoch_service<Clock>::invalidate_epoch_cache(
           // epoch and we need to refetch the epoch).
           if (s._cached_epoch <= epoch_causing_monotonicity_violation) {
               s._cached_epoch_time = Clock::time_point::min();
-              // Force this to be a blocking update so we don't get another
-              // sequence violation from the async update.
-              s._epoch_updated_time = Clock::time_point::min();
+              // We can't set the update time because we only advance that if
+              // the epoch changes, so we may run into a situation where we
+              // don't update the epoch and that causes epoch requests to fail
           }
       });
 }
@@ -537,7 +537,9 @@ bool cluster_epoch_service<Clock>::cache_entry_expired() const noexcept {
 }
 template<typename Clock>
 bool cluster_epoch_service<Clock>::cache_entry_needs_updated() const noexcept {
-    return Clock::now() > (_epoch_updated_time + max_same_epoch_cache_duration);
+    return Clock::now() > (_epoch_updated_time + max_same_epoch_cache_duration)
+           || Clock::now()
+                > (_cached_epoch_time + max_same_epoch_cache_duration);
 }
 
 template class cluster_epoch_service<ss::lowres_clock>;

--- a/src/v/cluster/cluster_epoch_service.cc
+++ b/src/v/cluster/cluster_epoch_service.cc
@@ -320,8 +320,11 @@ template<typename Clock>
 ss::future<> cluster_epoch_service<Clock>::invalidate_epoch_cache(
   int64_t epoch_causing_monotonicity_violation) {
     auto holder = _gate.hold();
-    // Don't do the cross shard calls if our local shard is up to date.
-    if (_cached_epoch > epoch_causing_monotonicity_violation) {
+    // Don't do the cross shard calls if our local shard is up to date or we
+    // already are going to get a new epoch from another invalidation.
+    if (
+      _cached_epoch > epoch_causing_monotonicity_violation
+      || _cached_epoch_time == Clock::time_point::min()) {
         co_return;
     }
     co_await this->container().invoke_on_all(

--- a/src/v/cluster/cluster_epoch_service.cc
+++ b/src/v/cluster/cluster_epoch_service.cc
@@ -320,6 +320,10 @@ template<typename Clock>
 ss::future<> cluster_epoch_service<Clock>::invalidate_epoch_cache(
   int64_t epoch_causing_monotonicity_violation) {
     auto holder = _gate.hold();
+    // Don't do the cross shard calls if our local shard is up to date.
+    if (_cached_epoch > epoch_causing_monotonicity_violation) {
+        co_return;
+    }
     co_await this->container().invoke_on_all(
       [epoch_causing_monotonicity_violation](cluster_epoch_service<Clock>& s) {
           s._gate.check();

--- a/src/v/cluster/cluster_epoch_service.h
+++ b/src/v/cluster/cluster_epoch_service.h
@@ -55,12 +55,6 @@ class cluster_epoch_service
     class raft0_state;
 
 public:
-    // TODO(cloud-topics): make these configuration knobs.
-    // Maximum amount of time to cache the same epoch before we block on the
-    // update.
-    constexpr static ss::lowres_clock::duration max_same_epoch_cache_duration
-      = 24 * 60min;
-
     cluster_epoch_service(
       model::node_id, ss::sharded<rpc::connection_cache>*) noexcept;
     // **For testing** support injecting a custom "remote fetch epoch" function.

--- a/src/v/cluster/cluster_epoch_service.h
+++ b/src/v/cluster/cluster_epoch_service.h
@@ -22,6 +22,7 @@
 #include <seastar/core/gate.hh>
 
 #include <expected>
+#include <limits>
 
 namespace cluster {
 
@@ -137,7 +138,7 @@ private:
     fetch_leader_epoch(ss::abort_source*);
 
     // The currently cached epoch
-    int64_t _cached_epoch{-1};
+    int64_t _cached_epoch{std::numeric_limits<int64_t>::min()};
     // The last time the epoch was cached
     Clock::time_point _cached_epoch_time{Clock::time_point::min()};
     // The last time the epoch actually ratcheted forward

--- a/src/v/cluster/tests/BUILD
+++ b/src/v/cluster/tests/BUILD
@@ -1275,6 +1275,7 @@ redpanda_cc_gtest(
     cpu = 2,
     deps = [
         "//src/v/cluster",
+        "//src/v/config",
         "//src/v/ssx:abort_source",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",

--- a/src/v/cluster/tests/epoch_service_test.cc
+++ b/src/v/cluster/tests/epoch_service_test.cc
@@ -9,6 +9,7 @@
 
 #include "cluster/cluster_epoch_service.h"
 #include "cluster/errc.h"
+#include "config/configuration.h"
 #include "gmock/gmock.h"
 #include "ssx/abort_source.h"
 #include "test_utils/async.h"
@@ -113,7 +114,9 @@ TEST_F_CORO(ClusterEpochService, TestCaching) {
     // After the max duration we wait to fetch the value
     ++cluster_epoch;
     ss::manual_clock::advance(
-      epoch_service::max_same_epoch_cache_duration + 1us);
+      config::shard_local_cfg()
+        .cloud_topics_epoch_service_max_same_epoch_duration()
+      + 1us);
     EXPECT_EQ(co_await get_cached_epoch(), cluster_epoch);
     EXPECT_EQ(accesses, 3);
 }
@@ -121,8 +124,10 @@ TEST_F_CORO(ClusterEpochService, TestCaching) {
 TEST_F_CORO(ClusterEpochService, IncrementMustHappenEventually) {
     EXPECT_EQ(co_await get_cached_epoch(), cluster_epoch);
     EXPECT_EQ(accesses, 1);
-    auto must_refresh_deadline = ss::manual_clock::now()
-                                 + epoch_service::max_same_epoch_cache_duration;
+    auto must_refresh_deadline
+      = ss::manual_clock::now()
+        + config::shard_local_cfg()
+            .cloud_topics_epoch_service_max_same_epoch_duration();
     // After the timeout we async re-fetch the value
     ss::manual_clock::advance(
       config::shard_local_cfg()

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4712,6 +4712,12 @@ configuration::configuration()
       "The local cache duration of a cluster wide epoch.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1min)
+  , cloud_topics_epoch_service_max_same_epoch_duration(
+      *this,
+      "cloud_topics_epoch_service_max_same_epoch_duration",
+      "The duration of time that a node can use the exact same epoch.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      24 * 60min)
   , cloud_topics_short_term_gc_minimum_object_age(
       *this,
       "cloud_topics_short_term_gc_minimum_object_age",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -807,6 +807,8 @@ public:
       cloud_topics_epoch_service_epoch_increment_interval;
     property<std::chrono::milliseconds>
       cloud_topics_epoch_service_local_epoch_cache_duration;
+    property<std::chrono::milliseconds>
+      cloud_topics_epoch_service_max_same_epoch_duration;
 
     property<std::chrono::milliseconds>
       cloud_topics_short_term_gc_minimum_object_age;


### PR DESCRIPTION
If we know the min window we know that if this shard has below that cached
it's doomed to fail the produce, so we invalidate the epoch cache before
uploading.

We also add a check in the epoch service to not spam cross core calls if
they are not needed.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
