### PR TITLE
cluster/namespaced_cache: stop eviction loop when no entries are evictable

### DIFF
--- a/src/v/cluster/namespaced_cache.h
+++ b/src/v/cluster/namespaced_cache.h
@@ -397,8 +397,7 @@ void namespaced_cache<
      * find the eviction spot. Therefore we do not yield here.
      */
     size_t iteration = 0;
-    while (_size >= _max_size() && iteration++ < _size) {
-        evict(it);
+    while (_size >= _max_size() && iteration++ < _size && evict(it)) {
     }
     /**
      * If there was no entry to evict from cache, throw cache full error


### PR DESCRIPTION
When all producers in the cache are unevictable (e.g. they have inflight
requests or open transactions), the eviction loop in `insert()` retries
up to `_size` times, each time doing a full linear scan of the LRU list.
This results in O(n^2) behavior: with 9000 producers, a single failed
insert takes ~400ms, causing reactor stalls.

Fix by checking the return value of `evict()` in the loop condition so
the loop exits immediately when no entry can be evicted.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x
- [ ] v25.1.x

## Release Notes

xref: https://redpandadata.slack.com/archives/C07HD9U0EHL/p1774648001411289

### Bug Fixes

- Fixed a reactor stall in the producer state cache when many producers
  are unevictable due to inflight requests or open transactions.