### PR TITLE
k/fetch: Add fetch_response_dropped_bytes metric

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -460,7 +460,13 @@ static void fill_fetch_responses(
             resp_units = std::move(res.memory_units);
             resp.records = batch_reader(std::move(res).release_data());
         } else {
-            // TODO: add probe to measure how much of read data is discarded
+            if (res.has_data()) {
+                // Data was read from cloud storage but cannot fit in the
+                // response budget. This is pure read amplification: S3 bytes
+                // were downloaded, materialized, and now dropped.
+                octx.rctx.probe().add_fetch_response_dropped_bytes(
+                  res.data_size_bytes());
+            }
             resp.records = batch_reader();
         }
 

--- a/src/v/kafka/server/kafka_probe.h
+++ b/src/v/kafka/server/kafka_probe.h
@@ -113,6 +113,20 @@ public:
               "in the future or in the past"))},
           {},
           {sm::shard_label});
+
+        _metrics.add_group(
+          "kafka",
+          {sm::make_counter(
+            "fetch_response_dropped_bytes",
+            [this] { return _fetch_response_dropped_bytes; },
+            sm::description(
+              "Total bytes read from storage (including cloud storage) that "
+              "were discarded in fill_fetch_responses because the response "
+              "budget was already consumed by other partitions. Non-zero "
+              "values indicate read amplification: data was fetched from S3 "
+              "but not delivered to the consumer."))},
+          {},
+          {sm::shard_label});
     }
 
     void setup_public_metrics() {
@@ -153,6 +167,10 @@ public:
         _fetch_latency.record(micros.count());
     }
 
+    void add_fetch_response_dropped_bytes(uint64_t bytes) {
+        _fetch_response_dropped_bytes += bytes;
+    }
+
     void record_batch(uint64_t size, model::compression compression) {
         _batch_size.record(size);
         if (auto idx = (size_t)compression;
@@ -167,6 +185,7 @@ private:
     friend prod_consume_fixture;
 
     uint32_t _produce_bad_create_time = 0;
+    uint64_t _fetch_response_dropped_bytes = 0;
 
     hist_t _produce_latency;
     hist_t _fetch_latency;


### PR DESCRIPTION
The metric tracks read amplification in bytes.
It's difficult to figure out amplification in case of cloud topics without this metric.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none