### PR TITLE
tests: Don't forward Azurite port to host

### DIFF
--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -58,8 +58,8 @@ services:
     container_name: azurite
     restart: always
     command: "azurite-blob -l /data --blobHost 0.0.0.0"
-    ports:
-    - 10000:10000
+    expose:
+    - '10000'
     # image: mcr.microsoft.com/azure-storage/azurite:3.34.0
     image: public.ecr.aws/l9j0i2e0/azurite-no-leaks:latest
     environment:


### PR DESCRIPTION
Only expose it in the docker-compose network instead.

Means we are not blocking a host port and exposing ports on 0.0.0.0 by default which is bad practice anyway.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes


* none
