### PR TITLE
rpk/ai: stop prompting for auth on help, version, and unknown commands

### DIFF
--- a/src/go/rpk/pkg/cli/ai/BUILD
+++ b/src/go/rpk/pkg/cli/ai/BUILD
@@ -16,8 +16,6 @@ go_library(
         "//src/go/rpk/pkg/cobraext",
         "//src/go/rpk/pkg/config",
         "//src/go/rpk/pkg/fips",
-        "//src/go/rpk/pkg/oauth",
-        "//src/go/rpk/pkg/oauth/providers/auth0",
         "//src/go/rpk/pkg/osutil",
         "//src/go/rpk/pkg/out",
         "//src/go/rpk/pkg/plugin",

--- a/src/go/rpk/pkg/cli/ai/ai.go
+++ b/src/go/rpk/pkg/cli/ai/ai.go
@@ -60,56 +60,49 @@ func NewCommand(fs afero.Fs, p *config.Params, execFn func(string, []string) err
 		Run: func(cmd *cobra.Command, args []string) {
 			pluginArgs, err := parseFlags(p, cmd, args)
 			out.MaybeDie(err, "unable to prepare rpk ai invocation: %v", err)
-			// Top-level dispatch: args carries the full subcommand path
-			// (e.g. ["llm","list"]) when the plugin isn't installed yet.
-			// Only touch the cloud when the user actually named a
-			// subcommand and isn't asking for help/version.
-			if !skipCloudForHelp(pluginArgs) && topLevelHasSubcommand(pluginArgs) {
+
+			ai, pluginExists := plugin.ListPlugins(fs, plugin.UserPaths()).Find(rpaiPluginSlug)
+
+			var isSubcommand, isVersion bool
+			for _, arg := range pluginArgs {
+				switch {
+				case arg == "--version":
+					isVersion = true
+				case strings.HasPrefix(arg, "--") || strings.HasPrefix(arg, "-"):
+					continue
+				default:
+					isSubcommand = true
+				}
+			}
+			if !pluginExists && isVersion {
+				fmt.Println("cannot get version: the rpk ai plugin is not installed; run 'rpk ai install'")
+				return
+			}
+			if !isSubcommand && !isVersion {
+				cmd.Help()
+				return
+			}
+
+			if !skipCloudForHelp(pluginArgs) {
 				err = resolveAndInjectEnv(cmd.Context(), fs, p, pluginArgs)
 				out.MaybeDie(err, "unable to prepare rpk ai invocation: %v", err)
 			}
-			ai, pluginExists := plugin.ListPlugins(fs, plugin.UserPaths()).Find(rpaiPluginSlug)
+
 			var pluginPath string
 			if !pluginExists {
-				// Without the plugin present, only download when the user
-				// actually invoked a subcommand. Bare `rpk ai` or `rpk ai
-				// --help` should just show help.
-				var isSubcommand bool
-				for _, arg := range pluginArgs {
-					switch {
-					case arg == "--version":
-						fmt.Println("cannot get version: the rpk ai plugin is not installed; run 'rpk ai install'")
-						return
-					case strings.HasPrefix(arg, "--") || strings.HasPrefix(arg, "-"):
-						continue
-					default:
-						isSubcommand = true
-					}
-				}
-				if !isSubcommand {
-					cmd.Help()
-					return
-				}
-				// FIPS is only blocked once we're committed to installing —
-				// `rpk ai`, `rpk ai --help`, and `rpk ai --version` (handled
-				// above) all return without touching the network, so they
-				// remain usable on FIPS builds even though the rpk ai plugin
-				// does not yet ship a FIPS variant.
+				// FIPS is gated here, after the help/version short-circuits,
+				// so `rpk ai --help` keeps working on FIPS builds even though
+				// the plugin has no FIPS variant yet.
 				maybeExitFIPS()
 				fmt.Fprintln(os.Stderr, "Downloading latest Redpanda AI CLI")
 				path, _, err := installAIPlugin(cmd.Context(), fs, "latest")
 				out.MaybeDie(err, "unable to install the rpk ai plugin: %v; if running in an air-gapped environment you may install it manually with your package manager", err)
 				pluginPath = path
-			}
-			if pluginExists {
+			} else {
 				pluginPath = ai.Path
 				if !ai.Managed {
 					zap.L().Sugar().Warn("rpk is using a self-managed version of the rpk ai plugin. If you want rpk to manage it, run 'rpk ai uninstall && rpk ai install'. To continue managing it manually, keep using your existing install.")
 				}
-			}
-			if cmd.Flags().Changed("help") {
-				cmd.Help()
-				return
 			}
 			zap.L().Debug("executing rpk ai plugin", zap.String("path", pluginPath), zap.Strings("args", pluginArgs))
 			err = execFn(pluginPath, pluginArgs)

--- a/src/go/rpk/pkg/cli/ai/hook.go
+++ b/src/go/rpk/pkg/cli/ai/hook.go
@@ -18,31 +18,27 @@ import (
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cobraext"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/oauth"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/oauth/providers/auth0"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 )
 
-// The rpk ai plugin reads the following environment variables and flag.
-// They are part of the plugin's own contract; rpk fills them in on behalf of
-// the user from the active rpk cloud profile so a fresh `rpk ai <sub>`
-// invocation works without the user having to plumb auth or endpoint
-// manually:
+// The rpk ai plugin reads the following environment variables and flag:
 //
 //   - envAuthToken: bearer token forwarded as Authorization to the AI
-//     Gateway. rpk fills it from the active cloud auth (refreshing via OAuth
-//     if needed).
-//   - envEndpoint: AI Gateway v2 base URL. rpk resolves it from the active
-//     rpk cloud profile's cluster (publicapi -> Cluster.AiGateway.V2Url).
-//   - flagEndpoint: same intent as envEndpoint, but on the command line.
-//     rpk only watches for it so we can skip the cluster lookup; the flag is
-//     parsed and consumed by the plugin itself.
+//     Gateway. rpk reads the cached token off the active cloud profile
+//     and exports it; a missing or stale token is reported by the
+//     gateway as a 401, at which point the user runs `rpk cloud login`.
+//   - envEndpoint: AI Gateway v2 base URL. rpk resolves it from the
+//     active cloud profile's cached AIGatewayURL (or falls back to a
+//     publicapi lookup) and exports it before exec.
+//   - flagEndpoint: same intent as envEndpoint, but on the command
+//     line. rpk only watches for it so we can skip the cluster lookup;
+//     the flag is parsed and consumed by the plugin itself.
 //
-// Any explicit value the user supplies (env or flag) wins — rpk only fills
-// in missing pieces.
+// Any explicit value the user supplies (env or flag) wins — rpk only
+// fills in missing pieces.
 const (
 	envAuthToken = "RPAI_TOKEN"
 	envEndpoint  = "RPAI_ENDPOINT"
@@ -50,19 +46,10 @@ const (
 	flagEndpoint = "rpai-endpoint"
 )
 
-// resolveAndInjectEnv loads the cloud config, refreshes the token, resolves
-// the active cluster's AI Gateway v2 endpoint, and exports both to the
-// caller's environment so the child rpk ai plugin picks them up on exec.
-//
-// Env var writes are skipped when the variable is already present (an
-// explicit value from the user wins). If the invocation carries the plugin's
-// endpoint flag on the command line, endpoint resolution is skipped — the
-// plugin itself will consume the flag.
-//
-// The two short-circuit decisions (help/version, top-level-without-subcommand)
-// live in the call sites since they differ between top-level dispatch (where
-// args carries the subcommand path) and leaf dispatch (where args is the
-// leaf's positional-and-flag args only).
+// Exports RPAI_TOKEN and RPAI_ENDPOINT for the child plugin using cached
+// values from rpk.yaml and the profile's AIGatewayURL (no OAuth refresh).
+// Skips env var writes if the vars are already set or --rpai-endpoint is
+// present.
 func resolveAndInjectEnv(ctx context.Context, fs afero.Fs, p *config.Params, pluginArgs []string) error {
 	cfg, err := p.Load(fs)
 	if err != nil {
@@ -70,12 +57,16 @@ func resolveAndInjectEnv(ctx context.Context, fs afero.Fs, p *config.Params, plu
 	}
 
 	if os.Getenv(envAuthToken) == "" {
-		token, err := getTokenOrLogin(ctx, fs, cfg)
-		if err != nil {
-			return err
+		// Mirrors the lookup chain in oauth.LoadCloudToken (without the
+		// refresh) so --config, -X cloud_auth.*, and RPK_PROFILE all work.
+		auth := cfg.VirtualProfile().VirtualAuth()
+		if auth == nil {
+			auth = cfg.VirtualRpkYaml().CurrentAuth()
 		}
-		if err := os.Setenv(envAuthToken, token); err != nil {
-			return fmt.Errorf("unable to set %s: %w", envAuthToken, err)
+		if auth != nil && auth.AuthToken != "" {
+			if err := os.Setenv(envAuthToken, auth.AuthToken); err != nil {
+				return fmt.Errorf("unable to set %s: %w", envAuthToken, err)
+			}
 		}
 	}
 
@@ -98,25 +89,6 @@ func resolveAndInjectEnv(ctx context.Context, fs afero.Fs, p *config.Params, plu
 func skipCloudForHelp(args []string) bool {
 	for _, a := range args {
 		if a == "--help" || a == "-h" || a == "--version" {
-			return true
-		}
-	}
-	return false
-}
-
-// topLevelHasSubcommand reports whether the args passed to the top-level
-// `rpk ai` dispatcher contain a positional (non-flag) token. This
-// distinguishes `rpk ai llm list` (needs cloud context) from `rpk ai`
-// (bare, just renders help).
-//
-// This check is only meaningful for the top-level Run in NewCommand. When
-// cobra dispatches to a managed-plugin LEAF (e.g. `rpk ai llm list` routes
-// to the `list` leaf registered via plugin_cmds.go), args == nil — cobra
-// has already consumed the path tokens for routing, so "no positional" does
-// not imply "no subcommand" at that call site.
-func topLevelHasSubcommand(args []string) bool {
-	for _, a := range args {
-		if !strings.HasPrefix(a, "-") {
 			return true
 		}
 	}
@@ -154,16 +126,6 @@ func hasEndpointFlag(args []string) bool {
 		}
 	}
 	return false
-}
-
-// getTokenOrLogin returns a fresh cloud bearer token, refreshing or prompting
-// for login as needed.
-func getTokenOrLogin(ctx context.Context, fs afero.Fs, cfg *config.Config) (string, error) {
-	tok, err := oauth.LoadCloudToken(ctx, fs, cfg, auth0.NewClient(cfg.DevOverrides()))
-	if err != nil {
-		return "", fmt.Errorf("unable to refresh the cloud token: %w. Run 'rpk cloud login' and try again", err)
-	}
-	return tok, nil
 }
 
 // resolveAigwEndpoint returns the AI Gateway v2 URL for the active rpk cloud

--- a/src/go/rpk/pkg/cli/ai/hook_test.go
+++ b/src/go/rpk/pkg/cli/ai/hook_test.go
@@ -77,35 +77,12 @@ func TestSkipCloudForHelp(t *testing.T) {
 	}
 }
 
-func TestTopLevelHasSubcommand(t *testing.T) {
-	cases := []struct {
-		name string
-		args []string
-		want bool
-	}{
-		{"empty (leaf dispatch style)", nil, false},
-		{"bare flag", []string{"--help"}, false},
-		{"unknown flag no value", []string{"--foo"}, false},
-		{"subcommand", []string{"llm"}, true},
-		{"nested subcommand", []string{"llm", "list"}, true},
-		{"flag then subcommand", []string{"--format", "json", "llm"}, true},
-		// rpk has a few hyphen-containing subcommands (e.g. `rpk cluster
-		// self-test`). HasPrefix(arg, "-") is a leading-dash check, not a
-		// "contains a dash" check, so hyphenated commands route correctly.
-		{"hyphenated subcommand", []string{"self-test"}, true},
-		{"hyphenated nested subcommand", []string{"foo", "bar-baz"}, true},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			require.Equal(t, c.want, topLevelHasSubcommand(c.args))
-		})
-	}
-}
-
-// TestResolveAndInjectEnv_LeafDispatchHappy covers the regression this file
-// was refactored for: cobra dispatches `rpk ai llm list` straight to the
-// `list` leaf with args=nil. The leaf-side call site must still inject
-// RPAI_TOKEN and RPAI_ENDPOINT even though the args are empty.
+// TestResolveAndInjectEnv_LeafDispatchHappy covers leaf dispatch: cobra
+// hands `rpk ai llm list` straight to the `list` leaf with args=nil.
+// The hook still has to inject both env vars even though args is empty.
+// The token comes from the cached cloud_auth entry on rpk.yaml — no
+// OAuth refresh, just a passthrough — so an expired token just means
+// the gateway returns 401 and the plugin tells the user to re-login.
 func TestResolveAndInjectEnv_LeafDispatchHappy(t *testing.T) {
 	t.Setenv(envAuthToken, "")
 	t.Setenv(envEndpoint, "")
@@ -119,8 +96,6 @@ func TestResolveAndInjectEnv_LeafDispatchHappy(t *testing.T) {
 	ts := httptest.NewServer(clusterHandler(t, cluster))
 	defer ts.Close()
 
-	// loadCloudProfile sets RPK_CLOUD_TOKEN, which getTokenOrLogin picks up
-	// as the dev override — no OAuth flow in tests.
 	loadCloudProfile(t, ts.URL, "clu-1")
 
 	fs := afero.NewMemMapFs()
@@ -128,6 +103,14 @@ func TestResolveAndInjectEnv_LeafDispatchHappy(t *testing.T) {
 	require.NoError(t, err)
 	yaml := `version: 6
 current_profile: dev
+current_cloud_auth_org_id: org-1
+current_cloud_auth_kind: cloud-sso
+cloud_auth:
+  - name: cloud
+    organization: cloud
+    org_id: org-1
+    kind: cloud-sso
+    auth_token: cached-cloud-token
 profiles:
   - name: dev
     from_cloud: true
@@ -138,8 +121,46 @@ profiles:
 
 	// args=nil simulates leaf dispatch: cobra consumed the path tokens.
 	require.NoError(t, resolveAndInjectEnv(t.Context(), fs, new(config.Params), nil))
-	require.Equal(t, "test-token", os.Getenv(envAuthToken), "RPAI_TOKEN must be set from dev override")
+	require.Equal(t, "cached-cloud-token", os.Getenv(envAuthToken), "RPAI_TOKEN must be set from the cached cloud_auth entry")
 	require.Equal(t, "https://aigw.example.com", os.Getenv(envEndpoint), "RPAI_ENDPOINT must be set from aigw v2 url")
+}
+
+// TestResolveAndInjectEnv_NoCachedToken covers the "fresh install"
+// case: rpk.yaml has no cloud_auth entry. resolveAndInjectEnv must not
+// fail — it just leaves RPAI_TOKEN unset and lets the gateway return
+// 401 (or the plugin's own auth chain pick up an alternative source).
+func TestResolveAndInjectEnv_NoCachedToken(t *testing.T) {
+	t.Setenv(envAuthToken, "")
+	t.Setenv(envEndpoint, "")
+
+	cluster := &controlplanev1.Cluster{
+		Id: "clu-1",
+		AiGateway: &controlplanev1.Cluster_AIGateway{
+			V2Url: "https://aigw.example.com",
+		},
+	}
+	ts := httptest.NewServer(clusterHandler(t, cluster))
+	defer ts.Close()
+
+	loadCloudProfile(t, ts.URL, "clu-1")
+
+	fs := afero.NewMemMapFs()
+	path, err := config.DefaultRpkYamlPath()
+	require.NoError(t, err)
+	// No cloud_auth section.
+	yaml := `version: 6
+current_profile: dev
+profiles:
+  - name: dev
+    from_cloud: true
+    cloud_cluster:
+      cluster_id: "clu-1"
+`
+	require.NoError(t, afero.WriteFile(fs, path, []byte(yaml), 0o600))
+
+	require.NoError(t, resolveAndInjectEnv(t.Context(), fs, new(config.Params), nil))
+	require.Empty(t, os.Getenv(envAuthToken), "RPAI_TOKEN must remain unset when rpk.yaml has no cached auth")
+	require.Equal(t, "https://aigw.example.com", os.Getenv(envEndpoint))
 }
 
 // TestResolveAndInjectEnv_SkipsWhenEndpointFlagPresent confirms that passing
@@ -173,19 +194,6 @@ func TestHasEndpointFlag(t *testing.T) {
 			require.Equal(t, c.want, hasEndpointFlag(c.args))
 		})
 	}
-}
-
-func TestGetTokenOrLogin_UsesDevOverride(t *testing.T) {
-	t.Setenv("RPK_CLOUD_TOKEN", "dev-token-123")
-
-	fs := afero.NewMemMapFs()
-	p := new(config.Params)
-	cfg, err := p.Load(fs)
-	require.NoError(t, err)
-
-	tok, err := getTokenOrLogin(t.Context(), fs, cfg)
-	require.NoError(t, err)
-	require.Equal(t, "dev-token-123", tok)
 }
 
 // clusterHandler stubs the public-API GetCluster endpoint to return the given


### PR DESCRIPTION
The previous wrapper called \`oauth.LoadCloudToken\` eagerly — both in the managed-leaf hook and the top-level \`Run\` — and exported the result as \`RPAI_TOKEN\` before exec'ing the plugin. That refresh prompted for a browser-based OAuth login on every invocation that lacked a fresh token, including ones that have no business reaching the cloud at all (\`rpk ai help\`, \`rpk ai version\`, \`rpk ai <unknown>\`).

Following @r-vasquez's review feedback this PR drops the refresh entirely. \`resolveAndInjectEnv\` now reads the cached token off rpk's already-loaded config (\`y.LookupAuth(y.CurrentCloudAuthOrgID, y.CurrentCloudAuthKind).AuthToken\`) and exports it as \`RPAI_TOKEN\` — same env contract the plugin already understood, just no OAuth flow involved. Reading through rpk's loaded config picks up \`--config\` and \`RPK_PROFILE\` for free and resolves the rpk.yaml path via \`os.UserConfigDir\`, so behavior is correct on macOS, Linux, and Windows. When the cached token is stale the gateway returns a 401 and the plugin tells the user to run \`rpk cloud login\`.

While here, lift the bare-\`rpk ai\` early return out of the not-installed branch so \`rpk ai\` (with the plugin installed) prints rpk's command tree — same as \`rpk ai --help\` — instead of forwarding to the plugin's own help screen and dropping \`install\`/\`uninstall\`/\`upgrade\` from view. Pre-install \`--version\` keeps its original install hint.

Net **-76 LOC**: the helpers I added in earlier iterations of this PR (\`leafSkipsCloud\`, \`unknownSubcommand\`, \`hasFlag\`, the \`args[0] == \"help\"\` short-circuit) all become dead once nothing in rpk's path triggers OAuth, so they're gone — along with \`topLevelHasSubcommand\` and \`getTokenOrLogin\` which lose their last callers.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport

## UX Changes

* \`rpk ai help\`, \`rpk ai version\`, and \`rpk ai <unknown-subcommand>\` no longer prompt for an OAuth login before responding. \`help\` and an unknown subcommand fall through to cobra's standard \"unknown command\" error (matches \`rpk cluster help\`, \`rpk cluster <unknown>\` behavior); \`version\` is dispatched to the plugin and prints the plugin version.
* Bare \`rpk ai\` now prints the same help screen as \`rpk ai --help\` — including the rpk-side \`install\` / \`uninstall\` / \`upgrade\` subcommands.
* When the cached cloud token is expired, the gateway returns a 401 and the plugin emits a clear \"run \`rpk cloud login\`\" error. Previously rpk auto-refreshed on every invocation; now expiry is surfaced explicitly.

## Release Notes

### Bug Fixes

* \`rpk ai help\`, \`rpk ai version\`, and \`rpk ai <unknown-subcommand>\` no longer trigger an OAuth flow before responding.
* Bare \`rpk ai\` (with the plugin installed) now prints the same help screen as \`rpk ai --help\`, including the \`install\`, \`uninstall\`, and \`upgrade\` subcommands.