### PR TITLE
cloud_io: clear scheduling group bw cap when throttling is disabled

### DIFF
--- a/src/v/cloud_io/io_resources.cc
+++ b/src/v/cloud_io/io_resources.cc
@@ -232,6 +232,8 @@ ss::future<> io_resources::set_disk_max_bandwidth(size_t tput) {
     try {
         if (tput == 0 || tput == std::numeric_limits<size_t>::max()) {
             _throttling_disabled = true;
+            co_await _scheduling_group.update_io_bandwidth(
+              effectively_unlimited_bw);
             vlog(
               log.info,
               "Scheduling group's {} bandwidth is not limited",

--- a/src/v/cloud_io/io_resources.h
+++ b/src/v/cloud_io/io_resources.h
@@ -28,6 +28,13 @@ class io_resources {
     friend class throttled_dl_source;
 
 public:
+    // Workaround for scylladb/seastar#3370: there is no API to clear the cap
+    // set by scheduling_group::update_io_bandwidth. Pass a value that is
+    // "effectively unlimited" and below the internal max_rate threshold so it
+    // does not throw. 1 PiB/s is well above any real device and comfortably
+    // below the ~1.31 EB/s ceiling computed from shared_token_bucket::max_rate.
+    static constexpr uint64_t effectively_unlimited_bw = uint64_t{1} << 50u;
+
     explicit io_resources(seastar::scheduling_group);
 
     ss::future<> start();

--- a/src/v/cloud_io/tests/BUILD
+++ b/src/v/cloud_io/tests/BUILD
@@ -146,6 +146,21 @@ redpanda_cc_gtest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "io_resources_test",
+    timeout = "short",
+    srcs = [
+        "io_resources_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/cloud_io:io_resources",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
 redpanda_cc_btest(
     name = "directory_walker_test",
     timeout = "short",

--- a/src/v/cloud_io/tests/io_resources_test.cc
+++ b/src/v/cloud_io/tests/io_resources_test.cc
@@ -26,7 +26,7 @@ TEST_CORO(io_resources, effectively_unlimited_bw_does_not_throw) {
 
     co_await ss::destroy_scheduling_group(sg);
 
-    EXPECT_FALSE(fut.failed());
+    EXPECT_FALSE(fut.failed()) << fmt::format("e: {}", fut.get_exception());
     if (fut.failed()) {
         std::rethrow_exception(fut.get_exception());
     }

--- a/src/v/cloud_io/tests/io_resources_test.cc
+++ b/src/v/cloud_io/tests/io_resources_test.cc
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "base/seastarx.h"
+#include "cloud_io/io_resources.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/scheduling.hh>
+#include <seastar/coroutine/as_future.hh>
+
+TEST_CORO(io_resources, effectively_unlimited_bw_does_not_throw) {
+    auto sg = co_await ss::create_scheduling_group("cloud_io_test", 100);
+
+    // Passing the "effectively unlimited" bandwidth must be a valid way to
+    // disable throttling. Regression test for scylladb/seastar#3370.
+    auto fut = co_await ss::coroutine::as_future(
+      sg.update_io_bandwidth(cloud_io::io_resources::effectively_unlimited_bw));
+
+    co_await ss::destroy_scheduling_group(sg);
+
+    EXPECT_FALSE(fut.failed());
+    if (fut.failed()) {
+        std::rethrow_exception(fut.get_exception());
+    }
+}


### PR DESCRIPTION
When set_disk_max_bandwidth is called with 0 or max to disable throttling, the cap previously set on the scheduling_group via update_io_bandwidth stayed in effect. Set it to an effectively unlimited value so the cap is lifted.

Workaround for scylladb/seastar#3370: there is no API to clear the cap, and values at/above the internal max_rate threshold throw, so pass 1 PiB/s which is well below that ceiling and well above any real device.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes


### Bug Fixes

* Fix tiered storage I/O remaining throttled at the previously-configured rate after `cloud_storage_max_throughput_per_shard` was unset.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
