### PR TITLE
ct: Add limits for the produce path concurrency

### DIFF
--- a/src/v/cloud_topics/level_zero/common/BUILD
+++ b/src/v/cloud_topics/level_zero/common/BUILD
@@ -73,6 +73,7 @@ redpanda_cc_library(
     ],
     deps = [
         "//src/v/base",
+        "//src/v/config",
         "//src/v/model",
         "@seastar",
     ],

--- a/src/v/cloud_topics/level_zero/common/level_zero_probe.cc
+++ b/src/v/cloud_topics/level_zero/common/level_zero_probe.cc
@@ -81,6 +81,13 @@ void pipeline_probe::setup_internal_metrics(bool disable, ss::sstring name) {
             "Amount of memory (in bytes) blocked due to memory pressure."),
           labels),
         sm::make_counter(
+          "request_limit_waits",
+          [this] { return _request_limit_waits; },
+          sm::description(
+            "Number of times requests had to wait for an in-flight slot "
+            "due to the write inflight limit."),
+          labels),
+        sm::make_counter(
           "bytes_in",
           [this] { return _total_bytes_in; },
           sm::description(

--- a/src/v/cloud_topics/level_zero/common/level_zero_probe.h
+++ b/src/v/cloud_topics/level_zero/common/level_zero_probe.h
@@ -52,6 +52,7 @@ public:
         _memory_pressure_blocked += mem;
         return ss::defer([this, mem] { _memory_pressure_blocked -= mem; });
     }
+    void register_request_limit_blocked() { ++_request_limit_waits; }
     void register_bytes_in(uint64_t bytes) {
         _total_bytes_in += bytes;
         _request_memory_histogram.record(bytes);
@@ -80,6 +81,8 @@ private:
     uint64_t _memory_pressure_waits{0};
     // memory pressure (memory blocked by waiting for semaphore)
     uint64_t _memory_pressure_blocked{0};
+    // request count limit pressure (req. waits for inflight slot)
+    uint64_t _request_limit_waits{0};
     // total bytes in (for write pipeline)
     uint64_t _total_bytes_in{0};
     // total bytes out (for read pipeline)

--- a/src/v/cloud_topics/level_zero/common/producer_queue.cc
+++ b/src/v/cloud_topics/level_zero/common/producer_queue.cc
@@ -10,9 +10,11 @@
 
 #include "cloud_topics/level_zero/common/producer_queue.h"
 
+#include "config/configuration.h"
 #include "container/chunked_hash_map.h"
 #include "model/record.h"
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 
@@ -33,14 +35,29 @@ public:
 
 namespace {
 
-/// A noop ticket that doesn't enforce any ordering. Used for no_producer_id.
-class noop_ticket_impl final : public producer_ticket::impl {
+class nopid_ticket_impl final : public producer_ticket::impl {
 public:
-    ~noop_ticket_impl() override = default;
+    explicit nopid_ticket_impl(ss::semaphore& s)
+      : _s(s) {}
+    ~nopid_ticket_impl() override = default;
 
-    ss::future<> redeem() override { return ss::now(); }
+    ss::future<> redeem() override {
+        try {
+            _units = co_await ss::get_units(_s, 1, _as);
+        } catch (const ss::abort_requested_exception&) {
+            // release() was called before the semaphore was acquired;
+            // return normally so the caller can propagate the abort.
+        }
+    }
 
-    void release() override {}
+    void release() override {
+        _units = {};
+        _as.request_abort();
+    }
+
+    ss::semaphore& _s;
+    ss::semaphore_units<> _units;
+    ss::abort_source _as;
 };
 
 /// A real ticket that enforces ordering by chaining futures.
@@ -113,9 +130,15 @@ private:
 
 class producer_queue::impl {
 public:
+    impl()
+      : _no_pid(
+          config::shard_local_cfg().cloud_topics_produce_no_pid_concurrency()) {
+    }
+
     producer_ticket reserve(model::producer_id pid) {
         if (pid == model::no_producer_id) {
-            return producer_ticket{std::make_unique<noop_ticket_impl>()};
+            return producer_ticket{
+              std::make_unique<nopid_ticket_impl>(_no_pid)};
         }
         auto it = _producer_states->find(pid);
         ticket_impl* prev = nullptr;
@@ -133,6 +156,8 @@ public:
 private:
     ss::lw_shared_ptr<producer_state_map> _producer_states
       = ss::make_lw_shared<producer_state_map>();
+
+    ss::semaphore _no_pid;
 };
 
 producer_ticket::producer_ticket() = default;

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
@@ -52,6 +52,9 @@ size_t get_cloud_topics_l0_write_path_memory() {
 template<class Clock>
 write_pipeline<Clock>::write_pipeline()
   : _mem_budget(get_cloud_topics_l0_write_path_memory(), "write-pipeline")
+  , _req_budget(
+      config::shard_local_cfg().cloud_topics_produce_write_inflight_limit(),
+      "write-pipeline-req-count")
   , _probe(
       "write",
       config::shard_local_cfg().disable_metrics(),
@@ -99,7 +102,17 @@ auto write_pipeline<Clock>::prepare_write(
         units = co_await ss::get_units(
           _mem_budget, sz, this->get_root_rtc().root_abort_source());
     }
-    co_return prepared_data(std::move(data_chunk), std::move(units.value()));
+
+    auto req_units = ss::try_get_units(_req_budget, 1);
+    if (!req_units) {
+        _probe.register_request_limit_blocked();
+        req_units = co_await ss::get_units(
+          _req_budget, 1, this->get_root_rtc().root_abort_source());
+    }
+    co_return prepared_data{
+      .data_chunk = std::move(data_chunk),
+      .mem_units = std::move(units.value()),
+      .req_units = std::move(req_units.value())};
 }
 
 template<class Clock>

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
@@ -64,7 +64,10 @@ public:
 
     struct prepared_data {
         serialized_chunk data_chunk;
-        ss::semaphore_units<ss::named_semaphore_exception_factory, Clock> units;
+        ss::semaphore_units<ss::named_semaphore_exception_factory, Clock>
+          mem_units;
+        ss::semaphore_units<ss::named_semaphore_exception_factory, Clock>
+          req_units;
     };
 
     ss::future<std::expected<prepared_data, std::error_code>>
@@ -284,6 +287,7 @@ private:
     size_t _bytes_total{0};
     // Semaphore that represents memory budget that we have
     ssx::named_semaphore<Clock> _mem_budget;
+    ssx::named_semaphore<Clock> _req_budget;
 
     pipeline_probe _probe;
 };

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4781,6 +4781,24 @@ configuration::configuration()
       {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
       3,
       {.min = 1})
+  , cloud_topics_produce_write_inflight_limit(
+      *this,
+      "cloud_topics_produce_write_inflight_limit",
+      "Maximum number of in-flight write requests per shard in the cloud "
+      "topics write pipeline. Requests that exceed this limit are queued "
+      "until a slot becomes available.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      1024,
+      {.min = 1})
+  , cloud_topics_produce_no_pid_concurrency(
+      *this,
+      "cloud_topics_produce_no_pid_concurrency",
+      "Maximum number of concurrent raft replication requests for producers "
+      "without a producer ID (idempotency disabled). Limits how many no-PID "
+      "writes can proceed past the producer queue into raft simultaneously.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      32,
+      {.min = 1})
   , development_feature_property_testing_only(
       *this,
       "development_feature_property_testing_only",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -825,6 +825,9 @@ public:
       cloud_topics_long_term_file_deletion_delay;
     bounded_property<int32_t> cloud_topics_num_metastore_partitions;
 
+    bounded_property<size_t> cloud_topics_produce_write_inflight_limit;
+    bounded_property<size_t> cloud_topics_produce_no_pid_concurrency;
+
     development_feature_property<int> development_feature_property_testing_only;
 
 private:


### PR DESCRIPTION
This PR limits number of in-flight requests in the pipeline and number of requests that can be committed concurrently. The latter only applies to non-idempotent producers.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none