### PR TITLE
rptest: allow configurable catalog name prefix in DatabricksWorkspace

### DIFF
--- a/tests/rptest/services/databricks_workspace.py
+++ b/tests/rptest/services/databricks_workspace.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import re
 import uuid
 from dataclasses import dataclass
 from typing import Set
@@ -66,6 +67,12 @@ class DatabricksWorkspace(Service):
         name_prefix controls the catalog name prefix, e.g. "panda" produces
         "panda-catalog-{uuid}" and "oxla" produces "oxla-catalog-{uuid}".
         """
+
+        if not re.fullmatch(r"[A-Za-z0-9_-]+", name_prefix):
+            raise ValueError(
+                f"name_prefix must be non-empty and contain only alphanumeric "
+                f"characters, hyphens, or underscores; got: {name_prefix!r}"
+            )
 
         self._location_names.add(bucket)
 

--- a/tests/rptest/services/databricks_workspace.py
+++ b/tests/rptest/services/databricks_workspace.py
@@ -57,9 +57,14 @@ class DatabricksWorkspace(Service):
         self._cleanup_dbx_locations()
         super().stop(**kwargs)
 
-    def create_catalog(self, bucket: str) -> "DatabricksCatalogInfo":
+    def create_catalog(
+        self, bucket: str, name_prefix: str = "panda"
+    ) -> "DatabricksCatalogInfo":
         """
         Creates a brand new catalog in the databricks workspace.
+
+        name_prefix controls the catalog name prefix, e.g. "panda" produces
+        "panda-catalog-{uuid}" and "oxla" produces "oxla-catalog-{uuid}".
         """
 
         self._location_names.add(bucket)
@@ -76,7 +81,7 @@ class DatabricksWorkspace(Service):
             self.logger.error(f"Failed to create external location: {str(e)}")
             raise
 
-        requested_catalog_name = f"panda-catalog-{uuid.uuid1()}"
+        requested_catalog_name = f"{name_prefix}-catalog-{uuid.uuid1()}"
         self._catalog_names.add(requested_catalog_name)
 
         catalog_info: CatalogInfo = self._client.catalogs.create(

--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -49,6 +49,7 @@ class DatalakeServices:
         ],
         catalog_type: CatalogType = CatalogType.REST_JDBC,
         warehouse_name: str = CatalogService.DEFAULT_WAREHOUSE_NAME,
+        catalog_name_prefix: str = "panda",
     ):
         self.test_ctx = test_ctx
         self.redpanda = redpanda
@@ -65,6 +66,7 @@ class DatalakeServices:
         self.query_engines: list[QueryEngineBase] = []
 
         self._catalog_type = catalog_type
+        self._catalog_name_prefix = catalog_name_prefix
         self._cloud_storage_bucket = self.redpanda.si_settings.cloud_storage_bucket
 
     def setUp(self):
@@ -411,7 +413,10 @@ class DatalakeServices:
             )
 
             dbx_workspace = DatabricksWorkspace(self.test_ctx)
-            dbx_catalog_info = dbx_workspace.create_catalog(self._cloud_storage_bucket)
+            dbx_catalog_info = dbx_workspace.create_catalog(
+                self._cloud_storage_bucket,
+                name_prefix=self._catalog_name_prefix,
+            )
 
             # Override.
             self.warehouse_name = dbx_catalog_info.name


### PR DESCRIPTION
Add name_prefix parameter to DatabricksWorkspace.create_catalog() so callers can produce catalogs like "oxla-catalog-{uuid}" in addition to the default "panda-catalog-{uuid}". DatalakeServices exposes this as catalog_name_prefix (default "panda") and forwards it through.

This small change is part of the RP-SQL preparation for Databricks Unity Catalogs support. Additional code including query engines expansion would be in a separate PR. Let's have smaller ones for easier/faster approvals.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none