### PR TITLE
build/deps: upgrade libxml2 to v2.15.3 (CVE-2026-6732)

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -303,7 +303,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "Ke6derljX9id+nZQqBwj+tDY/ek02Y/BFp8xSQeOgow=",
+        "bzlTransitiveDigest": "G8WfD8hokDWd3YtzbaZ3ueuQ4n91NwFz2bG/ExLjW0M=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -420,9 +420,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:libxml2.BUILD",
-              "sha256": "2769234c4fe2fab9b0b043e891c2af0f1ae51c8d4b94799472981e676ed8009e",
-              "strip_prefix": "libxml2-2.15.2",
-              "url": "https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/libxml2-v2.15.2.tar.gz"
+              "sha256": "5c6060277173270356c3f1c321a640ab629bdabc5e5ba9095b99e00759ba0c39",
+              "strip_prefix": "libxml2-2.15.3",
+              "url": "https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/libxml2-v2.15.3.tar.gz"
             }
           },
           "lksctp": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -100,9 +100,9 @@ def data_dependency():
     http_archive(
         name = "libxml2",
         build_file = "//bazel/thirdparty:libxml2.BUILD",
-        sha256 = "2769234c4fe2fab9b0b043e891c2af0f1ae51c8d4b94799472981e676ed8009e",
-        strip_prefix = "libxml2-2.15.2",
-        url = "https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/libxml2-v2.15.2.tar.gz",
+        sha256 = "5c6060277173270356c3f1c321a640ab629bdabc5e5ba9095b99e00759ba0c39",
+        strip_prefix = "libxml2-2.15.3",
+        url = "https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/libxml2-v2.15.3.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Upgrades libxml2 from 2.15.2 to 2.15.3 to fix CVE-2026-6732 (type confusion vulnerability in XSD validation with internal entity references, CVSS 7.1 High). Also affects v25.3.x (separate PR) and dev (redpanda-data/redpanda#30392).

This PR depends on redpanda-data/vtools#4233 being merged first so the artifact is available in S3.

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport

## Release Notes

### Bug Fixes

* Upgraded libxml2 to v2.15.3 to fix CVE-2026-6732 type confusion vulnerability in XSD validation.

FIXES=CORE-16201