### PR TITLE
`datalake`: fix typo leading to use-after-move in `scheduling_policies`

### DIFF
--- a/src/v/datalake/translation/scheduling_policies.cc
+++ b/src/v/datalake/translation/scheduling_policies.cc
@@ -32,7 +32,7 @@ simple_fcfs_scheduling_policy::simple_fcfs_scheduling_policy(
       datalake_log.info,
       "created simple_fcfs_scheduling_policy policy with {} translators "
       "and {} time quota",
-      max_concurrent_translators(),
+      _max_concurrent_translations(),
       std::chrono::duration_cast<std::chrono::milliseconds>(
         translation_time_quota));
 }
@@ -77,7 +77,7 @@ fair_scheduling_policy::fair_scheduling_policy(
       datalake_log.info,
       "created fair_scheduling_policy policy with {} translators "
       "and {} time quota",
-      max_concurrent_translators(),
+      _max_concurrent_translations(),
       std::chrono::duration_cast<std::chrono::milliseconds>(
         translation_time_quota));
     initialize_group_shares();


### PR DESCRIPTION

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes


* none
