### PR TITLE
`cluster`: sync `redpanda.storage.mode` in `cluster_link`

### DIFF
--- a/src/v/cluster/cluster_link/tests/frontend_validation_test.cc
+++ b/src/v/cluster/cluster_link/tests/frontend_validation_test.cc
@@ -980,17 +980,6 @@ TEST_F_CORO(
           co_await upsert_cluster_link(std::move(m1)),
           cluster::cluster_link::errc::topic_property_excluded_from_mirroring);
     }
-    {
-        auto m1 = create_base_metadata();
-        m1.configuration.topic_metadata_mirroring_cfg.topic_properties_to_mirror
-          = ::cluster_link::model::topic_metadata_mirroring_config::
-            properties_set{
-              ss::sstring{kafka::topic_property_redpanda_storage_mode}};
-
-        EXPECT_EQ(
-          co_await upsert_cluster_link(std::move(m1)),
-          cluster::cluster_link::errc::topic_property_excluded_from_mirroring);
-    }
 }
 
 TEST_F_CORO(frontend_validation_test, update_mirror_topic_properties_success) {

--- a/src/v/cluster_link/model/types.h
+++ b/src/v/cluster_link/model/types.h
@@ -67,6 +67,7 @@ inline auto default_synced_topic_properties = std::to_array<std::string_view>({
   kafka::topic_property_delete_retention_ms,
   kafka::topic_property_min_compaction_lag_ms,
   kafka::topic_property_max_compaction_lag_ms,
+  kafka::topic_property_redpanda_storage_mode,
 });
 
 /// List of topic properties that are not permitted to be synced
@@ -76,7 +77,6 @@ inline auto disallowed_topic_properties = std::to_array<std::string_view>({
   kafka::topic_property_remote_allow_gaps,
   kafka::topic_property_mpx_virtual_cluster_id,
   kafka::topic_property_leaders_preference,
-  kafka::topic_property_redpanda_storage_mode,
 });
 
 /**

--- a/src/v/cluster_link/source_topic_syncer.cc
+++ b/src/v/cluster_link/source_topic_syncer.cc
@@ -414,6 +414,19 @@ void source_topic_syncer::enqueue_create_mirror_topic_commands(
             continue;
         }
 
+        // Cloud topics cannot be mirrored via cluster linking.
+        auto storage_mode_it = configs->find(
+          ss::sstring(kafka::topic_property_redpanda_storage_mode));
+        if (
+          storage_mode_it != configs->end()
+          && storage_mode_it->second == "cloud") {
+            vlog(
+              logger().info,
+              "Skipping topic {} with redpanda.storage.mode=cloud",
+              describe_result.resource_name);
+            continue;
+        }
+
         commands.emplace_back(
           model::add_mirror_topic_cmd{
             .topic = it->first,
@@ -528,6 +541,27 @@ void source_topic_syncer::enqueue_update_mirror_topic_commands(
 
         auto configs = validate_and_get_configs_from_response(
           logger(), describe_result);
+
+        // If the source topic was changed to cloud storage mode, mark the
+        // mirror topic as failed — cloud topics cannot be mirrored.
+        if (configs.has_value()) {
+            auto storage_mode_it = configs->find(
+              ss::sstring(kafka::topic_property_redpanda_storage_mode));
+            if (
+              storage_mode_it != configs->end()
+              && storage_mode_it->second == "cloud") {
+                vlog(
+                  logger().info,
+                  "Topic {} redpanda.storage.mode=cloud, marking as failed",
+                  topic);
+                commands.emplace_back(
+                  model::update_mirror_topic_status_cmd{
+                    .topic = topic,
+                    .status = model::mirror_topic_status::failed,
+                  });
+                continue;
+            }
+        }
 
         if (configs.has_value()) {
             // Now check to see if the the properties on the topic have differed

--- a/src/v/cluster_link/tests/source_topic_syncer_test.cc
+++ b/src/v/cluster_link/tests/source_topic_syncer_test.cc
@@ -665,4 +665,73 @@ TEST_F_CORO(unsupported_describe_configs_test, unsupported_describe_configs) {
                             source_topic_syncer::task_name);
     EXPECT_EQ(task_report.task_state, model::task_state::link_unavailable);
 }
+TEST_F_CORO(source_topic_syncer_test, cloud_topic_not_mirrored) {
+    auto cloud_topic = ::model::topic("cloud-topic");
+    auto normal_topic = ::model::topic("normal-topic");
+
+    fixture()->get_cluster_mock().add_topic(
+      cloud_topic, 3, 3, kafka::topic_authorized_operations(0x508));
+    fixture()->get_cluster_mock().add_topic(
+      normal_topic, 3, 3, kafka::topic_authorized_operations(0x508));
+
+    // Set the cloud topic's storage mode to cloud
+    ::cluster::topic_properties cloud_props;
+    cloud_props.storage_mode = ::model::redpanda_storage_mode::cloud;
+    fixture()->get_cluster_mock().set_topic_properties(
+      cloud_topic, std::move(cloud_props));
+
+    co_await fixture()->upsert_link(get_default_metadata());
+
+    // The normal topic should be mirrored
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this, &normal_topic] {
+        auto link_metadata = fixture()->find_link_by_name(
+          model::name_t("test_link"));
+        return link_metadata->state.mirror_topics.contains(normal_topic);
+    });
+
+    // The cloud topic should not be mirrored. Let the syncer run a few more
+    // times to be sure.
+    co_await ss::sleep(3s);
+
+    auto link_metadata = fixture()->find_link_by_name(
+      model::name_t("test_link"));
+    auto& mirror_topics = link_metadata->state.mirror_topics;
+    EXPECT_EQ(mirror_topics.find(cloud_topic), mirror_topics.end())
+      << "Cloud topic should not be mirrored";
+}
+
+TEST_F_CORO(source_topic_syncer_test, cloud_topic_update_fails_mirror) {
+    auto topic_name = ::model::topic("test-topic");
+
+    fixture()->get_cluster_mock().add_topic(
+      topic_name, 3, 3, kafka::topic_authorized_operations(0x508));
+
+    co_await fixture()->upsert_link(get_default_metadata());
+
+    // Wait for the topic to be mirrored
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this, &topic_name] {
+        auto link_metadata = fixture()->find_link_by_name(
+          model::name_t("test_link"));
+        return link_metadata->state.mirror_topics.contains(topic_name);
+    });
+
+    // Now change the topic's storage mode to cloud
+    ::cluster::topic_properties cloud_props;
+    cloud_props.storage_mode = ::model::redpanda_storage_mode::cloud;
+    fixture()->get_cluster_mock().set_topic_properties(
+      topic_name, std::move(cloud_props));
+
+    // The mirror topic should be marked as failed
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this, &topic_name] {
+        auto link_metadata = fixture()->find_link_by_name(
+          model::name_t("test_link"));
+        auto& mirror_topics = link_metadata->state.mirror_topics;
+        auto it = mirror_topics.find(topic_name);
+        if (it == mirror_topics.end()) {
+            return false;
+        }
+        return it->second.status == model::mirror_topic_status::failed;
+    });
+}
+
 } // namespace cluster_link::tests

--- a/src/v/cluster_link/utils/topic_properties_utils.cc
+++ b/src/v/cluster_link/utils/topic_properties_utils.cc
@@ -317,6 +317,14 @@ bool maybe_append_update(
           kafka::max_compaction_lag_ms_validator);
     }
 
+    if (config_name == kafka::topic_property_redpanda_storage_mode) {
+        return parse_and_set(
+          topic_config.tp_ns,
+          update.properties.storage_mode,
+          config_value,
+          std::make_optional(topic_config.properties.storage_mode));
+    }
+
     return false;
 }
 } // namespace cluster_link::utils

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -78,6 +78,7 @@ DEFAULT_SYNCED_TOPIC_PROPERTIES = [
     "delete.retention.ms",
     "max.compaction.lag.ms",
     "min.compaction.lag.ms",
+    "redpanda.storage.mode",
 ]
 
 DISALLOWED_SYNCED_TOPIC_PROPERTIES = [
@@ -86,7 +87,6 @@ DISALLOWED_SYNCED_TOPIC_PROPERTIES = [
     "redpanda.remote.allowgaps",
     "redpanda.virtual.cluster.id",
     "redpanda.leaders.preference",
-    "redpanda.storage.mode",
 ]
 
 CONTROLLER_LOCKED_TASKS = [

--- a/tests/rptest/tests/cluster_linking_topic_syncing_test.py
+++ b/tests/rptest/tests/cluster_linking_topic_syncing_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 from ducktape.cluster.cluster import ClusterNode
+from ducktape.mark import matrix
 from ducktape.services.service import Service
 from rptest.clients.admin.proto.redpanda.core.admin.v2 import shadow_link_pb2
 from rptest.clients.admin.proto.redpanda.core.common.v1 import acl_pb2, tls_pb2

--- a/tests/rptest/tests/cluster_linking_topic_syncing_test.py
+++ b/tests/rptest/tests/cluster_linking_topic_syncing_test.py
@@ -17,9 +17,11 @@ from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
 from rptest.services.multi_cluster_services import SecondaryClusterArgs
 from rptest.services.redpanda import (
+    CLOUD_TOPICS_CONFIG_STR,
     LoggingConfig,
     SchemaRegistryConfig,
     SecurityConfig,
+    SISettings,
     TLSProvider,
 )
 from rptest.services.tls import CertificateAuthority, Certificate, TLSCertManager
@@ -28,7 +30,7 @@ from rptest.tests.cluster_linking_test_base import (
     ShadowLinkTestBase,
 )
 from rptest.tests.schema_registry_test import SchemaRegistryRedpandaClient
-from rptest.util import expect_exception, wait_until
+from rptest.util import expect_exception, expect_timeout, wait_until
 from typing import Any
 
 import ducktape.errors
@@ -1617,3 +1619,107 @@ class ClusterLinkingStorageModeSync(ClusterLinkingTopicSyncingTestBase):
             backoff_sec=1,
             err_msg="Storage mode change not synced to target cluster",
         )
+
+
+class ClusterLinkingCloudTopicSync(ShadowLinkTestBase):
+    """
+    Tests that cloud topics (redpanda.storage.mode=cloud) are not
+    mirrored to the target cluster via cluster linking.
+    """
+
+    def __init__(self, test_context, *args: Any, **kwargs: Any):
+        si_settings = SISettings(
+            test_context,
+            cloud_storage_max_connections=10,
+            cloud_storage_enable_remote_read=False,
+            cloud_storage_enable_remote_write=False,
+            fast_uploads=True,
+        )
+
+        super().__init__(
+            test_context,
+            si_settings=si_settings,
+            extra_rp_conf={
+                CLOUD_TOPICS_CONFIG_STR: True,
+                "enable_cluster_metadata_upload_loop": False,
+            },
+            secondary_cluster_args=SecondaryClusterArgs(
+                si_settings=si_settings,
+                extra_rp_conf={
+                    CLOUD_TOPICS_CONFIG_STR: True,
+                    "enable_shadow_linking": True,
+                    "enable_cluster_metadata_upload_loop": False,
+                },
+                log_config=LoggingConfig(
+                    "info",
+                    logger_levels={
+                        "cluster": "trace",
+                        "shadow_link": "trace",
+                        "kafka/client": "trace",
+                        "kafka": "trace",
+                    },
+                ),
+            ),
+            *args,
+            **kwargs,
+        )
+
+    @cluster(num_nodes=6)
+    def test_cloud_topic_not_mirrored(self):
+        """
+        A source topic with redpanda.storage.mode=cloud should not be
+        created on the target cluster. A non-cloud topic created alongside
+        it should still be mirrored normally.
+        """
+        cloud_topic = TopicSpec(
+            name="cloud-topic", partition_count=3, replication_factor=1
+        )
+        normal_topic = TopicSpec(
+            name="normal-topic", partition_count=3, replication_factor=1
+        )
+
+        source_rpk = RpkTool(self.source_cluster.service)
+
+        # Create a cloud topic and a normal topic on the source
+        source_rpk.create_topic(
+            topic=cloud_topic.name,
+            partitions=cloud_topic.partition_count,
+            replicas=cloud_topic.replication_factor,
+            config={
+                TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD,
+            },
+        )
+        source_rpk.create_topic(
+            topic=normal_topic.name,
+            partitions=normal_topic.partition_count,
+            replicas=normal_topic.replication_factor,
+        )
+
+        # Verify the source cloud topic actually has cloud storage mode
+        source_configs = source_rpk.describe_topic_configs(cloud_topic.name)
+        assert (
+            source_configs[TopicSpec.PROPERTY_STORAGE_MODE][0]
+            == TopicSpec.STORAGE_MODE_CLOUD
+        ), (
+            f"Source topic storage mode: {source_configs[TopicSpec.PROPERTY_STORAGE_MODE]}"
+        )
+
+        self.create_link("test-link")
+
+        # The normal topic should appear on the target
+        target_rpk = RpkTool(self.target_cluster.service)
+        wait_until(
+            lambda: normal_topic.name in target_rpk.list_topics(),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"Normal topic {normal_topic.name} not found in target cluster",
+        )
+
+        # The cloud topic should NOT appear on the target.
+        with expect_timeout():
+            wait_until(
+                lambda: cloud_topic.name in target_rpk.list_topics(),
+                timeout_sec=15,
+                backoff_sec=1,
+                err_msg=f"Cloud topic {cloud_topic.name} should not be mirrored",
+            )

--- a/tests/rptest/tests/cluster_linking_topic_syncing_test.py
+++ b/tests/rptest/tests/cluster_linking_topic_syncing_test.py
@@ -1509,3 +1509,111 @@ class ShadowLinkingValidateAclsMTls(ShadowLinkingValidateAclsBase):
                 common_name=self.redpanda.SUPERUSER_CREDENTIALS.username,
             ),
         )
+
+
+class ClusterLinkingStorageModeSync(ClusterLinkingTopicSyncingTestBase):
+    """
+    Tests for syncing redpanda.storage.mode via cluster linking.
+    """
+
+    @cluster(num_nodes=6)
+    @matrix(storage_mode=["unset", "local"])
+    def test_storage_mode_sync(self, storage_mode):
+        """
+        Verifies that redpanda.storage.mode is synced from source to target
+        when creating mirror topics via cluster linking.
+        """
+        topic_name = "test-storage-mode-topic"
+
+        topic = TopicSpec(name=topic_name, partition_count=3, replication_factor=1)
+
+        self.get_source_cluster_rpk().create_topic(
+            topic=topic.name,
+            partitions=topic.partition_count,
+            replicas=topic.replication_factor,
+            config={"redpanda.storage.mode": storage_mode},
+        )
+
+        # Verify source topic has the expected storage mode
+        source_configs = self.get_source_cluster_rpk().describe_topic_configs(
+            topic.name
+        )
+        assert source_configs["redpanda.storage.mode"][0] == storage_mode, (
+            f"Source topic storage mode: expected {storage_mode}, "
+            f"got {source_configs['redpanda.storage.mode'][0]}"
+        )
+
+        created_link = self.create_link("test-link")
+        self.validate_created_link(created_link)
+
+        wait_until(
+            lambda: self._topics_are_present(
+                self.get_target_cluster_rpk(), [topic], True
+            ),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Topic not created on target cluster",
+        )
+
+        # Verify target topic has the same storage mode
+        target_configs = self.get_target_cluster_rpk().describe_topic_configs(
+            topic.name
+        )
+        assert target_configs["redpanda.storage.mode"][0] == storage_mode, (
+            f"Target topic storage mode: expected {storage_mode}, "
+            f"got {target_configs['redpanda.storage.mode'][0]}"
+        )
+
+    @cluster(num_nodes=6)
+    def test_storage_mode_change_sync(self):
+        """
+        Verifies that changes to redpanda.storage.mode on the source topic
+        are synced to the mirror topic via cluster linking.
+        """
+        topic_name = "test-storage-mode-change"
+
+        topic = TopicSpec(name=topic_name, partition_count=3, replication_factor=1)
+
+        self.get_source_cluster_rpk().create_topic(
+            topic=topic.name,
+            partitions=topic.partition_count,
+            replicas=topic.replication_factor,
+            config={"redpanda.storage.mode": "unset"},
+        )
+
+        created_link = self.create_link("test-link")
+        self.validate_created_link(created_link)
+
+        wait_until(
+            lambda: self._topics_are_present(
+                self.get_target_cluster_rpk(), [topic], True
+            ),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Topic not created on target cluster",
+        )
+
+        # Verify initial storage mode
+        target_configs = self.get_target_cluster_rpk().describe_topic_configs(
+            topic.name
+        )
+        assert target_configs["redpanda.storage.mode"][0] == "unset", (
+            f"Expected unset, got {target_configs['redpanda.storage.mode'][0]}"
+        )
+
+        # Change storage mode on source from unset to local
+        self.get_source_cluster_rpk().alter_topic_config(
+            topic_name, "redpanda.storage.mode", "local"
+        )
+
+        # Wait for the change to sync
+        def storage_mode_synced():
+            configs = self.get_target_cluster_rpk().describe_topic_configs(topic.name)
+            return configs["redpanda.storage.mode"][0] == "local"
+
+        wait_until(
+            storage_mode_synced,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Storage mode change not synced to target cluster",
+        )


### PR DESCRIPTION
Starting in `v26.1`, we will begin to utilize `redpanda.storage.mode` as the de-facto way of managing tiered storage permissions (at least in Cloud deployments). For this reason, we need to make sure this property is correctly synced with shadow linking moving forward - otherwise, we could begin to see issues with topics created with `redpanda.storage.mode=tiered` and non-configured `redpanda.remote.{read/write}` permissions (since the synced topic may end up on the target cluster as `redpanda.storage.mode=unset`).

Also add a commit that explicitly prevents cloud topics from being synced across cluster links.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
