### PR TITLE
iceberg: serialize {initial,write}-default null for optional fields

### DIFF
--- a/src/v/iceberg/datatypes.h
+++ b/src/v/iceberg/datatypes.h
@@ -174,7 +174,7 @@ struct nested_field {
     field_required required;
     field_type type;
     std::optional<ss::sstring> doc;
-    // TODO: support initial-default and write-default optional literals.
+    // TODO: support non-null initial-default and write-default literals.
 
     /**
      * evolution_metadata - Variant holding annotation related to schema

--- a/src/v/iceberg/datatypes_json.cc
+++ b/src/v/iceberg/datatypes_json.cc
@@ -180,9 +180,12 @@ void rjson_serialize(iceberg::json_writer& w, const iceberg::nested_field& f) {
     w.Bool(bool(f.required));
     w.Key("type");
     rjson_serialize(w, f.type);
-    // TODO(iceberg): when/if we add support for required fields,
-    // 'initial-default' and 'write-default' should be written here See
-    // https://iceberg.apache.org/spec/#default-values for requirements
+    if (f.required == iceberg::field_required::no) {
+        w.Key("initial-default");
+        w.Null();
+        w.Key("write-default");
+        w.Null();
+    }
     w.EndObject();
 }
 

--- a/src/v/iceberg/tests/datatypes_json_test.cc
+++ b/src/v/iceberg/tests/datatypes_json_test.cc
@@ -10,6 +10,7 @@
 
 #include "iceberg/datatypes.h"
 #include "iceberg/datatypes_json.h"
+#include "iceberg/json_writer.h"
 #include "iceberg/tests/test_schemas.h"
 #include "json/document.h"
 
@@ -41,4 +42,43 @@ TEST(DataTypeJsonSerde, TestFieldType) {
     ASSERT_NE(parsed_roundtrip_type_moved, parsed_roundtrip_type);
     ASSERT_EQ(parsed_roundtrip_type, expected_type)
       << fmt::format("{}\nvs\n{}", parsed_roundtrip_as_str, expected_type_str);
+    // Serialization must be stable: a second serialize→parse→serialize cycle
+    // must produce identical JSON to the first. This catches asymmetries where
+    // fields are written but silently dropped on read (e.g. initial-default,
+    // write-default).
+    ASSERT_EQ(parsed_orig_as_str, parsed_roundtrip_as_str);
+}
+
+// Optional fields must serialize "initial-default": null and "write-default":
+// null. initial-default tells query engines what to substitute for missing
+// columns in old data files; write-default tells writers what to use when no
+// value is provided. Required fields must not include either.
+TEST(DataTypeJsonSerde, TestDefaultsSerialized) {
+    auto optional_field = nested_field::create(
+      1, "opt", field_required::no, string_type{});
+    auto required_field = nested_field::create(
+      2, "req", field_required::yes, int_type{});
+
+    const auto opt_json = to_json_str(*optional_field);
+    const auto req_json = to_json_str(*required_field);
+
+    json::Document opt_doc;
+    opt_doc.Parse(opt_json.c_str());
+    ASSERT_FALSE(opt_doc.HasParseError()) << opt_json;
+    ASSERT_TRUE(opt_doc.HasMember("initial-default"))
+      << "optional field must have initial-default; got: " << opt_json;
+    ASSERT_TRUE(opt_doc["initial-default"].IsNull())
+      << "optional field initial-default must be null; got: " << opt_json;
+    ASSERT_TRUE(opt_doc.HasMember("write-default"))
+      << "optional field must have write-default; got: " << opt_json;
+    ASSERT_TRUE(opt_doc["write-default"].IsNull())
+      << "optional field write-default must be null; got: " << opt_json;
+
+    json::Document req_doc;
+    req_doc.Parse(req_json.c_str());
+    ASSERT_FALSE(req_doc.HasParseError()) << req_json;
+    ASSERT_FALSE(req_doc.HasMember("initial-default"))
+      << "required field must not have initial-default; got: " << req_json;
+    ASSERT_FALSE(req_doc.HasMember("write-default"))
+      << "required field must not have write-default; got: " << req_json;
 }


### PR DESCRIPTION
Optional fields in an Iceberg schema must carry "initial-default": null
so that query engines reading data files written before the field was
added know to substitute null for the missing column. "write-default":
null tells writers to use null when no value is provided.

Without these, behavior across a schema evolution boundary is
engine-dependent. Since Redpanda's schema authority is the schema
registry, which has no concept of non-null defaults, null is always the
correct value for both defaults on any optional field.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [X] v25.3.x
- [X] v25.2.x

## Release Notes

* none

