### PR TITLE
tests/rm_stm: wait for STM replay before LSO check after restart

### DIFF
--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -1237,9 +1237,14 @@ FIXTURE_TEST(
     BOOST_REQUIRE(producers().contains(pid1.get_id()));
     BOOST_REQUIRE(producers().contains(pid2.get_id()));
 
-    // Ensure the LSO is held back by the open transactions.
-    auto lso = stm->last_stable_offset();
-    BOOST_REQUIRE_NE(lso, model::invalid_lso);
+    // Ensure the LSO is held back by the open transactions. After restart
+    // the STM has applied through the snapshot offset; data batches replay
+    // asynchronously, so wait for last_stable_offset() to become valid.
+    model::offset lso;
+    RPTEST_REQUIRE_EVENTUALLY(10s, [&]() {
+        lso = stm->last_stable_offset();
+        return lso != model::invalid_lso;
+    });
     BOOST_REQUIRE_LE(lso, model::offset(last_data_offset()));
 
     // Ensure pid1's transaction can be committed


### PR DESCRIPTION
After restart_stm_and_raft() the STM has only applied through the snapshot offset; data batches are still asynchronously replaying, so last_stable_offset() can briefly return invalid_lso. Wrap the check in RPTEST_REQUIRE_EVENTUALLY, mirroring the wait already used at the end of the test.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
