### PR TITLE
[v25.3.x] [CORE-15990] Audit/Kafka RPC: Add exponential backoff to audit client and memory pressure guard to k/d/rpc service

### DIFF
--- a/src/v/kafka/data/rpc/BUILD
+++ b/src/v/kafka/data/rpc/BUILD
@@ -39,6 +39,7 @@ redpanda_cc_library(
         "//src/v/serde:map",
         "//src/v/serde:vector",
         "//src/v/ssx:async_algorithm",
+        "//src/v/ssx:semaphore",
         "//src/v/storage",
         "//src/v/storage:record_batch_builder",
         "//src/v/transform/stm",

--- a/src/v/kafka/data/rpc/client.cc
+++ b/src/v/kafka/data/rpc/client.cc
@@ -54,9 +54,11 @@ std::invoke_result_t<Func> retry_with_backoff(Func func, ss::abort_source* as) {
           ss::futurize_invoke(func));
         backoff.next_backoff();
         if (fut.failed()) {
-            if (attempts < max_client_retries) {
+            if (attempts >= max_client_retries) {
                 co_return co_await std::move(fut);
             }
+            auto ex = fut.get_exception();
+            vlog(log.debug, "Retrying after error: {}", ex);
             continue;
         }
         result_type r = fut.get();

--- a/src/v/kafka/data/rpc/service.cc
+++ b/src/v/kafka/data/rpc/service.cc
@@ -11,7 +11,9 @@
 
 #include "kafka/data/rpc/service.h"
 
+#include "cluster/errc.h"
 #include "kafka/data/partition_proxy.h"
+#include "logger.h"
 #include "model/ktp.h"
 #include "model/metadata.h"
 #include "model/record.h"
@@ -34,6 +36,9 @@
 #include <utility>
 
 namespace kafka::data::rpc {
+
+using namespace std::chrono_literals;
+
 namespace {
 
 raft::replicate_options
@@ -222,6 +227,30 @@ ss::future<result<model::offset, cluster::errc>> local_service::produce(
 
 ss::future<produce_reply>
 network_service::produce(produce_request req, ::rpc::streaming_context&) {
+    static constexpr size_t memory_pressure_denominator = 10;
+    if (_server_memory != nullptr) {
+        auto available = _server_memory->current();
+        if (available <= _server_memory_total / memory_pressure_denominator) {
+            thread_local static ss::logger::rate_limit rate(1s);
+            log.log(
+              ss::log_level::warn,
+              rate,
+              "Rejecting produce request: RPC server memory pressure "
+              "(available={}, total={})",
+              available,
+              _server_memory_total);
+            produce_reply reply;
+            for (auto& td : req.topic_data) {
+                // errc::timeout is used here becuase clients already treat it
+                // as a retryable error. for a future major release, it would be
+                // better to add some explicit backoff advice to the produce
+                // response, similar to how the real kafka API works. for a
+                // serde-compatible OOM backstop, this is good enough.
+                reply.results.emplace_back(td.tp, cluster::errc::timeout);
+            }
+            co_return reply;
+        }
+    }
     co_await ss::coroutine::switch_to(get_scheduling_group());
     auto results = co_await _service->local().produce(
       std::move(req.topic_data), req.timeout);

--- a/src/v/kafka/data/rpc/service.h
+++ b/src/v/kafka/data/rpc/service.h
@@ -13,6 +13,7 @@
 #include "kafka/data/rpc/rpc_service.h"
 #include "kafka/data/rpc/serde.h"
 #include "model/fundamental.h"
+#include "ssx/semaphore.h"
 
 #include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/sharded.hh>
@@ -63,12 +64,24 @@ private:
  */
 class network_service final : public impl::kafka_data_rpc_service {
 public:
+    struct memory_config {
+        ssx::semaphore* memory{nullptr};
+        ssize_t total{0};
+    };
+
     network_service(
       ss::scheduling_group sc,
       ss::smp_service_group ssg,
-      ss::sharded<local_service>* service)
+      ss::sharded<local_service>* service,
+      memory_config mem_cfg)
       : impl::kafka_data_rpc_service{sc, ssg}
-      , _service(service) {}
+      , _service(service)
+      , _server_memory(mem_cfg.memory)
+      , _server_memory_total(mem_cfg.total) {
+        vassert(
+          (_server_memory == nullptr) == (_server_memory_total == 0),
+          "memory_config: memory and total must both be set or both be zero");
+    }
 
     ss::future<produce_reply>
     produce(produce_request, ::rpc::streaming_context&) override;
@@ -78,6 +91,8 @@ public:
 
 private:
     ss::sharded<local_service>* _service;
+    ssx::semaphore* _server_memory{nullptr};
+    ssize_t _server_memory_total{0};
 };
 
 } // namespace kafka::data::rpc

--- a/src/v/kafka/data/rpc/test/BUILD
+++ b/src/v/kafka/data/rpc/test/BUILD
@@ -14,7 +14,9 @@ redpanda_test_cc_library(
         "//src/v/kafka/data/rpc",
         "//src/v/model",
         "//src/v/model/tests:random",
+        "//src/v/rpc",
         "@abseil-cpp//absl/container:flat_hash_map",
+        "@seastar",
     ],
 )
 

--- a/src/v/kafka/data/rpc/test/deps.cc
+++ b/src/v/kafka/data/rpc/test/deps.cc
@@ -1,5 +1,7 @@
 #include "kafka/data/rpc/test/deps.h"
 
+#include "rpc/rpc_server.h"
+
 namespace kafka::data::rpc::test {
 
 void kafka_data_test_fixture::wire_up_and_start() {
@@ -77,12 +79,17 @@ void kafka_data_test_fixture::wire_up_and_start() {
 }
 
 void kafka_data_test_fixture::register_services(
-  std::vector<std::unique_ptr<::rpc::service>>& services) {
+  std::vector<std::unique_ptr<::rpc::service>>& services,
+  ::rpc::rpc_server* server) {
     services.push_back(
       std::make_unique<kafka::data::rpc::network_service>(
         ss::default_scheduling_group(),
         ss::default_smp_service_group(),
-        &_remote_services));
+        &_remote_services,
+        kafka::data::rpc::network_service::memory_config{
+          .memory = server ? &server->memory() : nullptr,
+          .total = server ? server->cfg.max_service_memory_per_core : 0,
+        }));
 }
 
 void kafka_data_test_fixture::elect_leader(

--- a/src/v/kafka/data/rpc/test/deps.h
+++ b/src/v/kafka/data/rpc/test/deps.h
@@ -7,6 +7,12 @@
 #include "model/record.h"
 #include "model/tests/random_batch.h"
 
+#include <seastar/core/condition-variable.hh>
+
+namespace rpc {
+class rpc_server;
+} // namespace rpc
+
 namespace kafka::data::rpc::test {
 
 // A small helper struct to allow copies for easier to read tests and
@@ -440,6 +446,9 @@ public:
             --_errors_to_inject;
             co_return cluster::errc::timeout;
         }
+        if (_stalled) {
+            co_await _stall_cv.wait([this] { return !_stalled; });
+        }
         auto pp = kafka::partition_proxy(
           std::make_unique<in_memory_proxy>(ntp, &_produced_batches));
         co_return co_await fn(&pp);
@@ -451,6 +460,8 @@ public:
 
 private:
     int _errors_to_inject = 0;
+    bool _stalled{false};
+    ss::condition_variable _stall_cv;
     ss::chunked_fifo<produced_batch> _produced_batches;
     model::ntp_map_type<ss::shard_id> _shard_locations;
 };
@@ -540,8 +551,9 @@ public:
 
     void wire_up_and_start();
 
-    void
-    register_services(std::vector<std::unique_ptr<::rpc::service>>& services);
+    void register_services(
+      std::vector<std::unique_ptr<::rpc::service>>& services,
+      ::rpc::rpc_server* server = nullptr);
 
     fake_topic_metadata_cache* remote_metadata_cache() { return _remote_ftmc; }
     fake_partition_manager* remote_partition_manager() { return _remote_fpm; }

--- a/src/v/kafka/data/rpc/test/kafka_data_rpc_test.cc
+++ b/src/v/kafka/data/rpc/test/kafka_data_rpc_test.cc
@@ -29,6 +29,8 @@ namespace kafka::data::rpc::test {
 
 namespace {
 
+using namespace std::chrono_literals;
+
 constexpr uint16_t test_server_port = 8080;
 constexpr model::node_id self_node = model::node_id(1);
 constexpr model::node_id other_node = model::node_id(2);
@@ -60,7 +62,7 @@ public:
         scfg.disable_public_metrics = net::public_metrics_disabled::yes;
         _server = std::make_unique<::rpc::rpc_server>(scfg);
         std::vector<std::unique_ptr<::rpc::service>> rpc_services;
-        _kd->register_services(rpc_services);
+        _kd->register_services(rpc_services, _server.get());
         _server->add_services(std::move(rpc_services));
         _server->start();
 
@@ -131,6 +133,8 @@ public:
     model::node_id non_leader_node() const {
         return GetParam().non_leader_node;
     }
+
+    ssx::semaphore& server_memory() { return _server->memory(); }
 
     record_batches non_leader_batches(const model::ntp& ntp) {
         return batches_for(non_leader_node(), ntp);
@@ -249,6 +253,25 @@ TEST_P(KafkaDataRpcTest, ClientCanRequestPartitionOffsets) {
     auto p_offsets_2
       = offsets_2[not_existing.tp.topic][not_existing.tp.partition];
     EXPECT_EQ(p_offsets_2.err, cluster::errc::topic_not_exists);
+}
+
+TEST_P(KafkaDataRpcTest, ProduceRejectsUnderMemoryPressure) {
+    if (leader_node() == self_node) {
+        GTEST_SKIP() << "Local produces bypass network_service";
+    }
+
+    auto ntp = make_ntp("memory-pressure-test");
+    create_topic(model::topic_namespace(ntp.ns, ntp.tp.topic));
+
+    // The test server is configured with 1 GiB of RPC memory. Exhaust
+    // it past the 10% low-water mark so the memory check in
+    // network_service::produce() rejects.
+    auto units = ss::get_units(
+                   server_memory(), server_memory().available_units() - 1)
+                   .get();
+
+    auto result = produce(ntp, record_batches::make());
+    EXPECT_EQ(result, cluster::errc::timeout);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -3397,7 +3397,11 @@ void application::start_runtime_services(
             std::make_unique<kafka::data::rpc::network_service>(
               sched_groups.transforms_sg(),
               smp_service_groups.transform_smp_sg(),
-              &_kafka_data_rpc_service));
+              &_kafka_data_rpc_service,
+              kafka::data::rpc::network_service::memory_config{
+                .memory = &s.memory(),
+                .total = s.cfg.max_service_memory_per_core,
+              }));
 
           if (wasm_data_transforms_enabled()) {
               runtime_services.push_back(

--- a/src/v/security/audit/client.cc
+++ b/src/v/security/audit/client.cc
@@ -59,6 +59,10 @@ public:
             return kafka::error_code::unknown_server_error;
         };
 
+        static constexpr auto base_backoff = 500ms;
+        static constexpr uint32_t max_backoff = 8;
+        exp_backoff_policy backoff;
+
         std::optional<kafka::error_code> ec;
         while (!as().abort_requested() && ss::timer<>::clock::now() < timeout) {
             auto r = co_await _rpc_client->produce(
@@ -66,6 +70,13 @@ public:
               batch.copy());
             ec.emplace(map_ec(r));
             if (ec.value() == kafka::error_code::none) {
+                break;
+            }
+            auto delay = base_backoff
+                         * std::min(max_backoff, backoff.next_backoff());
+            try {
+                co_await ss::sleep_abortable<ss::lowres_clock>(delay, as());
+            } catch (const ss::sleep_aborted&) {
                 break;
             }
         }

--- a/src/v/security/audit/client.h
+++ b/src/v/security/audit/client.h
@@ -147,6 +147,7 @@ public:
 
     cluster::controller* controller() { return _controller; }
     const ss::abort_source& as() const { return _as; }
+    ss::abort_source& as() { return _as; }
 
 protected:
     virtual ss::future<> do_produce(

--- a/src/v/transform/rpc/client.cc
+++ b/src/v/transform/rpc/client.cc
@@ -134,9 +134,11 @@ std::invoke_result_t<Func> retry_with_backoff(Func func, ss::abort_source* as) {
           ss::futurize_invoke(func));
         backoff.next_backoff();
         if (fut.failed()) {
-            if (attempts < max_client_retries) {
+            if (attempts >= max_client_retries) {
                 co_return co_await std::move(fut);
             }
+            auto ex = fut.get_exception();
+            vlog(log.debug, "Retrying after error: {}", ex);
             continue;
         }
         result_type r = fut.get();


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30041 

Fixes https://github.com/redpanda-data/redpanda/issues/30051

**Handful of superficial conflicts. See commit messages for detail.**