### PR TITLE
`bazel`: run `liburing` configure genrule locally

### DIFF
--- a/bazel/thirdparty/liburing.patch
+++ b/bazel/thirdparty/liburing.patch
@@ -1,6 +1,6 @@
 --- a/BUILD.bazel	2026-03-24 11:46:07.317446858 -0300
 +++ b/BUILD.bazel	2026-03-25 10:48:54.430923058 -0300
-@@ -20,20 +20,28 @@
+@@ -20,20 +20,29 @@
          "src/include/liburing/io_uring_version.h",
      ],
      cmd = """
@@ -30,6 +30,7 @@
              done
            """,
 -    toolchains = ["@bazel_tools//tools/cpp:current_cc_toolchain"],
++    local = True,
 +    toolchains = [
 +        "@bazel_tools//tools/cpp:current_cc_toolchain",
 +        "@bazel_tools//tools/cpp:cc_flags",


### PR DESCRIPTION
Full transparency: This is all Claude's work but it fixes my build failures locally and the commit message seems legit enough.

Robot's commit message:

The `liburing` `generate_headers` genrule runs `./configure` to probe for available system types and emits a `compat.h` with fallback definitions for anything missing. The configure probes compile test programs using the Bazel toolchain's sysroot (via `--sysroot` in `CC_FLAGS`), but this sysroot is not declared as an input to the genrule. In sandboxed execution, the sysroot directory is absent, so every probe fails and configure emits fallback definitions for all features.

This causes a build failure when the `compat.h` fallback definitions (e.g. `idtype_t`/`P_ALL`) conflict with the same definitions in the sysroot headers during actual compilation, which does use the sysroot.

Mark the genrule as `local = True` so it runs in the execroot where the sysroot is accessible. The genrule was already non-hermetic by design (it probes host capabilities), so this just makes that explicit.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
