### PR TITLE
tests/antithesis: add fixture test targets manifest

### DIFF
--- a/tests/antithesis/fixture_test_targets.yml
+++ b/tests/antithesis/fixture_test_targets.yml
@@ -1,0 +1,11 @@
+# Bazel target patterns packaged and submitted to Antithesis by the
+# "Nightly Antithesis Fixture Tests" Buildkite schedule (redpanda
+# pipeline, PIPELINE_ACTION=antithesis-fixture-submit).
+#
+# Each entry:
+#   - target:   Bazel label or pattern (required)
+#   - duration: AT run length in minutes (optional; defaults to 30)
+targets:
+  - target: "//src/v/cluster/tests/..."
+  - target: "//src/v/raft/tests/..."
+  - target: "//src/v/storage/tests/..."


### PR DESCRIPTION
Not dead set on this location for the run configuration file. Other options could be in the `vtools` repo or `tools/antithesis` within this repo. 

Follow up to https://github.com/redpanda-data/vtools/pull/4192
 
Lists the Bazel target patterns that the nightly "Antithesis Fixture Tests" Buildkite schedule packages (via tools/antithesis/single_binary_test_package.py) and submits to Antithesis. Each entry supports an optional `duration` (minutes; defaults to 30).

The vtools dynamic-pipeline handler for PIPELINE_ACTION=antithesis-fixture-submit reads this file at pipeline-generation time and fans out one Buildkite step per entry. Adding/removing AT coverage is a PR against this file alone — no vtools or devprod-infra change required.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
