### PR TITLE
kgo-verifier: fix transactional produce offset tracking

### DIFF
--- a/tests/go/kgo-verifier/pkg/worker/repeater/repeater_worker.go
+++ b/tests/go/kgo-verifier/pkg/worker/repeater/repeater_worker.go
@@ -375,7 +375,7 @@ loop:
 		}
 
 		if v.transactionsEnabled {
-			if _, err := v.transactionSTM.BeforeMessageSent(); err != nil {
+			if err := v.transactionSTM.BeforeMessageSent(); err != nil {
 				log.Errorf("Produce error; transaction failure: %v", err)
 				break loop
 			}

--- a/tests/go/kgo-verifier/pkg/worker/transaction_stm.go
+++ b/tests/go/kgo-verifier/pkg/worker/transaction_stm.go
@@ -85,13 +85,13 @@ func (t *TransactionSTM) BeforeMessageSent() error {
 	}
 
 	if !t.activeTransaction {
-		t.abortedTransaction = t.config.abortRate >= rand.Float64()
-		t.activeTransaction = true
-
 		if err := t.client.BeginTransaction(); err != nil {
 			log.Errorf("Couldn't start a transaction: %v", err)
 			return err
 		}
+
+		t.abortedTransaction = t.config.abortRate >= rand.Float64()
+		t.activeTransaction = true
 
 		log.Debugf("Started transaction; will abort = %t", t.abortedTransaction)
 	}

--- a/tests/go/kgo-verifier/pkg/worker/transaction_stm.go
+++ b/tests/go/kgo-verifier/pkg/worker/transaction_stm.go
@@ -64,49 +64,40 @@ func (t *TransactionSTM) TryEndTransaction() error {
 	return nil
 }
 
-// Returns true iff a new transaction was started and/or a current
-// transaction ended. This is to notify any producers that control
-// markers will be added to a partition's log.
-func (t *TransactionSTM) BeforeMessageSent() (int64, error) {
-	// EndTransaction/abort and BeginTransaction will each leave
-	// one control record in each partition's log.
-	var addedControlMarkers int64 = 0
-
+// BeforeMessageSent ends the current transaction if it has reached
+// msgsPerTransaction, then begins a new one if needed. Must be called
+// before each produce.
+func (t *TransactionSTM) BeforeMessageSent() error {
 	if t.currentMgsProduced == t.config.msgsPerTransaction {
 		if err := t.client.Flush(t.ctx); err != nil {
 			log.Errorf("Unable to flush: %v", err)
-			return addedControlMarkers, err
+			return err
 		}
 		if err := t.client.EndTransaction(t.ctx, kgo.TransactionEndTry(!t.abortedTransaction)); err != nil {
 			log.Errorf("Unable to end transaction: %v", err)
-			return addedControlMarkers, err
+			return err
 		}
 
 		log.Debugf("Ended transaction; aborted = %t", t.abortedTransaction)
 
 		t.currentMgsProduced = 0
 		t.activeTransaction = false
-
-		addedControlMarkers += 1
 	}
 
-	// Begin new transaction if one doesn't exist
 	if !t.activeTransaction {
 		t.abortedTransaction = t.config.abortRate >= rand.Float64()
 		t.activeTransaction = true
 
 		if err := t.client.BeginTransaction(); err != nil {
 			log.Errorf("Couldn't start a transaction: %v", err)
-			return 0, err
+			return err
 		}
 
 		log.Debugf("Started transaction; will abort = %t", t.abortedTransaction)
-
-		addedControlMarkers += 1
 	}
 
 	t.currentMgsProduced += 1
-	return addedControlMarkers, nil
+	return nil
 }
 
 func (t *TransactionSTM) InAbortedTransaction() bool {

--- a/tests/go/kgo-verifier/pkg/worker/transaction_stm.go
+++ b/tests/go/kgo-verifier/pkg/worker/transaction_stm.go
@@ -112,3 +112,9 @@ func (t *TransactionSTM) BeforeMessageSent() (int64, error) {
 func (t *TransactionSTM) InAbortedTransaction() bool {
 	return t.abortedTransaction
 }
+
+// WillEndTransaction returns true if the next call to BeforeMessageSent
+// will end the current transaction (msgsPerTransaction has been reached).
+func (t *TransactionSTM) WillEndTransaction() bool {
+	return t.activeTransaction && t.currentMgsProduced == t.config.msgsPerTransaction
+}

--- a/tests/go/kgo-verifier/pkg/worker/verifier/producer_worker.go
+++ b/tests/go/kgo-verifier/pkg/worker/verifier/producer_worker.go
@@ -398,7 +398,7 @@ func (pw *ProducerWorker) produceInner(n int64) (int64, []BadOffset, error) {
 		if pw.transactionsEnabled {
 			willEnd := pw.transactionSTM.WillEndTransaction()
 
-			_, err := pw.transactionSTM.BeforeMessageSent()
+			err := pw.transactionSTM.BeforeMessageSent()
 			if err != nil {
 				log.Errorf("Transaction error %v", err)
 				errored = true

--- a/tests/go/kgo-verifier/pkg/worker/verifier/producer_worker.go
+++ b/tests/go/kgo-verifier/pkg/worker/verifier/producer_worker.go
@@ -381,6 +381,14 @@ func (pw *ProducerWorker) produceInner(n int64) (int64, []BadOffset, error) {
 		rlimiter = rate.NewLimiter(rate.Limit(pw.config.rateLimitBytes), pw.config.rateLimitBytes)
 	}
 
+	// Per-partition tracking for transaction control record offsets.
+	// txPartitions tracks which partitions the current transaction has
+	// produced to (for commit/abort marker offset prediction).
+	// txPartitionSeen tracks whether we've already accounted for the
+	// fence batch on a partition in this transaction.
+	txPartitions := make(map[int32]bool)
+	txPartitionSeen := make(map[int32]bool)
+
 	for i := int64(0); i < n && !errored; i = i + 1 {
 		concurrent.Acquire(context.Background(), 1)
 		produced += 1
@@ -388,7 +396,9 @@ func (pw *ProducerWorker) produceInner(n int64) (int64, []BadOffset, error) {
 		var p = rand.Int31n(pw.config.nPartitions)
 
 		if pw.transactionsEnabled {
-			addedControlMarkers, err := pw.transactionSTM.BeforeMessageSent()
+			willEnd := pw.transactionSTM.WillEndTransaction()
+
+			_, err := pw.transactionSTM.BeforeMessageSent()
 			if err != nil {
 				log.Errorf("Transaction error %v", err)
 				errored = true
@@ -396,14 +406,24 @@ func (pw *ProducerWorker) produceInner(n int64) (int64, []BadOffset, error) {
 				break
 			}
 
-			if addedControlMarkers > 0 {
-				for i, _ := range nextOffset {
-					for j := int64(0); j < int64(addedControlMarkers); j = j + 1 {
-						pw.validOffsets.Insert(p, nextOffset[i]+j)
-					}
-					nextOffset[i] += addedControlMarkers
+			if willEnd {
+				// EndTransaction writes one commit/abort control
+				// batch to each partition the transaction touched
+				for tp := range txPartitions {
+					nextOffset[tp] += 1
 				}
+				txPartitions = make(map[int32]bool)
+				txPartitionSeen = make(map[int32]bool)
 			}
+
+			// First produce to this partition in this transaction
+			// triggers AddPartitionsToTxn which writes a fence
+			// batch (1 offset) before the data record
+			if !txPartitionSeen[p] {
+				nextOffset[p] += 1
+				txPartitionSeen[p] = true
+			}
+			txPartitions[p] = true
 		}
 
 		if pw.churnProducers && pw.Status.Sent > 0 && pw.Status.Sent%int64(pw.config.messagesPerProducerId) == 0 {


### PR DESCRIPTION
Transactional produces panicked or reported false bad_offsets because the offset prediction didn't account for control records correctly. The old code advanced nextOffset on all partitions using the count from BeforeMessageSent(), but control records only land in partitions the transaction actually wrote to, and BeginTransaction doesn't write a log record.

Redpanda writes two kinds of control records per transaction:
- A fence batch (1 offset) on each partition when it is first added to a transaction via AddPartitionsToTxn
- A commit/abort batch (1 offset) on each touched partition when EndTransaction is called

Track which partitions each transaction produces to and predict the fence and commit/abort offsets per-partition. Offset mismatches remain strict errors.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
