### PR TITLE
[CORE-8816] `rptest`: deflake `test_mirror_maker_with_limits`

### DIFF
--- a/tests/rptest/tests/controller_log_limiting_test.py
+++ b/tests/rptest/tests/controller_log_limiting_test.py
@@ -410,7 +410,6 @@ class ControllerLogLimitMirrorMakerTests(MirrorMakerService):
         self.start_workload()
 
         self.run_validation(consumer_timeout_sec=120)
-        self.mirror_maker.stop()
 
         def _all_topics_are_present():
             for t in topics:
@@ -426,6 +425,8 @@ class ControllerLogLimitMirrorMakerTests(MirrorMakerService):
             backoff_sec=2,
             err_msg="Not all the topics are present in the target cluster",
         )
+
+        self.mirror_maker.stop()
 
 
 class ControllerLogLimitPartitionBalancerTests(PartitionBalancerService):


### PR DESCRIPTION
The test stops MirrorMaker before verifying all topics are present on the target cluster. When the controller log rate limiter throttles a burst of `create_topics` requests, some topics get rejected with `throttling_quota_exceeded`. MirrorMaker would normally retry these, but since it is already stopped, the topics never appear and the test times out.

Move `mirror_maker.stop()` after the `wait_until()` check so MirrorMaker can retry throttled topic creations while the test waits.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
