### PR TITLE
[CORE-14786] `rptest`: speedup `data_stat`

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -5667,15 +5667,15 @@ class RedpandaService(Service, RedpandaServiceABC):
         under the Redpanda data directory. File paths are normalized to be relative
         to the data directory.
         """
-        cmd = (
-            f"find {RedpandaService.DATA_DIR} -type f -exec stat -c '%n %s' '{{}}' \\;"
-        )
+        # -ignore_readdir_race: a file may disappear between find's readdir and
+        # its internal stat for `%s` (e.g. segment GC during traversal). Without
+        # this flag, find emits a stderr warning and exits non-zero, which would
+        # cause ssh_output to raise before our filtering can drop the warning.
+        cmd = f"find {RedpandaService.DATA_DIR} -ignore_readdir_race -type f -printf '%p %s\\n'"
         lines = node.account.ssh_output(cmd, timeout_sec=120)
         lines = lines.decode().split("\n")
 
-        # 1. find and stat race. skip any files that were deleted.
-        # 2. skip empty lines: find may stick one on the end of the results
-        lines = filter(lambda l: "No such file or directory" not in l, lines)
+        # skip empty lines: find may stick one on the end of the results
         lines = filter(lambda l: len(l) > 0, lines)
 
         # split into pathlib.Path / file size pairs


### PR DESCRIPTION
Currently, we use:

```
f"find {RedpandaService.DATA_DIR} -type f -exec stat -c '%n %s' '{{}}' \\;"
```

as a way to stat all of the files in a `redpanda` directory on a node.
This is bad: with `-exec stat ... \;`, `find` runs one `stat` process per file.

We can do better simply by changing this command instead to:

```
f"find {RedpandaService.DATA_DIR} -type f -exec stat -c '%n %s' '{{}}' +"
```

Where `find` will batch as many files as possible to each `stat` call.
However, we can do even better by not using `-exec` at all:

```
f"find {RedpandaService.DATA_DIR} -ignore_readdir_race -type f -printf '%p %s\\n'"
```

Here, we don't fork any external processes at all, and everything is handled natively in `find`. Failures due to the concurrent removal of files is silenced with the flag `-ignore_readdir_race`.


This should fix timeouts in CI for tests with large numbers of files, where 20+ minutes is spent waiting on these stat commands.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
