### PR TITLE
skill: make create-backport-branch reusable across repos

### DIFF
--- a/.claude/skills/create-backport-branch/SKILL.md
+++ b/.claude/skills/create-backport-branch/SKILL.md
@@ -37,8 +37,10 @@ git checkout -b $backport_branch_name $target_branch
 Get the list of commit SHAs from the PR:
 
 ```bash
-gh api "repos/redpanda-data/redpanda/pulls/$pr_number/commits" --paginate --jq '[.[].sha[0:10]]|join(" ")'
+gh api "repos/{owner}/{repo}/pulls/$pr_number/commits" --paginate --jq '[.[].sha[0:10]]|join(" ")'
 ```
+
+`gh` resolves the `{owner}` and `{repo}` placeholders from the git remote of the current directory (see [`gh api` docs](https://cli.github.com/manual/gh_api)). Run this from a checkout of the repo that owns the PR.
 
 Save the full list of commits as `git_commits` and report how many commits were found.
 
@@ -126,10 +128,16 @@ A cherry-pick can also be empty without any conflict — git will report "The pr
 
 ### 6. Final report
 
-After all commits are cherry-picked successfully, report:
+After all commits are cherry-picked successfully, resolve the source-PR URL dynamically:
+
+```bash
+pr_url=$(gh pr view $pr_number --json url --jq .url)
+```
+
+Then emit this report to stdout:
 
 ```
-Backport of PR https://github.com/redpanda-data/redpanda/pull/${pr_number}
+Backport of PR ${pr_url}
 
 - Command: git cherry-pick -x ${git_commits}
 - Commits backported: ${total_commits}
@@ -137,16 +145,20 @@ Backport of PR https://github.com/redpanda-data/redpanda/pull/${pr_number}
 - Commits skipped (already on target): ${commits_skipped}
 - Backport branch: ${backport_branch_name}
 
-Conflict details:
+## Conflict details
+
 - ${commit_sha} (${file}): one-line explanation of what conflicted and how it was resolved
 ```
 
 For each conflict resolved, include a one-line explanation covering what conflicted and how you resolved it. This helps PR reviewers understand the backport without reading every diff.
 
-If `generated_files_touched` is non-empty, append a warning section:
+If `generated_files_touched` is non-empty, append this warning section:
 
 ```
-⚠️  Generated files were cherry-picked and may need regeneration:
+## ⚠️ Generated files
+
+The following files were cherry-picked and may need regeneration:
+
 - ${file_1}
 - ${file_2}
 
@@ -156,6 +168,8 @@ regenerate them on the target branch to ensure they're correct. For example:
 - *.pb.go / *.pb.cc / *.pb.h: rebuild protobuf targets
 - go.sum: run `go mod tidy`
 ```
+
+**Optional: machine-readable report.** If the `SKILL_REPORT_FILE` env var is set (callers like GitHub Actions workflows use this), write the exact same report text to that file path. The file content is designed to be usable verbatim as the body of the backport PR. Humans invoking the skill directly do not set this variable and simply read the report on stdout.
 
 ## Rules
 


### PR DESCRIPTION
## Summary

Two small non-breaking tweaks to `.claude/skills/create-backport-branch/SKILL.md` added in PR #30175 so the skill is easy to invoke from any repo — by humans or workflows — without having to override its body in the prompt.

- Step 3: `gh api repos/{owner}/{repo}/...` instead of the hardcoded `redpanda-data/redpanda`. `gh` auto-resolves the placeholders from the git remote of the current directory ([gh api docs](https://cli.github.com/manual/gh_api)).
- Step 6: source-PR URL derived via `gh pr view --json url`, plus an optional `SKILL_REPORT_FILE` env var for machine-readable handoff. When set, the skill also writes the Final-report text to that path — designed to be usable verbatim as a PR body (promoted "Conflict details" and the generated-files warning to proper H2 headings for nicer rendering).

Humans invoking the skill directly see no behavioural change.

## Why

[DEVPROD-4091] is wiring this skill into the `/backport` workflow as an AI-assisted conflict-resolution fallback. The original prompt from the staging PR was ~30 lines overriding skill internals (where to `cd`, to skip step 3, to write a custom handoff file to `\$GITHUB_ENV`). Pushing the reusable logic into the skill shrinks the workflow prompt to ~10 lines and keeps the skill usable by humans.

## Test plan

- [x] Re-ran all four skill evals (\`clean-cherry-pick\`, \`multi-commit-conflict\`, \`generated-files-modify-delete\`, \`already-present-empty\`) against the patched SKILL.md in this repo. All pass.
- [x] Staged and validated on \`redpanda-data/test-migration\` — three scenarios (clean path, AI-resolves, AI-aborts-on-modify/delete) all behave correctly with the ~10-line workflow prompt. AI-assisted PR now has the skill's report as the PR body verbatim.
- [x] Confirmed \`gh api \"repos/{owner}/{repo}/...\"\` resolves correctly when run inside a \`redpanda-data/redpanda\` checkout.

Does not touch any workflow file in `redpanda-data/redpanda`. The workflow port is tracked separately in DEVPROD-4091.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

[DEVPROD-4091]: https://redpandadata.atlassian.net/browse/DEVPROD-4091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ