### PR TITLE
tests: bump ducktape SHA

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -12,7 +12,7 @@ setup(
     package_data={"": ["*.md"]},
     include_package_data=True,
     install_requires=[
-        "ducktape@git+https://github.com/redpanda-data/ducktape.git@c3266e0740781cb26b56e74715c0da48ad59c6c7",
+        "ducktape@git+https://github.com/redpanda-data/ducktape.git@f2ddfea94619090688530f3c492ea9f72cb7290e",
         "prometheus-client==0.9.0",
         "kafka-python==2.0.6",
         "crc32c==2.2",


### PR DESCRIPTION
Bump ducktape dependency to pick up worker stack dumping on timeout via
faulthandler, so that hangs in native code produce useful diagnostics.

https://github.com/redpanda-data/ducktape/compare/c3266e0740781cb26b56e74715c0da48ad59c6c7...f2ddfea94619090688530f3c492ea9f72cb7290e

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none