### PR TITLE
CORE-3182 sr/json: support external schema references

### DIFF
--- a/src/v/datalake/record_schema_resolver.cc
+++ b/src/v/datalake/record_schema_resolver.cc
@@ -104,10 +104,10 @@ checked<resolved_type, type_resolver::errc> translate_json_schema(
   const ppsr::json_schema_definition& json_def, ppsr::schema_id id) {
     try {
         auto& doc = document(json_def());
+        auto externals = external_schema_documents(json_def());
+        auto base_uri = root_base_uri(json_def());
         auto fc = iceberg::conversion::json_schema::frontend{};
-        // todo figure out
-        auto json_schema = fc.compile(
-          doc, "https://example.com/schema.json", std::nullopt);
+        auto json_schema = fc.compile(doc, base_uri, std::nullopt, externals);
         auto iceberg_ir = iceberg::type_to_ir(json_schema);
         if (iceberg_ir.has_error()) {
             vlog(

--- a/src/v/iceberg/conversion/json_schema/frontend.cc
+++ b/src/v/iceberg/conversion/json_schema/frontend.cc
@@ -342,6 +342,33 @@ public:
         json_to_subschema_[node] = sub;
     }
 
+    void merge_from(const compile_context& other) {
+        for (const auto& [id, rctx] : other.ctx_by_id_) {
+            ctx_by_id_.emplace(id, rctx);
+            seen_ids_.insert(id);
+        }
+        for (const auto& [node, sub] : other.json_to_subschema_) {
+            json_to_subschema_.emplace(node, sub);
+        }
+    }
+
+    // Extract all schema_resource shared_ptrs in ctx_by_id_ other than
+    // `root`. This includes both externally-registered schemas and nested
+    // $id subresources of the root document. Callers transfer ownership
+    // of these into the root schema_resource so they outlive the
+    // compile_context.
+    std::vector<ss::shared_ptr<schema_resource>>
+    take_non_root_resources(const ss::shared_ptr<schema_resource>& root) {
+        auto deps = std::vector<ss::shared_ptr<schema_resource>>{};
+        for (auto& [id, rctx] : ctx_by_id_) {
+            auto s = rctx.schema();
+            if (s != root) {
+                deps.push_back(std::move(s));
+            }
+        }
+        return deps;
+    }
+
 private:
     absl::btree_map<std::string, resource_context> ctx_by_id_;
     chunked_hash_map<const json::Value*, const subschema*> json_to_subschema_;
@@ -495,8 +522,28 @@ public:
       const json::Document& doc,
       const std::string& initial_base_uri,
       std::optional<dialect> default_dialect) const {
+        return compile_document(doc, initial_base_uri, default_dialect, {});
+    }
+
+    ss::shared_ptr<schema_resource> compile_document(
+      const json::Document& doc,
+      const std::string& initial_base_uri,
+      std::optional<dialect> default_dialect,
+      const frontend::external_schemas_t& external_schemas) const {
         compile_context ctx{parse_base_uri(initial_base_uri), default_dialect};
 
+        // Phase 1: compile each external schema in its own context.
+        // This avoids interfering with the root document's compilation
+        // state (depth counter, seen_ids).
+        for (const auto& [uri_key, ext_doc] : external_schemas) {
+            compile_context ext_ctx{parse_base_uri(uri_key), default_dialect};
+            auto ext_sub = compile_subschema(ext_ctx, *ext_doc);
+            fix_subschemas_base(*ext_sub, nullptr);
+
+            ctx.merge_from(ext_ctx);
+        }
+
+        // Phase 2: compile the root document
         auto subschema = compile_subschema(ctx, doc);
         auto schema_rsc = ss::dynamic_pointer_cast<schema_resource>(subschema);
 
@@ -505,7 +552,16 @@ public:
           "The root of the schema must be a schema resource");
 
         fix_subschemas_base(*subschema, schema_rsc.get());
+
+        // Phase 3: resolve $refs in all compiled trees. External resources
+        // are registered in ctx_by_id_ so cross-document refs resolve
+        // naturally. We must resolve external trees too, since they may
+        // contain their own internal $refs.
         resolve_refs(ctx, *subschema);
+        for (auto& dep : ctx.take_non_root_resources(schema_rsc)) {
+            resolve_refs(ctx, *dep);
+            schema_rsc->add_external_dep(std::move(dep));
+        }
 
         return schema_rsc;
     }
@@ -792,6 +848,15 @@ schema frontend::compile(
   std::optional<dialect> default_dialect) const {
     return schema(
       impl_->compile_document(doc, initial_base_uri, default_dialect));
+};
+
+schema frontend::compile(
+  const json::Document& doc,
+  const std::string& initial_base_uri,
+  std::optional<dialect> default_dialect,
+  const external_schemas_t& external_schemas) const {
+    return schema(impl_->compile_document(
+      doc, initial_base_uri, default_dialect, external_schemas));
 };
 
 }; // namespace iceberg::conversion::json_schema

--- a/src/v/iceberg/conversion/json_schema/frontend.h
+++ b/src/v/iceberg/conversion/json_schema/frontend.h
@@ -14,6 +14,7 @@
 #include "json/document.h"
 
 #include <memory>
+#include <vector>
 
 namespace iceberg::conversion::json_schema {
 
@@ -55,6 +56,20 @@ public:
       const json::Document& doc,
       const std::string& initial_base_uri,
       std::optional<dialect> default_dialect) const;
+
+    /// \brief Like compile(), but with external schemas pre-registered.
+    ///
+    /// Each external schema entry is (uri_key, document*). The documents
+    /// are compiled into resource contexts and registered before $ref
+    /// resolution, so external references resolve naturally.
+    using external_schemas_t
+      = std::vector<std::pair<std::string, const json::Document*>>;
+
+    schema compile(
+      const json::Document& doc,
+      const std::string& initial_base_uri,
+      std::optional<dialect> default_dialect,
+      const external_schemas_t& external_schemas) const;
 
 private:
     std::unique_ptr<frontend_impl> impl_;

--- a/src/v/iceberg/conversion/json_schema/ir.h
+++ b/src/v/iceberg/conversion/json_schema/ir.h
@@ -367,10 +367,21 @@ public:
     const std::string& id() const { return id_; }
     dialect dialect() const { return dialect_; }
 
+    /// Record an external schema resource that this resource's subtree
+    /// depends on via $ref. Prevents the external subschema tree from
+    /// being destroyed while raw ref_ pointers still reference it.
+    void add_external_dep(ss::shared_ptr<schema_resource> dep) {
+        external_deps_.push_back(std::move(dep));
+    }
+
 private:
     /// The canonical URI of the schema resource.
     std::string id_;
     enum dialect dialect_;
+
+    /// External schema resources referenced via $ref from this resource's
+    /// subtree.
+    std::vector<ss::shared_ptr<schema_resource>> external_deps_;
 };
 
 /// Root of the intermediate representation (IR) tree for JSON schema.

--- a/src/v/iceberg/conversion/json_schema/tests/BUILD
+++ b/src/v/iceberg/conversion/json_schema/tests/BUILD
@@ -22,6 +22,7 @@ redpanda_cc_gtest(
         "frontend_test.cc",
     ],
     deps = [
+        "//src/v/iceberg/conversion:ir_json",
         "//src/v/iceberg/conversion/json_schema:frontend",
         "//src/v/iceberg/conversion/json_schema:ir",
         "//src/v/json",

--- a/src/v/iceberg/conversion/json_schema/tests/frontend_test.cc
+++ b/src/v/iceberg/conversion/json_schema/tests/frontend_test.cc
@@ -9,6 +9,7 @@
  */
 
 #include "gmock/gmock.h"
+#include "iceberg/conversion/ir_json.h"
 #include "iceberg/conversion/json_schema/frontend.h"
 #include "iceberg/conversion/json_schema/ir.h"
 #include "json/document.h"
@@ -1234,3 +1235,201 @@ TEST(frontend_test, non_object_root) {
       ThrowsMessage<std::runtime_error>(
         StrEq("JSON Schema document must be an object")));
 }
+
+// ---- External schema reference tests ----
+
+TEST(frontend_test, external_ref_still_throws_without_externals) {
+    auto root = parse_json(R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "lead": { "$ref": "https://example.com/missing.json" }
+      }
+    })");
+
+    EXPECT_THAT(
+      [&] {
+          frontend{}.compile(
+            root, "https://example.com/root.json", std::nullopt);
+      },
+      ThrowsMessage<std::runtime_error>(HasSubstr("Unresolvable $ref")));
+}
+
+TEST(frontend_test, root_id_collides_with_external_uri) {
+    // A root $id matching a pre-registered external URI must throw a clean
+    // "Duplicate schema ID" from push(), not trip dassert(inserted).
+    auto root = parse_json(R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://example.com/shared.json",
+      "type": "object"
+    })");
+
+    auto external = parse_json(R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://example.com/shared.json",
+      "type": "object"
+    })");
+
+    frontend::external_schemas_t externals;
+    externals.emplace_back("https://example.com/shared.json", &external);
+
+    EXPECT_THAT(
+      [&] {
+          frontend{}.compile(
+            root, "https://example.com/root.json", std::nullopt, externals);
+      },
+      ThrowsMessage<std::runtime_error>(HasSubstr("Duplicate schema ID")));
+}
+
+namespace {
+
+struct external_case {
+    std::string_view name;
+    std::string_view root;
+    std::string_view external_uri;
+    std::string_view external;
+    std::string_view initial_base_uri = "https://example.com/root.json";
+};
+
+} // namespace
+
+class ExternalRefCompileTest
+  : public ::testing::TestWithParam<external_case> {};
+
+TEST_P(ExternalRefCompileTest, CompilesToValidIR) {
+    const auto& p = GetParam();
+    auto root = parse_json(p.root);
+    auto ext = parse_json(p.external);
+
+    frontend::external_schemas_t externals;
+    externals.emplace_back(std::string{p.external_uri}, &ext);
+
+    auto s = frontend{}.compile(
+      root, std::string{p.initial_base_uri}, std::nullopt, externals);
+
+    auto ir = iceberg::type_to_ir(s);
+    ASSERT_FALSE(ir.has_error()) << ir.error();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  All,
+  ExternalRefCompileTest,
+  ::testing::ValuesIn(
+    std::vector<external_case>{
+      {.name = "basic_with_id",
+       .root = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "lead": { "$ref": "https://example.com/person.json" }
+      }
+    })",
+       .external_uri = "https://example.com/person.json",
+       .external = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://example.com/person.json",
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" }
+      }
+    })"},
+
+      {.name = "json_pointer_fragment",
+       .root = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": { "$ref": "https://example.com/types.json#/definitions/FullName" }
+      }
+    })",
+       .external_uri = "https://example.com/types.json",
+       .external = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://example.com/types.json",
+      "type": "object",
+      "definitions": {
+        "FullName": {
+          "type": "object",
+          "properties": {
+            "first": { "type": "string" },
+            "last": { "type": "string" }
+          }
+        }
+      }
+    })"},
+
+      {.name = "internal_refs_with_id",
+       .root = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "person": { "$ref": "https://example.com/person.json" }
+      }
+    })",
+       .external_uri = "https://example.com/person.json",
+       .external = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://example.com/person.json",
+      "type": "object",
+      "properties": {
+        "name": { "$ref": "#/definitions/FullName" }
+      },
+      "definitions": {
+        "FullName": {
+          "type": "object",
+          "properties": {
+            "first": { "type": "string" },
+            "last": { "type": "string" }
+          }
+        }
+      }
+    })"},
+
+      // SR behavior: schemas without $id use an empty base, and bare refs
+      // like "person.json" get absolutified to "/person.json".
+      {.name = "bare_ref_no_id",
+       .root = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "lead": { "$ref": "/person.json" }
+      }
+    })",
+       .external_uri = "/person.json",
+       .external = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" }
+      }
+    })",
+       .initial_base_uri = ""},
+
+      {.name = "bare_ref_internal_refs",
+       .root = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "person": { "$ref": "/person.json" }
+      }
+    })",
+       .external_uri = "/person.json",
+       .external = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": { "$ref": "#/definitions/FullName" }
+      },
+      "definitions": {
+        "FullName": {
+          "type": "object",
+          "properties": {
+            "first": { "type": "string" },
+            "last": { "type": "string" }
+          }
+        }
+      }
+    })",
+       .initial_base_uri = ""},
+    }),
+  [](const auto& info) { return std::string{info.param.name}; });

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -172,6 +172,11 @@ struct document_context {
     json::Document doc;
     json_schema_dialect dialect;
     id_to_schema_pointer bundled_schemas;
+    // External schemas keyed by absolute URI (e.g., "/person.json").
+    // Each entry is a fully independent document with its own bundled_schemas.
+    // For transitive references (A→B→C), the structure is recursive:
+    // A's external_schemas contains B, B's contains C.
+    chunked_hash_map<json_id_uri, document_context> external_schemas;
 };
 
 // Passed into is_superset_* methods where the path and the generated verbose
@@ -281,21 +286,6 @@ std::string_view as_string_view(const json::Value& v) {
     return {v.GetString(), v.GetStringLength()};
 }
 
-ss::future<> check_references(sharded_store& store, subject_schema schema) {
-    for (const auto& ref : schema.def().refs()) {
-        auto resolved_sub = ref.sub.resolve(schema.sub().ctx);
-        co_await store.get_id(resolved_sub, ref.version)
-          .discard_result()
-          .handle_exception_type([&](const exception& e) {
-              if (failed_subject_schema_lookup(e.code())) {
-                  throw as_exception(
-                    no_reference_found_for(schema, resolved_sub, ref.version));
-              }
-              throw;
-          });
-    }
-}
-
 // OutputStream adapter for rapidjson Writer to write directly to fmt::iterator
 struct fmt_iterator_output_stream {
     using Ch = char;
@@ -331,27 +321,54 @@ struct pjp {
 class schema_context {
 public:
     explicit schema_context(const json_schema_definition::impl& schema)
-      : _schema{schema} {}
+      : _doc_ctx{schema.ctx} {}
 
-    json_schema_dialect dialect() const { return _schema.ctx.dialect; }
-    const json::Value& doc() const { return _schema.ctx.doc; }
+    json_schema_dialect dialect() const { return _doc_ctx.get().dialect; }
+    const json::Value& doc() const { return _doc_ctx.get().doc; }
 
     const id_to_schema_pointer::mapped_type*
-    find_bundled(const json_id_uri id) const {
-        auto it = _schema.ctx.bundled_schemas.find(id);
-        if (it == _schema.ctx.bundled_schemas.end()) {
+    find_bundled(const json_id_uri& id) const {
+        auto it = _doc_ctx.get().bundled_schemas.find(id);
+        if (it == _doc_ctx.get().bundled_schemas.end()) {
             return nullptr;
         }
         return &(it->second);
+    }
+
+    const document_context* find_external(const json_id_uri& id) const {
+        auto it = _doc_ctx.get().external_schemas.find(id);
+        if (it == _doc_ctx.get().external_schemas.end()) {
+            return nullptr;
+        }
+        return &(it->second);
+    }
+
+    // Create a child context scoped to an external document.
+    // The child inherits the parent's remaining recursion budget.
+    schema_context make_child_context(const document_context& ext_ctx) const {
+        return schema_context{ext_ctx, _ref_units};
     }
 
     int remaining_ref_units() const { return _ref_units; }
     int consume_ref_units() { return --_ref_units; }
 
 private:
-    const json_schema_definition::impl& _schema;
+    schema_context(const document_context& ctx, int ref_units)
+      : _doc_ctx{ctx}
+      , _ref_units{ref_units} {}
+
+    std::reference_wrapper<const document_context> _doc_ctx;
     static constexpr int max_recursion_depth{63};
     int _ref_units{max_recursion_depth};
+};
+
+// Result of resolve_reference: the resolved JSON object, plus an optional
+// child schema_context when resolution crossed into an external document.
+// When child_ctx has a value, callers must use it for further $ref resolution
+// within the resolved sub-tree.
+struct resolved_ref {
+    json_const_object obj;
+    std::optional<schema_context> child_ctx;
 };
 
 struct compatibility_context {
@@ -829,12 +846,15 @@ resolve_pointer(const json::Pointer& p, const json::Value& root) {
 
 // iteratively resolve a reference, following the $ref field until the end or
 // the max_allowed_depth is reached. throws if the max depth is reached or if
-// the reference can't be resolved
-json_const_object
+// the reference can't be resolved.
+// When resolution crosses into an external document, returns a child
+// schema_context scoped to that document so callers can resolve further
+// $refs within the external sub-tree correctly.
+resolved_ref
 resolve_reference(schema_context& ctx, const json::Value& candidate) {
     auto ref_it = candidate.FindMember("$ref");
     if (ref_it == candidate.MemberEnd()) { // not a reference, no-op
-        return candidate.GetObject();
+        return {candidate.GetObject(), std::nullopt};
     }
 
     auto get_uri_fragment = [](std::string uri_s) {
@@ -849,51 +869,72 @@ resolve_reference(schema_context& ctx, const json::Value& candidate) {
     auto references_objects = absl::InlinedVector<json::Value::ConstObject, 4>{
       candidate.GetObject()};
 
-    // resolve the reference:
-    while (ctx.consume_ref_units() > 0) {
-        // try to find the bundled schema, get a pointer to it
-        auto* lookup_p = ctx.find_bundled(id_uri);
-        if (lookup_p == nullptr) {
-            // TODO use a better error code
-            throw_invalid_schema(
-              "schema pointer not found for uri '{}'", id_uri);
-        }
-        const auto& [schema_pointer, dialect] = *lookup_p;
+    // Track whether we've crossed into an external document
+    std::optional<schema_context> external_ctx;
+    auto active_ctx = [&]() -> schema_context& {
+        return external_ctx.has_value() ? *external_ctx : ctx;
+    };
 
-        // step 1: get the schema object
-        const auto& schema = resolve_pointer(schema_pointer, ctx.doc());
-        // step 2: get the referenced object inside the schema
-        const auto& referenced_obj = resolve_pointer(fragment_p, schema);
-        // step 2.5: store referenced_obj for merging later
-        references_objects.push_back(referenced_obj.GetObject());
+    while (active_ctx().consume_ref_units() > 0) {
+        auto* lookup_p = active_ctx().find_bundled(id_uri);
+        if (lookup_p != nullptr) {
+            const auto& [schema_pointer, dialect] = *lookup_p;
 
-        // step 3: check if the referenced object has a $ref field, and if so
-        // resolve it
-        if (
-          auto next_ref_it = referenced_obj.FindMember("$ref");
-          next_ref_it != referenced_obj.MemberEnd()) {
-            std::tie(id_uri, fragment_p) = get_uri_fragment(
-              next_ref_it->value.GetString());
-        } else {
-            // if this is the final target, return it.
+            const auto& schema = resolve_pointer(
+              schema_pointer, active_ctx().doc());
+            const auto& referenced_obj = resolve_pointer(fragment_p, schema);
+            references_objects.push_back(referenced_obj.GetObject());
 
-            // require that we are using the same dialect as the root object.
-            // this requirement could be relaxed but it requires to keep track
-            // of the dialect for each json::Value
-            if (dialect != ctx.dialect()) {
-                throw_invalid_schema(
-                  "schema dialect mismatch for uri '{}'", id_uri);
+            if (
+              auto next_ref_it = referenced_obj.FindMember("$ref");
+              next_ref_it != referenced_obj.MemberEnd()) {
+                std::tie(id_uri, fragment_p) = get_uri_fragment(
+                  next_ref_it->value.GetString());
+            } else {
+                // Validate dialect consistency within the active document.
+                // Cross-document external refs are allowed to differ because
+                // active_ctx() already switches into the external's own
+                // context, so this check applies to the active document only.
+                if (dialect != active_ctx().dialect()) {
+                    throw_invalid_schema(
+                      "schema dialect mismatch for uri '{}'", id_uri);
+                }
+                return {
+                  merge_references(references_objects),
+                  std::move(external_ctx)};
             }
-
-            return merge_references(references_objects);
+            continue;
         }
+
+        const auto* ext_doc = active_ctx().find_external(id_uri);
+        if (ext_doc != nullptr) {
+            external_ctx.emplace(active_ctx().make_child_context(*ext_doc));
+
+            const auto& referenced_obj = resolve_pointer(
+              fragment_p, ext_doc->doc);
+            references_objects.push_back(referenced_obj.GetObject());
+
+            if (
+              auto next_ref_it = referenced_obj.FindMember("$ref");
+              next_ref_it != referenced_obj.MemberEnd()) {
+                std::tie(id_uri, fragment_p) = get_uri_fragment(
+                  next_ref_it->value.GetString());
+            } else {
+                return {
+                  merge_references(references_objects),
+                  std::move(external_ctx)};
+            }
+            continue;
+        }
+
+        throw_invalid_schema("schema pointer not found for uri '{}'", id_uri);
     }
     throw_invalid_schema(
       "max traversals reached for uri {} '{}'", id_uri, pjp{fragment_p});
 }
 
 // helper to convert a boolean to a schema, and to traverse $refs
-json_const_object get_schema(schema_context& ctx, const json::Value& v) {
+resolved_ref get_schema(schema_context& ctx, const json::Value& v) {
     if (v.IsObject()) {
         return resolve_reference(ctx, v.GetObject());
     }
@@ -901,7 +942,8 @@ json_const_object get_schema(schema_context& ctx, const json::Value& v) {
     if (v.IsBool()) {
         // in >= draft6 "true/false" is a valid schema and means
         // {}/{"not":{}}
-        return v.GetBool() ? get_true_schema() : get_false_schema();
+        return {
+          v.GetBool() ? get_true_schema() : get_false_schema(), std::nullopt};
     }
     throw_invalid_schema(
       "Invalid JSON Schema, should be object or boolean: '{}'", pj{v});
@@ -2178,8 +2220,24 @@ json_compatibility_result is_superset(
         return res;
     }
 
-    auto older = get_schema(ctx.older, older_schema);
-    auto newer = get_schema(ctx.newer, newer_schema);
+    auto older_resolved = get_schema(ctx.older, older_schema);
+    auto newer_resolved = get_schema(ctx.newer, newer_schema);
+
+    // If resolution crossed into an external document, build a new
+    // compatibility_context with the child context for that side.
+    // This ensures all recursive is_superset calls for the resolved
+    // sub-tree use the external document's bundled_schemas.
+    auto child_ctx = compatibility_context{
+      .older = older_resolved.child_ctx.has_value()
+                 ? std::move(*older_resolved.child_ctx)
+                 : ctx.older,
+      .newer = newer_resolved.child_ctx.has_value()
+                 ? std::move(*newer_resolved.child_ctx)
+                 : ctx.newer,
+      .visited = ctx.visited};
+
+    const auto& older = older_resolved.obj;
+    const auto& newer = newer_resolved.obj;
 
     // extract { "type" : ... }
     auto older_types = normalized_type(older);
@@ -2227,16 +2285,16 @@ json_compatibility_result is_superset(
         res.merge(is_numeric_superset(older, newer, p));
     }
     if (newer_types.test(json_type::object)) {
-        res.merge(is_object_superset(ctx, older, newer, p));
+        res.merge(is_object_superset(child_ctx, older, newer, p));
     }
     if (newer_types.test(json_type::array)) {
-        res.merge(is_array_superset(ctx, older, newer, p));
+        res.merge(is_array_superset(child_ctx, older, newer, p));
     }
     // no check needed for boolean and null types
 
     res.merge(is_enum_superset(older, newer, p));
-    res.merge(is_not_combinator_superset(ctx, older, newer, p));
-    res.merge(is_positive_combinator_superset(ctx, older, newer, p));
+    res.merge(is_not_combinator_superset(child_ctx, older, newer, p));
+    res.merge(is_positive_combinator_superset(child_ctx, older, newer, p));
 
     // no rule in newer is less strict than older, older is superset of newer
     return res;
@@ -2446,11 +2504,121 @@ result<id_to_schema_pointer> collect_bundled_schema_and_fix_refs(
 
 } // namespace
 
+// Compute the base URI for a document_context — used for resolving relative
+// reference names to absolute URI keys.
+json_id_uri get_root_base_uri(const document_context& ctx) {
+    // The root $id is always registered in bundled_schemas. If the schema has
+    // an explicit $id, it's stored under that URI. If not, it's stored under
+    // the empty string "".
+    // We need the root $id URI to resolve relative ref names against.
+    // Look for the entry with json::Pointer{} (the root pointer).
+    for (const auto& [uri, entry] : ctx.bundled_schemas) {
+        if (entry.first == json::Pointer{}) {
+            return uri;
+        }
+    }
+    return json_id_uri{""};
+}
+
+// Recursively fetch and parse all external schemas referenced by a schema.
+// Each referenced schema is parsed into its own document_context and stored
+// in the parent's external_schemas map. Transitive references are resolved
+// recursively (depth-first).
+ss::future<> resolve_external_references(
+  schema_getter& store,
+  document_context& ctx,
+  const schema_definition::references& refs,
+  const context_subject& parent_sub,
+  int depth = 0) {
+    static constexpr int max_external_ref_depth = 32;
+    if (depth >= max_external_ref_depth) {
+        throw as_exception(
+          error_info{
+            error_code::schema_invalid,
+            fmt::format(
+              "External reference chain exceeds maximum depth of {}",
+              max_external_ref_depth)});
+    }
+
+    auto root_base = get_root_base_uri(ctx);
+    auto root_base_uri = jsoncons::uri{root_base()};
+
+    for (const auto& ref : refs) {
+        // Compute the absolute URI key that $ref was resolved to by
+        // collect_bundled_schema_and_fix_refs
+        auto key = to_json_id_uri(
+          jsoncons::uri{ref.name}.resolve(root_base_uri));
+
+        // Skip if already resolved in this schema's refs list
+        if (ctx.external_schemas.contains(key)) {
+            continue;
+        }
+
+        auto resolved_sub = ref.sub.resolve(parent_sub.ctx);
+        try {
+            auto ss = co_await store.get_subject_schema(
+              resolved_sub, ref.version, include_deleted::yes);
+
+            // Parse the external schema into its own document_context
+            auto ext_ctx = parse_json(ss.schema.def().shared_raw()())
+                             .value(); // throws on error
+
+            // The referrer's ref.name must agree with any $id the
+            // referenced schema declares. Without this, the $ref would
+            // silently fail to resolve downstream (e.g., during Iceberg
+            // translation).
+            auto declared_id = get_root_base_uri(ext_ctx);
+            if (!declared_id().empty()) {
+                auto declared_id_resolved = to_json_id_uri(
+                  jsoncons::uri{declared_id()}.resolve(root_base_uri));
+                if (declared_id_resolved != key) {
+                    throw as_exception(
+                      error_info{
+                        error_code::schema_invalid,
+                        fmt::format(
+                          "Schema reference name \"{}\" does not match "
+                          "$id \"{}\" declared by subject \"{}\" version {}",
+                          ref.name,
+                          declared_id(),
+                          resolved_sub,
+                          ref.version)});
+                }
+            }
+
+            co_await resolve_external_references(
+              store,
+              ext_ctx,
+              ss.schema.def().refs(),
+              ss.schema.sub(),
+              depth + 1);
+
+            ctx.external_schemas.emplace(key, std::move(ext_ctx));
+        } catch (const exception& e) {
+            if (failed_subject_schema_lookup(e.code())) {
+                throw as_exception(
+                  error_info{
+                    error_code::schema_missing_reference,
+                    fmt::format(
+                      "No schema reference found for subject \"{}\" "
+                      "and version {}",
+                      resolved_sub,
+                      ref.version)});
+            }
+            throw;
+        }
+    }
+}
+
 ss::future<json_schema_definition>
-make_json_schema_definition(schema_getter&, subject_schema schema) {
+make_json_schema_definition(schema_getter& store, subject_schema schema) {
     auto [sub, unparsed] = std::move(schema).destructure();
+    auto parent_sub = sub;
     auto [def, type, refs, meta] = std::move(unparsed).destructure();
     auto doc = parse_json(std::move(def)).value(); // throws on error
+
+    // Resolve external references — fetch and parse referenced schemas
+    co_await resolve_external_references(store, doc, refs, parent_sub);
+
     co_return json_schema_definition{
       ss::make_shared<json_schema_definition::impl>(
         std::move(doc), std::move(refs), std::move(meta))};
@@ -2459,9 +2627,16 @@ make_json_schema_definition(schema_getter&, subject_schema schema) {
 ss::future<subject_schema> make_canonical_json_schema(
   sharded_store& store, subject_schema unparsed_schema, normalize norm) {
     auto [sub, unparsed] = std::move(unparsed_schema).destructure();
+    auto parent_sub = sub;
     auto [def, type, refs, meta] = std::move(unparsed).destructure();
 
     auto ctx = parse_json(std::move(def)).value(); // throws on error
+
+    // Resolve external references to validate they exist and parse correctly.
+    // The resolved schemas are not retained in the canonical output — the
+    // canonical form keeps $ref values as-is (matching Confluent behavior).
+    co_await resolve_external_references(store, ctx, refs, parent_sub);
+
     if (norm) {
         sort(ctx.doc);
         std::sort(refs.begin(), refs.end());
@@ -2471,18 +2646,13 @@ ss::future<subject_schema> make_canonical_json_schema(
     json::Writer<json::chunked_buffer> w{out};
     ctx.doc.Accept(w);
 
-    subject_schema schema{
+    co_return subject_schema{
       std::move(sub),
       schema_definition{
         schema_definition::raw_string{std::move(out).as_iobuf()},
         type,
         std::move(refs),
         std::move(meta)}};
-
-    // Ensure all references exist
-    co_await check_references(store, schema.share());
-
-    co_return schema;
 }
 
 compatibility_result check_compatible(

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -241,6 +241,40 @@ const json::Document& document(const json_schema_definition::impl& impl) {
     return impl.ctx.doc;
 }
 
+namespace {
+void flatten_external_schemas(
+  const document_context& ctx,
+  std::vector<std::pair<std::string, const json::Document*>>& out) {
+    for (const auto& [uri, ext_ctx] : ctx.external_schemas) {
+        out.emplace_back(uri(), &ext_ctx.doc);
+        flatten_external_schemas(ext_ctx, out);
+    }
+}
+
+// Return the root $id URI for a document_context. The root entry in
+// bundled_schemas has an empty json::Pointer; its key is the $id URI
+// (or "" when no $id is declared).
+json_id_uri get_root_base_uri(const document_context& ctx) {
+    for (const auto& [uri, entry] : ctx.bundled_schemas) {
+        if (entry.first == json::Pointer{}) {
+            return uri;
+        }
+    }
+    return json_id_uri{""};
+}
+} // namespace
+
+std::vector<std::pair<std::string, const json::Document*>>
+external_schema_documents(const json_schema_definition::impl& impl) {
+    auto result = std::vector<std::pair<std::string, const json::Document*>>{};
+    flatten_external_schemas(impl.ctx, result);
+    return result;
+}
+
+ss::sstring root_base_uri(const json_schema_definition::impl& impl) {
+    return get_root_base_uri(impl.ctx)();
+}
+
 bool operator==(
   const json_schema_definition& lhs, const json_schema_definition& rhs) {
     return lhs.raw() == rhs.raw();
@@ -2503,22 +2537,6 @@ result<id_to_schema_pointer> collect_bundled_schema_and_fix_refs(
 }
 
 } // namespace
-
-// Compute the base URI for a document_context — used for resolving relative
-// reference names to absolute URI keys.
-json_id_uri get_root_base_uri(const document_context& ctx) {
-    // The root $id is always registered in bundled_schemas. If the schema has
-    // an explicit $id, it's stored under that URI. If not, it's stored under
-    // the empty string "".
-    // We need the root $id URI to resolve relative ref names against.
-    // Look for the entry with json::Pointer{} (the root pointer).
-    for (const auto& [uri, entry] : ctx.bundled_schemas) {
-        if (entry.first == json::Pointer{}) {
-            return uri;
-        }
-    }
-    return json_id_uri{""};
-}
 
 // Recursively fetch and parse all external schemas referenced by a schema.
 // Each referenced schema is parsed into its own document_context and stored

--- a/src/v/pandaproxy/schema_registry/json.h
+++ b/src/v/pandaproxy/schema_registry/json.h
@@ -15,6 +15,12 @@
 #include "pandaproxy/schema_registry/fwd.h"
 #include "pandaproxy/schema_registry/types.h"
 
+#include <seastar/core/sstring.hh>
+
+#include <string>
+#include <utility>
+#include <vector>
+
 namespace pandaproxy::schema_registry {
 
 ss::future<json_schema_definition>
@@ -29,5 +35,17 @@ compatibility_result check_compatible(
   verbose is_verbose = verbose::no);
 
 const json::Document& document(const json_schema_definition::impl& impl);
+
+// Return a flattened list of all external schemas (including transitive
+// dependencies) as (uri_key, document*) pairs. Used by the Iceberg
+// integration to pass external schemas to the JSON schema frontend.
+std::vector<std::pair<std::string, const json::Document*>>
+external_schema_documents(const json_schema_definition::impl& impl);
+
+// Return the root schema's base URI ($id value, or empty if absent).
+// Used by the Iceberg integration to pass the correct initial_base_uri
+// to the JSON schema frontend so that $ref resolution matches the
+// SR's URI normalization.
+ss::sstring root_base_uri(const json_schema_definition::impl& impl);
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/test/BUILD
+++ b/src/v/pandaproxy/schema_registry/test/BUILD
@@ -336,6 +336,22 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "json_schema_references_test",
+    timeout = "short",
+    srcs = [
+        "json_schema_references.cc",
+    ],
+    cpu = 1,
+    deps = [
+        ":store_fixture",
+        "//src/v/pandaproxy/schema_registry:core",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "context_subject_test",
     timeout = "short",
     srcs = [

--- a/src/v/pandaproxy/schema_registry/test/json_schema_references.cc
+++ b/src/v/pandaproxy/schema_registry/test/json_schema_references.cc
@@ -1,0 +1,502 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "pandaproxy/schema_registry/exceptions.h"
+#include "pandaproxy/schema_registry/json.h"
+#include "pandaproxy/schema_registry/test/store_fixture.h"
+#include "pandaproxy/schema_registry/types.h"
+
+#include <gtest/gtest.h>
+
+namespace pandaproxy::schema_registry {
+
+namespace {
+
+schema_reference
+make_ref(std::string_view name, std::string_view subject, int version) {
+    return schema_reference{
+      .name = ss::sstring{name.data(), name.size()},
+      .sub = context_subject_reference::unqualified(subject),
+      .version = schema_version(version)};
+}
+
+schema_definition
+raw_schema(std::string_view body, schema_definition::references refs = {}) {
+    return schema_definition{
+      body, schema_type::json, std::move(refs), std::nullopt};
+}
+
+} // namespace
+
+class JsonSchemaReferencesTest
+  : public ::testing::Test
+  , public test_utils::store_fixture {
+public:
+    json_schema_definition register_schema(
+      const context_subject& sub,
+      const schema_definition& schema_def,
+      schema_version version) {
+        auto json_def = make_json_schema_definition(
+                          _store, {sub, schema_def.share()})
+                          .get();
+
+        store_fixture::insert(sub, schema_def, version);
+
+        return json_def;
+    }
+};
+
+// ---- Parameterized happy-path tests ----
+
+namespace {
+
+struct dep_schema {
+    std::string_view subject;
+    std::string_view body;
+};
+
+struct ref_entry {
+    std::string_view name;
+    std::string_view subject;
+    int version;
+};
+
+struct happy_case {
+    std::string_view name;
+    std::vector<dep_schema> deps;
+    std::string_view root_subject;
+    std::string_view root_body;
+    std::vector<ref_entry> root_refs;
+};
+
+} // namespace
+
+class JsonSchemaHappyPathTest
+  : public JsonSchemaReferencesTest
+  , public ::testing::WithParamInterface<happy_case> {};
+
+TEST_P(JsonSchemaHappyPathTest, RegistersWithoutError) {
+    const auto& p = GetParam();
+
+    for (const auto& dep : p.deps) {
+        register_schema(
+          context_subject::unqualified(dep.subject),
+          raw_schema(dep.body),
+          schema_version{1});
+    }
+
+    schema_definition::references refs;
+    for (const auto& r : p.root_refs) {
+        refs.push_back(make_ref(r.name, r.subject, r.version));
+    }
+
+    ASSERT_NO_THROW(register_schema(
+      context_subject::unqualified(p.root_subject),
+      raw_schema(p.root_body, std::move(refs)),
+      schema_version{1}));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  All,
+  JsonSchemaHappyPathTest,
+  ::testing::ValuesIn(
+    std::vector<happy_case>{
+      {.name = "basic",
+       .deps = {{.subject = "PersonSubject", .body = R"({
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "age": { "type": "integer" }
+  }
+})"}},
+       .root_subject = "TeamSubject",
+       .root_body = R"({
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "lead": { "$ref": "person.json" }
+  }
+})",
+       .root_refs
+       = {{.name = "person.json", .subject = "PersonSubject", .version = 1}}},
+
+      {.name = "json_pointer_fragment",
+       .deps = {{.subject = "TypesSubject", .body = R"({
+  "type": "object",
+  "$defs": {
+    "FullName": {
+      "type": "object",
+      "properties": {
+        "first": { "type": "string" },
+        "last": { "type": "string" }
+      }
+    }
+  }
+})"}},
+       .root_subject = "PersonSubject",
+       .root_body = R"({
+  "type": "object",
+  "properties": {
+    "name": { "$ref": "types.json#/$defs/FullName" }
+  }
+})",
+       .root_refs
+       = {{.name = "types.json", .subject = "TypesSubject", .version = 1}}},
+
+      {.name = "multiple_refs_one_of",
+       .deps
+       = {{.subject = "PersonSubject", .body = R"({"type": "object", "properties": {"name": {"type": "string"}}})"}, {.subject = "CompanySubject", .body = R"({"type": "object", "properties": {"company_name": {"type": "string"}}})"}},
+       .root_subject = "ContactSubject",
+       .root_body = R"({
+  "oneOf": [
+    { "$ref": "person.json" },
+    { "$ref": "company.json" }
+  ]
+})",
+       .root_refs
+       = {{.name = "person.json", .subject = "PersonSubject", .version = 1}, {.name = "company.json", .subject = "CompanySubject", .version = 1}}},
+
+      {.name = "dot_slash_prefix",
+       .deps
+       = {{.subject = "PersonSubject", .body = R"({"type": "object", "properties": {"name": {"type": "string"}}})"}},
+       .root_subject = "TeamSubject",
+       .root_body = R"({
+  "type": "object",
+  "properties": {
+    "lead": { "$ref": "./person.json" }
+  }
+})",
+       .root_refs
+       = {{.name = "person.json", .subject = "PersonSubject", .version = 1}}},
+    }),
+  [](const auto& info) { return std::string{info.param.name}; });
+
+// ---- Multi-step and error tests ----
+
+TEST_F(JsonSchemaReferencesTest, TransitiveReferences) {
+    register_schema(
+      context_subject::unqualified("CountrySubject"),
+      raw_schema(R"({
+  "type": "object",
+  "properties": {
+    "code": { "type": "string" }
+  }
+})"),
+      schema_version{1});
+
+    register_schema(
+      context_subject::unqualified("AddressSubject"),
+      raw_schema(
+        R"({
+  "type": "object",
+  "properties": {
+    "street": { "type": "string" },
+    "country": { "$ref": "country.json" }
+  }
+})",
+        {make_ref("country.json", "CountrySubject", 1)}),
+      schema_version{1});
+
+    ASSERT_NO_THROW(register_schema(
+      context_subject::unqualified("PersonSubject"),
+      raw_schema(
+        R"({
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "address": { "$ref": "address.json" }
+  }
+})",
+        {make_ref("address.json", "AddressSubject", 1)}),
+      schema_version{1}));
+}
+
+TEST_F(JsonSchemaReferencesTest, DiamondDependencies) {
+    // A → {B, C} → D
+    register_schema(
+      context_subject::unqualified("BaseSubject"),
+      raw_schema(
+        R"({"type": "object", "properties": {"id": {"type": "string"}}})"),
+      schema_version{1});
+
+    register_schema(
+      context_subject::unqualified("LeftSubject"),
+      raw_schema(
+        R"({"type": "object", "properties": {"base": {"$ref": "base.json"}}})",
+        {make_ref("base.json", "BaseSubject", 1)}),
+      schema_version{1});
+
+    register_schema(
+      context_subject::unqualified("RightSubject"),
+      raw_schema(
+        R"({"type": "object", "properties": {"base": {"$ref": "base.json"}}})",
+        {make_ref("base.json", "BaseSubject", 1)}),
+      schema_version{1});
+
+    ASSERT_NO_THROW(register_schema(
+      context_subject::unqualified("TopSubject"),
+      raw_schema(
+        R"({
+  "type": "object",
+  "properties": {
+    "left": { "$ref": "left.json" },
+    "right": { "$ref": "right.json" }
+  }
+})",
+        {make_ref("left.json", "LeftSubject", 1),
+         make_ref("right.json", "RightSubject", 1)}),
+      schema_version{1}));
+}
+
+TEST_F(JsonSchemaReferencesTest, MissingReference) {
+    auto team_def = raw_schema(
+      R"({
+  "type": "object",
+  "properties": {
+    "lead": { "$ref": "person.json" }
+  }
+})",
+      {make_ref("person.json", "NonExistentSubject", 1)});
+
+    ASSERT_THROW(
+      make_json_schema_definition(
+        _store, {context_subject::unqualified("TeamSubject"), team_def.share()})
+        .get(),
+      exception);
+}
+
+TEST_F(JsonSchemaReferencesTest, RefNameMustMatchExternalId) {
+    // If the referenced schema declares a $id, the referrer's ref.name
+    // must agree. A mismatch is semantically ambiguous — $ref resolution
+    // would silently fail later in the translation pipeline — so reject
+    // it cleanly at registration time.
+    register_schema(
+      context_subject::unqualified("PersonSubject"),
+      raw_schema(R"({
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://canonical.com/person.json",
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" }
+  }
+})"),
+      schema_version{1});
+
+    // ref.name "person.json" does not match the referenced schema's
+    // declared $id "https://canonical.com/person.json".
+    auto team_def = raw_schema(
+      R"({
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "lead": { "$ref": "person.json" }
+  }
+})",
+      {make_ref("person.json", "PersonSubject", 1)});
+
+    ASSERT_THROW(
+      make_json_schema_definition(
+        _store, {context_subject::unqualified("TeamSubject"), team_def.share()})
+        .get(),
+      exception);
+}
+
+TEST_F(JsonSchemaReferencesTest, ExternalSchemaWithOwnId) {
+    // The external schema's $id must be preserved when resolving its
+    // internal relative $refs.
+    register_schema(
+      context_subject::unqualified("PersonSubject"),
+      raw_schema(R"({
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/person.json",
+  "type": "object",
+  "properties": {
+    "name": { "$ref": "#/definitions/FullName" }
+  },
+  "definitions": {
+    "FullName": {
+      "type": "object",
+      "properties": {
+        "first": { "type": "string" },
+        "last": { "type": "string" }
+      }
+    }
+  }
+})"),
+      schema_version{1});
+
+    ASSERT_NO_THROW(register_schema(
+      context_subject::unqualified("TeamSubject"),
+      raw_schema(
+        R"({
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "lead": { "$ref": "https://example.com/person.json" }
+  }
+})",
+        {make_ref("https://example.com/person.json", "PersonSubject", 1)}),
+      schema_version{1}));
+}
+
+// ---- Compatibility tests ----
+
+TEST_F(JsonSchemaReferencesTest, CompatibleRefChange) {
+    auto person_sub = context_subject::unqualified("PersonSubject");
+    register_schema(
+      person_sub,
+      raw_schema(R"({
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" }
+  }
+})"),
+      schema_version{1});
+
+    auto team_v1 = register_schema(
+      context_subject::unqualified("TeamSubject"),
+      raw_schema(
+        R"({
+  "type": "object",
+  "properties": {
+    "lead": { "$ref": "person.json" }
+  }
+})",
+        {make_ref("person.json", "PersonSubject", 1)}),
+      schema_version{1});
+
+    // Evolve person: add optional "age" property
+    register_schema(
+      person_sub,
+      raw_schema(R"({
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "age": { "type": "integer" }
+  }
+})"),
+      schema_version{2});
+
+    auto team_v2 = register_schema(
+      context_subject::unqualified("TeamSubject"),
+      raw_schema(
+        R"({
+  "type": "object",
+  "properties": {
+    "lead": { "$ref": "person.json" }
+  }
+})",
+        {make_ref("person.json", "PersonSubject", 2)}),
+      schema_version{2});
+
+    // Backward-compatible: reader=v1 ignores the added optional "age".
+    auto result = check_compatible(team_v1, team_v2, verbose::yes);
+    ASSERT_TRUE(result.is_compat) << result.messages;
+}
+
+TEST_F(JsonSchemaReferencesTest, IncompatibleRefChange) {
+    auto person_sub = context_subject::unqualified("PersonSubject");
+    register_schema(
+      person_sub,
+      raw_schema(R"({
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" }
+  }
+})"),
+      schema_version{1});
+
+    auto team_v1 = register_schema(
+      context_subject::unqualified("TeamSubject"),
+      raw_schema(
+        R"({
+  "type": "object",
+  "properties": {
+    "lead": { "$ref": "person.json" }
+  }
+})",
+        {make_ref("person.json", "PersonSubject", 1)}),
+      schema_version{1});
+
+    // Evolve person: change "name" from string to integer (incompatible)
+    register_schema(
+      person_sub,
+      raw_schema(R"({
+  "type": "object",
+  "properties": {
+    "name": { "type": "integer" }
+  }
+})"),
+      schema_version{2});
+
+    auto team_v2 = register_schema(
+      context_subject::unqualified("TeamSubject"),
+      raw_schema(
+        R"({
+  "type": "object",
+  "properties": {
+    "lead": { "$ref": "person.json" }
+  }
+})",
+        {make_ref("person.json", "PersonSubject", 2)}),
+      schema_version{2});
+
+    auto result = check_compatible(team_v1, team_v2, verbose::yes);
+    ASSERT_FALSE(result.is_compat);
+}
+
+TEST_F(JsonSchemaReferencesTest, ExternalRefWithInternalRefs) {
+    register_schema(
+      context_subject::unqualified("TypesSubject"),
+      raw_schema(R"({
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "name": { "$ref": "#/definitions/Name" },
+    "address": { "$ref": "#/definitions/Address" }
+  },
+  "definitions": {
+    "Name": {
+      "type": "object",
+      "properties": {
+        "first": { "type": "string" },
+        "last": { "type": "string" }
+      }
+    },
+    "Address": {
+      "type": "object",
+      "properties": {
+        "street": { "type": "string" },
+        "city": { "type": "string" }
+      }
+    }
+  }
+})"),
+      schema_version{1});
+
+    auto root_v1 = register_schema(
+      context_subject::unqualified("RootSubject"),
+      raw_schema(
+        R"({
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "person": { "$ref": "types.json" }
+  }
+})",
+        {make_ref("types.json", "TypesSubject", 1)}),
+      schema_version{1});
+
+    // Exercises cross-document $ref resolution during is_superset.
+    auto result = check_compatible(root_v1, root_v1, verbose::yes);
+    ASSERT_TRUE(result.is_compat) << result.messages;
+}
+
+} // namespace pandaproxy::schema_registry

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -916,6 +916,100 @@ message_type {
             spark_describe_out = spark.run_query_fetch_all(f"describe {table_name}")
             assert spark_describe_out == spark_expected_out, str(spark_describe_out)
 
+    # Note: nothing unique about this test so run it with single catalog/query engine.
+    @cluster(num_nodes=3)
+    @matrix(
+        cloud_storage_type=supported_storage_types(),
+        query_engine=[QueryEngineType.SPARK],
+        catalog_type=[CatalogType.REST_JDBC],
+    )
+    def test_json_references(self, cloud_storage_type, query_engine, catalog_type):
+        """
+        Test that JSON Schema external $ref references are resolved correctly
+        through the datalake pipeline. Registers an address schema, then a
+        person schema that references it via $ref, produces data matching
+        the composed schema, and verifies the Iceberg table has the expected
+        flattened structure.
+        """
+        json_address = """{
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "street": {"type": "string"},
+                "city": {"type": "string"},
+                "zip": {"type": "string"}
+            },
+            "required": ["street", "city", "zip"]
+        }"""
+
+        json_person = """{
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "age": {"type": "integer"},
+                "address": {"$ref": "address.json"}
+            },
+            "required": ["name", "age", "address"]
+        }"""
+
+        count = 100
+
+        with DatalakeServices(
+            self.test_ctx,
+            redpanda=self.redpanda,
+            include_query_engines=[query_engine],
+            catalog_type=catalog_type,
+        ) as dl:
+            rpk = RpkTool(self.redpanda)
+
+            subj_addr = "subject_for_addr"
+            subj_person = "subject_for_person"
+            rpk.create_schema_from_str(subj_addr, json_address, "json")
+            rpk.create_schema_from_str(
+                subj_person,
+                json_person,
+                "json",
+                references=f"address.json:{subj_addr}:1",
+            )
+
+            dl.create_iceberg_enabled_topic(
+                self.topic_name,
+                iceberg_mode=f"value_schema_latest:subject={subj_person}",
+            )
+
+            producer = Producer({"bootstrap.servers": self.redpanda.brokers()})
+            for i in range(count):
+                record = json.dumps(
+                    {
+                        "name": f"Person{i}",
+                        "age": 20 + (i % 50),
+                        "address": {
+                            "street": f"{i} Main St.",
+                            "city": "Redpanda City" if i % 2 == 0 else "Vectortown",
+                            "zip": "12345" if i % 3 == 0 else "67890",
+                        },
+                    }
+                )
+                producer.produce(topic=self.topic_name, value=record)
+            producer.flush()
+
+            dl.wait_for_translation(self.topic_name, msg_count=count)
+
+            table_name = f"redpanda.{self.topic_name}"
+            spark = dl.spark()
+            spark_expected_out = [
+                SPARK_RP_FIELD_TYPE,
+                ('address', 'struct<city:string,street:string,zip:string>', None),
+                ('age', 'bigint', None),
+                ('name', 'string', None),
+                ('', '', ''),
+                ('# Partitioning', '', ''),
+                ('Part 0', 'hours(redpanda.timestamp)', '')
+            ]  # yapf: disable
+            spark_describe_out = spark.run_query_fetch_all(f"describe {table_name}")
+            assert spark_describe_out == spark_expected_out, str(spark_describe_out)
+
     @cluster(num_nodes=4)
     @matrix(
         cloud_storage_type=supported_storage_types(),


### PR DESCRIPTION
This PR adds external schema reference support to JSON Schemas, bringing
  JSON parity with the existing behavior for Avro and Protobuf. A JSON
  schema registered with `references` pointing to other subjects in Schema
  Registry can now be resolved for compatibility checks and used as an
  Iceberg table schema. Previously only internal (`#/...`) and relative
  `$id`-based references worked.

The change lands in three layers:

  - **Schema Registry** (`pandaproxy/schema_registry/json.cc`):
    `document_context` carries a recursive `external_schemas` map keyed
    by base URI. `resolve_reference` returns a `resolved_ref` with an
    optional child context so `is_superset` can follow `$ref`s across
    document boundaries. `resolve_external_references` fetches referenced
    schemas via the existing `schema_getter`, with diamond dedup.
  - **Iceberg JSON schema frontend**
    (`iceberg/conversion/json_schema`): a new `compile()` overload
    pre-registers external schema documents in their own
    `compile_context`, merges their resolved nodes into the root
    context, and runs `$ref` resolution across the combined tree.
  - **Datalake pipeline** (`datalake/record_schema_resolver.cc`): the
    frontend is now passed the actual base URI of the root schema
    (previously hardcoded to `https://example.com/schema.json`) along
    with the flattened external-schema map extracted from the
    `json_schema_definition`.

Fixes https://redpandadata.atlassian.net/browse/CORE-3182

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Features
* Schema Registry: adds support for `references` in JSON schemas for external (i.e. cross-subject-version) references.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
