### PR TITLE
net: Set TCP NO_DELAY on all client connections

### DIFF
--- a/src/v/net/transport.cc
+++ b/src/v/net/transport.cc
@@ -78,6 +78,7 @@ ss::future<> base_transport::do_connect(clock_type::time_point timeout) {
         vlog(_log->trace, "Resolved address {}", resolved_address);
         ss::connected_socket fd = co_await connect_with_timeout(
           resolved_address, timeout, _log);
+        fd.set_nodelay(true);
 
         if (_creds) {
             // CORE-14958


### PR DESCRIPTION
We are already doing this for all the server connections but lacking it
for clients (HTTP, RPC, Kafka).

Do it to avoid delays. Possibly this also helps with benchmark noise.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes


* none
