### PR TITLE
syschecks: warn instead of throw on low memory

### DIFF
--- a/src/v/syschecks/syschecks.cc
+++ b/src/v/syschecks/syschecks.cc
@@ -73,18 +73,17 @@ ss::future<> disk(const ss::sstring& path) {
     });
 }
 
-void memory(bool ignore) {
+void memory(bool) {
     static const uint64_t kMinMemory = 1 << 30;
     const auto shard_mem = ss::memory::stats().total_memory();
     if (shard_mem >= kMinMemory) {
         return;
     }
-    auto line = fmt::format(
-      "Memory: '{}' below recommended: '{}'", shard_mem, kMinMemory);
-    checklog.error(line.c_str());
-    if (!ignore) {
-        throw std::runtime_error(line);
-    }
+    checklog.warn(
+      "Memory: '{}' below recommended: '{}'. Redpanda may not perform "
+      "optimally in memory-constrained environments.",
+      shard_mem,
+      kMinMemory);
 }
 
 ss::future<> systemd_notify_ready() {

--- a/src/v/syschecks/syschecks.h
+++ b/src/v/syschecks/syschecks.h
@@ -51,7 +51,7 @@ inline void cpu() {
 
 ss::future<> disk(const ss::sstring& path);
 
-void memory(bool ignore);
+void memory(bool);
 
 ss::future<> systemd_raw_message(ss::sstring out);
 


### PR DESCRIPTION
## Summary

Changes the memory check in `syschecks::memory()` to log a warning instead of throwing a `std::runtime_error` when per-shard memory is below the 1GB recommended minimum.

## Motivation

Currently, unless `developer_mode` is true, Redpanda throws on startup if there is less than 1GB of free memory per shard. Similar to how XFS is recommended but not required (the disk check logs a warning), the memory check should recommend rather than block startup. Redpanda can work in low memory situations, and not throwing allows deployment in memory-constrained environments without requiring `developer_mode`.

## Changes

- `src/v/syschecks/syschecks.cc`: Replaced `checklog.error` + `throw` with `checklog.warn` and a descriptive message. Removed the `ignore` parameter logic since we no longer throw.
- `src/v/syschecks/syschecks.h`: Updated declaration to reflect unused parameter.

## Testing

- No behavioral change beyond removing the throw; the warning is still emitted at the appropriate log level.
- All existing call sites continue to compile without changes.

Closes #2879