### PR TITLE
DO NOT COMMIT kafka/server: add oncore assert to response

### DIFF
--- a/src/v/kafka/server/response.h
+++ b/src/v/kafka/server/response.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "base/oncore.h"
 #include "base/seastarx.h"
 #include "bytes/iobuf.h"
 #include "kafka/protocol/types.h"
@@ -32,6 +33,8 @@ public:
       , _tags(
           flex ? std::optional<tagged_fields>(tagged_fields{}) : std::nullopt)
       , _writer(_buf) {}
+
+    ~response() noexcept { _oncore.assert_shard_source_location(); }
 
     protocol::encoder& writer() { return _writer; }
 
@@ -63,6 +66,7 @@ private:
     std::optional<tagged_fields> _tags;
     iobuf _buf;
     protocol::encoder _writer;
+    oncore _oncore;
 };
 
 using response_ptr = ss::foreign_ptr<std::unique_ptr<response>>;


### PR DESCRIPTION
Validate that `kafka::response` is always created and destroyed on the
same shard. This confirms that the `foreign_ptr` wrapper on
`response_ptr` is not needed — if it fires, it means responses are
crossing shard boundaries and the `foreign_ptr` is load-bearing.

**This is a CI-only validation, do not merge.**

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none