### PR TITLE
sr/dt: test context.name.strategy end-to-end with Java serde client

### DIFF
--- a/tests/java/kafka-serde/src/main/java/com/redpanda/AvroMessaging.java
+++ b/tests/java/kafka-serde/src/main/java/com/redpanda/AvroMessaging.java
@@ -47,7 +47,8 @@ public class AvroMessaging implements KafkaMessagingInterface {
   public Properties getProducerProperties(
       String brokers, String srAddr, SecuritySettings securitySettings,
       boolean autoRegisterSchema, boolean skipKnownTypes,
-      boolean useLatestVersion) {
+      boolean useLatestVersion, String contextNameStrategy,
+      String contextName) {
     Properties prop = new Properties();
     prop.put("bootstrap.servers", brokers);
     prop.put("key.serializer", StringSerializer.class);
@@ -61,6 +62,12 @@ public class AvroMessaging implements KafkaMessagingInterface {
     if (securitySettings != null) {
       prop.putAll(securitySettings.toProperties());
     }
+    if (contextNameStrategy != null) {
+      prop.put(
+          AbstractKafkaSchemaSerDeConfig.CONTEXT_NAME_STRATEGY,
+          contextNameStrategy);
+      prop.put(TopicContextNameStrategy.CONTEXT_NAME_CONFIG, contextName);
+    }
 
     return prop;
   }
@@ -73,7 +80,8 @@ public class AvroMessaging implements KafkaMessagingInterface {
   @Override
   public Properties getConsumerProperties(
       String brokers, String srAddr, SecuritySettings securitySettings,
-      String consumerGroup, boolean useLatestVersion) {
+      String consumerGroup, boolean useLatestVersion,
+      String contextNameStrategy, String contextName) {
     Properties prop = new Properties();
     prop.put("bootstrap.servers", brokers);
     prop.put("key.deserializer", StringDeserializer.class);
@@ -85,6 +93,12 @@ public class AvroMessaging implements KafkaMessagingInterface {
     prop.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     if (securitySettings != null) {
       prop.putAll(securitySettings.toProperties());
+    }
+    if (contextNameStrategy != null) {
+      prop.put(
+          AbstractKafkaSchemaSerDeConfig.CONTEXT_NAME_STRATEGY,
+          contextNameStrategy);
+      prop.put(TopicContextNameStrategy.CONTEXT_NAME_CONFIG, contextName);
     }
 
     return prop;

--- a/tests/java/kafka-serde/src/main/java/com/redpanda/JavaKafkaSerdeClient.java
+++ b/tests/java/kafka-serde/src/main/java/com/redpanda/JavaKafkaSerdeClient.java
@@ -31,6 +31,8 @@ public class JavaKafkaSerdeClient {
   private final SecuritySettings securitySettings;
   private final boolean skipKnownTypes;
   private final boolean useLatestVersion;
+  private final String contextNameStrategy;
+  private final String contextName;
 
   private final Logger log;
 
@@ -46,6 +48,10 @@ public class JavaKafkaSerdeClient {
    * @param skipKnownTypes Whether to skip known types when resolving schema
    *     dependencies
    * @param useLatestVersion Whether to use the latest schema version for lookup
+   * @param contextNameStrategy Fully qualified class name of the
+   *     ContextNameStrategy to use (may be null)
+   * @param contextName Context name to pass to the ContextNameStrategy
+   *     (may be null)
    * @param log The logger to use
    *
    * @see SecuritySettings
@@ -54,7 +60,8 @@ public class JavaKafkaSerdeClient {
   public JavaKafkaSerdeClient(
       String brokers, String topic, String srAddr, String consumerGroup,
       Protocol protocol, SecuritySettings securitySettings,
-      boolean skipKnownTypes, boolean useLatestVersion, Logger log) {
+      boolean skipKnownTypes, boolean useLatestVersion,
+      String contextNameStrategy, String contextName, Logger log) {
     this.brokers = brokers;
     this.topic = topic;
     this.srAddr = srAddr;
@@ -63,6 +70,8 @@ public class JavaKafkaSerdeClient {
     this.securitySettings = securitySettings;
     this.skipKnownTypes = skipKnownTypes;
     this.useLatestVersion = useLatestVersion;
+    this.contextNameStrategy = contextNameStrategy;
+    this.contextName = contextName;
     this.log = log;
   }
 
@@ -90,7 +99,8 @@ public class JavaKafkaSerdeClient {
         this.log,
         test_interface.getProducerProperties(
             this.brokers, this.srAddr, this.securitySettings, true,
-            this.skipKnownTypes, this.useLatestVersion),
+            this.skipKnownTypes, this.useLatestVersion,
+            this.contextNameStrategy, this.contextName),
         this.topic, count);
 
     log.info("Starting consume");
@@ -98,7 +108,8 @@ public class JavaKafkaSerdeClient {
         this.log,
         test_interface.getConsumerProperties(
             this.brokers, this.srAddr, this.securitySettings,
-            this.consumerGroup, this.useLatestVersion),
+            this.consumerGroup, this.useLatestVersion, this.contextNameStrategy,
+            this.contextName),
         this.topic, count);
 
     log.info("Done!");

--- a/tests/java/kafka-serde/src/main/java/com/redpanda/JavaKafkaSerdeClientMain.java
+++ b/tests/java/kafka-serde/src/main/java/com/redpanda/JavaKafkaSerdeClientMain.java
@@ -59,12 +59,15 @@ public class JavaKafkaSerdeClientMain {
     int count = ns.getInt("count");
     boolean skipKnownTypes = ns.getBoolean("skip_known_types");
     boolean useLatestVersion = ns.getBoolean("use_latest_version");
+    String contextNameStrategy = ns.getString("context_name_strategy");
+    String contextName = ns.getString("context_name");
 
     JavaKafkaSerdeClient.Protocol protocol = ns.get("protocol");
 
     JavaKafkaSerdeClient client = new JavaKafkaSerdeClient(
         brokers, topic, srAdr, consumerGroup, protocol, securitySettings,
-        skipKnownTypes, useLatestVersion, log);
+        skipKnownTypes, useLatestVersion, contextNameStrategy, contextName,
+        log);
 
     try {
       client.run(count);
@@ -119,6 +122,14 @@ public class JavaKafkaSerdeClientMain {
         .setDefault(false)
         .action(Arguments.storeTrue())
         .type(Boolean.class);
+    parser.addArgument("--context-name-strategy")
+        .help("Fully qualified class name of the ContextNameStrategy to use")
+        .setDefault((String)null)
+        .type(String.class);
+    parser.addArgument("--context-name")
+        .help("Context name to pass to the ContextNameStrategy")
+        .setDefault((String)null)
+        .type(String.class);
 
     return parser;
   }

--- a/tests/java/kafka-serde/src/main/java/com/redpanda/KafkaMessagingInterface.java
+++ b/tests/java/kafka-serde/src/main/java/com/redpanda/KafkaMessagingInterface.java
@@ -30,6 +30,10 @@ public interface KafkaMessagingInterface {
    *     dependencies
    * @param useLatestVersion   Whether to use the latest schema version for
    *     lookup
+   * @param contextNameStrategy Fully qualified class name of the
+   *     ContextNameStrategy to use (may be null)
+   * @param contextName Context name to pass to the ContextNameStrategy
+   *     (may be null)
    * @return Instance of Properties
    *
    * @see java.util.Properties
@@ -38,7 +42,7 @@ public interface KafkaMessagingInterface {
   Properties getProducerProperties(
       String brokers, String srAddr, SecuritySettings securitySettings,
       boolean autoRegisterSchema, boolean skipKnownTypes,
-      boolean useLatestVersion);
+      boolean useLatestVersion, String contextNameStrategy, String contextName);
 
   /**
    * Generates properties for a Kafka consumer
@@ -48,6 +52,10 @@ public interface KafkaMessagingInterface {
    * @param securitySettings The security settings (may be null)
    * @param consumerGroup The consumer group to use
    * @param useLatestVersion Whether to use the latest schema version for lookup
+   * @param contextNameStrategy Fully qualified class name of the
+   *     ContextNameStrategy to use (may be null)
+   * @param contextName Context name to pass to the ContextNameStrategy
+   *     (may be null)
    * @return Instance of Properties
    *
    * @see java.util.Properties
@@ -55,7 +63,8 @@ public interface KafkaMessagingInterface {
    */
   Properties getConsumerProperties(
       String brokers, String srAddr, SecuritySettings securitySettings,
-      String consumerGroup, boolean useLatestVersion);
+      String consumerGroup, boolean useLatestVersion,
+      String contextNameStrategy, String contextName);
 
   /**
    * Tests production of messages

--- a/tests/java/kafka-serde/src/main/java/com/redpanda/ProtobufMessaging.java
+++ b/tests/java/kafka-serde/src/main/java/com/redpanda/ProtobufMessaging.java
@@ -49,7 +49,8 @@ public class ProtobufMessaging implements KafkaMessagingInterface {
   public Properties getProducerProperties(
       String brokers, String srAddr, SecuritySettings securitySettings,
       boolean autoRegisterSchema, boolean skipKnownTypes,
-      boolean useLatestVersion) {
+      boolean useLatestVersion, String contextNameStrategy,
+      String contextName) {
     Properties prop = new Properties();
 
     prop.put("bootstrap.servers", brokers);
@@ -66,6 +67,12 @@ public class ProtobufMessaging implements KafkaMessagingInterface {
     if (securitySettings != null) {
       prop.putAll(securitySettings.toProperties());
     }
+    if (contextNameStrategy != null) {
+      prop.put(
+          AbstractKafkaSchemaSerDeConfig.CONTEXT_NAME_STRATEGY,
+          contextNameStrategy);
+      prop.put(TopicContextNameStrategy.CONTEXT_NAME_CONFIG, contextName);
+    }
 
     return prop;
   }
@@ -78,7 +85,8 @@ public class ProtobufMessaging implements KafkaMessagingInterface {
   @Override
   public Properties getConsumerProperties(
       String brokers, String srAddr, SecuritySettings securitySettings,
-      String consumerGroup, boolean useLatestVersion) {
+      String consumerGroup, boolean useLatestVersion,
+      String contextNameStrategy, String contextName) {
     Properties prop = new Properties();
 
     prop.put("bootstrap.servers", brokers);
@@ -91,6 +99,12 @@ public class ProtobufMessaging implements KafkaMessagingInterface {
     prop.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     if (securitySettings != null) {
       prop.putAll(securitySettings.toProperties());
+    }
+    if (contextNameStrategy != null) {
+      prop.put(
+          AbstractKafkaSchemaSerDeConfig.CONTEXT_NAME_STRATEGY,
+          contextNameStrategy);
+      prop.put(TopicContextNameStrategy.CONTEXT_NAME_CONFIG, contextName);
     }
 
     return prop;

--- a/tests/java/kafka-serde/src/main/java/com/redpanda/TopicContextNameStrategy.java
+++ b/tests/java/kafka-serde/src/main/java/com/redpanda/TopicContextNameStrategy.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package com.redpanda;
+
+import io.confluent.kafka.serializers.context.strategy.ContextNameStrategy;
+import java.util.Map;
+
+/**
+ * A configurable ContextNameStrategy that returns a fixed context name.
+ * The context name is read from the config key
+ * "context.name.strategy.context.name".
+ */
+public class TopicContextNameStrategy implements ContextNameStrategy {
+  public static final String CONTEXT_NAME_CONFIG
+      = "context.name.strategy.context.name";
+
+  private String contextName;
+
+  @Override
+  public void configure(Map<String, ?> config) {
+    this.contextName = (String)config.get(CONTEXT_NAME_CONFIG);
+    if (this.contextName == null) {
+      throw new IllegalArgumentException(
+          CONTEXT_NAME_CONFIG
+          + " must be set when using TopicContextNameStrategy");
+    }
+  }
+
+  @Override
+  public String contextName(String topic) {
+    return contextName;
+  }
+}

--- a/tests/rptest/services/serde_client.py
+++ b/tests/rptest/services/serde_client.py
@@ -51,6 +51,8 @@ class SerdeClient(BackgroundThreadService):
         subject_name_strategy: Optional[str] = None,
         payload_class: Optional[str] = None,
         compression_type: Optional[TopicSpec.CompressionTypes] = None,
+        context_name_strategy: Optional[str] = None,
+        context_name: Optional[str] = None,
     ):
         if num_nodes is None and nodes is None:
             num_nodes = 1
@@ -91,6 +93,13 @@ class SerdeClient(BackgroundThreadService):
         if compression_type is not None:
             assert self._serde_client_type == SerdeClientType.Python
             self._cmd_args += f" --compression-type {compression_type}"
+
+        if context_name_strategy is not None:
+            assert self._serde_client_type == SerdeClientType.Java
+            self._cmd_args += f" --context-name-strategy {context_name_strategy}"
+        if context_name is not None:
+            assert self._serde_client_type == SerdeClientType.Java
+            self._cmd_args += f" --context-name {context_name}"
 
         if self._serde_client_type == SerdeClientType.Golang:
             self._cmd_args += " --debug"

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -6823,6 +6823,36 @@ class SchemaRegistryContextTest(SchemaRegistryEndpoints):
             result = self.sr_client.set_mode_subject(subject=subject, data=mode_data)
             self.assert_not_equal(result.status_code, 422)
 
+    @cluster(num_nodes=4)
+    def test_context_name_strategy(self):
+        """
+        Verify that a Confluent Java serializer configured with
+        context.name.strategy registers schemas under the correct
+        context-qualified subject and can round-trip produce/consume.
+        """
+        topic = "serde-topic-context-strategy"
+        context = "myctx"
+        self._create_topic(topic=topic)
+
+        client = self._get_serde_client(
+            SchemaType.AVRO,
+            SerdeClientType.Java,
+            topic,
+            5,
+            context_name_strategy="com.redpanda.TopicContextNameStrategy",
+            context_name=context,
+        )
+        client.start()
+        client.wait()
+
+        # Verify the schema was registered under the context-qualified subject
+        result = self.sr_client.get_subjects()
+        subjects = result.json()
+        expected_subject = f":.{context}:{topic}-value"
+        assert expected_subject in subjects, (
+            f"Expected subject {expected_subject} not found in {subjects}"
+        )
+
 
 class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
     """

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1391,6 +1391,8 @@ class SchemaRegistryEndpoints(RedpandaTest):
         subject_name_strategy: Optional[str] = None,
         payload_class: Optional[str] = None,
         compression_type: Optional[TopicSpec.CompressionTypes] = None,
+        context_name_strategy: Optional[str] = None,
+        context_name: Optional[str] = None,
     ):
         schema_reg = self.redpanda.schema_reg().split(",", 1)[0]
         sec_cfg = self.redpanda.kafka_client_security().to_dict()
@@ -1409,6 +1411,8 @@ class SchemaRegistryEndpoints(RedpandaTest):
             subject_name_strategy=subject_name_strategy,
             payload_class=payload_class,
             compression_type=compression_type,
+            context_name_strategy=context_name_strategy,
+            context_name=context_name,
         )
 
     def _create_topic(


### PR DESCRIPTION
Verify that a Java serde producer/consumer client pair configured with
context.name.strategy produces and consumes messages through Redpanda,
with the schema registered under the context-qualified subject
:.myctx:{topic}-value.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
