### PR TITLE
ct: Add storage.mode toggle test

### DIFF
--- a/tests/rptest/tests/cloud_topics/e2e_test.py
+++ b/tests/rptest/tests/cloud_topics/e2e_test.py
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import time
+
 from ducktape.tests.test import TestContext
 from typing import Any
 from ducktape.utils.util import wait_until
@@ -266,6 +268,99 @@ class EndToEndCloudTopicsTest(EndToEndCloudTopicsBase):
         ct_utils.wait_until_l1_partition_size(
             self.admin, topic, partition, lambda size: size > 0
         )
+
+
+class EndToEndCloudTopicsStorageModeToggleTest(EndToEndCloudTopicsBase):
+    """Exercise toggling a topic between 'cloud' and 'tiered_cloud' storage
+    modes while a rate-limited producer is running, then validate the
+    resulting log with a sequential consumer."""
+
+    topics = (
+        TopicSpec(
+            name=EndToEndCloudTopicsBase.s3_topic_name,
+            partition_count=5,
+            replication_factor=3,
+        ),
+    )
+
+    def __init__(self, test_context, extra_rp_conf=None, env=None):
+        super(EndToEndCloudTopicsStorageModeToggleTest, self).__init__(
+            test_context, extra_rp_conf, env
+        )
+        self.msg_size = 16 * 1024
+        # Size the workload so the producer is still sending when the
+        # toggle window ends: at ~10 MB/s with 16 KiB messages this is
+        # ~400s of traffic, vs. a 5-minute toggle window.
+        self.msg_count = 250_000
+        self.rate_limit_bps = 10 * 1024 * 1024  # 10 MB/s
+        self.toggle_duration_sec = 5 * 60
+        self.toggle_interval_sec = 5
+
+    @cluster(num_nodes=5)
+    def test_toggle_storage_mode(self):
+        assert self.redpanda is not None
+        assert self.topic is not None
+        # Enable tiered cloud topics so we can flip into that mode. The
+        # topic is created in 'cloud' mode by the base setUp.
+        self.redpanda.set_feature_active("tiered_cloud_topics", True, timeout_sec=30)
+
+        producer = KgoVerifierProducer(
+            self.test_context,
+            self.redpanda,
+            self.topic,
+            msg_size=self.msg_size,
+            msg_count=self.msg_count,
+            rate_limit_bps=self.rate_limit_bps,
+            tolerate_failed_produce=True,
+        )
+        consumer = KgoVerifierSeqConsumer(
+            self.test_context,
+            self.redpanda,
+            self.topic,
+            self.msg_size,
+            loop=False,
+            producer=producer,
+        )
+        try:
+            producer.start()
+
+            start = time.time()
+            mode = TopicSpec.STORAGE_MODE_CLOUD
+            while time.time() - start < self.toggle_duration_sec:
+                time.sleep(self.toggle_interval_sec)
+                mode = (
+                    TopicSpec.STORAGE_MODE_TIERED_CLOUD
+                    if mode == TopicSpec.STORAGE_MODE_CLOUD
+                    else TopicSpec.STORAGE_MODE_CLOUD
+                )
+                self.rpk.alter_topic_config(
+                    self.topic, TopicSpec.PROPERTY_STORAGE_MODE, mode
+                )
+                self.logger.info(
+                    f"switched storage mode of {self.topic} to {mode} "
+                    f"(acked={producer.produce_status.acked})"
+                )
+
+            # Let the producer run to completion so the consumer has a
+            # natural stopping point.
+            producer.wait(timeout_sec=10 * 60)
+            self.logger.info(
+                f"producer finished with acked={producer.produce_status.acked}, "
+                f"bad_offsets={producer.produce_status.bad_offsets}"
+            )
+
+            # Passing the producer to the consumer makes wait() block
+            # until the consumer has read every produced offset and
+            # validates reads internally.
+            consumer.start(clean=False)
+            consumer.wait(timeout_sec=10 * 60)
+
+            self.wait_until_all_reconciled()
+        finally:
+            producer.stop()
+            consumer.stop()
+            producer.free()
+            consumer.free()
 
 
 class EndToEndCloudTopicsTxTest(EndToEndCloudTopicsBase):


### PR DESCRIPTION
The test changes storage mode between cloud and tiere_cloud constantly while producing.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none