### PR TITLE
rpk: add `rpk check` as a managed plugin for production readiness validation

### DIFF
--- a/src/go/rpk/pkg/cli/BUILD
+++ b/src/go/rpk/pkg/cli/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//src/go/rpk/pkg/cli/acl",
         "//src/go/rpk/pkg/cli/ai",
         "//src/go/rpk/pkg/cli/benchmark",
+        "//src/go/rpk/pkg/cli/check",
         "//src/go/rpk/pkg/cli/cloud",
         "//src/go/rpk/pkg/cli/cluster",
         "//src/go/rpk/pkg/cli/connect",

--- a/src/go/rpk/pkg/cli/check/BUILD
+++ b/src/go/rpk/pkg/cli/check/BUILD
@@ -1,0 +1,25 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "check",
+    srcs = [
+        "check.go",
+        "client.go",
+        "install.go",
+        "uninstall.go",
+        "upgrade.go",
+    ],
+    importpath = "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/check",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/go/rpk/pkg/cobraext",
+        "//src/go/rpk/pkg/config",
+        "//src/go/rpk/pkg/osutil",
+        "//src/go/rpk/pkg/out",
+        "//src/go/rpk/pkg/plugin",
+        "//src/go/rpk/pkg/redpanda",
+        "@com_github_spf13_afero//:afero",
+        "@com_github_spf13_cobra//:cobra",
+        "@org_uber_go_zap//:zap",
+    ],
+)

--- a/src/go/rpk/pkg/cli/check/check.go
+++ b/src/go/rpk/pkg/cli/check/check.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package check
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cobraext"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+// injectProfileArgs adds admin API connection flags derived from the current
+// rpk profile to pluginArgs, unless the user already passed them explicitly.
+// This lets 'rpk check' work against remote clusters by inheriting admin_api
+// and kafka_api settings from the active profile (same as other rpk commands).
+func injectProfileArgs(p *config.Params, fs afero.Fs, pluginArgs []string) []string {
+	cfg, err := p.Load(fs)
+	if err != nil {
+		zap.L().Debug("unable to load rpk config; skipping profile arg injection", zap.Error(err))
+		return pluginArgs
+	}
+	profile := cfg.VirtualProfile()
+	a := &profile.AdminAPI
+	if len(a.Addresses) > 0 && !hasFlag(pluginArgs, "--admin-url") {
+		pluginArgs = append(pluginArgs, "--admin-url", strings.Join(a.Addresses, ","))
+	}
+	if tls := a.TLS; tls != nil {
+		if tls.TruststoreFile != "" && !hasFlag(pluginArgs, "--admin-tls-ca") {
+			pluginArgs = append(pluginArgs, "--admin-tls-ca", tls.TruststoreFile)
+		}
+		if tls.CertFile != "" && !hasFlag(pluginArgs, "--admin-tls-cert") {
+			pluginArgs = append(pluginArgs, "--admin-tls-cert", tls.CertFile)
+		}
+		if tls.KeyFile != "" && !hasFlag(pluginArgs, "--admin-tls-key") {
+			pluginArgs = append(pluginArgs, "--admin-tls-key", tls.KeyFile)
+		}
+		if tls.InsecureSkipVerify && !hasFlag(pluginArgs, "--admin-tls-skip-verify") {
+			pluginArgs = append(pluginArgs, "--admin-tls-skip-verify")
+		}
+	}
+	if profile.KafkaAPI.SASL != nil {
+		sasl := profile.KafkaAPI.SASL
+		if sasl.User != "" && !hasFlag(pluginArgs, "--sasl-user") {
+			pluginArgs = append(pluginArgs, "--sasl-user", sasl.User)
+		}
+		// Pass the SASL password via REDPANDA_SASL_PASSWORD on the plugin
+		// subprocess rather than appending --sasl-password to argv, so it
+		// can't leak through process listings (ps, /proc/<pid>/cmdline)
+		// or the plugin-args debug log below. The plugin reads from this
+		// env var as of redpanda-check v0.1.3 with the flag retained as
+		// a fallback for explicit-flag callers.
+		if sasl.Password != "" && os.Getenv("REDPANDA_SASL_PASSWORD") == "" {
+			os.Setenv("REDPANDA_SASL_PASSWORD", sasl.Password)
+		}
+	}
+	return pluginArgs
+}
+
+func NewCommand(fs afero.Fs, p *config.Params, execFn func(string, []string) error) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                "check",
+		Short:              "Run production readiness checks for a Redpanda deployment",
+		DisableFlagParsing: true,
+		Args:               cobra.MinimumNArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			pluginArgs, err := parseCheckFlags(p, cmd, args)
+			out.MaybeDie(err, "unable to parse flags: %v", err)
+
+			// Help short-circuit. Done before profile-arg injection so an
+			// injected --admin-url value can't make the auto-install
+			// heuristic below think the user wants to run the plugin.
+			if cmd.Flags().Changed("help") {
+				cmd.Help()
+				return
+			}
+
+			check, pluginExists := plugin.ListPlugins(fs, plugin.UserPaths()).Find("check")
+			var pluginPath string
+			if !pluginExists {
+				// Decide whether to auto-install based on user-supplied args
+				// (profile injection hasn't run yet). Anything beyond bare
+				// help / version metadata is treated as intent to run the
+				// plugin, including key=value flag forms like
+				// --admin-url=<addr> that the previous heuristic missed.
+				var wantsRun bool
+				for _, arg := range pluginArgs {
+					switch arg {
+					case "--version":
+						fmt.Println("cannot get check version: redpanda-check is not installed; run 'rpk check install'")
+						cmd.Help()
+						return
+					case "--help", "-h":
+						// metadata-only; not enough to trigger an install
+					default:
+						wantsRun = true
+					}
+				}
+				if !wantsRun {
+					cmd.Help()
+					return
+				}
+				fmt.Fprintln(os.Stderr, "Downloading latest Redpanda Check")
+				path, _, err := installCheck(cmd.Context(), fs, "latest")
+				out.MaybeDie(err, "unable to install redpanda check: %v; you may install 'redpanda-check' manually", err)
+				pluginPath = path
+			} else {
+				pluginPath = check.Path
+				if !check.Managed {
+					zap.L().Sugar().Warn("rpk is using a self-managed version of Redpanda Check. If you want rpk to manage check, use rpk check uninstall && rpk check install.")
+				}
+			}
+
+			// Inject profile-derived connection info only when actually
+			// running checks. Skip for --version (metadata only, no need
+			// to set REDPANDA_SASL_PASSWORD on the rpk process env).
+			if !contains(pluginArgs, "--version") {
+				pluginArgs = injectProfileArgs(p, fs, pluginArgs)
+			}
+
+			zap.L().Debug("executing check plugin", zap.String("path", pluginPath), zap.Strings("args", pluginArgs))
+			err = execFn(pluginPath, pluginArgs)
+			out.MaybeDie(err, "unable to execute redpanda check plugin: %v", err)
+		},
+	}
+	// Declared so it shows up in 'rpk check --help'. Pass-through is wired
+	// in parseCheckFlags below; the actual print is handled by the plugin
+	// (or by the no-plugin-installed branch in Run).
+	cmd.Flags().Bool("version", false, "Print the installed redpanda-check plugin version")
+	cmd.AddCommand(
+		installCommand(fs),
+		uninstallCommand(fs),
+		upgradeCommand(fs),
+	)
+	return cmd
+}
+
+func parseCheckFlags(p *config.Params, cmd *cobra.Command, args []string) ([]string, error) {
+	f := cmd.Flags()
+	keepForPlugin, stripForRpk := cobraext.StripFlagset(args, f)
+	if err := f.Parse(stripForRpk); err != nil {
+		return nil, err
+	}
+	zap.ReplaceGlobals(p.BuildLogger())
+	if cobraext.LongFlagValue(args, f, "help", "h") == "true" && !contains(keepForPlugin, "--help") {
+		keepForPlugin = append(keepForPlugin, "--help")
+	}
+	if cobraext.LongFlagValue(args, f, "version", "") == "true" && !contains(keepForPlugin, "--version") {
+		keepForPlugin = append(keepForPlugin, "--version")
+	}
+	return keepForPlugin, nil
+}
+
+func hasFlag(args []string, flag string) bool {
+	for _, a := range args {
+		if a == flag || strings.HasPrefix(a, flag+"=") {
+			return true
+		}
+	}
+	return false
+}
+
+func contains(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/src/go/rpk/pkg/cli/check/client.go
+++ b/src/go/rpk/pkg/cli/check/client.go
@@ -1,0 +1,21 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package check
+
+import "github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
+
+const (
+	checkPluginSlug  = "check"
+	checkDisplayName = "Redpanda Check"
+)
+
+func newRepoClient() (*plugin.RepoClient, error) {
+	return plugin.NewRepoClient(checkPluginSlug, checkDisplayName)
+}

--- a/src/go/rpk/pkg/cli/check/install.go
+++ b/src/go/rpk/pkg/cli/check/install.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package check
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	rpkos "github.com/redpanda-data/redpanda/src/go/rpk/pkg/osutil"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+func installCommand(fs afero.Fs) *cobra.Command {
+	var (
+		version string
+		force   bool
+	)
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Install Redpanda Check",
+		Long: `Install Redpanda Check
+
+This command installs the latest version by default.
+
+Alternatively, you may specify a version using the --check-version flag.
+
+You may force the installation using the --force flag.
+`,
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
+			version = strings.ToLower(version)
+			err := validateVersion(version)
+			out.MaybeDieErr(err)
+			_, installed := plugin.ListPlugins(fs, plugin.UserPaths()).Find("check")
+			if installed && !force {
+				if version != "latest" {
+					out.Exit("Redpanda Check is already installed. Use --force to force installation, or delete current version with 'rpk check uninstall' first")
+				}
+				out.Exit("Redpanda Check is already installed.\nIf you want to upgrade to the latest version, please run 'rpk check upgrade'.")
+			}
+			_, installedVersion, err := installCheck(cmd.Context(), fs, version)
+			out.MaybeDie(err, "unable to install redpanda check: %v; you may install 'redpanda-check' manually", err)
+
+			fmt.Printf("Redpanda Check %v successfully installed.\n", installedVersion)
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "Force install of Redpanda Check")
+	cmd.Flags().StringVar(&version, "check-version", "latest", "Redpanda Check version to install (e.g. 0.1.0)")
+	return cmd
+}
+
+func installCheck(ctx context.Context, fs afero.Fs, version string) (path, installedVersion string, err error) {
+	pluginDir, err := plugin.DefaultBinPath()
+	if err != nil {
+		return "", "", fmt.Errorf("unable to determine plugin default path: %v", err)
+	}
+
+	art, ver, err := getCheckArtifact(ctx, version)
+	if err != nil {
+		return "", "", err
+	}
+	path, err = downloadAndInstallCheck(ctx, fs, pluginDir, art.Path, art.Sha256)
+	return path, ver, err
+}
+
+func getCheckArtifact(ctx context.Context, version string) (plugin.RepoArtifact, string, error) {
+	plCl, err := newRepoClient()
+	if err != nil {
+		return plugin.RepoArtifact{}, "", err
+	}
+	manifest, err := plCl.Manifest(ctx)
+	if err != nil {
+		return plugin.RepoArtifact{}, "", err
+	}
+	if version == "latest" || version == "" {
+		return manifest.LatestArtifact(checkDisplayName)
+	}
+	art, err := manifest.ArtifactVersion(checkDisplayName, version)
+	if err != nil {
+		return plugin.RepoArtifact{}, "", err
+	}
+	return art, version, nil
+}
+
+func downloadAndInstallCheck(ctx context.Context, fs afero.Fs, installPath, downloadURL, expShaPrefix string) (string, error) {
+	bin, err := plugin.Download(ctx, downloadURL, true, expShaPrefix)
+	if err != nil {
+		return "", fmt.Errorf("unable to download Redpanda Check from %q: %v", downloadURL, err)
+	}
+
+	if exists, _ := afero.DirExists(fs, installPath); !exists {
+		if rpkos.IsRunningSudo() {
+			return "", fmt.Errorf("detected rpk is running with sudo; please execute this command without sudo to avoid saving the plugin as a root owned binary in %s", installPath)
+		}
+		if err := fs.MkdirAll(installPath, 0o755); err != nil {
+			return "", fmt.Errorf("unable to create plugin directory %s: %v", installPath, err)
+		}
+	}
+	zap.L().Sugar().Debugf("writing Redpanda Check plugin to %v", installPath)
+	path, err := plugin.WriteBinary(fs, "check", installPath, bin, false, true)
+	if err != nil {
+		return "", fmt.Errorf("unable to write Redpanda Check plugin: %v", err)
+	}
+	return path, nil
+}
+
+func validateVersion(version string) error {
+	if version == "latest" {
+		return nil
+	}
+	vMatch := regexp.MustCompile(`^v?\d{1,2}\.\d{1,2}\.\d{1,2}`).MatchString(version)
+	if !vMatch {
+		return fmt.Errorf("provided version %q is not valid. Ensure it is either 'latest' or follows the format MAJOR.MINOR.PATCH (e.g., 0.1.0)", version)
+	}
+	return nil
+}

--- a/src/go/rpk/pkg/cli/check/uninstall.go
+++ b/src/go/rpk/pkg/cli/check/uninstall.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package check
+
+import (
+	"os"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func uninstallCommand(fs afero.Fs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Uninstall the Redpanda Check plugin",
+		Args:  cobra.NoArgs,
+		Run: func(_ *cobra.Command, _ []string) {
+			check, pluginExists := plugin.ListPlugins(fs, plugin.UserPaths()).Find("check")
+			if !pluginExists {
+				out.Exit("The Redpanda Check managed plugin is not installed!")
+			}
+			ops, anyFailed := check.Uninstall(true)
+			tw := out.NewTable("PATH", "MESSAGE")
+			defer func() {
+				tw.Flush()
+				if anyFailed {
+					os.Exit(1)
+				}
+			}()
+			for _, o := range ops {
+				tw.Print(o.Path, o.Message)
+			}
+		},
+	}
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/check/upgrade.go
+++ b/src/go/rpk/pkg/cli/check/upgrade.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package check
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/redpanda"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func upgradeCommand(fs afero.Fs) *cobra.Command {
+	var noConfirm bool
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Upgrade to the latest Redpanda Check version",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
+			pluginDir, err := plugin.DefaultBinPath()
+			out.MaybeDie(err, "unable to determine managed plugin path: %v", err)
+			check, pluginExists := plugin.ListPlugins(fs, plugin.UserPaths()).Find("check")
+			if !pluginExists {
+				out.Die("unable to find Redpanda Check plugin. You may install it running 'rpk check install'")
+			}
+			if !check.Managed {
+				out.Die("found a self-managed Redpanda Check plugin; unfortunately, we cannot upgrade it with this installation. Run rpk check uninstall && rpk check install, or manage the binary manually")
+			}
+			art, version, err := getCheckArtifact(cmd.Context(), "latest")
+			out.MaybeDieErr(err)
+
+			currentSha, err := plugin.Sha256Path(fs, check.Path)
+			out.MaybeDie(err, "unable to determine the sha256sum of current Redpanda Check %q: %v", check.Path, err)
+
+			if strings.HasPrefix(currentSha, art.Sha256) {
+				out.Exit("Redpanda Check already up-to-date")
+			}
+			currentVersion, err := checkVersion(cmd.Context(), check.Path)
+			out.MaybeDie(err, "unable to determine current version of Redpanda Check: %v", err)
+
+			if !noConfirm {
+				latestVersion, err := redpanda.VersionFromString(version)
+				out.MaybeDie(err, "unable to parse latest version of Redpanda Check: %v", err)
+				if latestVersion.Major > currentVersion.Major {
+					confirmed, err := out.Confirm("Confirm major version upgrade from %v to %v?", currentVersion.String(), latestVersion.String())
+					out.MaybeDie(err, "unable to confirm upgrade: %v", err)
+					if !confirmed {
+						out.Exit("Upgrade canceled.")
+					}
+				}
+			}
+
+			_, err = downloadAndInstallCheck(cmd.Context(), fs, pluginDir, art.Path, art.Sha256)
+			out.MaybeDieErr(err)
+
+			fmt.Printf("Redpanda Check successfully upgraded from %v to the latest version (%v).\n", currentVersion.String(), version)
+		},
+	}
+	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Disable confirmation prompt for major version upgrades")
+	return cmd
+}
+
+func checkVersion(ctx context.Context, checkPath string) (redpanda.Version, error) {
+	versionCmd := exec.CommandContext(ctx, checkPath, "--version")
+	var sb strings.Builder
+	versionCmd.Stdout = &sb
+	if err := versionCmd.Run(); err != nil {
+		return redpanda.Version{}, err
+	}
+	// The redpanda-check binary outputs just the version string (e.g. "0.1.0")
+	versionStr := strings.TrimSpace(sb.String())
+	version, err := redpanda.VersionFromString(versionStr)
+	if err != nil {
+		return redpanda.Version{}, fmt.Errorf("unable to determine version from %q: %v", versionStr, err)
+	}
+	return version, nil
+}

--- a/src/go/rpk/pkg/cli/root.go
+++ b/src/go/rpk/pkg/cli/root.go
@@ -23,6 +23,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/acl"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/ai"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/benchmark"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/check"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cloud"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/connect"
@@ -91,6 +92,17 @@ Use --print-tree to emit the full command tree as JSON.`,
 	pf := root.PersistentFlags()
 
 	searchLocal, _ := os.UserConfigDir()
+	if home, _ := os.UserHomeDir(); home != "" {
+		// Match exact-home or home followed by a separator; a plain
+		// HasPrefix would also match e.g. home `/home/al` against config
+		// dir `/home/alice/...` and emit an incorrect `~`-prefixed path.
+		switch {
+		case searchLocal == home:
+			searchLocal = "~"
+		case strings.HasPrefix(searchLocal, home+string(os.PathSeparator)):
+			searchLocal = "~" + searchLocal[len(home):]
+		}
+	}
 	if searchLocal == "" {
 		searchLocal = "~/.config"
 	}
@@ -128,6 +140,7 @@ Use --print-tree to emit the full command tree as JSON.`,
 		cloud.NewCommand(fs, p, osExec),
 		cluster.NewCommand(fs, p),
 		container.NewCommand(fs, p),
+		check.NewCommand(fs, p, osExec),
 		connect.NewCommand(fs, p, osExec),
 		profile.NewCommand(fs, p),
 		debug.NewCommand(fs, p),

--- a/src/go/rpk/pkg/cli/root_linux.go
+++ b/src/go/rpk/pkg/cli/root_linux.go
@@ -28,17 +28,12 @@ func addPlatformDependentCmds(fs afero.Fs, p *config.Params, cmd *cobra.Command)
 
 	// deprecated
 	cmd.AddCommand(
-		newCheckCommand(fs, p),
 		newConfigCommand(fs, p),
 		newModeCommand(fs, p),
 		newStartCommand(fs, p, rp.NewLauncher()),
 		newStopCommand(fs, p),
 		newTuneCommand(fs, p),
 	)
-}
-
-func newCheckCommand(fs afero.Fs, p *config.Params) *cobra.Command {
-	return cobraext.DeprecateCmd(redpanda.NewCheckCommand(fs, p), "rpk redpanda check")
 }
 
 func newConfigCommand(fs afero.Fs, p *config.Params) *cobra.Command {


### PR DESCRIPTION
Replace the deprecated `rpk check` command (deprecated since January 2021) with a managed plugin that validates Redpanda deployments against the official production readiness checklists.

The plugin binary lives in a separate repo ([redpanda-check](https://github.com/vuldin/redpanda-check)) and runs 30 checks covering cluster health, security, resource allocation, and Kubernetes best practices. rpk manages the plugin lifecycle (install, upgrade, uninstall) and injects admin API connection details from the active rpk profile before exec. This follows the same managed plugin pattern as `rpk connect`.

The `redpanda-check` repo contains the source, GoReleaser config, and the same `plugin_uploader` pipeline used by the connect repo to publish artifacts to S3 and generate the manifest at `rpk-plugins.redpanda.com`. To enable publishing, the repo needs to move to `redpanda-data/redpanda-check` and be granted IAM access to the `rpk-plugins-repo` S3 bucket. Once that is done, `rpk check install` will auto-download the binary. Until then, the binary must be placed manually for testing (see below).

RFC: https://docs.google.com/document/d/1qAl92reeEO0sGxhmbQd05FWt4NX38ZqM40JUkzvXcUM/edit

### Testing now (manual binary placement)

```bash
git clone https://github.com/vuldin/redpanda-check.git
cd redpanda-check && go build -o redpanda-check ./cmd/redpanda-check
cp redpanda-check ~/.local/bin/.rpk.managed-check

rpk check --admin-url <admin-api-addr> -v
rpk check --admin-url <admin-api-addr> --namespace <k8s-namespace> -v
```

### Testing after repo move and S3 access

```bash
rpk check install
rpk check --admin-url <admin-api-addr> -v
rpk check upgrade
rpk check uninstall
```

## Backports Required

- [x] none - not a bug fix

## Release Notes

### Features

* Add `rpk check` command as a managed plugin for production readiness validation. The plugin checks cluster health, broker configuration, security settings, replication factors, licensing, TLS, and Kubernetes resource configuration against the official production readiness checklists. Supports auto-install, upgrade, and uninstall via `rpk check install`, `rpk check upgrade`, and `rpk check uninstall`. Admin API connection details are injected automatically from the active rpk profile.
