### PR TITLE
cluster: fix stale clang format after merge race

### DIFF
--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3596,8 +3596,7 @@ struct batch_update_mirror_topic_status_request
 
     friend bool operator==(
       const batch_update_mirror_topic_status_request&,
-      const batch_update_mirror_topic_status_request&)
-      = default;
+      const batch_update_mirror_topic_status_request&) = default;
 
     auto serde_fields() { return std::tie(link_id, cmd, timeout); }
 };
@@ -3611,8 +3610,7 @@ struct batch_update_mirror_topic_status_response
 
     friend bool operator==(
       const batch_update_mirror_topic_status_response&,
-      const batch_update_mirror_topic_status_response&)
-      = default;
+      const batch_update_mirror_topic_status_response&) = default;
 
     auto serde_fields() { return std::tie(ec); }
 };

--- a/src/v/cluster_link/model/types.h
+++ b/src/v/cluster_link/model/types.h
@@ -925,8 +925,7 @@ struct batch_update_mirror_topic_status_cmd
 
     friend bool operator==(
       const batch_update_mirror_topic_status_cmd&,
-      const batch_update_mirror_topic_status_cmd&)
-      = default;
+      const batch_update_mirror_topic_status_cmd&) = default;
 
     auto serde_fields() { return std::tie(status, topics); }
 };


### PR DESCRIPTION
Clang format was stale on this PR: https://github.com/redpanda-data/redpanda/pull/30089 after the recent clang format changes.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
