### PR TITLE
tools/dt: set max-parallel default to 1000

### DIFF
--- a/tools/dt
+++ b/tools/dt
@@ -791,8 +791,8 @@ def main():
     run_parser.add_argument(
         "--max-parallel",
         type=int,
-        default=1,
-        help="Maximum parallel tests (default: 1)",
+        default=1000,
+        help="Maximum parallel tests (default: 1000)",
     )
     run_parser.add_argument(
         "--repeat",
@@ -876,8 +876,8 @@ def main():
     test_parser.add_argument(
         "--max-parallel",
         type=int,
-        default=1,
-        help="Maximum parallel tests (default: 1)",
+        default=1000,
+        help="Maximum parallel tests (default: 1000)",
     )
     test_parser.add_argument(
         "--repeat",
@@ -955,8 +955,8 @@ def main():
     repl_parser.add_argument(
         "--max-parallel",
         type=int,
-        default=1,
-        help="Maximum parallel tests (default: 1)",
+        default=1000,
+        help="Maximum parallel tests (default: 1000)",
     )
     repl_parser.add_argument(
         "--repeat",


### PR DESCRIPTION
The default `--max-parallel 1` means tests run serially unless you
remember to explicitly pass the flag. Change to 1000 which is
effectively unlimited, but DT still observes the limit imposed by the number of nodes required by the tests you are running (so actual parallelism will be limited and reasonable).

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none