### PR TITLE
Add ducktape test packaging for Antithesis

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -5093,7 +5093,7 @@ class RedpandaService(Service, RedpandaServiceABC):
             .removesuffix(".")
         )
         fqdn = (
-            node.account.ssh_output(cmd=f"host {hostname}", timeout_sec=10)
+            node.account.ssh_output(cmd=f"host -t A {hostname}", timeout_sec=10)
             .decode("utf-8")
             .split(" ")[0]
         )

--- a/tools/antithesis/ducktape_deps/ducktape_compose.yaml.j2
+++ b/tools/antithesis/ducktape_deps/ducktape_compose.yaml.j2
@@ -1,0 +1,69 @@
+networks:
+  redpanda-test:
+    driver: bridge
+
+services:
+
+  minio:
+    image: minio/minio:RELEASE.2025-07-23T15-54-02Z
+    container_name: minio-s3
+    hostname: minio-s3
+    init: true
+    command: server /data
+    environment:
+      MINIO_REGION_NAME: panda-region
+      MINIO_ROOT_PASSWORD: panda-secret
+      MINIO_ROOT_USER: panda-user
+      MINIO_BROWSER: "off"
+    expose:
+      - "9000"
+    healthcheck:
+      interval: 30s
+      retries: 3
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      timeout: 20s
+    networks:
+      - redpanda-test
+
+{% for i in range(1, nodes + 1) %}
+  rp-{{ i }}:
+    image: {{ node_image }}
+    container_name: rp-{{ i }}
+    hostname: rp-{{ i }}
+    init: true
+    ulimits:
+      nofile:
+        soft: 131072
+        hard: 131072
+    sysctls:
+      net.ipv4.ip_local_port_range: "34000 60999"
+    depends_on:
+      - minio
+    networks:
+      - redpanda-test
+
+{% endfor %}
+  ducktape-runner:
+    image: {{ runner_image }}
+    container_name: ducktape-runner
+    hostname: ducktape-runner
+    init: true
+    ulimits:
+      nofile:
+        soft: 131072
+        hard: 131072
+    sysctls:
+      net.ipv4.ip_local_port_range: "34000 60999"
+    environment:
+      DUCKTAPE_TEST_ARGS: '{{ test_args }}'
+      DUCKTAPE_MAX_PARALLEL: "{{ max_parallel }}"
+      DUCKTAPE_TEST_TIMEOUT: "{{ test_timeout }}"
+      DUCKTAPE_DISABLE_FAULTS: "{{ '1' if disable_faults else '0' }}"
+      BUILD_TYPE: release
+    depends_on:
+{% for i in range(1, nodes + 1) %}
+      - rp-{{ i }}
+{% endfor %}
+      - minio
+    networks:
+      - redpanda-test

--- a/tools/antithesis/ducktape_deps/ducktape_entrypoint.sh
+++ b/tools/antithesis/ducktape_deps/ducktape_entrypoint.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# ==================================================================
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+# ==================================================================
+#
+# Entrypoint for the Antithesis ducktape runner container.
+#
+# 1. Starts sshd (ducktape uses SSH internally)
+# 2. Emits the Antithesis setup_complete signal
+# 3. Sleeps forever (Antithesis invokes the singleton driver separately)
+#
+
+set -euo pipefail
+
+# Start sshd for ducktape's internal use.
+service ssh start
+
+# Emit setup_complete — Antithesis begins fault injection after this signal.
+if [ -n "${ANTITHESIS_OUTPUT_DIR:-}" ]; then
+  mkdir -p "$ANTITHESIS_OUTPUT_DIR"
+  printf '{"antithesis_setup": {"status": "complete", "details": null}}\n' \
+    >>"$ANTITHESIS_OUTPUT_DIR/sdk.jsonl"
+fi
+
+exec sleep infinity

--- a/tools/antithesis/ducktape_deps/ducktape_singleton_driver.sh
+++ b/tools/antithesis/ducktape_deps/ducktape_singleton_driver.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# ==================================================================
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+# ==================================================================
+#
+# Singleton driver for Antithesis ducktape tests.
+# Antithesis invokes this script to run the test suite.
+#
+# Test selection and ducktape parameters are controlled via container
+# environment variables set in the docker-compose.yaml.
+#
+
+set -euo pipefail
+
+# Pause fault injection if requested. ANTITHESIS_STOP_FAULTS is injected
+# by the Antithesis platform; DUCKTAPE_DISABLE_FAULTS is set by the packager.
+if [ "${DUCKTAPE_DISABLE_FAULTS:-0}" = "1" ] && [ -n "${ANTITHESIS_STOP_FAULTS:-}" ]; then
+  "${ANTITHESIS_STOP_FAULTS}" 86400
+fi
+
+pushd /root/tests
+
+ducktape \
+  --cluster=ducktape.cluster.json.JsonCluster \
+  --cluster-file=/root/.ducktape/cluster.json \
+  --results-root=/build/tests/results \
+  --max-parallel="${DUCKTAPE_MAX_PARALLEL:-1}" \
+  --test-runner-timeout="${DUCKTAPE_TEST_TIMEOUT:-1800000}" \
+  --globals=/root/.ducktape/globals.json \
+  ${DUCKTAPE_TEST_ARGS:?DUCKTAPE_TEST_ARGS must be set}
+
+popd

--- a/tools/antithesis/ducktape_deps/node.Dockerfile.j2
+++ b/tools/antithesis/ducktape_deps/node.Dockerfile.j2
@@ -1,0 +1,15 @@
+{% if rp_image %}
+FROM {{ rp_image }} AS rp
+{% endif %}
+FROM {{ base_image }}
+{% if rp_image %}
+COPY --from=rp /opt/redpanda/ /opt/redpanda/
+RUN mkdir -p {{ install_root }} && ln -sf /opt/redpanda {{ install_root }}/redpanda
+{% else %}
+COPY --from=packages redpanda_ducktape/ {{ install_root }}/redpanda/
+COPY --from=packages direct_consumer_verifier_ducktape/ {{ install_root }}/direct_consumer_verifier/
+{% endif %}
+RUN chmod 700 /root/.ssh && chmod 600 /root/.ssh/id_rsa \
+    && mkdir -p /symbols \
+    && ln -s {{ install_root }}/redpanda/bin/redpanda /symbols/redpanda \
+    && find {{ install_root }}/redpanda/lib/ -name '*.so*' -exec sh -c 'ln -s "$1" /symbols/"$(basename "$1")"' _ {} \;

--- a/tools/antithesis/ducktape_deps/runner.Dockerfile.j2
+++ b/tools/antithesis/ducktape_deps/runner.Dockerfile.j2
@@ -1,0 +1,17 @@
+FROM {{ node_image }}
+COPY cluster.json /root/.ducktape/cluster.json
+COPY globals.json /root/.ducktape/globals.json
+COPY --from=deps ducktape_singleton_driver.sh /opt/antithesis/test/v1/ducktape/singleton_driver_ducktape.sh
+COPY --from=deps ducktape_entrypoint.sh /usr/bin/antithesis_entrypoint.sh
+COPY --from=rptest . /root/tests/rptest/
+# Install the Antithesis Python SDK and symlink test code into the catalog
+# directory so the Antithesis instrumentor can discover and catalog assertions
+# defined in the ducktape tests. See:
+# https://antithesis.com/docs/using_antithesis/sdk/python/#instrumentation
+ARG ANTITHESIS_SDK_VERSION=0.2.0
+RUN pip install --no-cache-dir antithesis==${ANTITHESIS_SDK_VERSION} \
+    && mkdir -p /opt/antithesis/catalog \
+    && ln -s /root/tests/rptest /opt/antithesis/catalog/rptest \
+    && chmod 755 /opt/antithesis/test/v1/ducktape/singleton_driver_ducktape.sh \
+    && chmod 755 /usr/bin/antithesis_entrypoint.sh
+CMD ["/usr/bin/bash", "/usr/bin/antithesis_entrypoint.sh"]

--- a/tools/antithesis/ducktape_test_package.py
+++ b/tools/antithesis/ducktape_test_package.py
@@ -1,0 +1,386 @@
+#!/usr/bin/python3
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["jinja2"]
+# ///
+#
+# ==================================================================
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+# ==================================================================
+#
+# Package Redpanda ducktape tests into Docker images compatible with
+# Antithesis testing.
+#
+# This script:
+#   1. Builds Redpanda via Bazel (optionally with --config=antithesis)
+#   2. Builds the base test-node Docker image
+#   3. Builds the node image (test-node + baked-in Redpanda binaries)
+#   4. Builds the runner image (FROM node image + test code, config,
+#      singleton driver, entrypoint)
+#   5. Builds the config image (FROM scratch, docker-compose.yaml at /)
+#
+# Usage:
+#   ./tools/antithesis/ducktape_test_package.py \
+#       --ducktape-args rptest/tests/e2e_shadow_indexing_test.py
+#   ./tools/antithesis/ducktape_test_package.py \
+#       --ducktape-args rptest/tests/e2e_shadow_indexing_test.py \
+#       --nodes 3 --instrumented
+#
+
+import argparse
+import json
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from jinja2 import Template
+
+TOOLS_DIR = Path(__file__).resolve().parent
+DEPS_DIR = TOOLS_DIR / "ducktape_deps"
+REPO_ROOT = TOOLS_DIR.parent.parent
+
+# Root for installed binaries, matching tools/dt and RedpandaInstaller.
+INSTALL_ROOT = "/opt/redpanda_installs"
+
+
+def run(
+    cmd: list[str],
+    *,
+    check: bool = True,
+    cwd: Path | None = None,
+    capture: bool = False,
+) -> subprocess.CompletedProcess:
+    print(f"  $ {' '.join(str(c) for c in cmd)}")
+    return subprocess.run(
+        cmd,
+        check=check,
+        cwd=cwd,
+        capture_output=capture,
+        text=True,
+    )
+
+
+def render_template(template_path: Path, **kwargs) -> str:
+    with open(template_path) as f:
+        return Template(f.read()).render(**kwargs)
+
+
+def generate_cluster_json(nodes: int) -> str:
+    cluster_nodes = []
+    for i in range(1, nodes + 1):
+        hostname = f"rp-{i}"
+        cluster_nodes.append(
+            {
+                "externally_routable_ip": hostname,
+                "ssh_config": {
+                    "host": hostname,
+                    "hostname": hostname,
+                    "identityfile": "/root/.ssh/id_rsa",
+                    "password": "UNUSED",
+                    "port": 22,
+                    "user": "root",
+                },
+            }
+        )
+    return json.dumps({"nodes": cluster_nodes}, indent=4)
+
+
+def generate_globals_json(log_level: str) -> str:
+    return json.dumps(
+        {
+            "rp_install_path_root": f"{INSTALL_ROOT}/redpanda",
+            "direct_consumer_verifier_root": f"{INSTALL_ROOT}/direct_consumer_verifier",
+            "redpanda_log_level": log_level,
+            "scale": "local",
+            "enable_cov": "OFF",
+            "use_xfs_partitions": False,
+            "trim_logs": True,
+            "random_seed": None,
+            "cloud_storage_url_style": "path",
+            "node_ready_timeout_min_sec": 600,
+        },
+        indent=2,
+    )
+
+
+def generate_compose(
+    node_image: str,
+    runner_image: str,
+    nodes: int,
+    test_args: str,
+    max_parallel: int,
+    test_timeout: int,
+    disable_faults: bool,
+) -> str:
+    return render_template(
+        DEPS_DIR / "ducktape_compose.yaml.j2",
+        node_image=node_image,
+        runner_image=runner_image,
+        nodes=nodes,
+        test_args=test_args,
+        max_parallel=max_parallel,
+        test_timeout=test_timeout,
+        disable_faults=disable_faults,
+    )
+
+
+def build_redpanda(instrumented: bool, extra_bazel_args: list[str]) -> None:
+    print("==> Building Redpanda ducktape packages")
+    cmd = [
+        "bazel",
+        "build",
+        "//bazel/packaging:ducktape",
+        "//bazel/packaging:direct_consumer_verifier_ducktape",
+    ]
+    if instrumented:
+        cmd.append("--config=antithesis")
+    cmd.extend(extra_bazel_args)
+    run(cmd, cwd=REPO_ROOT)
+
+
+def build_test_node_image(image_tag: str) -> None:
+    print(f"==> Building base test node image: {image_tag}")
+
+    dockerignore_src = REPO_ROOT / "tests" / "docker" / "Dockerfile.dockerignore"
+    dockerignore_dst = REPO_ROOT / ".dockerignore"
+    shutil.copy(dockerignore_src, dockerignore_dst)
+
+    try:
+        run(
+            [
+                "docker",
+                "build",
+                "--tag",
+                image_tag,
+                "--file",
+                str(REPO_ROOT / "tests" / "docker" / "Dockerfile"),
+                str(REPO_ROOT),
+            ]
+        )
+    finally:
+        if dockerignore_dst.exists():
+            dockerignore_dst.unlink()
+
+
+def build_node_image(
+    base_image: str, node_tag: str, rp_image: str | None = None
+) -> None:
+    """Layer Redpanda binaries on top of the test-node image.
+
+    If rp_image is provided, binaries are extracted from that Docker image
+    (e.g. a nightly build from Docker Hub) instead of from the local Bazel
+    build output.
+    """
+    print(f"==> Building node image: {node_tag}")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        (tmp / "Dockerfile").write_text(
+            render_template(
+                DEPS_DIR / "node.Dockerfile.j2",
+                base_image=base_image,
+                rp_image=rp_image,
+                install_root=INSTALL_ROOT,
+            )
+        )
+        build_ctx_args: list[str] = []
+        if not rp_image:
+            pkg_root = REPO_ROOT / "bazel-bin" / "bazel" / "packaging"
+            for pkg in ("redpanda_ducktape", "direct_consumer_verifier_ducktape"):
+                if not (pkg_root / pkg).exists():
+                    sys.exit(
+                        f"Error: {pkg_root / pkg} not found. "
+                        f"Run without --skip-bazel-build or use --rp-image."
+                    )
+            build_ctx_args += ["--build-context", f"packages={pkg_root}"]
+        run(["docker", "build", *build_ctx_args, "--tag", node_tag, tmpdir])
+
+
+def build_runner_image(
+    node_image: str, runner_tag: str, cluster_json: str, globals_json: str
+) -> None:
+    """Layer test code, config, and driver on top of the node image."""
+    print(f"==> Building runner image: {runner_tag}")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+
+        # Generated config files (only these need a temp dir).
+        (tmp / "cluster.json").write_text(cluster_json)
+        (tmp / "globals.json").write_text(globals_json)
+        (tmp / "Dockerfile").write_text(
+            render_template(
+                DEPS_DIR / "runner.Dockerfile.j2",
+                node_image=node_image,
+            )
+        )
+
+        run(
+            [
+                "docker",
+                "build",
+                "--build-context",
+                f"deps={DEPS_DIR}",
+                "--build-context",
+                f"rptest={REPO_ROOT / 'tests' / 'rptest'}",
+                "--tag",
+                runner_tag,
+                tmpdir,
+            ]
+        )
+
+
+def build_config_image(config_tag: str, compose_content: str) -> None:
+    """Build a FROM scratch config image with docker-compose.yaml at /."""
+    print(f"==> Building config image: {config_tag}")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        (tmp / "docker-compose.yaml").write_text(compose_content)
+        (tmp / "Dockerfile").write_text(
+            "FROM scratch\nCOPY docker-compose.yaml /docker-compose.yaml\n"
+        )
+        run(["docker", "build", "--tag", config_tag, tmpdir])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Package Redpanda ducktape tests for Antithesis."
+    )
+    parser.add_argument(
+        "--ducktape-args",
+        required=True,
+        help="Arguments passed to the ducktape CLI "
+        "(e.g. rptest/tests/e2e_shadow_indexing_test.py)",
+    )
+    parser.add_argument(
+        "--nodes", type=int, default=3, help="Number of Redpanda nodes (default: 3)"
+    )
+    parser.add_argument(
+        "--name",
+        default="redpanda-ducktape",
+        help="Base name for images (default: redpanda-ducktape)",
+    )
+    parser.add_argument(
+        "--instrumented",
+        action="store_true",
+        help="Build with --config=antithesis for coverage",
+    )
+    parser.add_argument(
+        "--max-parallel",
+        type=int,
+        default=1,
+        help="Max parallel ducktape tests (default: 1)",
+    )
+    parser.add_argument(
+        "--test-timeout",
+        type=int,
+        default=1800000,
+        help="Ducktape test timeout in ms (default: 1800000)",
+    )
+    parser.add_argument(
+        "--disable-faults",
+        action="store_true",
+        help="Disable Antithesis fault injection during tests",
+    )
+    parser.add_argument(
+        "--log-level", default="info", help="Redpanda log level (default: info)"
+    )
+    parser.add_argument(
+        "--bazel-args", default="", help="Extra arguments passed to bazel build"
+    )
+    parser.add_argument(
+        "--rp-image",
+        default="",
+        help="Use a pre-built Redpanda Docker image instead of building "
+        "locally (e.g. docker.redpanda.com/redpandadata/redpanda-nightly:latest)",
+    )
+    parser.add_argument(
+        "--test-node-image",
+        default="",
+        help="Use a pre-built test-node image instead of building locally "
+        "(e.g. docker.redpanda.com/redpandadata/redpanda-test-node:dev-amd64-cache)",
+    )
+    parser.add_argument(
+        "--skip-bazel-build",
+        action="store_true",
+        help="Skip building Redpanda (use existing artifacts)",
+    )
+    parser.add_argument(
+        "--skip-docker-build",
+        action="store_true",
+        help="Skip building the base test-node Docker image",
+    )
+    args = parser.parse_args()
+
+    base_image = args.test_node_image or "vectorized/redpanda-test-node"
+    node_tag = f"{args.name}-node:latest"
+    runner_tag = f"{args.name}-runner:latest"
+    config_tag = f"{args.name}-config:latest"
+    extra_bazel_args = shlex.split(args.bazel_args) if args.bazel_args else []
+
+    rp_image = args.rp_image or None
+    if not rp_image and not args.skip_bazel_build:
+        build_redpanda(args.instrumented, extra_bazel_args)
+
+    if not args.test_node_image and not args.skip_docker_build:
+        build_test_node_image(base_image)
+
+    print("==> Generating config files")
+    cluster_json = generate_cluster_json(args.nodes)
+    globals_json = generate_globals_json(args.log_level)
+    compose = generate_compose(
+        node_image=node_tag,
+        runner_image=runner_tag,
+        nodes=args.nodes,
+        test_args=args.ducktape_args,
+        max_parallel=args.max_parallel,
+        test_timeout=args.test_timeout,
+        disable_faults=args.disable_faults,
+    )
+
+    build_node_image(base_image, node_tag, rp_image=rp_image)
+    build_runner_image(node_tag, runner_tag, cluster_json, globals_json)
+    build_config_image(config_tag, compose)
+
+    # Write compose file for local testing.
+    compose_out = REPO_ROOT / ".antithesis" / args.name
+    compose_out.mkdir(parents=True, exist_ok=True)
+    (compose_out / "docker-compose.yaml").write_text(compose)
+
+    print(f"""
+Images built:
+  node:   {node_tag}
+  runner: {runner_tag}
+  config: {config_tag}
+
+Run locally:
+  docker compose -f {compose_out}/docker-compose.yaml up -d
+  docker compose -f {compose_out}/docker-compose.yaml exec ducktape-runner \\
+      /opt/antithesis/test/v1/ducktape/singleton_driver_ducktape.sh
+  docker compose -f {compose_out}/docker-compose.yaml down
+
+Push to Antithesis registry:
+  TENANT=<your-tenant-name>
+  REGISTRY=us-central1-docker.pkg.dev/molten-verve-216720/$TENANT-repository
+  docker tag {node_tag} $REGISTRY/{args.name}-node:latest
+  docker push $REGISTRY/{args.name}-node:latest
+  docker tag {runner_tag} $REGISTRY/{args.name}-runner:latest
+  docker push $REGISTRY/{args.name}-runner:latest
+  docker tag {config_tag} $REGISTRY/{args.name}-config:latest
+  docker push $REGISTRY/{args.name}-config:latest
+""")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This PR introduces a packaging script for ducktape tests. The packager builds three images: a node image with Redpanda binaries baked in, a runner image with ducktape test code and the Antithesis Python SDK for assertion cataloging, and a config image with the docker-compose topology.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
