### PR TITLE
perf: Enable greedy leader balancer in all CPD tests

### DIFF
--- a/tests/rptest/perf/datalake_test.py
+++ b/tests/rptest/perf/datalake_test.py
@@ -26,10 +26,10 @@ from rptest.services.redpanda import PandaproxyConfig, SISettings, SchemaRegistr
 from rptest.tests.datalake.catalog_service_factory import filesystem_catalog_type
 from rptest.tests.datalake.datalake_services import DatalakeServices
 from rptest.tests.datalake.utils import supported_storage_types
-from rptest.tests.redpanda_test import RedpandaTest
+from rptest.perf.redpanda_perf_test import RedpandaPerfTest
 
 
-class DatalakeTest(RedpandaTest):
+class DatalakeTest(RedpandaPerfTest):
     def __init__(self, test_ctx: TestContext, *args: Any, **kwargs: Any):
         self._ctx = test_ctx
         super(DatalakeTest, self).__init__(

--- a/tests/rptest/perf/openmessaging_perf_test.py
+++ b/tests/rptest/perf/openmessaging_perf_test.py
@@ -12,16 +12,17 @@ from ducktape.tests.test import TestContext
 from rptest.services.cluster import cluster
 from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark
 from rptest.services.openmessaging_benchmark_configs import OMBSampleConfigurations
-from rptest.tests.redpanda_test import RedpandaTest
+from rptest.perf.redpanda_perf_test import RedpandaPerfTest
 
 
-class RedPandaOpenMessagingBenchmarkPerf(RedpandaTest):
+class RedPandaOpenMessagingBenchmarkPerf(RedpandaPerfTest):
     BENCHMARK_WAIT_TIME_MIN = 10
 
     def __init__(self, ctx: TestContext):
         self._ctx = ctx
         super(RedPandaOpenMessagingBenchmarkPerf, self).__init__(
-            test_context=ctx, num_brokers=3
+            test_context=ctx,
+            num_brokers=3,
         )
 
     @cluster(num_nodes=6)

--- a/tests/rptest/perf/redpanda_perf_test.py
+++ b/tests/rptest/perf/redpanda_perf_test.py
@@ -1,0 +1,21 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from typing import Any
+
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class RedpandaPerfTest(RedpandaTest):
+    def __init__(self, *args: Any, **kwargs: Any):
+        extra_rp_conf: dict[str, Any] = kwargs.get("extra_rp_conf") or {}
+        kwargs["extra_rp_conf"] = extra_rp_conf
+        if "leader_balancer_mode" not in extra_rp_conf:
+            extra_rp_conf["leader_balancer_mode"] = "greedy"
+        super().__init__(*args, **kwargs)

--- a/tests/rptest/perf/rpk_benchmark_test.py
+++ b/tests/rptest/perf/rpk_benchmark_test.py
@@ -12,10 +12,10 @@ from typing import Any
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import ResourceSettings
 from rptest.services.rpk_benchmark_service import RpkBenchmarkService
-from rptest.tests.redpanda_test import RedpandaTest
+from rptest.perf.redpanda_perf_test import RedpandaPerfTest
 
 
-class RpkBenchmarkPerf(RedpandaTest):
+class RpkBenchmarkPerf(RedpandaPerfTest):
     PARTITIONS = 18
     REPLICAS = 3
     CLIENTS = 60
@@ -25,7 +25,10 @@ class RpkBenchmarkPerf(RedpandaTest):
         # drop shards to two to reduce noise
         resource_settings = ResourceSettings(num_cpus=2)
         super().__init__(
-            *args, num_brokers=3, resource_settings=resource_settings, **kwargs
+            *args,
+            num_brokers=3,
+            resource_settings=resource_settings,
+            **kwargs,
         )
 
     def run_workload(self) -> None:

--- a/tests/rptest/perf/small_batches_test.py
+++ b/tests/rptest/perf/small_batches_test.py
@@ -2,17 +2,18 @@ from ducktape.tests.test import TestContext
 from rptest.services.cluster import cluster
 from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark
 from rptest.services.openmessaging_benchmark_configs import OMBSampleConfigurations
-from rptest.tests.redpanda_test import RedpandaTest
+from rptest.perf.redpanda_perf_test import RedpandaPerfTest
 
 
-class SmallBatchesTest(RedpandaTest):
+class SmallBatchesTest(RedpandaPerfTest):
     """
     A many clients and partitions test where producers send small batches to Redpanda.
     """
 
     def __init__(self, ctx: TestContext):
         super(SmallBatchesTest, self).__init__(
-            test_context=ctx, extra_rp_conf={"aggregate_metrics": True}
+            test_context=ctx,
+            extra_rp_conf={"aggregate_metrics": True},
         )
 
     @cluster(num_nodes=6)

--- a/tests/rptest/perf/ts_read_openmessaging_test.py
+++ b/tests/rptest/perf/ts_read_openmessaging_test.py
@@ -13,10 +13,10 @@ from rptest.services.cluster import cluster
 from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark
 from rptest.services.openmessaging_benchmark_configs import OMBSampleConfigurations
 from rptest.services.redpanda import SISettings
-from rptest.tests.redpanda_test import RedpandaTest
+from rptest.perf.redpanda_perf_test import RedpandaPerfTest
 
 
-class TSReadOpenmessagingTest(RedpandaTest):
+class TSReadOpenmessagingTest(RedpandaPerfTest):
     BENCHMARK_WAIT_TIME_MIN = 15
 
     def __init__(self, ctx):

--- a/tests/rptest/perf/ts_read_single_consumer_omb.py
+++ b/tests/rptest/perf/ts_read_single_consumer_omb.py
@@ -14,10 +14,10 @@ from rptest.services.cluster import cluster
 from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark
 from rptest.services.openmessaging_benchmark_configs import OMBSampleConfigurations
 from rptest.services.redpanda import SISettings
-from rptest.tests.redpanda_test import RedpandaTest
+from rptest.perf.redpanda_perf_test import RedpandaPerfTest
 
 
-class TSReadSingleConsumerOMBTest(RedpandaTest):
+class TSReadSingleConsumerOMBTest(RedpandaPerfTest):
     BENCHMARK_WAIT_TIME_MIN = 15
 
     def __init__(self, ctx: TestContext):

--- a/tests/rptest/perf/ts_write_openmessaging_test.py
+++ b/tests/rptest/perf/ts_write_openmessaging_test.py
@@ -11,10 +11,10 @@ from rptest.services.cluster import cluster
 from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark
 from rptest.services.openmessaging_benchmark_configs import OMBSampleConfigurations
 from rptest.services.redpanda import SISettings
-from rptest.tests.redpanda_test import RedpandaTest
+from rptest.perf.redpanda_perf_test import RedpandaPerfTest
 
 
-class TSWriteOpenmessagingTest(RedpandaTest):
+class TSWriteOpenmessagingTest(RedpandaPerfTest):
     BENCHMARK_WAIT_TIME_MIN = 10
 
     def __init__(self, ctx):


### PR DESCRIPTION
Enable greedy leader balancer unconditionally in CPD for more stable leadership behaviour.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes


* none
