### PR TITLE
`rptest`: collect `dmesg` logs when redpanda node stops unexpectedly

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -4411,6 +4411,9 @@ class RedpandaService(Service, RedpandaServiceABC):
             # not-running processes
             def check_pid(node: ClusterNode) -> tuple[ClusterNode, str] | None:
                 if not self.redpanda_pid(node):
+                    dmesg = self._capture_dmesg(node)
+                    if dmesg:
+                        self._save_dmesg_artifact(node, dmesg)
                     return (node, "Redpanda process unexpectedly stopped")
                 return None
 
@@ -4424,6 +4427,43 @@ class RedpandaService(Service, RedpandaServiceABC):
                 )
             else:
                 raise NodeCrash(crashes)
+
+    def _capture_dmesg(self, node: ClusterNode) -> str | None:
+        """Capture recent dmesg output from ``node`` for crash diagnostics."""
+        try:
+            slack_secs = 300
+            seconds_ago = int(time.time() - self._start_time) + slack_secs
+            lines: list[str] = []
+            max_lines = 1000
+            cmd = (
+                f"sudo dmesg -T --since '{seconds_ago} seconds ago' | tail -{max_lines}"
+            )
+            for line in node.account.ssh_capture(cmd, timeout_sec=10):
+                line = line.strip()
+                if line:
+                    lines.append(line)
+            return "\n".join(lines) if lines else None
+        except Exception as e:
+            self.logger.debug(
+                f"Failed to collect dmesg from {node.account.hostname}: {e}"
+            )
+            return None
+
+    def _save_dmesg_artifact(self, node: ClusterNode, dmesg: str) -> None:
+        node_dir = os.path.join(
+            TestContext.results_dir(self._context, self._context.test_index),
+            self.service_id,
+            node.account.hostname,
+        )
+        artifact_path = os.path.join(node_dir, "dmesg.txt")
+        try:
+            if not os.path.isdir(node_dir):
+                mkdir_p(node_dir)
+            self.logger.info(f"writing dmesg output to {artifact_path}")
+            with open(artifact_path, "w") as f:
+                f.write(dmesg)
+        except Exception as e:
+            self.logger.debug(f"Failed to write dmesg to {artifact_path}: {e}")
 
     def raw_metrics(
         self,

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -842,6 +842,22 @@ class RedpandaServiceSelfTest(RedpandaTest):
     def test_start(self) -> None:
         pass
 
+    @cluster(num_nodes=1)
+    def test_capture_dmesg(self) -> None:
+        """
+        Inject a synthetic line into the kernel ring buffer and verify
+        ``_capture_dmesg`` returns it.
+        """
+        rp = self.redpanda
+        node = rp.nodes[0]
+        marker = f"selftest-marker-{int(time.time())}"
+        msg = f"selftest synthetic kernel line {marker}"
+        node.account.ssh(f"cat > /dev/kmsg <<'EOF'\n{msg}\nEOF")
+
+        result = rp._capture_dmesg(node)
+        assert result is not None, "expected non-empty dmesg capture"
+        assert marker in result, f"marker missing from captured dmesg: {result}"
+
 
 class RedpandaClusteredServiceSelfTest(RedpandaTest):
     """Same as RedpandaServiceSelfTest but uses a 3-broker cluster.


### PR DESCRIPTION
([This is just for examining one test failure for now](https://redpandadata.slack.com/archives/C08P57TJXRT/p1774970467045099))

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
