### PR TITLE
cloud_io: apply throughput percent on each recompute

### DIFF
--- a/src/v/cloud_io/BUILD
+++ b/src/v/cloud_io/BUILD
@@ -18,6 +18,7 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/config",
         "//src/v/ssx:future_util",
+        "//src/v/ssx:mutex",
         "//src/v/ssx:semaphore",
         "//src/v/utils:adjustable_semaphore",
         "//src/v/utils:token_bucket",

--- a/src/v/cloud_io/io_resources.cc
+++ b/src/v/cloud_io/io_resources.cc
@@ -288,6 +288,7 @@ ss::input_stream<char> io_resources::throttle_download(
 }
 
 ss::future<> io_resources::update_throughput() {
+    auto units = co_await _update_lock.get_units();
     auto tp = get_throughput_limit(_device_throughput);
     if (ss::this_shard_id() == 0) {
         co_await set_disk_max_bandwidth(tp.disk_node_throughput_limit);

--- a/src/v/cloud_io/io_resources.cc
+++ b/src/v/cloud_io/io_resources.cc
@@ -129,13 +129,11 @@ throughput_limit get_throughput_limit(std::optional<size_t> device_throughput) {
                         .cloud_storage_max_throughput_per_shard()
                         .value_or(0)
                       * ss::smp::count;
+    auto percent = config::shard_local_cfg()
+                     .cloud_storage_throughput_limit_percent()
+                     .value_or(0);
 
-    if (
-      config::shard_local_cfg()
-          .cloud_storage_throughput_limit_percent()
-          .value_or(0)
-        == 0
-      || hard_limit == 0) {
+    if (percent == 0 || hard_limit == 0) {
         // Run tiered-storage without throttling by setting
         // 'cloud_storage_throughput_limit_percent' to nullopt or
         // 'cloud_storage_max_throughput_per_shard' to nullopt
@@ -153,7 +151,9 @@ throughput_limit get_throughput_limit(std::optional<size_t> device_throughput) {
         };
     }
 
-    auto tp = std::min(hard_limit, device_throughput.value());
+    auto scaled_device_throughput = muldiv(
+      device_throughput.value(), percent, 100);
+    auto tp = std::min(hard_limit, scaled_device_throughput);
     return {
       .disk_node_throughput_limit = tp,
       .download_shard_throughput_limit = tp / ss::smp::count,
@@ -170,17 +170,10 @@ ss::future<std::optional<device_throughput>> get_storage_device_throughput() {
         auto fs = co_await ss::file_stat(cache_path);
         auto& queue = ss::engine().get_io_queue(fs.device_id);
         auto cfg = queue.get_config();
-        auto percent = config::shard_local_cfg()
-                         .cloud_storage_throughput_limit_percent()
-                         .value_or(0);
-        if (percent > 0) {
-            // percent == nullopt indicates that the throttling is disabled
-            // intentionally
-            co_return device_throughput{
-              .read = muldiv(cfg.read_bytes_rate, percent, 100),
-              .write = muldiv(cfg.write_bytes_rate, percent, 100),
-            };
-        }
+        co_return device_throughput{
+          .read = cfg.read_bytes_rate,
+          .write = cfg.write_bytes_rate,
+        };
     } catch (...) {
         vlog(
           log.info,

--- a/src/v/cloud_io/io_resources.h
+++ b/src/v/cloud_io/io_resources.h
@@ -11,8 +11,7 @@
 
 #include "base/seastarx.h"
 #include "config/property.h"
-#include "ssx/semaphore.h"
-#include "utils/adjustable_semaphore.h"
+#include "ssx/mutex.h"
 #include "utils/token_bucket.h"
 
 #include <seastar/core/abort_source.hh>
@@ -66,6 +65,7 @@ private:
     bool _throttling_disabled{false};
     std::optional<size_t> _device_throughput;
     seastar::scheduling_group _scheduling_group;
+    ssx::mutex _update_lock{"cloud_io/io_resources/update"};
 };
 
 } // namespace cloud_io


### PR DESCRIPTION
`cloud_storage_throughput_limit_percent` is a live setting, but the device throughput was scaled by the percent once at startup and cached in `_device_throughput`. Subsequent changes to the percent had no effect on the disk limit. Additionally, if the percent was zero at startup, `_device_throughput` stayed unset and flipping the percent later would not engage disk throttling.

Store the raw device throughput and apply the percent on every `update_throughput()` call so live changes take effect.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes
### Bug Fixes

* Changes to `cloud_storage_throughput_limit_percent` cluster config now take effect at runtime instead of being ignored until restart.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
