### PR TITLE
security: include username in SCRAM authentication failure logs

### DIFF
--- a/src/v/security/scram_authenticator.cc
+++ b/src/v/security/scram_authenticator.cc
@@ -31,6 +31,10 @@ scram_authenticator<T>::handle_client_first(bytes_view auth_bytes) {
     auto credential = _credentials.get<scram_credential>(
       credential_user(authid));
     if (!credential) {
+        vlog(
+          seclog.warn,
+          "Authentication failed for user {}: not found in credential store",
+          authid);
         return errc::invalid_credentials;
     }
     _principal = credential->principal().value_or(
@@ -52,7 +56,11 @@ scram_authenticator<T>::handle_client_first(bytes_view auth_bytes) {
 
     if (
       !_client_first->authzid().empty() && _client_first->authzid() != authid) {
-        vlog(seclog.info, "Invalid authorization id and username pair");
+        vlog(
+          seclog.info,
+          "Authentication failed for user {}: invalid authorization id and "
+          "username pair",
+          authid);
         return errc::invalid_credentials;
     }
 
@@ -93,8 +101,9 @@ scram_authenticator<T>::handle_client_final(bytes_view auth_bytes) {
     if (computed_stored_key != _credential->stored_key()) {
         vlog(
           seclog.info,
-          "Authentication failed: stored and client submitted credentials do "
-          "not match");
+          "Authentication failed for user {}: stored and client submitted "
+          "credentials do not match",
+          _audit_user.name);
         return errc::invalid_credentials;
     }
 


### PR DESCRIPTION
## Summary

- Log the username in all three SCRAM authentication failure paths in `scram_authenticator.cc`:
  - **User not found** in credential store — was completely silent, now logs the attempted username
  - **Credential mismatch** — logged the failure but omitted which user, now includes username
  - **AuthzID/username pair mismatch** — same, now includes username

## Motivation

During **INC-2698** (SASL auth failure on a customer cluster after blue→green migration), broker logs showed repeated `scram_authenticator.cc:96 - Authentication failed: stored and client submitted credentials do not match` without any indication of *which* user was failing. This made it impossible to determine from logs alone whether the failures affected customer users, system users, or both — significantly slowing incident triage.

The success path already logs the username (`"Authentication key match for user {}"`), but all three failure paths omitted it.

## Test plan

- [ ] Existing SCRAM authenticator tests continue to pass
- [ ] Manual verification: trigger each failure path and confirm username appears in broker logs

Ref: INC-2698

🤖 Generated with [Claude Code](https://claude.com/claude-code)