### PR TITLE
bazel: update seastar to da67f271

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -303,7 +303,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "imVq/Zl1YH4M/22NJ9WbE3zIAXH1N0Mvvp8kx+LL4oo=",
+        "bzlTransitiveDigest": "OsWIpIdRjCSRtvPNuOPzNcf6QDCz7ZX4kFEWLZMRIUE=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -483,9 +483,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "b697dbed6afd966feae8bf58a3a3af704cb74ef4ee699c70506533948b23c740",
-              "strip_prefix": "seastar-7780db6428357bca114d405ee2c7c24c52db6901",
-              "url": "https://github.com/redpanda-data/seastar/archive/7780db6428357bca114d405ee2c7c24c52db6901.tar.gz"
+              "sha256": "1213beb82e4e862c13c402bd3d4eaf42f4766884c2f86e767b986dbedbf2635d",
+              "strip_prefix": "seastar-da67f2719482f6736345a8d326f9f5454fd9e266",
+              "url": "https://github.com/redpanda-data/seastar/archive/da67f2719482f6736345a8d326f9f5454fd9e266.tar.gz"
             }
           },
           "unordered_dense": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -171,9 +171,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "b697dbed6afd966feae8bf58a3a3af704cb74ef4ee699c70506533948b23c740",
-        strip_prefix = "seastar-7780db6428357bca114d405ee2c7c24c52db6901",
-        url = "https://github.com/redpanda-data/seastar/archive/7780db6428357bca114d405ee2c7c24c52db6901.tar.gz",
+        sha256 = "1213beb82e4e862c13c402bd3d4eaf42f4766884c2f86e767b986dbedbf2635d",
+        strip_prefix = "seastar-da67f2719482f6736345a8d326f9f5454fd9e266",
+        url = "https://github.com/redpanda-data/seastar/archive/da67f2719482f6736345a8d326f9f5454fd9e266.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
## Summary

Update Seastar dependency to latest from v26.2.x-pre (which is same as 26.1.x currently) branch.

- Previous SHA: `7780db642835`
- New SHA: `da67f2719482`
- [Compare changes](https://github.com/redpanda-data/seastar/compare/7780db6428357bca114d405ee2c7c24c52db6901...da67f2719482f6736345a8d326f9f5454fd9e266)

Changes:
- opt out of AI training per GitHub policy
- perf_tests: increase overhead column precision to 3 decimal places

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none