### PR TITLE
`storage`: remove `compaction_ratio` metric from `probe`

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1413,8 +1413,6 @@ ss::future<> disk_log_impl::housekeeping(housekeeping_config cfg) {
             std::rethrow_exception(fut.get_exception());
         }
     }
-
-    _probe->set_compaction_ratio(_compaction_ratio.get());
 }
 
 ss::future<> disk_log_impl::do_compact(

--- a/src/v/storage/probe.cc
+++ b/src/v/storage/probe.cc
@@ -258,18 +258,6 @@ void probe::setup_metrics(const model::ntp& ntp) {
       },
       {},
       {sm::shard_label, metrics::partition_label});
-
-    _metrics.add_group(
-      group_name,
-      {
-        // compaction_ratio cannot easily be aggregated since aggregation always
-        // sums values and sum is nonsensical for a compaction ratio
-        sm::make_total_bytes(
-          "compaction_ratio",
-          [this] { return _compaction_ratio; },
-          sm::description("Average segment compaction ratio"),
-          labels),
-      });
 }
 
 void probe::add_initial_segment(const segment& s) {

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -125,7 +125,6 @@ public:
     size_t partition_size() const { return _partition_bytes; }
     void add_initial_segment(const segment&);
     void remove_partition_bytes(size_t remove) { _partition_bytes -= remove; }
-    void set_compaction_ratio(double r) { _compaction_ratio = r; }
 
     int64_t get_batch_parse_errors() const { return _batch_parse_errors; }
     /**
@@ -164,7 +163,6 @@ private:
     uint32_t _batch_parse_errors = 0;
     uint32_t _batch_write_errors = 0;
 
-    double _compaction_ratio = 1.0;
     uint64_t _tombstones_removed = 0;
     uint64_t _control_batches_removed = 0;
     uint64_t _segment_cleanly_compacted = 0;


### PR DESCRIPTION
The cardinality of this metric is much too high, and its usefulness doesnot justify the cost. Aggregating it would also reduce its usefulness.

We have plenty of log lines from which one could infer the "compactibility" of a `segment`/`log`/`topic`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
