### PR TITLE
[v26.1.x] cloud_io: apply throughput percent on each recompute

### DIFF
--- a/src/v/cloud_io/BUILD
+++ b/src/v/cloud_io/BUILD
@@ -18,6 +18,7 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/config",
         "//src/v/ssx:future_util",
+        "//src/v/ssx:mutex",
         "//src/v/ssx:semaphore",
         "//src/v/utils:adjustable_semaphore",
         "//src/v/utils:token_bucket",

--- a/src/v/cloud_io/io_resources.cc
+++ b/src/v/cloud_io/io_resources.cc
@@ -288,6 +288,7 @@ ss::input_stream<char> io_resources::throttle_download(
 }
 
 ss::future<> io_resources::update_throughput() {
+    auto units = co_await _update_lock.get_units();
     auto tp = get_throughput_limit(_device_throughput);
     if (ss::this_shard_id() == 0) {
         co_await set_disk_max_bandwidth(tp.disk_node_throughput_limit);

--- a/src/v/cloud_io/io_resources.cc
+++ b/src/v/cloud_io/io_resources.cc
@@ -129,13 +129,11 @@ throughput_limit get_throughput_limit(std::optional<size_t> device_throughput) {
                         .cloud_storage_max_throughput_per_shard()
                         .value_or(0)
                       * ss::smp::count;
+    auto percent = config::shard_local_cfg()
+                     .cloud_storage_throughput_limit_percent()
+                     .value_or(0);
 
-    if (
-      config::shard_local_cfg()
-          .cloud_storage_throughput_limit_percent()
-          .value_or(0)
-        == 0
-      || hard_limit == 0) {
+    if (percent == 0 || hard_limit == 0) {
         // Run tiered-storage without throttling by setting
         // 'cloud_storage_throughput_limit_percent' to nullopt or
         // 'cloud_storage_max_throughput_per_shard' to nullopt
@@ -153,7 +151,9 @@ throughput_limit get_throughput_limit(std::optional<size_t> device_throughput) {
         };
     }
 
-    auto tp = std::min(hard_limit, device_throughput.value());
+    auto scaled_device_throughput = muldiv(
+      device_throughput.value(), percent, 100);
+    auto tp = std::min(hard_limit, scaled_device_throughput);
     return {
       .disk_node_throughput_limit = tp,
       .download_shard_throughput_limit = tp / ss::smp::count,
@@ -170,17 +170,10 @@ ss::future<std::optional<device_throughput>> get_storage_device_throughput() {
         auto fs = co_await ss::file_stat(cache_path);
         auto& queue = ss::engine().get_io_queue(fs.device_id);
         auto cfg = queue.get_config();
-        auto percent = config::shard_local_cfg()
-                         .cloud_storage_throughput_limit_percent()
-                         .value_or(0);
-        if (percent > 0) {
-            // percent == nullopt indicates that the throttling is disabled
-            // intentionally
-            co_return device_throughput{
-              .read = muldiv(cfg.read_bytes_rate, percent, 100),
-              .write = muldiv(cfg.write_bytes_rate, percent, 100),
-            };
-        }
+        co_return device_throughput{
+          .read = cfg.read_bytes_rate,
+          .write = cfg.write_bytes_rate,
+        };
     } catch (...) {
         vlog(
           log.info,

--- a/src/v/cloud_io/io_resources.h
+++ b/src/v/cloud_io/io_resources.h
@@ -11,8 +11,7 @@
 
 #include "base/seastarx.h"
 #include "config/property.h"
-#include "ssx/semaphore.h"
-#include "utils/adjustable_semaphore.h"
+#include "ssx/mutex.h"
 #include "utils/token_bucket.h"
 
 #include <seastar/core/abort_source.hh>
@@ -66,6 +65,7 @@ private:
     bool _throttling_disabled{false};
     std::optional<size_t> _device_throughput;
     seastar::scheduling_group _scheduling_group;
+    ssx::mutex _update_lock{"cloud_io/io_resources/update"};
 };
 
 } // namespace cloud_io


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30230
