### PR TITLE
[v25.3.x] rpc: derive requests_pending gauge from _correlations

### DIFF
--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -459,7 +459,8 @@ void transport::setup_metrics(
       "rpc_client",
       labels,
       aggregate_labels,
-      _probe->defs(labels, aggregate_labels));
+      _probe->defs(
+        labels, aggregate_labels, [this] { return _correlations.size(); }));
 }
 
 timing_info* transport::get_timing(uint32_t correlation) {
@@ -489,7 +490,8 @@ std::ostream& operator<<(std::ostream& o, const transport& t) {
 
 std::vector<ss::metrics::metric_definition> client_probe::defs(
   const std::vector<ss::metrics::label_instance>& labels,
-  const std::vector<ss::metrics::label>& aggregate_labels) {
+  const std::vector<ss::metrics::label>& aggregate_labels,
+  std::function<size_t()> pending_count) {
     namespace sm = ss::metrics;
     std::vector<sm::metric_definition> ret;
 
@@ -504,7 +506,7 @@ std::vector<ss::metrics::metric_definition> client_probe::defs(
     ret.emplace_back(
       sm::make_gauge(
         "requests_pending",
-        [this] { return _requests_pending; },
+        [pending_count = std::move(pending_count)] { return pending_count(); },
         sm::description("Number of requests pending"),
         labels)
         .aggregate(aggregate_labels));
@@ -588,7 +590,6 @@ std::vector<ss::metrics::metric_definition> client_probe::defs(
 std::ostream& operator<<(std::ostream& o, const client_probe& p) {
     o << "{"
       << " requests_sent: " << p._requests
-      << ", requests_pending: " << p._requests_pending
       << ", requests_completed: " << p._requests_completed
       << ", request_errors: " << p._request_errors
       << ", request_timeouts: " << p._request_timeouts

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -36,6 +36,7 @@
 
 #include <concepts>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -114,25 +115,13 @@ public:
     client_probe& operator=(client_probe&&) = delete;
     ~client_probe() = default;
 
-    void request() {
-        ++_requests;
-        ++_requests_pending;
-    }
+    void request() { ++_requests; }
 
-    void request_completed() {
-        ++_requests_completed;
-        --_requests_pending;
-    }
+    void request_completed() { ++_requests_completed; }
 
-    void request_timeout() {
-        ++_request_timeouts;
-        --_requests_pending;
-    }
+    void request_timeout() { ++_request_timeouts; }
 
-    void request_error() {
-        ++_request_errors;
-        --_requests_pending;
-    }
+    void request_error() { ++_request_errors; }
 
     void add_bytes_sent(size_t sent) { _out_bytes += sent; }
 
@@ -150,11 +139,11 @@ public:
 
     std::vector<ss::metrics::metric_definition> defs(
       const std::vector<ss::metrics::label_instance>& labels,
-      const std::vector<ss::metrics::label>& aggregate_labels);
+      const std::vector<ss::metrics::label>& aggregate_labels,
+      std::function<size_t()> pending_count);
 
 private:
     uint64_t _requests = 0;
-    uint32_t _requests_pending = 0;
     uint32_t _request_errors = 0;
     uint64_t _request_timeouts = 0;
     uint64_t _requests_completed = 0;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30264

- Command: git cherry-pick -x 29cd963cf4
- Commits backported: 1
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-30264-v25.3.x-1777059187

## Conflict details

- 29cd963cf4 (src/v/rpc/transport.cc): the upstream commit removed `requests_pending` from `client_probe::format_to`, but v25.3.x still uses an `operator<<(std::ostream&, const client_probe&)` streaming overload rather than `format_to`. Preserved the v25.3.x ostream-based overload and removed the now-stale `", requests_pending: " << p._requests_pending` line to match the removal of the `_requests_pending` member.
