### PR TITLE
rpk debug bundle: double-sample volatile /proc counters

### DIFF
--- a/src/go/rpk/pkg/cli/debug/bundle/bundle.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle.go
@@ -80,6 +80,10 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 				out.Die("--metrics-samples must be 2 or higher")
 			}
 
+			if opts.MetricsInterval <= 0 {
+				out.Die("--metrics-interval must be positive")
+			}
+
 			cfg, err := p.Load(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
@@ -78,6 +78,7 @@ func executeK8SBundle(ctx context.Context, bp bundleParams) error {
 		saveDataDirStructure(ps, bp.y),
 		saveDf(ctx, ps),
 		saveDiskUsage(ctx, ps, bp.y),
+		saveProcFileSampled(ctx, ps, "/proc/diskstats", "diskstats", bp.metricsInterval, bp.metricsSampleCount),
 		saveProcFileSampled(ctx, ps, "/proc/interrupts", "interrupts", bp.metricsInterval, bp.metricsSampleCount),
 		saveKafkaMetadata(ctx, ps, bp.cl),
 		saveKernelSymbols(ps),

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
@@ -78,7 +78,7 @@ func executeK8SBundle(ctx context.Context, bp bundleParams) error {
 		saveDataDirStructure(ps, bp.y),
 		saveDf(ctx, ps),
 		saveDiskUsage(ctx, ps, bp.y),
-		saveInterrupts(ps),
+		saveProcFileSampled(ctx, ps, "/proc/interrupts", "interrupts", bp.metricsInterval, bp.metricsSampleCount),
 		saveKafkaMetadata(ctx, ps, bp.cl),
 		saveKernelSymbols(ps),
 		saveLsblk(ctx, ps),
@@ -88,7 +88,7 @@ func executeK8SBundle(ctx context.Context, bp bundleParams) error {
 		saveResourceUsageData(ps, bp.y),
 		saveStartupLog(ps, bp.y),
 		saveSlabInfo(ps),
-		saveSoftwareInterrupts(ps),
+		saveProcFileSampled(ctx, ps, "/proc/softirqs", "softirqs", bp.metricsInterval, bp.metricsSampleCount),
 		saveUname(ctx, ps),
 	}
 

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
@@ -143,6 +143,7 @@ func executeBundle(ctx context.Context, bp bundleParams) error {
 		saveDataDirStructure(ps, bp.y),
 		saveDf(ctx, ps),
 		saveDiskUsage(ctx, ps, bp.y),
+		saveProcFileSampled(ctx, ps, "/proc/diskstats", "diskstats", bp.metricsInterval, bp.metricsSampleCount),
 		saveDmidecode(ctx, ps),
 		saveFree(ctx, ps),
 		saveIP(ctx, ps),

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
@@ -147,7 +147,7 @@ func executeBundle(ctx context.Context, bp bundleParams) error {
 		saveFree(ctx, ps),
 		saveIP(ctx, ps),
 		saveEthtool(ctx, ps),
-		saveInterrupts(ps),
+		saveProcFileSampled(ctx, ps, "/proc/interrupts", "interrupts", bp.metricsInterval, bp.metricsSampleCount),
 		saveKafkaMetadata(ctx, ps, bp.cl),
 		saveKernelSymbols(ps),
 		saveLogs(ctx, ps, bp.logsSince, bp.logsUntil, bp.logsLimitBytes),
@@ -162,7 +162,7 @@ func executeBundle(ctx context.Context, bp bundleParams) error {
 		saveStartupLog(ps, bp.y),
 		saveSlabInfo(ps),
 		saveSocketData(ctx, ps),
-		saveSoftwareInterrupts(ps),
+		saveProcFileSampled(ctx, ps, "/proc/softirqs", "softirqs", bp.metricsInterval, bp.metricsSampleCount),
 		saveSysctl(ctx, ps),
 		saveSyslog(ps),
 		saveTopOutput(ctx, ps),
@@ -671,27 +671,40 @@ func saveCPUInfo(ps *stepParams) step {
 	}
 }
 
-// Saves the contents of '/proc/interrupts'.
-func saveInterrupts(ps *stepParams) step {
+// saveProcFileSampled takes sampleCount snapshots of procPath at `interval`
+// apart, writing each to proc/<zipName>/t<N>.txt (t0, t1, …). Used for
+// volatile counter files where deltas between samples are the diagnostic
+// signal; each sample lives under its own directory so consumers can
+// enumerate samples without pattern-matching filenames.
+func saveProcFileSampled(ctx context.Context, ps *stepParams, procPath, zipName string, interval time.Duration, sampleCount int) step {
 	return func() error {
-		f, err := ps.fs.Open("/proc/interrupts")
-		if err != nil {
+		sample := func(n int) error {
+			f, err := ps.fs.Open(procPath)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			return writeStreamToZip(ps, fmt.Sprintf("proc/%s/t%d.txt", zipName, n), f)
+		}
+		if err := sample(0); err != nil {
 			return err
 		}
-		defer f.Close()
-		return writeStreamToZip(ps, "proc/interrupts", f)
-	}
-}
-
-// Saves the contents of '/proc/softirqs/'.
-func saveSoftwareInterrupts(ps *stepParams) step {
-	return func() error {
-		f, err := ps.fs.Open("/proc/softirqs")
-		if err != nil {
-			return err
+		if sampleCount <= 1 {
+			return nil
 		}
-		defer f.Close()
-		return writeStreamToZip(ps, "proc/softirqs", f)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for n := 1; n < sampleCount; n++ {
+			select {
+			case <-ticker.C:
+				if err := sample(n); err != nil {
+					return err
+				}
+			case <-ctx.Done():
+				return sample(n)
+			}
+		}
+		return nil
 	}
 }
 

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_test.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_test.go
@@ -12,6 +12,9 @@
 package bundle
 
 import (
+	"archive/zip"
+	"bytes"
+	"context"
 	"io"
 	"testing"
 	"time"
@@ -343,4 +346,93 @@ func TestSliceControllerDir(t *testing.T) {
 			require.Equal(t, test.exp, slice)
 		})
 	}
+}
+
+func TestSaveProcFileSampled(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	content := []byte("counter-snapshot")
+	require.NoError(t, afero.WriteFile(fs, "/proc/test", content, 0o644))
+
+	newPS := func(zw *zip.Writer) *stepParams {
+		return &stepParams{
+			fs:        fs,
+			w:         zw,
+			timeout:   time.Second,
+			fileRoot:  "bundle",
+			sharedBuf: make([]byte, 1024),
+		}
+	}
+
+	readZip := func(buf *bytes.Buffer) map[string][]byte {
+		zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+		require.NoError(t, err)
+		got := map[string][]byte{}
+		for _, f := range zr.File {
+			func(f *zip.File) {
+				rc, err := f.Open()
+				require.NoError(t, err)
+				defer func() {
+					require.NoError(t, rc.Close())
+				}()
+
+				data, err := io.ReadAll(rc)
+				require.NoError(t, err)
+				got[f.Name] = data
+			}(f)
+		}
+		return got
+	}
+
+	t.Run("each sample written to proc/<name>/tN.txt", func(t *testing.T) {
+		var buf bytes.Buffer
+		zw := zip.NewWriter(&buf)
+		step := saveProcFileSampled(context.Background(), newPS(zw), "/proc/test", "test", time.Millisecond, 3)
+		require.NoError(t, step())
+		require.NoError(t, zw.Close())
+
+		got := readZip(&buf)
+		require.Len(t, got, 3)
+		for _, n := range []string{
+			"bundle/proc/test/t0.txt",
+			"bundle/proc/test/t1.txt",
+			"bundle/proc/test/t2.txt",
+		} {
+			require.Contains(t, got, n)
+			require.Equal(t, content, got[n])
+		}
+	})
+
+	t.Run("ctx cancel captures final sample and returns", func(t *testing.T) {
+		var buf bytes.Buffer
+		zw := zip.NewWriter(&buf)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		step := saveProcFileSampled(ctx, newPS(zw), "/proc/test", "test", time.Hour, 5)
+		require.NoError(t, step())
+		require.NoError(t, zw.Close())
+
+		got := readZip(&buf)
+		require.Len(t, got, 2)
+		require.Contains(t, got, "bundle/proc/test/t0.txt")
+		require.Contains(t, got, "bundle/proc/test/t1.txt")
+	})
+
+	t.Run("sampleCount of 1 writes only t0", func(t *testing.T) {
+		var buf bytes.Buffer
+		zw := zip.NewWriter(&buf)
+		step := saveProcFileSampled(context.Background(), newPS(zw), "/proc/test", "test", time.Hour, 1)
+		require.NoError(t, step())
+		require.NoError(t, zw.Close())
+
+		got := readZip(&buf)
+		require.Len(t, got, 1)
+		require.Contains(t, got, "bundle/proc/test/t0.txt")
+	})
+
+	t.Run("missing source file surfaces error", func(t *testing.T) {
+		var buf bytes.Buffer
+		zw := zip.NewWriter(&buf)
+		step := saveProcFileSampled(context.Background(), newPS(zw), "/proc/does-not-exist", "nope", time.Millisecond, 2)
+		require.Error(t, step())
+	})
 }

--- a/tests/rptest/tests/debug_bundle_test.py
+++ b/tests/rptest/tests/debug_bundle_test.py
@@ -12,6 +12,7 @@ import io
 import json
 import random
 import socket
+import sys
 import time
 import zipfile
 from typing import Optional
@@ -24,6 +25,7 @@ from ducktape.services.service import Service
 from ducktape.utils.util import wait_until
 
 from rptest.clients.rpk import RpkTool
+from rptest.services.rpk_producer import RpkProducer
 from rptest.services.admin import (
     Admin,
     DebugBundleLabelSelection,
@@ -598,28 +600,49 @@ class DebugBundleTest(DebugBundleTestBase):
             f"Failed to find {search_str}"
         )
 
-    @cluster(num_nodes=1)
+    @cluster(num_nodes=2)
     def test_proc_file_sampling(self):
         """
-        Verify that /proc/interrupts and /proc/softirqs are captured as
-        N-sample snapshots under proc/<name>/t{N}.txt. Other /proc files
-        stay at their flat legacy paths, and metrics samples appear at
-        the same cadence.
+        Verify that /proc/interrupts, /proc/softirqs, and /proc/diskstats
+        are captured as N-sample snapshots under proc/<name>/t{N}.txt.
+        Other /proc files stay at their flat legacy paths, and metrics
+        samples appear at the same cadence.
         """
         node = random.choice(self.redpanda.started_nodes())
         samples = 2
 
-        job_id = uuid4()
-        self._run_debug_bundle(
-            job_id=job_id,
-            node=node,
-            config=DebugBundleStartConfigParams(
-                metrics_samples=samples,
-                metrics_interval_seconds=1,
-            ),
+        # /proc/diskstats only ticks when a block device sees I/O. Run
+        # a kafka producer against redpanda for the whole bundle
+        # duration so that redpanda keeps writing to its data dir, which
+        # guarantees diskstats activity in the t0/t1 sampling window.
+        probe_topic = "rptest_diskstats_probe"
+        RpkTool(self.redpanda).create_topic(probe_topic, partitions=1, replicas=1)
+        producer = RpkProducer(
+            self.test_context,
+            self.redpanda,
+            probe_topic,
+            msg_size=1024,
+            msg_count=sys.maxsize,
+            acks=-1,
         )
+        producer.start()
 
-        zip_bytes = self._retrieve_file(node=node)
+        try:
+            job_id = uuid4()
+            self._run_debug_bundle(
+                job_id=job_id,
+                node=node,
+                config=DebugBundleStartConfigParams(
+                    metrics_samples=samples,
+                    metrics_interval_seconds=1,
+                ),
+            )
+            zip_bytes = self._retrieve_file(node=node)
+        finally:
+            producer.stop()
+            producer.wait()
+            producer.free()
+
         with zipfile.ZipFile(io.BytesIO(zip_bytes), "r") as zf:
             names = zf.namelist()
             self.logger.debug(f"zip entries: {names}")
@@ -627,7 +650,11 @@ class DebugBundleTest(DebugBundleTestBase):
             # Strip the single top-level bundle-root directory from each entry.
             entries = {n.split("/", 1)[1]: n for n in names if "/" in n}
 
-            for proc_name in ("interrupts", "softirqs"):
+            # All three must change between t0 and t1:
+            #   - interrupts: timer IRQs tick continuously
+            #   - softirqs:   TIMER softirqs tick continuously
+            #   - diskstats:  guaranteed by the producer running above
+            for proc_name in ("interrupts", "softirqs", "diskstats"):
                 contents = []
                 for n in range(samples):
                     path = f"proc/{proc_name}/t{n}.txt"
@@ -638,10 +665,6 @@ class DebugBundleTest(DebugBundleTestBase):
                         data = f.read()
                     assert data, f"Expected {path} to be non-empty"
                     contents.append(data)
-                # At least one counter must differ between samples. Timer IRQs
-                # / TIMER softirqs tick continuously on any running kernel, so
-                # identical content across t0/t1 means the sampler didn't take
-                # two real snapshots.
                 assert contents[0] != contents[-1], (
                     f"Expected proc/{proc_name} to change between t0 and "
                     f"t{samples - 1}; content was identical"

--- a/tests/rptest/tests/debug_bundle_test.py
+++ b/tests/rptest/tests/debug_bundle_test.py
@@ -598,6 +598,69 @@ class DebugBundleTest(DebugBundleTestBase):
             f"Failed to find {search_str}"
         )
 
+    @cluster(num_nodes=1)
+    def test_proc_file_sampling(self):
+        """
+        Verify that /proc/interrupts and /proc/softirqs are captured as
+        N-sample snapshots under proc/<name>/t{N}.txt. Other /proc files
+        stay at their flat legacy paths, and metrics samples appear at
+        the same cadence.
+        """
+        node = random.choice(self.redpanda.started_nodes())
+        samples = 2
+
+        job_id = uuid4()
+        self._run_debug_bundle(
+            job_id=job_id,
+            node=node,
+            config=DebugBundleStartConfigParams(
+                metrics_samples=samples,
+                metrics_interval_seconds=1,
+            ),
+        )
+
+        zip_bytes = self._retrieve_file(node=node)
+        with zipfile.ZipFile(io.BytesIO(zip_bytes), "r") as zf:
+            names = zf.namelist()
+            self.logger.debug(f"zip entries: {names}")
+
+            # Strip the single top-level bundle-root directory from each entry.
+            entries = {n.split("/", 1)[1]: n for n in names if "/" in n}
+
+            for proc_name in ("interrupts", "softirqs"):
+                contents = []
+                for n in range(samples):
+                    path = f"proc/{proc_name}/t{n}.txt"
+                    assert path in entries, (
+                        f"Expected {path} in bundle; got {sorted(entries)}"
+                    )
+                    with zf.open(entries[path]) as f:
+                        data = f.read()
+                    assert data, f"Expected {path} to be non-empty"
+                    contents.append(data)
+                # At least one counter must differ between samples. Timer IRQs
+                # / TIMER softirqs tick continuously on any running kernel, so
+                # identical content across t0/t1 means the sampler didn't take
+                # two real snapshots.
+                assert contents[0] != contents[-1], (
+                    f"Expected proc/{proc_name} to change between t0 and "
+                    f"t{samples - 1}; content was identical"
+                )
+
+            for flat in ("proc/cpuinfo", "proc/cmdline", "proc/mounts"):
+                assert flat in entries, (
+                    f"Expected legacy flat path {flat}; got {sorted(entries)}"
+                )
+
+            for n in range(samples):
+                metric_samples = [
+                    e for e in entries if e.startswith("metrics/") and f"/t{n}_" in e
+                ]
+                assert len(metric_samples) >= 2, (
+                    f"Expected t{n} samples for both metrics and public_metrics; "
+                    f"got {sorted(metric_samples)}"
+                )
+
 
 class DebugBundleSCRAMAuthn(DebugBundleTestBase):
     """


### PR DESCRIPTION
The /proc counter files in the debug bundle (`interrupts`, `softirqs`, and now `diskstats`) are just that — counters. A single snapshot tells you the levels but not the rates, which is usually what support wants when triaging a bundle. This PR changes the collector so those files are sampled N times (N = `--metrics-samples`, default 2) at `--metrics-interval` spacing, reusing the cadence the metrics endpoints already use. The new sampler runs concurrently with `saveMetricsAPICalls`, so no wall-clock time is added to bundle generation.

The first commit adds the `saveProcFileSampled` helper and wires it in for `/proc/interrupts` and `/proc/softirqs`. The second commit extends it to `/proc/diskstats` (which was not previously collected at all) and teaches the ducktape test to drive a dd loop on the node so diskstats counters are guaranteed to tick between t0 and t1.

The first sample for each file stays at its existing flat path (`proc/<name>`) for backwards compatibility; additional samples land at `proc/<name>.t{N}` (t1, t2, …). Other `/proc` files (cpuinfo, cmdline, mounts, slabinfo, mdstat, kallsyms) are unchanged.

A Go unit test in `bundle_test.go` covers `saveProcFileSampled`, and a new ducktape test `DebugBundleTest.test_proc_file_sampling` opens the generated bundle zip and verifies both the path layout and that the counter contents actually differ between samples.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Improvements

* `rpk debug bundle` now samples `/proc/interrupts`, `/proc/softirqs`, and `/proc/diskstats` twice (at `--metrics-interval` spacing) so support can compute counter deltas. The first sample keeps the existing flat `proc/<name>` path; additional samples land at `proc/<name>.t{N}`.