### PR TITLE
pre-commit: disable golangci-lint hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,17 +26,23 @@ repos:
         # except that we add -d to provide some feedback about the error
         args: ['-i', '2', '-ci', '-s', '-w', '-d']
 
-  - repo: https://github.com/golangci/golangci-lint
-    rev: v2.11.4
-    hooks:
-      - id: golangci-lint-full
-        name: Go linting (golangci-lint)
-        entry: bash -c 'cd src/go/rpk && golangci-lint run --timeout=10m --verbose'
-        files: '^src/go/rpk/.*\.go$|^src/go/rpk/go\.(mod|sum)$|^src/go/rpk/\.golangci\.yml$'
-      - id: golangci-lint-config-verify
-        name: Go lint config verify
-        entry: bash -c 'cd src/go/rpk && golangci-lint config verify'
-        files: '^src/go/rpk/\.golangci\.yml$'
+  # Disabled: pre-commit's `language: golang` builds golangci-lint from source
+  # using the local Go toolchain, which (via golangci-lint's own go.mod) pulls
+  # Go 1.25 and produces a binary whose bundled `go/types` cannot type-check
+  # packages declaring `go 1.26` -- as src/go/rpk/go.mod now does. CI is
+  # unaffected because it downloads the prebuilt release binary (built with
+  # Go 1.26). Re-enable once the hook uses the same binary as CI.
+  # - repo: https://github.com/golangci/golangci-lint
+  #   rev: v2.11.4
+  #   hooks:
+  #     - id: golangci-lint-full
+  #       name: Go linting (golangci-lint)
+  #       entry: bash -c 'cd src/go/rpk && golangci-lint run --timeout=10m --verbose'
+  #       files: '^src/go/rpk/.*\.go$|^src/go/rpk/go\.(mod|sum)$|^src/go/rpk/\.golangci\.yml$'
+  #     - id: golangci-lint-config-verify
+  #       name: Go lint config verify
+  #       entry: bash -c 'cd src/go/rpk && golangci-lint config verify'
+  #       files: '^src/go/rpk/\.golangci\.yml$'
 
   # Local hooks
   - repo: local


### PR DESCRIPTION
The `golangci-lint-full` pre-commit hook has been broken locally since the Go 1.26.2 bump (284f558130) landed on 2026-04-08. Any developer running `pre-commit run --all-files` — or touching `src/go/rpk/**.go` with the hook installed hits (I think? seems weird):

```
Error: can't load config: the Go language version (go1.25) used to build golangci-lint is lower than the targeted Go version (1.26.2)
```

Pinning `run.go: "1.25"` in `.golangci.yml` gets past config load, but the 1.25 `go/types` bundled into the binary then panics on `go 1.26` source:

```
panic: package requires newer Go version go1.26 (application built with go1.25) [recovered, repanicked]
```

### Root cause

CI and pre-commit obtain different `golangci-lint` binaries:

| | Install path | Binary's build-time Go | Result |
|---|---|---|---|
| **CI** (`.github/workflows/lint-golang.yml`) | `golangci-lint-action@v9` downloads the **prebuilt release binary** | `go1.26.1` (per CI logs) | passes |
| **Pre-commit** (local) | `language: golang` clones the repo and **builds from source** with the local toolchain. golangci-lint's own [`go.mod`](https://github.com/golangci/golangci-lint/blob/v2.11.4/go.mod) declares `go 1.25.0`, so GOTOOLCHAIN pulls 1.25 | `go1.25.0` | panics on `go 1.26` packages |

There is no configuration-only fix: bumping `rev:` does nothing (golangci-lint `main` still declares `go 1.25.0`), and a `run.go` pin only shifts where it blows up.

The single commit in this PR comments out both `golangci-lint-full` and `golangci-lint-config-verify` in `.pre-commit-config.yaml` with an in-file comment pointing at the root cause. CI's `lint-golang` workflow is untouched and continues to enforce `golangci-lint` on the PR path.

### Precommit "golden rule"

When a pre-commit hook runs something different from CI, and the hook itself isn't exercised in CI, it will drift — silently, from either direction. Re-enabling should pick one of two paths, not just bump the pin:

1. Use the **same binary CI uses** (either `language: system` with a documented install step, or have the hook download the same release artifact), so the two stay in lockstep by construction; or
2. Have CI run `pre-commit run --all-files` directly, so any drift fails CI immediately.

Today this repo's hook does neither, which is why this drift went unnoticed until a developer tried to run `pre-commit` after the Go bump.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none