### PR TITLE
CORE-14957 cluster_link: batch mirror topic status updates during failover

### DIFF
--- a/src/v/cluster/cluster_link/frontend.cc
+++ b/src/v/cluster/cluster_link/frontend.cc
@@ -24,6 +24,8 @@
 #include "rpc/connection_cache.h"
 #include "ssx/when_all.h"
 
+#include <algorithm>
+
 namespace cluster::cluster_link {
 
 using ::cluster_link::model::add_mirror_topic_cmd;
@@ -1181,6 +1183,12 @@ ss::future<errc> frontend::failover_link_topics(
         }
     }
 
+    if (_features->is_active(features::feature::batch_mirror_topic_status)) {
+        co_return co_await failover_link_topics_batched(
+          id, std::move(topics_to_failover), timeout);
+    }
+
+    // Legacy per-topic path for mixed-version clusters
     chunked_vector<errc> errors;
     errors.reserve(topics_to_failover.size());
     co_await ss::max_concurrent_for_each(
@@ -1204,6 +1212,57 @@ ss::future<errc> frontend::failover_link_topics(
         vlog(
           cluster::clusterlog.warn,
           "Encountered {} errors while failing over topics of link id {}",
+          errors.size(),
+          id);
+        co_return map_errc(errors.front());
+    }
+    co_return errc::success;
+}
+
+ss::future<errc> frontend::failover_link_topics_batched(
+  ::cluster_link::model::id_t id,
+  chunked_vector<::model::topic> topics,
+  model::timeout_clock::duration timeout) {
+    auto batch_size
+      = config::shard_local_cfg().shadow_link_failover_batch_size();
+
+    chunked_vector<chunked_vector<::model::topic>> batches;
+    for (size_t i = 0; i < topics.size(); i += batch_size) {
+        auto begin = std::make_move_iterator(topics.begin() + i);
+        auto end = std::make_move_iterator(
+          topics.begin() + std::min(i + batch_size, topics.size()));
+        batches.emplace_back(begin, end);
+    }
+
+    // If batch_size is 1, this will allow up to 32 concurrent RPCs, if
+    // batch_size is 32 or more, this will allow 4 concurrent RPCs, and scales
+    // linearly in between. This is to prevent too much concurrency when the
+    // batch size is large, while still allowing for more concurrency when the
+    // batch size is small.
+    auto max_concurrent = std::max<size_t>(4, 32 / batch_size);
+    chunked_vector<errc> errors;
+    co_await ss::max_concurrent_for_each(
+      batches,
+      max_concurrent,
+      [this, &errors, id, timeout](chunked_vector<::model::topic>& batch) {
+          return batch_update_mirror_topic_status(
+                   id,
+                   {.status
+                    = ::cluster_link::model::mirror_topic_status::failing_over,
+                    .topics = std::move(batch)},
+                   model::timeout_clock::now() + timeout)
+            .then([&errors](errc err_code) {
+                if (err_code != errc::success) {
+                    errors.push_back(err_code);
+                }
+            });
+      });
+
+    if (!errors.empty()) {
+        vlog(
+          cluster::clusterlog.warn,
+          "Encountered {} errors while failing over topics of link id {} "
+          "(batched)",
           errors.size(),
           id);
         co_return map_errc(errors.front());

--- a/src/v/cluster/cluster_link/frontend.cc
+++ b/src/v/cluster/cluster_link/frontend.cc
@@ -789,52 +789,15 @@ errc frontend::validator::validate_mutation(const cluster_link_cmd& cmd) const {
           return errc::success;
       },
       [this](const cluster::cluster_link_update_mirror_topic_status_cmd& cmd) {
-          auto ec = model::validate_kafka_topic_name(cmd.value.topic);
-          if (ec) {
-              vlog(cluster::clusterlog.warn, "Invalid topic name: {}", ec);
-              return errc::mirror_topic_name_invalid;
-          }
           auto meta = _table->find_link_by_id(cmd.key);
           if (!meta) {
               return errc::does_not_exist;
           }
-          auto id = _table->find_id_by_topic(cmd.value.topic);
-          if (!id.has_value()) {
-              vlog(
-                cluster::clusterlog.warn,
-                "Topic '{}' is not being mirrored",
-                cmd.value.topic);
-              return errc::topic_not_being_mirrored;
-          } else if (id.value() != cmd.key) {
-              vlog(
-                cluster::clusterlog.warn,
-                "Topic '{}' is being mirrored by another link",
-                cmd.value.topic);
-              return errc::topic_being_mirrored_by_other_link;
-          }
-          auto status = _table->find_mirror_topic_status(cmd.value.topic);
-          if (!status) {
-              vlog(
-                cluster::clusterlog.warn,
-                "Topic '{}' is not being mirrored",
-                cmd.value.topic);
-              return errc::topic_not_being_mirrored;
-          }
-          // If not a force update, ensure a valid status transition
-          if (
-            !cmd.value.force_update
-            && !::cluster_link::model::is_valid_status_transition(
-              *status, cmd.value.status)) {
-              vlog(
-                cluster::clusterlog.warn,
-                "Attempting to change state of mirror topic {} from {} to "
-                "invalid state {}",
-                cmd.value.topic,
-                *status,
-                cmd.value.status);
-              return errc::invalid_update;
-          }
-          return errc::success;
+          return validate_mirror_topic_status_update(
+            cmd.key,
+            cmd.value.topic,
+            cmd.value.status,
+            bool(cmd.value.force_update));
       },
       [this](
         const cluster::cluster_link_update_mirror_topic_properties_cmd& cmd) {
@@ -1082,6 +1045,50 @@ errc frontend::validator::validate_metadata_mirroring_config(
         }
     }
 
+    return errc::success;
+}
+
+errc frontend::validator::validate_mirror_topic_status_update(
+  ::cluster_link::model::id_t link_id,
+  const model::topic& topic,
+  ::cluster_link::model::mirror_topic_status target_status,
+  bool force_update) const {
+    auto ec = model::validate_kafka_topic_name(topic);
+    if (ec) {
+        vlog(cluster::clusterlog.warn, "Invalid topic name: {}", ec);
+        return errc::mirror_topic_name_invalid;
+    }
+    auto id = _table->find_id_by_topic(topic);
+    if (!id.has_value()) {
+        vlog(
+          cluster::clusterlog.warn, "Topic '{}' is not being mirrored", topic);
+        return errc::topic_not_being_mirrored;
+    } else if (id.value() != link_id) {
+        vlog(
+          cluster::clusterlog.warn,
+          "Topic '{}' is being mirrored by another link",
+          topic);
+        return errc::topic_being_mirrored_by_other_link;
+    }
+    auto status = _table->find_mirror_topic_status(topic);
+    if (!status) {
+        vlog(
+          cluster::clusterlog.warn, "Topic '{}' is not being mirrored", topic);
+        return errc::topic_not_being_mirrored;
+    }
+    if (
+      !force_update
+      && !::cluster_link::model::is_valid_status_transition(
+        *status, target_status)) {
+        vlog(
+          cluster::clusterlog.warn,
+          "Attempting to change state of mirror topic {} from {} to "
+          "invalid state {}",
+          topic,
+          *status,
+          target_status);
+        return errc::invalid_update;
+    }
     return errc::success;
 }
 

--- a/src/v/cluster/cluster_link/frontend.cc
+++ b/src/v/cluster/cluster_link/frontend.cc
@@ -27,6 +27,7 @@
 namespace cluster::cluster_link {
 
 using ::cluster_link::model::add_mirror_topic_cmd;
+using ::cluster_link::model::batch_update_mirror_topic_status_cmd;
 using ::cluster_link::model::delete_mirror_topic_cmd;
 using ::cluster_link::model::id_t;
 using ::cluster_link::model::metadata;
@@ -157,6 +158,19 @@ ss::future<errc> frontend::update_mirror_topic_status(
     }
     cluster_link_cmd c{
       cluster::cluster_link_update_mirror_topic_status_cmd(id, std::move(cmd))};
+    co_return co_await do_mutation(std::move(c), timeout);
+}
+
+ss::future<errc> frontend::batch_update_mirror_topic_status(
+  id_t id,
+  batch_update_mirror_topic_status_cmd cmd,
+  model::timeout_clock::time_point timeout) {
+    if (!cluster_linking_enabled()) {
+        co_return errc::feature_disabled;
+    }
+    cluster_link_cmd c{
+      cluster::cluster_link_batch_update_mirror_topic_status_cmd(
+        id, std::move(cmd))};
     co_return co_await do_mutation(std::move(c), timeout);
 }
 
@@ -438,6 +452,29 @@ ss::future<errc> frontend::dispatch_mutation_to_remote(
                         }
                         return result<void>(r.value().ec);
                     });
+              },
+              [client, timeout](
+                cluster::cluster_link_batch_update_mirror_topic_status_cmd
+                  cmd) mutable {
+                  return client
+                    .batch_update_mirror_topic_status(
+                      cluster::batch_update_mirror_topic_status_request{
+                        .link_id = cmd.key,
+                        .cmd = std::move(cmd.value),
+                        .timeout = timeout},
+                      rpc::client_opts(timeout))
+                    .then(&rpc::get_ctx_data<
+                          cluster::batch_update_mirror_topic_status_response>)
+                    .then(
+                      [](
+                        result<
+                          cluster::batch_update_mirror_topic_status_response>
+                          r) {
+                          if (r.has_error()) {
+                              return result<void>(r.error());
+                          }
+                          return result<void>(r.value().ec);
+                      });
               },
               [client, timeout](
                 cluster::cluster_link_update_mirror_topic_properties_cmd
@@ -800,6 +837,21 @@ errc frontend::validator::validate_mutation(const cluster_link_cmd& cmd) const {
             bool(cmd.value.force_update));
       },
       [this](
+        const cluster::cluster_link_batch_update_mirror_topic_status_cmd& cmd) {
+          auto meta = _table->find_link_by_id(cmd.key);
+          if (!meta) {
+              return errc::does_not_exist;
+          }
+          for (const auto& topic : cmd.value.topics) {
+              auto ec = validate_mirror_topic_status_update(
+                cmd.key, topic, cmd.value.status, false);
+              if (ec != errc::success) {
+                  return ec;
+              }
+          }
+          return errc::success;
+      },
+      [this](
         const cluster::cluster_link_update_mirror_topic_properties_cmd& cmd) {
           auto ec = model::validate_kafka_topic_name(cmd.value.topic);
           if (ec) {
@@ -1128,6 +1180,7 @@ ss::future<errc> frontend::failover_link_topics(
             topics_to_failover.push_back(t);
         }
     }
+
     chunked_vector<errc> errors;
     errors.reserve(topics_to_failover.size());
     co_await ss::max_concurrent_for_each(

--- a/src/v/cluster/cluster_link/frontend.h
+++ b/src/v/cluster/cluster_link/frontend.h
@@ -159,6 +159,11 @@ private:
     cluster::cluster_link::errc
     validate_mutation(const cluster_link_cmd&) const;
 
+    ss::future<errc> failover_link_topics_batched(
+      ::cluster_link::model::id_t,
+      chunked_vector<::model::topic>,
+      model::timeout_clock::duration);
+
     bool is_sanctioned();
 
 public:

--- a/src/v/cluster/cluster_link/frontend.h
+++ b/src/v/cluster/cluster_link/frontend.h
@@ -175,6 +175,11 @@ public:
         cluster::cluster_link::errc validate_metadata_mirroring_config(
           const ::cluster_link::model::topic_metadata_mirroring_config& config)
           const;
+        cluster::cluster_link::errc validate_mirror_topic_status_update(
+          ::cluster_link::model::id_t link_id,
+          const model::topic& topic,
+          ::cluster_link::model::mirror_topic_status target_status,
+          bool force_update) const;
 
     private:
         table* _table;

--- a/src/v/cluster/cluster_link/frontend.h
+++ b/src/v/cluster/cluster_link/frontend.h
@@ -34,6 +34,7 @@ class frontend : public ss::peering_sharded_service<frontend> {
       cluster::cluster_link_add_mirror_topic_cmd,
       cluster::cluster_link_delete_mirror_topic_cmd,
       cluster::cluster_link_update_mirror_topic_status_cmd,
+      cluster::cluster_link_batch_update_mirror_topic_status_cmd,
       cluster::cluster_link_update_mirror_topic_properties_cmd,
       cluster::cluster_link_update_cluster_link_configuration_cmd>;
 
@@ -67,6 +68,10 @@ public:
     ss::future<errc> update_mirror_topic_status(
       ::cluster_link::model::id_t,
       ::cluster_link::model::update_mirror_topic_status_cmd,
+      model::timeout_clock::time_point);
+    ss::future<errc> batch_update_mirror_topic_status(
+      ::cluster_link::model::id_t,
+      ::cluster_link::model::batch_update_mirror_topic_status_cmd,
       model::timeout_clock::time_point);
     ss::future<errc> update_mirror_topic_properties(
       ::cluster_link::model::id_t,

--- a/src/v/cluster/cluster_link/table.cc
+++ b/src/v/cluster/cluster_link/table.cc
@@ -36,6 +36,7 @@ static constexpr auto accepted_commands = cluster::make_commands_list<
   cluster::cluster_link_add_mirror_topic_cmd,
   cluster::cluster_link_delete_mirror_topic_cmd,
   cluster::cluster_link_update_mirror_topic_status_cmd,
+  cluster::cluster_link_batch_update_mirror_topic_status_cmd,
   cluster::cluster_link_update_mirror_topic_properties_cmd,
   cluster::cluster_link_update_cluster_link_configuration_cmd>();
 
@@ -255,6 +256,12 @@ ss::future<std::error_code> table::apply_update(model::record_batch b) {
             const cluster::cluster_link_update_mirror_topic_status_cmd& state) {
               return table.update_mirror_topic_state(
                 state.key, state.value, revision);
+          },
+          [&table, revision](
+            const cluster::cluster_link_batch_update_mirror_topic_status_cmd&
+              cmd) {
+              return table.batch_update_mirror_topic_state(
+                cmd.key, cmd.value, revision);
           },
           [&table, revision](
             const cluster::cluster_link_update_mirror_topic_properties_cmd&
@@ -480,6 +487,37 @@ ss::future<cluster::cluster_link::errc> table::update_mirror_topic_state(
     link_metadata->state.mirror_topics[cmd.topic].status = cmd.status;
     _link_metadata[id] = std::move(link_metadata);
 
+    _link_revision_index[id] = revision;
+    run_callbacks(id, revision);
+    co_return errc::success;
+}
+
+ss::future<cluster::cluster_link::errc> table::batch_update_mirror_topic_state(
+  id_t id,
+  const ::cluster_link::model::batch_update_mirror_topic_status_cmd& cmd,
+  model::revision_id revision) {
+    auto link_it = _link_metadata.find(id);
+    if (link_it == _link_metadata.end()) {
+        vlog(
+          cluster::clusterlog.info,
+          "Unable to batch update mirror topics: link {} not found",
+          id);
+        co_return errc::does_not_exist;
+    }
+
+    // Single deep copy for the entire batch
+    auto link_metadata = ss::make_lw_shared<metadata>(
+      co_await link_it->second->copy());
+
+    for (const auto& topic : cmd.topics) {
+        auto it = link_metadata->state.mirror_topics.find(topic);
+        if (it == link_metadata->state.mirror_topics.end()) {
+            co_return errc::topic_not_being_mirrored;
+        }
+        it->second.status = cmd.status;
+    }
+
+    _link_metadata[id] = std::move(link_metadata);
     _link_revision_index[id] = revision;
     run_callbacks(id, revision);
     co_return errc::success;

--- a/src/v/cluster/cluster_link/table.h
+++ b/src/v/cluster/cluster_link/table.h
@@ -106,6 +106,11 @@ private:
       const ::cluster_link::model::update_mirror_topic_status_cmd& cmd,
       model::revision_id);
 
+    ss::future<cluster::cluster_link::errc> batch_update_mirror_topic_state(
+      ::cluster_link::model::id_t,
+      const ::cluster_link::model::batch_update_mirror_topic_status_cmd& cmd,
+      model::revision_id);
+
     ss::future<cluster::cluster_link::errc> update_mirror_topic_properties(
       ::cluster_link::model::id_t,
       const ::cluster_link::model::update_mirror_topic_properties_cmd&,

--- a/src/v/cluster/cluster_link/tests/frontend_validation_test.cc
+++ b/src/v/cluster/cluster_link/tests/frontend_validation_test.cc
@@ -19,6 +19,7 @@
 namespace cluster::cluster_link {
 
 using ::cluster_link::model::add_mirror_topic_cmd;
+using ::cluster_link::model::batch_update_mirror_topic_status_cmd;
 using ::cluster_link::model::connection_config;
 using ::cluster_link::model::delete_mirror_topic_cmd;
 using ::cluster_link::model::id_t;
@@ -166,6 +167,13 @@ public:
         }
 
         co_return ec;
+    }
+
+    cluster::cluster_link::errc batch_update_mirror_topic_status_validate(
+      id_t id, batch_update_mirror_topic_status_cmd cmd) {
+        cluster::cluster_link_batch_update_mirror_topic_status_cmd update_cmd{
+          id, std::move(cmd)};
+        return _validator->validate_mutation(std::move(update_cmd));
     }
 
     ss::future<cluster::cluster_link::errc>
@@ -1215,6 +1223,96 @@ TEST_F_CORO(
           co_await update_cluster_link_configuration(*id, update_cmd.copy()),
           errc::topic_property_excluded_from_mirroring);
     }
+}
+
+TEST_F_CORO(
+  frontend_validation_test, batch_update_mirror_topic_status_success) {
+    model::topic test_topic("mirror-link1");
+
+    auto m = create_base_metadata();
+    testing::set_link_mirror_topics(
+      m, test_topic, mirror_topic_status::active, test_topic);
+    ASSERT_EQ_CORO(co_await upsert_cluster_link(std::move(m)), errc::success);
+    auto id = _table.local().find_id_by_name(name_t("link1"));
+    ASSERT_TRUE_CORO(id.has_value());
+
+    chunked_vector<model::topic> topics;
+    topics.push_back(test_topic);
+
+    EXPECT_EQ(
+      batch_update_mirror_topic_status_validate(
+        id.value(),
+        batch_update_mirror_topic_status_cmd{
+          .status = mirror_topic_status::failing_over,
+          .topics = std::move(topics)}),
+      errc::success);
+}
+
+TEST_F_CORO(
+  frontend_validation_test, batch_update_mirror_topic_status_link_not_found) {
+    chunked_vector<model::topic> topics;
+    topics.push_back(model::topic("some-topic"));
+
+    EXPECT_EQ(
+      batch_update_mirror_topic_status_validate(
+        id_t{99},
+        batch_update_mirror_topic_status_cmd{
+          .status = mirror_topic_status::failing_over,
+          .topics = std::move(topics)}),
+      errc::does_not_exist);
+    co_return;
+}
+
+TEST_F_CORO(
+  frontend_validation_test,
+  batch_update_mirror_topic_status_topic_not_mirrored) {
+    auto m = create_base_metadata();
+    ASSERT_EQ_CORO(co_await upsert_cluster_link(std::move(m)), errc::success);
+    auto id = _table.local().find_id_by_name(name_t("link1"));
+    ASSERT_TRUE_CORO(id.has_value());
+
+    chunked_vector<model::topic> topics;
+    topics.push_back(model::topic("nonexistent-topic"));
+
+    EXPECT_EQ(
+      batch_update_mirror_topic_status_validate(
+        id.value(),
+        batch_update_mirror_topic_status_cmd{
+          .status = mirror_topic_status::failing_over,
+          .topics = std::move(topics)}),
+      errc::topic_not_being_mirrored);
+}
+
+TEST_F_CORO(
+  frontend_validation_test,
+  batch_update_mirror_topic_status_invalid_transition) {
+    model::topic test_topic("mirror-link1");
+
+    auto m = create_base_metadata();
+    testing::set_link_mirror_topics(
+      m, test_topic, mirror_topic_status::active, test_topic);
+    ASSERT_EQ_CORO(co_await upsert_cluster_link(std::move(m)), errc::success);
+    auto id = _table.local().find_id_by_name(name_t("link1"));
+    ASSERT_TRUE_CORO(id.has_value());
+
+    // First failover the topic
+    update_mirror_topic_status_cmd failover_cmd{
+      .topic = test_topic, .status = mirror_topic_status::failing_over};
+    ASSERT_EQ_CORO(
+      co_await update_mirror_topic_status(id.value(), std::move(failover_cmd)),
+      errc::success);
+
+    // Now try to batch-failover again — failing_over → failing_over is invalid
+    chunked_vector<model::topic> topics;
+    topics.push_back(test_topic);
+
+    EXPECT_EQ(
+      batch_update_mirror_topic_status_validate(
+        id.value(),
+        batch_update_mirror_topic_status_cmd{
+          .status = mirror_topic_status::failing_over,
+          .topics = std::move(topics)}),
+      errc::invalid_update);
 }
 
 } // namespace cluster::cluster_link

--- a/src/v/cluster/cluster_link/tests/table_test.cc
+++ b/src/v/cluster/cluster_link/tests/table_test.cc
@@ -24,6 +24,7 @@
 namespace cluster::cluster_link {
 
 using ::cluster_link::model::add_mirror_topic_cmd;
+using ::cluster_link::model::batch_update_mirror_topic_status_cmd;
 using ::cluster_link::model::connection_config;
 using ::cluster_link::model::id_t;
 using ::cluster_link::model::link_configuration;
@@ -942,6 +943,138 @@ TEST_F_CORO(cluster_link_table_test, update_non_existent_link) {
         id_t{1}, update_cmd.copy()));
 
     EXPECT_EQ(static_cast<errc>(ec.value()), errc::does_not_exist);
+}
+
+TEST_F_CORO(
+  cluster_link_table_test, test_batch_update_mirror_topic_state_all_topics) {
+    model::topic topic1("mirror-t1");
+    model::topic topic2("mirror-t2");
+    model::topic topic3("mirror-t3");
+
+    metadata link1{
+      .name = name_t("link1"),
+      .uuid = uuid_t(::uuid_t::create()),
+      .connection = connection_config{}};
+
+    auto res = co_await _table.local().apply_update(
+      testing::create_upsert_command(model::offset{1}, std::move(link1)));
+    ASSERT_EQ_CORO(res.value(), int(errc::success));
+
+    for (const auto& t : {topic1, topic2, topic3}) {
+        res = co_await _table.local().apply_update(
+          testing::create_add_mirror_topic_command(
+            id_t{1},
+            add_mirror_topic_cmd{
+              .topic = t,
+              .metadata = testing::create_mirror_topic_metadata(
+                mirror_topic_status::active, t)}));
+        ASSERT_EQ_CORO(res.value(), int(errc::success));
+    }
+
+    // Batch update all three topics to failing_over
+    chunked_vector<model::topic> topics;
+    topics.push_back(topic1);
+    topics.push_back(topic2);
+    topics.push_back(topic3);
+
+    res = co_await _table.local().apply_update(
+      testing::create_batch_update_mirror_topic_status_command(
+        id_t{1},
+        batch_update_mirror_topic_status_cmd{
+          .status = mirror_topic_status::failing_over,
+          .topics = std::move(topics)}));
+    ASSERT_EQ_CORO(res.value(), int(errc::success));
+
+    for (const auto& t : {topic1, topic2, topic3}) {
+        auto status = _table.local().find_mirror_topic_status(t);
+        ASSERT_TRUE_CORO(status.has_value());
+        EXPECT_EQ(status.value(), mirror_topic_status::failing_over);
+    }
+}
+
+TEST_F_CORO(
+  cluster_link_table_test,
+  test_batch_update_mirror_topic_state_unknown_topic_fails_batch) {
+    model::topic topic1("mirror-t1");
+    model::topic topic2("mirror-t2");
+    model::topic unknown_topic("unknown-topic");
+
+    metadata link1{
+      .name = name_t("link1"),
+      .uuid = uuid_t(::uuid_t::create()),
+      .connection = connection_config{}};
+
+    auto res = co_await _table.local().apply_update(
+      testing::create_upsert_command(model::offset{1}, std::move(link1)));
+    ASSERT_EQ_CORO(res.value(), int(errc::success));
+
+    for (const auto& t : {topic1, topic2}) {
+        res = co_await _table.local().apply_update(
+          testing::create_add_mirror_topic_command(
+            id_t{1},
+            add_mirror_topic_cmd{
+              .topic = t,
+              .metadata = testing::create_mirror_topic_metadata(
+                mirror_topic_status::active, t)}));
+        ASSERT_EQ_CORO(res.value(), int(errc::success));
+    }
+
+    // Include a topic not registered to this link — entire batch fails
+    chunked_vector<model::topic> topics;
+    topics.push_back(topic1);
+    topics.push_back(unknown_topic);
+    topics.push_back(topic2);
+
+    res = co_await _table.local().apply_update(
+      testing::create_batch_update_mirror_topic_status_command(
+        id_t{1},
+        batch_update_mirror_topic_status_cmd{
+          .status = mirror_topic_status::failing_over,
+          .topics = std::move(topics)}));
+    EXPECT_EQ(res.value(), int(errc::topic_not_being_mirrored));
+
+    // No topics should have been updated (copy was discarded)
+    for (const auto& t : {topic1, topic2}) {
+        auto status = _table.local().find_mirror_topic_status(t);
+        ASSERT_TRUE_CORO(status.has_value());
+        EXPECT_EQ(status.value(), mirror_topic_status::active);
+    }
+}
+
+TEST_F_CORO(
+  cluster_link_table_test, test_batch_update_mirror_topic_state_empty_batch) {
+    metadata link1{
+      .name = name_t("link1"),
+      .uuid = uuid_t(::uuid_t::create()),
+      .connection = connection_config{}};
+
+    auto res = co_await _table.local().apply_update(
+      testing::create_upsert_command(model::offset{1}, std::move(link1)));
+    ASSERT_EQ_CORO(res.value(), int(errc::success));
+
+    chunked_vector<model::topic> topics;
+    res = co_await _table.local().apply_update(
+      testing::create_batch_update_mirror_topic_status_command(
+        id_t{1},
+        batch_update_mirror_topic_status_cmd{
+          .status = mirror_topic_status::failing_over,
+          .topics = std::move(topics)}));
+    EXPECT_EQ(res.value(), int(errc::success));
+}
+
+TEST_F_CORO(
+  cluster_link_table_test,
+  test_batch_update_mirror_topic_state_link_not_found) {
+    chunked_vector<model::topic> topics;
+    topics.push_back(model::topic("some-topic"));
+
+    auto res = co_await _table.local().apply_update(
+      testing::create_batch_update_mirror_topic_status_command(
+        id_t{99},
+        batch_update_mirror_topic_status_cmd{
+          .status = mirror_topic_status::failing_over,
+          .topics = std::move(topics)}));
+    EXPECT_EQ(res.value(), int(errc::does_not_exist));
 }
 
 } // namespace cluster::cluster_link

--- a/src/v/cluster/cluster_link/tests/utils.cc
+++ b/src/v/cluster/cluster_link/tests/utils.cc
@@ -16,6 +16,7 @@
 namespace cluster::cluster_link::testing {
 
 using ::cluster_link::model::add_mirror_topic_cmd;
+using ::cluster_link::model::batch_update_mirror_topic_status_cmd;
 using ::cluster_link::model::delete_mirror_topic_cmd;
 using ::cluster_link::model::id_t;
 using ::cluster_link::model::metadata;
@@ -53,6 +54,13 @@ create_delete_mirror_topic_command(id_t id, delete_mirror_topic_cmd cmd) {
 model::record_batch create_update_mirror_topic_status_command(
   id_t id, update_mirror_topic_status_cmd cmd) {
     cluster::cluster_link_update_mirror_topic_status_cmd update_cmd(
+      id, std::move(cmd));
+    return cluster::serde_serialize_cmd(std::move(update_cmd));
+}
+
+model::record_batch create_batch_update_mirror_topic_status_command(
+  id_t id, batch_update_mirror_topic_status_cmd cmd) {
+    cluster::cluster_link_batch_update_mirror_topic_status_cmd update_cmd(
       id, std::move(cmd));
     return cluster::serde_serialize_cmd(std::move(update_cmd));
 }

--- a/src/v/cluster/cluster_link/tests/utils.h
+++ b/src/v/cluster/cluster_link/tests/utils.h
@@ -26,6 +26,9 @@ model::record_batch create_delete_mirror_topic_command(
 model::record_batch create_update_mirror_topic_status_command(
   ::cluster_link::model::id_t,
   ::cluster_link::model::update_mirror_topic_status_cmd);
+model::record_batch create_batch_update_mirror_topic_status_command(
+  ::cluster_link::model::id_t,
+  ::cluster_link::model::batch_update_mirror_topic_status_cmd);
 model::record_batch create_update_mirror_topic_properties_command(
   ::cluster_link::model::id_t,
   ::cluster_link::model::update_mirror_topic_properties_cmd);

--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -161,6 +161,8 @@ inline constexpr int8_t cluster_link_update_mirror_topic_properties_cmd_type
 inline constexpr int8_t cluster_link_update_cluster_link_configuration_cmd_type
   = 5;
 inline constexpr int8_t cluster_link_delete_mirror_topic_cmd_type = 6;
+inline constexpr int8_t cluster_link_batch_update_mirror_topic_state_cmd_type
+  = 7;
 
 using create_topic_cmd = controller_command<
   model::topic_namespace,
@@ -490,6 +492,13 @@ using cluster_link_update_mirror_topic_status_cmd = controller_command<
   ::cluster_link::model::id_t,
   ::cluster_link::model::update_mirror_topic_status_cmd,
   cluster_link_update_mirror_topic_state_cmd_type,
+  model::record_batch_type::cluster_link,
+  serde_opts::serde_only>;
+
+using cluster_link_batch_update_mirror_topic_status_cmd = controller_command<
+  ::cluster_link::model::id_t,
+  ::cluster_link::model::batch_update_mirror_topic_status_cmd,
+  cluster_link_batch_update_mirror_topic_state_cmd_type,
   model::record_batch_type::cluster_link,
   serde_opts::serde_only>;
 

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -193,6 +193,11 @@
             "output_type": "update_mirror_topic_status_response"
         },
         {
+            "name": "batch_update_mirror_topic_status",
+            "input_type": "batch_update_mirror_topic_status_request",
+            "output_type": "batch_update_mirror_topic_status_response"
+        },
+        {
             "name": "update_mirror_topic_properties",
             "input_type": "update_mirror_topic_properties_request",
             "output_type": "update_mirror_topic_properties_response"

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -894,6 +894,16 @@ service::update_mirror_topic_status(
     co_return update_mirror_topic_status_response{.ec = result};
 }
 
+ss::future<batch_update_mirror_topic_status_response>
+service::batch_update_mirror_topic_status(
+  batch_update_mirror_topic_status_request req, rpc::streaming_context&) {
+    auto deadline = model::timeout_clock::now() + req.timeout;
+    auto result = co_await _cluster_link_frontend.local()
+                    .batch_update_mirror_topic_status(
+                      req.link_id, std::move(req.cmd), deadline);
+    co_return batch_update_mirror_topic_status_response{.ec = result};
+}
+
 ss::future<update_mirror_topic_properties_response>
 service::update_mirror_topic_properties(
   update_mirror_topic_properties_request req, rpc::streaming_context&) {

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -153,6 +153,9 @@ public:
     add_mirror_topic(add_mirror_topic_request, rpc::streaming_context&) final;
     ss::future<update_mirror_topic_status_response> update_mirror_topic_status(
       update_mirror_topic_status_request, rpc::streaming_context&) final;
+    ss::future<batch_update_mirror_topic_status_response>
+    batch_update_mirror_topic_status(
+      batch_update_mirror_topic_status_request, rpc::streaming_context&) final;
     ss::future<update_mirror_topic_properties_response>
     update_mirror_topic_properties(
       update_mirror_topic_properties_request, rpc::streaming_context&) final;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3649,6 +3649,38 @@ struct update_mirror_topic_status_response
     auto serde_fields() { return std::tie(ec); }
 };
 
+struct batch_update_mirror_topic_status_request
+  : serde::envelope<
+      batch_update_mirror_topic_status_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    ::cluster_link::model::id_t link_id;
+    ::cluster_link::model::batch_update_mirror_topic_status_cmd cmd;
+    model::timeout_clock::duration timeout{};
+
+    friend bool operator==(
+      const batch_update_mirror_topic_status_request&,
+      const batch_update_mirror_topic_status_request&)
+      = default;
+
+    auto serde_fields() { return std::tie(link_id, cmd, timeout); }
+};
+
+struct batch_update_mirror_topic_status_response
+  : serde::envelope<
+      batch_update_mirror_topic_status_response,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    cluster_link::errc ec{cluster_link::errc::success};
+
+    friend bool operator==(
+      const batch_update_mirror_topic_status_response&,
+      const batch_update_mirror_topic_status_response&)
+      = default;
+
+    auto serde_fields() { return std::tie(ec); }
+};
+
 struct update_mirror_topic_properties_request
   : serde::envelope<
       update_mirror_topic_properties_request,

--- a/src/v/cluster_link/model/types.h
+++ b/src/v/cluster_link/model/types.h
@@ -918,6 +918,27 @@ struct update_mirror_topic_status_cmd
     auto serde_fields() { return std::tie(topic, status, force_update); }
 };
 
+/// \brief Batched command to update the state of multiple mirror topics
+///
+/// All topics in a batch share the same target status. Used by failover to
+/// update up to 1k topics in a single raft entry, avoiding per-topic deep
+/// copies of the link metadata.
+struct batch_update_mirror_topic_status_cmd
+  : serde::envelope<
+      batch_update_mirror_topic_status_cmd,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    mirror_topic_status status{mirror_topic_status::active};
+    chunked_vector<::model::topic> topics;
+
+    friend bool operator==(
+      const batch_update_mirror_topic_status_cmd&,
+      const batch_update_mirror_topic_status_cmd&)
+      = default;
+
+    auto serde_fields() { return std::tie(status, topics); }
+};
+
 /// \brief Command used to update the properties of a mirror topic
 ///
 /// Will be used by the cluster linking metadata sync test to update

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4551,6 +4551,14 @@ configuration::configuration()
       "cluster for data replication.",
       meta{.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)
+  , shadow_link_failover_batch_size(
+      *this,
+      "shadow_link_failover_batch_size",
+      "Maximum number of mirror topics to include in a single batched "
+      "failover controller command.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      1000,
+      {.min = 1})
   , internal_rpc_request_timeout_ms(
       *this,
       "internal_rpc_request_timeout_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -775,6 +775,7 @@ struct configuration final : public config_store {
     bounded_property<size_t> datalake_scheduler_disk_reservation_block_size;
     property<bool> consumer_offsets_topic_batch_cache_enabled;
     enterprise<property<bool>> enable_shadow_linking;
+    bounded_property<uint32_t> shadow_link_failover_batch_size;
     property<std::chrono::milliseconds> internal_rpc_request_timeout_ms;
 
     configuration();

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -44,6 +44,8 @@ std::string_view to_string_view(feature f) {
         return "consumer_groups_migrations";
     case feature::shadow_linking:
         return "shadow_linking";
+    case feature::batch_mirror_topic_status:
+        return "batch_mirror_topic_status";
     case feature::coordinated_compaction:
         return "coordinated_compaction";
     case feature::cloud_retention:

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -55,6 +55,7 @@ enum class feature : std::uint64_t {
     group_based_authorization = 1ULL << 12U,
     cloud_topics = 1ULL << 13U,
     tiered_cloud_topics = 1ULL << 14U,
+    batch_mirror_topic_status = 1ULL << 15U,
     node_isolation = 1ULL << 19U,
     group_offset_retention = 1ULL << 20U,
     membership_change_controller_cmds = 1ULL << 22U,
@@ -556,6 +557,12 @@ inline constexpr std::array feature_schema{
     "tiered_cloud_topics",
     feature::tiered_cloud_topics,
     feature_spec::available_policy::explicit_only,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    release_version::v26_2_1,
+    "batch_mirror_topic_status",
+    feature::batch_mirror_topic_status,
+    feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
 };
 


### PR DESCRIPTION
- Add a batched failover path that updates up to 1000 mirror topics per
    raft entry, replacing the current per-topic approach that deep-copies
    the entire link metadata for each topic
- Gate behind `batch_mirror_topic_status` feature (v26.2.1) with the
    legacy per-topic path preserved for mixed-version clusters
- Extract shared `validate_mirror_topic_status_update` helper to
    eliminate duplication between single and batch validation


Fixes https://redpandadata.atlassian.net/browse/CORE-14957

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
### Improvements
* Improve shadowing failover latency on shadow links with large topic counts.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
