### PR TITLE
`config`: purge known deprecated cluster properties

### DIFF
--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -12,6 +12,7 @@
 #include "config_manager.h"
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 #include "base/vlog.h"
 #include "cluster/config_frontend.h"
 #include "cluster/controller_service.h"
@@ -53,6 +54,62 @@ static constexpr std::string_view cache_file = "config_cache.yaml";
 
 // The filename within the data directory to use for first-start bootstrap
 static constexpr std::string_view bootstrap_file = ".bootstrap.yaml";
+
+// Property names that were fully removed from the configuration in past
+// versions. These need to be filtered out of _raw_values, the config cache, and
+// snapshots to prevent them from accumulating indefinitely.
+static const absl::flat_hash_set<ss::sstring> removed_properties{
+  "enable_coproc",
+  "coproc_max_inflight_bytes",
+  "coproc_max_ingest_bytes",
+  "coproc_max_batch_size",
+  "coproc_offset_flush_interval_ms",
+  "seed_server_meta_topic_partitions",
+  "min_version",
+  "max_version",
+  "raft_recovery_default_read_size",
+  "use_scheduling_groups",
+  "enable_admin_api",
+  "target_quota_byte_rate",
+  "target_fetch_quota_byte_rate",
+  "kafka_admin_topic_api_rate",
+  "tm_sync_timeout_ms",
+  "tx_registry_sync_timeout_ms",
+  "tm_violation_recovery_policy",
+  "rm_sync_timeout_ms",
+  "find_coordinator_timeout_ms",
+  "seq_table_min_size",
+  "rm_violation_recovery_policy",
+  "alter_topic_cfg_timeout_ms",
+  "log_message_timestamp_alert_before_ms",
+  "log_message_timestamp_alert_after_ms",
+  "metadata_status_wait_timeout_ms",
+  "log_compaction_adjacent_merge_self_compaction_count",
+  "log_compaction_disable_tx_batch_removal",
+  "transaction_coordinator_replication",
+  "id_allocator_replication",
+  "create_topic_timeout_ms",
+  "wait_for_leader_timeout_ms",
+  "recovery_append_timeout_ms",
+  "raft_max_concurrent_append_requests_per_follower",
+  "tx_registry_log_capacity",
+  "node_management_operation_timeout_ms",
+  "kafka_client_group_byte_rate_quota",
+  "kafka_client_group_fetch_byte_rate_quota",
+  "cloud_storage_reconciliation_ms",
+  "cloud_storage_disable_metadata_consistency_checks",
+  "full_raft_configuration_recovery_pattern",
+  "leader_balancer_mode",
+  "kafka_throughput_throttling_v2",
+  "kafka_quota_balancer_window",
+  "kafka_quota_balancer_node_period",
+  "kafka_quota_balancer_min_shard_throughput_ratio",
+  "kafka_quota_balancer_min_shard_throughput_bps",
+  "schema_registry_protobuf_renderer_v2",
+  "kafka_memory_batch_size_estimate_for_fetch",
+  "datalake_disk_space_monitor_interval",
+};
+
 
 config_manager::config_manager(
   config_manager::preload_result preload,

--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -399,8 +399,18 @@ static void preload_local(
         }
     } else {
         if (result.has_value()) {
-            vlog(clusterlog.info, "Ignoring unknown property: {}", key);
-            result.value().get().unknown.push_back(key);
+            bool is_deprecated = is_deprecated_property(key);
+            vlog(
+              clusterlog.info,
+              "Ignoring {} property: {}",
+              is_deprecated ? "deprecated" : "unknown",
+              key);
+            if (!is_deprecated) {
+                // Don't push back deprecated properties into the "unknown"
+                // category. They should be effectively purged from snapshots &
+                // the cache.
+                result.value().get().unknown.push_back(key);
+            }
         }
     }
 }
@@ -431,8 +441,18 @@ static void preload_local(
         return preload_local(key, ss::sstring(raw_value), result);
     } else {
         if (result.has_value()) {
-            vlog(clusterlog.info, "Ignoring unknown property: {}", key);
-            result.value().get().unknown.push_back(key);
+            bool is_deprecated = is_deprecated_property(key);
+            vlog(
+              clusterlog.info,
+              "Ignoring {} property: {}",
+              is_deprecated ? "deprecated" : "unknown",
+              key);
+            if (!is_deprecated) {
+                // Don't push back deprecated properties into the "unknown"
+                // category. They should be effectively purged from snapshots &
+                // the cache.
+                result.value().get().unknown.push_back(key);
+            }
         }
     }
 }
@@ -443,9 +463,18 @@ config_manager::preload_join(const controller_join_snapshot& snap) {
 
     result.version = snap.config.version;
     for (const auto& i : snap.config.values) {
-        result.raw_values.insert(i);
         auto& key = i.first;
         auto& value = i.second;
+
+        if (is_deprecated_property(key)) {
+            vlog(
+              clusterlog.info,
+              "Purging deprecated property from snapshot: {}",
+              key);
+            continue;
+        }
+
+        result.raw_values.insert(i);
 
         // Run locally to get validation fields of result
         preload_local(key, value, std::ref(result));
@@ -576,11 +605,21 @@ ss::future<config_manager::preload_result> config_manager::load_cache() {
         co_return result;
     }
 
+    bool should_purge_deprecated = false;
     for (const auto& i : config) {
         ss::sstring key = i.first.as<std::string>();
         auto& value = i.second;
         if (key == version_key) {
             result.version = value.as<config_version>();
+            continue;
+        }
+
+        if (is_deprecated_property(key)) {
+            vlog(
+              clusterlog.info,
+              "Purging deprecated property from cache: {}",
+              key);
+            should_purge_deprecated = true;
             continue;
         }
 
@@ -598,6 +637,12 @@ ss::future<config_manager::preload_result> config_manager::load_cache() {
         // Broadcast value to all shards
         co_await ss::smp::invoke_on_all(
           [&key, &value]() { preload_local(key, value, std::nullopt); });
+    }
+
+    if (should_purge_deprecated) {
+        // Rewrite the cache file immediately so deprecated properties don't
+        // linger on disk until the next config change.
+        co_await write_local_cache(result.version, result.raw_values);
     }
 
     co_return result;
@@ -701,12 +746,20 @@ apply_local(const cluster_config_delta_cmd_data& data, bool silent) {
     auto result = config_manager::apply_result{};
     for (const auto& u : data.upsert) {
         if (!cfg.contains(u.key)) {
-            // We never heard of this property.  Record it as unknown
-            // in our config_status.
+            bool is_deprecated = is_deprecated_property(u.key);
             if (!silent) {
-                vlog(clusterlog.info, "Unknown property {}", u.key);
+                vlog(
+                  clusterlog.info,
+                  "Ignoring {} property: {}",
+                  is_deprecated ? "deprecated" : "unknown",
+                  u.key);
             }
-            result.unknown.push_back(u.key);
+            if (!is_deprecated) {
+                // Don't push back deprecated properties into the "unknown"
+                // category. They should be effectively purged from snapshots &
+                // the cache.
+                result.unknown.push_back(u.key);
+            }
             continue;
         }
         auto& property = cfg.get(u.key);
@@ -880,6 +933,13 @@ config_manager::store_delta(const cluster_config_delta_cmd_data& data) {
     auto& cfg = config::shard_local_cfg();
 
     for (const auto& u : data.upsert) {
+        if (is_deprecated_property(u.key)) {
+            // Deprecated properties should be effectively purged from snapshots
+            // & the cache.
+            _raw_values.erase(u.key);
+            continue;
+        }
+
         /// skip section
         if (!cfg.contains(u.key)) {
             // passthrough unknown values
@@ -905,6 +965,11 @@ config_manager::store_delta(const cluster_config_delta_cmd_data& data) {
     for (const auto& d : data.remove) {
         _raw_values.erase(d);
     }
+
+    // Purge any lingering removed properties from _raw_values.
+    std::erase_if(_raw_values, [](const auto& kv) {
+        return is_deprecated_property(kv.first);
+    });
 
     return write_local_cache(_seen_version, _raw_values);
 }

--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -110,6 +110,18 @@ static const absl::flat_hash_set<ss::sstring> removed_properties{
   "datalake_disk_space_monitor_interval",
 };
 
+/// Check if a property should be purged from _raw_values. True for properties
+/// in the removed set (fully deleted from binary) and for deprecated_property
+/// instances still registered in the config store.
+static bool is_deprecated_property(const ss::sstring& key) {
+    if (removed_properties.contains(key)) {
+        return true;
+    }
+    auto& cfg = config::shard_local_cfg();
+    return cfg.contains(key)
+           && dynamic_cast<config::deprecated_property*>(&cfg.get(key))
+                != nullptr;
+}
 
 config_manager::config_manager(
   config_manager::preload_result preload,

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -257,6 +257,39 @@ class ClusterConfigHelpersMixin:
         self.redpanda.restart_nodes(self.redpanda.nodes)
         self._check_value_everywhere(key, expect_value)
 
+    def _upgrade(self, wipe_cache, version: RedpandaVersion = RedpandaInstaller.HEAD):
+        self.installer.install(self.redpanda.nodes, version)
+        for node in self.redpanda.nodes:
+            self.redpanda.stop_node(node)
+
+            if wipe_cache:
+                # Erase the cluster config cache, so that the node will replay from
+                # controller log and/or controller snapshots
+                cache_path = f"{self.redpanda.DATA_DIR}/config_cache.yaml"
+                self.logger.info("Erasing config cache on {node.name} at {cache_path}")
+                assert node.account.exists(cache_path)
+                node.account.remove(cache_path)
+
+            self.redpanda.start_node(node)
+
+        def all_versions_are_the_same():
+            admin = Admin(self.redpanda)
+            node_features = [admin.get_features(n) for n in self.redpanda.nodes]
+
+            self.logger.info(
+                f"Current cluster versions: {[f['cluster_version'] for f in node_features]}"
+            )
+            return all(
+                f["cluster_version"] == f["node_latest_version"] for f in node_features
+            )
+
+        wait_until(
+            all_versions_are_the_same,
+            30,
+            1,
+            "failed waiting for all brokers to report the same version",
+        )
+
 
 class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
     def __init__(self, *args, **kwargs):
@@ -2576,39 +2609,6 @@ class ClusterConfigLegacyDefaultTest(RedpandaTest, ClusterConfigHelpersMixin):
     def setUp(self):
         pass
 
-    def _upgrade(self, wipe_cache, version: RedpandaVersion = RedpandaInstaller.HEAD):
-        self.installer.install(self.redpanda.nodes, version)
-        for node in self.redpanda.nodes:
-            self.redpanda.stop_node(node)
-
-            if wipe_cache:
-                # Erase the cluster config cache, so that the node will replay from
-                # controller log and/or controller snapshots
-                cache_path = f"{self.redpanda.DATA_DIR}/config_cache.yaml"
-                self.logger.info("Erasing config cache on {node.name} at {cache_path}")
-                assert node.account.exists(cache_path)
-                node.account.remove(cache_path)
-
-            self.redpanda.start_node(node)
-
-        def all_versions_are_the_same():
-            admin = Admin(self.redpanda)
-            node_features = [admin.get_features(n) for n in self.redpanda.nodes]
-
-            self.logger.info(
-                f"Current cluster versions: {[f['cluster_version'] for f in node_features]}"
-            )
-            return all(
-                f["cluster_version"] == f["node_latest_version"] for f in node_features
-            )
-
-        wait_until(
-            all_versions_are_the_same,
-            30,
-            1,
-            "failed waiting for all brokers to report the same version",
-        )
-
     @cluster(num_nodes=3)
     @parametrize(wipe_cache=True)
     @parametrize(wipe_cache=False)
@@ -2735,6 +2735,152 @@ class ClusterConfigUnknownTest(RedpandaTest):
 
         # issue would appear when reloading the property back
         self.redpanda.restart_nodes(self.redpanda.nodes[0])
+
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    @matrix(wipe_cache=[False, True])
+    def test_removed_property_purged(self, wipe_cache):
+        """
+        Test that properties which have been removed completely from the binary/configuration
+        do not appear as unknown in the config status API. "enable_coproc" is
+        an example of a property that was once deprecated and since removed, and is in the
+        removed_properties set in config_manager.cc.
+        """
+        REMOVED_PROPERTY = "enable_coproc"
+        UNKNOWN_PROPERTY = "enable_coproc2"
+        cache_path = f"{self.redpanda.DATA_DIR}/config_cache.yaml"
+
+        # Force-write a removed property into the raft log
+        self.admin.patch_cluster_config(upsert={REMOVED_PROPERTY: "true"}, force=True)
+        # Force-write an unknown property into the raft log for a sanity check
+        self.admin.patch_cluster_config(upsert={UNKNOWN_PROPERTY: "true"}, force=True)
+
+        def _read_cache(node):
+            return node.account.ssh_output(f"cat {cache_path}").decode("utf-8")
+
+        # Wait for the unknown property to appear on all nodes (confirms
+        # status reconciliation is complete), then check the deprecated
+        # property is absent.
+        def _unknown_visible_deprecated_absent():
+            statuses = self.admin.get_cluster_config_status()
+            return all(
+                UNKNOWN_PROPERTY in s.get("unknown", [])
+                and REMOVED_PROPERTY not in s.get("unknown", [])
+                for s in statuses
+            )
+
+        wait_until(
+            _unknown_visible_deprecated_absent,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Expected unknown property visible and deprecated property absent",
+        )
+
+        # The removed property should not be in the config cache on any node,
+        # but the unknown property should be (it's preserved for rolling
+        # upgrade safety).
+        for node in self.redpanda.nodes:
+            cache = _read_cache(node)
+            assert REMOVED_PROPERTY not in cache, (
+                f"{REMOVED_PROPERTY} should not be in config cache on {node.name}"
+            )
+            assert UNKNOWN_PROPERTY in cache, (
+                f"{UNKNOWN_PROPERTY} should be in config cache on {node.name}"
+            )
+
+        # Restart all nodes
+        for node in self.redpanda.nodes:
+            self.redpanda.stop_node(node)
+
+            if wipe_cache:
+                # Erase the cluster config cache, so that the node will replay
+                # from controller log and/or controller snapshots
+                self.logger.info(f"Erasing config cache on {node.name}")
+                assert node.account.exists(cache_path)
+                node.account.remove(cache_path)
+
+            self.redpanda.start_node(node)
+
+        # Same status check after restart.
+        wait_until(
+            _unknown_visible_deprecated_absent,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Expected unknown property visible and deprecated property absent after restart",
+        )
+
+        # Config cache should still be clean after restart.
+        for node in self.redpanda.nodes:
+            cache = _read_cache(node)
+            assert REMOVED_PROPERTY not in cache, (
+                f"{REMOVED_PROPERTY} should not be in config cache on {node.name} after restart"
+            )
+            assert UNKNOWN_PROPERTY in cache, (
+                f"{UNKNOWN_PROPERTY} should be in config cache on {node.name} after restart"
+            )
+
+
+class ClusterConfigRemovedPropertyUpgradeTest(RedpandaTest, ClusterConfigHelpersMixin):
+    """
+    Test that properties removed from the configuration are purged from the
+    config cache and status API after upgrading from a version where they
+    were deprecated_property instances.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.admin = Admin(self.redpanda)
+        self.installer = self.redpanda._installer
+        self.initial_version = (25, 3)
+
+    def setUp(self):
+        self.installer.install(self.redpanda.nodes, self.initial_version)
+        super().setUp()
+
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    @matrix(wipe_cache=[False, True])
+    def test_removed_property_purged_on_upgrade(self, wipe_cache):
+        """
+        Start on v25.3 where enable_coproc exists as a deprecated_property,
+        set it, then upgrade to HEAD and verify it is purged.
+        """
+        REMOVED_PROPERTY = "enable_coproc"
+        # On v25.3 enable_coproc is a known deprecated_property. Setting it
+        # writes a delta to the raft log and stores the value in the config
+        # cache, even though the property value is ignored.
+        self.admin.patch_cluster_config(upsert={REMOVED_PROPERTY: "true"}, force=True)
+
+        def _deprecated_absent():
+            statuses = self.admin.get_cluster_config_status()
+            return all(REMOVED_PROPERTY not in s.get("unknown", []) for s in statuses)
+
+        # On the old version it should not be unknown (it's a known
+        # deprecated_property).
+        wait_until(
+            _deprecated_absent,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Expected unknown property visible and deprecated property absent",
+        )
+
+        for version in self.installer.upgrade_path_to_head(self.initial_version):
+            self._upgrade(wipe_cache, version)
+
+        # After upgrade to HEAD, enable_coproc is fully removed from the
+        # binary and is in the removed_properties set. Our purge logic should
+        # have cleaned it from _raw_values and the status API.
+        statuses = self.admin.get_cluster_config_status()
+        for s in statuses:
+            assert REMOVED_PROPERTY not in s.get("unknown", []), (
+                f"Removed property should not appear as unknown after upgrade on node {s['node_id']}"
+            )
+
+        # The removed property should have been purged from the config cache.
+        cache_path = f"{self.redpanda.DATA_DIR}/config_cache.yaml"
+        for node in self.redpanda.nodes:
+            cache = node.account.ssh_output(f"cat {cache_path}").decode("utf-8")
+            assert REMOVED_PROPERTY not in cache, (
+                f"{REMOVED_PROPERTY} should not be in config cache on {node.name} after upgrade"
+            )
 
 
 class DevelopmentFeatureTest(RedpandaTest):


### PR DESCRIPTION
In commit https://github.com/redpanda-data/redpanda/commit/798f02d1e0d477317fc1a1ed27054616d18e6099, we purged a bunch of long standing `deprecated_property`s from the binary entirely. However, because these properties have been persistent in user's `config_cache`s as well as their controller snapshots, they end up recognized as "unknown" properties in the admin endpoint post removal. This wouldn't be a huge issue, except the Redpanda operator up till now tries to issue AdminAPI commands to remove these unknown properties, leading to an upgrade failure for helm & a reconciliation wedge (though this has been turned into a no-op on unknown properties in https://github.com/redpanda-data/redpanda-operator/pull/1377).

This obviously is bad and we need a better deprecation process for `deprecated_property`s on the core side, since we shouldn't be limited to keeping these around forever. Unfortunately, for the `deprecated_property`s that were already removed, we don't have much of a choice but to hardcode these property names back into the core code in order to prevent them from being applied to in-memory state, as well as purge them from persistent storage in `config_cache`s and controller snapshots.

So, now, when applying cluster config deltas, preloading from the `config_cache`, and ultimately when writing back to controller snapshots & the cache, we will ignore and purge any deprecated properties. A new `write_local_cache()` call is added to the preload stage in order to purge any deprecated properties while they are still present.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Improvements

* Purge known deprecated properties from in-memory configuration state & broker local config caches in the configuration system. 
