### PR TITLE
`cluster`: reduce `parallel_for_each()` batch size to 512

### DIFF
--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -76,7 +76,7 @@ controller_api::get_reconciliation_state(chunked_vector<model::ntp> ntps) {
 
 ss::future<result<bool>>
 controller_api::all_reconciliations_done(std::deque<model::ntp> ntps) {
-    const size_t batch_size = 4096;
+    const size_t batch_size = 512;
     // For a huge topic with e.g. 100k partitions, this will be a huge loop:
     // that means we need parallelism, but not so much that we totally
     // saturate inter-core queues.


### PR DESCRIPTION
The concurrent limit of `4096` in `all_reconciliations_done()` is high enough to trigger `Too long queue accumulated` warnings from seastar within scale tests and high partition scenarios [1].

Reduce `batch_size` to 512 to reduce the amount of concurrency in the system and avoid flooding the reactor.

[1]: https://ci-artifacts.dev.vectorized.cloud/production-devprod/redpanda/82559/019d44d7-f18d-4bb0-b29d-8e7e4b79aa3f/vbuild/ducktape/results/2026-03-31--001/LargeMessagesTest/test_cloud_topics_large_messages_throughput/message_size_mib=32.mode=Mode.MANY_PARTS/69/RedpandaService-0-261542174272880/ip-172-31-21-232/, from https://ci-artifacts.dev.vectorized.cloud/production-devprod/redpanda/82559/019d44d7-f18d-4bb0-b29d-8e7e4b79aa3f/vbuild/ducktape/results/2026-03-31--001/report.html.

```
WARN  2026-03-31 20:39:58,374 [shard 0:kafk] seastar - Too long queue accumulated for kafka (2623 tasks)
 1: N7seastar8internal14do_until_stateIZZNS_23max_concurrent_for_eachINSt3__111__wrap_iterIPN7cluster12topic_resultEEES8_ZZN5kafka15wait_for_topicsERNS5_14metadata_cacheENS3_6vectorIS6_NS3_9allocatorIS6_EEEERNS5_14controller_apiENS3_6chrono10time_pointINS_12lowres_clockENSI_8durationIxNS3_5ratioILl1ELl1000000000EEEEEEEENK3$_0clERSF_EUlRS6_E_QaarQT1_T__XclfL1p_defL1p0_ERNS3_7same_asINS_6futureIvEEEEXppfL1p0_Eoosr3stdE7same_asIT0_SV_Esr3stdE12sentinel_forISZ_SV_EEESY_SV_SZ_mOSU_ENKUlRZNS2_IS8_S8_ST_QaarQSU_SV__XclfL2p_defL2p0_ERNSW_ISY_EEXppfL2p0_Eoosr3stdE7same_asISZ_SV_Esr3stdE12sentinel_forISZ_SV_EEESY_SV_SZ_mS10_E5stateE_clES12_EUlvE_ZZNS2_IS8_S8_ST_QaarQSU_SV__XclfL1p_defL1p0_ERNSW_ISY_EEXppfL1p0_Eoosr3stdE7same_asISZ_SV_Esr3stdE12sentinel_forISZ_SV_EEESY_SV_SZ_mS10_ENKS13_clES12_EUlvE0_EE
 2621: N7seastar8internal21coroutine_traits_baseINSt3__18optionalIN7cluster17backend_operationEEEE12promise_typeE
 1: N7seastar8internal21coroutine_traits_baseIN7cluster24ntp_reconciliation_stateEE12promise_typeE
```

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
