### PR TITLE
redpanda: Add support to map code into hugepages

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4857,6 +4857,12 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       128,
       {.min = 0, .max = 10000})
+  , code_hugepages_enabled(
+      *this,
+      "code_hugepages_enabled",
+      "Map the binary into hugepages",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      false)
   , development_feature_property_testing_only(
       *this,
       "development_feature_property_testing_only",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -841,6 +841,7 @@ public:
     property<std::chrono::milliseconds>
       cloud_topics_l1_reader_cache_eviction_timeout_ms;
     bounded_property<size_t> cloud_topics_l1_reader_cache_max_size;
+    property<bool> code_hugepages_enabled;
 
     development_feature_property<int> development_feature_property_testing_only;
 

--- a/src/v/redpanda/BUILD
+++ b/src/v/redpanda/BUILD
@@ -169,14 +169,20 @@ redpanda_cc_binary(
     srcs = [
         "main.cc",
     ],
-    linkopts =
-        select({
-            ":use_emit_relocs": [
-                "-Wl,--emit-relocs",
-            ],
-            "//conditions:default": [
-            ],
-        }),
+    linkopts = [
+        # Align loadable segments to 2 MB so the text segment is eligible for
+        # transparent huge pages (PMD-mapped). separate-loadable-segments
+        # ensures each PT_LOAD gets its own mmap at a 2 MB boundary rather
+        # than packing segments into a single mapping.
+        "-Wl,-z,max-page-size=2097152",
+        "-Wl,-z,separate-loadable-segments",
+    ] + select({
+        ":use_emit_relocs": [
+            "-Wl,--emit-relocs",
+        ],
+        "//conditions:default": [
+        ],
+    }),
     visibility = ["//visibility:public"],
     deps = [
         ":application",

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -45,6 +45,7 @@
 #include "security/audit/audit_log_manager.h"
 #include "storage/api.h"
 #include "storage/directories.h"
+#include "syschecks/hugepages.h"
 #include "syschecks/syschecks.h"
 #include "utils/file_io.h"
 #include "utils/human.h"
@@ -800,6 +801,18 @@ void application::check_environment() {
     syschecks::systemd_message("checking environment (CPU, Mem)").get();
     syschecks::cpu();
     syschecks::memory(config::node().developer_mode());
+    if (config::shard_local_cfg().code_hugepages_enabled()) {
+        syschecks::promote_code_to_hugepages();
+    }
+    _code_hugepages_binding.emplace(
+      config::shard_local_cfg().code_hugepages_enabled.bind());
+    _code_hugepages_binding->watch([this] {
+        if ((*_code_hugepages_binding)()) {
+            syschecks::promote_code_to_hugepages();
+        } else {
+            syschecks::demote_code_from_hugepages();
+        }
+    });
     memory_groups().log_memory_group_allocations(_log);
     storage::directories::initialize(
       config::node().data_directory().as_sstring())

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -293,6 +293,7 @@ private:
     ss::sharded<scheduling_groups_probe> _scheduling_groups_probe;
 
     std::optional<config::binding<bool>> _abort_on_oom;
+    std::optional<config::binding<bool>> _code_hugepages_binding;
 
     ss::sharded<memory_sampling> _memory_sampling;
     ss::sharded<rpc::rpc_server> _rpc;

--- a/src/v/syschecks/BUILD
+++ b/src/v/syschecks/BUILD
@@ -3,10 +3,12 @@ load("//bazel:build.bzl", "redpanda_cc_library")
 redpanda_cc_library(
     name = "syschecks",
     srcs = [
+        "hugepages.cc",
         "pidfile.cc",
         "syschecks.cc",
     ],
     hdrs = [
+        "hugepages.h",
         "syschecks.h",
     ],
     visibility = ["//visibility:public"],

--- a/src/v/syschecks/hugepages.cc
+++ b/src/v/syschecks/hugepages.cc
@@ -1,0 +1,139 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "syschecks/hugepages.h"
+
+#include "base/vlog.h"
+#include "syschecks/syschecks.h"
+
+#include <sys/mman.h>
+
+#include <cstddef>
+#include <link.h>
+
+// MADV_COLLAPSE was added in Linux 6.1. Define it for older headers.
+#ifndef MADV_COLLAPSE
+#define MADV_COLLAPSE 25
+#endif
+
+namespace syschecks {
+
+namespace {
+
+/// Invoke fn(addr, len) for each non-writable PT_LOAD segment across
+/// all loaded ELF objects (main binary + shared libraries). This covers
+/// .text (PF_R|PF_X) and .rodata (PF_R) segments.
+template<typename Fn>
+void for_each_ro_segment(Fn fn) {
+    dl_iterate_phdr(
+      [](struct dl_phdr_info* info, size_t /*size*/, void* data) -> int {
+          auto& callback = *static_cast<Fn*>(data);
+          for (int i = 0; i < info->dlpi_phnum; ++i) {
+              const auto& phdr = info->dlpi_phdr[i];
+              if (phdr.p_type != PT_LOAD) {
+                  continue;
+              }
+              // Skip writable segments (.data, .bss).
+              if (phdr.p_flags & PF_W) {
+                  continue;
+              }
+              auto addr = info->dlpi_addr + phdr.p_vaddr;
+              auto len = phdr.p_memsz;
+              if (len == 0) {
+                  continue;
+              }
+              callback(reinterpret_cast<void*>(addr), static_cast<size_t>(len));
+          }
+          return 0; // continue iteration
+      },
+      &fn);
+}
+
+} // namespace
+
+void promote_code_to_hugepages() {
+    vlog(checklog.info, "Starting hugepage promotioin of code segments");
+
+    size_t total_bytes = 0;
+    size_t marked_bytes = 0;
+    size_t collapsed_bytes = 0;
+
+    for_each_ro_segment([&](void* addr, size_t len) {
+        total_bytes += len;
+
+        // Mark the VMA for huge pages. In "madvise" THP mode (the common
+        // default), khugepaged only scans VMAs with VM_HUGEPAGE set, so this
+        // is required for ongoing huge page maintenance — not just a hint.
+        if (::madvise(addr, len, MADV_HUGEPAGE) == 0) {
+            marked_bytes += len;
+        }
+
+        // Fault in all pages so MADV_COLLAPSE has something to work with.
+        // At startup most pages are still demand-paged.
+        // In theory this is not needed with MADV_COLLAPSE but the docs leave a
+        // cop out so we are just explicit in any case.
+        // Incompatible with ASAN, disable if on
+#if !__has_feature(address_sanitizer)
+        auto* base = static_cast<volatile const char*>(addr);
+        for (size_t off = 0; off < len; off += 4096) {
+            [[maybe_unused]] char c = base[off];
+        }
+#endif
+
+        // Synchronously collapse 4 KB pages into 2 MB huge pages
+        // (Linux 6.1+). Without this, khugepaged promotes pages in the
+        // background over the next few seconds; MADV_COLLAPSE makes it
+        // immediate (best effort).
+        if (::madvise(addr, len, MADV_COLLAPSE) == 0) {
+            collapsed_bytes += len;
+        }
+    });
+
+    if (total_bytes > 0) {
+        vlog(
+          checklog.info,
+          "hugepages: {}/{} MiB marked, {}/{} MiB collapsed",
+          marked_bytes / (1024 * 1024),
+          total_bytes / (1024 * 1024),
+          collapsed_bytes / (1024 * 1024),
+          total_bytes / (1024 * 1024));
+    }
+}
+
+void demote_code_from_hugepages() {
+    size_t total_bytes = 0;
+    size_t demoted_bytes = 0;
+
+    for_each_ro_segment([&](void* addr, size_t len) {
+        total_bytes += len;
+
+        // Prevent khugepaged from re-promoting these pages.
+        if (::madvise(addr, len, MADV_NOHUGEPAGE) != 0) {
+            return;
+        }
+
+        // MADV_NOHUGEPAGE only prevents future promotions — existing PMD
+        // entries for file-backed pages are not split. MADV_DONTNEED drops
+        // the page table entries. They will be re-faulted at 4 KB granularity
+        // (since MADV_NOHUGEPAGE is set).
+        if (::madvise(addr, len, MADV_DONTNEED) == 0) {
+            demoted_bytes += len;
+        }
+    });
+
+    if (total_bytes > 0) {
+        vlog(
+          checklog.info,
+          "hugepages: demoted {}/{} MiB from huge pages",
+          demoted_bytes / (1024 * 1024),
+          total_bytes / (1024 * 1024));
+    }
+}
+
+} // namespace syschecks

--- a/src/v/syschecks/hugepages.h
+++ b/src/v/syschecks/hugepages.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+namespace syschecks {
+
+/// Promote file-backed executable mappings (code segments) to transparent huge
+/// pages.
+void promote_code_to_hugepages();
+
+/// Undo the effect of promote_code_to_hugepages(). Marks executable VMAs with
+/// MADV_NOHUGEPAGE
+void demote_code_from_hugepages();
+
+} // namespace syschecks


### PR DESCRIPTION
Adds support to map code into hugepages.

Mapping the code/binary into hugepages decreases iTLB/sTLB misses which
helps with frontend-boundness.

This patch maps the main redpanda binary into hugepages combining two
approaches:

 - Using THP for filed-back mappings, i.e.: the binary
 - Using MADV_COLLAPSE to force a sync mapping of the binary pages into
   hugepages. Avoiding lazy paging by khugepaged.

This patch also makes this runtime switchable by forcing the pages off
hugepages if the feature is being disabled. This is mostly useful for
testing.

The two things above rely on a few things being available:

 - Linux build flag CONFIG_READ_ONLY_THP_FOR_FS: Allows THP backing for
   files.
 - MADV_COLLAPSE being available: Requires Linux 6.1+

The latter is more and more common but the former is currently still
disabled in some major distributions (Ubuntu, RHEL) hence it will
generally be not very available. Because of this we disable the feature
by default.  Not because it would break on these systems but mostly
because it means we don't get much testing.

There is work in progress to remove the CONFIG_READ_ONLY_THP_FOR_FS
kernel flag and instead link it to filesystem support. See
https://lwn.net/Articles/1066582/. This would bring coverage out of the
box to XFS and ext4. We can reevaluate turning this on by default in the
future.

Note independent of kernel support the code pages need to be 2MiB
aligned as well to get successfully mapped.

To enforce this we unconditionally add a linker flag to the redpanda
binary which forces this alignment.

When doing the iteration with dl_iterate_phdr we would naturally include
linked shared libs. However, we currently don't add the aforementioned
linker flag to those and hence those will not map into hugepages.

I think this is a fair tradeoff as those would bloat quite a bit and
shouldn't matter that much from a perf POV. openssl is probably the only
interesting one but I'd claim anything openssl is either crypto compute
bound or syscall bound.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes


* none

