### PR TITLE
[Opening for tests] `rptest`: fail ducktape tests on `Too long queue accumulated`

### DIFF
--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -76,7 +76,7 @@ controller_api::get_reconciliation_state(chunked_vector<model::ntp> ntps) {
 
 ss::future<result<bool>>
 controller_api::all_reconciliations_done(std::deque<model::ntp> ntps) {
-    const size_t batch_size = 4096;
+    const size_t batch_size = 512;
     // For a huge topic with e.g. 100k partitions, this will be a huge loop:
     // that means we need parallelism, but not so much that we totally
     // saturate inter-core queues.

--- a/tests/rptest/services/utils.py
+++ b/tests/rptest/services/utils.py
@@ -137,6 +137,7 @@ class LogSearch(ABC):
         "Aborting on shard",
         "terminating due to uncaught exception",
         "oversized allocation",
+        "Too long queue accumulated",
     ]
 
     def __init__(


### PR DESCRIPTION
Opening for test purposes

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
