### PR TITLE
kafka/protocol: reject oversized tagged fields during parsing

### DIFF
--- a/src/v/kafka/protocol/flex_versions.cc
+++ b/src/v/kafka/protocol/flex_versions.cc
@@ -17,6 +17,8 @@
 
 #include <seastar/core/iostream.hh>
 
+#include <stdexcept>
+
 namespace kafka {
 
 namespace {
@@ -92,6 +94,10 @@ parse_tags(ss::input_stream<char>& src) {
     while (num_tags-- > 0) {
         auto id = co_await read_unsigned_vint(total_bytes_read, src);
         auto next_len = co_await read_unsigned_vint(total_bytes_read, src);
+        if (next_len > 128_KiB) {
+            throw std::invalid_argument(
+              fmt::format("Too large of a tagged field: {}", next_len));
+        }
         auto buf = co_await src.read_exactly(next_len);
         bytes data(bytes::initialized_later{}, buf.size());
         std::copy_n(buf.begin(), buf.size(), data.begin());


### PR DESCRIPTION
## Summary

- Adds a 128 KiB limit on individual tagged field payloads when parsing flex-version Kafka messages
- Without this bound, a fuzz-crafted message with a large vint-encoded length field could cause excessive memory allocation before hitting any other guard
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes

### Bug Fixes

* Prevents a potential oversized allocation in kafka protocol parsing of tagged fields