### PR TITLE
[v26.1.x] rpk: update console version to v3.7.0

### DIFF
--- a/src/go/rpk/pkg/cli/container/containerutil/common.go
+++ b/src/go/rpk/pkg/cli/container/containerutil/common.go
@@ -34,7 +34,7 @@ import (
 var (
 	tag               = "latest"
 	redpandaImageBase = "redpandadata/redpanda:" + tag
-	consoleImageBase  = "redpandadata/console:v3.5.1"
+	consoleImageBase  = "redpandadata/console:v3.7.0"
 )
 
 const (


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30002
