### PR TITLE
[v25.3.x] cloud_io/cache: fix shard 0 misuse in put ENOSPC handler

### DIFF
--- a/src/v/cloud_io/cache_service.cc
+++ b/src/v/cloud_io/cache_service.cc
@@ -1303,12 +1303,14 @@ ss::future<> cache::put(
 
             // Block further puts from being attempted until notify_disk_status
             // reports that there is space available.
-            set_block_puts(true);
+            co_await container().invoke_on_all(
+              [](cache& c) { c.set_block_puts(true); });
 
             // Trim proactively: if many fibers hit this concurrently,
             // they'll contend for cleanup_sm and the losers will skip
             // trim due to throttling.
-            co_await trim_throttled();
+            co_await container().invoke_on(
+              0, [](cache& c) { return c.trim_throttled(); });
         }
 
         std::rethrow_exception(eptr);

--- a/src/v/cloud_io/cache_service.cc
+++ b/src/v/cloud_io/cache_service.cc
@@ -76,6 +76,16 @@ cache::cache(
         _disk_reservation.watch([this]() { update_max_bytes(); });
         _max_bytes_cfg.watch([this]() { update_max_bytes(); });
         _max_percent.watch([this]() { update_max_bytes(); });
+    } else {
+        _cleanup_sm.broken(
+          std::runtime_error(
+            "cleanup_sm should not be used on non-zero shards"));
+        _access_tracker_writer_sm.broken(
+          std::runtime_error(
+            "access_tracker_writer_sm should not be used on non-zero shards"));
+        _tracker_sync_timer_sem.broken(
+          std::runtime_error(
+            "tracker_sync_timer_sem should not be used on non-zero shards"));
     }
 }
 
@@ -269,6 +279,7 @@ std::optional<std::chrono::milliseconds> cache::get_trim_delay() const {
 ss::future<> cache::trim_throttled_unlocked(
   std::optional<uint64_t> size_limit_override,
   std::optional<size_t> object_limit_override) {
+    vassert(ss::this_shard_id() == 0, "Method can only be invoked on shard 0");
     // If we trimmed very recently then do not do it immediately:
     // this reduces load and improves chance of currently promoted
     // segments finishing their read work before we demote their
@@ -290,6 +301,7 @@ ss::future<> cache::trim_throttled_unlocked(
 ss::future<> cache::trim_throttled(
   std::optional<uint64_t> size_limit_override,
   std::optional<size_t> object_limit_override) {
+    vassert(ss::this_shard_id() == 0, "Method can only be invoked on shard 0");
     auto units = co_await ss::get_units(_cleanup_sm, 1);
     co_await trim_throttled_unlocked(
       size_limit_override, object_limit_override);
@@ -1618,6 +1630,7 @@ cache::trim_carryover(uint64_t delete_bytes, uint64_t delete_objects) {
 }
 
 void cache::maybe_background_trim() {
+    vassert(ss::this_shard_id() == 0, "Method can only be invoked on shard 0");
     auto& trim_threshold_pct_objects
       = config::shard_local_cfg()
           .cloud_storage_cache_trim_threshold_percent_objects;
@@ -1919,6 +1932,8 @@ ss::future<> cache::initialize(std::filesystem::path cache_dir) {
 
 ss::future<> cache::sync_access_time_tracker(
   access_time_tracker::add_entries_t add_entries) {
+    vassert(ss::this_shard_id() == 0, "Method can only be invoked on shard 0");
+
     if (_cleanup_sm.available_units() <= 0) {
         vlog(
           log.debug, "syncing access time tracker postponed, trim is running");

--- a/src/v/cloud_io/tests/cache_test.cc
+++ b/src/v/cloud_io/tests/cache_test.cc
@@ -9,6 +9,7 @@
  */
 
 #include "base/units.h"
+#include "base/vassert.h"
 #include "bytes/iobuf.h"
 #include "bytes/iostream.h"
 #include "cache_test_fixture.h"
@@ -25,16 +26,20 @@
 #include <seastar/core/fstream.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/sleep.hh>
+#include <seastar/core/smp.hh>
 #include <seastar/util/file.hh>
 
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include <cerrno>
 #include <chrono>
 #include <cstdint>
+#include <filesystem>
 #include <fstream>
 #include <optional>
 #include <stdexcept>
+#include <system_error>
 
 using namespace cloud_io;
 
@@ -499,6 +504,44 @@ FIXTURE_TEST(test_clean_up_on_stream_exception, cache_test_fixture) {
     BOOST_CHECK_EQUAL(count_files(CACHE_DIR.native()).get(), 0);
 
     vlog(test_log.info, "Test passed");
+}
+
+/**
+ * Regression test for the ENOSPC handler in cache::put. The cache is sharded
+ * but trim() asserts shard 0 only; if put runs on a non-zero shard and the
+ * write fails with ENOSPC, the local trim_throttled() hop must route through
+ * shard 0 instead of executing on the calling shard.
+ */
+FIXTURE_TEST(test_put_enospc_on_non_zero_shard, cache_test_fixture) {
+    vassert(
+      ss::smp::count >= 2,
+      "Test requires at least 2 shards to exercise non-shard-0 put path");
+
+    BOOST_CHECK_EXCEPTION(
+      sharded_cache
+        .invoke_on(
+          ss::shard_id{1},
+          [](cloud_io::cache& c) -> ss::future<> {
+              auto reservation = co_await c.reserve_space(1, 1);
+              auto s = tests::make_throwing_stream(
+                std::filesystem::filesystem_error(
+                  "fake ENOSPC",
+                  std::error_code(ENOSPC, std::generic_category())));
+              std::filesystem::path key{
+                "shard1_topic/shard1_partition/shard1_segment.log"};
+              co_await c.put(key, s, reservation);
+          })
+        .get(),
+      std::filesystem::filesystem_error,
+      [](const std::filesystem::filesystem_error& e) {
+          return e.code() == std::errc::no_space_on_device;
+      });
+
+    // After ENOSPC, all shards must observe the block-puts flag, otherwise
+    // concurrent puts on other shards would keep racing into a full disk.
+    for (ss::shard_id s = 0; s < ss::smp::count; ++s) {
+        BOOST_CHECK(get_block_puts(s));
+    }
 }
 
 /**

--- a/src/v/cloud_io/tests/cache_test_fixture.h
+++ b/src/v/cloud_io/tests/cache_test_fixture.h
@@ -168,6 +168,12 @@ public:
           .get();
     }
 
+    bool get_block_puts(ss::shard_id shard) {
+        return sharded_cache
+          .invoke_on(shard, [](cloud_io::cache& c) { return c._block_puts; })
+          .get();
+    }
+
     scoped_config cfg;
 
     void sync_tracker(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30335

- Command: git cherry-pick -x 47364d0084 96d229f315
- Commits backported: 2
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-30335-v25.3.x-1777547943

## Conflict details

- 96d229f315 (src/v/cloud_io/cache_service.cc): `trim_throttled_unlocked` signature on v25.3.x lacks the `std::optional<ss::lowres_clock::time_point> deadline` parameter that exists on dev. Kept the v25.3.x signature unchanged and applied the incoming `vassert(ss::this_shard_id() == 0, "Method can only be invoked on shard 0")` at the top of the function.
