### PR TITLE
`rptest`: add logging to `consumer_offsets_test`

### DIFF
--- a/tests/rptest/transactions/consumer_offsets_test.py
+++ b/tests/rptest/transactions/consumer_offsets_test.py
@@ -71,12 +71,15 @@ class VerifyConsumerOffsetsThruUpgrades(RedpandaTest):
                 )
                 collectible = []
                 for replica in state["replicas"]:
+                    node_id = replica["raft_state"]["node_id"]
                     for stm in replica["raft_state"]["stms"]:
                         if stm["name"] == "group_tx_tracker_stm.snapshot":
-                            collectible.append(
-                                stm["last_applied_offset"]
-                                == stm["max_removable_local_log_offset"]
+                            lao = stm["last_applied_offset"]
+                            mrlo = stm["max_removable_local_log_offset"]
+                            self.redpanda.logger.debug(
+                                f"node {node_id}: {lao=}, {mrlo=}"
                             )
+                            collectible.append(lao == mrlo)
                 return len(collectible) == 3 and all(collectible)
             except Exception as e:
                 self.redpanda.logger.debug(f"failed to get partition state: {e}")


### PR DESCRIPTION
For deflaking


## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
