### PR TITLE
`ct/l1`: more `metastore` offset metadata validation 

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
@@ -904,6 +904,20 @@ replace_objects_db_update::validate_inputs() const {
     for (const auto& o : new_objects) {
         o.collect_extents_by_tidp(&new_extents_by_tp);
     }
+    for (const auto& [tidp, extents] : new_extents_by_tp) {
+        for (const auto& extent : extents) {
+            if (extent.base_offset > extent.last_offset) {
+                return std::unexpected(db_update_error(
+                  invalid_input,
+                  fmt::format(
+                    "Input object has inverted extent for partition {}: "
+                    "base_offset {} > last_offset {}",
+                    tidp,
+                    extent.base_offset,
+                    extent.last_offset)));
+            }
+        }
+    }
 
     auto contiguous_intervals = contiguous_intervals_for_extents(
       new_extents_by_tp);

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
@@ -531,6 +531,16 @@ add_objects_db_update::validate_inputs() const {
         }
         auto expected_next = extents.begin()->base_offset;
         for (const auto& extent : extents) {
+            if (extent.base_offset > extent.last_offset) {
+                return std::unexpected(db_update_error(
+                  invalid_input,
+                  fmt::format(
+                    "Input object has inverted extent for partition {}: "
+                    "base_offset {} > last_offset {}",
+                    tidp,
+                    extent.base_offset,
+                    extent.last_offset)));
+            }
             if (extent.base_offset != expected_next) {
                 return std::unexpected(db_update_error(
                   invalid_input,

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -220,6 +220,16 @@ replicated_object_builder::remove_pending_object(object_id oid) {
 std::expected<void, replicated_object_builder::error>
 replicated_object_builder::add(
   object_id oid, metastore::object_metadata::ntp_metadata ntp_meta) {
+    if (ntp_meta.base_offset > ntp_meta.last_offset) {
+        return std::unexpected(
+          error{fmt::format(
+            "Metadata has inverted offsets for partition {}, object {}: "
+            "base_offset {} > last_offset {}",
+            ntp_meta.tidp,
+            oid,
+            ntp_meta.base_offset,
+            ntp_meta.last_offset)});
+    }
     auto metastore_pid = fe_.metastore_partition(ntp_meta.tidp);
     if (!metastore_pid) {
         return std::unexpected(

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -79,6 +79,16 @@ simple_object_builder::add(
         return std::unexpected(
           error{fmt::format("Object {} is not a pending object", oid)});
     }
+    if (ntp_meta.base_offset > ntp_meta.last_offset) {
+        return std::unexpected(
+          error{fmt::format(
+            "Metadata has inverted offsets for partition {}, object {}: "
+            "base_offset {} > last_offset {}",
+            ntp_meta.tidp,
+            oid,
+            ntp_meta.base_offset,
+            ntp_meta.last_offset)});
+    }
     auto& pending_metas = it->second;
     pending_metas.emplace_back(ntp_meta);
     return {};

--- a/src/v/cloud_topics/level_one/metastore/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update.cc
@@ -165,6 +165,15 @@ std::expected<std::monostate, stm_update_error> add_objects_update::can_apply(
             continue;
         }
         for (const auto& extent : extents) {
+            if (extent.base_offset > extent.last_offset) {
+                return std::unexpected(stm_update_error(
+                  fmt::format(
+                    "Input object has inverted extent for partition {}: "
+                    "base_offset {} > last_offset {}",
+                    tidp,
+                    extent.base_offset,
+                    extent.last_offset)));
+            }
             if (extent.base_offset != expected_next) {
                 return std::unexpected(stm_update_error(
                   fmt::format(

--- a/src/v/cloud_topics/level_one/metastore/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update.cc
@@ -388,6 +388,19 @@ replace_objects_update::can_apply(const state& state) {
         }
         o.collect_extents_by_tidp(&new_extents_by_tp);
     }
+    for (const auto& [tidp, extents] : new_extents_by_tp) {
+        for (const auto& extent : extents) {
+            if (extent.base_offset > extent.last_offset) {
+                return std::unexpected(stm_update_error(
+                  fmt::format(
+                    "Input object has inverted extent for partition {}: "
+                    "base_offset {} > last_offset {}",
+                    tidp,
+                    extent.base_offset,
+                    extent.last_offset)));
+            }
+        }
+    }
 
     auto contiguous_intervals_by_tp = contiguous_intervals_for_extents(
       new_extents_by_tp);

--- a/src/v/cloud_topics/level_one/metastore/state_update_utils.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update_utils.cc
@@ -22,26 +22,8 @@ contiguous_intervals_for_extents(
         }
         auto current_base = extents.begin()->base_offset;
         auto current_last = extents.begin()->last_offset;
-        if (current_base > current_last) {
-            return std::unexpected(
-              fmt::format(
-                "Input object has inverted extent for partition {}: "
-                "base_offset {} > last_offset {}",
-                tidp,
-                current_base,
-                current_last));
-        }
         // Skip the first entry when iterating over `extents`.
         for (const auto& extent : extents | std::views::drop(1)) {
-            if (extent.base_offset > extent.last_offset) {
-                return std::unexpected(
-                  fmt::format(
-                    "Input object has inverted extent for partition {}: "
-                    "base_offset {} > last_offset {}",
-                    tidp,
-                    extent.base_offset,
-                    extent.last_offset));
-            }
             auto expected_next = kafka::next_offset(current_last);
             if (extent.base_offset == expected_next) {
                 // A new extent that is contiguous with the current interval.

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -272,6 +272,40 @@ TEST_P(ReplicatedMetastoreTest, TestAddNotFinished) {
     ASSERT_EQ(commit_res.error(), metastore::errc::invalid_request);
 }
 
+TEST_P(ReplicatedMetastoreTest, TestBuilderRejectsInvertedOffsets) {
+    auto& app = get_ct_app(model::node_id{0});
+    auto& meta = app.get_sharded_replicated_metastore()->local();
+    auto tp = make_tp(0);
+    auto obj_builder = meta.object_builder().get().value();
+    auto oid = obj_builder->get_or_create_object_for(tp).get().value();
+
+    // base_offset > last_offset should be rejected.
+    auto add_res = obj_builder->add(
+      oid,
+      metastore::object_metadata::ntp_metadata{
+        .tidp = tp,
+        .base_offset = o{99},
+        .last_offset = o{0},
+        .max_timestamp = ts{10000},
+        .pos = 0,
+        .size = 500,
+      });
+    ASSERT_FALSE(add_res.has_value());
+
+    // A valid extent should still be accepted.
+    auto add_res2 = obj_builder->add(
+      oid,
+      metastore::object_metadata::ntp_metadata{
+        .tidp = tp,
+        .base_offset = o{0},
+        .last_offset = o{99},
+        .max_timestamp = ts{10000},
+        .pos = 0,
+        .size = 500,
+      });
+    ASSERT_TRUE(add_res2.has_value()) << add_res2.error();
+}
+
 TEST_P(ReplicatedMetastoreTest, TestBuilderRemovedObjects) {
     auto& app = get_ct_app(model::node_id{0});
     auto& m = app.get_sharded_replicated_metastore()->local();

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -1090,6 +1090,39 @@ TEST(SimpleMetastoreTest, TestObjectBuilderCreatesNewObjects) {
     ASSERT_EQ(oids.size(), num_objects);
 }
 
+TEST(SimpleMetastoreTest, TestObjectBuilderRejectsInvertedExtent) {
+    simple_metastore m;
+    auto ob = m.object_builder().get().value();
+    auto tp = model::topic_id_partition::from(tid_a);
+    auto oid = ob->create_object_for(tp).get().value();
+
+    // base_offset > last_offset should be rejected.
+    auto res = ob->add(
+      oid,
+      metastore::object_metadata::ntp_metadata{
+        .tidp = tp,
+        .base_offset = 10_o,
+        .last_offset = 5_o,
+        .max_timestamp = 1000_t,
+        .pos = 0,
+        .size = 100,
+      });
+    EXPECT_FALSE(res.has_value());
+
+    // A valid extent should still be accepted.
+    auto res2 = ob->add(
+      oid,
+      metastore::object_metadata::ntp_metadata{
+        .tidp = tp,
+        .base_offset = 0_o,
+        .last_offset = 10_o,
+        .max_timestamp = 1000_t,
+        .pos = 0,
+        .size = 100,
+      });
+    EXPECT_TRUE(res2.has_value());
+}
+
 TEST(SimpleMetastoreTest, TestObjectBuilderBadObjects) {
     // Test calls for objects that don't exist in the builder.
     simple_metastore m;

--- a/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
@@ -515,6 +515,18 @@ TEST_P(StateUpdateParamTest, TestDuplicateAddSingleUpdate) {
     EXPECT_FALSE(res.has_value());
 }
 
+TEST_P(StateUpdateParamTest, TestAddRejectsInvertedExtent) {
+    // An extent with base_offset > last_offset should be rejected.
+    auto update = add_objects_builder()
+                    .add(new_obj_builder(oid1, 100, 1100)
+                           .add(tidp_a, 10_o, 5_o, 1999_t, 0, 99)
+                           .build())
+                    .add_term_start(tidp_a, 0_tm, 10_o)
+                    .build();
+    auto res = can_apply_add_objects(std::move(update));
+    EXPECT_FALSE(res.has_value());
+}
+
 TEST_P(StateUpdateParamTest, TestStartAfterZero) {
     auto update = add_objects_builder()
                     .add(new_obj_builder(oid1, 100, 1100)
@@ -815,6 +827,26 @@ TEST_P(StateUpdateParamTest, TestReplaceBadOrdering) {
                             .build())
                      .build();
 
+    auto replace_res = apply_replace_objects(std::move(replace));
+    EXPECT_FALSE(replace_res.has_value());
+}
+
+TEST_P(StateUpdateParamTest, TestReplaceRejectsInvertedExtent) {
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 100, 1100)
+                        .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                        .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .build();
+    auto add_res = apply_add_objects(std::move(add));
+    ASSERT_TRUE(add_res.has_value());
+
+    // Replacement with an inverted extent should be rejected.
+    auto replace = replace_objects_builder()
+                     .add(new_obj_builder(oid2, 100, 1100)
+                            .add(tidp_a, 10_o, 0_o, 1999_t, 0, 99)
+                            .build())
+                     .build();
     auto replace_res = apply_replace_objects(std::move(replace));
     EXPECT_FALSE(replace_res.has_value());
 }


### PR DESCRIPTION
As requested in https://github.com/redpanda-data/redpanda/pull/29914#discussion_r2969818359.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
