### PR TITLE
fix: fix 'occured' -> 'occurred' typos in wasm, http, datalake, storage

### DIFF
--- a/src/v/datalake/serde_parquet_writer.cc
+++ b/src/v/datalake/serde_parquet_writer.cc
@@ -23,7 +23,7 @@ ss::future<writer_error> serde_parquet_writer::add_data_struct(
     // Hence, the current solution is to return those errors on the subsequent
     // call to `add_data_struct`.
     //
-    // Similar to `local_parquet_file_writer` once an error has occured further
+    // Similar to `local_parquet_file_writer` once an error has occurred further
     // writes are prevented.
     if (_error != writer_error::ok) {
         co_return _error;

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -247,7 +247,7 @@ ss::future<reconnect_result_t> client::get_connected(
         // Reconnect attempts have to stop if:
         // - shutdown method was called
         // - abort was requested
-        // - unrecoverable error occured
+        // - unrecoverable error occurred
         // - timeout reached
         try {
             // base_transport::connect calls _dispatcher_gate.close

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -473,7 +473,7 @@ static ss::future<segment_set> do_recover(
 /**
  * \brief Open all segments in a directory.
  *
- * Returns an exceptional future if any error occured opening a
+ * Returns an exceptional future if any error occurred opening a
  * segment. Otherwise all open segment readers are returned.
  */
 static ss::future<segment_set::underlying_t> open_segments(

--- a/src/v/wasm/wasi.h
+++ b/src/v/wasm/wasi.h
@@ -223,7 +223,7 @@ struct event_t {
     errno_t error;
 
     /**
-     * The type of event that occured
+     * The type of event that occurred
      */
     event_type_t type;
 


### PR DESCRIPTION
Four files contained `occured` in comments:

| File | Line | Context |
|------|------|---------|
| `src/v/wasm/wasi.h` | 226 | `The type of event that occured` |
| `src/v/http/client.cc` | 250 | `unrecoverable error occured` |
| `src/v/datalake/serde_parquet_writer.cc` | 26 | `once an error has occured` |
| `src/v/storage/segment_set.cc` | 476 | `if any error occured opening` |

Fixed to `occurred`. Comment-only change.

Backports Required: none