### PR TITLE
[v26.1.x] bazel: update seastar to 4152d2fc

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -303,7 +303,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "ZwwmIWprImc0+0pL+jhHL89qwvjCw72DUjNJYelXvnI=",
+        "bzlTransitiveDigest": "GauW5CRC26lxp15CIg4YqPYSbs0XB8g6/TfjVnNOMcA=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -483,9 +483,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "73bbe2e56049db9383f83be6d9eaefab78f1a98e3a0a7433fb995aa4187f251e",
-              "strip_prefix": "seastar-84f6ad45fa3e313843454831ddafc64601d2134d",
-              "url": "https://github.com/redpanda-data/seastar/archive/84f6ad45fa3e313843454831ddafc64601d2134d.tar.gz"
+              "sha256": "baed9183f85246578bf0ecb05147732f844bc95be0245148fe62208850e316ad",
+              "strip_prefix": "seastar-4152d2fc93a01d6a7a3ff46be90813b22cb11162",
+              "url": "https://github.com/redpanda-data/seastar/archive/4152d2fc93a01d6a7a3ff46be90813b22cb11162.tar.gz"
             }
           },
           "unordered_dense": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -171,9 +171,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "73bbe2e56049db9383f83be6d9eaefab78f1a98e3a0a7433fb995aa4187f251e",
-        strip_prefix = "seastar-84f6ad45fa3e313843454831ddafc64601d2134d",
-        url = "https://github.com/redpanda-data/seastar/archive/84f6ad45fa3e313843454831ddafc64601d2134d.tar.gz",
+        sha256 = "baed9183f85246578bf0ecb05147732f844bc95be0245148fe62208850e316ad",
+        strip_prefix = "seastar-4152d2fc93a01d6a7a3ff46be90813b22cb11162",
+        url = "https://github.com/redpanda-data/seastar/archive/4152d2fc93a01d6a7a3ff46be90813b22cb11162.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Changes:
- ossl: error queue assert to only terminate in debug builds

Ref: https://github.com/redpanda-data/seastar/pull/275

CORE-15655

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
