### PR TITLE
[v26.1.x] rptest: avoid large alloc in abs cloud validation tests

### DIFF
--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -1671,7 +1671,7 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
             "AZURE_CLIENT_ID": "client_id",
             "AZURE_TENANT_ID": "tenantid",
             "AZURE_FEDERATED_TOKEN_FILE": "/etc/hosts",
-            "AZURE_AUTHORITY_HOST": "authority.host.com",
+            "AZURE_AUTHORITY_HOST": "http://localhost:42",
         },
     }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/29954
