### PR TITLE
rptest/consumer_group_test: throttle concurrent connections in large group test

### DIFF
--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -599,11 +599,15 @@ class ConsumerGroupTest(RedpandaTest):
                     raise
 
             async def create_groups(r):
+                # Limit to 10 concurrent connections to avoid overwhelming the broker
+                sem = asyncio.Semaphore(10)
+
+                async def throttled(i):
+                    async with sem:
+                        await asyncio.to_thread(poll_once, i + r * groups_in_round)
+
                 results = await asyncio.gather(
-                    *[
-                        asyncio.to_thread(poll_once, i + r * groups_in_round)
-                        for i in range(groups_in_round)
-                    ],
+                    *[throttled(i) for i in range(groups_in_round)],
                     return_exceptions=True,
                 )
                 for res in results:


### PR DESCRIPTION
## Summary

- Fixes flaky `NoBrokersAvailable` errors in `test_large_group_count` by limiting concurrent KafkaConsumer connections to 10 using an asyncio semaphore
- Previously, 100 simultaneous connection handshakes overwhelmed the broker during `check_version()` API negotiation
- Test still creates 1000 consumer groups (10 rounds × 100 groups), but throttles the connection setup phase

## Backports Required

*  none - not a bug fix
*  none - this is a backport
* none - issue does not exist in previous branches
* none - papercut/not impactful enough to backport

## Release Notes

* none