### PR TITLE
bazel: upgrade liburing to 2.14

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -340,6 +340,14 @@ test:lldb --run_under='@current_llvm_toolchain_llvm//:bin/lldb-server g :7654 --
 test:lldb --test_timeout=3600
 test:lldb --strategy=TestRunner=local
 
+# An indicator you want to use io_uring. Currently this
+# just enables the io_uring reactor backend when running
+# benchmarks and unit tests, but in the future it may do
+# more. Note there is also --@seastar//:io_uring, which
+# already defaults to true: that flag determines if Seastar
+# is built with io_uring support at all.
+build:io_uring --//bazel:io_uring=True
+
 # always pass through the following variables if they are set in the environment
 test --test_env=REDPANDA_RNG_SEEDING_MODE
 test --test_env=REDPANDA_DEBUG_TEST_HOOKS

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,7 +24,15 @@ bazel_dep(name = "crc32c", version = "1.1.0")
 bazel_dep(name = "fmt", version = "9.1.0")
 bazel_dep(name = "googletest", version = "1.17.0")
 bazel_dep(name = "lexy", version = "2025.05.0")
-bazel_dep(name = "liburing", version = "2.5")
+bazel_dep(name = "liburing", version = "2.14")
+single_version_override(
+    module_name = "liburing",
+    patch_strip = 1,
+    patches = [
+        "//bazel/thirdparty:liburing.patch",
+    ],
+)
+
 bazel_dep(name = "lz4", version = "1.9.4")
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "protobuf", version = "33.5")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -105,8 +105,8 @@
     "https://bcr.bazel.build/modules/lexy/2025.05.0/MODULE.bazel": "3edc26065513800529f59dc5238bfabf5c02dc4af855f32988542108b5088daf",
     "https://bcr.bazel.build/modules/lexy/2025.05.0/source.json": "774f00d9e2ced9f33cdac96d5b2909c511ae33699a38dfa2b42e701975f33f88",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
-    "https://bcr.bazel.build/modules/liburing/2.5/MODULE.bazel": "51768194b0b344123b2d7237b65928c9c119e7fc18a3f86f4870e83c0b71c00a",
-    "https://bcr.bazel.build/modules/liburing/2.5/source.json": "1ff3e7c04563757f99cc7d33c2d4cb4900c45d6aca2cf54d58a1b199e66460ec",
+    "https://bcr.bazel.build/modules/liburing/2.14/MODULE.bazel": "83a452082f02c8fc4a19a8b379356d8a990fe4b2a2cd33beb6478a1a6611c1bc",
+    "https://bcr.bazel.build/modules/liburing/2.14/source.json": "8af2769c7cd50cc015eb1a20ed85c721f5b5422d67d7d8dd281099bfccea28aa",
     "https://bcr.bazel.build/modules/lz4/1.9.4/MODULE.bazel": "e3d307b1d354d70f6c809167eafecf5d622c3f27e3971ab7273410f429c7f83a",
     "https://bcr.bazel.build/modules/lz4/1.9.4/source.json": "233f0bdfc21f254e3dda14683ddc487ca68c6a3a83b7d5db904c503f85bd089b",
     "https://bcr.bazel.build/modules/nlohmann_json/3.11.3/MODULE.bazel": "87023db2f55fc3a9949c7b08dc711fae4d4be339a80a99d04453c4bb3998eefc",
@@ -179,7 +179,8 @@
     "https://bcr.bazel.build/modules/rules_cc/0.1.2/MODULE.bazel": "557ddc3a96858ec0d465a87c0a931054d7dcfd6583af2c7ed3baf494407fd8d0",
     "https://bcr.bazel.build/modules/rules_cc/0.1.5/MODULE.bazel": "88dfc9361e8b5ae1008ac38f7cdfd45ad738e4fa676a3ad67d19204f045a1fd8",
     "https://bcr.bazel.build/modules/rules_cc/0.2.0/MODULE.bazel": "b5c17f90458caae90d2ccd114c81970062946f49f355610ed89bebf954f5783c",
-    "https://bcr.bazel.build/modules/rules_cc/0.2.0/source.json": "5f7f4e578e950adbf194217d4b607237a8197fc53ba46c367b3d61a86ecf35c2",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.17/MODULE.bazel": "1849602c86cb60da8613d2de887f9566a6d354a6df6d7009f9d04a14402f9a84",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.17/source.json": "3832f45d145354049137c0090df04629d9c2b5493dc5c2bf46f1834040133a07",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.10.1/MODULE.bazel": "b9527010e5fef060af92b6724edb3691970a5b1f76f74b21d39f7d433641be60",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.12.0/MODULE.bazel": "d850fab025ce79a845077035861034393f1cc1efc1d9d58d766272a26ba67def",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.12.0/source.json": "c97ddc022179fe30d1a9b94425d1e56d0a633f72332c55463e584a52ce1b38ac",
@@ -547,7 +548,7 @@
     },
     "@@apple_support+//crosstool:setup.bzl%apple_cc_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "xcBTf2+GaloFpg7YEh/Bv+1yAczRkiCt3DGws4K7kSk=",
+        "bzlTransitiveDigest": "KeQesfCOrAU1zyxCC2+z+3iMtc6ETRRZn7w+WqPasSM=",
         "usagesDigest": "39X2JjPCOAk6sThDALGv1L4q85GNjda2yfszm/phxxw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -2100,7 +2101,7 @@
     },
     "@@rules_rust+//crate_universe:extension.bzl%crate": {
       "general": {
-        "bzlTransitiveDigest": "3OBoetJUyL+gKi8+zKLBxer1HfUHxhs38NyKkHpP8/w=",
+        "bzlTransitiveDigest": "6dweJIn2jue6jXLsKdJmGasm4r9KLHL1Z2VV19RNhD0=",
         "usagesDigest": "ik68B3Un/74y+E605ZBhV6WSyOt4Sb/m8ZgtWkGvm6Q=",
         "recordedFileInputs": {
           "@@//bazel/thirdparty/Cargo.lock": "ccf410ef5c36e9543e1aacb4c1a6bee1d0e93c21a7b2e23adb16ef0e81140b23",
@@ -4119,6 +4120,16 @@
           ],
           [
             "rules_cc+",
+            "cc_compatibility_proxy",
+            "rules_cc++compatibility_proxy+cc_compatibility_proxy"
+          ],
+          [
+            "rules_cc+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_cc++compatibility_proxy+cc_compatibility_proxy",
             "rules_cc",
             "rules_cc+"
           ],

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -72,6 +72,18 @@ filegroup(
 )
 
 bool_flag(
+    name = "io_uring",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "io_uring_enabled",
+    flag_values = {
+        ":io_uring": "true",
+    },
+)
+
+bool_flag(
     name = "antithesis",
     build_setting_default = False,
 )

--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -12,6 +12,13 @@ load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 load(":internal.bzl", "antithesis_deps", "redpanda_copts")
 
+def _reactor_args():
+    """Returns additional reactor args for all reactor-using tests and benchmarks."""
+    return select({
+        "//bazel:io_uring_enabled": ["--reactor-backend=io_uring"],
+        "//conditions:default": [],
+    })
+
 def _has_flags(args, *flags):
     """
     Check if flags are present in a set of arguments.
@@ -148,6 +155,8 @@ def _redpanda_cc_test(
     # Google test / benchmarks don't understand the "--" protocol
     if args and dash_dash_protocol:
         args = ["--"] + args
+
+    args = args + _reactor_args()
 
     test_data, test_env, test_deps = _test_options()
     cc_test(
@@ -474,7 +483,7 @@ def redpanda_cc_bench(
         data = data,
     )
 
-    args = ["$(rootpath :{})".format(binary_name)] + args
+    args = ["$(rootpath :{})".format(binary_name)] + args + _reactor_args()
     env = env | {
         "MB_EXEC_IN_SHM": "1",
         "MB_REDIRECT_STDERR_DEFAULT": "1" if redirect_stderr else "0",

--- a/bazel/thirdparty/liburing.patch
+++ b/bazel/thirdparty/liburing.patch
@@ -1,0 +1,39 @@
+--- a/BUILD.bazel	2026-03-24 11:46:07.317446858 -0300
++++ b/BUILD.bazel	2026-03-25 10:48:54.430923058 -0300
+@@ -20,20 +20,28 @@
+         "src/include/liburing/io_uring_version.h",
+     ],
+     cmd = """
+-            export CC=$(CC) CXX=$(CC)++
++            export CC=$(CC) CXX=$(CC)++ CFLAGS="$(CC_FLAGS)"
+ 
+-            # switch to the package dir to execute "configure" right there
+-            pushd $$(dirname $(location configure))
+-              mkdir -p src/include/liburing
+-              ./configure --use-libc
+-            popd
++            # We do an out-of-source build of liburing here, so that
++            # CWD does not change and CC and other relative paths work
++            # (e.g. those embedded in sysroot). Currently, liburing
++            # doesn't support out of source builds, so we fake it
++            # with symlinks.
++            pkg_dir=$$(dirname $(location configure))
++            ln -sf $$pkg_dir/Makefile.common Makefile.common
++            ln -sf $$pkg_dir/liburing.spec liburing.spec
++            mkdir -p src/include/liburing
++            $$pkg_dir/configure --use-libc
+ 
+             # collect the outputs
+             for out in $(OUTS); do
+-              cp $$(realpath --relative-to=$(BINDIR) $$out) $$out
++              cp $${out#$(RULEDIR)/} $$out
+             done
+           """,
+-    toolchains = ["@bazel_tools//tools/cpp:current_cc_toolchain"],
++    toolchains = [
++        "@bazel_tools//tools/cpp:current_cc_toolchain",
++        "@bazel_tools//tools/cpp:cc_flags",
++    ],
+     tools = ["configure"],
+ )
+ 


### PR DESCRIPTION
Upgrade liburing from 2.5 to 2.14. Includes a patch to work around
out-of-source build issues (bazelbuild/bazel-central-registry#8079)
until we can pick up the upstream fix (axboe/liburing#1558).

We don't currently use liburing, so this is a no-op upgrade to stay
current.

I ran all unit tests with uring (see other commit) and had no new failures (one test failed even w/o io_uring, I think disk cache corruption).

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none