### PR TITLE
`ct`: reduce copies of `ntp` in `leader_router` local funcs

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/leader_router.cc
+++ b/src/v/cloud_topics/level_one/metastore/leader_router.cc
@@ -295,7 +295,7 @@ leader_router::process(req_t req, bool local_only) {
               req_name,
               l1_ntp);
             auto ret = co_await (this->*LocalFunc)(
-              std::move(req), std::move(l1_ntp), shard.value());
+              std::move(req), l1_ntp, shard.value());
             vlog(
               cd_log.debug,
               "Processed local request for {} as leader of {}",

--- a/src/v/cloud_topics/level_one/metastore/leader_router.cc
+++ b/src/v/cloud_topics/level_one/metastore/leader_router.cc
@@ -483,7 +483,7 @@ ss::future<rpc::add_objects_reply> leader_router::add_objects_locally(
     auto m = _probe.auto_measure_add_objects();
     co_return co_await container().invoke_on(
       shard,
-      [metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
+      [&metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
           return do_add_objects(
             *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
@@ -504,7 +504,7 @@ ss::future<rpc::replace_objects_reply> leader_router::replace_objects_locally(
     auto m = _probe.auto_measure_replace_objects();
     co_return co_await container().invoke_on(
       shard,
-      [metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
+      [&metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
           return do_replace_objects(
             *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
@@ -526,7 +526,7 @@ leader_router::get_first_offset_ge_locally(
     auto m = _probe.auto_measure_get_first_offset_ge();
     co_return co_await container().invoke_on(
       shard,
-      [metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
+      [&metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
           return do_get_first_offset_ge(
             *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
@@ -548,7 +548,7 @@ leader_router::get_first_timestamp_ge_locally(
     auto m = _probe.auto_measure_get_first_timestamp_ge();
     co_return co_await container().invoke_on(
       shard,
-      [metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
+      [&metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
           return do_get_first_timestamp_ge(
             *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
@@ -562,7 +562,7 @@ leader_router::get_first_offset_for_bytes_locally(
     auto m = _probe.auto_measure_get_first_offset_for_bytes();
     co_return co_await container().invoke_on(
       shard,
-      [metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
+      [&metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
           return do_get_first_offset_for_bytes(
             *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
@@ -595,7 +595,7 @@ ss::future<rpc::get_offsets_reply> leader_router::get_offsets_locally(
     auto m = _probe.auto_measure_get_offsets();
     co_return co_await container().invoke_on(
       shard,
-      [metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
+      [&metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
           return do_get_offsets(
             *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
@@ -616,7 +616,7 @@ ss::future<rpc::get_size_reply> leader_router::get_size_locally(
     auto m = _probe.auto_measure_get_size();
     co_return co_await container().invoke_on(
       shard,
-      [metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
+      [&metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
           return do_get_size(
             *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
@@ -638,7 +638,7 @@ leader_router::get_compaction_info_locally(
     auto m = _probe.auto_measure_get_compaction_info();
     co_return co_await container().invoke_on(
       shard,
-      [metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
+      [&metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
           return do_get_compaction_info(
             *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
@@ -660,7 +660,7 @@ leader_router::get_term_for_offset_locally(
     auto m = _probe.auto_measure_get_term_for_offset();
     co_return co_await container().invoke_on(
       shard,
-      [metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
+      [&metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
           return do_get_term_for_offset(
             *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
@@ -682,7 +682,7 @@ leader_router::get_end_offset_for_term_locally(
     auto m = _probe.auto_measure_get_end_offset_for_term();
     co_return co_await container().invoke_on(
       shard,
-      [metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
+      [&metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
           return do_get_end_offset_for_term(
             *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
@@ -705,7 +705,7 @@ ss::future<rpc::set_start_offset_reply> leader_router::set_start_offset_locally(
     auto m = _probe.auto_measure_set_start_offset();
     co_return co_await container().invoke_on(
       shard,
-      [metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
+      [&metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
           return do_set_start_offset(
             *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
@@ -726,7 +726,7 @@ ss::future<rpc::remove_topics_reply> leader_router::remove_topics_locally(
     auto m = _probe.auto_measure_remove_topics();
     co_return co_await container().invoke_on(
       shard,
-      [metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
+      [&metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
           return do_remove_topics(
             *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
@@ -748,7 +748,7 @@ leader_router::get_compaction_infos_locally(
     auto m = _probe.auto_measure_get_compaction_infos();
     co_return co_await container().invoke_on(
       shard,
-      [metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
+      [&metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
           return do_get_compaction_infos(
             *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
@@ -770,7 +770,7 @@ leader_router::get_extent_metadata_locally(
     auto m = _probe.auto_measure_get_extent_metadata();
     co_return co_await container().invoke_on(
       shard,
-      [metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
+      [&metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
           return do_get_extent_metadata(
             *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
@@ -791,7 +791,7 @@ ss::future<rpc::flush_domain_reply> leader_router::flush_domain_locally(
     auto m = _probe.auto_measure_flush_domain();
     co_return co_await container().invoke_on(
       shard,
-      [metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
+      [&metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
           return do_flush_domain(
             *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
@@ -812,7 +812,7 @@ ss::future<rpc::restore_domain_reply> leader_router::restore_domain_locally(
     auto m = _probe.auto_measure_restore_domain();
     co_return co_await container().invoke_on(
       shard,
-      [metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
+      [&metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
           return do_restore_domain(
             *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
@@ -834,7 +834,7 @@ leader_router::preregister_objects_locally(
     auto m = _probe.auto_measure_preregister_objects();
     co_return co_await container().invoke_on(
       shard,
-      [metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
+      [&metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
           return do_preregister_objects(
             *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });


### PR DESCRIPTION

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
