### PR TITLE
Add --dry-run pre-flight checks and /v1/debug/bundle/check_permissions admin endpoint

### DIFF
--- a/src/go/rpk/pkg/cli/debug/bundle/BUILD
+++ b/src/go/rpk/pkg/cli/debug/bundle/BUILD
@@ -7,6 +7,7 @@ go_library(
         "bundle_all.go",
         "bundle_k8s_linux.go",
         "bundle_linux.go",
+        "dry_run.go",
     ],
     importpath = "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/debug/bundle",
     visibility = ["//visibility:public"],

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle.go
@@ -61,6 +61,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		outFile   string
 		uploadURL string
 		timeout   time.Duration
+		dryRun    bool
 		opts      debugbundle.DebugBundleSharedOptions
 	)
 	cmd := &cobra.Command{
@@ -69,6 +70,10 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Long:  bundleHelpText,
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, _ []string) {
+			if !dryRun && cmd.Flags().Changed("format") {
+				fmt.Fprintln(os.Stderr, "warning: --format has no effect without --dry-run")
+			}
+
 			//  Redpanda queries for samples from Seastar every ~13 seconds by
 			//  default. Setting wait_ms to anything less than 13 seconds will
 			//  result in no samples being returned.
@@ -86,12 +91,34 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			// We do not config.CheckExitCloudAdmin here, because
 			// capturing a debug *can* have access sometimes (k8s).
 			var (
-				p           = cfg.VirtualProfile()
+				prof        = cfg.VirtualProfile()
 				y           = cfg.VirtualRedpandaYaml()
 				yActual, ok = cfg.ActualRedpandaYaml()
 			)
 			if !ok {
 				yActual = y
+			}
+
+			// --dry-run: probe every permission/access the bundle would need
+			// and print the results. No bundle file is created.
+			if dryRun {
+				// Resolve the output path the same way the real bundle
+				// would, so probeDirWrite exercises the actual target. If
+				// --output was explicitly set and is invalid, fail like the
+				// real run would.
+				path, perr := determineFilepath(fs, yActual, outFile, cmd.Flags().Changed(outputFlag))
+				if perr != nil && cmd.Flags().Changed(outputFlag) {
+					out.Die("unable to determine filepath %q: %v", outFile, perr)
+				}
+				result := runDryRun(cmd.Context(), fs, prof, yActual, opts.Namespace, path)
+
+				if isText, _, s, err := p.Formatter.Format(result); !isText {
+					out.MaybeDie(err, "unable to format dry-run result: %v", err)
+					fmt.Println(s)
+					return
+				}
+				printDryRunText(result)
+				return
 			}
 
 			path, err := determineFilepath(fs, yActual, outFile, cmd.Flags().Changed(outputFlag))
@@ -100,7 +127,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			partitions, err := parsePartitionFlag(opts.PartitionFlag)
 			out.MaybeDie(err, "unable to parse partition flag %v: %v", opts.PartitionFlag, err)
 
-			cl, err := kafka.NewFranzClient(fs, p)
+			cl, err := kafka.NewFranzClient(fs, prof)
 			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
 			defer cl.Close()
 
@@ -111,7 +138,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			out.MaybeDie(err, "unable to parse --controller-logs-size-limit: %v", err)
 			bp := bundleParams{
 				fs:                      fs,
-				p:                       p,
+				p:                       prof,
 				y:                       y,
 				yActual:                 yActual,
 				cl:                      cl,
@@ -153,11 +180,13 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 
 	p.InstallKafkaFlags(cmd)
 	p.InstallAdminFlags(cmd)
+	p.InstallFormatFlag(cmd)
 
 	f := cmd.Flags()
 	f.StringVarP(&outFile, outputFlag, "o", "", "The file path where the debug file will be written (default ./<timestamp>-bundle.zip)")
 	f.DurationVar(&timeout, "timeout", 60*time.Second, "How long to wait for child commands to execute. For example: 30s, 1.5m")
 	f.StringVar(&uploadURL, "upload-url", "", "If provided, where to upload the bundle in addition to creating a copy on disk")
+	f.BoolVar(&dryRun, "dry-run", false, "Probe every access the bundle would need (files, commands, admin API, Kafka, NTP, DNS, Kubernetes RBAC) and exit without creating a bundle")
 	// Debug bundle options.
 	opts.InstallFlags(f)
 
@@ -275,6 +304,16 @@ Topic 'foo', partitions 1, 2 and 3:
 Namespace _redpanda-internal, topic 'bar', partition 2
   --partitions _redpanda-internal/bar/2
 
-If you have an upload URL from the Redpanda support team, provide it in the 
+If you have an upload URL from the Redpanda support team, provide it in the
 --upload-url flag to upload your diagnostics bundle to Redpanda.
+
+DRY RUN
+
+Pass --dry-run to probe every access the bundle would actually need — file
+reads, commands, Kubernetes RBAC, admin-API and Kafka auth, NTP, and DNS —
+without collecting or creating a bundle. Safe to run on production brokers;
+useful for catching permission/network issues before a real debug bundle is
+requested by support.
+
+The global --format flag (text|json|yaml|wide) controls the dry-run output.
 `

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
@@ -40,7 +40,6 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/debug/debugbundle"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	osutil "github.com/redpanda-data/redpanda/src/go/rpk/pkg/osutil"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/rpkutil"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/system"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/system/syslog"
@@ -95,7 +94,7 @@ func determineFilepath(fs afero.Fs, rp *config.RedpandaYaml, path string, isFlag
 		}
 		home, err := os.UserHomeDir()
 		if err != nil {
-			out.Die("unable to create bundle file in %q due to permission issues and cannot use home directory: %v", path, err)
+			return "", fmt.Errorf("unable to create bundle file in %q due to permission issues and cannot use home directory: %v", path, err)
 		}
 		// We are here only if the user did not specify a flag so finalpath
 		// here is the <timestamp>-bundle.zip string

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_test.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_test.go
@@ -12,7 +12,10 @@
 package bundle
 
 import (
+	"context"
 	"io"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -293,6 +296,172 @@ func TestSortControllerLogDir(t *testing.T) {
 			require.Equal(t, test.exp, test.in)
 		})
 	}
+}
+
+func TestProbeFileRead(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/exists", []byte("data"), 0o644))
+
+	tests := []struct {
+		name   string
+		path   string
+		wantOK bool
+	}{
+		{"exists", "/exists", true},
+		{"missing", "/does-not-exist", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := probeFileRead(fs, categoryFile, tt.path, "")
+			require.Equal(t, categoryFile, r.Category)
+			require.Equal(t, tt.path, r.Resource)
+			require.Equal(t, tt.wantOK, r.OK)
+			if !tt.wantOK {
+				require.NotEmpty(t, r.Error)
+			}
+		})
+	}
+}
+
+func TestProbeDirRead(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.Mkdir("/empty", 0o755))
+	require.NoError(t, fs.Mkdir("/nonempty", 0o755))
+	require.NoError(t, afero.WriteFile(fs, "/nonempty/file", []byte("x"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, "/notadir", []byte("x"), 0o644))
+
+	tests := []struct {
+		name    string
+		path    string
+		wantOK  bool
+		wantErr string
+	}{
+		{"empty dir", "/empty", true, ""},
+		{"non-empty dir", "/nonempty", true, ""},
+		{"not a directory", "/notadir", false, "not a directory"},
+		{"missing", "/does-not-exist", false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := probeDirRead(fs, categoryFile, tt.path, "")
+			require.Equal(t, tt.wantOK, r.OK)
+			if tt.wantErr != "" {
+				require.Equal(t, tt.wantErr, r.Error)
+			} else if !tt.wantOK {
+				require.NotEmpty(t, r.Error)
+			}
+		})
+	}
+}
+
+func TestProbeDirWrite(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.Mkdir("/writable", 0o755))
+	require.NoError(t, afero.WriteFile(fs, "/notadir", []byte("x"), 0o644))
+
+	tests := []struct {
+		name    string
+		path    string
+		wantOK  bool
+		wantErr string
+	}{
+		{"writable", "/writable", true, ""},
+		{"missing", "/does-not-exist", false, ""},
+		{"not a directory", "/notadir", false, "not a directory"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := probeDirWrite(fs, categoryFile, tt.path, "")
+			require.Equal(t, tt.wantOK, r.OK)
+			if tt.wantErr != "" {
+				require.Equal(t, tt.wantErr, r.Error)
+			} else if !tt.wantOK {
+				require.NotEmpty(t, r.Error)
+			}
+		})
+	}
+}
+
+func TestProbeCommand(t *testing.T) {
+	tmp := t.TempDir()
+	fakeBin := filepath.Join(tmp, "rpktest-fake")
+	require.NoError(t, os.WriteFile(fakeBin, []byte("#!/bin/sh\n"), 0o755))
+	t.Setenv("PATH", tmp+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	tests := []struct {
+		name         string
+		cmd          string
+		requiresRoot bool
+		isRoot       bool
+		wantOK       bool
+	}{
+		{"in PATH", "rpktest-fake", false, true, true},
+		{"not in PATH", "rpktest-nonexistent-xyz", false, true, false},
+		{"needs root as non-root", "rpktest-fake", true, false, false},
+		{"needs root as root", "rpktest-fake", true, true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := probeCommand(tt.cmd, tt.requiresRoot, tt.isRoot, "")
+			require.Equal(t, categoryCommand, r.Category)
+			require.Equal(t, tt.cmd, r.Resource)
+			require.Equal(t, tt.wantOK, r.OK)
+		})
+	}
+}
+
+func TestProbeNTPContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	r := probeNTP(ctx, "pool.ntp.org")
+	require.Equal(t, categoryNetwork, r.Category)
+	require.False(t, r.OK)
+	require.NotEmpty(t, r.Error)
+}
+
+func TestProbeClusterDNSContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	r := probeClusterDNS(ctx)
+	require.Equal(t, categoryNetwork, r.Category)
+	require.False(t, r.OK)
+	require.NotEmpty(t, r.Error)
+}
+
+func loadTestProfile(t *testing.T) (afero.Fs, *config.RpkProfile) {
+	t.Helper()
+	fs := afero.NewMemMapFs()
+	params := &config.Params{IgnoreProfile: true}
+	cfg, err := params.Load(fs)
+	require.NoError(t, err)
+	return fs, cfg.VirtualProfile()
+}
+
+func TestProbeAdminAPIUnreachable(t *testing.T) {
+	// Port 1 is unassigned; connect attempts fail fast with a refused-connection
+	// error. The probe should surface the error and not mark OK.
+	fs, p := loadTestProfile(t)
+
+	r := probeAdminAPI(context.Background(), fs, p, "127.0.0.1:1")
+	require.Equal(t, categoryAdminAPI, r.Category)
+	require.Equal(t, "127.0.0.1:1", r.Resource)
+	require.False(t, r.OK)
+	require.NotEmpty(t, r.Error)
+}
+
+func TestProbeKafkaUnreachable(t *testing.T) {
+	// Same pattern: bootstrap at port 1 on localhost → Metadata request fails
+	// within the probe's 5s context deadline. The probe should surface the
+	// error, not OK.
+	fs, p := loadTestProfile(t)
+	p.KafkaAPI.Brokers = []string{"127.0.0.1:1"}
+
+	r := probeKafka(context.Background(), fs, p)
+	require.Equal(t, categoryKafka, r.Category)
+	require.False(t, r.OK)
+	require.NotEmpty(t, r.Error)
 }
 
 func TestSliceControllerDir(t *testing.T) {

--- a/src/go/rpk/pkg/cli/debug/bundle/dry_run.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/dry_run.go
@@ -1,0 +1,434 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+//go:build linux
+
+package bundle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/beevik/ntp"
+	"github.com/redpanda-data/common-go/rpadmin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
+	"github.com/spf13/afero"
+	"github.com/twmb/franz-go/pkg/kadm"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	categoryFile     = "file"
+	categoryCommand  = "command"
+	categoryK8sRBAC  = "k8s_rbac"
+	categoryAdminAPI = "admin_api"
+	categoryKafka    = "kafka"
+	categoryNetwork  = "network"
+)
+
+// probeResult describes the outcome of a single permission/access probe.
+type probeResult struct {
+	Category string `json:"category" yaml:"category"`
+	Resource string `json:"resource" yaml:"resource"`
+	OK       bool   `json:"ok" yaml:"ok"`
+	Error    string `json:"error,omitempty" yaml:"error,omitempty"`
+	Hint     string `json:"hint,omitempty" yaml:"hint,omitempty"`
+}
+
+// dryRunResult is the full output of a --dry-run invocation.
+type dryRunResult struct {
+	Probes []probeResult `json:"probes" yaml:"probes"`
+}
+
+// runDryRun executes every permission/access probe that the debug bundle
+// would rely on and returns the structured result. It performs no file
+// collection and creates no output bundle.
+func runDryRun(
+	ctx context.Context,
+	afs afero.Fs,
+	p *config.RpkProfile,
+	y *config.RedpandaYaml,
+	namespace, outputPath string,
+) dryRunResult {
+	var probes []probeResult
+
+	procFiles := []struct {
+		path string
+		hint string
+	}{
+		{"/proc/slabinfo", "requires root (debug bundle reads /proc/slabinfo for slab allocator info)"},
+		{"/proc/cpuinfo", ""},
+		{"/proc/interrupts", ""},
+		{"/proc/softirqs", ""},
+		{"/proc/mounts", ""},
+		{"/proc/cmdline", ""},
+		{"/proc/mdstat", ""},
+		{"/proc/kallsyms", "requires kernel.kptr_restrict=0 or CAP_SYSLOG for non-zero addresses"},
+	}
+	for _, pf := range procFiles {
+		probes = append(probes, probeFileRead(afs, categoryFile, pf.path, pf.hint))
+	}
+
+	if y != nil && y.Redpanda.Directory != "" {
+		probes = append(probes, probeDirRead(afs, categoryFile, y.Redpanda.Directory,
+			"Redpanda data directory; debug bundle walks this tree to describe layout"))
+	}
+
+	if outputPath != "" {
+		probes = append(probes, probeDirWrite(afs, categoryFile, filepath.Dir(outputPath),
+			"debug bundle output directory"))
+	}
+
+	isRoot := os.Geteuid() == 0
+	commands := []struct {
+		name         string
+		requiresRoot bool
+		hint         string
+	}{
+		{"dmidecode", true, "dmidecode reads DMI tables via /dev/mem; must run as root"},
+		{"journalctl", false, "requires membership in 'adm' or 'systemd-journal' group to read service logs"},
+		{"ethtool", false, "some subcommands (e.g., -c) require root"},
+		{"df", false, ""},
+		{"dig", false, ""},
+		{"du", false, ""},
+		{"free", false, ""},
+		{"ip", false, ""},
+		{"lsblk", false, ""},
+		{"lspci", false, ""},
+		{"ss", false, ""},
+		{"sysctl", false, ""},
+		{"top", false, ""},
+		{"uname", false, ""},
+		{"uptime", false, ""},
+		{"vmstat", false, ""},
+	}
+	for _, c := range commands {
+		probes = append(probes, probeCommand(c.name, c.requiresRoot, isRoot, c.hint))
+	}
+
+	if p != nil {
+		for _, addr := range p.AdminAPI.Addresses {
+			probes = append(probes, probeAdminAPI(ctx, afs, p, addr))
+		}
+		probes = append(probes, probeKafka(ctx, afs, p))
+	}
+
+	probes = append(probes, probeNTP(ctx, "pool.ntp.org"))
+
+	inK8s := os.Getenv("KUBERNETES_SERVICE_HOST") != "" && os.Getenv("KUBERNETES_SERVICE_PORT") != ""
+	if inK8s {
+		ns := resolveNamespace(namespace)
+		cl, err := k8sClientset()
+		if err != nil {
+			probes = append(probes, probeResult{
+				Category: categoryK8sRBAC,
+				Resource: fmt.Sprintf("kubernetes client in namespace %q", ns),
+				Error:    fmt.Sprintf("unable to create kubernetes client: %v", err),
+				Hint:     "running inside Kubernetes but the in-cluster config is unavailable or invalid; check the ServiceAccount mount and KUBERNETES_SERVICE_* env vars",
+			})
+		} else {
+			k8sListResources := []string{
+				"pods",
+				"services",
+				"configmaps",
+				"endpoints",
+				"events",
+				"limitranges",
+				"persistentvolumeclaims",
+				"replicationcontrollers",
+				"resourcequotas",
+				"serviceaccounts",
+			}
+			for _, resource := range k8sListResources {
+				probes = append(probes, probeK8sRBAC(ctx, cl, ns, "list", resource, ""))
+			}
+			probes = append(probes, probeK8sRBAC(ctx, cl, ns, "get", "pods", "log"))
+		}
+		probes = append(probes, probeClusterDNS(ctx))
+	}
+
+	return dryRunResult{Probes: probes}
+}
+
+func probeFileRead(afs afero.Fs, category, path, hint string) probeResult {
+	r := probeResult{Category: category, Resource: path, Hint: hint}
+	f, err := afs.Open(path)
+	if err != nil {
+		r.Error = err.Error()
+		if errors.Is(err, os.ErrPermission) && hint == "" {
+			r.Hint = "permission denied; may require root"
+		}
+		return r
+	}
+	defer f.Close()
+	// Some /proc entries (e.g. kptr-restricted kallsyms) open for non-root
+	// but fail on read; a 1-byte read exercises that path.
+	var buf [1]byte
+	if _, err := f.Read(buf[:]); err != nil && !errors.Is(err, io.EOF) {
+		r.Error = err.Error()
+		if errors.Is(err, os.ErrPermission) && hint == "" {
+			r.Hint = "readable to open(2) but read(2) denied; may require root"
+		}
+		return r
+	}
+	r.OK = true
+	r.Hint = ""
+	return r
+}
+
+func probeDirRead(afs afero.Fs, category, path, hint string) probeResult {
+	r := probeResult{Category: category, Resource: path, Hint: hint}
+	info, err := afs.Stat(path)
+	if err != nil {
+		r.Error = err.Error()
+		return r
+	}
+	if !info.IsDir() {
+		r.Error = "not a directory"
+		return r
+	}
+	d, err := afs.Open(path)
+	if err != nil {
+		r.Error = err.Error()
+		return r
+	}
+	defer d.Close()
+	if rd, ok := d.(interface {
+		Readdirnames(int) ([]string, error)
+	}); ok {
+		if _, err := rd.Readdirnames(1); err != nil && !errors.Is(err, io.EOF) {
+			r.Error = err.Error()
+			return r
+		}
+	}
+	r.OK = true
+	r.Hint = ""
+	return r
+}
+
+func probeDirWrite(afs afero.Fs, category, path, hint string) probeResult {
+	r := probeResult{Category: category, Resource: path, Hint: hint}
+	info, err := afs.Stat(path)
+	if err != nil {
+		r.Error = err.Error()
+		return r
+	}
+	if !info.IsDir() {
+		r.Error = "not a directory"
+		return r
+	}
+	tmp, err := afero.TempFile(afs, path, ".rpk-dry-run-*")
+	if err != nil {
+		r.Error = err.Error()
+		if errors.Is(err, os.ErrPermission) {
+			r.Hint = "no write permission; bundle zip cannot be created here"
+		}
+		return r
+	}
+	tmp.Close()
+	afs.Remove(tmp.Name())
+	r.OK = true
+	r.Hint = ""
+	return r
+}
+
+func probeCommand(name string, requiresRoot, isRoot bool, hint string) probeResult {
+	r := probeResult{Category: categoryCommand, Resource: name, Hint: hint}
+	path, err := exec.LookPath(name)
+	if err != nil {
+		r.Error = fmt.Sprintf("%s not found in PATH", name)
+		return r
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		r.Error = err.Error()
+		return r
+	}
+	if info.Mode()&0o111 == 0 {
+		r.Error = "not executable"
+		return r
+	}
+	if requiresRoot && !isRoot {
+		r.Error = "command requires root privileges; will fail when debug bundle runs as non-root"
+		return r
+	}
+	r.OK = true
+	r.Hint = ""
+	return r
+}
+
+func probeK8sRBAC(ctx context.Context, cl kubernetes.Interface, namespace, verb, resource, subresource string) probeResult {
+	fullResource := resource
+	if subresource != "" {
+		fullResource = resource + "/" + subresource
+	}
+	r := probeResult{
+		Category: categoryK8sRBAC,
+		Resource: fmt.Sprintf("%s %s in namespace %q", verb, fullResource, namespace),
+		Hint:     fmt.Sprintf("service account needs '%s' on '%s' in namespace '%s'", verb, fullResource, namespace),
+	}
+	sar := &authorizationv1.SelfSubjectAccessReview{
+		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace:   namespace,
+				Verb:        verb,
+				Resource:    resource,
+				Subresource: subresource,
+			},
+		},
+	}
+	resp, err := cl.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
+	if err != nil {
+		r.Error = err.Error()
+		return r
+	}
+	if !resp.Status.Allowed {
+		r.Error = "permission denied"
+		return r
+	}
+	r.OK = true
+	r.Hint = ""
+	return r
+}
+
+func probeAdminAPI(ctx context.Context, afs afero.Fs, p *config.RpkProfile, addr string) probeResult {
+	r := probeResult{
+		Category: categoryAdminAPI,
+		Resource: addr,
+		Hint:     "admin API connectivity + auth; bundle collects cluster config, health, metrics via this endpoint",
+	}
+	scoped := *p
+	scoped.AdminAPI.Addresses = []string{addr}
+
+	cl, err := adminapi.NewClient(ctx, afs, &scoped, rpadmin.ClientTimeout(5*time.Second))
+	if err != nil {
+		r.Error = err.Error()
+		return r
+	}
+	if _, err := cl.Brokers(ctx); err != nil {
+		r.Error = err.Error()
+		return r
+	}
+	r.OK = true
+	r.Hint = ""
+	return r
+}
+
+func probeKafka(ctx context.Context, afs afero.Fs, p *config.RpkProfile) probeResult {
+	brokers := "(default)"
+	if len(p.KafkaAPI.Brokers) > 0 {
+		brokers = fmt.Sprintf("%v", p.KafkaAPI.Brokers)
+	}
+	r := probeResult{
+		Category: categoryKafka,
+		Resource: brokers,
+		Hint:     "Kafka broker connectivity + auth; bundle collects topic/group/offset metadata via this connection",
+	}
+	cl, err := kafka.NewFranzClient(afs, p)
+	if err != nil {
+		r.Error = err.Error()
+		return r
+	}
+	defer cl.Close()
+
+	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	adm := kadm.NewClient(cl)
+	if _, err := adm.BrokerMetadata(cctx); err != nil {
+		r.Error = err.Error()
+		return r
+	}
+	r.OK = true
+	r.Hint = ""
+	return r
+}
+
+func probeNTP(ctx context.Context, host string) probeResult {
+	r := probeResult{
+		Category: categoryNetwork,
+		Resource: fmt.Sprintf("NTP %s", host),
+		Hint:     "bundle queries NTP for clock-drift; needs UDP/123 egress",
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := ntp.Query(host)
+		done <- err
+	}()
+	select {
+	case <-ctx.Done():
+		r.Error = ctx.Err().Error()
+		return r
+	case err := <-done:
+		if err != nil {
+			r.Error = err.Error()
+			return r
+		}
+	}
+	r.OK = true
+	r.Hint = ""
+	return r
+}
+
+func probeClusterDNS(ctx context.Context) probeResult {
+	const name = "kubernetes.default.svc"
+	r := probeResult{
+		Category: categoryNetwork,
+		Resource: fmt.Sprintf("DNS CNAME %s", name),
+		Hint:     "in-cluster DNS; bundle uses this to discover the K8s cluster domain",
+	}
+	var resolver net.Resolver
+	if _, err := resolver.LookupCNAME(ctx, name); err != nil {
+		r.Error = err.Error()
+		return r
+	}
+	r.OK = true
+	r.Hint = ""
+	return r
+}
+
+func printDryRunText(result dryRunResult) {
+	pass, fail := 0, 0
+	for _, p := range result.Probes {
+		if p.OK {
+			pass++
+		} else {
+			fail++
+		}
+	}
+	fmt.Printf("Debug bundle dry-run: %d probe(s), %d ok, %d issue(s)\n\n", len(result.Probes), pass, fail)
+
+	if fail == 0 {
+		fmt.Println("All probes passed. A debug bundle would collect every resource successfully.")
+		return
+	}
+
+	fmt.Println("Issues detected (these resources will be skipped or fail when generating a real bundle):")
+	for _, p := range result.Probes {
+		if p.OK {
+			continue
+		}
+		fmt.Printf("  - [%s] %s: %s", p.Category, p.Resource, p.Error)
+		if p.Hint != "" {
+			fmt.Printf(" (%s)", p.Hint)
+		}
+		fmt.Println()
+	}
+}

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3900,6 +3900,16 @@ configuration::configuration()
       "indefinitely.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       std::nullopt)
+  , debug_bundle_dry_run_timeout_seconds(
+      *this,
+      "debug_bundle_dry_run_timeout_seconds",
+      "Maximum time the debug bundle dry-run subprocess may run before it is "
+      "terminated. Dry-run probes may include multiple admin API and Kafka "
+      "auth checks plus Kubernetes RBAC reviews; bump this if those targets "
+      "are slow in the deployment.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      std::chrono::seconds(30),
+      {.min = std::chrono::seconds(5), .max = std::chrono::seconds(600)})
   , oidc_discovery_url(
       *this,
       "oidc_discovery_url",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -683,6 +683,7 @@ struct configuration final : public config_store {
     property<std::optional<std::filesystem::path>> debug_bundle_storage_dir;
     property<std::optional<std::chrono::seconds>>
       debug_bundle_auto_removal_seconds;
+    bounded_property<std::chrono::seconds> debug_bundle_dry_run_timeout_seconds;
 
     // oidc authentication
     property<ss::sstring> oidc_discovery_url;

--- a/src/v/debug_bundle/BUILD
+++ b/src/v/debug_bundle/BUILD
@@ -27,6 +27,7 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/config",
         "//src/v/ssx:mutex",
+        "//src/v/ssx:semaphore",
         "//src/v/storage",
         "@fmt",
         "@seastar",

--- a/src/v/debug_bundle/debug_bundle_service.cc
+++ b/src/v/debug_bundle/debug_bundle_service.cc
@@ -11,6 +11,7 @@
 
 #include "debug_bundle_service.h"
 
+#include "bytes/iostream.h"
 #include "config/configuration.h"
 #include "config/node_config.h"
 #include "container/chunked_vector.h"
@@ -24,10 +25,13 @@
 #include "utils/external_process.h"
 #include "utils/file_io.h"
 
+#include <seastar/core/fstream.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/shard_id.hh>
+#include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
+#include <seastar/core/with_timeout.hh>
 #include <seastar/coroutine/exception.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/util/process.hh>
@@ -123,6 +127,27 @@ validate_sha256_checksum(std::string_view path, bytes_view checksum) {
     auto sum = co_await calculate_sha256_sum(path);
     co_return sum == checksum;
 }
+
+constexpr std::string_view dry_run_flag = "--dry-run";
+constexpr std::string_view format_flag = "--format";
+constexpr std::string_view format_json = "json";
+
+// Buffer held via lw_shared_ptr so it outlives the handler if a consumer
+// future is still in flight after with_timeout -> terminate().
+struct single_buffer_handler {
+    using consumption_result_type =
+      typename ss::input_stream<char>::consumption_result_type;
+    using stop_consuming_type =
+      typename consumption_result_type::stop_consuming_type;
+    using tmp_buf = stop_consuming_type::tmp_buf;
+
+    ss::lw_shared_ptr<ss::sstring> buffer;
+
+    ss::future<consumption_result_type> operator()(tmp_buf buf) {
+        buffer->append(buf.begin(), buf.size());
+        co_return ss::continue_consuming{};
+    }
+};
 } // namespace
 
 struct service::output_handler {
@@ -269,6 +294,8 @@ service::service(storage::kvstore* kvstore)
   , _rpk_path_binding(config::shard_local_cfg().rpk_path.bind())
   , _debug_bundle_cleanup_binding(
       config::shard_local_cfg().debug_bundle_auto_removal_seconds.bind())
+  , _dry_run_timeout_binding(
+      config::shard_local_cfg().debug_bundle_dry_run_timeout_seconds.bind())
   , _process_control_mutex("debug_bundle_service::process_control") {
     _debug_bundle_storage_dir_binding.watch([this] {
         _debug_bundle_dir = form_debug_bundle_storage_directory();
@@ -983,6 +1010,88 @@ void service::maybe_rearm_timer() {
       (lowres_point - ss::lowres_clock::now()) / 1s);
 
     _cleanup_timer.rearm(lowres_point);
+}
+
+ss::future<result<ss::sstring>>
+service::run_rpk_dry_run(std::vector<ss::sstring> env) {
+    auto hold = _gate.hold();
+    if (ss::this_shard_id() != service_shard) {
+        co_return co_await container().invoke_on(
+          service_shard, [env = std::move(env)](service& s) mutable {
+              return s.run_rpk_dry_run(std::move(env));
+          });
+    }
+
+    auto sem_units = co_await ss::get_units(_dry_run_sem, 1);
+
+    if (!co_await ss::file_exists(_rpk_path_binding().native())) {
+        co_return error_info(
+          error_code::rpk_binary_not_present,
+          fmt::format("{} not present", _rpk_path_binding().native()));
+    }
+
+    std::vector<ss::sstring> args{
+      _rpk_path_binding().native(),
+      "debug",
+      "bundle",
+      ss::sstring{dry_run_flag},
+      ss::sstring{format_flag},
+      ss::sstring{format_json}};
+
+    if (lg.is_enabled(ss::log_level::debug)) {
+        print_arguments(args, env);
+    }
+
+    std::unique_ptr<external_process::external_process> proc;
+    try {
+        proc = co_await external_process::external_process::
+          create_external_process(std::move(args), std::move(env));
+    } catch (const std::exception& e) {
+        co_return error_info(
+          error_code::internal_error,
+          fmt::format(
+            "Starting rpk debug bundle --dry-run failed: {}", e.what()));
+    }
+
+    auto stdout_buf = ss::make_lw_shared<ss::sstring>();
+    auto stderr_buf = ss::make_lw_shared<ss::sstring>();
+    proc->set_stdout_consumer(single_buffer_handler{.buffer = stdout_buf});
+    proc->set_stderr_consumer(single_buffer_handler{.buffer = stderr_buf});
+
+    ss::experimental::process::wait_status wait_status;
+    bool timed_out = false;
+    std::optional<std::string> wait_error;
+    auto timeout = _dry_run_timeout_binding();
+    try {
+        wait_status = co_await ss::with_timeout(
+          ss::lowres_clock::now() + timeout, proc->wait());
+    } catch (const ss::timed_out_error&) {
+        timed_out = true;
+    } catch (const std::exception& e) {
+        wait_error = e.what();
+    }
+    if (timed_out) {
+        co_await proc->terminate(1s);
+        co_return error_info(
+          error_code::process_failed, "rpk debug bundle --dry-run timed out");
+    }
+    if (wait_error) {
+        co_return error_info(
+          error_code::process_failed,
+          fmt::format("rpk debug bundle --dry-run failed: {}", *wait_error));
+    }
+
+    auto* exited = std::get_if<ss::experimental::process::wait_exited>(
+      &wait_status);
+    if (exited == nullptr || exited->exit_code != 0) {
+        co_return error_info(
+          error_code::process_failed,
+          fmt::format(
+            "rpk debug bundle --dry-run exited abnormally; stderr: {}",
+            *stderr_buf));
+    }
+
+    co_return std::move(*stdout_buf);
 }
 
 } // namespace debug_bundle

--- a/src/v/debug_bundle/debug_bundle_service.h
+++ b/src/v/debug_bundle/debug_bundle_service.h
@@ -16,9 +16,11 @@
 #include "debug_bundle/error.h"
 #include "debug_bundle/types.h"
 #include "ssx/mutex.h"
+#include "ssx/semaphore.h"
 #include "storage/fwd.h"
 
 #include <seastar/core/gate.hh>
+#include <seastar/core/semaphore.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/timer.hh>
 #include <seastar/util/process.hh>
@@ -124,6 +126,25 @@ public:
      */
     ss::future<result<void>> delete_rpk_debug_bundle(job_id_t job_id);
 
+    /**
+     * @brief Runs `rpk debug bundle --dry-run --format json` and returns the
+     * raw JSON stdout as a single string. This is a short-lived probe that
+     * reports which files, commands, and K8s permissions the real bundle
+     * would need — without actually producing a bundle.
+     *
+     * Does NOT touch _rpk_process or the process control mutex. Safe to call
+     * concurrently with a regular bundle collection.
+     *
+     * @param env Optional environment variables as KEY=VALUE (e.g. the
+     * KUBERNETES_SERVICE_* vars that let rpk know it's in K8s).
+     * @return Result with possible error codes:
+     * * error_code::rpk_binary_not_present
+     * * error_code::process_failed
+     * * error_code::internal_error
+     */
+    ss::future<result<ss::sstring>>
+    run_rpk_dry_run(std::vector<ss::sstring> env = {});
+
     /// Returns the current debug bundle directory
     const std::filesystem::path& get_debug_bundle_output_directory() const {
         return _debug_bundle_dir;
@@ -222,6 +243,10 @@ private:
     /// Binding called when the debug bundle cleanup configuration has changed
     config::binding<std::optional<std::chrono::seconds>>
       _debug_bundle_cleanup_binding;
+    /// Maximum time the `rpk debug bundle --dry-run` subprocess may run
+    /// before it is terminated. Live-reloadable via the
+    /// `debug_bundle_dry_run_timeout_seconds` cluster config property.
+    config::binding<std::chrono::seconds> _dry_run_timeout_binding;
     /// External process
     std::unique_ptr<debug_bundle_process> _rpk_process;
     /// Metrics probe
@@ -230,6 +255,10 @@ private:
     ss::timer<ss::lowres_clock> _cleanup_timer;
     /// Mutex to guard control over the rpk debug bundle process
     ssx::mutex _process_control_mutex;
+    /// Serializes dry-run subprocess spawns. Separate from
+    /// _process_control_mutex so a dry-run does not block (or get blocked
+    /// by) a regular bundle collection.
+    ssx::semaphore _dry_run_sem{1, "debug_bundle::dry_run"};
     ss::gate _gate;
 };
 } // namespace debug_bundle

--- a/src/v/debug_bundle/tests/debug_bundle_service_test.cc
+++ b/src/v/debug_bundle/tests/debug_bundle_service_test.cc
@@ -1080,3 +1080,77 @@ TEST_F_CORO(
           bytes::from_string(debug_bundle::service::debug_bundle_metadata_key))
         .has_value());
 }
+
+TEST_F_CORO(debug_bundle_service_started_fixture, dry_run_happy_path) {
+    // Tell the shim not to sleep so this test finishes quickly.
+    std::vector<ss::sstring> env{"RPK_SHIM_SLEEP_TIME=0"};
+
+    auto res = co_await _service.local().run_rpk_dry_run(std::move(env));
+    ASSERT_TRUE_CORO(res.has_value()) << res.assume_error().message();
+
+    // The shim emits a fixed JSON payload on stdout when --dry-run is set.
+    constexpr std::string_view expected
+      = R"({"probes":[{"category":"file","resource":"/proc/cpuinfo","ok":true}]})"
+        "\n";
+    EXPECT_EQ(res.assume_value(), expected);
+}
+
+TEST_F_CORO(debug_bundle_service_started_fixture, dry_run_nonzero_exit) {
+    std::vector<ss::sstring> env{
+      "RPK_SHIM_SLEEP_TIME=0", "RPK_SHIM_EXIT_CODE=2"};
+
+    auto res = co_await _service.local().run_rpk_dry_run(std::move(env));
+    ASSERT_FALSE_CORO(res.has_value());
+    EXPECT_EQ(
+      res.assume_error().code(), debug_bundle::error_code::process_failed);
+}
+
+TEST_F_CORO(debug_bundle_service_started_fixture, dry_run_timeout) {
+    // Cap the timeout at the minimum the cluster config allows (5s). The
+    // shim is told to sleep for 10s — well past the timeout — so the
+    // subprocess must be terminated and the caller sees process_failed.
+    config::shard_local_cfg().debug_bundle_dry_run_timeout_seconds.set_value(
+      std::chrono::seconds(5));
+
+    std::vector<ss::sstring> env{"RPK_SHIM_SLEEP_TIME=10"};
+
+    auto res = co_await _service.local().run_rpk_dry_run(std::move(env));
+    ASSERT_FALSE_CORO(res.has_value());
+    EXPECT_EQ(
+      res.assume_error().code(), debug_bundle::error_code::process_failed);
+    EXPECT_NE(res.assume_error().message().find("timed out"), std::string::npos)
+      << "unexpected error message: " << res.assume_error().message();
+}
+
+TEST_F_CORO(
+  debug_bundle_service_started_fixture, dry_run_from_non_service_shard) {
+    // Exercises the invoke_on(service_shard, ...) branch at the top of
+    // run_rpk_dry_run: when called from any shard other than service_shard,
+    // the request hops over to service_shard and the result is returned to
+    // the caller transparently.
+    if (ss::smp::count < 2) {
+        co_return;
+    }
+    std::vector<ss::sstring> env{"RPK_SHIM_SLEEP_TIME=0"};
+    auto other_shard = (debug_bundle::service_shard + 1) % ss::smp::count;
+
+    auto res = co_await _service.invoke_on(
+      other_shard, [env = std::move(env)](debug_bundle::service& s) mutable {
+          return s.run_rpk_dry_run(std::move(env));
+      });
+    ASSERT_TRUE_CORO(res.has_value()) << res.assume_error().message();
+    EXPECT_FALSE(res.assume_value().empty());
+}
+
+TEST_F_CORO(debug_bundle_service_fixture, dry_run_missing_rpk) {
+    config::shard_local_cfg().rpk_path.set_value("/no/such/binary");
+    ASSERT_NO_THROW_CORO(
+      co_await _service.invoke_on_all(
+        [](debug_bundle::service& s) -> ss::future<> { co_await s.start(); }));
+
+    auto res = co_await _service.local().run_rpk_dry_run({});
+    ASSERT_FALSE_CORO(res.has_value());
+    EXPECT_EQ(
+      res.assume_error().code(),
+      debug_bundle::error_code::rpk_binary_not_present);
+}

--- a/src/v/debug_bundle/tests/rpk-shim.sh
+++ b/src/v/debug_bundle/tests/rpk-shim.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 original_args=("$@")
 
 output_file=""
+dry_run=0
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -11,18 +12,30 @@ while [[ $# -gt 0 ]]; do
       output_file="$2"
       shift 2
       ;;
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
     *)
       shift
       ;;
   esac
 done
 
-if [[ -z $output_file ]]; then
-  output_file=results.txt
+sleep_time="${RPK_SHIM_SLEEP_TIME:-5}"
+exit_code="${RPK_SHIM_EXIT_CODE:-0}"
+
+# In dry-run mode, emit JSON on stdout and skip writing any file; the real
+# `rpk debug bundle --dry-run` emits a JSON probe report and creates no
+# bundle artifact.
+if [[ $dry_run -eq 1 ]]; then
+  echo '{"probes":[{"category":"file","resource":"/proc/cpuinfo","ok":true}]}'
+else
+  if [[ -z $output_file ]]; then
+    output_file=results.txt
+  fi
+  echo "${original_args[*]}" | tee "${output_file}"
 fi
 
-sleep_time="${RPK_SHIM_SLEEP_TIME:-5}"
-
-echo "${original_args[*]}" | tee "${output_file}"
-
 sleep "${sleep_time}"
+exit "${exit_code}"

--- a/src/v/redpanda/admin/api-doc/debug_bundle.def.json
+++ b/src/v/redpanda/admin/api-doc/debug_bundle.def.json
@@ -68,4 +68,46 @@
       "type": "string"
     }
   }
+},
+"probe_result": {
+  "type": "object",
+  "required": [
+    "category",
+    "resource",
+    "ok"
+  ],
+  "properties": {
+    "category": {
+      "description": "Probe category: one of file, command, k8s_rbac, admin_api, kafka, network",
+      "type": "string"
+    },
+    "resource": {
+      "description": "The probed target: file path, command name, RBAC descriptor, admin URL, Kafka broker list, or network hostname",
+      "type": "string"
+    },
+    "ok": {
+      "description": "True if the probe succeeded",
+      "type": "boolean"
+    },
+    "error": {
+      "description": "Error detail if the probe failed",
+      "type": "string"
+    },
+    "hint": {
+      "description": "Optional hint explaining how to remediate a failed probe",
+      "type": "string"
+    }
+  }
+},
+"check_permissions_response": {
+  "type": "object",
+  "properties": {
+    "probes": {
+      "description": "Results of each permission/access probe, as produced by `rpk debug bundle --dry-run --format json`",
+      "type": "array",
+      "items": {
+        "$ref": "probe_result"
+      }
+    }
+  }
 }

--- a/src/v/redpanda/admin/api-doc/debug_bundle.json
+++ b/src/v/redpanda/admin/api-doc/debug_bundle.json
@@ -245,6 +245,42 @@
     }
   }
 },
+"/v1/debug/bundle/check_permissions": {
+  "post": {
+    "description": "Probes every file, command, network dependency (admin API, Kafka, NTP, DNS), and Kubernetes RBAC permission the debug bundle would need. Runs 'rpk debug bundle --dry-run --format json' on the broker; does not produce a bundle file. Intended for production readiness checks that want to pre-flight permission issues. Note: admin API and Kafka auth probes use the broker's on-disk rpk configuration; credentials supplied only via the caller's environment or mTLS client certs are not available to the probes and may show as auth failures.",
+    "summary": "Probe debug bundle collection permissions without generating a bundle",
+    "operationId": "post_debug_bundle_check_permissions",
+    "produces": [
+      "application/json"
+    ],
+    "responses": {
+      "200": {
+        "description": "OK",
+        "schema": {
+          "$ref": "#/definitions/check_permissions_response"
+        }
+      },
+      "401": {
+        "description": "Unauthorized",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      },
+      "403": {
+        "description": "Forbidden",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      },
+      "500": {
+        "description": "Internal server error",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      }
+    }
+  }
+},
 "/v1/debug/bundle/file/{filename}": {
   "get": {
     "description": "Returns the generated debug bundle ZIP file",

--- a/src/v/redpanda/admin/debug_bundle.cc
+++ b/src/v/redpanda/admin/debug_bundle.cc
@@ -18,6 +18,7 @@
 #include "ssx/sformat.h"
 
 #include <seastar/core/sstring.hh>
+#include <seastar/http/file_handler.hh>
 #include <seastar/http/reply.hh>
 #include <seastar/json/json_elements.hh>
 #include <seastar/util/short_streams.hh>
@@ -176,6 +177,13 @@ void admin_server::register_debug_bundle_routes() {
         std::unique_ptr<ss::http::request> req,
         std::unique_ptr<ss::http::reply> rep) {
           return delete_debug_bundle_file(std::move(req), std::move(rep));
+      });
+    register_route_raw_async<superuser>(
+      ss::httpd::debug_bundle_json::post_debug_bundle_check_permissions,
+      [this](
+        std::unique_ptr<ss::http::request> req,
+        std::unique_ptr<ss::http::reply> rep) {
+          return check_debug_bundle_permissions(std::move(req), std::move(rep));
       });
 }
 
@@ -339,5 +347,36 @@ admin_server::delete_debug_bundle_file(
     }
 
     rep->set_status(ss::http::reply::status_type::no_content);
+    co_return rep;
+}
+
+ss::future<std::unique_ptr<ss::http::reply>>
+admin_server::check_debug_bundle_permissions(
+  std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply> rep) {
+    std::vector<ss::sstring> env = ::get_enviromental_vars();
+    auto res = co_await _debug_bundle_service.local().run_rpk_dry_run(
+      std::move(env));
+    if (res.has_error()) {
+        co_return make_error_body(res.assume_error(), std::move(rep));
+    }
+
+    auto& body = res.assume_value();
+    // Validate the rpk output is well-formed JSON before forwarding. A broken
+    // stdout shouldn't surface to callers as 200-OK-with-garbage.
+    json::Document doc;
+    doc.Parse(body);
+    if (doc.HasParseError()) {
+        co_return make_error_body(
+          debug_bundle::error_code::process_failed,
+          fmt::format(
+            "rpk debug bundle --dry-run produced malformed JSON: {} at offset "
+            "{}",
+            rapidjson::GetParseError_En(doc.GetParseError()),
+            doc.GetErrorOffset()),
+          std::move(rep));
+    }
+
+    rep->set_status(ss::http::reply::status_type::ok);
+    rep->write_body("json", std::move(body));
     co_return rep;
 }

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -730,6 +730,8 @@ private:
       std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply>);
     ss::future<std::unique_ptr<ss::http::reply>> delete_debug_bundle_file(
       std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply>);
+    ss::future<std::unique_ptr<ss::http::reply>> check_debug_bundle_permissions(
+      std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply>);
 
     // Shard store message routes
     ss::future<std::unique_ptr<ss::http::reply>> put_ctracker_va(

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -2151,6 +2151,10 @@ class Admin:
         path = f"debug/bundle/file/{filename}"
         return self._request("DELETE", path, node=node)
 
+    def check_debug_bundle_permissions(self, node: MaybeNode = None) -> Response:
+        path = "debug/bundle/check_permissions"
+        return self._request("POST", path, node=node)
+
     def unsafe_abort_group_transaction(
         self, group_id: str, *, pid: int, epoch: int, sequence: int
     ) -> Response:

--- a/tests/rptest/tests/debug_bundle_test.py
+++ b/tests/rptest/tests/debug_bundle_test.py
@@ -506,6 +506,38 @@ class DebugBundleTest(DebugBundleTestBase):
         )
 
     @cluster(num_nodes=1)
+    def test_check_permissions(self):
+        """
+        Verify POST /v1/debug/bundle/check_permissions returns 200 with a
+        well-formed probe list when invoked against a live broker. The endpoint
+        shells out to `rpk debug bundle --dry-run --format json` so this is an
+        end-to-end test of the admin handler, the debug_bundle service method,
+        and rpk's dry-run output contract.
+        """
+        node = random.choice(self.redpanda.started_nodes())
+
+        res = self.admin.check_debug_bundle_permissions(node=node)
+        assert res.status_code == requests.codes.ok, res.text
+
+        body = res.json()
+        assert "probes" in body, body
+        assert isinstance(body["probes"], list), body
+        assert len(body["probes"]) > 0, body
+
+        valid_categories = (
+            "file",
+            "command",
+            "k8s_rbac",
+            "admin_api",
+            "kafka",
+            "network",
+        )
+        for probe in body["probes"]:
+            assert set(["category", "resource", "ok"]).issubset(probe.keys()), probe
+            assert probe["category"] in valid_categories, probe
+            assert isinstance(probe["ok"], bool), probe
+
+    @cluster(num_nodes=1)
     def test_delete_cancelled_job(self):
         """
         This test verifies that after a bundle job has been cancelled,


### PR DESCRIPTION
Today, `rpk debug bundle` silently skips collection steps when permissions, commands, or network dependencies are missing on the broker host. Users usually find out about the gaps after the support team let's them know:
1. send a bundle to support
2. support unpacks the zip
3. spots `errors.txt`
4. asks the operator to fix the issues (check ACLs, mount the right ServiceAccount, install `dmidecode`, etc.)

This change adds a dry-run mode to `rpk debug bundle` and surfaces it on a new admin API endpoint. This admin API integration makes it possible to access these details externally from other tools (like a remote rpk instance in the future).

## What this PR does

- `rpk debug bundle --dry-run` probes every file, command, admin API, Kafka, NTP, DNS, and Kubernetes RBAC access the bundle would need, without creating a bundle. Output format is selected via `--format text|json|yaml|wide`. Safe to run against production brokers.
- New admin endpoint `POST /v1/debug/bundle/check_permissions` exposes the same probe set for remote tooling such as production-readiness checks.
- New cluster config property `debug_bundle_dry_run_timeout_seconds` (default 30, range 5–600, live-reloadable) caps how long a single dry-run invocation may run before being terminated.

## Testing

- Go: new `TestProbe*` unit tests in `bundle_test.go`
- C++: new tests in `debug_bundle_service_test.cc`
- Ducktape: `test_check_permissions` in `debug_bundle_test.py`
- The `rpk-shim.sh` test harness was extended with `--dry-run` (no output file) and `RPK_SHIM_EXIT_CODE`.

## Backports Required

- [x] none - not a bug fix