### PR TITLE
`rptest`: ignore staged `compaction_index` files in `raise_on_storage_usage_inconsistency()`

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -4592,6 +4592,7 @@ class RedpandaService(Service, RedpandaServiceABC):
             if (
                 "compaction.staging" in file.name
                 or "compaction.compaction_index" in file.name
+                or "compaction_index.staging" in file.name
             ):
                 # compaction staging files are temporary and are generally
                 # cleaned up after compaction finishes, or at next round of


### PR DESCRIPTION
We were correctly ignoring temporarily staged `segment` files (`compaction.staging`) as well as the built `compaction_index` files for staged segment files (`compaction.compaction_index`), but we were _not_ ignoring the in-progress `compaction_index` files being built for staged `segment` files (`compaction_index.staging`).

Add a filter for these temporary files to the list of exclusions for `raise_on_storage_usage_inconsistency()`.

Fixes https://redpandadata.atlassian.net/browse/CORE-14785, 
Fixes https://redpandadata.atlassian.net/browse/CORE-15819, 
Fixes https://redpandadata.atlassian.net/browse/CORE-15766, 
Fixes https://redpandadata.atlassian.net/browse/CORE-14854

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
