### PR TITLE
bazel: make build byte-for-byte reproducible

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -307,7 +307,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "ZtSnFu4+NXfuxuGvvbUJp7UjeyCebjpwwaLk/CVuao8=",
+        "bzlTransitiveDigest": "SDTLfnB2Pm4MoythhHEjKLwqGadLnImYvdjBbsTPxPw=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -443,6 +443,12 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:openssl.BUILD",
+              "patches": [
+                "@@//bazel/thirdparty:openssl-reproducible-buildinf.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ],
               "sha256": "deae7c80cba99c4b4f940ecadb3c3338b13cb77418409238e57d7f31f2a3b736",
               "strip_prefix": "openssl-3.5.6",
               "url": "https://vectorized-public.s3.amazonaws.com/dependencies/openssl-3.5.6.tar.gz"

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -133,6 +133,8 @@ def data_dependency():
     http_archive(
         name = "openssl",
         build_file = "//bazel/thirdparty:openssl.BUILD",
+        patches = ["//bazel/thirdparty:openssl-reproducible-buildinf.patch"],
+        patch_args = ["-p1"],
         sha256 = "deae7c80cba99c4b4f940ecadb3c3338b13cb77418409238e57d7f31f2a3b736",
         strip_prefix = "openssl-3.5.6",
         url = "https://vectorized-public.s3.amazonaws.com/dependencies/openssl-3.5.6.tar.gz",

--- a/bazel/thirdparty/hwloc.BUILD
+++ b/bazel/thirdparty/hwloc.BUILD
@@ -33,9 +33,17 @@ configure_make(
         # Build a static library
         "--disable-shared",
         "--enable-static",
+
+        # Use a fixed runstatedir so the autoconf-derived path doesn't embed
+        # the sandbox directory into compiled objects.
+        "--runstatedir=/var/run/hwloc",
     ],
     env = {
         "HWLOC_BUILD_JOBS": "$(BUILD_JOBS)",
+        # Remap the sandbox root in __FILE__ expansions so that inlined
+        # headers (helper.h, plugins.h) produce deterministic assert strings.
+        "CFLAGS": "-ffile-prefix-map=$$EXT_BUILD_ROOT=.",
+        "CXXFLAGS": "-ffile-prefix-map=$$EXT_BUILD_ROOT=.",
     },
     lib_source = ":srcs",
     out_binaries = [

--- a/bazel/thirdparty/openssl-reproducible-buildinf.patch
+++ b/bazel/thirdparty/openssl-reproducible-buildinf.patch
@@ -1,0 +1,21 @@
+diff --git a/util/mkbuildinf.pl b/util/mkbuildinf.pl
+index abcdef1..1234567 100644
+--- a/util/mkbuildinf.pl
++++ b/util/mkbuildinf.pl
+@@ -11,6 +11,16 @@ use warnings;
+ my $platform = pop @ARGV;
+ my $cflags = join(' ', @ARGV);
+ $cflags =~ s(\\)(\\\\)g;
++
++# Strip sandbox/build-root absolute paths so the output is reproducible
++# across different Bazel output bases and sandbox instances. Note: the
++# cflags modified here are only embedded as a diagnostic string (shown by
++# `openssl version -a`), not used for actual compilation.
++my $ebr = $ENV{'EXT_BUILD_ROOT'} // '';
++if ($ebr ne '') {
++    $cflags =~ s/\Q$ebr\E\/?/./g;
++}
++
+ $cflags = "compiler: $cflags";
+
+ # Use the value of the envvar SOURCE_DATE_EPOCH, even if it's

--- a/bazel/thirdparty/openssl.BUILD
+++ b/bazel/thirdparty/openssl.BUILD
@@ -67,6 +67,10 @@ configure_make(
     }),
     env = {
         "OPENSSL_BUILD_JOBS": "$(BUILD_JOBS)",
+        # Pin the build timestamp to epoch 0 for reproducible builds.
+        # Without this, mkbuildinf.pl embeds the current time into
+        # crypto/buildinf.h.
+        "SOURCE_DATE_EPOCH": "0",
     },
     lib_source = ":srcs",
     out_binaries = [


### PR DESCRIPTION
Make the Bazel build of `//:redpanda` byte-for-byte reproducible across
builds on the same host (with different output bases or sandbox instances).

Five third-party dependencies were embedding sandbox-specific absolute paths
or timestamps into compiled artifacts. Each commit fixes one dependency:

- **hwloc**: `-ffile-prefix-map` to normalize `__FILE__` in inlined asserts,
  `--runstatedir` to avoid baking the sandbox install prefix into `HWLOC_RUN_DIR`
- **openssl**: `SOURCE_DATE_EPOCH=0` to pin the build timestamp, patch
  `mkbuildinf.pl` to strip `$EXT_BUILD_ROOT` from the compiler info string
- **libxml2**: `--sysconfdir=/etc` to fix the XML catalog path to the standard
  Linux location (instead of a sandbox-derived prefix), `-ffile-prefix-map` for
  `__FILE__` normalization
- **cranelift-codegen**: patch `make_isle_source_path_relative()` to compute
  relative paths via common ancestor when `strip_prefix` fails (i.e., when
  `OUT_DIR` is not under `CWD`, as in sandboxed builds)
- **cranelift-assembler-x64**: patch `build.rs` to relativize `OUT_DIR` paths
  in `generated-files.rs` before they get compiled into the library

Verified: building `//:redpanda` twice with separate `--output_base` dirs
produces bit-for-bit identical binaries.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none