### PR TITLE
[CORE-7942] dt: Fix matrix for read replica e2e test

### DIFF
--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -26,6 +26,7 @@ from rptest.services.redpanda import (
     SISettings,
     get_cloud_provider,
     get_cloud_storage_type,
+    get_cloud_storage_type_and_url_style,
     make_redpanda_service,
 )
 from rptest.services.redpanda_installer import InstallOptions, RedpandaInstaller
@@ -535,7 +536,7 @@ class TestReadReplicaService(EndToEndTest):
     @cluster(num_nodes=9, log_allow_list=READ_REPLICA_LOG_ALLOW_LIST)
     @matrix(
         partition_count=[10],
-        cloud_storage_type_and_url_style=[[CloudStorageType.S3, "path"]],
+        cloud_storage_type_and_url_style=get_cloud_storage_type_and_url_style(),
         mode=get_read_replica_sources(),
     )
     def test_simple_end_to_end(


### PR DESCRIPTION
The matrix hardcoded using S3 storage, so when CDT ran on Azure the test would fail trying to resolve minio, which wasn't started.

Fixes CORE-7942

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none