### PR TITLE
features: add v26.2.1 to release_versions

### DIFF
--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -177,7 +177,7 @@ constexpr cluster_version latest_version = to_cluster_version(
 // a freshly initialized node will start at. All features up to this cluster
 // version will automatically be enabled when Redpanda starts.
 constexpr cluster_version earliest_version = to_cluster_version(
-  release_version::v25_3_1);
+  release_version::v26_1_1);
 
 static_assert(
   latest_version - earliest_version == 1L,
@@ -215,6 +215,7 @@ bool is_major_version_release(cluster::cluster_version version) {
     case release_version::v25_2_1:
     case release_version::v25_3_1:
     case release_version::v26_1_1:
+    case release_version::v26_2_1:
         return true;
     }
     __builtin_unreachable();

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -163,7 +163,8 @@ enum class release_version : int64_t {
     v25_2_1 = 16,
     v25_3_1 = 17,
     v26_1_1 = 18,
-    MAX = v26_1_1, // affects the latest_version
+    v26_2_1 = 19,
+    MAX = v26_2_1, // affects the latest_version
 };
 
 constexpr cluster::cluster_version to_cluster_version(release_version rv) {
@@ -184,6 +185,7 @@ constexpr cluster::cluster_version to_cluster_version(release_version rv) {
     case release_version::v25_2_1:
     case release_version::v25_3_1:
     case release_version::v26_1_1:
+    case release_version::v26_2_1:
         return cluster::cluster_version{static_cast<int64_t>(rv)};
     }
     vunreachable("Invalid release_version");

--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -46,6 +46,11 @@ RP_GIT_RELEASED_VERSIONS = "RP_GIT_RELEASED_VERSIONS"
 
 REDPANDA_INSTALLER_HEAD_TAG = "head"
 
+# The latest major version that has been released (binaries available on S3).
+# Update this when a new major version is published. No need to update it for
+# minors.
+LATEST_RELEASED_MAJOR: tuple[int, int, int] = (26, 1, 1)
+
 RedpandaVersionTriple = tuple[int, int, int]
 RedpandaVersionLine = tuple[int, int]
 RedpandaVersion = Literal["head"] | RedpandaVersionLine | RedpandaVersionTriple
@@ -517,6 +522,22 @@ class RedpandaInstaller:
         """
         self.start()
         return self.released_versions[-1]
+
+    @staticmethod
+    def next_major_version(line: RedpandaVersionLine) -> RedpandaVersionLine:
+        """
+        Given a release line like (25, 3), return the next release line
+        in sequence. The scheme has 3 minor versions per major year:
+        X.1 -> X.2 -> X.3 -> (X+1).1
+        """
+        if line[0] == 0:
+            raise ValueError(
+                f"Cannot compute next major version from dev version {line}. "
+                "Build with --config=stamp to get a real version tag."
+            )
+        if line[1] == 3:
+            return (line[0] + 1, 1)
+        return (line[0], line[1] + 1)
 
     def latest_unsupported_line(self) -> tuple[int, int]:
         """

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -701,15 +701,18 @@ class AccessControlListTestUpgrade(AccessControlListTest):
 
     @cluster(num_nodes=3)
     def test_upgrade_gbac(self):
-        # Start with a version installed that's not aware of GBAC
-        self.installer.install(self.redpanda.nodes, (25, 3, 1))
+        # GBAC was introduced in v26.1, so start on v25.3 (pre-GBAC)
+        from_version = (25, 3)
+        to_version = RedpandaInstaller.next_major_version(from_version)
+
+        self.installer.install(self.redpanda.nodes, from_version)
         self.prepare_cluster(use_tls=False, use_sasl=True)
 
         # Upgrades nodes 0 and 1 and halt node 2
         # This ensures we have controller quorum but the old version node
         # is stopped so ACL creation fails due to the GBAC feature not being active
         self.installer.install(
-            [self.redpanda.nodes[0], self.redpanda.nodes[1]], RedpandaInstaller.HEAD
+            [self.redpanda.nodes[0], self.redpanda.nodes[1]], to_version
         )
         self.redpanda.restart_nodes([self.redpanda.nodes[0], self.redpanda.nodes[1]])
         self.redpanda.stop_node(self.redpanda.nodes[2])
@@ -737,7 +740,7 @@ class AccessControlListTestUpgrade(AccessControlListTest):
         )
 
         # Upgrade remaining nodes
-        self.installer.install([self.redpanda.nodes[2]], RedpandaInstaller.HEAD)
+        self.installer.install([self.redpanda.nodes[2]], to_version)
         self.redpanda.start_node(self.redpanda.nodes[2])
 
         wait_until(

--- a/tests/rptest/tests/cloud_topics/upgrade_test.py
+++ b/tests/rptest/tests/cloud_topics/upgrade_test.py
@@ -31,10 +31,6 @@ class CloudTopicsUpgradeTest(RedpandaTest):
     completes.
     """
 
-    # The cloud_topics feature is gated at v26.1.1, so we start the cluster
-    # on v25.3.x and upgrade to HEAD.
-    OLD_VERSION = (25, 3)
-
     def __init__(self, test_context: TestContext):
         si_settings = SISettings(
             test_context,
@@ -59,6 +55,10 @@ class CloudTopicsUpgradeTest(RedpandaTest):
         self.installer = self.redpanda._installer
         self.admin = Admin(self.redpanda)
         self.rpk = RpkTool(self.redpanda)
+
+    # cloud_topics feature is gated at v26.1, so start on v25.3 (pre-feature)
+    OLD_VERSION = (25, 3)
+    NEW_VERSION = RedpandaInstaller.next_major_version(OLD_VERSION)
 
     def setUp(self):
         self.installer.install(self.redpanda.nodes, self.OLD_VERSION)
@@ -113,13 +113,10 @@ class CloudTopicsUpgradeTest(RedpandaTest):
         should succeed.
         """
         initial_version = self.admin.get_features()["cluster_version"]
-        self.logger.info(
-            f"Starting upgrade test: initial_version={initial_version}, "
-            f"old_version={self.OLD_VERSION}"
-        )
+        self.logger.info(f"Starting upgrade test: initial_version={initial_version}")
 
         # Upgrade all nodes to HEAD one at a time.
-        self.installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
+        self.installer.install(self.redpanda.nodes, self.NEW_VERSION)
         for node in self.redpanda.nodes:
             self.redpanda.restart_nodes([node])
 

--- a/tests/rptest/tests/quota_management_test.py
+++ b/tests/rptest/tests/quota_management_test.py
@@ -807,7 +807,11 @@ class QuotaManagementUpgradeTest(EndToEndTest, QuotaManagementUtils):
 
     @cluster(num_nodes=2, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_upgrade(self):
-        install_opts = InstallOptions(version=RedpandaVersionTriple((25, 3, 1)))
+        # user_based_client_quota feature introduced in v26.1, start on v25.3
+        from_version = (25, 3, 1)
+        to_version = RedpandaInstaller.next_major_version(from_version[0:2])
+
+        install_opts = InstallOptions(version=RedpandaVersionTriple(from_version))
         self.start_redpanda(
             num_nodes=2,
             si_settings=SISettings(test_context=self.test_context),
@@ -847,8 +851,8 @@ class QuotaManagementUpgradeTest(EndToEndTest, QuotaManagementUtils):
             f"Unexpected entry: {entry}"
         )
 
-        # Upgrade one node to the head version.
-        self.redpanda._installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
+        # Upgrade one node to the next version.
+        self.redpanda._installer.install(self.redpanda.nodes, to_version)
         self.redpanda.restart_nodes([first_node])
         wait_for_num_versions(self.redpanda, 2)
 
@@ -877,7 +881,11 @@ class QuotaManagementUpgradeTest(EndToEndTest, QuotaManagementUtils):
 
     @cluster(num_nodes=2, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_quotas_during_upgrade(self):
-        install_opts = InstallOptions(version=RedpandaVersionTriple((25, 3, 1)))
+        # client-id quotas predate v25.3, test they survive the upgrade
+        from_version = (25, 3, 1)
+        to_version = RedpandaInstaller.next_major_version(from_version[0:2])
+
+        install_opts = InstallOptions(version=RedpandaVersionTriple(from_version))
         self.start_redpanda(
             num_nodes=2,
             si_settings=SISettings(test_context=self.test_context),
@@ -934,8 +942,8 @@ class QuotaManagementUpgradeTest(EndToEndTest, QuotaManagementUtils):
         for etype, quota in all_quotas.values():
             check_all_nodes(etype, quota)
 
-        # Upgrade one node to the head version.
-        self.redpanda._installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
+        # Upgrade one node to the next version.
+        self.redpanda._installer.install(self.redpanda.nodes, to_version)
         self.redpanda.restart_nodes([first_node])
         wait_for_num_versions(self.redpanda, 2)
 

--- a/tests/rptest/tests/storage_mode_test.py
+++ b/tests/rptest/tests/storage_mode_test.py
@@ -169,11 +169,12 @@ class StorageModeUpgradeTest(StorageModeTestBase):
         )
         self.installer = self.redpanda._installer
 
+    # storage_mode property introduced in v26.1, start on v25.3 (pre-feature)
+    FROM_VERSION = (25, 3)
+    TO_VERSION = RedpandaInstaller.next_major_version(FROM_VERSION)
+
     def setUp(self):
-        # Use v25.3 as the previous version (before storage_mode existed)
-        self.prev_version = (25, 3)
-        # Install old version before starting cluster
-        self.installer.install(self.redpanda.nodes, self.prev_version)
+        self.installer.install(self.redpanda.nodes, self.FROM_VERSION)
         super(StorageModeUpgradeTest, self).setUp()
 
     def _create_topic_with_tiered_storage_config(
@@ -226,8 +227,8 @@ class StorageModeUpgradeTest(StorageModeTestBase):
                 f"Topic {topic_name} remote_write mismatch: expected {str(remote_write).lower()}, got {actual_write}"
             )
 
-        # Upgrade all nodes to HEAD
-        self.installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
+        # Upgrade all nodes to next version
+        self.installer.install(self.redpanda.nodes, self.TO_VERSION)
         self.redpanda.restart_nodes(self.redpanda.nodes)
 
         # Wait for cluster to stabilize on new version

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -34,6 +34,7 @@ from rptest.services.redpanda import (
     get_cloud_storage_type,
 )
 from rptest.services.redpanda_installer import (
+    LATEST_RELEASED_MAJOR,
     InstallOptions,
     RedpandaInstaller,
     wait_for_num_versions,
@@ -697,6 +698,23 @@ class RedpandaInstallerTest(RedpandaTest):
         this isn't actually doing upgrades in the traditional sense,
         instead is intentionally wiping and restarting the cluster with new binaries
         """
+
+        # Verify next_line arithmetic
+        assert RedpandaInstaller.next_major_version((25, 1)) == (25, 2)
+        assert RedpandaInstaller.next_major_version((25, 2)) == (25, 3)
+        assert RedpandaInstaller.next_major_version((25, 3)) == (26, 1)
+        assert RedpandaInstaller.next_major_version((26, 3)) == (27, 1)
+
+        # Verify LATEST_RELEASED_MAJOR is the newest in released_versions.
+        # If it's not, either github releases are not up to date (used
+        # locally), RP_GIT_RELEASED_VERSIONS is not set correctly in CI,
+        # or LATEST_RELEASED_MAJOR needs to be bumped.
+        released = self.redpanda._installer.released_versions
+        assert released[0] == LATEST_RELEASED_MAJOR, (
+            f"Expected LATEST_RELEASED_MAJOR {LATEST_RELEASED_MAJOR} to be the "
+            f"newest released version, but got {released[0]} "
+            f"(first 10: {released[:10]})"
+        )
 
         # base step, exercise edge case of asking to install a release that is actually HEAD
         head_version, head_version_str = self.redpanda._installer.install(

--- a/tools/dt
+++ b/tools/dt
@@ -61,6 +61,8 @@ class DucktapeRunner:
         # Bazel config
         self.build_type = args.build_type if hasattr(args, "build_type") else None
         self.bazel_config = f"--config={self.build_type}"
+        if getattr(args, "stamp", False):
+            self.bazel_config += " --config=stamp"
         if hasattr(args, "bazel_args"):
             self.bazel_config += f" {args.bazel_args}"
 
@@ -402,7 +404,7 @@ class DucktapeRunner:
         ]
 
         # Pass through some optional environment variables if they exist
-        for env_var in ["REDPANDA_SAMPLE_LICENSE", "REDPANDA_SECOND_SAMPLE_LICENSE"]:
+        for env_var in ["REDPANDA_SAMPLE_LICENSE", "REDPANDA_SECOND_SAMPLE_LICENSE", "RP_GIT_RELEASED_VERSIONS"]:
             if env_var in os.environ:
                 docker_cmd.extend(["--env", f"{env_var}={os.environ[env_var]}"])
 
@@ -776,6 +778,11 @@ def main():
         "--bazel-args", default="", help="Additional bazel arguments"
     )
     run_parser.add_argument(
+        "--stamp",
+        action="store_true",
+        help="Stamp the build with the git tag version (needed for upgrade tests)",
+    )
+    run_parser.add_argument(
         "--skip-bazel-build",
         action="store_true",
         help="Skip building bazel package (use existing artifacts)",
@@ -869,6 +876,11 @@ def main():
         "--bazel-args", default="", help="Additional bazel arguments"
     )
     test_parser.add_argument(
+        "--stamp",
+        action="store_true",
+        help="Stamp the build with the git tag version (needed for upgrade tests)",
+    )
+    test_parser.add_argument(
         "--skip-bazel-build",
         action="store_true",
         help="Skip building bazel package (use existing artifacts)",
@@ -938,6 +950,11 @@ def main():
     )
     repl_parser.add_argument(
         "--bazel-args", default="", help="Additional bazel arguments"
+    )
+    repl_parser.add_argument(
+        "--stamp",
+        action="store_true",
+        help="Stamp the build with the git tag version (needed for upgrade tests)",
     )
     repl_parser.add_argument(
         "--skip-bazel-build",


### PR DESCRIPTION
Add the v26.2 release version to the feature table and bump the earliest upgradeable version from v25.3.1 to v26.1.1 (these two changes are coupled by a static_assert).

Prior instances of this change:
- cba565cc7b features: Add v26.1.1 to release_versions
- 5d13076813 features/table: bump latest version (v25.3.1)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
