### PR TITLE
ci/ducktape: point retry compare_with_branch to v26.1.x

### DIFF
--- a/tests/ducktape-common-retry.yml
+++ b/tests/ducktape-common-retry.yml
@@ -8,7 +8,7 @@ common_pc_definitions: &common_pc_definitions
   statistical-default:
     mode:
       statistical:
-        compare_with_branch: dev
+        compare_with_branch: v26.1.x
         time_window: 2w
         reject_threshold: 0.01
         trust_threshold: 0.5
@@ -16,14 +16,14 @@ common_pc_definitions: &common_pc_definitions
   zero-drift:
     mode:
       dynamic_reliability:
-        compare_with_branch: dev
+        compare_with_branch: v26.1.x
         time_window: 2w
         allowed_drift: 0 # upstream_reliability - current_ci_reliability <= allowed_drift
         fallback_reliability: 90.0 # when reliability cannot be fetched from branch (e.g. new test)
   fifty-drift:
     mode:
       dynamic_reliability:
-        compare_with_branch: dev
+        compare_with_branch: v26.1.x
         time_window: 2w
         allowed_drift: 50 # upstream_reliability - current_ci_reliability <= allowed_drift
         fallback_reliability: 90.0 # when reliability cannot be fetched from branch (e.g. new test)


### PR DESCRIPTION
After branching v26.1.x, update the ducktape retry criteria to
compare against v26.1.x instead of dev, so that test reliability
comparisons use the stable release branch as the baseline.

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none