### PR TITLE
`ct`: respect `max.compaction.lag.ms` in the `reconciler`

### DIFF
--- a/src/v/cloud_topics/reconciler/BUILD
+++ b/src/v/cloud_topics/reconciler/BUILD
@@ -69,6 +69,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics/level_zero/stm:ctp_stm_api",
         "//src/v/config",
         "//src/v/kafka/utils:txn_reader",
+        "//src/v/storage",
         "//src/v/utils:retry_chain_node",
     ],
     visibility = ["//visibility:public"],

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -74,9 +74,16 @@ reconciler<Clock>::reconciler(
   , _metadata_cache(metadata_cache)
   , _reconciler_sg(reconciler_sg)
   , _upload_part_size(config::shard_local_cfg().cloud_topics_upload_part_size())
+  , _min_interval_binding(
+      config::shard_local_cfg().cloud_topics_reconciliation_min_interval.bind())
+  , _max_interval_binding(
+      config::shard_local_cfg().cloud_topics_reconciliation_max_interval.bind())
   , _reconciliation_sem(
       config::shard_local_cfg().cloud_topics_reconciliation_parallelism(),
-      "reconciler/parallelism") {}
+      "reconciler/parallelism") {
+    _min_interval_binding.watch([this]() { _loop_cv.signal(); });
+    _max_interval_binding.watch([this]() { _loop_cv.signal(); });
+}
 
 template<class Clock>
 reconciler<Clock>::topic_scheduler_state::topic_scheduler_state(
@@ -168,6 +175,7 @@ ss::future<> reconciler<Clock>::start() {
 template<class Clock>
 ss::future<> reconciler<Clock>::stop() {
     _as.request_abort();
+    _loop_cv.broken();
     co_await _gate.close();
 }
 
@@ -236,9 +244,11 @@ ss::future<> reconciler<Clock>::reconciliation_loop() {
         auto next_wait = compute_next_wait();
 
         try {
-            co_await ss::sleep_abortable<Clock>(next_wait, _as);
-        } catch (const ss::sleep_aborted&) {
-            // If the sleep was aborted, we can exit our loop
+            co_await _loop_cv.wait(next_wait);
+        } catch (const ss::condition_variable_timed_out&) {
+            // Normal timeout, fall through to reconcile.
+        } catch (const ss::broken_condition_variable&) {
+            // If the condition variable was broken, we can exit our loop
             co_return;
         }
 

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -159,7 +159,19 @@ typename Clock::duration reconciler<Clock>::compute_next_wait() const {
         min_wait = std::min(min_wait, wait);
     }
 
-    return std::min(min_wait, default_wait);
+    auto result = std::min(min_wait, default_wait);
+
+    // Check compaction lag deadlines across all sources.
+    for (auto& [_, src] : _sources) {
+        auto remaining = src->compaction_lag_remaining();
+        if (remaining.has_value()) {
+            auto dur = std::chrono::duration_cast<typename Clock::duration>(
+              remaining.value());
+            result = std::min(result, std::max(dur, Clock::duration::zero()));
+        }
+    }
+
+    return result;
 }
 
 template<class Clock>
@@ -365,7 +377,16 @@ ss::future<> reconciler<Clock>::reconcile() {
         auto next_due = sched_it->second.last_reconciled
                         + sched_it->second.scheduler.current_interval();
 
-        if (now >= next_due) {
+        // For compacted topics, cap next_due by the max_compaction_lag_ms
+        // deadline of the oldest unreconciled data.
+        auto is_due_for_compaction = [&]() -> bool {
+            auto remaining = topic_sources.front()->compaction_lag_remaining();
+            return remaining.has_value()
+                   && remaining.value() <= std::chrono::milliseconds{0};
+        };
+        bool is_due = now >= next_due || is_due_for_compaction();
+
+        if (is_due) {
             due_topics.push_back(std::move(topic_sources));
         }
     }

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -25,6 +25,7 @@
 #include "model/fundamental.h"
 #include "ssx/semaphore.h"
 
+#include <seastar/core/condition-variable.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/scheduling.hh>
@@ -305,6 +306,9 @@ private:
     // does not take effect without a restart (and without bumping the
     // corresponding memory reservation).
     size_t _upload_part_size;
+    ss::condition_variable _loop_cv;
+    config::binding<std::chrono::milliseconds> _min_interval_binding;
+    config::binding<std::chrono::milliseconds> _max_interval_binding;
     // Bounds total concurrent domain-level reconciliations (multipart
     // uploads) across all topics on this shard.
     ssx::named_semaphore<Clock> _reconciliation_sem;

--- a/src/v/cloud_topics/reconciler/reconciliation_source.cc
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.cc
@@ -22,6 +22,8 @@
 #include "model/fundamental.h"
 #include "model/record_batch_reader.h"
 #include "model/timeout_clock.h"
+#include "storage/segment.h"
+#include "storage/segment_set.h"
 #include "utils/retry_chain_node.h"
 
 #include <expected>
@@ -148,6 +150,51 @@ public:
         co_return model::make_readahead_record_batch_reader(
           model::make_record_batch_reader<kafka::read_committed_reader>(
             std::move(tracker), std::move(reader.reader)));
+    }
+
+    std::optional<std::chrono::milliseconds>
+    compaction_lag_remaining() override {
+        if (!has_pending_data()) {
+            return std::nullopt;
+        }
+
+        const auto& cfg = _partition->get_ntp_config();
+
+        if (!cfg.is_remotely_compacted()) {
+            return std::nullopt;
+        }
+
+        auto max_lag = cfg.max_compaction_lag_ms();
+
+        std::optional<model::timestamp> earliest_ts;
+        try {
+            auto lro = last_reconciled_offset();
+            auto ot_state = _partition->get_offset_translator_state();
+            auto next_kafka = kafka::next_offset(lro);
+            auto log_offset = ot_state->to_log_offset(
+              kafka::offset_cast(next_kafka));
+            const auto& segs = _partition->log()->segments();
+            auto it = segs.lower_bound(log_offset);
+
+            for (; it != segs.end(); ++it) {
+                const auto& seg = *it;
+                auto ts = seg->index().base_timestamp();
+                if (!earliest_ts.has_value() || ts < earliest_ts.value()) {
+                    earliest_ts = ts;
+                }
+            }
+        } catch (...) {
+            // fallthrough
+        }
+
+        if (!earliest_ts.has_value()) {
+            return std::nullopt;
+        }
+
+        const auto now = to_time_point(model::timestamp::now());
+        const auto age = now - to_time_point(earliest_ts.value());
+        return std::chrono::duration_cast<std::chrono::milliseconds>(
+          max_lag - age);
     }
 
 private:

--- a/src/v/cloud_topics/reconciler/reconciliation_source.h
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.h
@@ -83,6 +83,13 @@ public:
     virtual ss::future<model::record_batch_reader>
       make_reader(reader_config) = 0;
 
+    // Returns the remaining time until this source's max.compaction.lag.ms
+    // deadline, based on the lowest base timestamp of all unreconciled data.
+    // Returns std::nullopt if the topic is not compacted or has no pending
+    // unreconciled data.
+    virtual std::optional<std::chrono::milliseconds>
+    compaction_lag_remaining() = 0;
+
 private:
     model::ntp _ntp;
     model::topic_id_partition _tidp;

--- a/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
@@ -60,9 +60,8 @@ public:
         return src;
     }
 
-    void reconcile() {
-        // Advance the clock to ensure all topics are due for reconciliation.
-        ss::manual_clock::advance(std::chrono::hours(1));
+    void reconcile(ss::manual_clock::duration advance = std::chrono::hours(1)) {
+        ss::manual_clock::advance(advance);
         _reconciler.reconcile().get();
     }
 
@@ -747,4 +746,49 @@ TEST_F(ReconcilerTest, DetachDuringReconcileDoesNotOrphanScheduler) {
     // the orphaned scheduler has no matching sources.
     reconcile();
     EXPECT_EQ(_reconciler.topic_scheduler_count_for_tests(), 1);
+}
+
+TEST_F(ReconcilerTest, CompactionLagDeadlinePassed) {
+    auto src = add_source();
+    src->add_batch({.count = 10});
+
+    // First reconcile to establish a real last_reconciled timestamp.
+    reconcile();
+    EXPECT_EQ(src->last_reconciled_offset(), kafka::offset{9});
+
+    // Add more data. Set deadline 5 seconds in the past.
+    src->add_batch({.count = 10});
+    src->set_compaction_deadline(
+      ss::manual_clock::now() - std::chrono::seconds{5});
+
+    // Without advancing the clock, the adaptive interval hasn't elapsed,
+    // but the compaction lag deadline has passed so it should reconcile.
+    reconcile_without_advancing_clock();
+    EXPECT_EQ(src->last_reconciled_offset(), kafka::offset{19});
+}
+
+TEST_F(ReconcilerTest, CompactionLagDeadlineInFuture) {
+    auto src = add_source();
+    src->add_batch({.count = 10});
+
+    // First reconcile to establish a real last_reconciled timestamp.
+    reconcile();
+    EXPECT_EQ(src->last_reconciled_offset(), kafka::offset{9});
+
+    // Add more data. Deadline is 15 seconds in the future.
+    src->add_batch({.count = 10});
+    src->set_compaction_deadline(
+      ss::manual_clock::now() + std::chrono::seconds{15});
+
+    // Without advancing the clock, the topic should NOT be due.
+    reconcile_without_advancing_clock();
+    EXPECT_EQ(src->last_reconciled_offset(), kafka::offset{9});
+
+    // Advance by 6 seconds — still 9 seconds until deadline, not due.
+    reconcile(std::chrono::seconds{6});
+    EXPECT_EQ(src->last_reconciled_offset(), kafka::offset{9});
+
+    // Advance past the deadline (another 10 seconds, total 16s > 15s).
+    reconcile(std::chrono::seconds{10});
+    EXPECT_EQ(src->last_reconciled_offset(), kafka::offset{19});
 }

--- a/src/v/cloud_topics/reconciler/tests/test_utils.h
+++ b/src/v/cloud_topics/reconciler/tests/test_utils.h
@@ -89,10 +89,24 @@ public:
           std::move(log));
     }
 
+    std::optional<std::chrono::milliseconds>
+    compaction_lag_remaining() override {
+        if (!_compaction_deadline.has_value()) {
+            return std::nullopt;
+        }
+        auto now = ss::manual_clock::now();
+        return std::chrono::duration_cast<std::chrono::milliseconds>(
+          _compaction_deadline.value() - now);
+    }
+
     void fail_set_lro(bool fail) { _fail_set_lro = fail; }
     void fail_make_reader(bool fail) { _fail_make_reader = fail; }
     void set_on_make_reader(std::function<void()> cb) {
         _on_make_reader = std::move(cb);
+    }
+    void set_compaction_deadline(
+      std::optional<ss::manual_clock::time_point> deadline) {
+        _compaction_deadline = deadline;
     }
 
 private:
@@ -101,6 +115,7 @@ private:
     bool _fail_set_lro = false;
     bool _fail_make_reader = false;
     std::function<void()> _on_make_reader;
+    std::optional<ss::manual_clock::time_point> _compaction_deadline;
 };
 
 class unreliable_metastore : public l1::simple_metastore {

--- a/tests/rptest/tests/cloud_topics/e2e_test.py
+++ b/tests/rptest/tests/cloud_topics/e2e_test.py
@@ -471,3 +471,98 @@ class EndToEndCloudTopicsCompactionTest(EndToEndCloudTopicsBase):
                 backoff_sec=1,
                 err_msg="Did not see a fully compacted CTP log.",
             )
+
+
+class EndToEndCloudTopicsCompactionLagTest(EndToEndCloudTopicsBase):
+    """Verify that the reconciler respects max.compaction.lag.ms for compacted
+    cloud topics, even when the reconciliation interval is set very high."""
+
+    # Use a normal min interval for the initial reconciliation.
+    RECONCILIATION_MIN_INTERVAL_MS = 2000
+    MAX_COMPACTION_LAG_MS = 10000  # 10 seconds
+
+    # We will create the topic manually with a custom config
+    topics = ()
+
+    def __init__(self, test_context):
+        extra_rp_conf = {
+            "cloud_topics_reconciliation_min_interval": self.RECONCILIATION_MIN_INTERVAL_MS,
+        }
+        super().__init__(test_context, extra_rp_conf)
+
+    def _metric_sum(self, metric_name):
+        assert self.redpanda
+        return self.redpanda.metric_sum(
+            metric_name=metric_name,
+            metrics_endpoint=MetricsEndpoint.METRICS,
+        )
+
+    def _partitions_reconciled(self):
+        return self._metric_sum(
+            "vectorized_cloud_topics_reconciler_partitions_reconciled_total"
+        )
+
+    @cluster(num_nodes=3)
+    def test_max_compaction_lag_forces_reconciliation(self):
+        """Create a compacted cloud topic with max.compaction.lag.ms,
+        produce data, and verify the reconciler lifts it to L1. Then
+        increase the reconciliation interval to be much longer than the
+        lag, produce more data, and verify it still gets reconciled
+        within the lag window."""
+        assert self.redpanda
+        self.rpk.create_topic(
+            topic=self.s3_topic_name,
+            partitions=1,
+            replicas=3,
+            config={
+                TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD,
+                "cleanup.policy": TopicSpec.CLEANUP_COMPACT,
+                "max.compaction.lag.ms": str(self.MAX_COMPACTION_LAG_MS),
+            },
+        )
+
+        # Produce initial data and wait for it to be reconciled.
+        for i in range(10):
+            self.rpk.produce(
+                self.s3_topic_name,
+                f"key-{i}",
+                f"value-{i}",
+            )
+        wait_until(
+            lambda: self._partitions_reconciled() > 0,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Initial reconciliation did not happen",
+        )
+
+        # Bump the reconciliation interval before producing more data.
+        self.redpanda.set_cluster_config(
+            {
+                "cloud_topics_reconciliation_min_interval": 3600000,
+                "cloud_topics_reconciliation_max_interval": 3600000,
+            }
+        )
+
+        # Produce more data.
+        reconciled_before = self._partitions_reconciled()
+        for i in range(10):
+            self.rpk.produce(
+                self.s3_topic_name,
+                f"key-{i}",
+                f"new-value-{i}",
+            )
+
+        # Alter the reconciliation interval once again to wake the reconciler up.
+        self.redpanda.set_cluster_config(
+            {
+                "cloud_topics_reconciliation_min_interval": 3600001,
+                "cloud_topics_reconciliation_max_interval": 3600001,
+            }
+        )
+
+        wait_until(
+            lambda: self._partitions_reconciled() > reconciled_before,
+            timeout_sec=self.MAX_COMPACTION_LAG_MS // 1000 + 30,
+            backoff_sec=2,
+            err_msg=("Reconciler did not reconcile within max.compaction.lag.ms"),
+        )


### PR DESCRIPTION
We need to respect `max.compaction.lag.ms` in the reconciler- this Kafka property dictates the maximum amount of time that is allowed to pass before data should be considered eligible for compaction. Because we only compact data in L1, this means the reconciler needs to consider the timestamps of unreconciled Kafka data and topic level `max.compaction.lag.ms` properties for topics with a `compact` enabled `cleanup.policy` when scheduling the reconciliation of data in L0.
  
Backporting because `v26.1.x` is still fresh and these changes should be clean/easily justifiable

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
