### PR TITLE
bazel: Triple bazel repo download retries

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,6 +5,10 @@ common --extra_toolchains=@current_llvm_toolchain//:all
 # flakiness due to Github
 startup --experimental_remote_repo_contents_cache
 
+# Triple repo downloader retries to try working around github flakiness.
+common --experimental_repository_downloader_retries=15
+common --http_connector_attempts=24
+
 # Bazel 9 removes native C++ rule symbols. Autoload them for external rulesets
 # that have not migrated all generated BUILD/Starlark files to explicit loads.
 common --incompatible_autoload_externally=+@rules_cc


### PR DESCRIPTION
Try to workaround github flakiness.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes


* none

