### PR TITLE
pre-commit-config: add java to clang-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
         name: C++ formatting (clang-format)
         entry: ./tools/clang-format -i
         language: script
-        types_or: [c++, c, proto]
+        types_or: [c++, c, proto, java]
 
       - id: bazel/buildifier
         name: Bazel formatting


### PR DESCRIPTION
Align the pre-commit hook with the clang-format github action:

https://github.com/redpanda-data/redpanda/blob/aba0a80779f0a1682a3ed4468ec624b15ab951ff/.github/workflows/lint-cpp.yml#L38-L45

Example failing GH action: https://github.com/redpanda-data/redpanda/actions/runs/23501614604/job/68397934743?pr=29946

I've manually tested that with this PR, the check correctly runs for changes in java files (e.g.; `tests/java/kafka-serde/src/main/java/com/redpanda/AvroMessaging.java`)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
