### PR TITLE
`cluster`: catch exceptions in `sync_kafka_start_offset_override()` & fetch path

### DIFF
--- a/src/v/cluster/log_eviction_stm.h
+++ b/src/v/cluster/log_eviction_stm.h
@@ -42,8 +42,14 @@ class consensus;
  * stm will be searching for. Upon processing of this record a new snapshot will
  * be written which may also trigger deletion of data on disk.
  */
+namespace testing {
+class log_eviction_stm_accessor;
+} // namespace testing
+
 class log_eviction_stm
   : public raft::persisted_stm<raft::kvstore_backed_stm_snapshot> {
+    friend class testing::log_eviction_stm_accessor;
+
 public:
     static constexpr std::string_view name = "log_eviction_stm";
 
@@ -157,7 +163,36 @@ private:
 
     // Kafka offset of the last `prefix_truncate_record` applied to this stm.
     kafka::offset _cached_kafka_start_offset_override;
+
+    ss::gate& gate() { return _gate; }
 };
+
+namespace testing {
+
+/// Test-only accessor for log_eviction_stm internals. Allows tests to
+/// simulate a stopped STM (gate closed) and then reset it for clean teardown.
+class log_eviction_stm_accessor {
+public:
+    static ss::future<> close_gate(log_eviction_stm& stm) {
+        return stm.gate().close();
+    }
+
+    static void reset_gate(log_eviction_stm& stm) { stm.gate() = ss::gate{}; }
+
+    static void request_abort(log_eviction_stm& stm) {
+        stm._as.request_abort();
+    }
+
+    static void reset_abort_source(log_eviction_stm& stm) {
+        stm._as = ss::abort_source{};
+    }
+
+    static void break_has_pending_truncation(log_eviction_stm& stm) {
+        stm._has_pending_truncation.broken();
+    }
+};
+
+} // namespace testing
 
 class log_eviction_stm_factory : public state_machine_factory {
 public:

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -31,6 +31,7 @@
 #include "raft/fundamental.h"
 #include "raft/fwd.h"
 #include "raft/state_machine_manager.h"
+#include "ssx/future-util.h"
 #include "ssx/when_all.h"
 #include "storage/ntp_config.h"
 
@@ -1451,68 +1452,83 @@ partition::get_cloud_storage_manifest_view() {
 ss::future<result<model::offset, std::error_code>>
 partition::sync_kafka_start_offset_override(
   model::timeout_clock::duration timeout) {
-    if (is_read_replica_mode_enabled()) {
-        auto term = _raft->term();
-        if (!co_await _archival_meta_stm->sync(timeout)) {
-            if (term != _raft->term()) {
-                co_return errc::not_leader;
-            } else {
-                co_return errc::timeout;
+    try {
+        if (is_read_replica_mode_enabled()) {
+            auto term = _raft->term();
+            if (!co_await _archival_meta_stm->sync(timeout)) {
+                if (term != _raft->term()) {
+                    co_return errc::not_leader;
+                } else {
+                    co_return errc::timeout;
+                }
+            }
+            auto start_kafka_offset = _archival_meta_stm->manifest()
+                                        .get_start_kafka_offset_override();
+
+            co_return kafka::offset_cast(start_kafka_offset);
+        }
+
+        if (_log_eviction_stm) {
+            auto offset_res = co_await _log_eviction_stm
+                                ->sync_kafka_start_offset_override(timeout);
+            if (offset_res.has_failure()) {
+                co_return offset_res.as_failure();
+            }
+            if (offset_res.value() != kafka::offset{}) {
+                co_return kafka::offset_cast(offset_res.value());
             }
         }
+
+        if (!_archival_meta_stm) {
+            co_return model::offset{};
+        }
+
+        // There are a few cases in which the log_eviction_stm will return a
+        // kafka offset of `kafka::offset{}` for the start offset override.
+        // - The topic was remotely recovered.
+        // - A start offset override was never set.
+        // - The broker has restarted and the log_eviction_stm couldn't recover
+        //   the kafka offset for the start offset override.
+        //
+        // In all cases we'll need to fall back to the archival stm to figure
+        // out if a start offset override exists, and if so, what it is.
+        //
+        // For this we'll sync the archival stm a single time to ensure we have
+        // the most up-to-date manifest. From that point onwards the offset
+        // `_archival_meta_stm->manifest().get_start_kafka_offset_override()`
+        // will be correct without having to sync again. This is since the
+        // offset will not change until another offset override has been applied
+        // to the log eviction stm. And at that point the log eviction stm will
+        // be able to give us the correct offset override.
+        if (!_has_synced_archival_for_start_override) [[unlikely]] {
+            auto term = _raft->term();
+            if (!co_await _archival_meta_stm->sync(timeout)) {
+                if (term != _raft->term()) {
+                    co_return errc::not_leader;
+                } else {
+                    co_return errc::timeout;
+                }
+            }
+            _has_synced_archival_for_start_override = true;
+        }
+
         auto start_kafka_offset
           = _archival_meta_stm->manifest().get_start_kafka_offset_override();
-
         co_return kafka::offset_cast(start_kafka_offset);
-    }
-
-    if (_log_eviction_stm) {
-        auto offset_res = co_await _log_eviction_stm
-                            ->sync_kafka_start_offset_override(timeout);
-        if (offset_res.has_failure()) {
-            co_return offset_res.as_failure();
+    } catch (...) {
+        auto eptr = std::current_exception();
+        bool is_shutdown = ssx::is_shutdown_exception(eptr);
+        vlogl(
+          clusterlog,
+          is_shutdown ? ss::log_level::debug : ss::log_level::warn,
+          "ntp {}: exception in sync_kafka_start_offset_override: {}",
+          _raft->ntp(),
+          eptr);
+        if (is_shutdown) {
+            co_return errc::shutting_down;
         }
-        if (offset_res.value() != kafka::offset{}) {
-            co_return kafka::offset_cast(offset_res.value());
-        }
+        co_return errc::timeout;
     }
-
-    if (!_archival_meta_stm) {
-        co_return model::offset{};
-    }
-
-    // There are a few cases in which the log_eviction_stm will return a kafka
-    // offset of `kafka::offset{}` for the start offset override.
-    // - The topic was remotely recovered.
-    // - A start offset override was never set.
-    // - The broker has restarted and the log_eviction_stm couldn't recover the
-    //   kafka offset for the start offset override.
-    //
-    // In all cases we'll need to fall back to the archival stm to figure out if
-    // a start offset override exists, and if so, what it is.
-    //
-    // For this we'll sync the archival stm a single time to ensure we have the
-    // most up-to-date manifest. From that point onwards the offset
-    // `_archival_meta_stm->manifest().get_start_kafka_offset_override()` will
-    // be correct without having to sync again. This is since the offset will
-    // not change until another offset override has been applied to the log
-    // eviction stm. And at that point the log eviction stm will be able to give
-    // us the correct offset override.
-    if (!_has_synced_archival_for_start_override) [[unlikely]] {
-        auto term = _raft->term();
-        if (!co_await _archival_meta_stm->sync(timeout)) {
-            if (term != _raft->term()) {
-                co_return errc::not_leader;
-            } else {
-                co_return errc::timeout;
-            }
-        }
-        _has_synced_archival_for_start_override = true;
-    }
-
-    auto start_kafka_offset
-      = _archival_meta_stm->manifest().get_start_kafka_offset_override();
-    co_return kafka::offset_cast(start_kafka_offset);
 }
 
 model::offset partition::last_stable_offset() const {

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -317,24 +317,12 @@ static ss::future<read_result> do_read_from_ntp(
               preferred_replica);
         }
     }
-    auto res_fut = co_await ss::coroutine::as_future(read_from_partition(
-      std::move(*kafka_partition),
-      maybe_lso.value(),
-      ntp_config.cfg,
-      deadline));
-    if (res_fut.failed()) {
-        auto ex = res_fut.get_exception();
-        if (ssx::is_shutdown_exception(ex)) {
-            co_return make_errored_read_result(
-              md_cache, ntp_config.ktp(), error_code::not_leader_for_partition);
-        }
-        std::rethrow_exception(ex);
-    }
+    auto result = co_await read_from_partition(
+      std::move(*kafka_partition), maybe_lso.value(), ntp_config.cfg, deadline);
 
     // Note that units can be both increased and decreassed here. Increases
     // happen because there is no strict limit on read size when reading the
     // obligatory batch.
-    auto result = std::move(res_fut.get());
     memory_units.adjust_units(result.data_size_bytes());
     result.memory_units = std::move(memory_units);
     co_return result;
@@ -555,6 +543,22 @@ static ss::future<chunked_vector<read_result>> fetch_ntps(
                       res.delta_from_tip_ms.value());
                 }
 
+                results[cfg_idx] = std::move(res);
+            })
+            .handle_exception([&, cfg_idx](const std::exception_ptr& e) {
+                bool is_shutdown = ssx::is_shutdown_exception(e);
+                // Return not_leader_for_partition error to force clients retry
+                // for potential transient errors.
+                auto ec = error_code::not_leader_for_partition;
+                vlogl(
+                  klog,
+                  is_shutdown ? ss::log_level::debug : ss::log_level::warn,
+                  "ntp {}: caught unhandled exception {} in fetch path",
+                  ntp_cfg.ktp(),
+                  e);
+                auto res = make_errored_read_result(
+                  md_cache, ntp_cfg.ktp(), ec);
+                res.partition = ntp_cfg.ktp().get_partition();
                 results[cfg_idx] = std::move(res);
             });
       });

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -782,6 +782,7 @@ redpanda_cc_btest(
     cpu = 1,
     deps = [
         "//src/v/base",
+        "//src/v/cluster",
         "//src/v/cluster/tests:cluster_test_fixture",
         "//src/v/container:chunked_vector",
         "//src/v/kafka/protocol",

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0
 
 #include "base/units.h"
+#include "cluster/log_eviction_stm.h"
 #include "cluster/tests/cluster_test_fixture.h"
 #include "container/chunked_vector.h"
 #include "kafka/protocol/batch_consumer.h"
@@ -1318,4 +1319,131 @@ FIXTURE_TEST(
     auto new_log_start = resp2.data.responses[0].partitions[0].log_start_offset;
     BOOST_REQUIRE_GT(new_log_start, initial_log_start);
     BOOST_REQUIRE_EQUAL(new_log_start, model::offset(5));
+}
+
+// Regression test: when one partition's log_eviction_stm has its gate closed
+// (e.g. during shutdown/partition move), the multi-partition fetch should
+// still succeed for the remaining healthy partitions rather than failing the
+// entire request.
+FIXTURE_TEST(
+  fetch_multi_partition_with_mixed_failures, redpanda_thread_fixture) {
+    model::topic topic("foo");
+    constexpr int num_partitions = 4;
+    // The partition whose STM we will stop.
+    constexpr int stopped_partition_idx = 1;
+
+    wait_for_controller_leadership().get();
+    add_topic(model::topic_namespace(model::ns("kafka"), topic), num_partitions)
+      .get();
+
+    for (int i = 0; i < num_partitions; ++i) {
+        auto ntp = make_default_ntp(topic, model::partition_id(i));
+        wait_for_partition_offset(ntp, model::offset(0)).get();
+    }
+
+    // Write data to all partitions.
+    for (int i = 0; i < num_partitions; ++i) {
+        auto ntp = make_default_ntp(topic, model::partition_id(i));
+        auto shard = app.shard_table.local().shard_for(ntp);
+        app.partition_manager
+          .invoke_on(
+            *shard,
+            [ntp](cluster::partition_manager& mgr) {
+                return model::test::make_random_batches(model::offset(0), 5)
+                  .then([ntp, &mgr](auto batches) {
+                      auto partition = mgr.get(ntp);
+                      return partition->raft()->replicate(
+                        chunked_vector<model::record_batch>(
+                          std::from_range,
+                          std::move(batches) | std::views::as_rvalue),
+                        raft::replicate_options(
+                          raft::consistency_level::quorum_ack));
+                  });
+            })
+          .discard_result()
+          .get();
+    }
+
+    // Close the log_eviction_stm's gate on one partition to simulate a
+    // shutdown race. sync_kafka_start_offset_override will encounter a
+    // gate_closed_exception on this partition.
+    auto stopped_ntp = make_default_ntp(
+      topic, model::partition_id(stopped_partition_idx));
+    auto stopped_shard = app.shard_table.local().shard_for(stopped_ntp);
+    app.partition_manager
+      .invoke_on(
+        *stopped_shard,
+        [stopped_ntp](cluster::partition_manager& mgr) {
+            auto partition = mgr.get(stopped_ntp);
+            auto stm = partition->raft()
+                         ->stm_manager()
+                         ->get<cluster::log_eviction_stm>();
+            using accessor = cluster::testing::log_eviction_stm_accessor;
+            accessor::request_abort(*stm);
+            accessor::break_has_pending_truncation(*stm);
+            return accessor::close_gate(*stm);
+        })
+      .get();
+
+    // Build a fetch request spanning all partitions.
+    kafka::fetch_request req;
+    req.data.max_bytes = std::numeric_limits<int32_t>::max();
+    req.data.min_bytes = 1;
+    req.data.max_wait_ms = std::chrono::milliseconds(0);
+    req.data.session_id = kafka::invalid_fetch_session_id;
+    req.data.topics.emplace_back(
+      kafka::fetch_topic{
+        .topic = topic,
+        .partitions = {},
+      });
+    for (int i = 0; i < num_partitions; ++i) {
+        kafka::fetch_request::partition p;
+        p.partition = model::partition_id(i);
+        p.fetch_offset = model::offset(0);
+        p.partition_max_bytes = std::numeric_limits<int32_t>::max();
+        req.data.topics[0].partitions.push_back(p);
+    }
+
+    auto client = make_kafka_client().get();
+    client.connect().get();
+    auto resp = client.dispatch(std::move(req), kafka::api_version(4)).get();
+    client.stop().then([&client] { client.shutdown(); }).get();
+
+    // The fetch must return responses for all partitions.
+    BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
+    BOOST_REQUIRE_EQUAL(
+      resp.data.responses[0].partitions.size(), num_partitions);
+
+    for (int i = 0; i < num_partitions; ++i) {
+        const auto& partition_resp = resp.data.responses[0].partitions[i];
+        BOOST_REQUIRE_EQUAL(
+          partition_resp.partition_index, model::partition_id(i));
+
+        if (i == stopped_partition_idx) {
+            // The stopped partition should return an error, not crash the
+            // fetch.
+            BOOST_REQUIRE(partition_resp.error_code != kafka::error_code::none);
+        } else {
+            // Healthy partitions must return data successfully.
+            BOOST_REQUIRE_EQUAL(
+              partition_resp.error_code, kafka::error_code::none);
+            BOOST_REQUIRE(partition_resp.records);
+            BOOST_REQUIRE_GT(partition_resp.records->size_bytes(), 0);
+        }
+    }
+
+    // Reset the STM state so the fixture can shut down cleanly.
+    app.partition_manager
+      .invoke_on(
+        *stopped_shard,
+        [stopped_ntp](cluster::partition_manager& mgr) {
+            auto partition = mgr.get(stopped_ntp);
+            auto stm = partition->raft()
+                         ->stm_manager()
+                         ->get<cluster::log_eviction_stm>();
+            using accessor = cluster::testing::log_eviction_stm_accessor;
+            accessor::reset_gate(*stm);
+            accessor::reset_abort_source(*stm);
+        })
+      .get();
 }


### PR DESCRIPTION
Calls made to `log_eviction_stm` and `archival_metadata_stm` within this function can throw various exceptions (`timed_out`, shutdown exceptions). These propagate as exceptional futures through `validate_fetch_offset()` into the fetch handler's `max_concurrent_for_each()` loop, causing an entire multi-partition fetch request to fail when only one partition has an error. This actually causes the entire request to hang on Redpanda's side with no response to the Kafka client, leaving connections open until the client request times out on their end.

Wrap the coroutine body in a try-catch so that exceptions are returned as result errors instead. Shutdown exceptions map to `errc::shutting_down` and all other exceptions map to `errc::timeout`, ensuring that a failure in the fetch path for a single partition will _only_ affect the single partition's response.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [X] v25.3.x
- [x] v25.2.x

## Release Notes

### Improvements

* Make the fetch path more resilient to errors in single partitions.
