### PR TITLE
rpk: add root '--print-tree' flag

### DIFF
--- a/src/go/rpk/pkg/cli/BUILD
+++ b/src/go/rpk/pkg/cli/BUILD
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "deprecated.go",
         "plugin_cmds.go",
+        "printtree.go",
         "root.go",
         "root_darwin.go",
         "root_linux.go",
@@ -40,6 +41,7 @@ go_library(
         "@com_github_moby_term//:term",
         "@com_github_spf13_afero//:afero",
         "@com_github_spf13_cobra//:cobra",
+        "@com_github_spf13_pflag//:pflag",
         "@org_golang_x_term//:term",
         "@org_uber_go_zap//:zap",
     ] + select({
@@ -68,10 +70,14 @@ go_library(
 go_test(
     name = "cli_test",
     size = "small",
-    srcs = ["root_test.go"],
+    srcs = [
+        "printtree_test.go",
+        "root_test.go",
+    ],
     embed = [":cli"],
     deps = [
         "@com_github_spf13_cobra//:cobra",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/src/go/rpk/pkg/cli/printtree.go
+++ b/src/go/rpk/pkg/cli/printtree.go
@@ -1,0 +1,166 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package cli
+
+import (
+	"cmp"
+	"encoding/json"
+	"fmt"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type flagPrint struct {
+	Name        string `json:"name"`
+	Shorthand   string `json:"shorthand,omitempty"`
+	Type        string `json:"type"`
+	Description string `json:"description"`
+	Default     any    `json:"default"`
+	Required    bool   `json:"required"`
+	Deprecated  string `json:"deprecated,omitempty"`
+}
+
+type commandPrint struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Usage       string         `json:"usage"`
+	Aliases     []string       `json:"aliases"`
+	Examples    string         `json:"examples,omitempty"`
+	Deprecated  string         `json:"deprecated,omitempty"`
+	Flags       []flagPrint    `json:"flags"`
+	Commands    []commandPrint `json:"commands"`
+}
+
+type rootPrint struct {
+	Name        string         `json:"name"`
+	Version     string         `json:"version"`
+	Description string         `json:"description"`
+	Usage       string         `json:"usage"`
+	GlobalFlags []flagPrint    `json:"global_flags"`
+	Commands    []commandPrint `json:"commands"`
+}
+
+func printTreeJSON(root *cobra.Command) ([]byte, error) {
+	rp := rootPrint{
+		Name:        root.Name(),
+		Version:     version.Pretty(),
+		Description: root.Short,
+		Usage:       root.UseLine(),
+		GlobalFlags: printFlagSet(root.PersistentFlags()),
+		Commands:    printChildren(root),
+	}
+	return json.Marshal(rp)
+}
+
+func printTreeAndExit(root *cobra.Command) {
+	b, err := printTreeJSON(root)
+	out.MaybeDie(err, "unable to marshal command tree: %v", err)
+	fmt.Fprintln(os.Stdout, string(b))
+	os.Exit(0)
+}
+
+func printChildren(parent *cobra.Command) []commandPrint {
+	children := parent.Commands()
+	cp := make([]commandPrint, 0, len(children))
+	for _, c := range children {
+		if c.Hidden {
+			continue
+		}
+		cp = append(cp, printCommand(c))
+	}
+	slices.SortFunc(cp, func(a, b commandPrint) int { return cmp.Compare(a.Name, b.Name) })
+	return cp
+}
+
+func printCommand(c *cobra.Command) commandPrint {
+	desc := c.Long
+	if desc == "" {
+		desc = c.Short
+	}
+	aliases := c.Aliases
+	if aliases == nil {
+		aliases = []string{}
+	}
+	return commandPrint{
+		Name:        c.Name(),
+		Description: desc,
+		Usage:       c.UseLine(),
+		Aliases:     aliases,
+		Examples:    c.Example,
+		Deprecated:  c.Deprecated,
+		Flags:       printFlagSet(c.LocalFlags()),
+		Commands:    printChildren(c),
+	}
+}
+
+func printFlagSet(fs *pflag.FlagSet) []flagPrint {
+	fp := []flagPrint{} // Assign to prevent printing `null` in the json output.
+	fs.VisitAll(func(f *pflag.Flag) {
+		if f.Hidden {
+			return
+		}
+		if f.Name == "help" && f.Shorthand == "h" {
+			return
+		}
+		fp = append(fp, printFlag(f))
+	})
+	return fp
+}
+
+func printFlag(f *pflag.Flag) flagPrint {
+	return flagPrint{
+		Name:        f.Name,
+		Shorthand:   f.Shorthand,
+		Type:        f.Value.Type(),
+		Description: f.Usage,
+		Default:     parseDefault(f),
+		Required:    slices.Contains(f.Annotations[cobra.BashCompOneRequiredFlag], "true"),
+		Deprecated:  f.Deprecated,
+	}
+}
+
+func parseDefault(f *pflag.Flag) any {
+	t := f.Value.Type()
+	if strings.HasSuffix(t, "Slice") || strings.HasSuffix(t, "Array") {
+		if f.DefValue == "" || f.DefValue == "[]" {
+			return []any{}
+		}
+		return f.DefValue
+	}
+	if f.DefValue == "" {
+		if t == "string" {
+			return ""
+		}
+		return nil
+	}
+	switch t {
+	case "bool":
+		if b, err := strconv.ParseBool(f.DefValue); err == nil {
+			return b
+		}
+	case "int", "int8", "int16", "int32", "int64",
+		"uint", "uint8", "uint16", "uint32", "uint64", "count":
+		if n, err := strconv.ParseInt(f.DefValue, 10, 64); err == nil {
+			return n
+		}
+	case "float32", "float64":
+		if x, err := strconv.ParseFloat(f.DefValue, 64); err == nil {
+			return x
+		}
+	}
+	return f.DefValue
+}

--- a/src/go/rpk/pkg/cli/printtree_test.go
+++ b/src/go/rpk/pkg/cli/printtree_test.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func newPrintTreeTestRoot() *cobra.Command {
+	root := &cobra.Command{
+		Use:               "rpk",
+		Short:             "rpk root",
+		CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
+	}
+	root.SetHelpCommand(&cobra.Command{Use: "no-help", Hidden: true})
+	root.PersistentFlags().StringP("config", "c", "", "config file")
+	root.PersistentFlags().BoolP("verbose", "v", false, "verbose")
+
+	topic := &cobra.Command{
+		Use:     "topic",
+		Short:   "manage topics",
+		Long:    "manage topics in detail",
+		Aliases: []string{"t"},
+		Example: "rpk topic create foo",
+	}
+	topic.Flags().Int("partitions", 3, "number of partitions")
+	topic.Flags().StringP("name", "n", "", "topic name")
+	topic.MarkFlagRequired("name")
+	topic.Flags().StringSlice("tags", nil, "topic tags")
+	topic.Flags().StringArray("entries", nil, "topic config entries")
+	topic.Flags().String("internal", "", "internal use")
+	topic.Flags().MarkHidden("internal")
+	topic.Flags().String("legacy", "old", "legacy flag")
+	topic.Flags().Lookup("legacy").Deprecated = "use --new-flag"
+
+	short := &cobra.Command{Use: "short-only", Short: "short fallback"}
+	old := &cobra.Command{Use: "old", Short: "old", Deprecated: "use new"}
+	hidden := &cobra.Command{Use: "secret", Short: "hidden", Hidden: true}
+
+	root.AddCommand(topic, short, old, hidden)
+	return root
+}
+
+func TestPrintTree(t *testing.T) {
+	root := newPrintTreeTestRoot()
+
+	b, err := printTreeJSON(root)
+	require.NoError(t, err)
+
+	var got rootPrint
+	require.NoError(t, json.Unmarshal(b, &got))
+
+	require.Equal(t, "rpk", got.Name)
+	require.Equal(t, "rpk root", got.Description)
+
+	globals := flagsByName(got.GlobalFlags)
+	require.Len(t, got.GlobalFlags, 2)
+	require.Equal(t, "c", globals["config"].Shorthand)
+	require.Equal(t, "string", globals["config"].Type)
+	require.Equal(t, "bool", globals["verbose"].Type)
+	require.Equal(t, false, globals["verbose"].Default)
+
+	names := make([]string, len(got.Commands))
+	for i, c := range got.Commands {
+		names[i] = c.Name
+	}
+	require.Equal(t, []string{"old", "short-only", "topic"}, names, "children must be sorted and exclude hidden")
+
+	cmds := commandsByName(got.Commands)
+	require.Equal(t, "use new", cmds["old"].Deprecated)
+	require.Equal(t, "short fallback", cmds["short-only"].Description, "Short is used when Long is empty")
+	require.Equal(t, []string{}, cmds["short-only"].Aliases, "nil aliases must marshal as []")
+
+	tc := cmds["topic"]
+	require.Equal(t, "manage topics in detail", tc.Description, "Long is preferred over Short")
+	require.Equal(t, []string{"t"}, tc.Aliases)
+	require.Equal(t, "rpk topic create foo", tc.Examples)
+
+	flags := flagsByName(tc.Flags)
+	require.Len(t, tc.Flags, 5, "hidden flag must be excluded")
+	require.Equal(t, "int", flags["partitions"].Type)
+	require.Equal(t, float64(3), flags["partitions"].Default)
+	require.False(t, flags["partitions"].Required)
+	require.True(t, flags["name"].Required)
+	require.Equal(t, "", flags["name"].Default)
+	require.Equal(t, "n", flags["name"].Shorthand)
+	require.Equal(t, []any{}, flags["tags"].Default)
+	require.Equal(t, []any{}, flags["entries"].Default)
+	require.Equal(t, "use --new-flag", flags["legacy"].Deprecated)
+
+	raw := string(b)
+	require.NotContains(t, raw, `"deprecated":""`, "empty deprecated must be omitted")
+	require.NotContains(t, raw, `"examples":""`, "empty examples must be omitted")
+}
+
+func flagsByName(fs []flagPrint) map[string]flagPrint {
+	m := make(map[string]flagPrint, len(fs))
+	for _, f := range fs {
+		m[f.Name] = f
+	}
+	return m
+}
+
+func commandsByName(cs []commandPrint) map[string]commandPrint {
+	m := make(map[string]commandPrint, len(cs))
+	for _, c := range cs {
+		m[c.Name] = c
+	}
+	return m
+}

--- a/src/go/rpk/pkg/cli/root.go
+++ b/src/go/rpk/pkg/cli/root.go
@@ -56,6 +56,7 @@ func Execute() {
 	}
 
 	p := new(config.Params)
+	var printTree bool
 	runXHelp := func() {
 		for _, o := range p.FlagOverrides {
 			switch o {
@@ -69,18 +70,24 @@ func Execute() {
 			os.Exit(0)
 		}
 	}
-	cobra.OnInitialize(func() {
-		runXHelp()
-		zap.ReplaceGlobals(p.Logger())
-	})
 	root := &cobra.Command{
-		Use:     "rpk",
-		Short:   "rpk is the Redpanda CLI & toolbox",
-		Long:    "",
+		Use:   "rpk",
+		Short: "rpk is the Redpanda CLI & toolbox",
+		Long: `rpk is the Redpanda CLI & toolbox.
+
+Use --print-tree to emit the full command tree as JSON.`,
 		Version: version.Pretty(),
 
 		CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
 	}
+	cobra.OnInitialize(func() {
+		runXHelp()
+		if printTree {
+			printTreeAndExit(root)
+		}
+		zap.ReplaceGlobals(p.Logger())
+	})
+	root.Flags().BoolVar(&printTree, "print-tree", false, "Print the rpk command tree as JSON and exit; intended for LLM/automation tooling")
 	pf := root.PersistentFlags()
 
 	searchLocal, _ := os.UserConfigDir()


### PR DESCRIPTION
Emit the full rpk command tree as a single
JSON document. The intended consumer is LLM
or automation tooling that needs to discover
rpk's surface (commands, flags, types,
defaults, examples) without parsing the
human-oriented --help output.

The walk runs against the live cobra tree, so
plugins and platform-dependent commands that
are mounted before Execute() are included
automatically. Hidden commands and hidden
flags are excluded.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Features

* `rpk --print-tree`: emits the full rpk command tree as a single JSON document, suited for LLMs and automations.

