### PR TITLE
treewide: replace deprecated http::reply::done()

### DIFF
--- a/src/v/cloud_io/tests/db_s3_imposter_fixture.cc
+++ b/src/v/cloud_io/tests/db_s3_imposter_fixture.cc
@@ -125,7 +125,7 @@ struct db_s3_imposter_fixture::handler : ss::httpd::handler_base {
             rep->set_status(ss::http::reply::status_type::bad_request);
         }
 
-        rep->done("xml");
+        rep->set_content_type("xml");
         co_return std::move(rep);
     }
 

--- a/src/v/http/tests/utils.cc
+++ b/src/v/http/tests/utils.cc
@@ -45,16 +45,15 @@ ss::future<std::unique_ptr<ss::http::reply>> flexible_function_handler::handle(
       .then([this](std::unique_ptr<ss::http::reply> rep) {
           if (
             _content_type_overrides.contains(rep->get_header("Content-Type"))) {
-              rep->done();
+              // content type already set via override; nothing to do
           } else if (_content_type == "xml") {
               // Because `application/xml` is not implemented as a mapping
               // in `http/mime_types.cc`, in order to construct a reply with
               // the `Content-Type` header set to `application/xml`, we
               // need to hard code a path here.
               rep->set_content_type("application/xml");
-              rep->done();
           } else {
-              rep->done(_content_type);
+              rep->set_content_type(_content_type);
           }
           return ss::make_ready_future<std::unique_ptr<ss::http::reply>>(
             std::move(rep));

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -397,7 +397,6 @@ public:
               std::current_exception());
             rep = serde::pb::rpc::internal_exception().handle(std::move(rep));
         }
-        rep->done();
         co_return rep;
     }
 


### PR DESCRIPTION
Seastar v26.2 deprecates `reply::done()` and `reply::done(content_type)`:

- The bare `done()` cached `_response_line`, which `write_reply()` never read,
  so it was always dead. Replacement: just remove the call.
- `done(content_type)` is equivalent to `set_content_type(content_type)` (the
  upstream impl forwards to it). Replacement: call `set_content_type()` directly.

This change replaces the four call sites in this tree accordingly. The
replacements are also valid against the currently-pinned seastar SHA, where
`_response_line` is similarly write-only and `set_content_type(string_view)`
already exists with the same signature. So this is safe to land on `dev` ahead
of the seastar v26.2 rebase — it just preempts the `-Werror` deprecation
warnings that the rebase will turn on.

Mirrors the same upstream pattern applied in seastar's own
`src/http/routes.cc`, `httpd.cc`, `file_handler.cc` etc. when the deprecation
was introduced.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none