### PR TITLE
bazel: suppress protobuf deprecation warnings in generated .pb.cc files

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -84,6 +84,7 @@ build --per_file_copt=src/v/serde/protobuf/tests/round_trip_test.cc@-Wno-depreca
 build --per_file_copt=src/v/serde/protobuf/tests/parser_test.cc@-Wno-deprecated-declarations
 build --per_file_copt=src/v/iceberg/conversion/tests/iceberg_protobuf_tests.cc@-Wno-deprecated-declarations
 build --per_file_copt=src/v/pandaproxy/schema_registry/protobuf.cc@-Wno-deprecated-declarations
+build --per_file_copt=.*\\.pb\\.cc@-Wno-deprecated-declarations
 # Suppress deprecated declarations in the protobuf external module itself
 build --per_file_copt=external/protobuf.*@-Wno-deprecated-declarations
 build --host_per_file_copt=external/protobuf.*@-Wno-deprecated-declarations


### PR DESCRIPTION
Existing per-file suppressions covered the external protobuf sources and
specific redpanda `.cc` files that include protobuf headers, but missed
generated `.pb.cc` files (e.g. under `proto/` or `src/v/schema/protobuf/`).
This adds a wildcard `per_file_copt` rule for all `*.pb.cc` files so new
proto targets don't need individual entries.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none