### PR TITLE
rpc: derive requests_pending gauge from _correlations

### DIFF
--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -452,7 +452,8 @@ void transport::setup_metrics(
       "rpc_client",
       labels,
       aggregate_labels,
-      _probe->defs(labels, aggregate_labels));
+      _probe->defs(
+        labels, aggregate_labels, [this] { return _correlations.size(); }));
 }
 
 timing_info* transport::get_timing(uint32_t correlation) {
@@ -481,7 +482,8 @@ fmt::iterator transport::format_to(fmt::iterator it) const {
 
 std::vector<ss::metrics::metric_definition> client_probe::defs(
   const std::vector<ss::metrics::label_instance>& labels,
-  const std::vector<ss::metrics::label>& aggregate_labels) {
+  const std::vector<ss::metrics::label>& aggregate_labels,
+  std::function<size_t()> pending_count) {
     namespace sm = ss::metrics;
     std::vector<sm::metric_definition> ret;
 
@@ -496,7 +498,7 @@ std::vector<ss::metrics::metric_definition> client_probe::defs(
     ret.emplace_back(
       sm::make_gauge(
         "requests_pending",
-        [this] { return _requests_pending; },
+        [pending_count = std::move(pending_count)] { return pending_count(); },
         sm::description("Number of requests pending"),
         labels)
         .aggregate(aggregate_labels));
@@ -580,14 +582,13 @@ std::vector<ss::metrics::metric_definition> client_probe::defs(
 fmt::iterator client_probe::format_to(fmt::iterator it) const {
     return fmt::format_to(
       it,
-      "{{ requests_sent: {}, requests_pending: {}, requests_completed: {}, "
+      "{{ requests_sent: {}, requests_completed: {}, "
       "request_errors: {}, request_timeouts: {}, in_bytes: {}, out_bytes: {}, "
       "connects: {}, connections: {}, connection_errors: {}, "
       "read_dispatch_errors: {}, corrupted_headers: {}, "
       "server_correlation_errors: {}, client_correlation_errors: {}, "
       "requests_blocked_memory: {} }}",
       _requests,
-      _requests_pending,
       _requests_completed,
       _request_errors,
       _request_timeouts,

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -37,6 +37,7 @@
 
 #include <concepts>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -115,25 +116,13 @@ public:
     client_probe& operator=(client_probe&&) = delete;
     ~client_probe() = default;
 
-    void request() {
-        ++_requests;
-        ++_requests_pending;
-    }
+    void request() { ++_requests; }
 
-    void request_completed() {
-        ++_requests_completed;
-        --_requests_pending;
-    }
+    void request_completed() { ++_requests_completed; }
 
-    void request_timeout() {
-        ++_request_timeouts;
-        --_requests_pending;
-    }
+    void request_timeout() { ++_request_timeouts; }
 
-    void request_error() {
-        ++_request_errors;
-        --_requests_pending;
-    }
+    void request_error() { ++_request_errors; }
 
     void add_bytes_sent(size_t sent) { _out_bytes += sent; }
 
@@ -151,11 +140,11 @@ public:
 
     std::vector<ss::metrics::metric_definition> defs(
       const std::vector<ss::metrics::label_instance>& labels,
-      const std::vector<ss::metrics::label>& aggregate_labels);
+      const std::vector<ss::metrics::label>& aggregate_labels,
+      std::function<size_t()> pending_count);
 
 private:
     uint64_t _requests = 0;
-    uint32_t _requests_pending = 0;
     uint32_t _request_errors = 0;
     uint64_t _request_timeouts = 0;
     uint64_t _requests_completed = 0;


### PR DESCRIPTION
The `vectorized_rpc_client_requests_pending` gauge was observed
drifting over time (and occasionally reporting values near
`UINT32_MAX`). Replace the manual counter with
`_correlations.size()`, which tracks the in-flight request count by
construction and cannot drift.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes

### Bug Fixes

* Fixed the `vectorized_rpc_client_requests_pending` gauge drifting
  over time.