### PR TITLE
ct: Add early max_bytes check to L1 reader

### DIFF
--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -112,6 +112,10 @@ level_one_log_reader_impl::open_reader_at(
 ss::future<model::record_batch_reader::storage_t>
 level_one_log_reader_impl::read_some(
   model::timeout_clock::time_point deadline) {
+    if (_config.strict_max_bytes && _config.max_bytes == 0) {
+        set_end_of_stream();
+        co_return model::record_batch_reader::storage_t{};
+    }
     while (true) {
         if (_next_offset > _config.max_offset) {
             vlog(


### PR DESCRIPTION
The reader pulls some data from the cloud even if max_bytes is set to zero. This PR fixes this.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none