### PR TITLE
[v26.1.x] cluster/metrics_reporter: report local and cloud topic counts

### DIFF
--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -356,6 +356,16 @@ metrics_reporter::build_metrics_snapshot() {
             ++snapshot.topics_with_iceberg_schema_latest;
             break;
         }
+
+        if (md.get_configuration_properties().is_local_topic()) {
+            ++snapshot.local_topic_count;
+        }
+
+        if (
+          md.get_configuration().properties.storage_mode
+          == model::redpanda_storage_mode::cloud) {
+            ++snapshot.cloud_topic_count;
+        }
     }
 
     snapshot.nodes.reserve(metrics_map.size());
@@ -717,6 +727,12 @@ void rjson_serialize(
     w.Uint64(snapshot.topics_with_iceberg_schema_id);
     w.Key("topics_with_iceberg_latest_protobuf_value");
     w.Uint64(snapshot.topics_with_iceberg_schema_latest);
+
+    w.Key("local_topic_count");
+    w.Uint(snapshot.local_topic_count);
+
+    w.Key("cloud_topic_count");
+    w.Uint(snapshot.cloud_topic_count);
 
     w.Key("partition_count");
     w.Uint64(snapshot.partition_count);

--- a/src/v/cluster/metrics_reporter.h
+++ b/src/v/cluster/metrics_reporter.h
@@ -114,6 +114,9 @@ public:
         uint32_t topics_with_iceberg_schema_id{0};
         uint32_t topics_with_iceberg_schema_latest{0};
 
+        uint32_t local_topic_count{0};
+        uint32_t cloud_topic_count{0};
+
         cluster_version active_logical_version{invalid_version};
         cluster_version original_logical_version{invalid_version};
 

--- a/src/v/cluster/topic_properties.cc
+++ b/src/v/cluster/topic_properties.cc
@@ -106,6 +106,23 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
 
     return o;
 }
+
+bool topic_properties::is_local_topic() const {
+    switch (storage_mode) {
+    case model::redpanda_storage_mode::local:
+        return true;
+    case model::redpanda_storage_mode::tiered:
+        return false;
+    case model::redpanda_storage_mode::cloud:
+        return false;
+    case model::redpanda_storage_mode::unset:
+        // Unset storage mode, infer from archival and remote fetch settings.
+        return !is_archival_enabled() && !is_remote_fetch_enabled();
+    }
+    vunreachable(
+      "unknown redpanda_storage_mode: {}", std::to_underlying(storage_mode));
+}
+
 bool topic_properties::is_compacted() const {
     if (!cleanup_policy_bitflags) {
         return false;

--- a/src/v/cluster/topic_properties.h
+++ b/src/v/cluster/topic_properties.h
@@ -235,6 +235,8 @@ struct topic_properties
     model::redpanda_storage_mode storage_mode{
       storage::ntp_config::default_storage_mode};
 
+    bool is_local_topic() const;
+
     bool is_compacted() const;
     bool has_overrides() const;
     // Returns true if this topic is a tiered topic that requires

--- a/tests/rptest/tests/metrics_reporter_test.py
+++ b/tests/rptest/tests/metrics_reporter_test.py
@@ -160,6 +160,8 @@ class MetricsReporterTest(RedpandaTest):
         # get the last report
         last = metadata.pop()
         assert last["topic_count"] == total_topics
+        assert last["local_topic_count"] == total_topics
+        assert last["cloud_topic_count"] == 0
         assert last["partition_count"] == total_partitions
         assert last["has_kafka_gssapi"] is False
         assert last["has_oidc"] is False


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30302

Manual backport: the auto cherry-pick failed because `is_cloud_topic()` is not on `topic_properties` in v26.1.x (it lives on `topic_configuration`), and `model::redpanda_storage_mode::tiered_cloud` doesn't exist on this branch.

Adapted:
- Kept only the new `is_local_topic()` declaration on `topic_properties`.
- Dropped the `tiered_cloud` case from `is_local_topic()`.
- Removed the now-irrelevant comment about excluding `tiered_cloud` topics from `cloud_topic_count`.