### PR TITLE
bazel: bump rules_cc to 0.2.17

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -46,7 +46,7 @@ single_version_override(
 )
 
 bazel_dep(name = "re2", version = "2024-07-02.bcr.1")
-bazel_dep(name = "rules_cc", version = "0.2.0")
+bazel_dep(name = "rules_cc", version = "0.2.17")
 bazel_dep(name = "rules_foreign_cc", version = "0.12.0")
 bazel_dep(name = "rules_go", version = "0.59.0")
 bazel_dep(name = "rules_pkg", version = "1.0.1")


### PR DESCRIPTION
Bazel emits a direct-dependency mismatch warning because
`MODULE.bazel` declares `rules_cc@0.2.0`, while the resolved
dependency graph pulls in `rules_cc@0.2.17` transitively. Bumping
the declared version to match silences the warning without
changing the effective dependency.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none