### PR TITLE
`cluster`: fix typo in `topic_table::all_topics()`

### DIFF
--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -47,7 +47,7 @@ metadata_cache::metadata_cache(
   , _leaders(leaders)
   , _health_monitor(health_monitor) {}
 
-std::vector<model::topic_namespace> metadata_cache::all_topics() const {
+chunked_vector<model::topic_namespace> metadata_cache::all_topics() const {
     return _topics_state.local().all_topics();
 }
 

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -63,7 +63,7 @@ public:
     ss::future<> stop() { return ss::now(); }
 
     /// Returns list of all topics that exists in the cluster.
-    std::vector<model::topic_namespace> all_topics() const;
+    chunked_vector<model::topic_namespace> all_topics() const;
 
     ///\brief Returns metadata of single topic.
     ///

--- a/src/v/cluster/tests/replicas_rebalancing_tests.cc
+++ b/src/v/cluster/tests/replicas_rebalancing_tests.cc
@@ -63,7 +63,7 @@ void wait_for_all_partition_moves_to_finish(
         auto topics = cache.all_topics();
         return ss::do_with(
           cache.all_topics(),
-          [&api](std::vector<model::topic_namespace>& topics) {
+          [&api](chunked_vector<model::topic_namespace>& topics) {
               return ssx::parallel_transform(
                        topics.begin(),
                        topics.end(),

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -1819,8 +1819,8 @@ ss::future<> topic_table::notify_waiters() {
     }
 }
 
-std::vector<model::topic_namespace> topic_table::all_topics() const {
-    std::vector<model::topic_namespace> topics;
+chunked_vector<model::topic_namespace> topic_table::all_topics() const {
+    chunked_vector<model::topic_namespace> topics;
     topics.reserve(_topics.size());
     for (auto& [tp_ns, _] : _topics) {
         topics.push_back(tp_ns);

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -1821,7 +1821,7 @@ ss::future<> topic_table::notify_waiters() {
 
 std::vector<model::topic_namespace> topic_table::all_topics() const {
     std::vector<model::topic_namespace> topics;
-    topics.reserve(topics.size());
+    topics.reserve(_topics.size());
     for (auto& [tp_ns, _] : _topics) {
         topics.push_back(tp_ns);
     }

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -589,7 +589,7 @@ public:
     /// Query API
 
     /// Returns list of all topics that exists in the cluster.
-    std::vector<model::topic_namespace> all_topics() const;
+    chunked_vector<model::topic_namespace> all_topics() const;
 
     // Returns the number of topics that exist in the cluster.
     size_t all_topics_count() const;


### PR DESCRIPTION
Also migrate to `chunked_vector<>` from `std::vector<>`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
