### PR TITLE
[v26.1.x] build/deps: upgrade openssl to v3.5.6 (CVE-2026-31790)

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -303,7 +303,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "GauW5CRC26lxp15CIg4YqPYSbs0XB8g6/TfjVnNOMcA=",
+        "bzlTransitiveDigest": "Ke6derljX9id+nZQqBwj+tDY/ek02Y/BFp8xSQeOgow=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -447,9 +447,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:openssl.BUILD",
-              "sha256": "b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89",
-              "strip_prefix": "openssl-3.5.5",
-              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/openssl-3.5.5.tar.gz"
+              "sha256": "deae7c80cba99c4b4f940ecadb3c3338b13cb77418409238e57d7f31f2a3b736",
+              "strip_prefix": "openssl-3.5.6",
+              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/openssl-3.5.6.tar.gz"
             }
           },
           "openssl-fips": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -138,9 +138,9 @@ def data_dependency():
     http_archive(
         name = "openssl",
         build_file = "//bazel/thirdparty:openssl.BUILD",
-        sha256 = "b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89",
-        strip_prefix = "openssl-3.5.5",
-        url = "https://vectorized-public.s3.amazonaws.com/dependencies/openssl-3.5.5.tar.gz",
+        sha256 = "deae7c80cba99c4b4f940ecadb3c3338b13cb77418409238e57d7f31f2a3b736",
+        strip_prefix = "openssl-3.5.6",
+        url = "https://vectorized-public.s3.amazonaws.com/dependencies/openssl-3.5.6.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30238

- Command: git cherry-pick -x d361ea0f38
- Commits backported: 1
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-30238-v26.1.x-1778012960

FIXES=[30257](https://github.com/redpanda-data/redpanda/issues/30257)

## Conflict details

- d361ea0f38 (MODULE.bazel.lock): generated lockfile conflict — accepted theirs (the cherry-picked side) per the standard generated-file rule; the lockfile will be regenerated by the build.

## ⚠️ Generated files

The following files were cherry-picked and may need regeneration:

- MODULE.bazel.lock

These files were accepted as-is from the source branch. Before merging,
regenerate them on the target branch to ensure they're correct. For example:
- MODULE.bazel.lock: run `bazel mod deps --lockfile_mode=update`
- *.pb.go / *.pb.cc / *.pb.h: rebuild protobuf targets
- go.sum: run `go mod tidy`
