### PR TITLE
`ct/l1`: add `domain_manager_probe`

### DIFF
--- a/src/v/cloud_topics/level_one/domain/BUILD
+++ b/src/v/cloud_topics/level_one/domain/BUILD
@@ -24,6 +24,7 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         ":db_domain_manager",
+        ":domain_manager_probe",
         ":simple_domain_manager",
         "//src/v/cloud_topics:logger",
         "//src/v/cloud_topics/level_one/common:abstract_io",
@@ -114,6 +115,7 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":domain_manager",
+        ":domain_manager_probe",
         "//src/v/base",
         "//src/v/cloud_topics/level_one/common:abstract_io",
         "//src/v/cloud_topics/level_one/common:object_id",

--- a/src/v/cloud_topics/level_one/domain/BUILD
+++ b/src/v/cloud_topics/level_one/domain/BUILD
@@ -73,6 +73,21 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "domain_manager_probe",
+    srcs = [
+        "domain_manager_probe.cc",
+    ],
+    hdrs = [
+        "domain_manager_probe.h",
+    ],
+    deps = [
+        "//src/v/config",
+        "//src/v/metrics",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "db_domain_manager",
     srcs = [
         "db_domain_manager.cc",

--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -246,7 +246,8 @@ db_domain_manager::db_domain_manager(
   cloud_io::remote* remote,
   cloud_storage_clients::bucket_name bucket,
   io* object_io,
-  ss::scheduling_group sg)
+  ss::scheduling_group sg,
+  domain_manager_probe* probe)
   : expected_term_(expected_term)
   , staging_dir_(std::move(staging_dir))
   , remote_(remote)
@@ -256,7 +257,8 @@ db_domain_manager::db_domain_manager(
   , stm_(std::move(stm))
   , gc_interval_(
       config::shard_local_cfg()
-        .cloud_topics_long_term_garbage_collection_interval) {
+        .cloud_topics_long_term_garbage_collection_interval)
+  , probe_(probe) {
     gc_interval_.watch([this]() { sem_.signal(); });
 }
 
@@ -1440,6 +1442,7 @@ db_domain_manager::preregister_objects(rpc::preregister_objects_request req) {
         };
     }
 
+    probe_->objects_preregistered(req.count);
     co_return rpc::preregister_objects_reply{
       .ec = rpc::errc::ok,
       .object_ids = std::move(update.object_ids),
@@ -1633,7 +1636,7 @@ ss::future<> db_domain_manager::gc_loop() {
     }
 
     auto ntp = stm_->raft()->log()->config().ntp();
-    db_garbage_collector gc(object_io_);
+    db_garbage_collector gc(object_io_, probe_);
     while (!as_.abort_requested()) {
         // NOTE: even though the garbage collector will remove objects and
         // actually write to the database, we don't need to take entity locks.
@@ -1884,6 +1887,7 @@ db_domain_manager::expire_preregistered_objects(chunked_vector<object_id> ids) {
           locks_res.error());
         co_return;
     }
+    auto num_ids = ids.size();
     expire_preregistered_objects_db_update update{.object_ids = std::move(ids)};
     auto reader = state_reader(db_->db().create_snapshot());
     chunked_vector<write_batch_row> rows;
@@ -1903,7 +1907,9 @@ db_domain_manager::expire_preregistered_objects(chunked_vector<object_id> ids) {
           cd_log.warn,
           "Error writing preregistered object expiry rows: {}",
           write_res.error());
+        co_return;
     }
+    probe_->gc_objects_expired(num_ids);
 }
 
 ss::future<std::expected<void, rpc::errc>>

--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.h
@@ -12,6 +12,7 @@
 #include "absl/container/btree_set.h"
 #include "cloud_topics/level_one/common/object_id.h"
 #include "cloud_topics/level_one/domain/domain_manager.h"
+#include "cloud_topics/level_one/domain/domain_manager_probe.h"
 #include "cloud_topics/level_one/domain/entity_lock_map.h"
 #include "cloud_topics/level_one/metastore/lsm/replicated_db.h"
 #include "cloud_topics/level_one/metastore/lsm/stm.h"
@@ -39,7 +40,8 @@ public:
       cloud_io::remote* remote,
       cloud_storage_clients::bucket_name bucket,
       io* object_io,
-      ss::scheduling_group sg);
+      ss::scheduling_group sg,
+      domain_manager_probe* probe);
 
     void start() override;
     ss::future<> stop_and_wait() override;
@@ -250,6 +252,8 @@ private:
     // Operations will only succeed with this db when the underlying Raft
     // partition is leader of the expected term.
     std::unique_ptr<replicated_database> db_;
+
+    domain_manager_probe* probe_;
 };
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/domain/domain_manager_probe.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_manager_probe.cc
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/domain/domain_manager_probe.h"
+
+#include "config/configuration.h"
+#include "metrics/metrics.h"
+#include "metrics/prometheus_sanitize.h"
+
+#include <seastar/core/metrics.hh>
+
+namespace cloud_topics::l1 {
+
+void domain_manager_probe::setup_metrics() {
+    namespace sm = ss::metrics;
+
+    if (config::shard_local_cfg().disable_metrics()) {
+        return;
+    }
+
+    _metrics.add_group(
+      prometheus_sanitize::metrics_name("cloud_topics:l1:domain_manager"),
+      {
+        sm::make_counter(
+          "objects_preregistered_total",
+          [this] { return _objects_preregistered; },
+          sm::description(
+            "Total number of L1 objects preregistered in cloud storage.")),
+        sm::make_counter(
+          "gc_objects_deleted_total",
+          [this] { return _gc_objects_deleted; },
+          sm::description(
+            "Total number of unreferenced L1 objects deleted from cloud "
+            "storage by garbage collection.")),
+        sm::make_counter(
+          "gc_object_deletions_replicated_total",
+          [this] { return _gc_object_deletions_replicated; },
+          sm::description(
+            "Total number of L1 object deletions replicated by garbage "
+            "collection.")),
+        sm::make_counter(
+          "gc_objects_expired_total",
+          [this] { return _gc_objects_expired; },
+          sm::description(
+            "Total number of stale preregistered L1 objects expired by "
+            "garbage collection.")),
+      });
+}
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/domain/domain_manager_probe.h
+++ b/src/v/cloud_topics/level_one/domain/domain_manager_probe.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "metrics/metrics.h"
+
+#include <seastar/core/metrics_registration.hh>
+
+#include <cstdint>
+
+namespace cloud_topics::l1 {
+
+class domain_manager_probe {
+public:
+    domain_manager_probe() = default;
+
+    domain_manager_probe(const domain_manager_probe&) = delete;
+    domain_manager_probe& operator=(const domain_manager_probe&) = delete;
+    domain_manager_probe(domain_manager_probe&&) = delete;
+    domain_manager_probe& operator=(domain_manager_probe&&) = delete;
+    ~domain_manager_probe() = default;
+
+    void setup_metrics();
+
+    void objects_preregistered(uint64_t count) {
+        _objects_preregistered += count;
+    }
+    void gc_objects_deleted(uint64_t count) { _gc_objects_deleted += count; }
+    void gc_object_deletions_replicated(uint64_t count) {
+        _gc_object_deletions_replicated += count;
+    }
+    void gc_objects_expired(uint64_t count) { _gc_objects_expired += count; }
+
+private:
+    uint64_t _objects_preregistered{0};
+    uint64_t _gc_objects_deleted{0};
+    uint64_t _gc_object_deletions_replicated{0};
+    uint64_t _gc_objects_expired{0};
+
+    metrics::internal_metric_groups _metrics;
+};
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/domain/domain_supervisor.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_supervisor.cc
@@ -12,6 +12,7 @@
 
 #include "cloud_topics/level_one/common/abstract_io.h"
 #include "cloud_topics/level_one/domain/db_domain_manager.h"
+#include "cloud_topics/level_one/domain/domain_manager_probe.h"
 #include "cloud_topics/level_one/domain/simple_domain_manager.h"
 #include "cloud_topics/level_one/metastore/lsm/stm.h"
 #include "cloud_topics/logger.h"
@@ -49,6 +50,7 @@ public:
       }) {}
 
     ss::future<> start() {
+        _probe.setup_metrics();
         if (ss::this_shard_id() == 0) {
             _as = {};
             _loop = do_topic_reconciliation_loop();
@@ -330,7 +332,8 @@ private:
               _remote,
               _bucket,
               _object_io,
-              _sg);
+              _sg,
+              &_probe);
         } else {
             domain_mgr = ss::make_shared<simple_domain_manager>(
               stm_manager->get<simple_stm>(), _object_io);
@@ -355,6 +358,8 @@ private:
     using domain_manager_id = model::ntp;
     chunked_hash_map<domain_manager_id, ss::shared_ptr<domain_manager>>
       _domains;
+
+    domain_manager_probe _probe;
 
     std::optional<ss::future<>> _loop;
     ss::abort_source _as;

--- a/src/v/cloud_topics/level_one/domain/tests/BUILD
+++ b/src/v/cloud_topics/level_one/domain/tests/BUILD
@@ -32,6 +32,7 @@ redpanda_cc_gtest(
         "//src/v/cloud_topics/level_one/common:object_id",
         "//src/v/cloud_topics/level_one/common:object_utils",
         "//src/v/cloud_topics/level_one/domain:db_domain_manager",
+        "//src/v/cloud_topics/level_one/domain:domain_manager_probe",
         "//src/v/cloud_topics/level_one/metastore:domain_uuid",
         "//src/v/cloud_topics/level_one/metastore:rpc_types",
         "//src/v/cloud_topics/level_one/metastore:state_update",

--- a/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
+++ b/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
@@ -15,6 +15,7 @@
 #include "cloud_topics/level_one/common/object_id.h"
 #include "cloud_topics/level_one/common/object_utils.h"
 #include "cloud_topics/level_one/domain/db_domain_manager.h"
+#include "cloud_topics/level_one/domain/domain_manager_probe.h"
 #include "cloud_topics/level_one/metastore/domain_uuid.h"
 #include "cloud_topics/level_one/metastore/lsm/state_reader.h"
 #include "cloud_topics/level_one/metastore/lsm/state_update.h"
@@ -77,7 +78,8 @@ struct domain_manager_node {
           remote,
           bucket,
           &object_io,
-          ss::default_scheduling_group());
+          ss::default_scheduling_group(),
+          &probe);
         if (start_gc) {
             mgr->start();
         }
@@ -118,6 +120,7 @@ struct domain_manager_node {
     const cloud_storage_clients::bucket_name& bucket;
     temporary_dir staging_directory;
     file_io object_io;
+    domain_manager_probe probe;
 
     // Active managers on this node. These managers may be operated on by
     // callers. Not all of these managers are expected to actually work, e.g.

--- a/src/v/cloud_topics/level_one/metastore/lsm/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/lsm/BUILD
@@ -326,6 +326,7 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/cloud_topics:logger",
         "//src/v/cloud_topics/level_one/common:abstract_io",
+        "//src/v/cloud_topics/level_one/domain:domain_manager_probe",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -335,7 +336,6 @@ redpanda_cc_library(
         "//src/v/container:chunked_vector",
         "//src/v/model",
         "//src/v/utils:detailed_error",
-        "//src/v/utils:named_type",
         "@seastar",
     ],
 )

--- a/src/v/cloud_topics/level_one/metastore/lsm/garbage_collector.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/garbage_collector.cc
@@ -13,6 +13,7 @@
 #include "base/vlog.h"
 #include "cloud_topics/level_one/common/abstract_io.h"
 #include "cloud_topics/level_one/common/object_id.h"
+#include "cloud_topics/level_one/domain/domain_manager_probe.h"
 #include "cloud_topics/level_one/metastore/lsm/keys.h"
 #include "cloud_topics/level_one/metastore/lsm/replicated_db.h"
 #include "cloud_topics/level_one/metastore/lsm/state_reader.h"
@@ -81,8 +82,9 @@ db_garbage_collector::error wrap_db_err(
 }
 } // namespace
 
-db_garbage_collector::db_garbage_collector(io* io)
-  : io_(io) {}
+db_garbage_collector::db_garbage_collector(io* io, domain_manager_probe* probe)
+  : io_(io)
+  , probe_(probe) {}
 
 ss::future<std::expected<std::optional<object_id>, db_garbage_collector::error>>
 db_garbage_collector::remove_unreferenced_batch(
@@ -197,11 +199,13 @@ db_garbage_collector::remove_unreferenced_batch(
         co_return next_batch_start;
     }
 
+    auto num_to_remove = to_remove.size();
     auto del_res = co_await io_->delete_objects(to_remove.copy(), as);
     if (!del_res.has_value()) {
         co_return std::unexpected(
           error(errc::io_error, "Error deleting objects: {}", del_res.error()));
     }
+    probe_->gc_objects_deleted(num_to_remove);
     remove_objects_db_update update{std::move(to_remove)};
     chunked_vector<write_batch_row> rows;
     auto build_res = co_await update.build_rows(rows);
@@ -218,6 +222,7 @@ db_garbage_collector::remove_unreferenced_batch(
               "Error replicating rows for object removal"));
         }
     }
+    probe_->gc_object_deletions_replicated(num_to_remove);
     co_return next_batch_start;
 }
 

--- a/src/v/cloud_topics/level_one/metastore/lsm/garbage_collector.h
+++ b/src/v/cloud_topics/level_one/metastore/lsm/garbage_collector.h
@@ -14,7 +14,6 @@
 #include "container/chunked_vector.h"
 #include "model/timestamp.h"
 #include "utils/detailed_error.h"
-#include "utils/named_type.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
@@ -24,6 +23,7 @@
 
 namespace cloud_topics::l1 {
 
+class domain_manager_probe;
 class io;
 class replicated_database;
 
@@ -46,7 +46,7 @@ public:
     };
     using error = detailed_error<errc>;
 
-    explicit db_garbage_collector(io* io);
+    explicit db_garbage_collector(io* io, domain_manager_probe* probe);
 
     // Removes all unreferenced objects from cloud storage, and collects stale
     // preregistered objects that need expiry. Returns the list of object IDs
@@ -76,6 +76,7 @@ private:
       chunked_vector<object_id>& to_expire_out);
 
     io* io_;
+    domain_manager_probe* probe_;
 };
 
 inline std::ostream& operator<<(std::ostream& o, db_garbage_collector::errc e) {


### PR DESCRIPTION
Add a metrics probe for the L1 domain manager with counters for:
- objects_preregistered_total
- gc_objects_deleted_total
- gc_objects_deletions_replicated_total
- gc_objects_expired_total

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
