### PR TITLE
[v26.1.x] `ct/l0`: hold gate in `list_delete_worker::next_page()`

### DIFF
--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -113,6 +113,11 @@ public:
       chunked_vector<cloud_storage_clients::client::list_bucket_item>,
       cloud_storage_clients::error_outcome>>
     next_page() {
+        if (gate_.is_closed()) {
+            co_return chunked_vector<
+              cloud_storage_clients::client::list_bucket_item>{};
+        }
+        auto holder = gate_.hold();
         while (
           !as_.abort_requested()
           && (continuation_token_.has_value() || (curr_prefix_ = next_prefix()).has_value())) {


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30030
