### PR TITLE
ci: add /install-pack slash command dispatch

### DIFF
--- a/.github/workflows/buildkite-slash-commands.yml
+++ b/.github/workflows/buildkite-slash-commands.yml
@@ -6,6 +6,7 @@ on:
       - cdt-command
       - ci-repeat-command
       - dt-command
+      - install-pack-command
       - microbench-command
       - rp-unit-test-command
       - test-arm64-command

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -29,6 +29,7 @@ jobs:
             cdt
             ci-repeat
             dt
+            install-pack
             microbench
             rp-unit-test
             test-arm64


### PR DESCRIPTION
Add `install-pack` to slash command dispatch workflows.
Enables `/install-pack` on redpanda PRs to build and publish a custom
installpack for testing on cloud BYOC clusters.

Companion PR: https://github.com/redpanda-data/vtools/pull/4167

---

### Backports Required

- [ ] none - not a bug fix

## Release Notes

* none