### PR TITLE
CORE-14686 - Archival Scrubber - Add a bit of slack to skip condition to deflake post-ducktape scrub

### DIFF
--- a/src/v/cluster/archival/scrubber_scheduler.h
+++ b/src/v/cluster/archival/scrubber_scheduler.h
@@ -77,13 +77,16 @@ public:
         });
     }
 
+    /// Returns true if the next scheduled scrub is due. A small slack is
+    /// applied so a caller running on a periodic loop (e.g. the housekeeping
+    /// workflow) isn't forced to skip when it polls a few milliseconds early
+    /// — otherwise that miss costs a full cycle of that loop. In production
+    /// the per-partition scrub interval is on the order of hours, so the
+    /// slack never meaningfully widens the window.
     bool should_scrub() const {
-        if (_next_scrub_at == model::timestamp::missing()) {
-            return false;
-        }
-
-        const auto now_ts = model::to_timestamp(Clock::now());
-        return now_ts >= _next_scrub_at;
+        constexpr auto slack = std::chrono::milliseconds{500};
+        const auto until_next = until_next_scrub();
+        return until_next.has_value() && *until_next <= slack;
     }
 
     void pick_next_scrub_time() {

--- a/src/v/cluster/archival/tests/scrubber_scheduler_test.cc
+++ b/src/v/cluster/archival/tests/scrubber_scheduler_test.cc
@@ -300,3 +300,53 @@ BOOST_AUTO_TEST_CASE(test_update_interval) {
         last_scrub_time = model::to_timestamp(ss::manual_clock::now());
     }
 }
+
+// `should_scrub` applies a small (~500ms) slack so the scheduler waking up a
+// few ms before `_next_scrub_at` still returns true. Verify by using a
+// sub-slack interval: with partial_interval well under the slack, the
+// scheduler should report due at t=0 — before the clock reaches
+// `_next_scrub_at`.
+BOOST_AUTO_TEST_CASE(test_should_scrub_slack) {
+    auto& partial_interval
+      = config::shard_local_cfg().cloud_storage_partial_scrub_interval_ms;
+    auto full_interval
+      = config::shard_local_cfg().cloud_storage_full_scrub_interval_ms.bind();
+    auto& jitter
+      = config::shard_local_cfg().cloud_storage_scrubbing_interval_jitter_ms;
+
+    using namespace std::chrono_literals;
+
+    partial_interval.set_value(100ms);
+    // `simple_time_jitter` UBs at jitter=0 (`get_int(-1)`); pick 1ms so
+    // `next_jitter_duration` deterministically returns 0.
+    jitter.set_value(1ms);
+
+    auto reset_configs = ss::defer([&partial_interval, &jitter] {
+        partial_interval.reset();
+        jitter.reset();
+    });
+
+    model::timestamp last_scrub_time;
+    scrub_status last_status{scrub_status::partial};
+    archival::scrubber_scheduler<ss::manual_clock> sched{
+      [&last_scrub_time, &last_status] {
+          return std::make_tuple(last_scrub_time, last_status);
+      },
+      partial_interval.bind(),
+      full_interval,
+      jitter.bind()};
+
+    // Nothing scheduled yet.
+    BOOST_REQUIRE(!sched.should_scrub());
+
+    // Schedule: _next_scrub_at ~= now + 100ms, which is within the slack.
+    last_scrub_time = model::to_timestamp(ss::manual_clock::now());
+    sched.pick_next_scrub_time();
+    BOOST_REQUIRE(sched.should_scrub());
+
+    // Schedule _next_scrub_at ~= now + 1s, which is not within the slack.
+    last_scrub_time = model::to_timestamp(ss::manual_clock::now() - 4s);
+    partial_interval.set_value(5s);
+    sched.pick_next_scrub_time();
+    BOOST_REQUIRE(!sched.should_scrub());
+}

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -6370,12 +6370,22 @@ class RedpandaService(Service, RedpandaServiceABC):
 
             return len(waiting_for) == 0
 
+        # Primary failure signal is progress: bail only if no partition
+        # completes scrubbing within progress_sec. timeout_sec is an
+        # absolute ceiling that scales with the workload so large-partition
+        # tests get a proportionally longer budget.
         n_partitions = len(cloud_storage_partitions)
         timeout = (n_partitions // 100) * 60 + 120
-        wait_until(
-            all_partitions_scrubbed,
+        wait_until_with_progress_check(
+            check=lambda: len(scrubbed),
+            condition=all_partitions_scrubbed,
             timeout_sec=timeout,
+            progress_sec=30,
             backoff_sec=5,
+            err_msg=lambda: (
+                f"internal scrub pending: {cloud_storage_partitions - scrubbed}"
+            ),
+            logger=self.logger,
             retry_on_exc=True,
         )
 

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -147,8 +147,9 @@ def wait_until_with_progress_check(
     timeout_sec: float,
     progress_sec: float,
     backoff_sec: float,
-    err_msg: str | None = None,
+    err_msg: str | Callable[[], str] | None = None,
     logger: Logger | None = None,
+    retry_on_exc: bool = False,
 ):
     """
     a wrapper around ducktape's wait_until that provides the ability to track
@@ -168,6 +169,8 @@ def wait_until_with_progress_check(
       - progress_sec (see above)
       - err_msg: Passed down to wait_until
       - logger: log progress after each progress_sec iteration
+      - retry_on_exc: Passed down to wait_until; swallow exceptions raised by
+        the condition and keep polling instead of bailing out.
     """
     val = check()
     elapsed_sec = 0
@@ -179,6 +182,7 @@ def wait_until_with_progress_check(
                 timeout_sec=progress_sec,
                 backoff_sec=backoff_sec,
                 err_msg=err_msg,
+                retry_on_exc=retry_on_exc,
             )
             break
         except TimeoutError as e:
@@ -202,9 +206,8 @@ def wait_until_with_progress_check(
         "If the condition doesn't hold an exception should have fired"
     )
 
-    raise TimeoutError(
-        f"{err_msg if err_msg is not None else ''} after {timeout_sec=}"
-    ) from last_exception
+    msg = err_msg() if callable(err_msg) else (err_msg or "")
+    raise TimeoutError(f"{msg} after {timeout_sec=}") from last_exception
 
 
 def segments_count(redpanda, topic, partition_idx):


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

The internal scrub in ducktape post checks still times out occasionally.

This seems to happen when a scrubber run gets a tiny slice of quota at
the end of a housekeeping run and exhausts that quota very quicky resulting
in "partial" status. Then if the partial scrub gets bumped to the front
of the line in the next housekeeping run, the already very short (100ms)
partial_scrub_interval may not have elapsed yet, leading to a hard skip
and bumping that partial scrub over to the _next_ housekeeping run, which
might not occur for some time depending on the shape of the test. Could
be on the order of tens or hundreds of seconds for a ManyPartitions style
test case, in which case we time out waiting for all_partitions_scrubbed.

The solution here is to hard-code a small amount of slack into the scheduler's
should_skip predicate to account for this exact scenario. In production,
the partial scrub interval is much longer, so this should have no real
affect on fairness or housekeeping cloud I/O. However for ducktape tests,
where the goal is to actually scrub everything, it effectively guarantees
that quota-starved partial scrubs will be retried immediately, avoiding
any workload dependent queueing issues.

proof: https://buildkite.com/redpanda/redpanda/builds/83539#019db80c-69ef-4168-8324-d9c6c214012a

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
