### PR TITLE
cluster/rm_stm: preserve open transaction producers in local snapshots

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -2134,7 +2134,9 @@ ss::future<raft::stm_snapshot> rm_stm::do_take_local_snapshot(
           snap.finished_requests, [start_kafka_offset](const auto& req) {
               return req.last_offset < start_kafka_offset;
           });
-        if (!snap.finished_requests.empty()) {
+        if (
+          !snap.finished_requests.empty()
+          || state->has_transaction_in_progress()) {
             stm_snapshot.producers.push_back(std::move(snap));
         }
     }

--- a/src/v/cluster/tests/rm_stm_test_fixture.h
+++ b/src/v/cluster/tests/rm_stm_test_fixture.h
@@ -100,6 +100,21 @@ struct rm_stm_test_fixture : simple_raft_fixture {
         return _stm->apply_local_snapshot(hdr, std::move(buf));
     }
 
+    // Tears down all infrastructure and recreates it from the same data
+    // directory. Invalidates all existing references to _stm and _raft.
+    void restart_stm_and_raft(
+      storage::ntp_config::default_overrides overrides = {}) {
+        stop_all();
+        producer_state_manager.stop().get();
+        producer_expiration_ms.stop().get();
+        max_concurent_producers.stop().get();
+        create_stm_and_start_raft(overrides);
+        _stm->testing_only_disable_auto_abort();
+        _stm->start().get();
+        wait_for_confirmed_leader();
+        wait_for_meta_initialized();
+    }
+
     auto wait_for_kafka_offset_apply(kafka::offset offset) {
         auto raft_offset = _stm->to_log_offset(offset);
         return _stm->wait(raft_offset, model::timeout_clock::now() + 10ms);

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -1200,3 +1200,63 @@ FIXTURE_TEST(test_raft_snapshot_roundtrip, rm_stm_test_fixture) {
         BOOST_REQUIRE((bool)offset_r);
     }
 }
+
+// Ensures that a transaction whose begin marker is in a local snapshot, but
+// whose data batches aren't is still able to be committed and aborted after a
+// restart.
+FIXTURE_TEST(
+  test_local_snapshot_preserves_open_tx_producer, rm_stm_test_fixture) {
+    start_and_disable_auto_abort();
+    auto* stm = _stm.get();
+
+    auto pid1 = model::producer_identity{1, 0};
+    auto pid2 = model::producer_identity{2, 0};
+    auto tx_seq = model::tx_seq{0};
+
+    BOOST_REQUIRE(stm->begin_tx(pid1, tx_seq, timeout, model::partition_id(0))
+                    .get()
+                    .has_value());
+    BOOST_REQUIRE(stm->begin_tx(pid2, tx_seq, timeout, model::partition_id(0))
+                    .get()
+                    .has_value());
+
+    // Take a local snapshot after the fences but before data batches.
+    // Both producers have open transactions (status=initialized) but no
+    // finished_requests.
+    stm->write_local_snapshot().get();
+
+    // Replicate data batches for both producers.
+    auto r1 = replicate_all(*stm, make_batches(pid1, 0, 5, true)).get();
+    BOOST_REQUIRE(r1.has_value());
+    auto r2 = replicate_all(*stm, make_batches(pid2, 0, 5, true)).get();
+    BOOST_REQUIRE(r2.has_value());
+    auto last_data_offset = r2.value().last_offset;
+
+    // Restart the entire raft group. On start, the STM loads the local
+    // snapshot from disk and replays the log from the snapshot offset.
+    restart_stm_and_raft();
+    stm = _stm.get();
+
+    // Ensure the producers weren't lost from restarting.
+    BOOST_REQUIRE(producers().contains(pid1.get_id()));
+    BOOST_REQUIRE(producers().contains(pid2.get_id()));
+
+    // Ensure the LSO is held back by the open transactions.
+    auto lso = stm->last_stable_offset();
+    BOOST_REQUIRE_NE(lso, model::invalid_lso);
+    BOOST_REQUIRE_LE(lso, model::offset(last_data_offset()));
+
+    // Ensure pid1's transaction can be committed
+    auto commit_result = stm->commit_tx(pid1, tx_seq, 2'000ms).get();
+    BOOST_REQUIRE_EQUAL(commit_result, cluster::tx::errc::none);
+
+    // Ensure pid2's transaction can be aborted
+    auto abort_result
+      = stm->abort_tx(pid2, tx_seq, model::timeout_clock::duration{2'000ms})
+          .get();
+    BOOST_REQUIRE_EQUAL(abort_result, cluster::tx::errc::none);
+
+    RPTEST_REQUIRE_EVENTUALLY(10s, [stm, last_data_offset]() {
+        return model::offset(last_data_offset()) < stm->last_stable_offset();
+    });
+}


### PR DESCRIPTION
  Fixes a bug in `rm_stm::do_take_local_snapshot` where transactional producers with open transactions but no data batches are silently dropped from local snapshots. On restart, the fence batch (which carries `tx_seq`, `timeout`, and `coordinator_partition`) is behind the snapshot offset and not replayed. Data batches replayed after the snapshot synthesize transaction state with `tx_seq{-1}` and `timeout=nullopt`, making the transaction impossible to commit, abort, or auto-expire, permanently stalling LSO on the partition.

### Steps to reproduce

  1. Begin a transaction to ensure a fence batch is replicated
  2. Take a local snaphot before any data batches are replicated. The producer has `finished_requests` empty, so it's dropped from the snapshot.
  3. Add data batches to the transaction.
  4. Restart a node that leads some partition in the transaction. This will then load the snapshot, replay the log from `snapshot_offset + 1` (fence is not replayed). The data batches will be replayed and `apply_data` will synthesizes `transaction_state` with `tx_seq{-1}` and `timeout=nullopt`.
  5. Ensure the restarted node still leads some partition in the transaction.
  6. The coordinator then could send a `commit_tx` with `tx_seq=0`(or whatever the actual seq was) and the `rm_stm` for the partition will reject it(`-1 != 0`). It could also send a `abort_tx` with `tx_seq=0` and the `rm_stm` for the partition will reject it as well(`-1 < 0` interpreted as "from the future")
  7. Auto-abort timer checks `ms_since_last_update() > timeout_ms()`, `timeout_ms()` returns `max()` due to `nullopt` so it'll never expire.
 
All of this will result in the LSO for the partition becoming permanently stuck.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [X] v25.3.x
- [X] v25.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
