### PR TITLE
`utils`: add and use `xml` utilities

### DIFF
--- a/src/v/cloud_roles/BUILD
+++ b/src/v/cloud_roles/BUILD
@@ -135,6 +135,7 @@ redpanda_cc_library(
         "//src/v/utils:base64",
         "//src/v/utils:file_io",
         "//src/v/utils:named_type",
+        "//src/v/utils:xml",
         "@abseil-cpp//absl/strings",
         "@ada",
         "@boost//:algorithm",

--- a/src/v/cloud_roles/aws_sts_refresh_impl.cc
+++ b/src/v/cloud_roles/aws_sts_refresh_impl.cc
@@ -14,6 +14,7 @@
 #include "cloud_roles/logger.h"
 #include "request_response_helpers.h"
 #include "utils/file_io.h"
+#include "utils/xml.h"
 
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/property_tree/ptree.hpp>
@@ -73,20 +74,6 @@ static ss::sstring load_from_env(std::string_view env_var) {
             env_var));
     }
     return env_value;
-}
-
-static boost::property_tree::ptree iobuf_to_ptree(iobuf&& buf) {
-    namespace pt = boost::property_tree;
-    try {
-        iobuf_istreambuf strbuf(buf);
-        std::istream stream(&strbuf);
-        pt::ptree res;
-        pt::read_xml(stream, res);
-        return res;
-    } catch (...) {
-        vlog(clrl_log.error, "!!parsing error {}", std::current_exception());
-        throw;
-    }
 }
 
 aws_sts_refresh_impl::aws_sts_refresh_impl(
@@ -152,7 +139,8 @@ ss::future<api_response> aws_sts_refresh_impl::fetch_credentials() {
 }
 
 api_response_parse_result aws_sts_refresh_impl::parse_response(iobuf resp) {
-    auto root = iobuf_to_ptree(std::move(resp));
+    auto root = xml::iobuf_to_ptree(
+      std::move(resp), clrl_log, xml::log_body_on_failure::no);
 
     auto creds_node_maybe = root.get_child_optional(
       response_node_credential_path.data());

--- a/src/v/cloud_storage_clients/BUILD
+++ b/src/v/cloud_storage_clients/BUILD
@@ -77,6 +77,7 @@ redpanda_cc_library(
         "//src/v/utils:stop_signal",
         "//src/v/utils:unresolved_address",
         "//src/v/utils:uuid",
+        "//src/v/utils:xml",
         "@ada",
         "@boost//:beast",
         "@boost//:lexical_cast",

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -29,6 +29,7 @@
 #include "json/istreamwrapper.h"
 #include "utils/base64.h"
 #include "utils/uuid.h"
+#include "utils/xml.h"
 
 #include <charconv>
 #include <utility>
@@ -118,10 +119,11 @@ parse_xml_rest_error_response(boost::beast::http::status result, iobuf buf) {
     using namespace cloud_storage_clients;
 
     try {
-        auto resp = util::iobuf_to_ptree(std::move(buf), abs_log);
-        auto code = resp.get<ss::sstring>("Error.Code", "Unknown");
-        auto msg = resp.get<ss::sstring>("Error.Message", "");
-        return {std::move(code), std::move(msg), result};
+        auto resp = xml::iobuf_to_ptree(std::move(buf), abs_log);
+        auto code = xml::get_from_ptree<std::string>(
+          resp, "Error.Code", "Unknown");
+        auto msg = xml::get_from_ptree<std::string>(resp, "Error.Message", "");
+        return {code, msg, result};
     } catch (...) {
         vlog(
           cloud_storage_clients::abs_log.error,

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -34,6 +34,7 @@
 #include "json/istreamwrapper.h"
 #include "json/reader.h"
 #include "utils/base64.h"
+#include "utils/xml.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/coroutine.hh>
@@ -545,12 +546,15 @@ status_to_error_code(boost::beast::http::status s) {
 
 rest_error_response parse_xml_rest_error_response(iobuf&& buf) {
     try {
-        auto resp = util::iobuf_to_ptree(std::move(buf), s3_log);
+        auto resp = xml::iobuf_to_ptree(std::move(buf), s3_log);
         constexpr const char* empty = "";
-        auto code = resp.get<ss::sstring>("Error.Code", empty);
-        auto msg = resp.get<ss::sstring>("Error.Message", empty);
-        auto rid = resp.get<ss::sstring>("Error.RequestId", empty);
-        auto res = resp.get<ss::sstring>("Error.Resource", empty);
+        auto code = xml::get_from_ptree<std::string>(resp, "Error.Code", empty);
+        auto msg = xml::get_from_ptree<std::string>(
+          resp, "Error.Message", empty);
+        auto rid = xml::get_from_ptree<std::string>(
+          resp, "Error.RequestId", empty);
+        auto res = xml::get_from_ptree<std::string>(
+          resp, "Error.Resource", empty);
         rest_error_response err(code, msg, rid, res);
         return err;
     } catch (...) {
@@ -1389,19 +1393,24 @@ ss::future<> s3_client::do_delete_object(
 
 std::variant<client::delete_objects_result, rest_error_response>
 iobuf_to_delete_objects_result(iobuf&& buf) {
-    auto root = util::iobuf_to_ptree(std::move(buf), s3_log);
+    auto root = xml::iobuf_to_ptree(std::move(buf), s3_log);
     auto result = client::delete_objects_result{};
     try {
         if (
-          auto error_code = root.get_optional<ss::sstring>("Error.Code");
+          auto error_code = xml::get_optional_from_ptree<std::string>(
+            root, "Error.Code");
           error_code) {
             // This is an error response. S3 can reply with 200 error code and
             // error response in the body.
             constexpr const char* empty = "";
-            auto code = root.get<ss::sstring>("Error.Code", empty);
-            auto msg = root.get<ss::sstring>("Error.Message", empty);
-            auto rid = root.get<ss::sstring>("Error.RequestId", empty);
-            auto res = root.get<ss::sstring>("Error.Resource", empty);
+            auto code = xml::get_from_ptree<std::string>(
+              root, "Error.Code", empty);
+            auto msg = xml::get_from_ptree<std::string>(
+              root, "Error.Message", empty);
+            auto rid = xml::get_from_ptree<std::string>(
+              root, "Error.RequestId", empty);
+            auto res = xml::get_from_ptree<std::string>(
+              root, "Error.Resource", empty);
             rest_error_response err(code, msg, rid, res);
             return err;
         }
@@ -1409,10 +1418,13 @@ iobuf_to_delete_objects_result(iobuf&& buf) {
             if (tag != "Error") {
                 continue;
             }
-            auto code = value.get_optional<ss::sstring>("Code");
-            auto key = value.get_optional<ss::sstring>("Key");
-            auto message = value.get_optional<ss::sstring>("Message");
-            auto version_id = value.get_optional<ss::sstring>("VersionId");
+            auto code = xml::get_optional_from_ptree<std::string>(
+              value, "Code");
+            auto key = xml::get_optional_from_ptree<std::string>(value, "Key");
+            auto message = xml::get_optional_from_ptree<std::string>(
+              value, "Message");
+            auto version_id = xml::get_optional_from_ptree<std::string>(
+              value, "VersionId");
             vlog(
               s3_log.trace,
               R"(delete_objects_result::undeleted_keys Key:"{}" Code: "{}" Message:"{}" VersionId:"{}")",
@@ -1832,10 +1844,10 @@ ss::future<> s3_multipart_state::initialize_multipart() {
     auto response_buf = co_await http::drain(std::move(response_stream));
 
     try {
-        auto response_tree = util::iobuf_to_ptree(
+        auto response_tree = xml::iobuf_to_ptree(
           std::move(response_buf), s3_log);
-        _upload_id = response_tree.get<ss::sstring>(
-          "InitiateMultipartUploadResult.UploadId");
+        _upload_id = xml::get_from_ptree<std::string>(
+          response_tree, "InitiateMultipartUploadResult.UploadId");
 
         _client->_probe->register_multipart_create();
 
@@ -1952,18 +1964,18 @@ ss::future<> s3_multipart_state::complete_multipart_upload() {
     // See:
     // https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html
     auto response_buf = co_await http::drain(std::move(response_stream));
-    auto response_tree = util::iobuf_to_ptree(std::move(response_buf), s3_log);
+    auto response_tree = xml::iobuf_to_ptree(std::move(response_buf), s3_log);
     if (
-      auto error_code = response_tree.get_optional<std::string>("Error.Code");
+      auto error_code = xml::get_optional_from_ptree<std::string>(
+        response_tree, "Error.Code");
       error_code) {
-        // Use std::string for ptree extraction since ss::sstring's stream
-        // extraction operator reads only until whitespace, which truncates
-        // multi-word error messages.
         throw rest_error_response(
           *error_code,
-          response_tree.get<std::string>("Error.Message", ""),
-          response_tree.get<std::string>("Error.RequestId", ""),
-          response_tree.get<std::string>("Error.Resource", ""));
+          xml::get_from_ptree<std::string>(response_tree, "Error.Message", ""),
+          xml::get_from_ptree<std::string>(
+            response_tree, "Error.RequestId", ""),
+          xml::get_from_ptree<std::string>(
+            response_tree, "Error.Resource", ""));
     }
 
     _client->_probe->register_multipart_complete();

--- a/src/v/cloud_storage_clients/tests/s3_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/s3_client_test.cc
@@ -989,6 +989,8 @@ SEASTAR_THREAD_TEST_CASE(test_parse_delete_object_response_infra_error) {
       &result);
     BOOST_REQUIRE_NE(error, nullptr);
     BOOST_REQUIRE_EQUAL(error->code_string(), "SlowDown");
+    BOOST_REQUIRE_EQUAL(error->message(), "Please reduce your request rate.");
+    BOOST_REQUIRE_EQUAL(error->request_id(), "R123");
 }
 
 SEASTAR_THREAD_TEST_CASE(test_parse_delete_object_response_key_error) {

--- a/src/v/cloud_storage_clients/util.cc
+++ b/src/v/cloud_storage_clients/util.cc
@@ -12,15 +12,12 @@
 
 #include "base/external_fmt.h"
 #include "base/vlog.h"
-#include "bytes/streambuf.h"
 #include "container/chunked_vector.h"
 #include "http/utils.h"
 #include "net/connection.h"
 #include "utils/retry_chain_node.h"
 
 #include <seastar/core/future.hh>
-
-#include <boost/property_tree/xml_parser.hpp>
 
 #include <exception>
 #include <system_error>
@@ -152,43 +149,11 @@ handle_client_transport_error<ss::logger>(std::exception_ptr, ss::logger&);
 template error_outcome handle_client_transport_error<retry_chain_logger>(
   std::exception_ptr, retry_chain_logger&);
 
-boost::property_tree::ptree iobuf_to_ptree(iobuf&& buf, ss::logger& logger) {
-    namespace pt = boost::property_tree;
-    try {
-        iobuf_istreambuf strbuf(buf);
-        std::istream stream(&strbuf);
-        pt::ptree res;
-        pt::read_xml(stream, res);
-        return res;
-    } catch (...) {
-        log_buffer_with_rate_limiting("unexpected reply", buf, logger);
-        vlog(logger.error, "!!parsing error {}", std::current_exception());
-        throw;
-    }
-}
-
 std::chrono::system_clock::time_point parse_timestamp(std::string_view sv) {
     std::tm tm = {};
     std::stringstream ss({sv.data(), sv.size()});
     ss >> std::get_time(&tm, "%Y-%m-%dT%H:%M:%S.Z%Z");
     return std::chrono::system_clock::from_time_t(timegm(&tm));
-}
-
-void log_buffer_with_rate_limiting(
-  const char* msg, iobuf& buf, ss::logger& logger) {
-    static constexpr int buffer_size = 0x100;
-    static constexpr auto rate_limit = std::chrono::seconds(1);
-    thread_local static ss::logger::rate_limit rate(rate_limit);
-    auto log_with_rate_limit = [&logger](
-                                 ss::logger::format_info fmt, auto... args) {
-        logger.log(ss::log_level::warn, rate, fmt, args...);
-    };
-    iobuf_istreambuf strbuf(buf);
-    std::istream stream(&strbuf);
-    std::array<char, buffer_size> str{};
-    auto sz = stream.readsome(str.data(), buffer_size);
-    auto sview = std::string_view(str.data(), sz);
-    vlog(log_with_rate_limit, "{}: {}", msg, sview);
 }
 
 std::vector<object_key> all_paths_to_file(const object_key& path) {

--- a/src/v/cloud_storage_clients/util.h
+++ b/src/v/cloud_storage_clients/util.h
@@ -17,8 +17,6 @@
 
 #include <seastar/util/log.hh>
 
-#include <boost/property_tree/ptree.hpp>
-
 #include <expected>
 
 namespace cloud_storage_clients::util {
@@ -31,14 +29,8 @@ template<typename Logger>
 error_outcome handle_client_transport_error(
   std::exception_ptr current_exception, Logger& logger);
 
-/// \brief: Convert iobuf that contains xml data to boost::property_tree
-boost::property_tree::ptree iobuf_to_ptree(iobuf&& buf, ss::logger& logger);
-
 /// \brief: Parse timestamp in format that S3 and ABS use
 std::chrono::system_clock::time_point parse_timestamp(std::string_view sv);
-
-void log_buffer_with_rate_limiting(
-  const char* msg, iobuf& buf, ss::logger& logger);
 
 bool has_abort_or_gate_close_exception(const ss::nested_exception& ex);
 

--- a/src/v/utils/BUILD
+++ b/src/v/utils/BUILD
@@ -715,3 +715,20 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "xml",
+    srcs = [
+        "xml.cc",
+    ],
+    hdrs = [
+        "xml.h",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:streambuf",
+        "@boost//:property_tree",
+        "@seastar",
+    ],
+)

--- a/src/v/utils/xml.cc
+++ b/src/v/utils/xml.cc
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "utils/xml.h"
+
+#include "base/vlog.h"
+#include "bytes/streambuf.h"
+
+#include <boost/property_tree/xml_parser.hpp>
+
+#include <exception>
+
+namespace {
+void log_buffer_with_rate_limiting(
+  const char* msg, iobuf& buf, ss::logger& logger) {
+    static constexpr int buffer_size = 0x100;
+    static constexpr auto rate_limit = std::chrono::seconds(1);
+    thread_local static ss::logger::rate_limit rate(rate_limit);
+    auto log_with_rate_limit = [&logger](
+                                 ss::logger::format_info fmt, auto... args) {
+        logger.log(ss::log_level::warn, rate, fmt, args...);
+    };
+    iobuf_istreambuf strbuf(buf);
+    std::istream stream(&strbuf);
+    std::array<char, buffer_size> str{};
+    auto sz = stream.readsome(str.data(), buffer_size);
+    auto sview = std::string_view(str.data(), sz);
+    vlog(log_with_rate_limit, "{}: {}", msg, sview);
+}
+
+} // namespace
+
+namespace xml {
+
+boost::property_tree::ptree
+iobuf_to_ptree(iobuf&& buf, ss::logger& logger, log_body_on_failure log_body) {
+    namespace pt = boost::property_tree;
+    try {
+        iobuf_istreambuf strbuf(buf);
+        std::istream stream(&strbuf);
+        pt::ptree res;
+        pt::read_xml(stream, res);
+        return res;
+    } catch (...) {
+        if (log_body) {
+            log_buffer_with_rate_limiting("unexpected reply", buf, logger);
+        }
+        vlog(logger.error, "!!parsing error {}", std::current_exception());
+        throw;
+    }
+}
+
+} // namespace xml

--- a/src/v/utils/xml.h
+++ b/src/v/utils/xml.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+
+#include <seastar/util/bool_class.hh>
+#include <seastar/util/log.hh>
+
+#include <boost/property_tree/ptree.hpp>
+
+namespace xml {
+
+/// Controls whether iobuf_to_ptree dumps a prefix of the input buffer to the
+/// log when XML parsing fails. Callers whose response bodies may contain
+/// secrets (e.g. STS credentials) must pass `no`.
+using log_body_on_failure = ss::bool_class<struct log_body_on_failure_tag>;
+
+/// \brief: Convert iobuf that contains xml data to boost::property_tree
+boost::property_tree::ptree iobuf_to_ptree(
+  iobuf&& buf,
+  ss::logger& logger,
+  log_body_on_failure log_body = log_body_on_failure::yes);
+
+/// A type usable with boost::property_tree's typed extraction.
+///
+/// ss::sstring is excluded because its stream extraction reads only until
+/// whitespace, which would truncate output - use std::string instead for
+/// string parsing from a boost::property_tree.
+template<typename T>
+concept PtreeExtractable = !std::is_same_v<T, ss::sstring>;
+
+template<PtreeExtractable T>
+decltype(auto) get_from_ptree(
+  const boost::property_tree::ptree& tree,
+  const boost::property_tree::ptree::path_type& path) {
+    return tree.get<T>(path);
+}
+
+template<PtreeExtractable T>
+decltype(auto) get_from_ptree(
+  const boost::property_tree::ptree& tree,
+  const boost::property_tree::ptree::path_type& path,
+  const T& default_value) {
+    return tree.get<T>(path, default_value);
+}
+
+template<PtreeExtractable T>
+decltype(auto) get_optional_from_ptree(
+  const boost::property_tree::ptree& tree,
+  const boost::property_tree::ptree::path_type& path) {
+    return tree.get_optional<T>(path);
+}
+
+} // namespace xml


### PR DESCRIPTION
`boost::property_tree::get<ss::sstring>()` is a footgun, since `ss::sstring`'s stream extraction operator reads only until whitespace, which truncates multi-word error messages.

Extract some common `property_tree` utilities out in wrappers within an `xml` library in `utils` to ensure safe use of these functions.

As a demonstration:

```cpp
TEST_F(XmlPtreeExtraction, StdStringExtractsFullValue) {
    boost::property_tree::ptree tree;
    tree.put("Error.Message", "The specified key does not exist");
    auto res = tree.get<std::string>("Error.Message", "Empty");
    // This succeeds
    EXPECT_EQ(res, "The specified key does not exist");
}

TEST_F(XmlPtreeExtraction, SsStringFailsToExtractMessage) {
    boost::property_tree::ptree tree;
    tree.put("Error.Message", "The specified key does not exist");
    auto res = tree.get<ss::sstring>("Error.Message", "Empty");
    // This fails with res == "Empty"
    EXPECT_EQ(res, "The specified key does not exist");
}
```

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
