### PR TITLE
datalake: add cdc_key_value iceberg mode

### DIFF
--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -358,6 +358,9 @@ metrics_reporter::build_metrics_snapshot() {
         case model::iceberg_mode::variant::debezium:
             ++snapshot.topics_with_iceberg_debezium;
             break;
+        case model::iceberg_mode::variant::cdc_key_value:
+            ++snapshot.topics_with_iceberg_kv;
+            break;
         }
     }
 

--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -150,6 +150,7 @@ redpanda_cc_library(
     deps = [
         ":backlog_controller",
         ":catalog_schema_manager",
+        ":cdc_key_value_translator",
         ":cloud_data_io",
         ":debezium_translator",
         ":location",
@@ -411,6 +412,29 @@ redpanda_cc_library(
         ":schema_identifier",
         "//src/v/base",
         "//src/v/iceberg:datatypes",
+        "//src/v/model",
+    ],
+)
+
+redpanda_cc_library(
+    name = "cdc_key_value_translator",
+    srcs = [
+        "cdc_key_value_translator.cc",
+    ],
+    hdrs = [
+        "cdc_key_value_translator.h",
+    ],
+    implementation_deps = [
+        ":logger",
+        ":table_definition",
+    ],
+    visibility = [":__subpackages__"],
+    deps = [
+        ":record_translator",
+        "//src/v/base",
+        "//src/v/iceberg:datatypes",
+        "//src/v/iceberg:values",
+        "//src/v/metrics",
         "//src/v/model",
     ],
 )

--- a/src/v/datalake/cdc_key_value_translator.cc
+++ b/src/v/datalake/cdc_key_value_translator.cc
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "datalake/cdc_key_value_translator.h"
+
+#include "datalake/logger.h"
+#include "datalake/table_definition.h"
+
+namespace datalake {
+
+record_type
+cdc_key_value_translator::build_type(std::optional<shared_resolved_type_t>) {
+    // Identical schema to key_value_translator. The key column lives
+    // inside the redpanda system struct as redpanda.key.
+    auto ret_type = schemaless_struct_type();
+    ret_type.fields.emplace_back(
+      iceberg::nested_field::create(
+        schemaless_next_field_id,
+        "value",
+        iceberg::field_required::no,
+        iceberg::binary_type{}));
+    return record_type{
+      .comps = record_schema_components{
+        .key_identifier = std::nullopt,
+        .val_identifier = std::nullopt,
+      },
+      .type = std::move(ret_type),
+      // The delete key is redpanda.key. The dotted name triggers
+      // nested field lookup via find_field_by_name.
+      .key_field_names = chunked_vector<ss::sstring>{"redpanda.key"},
+    };
+}
+
+ss::future<checked<translated_record, record_translator::errc>>
+cdc_key_value_translator::translate_data(
+  model::partition_id pid,
+  kafka::offset o,
+  std::optional<iobuf> key,
+  const std::optional<shared_resolved_type_t>& val_type,
+  std::optional<iobuf> parsable_val,
+  model::timestamp ts,
+  model::timestamp_type ts_t,
+  const chunked_vector<model::record_header>& headers) {
+    if (val_type.has_value()) {
+        vlog(
+          datalake_log.error,
+          "Must not have parsed schema when using cdc_key_value mode");
+        co_return errc::unexpected_schema;
+    }
+
+    // Build the delete key from the record key.
+    std::optional<iceberg::struct_value> delete_key;
+    if (key.has_value()) {
+        iceberg::struct_value dk;
+        dk.fields.emplace_back(iceberg::binary_value(key->copy()));
+        delete_key = std::move(dk);
+    }
+
+    // Tombstone: null value means pure delete.
+    if (!parsable_val.has_value()) {
+        co_return translated_record{
+          .data_row = std::nullopt,
+          .delete_key = std::move(delete_key),
+        };
+    }
+
+    // Data row identical to key_value_translator.
+    auto system_data = build_rp_struct(
+      pid, o, std::move(key), ts, ts_t, headers);
+    iceberg::struct_value ret_data;
+    ret_data.fields.emplace_back(std::move(system_data));
+    ret_data.fields.emplace_back(
+      iceberg::binary_value(std::move(*parsable_val)));
+
+    co_return translated_record{
+      .data_row = std::move(ret_data),
+      .delete_key = std::move(delete_key),
+    };
+}
+
+} // namespace datalake

--- a/src/v/datalake/cdc_key_value_translator.h
+++ b/src/v/datalake/cdc_key_value_translator.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "datalake/record_translator.h"
+
+namespace datalake {
+
+/// Translates records using key_value semantics with CDC: every record
+/// produces an equality delete for its key, and tombstones (null value)
+/// are treated as pure deletes.
+class cdc_key_value_translator : public record_translator {
+public:
+    record_type
+    build_type(std::optional<shared_resolved_type_t> val_type) override;
+
+    ss::future<checked<translated_record, errc>> translate_data(
+      model::partition_id pid,
+      kafka::offset o,
+      std::optional<iobuf> key,
+      const std::optional<shared_resolved_type_t>& val_type,
+      std::optional<iobuf> parsable_val,
+      model::timestamp ts,
+      model::timestamp_type ts_t,
+      const chunked_vector<model::record_header>& headers) override;
+
+    ~cdc_key_value_translator() override = default;
+};
+
+} // namespace datalake

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -17,6 +17,7 @@
 #include "config/node_config.h"
 #include "datalake/backlog_controller.h"
 #include "datalake/catalog_schema_manager.h"
+#include "datalake/cdc_key_value_translator.h"
 #include "datalake/cloud_data_io.h"
 #include "datalake/coordinator/catalog_factory.h"
 #include "datalake/coordinator/frontend.h"
@@ -51,6 +52,7 @@ static std::unique_ptr<type_resolver> make_type_resolver(
           false,
           "Cannot make record translator when iceberg is disabled, logic bug.");
     case model::iceberg_mode::variant::key_value:
+    case model::iceberg_mode::variant::cdc_key_value:
         return std::make_unique<binary_type_resolver>();
     case model::iceberg_mode::variant::value_schema_id_prefix:
     case model::iceberg_mode::variant::debezium:
@@ -80,6 +82,8 @@ static std::unique_ptr<record_translator> make_record_translator(
           "Cannot make record translator when iceberg is disabled, logic bug.");
     case model::iceberg_mode::variant::key_value:
         return std::make_unique<key_value_translator>();
+    case model::iceberg_mode::variant::cdc_key_value:
+        return std::make_unique<cdc_key_value_translator>();
     case model::iceberg_mode::variant::value_schema_id_prefix:
     case model::iceberg_mode::variant::value_schema_latest:
         return std::make_unique<structured_data_translator>();

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -676,6 +676,10 @@ public:
         // user.
         value_schema_latest = 3,
         debezium = 4,
+        // Like key_value but with CDC semantics: every record produces
+        // an equality delete for its key, and tombstones (null value)
+        // are treated as pure deletes.
+        cdc_key_value = 5,
     };
     static iceberg_mode disabled;
 
@@ -684,6 +688,8 @@ public:
     static iceberg_mode value_schema_id_prefix;
 
     static iceberg_mode debezium;
+
+    static iceberg_mode cdc_key_value;
 
     // Creates a new iceberg mode with the latest protobuf value kind and the
     // protobuf full name.
@@ -764,13 +770,17 @@ private:
     struct debezium_impl {
         bool operator==(const debezium_impl&) const = default;
     };
+    struct cdc_key_value_impl {
+        bool operator==(const cdc_key_value_impl&) const = default;
+    };
 
     std::variant<
       disabled_impl,
       key_value_impl,
       value_schema_id_prefix_impl,
       value_schema_latest_impl,
-      debezium_impl>
+      debezium_impl,
+      cdc_key_value_impl>
       _impl;
 };
 

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -656,6 +656,8 @@ iceberg_mode iceberg_mode::value_schema_id_prefix
   = iceberg_mode::make<iceberg_mode::variant::value_schema_id_prefix>();
 iceberg_mode iceberg_mode::debezium
   = iceberg_mode::make<iceberg_mode::variant::debezium>();
+iceberg_mode iceberg_mode::cdc_key_value
+  = iceberg_mode::make<iceberg_mode::variant::cdc_key_value>();
 
 void write_nested(iobuf& out, const iceberg_mode& m) {
     using serde::write;
@@ -692,6 +694,9 @@ void read_nested(
     case iceberg_mode::variant::debezium:
         m = iceberg_mode::debezium;
         return;
+    case iceberg_mode::variant::cdc_key_value:
+        m = iceberg_mode::cdc_key_value;
+        return;
     }
     throw serde::serde_exception(
       fmt::format("unknown iceberg_mode variant: {}", std::to_underlying(v)));
@@ -724,6 +729,8 @@ std::ostream& operator<<(std::ostream& os, const iceberg_mode& mode) {
     }
     case iceberg_mode::variant::debezium:
         return os << "debezium_schema_id_prefix";
+    case iceberg_mode::variant::cdc_key_value:
+        return os << "cdc_key_value";
     }
 }
 
@@ -769,6 +776,8 @@ std::istream& operator>>(std::istream& is, iceberg_mode& mode) {
         mode = iceberg_mode::value_schema_id_prefix;
     } else if (s == "debezium_schema_id_prefix") {
         mode = iceberg_mode::debezium;
+    } else if (s == "cdc_key_value") {
+        mode = iceberg_mode::cdc_key_value;
     } else if (s.starts_with("value_schema_latest")) {
         s = s.substr(std::strlen("value_schema_latest"));
         auto options = parse_config_options(s);

--- a/tests/rptest/tests/datalake/cdc_key_value_test.py
+++ b/tests/rptest/tests/datalake/cdc_key_value_test.py
@@ -1,0 +1,109 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+"""Test for cdc_key_value iceberg mode.
+
+Verifies that records with keys produce equality deletes, and
+tombstones (null value) are treated as pure deletes.
+"""
+
+from ducktape.mark import matrix
+from ducktape.utils.util import wait_until
+
+from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import SISettings, SchemaRegistryConfig
+from rptest.tests.datalake.datalake_services import DatalakeServices
+from rptest.tests.datalake.query_engine_base import QueryEngineType
+from rptest.tests.datalake.utils import supported_storage_types
+from rptest.tests.redpanda_test import RedpandaTest
+
+TOPIC = "cdc-kv-test"
+
+
+class CdcKeyValueTest(RedpandaTest):
+    """Tests for cdc_key_value iceberg mode."""
+
+    def __init__(self, test_ctx):
+        super().__init__(
+            test_ctx,
+            num_brokers=1,
+            si_settings=SISettings(test_context=test_ctx),
+            schema_registry_config=SchemaRegistryConfig(),
+            extra_rp_conf={
+                "iceberg_enabled": True,
+                "iceberg_catalog_commit_interval_ms": 5000,
+            },
+        )
+        self.dl = DatalakeServices(
+            self.test_context,
+            redpanda=self.redpanda,
+            include_query_engines=[QueryEngineType.SPARK],
+        )
+
+    def setUp(self):
+        self.dl.setUp()
+
+    def tearDown(self):
+        self.dl.tearDown()
+        super().tearDown()
+
+    @cluster(num_nodes=3)
+    @matrix(cloud_storage_type=supported_storage_types())
+    def test_cdc_key_value_upsert_delete(self, cloud_storage_type):
+        """Insert, update (overwrite key), and delete (tombstone)."""
+        self.dl.create_iceberg_enabled_topic(
+            TOPIC,
+            iceberg_mode="cdc_key_value",
+            config={
+                TopicSpec.PROPERTY_ICEBERG_PARTITION_SPEC: "(identity(redpanda.key))",
+            },
+        )
+
+        rpk = RpkTool(self.redpanda)
+
+        # Insert three records.
+        rpk.produce(TOPIC, key="k1", msg="alice")
+        rpk.produce(TOPIC, key="k2", msg="bob")
+        rpk.produce(TOPIC, key="k3", msg="charlie")
+
+        self.dl.wait_for_translation(TOPIC, msg_count=3)
+
+        # Update k1 (produces equality delete for k1 + new data row).
+        rpk.produce(TOPIC, key="k1", msg="alicia")
+        # Delete k2 via tombstone.
+        rpk.produce(TOPIC, key="k2", msg="", tombstone=True)
+
+        spark = self.dl.query_engine(QueryEngineType.SPARK)
+        tbl = f"redpanda.{spark.escape_identifier(TOPIC)}"
+
+        def _check():
+            try:
+                rows = spark.run_query_fetch_all(
+                    f"SELECT redpanda.key, value FROM {tbl} ORDER BY redpanda.key"
+                )
+                self.logger.info(f"Rows: {rows}")
+                # k1 updated to 'alicia', k2 deleted, k3 unchanged.
+                # Key and value are binary; Spark returns them as bytes.
+                expected = [
+                    (bytearray(b"k1"), bytearray(b"alicia")),
+                    (bytearray(b"k3"), bytearray(b"charlie")),
+                ]
+                return rows == expected
+            except Exception as e:
+                self.logger.info(f"Query failed: {e}")
+                return False
+
+        wait_until(
+            _check,
+            timeout_sec=120,
+            backoff_sec=5,
+            err_msg="CDC final state not reflected in Iceberg",
+        )


### PR DESCRIPTION
Add cdc_key_value_translator that interprets the record key as the
equality delete key and the value as the data payload, producing both
data rows and delete keys without requiring a schema registry. This
enables simple CDC use cases where the key naturally identifies the
row to upsert or delete.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>