### PR TITLE
bazel: suppress protobuf deprecation warnings in generated .pb.cc files

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -84,6 +84,7 @@ build --per_file_copt=src/v/serde/protobuf/tests/round_trip_test.cc@-Wno-depreca
 build --per_file_copt=src/v/serde/protobuf/tests/parser_test.cc@-Wno-deprecated-declarations
 build --per_file_copt=src/v/iceberg/conversion/tests/iceberg_protobuf_tests.cc@-Wno-deprecated-declarations
 build --per_file_copt=src/v/pandaproxy/schema_registry/protobuf.cc@-Wno-deprecated-declarations
+build --per_file_copt=.*\\.pb\\.cc@-Wno-deprecated-declarations
 # Suppress deprecated declarations in the protobuf external module itself
 build --per_file_copt=external/protobuf.*@-Wno-deprecated-declarations
 build --host_per_file_copt=external/protobuf.*@-Wno-deprecated-declarations


### PR DESCRIPTION
## Summary
- Adds a `per_file_copt` rule to suppress `-Wdeprecated-declarations` for all generated `.pb.cc` files, replacing the need to enumerate each individual source file that uses protobuf-generated code.

## Test plan
- [ ] CI build passes without protobuf deprecation warnings from generated files