### PR TITLE
[v26.1.x] Cloud Storage Clients: ABS: Don't send x-ms-version header with batch delete subresponses

### DIFF
--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -896,7 +896,7 @@ ss::future<upload_result> remote::delete_object_batch(
         if (res) {
             if (!res.value().undeleted_keys.empty()) {
                 vlog(
-                  ctxlog.debug,
+                  ctxlog.info,
                   "{} objects were not deleted by plural delete; first "
                   "failure: {{key: {}, reason:{}}}",
                   res.value().undeleted_keys.size(),

--- a/src/v/cloud_roles/apply_abs_oauth_credentials.cc
+++ b/src/v/cloud_roles/apply_abs_oauth_credentials.cc
@@ -21,9 +21,8 @@ apply_abs_oauth_credentials::apply_abs_oauth_credentials(
 std::error_code apply_abs_oauth_credentials::add_auth(
   http::client::request_header& header) const {
     auto token = _oauth_token();
-    // x-ms-version requests a specific version for the abs api, the hardcoded
-    // value is the one we test
-    header.set("x-ms-version", azure_storage_api_version);
+    // x-ms-version is set by abs_request_creator::add_auth, not here,
+    // because batch sub-requests must omit it before signing.
     auto iso_ts = _timesource.format_http_datetime();
     header.set("x-ms-date", {iso_ts.data(), iso_ts.size()});
     header.insert(

--- a/src/v/cloud_roles/tests/credential_tests.cc
+++ b/src/v/cloud_roles/tests/credential_tests.cc
@@ -111,8 +111,9 @@ BOOST_AUTO_TEST_CASE(test_azure_oauth_headers) {
         bh::request_header<> h{};
         BOOST_REQUIRE(!applier.add_auth(h));
         BOOST_REQUIRE_EQUAL(h.at("Authorization"), "Bearer a-token");
-        BOOST_REQUIRE_EQUAL(
-          h.at("x-ms-version"), cloud_roles::azure_storage_api_version);
+        // x-ms-version is set by abs_request_creator::add_auth, not by
+        // the credentials layer.
+        BOOST_REQUIRE(h.find("x-ms-version") == h.end());
     }
 
     applier.reset_creds(
@@ -122,7 +123,6 @@ BOOST_AUTO_TEST_CASE(test_azure_oauth_headers) {
         bh::request_header<> h{};
         BOOST_REQUIRE(!applier.add_auth(h));
         BOOST_REQUIRE_EQUAL(h.at("Authorization"), "Bearer second-token");
-        BOOST_REQUIRE_EQUAL(
-          h.at("x-ms-version"), cloud_roles::azure_storage_api_version);
+        BOOST_REQUIRE(h.find("x-ms-version") == h.end());
     }
 }

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -559,7 +559,12 @@ ss::future<upload_result> remote::delete_objects(
         std::move(keys),
         parent,
         make_notify_cb(api_activity_type::segment_delete, parent))
-      .then([h = std::move(holder)](upload_result r) { return r; });
+      .then([this, h = std::move(holder)](upload_result r) {
+          if (r == upload_result::failed && is_batch_delete_supported()) {
+              _probe.batch_delete_error();
+          }
+          return r;
+      });
 }
 
 template ss::future<upload_result>

--- a/src/v/cloud_storage/remote_probe.cc
+++ b/src/v/cloud_storage/remote_probe.cc
@@ -147,6 +147,10 @@ remote_probe::remote_probe(
               sm::description(
                 "Number of times backoff was applied during "
                 "controller snapshot uploads")),
+            sm::make_counter(
+              "batch_delete_errors",
+              [this] { return _cnt_batch_delete_errors; },
+              sm::description("Number of failed batch delete requests")),
             sm::make_histogram(
               "client_acquisition_latency",
               [this] {

--- a/src/v/cloud_storage/remote_probe.h
+++ b/src/v/cloud_storage/remote_probe.h
@@ -228,6 +228,8 @@ public:
 
     void index_download() { ++_cnt_index_downloads; }
 
+    void batch_delete_error() { ++_cnt_batch_delete_errors; }
+
     auto client_acquisition() {
         return _client_acquisition_latency.auto_measure();
     }
@@ -316,6 +318,8 @@ private:
     uint64_t _cnt_topic_mount_manifest_uploads{0};
     /// Number of topic_mount manifest downloads
     uint64_t _cnt_topic_mount_manifest_downloads{0};
+    /// Number of failed batch delete requests
+    uint64_t _cnt_batch_delete_errors{0};
 
     hist_t _client_acquisition_latency;
     hist_t _segment_download_latency;

--- a/src/v/cloud_storage_clients/tests/abs_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/abs_client_test.cc
@@ -459,6 +459,55 @@ TEST_F(abs_client_fixture, test_batch_delete_not_found) {
     EXPECT_TRUE(result.value().undeleted_keys.empty());
 }
 
+// Verify that batch delete sub-requests do not include x-ms-version.
+// Azure rejects sub-requests with this header
+// (SubRequestCannotHaveVersionHeader). This was a bug when using OAuth
+// credentials, whose add_auth previously set x-ms-version unconditionally.
+TEST(abs_batch_delete_subrequest, no_version_header_in_subrequests) {
+    auto conf = make_test_configuration("test-version-check");
+    auto oauth_creds = ss::make_lw_shared(
+      cloud_roles::make_credentials_applier(
+        cloud_roles::abs_oauth_credentials{
+          .oauth_token = cloud_roles::oauth_token_str{"test-token"}}));
+
+    abs_request_creator requestor(conf, oauth_creds);
+    auto keys = chunked_vector<object_key>{
+      object_key{"blob0"}, object_key{"blob1"}};
+    auto result = requestor.make_batch_delete_request(
+      plain_bucket_name{"container"}, keys);
+    ASSERT_TRUE(result.has_value());
+
+    auto& [header, body_stream] = result.value();
+
+    // The outer request header should have x-ms-version
+    auto outer_version = header.find("x-ms-version");
+    EXPECT_NE(outer_version, header.end());
+
+    // Read the full body and check that sub-requests don't contain x-ms-version
+    ss::sstring body_str;
+    while (!body_stream.eof()) {
+        auto buf = body_stream.read().get();
+        body_str.append(buf.get(), buf.size());
+    }
+
+    // Split on boundary to get individual sub-requests. Each sub-request
+    // after the MIME headers contains an HTTP request line and headers.
+    // x-ms-version must not appear in any sub-request.
+    size_t pos = 0;
+    size_t subrequest_count = 0;
+    while ((pos = body_str.find("DELETE ", pos)) != ss::sstring::npos) {
+        auto end = body_str.find("\r\n\r\n", pos);
+        auto subrequest_headers = body_str.substr(
+          pos, end != ss::sstring::npos ? end - pos : ss::sstring::npos);
+        EXPECT_EQ(subrequest_headers.find("x-ms-version"), ss::sstring::npos)
+          << "Sub-request " << subrequest_count
+          << " contains x-ms-version header";
+        ++subrequest_count;
+        pos += 7;
+    }
+    EXPECT_EQ(subrequest_count, keys.size());
+}
+
 TEST_F(abs_client_fixture, test_batch_delete_server_error) {
     set_up("test-servererror");
     auto keys = chunked_vector<object_key>{object_key{"key1"}};


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30133
