### PR TITLE
ducktape: retry apt/PPA installs in ocsf-server

### DIFF
--- a/tests/docker/ducktape-deps/ocsf-server
+++ b/tests/docker/ducktape-deps/ocsf-server
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 set -e
 
+# Retry an apt-related command with exponential backoff. Tolerates transient
+# Canonical/Launchpad PPA outages observed in CDT (DEVPROD-4196).
+retry_apt() {
+  local max_attempts=3 delay=30 attempt=1
+  until "$@"; do
+    if ((attempt >= max_attempts)); then
+      echo "retry_apt: '$*' failed after ${max_attempts} attempts" >&2
+      return 1
+    fi
+    echo "retry_apt: attempt ${attempt}/${max_attempts} of '$*' failed; sleeping ${delay}s" >&2
+    sleep "$delay"
+    delay=$((delay * 2))
+    attempt=$((attempt + 1))
+  done
+}
+
 OCSF_SCHEMA_VERSION=9608805fe0b61035cb821bb9068096fe47fed12d # tip of v1.0.0 branch
 OCSF_SERVER_VERSION=d3b26de39df9eb33c6d63e34a126c77c0811c7a0
 
@@ -15,12 +31,12 @@ tar -xvzf ${OCSF_SERVER_VERSION}.tar.gz
 rm ${OCSF_SERVER_VERSION}.tar.gz
 mv ocsf-server-${OCSF_SERVER_VERSION} /opt/ocsf-server
 
-apt-get update
-apt-get install -qq software-properties-common
+retry_apt apt-get update
+retry_apt apt-get install -qq software-properties-common
 
-add-apt-repository -y ppa:rabbitmq/rabbitmq-erlang
-apt-get update
-apt-get install -qq elixir erlang-dev erlang-xmerl
+retry_apt add-apt-repository -y ppa:rabbitmq/rabbitmq-erlang
+retry_apt apt-get update
+retry_apt apt-get install -qq elixir erlang-dev erlang-xmerl
 
 mix local.hex --force && mix local.rebar --force
 
@@ -35,7 +51,7 @@ fi
 ./build_server.sh
 
 # remove added repository for other packages stability
-add-apt-repository -ry ppa:rabbitmq/rabbitmq-erlang
+retry_apt add-apt-repository -ry ppa:rabbitmq/rabbitmq-erlang
 
 # The following is required because the server attempts to write logs
 # to the `dist/tmp` directory.  This is fine in docker ducktape as the user


### PR DESCRIPTION
Wrap apt and add-apt-repository commands in `tests/docker/ducktape-deps/ocsf-server` with a `retry_apt` helper using exponential backoff (3 attempts, 30s/60s sleep) to ride out transient Canonical/Launchpad PPA outages observed in CDT.

Multiple cdt-aws and cdt-gcp nightly builds across 2026-05-03..05 failed at this exact step with `Connection refused` or `connection timed out` to `ppa.launchpadcontent.net`, or `HTTP 504` from Launchpad's REST API during `add-apt-repository`'s signing-key fetch:

| Build | Pipeline / job | Failure surface |
|---|---|---|
| [84028](https://buildkite.com/redpanda/redpanda/builds/84028) | redpanda / cdt-aws-internal-amd64 | `connection timed out` |
| [28906](https://buildkite.com/redpanda/vtools/builds/28906) | vtools / cdt-gcp-nightly-amd64 | `Connection refused` |
| [28905](https://buildkite.com/redpanda/vtools/builds/28905) | vtools / cdt-gcp-nightly-amd64 | `Connection refused` |
| [28904](https://buildkite.com/redpanda/vtools/builds/28904) | vtools / cdt-aws-nightly-amd64 | `Connection refused` |
| [28902](https://buildkite.com/redpanda/vtools/builds/28902) | vtools / cdt-aws-nightly-amd64 | `Connection refused` |
| [28900](https://buildkite.com/redpanda/vtools/builds/28900) | vtools / cdt-gcp-nightly-amd64 | `Connection refused` (downstream Elixir 1.12 vs `~> 1.14` mismatch) |
| [28894](https://buildkite.com/redpanda/vtools/builds/28894) | vtools / cdt-aws-nightly-arm64 | `connection timed out` |
| [28880](https://buildkite.com/redpanda/vtools/builds/28880) | vtools / cdt-aws-nightly-amd64 | `HTTP 504` from Launchpad REST API |

Worst-case wall-time added on the failure path: ~1m30s of sleep plus per-attempt apt time. Happy path: no observable change.

This is a transient mitigation. Eliminating the runtime dependency on Launchpad infrastructure (mirror erlang/elixir to a Redpanda-controlled host, or bake into the base AMI) is tracked separately in [DEVPROD-4198].

[DEVPROD-4196]

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes

* none

[DEVPROD-4198]: https://redpandadata.atlassian.net/browse/DEVPROD-4198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ