### PR TITLE
[v25.2.x] rpc: derive requests_pending gauge from _correlations

### DIFF
--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -458,7 +458,8 @@ void transport::setup_metrics(
       "rpc_client",
       labels,
       aggregate_labels,
-      _probe->defs(labels, aggregate_labels));
+      _probe->defs(
+        labels, aggregate_labels, [this] { return _correlations.size(); }));
 }
 
 timing_info* transport::get_timing(uint32_t correlation) {
@@ -488,7 +489,8 @@ std::ostream& operator<<(std::ostream& o, const transport& t) {
 
 std::vector<ss::metrics::metric_definition> client_probe::defs(
   const std::vector<ss::metrics::label_instance>& labels,
-  const std::vector<ss::metrics::label>& aggregate_labels) {
+  const std::vector<ss::metrics::label>& aggregate_labels,
+  std::function<size_t()> pending_count) {
     namespace sm = ss::metrics;
     std::vector<sm::metric_definition> ret;
 
@@ -499,12 +501,13 @@ std::vector<ss::metrics::metric_definition> client_probe::defs(
                        labels)
                        .aggregate(aggregate_labels));
 
-    ret.emplace_back(sm::make_gauge(
-                       "requests_pending",
-                       [this] { return _requests_pending; },
-                       sm::description("Number of requests pending"),
-                       labels)
-                       .aggregate(aggregate_labels));
+    ret.emplace_back(
+      sm::make_gauge(
+        "requests_pending",
+        [pending_count = std::move(pending_count)] { return pending_count(); },
+        sm::description("Number of requests pending"),
+        labels)
+        .aggregate(aggregate_labels));
 
     ret.emplace_back(sm::make_counter(
                        "request_errors",
@@ -581,7 +584,6 @@ std::vector<ss::metrics::metric_definition> client_probe::defs(
 std::ostream& operator<<(std::ostream& o, const client_probe& p) {
     o << "{"
       << " requests_sent: " << p._requests
-      << ", requests_pending: " << p._requests_pending
       << ", requests_completed: " << p._requests_completed
       << ", request_errors: " << p._request_errors
       << ", request_timeouts: " << p._request_timeouts

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -35,6 +35,7 @@
 
 #include <concepts>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -113,25 +114,13 @@ public:
     client_probe& operator=(client_probe&&) = delete;
     ~client_probe() = default;
 
-    void request() {
-        ++_requests;
-        ++_requests_pending;
-    }
+    void request() { ++_requests; }
 
-    void request_completed() {
-        ++_requests_completed;
-        --_requests_pending;
-    }
+    void request_completed() { ++_requests_completed; }
 
-    void request_timeout() {
-        ++_request_timeouts;
-        --_requests_pending;
-    }
+    void request_timeout() { ++_request_timeouts; }
 
-    void request_error() {
-        ++_request_errors;
-        --_requests_pending;
-    }
+    void request_error() { ++_request_errors; }
 
     void add_bytes_sent(size_t sent) { _out_bytes += sent; }
 
@@ -149,11 +138,11 @@ public:
 
     std::vector<ss::metrics::metric_definition> defs(
       const std::vector<ss::metrics::label_instance>& labels,
-      const std::vector<ss::metrics::label>& aggregate_labels);
+      const std::vector<ss::metrics::label>& aggregate_labels,
+      std::function<size_t()> pending_count);
 
 private:
     uint64_t _requests = 0;
-    uint32_t _requests_pending = 0;
     uint32_t _request_errors = 0;
     uint64_t _request_timeouts = 0;
     uint64_t _requests_completed = 0;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30264

- Command: git cherry-pick -x 29cd963cf4
- Commits backported: 1
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-30264-v25.2.x-1777059165

## Conflict details

- 29cd963cf4 (src/v/rpc/transport.cc): the incoming commit (a) replaced the manual `_requests_pending` field with a `pending_count` callback in `client_probe::defs` and (b) updated a `format_to` member to drop the now-removed field. The target branch v25.2.x still uses an `operator<<(ostream&, const client_probe&)` instead of `format_to` (not yet migrated to the new printing style). Resolved by taking the incoming side for the `defs` gauge (callback-based lookup) and keeping the target branch's `operator<<` overload while removing the `requests_pending`/`_requests_pending` line, since the field no longer exists.
