### PR TITLE
go: bump Go projects to 1.26.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -221,20 +221,20 @@ COMPILERS = {
 # Go Toolchain
 # ====================================
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk", dev_dependency = True)
-go_sdk.download(version = "1.25.7")
+go_sdk.download(version = "1.26.2")
 
 # The microsoft compiler versions can be listed at their github release under the `asset.json` file
 go_sdk.download(
     name = "go_sdk_with_systemcrypto",
     experiments = ["systemcrypto"],
     sdks = {
-        "linux_amd64": ("b6ae036e2c246d52bd15d5300994c8ee/go1.25.7-20260204.4.linux-amd64.tar.gz", "328b235ebd36ddc92c852b6d25b01d8e9478c2779bbbac3c8964890118a8aa6f"),
-        "linux_arm64": ("218094e73bfc123b8065805487bd52fa/go1.25.7-20260204.4.linux-arm64.tar.gz", "73c5ffdedf6cf5ec57eb2478a64ab50a363e17cb1f53e37049d4a42b2886f939"),
-        "darwin_amd64": ("16503ff2f5ff30261b0602f647300571/go1.25.7-20260204.4.darwin-amd64.tar.gz", "3cca680b5619449e436a15e4d799d6ae3c4e79616637b4c6fadc0b186df8e61a"),
-        "darwin_arm64": ("cda77c95a10a9e64d75094d1cdc79d03/go1.25.7-20260204.4.darwin-arm64.tar.gz", "e8ebdd66099a1e216adb643355f040416cd27077c2215681f9e7419d98266679"),
+        "linux_amd64": ("606a9119cca2b06097017987a66db36a/go1.26.2-20260407.2.linux-amd64.tar.gz", "68bcd46d095165b37f4773450a8239ae5aa8d7e5be371eb69aea0510526ced5a"),
+        "linux_arm64": ("a5234a67f99d71512680ddea0881fe04/go1.26.2-20260407.2.linux-arm64.tar.gz", "0274f18451d73bf234798b1d1212e60b59ed1cd86d1b982701df3df76c563571"),
+        "darwin_amd64": ("0c2f246caa635f2270f7fb31e0bff430/go1.26.2-20260407.2.darwin-amd64.tar.gz", "46291a8b87fb39dc499333d9657d590a7d38fefbd88d80da387f6d01660be446"),
+        "darwin_arm64": ("6c465361732842d8ffa7df6086354d80/go1.26.2-20260407.2.darwin-arm64.tar.gz", "411616b1e261235c700220ff4aae3773d0d09a8697077400f67ebbd46b9e0003"),
     },
-    urls = ["https://download.visualstudio.microsoft.com/download/pr/39e12277-1463-47e4-9f91-f71f8c450c61/{}"],
-    version = "1.25.7",
+    urls = ["https://download.visualstudio.microsoft.com/download/pr/a29a63c1-f82c-449f-baff-9c086f732ce6/{}"],
+    version = "1.26.2",
 )
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")

--- a/bazel/thirdparty/go.work
+++ b/bazel/thirdparty/go.work
@@ -1,5 +1,5 @@
 // This should match what is listed in MODULE.bazel
-go 1.25.7
+go 1.26.2
 
 // Everything we build with Bazel goes here.
 use (

--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda/src/go/rpk
 
-go 1.25.7
+go 1.26.2
 
 // add the git commit hash as the target version and `go mod tidy` will transform it into pseudo-version
 replace github.com/hamba/avro/v2 => github.com/redpanda-data/go-avro/v2 v2.0.0-20240405204525-77b1144dc525

--- a/src/v/test_utils/go/go.mod
+++ b/src/v/test_utils/go/go.mod
@@ -1,6 +1,6 @@
 module redpanda-test-utils
 
-go 1.25.7
+go 1.26.2
 
 require (
 	github.com/kr/pretty v0.3.1


### PR DESCRIPTION
The tooling (vtools) has been updated to support Go 1.26.2.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
