### PR TITLE
backport: add AI-assisted conflict resolution

### DIFF
--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -125,10 +125,14 @@ jobs:
           repository: ${{ steps.user.outputs.username }}/${{ steps.user.outputs.repo }}
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           path: ./fork
+      - name: Setup uv
+        if: needs.backport-type.outputs.commented_on == 'pr'
+        uses: astral-sh/setup-uv@v4
       - name: Backport commits and get details
         if: needs.backport-type.outputs.commented_on == 'pr'
         env:
           GITHUB_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ORIG_TITLE: ${{ github.event.client_payload.github.payload.issue.title }}
           BACKPORT_COMMITS: ${{ steps.backport_commits.outputs.backport_commits }}
           IS_MERGED: ${{ github.event.client_payload.pull_request.merged }}
@@ -137,7 +141,9 @@ jobs:
           GIT_USER: ${{ steps.user.outputs.username }}
           GIT_EMAIL: ${{ steps.user.outputs.email }}
         id: pr_details
-        run: $SCRIPT_DIR/pr_details.sh
+        run: |
+          echo "::add-mask::$ANTHROPIC_API_KEY"
+          $SCRIPT_DIR/pr_details.sh
         shell: bash
       - name: Create pull request
         if: needs.backport-type.outputs.commented_on == 'pr'
@@ -151,6 +157,8 @@ jobs:
           ORIG_PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
           ORIG_PR_URL: ${{ github.event.client_payload.pull_request.html_url }}
           GIT_USER: ${{ steps.user.outputs.username }}
+          AI_RESOLVED_FILES: ${{ steps.pr_details.outputs.ai_resolved_files }}
+          AI_DIFFICULTY: ${{ steps.pr_details.outputs.ai_difficulty }}
         id: create_pr
         run: $SCRIPT_DIR/create_pr.sh
         shell: bash

--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -128,6 +128,7 @@ jobs:
       - name: Setup uv
         if: needs.backport-type.outputs.commented_on == 'pr'
         uses: astral-sh/setup-uv@v4
+        continue-on-error: true
       - name: Backport commits and get details
         if: needs.backport-type.outputs.commented_on == 'pr'
         env:

--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -159,7 +159,6 @@ jobs:
           ORIG_PR_URL: ${{ github.event.client_payload.pull_request.html_url }}
           GIT_USER: ${{ steps.user.outputs.username }}
           AI_RESOLVED_FILES: ${{ steps.pr_details.outputs.ai_resolved_files }}
-          AI_DIFFICULTY: ${{ steps.pr_details.outputs.ai_difficulty }}
           AI_DIFFICULTY_COMMENT: ${{ steps.pr_details.outputs.ai_difficulty_comment }}
         id: create_pr
         run: $SCRIPT_DIR/create_pr.sh

--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -160,6 +160,7 @@ jobs:
           GIT_USER: ${{ steps.user.outputs.username }}
           AI_RESOLVED_FILES: ${{ steps.pr_details.outputs.ai_resolved_files }}
           AI_DIFFICULTY: ${{ steps.pr_details.outputs.ai_difficulty }}
+          AI_DIFFICULTY_COMMENT: ${{ steps.pr_details.outputs.ai_difficulty_comment }}
         id: create_pr
         run: $SCRIPT_DIR/create_pr.sh
         shell: bash

--- a/.github/workflows/scripts/backport-command/ai_resolve.py
+++ b/.github/workflows/scripts/backport-command/ai_resolve.py
@@ -1,0 +1,131 @@
+# /// script
+# dependencies = ["anthropic==0.50.0"]
+# ///
+
+import fnmatch
+import os
+import subprocess
+import sys
+import time
+
+import anthropic
+
+GENERATED_PATTERNS = [
+    "*.pb.go", "*.pb.h", "*.pb.cc", "*.pb.rs", "*_pb2.py",
+    "MODULE.bazel", "*.lock", "go.sum", "package-lock.json", "Cargo.lock",
+]
+
+SYSTEM_PROMPT = (
+    "You are a git conflict resolver. Return the resolved file with all conflict "
+    "markers removed. If you cannot resolve it confidently, respond with: UNCERTAIN"
+)
+
+BACKPORT_COMMITS = os.environ["BACKPORT_COMMITS"]
+BACKPORT_BRANCH = os.environ["BACKPORT_BRANCH"]
+
+client = anthropic.Anthropic()
+
+
+def matches_any(path: str, patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatch(os.path.basename(path), p) for p in patterns)
+
+
+def call_with_retry(path: str, diff: str, file_content: str):
+    prompt = (
+        f"Target branch: {BACKPORT_BRANCH}\nFile: {path}\n\n"
+        f"--- commit diff (file-specific) ---\n{diff}\n"
+        f"--- conflicted file ---\n{file_content}"
+    )
+    for attempt in range(2):
+        try:
+            return client.messages.create(
+                model="claude-opus-4-6",
+                max_tokens=2048,
+                timeout=30,
+                system=SYSTEM_PROMPT,
+                messages=[{"role": "user", "content": prompt}],
+            )
+        except anthropic.RateLimitError:
+            if attempt == 0:
+                print(f"{path}: rate limited, retrying in 10s...")
+                time.sleep(10)
+                continue
+            raise
+
+
+def difficulty_rating(resolved_count: int, total_diff_lines: int) -> str:
+    if resolved_count >= 3 or total_diff_lines > 150:
+        return "hairy"
+    if resolved_count == 1 and total_diff_lines <= 50:
+        return "easy"
+    return "medium"
+
+
+conflicted = subprocess.check_output(
+    ["git", "diff", "--name-only", "--diff-filter=U"]
+).decode().splitlines()
+
+eligible = [f for f in conflicted if not matches_any(f, GENERATED_PATTERNS)]
+skipped = [f for f in conflicted if matches_any(f, GENERATED_PATTERNS)]
+
+if skipped:
+    print(f"Skipping generated files: {skipped}")
+if not eligible:
+    print("No eligible files. Falling back.")
+    sys.exit(1)
+
+resolved = []
+total_diff_lines = 0
+
+for path in eligible:
+    diff = subprocess.check_output(
+        ["git", "show", "-U0"] + BACKPORT_COMMITS.split() + ["--", path]
+    ).decode(errors="replace")
+
+    diff_lines = diff.splitlines()
+    if len(diff_lines) > 200:
+        print(f"{path}: diff too large ({len(diff_lines)} lines). Skipping.")
+        continue
+
+    file_content = open(path, encoding="utf-8", errors="replace").read()
+
+    try:
+        response = call_with_retry(path, diff, file_content)
+    except Exception as e:
+        print(f"{path}: API error ({type(e).__name__}: {e}). Skipping.")
+        continue
+
+    if response.stop_reason != "end_turn":
+        print(f"{path}: response truncated (stop_reason={response.stop_reason}). Skipping.")
+        continue
+
+    text = response.content[0].text.strip()
+
+    if text.upper() == "UNCERTAIN":
+        print(f"{path}: model uncertain. Skipping.")
+        continue
+
+    if any(m in text for m in ["<<<<<<<", "=======", ">>>>>>>"]):
+        print(f"{path}: model output still contains conflict markers. Skipping.")
+        continue
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(text)
+    subprocess.run(["git", "add", "--", path], check=True)
+    resolved.append(path)
+    total_diff_lines += len(diff_lines)
+    print(f"{path}: resolved and staged.")
+
+if not resolved:
+    print("No files were resolved. Falling back.")
+    sys.exit(1)
+
+with open(os.environ["RESOLVED_FILES_OUT"], "w") as f:
+    f.write("\n".join(resolved))
+
+rating = difficulty_rating(len(resolved), total_diff_lines)
+with open(os.environ["DIFFICULTY_OUT"], "w") as f:
+    f.write(rating)
+
+print(f"Difficulty: {rating}")
+sys.exit(0)

--- a/.github/workflows/scripts/backport-command/ai_resolve.py
+++ b/.github/workflows/scripts/backport-command/ai_resolve.py
@@ -15,9 +15,14 @@ GENERATED_PATTERNS = [
     "MODULE.bazel", "*.lock", "go.sum", "package-lock.json", "Cargo.lock",
 ]
 
+MODEL = "claude-opus-4-6"
+MAX_TOKENS = 2048
+UNCERTAIN_RESPONSE = "UNCERTAIN"
+CONFLICT_MARKERS = ["<<<<<<<", "=======", ">>>>>>>"]
+
 SYSTEM_PROMPT = (
     "You are a git conflict resolver. Return the resolved file with all conflict "
-    "markers removed. If you cannot resolve it confidently, respond with: UNCERTAIN"
+    f"markers removed. If you cannot resolve it confidently, respond with: {UNCERTAIN_RESPONSE}"
 )
 
 BACKPORT_COMMITS = os.environ["BACKPORT_COMMITS"]
@@ -39,8 +44,8 @@ def call_with_retry(path: str, diff: str, file_content: str):
     for attempt in range(2):
         try:
             return client.messages.create(
-                model="claude-opus-4-6",
-                max_tokens=2048,
+                model=MODEL,
+                max_tokens=MAX_TOKENS,
                 timeout=30,
                 system=SYSTEM_PROMPT,
                 messages=[{"role": "user", "content": prompt}],
@@ -101,11 +106,11 @@ for path in eligible:
 
     text = response.content[0].text.strip()
 
-    if text.upper() == "UNCERTAIN":
+    if text.upper() == UNCERTAIN_RESPONSE:
         print(f"{path}: model uncertain. Skipping.")
         continue
 
-    if any(m in text for m in ["<<<<<<<", "=======", ">>>>>>>"]):
+    if any(m in text for m in CONFLICT_MARKERS):
         print(f"{path}: model output still contains conflict markers. Skipping.")
         continue
 

--- a/.github/workflows/scripts/backport-command/ai_resolve.py
+++ b/.github/workflows/scripts/backport-command/ai_resolve.py
@@ -113,13 +113,13 @@ resolved = []
 total_diff_lines = 0
 
 for path in eligible:
-    # --reverse: chronological order so the model reasons oldest-to-newest.
-    # -U0: the conflicted file already provides context; sending it in the
-    #      diff too would be redundant and waste tokens.
+    # Only show the diff from the commit that actually conflicted (the one
+    # cherry-pick stopped on), not all commits in the sequence. The earlier
+    # commits applied cleanly so their diffs are noise that bloats past the
+    # complexity filter.
+    failing_commit = BACKPORT_COMMITS.split()[-1]
     diff = subprocess.check_output(
-        ["git", "log", "-p", "-U0", "--reverse"]
-        + BACKPORT_COMMITS.split()
-        + ["--", path]
+        ["git", "log", "-p", "-U0", "-1", failing_commit, "--", path]
     ).decode(errors="replace")
 
     diff_lines = diff.splitlines()

--- a/.github/workflows/scripts/backport-command/ai_resolve.py
+++ b/.github/workflows/scripts/backport-command/ai_resolve.py
@@ -36,8 +36,10 @@ UNCERTAIN_RESPONSE = "UNCERTAIN"
 CONFLICT_MARKERS = ["<<<<<<<", "=======", ">>>>>>>"]
 
 SYSTEM_PROMPT = (
-    "You are a git conflict resolver. Return the resolved file with all conflict "
-    f"markers removed. If you cannot resolve it confidently, respond with: {UNCERTAIN_RESPONSE}"
+    "You are a git conflict resolver. Output ONLY the raw file content, exactly as "
+    "it should be written to disk. No markdown, no code fences, no explanations, no "
+    "preamble. Start with the first line of the file. If you cannot resolve it "
+    f"confidently, respond with exactly: {UNCERTAIN_RESPONSE}"
 )
 
 BACKPORT_COMMITS = os.environ["BACKPORT_COMMITS"]
@@ -146,6 +148,13 @@ for path in eligible:
         continue
 
     text = response.content[0].text.strip()
+
+    # Belt-and-suspenders: strip markdown fences if the model wraps the output
+    # despite the prompt instructions. Handles ```python, ```cpp, ``` etc.
+    if text.startswith("```"):
+        lines = text.splitlines()
+        if lines[-1].strip() == "```":
+            text = "\n".join(lines[1:-1])
 
     if text.upper() == UNCERTAIN_RESPONSE:
         print(f"{path}: model uncertain. Skipping.")

--- a/.github/workflows/scripts/backport-command/ai_resolve.py
+++ b/.github/workflows/scripts/backport-command/ai_resolve.py
@@ -71,8 +71,8 @@ def call_with_retry(path: str, diff: str, file_content: str):
             if attempt == 0:
                 print(f"{path}: rate limited, retrying in 10s...")
                 time.sleep(10)
-                continue
-            raise
+            else:
+                raise
 
 
 def difficulty_rating(resolved_count: int, total_diff_lines: int) -> str:
@@ -86,12 +86,13 @@ def difficulty_rating(resolved_count: int, total_diff_lines: int) -> str:
 def build_comment(
     resolved: list[str], skipped: list[str], total_diff_lines: int
 ) -> str:
+    n = len(resolved)
+    file_word = "file" if n == 1 else "files"
     files_list = "\n".join(f"- `{f}`" for f in resolved)
-    file_word = "file" if len(resolved) == 1 else "files"
     return (
-        f"**AI conflict resolution** — {len(resolved)} {file_word}, "
+        f"**AI conflict resolution** — {n} {file_word}, "
         f"{total_diff_lines} diff lines\n\n"
-        f"Resolved in {len(resolved)} {file_word}. "
+        f"Resolved in {n} {file_word}. "
         f"The original diff was {total_diff_lines} lines. "
         f"Skipped {len(skipped)} files (generated).\n\n"
         f"Resolved:\n{files_list}"
@@ -104,8 +105,9 @@ conflicted = (
     .splitlines()
 )
 
-eligible = [f for f in conflicted if not matches_any(f, GENERATED_PATTERNS)]
-skipped = [f for f in conflicted if matches_any(f, GENERATED_PATTERNS)]
+eligible, skipped = [], []
+for f in conflicted:
+    (skipped if matches_any(f, GENERATED_PATTERNS) else eligible).append(f)
 
 if skipped:
     print(f"Skipping generated files: {skipped}")
@@ -134,7 +136,8 @@ for path in eligible:
         print(f"{path}: diff too large ({len(diff_lines)} lines). Skipping.")
         continue
 
-    file_content = open(path, encoding="utf-8", errors="replace").read()
+    with open(path, encoding="utf-8", errors="replace") as f:
+        file_content = f.read()
 
     try:
         response = call_with_retry(path, diff, file_content)

--- a/.github/workflows/scripts/backport-command/ai_resolve.py
+++ b/.github/workflows/scripts/backport-command/ai_resolve.py
@@ -75,14 +75,6 @@ def call_with_retry(path: str, diff: str, file_content: str):
                 raise
 
 
-def difficulty_rating(resolved_count: int, total_diff_lines: int) -> str:
-    if resolved_count >= 3 or total_diff_lines > 150:
-        return "hairy"
-    if resolved_count == 1 and total_diff_lines <= 50:
-        return "easy"
-    return "medium"
-
-
 def build_comment(
     resolved: list[str], skipped: list[str], total_diff_lines: int
 ) -> str:
@@ -177,12 +169,6 @@ if not resolved:
 with open(os.environ["RESOLVED_FILES_OUT"], "w") as f:
     f.write("\n".join(resolved))
 
-rating = difficulty_rating(len(resolved), total_diff_lines)
-with open(os.environ["DIFFICULTY_OUT"], "w") as f:
-    f.write(rating)
-
 with open(os.environ["DIFFICULTY_COMMENT_OUT"], "w") as f:
     f.write(build_comment(resolved, skipped, total_diff_lines))
-
-print(f"Difficulty: {rating}")
 sys.exit(0)

--- a/.github/workflows/scripts/backport-command/ai_resolve.py
+++ b/.github/workflows/scripts/backport-command/ai_resolve.py
@@ -84,7 +84,7 @@ total_diff_lines = 0
 
 for path in eligible:
     diff = subprocess.check_output(
-        ["git", "show", "-U0"] + BACKPORT_COMMITS.split() + ["--", path]
+        ["git", "log", "-p", "-U0", "--reverse"] + BACKPORT_COMMITS.split() + ["--", path]
     ).decode(errors="replace")
 
     diff_lines = diff.splitlines()

--- a/.github/workflows/scripts/backport-command/ai_resolve.py
+++ b/.github/workflows/scripts/backport-command/ai_resolve.py
@@ -83,7 +83,9 @@ def difficulty_rating(resolved_count: int, total_diff_lines: int) -> str:
     return "medium"
 
 
-def build_comment(resolved: list[str], skipped: list[str], total_diff_lines: int) -> str:
+def build_comment(
+    resolved: list[str], skipped: list[str], total_diff_lines: int
+) -> str:
     files_list = "\n".join(f"- `{f}`" for f in resolved)
     file_word = "file" if len(resolved) == 1 else "files"
     return (

--- a/.github/workflows/scripts/backport-command/ai_resolve.py
+++ b/.github/workflows/scripts/backport-command/ai_resolve.py
@@ -10,13 +10,20 @@ import time
 
 import anthropic
 
+# Best-effort: unknown generated types not listed here will be sent to the
+# model, but conflict-marker validation and UNCERTAIN catches garbage output.
 GENERATED_PATTERNS = [
     "*.pb.go", "*.pb.h", "*.pb.cc", "*.pb.rs", "*_pb2.py",
     "MODULE.bazel", "*.lock", "go.sum", "package-lock.json", "Cargo.lock",
 ]
 
 MODEL = "claude-opus-4-6"
+# Sized to hold a typical resolved source file. The model's context window
+# (200k) is not the constraint; output truncation is. If the resolved file
+# would exceed this, stop_reason != "end_turn" and we discard the response.
 MAX_TOKENS = 2048
+# The model signals uncertainty with this literal string rather than returning
+# a partial or empty file, which would be harder to detect reliably.
 UNCERTAIN_RESPONSE = "UNCERTAIN"
 CONFLICT_MARKERS = ["<<<<<<<", "=======", ">>>>>>>"]
 
@@ -51,6 +58,8 @@ def call_with_retry(path: str, diff: str, file_content: str):
                 messages=[{"role": "user", "content": prompt}],
             )
         except anthropic.RateLimitError:
+            # Only rate limits are worth retrying; auth/server errors won't
+            # resolve on a second attempt.
             if attempt == 0:
                 print(f"{path}: rate limited, retrying in 10s...")
                 time.sleep(10)
@@ -83,11 +92,17 @@ resolved = []
 total_diff_lines = 0
 
 for path in eligible:
+    # --reverse: chronological order so the model reasons oldest-to-newest.
+    # -U0: the conflicted file already provides context; sending it in the
+    #      diff too would be redundant and waste tokens.
     diff = subprocess.check_output(
         ["git", "log", "-p", "-U0", "--reverse"] + BACKPORT_COMMITS.split() + ["--", path]
     ).decode(errors="replace")
 
     diff_lines = diff.splitlines()
+    # 200-line cap is a complexity filter, not a token-exhaustion guard. A diff
+    # this large likely signals structural divergence that needs a human, not a
+    # mechanical conflict the model can fix reliably.
     if len(diff_lines) > 200:
         print(f"{path}: diff too large ({len(diff_lines)} lines). Skipping.")
         continue
@@ -100,6 +115,8 @@ for path in eligible:
         print(f"{path}: API error ({type(e).__name__}: {e}). Skipping.")
         continue
 
+    # Any stop reason other than "end_turn" means the output was cut off;
+    # writing a partial file to disk would corrupt the cherry-pick.
     if response.stop_reason != "end_turn":
         print(f"{path}: response truncated (stop_reason={response.stop_reason}). Skipping.")
         continue

--- a/.github/workflows/scripts/backport-command/ai_resolve.py
+++ b/.github/workflows/scripts/backport-command/ai_resolve.py
@@ -83,6 +83,19 @@ def difficulty_rating(resolved_count: int, total_diff_lines: int) -> str:
     return "medium"
 
 
+def build_comment(resolved: list[str], skipped: list[str], total_diff_lines: int) -> str:
+    files_list = "\n".join(f"- `{f}`" for f in resolved)
+    file_word = "file" if len(resolved) == 1 else "files"
+    return (
+        f"**AI conflict resolution** — {len(resolved)} {file_word}, "
+        f"{total_diff_lines} diff lines\n\n"
+        f"Resolved in {len(resolved)} {file_word}. "
+        f"The original diff was {total_diff_lines} lines. "
+        f"Skipped {len(skipped)} files (generated).\n\n"
+        f"Resolved:\n{files_list}"
+    )
+
+
 conflicted = (
     subprocess.check_output(["git", "diff", "--name-only", "--diff-filter=U"])
     .decode()
@@ -162,6 +175,9 @@ with open(os.environ["RESOLVED_FILES_OUT"], "w") as f:
 rating = difficulty_rating(len(resolved), total_diff_lines)
 with open(os.environ["DIFFICULTY_OUT"], "w") as f:
     f.write(rating)
+
+with open(os.environ["DIFFICULTY_COMMENT_OUT"], "w") as f:
+    f.write(build_comment(resolved, skipped, total_diff_lines))
 
 print(f"Difficulty: {rating}")
 sys.exit(0)

--- a/.github/workflows/scripts/backport-command/ai_resolve.py
+++ b/.github/workflows/scripts/backport-command/ai_resolve.py
@@ -13,8 +13,16 @@ import anthropic
 # Best-effort: unknown generated types not listed here will be sent to the
 # model, but conflict-marker validation and UNCERTAIN catches garbage output.
 GENERATED_PATTERNS = [
-    "*.pb.go", "*.pb.h", "*.pb.cc", "*.pb.rs", "*_pb2.py",
-    "MODULE.bazel", "*.lock", "go.sum", "package-lock.json", "Cargo.lock",
+    "*.pb.go",
+    "*.pb.h",
+    "*.pb.cc",
+    "*.pb.rs",
+    "*_pb2.py",
+    "MODULE.bazel",
+    "*.lock",
+    "go.sum",
+    "package-lock.json",
+    "Cargo.lock",
 ]
 
 MODEL = "claude-opus-4-6"
@@ -75,9 +83,11 @@ def difficulty_rating(resolved_count: int, total_diff_lines: int) -> str:
     return "medium"
 
 
-conflicted = subprocess.check_output(
-    ["git", "diff", "--name-only", "--diff-filter=U"]
-).decode().splitlines()
+conflicted = (
+    subprocess.check_output(["git", "diff", "--name-only", "--diff-filter=U"])
+    .decode()
+    .splitlines()
+)
 
 eligible = [f for f in conflicted if not matches_any(f, GENERATED_PATTERNS)]
 skipped = [f for f in conflicted if matches_any(f, GENERATED_PATTERNS)]
@@ -96,7 +106,9 @@ for path in eligible:
     # -U0: the conflicted file already provides context; sending it in the
     #      diff too would be redundant and waste tokens.
     diff = subprocess.check_output(
-        ["git", "log", "-p", "-U0", "--reverse"] + BACKPORT_COMMITS.split() + ["--", path]
+        ["git", "log", "-p", "-U0", "--reverse"]
+        + BACKPORT_COMMITS.split()
+        + ["--", path]
     ).decode(errors="replace")
 
     diff_lines = diff.splitlines()
@@ -118,7 +130,9 @@ for path in eligible:
     # Any stop reason other than "end_turn" means the output was cut off;
     # writing a partial file to disk would corrupt the cherry-pick.
     if response.stop_reason != "end_turn":
-        print(f"{path}: response truncated (stop_reason={response.stop_reason}). Skipping.")
+        print(
+            f"{path}: response truncated (stop_reason={response.stop_reason}). Skipping."
+        )
         continue
 
     text = response.content[0].text.strip()

--- a/.github/workflows/scripts/backport-command/create_pr.sh
+++ b/.github/workflows/scripts/backport-command/create_pr.sh
@@ -65,14 +65,8 @@ pr_url=$(gh pr create --title "[$BACKPORT_BRANCH] $ORIG_TITLE" \
   --body "Backport of PR $ORIG_ISSUE_URL
 $backport_issue_urls")
 
-if [[ -n ${AI_RESOLVED_FILES:-} && -n ${AI_DIFFICULTY:-} ]]; then
-  files_list=$(echo "$AI_RESOLVED_FILES" | sed 's/^/- /')
+if [[ -n ${AI_RESOLVED_FILES:-} && -n ${AI_DIFFICULTY_COMMENT:-} ]]; then
   gh pr comment "$pr_url" \
     --repo "$TARGET_ORG/$TARGET_REPO" \
-    --body "AI conflict resolution — difficulty: **${AI_DIFFICULTY}**
-
-Conflicts resolved automatically in:
-${files_list}
-
-Review the resolved hunks carefully before merging."
+    --body "$AI_DIFFICULTY_COMMENT"
 fi

--- a/.github/workflows/scripts/backport-command/create_pr.sh
+++ b/.github/workflows/scripts/backport-command/create_pr.sh
@@ -66,7 +66,7 @@ pr_url=$(gh pr create --title "[$BACKPORT_BRANCH] $ORIG_TITLE" \
 $backport_issue_urls")
 
 if [[ -n "${AI_RESOLVED_FILES:-}" && -n "${AI_DIFFICULTY:-}" ]]; then
-  files_list=$(printf '%s\n' $AI_RESOLVED_FILES | sed 's/^/- /')
+  files_list=$(echo "$AI_RESOLVED_FILES" | sed 's/^/- /')
   gh pr comment "$pr_url" \
     --repo "$TARGET_ORG/$TARGET_REPO" \
     --body "AI conflict resolution — difficulty: **${AI_DIFFICULTY}**

--- a/.github/workflows/scripts/backport-command/create_pr.sh
+++ b/.github/workflows/scripts/backport-command/create_pr.sh
@@ -51,7 +51,7 @@ if [[ $FIXING_ISSUE_URLS != "" ]]; then
 fi
 
 labels="kind/backport"
-if [[ -n "${AI_RESOLVED_FILES:-}" ]]; then
+if [[ -n ${AI_RESOLVED_FILES:-} ]]; then
   labels="$labels,ai-resolved-conflicts"
 fi
 
@@ -65,7 +65,7 @@ pr_url=$(gh pr create --title "[$BACKPORT_BRANCH] $ORIG_TITLE" \
   --body "Backport of PR $ORIG_ISSUE_URL
 $backport_issue_urls")
 
-if [[ -n "${AI_RESOLVED_FILES:-}" && -n "${AI_DIFFICULTY:-}" ]]; then
+if [[ -n ${AI_RESOLVED_FILES:-} && -n ${AI_DIFFICULTY:-} ]]; then
   files_list=$(echo "$AI_RESOLVED_FILES" | sed 's/^/- /')
   gh pr comment "$pr_url" \
     --repo "$TARGET_ORG/$TARGET_REPO" \

--- a/.github/workflows/scripts/backport-command/create_pr.sh
+++ b/.github/workflows/scripts/backport-command/create_pr.sh
@@ -50,12 +50,29 @@ if [[ $FIXING_ISSUE_URLS != "" ]]; then
   backport_issue_urls=$(echo "$backport_issue_urls" | sed 's/.$//')
 fi
 
-gh pr create --title "[$BACKPORT_BRANCH] $ORIG_TITLE" \
+labels="kind/backport"
+if [[ -n "${AI_RESOLVED_FILES:-}" ]]; then
+  labels="$labels,ai-resolved-conflicts"
+fi
+
+pr_url=$(gh pr create --title "[$BACKPORT_BRANCH] $ORIG_TITLE" \
   --base "$BACKPORT_BRANCH" \
-  --label "kind/backport" \
+  --label "$labels" \
   --head "$GIT_USER:$HEAD_BRANCH" \
   --repo "$TARGET_ORG/$TARGET_REPO" \
   --reviewer "$AUTHOR" \
   --milestone "$TARGET_MILESTONE" \
   --body "Backport of PR $ORIG_ISSUE_URL
-$backport_issue_urls"
+$backport_issue_urls")
+
+if [[ -n "${AI_RESOLVED_FILES:-}" && -n "${AI_DIFFICULTY:-}" ]]; then
+  files_list=$(printf '%s\n' $AI_RESOLVED_FILES | sed 's/^/- /')
+  gh pr comment "$pr_url" \
+    --repo "$TARGET_ORG/$TARGET_REPO" \
+    --body "AI conflict resolution — difficulty: **${AI_DIFFICULTY}**
+
+Conflicts resolved automatically in:
+${files_list}
+
+Review the resolved hunks carefully before merging."
+fi

--- a/.github/workflows/scripts/backport-command/pr_details.sh
+++ b/.github/workflows/scripts/backport-command/pr_details.sh
@@ -44,25 +44,46 @@ head_branch=$(echo "backport-pr-$PR_NUMBER-$BACKPORT_BRANCH-$suffix" | sed 's/ /
 git checkout -b "$head_branch" "remotes/upstream/$BACKPORT_BRANCH"
 
 if ! git cherry-pick -x $BACKPORT_COMMITS; then
-  msg="Failed to create a backport PR to $BACKPORT_BRANCH branch. I tried:\n
-\`\`\`\r
-git remote add upstream "https://github.com/$TARGET_FULL_REPO.git"
-git fetch --all
-git checkout -b "$head_branch" "remotes/upstream/$BACKPORT_BRANCH"
-git cherry-pick -x $BACKPORT_COMMITS
-\`\`\`"
-
-  # Multiline workaround for GitHub Actions.
-  {
-    echo 'BACKPORT_ERROR<<EOF'
-    echo -e "$msg"
-    echo 'EOF'
-  } >>"$GITHUB_ENV"
-
-  backport_failure "$msg"
+  echo "Cherry-pick failed. Attempting AI conflict resolution..."
+  RESOLVED_OUT=$(mktemp)
+  DIFFICULTY_OUT=$(mktemp)
+  export RESOLVED_FILES_OUT="$RESOLVED_OUT"
+  export DIFFICULTY_OUT
+  if uv run "$SCRIPT_DIR/ai_resolve.py"; then
+    ai_resolved_files=$(cat "$RESOLVED_OUT")
+    ai_difficulty=$(cat "$DIFFICULTY_OUT")
+    if ! git cherry-pick --continue --no-edit; then
+      git cherry-pick --abort 2>/dev/null || true
+      rm -f "$RESOLVED_OUT" "$DIFFICULTY_OUT"
+      msg="AI resolution staged changes but cherry-pick --continue failed (unresolved conflicts remain). Manual backport required."
+      {
+        echo 'BACKPORT_ERROR<<EOF'
+        echo -e "$msg"
+        echo 'EOF'
+      } >>"$GITHUB_ENV"
+      backport_failure "$msg"
+    fi
+  else
+    git cherry-pick --abort 2>/dev/null || true
+    rm -f "$RESOLVED_OUT" "$DIFFICULTY_OUT"
+    msg="Cherry-pick failed and AI resolution could not resolve conflicts automatically. Manual backport required."
+    {
+      echo 'BACKPORT_ERROR<<EOF'
+      echo -e "$msg"
+      echo 'EOF'
+    } >>"$GITHUB_ENV"
+    backport_failure "$msg"
+  fi
+  rm -f "$RESOLVED_OUT" "$DIFFICULTY_OUT"
 fi
 
 git push --set-upstream origin "$head_branch"
 git remote rm upstream
 echo "head_branch=$head_branch" >>$GITHUB_OUTPUT
 echo "fixing_issue_urls=$fixing_issue_urls" >>$GITHUB_OUTPUT
+{
+  echo 'ai_resolved_files<<EOF'
+  echo "${ai_resolved_files:-}"
+  echo 'EOF'
+} >>"$GITHUB_OUTPUT"
+echo "ai_difficulty=${ai_difficulty:-}" >>"$GITHUB_OUTPUT"

--- a/.github/workflows/scripts/backport-command/pr_details.sh
+++ b/.github/workflows/scripts/backport-command/pr_details.sh
@@ -47,12 +47,15 @@ if ! git cherry-pick -x $BACKPORT_COMMITS; then
   echo "Cherry-pick failed. Attempting AI conflict resolution..."
   RESOLVED_OUT=$(mktemp)
   DIFFICULTY_OUT=$(mktemp)
-  trap 'rm -f "$RESOLVED_OUT" "$DIFFICULTY_OUT"' EXIT
+  DIFFICULTY_COMMENT_OUT=$(mktemp)
+  trap 'rm -f "$RESOLVED_OUT" "$DIFFICULTY_OUT" "$DIFFICULTY_COMMENT_OUT"' EXIT
   export RESOLVED_FILES_OUT="$RESOLVED_OUT"
   export DIFFICULTY_OUT
+  export DIFFICULTY_COMMENT_OUT
   if uv run "$SCRIPT_DIR/ai_resolve.py"; then
     ai_resolved_files=$(cat "$RESOLVED_OUT")
     ai_difficulty=$(cat "$DIFFICULTY_OUT")
+    ai_difficulty_comment=$(cat "$DIFFICULTY_COMMENT_OUT")
     if ! git cherry-pick --continue --no-edit; then
       git cherry-pick --abort 2>/dev/null || true
       msg="AI resolution staged changes but cherry-pick --continue failed (unresolved conflicts remain). Manual backport required."
@@ -85,3 +88,8 @@ echo "fixing_issue_urls=$fixing_issue_urls" >>$GITHUB_OUTPUT
   echo 'EOF'
 } >>"$GITHUB_OUTPUT"
 echo "ai_difficulty=${ai_difficulty:-}" >>"$GITHUB_OUTPUT"
+{
+  echo 'ai_difficulty_comment<<EOF'
+  echo "${ai_difficulty_comment:-}"
+  echo 'EOF'
+} >>"$GITHUB_OUTPUT"

--- a/.github/workflows/scripts/backport-command/pr_details.sh
+++ b/.github/workflows/scripts/backport-command/pr_details.sh
@@ -46,15 +46,12 @@ git checkout -b "$head_branch" "remotes/upstream/$BACKPORT_BRANCH"
 if ! git cherry-pick -x $BACKPORT_COMMITS; then
   echo "Cherry-pick failed. Attempting AI conflict resolution..."
   RESOLVED_OUT=$(mktemp)
-  DIFFICULTY_OUT=$(mktemp)
   DIFFICULTY_COMMENT_OUT=$(mktemp)
-  trap 'rm -f "$RESOLVED_OUT" "$DIFFICULTY_OUT" "$DIFFICULTY_COMMENT_OUT"' EXIT
+  trap 'rm -f "$RESOLVED_OUT" "$DIFFICULTY_COMMENT_OUT"' EXIT
   export RESOLVED_FILES_OUT="$RESOLVED_OUT"
-  export DIFFICULTY_OUT
   export DIFFICULTY_COMMENT_OUT
   if uv run "$SCRIPT_DIR/ai_resolve.py"; then
     ai_resolved_files=$(cat "$RESOLVED_OUT")
-    ai_difficulty=$(cat "$DIFFICULTY_OUT")
     ai_difficulty_comment=$(cat "$DIFFICULTY_COMMENT_OUT")
     if ! git cherry-pick --continue --no-edit; then
       git cherry-pick --abort 2>/dev/null || true
@@ -87,7 +84,6 @@ echo "fixing_issue_urls=$fixing_issue_urls" >>$GITHUB_OUTPUT
   echo "${ai_resolved_files:-}"
   echo 'EOF'
 } >>"$GITHUB_OUTPUT"
-echo "ai_difficulty=${ai_difficulty:-}" >>"$GITHUB_OUTPUT"
 {
   echo 'ai_difficulty_comment<<EOF'
   echo "${ai_difficulty_comment:-}"

--- a/.github/workflows/scripts/backport-command/pr_details.sh
+++ b/.github/workflows/scripts/backport-command/pr_details.sh
@@ -47,6 +47,7 @@ if ! git cherry-pick -x $BACKPORT_COMMITS; then
   echo "Cherry-pick failed. Attempting AI conflict resolution..."
   RESOLVED_OUT=$(mktemp)
   DIFFICULTY_OUT=$(mktemp)
+  trap 'rm -f "$RESOLVED_OUT" "$DIFFICULTY_OUT"' EXIT
   export RESOLVED_FILES_OUT="$RESOLVED_OUT"
   export DIFFICULTY_OUT
   if uv run "$SCRIPT_DIR/ai_resolve.py"; then
@@ -54,7 +55,6 @@ if ! git cherry-pick -x $BACKPORT_COMMITS; then
     ai_difficulty=$(cat "$DIFFICULTY_OUT")
     if ! git cherry-pick --continue --no-edit; then
       git cherry-pick --abort 2>/dev/null || true
-      rm -f "$RESOLVED_OUT" "$DIFFICULTY_OUT"
       msg="AI resolution staged changes but cherry-pick --continue failed (unresolved conflicts remain). Manual backport required."
       {
         echo 'BACKPORT_ERROR<<EOF'
@@ -65,7 +65,6 @@ if ! git cherry-pick -x $BACKPORT_COMMITS; then
     fi
   else
     git cherry-pick --abort 2>/dev/null || true
-    rm -f "$RESOLVED_OUT" "$DIFFICULTY_OUT"
     msg="Cherry-pick failed and AI resolution could not resolve conflicts automatically. Manual backport required."
     {
       echo 'BACKPORT_ERROR<<EOF'
@@ -74,7 +73,6 @@ if ! git cherry-pick -x $BACKPORT_COMMITS; then
     } >>"$GITHUB_ENV"
     backport_failure "$msg"
   fi
-  rm -f "$RESOLVED_OUT" "$DIFFICULTY_OUT"
 fi
 
 git push --set-upstream origin "$head_branch"

--- a/.github/workflows/scripts/backport-command/test_ai_resolve.sh
+++ b/.github/workflows/scripts/backport-command/test_ai_resolve.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Local test for ai_resolve.py against a synthetic cherry-pick conflict.
+#
+# Usage:
+#   ANTHROPIC_API_KEY=... bash test_ai_resolve.sh
+#
+# The test constructs a minimal git repo, stages a cherry-pick conflict that
+# mirrors the class of mechanical conflicts the script is designed to handle
+# (context drift + nearby line change), then validates that the resolved file
+# is clean and contains no model reasoning or markdown artifacts.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$TMP"
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+
+# Base: a simple C++ function
+cat >foo.cc <<'EOF'
+// Copyright Redpanda Data, Inc.
+void process(int a, int b) {
+    log("processing");
+    return a + b;
+}
+EOF
+git add foo.cc
+git commit -qm "base: add process()"
+
+# Release branch diverges: adds a third parameter
+git checkout -qb release
+cat >foo.cc <<'EOF'
+// Copyright Redpanda Data, Inc.
+void process(int a, int b, int c) {
+    log("processing");
+    return a + b + c;
+}
+EOF
+git add foo.cc
+git commit -qm "release: add parameter c to process()"
+
+# Dev branch: adds a log message in the same area (mechanical context drift)
+git checkout -q -
+cat >foo.cc <<'EOF'
+// Copyright Redpanda Data, Inc.
+void process(int a, int b) {
+    log("processing", a, b);
+    return a + b;
+}
+EOF
+git add foo.cc
+COMMIT=$(git commit -qm "dev: improve log message" && git rev-parse HEAD)
+
+# Cherry-pick onto release — will conflict around the function signature
+git checkout -q release
+git cherry-pick -x "$COMMIT" >/dev/null 2>&1 || true
+
+echo "Conflict staged. Running ai_resolve.py..."
+
+RESOLVED_OUT=$(mktemp)
+DIFFICULTY_OUT=$(mktemp)
+export RESOLVED_FILES_OUT="$RESOLVED_OUT"
+export DIFFICULTY_OUT
+export BACKPORT_COMMITS="$COMMIT"
+export BACKPORT_BRANCH="release"
+
+if ! uv run "$SCRIPT_DIR/ai_resolve.py"; then
+  echo "FAIL: ai_resolve.py exited non-zero (model could not resolve)"
+  exit 1
+fi
+
+echo ""
+echo "=== Resolved file ==="
+cat foo.cc
+echo ""
+
+# Validation
+fail=0
+
+if grep -qE "^<<<<<<|^=======$|^>>>>>>>" foo.cc; then
+  echo "FAIL: conflict markers remain in resolved file"
+  fail=1
+fi
+
+if grep -qE '^```' foo.cc; then
+  echo "FAIL: markdown code fences found in resolved file"
+  fail=1
+fi
+
+if head -1 foo.cc | grep -qiE "^(looking|here is|the resolved|i'll|let me|this file)"; then
+  echo "FAIL: model reasoning leaked into first line of resolved file"
+  fail=1
+fi
+
+if ! grep -q "Copyright" foo.cc; then
+  echo "FAIL: copyright header missing — file may be truncated or replaced"
+  fail=1
+fi
+
+if [[ $fail -eq 0 ]]; then
+  echo "PASS: resolved cleanly (difficulty: $(cat "$DIFFICULTY_OUT"))"
+fi
+
+exit $fail


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

When a cherry-pick fails during automated backport, the workflow currently gives up and creates a manual tracking issue. This PR adds an intermediate AI-assisted resolution step before that fallback.

On cherry-pick failure, `ai_resolve.py` is invoked per conflicted file. It calls the Claude API with the conflict markers and the original commit diff as context, and attempts to produce a resolved file. Files that the model resolves cleanly are staged; any the model marks as uncertain (`UNCERTAIN`) are left for the fallback path. If all conflicts are resolved, the PR is created automatically with an `ai-resolved-conflicts` label and a difficulty comment (`easy` / `medium` / `hairy`) so reviewers know which hunks to examine closely.

Additional commits in this PR clean up the surrounding shell scripts and improve the resolution context passed to the model:
- Use `git log -p --reverse` instead of `git show` so commit boundaries are clearly labeled and commit messages are included as resolution context
- Guard `setup-uv` with `continue-on-error` so a uv failure produces a proper tracking issue rather than a silent job death
- Extract tuning constants (`MODEL`, `MAX_TOKENS`, etc.) to module level in `ai_resolve.py`
- Fix an unquoted word-split bug in `create_pr.sh` for the resolved files list
- Add inline comments explaining non-obvious decisions (token budget sizing, `UNCERTAIN` sentinel, 200-line complexity filter, `-U0`/`--reverse` flag reasoning)

Uses PEP 723 inline script metadata + `uv`; no `requirements.txt` needed. `ANTHROPIC_API_KEY` is injected from a GitHub repo secret.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none