### PR TITLE
`config`: drop `compaction_ctrl_max_shares` default

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1812,7 +1812,7 @@ configuration::configuration()
       "compaction_ctrl_max_shares",
       "Maximum number of I/O and CPU shares that compaction process can use.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      1000)
+      300)
   , compaction_ctrl_backlog_size(
       *this,
       "compaction_ctrl_backlog_size",


### PR DESCRIPTION
`1000` as the default max shares for compaction is really high. This means that compaction can take equal shares with `raft`, `kafka`, `fetch`, and `produce`.

We've seen how compaction can dominate CPU charts and run shards red-hot, so maybe dropping this default for the future can help alleviate that behavior while still allowing compaction to make solid progress when it needs to.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
