### PR TITLE
[v26.1.x] utils: fix token bucket underflow after rate decrease

### DIFF
--- a/src/v/utils/token_bucket.h
+++ b/src/v/utils/token_bucket.h
@@ -117,7 +117,7 @@ public:
 
         if (_rate > new_rate) {
             if (_sem.current() <= _rate) {
-                _sem.consume(_rate - new_rate);
+                _sem.consume(std::min(_rate - new_rate, _sem.current()));
             } else {
                 /*
                  * if current > rate it means that we have accumulated tokens


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/21357
