### PR TITLE
storage: Avoid oversized alloc in compaction reducers

### DIFF
--- a/src/v/cloud_topics/level_one/compaction/filter.cc
+++ b/src/v/cloud_topics/level_one/compaction/filter.cc
@@ -50,16 +50,16 @@ ss::future<bool> compaction_filter::should_keep(
 ss::future<> compaction_filter::maybe_index_offset_delta(
   const model::record_batch& b,
   const model::record& r,
-  std::vector<int32_t>& offset_deltas) const {
+  chunked_vector<int32_t>& offset_deltas) const {
     if (co_await should_keep(b, r)) {
         offset_deltas.push_back(r.offset_delta());
     }
 }
 
-ss::future<std::vector<int32_t>>
+ss::future<chunked_vector<int32_t>>
 compaction_filter::compute_offset_deltas_to_keep(
   const model::record_batch& b) const {
-    std::vector<int32_t> offset_deltas;
+    chunked_vector<int32_t> offset_deltas;
     offset_deltas.reserve(b.record_count());
 
     co_await b.for_each_record_async(
@@ -72,7 +72,7 @@ compaction_filter::compute_offset_deltas_to_keep(
 
 ss::future<std::optional<model::record_batch>>
 compaction_filter::filter_batch_with_offset_deltas(
-  model::record_batch b, std::vector<int32_t> offset_deltas) const {
+  model::record_batch b, chunked_vector<int32_t> offset_deltas) const {
     co_return co_await do_filter_batch(std::move(b), std::move(offset_deltas));
 }
 

--- a/src/v/cloud_topics/level_one/compaction/filter.h
+++ b/src/v/cloud_topics/level_one/compaction/filter.h
@@ -31,14 +31,14 @@ private:
     ss::future<> maybe_index_offset_delta(
       const model::record_batch&,
       const model::record&,
-      std::vector<int32_t>&) const;
+      chunked_vector<int32_t>&) const;
 
-    ss::future<std::vector<int32_t>>
+    ss::future<chunked_vector<int32_t>>
     compute_offset_deltas_to_keep(const model::record_batch&) const final;
 
     ss::future<std::optional<model::record_batch>>
       filter_batch_with_offset_deltas(
-        model::record_batch, std::vector<int32_t>) const final;
+        model::record_batch, chunked_vector<int32_t>) const final;
 
 private:
     const compaction::key_offset_map& _map;

--- a/src/v/compaction/BUILD
+++ b/src/v/compaction/BUILD
@@ -115,6 +115,7 @@ redpanda_cc_library(
         ":reducer",
         ":types",
         "//src/v/bytes",
+        "//src/v/container:chunked_vector",
         "//src/v/model",
         "@seastar",
     ],

--- a/src/v/compaction/filter.cc
+++ b/src/v/compaction/filter.cc
@@ -10,6 +10,7 @@
 #include "filter.h"
 
 #include "compaction/utils.h"
+#include "container/chunked_vector.h"
 #include "model/batch_compression.h"
 #include "model/record.h"
 
@@ -37,8 +38,8 @@ filter::filter_batch(model::record_batch b) const {
     }
 
     // compute which records to keep
-    std::vector<int32_t> offset_deltas = co_await compute_offset_deltas_to_keep(
-      b);
+    chunked_vector<int32_t> offset_deltas
+      = co_await compute_offset_deltas_to_keep(b);
 
     auto ret = co_await filter_batch_with_offset_deltas(
       std::move(b), std::move(offset_deltas));
@@ -46,7 +47,7 @@ filter::filter_batch(model::record_batch b) const {
 }
 
 ss::future<std::optional<model::record_batch>> filter::do_filter_batch(
-  model::record_batch b, std::vector<int32_t> offset_deltas) const {
+  model::record_batch b, chunked_vector<int32_t> offset_deltas) const {
     // no records to keep
     if (offset_deltas.empty()) {
         co_return std::nullopt;

--- a/src/v/compaction/filter.h
+++ b/src/v/compaction/filter.h
@@ -44,7 +44,7 @@ protected:
     // Creates a new batch based on the provided batch and offset_deltas
     // indicated.
     ss::future<std::optional<model::record_batch>> do_filter_batch(
-      model::record_batch b, std::vector<int32_t> offset_deltas) const;
+      model::record_batch b, chunked_vector<int32_t> offset_deltas) const;
 
     mutable stats _stats;
 
@@ -52,7 +52,7 @@ private:
     // For a given batch, this function should return a vector containing offset
     // deltas from records in the batch which we intend on keeping when
     // performing record batch filtering.
-    virtual ss::future<std::vector<int32_t>>
+    virtual ss::future<chunked_vector<int32_t>>
     compute_offset_deltas_to_keep(const model::record_batch& b) const = 0;
 
     // For most implementations, this should serve as a pass through function to
@@ -62,7 +62,7 @@ private:
     // placeholder batch if `offset_deltas` is empty.
     virtual ss::future<std::optional<model::record_batch>>
     filter_batch_with_offset_deltas(
-      model::record_batch b, std::vector<int32_t> offset_deltas) const = 0;
+      model::record_batch b, chunked_vector<int32_t> offset_deltas) const = 0;
 
     // Computes offset deltas from the batch to keep, and then filters the
     // provided batch.

--- a/src/v/compaction/tests/simple_reducer.h
+++ b/src/v/compaction/tests/simple_reducer.h
@@ -37,15 +37,15 @@ private:
     ss::future<> maybe_index_offset_delta(
       const model::record_batch& b,
       const model::record& r,
-      std::vector<int32_t>& offset_deltas) const {
+      chunked_vector<int32_t>& offset_deltas) const {
         if (co_await is_latest_record_for_key(_map, b, r)) {
             offset_deltas.push_back(r.offset_delta());
         }
     }
 
-    ss::future<std::vector<int32_t>>
+    ss::future<chunked_vector<int32_t>>
     compute_offset_deltas_to_keep(const model::record_batch& b) const final {
-        std::vector<int32_t> offset_deltas;
+        chunked_vector<int32_t> offset_deltas;
         offset_deltas.reserve(b.record_count());
 
         co_await b.for_each_record_async(
@@ -58,7 +58,8 @@ private:
 
     ss::future<std::optional<model::record_batch>>
     filter_batch_with_offset_deltas(
-      model::record_batch b, std::vector<int32_t> offset_deltas) const final {
+      model::record_batch b,
+      chunked_vector<int32_t> offset_deltas) const final {
         co_return co_await do_filter_batch(
           std::move(b), std::move(offset_deltas));
     }

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -125,7 +125,7 @@ ss::future<> copy_data_segment_reducer::maybe_keep_offset(
   const model::record_batch& batch,
   const model::record& r,
   bool is_last_record_in_batch,
-  std::vector<int32_t>& offset_deltas) {
+  chunked_vector<int32_t>& offset_deltas) {
     if (co_await _should_keep_fn(batch, r, is_last_record_in_batch)) {
         offset_deltas.push_back(r.offset_delta());
         co_return;
@@ -171,7 +171,7 @@ copy_data_segment_reducer::filter(model::record_batch batch) {
     }
 
     // 1. compute which records to keep
-    std::vector<int32_t> offset_deltas;
+    chunked_vector<int32_t> offset_deltas;
     offset_deltas.reserve(batch.record_count());
 
     int32_t records_seen = 0;

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -170,7 +170,7 @@ private:
       const model::record_batch&,
       const model::record&,
       bool,
-      std::vector<int32_t>&);
+      chunked_vector<int32_t>&);
 
     ss::future<std::optional<model::record_batch>> filter(model::record_batch);
 


### PR DESCRIPTION
Store offset deltas in chunked_vector to avoid oversized allocs with too many deltas.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes

* none

