### PR TITLE
Cloud Storage Clients: Fix oauth subrequest headers in batch delete + some other fixes along the way

### DIFF
--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -896,7 +896,7 @@ ss::future<upload_result> remote::delete_object_batch(
         if (res) {
             if (!res.value().undeleted_keys.empty()) {
                 vlog(
-                  ctxlog.debug,
+                  ctxlog.info,
                   "{} objects were not deleted by plural delete; first "
                   "failure: {{key: {}, reason:{}}}",
                   res.value().undeleted_keys.size(),

--- a/src/v/cloud_roles/apply_abs_oauth_credentials.cc
+++ b/src/v/cloud_roles/apply_abs_oauth_credentials.cc
@@ -21,9 +21,8 @@ apply_abs_oauth_credentials::apply_abs_oauth_credentials(
 std::error_code apply_abs_oauth_credentials::add_auth(
   http::client::request_header& header) const {
     auto token = _oauth_token();
-    // x-ms-version requests a specific version for the abs api, the hardcoded
-    // value is the one we test
-    header.set("x-ms-version", azure_storage_api_version);
+    // x-ms-version is set by abs_request_creator::add_auth, not here,
+    // because batch sub-requests must omit it before signing.
     auto iso_ts = _timesource.format_http_datetime();
     header.set("x-ms-date", {iso_ts.data(), iso_ts.size()});
     header.insert(

--- a/src/v/cloud_roles/tests/credential_tests.cc
+++ b/src/v/cloud_roles/tests/credential_tests.cc
@@ -111,8 +111,9 @@ BOOST_AUTO_TEST_CASE(test_azure_oauth_headers) {
         bh::request_header<> h{};
         BOOST_REQUIRE(!applier.add_auth(h));
         BOOST_REQUIRE_EQUAL(h.at("Authorization"), "Bearer a-token");
-        BOOST_REQUIRE_EQUAL(
-          h.at("x-ms-version"), cloud_roles::azure_storage_api_version);
+        // x-ms-version is set by abs_request_creator::add_auth, not by
+        // the credentials layer.
+        BOOST_REQUIRE(h.find("x-ms-version") == h.end());
     }
 
     applier.reset_creds(
@@ -122,7 +123,6 @@ BOOST_AUTO_TEST_CASE(test_azure_oauth_headers) {
         bh::request_header<> h{};
         BOOST_REQUIRE(!applier.add_auth(h));
         BOOST_REQUIRE_EQUAL(h.at("Authorization"), "Bearer second-token");
-        BOOST_REQUIRE_EQUAL(
-          h.at("x-ms-version"), cloud_roles::azure_storage_api_version);
+        BOOST_REQUIRE(h.find("x-ms-version") == h.end());
     }
 }

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -559,7 +559,12 @@ ss::future<upload_result> remote::delete_objects(
         std::move(keys),
         parent,
         make_notify_cb(api_activity_type::segment_delete, parent))
-      .then([h = std::move(holder)](upload_result r) { return r; });
+      .then([this, h = std::move(holder)](upload_result r) {
+          if (r == upload_result::failed && is_batch_delete_supported()) {
+              _probe.batch_delete_error();
+          }
+          return r;
+      });
 }
 
 template ss::future<upload_result>

--- a/src/v/cloud_storage/remote_probe.cc
+++ b/src/v/cloud_storage/remote_probe.cc
@@ -147,6 +147,10 @@ remote_probe::remote_probe(
               sm::description(
                 "Number of times backoff was applied during "
                 "controller snapshot uploads")),
+            sm::make_counter(
+              "batch_delete_errors",
+              [this] { return _cnt_batch_delete_errors; },
+              sm::description("Number of failed batch delete requests")),
             sm::make_histogram(
               "client_acquisition_latency",
               [this] {

--- a/src/v/cloud_storage/remote_probe.h
+++ b/src/v/cloud_storage/remote_probe.h
@@ -228,6 +228,8 @@ public:
 
     void index_download() { ++_cnt_index_downloads; }
 
+    void batch_delete_error() { ++_cnt_batch_delete_errors; }
+
     auto client_acquisition() {
         return _client_acquisition_latency.auto_measure();
     }
@@ -316,6 +318,8 @@ private:
     uint64_t _cnt_topic_mount_manifest_uploads{0};
     /// Number of topic_mount manifest downloads
     uint64_t _cnt_topic_mount_manifest_downloads{0};
+    /// Number of failed batch delete requests
+    uint64_t _cnt_batch_delete_errors{0};
 
     hist_t _client_acquisition_latency;
     hist_t _segment_download_latency;

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -234,18 +234,28 @@ parse_batch_delete_response(
     while ((part = parts.get_part()).has_value()) {
         iobuf_parser part_parser{std::move(part).value()};
         auto mime = util::mime_header::from(part_parser);
+        // Parse the sub-response before checking Content-ID so error
+        // details are available for logging even when correlation fails.
+        // Note: this throws on truly malformed parts (not valid HTTP),
+        // which will fail the entire batch. That's acceptable — if the
+        // response is so broken we can't parse it, there's nothing
+        // useful to extract.
+        auto subrequest = util::multipart_subresponse::from(part_parser);
         auto maybe_content_id = mime.content_id<size_t>(convert_content_id);
         if (!maybe_content_id.has_value()) {
-            vlog(
-              abs_log.debug,
-              "batch_delete_response: MIME header missing 'Content-ID' from "
-              "batch response, skipping part");
+            auto err = subrequest.error(error_code_name);
+            auto lvl = err.has_value() ? ss::log_level::warn
+                                       : ss::log_level::debug;
+            vlogl(
+              abs_log,
+              lvl,
+              "batch_delete_response: MIME header missing 'Content-ID' "
+              "from batch response, skipping part. Sub-response "
+              "error: {}",
+              err);
             continue;
         }
         content_ids_seen.insert(maybe_content_id.value());
-        // having stripped off the leading MIME headers, we should have a
-        // complete HTTP response at the front of the parser
-        auto subrequest = util::multipart_subresponse::from(part_parser);
 
         if (maybe_content_id.value() >= keys.size()) {
             vlog(

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -712,18 +712,28 @@ parse_gcs_batch_delete_response(
     while ((part = parts.get_part()).has_value()) {
         iobuf_parser part_parser{std::move(part).value()};
         auto mime = util::mime_header::from(part_parser);
+        // Parse the sub-response before checking Content-ID so error
+        // details are available for logging even when correlation fails.
+        // Note: this throws on truly malformed parts (not valid HTTP),
+        // which will fail the entire batch. That's acceptable — if the
+        // response is so broken we can't parse it, there's nothing
+        // useful to extract.
+        auto subrequest = util::multipart_subresponse::from(part_parser);
         auto maybe_content_id = mime.content_id<size_t>(convert_content_id);
         if (!maybe_content_id.has_value()) {
-            vlog(
-              s3_log.debug,
-              "MIME header missing 'Content-ID' from batch response, skipping "
-              "part");
+            auto err = subrequest.error(parse_gcs_error_reason);
+            auto lvl = err.has_value() ? ss::log_level::warn
+                                       : ss::log_level::debug;
+            vlogl(
+              s3_log,
+              lvl,
+              "batch_delete_response: MIME header missing 'Content-ID' "
+              "from batch response, skipping part. Sub-response "
+              "error: {}",
+              err);
             continue;
         }
         content_ids_seen.insert(maybe_content_id.value());
-        // having stripped off the leading MIME headers, we should have a
-        // complete HTTP response at the front of the parser
-        auto subrequest = util::multipart_subresponse::from(part_parser);
 
         if (maybe_content_id.value() >= keys.size()) {
             vlog(

--- a/src/v/cloud_storage_clients/tests/abs_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/abs_client_test.cc
@@ -459,6 +459,55 @@ TEST_F(abs_client_fixture, test_batch_delete_not_found) {
     EXPECT_TRUE(result.value().undeleted_keys.empty());
 }
 
+// Verify that batch delete sub-requests do not include x-ms-version.
+// Azure rejects sub-requests with this header
+// (SubRequestCannotHaveVersionHeader). This was a bug when using OAuth
+// credentials, whose add_auth previously set x-ms-version unconditionally.
+TEST(abs_batch_delete_subrequest, no_version_header_in_subrequests) {
+    auto conf = make_test_configuration("test-version-check");
+    auto oauth_creds = ss::make_lw_shared(
+      cloud_roles::make_credentials_applier(
+        cloud_roles::abs_oauth_credentials{
+          .oauth_token = cloud_roles::oauth_token_str{"test-token"}}));
+
+    abs_request_creator requestor(conf, oauth_creds);
+    auto keys = chunked_vector<object_key>{
+      object_key{"blob0"}, object_key{"blob1"}};
+    auto result = requestor.make_batch_delete_request(
+      plain_bucket_name{"container"}, keys);
+    ASSERT_TRUE(result.has_value());
+
+    auto& [header, body_stream] = result.value();
+
+    // The outer request header should have x-ms-version
+    auto outer_version = header.find("x-ms-version");
+    EXPECT_NE(outer_version, header.end());
+
+    // Read the full body and check that sub-requests don't contain x-ms-version
+    ss::sstring body_str;
+    while (!body_stream.eof()) {
+        auto buf = body_stream.read().get();
+        body_str.append(buf.get(), buf.size());
+    }
+
+    // Split on boundary to get individual sub-requests. Each sub-request
+    // after the MIME headers contains an HTTP request line and headers.
+    // x-ms-version must not appear in any sub-request.
+    size_t pos = 0;
+    size_t subrequest_count = 0;
+    while ((pos = body_str.find("DELETE ", pos)) != ss::sstring::npos) {
+        auto end = body_str.find("\r\n\r\n", pos);
+        auto subrequest_headers = body_str.substr(
+          pos, end != ss::sstring::npos ? end - pos : ss::sstring::npos);
+        EXPECT_EQ(subrequest_headers.find("x-ms-version"), ss::sstring::npos)
+          << "Sub-request " << subrequest_count
+          << " contains x-ms-version header";
+        ++subrequest_count;
+        pos += 7;
+    }
+    EXPECT_EQ(subrequest_count, keys.size());
+}
+
 TEST_F(abs_client_fixture, test_batch_delete_server_error) {
     set_up("test-servererror");
     auto keys = chunked_vector<object_key>{object_key{"key1"}};

--- a/src/v/cloud_storage_clients/tests/util_test.cc
+++ b/src/v/cloud_storage_clients/tests/util_test.cc
@@ -1040,6 +1040,48 @@ TEST(FindMultipartBoundary, EmptyBoundaryParameter) {
       result.error(), testing::HasSubstr("Boundary missing from multipart"));
 }
 
+TEST(FindMultipartBoundary, TrailingParameterAfterBoundary) {
+    using namespace cloud_storage_clients;
+
+    http::client::response_header headers;
+    headers.insert(
+      boost::beast::http::field::content_type,
+      "multipart/mixed; boundary=batch_abc123; charset=utf-8");
+
+    auto result = util::find_multipart_boundary(headers);
+
+    EXPECT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), "batch_abc123");
+}
+
+TEST(FindMultipartBoundary, TrailingParameterAfterQuotedBoundary) {
+    using namespace cloud_storage_clients;
+
+    http::client::response_header headers;
+    headers.insert(
+      boost::beast::http::field::content_type,
+      R"(multipart/mixed; boundary="batch_abc123"; charset=utf-8)");
+
+    auto result = util::find_multipart_boundary(headers);
+
+    EXPECT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), "batch_abc123");
+}
+
+TEST(FindMultipartBoundary, BoundaryNotFirstParameter) {
+    using namespace cloud_storage_clients;
+
+    http::client::response_header headers;
+    headers.insert(
+      boost::beast::http::field::content_type,
+      "multipart/mixed; charset=utf-8; boundary=batch_abc123");
+
+    auto result = util::find_multipart_boundary(headers);
+
+    EXPECT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), "batch_abc123");
+}
+
 // ============================================================================
 // Preamble handling tests
 //

--- a/src/v/cloud_storage_clients/tests/util_test.cc
+++ b/src/v/cloud_storage_clients/tests/util_test.cc
@@ -284,6 +284,32 @@ TEST(MultipartParser, EmptyBuffer) {
     EXPECT_FALSE(part.has_value());
 }
 
+TEST(MultipartParser, PartialDelimiterOverlapWithRealBoundary) {
+    using namespace cloud_storage_clients;
+
+    // The part body contains "--b-" which partially matches the delimiter
+    // "--boundary". The third '-' breaks the match at _delim[3]='o' but is
+    // also _delim[0]='-', so the parser must re-check it as the potential
+    // start of a new delimiter match.
+    std::string_view multipart_data = "--boundary\r\n"
+                                      "Content-ID: 0\r\n"
+                                      "\r\n"
+                                      "data--b-more\r\n"
+                                      "--boundary--\r\n";
+
+    auto buf = iobuf::from(multipart_data);
+
+    util::multipart_response_parser parser(
+      std::move(buf), ss::sstring("--boundary"));
+
+    auto part1 = parser.get_part();
+    ASSERT_TRUE(part1.has_value());
+    EXPECT_THAT(
+      part1.value().linearize_to_string(), testing::HasSubstr("data--b-more"));
+
+    EXPECT_FALSE(parser.get_part().has_value());
+}
+
 // ============================================================================
 // multipart_subresponse tests
 // ============================================================================

--- a/src/v/cloud_storage_clients/util.cc
+++ b/src/v/cloud_storage_clients/util.cc
@@ -570,12 +570,32 @@ find_multipart_boundary(const http::client::response_header& headers) {
         if (n_eq != 1) {
             boundary = {};
         }
-        // Remove quotes if present
+        // Remove quotes if present. Per RFC 2045 a parameter value is
+        // either a token or a quoted-string.
         if (!boundary.empty() && boundary.front() == '"') {
             boundary = boundary.substr(1);
-        }
-        if (!boundary.empty() && boundary.back() == '"') {
-            boundary = boundary.substr(0, boundary.size() - 1);
+            // The closing quote marks the end of the value.
+            if (auto q = boundary.find('"'); q != boundary.npos) {
+                boundary = boundary.substr(0, q);
+            } else {
+                // Malformed: opening quote with no closing quote.
+                // Trim at semicolon as a fallback.
+                if (auto sc = boundary.find(';'); sc != boundary.npos) {
+                    boundary = boundary.substr(0, sc);
+                }
+            }
+        } else {
+            // Unquoted token: trim at the first semicolon (start of the
+            // next Content-Type parameter) per RFC 2045 §5.1.
+            if (auto sc = boundary.find(';'); sc != boundary.npos) {
+                boundary = boundary.substr(0, sc);
+            }
+            // Also strip any trailing whitespace that may precede the
+            // semicolon or end of header.
+            while (!boundary.empty()
+                   && (boundary.back() == ' ' || boundary.back() == '\t')) {
+                boundary = boundary.substr(0, boundary.size() - 1);
+            }
         }
     }
     if (boundary.empty()) {

--- a/src/v/cloud_storage_clients/util.cc
+++ b/src/v/cloud_storage_clients/util.cc
@@ -389,9 +389,24 @@ std::optional<iobuf> multipart_response_parser::get_part() {
             continue;
         }
         // unlikely, but we may have skipped some bytes that appeared to be
-        // part of a delimiter.
-        part_len += delim_idx + 1;
+        // part of a delimiter. Re-check the current character against the
+        // start of the delimiter, as in advance_to_first_boundary.
+        // NOTE: this is not full string search — it only handles overlap with
+        // _delim[0], not longer prefix/suffix overlaps. Fine in practice
+        // because RFC 2046 boundaries start with "--" and real server
+        // boundaries don't have repeated prefixes.
+        auto matched_prefix_len = delim_idx;
         delim_idx = 0;
+        if (c == _delim[0]) {
+            // The character that broke the match is also the start of a
+            // potential new match. Only commit the previously matched
+            // prefix to the part length; keep c out of the content until
+            // we know whether this new match succeeds.
+            part_len += matched_prefix_len;
+            delim_idx = 1;
+            continue;
+        }
+        part_len += matched_prefix_len + 1;
         auto [is_lf, _] = line_feed.try_put(c);
         // eat up any leading CRLFs so the resulting part starts on text
         if (!part_start.has_value()) [[unlikely]] {

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -184,7 +184,7 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
         return all_uploads_done(self.rpk, self.topic, self.redpanda, self.logger)
 
     @cluster(num_nodes=4)
-    @matrix(cloud_storage_type=get_cloud_storage_type()[0:1])
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_reset(self, cloud_storage_type):
         msg_count_before_reset = 50 * (self.segment_size // 2056)
         producer = KgoVerifierProducer(


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Saw some issues on the LRC where every batch delete from archival garbage collection was failing silently. Went through some different possibilities, so this PR contains some unrelated improvements discovered along the way.

1. Root cause: apply_abs_oauth_credentials added x-ms-version to every request,
  including batch sub-requests where Azure forbids it. Only surfaced on OAuth clusters
   — Shared Key auth never had this.
2. Hidden by: response parser skipping parts without Content-ID before parsing the
  sub-response, so the 400 SubRequestCannotHaveVersionHeader was silently dropped and
  reported as "Object missing from batch response" at debug level.
3. Also fixed along the way: boundary parsing with trailing Content-Type params,
  multipart delimiter matching overlap, log level for undeleted keys, and the GCS path
   has the same sub-response parsing fix.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Bug Fixes

* Fix an issue where multi-part delete requests were rejected by ABS when using OAuth (unexpected headers).

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
