### PR TITLE
Revert "c/rm_stm: hold locks when taking snapshots"

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -2038,8 +2038,6 @@ ss::future<raft::stm_snapshot> rm_stm::do_take_local_snapshot(
       "Unsupported snapshot version requested: {}",
       version);
 
-    auto units = co_await _state_lock.hold_read_lock();
-
     auto start_offset = _raft->start_offset();
     vlog(
       _ctx_log.trace,
@@ -2307,9 +2305,6 @@ rm_stm::take_raft_snapshot(model::offset last_included_offset) {
     // this is always called under apply lock, so we can be sure
     // that no concurrent modifications to the state are happening via apply
     // path.
-
-    // write lock is probably excessive here because the loop below is
-    // synchronous
     auto units = co_await _state_lock.hold_write_lock();
     tx::raft_snapshot snapshot;
     auto kafka_offset = from_log_offset(last_included_offset);


### PR DESCRIPTION
This reverts commit ba6b60085cbbdfffa869654caa990ae5842735e6.

 `apply_raft_snapshot` holds `_apply_lock` (it runs through the
`state_machine_base::apply()` path or holds it explicitly), so it is
already serialized with `take_local_snapshot` via `_apply_lock`. The
added `_state_lock` read in `do_take_local_snapshot` is redundant and
introduces the deadlock.

Fixes: [CORE-16085](https://redpandadata.atlassian.net/browse/CORE-16085)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- fixes a 3-way circular deadlock can occur in `rm_stm` involving. The deadlock can happen when processing transactions 

[CORE-16085]: https://redpandadata.atlassian.net/browse/CORE-16085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ