### PR TITLE
schema_registry/protobuf: fix MESSAGE_REMOVED for removed map fields

### DIFF
--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -771,6 +771,9 @@ struct compatibility_checker {
 
         for (int i = 0; i < writer->nested_type_count(); ++i) {
             auto w = writer->nested_type(i);
+            if (w->options().has_map_entry()) {
+                continue;
+            }
             auto r = reader->FindNestedTypeByName(w->name());
             if (!r) {
                 compat_result.emplace<proto_incompatibility>(

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -1830,6 +1830,71 @@ service FooService {
 )"));
 }
 
+SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_remove_map_field) {
+    constexpr std::string_view with_map = R"(syntax = "proto3";
+
+message Product {
+  string name = 1;
+  map<string, string> tags = 10;
+}
+)";
+    constexpr std::string_view without_map = R"(syntax = "proto3";
+
+message Product {
+  string name = 1;
+}
+)";
+
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::backward, without_map, with_map));
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::backward_transitive, without_map, with_map));
+    BOOST_REQUIRE(
+      check_compatible(pps::compatibility_level::full, without_map, with_map));
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::full_transitive, without_map, with_map));
+
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::forward, with_map, without_map));
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::forward_transitive, with_map, without_map));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_map_in_nested_message) {
+    constexpr std::string_view with_map = R"(syntax = "proto3";
+
+message Outer {
+  message Inner {
+    string id = 1;
+    map<string, string> tags = 2;
+  }
+  Inner inner = 1;
+}
+)";
+    constexpr std::string_view without_map = R"(syntax = "proto3";
+
+message Outer {
+  message Inner {
+    string id = 1;
+  }
+  Inner inner = 1;
+}
+)";
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::backward, without_map, with_map));
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::backward_transitive, without_map, with_map));
+    BOOST_REQUIRE(
+      check_compatible(pps::compatibility_level::full, without_map, with_map));
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::full_transitive, without_map, with_map));
+
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::forward, with_map, without_map));
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::forward_transitive, with_map, without_map));
+}
+
 SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_message_removed) {
     BOOST_REQUIRE(!check_compatible(
       pps::compatibility_level::backward,


### PR DESCRIPTION
Protobuf map fields are represented in descriptors as compiler-generated
nested `*Entry` message types. Redpanda schema registry was comparing those map entry types
as regular nested messages during compatibility checks, so removing a map
field could incorrectly fail with `MESSAGE_REMOVED`

Skip protobuf map entry types when checking nested message compatibility.
This matches Confluent Schema Registry behavior and fixes map field removal
compatibility for all protobuf map key/value combinations.

Fixes #30374

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes

### Bug Fixes

* Schema Registry: fixed protobuf compatibility checks incorrectly failing
  with `MESSAGE_REMOVED` when a map field is removed.