### PR TITLE
cloud_io/cache: fix shard 0 misuse in put ENOSPC handler

### DIFF
--- a/src/v/cloud_io/cache_service.cc
+++ b/src/v/cloud_io/cache_service.cc
@@ -1318,12 +1318,14 @@ ss::future<> cache::put(
 
             // Block further puts from being attempted until notify_disk_status
             // reports that there is space available.
-            set_block_puts(true);
+            co_await container().invoke_on_all(
+              [](cache& c) { c.set_block_puts(true); });
 
             // Trim proactively: if many fibers hit this concurrently,
             // they'll contend for cleanup_sm and the losers will skip
             // trim due to throttling.
-            co_await trim_throttled();
+            co_await container().invoke_on(
+              0, [](cache& c) { return c.trim_throttled(); });
         }
 
         std::rethrow_exception(eptr);

--- a/src/v/cloud_io/cache_service.cc
+++ b/src/v/cloud_io/cache_service.cc
@@ -75,6 +75,16 @@ cache::cache(
         _disk_reservation.watch([this]() { update_max_bytes(); });
         _max_bytes_cfg.watch([this]() { update_max_bytes(); });
         _max_percent.watch([this]() { update_max_bytes(); });
+    } else {
+        _cleanup_sm.broken(
+          std::runtime_error(
+            "cleanup_sm should not be used on non-zero shards"));
+        _access_tracker_writer_sm.broken(
+          std::runtime_error(
+            "access_tracker_writer_sm should not be used on non-zero shards"));
+        _tracker_sync_timer_sem.broken(
+          std::runtime_error(
+            "tracker_sync_timer_sem should not be used on non-zero shards"));
     }
 }
 
@@ -270,6 +280,7 @@ ss::future<> cache::trim_throttled_unlocked(
   std::optional<uint64_t> size_limit_override,
   std::optional<size_t> object_limit_override,
   std::optional<ss::lowres_clock::time_point> deadline) {
+    vassert(ss::this_shard_id() == 0, "Method can only be invoked on shard 0");
     // If we trimmed very recently then do not do it immediately:
     // this reduces load and improves chance of currently promoted
     // segments finishing their read work before we demote their
@@ -294,6 +305,7 @@ ss::future<> cache::trim_throttled_unlocked(
 ss::future<> cache::trim_throttled(
   std::optional<uint64_t> size_limit_override,
   std::optional<size_t> object_limit_override) {
+    vassert(ss::this_shard_id() == 0, "Method can only be invoked on shard 0");
     auto units = co_await ss::get_units(_cleanup_sm, 1);
     co_await trim_throttled_unlocked(
       size_limit_override, object_limit_override);
@@ -1645,6 +1657,7 @@ cache::trim_carryover(uint64_t delete_bytes, uint64_t delete_objects) {
 }
 
 void cache::maybe_background_trim() {
+    vassert(ss::this_shard_id() == 0, "Method can only be invoked on shard 0");
     auto& trim_threshold_pct_objects
       = config::shard_local_cfg()
           .cloud_storage_cache_trim_threshold_percent_objects;
@@ -1970,6 +1983,8 @@ ss::future<> cache::initialize(std::filesystem::path cache_dir) {
 
 ss::future<> cache::sync_access_time_tracker(
   access_time_tracker::add_entries_t add_entries) {
+    vassert(ss::this_shard_id() == 0, "Method can only be invoked on shard 0");
+
     if (_cleanup_sm.available_units() <= 0) {
         vlog(
           log.debug, "syncing access time tracker postponed, trim is running");

--- a/src/v/cloud_io/tests/cache_test.cc
+++ b/src/v/cloud_io/tests/cache_test.cc
@@ -9,6 +9,7 @@
  */
 
 #include "base/units.h"
+#include "base/vassert.h"
 #include "bytes/iobuf.h"
 #include "bytes/iostream.h"
 #include "cache_test_fixture.h"
@@ -25,16 +26,20 @@
 #include <seastar/core/fstream.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/sleep.hh>
+#include <seastar/core/smp.hh>
 #include <seastar/util/file.hh>
 
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include <cerrno>
 #include <chrono>
 #include <cstdint>
+#include <filesystem>
 #include <fstream>
 #include <optional>
 #include <stdexcept>
+#include <system_error>
 
 using namespace cloud_io;
 
@@ -499,6 +504,44 @@ FIXTURE_TEST(test_clean_up_on_stream_exception, cache_test_fixture) {
     BOOST_CHECK_EQUAL(count_files(CACHE_DIR.native()).get(), 0);
 
     vlog(test_log.info, "Test passed");
+}
+
+/**
+ * Regression test for the ENOSPC handler in cache::put. The cache is sharded
+ * but trim() asserts shard 0 only; if put runs on a non-zero shard and the
+ * write fails with ENOSPC, the local trim_throttled() hop must route through
+ * shard 0 instead of executing on the calling shard.
+ */
+FIXTURE_TEST(test_put_enospc_on_non_zero_shard, cache_test_fixture) {
+    vassert(
+      ss::smp::count >= 2,
+      "Test requires at least 2 shards to exercise non-shard-0 put path");
+
+    BOOST_CHECK_EXCEPTION(
+      sharded_cache
+        .invoke_on(
+          ss::shard_id{1},
+          [](cloud_io::cache& c) -> ss::future<> {
+              auto reservation = co_await c.reserve_space(1, 1);
+              auto s = tests::make_throwing_stream(
+                std::filesystem::filesystem_error(
+                  "fake ENOSPC",
+                  std::error_code(ENOSPC, std::generic_category())));
+              std::filesystem::path key{
+                "shard1_topic/shard1_partition/shard1_segment.log"};
+              co_await c.put(key, s, reservation);
+          })
+        .get(),
+      std::filesystem::filesystem_error,
+      [](const std::filesystem::filesystem_error& e) {
+          return e.code() == std::errc::no_space_on_device;
+      });
+
+    // After ENOSPC, all shards must observe the block-puts flag, otherwise
+    // concurrent puts on other shards would keep racing into a full disk.
+    for (ss::shard_id s = 0; s < ss::smp::count; ++s) {
+        BOOST_CHECK(get_block_puts(s));
+    }
 }
 
 /**

--- a/src/v/cloud_io/tests/cache_test_fixture.h
+++ b/src/v/cloud_io/tests/cache_test_fixture.h
@@ -168,6 +168,12 @@ public:
           .get();
     }
 
+    bool get_block_puts(ss::shard_id shard) {
+        return sharded_cache
+          .invoke_on(shard, [](cloud_io::cache& c) { return c._block_puts; })
+          .get();
+    }
+
     scoped_config cfg;
 
     void sync_tracker(


### PR DESCRIPTION
`cache::put` runs on every shard (the cache is a fully sharded service),
but its ENOSPC handler called `trim_throttled()` and `set_block_puts(true)`
on the local shard. `trim()` asserts shard 0, so a put on any non-zero
shard that hit `no_space_on_device` would abort the process. Even if
trim had been routed correctly, the local-only `set_block_puts` left
other shards racing into a full disk, defeating the purpose of the flag.

The first commit routes `trim_throttled` through `invoke_on(0, ...)`
and broadcasts the block-puts flag with `invoke_on_all`, mirroring the
existing pattern in `notify_disk_status`. It also adds a regression
test that injects a `filesystem_error{ENOSPC}` from a put on shard 1
and checks the error propagates without aborting and that every shard
observes `_block_puts == true`.

The second commit adds `vassert(this_shard_id() == 0, ...)` to the
remaining trim/tracker entry points (`trim_throttled`,
`trim_throttled_unlocked`, `maybe_background_trim`,
`sync_access_time_tracker`) and `.broken()`s the cleanup,
access-tracker-writer, and tracker-sync semaphores in the
non-zero-shard constructor branch, so any future shard misuse fails
loudly instead of silently operating on shard-local state that's only
meaningful on shard 0.

The bug has existed since the ENOSPC handler was added in May 2023.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes

### Bug Fixes

* Fix a process abort when the tiered storage cache's local disk fills
  up while a segment download is in progress on a non-zero shard.