### PR TITLE
ct: fix metric units

### DIFF
--- a/src/v/cloud_topics/level_one/compaction/worker_probe.cc
+++ b/src/v/cloud_topics/level_one/compaction/worker_probe.cc
@@ -53,7 +53,7 @@ void compaction_worker_probe::setup_metrics() {
             "Number of tombstone records removed across all cloud topic "
             "partitions on this shard")),
         sm::make_histogram(
-          "compaction_duration_seconds",
+          "compaction_duration_microseconds",
           [this] { return _compaction_runs.internal_histogram_logform(); },
           sm::description(
             "The duration of a compaction run for cloud topic partitions on "

--- a/src/v/cloud_topics/level_zero/common/level_zero_probe.cc
+++ b/src/v/cloud_topics/level_zero/common/level_zero_probe.cc
@@ -58,7 +58,7 @@ void pipeline_probe::setup_internal_metrics(bool disable, ss::sstring name) {
         sm::make_histogram(
           "request_processing_time_ms",
           [this] {
-              return _request_processing_time.public_histogram_logform();
+              return _request_processing_time.internal_histogram_logform();
           },
           sm::description("Request processing time histogram in milliseconds."),
           labels),

--- a/src/v/cloud_topics/reconciler/reconciler_probe.cc
+++ b/src/v/cloud_topics/reconciler/reconciler_probe.cc
@@ -57,17 +57,17 @@ void reconciler_probe::setup_metrics() {
 
         // Histograms.
         sm::make_histogram(
-          "l0_read_duration_seconds",
+          "l0_read_duration_microseconds",
           [this] { return _l0_read_duration.internal_histogram_logform(); },
           sm::description("Duration reading from L0")),
         sm::make_histogram(
-          "object_build_duration_seconds",
+          "object_build_duration_microseconds",
           [this] {
               return _object_build_duration.internal_histogram_logform();
           },
           sm::description("Duration building and uploading L1 objects")),
         sm::make_histogram(
-          "metastore_add_objects_duration_seconds",
+          "metastore_add_objects_duration_microseconds",
           [this] {
               return _metastore_add_objects_duration
                 .internal_histogram_logform();


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
In going through docs I noticed that a few metrics are suspiciously reported as being in seconds, while others are in microseconds, so I asked Claude to take a look. It spotted a few that were mislabeled or using the wrong histogram type.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
