### PR TITLE
skill: add create-backport-branch for automated PR cherry-picks

### DIFF
--- a/.claude/skills/.gitignore
+++ b/.claude/skills/.gitignore
@@ -1,0 +1,2 @@
+# skill-creator eval workspace (generated output from eval runs)
+*-workspace/

--- a/.claude/skills/create-backport-branch/SKILL.md
+++ b/.claude/skills/create-backport-branch/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: create-backport-branch
+description: "Create a new backport branch with prefix `ai-backport-` by cherry-picking all commits from a GitHub PR onto a target release branch. Use when the user wants to backport a PR, create a backport branch, cherry-pick PR commits to a release branch, or mentions backporting changes from dev/main to a version branch (e.g. v25.1.x, v25.2.x). Requires two arguments: TARGET_BRANCH (the release branch to backport onto) and PR_NUM (the GitHub PR number to backport)."
+argument-hint: [target-branch] [pr-number]
+allowed-tools: Bash(git *), Bash(gh *), Bash(date *), Bash(grep *), Bash(wc *), Read, Write, Edit, Glob, Grep, Agent
+model: opus[1m]
+effort: high
+---
+
+# Create Backport Branch
+
+Cherry-pick all commits from a GitHub PR onto a target release branch, resolving conflicts along the way.
+
+Arguments:
+- `$0` is target-branch (e.g. `v25.1.x`)
+- `$1` is pr-number (e.g. `12345`)
+
+## Procedure
+
+### 1. Validate inputs and set up
+
+1. Both arguments must be provided. If either target-branch or pr-number is empty, abort with: "Usage: /create-backport-branch <target-branch> <pr-number>"
+2. Generate the backport-branch-name using the current Unix timestamp:
+   ```bash
+   date +%s
+   ```
+   backport-branch-name format: `ai-backport-pr-${pr_number}-${target_branch}-${unix_timestamp}`
+
+### 2. Create the backport branch
+
+```bash
+git checkout -b $backport_branch_name $target_branch
+```
+
+### 3. Fetch PR commits
+
+Get the list of commit SHAs from the PR:
+
+```bash
+gh api "repos/redpanda-data/redpanda/pulls/$pr_number/commits" --paginate --jq '[.[].sha[0:10]]|join(" ")'
+```
+
+Save the full list of commits as git-commits and report how many commits were found.
+
+### 4. Cherry-pick commits
+
+Run the cherry-pick for all commits at once:
+
+```bash
+git cherry-pick -x $git_commits
+```
+
+Track these counters as you go:
+- **total_commits**: number of commits from the PR
+- **conflicts_resolved**: number of commits that needed conflict resolution
+- **commits_skipped**: number of commits skipped because they were already present on the target branch
+- **generated_files_touched**: list of generated files that were part of the cherry-picked commits (whether conflicted or not)
+
+If the cherry-pick succeeds cleanly, check if any generated files were touched (see step 4a), then skip to step 6.
+
+### 4a. Check for generated files in cherry-picked commits
+
+After each successful cherry-pick (clean or after conflict resolution), check if any generated files were touched. Use the same generated file patterns from step 5.3. For clean cherry-picks, check the files changed in the commit(s) just applied:
+
+```bash
+git diff --name-only HEAD~1 HEAD
+```
+
+Match the output against the generated file patterns. Add any matches to `generated_files_touched`.
+
+### 5. Resolve conflicts
+
+If the cherry-pick fails with merge conflicts, attempt resolution. For each conflicted state:
+
+1. Identify the commit that caused the conflict (the one currently being cherry-picked).
+2. List conflicted files: `git diff --name-only --diff-filter=U`
+3. Categorize each file:
+   - **Generated files** (accept theirs and move on): `*.pb.go`, `*.pb.h`, `*.pb.cc`, `*.pb.rs`, `*_pb2.py`, `go.sum`, `*.lock`, `MODULE.bazel.lock`, `package-lock.json`, `Cargo.lock`, `MODULE.bazel`
+     - For generated files: `git checkout --theirs -- $FILE && git add -- $FILE`
+     - Add each generated file to the `generated_files_touched` list
+   - **Modify/delete conflicts**: file deleted on one side but modified on the other. These require human judgment — **abort immediately** (see abort procedure below).
+   - **Content conflicts**: files with `<<<<<<<` / `=======` / `>>>>>>>` markers. Attempt resolution.
+
+4. For each content conflict:
+   a. Read the full conflicted file
+   b. Run `git log -p -1 $FAILING_COMMIT -- $FILE` to understand what the cherry-picked commit intended
+   c. Understand both sides:
+      - **HEAD side** (`<<<<<<<` to `=======`): what the target release branch has
+      - **Incoming side** (`=======` to `>>>>>>>`): what the cherry-picked commit brings
+   d. Read surrounding code if needed to understand context (imports, types, function signatures)
+   e. Determine the correct resolution:
+      - The goal is to apply the *intent* of the cherry-picked commit to the target branch
+      - Adapt to the target branch's patterns, names, and APIs where they diverge
+   f. Edit the file to remove all conflict markers and write the correct merged code
+   g. Stage: `git add -- $FILE`
+
+5. Verify the resolution is clean:
+   ```bash
+   grep -rn '<<<<<<< \|=======$\|>>>>>>> ' -- $RESOLVED_FILES
+   git diff --name-only --diff-filter=U
+   ```
+   Both commands should produce no output. If unmerged paths remain, something was missed.
+
+6. Continue the cherry-pick:
+   ```bash
+   git cherry-pick --continue --no-edit
+   ```
+   If `--continue` reports "The previous cherry-pick is now empty", the commit's changes are already on the target branch. Run `git cherry-pick --skip` to move on, and increment `commits_skipped`.
+
+7. Increment `conflicts_resolved` counter.
+
+8. If the next commit also conflicts, repeat from step 5.1.
+
+### 5a. Empty cherry-picks (no conflict)
+
+A cherry-pick can also be empty without any conflict — git will report "The previous cherry-pick is now empty" immediately. This happens when the commit's changes already exist on the target branch (e.g., from a prior backport or parallel fix). Run `git cherry-pick --skip` to move on and increment `commits_skipped`. This is normal and not an error.
+
+**Abort procedure** — If at any point you are uncertain how to resolve a conflict (ambiguous intent, modify/delete conflicts, architectural changes you don't understand, or anything that feels risky):
+
+1. Run `git cherry-pick --abort`
+2. Report an error with:
+   - The exact `git cherry-pick -x ...` command that was being attempted
+   - The specific commit SHA that caused the uncertain conflict
+   - Which files were conflicted and why you couldn't resolve them
+3. Stop immediately. Do NOT attempt further cherry-picks.
+
+### 6. Final report
+
+After all commits are cherry-picked successfully, report:
+
+```
+Backport of PR https://github.com/redpanda-data/redpanda/pull/$PR_NUM
+
+- Command: git cherry-pick -x $GIT_COMMITS
+- Commits backported: $TOTAL_COMMITS
+- Conflicts resolved: $CONFLICTS_RESOLVED
+- Commits skipped (already on target): $COMMITS_SKIPPED
+- Backport branch: $BRANCH_NAME
+
+Conflict details:
+- $COMMIT_SHA ($FILE): one-line explanation of what conflicted and how it was resolved
+```
+
+For each conflict resolved, include a one-line explanation covering what conflicted and how you resolved it. This helps PR reviewers understand the backport without reading every diff.
+
+If `generated_files_touched` is non-empty, append a warning section:
+
+```
+⚠️  Generated files were cherry-picked and may need regeneration:
+- $FILE_1
+- $FILE_2
+
+These files were accepted as-is from the source branch. Before merging,
+regenerate them on the target branch to ensure they're correct. For example:
+- MODULE.bazel.lock: run `bazel mod deps --lockfile_mode=update`
+- *.pb.go / *.pb.cc / *.pb.h: rebuild protobuf targets
+- go.sum: run `go mod tidy`
+```
+
+## Rules
+
+- NEVER guess at conflict resolutions. If uncertain, abort immediately using the abort procedure.
+- NEVER silently drop code. Incoming changes that add new functionality must be preserved (adapted to the target branch's conventions).
+- Do NOT add comments to resolved code unless the original commit had them.
+- Preserve the formatting style of the target branch.
+- For generated files (protobuf, lockfiles, MODULE.bazel), just accept theirs — they'll be regenerated by the build.

--- a/.claude/skills/create-backport-branch/SKILL.md
+++ b/.claude/skills/create-backport-branch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: create-backport-branch
-description: "Create a new backport branch with prefix `ai-backport-` by cherry-picking all commits from a GitHub PR onto a target release branch. Use when the user wants to backport a PR, create a backport branch, cherry-pick PR commits to a release branch, or mentions backporting changes from dev/main to a version branch (e.g. v25.1.x, v25.2.x). Requires two arguments: TARGET_BRANCH (the release branch to backport onto) and PR_NUM (the GitHub PR number to backport)."
-argument-hint: [target-branch] [pr-number]
+description: "Create a new backport branch with prefix `ai-backport-` by cherry-picking all commits from a GitHub PR onto a target release branch or commit. Use when the user wants to backport a PR, create a backport branch, cherry-pick PR commits to a release branch, or mentions backporting changes from dev/main to a version branch (e.g. v25.1.x, v25.2.x). Requires two arguments: TARGET (the release branch or commit hash to backport onto) and PR_NUM (the GitHub PR number to backport)."
+argument-hint: [target-branch-or-commit] [pr-number]
 allowed-tools: Bash(git *), Bash(gh *), Bash(date *), Bash(grep *), Bash(wc *), Read, Write, Edit, Glob, Grep, Agent
 model: opus[1m]
 effort: high
@@ -12,7 +12,7 @@ effort: high
 Cherry-pick all commits from a GitHub PR onto a target release branch, resolving conflicts along the way.
 
 Arguments:
-- `$0` is target-branch (e.g. `v25.1.x`)
+- `$0` is target — a release branch (e.g. `v25.1.x`) or a commit hash (e.g. `81d9e1af33`)
 - `$1` is pr-number (e.g. `12345`)
 
 ## Procedure
@@ -40,7 +40,7 @@ Get the list of commit SHAs from the PR:
 gh api "repos/redpanda-data/redpanda/pulls/$pr_number/commits" --paginate --jq '[.[].sha[0:10]]|join(" ")'
 ```
 
-Save the full list of commits as git-commits and report how many commits were found.
+Save the full list of commits as `git_commits` and report how many commits were found.
 
 ### 4. Cherry-pick commits
 
@@ -129,16 +129,16 @@ A cherry-pick can also be empty without any conflict — git will report "The pr
 After all commits are cherry-picked successfully, report:
 
 ```
-Backport of PR https://github.com/redpanda-data/redpanda/pull/$PR_NUM
+Backport of PR https://github.com/redpanda-data/redpanda/pull/${pr_number}
 
-- Command: git cherry-pick -x $GIT_COMMITS
-- Commits backported: $TOTAL_COMMITS
-- Conflicts resolved: $CONFLICTS_RESOLVED
-- Commits skipped (already on target): $COMMITS_SKIPPED
-- Backport branch: $BRANCH_NAME
+- Command: git cherry-pick -x ${git_commits}
+- Commits backported: ${total_commits}
+- Conflicts resolved: ${conflicts_resolved}
+- Commits skipped (already on target): ${commits_skipped}
+- Backport branch: ${backport_branch_name}
 
 Conflict details:
-- $COMMIT_SHA ($FILE): one-line explanation of what conflicted and how it was resolved
+- ${commit_sha} (${file}): one-line explanation of what conflicted and how it was resolved
 ```
 
 For each conflict resolved, include a one-line explanation covering what conflicted and how you resolved it. This helps PR reviewers understand the backport without reading every diff.
@@ -147,8 +147,8 @@ If `generated_files_touched` is non-empty, append a warning section:
 
 ```
 ⚠️  Generated files were cherry-picked and may need regeneration:
-- $FILE_1
-- $FILE_2
+- ${file_1}
+- ${file_2}
 
 These files were accepted as-is from the source branch. Before merging,
 regenerate them on the target branch to ensure they're correct. For example:

--- a/.claude/skills/create-backport-branch/evals/evals.json
+++ b/.claude/skills/create-backport-branch/evals/evals.json
@@ -1,0 +1,65 @@
+{
+  "skill_name": "create-backport-branch",
+  "evals": [
+    {
+      "id": 0,
+      "name": "clean-cherry-pick",
+      "prompt": "/create-backport-branch 81d9e1af33 30160",
+      "expected_output": "Creates a backport branch from commit 81d9e1af33 (v25.3.x before PR 30160 was backported). The single commit from PR #30160 should cherry-pick cleanly with no conflicts and no empty result. Produces a structured report.",
+      "files": [],
+      "expectations": [
+        "Branch was created with naming pattern ai-backport-pr-30160-81d9e1af33-{timestamp}",
+        "Cherry-pick command used the -x flag to record the source commit",
+        "Cherry-pick succeeded cleanly with no conflicts",
+        "Final report includes total commits count (1), conflicts resolved count (0), and commits skipped count (0)",
+        "Final report includes the backport branch name",
+        "The backport branch has exactly 1 new commit beyond the base"
+      ]
+    },
+    {
+      "id": 1,
+      "name": "multi-commit-conflict",
+      "prompt": "/create-backport-branch 5cdd00f4ca 30089",
+      "expected_output": "Creates a backport branch from commit 5cdd00f4ca (v26.1.x). Cherry-picks 8 commits from PR #30089. Should encounter conflict in feature_table.h and resolve it by adapting to the target branch's release_version values.",
+      "files": [],
+      "expectations": [
+        "Branch was created with naming pattern ai-backport-pr-30089-5cdd00f4ca-{timestamp}",
+        "All 8 commits were fetched from the PR via gh api",
+        "Cherry-pick command used the -x flag",
+        "Either all conflicts were resolved and continued, OR agent aborted cleanly listing the specific commit SHA and conflicted files",
+        "If conflicts were resolved, the final report includes a per-conflict one-line explanation",
+        "No conflict markers (<<<<<<< or ======= or >>>>>>>) remain in any resolved files"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "generated-files-modify-delete",
+      "prompt": "/create-backport-branch d0a6248434 30115",
+      "expected_output": "Creates a backport branch from commit d0a6248434 (v25.1.x). Cherry-picks 3 commits from PR #30115. Should encounter modify/delete conflict on buf.gen.yaml and abort cleanly per skill rules.",
+      "files": [],
+      "expectations": [
+        "Branch was created with naming pattern ai-backport-pr-30115-d0a6248434-{timestamp}",
+        "Generated files (go.sum, MODULE.bazel, or similar) were identified",
+        "Cherry-pick command used the -x flag",
+        "Agent aborted cleanly on modify/delete conflict, listing the specific commit SHA and conflicted files",
+        "Abort report includes the exact cherry-pick command that was being attempted",
+        "Final report includes total commits count, conflicts resolved count, and commits skipped count"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "already-present-empty",
+      "prompt": "/create-backport-branch ea6e2533c7 30160",
+      "expected_output": "Creates a backport branch from commit ea6e2533c7 (v25.3.x after PR 30160 was already backported). The cherry-pick should result in an empty commit since the change is already present. Should handle with git cherry-pick --skip and report as skipped.",
+      "files": [],
+      "expectations": [
+        "Branch was created with naming pattern ai-backport-pr-30160-ea6e2533c7-{timestamp}",
+        "Cherry-pick command used the -x flag",
+        "Empty cherry-pick was handled with git cherry-pick --skip (not --abort)",
+        "Final report includes commits skipped count of 1",
+        "Final report correctly indicates the commit was already on the target branch",
+        "The backport branch was preserved (not deleted)"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds a Claude Code skill (`/create-backport-branch`) that automates cherry-picking all commits from a GitHub PR onto a target release branch
- Includes structured conflict resolution procedure: content conflicts are resolved by adapting to the target branch, generated files use `--theirs`, and modify/delete conflicts trigger a clean abort
- Adds eval test cases with fixed commit hashes for repeatable benchmarking

## Example output

prompt:
```
/create-backport-branch v25.2.x 27225
```
output:
```
⏺ No generated files were touched. All clean.

  ---
  Backport of PR https://github.com/redpanda-data/redpanda/pull/27225

  - Command: git cherry-pick -x 23510a39ba 96b0438a44
  - Commits backported: 2
  - Conflicts resolved: 0
  - Commits skipped (already on target): 0
  - Backport branch: ai-backport-pr-27225-v25.2.x-1776278710

  Cherry-pick completed cleanly with no conflicts.

✻ Cooked for 34s
```

## How this skill was developed

The skill was created and evaluated using the [skill-creator](https://github.com/anthropics/claude-plugins-official/blob/main/plugins/skill-creator/skills/skill-creator/SKILL.md) plugin (`/skill-creator:skill-creator`). This plugin provides a structured workflow for building Claude Code skills:

1. **Drafting** — The skill's `SKILL.md` was written with a step-by-step procedure for backporting PRs: input validation, branch creation, commit fetching via `gh api`, cherry-picking with `-x`, conflict resolution (with categories for content conflicts, generated files, and modify/delete), and a structured final report.

2. **Eval-driven iteration** — The `skill-creator` spawns parallel subagent runs (with-skill and without-skill baselines) in isolated git worktrees, then grades outputs against quantitative assertions. This reveals what the skill actually adds vs what Claude would do on its own.

3. **Benchmarking** — Results are aggregated into a benchmark comparing pass rates, timing, and token usage. An HTML eval viewer lets the author review each test case's transcript and output side-by-side.

Over two iterations, the skill was benchmarked at **100% assertion pass rate** (vs 50% baseline) while being **35% faster** and using fewer tokens — the structured procedure eliminates trial-and-error that the baseline agent otherwise does.

### How `evals/evals.json` works

The `evals.json` file defines repeatable test cases for the skill. Each eval specifies:
- A **prompt** (e.g., `/create-backport-branch 81d9e1af33 30160`) using fixed commit hashes so results don't change as branches advance
- **Expectations** — verifiable assertions like "cherry-pick used -x flag" or "report includes structured counters"

The four test cases cover the key scenarios:

| Eval | Target | PR | Scenario |
|------|--------|-----|----------|
| `clean-cherry-pick` | `81d9e1af33` | 30160 | Clean, non-empty apply |
| `multi-commit-conflict` | `5cdd00f4ca` | 30089 | 8-commit PR with content conflict |
| `generated-files-modify-delete` | `d0a6248434` | 30115 | Generated files + modify/delete abort |
| `already-present-empty` | `ea6e2533c7` | 30160 | Already-backported, empty skip |

To re-run the evals, use `/skill-creator:skill-creator eval .claude/skills/create-backport-branch/SKILL.md`. The `skill-creator` will use the prompts from `evals.json` to test the skill and compare against baselines, ensuring future changes to the skill don't regress behavior.

## Test plan
- [x] Evaluated with 4 test scenarios: clean cherry-pick, multi-commit with conflict, generated files with modify/delete, already-present empty cherry-pick
- [x] Benchmarked with-skill vs without-skill: 100% vs 50% assertion pass rate
- [x] Verified commit-hash-based targets produce repeatable results across iterations
- [ ] Manual verification of conflict resolution quality on a real backport PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none