### PR TITLE
gha: raise AI-assisted backport max-turns to 80

### DIFF
--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -156,7 +156,7 @@ jobs:
           track_progress: false
           claude_args: >
             --model opus
-            --max-turns 40
+            --max-turns 80
             --disallowed-tools "WebFetch,WebSearch"
             --allowed-tools "
               Bash(git *),


### PR DESCRIPTION
Run [25047762576](https://github.com/redpanda-data/redpanda/actions/runs/25047762576) hit the 40-turn limit while backporting [#30302](https://github.com/redpanda-data/redpanda/pull/30302) (1 commit, 43 LOC, single content conflict). Walking the turn log:

- ~9 turns burned on sandbox friction (`cd <dir> && git ...` blocked, `mkdir` outside the action's session dir blocked).
- ~17 turns on legitimate conflict investigation (`git show`/`grep`/`sed` of HEAD vs incoming).
- ~5 turns on `cherry-pick --continue` and verification.
- The cherry-pick **succeeded**, but the trailing `git push --set-upstream` from the prompt never ran — the model's final tool batch overran turn 40.

A second recent failure ([25015920693](https://github.com/redpanda-data/redpanda/actions/runs/25015920693), backport of [#30169](https://github.com/redpanda-data/redpanda/pull/30169) — 19 commits) hit the same cap. That one needs more than 80 even after this bump; tracked separately as a skill optimization (skip empty cherry-picks without investigating parents).

Distribution of source PRs in the last 50 v26.1.x backports:
- 1 commit: ~70% (always fits)
- 2-4 commits: ~22% (80 fits comfortably)
- 8-19 commits: ~8% (8 fits; 11 borderline; 19 still overruns)

80 is enough for ~95% of cases that reach the AI fallback path. The flag only caps; it doesn't cost anything when unused.

Tracked under [DEVPROD-4165].

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## UX Changes

## Release Notes

* none

[DEVPROD-4165]: https://redpandadata.atlassian.net/browse/DEVPROD-4165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ