### PR TITLE
rpk: bump twmb/avro to v1.4.1

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/sjson v1.2.5
 	github.com/tklauser/go-sysconf v0.3.16
-	github.com/twmb/avro v1.3.4
+	github.com/twmb/avro v1.4.1
 	github.com/twmb/franz-go v1.20.5
 	github.com/twmb/franz-go/pkg/kadm v1.17.2
 	github.com/twmb/franz-go/pkg/kfake v0.0.0-20251024215757-aea970d4d0d2

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -338,8 +338,8 @@ github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYI
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
-github.com/twmb/avro v1.3.4 h1:4tTV207HOUHKTdAMv6fGPyqgwmGfMLUfnFg5R4cfIX0=
-github.com/twmb/avro v1.3.4/go.mod h1:TUQS96Ptl8tDRyK0Jw91FXIVCoPKz4sXxvUSShiG5FA=
+github.com/twmb/avro v1.4.1 h1:pzXZivLS0YkI7lntpxnu6aYkNJBUJ3vSp6uzEGLeQOI=
+github.com/twmb/avro v1.4.1/go.mod h1:X0fT1dY2xcbV4YuCE4mYro+qljHl4kUF5uA/2z1rgSk=
 github.com/twmb/franz-go v1.20.5 h1:Gj9jdkvlddf8pdrehvtDHLPult5JS8q65oITUff6dXo=
 github.com/twmb/franz-go v1.20.5/go.mod h1:gZmp2nTNfKuiKKND8qAsv28VdMlr/Gf4BIcsj99Bmtk=
 github.com/twmb/franz-go/pkg/kadm v1.17.2 h1:g5f1sAxnTkYC6G96pV5u715HWhxd66hWaDZUAQ8xHY8=

--- a/src/go/rpk/pkg/serde/avro.go
+++ b/src/go/rpk/pkg/serde/avro.go
@@ -58,48 +58,47 @@ func newAvroDecoder(schema *avro.Schema) (serdeFunc, error) {
 // generateAvroSchema parses the schema and its references, returning a
 // compiled schema that can be used for encoding and decoding.
 func generateAvroSchema(ctx context.Context, cl *sr.Client, schema *sr.Schema) (*avro.Schema, error) {
-	if len(schema.References) == 0 {
-		s, err := avro.Parse(schema.Schema)
-		if err != nil {
-			return nil, fmt.Errorf("unable to parse schema: %v", err)
-		}
-		return s, nil
-	}
 	cache := &avro.SchemaCache{}
-	seen := make(map[string]bool)
-	if err := parseAvroReferences(ctx, cl, cache, schema, seen); err != nil {
-		return nil, fmt.Errorf("unable to parse references: %v", err)
+	if err := parseAvroReferences(ctx, cl, cache, schema, make(map[string]bool), make(map[string]bool)); err != nil {
+		return nil, fmt.Errorf("unable to parse references: %w", err)
 	}
 	s, err := cache.Parse(schema.Schema)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse schema: %v", err)
+		return nil, fmt.Errorf("unable to parse schema: %w", err)
 	}
 	return s, nil
 }
 
 // parseAvroReferences recursively parses all schema references into the cache
-// so they are available when parsing the parent schema. The seen map tracks
-// already-fetched subject+version pairs to avoid redundant registry requests.
-func parseAvroReferences(ctx context.Context, cl *sr.Client, cache *avro.SchemaCache, schema *sr.Schema, seen map[string]bool) error {
+// so they are available when parsing the parent schema. stack tracks
+// references currently being walked for cycle detection; parsed tracks
+// references already added to the cache to avoid redundant work on shared
+// subgraphs.
+func parseAvroReferences(ctx context.Context, cl *sr.Client, cache *avro.SchemaCache, schema *sr.Schema, stack, parsed map[string]bool) error {
 	for _, ref := range schema.References {
 		key := fmt.Sprintf("%s-%d", ref.Subject, ref.Version)
-		if seen[key] {
+		if stack[key] {
+			return fmt.Errorf("circular avro schema reference detected for subject %q version %d", ref.Subject, ref.Version)
+		}
+		if parsed[key] {
 			continue
 		}
-		seen[key] = true
+		stack[key] = true
 		r, err := cl.SchemaByVersion(ctx, ref.Subject, ref.Version)
 		if err != nil {
-			return fmt.Errorf("unable to get reference schema with subject %q and version %v: %v", ref.Subject, ref.Version, err)
+			return fmt.Errorf("unable to get reference schema with subject %q and version %d: %w", ref.Subject, ref.Version, err)
 		}
 		refSchema := r.Schema
 		if len(refSchema.References) > 0 {
-			if err := parseAvroReferences(ctx, cl, cache, &refSchema, seen); err != nil {
-				return fmt.Errorf("unable to parse schema with subject %q and version %v: %v", ref.Subject, ref.Version, err)
+			if err := parseAvroReferences(ctx, cl, cache, &refSchema, stack, parsed); err != nil {
+				return fmt.Errorf("unable to parse schema with subject %q and version %d: %w", ref.Subject, ref.Version, err)
 			}
 		}
 		if _, err := cache.Parse(refSchema.Schema); err != nil {
-			return fmt.Errorf("unable to parse schema with subject %q and version %v: %v", ref.Subject, ref.Version, err)
+			return fmt.Errorf("unable to parse schema with subject %q and version %d: %w", ref.Subject, ref.Version, err)
 		}
+		delete(stack, key)
+		parsed[key] = true
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Routine maintenance bump from v1.3.4 to v1.4.1 for rpk's Avro serde.

v1.4.1 release notes: https://github.com/twmb/avro/releases/tag/v1.4.1

v1.4.1 fixes an edge case where records with zero fields emitted as `{"type":"record","name":"x"}` (missing the required `fields` attribute), which strict Avro readers reject. rpk is highly unlikely to hit this in practice — `pkg/serde/avro.go` parses schemas from schema registry and produces/consumes records, and empty-record schemas are rare in normal data. Primarily a "stay current" bump.

v1.4.0 (also included) added atype subpackage, SchemaNode struct-literal construction, case-insensitive JSON parsing for janky encoders, duplicate-JSON-key tolerance, and named-type dedup. None of these change behavior for rpk's existing usage.

## Test plan

- [x] `go mod tidy` clean
- [x] `go build ./...` clean
- [x] `go test ./pkg/serde/...` passes