### PR TITLE
iceberg-rest-catalog: fix genrule

### DIFF
--- a/tests/java/iceberg-rest-catalog/BUILD
+++ b/tests/java/iceberg-rest-catalog/BUILD
@@ -14,11 +14,10 @@ genrule(
         OUT_PATH=$$(realpath $(OUTS))
         SRC_DIR=$$(dirname $(location gradlew))
         cd $$SRC_DIR
-        chmod +x ./gradlew
+        export GRADLE_USER_HOME="$$(pwd)/.gradle-home"
         ./gradlew --no-daemon shadowJar
         cp build/libs/iceberg-rest-catalog-all.jar $$OUT_PATH
     """,
-    local = True,
     tags = ["requires-network"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
local = True was forcing local, unsandboxed execution and making the build bypass the remote cache.

This commit:
- drops local = True so the action runs with a sandbox and can use remote cache,
- sets an explicit GRADLE_USER_HOME, otherwise would fallback on $HOME/.gradle which is read-only from the sandbox,
- drops the `chmod +x ./gradlew` which was unneeded, plus it breaks in the sandbox because it is read-only

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
