### PR TITLE
bazel: enable --check_direct_dependencies=error

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,10 @@
 common --registry=https://bcr.bazel.build
 common --extra_toolchains=@current_llvm_toolchain//:all
 
+# Fail the build if MODULE.bazel declares a direct dependency on a version
+# that doesn't match what the resolved module graph actually uses.
+common --check_direct_dependencies=error
+
 common --@toolchains_llvm//toolchain/config:libunwind=False
 common --@toolchains_llvm//toolchain/config:compiler-rt=False
 build --linkopt --unwindlib=libgcc


### PR DESCRIPTION
Turns on Bazel's `--check_direct_dependencies=error`, which fails the build
whenever a `bazel_dep(..., version = ...)` in `MODULE.bazel` declares a
direct-dependency version that doesn't match what the module graph actually
resolves to (e.g. a transitive dep has pulled in a newer version via MVS).

Without this flag, such mismatches are silently ignored and the pinned
version in `MODULE.bazel` drifts from the version that's actually used,
which makes the file misleading. With it, any drift forces us to update
the declared version (or investigate why the transitive dep bumped), so
`MODULE.bazel` stays honest.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none