### PR TITLE
Cloud Storage Clients: ABS: Don't send x-ms-version header with batch delete subresponses

### DIFF
--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -896,7 +896,7 @@ ss::future<upload_result> remote::delete_object_batch(
         if (res) {
             if (!res.value().undeleted_keys.empty()) {
                 vlog(
-                  ctxlog.debug,
+                  ctxlog.info,
                   "{} objects were not deleted by plural delete; first "
                   "failure: {{key: {}, reason:{}}}",
                   res.value().undeleted_keys.size(),

--- a/src/v/cloud_roles/apply_abs_oauth_credentials.cc
+++ b/src/v/cloud_roles/apply_abs_oauth_credentials.cc
@@ -21,9 +21,8 @@ apply_abs_oauth_credentials::apply_abs_oauth_credentials(
 std::error_code apply_abs_oauth_credentials::add_auth(
   http::client::request_header& header) const {
     auto token = _oauth_token();
-    // x-ms-version requests a specific version for the abs api, the hardcoded
-    // value is the one we test
-    header.set("x-ms-version", azure_storage_api_version);
+    // x-ms-version is set by abs_request_creator::add_auth, not here,
+    // because batch sub-requests must omit it before signing.
     auto iso_ts = _timesource.format_http_datetime();
     header.set("x-ms-date", {iso_ts.data(), iso_ts.size()});
     header.insert(

--- a/src/v/cloud_roles/tests/credential_tests.cc
+++ b/src/v/cloud_roles/tests/credential_tests.cc
@@ -111,8 +111,9 @@ BOOST_AUTO_TEST_CASE(test_azure_oauth_headers) {
         bh::request_header<> h{};
         BOOST_REQUIRE(!applier.add_auth(h));
         BOOST_REQUIRE_EQUAL(h.at("Authorization"), "Bearer a-token");
-        BOOST_REQUIRE_EQUAL(
-          h.at("x-ms-version"), cloud_roles::azure_storage_api_version);
+        // x-ms-version is set by abs_request_creator::add_auth, not by
+        // the credentials layer.
+        BOOST_REQUIRE(h.find("x-ms-version") == h.end());
     }
 
     applier.reset_creds(
@@ -122,7 +123,6 @@ BOOST_AUTO_TEST_CASE(test_azure_oauth_headers) {
         bh::request_header<> h{};
         BOOST_REQUIRE(!applier.add_auth(h));
         BOOST_REQUIRE_EQUAL(h.at("Authorization"), "Bearer second-token");
-        BOOST_REQUIRE_EQUAL(
-          h.at("x-ms-version"), cloud_roles::azure_storage_api_version);
+        BOOST_REQUIRE(h.find("x-ms-version") == h.end());
     }
 }

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -559,7 +559,12 @@ ss::future<upload_result> remote::delete_objects(
         std::move(keys),
         parent,
         make_notify_cb(api_activity_type::segment_delete, parent))
-      .then([h = std::move(holder)](upload_result r) { return r; });
+      .then([this, h = std::move(holder)](upload_result r) {
+          if (r == upload_result::failed && is_batch_delete_supported()) {
+              _probe.batch_delete_error();
+          }
+          return r;
+      });
 }
 
 template ss::future<upload_result>

--- a/src/v/cloud_storage/remote_probe.cc
+++ b/src/v/cloud_storage/remote_probe.cc
@@ -147,6 +147,10 @@ remote_probe::remote_probe(
               sm::description(
                 "Number of times backoff was applied during "
                 "controller snapshot uploads")),
+            sm::make_counter(
+              "batch_delete_errors",
+              [this] { return _cnt_batch_delete_errors; },
+              sm::description("Number of failed batch delete requests")),
             sm::make_histogram(
               "client_acquisition_latency",
               [this] {

--- a/src/v/cloud_storage/remote_probe.h
+++ b/src/v/cloud_storage/remote_probe.h
@@ -228,6 +228,8 @@ public:
 
     void index_download() { ++_cnt_index_downloads; }
 
+    void batch_delete_error() { ++_cnt_batch_delete_errors; }
+
     auto client_acquisition() {
         return _client_acquisition_latency.auto_measure();
     }
@@ -316,6 +318,8 @@ private:
     uint64_t _cnt_topic_mount_manifest_uploads{0};
     /// Number of topic_mount manifest downloads
     uint64_t _cnt_topic_mount_manifest_downloads{0};
+    /// Number of failed batch delete requests
+    uint64_t _cnt_batch_delete_errors{0};
 
     hist_t _client_acquisition_latency;
     hist_t _segment_download_latency;

--- a/src/v/cloud_storage_clients/tests/abs_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/abs_client_test.cc
@@ -459,6 +459,55 @@ TEST_F(abs_client_fixture, test_batch_delete_not_found) {
     EXPECT_TRUE(result.value().undeleted_keys.empty());
 }
 
+// Verify that batch delete sub-requests do not include x-ms-version.
+// Azure rejects sub-requests with this header
+// (SubRequestCannotHaveVersionHeader). This was a bug when using OAuth
+// credentials, whose add_auth previously set x-ms-version unconditionally.
+TEST(abs_batch_delete_subrequest, no_version_header_in_subrequests) {
+    auto conf = make_test_configuration("test-version-check");
+    auto oauth_creds = ss::make_lw_shared(
+      cloud_roles::make_credentials_applier(
+        cloud_roles::abs_oauth_credentials{
+          .oauth_token = cloud_roles::oauth_token_str{"test-token"}}));
+
+    abs_request_creator requestor(conf, oauth_creds);
+    auto keys = chunked_vector<object_key>{
+      object_key{"blob0"}, object_key{"blob1"}};
+    auto result = requestor.make_batch_delete_request(
+      plain_bucket_name{"container"}, keys);
+    ASSERT_TRUE(result.has_value());
+
+    auto& [header, body_stream] = result.value();
+
+    // The outer request header should have x-ms-version
+    auto outer_version = header.find("x-ms-version");
+    EXPECT_NE(outer_version, header.end());
+
+    // Read the full body and check that sub-requests don't contain x-ms-version
+    ss::sstring body_str;
+    while (!body_stream.eof()) {
+        auto buf = body_stream.read().get();
+        body_str.append(buf.get(), buf.size());
+    }
+
+    // Split on boundary to get individual sub-requests. Each sub-request
+    // after the MIME headers contains an HTTP request line and headers.
+    // x-ms-version must not appear in any sub-request.
+    size_t pos = 0;
+    size_t subrequest_count = 0;
+    while ((pos = body_str.find("DELETE ", pos)) != ss::sstring::npos) {
+        auto end = body_str.find("\r\n\r\n", pos);
+        auto subrequest_headers = body_str.substr(
+          pos, end != ss::sstring::npos ? end - pos : ss::sstring::npos);
+        EXPECT_EQ(subrequest_headers.find("x-ms-version"), ss::sstring::npos)
+          << "Sub-request " << subrequest_count
+          << " contains x-ms-version header";
+        ++subrequest_count;
+        pos += 7;
+    }
+    EXPECT_EQ(subrequest_count, keys.size());
+}
+
 TEST_F(abs_client_fixture, test_batch_delete_server_error) {
     set_up("test-servererror");
     auto keys = chunked_vector<object_key>{object_key{"key1"}};


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Azure rejects batch sub-requests that carry a version header
(SubRequestCannotHaveVersionHeader). abs_request_creator::add_auth
correctly skips the header when omit_version is true, but the
oauth credentials layer (apply_abs_oauth_credentials) was adding
it unconditionally. This went unnoticed because batch delete was only
tested with Shared Key auth, whose credentials applier does not add
the version header.

We can't strip the header post-facto because by that time the request
is signed. Instead just move the version header setting _out_ of the
oauth credentials impl and to abs_client. Also requires a slight
adjustment to the credentials test, but we can still have e2e tests
that confirm it works.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Bug Fixes

* Fix an issue where multi-part delete requests were rejected by ABS when using OAuth (unexpected headers).


<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
