### PR TITLE
kafka: Only generate latency histograms for important handlers

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -886,6 +886,14 @@ configuration::configuration()
       "Use separate scheduler group to handle parsing Kafka protocol requests",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       true)
+  , kafka_handler_latency_all(
+      *this,
+      "kafka_handler_latency_all",
+      "Enable latency histograms for all Kafka API handlers. When disabled, "
+      "only important handlers (produce, fetch, metadata, api_versions, "
+      "offset_commit) have latency histograms.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      false)
   , kafka_tcp_keepalive_idle_timeout_seconds(
       *this,
       "kafka_tcp_keepalive_timeout",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -220,6 +220,7 @@ struct configuration final : public config_store {
     property<bool> use_fetch_scheduler_group;
     property<bool> use_produce_scheduler_group;
     property<bool> use_kafka_handler_scheduler_group;
+    property<bool> kafka_handler_latency_all;
     property<std::chrono::seconds> kafka_tcp_keepalive_idle_timeout_seconds;
     property<std::chrono::seconds> kafka_tcp_keepalive_probe_interval_seconds;
     property<uint32_t> kafka_tcp_keepalive_probes;

--- a/src/v/kafka/server/handlers/api_versions.h
+++ b/src/v/kafka/server/handlers/api_versions.h
@@ -16,7 +16,13 @@
 namespace kafka {
 
 struct api_versions_handler
-  : public single_stage_handler<api_versions_api, 0, 4> {
+  : public single_stage_handler<
+      api_versions_api,
+      0,
+      4,
+      default_estimate_adaptor,
+      default_scheduling_group_provider,
+      latency_hist::yes> {
     static constexpr api_version min_flexible = api_version(3);
 
     static ss::future<response_ptr>

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -36,7 +36,8 @@ using fetch_handler = single_stage_handler<
   4,
   13,
   default_estimate_adaptor,
-  fetch_scheduling_group_provider>;
+  fetch_scheduling_group_provider,
+  latency_hist::yes>;
 
 /*
  * Fetch operation context

--- a/src/v/kafka/server/handlers/handler.h
+++ b/src/v/kafka/server/handlers/handler.h
@@ -33,6 +33,10 @@ default_scheduling_group_provider(const connection_context&) {
     return std::nullopt;
 }
 
+// Whether a handler should have a per-handler latency histogram registered.
+// Only enable for very important common methods.
+enum class latency_hist : bool { no = false, yes = true };
+
 /**
  * Handlers are generally specializations of this template, via one of the
  * two aliases (handler or two_phase_hander) declared below, though it is
@@ -48,11 +52,14 @@ template<
   api_version::type MaxSupported,
   typename HandleRetType,
   memory_estimate_fn MemEstimator,
-  scheduling_group_provider_fn SgProvider>
+  scheduling_group_provider_fn SgProvider,
+  latency_hist LatencyHistogram>
 struct handler_template {
     using api = RequestApi;
     static constexpr api_version min_supported = api_version(MinSupported);
     static constexpr api_version max_supported = api_version(MaxSupported);
+    static constexpr bool has_latency_histogram = LatencyHistogram
+                                                  == latency_hist::yes;
 
     static HandleRetType handle(request_context, ss::smp_service_group);
 
@@ -91,14 +98,16 @@ template<
   api_version::type MinSupported,
   api_version::type MaxSupported,
   memory_estimate_fn MemEstimator = default_estimate_adaptor,
-  scheduling_group_provider_fn SgProvider = default_scheduling_group_provider>
+  scheduling_group_provider_fn SgProvider = default_scheduling_group_provider,
+  latency_hist LatencyHistogram = latency_hist::no>
 using single_stage_handler = handler_template<
   RequestApi,
   MinSupported,
   MaxSupported,
   ss::future<response_ptr>,
   MemEstimator,
-  SgProvider>;
+  SgProvider,
+  LatencyHistogram>;
 
 /**
  * A two-stage handler has an initial stage which happens before any other
@@ -112,14 +121,16 @@ template<
   api_version::type MinSupported,
   api_version::type MaxSupported,
   memory_estimate_fn MemEstimator = default_estimate_adaptor,
-  scheduling_group_provider_fn SgProvider = default_scheduling_group_provider>
+  scheduling_group_provider_fn SgProvider = default_scheduling_group_provider,
+  latency_hist LatencyHistogram = latency_hist::no>
 using two_phase_handler = handler_template<
   RequestApi,
   MinSupported,
   MaxSupported,
   process_result_stages,
   MemEstimator,
-  SgProvider>;
+  SgProvider,
+  LatencyHistogram>;
 
 template<typename T>
 concept KafkaApiHandler

--- a/src/v/kafka/server/handlers/handler_interface.cc
+++ b/src/v/kafka/server/handlers/handler_interface.cc
@@ -28,19 +28,22 @@ struct handler_info {
       api_version min_api,
       api_version max_api,
       memory_estimate_fn* mem_estimate,
-      scheduling_group_provider_fn* sg_provider) noexcept
+      scheduling_group_provider_fn* sg_provider,
+      bool has_latency_histogram) noexcept
       : _key(key)
       , _name(name)
       , _min_api(min_api)
       , _max_api(max_api)
       , _mem_estimate(mem_estimate)
-      , _sg_provider(sg_provider) {}
+      , _sg_provider(sg_provider)
+      , _has_latency_histogram(has_latency_histogram) {}
 
     api_key _key;
     const char* _name;
     api_version _min_api, _max_api;
     memory_estimate_fn* _mem_estimate;
     scheduling_group_provider_fn* _sg_provider;
+    bool _has_latency_histogram;
 };
 
 /**
@@ -96,6 +99,10 @@ struct handler_base final : public handler_interface {
         return _info._sg_provider(conn_ctx);
     }
 
+    bool has_latency_histogram() const override {
+        return _info._has_latency_histogram;
+    }
+
 private:
     handler_info _info;
     fn_type* _handle_fn;
@@ -118,7 +125,8 @@ struct handler_holder {
         H::min_supported,
         H::max_supported,
         H::memory_estimate,
-        H::scheduling_group_override},
+        H::scheduling_group_override,
+        H::has_latency_histogram},
       H::handle};
 };
 

--- a/src/v/kafka/server/handlers/handler_interface.h
+++ b/src/v/kafka/server/handlers/handler_interface.h
@@ -94,6 +94,9 @@ struct handler_interface {
     virtual std::optional<ss::scheduling_group>
     scheduling_group_override(const connection_context&) const = 0;
 
+    /// Whether this handler should have a per-handler latency histogram.
+    virtual bool has_latency_histogram() const = 0;
+
     virtual ~handler_interface() = default;
 };
 

--- a/src/v/kafka/server/handlers/handler_probe.cc
+++ b/src/v/kafka/server/handlers/handler_probe.cc
@@ -31,10 +31,21 @@ handler_probe_manager::handler_probe_manager()
   : _metrics()
   , _probes(max_api_key() + 2) {
     const auto unknown_handler_key = max_api_key() + 1;
+    const bool handler_latency_all
+      = config::shard_local_cfg().kafka_handler_latency_all();
     for (size_t i = 0; i < _probes.size(); i++) {
         auto key = api_key(i);
+        auto handler = handler_for_key(key);
 
-        if (handler_for_key(key) || i == unknown_handler_key) {
+        if (handler || i == unknown_handler_key) {
+            bool enable_histogram
+              = handler_latency_all
+                || (handler && (*handler)->has_latency_histogram());
+
+            if (enable_histogram) {
+                _probes[i].enable_histogram();
+            }
+
             _probes[i].setup_metrics(_metrics, key);
 
             if (key == produce_api::key || key == fetch_api::key) {
@@ -95,14 +106,23 @@ void handler_probe::setup_metrics(
           [this] { return _bytes_sent; },
           sm::description("Number of bytes sent in kafka replies"),
           labels),
-        sm::make_histogram(
-          "latency_microseconds",
-          sm::description("Latency histogram of kafka requests"),
-          labels,
-          [this] { return _latency.internal_histogram_logform(); }),
       },
       {},
       {seastar::metrics::shard_label});
+
+    if (_latency) {
+        metrics.add_group(
+          prometheus_sanitize::metrics_name("kafka_handler"),
+          {
+            sm::make_histogram(
+              "latency_microseconds",
+              sm::description("Latency histogram of kafka requests"),
+              labels,
+              [this] { return _latency->internal_histogram_logform(); }),
+          },
+          {},
+          {seastar::metrics::shard_label});
+    }
 
     // Don't want to aggregate the shard label away so that we get per shard RPS
     // in any case
@@ -131,16 +151,18 @@ void handler_probe::setup_public_metrics(
 
     std::vector<sm::label_instance> labels{sm::label("handler")(handler_name)};
 
-    metrics.add_group(
-      prometheus_sanitize::metrics_name("kafka_handler"),
-      {
-        sm::make_histogram(
-          "latency_seconds",
-          sm::description("Latency histogram of kafka requests"),
-          labels,
-          [this] { return _latency.public_histogram_logform(); })
-          .aggregate({sm::shard_label}),
-      });
+    if (_latency) {
+        metrics.add_group(
+          prometheus_sanitize::metrics_name("kafka_handler"),
+          {
+            sm::make_histogram(
+              "latency_seconds",
+              sm::description("Latency histogram of kafka requests"),
+              labels,
+              [this] { return _latency->public_histogram_logform(); })
+              .aggregate({sm::shard_label}),
+          });
+    }
 }
 
 /*

--- a/src/v/kafka/server/handlers/handler_probe.h
+++ b/src/v/kafka/server/handlers/handler_probe.h
@@ -60,7 +60,16 @@ public:
     void add_bytes_sent(size_t bytes) { _bytes_sent += bytes; }
 
     std::unique_ptr<hist_t::measurement> auto_latency_measurement() {
-        return _latency.auto_measure();
+        if (_latency) {
+            return _latency->auto_measure();
+        }
+        return nullptr;
+    }
+
+    void enable_histogram() {
+        if (!_latency.has_value()) {
+            _latency.emplace();
+        }
     }
 
 private:
@@ -75,7 +84,7 @@ private:
     uint64_t _bytes_received{0};
     uint64_t _bytes_sent{0};
 
-    hist_t _latency{};
+    std::optional<hist_t> _latency;
 };
 
 /**

--- a/src/v/kafka/server/handlers/metadata.h
+++ b/src/v/kafka/server/handlers/metadata.h
@@ -24,7 +24,12 @@ namespace kafka {
  */
 memory_estimate_fn metadata_memory_estimator;
 
-using metadata_handler
-  = single_stage_handler<metadata_api, 0, 12, metadata_memory_estimator>;
+using metadata_handler = single_stage_handler<
+  metadata_api,
+  0,
+  12,
+  metadata_memory_estimator,
+  default_scheduling_group_provider,
+  latency_hist::yes>;
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/offset_commit.h
+++ b/src/v/kafka/server/handlers/offset_commit.h
@@ -18,6 +18,12 @@ namespace kafka {
 // in version 0 kafka stores offsets in zookeeper. if we ever need to
 // support version 0 then we need to do some code review to see if this has
 // any implications on semantics.
-using offset_commit_handler = two_phase_handler<offset_commit_api, 1, 8>;
+using offset_commit_handler = two_phase_handler<
+  offset_commit_api,
+  1,
+  8,
+  default_estimate_adaptor,
+  default_scheduling_group_provider,
+  latency_hist::yes>;
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/produce.h
+++ b/src/v/kafka/server/handlers/produce.h
@@ -22,7 +22,8 @@ using produce_handler = two_phase_handler<
   0,
   7,
   default_estimate_adaptor,
-  produce_scheduling_group_provider>;
+  produce_scheduling_group_provider,
+  latency_hist::yes>;
 
 struct partition_produce_stages {
     ss::future<> dispatched;


### PR DESCRIPTION
Latency handler probes cause lots of metric series due to the latency
histograms for each api method. This causes strain on the metrics infra.

Most of the methods are uninteresting. Hence only enable histograms for
the important methods that are interesting.

Add a flag to optionally revert to the old behaviour.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes


* none
