### PR TITLE
cluster/self_test: abort multipart upload on failure

### DIFF
--- a/src/v/cluster/self_test/cloudcheck.cc
+++ b/src/v/cluster/self_test/cloudcheck.cc
@@ -555,13 +555,23 @@ cloudcheck::verify_multipart_upload(
 
         auto upload = std::move(upload_result.value());
 
-        // Upload the same 5 MiB chunk 3 times to exercise multipart path
-        auto chunk = make_random_payload(part_size);
-        for (int i = 0; i < 3; ++i) {
-            co_await upload->put(chunk.share());
+        std::exception_ptr eptr;
+        try {
+            // Upload the same 5 MiB chunk 3 times to exercise multipart path
+            auto chunk = make_random_payload(part_size);
+            for (int i = 0; i < 3; ++i) {
+                co_await upload->put(chunk.share());
+            }
+
+            co_await upload->complete();
+        } catch (...) {
+            eptr = std::current_exception();
         }
 
-        co_await upload->complete();
+        if (eptr) {
+            co_await upload->abort();
+            std::rethrow_exception(eptr);
+        }
 
     } catch (const std::exception& e) {
         result.error = e.what();


### PR DESCRIPTION
cloudcheck's multipart test caught upload exceptions but did not
finalize the handle, hitting the destructor assert. Abort the handle
on error before rethrowing.

## Backports Required

- [x] v26.1.x

## Release Notes

### Bug Fixes

* Fix an assertion crash in the cloud storage self-test when a multipart upload part failed mid-sequence.
