### PR TITLE
[v26.1.x] rptest: simplify traffic shaping to block all outgoing HTTPS

### DIFF
--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -1659,6 +1659,8 @@ class ShadowIndexingTrafficShapingTest(PreallocNodesTest):
             )
             self.rp_qdisc.drop_incoming(s3_service_dest)
 
+            return self.rp_qdisc
+
         def __exit__(self, exc_type, exc_value, traceback):
             self.rp_qdisc.remove_all()
 
@@ -1703,6 +1705,8 @@ class ShadowIndexingTrafficShapingTest(PreallocNodesTest):
                     metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS,
                     nodes=self.redpanda.nodes[0:1],
                 )
+                if not v:
+                    return False
                 u = [s.value for s in v.samples]
                 self.logger.info(
                     f"redpanda_cloud_client_client_pool_utilization: {json.dumps(u)}"

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -9,7 +9,6 @@
 import json
 import random
 import re
-import socket
 import time
 from collections import defaultdict
 from datetime import datetime, timedelta
@@ -1625,6 +1624,9 @@ class ShadowIndexingTrafficShapingTest(PreallocNodesTest):
                 "enable_cluster_metadata_upload_loop": True,
                 "controller_snapshot_max_age_sec": 1,
                 "cloud_storage_client_lease_timeout_ms": 1000,
+                # Enable HNS explicitly to avoid self configuration failure on
+                # startup caused by blocked egress.
+                "cloud_storage_azure_hierarchical_namespace_enabled": True,
             },
             environment={"__REDPANDA_TOPIC_REC_DL_CHECK_MILLIS": 5000},
             si_settings=si_settings,
@@ -1641,23 +1643,18 @@ class ShadowIndexingTrafficShapingTest(PreallocNodesTest):
             self.redpanda = redpanda
 
         def __enter__(self) -> NodeQdisc:
-            s3_service_ep = self.redpanda.si_settings.cloud_storage_api_endpoint
-
-            #  block all outgoing https if we can't get an IP address or the api endpoint is not config'ed
-            s3_service_dest = ":443"
-            try:
-                s3_service_dest = socket.gethostbyname(s3_service_ep)
-            except Exception:
-                pass
-
+            # Shape all traffic to port 443 rather than resolving the cloud
+            # storage endpoint IP, which is unreliable across backends
+            # (S3, GCS, Azure, Docker, etc).
+            object_storage_dest = [":9000", ":443"]
             self.rp_qdisc = NodeQdisc(
                 self.redpanda.nodes[0], ClusterTopology._get_if_in_use(), 1
             )
             self.rp_qdisc.initialize()
             self.rp_qdisc.add(
-                target_addresses=[s3_service_dest], spec=NetemSpec(300, 100)
+                target_addresses=object_storage_dest, spec=NetemSpec(300, 100)
             )
-            self.rp_qdisc.drop_incoming(s3_service_dest)
+            self.rp_qdisc.drop_incoming(object_storage_dest)
 
             return self.rp_qdisc
 
@@ -1703,7 +1700,7 @@ class ShadowIndexingTrafficShapingTest(PreallocNodesTest):
                     nodes=self.redpanda.nodes[0:1],
                     expect_metric=True,
                 )
-                self.logger.info(f"redpanda_cloud_client_lease_timeout_total: {v}")
+                self.logger.debug(f"redpanda_cloud_client_lease_timeout_total: {v}")
                 return v
 
             def pool_utilization(pct):
@@ -1715,13 +1712,13 @@ class ShadowIndexingTrafficShapingTest(PreallocNodesTest):
                 if not v:
                     return False
                 u = [s.value for s in v.samples]
-                self.logger.info(
+                self.logger.debug(
                     f"redpanda_cloud_client_client_pool_utilization: {json.dumps(u)}"
                 )
                 return all(v == pct for v in u)
 
             producer.start()
-            self.logger.debug(
+            self.logger.info(
                 "Wait until the client pool is backed up due to long-running requests"
             )
             try:
@@ -1733,13 +1730,13 @@ class ShadowIndexingTrafficShapingTest(PreallocNodesTest):
             finally:
                 producer.stop()
 
-        self.logger.debug(
+        self.logger.info(
             "Now check that the things return to normal after traffic shaping is switched off"
         )
         producer.start()
         try:
             wait_until(
-                lambda: nodes_report_cloud_segments(self.redpanda, 10000),
+                lambda: nodes_report_cloud_segments(self.redpanda, 1000),
                 timeout_sec=180,
                 backoff_sec=3,
             )

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -1666,10 +1666,17 @@ class ShadowIndexingTrafficShapingTest(PreallocNodesTest):
 
     @skip_debug_mode
     @cluster(num_nodes=2)
-    def test_many_partitions_recovery_with_traffic_shaping(self):
+    def test_lease_timeout_with_traffic_shaping(self):
         """
-        Test that reproduces an OOM when doing recovery with a large dataset in
-        the bucket.
+        Verify that cloud_storage client lease timeouts fire under degraded
+        network conditions and that uploads recover once the network heals.
+
+        Uses netem traffic shaping (added latency + dropped incoming packets)
+        on the link between the Redpanda node and S3 to simulate stuck HTTP
+        connections. With traffic shaping active, waits for lease timeout
+        metrics to accumulate and the client pool to reach full utilization.
+        After removing traffic shaping, confirms that segment uploads resume
+        and reach the expected count.
         """
         producer = KgoVerifierProducer(
             self.test_context,
@@ -1738,19 +1745,3 @@ class ShadowIndexingTrafficShapingTest(PreallocNodesTest):
             )
         finally:
             producer.stop()
-
-        node = self.redpanda.nodes[0]
-        self.redpanda.stop()
-        self.redpanda.remove_local_data(node)
-        self.redpanda.restart_nodes(
-            self.redpanda.nodes, auto_assign_node_id=True, omit_seeds_on_idx_one=False
-        )
-        self.redpanda._admin.await_stable_leader(
-            "controller", partition=0, namespace="redpanda", timeout_s=60, backoff_s=2
-        )
-
-        rpk = RpkTool(self.redpanda)
-        rpk.cluster_recovery_start(wait=True)
-        wait_until(
-            lambda: len(set(rpk.list_topics())) == 1, timeout_sec=120, backoff_sec=3
-        )

--- a/tests/rptest/utils/cluster_topology.py
+++ b/tests/rptest/utils/cluster_topology.py
@@ -149,32 +149,37 @@ class NodeQdisc:
 
         self.next_flow += 1
 
-    def drop_incoming(self, src_address):
+    def drop_incoming(self, src_addresses: str | list[str]):
         self.has_ingress_shaping = True
         self._tc_execute(
             ["qdisc", "add", "dev", self.dev, "handle", "ffff:", "ingress"]
         )
-        match_rule = ["ip", "src", src_address]
-        if src_address[0] == ":":
-            match_rule = ["ip", "sport", src_address[1:], "0xffff"]
 
-        self._tc_execute(
-            [
-                "filter",
-                "add",
-                "dev",
-                self.dev,
-                "parent",
-                "ffff:",
-                "protocol",
-                "ip",
-                "u32",
-                "match",
-                *match_rule,
-                "action",
-                "drop",
-            ]
-        )
+        if isinstance(src_addresses, str):
+            src_addresses = [src_addresses]
+
+        for addr in src_addresses:
+            match_rule = ["ip", "src", addr]
+            if addr[0] == ":":
+                match_rule = ["ip", "sport", addr[1:], "0xffff"]
+
+            self._tc_execute(
+                [
+                    "filter",
+                    "add",
+                    "dev",
+                    self.dev,
+                    "parent",
+                    "ffff:",
+                    "protocol",
+                    "ip",
+                    "u32",
+                    "match",
+                    *match_rule,
+                    "action",
+                    "drop",
+                ]
+            )
 
     def _tc_qdisc_add(self, queue_spec):
         return self._tc_execute(["qdisc", "add", "dev", self.dev] + queue_spec)


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/29958
