### PR TITLE
tests: bump ducktape SHA

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -12,7 +12,7 @@ setup(
     package_data={"": ["*.md"]},
     include_package_data=True,
     install_requires=[
-        "ducktape@git+https://github.com/redpanda-data/ducktape.git@f2ddfea94619090688530f3c492ea9f72cb7290e",
+        "ducktape@git+https://github.com/redpanda-data/ducktape.git@415769d381596dd0c27f0a7a4cf5f91dfc21f623",
         "prometheus-client==0.9.0",
         "kafka-python==2.0.6",
         "crc32c==2.2",


### PR DESCRIPTION
Detect dead workers and report exit reason on timeout instead of
silently ignoring signal delivery failures.

https://github.com/redpanda-data/ducktape/compare/f2ddfea94619090688530f3c492ea9f72cb7290e...415769d381596dd0c27f0a7a4cf5f91dfc21f623

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none