### PR TITLE
`ct/l1`: add `vassert` to `compaction_sink::flush()`

### DIFF
--- a/src/v/cloud_topics/level_one/compaction/sink.cc
+++ b/src/v/cloud_topics/level_one/compaction/sink.cc
@@ -198,6 +198,9 @@ ss::future<> compaction_sink::flush(kafka::offset object_last_offset) {
     auto builder = std::exchange(inflight_object->builder, nullptr);
     auto oid = inflight_object->oid;
     auto object_base_offset = inflight_object->object_base_offset;
+    vassert(
+      object_last_offset >= object_base_offset,
+      "Offset range must be properly bounded");
 
     // Write the footer and get object metadata.
     auto object_info_fut = co_await ss::coroutine::as_future(builder->finish());


### PR DESCRIPTION
Test

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
