### PR TITLE
`misc`: inherit publicly from `std::exception`

### DIFF
--- a/src/v/cloud_storage_clients/abs_error.h
+++ b/src/v/cloud_storage_clients/abs_error.h
@@ -48,7 +48,7 @@ enum class abs_error_code {
 std::istream& operator>>(std::istream& i, abs_error_code& code);
 
 /// Error received in a response from the server
-class abs_rest_error_response : std::exception {
+class abs_rest_error_response : public std::exception {
 public:
     abs_rest_error_response(
       ss::sstring code,

--- a/src/v/cloud_storage_clients/s3_error.h
+++ b/src/v/cloud_storage_clients/s3_error.h
@@ -167,7 +167,7 @@ std::ostream& operator<<(std::ostream& o, s3_error_code code);
 std::istream& operator>>(std::istream& i, s3_error_code& code);
 
 /// Error received in a response from the server
-class rest_error_response : std::exception {
+class rest_error_response : public std::exception {
 public:
     rest_error_response(
       std::string_view code,

--- a/src/v/datalake/partition_key_path.h
+++ b/src/v/datalake/partition_key_path.h
@@ -17,7 +17,7 @@ namespace datalake {
 /**
  * Error in partition key to path conversion
  */
-class partition_key_error : std::exception {
+class partition_key_error : public std::exception {
 public:
     explicit partition_key_error(std::string msg) noexcept
       : msg_(std::move(msg)) {}

--- a/src/v/iceberg/transform_utils.h
+++ b/src/v/iceberg/transform_utils.h
@@ -14,7 +14,7 @@
 #include "iceberg/values.h"
 
 namespace iceberg {
-class partition_spec_field_error : std::exception {
+class partition_spec_field_error : public std::exception {
 public:
     explicit partition_spec_field_error(std::string msg) noexcept
       : msg_(std::move(msg)) {}

--- a/src/v/net/batched_output_stream.h
+++ b/src/v/net/batched_output_stream.h
@@ -21,7 +21,7 @@
 
 namespace net {
 
-class batched_output_stream_closed : std::exception {
+class batched_output_stream_closed : public std::exception {
 public:
     batched_output_stream_closed(size_t ignored_bytes)
       : msg(

--- a/src/v/rpc/exceptions.h
+++ b/src/v/rpc/exceptions.h
@@ -18,7 +18,7 @@
 #include <exception>
 
 namespace rpc {
-class request_timeout_exception final : std::exception {
+class request_timeout_exception final : public std::exception {
 public:
     explicit request_timeout_exception(ss::sstring what)
       : what_(std::move(what)) {}

--- a/src/v/wasm/parser/leb128.h
+++ b/src/v/wasm/parser/leb128.h
@@ -59,7 +59,7 @@ bytes encode(int_type value) {
     return output;
 }
 
-class decode_exception : std::exception {};
+class decode_exception : public std::exception {};
 
 template<typename int_type>
 int_type decode(iobuf_parser_base* stream) {


### PR DESCRIPTION
Several exception classes used private inheritance from `std::exception` (the default for `class`). This prevents `catch(const std::exception&)` from matching, and causes `exception_ptr` formatting to print only the type name instead of the full `what()` message.

I discovered this when trying to debug an `ERROR` log line which wasn't very helpful:

```
ERROR 2026-03-31 20:40:20,925 [shard 1:ctr ] cloud_io - multipart_upload.cc:175 - Multipart upload completion failed, aborting: cloud_storage_clients::rest_error_response
```

from

https://github.com/redpanda-data/redpanda/blob/32b08d734306d045fb5259e532867af9fedea6f3/src/v/cloud_storage_clients/multipart_upload.cc#L169-L175

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
