### PR TITLE
`ct/l1`: `compaction_sink` fix & strengthened checks in `metastore`

### DIFF
--- a/src/v/cloud_topics/level_one/compaction/sink.cc
+++ b/src/v/cloud_topics/level_one/compaction/sink.cc
@@ -394,7 +394,7 @@ ss::future<> compaction_sink::compact_objects_with_update(
     }
 }
 
-ss::future<> compaction_sink::finalize() {
+ss::future<> compaction_sink::finalize(bool /*success*/) {
     if (!_metadata_builder) {
         co_return;
     }

--- a/src/v/cloud_topics/level_one/compaction/sink.cc
+++ b/src/v/cloud_topics/level_one/compaction/sink.cc
@@ -246,6 +246,13 @@ ss::future<> compaction_sink::flush(kafka::offset object_last_offset) {
     vassert(
       std::distance(first, last) == 1,
       "Expected one partition range in builder.");
+    dassert(
+      object_base_offset <= object_last_offset,
+      "Compaction sink produced inverted extent for tidp {}: base_offset {} "
+      "> last_offset {}",
+      _tp,
+      object_base_offset,
+      object_last_offset);
     auto ntp_md = metastore::object_metadata::ntp_metadata{
       .tidp = _tp,
       .base_offset = object_base_offset,
@@ -394,17 +401,35 @@ ss::future<> compaction_sink::compact_objects_with_update(
     }
 }
 
-ss::future<> compaction_sink::finalize(bool /*success*/) {
+ss::future<> compaction_sink::finalize(bool success) {
     if (!_metadata_builder) {
         co_return;
     }
 
     if (_inflight_object) {
-        if (!_processed_extents.empty()) {
+        if (success && !_processed_extents.empty()) {
             auto last_offset
               = _processed_extents.make_reverse_stream().next().last_offset;
             co_await flush(last_offset);
         } else {
+            // On the exceptional path, the inflight object may either:
+            // 1. Have a base offset > the last processed extent's last offset.
+            //    E.g., iterating over extents [[0,9], [10,19]], a new object is
+            //    rolled with `object_base_offset=15`, an exception is thrown
+            //    and caught, and we call `sink->finalize()` with
+            //    `last_offset=9`. Flushing would give us an object with offsets
+            //    [15,9], violating the offset space.
+            // 2. Have partially-processed extent data that extends beyond what
+            //    `_processed_extents` tracks. E.g., iterating over extents
+            //    [[0,9], [10,19]] with `object_base_offset=0`, we iterate up to
+            //    offset 15 in the second extent, an exception is thrown and and
+            //    caught, and we call `sink->finalize()` with `last_offset=9`.
+            //    Flushing would give us an object with offsets [0,9], even
+            //    though the inflight object now contains data for the offset
+            //    space [0,15].
+            // In either case, discard the inflight object in the exceptional
+            // path to avoid uploading an object whose contents don't match the
+            // recorded metadata.
             auto inflight_object = std::exchange(_inflight_object, nullptr);
             co_await discard_object(
               std::move(inflight_object->upload),

--- a/src/v/cloud_topics/level_one/compaction/sink.h
+++ b/src/v/cloud_topics/level_one/compaction/sink.h
@@ -55,7 +55,7 @@ public:
     ss::future<ss::stop_iteration>
     operator()(model::record_batch, model::compression) final;
 
-    ss::future<> finalize() final;
+    ss::future<> finalize(bool success) final;
 
 private:
     // The target maximum L1 object size that will be built.

--- a/src/v/cloud_topics/level_one/compaction/sink.h
+++ b/src/v/cloud_topics/level_one/compaction/sink.h
@@ -140,6 +140,9 @@ private:
     // `map_deduplication_iteration`.
     chunked_vector<metastore::compaction_update::cleaned_range>
       _new_cleaned_ranges;
+
+private:
+    friend class throwing_compaction_sink;
 };
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/sink.h
+++ b/src/v/cloud_topics/level_one/compaction/sink.h
@@ -46,11 +46,11 @@ public:
     // to the `sink`. This is an asynchronous function because the active L1
     // object may need to be rolled, in case that the next extent range provided
     // is non-contiguous.
-    ss::future<> prepare_iteration(kafka::offset);
+    ss::future<> prepare_iteration(kafka::offset) final;
 
     // Called by the `source` after batches in an extent range are provided
     // to the `sink`.
-    ss::future<> finish_iteration(kafka::offset, kafka::offset);
+    ss::future<> finish_iteration(kafka::offset, kafka::offset) final;
 
     ss::future<ss::stop_iteration>
     operator()(model::record_batch, model::compression) final;

--- a/src/v/cloud_topics/level_one/compaction/source.cc
+++ b/src/v/cloud_topics/level_one/compaction/source.cc
@@ -12,7 +12,6 @@
 
 #include "cloud_topics/level_one/compaction/filter.h"
 #include "cloud_topics/level_one/compaction/logger.h"
-#include "cloud_topics/level_one/compaction/sink.h"
 #include "cloud_topics/level_one/frontend_reader/level_one_reader.h"
 #include "cloud_topics/level_one/metastore/extent_metadata_reader.h"
 #include "cloud_topics/level_one/metastore/offset_interval_set.h"
@@ -245,7 +244,6 @@ ss::future<ss::stop_iteration> compaction_source::map_building_iteration() {
 
 ss::future<ss::stop_iteration> compaction_source::deduplication_iteration(
   compaction::sliding_window_reducer::sink& sink) {
-    auto& ct_sink = static_cast<compaction_sink&>(sink);
     if (preempted()) {
         co_return ss::stop_iteration::yes;
     }
@@ -283,11 +281,11 @@ ss::future<ss::stop_iteration> compaction_source::deduplication_iteration(
           std::make_unique<level_one_log_reader_impl>(
             config, _ntp, _tp, _metastore, _io, _l1_reader_probe));
 
-        co_await ct_sink.prepare_iteration(start_offset);
+        co_await sink.prepare_iteration(start_offset);
         auto stats = co_await rdr.consume(
-          compaction_filter{ct_sink, *_map, _ntp, _removable_tombstone_ranges},
+          compaction_filter{sink, *_map, _ntp, _removable_tombstone_ranges},
           model::no_timeout);
-        co_await ct_sink.finish_iteration(start_offset, last_offset);
+        co_await sink.finish_iteration(start_offset, last_offset);
         if (stats.has_removed_data()) {
             vlog(
               compaction_log.info,

--- a/src/v/cloud_topics/level_one/compaction/tests/BUILD
+++ b/src/v/cloud_topics/level_one/compaction/tests/BUILD
@@ -1,6 +1,19 @@
 load("//bazel:test.bzl", "redpanda_cc_gtest", "redpanda_test_cc_library")
 
 redpanda_test_cc_library(
+    name = "throwing_compaction_sink",
+    hdrs = [
+        "throwing_compaction_sink.h",
+    ],
+    deps = [
+        "//src/v/cloud_topics/level_one/compaction:source_and_sink",
+        "//src/v/compaction:reducer",
+        "//src/v/model",
+        "@seastar",
+    ],
+)
+
+redpanda_test_cc_library(
     name = "in_memory_sink",
     srcs = [
         "in_memory_sink.cc",
@@ -28,6 +41,7 @@ redpanda_cc_gtest(
     ],
     deps = [
         ":in_memory_sink",
+        ":throwing_compaction_sink",
         "//src/v/bytes:iobuf",
         "//src/v/bytes:iobuf_parser",
         "//src/v/bytes:iostream",

--- a/src/v/cloud_topics/level_one/compaction/tests/in_memory_sink.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/in_memory_sink.cc
@@ -72,7 +72,7 @@ in_memory_sink::operator()(model::record_batch b, model::compression c) {
     co_return ss::stop_iteration::no;
 }
 
-ss::future<> in_memory_sink::finalize() {
+ss::future<> in_memory_sink::finalize(bool /*success*/) {
     co_await maybe_flush_object_builder();
     co_return;
 }

--- a/src/v/cloud_topics/level_one/compaction/tests/in_memory_sink.h
+++ b/src/v/cloud_topics/level_one/compaction/tests/in_memory_sink.h
@@ -34,6 +34,10 @@ public:
     ss::future<ss::stop_iteration>
     operator()(model::record_batch, model::compression) final;
     ss::future<> finalize(bool) final;
+    ss::future<> prepare_iteration(kafka::offset) final { co_return; }
+    ss::future<> finish_iteration(kafka::offset, kafka::offset) final {
+        co_return;
+    }
 
 private:
     bool needs_roll() const;

--- a/src/v/cloud_topics/level_one/compaction/tests/in_memory_sink.h
+++ b/src/v/cloud_topics/level_one/compaction/tests/in_memory_sink.h
@@ -33,7 +33,7 @@ public:
     initialize(compaction::sliding_window_reducer::source&) final;
     ss::future<ss::stop_iteration>
     operator()(model::record_batch, model::compression) final;
-    ss::future<> finalize() final;
+    ss::future<> finalize(bool) final;
 
 private:
     bool needs_roll() const;

--- a/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
@@ -18,6 +18,7 @@
 #include "cloud_topics/level_one/compaction/sink.h"
 #include "cloud_topics/level_one/compaction/source.h"
 #include "cloud_topics/level_one/compaction/tests/in_memory_sink.h"
+#include "cloud_topics/level_one/compaction/tests/throwing_compaction_sink.h"
 #include "cloud_topics/level_one/compaction/worker_probe.h"
 #include "cloud_topics/level_one/frontend_reader/tests/l1_reader_fixture.h"
 #include "cloud_topics/level_one/metastore/metastore.h"
@@ -130,6 +131,59 @@ ss::future<> do_compact(
       as,
       config::mock_binding<size_t>(128_MiB),
       16_MiB);
+    auto reducer = compaction::sliding_window_reducer(
+      std::move(src), std::move(sink));
+
+    co_await std::move(reducer).run();
+}
+
+ss::future<> do_compact_with_throwing_sink(
+  model::topic_id_partition tidp,
+  model::ntp ntp,
+  l1::metastore::compaction_offsets_response offsets_response,
+  l1::metastore::compaction_epoch expected_compaction_epoch,
+  kafka::offset start_offset,
+  l1::metastore* metastore,
+  l1::io* io,
+  l1::throwing_compaction_sink::predicate_t should_roll,
+  l1::throwing_compaction_sink::predicate_t should_throw,
+  std::chrono::milliseconds min_compaction_lag_ms = 0ms,
+  kafka::offset max_compactible_offset = kafka::offset::max()) {
+    ss::abort_source as;
+    auto state = l1::compaction_job_state::running;
+    auto map = compaction::simple_key_offset_map();
+    auto dirty_range_intervals = offsets_response.dirty_ranges.to_vec();
+    l1::compaction_worker_probe probe;
+    auto src = std::make_unique<l1::compaction_source>(
+      ntp,
+      tidp,
+      dirty_range_intervals,
+      offsets_response.removable_tombstone_ranges,
+      start_offset,
+      max_compactible_offset,
+      &map,
+      min_compaction_lag_ms,
+      metastore,
+      io,
+      as,
+      state,
+      probe,
+      nullptr);
+    // Use a very large max_object_size to disable size-based rolls; the
+    // throwing_compaction_sink's should_roll predicate controls rolling.
+    auto inner_sink = std::make_unique<l1::compaction_sink>(
+      tidp,
+      dirty_range_intervals,
+      offsets_response.removable_tombstone_ranges,
+      expected_compaction_epoch,
+      start_offset,
+      io,
+      metastore,
+      as,
+      config::mock_binding<size_t>(128_MiB),
+      16_MiB);
+    auto sink = std::make_unique<l1::throwing_compaction_sink>(
+      std::move(inner_sink), std::move(should_roll), std::move(should_throw));
     auto reducer = compaction::sliding_window_reducer(
       std::move(src), std::move(sink));
 
@@ -860,4 +914,169 @@ TEST_F(ReducerTestFixture, MaxCompactibleOffsetReducer) {
     ASSERT_GT(compaction_info->dirty_ratio, 0.0);
     ASSERT_TRUE(compaction_info->offsets_response.dirty_ranges.covers(
       max_compactible_offset, last_offset));
+}
+
+// Tests the exceptional path in compaction_sink::finalize() where the inflight
+// object has been rolled mid-extent (Case 1 from the finalize() comments).
+// Setup: two contiguous extents [[0,9], [10,19]], 1 record per batch.
+// A forced roll at batch 15 creates a new object with object_base_offset=15.
+// The throw fires immediately after, before finish_iteration for [10,19].
+// At finalize(false), _processed_extents = {[0,9]}, last_offset=9.
+// Flushing the inflight object would give offsets [15,9] - an inverted range,
+// which would trigger an assert. `finalize()` must discard it instead.
+TEST_F(ReducerTestFixture, ExceptionalFinalizeAfterObjectRoll) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+    int batches_per_extent = 10;
+    auto gen = linear_int_kv_batch_generator();
+    auto ts = model::timestamp::now();
+    auto spec = model::test::record_batch_spec{
+      .allow_compression = false,
+      .count = 1,
+      .timestamp = ts,
+      .all_records_have_same_timestamp = true};
+
+    // Two extents, 1 record per batch, 10 batches each -> offsets [0,9] and
+    // [10,19].
+    for (int i = 0; i < 2; ++i) {
+        auto batches = gen(spec, batches_per_extent);
+        std::vector<tidp_batches_t> tidp_batches;
+        tidp_batches.emplace_back(tidp, std::move(batches));
+        make_l1_objects(std::move(tidp_batches)).get();
+    }
+
+    auto info_spec = l1::metastore::compaction_info_spec{
+      .tidp = tidp,
+      .tombstone_removal_upper_bound_ts = model::timestamp::max()};
+    auto compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+
+    // Roll at batch 15 (offset 15, i.e. the 6th batch of the second extent),
+    // then throw immediately after.
+    int batch_count = 0;
+    int roll_at = batches_per_extent + 5;
+    auto should_roll = [&batch_count, roll_at]() -> bool {
+        return batch_count == roll_at;
+    };
+    auto should_throw = [&batch_count, roll_at]() -> bool {
+        ++batch_count;
+        return batch_count == roll_at + 1;
+    };
+
+    EXPECT_THROW(
+      do_compact_with_throwing_sink(
+        tidp,
+        ntp,
+        std::move(compaction_info->offsets_response),
+        compaction_info->compaction_epoch,
+        compaction_info->start_offset,
+        &_metastore,
+        &_io,
+        std::move(should_roll),
+        std::move(should_throw))
+        .get(),
+      std::runtime_error);
+
+    // The log must still be readable after the exceptional compaction.
+    auto reader = make_reader(ntp, tidp);
+    auto output_batches = read_all(std::move(reader));
+    ASSERT_FALSE(output_batches.empty());
+}
+
+// Tests the exceptional path in compaction_sink::finalize() where the inflight
+// object contains partially-processed extent data beyond what
+// _processed_extents tracks (Case 2 from the finalize() comments).
+//
+// Setup: two contiguous extents [[0,9], [10,19]], 1 record per batch.
+// No roll occurs — the single object spans both extents. The throw fires at
+// batch 15 (offset 15), before finish_iteration for [10,19].
+// At finalize(false), _processed_extents = {[0,9]}, last_offset=9.
+// Flushing would give an object with offsets [0,9], but the object actually
+// contains data up to offset 15. finalize must discard it instead.
+TEST_F(ReducerTestFixture, ExceptionalFinalizePartialExtent) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+    int batches_per_extent = 10;
+    auto gen = linear_int_kv_batch_generator();
+    auto ts = model::timestamp::now();
+    auto spec = model::test::record_batch_spec{
+      .allow_compression = false,
+      .count = 1,
+      .timestamp = ts,
+      .all_records_have_same_timestamp = true};
+
+    for (int i = 0; i < 2; ++i) {
+        auto batches = gen(spec, batches_per_extent);
+        std::vector<tidp_batches_t> tidp_batches;
+        tidp_batches.emplace_back(tidp, std::move(batches));
+        make_l1_objects(std::move(tidp_batches)).get();
+    }
+
+    auto info_spec = l1::metastore::compaction_info_spec{
+      .tidp = tidp,
+      .tombstone_removal_upper_bound_ts = model::timestamp::max()};
+    auto compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+
+    // No roll. Throw at batch 15 (offset 15, the 6th batch of the second
+    // extent). The inflight object contains data for [0,15] but
+    // _processed_extents only covers [0,9].
+    int batch_count = 0;
+    int throw_at = batches_per_extent + 5;
+    auto no_roll = []() -> bool { return false; };
+    auto should_throw = [&batch_count, throw_at]() -> bool {
+        ++batch_count;
+        return batch_count == throw_at + 1;
+    };
+
+    EXPECT_THROW(
+      do_compact_with_throwing_sink(
+        tidp,
+        ntp,
+        std::move(compaction_info->offsets_response),
+        compaction_info->compaction_epoch,
+        compaction_info->start_offset,
+        &_metastore,
+        &_io,
+        std::move(no_roll),
+        std::move(should_throw))
+        .get(),
+      std::runtime_error);
+
+    // Verify that each object's physical data matches its metadata. If the
+    // inflight object were flushed instead of discarded, the new object
+    // would contain batches beyond what the metadata records (e.g., metadata
+    // says [0,9] but the object physically has data up to offset 15).
+    auto extents_res = _metastore
+                         .get_extent_metadata_forwards(
+                           tidp,
+                           kafka::offset{0},
+                           kafka::offset::max(),
+                           /*max_num_extents=*/100,
+                           l1::metastore::include_object_metadata::yes)
+                         .get();
+    ASSERT_TRUE(extents_res.has_value());
+    for (const auto& extent : extents_res->extents) {
+        ASSERT_TRUE(extent.object_info.has_value());
+        auto obj = _io.get_object(extent.object_info->oid);
+        ASSERT_TRUE(obj.has_value());
+        auto rdr = l1::object_reader::create(
+          make_iobuf_input_stream(std::move(obj.value())));
+        auto close_rdr = ss::defer([&rdr] { rdr->close().get(); });
+
+        kafka::offset physical_last_offset{};
+        while (true) {
+            auto res = rdr->read_next().get();
+            if (std::holds_alternative<model::record_batch>(res)) {
+                auto& batch = std::get<model::record_batch>(res);
+                physical_last_offset = model::offset_cast(batch.last_offset());
+            }
+            if (std::holds_alternative<l1::object_reader::eof>(res)) {
+                break;
+            }
+        }
+
+        EXPECT_EQ(physical_last_offset, extent.last_offset)
+          << "Object " << extent.object_info->oid
+          << " physical last offset does not match metadata last offset: "
+          << physical_last_offset << " != " << extent.last_offset;
+    }
 }

--- a/src/v/cloud_topics/level_one/compaction/tests/throwing_compaction_sink.h
+++ b/src/v/cloud_topics/level_one/compaction/tests/throwing_compaction_sink.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_topics/level_one/compaction/sink.h"
+#include "compaction/reducer.h"
+
+#include <stdexcept>
+
+namespace cloud_topics::l1 {
+
+/// A test wrapper that composes a compaction_sink and injects controlled
+/// object rolls and exceptions during operator(). Used to test the exceptional
+/// path in compaction_sink::finalize(), where an inflight object must be
+/// discarded rather than flushed.
+class throwing_compaction_sink
+  : public compaction::sliding_window_reducer::sink {
+public:
+    using predicate_t = ss::noncopyable_function<bool()>;
+
+    /// \param inner        The compaction_sink to delegate to.
+    /// \param should_roll  Called before each operator() delegation. If true,
+    ///                     forces the inner sink to flush its current object
+    ///                     and start a new one, simulating a roll due to
+    ///                     max_object_size being exceeded.
+    /// \param should_throw Called after each operator() delegation. If true,
+    ///                     throws a std::runtime_error.
+    throwing_compaction_sink(
+      std::unique_ptr<compaction_sink> inner,
+      predicate_t should_roll,
+      predicate_t should_throw)
+      : _inner(std::move(inner))
+      , _should_roll(std::move(should_roll))
+      , _should_throw(std::move(should_throw)) {}
+
+    ss::future<bool>
+    initialize(compaction::sliding_window_reducer::source& src) final {
+        return _inner->initialize(src);
+    }
+
+    ss::future<ss::stop_iteration>
+    operator()(model::record_batch b, model::compression c) final {
+        if (_should_roll()) {
+            auto next_offset = model::offset_cast(b.base_offset());
+            auto prev_offset = kafka::prev_offset(next_offset);
+            co_await _inner->flush(prev_offset);
+            co_await _inner->initialize_builder(next_offset);
+        }
+        auto res = co_await (*_inner)(std::move(b), c);
+        if (_should_throw()) {
+            throw std::runtime_error(
+              "throwing_compaction_sink: injected exception");
+        }
+        co_return res;
+    }
+
+    ss::future<> prepare_iteration(kafka::offset o) final {
+        return _inner->prepare_iteration(o);
+    }
+
+    ss::future<>
+    finish_iteration(kafka::offset base, kafka::offset last) final {
+        return _inner->finish_iteration(base, last);
+    }
+
+    ss::future<> finalize(bool success) final {
+        return _inner->finalize(success);
+    }
+
+private:
+    std::unique_ptr<compaction_sink> _inner;
+    predicate_t _should_roll;
+    predicate_t _should_throw;
+};
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/state_update_utils.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update_utils.cc
@@ -22,8 +22,26 @@ contiguous_intervals_for_extents(
         }
         auto current_base = extents.begin()->base_offset;
         auto current_last = extents.begin()->last_offset;
+        if (current_base > current_last) {
+            return std::unexpected(
+              fmt::format(
+                "Input object has inverted extent for partition {}: "
+                "base_offset {} > last_offset {}",
+                tidp,
+                current_base,
+                current_last));
+        }
         // Skip the first entry when iterating over `extents`.
         for (const auto& extent : extents | std::views::drop(1)) {
+            if (extent.base_offset > extent.last_offset) {
+                return std::unexpected(
+                  fmt::format(
+                    "Input object has inverted extent for partition {}: "
+                    "base_offset {} > last_offset {}",
+                    tidp,
+                    extent.base_offset,
+                    extent.last_offset));
+            }
             auto expected_next = kafka::next_offset(current_last);
             if (extent.base_offset == expected_next) {
                 // A new extent that is contiguous with the current interval.

--- a/src/v/compaction/reducer.cc
+++ b/src/v/compaction/reducer.cc
@@ -38,7 +38,8 @@ ss::future<> compaction::sliding_window_reducer::run() && {
     }
 
     // Done!
-    co_await _sink->finalize();
+    bool success = eptr == nullptr;
+    co_await _sink->finalize(success);
 
     if (eptr) {
         std::rethrow_exception(eptr);

--- a/src/v/compaction/reducer.h
+++ b/src/v/compaction/reducer.h
@@ -81,6 +81,8 @@ public:
         virtual ss::future<ss::stop_iteration>
         operator()(model::record_batch, model::compression) = 0;
         virtual ss::future<> finalize(bool) = 0;
+        virtual ss::future<> prepare_iteration(kafka::offset) = 0;
+        virtual ss::future<> finish_iteration(kafka::offset, kafka::offset) = 0;
     };
 
     // The source of data for compaction.

--- a/src/v/compaction/reducer.h
+++ b/src/v/compaction/reducer.h
@@ -62,8 +62,11 @@ public:
     // (which has already been determined to be written by a
     // `compaction::filter`) and is responsible for writing its contents to
     // whichever data format/store this `sink` represents.
-    // 3. `finalize()`: perform any final steps required in the `sink` layer,
-    // i.e flushing in progress writes, update final metadata, etc.
+    // 3. `finalize(success)`: perform any final steps required in the `sink`
+    // layer, i.e flushing in progress writes, update final metadata, etc.
+    // `success` is true if the deduplication pass completed without exception,
+    // false if an exception was caught. Implementations may use this to discard
+    // partially-written state rather than committing it.
     class sink {
     public:
         sink() noexcept = default;
@@ -77,7 +80,7 @@ public:
         virtual ss::future<bool> initialize(source&) = 0;
         virtual ss::future<ss::stop_iteration>
         operator()(model::record_batch, model::compression) = 0;
-        virtual ss::future<> finalize() = 0;
+        virtual ss::future<> finalize(bool) = 0;
     };
 
     // The source of data for compaction.

--- a/src/v/compaction/tests/simple_reducer.h
+++ b/src/v/compaction/tests/simple_reducer.h
@@ -82,7 +82,7 @@ public:
         co_return ss::stop_iteration::no;
     }
 
-    ss::future<> finalize() final { co_return; }
+    ss::future<> finalize(bool /*success*/) final { co_return; }
 
     chunked_circular_buffer<model::record_batch>& _output_batches;
 };

--- a/src/v/compaction/tests/simple_reducer.h
+++ b/src/v/compaction/tests/simple_reducer.h
@@ -84,6 +84,11 @@ public:
 
     ss::future<> finalize(bool /*success*/) final { co_return; }
 
+    ss::future<> prepare_iteration(kafka::offset) final { co_return; }
+    ss::future<> finish_iteration(kafka::offset, kafka::offset) final {
+        co_return;
+    }
+
     chunked_circular_buffer<model::record_batch>& _output_batches;
 };
 


### PR DESCRIPTION
* We could create malformed objects if we hit an exception in the middle of an extent, since we still proceed to call `sink->finalize()` in the exceptional path with the `compaction::sliding_window_reducer`. See commit/code comment for color.
* Strengthening the checks around malformed extents before committing to and corrupting the `metastore` is a good idea.

Log lines which provide the smoking gun:

```
Compacting as normal
================
2026-03-20 20:24:01.697 info REDPANDA     rp-d6scjsgo0bqb2hs06ss0-blue-a-0     redpanda     INFO          INFO  2026-03-20 20:24:01,697 [shard  2:ctc ] cloud_topics_compaction - source.cc:299 - L1 compaction removing data from CTP {kafka/ct-stress-iceberg-4/3}, offset range (0~56762981), stats: { batches_processed: 4221, batches_discarded: 769, records_discarded: 2358, expired_tombstones_discarded: 0, non_compactible_batches: 0}

Uh oh
=================
2026-03-20 20:24:13.267 warn REDPANDA     rp-d6scjsgo0bqb2hs06ss0-blue-a-0     redpanda     WARN          WARN  2026-03-20 20:24:13,266 [shard  2:ctc ] cloud_topics_compaction - worker.cc:264 - Caught exception cloud_storage_clients::rest_error_response while compacting CTP {64dc98de-15df-4595-aa6d-ddeaf6b980cd/3}.
2026-03-20 20:24:13.267 info REDPANDA     rp-d6scjsgo0bqb2hs06ss0-blue-a-0     redpanda     INFO          INFO  2026-03-20 20:24:13,266 [shard  2:ctc ] cloud_topics_compaction - sink.cc:384 - Finalized compaction of tidp {64dc98de-15df-4595-aa6d-ddeaf6b980cd/3} with compaction metadata update {new_cleaned_ranges:[], removed_tombstone_ranges:{}, cleaned_at:{timestamp: 1774038253261}, expected_compaction_epoch: 1552}

First instance of weird offsets
===========
2026-03-20 20:24:30.746 info REDPANDA     rp-d6scjsgo0bqb2hs06ss0-blue-a-0     redpanda     INFO          INFO  2026-03-20 20:24:30,745 [shard  6:ctc ] cloud_topics_compaction - source.cc:299 - L1 compaction removing data from CTP {kafka/ct-stress-iceberg-4/3}, offset range (0~56796658), stats: { batches_processed: 4204, batches_discarded: 396, records_discarded: 1328, expired_tombstones_discarded: 0, non_compactible_batches: 0}
2026-03-20 20:24:32.038 info REDPANDA     rp-d6scjsgo0bqb2hs06ss0-blue-a-0     redpanda     INFO          INFO  2026-03-20 20:24:32,037 [shard  6:ctc ] cloud_topics_compaction - source.cc:299 - L1 compaction removing data from CTP {kafka/ct-stress-iceberg-4/3}, offset range (56762982~56831560), stats: { batches_processed: 1676, batches_discarded: 169, records_discarded: 3288, expired_tombstones_discarded: 0, non_compactible_batches: 0}
```

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
