### PR TITLE
build/deps: upgrade openssl to v3.5.6 (CVE-2026-31790)

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -303,7 +303,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "9Ya4lxpgGE79mszfB3VFPPclYo1CFA7b1yO/NKUxkdE=",
+        "bzlTransitiveDigest": "OKsSmh4vvm3UPUKAKMHmLmIlyDP2PXBA+yscTNQLOiQ=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -447,9 +447,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:openssl.BUILD",
-              "sha256": "b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89",
-              "strip_prefix": "openssl-3.5.5",
-              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/openssl-3.5.5.tar.gz"
+              "sha256": "deae7c80cba99c4b4f940ecadb3c3338b13cb77418409238e57d7f31f2a3b736",
+              "strip_prefix": "openssl-3.5.6",
+              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/openssl-3.5.6.tar.gz"
             }
           },
           "openssl-fips": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -138,9 +138,9 @@ def data_dependency():
     http_archive(
         name = "openssl",
         build_file = "//bazel/thirdparty:openssl.BUILD",
-        sha256 = "b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89",
-        strip_prefix = "openssl-3.5.5",
-        url = "https://vectorized-public.s3.amazonaws.com/dependencies/openssl-3.5.5.tar.gz",
+        sha256 = "deae7c80cba99c4b4f940ecadb3c3338b13cb77418409238e57d7f31f2a3b736",
+        strip_prefix = "openssl-3.5.6",
+        url = "https://vectorized-public.s3.amazonaws.com/dependencies/openssl-3.5.6.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Backport of PR #30238

Fixes #30257

Upgrades the base OpenSSL build from 3.5.5 to 3.5.6 to fix CVE-2026-31790
(SNYK-UNMANAGED-OPENSSL-15928863): Improper Check for Unusual or Exceptional
Conditions in the RSASVE encapsulation path — an invalid RSA public key causes
uninitialized memory to be used as ciphertext output.

## Backports Required

- [x] none - this is a backport

## Release Notes

### Bug Fixes

* Upgraded OpenSSL from 3.5.5 to 3.5.6 to address CVE-2026-31790, which could allow an attacker supplying a malformed RSA public key to trigger use of uninitialized memory during RSA key encapsulation.