### PR TITLE
rpk: standardize empty spaces in table column header

### DIFF
--- a/src/go/rpk/pkg/cli/shadow/status.go
+++ b/src/go/rpk/pkg/cli/shadow/status.go
@@ -195,7 +195,7 @@ func printStatusTasks(tasks []taskStatus) {
 		fmt.Println("No tasks to display right now.")
 		return
 	}
-	t := out.NewTable("Name", "Broker_ID", "Shard", "State", "Reason")
+	t := out.NewTable("Name", "Broker-ID", "Shard", "State", "Reason")
 	defer t.Flush()
 	for _, task := range tasks {
 		t.Print(task.Name, task.BrokerID, task.Shard, task.State, task.Reason)
@@ -225,7 +225,7 @@ func printStatusTopics(topics []topicStatus, props []string) {
 }
 
 func printStatusPartitionTable(partitions []partitionInfo) {
-	t := out.NewTable("", "Partition", "SRC_LSO", "SRC_HWM", "DST_HWM", "Lag")
+	t := out.NewTable("", "Partition", "SRC-LSO", "SRC-HWM", "DST-HWM", "Lag")
 	defer t.Flush()
 	for _, p := range partitions {
 		t.Print("", p.PartitionID, p.SrcLSO, p.SrcHWM, p.DstHWM, p.Lag)

--- a/src/go/rpk/pkg/cli/topic/list.go
+++ b/src/go/rpk/pkg/cli/topic/list.go
@@ -226,10 +226,10 @@ func printDetailedListView(f config.OutFormatter, topics []detailedListTopic, w 
 		}
 		headers = append(headers, "replicas")
 		if topic.isOffline {
-			headers = append(headers, "offline_replicas")
+			headers = append(headers, "offline-replicas")
 		}
 		if topic.isLoadErr {
-			headers = append(headers, "load_error")
+			headers = append(headers, "load-error")
 		}
 		printPartitionTable(w, headers, topic, topic.PartitionList)
 		if i != len(topics)-1 {

--- a/src/go/rpk/pkg/cli/topic/list_test.go
+++ b/src/go/rpk/pkg/cli/topic/list_test.go
@@ -82,7 +82,7 @@ func TestDetailedListView(t *testing.T) {
 	printDetailedListView(f, d, b)
 	require.Equal(t, [][]string{
 		{"test-topic,", "2", "partitions,", "3", "replicas"},
-		{"PARTITION", "LEADER", "EPOCH", "REPLICAS", "OFFLINE_REPLICAS"},
+		{"PARTITION", "LEADER", "EPOCH", "REPLICAS", "OFFLINE-REPLICAS"},
 		{"0", "1", "5", "[1", "2", "3]", "[]"},
 		{"1", "2", "3", "[1", "2", "3]", "[1]"},
 	}, out.TableRows(b.String()))
@@ -115,7 +115,7 @@ func TestDetailedListViewWithInternal(t *testing.T) {
 		{"0", "1", "1", "[1]"},
 		{},
 		{"test-topic,", "2", "partitions,", "3", "replicas"},
-		{"PARTITION", "LEADER", "EPOCH", "REPLICAS", "OFFLINE_REPLICAS"},
+		{"PARTITION", "LEADER", "EPOCH", "REPLICAS", "OFFLINE-REPLICAS"},
 		{"0", "1", "5", "[1", "2", "3]", "[]"},
 		{"1", "2", "3", "[1", "2", "3]", "[1]"},
 	}, out.TableRows(b.String()))

--- a/src/go/rpk/pkg/cli/transform/list.go
+++ b/src/go/rpk/pkg/cli/transform/list.go
@@ -155,7 +155,7 @@ func printSummary(f config.OutFormatter, s []summarizedTransformMetadata, w io.W
 		fmt.Fprintf(w, "%s\n", t)
 		return
 	}
-	tw := out.NewTableTo(w, "Name", "Input Topic", "Output Topic", "Running", "Lag")
+	tw := out.NewTableTo(w, "Name", "Input-Topic", "Output-Topic", "Running", "Lag")
 	defer tw.Flush()
 	for _, m := range s {
 		tw.Print(m.Name, m.InputTopic, strings.Join(m.OutputTopics, ", "), m.Running, m.Lag)

--- a/src/go/rpk/pkg/cli/transform/list_test.go
+++ b/src/go/rpk/pkg/cli/transform/list_test.go
@@ -89,7 +89,7 @@ func TestPrintSummaryView(t *testing.T) {
 	b := &strings.Builder{}
 	printSummary(f, s, b)
 	require.Equal(t, [][]string{
-		{"NAME", "INPUT", "TOPIC", "OUTPUT", "TOPIC", "RUNNING", "LAG"},
+		{"NAME", "INPUT-TOPIC", "OUTPUT-TOPIC", "RUNNING", "LAG"},
 		{"foo2bar", "foo", "bar", "2", "/", "3", "7"},
 		{"scrubber", "pii", "cleaned,", "munged", "0", "/", "1", "99"},
 	}, out.TableRows(b.String()))

--- a/src/go/rpk/pkg/out/out.go
+++ b/src/go/rpk/pkg/out/out.go
@@ -243,7 +243,9 @@ func NewTable(headers ...string) *TabWriter {
 func NewTableTo(w io.Writer, headers ...string) *TabWriter {
 	var iheaders []any
 	for _, header := range headers {
-		iheaders = append(iheaders, norm(header))
+		// Normalize headers: replace spaces and underscores with `-` so all
+		// table headers render with a consistent separator.
+		iheaders = append(iheaders, strings.ReplaceAll(strings.ReplaceAll(norm(header), " ", "-"), "_", "-"))
 	}
 	t := NewTabWriterTo(w)
 	if len(iheaders) > 0 {


### PR DESCRIPTION
We use everywhere `-` instead of spaces; there were just these 3 places where we didn't.

On top of that, now we automatically replace
empty spaces and `_` as part of the header string
normalization.

Cosmetic issue found by @twmb 
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Improvements

* rpk: all column headers now are standardized to avoid white spaces, and underscores in favor of `-`