### PR TITLE
gha: add AI-assisted fallback to /backport command

### DIFF
--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -127,6 +127,7 @@ jobs:
           path: ./fork
       - name: Backport commits and get details
         if: needs.backport-type.outputs.commented_on == 'pr'
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
           ORIG_TITLE: ${{ github.event.client_payload.github.payload.issue.title }}
@@ -139,14 +140,105 @@ jobs:
         id: pr_details
         run: $SCRIPT_DIR/pr_details.sh
         shell: bash
+      - name: AI-assisted backport
+        if: needs.backport-type.outputs.commented_on == 'pr' && steps.pr_details.outcome == 'failure'
+        id: ai_backport
+        uses: anthropics/claude-code-action@v1
+        env:
+          GITHUB_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
+          GH_REPO: ${{ env.TARGET_FULL_REPO }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ env.ACTIONS_BOT_TOKEN }}
+          allowed_bots: ""
+          allowed_non_write_users: ""
+          show_full_output: true
+          track_progress: false
+          claude_args: >
+            --model opus
+            --max-turns 40
+            --disallowed-tools "WebFetch,WebSearch"
+            --allowed-tools "
+              Bash(git *),
+              Bash(gh *),
+              Bash(date *),
+              Bash(grep *),
+              Bash(wc *),
+              Bash(echo *),
+              Bash(printf *),
+              Bash(cat *),
+              Bash(cd *),
+              Read,
+              Write,
+              Edit,
+              Glob,
+              Grep,
+              Agent"
+          prompt: |
+            The plain `git cherry-pick` in the prior step failed. Re-do the
+            backport using the skill at
+            ${{ github.workspace }}/.claude/skills/create-backport-branch/SKILL.md.
+
+            Preflight (bash):
+              cd "${{ github.workspace }}/fork"
+              git cherry-pick --abort || true
+              export SKILL_REPORT_FILE="${{ github.workspace }}/.ai-backport-meta/report.md"
+              mkdir -p "$(dirname "$SKILL_REPORT_FILE")"
+
+            Invoke the skill with:
+              $0 = ${{ env.BACKPORT_BRANCH }}  (target — the release branch)
+              $1 = ${{ env.PR_NUMBER }}        (pr-number)
+
+            When the skill finishes successfully:
+              branch=$(git branch --show-current)
+              git push --set-upstream origin "$branch"
+
+            If the skill aborts (modify/delete, architectural unknown, etc.),
+            exit 1. Do NOT push, do NOT write a report file.
+      - name: Load AI skill report
+        id: load_ai_handoff
+        if: steps.ai_backport.outcome == 'success'
+        run: |
+          report="${GITHUB_WORKSPACE}/.ai-backport-meta/report.md"
+          if [[ ! -s "$report" ]]; then
+            echo "::error::Skill report file missing or empty at $report (skill probably aborted)"
+            exit 1
+          fi
+          branch=$(cd "${GITHUB_WORKSPACE}/fork" && git branch --list 'ai-backport-pr-*' --sort=-committerdate --format='%(refname:short)' | head -1)
+          if [[ -z "$branch" ]]; then
+            echo "::error::Report file written but no ai-backport-pr-* branch found"
+            exit 1
+          fi
+          {
+            echo "AI_HEAD_BRANCH=$branch"
+            echo "AI_REPORT_FILE=$report"
+          } >> "$GITHUB_ENV"
+          echo "AI branch: $branch"
+          echo "AI report: $report ($(wc -l < "$report") lines)"
+        shell: bash
+      - name: Diagnostic after AI
+        if: always() && needs.backport-type.outputs.commented_on == 'pr'
+        run: |
+          cd "${GITHUB_WORKSPACE}/fork" 2>/dev/null || exit 0
+          echo "== git log =="
+          git log --oneline -20 || true
+          echo "== git status =="
+          git status || true
+          echo "== current branch =="
+          git branch --show-current || true
+          echo "== remotes =="
+          git remote -v || true
+          echo "== AI_HEAD_BRANCH =="
+          echo "${AI_HEAD_BRANCH:-<unset>}"
+        shell: bash
       - name: Create pull request
-        if: needs.backport-type.outputs.commented_on == 'pr'
+        if: needs.backport-type.outputs.commented_on == 'pr' && (steps.pr_details.outcome == 'success' || steps.load_ai_handoff.outcome == 'success')
         env:
           GITHUB_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
           TARGET_MILESTONE: ${{ steps.create_milestone.outputs.milestone }}
           ORIG_TITLE: ${{ github.event.client_payload.github.payload.issue.title }}
           AUTHOR: ${{ github.event.client_payload.pull_request.user.login }}
-          HEAD_BRANCH: ${{ steps.pr_details.outputs.head_branch }}
+          HEAD_BRANCH: ${{ env.AI_HEAD_BRANCH || steps.pr_details.outputs.head_branch }}
           FIXING_ISSUE_URLS: ${{ steps.pr_details.outputs.fixing_issue_urls }}
           ORIG_PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
           ORIG_PR_URL: ${{ github.event.client_payload.pull_request.html_url }}
@@ -154,7 +246,25 @@ jobs:
         id: create_pr
         run: $SCRIPT_DIR/create_pr.sh
         shell: bash
+      - name: Label AI-assisted PR
+        if: steps.load_ai_handoff.outcome == 'success' && steps.create_pr.outcome == 'success'
+        env:
+          GITHUB_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
+          PR_HEAD: ${{ env.AI_HEAD_BRANCH }}
+          GIT_USER: ${{ steps.user.outputs.username }}
+        run: |
+          pr_num=$(gh pr list --repo "$TARGET_FULL_REPO" \
+            --head "$GIT_USER:$PR_HEAD" --state open \
+            --json number --jq '.[0].number')
+          if [[ -z "$pr_num" ]]; then
+            echo "::warning::Could not find backport PR with head=$GIT_USER:$PR_HEAD"
+            exit 0
+          fi
+          gh pr edit "$pr_num" --repo "$TARGET_FULL_REPO" \
+            --add-label ai-resolved-conflicts
+        shell: bash
       - name: Add reaction
+        if: steps.pr_details.outcome == 'success' || steps.load_ai_handoff.outcome == 'success'
         uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ env.ACTIONS_BOT_TOKEN }}
@@ -162,22 +272,22 @@ jobs:
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           reactions: hooray
       - name: Failed reaction
+        if: always() && steps.pr_details.outcome == 'failure' && steps.load_ai_handoff.outcome != 'success'
         uses: peter-evans/create-or-update-comment@v4
-        if: failure()
         with:
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           reactions: "-1"
       - name: Post Error
-        if: failure()
+        if: always() && steps.pr_details.outcome == 'failure' && steps.load_ai_handoff.outcome != 'success'
         env:
           COMMENTED_ON: ${{ needs.backport-type.outputs.commented_on }}
           GITHUB_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
         run: $SCRIPT_DIR/post_error.sh
         shell: bash
       - name: Create Issue On Error
-        if: failure()
+        if: always() && steps.pr_details.outcome == 'failure' && steps.load_ai_handoff.outcome != 'success'
         env:
           GITHUB_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
           TARGET_MILESTONE: ${{ steps.create_milestone.outputs.milestone }}

--- a/.github/workflows/scripts/backport-command/create_pr.sh
+++ b/.github/workflows/scripts/backport-command/create_pr.sh
@@ -50,6 +50,15 @@ if [[ $FIXING_ISSUE_URLS != "" ]]; then
   backport_issue_urls=$(echo "$backport_issue_urls" | sed 's/.$//')
 fi
 
+# If the AI path produced a skill report, use it verbatim as the PR body.
+# Otherwise fall back to the plain one-line summary below.
+if [[ -n "${AI_REPORT_FILE:-}" && -s "$AI_REPORT_FILE" ]]; then
+  body_args=(--body-file "$AI_REPORT_FILE")
+else
+  body_args=(--body "Backport of PR $ORIG_ISSUE_URL
+$backport_issue_urls")
+fi
+
 gh pr create --title "[$BACKPORT_BRANCH] $ORIG_TITLE" \
   --base "$BACKPORT_BRANCH" \
   --label "kind/backport" \
@@ -57,5 +66,4 @@ gh pr create --title "[$BACKPORT_BRANCH] $ORIG_TITLE" \
   --repo "$TARGET_ORG/$TARGET_REPO" \
   --reviewer "$AUTHOR" \
   --milestone "$TARGET_MILESTONE" \
-  --body "Backport of PR $ORIG_ISSUE_URL
-$backport_issue_urls"
+  "${body_args[@]}"

--- a/.github/workflows/scripts/backport-command/create_pr.sh
+++ b/.github/workflows/scripts/backport-command/create_pr.sh
@@ -52,7 +52,7 @@ fi
 
 # If the AI path produced a skill report, use it verbatim as the PR body.
 # Otherwise fall back to the plain one-line summary below.
-if [[ -n "${AI_REPORT_FILE:-}" && -s "$AI_REPORT_FILE" ]]; then
+if [[ -n ${AI_REPORT_FILE:-} && -s $AI_REPORT_FILE ]]; then
   body_args=(--body-file "$AI_REPORT_FILE")
 else
   body_args=(--body "Backport of PR $ORIG_ISSUE_URL

--- a/.github/workflows/scripts/backport-command/create_pr.sh
+++ b/.github/workflows/scripts/backport-command/create_pr.sh
@@ -50,10 +50,16 @@ if [[ $FIXING_ISSUE_URLS != "" ]]; then
   backport_issue_urls=$(echo "$backport_issue_urls" | sed 's/.$//')
 fi
 
-# If the AI path produced a skill report, use it verbatim as the PR body.
-# Otherwise fall back to the plain one-line summary below.
+# If the AI path produced a skill report, use it as the PR body but still
+# append the Fixes: lines so the backport PR auto-closes the backport issues
+# this script just created. Otherwise fall back to the plain one-line summary.
 if [[ -n ${AI_REPORT_FILE:-} && -s $AI_REPORT_FILE ]]; then
-  body_args=(--body-file "$AI_REPORT_FILE")
+  combined_body=$(mktemp)
+  cat "$AI_REPORT_FILE" >"$combined_body"
+  if [[ -n $backport_issue_urls ]]; then
+    printf '\n\n%s\n' "$backport_issue_urls" >>"$combined_body"
+  fi
+  body_args=(--body-file "$combined_body")
 else
   body_args=(--body "Backport of PR $ORIG_ISSUE_URL
 $backport_issue_urls")

--- a/.github/workflows/scripts/backport-command/pr_details.sh
+++ b/.github/workflows/scripts/backport-command/pr_details.sh
@@ -33,6 +33,11 @@ fixing_issue_urls=$(gh api graphql -f query='{
   }
 }' --jq '.data.resource.closingIssuesReferences.nodes | map(.url) | join(" ")')
 
+# Emit fixing_issue_urls now so downstream steps (e.g. the AI fallback's
+# create_pr call) can read it even if the cherry-pick below fails and we
+# exit via backport_failure.
+echo "fixing_issue_urls=$fixing_issue_urls" >>$GITHUB_OUTPUT
+
 suffix=$((RANDOM % 1000))
 git config --global user.email "$GIT_EMAIL"
 git config --global user.name "$GIT_USER"
@@ -65,4 +70,3 @@ fi
 git push --set-upstream origin "$head_branch"
 git remote rm upstream
 echo "head_branch=$head_branch" >>$GITHUB_OUTPUT
-echo "fixing_issue_urls=$fixing_issue_urls" >>$GITHUB_OUTPUT


### PR DESCRIPTION
When `/backport` triggers a cherry-pick that conflicts, the `type-branch` job now hands off to `anthropics/claude-code-action@v1` running the `create-backport-branch` skill (already on `dev` via #30248). If the skill resolves the conflict, the workflow opens a backport PR tagged `ai-resolved-conflicts` with the skill's Markdown conflict report as the PR body. If the skill aborts (modify/delete or anything it can't confidently resolve), behaviour matches today: no backport PR, a fallback issue is opened, and the `/backport` comment gets a 👎.

The happy path is unchanged. When the plain cherry-pick succeeds, the AI step is skipped and no Anthropic API call is made — existing `/backport` requests that don't hit conflicts see no difference.

[DEVPROD-4091]

## Implementation notes

- `pr_details` gets `continue-on-error: true` so the job can fall through to the AI step on cherry-pick failure. The existing `backport_failure` still writes `BACKPORT_ERROR` to `$GITHUB_ENV` for the fallback-issue body.
- `Load AI skill report` treats `.ai-backport-meta/report.md`'s presence as the real success signal (the action exits 0 even when the skill intentionally aborts).
- `GH_REPO=$TARGET_FULL_REPO` is exported for the AI step so the skill's `gh api "repos/{owner}/{repo}/..."` resolves to `redpanda-data/redpanda` rather than the bot fork that `origin` points at.
- Failure-path steps (`Failed reaction`, `Post Error`, `Create Issue On Error`) are gated on `always() && pr_details.outcome == 'failure' && load_ai_handoff.outcome != 'success'` — the `always()` is mandatory because `continue-on-error` would otherwise make GitHub treat the job as successful and skip these.
- `create_pr.sh` honours `$AI_REPORT_FILE` via `--body-file` when set; otherwise uses the existing one-line `--body` string.
- Label `ai-resolved-conflicts` is pre-created on redpanda-data/redpanda.

## Cost

Each AI fallback invocation is an Anthropic API call — ~40k tokens observed on the test-migration validation runs. Happy-path backports spend nothing.

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

## Test plan

Staged and validated end-to-end on [redpanda-data/test-migration](https://github.com/redpanda-data/test-migration) (see DEVPROD-4091 for links to the three scenario runs). Redpanda is the hot repo, so no pre-merge test; post-merge controlled verification plan:

- [ ] Clean cherry-pick regression — `/backport v25.3.x` on #30227 (small use-after-move fix, `merge-tree` predicts 0 conflicts against all recent release branches). Expect: `pr_details` succeeds, AI step skipped, backport PR with `kind/backport` only, no Anthropic cost.
- [ ] AI resolves content conflict — `/backport v25.3.x` on #30191 (`kafka/protocol: bound parse_tags`, `merge-tree` predicts 2 content conflicts in `transport.cc` and `protocol_utils.cc`). Expect: AI step runs, backport PR opens on `ai-backport-pr-30191-v25.3.x-<ts>` with labels `kind/backport` + `ai-resolved-conflicts`, PR body is the skill's Markdown report.
- [ ] AI aborts on modify/delete — `/backport v25.2.x` on #30191 (`transport.cc` is deleted on v25.2.x). Expect: AI aborts, fallback issue created, no `ai-backport-pr-*` branch pushed to `vbotbuildovich/redpanda`, 👎 reaction on comment.

Rollback: revert this commit. Label stays (harmless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DEVPROD-4091]: https://redpandadata.atlassian.net/browse/DEVPROD-4091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ