### PR TITLE
pre-commit: Reenable golanglint-ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,11 +32,16 @@ repos:
       - id: golangci-lint-full
         name: Go linting (golangci-lint)
         entry: bash -c 'cd src/go/rpk && golangci-lint run --timeout=10m --verbose'
+        language_version: 1.26.2
         files: '^src/go/rpk/.*\.go$|^src/go/rpk/go\.(mod|sum)$|^src/go/rpk/\.golangci\.yml$'
+        pass_filenames: false
+
       - id: golangci-lint-config-verify
         name: Go lint config verify
-        entry: bash -c 'cd src/go/rpk && golangci-lint config verify'
+        entry: bash -c 'cd src/go/rpk && golangci-lint config verify --config .golangci.yml'
+        language_version: 1.26.2
         files: '^src/go/rpk/\.golangci\.yml$'
+        pass_filenames: false
 
   # Local hooks
   - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,23 +26,17 @@ repos:
         # except that we add -d to provide some feedback about the error
         args: ['-i', '2', '-ci', '-s', '-w', '-d']
 
-  # Disabled: pre-commit's `language: golang` builds golangci-lint from source
-  # using the local Go toolchain, which (via golangci-lint's own go.mod) pulls
-  # Go 1.25 and produces a binary whose bundled `go/types` cannot type-check
-  # packages declaring `go 1.26` -- as src/go/rpk/go.mod now does. CI is
-  # unaffected because it downloads the prebuilt release binary (built with
-  # Go 1.26). Re-enable once the hook uses the same binary as CI.
-  # - repo: https://github.com/golangci/golangci-lint
-  #   rev: v2.11.4
-  #   hooks:
-  #     - id: golangci-lint-full
-  #       name: Go linting (golangci-lint)
-  #       entry: bash -c 'cd src/go/rpk && golangci-lint run --timeout=10m --verbose'
-  #       files: '^src/go/rpk/.*\.go$|^src/go/rpk/go\.(mod|sum)$|^src/go/rpk/\.golangci\.yml$'
-  #     - id: golangci-lint-config-verify
-  #       name: Go lint config verify
-  #       entry: bash -c 'cd src/go/rpk && golangci-lint config verify'
-  #       files: '^src/go/rpk/\.golangci\.yml$'
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v2.11.4
+    hooks:
+      - id: golangci-lint-full
+        name: Go linting (golangci-lint)
+        entry: bash -c 'cd src/go/rpk && golangci-lint run --timeout=10m --verbose'
+        files: '^src/go/rpk/.*\.go$|^src/go/rpk/go\.(mod|sum)$|^src/go/rpk/\.golangci\.yml$'
+      - id: golangci-lint-config-verify
+        name: Go lint config verify
+        entry: bash -c 'cd src/go/rpk && golangci-lint config verify'
+        files: '^src/go/rpk/\.golangci\.yml$'
 
   # Local hooks
   - repo: local


### PR DESCRIPTION
It was previously broken since we upgraded to Go 1.26. golanglint-ci has
supported Go 1.26 for a long time (version 2.9).

However, without specifying the language version in the hook it would
just use the system version which might be older and golanglint-ci
always needs to be used with a go version newer or equal to the version
it lints.

Also set pass_filenames to false. golanglint-ci operates on modules so
passing individual files can break it.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes


* none

