### PR TITLE
[v26.1.x] lsm/io: skip delete_objects call when no keys to delete

### DIFF
--- a/src/v/lsm/io/cloud_cache_persistence.cc
+++ b/src/v/lsm/io/cloud_cache_persistence.cc
@@ -494,6 +494,9 @@ public:
             }
             keys_to_delete.push_back(key);
         }
+        if (keys_to_delete.empty()) {
+            co_return;
+        }
         result = co_await _remote->delete_objects(
           _bucket, std::move(keys_to_delete), rtc, [](size_t) {});
     }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30217
