### PR TITLE
bazel: ban boost::property_tree::get<ss::sstring> via force-include

### DIFF
--- a/bazel/build.bzl
+++ b/bazel/build.bzl
@@ -7,7 +7,7 @@ making behavior changes across the entire build.
 
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
-load(":internal.bzl", "antithesis_deps", "redpanda_copts")
+load(":internal.bzl", "antithesis_deps", "redpanda_copts", "redpanda_implicit_deps")
 
 # buildifier: disable=function-docstring-args
 def redpanda_cc_library(
@@ -35,7 +35,7 @@ def redpanda_cc_library(
         local_defines = local_defines,
         visibility = visibility,
         include_prefix = include_prefix,
-        implementation_deps = implementation_deps,
+        implementation_deps = implementation_deps + redpanda_implicit_deps(),
         deps = deps,
         copts = redpanda_copts() + copts,
         tags = tags,
@@ -64,7 +64,7 @@ def redpanda_cc_binary(
         defines = defines,
         local_defines = local_defines,
         visibility = visibility,
-        deps = deps + antithesis_deps(),
+        deps = deps + antithesis_deps() + redpanda_implicit_deps(),
         testonly = testonly,
         copts = redpanda_copts() + copts,
         linkopts = linkopts,

--- a/bazel/internal.bzl
+++ b/bazel/internal.bzl
@@ -17,8 +17,17 @@ def redpanda_copts():
     copts.append("-Wextra")
     copts.append("-Wno-missing-field-initializers")
     copts.append("-Wimplicit-fallthrough")
+    copts.append("-include")
+    copts.append("base/ptree_ban.h")
 
     return copts
+
+def redpanda_implicit_deps():
+    """
+    Deps that must be present on every redpanda C++ target so that
+    the headers force-included via redpanda_copts() are visible.
+    """
+    return ["//src/v/base:ptree_ban"]
 
 def antithesis_deps():
     """Conditional deps for Antithesis coverage instrumentation."""

--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -10,7 +10,7 @@ load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
-load(":internal.bzl", "antithesis_deps", "redpanda_copts")
+load(":internal.bzl", "antithesis_deps", "redpanda_copts", "redpanda_implicit_deps")
 
 def _reactor_args():
     """Returns additional reactor args for all reactor-using tests and benchmarks."""
@@ -164,7 +164,7 @@ def _redpanda_cc_test(
         timeout = timeout,
         srcs = srcs,
         defines = defines,
-        deps = deps + test_deps,
+        deps = deps + test_deps + redpanda_implicit_deps(),
         copts = redpanda_copts(),
         args = args,
         features = [
@@ -206,7 +206,7 @@ def _redpanda_cc_fuzz_test(
         timeout = timeout,
         srcs = srcs,
         defines = defines,
-        deps = deps + test_deps,
+        deps = deps + test_deps + redpanda_implicit_deps(),
         copts = redpanda_copts(),
         args = custom_args,
         features = [
@@ -354,7 +354,7 @@ def redpanda_cc_btest_no_seastar(
             "//src/v/test_utils:boost_result_redirect",
             "//src/v/test_utils:boost_test_hooks",
             "@boost//:test.so",
-        ] + deps + test_deps,
+        ] + deps + test_deps + redpanda_implicit_deps(),
         data = test_data,
         env = test_env,
     )
@@ -377,7 +377,7 @@ def redpanda_test_cc_library(
         local_defines = local_defines,
         visibility = visibility,
         include_prefix = native.package_name().removeprefix("src/v/"),
-        implementation_deps = implementation_deps,
+        implementation_deps = implementation_deps + redpanda_implicit_deps(),
         deps = deps,
         copts = redpanda_copts(),
         testonly = True,
@@ -472,7 +472,7 @@ def redpanda_cc_bench(
         name = binary_name,
         srcs = srcs,
         defines = defines,
-        deps = deps + test_deps,
+        deps = deps + test_deps + redpanda_implicit_deps(),
         testonly = True,
         copts = redpanda_copts(),
         features = [

--- a/src/v/base/BUILD
+++ b/src/v/base/BUILD
@@ -1,4 +1,12 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:build.bzl", "redpanda_cc_library")
+
+cc_library(
+    name = "ptree_ban",
+    hdrs = ["ptree_ban.h"],
+    include_prefix = "base",
+    visibility = ["//visibility:public"],
+)
 
 redpanda_cc_library(
     name = "base",

--- a/src/v/base/ptree_ban.h
+++ b/src/v/base/ptree_ban.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <string>
+
+namespace seastar {
+template<typename char_type, typename Size, Size max_size, bool NulTerminate>
+class basic_sstring;
+} // namespace seastar
+
+namespace boost::property_tree {
+
+template<typename Internal, typename External>
+struct translator_between;
+
+template<
+  typename Ch,
+  typename Traits,
+  typename Alloc,
+  typename CharT,
+  typename Size,
+  Size MaxSize,
+  bool NulTerminate>
+struct translator_between<
+  std::basic_string<Ch, Traits, Alloc>,
+  ::seastar::basic_sstring<CharT, Size, MaxSize, NulTerminate>> {
+    static_assert(
+      false,
+      "boost::property_tree::ptree::get<seastar::sstring> silently returns "
+      "the default for non-empty trees because seastar::sstring lacks a "
+      "stream extractor. Use std::string and convert at the call site.");
+};
+
+} // namespace boost::property_tree


### PR DESCRIPTION
`boost::property_tree::ptree::get<ss::sstring>(path, default)` silently
returns the supplied default for non-empty trees because
`seastar::sstring` lacks a stream extractor; boost's `stream_translator`
falls through and the failure is invisible at both compile time and
runtime — the call site looks correct.

This PR makes the pattern a hard compile error.

### What's wired

- `src/v/base/ptree_ban.h`: forward-declares `seastar::basic_sstring` and
  partially specializes `boost::property_tree::translator_between` for
  it with a `static_assert(false, …)` carrying a pointed message.
- `//src/v/base:ptree_ban`: header-only `cc_library` (uses the native
  rule directly to avoid the `redpanda_cc_library` macro recursing into
  itself).
- `bazel/internal.bzl`: `redpanda_copts()` appends
  `-include base/ptree_ban.h`; new `redpanda_implicit_deps()` returns
  `["//src/v/base:ptree_ban"]` so the header is visible under
  `layering_check`.
- `bazel/build.bzl` + `bazel/test.bzl`: thread `redpanda_implicit_deps()`
  through `redpanda_cc_library`, `redpanda_cc_binary`,
  `_redpanda_cc_test`, `_redpanda_cc_fuzz_test`,
  `redpanda_cc_btest_no_seastar`, `redpanda_test_cc_library`, and
  `redpanda_cc_bench`.

Third-party `cc_library` targets are unaffected — only Redpanda's own
macros inject the force-include.

### Diagnostic

```
ptree_ban.h:38:7: error: static assertion failed:
  boost::property_tree::ptree::get<seastar::sstring> silently returns
  the default for non-empty trees because seastar::sstring lacks a
  stream extractor. Use std::string and convert at the call site.
note: in instantiation of … translator_between<std::string,
      seastar::basic_sstring<char, unsigned int, 15>> requested here
src/v/cloud_storage_clients/abs_client.cc:122:26: note: in instantiation
  of … resp.get<ss::sstring>("Error.Code", "Unknown");
```

### Existing breakage surfaced

This change does not compile against `dev` as-is — it surfaces what
appear to be real, latent silent failures in S3/Azure error parsing
that need follow-up fixes:

- `src/v/cloud_storage_clients/abs_client.cc:122-123`
- `src/v/cloud_storage_clients/s3_client.cc:550-553, 1401-1404, 1837`

Those call sites parse cloud error responses and have been resolving
`Error.Code` / `Error.Message` / `Error.RequestId` to the supplied
defaults (`"Unknown"` / `""`) regardless of what the server returned.
A follow-up PR will switch them to `std::string` and adapt the call
sites; this PR is filed as a draft to discuss the approach before that
follow-up lands.

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none