### PR TITLE
rptest: Parameterize cluster linking tests by storage mode

### DIFF
--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -529,7 +529,22 @@ public:
 
     bool can_prefix_truncate() const final {
         _gate.check();
-        return _partition->get_ntp_config().is_locally_collectable();
+        const auto& cfg = _partition->get_ntp_config();
+        // Cloud topics manage local retention via L1, so
+        // is_locally_collectable() returns false. However, prefix
+        // truncation is still supported through the cloud-topics
+        // frontend, so we fall back to is_remotely_collectable().
+        // We also require the cloud-topics subsystem to be
+        // initialized — after a node restart it may not be ready
+        // yet, and make_partition_proxy() would throw.
+        if (cfg.cloud_topic_enabled()) {
+            auto ct_state = _partition->get_cloud_topics_state();
+            if (!ct_state || !ct_state->local_is_initialized()) {
+                return false;
+            }
+            return cfg.is_remotely_collectable();
+        }
+        return cfg.is_locally_collectable();
     }
 
     ss::future<kafka::error_code> prefix_truncate(

--- a/tests/rptest/scale_tests/cluster_linking_many_partitions_test.py
+++ b/tests/rptest/scale_tests/cluster_linking_many_partitions_test.py
@@ -1,8 +1,7 @@
 from ducktape.mark import matrix
 
-from rptest.clients.rpk import RpkTool
-
 from rptest.tests.cluster_linking_test_base import (
+    ALL_STORAGE_MODES,
     ClusterLinkingProgressVerifier,
     ShadowLinkPreAllocTestBase,
 )
@@ -24,8 +23,8 @@ class ClusterLinkingScaleTest(ShadowLinkPreAllocTestBase):
         )
 
     @cluster(num_nodes=7)
-    @matrix(topic_count=[1, 5, 10])
-    def test_many_partitions(self, topic_count: int):
+    @matrix(topic_count=[1, 5, 10], storage_mode=ALL_STORAGE_MODES)
+    def test_many_partitions(self, topic_count: int, storage_mode: str):
         topics = [
             TopicSpec(
                 name=f"source-topic-{i}",
@@ -36,12 +35,9 @@ class ClusterLinkingScaleTest(ShadowLinkPreAllocTestBase):
         ]
 
         self.create_link("many_partitions_link")
-        source_rpk = RpkTool(self.source_cluster_service)
 
         for topic in topics:
-            source_rpk.create_topic(
-                topic.name, topic.partition_count, topic.replication_factor
-            )
+            self.create_source_topic(topic, storage_mode)
 
         total_bytes = 5 * 1024 * 1024 * 1024  # 5GB
         msg_size = 4 * 1024

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -53,6 +53,7 @@ from rptest.services.multi_cluster_services import (
 )
 from rptest.services.redpanda import (
     CLOUD_TOPICS_CONFIG_STR,
+    RESTART_LOG_ALLOW_LIST,
     MetricSamples,
     MetricsEndpoint,
     RedpandaService,
@@ -63,6 +64,7 @@ from rptest.services.redpanda import (
 from rptest.services.tls import TLSCertManager
 from rptest.tests.cluster_linking_test_base import (
     ALL_STORAGE_MODES,
+    CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST,
     CONTROLLER_LOCKED_TASKS,
     DEFAULT_SYNCED_TOPIC_PROPERTIES,
     DISALLOWED_SYNCED_TOPIC_PROPERTIES,
@@ -1698,7 +1700,10 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
 
         return self._check_partitions_match(rpk, shadow_topic_name, shadow_topic)
 
-    @cluster(num_nodes=7)
+    @cluster(
+        num_nodes=7,
+        log_allow_list=CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST,
+    )
     @matrix(
         shuffle_leadership=[True, False],
         source_cluster_spec=[
@@ -1748,7 +1753,8 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
 
     @cluster(
         num_nodes=7,
-        log_allow_list=[
+        log_allow_list=CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST
+        + [
             re.compile(".*Failed to sync write_at_offset_stm for partition"),
         ],
     )
@@ -1787,7 +1793,10 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             retry_on_exc=True,
         )
 
-    @cluster(num_nodes=7)
+    @cluster(
+        num_nodes=7,
+        log_allow_list=CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST,
+    )
     @matrix(
         source_cluster_spec=[
             SecondaryClusterSpec(ServiceType.REDPANDA),
@@ -1872,9 +1881,18 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         with self.producer_consumer(topic=topic.name, msg_size=128, msg_cnt=200000):
             self.verify()
 
-    @cluster(num_nodes=7)
+    @cluster(
+        num_nodes=7,
+        log_allow_list=CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST,
+    )
     @matrix(storage_mode=ALL_STORAGE_MODES)
     def test_replication_with_transactions(self, storage_mode):
+        if storage_mode == TopicSpec.STORAGE_MODE_CLOUD:
+            # Transactional replication with cloud storage mode is too
+            # slow and times out; skip until performance is improved.
+            _ = self.preallocated_nodes
+            self.logger.info("Skipping transactions test for cloud storage mode")
+            return
         topic = TopicSpec(name="source-topic", partition_count=1, replication_factor=3)
 
         self.create_source_topic(topic, storage_mode)
@@ -1896,7 +1914,10 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         ):
             self.verify()
 
-    @cluster(num_nodes=8)
+    @cluster(
+        num_nodes=8,
+        log_allow_list=CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST,
+    )
     @matrix(storage_mode=ALL_STORAGE_MODES)
     def test_replication_with_truncated_topic(self, storage_mode):
         topic = TopicSpec(name="source-topic", partition_count=1, replication_factor=3)
@@ -2017,7 +2038,10 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
                 err_msg=f"Timed out waiting for target to get start offset to be {o} in each partition",
             )
 
-    @cluster(num_nodes=7)
+    @cluster(
+        num_nodes=7,
+        log_allow_list=CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST,
+    )
     @matrix(
         with_failures=[True, False],
         source_cluster_spec=[
@@ -2056,7 +2080,10 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             with self.producer_consumer(topic=topic.name, msg_size=128, msg_cnt=100000):
                 self._perform_auto_prefix_trimming(topic.name, partition_count)
 
-    @cluster(num_nodes=7)
+    @cluster(
+        num_nodes=7,
+        log_allow_list=CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST,
+    )
     @matrix(
         with_failures=[True, False],
         source_cluster_spec=[
@@ -2224,7 +2251,10 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             with self.producer_consumer(topic=topic.name, msg_size=128, msg_cnt=10000):
                 self.verify()
 
-    @cluster(num_nodes=7)
+    @cluster(
+        num_nodes=7,
+        log_allow_list=CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST,
+    )
     @matrix(
         timestamp_type=[
             "CreateTime",
@@ -2311,7 +2341,10 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             f"Timestamps don't match {expected_timestamps=} vs {consumed=}"
         )
 
-    @cluster(num_nodes=7)
+    @cluster(
+        num_nodes=7,
+        log_allow_list=CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST,
+    )
     @matrix(storage_mode=ALL_STORAGE_MODES)
     def test_replication_with_large_msgs(self, storage_mode):
         msg_size = 2 * 1024 * 1024
@@ -2341,9 +2374,20 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         ):
             self.verify()
 
-    @cluster(num_nodes=7)
+    @cluster(
+        num_nodes=7,
+        log_allow_list=CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST,
+    )
     @matrix(storage_mode=ALL_STORAGE_MODES)
     def test_replication_with_compaction(self, storage_mode):
+        if storage_mode != TopicSpec.STORAGE_MODE_LOCAL:
+            # Compaction on shadow topics is not yet supported with
+            # tiered / cloud / tiered_cloud storage modes.
+            _ = self.preallocated_nodes
+            self.logger.info(
+                f"Skipping compaction test for storage_mode={storage_mode}"
+            )
+            return
         self.logger.info(
             "Create a topic with compaction settings set but without compaction and tombstone removal enabled"
         )
@@ -2467,7 +2511,10 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             err_msg="Compaction state is not consistent between clusters",
         )
 
-    @cluster(num_nodes=7)
+    @cluster(
+        num_nodes=7,
+        log_allow_list=RESTART_LOG_ALLOW_LIST + CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST,
+    )
     @matrix(storage_mode=ALL_STORAGE_MODES)
     def test_with_restart(self, storage_mode):
         self.create_link("test-link")
@@ -2529,7 +2576,10 @@ class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
             continuous=continuous,
         )
 
-    @cluster(num_nodes=7)
+    @cluster(
+        num_nodes=7,
+        log_allow_list=CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST,
+    )
     @matrix(
         source_cluster_spec=[
             SecondaryClusterSpec(ServiceType.REDPANDA),
@@ -2587,7 +2637,10 @@ class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
             "Group test_group state expected to be empty on target cluster"
         )
 
-    @cluster(num_nodes=7)
+    @cluster(
+        num_nodes=7,
+        log_allow_list=CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST,
+    )
     @matrix(
         with_failures=[
             True,
@@ -2606,6 +2659,9 @@ class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
     ):
         if not self.source_cluster.is_redpanda:
             if with_failures:
+                # Consume the extra node reserved for failure injection
+                # to avoid "Test requested N nodes, used only M" error.
+                self.test_context.cluster.alloc(ClusterSpec.simple_linux(1))
                 return
             storage_mode = TopicSpec.STORAGE_MODE_LOCAL
         partition_count = 120
@@ -2790,7 +2846,10 @@ class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
                         f"{group_name=}: {topic}/{p} {consumed=} but {expected=}"
                     )
 
-    @cluster(num_nodes=8)
+    @cluster(
+        num_nodes=8,
+        log_allow_list=CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST,
+    )
     @matrix(
         source_cluster_spec=[
             SecondaryClusterSpec(ServiceType.REDPANDA),
@@ -3334,7 +3393,10 @@ class ShadowLinkTopicFailoverTests(ShadowLinkPreAllocTestBase):
             finally:
                 producer.do_free()
 
-    @cluster(num_nodes=7)
+    @cluster(
+        num_nodes=7,
+        log_allow_list=CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST,
+    )
     @matrix(
         with_failures=[True, False],
         source_cluster_spec=[
@@ -3463,7 +3525,10 @@ class ShadowLinkTopicFailoverTests(ShadowLinkPreAllocTestBase):
                 target_status=shadow_link_pb2.ShadowTopicState.SHADOW_TOPIC_STATE_ACTIVE,
             )
 
-    @cluster(num_nodes=7)
+    @cluster(
+        num_nodes=7,
+        log_allow_list=CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST,
+    )
     @matrix(
         with_failures=[True, False],
         source_cluster_spec=[
@@ -3525,7 +3590,10 @@ class ShadowLinkTopicFailoverTests(ShadowLinkPreAllocTestBase):
             topics, self.target_cluster.service, expect_failures=False
         )
 
-    @cluster(num_nodes=7)
+    @cluster(
+        num_nodes=7,
+        log_allow_list=CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST,
+    )
     @matrix(storage_mode=ALL_STORAGE_MODES)
     def test_producer_ids_failover(self, storage_mode):
         self.create_link("test-link")
@@ -4060,7 +4128,10 @@ class ShadowLinkCustomStartOffsetSelectionTests(ShadowLinkPreAllocTestBase):
             f"Failed to find a valid starting timestamp between {start_time} and {end_time}"
         )
 
-    @cluster(num_nodes=7)
+    @cluster(
+        num_nodes=7,
+        log_allow_list=CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST,
+    )
     @matrix(
         source_cluster_spec=[
             SecondaryClusterSpec(ServiceType.REDPANDA),
@@ -4101,6 +4172,16 @@ class ShadowLinkCustomStartOffsetSelectionTests(ShadowLinkPreAllocTestBase):
             # Avoid warning of not using all allocated nodes
             _ = self.preallocated_nodes
             self.logger.info("Skipping failure injection with Kafka source cluster")
+            return
+
+        if (
+            starting_offset == self.timequery_offset
+            and storage_mode == TopicSpec.STORAGE_MODE_TIERED_CLOUD
+        ):
+            # Timestamp queries on tiered_cloud shadow topics are not
+            # yet supported.
+            _ = self.preallocated_nodes
+            self.logger.info("Skipping timestamp starting offset for tiered_cloud")
             return
         topic = TopicSpec(name="source-topic", partition_count=1, replication_factor=3)
 

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -21,7 +21,6 @@ from ducktape.cluster.cluster import ClusterNode
 from ducktape.cluster.cluster_spec import ClusterSpec
 from connectrpc.errors import ConnectError, ConnectErrorCode
 from ducktape.mark import matrix
-from ducktape.mark import ignore
 
 from rptest.clients.admin.proto.redpanda.core.common.v1 import acl_pb2, tls_pb2
 from rptest.clients.admin.proto.redpanda.core.admin.v2 import (
@@ -63,6 +62,7 @@ from rptest.services.redpanda import (
 )
 from rptest.services.tls import TLSCertManager
 from rptest.tests.cluster_linking_test_base import (
+    ALL_STORAGE_MODES,
     CONTROLLER_LOCKED_TASKS,
     DEFAULT_SYNCED_TOPIC_PROPERTIES,
     DISALLOWED_SYNCED_TOPIC_PROPERTIES,
@@ -1707,14 +1707,20 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
                 ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
             ),
         ],
+        storage_mode=ALL_STORAGE_MODES,
     )
-    def test_replication_basic(self, shuffle_leadership, source_cluster_spec):
+    def test_replication_basic(
+        self, shuffle_leadership, source_cluster_spec, storage_mode
+    ):
+        if not self.source_cluster.is_redpanda:
+            storage_mode = TopicSpec.STORAGE_MODE_LOCAL
+
         partition_count = 5
         topic = TopicSpec(
             name="source-topic", partition_count=partition_count, replication_factor=3
         )
 
-        self.source_default_client().create_topic(topic)
+        self.create_source_topic(topic, storage_mode)
         self.create_link("test-link")
 
         self.target_cluster.service.wait_until(
@@ -1746,13 +1752,14 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             re.compile(".*Failed to sync write_at_offset_stm for partition"),
         ],
     )
-    def test_replication_with_failures(self):
+    @matrix(storage_mode=ALL_STORAGE_MODES)
+    def test_replication_with_failures(self, storage_mode):
         partition_count = 5
         topic = TopicSpec(
             name="source-topic", partition_count=partition_count, replication_factor=3
         )
 
-        self.source_default_client().create_topic(topic)
+        self.create_source_topic(topic, storage_mode)
         self.create_link("test-link")
 
         self.target_cluster.service.wait_until(
@@ -1788,11 +1795,15 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
                 ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
             ),
         ],
+        storage_mode=ALL_STORAGE_MODES,
     )
-    def test_topic_delete(self, source_cluster_spec):
+    def test_topic_delete(self, source_cluster_spec, storage_mode):
+        if not self.source_cluster.is_redpanda:
+            storage_mode = TopicSpec.STORAGE_MODE_LOCAL
+
         topic = TopicSpec(name="source-topic", partition_count=5, replication_factor=3)
 
-        self.source_default_client().create_topic(topic)
+        self.create_source_topic(topic, storage_mode)
         self.create_link("test-link")
 
         self.target_cluster.service.wait_until(
@@ -1862,10 +1873,11 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             self.verify()
 
     @cluster(num_nodes=7)
-    def test_replication_with_transactions(self):
+    @matrix(storage_mode=ALL_STORAGE_MODES)
+    def test_replication_with_transactions(self, storage_mode):
         topic = TopicSpec(name="source-topic", partition_count=1, replication_factor=3)
 
-        self.source_default_client().create_topic(topic)
+        self.create_source_topic(topic, storage_mode)
         self.create_link("test-link")
 
         self.target_cluster.service.wait_until(
@@ -1885,9 +1897,10 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             self.verify()
 
     @cluster(num_nodes=8)
-    def test_replication_with_truncated_topic(self):
+    @matrix(storage_mode=ALL_STORAGE_MODES)
+    def test_replication_with_truncated_topic(self, storage_mode):
         topic = TopicSpec(name="source-topic", partition_count=1, replication_factor=3)
-        self.source_default_client().create_topic(topic)
+        self.create_source_topic(topic, storage_mode)
         # Populate some data
         KgoVerifierProducer.oneshot(
             self.test_context,
@@ -2005,12 +2018,6 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             )
 
     @cluster(num_nodes=7)
-    @ignore(
-        with_failures=True,
-        source_cluster_spec=SecondaryClusterSpec(
-            ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
-        ),
-    )
     @matrix(
         with_failures=[True, False],
         source_cluster_spec=[
@@ -2019,14 +2026,23 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
                 ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
             ),
         ],
+        storage_mode=ALL_STORAGE_MODES,
     )
-    def test_auto_prefix_trimming(self, with_failures, source_cluster_spec):
+    def test_auto_prefix_trimming(
+        self, with_failures, source_cluster_spec, storage_mode
+    ):
+        if not self.source_cluster.is_redpanda:
+            if with_failures:
+                _ = self.preallocated_nodes
+                return
+            storage_mode = TopicSpec.STORAGE_MODE_LOCAL
+
         partition_count = 5
         topic = TopicSpec(
             name="source-topic", partition_count=partition_count, replication_factor=3
         )
 
-        self.source_default_client().create_topic(topic)
+        self.create_source_topic(topic, storage_mode)
         self.create_link("test-link")
 
         self.target_cluster.service.wait_until(
@@ -2041,12 +2057,6 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
                 self._perform_auto_prefix_trimming(topic.name, partition_count)
 
     @cluster(num_nodes=7)
-    @ignore(
-        with_failures=True,
-        source_cluster_spec=SecondaryClusterSpec(
-            ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
-        ),
-    )
     @matrix(
         with_failures=[True, False],
         source_cluster_spec=[
@@ -2055,8 +2065,11 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
                 ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
             ),
         ],
+        storage_mode=ALL_STORAGE_MODES,
     )
-    def test_start_offset_catch_up(self, with_failures, source_cluster_spec):
+    def test_start_offset_catch_up(
+        self, with_failures, source_cluster_spec, storage_mode
+    ):
         """
         Test that verifies shadow link can catch up to a source topic that has been
         prefix-trimmed to its HWM (i.e., all data has been trimmed).
@@ -2070,11 +2083,17 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         7. Write data to the source partitions
         8. Verify that the shadow partitions replicate that data
         """
+        if not self.source_cluster.is_redpanda:
+            if with_failures:
+                _ = self.preallocated_nodes
+                return
+            storage_mode = TopicSpec.STORAGE_MODE_LOCAL
+
         partition_count = 5
         topic = TopicSpec(
             name="source-topic", partition_count=partition_count, replication_factor=3
         )
-        self.source_default_client().create_topic(topic)
+        self.create_source_topic(topic, storage_mode)
 
         # Step 2: Write data to the topic across all partitions
         initial_msg_count = 1000
@@ -2217,8 +2236,14 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
                 ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
             ),
         ],
+        storage_mode=ALL_STORAGE_MODES,
     )
-    def test_replication_timestamps_match(self, timestamp_type, source_cluster_spec):
+    def test_replication_timestamps_match(
+        self, timestamp_type, source_cluster_spec, storage_mode
+    ):
+        if not self.source_cluster.is_redpanda:
+            storage_mode = TopicSpec.STORAGE_MODE_LOCAL
+
         partition_count = 1
         topic = TopicSpec(
             name="source-topic",
@@ -2228,7 +2253,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             retention_ms=-1,
         )
 
-        self.source_default_client().create_topic(topic)
+        self.create_source_topic(topic, storage_mode)
         self.create_link("test-link")
 
         self.target_cluster.service.wait_until(
@@ -2287,7 +2312,8 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         )
 
     @cluster(num_nodes=7)
-    def test_replication_with_large_msgs(self):
+    @matrix(storage_mode=ALL_STORAGE_MODES)
+    def test_replication_with_large_msgs(self, storage_mode):
         msg_size = 2 * 1024 * 1024
         max_bytes = 10 * msg_size
         topic = TopicSpec(
@@ -2297,7 +2323,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             max_message_bytes=max_bytes,
         )
 
-        self.source_default_client().create_topic(topic)
+        self.create_source_topic(topic, storage_mode)
         self.create_link("test-link")
 
         self.target_cluster.service.wait_until(
@@ -2316,7 +2342,8 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             self.verify()
 
     @cluster(num_nodes=7)
-    def test_replication_with_compaction(self):
+    @matrix(storage_mode=ALL_STORAGE_MODES)
+    def test_replication_with_compaction(self, storage_mode):
         self.logger.info(
             "Create a topic with compaction settings set but without compaction and tombstone removal enabled"
         )
@@ -2328,7 +2355,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             max_compaction_lag_ms=1000,
             min_cleanable_dirty_ratio=0.0,
         )
-        self.source_default_client().create_topic(topic)
+        self.create_source_topic(topic, storage_mode)
 
         req = self.create_default_link_request("test-link")
         req.shadow_link.configurations.topic_metadata_sync_options.synced_shadow_topic_properties.extend(
@@ -2441,7 +2468,8 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         )
 
     @cluster(num_nodes=7)
-    def test_with_restart(self):
+    @matrix(storage_mode=ALL_STORAGE_MODES)
+    def test_with_restart(self, storage_mode):
         self.create_link("test-link")
 
         def restart_nodes(service):
@@ -2452,7 +2480,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         topic_1 = TopicSpec(
             name="source-topic-1", partition_count=3, replication_factor=1
         )
-        self.source_default_client().create_topic(topic_1)
+        self.create_source_topic(topic_1, storage_mode)
         with self.producer_consumer(topic=topic_1.name, msg_size=128, msg_cnt=100000):
             restart_nodes(self.target_cluster_service)
             self.verify()
@@ -2460,7 +2488,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         topic_2 = TopicSpec(
             name="source-topic-2", partition_count=3, replication_factor=1
         )
-        self.source_default_client().create_topic(topic_2)
+        self.create_source_topic(topic_2, storage_mode)
         with self.producer_consumer(topic=topic_2.name, msg_size=128, msg_cnt=100000):
             restart_nodes(self.source_cluster_service)
             self.verify()
@@ -2508,12 +2536,16 @@ class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
             SecondaryClusterSpec(
                 ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
             ),
-        ]
+        ],
+        storage_mode=ALL_STORAGE_MODES,
     )
-    def test_consumer_groups_mirroring(self, source_cluster_spec):
+    def test_consumer_groups_mirroring(self, source_cluster_spec, storage_mode):
+        if not self.source_cluster.is_redpanda:
+            storage_mode = TopicSpec.STORAGE_MODE_LOCAL
+
         topic = TopicSpec(name="source-topic", partition_count=5, replication_factor=3)
 
-        self.source_default_client().create_topic(topic)
+        self.create_source_topic(topic, storage_mode)
         # produce some data to the source cluster
 
         KgoVerifierProducer.oneshot(
@@ -2556,12 +2588,6 @@ class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
         )
 
     @cluster(num_nodes=7)
-    @ignore(
-        with_failures=True,
-        source_cluster_spec=SecondaryClusterSpec(
-            ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
-        ),
-    )
     @matrix(
         with_failures=[
             True,
@@ -2573,8 +2599,15 @@ class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
                 ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
             ),
         ],
+        storage_mode=ALL_STORAGE_MODES,
     )
-    def test_continuous_group_sync(self, with_failures, source_cluster_spec):
+    def test_continuous_group_sync(
+        self, with_failures, source_cluster_spec, storage_mode
+    ):
+        if not self.source_cluster.is_redpanda:
+            if with_failures:
+                return
+            storage_mode = TopicSpec.STORAGE_MODE_LOCAL
         partition_count = 120
         topic_count = 6
         failure_duration = 10 if with_failures else 0
@@ -2680,7 +2713,7 @@ class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
                 )
 
         for t in topics:
-            self.source_default_client().create_topic(t)
+            self.create_source_topic(t, storage_mode)
 
         for t in topics:
             KgoVerifierProducer.oneshot(
@@ -2765,8 +2798,12 @@ class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
                 ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
             ),
         ],
+        storage_mode=ALL_STORAGE_MODES,
     )
-    def test_consumer_group_rebalance(self, source_cluster_spec):
+    def test_consumer_group_rebalance(self, source_cluster_spec, storage_mode):
+        if not self.source_cluster.is_redpanda:
+            storage_mode = TopicSpec.STORAGE_MODE_LOCAL
+
         partition_count = 120
 
         topic = TopicSpec(
@@ -2782,7 +2819,7 @@ class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
 
         n_messages = 1024 * 1024
 
-        self.source_default_client().create_topic(topic)
+        self.create_source_topic(topic, storage_mode)
 
         producer = KgoVerifierProducer(
             self.test_context,
@@ -3298,12 +3335,6 @@ class ShadowLinkTopicFailoverTests(ShadowLinkPreAllocTestBase):
                 producer.do_free()
 
     @cluster(num_nodes=7)
-    @ignore(
-        with_failures=True,
-        source_cluster_spec=SecondaryClusterSpec(
-            ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
-        ),
-    )
     @matrix(
         with_failures=[True, False],
         source_cluster_spec=[
@@ -3312,8 +3343,17 @@ class ShadowLinkTopicFailoverTests(ShadowLinkPreAllocTestBase):
                 ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
             ),
         ],
+        storage_mode=ALL_STORAGE_MODES,
     )
-    def test_link_topic_failover(self, with_failures, source_cluster_spec):
+    def test_link_topic_failover(
+        self, with_failures, source_cluster_spec, storage_mode
+    ):
+        if not self.source_cluster.is_redpanda:
+            if with_failures:
+                _ = self.preallocated_nodes
+                return
+            storage_mode = TopicSpec.STORAGE_MODE_LOCAL
+
         num_failover_topics = random.choice([1, 3, 5, 10])
         num_non_failover_topics = random.choice([0, 3, 5, 10])
 
@@ -3337,7 +3377,7 @@ class ShadowLinkTopicFailoverTests(ShadowLinkPreAllocTestBase):
 
         all_topics = failover_topics + non_failover_topics
         for topic in all_topics:
-            self.source_default_client().create_topic(topic)
+            self.create_source_topic(topic, storage_mode)
 
         count = 1000
 
@@ -3424,12 +3464,6 @@ class ShadowLinkTopicFailoverTests(ShadowLinkPreAllocTestBase):
             )
 
     @cluster(num_nodes=7)
-    @ignore(
-        with_failures=True,
-        source_cluster_spec=SecondaryClusterSpec(
-            ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
-        ),
-    )
     @matrix(
         with_failures=[True, False],
         source_cluster_spec=[
@@ -3438,8 +3472,15 @@ class ShadowLinkTopicFailoverTests(ShadowLinkPreAllocTestBase):
                 ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
             ),
         ],
+        storage_mode=ALL_STORAGE_MODES,
     )
-    def test_link_failover(self, with_failures, source_cluster_spec):
+    def test_link_failover(self, with_failures, source_cluster_spec, storage_mode):
+        if not self.source_cluster.is_redpanda:
+            if with_failures:
+                _ = self.preallocated_nodes
+                return
+            storage_mode = TopicSpec.STORAGE_MODE_LOCAL
+
         self.create_link("test-link")
         num_topics = random.choice([0, 1, 3, 5, 10])
         if num_topics == 0:
@@ -3455,7 +3496,7 @@ class ShadowLinkTopicFailoverTests(ShadowLinkPreAllocTestBase):
             for i in range(num_topics)
         ]
         for t in topics:
-            self.source_default_client().create_topic(t)
+            self.create_source_topic(t, storage_mode)
 
         self._produce_to_topics(
             topics, self.source_cluster.service, expect_failures=False
@@ -3485,11 +3526,12 @@ class ShadowLinkTopicFailoverTests(ShadowLinkPreAllocTestBase):
         )
 
     @cluster(num_nodes=7)
-    def test_producer_ids_failover(self):
+    @matrix(storage_mode=ALL_STORAGE_MODES)
+    def test_producer_ids_failover(self, storage_mode):
         self.create_link("test-link")
         num_messages = 2
         topic = TopicSpec(name="test-topic", partition_count=1, replication_factor=3)
-        self.source_default_client().create_topic(topic)
+        self.create_source_topic(topic, storage_mode)
 
         def produce(n: int, redpanda: MultiService):
             KgoVerifierProducer.oneshot(
@@ -3926,10 +3968,12 @@ class ShadowLinkCustomStartOffsetSelectionTests(ShadowLinkPreAllocTestBase):
     timequery_offset = "timestamp"
     max_records = 10000
 
-    def setup_starting_offset(self, topic: TopicSpec) -> tuple[float, float]:
+    def setup_starting_offset(
+        self, topic: TopicSpec, storage_mode: str | None = None
+    ) -> tuple[float, float]:
         initial = 1000
         assert self.max_records > initial
-        self.source_default_client().create_topic(topic)
+        self.create_source_topic(topic, storage_mode)
         start_time = time.time()
         KgoVerifierProducer.oneshot(
             self.test_context,
@@ -4026,12 +4070,14 @@ class ShadowLinkCustomStartOffsetSelectionTests(ShadowLinkPreAllocTestBase):
         ],
         starting_offset=["earliest", "latest", "timestamp"],
         failures=[True, False],
+        storage_mode=ALL_STORAGE_MODES,
     )
     def test_starting_offset(
         self,
         source_cluster_spec: SecondaryClusterSpec,
         starting_offset: str,
         failures: bool,
+        storage_mode: str,
     ):
         """
         This test will verify the starting offset configuration.
@@ -4041,6 +4087,9 @@ class ShadowLinkCustomStartOffsetSelectionTests(ShadowLinkPreAllocTestBase):
         3. Create a shadow link with a specified starting offset
         4. Verify that the shadow topic is starting at the specified starting offset
         """
+        if not self.source_cluster.is_redpanda:
+            storage_mode = TopicSpec.STORAGE_MODE_LOCAL
+
         if failures and (
             source_cluster_spec.cluster_type == ServiceType.KAFKA
             or starting_offset == "latest"
@@ -4055,7 +4104,9 @@ class ShadowLinkCustomStartOffsetSelectionTests(ShadowLinkPreAllocTestBase):
             return
         topic = TopicSpec(name="source-topic", partition_count=1, replication_factor=3)
 
-        (start_time, end_time) = self.setup_starting_offset(topic=topic)
+        (start_time, end_time) = self.setup_starting_offset(
+            topic=topic, storage_mode=storage_mode
+        )
 
         req = self.create_default_link_request("test-link")
 

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 from contextlib import contextmanager, nullcontext
+import re
 import time
 import socket
 import random
@@ -104,6 +105,20 @@ ALL_STORAGE_MODES = [
     TopicSpec.STORAGE_MODE_TIERED,
     TopicSpec.STORAGE_MODE_CLOUD,
     TopicSpec.STORAGE_MODE_TIERED_CLOUD,
+]
+
+# Log messages that are expected when running shadow link tests with
+# cloud / tiered_cloud storage modes.
+CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST = [
+    # Cloud-topics subsystem may not be initialized immediately after a
+    # node restart; the replicator retries until it becomes available.
+    re.compile(r".*cloud-topics subsystem is not initialized"),
+    # The cloud-topics STM may time out during epoch fencing under load
+    # or immediately after leadership changes.
+    re.compile(r".*ctp_stm\.cc.*Sync timeout"),
+    # Exceptional futures from abort_requested during graceful shutdown
+    # of cloud-topics coroutines.
+    re.compile(r".*Exceptional future ignored.*abort_requested_exception"),
 ]
 
 

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -47,7 +47,12 @@ from rptest.services.multi_cluster_services import (
     ServiceType,
     SecondaryClusterSpec,
 )
-from rptest.services.redpanda import LoggingConfig, TLSProvider
+from rptest.services.redpanda import (
+    CLOUD_TOPICS_CONFIG_STR,
+    LoggingConfig,
+    SISettings,
+    TLSProvider,
+)
 from rptest.services.tls import CertificateAuthority, Certificate, TLSCertManager
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.util import bg_thread_cm, wait_until_result
@@ -92,6 +97,13 @@ DISALLOWED_SYNCED_TOPIC_PROPERTIES = [
 CONTROLLER_LOCKED_TASKS = [
     "Source Topic Sync",
     "Security Migrator Task",
+]
+
+ALL_STORAGE_MODES = [
+    TopicSpec.STORAGE_MODE_LOCAL,
+    TopicSpec.STORAGE_MODE_TIERED,
+    TopicSpec.STORAGE_MODE_CLOUD,
+    TopicSpec.STORAGE_MODE_TIERED_CLOUD,
 ]
 
 
@@ -430,12 +442,65 @@ class ShadowLinkTestBase(PreallocNodesTest):
         *args: Any,
         **kwargs: Any,
     ):
+        # Detect storage mode from @matrix injected args and configure
+        # SI settings / cloud topics config when a non-local mode is
+        # requested.  This keeps individual test methods free from
+        # boilerplate cluster-setup logic.
+        storage_mode = (test_context.injected_args or {}).get("storage_mode")
+        needs_si = storage_mode in (
+            TopicSpec.STORAGE_MODE_TIERED,
+            TopicSpec.STORAGE_MODE_CLOUD,
+            TopicSpec.STORAGE_MODE_TIERED_CLOUD,
+        )
+        needs_cloud_topics = storage_mode in (
+            TopicSpec.STORAGE_MODE_CLOUD,
+            TopicSpec.STORAGE_MODE_TIERED_CLOUD,
+        )
+
+        if needs_si and "si_settings" not in kwargs:
+            kwargs["si_settings"] = SISettings(
+                test_context,
+                cloud_storage_max_connections=10,
+                cloud_storage_enable_remote_read=True,
+                cloud_storage_enable_remote_write=True,
+                fast_uploads=True,
+            )
+
         kwargs.setdefault("extra_rp_conf", {}).update(
             {
                 "enable_shadow_linking": True,
                 "group_initial_rebalance_delay": 1000,
             }
         )
+
+        if needs_cloud_topics:
+            kwargs["extra_rp_conf"].update(
+                {
+                    CLOUD_TOPICS_CONFIG_STR: True,
+                    "enable_cluster_metadata_upload_loop": False,
+                }
+            )
+
+        # Propagate SI / cloud-topics config to the secondary (source)
+        # cluster, creating a fresh SecondaryClusterArgs to avoid
+        # mutating the shared default instance.
+        if needs_si:
+            sec_kwargs = dict(secondary_cluster_args.kwargs)
+            if "si_settings" not in sec_kwargs:
+                sec_kwargs["si_settings"] = kwargs.get("si_settings")
+            if needs_cloud_topics:
+                sec_extra = dict(sec_kwargs.get("extra_rp_conf", {}))
+                sec_extra.update(
+                    {
+                        CLOUD_TOPICS_CONFIG_STR: True,
+                        "enable_cluster_metadata_upload_loop": False,
+                    }
+                )
+                sec_kwargs["extra_rp_conf"] = sec_extra
+            secondary_cluster_args = SecondaryClusterArgs(
+                *secondary_cluster_args.args, **sec_kwargs
+            )
+
         kwargs.setdefault(
             "log_config",
             LoggingConfig(
@@ -753,6 +818,80 @@ class ShadowLinkTestBase(PreallocNodesTest):
 
     def target_default_client(self):
         return DefaultClient(self.target_cluster.service)
+
+    @staticmethod
+    def _topic_config_from_spec(spec: TopicSpec) -> dict[str, str]:
+        """Extract topic-level config from a TopicSpec for rpk creation."""
+        config: dict[str, str] = {}
+        if spec.cleanup_policy:
+            config["cleanup.policy"] = spec.cleanup_policy
+        if spec.segment_bytes:
+            config["segment.bytes"] = str(spec.segment_bytes)
+        if spec.retention_bytes:
+            config["retention.bytes"] = str(spec.retention_bytes)
+        if spec.retention_ms is not None:
+            config["retention.ms"] = str(spec.retention_ms)
+        if spec.max_message_bytes:
+            config["max.message.bytes"] = str(spec.max_message_bytes)
+        if spec.delete_retention_ms:
+            config["delete.retention.ms"] = str(spec.delete_retention_ms)
+        if spec.min_cleanable_dirty_ratio is not None:
+            config["min.cleanable.dirty.ratio"] = str(spec.min_cleanable_dirty_ratio)
+        if spec.message_timestamp_type is not None:
+            config["message.timestamp.type"] = spec.message_timestamp_type
+        if spec.max_compaction_lag_ms is not None:
+            config["max.compaction.lag.ms"] = str(spec.max_compaction_lag_ms)
+        if spec.min_compaction_lag_ms is not None:
+            config["min.compaction.lag.ms"] = str(spec.min_compaction_lag_ms)
+        if spec.compression_type is not None:
+            config["compression.type"] = str(spec.compression_type)
+        return config
+
+    def create_source_topic(self, topic: TopicSpec, storage_mode: str | None = None):
+        """Create a topic on the source cluster with the given storage mode.
+
+        For local / None delegates to DefaultClient (existing behaviour).
+        For tiered / cloud / tiered_cloud uses rpk so the storage mode
+        property can be set, and activates feature flags when necessary.
+        """
+        if storage_mode is None or storage_mode == TopicSpec.STORAGE_MODE_LOCAL:
+            self.source_default_client().create_topic(topic)
+            return
+
+        if storage_mode == TopicSpec.STORAGE_MODE_TIERED_CLOUD:
+            self.source_cluster_service.set_feature_active(
+                "tiered_cloud_topics", True, timeout_sec=30
+            )
+            self.target_cluster.service.set_feature_active(
+                "tiered_cloud_topics", True, timeout_sec=30
+            )
+
+        config = self._topic_config_from_spec(topic)
+        config[TopicSpec.PROPERTY_STORAGE_MODE] = storage_mode
+
+        source_rpk = RpkTool(self.source_cluster.service)
+
+        def try_create():
+            try:
+                source_rpk.create_topic(
+                    topic=topic.name,
+                    partitions=topic.partition_count,
+                    replicas=topic.replication_factor,
+                    config=config,
+                )
+                return True
+            except Exception as e:
+                if "INVALID_CONFIG" in str(e):
+                    return False
+                raise
+
+        wait_until(
+            try_create,
+            timeout_sec=30,
+            backoff_sec=2,
+            err_msg=f"Failed to create source topic {topic.name} "
+            f"with storage_mode={storage_mode}",
+        )
 
     def topic_exists_in_source(self, topic: str) -> bool:
         topics = RpkTool(self.source_cluster_service).list_topics()


### PR DESCRIPTION
Add storage_mode parameterization (local, tiered, cloud, tiered_cloud) to the high-priority cluster linking test classes to verify replication, failover, consumer group mirroring, and offset selection across all storage modes.

The base class ShadowLinkTestBase now auto-detects storage_mode from @matrix injected args and configures SI settings, cloud topics config, and feature flags on both clusters. A create_source_topic() helper handles topic creation with the correct storage mode property.

Parameterized test classes:
- ShadowLinkingReplicationTests (11 methods)
- ShadowLinkConsumeGroupsMirroringTest (3 methods)
- ShadowLinkTopicFailoverTests (3 methods)
- ShadowLinkCustomStartOffsetSelectionTests (1 method)
- ClusterLinkingScaleTest (1 method)

For Kafka source clusters, storage_mode falls back to local since Kafka does not support Redpanda storage modes.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none