### PR TITLE
kafka/list_offsets: return correct leader epoch for earliest, timequery, and empty paths

### DIFF
--- a/src/v/kafka/data/cloud_topic_partition.cc
+++ b/src/v/kafka/data/cloud_topic_partition.cc
@@ -136,6 +136,12 @@ kafka::leader_epoch cloud_topic_partition::leader_epoch() const {
     return kafka::leader_epoch(static_cast<int32_t>(term()));
 }
 
+std::optional<model::term_id>
+cloud_topic_partition::get_term(model::offset) const {
+    // TODO: implement for cloud topics (CORE-12700)
+    return std::nullopt;
+}
+
 ss::future<storage::translating_reader>
 cloud_topic_partition::make_reader(kafka::log_reader_config cfg) {
     auto config = kafka_to_cloud_topic_log_reader_config(cfg);

--- a/src/v/kafka/data/cloud_topic_partition.h
+++ b/src/v/kafka/data/cloud_topic_partition.h
@@ -86,6 +86,7 @@ public:
       get_leader_epoch_last_offset(kafka::leader_epoch) const final;
 
     kafka::leader_epoch leader_epoch() const final;
+    std::optional<model::term_id> get_term(model::offset) const final;
 
     ss::future<error_code> validate_fetch_offset(
       model::offset, bool, model::timeout_clock::time_point) final;

--- a/src/v/kafka/data/cloud_topic_read_replica.cc
+++ b/src/v/kafka/data/cloud_topic_read_replica.cc
@@ -121,6 +121,11 @@ kafka::leader_epoch partition_proxy::leader_epoch() const {
     return kafka::leader_epoch(static_cast<int32_t>(term()));
 }
 
+std::optional<model::term_id> partition_proxy::get_term(model::offset) const {
+    // TODO: implement for read replicas (CORE-12700)
+    return std::nullopt;
+}
+
 ss::future<std::optional<model::offset>>
 partition_proxy::get_leader_epoch_last_offset(kafka::leader_epoch epoch) const {
     auto snap_res = co_await get_snapshot();

--- a/src/v/kafka/data/cloud_topic_read_replica.h
+++ b/src/v/kafka/data/cloud_topic_read_replica.h
@@ -78,6 +78,7 @@ public:
 
     // Returns the leader epoch from the source partition's term.
     kafka::leader_epoch leader_epoch() const final;
+    std::optional<model::term_id> get_term(model::offset) const final;
 
     // Queries the cloud database for the last offset in the given epoch.
     ss::future<std::optional<model::offset>>

--- a/src/v/kafka/data/partition_proxy.h
+++ b/src/v/kafka/data/partition_proxy.h
@@ -65,6 +65,7 @@ public:
         virtual checked<model::offset, error_code>
         last_stable_offset() const = 0;
         virtual kafka::leader_epoch leader_epoch() const = 0;
+        virtual std::optional<model::term_id> get_term(model::offset) const = 0;
         virtual ss::future<std::optional<model::offset>>
           get_leader_epoch_last_offset(kafka::leader_epoch) const = 0;
 
@@ -157,6 +158,10 @@ public:
     cluster::partition_probe& probe() { return _impl->probe(); }
 
     kafka::leader_epoch leader_epoch() const { return _impl->leader_epoch(); }
+
+    std::optional<model::term_id> get_term(model::offset o) const {
+        return _impl->get_term(o);
+    }
 
     ss::future<std::optional<model::offset>>
     get_leader_epoch_last_offset(kafka::leader_epoch epoch) const {

--- a/src/v/kafka/data/replicated_partition.cc
+++ b/src/v/kafka/data/replicated_partition.cc
@@ -201,6 +201,16 @@ kafka::leader_epoch replicated_partition::leader_epoch() const {
     return leader_epoch_from_term(_partition->raft()->confirmed_term());
 }
 
+std::optional<model::term_id>
+replicated_partition::get_term(model::offset o) const {
+    auto log_offset = _translator->to_log_offset(o);
+    auto term = _partition->get_term(log_offset);
+    if (term == model::term_id{}) {
+        return std::nullopt;
+    }
+    return term;
+}
+
 // TODO: use previous translation speed up lookup
 ss::future<storage::translating_reader>
 replicated_partition::make_reader(kafka::log_reader_config cfg) {

--- a/src/v/kafka/data/replicated_partition.h
+++ b/src/v/kafka/data/replicated_partition.h
@@ -93,6 +93,7 @@ public:
      * the leader election starts.
      */
     kafka::leader_epoch leader_epoch() const final;
+    std::optional<model::term_id> get_term(model::offset) const final;
 
     ss::future<error_code> validate_fetch_offset(
       model::offset, bool, model::timeout_clock::time_point) final;

--- a/src/v/kafka/data/rpc/test/deps.h
+++ b/src/v/kafka/data/rpc/test/deps.h
@@ -104,6 +104,9 @@ public:
     kafka::leader_epoch leader_epoch() const final {
         throw std::runtime_error("unimplemented");
     }
+    std::optional<model::term_id> get_term(model::offset) const final {
+        throw std::runtime_error("unimplemented");
+    }
     ss::future<std::optional<model::offset>>
     get_leader_epoch_last_offset(kafka::leader_epoch) const final {
         throw std::runtime_error("unimplemented");

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -16,6 +16,7 @@
 #include "kafka/data/partition_proxy.h"
 #include "kafka/data/replicated_partition.h"
 #include "kafka/protocol/errors.h"
+#include "kafka/protocol/types.h"
 #include "kafka/server/errors.h"
 #include "kafka/server/handlers/details/leader_epoch.h"
 #include "kafka/server/request_context.h"
@@ -118,11 +119,17 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
               ktp.get_partition(), maybe_start_ofs.error());
         }
 
+        // TODO: get_term returns nullopt for cloud/tiered storage partitions
+        // (CORE-12700). In that case leader_epoch_from_term returns -1,
+        // which is better than the previous bug (returning the current
+        // leader epoch) but not the correct historical epoch.
+        auto start_epoch = leader_epoch_from_term(
+          kafka_partition->get_term(maybe_start_ofs.value()));
         co_return list_offsets_response::make_partition(
           ktp.get_partition(),
           model::timestamp(-1),
           maybe_start_ofs.value(),
-          kafka_partition->leader_epoch());
+          start_epoch);
 
     } else if (timestamp == list_offsets_request::latest_timestamp) {
         co_return list_offsets_response::make_partition(
@@ -140,7 +147,7 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
           ktp.get_partition(),
           model::timestamp(-1),
           model::offset(-1),
-          kafka_partition->leader_epoch());
+          kafka::invalid_leader_epoch);
     }
 
     auto res_fut = co_await ss::coroutine::as_future(kafka_partition->timequery(
@@ -163,7 +170,7 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
     auto res = res_fut.get();
     if (res) {
         co_return list_offsets_response::make_partition(
-          id, res->time, res->offset, kafka_partition->leader_epoch());
+          id, res->time, res->offset, leader_epoch_from_term(res->term));
     }
     co_return list_offsets_response::make_partition(id, error_code::none);
 }

--- a/src/v/kafka/server/tests/list_offsets_test.cc
+++ b/src/v/kafka/server/tests/list_offsets_test.cc
@@ -189,6 +189,138 @@ FIXTURE_TEST(list_offsets_not_found, redpanda_thread_fixture) {
       == kafka::leader_epoch(-1));
 }
 
+FIXTURE_TEST(list_offsets_leader_epoch, redpanda_thread_fixture) {
+    wait_for_controller_leadership().get();
+
+    auto base_ts = model::timestamp{10000};
+    auto ntp = make_data(base_ts);
+    auto shard = app.shard_table.local().shard_for(ntp);
+    tests::cooperative_spin_wait_with_timeout(10s, [this, shard, ntp = ntp] {
+        return app.partition_manager.invoke_on(
+          *shard, [ntp](cluster::partition_manager& mgr) {
+              auto partition = mgr.get(ntp);
+              return partition
+                     && partition->committed_offset() >= model::offset(1);
+          });
+    }).get();
+
+    // Record the epoch of the data we just produced.
+    auto initial_epoch = app.partition_manager
+                           .invoke_on(
+                             *shard,
+                             [ntp](cluster::partition_manager& mgr) {
+                                 auto partition = mgr.get(ntp);
+                                 return partition->raft()->term();
+                             })
+                           .get();
+
+    // Bump the term without producing new data.  On a single-node
+    // cluster the node immediately re-elects itself at a higher term.
+    app.partition_manager
+      .invoke_on(
+        *shard,
+        [ntp, this](cluster::partition_manager& mgr) {
+            auto partition = mgr.get(ntp);
+            partition->raft()->step_down("bump epoch for test").get();
+            wait_for_leader(ntp.to_ntp(), 10s).get();
+        })
+      .get();
+
+    auto current_epoch = app.partition_manager
+                           .invoke_on(
+                             *shard,
+                             [ntp](cluster::partition_manager& mgr) {
+                                 auto partition = mgr.get(ntp);
+                                 return partition->raft()->term();
+                             })
+                           .get();
+
+    BOOST_REQUIRE(current_epoch > initial_epoch);
+
+    auto client = make_kafka_client().get();
+    client.connect().get();
+
+    auto initial_leader_epoch = kafka::leader_epoch(initial_epoch());
+    auto current_leader_epoch = kafka::leader_epoch(current_epoch());
+
+    // Helper to send a ListOffsets request at v4 and return the
+    // partition response.
+    auto list_offset = [&client, &ntp](auto timestamp) {
+        kafka::list_offsets_request req;
+        req.data.topics.emplace_back(
+          kafka::list_offset_topic{
+            .name = ntp.get_topic(),
+            .partitions = {{
+              .partition_index = ntp.get_partition(),
+              .timestamp = timestamp,
+            }},
+          });
+        auto resp
+          = client.dispatch(std::move(req), kafka::api_version(4)).get();
+        BOOST_REQUIRE_EQUAL(resp.data.topics.size(), 1);
+        BOOST_REQUIRE_EQUAL(resp.data.topics[0].partitions.size(), 1);
+        return std::move(resp.data.topics[0].partitions[0]);
+    };
+
+    // Earliest: should return the record epoch, not the current epoch.
+    {
+        auto p = list_offset(kafka::list_offsets_request::earliest_timestamp);
+        BOOST_CHECK(p.offset == model::offset(0));
+        BOOST_CHECK_EQUAL(p.leader_epoch, initial_leader_epoch);
+    }
+
+    // Latest: should return the current leader epoch.
+    {
+        auto p = list_offset(kafka::list_offsets_request::latest_timestamp);
+        BOOST_CHECK(p.offset > model::offset(0));
+        BOOST_CHECK_EQUAL(p.leader_epoch, current_leader_epoch);
+    }
+
+    // Timequery: should return the record epoch, not the current epoch.
+    {
+        auto p = list_offset(base_ts);
+        BOOST_CHECK(p.offset == model::offset(0));
+        BOOST_CHECK_EQUAL(p.leader_epoch, initial_leader_epoch);
+    }
+
+    client.stop().then([&client] { client.shutdown(); }).get();
+}
+
+FIXTURE_TEST(list_offsets_empty_partition_epoch, redpanda_thread_fixture) {
+    wait_for_controller_leadership().get();
+
+    // Create an empty topic — no records produced.
+    model::ntp ntp(
+      model::kafka_namespace,
+      model::topic(random_generators::gen_alphanum_string(8)),
+      model::partition_id(0));
+    add_topic(model::topic_namespace_view{ntp}, 1).get();
+    wait_for_partition_offset(ntp, model::offset(0)).get();
+
+    auto client = make_kafka_client().get();
+    client.connect().get();
+
+    // Timequery on an empty partition: max_offset < min_offset triggers
+    // the empty partition path which should return leader_epoch=-1.
+    kafka::list_offsets_request req;
+    req.data.topics.emplace_back(
+      kafka::list_offset_topic{
+        .name = ntp.tp.topic,
+        .partitions = {{
+          .partition_index = ntp.tp.partition,
+          .timestamp = model::timestamp(0),
+        }},
+      });
+    auto resp = client.dispatch(std::move(req), kafka::api_version(4)).get();
+    client.stop().then([&client] { client.shutdown(); }).get();
+
+    BOOST_REQUIRE_EQUAL(resp.data.topics.size(), 1);
+    BOOST_REQUIRE_EQUAL(resp.data.topics[0].partitions.size(), 1);
+    auto& p = resp.data.topics[0].partitions[0];
+    BOOST_CHECK(p.offset == model::offset(-1));
+    BOOST_CHECK(p.leader_epoch == kafka::leader_epoch(-1));
+}
+
 kafka::produce_request
 make_produce_request(model::topic_partition tp, model::record_batch&& batch) {
     chunked_vector<kafka::produce_request::partition> partitions;

--- a/tests/rptest/tests/list_offsets_epoch_test.py
+++ b/tests/rptest/tests/list_offsets_epoch_test.py
@@ -1,0 +1,230 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import kafka.protocol.types as types
+from kafka import errors as kerr
+from kafka.admin import KafkaAdminClient
+from kafka.protocol.api import Request, Response
+
+from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+# --- ListOffsets v4 (API key 2) ---
+# v4 is the first version with leader_epoch in the response.
+
+
+class ListOffsetsResponse_v4(Response):
+    API_KEY = 2
+    API_VERSION = 4
+    SCHEMA = types.Schema(
+        ("throttle_time_ms", types.Int32),
+        (
+            "topics",
+            types.Array(
+                ("topic", types.String("utf-8")),
+                (
+                    "partitions",
+                    types.Array(
+                        ("partition", types.Int32),
+                        ("error_code", types.Int16),
+                        ("timestamp", types.Int64),
+                        ("offset", types.Int64),
+                        ("leader_epoch", types.Int32),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+class ListOffsetsRequest_v4(Request):
+    API_KEY = 2
+    API_VERSION = 4
+    RESPONSE_TYPE = ListOffsetsResponse_v4
+    SCHEMA = types.Schema(
+        ("replica_id", types.Int32),
+        ("isolation_level", types.Int8),
+        (
+            "topics",
+            types.Array(
+                ("topic", types.String("utf-8")),
+                (
+                    "partitions",
+                    types.Array(
+                        ("partition", types.Int32),
+                        ("current_leader_epoch", types.Int32),
+                        ("timestamp", types.Int64),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+class ListOffsetsLeaderEpochTest(RedpandaTest):
+    """
+    Verify that ListOffsets returns the correct leader epoch per return
+    path.  Redpanda incorrectly returned the current leader epoch instead
+    of the historical epoch for earliest, timequery, and empty partition
+    paths.
+    """
+
+    topics = (TopicSpec(name="epoch-test", partition_count=1, replication_factor=3),)
+
+    def __init__(self, test_ctx, *args, **kwargs):
+        super().__init__(
+            test_ctx,
+            *args,
+            num_brokers=3,
+            extra_rp_conf={"enable_leader_balancer": False},
+            **kwargs,
+        )
+
+    def _setup_topic_with_epoch_gap(self):
+        """Produce 12 records, then transfer leadership 3 times.
+
+        After this setup all 12 records are from the initial epoch and
+        the current leader epoch is >= 3, creating a gap between the
+        record epoch and the current epoch.
+
+        Returns (initial_epoch, current_epoch).
+        """
+        rpk = RpkTool(self.redpanda)
+        admin = Admin(self.redpanda)
+
+        for i in range(12):
+            rpk.produce("epoch-test", f"key-{i}", f"val-{i}")
+
+        partitions = list(rpk.describe_topic("epoch-test"))
+        assert partitions[0].high_watermark == 12, (
+            f"Expected HWM 12, got {partitions[0].high_watermark}"
+        )
+        initial_epoch = partitions[0].leader_epoch
+        self.logger.info(f"Initial state: HWM=12, epoch={initial_epoch}")
+
+        for i in range(3):
+            partitions = list(rpk.describe_topic("epoch-test"))
+            current_leader = partitions[0].leader
+            replicas = partitions[0].replicas
+            target = next(r for r in replicas if r != current_leader)
+            admin.transfer_leadership_to(
+                namespace="kafka",
+                topic="epoch-test",
+                partition=0,
+                target_id=target,
+            )
+            admin.await_stable_leader(topic="epoch-test", partition=0, timeout_s=30)
+            self.logger.info(
+                f"Leadership transfer {i + 1}/3: {current_leader} -> {target}"
+            )
+
+        partitions = list(rpk.describe_topic("epoch-test"))
+        current_epoch = partitions[0].leader_epoch
+        assert current_epoch >= 3, (
+            f"Expected epoch >= 3 after 3 transfers, got {current_epoch}"
+        )
+        self.logger.info(
+            f"Setup complete: HWM={partitions[0].high_watermark}, "
+            f"epoch={current_epoch} (records from epoch {initial_epoch})"
+        )
+
+        return initial_epoch, current_epoch
+
+    def _list_offsets(self, topic, partition, timestamp):
+        """Call ListOffsets API v4 and return (offset, leader_epoch)."""
+        rpk = RpkTool(self.redpanda)
+        client = KafkaAdminClient(bootstrap_servers=self.redpanda.brokers())
+        try:
+            partitions = list(rpk.describe_topic(topic))
+            leader_id = partitions[partition].leader
+
+            f = client._client.add_topic(topic)
+            client._wait_for_futures([f])
+
+            request = ListOffsetsRequest_v4(
+                replica_id=-1,
+                isolation_level=0,
+                topics=[
+                    (
+                        topic,
+                        [(partition, -1, timestamp)],
+                    )
+                ],
+            )
+            future = client._send_request_to_node(leader_id, request)
+            client._wait_for_futures([future])
+            response = future.value
+
+            for resp_topic, resp_partitions in response.topics:
+                for (
+                    part_id,
+                    error_code,
+                    resp_ts,
+                    resp_offset,
+                    leader_epoch,
+                ) in resp_partitions:
+                    if part_id == partition:
+                        error = kerr.for_code(error_code)
+                        if error is not kerr.NoError:
+                            raise error(
+                                f"ListOffsets error for {topic}/{partition}: {error_code}"
+                            )
+                        return (resp_offset, leader_epoch)
+
+            raise RuntimeError(
+                f"Partition {partition} not found in ListOffsets response"
+            )
+        finally:
+            client.close()
+
+    @cluster(num_nodes=3)
+    def test_list_offsets_epoch(self):
+        """Verify ListOffsets returns the correct leader epoch for each
+        timestamp query type.
+
+        All 12 records are produced before leadership is transferred 3
+        times.  The earliest and timequery paths should return the
+        initial epoch (the record epoch), while the latest path should
+        return the current leader epoch.
+        """
+        initial_epoch, current_epoch = self._setup_topic_with_epoch_gap()
+
+        # Earliest (timestamp = -2): should return the record epoch.
+        offset, epoch = self._list_offsets("epoch-test", 0, timestamp=-2)
+        self.logger.info(
+            f"Earliest: offset={offset}, epoch={epoch}, current_epoch={current_epoch}"
+        )
+        assert epoch == initial_epoch, (
+            f"Earliest epoch should be {initial_epoch} (record epoch), got {epoch}"
+        )
+
+        # Latest (timestamp = -1): should return the current leader epoch.
+        offset, epoch = self._list_offsets("epoch-test", 0, timestamp=-1)
+        self.logger.info(
+            f"Latest: offset={offset}, epoch={epoch}, current_epoch={current_epoch}"
+        )
+        assert epoch == current_epoch, (
+            f"Latest epoch should be current leader epoch "
+            f"({current_epoch}), got {epoch}"
+        )
+
+        # Timequery (timestamp = 0): should return the record epoch.
+        # timestamp=0 is earlier than any wall-clock record timestamp,
+        # so the query returns the start of the log.
+        offset, epoch = self._list_offsets("epoch-test", 0, timestamp=0)
+        self.logger.info(
+            f"Timequery: offset={offset}, epoch={epoch}, current_epoch={current_epoch}"
+        )
+        assert epoch == initial_epoch, (
+            f"Timequery epoch should be {initial_epoch} (record epoch), got {epoch}"
+        )

--- a/tools/type-checking/type-check-strictness.json
+++ b/tools/type-checking/type-check-strictness.json
@@ -377,6 +377,7 @@
         "rptest/tests/leaders_redirect_test.py",
         "rptest/tests/license_enforcement_test.py",
         "rptest/tests/limits_test.py",
+        "rptest/tests/list_offsets_epoch_test.py",
         "rptest/tests/log_compaction_test.py",
         "rptest/tests/lw_heartbeats_test.py",
         "rptest/tests/metrics_test.py",


### PR DESCRIPTION
Fixes [CORE-12505](https://redpandadata.atlassian.net/browse/CORE-12505)

ListOffsets incorrectly returns the current leader epoch on the earliest,
timequery, and empty partition return paths instead of the epoch associated
with the returned offset. This causes rpk group seek to commit wrong epoch
values, which can prevent franz-go consumers from advancing on stationary
topics (where records exist at a lower epoch than the current leader epoch).

The fix uses the term from the batch (for timequery, via `res->term`) or looks
it up via a new `get_term(offset)` method on the partition proxy (for earliest).
Empty partitions return `invalid_leader_epoch` (-1). The latest path
(timestamp=-1) is unchanged — the reference implementation returns the
current leader epoch for this case.

Cloud/tiered storage partitions return nullopt from `get_term` pending
CORE-12700 (#27097 implements this). In that case the earliest path falls
back to `invalid_leader_epoch` (-1).

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes

### Bug Fixes

* Fixed ListOffsets returning the current leader epoch instead of the
  historical epoch for earliest, timequery, and empty partition return
  paths. This could cause rpk group seek to commit incorrect epoch
  values, preventing consumer groups from advancing on stationary topics.

[CORE-12505]: https://redpandadata.atlassian.net/browse/CORE-12505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ