### PR TITLE
build/deps: upgrade openssl to v3.0.20 (CVE-2026-31790)

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -302,7 +302,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "0zGACR1jmGo+VgbH+RrCXv+aCBNEhJnS487cgHn//8A=",
+        "bzlTransitiveDigest": "yJz+4XmMSmQHoa0CNw9Fej2ebHm4hJH3IIF2Gy7mmMs=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -446,9 +446,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:openssl.BUILD",
-              "sha256": "fa5a4143b8aae18be53ef2f3caf29a2e0747430b8bc74d32d88335b94ab63072",
-              "strip_prefix": "openssl-3.0.19",
-              "url": "https://github.com/openssl/openssl/releases/download/openssl-3.0.19/openssl-3.0.19.tar.gz"
+              "sha256": "c80a01dfc70ece4dc21168932c37739042d404d46ccc81a5986dd75314ecda6f",
+              "strip_prefix": "openssl-3.0.20",
+              "url": "https://github.com/openssl/openssl/releases/download/openssl-3.0.20/openssl-3.0.20.tar.gz"
             }
           },
           "openssl-fips": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -138,9 +138,9 @@ def data_dependency():
     http_archive(
         name = "openssl",
         build_file = "//bazel/thirdparty:openssl.BUILD",
-        sha256 = "fa5a4143b8aae18be53ef2f3caf29a2e0747430b8bc74d32d88335b94ab63072",
-        strip_prefix = "openssl-3.0.19",
-        url = "https://github.com/openssl/openssl/releases/download/openssl-3.0.19/openssl-3.0.19.tar.gz",
+        sha256 = "c80a01dfc70ece4dc21168932c37739042d404d46ccc81a5986dd75314ecda6f",
+        strip_prefix = "openssl-3.0.20",
+        url = "https://github.com/openssl/openssl/releases/download/openssl-3.0.20/openssl-3.0.20.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Upgrades the base OpenSSL build from 3.0.19 to 3.0.20 to fix CVE-2026-31790
(SNYK-UNMANAGED-OPENSSL-15928863): Improper Check for Unusual or Exceptional
Conditions in the RSASVE encapsulation path — an invalid RSA public key causes
uninitialized memory to be used as ciphertext output.

The `openssl-fips` build (3.0.9) is intentionally unchanged: it produces only
`fips.so` (the NIST CMVP-validated provider module), which does not contain the
vulnerable EVP encapsulation code. No validated fix version exists for the 3.0.x
FIPS provider; that finding is tracked separately.

The corresponding fix for `dev` and `v26.1.x` (OpenSSL 3.5.6) is in
redpanda-data/redpanda#30238.

No vtools PR is required — this branch references OpenSSL via direct GitHub
release URL.

## Backports Required

- [x] none - this is a backport

## Release Notes

### Bug Fixes

* Upgraded OpenSSL from 3.0.19 to 3.0.20 to address CVE-2026-31790, which could allow an attacker supplying a malformed RSA public key to trigger use of uninitialized memory during RSA key encapsulation.

FIXES=CORE-16121