### PR TITLE
`syschecks`: log, don't abort on low available memory

### DIFF
--- a/src/v/cloud_topics/level_one/maintenance/tests/scheduler_fixture.h
+++ b/src/v/cloud_topics/level_one/maintenance/tests/scheduler_fixture.h
@@ -17,6 +17,7 @@
 #include "cluster/topic_configuration.h"
 #include "cluster/topic_properties.h"
 #include "container/chunked_hash_map.h"
+#include "test_utils/scoped_config.h"
 
 class fake_topic_metadata_provider : public l1::topic_cfg_provider {
 public:
@@ -51,7 +52,10 @@ public:
 
 class SchedulerTestFixture : public l1::l1_reader_fixture {
 public:
-    ss::future<> SetUpAsync() override { co_await start_scheduler(); }
+    ss::future<> SetUpAsync() override {
+        cfg.get("cloud_topics_enabled").set_value(true);
+        co_await start_scheduler();
+    }
 
     ss::future<> start_scheduler() {
         auto info_collector = l1::log_info_collector(
@@ -141,4 +145,6 @@ public:
 
 protected:
     std::unique_ptr<l1::compaction_scheduler> scheduler{nullptr};
+
+    scoped_config cfg;
 };

--- a/src/v/cloud_topics/level_one/maintenance/tests/scheduler_multithread_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/tests/scheduler_multithread_test.cc
@@ -12,7 +12,6 @@
 #include "container/chunked_hash_map.h"
 #include "model/fundamental.h"
 #include "random/generators.h"
-#include "test_utils/scoped_config.h"
 
 #include <gtest/gtest.h>
 
@@ -32,7 +31,6 @@ TEST_F(SchedulerTestFixture, TestSchedulerMultithread) {
     int num_rounds = 50;
 #endif
 
-    scoped_config cfg;
     cfg.get("cloud_topics_compaction_interval_ms").set_value(100ms);
     ss::abort_source as;
     chunked_hash_set<ss::shard_id> paused_workers;

--- a/src/v/cloud_topics/level_one/maintenance/tests/scheduler_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/tests/scheduler_test.cc
@@ -130,7 +130,6 @@ TEST_F(SchedulerTestFixture, TestScheduler) {
     int num_rounds = 50;
 #endif
 
-    scoped_config cfg;
     cfg.get("cloud_topics_compaction_interval_ms").set_value(100ms);
     ss::abort_source as;
     chunked_hash_set<ss::shard_id> paused_workers;

--- a/src/v/cluster/cluster_discovery.cc
+++ b/src/v/cluster/cluster_discovery.cc
@@ -25,6 +25,8 @@
 #include <seastar/core/seastar.hh>
 
 #include <chrono>
+#include <optional>
+#include <vector>
 
 using model::node_id;
 using std::vector;
@@ -41,8 +43,17 @@ cluster_discovery::cluster_discovery(
   , _join_timeout(std::chrono::seconds(2))
   , _as(as) {}
 
-ss::future<cluster_discovery::registration_result>
-cluster_discovery::register_with_cluster() {
+ss::future<std::optional<cluster_discovery::registration_result>>
+cluster_discovery::register_with_cluster(join_retry_policy policy) {
+    if (policy == join_retry_policy::require_existing_cluster) {
+        // Skip founder discovery: this path assumes a cluster already exists
+        // (e.g. a wiped seed rejoining, taking the fast joiner path). Make a
+        // single bounded registration pass; a nullopt result means no seed
+        // answered, so the caller can defer to the authoritative founder
+        // handshake once every broker's RPC server is up.
+        co_return co_await dispatch_node_uuid_registration_to_seeds();
+    }
+
     // Initialize cluster founder state, in case we are starting a new cluster.
     // This will validate our configured node ID if we are a cluster founder.
     bool is_founder = co_await is_cluster_founder();
@@ -135,8 +146,12 @@ cluster_discovery::node_ids_by_uuid& cluster_discovery::get_node_ids_by_uuid() {
 ss::future<std::optional<cluster_discovery::registration_result>>
 cluster_discovery::dispatch_node_uuid_registration_to_seeds() {
     const auto& seed_servers = config::node().seed_servers();
+    const auto self_addr = config::node().advertised_rpc_api();
     auto self = make_self_broker(config::node());
     for (const auto& s : seed_servers) {
+        if (s.addr == self_addr) {
+            continue;
+        }
         vlog(
           clusterlog.info,
           "Requesting node ID {} for node UUID {} from {}",
@@ -270,15 +285,32 @@ cluster_discovery::fetch_controller_snapshot_from_leader(
     co_return std::nullopt;
 }
 
+ss::future<result<cluster_bootstrap_info_reply>>
+cluster_discovery::request_cluster_bootstrap_info_attempt(
+  net::unresolved_address addr, std::chrono::milliseconds timeout) const {
+    return do_with_client_one_shot<cluster_bootstrap_client_protocol>(
+      addr,
+      config::node().rpc_server_tls(),
+      timeout,
+      rpc::transport_version::v2,
+      [timeout](cluster_bootstrap_client_protocol c) {
+          return c
+            .cluster_bootstrap_info(
+              cluster_bootstrap_info_request{},
+              rpc::client_opts(rpc::clock_type::now() + timeout))
+            .then(&rpc::get_ctx_data<cluster_bootstrap_info_reply>);
+      });
+}
+
 ss::future<cluster_bootstrap_info_reply>
 cluster_discovery::request_cluster_bootstrap_info_single(
   net::unresolved_address addr) const {
     vlog(clusterlog.info, "Requesting cluster bootstrap info from {}", addr);
     _as.check();
+    static constexpr auto cluster_bootstrap_info_timeout = std::chrono::seconds(
+      2);
     auto repeat_jitter = simple_time_jitter<model::timeout_clock>(1s);
     while (true) {
-        result<cluster_bootstrap_info_reply> reply_result(
-          std::errc::connection_refused);
         if (_is_cluster_founder.has_value()) {
             // Another fiber detected the presence of a cluster. Just exit
             // early.
@@ -289,19 +321,8 @@ cluster_discovery::request_cluster_bootstrap_info_single(
             co_return cluster_bootstrap_info_reply{};
         }
         try {
-            reply_result = co_await do_with_client_one_shot<
-              cluster_bootstrap_client_protocol>(
-              addr,
-              config::node().rpc_server_tls(),
-              2s,
-              rpc::transport_version::v2,
-              [](cluster_bootstrap_client_protocol c) {
-                  return c
-                    .cluster_bootstrap_info(
-                      cluster_bootstrap_info_request{},
-                      rpc::client_opts(rpc::clock_type::now() + 2s))
-                    .then(&rpc::get_ctx_data<cluster_bootstrap_info_reply>);
-              });
+            auto reply_result = co_await request_cluster_bootstrap_info_attempt(
+              addr, cluster_bootstrap_info_timeout);
             if (reply_result) {
                 vlog(
                   clusterlog.info,

--- a/src/v/cluster/cluster_discovery.h
+++ b/src/v/cluster/cluster_discovery.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "absl/container/flat_hash_map.h"
+#include "base/outcome.h"
 #include "base/seastarx.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -79,6 +80,24 @@ public:
       std::optional<model::cluster_uuid> cluster_uuid,
       ss::abort_source&);
 
+    // Controls how register_with_cluster() behaves.
+    enum class join_retry_policy : uint8_t {
+        // Determine whether this node is a cluster founder (which may block on
+        // the full mutual seed handshake, so this is only safe once every
+        // seed's RPC server is listening) and, if not, retry registration until
+        // it succeeds. This path is taken for non-registered joining nodes, as
+        // well as seed nodes that are attempting to form a cluster for the
+        // first time.
+        retry_until_joined,
+        // Assume a cluster already exists: skip founder discovery entirely and
+        // make a single, bounded registration pass. If no cluster answers,
+        // return an empty result rather than blocking. This path is taken for
+        // apparent seed nodes (e.g. brokers that indicate they are seed nodes
+        // according to their node-local config) that may in fact be wiped nodes
+        // trying to join an existing cluster.
+        require_existing_cluster,
+    };
+
     // Register with the cluster:
     // - If we are a fresh cluster founder, broadcast to other founders
     //   to ensure we agree on the seed servers, then proceed.
@@ -91,7 +110,14 @@ public:
     // the cluster has accepted our request to join, and we have a controller
     // snapshot that we can use to prime configuration/features state before
     // starting up the controller.
-    ss::future<registration_result> register_with_cluster();
+    //
+    // With join_retry_policy::require_existing_cluster the founder handshake is
+    // skipped and a single bounded registration pass is made; the result is
+    // nullopt if no cluster answered (the caller should then defer to the late
+    // founder handshake). join_retry_policy::retry_until_joined always yields a
+    // result (or throws on shutdown).
+    ss::future<std::optional<registration_result>> register_with_cluster(
+      join_retry_policy = join_retry_policy::retry_until_joined);
 
     // Returns brokers to be used to form a Raft group for a new cluster.
     //
@@ -143,9 +169,14 @@ private:
     ss::future<std::optional<registration_result>>
     dispatch_node_uuid_registration_to_seeds();
 
-    // Requests `cluster_bootstrap_info` from the given address, returning
-    // early with a bogus result if it's already been determined if this node
-    // is a cluster founder.
+    // Issues a single cluster_bootstrap_info RPC to the given address.
+    ss::future<result<cluster_bootstrap_info_reply>>
+    request_cluster_bootstrap_info_attempt(
+      net::unresolved_address, std::chrono::milliseconds timeout) const;
+
+    // Requests `cluster_bootstrap_info` from the given address, retrying until
+    // it succeeds, and returning early with a bogus result if it's already been
+    // determined that this node is a cluster founder.
     ss::future<cluster_bootstrap_info_reply>
       request_cluster_bootstrap_info_single(net::unresolved_address) const;
 

--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -290,8 +290,8 @@ std::filesystem::path config_manager::cache_path() {
 static void preload_local(
   const ss::sstring& key,
   const ss::sstring& raw_value,
-  std::optional<std::reference_wrapper<config_manager::preload_result>>
-    result) {
+  std::optional<std::reference_wrapper<config_manager::preload_result>> result,
+  defer_needs_restart defer = defer_needs_restart::no) {
     auto& cfg = config::shard_local_cfg();
     if (cfg.contains(key)) {
         auto& property = cfg.get(key);
@@ -301,13 +301,18 @@ static void preload_local(
             // but for strings it's not (the literal value in the cache is
             // "\"foo\"").
             auto decoded = YAML::Load(raw_value);
-            bool set = property.set_value(decoded);
 
-            // We intentionally use set_value (not set_pending_value) even
-            // for needs_restart properties: preload runs before anything
-            // reads the config, so values go straight into _value.
-            // STM replay later calls set_pending_value for any updates
-            // beyond the cache.
+            // Normally preload runs before anything reads the config, so
+            // values (even needs_restart ones) go straight into _value via
+            // set_value; STM replay later calls set_pending_value for updates
+            // beyond the cache. But a join snapshot applied late in startup
+            // (defer_needs_restart) must not promote needs_restart properties
+            // live - that would make the running value disagree with what
+            // memory groups and other consumers already sized against - so
+            // persist them as pending, activated on the next restart.
+            bool set = (defer && property.needs_restart())
+                         ? property.set_pending_value(decoded)
+                         : property.set_value(decoded);
 
             if (result.has_value() && set) {
                 vlog(
@@ -366,8 +371,8 @@ static void preload_local(
     }
 }
 
-ss::future<config_manager::preload_result>
-config_manager::preload_join(const controller_join_snapshot& snap) {
+ss::future<config_manager::preload_result> config_manager::preload_join(
+  const controller_join_snapshot& snap, defer_needs_restart defer) {
     preload_result result;
 
     result.version = snap.config.version;
@@ -377,11 +382,12 @@ config_manager::preload_join(const controller_join_snapshot& snap) {
         auto& value = i.second;
 
         // Run locally to get validation fields of result
-        preload_local(key, value, std::ref(result));
+        preload_local(key, value, std::ref(result), defer);
 
         // Broadcast value to all shards
-        co_await ss::smp::invoke_on_all(
-          [&key, &value]() { preload_local(key, value, std::nullopt); });
+        co_await ss::smp::invoke_on_all([&key, &value, defer]() {
+            preload_local(key, value, std::nullopt, defer);
+        });
     }
 
     co_return result;

--- a/src/v/cluster/config_manager.h
+++ b/src/v/cluster/config_manager.h
@@ -21,12 +21,18 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/sharded.hh>
+#include <seastar/util/bool_class.hh>
 
 namespace YAML {
 class Node;
 }
 
 namespace cluster {
+
+// When set, needs_restart properties applied from a late join snapshot are
+// persisted as pending (activated on the next restart) rather than promoted
+// live. See preload_join().
+using defer_needs_restart = ss::bool_class<struct defer_needs_restart_tag>;
 
 /// This state machine receives updates to the global cluster config,
 /// and uses them to update the per-shard configuration objects
@@ -61,8 +67,12 @@ public:
 
     // Preload while joining the cluster, from a controller snapshot sent
     // in response to a join request.
-    static ss::future<preload_result>
-    preload_join(const controller_join_snapshot&);
+    //
+    // When defer_needs_restart is set, needs_restart properties are applied as
+    // pending (activated on the next restart) rather than promoted live.
+    static ss::future<preload_result> preload_join(
+      const controller_join_snapshot&,
+      defer_needs_restart = defer_needs_restart::no);
 
     ss::future<> start();
     ss::future<> stop();

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1574,8 +1574,7 @@ configuration::configuration()
       "storage_compaction_key_map_memory_limit_percent",
       "Limit on `storage_compaction_key_map_memory`, expressed as a percentage "
       "of memory per shard, that bounds the amount of memory used by "
-      "compaction key-offset maps. Memory per shard is computed after "
-      "`data_transforms_per_core_memory_reservation`, and only applies when "
+      "compaction key-offset maps. Only applies when "
       "`log_compaction_use_sliding_window` is set to `true`.",
       {.needs_restart = needs_restart::yes,
        .example = "12.0",

--- a/src/v/kafka/client/test/fixture.h
+++ b/src/v/kafka/client/test/fixture.h
@@ -35,7 +35,7 @@ public:
         app.wire_up_bootstrap_services();
         app.hydrate_cluster_config(make_minimal_cfg());
         app.bootstrap_from_kvstore();
-        app.establish_cluster_view();
+        app.establish_cluster_view(app_signal->abort_source());
         app.initialize(proxy_config(), proxy_client_config());
         app.check_environment();
         app.wire_up_and_start(*app_signal, test_mode);

--- a/src/v/kafka/server/tests/topic_recreate_test.cc
+++ b/src/v/kafka/server/tests/topic_recreate_test.cc
@@ -141,7 +141,7 @@ public:
         app.wire_up_bootstrap_services();
         app.hydrate_cluster_config(make_minimal_cfg());
         app.bootstrap_from_kvstore();
-        app.establish_cluster_view();
+        app.establish_cluster_view(app_signal->abort_source());
         app.initialize(proxy_config(), proxy_client_config());
         app.check_environment();
         app.wire_up_and_start(*app_signal, true);

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -348,11 +348,11 @@ int application::run(int ac, char** av) {
                 wire_up_and_start_crypto_services();
                 mark_config_ready(false).get();
                 hydrate_cluster_config(node_cfg_yaml);
+                init_crashtracker(app_signal);
                 wire_up_bootstrap_services();
                 bootstrap_from_kvstore();
-                establish_cluster_view();
+                establish_cluster_view(app_signal.abort_source());
                 log_cluster_config();
-                init_crashtracker(app_signal);
                 initialize();
                 check_environment();
                 setup_metrics();
@@ -769,8 +769,28 @@ void application::wire_up_bootstrap_services() {
       .get();
 }
 
-void application::establish_cluster_view() {
-    bootstrap_controller_view().get();
+void application::establish_cluster_view(ss::abort_source& as) {
+    _cluster_discovery = std::make_unique<cluster::cluster_discovery>(
+      storage.local().node_uuid(), storage.local().get_cluster_uuid(), as);
+
+    // Classify how this node obtains its node ID once, up front.
+    _node_id_source = classify_node_id_source();
+
+    switch (_node_id_source.value()) {
+    case node_id_source::unregistered:
+        // A first-time joiner learns the cluster's configuration via its join
+        // reply. This covers non-seed joiners and wiped seed joiners that
+        // detect an existing cluster.
+        prime_node_identity().get();
+        break;
+    case node_id_source::established:
+    case node_id_source::overridden:
+        // A restarting node refreshes its view from the controller leader here,
+        // when it has a persisted member set to fetch from; otherwise this is a
+        // no-op and the node falls back to its local cache.
+        bootstrap_controller_view().get();
+        break;
+    }
 
     // The shard_local_cfg() is now safe to use as we have a view consistent
     // with the rest of the cluster.

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -890,7 +890,8 @@ void application::check_environment() {
       = "/proc/sys/crypto/fips_enabled";
     syschecks::systemd_message("checking environment (CPU, Mem)").get();
     syschecks::cpu();
-    syschecks::memory(config::node().developer_mode());
+    syschecks::memory(
+      memory_groups().total_reserved_memory(), config::node().developer_mode());
     if (config::shard_local_cfg().code_hugepages_enabled()) {
         syschecks::promote_code_to_hugepages();
     }

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -16,6 +16,7 @@
 #include "cloud_topics/app.h"
 #include "cloud_topics/test_fixture_cfg.h"
 #include "cluster/archival/fwd.h"
+#include "cluster/cluster_discovery.h"
 #include "cluster/config_manager.h"
 #include "cluster/fwd.h"
 #include "cluster/inventory_service.h"
@@ -242,16 +243,20 @@ public:
     // 1. Applying any local kvstore snapshots (which contain potentially
     //    stale config and feature table state, as well as persisted
     //    node/cluster UUID information).
-    // 2. If we already have an identity and a persisted member set,
-    //    refreshing that view by fetching an authoritative
-    //    controller_join_snapshot from the controller leader via the
-    //    `fetch_controller_snapshot` RPC. New nodes that lack persisted
-    //    state skip this step; they will instead receive their snapshot
-    //    later through the join_node response in resolve_node_identity.
-    // 3. Marking shard_local_cfg() as ready, after which downstream
+    // 2. For a first-time joiner, registering with the cluster and applying the
+    //    controller_join_snapshot from the join reply. This covers non-seed
+    //    joiners and wiped seeds that are rejoining an existing cluster.
+    //    Genuine founders (which need the RPC service for the founder
+    //    handshake) and node-ID overrides are resolved later in
+    //    resolve_node_identity().
+    // 3. For a restarting node with a persisted member set, refreshing that
+    //    view by fetching an authoritative controller_join_snapshot from the
+    //    controller leader via the `fetch_controller_snapshot` RPC.
+    // 4. Marking shard_local_cfg() as ready, after which downstream
     //    services may safely read cluster configuration.
+    // The abort source (owned by the caller) bounds cluster discovery.
     // Public for test fixture access.
-    void establish_cluster_view();
+    void establish_cluster_view(ss::abort_source&);
 
     // Constructs and starts the services required to provide cryptographic
     // algorithm support to Redpanda. Public for test fixture access.
@@ -296,16 +301,53 @@ private:
     // Attempts to read a local feature table snapshot from the kvstore and
     // apply it.
     ss::future<> maybe_apply_local_feature_table_snapshot();
+    // How this node obtains its node ID at startup.
+    enum class node_id_source {
+        // A node ID is already persisted (this node ran a controller before):
+        // reuse it. A restarting node.
+        established,
+        // An operator override supplies the node ID, rewriting the persisted
+        // configuration_invariants.
+        overridden,
+        // No usable node ID yet. The node must register with the cluster to be
+        // assigned one. A first-time founder or joining node.
+        unregistered,
+    };
+    // Returns true if this node is present in the local node config's list of
+    // seed servers, false otherwise.
+    bool is_seed_node() const;
+    // Classifies how this node obtains its node ID from persisted invariants,
+    // node config and node-ID overrides. Reads the kvstore; call once and cache
+    // the result in _node_id_source.
+    node_id_source classify_node_id_source();
     // Performs cluster discovery for first time cluster joiners, or resolves
-    // node identity from persisted kvstore state.
+    // node identity from persisted kvstore state. Also persists the node UUID.
+    // No-op for the discovery/snapshot step if identity was already resolved
+    // early via prime_node_identity().
     ss::future<> resolve_node_identity();
+    // Applies an operator node-ID override: rewrites the persisted
+    // configuration_invariants and returns the overridden node ID.
+    ss::future<model::node_id> apply_node_id_override();
+    // Registers with the cluster per the retry_policy and, if a
+    // controller_join_snapshot is returned in the join reply, applies it and
+    // returns the assigned node ID. When defer_needs_restart is set,
+    // needs_restart configs are applied as pending rather than promoted live.
+    ss::future<std::optional<model::node_id>> register_and_apply_join_snapshot(
+      cluster::cluster_discovery::join_retry_policy policy,
+      cluster::defer_needs_restart = cluster::defer_needs_restart::no);
+    // Resolves node identity early by registering with the cluster and applying
+    // the join snapshot. Used for a first-time joiner (a non-seed, or a seed
+    // that finds an existing cluster).
+    ss::future<> prime_node_identity();
     // Fetches and applies a view of the controller_stm from the current
     // controller leader.
     ss::future<> bootstrap_controller_view();
     // Refreshes the cluster config and feature table from the provided
-    // snapshot.
-    ss::future<>
-    apply_controller_snapshot(const cluster::controller_join_snapshot&);
+    // snapshot. When defer_needs_restart is set, needs_restart config
+    // properties are applied as pending.
+    ss::future<> apply_controller_snapshot(
+      const cluster::controller_join_snapshot&,
+      cluster::defer_needs_restart = cluster::defer_needs_restart::no);
 
     void trigger_abort_source();
 
@@ -344,7 +386,10 @@ private:
     cluster::config_manager::preload_result _config_preload;
 
     std::unique_ptr<cluster::cluster_discovery> _cluster_discovery;
-    bool _node_uuid_needs_persisting{false};
+    // Set once node identity has been resolved, either early via
+    // prime_node_identity() or later via resolve_node_identity().
+    bool _node_identity_resolved{false};
+    std::optional<node_id_source> _node_id_source;
 
     // When joining a cluster, we are tipped off as to the last applied
     // offset of the controller stm from another node.  We will wait for

--- a/src/v/redpanda/application_bootstrap.cc
+++ b/src/v/redpanda/application_bootstrap.cc
@@ -50,6 +50,8 @@
 #include <seastar/core/memory.hh>
 #include <seastar/core/smp.hh>
 
+#include <chrono>
+
 namespace {
 
 bytes node_uuid_key() {
@@ -223,6 +225,7 @@ void application::bootstrap_from_kvstore() {
     // Load the local node UUID, or create one if none exists.
     auto& kvs = storage.local().kvs();
     model::node_uuid node_uuid;
+    bool node_uuid_is_new = false;
     auto node_uuid_buf = kvs.get(
       storage::kvstore::key_space::controller, node_uuid_key());
     if (node_uuid_buf) {
@@ -235,7 +238,7 @@ void application::bootstrap_from_kvstore() {
     } else {
         node_uuid = model::node_uuid(uuid_t::create());
         vlog(_log.info, "Generated new UUID for node: {}", node_uuid);
-        _node_uuid_needs_persisting = true;
+        node_uuid_is_new = true;
     }
 
     _node_overrides.maybe_set_overrides(
@@ -249,13 +252,22 @@ void application::bootstrap_from_kvstore() {
           node_uuid,
           u.value());
         node_uuid = u.value();
-        _node_uuid_needs_persisting = true;
+        node_uuid_is_new = true;
     }
     storage
       .invoke_on_all([node_uuid](storage::api& storage) mutable {
           storage.set_node_uuid(node_uuid);
       })
       .get();
+
+    if (node_uuid_is_new) {
+        kvs
+          .persist_pre_start(
+            storage::kvstore::key_space::controller,
+            node_uuid_key(),
+            serde::to_iobuf(node_uuid))
+          .get();
+    }
 }
 
 void application::start_storage_services(test_cfg cfg) {
@@ -271,78 +283,150 @@ void application::start_storage_services(test_cfg cfg) {
       .get();
 }
 
-ss::future<> application::resolve_node_identity() {
-    auto& kvs = storage.local().kvs();
+ss::future<std::optional<model::node_id>>
+application::register_and_apply_join_snapshot(
+  cluster::cluster_discovery::join_retry_policy policy,
+  cluster::defer_needs_restart defer_needs_restart) {
+    auto registration_result
+      = co_await _cluster_discovery->register_with_cluster(policy);
 
-    // We need to persist the node's local UUID before potentially joining the
-    // cluster for the first time.
-    if (_node_uuid_needs_persisting) {
-        co_await kvs.put(
-          storage::kvstore::key_space::controller,
-          node_uuid_key(),
-          serde::to_iobuf(storage.local().node_uuid()));
+    if (!registration_result.has_value()) {
+        vassert(
+          policy
+            == cluster::cluster_discovery::join_retry_policy::
+              require_existing_cluster,
+          "register_with_cluster returned no result under retry_until_joined");
+        // No existing cluster was found (this node is likely a founder).
+        // Registration is deferred until later in the bootstrapping process.
+        co_return std::nullopt;
     }
 
-    auto invariants_buf = kvs.get(
-      storage::kvstore::key_space::controller,
-      cluster::controller::invariants_key());
-
-    bool ever_ran_controller = invariants_buf.has_value();
-
-    bool has_id = config::node().node_id().has_value() && ever_ran_controller;
-
-    bool force_override = _node_overrides.node_id().has_value()
-                          && _node_overrides.ignore_existing_node_id();
-
-    model::node_id node_id;
-    if (has_id && !force_override) {
+    if (registration_result->newly_registered) {
         vlog(
           _log.info,
-          "Running with already-established node ID {}",
-          config::node().node_id());
-        node_id = config::node().node_id().value();
-    } else if (auto id = _node_overrides.node_id(); id.has_value()) {
-        vlog(
-          _log.warn,
-          "Overriding node ID: {} -> {} [ignore_existing_node_id? {}]",
-          config::node().node_id(),
-          id,
-          has_id && force_override);
-        node_id = id.value();
-        // null out the config'ed ID indiscriminately; it will be set outside
-        // the conditional
-        co_await ss::smp::invoke_on_all(
-          [] { config::node().node_id.set_value(std::nullopt); });
-        if (invariants_buf.has_value()) {
-            auto invariants
-              = reflection::from_iobuf<cluster::configuration_invariants>(
-                std::move(invariants_buf.value()));
-            invariants.node_id = node_id;
-            co_await kvs.put(
-              storage::kvstore::key_space::controller,
-              cluster::controller::invariants_key(),
-              reflection::to_iobuf(
-                cluster::configuration_invariants{invariants}));
-            vlog(_log.debug, "Force-updated local node_id to {}", node_id);
+          "Registered with cluster as node ID {}",
+          registration_result->assigned_node_id);
+        if (registration_result->controller_snapshot.has_value()) {
+            auto snap = serde::from_iobuf<cluster::controller_join_snapshot>(
+              std::move(registration_result->controller_snapshot.value()));
+            co_await apply_controller_snapshot(snap, defer_needs_restart);
         }
-    } else {
-        auto registration_result
-          = co_await _cluster_discovery->register_with_cluster();
-        node_id = registration_result.assigned_node_id;
+    }
+    co_return registration_result->assigned_node_id;
+}
 
-        if (registration_result.newly_registered) {
-            vlog(
-              _log.info,
-              "Registered with cluster as node ID {}",
-              registration_result.assigned_node_id);
-            if (registration_result.controller_snapshot.has_value()) {
-                // Do something with the controller snapshot
-                auto snap
-                  = serde::from_iobuf<cluster::controller_join_snapshot>(
-                    std::move(registration_result.controller_snapshot.value()));
-                co_await apply_controller_snapshot(snap);
-            }
-        }
+application::node_id_source application::classify_node_id_source() {
+    bool ever_ran_controller = storage.local()
+                                 .kvs()
+                                 .get(
+                                   storage::kvstore::key_space::controller,
+                                   cluster::controller::invariants_key())
+                                 .has_value();
+    bool has_id = config::node().node_id().has_value() && ever_ran_controller;
+    bool force_override = _node_overrides.node_id().has_value()
+                          && _node_overrides.ignore_existing_node_id();
+    if (has_id && !force_override) {
+        return node_id_source::established;
+    }
+    if (_node_overrides.node_id().has_value()) {
+        return node_id_source::overridden;
+    }
+    return node_id_source::unregistered;
+}
+
+bool application::is_seed_node() const {
+    const auto& self_addr = config::node().advertised_rpc_api();
+    const auto& seeds = config::node().seed_servers();
+    return std::ranges::any_of(
+      seeds, [&](const auto& s) { return s.addr == self_addr; });
+}
+
+ss::future<> application::prime_node_identity() {
+    // A non-seed joiner always has an existing cluster to join, so register,
+    // retrying until it succeeds. A seed is either a genuine founder (no
+    // cluster exists yet) or a wiped seed rejoining.
+    // For the former, we fast-fail and defer to the authoritative founder
+    // handshake later in the bootstrapping process. For the latter, we take the
+    // fast joiner path.
+    const auto policy
+      = is_seed_node()
+          ? cluster::cluster_discovery::join_retry_policy::
+              require_existing_cluster
+          : cluster::cluster_discovery::join_retry_policy::retry_until_joined;
+    auto node_id = co_await register_and_apply_join_snapshot(policy);
+    if (!node_id.has_value()) {
+        co_return;
+    }
+    if (config::node().node_id() == std::nullopt) {
+        // If we previously didn't have a node ID, set it in the config. We
+        // will persist it in the kvstore when the controller starts up.
+        co_await ss::smp::invoke_on_all([id = *node_id] {
+            config::node().node_id.set_value(
+              std::make_optional<model::node_id>(id));
+        });
+    }
+    _node_identity_resolved = true;
+    vlog(
+      _log.info,
+      "Resolved node identity early as node_id {}, cluster UUID {}",
+      *node_id,
+      storage.local().get_cluster_uuid());
+}
+
+ss::future<model::node_id> application::apply_node_id_override() {
+    auto node_id = _node_overrides.node_id().value();
+    vlog(
+      _log.warn,
+      "Overriding node ID: {} -> {} [ignore_existing_node_id? {}]",
+      config::node().node_id(),
+      node_id,
+      _node_overrides.ignore_existing_node_id());
+    // Null out the config'ed ID; the caller re-sets it after we return.
+    co_await ss::smp::invoke_on_all(
+      [] { config::node().node_id.set_value(std::nullopt); });
+    if (
+      auto invariants_buf = storage.local().kvs().get(
+        storage::kvstore::key_space::controller,
+        cluster::controller::invariants_key());
+      invariants_buf.has_value()) {
+        auto invariants
+          = reflection::from_iobuf<cluster::configuration_invariants>(
+            std::move(invariants_buf.value()));
+        invariants.node_id = node_id;
+        co_await storage.local().kvs().put(
+          storage::kvstore::key_space::controller,
+          cluster::controller::invariants_key(),
+          reflection::to_iobuf(cluster::configuration_invariants{invariants}));
+        vlog(_log.debug, "Force-updated local node_id to {}", node_id);
+    }
+    co_return node_id;
+}
+
+ss::future<> application::resolve_node_identity() {
+    if (_node_identity_resolved) {
+        co_return;
+    }
+
+    model::node_id node_id;
+    switch (_node_id_source.value()) {
+    case node_id_source::established:
+        node_id = config::node().node_id().value();
+        vlog(_log.info, "Running with already-established node ID {}", node_id);
+        break;
+    case node_id_source::overridden:
+        node_id = co_await apply_node_id_override();
+        break;
+    case node_id_source::unregistered:
+        // Reached only by an unregistered seed (a founding node, or a wiped
+        // seed rejoining whose early registration found no cluster).
+        // This runs after initialization has already occured, so apply the
+        // join snapshot with needs_restart configs pending.
+        node_id = (co_await register_and_apply_join_snapshot(
+                     cluster::cluster_discovery::join_retry_policy::
+                       retry_until_joined,
+                     cluster::defer_needs_restart::yes))
+                    .value();
+        break;
     }
 
     if (config::node().node_id() == std::nullopt) {
@@ -354,6 +438,7 @@ ss::future<> application::resolve_node_identity() {
         });
     }
 
+    _node_identity_resolved = true;
     vlog(
       _log.info,
       "Starting Redpanda with node_id {}, cluster UUID {}",
@@ -409,13 +494,15 @@ ss::future<> application::bootstrap_controller_view() {
 }
 
 ss::future<> application::apply_controller_snapshot(
-  const cluster::controller_join_snapshot& snap) {
+  const cluster::controller_join_snapshot& snap,
+  cluster::defer_needs_restart defer_needs_restart) {
     co_await apply_feature_table_snapshot(snap.features.snap);
 
     // Only apply the snapshot's cluster config state if its version is higher
     // than the existing preloaded state.
     if (snap.config.version > _config_preload.version) {
-        _config_preload = co_await cluster::config_manager::preload_join(snap);
+        _config_preload = co_await cluster::config_manager::preload_join(
+          snap, defer_needs_restart);
         co_await cluster::config_manager::write_local_cache(
           _config_preload.version, _config_preload.raw_values);
     }
@@ -523,14 +610,6 @@ void application::wire_up_and_start(
     // Storage services.
     wire_up_storage_services();
     start_storage_services(cfg);
-
-    // Begin the cluster discovery manager so we can confirm our initial node
-    // ID. A valid node ID is required before we can initialize the rest of our
-    // subsystems.
-    _cluster_discovery = std::make_unique<cluster::cluster_discovery>(
-      storage.local().node_uuid(),
-      storage.local().get_cluster_uuid(),
-      app_signal.abort_source());
 
     wire_up_and_start_rpc_service();
 

--- a/src/v/redpanda/tests/fixture.cc
+++ b/src/v/redpanda/tests/fixture.cc
@@ -129,7 +129,7 @@ redpanda_thread_fixture::redpanda_thread_fixture(
         app.wire_up_bootstrap_services();
         app.hydrate_cluster_config(make_minimal_cfg());
         app.bootstrap_from_kvstore();
-        app.establish_cluster_view();
+        app.establish_cluster_view(app_signal->abort_source());
         app.check_environment();
         app.wire_up_and_start(
           *app_signal,
@@ -358,7 +358,7 @@ void redpanda_thread_fixture::restart(should_wipe w) {
     app.wire_up_bootstrap_services();
     app.hydrate_cluster_config(make_minimal_cfg());
     app.bootstrap_from_kvstore();
-    app.establish_cluster_view();
+    app.establish_cluster_view(app_signal->abort_source());
     app.check_environment();
     app.wire_up_and_start(
       *app_signal,

--- a/src/v/resource_mgmt/memory_groups.cc
+++ b/src/v/resource_mgmt/memory_groups.cc
@@ -20,6 +20,10 @@
 
 namespace {
 
+bool sliding_window_compaction_enabled() {
+    return config::shard_local_cfg().log_compaction_use_sliding_window();
+}
+
 bool wasm_enabled() {
     return config::shard_local_cfg().data_transforms_enabled.value()
            && !config::node().emergency_disable_data_transforms.value();
@@ -79,6 +83,7 @@ system_memory_groups::system_memory_groups(
   compaction_memory_reservation compaction,
   cloud_topics_compaction_memory_reservation cloud_topics_compaction,
   cloud_topics_reconciler_memory_reservation cloud_topics_reconciler,
+  data_transforms_memory_reservation data_transforms,
   bool wasm_enabled,
   bool datalake_enabled,
   bool cloud_storage_enabled,
@@ -89,6 +94,7 @@ system_memory_groups::system_memory_groups(
       cloud_topics_compaction.reserved_bytes())
   , _cloud_topics_reconciler_reserved_memory(
       cloud_topics_reconciler.reserved_bytes())
+  , _data_transforms_reserved_memory(data_transforms.reserved_bytes())
   , _partitions_reserved_memory(
       partitions.reserved_bytes(total_available_memory))
   , _total_available_memory(total_available_memory)
@@ -153,7 +159,7 @@ size_t system_memory_groups::total_reserved_memory() const {
     return _compaction_reserved_memory
            + _cloud_topics_compaction_reserved_memory
            + _cloud_topics_reconciler_reserved_memory
-           + _partitions_reserved_memory;
+           + _data_transforms_reserved_memory + _partitions_reserved_memory;
 }
 
 double system_memory_groups::partitions_max_memory_share() const {
@@ -193,7 +199,8 @@ void system_memory_groups::log_memory_group_allocations(seastar::logger& log) {
       "{}, total memory minus pre-share reservations: {}, chunk cache: {}, "
       "kafka: {}, rpc: {}, recovery: {}, tiered storage: {}, admin: {}, data "
       "transforms: {}, compaction: {}, cloud topics compaction: {}, cloud "
-      "topics reconciler: {}, datalake: {}, partitions: {}",
+      "topics reconciler: {}, data transforms reserved: {}, datalake: {}, "
+      "partitions: {}",
       human::bytes(ss::memory::stats().total_memory()),
       human::bytes(total_reserved_memory()),
       human::bytes(total_memory()),
@@ -207,6 +214,7 @@ void system_memory_groups::log_memory_group_allocations(seastar::logger& log) {
       human::bytes(compaction_reserved_memory()),
       human::bytes(cloud_topics_compaction_reserved_memory()),
       human::bytes(cloud_topics_reconciler_reserved_memory()),
+      human::bytes(data_transforms_reserved_memory()),
       human::bytes(datalake_max_memory()),
       human::bytes(partitions_max_memory()));
 }
@@ -221,35 +229,44 @@ system_memory_groups& memory_groups() {
     if (groups) {
         return *groups;
     }
-    size_t total = ss::memory::stats().total_memory();
-    bool wasm = wasm_enabled();
+
+    auto sliding_window_compaction = sliding_window_compaction_enabled();
+    auto wasm = wasm_enabled();
+    auto datalake = datalake_enabled();
+    auto cloud_storage = cloud_storage_enabled();
+
     const auto& cfg = config::shard_local_cfg();
-    if (wasm) {
-        size_t wasm_memory_reservation
-          = cfg.data_transforms_per_core_memory_reservation.value();
-        total -= wasm_memory_reservation;
-    }
-    compaction_memory_reservation compaction;
-    if (cfg.log_compaction_use_sliding_window.value()) {
-        compaction.max_bytes = cfg.storage_compaction_key_map_memory.value();
-        compaction.max_limit_pct
-          = cfg.storage_compaction_key_map_memory_limit_percent.value();
-    }
+    compaction_memory_reservation compaction{
+      .max_bytes = sliding_window_compaction
+                     ? cfg.storage_compaction_key_map_memory.value()
+                     : 0,
+      .max_limit_pct
+      = cfg.storage_compaction_key_map_memory_limit_percent.value()};
+    data_transforms_memory_reservation data_transforms{
+      .max_bytes = wasm
+                     ? cfg.data_transforms_per_core_memory_reservation.value()
+                     : 0};
     cloud_topics_compaction_memory_reservation cloud_topics_compaction{
-      .max_bytes = cfg.cloud_topics_compaction_key_map_memory.value()};
+      .max_bytes = cloud_storage
+                     ? cfg.cloud_topics_compaction_key_map_memory.value()
+                         + cfg.cloud_topics_upload_part_size()
+                     : 0};
     cloud_topics_reconciler_memory_reservation cloud_topics_reconciler{
-      .max_bytes = cfg.cloud_topics_upload_part_size()
-                   * cfg.cloud_topics_reconciliation_parallelism()};
+      .max_bytes = cloud_storage
+                     ? cfg.cloud_topics_upload_part_size()
+                         * cfg.cloud_topics_reconciliation_parallelism()
+                     : 0};
     partitions_memory_reservation partitions{
       .max_limit_pct = cfg.topic_partitions_memory_allocation_percent()};
     groups.emplace(
-      total,
+      ss::memory::stats().total_memory(),
       compaction,
       cloud_topics_compaction,
       cloud_topics_reconciler,
+      data_transforms,
       wasm,
-      datalake_enabled(),
-      cloud_storage_enabled(),
+      datalake,
+      cloud_storage,
       partitions);
     return *groups;
 }

--- a/src/v/resource_mgmt/memory_groups.cc
+++ b/src/v/resource_mgmt/memory_groups.cc
@@ -187,14 +187,15 @@ size_t system_memory_groups::total_memory() const {
 }
 
 void system_memory_groups::log_memory_group_allocations(seastar::logger& log) {
-    log.info(
-      "Per shard memory group allocations: total memory: {}, "
-      "total memory minus pre-share reservations: {}, chunk cache: {}, kafka: "
-      "{}, rpc: {}, recovery: {}, "
-      "tiered storage: {}, admin: {}, data transforms: {}, compaction: {}, "
-      "cloud topics compaction: {}, cloud topics reconciler: {}, "
-      "datalake: {}, partitions: {}",
+    vlog(
+      log.info,
+      "Per shard memory group allocations: total memory: {}, reserved memory: "
+      "{}, total memory minus pre-share reservations: {}, chunk cache: {}, "
+      "kafka: {}, rpc: {}, recovery: {}, tiered storage: {}, admin: {}, data "
+      "transforms: {}, compaction: {}, cloud topics compaction: {}, cloud "
+      "topics reconciler: {}, datalake: {}, partitions: {}",
       human::bytes(ss::memory::stats().total_memory()),
+      human::bytes(total_reserved_memory()),
       human::bytes(total_memory()),
       human::bytes(chunk_cache_max_memory()),
       human::bytes(kafka_total_memory()),

--- a/src/v/resource_mgmt/memory_groups.cc
+++ b/src/v/resource_mgmt/memory_groups.cc
@@ -91,10 +91,7 @@ system_memory_groups::system_memory_groups(
       cloud_topics_reconciler.reserved_bytes())
   , _partitions_reserved_memory(
       partitions.reserved_bytes(total_available_memory))
-  , _total_system_memory(
-      total_available_memory - _compaction_reserved_memory
-      - _cloud_topics_compaction_reserved_memory
-      - _cloud_topics_reconciler_reserved_memory - _partitions_reserved_memory)
+  , _total_available_memory(total_available_memory)
   , _wasm_enabled(wasm_enabled)
   , _datalake_enabled(datalake_enabled)
   , _cloud_storage_enabled(cloud_storage_enabled) {}
@@ -152,6 +149,13 @@ size_t system_memory_groups::partitions_max_memory() const {
     return _partitions_reserved_memory;
 }
 
+size_t system_memory_groups::total_reserved_memory() const {
+    return _compaction_reserved_memory
+           + _cloud_topics_compaction_reserved_memory
+           + _cloud_topics_reconciler_reserved_memory
+           + _partitions_reserved_memory;
+}
+
 double system_memory_groups::partitions_max_memory_share() const {
     return _partitions_reserved_memory
            / static_cast<double>(ss::memory::stats().total_memory());
@@ -168,7 +172,18 @@ size_t system_memory_groups::subsystem_memory() const {
 }
 
 size_t system_memory_groups::total_memory() const {
-    return _total_system_memory;
+    size_t reserved_memory = total_reserved_memory();
+    size_t available_memory = _total_available_memory;
+    if (reserved_memory > available_memory) {
+        dassert(
+          false,
+          "Reserved memory {} is greater than the memory available to the "
+          "system {}",
+          human::bytes(reserved_memory),
+          human::bytes(available_memory));
+        return 0;
+    }
+    return available_memory - reserved_memory;
 }
 
 void system_memory_groups::log_memory_group_allocations(seastar::logger& log) {

--- a/src/v/resource_mgmt/memory_groups.h
+++ b/src/v/resource_mgmt/memory_groups.h
@@ -123,6 +123,11 @@ public:
         return _cloud_topics_reconciler_reserved_memory;
     }
 
+    /// Sum of all per-shard memory reservations subtracted from the shard's
+    /// total before share-based allocation. This is the minimum per-shard
+    /// memory below which the share-based allocator has no memory to divide.
+    size_t total_reserved_memory() const;
+
     size_t datalake_max_memory() const;
 
     size_t cloud_topics_memory() const;
@@ -152,7 +157,7 @@ private:
     size_t _cloud_topics_compaction_reserved_memory;
     size_t _cloud_topics_reconciler_reserved_memory;
     size_t _partitions_reserved_memory;
-    size_t _total_system_memory;
+    size_t _total_available_memory;
     bool _wasm_enabled;
     bool _datalake_enabled;
     bool _cloud_storage_enabled;

--- a/src/v/resource_mgmt/memory_groups.h
+++ b/src/v/resource_mgmt/memory_groups.h
@@ -58,6 +58,18 @@ struct cloud_topics_reconciler_memory_reservation {
     size_t reserved_bytes() const { return max_bytes; }
 };
 
+/**
+ * Memory reservation for the WebAssembly runtime (data transforms). Held
+ * off the top, separate from the share-based allocation that
+ * `data_transforms_max_memory()` provides for the rest of the data
+ * transforms subsystem.
+ */
+struct data_transforms_memory_reservation {
+    size_t max_bytes{0};
+
+    size_t reserved_bytes() const { return max_bytes; }
+};
+
 namespace testing {
 class system_memory_groups_accessor;
 }
@@ -76,6 +88,7 @@ public:
       compaction_memory_reservation compaction,
       cloud_topics_compaction_memory_reservation cloud_topics_compaction,
       cloud_topics_reconciler_memory_reservation cloud_topics_reconciler,
+      data_transforms_memory_reservation data_transforms,
       bool wasm_enabled,
       bool datalake_enabled,
       bool cloud_storage_enabled,
@@ -123,6 +136,10 @@ public:
         return _cloud_topics_reconciler_reserved_memory;
     }
 
+    size_t data_transforms_reserved_memory() const {
+        return _data_transforms_reserved_memory;
+    }
+
     /// Sum of all per-shard memory reservations subtracted from the shard's
     /// total before share-based allocation. This is the minimum per-shard
     /// memory below which the share-based allocator has no memory to divide.
@@ -156,6 +173,7 @@ private:
     size_t _compaction_reserved_memory;
     size_t _cloud_topics_compaction_reserved_memory;
     size_t _cloud_topics_reconciler_reserved_memory;
+    size_t _data_transforms_reserved_memory;
     size_t _partitions_reserved_memory;
     size_t _total_available_memory;
     bool _wasm_enabled;

--- a/src/v/resource_mgmt/tests/memory_groups_test.cc
+++ b/src/v/resource_mgmt/tests/memory_groups_test.cc
@@ -48,10 +48,10 @@ public:
 
 TEST_P(MemoryGroupSharesTest, DividesSharesCorrectly) {
     auto total_available_memory = total_memory;
-    auto total_system_memory = total_memory;
+    data_transforms_memory_reservation data_transforms_reservation{};
     if (wasm_enabled()) {
-        total_system_memory -= user_wasm_reservation;
         total_available_memory -= user_wasm_reservation;
+        data_transforms_reservation = {.max_bytes = user_wasm_reservation};
     }
     compaction_memory_reservation reservation{};
     if (compaction_enabled()) {
@@ -64,13 +64,14 @@ TEST_P(MemoryGroupSharesTest, DividesSharesCorrectly) {
     cloud_topics_compaction_memory_reservation ct_compaction_reservation{
       .max_bytes = user_cloud_topics_compaction_reservation};
     partitions_memory_reservation partitions{.max_limit_pct = 20};
-    total_available_memory -= partitions.reserved_bytes(total_system_memory);
+    total_available_memory -= partitions.reserved_bytes(total_memory);
 
     class system_memory_groups groups(
-      total_system_memory,
+      total_memory,
       reservation,
       ct_compaction_reservation,
       /*cloud_topics_reconciler_memory_reservation=*/{},
+      data_transforms_reservation,
       wasm_enabled(),
       datalake_enabled(),
       cloud_storage_enabled(),
@@ -153,6 +154,7 @@ TEST(MemoryGroups, CompactionMemoryBytes) {
           },
           /*cloud_topics_compaction_memory_reservation=*/{},
           /*cloud_topics_reconciler_memory_reservation=*/{},
+          /*data_transforms_memory_reservation=*/{},
           /*wasm_enabled=*/false,
           /*datalake_enabled=*/false,
           /*cloud_storage_enabled=*/false,
@@ -172,6 +174,7 @@ TEST(MemoryGroups, CompactionMemoryBytes) {
           },
           /*cloud_topics_compaction_memory_reservation=*/{},
           /*cloud_topics_reconciler_memory_reservation=*/{},
+          /*data_transforms_memory_reservation=*/{},
           /*wasm_enabled=*/false,
           /*datalake_enabled=*/false,
           /*cloud_storage_enabled=*/false,

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -26,6 +26,7 @@
 #include "storage/types.h"
 
 #include <seastar/core/metrics.hh>
+#include <seastar/core/seastar.hh>
 #include <seastar/coroutine/exception.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/util/log.hh>
@@ -198,6 +199,35 @@ ss::future<> kvstore::put(key_space ks, bytes key, std::optional<iobuf> value) {
           }
           return w.done.get_future();
       });
+}
+
+ss::future<> kvstore::persist_pre_start(key_space ks, bytes key, iobuf value) {
+    vassert(
+      _recovered,
+      "kvstore::persist_pre_start called before recover() for dir {}",
+      _ntpc.work_directory());
+    vassert(
+      !_started,
+      "kvstore::persist_pre_start must be called before start() for dir {}",
+      _ntpc.work_directory());
+
+    // The partition directory (where the snapshot is written) is normally
+    // created lazily when the first segment is rolled. We bypass that path, so
+    // ensure it exists.
+    co_await ss::recursive_touch_directory(_ntpc.work_directory());
+
+    _probe.entry_written();
+    {
+        auto units = co_await _db_mut.get_units();
+        apply_op(
+          make_spaced_key(ks, key),
+          std::make_optional(std::move(value)),
+          units);
+        units.return_all();
+    }
+
+    _next_offset = model::next_offset(_next_offset);
+    co_await save_snapshot();
 }
 
 ss::future<> kvstore::for_each(

--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -132,6 +132,16 @@ public:
     ss::future<> put(key_space ks, bytes key, iobuf value);
     ss::future<> remove(key_space ks, bytes key);
 
+    /// Durably persist a single key/value during bootstrap, before the kvstore
+    /// has been start()ed and therefore before its segment/chunk-cache write
+    /// path is available. Applies the value to the in-memory db and writes a
+    /// snapshot (plain file I/O, no chunk cache). Must be called after
+    /// recover() and before start(), with no other writer active.
+    ///
+    /// Intended for the narrow bootstrap case where a value must be durable
+    /// before the kvstore is start()ed; prefer put() everywhere else.
+    ss::future<> persist_pre_start(key_space ks, bytes key, iobuf value);
+
     /// Iterate over all key-value pairs in a keyspace.
     /// NOTE: this will stall all updates, so use with a lot of caution.
     ss::future<> for_each(

--- a/src/v/storage/tests/kvstore_test.cc
+++ b/src/v/storage/tests/kvstore_test.cc
@@ -194,3 +194,288 @@ TEST_F(kvstore_test_fixture, kvstore) {
     }
     kvs->stop().get();
 }
+
+// persist_pre_start() durably writes a key on a fresh (empty) kvstore, before
+// start(), and the value survives a restart.
+TEST_F(kvstore_test_fixture, persist_pre_start_empty) {
+    set_configuration("disable_metrics", true);
+
+    const auto key = tests::random_bytes(8);
+    const auto value = bytes_to_iobuf(tests::random_bytes(128));
+
+    auto kvs = make_kvstore();
+    kvs->recover().get();
+    kvs
+      ->persist_pre_start(
+        storage::kvstore::key_space::testing, key, value.copy())
+      .get();
+    kvs->start().get();
+    EXPECT_EQ(
+      kvs->get(storage::kvstore::key_space::testing, key).value(), value);
+    kvs->stop().get();
+
+    // Durable across a restart (it was written to a snapshot).
+    kvs = make_kvstore();
+    kvs->start().get();
+    EXPECT_EQ(
+      kvs->get(storage::kvstore::key_space::testing, key).value(), value);
+    kvs->stop().get();
+}
+
+// persist_pre_start() must not corrupt a kvstore that already has state on disk
+// (a snapshot and segments): the pre-existing keys and the injected key must
+// both be present, before and after a restart.
+TEST_F(kvstore_test_fixture, persist_pre_start_preserves_existing_state) {
+    set_configuration("disable_metrics", true);
+
+    // Populate with enough data (>> the 8KiB max segment size) to force segment
+    // rolls and at least one snapshot, then stop so it's all on disk.
+    std::map<bytes, iobuf> truth;
+    auto kvs = make_kvstore();
+    kvs->start().get();
+    for (int i = 0; i < 200; i++) {
+        auto key = tests::random_bytes(8);
+        auto value = bytes_to_iobuf(tests::random_bytes(128));
+        truth[key] = value.copy();
+        kvs->put(storage::kvstore::key_space::testing, key, std::move(value))
+          .get();
+    }
+    kvs->stop().get();
+
+    // Recover that state, inject a new key via persist_pre_start (before
+    // start()), then bring the store up.
+    const auto sentinel_key = tests::random_bytes(8);
+    const auto sentinel_value = bytes_to_iobuf(tests::random_bytes(128));
+    kvs = make_kvstore();
+    kvs->recover().get();
+    kvs
+      ->persist_pre_start(
+        storage::kvstore::key_space::testing,
+        sentinel_key,
+        sentinel_value.copy())
+      .get();
+    kvs->start().get();
+
+    // Pre-existing state is intact and the injected key is present.
+    for (const auto& e : truth) {
+        EXPECT_EQ(
+          kvs->get(storage::kvstore::key_space::testing, e.first).value(),
+          e.second);
+    }
+    EXPECT_EQ(
+      kvs->get(storage::kvstore::key_space::testing, sentinel_key).value(),
+      sentinel_value);
+    kvs->stop().get();
+
+    // ...and both survive a subsequent restart (snapshot/segment offsets line
+    // up on recovery).
+    kvs = make_kvstore();
+    kvs->start().get();
+    for (const auto& e : truth) {
+        EXPECT_EQ(
+          kvs->get(storage::kvstore::key_space::testing, e.first).value(),
+          e.second);
+    }
+    EXPECT_EQ(
+      kvs->get(storage::kvstore::key_space::testing, sentinel_key).value(),
+      sentinel_value);
+    kvs->stop().get();
+}
+
+// The bootstrap sequence: a pre-start write followed by normal post-start
+// writes. This is the key offset-bookkeeping guarantee - the pre-start snapshot
+// (at offset 0) and the later segment writes must be consistent on recovery, so
+// everything survives a restart.
+TEST_F(
+  kvstore_test_fixture, persist_pre_start_then_normal_puts_survive_restart) {
+    set_configuration("disable_metrics", true);
+
+    const auto early_key = tests::random_bytes(8);
+    const auto early_value = bytes_to_iobuf(tests::random_bytes(128));
+
+    auto kvs = make_kvstore();
+    kvs->recover().get();
+    kvs
+      ->persist_pre_start(
+        storage::kvstore::key_space::testing, early_key, early_value.copy())
+      .get();
+    kvs->start().get();
+
+    // Enough normal writes to roll segments and snapshot past the pre-start op.
+    std::map<bytes, iobuf> truth;
+    for (int i = 0; i < 200; i++) {
+        auto key = tests::random_bytes(8);
+        auto value = bytes_to_iobuf(tests::random_bytes(128));
+        truth[key] = value.copy();
+        kvs->put(storage::kvstore::key_space::testing, key, std::move(value))
+          .get();
+    }
+    kvs->stop().get();
+
+    kvs = make_kvstore();
+    kvs->start().get();
+    EXPECT_EQ(
+      kvs->get(storage::kvstore::key_space::testing, early_key).value(),
+      early_value);
+    for (const auto& e : truth) {
+        EXPECT_EQ(
+          kvs->get(storage::kvstore::key_space::testing, e.first).value(),
+          e.second);
+    }
+    kvs->stop().get();
+}
+
+// Multiple pre-start writes each advance the offset and snapshot; all must be
+// durable across a restart.
+TEST_F(kvstore_test_fixture, persist_pre_start_multiple_keys) {
+    set_configuration("disable_metrics", true);
+
+    std::map<bytes, iobuf> truth;
+    auto kvs = make_kvstore();
+    kvs->recover().get();
+    for (int i = 0; i < 5; i++) {
+        auto key = tests::random_bytes(8);
+        auto value = bytes_to_iobuf(tests::random_bytes(128));
+        truth[key] = value.copy();
+        kvs
+          ->persist_pre_start(
+            storage::kvstore::key_space::testing, key, std::move(value))
+          .get();
+    }
+    kvs->start().get();
+    for (const auto& e : truth) {
+        EXPECT_EQ(
+          kvs->get(storage::kvstore::key_space::testing, e.first).value(),
+          e.second);
+    }
+    kvs->stop().get();
+
+    kvs = make_kvstore();
+    kvs->start().get();
+    for (const auto& e : truth) {
+        EXPECT_EQ(
+          kvs->get(storage::kvstore::key_space::testing, e.first).value(),
+          e.second);
+    }
+    kvs->stop().get();
+}
+
+// The crash scenario the feature guards against: a value is persisted before
+// start(), then the process dies before doing anything else. A fresh recovery
+// must still see the value (it was durably snapshotted).
+TEST_F(kvstore_test_fixture, persist_pre_start_survives_crash_before_start) {
+    set_configuration("disable_metrics", true);
+
+    const auto key = tests::random_bytes(8);
+    const auto value = bytes_to_iobuf(tests::random_bytes(128));
+
+    auto kvs = make_kvstore();
+    kvs->recover().get();
+    kvs
+      ->persist_pre_start(
+        storage::kvstore::key_space::testing, key, value.copy())
+      .get();
+    // Simulate a crash: drop the instance without ever start()ing or stop()ing
+    // it. No flush fiber was spawned, so tearing down a recover-only kvstore is
+    // clean.
+    kvs.reset();
+
+    kvs = make_kvstore();
+    kvs->start().get();
+    EXPECT_EQ(
+      kvs->get(storage::kvstore::key_space::testing, key).value(), value);
+    kvs->stop().get();
+}
+
+// A normal write after start() to the same key supersedes the pre-start value,
+// and the newer value wins on recovery (the post-start op sits at a later
+// offset than the pre-start snapshot).
+TEST_F(kvstore_test_fixture, persist_pre_start_overwritten_by_later_put) {
+    set_configuration("disable_metrics", true);
+
+    const auto key = tests::random_bytes(8);
+    const auto pre_start_value = bytes_to_iobuf(tests::random_bytes(128));
+    const auto post_start_value = bytes_to_iobuf(tests::random_bytes(128));
+
+    auto kvs = make_kvstore();
+    kvs->recover().get();
+    kvs
+      ->persist_pre_start(
+        storage::kvstore::key_space::testing, key, pre_start_value.copy())
+      .get();
+    kvs->start().get();
+    kvs->put(storage::kvstore::key_space::testing, key, post_start_value.copy())
+      .get();
+    EXPECT_EQ(
+      kvs->get(storage::kvstore::key_space::testing, key).value(),
+      post_start_value);
+    kvs->stop().get();
+
+    // The later value wins after a restart.
+    kvs = make_kvstore();
+    kvs->start().get();
+    EXPECT_EQ(
+      kvs->get(storage::kvstore::key_space::testing, key).value(),
+      post_start_value);
+    kvs->stop().get();
+}
+
+// persist_pre_start updates (not just inserts) a key that already exists in the
+// recovered db, and the update is durable.
+TEST_F(kvstore_test_fixture, persist_pre_start_updates_existing_key) {
+    set_configuration("disable_metrics", true);
+
+    const auto key = tests::random_bytes(8);
+    const auto old_value = bytes_to_iobuf(tests::random_bytes(128));
+    const auto new_value = bytes_to_iobuf(tests::random_bytes(128));
+
+    // Write the key normally and persist it.
+    auto kvs = make_kvstore();
+    kvs->start().get();
+    kvs->put(storage::kvstore::key_space::testing, key, old_value.copy()).get();
+    kvs->stop().get();
+
+    // Recover, then update the same key via persist_pre_start before start().
+    kvs = make_kvstore();
+    kvs->recover().get();
+    EXPECT_EQ(
+      kvs->get(storage::kvstore::key_space::testing, key).value(), old_value);
+    kvs
+      ->persist_pre_start(
+        storage::kvstore::key_space::testing, key, new_value.copy())
+      .get();
+    kvs->start().get();
+    EXPECT_EQ(
+      kvs->get(storage::kvstore::key_space::testing, key).value(), new_value);
+    kvs->stop().get();
+
+    // The update is durable across a restart.
+    kvs = make_kvstore();
+    kvs->start().get();
+    EXPECT_EQ(
+      kvs->get(storage::kvstore::key_space::testing, key).value(), new_value);
+    kvs->stop().get();
+}
+
+// persist_pre_start writes into the given key space only; the same key in
+// another key space is unaffected (verifies its key namespacing matches the
+// normal read path).
+TEST_F(kvstore_test_fixture, persist_pre_start_key_space_isolation) {
+    set_configuration("disable_metrics", true);
+
+    const auto key = tests::random_bytes(8);
+    const auto value = bytes_to_iobuf(tests::random_bytes(128));
+
+    auto kvs = make_kvstore();
+    kvs->recover().get();
+    kvs
+      ->persist_pre_start(
+        storage::kvstore::key_space::testing, key, value.copy())
+      .get();
+    kvs->start().get();
+    EXPECT_EQ(
+      kvs->get(storage::kvstore::key_space::testing, key).value(), value);
+    EXPECT_FALSE(
+      kvs->get(storage::kvstore::key_space::consensus, key).has_value());
+    kvs->stop().get();
+}

--- a/src/v/syschecks/BUILD
+++ b/src/v/syschecks/BUILD
@@ -15,6 +15,7 @@ redpanda_cc_library(
     deps = [
         "//src/v/base",
         "//src/v/ssx:sformat",
+        "//src/v/utils:human",
         "//src/v/version",
         "@seastar",
     ],

--- a/src/v/syschecks/syschecks.cc
+++ b/src/v/syschecks/syschecks.cc
@@ -10,6 +10,9 @@
 #include "syschecks/syschecks.h"
 
 #include "base/seastarx.h"
+#include "base/units.h"
+#include "base/vassert.h"
+#include "utils/human.h"
 #include "version/version.h"
 
 #include <seastar/core/coroutine.hh>
@@ -75,17 +78,38 @@ ss::future<> disk(const ss::sstring& path) {
     });
 }
 
-void memory(bool ignore) {
-    static const uint64_t kMinMemory = 1 << 30;
+void memory(
+  size_t reservation_required_per_shard, bool developer_mode_enabled) {
+    static constexpr size_t kRecommendedMemory = 1_GiB;
+    static constexpr size_t kBaselineMemory = 128_MiB;
+    // The total amount of memory required per shard is the amount of memory
+    // reservations memory_groups has reported, plus some flat amount we think
+    // `redpanda` requires at a baseline.
+    size_t required_per_shard = reservation_required_per_shard
+                                + kBaselineMemory;
+    dassert(
+      kRecommendedMemory > required_per_shard,
+      "The amount of memory Redpanda recommends ({}) is less than is actually "
+      "required ({}) - we need to re-evaluate our recommended value.",
+      human::bytes(kRecommendedMemory),
+      human::bytes(required_per_shard));
     const auto shard_mem = ss::memory::stats().total_memory();
-    if (shard_mem >= kMinMemory) {
-        return;
-    }
-    auto line = fmt::format(
-      "Memory: '{}' below recommended: '{}'", shard_mem, kMinMemory);
-    checklog.error(line.c_str());
-    if (!ignore) {
+    if (shard_mem < required_per_shard && !developer_mode_enabled) {
+        auto line = fmt::format(
+          "Memory: '{}' below required: '{}'",
+          human::bytes(shard_mem),
+          human::bytes(required_per_shard));
+        checklog.error(line.c_str());
         throw std::runtime_error(line);
+    }
+    if (shard_mem < kRecommendedMemory) {
+        auto line = fmt::format(
+          "Memory: '{}' below recommended: '{}'",
+          human::bytes(shard_mem),
+          human::bytes(kRecommendedMemory));
+        auto log_lvl = developer_mode_enabled ? ss::log_level::warn
+                                              : ss::log_level::error;
+        checklog.log(log_lvl, line.c_str());
     }
 }
 

--- a/src/v/syschecks/syschecks.h
+++ b/src/v/syschecks/syschecks.h
@@ -51,7 +51,7 @@ inline void cpu() {
 
 ss::future<> disk(const ss::sstring& path);
 
-void memory(bool ignore);
+void memory(size_t reservation_required_per_shard, bool developer_mode_enabled);
 
 ss::future<> systemd_raw_message(ss::sstring out);
 

--- a/tests/rptest/tests/cluster_bootstrap_test.py
+++ b/tests/rptest/tests/cluster_bootstrap_test.py
@@ -11,11 +11,12 @@ import concurrent.futures
 import threading
 
 from ducktape.mark import matrix
+from ducktape.utils.util import wait_until
 from requests.exceptions import ConnectionError
 
 from rptest.clients.rpk import TopicSpec
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import RpkTool
+from rptest.services.redpanda import RedpandaService, RpkTool, SISettings
 from rptest.services.redpanda_installer import RedpandaInstaller
 from rptest.services.utils import NodeCrash
 from rptest.tests.redpanda_test import RedpandaTest
@@ -235,4 +236,127 @@ class ClusterBootstrapUpgrade(RedpandaTest):
                 "empty_seed_starts_cluster": empty_seed_starts_cluster
             },
             omit_seeds_on_idx_one=False,
+        )
+
+
+class ClusterBootstrapJoinerConfigPriming(RedpandaTest):
+    """
+    Ensures that a first time joiner (non-seed) node correctly recieves a cluster
+    wide view of the config before initializing its subsystems (just as a restarting node would).
+    """
+
+    def __init__(self, test_context):
+        super().__init__(
+            test_context=test_context,
+            num_brokers=4,
+            si_settings=SISettings(test_context=test_context),
+        )
+        self.admin = self.redpanda._admin
+
+    def setUp(self):
+        # Defer startup to the test body so we can add the joiner separately.
+        pass
+
+    @cluster(num_nodes=4)
+    def test_joiner_primes_config_before_sizing_memory_groups(self):
+        seeds = self.redpanda.nodes[:3]
+        joiner = self.redpanda.nodes[3]
+
+        # Form the cluster (with cloud storage enabled as a cluster-level
+        # bootstrap config) using only the seed nodes.
+        set_seeds_for_cluster(self.redpanda, num_seeds=3)
+        self.redpanda.start(nodes=seeds)
+
+        # Make `joiner` a genuine first-time joiner that must learn the cluster's
+        # cloud-storage configuration from its join snapshot rather than from a
+        # local file. ducktape pre-writes .bootstrap.yaml to every node; remove
+        # it so the joiner starts with cloud_storage_enabled at its default
+        # (false), exactly as a freshly-(re)added node does in production.
+        joiner.account.ssh(f"rm -f {RedpandaService.CLUSTER_BOOTSTRAP_CONFIG_FILE}")
+
+        # Add the joiner and wait for it to fully register with the cluster.
+        self.redpanda.start_node(joiner)
+        wait_until(
+            lambda: self.redpanda.registered(joiner),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="joiner failed to register with the cluster",
+        )
+
+        # The joiner logs its per-shard memory-group allocations once at
+        # startup. With cloud storage enabled cluster-wide, its cloud-topics
+        # compaction reservation must be non-zero; a zero reservation means it
+        # sized memory groups before applying its join snapshot.
+        assert self.redpanda.search_log_node(
+            joiner, "Per shard memory group allocations"
+        ), "joiner did not log its per-shard memory-group allocations"
+        assert not self.redpanda.search_log_node(
+            joiner, "cloud topics compaction: 0.000bytes"
+        ), (
+            "joiner sized its memory groups before its cloud storage "
+            "configuration was primed (cloud-topics reservation was 0)"
+        )
+        assert self.redpanda.search_log_node(
+            joiner, "Resolved node identity early as node_id"
+        ), "joiner did not take the early first-time-join prime path"
+
+
+class ClusterBootstrapWipedSeedRejoin(RedpandaTest):
+    """
+    Regression test for a wiped seed node rejoining a cloud-storage cluster.
+    """
+
+    def __init__(self, test_context):
+        super().__init__(
+            test_context=test_context,
+            num_brokers=3,
+            si_settings=SISettings(test_context=test_context),
+        )
+
+    def setUp(self):
+        # Defer startup so we can wipe and re-add a seed from the test body.
+        pass
+
+    PRIMED_EARLY = "Resolved node identity early as node_id"
+    ZERO_CLOUD_RESERVATION = "cloud topics compaction: 0.000bytes"
+
+    @cluster(num_nodes=3)
+    def test_wiped_seed_rejoin_primes_config_early(self):
+        # All three nodes are seeds; cloud storage is enabled cluster-wide.
+        set_seeds_for_cluster(self.redpanda, num_seeds=3)
+        self.redpanda.start()
+
+        victim = self.redpanda.nodes[2]
+
+        # Wipe the seed's local state and its .bootstrap.yaml so it rejoins as a
+        # wiped seed with cloud_storage_enabled at its default (false) locally,
+        # forcing it to learn cloud storage from the cluster. Truncate the log
+        # too so the assertions below only see the rejoin boot, not the original
+        # one that had cloud storage enabled from .bootstrap.yaml.
+        self.redpanda.stop_node(victim)
+        self.redpanda.remove_local_data(victim)
+        victim.account.ssh(f"rm -f {RedpandaService.CLUSTER_BOOTSTRAP_CONFIG_FILE}")
+        victim.account.ssh(f"truncate -s 0 {RedpandaService.STDOUT_STDERR_CAPTURE}")
+
+        self.redpanda.start_node(victim)
+        wait_until(
+            lambda: self.redpanda.registered(victim),
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="wiped seed failed to rejoin the cluster",
+        )
+
+        # The wiped seed should have registered with the existing cluster via
+        # the bounded require_existing_cluster path and primed its identity
+        # early, rather than falling through to the late founder/resolve path.
+        assert self.redpanda.search_log_node(victim, self.PRIMED_EARLY), (
+            "wiped seed did not take the early prime path "
+            "(require_existing_cluster registration)"
+        )
+
+        # Memory groups should be sized *with* cloud storage enabled, so the
+        # running config and the sizing agree.
+        assert not self.redpanda.search_log_node(victim, self.ZERO_CLOUD_RESERVATION), (
+            "wiped seed sized its memory groups before priming cloud storage "
+            "(cloud-topics reservation was 0)"
         )

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -1409,15 +1409,15 @@ class PandaProxyInvalidInputsTest(PandaProxyEndpoints):
                 "zIGFyZSBtdWNoIG1vcmUgdGhhbiB0aGUgcmVxdWVzdCBpdHNlbGYuIE1lc3NhZ2UgRW5kLg=="
             )
         }
-        values = [value for _ in range(50000)]
+        values = [value for _ in range(120000)]
         data = {"records": values}
         data_json = json.dumps(data)
 
         # With 512Mb available per core and the various memory reservations
         # (compaction, cloud topics, partitions), the available memory for
-        # the kafka services is well under 90Mb. We want to ensure that
+        # the kafka services should be under ~180Mb. We want to ensure that
         # this request is larger than this.
-        memory_limit = 90.4 * 1024 * 1024
+        memory_limit = 180 * 1024 * 1024
         assert len(data_json) > memory_limit, (
             f"Expected request larger than {memory_limit}b. Got {len(data_json)}b, instead"
         )

--- a/tests/rptest/tests/throttled_raft0_test.py
+++ b/tests/rptest/tests/throttled_raft0_test.py
@@ -152,11 +152,19 @@ class AddNode:
     pinned) id to appear in the controller group_configuration learners list;
     ``False`` asserts it does not become a learner within a short window (e.g.
     because raft0 is already stuck on another in-flight add). ``None`` skips
-    the check."""
+    the check.
+
+    ``wait_node_voter`` blocks until the node has fully joined raft0 as a voter
+    (its add reconfiguration has completed and raft0 is back to `simple`) before
+    the operation returns. Use to make add->throttle ordering deterministic
+    instead of racing an in-flight add against a subsequent throttle: a learner
+    still catching up keeps raft0 in a reconfiguration that, once recovery is
+    throttled to 0, can never complete and blocks later adds."""
 
     node_id: int | None = None
     node: ClusterNode | None = None
     expect_learner: bool | None = None
+    wait_node_voter: bool = False
 
 
 @dataclass
@@ -312,6 +320,14 @@ class _StuckRaft0LearnerBase(RedpandaTest):
         if config is None:
             return set()
         return set(config.current.learners)
+
+    def _raft0_voter_ids(self) -> set[int]:
+        """node ids that are voters in the controller leader's current raft0
+        configuration"""
+        config = self._raft0_configuration()
+        if config is None:
+            return set()
+        return set(config.current.voters)
 
     def _broker_ids(self) -> set[int]:
         """node ids currently registered as cluster members"""
@@ -1401,6 +1417,23 @@ class Raft0MembershipOpsTest(_StuckRaft0LearnerBase):
                 )
                 if op.expect_learner is not None:
                     self._assert_learner_expectation(assigned_id, op.expect_learner, i)
+                if op.wait_node_voter:
+                    self.logger.info(
+                        f"[raft0-ops] op {i}: waiting for node_id={assigned_id} "
+                        f"to fully join raft0 as a voter"
+                    )
+                    wait_until(
+                        lambda aid=assigned_id: (
+                            self._controller_state() == GroupConfigurationState.SIMPLE
+                            and aid in self._raft0_voter_ids()
+                        ),
+                        timeout_sec=LONG_TIMEOUT.timeout_s,
+                        backoff_sec=LONG_TIMEOUT.backoff_s,
+                        err_msg=(
+                            f"op {i}: node_id={assigned_id} never became a "
+                            f"stable raft0 voter"
+                        ),
+                    )
             elif isinstance(op, StopNode):
                 node = resolve_node(op, i, "StopNode")
                 self.logger.info(f"[raft0-ops] op {i}: stopping node {node.name}")
@@ -1496,7 +1529,7 @@ class Raft0MembershipOpsTest(_StuckRaft0LearnerBase):
         self._start_seed_cluster()
         self._run_operations(
             [
-                AddNode(node_id=NEW_JOINER),
+                AddNode(node_id=NEW_JOINER, wait_node_voter=True),
                 ThrottleRaft0(),
                 AddNode(node_id=STUCK_JOINER, expect_learner=True),
                 StopNode(node_id=STUCK_JOINER),


### PR DESCRIPTION
Change this exception throwing site to a log line - `WARN` if developer mode is enabled, and `ERROR` otherwise.

This is commonly called out as a bad UX for those who just want to test `redpanda` or are running in certain environments.

Fixes https://github.com/redpanda-data/redpanda/issues/2879

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
