### PR TITLE
[UX-984] Forward group principals to the dataplane

### DIFF
--- a/src/go/rpk/pkg/cli/security/role/BUILD
+++ b/src/go/rpk/pkg/cli/security/role/BUILD
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "role",
@@ -19,8 +19,6 @@ go_library(
         "//src/go/rpk/pkg/kafka",
         "//src/go/rpk/pkg/out",
         "//src/go/rpk/pkg/publicapi",
-        "//src/go/rpk/pkg/redpanda",
-        "@build_buf_gen_go_redpandadata_core_protocolbuffers_go//redpanda/core/admin/v2:admin",
         "@build_buf_gen_go_redpandadata_dataplane_protocolbuffers_go//redpanda/api/dataplane/v1:dataplane",
         "@com_connectrpc_connect//:connect",
         "@com_github_redpanda_data_common_go_rpadmin//:rpadmin",
@@ -29,4 +27,11 @@ go_library(
         "@com_github_twmb_franz_go_pkg_kadm//:kadm",
         "@com_github_twmb_types//:types",
     ],
+)
+
+go_test(
+    name = "role_test",
+    srcs = ["role_test.go"],
+    embed = [":role"],
+    deps = ["@com_github_stretchr_testify//require"],
 )

--- a/src/go/rpk/pkg/cli/security/role/assign.go
+++ b/src/go/rpk/pkg/cli/security/role/assign.go
@@ -12,7 +12,6 @@ package role
 import (
 	"fmt"
 
-	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
 	dataplanev1 "buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go/redpanda/api/dataplane/v1"
 	"connectrpc.com/connect"
 	"github.com/redpanda-data/common-go/rpadmin"
@@ -26,21 +25,15 @@ import (
 
 func assignCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	var principals []string
-	var groups []string
 	cmd := &cobra.Command{
-		Use:     "assign [ROLE] --principal [PRINCIPALS...] --group [GROUPS...]",
+		Use:     "assign [ROLE] --principal [PRINCIPALS...]",
 		Aliases: []string{"add"},
-		Short:   "Assign a Redpanda role to a principal or group",
-		Long: `Assign a Redpanda role to a principal or group.
+		Short:   "Assign a Redpanda role to a principal",
+		Long: `Assign a Redpanda role to a principal.
 
 The '--principal' flag accepts principals with the format
 '<PrincipalPrefix>:<Principal>'. If 'PrincipalPrefix' is not provided, then
 defaults to 'User:'.
-
-The '--group' flag assigns the role to an identity provider group, granting all members
-of that group the permissions associated with the role. Group assignments are only
-supported on local (non-cloud) clusters running
-Redpanda ` + minGroupVersion.String() + ` or later.
 `,
 		Example: `
 Assign role "redpanda-admin" to user "red"
@@ -49,11 +42,8 @@ Assign role "redpanda-admin" to user "red"
 Assign role "redpanda-admin" to users "red" and "panda"
   rpk security role assign redpanda-admin --principal red,panda
 
-Assign role "data-reader" to group "engineering"
-  rpk security role assign data-reader --group engineering
-
-Assign role "data-reader" to both a user and a group
-  rpk security role assign data-reader --principal alice --group engineering
+Assign role "redpanda-admin" to group "pandas"
+  rpk security role assign redpanda-admin --principal Group:pandas
 `,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -89,28 +79,6 @@ Assign role "data-reader" to both a user and a group
 				}
 			}
 
-			// Handle groups (local-only).
-			if len(groups) > 0 {
-				if prof.CheckFromCloud() {
-					out.Die("--group is not supported for cloud clusters")
-				}
-				cl, err := adminapi.NewClient(cmd.Context(), fs, prof)
-				out.MaybeDie(err, "unable to initialize admin api client: %v", err)
-
-				if !adminapi.HasMinimumVersion(cmd.Context(), cl, minGroupVersion) {
-					out.Die("--group requires Redpanda version %s or later", minGroupVersion.String())
-				}
-				members := make([]*adminv2.RoleMember, len(groups))
-				for i, g := range groups {
-					members[i] = &adminv2.RoleMember{Member: &adminv2.RoleMember_Group{Group: &adminv2.RoleGroup{Name: g}}}
-				}
-				_, err = cl.SecurityService().AddRoleMembers(cmd.Context(), connect.NewRequest(&adminv2.AddRoleMembersRequest{
-					RoleName: roleName,
-					Members:  members,
-				}))
-				out.MaybeDie(err, "unable to assign group(s) to role %q: %v", roleName, err)
-			}
-
 			// Output principals.
 			if len(toAdd) > 0 {
 				if isText, _, s, err := f.Format(toAdd); !isText {
@@ -124,16 +92,10 @@ Assign role "data-reader" to both a user and a group
 					tw.PrintStructFields(m)
 				}
 			}
-
-			// Output groups.
-			if len(groups) > 0 {
-				fmt.Printf("Successfully assigned role %q to group(s) %v\n", roleName, groups)
-			}
 		},
 	}
 
 	cmd.Flags().StringSliceVar(&principals, "principal", nil, "Principal to assign the role to (repeatable)")
-	cmd.Flags().StringSliceVar(&groups, "group", nil, "group to assign the role to (repeatable)")
-	cmd.MarkFlagsOneRequired("principal", "group")
+	cmd.MarkFlagRequired("principal")
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/security/role/role.go
+++ b/src/go/rpk/pkg/cli/security/role/role.go
@@ -16,17 +16,15 @@ import (
 	"github.com/redpanda-data/common-go/rpadmin"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/redpanda"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
 const (
-	rolePrefix = "RedpandaRole:"
-	userPrefix = "User:"
+	rolePrefix  = "RedpandaRole:"
+	userPrefix  = "User:"
+	groupPrefix = "Group:"
 )
-
-var minGroupVersion = redpanda.Version{Major: 26, Feature: 1}
 
 func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd := &cobra.Command{
@@ -51,9 +49,13 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 // parsePrincipal returns the prefix, and principal. If no prefix is present,
 // returns 'User'.
 func parsePrincipal(p string) (principalType string, name string) {
-	if strings.HasPrefix(p, userPrefix) {
-		return "User", strings.TrimPrefix(p, userPrefix)
+	if s, ok := strings.CutPrefix(p, userPrefix); ok {
+		return "User", s
 	}
+	if s, ok := strings.CutPrefix(p, groupPrefix); ok {
+		return "Group", s
+	}
+
 	return "User", p
 }
 

--- a/src/go/rpk/pkg/cli/security/role/role_test.go
+++ b/src/go/rpk/pkg/cli/security/role/role_test.go
@@ -1,0 +1,35 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package role
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePrincipal(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantType string
+		wantName string
+	}{
+		{input: "alice", wantType: "User", wantName: "alice"},
+		{input: "User:alice", wantType: "User", wantName: "alice"},
+		{input: "Group:engineering", wantType: "Group", wantName: "engineering"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			gotType, gotName := parsePrincipal(tt.input)
+			require.Equal(t, tt.wantType, gotType)
+			require.Equal(t, tt.wantName, gotName)
+		})
+	}
+}

--- a/src/go/rpk/pkg/cli/security/role/unassign.go
+++ b/src/go/rpk/pkg/cli/security/role/unassign.go
@@ -12,7 +12,6 @@ package role
 import (
 	"fmt"
 
-	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
 	dataplanev1 "buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go/redpanda/api/dataplane/v1"
 	"connectrpc.com/connect"
 	"github.com/redpanda-data/common-go/rpadmin"
@@ -26,20 +25,15 @@ import (
 
 func unassignCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	var principals []string
-	var groups []string
 	cmd := &cobra.Command{
-		Use:     "unassign [ROLE] --principal [PRINCIPALS...] --group [GROUPS...]",
+		Use:     "unassign [ROLE] --principal [PRINCIPALS...]",
 		Aliases: []string{"remove"},
-		Short:   "Unassign a Redpanda role from a principal or group",
-		Long: `Unassign a Redpanda role from a principal or group.
+		Short:   "Unassign a Redpanda role from a principal",
+		Long: `Unassign a Redpanda role from a principal.
 
 The '--principal' flag accepts principals with the format
 '<PrincipalPrefix>:<Principal>'. If 'PrincipalPrefix' is not provided, then
 defaults to 'User:'.
-
-The '--group' flag removes the role from an identity provider group.
-Group assignments are only supported on local (non-cloud) clusters running
-Redpanda ` + minGroupVersion.String() + ` or later.
 `,
 		Example: `
 Unassign role "redpanda-admin" from user "red"
@@ -48,11 +42,8 @@ Unassign role "redpanda-admin" from user "red"
 Unassign role "redpanda-admin" from users "red" and "panda"
   rpk security role unassign redpanda-admin --principal red,panda
 
-Unassign role "data-reader" from group "engineering"
-  rpk security role unassign data-reader --group engineering
-
-Unassign role "data-reader" from both a user and a group
-  rpk security role unassign data-reader --principal alice --group engineering
+Unassign role "redpanda-admin" from group "pandas"
+  rpk security role unassign redpanda-admin --principal Group:pandas
 `,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -88,28 +79,6 @@ Unassign role "data-reader" from both a user and a group
 				}
 			}
 
-			// Handle groups (local-only).
-			if len(groups) > 0 {
-				if prof.CheckFromCloud() {
-					out.Die("--group is not supported for cloud clusters")
-				}
-				cl, err := adminapi.NewClient(cmd.Context(), fs, prof)
-				out.MaybeDie(err, "unable to initialize admin api client: %v", err)
-
-				if !adminapi.HasMinimumVersion(cmd.Context(), cl, minGroupVersion) {
-					out.Die("--group requires Redpanda version %s or later", minGroupVersion.String())
-				}
-				members := make([]*adminv2.RoleMember, len(groups))
-				for i, g := range groups {
-					members[i] = &adminv2.RoleMember{Member: &adminv2.RoleMember_Group{Group: &adminv2.RoleGroup{Name: g}}}
-				}
-				_, err = cl.SecurityService().RemoveRoleMembers(cmd.Context(), connect.NewRequest(&adminv2.RemoveRoleMembersRequest{
-					RoleName: roleName,
-					Members:  members,
-				}))
-				out.MaybeDie(err, "unable to unassign group(s) from role %q: %v", roleName, err)
-			}
-
 			// Output principals.
 			if len(toRemove) > 0 {
 				if isText, _, s, err := f.Format(toRemove); !isText {
@@ -123,16 +92,10 @@ Unassign role "data-reader" from both a user and a group
 					tw.PrintStructFields(m)
 				}
 			}
-
-			// Output groups.
-			if len(groups) > 0 {
-				fmt.Printf("Successfully unassigned role %q from group(s) %v\n", roleName, groups)
-			}
 		},
 	}
 
 	cmd.Flags().StringSliceVar(&principals, "principal", nil, "Principal to unassign the role from (repeatable)")
-	cmd.Flags().StringSliceVar(&groups, "group", nil, "Group to unassign the role from (repeatable)")
-	cmd.MarkFlagsOneRequired("principal", "group")
+	cmd.MarkFlagRequired("principal")
 	return cmd
 }


### PR DESCRIPTION
## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Improvements

* Add `Group:` principal support to `rpk security role assign/unassign` and remove the explicit `--group` flag to prevent confusion