### PR TITLE
`core`: replace unbounded `parallel_for_each()` with `max_concurrent_for_each()`

### DIFF
--- a/src/v/cluster/data_migration_backend.cc
+++ b/src/v/cluster/data_migration_backend.cc
@@ -286,8 +286,9 @@ backend::get_entities_status(id migration_id) {
           migration_id,
           groups_by_partition.size());
         errc last_errc = errc::success;
-        co_await ss::parallel_for_each(
+        co_await ss::max_concurrent_for_each(
           std::move(groups_by_partition),
+          64,
           [this, &ret, &last_errc](auto&& pair) {
               // TODO: retry per-partition
               auto&& [pid, groups] = pair;
@@ -421,8 +422,9 @@ backend::set_entities_status(id migration_id, entities_status status) {
                   });
 
                 errc last_error = errc::success;
-                co_await ss::parallel_for_each(
+                co_await ss::max_concurrent_for_each(
                   *mrstate.partition_group_map,
+                  64,
                   [&requests, this, &last_error](const auto& pair) {
                       auto& [pid, groups] = pair;
                       auto& request = requests.at(pid);

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -330,8 +330,8 @@ private:
     }
 
     ss::future<> shutdown_groups(std::vector<group_ptr> groups) {
-        return ss::parallel_for_each(
-          groups, [](auto group_ptr) { return group_ptr->shutdown(); });
+        return ss::max_concurrent_for_each(
+          groups, 64, [](auto group_ptr) { return group_ptr->shutdown(); });
     }
 
     ss::future<> collect_consumer_lag_metrics();

--- a/src/v/raft/group_manager.cc
+++ b/src/v/raft/group_manager.cc
@@ -18,6 +18,7 @@
 #include "raft/group_configuration.h"
 #include "raft/rpc_client_protocol.h"
 
+#include <seastar/core/loop.hh>
 #include <seastar/core/scheduling.hh>
 
 #include <optional>
@@ -107,8 +108,8 @@ ss::future<> group_manager::stop() {
 
     return f
       .then([this] {
-          return ss::parallel_for_each(
-            _groups, [](ss::lw_shared_ptr<consensus> raft) {
+          return ss::max_concurrent_for_each(
+            _groups, 128, [](ss::lw_shared_ptr<consensus> raft) {
                 return raft->stop().discard_result();
             });
       })

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -323,8 +323,8 @@ ss::future<std::optional<ss::sstring>> disk_log_impl::close() {
     bool errors = false;
 
     co_await _readers_cache->stop().then([this, &errors] {
-        return ss::parallel_for_each(
-          _segs, [&errors](ss::lw_shared_ptr<segment>& h) {
+        return ss::max_concurrent_for_each(
+          _segs, 128, [&errors](ss::lw_shared_ptr<segment>& h) {
               return h->close().handle_exception(
                 [&errors, h](std::exception_ptr e) {
                     vlog(stlog.error, "Error closing segment:{} - {}", e, h);

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -216,8 +216,8 @@ ss::future<> log_manager::stop() {
     _gc_sem.broken();
 
     co_await _gate.close();
-    co_await ss::coroutine::parallel_for_each(
-      _logs, [this](logs_type::value_type& entry) -> ss::future<> {
+    co_await ss::max_concurrent_for_each(
+      _logs, 128, [this](logs_type::value_type& entry) -> ss::future<> {
           auto close_fut = entry.second->housekeeping_gate.close();
           return clean_close(entry.second->handle)
             .then(

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -454,8 +454,9 @@ static ss::future<segment_set> do_recover(
         [copy = std::move(copy)](const std::exception_ptr& ex) mutable {
             return ss::do_with(
               std::move(copy), [ex](segment_set::underlying_t& segments) {
-                  return ss::parallel_for_each(
+                  return ss::max_concurrent_for_each(
                            segments,
+                           128,
                            [](segment_set::type& segment) {
                                if (segment && !segment->is_closed()) {
                                    return segment->close();

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -1107,8 +1107,9 @@ ss::future<> do_write_concatenated_compacted_index(
             std::move(readers),
             [cfg, target_path = std::move(target_path), &resources](
               chunked_vector<compacted_index_reader>& readers) mutable {
-                return ss::parallel_for_each(
+                return ss::max_concurrent_for_each(
                          readers,
+                         32,
                          [](compacted_index_reader& reader) {
                              return reader.verify_integrity();
                          })
@@ -1139,9 +1140,10 @@ ss::future<> do_write_concatenated_compacted_index(
                         std::move(writer), readers);
                   })
                   .finally([&readers] {
-                      return ss::parallel_for_each(
-                        readers,
-                        [](compacted_index_reader& r) { return r.close(); });
+                      return ss::max_concurrent_for_each(
+                        readers, 32, [](compacted_index_reader& r) {
+                            return r.close();
+                        });
                   });
             });
       });

--- a/src/v/transform/transform_manager.cc
+++ b/src/v/transform/transform_manager.cc
@@ -182,9 +182,10 @@ public:
     }
 
     ss::future<> clear() {
-        co_await ss::parallel_for_each(
+        co_await ss::max_concurrent_for_each(
           _table.begin(),
           _table.end(),
+          64,
           // NOLINTNEXTLINE(cppcoreguidelines-avoid-reference-coroutine-parameters)
           [](auto& e) { return e.second.processor()->stop(); });
         _table.clear();


### PR DESCRIPTION
The ask:

> Analyze the redpanda code base. Tell me what would be the highest value place to work on within a week, mostly done by AI programming.     

The answer:

```
  1. operator<< → format_to Migration (Highest Value)                                                                                                                                         
                                                                                                                                                                                              
  The opportunity: 1,641 operator<<(ostream&, ...) overloads in production code vs only 115 already migrated to the format_to pattern. The CLAUDE.md coding guidelines explicitly say to
  prefer format_to. This is the project's own stated direction.                                                                                                                               
                                                                  
  Why this is ideal for AI:                                                                                                                                                                   
  - Each migration is mechanical and self-contained — read the operator<< body, rewrite it as a format_to(fmt::iterator) member function, remove the free function
  - The pattern is clearly defined in src/v/base/format_to.h                                                                                                                                  
  - Low risk of correctness bugs (formatting only)          
  - Can be done subsystem-by-subsystem, PR-by-PR                                                                                                                                              
  - The team just upgraded to clang-22 and did major reformatting — this is a natural continuation of modernization                                                                           
                                                                                                                                                                                              
  Scope in 1 week: Migrate 100-200 types across 2-3 subsystems (e.g., model/ with 57 overloads, storage/ with 62, config/ with 22). Each subsystem is a clean PR.                             
                                                                                                                                                                                              
  Impact: Removes tech debt across the most foundational types, improves consistency, makes fmt::format work natively everywhere.                                                             
                                                                                                                                                                                              
  ---                                                                                                                                                                                         
  2. ss::parallel_for_each → ss::max_concurrent_for_each Audit + Fix
                                                                                                                                                                                              
  The opportunity: ~103 uses of unbounded parallel_for_each in production code, many in cluster/ (partition iteration, data migration, metadata dissemination) — exactly the "ranges that can
  grow large" the guidelines warn about.                                                                                                                                                      
                                                                  
  Why this is ideal for AI:                                                                                                                                                                   
  - Each call site needs analysis of what it iterates over (partitions? topics? nodes?)
  - If the range scales with cluster size, it should be bounded                                                                                                                               
  - Changes are small (add a concurrency limit argument)       
  - Directly prevents latency spikes and memory pressure in large clusters                                                                                                                    
                                                                                                                                                                                              
  Scope in 1 week: Audit all 103 sites, fix the ~20-30 that iterate over partitions/topics/segments.                                                                                          
                                                                                                                                                                                              
  Impact: Directly improves production stability for large clusters. This is the kind of thing that prevents oncall pages.    
```

This PR is obviously the changes for 2.


```
● The parallel_for_each audit agent is done. Here are the results:                                                                                                                            
                                                                                                                                                                                              
  parallel_for_each Audit — Complete                                                                                                                                                          
                                                                                                                                                                                              
  40 call sites audited, 10 fixed across 8 files. All builds pass.                                                                                                                            
                                                                                                                                                                                              
  Fixed (unbounded → bounded concurrency)                                                                                                                                                     
  
  ┌────────────────────────────────────────┬──────────────────────────────────┬───────┬───────────────────┐                                                                                   
  │                  File                  │         What it iterates         │ Limit │        Why        │
  ├────────────────────────────────────────┼──────────────────────────────────┼───────┼───────────────────┤                                                                                   
  │ storage/log_manager.cc                 │ All logs on shard (thousands)    │ 128   │ I/O-bound close   │
  ├────────────────────────────────────────┼──────────────────────────────────┼───────┼───────────────────┤
  │ storage/disk_log_impl.cc               │ All segments in a log (hundreds) │ 128   │ I/O-bound close   │                                                                                   
  ├────────────────────────────────────────┼──────────────────────────────────┼───────┼───────────────────┤
  │ storage/segment_set.cc                 │ Segments during error recovery   │ 128   │ I/O-bound close   │                                                                                   
  ├────────────────────────────────────────┼──────────────────────────────────┼───────┼───────────────────┤                                                                                   
  │ storage/segment_utils.cc (x2)          │ Compacted index readers          │ 32    │ Disk I/O          │
  ├────────────────────────────────────────┼──────────────────────────────────┼───────┼───────────────────┤                                                                                   
  │ raft/group_manager.cc                  │ All raft groups on shard         │ 128   │ I/O-bound stop    │
  ├────────────────────────────────────────┼──────────────────────────────────┼───────┼───────────────────┤                                                                                   
  │ kafka/server/group_manager.h           │ Consumer groups shutdown         │ 64    │ Some I/O          │
  ├────────────────────────────────────────┼──────────────────────────────────┼───────┼───────────────────┤                                                                                   
  │ transform/transform_manager.cc         │ All transform processors         │ 64    │ Stop involves I/O │
  ├────────────────────────────────────────┼──────────────────────────────────┼───────┼───────────────────┤                                                                                   
  │ cluster/data_migration_backend.cc (x2) │ Partition-group maps             │ 64    │ RPC calls         │
  └────────────────────────────────────────┴──────────────────────────────────┴───────┴───────────────────┘                                                                                   
                                                                           
  Left as-is (correctly bounded)                                                                                                                                                              
  
  ~30 call sites iterate over nodes, shards, seed servers, or already have semaphore backpressure — all safe.
```

`parallel_for_each()` launches all iterations concurrently, which creates massive memory pressure when iterating over large collections like partitions, segments, or consumer groups. Replace with `max_concurrent_for_each()` at sites where the collection can grow large.

Concurrency limits chosen based on collection size and work type:
- 128 for segments/partitions/raft groups (I/O bound stops)
- 64 for consumer groups and migration partition maps (RPC calls)
- 32 for compacted index readers (disk I/O)

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
