### PR TITLE
rpk/cloud/auth: add 'token' subcommand

### DIFF
--- a/src/go/rpk/pkg/cli/cloud/auth/BUILD
+++ b/src/go/rpk/pkg/cli/cloud/auth/BUILD
@@ -9,6 +9,7 @@ go_library(
         "edit.go",
         "list.go",
         "rename.go",
+        "token.go",
         "use.go",
     ],
     importpath = "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cloud/auth",

--- a/src/go/rpk/pkg/cli/cloud/auth/auth.go
+++ b/src/go/rpk/pkg/cli/cloud/auth/auth.go
@@ -38,6 +38,7 @@ only use a single SSO based login.
 		newEditCommand(fs, p),
 		newListCommand(fs, p),
 		newRenameToCommand(fs, p),
+		newTokenCommand(fs, p),
 		newUseCommand(fs, p),
 	)
 

--- a/src/go/rpk/pkg/cli/cloud/auth/token.go
+++ b/src/go/rpk/pkg/cli/cloud/auth/token.go
@@ -1,0 +1,50 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package auth
+
+import (
+	"fmt"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newTokenCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	return &cobra.Command{
+		Use:   "token",
+		Short: "Print the cloud auth token of the current profile",
+		Long: `Print the cloud auth token of the current profile.
+
+This command prints the auth token for the currently selected cloud
+authentication to stdout. This is useful for piping the token into other
+commands or scripts that need to authenticate with Redpanda Cloud.`,
+		Args: cobra.ExactArgs(0),
+		Run: func(_ *cobra.Command, _ []string) {
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "rpk unable to load config: %v", err)
+
+			y, ok := cfg.ActualRpkYaml()
+			if !ok {
+				out.Die("rpk.yaml file does not exist")
+			}
+
+			a := y.CurrentAuth()
+			if a == nil {
+				out.Die("no current cloud auth selected, use 'rpk cloud login' to log in")
+			}
+			if a.AuthToken == "" {
+				out.Die("current auth has no token, use 'rpk cloud login' to log in")
+			}
+			fmt.Print(a.AuthToken)
+		},
+	}
+}


### PR DESCRIPTION
## What

Add `rpk cloud auth token` command that prints the current cloud auth token to stdout.

## Why

There's no simple way to extract the auth token for scripting or piping into other tools that need to authenticate with Redpanda Cloud.

## Implementation details

New `token` subcommand under `rpk cloud auth`. Loads the rpk.yaml config, looks up the current cloud auth, and prints the raw token with no trailing newline -- ready for `$(rpk cloud auth token)` substitution or piping.

Dies with a clear message if no auth is selected or the token is empty.