### PR TITLE
tests: compare with v26.1.x branch for pass criteria

### DIFF
--- a/tests/ducktape-common-retry.yml
+++ b/tests/ducktape-common-retry.yml
@@ -8,7 +8,7 @@ common_pc_definitions: &common_pc_definitions
   statistical-default:
     mode:
       statistical:
-        compare_with_branch: dev
+        compare_with_branch: v26.1.x
         time_window: 2w
         reject_threshold: 0.01
         trust_threshold: 0.5
@@ -16,14 +16,14 @@ common_pc_definitions: &common_pc_definitions
   zero-drift:
     mode:
       dynamic_reliability:
-        compare_with_branch: dev
+        compare_with_branch: v26.1.x
         time_window: 2w
         allowed_drift: 0 # upstream_reliability - current_ci_reliability <= allowed_drift
         fallback_reliability: 90.0 # when reliability cannot be fetched from branch (e.g. new test)
   fifty-drift:
     mode:
       dynamic_reliability:
-        compare_with_branch: dev
+        compare_with_branch: v26.1.x
         time_window: 2w
         allowed_drift: 50 # upstream_reliability - current_ci_reliability <= allowed_drift
         fallback_reliability: 90.0 # when reliability cannot be fetched from branch (e.g. new test)


### PR DESCRIPTION
Now that `v26.1.x` is cut and test results are available, the pt auto-retry config should compare with the `v26.1.x` branch.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none