### PR TITLE
  c/tx_gateway_frontend: hold tm_stm gate in with() and with_free()

### DIFF
--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -51,10 +51,12 @@ static auto with(
   const kafka::transactional_id& tx_id,
   const std::string_view name,
   Func&& func) {
+    auto gh = stm->gate().hold();
     return stm->lock_tx(tx_id, name)
-      .then([stm, func = std::forward<Func>(func)](auto units) mutable {
+      .then([stm, func = std::forward<Func>(func), gh = std::move(gh)](
+              auto units) mutable {
           return ss::futurize_invoke(std::forward<Func>(func))
-            .finally([units = std::move(units)] {});
+            .finally([units = std::move(units), gh = std::move(gh)] {});
       });
 }
 
@@ -64,6 +66,7 @@ static auto with_free(
   const kafka::transactional_id& tx_id,
   const std::string_view name,
   Func&& func) {
+    auto gh = stm->gate().hold();
     auto units = stm->try_lock_tx(tx_id, name);
     auto f = ss::now();
 
@@ -71,11 +74,12 @@ static auto with_free(
         f = ss::make_exception_future(ss::semaphore_timed_out());
     }
 
-    return f.then(
-      [units = std::move(units), func = std::forward<Func>(func)]() mutable {
-          return ss::futurize_invoke(std::forward<Func>(func))
-            .finally([units = std::move(units)] {});
-      });
+    return f.then([units = std::move(units),
+                   func = std::forward<Func>(func),
+                   gh = std::move(gh)]() mutable {
+        return ss::futurize_invoke(std::forward<Func>(func))
+          .finally([units = std::move(units), gh = std::move(gh)] {});
+    });
 }
 
 static auto send(tx_gateway_client_protocol& cp, try_abort_request&& request) {


### PR DESCRIPTION
  Fix for this segfault:

  ```
  Backtrace:
[Backtrace #0]
seastar::guarded_backtrace(void**, int) at ././external/+non_module_dependencies+seastar/src/util/backtrace.cc:102 void seastar::backtrace<seastar::backtrace_buffer::append_backtrace()::{lambda(seastar::frame)#1}>(seastar::backtrace_buffer::append_backtrace()::{lambda(seastar::frame)#1}&&, bool) at ./external/+non_module_dependencies+seastar/include/seastar/util/backtrace.hh:89 seastar::backtrace_buffer::append_backtrace() at ././external/+non_module_dependencies+seastar/src/core/reactor.cc:801
 (inlined by) seastar::print_with_backtrace(seastar::backtrace_buffer&, bool) at ././external/+non_module_dependencies+seastar/src/core/reactor.cc:839
seastar::print_with_backtrace(char const*, bool, bool) at ././external/+non_module_dependencies+seastar/src/core/reactor.cc:859 seastar::sigsegv_action(siginfo_t*, ucontext_t*) at ././external/+non_module_dependencies+seastar/src/core/reactor.cc:4260
 (inlined by) seastar::install_oneshot_signal_handler<11, (void (*)(siginfo_t*, ucontext_t*))(&seastar::sigsegv_action)>()::{lambda(int, siginfo_t*, void*)#1}::operator()(int, siginfo_t*, void*) const at ././external/+non_module_dependencies+seastar/src/core/reactor.cc:4194
 (inlined by) seastar::install_oneshot_signal_handler<11, (void (*)(siginfo_t*, ucontext_t*))(&seastar::sigsegv_action)>()::{lambda(int, siginfo_t*, void*)#1}::__invoke(int, siginfo_t*, void*) at ././external/+non_module_dependencies+seastar/src/core/reactor.cc:4189
addr2line: '/opt/redpanda/lib/libc.so.6': No such file /opt/redpanda/lib/libc.so.6 0x4251f
std::__1::vector<ankerl::unordered_dense::v4_4_0::bucket_type::standard, std::__1::allocator<ankerl::unordered_dense::v4_4_0::bucket_type::standard> >::operator[][abi:ne200100](unsigned long) at ./external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__vector/vector.h:404
 (inlined by) chunked_vector<ankerl::unordered_dense::v4_4_0::bucket_type::standard>::operator[](unsigned long) at ./bazel-out/k8-opt/bin/src/v/container/_virtual_includes/chunked_vector/container/chunked_vector.h:241
 (inlined by) ankerl::unordered_dense::v4_4_0::detail::table<detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, kafka::kafka_transactional_id, std::__1::integral_constant<bool, false> >, cluster::tm_stm::tx_wrapper, ankerl::unordered_dense::v4_4_0::hash<detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, kafka::kafka_transactional_id, std::__1::integral_constant<bool, false> >, void>, std::__1::equal_to<detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, kafka::kafka_transactional_id, std::__1::integral_constant<bool, false> > >, chunked_vector<std::__1::pair<detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, kafka::kafka_transactional_id, std::__1::integral_constant<bool, false> >, cluster::tm_stm::tx_wrapper> >, ankerl::unordered_dense::v4_4_0::bucket_type::standard, chunked_vector<ankerl::unordered_dense::v4_4_0::bucket_type::standard>, true>::at(chunked_vector<ankerl::unordered_dense::v4_4_0::bucket_type::standard>&, unsigned long) at ./bazel-out/k8-opt/bin/external/+non_module_dependencies+unordered_dense/_virtual_includes/unordered_dense/ankerl/unordered_dense.h:873
 (inlined by) chunked_vector<std::__1::pair<detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, kafka::kafka_transactional_id, std::__1::integral_constant<bool, false> >, cluster::tm_stm::tx_wrapper> >::iter<false> ankerl::unordered_dense::v4_4_0::detail::table<detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, kafka::kafka_transactional_id, std::__1::integral_constant<bool, false> >, cluster::tm_stm::tx_wrapper, ankerl::unordered_dense::v4_4_0::hash<detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, kafka::kafka_transactional_id, std::__1::integral_constant<bool, false> >, void>, std::__1::equal_to<detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, kafka::kafka_transactional_id, std::__1::integral_constant<bool, false> > >, chunked_vector<std::__1::pair<detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, kafka::kafka_transactional_id, std::__1::integral_constant<bool, false> >, cluster::tm_stm::tx_wrapper> >, ankerl::unordered_dense::v4_4_0::bucket_type::standard, chunked_vector<ankerl::unordered_dense::v4_4_0::bucket_type::standard>, true>::do_find<detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, kafka::kafka_transactional_id, std::__1::integral_constant<bool, false> > >(detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, kafka::kafka_transactional_id, std::__1::integral_constant<bool, false> > const&) at ./bazel-out/k8-opt/bin/external/+non_module_dependencies+unordered_dense/_virtual_includes/unordered_dense/ankerl/unordered_dense.h:1161
ankerl::unordered_dense::v4_4_0::detail::table<detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, kafka::kafka_transactional_id, std::__1::integral_constant<bool, false> >, cluster::tm_stm::tx_wrapper, ankerl::unordered_dense::v4_4_0::hash<detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, kafka::kafka_transactional_id, std::__1::integral_constant<bool, false> >, void>, std::__1::equal_to<detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, kafka::kafka_transactional_id, std::__1::integral_constant<bool, false> > >, chunked_vector<std::__1::pair<detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, kafka::kafka_transactional_id, std::__1::integral_constant<bool, false> >, cluster::tm_stm::tx_wrapper> >, ankerl::unordered_dense::v4_4_0::bucket_type::standard, chunked_vector<ankerl::unordered_dense::v4_4_0::bucket_type::standard>, true>::find(detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, kafka::kafka_transactional_id, std::__1::integral_constant<bool, false> > const&) at ./bazel-out/k8-opt/bin/external/+non_module_dependencies+unordered_dense/_virtual_includes/unordered_dense/ankerl/unordered_dense.h:1804
 (inlined by) cluster::tm_stm::try_rm_lock(detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, kafka::kafka_transactional_id, std::__1::integral_constant<bool, false> > const&) at ./bazel-out/k8-opt/bin/src/v/cluster/_virtual_includes/cluster/cluster/tm_stm.h:233
seastar::continuation<seastar::internal::promise_base_with_type<boost::outcome_v2::basic_result<cluster::tx_metadata, cluster::tx::errc, boost::outcome_v2::policy::throw_bad_result_access<cluster::tx::errc, void> > >, seastar::future<boost::outcome_v2::basic_result<cluster::tx_metadata, cluster::tx::errc, boost::outcome_v2::policy::throw_bad_result_access<cluster::tx::errc, void> > >::finally_body<cluster::with<cluster::tx_gateway_frontend::process_locally(seastar::shared_ptr<cluster::tm_stm>, cluster::try_abort_request)::$_1::operator()()::{lambda()#1}>(seastar::shared_ptr<cluster::tm_stm>, detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, kafka::kafka_transactional_id, std::__1::integral_constant<bool, false> > const&, std::__1::basic_string_view<char, std::__1::char_traits<char> >, cluster::tx_gateway_frontend::process_locally(seastar::shared_ptr<cluster::tm_stm>, cluster::try_abort_request)::$_1::operator()()::{lambda()#1}&&)::{lambda(auto:1)#1}::operator()<cluster::txlock_unit>(cluster::txlock_unit)::{lambda()#1}, false>, seastar::future<boost::outcome_v2::basic_result<cluster::tx_metadata, cluster::tx::errc, boost::outcome_v2::policy::throw_bad_result_access<cluster::tx::errc, void> > >::then_wrapped_nrvo<seastar::future<boost::outcome_v2::basic_result<cluster::tx_metadata, cluster::tx::errc, boost::outcome_v2::policy::throw_bad_result_access<cluster::tx::errc, void> > >, seastar::future<boost::outcome_v2::basic_result<cluster::tx_metadata, cluster::tx::errc, boost::outcome_v2::policy::throw_bad_result_access<cluster::tx::errc, void> > >::finally_body<cluster::with<cluster::tx_gateway_frontend::process_locally(seastar::shared_ptr<cluster::tm_stm>, cluster::try_abort_request)::$_1::operator()()::{lambda()#1}>(seastar::shared_ptr<cluster::tm_stm>, detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, kafka::kafka_transactional_id, std::__1::integral_constant<bool, false> > const&, std::__1::basic_string_view<char, std::__1::char_traits<char> >, cluster::tx_gateway_frontend::process_locally(seastar::shared_ptr<cluster::tm_stm>, cluster::try_abort_request)::$_1::operator()()::{lambda()#1}&&)::{lambda(auto:1)#1}::operator()<cluster::txlock_unit>(cluster::txlock_unit)::{lambda()#1}, false> >(seastar::future<boost::outcome_v2::basic_result<cluster::tx_metadata, cluster::tx::errc, boost::outcome_v2::policy::throw_bad_result_access<cluster::tx::errc, void> > >::finally_body<cluster::with<cluster::tx_gateway_frontend::process_locally(seastar::shared_ptr<cluster::tm_stm>, cluster::try_abort_request)::$_1::operator()()::{lambda()#1}>(seastar::shared_ptr<cluster::tm_stm>, detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, kafka::kafka_transactional_id, std::__1::integral_constant<bool, false> > const&, std::__1::basic_string_view<char, std::__1::char_traits<char> >, cluster::tx_gateway_frontend::process_locally(seastar::shared_ptr<cluster::tm_stm>, cluster::try_abort_request)::$_1::operator()()::{lambda()#1}&&)::{lambda(auto:1)#1}::operator()<cluster::txlock_unit>(cluster::txlock_unit)::{lambda()#1}, false>&&)::{lambda(seastar::internal::promise_base_with_type<boost::outcome_v2::basic_result<cluster::tx_metadata, cluster::tx::errc, boost::outcome_v2::policy::throw_bad_result_access<cluster::tx::errc, void> > >&&, seastar::future<boost::outcome_v2::basic_result<cluster::tx_metadata, cluster::tx::errc, boost::outcome_v2::policy::throw_bad_result_access<cluster::tx::errc, void> > >::finally_body<cluster::with<cluster::tx_gateway_frontend::process_locally(seastar::shared_ptr<cluster::tm_stm>, cluster::try_abort_request)::$_1::operator()()::{lambda()#1}>(seastar::shared_ptr<cluster::tm_stm>, detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, kafka::kafka_transactional_id, std::__1::integral_constant<bool, false> > const&, std::__1::basic_string_view<char, std::__1::char_traits<char> >, auto:1&&)::{lambda(auto:1)#1}::operator()<cluster::txlock_unit>(auto:1)::{lambda()#1}, false>&&, seastar::future_state<boost::outcome_v2::basic_result<cluster::tx_metadata, cluster::tx::errc, boost::outcome_v2::policy::throw_bad_result_access<cluster::tx::errc, void> > >&&)#1}, boost::outcome_v2::basic_result<cluster::tx_metadata, cluster::tx::errc, boost::outcome_v2::policy::throw_bad_result_access<cluster::tx::errc, void> > >::run_and_dispose() at ./bazel-out/k8-opt/bin/src/v/cluster/_virtual_includes/cluster/cluster/tm_stm.h:447
  ```

  Seems the root cause is the lock units is accessing the stm state
  (via raw pointer) _after_ the stm got destroyed.

  This primarily happens via with() and with_free(). So the scenario is
  the the stm is shutdown and the paritition is stopped racily before
  units are returned.

  There are multiple solutions to this but holding the gate in
  with()/with_free() and preventing the stm shutdown seems the easiest
  to reason about.

  The code here is very old, super convulted and hard to reason about and
  carries a risk of introducing deadlocks with any deeper changes, so
  intentionally kept the surface area of this change simple.

Fixes: https://redpandadata.atlassian.net/browse/CORE-16022

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes
### Bug Fixes

* Fixes a rare crash due to race condition between transaction related operations and partition shutdown.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
