### PR TITLE
cloud_storage/tests: fix retry budget exhaustion in TestDownloadLabeldManifestWithHint

### DIFF
--- a/src/v/cloud_storage/tests/topic_manifest_downloader_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_downloader_test.cc
@@ -219,12 +219,12 @@ TEST_F(TopicManifestDownloaderTest, TestDownloadLabeledManifestWithHint) {
     auto tm = dummy_topic_manifest();
     ASSERT_NO_FATAL_FAILURE(upload_labeled_bin_manifest(tm));
 
-    retry_chain_node retry(never_abort, 1s, 10ms);
     for (size_t i = 0; i < test_uuid_str.size(); i++) {
         auto uuid_substr = test_uuid_str.substr(0, i);
         topic_manifest_downloader dl(
           bucket_name, uuid_substr, test_tp_ns, remote_.local());
         topic_manifest dl_tm;
+        retry_chain_node retry(never_abort, 1s, 10ms);
         auto dl_res = dl.download_manifest(
                           retry, ss::lowres_clock::now() + 1s, 10ms, &dl_tm)
                         .get();
@@ -243,6 +243,7 @@ TEST_F(TopicManifestDownloaderTest, TestDownloadLabeledManifestWithHint) {
         topic_manifest_downloader dl(
           bucket_name, hint, test_tp_ns, remote_.local());
         topic_manifest dl_tm;
+        retry_chain_node retry(never_abort, 1s, 10ms);
         auto dl_res = dl.download_manifest(
                           retry, ss::lowres_clock::now() + 1s, 10ms, &dl_tm)
                         .get();
@@ -264,6 +265,7 @@ TEST_F(TopicManifestDownloaderTest, TestDownloadLabeledManifestWithHint) {
         topic_manifest_downloader dl(
           bucket_name, hint, test_tp_ns, remote_.local());
         topic_manifest dl_tm;
+        retry_chain_node retry(never_abort, 1s, 10ms);
         auto dl_res = dl.download_manifest(
                           retry, ss::lowres_clock::now() + 1s, 10ms, &dl_tm)
                         .get();


### PR DESCRIPTION
The test iterates over 45+ hint strings across three loops, passing the same retry_chain_node to each download_manifest call. On slow CI machines, the shared 1s budget was exhausted mid-test, causing ListObjectsV2 to fail with "backoff quota exceeded".

Fix by declaring a fresh retry_chain_node per iteration so each call gets its own 1s budget.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
