### PR TITLE
Cloud Topics: Improve backoff algorithm in L0 GC

### DIFF
--- a/src/v/cloud_topics/app.h
+++ b/src/v/cloud_topics/app.h
@@ -39,7 +39,8 @@ class api;
 namespace cloud_topics {
 class data_plane_api;
 class cloud_topics_manager;
-class level_zero_gc;
+template<class>
+class level_zero_gc_t;
 class housekeeper_manager;
 class topic_manifest_upload_manager;
 
@@ -88,7 +89,7 @@ public:
     ss::sharded<reconciler::reconciler<>>* get_reconciler();
     ss::sharded<l1::replicated_metastore>* get_sharded_replicated_metastore();
     l1::compaction_scheduler* get_compaction_scheduler();
-    ss::sharded<level_zero_gc>* get_level_zero_gc();
+    ss::sharded<level_zero_gc_t<ss::lowres_clock>>* get_level_zero_gc();
     cluster_services& get_local_cluster_services();
 
     // TODO: add 'get_control_plane_api' etc
@@ -112,7 +113,7 @@ private:
     ss::sharded<l1::topic_purger_manager> topic_purge_manager;
     ss::sharded<l1::flush_loop_manager> flush_loop_manager;
     ss::sharded<cloud_topics_manager> manager;
-    ss::sharded<level_zero_gc> l0_gc;
+    ss::sharded<level_zero_gc_t<ss::lowres_clock>> l0_gc;
     ss::sharded<housekeeper_manager> housekeeper_manager;
     ss::sharded<topic_manifest_upload_manager> topic_manifest_upload_mgr;
     std::unique_ptr<l1::compaction_scheduler> compaction_scheduler;

--- a/src/v/cloud_topics/level_zero/gc/BUILD
+++ b/src/v/cloud_topics/level_zero/gc/BUILD
@@ -17,6 +17,23 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "level_zero_gc_types",
+    hdrs = [
+        "level_zero_gc_types.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":level_zero_gc_probe",
+        "//src/v/cloud_io:io_result",
+        "//src/v/cloud_storage_clients",
+        "//src/v/cloud_topics:types",
+        "//src/v/container:chunked_hash_map",
+        "//src/v/model",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "level_zero_gc",
     srcs = [
         "level_zero_gc.cc",
@@ -37,11 +54,9 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":level_zero_gc_probe",
-        "//src/v/cloud_io:io_result",
+        ":level_zero_gc_types",
         "//src/v/cloud_storage_clients",
         "//src/v/cloud_topics:types",
-        "//src/v/container:chunked_hash_map",
-        "//src/v/model",
         "@seastar",
     ],
 )

--- a/src/v/cloud_topics/level_zero/gc/BUILD
+++ b/src/v/cloud_topics/level_zero/gc/BUILD
@@ -48,6 +48,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics:object_utils",
         "//src/v/cluster",
         "//src/v/config",
+        "//src/v/random:time_jitter",
         "//src/v/ssx:semaphore",
         "//src/v/ssx:work_queue",
     ],
@@ -57,6 +58,7 @@ redpanda_cc_library(
         ":level_zero_gc_types",
         "//src/v/cloud_storage_clients",
         "//src/v/cloud_topics:types",
+        "//src/v/random:generators",
         "@seastar",
     ],
 )

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -741,6 +741,9 @@ seastar::future<> level_zero_gc::start() {
     vlog(cd_log.info, "Starting cloud topics L0 GC worker");
     delete_worker_->start();
     safety_monitor_->start();
+    if (!should_run_) {
+        skip_backoff_ = true;
+    }
     should_run_ = true;
     worker_cv_.signal();
 }
@@ -753,6 +756,7 @@ seastar::future<> level_zero_gc::pause() {
     vlog(cd_log.info, "Pausing cloud topics L0 GC worker");
     should_run_ = false;
     asrc_.request_abort();
+    backoff_asrc_.request_abort();
     delete_worker_->pause();
 }
 
@@ -760,6 +764,7 @@ seastar::future<> level_zero_gc::stop() {
     vlog(cd_log.info, "Stopping cloud topics L0 GC worker");
     should_shutdown_ = true;
     asrc_.request_abort();
+    backoff_asrc_.request_abort();
     worker_cv_.signal();
     co_await delete_worker_->stop();
     co_await std::exchange(worker_, seastar::make_ready_future<>());
@@ -774,6 +779,7 @@ seastar::future<> level_zero_gc::reset() {
     vlog(cd_log.info, "Resetting cloud topics L0 GC worker state");
 
     resetting_ = true;
+    skip_backoff_ = true;
     const bool was_running = should_run_;
 
     auto done = ss::defer([this] {
@@ -784,6 +790,7 @@ seastar::future<> level_zero_gc::reset() {
     // Pause the outer worker loop so it blocks on the CV
     should_run_ = false;
     asrc_.request_abort();
+    backoff_asrc_.request_abort();
 
     co_await delete_worker_->reset();
 
@@ -819,6 +826,30 @@ std::string_view to_string_view(state s) {
 
 auto format_as(state s) { return to_string_view(s); }
 
+std::string_view to_string_view(collection_outcome::status s) {
+    using enum collection_outcome::status;
+    switch (s) {
+    case progress:
+        return "progress";
+    case epoch_ineligible:
+        return "epoch_ineligible";
+    case age_ineligible:
+        return "age_ineligible";
+    case empty:
+        return "empty";
+    case at_capacity:
+        return "at_capacity";
+    }
+    vunreachable(
+      "Unrecognized collection_outcome::status: {}", static_cast<int>(s));
+}
+
+auto format_as(collection_outcome::status s) { return to_string_view(s); }
+
+fmt::iterator collection_outcome::format_to(fmt::iterator it) const {
+    return fmt::format_to(it, "{{st={}, eligible={}}}", st, eligible_);
+}
+
 } // namespace l0::gc
 
 l0::gc::state level_zero_gc::get_state() const {
@@ -847,6 +878,12 @@ l0::gc::state level_zero_gc::get_state() const {
 seastar::future<> level_zero_gc::worker() {
     std::chrono::milliseconds backoff{0};
 
+    // Abort the backoff sleep when the grace period changes so we
+    // recalculate how long to sleep. Without this, a reduction in
+    // grace period wouldn't take effect until the current sleep expires.
+    config_.deletion_grace_period.watch(
+      [this] { backoff_asrc_.request_abort(); });
+
     while (true) {
         try {
             co_await worker_cv_.wait(
@@ -860,6 +897,7 @@ seastar::future<> level_zero_gc::worker() {
             // may subscribe or reset the abort source since it is able to
             // ensure that the abort source is unreferenced at this time.
             asrc_ = {};
+            backoff_asrc_ = {};
 
             if (auto safety = safety_monitor_->can_proceed(); !safety.ok) {
                 vlog(
@@ -874,10 +912,18 @@ seastar::future<> level_zero_gc::worker() {
                 continue;
             }
 
+            if (std::exchange(skip_backoff_, false)) {
+                backoff = std::chrono::milliseconds{0};
+            }
             if (backoff.count() > 0) {
                 auto t0 = ss::lowres_clock::now();
+                // Use a dedicated abort source for the backoff sleep so
+                // that config changes (grace period watcher) and state
+                // changes (pause/stop/reset) can wake us without aborting
+                // asrc_, which is reserved for cancelling in-flight
+                // service calls.
                 (co_await seastar::coroutine::as_future(
-                   seastar::sleep_abortable(backoff, asrc_)))
+                   seastar::sleep_abortable(backoff, backoff_asrc_)))
                   .ignore_ready_future();
                 auto elapsed
                   = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -889,10 +935,22 @@ seastar::future<> level_zero_gc::worker() {
 
             auto res = co_await try_to_collect();
             if (res.has_value()) {
-                if (res.value() > 0) {
+                using enum l0::gc::collection_outcome::status;
+                switch (res->st) {
+                case progress:
+                case at_capacity:
                     backoff = config_.throttle_progress();
-                } else {
+                    break;
+                case epoch_ineligible:
                     backoff = config_.throttle_no_progress();
+                    break;
+                case age_ineligible:
+                    backoff = res->age_backoff(config_.deletion_grace_period())
+                                .value_or(config_.throttle_no_progress());
+                    break;
+                case empty:
+                    backoff = config_.deletion_grace_period();
+                    break;
                 }
             } else {
                 switch (res.error()) {
@@ -915,31 +973,68 @@ seastar::future<> level_zero_gc::worker() {
     vlog(cd_log.info, "Level zero GC worker is exiting");
 }
 
-seastar::future<std::expected<size_t, l0::gc::collection_error>>
+seastar::future<
+  std::expected<l0::gc::collection_outcome, l0::gc::collection_error>>
 level_zero_gc::try_to_collect() {
+    using enum l0::gc::collection_outcome::status;
+
     // Ultra-temporary cache to avoid repeatedly querying for max gc-able epoch.
     // Since the result will always be valid clusterwide, compute exactly once
     // per collection loop.
     std::optional<cluster_epoch> max_gc_epoch;
-    size_t total_eligible{0};
+    l0::gc::collection_outcome outcome(empty);
+    size_t pages_scanned{0};
     probe_.reset_deletion_epoch();
     probe_.collection_round();
-    while (delete_worker_->has_capacity()) {
-        auto res = co_await do_try_to_collect(std::ref(max_gc_epoch));
-        if (!res.has_value()) {
-            co_return res;
-        }
-        if (res.value() == 0) {
-            break;
-        }
-        total_eligible += res.value();
+
+    if (!delete_worker_->has_capacity()) {
+        co_return l0::gc::collection_outcome(at_capacity);
     }
 
-    co_return total_eligible;
+    while (delete_worker_->has_capacity()) {
+        ++pages_scanned;
+        auto res = co_await do_try_to_collect(std::ref(max_gc_epoch));
+        if (!res.has_value()) {
+            co_return std::unexpected(res.error());
+        }
+        if (!res.value().has_value()) {
+            // All prefixes exhausted.
+            break;
+        }
+        outcome.merge(res->value());
+        if (res->value().st != progress) {
+            // Page had objects but none were eligible. Continue
+            // scanning only if we're tracking age-ineligible objects —
+            // we need the full picture to compute age_backoff
+            // accurately. For epoch-ineligible objects, further pages
+            // don't help (we can't predict epoch advancement), and
+            // continuing would hold a stale max_gc_epoch cache while
+            // the real epoch may be advancing.
+            if (outcome.st != age_ineligible) {
+                break;
+            }
+            (co_await seastar::coroutine::as_future(
+               seastar::sleep_abortable(config_.throttle_progress(), asrc_)))
+              .ignore_ready_future();
+            if (asrc_.abort_requested()) {
+                break;
+            }
+        }
+    }
+
+    vlog(
+      cd_log.debug,
+      "Collection round scanned {} pages: {}",
+      pages_scanned,
+      outcome);
+    co_return outcome;
 }
 
-seastar::future<std::expected<size_t, l0::gc::collection_error>>
+seastar::future<std::expected<
+  std::optional<l0::gc::collection_outcome>,
+  l0::gc::collection_error>>
 level_zero_gc::do_try_to_collect(std::optional<cluster_epoch>& max_gc_epoch) {
+    using enum l0::gc::collection_outcome::status;
     auto candidate_objects = co_await delete_worker_->next_page();
     if (!candidate_objects.has_value()) {
         vlog(
@@ -947,6 +1042,10 @@ level_zero_gc::do_try_to_collect(std::optional<cluster_epoch>& max_gc_epoch) {
           "Received error listing objects during L0 GC: {}",
           candidate_objects.error());
         co_return std::unexpected(l0::gc::collection_error::service_error);
+    }
+
+    if (candidate_objects.value().empty()) {
+        co_return std::nullopt;
     }
 
     if (!max_gc_epoch.has_value()) {
@@ -978,10 +1077,10 @@ level_zero_gc::do_try_to_collect(std::optional<cluster_epoch>& max_gc_epoch) {
       max_gc_epoch.value(),
       max_gc_birthday);
 
-    // objects that can be safely deleted
+    l0::gc::collection_outcome page_outcome(empty);
+
     chunked_vector<cloud_storage_clients::client::list_bucket_item>
       eligible_objects;
-    // total size of eligible keys
     size_t object_keys_total_bytes = 0;
 
     // used to detect unsorted object listings
@@ -1051,6 +1150,7 @@ level_zero_gc::do_try_to_collect(std::optional<cluster_epoch>& max_gc_epoch) {
               "Ignoring object with non-collectible epoch: {} > {}",
               object.key,
               max_gc_epoch.value());
+            page_outcome.mark_epoch_ineligible();
             probe_.object_skipped_not_eligible();
             continue;
         }
@@ -1063,6 +1163,7 @@ level_zero_gc::do_try_to_collect(std::optional<cluster_epoch>& max_gc_epoch) {
               object.key,
               object.last_modified,
               max_gc_birthday);
+            page_outcome.mark_age_ineligible(object.last_modified);
             probe_.object_skipped_too_young();
             continue;
         }
@@ -1072,8 +1173,9 @@ level_zero_gc::do_try_to_collect(std::optional<cluster_epoch>& max_gc_epoch) {
         probe_.report_deletion_epoch(object_epoch.value());
     }
 
-    co_return delete_worker_->delete_objects(
-      std::move(eligible_objects), object_keys_total_bytes);
+    page_outcome.add_eligible(delete_worker_->delete_objects(
+      std::move(eligible_objects), object_keys_total_bytes));
+    co_return page_outcome;
 }
 
 std::optional<prefix_range_inclusive>

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -45,8 +45,8 @@ class level_zero_gc::list_delete_worker {
 
 public:
     explicit list_delete_worker(
-      std::unique_ptr<object_storage> storage,
-      std::unique_ptr<node_info> node_info,
+      std::unique_ptr<l0::gc::object_storage> storage,
+      std::unique_ptr<l0::gc::node_info> node_info,
       level_zero_gc_probe& probe)
       : storage_(std::move(storage))
       , node_info_(std::move(node_info))
@@ -259,8 +259,8 @@ private:
         co_return std::move(objects.contents);
     }
 
-    std::unique_ptr<object_storage> storage_;
-    std::unique_ptr<node_info> node_info_;
+    std::unique_ptr<l0::gc::object_storage> storage_;
+    std::unique_ptr<l0::gc::node_info> node_info_;
     level_zero_gc_probe* probe_;
     std::unique_ptr<ssx::work_queue> worker_;
     // TODO: configurable limits?
@@ -276,7 +276,7 @@ private:
     prefix_compressor key_prefixes_;
 };
 
-class object_storage_remote_impl : public level_zero_gc::object_storage {
+class object_storage_remote_impl : public l0::gc::object_storage {
 public:
     // TODO(noah) some random-but-not-awful values for the retry chain that
     // cloud io requires. will need to be fine tuned at some point.
@@ -336,7 +336,7 @@ private:
 };
 
 seastar::future<std::expected<std::optional<cluster_epoch>, std::string>>
-level_zero_gc::epoch_source::max_gc_eligible_epoch(seastar::abort_source* as) {
+l0::gc::epoch_source::max_gc_eligible_epoch(seastar::abort_source* as) {
     /*
      * First retrieve a consistent snapshot of cloud topic partitions. This
      * establishes a set of partitions from which we must obtain an epoch
@@ -415,7 +415,7 @@ level_zero_gc::epoch_source::max_gc_eligible_epoch(seastar::abort_source* as) {
     co_return result;
 }
 
-class epoch_source_impl : public level_zero_gc::epoch_source {
+class epoch_source_impl : public l0::gc::epoch_source {
 public:
     explicit epoch_source_impl(
       seastar::sharded<cluster::health_monitor_frontend>* health_monitor,
@@ -589,7 +589,7 @@ private:
     seastar::sharded<cluster::topic_table>* topic_table_;
 };
 
-class node_info_impl : public level_zero_gc::node_info {
+class node_info_impl : public l0::gc::node_info {
 public:
     node_info_impl(
       model::node_id self, seastar::sharded<cluster::members_table>* mt)
@@ -617,7 +617,7 @@ private:
     seastar::sharded<cluster::members_table>* members_table_;
 };
 
-class cluster_safety_monitor : public level_zero_gc::safety_monitor {
+class cluster_safety_monitor : public l0::gc::safety_monitor {
 public:
     explicit cluster_safety_monitor(
       seastar::sharded<cluster::health_monitor_frontend>* health_monitor,
@@ -686,10 +686,10 @@ private:
 
 level_zero_gc::level_zero_gc(
   level_zero_gc_config config,
-  std::unique_ptr<object_storage> storage,
-  std::unique_ptr<epoch_source> epoch_source,
-  std::unique_ptr<node_info> node_info,
-  std::unique_ptr<safety_monitor> safety_monitor)
+  std::unique_ptr<l0::gc::object_storage> storage,
+  std::unique_ptr<l0::gc::epoch_source> epoch_source,
+  std::unique_ptr<l0::gc::node_info> node_info,
+  std::unique_ptr<l0::gc::safety_monitor> safety_monitor)
   : config_(std::move(config))
   , epoch_source_(std::move(epoch_source))
   , safety_monitor_(std::move(safety_monitor))
@@ -796,54 +796,53 @@ seastar::future<> level_zero_gc::reset() {
     }
 }
 
-std::string_view to_string_view(level_zero_gc::state s) {
+namespace l0::gc {
+
+std::string_view to_string_view(state s) {
     switch (s) {
-        using enum level_zero_gc::state;
+        using enum state;
     case paused:
-        return "level_zero_gc::state::paused";
+        return "l0_gc_state::paused";
     case running:
-        return "level_zero_gc::state::running";
+        return "l0_gc_state::running";
     case resetting:
-        return "level_zero_gc::state::resetting";
+        return "l0_gc_state::resetting";
     case stopping:
-        return "level_zero_gc::state::stopping";
+        return "l0_gc_state::stopping";
     case stopped:
-        return "level_zero_gc::state::stopped";
+        return "l0_gc_state::stopped";
     case safety_blocked:
-        return "level_zero_gc::state::safety_blocked";
+        return "l0_gc_state::safety_blocked";
     }
     vunreachable("Unrecognized GC state: {}", s);
 }
 
-auto format_as(level_zero_gc::state s) { return to_string_view(s); }
+auto format_as(state s) { return to_string_view(s); }
 
-auto level_zero_gc::get_state() const -> state {
+} // namespace l0::gc
+
+l0::gc::state level_zero_gc::get_state() const {
     auto st = [this] {
         if (should_shutdown_) {
-            return worker_.available() ? state::stopped : state::stopping;
+            return worker_.available() ? l0::gc::state::stopped
+                                       : l0::gc::state::stopping;
         }
         if (resetting_) {
-            return state::resetting;
+            return l0::gc::state::resetting;
         }
         if (!should_run_) {
-            return state::paused;
+            return l0::gc::state::paused;
         }
-        return safety_monitor_->can_proceed().ok ? state::running
-                                                 : state::safety_blocked;
+        return safety_monitor_->can_proceed().ok
+                 ? l0::gc::state::running
+                 : l0::gc::state::safety_blocked;
     }();
     vlog(cd_log.debug, "cloud_topics L0 GC worker state: {}", st);
     return st;
 }
 
-// internal error codes used between the worker fiber and the main GC function
-enum class level_zero_gc::collection_error : int8_t {
-    // problem occurred interacting with the storage or epoch services
-    service_error,
-    // the cluster is reporting that no collectible epoch exists
-    no_collectible_epoch,
-    // object listing contained an invalid object name
-    invalid_object_name,
-};
+// The collection_error enum is defined in level_zero_gc_types.h as
+// l0::gc::collection_error.
 
 seastar::future<> level_zero_gc::worker() {
     std::chrono::milliseconds backoff{0};
@@ -897,9 +896,9 @@ seastar::future<> level_zero_gc::worker() {
                 }
             } else {
                 switch (res.error()) {
-                case collection_error::service_error:
-                case collection_error::invalid_object_name:
-                case collection_error::no_collectible_epoch:
+                case l0::gc::collection_error::service_error:
+                case l0::gc::collection_error::invalid_object_name:
+                case l0::gc::collection_error::no_collectible_epoch:
                     backoff = config_.throttle_no_progress();
                 }
             }
@@ -916,7 +915,7 @@ seastar::future<> level_zero_gc::worker() {
     vlog(cd_log.info, "Level zero GC worker is exiting");
 }
 
-seastar::future<std::expected<size_t, level_zero_gc::collection_error>>
+seastar::future<std::expected<size_t, l0::gc::collection_error>>
 level_zero_gc::try_to_collect() {
     // Ultra-temporary cache to avoid repeatedly querying for max gc-able epoch.
     // Since the result will always be valid clusterwide, compute exactly once
@@ -939,7 +938,7 @@ level_zero_gc::try_to_collect() {
     co_return total_eligible;
 }
 
-seastar::future<std::expected<size_t, level_zero_gc::collection_error>>
+seastar::future<std::expected<size_t, l0::gc::collection_error>>
 level_zero_gc::do_try_to_collect(std::optional<cluster_epoch>& max_gc_epoch) {
     auto candidate_objects = co_await delete_worker_->next_page();
     if (!candidate_objects.has_value()) {
@@ -947,7 +946,7 @@ level_zero_gc::do_try_to_collect(std::optional<cluster_epoch>& max_gc_epoch) {
           cd_log.debug,
           "Received error listing objects during L0 GC: {}",
           candidate_objects.error());
-        co_return std::unexpected(collection_error::service_error);
+        co_return std::unexpected(l0::gc::collection_error::service_error);
     }
 
     if (!max_gc_epoch.has_value()) {
@@ -958,14 +957,15 @@ level_zero_gc::do_try_to_collect(std::optional<cluster_epoch>& max_gc_epoch) {
               cd_log.debug,
               "Received error retrieving GC eligible epoch: {}",
               maybe_max_gc_epoch.error());
-            co_return std::unexpected(collection_error::service_error);
+            co_return std::unexpected(l0::gc::collection_error::service_error);
         }
         max_gc_epoch = maybe_max_gc_epoch.value();
     }
 
     if (!max_gc_epoch.has_value()) {
         vlog(cd_log.info, "No GC eligible epoch currently exists");
-        co_return std::unexpected(collection_error::no_collectible_epoch);
+        co_return std::unexpected(
+          l0::gc::collection_error::no_collectible_epoch);
     }
     probe_.set_max_gc_eligible_epoch(max_gc_epoch.value());
 
@@ -999,7 +999,8 @@ level_zero_gc::do_try_to_collect(std::optional<cluster_epoch>& max_gc_epoch) {
               cd_log.error,
               "Unable to parse epoch during L0 GC: {}",
               object_epoch.error());
-            co_return std::unexpected(collection_error::invalid_object_name);
+            co_return std::unexpected(
+              l0::gc::collection_error::invalid_object_name);
         }
 
         const auto object_pfx = object_path_factory::level_zero_path_to_prefix(
@@ -1010,7 +1011,8 @@ level_zero_gc::do_try_to_collect(std::optional<cluster_epoch>& max_gc_epoch) {
               cd_log.error,
               "Unable to parse prefix during L0 GC: {}",
               object_pfx.error());
-            co_return std::unexpected(collection_error::invalid_object_name);
+            co_return std::unexpected(
+              l0::gc::collection_error::invalid_object_name);
         }
 
         // detect non-lexicographic ordering. this may indicate that GC will

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -20,6 +20,7 @@
 #include "cluster/members_table.h"
 #include "cluster/topic_table.h"
 #include "config/configuration.h"
+#include "random/simple_time_jitter.h"
 #include "ssx/semaphore.h"
 #include "ssx/work_queue.h"
 
@@ -30,6 +31,7 @@
 #include <seastar/core/sleep.hh>
 #include <seastar/coroutine/as_future.hh>
 
+#include <chrono>
 #include <memory>
 
 namespace {
@@ -692,10 +694,12 @@ level_zero_gc_t<Clock>::level_zero_gc_t(
   std::unique_ptr<l0::gc::object_storage> storage,
   std::unique_ptr<l0::gc::epoch_source> epoch_source,
   std::unique_ptr<l0::gc::node_info> node_info,
-  std::unique_ptr<l0::gc::safety_monitor> safety_monitor)
+  std::unique_ptr<l0::gc::safety_monitor> safety_monitor,
+  jitter_fn fn)
   : config_(std::move(config))
   , epoch_source_(std::move(epoch_source))
   , safety_monitor_(std::move(safety_monitor))
+  , jitter_fn_(std::move(fn))
   , should_run_(false) // begin in a stopped state
   , should_shutdown_(false)
   , worker_(worker())
@@ -887,7 +891,7 @@ l0::gc::state level_zero_gc_t<Clock>::get_state() const {
 
 template<class Clock>
 seastar::future<> level_zero_gc_t<Clock>::worker() {
-    std::chrono::milliseconds backoff{0};
+    typename Clock::duration backoff{0ms};
 
     // Abort the backoff sleep when the grace period changes so we
     // recalculate how long to sleep. Without this, a reduction in
@@ -972,6 +976,10 @@ seastar::future<> level_zero_gc_t<Clock>::worker() {
                 }
             }
 
+            if (backoff > 0ms) {
+                backoff += jitter_fn_(backoff);
+            }
+
         } catch (...) {
             vlog(
               cd_log.info,
@@ -1003,6 +1011,12 @@ level_zero_gc_t<Clock>::try_to_collect() {
         co_return l0::gc::collection_outcome(at_capacity);
     }
 
+    // Jitter inter-page sleeps to avoid tight LIST cadence against
+    // the object store. +[0, 10%) of throttle_progress.
+    simple_time_jitter<Clock> page_jitter(
+      config_.throttle_progress(),
+      std::max(config_.throttle_progress() / 10, 1ms));
+
     while (delete_worker_->has_capacity()) {
         ++pages_scanned;
         auto res = co_await do_try_to_collect(std::ref(max_gc_epoch));
@@ -1027,7 +1041,7 @@ level_zero_gc_t<Clock>::try_to_collect() {
             }
             (co_await seastar::coroutine::as_future(
                seastar::sleep_abortable<Clock>(
-                 config_.throttle_progress(), asrc_)))
+                 page_jitter.next_duration(), asrc_)))
               .ignore_ready_future();
             if (asrc_.abort_requested()) {
                 break;

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -231,6 +231,7 @@ private:
           curr_prefix_);
         // cached continuation is single use. pass it to list_objects and
         // null it out immediately.
+        probe_->list_request();
         auto list_result = co_await storage_->list_objects(
           &as_, curr_prefix_, std::exchange(continuation_token_, std::nullopt));
         if (!list_result.has_value()) {

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -25,6 +25,7 @@
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/gate.hh>
+#include <seastar/core/manual_clock.hh>
 #include <seastar/core/shard_id.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/coroutine/as_future.hh>
@@ -38,7 +39,8 @@ constexpr ss::lowres_clock::duration health_report_query_timeout = 10s;
 
 namespace cloud_topics {
 
-class level_zero_gc::list_delete_worker {
+template<class Clock>
+class level_zero_gc_t<Clock>::list_delete_worker {
     static constexpr auto handle_worker_exc = [](std::exception_ptr eptr) {
         vlog(cd_log.warn, "Exception from delete worker: {}", eptr);
     };
@@ -224,7 +226,7 @@ private:
     seastar::future<std::expected<
       chunked_vector<cloud_storage_clients::client::list_bucket_item>,
       cloud_storage_clients::error_outcome>>
-    do_next_page(const cloud_storage_clients::object_key& prefix) {
+    do_next_page(const cloud_storage_clients::object_key&) {
         vlog(
           cd_log.trace,
           "list_delete_worker: Processing key prefix {}",
@@ -684,7 +686,8 @@ private:
     seastar::future<> poll_loop_;
 };
 
-level_zero_gc::level_zero_gc(
+template<class Clock>
+level_zero_gc_t<Clock>::level_zero_gc_t(
   level_zero_gc_config config,
   std::unique_ptr<l0::gc::object_storage> storage,
   std::unique_ptr<l0::gc::epoch_source> epoch_source,
@@ -703,7 +706,8 @@ level_zero_gc::level_zero_gc(
     epoch_source_->set_probe(&probe_);
 }
 
-level_zero_gc::level_zero_gc(
+template<>
+level_zero_gc_t<ss::lowres_clock>::level_zero_gc_t(
   model::node_id self,
   cloud_io::remote* remote,
   cloud_storage_clients::bucket_name bucket,
@@ -711,7 +715,7 @@ level_zero_gc::level_zero_gc(
   seastar::sharded<cluster::controller_stm>* controller_stm,
   seastar::sharded<cluster::topic_table>* topic_table,
   seastar::sharded<cluster::members_table>* members_table)
-  : level_zero_gc(
+  : level_zero_gc_t(
       level_zero_gc_config{
         .deletion_grace_period
         = config::shard_local_cfg()
@@ -731,9 +735,11 @@ level_zero_gc::level_zero_gc(
         config::shard_local_cfg()
           .cloud_topics_gc_health_check_interval.bind())) {}
 
-level_zero_gc::~level_zero_gc() = default;
+template<class Clock>
+level_zero_gc_t<Clock>::~level_zero_gc_t() = default;
 
-seastar::future<> level_zero_gc::start() {
+template<class Clock>
+seastar::future<> level_zero_gc_t<Clock>::start() {
     while (resetting_) {
         co_await reset_cv_.wait(
           control_timeout, [this] { return !resetting_; });
@@ -748,7 +754,8 @@ seastar::future<> level_zero_gc::start() {
     worker_cv_.signal();
 }
 
-seastar::future<> level_zero_gc::pause() {
+template<class Clock>
+seastar::future<> level_zero_gc_t<Clock>::pause() {
     while (resetting_) {
         co_await reset_cv_.wait(
           control_timeout, [this] { return !resetting_; });
@@ -760,7 +767,8 @@ seastar::future<> level_zero_gc::pause() {
     delete_worker_->pause();
 }
 
-seastar::future<> level_zero_gc::stop() {
+template<class Clock>
+seastar::future<> level_zero_gc_t<Clock>::stop() {
     vlog(cd_log.info, "Stopping cloud topics L0 GC worker");
     should_shutdown_ = true;
     asrc_.request_abort();
@@ -772,7 +780,8 @@ seastar::future<> level_zero_gc::stop() {
     vlog(cd_log.info, "Stopped cloud_topics L0 GC worker");
 }
 
-seastar::future<> level_zero_gc::reset() {
+template<class Clock>
+seastar::future<> level_zero_gc_t<Clock>::reset() {
     if (should_shutdown_ || resetting_) {
         co_return;
     }
@@ -852,7 +861,8 @@ fmt::iterator collection_outcome::format_to(fmt::iterator it) const {
 
 } // namespace l0::gc
 
-l0::gc::state level_zero_gc::get_state() const {
+template<class Clock>
+l0::gc::state level_zero_gc_t<Clock>::get_state() const {
     auto st = [this] {
         if (should_shutdown_) {
             return worker_.available() ? l0::gc::state::stopped
@@ -875,7 +885,8 @@ l0::gc::state level_zero_gc::get_state() const {
 // The collection_error enum is defined in level_zero_gc_types.h as
 // l0::gc::collection_error.
 
-seastar::future<> level_zero_gc::worker() {
+template<class Clock>
+seastar::future<> level_zero_gc_t<Clock>::worker() {
     std::chrono::milliseconds backoff{0};
 
     // Abort the backoff sleep when the grace period changes so we
@@ -906,7 +917,7 @@ seastar::future<> level_zero_gc::worker() {
                   safety.reason.value_or("unknown"));
                 probe_.safety_blocked();
                 (co_await seastar::coroutine::as_future(
-                   seastar::sleep_abortable(
+                   seastar::sleep_abortable<Clock>(
                      config_.throttle_no_progress(), asrc_)))
                   .ignore_ready_future();
                 continue;
@@ -916,18 +927,18 @@ seastar::future<> level_zero_gc::worker() {
                 backoff = std::chrono::milliseconds{0};
             }
             if (backoff.count() > 0) {
-                auto t0 = ss::lowres_clock::now();
+                auto t0 = Clock::now();
                 // Use a dedicated abort source for the backoff sleep so
                 // that config changes (grace period watcher) and state
                 // changes (pause/stop/reset) can wake us without aborting
                 // asrc_, which is reserved for cancelling in-flight
                 // service calls.
                 (co_await seastar::coroutine::as_future(
-                   seastar::sleep_abortable(backoff, backoff_asrc_)))
+                   seastar::sleep_abortable<Clock>(backoff, backoff_asrc_)))
                   .ignore_ready_future();
                 auto elapsed
                   = std::chrono::duration_cast<std::chrono::milliseconds>(
-                    ss::lowres_clock::now() - t0);
+                    Clock::now() - t0);
                 probe_.add_backpressure(
                   static_cast<double>(elapsed.count()) / 1000.0);
                 backoff = std::chrono::seconds{0};
@@ -973,9 +984,10 @@ seastar::future<> level_zero_gc::worker() {
     vlog(cd_log.info, "Level zero GC worker is exiting");
 }
 
+template<class Clock>
 seastar::future<
   std::expected<l0::gc::collection_outcome, l0::gc::collection_error>>
-level_zero_gc::try_to_collect() {
+level_zero_gc_t<Clock>::try_to_collect() {
     using enum l0::gc::collection_outcome::status;
 
     // Ultra-temporary cache to avoid repeatedly querying for max gc-able epoch.
@@ -1014,7 +1026,8 @@ level_zero_gc::try_to_collect() {
                 break;
             }
             (co_await seastar::coroutine::as_future(
-               seastar::sleep_abortable(config_.throttle_progress(), asrc_)))
+               seastar::sleep_abortable<Clock>(
+                 config_.throttle_progress(), asrc_)))
               .ignore_ready_future();
             if (asrc_.abort_requested()) {
                 break;
@@ -1030,10 +1043,12 @@ level_zero_gc::try_to_collect() {
     co_return outcome;
 }
 
+template<class Clock>
 seastar::future<std::expected<
   std::optional<l0::gc::collection_outcome>,
   l0::gc::collection_error>>
-level_zero_gc::do_try_to_collect(std::optional<cluster_epoch>& max_gc_epoch) {
+level_zero_gc_t<Clock>::do_try_to_collect(
+  std::optional<cluster_epoch>& max_gc_epoch) {
     using enum l0::gc::collection_outcome::status;
     auto candidate_objects = co_await delete_worker_->next_page();
     if (!candidate_objects.has_value()) {
@@ -1207,5 +1222,8 @@ compute_prefix_range(size_t shard_idx, size_t total_shards) {
 
     return prefix_range_inclusive{min, max};
 }
+
+template class level_zero_gc_t<ss::lowres_clock>;
+template class level_zero_gc_t<ss::manual_clock>;
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
@@ -262,6 +262,9 @@ public:
     l0::gc::state get_state() const;
 
 private:
+    seastar::condition_variable worker_cv_;
+    seastar::condition_variable reset_cv_;
+
     level_zero_gc_config config_;
     std::unique_ptr<l0::gc::epoch_source> epoch_source_;
     std::unique_ptr<l0::gc::safety_monitor> safety_monitor_;
@@ -270,20 +273,27 @@ private:
     bool should_shutdown_;
     bool resetting_{false};
     seastar::abort_source asrc_;
-    seastar::condition_variable worker_cv_;
+    seastar::abort_source backoff_asrc_;
     seastar::future<> worker_;
-    seastar::condition_variable reset_cv_;
 
     seastar::future<> worker();
 
-    seastar::future<std::expected<size_t, l0::gc::collection_error>>
+    seastar::future<
+      std::expected<l0::gc::collection_outcome, l0::gc::collection_error>>
     try_to_collect();
 
-    /// Returns eligible count, or nullopt when all prefixes are exhausted.
-    seastar::future<std::expected<size_t, l0::gc::collection_error>>
+    /// Returns per-page outcome, or nullopt when all prefixes are exhausted.
+    seastar::future<std::expected<
+      std::optional<l0::gc::collection_outcome>,
+      l0::gc::collection_error>>
     do_try_to_collect(std::optional<cluster_epoch>&);
 
     level_zero_gc_probe probe_;
+
+    /// Set by start() and reset() to force the worker to skip its next
+    /// backoff sleep so the first round after a state change runs
+    /// immediately.
+    bool skip_backoff_{false};
 
     class list_delete_worker;
     std::unique_ptr<list_delete_worker> delete_worker_{};

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
@@ -11,11 +11,13 @@
 
 #include "cloud_topics/level_zero/gc/level_zero_gc_probe.h"
 #include "cloud_topics/level_zero/gc/level_zero_gc_types.h"
+#include "random/generators.h"
 
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/sharded.hh>
+#include <seastar/util/noncopyable_function.hh>
 
 #include <expected>
 
@@ -211,6 +213,22 @@ struct level_zero_gc_config {
 template<class Clock = ss::lowres_clock>
 class level_zero_gc_t {
 public:
+    using jitter_fn = ss::noncopyable_function<typename Clock::duration(
+      typename Clock::duration)>;
+
+    // Add positive jitter to despread wake times across
+    // shards. +[0, 10%] of the computed backoff.
+    static constexpr auto default_jitter =
+      [](Clock::duration base) -> Clock::duration {
+        using namespace std::chrono_literals;
+        // 2m is sort of arbitrary here with the aim of roughly staggering GC
+        // wakeups. "longer than a collection round but much shorter than a
+        // grace period"
+        constexpr typename Clock::duration max_jitter{120s};
+        auto ub = std::min(base / 10, max_jitter);
+        return std::chrono::milliseconds{random_generators::get_int(ub / 1ms)};
+    };
+
     /*
      * Construct with the given storage and epoch providers. This interface is
      * intended to be used by tests which swap in mock implementations.
@@ -220,7 +238,8 @@ public:
       std::unique_ptr<l0::gc::object_storage>,
       std::unique_ptr<l0::gc::epoch_source>,
       std::unique_ptr<l0::gc::node_info>,
-      std::unique_ptr<l0::gc::safety_monitor>);
+      std::unique_ptr<l0::gc::safety_monitor>,
+      jitter_fn = default_jitter);
 
     /*
      * Construct with default implementations of storage and epoch providers.
@@ -270,6 +289,7 @@ private:
     level_zero_gc_config config_;
     std::unique_ptr<l0::gc::epoch_source> epoch_source_;
     std::unique_ptr<l0::gc::safety_monitor> safety_monitor_;
+    jitter_fn jitter_fn_;
 
     bool should_run_;
     bool should_shutdown_;

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
@@ -9,12 +9,8 @@
  */
 #pragma once
 
-#include "cloud_io/io_result.h"
-#include "cloud_storage_clients/client.h"
-#include "cloud_storage_clients/types.h"
 #include "cloud_topics/level_zero/gc/level_zero_gc_probe.h"
-#include "cloud_topics/types.h"
-#include "container/chunked_hash_map.h"
+#include "cloud_topics/level_zero/gc/level_zero_gc_types.h"
 
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/future.hh>
@@ -214,151 +210,15 @@ struct level_zero_gc_config {
 class level_zero_gc {
 public:
     /*
-     * Object storage interface used by L0 GC.
-     */
-    class object_storage {
-    public:
-        object_storage() = default;
-        object_storage(const object_storage&) = delete;
-        object_storage(object_storage&&) = delete;
-        object_storage& operator=(const object_storage&) = delete;
-        object_storage& operator=(object_storage&&) = delete;
-        virtual ~object_storage() = default;
-
-        /*
-         * Implementations are expected to limit the listing to only L0 data
-         * objects, and provide the listing in _globally_ lexicographic order.
-         */
-        virtual seastar::future<std::expected<
-          cloud_storage_clients::client::list_bucket_result,
-          cloud_storage_clients::error_outcome>>
-        list_objects(
-          seastar::abort_source*,
-          std::optional<cloud_storage_clients::object_key> prefix
-          = std::nullopt,
-          std::optional<ss::sstring> continuation_token = std::nullopt)
-          = 0;
-
-        virtual seastar::future<std::expected<void, cloud_io::upload_result>>
-        delete_objects(
-          seastar::abort_source*,
-          chunked_vector<cloud_storage_clients::client::list_bucket_item>)
-          = 0;
-    };
-
-    /*
-     * Interface for computing the maximum epoch eligible for GC.
-     */
-    class epoch_source {
-    public:
-        struct partitions_snapshot {
-            using partition_map = chunked_hash_map<
-              model::topic_namespace,
-              chunked_vector<model::partition_id>,
-              model::topic_namespace_hash,
-              model::topic_namespace_eq>;
-
-            partition_map partitions;
-            cluster_epoch snap_revision;
-        };
-
-        using partitions_max_gc_epoch = chunked_hash_map<
-          model::topic_namespace,
-          chunked_hash_map<model::partition_id, cluster_epoch>,
-          model::topic_namespace_hash,
-          model::topic_namespace_eq>;
-
-        epoch_source() = default;
-        epoch_source(const epoch_source&) = default;
-        epoch_source(epoch_source&&) = delete;
-        epoch_source& operator=(const epoch_source&) = default;
-        epoch_source& operator=(epoch_source&&) = delete;
-        virtual ~epoch_source() = default;
-
-        void set_probe(level_zero_gc_probe* p) { probe_ = p; }
-
-        /*
-         * L0 objects with epochs <= the return value may be deleted. An
-         * expected return value of std::nullopt is not an error, but rather
-         * indicates that no GC eligible epoch could yet be determined.
-         */
-        virtual seastar::future<
-          std::expected<std::optional<cluster_epoch>, std::string>>
-        max_gc_eligible_epoch(seastar::abort_source*);
-
-        /*
-         * Snapshot of existing cloud topic partition identifiers along with the
-         * maximum possible GC eligible epoch for the set of partitions.
-         */
-        virtual seastar::future<std::expected<partitions_snapshot, std::string>>
-        get_partitions(seastar::abort_source*) = 0;
-
-        /*
-         * Reported max GC eligible epochs for cloud topic partitions.
-         */
-        virtual seastar::future<
-          std::expected<partitions_max_gc_epoch, std::string>>
-        get_partitions_max_gc_epoch(seastar::abort_source*) = 0;
-
-    protected:
-        level_zero_gc_probe* probe_{nullptr};
-    };
-
-    /**
-     * Interface for determining the total number of shards in the cluster
-     * and the current shard's position in logical, ordered list of shard IDs
-     * starting at 0 (node 0, shard 0) and ending at total_shards - 1.
-     */
-    struct node_info {
-        node_info() = default;
-        node_info(const node_info&) = default;
-        node_info(node_info&&) = delete;
-        node_info& operator=(const node_info&) = default;
-        node_info& operator=(node_info&&) = delete;
-        virtual ~node_info() = default;
-
-        virtual size_t shard_index() const = 0;
-        virtual size_t total_shards() const = 0;
-    };
-
-    /// Interface for gating GC on system-level safety conditions.
-    ///
-    /// Production implementations poll external signals (e.g. cluster health)
-    /// in a background fiber and cache the result so that can_proceed() is
-    /// synchronous and cheap. This is orthogonal to admin pause/start — even
-    /// if an operator calls start(), GC will not proceed while the safety
-    /// monitor reports not-ok.
-    class safety_monitor {
-    public:
-        safety_monitor() = default;
-        safety_monitor(const safety_monitor&) = delete;
-        safety_monitor(safety_monitor&&) = delete;
-        safety_monitor& operator=(const safety_monitor&) = delete;
-        safety_monitor& operator=(safety_monitor&&) = delete;
-        virtual ~safety_monitor() = default;
-
-        struct result {
-            bool ok;
-            std::optional<ss::sstring> reason;
-        };
-
-        virtual result can_proceed() const = 0;
-
-        virtual void start() {}
-        virtual seastar::future<> stop() { return seastar::now(); }
-    };
-
-public:
-    /*
      * Construct with the given storage and epoch providers. This interface is
      * intended to be used by tests which swap in mock implementations.
      */
     level_zero_gc(
       level_zero_gc_config,
-      std::unique_ptr<object_storage>,
-      std::unique_ptr<epoch_source>,
-      std::unique_ptr<node_info>,
-      std::unique_ptr<safety_monitor>);
+      std::unique_ptr<l0::gc::object_storage>,
+      std::unique_ptr<l0::gc::epoch_source>,
+      std::unique_ptr<l0::gc::node_info>,
+      std::unique_ptr<l0::gc::safety_monitor>);
 
     /*
      * Construct with default implementations of storage and epoch providers.
@@ -397,34 +257,14 @@ public:
     seastar::future<> stop();
 
     /**
-     * @brief Shard-local state for an instance of level_zero_gc
-     *
-     *   - paused: Paused indefinitely, call start() to run
-     *   - running: GC will run until paused or stopped
-     *   - resetting: reset() is draining in-flight work
-     *   - stopping: stop() requested but there may be work still in flight
-     *   - stopped: Permanently stopped.
-     *   - safety_blocked: GC is started but the safety monitor is preventing
-     *     collection (e.g. cluster unhealthy)
-     */
-    enum class state : uint8_t {
-        paused,
-        running,
-        resetting,
-        stopping,
-        stopped,
-        safety_blocked,
-    };
-
-    /**
      * @brief Compute the runtime state of this GC instance.
      */
-    state get_state() const;
+    l0::gc::state get_state() const;
 
 private:
     level_zero_gc_config config_;
-    std::unique_ptr<epoch_source> epoch_source_;
-    std::unique_ptr<safety_monitor> safety_monitor_;
+    std::unique_ptr<l0::gc::epoch_source> epoch_source_;
+    std::unique_ptr<l0::gc::safety_monitor> safety_monitor_;
 
     bool should_run_;
     bool should_shutdown_;
@@ -435,9 +275,12 @@ private:
     seastar::condition_variable reset_cv_;
 
     seastar::future<> worker();
-    enum class collection_error : int8_t;
-    seastar::future<std::expected<size_t, collection_error>> try_to_collect();
-    seastar::future<std::expected<size_t, collection_error>>
+
+    seastar::future<std::expected<size_t, l0::gc::collection_error>>
+    try_to_collect();
+
+    /// Returns eligible count, or nullopt when all prefixes are exhausted.
+    seastar::future<std::expected<size_t, l0::gc::collection_error>>
     do_try_to_collect(std::optional<cluster_epoch>&);
 
     level_zero_gc_probe probe_;
@@ -466,7 +309,5 @@ private:
 struct prefix_range_inclusive;
 std::optional<prefix_range_inclusive>
 compute_prefix_range(size_t shard_idx, size_t total_shards);
-
-std::string_view to_string_view(level_zero_gc::state s);
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
@@ -14,6 +14,7 @@
 
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/lowres_clock.hh>
 #include <seastar/core/sharded.hh>
 
 #include <expected>
@@ -207,13 +208,14 @@ struct level_zero_gc_config {
  *
  *  start()/pause() block while resetting_ is true.
  */
-class level_zero_gc {
+template<class Clock = ss::lowres_clock>
+class level_zero_gc_t {
 public:
     /*
      * Construct with the given storage and epoch providers. This interface is
      * intended to be used by tests which swap in mock implementations.
      */
-    level_zero_gc(
+    level_zero_gc_t(
       level_zero_gc_config,
       std::unique_ptr<l0::gc::object_storage>,
       std::unique_ptr<l0::gc::epoch_source>,
@@ -223,7 +225,7 @@ public:
     /*
      * Construct with default implementations of storage and epoch providers.
      */
-    level_zero_gc(
+    level_zero_gc_t(
       model::node_id,
       cloud_io::remote*,
       cloud_storage_clients::bucket_name,
@@ -232,7 +234,7 @@ public:
       seastar::sharded<cluster::topic_table>*,
       seastar::sharded<cluster::members_table>*);
 
-    ~level_zero_gc();
+    ~level_zero_gc_t();
 
     /*
      * Request that GC be started or paused. These can be called multiple times
@@ -298,6 +300,8 @@ private:
     class list_delete_worker;
     std::unique_ptr<list_delete_worker> delete_worker_{};
 };
+
+using level_zero_gc = level_zero_gc_t<>;
 
 /**
  * @brief Compute a subrange of [0,999] for some shard.

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc_probe.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc_probe.cc
@@ -77,6 +77,13 @@ void level_zero_gc_probe::setup_internal_metrics(bool disable) {
             "collection."),
           labels),
         sm::make_counter(
+          "list_requests_total",
+          [this] { return list_requests_; },
+          sm::description(
+            "Number of LIST API calls to object storage by L0 garbage "
+            "collection."),
+          labels),
+        sm::make_counter(
           "list_errors_total",
           [this] { return list_errors_; },
           sm::description(

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc_probe.h
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc_probe.h
@@ -30,6 +30,7 @@ public:
     void object_skipped_too_young() { objects_skipped_too_young_++; }
     void collection_round() { collection_rounds_++; }
     void delete_request() { delete_requests_++; }
+    void list_request() { list_requests_++; }
     void list_error() { list_errors_++; }
     void delete_error() { delete_errors_++; }
     void add_backpressure(double seconds) { backpressure_seconds_ += seconds; }
@@ -57,6 +58,7 @@ private:
     uint64_t objects_skipped_too_young_{0};
     uint64_t collection_rounds_{0};
     uint64_t delete_requests_{0};
+    uint64_t list_requests_{0};
     uint64_t list_errors_{0};
     uint64_t delete_errors_{0};
     double backpressure_seconds_{0};

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc_types.h
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc_types.h
@@ -9,6 +9,7 @@
  */
 #pragma once
 
+#include "base/format_to.h"
 #include "cloud_io/io_result.h"
 #include "cloud_storage_clients/client.h"
 #include "cloud_storage_clients/types.h"
@@ -157,6 +158,106 @@ public:
     virtual seastar::future<> stop() { return seastar::now(); }
 };
 
+/// Outcome of a collection round, used by the worker to decide
+/// how long to sleep before the next round.
+struct collection_outcome {
+    enum class status : int8_t {
+        /// Deleted objects — poll at throttle_progress.
+        progress,
+        /// Objects skipped because their epoch exceeds the
+        /// collectible epoch — poll at throttle_no_progress.
+        epoch_ineligible,
+        /// Objects skipped because they are too young —
+        /// sleep until the oldest one ages past the grace period.
+        age_ineligible,
+        /// No objects listed (empty storage or all deleted) —
+        /// sleep for the full grace period.
+        empty,
+        /// Delete worker at capacity — poll at throttle_progress.
+        at_capacity,
+    };
+
+    status st;
+
+    explicit collection_outcome(status s)
+      : st(s) {}
+    size_t eligible() const { return eligible_; }
+
+    /// Record that objects were submitted for deletion. Progress
+    /// always takes precedence over any other status.
+    void add_eligible(size_t n) {
+        eligible_ += n;
+        if (eligible_ > 0) {
+            st = status::progress;
+        }
+    }
+
+    /// Record that an object was skipped because its epoch exceeds
+    /// the collectible epoch. Does not downgrade from progress.
+    void mark_epoch_ineligible() {
+        if (st != status::progress) {
+            st = status::epoch_ineligible;
+        }
+    }
+
+    /// Record that an object was skipped because it is younger
+    /// than the grace period. Tracks the oldest such object so
+    /// we can compute exactly when it becomes eligible.
+    /// Does not downgrade from progress or epoch_ineligible.
+    void
+    mark_age_ineligible(std::chrono::system_clock::time_point last_modified) {
+        if (
+          !oldest_ineligible_modified_.has_value()
+          || last_modified < oldest_ineligible_modified_.value()) {
+            oldest_ineligible_modified_ = last_modified;
+        }
+        if (st != status::progress && st != status::epoch_ineligible) {
+            st = status::age_ineligible;
+        }
+    }
+
+    /// Merge another page's outcome into this one.
+    void merge(const collection_outcome& other) {
+        add_eligible(other.eligible_);
+        if (other.oldest_ineligible_modified_.has_value()) {
+            mark_age_ineligible(other.oldest_ineligible_modified_.value());
+        }
+        if (other.st == status::epoch_ineligible) {
+            mark_epoch_ineligible();
+        }
+    }
+
+    /// Compute the backoff for the age_ineligible case: how long
+    /// until the oldest too-young object ages past the grace
+    /// period. Returns nullopt if the oldest_ineligible timestamp
+    /// is missing OR the object is already old enough (race or clock skew)
+    std::optional<std::chrono::milliseconds>
+    age_backoff(std::chrono::milliseconds grace_period) const {
+        return oldest_ineligible_modified_
+          .transform([grace_period](
+                       std::chrono::system_clock::time_point oldest_modified) {
+              return oldest_modified + grace_period;
+          })
+          .and_then(
+            [](std::chrono::system_clock::time_point wake_at)
+              -> std::optional<std::chrono::milliseconds> {
+                auto now = std::chrono::system_clock::now();
+                if (wake_at <= now) {
+                    return std::nullopt;
+                }
+                return std::chrono::duration_cast<std::chrono::milliseconds>(
+                  wake_at - now);
+            });
+    }
+
+    fmt::iterator format_to(fmt::iterator) const;
+
+private:
+    size_t eligible_{0};
+    std::optional<std::chrono::system_clock::time_point>
+      oldest_ineligible_modified_;
+};
+
 enum class collection_error : int8_t {
     // problem occurred interacting with the storage or epoch services
     service_error,
@@ -187,5 +288,6 @@ enum class state : uint8_t {
 };
 
 std::string_view to_string_view(state s);
+std::string_view to_string_view(collection_outcome::status s);
 
 } // namespace cloud_topics::l0::gc

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc_types.h
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc_types.h
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "cloud_io/io_result.h"
+#include "cloud_storage_clients/client.h"
+#include "cloud_storage_clients/types.h"
+#include "cloud_topics/level_zero/gc/level_zero_gc_probe.h"
+#include "cloud_topics/types.h"
+#include "container/chunked_hash_map.h"
+
+#include <seastar/core/future.hh>
+
+#include <chrono>
+#include <expected>
+#include <optional>
+
+namespace cloud_topics::l0::gc {
+
+/*
+ * Object storage interface used by L0 GC.
+ */
+class object_storage {
+public:
+    object_storage() = default;
+    object_storage(const object_storage&) = delete;
+    object_storage(object_storage&&) = delete;
+    object_storage& operator=(const object_storage&) = delete;
+    object_storage& operator=(object_storage&&) = delete;
+    virtual ~object_storage() = default;
+
+    /*
+     * Implementations are expected to limit the listing to only L0 data
+     * objects, and provide the listing in _globally_ lexicographic order.
+     */
+    virtual seastar::future<std::expected<
+      cloud_storage_clients::client::list_bucket_result,
+      cloud_storage_clients::error_outcome>>
+    list_objects(
+      seastar::abort_source*,
+      std::optional<cloud_storage_clients::object_key> prefix = std::nullopt,
+      std::optional<ss::sstring> continuation_token = std::nullopt)
+      = 0;
+
+    virtual seastar::future<std::expected<void, cloud_io::upload_result>>
+    delete_objects(
+      seastar::abort_source*,
+      chunked_vector<cloud_storage_clients::client::list_bucket_item>)
+      = 0;
+};
+
+/*
+ * Interface for computing the maximum epoch eligible for GC.
+ */
+class epoch_source {
+public:
+    struct partitions_snapshot {
+        using partition_map = chunked_hash_map<
+          model::topic_namespace,
+          chunked_vector<model::partition_id>,
+          model::topic_namespace_hash,
+          model::topic_namespace_eq>;
+
+        partition_map partitions;
+        cluster_epoch snap_revision;
+    };
+
+    using partitions_max_gc_epoch = chunked_hash_map<
+      model::topic_namespace,
+      chunked_hash_map<model::partition_id, cluster_epoch>,
+      model::topic_namespace_hash,
+      model::topic_namespace_eq>;
+
+    epoch_source() = default;
+    epoch_source(const epoch_source&) = default;
+    epoch_source(epoch_source&&) = delete;
+    epoch_source& operator=(const epoch_source&) = default;
+    epoch_source& operator=(epoch_source&&) = delete;
+    virtual ~epoch_source() = default;
+
+    void set_probe(level_zero_gc_probe* p) { probe_ = p; }
+
+    /*
+     * L0 objects with epochs <= the return value may be deleted. An
+     * expected return value of std::nullopt is not an error, but rather
+     * indicates that no GC eligible epoch could yet be determined.
+     */
+    virtual seastar::future<
+      std::expected<std::optional<cluster_epoch>, std::string>>
+    max_gc_eligible_epoch(seastar::abort_source*);
+
+    /*
+     * Snapshot of existing cloud topic partition identifiers along with the
+     * maximum possible GC eligible epoch for the set of partitions.
+     */
+    virtual seastar::future<std::expected<partitions_snapshot, std::string>>
+    get_partitions(seastar::abort_source*) = 0;
+
+    /*
+     * Reported max GC eligible epochs for cloud topic partitions.
+     */
+    virtual seastar::future<std::expected<partitions_max_gc_epoch, std::string>>
+    get_partitions_max_gc_epoch(seastar::abort_source*) = 0;
+
+protected:
+    level_zero_gc_probe* probe_{nullptr};
+};
+
+/**
+ * Interface for determining the total number of shards in the cluster
+ * and the current shard's position in logical, ordered list of shard IDs
+ * starting at 0 (node 0, shard 0) and ending at total_shards - 1.
+ */
+struct node_info {
+    node_info() = default;
+    node_info(const node_info&) = default;
+    node_info(node_info&&) = delete;
+    node_info& operator=(const node_info&) = default;
+    node_info& operator=(node_info&&) = delete;
+    virtual ~node_info() = default;
+
+    virtual size_t shard_index() const = 0;
+    virtual size_t total_shards() const = 0;
+};
+
+/// Interface for gating GC on system-level safety conditions.
+///
+/// Production implementations poll external signals (e.g. cluster health)
+/// in a background fiber and cache the result so that can_proceed() is
+/// synchronous and cheap. This is orthogonal to admin pause/start — even
+/// if an operator calls start(), GC will not proceed while the safety
+/// monitor reports not-ok.
+class safety_monitor {
+public:
+    safety_monitor() = default;
+    safety_monitor(const safety_monitor&) = delete;
+    safety_monitor(safety_monitor&&) = delete;
+    safety_monitor& operator=(const safety_monitor&) = delete;
+    safety_monitor& operator=(safety_monitor&&) = delete;
+    virtual ~safety_monitor() = default;
+
+    struct result {
+        bool ok;
+        std::optional<ss::sstring> reason;
+    };
+
+    virtual result can_proceed() const = 0;
+
+    virtual void start() {}
+    virtual seastar::future<> stop() { return seastar::now(); }
+};
+
+enum class collection_error : int8_t {
+    // problem occurred interacting with the storage or epoch services
+    service_error,
+    // the cluster is reporting that no collectible epoch exists
+    no_collectible_epoch,
+    // object listing contained an invalid object name
+    invalid_object_name,
+};
+
+/**
+ * @brief Shard-local state for an instance of level_zero_gc
+ *
+ *   - paused: Paused indefinitely, call start() to run
+ *   - running: GC will run until paused or stopped
+ *   - resetting: reset() is draining in-flight work
+ *   - stopping: stop() requested but there may be work still in flight
+ *   - stopped: Permanently stopped.
+ *   - safety_blocked: GC is started but the safety monitor is preventing
+ *     collection (e.g. cluster unhealthy)
+ */
+enum class state : uint8_t {
+    paused,
+    running,
+    resetting,
+    stopping,
+    stopped,
+    safety_blocked,
+};
+
+std::string_view to_string_view(state s);
+
+} // namespace cloud_topics::l0::gc

--- a/src/v/cloud_topics/level_zero/gc/tests/BUILD
+++ b/src/v/cloud_topics/level_zero/gc/tests/BUILD
@@ -9,6 +9,7 @@ redpanda_cc_gtest(
     deps = [
         "//src/v/cloud_topics:object_utils",
         "//src/v/cloud_topics/level_zero/gc:level_zero_gc",
+        "//src/v/config",
         "//src/v/ssx:mutex",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",

--- a/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_mt_test.cc
+++ b/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_mt_test.cc
@@ -57,7 +57,7 @@ struct shared_bucket_state {
  * Object storage mock that builds results locally on each shard.
  * Cross-shard calls are only used for tracking and atomic updates.
  */
-class mt_object_storage : public level_zero_gc::object_storage {
+class mt_object_storage : public l0::gc::object_storage {
 public:
     mt_object_storage(shared_bucket_state* bucket_state)
       : g_bucket_state(bucket_state) {}
@@ -135,7 +135,7 @@ public:
 /*
  * Epoch source that accesses the global shared state.
  */
-class mt_epoch_source : public level_zero_gc::epoch_source {
+class mt_epoch_source : public l0::gc::epoch_source {
 public:
     explicit mt_epoch_source(shared_bucket_state* bucket_state)
       : g_bucket_state(bucket_state) {}
@@ -165,14 +165,13 @@ public:
 /*
  * Node info that returns shard index based on the current Seastar shard.
  */
-class mt_node_info : public level_zero_gc::node_info {
+class mt_node_info : public l0::gc::node_info {
 public:
     size_t shard_index() const override { return ss::this_shard_id(); }
     size_t total_shards() const override { return ss::smp::count; }
 };
 
-class safety_monitor_test_impl
-  : public cloud_topics::level_zero_gc::safety_monitor {
+class safety_monitor_test_impl : public cloud_topics::l0::gc::safety_monitor {
 public:
     result can_proceed() const override {
         return {.ok = true, .reason = std::nullopt};

--- a/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
+++ b/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
@@ -231,7 +231,8 @@ public:
           std::move(storage),
           std::make_unique<epoch_source_test_impl>(&max_epoch),
           std::make_unique<node_info_test_impl>(),
-          std::make_unique<safety_monitor_test_impl>(&safety_ok));
+          std::make_unique<safety_monitor_test_impl>(&safety_ok),
+          [](ss::lowres_clock::duration) { return 0ms; });
     }
 
     void TearDown() override { gc->stop().get(); }
@@ -682,7 +683,8 @@ public:
           std::move(s),
           std::make_unique<epoch_source_test_impl>(&max_epoch),
           std::make_unique<node_info_test_impl>(),
-          std::make_unique<safety_monitor_test_impl>(&safety_ok));
+          std::make_unique<safety_monitor_test_impl>(&safety_ok),
+          [](ss::manual_clock::duration) { return 0ms; });
     }
 
     void add_listed(int64_t epoch, std::chrono::milliseconds age) {
@@ -718,21 +720,23 @@ public:
     /// backoff sleep. Returns the stabilized list_call_count_.
     ss::future<uint64_t> wait_for_round() {
         co_await tick_until([this] { return storage_->list_call_count_ > 0; });
-        // Require the count to be unchanged for two consecutive ticks
-        // to avoid catching a gap between pages where the inter-page
-        // sleep hasn't resolved yet.
+        // Require the count to be unchanged for two consecutive ticks.
+        // Use a step larger than throttle_progress (the inter-page
+        // sleep) so each tick fully flushes any pending page work.
         int stable_ticks = 0;
         uint64_t prev = 0;
-        co_await tick_until([this, &prev, &stable_ticks] {
-            auto cur = storage_->list_call_count_;
-            if (cur == prev && cur > 0) {
-                ++stable_ticks;
-            } else {
-                stable_ticks = 0;
-            }
-            prev = cur;
-            return stable_ticks >= 2;
-        });
+        co_await tick_until(
+          [this, &prev, &stable_ticks] {
+              auto cur = storage_->list_call_count_;
+              if (cur == prev && cur > 0) {
+                  ++stable_ticks;
+              } else {
+                  stable_ticks = 0;
+              }
+              prev = cur;
+              return stable_ticks >= 2;
+          },
+          20ms);
         co_return storage_->list_call_count_;
     }
 
@@ -1051,7 +1055,8 @@ public:
           std::make_unique<epoch_source_test_impl>(&max_epoch_),
           std::make_unique<node_info_test_impl>(
             std::get<0>(GetParam()), std::get<1>(GetParam())),
-          std::make_unique<safety_monitor_test_impl>()) {}
+          std::make_unique<safety_monitor_test_impl>(),
+          [](ss::lowres_clock::duration) { return 0ms; }) {}
 
     void TearDown() override { gc_.stop().get(); }
 

--- a/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
+++ b/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
@@ -27,8 +27,7 @@ constexpr size_t prefix_max = cloud_topics::object_id::prefix_max;
 constexpr size_t n_prefixes = prefix_max + 1;
 } // namespace
 
-class object_storage_test_impl
-  : public cloud_topics::level_zero_gc::object_storage {
+class object_storage_test_impl : public cloud_topics::l0::gc::object_storage {
 public:
     object_storage_test_impl(
       chunked_vector<cloud_storage_clients::client::list_bucket_item>* listed,
@@ -129,8 +128,7 @@ private:
     seastar::condition_variable delete_cv_;
 };
 
-class epoch_source_test_impl
-  : public cloud_topics::level_zero_gc::epoch_source {
+class epoch_source_test_impl : public cloud_topics::l0::gc::epoch_source {
 public:
     explicit epoch_source_test_impl(std::optional<int64_t>* epoch)
       : epoch_(epoch) {}
@@ -173,7 +171,7 @@ private:
  * indices based on the members table, this allows direct control over the
  * shard index and total shard count.
  */
-class node_info_test_impl : public cloud_topics::level_zero_gc::node_info {
+class node_info_test_impl : public cloud_topics::l0::gc::node_info {
 public:
     node_info_test_impl() = default;
     node_info_test_impl(size_t shard_idx, size_t total)
@@ -187,8 +185,7 @@ private:
     size_t total_shards_{1};
 };
 
-class safety_monitor_test_impl
-  : public cloud_topics::level_zero_gc::safety_monitor {
+class safety_monitor_test_impl : public cloud_topics::l0::gc::safety_monitor {
     static constexpr bool default_ok{true};
 
 public:
@@ -426,8 +423,7 @@ TEST_F(LevelZeroGCTest, ResetConcurrentOps) {
     // Give it a chance to enter the resetting state
     EXPECT_TRUE(Eventually(
       [this] {
-          return gc->get_state()
-                 == cloud_topics::level_zero_gc::state::resetting;
+          return gc->get_state() == cloud_topics::l0::gc::state::resetting;
       },
       5 /* wait ~100ms */));
 
@@ -439,7 +435,7 @@ TEST_F(LevelZeroGCTest, ResetConcurrentOps) {
     EXPECT_FALSE(start_fut.available());
 
     // Still resetting (first reset is blocked)
-    EXPECT_EQ(gc->get_state(), cloud_topics::level_zero_gc::state::resetting);
+    EXPECT_EQ(gc->get_state(), cloud_topics::l0::gc::state::resetting);
     EXPECT_EQ(deleted.size(), 0);
 
     // Unblock deletes — reset completes, which signals the CV, unblocking
@@ -458,7 +454,7 @@ TEST_F(LevelZeroGCTest, ResetConcurrentOps) {
  * eligible epoch calculation, so that is not overriden.
  */
 class epoch_source_test_default_impl
-  : public cloud_topics::level_zero_gc::epoch_source {
+  : public cloud_topics::l0::gc::epoch_source {
 public:
     explicit epoch_source_test_default_impl(
       partitions_snapshot* get_partitions_value,
@@ -503,7 +499,7 @@ private:
 
 class LevelZeroGCMaxEpochTest : public testing::Test {
 public:
-    using epoch_source_type = cloud_topics::level_zero_gc::epoch_source;
+    using epoch_source_type = cloud_topics::l0::gc::epoch_source;
     using partitions_snapshot = epoch_source_type::partitions_snapshot;
     using partitions_max_gc_epoch = epoch_source_type::partitions_max_gc_epoch;
 

--- a/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
+++ b/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
@@ -9,8 +9,12 @@
  */
 #include "cloud_topics/level_zero/gc/level_zero_gc.h"
 #include "cloud_topics/object_utils.h"
+#include "config/mock_property.h"
 #include "ssx/mutex.h"
+#include "test_utils/async.h"
+#include "test_utils/test.h"
 
+#include <seastar/core/manual_clock.hh>
 #include <seastar/core/sleep.hh>
 
 #include <gtest/gtest.h>
@@ -51,6 +55,7 @@ public:
             co_return std::unexpected{
               cloud_storage_clients::error_outcome::fail};
         }
+        ++list_call_count_;
         chunked_vector<cloud_storage_clients::client::list_bucket_item> keep;
         co_await seastar::sleep(cfg_->list_cost);
         auto lu = co_await list_mtx_.get_units(*as);
@@ -119,6 +124,7 @@ public:
     chunked_vector<cloud_storage_clients::client::list_bucket_item>* listed_;
     std::unordered_set<ss::sstring>* deleted_;
     gc_test_config* cfg_;
+    uint64_t list_call_count_{0};
 
     ssx::mutex list_mtx_{"object-store-impl-list"};
     ssx::mutex delete_mtx_{"object-store-impl-delete"};
@@ -214,8 +220,7 @@ public:
         storage_ = storage.get();
         gc = std::make_unique<cloud_topics::level_zero_gc>(
           cloud_topics::level_zero_gc_config{
-            .deletion_grace_period
-            = config::mock_binding<std::chrono::milliseconds>(12h),
+            .deletion_grace_period = grace_period_.bind(),
             .throttle_progress
             = config::mock_binding<std::chrono::milliseconds>(
               throttle_progress),
@@ -235,7 +240,7 @@ public:
      * Insert an entry into the `listed` container which is the source of
      * objects reported by `list_objects`.
      */
-    void add_listed(int64_t epoch, std::chrono::seconds age) {
+    void add_listed(int64_t epoch, std::chrono::milliseconds age) {
         auto key = cloud_topics::object_path_factory::level_zero_path(
           cloud_topics::object_id{
             .epoch = cloud_topics::cluster_epoch(epoch),
@@ -252,6 +257,8 @@ public:
     chunked_vector<cloud_storage_clients::client::list_bucket_item> listed;
     std::unordered_set<ss::sstring> deleted;
     std::optional<int64_t> max_epoch;
+    config::mock_property<std::chrono::milliseconds> grace_period_{
+      std::chrono::milliseconds{12h}};
     std::unique_ptr<cloud_topics::level_zero_gc> gc;
     gc_test_config cfg{};
     object_storage_test_impl* storage_{nullptr};
@@ -636,6 +643,216 @@ TEST_F(LevelZeroGCScaleOutTest, ConcurrentDeletesPipelineSaturation) {
       [this, expected = (size_t)n] { return deleted.size() == expected; },
       50,
       100ms));
+}
+
+// =============================================================================
+// Backoff behavior tests (manual clock)
+//
+// These instantiate level_zero_gc_t<ss::manual_clock> so that time
+// progression is fully controlled by the test. Each test advances the
+// manual clock and verifies the worker wakes at the right time.
+// =============================================================================
+
+class LevelZeroGCBackoffTest : public seastar_test {
+public:
+    ss::future<> TearDownAsync() override {
+        if (gc_) {
+            co_await gc_->stop();
+        }
+    }
+
+    void configure(
+      std::chrono::milliseconds gp,
+      std::chrono::milliseconds throttle_progress = 10ms,
+      std::chrono::milliseconds throttle_no_progress = 10ms) {
+        grace_period_.update(std::chrono::milliseconds{gp});
+        auto s = std::make_unique<object_storage_test_impl>(
+          &listed, &deleted, &cfg);
+        storage_ = s.get();
+        gc_ = std::make_unique<cloud_topics::level_zero_gc_t<ss::manual_clock>>(
+          cloud_topics::level_zero_gc_config{
+            .deletion_grace_period = grace_period_.bind(),
+            .throttle_progress
+            = config::mock_binding<std::chrono::milliseconds>(
+              throttle_progress),
+            .throttle_no_progress
+            = config::mock_binding<std::chrono::milliseconds>(
+              throttle_no_progress),
+          },
+          std::move(s),
+          std::make_unique<epoch_source_test_impl>(&max_epoch),
+          std::make_unique<node_info_test_impl>(),
+          std::make_unique<safety_monitor_test_impl>(&safety_ok));
+    }
+
+    void add_listed(int64_t epoch, std::chrono::milliseconds age) {
+        auto key = cloud_topics::object_path_factory::level_zero_path(
+          cloud_topics::object_id{
+            .epoch = cloud_topics::cluster_epoch(epoch),
+            .name = uuid_t::create(),
+            .prefix = 0,
+          });
+        cloud_storage_clients::client::list_bucket_item item{
+          .key = key().string(),
+          .last_modified = std::chrono::system_clock::now() - age,
+        };
+        listed.push_back(item);
+    }
+
+    ss::future<>
+    tick(std::chrono::milliseconds delta = std::chrono::milliseconds{0}) {
+        ss::manual_clock::advance(delta);
+        co_await tests::drain_task_queue();
+    }
+
+    template<class Fn>
+    ss::future<> tick_until(
+      Fn&& fn, std::chrono::milliseconds step = 10ms, int retries = 20) {
+        for (int i = 0; i < retries && !fn(); ++i) {
+            co_await tick(step);
+        }
+    }
+
+    /// Wait for a collection round to fully complete (all pages +
+    /// inter-page throttle sleeps) and the worker to enter its
+    /// backoff sleep. Returns the stabilized list_call_count_.
+    ss::future<uint64_t> wait_for_round() {
+        co_await tick_until([this] { return storage_->list_call_count_ > 0; });
+        // Require the count to be unchanged for two consecutive ticks
+        // to avoid catching a gap between pages where the inter-page
+        // sleep hasn't resolved yet.
+        int stable_ticks = 0;
+        uint64_t prev = 0;
+        co_await tick_until([this, &prev, &stable_ticks] {
+            auto cur = storage_->list_call_count_;
+            if (cur == prev && cur > 0) {
+                ++stable_ticks;
+            } else {
+                stable_ticks = 0;
+            }
+            prev = cur;
+            return stable_ticks >= 2;
+        });
+        co_return storage_->list_call_count_;
+    }
+
+    chunked_vector<cloud_storage_clients::client::list_bucket_item> listed;
+    std::unordered_set<ss::sstring> deleted;
+    std::optional<int64_t> max_epoch;
+    config::mock_property<std::chrono::milliseconds> grace_period_{
+      std::chrono::milliseconds{12h}};
+    gc_test_config cfg{};
+    object_storage_test_impl* storage_{nullptr};
+    bool safety_ok{true};
+    std::unique_ptr<cloud_topics::level_zero_gc_t<ss::manual_clock>> gc_;
+};
+
+// age_backoff computes a duration from system_clock time points. That
+// duration is passed to sleep_abortable<manual_clock>, so advancing
+// the manual clock by that amount resolves the sleep.
+TEST_F_CORO(LevelZeroGCBackoffTest, AgeIneligibleWakesAtGracePeriod) {
+    configure(1000ms, 10ms, 10ms);
+    for (int i = 0; i < 5; ++i) {
+        add_listed(i, 200ms);
+    }
+    max_epoch = 100;
+    gc_->start().get();
+
+    auto baseline = co_await wait_for_round();
+
+    // The computed backoff is ~800ms (1000ms grace - ~200ms age).
+    // Advance 500ms — well within. Worker should still be sleeping.
+    co_await tick(500ms);
+    ASSERT_EQ_CORO(storage_->list_call_count_, baseline);
+
+    // Advance past the backoff. Worker should wake and list again.
+    co_await tick_until(
+      [this, baseline] { return storage_->list_call_count_ > baseline; }, 50ms);
+    ASSERT_GT_CORO(storage_->list_call_count_, baseline);
+}
+
+TEST_F_CORO(LevelZeroGCBackoffTest, EpochIneligiblePollsAtThrottle) {
+    configure(1000ms, 10ms, 50ms);
+    for (int i = 50; i < 55; ++i) {
+        add_listed(i, 24h);
+    }
+    max_epoch = 10;
+    gc_->start().get();
+
+    auto count_after_first = co_await wait_for_round();
+
+    // Advance past throttle_no_progress (50ms) — another round fires.
+    co_await tick_until(
+      [this, count_after_first] {
+          return storage_->list_call_count_ > count_after_first;
+      },
+      10ms);
+    ASSERT_GT_CORO(storage_->list_call_count_, count_after_first);
+}
+
+TEST_F_CORO(LevelZeroGCBackoffTest, EmptyStorageSleepsForGracePeriod) {
+    configure(500ms, 10ms, 10ms);
+    max_epoch = 100;
+    gc_->start().get();
+
+    auto baseline = co_await wait_for_round();
+
+    // 300ms — well within the 500ms grace period. Still sleeping.
+    co_await tick(300ms);
+    ASSERT_EQ_CORO(storage_->list_call_count_, baseline);
+
+    // Past the grace period — worker should wake.
+    co_await tick_until(
+      [this, baseline] { return storage_->list_call_count_ > baseline; }, 50ms);
+    ASSERT_GT_CORO(storage_->list_call_count_, baseline);
+}
+
+TEST_F_CORO(LevelZeroGCBackoffTest, GracePeriodReductionWakesWorker) {
+    configure(1000ms, 10ms, 10ms);
+    for (int i = 0; i < 5; ++i) {
+        add_listed(i, 500ms);
+    }
+    max_epoch = 100;
+    gc_->start().get();
+
+    co_await wait_for_round();
+
+    // Reduce grace period below the object age — objects become
+    // eligible. The config watcher aborts the backoff sleep.
+    grace_period_.update(std::chrono::milliseconds{200ms});
+    co_await tick_until([this] { return deleted.size() == 5; });
+    ASSERT_EQ_CORO(deleted.size(), 5u);
+}
+
+// After pause/start, the skip_backoff flag should cause the first
+// round after restart to run immediately, not after the old backoff.
+TEST_F_CORO(LevelZeroGCBackoffTest, StartAfterPauseSkipsBackoff) {
+    configure(1000ms, 10ms, 10ms);
+    // Objects 200ms old with 1000ms grace period → too young, worker
+    // enters a ~800ms backoff.
+    for (int i = 0; i < 10; ++i) {
+        add_listed(i, 200ms);
+    }
+    max_epoch = 100;
+    gc_->start().get();
+
+    auto count_before = co_await wait_for_round();
+
+    // Verify worker is sleeping — no new LISTs after 200ms
+    // (well within ~800ms backoff).
+    co_await tick(200ms);
+    ASSERT_EQ_CORO(storage_->list_call_count_, count_before);
+
+    gc_->pause().get();
+    gc_->start().get();
+
+    // A fresh round should happen promptly (skip_backoff_ set).
+    co_await tick_until(
+      [this, count_before] {
+          return storage_->list_call_count_ > count_before;
+      },
+      10ms);
+    ASSERT_GT_CORO(storage_->list_call_count_, count_before);
 }
 
 // =============================================================================

--- a/src/v/redpanda/admin/services/internal/BUILD
+++ b/src/v/redpanda/admin/services/internal/BUILD
@@ -79,6 +79,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics:state_accessors",
         "//src/v/cloud_topics/frontend",
         "//src/v/cloud_topics/level_zero/gc:level_zero_gc",
+        "//src/v/cloud_topics/level_zero/gc:level_zero_gc_types",
         "//src/v/cluster",
         "//src/v/model",
         "//src/v/redpanda/admin/proxy:client",

--- a/src/v/redpanda/admin/services/internal/level_zero.cc
+++ b/src/v/redpanda/admin/services/internal/level_zero.cc
@@ -13,6 +13,7 @@
 #include "base/vassert.h"
 #include "cloud_topics/frontend/frontend.h"
 #include "cloud_topics/level_zero/gc/level_zero_gc.h"
+#include "cloud_topics/level_zero/gc/level_zero_gc_types.h"
 #include "cloud_topics/state_accessors.h"
 #include "cluster/partition_leaders_table.h"
 #include "cluster/partition_manager.h"
@@ -48,10 +49,10 @@ namespace admin {
 
 namespace {
 constexpr proto::admin::level_zero::status
-map_gc_state(cloud_topics::level_zero_gc::state st) {
+map_gc_state(cloud_topics::l0::gc::state st) {
     using namespace proto::admin::level_zero;
     switch (st) {
-        using enum cloud_topics::level_zero_gc::state;
+        using enum cloud_topics::l0::gc::state;
     case paused:
         return status::l0_gc_status_paused;
     case running:


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

**NOTE TO REVIEWERS**: sequence after https://github.com/redpanda-data/redpanda/pull/29978 (merged)

Replace the flat throttle_no_progress backoff with backoff derived
from what the collection round actually observed. try_to_collect
now returns a collection_outcome that the worker maps to a sleep
duration: age-ineligible objects sleep until the oldest one ages
past the grace period, empty storage sleeps for the full grace
period, and epoch-ineligible objects poll at throttle_no_progress.

The inner loop now pages through all prefixes (with throttled
pauses) before returning, so the outcome reflects the full bucket
state rather than just the first page. Previously a single page of
ineligible objects would stop the scan. This is fine with a static
backoff duration, but, now that we might go to sleep for several
hours, pay the up-front cost of a full prefix scan so that we can
confidently avoid wasted work during a known idle period.

A config watcher on deletion_grace_period wakes the worker if the
grace period shrinks while sleeping.

Also adds a new metric to count list operations. 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
