### PR TITLE
`ct/frontend`: avoid ignoring exceptional future in `replicate_at_offset()`

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -1331,6 +1331,20 @@ ss::future<result<raft::replicate_result>> frontend::replicate_at_offset(
       timeout,
       as);
 
+    auto enqueued_fut = co_await ss::coroutine::as_future(
+      std::move(stages.request_enqueued));
+    if (enqueued_fut.failed()) {
+        auto ex = enqueued_fut.get_exception();
+        vlogl(
+          cd_log,
+          ssx::is_shutdown_exception(ex) ? ss::log_level::debug
+                                         : ss::log_level::warn,
+          "Failed to enqueue replicate request for ntp {}: {}",
+          ntp(),
+          ex);
+        // fallthrough - we expect the finish command to throw if this one did
+        // and we don't want to abandon the replicate_finished future
+    }
     co_return co_await std::move(stages.replicate_finished);
 }
 

--- a/src/v/kafka/server/write_at_offset_stm.cc
+++ b/src/v/kafka/server/write_at_offset_stm.cc
@@ -18,6 +18,7 @@
 #include <seastar/coroutine/as_future.hh>
 
 #include <algorithm>
+#include <exception>
 
 namespace kafka {
 
@@ -177,9 +178,9 @@ ss::future<result<raft::replicate_result>> write_at_offset_stm::do_replicate(
   model::timeout_clock::duration timeout,
   std::optional<std::reference_wrapper<ss::abort_source>> as,
   ss::promise<> enqueued_promise) {
+    auto enqueue_guard = ss::defer([&]() { enqueued_promise.set_value(); });
     if (batches.empty() || expected_base_offsets.size() != batches.size())
       [[unlikely]] {
-        enqueued_promise.set_value();
         co_return make_error_code(errc::invalid_input);
     }
     // offset translated batches are not supported by write at offset state
@@ -189,7 +190,6 @@ ss::future<result<raft::replicate_result>> write_at_offset_stm::do_replicate(
           return is_offset_translated_batch(batch);
       });
     if (any_offset_translated) [[unlikely]] {
-        enqueued_promise.set_value();
         co_return make_error_code(errc::invalid_batch_type);
     }
 
@@ -204,7 +204,6 @@ ss::future<result<raft::replicate_result>> write_at_offset_stm::do_replicate(
     auto sync_result = co_await sync(timeout);
     if (!sync_result) {
         _inflight_last_offset.reset();
-        enqueued_promise.set_value();
         co_return raft::errc::not_leader;
     }
     const auto current_insync_term = _insync_term;
@@ -234,7 +233,6 @@ ss::future<result<raft::replicate_result>> write_at_offset_stm::do_replicate(
      * stm_last_offset.
      */
     if (effective_prev_log_offset != stm_last_offset) {
-        enqueued_promise.set_value();
         vlog(
           _log.debug,
           "Expected last log offset: {} does not match with last stm"
@@ -252,7 +250,6 @@ ss::future<result<raft::replicate_result>> write_at_offset_stm::do_replicate(
     for (auto&& [expected_offset, batch] :
          std::ranges::zip_view(expected_base_offsets, batches)) {
         if (expected_offset < last_seen_offset) [[unlikely]] {
-            enqueued_promise.set_value();
             vlog(
               _log.warn,
               "Expected batch offsets are not monotonically increasing: {} "
@@ -303,6 +300,7 @@ ss::future<result<raft::replicate_result>> write_at_offset_stm::do_replicate(
     });
 
     std::move(enq).forward_to(std::move(enqueued_promise));
+    enqueue_guard.cancel();
 
     auto r_fut = co_await ss::coroutine::as_future(
       std::move(stages.replicate_finished));

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -116,9 +116,6 @@ CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST = [
     # The cloud-topics STM may time out during epoch fencing under load
     # or immediately after leadership changes.
     re.compile(r".*ctp_stm\.cc.*Sync timeout"),
-    # Exceptional futures from abort_requested during graceful shutdown
-    # of cloud-topics coroutines.
-    re.compile(r".*Exceptional future ignored.*abort_requested_exception"),
 ]
 
 


### PR DESCRIPTION
Observed here: https://ci-artifacts.dev.vectorized.cloud/production-devprod/redpanda/83776/019dd5a8-ee45-4265-a0ed-119ab8244ee7/vbuild/ducktape/results/2026-04-28--001/report.html

That test failed for other reasons, but it feels correct to fix this issue as well.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
