### PR TITLE
config/tx: have reasonable defaults for idempotency/tx configurations.

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -957,14 +957,9 @@ configuration::configuration()
       "Maximum number of active producer sessions per shard. Each shard "
       "tracks producer IDs using an LRU (Least Recently Used) eviction "
       "policy. When the configured limit is exceeded, the least recently "
-      "used producer IDs are evicted from the cache. IMPORTANT: The default "
-      "value is unlimited, which can lead to unbounded memory growth and "
-      "out-of-memory (OOM) crashes in production environments with heavy "
-      "producer usage, especially when using transactions or idempotent "
-      "producers. It is strongly recommended to set a reasonable limit in "
-      "production deployments.",
+      "used producer IDs are evicted from the cache.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      std::numeric_limits<uint64_t>::max(),
+      100000,
       {.min = 1})
   , max_transactions_per_coordinator(
       *this,
@@ -976,7 +971,7 @@ configuration::configuration()
       "invalid producer epoch or invalid_producer_id_mapping error (depends on "
       "the transaction execution phase).",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      std::numeric_limits<uint64_t>::max(),
+      10000,
       {.min = 1})
   , enable_idempotence(
       *this,


### PR DESCRIPTION
max_concurrent_producer_ids: old: int64_max new: 100k
max_transactions_per_coordinator: old: int64_max new: 10k

Neither of these changes have correctness implications. Compared to defaults, they evict unused producers more aggressively.

The new defaults are also pretty generous and probably cover most usecases.

Even if a usage falls outside these defaults, worst that could happen is old producers get evicted to make room for new producers, so the old producer may have to reinit incase of transactions and most clients are already equipped to do that and it is fully transparent to idempotent producers.

On the flip side, this avoids accumulation of a ton of producers in snapshots and such.

Upgrade considerations: if there is a non default value set, nothing changes (eg: cloud). If there was no value set, the brokers pick up the new default and may do a bunch of evictions if there are many historical producers accumulated (which is rare in most applications).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
### Improvements

* `max_concurrent_producer_ids` and `max_transactions_per_coordinator` now default to   
  100,000 and 10,000 respectively (previously unlimited), reducing memory usage from
   accumulated producer state; existing explicit overrides are unaffected.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
