### PR TITLE
Stabilize shadow-linking tests

### DIFF
--- a/src/v/kafka/client/direct_consumer/direct_consumer.cc
+++ b/src/v/kafka/client/direct_consumer/direct_consumer.cc
@@ -212,9 +212,16 @@ bool direct_consumer::update_and_filter_offsets(
     if (
       subscription.last_known_source_offsets.last_stable_offset
       > spo.last_stable_offset) {
+        // A source broker may transiently advertise an LSO below the
+        // high watermark (and below the previously observed LSO) just
+        // after a restart: the fetch handler can run before the
+        // partition's rm_stm has replayed up to HWM, so LSO is reported
+        // from cold rm_stm state while HWM already reflects recovered
+        // storage. This self-corrects on the next poll once rm_stm
+        // catches up, so treat it as noise rather than an error.
         vlog(
-          _cluster->logger().error,
-          "{}/{} last known stable should never move backward, "
+          _cluster->logger().warn,
+          "{}/{} last known stable should not normally move backward, "
           "current: {}, found: {}",
           topic_name,
           partition_data.partition_id,

--- a/tests/rptest/utils/data_migrations.py
+++ b/tests/rptest/utils/data_migrations.py
@@ -10,6 +10,7 @@
 import time
 
 import requests
+from confluent_kafka import KafkaException
 from ducktape.utils.util import wait_until
 from requests.exceptions import ConnectionError
 
@@ -82,9 +83,22 @@ class DataMigrationTestMixin(RedpandaTest):
             redpanda = self.redpanda
         client = DefaultClient(redpanda)
 
-        # we may be unlucky to query a slow node
+        def all_partitions_gone():
+            # The failure injector thread used by some tests may terminate
+            # a broker mid-poll; the admin client can land on it and raise
+            # KafkaException(_TIMED_OUT) from list_topics. Treat transient
+            # client errors as "not yet" and let wait_until keep retrying
+            # within its budget.
+            try:
+                return all(client.describe_topic(t).partitions == [] for t in topics)
+            except KafkaException as e:
+                redpanda.logger.debug(
+                    f"describe_topic transient error, will retry: {e}"
+                )
+                return False
+
         wait_until(
-            lambda: all(client.describe_topic(t).partitions == [] for t in topics),
+            all_partitions_gone,
             timeout_sec=90,
             backoff_sec=1,
             err_msg="Failed waiting for partitions to disappear",


### PR DESCRIPTION
A source broker may transiently advertise a `last_stable_offset` below its `high_watermark` (and below the previously observed LSO) right after a restart, because the fetch handler can run before `rm_stm` has replayed up to HWM. The direct consumer treats this as an invariant violation and logs at ERROR, which trips `BadLogLines` in shadow-linking tests that restart the source cluster (e.g. `ShadowLinkingReplicationTests.test_with_restart` on RF=1 partitions). The condition self-corrects on the next poll, so downgrade to WARN and document the cause. The problem shouldn't appear in normal circumstances (RF > 1) because the direct consumer will fallback to a follower.

Why the `tiered_cloud` is behind? The test is not long enough in order for the `local` or `tiered` to actually evict anything from the local log. After the restart the broker just replays the log from offset zero so nothing is racing. In case of `tiered_cloud` and `cloud` the local log is truncated aggressively. So after the restart the `rm_stm` could be behind other STM's. In this case the replay is happening in the background fiber and we can see this race. This is kind of by design and shouldn't cause any problems in live environment.

`wait_partitions_disappear` is called by tests that run under `finj_thread`, which terminates random brokers in the background. When the admin client bootstraps against the terminated broker, `list_topics` raises `KafkaException(_TIMED_OUT)` and the exception propagates out of the `wait_until` lambda, aborting the test instead of retrying within the 90s budget. Catch `KafkaException` in the predicate and return False so `wait_until` keeps polling.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none