### PR TITLE
kafka/server: remove foreign_ptr from response_ptr

### DIFF
--- a/src/v/base/oncore.h
+++ b/src/v/base/oncore.h
@@ -48,3 +48,11 @@ private:
     do {                                                                       \
         expression_in_debug_mode((member).assert_shard_source_location());     \
     } while (0)
+
+/// An oncore that debug-asserts same-shard in its destructor.
+/// Embed as a member to catch cross-shard destruction in debug builds.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions,hicpp-special-member-functions)
+struct oncore_auto final {
+    ~oncore_auto() noexcept { oncore_debug_verify(_oncore); }
+    oncore _oncore;
+};

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -19,6 +19,7 @@
 #include "kafka/server/handlers/details/security.h"
 #include "kafka/server/handlers/handler_probe.h"
 #include "kafka/server/logger.h"
+#include "kafka/server/response.h"
 #include "net/connection.h"
 #include "net/server_probe.h"
 #include "proto/redpanda/core/admin/v2/kafka_connections.proto.h"
@@ -48,8 +49,6 @@
 #include <vector>
 
 namespace kafka {
-
-using response_ptr = ss::foreign_ptr<std::unique_ptr<response>>;
 
 using closed_connections_t
   = std::deque<ss::lw_shared_ptr<const proto::admin::kafka_connection>>;

--- a/src/v/kafka/server/protocol_utils.cc
+++ b/src/v/kafka/server/protocol_utils.cc
@@ -155,7 +155,8 @@ ss::scattered_message<char> response_as_scattered(response_ptr response) {
           msg.append_static(src, sz);
           return ss::stop_iteration::no;
       });
-    // MUST be the foreign ptr not the iobuf
+    // The response must outlive the scattered message since the message
+    // references the iobuf fragments directly via append_static.
     msg.on_delete([response = std::move(response)] {});
     return msg;
 }

--- a/src/v/kafka/server/response.h
+++ b/src/v/kafka/server/response.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "base/oncore.h"
 #include "base/seastarx.h"
 #include "bytes/iobuf.h"
 #include "kafka/protocol/types.h"
@@ -63,9 +64,10 @@ private:
     std::optional<tagged_fields> _tags;
     iobuf _buf;
     protocol::encoder _writer;
+    oncore_auto _oncore;
 };
 
-using response_ptr = ss::foreign_ptr<std::unique_ptr<response>>;
+using response_ptr = std::unique_ptr<response>;
 
 struct process_result_stages {
     process_result_stages(


### PR DESCRIPTION
The `response_ptr` type was `ss::foreign_ptr<std::unique_ptr<response>>`,
but the `foreign_ptr` wrapper is unnecessary: the response is always
allocated and destroyed on the connection's shard. The wrapper was added
in 2020 (1313f09f4f) when `iobuf` stopped forwarding fragment deleters
to the home core, but this is now handled at a higher level by
`foreign_record_batch_reader`. The `respond()` path in `request_context`
serializes into fresh local buffers, so the response iobuf never
contains foreign fragments.

This PR adds an `oncore_auto` helper (an `oncore` that debug-asserts
same-shard in its destructor), embeds it in `response`, and replaces
`foreign_ptr<unique_ptr<response>>` with a plain `unique_ptr<response>`.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none