### PR TITLE
`ct`: add `compaction_epoch` validation to `replace_objects()` commands in the `metastore`

### DIFF
--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -341,9 +341,8 @@ db_domain_manager::add_objects(rpc::add_objects_request req) {
     };
 }
 
-ss::future<rpc::replace_objects_no_compact_reply>
-db_domain_manager::replace_objects_no_compact(
-  rpc::replace_objects_no_compact_request req) {
+ss::future<rpc::replace_objects_reply>
+db_domain_manager::replace_objects(rpc::replace_objects_request req) {
     // Collect topics and partitions upfront.
     absl::btree_set<model::topic_id> topics;
     absl::btree_set<model::topic_id_partition> partitions;
@@ -359,7 +358,7 @@ db_domain_manager::replace_objects_no_compact(
       .partition_locks = std::move(partitions),
     });
     if (!locks_res.has_value()) {
-        co_return rpc::replace_objects_no_compact_reply{
+        co_return rpc::replace_objects_reply{
           .ec = locks_res.error(),
         };
     }
@@ -375,7 +374,7 @@ db_domain_manager::replace_objects_no_compact(
         const auto& p = tp.partition;
         nested_epochs[t][p] = epoch;
     }
-    auto update = replace_objects_no_compact_db_update{
+    auto update = replace_objects_db_update{
       .new_objects = std::move(req.new_objects),
       .expected_epochs = std::move(nested_epochs),
     };
@@ -390,7 +389,7 @@ db_domain_manager::replace_objects_no_compact(
         auto discovered_res = co_await update.discover_replaced_object_ids(
           discovery_reader);
         if (!discovered_res.has_value()) {
-            co_return rpc::replace_objects_no_compact_reply{
+            co_return rpc::replace_objects_reply{
               .ec = log_and_convert(
                 discovered_res.error(), "Error discovering replaced objects: "),
             };
@@ -399,7 +398,7 @@ db_domain_manager::replace_objects_no_compact(
         auto obj_locks_res = co_await locks_res.value().acquire_objects(
           std::move(all_oids));
         if (!obj_locks_res.has_value()) {
-            co_return rpc::replace_objects_no_compact_reply{
+            co_return rpc::replace_objects_reply{
               .ec = obj_locks_res.error(),
             };
         }
@@ -410,18 +409,18 @@ db_domain_manager::replace_objects_no_compact(
     chunked_vector<write_batch_row> rows;
     auto build_res = co_await update.build_rows(reader, rows);
     if (!build_res.has_value()) {
-        co_return rpc::replace_objects_no_compact_reply{
+        co_return rpc::replace_objects_reply{
           .ec = log_and_convert(
             build_res.error(), "Rejecting request to replace objects: "),
         };
     }
     auto apply_res = co_await write_rows(locks_res.value(), std::move(rows));
     if (!apply_res.has_value()) {
-        co_return rpc::replace_objects_no_compact_reply{
+        co_return rpc::replace_objects_reply{
           .ec = apply_res.error(),
         };
     }
-    co_return rpc::replace_objects_no_compact_reply{
+    co_return rpc::replace_objects_reply{
       .ec = rpc::errc::ok,
     };
 }

--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -341,6 +341,91 @@ db_domain_manager::add_objects(rpc::add_objects_request req) {
     };
 }
 
+ss::future<rpc::replace_objects_no_compact_reply>
+db_domain_manager::replace_objects_no_compact(
+  rpc::replace_objects_no_compact_request req) {
+    // Collect topics and partitions upfront.
+    absl::btree_set<model::topic_id> topics;
+    absl::btree_set<model::topic_id_partition> partitions;
+    collect_topics_and_partitions(req.new_objects, topics, partitions);
+    for (const auto& [tp, _] : req.expected_epochs) {
+        topics.insert(tp.topic_id);
+        partitions.insert(tp);
+    }
+
+    // Acquire topic and partition locks only — no object locks yet.
+    auto locks_res = co_await gate_and_open_writes({
+      .topic_read_locks = std::move(topics),
+      .partition_locks = std::move(partitions),
+    });
+    if (!locks_res.has_value()) {
+        co_return rpc::replace_objects_no_compact_reply{
+          .ec = locks_res.error(),
+        };
+    }
+
+    chunked_hash_map<
+      model::topic_id,
+      chunked_hash_map<
+        model::partition_id,
+        partition_state::compaction_epoch_t>>
+      nested_epochs;
+    for (auto& [tp, epoch] : req.expected_epochs) {
+        const auto& t = tp.topic_id;
+        const auto& p = tp.partition;
+        nested_epochs[t][p] = epoch;
+    }
+    auto update = replace_objects_no_compact_db_update{
+      .new_objects = std::move(req.new_objects),
+      .expected_epochs = std::move(nested_epochs),
+    };
+
+    // Discover old objects being replaced, merge with new object IDs,
+    // and acquire all object locks in one sorted batch.
+    {
+        absl::btree_set<object_id> all_oids;
+        collect_object_ids(update.new_objects, all_oids);
+
+        auto discovery_reader = state_reader(db_->db().create_snapshot());
+        auto discovered_res = co_await update.discover_replaced_object_ids(
+          discovery_reader);
+        if (!discovered_res.has_value()) {
+            co_return rpc::replace_objects_no_compact_reply{
+              .ec = log_and_convert(
+                discovered_res.error(), "Error discovering replaced objects: "),
+            };
+        }
+        all_oids.merge(discovered_res.value());
+        auto obj_locks_res = co_await locks_res.value().acquire_objects(
+          std::move(all_oids));
+        if (!obj_locks_res.has_value()) {
+            co_return rpc::replace_objects_no_compact_reply{
+              .ec = obj_locks_res.error(),
+            };
+        }
+    }
+
+    // Final snapshot under full lock protection.
+    auto reader = state_reader(db_->db().create_snapshot());
+    chunked_vector<write_batch_row> rows;
+    auto build_res = co_await update.build_rows(reader, rows);
+    if (!build_res.has_value()) {
+        co_return rpc::replace_objects_no_compact_reply{
+          .ec = log_and_convert(
+            build_res.error(), "Rejecting request to replace objects: "),
+        };
+    }
+    auto apply_res = co_await write_rows(locks_res.value(), std::move(rows));
+    if (!apply_res.has_value()) {
+        co_return rpc::replace_objects_no_compact_reply{
+          .ec = apply_res.error(),
+        };
+    }
+    co_return rpc::replace_objects_no_compact_reply{
+      .ec = rpc::errc::ok,
+    };
+}
+
 ss::future<rpc::replace_objects_reply>
 db_domain_manager::replace_objects(rpc::replace_objects_request req) {
     // Collect topics and partitions upfront.

--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -426,8 +426,8 @@ db_domain_manager::replace_objects_no_compact(
     };
 }
 
-ss::future<rpc::replace_objects_reply>
-db_domain_manager::replace_objects(rpc::replace_objects_request req) {
+ss::future<rpc::compact_objects_reply>
+db_domain_manager::compact_objects(rpc::compact_objects_request req) {
     // Collect topics and partitions upfront.
     absl::btree_set<model::topic_id> topics;
     absl::btree_set<model::topic_id_partition> partitions;
@@ -443,7 +443,7 @@ db_domain_manager::replace_objects(rpc::replace_objects_request req) {
       .partition_locks = std::move(partitions),
     });
     if (!locks_res.has_value()) {
-        co_return rpc::replace_objects_reply{
+        co_return rpc::compact_objects_reply{
           .ec = locks_res.error(),
         };
     }
@@ -457,7 +457,7 @@ db_domain_manager::replace_objects(rpc::replace_objects_request req) {
         const auto& p = tp.partition;
         req_compaction_updates[t][p] = std::move(update);
     }
-    auto update = replace_objects_db_update{
+    auto update = compact_objects_db_update{
       .new_objects = std::move(req.new_objects),
       .compaction_updates = std::move(req_compaction_updates),
     };
@@ -472,7 +472,7 @@ db_domain_manager::replace_objects(rpc::replace_objects_request req) {
         auto discovered_res = co_await update.discover_replaced_object_ids(
           discovery_reader);
         if (!discovered_res.has_value()) {
-            co_return rpc::replace_objects_reply{
+            co_return rpc::compact_objects_reply{
               .ec = log_and_convert(
                 discovered_res.error(), "Error discovering replaced objects: "),
             };
@@ -481,7 +481,7 @@ db_domain_manager::replace_objects(rpc::replace_objects_request req) {
         auto obj_locks_res = co_await locks_res.value().acquire_objects(
           std::move(all_oids));
         if (!obj_locks_res.has_value()) {
-            co_return rpc::replace_objects_reply{
+            co_return rpc::compact_objects_reply{
               .ec = obj_locks_res.error(),
             };
         }
@@ -492,18 +492,18 @@ db_domain_manager::replace_objects(rpc::replace_objects_request req) {
     chunked_vector<write_batch_row> rows;
     auto build_res = co_await update.build_rows(reader, rows);
     if (!build_res.has_value()) {
-        co_return rpc::replace_objects_reply{
+        co_return rpc::compact_objects_reply{
           .ec = log_and_convert(
-            build_res.error(), "Rejecting request to replace objects: "),
+            build_res.error(), "Rejecting request to compact objects: "),
         };
     }
     auto apply_res = co_await write_rows(locks_res.value(), std::move(rows));
     if (!apply_res.has_value()) {
-        co_return rpc::replace_objects_reply{
+        co_return rpc::compact_objects_reply{
           .ec = apply_res.error(),
         };
     }
-    co_return rpc::replace_objects_reply{
+    co_return rpc::compact_objects_reply{
       .ec = rpc::errc::ok,
     };
 }

--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.h
@@ -50,9 +50,8 @@ public:
     ss::future<rpc::add_objects_reply>
       add_objects(rpc::add_objects_request) override;
 
-    ss::future<rpc::replace_objects_no_compact_reply>
-      replace_objects_no_compact(
-        rpc::replace_objects_no_compact_request) override;
+    ss::future<rpc::replace_objects_reply>
+      replace_objects(rpc::replace_objects_request) override;
 
     ss::future<rpc::compact_objects_reply>
       compact_objects(rpc::compact_objects_request) override;

--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.h
@@ -50,6 +50,10 @@ public:
     ss::future<rpc::add_objects_reply>
       add_objects(rpc::add_objects_request) override;
 
+    ss::future<rpc::replace_objects_no_compact_reply>
+      replace_objects_no_compact(
+        rpc::replace_objects_no_compact_request) override;
+
     ss::future<rpc::replace_objects_reply>
       replace_objects(rpc::replace_objects_request) override;
 

--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.h
@@ -54,8 +54,8 @@ public:
       replace_objects_no_compact(
         rpc::replace_objects_no_compact_request) override;
 
-    ss::future<rpc::replace_objects_reply>
-      replace_objects(rpc::replace_objects_request) override;
+    ss::future<rpc::compact_objects_reply>
+      compact_objects(rpc::compact_objects_request) override;
 
     ss::future<rpc::get_first_offset_ge_reply>
       get_first_offset_ge(rpc::get_first_offset_ge_request) override;

--- a/src/v/cloud_topics/level_one/domain/domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.h
@@ -59,8 +59,8 @@ public:
     virtual ss::future<rpc::add_objects_reply>
       add_objects(rpc::add_objects_request) = 0;
 
-    virtual ss::future<rpc::replace_objects_no_compact_reply>
-      replace_objects_no_compact(rpc::replace_objects_no_compact_request) = 0;
+    virtual ss::future<rpc::replace_objects_reply>
+      replace_objects(rpc::replace_objects_request) = 0;
 
     virtual ss::future<rpc::compact_objects_reply>
       compact_objects(rpc::compact_objects_request) = 0;

--- a/src/v/cloud_topics/level_one/domain/domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.h
@@ -59,6 +59,9 @@ public:
     virtual ss::future<rpc::add_objects_reply>
       add_objects(rpc::add_objects_request) = 0;
 
+    virtual ss::future<rpc::replace_objects_no_compact_reply>
+      replace_objects_no_compact(rpc::replace_objects_no_compact_request) = 0;
+
     virtual ss::future<rpc::replace_objects_reply>
       replace_objects(rpc::replace_objects_request) = 0;
 

--- a/src/v/cloud_topics/level_one/domain/domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.h
@@ -62,8 +62,8 @@ public:
     virtual ss::future<rpc::replace_objects_no_compact_reply>
       replace_objects_no_compact(rpc::replace_objects_no_compact_request) = 0;
 
-    virtual ss::future<rpc::replace_objects_reply>
-      replace_objects(rpc::replace_objects_request) = 0;
+    virtual ss::future<rpc::compact_objects_reply>
+      compact_objects(rpc::compact_objects_request) = 0;
 
     virtual ss::future<rpc::get_first_offset_ge_reply>
       get_first_offset_ge(rpc::get_first_offset_ge_request) = 0;

--- a/src/v/cloud_topics/level_one/domain/simple_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/simple_domain_manager.cc
@@ -170,18 +170,17 @@ simple_domain_manager::add_objects(rpc::add_objects_request req) {
     };
 }
 
-ss::future<rpc::replace_objects_no_compact_reply>
-simple_domain_manager::replace_objects_no_compact(
-  rpc::replace_objects_no_compact_request req) {
+ss::future<rpc::replace_objects_reply>
+simple_domain_manager::replace_objects(rpc::replace_objects_request req) {
     auto gate = maybe_gate();
     if (!gate.has_value()) {
-        co_return rpc::replace_objects_no_compact_reply{
+        co_return rpc::replace_objects_reply{
           .ec = rpc::errc::not_leader,
         };
     }
     auto sync_res = co_await stm_->sync(10s);
     if (!sync_res.has_value()) {
-        co_return rpc::replace_objects_no_compact_reply{
+        co_return rpc::replace_objects_reply{
           .ec = convert_stm_errc(sync_res.error()),
         };
     }
@@ -190,26 +189,26 @@ simple_domain_manager::replace_objects_no_compact(
         added_oids.emplace(obj.oid);
     }
     auto& stm_state = stm_->state();
-    auto update_res = replace_objects_no_compact_update::build(
+    auto update_res = replace_objects_update::build(
       stm_state, std::move(req.new_objects), std::move(req.expected_epochs));
     if (!update_res.has_value()) {
         vlog(
           cd_log.debug,
           "Rejecting request to replace objects: {}",
           update_res.error());
-        co_return rpc::replace_objects_no_compact_reply{
+        co_return rpc::replace_objects_reply{
           .ec = rpc::errc::concurrent_requests,
         };
     }
     storage::record_batch_builder builder(
       model::record_batch_type::l1_stm, model::offset{0});
     builder.add_raw_kv(
-      serde::to_iobuf(replace_objects_no_compact_update::key),
+      serde::to_iobuf(replace_objects_update::key),
       serde::to_iobuf(std::move(update_res.value())));
     auto repl_res = co_await stm_->replicate_and_wait(
       sync_res.value(), std::move(builder).build(), as_);
     if (!repl_res.has_value()) {
-        co_return rpc::replace_objects_no_compact_reply{
+        co_return rpc::replace_objects_reply{
           .ec = convert_stm_errc(repl_res.error()),
         };
     }
@@ -224,11 +223,11 @@ simple_domain_manager::replace_objects_no_compact(
         }
     }
     if (!any_added) {
-        co_return rpc::replace_objects_no_compact_reply{
+        co_return rpc::replace_objects_reply{
           .ec = rpc::errc::concurrent_requests,
         };
     }
-    co_return rpc::replace_objects_no_compact_reply{
+    co_return rpc::replace_objects_reply{
       .ec = rpc::errc::ok,
     };
 }

--- a/src/v/cloud_topics/level_one/domain/simple_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/simple_domain_manager.cc
@@ -170,6 +170,69 @@ simple_domain_manager::add_objects(rpc::add_objects_request req) {
     };
 }
 
+ss::future<rpc::replace_objects_no_compact_reply>
+simple_domain_manager::replace_objects_no_compact(
+  rpc::replace_objects_no_compact_request req) {
+    auto gate = maybe_gate();
+    if (!gate.has_value()) {
+        co_return rpc::replace_objects_no_compact_reply{
+          .ec = rpc::errc::not_leader,
+        };
+    }
+    auto sync_res = co_await stm_->sync(10s);
+    if (!sync_res.has_value()) {
+        co_return rpc::replace_objects_no_compact_reply{
+          .ec = convert_stm_errc(sync_res.error()),
+        };
+    }
+    chunked_hash_set<object_id> added_oids;
+    for (const auto& obj : req.new_objects) {
+        added_oids.emplace(obj.oid);
+    }
+    auto& stm_state = stm_->state();
+    auto update_res = replace_objects_no_compact_update::build(
+      stm_state, std::move(req.new_objects), std::move(req.expected_epochs));
+    if (!update_res.has_value()) {
+        vlog(
+          cd_log.debug,
+          "Rejecting request to replace objects: {}",
+          update_res.error());
+        co_return rpc::replace_objects_no_compact_reply{
+          .ec = rpc::errc::concurrent_requests,
+        };
+    }
+    storage::record_batch_builder builder(
+      model::record_batch_type::l1_stm, model::offset{0});
+    builder.add_raw_kv(
+      serde::to_iobuf(replace_objects_no_compact_update::key),
+      serde::to_iobuf(std::move(update_res.value())));
+    auto repl_res = co_await stm_->replicate_and_wait(
+      sync_res.value(), std::move(builder).build(), as_);
+    if (!repl_res.has_value()) {
+        co_return rpc::replace_objects_no_compact_reply{
+          .ec = convert_stm_errc(repl_res.error()),
+        };
+    }
+    // Check if any of the objects were successfully added. Presumably the
+    // presence of any objects is signal enough that the update was
+    // successfully applied, given these updates are atomic.
+    bool any_added = false;
+    for (const auto& oid : added_oids) {
+        if (stm_->state().objects.contains(oid)) {
+            any_added = true;
+            break;
+        }
+    }
+    if (!any_added) {
+        co_return rpc::replace_objects_no_compact_reply{
+          .ec = rpc::errc::concurrent_requests,
+        };
+    }
+    co_return rpc::replace_objects_no_compact_reply{
+      .ec = rpc::errc::ok,
+    };
+}
+
 ss::future<rpc::replace_objects_reply>
 simple_domain_manager::replace_objects(rpc::replace_objects_request req) {
     auto gate = maybe_gate();

--- a/src/v/cloud_topics/level_one/domain/simple_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/simple_domain_manager.cc
@@ -233,17 +233,17 @@ simple_domain_manager::replace_objects_no_compact(
     };
 }
 
-ss::future<rpc::replace_objects_reply>
-simple_domain_manager::replace_objects(rpc::replace_objects_request req) {
+ss::future<rpc::compact_objects_reply>
+simple_domain_manager::compact_objects(rpc::compact_objects_request req) {
     auto gate = maybe_gate();
     if (!gate.has_value()) {
-        co_return rpc::replace_objects_reply{
+        co_return rpc::compact_objects_reply{
           .ec = rpc::errc::not_leader,
         };
     }
     auto sync_res = co_await stm_->sync(10s);
     if (!sync_res.has_value()) {
-        co_return rpc::replace_objects_reply{
+        co_return rpc::compact_objects_reply{
           .ec = convert_stm_errc(sync_res.error()),
         };
     }
@@ -252,26 +252,26 @@ simple_domain_manager::replace_objects(rpc::replace_objects_request req) {
         added_oids.emplace(obj.oid);
     }
     auto& stm_state = stm_->state();
-    auto update_res = replace_objects_update::build(
+    auto update_res = compact_objects_update::build(
       stm_state, std::move(req.new_objects), std::move(req.compaction_updates));
     if (!update_res.has_value()) {
         vlog(
           cd_log.debug,
-          "Rejecting request to replace objects: {}",
+          "Rejecting request to compact objects: {}",
           update_res.error());
-        co_return rpc::replace_objects_reply{
+        co_return rpc::compact_objects_reply{
           .ec = rpc::errc::concurrent_requests,
         };
     }
     storage::record_batch_builder builder(
       model::record_batch_type::l1_stm, model::offset{0});
     builder.add_raw_kv(
-      serde::to_iobuf(replace_objects_update::key),
+      serde::to_iobuf(compact_objects_update::key),
       serde::to_iobuf(std::move(update_res.value())));
     auto repl_res = co_await stm_->replicate_and_wait(
       sync_res.value(), std::move(builder).build(), as_);
     if (!repl_res.has_value()) {
-        co_return rpc::replace_objects_reply{
+        co_return rpc::compact_objects_reply{
           .ec = convert_stm_errc(repl_res.error()),
         };
     }
@@ -286,11 +286,11 @@ simple_domain_manager::replace_objects(rpc::replace_objects_request req) {
         }
     }
     if (!any_added) {
-        co_return rpc::replace_objects_reply{
+        co_return rpc::compact_objects_reply{
           .ec = rpc::errc::concurrent_requests,
         };
     }
-    co_return rpc::replace_objects_reply{
+    co_return rpc::compact_objects_reply{
       .ec = rpc::errc::ok,
     };
 }

--- a/src/v/cloud_topics/level_one/domain/simple_domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/simple_domain_manager.h
@@ -33,9 +33,8 @@ public:
     ss::future<rpc::add_objects_reply>
       add_objects(rpc::add_objects_request) override;
 
-    ss::future<rpc::replace_objects_no_compact_reply>
-      replace_objects_no_compact(
-        rpc::replace_objects_no_compact_request) override;
+    ss::future<rpc::replace_objects_reply>
+      replace_objects(rpc::replace_objects_request) override;
 
     ss::future<rpc::compact_objects_reply>
       compact_objects(rpc::compact_objects_request) override;

--- a/src/v/cloud_topics/level_one/domain/simple_domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/simple_domain_manager.h
@@ -33,6 +33,10 @@ public:
     ss::future<rpc::add_objects_reply>
       add_objects(rpc::add_objects_request) override;
 
+    ss::future<rpc::replace_objects_no_compact_reply>
+      replace_objects_no_compact(
+        rpc::replace_objects_no_compact_request) override;
+
     ss::future<rpc::replace_objects_reply>
       replace_objects(rpc::replace_objects_request) override;
 

--- a/src/v/cloud_topics/level_one/domain/simple_domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/simple_domain_manager.h
@@ -37,8 +37,8 @@ public:
       replace_objects_no_compact(
         rpc::replace_objects_no_compact_request) override;
 
-    ss::future<rpc::replace_objects_reply>
-      replace_objects(rpc::replace_objects_request) override;
+    ss::future<rpc::compact_objects_reply>
+      compact_objects(rpc::compact_objects_request) override;
 
     ss::future<rpc::get_first_offset_ge_reply>
       get_first_offset_ge(rpc::get_first_offset_ge_request) override;

--- a/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
+++ b/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
@@ -515,8 +515,7 @@ public:
               random_generators::get_int<int64_t>(
                 min_replaced_offset, max_replaced_offset));
 
-            std::vector<ss::future<l1_rpc::replace_objects_no_compact_reply>>
-              futs;
+            std::vector<ss::future<l1_rpc::replace_objects_reply>> futs;
             std::vector<db_domain_manager*> managers;
             managers.reserve(node.managers.size());
             for (auto& mgr : node.managers) {
@@ -530,15 +529,14 @@ public:
                 if (prereg.ec != l1_rpc::errc::ok) {
                     continue;
                 }
-                l1_rpc::replace_objects_no_compact_request req{
+                l1_rpc::replace_objects_request req{
                   .metastore_partition = model::partition_id(0),
                   .new_objects = make_new_objects_with_ids(
                     tp, offset_to_replace, 1, prereg.object_ids),
                   .expected_epochs
                   = {{tp, partition_state::compaction_epoch_t{0}}},
                 };
-                futs.emplace_back(
-                  mgr->replace_objects_no_compact(std::move(req)));
+                futs.emplace_back(mgr->replace_objects(std::move(req)));
 
                 co_await ss::maybe_yield();
             }
@@ -876,14 +874,13 @@ TEST_F(DbDomainManagerTest, TestBasicReplaceObjects) {
                           })
                           .get();
     ASSERT_EQ(prereg_reply.ec, l1_rpc::errc::ok);
-    l1_rpc::replace_objects_no_compact_request req{
+    l1_rpc::replace_objects_request req{
       .metastore_partition = model::partition_id(0),
       .new_objects = make_new_objects_with_ids(
         tp, kafka::offset(0), 10, prereg_reply.object_ids),
       .expected_epochs = {{tp, partition_state::compaction_epoch_t{0}}},
     };
-    auto reply
-      = initial_manager->replace_objects_no_compact(std::move(req)).get();
+    auto reply = initial_manager->replace_objects(std::move(req)).get();
     ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
 
     // Check that the replacement results in 1 extent.
@@ -1207,15 +1204,14 @@ TEST_F(DbDomainManagerTest, TestGetSizeAfterReplace) {
                                   })
                                   .get();
     ASSERT_EQ(replace_prereg_reply.ec, l1_rpc::errc::ok);
-    l1_rpc::replace_objects_no_compact_request replace_req{
+    l1_rpc::replace_objects_request replace_req{
       .metastore_partition = model::partition_id(0),
       .new_objects = make_new_objects_with_ids(
         tp, kafka::offset(0), 5, replace_prereg_reply.object_ids),
       .expected_epochs = {{tp, partition_state::compaction_epoch_t{0}}},
     };
-    auto replace_reply = initial_manager
-                           ->replace_objects_no_compact(std::move(replace_req))
-                           .get();
+    auto replace_reply
+      = initial_manager->replace_objects(std::move(replace_req)).get();
     ASSERT_EQ(replace_reply.ec, l1_rpc::errc::ok);
 
     // Size should now be 1 * 512 = 512 bytes.

--- a/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
+++ b/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
@@ -515,7 +515,8 @@ public:
               random_generators::get_int<int64_t>(
                 min_replaced_offset, max_replaced_offset));
 
-            std::vector<ss::future<l1_rpc::replace_objects_reply>> futs;
+            std::vector<ss::future<l1_rpc::replace_objects_no_compact_reply>>
+              futs;
             std::vector<db_domain_manager*> managers;
             managers.reserve(node.managers.size());
             for (auto& mgr : node.managers) {
@@ -529,12 +530,15 @@ public:
                 if (prereg.ec != l1_rpc::errc::ok) {
                     continue;
                 }
-                l1_rpc::replace_objects_request req{
+                l1_rpc::replace_objects_no_compact_request req{
                   .metastore_partition = model::partition_id(0),
                   .new_objects = make_new_objects_with_ids(
                     tp, offset_to_replace, 1, prereg.object_ids),
+                  .expected_epochs
+                  = {{tp, partition_state::compaction_epoch_t{0}}},
                 };
-                futs.emplace_back(mgr->replace_objects(std::move(req)));
+                futs.emplace_back(
+                  mgr->replace_objects_no_compact(std::move(req)));
 
                 co_await ss::maybe_yield();
             }
@@ -872,12 +876,14 @@ TEST_F(DbDomainManagerTest, TestBasicReplaceObjects) {
                           })
                           .get();
     ASSERT_EQ(prereg_reply.ec, l1_rpc::errc::ok);
-    l1_rpc::replace_objects_request req{
+    l1_rpc::replace_objects_no_compact_request req{
       .metastore_partition = model::partition_id(0),
       .new_objects = make_new_objects_with_ids(
         tp, kafka::offset(0), 10, prereg_reply.object_ids),
+      .expected_epochs = {{tp, partition_state::compaction_epoch_t{0}}},
     };
-    auto reply = initial_manager->replace_objects(std::move(req)).get();
+    auto reply
+      = initial_manager->replace_objects_no_compact(std::move(req)).get();
     ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
 
     // Check that the replacement results in 1 extent.
@@ -1201,13 +1207,15 @@ TEST_F(DbDomainManagerTest, TestGetSizeAfterReplace) {
                                   })
                                   .get();
     ASSERT_EQ(replace_prereg_reply.ec, l1_rpc::errc::ok);
-    l1_rpc::replace_objects_request replace_req{
+    l1_rpc::replace_objects_no_compact_request replace_req{
       .metastore_partition = model::partition_id(0),
       .new_objects = make_new_objects_with_ids(
         tp, kafka::offset(0), 5, replace_prereg_reply.object_ids),
+      .expected_epochs = {{tp, partition_state::compaction_epoch_t{0}}},
     };
-    auto replace_reply
-      = initial_manager->replace_objects(std::move(replace_req)).get();
+    auto replace_reply = initial_manager
+                           ->replace_objects_no_compact(std::move(replace_req))
+                           .get();
     ASSERT_EQ(replace_reply.ec, l1_rpc::errc::ok);
 
     // Size should now be 1 * 512 = 512 bytes.

--- a/src/v/cloud_topics/level_one/metastore/leader_router.cc
+++ b/src/v/cloud_topics/level_one/metastore/leader_router.cc
@@ -38,16 +38,15 @@ ss::future<rpc::add_objects_reply> do_add_objects(
     co_return co_await domain_mgr->add_objects(std::move(req));
 }
 
-ss::future<rpc::replace_objects_no_compact_reply> do_replace_objects_no_compact(
+ss::future<rpc::replace_objects_reply> do_replace_objects(
   domain_supervisor& domain_supervisor,
   const model::ntp& ntp,
-  rpc::replace_objects_no_compact_request req) {
+  rpc::replace_objects_request req) {
     auto domain_mgr = domain_supervisor.get(ntp);
     if (!domain_mgr) {
-        co_return rpc::replace_objects_no_compact_reply{
-          .ec = rpc::errc::not_leader};
+        co_return rpc::replace_objects_reply{.ec = rpc::errc::not_leader};
     }
-    co_return co_await domain_mgr->replace_objects_no_compact(std::move(req));
+    co_return co_await domain_mgr->replace_objects(std::move(req));
 }
 
 ss::future<rpc::compact_objects_reply> do_compact_objects(
@@ -356,15 +355,13 @@ template ss::future<rpc::compact_objects_reply> leader_router::process<
   &leader_router::compact_objects_locally,
   &leader_router::client::compact_objects>(rpc::compact_objects_request, bool);
 
-template ss::future<rpc::replace_objects_no_compact_reply>
-  leader_router::remote_dispatch<
-    &leader_router::client::replace_objects_no_compact>(
-    rpc::replace_objects_no_compact_request, model::node_id);
-template ss::future<rpc::replace_objects_no_compact_reply>
-leader_router::process<
-  &leader_router::replace_objects_no_compact_locally,
+template ss::future<rpc::replace_objects_reply> leader_router::remote_dispatch<
   &leader_router::client::replace_objects_no_compact>(
-  rpc::replace_objects_no_compact_request, bool);
+  rpc::replace_objects_request, model::node_id);
+template ss::future<rpc::replace_objects_reply> leader_router::process<
+  &leader_router::replace_objects_locally,
+  &leader_router::client::replace_objects_no_compact>(
+  rpc::replace_objects_request, bool);
 
 template ss::future<rpc::get_first_offset_ge_reply>
   leader_router::remote_dispatch<&leader_router::client::get_first_offset_ge>(
@@ -546,26 +543,24 @@ ss::future<rpc::compact_objects_reply> leader_router::compact_objects(
       &client::compact_objects>(std::move(request), bool(local_only_exec));
 }
 
-ss::future<rpc::replace_objects_no_compact_reply>
-leader_router::replace_objects_no_compact_locally(
-  rpc::replace_objects_no_compact_request request,
+ss::future<rpc::replace_objects_reply> leader_router::replace_objects_locally(
+  rpc::replace_objects_request request,
   const model::ntp& metastore_ntp,
   ss::shard_id shard) {
-    auto m = _probe.auto_measure_replace_objects_no_compact();
+    auto m = _probe.auto_measure_replace_objects();
     co_return co_await container().invoke_on(
       shard,
       [&metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
-          return do_replace_objects_no_compact(
+          return do_replace_objects(
             *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
 }
 
-ss::future<rpc::replace_objects_no_compact_reply>
-leader_router::replace_objects_no_compact(
-  rpc::replace_objects_no_compact_request request, local_only local_only_exec) {
+ss::future<rpc::replace_objects_reply> leader_router::replace_objects(
+  rpc::replace_objects_request request, local_only local_only_exec) {
     auto holder = _gate.hold();
     co_return co_await process<
-      &leader_router::replace_objects_no_compact_locally,
+      &leader_router::replace_objects_locally,
       &client::replace_objects_no_compact>(
       std::move(request), bool(local_only_exec));
 }

--- a/src/v/cloud_topics/level_one/metastore/leader_router.cc
+++ b/src/v/cloud_topics/level_one/metastore/leader_router.cc
@@ -38,6 +38,18 @@ ss::future<rpc::add_objects_reply> do_add_objects(
     co_return co_await domain_mgr->add_objects(std::move(req));
 }
 
+ss::future<rpc::replace_objects_no_compact_reply> do_replace_objects_no_compact(
+  domain_supervisor& domain_supervisor,
+  const model::ntp& ntp,
+  rpc::replace_objects_no_compact_request req) {
+    auto domain_mgr = domain_supervisor.get(ntp);
+    if (!domain_mgr) {
+        co_return rpc::replace_objects_no_compact_reply{
+          .ec = rpc::errc::not_leader};
+    }
+    co_return co_await domain_mgr->replace_objects_no_compact(std::move(req));
+}
+
 ss::future<rpc::replace_objects_reply> do_replace_objects(
   domain_supervisor& domain_supervisor,
   const model::ntp& ntp,
@@ -344,6 +356,16 @@ template ss::future<rpc::replace_objects_reply> leader_router::process<
   &leader_router::replace_objects_locally,
   &leader_router::client::replace_objects>(rpc::replace_objects_request, bool);
 
+template ss::future<rpc::replace_objects_no_compact_reply>
+  leader_router::remote_dispatch<
+    &leader_router::client::replace_objects_no_compact>(
+    rpc::replace_objects_no_compact_request, model::node_id);
+template ss::future<rpc::replace_objects_no_compact_reply>
+leader_router::process<
+  &leader_router::replace_objects_no_compact_locally,
+  &leader_router::client::replace_objects_no_compact>(
+  rpc::replace_objects_no_compact_request, bool);
+
 template ss::future<rpc::get_first_offset_ge_reply>
   leader_router::remote_dispatch<&leader_router::client::get_first_offset_ge>(
     rpc::get_first_offset_ge_request, model::node_id);
@@ -522,6 +544,30 @@ ss::future<rpc::replace_objects_reply> leader_router::replace_objects(
     co_return co_await process<
       &leader_router::replace_objects_locally,
       &client::replace_objects>(std::move(request), bool(local_only_exec));
+}
+
+ss::future<rpc::replace_objects_no_compact_reply>
+leader_router::replace_objects_no_compact_locally(
+  rpc::replace_objects_no_compact_request request,
+  const model::ntp& metastore_ntp,
+  ss::shard_id shard) {
+    auto m = _probe.auto_measure_replace_objects_no_compact();
+    co_return co_await container().invoke_on(
+      shard,
+      [&metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
+          return do_replace_objects_no_compact(
+            *(fe._domain_supervisor), metastore_ntp, std::move(req));
+      });
+}
+
+ss::future<rpc::replace_objects_no_compact_reply>
+leader_router::replace_objects_no_compact(
+  rpc::replace_objects_no_compact_request request, local_only local_only_exec) {
+    auto holder = _gate.hold();
+    co_return co_await process<
+      &leader_router::replace_objects_no_compact_locally,
+      &client::replace_objects_no_compact>(
+      std::move(request), bool(local_only_exec));
 }
 
 ss::future<rpc::get_first_offset_ge_reply>

--- a/src/v/cloud_topics/level_one/metastore/leader_router.cc
+++ b/src/v/cloud_topics/level_one/metastore/leader_router.cc
@@ -50,15 +50,15 @@ ss::future<rpc::replace_objects_no_compact_reply> do_replace_objects_no_compact(
     co_return co_await domain_mgr->replace_objects_no_compact(std::move(req));
 }
 
-ss::future<rpc::replace_objects_reply> do_replace_objects(
+ss::future<rpc::compact_objects_reply> do_compact_objects(
   domain_supervisor& domain_supervisor,
   const model::ntp& ntp,
-  rpc::replace_objects_request req) {
+  rpc::compact_objects_request req) {
     auto domain_mgr = domain_supervisor.get(ntp);
     if (!domain_mgr) {
-        co_return rpc::replace_objects_reply{.ec = rpc::errc::not_leader};
+        co_return rpc::compact_objects_reply{.ec = rpc::errc::not_leader};
     }
-    co_return co_await domain_mgr->replace_objects(std::move(req));
+    co_return co_await domain_mgr->compact_objects(std::move(req));
 }
 
 ss::future<rpc::get_first_offset_ge_reply> do_get_first_offset_ge(
@@ -349,12 +349,12 @@ template ss::future<rpc::add_objects_reply> leader_router::process<
   &leader_router::add_objects_locally,
   &leader_router::client::add_objects>(rpc::add_objects_request, bool);
 
-template ss::future<rpc::replace_objects_reply>
-  leader_router::remote_dispatch<&leader_router::client::replace_objects>(
-    rpc::replace_objects_request, model::node_id);
-template ss::future<rpc::replace_objects_reply> leader_router::process<
-  &leader_router::replace_objects_locally,
-  &leader_router::client::replace_objects>(rpc::replace_objects_request, bool);
+template ss::future<rpc::compact_objects_reply>
+  leader_router::remote_dispatch<&leader_router::client::compact_objects>(
+    rpc::compact_objects_request, model::node_id);
+template ss::future<rpc::compact_objects_reply> leader_router::process<
+  &leader_router::compact_objects_locally,
+  &leader_router::client::compact_objects>(rpc::compact_objects_request, bool);
 
 template ss::future<rpc::replace_objects_no_compact_reply>
   leader_router::remote_dispatch<
@@ -525,25 +525,25 @@ ss::future<rpc::add_objects_reply> leader_router::add_objects(
       &client::add_objects>(std::move(request), bool(local_only_exec));
 }
 
-ss::future<rpc::replace_objects_reply> leader_router::replace_objects_locally(
-  rpc::replace_objects_request request,
+ss::future<rpc::compact_objects_reply> leader_router::compact_objects_locally(
+  rpc::compact_objects_request request,
   const model::ntp& metastore_ntp,
   ss::shard_id shard) {
-    auto m = _probe.auto_measure_replace_objects();
+    auto m = _probe.auto_measure_compact_objects();
     co_return co_await container().invoke_on(
       shard,
       [&metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
-          return do_replace_objects(
+          return do_compact_objects(
             *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
 }
 
-ss::future<rpc::replace_objects_reply> leader_router::replace_objects(
-  rpc::replace_objects_request request, local_only local_only_exec) {
+ss::future<rpc::compact_objects_reply> leader_router::compact_objects(
+  rpc::compact_objects_request request, local_only local_only_exec) {
     auto holder = _gate.hold();
     co_return co_await process<
-      &leader_router::replace_objects_locally,
-      &client::replace_objects>(std::move(request), bool(local_only_exec));
+      &leader_router::compact_objects_locally,
+      &client::compact_objects>(std::move(request), bool(local_only_exec));
 }
 
 ss::future<rpc::replace_objects_no_compact_reply>

--- a/src/v/cloud_topics/level_one/metastore/leader_router.h
+++ b/src/v/cloud_topics/level_one/metastore/leader_router.h
@@ -60,9 +60,8 @@ public:
     ss::future<rpc::add_objects_reply>
       add_objects(rpc::add_objects_request, local_only = local_only::no);
 
-    ss::future<rpc::replace_objects_no_compact_reply>
-      replace_objects_no_compact(
-        rpc::replace_objects_no_compact_request, local_only = local_only::no);
+    ss::future<rpc::replace_objects_reply> replace_objects(
+      rpc::replace_objects_request, local_only = local_only::no);
 
     ss::future<rpc::compact_objects_reply> compact_objects(
       rpc::compact_objects_request, local_only = local_only::no);
@@ -155,9 +154,8 @@ private:
     ss::future<rpc::add_objects_reply> add_objects_locally(
       rpc::add_objects_request, const model::ntp& metastore_ntp, ss::shard_id);
 
-    ss::future<rpc::replace_objects_no_compact_reply>
-    replace_objects_no_compact_locally(
-      rpc::replace_objects_no_compact_request,
+    ss::future<rpc::replace_objects_reply> replace_objects_locally(
+      rpc::replace_objects_request,
       const model::ntp& metastore_ntp,
       ss::shard_id);
 

--- a/src/v/cloud_topics/level_one/metastore/leader_router.h
+++ b/src/v/cloud_topics/level_one/metastore/leader_router.h
@@ -60,6 +60,10 @@ public:
     ss::future<rpc::add_objects_reply>
       add_objects(rpc::add_objects_request, local_only = local_only::no);
 
+    ss::future<rpc::replace_objects_no_compact_reply>
+      replace_objects_no_compact(
+        rpc::replace_objects_no_compact_request, local_only = local_only::no);
+
     ss::future<rpc::replace_objects_reply> replace_objects(
       rpc::replace_objects_request, local_only = local_only::no);
 
@@ -150,6 +154,12 @@ private:
 
     ss::future<rpc::add_objects_reply> add_objects_locally(
       rpc::add_objects_request, const model::ntp& metastore_ntp, ss::shard_id);
+
+    ss::future<rpc::replace_objects_no_compact_reply>
+    replace_objects_no_compact_locally(
+      rpc::replace_objects_no_compact_request,
+      const model::ntp& metastore_ntp,
+      ss::shard_id);
 
     ss::future<rpc::replace_objects_reply> replace_objects_locally(
       rpc::replace_objects_request,

--- a/src/v/cloud_topics/level_one/metastore/leader_router.h
+++ b/src/v/cloud_topics/level_one/metastore/leader_router.h
@@ -64,8 +64,8 @@ public:
       replace_objects_no_compact(
         rpc::replace_objects_no_compact_request, local_only = local_only::no);
 
-    ss::future<rpc::replace_objects_reply> replace_objects(
-      rpc::replace_objects_request, local_only = local_only::no);
+    ss::future<rpc::compact_objects_reply> compact_objects(
+      rpc::compact_objects_request, local_only = local_only::no);
 
     ss::future<rpc::get_first_offset_ge_reply> get_first_offset_ge(
       rpc::get_first_offset_ge_request, local_only = local_only::no);
@@ -161,8 +161,8 @@ private:
       const model::ntp& metastore_ntp,
       ss::shard_id);
 
-    ss::future<rpc::replace_objects_reply> replace_objects_locally(
-      rpc::replace_objects_request,
+    ss::future<rpc::compact_objects_reply> compact_objects_locally(
+      rpc::compact_objects_request,
       const model::ntp& metastore_ntp,
       ss::shard_id);
 

--- a/src/v/cloud_topics/level_one/metastore/leader_router_probe.cc
+++ b/src/v/cloud_topics/level_one/metastore/leader_router_probe.cc
@@ -34,12 +34,9 @@ void leader_router_probe::setup_metrics() {
           [this] { return _compact_objects.internal_histogram_logform(); },
           sm::description("Latency of local compact_objects requests")),
         sm::make_histogram(
-          "replace_objects_no_compact_duration_microseconds",
-          [this] {
-              return _replace_objects_no_compact.internal_histogram_logform();
-          },
-          sm::description(
-            "Latency of local replace_objects_no_compact requests")),
+          "replace_objects_duration_microseconds",
+          [this] { return _replace_objects.internal_histogram_logform(); },
+          sm::description("Latency of local replace_objects requests")),
         sm::make_histogram(
           "get_first_offset_ge_duration_microseconds",
           [this] { return _get_first_offset_ge.internal_histogram_logform(); },

--- a/src/v/cloud_topics/level_one/metastore/leader_router_probe.cc
+++ b/src/v/cloud_topics/level_one/metastore/leader_router_probe.cc
@@ -34,6 +34,13 @@ void leader_router_probe::setup_metrics() {
           [this] { return _replace_objects.internal_histogram_logform(); },
           sm::description("Latency of local replace_objects requests")),
         sm::make_histogram(
+          "replace_objects_no_compact_duration_microseconds",
+          [this] {
+              return _replace_objects_no_compact.internal_histogram_logform();
+          },
+          sm::description(
+            "Latency of local replace_objects_no_compact requests")),
+        sm::make_histogram(
           "get_first_offset_ge_duration_microseconds",
           [this] { return _get_first_offset_ge.internal_histogram_logform(); },
           sm::description("Latency of local get_first_offset_ge requests")),

--- a/src/v/cloud_topics/level_one/metastore/leader_router_probe.cc
+++ b/src/v/cloud_topics/level_one/metastore/leader_router_probe.cc
@@ -30,9 +30,9 @@ void leader_router_probe::setup_metrics() {
           [this] { return _add_objects.internal_histogram_logform(); },
           sm::description("Latency of local add_objects requests")),
         sm::make_histogram(
-          "replace_objects_duration_microseconds",
-          [this] { return _replace_objects.internal_histogram_logform(); },
-          sm::description("Latency of local replace_objects requests")),
+          "compact_objects_duration_microseconds",
+          [this] { return _compact_objects.internal_histogram_logform(); },
+          sm::description("Latency of local compact_objects requests")),
         sm::make_histogram(
           "replace_objects_no_compact_duration_microseconds",
           [this] {

--- a/src/v/cloud_topics/level_one/metastore/leader_router_probe.h
+++ b/src/v/cloud_topics/level_one/metastore/leader_router_probe.h
@@ -40,9 +40,8 @@ public:
         return _compact_objects.auto_measure();
     }
 
-    std::unique_ptr<hist_t::measurement>
-    auto_measure_replace_objects_no_compact() {
-        return _replace_objects_no_compact.auto_measure();
+    std::unique_ptr<hist_t::measurement> auto_measure_replace_objects() {
+        return _replace_objects.auto_measure();
     }
 
     std::unique_ptr<hist_t::measurement> auto_measure_get_first_offset_ge() {
@@ -110,7 +109,7 @@ public:
 private:
     hist_t _add_objects;
     hist_t _compact_objects;
-    hist_t _replace_objects_no_compact;
+    hist_t _replace_objects;
     hist_t _get_first_offset_ge;
     hist_t _get_first_timestamp_ge;
     hist_t _get_first_offset_for_bytes;

--- a/src/v/cloud_topics/level_one/metastore/leader_router_probe.h
+++ b/src/v/cloud_topics/level_one/metastore/leader_router_probe.h
@@ -40,6 +40,11 @@ public:
         return _replace_objects.auto_measure();
     }
 
+    std::unique_ptr<hist_t::measurement>
+    auto_measure_replace_objects_no_compact() {
+        return _replace_objects_no_compact.auto_measure();
+    }
+
     std::unique_ptr<hist_t::measurement> auto_measure_get_first_offset_ge() {
         return _get_first_offset_ge.auto_measure();
     }
@@ -105,6 +110,7 @@ public:
 private:
     hist_t _add_objects;
     hist_t _replace_objects;
+    hist_t _replace_objects_no_compact;
     hist_t _get_first_offset_ge;
     hist_t _get_first_timestamp_ge;
     hist_t _get_first_offset_for_bytes;

--- a/src/v/cloud_topics/level_one/metastore/leader_router_probe.h
+++ b/src/v/cloud_topics/level_one/metastore/leader_router_probe.h
@@ -36,8 +36,8 @@ public:
         return _add_objects.auto_measure();
     }
 
-    std::unique_ptr<hist_t::measurement> auto_measure_replace_objects() {
-        return _replace_objects.auto_measure();
+    std::unique_ptr<hist_t::measurement> auto_measure_compact_objects() {
+        return _compact_objects.auto_measure();
     }
 
     std::unique_ptr<hist_t::measurement>
@@ -109,7 +109,7 @@ public:
 
 private:
     hist_t _add_objects;
-    hist_t _replace_objects;
+    hist_t _compact_objects;
     hist_t _replace_objects_no_compact;
     hist_t _get_first_offset_ge;
     hist_t _get_first_timestamp_ge;

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
@@ -1057,6 +1057,22 @@ replace_objects_db_update::validate_inputs() const {
         }
     }
 
+    // Every partition with new extents must have a compaction_update entry
+    // so its expected_compaction_epoch can be validated. Without this,
+    // callers could silently bump epochs without OCC.
+    for (const auto& [tidp, _] : new_extents_by_tp) {
+        auto t_it = compaction_updates.find(tidp.topic_id);
+        if (
+          t_it == compaction_updates.end()
+          || !t_it->second.contains(tidp.partition)) {
+            return std::unexpected(db_update_error(
+              invalid_input,
+              fmt::format(
+                "Partition {} has new extents but no compaction_update entry",
+                tidp)));
+        }
+    }
+
     return std::expected<void, db_update_error>{};
 }
 

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
@@ -1077,7 +1077,7 @@ compact_objects_db_update::validate_inputs() const {
 }
 
 std::expected<void, db_update_error>
-replace_objects_no_compact_db_update::validate_inputs() const {
+replace_objects_db_update::validate_inputs() const {
     auto layout_res = validate_new_objects_extent_layout(new_objects);
     if (!layout_res.has_value()) {
         return std::unexpected(layout_res.error());
@@ -1115,7 +1115,7 @@ replace_objects_no_compact_db_update::validate_inputs() const {
 }
 
 ss::future<std::expected<absl::btree_set<object_id>, db_update_error>>
-replace_objects_no_compact_db_update::discover_replaced_object_ids(
+replace_objects_db_update::discover_replaced_object_ids(
   state_reader& state) const {
     auto validate_res = validate_inputs();
     if (!validate_res.has_value()) {
@@ -1126,7 +1126,7 @@ replace_objects_no_compact_db_update::discover_replaced_object_ids(
 }
 
 ss::future<std::expected<void, db_update_error>>
-replace_objects_no_compact_db_update::build_rows(
+replace_objects_db_update::build_rows(
   state_reader& state, chunked_vector<write_batch_row>& out) const {
     auto validate_res = validate_inputs();
     if (!validate_res.has_value()) {

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
@@ -1060,6 +1060,102 @@ replace_objects_db_update::validate_inputs() const {
     return std::expected<void, db_update_error>{};
 }
 
+std::expected<void, db_update_error>
+replace_objects_no_compact_db_update::validate_inputs() const {
+    auto layout_res = validate_new_objects_extent_layout(new_objects);
+    if (!layout_res.has_value()) {
+        return std::unexpected(layout_res.error());
+    }
+    const auto& new_extents_by_tp = layout_res.value();
+
+    // Bidirectional invariant between expected_epochs and new_extents.
+    for (const auto& [t, p_epochs] : expected_epochs) {
+        for (const auto& [p, _] : p_epochs) {
+            model::topic_id_partition tidp{t, p};
+            if (!new_extents_by_tp.contains(tidp)) {
+                return std::unexpected(db_update_error(
+                  invalid_input,
+                  fmt::format(
+                    "expected_epochs entry for {} does not refer to a "
+                    "partition with new extents",
+                    tidp)));
+            }
+        }
+    }
+    for (const auto& [tidp, _] : new_extents_by_tp) {
+        auto t_it = expected_epochs.find(tidp.topic_id);
+        if (
+          t_it == expected_epochs.end()
+          || !t_it->second.contains(tidp.partition)) {
+            return std::unexpected(db_update_error(
+              invalid_input,
+              fmt::format(
+                "Partition {} has new extents but no expected_epochs entry",
+                tidp)));
+        }
+    }
+
+    return std::expected<void, db_update_error>{};
+}
+
+ss::future<std::expected<absl::btree_set<object_id>, db_update_error>>
+replace_objects_no_compact_db_update::discover_replaced_object_ids(
+  state_reader& state) const {
+    auto validate_res = validate_inputs();
+    if (!validate_res.has_value()) {
+        co_return std::unexpected(std::move(validate_res.error()));
+    }
+    co_return co_await discover_replaced_object_ids_for_extents(
+      state, new_objects);
+}
+
+ss::future<std::expected<void, db_update_error>>
+replace_objects_no_compact_db_update::build_rows(
+  state_reader& state, chunked_vector<write_batch_row>& out) const {
+    auto validate_res = validate_inputs();
+    if (!validate_res.has_value()) {
+        co_return std::unexpected(std::move(validate_res.error()));
+    }
+
+    /*
+     * The `updated_metadata` map tracks metadata that needs to be updated. Use
+     * the `get_metadata_for_update` helper to index into `updated_metadata`
+     * which will fetch the current metadata state if necessary.
+     */
+    chunked_hash_map<model::topic_id_partition, metadata_row_value>
+      updated_metadata;
+
+    // Per-partition expected compaction epoch validation.
+    for (const auto& [t, p_epochs] : expected_epochs) {
+        for (const auto& [p, expected_epoch] : p_epochs) {
+            model::topic_id_partition tidp{t, p};
+            auto meta = co_await get_metadata_for_update(
+              state, updated_metadata, tidp, "epoch validation");
+            if (!meta.has_value()) {
+                co_return std::unexpected(std::move(meta.error()));
+            }
+            if (meta.value()->compaction_epoch != expected_epoch) {
+                co_return std::unexpected(db_update_error(
+                  invalid_update,
+                  fmt::format(
+                    "Compaction epoch mismatch for {}: expected {}, got {}",
+                    tidp,
+                    expected_epoch,
+                    meta.value()->compaction_epoch)));
+            }
+        }
+    }
+
+    auto replacements_res = co_await validate_replacement(
+      state, new_objects, updated_metadata);
+    if (!replacements_res.has_value()) {
+        co_return std::unexpected(std::move(replacements_res.error()));
+    }
+
+    co_return co_await build_replacement_rows(
+      state, std::move(replacements_res).value(), updated_metadata, out);
+}
+
 ss::future<std::expected<void, db_update_error>>
 set_start_offset_db_update::build_rows(
   state_reader& reader,

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
@@ -907,7 +907,7 @@ add_objects_db_update::validate_inputs() const {
 }
 
 ss::future<std::expected<void, db_update_error>>
-replace_objects_db_update::build_rows(
+compact_objects_db_update::build_rows(
   state_reader& state, chunked_vector<write_batch_row>& out) const {
     auto validate_res = validate_inputs();
     if (!validate_res.has_value()) {
@@ -989,7 +989,7 @@ replace_objects_db_update::build_rows(
 }
 
 ss::future<std::expected<absl::btree_set<object_id>, db_update_error>>
-replace_objects_db_update::discover_replaced_object_ids(
+compact_objects_db_update::discover_replaced_object_ids(
   state_reader& state) const {
     auto validate_res = validate_inputs();
     if (!validate_res.has_value()) {
@@ -1000,7 +1000,7 @@ replace_objects_db_update::discover_replaced_object_ids(
 }
 
 std::expected<void, db_update_error>
-replace_objects_db_update::validate_inputs() const {
+compact_objects_db_update::validate_inputs() const {
     auto layout_res = validate_new_objects_extent_layout(new_objects);
     if (!layout_res.has_value()) {
         return std::unexpected(layout_res.error());

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
@@ -343,6 +343,296 @@ build_object_removal_entries(
     co_return updated_old_objects;
 }
 
+// Validates that extents provided in new objects are non-empty, are
+// non-inverted, and form contiguous intervals per partition. Returns a map of
+// partitions to sorted extents on success and an error otherwise.
+std::expected<sorted_extents_by_tidp_t, db_update_error>
+validate_new_objects_extent_layout(
+  const chunked_vector<new_object>& new_objects) {
+    if (new_objects.empty()) {
+        return std::unexpected(
+          db_update_error(invalid_input, "No objects requested"));
+    }
+
+    sorted_extents_by_tidp_t new_extents_by_tp;
+    for (const auto& o : new_objects) {
+        o.collect_extents_by_tidp(&new_extents_by_tp);
+    }
+    for (const auto& [tidp, extents] : new_extents_by_tp) {
+        for (const auto& extent : extents) {
+            if (extent.base_offset > extent.last_offset) {
+                return std::unexpected(db_update_error(
+                  invalid_input,
+                  fmt::format(
+                    "Input object has inverted extent for partition {}: "
+                    "base_offset {} > last_offset {}",
+                    tidp,
+                    extent.base_offset,
+                    extent.last_offset)));
+            }
+        }
+    }
+
+    auto contiguous_intervals = contiguous_intervals_for_extents(
+      new_extents_by_tp);
+    if (!contiguous_intervals.has_value()) {
+        return std::unexpected(
+          db_update_error(invalid_input, contiguous_intervals.error()));
+    }
+
+    return new_extents_by_tp;
+}
+
+// Walks the partition-level extent ranges that intersect the requested
+// new_objects' offsets and collects the object_ids of the existing extents
+// being replaced. Used by compact_objects_db_update and
+// replace_objects_db_update to acquire object locks before staging rows.
+ss::future<std::expected<absl::btree_set<object_id>, db_update_error>>
+discover_replaced_object_ids_for_extents(
+  state_reader& state, const chunked_vector<new_object>& new_objects) {
+    sorted_extents_by_tidp_t new_extents_by_tp;
+    for (const auto& o : new_objects) {
+        o.collect_extents_by_tidp(&new_extents_by_tp);
+    }
+
+    auto contiguous_intervals_res = contiguous_intervals_for_extents(
+      new_extents_by_tp);
+    if (!contiguous_intervals_res.has_value()) {
+        co_return std::unexpected(db_update_error(
+          invalid_input, std::move(contiguous_intervals_res.error())));
+    }
+
+    // For each partition's replacement intervals, scan existing extents
+    // in that range and collect their object IDs. We use get_inclusive_extents
+    // rather than get_extent_range — discovery only needs OIDs, not exact
+    // alignment validation (build_rows handles that).
+    absl::btree_set<object_id> discovered_oids;
+    for (const auto& [tidp, intervals] : contiguous_intervals_res.value()) {
+        for (const auto& interval : intervals) {
+            auto extents_res = co_await state.get_inclusive_extents(
+              tidp, interval.base_offset, interval.last_offset);
+            if (!extents_res.has_value()) {
+                co_return std::unexpected(wrap_read_err(
+                  std::move(extents_res.error()),
+                  "Error getting {} extents for discovery in [{}, {}]",
+                  tidp,
+                  interval.base_offset,
+                  interval.last_offset));
+            }
+            if (!extents_res->has_value()) {
+                continue;
+            }
+            auto gen = (*extents_res)->get_rows();
+            while (auto row_res = co_await gen()) {
+                const auto& row = row_res->get();
+                if (!row.has_value()) {
+                    co_return std::unexpected(wrap_read_err(
+                      row.error(),
+                      "Error iterating {} extents during discovery",
+                      tidp));
+                }
+                discovered_oids.insert(row->val.oid);
+            }
+        }
+    }
+    co_return discovered_oids;
+}
+
+// State produced by validate_replacement and consumed by
+// build_replacement_rows. Holds everything an "extent replacement"
+// build_rows needs between phases. Compact-path callers also read
+// new_extents_by_tp during their compaction-state work.
+struct validated_object_replacements {
+    sorted_extents_by_tidp_t new_extents_by_tp;
+    chunked_hash_map<object_id, object_entry> new_objects_map;
+    chunked_hash_map<model::topic_id_partition, kafka::offset>
+      start_offsets_by_tp;
+    chunked_hash_map<object_id, size_t> old_extent_sizes_by_oid;
+    chunked_hash_map<model::topic_id_partition, chunked_vector<ss::sstring>>
+      extent_keys_to_delete;
+    chunked_hash_map<object_id, object_entry> updated_old_objects;
+};
+
+// Checks that the input objects are valid replacements for objects that
+// currently exist in a partition's state.
+ss::future<std::expected<validated_object_replacements, db_update_error>>
+validate_replacement(
+  state_reader& state,
+  const chunked_vector<new_object>& new_objects,
+  chunked_hash_map<model::topic_id_partition, metadata_row_value>&
+    updated_metadata) {
+    validated_object_replacements replacements;
+    auto new_extents_res = co_await validate_preregistered_and_collect(
+      new_objects,
+      state,
+      replacements.new_extents_by_tp,
+      replacements.new_objects_map);
+    if (!new_extents_res.has_value()) {
+        co_return std::unexpected(std::move(new_extents_res.error()));
+    }
+
+    // Calculate contiguous intervals and validate that they align with
+    // appropriate extents.
+    auto contiguous_intervals_res = contiguous_intervals_for_extents(
+      replacements.new_extents_by_tp);
+    if (!contiguous_intervals_res.has_value()) {
+        co_return std::unexpected(db_update_error(
+          invalid_input, std::move(contiguous_intervals_res.error())));
+    }
+    const auto& contiguous_intervals_by_tp = contiguous_intervals_res.value();
+
+    for (const auto& [tidp, intervals] : contiguous_intervals_by_tp) {
+        auto meta_res = co_await get_metadata_for_update(
+          state, updated_metadata, tidp, "contiguous interval processing");
+        if (!meta_res.has_value()) {
+            co_return std::unexpected(std::move(meta_res.error()));
+        }
+        replacements.start_offsets_by_tp[tidp] = meta_res.value()->start_offset;
+        // Track removed sizes for this partition specifically.
+        chunked_hash_map<object_id, size_t> tidp_removed_sizes;
+        auto exact_intervals_res = co_await collect_exact_intervals(
+          tidp,
+          intervals,
+          meta_res.value()->start_offset,
+          state,
+          replacements.extent_keys_to_delete[tidp],
+          tidp_removed_sizes);
+        if (!exact_intervals_res.has_value()) {
+            co_return std::unexpected(std::move(exact_intervals_res.error()));
+        }
+        // Accumulate total removed size for this partition, and then fold the
+        // updates for this partition back into old_extent_sizes_by_oid which
+        // tracks per object instead of per partition. The total is then
+        // subtracted off of the metadata which will later be updated in the db.
+        ssize_t removed_for_tidp = 0;
+        for (const auto& [oid, sz] : tidp_removed_sizes) {
+            removed_for_tidp += sz;
+            replacements.old_extent_sizes_by_oid[oid] += sz;
+        }
+        auto prev_size = static_cast<ssize_t>(meta_res.value()->size);
+        meta_res.value()->size = std::max(
+          ssize_t(0), prev_size - removed_for_tidp);
+        meta_res.value()->num_extents -= std::min(
+          meta_res.value()->num_extents,
+          replacements.extent_keys_to_delete[tidp].size());
+    }
+
+    // Update existing object entries to indicate the removal of data from
+    // replaced extents.
+    auto updated_old_objects_res = co_await build_object_removal_entries(
+      state, replacements.old_extent_sizes_by_oid);
+    if (!updated_old_objects_res.has_value()) {
+        co_return std::unexpected(updated_old_objects_res.error());
+    }
+    replacements.updated_old_objects = std::move(
+      updated_old_objects_res.value());
+
+    co_return replacements;
+}
+
+// Phase 2 of extent replacement, shared by both build_rows. Builds extent
+// rows for the new extents, and builds all the row writes that are shared
+// between object compaction and replacement: extent deletions, updated and new
+// object entries, and metadata.
+//
+// Caller must build any path-specific rows (e.g. compact_objects_db_update
+// builds compaction_row writes for partitions with cleaned-range or
+// tombstone work) before calling this, since this writes metadata rows
+// last.
+ss::future<std::expected<void, db_update_error>> build_replacement_rows(
+  state_reader& state,
+  validated_object_replacements replacements,
+  chunked_hash_map<model::topic_id_partition, metadata_row_value>&
+    updated_metadata,
+  chunked_vector<write_batch_row>& out) {
+    chunked_hash_set<ss::sstring> added_extent_keys;
+    for (const auto& [tidp, extents] : replacements.new_extents_by_tp) {
+        auto start_it = replacements.start_offsets_by_tp.find(tidp);
+        auto start_offset = start_it != replacements.start_offsets_by_tp.end()
+                              ? start_it->second
+                              : kafka::offset{0};
+        size_t added_for_tidp = 0;
+        size_t added_extents_for_tidp = 0;
+        for (const auto& extent : extents) {
+            // Skip extents fully below start_offset. These are stale
+            // replacements for extents that have been truncated.
+            if (extent.last_offset < start_offset) {
+                replacements.new_objects_map[extent.oid].removed_data_size
+                  += extent.len;
+                continue;
+            }
+            auto key = extent_row_key::encode(tidp, extent.base_offset);
+            added_extent_keys.emplace(key);
+            added_for_tidp += extent.len;
+            ++added_extents_for_tidp;
+            out.emplace_back(
+              write_batch_row{
+                .key = extent_row_key::encode(tidp, extent.base_offset),
+                .value = serde::to_iobuf(
+                  extent_row_value{
+                    .last_offset = extent.last_offset,
+                    .max_timestamp = extent.max_timestamp,
+                    .filepos = extent.filepos,
+                    .len = extent.len,
+                    .oid = extent.oid,
+                  }),
+              });
+        }
+
+        auto meta_res = co_await get_metadata_for_update(
+          state, updated_metadata, tidp, "new extents");
+        if (!meta_res.has_value()) {
+            co_return std::unexpected(std::move(meta_res.error()));
+        }
+        meta_res.value()->size += added_for_tidp;
+        meta_res.value()->num_extents += added_extents_for_tidp;
+    }
+    if (added_extent_keys.empty()) {
+        // No extents, e.g. because all replacements are below the current
+        // start offsets.
+        co_return std::unexpected(db_update_error(
+          invalid_update, "Replacement extents all filtered out"));
+    }
+
+    for (const auto& [tidp, keys] : replacements.extent_keys_to_delete) {
+        for (const auto& key : keys) {
+            if (added_extent_keys.contains(key)) {
+                // Don't delete keys that are also being added.
+                continue;
+            }
+            out.emplace_back(
+              write_batch_row{
+                .key = key,
+                .value = iobuf{},
+              });
+        }
+    }
+    for (const auto& [oid, entry] : replacements.updated_old_objects) {
+        out.emplace_back(
+          write_batch_row{
+            .key = object_row_key::encode(oid),
+            .value = serde::to_iobuf(object_row_value{.object = entry}),
+          });
+    }
+    for (const auto& [oid, entry] : replacements.new_objects_map) {
+        out.emplace_back(
+          write_batch_row{
+            .key = object_row_key::encode(oid),
+            .value = serde::to_iobuf(object_row_value{.object = entry}),
+          });
+    }
+
+    for (auto& [tidp, meta] : updated_metadata) {
+        out.emplace_back(
+          write_batch_row{
+            .key = metadata_row_key::encode(tidp),
+            .value = serde::to_iobuf(meta),
+          });
+    }
+
+    co_return std::expected<void, db_update_error>{};
+}
+
 } // namespace
 
 ss::future<std::expected<void, db_update_error>>
@@ -623,28 +913,6 @@ replace_objects_db_update::build_rows(
     if (!validate_res.has_value()) {
         co_return std::unexpected(std::move(validate_res.error()));
     }
-    sorted_extents_by_tidp_t new_extents_by_tp;
-    chunked_hash_map<object_id, object_entry> new_objects_map;
-    auto new_extents_res = co_await validate_preregistered_and_collect(
-      new_objects, state, new_extents_by_tp, new_objects_map);
-    if (!new_extents_res.has_value()) {
-        co_return std::unexpected(std::move(new_extents_res.error()));
-    }
-
-    // Calculate contiguous intervals and validate that they align with
-    // appropriate extents.
-    auto contiguous_intervals_res = contiguous_intervals_for_extents(
-      new_extents_by_tp);
-    if (!contiguous_intervals_res.has_value()) {
-        co_return std::unexpected(db_update_error(
-          invalid_input, std::move(contiguous_intervals_res.error())));
-    }
-    const auto& contiguous_intervals_by_tp = contiguous_intervals_res.value();
-    chunked_hash_map<object_id, size_t> old_extent_sizes_by_oid;
-    chunked_hash_map<model::topic_id_partition, chunked_vector<ss::sstring>>
-      extent_keys_to_delete;
-    chunked_hash_map<model::topic_id_partition, kafka::offset>
-      start_offsets_by_tp;
 
     /*
      * The `updated_metadata` map tracks metadata that needs to be updated. Use
@@ -654,53 +922,17 @@ replace_objects_db_update::build_rows(
     chunked_hash_map<model::topic_id_partition, metadata_row_value>
       updated_metadata;
 
-    for (const auto& [tidp, intervals] : contiguous_intervals_by_tp) {
-        auto meta_res = co_await get_metadata_for_update(
-          state, updated_metadata, tidp, "contiguous interval processing");
-        if (!meta_res.has_value()) {
-            co_return std::unexpected(std::move(meta_res.error()));
-        }
-        start_offsets_by_tp[tidp] = meta_res.value()->start_offset;
-        // Track removed sizes for this partition specifically.
-        chunked_hash_map<object_id, size_t> tidp_removed_sizes;
-        auto exact_intervals_res = co_await collect_exact_intervals(
-          tidp,
-          intervals,
-          meta_res.value()->start_offset,
-          state,
-          extent_keys_to_delete[tidp],
-          tidp_removed_sizes);
-        if (!exact_intervals_res.has_value()) {
-            co_return std::unexpected(std::move(exact_intervals_res.error()));
-        }
-        // Accumulate total removed size for this partition, and then fold the
-        // updates for this partition back into old_extent_sizes_by_oid which
-        // tracks per object instead of per partition. The total is then
-        // subtracted off of the metadata which will later be updated in the db.
-        ssize_t removed_for_tidp = 0;
-        for (const auto& [oid, sz] : tidp_removed_sizes) {
-            removed_for_tidp += sz;
-            old_extent_sizes_by_oid[oid] += sz;
-        }
-        auto prev_size = static_cast<ssize_t>(meta_res.value()->size);
-        meta_res.value()->size = std::max(
-          ssize_t(0), prev_size - removed_for_tidp);
-        meta_res.value()->num_extents -= std::min(
-          meta_res.value()->num_extents, extent_keys_to_delete[tidp].size());
+    auto replacements_res = co_await validate_replacement(
+      state, new_objects, updated_metadata);
+    if (!replacements_res.has_value()) {
+        co_return std::unexpected(std::move(replacements_res.error()));
     }
 
-    // Update existing object entries to indicate the removal of data from
-    // replaced extents.
-    auto updated_old_objects_res = co_await build_object_removal_entries(
-      state, old_extent_sizes_by_oid);
-    if (!updated_old_objects_res.has_value()) {
-        co_return std::unexpected(updated_old_objects_res.error());
-    }
-    auto& updated_old_objects = updated_old_objects_res.value();
+    auto& replacements = replacements_res.value();
 
+    // Process compaction state mutations and build compaction rows.
     chunked_hash_map<model::topic_id_partition, compaction_state>
       merged_compaction_states;
-
     for (const auto& [t, p_updates] : compaction_updates) {
         for (const auto& [p, comp_update] : p_updates) {
             model::topic_id_partition tidp{t, p};
@@ -723,8 +955,9 @@ replace_objects_db_update::build_rows(
             // down to the start of the log. By definition, this is a
             // requirement of cleaning the log.
             if (!comp_update.new_cleaned_ranges.empty()) {
-                auto new_extent_iter = new_extents_by_tp.find(tidp);
-                if (new_extent_iter != new_extents_by_tp.end()) {
+                auto new_extent_iter = replacements.new_extents_by_tp.find(
+                  tidp);
+                if (new_extent_iter != replacements.new_extents_by_tp.end()) {
                     auto req_extents_base
                       = new_extent_iter->second.begin()->base_offset;
                     auto start_offset = updated_metadata[tidp].start_offset;
@@ -743,81 +976,6 @@ replace_objects_db_update::build_rows(
         }
     }
 
-    // Generate the rows.
-    chunked_hash_set<ss::sstring> added_extent_keys;
-    for (const auto& [tidp, extents] : new_extents_by_tp) {
-        auto start_it = start_offsets_by_tp.find(tidp);
-        auto start_offset = start_it != start_offsets_by_tp.end()
-                              ? start_it->second
-                              : kafka::offset{0};
-        size_t added_for_tidp = 0;
-        size_t added_extents_for_tidp = 0;
-        for (const auto& extent : extents) {
-            // Skip extents fully below start_offset. These are stale
-            // replacements for extents that have been truncated.
-            if (extent.last_offset < start_offset) {
-                new_objects_map[extent.oid].removed_data_size += extent.len;
-                continue;
-            }
-            auto key = extent_row_key::encode(tidp, extent.base_offset);
-            added_extent_keys.emplace(key);
-            added_for_tidp += extent.len;
-            ++added_extents_for_tidp;
-            out.emplace_back(
-              write_batch_row{
-                .key = extent_row_key::encode(tidp, extent.base_offset),
-                .value = serde::to_iobuf(
-                  extent_row_value{
-                    .last_offset = extent.last_offset,
-                    .max_timestamp = extent.max_timestamp,
-                    .filepos = extent.filepos,
-                    .len = extent.len,
-                    .oid = extent.oid,
-                  }),
-              });
-        }
-
-        auto meta_res = co_await get_metadata_for_update(
-          state, updated_metadata, tidp, "new extents");
-        if (!meta_res.has_value()) {
-            co_return std::unexpected(std::move(meta_res.error()));
-        }
-        meta_res.value()->size += added_for_tidp;
-        meta_res.value()->num_extents += added_extents_for_tidp;
-    }
-    if (added_extent_keys.empty()) {
-        // No extents, e.g. because all replacements are below the current
-        // start offsets.
-        co_return std::unexpected(db_update_error(
-          invalid_update, "Replacement extents all filtered out"));
-    }
-    for (const auto& [tidp, keys] : extent_keys_to_delete) {
-        for (const auto& key : keys) {
-            if (added_extent_keys.contains(key)) {
-                // Don't delete keys that are also being added.
-                continue;
-            }
-            out.emplace_back(
-              write_batch_row{
-                .key = key,
-                .value = iobuf{},
-              });
-        }
-    }
-    for (const auto& [oid, entry] : updated_old_objects) {
-        out.emplace_back(
-          write_batch_row{
-            .key = object_row_key::encode(oid),
-            .value = serde::to_iobuf(object_row_value{.object = entry}),
-          });
-    }
-    for (const auto& [oid, entry] : new_objects_map) {
-        out.emplace_back(
-          write_batch_row{
-            .key = object_row_key::encode(oid),
-            .value = serde::to_iobuf(object_row_value{.object = entry}),
-          });
-    }
     for (const auto& [tidp, comp_state] : merged_compaction_states) {
         out.emplace_back(
           write_batch_row{
@@ -826,15 +984,8 @@ replace_objects_db_update::build_rows(
           });
     }
 
-    for (auto& [tidp, meta] : updated_metadata) {
-        out.emplace_back(
-          write_batch_row{
-            .key = metadata_row_key::encode(tidp),
-            .value = serde::to_iobuf(meta),
-          });
-    }
-
-    co_return std::expected<void, db_update_error>{};
+    co_return co_await build_replacement_rows(
+      state, std::move(replacements), updated_metadata, out);
 }
 
 ss::future<std::expected<absl::btree_set<object_id>, db_update_error>>
@@ -844,91 +995,18 @@ replace_objects_db_update::discover_replaced_object_ids(
     if (!validate_res.has_value()) {
         co_return std::unexpected(std::move(validate_res.error()));
     }
-    sorted_extents_by_tidp_t new_extents_by_tp;
-    for (const auto& o : new_objects) {
-        o.collect_extents_by_tidp(&new_extents_by_tp);
-    }
-
-    auto contiguous_intervals_res = contiguous_intervals_for_extents(
-      new_extents_by_tp);
-    if (!contiguous_intervals_res.has_value()) {
-        co_return std::unexpected(db_update_error(
-          invalid_input, std::move(contiguous_intervals_res.error())));
-    }
-
-    // For each partition's replacement intervals, scan existing extents
-    // in that range and collect their object IDs. We use get_inclusive_extents
-    // rather than get_extent_range — discovery only needs OIDs, not exact
-    // alignment validation (build_rows handles that).
-    absl::btree_set<object_id> discovered_oids;
-    for (const auto& [tidp, intervals] : contiguous_intervals_res.value()) {
-        for (const auto& interval : intervals) {
-            auto extents_res = co_await state.get_inclusive_extents(
-              tidp, interval.base_offset, interval.last_offset);
-            if (!extents_res.has_value()) {
-                co_return std::unexpected(wrap_read_err(
-                  std::move(extents_res.error()),
-                  "Error getting {} extents for discovery in [{}, {}]",
-                  tidp,
-                  interval.base_offset,
-                  interval.last_offset));
-            }
-            if (!extents_res->has_value()) {
-                continue;
-            }
-            auto gen = (*extents_res)->get_rows();
-            while (auto row_res = co_await gen()) {
-                const auto& row = row_res->get();
-                if (!row.has_value()) {
-                    co_return std::unexpected(wrap_read_err(
-                      row.error(),
-                      "Error iterating {} extents during discovery",
-                      tidp));
-                }
-                discovered_oids.insert(row->val.oid);
-            }
-        }
-    }
-    co_return discovered_oids;
+    co_return co_await discover_replaced_object_ids_for_extents(
+      state, new_objects);
 }
 
 std::expected<void, db_update_error>
 replace_objects_db_update::validate_inputs() const {
-    if (new_objects.empty()) {
-        return std::unexpected(
-          db_update_error(invalid_input, "No objects requested"));
+    auto layout_res = validate_new_objects_extent_layout(new_objects);
+    if (!layout_res.has_value()) {
+        return std::unexpected(layout_res.error());
     }
+    const auto& new_extents_by_tp = layout_res.value();
 
-    sorted_extents_by_tidp_t new_extents_by_tp;
-    for (const auto& o : new_objects) {
-        o.collect_extents_by_tidp(&new_extents_by_tp);
-    }
-    for (const auto& [tidp, extents] : new_extents_by_tp) {
-        for (const auto& extent : extents) {
-            if (extent.base_offset > extent.last_offset) {
-                return std::unexpected(db_update_error(
-                  invalid_input,
-                  fmt::format(
-                    "Input object has inverted extent for partition {}: "
-                    "base_offset {} > last_offset {}",
-                    tidp,
-                    extent.base_offset,
-                    extent.last_offset)));
-            }
-        }
-    }
-
-    auto contiguous_intervals = contiguous_intervals_for_extents(
-      new_extents_by_tp);
-    if (!contiguous_intervals.has_value()) {
-        return std::unexpected(
-          db_update_error(invalid_input, contiguous_intervals.error()));
-    }
-
-    // Validate compaction updates align with extents
-    if (compaction_updates.empty()) {
-        return std::expected<void, db_update_error>{};
-    }
     for (const auto& [t, t_req] : compaction_updates) {
         for (const auto& [p, compaction_update] : t_req) {
             model::topic_id_partition tidp{t, p};

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.h
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.h
@@ -60,7 +60,7 @@ struct add_objects_db_update {
     term_state_update_t new_terms;
 };
 
-struct replace_objects_no_compact_db_update {
+struct replace_objects_db_update {
     ss::future<std::expected<void, db_update_error>>
     build_rows(state_reader&, chunked_vector<write_batch_row>&) const;
 

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.h
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.h
@@ -95,7 +95,9 @@ struct replace_objects_db_update {
     // Validates the given update is well-formed:
     // - There are new objects
     // - Input extents are in order and form contiguous intervals
-    // - Compaction updates align with new extents
+    // - Every partition in new_objects has a compaction_update entry and
+    //   vice versa (the bidirectional invariant that gates the OCC epoch
+    //   bump)
     std::expected<void, db_update_error> validate_inputs() const;
 
     chunked_vector<new_object> new_objects;

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.h
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.h
@@ -60,6 +60,30 @@ struct add_objects_db_update {
     term_state_update_t new_terms;
 };
 
+struct replace_objects_no_compact_db_update {
+    ss::future<std::expected<void, db_update_error>>
+    build_rows(state_reader&, chunked_vector<write_batch_row>&) const;
+
+    /// Returns the set of object IDs referenced by the extents being replaced.
+    ss::future<std::expected<absl::btree_set<object_id>, db_update_error>>
+    discover_replaced_object_ids(state_reader&) const;
+
+    // Validates the given update is well-formed:
+    // - There are new objects
+    // - Input extents are in order and form contiguous intervals
+    // - Every partition in new_objects has an entry in expected_epochs and
+    //   vice versa
+    std::expected<void, db_update_error> validate_inputs() const;
+
+    chunked_vector<new_object> new_objects;
+    chunked_hash_map<
+      model::topic_id,
+      chunked_hash_map<
+        model::partition_id,
+        partition_state::compaction_epoch_t>>
+      expected_epochs;
+};
+
 struct replace_objects_db_update {
     ss::future<std::expected<void, db_update_error>>
     build_rows(state_reader&, chunked_vector<write_batch_row>&) const;

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.h
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.h
@@ -84,7 +84,7 @@ struct replace_objects_no_compact_db_update {
       expected_epochs;
 };
 
-struct replace_objects_db_update {
+struct compact_objects_db_update {
     ss::future<std::expected<void, db_update_error>>
     build_rows(state_reader&, chunked_vector<write_batch_row>&) const;
 

--- a/src/v/cloud_topics/level_one/metastore/lsm/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/tests/state_update_test.cc
@@ -187,8 +187,8 @@ struct replace_spec {
 using replace_specs = std::vector<replace_spec>;
 
 template<typename... Objects>
-replace_objects_no_compact_db_update make_replace_objects_no_compact_update(
-  const replace_specs& rs, Objects... objects) {
+replace_objects_db_update
+make_replace_objects_update(const replace_specs& rs, Objects... objects) {
     chunked_hash_map<
       model::topic_id,
       chunked_hash_map<
@@ -201,7 +201,7 @@ replace_objects_no_compact_db_update make_replace_objects_no_compact_update(
     }
 
     auto new_objects = make_new_objects(objects...);
-    return replace_objects_no_compact_db_update{
+    return replace_objects_db_update{
       .new_objects = std::move(new_objects),
       .expected_epochs = std::move(expected_epochs),
     };
@@ -289,8 +289,7 @@ protected:
         db_->apply(std::move(wb)).get();
     }
 
-    void apply_replace_no_compact_update(
-      replace_objects_no_compact_db_update& update) {
+    void apply_replace_no_compact_update(replace_objects_db_update& update) {
         preregister_new_objects(update.new_objects);
         auto reader = make_reader();
         chunked_vector<write_batch_row> rows;
@@ -445,9 +444,8 @@ protected:
     }
 
     template<typename... Objects>
-    void replace_objects_no_compact(replace_specs rs, Objects... objects) {
-        auto db_update = make_replace_objects_no_compact_update(
-          std::move(rs), objects...);
+    void replace_objects(replace_specs rs, Objects... objects) {
+        auto db_update = make_replace_objects_update(std::move(rs), objects...);
         apply_replace_no_compact_update(db_update);
     }
 
@@ -851,7 +849,7 @@ TEST_F(StateUpdateTest, TestReplaceObjectsBasic) {
 
     // Create a new object that replaces the first two extents [0-199].
     auto new_oid = make_oid();
-    replace_objects_no_compact(
+    replace_objects(
       replace_specs{{.tidp = tidp0, .epoch = 0}},
       make_object(new_oid, tp(tidp0, 0, 199).pos(0, 2047)));
 
@@ -874,7 +872,7 @@ TEST_F(StateUpdateTest, TestReplaceObjectsRejectsMissingPartition) {
     prereg_oids.push_back(oid);
     preregister_objects(std::move(prereg_oids), model::timestamp(1000));
 
-    auto db_update = make_replace_objects_no_compact_update(
+    auto db_update = make_replace_objects_update(
       replace_specs{{.tidp = tidp0, .epoch = 0}},
       make_object(oid, tp(tidp0, 0, 99).pos(0, 1023)));
     auto reader = make_reader();
@@ -887,7 +885,7 @@ TEST_F(StateUpdateTest, TestReplaceObjectsRejectsMissingPartition) {
 }
 
 TEST_F(StateUpdateTest, TestReplaceObjectsRejectsEmptyObjects) {
-    replace_objects_no_compact_db_update update{
+    replace_objects_db_update update{
       .new_objects = {},
       .expected_epochs = {},
     };
@@ -962,7 +960,7 @@ TEST_F(StateUpdateTest, TestReplaceObjectsRejectsDuplicateObject) {
       make_object(oid, tp(tidp0, 0, 99).pos(0, 1023)));
 
     // Try to replace using an object ID that already exists.
-    auto db_update = make_replace_objects_no_compact_update(
+    auto db_update = make_replace_objects_update(
       replace_specs{{.tidp = tidp0, .epoch = 0}},
       make_object(oid, tp(tidp0, 0, 99).pos(0, 1023)));
     auto reader = make_reader();
@@ -1574,7 +1572,7 @@ TEST_F(StateUpdateTest, TestReplaceObjectsTracksSize) {
 
     // Replace both extents with a single smaller extent.
     auto new_oid = make_oid();
-    replace_objects_no_compact(
+    replace_objects(
       replace_specs{{.tidp = tidp0, .epoch = 0}},
       make_object(new_oid, tp(tidp0, 0, 199).pos(0, 511)));
 
@@ -1597,7 +1595,7 @@ TEST_F(StateUpdateTest, TestReplaceObjectsTracksSizeMultiplePartitions) {
     verify_metadata_size(tidp1, 500);
 
     // Replace only tidp0's extent with a smaller one.
-    replace_objects_no_compact(
+    replace_objects(
       replace_specs{{.tidp = tidp0, .epoch = 0}},
       make_object(make_oid(), tp(tidp0, 0, 99).pos(0, 199))); // size = 200
 
@@ -1837,7 +1835,7 @@ TEST_F(StateUpdateTest, TestDiscoverReplacedObjectIds) {
     // Build a replace update that replaces extents [0-199]. Discovery
     // should find old_oid1 and old_oid2 but not old_oid3.
     auto new_oid = make_oid();
-    auto db_update = make_replace_objects_no_compact_update(
+    auto db_update = make_replace_objects_update(
       replace_specs{{.tidp = tidp0, .epoch = 0}},
       make_object(new_oid, tp(tidp0, 0, 199).pos(0, 2047)));
 
@@ -1893,7 +1891,7 @@ TEST_F(StateUpdateTest, TestReplaceObjectsEpochMismatchRejectedAtBuildRows) {
 
     verify_metadata(tidp0, kafka::offset(0), kafka::offset(100));
 
-    // Build a replace_objects_no_compact_db_update with expected_epoch = 1, but
+    // Build a replace_objects_db_update with expected_epoch = 1, but
     // the actual epoch is still 0.
     auto new_oid = make_oid();
     chunked_vector<object_id> prereg_oids;
@@ -1909,7 +1907,7 @@ TEST_F(StateUpdateTest, TestReplaceObjectsEpochMismatchRejectedAtBuildRows) {
     expected_epochs[tidp0.topic_id][tidp0.partition]
       = partition_state::compaction_epoch_t{1};
 
-    replace_objects_no_compact_db_update db_update{
+    replace_objects_db_update db_update{
       .new_objects = make_new_objects(
         make_object(new_oid, tp(tidp0, 0, 99).pos(0, 1023))),
       .expected_epochs = std::move(expected_epochs),
@@ -1926,12 +1924,12 @@ TEST_F(StateUpdateTest, TestReplaceObjectsEpochMismatchRejectedAtBuildRows) {
 }
 
 TEST_F(StateUpdateTest, TestReplaceObjectsRejectsExtentsWithoutEpochEntry) {
-    // Build a replace_objects_no_compact_db_update with new_objects but empty
+    // Build a replace_objects_db_update with new_objects but empty
     // expected_epochs. validate_inputs should reject it because the
     // bidirectional invariant requires an expected_epochs entry for every
     // partition that has new extents.
     auto oid = make_oid();
-    replace_objects_no_compact_db_update db_update{
+    replace_objects_db_update db_update{
       .new_objects = make_new_objects(
         make_object(oid, tp(tidp0, 0, 99).pos(0, 1023))),
       .expected_epochs = {},
@@ -1944,7 +1942,7 @@ TEST_F(StateUpdateTest, TestReplaceObjectsRejectsExtentsWithoutEpochEntry) {
 }
 
 TEST_F(StateUpdateTest, TestReplaceObjectsRejectsEpochEntryWithoutExtents) {
-    // Build a replace_objects_no_compact_db_update where expected_epochs
+    // Build a replace_objects_db_update where expected_epochs
     // contains an entry for a partition that has no corresponding new extents.
     // validate_inputs should reject it (bidirectional invariant).
     auto oid = make_oid();
@@ -1968,7 +1966,7 @@ TEST_F(StateUpdateTest, TestReplaceObjectsRejectsEpochEntryWithoutExtents) {
     expected_epochs[other_tidp.topic_id][other_tidp.partition]
       = partition_state::compaction_epoch_t{0};
 
-    replace_objects_no_compact_db_update db_update{
+    replace_objects_db_update db_update{
       .new_objects = make_new_objects(
         make_object(oid, tp(tidp0, 0, 99).pos(0, 1023))),
       .expected_epochs = std::move(expected_epochs),

--- a/src/v/cloud_topics/level_one/metastore/lsm/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/tests/state_update_test.cc
@@ -180,6 +180,33 @@ make_replace_objects_update(const compact_specs& cs, Objects... objects) {
     };
 }
 
+struct replace_spec {
+    model::topic_id_partition tidp;
+    int64_t epoch{0};
+};
+using replace_specs = std::vector<replace_spec>;
+
+template<typename... Objects>
+replace_objects_no_compact_db_update make_replace_objects_no_compact_update(
+  const replace_specs& rs, Objects... objects) {
+    chunked_hash_map<
+      model::topic_id,
+      chunked_hash_map<
+        model::partition_id,
+        partition_state::compaction_epoch_t>>
+      expected_epochs;
+    for (const auto& r : rs) {
+        expected_epochs[r.tidp.topic_id][r.tidp.partition]
+          = partition_state::compaction_epoch_t(r.epoch);
+    }
+
+    auto new_objects = make_new_objects(objects...);
+    return replace_objects_no_compact_db_update{
+      .new_objects = std::move(new_objects),
+      .expected_epochs = std::move(expected_epochs),
+    };
+}
+
 model::topic_id_partition make_tidp(int partition) {
     return model::topic_id_partition(
       model::topic_id(
@@ -244,6 +271,26 @@ protected:
     }
 
     void apply_replace_update(replace_objects_db_update& update) {
+        preregister_new_objects(update.new_objects);
+        auto reader = make_reader();
+        chunked_vector<write_batch_row> rows;
+        auto result = update.build_rows(reader, rows).get();
+        ASSERT_TRUE(result.has_value());
+
+        auto seqno = next_seqno();
+        auto wb = db_->create_write_batch();
+        for (const auto& row : rows) {
+            if (row.value.empty()) {
+                wb.remove(row.key, seqno);
+            } else {
+                wb.put(row.key, row.value.copy(), seqno);
+            }
+        }
+        db_->apply(std::move(wb)).get();
+    }
+
+    void apply_replace_no_compact_update(
+      replace_objects_no_compact_db_update& update) {
         preregister_new_objects(update.new_objects);
         auto reader = make_reader();
         chunked_vector<write_batch_row> rows;
@@ -395,6 +442,13 @@ protected:
     void replace_objects(compact_specs cs, Objects... objects) {
         auto db_update = make_replace_objects_update(std::move(cs), objects...);
         apply_replace_update(db_update);
+    }
+
+    template<typename... Objects>
+    void replace_objects_no_compact(replace_specs rs, Objects... objects) {
+        auto db_update = make_replace_objects_no_compact_update(
+          std::move(rs), objects...);
+        apply_replace_no_compact_update(db_update);
     }
 
     void apply_set_start_offset_update(set_start_offset_db_update& update) {
@@ -797,8 +851,9 @@ TEST_F(StateUpdateTest, TestReplaceObjectsBasic) {
 
     // Create a new object that replaces the first two extents [0-199].
     auto new_oid = make_oid();
-    replace_objects(
-      compact_specs{}, make_object(new_oid, tp(tidp0, 0, 199).pos(0, 2047)));
+    replace_objects_no_compact(
+      replace_specs{{.tidp = tidp0, .epoch = 0}},
+      make_object(new_oid, tp(tidp0, 0, 199).pos(0, 2047)));
 
     // Metadata should be unchanged.
     verify_metadata(tidp0, kafka::offset(0), kafka::offset(300));
@@ -819,8 +874,9 @@ TEST_F(StateUpdateTest, TestReplaceObjectsRejectsMissingPartition) {
     prereg_oids.push_back(oid);
     preregister_objects(std::move(prereg_oids), model::timestamp(1000));
 
-    auto db_update = make_replace_objects_update(
-      compact_specs{}, make_object(oid, tp(tidp0, 0, 99).pos(0, 1023)));
+    auto db_update = make_replace_objects_no_compact_update(
+      replace_specs{{.tidp = tidp0, .epoch = 0}},
+      make_object(oid, tp(tidp0, 0, 99).pos(0, 1023)));
     auto reader = make_reader();
     chunked_vector<write_batch_row> rows;
     auto result = db_update.build_rows(reader, rows).get();
@@ -831,9 +887,9 @@ TEST_F(StateUpdateTest, TestReplaceObjectsRejectsMissingPartition) {
 }
 
 TEST_F(StateUpdateTest, TestReplaceObjectsRejectsEmptyObjects) {
-    replace_objects_db_update update{
+    replace_objects_no_compact_db_update update{
       .new_objects = {},
-      .compaction_updates = {},
+      .expected_epochs = {},
     };
     auto validate_res = update.validate_inputs();
     ASSERT_FALSE(validate_res.has_value());
@@ -844,7 +900,7 @@ TEST_F(StateUpdateTest, TestReplaceObjectsRejectsEmptyObjects) {
 }
 
 TEST_F(
-  StateUpdateTest, TestReplaceObjectsRejectsCompactionUpdateWithoutExtents) {
+  StateUpdateTest, TestCompactObjectsRejectsCompactionUpdateWithoutExtents) {
     auto tidp1 = make_tidp(1);
 
     // Compaction update for tidp1, but extents only for tidp0.
@@ -864,7 +920,7 @@ TEST_F(
 }
 
 TEST_F(
-  StateUpdateTest, TestReplaceObjectsRejectsCleanedRangeExceedsExtentsEnd) {
+  StateUpdateTest, TestCompactObjectsRejectsCleanedRangeExceedsExtentsEnd) {
     // Cleaned range [0-299], but extents only [0-199].
     auto db_update = make_replace_objects_update(
       {{compact_spec{
@@ -882,7 +938,7 @@ TEST_F(
 }
 
 TEST_F(
-  StateUpdateTest, TestReplaceObjectsRejectsCleanedRangeStartsBeforeExtents) {
+  StateUpdateTest, TestCompactObjectsRejectsCleanedRangeStartsBeforeExtents) {
     // Extents start at 100, but cleaned range starts at 50.
     auto db_update = make_replace_objects_update(
       {{compact_spec{
@@ -906,8 +962,9 @@ TEST_F(StateUpdateTest, TestReplaceObjectsRejectsDuplicateObject) {
       make_object(oid, tp(tidp0, 0, 99).pos(0, 1023)));
 
     // Try to replace using an object ID that already exists.
-    auto db_update = make_replace_objects_update(
-      compact_specs{}, make_object(oid, tp(tidp0, 0, 99).pos(0, 1023)));
+    auto db_update = make_replace_objects_no_compact_update(
+      replace_specs{{.tidp = tidp0, .epoch = 0}},
+      make_object(oid, tp(tidp0, 0, 99).pos(0, 1023)));
     auto reader = make_reader();
     chunked_vector<write_batch_row> rows;
     auto result = db_update.build_rows(reader, rows).get();
@@ -917,7 +974,7 @@ TEST_F(StateUpdateTest, TestReplaceObjectsRejectsDuplicateObject) {
       fmt::format("{}", result.error()), HasSubstr("not pre-registered"));
 }
 
-TEST_F(StateUpdateTest, TestReplaceObjectsRejectsOverlappingCleanedRanges) {
+TEST_F(StateUpdateTest, TestCompactObjectsRejectsOverlappingCleanedRanges) {
     // Set up partition with existing cleaned range with tombstones.
     add_objects(
       {terms(tidp0, {{0, 1}})},
@@ -961,7 +1018,7 @@ TEST_F(StateUpdateTest, TestReplaceObjectsRejectsOverlappingCleanedRanges) {
       HasSubstr("overlaps with an existing cleaned range"));
 }
 
-TEST_F(StateUpdateTest, TestReplaceObjectsRejectsRemovingUntrackedTombstones) {
+TEST_F(StateUpdateTest, TestCompactObjectsRejectsRemovingUntrackedTombstones) {
     // Set up partition without any tombstone tracking.
     add_objects(
       {terms(tidp0, {{0, 1}})},
@@ -990,14 +1047,14 @@ TEST_F(StateUpdateTest, TestReplaceObjectsRejectsRemovingUntrackedTombstones) {
       HasSubstr("is not tracked as having tombstones"));
 }
 
-TEST_F(StateUpdateTest, TestReplaceObjectsWithCompactionAndTombstones) {
+TEST_F(StateUpdateTest, TestCompactObjectsWithCompactionAndTombstones) {
     // Set up initial partition.
     add_objects(
       {terms(tidp0, {{0, 1}})},
       make_object(make_oid(), tp(tidp0, 0, 99).pos(0, 2047)),
       make_object(make_oid(), tp(tidp0, 100, 199).pos(0, 2047)));
 
-    // First replace with cleaned range with tombstones [0-99].
+    // First compact with cleaned range with tombstones [0-99].
     auto new_oid1 = make_oid();
     replace_objects(
       {{compact_spec{
@@ -1016,7 +1073,7 @@ TEST_F(StateUpdateTest, TestReplaceObjectsWithCompactionAndTombstones) {
       /*expected_cleaned_ranges=*/{{0, 99}},
       /*expected_tombstone_ranges=*/{{0, 99, 1000}});
 
-    // Second replace: add non-overlapping cleaned range with tombstones
+    // Second compact: add non-overlapping cleaned range with tombstones
     // [150-199], and remove tombstones from [0-49].
     // epoch=1 because the first compaction incremented it from 0 to 1.
     auto new_oid2 = make_oid();
@@ -1040,7 +1097,7 @@ TEST_F(StateUpdateTest, TestReplaceObjectsWithCompactionAndTombstones) {
       /*expected_tombstone_ranges=*/{{50, 99, 1000}, {150, 199, 2000}});
 }
 
-TEST_F(StateUpdateTest, TestReplaceObjectsRejectsCleanedRangeNotAtLogStart) {
+TEST_F(StateUpdateTest, TestCompactObjectsRejectsCleanedRangeNotAtLogStart) {
     add_objects(
       {terms(tidp0, {{0, 1}})},
       make_object(make_oid(), tp(tidp0, 0, 99).pos(0, 1023)),
@@ -1048,7 +1105,7 @@ TEST_F(StateUpdateTest, TestReplaceObjectsRejectsCleanedRangeNotAtLogStart) {
 
     verify_metadata(tidp0, kafka::offset(0), kafka::offset(200));
 
-    // Try to replace with cleaned range [100-199], but without replacing down
+    // Try to compact with cleaned range [100-199], but without replacing down
     // to offset 0. This should be rejected because cleaning requires
     // replacing from the start of the log.
     auto partial_oid = make_oid();
@@ -1072,7 +1129,7 @@ TEST_F(StateUpdateTest, TestReplaceObjectsRejectsCleanedRangeNotAtLogStart) {
       fmt::format("{}", result.error()),
       HasSubstr("does not replace to the beginning of the log"));
 
-    // Now validate that replacing down to 0 works.
+    // Now validate that compacting down to 0 works.
     replace_objects(
       {{compact_spec{
         .tidp = tidp0,
@@ -1517,8 +1574,9 @@ TEST_F(StateUpdateTest, TestReplaceObjectsTracksSize) {
 
     // Replace both extents with a single smaller extent.
     auto new_oid = make_oid();
-    replace_objects(
-      compact_specs{}, make_object(new_oid, tp(tidp0, 0, 199).pos(0, 511)));
+    replace_objects_no_compact(
+      replace_specs{{.tidp = tidp0, .epoch = 0}},
+      make_object(new_oid, tp(tidp0, 0, 199).pos(0, 511)));
 
     // Size should be updated to the new extent size (512).
     verify_metadata_size(tidp0, 512);
@@ -1539,8 +1597,8 @@ TEST_F(StateUpdateTest, TestReplaceObjectsTracksSizeMultiplePartitions) {
     verify_metadata_size(tidp1, 500);
 
     // Replace only tidp0's extent with a smaller one.
-    replace_objects(
-      compact_specs{},
+    replace_objects_no_compact(
+      replace_specs{{.tidp = tidp0, .epoch = 0}},
       make_object(make_oid(), tp(tidp0, 0, 99).pos(0, 199))); // size = 200
 
     // tidp0 should have updated size, tidp1 should be unchanged.
@@ -1779,8 +1837,9 @@ TEST_F(StateUpdateTest, TestDiscoverReplacedObjectIds) {
     // Build a replace update that replaces extents [0-199]. Discovery
     // should find old_oid1 and old_oid2 but not old_oid3.
     auto new_oid = make_oid();
-    auto db_update = make_replace_objects_update(
-      compact_specs{}, make_object(new_oid, tp(tidp0, 0, 199).pos(0, 2047)));
+    auto db_update = make_replace_objects_no_compact_update(
+      replace_specs{{.tidp = tidp0, .epoch = 0}},
+      make_object(new_oid, tp(tidp0, 0, 199).pos(0, 2047)));
 
     // Preregister the new object so validate_inputs passes.
     preregister_new_objects(db_update.new_objects);
@@ -1824,4 +1883,100 @@ TEST_F(StateUpdateTest, TestDiscoverRemoveTopicsObjectIds) {
     EXPECT_TRUE(result.value().contains(oid1));
     EXPECT_TRUE(result.value().contains(oid2));
     EXPECT_FALSE(result.value().contains(oid3));
+}
+
+TEST_F(StateUpdateTest, TestReplaceObjectsEpochMismatchRejectedAtBuildRows) {
+    // Set up a partition at epoch 0.
+    add_objects(
+      {terms(tidp0, {{0, 1}})},
+      make_object(make_oid(), tp(tidp0, 0, 99).pos(0, 1023)));
+
+    verify_metadata(tidp0, kafka::offset(0), kafka::offset(100));
+
+    // Build a replace_objects_no_compact_db_update with expected_epoch = 1, but
+    // the actual epoch is still 0.
+    auto new_oid = make_oid();
+    chunked_vector<object_id> prereg_oids;
+    prereg_oids.push_back(new_oid);
+    preregister_objects(std::move(prereg_oids), model::timestamp(1000));
+
+    chunked_hash_map<
+      model::topic_id,
+      chunked_hash_map<
+        model::partition_id,
+        partition_state::compaction_epoch_t>>
+      expected_epochs;
+    expected_epochs[tidp0.topic_id][tidp0.partition]
+      = partition_state::compaction_epoch_t{1};
+
+    replace_objects_no_compact_db_update db_update{
+      .new_objects = make_new_objects(
+        make_object(new_oid, tp(tidp0, 0, 99).pos(0, 1023))),
+      .expected_epochs = std::move(expected_epochs),
+    };
+
+    auto reader = make_reader();
+    chunked_vector<write_batch_row> rows;
+    auto result = db_update.build_rows(reader, rows).get();
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().e, db_update_errc::invalid_update);
+    EXPECT_THAT(
+      fmt::format("{}", result.error()),
+      HasSubstr("Compaction epoch mismatch"));
+}
+
+TEST_F(StateUpdateTest, TestReplaceObjectsRejectsExtentsWithoutEpochEntry) {
+    // Build a replace_objects_no_compact_db_update with new_objects but empty
+    // expected_epochs. validate_inputs should reject it because the
+    // bidirectional invariant requires an expected_epochs entry for every
+    // partition that has new extents.
+    auto oid = make_oid();
+    replace_objects_no_compact_db_update db_update{
+      .new_objects = make_new_objects(
+        make_object(oid, tp(tidp0, 0, 99).pos(0, 1023))),
+      .expected_epochs = {},
+    };
+    auto result = db_update.validate_inputs();
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().e, db_update_errc::invalid_input);
+    EXPECT_THAT(
+      fmt::format("{}", result.error()), HasSubstr("no expected_epochs entry"));
+}
+
+TEST_F(StateUpdateTest, TestReplaceObjectsRejectsEpochEntryWithoutExtents) {
+    // Build a replace_objects_no_compact_db_update where expected_epochs
+    // contains an entry for a partition that has no corresponding new extents.
+    // validate_inputs should reject it (bidirectional invariant).
+    auto oid = make_oid();
+
+    chunked_hash_map<
+      model::topic_id,
+      chunked_hash_map<
+        model::partition_id,
+        partition_state::compaction_epoch_t>>
+      expected_epochs;
+
+    // tidp0 has extents.
+    expected_epochs[tidp0.topic_id][tidp0.partition]
+      = partition_state::compaction_epoch_t{0};
+
+    // Add an entry for a different partition that has no extents.
+    auto other_tidp = model::topic_id_partition(
+      model::topic_id(
+        uuid_t::from_string("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")),
+      model::partition_id(0));
+    expected_epochs[other_tidp.topic_id][other_tidp.partition]
+      = partition_state::compaction_epoch_t{0};
+
+    replace_objects_no_compact_db_update db_update{
+      .new_objects = make_new_objects(
+        make_object(oid, tp(tidp0, 0, 99).pos(0, 1023))),
+      .expected_epochs = std::move(expected_epochs),
+    };
+    auto result = db_update.validate_inputs();
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().e, db_update_errc::invalid_input);
+    EXPECT_THAT(
+      fmt::format("{}", result.error()),
+      HasSubstr("expected_epochs entry for"));
 }

--- a/src/v/cloud_topics/level_one/metastore/lsm/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/tests/state_update_test.cc
@@ -148,8 +148,8 @@ make_add_objects_update(const term_specs& terms, Objects... objects) {
 }
 
 template<typename... Objects>
-replace_objects_db_update
-make_replace_objects_update(const compact_specs& cs, Objects... objects) {
+compact_objects_db_update
+make_compact_objects_update(const compact_specs& cs, Objects... objects) {
     chunked_hash_map<
       model::topic_id,
       chunked_hash_map<model::partition_id, compaction_state_update>>
@@ -174,7 +174,7 @@ make_replace_objects_update(const compact_specs& cs, Objects... objects) {
     }
 
     auto new_objects = make_new_objects(objects...);
-    return replace_objects_db_update{
+    return compact_objects_db_update{
       .new_objects = std::move(new_objects),
       .compaction_updates = std::move(compaction_updates),
     };
@@ -270,7 +270,7 @@ protected:
         db_->apply(std::move(wb)).get();
     }
 
-    void apply_replace_update(replace_objects_db_update& update) {
+    void apply_compact_update(compact_objects_db_update& update) {
         preregister_new_objects(update.new_objects);
         auto reader = make_reader();
         chunked_vector<write_batch_row> rows;
@@ -439,9 +439,9 @@ protected:
     }
 
     template<typename... Objects>
-    void replace_objects(compact_specs cs, Objects... objects) {
-        auto db_update = make_replace_objects_update(std::move(cs), objects...);
-        apply_replace_update(db_update);
+    void compact_objects(compact_specs cs, Objects... objects) {
+        auto db_update = make_compact_objects_update(std::move(cs), objects...);
+        apply_compact_update(db_update);
     }
 
     template<typename... Objects>
@@ -904,7 +904,7 @@ TEST_F(
     auto tidp1 = make_tidp(1);
 
     // Compaction update for tidp1, but extents only for tidp0.
-    auto db_update = make_replace_objects_update(
+    auto db_update = make_compact_objects_update(
       {{compact_spec{
         .tidp = tidp1,
         .cleaned = {{0, 99, false}},
@@ -922,7 +922,7 @@ TEST_F(
 TEST_F(
   StateUpdateTest, TestCompactObjectsRejectsCleanedRangeExceedsExtentsEnd) {
     // Cleaned range [0-299], but extents only [0-199].
-    auto db_update = make_replace_objects_update(
+    auto db_update = make_compact_objects_update(
       {{compact_spec{
         .tidp = tidp0,
         .cleaned = {{0, 299, false}},
@@ -940,7 +940,7 @@ TEST_F(
 TEST_F(
   StateUpdateTest, TestCompactObjectsRejectsCleanedRangeStartsBeforeExtents) {
     // Extents start at 100, but cleaned range starts at 50.
-    auto db_update = make_replace_objects_update(
+    auto db_update = make_compact_objects_update(
       {{compact_spec{
         .tidp = tidp0,
         .cleaned = {{50, 199, false}},
@@ -981,7 +981,7 @@ TEST_F(StateUpdateTest, TestCompactObjectsRejectsOverlappingCleanedRanges) {
       make_object(make_oid(), tp(tidp0, 0, 99).pos(0, 1023)));
 
     // Add a cleaned range [0-49].
-    replace_objects(
+    compact_objects(
       {{compact_spec{
         .tidp = tidp0,
         .cleaned = {{0, 49, true}},
@@ -999,7 +999,7 @@ TEST_F(StateUpdateTest, TestCompactObjectsRejectsOverlappingCleanedRanges) {
     prereg_oids.push_back(overlap_oid);
     preregister_objects(std::move(prereg_oids), model::timestamp(1000));
 
-    auto db_update = make_replace_objects_update(
+    auto db_update = make_compact_objects_update(
       {{compact_spec{
         .tidp = tidp0,
         .cleaned_at = 2000,
@@ -1030,7 +1030,7 @@ TEST_F(StateUpdateTest, TestCompactObjectsRejectsRemovingUntrackedTombstones) {
     prereg_oids.push_back(tomb_oid);
     preregister_objects(std::move(prereg_oids), model::timestamp(1000));
 
-    auto db_update = make_replace_objects_update(
+    auto db_update = make_compact_objects_update(
       {{compact_spec{
         .tidp = tidp0,
         .rm_tombstones = {{0, 49}},
@@ -1056,7 +1056,7 @@ TEST_F(StateUpdateTest, TestCompactObjectsWithCompactionAndTombstones) {
 
     // First compact with cleaned range with tombstones [0-99].
     auto new_oid1 = make_oid();
-    replace_objects(
+    compact_objects(
       {{compact_spec{
         .tidp = tidp0,
         .cleaned_at = 1000,
@@ -1077,7 +1077,7 @@ TEST_F(StateUpdateTest, TestCompactObjectsWithCompactionAndTombstones) {
     // [150-199], and remove tombstones from [0-49].
     // epoch=1 because the first compaction incremented it from 0 to 1.
     auto new_oid2 = make_oid();
-    replace_objects(
+    compact_objects(
       {{compact_spec{
         .tidp = tidp0,
         .cleaned_at = 2000,
@@ -1113,7 +1113,7 @@ TEST_F(StateUpdateTest, TestCompactObjectsRejectsCleanedRangeNotAtLogStart) {
     prereg_oids.push_back(partial_oid);
     preregister_objects(std::move(prereg_oids), model::timestamp(1000));
 
-    auto db_update = make_replace_objects_update(
+    auto db_update = make_compact_objects_update(
       {{compact_spec{
         .tidp = tidp0,
         .cleaned = {{100, 199, false}},
@@ -1130,7 +1130,7 @@ TEST_F(StateUpdateTest, TestCompactObjectsRejectsCleanedRangeNotAtLogStart) {
       HasSubstr("does not replace to the beginning of the log"));
 
     // Now validate that compacting down to 0 works.
-    replace_objects(
+    compact_objects(
       {{compact_spec{
         .tidp = tidp0,
         .cleaned = {{100, 199, false}},
@@ -1308,7 +1308,7 @@ TEST_F(StateUpdateTest, TestSetStartOffsetTruncatesCompactionState) {
       {terms(tidp0, {{0, 1}})},
       make_object(oid1, tp(tidp0, 0, 99).pos(0, 1023)));
 
-    replace_objects(
+    compact_objects(
       {{compact_spec{
         .tidp = tidp0,
         .cleaned = {{20, 80, true}},
@@ -1397,7 +1397,7 @@ TEST_F(StateUpdateTest, TestRemoveTopicsWithCompaction) {
       make_object(oid, tp(tidp0, 0, 99).pos(0, 1023)));
 
     // Add a cleaned range.
-    replace_objects(
+    compact_objects(
       {{compact_spec{
         .tidp = tidp0,
         .cleaned = {{0, 49, true}},

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -207,17 +207,6 @@ public:
     virtual ss::future<std::expected<add_response, errc>>
     add_objects(const object_metadata_builder&, const term_offset_map_t&) = 0;
 
-    // Adds the given objects to the metastore, expecting that the new extents
-    // replace an extent or set of extents covering the same range.
-    // It is expected that the set of new extents per partition covers a
-    // contiguous range of that partition's offset space.
-    //
-    // While these constraints aren't the only way we could ensure
-    // correctness, these simplify accounting and makes it easier to validate
-    // that we haven't lost data.
-    virtual ss::future<std::expected<void, errc>>
-    replace_objects(const object_metadata_builder&) = 0;
-
     // Moves the start offset of the given partition's log to the given offset.
     virtual ss::future<std::expected<void, errc>>
     set_start_offset(const model::topic_id_partition&, kafka::offset) = 0;
@@ -333,6 +322,24 @@ public:
     };
     using compaction_map_t
       = chunked_hash_map<model::topic_id_partition, compaction_update>;
+    using replace_epoch_map_t
+      = chunked_hash_map<model::topic_id_partition, compaction_epoch>;
+
+    // Adds the given objects to the metastore, expecting that the new
+    // extents replace an extent or set of extents covering the same range.
+    // It is expected that the set of new extents per partition covers a
+    // contiguous range of that partition's offset space.
+    //
+    // While these constraints aren't the only way we could ensure
+    // correctness, these simplify accounting and makes it easier to validate
+    // that we haven't lost data.
+    //
+    // The caller must supply expected_epochs: a map from each partition
+    // that has extents being replaced to the epoch value expected at time
+    // of application. Each successful call increments the stored epoch,
+    // enabling optimistic-concurrency detection by the next caller.
+    virtual ss::future<std::expected<void, errc>> replace_objects(
+      const object_metadata_builder&, const replace_epoch_map_t&) = 0;
 
     struct compaction_offsets_response {
         // Offset ranges whose keys have not been fully deduplicated from the

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -492,7 +492,7 @@ replicated_metastore::replace_objects(
     }
     for (auto& [partition_id, partition_objects] :
          replicated_builder.partitions_) {
-        rpc::replace_objects_no_compact_request req;
+        rpc::replace_objects_request req;
         req.metastore_partition = partition_id;
         chunked_vector<new_object> new_objects;
         for (auto& obj : partition_objects.finished_objects_) {
@@ -504,7 +504,7 @@ replicated_metastore::replace_objects(
             req.expected_epochs = std::move(it->second);
         }
         auto reply_fut = co_await ss::coroutine::as_future(
-          fe_.replace_objects_no_compact(std::move(req)));
+          fe_.replace_objects(std::move(req)));
         if (reply_fut.failed()) {
             auto ex = reply_fut.get_exception();
             vlog(cd_log.warn, "Error while sending request: {}", ex);

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -454,7 +454,8 @@ replicated_metastore::add_objects(
 
 ss::future<std::expected<void, metastore::errc>>
 replicated_metastore::replace_objects(
-  const metastore::object_metadata_builder& builder) {
+  const metastore::object_metadata_builder& builder,
+  const metastore::replace_epoch_map_t& epoch_map) {
     auto& replicated_builder = static_cast<const replicated_object_builder&>(
       builder);
 
@@ -467,20 +468,43 @@ replicated_metastore::replace_objects(
             co_return std::unexpected(metastore::errc::invalid_request);
         }
     }
+    chunked_hash_map<
+      model::partition_id,
+      chunked_hash_map<
+        model::topic_id_partition,
+        partition_state::compaction_epoch_t>>
+      epochs_by_partition;
+    for (const auto& [tp, epoch] : epoch_map) {
+        auto metastore_partition = fe_.metastore_partition(tp);
+        if (!metastore_partition) {
+            vlog(cd_log.warn, "Unable to get metastore partition for {}", tp);
+            co_return std::unexpected(errc::transport_error);
+        }
+        if (!replicated_builder.partitions_.contains(*metastore_partition)) {
+            vlog(
+              cd_log.error,
+              "Expected objects for partition {}",
+              *metastore_partition);
+            co_return std::unexpected(errc::invalid_request);
+        }
+        epochs_by_partition[*metastore_partition].emplace(
+          tp, partition_state::compaction_epoch_t{epoch()});
+    }
     for (auto& [partition_id, partition_objects] :
          replicated_builder.partitions_) {
-        rpc::replace_objects_request req;
+        rpc::replace_objects_no_compact_request req;
         req.metastore_partition = partition_id;
         chunked_vector<new_object> new_objects;
         for (auto& obj : partition_objects.finished_objects_) {
             new_objects.emplace_back(meta_to_rpc_obj(obj));
         }
         req.new_objects = std::move(new_objects);
-
-        // Empty compaction updates for basic replace
-        req.compaction_updates.clear();
+        auto it = epochs_by_partition.find(partition_id);
+        if (it != epochs_by_partition.end()) {
+            req.expected_epochs = std::move(it->second);
+        }
         auto reply_fut = co_await ss::coroutine::as_future(
-          fe_.replace_objects(std::move(req)));
+          fe_.replace_objects_no_compact(std::move(req)));
         if (reply_fut.failed()) {
             auto ex = reply_fut.get_exception();
             vlog(cd_log.warn, "Error while sending request: {}", ex);

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -756,7 +756,7 @@ replicated_metastore::compact_objects(
     }
     for (auto& [partition_id, partition_objects] :
          replicated_builder.partitions_) {
-        rpc::replace_objects_request req;
+        rpc::compact_objects_request req;
         req.metastore_partition = partition_id;
         chunked_vector<new_object> new_objects;
         for (auto& obj : partition_objects.finished_objects_) {
@@ -767,7 +767,7 @@ replicated_metastore::compact_objects(
         req.compaction_updates = std::move(
           compaction_updates_by_partition.at(partition_id));
         auto reply_fut = co_await ss::coroutine::as_future(
-          fe_.replace_objects(std::move(req)));
+          fe_.compact_objects(std::move(req)));
         if (reply_fut.failed()) {
             auto ex = reply_fut.get_exception();
             vlog(cd_log.warn, "Error while sending request: {}", ex);

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
@@ -44,8 +44,8 @@ public:
     ss::future<std::expected<add_response, errc>> add_objects(
       const object_metadata_builder&, const term_offset_map_t&) override;
 
-    ss::future<std::expected<void, errc>>
-    replace_objects(const object_metadata_builder&) override;
+    ss::future<std::expected<void, errc>> replace_objects(
+      const object_metadata_builder&, const replace_epoch_map_t&) override;
 
     ss::future<std::expected<void, errc>>
     set_start_offset(const model::topic_id_partition&, kafka::offset) override;

--- a/src/v/cloud_topics/level_one/metastore/rpc.json
+++ b/src/v/cloud_topics/level_one/metastore/rpc.json
@@ -23,8 +23,8 @@
         },
         {
             "name": "replace_objects_no_compact",
-            "input_type": "replace_objects_no_compact_request",
-            "output_type": "replace_objects_no_compact_reply"
+            "input_type": "replace_objects_request",
+            "output_type": "replace_objects_reply"
         },
         {
             "name": "get_first_offset_ge",

--- a/src/v/cloud_topics/level_one/metastore/rpc.json
+++ b/src/v/cloud_topics/level_one/metastore/rpc.json
@@ -17,6 +17,11 @@
             "output_type": "replace_objects_reply"
         },
         {
+            "name": "replace_objects_no_compact",
+            "input_type": "replace_objects_no_compact_request",
+            "output_type": "replace_objects_no_compact_reply"
+        },
+        {
             "name": "get_first_offset_ge",
             "input_type": "get_first_offset_ge_request",
             "output_type": "get_first_offset_ge_reply"

--- a/src/v/cloud_topics/level_one/metastore/rpc.json
+++ b/src/v/cloud_topics/level_one/metastore/rpc.json
@@ -12,9 +12,14 @@
             "output_type": "add_objects_reply"
         },
         {
-            "name": "replace_objects",
-            "input_type": "replace_objects_request",
-            "output_type": "replace_objects_reply"
+            "name": "compact_objects",
+            "input_type": "compact_objects_request",
+            "output_type": "compact_objects_reply",
+            "legacy_id": {
+                "name": "replace_objects",
+                "input_type": "replace_objects_request",
+                "output_type": "replace_objects_reply"
+            }
         },
         {
             "name": "replace_objects_no_compact",

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -87,21 +87,21 @@ struct compact_objects_request
       compaction_updates;
 };
 
-struct replace_objects_no_compact_reply
+struct replace_objects_reply
   : serde::envelope<
-      replace_objects_no_compact_reply,
+      replace_objects_reply,
       serde::version<0>,
       serde::compat_version<0>> {
     auto serde_fields() { return std::tie(ec); }
 
     errc ec;
 };
-struct replace_objects_no_compact_request
+struct replace_objects_request
   : serde::envelope<
-      replace_objects_no_compact_request,
+      replace_objects_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using resp_t = replace_objects_no_compact_reply;
+    using resp_t = replace_objects_reply;
     auto serde_fields() {
         return std::tie(metastore_partition, new_objects, expected_epochs);
     }

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -87,6 +87,33 @@ struct replace_objects_request
       compaction_updates;
 };
 
+struct replace_objects_no_compact_reply
+  : serde::envelope<
+      replace_objects_no_compact_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    auto serde_fields() { return std::tie(ec); }
+
+    errc ec;
+};
+struct replace_objects_no_compact_request
+  : serde::envelope<
+      replace_objects_no_compact_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using resp_t = replace_objects_no_compact_reply;
+    auto serde_fields() {
+        return std::tie(metastore_partition, new_objects, expected_epochs);
+    }
+
+    model::partition_id metastore_partition;
+    chunked_vector<new_object> new_objects;
+    chunked_hash_map<
+      model::topic_id_partition,
+      partition_state::compaction_epoch_t>
+      expected_epochs;
+};
+
 struct object_metadata
   : serde::
       envelope<object_metadata, serde::version<0>, serde::compat_version<0>> {

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -62,21 +62,21 @@ struct add_objects_request
     term_state_update_t new_terms;
 };
 
-struct replace_objects_reply
+struct compact_objects_reply
   : serde::envelope<
-      replace_objects_reply,
+      compact_objects_reply,
       serde::version<0>,
       serde::compat_version<0>> {
     auto serde_fields() { return std::tie(ec); }
 
     errc ec;
 };
-struct replace_objects_request
+struct compact_objects_request
   : serde::envelope<
-      replace_objects_request,
+      compact_objects_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using resp_t = replace_objects_reply;
+    using resp_t = compact_objects_reply;
     auto serde_fields() {
         return std::tie(metastore_partition, new_objects, compaction_updates);
     }

--- a/src/v/cloud_topics/level_one/metastore/service.cc
+++ b/src/v/cloud_topics/level_one/metastore/service.cc
@@ -27,10 +27,9 @@ service::add_objects(add_objects_request request, ::rpc::streaming_context&) {
       std::move(request), leader_router::local_only::yes);
 }
 
-ss::future<replace_objects_no_compact_reply>
-service::replace_objects_no_compact(
-  replace_objects_no_compact_request request, ::rpc::streaming_context&) {
-    return _leader_router->local().replace_objects_no_compact(
+ss::future<replace_objects_reply> service::replace_objects_no_compact(
+  replace_objects_request request, ::rpc::streaming_context&) {
+    return _leader_router->local().replace_objects(
       std::move(request), leader_router::local_only::yes);
 }
 

--- a/src/v/cloud_topics/level_one/metastore/service.cc
+++ b/src/v/cloud_topics/level_one/metastore/service.cc
@@ -27,6 +27,13 @@ service::add_objects(add_objects_request request, ::rpc::streaming_context&) {
       std::move(request), leader_router::local_only::yes);
 }
 
+ss::future<replace_objects_no_compact_reply>
+service::replace_objects_no_compact(
+  replace_objects_no_compact_request request, ::rpc::streaming_context&) {
+    return _leader_router->local().replace_objects_no_compact(
+      std::move(request), leader_router::local_only::yes);
+}
+
 ss::future<replace_objects_reply> service::replace_objects(
   replace_objects_request request, ::rpc::streaming_context&) {
     return _leader_router->local().replace_objects(

--- a/src/v/cloud_topics/level_one/metastore/service.cc
+++ b/src/v/cloud_topics/level_one/metastore/service.cc
@@ -34,9 +34,9 @@ service::replace_objects_no_compact(
       std::move(request), leader_router::local_only::yes);
 }
 
-ss::future<replace_objects_reply> service::replace_objects(
-  replace_objects_request request, ::rpc::streaming_context&) {
-    return _leader_router->local().replace_objects(
+ss::future<compact_objects_reply> service::compact_objects(
+  compact_objects_request request, ::rpc::streaming_context&) {
+    return _leader_router->local().compact_objects(
       std::move(request), leader_router::local_only::yes);
 }
 

--- a/src/v/cloud_topics/level_one/metastore/service.h
+++ b/src/v/cloud_topics/level_one/metastore/service.h
@@ -29,8 +29,8 @@ public:
     ss::future<add_objects_reply>
     add_objects(add_objects_request, ::rpc::streaming_context&) override;
 
-    ss::future<replace_objects_no_compact_reply> replace_objects_no_compact(
-      replace_objects_no_compact_request, ::rpc::streaming_context&) override;
+    ss::future<replace_objects_reply> replace_objects_no_compact(
+      replace_objects_request, ::rpc::streaming_context&) override;
 
     ss::future<compact_objects_reply> compact_objects(
       compact_objects_request, ::rpc::streaming_context&) override;

--- a/src/v/cloud_topics/level_one/metastore/service.h
+++ b/src/v/cloud_topics/level_one/metastore/service.h
@@ -29,6 +29,9 @@ public:
     ss::future<add_objects_reply>
     add_objects(add_objects_request, ::rpc::streaming_context&) override;
 
+    ss::future<replace_objects_no_compact_reply> replace_objects_no_compact(
+      replace_objects_no_compact_request, ::rpc::streaming_context&) override;
+
     ss::future<replace_objects_reply> replace_objects(
       replace_objects_request, ::rpc::streaming_context&) override;
 

--- a/src/v/cloud_topics/level_one/metastore/service.h
+++ b/src/v/cloud_topics/level_one/metastore/service.h
@@ -32,8 +32,8 @@ public:
     ss::future<replace_objects_no_compact_reply> replace_objects_no_compact(
       replace_objects_no_compact_request, ::rpc::streaming_context&) override;
 
-    ss::future<replace_objects_reply> replace_objects(
-      replace_objects_request, ::rpc::streaming_context&) override;
+    ss::future<compact_objects_reply> compact_objects(
+      compact_objects_request, ::rpc::streaming_context&) override;
 
     ss::future<set_start_offset_reply> set_start_offset(
       set_start_offset_request, ::rpc::streaming_context&) override;

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -284,7 +284,7 @@ simple_metastore::replace_objects(
     for (const auto& [tp, epoch] : epoch_map) {
         expected_epochs[tp] = partition_state::compaction_epoch_t{epoch()};
     }
-    auto update_res = replace_objects_no_compact_update::build(
+    auto update_res = replace_objects_update::build(
       state_, std::move(new_objects), std::move(expected_epochs));
     if (!update_res.has_value()) {
         vlog(cd_log.debug, "Object replacement failed: {}", update_res.error());

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -255,7 +255,8 @@ simple_metastore::add_objects(
 
 ss::future<std::expected<void, metastore::errc>>
 simple_metastore::replace_objects(
-  const metastore::object_metadata_builder& builder) {
+  const metastore::object_metadata_builder& builder,
+  const replace_epoch_map_t& epoch_map) {
     auto& simple_builder = dynamic_cast<const simple_object_builder&>(builder);
     if (!simple_builder.pending_objects_.empty()) {
         vlog(
@@ -264,18 +265,27 @@ simple_metastore::replace_objects(
           simple_builder.pending_objects_.size());
         co_return std::unexpected(metastore::errc::invalid_request);
     }
-    co_return co_await replace_objects(simple_builder.finished_objects_);
+    co_return co_await replace_objects(
+      simple_builder.finished_objects_, epoch_map);
 }
 
 ss::future<std::expected<void, metastore::errc>>
 simple_metastore::replace_objects(
-  const chunked_vector<object_metadata>& objects) {
+  const chunked_vector<object_metadata>& objects,
+  const replace_epoch_map_t& epoch_map) {
     chunked_vector<new_object> new_objects;
     for (const auto& o : objects) {
         new_objects.emplace_back(make_new_object(o));
     }
-    auto update_res = replace_objects_update::build(
-      state_, std::move(new_objects));
+    chunked_hash_map<
+      model::topic_id_partition,
+      partition_state::compaction_epoch_t>
+      expected_epochs;
+    for (const auto& [tp, epoch] : epoch_map) {
+        expected_epochs[tp] = partition_state::compaction_epoch_t{epoch()};
+    }
+    auto update_res = replace_objects_no_compact_update::build(
+      state_, std::move(new_objects), std::move(expected_epochs));
     if (!update_res.has_value()) {
         vlog(cd_log.debug, "Object replacement failed: {}", update_res.error());
         co_return std::unexpected(metastore::errc::invalid_request);

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -558,7 +558,7 @@ simple_metastore::compact_objects(
         compaction_updates[tp] = std::move(p_update);
     }
 
-    auto update_res = replace_objects_update::build(
+    auto update_res = compact_objects_update::build(
       state_, std::move(new_objects), std::move(compaction_updates));
     if (!update_res.has_value()) {
         vlog(cd_log.debug, "Object replacement failed: {}", update_res.error());

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -70,10 +70,10 @@ public:
     ss::future<std::expected<add_response, errc>> add_objects(
       const chunked_vector<object_metadata>&, const term_offset_map_t&);
 
-    ss::future<std::expected<void, errc>>
-    replace_objects(const object_metadata_builder&) override;
-    ss::future<std::expected<void, errc>>
-    replace_objects(const chunked_vector<object_metadata>&);
+    ss::future<std::expected<void, errc>> replace_objects(
+      const object_metadata_builder&, const replace_epoch_map_t&) override;
+    ss::future<std::expected<void, errc>> replace_objects(
+      const chunked_vector<object_metadata>&, const replace_epoch_map_t&);
 
     ss::future<std::expected<void, errc>>
     set_start_offset(const model::topic_id_partition&, kafka::offset) override;

--- a/src/v/cloud_topics/level_one/metastore/simple_stm.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_stm.cc
@@ -142,9 +142,8 @@ ss::future<> simple_stm::do_apply(const model::record_batch& batch) {
             maybe_log_update_error(_log, key, o, result);
             break;
         }
-        case update_key::replace_objects_no_compact: {
-            auto update = serde::read<replace_objects_no_compact_update>(
-              value_parser);
+        case update_key::replace_objects: {
+            auto update = serde::read<replace_objects_update>(value_parser);
             auto result = update.apply(state_);
             maybe_log_update_error(_log, key, o, result);
             break;

--- a/src/v/cloud_topics/level_one/metastore/simple_stm.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_stm.cc
@@ -142,6 +142,13 @@ ss::future<> simple_stm::do_apply(const model::record_batch& batch) {
             maybe_log_update_error(_log, key, o, result);
             break;
         }
+        case update_key::replace_objects_no_compact: {
+            auto update = serde::read<replace_objects_no_compact_update>(
+              value_parser);
+            auto result = update.apply(state_);
+            maybe_log_update_error(_log, key, o, result);
+            break;
+        }
         case update_key::set_start_offset: {
             auto update = serde::read<set_start_offset_update>(value_parser);
             auto result = update.apply(state_);

--- a/src/v/cloud_topics/level_one/metastore/simple_stm.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_stm.cc
@@ -136,8 +136,8 @@ ss::future<> simple_stm::do_apply(const model::record_batch& batch) {
             maybe_log_update_error(_log, key, o, result);
             break;
         }
-        case update_key::replace_objects: {
-            auto update = serde::read<replace_objects_update>(value_parser);
+        case update_key::compact_objects: {
+            auto update = serde::read<compact_objects_update>(value_parser);
             auto result = update.apply(state_);
             maybe_log_update_error(_log, key, o, result);
             break;

--- a/src/v/cloud_topics/level_one/metastore/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update.cc
@@ -753,6 +753,21 @@ replace_objects_update::can_apply(const state& state) {
         }
     }
 
+    // Every partition with new extents must have a compaction_update entry
+    // so its expected_compaction_epoch can be validated. Without this,
+    // callers could silently bump epochs without OCC.
+    for (const auto& [tidp, _] : new_extents_by_tp) {
+        auto t_it = compaction_updates.find(tidp.topic_id);
+        if (
+          t_it == compaction_updates.end()
+          || !t_it->second.contains(tidp.partition)) {
+            return std::unexpected(stm_update_error(
+              fmt::format(
+                "Partition {} has new extents but no compaction_update entry",
+                tidp)));
+        }
+    }
+
     return std::monostate{};
 }
 

--- a/src/v/cloud_topics/level_one/metastore/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update.cc
@@ -536,7 +536,7 @@ add_objects_update::apply(state& state) {
 }
 
 std::expected<std::monostate, stm_update_error>
-replace_objects_no_compact_update::can_apply(const state& state) {
+replace_objects_update::can_apply(const state& state) {
     auto layout_res = validate_new_objects_layout(state, new_objects);
     if (!layout_res.has_value()) {
         return std::unexpected(layout_res.error());
@@ -589,7 +589,7 @@ replace_objects_no_compact_update::can_apply(const state& state) {
 }
 
 std::expected<std::monostate, stm_update_error>
-replace_objects_no_compact_update::apply(state& state) {
+replace_objects_update::apply(state& state) {
     auto allowed = can_apply(state);
     if (!allowed.has_value()) {
         return std::unexpected(allowed.error());
@@ -599,8 +599,8 @@ replace_objects_no_compact_update::apply(state& state) {
     return std::monostate{};
 }
 
-std::expected<replace_objects_no_compact_update, stm_update_error>
-replace_objects_no_compact_update::build(
+std::expected<replace_objects_update, stm_update_error>
+replace_objects_update::build(
   const state& state,
   chunked_vector<new_object> objects,
   chunked_hash_map<
@@ -615,7 +615,7 @@ replace_objects_no_compact_update::build(
     for (auto& [tp, epoch] : flat_expected_epochs) {
         expected_epochs[tp.topic_id][tp.partition] = epoch;
     }
-    replace_objects_no_compact_update update{
+    replace_objects_update update{
       .new_objects = std::move(objects),
       .expected_epochs = std::move(expected_epochs),
     };

--- a/src/v/cloud_topics/level_one/metastore/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update.cc
@@ -536,6 +536,97 @@ add_objects_update::apply(state& state) {
 }
 
 std::expected<std::monostate, stm_update_error>
+replace_objects_no_compact_update::can_apply(const state& state) {
+    auto layout_res = validate_new_objects_layout(state, new_objects);
+    if (!layout_res.has_value()) {
+        return std::unexpected(layout_res.error());
+    }
+    const auto& new_extents_by_tp = layout_res.value();
+
+    // Bidirectional invariant: expected_epochs entries must match new extents.
+    for (const auto& [t, p_epochs] : expected_epochs) {
+        for (const auto& [p, _] : p_epochs) {
+            model::topic_id_partition tidp{t, p};
+            if (!new_extents_by_tp.contains(tidp)) {
+                return std::unexpected(stm_update_error(
+                  fmt::format(
+                    "expected_epochs entry for {} does not refer to a "
+                    "partition with new extents",
+                    tidp)));
+            }
+        }
+    }
+    for (const auto& [tidp, _] : new_extents_by_tp) {
+        const auto& t = tidp.topic_id;
+        const auto& p = tidp.partition;
+        auto t_it = expected_epochs.find(t);
+        if (t_it == expected_epochs.end() || !t_it->second.contains(p)) {
+            return std::unexpected(stm_update_error(
+              fmt::format(
+                "Partition {} has new extents but no expected_epochs entry",
+                tidp)));
+        }
+        // Validate epoch.
+        auto p_state = state.partition_state(tidp);
+        if (!p_state) {
+            return std::unexpected(stm_update_error(
+              fmt::format("Partition {} not tracked by state", tidp)));
+        }
+        auto expected_epoch = t_it->second.at(p);
+        const auto& current_epoch = p_state->get().compaction_epoch;
+        if (expected_epoch != current_epoch) {
+            return std::unexpected(stm_update_error(
+              fmt::format(
+                "Expected compaction epoch {} does not match the current "
+                "compaction epoch {} for {}",
+                expected_epoch,
+                current_epoch,
+                tidp)));
+        }
+    }
+
+    return std::monostate{};
+}
+
+std::expected<std::monostate, stm_update_error>
+replace_objects_no_compact_update::apply(state& state) {
+    auto allowed = can_apply(state);
+    if (!allowed.has_value()) {
+        return std::unexpected(allowed.error());
+    }
+    apply_new_objects_replacement(state, new_objects);
+
+    return std::monostate{};
+}
+
+std::expected<replace_objects_no_compact_update, stm_update_error>
+replace_objects_no_compact_update::build(
+  const state& state,
+  chunked_vector<new_object> objects,
+  chunked_hash_map<
+    model::topic_id_partition,
+    partition_state::compaction_epoch_t> flat_expected_epochs) {
+    chunked_hash_map<
+      model::topic_id,
+      chunked_hash_map<
+        model::partition_id,
+        partition_state::compaction_epoch_t>>
+      expected_epochs;
+    for (auto& [tp, epoch] : flat_expected_epochs) {
+        expected_epochs[tp.topic_id][tp.partition] = epoch;
+    }
+    replace_objects_no_compact_update update{
+      .new_objects = std::move(objects),
+      .expected_epochs = std::move(expected_epochs),
+    };
+    auto allowed = update.can_apply(state);
+    if (!allowed.has_value()) {
+        return std::unexpected(allowed.error());
+    }
+    return update;
+}
+
+std::expected<std::monostate, stm_update_error>
 replace_objects_update::can_apply(const state& state) {
     auto layout_res = validate_new_objects_layout(state, new_objects);
     if (!layout_res.has_value()) {

--- a/src/v/cloud_topics/level_one/metastore/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update.cc
@@ -627,7 +627,7 @@ replace_objects_no_compact_update::build(
 }
 
 std::expected<std::monostate, stm_update_error>
-replace_objects_update::can_apply(const state& state) {
+compact_objects_update::can_apply(const state& state) {
     auto layout_res = validate_new_objects_layout(state, new_objects);
     if (!layout_res.has_value()) {
         return std::unexpected(layout_res.error());
@@ -772,7 +772,7 @@ replace_objects_update::can_apply(const state& state) {
 }
 
 std::expected<std::monostate, stm_update_error>
-replace_objects_update::apply(state& state) {
+compact_objects_update::apply(state& state) {
     auto allowed = can_apply(state);
     if (!allowed.has_value()) {
         return std::unexpected(allowed.error());
@@ -841,8 +841,8 @@ replace_objects_update::apply(state& state) {
     return std::monostate{};
 }
 
-std::expected<replace_objects_update, stm_update_error>
-replace_objects_update::build(
+std::expected<compact_objects_update, stm_update_error>
+compact_objects_update::build(
   const state& state,
   chunked_vector<new_object> objects,
   chunked_hash_map<model::topic_id_partition, compaction_state_update>
@@ -854,7 +854,7 @@ replace_objects_update::build(
     for (auto& [tp, update] : compaction_updates) {
         cmp_state_updates[tp.topic_id][tp.partition] = std::move(update);
     }
-    replace_objects_update update{
+    compact_objects_update update{
       .new_objects = std::move(objects),
       .compaction_updates = std::move(cmp_state_updates),
     };

--- a/src/v/cloud_topics/level_one/metastore/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update.cc
@@ -84,6 +84,172 @@ void remove_extents_below_start_offset_for_tp(
     }
 }
 
+// Validates the basic shape of new_objects against the state:
+// - non-empty
+// - every object is pre-registered and not yet finalized
+// - extents are not inverted (base <= last)
+// - extents form contiguous intervals per partition
+// - each interval aligns with existing partition extents at the right offsets
+//
+// Returns the populated extent map on success so callers can drive
+// subsequent per-partition work (epoch checks, cleaned-range validation,
+// etc.) without recomputing it.
+std::expected<sorted_extents_by_tidp_t, stm_update_error>
+validate_new_objects_layout(
+  const state& state, const chunked_vector<new_object>& new_objects) {
+    if (new_objects.empty()) {
+        return std::unexpected(stm_update_error{"No objects requested"});
+    }
+    sorted_extents_by_tidp_t new_extents_by_tp;
+    for (const auto& o : new_objects) {
+        auto it = state.objects.find(o.oid);
+        if (it == state.objects.end()) {
+            return std::unexpected(
+              stm_update_error{
+                fmt::format("Object {} not pre-registered", o.oid)});
+        }
+        if (!it->second.is_preregistration) {
+            return std::unexpected(
+              stm_update_error{fmt::format("Object {} already exists", o.oid)});
+        }
+        o.collect_extents_by_tidp(&new_extents_by_tp);
+    }
+    for (const auto& [tidp, extents] : new_extents_by_tp) {
+        for (const auto& extent : extents) {
+            if (extent.base_offset > extent.last_offset) {
+                return std::unexpected(stm_update_error(
+                  fmt::format(
+                    "Input object has inverted extent for partition {}: "
+                    "base_offset {} > last_offset {}",
+                    tidp,
+                    extent.base_offset,
+                    extent.last_offset)));
+            }
+        }
+    }
+
+    auto contiguous_intervals_by_tp = contiguous_intervals_for_extents(
+      new_extents_by_tp);
+    if (!contiguous_intervals_by_tp.has_value()) {
+        return std::unexpected(
+          stm_update_error(contiguous_intervals_by_tp.error()));
+    }
+
+    for (const auto& [tidp, intervals] : contiguous_intervals_by_tp.value()) {
+        for (const auto& interval : intervals) {
+            auto req_base = interval.base_offset;
+            auto req_last = interval.last_offset;
+
+            auto p_state = state.partition_state(tidp);
+            if (!p_state) {
+                return std::unexpected(stm_update_error(
+                  fmt::format("Partition {} not tracked by state", tidp)));
+            }
+
+            // Check that the new range's offset aligns with existing extents
+            // above the log's start offset.
+            const auto& prt = p_state->get();
+            auto iters = get_range(
+              prt.extents, req_base, req_last, prt.start_offset);
+            if (!iters.has_value()) {
+                return std::unexpected(stm_update_error(
+                  fmt::format(
+                    "Partition {} doesn't contain extents that span exactly "
+                    "[{}, {}]",
+                    tidp,
+                    req_base,
+                    req_last)));
+            }
+        }
+    }
+    return new_extents_by_tp;
+}
+
+// Applies the extent-replacement portion shared by compact_objects_update
+// and replace_objects_update: marks new_objects as finalized in
+// state.objects, removes the old extents the new ones replace, inserts
+// the new extents, and prunes anything below the partition's start
+// offset.
+//
+// Returns the populated extent map for callers that need it.
+sorted_extents_by_tidp_t apply_new_objects_replacement(
+  state& state, const chunked_vector<new_object>& new_objects) {
+    sorted_extents_by_tidp_t new_extents_by_tp;
+    for (const auto& o : new_objects) {
+        o.collect_extents_by_tidp(&new_extents_by_tp);
+        state.objects[o.oid] = object_entry{
+          .total_data_size = 0,
+          .removed_data_size = 0,
+          .footer_pos = o.footer_pos,
+          .object_size = o.object_size,
+          .last_updated = model::timestamp::now(),
+          .is_preregistration = false,
+        };
+    }
+
+    auto contiguous_intervals_by_tp
+      = contiguous_intervals_for_extents(new_extents_by_tp).value();
+
+    for (const auto& [tidp, intervals] : contiguous_intervals_by_tp) {
+        auto& p_state
+          = state.topic_to_state[tidp.topic_id].pid_to_state[tidp.partition];
+        for (const auto& interval : intervals) {
+            auto requested_base = interval.base_offset;
+            auto requested_last = interval.last_offset;
+            auto iters = get_range(
+              p_state.extents,
+              requested_base,
+              requested_last,
+              p_state.start_offset);
+            auto [base_it, last_it] = *iters;
+            auto end_it = std::next(last_it);
+            for (auto iter = base_it; iter != end_it; ++iter) {
+                auto& old_extent = *iter;
+                state.objects[old_extent.oid].removed_data_size
+                  += old_extent.len;
+                vlog(
+                  cd_log.debug,
+                  "Removing extent of {} in {} [{}, {}]",
+                  tidp,
+                  old_extent.oid,
+                  old_extent.base_offset,
+                  old_extent.last_offset);
+            }
+
+            p_state.extents.erase(base_it, end_it);
+        }
+    }
+
+    for (const auto& [tidp, new_extents] : new_extents_by_tp) {
+        auto& p_state
+          = state.topic_to_state[tidp.topic_id].pid_to_state[tidp.partition];
+        // NOTE: we don't need to update the start or next offsets since we've
+        // validated that the new extents replace exact ranges.
+
+        for (const auto& e : new_extents) {
+            p_state.extents.emplace(e);
+            vlog(
+              cd_log.debug,
+              "Adding replacement extent of {} in {} [{}, {}]",
+              tidp,
+              e.oid,
+              e.base_offset,
+              e.last_offset);
+        }
+
+        for (const auto& extent : new_extents) {
+            state.objects[extent.oid].total_data_size += extent.len;
+        }
+    }
+
+    for (const auto& [tidp, _] : new_extents_by_tp) {
+        remove_extents_below_start_offset_for_tp(
+          state, tidp, "Added replacement below start offset");
+    }
+
+    return new_extents_by_tp;
+}
+
 } // namespace
 
 size_t
@@ -371,74 +537,11 @@ add_objects_update::apply(state& state) {
 
 std::expected<std::monostate, stm_update_error>
 replace_objects_update::can_apply(const state& state) {
-    if (new_objects.empty()) {
-        return std::unexpected(stm_update_error{"No objects requested"});
+    auto layout_res = validate_new_objects_layout(state, new_objects);
+    if (!layout_res.has_value()) {
+        return std::unexpected(layout_res.error());
     }
-    sorted_extents_by_tidp_t new_extents_by_tp;
-    for (const auto& o : new_objects) {
-        auto it = state.objects.find(o.oid);
-        if (it == state.objects.end()) {
-            return std::unexpected(
-              stm_update_error{
-                fmt::format("Object {} not pre-registered", o.oid)});
-        }
-        if (!it->second.is_preregistration) {
-            return std::unexpected(
-              stm_update_error{fmt::format("Object {} already exists", o.oid)});
-        }
-        o.collect_extents_by_tidp(&new_extents_by_tp);
-    }
-    for (const auto& [tidp, extents] : new_extents_by_tp) {
-        for (const auto& extent : extents) {
-            if (extent.base_offset > extent.last_offset) {
-                return std::unexpected(stm_update_error(
-                  fmt::format(
-                    "Input object has inverted extent for partition {}: "
-                    "base_offset {} > last_offset {}",
-                    tidp,
-                    extent.base_offset,
-                    extent.last_offset)));
-            }
-        }
-    }
-
-    auto contiguous_intervals_by_tp = contiguous_intervals_for_extents(
-      new_extents_by_tp);
-    if (!contiguous_intervals_by_tp.has_value()) {
-        return std::unexpected(
-          stm_update_error(contiguous_intervals_by_tp.error()));
-    }
-
-    for (const auto& [tidp, intervals] : contiguous_intervals_by_tp.value()) {
-        for (const auto& interval : intervals) {
-            auto req_base = interval.base_offset;
-            auto req_last = interval.last_offset;
-
-            auto p_state = state.partition_state(tidp);
-            if (!p_state) {
-                return std::unexpected(stm_update_error(
-                  fmt::format("Partition {} not tracked by state", tidp)));
-            }
-
-            // Check that the new range's offset aligns with existing extents
-            // above the log's start offset.
-            const auto& prt = p_state->get();
-            auto iters = get_range(
-              prt.extents, req_base, req_last, prt.start_offset);
-            if (!iters.has_value()) {
-                return std::unexpected(stm_update_error(
-                  fmt::format(
-                    "Partition {} doesn't contain extents that span exactly "
-                    "[{}, {}]",
-                    tidp,
-                    req_base,
-                    req_last)));
-            }
-        }
-    }
-    if (compaction_updates.empty()) {
-        return std::monostate{};
-    }
+    const auto& new_extents_by_tp = layout_res.value();
 
     for (const auto& [t, t_req] : compaction_updates) {
         for (const auto& [p, compaction_update] : t_req) {
@@ -558,6 +661,7 @@ replace_objects_update::can_apply(const state& state) {
             }
         }
     }
+
     return std::monostate{};
 }
 
@@ -567,78 +671,7 @@ replace_objects_update::apply(state& state) {
     if (!allowed.has_value()) {
         return std::unexpected(allowed.error());
     }
-    sorted_extents_by_tidp_t new_extents_by_tp;
-    for (const auto& o : new_objects) {
-        o.collect_extents_by_tidp(&new_extents_by_tp);
-        state.objects[o.oid] = object_entry{
-          .total_data_size = 0,
-          .removed_data_size = 0,
-          .footer_pos = o.footer_pos,
-          .object_size = o.object_size,
-          .last_updated = model::timestamp::now(),
-          .is_preregistration = false,
-        };
-    }
-
-    auto contiguous_intervals_by_tp
-      = contiguous_intervals_for_extents(new_extents_by_tp).value();
-
-    for (const auto& [tidp, intervals] : contiguous_intervals_by_tp) {
-        auto& p_state
-          = state.topic_to_state[tidp.topic_id].pid_to_state[tidp.partition];
-        for (const auto& interval : intervals) {
-            auto requested_base = interval.base_offset;
-            auto requested_last = interval.last_offset;
-            auto iters = get_range(
-              p_state.extents,
-              requested_base,
-              requested_last,
-              p_state.start_offset);
-            auto [base_it, last_it] = *iters;
-            auto end_it = std::next(last_it);
-            for (auto iter = base_it; iter != end_it; ++iter) {
-                auto& old_extent = *iter;
-                state.objects[old_extent.oid].removed_data_size
-                  += old_extent.len;
-                vlog(
-                  cd_log.debug,
-                  "Removing extent of {} in {} [{}, {}]",
-                  tidp,
-                  old_extent.oid,
-                  old_extent.base_offset,
-                  old_extent.last_offset);
-            }
-
-            p_state.extents.erase(base_it, end_it);
-        }
-    }
-
-    for (const auto& [tidp, new_extents] : new_extents_by_tp) {
-        auto& p_state
-          = state.topic_to_state[tidp.topic_id].pid_to_state[tidp.partition];
-        // NOTE: we don't need to update the start or next offsets since we've
-        // validated that the new extents replace exact ranges.
-
-        for (const auto& e : new_extents) {
-            p_state.extents.emplace(e);
-            vlog(
-              cd_log.debug,
-              "Adding replacement extent of {} in {} [{}, {}]",
-              tidp,
-              e.oid,
-              e.base_offset,
-              e.last_offset);
-        }
-
-        for (const auto& extent : new_extents) {
-            state.objects[extent.oid].total_data_size += extent.len;
-        }
-    }
-
-    for (const auto& [tidp, _] : new_extents_by_tp) {
-        remove_extents_below_start_offset_for_tp(
-          state, tidp, "Added replacement below start offset");
-    }
+    auto new_extents_by_tp = apply_new_objects_replacement(state, new_objects);
 
     for (const auto& [t, t_req] : compaction_updates) {
         for (const auto& [p, compaction_update] : t_req) {
@@ -698,6 +731,7 @@ replace_objects_update::apply(state& state) {
             ++p_state.compaction_epoch;
         }
     }
+
     return std::monostate{};
 }
 

--- a/src/v/cloud_topics/level_one/metastore/state_update.h
+++ b/src/v/cloud_topics/level_one/metastore/state_update.h
@@ -165,7 +165,10 @@ struct replace_objects_update
 
     chunked_vector<new_object> new_objects;
 
-    // The new cleaned ranges that are represented in 'new_objects', if any.
+    // Per-partition compaction-state updates. Every partition with new
+    // extents MUST have an entry here; can_apply enforces this so callers
+    // can't silently bump compaction_epoch without also passing the OCC
+    // epoch via expected_compaction_epoch.
     chunked_hash_map<
       model::topic_id,
       chunked_hash_map<model::partition_id, compaction_state_update>>

--- a/src/v/cloud_topics/level_one/metastore/state_update.h
+++ b/src/v/cloud_topics/level_one/metastore/state_update.h
@@ -29,7 +29,7 @@ enum class update_key : uint8_t {
     remove_topics = 4,
     preregister_objects = 5,
     expire_preregistered_objects = 6,
-    replace_objects_no_compact = 7,
+    replace_objects = 7,
 };
 
 using stm_update_error = named_type<ss::sstring, struct update_error_tag>;
@@ -175,19 +175,17 @@ struct compact_objects_update
       compaction_updates;
 };
 
-struct replace_objects_no_compact_update
+struct replace_objects_update
   : public serde::envelope<
-      replace_objects_no_compact_update,
+      replace_objects_update,
       serde::version<0>,
       serde::compat_version<0>> {
     friend bool operator==(
-      const replace_objects_no_compact_update&,
-      const replace_objects_no_compact_update&) = default;
+      const replace_objects_update&, const replace_objects_update&) = default;
     auto serde_fields() { return std::tie(new_objects, expected_epochs); }
 
-    static constexpr auto key{update_key::replace_objects_no_compact};
-    static std::expected<replace_objects_no_compact_update, stm_update_error>
-    build(
+    static constexpr auto key{update_key::replace_objects};
+    static std::expected<replace_objects_update, stm_update_error> build(
       const state&,
       chunked_vector<new_object>,
       chunked_hash_map<
@@ -336,9 +334,8 @@ struct fmt::formatter<cloud_topics::l1::update_key> final
         case cloud_topics::l1::update_key::expire_preregistered_objects:
             return formatter<string_view>::format(
               "expire_preregistered_objects", ctx);
-        case cloud_topics::l1::update_key::replace_objects_no_compact:
-            return formatter<string_view>::format(
-              "replace_objects_no_compact", ctx);
+        case cloud_topics::l1::update_key::replace_objects:
+            return formatter<string_view>::format("replace_objects", ctx);
         }
     }
 };

--- a/src/v/cloud_topics/level_one/metastore/state_update.h
+++ b/src/v/cloud_topics/level_one/metastore/state_update.h
@@ -29,6 +29,7 @@ enum class update_key : uint8_t {
     remove_topics = 4,
     preregister_objects = 5,
     expire_preregistered_objects = 6,
+    replace_objects_no_compact = 7,
 };
 
 using stm_update_error = named_type<ss::sstring, struct update_error_tag>;
@@ -171,6 +172,41 @@ struct replace_objects_update
       compaction_updates;
 };
 
+struct replace_objects_no_compact_update
+  : public serde::envelope<
+      replace_objects_no_compact_update,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    friend bool operator==(
+      const replace_objects_no_compact_update&,
+      const replace_objects_no_compact_update&) = default;
+    auto serde_fields() { return std::tie(new_objects, expected_epochs); }
+
+    static constexpr auto key{update_key::replace_objects_no_compact};
+    static std::expected<replace_objects_no_compact_update, stm_update_error>
+    build(
+      const state&,
+      chunked_vector<new_object>,
+      chunked_hash_map<
+        model::topic_id_partition,
+        partition_state::compaction_epoch_t>);
+
+    std::expected<std::monostate, stm_update_error> can_apply(const state&);
+    std::expected<std::monostate, stm_update_error> apply(state&);
+
+    chunked_vector<new_object> new_objects;
+    // Per-partition expected compaction epoch. Every partition whose
+    // extents appear in new_objects MUST have an entry here; the build
+    // and can_apply enforce this. apply increments each partition's
+    // compaction_epoch by 1.
+    chunked_hash_map<
+      model::topic_id,
+      chunked_hash_map<
+        model::partition_id,
+        partition_state::compaction_epoch_t>>
+      expected_epochs;
+};
+
 struct set_start_offset_update
   : public serde::envelope<
       set_start_offset_update,
@@ -297,6 +333,9 @@ struct fmt::formatter<cloud_topics::l1::update_key> final
         case cloud_topics::l1::update_key::expire_preregistered_objects:
             return formatter<string_view>::format(
               "expire_preregistered_objects", ctx);
+        case cloud_topics::l1::update_key::replace_objects_no_compact:
+            return formatter<string_view>::format(
+              "replace_objects_no_compact", ctx);
         }
     }
 };

--- a/src/v/cloud_topics/level_one/metastore/state_update.h
+++ b/src/v/cloud_topics/level_one/metastore/state_update.h
@@ -23,7 +23,7 @@ namespace cloud_topics::l1 {
 
 enum class update_key : uint8_t {
     add_objects = 0,
-    replace_objects = 1,
+    compact_objects = 1,
     set_start_offset = 2,
     remove_objects = 3,
     remove_topics = 4,
@@ -144,17 +144,17 @@ struct compaction_state_update
     partition_state::compaction_epoch_t expected_compaction_epoch;
 };
 
-struct replace_objects_update
+struct compact_objects_update
   : public serde::envelope<
-      replace_objects_update,
+      compact_objects_update,
       serde::version<0>,
       serde::compat_version<0>> {
     friend bool operator==(
-      const replace_objects_update&, const replace_objects_update&) = default;
+      const compact_objects_update&, const compact_objects_update&) = default;
     auto serde_fields() { return std::tie(new_objects, compaction_updates); }
 
-    static constexpr auto key{update_key::replace_objects};
-    static std::expected<replace_objects_update, stm_update_error> build(
+    static constexpr auto key{update_key::compact_objects};
+    static std::expected<compact_objects_update, stm_update_error> build(
       const state&,
       chunked_vector<new_object>,
       chunked_hash_map<model::topic_id_partition, compaction_state_update>
@@ -323,8 +323,8 @@ struct fmt::formatter<cloud_topics::l1::update_key> final
         switch (k) {
         case cloud_topics::l1::update_key::add_objects:
             return formatter<string_view>::format("add_objects", ctx);
-        case cloud_topics::l1::update_key::replace_objects:
-            return formatter<string_view>::format("replace_objects", ctx);
+        case cloud_topics::l1::update_key::compact_objects:
+            return formatter<string_view>::format("compact_objects", ctx);
         case cloud_topics::l1::update_key::set_start_offset:
             return formatter<string_view>::format("set_start_offset", ctx);
         case cloud_topics::l1::update_key::remove_objects:

--- a/src/v/cloud_topics/level_one/metastore/tests/builders.h
+++ b/src/v/cloud_topics/level_one/metastore/tests/builders.h
@@ -104,4 +104,19 @@ private:
     cmap_t out;
 };
 
+/// Returns a replace_epoch_map_t covering every partition in `objects` at
+/// the given epoch (default 0). Used to satisfy the replace_objects() API
+/// in tests that don't exercise epoch validation.
+inline metastore::replace_epoch_map_t make_epoch_map(
+  const om_list_t& objects,
+  metastore::compaction_epoch epoch = metastore::compaction_epoch{0}) {
+    metastore::replace_epoch_map_t out;
+    for (const auto& obj : objects) {
+        for (const auto& ntp : obj.ntp_metas) {
+            out.try_emplace(ntp.tidp, epoch);
+        }
+    }
+    return out;
+}
+
 } // namespace cloud_topics::l1::test_utils

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -1180,6 +1180,99 @@ TEST_P(ReplicatedMetastoreTest, TestRestoreCreatesCorrectPartitionCount) {
     ASSERT_EQ(cfg->partition_count, expected_partitions);
 }
 
+TEST_P(ReplicatedMetastoreTest, TestReplaceObjectsRejectsEpoch) {
+    auto& app = get_ct_app(model::node_id{0});
+    auto& meta = app.get_sharded_replicated_metastore()->local();
+
+    // Add initial objects for one partition.
+    ASSERT_NO_FATAL_FAILURE(add_initial_objects(meta, 1, 99).get());
+
+    auto tp = make_tp(0);
+
+    // Read the current compaction epoch - should be 0.
+    auto spec = metastore::compaction_info_spec{
+      .tidp = tp, .tombstone_removal_upper_bound_ts = model::timestamp::min()};
+    auto info = meta.get_compaction_info(spec).get();
+    ASSERT_TRUE(info.has_value()) << fmt::to_string(info.error());
+    EXPECT_EQ(info->compaction_epoch, metastore::compaction_epoch{0});
+
+    // Replace with correct epoch (0). Should succeed.
+    std::unique_ptr<metastore::object_metadata_builder> new_objs;
+    ASSERT_NO_FATAL_FAILURE(create_initial_objects(meta, 1, 99, &new_objs));
+    metastore::replace_epoch_map_t epoch_map;
+    epoch_map[tp] = metastore::compaction_epoch{0};
+    auto replace_res = meta.replace_objects(*new_objs, epoch_map).get();
+    ASSERT_TRUE(replace_res.has_value()) << fmt::to_string(replace_res.error());
+
+    // Epoch should still be 0, since replace_objects() does not bump the epoch.
+    info = meta.get_compaction_info(spec).get();
+    ASSERT_TRUE(info.has_value());
+    EXPECT_EQ(info->compaction_epoch, metastore::compaction_epoch{0});
+
+    // Replace again with incorrect epoch (1). Should fail.
+    std::unique_ptr<metastore::object_metadata_builder> incorrect_objs;
+    ASSERT_NO_FATAL_FAILURE(
+      create_initial_objects(meta, 1, 99, &incorrect_objs));
+    metastore::replace_epoch_map_t incorrect_map;
+    incorrect_map[tp] = metastore::compaction_epoch{1};
+    auto incorrect_res
+      = meta.replace_objects(*incorrect_objs, incorrect_map).get();
+    ASSERT_FALSE(incorrect_res.has_value());
+    EXPECT_EQ(incorrect_res.error(), metastore::errc::invalid_request);
+}
+
+TEST_P(ReplicatedMetastoreTest, TestCompactObjectsBumpsEpochAndRejectsStale) {
+    auto& app = get_ct_app(model::node_id{0});
+    auto& meta = app.get_sharded_replicated_metastore()->local();
+
+    // Add initial objects for one partition.
+    ASSERT_NO_FATAL_FAILURE(add_initial_objects(meta, 1, 99).get());
+
+    auto tp = make_tp(0);
+
+    // Read the current compaction epoch - should be 0.
+    auto spec = metastore::compaction_info_spec{
+      .tidp = tp, .tombstone_removal_upper_bound_ts = model::timestamp::min()};
+    auto info = meta.get_compaction_info(spec).get();
+    ASSERT_TRUE(info.has_value()) << fmt::to_string(info.error());
+    EXPECT_EQ(info->compaction_epoch, metastore::compaction_epoch{0});
+
+    // First compact with correct epoch (0). Should succeed.
+    std::unique_ptr<metastore::object_metadata_builder> new_objs;
+    ASSERT_NO_FATAL_FAILURE(create_initial_objects(meta, 1, 99, &new_objs));
+    metastore::compaction_map_t cmap;
+    metastore::compaction_update update;
+    update.cleaned_at = model::timestamp(3000);
+    update.new_cleaned_ranges.push_back(
+      metastore::compaction_update::cleaned_range{
+        .base_offset = o{0}, .last_offset = o{99}});
+    update.expected_compaction_epoch = metastore::compaction_epoch{0};
+    cmap[tp] = std::move(update);
+    auto compact_res = meta.compact_objects(*new_objs, cmap).get();
+    ASSERT_TRUE(compact_res.has_value()) << fmt::to_string(compact_res.error());
+
+    // Epoch should now be 1.
+    info = meta.get_compaction_info(spec).get();
+    ASSERT_TRUE(info.has_value());
+    EXPECT_EQ(info->compaction_epoch, metastore::compaction_epoch{1});
+
+    // Second compact with stale epoch (0). Should fail.
+    std::unique_ptr<metastore::object_metadata_builder> stale_objs;
+    ASSERT_NO_FATAL_FAILURE(create_initial_objects(meta, 1, 99, &stale_objs));
+    metastore::compaction_map_t stale_cmap;
+    metastore::compaction_update stale_update;
+    stale_update.cleaned_at = model::timestamp(3000);
+    stale_update.new_cleaned_ranges.push_back(
+      metastore::compaction_update::cleaned_range{
+        .base_offset = o{0}, .last_offset = o{99}});
+    stale_update.expected_compaction_epoch = metastore::compaction_epoch{
+      0}; // stale
+    stale_cmap[tp] = std::move(stale_update);
+    auto stale_res = meta.compact_objects(*stale_objs, stale_cmap).get();
+    ASSERT_FALSE(stale_res.has_value());
+    EXPECT_EQ(stale_res.error(), metastore::errc::invalid_request);
+}
+
 INSTANTIATE_TEST_SUITE_P(
   MetastoreBackends,
   ReplicatedMetastoreTest,

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -2681,3 +2681,119 @@ TEST(SimpleMetastoreTest, TestGetExtentMetadataForwardsWithObjectMetadata) {
         EXPECT_FALSE(res->end_of_stream);
     }
 }
+
+TEST(SimpleMetastoreTest, ReplaceObjectsRejectsEpoch) {
+    simple_metastore m;
+    auto tp = model::topic_id_partition::from(tid_a);
+
+    // Add an initial object.
+    auto ometa = om_builder(oid1, 100, 1100)
+                   .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
+                   .build();
+    m.preregister_objects(chunked_vector<object_id>::single(oid1));
+    auto add_res = m.add_objects(
+                      om_list_t::single(std::move(ometa)),
+                      terms_builder().add(tid_a, 0_tm, 0_o).build())
+                     .get();
+    ASSERT_TRUE(add_res.has_value()) << int(add_res.error());
+
+    // Read the current epoch (should be 0 since no replace has happened).
+    auto info_res = m.get_compaction_info({
+                                            .tidp = tp,
+                                            .tombstone_removal_upper_bound_ts
+                                            = model::timestamp::min(),
+                                          })
+                      .get();
+    ASSERT_TRUE(info_res.has_value()) << int(info_res.error());
+    EXPECT_EQ(info_res->compaction_epoch, metastore::compaction_epoch{0});
+
+    // First replace with the correct epoch (0). Should succeed.
+    om_list_t new_os1;
+    new_os1.emplace_back(
+      om_builder(oid2, 100, 1100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+    m.preregister_objects(chunked_vector<object_id>::single(oid2));
+    metastore::replace_epoch_map_t epochs1;
+    epochs1[tp] = metastore::compaction_epoch{0};
+    auto replace1 = m.replace_objects(new_os1, epochs1).get();
+    ASSERT_TRUE(replace1.has_value()) << int(replace1.error());
+
+    // Epoch should still be 0, since replace_objects() does not bump the epoch.
+    info_res = m
+                 .get_compaction_info({
+                   .tidp = tp,
+                   .tombstone_removal_upper_bound_ts = model::timestamp::min(),
+                 })
+                 .get();
+    ASSERT_TRUE(info_res.has_value());
+    EXPECT_EQ(info_res->compaction_epoch, metastore::compaction_epoch{0});
+
+    // Replace again with incorrect epoch (1). Should fail.
+    om_list_t new_os2;
+    new_os2.emplace_back(
+      om_builder(oid3, 100, 1100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+    m.preregister_objects(chunked_vector<object_id>::single(oid3));
+    metastore::replace_epoch_map_t incorrect_epochs;
+    incorrect_epochs[tp] = metastore::compaction_epoch{1};
+    auto replace2 = m.replace_objects(new_os2, incorrect_epochs).get();
+    ASSERT_FALSE(replace2.has_value());
+    EXPECT_EQ(replace2.error(), metastore::errc::invalid_request);
+}
+
+TEST(SimpleMetastoreTest, CompactObjectsBumpsEpochAndRejectsStale) {
+    simple_metastore m;
+    auto tp = model::topic_id_partition::from(tid_a);
+
+    // Add an initial object.
+    auto ometa = om_builder(oid1, 100, 1100)
+                   .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
+                   .build();
+    m.preregister_objects(chunked_vector<object_id>::single(oid1));
+    auto add_res = m.add_objects(
+                      om_list_t::single(std::move(ometa)),
+                      terms_builder().add(tid_a, 0_tm, 0_o).build())
+                     .get();
+    ASSERT_TRUE(add_res.has_value()) << int(add_res.error());
+
+    // Read the current epoch (should be 0).
+    auto info_res = m.get_compaction_info({
+                                            .tidp = tp,
+                                            .tombstone_removal_upper_bound_ts
+                                            = model::timestamp::min(),
+                                          })
+                      .get();
+    ASSERT_TRUE(info_res.has_value()) << int(info_res.error());
+    EXPECT_EQ(info_res->compaction_epoch, metastore::compaction_epoch{0});
+
+    // First compact with the correct epoch (0). Should succeed.
+    om_list_t new_os1;
+    new_os1.emplace_back(
+      om_builder(oid2, 100, 1100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+    m.preregister_objects(chunked_vector<object_id>::single(oid2));
+    auto cmb1 = cm_builder();
+    cmb1.clean(tid_a, 3_o, 5_o, 3000_t);
+    cmb1.set_expected_epoch(tid_a, metastore::compaction_epoch{0});
+    auto compact1 = m.compact_objects(new_os1, cmb1.build()).get();
+    ASSERT_TRUE(compact1.has_value()) << int(compact1.error());
+
+    // Epoch should now be 1.
+    info_res = m
+                 .get_compaction_info({
+                   .tidp = tp,
+                   .tombstone_removal_upper_bound_ts = model::timestamp::min(),
+                 })
+                 .get();
+    ASSERT_TRUE(info_res.has_value());
+    EXPECT_EQ(info_res->compaction_epoch, metastore::compaction_epoch{1});
+
+    // Second compact with the stale epoch (0). Should fail.
+    om_list_t new_os2;
+    new_os2.emplace_back(
+      om_builder(oid3, 100, 1100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+    m.preregister_objects(chunked_vector<object_id>::single(oid3));
+    auto cmb2 = cm_builder();
+    cmb2.clean(tid_a, 6_o, 8_o, 3000_t);
+    cmb2.set_expected_epoch(tid_a, metastore::compaction_epoch{0});
+    auto compact2 = m.compact_objects(new_os2, cmb2.build()).get();
+    ASSERT_FALSE(compact2.has_value());
+    EXPECT_EQ(compact2.error(), metastore::errc::invalid_request);
+}

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -474,7 +474,7 @@ TEST(StateUpdateTest, TestReplaceBasic) {
     new_os.emplace_back(
       om_builder(oid2, 100, 1100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
     m.preregister_objects(chunked_vector<object_id>::single(oid2));
-    auto replace_res = m.replace_objects(new_os).get();
+    auto replace_res = m.replace_objects(new_os, make_epoch_map(new_os)).get();
     ASSERT_TRUE(replace_res.has_value());
 
     // Sanity check that replacement leaves us with expected offsets.
@@ -513,7 +513,7 @@ TEST(StateUpdateTest, TestReplaceMultipleOnePartition) {
     new_os.emplace_back(
       om_builder(oid3, 100, 1100).add(tid_a, 0_o, 20_o, 2000_t, 0, 99).build());
     m.preregister_objects(chunked_vector<object_id>::single(oid3));
-    auto replace_res = m.replace_objects(new_os).get();
+    auto replace_res = m.replace_objects(new_os, make_epoch_map(new_os)).get();
     ASSERT_TRUE(replace_res.has_value());
 
     // Replaced offsets should be served from oid3.
@@ -590,7 +590,7 @@ TEST(StateUpdateTest, TestReplaceMultipleMultiplePartitions) {
                           .add(tid_b, 11_o, 20_o, 2000_t, 0, 99)
                           .build());
     m.preregister_objects(chunked_vector<object_id>::single(oid3));
-    auto replace_res = m.replace_objects(new_os).get();
+    auto replace_res = m.replace_objects(new_os, make_epoch_map(new_os)).get();
     ASSERT_TRUE(replace_res.has_value());
 
     // Replaced offsets should be served from oid3.
@@ -646,7 +646,7 @@ TEST(StateUpdateTest, TestReplaceEmptyRequest) {
 
     // Add a replacement object that has no objects.
     om_list_t new_os;
-    auto replace_res = m.replace_objects(new_os).get();
+    auto replace_res = m.replace_objects(new_os, make_epoch_map(new_os)).get();
     ASSERT_FALSE(replace_res.has_value());
     EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
 }
@@ -656,7 +656,8 @@ TEST(StateUpdateTest, TestReplaceEmptyState) {
     {
         // Add a replacement object that has no objects.
         om_list_t new_os;
-        auto replace_res = m.replace_objects(new_os).get();
+        auto replace_res
+          = m.replace_objects(new_os, make_epoch_map(new_os)).get();
         ASSERT_FALSE(replace_res.has_value());
         EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
     }
@@ -667,7 +668,8 @@ TEST(StateUpdateTest, TestReplaceEmptyState) {
                               .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                               .build());
         m.preregister_objects(chunked_vector<object_id>::single(oid1));
-        auto replace_res = m.replace_objects(new_os).get();
+        auto replace_res
+          = m.replace_objects(new_os, make_epoch_map(new_os)).get();
         ASSERT_FALSE(replace_res.has_value());
         EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
     }
@@ -691,7 +693,8 @@ TEST(StateUpdateTest, TestReplaceMisaligned) {
                               .add(tid_a, base_o, last_o, 2000_t, 0, 99)
                               .build());
         m.preregister_objects(chunked_vector<object_id>::single(oid2));
-        auto replace_res = m.replace_objects(new_os).get();
+        auto replace_res
+          = m.replace_objects(new_os, make_epoch_map(new_os)).get();
         ASSERT_FALSE(replace_res.has_value());
         EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
     }
@@ -716,7 +719,8 @@ TEST(StateUpdateTest, TestReplaceOneWithMultipleMisaligned) {
                               .add(tid_a, 11_o, 12_o, 2000_t, 0, 99)
                               .build());
         m.preregister_objects(chunked_vector<object_id>::single(oid2));
-        auto replace_res = m.replace_objects(new_os).get();
+        auto replace_res
+          = m.replace_objects(new_os, make_epoch_map(new_os)).get();
         ASSERT_FALSE(replace_res.has_value());
         EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
     }
@@ -728,7 +732,8 @@ TEST(StateUpdateTest, TestReplaceOneWithMultipleMisaligned) {
                               .add(tid_b, 0_o, 10_o, 2000_t, 0, 99)
                               .build());
         m.preregister_objects(chunked_vector<object_id>::single(oid2));
-        auto replace_res = m.replace_objects(new_os).get();
+        auto replace_res
+          = m.replace_objects(new_os, make_epoch_map(new_os)).get();
         ASSERT_FALSE(replace_res.has_value());
         EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
     }
@@ -764,7 +769,8 @@ TEST(StateUpdateTest, TestReplaceMultipleMisaligned) {
                               .add(tid_a, 0_o, 19_o, 2000_t, 0, 99)
                               .build());
         m.preregister_objects(chunked_vector<object_id>::single(oid3));
-        auto replace_res = m.replace_objects(new_os).get();
+        auto replace_res
+          = m.replace_objects(new_os, make_epoch_map(new_os)).get();
         ASSERT_FALSE(replace_res.has_value());
         EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
     }
@@ -776,7 +782,8 @@ TEST(StateUpdateTest, TestReplaceMultipleMisaligned) {
                               .add(tid_b, 0_o, 19_o, 2000_t, 0, 99)
                               .build());
         m.preregister_objects(chunked_vector<object_id>::single(oid3));
-        auto replace_res = m.replace_objects(new_os).get();
+        auto replace_res
+          = m.replace_objects(new_os, make_epoch_map(new_os)).get();
         ASSERT_FALSE(replace_res.has_value());
         EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
     }
@@ -1252,7 +1259,9 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
         ASSERT_TRUE(add_res.has_value());
         auto fin_res = ob->finish(o_a, 0, 1000);
         ASSERT_TRUE(fin_res.has_value());
-        auto replace_obj_res = m.replace_objects(*ob).get();
+        metastore::replace_epoch_map_t replace_epochs;
+        replace_epochs[tp_a] = metastore::compaction_epoch{0};
+        auto replace_obj_res = m.replace_objects(*ob, replace_epochs).get();
         ASSERT_TRUE(replace_obj_res.has_value());
 
         auto offsets_res = m.get_offsets(tp_a).get();

--- a/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
@@ -134,6 +134,24 @@ public:
 private:
     replace_objects_update out;
 };
+
+struct replace_objects_no_compact_builder {
+public:
+    replace_objects_no_compact_builder& add(new_object o) {
+        out.new_objects.emplace_back(std::move(o));
+        return *this;
+    }
+    replace_objects_no_compact_builder& set_expected_epoch(
+      std::string_view tp_str, partition_state::compaction_epoch_t epoch) {
+        auto tp = model::topic_id_partition::from(tp_str);
+        out.expected_epochs[tp.topic_id][tp.partition] = epoch;
+        return *this;
+    }
+    replace_objects_no_compact_update build() { return std::move(out); }
+
+private:
+    replace_objects_no_compact_update out;
+};
 } // namespace
 
 enum class state_backend { simple, lsm };
@@ -210,6 +228,38 @@ protected:
         replace_objects_db_update db_update{
           .new_objects = std::move(update.new_objects),
           .compaction_updates = std::move(update.compaction_updates),
+        };
+        auto reader = state_reader(db_->create_snapshot());
+        chunked_vector<write_batch_row> rows;
+        auto result = db_update.build_rows(reader, rows).get();
+        if (!result.has_value()) {
+            return std::unexpected(
+              stm_update_error{fmt::format("{}", result.error())});
+        }
+        apply_rows_to_db(rows);
+        return std::monostate{};
+    }
+
+    std::expected<std::monostate, stm_update_error>
+    apply_replace_objects_no_compact(replace_objects_no_compact_update update) {
+        chunked_vector<object_id> oids;
+        for (const auto& o : update.new_objects) {
+            oids.push_back(o.oid);
+        }
+        if (GetParam() == state_backend::simple) {
+            auto prereg = preregister_for_simple(oids);
+            if (!prereg.has_value()) {
+                return prereg;
+            }
+            return update.apply(state_);
+        }
+        auto prereg = preregister_for_lsm(oids);
+        if (!prereg.has_value()) {
+            return prereg;
+        }
+        replace_objects_no_compact_db_update db_update{
+          .new_objects = std::move(update.new_objects),
+          .expected_epochs = std::move(update.expected_epochs),
         };
         auto reader = state_reader(db_->create_snapshot());
         chunked_vector<write_batch_row> rows;
@@ -715,14 +765,17 @@ TEST_P(StateUpdateParamTest, TestReplaceBasic) {
     ASSERT_TRUE(add_res.has_value());
 
     // Fully replace partition a, partially replace c.
-    auto replace = replace_objects_builder()
-                     .add(new_obj_builder(oid3, 100, 1100)
-                            .add(tidp_a, 0_o, 20_o, 1999_t, 0, 99)
-                            .add(tidp_c, 0_o, 10_o, 1999_t, 100, 199)
-                            .build())
-                     .build();
+    auto replace
+      = replace_objects_no_compact_builder()
+          .add(new_obj_builder(oid3, 100, 1100)
+                 .add(tidp_a, 0_o, 20_o, 1999_t, 0, 99)
+                 .add(tidp_c, 0_o, 10_o, 1999_t, 100, 199)
+                 .build())
+          .set_expected_epoch(tidp_a, partition_state::compaction_epoch_t{0})
+          .set_expected_epoch(tidp_c, partition_state::compaction_epoch_t{0})
+          .build();
 
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
     ASSERT_TRUE(replace_res.has_value());
 
     auto& s = get_state();
@@ -751,13 +804,15 @@ TEST_P(StateUpdateParamTest, TestReplaceBasic) {
 }
 
 TEST_P(StateUpdateParamTest, TestReplaceEmptyState) {
-    auto replace = replace_objects_builder()
+    auto replace = replace_objects_no_compact_builder()
                      .add(new_obj_builder(oid1, 100, 1100)
                             .add(tidp_a, 0_o, 20_o, 1999_t, 0, 99)
                             .build())
+                     .set_expected_epoch(
+                       tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
     EXPECT_FALSE(replace_res.has_value());
 }
 
@@ -771,13 +826,15 @@ TEST_P(StateUpdateParamTest, TestReplaceDuplicate) {
     auto add_res = apply_add_objects(std::move(add));
     ASSERT_TRUE(add_res.has_value());
 
-    auto replace = replace_objects_builder()
+    auto replace = replace_objects_no_compact_builder()
                      .add(new_obj_builder(oid1, 100, 1100)
                             .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                             .build())
+                     .set_expected_epoch(
+                       tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
     EXPECT_FALSE(replace_res.has_value());
 }
 
@@ -791,13 +848,15 @@ TEST_P(StateUpdateParamTest, TestReplaceMisaligned) {
     auto add_res = apply_add_objects(std::move(add));
     ASSERT_TRUE(add_res.has_value());
 
-    auto replace = replace_objects_builder()
+    auto replace = replace_objects_no_compact_builder()
                      .add(new_obj_builder(oid2, 100, 1100)
                             .add(tidp_a, 0_o, 9_o, 1999_t, 0, 99)
                             .build())
+                     .set_expected_epoch(
+                       tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
     EXPECT_FALSE(replace_res.has_value());
 }
 
@@ -812,16 +871,18 @@ TEST_P(StateUpdateParamTest, TestReplaceBadOrdering) {
     ASSERT_TRUE(add_res.has_value());
 
     // Make the replacement overlap with itself.
-    auto replace = replace_objects_builder()
+    auto replace = replace_objects_no_compact_builder()
                      .add(new_obj_builder(oid2, 100, 1100)
                             .add(tidp_a, 0_o, 7_o, 1999_t, 0, 99)
                             .build())
                      .add(new_obj_builder(oid3, 100, 1100)
                             .add(tidp_a, 5_o, 10_o, 1999_t, 0, 99)
                             .build())
+                     .set_expected_epoch(
+                       tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
     EXPECT_FALSE(replace_res.has_value());
 }
 
@@ -836,12 +897,14 @@ TEST_P(StateUpdateParamTest, TestReplaceRejectsInvertedExtent) {
     ASSERT_TRUE(add_res.has_value());
 
     // Replacement with an inverted extent should be rejected.
-    auto replace = replace_objects_builder()
+    auto replace = replace_objects_no_compact_builder()
                      .add(new_obj_builder(oid2, 100, 1100)
                             .add(tidp_a, 10_o, 0_o, 1999_t, 0, 99)
                             .build())
+                     .set_expected_epoch(
+                       tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
     EXPECT_FALSE(replace_res.has_value());
 }
 
@@ -855,9 +918,9 @@ TEST_P(StateUpdateParamTest, TestEmptyReplace) {
     auto add_res = apply_add_objects(std::move(add));
     ASSERT_TRUE(add_res.has_value());
 
-    auto replace = replace_objects_builder().build();
+    auto replace = replace_objects_no_compact_builder().build();
 
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
     EXPECT_FALSE(replace_res.has_value());
 }
 
@@ -881,16 +944,18 @@ TEST_P(StateUpdateParamTest, TestReplaceValidNonContiguous) {
     // non-contiguous update. While the update itself is non-contiguous, the
     // individual objects still align with existing extents, and is therefore
     // valid.
-    auto replace = replace_objects_builder()
+    auto replace = replace_objects_no_compact_builder()
                      .add(new_obj_builder(oid4, 100, 1100)
                             .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
                             .build())
                      .add(new_obj_builder(oid5, 100, 1100)
                             .add(tidp_a, 200_o, 299_o, 1999_t, 0, 99)
                             .build())
+                     .set_expected_epoch(
+                       tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
     ASSERT_TRUE(replace_res.has_value());
 
     auto& s = get_state();
@@ -918,7 +983,7 @@ TEST_P(StateUpdateParamTest, TestReplaceValidNonContiguousSplitExtent) {
     // non-contiguous update whose objects align with existing extents.
     // The update should see oid3 split into two new extents (for a total of 4
     // extents).
-    auto replace = replace_objects_builder()
+    auto replace = replace_objects_no_compact_builder()
                      .add(new_obj_builder(oid4, 100, 1100)
                             .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
                             .build())
@@ -928,9 +993,11 @@ TEST_P(StateUpdateParamTest, TestReplaceValidNonContiguousSplitExtent) {
                      .add(new_obj_builder(oid6, 100, 1100)
                             .add(tidp_a, 250_o, 299_o, 1999_t, 0, 99)
                             .build())
+                     .set_expected_epoch(
+                       tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
     ASSERT_TRUE(replace_res.has_value());
 
     auto& s = get_state();
@@ -956,7 +1023,7 @@ TEST_P(StateUpdateParamTest, TestReplaceInvalidNonContiguousBadOffsets) {
 
     // Attempt to replace oid1 and oid3 while leaving oid2 in place with a
     // invalid non-contiguous update with bad offsets.
-    auto replace = replace_objects_builder()
+    auto replace = replace_objects_no_compact_builder()
                      .add(new_obj_builder(oid4, 100, 1100)
                             .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
                             .build())
@@ -966,9 +1033,11 @@ TEST_P(StateUpdateParamTest, TestReplaceInvalidNonContiguousBadOffsets) {
                      .add(new_obj_builder(oid6, 100, 1100)
                             .add(tidp_a, 239_o, 299_o, 1999_t, 0, 99)
                             .build())
+                     .set_expected_epoch(
+                       tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
     EXPECT_FALSE(replace_res.has_value());
 
     auto& s = get_state();
@@ -994,7 +1063,7 @@ TEST_P(StateUpdateParamTest, TestReplaceInvalidNonContiguousDoesNotSpan) {
 
     // Attempt to replace oid1 and oid3 while leaving oid2 in place with a
     // invalid non-contiguous update that doesn't exactly span existing extents.
-    auto replace = replace_objects_builder()
+    auto replace = replace_objects_no_compact_builder()
                      .add(new_obj_builder(oid4, 100, 1100)
                             .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
                             .build())
@@ -1004,9 +1073,11 @@ TEST_P(StateUpdateParamTest, TestReplaceInvalidNonContiguousDoesNotSpan) {
                      .add(new_obj_builder(oid6, 100, 1100)
                             .add(tidp_a, 250_o, 298_o, 1999_t, 0, 99)
                             .build())
+                     .set_expected_epoch(
+                       tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
     EXPECT_FALSE(replace_res.has_value());
 
     auto& s = get_state();
@@ -1038,7 +1109,7 @@ TEST_P(StateUpdateParamTest, TestReplaceSingleExtentBeforeNewStartOffset) {
     // containing offsets before the truncation point (the new start offset).
     // The metastore should be able to apply the update by ignoring the first
     // extent.
-    auto replace = replace_objects_builder()
+    auto replace = replace_objects_no_compact_builder()
                      .add(new_obj_builder(oid4, 100, 1100)
                             .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
                             .build())
@@ -1048,9 +1119,11 @@ TEST_P(StateUpdateParamTest, TestReplaceSingleExtentBeforeNewStartOffset) {
                      .add(new_obj_builder(oid6, 100, 1100)
                             .add(tidp_a, 200_o, 299_o, 1999_t, 0, 99)
                             .build())
+                     .set_expected_epoch(
+                       tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
     ASSERT_TRUE(replace_res.has_value());
 }
 
@@ -1078,7 +1151,7 @@ TEST_P(
     // Attempt to replace with a list of valid objects built before the
     // truncation occurred. The metastore should be able to accept and prune the
     // extents below the start offset.
-    auto replace = replace_objects_builder()
+    auto replace = replace_objects_no_compact_builder()
                      .add(new_obj_builder(oid4, 100, 1100)
                             .add(tidp_a, 0_o, 30_o, 1999_t, 0, 99)
                             .build())
@@ -1088,9 +1161,11 @@ TEST_P(
                      .add(new_obj_builder(oid6, 100, 1100)
                             .add(tidp_a, 61_o, 100_o, 1999_t, 0, 99)
                             .build())
+                     .set_expected_epoch(
+                       tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
     ASSERT_TRUE(replace_res.has_value());
 
     auto& s = get_state();
@@ -1122,7 +1197,7 @@ TEST_P(StateUpdateParamTest, TestReplaceAllExtentsBeforeNewStartOffset) {
     // Attempt to replace with a list of valid objects, with all extents
     // containing offsets before the truncation point (the new start offset).
     // The metastore should be able to recognize this is a no-op.
-    auto replace = replace_objects_builder()
+    auto replace = replace_objects_no_compact_builder()
                      .add(new_obj_builder(oid4, 100, 1100)
                             .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
                             .build())
@@ -1132,9 +1207,11 @@ TEST_P(StateUpdateParamTest, TestReplaceAllExtentsBeforeNewStartOffset) {
                      .add(new_obj_builder(oid6, 100, 1100)
                             .add(tidp_a, 200_o, 299_o, 1999_t, 0, 99)
                             .build())
+                     .set_expected_epoch(
+                       tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
     ASSERT_FALSE(replace_res.has_value());
 }
 
@@ -1157,7 +1234,7 @@ TEST_P(StateUpdateParamTest, TestReplaceMultipleExtentsBeforeNewStartOffset) {
     // If we fail to consider the fact that the extent {0,100} is still
     // present in the existing state, removing the first two extents would
     // result in a misaligned update and a failure to replace.
-    auto replace = replace_objects_builder()
+    auto replace = replace_objects_no_compact_builder()
                      .add(new_obj_builder(oid2, 100, 1100)
                             .add(tidp_a, 0_o, 30_o, 1999_t, 0, 99)
                             .build())
@@ -1167,9 +1244,11 @@ TEST_P(StateUpdateParamTest, TestReplaceMultipleExtentsBeforeNewStartOffset) {
                      .add(new_obj_builder(oid4, 100, 1100)
                             .add(tidp_a, 61_o, 100_o, 1999_t, 0, 99)
                             .build())
+                     .set_expected_epoch(
+                       tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
     ASSERT_TRUE(replace_res.has_value());
 
     auto& s = get_state();
@@ -1203,16 +1282,18 @@ TEST_P(
     // Attempt to replace with a list of extents that are misaligned to the
     // existing extents ([11,20],[21,30]), but form a valid, contiguous update
     // when considering the new start offset.
-    auto replace = replace_objects_builder()
+    auto replace = replace_objects_no_compact_builder()
                      .add(new_obj_builder(oid4, 100, 1100)
                             .add(tidp_a, 0_o, 15_o, 1999_t, 0, 99)
                             .build())
                      .add(new_obj_builder(oid5, 100, 1100)
                             .add(tidp_a, 16_o, 30_o, 1999_t, 0, 99)
                             .build())
+                     .set_expected_epoch(
+                       tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
     ASSERT_TRUE(replace_res.has_value());
 
     auto& s = get_state();
@@ -1221,7 +1302,101 @@ TEST_P(
     EXPECT_EQ(p_state->get().extents.size(), 2);
 }
 
-TEST_P(StateUpdateParamTest, TestReplaceWithCompaction) {
+TEST_P(StateUpdateParamTest, TestCompactWithoutUpdateRejects) {
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 100, 1100)
+                        .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                        .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .build();
+    auto add_res = apply_add_objects(std::move(add));
+    ASSERT_TRUE(add_res.has_value());
+
+    // A replace_objects request that supplies new extents for a partition
+    // but omits the compaction_update entry must be rejected. Without that
+    // invariant the apply path would silently bump the partition's
+    // compaction_epoch without OCC.
+    auto replace = replace_objects_builder()
+                     .add(new_obj_builder(oid2, 100, 1100)
+                            .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                            .build())
+                     .build();
+
+    auto replace_res = apply_replace_objects(std::move(replace));
+    ASSERT_FALSE(replace_res.has_value());
+    EXPECT_THAT(
+      replace_res.error()(), testing::HasSubstr("no compaction_update entry"));
+}
+
+TEST_P(StateUpdateParamTest, TestCompactWithEpochOnlyUpdate) {
+    using testing::ElementsAre;
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 100, 1100)
+                        .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                        .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .build();
+    auto add_res = apply_add_objects(std::move(add));
+    ASSERT_TRUE(add_res.has_value());
+
+    // A replace_objects request whose compaction_update has only the
+    // expected_compaction_epoch set — no cleaned ranges, no tombstone
+    // removals — is valid. Extents are replaced, the epoch is bumped, and
+    // an empty compaction_state is visible.
+    auto replace = replace_objects_builder()
+                     .add(new_obj_builder(oid2, 100, 1100)
+                            .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                            .build())
+                     .set_expected_epoch(
+                       tidp_a, partition_state::compaction_epoch_t{0})
+                     .build();
+
+    auto replace_res = apply_replace_objects(std::move(replace));
+    ASSERT_TRUE(replace_res.has_value()) << replace_res.error();
+
+    auto& s = get_state();
+    const auto& prt_a
+      = s.partition_state(model::topic_id_partition::from(tidp_a))->get();
+    EXPECT_THAT(prt_a.extents, ElementsAre(MatchesRange(oid2, 0_o, 10_o)));
+    EXPECT_EQ(prt_a.compaction_epoch, partition_state::compaction_epoch_t{1});
+    EXPECT_TRUE(prt_a.compaction_state.has_value());
+}
+
+TEST_P(StateUpdateParamTest, TestRejectsNotPreregistered) {
+    // Exercise the "Object not pre-registered" error path in
+    // validate_new_objects_layout. The apply_replace_objects_no_compact helper
+    // auto-pre-registers objects, so we bypass it and call can_apply()
+    // directly on the in-memory state.
+    //
+    // First set up a valid partition so epoch validation doesn't fire first.
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 100, 1100)
+                        .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                        .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .build();
+    auto add_res = apply_add_objects(std::move(add));
+    ASSERT_TRUE(add_res.has_value());
+
+    // Build the update manually and call can_apply() directly without
+    // pre-registering oid2. Both backends derive the check from the
+    // in-memory state returned by get_state().
+    replace_objects_no_compact_update update;
+    update.new_objects.push_back(new_obj_builder(oid2, 100, 1100)
+                                   .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                                   .build());
+    auto tidp_a_tp = model::topic_id_partition::from(tidp_a);
+    update.expected_epochs[tidp_a_tp.topic_id][tidp_a_tp.partition]
+      = partition_state::compaction_epoch_t{0};
+
+    auto& s = get_state();
+    auto can_apply_res = update.can_apply(s);
+    ASSERT_FALSE(can_apply_res.has_value());
+    EXPECT_THAT(
+      can_apply_res.error()(), testing::HasSubstr("not pre-registered"));
+}
+
+TEST_P(StateUpdateParamTest, TestCompactWithCompaction) {
     using testing::ElementsAre;
     using range = struct compaction_state_update::cleaned_range;
     auto add = add_objects_builder()
@@ -1941,15 +2116,19 @@ TEST_P(StateUpdateParamTest, TestRemoveObjectsBasic) {
     EXPECT_EQ(2, get_state().objects.size());
 
     // Replace objects to mark originals as unreferenced.
-    auto replace = replace_objects_builder()
-                     .add(new_obj_builder(oid3, 100, 1100)
-                            .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
-                            .build())
-                     .add(new_obj_builder(oid4, 100, 1100)
-                            .add(tidp_b, 0_o, 10_o, 1999_t, 0, 99)
-                            .build())
-                     .build();
-    ASSERT_TRUE(apply_replace_objects(std::move(replace)).has_value());
+    auto replace
+      = replace_objects_no_compact_builder()
+          .add(new_obj_builder(oid3, 100, 1100)
+                 .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                 .build())
+          .add(new_obj_builder(oid4, 100, 1100)
+                 .add(tidp_b, 0_o, 10_o, 1999_t, 0, 99)
+                 .build())
+          .set_expected_epoch(tidp_a, partition_state::compaction_epoch_t{0})
+          .set_expected_epoch(tidp_b, partition_state::compaction_epoch_t{0})
+          .build();
+    ASSERT_TRUE(
+      apply_replace_objects_no_compact(std::move(replace)).has_value());
     EXPECT_EQ(4, get_state().objects.size());
 
     // Remove the unreferenced objects.
@@ -2275,6 +2454,148 @@ TEST_P(StateUpdateParamTest, TestExpirePreregisteredObjectsClearsFlag) {
     // oid2 untouched
     ASSERT_TRUE(s.objects.contains(oid2));
     EXPECT_TRUE(s.objects.at(oid2).is_preregistration);
+}
+
+// Tests for the new replace_objects_no_compact_update (key 7, epoch-validating
+// replace path). These are distinct from the compact path (key 1).
+TEST_P(StateUpdateParamTest, TestReplaceObjectsEpoch) {
+    // Set up a partition at epoch 0.
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 100, 1100)
+                        .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                        .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .build();
+    ASSERT_TRUE(apply_add_objects(std::move(add)).has_value());
+
+    // Build a replace_objects_no_compact_update with expected_epoch = 0.
+    auto replace = replace_objects_no_compact_builder()
+                     .add(new_obj_builder(oid2, 100, 1100)
+                            .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                            .build())
+                     .set_expected_epoch(
+                       tidp_a, partition_state::compaction_epoch_t{0})
+                     .build();
+
+    auto res = apply_replace_objects_no_compact(std::move(replace));
+    ASSERT_TRUE(res.has_value()) << res.error();
+
+    auto& s = get_state();
+    auto p_ref = s.partition_state(model::topic_id_partition::from(tidp_a));
+    ASSERT_TRUE(p_ref.has_value());
+    const auto& p = p_ref->get();
+
+    // Epoch should still be 0, since replace_objects_no_compact() does not bump
+    // the epoch.
+    EXPECT_EQ(p.compaction_epoch, partition_state::compaction_epoch_t{0});
+
+    // The replace path must NOT create compaction_state for partitions that
+    // have never been compacted.
+    EXPECT_FALSE(p.compaction_state.has_value());
+}
+
+TEST_P(StateUpdateParamTest, TestReplaceObjectsEpochMismatchRejects) {
+    // Set up a partition at epoch 0.
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 100, 1100)
+                        .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                        .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .build();
+    ASSERT_TRUE(apply_add_objects(std::move(add)).has_value());
+
+    // Supply expected_epoch = 1, but the actual epoch is still 0.
+    auto replace = replace_objects_no_compact_builder()
+                     .add(new_obj_builder(oid2, 100, 1100)
+                            .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                            .build())
+                     .set_expected_epoch(
+                       tidp_a, partition_state::compaction_epoch_t{1})
+                     .build();
+
+    auto res = apply_replace_objects_no_compact(std::move(replace));
+    EXPECT_FALSE(res.has_value());
+    EXPECT_THAT(fmt::format("{}", res.error()), testing::HasSubstr("epoch"));
+
+    // Partition state must be unchanged.
+    auto& s = get_state();
+    auto p_ref = s.partition_state(model::topic_id_partition::from(tidp_a));
+    ASSERT_TRUE(p_ref.has_value());
+    EXPECT_EQ(
+      p_ref->get().compaction_epoch, partition_state::compaction_epoch_t{0});
+}
+
+TEST_P(
+  StateUpdateParamTest,
+  TestReplaceObjectsEpochRejectsExtentsWithoutEpochEntry) {
+    // Set up partition a.
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 100, 1100)
+                        .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                        .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .build();
+    ASSERT_TRUE(apply_add_objects(std::move(add)).has_value());
+
+    // Pre-register oid2 so can_apply() passes the pre-registration check
+    // and reaches the bidirectional invariant check.
+    ASSERT_TRUE(apply_preregister_objects({oid2}).has_value());
+
+    // Build an update with extents for tidp_a but no expected_epochs entry.
+    replace_objects_no_compact_update update;
+    update.new_objects.push_back(new_obj_builder(oid2, 100, 1100)
+                                   .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                                   .build());
+    // expected_epochs is intentionally empty.
+
+    // Build should fail because the bidirectional invariant is violated.
+    auto& s = get_state();
+    auto build_res = replace_objects_no_compact_update::build(
+      s, std::move(update.new_objects), {});
+    EXPECT_FALSE(build_res.has_value());
+    EXPECT_THAT(
+      fmt::format("{}", build_res.error()),
+      testing::HasSubstr("expected_epochs"));
+}
+
+TEST_P(
+  StateUpdateParamTest,
+  TestReplaceObjectsEpochRejectsEpochEntryWithoutExtents) {
+    // Set up partition a.
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 100, 1100)
+                        .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                        .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .build();
+    ASSERT_TRUE(apply_add_objects(std::move(add)).has_value());
+
+    // Pre-register oid2 so can_apply() passes the pre-registration check
+    // and reaches the bidirectional invariant check.
+    ASSERT_TRUE(apply_preregister_objects({oid2}).has_value());
+
+    // Extents are for tidp_a but expected_epochs has an entry for tidp_b.
+    auto tp_a = model::topic_id_partition::from(tidp_a);
+    auto tp_b = model::topic_id_partition::from(tidp_b);
+    chunked_hash_map<
+      model::topic_id_partition,
+      partition_state::compaction_epoch_t>
+      flat_epochs;
+    flat_epochs[tp_a] = partition_state::compaction_epoch_t{0};
+    flat_epochs[tp_b] = partition_state::compaction_epoch_t{0};
+
+    chunked_vector<new_object> new_objs;
+    new_objs.push_back(new_obj_builder(oid2, 100, 1100)
+                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                         .build());
+
+    auto& s = get_state();
+    auto build_res = replace_objects_no_compact_update::build(
+      s, std::move(new_objs), std::move(flat_epochs));
+    EXPECT_FALSE(build_res.has_value());
+    EXPECT_THAT(
+      fmt::format("{}", build_res.error()),
+      testing::HasSubstr("expected_epochs"));
 }
 
 TEST(AddObjectsUpdateTest, RejectsUnregisteredObject) {

--- a/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
@@ -135,22 +135,22 @@ private:
     compact_objects_update out;
 };
 
-struct replace_objects_no_compact_builder {
+struct replace_objects_builder {
 public:
-    replace_objects_no_compact_builder& add(new_object o) {
+    replace_objects_builder& add(new_object o) {
         out.new_objects.emplace_back(std::move(o));
         return *this;
     }
-    replace_objects_no_compact_builder& set_expected_epoch(
+    replace_objects_builder& set_expected_epoch(
       std::string_view tp_str, partition_state::compaction_epoch_t epoch) {
         auto tp = model::topic_id_partition::from(tp_str);
         out.expected_epochs[tp.topic_id][tp.partition] = epoch;
         return *this;
     }
-    replace_objects_no_compact_update build() { return std::move(out); }
+    replace_objects_update build() { return std::move(out); }
 
 private:
-    replace_objects_no_compact_update out;
+    replace_objects_update out;
 };
 } // namespace
 
@@ -241,7 +241,7 @@ protected:
     }
 
     std::expected<std::monostate, stm_update_error>
-    apply_replace_objects_no_compact(replace_objects_no_compact_update update) {
+    apply_replace_objects(replace_objects_update update) {
         chunked_vector<object_id> oids;
         for (const auto& o : update.new_objects) {
             oids.push_back(o.oid);
@@ -257,7 +257,7 @@ protected:
         if (!prereg.has_value()) {
             return prereg;
         }
-        replace_objects_no_compact_db_update db_update{
+        replace_objects_db_update db_update{
           .new_objects = std::move(update.new_objects),
           .expected_epochs = std::move(update.expected_epochs),
         };
@@ -766,7 +766,7 @@ TEST_P(StateUpdateParamTest, TestReplaceBasic) {
 
     // Fully replace partition a, partially replace c.
     auto replace
-      = replace_objects_no_compact_builder()
+      = replace_objects_builder()
           .add(new_obj_builder(oid3, 100, 1100)
                  .add(tidp_a, 0_o, 20_o, 1999_t, 0, 99)
                  .add(tidp_c, 0_o, 10_o, 1999_t, 100, 199)
@@ -775,7 +775,7 @@ TEST_P(StateUpdateParamTest, TestReplaceBasic) {
           .set_expected_epoch(tidp_c, partition_state::compaction_epoch_t{0})
           .build();
 
-    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
+    auto replace_res = apply_replace_objects(std::move(replace));
     ASSERT_TRUE(replace_res.has_value());
 
     auto& s = get_state();
@@ -804,7 +804,7 @@ TEST_P(StateUpdateParamTest, TestReplaceBasic) {
 }
 
 TEST_P(StateUpdateParamTest, TestReplaceEmptyState) {
-    auto replace = replace_objects_no_compact_builder()
+    auto replace = replace_objects_builder()
                      .add(new_obj_builder(oid1, 100, 1100)
                             .add(tidp_a, 0_o, 20_o, 1999_t, 0, 99)
                             .build())
@@ -812,7 +812,7 @@ TEST_P(StateUpdateParamTest, TestReplaceEmptyState) {
                        tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
+    auto replace_res = apply_replace_objects(std::move(replace));
     EXPECT_FALSE(replace_res.has_value());
 }
 
@@ -826,7 +826,7 @@ TEST_P(StateUpdateParamTest, TestReplaceDuplicate) {
     auto add_res = apply_add_objects(std::move(add));
     ASSERT_TRUE(add_res.has_value());
 
-    auto replace = replace_objects_no_compact_builder()
+    auto replace = replace_objects_builder()
                      .add(new_obj_builder(oid1, 100, 1100)
                             .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                             .build())
@@ -834,7 +834,7 @@ TEST_P(StateUpdateParamTest, TestReplaceDuplicate) {
                        tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
+    auto replace_res = apply_replace_objects(std::move(replace));
     EXPECT_FALSE(replace_res.has_value());
 }
 
@@ -848,7 +848,7 @@ TEST_P(StateUpdateParamTest, TestReplaceMisaligned) {
     auto add_res = apply_add_objects(std::move(add));
     ASSERT_TRUE(add_res.has_value());
 
-    auto replace = replace_objects_no_compact_builder()
+    auto replace = replace_objects_builder()
                      .add(new_obj_builder(oid2, 100, 1100)
                             .add(tidp_a, 0_o, 9_o, 1999_t, 0, 99)
                             .build())
@@ -856,7 +856,7 @@ TEST_P(StateUpdateParamTest, TestReplaceMisaligned) {
                        tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
+    auto replace_res = apply_replace_objects(std::move(replace));
     EXPECT_FALSE(replace_res.has_value());
 }
 
@@ -871,7 +871,7 @@ TEST_P(StateUpdateParamTest, TestReplaceBadOrdering) {
     ASSERT_TRUE(add_res.has_value());
 
     // Make the replacement overlap with itself.
-    auto replace = replace_objects_no_compact_builder()
+    auto replace = replace_objects_builder()
                      .add(new_obj_builder(oid2, 100, 1100)
                             .add(tidp_a, 0_o, 7_o, 1999_t, 0, 99)
                             .build())
@@ -882,7 +882,7 @@ TEST_P(StateUpdateParamTest, TestReplaceBadOrdering) {
                        tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
+    auto replace_res = apply_replace_objects(std::move(replace));
     EXPECT_FALSE(replace_res.has_value());
 }
 
@@ -897,14 +897,14 @@ TEST_P(StateUpdateParamTest, TestReplaceRejectsInvertedExtent) {
     ASSERT_TRUE(add_res.has_value());
 
     // Replacement with an inverted extent should be rejected.
-    auto replace = replace_objects_no_compact_builder()
+    auto replace = replace_objects_builder()
                      .add(new_obj_builder(oid2, 100, 1100)
                             .add(tidp_a, 10_o, 0_o, 1999_t, 0, 99)
                             .build())
                      .set_expected_epoch(
                        tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
-    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
+    auto replace_res = apply_replace_objects(std::move(replace));
     EXPECT_FALSE(replace_res.has_value());
 }
 
@@ -918,9 +918,9 @@ TEST_P(StateUpdateParamTest, TestEmptyReplace) {
     auto add_res = apply_add_objects(std::move(add));
     ASSERT_TRUE(add_res.has_value());
 
-    auto replace = replace_objects_no_compact_builder().build();
+    auto replace = replace_objects_builder().build();
 
-    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
+    auto replace_res = apply_replace_objects(std::move(replace));
     EXPECT_FALSE(replace_res.has_value());
 }
 
@@ -944,7 +944,7 @@ TEST_P(StateUpdateParamTest, TestReplaceValidNonContiguous) {
     // non-contiguous update. While the update itself is non-contiguous, the
     // individual objects still align with existing extents, and is therefore
     // valid.
-    auto replace = replace_objects_no_compact_builder()
+    auto replace = replace_objects_builder()
                      .add(new_obj_builder(oid4, 100, 1100)
                             .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
                             .build())
@@ -955,7 +955,7 @@ TEST_P(StateUpdateParamTest, TestReplaceValidNonContiguous) {
                        tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
+    auto replace_res = apply_replace_objects(std::move(replace));
     ASSERT_TRUE(replace_res.has_value());
 
     auto& s = get_state();
@@ -983,7 +983,7 @@ TEST_P(StateUpdateParamTest, TestReplaceValidNonContiguousSplitExtent) {
     // non-contiguous update whose objects align with existing extents.
     // The update should see oid3 split into two new extents (for a total of 4
     // extents).
-    auto replace = replace_objects_no_compact_builder()
+    auto replace = replace_objects_builder()
                      .add(new_obj_builder(oid4, 100, 1100)
                             .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
                             .build())
@@ -997,7 +997,7 @@ TEST_P(StateUpdateParamTest, TestReplaceValidNonContiguousSplitExtent) {
                        tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
+    auto replace_res = apply_replace_objects(std::move(replace));
     ASSERT_TRUE(replace_res.has_value());
 
     auto& s = get_state();
@@ -1023,7 +1023,7 @@ TEST_P(StateUpdateParamTest, TestReplaceInvalidNonContiguousBadOffsets) {
 
     // Attempt to replace oid1 and oid3 while leaving oid2 in place with a
     // invalid non-contiguous update with bad offsets.
-    auto replace = replace_objects_no_compact_builder()
+    auto replace = replace_objects_builder()
                      .add(new_obj_builder(oid4, 100, 1100)
                             .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
                             .build())
@@ -1037,7 +1037,7 @@ TEST_P(StateUpdateParamTest, TestReplaceInvalidNonContiguousBadOffsets) {
                        tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
+    auto replace_res = apply_replace_objects(std::move(replace));
     EXPECT_FALSE(replace_res.has_value());
 
     auto& s = get_state();
@@ -1063,7 +1063,7 @@ TEST_P(StateUpdateParamTest, TestReplaceInvalidNonContiguousDoesNotSpan) {
 
     // Attempt to replace oid1 and oid3 while leaving oid2 in place with a
     // invalid non-contiguous update that doesn't exactly span existing extents.
-    auto replace = replace_objects_no_compact_builder()
+    auto replace = replace_objects_builder()
                      .add(new_obj_builder(oid4, 100, 1100)
                             .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
                             .build())
@@ -1077,7 +1077,7 @@ TEST_P(StateUpdateParamTest, TestReplaceInvalidNonContiguousDoesNotSpan) {
                        tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
+    auto replace_res = apply_replace_objects(std::move(replace));
     EXPECT_FALSE(replace_res.has_value());
 
     auto& s = get_state();
@@ -1109,7 +1109,7 @@ TEST_P(StateUpdateParamTest, TestReplaceSingleExtentBeforeNewStartOffset) {
     // containing offsets before the truncation point (the new start offset).
     // The metastore should be able to apply the update by ignoring the first
     // extent.
-    auto replace = replace_objects_no_compact_builder()
+    auto replace = replace_objects_builder()
                      .add(new_obj_builder(oid4, 100, 1100)
                             .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
                             .build())
@@ -1123,7 +1123,7 @@ TEST_P(StateUpdateParamTest, TestReplaceSingleExtentBeforeNewStartOffset) {
                        tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
+    auto replace_res = apply_replace_objects(std::move(replace));
     ASSERT_TRUE(replace_res.has_value());
 }
 
@@ -1151,7 +1151,7 @@ TEST_P(
     // Attempt to replace with a list of valid objects built before the
     // truncation occurred. The metastore should be able to accept and prune the
     // extents below the start offset.
-    auto replace = replace_objects_no_compact_builder()
+    auto replace = replace_objects_builder()
                      .add(new_obj_builder(oid4, 100, 1100)
                             .add(tidp_a, 0_o, 30_o, 1999_t, 0, 99)
                             .build())
@@ -1165,7 +1165,7 @@ TEST_P(
                        tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
+    auto replace_res = apply_replace_objects(std::move(replace));
     ASSERT_TRUE(replace_res.has_value());
 
     auto& s = get_state();
@@ -1197,7 +1197,7 @@ TEST_P(StateUpdateParamTest, TestReplaceAllExtentsBeforeNewStartOffset) {
     // Attempt to replace with a list of valid objects, with all extents
     // containing offsets before the truncation point (the new start offset).
     // The metastore should be able to recognize this is a no-op.
-    auto replace = replace_objects_no_compact_builder()
+    auto replace = replace_objects_builder()
                      .add(new_obj_builder(oid4, 100, 1100)
                             .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
                             .build())
@@ -1211,7 +1211,7 @@ TEST_P(StateUpdateParamTest, TestReplaceAllExtentsBeforeNewStartOffset) {
                        tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
+    auto replace_res = apply_replace_objects(std::move(replace));
     ASSERT_FALSE(replace_res.has_value());
 }
 
@@ -1234,7 +1234,7 @@ TEST_P(StateUpdateParamTest, TestReplaceMultipleExtentsBeforeNewStartOffset) {
     // If we fail to consider the fact that the extent {0,100} is still
     // present in the existing state, removing the first two extents would
     // result in a misaligned update and a failure to replace.
-    auto replace = replace_objects_no_compact_builder()
+    auto replace = replace_objects_builder()
                      .add(new_obj_builder(oid2, 100, 1100)
                             .add(tidp_a, 0_o, 30_o, 1999_t, 0, 99)
                             .build())
@@ -1248,7 +1248,7 @@ TEST_P(StateUpdateParamTest, TestReplaceMultipleExtentsBeforeNewStartOffset) {
                        tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
+    auto replace_res = apply_replace_objects(std::move(replace));
     ASSERT_TRUE(replace_res.has_value());
 
     auto& s = get_state();
@@ -1282,7 +1282,7 @@ TEST_P(
     // Attempt to replace with a list of extents that are misaligned to the
     // existing extents ([11,20],[21,30]), but form a valid, contiguous update
     // when considering the new start offset.
-    auto replace = replace_objects_no_compact_builder()
+    auto replace = replace_objects_builder()
                      .add(new_obj_builder(oid4, 100, 1100)
                             .add(tidp_a, 0_o, 15_o, 1999_t, 0, 99)
                             .build())
@@ -1293,7 +1293,7 @@ TEST_P(
                        tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects_no_compact(std::move(replace));
+    auto replace_res = apply_replace_objects(std::move(replace));
     ASSERT_TRUE(replace_res.has_value());
 
     auto& s = get_state();
@@ -1364,7 +1364,7 @@ TEST_P(StateUpdateParamTest, TestCompactWithEpochOnlyUpdate) {
 
 TEST_P(StateUpdateParamTest, TestRejectsNotPreregistered) {
     // Exercise the "Object not pre-registered" error path in
-    // validate_new_objects_layout. The apply_replace_objects_no_compact helper
+    // validate_new_objects_layout. The apply_replace_objects helper
     // auto-pre-registers objects, so we bypass it and call can_apply()
     // directly on the in-memory state.
     //
@@ -1381,7 +1381,7 @@ TEST_P(StateUpdateParamTest, TestRejectsNotPreregistered) {
     // Build the update manually and call can_apply() directly without
     // pre-registering oid2. Both backends derive the check from the
     // in-memory state returned by get_state().
-    replace_objects_no_compact_update update;
+    replace_objects_update update;
     update.new_objects.push_back(new_obj_builder(oid2, 100, 1100)
                                    .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                                    .build());
@@ -2117,7 +2117,7 @@ TEST_P(StateUpdateParamTest, TestRemoveObjectsBasic) {
 
     // Replace objects to mark originals as unreferenced.
     auto replace
-      = replace_objects_no_compact_builder()
+      = replace_objects_builder()
           .add(new_obj_builder(oid3, 100, 1100)
                  .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                  .build())
@@ -2127,8 +2127,7 @@ TEST_P(StateUpdateParamTest, TestRemoveObjectsBasic) {
           .set_expected_epoch(tidp_a, partition_state::compaction_epoch_t{0})
           .set_expected_epoch(tidp_b, partition_state::compaction_epoch_t{0})
           .build();
-    ASSERT_TRUE(
-      apply_replace_objects_no_compact(std::move(replace)).has_value());
+    ASSERT_TRUE(apply_replace_objects(std::move(replace)).has_value());
     EXPECT_EQ(4, get_state().objects.size());
 
     // Remove the unreferenced objects.
@@ -2456,7 +2455,7 @@ TEST_P(StateUpdateParamTest, TestExpirePreregisteredObjectsClearsFlag) {
     EXPECT_TRUE(s.objects.at(oid2).is_preregistration);
 }
 
-// Tests for the new replace_objects_no_compact_update (key 7, epoch-validating
+// Tests for the new replace_objects_update (key 7, epoch-validating
 // replace path). These are distinct from the compact path (key 1).
 TEST_P(StateUpdateParamTest, TestReplaceObjectsEpoch) {
     // Set up a partition at epoch 0.
@@ -2468,8 +2467,8 @@ TEST_P(StateUpdateParamTest, TestReplaceObjectsEpoch) {
                  .build();
     ASSERT_TRUE(apply_add_objects(std::move(add)).has_value());
 
-    // Build a replace_objects_no_compact_update with expected_epoch = 0.
-    auto replace = replace_objects_no_compact_builder()
+    // Build a replace_objects_update with expected_epoch = 0.
+    auto replace = replace_objects_builder()
                      .add(new_obj_builder(oid2, 100, 1100)
                             .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                             .build())
@@ -2477,7 +2476,7 @@ TEST_P(StateUpdateParamTest, TestReplaceObjectsEpoch) {
                        tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto res = apply_replace_objects_no_compact(std::move(replace));
+    auto res = apply_replace_objects(std::move(replace));
     ASSERT_TRUE(res.has_value()) << res.error();
 
     auto& s = get_state();
@@ -2485,7 +2484,7 @@ TEST_P(StateUpdateParamTest, TestReplaceObjectsEpoch) {
     ASSERT_TRUE(p_ref.has_value());
     const auto& p = p_ref->get();
 
-    // Epoch should still be 0, since replace_objects_no_compact() does not bump
+    // Epoch should still be 0, since replace_objects() does not bump
     // the epoch.
     EXPECT_EQ(p.compaction_epoch, partition_state::compaction_epoch_t{0});
 
@@ -2505,7 +2504,7 @@ TEST_P(StateUpdateParamTest, TestReplaceObjectsEpochMismatchRejects) {
     ASSERT_TRUE(apply_add_objects(std::move(add)).has_value());
 
     // Supply expected_epoch = 1, but the actual epoch is still 0.
-    auto replace = replace_objects_no_compact_builder()
+    auto replace = replace_objects_builder()
                      .add(new_obj_builder(oid2, 100, 1100)
                             .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                             .build())
@@ -2513,7 +2512,7 @@ TEST_P(StateUpdateParamTest, TestReplaceObjectsEpochMismatchRejects) {
                        tidp_a, partition_state::compaction_epoch_t{1})
                      .build();
 
-    auto res = apply_replace_objects_no_compact(std::move(replace));
+    auto res = apply_replace_objects(std::move(replace));
     EXPECT_FALSE(res.has_value());
     EXPECT_THAT(fmt::format("{}", res.error()), testing::HasSubstr("epoch"));
 
@@ -2542,7 +2541,7 @@ TEST_P(
     ASSERT_TRUE(apply_preregister_objects({oid2}).has_value());
 
     // Build an update with extents for tidp_a but no expected_epochs entry.
-    replace_objects_no_compact_update update;
+    replace_objects_update update;
     update.new_objects.push_back(new_obj_builder(oid2, 100, 1100)
                                    .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                                    .build());
@@ -2550,7 +2549,7 @@ TEST_P(
 
     // Build should fail because the bidirectional invariant is violated.
     auto& s = get_state();
-    auto build_res = replace_objects_no_compact_update::build(
+    auto build_res = replace_objects_update::build(
       s, std::move(update.new_objects), {});
     EXPECT_FALSE(build_res.has_value());
     EXPECT_THAT(
@@ -2590,7 +2589,7 @@ TEST_P(
                          .build());
 
     auto& s = get_state();
-    auto build_res = replace_objects_no_compact_update::build(
+    auto build_res = replace_objects_update::build(
       s, std::move(new_objs), std::move(flat_epochs));
     EXPECT_FALSE(build_res.has_value());
     EXPECT_THAT(

--- a/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
@@ -98,13 +98,13 @@ private:
     add_objects_update out;
 };
 
-struct replace_objects_builder {
+struct compact_objects_builder {
 public:
-    replace_objects_builder& add(new_object o) {
+    compact_objects_builder& add(new_object o) {
         out.new_objects.emplace_back(std::move(o));
         return *this;
     }
-    replace_objects_builder& clean(
+    compact_objects_builder& clean(
       std::string_view tp_str,
       compaction_state_update::cleaned_range r,
       model::timestamp cleaned_at) {
@@ -114,14 +114,14 @@ public:
         c_state.new_cleaned_ranges.push_back(std::move(r));
         return *this;
     }
-    replace_objects_builder& clean_tombstones(
+    compact_objects_builder& clean_tombstones(
       std::string_view tp_str, kafka::offset base, kafka::offset last) {
         auto tp = model::topic_id_partition::from(tp_str);
         auto& c_state = out.compaction_updates[tp.topic_id][tp.partition];
         c_state.removed_tombstones_ranges.insert(base, last);
         return *this;
     }
-    replace_objects_builder& set_expected_epoch(
+    compact_objects_builder& set_expected_epoch(
       std::string_view tp_str,
       partition_state::compaction_epoch_t compaction_epoch) {
         auto tp = model::topic_id_partition::from(tp_str);
@@ -129,10 +129,10 @@ public:
         c_state.expected_compaction_epoch = compaction_epoch;
         return *this;
     }
-    replace_objects_update build() { return std::move(out); }
+    compact_objects_update build() { return std::move(out); }
 
 private:
-    replace_objects_update out;
+    compact_objects_update out;
 };
 
 struct replace_objects_no_compact_builder {
@@ -209,7 +209,7 @@ protected:
     }
 
     std::expected<std::monostate, stm_update_error>
-    apply_replace_objects(replace_objects_update update) {
+    apply_compact_objects(compact_objects_update update) {
         chunked_vector<object_id> oids;
         for (const auto& o : update.new_objects) {
             oids.push_back(o.oid);
@@ -225,7 +225,7 @@ protected:
         if (!prereg.has_value()) {
             return prereg;
         }
-        replace_objects_db_update db_update{
+        compact_objects_db_update db_update{
           .new_objects = std::move(update.new_objects),
           .compaction_updates = std::move(update.compaction_updates),
         };
@@ -1312,17 +1312,17 @@ TEST_P(StateUpdateParamTest, TestCompactWithoutUpdateRejects) {
     auto add_res = apply_add_objects(std::move(add));
     ASSERT_TRUE(add_res.has_value());
 
-    // A replace_objects request that supplies new extents for a partition
+    // A compact_objects request that supplies new extents for a partition
     // but omits the compaction_update entry must be rejected. Without that
     // invariant the apply path would silently bump the partition's
     // compaction_epoch without OCC.
-    auto replace = replace_objects_builder()
+    auto replace = compact_objects_builder()
                      .add(new_obj_builder(oid2, 100, 1100)
                             .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                             .build())
                      .build();
 
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_compact_objects(std::move(replace));
     ASSERT_FALSE(replace_res.has_value());
     EXPECT_THAT(
       replace_res.error()(), testing::HasSubstr("no compaction_update entry"));
@@ -1339,11 +1339,11 @@ TEST_P(StateUpdateParamTest, TestCompactWithEpochOnlyUpdate) {
     auto add_res = apply_add_objects(std::move(add));
     ASSERT_TRUE(add_res.has_value());
 
-    // A replace_objects request whose compaction_update has only the
+    // A compact_objects request whose compaction_update has only the
     // expected_compaction_epoch set — no cleaned ranges, no tombstone
     // removals — is valid. Extents are replaced, the epoch is bumped, and
     // an empty compaction_state is visible.
-    auto replace = replace_objects_builder()
+    auto replace = compact_objects_builder()
                      .add(new_obj_builder(oid2, 100, 1100)
                             .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                             .build())
@@ -1351,7 +1351,7 @@ TEST_P(StateUpdateParamTest, TestCompactWithEpochOnlyUpdate) {
                        tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
 
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_compact_objects(std::move(replace));
     ASSERT_TRUE(replace_res.has_value()) << replace_res.error();
 
     auto& s = get_state();
@@ -1414,7 +1414,7 @@ TEST_P(StateUpdateParamTest, TestCompactWithCompaction) {
 
     // Fully replace partition a and clean part of it.
     auto replace
-      = replace_objects_builder()
+      = compact_objects_builder()
           .add(new_obj_builder(oid2, 100, 1100)
                  .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                  .build())
@@ -1426,7 +1426,7 @@ TEST_P(StateUpdateParamTest, TestCompactWithCompaction) {
           .set_expected_epoch(tidp_a, partition_state::compaction_epoch_t{0})
           .build();
 
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_compact_objects(std::move(replace));
     ASSERT_TRUE(replace_res.has_value());
 
     // Compact an extent, marking [5, 10] cleaned with tombstones.
@@ -1448,7 +1448,7 @@ TEST_P(StateUpdateParamTest, TestCompactWithCompaction) {
 
     // Compact an extent, marking [3, 4] cleaned with tombstones.
     replace
-      = replace_objects_builder()
+      = compact_objects_builder()
           .add(new_obj_builder(oid3, 100, 1100)
                  .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                  .build())
@@ -1459,7 +1459,7 @@ TEST_P(StateUpdateParamTest, TestCompactWithCompaction) {
             1999_t)
           .set_expected_epoch(tidp_a, partition_state::compaction_epoch_t{1})
           .build();
-    replace_res = apply_replace_objects(std::move(replace));
+    replace_res = apply_compact_objects(std::move(replace));
     ASSERT_TRUE(replace_res.has_value());
 
     {
@@ -1478,7 +1478,7 @@ TEST_P(StateUpdateParamTest, TestCompactWithCompaction) {
     }
 
     // Now mark [3, 8] as having removed tombstones.
-    replace = replace_objects_builder()
+    replace = compact_objects_builder()
                 .add(new_obj_builder(oid4, 100, 1100)
                        .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                        .build())
@@ -1486,7 +1486,7 @@ TEST_P(StateUpdateParamTest, TestCompactWithCompaction) {
                 .set_expected_epoch(
                   tidp_a, partition_state::compaction_epoch_t{2})
                 .build();
-    replace_res = apply_replace_objects(std::move(replace));
+    replace_res = apply_compact_objects(std::move(replace));
     ASSERT_TRUE(replace_res.has_value()) << replace_res.error();
 
     auto& s = get_state();
@@ -1517,7 +1517,7 @@ TEST_P(StateUpdateParamTest, TestCompactionMissingExtent) {
 
     // Add a clean range for tidp_a but only supply an extent with tidp_b.
     auto replace
-      = replace_objects_builder()
+      = compact_objects_builder()
           .add(new_obj_builder(oid2, 100, 1100)
                  .add(tidp_b, 0_o, 10_o, 1999_t, 0, 99)
                  .build())
@@ -1528,7 +1528,7 @@ TEST_P(StateUpdateParamTest, TestCompactionMissingExtent) {
             1999_t)
           .set_expected_epoch(tidp_a, partition_state::compaction_epoch_t{0})
           .build();
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_compact_objects(std::move(replace));
     EXPECT_FALSE(replace_res.has_value());
 }
 
@@ -1546,7 +1546,7 @@ TEST_P(StateUpdateParamTest, TestCompactionDoesntReplaceExtents) {
     ASSERT_TRUE(add_res.has_value());
 
     auto replace
-      = replace_objects_builder()
+      = compact_objects_builder()
           .add(new_obj_builder(oid3, 100, 1100)
                  .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                  .build())
@@ -1557,7 +1557,7 @@ TEST_P(StateUpdateParamTest, TestCompactionDoesntReplaceExtents) {
             1999_t)
           .set_expected_epoch(tidp_a, partition_state::compaction_epoch_t{0})
           .build();
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_compact_objects(std::move(replace));
     EXPECT_FALSE(replace_res.has_value());
 }
 
@@ -1584,7 +1584,7 @@ TEST_P(StateUpdateParamTest, TestCompactionDoesntReplaceExtentsStart) {
 
     // Add a replacement extent and claim that it cleans a larger offset range.
     auto replace
-      = replace_objects_builder()
+      = compact_objects_builder()
           .add(new_obj_builder(oid3, 100, 1100)
                  .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
                  .build())
@@ -1595,7 +1595,7 @@ TEST_P(StateUpdateParamTest, TestCompactionDoesntReplaceExtentsStart) {
             1999_t)
           .set_expected_epoch(tidp_a, partition_state::compaction_epoch_t{0})
           .build();
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_compact_objects(std::move(replace));
     EXPECT_FALSE(replace_res.has_value());
 }
 
@@ -1622,7 +1622,7 @@ TEST_P(StateUpdateParamTest, TestCompactionDoesntReplaceLogStart) {
 
     // Add a replacement extent and claim that it makes a larger range clean.
     auto replace
-      = replace_objects_builder()
+      = compact_objects_builder()
           .add(new_obj_builder(oid3, 100, 1100)
                  .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
                  .build())
@@ -1633,7 +1633,7 @@ TEST_P(StateUpdateParamTest, TestCompactionDoesntReplaceLogStart) {
             1999_t)
           .set_expected_epoch(tidp_a, partition_state::compaction_epoch_t{0})
           .build();
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_compact_objects(std::move(replace));
     EXPECT_FALSE(replace_res.has_value());
 }
 
@@ -1651,7 +1651,7 @@ TEST_P(StateUpdateParamTest, TestOverlappingTombstones) {
     ASSERT_TRUE(add_res.has_value());
 
     auto replace
-      = replace_objects_builder()
+      = compact_objects_builder()
           .add(new_obj_builder(oid2, 100, 1100)
                  .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                  .build())
@@ -1662,11 +1662,11 @@ TEST_P(StateUpdateParamTest, TestOverlappingTombstones) {
             1999_t)
           .set_expected_epoch(tidp_a, partition_state::compaction_epoch_t{0})
           .build();
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_compact_objects(std::move(replace));
     ASSERT_TRUE(replace_res.has_value());
 
     replace
-      = replace_objects_builder()
+      = compact_objects_builder()
           .add(new_obj_builder(oid3, 100, 1100)
                  .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                  .build())
@@ -1677,7 +1677,7 @@ TEST_P(StateUpdateParamTest, TestOverlappingTombstones) {
             1999_t)
           .set_expected_epoch(tidp_a, partition_state::compaction_epoch_t{1})
           .build();
-    replace_res = apply_replace_objects(std::move(replace));
+    replace_res = apply_compact_objects(std::move(replace));
     EXPECT_FALSE(replace_res.has_value());
 }
 
@@ -1693,7 +1693,7 @@ TEST_P(StateUpdateParamTest, TestRemoveNonExistingTombstones) {
     auto add_res = apply_add_objects(std::move(add));
     ASSERT_TRUE(add_res.has_value());
 
-    auto replace = replace_objects_builder()
+    auto replace = compact_objects_builder()
                      .add(new_obj_builder(oid2, 100, 1100)
                             .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                             .build())
@@ -1701,7 +1701,7 @@ TEST_P(StateUpdateParamTest, TestRemoveNonExistingTombstones) {
                      .set_expected_epoch(
                        tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
-    auto replace_res = apply_replace_objects(std::move(replace));
+    auto replace_res = apply_compact_objects(std::move(replace));
     EXPECT_FALSE(replace_res.has_value());
 }
 
@@ -2049,7 +2049,7 @@ TEST_P(StateUpdateParamTest, TestSetStartOffsetWithCompactionState) {
 
     // Compact part of the extent (clean offsets [5, 15])
     auto replace_update
-      = replace_objects_builder()
+      = compact_objects_builder()
           .add(new_obj_builder(oid2, 100, 1100)
                  .add(tidp_a, 0_o, 20_o, 2000_t, 0, 99)
                  .build())
@@ -2060,7 +2060,7 @@ TEST_P(StateUpdateParamTest, TestSetStartOffsetWithCompactionState) {
             3000_t)
           .set_expected_epoch(tidp_a, partition_state::compaction_epoch_t{0})
           .build();
-    auto replace_res = apply_replace_objects(std::move(replace_update));
+    auto replace_res = apply_compact_objects(std::move(replace_update));
     ASSERT_TRUE(replace_res.has_value());
 
     auto tp = model::topic_id_partition::from(tidp_a);
@@ -2363,7 +2363,7 @@ TEST_P(StateUpdateParamTest, TestCompactionValidatesEpoch) {
     {
         // Attempt to fully compact partition A with an invalid compaction
         // epoch.
-        auto replace = replace_objects_builder()
+        auto replace = compact_objects_builder()
                          .add(new_obj_builder(oid2, 100, 1100)
                                 .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                                 .build())
@@ -2378,14 +2378,14 @@ TEST_P(StateUpdateParamTest, TestCompactionValidatesEpoch) {
                            tidp_a, partition_state::compaction_epoch_t{999})
                          .build();
 
-        auto replace_res = apply_replace_objects(std::move(replace));
+        auto replace_res = apply_compact_objects(std::move(replace));
         ASSERT_FALSE(replace_res.has_value());
     }
 
     {
         // Fix the expected epoch and see state increment its internal
         // compaction_epoch.
-        auto replace = replace_objects_builder()
+        auto replace = compact_objects_builder()
                          .add(new_obj_builder(oid3, 100, 1100)
                                 .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                                 .build())
@@ -2400,7 +2400,7 @@ TEST_P(StateUpdateParamTest, TestCompactionValidatesEpoch) {
                            tidp_a, partition_state::compaction_epoch_t{0})
                          .build();
 
-        auto replace_res = apply_replace_objects(std::move(replace));
+        auto replace_res = apply_compact_objects(std::move(replace));
         ASSERT_TRUE(replace_res.has_value());
         auto& s = get_state();
         auto tp = model::topic_id_partition::from(tidp_a);

--- a/src/v/cloud_topics/read_replica/snapshot_metastore.cc
+++ b/src/v/cloud_topics/read_replica/snapshot_metastore.cc
@@ -201,7 +201,8 @@ snapshot_metastore::add_objects(
 }
 
 ss::future<std::expected<void, l1::metastore::errc>>
-snapshot_metastore::replace_objects(const object_metadata_builder&) {
+snapshot_metastore::replace_objects(
+  const object_metadata_builder&, const replace_epoch_map_t&) {
     co_return std::unexpected(errc::invalid_request);
 }
 

--- a/src/v/cloud_topics/read_replica/snapshot_metastore.h
+++ b/src/v/cloud_topics/read_replica/snapshot_metastore.h
@@ -46,8 +46,8 @@ public:
     ss::future<std::expected<add_response, errc>> add_objects(
       const object_metadata_builder&, const term_offset_map_t&) override;
 
-    ss::future<std::expected<void, errc>>
-    replace_objects(const object_metadata_builder&) override;
+    ss::future<std::expected<void, errc>> replace_objects(
+      const object_metadata_builder&, const replace_epoch_map_t&) override;
 
     ss::future<std::expected<void, errc>>
     set_start_offset(const model::topic_id_partition&, kafka::offset) override;

--- a/src/v/rpc/rpc_compiler.py
+++ b/src/v/rpc/rpc_compiler.py
@@ -245,7 +245,16 @@ def _enrich_methods(service: Any):
         bytes("%s:%s" % (service["namespace"], service["service_name"]), "utf-8")
     )
 
+    # Method IDs are derived from the method name and the input/output type
+    # names, so renaming any of them changes the wire-level dispatch ID. To
+    # let a method be renamed (or its types renamed) without breaking older
+    # peers that still use the previous identifiers, an entry may set
+    # `legacy_id` to the prior name/types. The hash is then computed from
+    # those, and the generated method ID matches what the old codegen would
+    # have produced. This is safe only when the underlying serde payload is
+    # field-for-field compatible across the rename.
     def _xor_id(m):
+        m = m.get("legacy_id", m)
         mid = ("%s:" % service["namespace"]).join(
             [m["name"], m["input_type"], m["output_type"]]
         )


### PR DESCRIPTION
As a precursor to leveling, we need to validate `compaction_epoch` in the `metastore` for regular `replace_objects()` commands, since the same concurrent race of re-adding stale data to the log is possible with a regular `replace_objects()` command as it is with a `compact_objects()` command.

This PR now reworks the existing `replace_objects()` command & RPC types in the `metastore` layer to exist as a `compact_objects()` RPC (to be compatible with existing callers) and adds a newly dedicated `replace_objects()` type & RPC which only carries expected `compaction_epoch` metadata with it instead of potentially holding compaction update metadata.

This backwards compatibility is only one way - old nodes will not be able to recognize the new `replace_objects` nor the new `compact_objects` RPCs.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
