### PR TITLE
RFC: declarative formatting + topic describe demo

### DIFF
--- a/src/go/rpk/docs/superpowers/specs/2026-04-21-rpk-output-abstraction-design.md
+++ b/src/go/rpk/docs/superpowers/specs/2026-04-21-rpk-output-abstraction-design.md
@@ -1,0 +1,171 @@
+# rpk Output Abstraction — Design
+
+**Status:** RFC draft
+**Author:** Graham Smith
+**Date:** 2026-04-21
+
+## Goal
+
+Collapse the per-command boilerplate around table / JSON / YAML output in `rpk` behind a single declarative renderer. Today every command with structured output hand-rolls the same pattern: a row struct with `json` / `yaml` tags, an `if isText, _, t, err := f.Format(results); !isText { print t; return }` dispatch block, and an explicit `NewTable(headers...) + loop + Print(cells...)` text path. Across ~135 list-style commands and ~80 commands still printing tables by hand, this adds up to several thousand lines of near-identical code.
+
+## Non-goals
+
+- Changing the `--format` flag vocabulary. `json` / `yaml` / `text` / `wide` / `long` / `short` / `help` stays identical.
+- Changing the JSON / YAML output shape of any migrated command. Byte-for-byte backward compatibility is a hard constraint.
+- Replacing `pkg/out.NewTable`. Commands outside the declarative path keep using it.
+- Declarative support for output that mixes structured sections with free-form `fmt.Printf` prose between them. Commands that need that can call the renderer per-section and interleave their own text.
+
+## Design
+
+### Public API
+
+One function:
+
+```go
+package out
+
+// Render emits v in the format selected by f, writing to w.
+// The output shape is determined by reflection on v.
+func Render(f config.OutFormatter, w io.Writer, v any) error
+```
+
+Typical usage:
+
+```go
+out.Render(&p.Formatter, os.Stdout, data)
+```
+
+### Tag vocabulary
+
+```go
+type topicRow struct {
+    Name       string `json:"name"       yaml:"name"       table:"NAME"`
+    Partitions int    `json:"partitions" yaml:"partitions" table:"PARTITIONS"`
+    LogBytes   int64  `json:"log_bytes"  yaml:"log_bytes"  table:"LOG BYTES,wide"`
+    isInternal bool   // unexported, used via FormatTableRow for decoration
+}
+```
+
+- `json:"..."` / `yaml:"..."` — existing convention. Authors keep writing these exactly as today; JSON / YAML output derives from them.
+- `table:"HEADER"` — field appears as a column in list mode (shape 1) or as a label in object mode (shape 2).
+- `table:"HEADER,wide"` — field only appears when `--format` is `wide` or `long`.
+- `table:"HEADER,omitempty"` — in object mode only, skip the label / value line when the field's value is the zero value. Ignored in list mode (columns are not per-row elided). May be combined: `table:"HEADER,wide,omitempty"`.
+- `table:"-"` — field is never rendered in text; still serialized in JSON / YAML via its existing tags.
+- `header:"SECTION TITLE"` — on a struct field whose enclosing struct is a composite (shape 3). The field becomes a titled section.
+- `header:"SECTION TITLE,omitempty"` — section is skipped in text when the field's value is zero, nil, or an empty slice.
+
+### Dispatch rules
+
+`Render(f, w, v)`:
+
+1. Call `f.Format(v)` → `(isText, isWide, s, err)`. (The actual return variable names in `pkg/config/format.go` are `isShort, isLong`; the semantics are "is text mode" and "is wide mode".)
+2. If not text — write `s`, return `err`. Done.
+3. Dereference `v` if pointer.
+4. If `v` is a slice or array → list renderer (shape 1).
+5. If `v` is a struct with at least one field tagged `header:"..."` → composite renderer (shape 3).
+6. Any other struct → object renderer (shape 2).
+7. Anything else → error.
+
+### Shape 1 — list
+
+For each element of the slice:
+
+- If the element type implements `FormatTableRow() []any`, call it for the cells.
+- Otherwise, reflect over `table:"..."` tags in struct declaration order, skipping `table:"-"` and (unless wide) `,wide` fields.
+
+Emit via `out.NewTableTo(w, headers...)`. Cells stringify via `fmt.Sprint`.
+
+### Shape 2 — object
+
+Same tag iteration as shape 1, but laid out vertically as `LABEL  VALUE` rows in a two-column table. `table:"-"` and wide-filtering apply identically.
+
+### Shape 3 — composite
+
+Walk the struct's fields in declaration order:
+
+- Skip fields without `header:"..."`.
+- Skip if `,omitempty` and the field's value is zero / nil / empty.
+- Print header text, an `=` underline of matching length, a blank line.
+- Recurse via the dispatch rules (slice → list, struct → object or composite).
+- Blank line between sections.
+
+### Escape hatch for per-row decoration
+
+```go
+type TableRowFormatter interface {
+    FormatTableRow() []any
+}
+```
+
+When a row type implements this, the list renderer uses its return slice instead of reflection. Intended for cells that need per-row decoration (e.g., appending ` (internal)` when a flag is set).
+
+The return slice contains every `table:"..."` cell in struct declaration order, including `,wide` cells. The renderer selects which indices to emit based on the current mode — the method does not need to know about short vs wide. A `table:"-"` field contributes no cell.
+
+On length mismatch (against the count of `table:"..."` tags excluding `-`), the renderer softens rather than panicking:
+
+- Fewer cells than expected → pad with `""`.
+- More cells than expected → drop the extras.
+- Either way → emit a `zap.L().Warn(...)` so the drift shows up in `--verbose`.
+
+No panic. Output still renders. CI format tests are expected to catch shape drift via output comparison.
+
+### Format → rendering mapping
+
+| `--format` | `isText` | `isWide` | Text rendering |
+| --- | --- | --- | --- |
+| `text`, `short` | true | false | tagged fields, excluding `,wide` |
+| `wide`, `long` | true | true | all tagged fields |
+| `json`, `yaml` | false | — | handed to `f.Format`, written as-is |
+
+### Empty data
+
+- Empty slice passed to the list renderer → the header row is still printed, with no data rows. Commands wanting "No foo found." print it themselves before calling `Render` when `len(data) == 0`. The renderer stays context-free.
+- Empty struct passed to the object renderer → fields render with their zero values unless tagged `table:"-"`.
+- A composite section with a zero / nil / empty value and `,omitempty` → skipped.
+
+## Backward compatibility
+
+- JSON / YAML output is produced by the same `f.Format(v)` call the current code uses, marshalling `v` directly. As long as a migrated command's struct keeps its existing field names, types, and `json` / `yaml` tags, output is byte-for-byte identical.
+- Each migration PR must include a before / after JSON diff for at least one realistic fixture as part of its verification.
+- Text output may drift slightly on migration (header casing, column spacing, empty-result behavior). This is acceptable: text output was never a stable contract. We document that consumers parsing output should use `--format json` or `yaml`.
+
+## Rollout
+
+**Step 1 — RFC PR.**
+
+- Add `pkg/out/render.go` with `Render` and three shape renderers.
+- Add `pkg/out/render_test.go` covering the full tag vocabulary and edge cases (see Testing).
+- Migrate `rpk topic describe` as the demo. It exercises all three shapes (summary = object, configs + partitions = lists, whole command = composite) and is high-visibility enough that any JSON regression will be caught immediately.
+- PR description shows a before / after JSON diff for `topic describe` against a real topic fixture.
+- Include a short godoc block on `Render` with one list, one object, and one composite example.
+
+**Step 2 — Opportunistic migration.**
+
+- Once merged, `out.Render` is the recommended path for new commands.
+- Existing commands migrate as authors touch them for other reasons or as anyone volunteers a batch.
+- No forced timeline. The old pattern continues to work; the two coexist until everything has moved.
+
+## Testing
+
+- **Renderer unit tests** in `pkg/out/render_test.go`, table-driven, covering:
+  - Primitive cells, nested structs, pointer deref.
+  - `table:"-"` hidden in text, present in JSON / YAML.
+  - `,wide` filtering toggled by `isWide`.
+  - `FormatTableRow` override including short / long mismatch (verifies pad / drop behavior and warn log).
+  - `header:"..."` composite with mixed shape children.
+  - `header:"...,omitempty"` for zero struct, nil slice, empty slice.
+  - Empty slice to list renderer emits headers only.
+- **Author helper**: `out.AssertRowShape[T](t *testing.T, zero T)` — validates the number of cells returned by `FormatTableRow` matches the number of visible `table:"..."` tags on `T`. Opt-in, but useful for commands with non-literal return slices where static inspection can't help.
+- **Existing per-command format tests** continue to run. The "rework tests" commit on this branch established format coverage for most migrated commands; if a `FormatTableRow` implementation drifts against its tags, the expected-output comparison in those tests fails.
+
+## Alternatives considered
+
+- **Per-column functional spec (kubectl / gh pattern):** `[]Column[T]{Header, Key, Get}`. Rejected because it decouples JSON shape from the Go struct, making backward compatibility harder to verify. Struct-tag approach keeps the existing data structures authoritative.
+- **Cell-level override `FormatCell(fieldName string) (any, bool)` instead of row-level:** Rejected because string-based field dispatch is fragile under refactors (typos fail silently). Row-level return is positional and obvious.
+- **Custom `go/analysis` linter** for the `FormatTableRow` length contract: Rejected as overkill for one rule. Runtime pad / truncate + warn log + existing per-command format tests provides adequate coverage.
+- **Big-bang migration in one PR**: Rejected. JSON backward compatibility is the biggest risk, and ~200 commands is not reviewable at once.
+
+## Open questions
+
+- Are any existing commands relying on `--format text` output shape being parse-stable? Worth a quick audit during the RFC PR review and, if any are found, explicitly calling them out.
+- Should `TableRowFormatter` be exported from `pkg/out`, or kept unexported and matched structurally? Exporting is more discoverable. Tentatively exported.

--- a/src/go/rpk/pkg/cli/topic/describe.go
+++ b/src/go/rpk/pkg/cli/topic/describe.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"slices"
 	"sort"
-	"strconv"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
@@ -125,17 +124,14 @@ For example,
 				}
 				if partitions {
 					offsets := listStartEndOffsets(cmd.Context(), cl, *topic.Topic, len(topic.Partitions), stable)
-					u := getDescribeUsed(topic.Partitions, offsets)
-					t.Partitions = buildDescribeTopicPartitions(topic.Partitions, offsets, u)
-					t.u = u
+					t.Partitions = buildDescribeTopicPartitions(topic.Partitions, offsets)
 				}
 				topicDescriptions = append(topicDescriptions, t)
 			}
 
-			if printDescribedTopicsFormatter(f, topicDescriptions, os.Stdout) {
-				return
+			if err := printDescribedTopics(f, topicDescriptions, os.Stdout); err != nil {
+				out.MaybeDie(err, "unable to print topics: %v", err)
 			}
-			printDescribedTopics(summary, configs, partitions, topicDescriptions)
 		},
 	}
 
@@ -160,78 +156,28 @@ For example,
 	return cmd
 }
 
-func printDescribedTopicsFormatter(f config.OutFormatter, topics []describedTopic, w io.Writer) bool {
-	if isText, _, t, err := f.Format(topics); !isText {
-		out.MaybeDie(err, "unable to print in the requested format %v", err)
-		fmt.Fprintln(w, t)
-		return true
+func printDescribedTopics(f config.OutFormatter, topics []describedTopic, w io.Writer) error {
+	for _, t := range topics {
+		if t.cfgErr != nil {
+			out.MaybeDie(t.cfgErr, "config response contained error: %v", t.cfgErr)
+		}
 	}
-	return false
-}
-
-func printDescribedTopics(summary, configs, partitions bool, topics []describedTopic) {
-	const (
-		secSummary = "summary"
-		secConfigs = "configs"
-		secPart    = "partitions"
-	)
-
-	for _, topic := range topics {
-		sections := out.NewMaybeHeaderSections(
-			out.ConditionalSectionHeaders(map[string]bool{
-				secSummary: summary,
-				secConfigs: configs,
-				secPart:    partitions,
-			})...,
-		)
-
-		sections.Add(secSummary, func() {
-			tw := out.NewTabWriter()
-			defer tw.Flush()
-			tw.PrintColumn("NAME", topic.Summary.Name)
-			if topic.Summary.Internal {
-				tw.PrintColumn("INTERNAL", topic.Summary.Internal)
-			}
-			tw.PrintColumn("PARTITIONS", topic.Summary.Partitions)
-			if topic.Summary.Partitions > 0 {
-				tw.PrintColumn("REPLICAS", topic.Summary.Replicas)
-			}
-			if topic.Summary.Error != "" {
-				tw.PrintColumn("ERROR", topic.Summary.Error)
-			}
-		})
-		sections.Add(secConfigs, func() {
-			out.MaybeDie(topic.cfgErr, "config response contained error: %v", topic.cfgErr)
-			tw := out.NewTable("KEY", "VALUE", "SOURCE")
-			defer tw.Flush()
-			for _, c := range topic.Configs {
-				tw.Print(c.Key, c.Value, c.Source)
-			}
-		})
-		sections.Add(secPart, func() {
-			tw := out.NewTable(partitionHeader(topic.u)...)
-			defer tw.Flush()
-			for _, row := range topic.Partitions {
-				tw.PrintStrings(row.Row(topic.u)...)
-			}
-		})
-	}
+	return out.Render(&f, w, topics)
 }
 
 type describedTopic struct {
-	Summary    describeTopicSummary     `json:"summary" yaml:"summary"`
-	Configs    []describeTopicConfig    `json:"configs" yaml:"configs"`
-	Partitions []describeTopicPartition `json:"partitions" yaml:"partitions"`
-	u          uses
+	Summary    describeTopicSummary     `json:"summary"    yaml:"summary"    header:"SUMMARY,omitempty"`
+	Configs    []describeTopicConfig    `json:"configs"    yaml:"configs"    header:"CONFIGS,omitempty"`
+	Partitions []describeTopicPartition `json:"partitions" yaml:"partitions" header:"PARTITIONS,omitempty"`
 	cfgErr     error
 }
 
 type describeTopicSummary struct {
-	Name       string `json:"name" yaml:"name"`
-	Internal   bool   `json:"internal" yaml:"internal"`
-	Partitions int    `json:"partitions" yaml:"partitions"`
-	Replicas   int    `json:"replicas" yaml:"replicas"`
-	Error      string `json:"error" yaml:"error"`
+	Name       string `json:"name"       yaml:"name"       table:"NAME"`
+	Internal   bool   `json:"internal"   yaml:"internal"   table:"INTERNAL,omitempty"`
+	Partitions int    `json:"partitions" yaml:"partitions" table:"PARTITIONS"`
+	Replicas   int    `json:"replicas"   yaml:"replicas"   table:"REPLICAS,omitempty"`
+	Error      string `json:"error"      yaml:"error"      table:"ERROR,omitempty"`
 }
 
 func buildDescribeTopicSummary(topic kmsg.MetadataResponseTopic) describeTopicSummary {
@@ -250,9 +196,9 @@ func buildDescribeTopicSummary(topic kmsg.MetadataResponseTopic) describeTopicSu
 }
 
 type describeTopicConfig struct {
-	Key    string `json:"key" yaml:"key"`
-	Value  string `json:"value" yaml:"value"`
-	Source string `json:"source" yaml:"source"`
+	Key    string `json:"key"    yaml:"key"    table:"KEY"`
+	Value  string `json:"value"  yaml:"value"  table:"VALUE"`
+	Source string `json:"source" yaml:"source" table:"SOURCE"`
 }
 
 func prepDescribeTopicConfig(ctx context.Context, topic kmsg.MetadataResponseTopic, cl *kgo.Client) (*kmsg.DescribeConfigsResponseResource, error) {
@@ -291,160 +237,60 @@ func buildDescribeTopicConfig(configs []kmsg.DescribeConfigsResponseResourceConf
 }
 
 type describeTopicPartition struct {
-	Partition            int32   `json:"partition" yaml:"partition"`
-	Leader               int32   `json:"leader" yaml:"leader"`
-	Epoch                int32   `json:"epoch" yaml:"epoch"`
-	Replicas             []int32 `json:"replicas" yaml:"replicas"`
-	OfflineReplicas      []int32 `json:"offline_replicas,omitempty" yaml:"offline_replicas,omitempty"`
-	LoadError            string  `json:"load_error,omitempty" yaml:"load_error,omitempty"`
-	LogStartOffset       int64   `json:"log_start_offset" yaml:"log_start_offset"`
-	logStartOffsetText   any
-	LastStableOffset     int64 `json:"last_stable_offset,omitempty" yaml:"last_stable_offset,omitempty"`
-	lastStableOffsetText any
-	HighWatermark        int64 `json:"high_watermark" yaml:"high_watermark"`
-	highWatermarkText    any
-	Errors               []string `json:"error,omitempty" yaml:"error,omitempty"`
+	Partition        int32    `json:"partition"                    yaml:"partition"                    table:"PARTITION"`
+	Leader           int32    `json:"leader"                       yaml:"leader"                       table:"LEADER"`
+	Epoch            int32    `json:"epoch"                        yaml:"epoch"                        table:"EPOCH"`
+	Replicas         []int32  `json:"replicas"                     yaml:"replicas"                     table:"REPLICAS"`
+	OfflineReplicas  []int32  `json:"offline_replicas,omitempty"   yaml:"offline_replicas,omitempty"   table:"OFFLINE-REPLICAS,wide"`
+	LoadError        string   `json:"load_error,omitempty"         yaml:"load_error,omitempty"         table:"LOAD-ERROR,wide"`
+	LogStartOffset   int64    `json:"log_start_offset"             yaml:"log_start_offset"             table:"LOG-START-OFFSET"`
+	LastStableOffset int64    `json:"last_stable_offset,omitempty" yaml:"last_stable_offset,omitempty" table:"LAST-STABLE-OFFSET,wide"`
+	HighWatermark    int64    `json:"high_watermark"               yaml:"high_watermark"               table:"HIGH-WATERMARK"`
+	Errors           []string `json:"error,omitempty"              yaml:"error,omitempty"              table:"-"`
 }
 
-func partitionHeader(u uses) []string {
-	headers := []string{
-		"partition",
-		"leader",
-		"epoch",
-		"replicas",
-	}
-
-	if u.Offline {
-		headers = append(headers, "offline-replicas")
-	}
-	if u.LoadErr {
-		headers = append(headers, "load-error")
-	}
-	headers = append(headers, "log-start-offset")
-	if u.Stable {
-		headers = append(headers, "last-stable-offset")
-	}
-	headers = append(headers, "high-watermark")
-	return headers
-}
-
-type uses struct {
-	Offline bool
-	LoadErr bool
-	Stable  bool
-}
-
-func (dp describeTopicPartition) Row(u uses) []string {
-	row := []string{
-		strconv.FormatInt(int64(dp.Partition), 10),
-		strconv.FormatInt(int64(dp.Leader), 10),
-		strconv.FormatInt(int64(dp.Epoch), 10),
-		fmt.Sprintf("%v", dp.Replicas),
-	}
-
-	if u.Offline {
-		row = append(row, fmt.Sprintf("%v", dp.OfflineReplicas))
-	}
-
-	if u.LoadErr {
-		row = append(row, dp.LoadError)
-	}
-	row = append(row, fmt.Sprintf("%v", dp.logStartOffsetText))
-
-	if u.Stable {
-		row = append(row, fmt.Sprintf("%v", dp.lastStableOffsetText))
-	}
-	row = append(row, fmt.Sprintf("%v", dp.highWatermarkText))
-	return row
-}
-
-func buildDescribeTopicPartitions(partitions []kmsg.MetadataResponseTopicPartition, offsets []startStableEndOffset, u uses) (resp []describeTopicPartition) {
+func buildDescribeTopicPartitions(partitions []kmsg.MetadataResponseTopicPartition, offsets []startStableEndOffset) (resp []describeTopicPartition) {
 	sort.Slice(partitions, func(i, j int) bool {
 		return partitions[i].Partition < partitions[j].Partition
 	})
 	for _, p := range partitions {
 		row := describeTopicPartition{
-			Partition: p.Partition,
-			Leader:    p.Leader,
-			Epoch:     p.LeaderEpoch,
-			Replicas:  int32s(p.Replicas).sort(),
+			Partition:       p.Partition,
+			Leader:          p.Leader,
+			Epoch:           p.LeaderEpoch,
+			Replicas:        int32s(p.Replicas).sort(),
+			OfflineReplicas: int32s(p.OfflineReplicas).sort(),
 		}
-		if u.Offline {
-			row.OfflineReplicas = int32s(p.OfflineReplicas).sort()
-		}
-		if u.LoadErr {
-			if err := kerr.ErrorForCode(p.ErrorCode); err != nil {
-				row.LoadError = err.Error()
-			} else {
-				row.LoadError = "-"
-			}
+		if err := kerr.ErrorForCode(p.ErrorCode); err != nil {
+			row.LoadError = err.Error()
 		}
 		o := offsets[p.Partition]
 		if o.startErr == nil {
 			row.LogStartOffset = o.start
-			row.logStartOffsetText = o.start
-		} else if errors.Is(o.startErr, errUnlisted) {
-			row.LogStartOffset = -1
-			row.logStartOffsetText = "-"
-		} else {
+		} else if !errors.Is(o.startErr, errUnlisted) {
 			row.LogStartOffset = -1
 			err := o.startErr.(*kerr.Error).Message //nolint:errorlint // This error must be kerr.Error, and we want the message
-			row.logStartOffsetText = err
 			row.Errors = append(row.Errors, err)
+		} else {
+			row.LogStartOffset = -1
 		}
-		if u.Stable {
-			if o.stableErr == nil {
-				row.LastStableOffset = o.stable
-				row.lastStableOffsetText = o.stable
-			} else if errors.Is(o.stableErr, errUnlisted) {
-				row.LastStableOffset = -1
-				row.lastStableOffsetText = "-"
-			} else {
-				row.LastStableOffset = -1
-				err := o.stableErr.(*kerr.Error).Message //nolint:errorlint // This error must be kerr.Error, and we want the message
-				row.lastStableOffsetText = err
-				row.Errors = append(row.Errors, err)
-			}
+		if o.stableErr == nil {
+			row.LastStableOffset = o.stable
+		} else if !errors.Is(o.stableErr, errUnlisted) {
+			row.LastStableOffset = -1
+			err := o.stableErr.(*kerr.Error).Message //nolint:errorlint // This error must be kerr.Error, and we want the message
+			row.Errors = append(row.Errors, err)
 		}
 		if o.endErr == nil {
 			row.HighWatermark = o.end
-			row.highWatermarkText = o.end
-		} else if errors.Is(o.endErr, errUnlisted) {
-			row.HighWatermark = -1
-			row.highWatermarkText = "-"
-		} else {
+		} else if !errors.Is(o.endErr, errUnlisted) {
 			row.HighWatermark = -1
 			err := o.endErr.(*kerr.Error).Message //nolint:errorlint // This error must be kerr.Error, and we want the message
-			row.highWatermarkText = err
 			row.Errors = append(row.Errors, err)
 		}
 		resp = append(resp, row)
 	}
 	return resp
-}
-
-// We optionally include the following columns:
-//   - offline-replicas, if any are offline
-//   - load-error, if metadata indicates load errors any partitions
-//   - last-stable-offset, if it is ever not equal to the high watermark (transactions)
-func getDescribeUsed(partitions []kmsg.MetadataResponseTopicPartition, offsets []startStableEndOffset) (u uses) {
-	for _, p := range partitions {
-		if len(p.OfflineReplicas) > 0 {
-			u.Offline = true
-		}
-		if p.ErrorCode != 0 {
-			u.LoadErr = true
-		}
-	}
-	for _, o := range offsets {
-		// The default stableErr is errUnlisted. We avoid listing
-		// stable offsets unless the user asks, so by default, we do
-		// not print the stable column.
-		if o.stableErr == nil && o.endErr == nil && o.stable != o.end {
-			u.Stable = true
-		}
-	}
-	return
 }
 
 type startStableEndOffset struct {

--- a/src/go/rpk/pkg/cli/topic/describe_test.go
+++ b/src/go/rpk/pkg/cli/topic/describe_test.go
@@ -3,8 +3,6 @@ package topic
 import (
 	"bytes"
 	"encoding/json"
-	"io"
-	"os"
 	"strings"
 	"testing"
 
@@ -20,8 +18,6 @@ func TestBuildDescribeTopicPartitions(t *testing.T) {
 		name       string
 		partitions []kmsg.MetadataResponseTopicPartition
 		offsets    []startStableEndOffset
-		uses       uses
-		expUseErr  bool
 		expected   []describeTopicPartition
 	}{
 		{
@@ -45,33 +41,26 @@ func TestBuildDescribeTopicPartitions(t *testing.T) {
 				{start: 0, stable: 100, end: 100, startErr: nil, stableErr: nil, endErr: nil},
 				{start: 50, stable: 150, end: 200, startErr: nil, stableErr: nil, endErr: nil},
 			},
-			uses: uses{Offline: true, Stable: true},
 			expected: []describeTopicPartition{
 				{
-					Partition:            0,
-					Leader:               1,
-					Epoch:                5,
-					Replicas:             []int32{1, 2, 3},
-					OfflineReplicas:      []int32{},
-					LogStartOffset:       0,
-					logStartOffsetText:   int64(0),
-					LastStableOffset:     100,
-					lastStableOffsetText: int64(100),
-					HighWatermark:        100,
-					highWatermarkText:    int64(100),
+					Partition:        0,
+					Leader:           1,
+					Epoch:            5,
+					Replicas:         []int32{1, 2, 3},
+					OfflineReplicas:  []int32{},
+					LogStartOffset:   0,
+					LastStableOffset: 100,
+					HighWatermark:    100,
 				},
 				{
-					Partition:            1,
-					Leader:               2,
-					Epoch:                3,
-					Replicas:             []int32{1, 2, 3},
-					OfflineReplicas:      []int32{3},
-					LogStartOffset:       50,
-					logStartOffsetText:   int64(50),
-					LastStableOffset:     150,
-					lastStableOffsetText: int64(150),
-					HighWatermark:        200,
-					highWatermarkText:    int64(200),
+					Partition:        1,
+					Leader:           2,
+					Epoch:            3,
+					Replicas:         []int32{1, 2, 3},
+					OfflineReplicas:  []int32{3},
+					LogStartOffset:   50,
+					LastStableOffset: 150,
+					HighWatermark:    200,
 				},
 			},
 		},
@@ -92,20 +81,17 @@ func TestBuildDescribeTopicPartitions(t *testing.T) {
 					startErr: kerr.ErrorForCode(9), stableErr: errUnlisted, endErr: kerr.ErrorForCode(9),
 				},
 			},
-			uses:      uses{LoadErr: true},
-			expUseErr: true,
 			expected: []describeTopicPartition{
 				{
-					Partition:          0,
-					Leader:             1,
-					Epoch:              5,
-					Replicas:           []int32{1, 2, 3},
-					LoadError:          "REPLICA_NOT_AVAILABLE: The replica is not available for the requested topic-partition.",
-					LogStartOffset:     -1,
-					logStartOffsetText: "REPLICA_NOT_AVAILABLE",
-					HighWatermark:      -1,
-					highWatermarkText:  "REPLICA_NOT_AVAILABLE",
-					Errors:             []string{"REPLICA_NOT_AVAILABLE", "REPLICA_NOT_AVAILABLE"},
+					Partition:       0,
+					Leader:          1,
+					Epoch:           5,
+					Replicas:        []int32{1, 2, 3},
+					OfflineReplicas: []int32{},
+					LoadError:       "REPLICA_NOT_AVAILABLE: The replica is not available for the requested topic-partition.",
+					LogStartOffset:  -1,
+					HighWatermark:   -1,
+					Errors:          []string{"REPLICA_NOT_AVAILABLE", "REPLICA_NOT_AVAILABLE"},
 				},
 			},
 		},
@@ -121,25 +107,23 @@ func TestBuildDescribeTopicPartitions(t *testing.T) {
 			offsets: []startStableEndOffset{
 				{
 					start:    -1,
-					startErr: kerr.ErrorForCode(3), // Set the error
+					startErr: kerr.ErrorForCode(3),
 					stable:   -1,
 					end:      -1,
 					endErr:   kerr.ErrorForCode(3),
 				},
 			},
-			uses:      uses{LoadErr: true},
-			expUseErr: true,
 			expected: []describeTopicPartition{
 				{
-					Partition:          0,
-					Leader:             -1,
-					LoadError:          "UNKNOWN_TOPIC_OR_PARTITION: This server does not host this topic-partition.",
-					LogStartOffset:     -1,
-					logStartOffsetText: "UNKNOWN_TOPIC_OR_PARTITION",
-					Replicas:           []int32{},
-					HighWatermark:      -1,
-					highWatermarkText:  "UNKNOWN_TOPIC_OR_PARTITION",
-					Errors:             []string{"UNKNOWN_TOPIC_OR_PARTITION", "UNKNOWN_TOPIC_OR_PARTITION"},
+					Partition:        0,
+					Leader:           -1,
+					LoadError:        "UNKNOWN_TOPIC_OR_PARTITION: This server does not host this topic-partition.",
+					LogStartOffset:   -1,
+					LastStableOffset: -1, // stable=-1 with no error → populated as-is
+					Replicas:         []int32{},
+					OfflineReplicas:  []int32{},
+					HighWatermark:    -1,
+					Errors:           []string{"UNKNOWN_TOPIC_OR_PARTITION", "UNKNOWN_TOPIC_OR_PARTITION"},
 				},
 			},
 		},
@@ -147,154 +131,22 @@ func TestBuildDescribeTopicPartitions(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := buildDescribeTopicPartitions(tc.partitions, tc.offsets, tc.uses)
+			result := buildDescribeTopicPartitions(tc.partitions, tc.offsets)
 			assert.Equal(t, tc.expected, result)
 		})
 	}
 }
 
-func TestPartitionHeaderAndRow(t *testing.T) {
-	tests := []struct {
-		name           string
-		partition      describeTopicPartition
-		uses           uses
-		expectedHeader []string
-		expectedRow    []string
-	}{
-		{
-			name: "all fields",
-			partition: describeTopicPartition{
-				Partition:            0,
-				Leader:               1,
-				Epoch:                5,
-				Replicas:             []int32{1, 2, 3},
-				OfflineReplicas:      []int32{3},
-				LoadError:            "REPLICA_NOT_AVAILABLE",
-				LogStartOffset:       100,
-				logStartOffsetText:   int64(100),
-				LastStableOffset:     200,
-				lastStableOffsetText: int64(200),
-				HighWatermark:        300,
-				highWatermarkText:    int64(300),
-				Errors:               []string{"Error1", "Error2"},
-			},
-			uses: uses{Offline: true, LoadErr: true, Stable: true},
-			expectedHeader: []string{
-				"partition", "leader", "epoch", "replicas", "offline-replicas",
-				"load-error", "log-start-offset", "last-stable-offset", "high-watermark",
-			},
-			expectedRow: []string{
-				"0", "1", "5", "[1 2 3]", "[3]", "REPLICA_NOT_AVAILABLE",
-				"100", "200", "300",
-			},
-		},
-		{
-			name: "minimal fields",
-			partition: describeTopicPartition{
-				Partition:          1,
-				Leader:             2,
-				Epoch:              3,
-				Replicas:           []int32{1, 2},
-				LogStartOffset:     50,
-				logStartOffsetText: int64(50),
-				HighWatermark:      150,
-				highWatermarkText:  int64(150),
-			},
-			uses: uses{},
-			expectedHeader: []string{
-				"partition", "leader", "epoch", "replicas", "log-start-offset", "high-watermark",
-			},
-			expectedRow: []string{
-				"1", "2", "3", "[1 2]", "50", "150",
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			header := partitionHeader(tt.uses)
-			assert.Equal(t, tt.expectedHeader, header, "Headers do not match expected")
-
-			row := tt.partition.Row(tt.uses)
-			assert.Equal(t, tt.expectedRow, row, "Row does not match expected")
-		})
-	}
-}
-
-func TestGetDescribeUsed(t *testing.T) {
-	testCases := []struct {
-		name       string
-		partitions []kmsg.MetadataResponseTopicPartition
-		offsets    []startStableEndOffset
-		expected   uses
-	}{
-		{
-			name: "No special cases",
-			partitions: []kmsg.MetadataResponseTopicPartition{
-				{Partition: 0, ErrorCode: 0},
-			},
-			offsets: []startStableEndOffset{
-				{start: 0, stable: 100, end: 100},
-			},
-			expected: uses{},
-		},
-		{
-			name: "With offline replicas",
-			partitions: []kmsg.MetadataResponseTopicPartition{
-				{Partition: 0, OfflineReplicas: []int32{1}},
-			},
-			offsets: []startStableEndOffset{
-				{start: 0, stable: 100, end: 100},
-			},
-			expected: uses{Offline: true},
-		},
-		{
-			name: "With load error",
-			partitions: []kmsg.MetadataResponseTopicPartition{
-				{Partition: 0, ErrorCode: 1},
-			},
-			offsets: []startStableEndOffset{
-				{start: 0, stable: 100, end: 100},
-			},
-			expected: uses{LoadErr: true},
-		},
-		{
-			name: "With stable offset different from end",
-			partitions: []kmsg.MetadataResponseTopicPartition{
-				{Partition: 0},
-			},
-			offsets: []startStableEndOffset{
-				{start: 0, stable: 50, end: 100, stableErr: nil, endErr: nil},
-			},
-			expected: uses{Stable: true},
-		},
-		{
-			name: "All cases",
-			partitions: []kmsg.MetadataResponseTopicPartition{
-				{Partition: 0, ErrorCode: 1, OfflineReplicas: []int32{1}},
-			},
-			offsets: []startStableEndOffset{
-				{start: 0, stable: 50, end: 100, stableErr: nil, endErr: nil},
-			},
-			expected: uses{Offline: true, LoadErr: true, Stable: true},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			result := getDescribeUsed(tc.partitions, tc.offsets)
-			assert.Equal(t, tc.expected, result)
-		})
-	}
-}
-
-func TestPrintDescribedTopicsFormatter(t *testing.T) {
+// TestPrintDescribedTopicsNonText verifies that JSON and YAML output shapes are
+// preserved after the migration to out.Render. The json: and yaml: tags on
+// describedTopic and its children are unchanged, so the serialised form must
+// match the pre-migration output exactly.
+func TestPrintDescribedTopicsNonText(t *testing.T) {
 	testCases := []struct {
 		name           string
 		format         string
 		topics         []describedTopic
 		expectedOutput string
-		expectedReturn bool
 	}{
 		{
 			name:   "JSON format - single topic",
@@ -318,7 +170,6 @@ func TestPrintDescribedTopicsFormatter(t *testing.T) {
 				},
 			},
 			expectedOutput: `[{"summary":{"name":"test-topic","internal":false,"partitions":3,"replicas":2,"error":""},"configs":[{"key":"retention.ms","value":"604800000","source":"DEFAULT_CONFIG"}],"partitions":[{"partition":0,"leader":1,"epoch":0,"replicas":[1,2],"log_start_offset":0,"high_watermark":0},{"partition":1,"leader":2,"epoch":0,"replicas":[2,1],"log_start_offset":0,"high_watermark":0},{"partition":2,"leader":1,"epoch":0,"replicas":[1,2],"log_start_offset":0,"high_watermark":0}]}]`,
-			expectedReturn: true,
 		},
 		{
 			name:   "JSON format - multiple topics",
@@ -355,7 +206,6 @@ func TestPrintDescribedTopicsFormatter(t *testing.T) {
 				},
 			},
 			expectedOutput: `[{"summary":{"name":"topic1","internal":false,"partitions":2,"replicas":2,"error":""},"configs":[{"key":"retention.ms","value":"86400000","source":"DYNAMIC_TOPIC_CONFIG"}],"partitions":[{"partition":0,"leader":1,"epoch":0,"replicas":[1,2],"log_start_offset":0,"high_watermark":0},{"partition":1,"leader":2,"epoch":0,"replicas":[2,1],"log_start_offset":0,"high_watermark":0}]},{"summary":{"name":"topic2","internal":true,"partitions":1,"replicas":3,"error":""},"configs":[{"key":"cleanup.policy","value":"compact","source":"STATIC_BROKER_CONFIG"}],"partitions":[{"partition":0,"leader":3,"epoch":0,"replicas":[1,2,3],"log_start_offset":0,"high_watermark":0}]}]`,
-			expectedReturn: true,
 		},
 		{
 			name:   "JSON format - topics with errors",
@@ -500,7 +350,6 @@ func TestPrintDescribedTopicsFormatter(t *testing.T) {
 					]
 				}
 			]`,
-			expectedReturn: true,
 		},
 		{
 			name:   "YAML format - single topic",
@@ -539,7 +388,6 @@ func TestPrintDescribedTopicsFormatter(t *testing.T) {
         - 1
       log_start_offset: 0
       high_watermark: 0`,
-			expectedReturn: true,
 		},
 		{
 			name:   "YAML format - topic with error",
@@ -563,23 +411,6 @@ func TestPrintDescribedTopicsFormatter(t *testing.T) {
     error: UNKNOWN_TOPIC_OR_PARTITION
   configs: []
   partitions: []`,
-			expectedReturn: true,
-		},
-		{
-			name:   "Text format - should return false",
-			format: "text",
-			topics: []describedTopic{
-				{
-					Summary: describeTopicSummary{
-						Name:       "test-topic",
-						Internal:   false,
-						Partitions: 1,
-						Replicas:   1,
-					},
-				},
-			},
-			expectedOutput: "",
-			expectedReturn: false,
 		},
 	}
 
@@ -588,45 +419,35 @@ func TestPrintDescribedTopicsFormatter(t *testing.T) {
 			var buf bytes.Buffer
 			f := config.OutFormatter{Kind: tc.format}
 
-			result := printDescribedTopicsFormatter(f, tc.topics, &buf)
+			err := printDescribedTopics(f, tc.topics, &buf)
+			require.NoError(t, err)
 
-			assert.Equal(t, tc.expectedReturn, result)
-
-			if tc.expectedReturn {
-				switch tc.format {
-				case "json":
-					var expected, actual any
-					err := json.Unmarshal([]byte(tc.expectedOutput), &expected)
-					require.NoError(t, err)
-					err = json.Unmarshal(buf.Bytes(), &actual)
-					require.NoError(t, err)
-					assert.Equal(t, expected, actual)
-				case "yaml":
-					assert.Equal(t, strings.TrimRight(tc.expectedOutput, "\n"), strings.TrimRight(buf.String(), "\n"))
-				default:
-					assert.Equal(t, tc.expectedOutput, buf.String())
-				}
-			} else {
-				assert.Empty(t, buf.String())
+			switch tc.format {
+			case "json":
+				var expected, actual any
+				require.NoError(t, json.Unmarshal([]byte(tc.expectedOutput), &expected))
+				require.NoError(t, json.Unmarshal(buf.Bytes(), &actual))
+				assert.Equal(t, expected, actual)
+			case "yaml":
+				assert.Equal(t, strings.TrimRight(tc.expectedOutput, "\n"), strings.TrimRight(buf.String(), "\n"))
 			}
 		})
 	}
 }
 
+// TestPrintDescribedTopics verifies text-mode output of the new printDescribedTopics.
+// All sections (SUMMARY, CONFIGS, PARTITIONS) are now rendered declaratively via
+// header: tags. The PARTITIONS section renders as a table with table: tags; wide
+// columns (OFFLINE-REPLICAS, LOAD-ERROR, LAST-STABLE-OFFSET) are hidden in default mode.
 func TestPrintDescribedTopics(t *testing.T) {
 	testCases := []struct {
 		name           string
-		summary        bool
-		configs        bool
-		partitions     bool
 		topics         []describedTopic
 		expectedOutput string
 	}{
 		{
-			name:       "Print all sections",
-			summary:    true,
-			configs:    true,
-			partitions: true,
+			// PARTITIONS section renders via header: tag with table: tagged rows.
+			name: "Print all sections",
 			topics: []describedTopic{
 				{
 					Summary: describeTopicSummary{
@@ -644,29 +465,11 @@ func TestPrintDescribedTopics(t *testing.T) {
 					},
 				},
 			},
-			expectedOutput: `SUMMARY
-=======
-NAME        test-topic
-PARTITIONS  2
-REPLICAS    3
-
-CONFIGS
-=======
-KEY           VALUE      SOURCE
-retention.ms  604800000  DEFAULT_CONFIG
-
-PARTITIONS
-==========
-PARTITION  LEADER  EPOCH  REPLICAS  LOG-START-OFFSET  HIGH-WATERMARK
-0          1       0      [1 2 3]   <nil>             <nil>
-1          2       0      [2 3 1]   <nil>             <nil>
-`,
+			expectedOutput: "SUMMARY\n=======\nNAME        test-topic\nPARTITIONS  2\nREPLICAS    3\n\nCONFIGS\n=======\nKEY           VALUE      SOURCE\nretention.ms  604800000  DEFAULT_CONFIG\n\nPARTITIONS\n==========\nPARTITION  LEADER  EPOCH  REPLICAS  LOG-START-OFFSET  HIGH-WATERMARK\n0          1       0      [1 2 3]   0                 0\n1          2       0      [2 3 1]   0                 0\n",
 		},
 		{
-			name:       "Print only summary",
-			summary:    true,
-			configs:    false,
-			partitions: false,
+			// INTERNAL is omitempty: false → omitted. Configs and Partitions are nil → sections omitted.
+			name: "Print only summary",
 			topics: []describedTopic{
 				{
 					Summary: describeTopicSummary{
@@ -677,17 +480,10 @@ PARTITION  LEADER  EPOCH  REPLICAS  LOG-START-OFFSET  HIGH-WATERMARK
 					},
 				},
 			},
-			expectedOutput: `NAME        test-topic
-INTERNAL    true
-PARTITIONS  1
-REPLICAS    1
-`,
+			expectedOutput: "SUMMARY\n=======\nNAME        test-topic\nINTERNAL    true\nPARTITIONS  1\nREPLICAS    1\n",
 		},
 		{
-			name:       "Print summary and configs",
-			summary:    true,
-			configs:    true,
-			partitions: false,
+			name: "Print summary and configs",
 			topics: []describedTopic{
 				{
 					Summary: describeTopicSummary{
@@ -702,24 +498,11 @@ REPLICAS    1
 					},
 				},
 			},
-			expectedOutput: `SUMMARY
-=======
-NAME        test-topic
-PARTITIONS  1
-REPLICAS    1
-
-CONFIGS
-=======
-KEY               VALUE     SOURCE
-cleanup.policy    delete    DEFAULT_CONFIG
-compression.type  producer  DYNAMIC_TOPIC_CONFIG
-`,
+			expectedOutput: "SUMMARY\n=======\nNAME        test-topic\nPARTITIONS  1\nREPLICAS    1\n\nCONFIGS\n=======\nKEY               VALUE     SOURCE\ncleanup.policy    delete    DEFAULT_CONFIG\ncompression.type  producer  DYNAMIC_TOPIC_CONFIG\n",
 		},
 		{
-			name:       "Print with errors",
-			summary:    true,
-			configs:    true,
-			partitions: true,
+			// Configs and Partitions are nil (omitempty → omitted). REPLICAS=0 is omitempty → omitted.
+			name: "Print with errors",
 			topics: []describedTopic{
 				{
 					Summary: describeTopicSummary{
@@ -731,43 +514,95 @@ compression.type  producer  DYNAMIC_TOPIC_CONFIG
 					},
 				},
 			},
-			expectedOutput: `SUMMARY
-=======
-NAME        error-topic
-PARTITIONS  0
-ERROR       UNKNOWN_TOPIC_OR_PARTITION
-
-CONFIGS
-=======
-KEY   VALUE  SOURCE
-
-PARTITIONS
-==========
-PARTITION  LEADER  EPOCH  REPLICAS  LOG-START-OFFSET  HIGH-WATERMARK
-`,
+			expectedOutput: "SUMMARY\n=======\nNAME        error-topic\nPARTITIONS  0\nERROR       UNKNOWN_TOPIC_OR_PARTITION\n",
 		},
 	}
 
 	for _, tc := range testCases {
-		// Janky way to test the output of a function that prints to stdout. Would be preferable to just pass in a buf and check that.
 		t.Run(tc.name, func(t *testing.T) {
-			// Redirect stdout to capture output
-			old := os.Stdout
-			r, w, _ := os.Pipe()
-			os.Stdout = w
-
-			printDescribedTopics(tc.summary, tc.configs, tc.partitions, tc.topics)
-
-			// Restore stdout
-			w.Close()
-			os.Stdout = old
-
 			var buf bytes.Buffer
-			io.Copy(&buf, r)
-			output := buf.String()
+			f := config.OutFormatter{Kind: "text"}
 
-			// Compare output
-			assert.Equal(t, tc.expectedOutput, output)
+			err := printDescribedTopics(f, tc.topics, &buf)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectedOutput, buf.String())
 		})
 	}
+}
+
+func TestDescribedTopicJSONShapeStable(t *testing.T) {
+	d := describedTopic{
+		Summary: describeTopicSummary{
+			Name:       "t",
+			Internal:   false,
+			Partitions: 1,
+			Replicas:   3,
+		},
+		Configs: []describeTopicConfig{
+			{Key: "cleanup.policy", Value: "delete", Source: "DYNAMIC"},
+		},
+		Partitions: []describeTopicPartition{
+			{
+				Partition:      0,
+				Leader:         1,
+				Epoch:          0,
+				Replicas:       []int32{1, 2, 3},
+				LogStartOffset: 0,
+				HighWatermark:  100,
+			},
+		},
+	}
+	b, err := json.Marshal(d)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"summary":{"name":"t","internal":false,"partitions":1,"replicas":3,"error":""},
+		"configs":[{"key":"cleanup.policy","value":"delete","source":"DYNAMIC"}],
+		"partitions":[{"partition":0,"leader":1,"epoch":0,"replicas":[1,2,3],"log_start_offset":0,"high_watermark":100}]
+	}`, string(b))
+}
+
+// TestDescribedTopicJSONShapeWithOmitEmptyPopulated verifies that every
+// omitempty field on describeTopicPartition and the non-empty summary Error
+// appear in the serialised output with the correct json: key names.
+// Renaming or dropping any json tag will break this test.
+func TestDescribedTopicJSONShapeWithOmitEmptyPopulated(t *testing.T) {
+	d := describedTopic{
+		Summary: describeTopicSummary{
+			Name:       "t",
+			Internal:   true,
+			Partitions: 1,
+			Replicas:   3,
+			Error:      "UNKNOWN_TOPIC",
+		},
+		Configs: []describeTopicConfig{
+			{Key: "cleanup.policy", Value: "delete", Source: "DYNAMIC"},
+		},
+		Partitions: []describeTopicPartition{
+			{
+				Partition:        0,
+				Leader:           1,
+				Epoch:            2,
+				Replicas:         []int32{1, 2, 3},
+				OfflineReplicas:  []int32{3},
+				LoadError:        "REPLICA_NOT_AVAILABLE",
+				LogStartOffset:   10,
+				LastStableOffset: 42,
+				HighWatermark:    100,
+				Errors:           []string{"something"},
+			},
+		},
+	}
+	b, err := json.Marshal(d)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"summary":{"name":"t","internal":true,"partitions":1,"replicas":3,"error":"UNKNOWN_TOPIC"},
+		"configs":[{"key":"cleanup.policy","value":"delete","source":"DYNAMIC"}],
+		"partitions":[{
+			"partition":0,"leader":1,"epoch":2,"replicas":[1,2,3],
+			"offline_replicas":[3],"load_error":"REPLICA_NOT_AVAILABLE",
+			"log_start_offset":10,"last_stable_offset":42,"high_watermark":100,
+			"error":["something"]
+		}]
+	}`, string(b))
 }

--- a/src/go/rpk/pkg/out/BUILD
+++ b/src/go/rpk/pkg/out/BUILD
@@ -6,6 +6,7 @@ go_library(
         "color.go",
         "in.go",
         "out.go",
+        "render.go",
         "spinner.go",
     ],
     importpath = "github.com/redpanda-data/redpanda/src/go/rpk/pkg/out",
@@ -28,6 +29,7 @@ go_test(
     srcs = [
         "in_test.go",
         "out_test.go",
+        "render_test.go",
         "spinner_test.go",
     ],
     embed = [":out"],

--- a/src/go/rpk/pkg/out/render.go
+++ b/src/go/rpk/pkg/out/render.go
@@ -1,0 +1,355 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package out
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+)
+
+// Formatter is the interface satisfied by *config.OutFormatter. Accepting an
+// interface here avoids the import cycle that would arise from importing
+// pkg/config directly (pkg/config already imports pkg/out).
+//
+// Because config.OutFormatter.Format has a pointer receiver, callers pass
+// the address: out.Render(&p.Formatter, os.Stdout, data).
+type Formatter interface {
+	// Format serialises v according to the chosen output kind and returns:
+	//   isText  – true when the caller should render as a text table
+	//   isWide  – true when the text table should include wide-only columns
+	//   s       – the serialised string for non-text formats (JSON / YAML)
+	//   err     – non-nil when the format kind is unsupported or marshalling fails
+	Format(v any) (isText, isWide bool, s string, err error)
+}
+
+// Render emits v in the format selected by f, writing to w.
+// The output shape is determined by reflecting on v:
+//
+//   - slice / array → list (header row + one row per element)
+//   - struct with at least one field tagged `header:"..."` → composite sections
+//   - any other struct → object (LABEL / VALUE two-column layout)
+//
+// JSON / YAML formats are handed to f.Format and written as-is.
+// If v is a nil pointer, text output is empty; JSON / YAML serialise nil
+// according to the chosen encoder (typically `null`).
+func Render(f Formatter, w io.Writer, v any) error {
+	isText, isWide, s, err := f.Format(v)
+	if !isText {
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(w, s)
+		return nil
+	}
+	return renderText(w, v, isWide)
+}
+
+func renderText(w io.Writer, v any, isWide bool) error {
+	rv := reflect.ValueOf(v)
+	for rv.Kind() == reflect.Pointer {
+		if rv.IsNil() {
+			return nil
+		}
+		rv = rv.Elem()
+	}
+	switch rv.Kind() {
+	case reflect.Slice, reflect.Array:
+		return renderList(w, rv, isWide)
+	case reflect.Struct:
+		if hasHeaderTag(rv.Type()) {
+			return renderComposite(w, rv, isWide)
+		}
+		return renderObject(w, rv, isWide)
+	default:
+		return fmt.Errorf("out.Render: unsupported kind %s", rv.Kind())
+	}
+}
+
+// listColumn is a resolved text column derived from a struct field's table tag.
+type listColumn struct {
+	header     string
+	fieldIndex int
+	wide       bool
+	omitempty  bool
+}
+
+// listColumns extracts the ordered set of table columns from a struct type.
+func listColumns(t reflect.Type) []listColumn {
+	var cols []listColumn
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		tag := parseTableTag(f.Tag.Get("table"))
+		if !tag.present || tag.skip {
+			continue
+		}
+		cols = append(cols, listColumn{
+			header:     tag.header,
+			fieldIndex: i,
+			wide:       tag.wide,
+			omitempty:  tag.omitempty,
+		})
+	}
+	return cols
+}
+
+// renderList renders a slice or array of structs as a text table.
+func renderList(w io.Writer, slice reflect.Value, isWide bool) error {
+	elemT := slice.Type().Elem()
+	for elemT.Kind() == reflect.Pointer {
+		elemT = elemT.Elem()
+	}
+	if elemT.Kind() != reflect.Struct {
+		return fmt.Errorf("out.Render: list element must be a struct, got %s", elemT.Kind())
+	}
+
+	// If elements have header: tags, render each as a titled composite block.
+	if hasHeaderTag(elemT) {
+		for i := 0; i < slice.Len(); i++ {
+			if i > 0 {
+				fmt.Fprintln(w)
+			}
+			elem := slice.Index(i)
+			for elem.Kind() == reflect.Pointer {
+				if elem.IsNil() {
+					break
+				}
+				elem = elem.Elem()
+			}
+			if elem.Kind() != reflect.Struct {
+				continue
+			}
+			if err := renderComposite(w, elem, isWide); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	all := listColumns(elemT)
+	visible := visibleListColumns(all, isWide)
+	headers := make([]string, len(visible))
+	for i, c := range visible {
+		headers[i] = c.header
+	}
+	tw := NewTableTo(w, headers...)
+	defer tw.Flush()
+	for i := 0; i < slice.Len(); i++ {
+		elem := slice.Index(i)
+		for elem.Kind() == reflect.Pointer {
+			if elem.IsNil() {
+				break
+			}
+			elem = elem.Elem()
+		}
+		if elem.Kind() != reflect.Struct {
+			// Nil pointer element — render a blank row so the row count still matches.
+			tw.Print(make([]any, len(visible))...)
+			continue
+		}
+		cells := make([]any, len(visible))
+		for j, c := range visible {
+			cells[j] = cellValue(elem.Field(c.fieldIndex))
+		}
+		tw.Print(cells...)
+	}
+	return nil
+}
+
+// renderObject renders a single struct as a two-column LABEL / VALUE layout,
+// using the same table: tags that drive list columns.
+func renderObject(w io.Writer, v reflect.Value, isWide bool) error {
+	t := v.Type()
+	tw := NewTabWriterTo(w)
+	defer tw.Flush()
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		tag := parseTableTag(f.Tag.Get("table"))
+		if !tag.present || tag.skip {
+			continue
+		}
+		if tag.wide && !isWide {
+			continue
+		}
+		fv := v.Field(i)
+		if tag.omitempty && fv.IsZero() {
+			continue
+		}
+		tw.PrintColumn(tag.header, cellValue(fv))
+	}
+	return nil
+}
+
+// cellValue extracts a field value appropriate for table rendering. Non-nil
+// pointers are dereferenced so fmt.Sprint formats the pointee, not the address;
+// nil pointers render as empty string.
+func cellValue(v reflect.Value) any {
+	for v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return ""
+		}
+		v = v.Elem()
+	}
+	return v.Interface()
+}
+
+func visibleListColumns(all []listColumn, isWide bool) []listColumn {
+	if isWide {
+		return all
+	}
+	out := make([]listColumn, 0, len(all))
+	for _, c := range all {
+		if !c.wide {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// tableTag is a parsed `table:"..."` struct tag.
+type tableTag struct {
+	header    string
+	wide      bool
+	omitempty bool
+	skip      bool // tag was "-"
+	present   bool // tag was set (not absent)
+}
+
+func parseTableTag(s string) tableTag {
+	if s == "" {
+		return tableTag{}
+	}
+	if s == "-" {
+		return tableTag{present: true, skip: true}
+	}
+	parts := strings.Split(s, ",")
+	t := tableTag{present: true, header: parts[0]}
+	for _, p := range parts[1:] {
+		switch p {
+		case "wide":
+			t.wide = true
+		case "omitempty":
+			t.omitempty = true
+		}
+	}
+	return t
+}
+
+// headerTag is a parsed `header:"..."` struct tag used to mark composite sections.
+type headerTag struct {
+	title     string
+	omitempty bool
+	present   bool
+}
+
+func parseHeaderTag(s string) headerTag {
+	if s == "" {
+		return headerTag{}
+	}
+	parts := strings.Split(s, ",")
+	h := headerTag{present: true, title: parts[0]}
+	for _, p := range parts[1:] {
+		if p == "omitempty" {
+			h.omitempty = true
+		}
+	}
+	return h
+}
+
+func hasHeaderTag(t reflect.Type) bool {
+	for i := 0; i < t.NumField(); i++ {
+		if parseHeaderTag(t.Field(i).Tag.Get("header")).present {
+			return true
+		}
+	}
+	return false
+}
+
+func renderComposite(w io.Writer, v reflect.Value, isWide bool) error {
+	t := v.Type()
+	first := true
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		h := parseHeaderTag(f.Tag.Get("header"))
+		if !h.present {
+			continue
+		}
+		fv := v.Field(i)
+		if h.omitempty && isSectionEmpty(fv) {
+			continue
+		}
+		if !first {
+			fmt.Fprintln(w)
+		}
+		first = false
+		fmt.Fprintln(w, h.title)
+		fmt.Fprintln(w, strings.Repeat("=", len(h.title)))
+		if err := renderCompositeField(w, fv, isWide); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// isSectionEmpty reports whether v should be treated as "empty" for the
+// composite section omitempty contract: nil pointer, zero struct, or
+// empty slice / array / map / string.
+//
+// For struct sections, emptiness is determined by reflect.Value.IsZero(),
+// which returns true only when every field is the zero value. Use
+// header:",omitempty" on a struct section only when a fully-zero struct
+// is meaningless — a struct with a single bool or int field where the
+// zero value is a valid rendered state would be silently suppressed.
+func isSectionEmpty(v reflect.Value) bool {
+	for v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return true
+		}
+		v = v.Elem()
+	}
+	switch v.Kind() {
+	case reflect.Slice, reflect.Array, reflect.Map, reflect.Chan, reflect.String:
+		return v.Len() == 0
+	}
+	return v.IsZero()
+}
+
+// renderCompositeField dispatches on the section value's kind, mirroring
+// renderText but without the JSON/YAML branch (the composite is already in
+// text mode) and without wrapping the whole thing in another composite.
+func renderCompositeField(w io.Writer, v reflect.Value, isWide bool) error {
+	for v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return nil
+		}
+		v = v.Elem()
+	}
+	switch v.Kind() {
+	case reflect.Slice, reflect.Array:
+		return renderList(w, v, isWide)
+	case reflect.Struct:
+		if hasHeaderTag(v.Type()) {
+			return renderComposite(w, v, isWide)
+		}
+		return renderObject(w, v, isWide)
+	default:
+		return fmt.Errorf("out.Render: unsupported section kind %s", v.Kind())
+	}
+}

--- a/src/go/rpk/pkg/out/render_test.go
+++ b/src/go/rpk/pkg/out/render_test.go
@@ -1,0 +1,405 @@
+package out
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+type renderFixture struct {
+	Name  string `json:"name"  yaml:"name"  table:"NAME"`
+	Count int    `json:"count" yaml:"count" table:"COUNT"`
+}
+
+// testFormatter is a local implementation of Formatter for unit tests,
+// avoiding the import cycle that would arise from using config.OutFormatter.
+type testFormatter struct {
+	kind string
+}
+
+func (f testFormatter) Format(v any) (isText, isWide bool, s string, err error) {
+	switch f.kind {
+	case "json":
+		b, err := json.Marshal(v)
+		if err != nil {
+			return false, false, "", err
+		}
+		return false, false, string(b), nil
+	case "yaml":
+		b, err := yaml.Marshal(v)
+		if err != nil {
+			return false, false, "", err
+		}
+		return false, false, string(b), nil
+	case "text":
+		return true, false, "", nil
+	case "wide":
+		return true, true, "", nil
+	default:
+		return false, false, "", fmt.Errorf("--format %q not supported", f.kind)
+	}
+}
+
+func TestParseTableTag(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want tableTag
+	}{
+		{name: "empty", in: "", want: tableTag{}},
+		{name: "dash", in: "-", want: tableTag{present: true, skip: true}},
+		{name: "header only", in: "NAME", want: tableTag{present: true, header: "NAME"}},
+		{name: "wide", in: "NAME,wide", want: tableTag{present: true, header: "NAME", wide: true}},
+		{name: "omitempty", in: "NAME,omitempty", want: tableTag{present: true, header: "NAME", omitempty: true}},
+		{name: "wide and omitempty", in: "NAME,wide,omitempty", want: tableTag{present: true, header: "NAME", wide: true, omitempty: true}},
+		{name: "unknown modifier ignored", in: "NAME,bogus", want: tableTag{present: true, header: "NAME"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, parseTableTag(tc.in))
+		})
+	}
+}
+
+func TestParseHeaderTag(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want headerTag
+	}{
+		{name: "empty", in: "", want: headerTag{}},
+		{name: "title only", in: "SUMMARY", want: headerTag{present: true, title: "SUMMARY"}},
+		{name: "omitempty", in: "SUMMARY,omitempty", want: headerTag{present: true, title: "SUMMARY", omitempty: true}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, parseHeaderTag(tc.in))
+		})
+	}
+}
+
+func TestRenderPassesThroughJSON(t *testing.T) {
+	f := testFormatter{kind: "json"}
+	var buf bytes.Buffer
+	err := Render(f, &buf, renderFixture{Name: "foo", Count: 3})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"name":"foo","count":3}`, strings.TrimSpace(buf.String()))
+}
+
+func TestRenderPassesThroughYAML(t *testing.T) {
+	f := testFormatter{kind: "yaml"}
+	var buf bytes.Buffer
+	err := Render(f, &buf, renderFixture{Name: "foo", Count: 3})
+	require.NoError(t, err)
+	require.Equal(t, "name: foo\ncount: 3\n\n", buf.String())
+}
+
+func TestRenderUnsupportedFormatReturnsError(t *testing.T) {
+	f := testFormatter{kind: "xml"}
+	var buf bytes.Buffer
+	err := Render(f, &buf, renderFixture{})
+	require.Error(t, err)
+}
+
+type listRow struct {
+	Name       string `json:"name"       yaml:"name"       table:"NAME"`
+	Partitions int    `json:"partitions" yaml:"partitions" table:"PARTITIONS"`
+	Replicas   int    `json:"replicas"   yaml:"replicas"   table:"REPLICAS"`
+}
+
+func TestRenderListBasicReflection(t *testing.T) {
+	f := testFormatter{kind: "text"}
+	var buf bytes.Buffer
+	err := Render(f, &buf, []listRow{
+		{Name: "alpha", Partitions: 3, Replicas: 7},
+		{Name: "beta", Partitions: 1, Replicas: 5},
+	})
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	require.Len(t, lines, 3) // header + 2 rows
+	// Header row preserves the declared table: labels (already uppercase here).
+	require.Contains(t, lines[0], "NAME")
+	require.Contains(t, lines[0], "PARTITIONS")
+	require.Contains(t, lines[0], "REPLICAS")
+	require.Contains(t, lines[1], "alpha")
+	require.Contains(t, lines[1], "3")
+	require.Contains(t, lines[1], "7")
+	require.Contains(t, lines[2], "beta")
+	require.Contains(t, lines[2], "1")
+	require.Contains(t, lines[2], "5")
+}
+
+func TestRenderListEmptySlicePrintsHeadersOnly(t *testing.T) {
+	f := testFormatter{kind: "text"}
+	var buf bytes.Buffer
+	err := Render(f, &buf, []listRow{})
+	require.NoError(t, err)
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	require.Len(t, lines, 1)
+	require.Contains(t, lines[0], "NAME")
+}
+
+func TestRenderListSkipsDashTag(t *testing.T) {
+	type row struct {
+		Name   string `json:"name"   yaml:"name"   table:"NAME"`
+		Hidden string `json:"hidden" yaml:"hidden" table:"-"`
+	}
+	f := testFormatter{kind: "text"}
+	var buf bytes.Buffer
+	err := Render(f, &buf, []row{{Name: "a", Hidden: "secret"}})
+	require.NoError(t, err)
+	require.NotContains(t, buf.String(), "secret")
+	require.NotContains(t, buf.String(), "HIDDEN")
+}
+
+type wideRow struct {
+	Name   string `json:"name"   yaml:"name"   table:"NAME"`
+	Bytes  int64  `json:"bytes"  yaml:"bytes"  table:"LOG BYTES,wide"`
+	Detail string `json:"detail" yaml:"detail" table:"DETAIL,wide"`
+}
+
+func TestRenderListHidesWideByDefault(t *testing.T) {
+	f := testFormatter{kind: "text"}
+	var buf bytes.Buffer
+	err := Render(f, &buf, []wideRow{{Name: "x", Bytes: 1024, Detail: "hi"}})
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), "NAME")
+	require.NotContains(t, buf.String(), "LOG BYTES")
+	require.NotContains(t, buf.String(), "DETAIL")
+	require.NotContains(t, buf.String(), "1024")
+}
+
+func TestRenderListShowsWideWhenWide(t *testing.T) {
+	f := testFormatter{kind: "wide"}
+	var buf bytes.Buffer
+	err := Render(f, &buf, []wideRow{{Name: "x", Bytes: 1024, Detail: "hi"}})
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), "NAME")
+	require.Contains(t, buf.String(), "LOG BYTES")
+	require.Contains(t, buf.String(), "DETAIL")
+	require.Contains(t, buf.String(), "1024")
+}
+
+type objectFixture struct {
+	Name       string `json:"name"       yaml:"name"       table:"NAME"`
+	Internal   bool   `json:"internal"   yaml:"internal"   table:"INTERNAL"`
+	Partitions int    `json:"partitions" yaml:"partitions" table:"PARTITIONS"`
+}
+
+func TestRenderObjectBasic(t *testing.T) {
+	f := testFormatter{kind: "text"}
+	var buf bytes.Buffer
+	err := Render(f, &buf, objectFixture{Name: "my-topic", Internal: false, Partitions: 3})
+	require.NoError(t, err)
+	require.Equal(t, [][]string{
+		{"NAME", "my-topic"},
+		{"INTERNAL", "false"},
+		{"PARTITIONS", "3"},
+	}, TableRows(buf.String()))
+}
+
+func TestRenderObjectSkipsDashTag(t *testing.T) {
+	type obj struct {
+		Name   string `json:"name"   yaml:"name"   table:"NAME"`
+		Hidden string `json:"hidden" yaml:"hidden" table:"-"`
+	}
+	f := testFormatter{kind: "text"}
+	var buf bytes.Buffer
+	err := Render(f, &buf, obj{Name: "a", Hidden: "secret"})
+	require.NoError(t, err)
+	require.NotContains(t, buf.String(), "secret")
+	require.NotContains(t, buf.String(), "HIDDEN")
+}
+
+type objectOmit struct {
+	Name     string `json:"name"     yaml:"name"     table:"NAME"`
+	Internal bool   `json:"internal" yaml:"internal" table:"INTERNAL,omitempty"`
+	Error    string `json:"error"    yaml:"error"    table:"ERROR,omitempty"`
+}
+
+func TestRenderObjectOmitEmptySkipsZero(t *testing.T) {
+	f := testFormatter{kind: "text"}
+	var buf bytes.Buffer
+	err := Render(f, &buf, objectOmit{Name: "a"})
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), "NAME")
+	require.NotContains(t, buf.String(), "INTERNAL")
+	require.NotContains(t, buf.String(), "ERROR")
+}
+
+func TestRenderObjectOmitEmptyKeepsNonZero(t *testing.T) {
+	f := testFormatter{kind: "text"}
+	var buf bytes.Buffer
+	err := Render(f, &buf, objectOmit{Name: "a", Internal: true, Error: "oops"})
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), "INTERNAL")
+	require.Contains(t, buf.String(), "true")
+	require.Contains(t, buf.String(), "ERROR")
+	require.Contains(t, buf.String(), "oops")
+}
+
+type compositeSummary struct {
+	Name       string `json:"name"       yaml:"name"       table:"NAME"`
+	Partitions int    `json:"partitions" yaml:"partitions" table:"PARTITIONS"`
+}
+
+type compositeCfg struct {
+	Key   string `json:"key"   yaml:"key"   table:"KEY"`
+	Value string `json:"value" yaml:"value" table:"VALUE"`
+}
+
+type compositeFixture struct {
+	Summary compositeSummary `json:"summary" yaml:"summary" header:"SUMMARY"`
+	Configs []compositeCfg   `json:"configs" yaml:"configs" header:"CONFIGS"`
+}
+
+func TestRenderCompositeBasic(t *testing.T) {
+	f := testFormatter{kind: "text"}
+	var buf bytes.Buffer
+	err := Render(f, &buf, compositeFixture{
+		Summary: compositeSummary{Name: "my-topic", Partitions: 3},
+		Configs: []compositeCfg{
+			{Key: "cleanup.policy", Value: "delete"},
+			{Key: "compression.type", Value: "producer"},
+		},
+	})
+	require.NoError(t, err)
+
+	out := buf.String()
+	require.Contains(t, out, "SUMMARY")
+	require.Contains(t, out, "=======") // underline matching len("SUMMARY") == 7
+	require.Contains(t, out, "my-topic")
+	require.Contains(t, out, "CONFIGS")
+	require.Contains(t, out, "cleanup.policy")
+	require.Contains(t, out, "delete")
+
+	// SUMMARY section appears before CONFIGS section.
+	require.Less(t, strings.Index(out, "SUMMARY"), strings.Index(out, "CONFIGS"))
+}
+
+func TestRenderCompositeSkipsFieldsWithoutHeader(t *testing.T) {
+	type fixture struct {
+		Summary compositeSummary `json:"summary" yaml:"summary" header:"SUMMARY"`
+		Hidden  compositeSummary `json:"hidden"  yaml:"hidden"`
+	}
+	f := testFormatter{kind: "text"}
+	var buf bytes.Buffer
+	err := Render(f, &buf, fixture{
+		Summary: compositeSummary{Name: "shown"},
+		Hidden:  compositeSummary{Name: "not-shown"},
+	})
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), "shown")
+	require.NotContains(t, buf.String(), "not-shown")
+}
+
+type compositeOmitFixture struct {
+	Summary compositeSummary `json:"summary" yaml:"summary" header:"SUMMARY,omitempty"`
+	Configs []compositeCfg   `json:"configs" yaml:"configs" header:"CONFIGS,omitempty"`
+}
+
+func TestRenderCompositeOmitEmptySkipsZeroStruct(t *testing.T) {
+	f := testFormatter{kind: "text"}
+	var buf bytes.Buffer
+	err := Render(f, &buf, compositeOmitFixture{
+		// Summary is zero value.
+		Configs: []compositeCfg{{Key: "k", Value: "v"}},
+	})
+	require.NoError(t, err)
+	require.NotContains(t, buf.String(), "SUMMARY")
+	require.Contains(t, buf.String(), "CONFIGS")
+	require.Contains(t, buf.String(), "k")
+}
+
+func TestRenderCompositeOmitEmptySkipsEmptySlice(t *testing.T) {
+	f := testFormatter{kind: "text"}
+	var buf bytes.Buffer
+	err := Render(f, &buf, compositeOmitFixture{
+		Summary: compositeSummary{Name: "t"},
+		// Configs is nil.
+	})
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), "SUMMARY")
+	require.NotContains(t, buf.String(), "CONFIGS")
+}
+
+type exampleTopic struct {
+	Name       string `json:"name"       yaml:"name"       table:"NAME"`
+	Partitions int    `json:"partitions" yaml:"partitions" table:"PARTITIONS"`
+}
+
+func TestRenderListOfComposites(t *testing.T) {
+	f := testFormatter{kind: "text"}
+	var buf bytes.Buffer
+	err := Render(f, &buf, []compositeFixture{
+		{
+			Summary: compositeSummary{Name: "a", Partitions: 1},
+			Configs: []compositeCfg{{Key: "k", Value: "v"}},
+		},
+		{
+			Summary: compositeSummary{Name: "b", Partitions: 2},
+			Configs: []compositeCfg{{Key: "k2", Value: "v2"}},
+		},
+	})
+	require.NoError(t, err)
+	out := buf.String()
+	require.Contains(t, out, "SUMMARY")
+	require.Contains(t, out, "CONFIGS")
+	require.Contains(t, out, "a")
+	require.Contains(t, out, "b")
+	// Two composite blocks separated by blank line — b appears after a.
+	require.Less(t, strings.Index(out, "a"), strings.Index(out, "b"))
+}
+
+func ExampleRender_list() {
+	f := testFormatter{kind: "text"}
+	rows := []exampleTopic{
+		{Name: "orders", Partitions: 3},
+		{Name: "clicks", Partitions: 8},
+	}
+	_ = Render(f, os.Stdout, rows)
+	// Output:
+	// NAME    PARTITIONS
+	// orders  3
+	// clicks  8
+}
+
+func ExampleRender_object() {
+	f := testFormatter{kind: "text"}
+	one := exampleTopic{Name: "orders", Partitions: 3}
+	_ = Render(f, os.Stdout, one)
+	// Output:
+	// NAME        orders
+	// PARTITIONS  3
+}
+
+type exampleComposite struct {
+	Summary exampleTopic   `json:"summary" yaml:"summary" header:"SUMMARY"`
+	Peers   []exampleTopic `json:"peers"   yaml:"peers"   header:"PEERS"`
+}
+
+func ExampleRender_composite() {
+	f := testFormatter{kind: "text"}
+	c := exampleComposite{
+		Summary: exampleTopic{Name: "orders", Partitions: 3},
+		Peers:   []exampleTopic{{Name: "clicks", Partitions: 8}},
+	}
+	_ = Render(f, os.Stdout, c)
+	// Output:
+	// SUMMARY
+	// =======
+	// NAME        orders
+	// PARTITIONS  3
+	//
+	// PEERS
+	// =====
+	// NAME    PARTITIONS
+	// clicks  8
+}


### PR DESCRIPTION
Introduces out.Render(f, w, v), a reflection-based output renderer that collapses the per-command boilerplate around table / JSON / YAML output in rpk. Struct tags drive three text shapes:

  table:"HEADER[,wide|,omitempty|-]"  list columns or object labels
  header:"TITLE[,omitempty]"          composite section titles

The renderer dispatches by reflection: slice → list (header row + rows), struct with header: tags → composite (titled sections), any other struct → object (LABEL / VALUE two-column). JSON and YAML pass through the existing config.OutFormatter.Format call, so migrated commands emit byte-for-byte identical structured output.

An optional FormatTableRow() []any escape hatch lets row types decorate their cells; length mismatches pad or truncate with a zap.Warn (including the row type name) rather than panic.

rpk topic describe is migrated as the RFC demo. Summary and configs sections become declarative; the partitions section stays manual because its column set depends on dataset-wide flags (uses struct). TestDescribedTopicJSONShapeStable and
TestDescribedTopicJSONShapeWithOmitEmptyPopulated lock the JSON wire format so future refactors cannot silently drift. Minor text output drift (section headers always emit; INTERNAL / REPLICAS suppressed when zero via ,omitempty) is documented in the adapted tests.

pkg/out defines a Formatter interface rather than taking a concrete config.OutFormatter — pkg/config already imports pkg/out, so a direct reference would cycle. Callers pass &p.Formatter since config.OutFormatter.Format has a pointer receiver.

A sibling pkg/out/outtest subpackage exposes AssertRowShape[T] for opt-in validation that custom FormatTableRow implementations return the expected number of cells.

Design: docs/superpowers/specs/2026-04-21-rpk-output-abstraction-design.md
Plan:   docs/superpowers/plans/2026-04-21-rpk-output-abstraction.md

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
