### PR TITLE
`redpanda`: don't error on unknown property removal in `admin_server::patch_cluster_config_handler()`

### DIFF
--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -2303,8 +2303,6 @@ admin_server::patch_cluster_config_handler(
         for (const auto& key : update.remove) {
             if (cfg->contains(key)) {
                 cfg->get(key).reset();
-            } else {
-                errors[key] = "Unknown property";
             }
         }
 

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -2736,6 +2736,42 @@ class ClusterConfigUnknownTest(RedpandaTest):
         # issue would appear when reloading the property back
         self.redpanda.restart_nodes(self.redpanda.nodes[0])
 
+    @cluster(num_nodes=3)
+    def test_unknown_value_can_be_removed(self):
+        """
+        Test that an unknown property forced into the log can be removed through the admin API _without_
+        use of ?force=true.
+        """
+        FAKE_PROPERTY = "my_fake_property"
+        # Force-write a removed property into the raft log
+        self.admin.patch_cluster_config(upsert={FAKE_PROPERTY: "true"}, force=True)
+
+        def _unknown_visible(expect_visible):
+            statuses = self.admin.get_cluster_config_status()
+            return all(
+                (FAKE_PROPERTY in s.get("unknown", [])) == expect_visible
+                for s in statuses
+            )
+
+        # Wait for all nodes to report it as unknown
+        wait_until(
+            lambda: _unknown_visible(True),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"{FAKE_PROPERTY} did not appear as unknown on all nodes",
+        )
+
+        # Remove the unknown property without force=true
+        self.admin.patch_cluster_config(remove=[FAKE_PROPERTY], force=False)
+
+        # Wait for all nodes to no longer report it as unknown
+        wait_until(
+            lambda: _unknown_visible(False),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"{FAKE_PROPERTY} was not removed from unknown on all nodes",
+        )
+
 
 class DevelopmentFeatureTest(RedpandaTest):
     def __init__(self, test_context):


### PR DESCRIPTION
For example, If I put an unknown property into the `config_cache.yaml` or directly force it through the AdminAPI with a command like

```
curl -X PUT 'http://localhost:9644/v1/cluster_config?force=true' \
     -H 'Content-Type: application/json' \
     -d '{"upsert": {"my_fake_property": "true"}, "remove": []}'
```

Then it will be persisted to the configuration system via the `config_cache.yaml`, as well as the controller log/snapshots.

```
willem@bloom:~/redpanda$ rpk cluster config status
NODE  CONFIG-VERSION  NEEDS-RESTART  INVALID  UNKNOWN
0     24              false          []       [my_fake_property]
1     24              false          []       [my_fake_property]
2     24              false          []       [my_fake_property]
```

Up till now, an admin API deletion request would be unable to remove this without `?force=true`, instead returning an error:

```
$ curl -X PUT 'http://localhost:9644/v1/cluster_config' \
     -H 'Content-Type: application/json' \
     -d '{"upsert": {}, "remove": ["my_fake_property"]}'
 {"my_fake_property":"Unknown property"}

$ curl -X PUT 'http://localhost:9644/v1/cluster_config?force=true' \
     -H 'Content-Type: application/json' \
     -d '{"upsert": {}, "remove": ["my_fake_property"]}'
 {"config_version": 25}
```

We can choose to be silent about this instead, for the property we may be attempting to remove (very validly without removing guardrails in place via `?force=true`) _could_ be one of these unknown properties.

Remove erroring on this path and instead apply the update. This also fixes the issue encountered by the redpanda operator discussed in https://github.com/redpanda-data/redpanda-operator/pull/1377.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [X] v25.3.x
- [ ] v25.2.x

## Release Notes

### Improvements

* Don't error on potentially unknown cluster properties when attempting to issue removal requests through the admin API.
