### PR TITLE
net/connection: declare TLS reconnect error codes locally

### DIFF
--- a/src/v/net/BUILD
+++ b/src/v/net/BUILD
@@ -55,6 +55,7 @@ redpanda_cc_library(
     implementation_deps = [
         "//src/v/bytes:iobuf",
         "//src/v/strings:utf8",
+        "@openssl",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -19,11 +19,24 @@
 #include <seastar/core/future.hh>
 #include <seastar/net/tls.hh>
 
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+
 #include <algorithm>
 #include <exception>
 #include <system_error>
 
 namespace net {
+
+// OpenSSL handshake-time reason codes that the TLS backend surfaces as the
+// raw packed value of std::error_code. Declared locally because seastar's
+// ss::tls::ERROR_* aliases for these reasons are not available on every
+// supported seastar branch.
+constexpr int err_wrong_version_number = ERR_PACK(
+  ERR_LIB_SSL, 0, SSL_R_WRONG_VERSION_NUMBER);
+constexpr int err_http_request = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_HTTP_REQUEST);
+constexpr int err_https_proxy_request = ERR_PACK(
+  ERR_LIB_SSL, 0, SSL_R_HTTPS_PROXY_REQUEST);
 
 /**
  * Identify error cases that should be quickly retried, e.g.
@@ -42,9 +55,9 @@ bool is_reconnect_error(const std::system_error& e) {
       ss::tls::ERROR_PREMATURE_TERMINATION,
       ss::tls::ERROR_DECRYPTION_FAILED,
       ss::tls::ERROR_MAC_VERIFY_FAILED,
-      ss::tls::ERROR_WRONG_VERSION_NUMBER,
-      ss::tls::ERROR_HTTP_REQUEST,
-      ss::tls::ERROR_HTTPS_PROXY_REQUEST};
+      err_wrong_version_number,
+      err_http_request,
+      err_https_proxy_request};
 
     if (e.code().category() == ss::tls::error_category()) {
         return std::ranges::any_of(


### PR DESCRIPTION
The TLS reconnect-error array in `is_reconnect_error()` referenced three
seastar-side aliases — `ss::tls::ERROR_WRONG_VERSION_NUMBER`,
`ss::tls::ERROR_HTTP_REQUEST`, `ss::tls::ERROR_HTTPS_PROXY_REQUEST` —
which are OpenSSL-specific reason codes added by the redpanda fork of
seastar. The in-progress upstream-aligned seastar rebase ships a generic
TLS implementation that does not expose these as named constants, so
relying on them ties the file to one particular seastar branch.

Replace those three references with locally-declared `constexpr int`s
built from `ERR_PACK(ERR_LIB_SSL, 0, SSL_R_*)`. The packed integer is
identical to what the OpenSSL TLS backend stores in
`std::error_code::value()`, so the reconnect behaviour is preserved
exactly. Pulls `@openssl` into `net`'s `implementation_deps` for
`<openssl/err.h>` and `<openssl/ssl.h>`, matching the pattern already
used in `src/v/config/tls_config.cc`.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none