### PR TITLE
bytes: Fix iobuf hash

### DIFF
--- a/src/v/bytes/BUILD
+++ b/src/v/bytes/BUILD
@@ -47,6 +47,7 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":iobuf",
+        "//src/v/hashing:xx",
         "@boost//:container_hash",
     ],
 )

--- a/src/v/bytes/hash.h
+++ b/src/v/bytes/hash.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 #include "bytes/iobuf.h"
+#include "hashing/xx.h"
 
 #include <boost/container_hash/hash.hpp>
 
@@ -17,12 +18,14 @@ namespace std {
 template<>
 struct hash<::iobuf> {
     size_t operator()(const ::iobuf& b) const {
-        size_t h = 0;
-        for (auto& f : b) {
-            boost::hash_combine(
-              h, std::hash<std::string_view>{}({f.get(), f.size()}));
+        incremental_xxhash64 h;
+        for (const auto& f : b) {
+            h.update(f.get(), f.size());
         }
-        return h;
+        // mix once
+        size_t seed = 0;
+        boost::hash_combine(seed, h.digest());
+        return seed;
     }
 };
 } // namespace std

--- a/src/v/bytes/tests/iobuf_utils_tests.cc
+++ b/src/v/bytes/tests/iobuf_utils_tests.cc
@@ -15,6 +15,8 @@
 
 #include <seastar/testing/thread_test_case.hh>
 
+#include <iterator>
+
 SEASTAR_THREAD_TEST_CASE(test_reading_zero_bytes_empty_stream) {
     auto buf = iobuf();
     auto is = make_iobuf_input_stream(std::move(buf));
@@ -57,4 +59,27 @@ SEASTAR_THREAD_TEST_CASE(test_bytes_conversion) {
       absl::Hash<bytes>{}(roundtrip_buf), absl::Hash<bytes>{}(bytes_buf));
     BOOST_REQUIRE_EQUAL(
       absl::Hash<iobuf>{}(buf), absl::Hash<iobuf>{}(converted_back));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_iobuf_hash_ignores_fragmentation) {
+    iobuf split_a;
+    split_a.append("aa", 2);
+    iobuf split_b;
+    split_b.append("bb", 2);
+
+    iobuf split;
+    split.append_fragments(std::move(split_a));
+    split.append_fragments(std::move(split_b));
+
+    iobuf contiguous;
+    contiguous.append("aabb", 4);
+
+    BOOST_REQUIRE_EQUAL(split, contiguous);
+    BOOST_REQUIRE_NE(
+      std::distance(split.cbegin(), split.cend()),
+      std::distance(contiguous.cbegin(), contiguous.cend()));
+    BOOST_REQUIRE_EQUAL(
+      std::hash<iobuf>{}(split), std::hash<iobuf>{}(contiguous));
+    BOOST_REQUIRE_EQUAL(
+      absl::Hash<iobuf>{}(split), absl::Hash<iobuf>{}(contiguous));
 }

--- a/src/v/hashing/tests/BUILD
+++ b/src/v/hashing/tests/BUILD
@@ -48,6 +48,7 @@ redpanda_cc_bench(
     ],
     deps = [
         "//src/v/bytes",
+        "//src/v/bytes:hash",
         "//src/v/hashing:crc32c",
         "//src/v/hashing:murmur",
         "//src/v/hashing:xx",

--- a/src/v/hashing/tests/hash_bench.cc
+++ b/src/v/hashing/tests/hash_bench.cc
@@ -10,6 +10,7 @@
 #include "absl/hash/hash.h"
 #include "absl/strings/string_view.h"
 #include "bytes/bytes.h"
+#include "bytes/hash.h"
 #include "hashing/crc32c.h"
 #include "hashing/murmur.h"
 #include "hashing/xx.h"
@@ -280,6 +281,11 @@ bytes generate_data() {
     return buf;
 }
 
+iobuf make_fragmented_iobuf(const bytes& buf) {
+    return tests::fragmented_iobuf(
+      {reinterpret_cast<const char*>(buf.data()), buf.size()}, 3);
+}
+
 template<size_t... Offset>
 size_t murmurhash3_x86_32_continuous() {
     auto buf = generate_data();
@@ -304,17 +310,40 @@ PERF_TEST(murmur_hash_x86_32, unaligned) {
     return murmurhash3_x86_32_continuous<1, 2, 3>();
 }
 
-PERF_TEST(murmur_hash_x86_32, iobuf) {
+template<bool Fragmented, typename HashFn>
+size_t iobuf_hash_body(HashFn hash_fn) {
     auto buf = generate_data();
-    iobuf split_buf = tests::fragmented_iobuf(
-      {reinterpret_cast<const char*>(buf.data()), buf.size()}, 3);
+
+    iobuf io;
+    if constexpr (Fragmented) {
+        io = make_fragmented_iobuf(buf);
+    } else {
+        io.append(reinterpret_cast<const char*>(buf.data()), buf.size());
+    }
+
     perf_tests::start_measuring_time();
     for (auto i = inner_iters; i--;) {
-        auto s = murmurhash3_x86_32(split_buf);
+        auto s = hash_fn(io);
         perf_tests::do_not_optimize(s);
     }
     perf_tests::stop_measuring_time();
+
     return inner_iters;
+}
+
+PERF_TEST(murmur_hash_x86_32, iobuf) {
+    return iobuf_hash_body<true>(
+      [](const iobuf& io) { return murmurhash3_x86_32(io); });
+}
+
+PERF_TEST(iobuf_hash, std_hash_contiguous) {
+    return iobuf_hash_body<false>(
+      [](const iobuf& io) { return std::hash<iobuf>{}(io); });
+}
+
+PERF_TEST(iobuf_hash, std_hash_fragmented) {
+    return iobuf_hash_body<true>(
+      [](const iobuf& io) { return std::hash<iobuf>{}(io); });
 }
 
 } // namespace


### PR DESCRIPTION
iobuf hash was dependent on the exact io fragments layout.

Fix to only rely on bytes to match operator<=>.

Use xxhash streaming hash and one final mixing step.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
