### PR TITLE
CORE-15586 Config: Suppress changes to needs_restart properties until restart.

### DIFF
--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -12,6 +12,7 @@
 #include "config_manager.h"
 
 #include "base/vlog.h"
+#include "cluster/cluster_recovery_table.h"
 #include "cluster/config_frontend.h"
 #include "cluster/controller_service.h"
 #include "cluster/controller_snapshot.h"
@@ -56,13 +57,15 @@ config_manager::config_manager(
   ss::sharded<rpc::connection_cache>& cc,
   ss::sharded<partition_leaders_table>& pl,
   ss::sharded<cluster::members_table>& mt,
-  ss::sharded<ss::abort_source>& as)
+  ss::sharded<ss::abort_source>& as,
+  ss::sharded<cluster_recovery_table>& rt)
   : _self(*config::node().node_id())
   , _frontend(cf)
   , _connection_cache(cc)
   , _leaders(pl)
   , _members(mt)
-  , _as(as) {
+  , _as(as)
+  , _recovery_table(rt) {
     if (ss::this_shard_id() == controller_stm_shard) {
         // Only the controller stm shard handles updates: leave these
         // members in default initialized state on other shards.
@@ -186,7 +189,41 @@ ss::future<> config_manager::do_bootstrap() {
     }
 }
 
+namespace {
+
+/// needs_restart properties accumulate pending values via set_pending_value()
+/// during apply_local(). They are promoted (pending -> active) at three points:
+///
+///   1. start() — after STM replay on node restart
+///      preload() seeds active values from the config cache, then STM replay
+///      stages any values newer than cache state as pending. start() promotes
+///      them all once replay is complete.
+///
+///   2. apply_delta() — during initial bootstrap or cluster recovery
+///      The node is fresh with no running workload, so pending values are
+///      promoted immediately and the restart flag is cleared.
+///
+///   3. apply_snapshot() — after controller snapshot installation
+///      Wholesale state replacement; pending values are promoted
+///      unconditionally. May overlap with (2) when recovery is active, but
+///      promote_pending() on a property with no pending value is a no-op.
+///
+/// During normal operation (a delta applied to a running node outside
+/// bootstrap/recovery), needs_restart properties stay pending until the node
+/// restarts and hits promotion point 1.
+ss::future<> promote_all_pending() {
+    co_await ss::smp::invoke_on_all(
+      [] { config::shard_local_cfg().promote_pending(); });
+}
+} // namespace
+
 ss::future<> config_manager::start() {
+    // Promote any pending values accumulated during STM replay.
+    // With a fresh config cache, this is a no-op (replay values match
+    // preloaded active values). With a stale cache, this promotes
+    // values that replay set as pending.
+    co_await promote_all_pending();
+
     if (_seen_version == config_version_unset) {
         vlog(clusterlog.trace, "Starting config_manager... (initial)");
 
@@ -303,9 +340,11 @@ static void preload_local(
             auto decoded = YAML::Load(raw_value);
             bool set = property.set_value(decoded);
 
-            // Because we are in preload, it doesn't matter if the property
-            // requires restart.  We are setting it before anything else
-            // can be using it.
+            // We intentionally use set_value (not set_pending_value) even
+            // for needs_restart properties: preload runs before anything
+            // reads the config, so values go straight into _value.
+            // STM replay later calls set_pending_value for any updates
+            // beyond the cache, and start() promotes them.
 
             if (result.has_value() && set) {
                 vlog(
@@ -618,7 +657,6 @@ ss::future<> config_manager::reconcile_status() {
  * @param silent if true, do not log issues with properties.  Useful
  *               when invoking on N shards to avoid spamming the
  *               same errors to the log N times.
- *
  * @return an `apply_result` indicating any issues, to be fed back
  *         into cluster_status by the caller.
  */
@@ -667,8 +705,11 @@ apply_local(const cluster_config_delta_cmd_data& data, bool silent) {
                 // earlier redpanda versions with weaker validation.
             }
 
-            bool changed = property.set_value(val);
-            result.restart |= (property.needs_restart() && changed);
+            if (property.needs_restart()) {
+                result.restart |= property.set_pending_value(val);
+            } else {
+                property.set_value(val);
+            }
         } catch (const YAML::ParserException&) {
             if (!silent) {
                 vlog(
@@ -721,21 +762,26 @@ apply_local(const cluster_config_delta_cmd_data& data, bool silent) {
         }
 
         auto& property = cfg.get(r);
-        result.restart |= property.needs_restart();
-        try {
-            property.reset();
-        } catch (...) {
-            // Most probably one of the watch callbacks is buggy and failed to
-            // handle the update. Don't stop the controller STM, but log with
-            // error severity so that at least we can catch these bugs in tests.
-            if (!silent) {
-                vlog(
-                  clusterlog.error,
-                  "Unexpected error resetting property {}: {}",
-                  r,
-                  std::current_exception());
+        if (property.needs_restart()) {
+            property.set_pending_value_to_default();
+            result.restart |= property.has_pending();
+        } else {
+            try {
+                property.reset();
+            } catch (...) {
+                // Most probably one of the watch callbacks is buggy and
+                // failed to handle the update. Don't stop the controller STM,
+                // but log with error severity so that at least we can catch
+                // these bugs in tests.
+                if (!silent) {
+                    vlog(
+                      clusterlog.error,
+                      "Unexpected error resetting property {}: {}",
+                      r,
+                      std::current_exception());
+                }
+                continue;
             }
-            continue;
         }
     }
 
@@ -900,6 +946,7 @@ config_manager::apply_delta(cluster_config_delta_cmd&& cmd_in) {
           _seen_version);
         co_return errc::success;
     }
+    const bool is_initial_bootstrap = _seen_version == config_version_unset;
     _seen_version = delta_version;
     // version_shard is chosen to match controller_stm_shard, so
     // our raft0 stm apply operations do not need a core jump to
@@ -924,6 +971,16 @@ config_manager::apply_delta(cluster_config_delta_cmd&& cmd_in) {
     auto apply_r = apply_local(data, false);
 
     co_await ss::smp::invoke_on_all([&data] { apply_local(data, true); });
+
+    // During initial bootstrap or cluster recovery, the node is fresh and
+    // has nothing to "restart" from — promote pending values immediately
+    // so needs_restart properties take effect.
+    if (is_initial_bootstrap || _recovery_table.local().is_recovery_active()) {
+        co_await promote_all_pending();
+        // Pending values have been promoted, so any computed restart
+        // requirement no longer applies.
+        apply_r.restart = false;
+    }
 
     // Merge results from this delta into our status.
     my_latest_status.version = delta_version;
@@ -1038,6 +1095,11 @@ config_manager::apply_snapshot(model::offset, const controller_snapshot& snap) {
           ec.message(),
           ec));
     }
+
+    // Snapshot application is a wholesale state replacement — promote
+    // all pending values immediately so needs_restart properties take
+    // effect (e.g. during cluster recovery).
+    co_await promote_all_pending();
 }
 
 } // namespace cluster

--- a/src/v/cluster/config_manager.h
+++ b/src/v/cluster/config_manager.h
@@ -54,7 +54,8 @@ public:
       ss::sharded<rpc::connection_cache>&,
       ss::sharded<partition_leaders_table>&,
       ss::sharded<cluster::members_table>&,
-      ss::sharded<ss::abort_source>&);
+      ss::sharded<ss::abort_source>&,
+      ss::sharded<cluster_recovery_table>&);
 
     // Preload early in startup, from bootstrap file or config cache
     static ss::future<preload_result> preload(const YAML::Node&);
@@ -139,6 +140,7 @@ private:
 
     ss::condition_variable _reconcile_wait;
     ss::sharded<ss::abort_source>& _as;
+    ss::sharded<cluster_recovery_table>& _recovery_table;
     ss::gate _gate;
 };
 

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -332,7 +332,8 @@ ss::future<> controller::start(
       std::ref(_connections),
       std::ref(_partition_leaders),
       std::ref(_members_table),
-      std::ref(_as));
+      std::ref(_as),
+      std::ref(_recovery_table));
 
     if (auto bucket_opt = get_configured_bucket(); bucket_opt.has_value()) {
         co_await _topic_mount_handler.start(

--- a/src/v/config/base_property.h
+++ b/src/v/config/base_property.h
@@ -66,6 +66,52 @@ using legacy_version = named_type<int64_t, struct legacy_version_tag>;
 std::string_view to_string_view(visibility v);
 fmt::iterator format_to(visibility v, fmt::iterator);
 
+/**
+ * Abstract interface for all configuration properties.
+ *
+ * Properties that have needs_restart::yes maintain two value slots: an active
+ * value used by the running system, and an optional pending value representing
+ * a user-submitted change that takes effect after restart. The configured_value
+ * (exposed via to_json with use_pending::yes) returns the pending value when
+ * present, otherwise the active value.
+ *
+ * Lifecycle of a needs_restart property:
+ *
+ *                         set_value(V1)
+ *                    (live-settable props only)
+ *   +----------+    ───────────────────────────>    +----------+
+ *   |  active  |                                    |  active  |
+ *   |   = V0   |                                    |   = V1   |
+ *   | pending  |                                    | pending  |
+ *   |   = {}   |                                    |   = {}   |
+ *   +----------+                                    +----------+
+ *        │
+ *        │ set_pending_value(V1)
+ *        v
+ *   +----------+    promote_pending()               +----------+
+ *   |  active  |    ─────────────────────────>      |  active  |
+ *   |   = V0   |       (on restart)                 |   = V1   |
+ *   | pending  |                                    | pending  |
+ *   |   = V1   |                                    |   = {}   |
+ *   +----------+                                    +----------+
+ *        │
+ *        │ set_pending_value_to_default()
+ *        v
+ *   +---------------+
+ *   |  active       |
+ *   |   = V0        |
+ *   | pending       |
+ *   |   = default() |
+ *   +---------------+
+ *
+ * Query methods in each state (when pending = V1, active = V0):
+ *
+ *   value()            -> V0   (always the active runtime value)
+ *   configured_value() -> V1   (pending if present, else active)
+ *   has_pending()      -> true
+ *   is_default()       -> V0 == default
+ *   is_default_pending() -> V1 == default
+ */
 class base_property {
 public:
     struct metadata {
@@ -114,10 +160,52 @@ public:
       json::Writer<json::StringBuffer>& w, redact_secrets redact) const = 0;
 
     virtual fmt::iterator format_to(fmt::iterator it) const = 0;
+
+    /// Set the active value from a YAML node. For needs_restart properties,
+    /// this immediately changes the runtime value; prefer set_pending_value
+    /// when the caller intends the change to take effect after restart.
+    /// Returns true if the value changed.
     virtual bool set_value(YAML::Node) = 0;
+
+    /// Set the active value from a type-erased std::any.
     virtual void set_value(std::any) = 0;
+
+    /// Reset the active value to its default.
     virtual void reset() = 0;
+
+    /// Stage a pending value from a YAML node. The pending value is not
+    /// visible to property::value() until promote_pending() is called
+    /// (typically on restart). Returns true if, after this call, a pending
+    /// value is staged that differs from the active value (i.e. if a restart is
+    /// required).
+    virtual bool set_pending_value(YAML::Node) = 0;
+
+    /// Stage a pending value from a type-erased std::any.
+    virtual void set_pending_value(std::any) = 0;
+
+    /// Set the pending value to the property's default. Unlike reset()
+    /// (which immediately changes the active value), this stages the default
+    /// as pending so it takes effect after restart.
+    virtual void set_pending_value_to_default() = 0;
+
+    /// Returns true if a pending value has been staged that differs from
+    /// the active value.
+    virtual bool has_pending() const = 0;
+
+    /// Promote the pending value to become the active value. After this
+    /// call, has_pending() returns false and value() reflects the
+    /// previously-pending value.
+    virtual void promote_pending() = 0;
+
+    /// Returns true if the active runtime value equals the default.
     virtual bool is_default() const = 0;
+
+    /// Returns true if the configured value (pending if present, otherwise
+    /// active) equals the default. Use this when filtering with
+    /// use_pending::yes to correctly exclude properties whose pending
+    /// value is the default.
+    virtual bool is_default_pending() const = 0;
+
     virtual bool is_set() const = 0;
     virtual bool is_hidden() const = 0;
 
@@ -163,6 +251,15 @@ public:
     virtual std::optional<validation_error>
       check_restricted(YAML::Node) const = 0;
 
+    /// Copy the configured value (pending if present, otherwise active)
+    /// from another property of the same type into this property's active
+    /// value. This is used when creating temporary config copies for
+    /// validation, ensuring the copy reflects the user's configured intent
+    /// rather than just the current runtime state.
+    ///
+    /// NB: This sets the active value directly (triggering watchers and
+    /// clearing any pending state on the target). Only safe on temporary
+    /// config objects — do not use on the live shard_local_cfg().
     virtual base_property& operator=(const base_property&) = 0;
     virtual ~base_property() noexcept = default;
 

--- a/src/v/config/base_property.h
+++ b/src/v/config/base_property.h
@@ -59,6 +59,10 @@ enum class odd_even_constraint {
     odd,
 };
 
+// Whether to use the pending (pre-restart) value instead of the active value
+// when serializing properties.
+using use_pending = ss::bool_class<struct use_pending_tag>;
+
 // This is equivalent to cluster::cluster_version, but defined here to
 // avoid a dependency between config/ and cluster/
 using legacy_version = named_type<int64_t, struct legacy_version_tag>;
@@ -153,11 +157,17 @@ public:
     }
     bool gets_restored() const { return bool(_meta.gets_restored); }
 
-    // this serializes the property value. a full configuration serialization is
-    // performed in config_store::to_json where the json object key is taken
-    // from the property name.
+    /// Serialize the property value to JSON. A full configuration
+    /// serialization is performed in config_store::to_json where the JSON
+    /// object key is taken from the property name.
+    ///
+    /// When \p pending is use_pending::yes (the default), properties that
+    /// have a pending value awaiting restart will serialize that pending
+    /// value. When use_pending::no, only the active runtime value is used.
     virtual void to_json(
-      json::Writer<json::StringBuffer>& w, redact_secrets redact) const = 0;
+      json::Writer<json::StringBuffer>& w,
+      redact_secrets redact,
+      use_pending pending = use_pending::yes) const = 0;
 
     virtual fmt::iterator format_to(fmt::iterator it) const = 0;
 

--- a/src/v/config/bounded_property.h
+++ b/src/v/config/bounded_property.h
@@ -235,6 +235,15 @@ public:
         return clamp_and_update(val);
     }
 
+    bool set_pending_value(YAML::Node n) override {
+        auto val = std::move(n.as<T>());
+        return clamp_and_update_pending(val);
+    }
+
+    void set_pending_value(std::any v) override {
+        property<T>::update_pending_value(std::any_cast<T>(std::move(v)));
+    }
+
     std::optional<std::string_view> example() const override {
         if (!_example.empty()) {
             return _example;
@@ -271,6 +280,21 @@ private:
             }
         } else {
             return property<T>::update_value(std::move(clamp_with_bounds(val)));
+        }
+    }
+
+    bool clamp_and_update_pending(T val) {
+        using outer_type = std::decay_t<T>;
+        if constexpr (reflection::is_std_optional<outer_type>) {
+            if (val.has_value()) {
+                return property<T>::update_pending_value(
+                  std::move(clamp_with_bounds(val.value())));
+            } else {
+                return property<T>::update_pending_value(std::move(val));
+            }
+        } else {
+            return property<T>::update_pending_value(
+              std::move(clamp_with_bounds(val)));
         }
     }
 

--- a/src/v/config/config_store.h
+++ b/src/v/config/config_store.h
@@ -197,6 +197,18 @@ public:
         w.EndObject();
     }
 
+    /// Return names of properties that need a restart and have a pending
+    /// value that differs from the current live value.
+    std::vector<ss::sstring> properties_pending_restart() const {
+        std::vector<ss::sstring> result;
+        for (const auto& [name, prop] : _properties) {
+            if (prop->has_pending()) {
+                result.emplace_back(name);
+            }
+        }
+        return result;
+    }
+
     std::set<std::string_view> property_names() const {
         std::set<std::string_view> result;
         for (const auto& i : _properties) {

--- a/src/v/config/config_store.h
+++ b/src/v/config/config_store.h
@@ -125,6 +125,14 @@ public:
         }
     }
 
+    void promote_pending() {
+        for_each([](auto& p) {
+            if (p.has_pending()) {
+                p.promote_pending();
+            }
+        });
+    }
+
     /**
      *
      * @param filter optional callback for filtering out config properties.

--- a/src/v/config/config_store.h
+++ b/src/v/config/config_store.h
@@ -133,8 +133,8 @@ public:
     void to_json(
       json::Writer<json::StringBuffer>& w,
       redact_secrets redact,
-      std::optional<std::function<bool(base_property&)>> filter
-      = std::nullopt) const {
+      std::optional<std::function<bool(base_property&)>> filter = std::nullopt,
+      use_pending pending = use_pending::yes) const {
         w.StartObject();
 
         for (const auto& [name, property] : _properties) {
@@ -147,7 +147,7 @@ public:
             }
 
             w.Key(name.data(), name.size());
-            property->to_json(w, redact);
+            property->to_json(w, redact, pending);
         }
 
         w.EndObject();
@@ -157,13 +157,14 @@ public:
     void to_json_single_key(
       json::Writer<json::StringBuffer>& w,
       redact_secrets redact,
-      std::string_view key) {
+      std::string_view key,
+      use_pending pending = use_pending::yes) {
         // Whether key was either an original property name or an
         // alias, we will obtain the original property here.
         const auto& property = get(key);
         w.StartObject();
         w.Key(key.data(), key.size());
-        property.to_json(w, redact);
+        property.to_json(w, redact, pending);
         w.EndObject();
     }
 

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -105,6 +105,7 @@ public:
       : base_property(rhs)
       , _value(std::move(rhs._value))
       , _default(std::move(rhs._default))
+      , _pending_value(std::move(rhs._pending_value))
       , _validator(std::move(rhs._validator))
       , _bindings(std::move(rhs._bindings)) {
         for (auto& binding : _bindings) {
@@ -122,6 +123,16 @@ public:
 
     const value_type& value() const { return _value; }
 
+    /// Return the pending value if one exists, otherwise the active value.
+    /// Use this to check the user's configured intent (e.g. for enterprise
+    /// feature enforcement) rather than the currently active runtime value.
+    const value_type& configured_value() const {
+        if (_pending_value.has_value()) {
+            return *_pending_value;
+        }
+        return _value;
+    }
+
     const value_type& default_value() const { return _default; }
 
     std::string_view type_name() const override;
@@ -135,6 +146,10 @@ public:
     bool is_overriden() const { return is_required() || _value != _default; }
 
     bool is_default() const override { return _value == _default; }
+
+    bool is_default_pending() const override {
+        return configured_value() == _default;
+    }
 
     bool is_set() const override { return _is_set; }
 
@@ -183,6 +198,30 @@ public:
         return update_value(std::move(n.as<T>()));
     }
 
+    bool set_pending_value(YAML::Node n) override {
+        return update_pending_value(std::move(n.as<T>()));
+    }
+
+    void set_pending_value(std::any v) override {
+        update_pending_value(std::any_cast<value_type>(std::move(v)));
+    }
+
+    void set_pending_value_to_default() override {
+        auto v = default_value();
+        update_pending_value(std::move(v));
+    }
+
+    bool has_pending() const override {
+        return _pending_value.has_value() && *_pending_value != _value;
+    }
+
+    void promote_pending() override {
+        if (_pending_value.has_value()) {
+            auto v = std::exchange(_pending_value, std::nullopt).value();
+            update_value(std::move(v));
+        }
+    }
+
     std::optional<validation_error> validate(const value_type& v) const {
         if (auto err = _validator(v); err) {
             return std::make_optional<validation_error>(name().data(), *err);
@@ -211,7 +250,8 @@ public:
     }
 
     base_property& operator=(const base_property& pr) override {
-        auto v = dynamic_cast<const property<value_type>&>(pr)._value;
+        auto v
+          = dynamic_cast<const property<value_type>&>(pr).configured_value();
         update_value(std::move(v));
         return *this;
     }
@@ -293,20 +333,43 @@ protected:
         // Set flag even if the value won't be updated. This is to mark that
         // someone tried to explicitly set this property
         _is_set = true;
+        // if there is an update pending either
+        //   - we are in the process of promoting it OR
+        //   - it is stale with respect to new_value
+        _pending_value.reset();
         if (new_value != _value) {
             // Update the main value first, in case one of the binding updates
             // throws.
             _value = std::move(new_value);
             notify_watchers(_value);
-
             return true;
         } else {
             return false;
         }
     }
 
+    bool update_pending_value(value_type&& new_value) {
+        vassert(
+          needs_restart(),
+          "set_pending_value called on property '{}' which does not require "
+          "restart",
+          name());
+        _is_set = true;
+        if (new_value != _value) {
+            _pending_value = std::move(new_value);
+            return true;
+        } else {
+            // new value matches current _active_ value of the property, so
+            // a) there's no need to cache anything
+            // b) anything previously cached is out of date
+            _pending_value.reset();
+            return false;
+        }
+    }
+
     value_type _value;
     value_type _default;
+    std::optional<value_type> _pending_value;
 
     // An alternative default that applies if the cluster's original logical
     // version is <= the defined version
@@ -796,6 +859,11 @@ public:
         return property<std::vector<T>>::update_value(std::move(value));
     }
 
+    bool set_pending_value(YAML::Node n) override {
+        auto value = decode_yaml(n);
+        return property<std::vector<T>>::update_pending_value(std::move(value));
+    }
+
     std::optional<validation_error>
     validate([[maybe_unused]] YAML::Node n) const override {
         std::vector<T> value = decode_yaml(n);
@@ -835,6 +903,12 @@ public:
         auto value = decode_yaml(n);
         return property<std::unordered_map<typename T::key_type, T>>::
           update_value(std::move(value));
+    }
+
+    bool set_pending_value(YAML::Node n) override {
+        auto value = decode_yaml(n);
+        return property<std::unordered_map<typename T::key_type, T>>::
+          update_pending_value(std::move(value));
     }
 
     std::optional<validation_error> validate(YAML::Node n) const override {
@@ -887,6 +961,15 @@ public:
     bool set_value(YAML::Node) override {
         vlog(configlog.warn, "{}", deprecated_property_log_line());
         return false;
+    }
+
+    bool set_pending_value(YAML::Node) override {
+        vlog(configlog.warn, "{}", deprecated_property_log_line());
+        return false;
+    }
+
+    void set_pending_value(std::any) override {
+        vlog(configlog.warn, "{}", deprecated_property_log_line());
     }
 };
 
@@ -988,6 +1071,16 @@ public:
         return update_value(n.as<std::chrono::milliseconds>());
     }
 
+    bool set_pending_value(YAML::Node n) final {
+        return update_pending_value_ms(n.as<std::chrono::milliseconds>());
+    }
+
+    void set_pending_value(std::any v) final {
+        update_pending_value_ms(
+          std::any_cast<std::optional<std::chrono::milliseconds>>(std::move(v))
+            .value_or(-1ms));
+    }
+
     fmt::iterator format_to(fmt::iterator it) const final {
         vassert(!is_secret(), "{} must not be a secret", name());
         return fmt::format_to(it, "{}:{}", name(), _value.value_or(-1ms));
@@ -1002,7 +1095,7 @@ public:
         // non-secret; if a secret retention duration is ever introduced,
         // redact it, but consider the implications on the JSON type.
         vassert(!is_secret(), "{} must not be a secret", name());
-        json::rjson_serialize(w, _value.value_or(-1ms));
+        json::rjson_serialize(w, value().value_or(-1ms));
     }
 
 private:
@@ -1011,6 +1104,14 @@ private:
             return property::update_value(std::nullopt);
         } else {
             return property::update_value(value);
+        }
+    }
+
+    bool update_pending_value_ms(std::chrono::milliseconds value) {
+        if (value < 0ms) {
+            return property::update_pending_value(std::nullopt);
+        } else {
+            return property::update_pending_value(value);
         }
     }
 };

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -173,12 +173,17 @@ public:
     // serialize the value. the key is taken from the property name at the
     // serialization point in config_store::to_json to avoid users from being
     // forced to consume the property as a json object.
-    void to_json(json::Writer<json::StringBuffer>& w, redact_secrets redact)
-      const override {
-        if (is_secret() && !is_default() && redact == redact_secrets::yes) {
+    void to_json(
+      json::Writer<json::StringBuffer>& w,
+      redact_secrets redact,
+      use_pending pending = use_pending::yes) const override {
+        const auto& v = (pending == use_pending::yes) ? configured_value()
+                                                      : _value;
+        bool has_non_default = v != _default;
+        if (is_secret() && has_non_default && redact == redact_secrets::yes) {
             json::rjson_serialize(w, secret_placeholder);
         } else {
-            json::rjson_serialize(w, _value);
+            json::rjson_serialize(w, v);
         }
     }
 
@@ -1089,13 +1094,17 @@ public:
     // serialize the value. the key is taken from the property name at the
     // serialization point in config_store::to_json to avoid users from being
     // forced to consume the property as a json object.
-    void
-    to_json(json::Writer<json::StringBuffer>& w, redact_secrets) const final {
+    void to_json(
+      json::Writer<json::StringBuffer>& w,
+      redact_secrets,
+      use_pending pending = use_pending::yes) const final {
         // TODO: there's nothing forcing the retention duration to be a
         // non-secret; if a secret retention duration is ever introduced,
         // redact it, but consider the implications on the JSON type.
         vassert(!is_secret(), "{} must not be a secret", name());
-        json::rjson_serialize(w, value().value_or(-1ms));
+        const auto& v = (pending == use_pending::yes) ? configured_value()
+                                                      : _value;
+        json::rjson_serialize(w, v.value_or(-1ms));
     }
 
 private:

--- a/src/v/config/tests/BUILD
+++ b/src/v/config/tests/BUILD
@@ -45,7 +45,7 @@ redpanda_cc_btest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "config_store_test",
     timeout = "short",
     srcs = [
@@ -55,9 +55,9 @@ redpanda_cc_btest(
     deps = [
         "//src/v/config",
         "//src/v/json",
-        "//src/v/test_utils:seastar_boost",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
         "@seastar",
-        "@seastar//:testing",
     ],
 )
 

--- a/src/v/config/tests/config_store_test.cc
+++ b/src/v/config/tests/config_store_test.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "config/bounded_property.h"
 #include "config/config_store.h"
 #include "json/document.h"
 #include "json/stringbuffer.h"
@@ -42,6 +43,7 @@ struct test_config : public config::config_store {
     config::property<ss::sstring> default_secret_string;
     config::property<ss::sstring> secret_string;
     config::property<bool> aliased_bool;
+    config::bounded_property<int, config::numeric_bounds> bounded_int;
 
     test_config()
       : optional_int(
@@ -111,7 +113,14 @@ struct test_config : public config::config_store {
           "aliased_bool",
           "Property with a compat alias",
           {.aliases = {"aliased_bool_legacy"}},
-          true) {}
+          true)
+      , bounded_int(
+          *this,
+          "bounded_int",
+          "Bounded integer property",
+          {},
+          50,
+          {.min = 0, .max = 100}) {}
 };
 
 struct noop_config : public config::config_store {};
@@ -607,4 +616,231 @@ aliased_bool_legacy: false
         auto noop_cfg = noop_config{};
         EXPECT_NO_THROW(noop_cfg.read_yaml(yaml_with_unknown_properties));
     }
+}
+
+TEST(ConfigStoreTest, PendingValueSuppressesActive) {
+    auto cfg = test_config();
+    // optional_int has needs_restart::yes (default metadata)
+    EXPECT_EQ(cfg.optional_int(), 100);
+    EXPECT_FALSE(cfg.optional_int.has_pending());
+
+    // Set a pending value via YAML
+    auto node = YAML::Load("42");
+    bool changed = cfg.optional_int.set_pending_value(node);
+    EXPECT_TRUE(changed);
+    EXPECT_TRUE(cfg.optional_int.has_pending());
+
+    // Active value is unchanged
+    EXPECT_EQ(cfg.optional_int(), 100);
+}
+
+TEST(ConfigStoreTest, PendingValueSameAsActive) {
+    auto cfg = test_config();
+    EXPECT_EQ(cfg.optional_int(), 100);
+
+    // Set pending to same value as active
+    auto node = YAML::Load("100");
+    bool changed = cfg.optional_int.set_pending_value(node);
+    EXPECT_FALSE(changed);
+    EXPECT_FALSE(cfg.optional_int.has_pending());
+}
+
+TEST(ConfigStoreTest, PendingValueMultipleUpdates) {
+    auto cfg = test_config();
+    EXPECT_EQ(cfg.optional_int(), 100);
+
+    auto node1 = YAML::Load("42");
+    cfg.optional_int.set_pending_value(node1);
+    EXPECT_TRUE(cfg.optional_int.has_pending());
+    EXPECT_EQ(cfg.optional_int(), 100);
+
+    // Second pending update overwrites first
+    auto node2 = YAML::Load("99");
+    cfg.optional_int.set_pending_value(node2);
+    EXPECT_TRUE(cfg.optional_int.has_pending());
+    EXPECT_EQ(cfg.optional_int(), 100);
+}
+
+TEST(ConfigStoreTest, ResetPendingToDefault) {
+    auto cfg = test_config();
+    // First change active value away from default
+    cfg.optional_int.set_value(YAML::Load("50"));
+    EXPECT_EQ(cfg.optional_int(), 50);
+
+    // Set a pending value
+    auto node = YAML::Load("42");
+    cfg.optional_int.set_pending_value(node);
+    EXPECT_TRUE(cfg.optional_int.has_pending());
+
+    // Reset pending to default (100)
+    cfg.optional_int.set_pending_value_to_default();
+    // Pending is default (100), active is 50, so has_pending is true
+    EXPECT_TRUE(cfg.optional_int.has_pending());
+    // Active value unchanged
+    EXPECT_EQ(cfg.optional_int(), 50);
+}
+
+TEST(ConfigStoreTest, ResetPendingWhenActiveIsDefault) {
+    auto cfg = test_config();
+    // Active is already default (100)
+    EXPECT_EQ(cfg.optional_int(), 100);
+
+    // Set a pending value
+    auto node = YAML::Load("42");
+    cfg.optional_int.set_pending_value(node);
+    EXPECT_TRUE(cfg.optional_int.has_pending());
+
+    // Reset pending to default — matches active, so no pending
+    cfg.optional_int.set_pending_value_to_default();
+    EXPECT_FALSE(cfg.optional_int.has_pending());
+}
+
+TEST(ConfigStoreTest, SetPendingToDefaultThenPromote) {
+    auto cfg = test_config();
+
+    // Move active away from default
+    cfg.optional_int.set_value(YAML::Load("50"));
+    EXPECT_EQ(cfg.optional_int(), 50);
+
+    // Set a pending value, then reset pending to default
+    cfg.optional_int.set_pending_value(YAML::Load("42"));
+    EXPECT_TRUE(cfg.optional_int.has_pending());
+    cfg.optional_int.set_pending_value_to_default();
+    // Pending is default (100), active is 50
+    EXPECT_TRUE(cfg.optional_int.has_pending());
+
+    // Promote: active should become the default, not 50 or 42
+    cfg.optional_int.promote_pending();
+    EXPECT_EQ(cfg.optional_int(), 100);
+    EXPECT_FALSE(cfg.optional_int.has_pending());
+}
+
+TEST(ConfigStoreTest, BoundedPropertyPendingValueClamped) {
+    auto cfg = test_config();
+    EXPECT_EQ(cfg.bounded_int(), 50);
+
+    // Pending value within bounds
+    cfg.bounded_int.set_pending_value(YAML::Load("75"));
+    EXPECT_TRUE(cfg.bounded_int.has_pending());
+    cfg.bounded_int.promote_pending();
+    EXPECT_EQ(cfg.bounded_int(), 75);
+
+    // Pending value exceeding upper bound is clamped to max (100)
+    cfg.bounded_int.set_pending_value(YAML::Load("200"));
+    EXPECT_TRUE(cfg.bounded_int.has_pending());
+    cfg.bounded_int.promote_pending();
+    EXPECT_EQ(cfg.bounded_int(), 100);
+
+    // Pending value below lower bound is clamped to min (0)
+    cfg.bounded_int.set_pending_value(YAML::Load("-5"));
+    EXPECT_TRUE(cfg.bounded_int.has_pending());
+    cfg.bounded_int.promote_pending();
+    EXPECT_EQ(cfg.bounded_int(), 0);
+}
+
+TEST(ConfigStoreTest, SetValueClearsPending) {
+    auto cfg = test_config();
+
+    // Set a pending value
+    auto node = YAML::Load("42");
+    cfg.optional_int.set_pending_value(node);
+    EXPECT_TRUE(cfg.optional_int.has_pending());
+
+    // Now set_value (simulating startup replay) clears pending
+    cfg.optional_int.set_value(YAML::Load("42"));
+    EXPECT_EQ(cfg.optional_int(), 42);
+    EXPECT_FALSE(cfg.optional_int.has_pending());
+}
+
+TEST(ConfigStoreTest, PendingValueViaStdAny) {
+    auto cfg = test_config();
+    EXPECT_EQ(cfg.optional_int(), 100);
+
+    cfg.optional_int.set_pending_value(std::make_any<int>(42));
+    EXPECT_EQ(cfg.optional_int(), 100);
+    EXPECT_TRUE(cfg.optional_int.has_pending());
+}
+
+TEST(ConfigStoreTest, PromotePendingToActive) {
+    auto cfg = test_config();
+    EXPECT_EQ(cfg.optional_int(), 100);
+
+    cfg.optional_int.set_pending_value(YAML::Load("42"));
+    EXPECT_EQ(cfg.optional_int(), 100); // still old active
+    EXPECT_TRUE(cfg.optional_int.has_pending());
+
+    cfg.optional_int.promote_pending();
+    EXPECT_EQ(cfg.optional_int(), 42); // now promoted
+    EXPECT_FALSE(cfg.optional_int.has_pending());
+}
+
+TEST(ConfigStoreTest, PromotePendingNoOpWhenNoPending) {
+    auto cfg = test_config();
+    EXPECT_EQ(cfg.optional_int(), 100);
+    EXPECT_FALSE(cfg.optional_int.has_pending());
+
+    // promote_pending with nothing pending is a safe no-op
+    cfg.optional_int.promote_pending();
+    EXPECT_EQ(cfg.optional_int(), 100);
+    EXPECT_FALSE(cfg.optional_int.has_pending());
+}
+
+TEST(ConfigStoreTest, PromotePendingSimulatesReplayFlow) {
+    // Simulates the startup flow: preload sets active via set_value,
+    // STM replay sets pending via set_pending_value, start() promotes.
+    auto cfg = test_config();
+
+    // Step 1: Preload from config cache (set_value)
+    cfg.optional_int.set_value(YAML::Load("50"));
+    EXPECT_EQ(cfg.optional_int(), 50);
+
+    // Step 2: STM replay sets pending (simulating apply_local)
+    cfg.optional_int.set_pending_value(YAML::Load("75"));
+    EXPECT_EQ(cfg.optional_int(), 50); // active unchanged during replay
+    EXPECT_TRUE(cfg.optional_int.has_pending());
+
+    // Step 3: start() promotes pending to active
+    cfg.optional_int.promote_pending();
+    EXPECT_EQ(cfg.optional_int(), 75);
+    EXPECT_FALSE(cfg.optional_int.has_pending());
+}
+
+TEST(ConfigStoreTest, PromotePendingFreshCache) {
+    // When the config cache is fresh, replay's set_pending_value
+    // matches active, so has_pending() is false. promote is a no-op.
+    auto cfg = test_config();
+
+    // Preload from cache
+    cfg.optional_int.set_value(YAML::Load("50"));
+    EXPECT_EQ(cfg.optional_int(), 50);
+
+    // Replay sets same value as pending — no effective pending
+    cfg.optional_int.set_pending_value(YAML::Load("50"));
+    EXPECT_FALSE(cfg.optional_int.has_pending());
+
+    // promote_pending is a no-op (pending matches active)
+    cfg.optional_int.promote_pending();
+    EXPECT_EQ(cfg.optional_int(), 50);
+}
+
+TEST(ConfigStoreTest, PromotePendingForEachProperty) {
+    // Simulates the promote_all_pending() pattern used in
+    // config_manager::start().
+    auto cfg = test_config();
+
+    cfg.optional_int.set_value(YAML::Load("50"));
+    cfg.optional_int.set_pending_value(YAML::Load("75"));
+    cfg.an_int64_t.set_pending_value(YAML::Load("999"));
+
+    // Promote all pending via for_each
+    cfg.for_each([](auto& p) {
+        if (p.has_pending()) {
+            p.promote_pending();
+        }
+    });
+
+    EXPECT_EQ(cfg.optional_int(), 75);
+    EXPECT_FALSE(cfg.optional_int.has_pending());
+    EXPECT_EQ(cfg.an_int64_t(), 999);
+    EXPECT_FALSE(cfg.an_int64_t.has_pending());
 }

--- a/src/v/config/tests/config_store_test.cc
+++ b/src/v/config/tests/config_store_test.cc
@@ -13,8 +13,9 @@
 #include "json/writer.h"
 
 #include <seastar/core/sstring.hh>
-#include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/log.hh>
+
+#include <gtest/gtest.h>
 
 #include <cstdint>
 #include <iostream>
@@ -143,19 +144,6 @@ YAML::Node valid_configuration() {
 
 } // namespace
 
-namespace std {
-static inline std::ostream&
-operator<<(std::ostream& ostr, const std::optional<int16_t>& rhs) {
-    if (rhs.has_value()) {
-        ostr << rhs.value();
-    } else {
-        ostr << "~";
-    }
-    return ostr;
-}
-
-} // namespace std
-
 namespace YAML {
 template<>
 struct convert<testing::custom_aggregate> {
@@ -180,88 +168,87 @@ struct convert<testing::custom_aggregate> {
 };
 } // namespace YAML
 
-SEASTAR_THREAD_TEST_CASE(read_minimal_valid_configuration) {
+TEST(ConfigStoreTest, ReadMinimalValidConfiguration) {
     auto cfg = test_config();
     auto errors = cfg.read_yaml(minimal_valid_configuration());
-    BOOST_TEST(errors.size() == 0);
+    EXPECT_EQ(errors.size(), 0);
 
-    BOOST_TEST(cfg.optional_int() == 100);
-    BOOST_TEST(cfg.required_string() == "test_value_1");
-    BOOST_TEST(cfg.an_int64_t() == 200);
-    BOOST_TEST(cfg.an_aggregate().string_value == "str");
-    BOOST_TEST(cfg.an_aggregate().int_value == 10);
-    BOOST_TEST(cfg.strings().at(0) == "first");
-    BOOST_TEST(cfg.strings().at(1) == "second");
-    BOOST_TEST(cfg.strings().at(2) == "third");
-    BOOST_TEST(cfg.nullable_int() == std::nullopt);
-};
+    EXPECT_EQ(cfg.optional_int(), 100);
+    EXPECT_EQ(cfg.required_string(), "test_value_1");
+    EXPECT_EQ(cfg.an_int64_t(), 200);
+    EXPECT_EQ(cfg.an_aggregate().string_value, "str");
+    EXPECT_EQ(cfg.an_aggregate().int_value, 10);
+    EXPECT_EQ(cfg.strings().at(0), "first");
+    EXPECT_EQ(cfg.strings().at(1), "second");
+    EXPECT_EQ(cfg.strings().at(2), "third");
+    EXPECT_EQ(cfg.nullable_int(), std::nullopt);
+}
 
-SEASTAR_THREAD_TEST_CASE(read_valid_configuration) {
+TEST(ConfigStoreTest, ReadValidConfiguration) {
     auto cfg = test_config();
     auto errors = cfg.read_yaml(valid_configuration());
-    BOOST_TEST(errors.size() == 0);
+    EXPECT_EQ(errors.size(), 0);
 
-    BOOST_TEST(cfg.optional_int() == 3);
-    BOOST_TEST(cfg.required_string() == "test_value_2");
-    BOOST_TEST(cfg.an_int64_t() == 55);
-    BOOST_TEST(cfg.an_aggregate().string_value == "some_value");
-    BOOST_TEST(cfg.an_aggregate().int_value == 88);
-    BOOST_TEST(cfg.strings().at(0) == "one");
-    BOOST_TEST(cfg.strings().at(1) == "two");
-    BOOST_TEST(cfg.strings().at(2) == "three");
-    BOOST_TEST(cfg.nullable_int() == std::make_optional(111));
-    BOOST_TEST(cfg.secret_string() == "actual_secret");
-    BOOST_TEST(cfg.aliased_bool() == false);
-};
+    EXPECT_EQ(cfg.optional_int(), 3);
+    EXPECT_EQ(cfg.required_string(), "test_value_2");
+    EXPECT_EQ(cfg.an_int64_t(), 55);
+    EXPECT_EQ(cfg.an_aggregate().string_value, "some_value");
+    EXPECT_EQ(cfg.an_aggregate().int_value, 88);
+    EXPECT_EQ(cfg.strings().at(0), "one");
+    EXPECT_EQ(cfg.strings().at(1), "two");
+    EXPECT_EQ(cfg.strings().at(2), "three");
+    EXPECT_EQ(cfg.nullable_int(), std::make_optional(111));
+    EXPECT_EQ(cfg.secret_string(), "actual_secret");
+    EXPECT_EQ(cfg.aliased_bool(), false);
+}
 
-SEASTAR_THREAD_TEST_CASE(update_property_value) {
+TEST(ConfigStoreTest, UpdatePropertyValue) {
     auto cfg = test_config();
     auto errors = cfg.read_yaml(minimal_valid_configuration());
-    BOOST_TEST(errors.size() == 0);
+    EXPECT_EQ(errors.size(), 0);
 
-    BOOST_TEST(cfg.required_string() == "test_value_1");
+    EXPECT_EQ(cfg.required_string(), "test_value_1");
     cfg.get("required_string").set_value(ss::sstring("new_string_value"));
-    BOOST_TEST(cfg.required_string() == "new_string_value");
-};
+    EXPECT_EQ(cfg.required_string(), "new_string_value");
+}
 
-SEASTAR_THREAD_TEST_CASE(track_set_state) {
+TEST(ConfigStoreTest, TrackSetState) {
     auto cfg = test_config();
 
-    BOOST_TEST(cfg.optional_int() == 100);
-    BOOST_TEST(cfg.optional_int.is_default() == true);
-    BOOST_TEST(cfg.optional_int.is_set() == false);
+    EXPECT_EQ(cfg.optional_int(), 100);
+    EXPECT_TRUE(cfg.optional_int.is_default());
+    EXPECT_FALSE(cfg.optional_int.is_set());
 
     // set to default value
     cfg.get("required_string").set_value(ss::sstring{});
-    BOOST_TEST(cfg.required_string.is_default() == true);
-    BOOST_TEST(cfg.required_string.is_set() == true);
+    EXPECT_TRUE(cfg.required_string.is_default());
+    EXPECT_TRUE(cfg.required_string.is_set());
 
     // set to non-default value
     cfg.get("an_int64_t").set_value(int64_t{100});
-    BOOST_TEST(cfg.an_int64_t.is_default() == false);
-    BOOST_TEST(cfg.an_int64_t.is_set() == true);
-};
-
-SEASTAR_THREAD_TEST_CASE(validate_valid_configuration) {
-    auto cfg = test_config();
-    auto errors = cfg.read_yaml(valid_configuration());
-    BOOST_TEST(errors.size() == 0);
+    EXPECT_FALSE(cfg.an_int64_t.is_default());
+    EXPECT_TRUE(cfg.an_int64_t.is_set());
 }
 
-SEASTAR_THREAD_TEST_CASE(validate_invalid_configuration) {
+TEST(ConfigStoreTest, ValidateValidConfiguration) {
     auto cfg = test_config();
     auto errors = cfg.read_yaml(valid_configuration());
-    BOOST_TEST(errors.size() == 0);
+    EXPECT_EQ(errors.size(), 0);
 }
 
-SEASTAR_THREAD_TEST_CASE(config_json_serialization) {
+TEST(ConfigStoreTest, ValidateAnotherValidConfiguration) {
+    auto cfg = test_config();
+    auto errors = cfg.read_yaml(valid_configuration());
+    EXPECT_EQ(errors.size(), 0);
+}
+
+TEST(ConfigStoreTest, ConfigJsonSerialization) {
     const auto test_with_redaction = [](config::redact_secrets redact) {
         auto cfg = test_config();
         auto errors = cfg.read_yaml(valid_configuration());
-        BOOST_TEST(errors.size() == 0);
+        EXPECT_EQ(errors.size(), 0);
         lg.info("Config: {}", cfg);
         // json data
-        // TODO: get this to work with fmt.
         auto expected_result = redact == config::redact_secrets::yes
                                  ? "{"
                                    "\"strings\": [\"one\", \"two\", \"three\"],"
@@ -305,47 +292,45 @@ SEASTAR_THREAD_TEST_CASE(config_json_serialization) {
         exp_doc.Parse(expected_result);
 
         // test equivalence
-        BOOST_TEST(res_doc["required_string"].IsString());
-        BOOST_TEST(
-          res_doc["required_string"].GetString()
-          == exp_doc["required_string"].GetString());
+        EXPECT_TRUE(res_doc["required_string"].IsString());
+        EXPECT_STREQ(
+          res_doc["required_string"].GetString(),
+          exp_doc["required_string"].GetString());
 
-        BOOST_TEST(res_doc["optional_int"].IsInt());
-        BOOST_TEST(
-          res_doc["optional_int"].GetInt() == exp_doc["optional_int"].GetInt());
+        EXPECT_TRUE(res_doc["optional_int"].IsInt());
+        EXPECT_EQ(
+          res_doc["optional_int"].GetInt(), exp_doc["optional_int"].GetInt());
 
-        BOOST_TEST(res_doc["an_int64_t"].IsInt64());
-        BOOST_TEST(
-          res_doc["an_int64_t"].GetInt64() == exp_doc["an_int64_t"].GetInt64());
+        EXPECT_TRUE(res_doc["an_int64_t"].IsInt64());
+        EXPECT_EQ(
+          res_doc["an_int64_t"].GetInt64(), exp_doc["an_int64_t"].GetInt64());
 
-        BOOST_TEST(res_doc["an_aggregate"].IsObject());
+        EXPECT_TRUE(res_doc["an_aggregate"].IsObject());
 
-        BOOST_TEST(res_doc["an_aggregate"]["int_value"].IsInt());
-        BOOST_TEST(
-          res_doc["an_aggregate"]["int_value"].GetInt()
-          == exp_doc["an_aggregate"]["int_value"].GetInt());
+        EXPECT_TRUE(res_doc["an_aggregate"]["int_value"].IsInt());
+        EXPECT_EQ(
+          res_doc["an_aggregate"]["int_value"].GetInt(),
+          exp_doc["an_aggregate"]["int_value"].GetInt());
 
-        BOOST_TEST(res_doc["an_aggregate"]["string_value"].IsString());
-        BOOST_TEST(
-          res_doc["an_aggregate"]["string_value"].GetString()
-          == exp_doc["an_aggregate"]["string_value"].GetString());
+        EXPECT_TRUE(res_doc["an_aggregate"]["string_value"].IsString());
+        EXPECT_STREQ(
+          res_doc["an_aggregate"]["string_value"].GetString(),
+          exp_doc["an_aggregate"]["string_value"].GetString());
 
-        BOOST_TEST(res_doc["strings"].IsArray());
+        EXPECT_TRUE(res_doc["strings"].IsArray());
 
-        BOOST_TEST(res_doc["nullable_int"].IsInt());
-        BOOST_TEST(
-          res_doc["nullable_int"].GetInt() == exp_doc["nullable_int"].GetInt());
-        BOOST_TEST(
-          res_doc["secret_string"].GetString()
-          == exp_doc["secret_string"].GetString());
+        EXPECT_TRUE(res_doc["nullable_int"].IsInt());
+        EXPECT_EQ(
+          res_doc["nullable_int"].GetInt(), exp_doc["nullable_int"].GetInt());
+        EXPECT_STREQ(
+          res_doc["secret_string"].GetString(),
+          exp_doc["secret_string"].GetString());
     };
     test_with_redaction(config::redact_secrets::yes);
     test_with_redaction(config::redact_secrets::no);
 }
 
-/// Test that unset std::optional options are decoded correctly
-/// when given as 'null', not just when absent.
-SEASTAR_THREAD_TEST_CASE(deserialize_explicit_null) {
+TEST(ConfigStoreTest, DeserializeExplicitNull) {
     auto with_null = YAML::Load(
       "required_string: test_value_1\n"
       "strings:\n"
@@ -356,103 +341,103 @@ SEASTAR_THREAD_TEST_CASE(deserialize_explicit_null) {
 
     auto cfg = test_config();
     auto errors = cfg.read_yaml(with_null);
-    BOOST_TEST(errors.size() == 0);
-    BOOST_TEST(cfg.nullable_int() == std::nullopt);
+    EXPECT_EQ(errors.size(), 0);
+    EXPECT_EQ(cfg.nullable_int(), std::nullopt);
 }
 
-SEASTAR_THREAD_TEST_CASE(property_metadata) {
+TEST(ConfigStoreTest, PropertyMetadata) {
     auto cfg = test_config();
-    BOOST_TEST(cfg.optional_int.type_name() == "integer");
-    BOOST_TEST(
-      config::to_string_view(cfg.optional_int.get_visibility()) == "tunable");
+    EXPECT_EQ(cfg.optional_int.type_name(), "integer");
+    EXPECT_EQ(
+      config::to_string_view(cfg.optional_int.get_visibility()), "tunable");
 
-    BOOST_TEST(cfg.boolean.is_nullable() == false);
-    BOOST_TEST(cfg.nullable_string.is_array() == false);
+    EXPECT_FALSE(cfg.boolean.is_nullable());
+    EXPECT_FALSE(cfg.nullable_string.is_array());
 
-    BOOST_TEST(cfg.required_string.type_name() == "string");
-    BOOST_TEST(cfg.required_string.is_array() == false);
-    BOOST_TEST(
-      config::to_string_view(cfg.required_string.get_visibility()) == "user");
+    EXPECT_EQ(cfg.required_string.type_name(), "string");
+    EXPECT_FALSE(cfg.required_string.is_array());
+    EXPECT_EQ(
+      config::to_string_view(cfg.required_string.get_visibility()), "user");
 
-    BOOST_TEST(cfg.boolean.is_nullable() == false);
+    EXPECT_FALSE(cfg.boolean.is_nullable());
 
-    BOOST_TEST(cfg.an_int64_t.type_name() == "integer");
-    BOOST_TEST(cfg.boolean.is_nullable() == false);
-    BOOST_TEST(cfg.nullable_string.is_array() == false);
+    EXPECT_EQ(cfg.an_int64_t.type_name(), "integer");
+    EXPECT_FALSE(cfg.boolean.is_nullable());
+    EXPECT_FALSE(cfg.nullable_string.is_array());
 
-    BOOST_TEST(cfg.an_aggregate.type_name() == "custom_aggregate");
-    BOOST_TEST(cfg.boolean.is_nullable() == false);
-    BOOST_TEST(cfg.nullable_string.is_array() == false);
+    EXPECT_EQ(cfg.an_aggregate.type_name(), "custom_aggregate");
+    EXPECT_FALSE(cfg.boolean.is_nullable());
+    EXPECT_FALSE(cfg.nullable_string.is_array());
 
-    BOOST_TEST(cfg.strings.type_name() == "string");
-    BOOST_TEST(cfg.strings.is_array() == true);
-    BOOST_TEST(cfg.strings.is_nullable() == false);
+    EXPECT_EQ(cfg.strings.type_name(), "string");
+    EXPECT_TRUE(cfg.strings.is_array());
+    EXPECT_FALSE(cfg.strings.is_nullable());
 
-    BOOST_TEST(cfg.nullable_string.type_name() == "string");
-    BOOST_TEST(cfg.nullable_string.is_nullable() == true);
-    BOOST_TEST(cfg.nullable_string.is_array() == false);
+    EXPECT_EQ(cfg.nullable_string.type_name(), "string");
+    EXPECT_TRUE(cfg.nullable_string.is_nullable());
+    EXPECT_FALSE(cfg.nullable_string.is_array());
 
-    BOOST_TEST(cfg.nullable_strings.type_name() == "string");
-    BOOST_TEST(cfg.nullable_strings.is_nullable() == true);
-    BOOST_TEST(cfg.nullable_strings.is_array() == true);
+    EXPECT_EQ(cfg.nullable_strings.type_name(), "string");
+    EXPECT_TRUE(cfg.nullable_strings.is_nullable());
+    EXPECT_TRUE(cfg.nullable_strings.is_array());
 
-    BOOST_TEST(cfg.nullable_int.type_name() == "integer");
-    BOOST_TEST(cfg.nullable_int.is_nullable() == true);
-    BOOST_TEST(cfg.nullable_int.is_array() == false);
+    EXPECT_EQ(cfg.nullable_int.type_name(), "integer");
+    EXPECT_TRUE(cfg.nullable_int.is_nullable());
+    EXPECT_FALSE(cfg.nullable_int.is_array());
 
-    BOOST_TEST(cfg.boolean.type_name() == "boolean");
-    BOOST_TEST(cfg.boolean.is_nullable() == false);
-    BOOST_TEST(cfg.boolean.is_array() == false);
+    EXPECT_EQ(cfg.boolean.type_name(), "boolean");
+    EXPECT_FALSE(cfg.boolean.is_nullable());
+    EXPECT_FALSE(cfg.boolean.is_array());
 
-    BOOST_TEST(cfg.seconds.type_name() == "integer");
-    BOOST_TEST(cfg.seconds.units_name() == "s");
-    BOOST_TEST(cfg.seconds.is_nullable() == false);
-    BOOST_TEST(cfg.seconds.is_array() == false);
+    EXPECT_EQ(cfg.seconds.type_name(), "integer");
+    EXPECT_EQ(cfg.seconds.units_name(), "s");
+    EXPECT_FALSE(cfg.seconds.is_nullable());
+    EXPECT_FALSE(cfg.seconds.is_array());
 
-    BOOST_TEST(cfg.optional_seconds.type_name() == "integer");
-    BOOST_TEST(cfg.optional_seconds.units_name() == "s");
-    BOOST_TEST(cfg.optional_seconds.is_nullable() == true);
-    BOOST_TEST(cfg.optional_seconds.is_array() == false);
+    EXPECT_EQ(cfg.optional_seconds.type_name(), "integer");
+    EXPECT_EQ(cfg.optional_seconds.units_name(), "s");
+    EXPECT_TRUE(cfg.optional_seconds.is_nullable());
+    EXPECT_FALSE(cfg.optional_seconds.is_array());
 
-    BOOST_TEST(cfg.milliseconds.type_name() == "integer");
-    BOOST_TEST(cfg.milliseconds.units_name() == "ms");
-    BOOST_TEST(cfg.milliseconds.is_nullable() == false);
-    BOOST_TEST(cfg.milliseconds.is_array() == false);
-};
+    EXPECT_EQ(cfg.milliseconds.type_name(), "integer");
+    EXPECT_EQ(cfg.milliseconds.units_name(), "ms");
+    EXPECT_FALSE(cfg.milliseconds.is_nullable());
+    EXPECT_FALSE(cfg.milliseconds.is_array());
+}
 
-SEASTAR_THREAD_TEST_CASE(property_bind) {
+TEST(ConfigStoreTest, PropertyBind) {
     auto cfg = test_config();
-    BOOST_TEST(cfg.boolean() == false);
+    EXPECT_FALSE(cfg.boolean());
     auto binding = cfg.boolean.bind();
-    BOOST_TEST(binding() == false);
+    EXPECT_FALSE(binding());
     cfg.boolean.set_value(true);
-    BOOST_TEST(cfg.boolean() == true);
-    BOOST_TEST(binding() == true);
+    EXPECT_TRUE(cfg.boolean());
+    EXPECT_TRUE(binding());
 
     int watch_count = 0;
 
-    BOOST_TEST(cfg.required_string() == cfg.required_string.default_value());
+    EXPECT_EQ(cfg.required_string(), cfg.required_string.default_value());
     auto str_binding = cfg.required_string.bind();
-    BOOST_TEST(str_binding() == cfg.required_string.default_value());
+    EXPECT_EQ(str_binding(), cfg.required_string.default_value());
     str_binding.watch([&watch_count]() { ++watch_count; });
 
     cfg.required_string.set_value(ss::sstring("newvalue"));
-    BOOST_TEST(cfg.required_string() == "newvalue");
-    BOOST_TEST(str_binding() == "newvalue");
-    BOOST_TEST(watch_count == 1);
+    EXPECT_EQ(cfg.required_string(), "newvalue");
+    EXPECT_EQ(str_binding(), "newvalue");
+    EXPECT_EQ(watch_count, 1);
 
     // Check that bindings are safe to use after move
     config::binding<ss::sstring> bind2 = std::move(str_binding);
     cfg.required_string.set_value(ss::sstring("newvalue2"));
-    BOOST_TEST(bind2() == "newvalue2");
-    BOOST_TEST(watch_count == 2);
+    EXPECT_EQ(bind2(), "newvalue2");
+    EXPECT_EQ(watch_count, 2);
 
     // Check that bindings are safe to use after copy
     config::binding<ss::sstring> bind3 = bind2;
     cfg.required_string.set_value(ss::sstring("newvalue3"));
-    BOOST_TEST(bind2() == "newvalue3");
-    BOOST_TEST(bind3() == "newvalue3");
-    BOOST_TEST(watch_count == 4);
+    EXPECT_EQ(bind2(), "newvalue3");
+    EXPECT_EQ(bind3(), "newvalue3");
+    EXPECT_EQ(watch_count, 4);
 
     // Check the bindings are bound to the moved-to properties, not to the
     // moved-from ones
@@ -460,31 +445,31 @@ SEASTAR_THREAD_TEST_CASE(property_bind) {
     cfg2.required_string.set_value(ss::sstring("newvalue4"));
     // NOLINTNEXTLINE
     cfg.required_string.set_value(ss::sstring("badvalue"));
-    BOOST_TEST(bind2() == "newvalue4");
-    BOOST_TEST(bind3() == "newvalue4");
-    BOOST_TEST(watch_count == 6);
+    EXPECT_EQ(bind2(), "newvalue4");
+    EXPECT_EQ(bind3(), "newvalue4");
+    EXPECT_EQ(watch_count, 6);
 
     // Check that the bindings are updated when the property is reset to its
     // default value.
     cfg2.required_string.reset();
-    BOOST_TEST(bind2() == "");
-    BOOST_TEST(bind3() == "");
-    BOOST_TEST(watch_count == 8);
+    EXPECT_EQ(bind2(), "");
+    EXPECT_EQ(bind3(), "");
+    EXPECT_EQ(watch_count, 8);
 }
 
-SEASTAR_THREAD_TEST_CASE(property_conversion_bind) {
+TEST(ConfigStoreTest, PropertyConversionBind) {
     auto cfg = test_config();
-    BOOST_TEST(cfg.boolean() == false);
+    EXPECT_FALSE(cfg.boolean());
     auto binding = cfg.boolean.bind<ss::sstring>(
       [](bool v) { return v ? "true" : "false"; });
-    BOOST_TEST(binding() == "false");
+    EXPECT_EQ(binding(), "false");
     cfg.boolean.set_value(true);
-    BOOST_TEST(cfg.boolean() == true);
-    BOOST_TEST(binding() == "true");
+    EXPECT_TRUE(cfg.boolean());
+    EXPECT_EQ(binding(), "true");
 
     int watch_count = 0;
 
-    BOOST_TEST(cfg.required_string() == cfg.required_string.default_value());
+    EXPECT_EQ(cfg.required_string(), cfg.required_string.default_value());
     auto str_binding = cfg.required_string.bind<std::string>(
       [](const ss::sstring& s) {
           return std::string(
@@ -494,23 +479,23 @@ SEASTAR_THREAD_TEST_CASE(property_conversion_bind) {
     str_binding.watch([&watch_count]() { ++watch_count; });
 
     cfg.required_string.set_value(ss::sstring("newvalue"));
-    BOOST_TEST(cfg.required_string() == "newvalue");
-    BOOST_TEST(str_binding() == "eulavwen");
-    BOOST_TEST(watch_count == 1);
+    EXPECT_EQ(cfg.required_string(), "newvalue");
+    EXPECT_EQ(str_binding(), "eulavwen");
+    EXPECT_EQ(watch_count, 1);
 
     // Check that bindings are safe to use after move
     config::conversion_binding<std::string, ss::sstring> bind2 = std::move(
       str_binding);
     cfg.required_string.set_value(ss::sstring("newvalue2"));
-    BOOST_TEST(bind2() == "2eulavwen");
-    BOOST_TEST(watch_count == 2);
+    EXPECT_EQ(bind2(), "2eulavwen");
+    EXPECT_EQ(watch_count, 2);
 
     // Check that bindings are safe to use after copy
     config::conversion_binding<std::string, ss::sstring> bind3 = bind2;
     cfg.required_string.set_value(ss::sstring("newvalue3"));
-    BOOST_TEST(bind2() == "3eulavwen");
-    BOOST_TEST(bind3() == "3eulavwen");
-    BOOST_TEST(watch_count == 4);
+    EXPECT_EQ(bind2(), "3eulavwen");
+    EXPECT_EQ(bind3(), "3eulavwen");
+    EXPECT_EQ(watch_count, 4);
 
     // Check the bindings are bound to the moved-to properties, not to the
     // moved-from ones
@@ -518,12 +503,12 @@ SEASTAR_THREAD_TEST_CASE(property_conversion_bind) {
     cfg2.required_string.set_value(ss::sstring("newvalue4"));
     // NOLINTNEXTLINE
     cfg.required_string.set_value(ss::sstring("badvalue"));
-    BOOST_TEST(bind2() == "4eulavwen");
-    BOOST_TEST(bind3() == "4eulavwen");
-    BOOST_TEST(watch_count == 6);
+    EXPECT_EQ(bind2(), "4eulavwen");
+    EXPECT_EQ(bind3(), "4eulavwen");
+    EXPECT_EQ(watch_count, 6);
 }
 
-SEASTAR_THREAD_TEST_CASE(property_bind_with_multiple_config_stores) {
+TEST(ConfigStoreTest, PropertyBindWithMultipleConfigStores) {
     // check that a copy of a configuration store, created for validating an
     // incoming value, does not propagate the value to the bindings to the
     // original configuration store
@@ -533,17 +518,16 @@ SEASTAR_THREAD_TEST_CASE(property_bind_with_multiple_config_stores) {
     // set a property to a defined value
     constexpr auto boolean_expected_value = false;
     cfg.boolean.set_value(boolean_expected_value);
-    // create a like it's done in the codebase
+    // create a binding like it's done in the codebase
     auto boolean_bind = cfg.boolean.bind();
     boolean_bind.watch([&] {
-        BOOST_TEST_CONTEXT("this watcher should not be called in this test") {
-            BOOST_CHECK_MESSAGE(false, "watcher called");
-            BOOST_CHECK_EQUAL(cfg.boolean.value(), boolean_expected_value);
-        }
+        ADD_FAILURE() << "watcher should not be called in this test";
+        EXPECT_EQ(cfg.boolean.value(), boolean_expected_value);
     });
 
-    BOOST_CHECK(cfg.boolean.value() == boolean_expected_value);
-    BOOST_TEST_CONTEXT("simulating patch_cluster_config") {
+    EXPECT_EQ(cfg.boolean.value(), boolean_expected_value);
+    {
+        SCOPED_TRACE("simulating patch_cluster_config");
         // tmp copy meant to validate an incoming value (see
         // admin/server.cc::patch_cluster_config)
         auto cfg_tmp = test_config();
@@ -553,27 +537,24 @@ SEASTAR_THREAD_TEST_CASE(property_bind_with_multiple_config_stores) {
             tmp_p = p;
         });
 
-        BOOST_CHECK(cfg_tmp.boolean.value() == boolean_expected_value);
+        EXPECT_EQ(cfg_tmp.boolean.value(), boolean_expected_value);
         auto anti_value = YAML::Load(
           fmt::format("{}", !boolean_expected_value));
         auto& boolean_prop = cfg_tmp.get("boolean");
-        BOOST_CHECK_MESSAGE(
-          boolean_prop.validate(anti_value) == std::nullopt,
-          "sanity check: the test should pass validation");
+        EXPECT_EQ(boolean_prop.validate(anti_value), std::nullopt)
+          << "sanity check: the test should pass validation";
 
-        // this is expected not to trigger the booload_bind watcher
+        // this is expected not to trigger the boolean_bind watcher
         boolean_prop.set_value(anti_value);
     }
 }
 
-SEASTAR_THREAD_TEST_CASE(property_aliasing) {
+TEST(ConfigStoreTest, PropertyAliasing) {
     auto cfg = test_config();
 
     // Aliases should work when retrieving a property with get()
-    BOOST_TEST(cfg.get("aliased_bool").name() == "aliased_bool");
-    BOOST_TEST(cfg.get("aliased_bool_legacy").name() == "aliased_bool");
-
-    // Aliases should pass a contains() check
+    EXPECT_EQ(cfg.get("aliased_bool").name(), "aliased_bool");
+    EXPECT_EQ(cfg.get("aliased_bool_legacy").name(), "aliased_bool");
 
     // Aliases should not show up when iterating through properties
     bool seen_primary = false;
@@ -585,43 +566,45 @@ SEASTAR_THREAD_TEST_CASE(property_aliasing) {
             seen_secondary = true;
         }
     });
-    BOOST_TEST(seen_primary == true);
-    BOOST_TEST(seen_secondary == false);
+    EXPECT_TRUE(seen_primary);
+    EXPECT_FALSE(seen_secondary);
 
     // Aliases should not show up when getting the list of all properties
     auto property_names = cfg.property_names();
-    BOOST_TEST(property_names.contains("aliased_bool") == true);
-    BOOST_TEST(property_names.contains("aliased_bool_legacy") == false);
+    EXPECT_TRUE(property_names.contains("aliased_bool"));
+    EXPECT_FALSE(property_names.contains("aliased_bool_legacy"));
 
-    BOOST_TEST(cfg.property_names_and_aliases().contains("aliased_bool"));
+    EXPECT_TRUE(cfg.property_names_and_aliases().contains("aliased_bool"));
 }
 
-SEASTAR_THREAD_TEST_CASE(ignored_keys) {
+TEST(ConfigStoreTest, IgnoredKeys) {
     auto yaml_with_unknown_properties = YAML::Load(R"yaml(
 secret_string: terces
 aliased_bool_legacy: false
     )yaml");
 
-    BOOST_TEST_CONTEXT(
-      "smoke test: check that the properties are valid for test_config") {
+    {
+        SCOPED_TRACE(
+          "smoke test: check that the properties are valid for test_config");
         auto cfg = test_config{};
-        BOOST_CHECK_EQUAL(cfg.secret_string.value(), "");
-        BOOST_CHECK_EQUAL(cfg.aliased_bool.value(), true);
-        BOOST_REQUIRE_NO_THROW(cfg.read_yaml(yaml_with_unknown_properties));
-        BOOST_CHECK_EQUAL(cfg.secret_string.value(), "terces");
-        BOOST_CHECK_EQUAL(cfg.aliased_bool.value(), false);
+        EXPECT_EQ(cfg.secret_string.value(), "");
+        EXPECT_EQ(cfg.aliased_bool.value(), true);
+        EXPECT_NO_THROW(cfg.read_yaml(yaml_with_unknown_properties));
+        EXPECT_EQ(cfg.secret_string.value(), "terces");
+        EXPECT_EQ(cfg.aliased_bool.value(), false);
     }
-    BOOST_TEST_CONTEXT(
-      "if a key is managed by the config, it will be set and "
-      "the ignored_missing list does not matter") {
+    {
+        SCOPED_TRACE(
+          "if a key is managed by the config, it will be set and "
+          "the ignored_missing list does not matter");
         auto cfg = test_config{};
-        BOOST_REQUIRE_NO_THROW(cfg.read_yaml(yaml_with_unknown_properties));
-        BOOST_CHECK_EQUAL(cfg.secret_string.value(), "terces");
-        BOOST_CHECK_EQUAL(cfg.aliased_bool.value(), false);
+        EXPECT_NO_THROW(cfg.read_yaml(yaml_with_unknown_properties));
+        EXPECT_EQ(cfg.secret_string.value(), "terces");
+        EXPECT_EQ(cfg.aliased_bool.value(), false);
     }
-    BOOST_TEST_CONTEXT("an unknown key will not generate an exception") {
+    {
+        SCOPED_TRACE("an unknown key will not generate an exception");
         auto noop_cfg = noop_config{};
-        BOOST_REQUIRE_NO_THROW(
-          noop_cfg.read_yaml(yaml_with_unknown_properties));
+        EXPECT_NO_THROW(noop_cfg.read_yaml(yaml_with_unknown_properties));
     }
 }

--- a/src/v/config/tests/config_store_test.cc
+++ b/src/v/config/tests/config_store_test.cc
@@ -844,3 +844,142 @@ TEST(ConfigStoreTest, PromotePendingForEachProperty) {
     EXPECT_EQ(cfg.an_int64_t(), 999);
     EXPECT_FALSE(cfg.an_int64_t.has_pending());
 }
+
+TEST(ConfigStoreTest, ToJsonWithPendingValues) {
+    auto cfg = test_config();
+    auto errors = cfg.read_yaml(minimal_valid_configuration());
+    EXPECT_EQ(errors.size(), 0);
+
+    // optional_int has needs_restart::yes (default metadata), default=100
+    cfg.optional_int.set_pending_value(YAML::Load("42"));
+    EXPECT_TRUE(cfg.optional_int.has_pending());
+    EXPECT_EQ(cfg.optional_int(), 100);
+
+    // Default (use_pending::yes): serializes pending value
+    {
+        json::StringBuffer buf;
+        json::Writer<json::StringBuffer> w(buf);
+        cfg.to_json(w, config::redact_secrets::no);
+        json::Document doc;
+        doc.Parse(buf.GetString());
+        EXPECT_EQ(doc["optional_int"].GetInt(), 42);
+    }
+
+    // Explicit use_pending::no: serializes active value
+    {
+        json::StringBuffer buf;
+        json::Writer<json::StringBuffer> w(buf);
+        cfg.to_json(
+          w, config::redact_secrets::no, std::nullopt, config::use_pending::no);
+        json::Document doc;
+        doc.Parse(buf.GetString());
+        EXPECT_EQ(doc["optional_int"].GetInt(), 100);
+    }
+}
+
+TEST(ConfigStoreTest, ToJsonSecretWithPendingValues) {
+    auto cfg = test_config();
+    auto errors = cfg.read_yaml(minimal_valid_configuration());
+    EXPECT_EQ(errors.size(), 0);
+
+    // secret_string: secret, needs_restart::yes, default=""
+    // Active is default (empty), so not redacted even with redact=yes.
+    // Set a pending non-default value: should be redacted when pending=yes.
+    cfg.secret_string.set_pending_value(YAML::Load("hunter2"));
+    EXPECT_TRUE(cfg.secret_string.has_pending());
+
+    // Default (use_pending::yes) + redact: pending is non-default → redacted
+    {
+        json::StringBuffer buf;
+        json::Writer<json::StringBuffer> w(buf);
+        cfg.to_json_single_key(w, config::redact_secrets::yes, "secret_string");
+        json::Document doc;
+        doc.Parse(buf.GetString());
+        EXPECT_STREQ(doc["secret_string"].GetString(), "[secret]");
+    }
+
+    // Default (use_pending::yes) + no redact: pending value shown in the clear
+    {
+        json::StringBuffer buf;
+        json::Writer<json::StringBuffer> w(buf);
+        cfg.to_json_single_key(w, config::redact_secrets::no, "secret_string");
+        json::Document doc;
+        doc.Parse(buf.GetString());
+        EXPECT_STREQ(doc["secret_string"].GetString(), "hunter2");
+    }
+
+    // Explicit use_pending::no + redact: active is default → not redacted
+    {
+        json::StringBuffer buf;
+        json::Writer<json::StringBuffer> w(buf);
+        cfg.to_json_single_key(
+          w,
+          config::redact_secrets::yes,
+          "secret_string",
+          config::use_pending::no);
+        json::Document doc;
+        doc.Parse(buf.GetString());
+        EXPECT_STREQ(doc["secret_string"].GetString(), "");
+    }
+
+    // Now set active to non-default, and pending back to default (reset).
+    // This simulates: secret was set, user resets it, awaiting restart.
+    cfg.secret_string.set_value(YAML::Load("hunter2"));
+    cfg.secret_string.set_pending_value_to_default();
+
+    // Default (use_pending::yes) + redact: pending is default → not redacted
+    {
+        json::StringBuffer buf;
+        json::Writer<json::StringBuffer> w(buf);
+        cfg.to_json_single_key(w, config::redact_secrets::yes, "secret_string");
+        json::Document doc;
+        doc.Parse(buf.GetString());
+        EXPECT_STREQ(doc["secret_string"].GetString(), "");
+    }
+
+    // Explicit use_pending::no + redact: active is non-default → redacted
+    {
+        json::StringBuffer buf;
+        json::Writer<json::StringBuffer> w(buf);
+        cfg.to_json_single_key(
+          w,
+          config::redact_secrets::yes,
+          "secret_string",
+          config::use_pending::no);
+        json::Document doc;
+        doc.Parse(buf.GetString());
+        EXPECT_STREQ(doc["secret_string"].GetString(), "[secret]");
+    }
+}
+
+TEST(ConfigStoreTest, ToJsonSingleKeyWithPendingValues) {
+    auto cfg = test_config();
+    auto errors = cfg.read_yaml(minimal_valid_configuration());
+    EXPECT_EQ(errors.size(), 0);
+
+    cfg.optional_int.set_pending_value(YAML::Load("42"));
+
+    // Default (use_pending::yes): serializes pending value
+    {
+        json::StringBuffer buf;
+        json::Writer<json::StringBuffer> w(buf);
+        cfg.to_json_single_key(w, config::redact_secrets::no, "optional_int");
+        json::Document doc;
+        doc.Parse(buf.GetString());
+        EXPECT_EQ(doc["optional_int"].GetInt(), 42);
+    }
+
+    // Explicit use_pending::no: serializes active value
+    {
+        json::StringBuffer buf;
+        json::Writer<json::StringBuffer> w(buf);
+        cfg.to_json_single_key(
+          w,
+          config::redact_secrets::no,
+          "optional_int",
+          config::use_pending::no);
+        json::Document doc;
+        doc.Parse(buf.GetString());
+        EXPECT_EQ(doc["optional_int"].GetInt(), 100);
+    }
+}

--- a/src/v/config/tests/config_store_test.cc
+++ b/src/v/config/tests/config_store_test.cc
@@ -13,9 +13,9 @@
 #include "json/writer.h"
 
 #include <seastar/core/sstring.hh>
-#include <seastar/core/thread.hh>
-#include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/log.hh>
+
+#include <gtest/gtest.h>
 
 #include <cstdint>
 #include <iostream>
@@ -189,88 +189,87 @@ struct convert<testing::custom_aggregate> {
 };
 } // namespace YAML
 
-SEASTAR_THREAD_TEST_CASE(read_minimal_valid_configuration) {
+TEST(ConfigStoreTest, ReadMinimalValidConfiguration) {
     auto cfg = test_config();
     auto errors = cfg.read_yaml(minimal_valid_configuration());
-    BOOST_TEST(errors.size() == 0);
+    EXPECT_EQ(errors.size(), 0);
 
-    BOOST_TEST(cfg.optional_int() == 100);
-    BOOST_TEST(cfg.required_string() == "test_value_1");
-    BOOST_TEST(cfg.an_int64_t() == 200);
-    BOOST_TEST(cfg.an_aggregate().string_value == "str");
-    BOOST_TEST(cfg.an_aggregate().int_value == 10);
-    BOOST_TEST(cfg.strings().at(0) == "first");
-    BOOST_TEST(cfg.strings().at(1) == "second");
-    BOOST_TEST(cfg.strings().at(2) == "third");
-    BOOST_TEST(cfg.nullable_int() == std::nullopt);
-};
+    EXPECT_EQ(cfg.optional_int(), 100);
+    EXPECT_EQ(cfg.required_string(), "test_value_1");
+    EXPECT_EQ(cfg.an_int64_t(), 200);
+    EXPECT_EQ(cfg.an_aggregate().string_value, "str");
+    EXPECT_EQ(cfg.an_aggregate().int_value, 10);
+    EXPECT_EQ(cfg.strings().at(0), "first");
+    EXPECT_EQ(cfg.strings().at(1), "second");
+    EXPECT_EQ(cfg.strings().at(2), "third");
+    EXPECT_EQ(cfg.nullable_int(), std::nullopt);
+}
 
-SEASTAR_THREAD_TEST_CASE(read_valid_configuration) {
+TEST(ConfigStoreTest, ReadValidConfiguration) {
     auto cfg = test_config();
     auto errors = cfg.read_yaml(valid_configuration());
-    BOOST_TEST(errors.size() == 0);
+    EXPECT_EQ(errors.size(), 0);
 
-    BOOST_TEST(cfg.optional_int() == 3);
-    BOOST_TEST(cfg.required_string() == "test_value_2");
-    BOOST_TEST(cfg.an_int64_t() == 55);
-    BOOST_TEST(cfg.an_aggregate().string_value == "some_value");
-    BOOST_TEST(cfg.an_aggregate().int_value == 88);
-    BOOST_TEST(cfg.strings().at(0) == "one");
-    BOOST_TEST(cfg.strings().at(1) == "two");
-    BOOST_TEST(cfg.strings().at(2) == "three");
-    BOOST_TEST(cfg.nullable_int() == std::make_optional(111));
-    BOOST_TEST(cfg.secret_string() == "actual_secret");
-    BOOST_TEST(cfg.aliased_bool() == false);
-};
+    EXPECT_EQ(cfg.optional_int(), 3);
+    EXPECT_EQ(cfg.required_string(), "test_value_2");
+    EXPECT_EQ(cfg.an_int64_t(), 55);
+    EXPECT_EQ(cfg.an_aggregate().string_value, "some_value");
+    EXPECT_EQ(cfg.an_aggregate().int_value, 88);
+    EXPECT_EQ(cfg.strings().at(0), "one");
+    EXPECT_EQ(cfg.strings().at(1), "two");
+    EXPECT_EQ(cfg.strings().at(2), "three");
+    EXPECT_EQ(cfg.nullable_int(), std::make_optional(111));
+    EXPECT_EQ(cfg.secret_string(), "actual_secret");
+    EXPECT_EQ(cfg.aliased_bool(), false);
+}
 
-SEASTAR_THREAD_TEST_CASE(update_property_value) {
+TEST(ConfigStoreTest, UpdatePropertyValue) {
     auto cfg = test_config();
     auto errors = cfg.read_yaml(minimal_valid_configuration());
-    BOOST_TEST(errors.size() == 0);
+    EXPECT_EQ(errors.size(), 0);
 
-    BOOST_TEST(cfg.required_string() == "test_value_1");
+    EXPECT_EQ(cfg.required_string(), "test_value_1");
     cfg.get("required_string").set_value(ss::sstring("new_string_value"));
-    BOOST_TEST(cfg.required_string() == "new_string_value");
-};
+    EXPECT_EQ(cfg.required_string(), "new_string_value");
+}
 
-SEASTAR_THREAD_TEST_CASE(track_set_state) {
+TEST(ConfigStoreTest, TrackSetState) {
     auto cfg = test_config();
 
-    BOOST_TEST(cfg.optional_int() == 100);
-    BOOST_TEST(cfg.optional_int.is_default() == true);
-    BOOST_TEST(cfg.optional_int.is_set() == false);
+    EXPECT_EQ(cfg.optional_int(), 100);
+    EXPECT_TRUE(cfg.optional_int.is_default());
+    EXPECT_FALSE(cfg.optional_int.is_set());
 
     // set to default value
     cfg.get("required_string").set_value(ss::sstring{});
-    BOOST_TEST(cfg.required_string.is_default() == true);
-    BOOST_TEST(cfg.required_string.is_set() == true);
+    EXPECT_TRUE(cfg.required_string.is_default());
+    EXPECT_TRUE(cfg.required_string.is_set());
 
     // set to non-default value
     cfg.get("an_int64_t").set_value(int64_t{100});
-    BOOST_TEST(cfg.an_int64_t.is_default() == false);
-    BOOST_TEST(cfg.an_int64_t.is_set() == true);
-};
-
-SEASTAR_THREAD_TEST_CASE(validate_valid_configuration) {
-    auto cfg = test_config();
-    auto errors = cfg.read_yaml(valid_configuration());
-    BOOST_TEST(errors.size() == 0);
+    EXPECT_FALSE(cfg.an_int64_t.is_default());
+    EXPECT_TRUE(cfg.an_int64_t.is_set());
 }
 
-SEASTAR_THREAD_TEST_CASE(validate_invalid_configuration) {
+TEST(ConfigStoreTest, ValidateValidConfiguration) {
     auto cfg = test_config();
     auto errors = cfg.read_yaml(valid_configuration());
-    BOOST_TEST(errors.size() == 0);
+    EXPECT_EQ(errors.size(), 0);
 }
 
-SEASTAR_THREAD_TEST_CASE(config_json_serialization) {
+TEST(ConfigStoreTest, ValidateAnotherValidConfiguration) {
+    auto cfg = test_config();
+    auto errors = cfg.read_yaml(valid_configuration());
+    EXPECT_EQ(errors.size(), 0);
+}
+
+TEST(ConfigStoreTest, ConfigJsonSerialization) {
     const auto test_with_redaction = [](config::redact_secrets redact) {
         auto cfg = test_config();
         auto errors = cfg.read_yaml(valid_configuration());
-        BOOST_TEST(errors.size() == 0);
+        EXPECT_EQ(errors.size(), 0);
         lg.info("Config: {}", cfg);
         // json data
-        // TODO: get this to work with fmt.
         auto expected_result = redact == config::redact_secrets::yes
                                  ? "{"
                                    "\"strings\": [\"one\", \"two\", \"three\"],"
@@ -314,47 +313,45 @@ SEASTAR_THREAD_TEST_CASE(config_json_serialization) {
         exp_doc.Parse(expected_result);
 
         // test equivalence
-        BOOST_TEST(res_doc["required_string"].IsString());
-        BOOST_TEST(
-          res_doc["required_string"].GetString()
-          == exp_doc["required_string"].GetString());
+        EXPECT_TRUE(res_doc["required_string"].IsString());
+        EXPECT_STREQ(
+          res_doc["required_string"].GetString(),
+          exp_doc["required_string"].GetString());
 
-        BOOST_TEST(res_doc["optional_int"].IsInt());
-        BOOST_TEST(
-          res_doc["optional_int"].GetInt() == exp_doc["optional_int"].GetInt());
+        EXPECT_TRUE(res_doc["optional_int"].IsInt());
+        EXPECT_EQ(
+          res_doc["optional_int"].GetInt(), exp_doc["optional_int"].GetInt());
 
-        BOOST_TEST(res_doc["an_int64_t"].IsInt64());
-        BOOST_TEST(
-          res_doc["an_int64_t"].GetInt64() == exp_doc["an_int64_t"].GetInt64());
+        EXPECT_TRUE(res_doc["an_int64_t"].IsInt64());
+        EXPECT_EQ(
+          res_doc["an_int64_t"].GetInt64(), exp_doc["an_int64_t"].GetInt64());
 
-        BOOST_TEST(res_doc["an_aggregate"].IsObject());
+        EXPECT_TRUE(res_doc["an_aggregate"].IsObject());
 
-        BOOST_TEST(res_doc["an_aggregate"]["int_value"].IsInt());
-        BOOST_TEST(
-          res_doc["an_aggregate"]["int_value"].GetInt()
-          == exp_doc["an_aggregate"]["int_value"].GetInt());
+        EXPECT_TRUE(res_doc["an_aggregate"]["int_value"].IsInt());
+        EXPECT_EQ(
+          res_doc["an_aggregate"]["int_value"].GetInt(),
+          exp_doc["an_aggregate"]["int_value"].GetInt());
 
-        BOOST_TEST(res_doc["an_aggregate"]["string_value"].IsString());
-        BOOST_TEST(
-          res_doc["an_aggregate"]["string_value"].GetString()
-          == exp_doc["an_aggregate"]["string_value"].GetString());
+        EXPECT_TRUE(res_doc["an_aggregate"]["string_value"].IsString());
+        EXPECT_STREQ(
+          res_doc["an_aggregate"]["string_value"].GetString(),
+          exp_doc["an_aggregate"]["string_value"].GetString());
 
-        BOOST_TEST(res_doc["strings"].IsArray());
+        EXPECT_TRUE(res_doc["strings"].IsArray());
 
-        BOOST_TEST(res_doc["nullable_int"].IsInt());
-        BOOST_TEST(
-          res_doc["nullable_int"].GetInt() == exp_doc["nullable_int"].GetInt());
-        BOOST_TEST(
-          res_doc["secret_string"].GetString()
-          == exp_doc["secret_string"].GetString());
+        EXPECT_TRUE(res_doc["nullable_int"].IsInt());
+        EXPECT_EQ(
+          res_doc["nullable_int"].GetInt(), exp_doc["nullable_int"].GetInt());
+        EXPECT_STREQ(
+          res_doc["secret_string"].GetString(),
+          exp_doc["secret_string"].GetString());
     };
     test_with_redaction(config::redact_secrets::yes);
     test_with_redaction(config::redact_secrets::no);
 }
 
-/// Test that unset std::optional options are decoded correctly
-/// when given as 'null', not just when absent.
-SEASTAR_THREAD_TEST_CASE(deserialize_explicit_null) {
+TEST(ConfigStoreTest, DeserializeExplicitNull) {
     auto with_null = YAML::Load(
       "required_string: test_value_1\n"
       "strings:\n"
@@ -365,103 +362,103 @@ SEASTAR_THREAD_TEST_CASE(deserialize_explicit_null) {
 
     auto cfg = test_config();
     auto errors = cfg.read_yaml(with_null);
-    BOOST_TEST(errors.size() == 0);
-    BOOST_TEST(cfg.nullable_int() == std::nullopt);
+    EXPECT_EQ(errors.size(), 0);
+    EXPECT_EQ(cfg.nullable_int(), std::nullopt);
 }
 
-SEASTAR_THREAD_TEST_CASE(property_metadata) {
+TEST(ConfigStoreTest, PropertyMetadata) {
     auto cfg = test_config();
-    BOOST_TEST(cfg.optional_int.type_name() == "integer");
-    BOOST_TEST(
-      config::to_string_view(cfg.optional_int.get_visibility()) == "tunable");
+    EXPECT_EQ(cfg.optional_int.type_name(), "integer");
+    EXPECT_EQ(
+      config::to_string_view(cfg.optional_int.get_visibility()), "tunable");
 
-    BOOST_TEST(cfg.boolean.is_nullable() == false);
-    BOOST_TEST(cfg.nullable_string.is_array() == false);
+    EXPECT_FALSE(cfg.boolean.is_nullable());
+    EXPECT_FALSE(cfg.nullable_string.is_array());
 
-    BOOST_TEST(cfg.required_string.type_name() == "string");
-    BOOST_TEST(cfg.required_string.is_array() == false);
-    BOOST_TEST(
-      config::to_string_view(cfg.required_string.get_visibility()) == "user");
+    EXPECT_EQ(cfg.required_string.type_name(), "string");
+    EXPECT_FALSE(cfg.required_string.is_array());
+    EXPECT_EQ(
+      config::to_string_view(cfg.required_string.get_visibility()), "user");
 
-    BOOST_TEST(cfg.boolean.is_nullable() == false);
+    EXPECT_FALSE(cfg.boolean.is_nullable());
 
-    BOOST_TEST(cfg.an_int64_t.type_name() == "integer");
-    BOOST_TEST(cfg.boolean.is_nullable() == false);
-    BOOST_TEST(cfg.nullable_string.is_array() == false);
+    EXPECT_EQ(cfg.an_int64_t.type_name(), "integer");
+    EXPECT_FALSE(cfg.boolean.is_nullable());
+    EXPECT_FALSE(cfg.nullable_string.is_array());
 
-    BOOST_TEST(cfg.an_aggregate.type_name() == "custom_aggregate");
-    BOOST_TEST(cfg.boolean.is_nullable() == false);
-    BOOST_TEST(cfg.nullable_string.is_array() == false);
+    EXPECT_EQ(cfg.an_aggregate.type_name(), "custom_aggregate");
+    EXPECT_FALSE(cfg.boolean.is_nullable());
+    EXPECT_FALSE(cfg.nullable_string.is_array());
 
-    BOOST_TEST(cfg.strings.type_name() == "string");
-    BOOST_TEST(cfg.strings.is_array() == true);
-    BOOST_TEST(cfg.strings.is_nullable() == false);
+    EXPECT_EQ(cfg.strings.type_name(), "string");
+    EXPECT_TRUE(cfg.strings.is_array());
+    EXPECT_FALSE(cfg.strings.is_nullable());
 
-    BOOST_TEST(cfg.nullable_string.type_name() == "string");
-    BOOST_TEST(cfg.nullable_string.is_nullable() == true);
-    BOOST_TEST(cfg.nullable_string.is_array() == false);
+    EXPECT_EQ(cfg.nullable_string.type_name(), "string");
+    EXPECT_TRUE(cfg.nullable_string.is_nullable());
+    EXPECT_FALSE(cfg.nullable_string.is_array());
 
-    BOOST_TEST(cfg.nullable_strings.type_name() == "string");
-    BOOST_TEST(cfg.nullable_strings.is_nullable() == true);
-    BOOST_TEST(cfg.nullable_strings.is_array() == true);
+    EXPECT_EQ(cfg.nullable_strings.type_name(), "string");
+    EXPECT_TRUE(cfg.nullable_strings.is_nullable());
+    EXPECT_TRUE(cfg.nullable_strings.is_array());
 
-    BOOST_TEST(cfg.nullable_int.type_name() == "integer");
-    BOOST_TEST(cfg.nullable_int.is_nullable() == true);
-    BOOST_TEST(cfg.nullable_int.is_array() == false);
+    EXPECT_EQ(cfg.nullable_int.type_name(), "integer");
+    EXPECT_TRUE(cfg.nullable_int.is_nullable());
+    EXPECT_FALSE(cfg.nullable_int.is_array());
 
-    BOOST_TEST(cfg.boolean.type_name() == "boolean");
-    BOOST_TEST(cfg.boolean.is_nullable() == false);
-    BOOST_TEST(cfg.boolean.is_array() == false);
+    EXPECT_EQ(cfg.boolean.type_name(), "boolean");
+    EXPECT_FALSE(cfg.boolean.is_nullable());
+    EXPECT_FALSE(cfg.boolean.is_array());
 
-    BOOST_TEST(cfg.seconds.type_name() == "integer");
-    BOOST_TEST(cfg.seconds.units_name() == "s");
-    BOOST_TEST(cfg.seconds.is_nullable() == false);
-    BOOST_TEST(cfg.seconds.is_array() == false);
+    EXPECT_EQ(cfg.seconds.type_name(), "integer");
+    EXPECT_EQ(cfg.seconds.units_name(), "s");
+    EXPECT_FALSE(cfg.seconds.is_nullable());
+    EXPECT_FALSE(cfg.seconds.is_array());
 
-    BOOST_TEST(cfg.optional_seconds.type_name() == "integer");
-    BOOST_TEST(cfg.optional_seconds.units_name() == "s");
-    BOOST_TEST(cfg.optional_seconds.is_nullable() == true);
-    BOOST_TEST(cfg.optional_seconds.is_array() == false);
+    EXPECT_EQ(cfg.optional_seconds.type_name(), "integer");
+    EXPECT_EQ(cfg.optional_seconds.units_name(), "s");
+    EXPECT_TRUE(cfg.optional_seconds.is_nullable());
+    EXPECT_FALSE(cfg.optional_seconds.is_array());
 
-    BOOST_TEST(cfg.milliseconds.type_name() == "integer");
-    BOOST_TEST(cfg.milliseconds.units_name() == "ms");
-    BOOST_TEST(cfg.milliseconds.is_nullable() == false);
-    BOOST_TEST(cfg.milliseconds.is_array() == false);
-};
+    EXPECT_EQ(cfg.milliseconds.type_name(), "integer");
+    EXPECT_EQ(cfg.milliseconds.units_name(), "ms");
+    EXPECT_FALSE(cfg.milliseconds.is_nullable());
+    EXPECT_FALSE(cfg.milliseconds.is_array());
+}
 
-SEASTAR_THREAD_TEST_CASE(property_bind) {
+TEST(ConfigStoreTest, PropertyBind) {
     auto cfg = test_config();
-    BOOST_TEST(cfg.boolean() == false);
+    EXPECT_FALSE(cfg.boolean());
     auto binding = cfg.boolean.bind();
-    BOOST_TEST(binding() == false);
+    EXPECT_FALSE(binding());
     cfg.boolean.set_value(true);
-    BOOST_TEST(cfg.boolean() == true);
-    BOOST_TEST(binding() == true);
+    EXPECT_TRUE(cfg.boolean());
+    EXPECT_TRUE(binding());
 
     int watch_count = 0;
 
-    BOOST_TEST(cfg.required_string() == cfg.required_string.default_value());
+    EXPECT_EQ(cfg.required_string(), cfg.required_string.default_value());
     auto str_binding = cfg.required_string.bind();
-    BOOST_TEST(str_binding() == cfg.required_string.default_value());
+    EXPECT_EQ(str_binding(), cfg.required_string.default_value());
     str_binding.watch([&watch_count]() { ++watch_count; });
 
     cfg.required_string.set_value(ss::sstring("newvalue"));
-    BOOST_TEST(cfg.required_string() == "newvalue");
-    BOOST_TEST(str_binding() == "newvalue");
-    BOOST_TEST(watch_count == 1);
+    EXPECT_EQ(cfg.required_string(), "newvalue");
+    EXPECT_EQ(str_binding(), "newvalue");
+    EXPECT_EQ(watch_count, 1);
 
     // Check that bindings are safe to use after move
     config::binding<ss::sstring> bind2 = std::move(str_binding);
     cfg.required_string.set_value(ss::sstring("newvalue2"));
-    BOOST_TEST(bind2() == "newvalue2");
-    BOOST_TEST(watch_count == 2);
+    EXPECT_EQ(bind2(), "newvalue2");
+    EXPECT_EQ(watch_count, 2);
 
     // Check that bindings are safe to use after copy
     config::binding<ss::sstring> bind3 = bind2;
     cfg.required_string.set_value(ss::sstring("newvalue3"));
-    BOOST_TEST(bind2() == "newvalue3");
-    BOOST_TEST(bind3() == "newvalue3");
-    BOOST_TEST(watch_count == 4);
+    EXPECT_EQ(bind2(), "newvalue3");
+    EXPECT_EQ(bind3(), "newvalue3");
+    EXPECT_EQ(watch_count, 4);
 
     // Check the bindings are bound to the moved-to properties, not to the
     // moved-from ones
@@ -469,31 +466,31 @@ SEASTAR_THREAD_TEST_CASE(property_bind) {
     cfg2.required_string.set_value(ss::sstring("newvalue4"));
     // NOLINTNEXTLINE
     cfg.required_string.set_value(ss::sstring("badvalue"));
-    BOOST_TEST(bind2() == "newvalue4");
-    BOOST_TEST(bind3() == "newvalue4");
-    BOOST_TEST(watch_count == 6);
+    EXPECT_EQ(bind2(), "newvalue4");
+    EXPECT_EQ(bind3(), "newvalue4");
+    EXPECT_EQ(watch_count, 6);
 
     // Check that the bindings are updated when the property is reset to its
     // default value.
     cfg2.required_string.reset();
-    BOOST_TEST(bind2() == "");
-    BOOST_TEST(bind3() == "");
-    BOOST_TEST(watch_count == 8);
+    EXPECT_EQ(bind2(), "");
+    EXPECT_EQ(bind3(), "");
+    EXPECT_EQ(watch_count, 8);
 }
 
-SEASTAR_THREAD_TEST_CASE(property_conversion_bind) {
+TEST(ConfigStoreTest, PropertyConversionBind) {
     auto cfg = test_config();
-    BOOST_TEST(cfg.boolean() == false);
+    EXPECT_FALSE(cfg.boolean());
     auto binding = cfg.boolean.bind<ss::sstring>(
       [](bool v) { return v ? "true" : "false"; });
-    BOOST_TEST(binding() == "false");
+    EXPECT_EQ(binding(), "false");
     cfg.boolean.set_value(true);
-    BOOST_TEST(cfg.boolean() == true);
-    BOOST_TEST(binding() == "true");
+    EXPECT_TRUE(cfg.boolean());
+    EXPECT_EQ(binding(), "true");
 
     int watch_count = 0;
 
-    BOOST_TEST(cfg.required_string() == cfg.required_string.default_value());
+    EXPECT_EQ(cfg.required_string(), cfg.required_string.default_value());
     auto str_binding = cfg.required_string.bind<std::string>(
       [](const ss::sstring& s) {
           return std::string(
@@ -503,23 +500,23 @@ SEASTAR_THREAD_TEST_CASE(property_conversion_bind) {
     str_binding.watch([&watch_count]() { ++watch_count; });
 
     cfg.required_string.set_value(ss::sstring("newvalue"));
-    BOOST_TEST(cfg.required_string() == "newvalue");
-    BOOST_TEST(str_binding() == "eulavwen");
-    BOOST_TEST(watch_count == 1);
+    EXPECT_EQ(cfg.required_string(), "newvalue");
+    EXPECT_EQ(str_binding(), "eulavwen");
+    EXPECT_EQ(watch_count, 1);
 
     // Check that bindings are safe to use after move
     config::conversion_binding<std::string, ss::sstring> bind2 = std::move(
       str_binding);
     cfg.required_string.set_value(ss::sstring("newvalue2"));
-    BOOST_TEST(bind2() == "2eulavwen");
-    BOOST_TEST(watch_count == 2);
+    EXPECT_EQ(bind2(), "2eulavwen");
+    EXPECT_EQ(watch_count, 2);
 
     // Check that bindings are safe to use after copy
     config::conversion_binding<std::string, ss::sstring> bind3 = bind2;
     cfg.required_string.set_value(ss::sstring("newvalue3"));
-    BOOST_TEST(bind2() == "3eulavwen");
-    BOOST_TEST(bind3() == "3eulavwen");
-    BOOST_TEST(watch_count == 4);
+    EXPECT_EQ(bind2(), "3eulavwen");
+    EXPECT_EQ(bind3(), "3eulavwen");
+    EXPECT_EQ(watch_count, 4);
 
     // Check the bindings are bound to the moved-to properties, not to the
     // moved-from ones
@@ -527,12 +524,12 @@ SEASTAR_THREAD_TEST_CASE(property_conversion_bind) {
     cfg2.required_string.set_value(ss::sstring("newvalue4"));
     // NOLINTNEXTLINE
     cfg.required_string.set_value(ss::sstring("badvalue"));
-    BOOST_TEST(bind2() == "4eulavwen");
-    BOOST_TEST(bind3() == "4eulavwen");
-    BOOST_TEST(watch_count == 6);
+    EXPECT_EQ(bind2(), "4eulavwen");
+    EXPECT_EQ(bind3(), "4eulavwen");
+    EXPECT_EQ(watch_count, 6);
 }
 
-SEASTAR_THREAD_TEST_CASE(property_bind_with_multiple_config_stores) {
+TEST(ConfigStoreTest, PropertyBindWithMultipleConfigStores) {
     // check that a copy of a configuration store, created for validating an
     // incoming value, does not propagate the value to the bindings to the
     // original configuration store
@@ -542,17 +539,16 @@ SEASTAR_THREAD_TEST_CASE(property_bind_with_multiple_config_stores) {
     // set a property to a defined value
     constexpr auto boolean_expected_value = false;
     cfg.boolean.set_value(boolean_expected_value);
-    // create a like it's done in the codebase
+    // create a binding like it's done in the codebase
     auto boolean_bind = cfg.boolean.bind();
     boolean_bind.watch([&] {
-        BOOST_TEST_CONTEXT("this watcher should not be called in this test") {
-            BOOST_CHECK_MESSAGE(false, "watcher called");
-            BOOST_CHECK_EQUAL(cfg.boolean.value(), boolean_expected_value);
-        }
+        ADD_FAILURE() << "watcher should not be called in this test";
+        EXPECT_EQ(cfg.boolean.value(), boolean_expected_value);
     });
 
-    BOOST_CHECK(cfg.boolean.value() == boolean_expected_value);
-    BOOST_TEST_CONTEXT("simulating patch_cluster_config") {
+    EXPECT_EQ(cfg.boolean.value(), boolean_expected_value);
+    {
+        SCOPED_TRACE("simulating patch_cluster_config");
         // tmp copy meant to validate an incoming value (see
         // admin/server.cc::patch_cluster_config)
         auto cfg_tmp = test_config();
@@ -562,27 +558,24 @@ SEASTAR_THREAD_TEST_CASE(property_bind_with_multiple_config_stores) {
             tmp_p = p;
         });
 
-        BOOST_CHECK(cfg_tmp.boolean.value() == boolean_expected_value);
+        EXPECT_EQ(cfg_tmp.boolean.value(), boolean_expected_value);
         auto anti_value = YAML::Load(
           fmt::format("{}", !boolean_expected_value));
         auto& boolean_prop = cfg_tmp.get("boolean");
-        BOOST_CHECK_MESSAGE(
-          boolean_prop.validate(anti_value) == std::nullopt,
-          "sanity check: the test should pass validation");
+        EXPECT_EQ(boolean_prop.validate(anti_value), std::nullopt)
+          << "sanity check: the test should pass validation";
 
-        // this is expected not to trigger the booload_bind watcher
+        // this is expected not to trigger the boolean_bind watcher
         boolean_prop.set_value(anti_value);
     }
 }
 
-SEASTAR_THREAD_TEST_CASE(property_aliasing) {
+TEST(ConfigStoreTest, PropertyAliasing) {
     auto cfg = test_config();
 
     // Aliases should work when retrieving a property with get()
-    BOOST_TEST(cfg.get("aliased_bool").name() == "aliased_bool");
-    BOOST_TEST(cfg.get("aliased_bool_legacy").name() == "aliased_bool");
-
-    // Aliases should pass a contains() check
+    EXPECT_EQ(cfg.get("aliased_bool").name(), "aliased_bool");
+    EXPECT_EQ(cfg.get("aliased_bool_legacy").name(), "aliased_bool");
 
     // Aliases should not show up when iterating through properties
     bool seen_primary = false;
@@ -594,43 +587,45 @@ SEASTAR_THREAD_TEST_CASE(property_aliasing) {
             seen_secondary = true;
         }
     });
-    BOOST_TEST(seen_primary == true);
-    BOOST_TEST(seen_secondary == false);
+    EXPECT_TRUE(seen_primary);
+    EXPECT_FALSE(seen_secondary);
 
     // Aliases should not show up when getting the list of all properties
     auto property_names = cfg.property_names();
-    BOOST_TEST(property_names.contains("aliased_bool") == true);
-    BOOST_TEST(property_names.contains("aliased_bool_legacy") == false);
+    EXPECT_TRUE(property_names.contains("aliased_bool"));
+    EXPECT_FALSE(property_names.contains("aliased_bool_legacy"));
 
-    BOOST_TEST(cfg.property_names_and_aliases().contains("aliased_bool"));
+    EXPECT_TRUE(cfg.property_names_and_aliases().contains("aliased_bool"));
 }
 
-SEASTAR_THREAD_TEST_CASE(ignored_keys) {
+TEST(ConfigStoreTest, IgnoredKeys) {
     auto yaml_with_unknown_properties = YAML::Load(R"yaml(
 secret_string: terces
 aliased_bool_legacy: false
     )yaml");
 
-    BOOST_TEST_CONTEXT(
-      "smoke test: check that the properties are valid for test_config") {
+    {
+        SCOPED_TRACE(
+          "smoke test: check that the properties are valid for test_config");
         auto cfg = test_config{};
-        BOOST_CHECK_EQUAL(cfg.secret_string.value(), "");
-        BOOST_CHECK_EQUAL(cfg.aliased_bool.value(), true);
-        BOOST_REQUIRE_NO_THROW(cfg.read_yaml(yaml_with_unknown_properties));
-        BOOST_CHECK_EQUAL(cfg.secret_string.value(), "terces");
-        BOOST_CHECK_EQUAL(cfg.aliased_bool.value(), false);
+        EXPECT_EQ(cfg.secret_string.value(), "");
+        EXPECT_EQ(cfg.aliased_bool.value(), true);
+        EXPECT_NO_THROW(cfg.read_yaml(yaml_with_unknown_properties));
+        EXPECT_EQ(cfg.secret_string.value(), "terces");
+        EXPECT_EQ(cfg.aliased_bool.value(), false);
     }
-    BOOST_TEST_CONTEXT(
-      "if a key is managed by the config, it will be set and "
-      "the ignored_missing list does not matter") {
+    {
+        SCOPED_TRACE(
+          "if a key is managed by the config, it will be set and "
+          "the ignored_missing list does not matter");
         auto cfg = test_config{};
-        BOOST_REQUIRE_NO_THROW(cfg.read_yaml(yaml_with_unknown_properties));
-        BOOST_CHECK_EQUAL(cfg.secret_string.value(), "terces");
-        BOOST_CHECK_EQUAL(cfg.aliased_bool.value(), false);
+        EXPECT_NO_THROW(cfg.read_yaml(yaml_with_unknown_properties));
+        EXPECT_EQ(cfg.secret_string.value(), "terces");
+        EXPECT_EQ(cfg.aliased_bool.value(), false);
     }
-    BOOST_TEST_CONTEXT("an unknown key will not generate an exception") {
+    {
+        SCOPED_TRACE("an unknown key will not generate an exception");
         auto noop_cfg = noop_config{};
-        BOOST_REQUIRE_NO_THROW(
-          noop_cfg.read_yaml(yaml_with_unknown_properties));
+        EXPECT_NO_THROW(noop_cfg.read_yaml(yaml_with_unknown_properties));
     }
 }

--- a/src/v/kafka/server/tests/topic_properties_helpers.h
+++ b/src/v/kafka/server/tests/topic_properties_helpers.h
@@ -9,6 +9,7 @@
 
 #include "cluster/config_frontend.h"
 #include "cluster/controller.h"
+#include "config/configuration.h"
 #include "kafka/client/transport.h"
 #include "kafka/protocol/create_partitions.h"
 #include "kafka/protocol/create_topics.h"
@@ -51,6 +52,11 @@ public:
             },
             model::timeout_clock::now() + 5s)
           .get();
+        // Tests have no restart mechanism, so promote pending values
+        // immediately so that needs_restart properties take effect.
+        ss::smp::invoke_on_all([] {
+            config::shard_local_cfg().promote_pending();
+        }).get();
     }
 
     template<typename Func>

--- a/src/v/redpanda/admin/api-doc/cluster_config.json
+++ b/src/v/redpanda/admin/api-doc/cluster_config.json
@@ -99,6 +99,14 @@
           "nickname": "get_cluster_config_status",
           "produces": ["application/json"],
           "parameters": [
+            {
+              "name": "show_pending",
+              "in": "query",
+              "schema": {"type": "boolean"},
+              "required": false,
+              "allowMultiple": false,
+              "description": "If true, include the list of configs awaiting restart to apply pending values."
+            }
           ]
         }
       ]
@@ -153,6 +161,13 @@
             "type": "string"
           },
           "description": "List of properties unknown to this node"
+        },
+        "pending": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of properties with pending changes awaiting restart on the node serving the request."
         }
       }
     },

--- a/src/v/redpanda/admin/api-doc/cluster_config.json
+++ b/src/v/redpanda/admin/api-doc/cluster_config.json
@@ -71,6 +71,14 @@
               "required": false,
               "allowMultiple": false,
               "description": "If false, only properties which have been changed from the default are included."
+            },
+            {
+              "name": "suppress_pending",
+              "in": "query",
+              "schema": {"type": "boolean"},
+              "required": false,
+              "allowMultiple": false,
+                "description": "If set, report the active runtime values for all configs. By default, properties with pending values (awaiting restart) report the pending value."
             }
           ],
           "responses": {
@@ -167,7 +175,7 @@
           "items": {
             "type": "string"
           },
-          "description": "List of properties with pending changes awaiting restart on the node serving the request."
+          "description": "List of properties with pending changes awaiting restart. Only populated for the node serving the request; for other nodes this list is empty."
         }
       }
     },

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -2069,7 +2069,13 @@ void admin_server::check_license(const ss::sstring& msg) const {
 void admin_server::register_cluster_config_routes() {
     register_route<superuser>(
       ss::httpd::cluster_config_json::get_cluster_config_status,
-      [this](std::unique_ptr<ss::http::request>) {
+      [this](std::unique_ptr<ss::http::request> req) {
+          auto local_node = _controller->self();
+          auto show_pending = get_boolean_query_param(*req, "show_pending");
+          auto local_pending
+            = show_pending
+                ? config::shard_local_cfg().properties_pending_restart()
+                : std::vector<ss::sstring>{};
           auto& cfg = _controller->get_config_manager();
           return cfg
             .invoke_on(
@@ -2077,7 +2083,8 @@ void admin_server::register_cluster_config_routes() {
               [](cluster::config_manager& manager) {
                   return manager.get_projected_status();
               })
-            .then([](auto statuses) {
+            .then([local_node,
+                   local_pending = std::move(local_pending)](auto statuses) {
                 std::vector<
                   ss::httpd::cluster_config_json::cluster_config_status>
                   res;
@@ -2095,9 +2102,19 @@ void admin_server::register_cluster_config_routes() {
                     // is then cleared in the subsequent operator=).
                     rs.invalid.push(ss::sstring("hack"));
                     rs.unknown.push(ss::sstring("hack"));
+                    rs.pending.push(ss::sstring("hack"));
 
                     rs.invalid = s.second.invalid;
                     rs.unknown = s.second.unknown;
+
+                    if (s.first == local_node) {
+                        rs.pending = local_pending;
+                    } else {
+                        // TODO: Pending state is local-only: extending
+                        // config_status (on-wire type) is needed to
+                        // propagate pending info from remote nodes.
+                        rs.pending = std::vector<ss::sstring>{};
+                    }
                 }
 
                 return ss::json::json_return_type(res);

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1547,12 +1547,17 @@ void admin_server::register_config_routes() {
               include_defaults = str_to_bool(include_defaults_str);
           }
 
+          auto pending = config::use_pending::yes;
+          if (get_boolean_query_param(req, "suppress_pending")) {
+              pending = config::use_pending::no;
+          }
+
           auto key_str = req.get_query_param("key");
           if (!key_str.empty()) {
               // Write a single key to json.
               try {
                   config::shard_local_cfg().to_json_single_key(
-                    writer, config::redact_secrets::yes, key_str);
+                    writer, config::redact_secrets::yes, key_str, pending);
               } catch (const std::out_of_range&) {
                   throw ss::httpd::bad_param_exception(
                     fmt::format("Unknown property {{{}}}", key_str));
@@ -1562,9 +1567,15 @@ void admin_server::register_config_routes() {
               config::shard_local_cfg().to_json(
                 writer,
                 config::redact_secrets::yes,
-                [include_defaults](config::base_property& p) {
-                    return include_defaults || !p.is_default();
-                });
+                [include_defaults, pending](config::base_property& p) {
+                    if (include_defaults) {
+                        return true;
+                    }
+                    return pending == config::use_pending::yes
+                             ? !p.is_default_pending()
+                             : !p.is_default();
+                },
+                pending);
           }
 
           reply.set_status(ss::http::reply::status_type::ok, buf.GetString());

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -859,13 +859,16 @@ class Admin:
         node: MaybeNode = None,
         include_defaults: bool | None = None,
         key: str | None = None,
+        suppress_pending: bool | None = None,
     ) -> dict[str, Any]:
+        params: dict[str, Any] = {}
         if key is not None:
-            kwargs = {"params": {"key": key}}
-        elif include_defaults is not None:
-            kwargs = {"params": {"include_defaults": include_defaults}}
-        else:
-            kwargs = {}
+            params["key"] = key
+        if include_defaults is not None:
+            params["include_defaults"] = include_defaults
+        if suppress_pending is not None:
+            params["suppress_pending"] = suppress_pending
+        kwargs = {"params": params} if params else {}
 
         return self._request("GET", "cluster_config", node=node, **kwargs).json()
 

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -407,6 +407,55 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
         check_restart_clears(self.admin, self.redpanda)
 
     @cluster(num_nodes=3)
+    def test_suppress_pending_query_param(self):
+        """
+        Verify the suppress_pending query parameter on GET /v1/cluster_config.
+
+        By default (suppress_pending=false), the API returns configured values
+        including any pending changes that haven't been applied via restart.
+        With suppress_pending=true, only active runtime values are returned.
+        After restart, both views should converge.
+        """
+        # kafka_qdc_idle_depth requires restart, default is 10
+        key = "kafka_qdc_idle_depth"
+        new_value = 77
+        default_value = self.admin.get_cluster_config()[key]
+        assert default_value != new_value
+
+        patch_result = self.admin.patch_cluster_config(upsert={key: new_value})
+        wait_for_version_status_sync(
+            self.admin, self.redpanda, patch_result["config_version"]
+        )
+
+        # Default behavior: pending value is visible immediately
+        assert self.admin.get_cluster_config()[key] == new_value
+
+        # suppress_pending=false: same as default
+        assert self.admin.get_cluster_config(suppress_pending=False)[key] == new_value
+
+        # suppress_pending=true: shows the active runtime value (still default)
+        assert (
+            self.admin.get_cluster_config(suppress_pending=True)[key] == default_value
+        )
+
+        # Same behavior with single-key query
+        assert (
+            self.admin.get_cluster_config(key=key, suppress_pending=True)[key]
+            == default_value
+        )
+        assert (
+            self.admin.get_cluster_config(key=key, suppress_pending=False)[key]
+            == new_value
+        )
+
+        # After restart, pending value is promoted to active
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+
+        # Both views now show the new value
+        assert self.admin.get_cluster_config()[key] == new_value
+        assert self.admin.get_cluster_config(suppress_pending=True)[key] == new_value
+
+    @cluster(num_nodes=3)
     def test_multistring_restart(self):
         """
         Reproduce an issue where the key we edit is saved correctly,

--- a/tests/rptest/tests/datalake/blocked_catalog_test.py
+++ b/tests/rptest/tests/datalake/blocked_catalog_test.py
@@ -334,7 +334,6 @@ class DatalakeBlockedCatalogTest(RedpandaTest):
                 hwm, _ = self.get_hwm_lso()
                 return hwm > target_o
 
-            rpk = RpkTool(self.redpanda)
             with firewall_blocked(
                 self.redpanda.nodes, dl.catalog_service.iceberg_rest_port
             ):
@@ -351,12 +350,16 @@ class DatalakeBlockedCatalogTest(RedpandaTest):
                 assert lso == 0, f"Expected {lso} = 0"
 
                 # Now disable Iceberg and wait for data to be trimmed.
-                rpk.cluster_config_set("iceberg_enabled", "false")
+                # iceberg_enabled requires restart to take effect.
+                self.redpanda.set_cluster_config(
+                    {"iceberg_enabled": False}, expect_restart=True
+                )
                 wait_until(self.cloud_log_trimmed, timeout_sec=30, backoff_sec=1)
 
             # Now reenable Iceberg and check that we commit data.
-            rpk.cluster_config_set("iceberg_enabled", "true")
-            self.redpanda.restart_nodes(self.redpanda.nodes)
+            self.redpanda.set_cluster_config(
+                {"iceberg_enabled": True}, expect_restart=True
+            )
 
             hwm, _ = self.get_hwm_lso()
             dl.wait_for_translation_until_offset(self.topic_name, hwm - 1)


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR reworks needs_restart cluster configuration semantics so that changes are staged as pending and do not affect the active runtime configuration until a node restart (with exceptions for bootstrap/recovery). It also extends the Admin API and tests to support querying either the configured (pending-inclusive) view or the active runtime view.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes

### Improvements

- Alters the behavior of restart-required cluster configs so that changes will are invisible to Redpanda internals until a node is actually restarted. Pending changes (and the restart status) still appear in the admin API as before.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
