### PR TITLE
tests: bump ducktape SHA

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -12,7 +12,7 @@ setup(
     package_data={"": ["*.md"]},
     include_package_data=True,
     install_requires=[
-        "ducktape@git+https://github.com/redpanda-data/ducktape.git@415769d381596dd0c27f0a7a4cf5f91dfc21f623",
+        "ducktape@git+https://github.com/redpanda-data/ducktape.git@c5a2f1ea5023c25f79d01b6733d5119ad150f5e2",
         "prometheus-client==0.9.0",
         "kafka-python==2.0.6",
         "crc32c==2.2",


### PR DESCRIPTION
Bump ducktape dependency from 415769d381596dd0c27f0a7a4cf5f91dfc21f623 to c5a2f1ea5023c25f79d01b6733d5119ad150f5e2.

Changes: https://github.com/redpanda-data/ducktape/compare/415769d381596dd0c27f0a7a4cf5f91dfc21f623...c5a2f1ea5023c25f79d01b6733d5119ad150f5e2

Enable `faulthandler` for fatal signals in worker processes (redpanda-data/ducktape#59), improving debuggability of hangs and crashes during ducktape test runs.

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none