### PR TITLE
rptest: add retries with exponential backoff for tsh commands

### DIFF
--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -21,27 +21,51 @@ TSH_RETRY_COUNT = 3
 TSH_RETRY_BACKOFF_SEC = 5
 
 
-def run_with_retries(cmd: list[str],
-                     retries: int = TSH_RETRY_COUNT,
-                     backoff_sec: float = TSH_RETRY_BACKOFF_SEC,
-                     logger=None,
-                     **kwargs) -> bytes:
+def run_with_retries(
+    cmd: list[str],
+    retries: int = TSH_RETRY_COUNT,
+    backoff_sec: float = TSH_RETRY_BACKOFF_SEC,
+    logger=None,
+    **kwargs,
+) -> bytes:
     """Run a subprocess command with retries on CalledProcessError.
 
     Intended for tsh/ssh commands that may fail transiently due to
-    connectivity or auth issues.
+    connectivity or auth issues. Makes ``retries`` total attempts with
+    exponential backoff (backoff_sec, 2*backoff_sec, ...) between them.
     """
+    if retries < 1:
+        raise ValueError(f"retries must be >= 1, got {retries}")
+
+    # Capture stderr so that error output is available for logging.
+    kwargs.setdefault("stderr", subprocess.STDOUT)
+
+    last_err: subprocess.CalledProcessError | None = None
     for attempt in range(1, retries + 1):
         try:
             return subprocess.check_output(cmd, **kwargs)
         except subprocess.CalledProcessError as e:
-            if attempt == retries:
-                raise
-            if logger:
-                logger.warning(
-                    f"Command failed (attempt {attempt}/{retries}, "
-                    f"rc={e.returncode}): {' '.join(cmd)}")
-            time.sleep(backoff_sec * (2**(attempt - 1)))
+            last_err = e
+            output = ""
+            if e.output:
+                output = e.output.decode("utf-8", errors="replace")[:300]
+            if attempt < retries:
+                if logger:
+                    logger.warning(
+                        f"Command failed (attempt {attempt}/{retries}, "
+                        f"rc={e.returncode}): {' '.join(cmd)}"
+                        + (f"\n{output}" if output else "")
+                    )
+                time.sleep(backoff_sec * (2 ** (attempt - 1)))
+    if logger and last_err:
+        output = ""
+        if last_err.output:
+            output = last_err.output.decode("utf-8", errors="replace")[:300]
+        logger.error(
+            f"Command failed after {retries} attempts: {' '.join(cmd)}"
+            + (f"\n{output}" if output else "")
+        )
+    raise last_err  # type: ignore[misc]
 
 
 def is_redpanda_pod(pod_obj: dict[str, Any], cluster_id: str) -> bool:

--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -10,10 +10,38 @@
 import json
 import os
 import subprocess
+import time
 from logging import Logger
 from typing import Any, Generator, Union, overload, Literal
 
 SUPPORTED_PROVIDERS = ["aws", "gcp", "azure"]
+
+# Default retry settings for transient tsh/ssh failures
+TSH_RETRY_COUNT = 3
+TSH_RETRY_BACKOFF_SEC = 5
+
+
+def run_with_retries(cmd: list[str],
+                     retries: int = TSH_RETRY_COUNT,
+                     backoff_sec: float = TSH_RETRY_BACKOFF_SEC,
+                     logger=None,
+                     **kwargs) -> bytes:
+    """Run a subprocess command with retries on CalledProcessError.
+
+    Intended for tsh/ssh commands that may fail transiently due to
+    connectivity or auth issues.
+    """
+    for attempt in range(1, retries + 1):
+        try:
+            return subprocess.check_output(cmd, **kwargs)
+        except subprocess.CalledProcessError as e:
+            if attempt == retries:
+                raise
+            if logger:
+                logger.warning(
+                    f"Command failed (attempt {attempt}/{retries}, "
+                    f"rc={e.returncode}): {' '.join(cmd)}")
+            time.sleep(backoff_sec * (2**(attempt - 1)))
 
 
 def is_redpanda_pod(pod_obj: dict[str, Any], cluster_id: str) -> bool:
@@ -446,7 +474,7 @@ class KubectlTool:
         self._redpanda.logger.info(filename_path)
         setup_cmd = self._scp_cmd(filename_path, f"{self._remote_uri}:")
         self._redpanda.logger.info(setup_cmd)
-        subprocess.check_output(setup_cmd)
+        run_with_retries(setup_cmd, logger=self._redpanda.logger)
         apply_cmd = ["kubectl", "apply", "-f", filename]
         self._ssh_cmd(apply_cmd)
 

--- a/tests/rptest/services/cloud_broker.py
+++ b/tests/rptest/services/cloud_broker.py
@@ -5,7 +5,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Any
 
-from rptest.clients.kubectl import KubeNodeShell
+from rptest.clients.kubectl import KubeNodeShell, run_with_retries
 
 
 @dataclass
@@ -108,7 +108,7 @@ class CloudBroker:
             script_path, f"{self._kubeclient._remote_uri}:{unique_script_name}"
         )
         self.logger.debug(_scp_cmd)
-        subprocess.check_output(_scp_cmd)
+        run_with_retries(_scp_cmd, logger=self.logger)
         # Copy agent -> broker node
         remote_path = os.path.join("/tmp", script_name)
         _cp_cmd = self._kubeclient._ssh_prefix() + [
@@ -120,7 +120,7 @@ class CloudBroker:
             f"{self.nodeshell.pod_name}:{remote_path}",
         ]
         self.logger.debug(_cp_cmd)
-        subprocess.check_output(_cp_cmd)
+        run_with_retries(_cp_cmd, logger=self.logger)
 
         # Remove script from agent node
         self._kubeclient._ssh_cmd(["rm", unique_script_name])

--- a/tests/rptest/services/cloud_broker.py
+++ b/tests/rptest/services/cloud_broker.py
@@ -1,6 +1,5 @@
 import json
 import os
-import subprocess
 import uuid
 from dataclasses import dataclass
 from typing import Any


### PR DESCRIPTION
Attempts to fix latest iteration of DEVPROD-1907.

Transient tsh scp/ssh failures during cloud test setup (e.g. connectivity blips, auth token timing) cause test failures before the actual test runs. Add a `run_with_retries` helper that retries up to 3 times with exponential backoff (5s, 10s, 20s) and apply it to the bare `subprocess.check_output` calls in `KubectlTool._setup_privileged_pod` and `CloudBroker.inject_script`.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
