### PR TITLE
rptest: fix cross-region bucket specification

### DIFF
--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -601,9 +601,20 @@ class TestReadReplicaService(EndToEndTest):
         mode: ReadReplicaSourceMode,
     ):
         self.mode = mode
-        bucket_region = self.rr_settings.cloud_storage_region
-        bucket_endpoint = self.rr_settings.cloud_storage_api_endpoint
-        self.rr_topic_bucket = f"{self.si_settings.cloud_storage_bucket}?region={bucket_region}&endpoint={bucket_endpoint}"
+        self.si_settings.load_context(self.logger, self.test_context)
+        bucket_name = self.si_settings.cloud_storage_bucket
+        bucket_region = self.si_settings.cloud_storage_region
+        # si_settings.cloud_storage_api_endpoint is only valid for docker
+        # (minio-s3). In CDT the endpoint is not set in SISettings, so we
+        # construct the real S3 endpoint from the region.
+        # NOTE: this test currently only runs on AWS or docker.
+        if get_cloud_provider() == "docker":
+            bucket_endpoint = self.si_settings.cloud_storage_api_endpoint
+        else:
+            bucket_endpoint = f"s3.{bucket_region}.amazonaws.com"
+        self.rr_topic_bucket = (
+            f"{bucket_name}?region={bucket_region}&endpoint={bucket_endpoint}"
+        )
 
         # Bogus region and endpoint to test overrides take effect.
         self.rr_settings.cloud_storage_region = "unknown-region-1"


### PR DESCRIPTION
In CDT this test would consistently fail because the read replica is configured to point at minio-s3.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
