### PR TITLE
bazel: fix liburing configure probe failures on Fedora

### DIFF
--- a/bazel/thirdparty/liburing.patch
+++ b/bazel/thirdparty/liburing.patch
@@ -11,7 +11,7 @@
 +            # exposed by bazel, system ld gets used, which can't
 +            # resolve sysroot linker scripts in the sandbox.
 +            export LDFLAGS="-c"
- 
+
 -            # switch to the package dir to execute "configure" right there
 -            pushd $$(dirname $(location configure))
 -              mkdir -p src/include/liburing
@@ -27,7 +27,7 @@
 +            ln -sf $$pkg_dir/liburing.spec liburing.spec
 +            mkdir -p src/include/liburing
 +            $$pkg_dir/configure --use-libc
- 
+
              # collect the outputs
              for out in $(OUTS); do
 -              cp $$(realpath --relative-to=$(BINDIR) $$out) $$out
@@ -41,4 +41,12 @@
 +    ],
      tools = ["configure"],
  )
- 
+
+@@ -76,6 +89,7 @@
+         "-Wall",
+         "-Wextra",
+         "-fno-stack-protector",
++        "-Wno-unused-parameter",
+         "-include config-host.h",
+     ],
+     includes = ["src/include"],

--- a/bazel/thirdparty/liburing.patch
+++ b/bazel/thirdparty/liburing.patch
@@ -1,11 +1,16 @@
---- a/BUILD.bazel	2026-03-24 11:46:07.317446858 -0300
-+++ b/BUILD.bazel	2026-03-25 10:48:54.430923058 -0300
-@@ -20,20 +20,29 @@
+--- a/BUILD.bazel	2026-04-01 10:22:09.813888242 -0300
++++ b/BUILD.bazel	2026-04-01 11:13:26.423352671 -0300
+@@ -20,20 +20,33 @@
          "src/include/liburing/io_uring_version.h",
      ],
      cmd = """
 -            export CC=$(CC) CXX=$(CC)++
 +            export CC=$(CC) CXX=$(CC)++ CFLAGS="$(CC_FLAGS)"
++            # CORE-15978 Skip linking: probes only need compilation,
++            # and because there is no LD_FLAGS equivalent of CC_FLAGS
++            # exposed by bazel, system ld gets used, which can't
++            # resolve sysroot linker scripts in the sandbox.
++            export LDFLAGS="-c"
  
 -            # switch to the package dir to execute "configure" right there
 -            pushd $$(dirname $(location configure))
@@ -30,7 +35,6 @@
              done
            """,
 -    toolchains = ["@bazel_tools//tools/cpp:current_cc_toolchain"],
-+    local = True,
 +    toolchains = [
 +        "@bazel_tools//tools/cpp:current_cc_toolchain",
 +        "@bazel_tools//tools/cpp:cc_flags",


### PR DESCRIPTION
The liburing configure genrule probes compile-and-link test programs to detect
type/struct availability. All probes fail at the link step because GNU ld (the
system linker) cannot resolve absolute paths in the sysroot's libc.so linker
script when running inside Bazel's sandbox. On Ubuntu CI this is masked because
the host happens to have matching paths; on Fedora 43 (and likely other
non-Debian distros) the build breaks with compat.h redefinition errors.

Fix by passing `LDFLAGS="-c"` so the probes only compile. None of them execute
what they build, so linking is unnecessary. This also removes the `local=True`
workaround from PR #30029 since it is no longer needed.

[CORE-15978](https://redpandadata.atlassian.net/browse/CORE-15978)

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

[CORE-15978]: https://redpandadata.atlassian.net/browse/CORE-15978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ