### PR TITLE
[v25.3.x] CORE-15653 crypto/ossl: prevent openssl.cnf loading

### DIFF
--- a/src/v/crypto/ossl_context_service.cc
+++ b/src/v/crypto/ossl_context_service.cc
@@ -115,9 +115,7 @@ initialize_result<initialize_return> initialize_openssl(
         vlog(lg.debug, "Set default properties to \"fips=yes\"");
     }
 
-    if (!OPENSSL_init_ssl(
-          OPENSSL_INIT_LOAD_SSL_STRINGS | OPENSSL_INIT_NO_LOAD_CONFIG,
-          nullptr)) {
+    if (!OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS, nullptr)) {
         return make_ssl_error_response("Failed to initialize OpenSSL");
     }
 
@@ -191,6 +189,46 @@ public:
 
     ss::future<> start() {
         vlog(lg.debug, "Starting OpenSSL Context service...");
+
+        // Prevent the default OpenSSL config from being loaded (OPENSSL_CONF
+        // env var or /etc/ssl/openssl.cnf file) as we want to control the
+        // initialization of OpenSSL and avoid any incompatibilities between the
+        // OS-provided openssl.cnf and our statically linked OpenSSL version.
+        //
+        // OpenSSL uses internal RUN_ONCE guards for initialization flags.
+        // When OPENSSL_init_ssl/OPENSSL_init_crypto is called, each flag
+        // (like LOAD_CONFIG vs NO_LOAD_CONFIG) races to be the first to set
+        // its corresponding one-shot initializer. The "NO_*" flags are
+        // sticky: once NO_LOAD_CONFIG wins, subsequent calls with LOAD_CONFIG
+        // are silently ignored. By calling this early with NO_LOAD_CONFIG, we
+        // ensure no other code path can accidentally trigger config loading
+        // first.
+        //
+        // Note that most OpenSSL APIs (e.g. SSL_CTX_new) will trigger implicit
+        // initialization if it hasn't already occurred, so it's important to
+        // call this before any other OpenSSL usage.
+        if (!OPENSSL_init_crypto(OPENSSL_INIT_NO_LOAD_CONFIG, nullptr)) {
+            throw exception(make_ssl_error_response(
+              "Failed to initialize OpenSSL with NO_LOAD_CONFIG"));
+        }
+
+        // Per the OPENSSL_load_builtin_modules(3) docs: "Applications which
+        // use the configuration functions directly will need to call
+        // OPENSSL_load_builtin_modules() themselves before any other
+        // configuration code." Since NO_LOAD_CONFIG above opts out of
+        // automatic config loading (which would have called this
+        // internally), and we later call OSSL_LIB_CTX_load_config directly,
+        // we must call it ourselves.
+        //
+        // This also must happen while the thread-local default is still the
+        // global default context: the CONF module list is protected by a
+        // global RCU lock (conf_mod.c) initialized once via pthread_once
+        // with ossl_rcu_lock_new(1, NULL), which resolves NULL to the
+        // current thread-local default OSSL_LIB_CTX and permanently stores
+        // the pointer. If a custom context were the default at that point,
+        // the lock would hold a dangling pointer after that context is freed.
+        OPENSSL_load_builtin_modules();
+
         vassert(
           OSSL_LIB_CTX_get0_global_default()
             == OSSL_LIB_CTX_set0_default(nullptr),

--- a/src/v/kafka/client/test/fixture.h
+++ b/src/v/kafka/client/test/fixture.h
@@ -32,6 +32,7 @@ public:
         }).get();
         app.initialize(proxy_config(), proxy_client_config());
         app.check_environment();
+        app.wire_up_and_start_crypto_services();
         app.wire_up_and_start(*app_signal, test_mode);
     }
 

--- a/src/v/kafka/server/tests/topic_recreate_test.cc
+++ b/src/v/kafka/server/tests/topic_recreate_test.cc
@@ -145,6 +145,7 @@ public:
         }).get();
         app.initialize(proxy_config(), proxy_client_config());
         app.check_environment();
+        app.wire_up_and_start_crypto_services();
         app.wire_up_and_start(*app_signal, true);
     }
 };

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -565,7 +565,11 @@ int application::run(int ac, char** av) {
                     vlog(_log.info, "Shutdown complete.");
                 });
                 // must initialize configuration before services
-                hydrate_config(cfg);
+                auto node_cfg_yaml = hydrate_node_config(cfg);
+                // Cluster config validation uses OpenSSL (e.g. TLS cipher
+                // checks), so crypto must be initialized first.
+                wire_up_and_start_crypto_services();
+                hydrate_cluster_config(node_cfg_yaml);
                 init_crashtracker(app_signal);
                 initialize();
                 check_environment();
@@ -871,7 +875,7 @@ ss::app_template::config application::setup_app_config() {
     return app_cfg;
 }
 
-void application::hydrate_config(const po::variables_map& cfg) {
+YAML::Node application::hydrate_node_config(const po::variables_map& cfg) {
     auto raw_cfg_path = cfg["redpanda-cfg"].as<std::string>();
     // Expand ~/redpanda.yaml to the full path
     if (raw_cfg_path.starts_with("~")) {
@@ -906,18 +910,6 @@ void application::hydrate_config(const po::variables_map& cfg) {
 
         throw;
     }
-
-    auto config_printer = [this](std::string_view service, const auto& cfg) {
-        std::vector<ss::sstring> items;
-        cfg.for_each([&items, &service](const auto& item) {
-            items.push_back(
-              ssx::sformat("{}.{}\t- {}", service, item, item.desc()));
-        });
-        std::sort(items.begin(), items.end());
-        for (const auto& item : items) {
-            vlog(_log.info, "{}", item);
-        }
-    };
 
     ss::smp::invoke_on_all([&config, cfg_path] {
         config::node().load(cfg_path, config);
@@ -957,6 +949,22 @@ void application::hydrate_config(const po::variables_map& cfg) {
                 .as<std::vector<config::node_id_override>>());
         }).get();
     }
+
+    return config;
+}
+
+void application::hydrate_cluster_config(const YAML::Node& config) {
+    auto config_printer = [this](std::string_view service, const auto& cfg) {
+        std::vector<ss::sstring> items;
+        cfg.for_each([&items, &service](const auto& item) {
+            items.push_back(
+              ssx::sformat("{}.{}\t- {}", service, item, item.desc()));
+        });
+        std::sort(items.begin(), items.end());
+        for (const auto& item : items) {
+            vlog(_log.info, "{}", item);
+        }
+    };
 
     // This includes loading from local bootstrap file or legacy
     // config file on first-start or upgrade cases.
@@ -2966,7 +2974,6 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
     construct_service(_as).get();
 
     // Bootstrap services.
-    wire_up_and_start_crypto_services();
     wire_up_bootstrap_services();
     start_bootstrap_services();
 

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -221,11 +221,11 @@ public:
         return _datalake_coordinator_fe;
     }
 
-private:
     // Constructs and starts the services required to provide cryptographic
-    // algorithm support to Redpanda
+    // algorithm support to Redpanda. Public for test fixture access.
     void wire_up_and_start_crypto_services();
 
+private:
     // Constructs services across shards required to get bootstrap metadata.
     void wire_up_bootstrap_services();
 
@@ -253,7 +253,8 @@ private:
     // All methods are calleds from Seastar thread
     ss::app_template::config setup_app_config();
     void validate_arguments(const po::variables_map&);
-    void hydrate_config(const po::variables_map&);
+    YAML::Node hydrate_node_config(const po::variables_map&);
+    void hydrate_cluster_config(const YAML::Node& config);
 
     bool requires_cloud_io();
 

--- a/src/v/redpanda/tests/fixture.cc
+++ b/src/v/redpanda/tests/fixture.cc
@@ -126,6 +126,7 @@ redpanda_thread_fixture::redpanda_thread_fixture(
           audit_log_client_config(kafka_port),
           sch_groups);
         app.check_environment();
+        app.wire_up_and_start_crypto_services();
         app.wire_up_and_start(*app_signal, true);
     } catch (...) {
         // shutdown half-initialized app nicely so that its destructor doesn't
@@ -340,6 +341,7 @@ void redpanda_thread_fixture::restart(should_wipe w) {
     }).get();
     app.initialize(proxy_config(), proxy_client_config());
     app.check_environment();
+    app.wire_up_and_start_crypto_services();
     app.wire_up_and_start(*app_signal, true);
 }
 

--- a/src/v/security/license.cc
+++ b/src/v/security/license.cc
@@ -28,29 +28,34 @@ namespace security {
 namespace crypto {
 
 namespace {
-const ::crypto::key public_key = []() {
-    static const ss::sstring public_key_material
-      = "-----BEGIN PUBLIC KEY-----\n"
-        "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt0Y2jGOLI70xkF4rmpNM\n"
-        "hBqU3cUrwYCREgjT9TT77KusvhPVc16cdK83bpaGQy+Or1WyZpN+TCxT2vlaZet6\n"
-        "RDo+55jRk7epazAHx9s+DLd6IzhSXakf6Sxh5JRK7Zn/75C1hYJMspcJ75EhLv4H\n"
-        "qXj12dkyivcLAecGhWdIGK95J0P7f4EQQGwGL3rilCSlfkVVmE4qaPUaLqULKelq\n"
-        "7T2d+AklR+KwgtHINyKDPJ9+cCAMoEOrRBDPjcQ79k0yvP3BdHV394F+2Vt/AYOL\n"
-        "dcVQBm3tqIySLGFtiJp+RIa+nJhMrd+G4sqwm4FhsmG35Fbr0XQJY0sM6MaFJcDH\n"
-        "swIDAQAB\n"
-        "-----END PUBLIC KEY-----\n";
-    return ::crypto::key::load_key(
-      public_key_material,
-      ::crypto::format_type::PEM,
-      ::crypto::is_private_key_t::no);
-}();
+const ::crypto::key& public_key() {
+    // Defer the loading of the public key until OpenSSL has been initialized by
+    // ossl_context_service
+    static const ::crypto::key result = []() {
+        static const ss::sstring public_key_material
+          = "-----BEGIN PUBLIC KEY-----\n"
+            "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt0Y2jGOLI70xkF4rmpNM\n"
+            "hBqU3cUrwYCREgjT9TT77KusvhPVc16cdK83bpaGQy+Or1WyZpN+TCxT2vlaZet6\n"
+            "RDo+55jRk7epazAHx9s+DLd6IzhSXakf6Sxh5JRK7Zn/75C1hYJMspcJ75EhLv4H\n"
+            "qXj12dkyivcLAecGhWdIGK95J0P7f4EQQGwGL3rilCSlfkVVmE4qaPUaLqULKelq\n"
+            "7T2d+AklR+KwgtHINyKDPJ9+cCAMoEOrRBDPjcQ79k0yvP3BdHV394F+2Vt/AYOL\n"
+            "dcVQBm3tqIySLGFtiJp+RIa+nJhMrd+G4sqwm4FhsmG35Fbr0XQJY0sM6MaFJcDH\n"
+            "swIDAQAB\n"
+            "-----END PUBLIC KEY-----\n";
+        return ::crypto::key::load_key(
+          public_key_material,
+          ::crypto::format_type::PEM,
+          ::crypto::is_private_key_t::no);
+    }();
+    return result;
+}
 
 /// The redpanda license is comprised of 2 sections seperated by a delimiter.
 /// The first section is the data section (base64 encoded), the second being the
 /// signature, which is a PCKS1.5 sigature of the contents of the data section.
 bool verify_license(const ss::sstring& data, const ss::sstring& signature) {
     return ::crypto::verify_signature(
-      ::crypto::digest_type::SHA256, public_key, data, signature);
+      ::crypto::digest_type::SHA256, public_key(), data, signature);
 }
 } // namespace
 

--- a/tests/rptest/tests/openssl_config_test.py
+++ b/tests/rptest/tests/openssl_config_test.py
@@ -85,8 +85,14 @@ class OpenSSLConfigIsolationTest(RedpandaTest):
     # Path on the node where we'll write the restrictive OpenSSL config
     RESTRICTIVE_CONFIG_PATH = "/tmp/restrictive_openssl.cnf"
 
+    # Same as the default value of tls_v1_3_cipher_suites, but reordered to trigger config validation
+    REORDERED_DEFAULT_CIPHERS = "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_AES_128_CCM_SHA256:TLS_CHACHA20_POLY1305_SHA256"
+
     def __init__(self, test_context: TestContext):
-        super(OpenSSLConfigIsolationTest, self).__init__(test_context)
+        super(OpenSSLConfigIsolationTest, self).__init__(
+            test_context,
+            extra_rp_conf={"tls_v1_3_cipher_suites": self.REORDERED_DEFAULT_CIPHERS},
+        )
         self.security = SecurityConfig()
         self.tls = TLSCertManager(self.logger)
 

--- a/tests/rptest/tests/openssl_config_test.py
+++ b/tests/rptest/tests/openssl_config_test.py
@@ -1,0 +1,221 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import socket
+import subprocess
+
+from ducktape.cluster.cluster import ClusterNode
+from ducktape.services.service import Service
+from ducktape.tests.test import TestContext
+
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import (
+    SecurityConfig,
+    TLSProvider,
+)
+from rptest.services.tls import (
+    Certificate,
+    CertificateAuthority,
+    TLSCertManager,
+)
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class OpenSSLConfigTestProvider(TLSProvider):
+    """Simple TLS provider for the OpenSSL config isolation test."""
+
+    def __init__(self, tls: TLSCertManager):
+        self._tls = tls
+
+    @property
+    def ca(self) -> CertificateAuthority:
+        return self._tls.ca
+
+    def create_broker_cert(self, service: Service, node: ClusterNode) -> Certificate:
+        assert node in service.nodes
+        return self._tls.create_cert(node.name)
+
+    def create_service_client_cert(self, service: Service, name: str) -> Certificate:
+        return self._tls.create_cert(socket.gethostname(), name=name)
+
+
+# OpenSSL config that restricts TLS to version 1.2 maximum
+# If this config is loaded by Redpanda, TLS 1.3 handshakes will fail
+RESTRICTIVE_OPENSSL_CNF = """
+# OpenSSL config that blocks TLS 1.3
+openssl_conf = openssl_init
+
+[openssl_init]
+ssl_conf = ssl_sect
+
+[ssl_sect]
+system_default = system_default_sect
+
+[system_default_sect]
+# This setting would prevent TLS 1.3 connections if loaded
+MaxProtocol = TLSv1.2
+"""
+
+
+class OpenSSLConfigIsolationTest(RedpandaTest):
+    """
+    Test that Redpanda does not load the system's openssl.cnf file.
+
+    This test verifies the fix for the OpenSSL initialization ordering bug
+    where Redpanda could unintentionally pick up the OS's OPENSSL_CONF-configured
+    openssl.cnf file, causing wrong crypto behavior.
+
+    The test works by:
+    1. Creating a custom openssl.cnf that sets MaxProtocol = TLSv1.2
+    2. Setting OPENSSL_CONF to point to this restrictive config
+    3. Starting Redpanda with TLS enabled
+    4. Attempting a TLS 1.3 handshake
+
+    If Redpanda incorrectly loads the system config, TLS 1.3 would be blocked
+    and the handshake would fail. If Redpanda correctly ignores the system
+    config (using OPENSSL_INIT_NO_LOAD_CONFIG), TLS 1.3 should succeed.
+    """
+
+    # Path on the node where we'll write the restrictive OpenSSL config
+    RESTRICTIVE_CONFIG_PATH = "/tmp/restrictive_openssl.cnf"
+
+    def __init__(self, test_context: TestContext):
+        super(OpenSSLConfigIsolationTest, self).__init__(test_context)
+        self.security = SecurityConfig()
+        self.tls = TLSCertManager(self.logger)
+
+    def setUp(self):
+        # Configure TLS
+        self.security.tls_provider = OpenSSLConfigTestProvider(tls=self.tls)
+        self.redpanda.set_security_settings(self.security)
+
+        # Create a client certificate for testing TLS connections
+        # The Kafka listener requires client certificate authentication
+        self._client_cert = self.tls.create_cert(
+            socket.gethostname(), name="test_client"
+        )
+
+        # Write the restrictive OpenSSL config to each node
+        for node in self.redpanda.nodes:
+            node.account.create_file(
+                self.RESTRICTIVE_CONFIG_PATH, RESTRICTIVE_OPENSSL_CNF
+            )
+
+        # Set OPENSSL_CONF environment variable to point to the restrictive config
+        # If Redpanda loads this config, TLS 1.3 will be blocked
+        self.redpanda.set_environment({"OPENSSL_CONF": self.RESTRICTIVE_CONFIG_PATH})
+
+        # Start Redpanda with TLS enabled
+        super().setUp()
+
+    def _verify_tls_version_works(
+        self, node: ClusterNode, tls_version: str, port: int
+    ) -> bool:
+        """
+        Attempt a TLS handshake with the specified version.
+
+        Returns True if the handshake succeeds, False if it fails.
+        """
+        # Include client certificate since Kafka listener requires client auth
+        cmd = (
+            f"openssl s_client {tls_version} "
+            f"-CAfile {self.tls.ca.crt} "
+            f"-cert {self._client_cert.crt} "
+            f"-key {self._client_cert.key} "
+            f"-connect {node.name}:{port}"
+        )
+        self.logger.debug(f"Running: {cmd}")
+
+        try:
+            output = subprocess.check_output(
+                cmd.split(),
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                timeout=10,
+            )
+            output_str = output.decode()
+            # Check for successful verification
+            return (
+                "Verify return code: 0" in output_str
+                or "Verify return code: 19" in output_str
+            )
+        except subprocess.CalledProcessError as e:
+            output_str = e.output.decode()
+            self.logger.debug(f"TLS command output: {output_str}")
+
+            # Check for TLS version-specific errors FIRST - these indicate the
+            # protocol version was rejected. Note: "Verify return code: 0" can
+            # be misleading when the handshake fails before certificate exchange
+            # (nothing to verify means verification "succeeds" vacuously)
+            tls_version_errors = [
+                "no protocols available",
+                "tlsv1 alert protocol version",
+                "wrong version number",
+                "unsupported protocol",
+            ]
+            if any(err in output_str for err in tls_version_errors):
+                self.logger.debug("TLS version negotiation failed")
+                return False
+
+            # Check that a cipher was actually negotiated (not "(NONE)")
+            # If no cipher was negotiated, the TLS handshake failed
+            if "Cipher is (NONE)" in output_str:
+                self.logger.debug("TLS handshake failed - no cipher negotiated")
+                return False
+
+            # Check for successful verification - openssl s_client may return
+            # non-zero even when TLS handshake succeeded (e.g., server closes
+            # connection after handshake)
+            if (
+                "Verify return code: 0" in output_str
+                or "Verify return code: 19" in output_str
+            ):
+                self.logger.debug("TLS verification succeeded")
+                return True
+
+            # For other errors (like generic handshake failures), log and fail
+            self.logger.debug("TLS handshake failed for non-version reason")
+            return False
+        except subprocess.TimeoutExpired:
+            self.logger.error("TLS handshake timed out")
+            return False
+
+    @cluster(num_nodes=1)
+    def test_system_openssl_config_not_loaded(self):
+        """
+        Verify that Redpanda ignores the system's OPENSSL_CONF setting.
+
+        This test sets OPENSSL_CONF to a config that blocks TLS 1.3, then
+        verifies that TLS 1.3 handshakes still succeed. This proves Redpanda
+        is using OPENSSL_INIT_NO_LOAD_CONFIG to prevent loading the system
+        config.
+        """
+        node = self.redpanda.nodes[0]
+        kafka_port = 9092
+
+        # First verify TLS 1.2 works (baseline - should work regardless)
+        self.logger.info("Verifying TLS 1.2 works (baseline check)")
+        tls12_works = self._verify_tls_version_works(node, "-tls1_2", kafka_port)
+        assert tls12_works, "TLS 1.2 should work - this is a baseline check"
+
+        # Now verify TLS 1.3 works - this is the actual test
+        # If OPENSSL_CONF was loaded, TLS 1.3 would be blocked by MaxProtocol=TLSv1.2
+        self.logger.info("Verifying TLS 1.3 works (proves system config not loaded)")
+        tls13_works = self._verify_tls_version_works(node, "-tls1_3", kafka_port)
+
+        assert tls13_works, (
+            "TLS 1.3 handshake failed! This suggests Redpanda loaded the "
+            "system's OPENSSL_CONF which has MaxProtocol=TLSv1.2. "
+            "Redpanda should use OPENSSL_INIT_NO_LOAD_CONFIG to prevent this."
+        )
+
+        self.logger.info(
+            "SUCCESS: TLS 1.3 works despite OPENSSL_CONF setting MaxProtocol=TLSv1.2. "
+            "This proves Redpanda correctly ignores the system OpenSSL config."
+        )


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/29763
Resolves https://github.com/redpanda-data/redpanda/issues/30143

Conflict resolution notes:
- `application_bootstrap.cc` (modify/delete): This file doesn't exist on v25.3.x — `wire_up_and_start()` lives in `application.cc`. Removed the `wire_up_and_start_crypto_services()` call from `wire_up_and_start()` in `application.cc` instead, matching the intent of the original commit.
- `fixture.cc` (content conflict): Added the `wire_up_and_start_crypto_services()` call before `wire_up_and_start()`, but kept the v25.3.x signature (no `ct_test_cfg` parameter).