### PR TITLE
rptest/datalake/verifier: fix consumer close race with poll thread

### DIFF
--- a/tests/rptest/tests/datalake/datalake_verifier.py
+++ b/tests/rptest/tests/datalake/datalake_verifier.py
@@ -10,7 +10,7 @@
 import random
 import threading
 from collections import defaultdict
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor, wait as futures_wait
 from time import sleep
 from typing import List, Optional
 
@@ -83,6 +83,8 @@ class DatalakeVerifier:
         self._query_batch_size = 1000
         self._query_batch_wait_timeout_s = 3
         self._executor = ThreadPoolExecutor(max_workers=2)
+        self._consumer_future: Future | None = None
+        self._query_future: Future | None = None
         self._rpk = RpkTool(self.redpanda)
         # errors found during verification
         self._errors = []
@@ -326,8 +328,8 @@ class DatalakeVerifier:
                 sleep(2)
 
     def start(self, wait_first_iceberg_msg=False):
-        self._executor.submit(self._consumer_thread)
-        self._executor.submit(self._query_thread)
+        self._consumer_future = self._executor.submit(self._consumer_thread)
+        self._query_future = self._executor.submit(self._query_thread)
         if wait_first_iceberg_msg:
             self._received_first_iceberg_message.wait()
 
@@ -383,12 +385,24 @@ class DatalakeVerifier:
         finally:
             self.stop(check=check)
 
+    _SHUTDOWN_TIMEOUT_S = 30
+
     def stop(self, check=True):
         self.logger.debug("stopping")
         try:
             self._stop.set()
             self._msg_semaphore.release()
-            self._executor.shutdown(wait=False)
+            futures = [
+                f for f in [self._consumer_future, self._query_future] if f is not None
+            ]
+            done, not_done = futures_wait(futures, timeout=self._SHUTDOWN_TIMEOUT_S)
+            if not_done:
+                self.logger.error(
+                    f"Verifier threads did not stop within {self._SHUTDOWN_TIMEOUT_S}s"
+                )
+                self._executor.shutdown(wait=False)
+            else:
+                self._executor.shutdown(wait=True)
             if check:
                 assert len(self._errors) == 0, (
                     f"Topic {self.topic} validation errors: {self._errors}"


### PR DESCRIPTION
DatalakeVerifier.stop() called executor.shutdown(wait=False) and then immediately called consumer.close() in the finally block. Since shutdown(wait=False) does not wait for threads to exit, the consumer thread could still be inside consumer.poll() when close() is called from the main thread. This is a concurrent access on the underlying librdkafka C handle which can trigger abort() — manifesting as SIGABRT of the entire Python test runner process.

This is a known librdkafka limitation: while the API is generally thread-safe, rd_kafka_destroy() (called internally by close()) must not run concurrently with rd_kafka_consumer_poll(). The Python GIL does not prevent this because confluent-kafka-python releases it during blocking C calls. Relevant upstream issues: confluentinc/confluent-kafka-python#1797,
confluentinc/confluent-kafka-python#1761,
confluentinc/librdkafka#2432.

Wait for the consumer and query futures (with a 30s timeout) before closing the consumer. On timeout, log an error and fall through with shutdown(wait=False) — best-effort, since skipping consumer.close() entirely also crashes (the destructor segfaults without a prior close() per confluentinc/confluent-kafka-python#358).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
