### PR TITLE
Deflake node restart probe test; treat down replicas as lagged

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -618,7 +618,9 @@ health_monitor_backend::get_current_node_in_sync_replicas_share(
         const followers_stats& fs,
         const model::topic_namespace&,
         model::partition_id) {
-          if (std::ranges::count(fs.out_of_sync, _self)) {
+          if (
+            std::ranges::contains(fs.out_of_sync, _self)
+            || std::ranges::contains(fs.down, _self)) {
               ++out_of_sync_replicas;
           } else {
               ++in_sync_replicas;

--- a/tests/rptest/services/tc_netem.py
+++ b/tests/rptest/services/tc_netem.py
@@ -14,8 +14,8 @@ class NetemDelayDistribution(Enum):
 class NetemDelay(typing.NamedTuple):
     delay_us: int
     jitter_us: int
-    correlation_us: str
-    distribution: NetemDelayDistribution
+    correlation_us: str | None = None
+    distribution: NetemDelayDistribution | None = None
 
     def validate(self):
         if not self.delay_us:

--- a/tests/rptest/tests/node_restart_probe_test.py
+++ b/tests/rptest/tests/node_restart_probe_test.py
@@ -344,61 +344,72 @@ class NodePreRestartProbeTest(NodeRestartProbeTestBase):
         self.wait_pre_restart_probes(inevitable_risks, timeout_sec=240)
 
 
-# Same as `wait_until(lambda: value_fn() == target, **kwargs)`, but also checks
-# that:
-# 1) intermediate values can be increased by no more than `max_drop` each but
-# no higher than to `target` to form a non-decreasing sequence.
-# 2) it receives at least `min_values` values, apart from `bottom` and `target`
-def wait_gradually_increases(value_fn, target, max_drop, min_values, **kwargs):
-    max_seen_value = None
-    distinct_values = set()
+# Waits for value_fn() to eventually settle into a monotonically increasing
+# sequence from `from_at_most` (or lower) up to `to`, with at least
+# `min_values` distinct values in that final run.  Earlier dips are tolerated:
+# any decrease resets the tracked run.
+def wait_eventually_gradually_increases(
+    value_fn, from_at_most, to, min_values, **kwargs
+):
+    last_dip = None
+    prev = None
+    distinct_values_since_last_dip = 0
 
     def completed():
-        nonlocal max_seen_value, distinct_values
+        nonlocal last_dip, prev, distinct_values_since_last_dip
         cur_value = value_fn()
-        if max_seen_value is None:
-            max_seen_value = cur_value
-        assert cur_value >= max_seen_value - max_drop, (
-            f"received {cur_value} after {max_seen_value}"
+        if prev is None or cur_value < prev:
+            last_dip = cur_value
+            distinct_values_since_last_dip = 1
+        elif cur_value > prev:
+            distinct_values_since_last_dip += 1
+        prev = cur_value
+        return (
+            cur_value == to
+            and last_dip <= from_at_most
+            and distinct_values_since_last_dip >= min_values
         )
-        max_seen_value = max(max_seen_value, cur_value)
-        if len(distinct_values) < min_values:
-            distinct_values.add(cur_value)
-        return cur_value == target and len(distinct_values) == min_values
 
     wait_until(completed, **kwargs)
 
 
-def unittest_wait_gradually_increases():
+def unittest_wait_eventually_gradually_increases():
     def make_val_fn(*values):
         it = iter(values)
         return lambda: next(it)
 
     default_params = dict(
-        target=100, max_drop=2, min_values=5, timeout_sec=1, backoff_sec=0
+        from_at_most=50, to=100, min_values=5, timeout_sec=1, backoff_sec=0
     )
 
-    def call_wgi(*values):
-        wait_gradually_increases(make_val_fn(*values), **default_params)
+    def call(*values):
+        wait_eventually_gradually_increases(make_val_fn(*values), **default_params)
 
-    def expect_wgi_pass(*values):
-        call_wgi(*values)
+    def expect_pass(*values):
+        call(*values)
 
-    def expect_wgi_fail(*values):
+    def expect_fail(*values):
         try:
-            call_wgi(*values)
-        except StopIteration:
-            pass
-        except AssertionError:
+            call(*values)
+        except (StopIteration, AssertionError):
             pass
         else:
             assert False, "should have failed"
 
-    expect_wgi_pass(1, 0, 60, 58, 100)
-    expect_wgi_pass(1, 0, 50, 48, 78, 100)
-    expect_wgi_fail(5, 60, 58, 58, 60, 100)  # too few distinct vals
-    expect_wgi_fail(11, 40, 60, 58, 56, 100)  # decreases too much
-    expect_wgi_fail(1, 40, 60, 58, 59, 99)  # does not reach 100
+    # dip to 40 (<= 50), then monotonic rise with 5 distinct values
+    expect_pass(80, 70, 40, 55, 70, 85, 100)
+    # dip to 30, rise, another dip to 45, then final monotonic rise
+    expect_pass(60, 30, 50, 45, 55, 70, 85, 95, 100)
+    # dip to 50 (== from_at_most), valid
+    expect_pass(80, 50, 60, 70, 80, 100)
+    # never dips to from_at_most
+    expect_fail(60, 55, 70, 85, 95, 100)
+    # dips to from_at_most but the last dip is above from_at_most
+    expect_fail(60, 45, 70, 55, 95, 100)
+    # too few distinct values in final run
+    expect_fail(80, 40, 90, 100)
+    # does not reach `to`
+    expect_fail(80, 40, 55, 70, 85, 99)
 
 
 class NodePostRestartProbeTest(NodeRestartProbeTestBase):
@@ -429,7 +440,7 @@ class NodePostRestartProbeTest(NodeRestartProbeTestBase):
     @skip_debug_mode
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def post_restart_probe_test(self):
-        unittest_wait_gradually_increases()
+        unittest_wait_eventually_gradually_increases()
 
         self.create_topics()
 
@@ -458,14 +469,15 @@ class NodePostRestartProbeTest(NodeRestartProbeTestBase):
             err_msg="lagged replica load_reclamed_pc won't go down",
         )
 
-        wait_gradually_increases(
+        # Score may fluctuate as it takes some time to gather up-to-date health info from all nodes
+        wait_eventually_gradually_increases(
             lambda: self.get_load_reclaimed_pc(lagging_node),
-            target=100,
-            max_drop=10,
+            from_at_least=75,
+            to=100,
             min_values=3,
             timeout_sec=30,
             backoff_sec=0.1,
-            err_msg="lagged replica load_reclamed_pc won't reach 100%",
+            err_msg="lagged replica load_reclamed_pc won't reach 100% gradually",
         )
 
         for n in self.redpanda.nodes:

--- a/tests/rptest/tests/node_restart_probe_test.py
+++ b/tests/rptest/tests/node_restart_probe_test.py
@@ -22,6 +22,8 @@ from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 from rptest.tests.redpanda_test import RedpandaTest
+
+from rptest.services.tc_netem import NetemDelay, tc_netem_add, tc_netem_delete
 from rptest.utils.mode_checks import skip_debug_mode
 
 
@@ -420,8 +422,36 @@ class NodePostRestartProbeTest(NodeRestartProbeTestBase):
         super(NodePostRestartProbeTest, self).__init__(
             test_context=test_context,
             num_brokers=3,
-            extra_rp_conf={"health_monitor_max_metadata_age": 30},
+            extra_rp_conf={
+                "health_monitor_max_metadata_age": 500,  # ms
+                # Leader balancer transfers can cause partitions to be
+                # momentarily "unclaimed" in the health walk (node stepped
+                # down but new leader not yet reported), making
+                # load_reclaimed_pc drop non-monotonically.
+                "enable_leader_balancer": False,
+                # High concurrency with the minimum memory budget makes
+                # each recovery_stm read tiny chunks
+                # (32 MiB / 16384 ≈ 2 KiB per round), slowing individual
+                # recovery throughput while keeping all lagging partitions
+                # in is_recovering state simultaneously.
+                "raft_recovery_concurrency_per_shard": 16384,
+                "raft_max_recovery_memory": 33554432,  # 32 MiB (minimum)
+            },
         )
+
+    @contextmanager
+    def with_netem_delay(self):
+        """Add 10ms delay on all nodes (bidirectional) to slow down
+        recovery round-trips. With ~2 KiB per round and ~1000-4000
+        rounds per partition, 10ms × rounds ≈ 20-80s of recovery."""
+        delay = NetemDelay(delay_us=10000, jitter_us=4000)
+        try:
+            for node in self.redpanda.nodes:
+                tc_netem_add(node, delay)
+            yield
+        finally:
+            for node in self.redpanda.nodes:
+                tc_netem_delete(node)
 
     def create_topics(self):
         self.topics = [
@@ -430,12 +460,12 @@ class NodePostRestartProbeTest(NodeRestartProbeTestBase):
         self.client().create_topic(self.topics)
 
     def get_load_reclaimed_pc(self, node):
-        load_reclamed_pc = self.admin.get_broker_post_restart_probe(node)[
+        load_reclaimed_pc = self.admin.get_broker_post_restart_probe(node)[
             "load_reclaimed_pc"
         ]
-        assert 0 <= load_reclamed_pc <= 100
-        self.redpanda.logger.info(f"{load_reclamed_pc=}")
-        return load_reclamed_pc
+        assert 0 <= load_reclaimed_pc <= 100
+        self.redpanda.logger.info(f"{load_reclaimed_pc=}")
+        return load_reclaimed_pc
 
     @skip_debug_mode
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
@@ -452,38 +482,46 @@ class NodePostRestartProbeTest(NodeRestartProbeTestBase):
             lambda: self.get_load_reclaimed_pc(lagging_node) == 100,
             timeout_sec=10,
             backoff_sec=1,
-            err_msg="non-lagged replica load_reclamed_pc won't reach 100%",
+            err_msg="non-lagged replica load_reclaimed_pc won't reach 100%",
         )
 
         all_partitions = [
             (t.name, pid) for t in self.topics for pid in range(t.partition_count)
         ]
-        with self.with_append_entries_error_injection(lagging_node, all_partitions):
-            self.produce_to_all_partitions(acks=1)
 
-        # system partitions won't lag, some data partitions catch up quickly
-        wait_until(
-            lambda: self.get_load_reclaimed_pc(lagging_node) <= 75,
-            timeout_sec=10,
-            backoff_sec=0.1,
-            err_msg="lagged replica load_reclamed_pc won't go down",
-        )
+        # Netem wraps the entire recovery phase: it must be active
+        # before error injection is lifted so recovery RPCs are slow
+        # from the very first round.
+        with self.with_netem_delay():
+            with self.with_append_entries_error_injection(lagging_node, all_partitions):
+                self.produce_to_all_partitions(acks=1)
 
-        # Score may fluctuate as it takes some time to gather up-to-date health info from all nodes
-        wait_eventually_gradually_increases(
-            lambda: self.get_load_reclaimed_pc(lagging_node),
-            from_at_least=75,
-            to=100,
-            min_values=3,
-            timeout_sec=30,
-            backoff_sec=0.1,
-            err_msg="lagged replica load_reclamed_pc won't reach 100% gradually",
-        )
+            # After error injection is lifted, recovery_stm starts a continuous read loop for every
+            # lagging partition. With a tiny per-recovery read budget (≈2 KiB) and and netem adding
+            # 10 ms delay per direction on all nodes, each partition takes seconds to recover, so
+            # the metric drops deep and then climbs gradually as partitions finish one by one.
+            wait_until(
+                lambda: self.get_load_reclaimed_pc(lagging_node) <= 60,
+                timeout_sec=10,
+                backoff_sec=0.1,
+                err_msg="lagged replica load_reclaimed_pc won't go down",
+            )
+
+            # Score may fluctuate as it takes some time to gather up-to-date health info from all nodes
+            wait_eventually_gradually_increases(
+                lambda: self.get_load_reclaimed_pc(lagging_node),
+                from_at_most=60,
+                to=100,
+                min_values=4,
+                timeout_sec=60,
+                backoff_sec=0.1,
+                err_msg="lagged replica load_reclaimed_pc won't reach 100% gradually",
+            )
 
         for n in self.redpanda.nodes:
             wait_until(
                 lambda: self.get_load_reclaimed_pc(n) == 100,
                 timeout_sec=10,
                 backoff_sec=2,
-                err_msg="non-lagged replica load_reclamed_pc won't reach 100%",
+                err_msg="non-lagged replica load_reclaimed_pc won't reach 100%",
             )


### PR DESCRIPTION
1. Count down replicas as lagging.
2. In the test use network slowness simulation for slow recovery -- improves the test reliability.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
