### PR TITLE
admin: convert uuid_t to sstring for json_return_type

### DIFF
--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -3421,7 +3421,7 @@ admin_server::self_test_start_handler(std::unique_ptr<ss::http::request> req) {
               return self_test_frontend.start_test(r, ids);
           });
         vlog(adminlog.info, "Request to start self test succeeded: {}", tid);
-        co_return ss::json::json_return_type(tid);
+        co_return ss::json::json_return_type(ss::sstring(tid));
     } catch (const std::exception& ex) {
         throw ss::httpd::base_exception(
           fmt::format("Failed to start self test, reason: {}", ex),


### PR DESCRIPTION
Upcoming Seastar versions change `formatter::to_json(const sstring&)` to
`to_json(std::string_view)`. `uuid_t` provides `operator ss::sstring()`,
so the path `uuid_t -> sstring` previously matched as a single
user-defined conversion. With the new signature, reaching
`to_json(string_view)` from `uuid_t` would need two user-defined
conversions (`uuid_t -> sstring -> string_view`), which C++ disallows,
and `uuid_t` isn't an `input_range` either, so no overload matches.

Force the conversion at the call site. Compatible with both the current
pinned Seastar (resolves to `to_json(const sstring&)`) and the rebased
Seastar (resolves to `to_json(std::string_view)`).

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none