### PR TITLE
.gitignore: ignore claude worktrees dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -283,6 +283,7 @@ bazel_cc_flags.json
 
 # claude local settings
 **/.claude/settings.local.json
+**/.claude/worktrees/
 
 # perf
 perf.data*


### PR DESCRIPTION
## Summary
- Add `**/.claude/worktrees/` to `.gitignore` so the local Claude Code worktrees directory isn't tracked.

Per the official Claude Code docs, [Run parallel Claude Code sessions with Git worktrees](https://code.claude.com/docs/en/common-workflows#run-parallel-claude-code-sessions-with-git-worktrees):

> Add `.claude/worktrees/` to your `.gitignore` to prevent worktree contents from appearing as untracked files in your main repository.

Worktrees are created at `<repo>/.claude/worktrees/<name>` when using `claude --worktree` or subagent worktree isolation.

## Test plan
- [x] `git status` no longer shows `.claude/worktrees/` as untracked

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

🤖 Generated with [Claude Code](https://claude.com/claude-code)