### PR TITLE
build: upstream fixes from nix work

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,7 +25,7 @@ build --copt=-ffile-compilation-dir=. --host_copt=-ffile-compilation-dir=.
 build:system-clang --extra_toolchains=@local_config_cc_toolchains//:all
 build:system-clang --action_env=BAZEL_COMPILER=clang
 build:system-clang --cxxopt=-std=c++23 --host_cxxopt=-std=c++23
-build:system-clang --linkopt -fuse-ld=lld
+build:system-clang --linkopt -fuse-ld=lld --host_linkopt -fuse-ld=lld
 
 # Use new proto toolchain resolution
 build --incompatible_enable_proto_toolchain_resolution
@@ -341,4 +341,5 @@ build:io_uring --//bazel:io_uring=True
 test --test_env=REDPANDA_RNG_SEEDING_MODE
 test --test_env=REDPANDA_DEBUG_TEST_HOOKS
 
+try-import %workspace%/.bazelrc.nix
 try-import %workspace%/user.bazelrc

--- a/.bazelrc
+++ b/.bazelrc
@@ -341,5 +341,4 @@ build:io_uring --//bazel:io_uring=True
 test --test_env=REDPANDA_RNG_SEEDING_MODE
 test --test_env=REDPANDA_DEBUG_TEST_HOOKS
 
-try-import %workspace%/.bazelrc.nix
 try-import %workspace%/user.bazelrc

--- a/bazel/thirdparty/krb5.BUILD
+++ b/bazel/thirdparty/krb5.BUILD
@@ -58,6 +58,9 @@ configure_make(
         # Need to pass this additionally here because of a bug in the kerberos build where it doesn't properly pass the linker flag down
         "KRB5_BUILD_JOBS": "$(BUILD_JOBS)",
         "LINKER": "$(LINKER)",
+        # configure runs test binaries that link against libcrypto; they
+        # need LD_LIBRARY_PATH to find the .so at runtime.
+        "LD_LIBRARY_PATH": "$$EXT_BUILD_DEPS/openssl_foreign_cc/lib",
     },
     lib_source = ":srcs",
     out_shared_libs = [

--- a/src/v/version/expand_with_stamp_vars.bzl
+++ b/src/v/version/expand_with_stamp_vars.bzl
@@ -8,8 +8,10 @@ is not stamped (ie. dev builds).
 
 def _expand_with_stamp_vars(ctx):
     toolchain = ctx.toolchains[Label("@rules_python//python:toolchain_type")]
-    interpreter = toolchain.py3_runtime.interpreter
-    tools = [ctx.executable._tool] + ([interpreter] if interpreter else [])
+    runtime = toolchain.py3_runtime
+    if not runtime.interpreter and not runtime.interpreter_path:
+        fail("Python toolchain has no interpreter; configure a hermetic Python toolchain or set interpreter_path")
+    tools = [ctx.executable._tool] + ([runtime.interpreter] if runtime.interpreter else [])
     ctx.actions.run(
         outputs = [ctx.outputs.out],
         inputs = [ctx.file.defaults_file, ctx.file.template, ctx.info_file],

--- a/src/v/version/expand_with_stamp_vars.bzl
+++ b/src/v/version/expand_with_stamp_vars.bzl
@@ -8,11 +8,13 @@ is not stamped (ie. dev builds).
 
 def _expand_with_stamp_vars(ctx):
     toolchain = ctx.toolchains[Label("@rules_python//python:toolchain_type")]
+    interpreter = toolchain.py3_runtime.interpreter
+    tools = [ctx.executable._tool] + ([interpreter] if interpreter else [])
     ctx.actions.run(
         outputs = [ctx.outputs.out],
         inputs = [ctx.file.defaults_file, ctx.file.template, ctx.info_file],
-        tools = [ctx.executable._tool, toolchain.py3_runtime.interpreter],
-        executable = ctx.executable._tool.path,
+        tools = tools,
+        executable = ctx.executable._tool,
         arguments = [
             "--template",
             ctx.file.template.path,


### PR DESCRIPTION
## Summary

Direct fixes to build files discovered during Nix integration work. These are
generic improvements that benefit all build environments, not Nix-specific.

- **`.bazelrc`**: Add missing `--host_linkopt -fuse-ld=lld` to `system-clang`
  config — host tools should use the same linker as target builds. Also add
  `try-import .bazelrc.nix` (no-op when file doesn't exist).
- **`krb5.BUILD`**: Add `LD_LIBRARY_PATH` so krb5's configure test binaries can
  find libcrypto at runtime inside the `openssl_foreign_cc` sandbox directory.
  Fixes builds where openssl isn't system-installed.
- **`expand_with_stamp_vars.bzl`**: Guard against `None` interpreter (system
  Python toolchain) and pass executable as object instead of `.path` string
  for proper Bazel dependency tracking.

This PR should be merged before #29919 (Nix Flakes build), which has been
updated to depend on these direct fixes rather than carrying them as patches.

## Test plan

- [ ] `bazel build //...` passes (non-Nix path)
- [x] `nix build .#redpanda` passes (verified locally)
- [x] `nix build .#redpanda-cached` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)