### PR TITLE
`ct/l0`: hold gate in `list_delete_worker::next_page()`

### DIFF
--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -113,6 +113,11 @@ public:
       chunked_vector<cloud_storage_clients::client::list_bucket_item>,
       cloud_storage_clients::error_outcome>>
     next_page() {
+        if (gate_.is_closed()) {
+            co_return chunked_vector<
+              cloud_storage_clients::client::list_bucket_item>{};
+        }
+        auto holder = gate_.hold();
         while (
           !as_.abort_requested()
           && (continuation_token_.has_value() || (curr_prefix_ = next_prefix()).has_value())) {


### PR DESCRIPTION
`next_page()` has a `vassert()` which checks the invariant that if `continuation_token_` has a value, then `curr_prefix_` must as well, as displayed in the condition:

```
        while (
          !as_.abort_requested()
          && (continuation_token_.has_value() || (curr_prefix_ = next_prefix()).has_value())) {
            vassert(
              curr_prefix_.has_value(),
              "Expected curr_prefix_ to be populated here...");
...
```

However, concurrent fibers between `reset()` and `do_next_page()` _could_ result in the `continuation_token_` and `curr_prefix_` being reset (in `reset()`), `do_next_page()` then setting the `continuation_token_`, and `next_page()` then enters the `while` condition above with a fresh abort source (which has not been aborted), a `continuation_token_` with a value, but no `curr_prefix_`, leading to the `vassert()` firing.

```
ERROR 2026-04-01 03:13:30,187 [shard 0:main] assert - Assert failure: (src/v/cloud_topics/level_zero/gc/level_zero_gc.cc:121) 'curr_prefix_.has_value()' Expected curr_prefix_ to be populated here...
```

Hold the gate so that `gate_.close()` in `reset()` blocks until any in-flight `next_page()` completes and observes the original aborted `as_`.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

