### PR TITLE
[v25.2.x] cluster/namespaced_cache: stop eviction loop when no entries are evictable

### DIFF
--- a/src/v/cluster/namespaced_cache.h
+++ b/src/v/cluster/namespaced_cache.h
@@ -396,8 +396,7 @@ void namespaced_cache<
      * find the eviction spot. Therefore we do not yield here.
      */
     size_t iteration = 0;
-    while (_size >= _max_size() && iteration++ < _size) {
-        evict(it);
+    while (_size >= _max_size() && iteration++ < _size && evict(it)) {
     }
     /**
      * If there was no entry to evict from cache, throw cache full error


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/29991
