### PR TITLE
[v26.1.x] CORE-14944 ACLs: replace vector with chunked_vector

### DIFF
--- a/src/v/cluster/cloud_metadata/cluster_recovery_backend.cc
+++ b/src/v/cluster/cloud_metadata/cluster_recovery_backend.cc
@@ -221,7 +221,7 @@ ss::future<cluster::errc> cluster_recovery_backend::do_action(
     case recovery_stage::recovered_acls: {
         retry_chain_node acls_retry(&parent_retry);
         // TODO: batch this up.
-        std::vector<security::acl_binding> acls;
+        chunked_vector<security::acl_binding> acls;
         for (size_t i = 0; i < actions.acls.size(); i++) {
             acls.emplace_back(std::move(actions.acls[i]));
         }

--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -33,6 +33,8 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/when_all.hh>
 
+#include <concepts>
+
 namespace cluster {
 
 using command_type = named_type<int8_t, struct command_type_tag>;
@@ -45,6 +47,21 @@ enum class serde_opts {
     // when all nodes are on a Redpanda version that supports serde.
     serde_only = 1,
 };
+
+// Deep-copies cmd. Prefers an explicit copy() method, falls back to the copy
+// ctor. The copy() check must come first: is_copy_constructible_v is true even
+// for types whose copy ctor only fails at instantiation, e.g. std::vector of a
+// move-only element.
+template<typename T>
+T copy_cmd(const T& cmd) {
+    if constexpr (requires {
+                      { cmd.copy() } -> std::same_as<T>;
+                  }) {
+        return cmd.copy();
+    } else {
+        return T(cmd);
+    }
+}
 
 // Controller state updates are represented in terms of commands. Each
 // command represent different type of action that is going to be executed
@@ -82,6 +99,11 @@ struct controller_command {
     controller_command(K k, V v)
       : key(std::move(k))
       , value(std::move(v)) {}
+
+    // Deep copy. Required because some command data types are move-only.
+    controller_command copy() const {
+        return controller_command(copy_cmd(key), copy_cmd(value));
+    }
 
     key_t key; // we use key to leverage kafka key based compaction
     value_t value;

--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -602,7 +602,9 @@ struct deserializer {
                 auto results = co_await ss::when_all_succeed(
                   reflection::async_adl<key_t>{}.from(k_parser),
                   reflection::async_adl<value_t>{}.from(v_parser));
-                co_return Cmd(std::get<0>(results), std::get<1>(results));
+                co_return Cmd(
+                  std::move(std::get<0>(results)),
+                  std::move(std::get<1>(results)));
             }
         }
         vassert(use_serde, "Requested to ADL serialize a serde-only type");

--- a/src/v/cluster/security_frontend.cc
+++ b/src/v/cluster/security_frontend.cc
@@ -80,6 +80,16 @@ static inline cluster::errc map_errc(std::error_code ec) {
     return errc::replication_error;
 }
 
+static chunked_vector<delete_acls_result>
+make_delete_acls_error_results(size_t n, errc err) {
+    chunked_vector<delete_acls_result> results;
+    results.reserve(n);
+    for (size_t i = 0; i < n; ++i) {
+        results.emplace_back(delete_acls_result{.error = err});
+    }
+    return results;
+}
+
 security_frontend::security_frontend(
   model::node_id self,
   controller* controller,
@@ -276,8 +286,9 @@ ss::future<std::vector<errc>> security_frontend::do_create_acls(
     co_return result;
 }
 
-ss::future<std::vector<delete_acls_result>> security_frontend::do_delete_acls(
-  std::vector<security::acl_binding_filter> filters,
+ss::future<chunked_vector<delete_acls_result>>
+security_frontend::do_delete_acls(
+  chunked_vector<security::acl_binding_filter> filters,
   model::timeout_clock::duration timeout) {
     /*
      * The removal is performed as a dry run to create the set of binding that
@@ -309,7 +320,7 @@ ss::future<std::vector<delete_acls_result>> security_frontend::do_delete_acls(
         err = errc::replication_error;
     }
 
-    std::vector<delete_acls_result> res;
+    chunked_vector<delete_acls_result> res;
 
     if (err == errc::success) {
         res.reserve(removed_bindings.size());
@@ -323,30 +334,23 @@ ss::future<std::vector<delete_acls_result>> security_frontend::do_delete_acls(
         co_return res;
     }
 
-    res.assign(
-      removed_bindings.size(),
-      delete_acls_result{
-        .error = err,
-      });
+    res = make_delete_acls_error_results(removed_bindings.size(), err);
 
     co_return res;
 }
 
-ss::future<std::vector<delete_acls_result>> security_frontend::delete_acls(
-  std::vector<security::acl_binding_filter> filters,
+ss::future<chunked_vector<delete_acls_result>> security_frontend::delete_acls(
+  chunked_vector<security::acl_binding_filter> filters,
   model::timeout_clock::duration timeout) {
     if (unlikely(filters.empty())) {
-        co_return std::vector<delete_acls_result>{};
+        co_return chunked_vector<delete_acls_result>{};
     }
 
     auto leader = _leaders.local().get_leader(model::controller_ntp);
 
     if (!leader) {
-        co_return std::vector<delete_acls_result>(
-          filters.size(),
-          delete_acls_result{
-            .error = errc::no_leader_controller,
-          });
+        co_return make_delete_acls_error_results(
+          filters.size(), errc::no_leader_controller);
     }
 
     if (leader == _self) {
@@ -357,10 +361,10 @@ ss::future<std::vector<delete_acls_result>> security_frontend::delete_acls(
       leader.value(), std::move(filters), timeout);
 }
 
-ss::future<std::vector<delete_acls_result>>
+ss::future<chunked_vector<delete_acls_result>>
 security_frontend::dispatch_delete_acls_to_leader(
   model::node_id leader,
-  std::vector<security::acl_binding_filter> filters,
+  chunked_vector<security::acl_binding_filter> filters,
   model::timeout_clock::duration timeout) {
     const auto num_filters = filters.size();
     return _connections.local()
@@ -379,11 +383,8 @@ security_frontend::dispatch_delete_acls_to_leader(
       .then(&rpc::get_ctx_data<delete_acls_reply>)
       .then([num_filters](result<delete_acls_reply> r) {
           if (r.has_error()) {
-              return std::vector<delete_acls_result>(
-                num_filters,
-                delete_acls_result{
-                  .error = map_errc(r.error()),
-                });
+              return make_delete_acls_error_results(
+                num_filters, map_errc(r.error()));
           }
           return std::move(r.value().results);
       });

--- a/src/v/cluster/security_frontend.cc
+++ b/src/v/cluster/security_frontend.cc
@@ -174,7 +174,7 @@ ss::future<std::error_code> security_frontend::update_role(
 }
 
 ss::future<std::vector<errc>> security_frontend::create_acls(
-  std::vector<security::acl_binding> bindings,
+  chunked_vector<security::acl_binding> bindings,
   model::timeout_clock::duration timeout) {
     if (unlikely(bindings.empty())) {
         co_return std::vector<errc>{};
@@ -197,7 +197,7 @@ ss::future<std::vector<errc>> security_frontend::create_acls(
 
 ss::future<std::vector<errc>> security_frontend::dispatch_create_acls_to_leader(
   model::node_id leader,
-  std::vector<security::acl_binding> bindings,
+  chunked_vector<security::acl_binding> bindings,
   model::timeout_clock::duration timeout) {
     auto num_bindings = bindings.size();
     return _connections.local()
@@ -223,7 +223,7 @@ ss::future<std::vector<errc>> security_frontend::dispatch_create_acls_to_leader(
 }
 
 ss::future<std::vector<errc>> security_frontend::do_create_acls(
-  std::vector<security::acl_binding> bindings,
+  chunked_vector<security::acl_binding> bindings,
   model::timeout_clock::duration timeout) {
     const auto num_bindings = bindings.size();
 

--- a/src/v/cluster/security_frontend.cc
+++ b/src/v/cluster/security_frontend.cc
@@ -90,6 +90,15 @@ make_delete_acls_error_results(size_t n, errc err) {
     return results;
 }
 
+static chunked_vector<errc> make_create_acls_error_results(size_t n, errc err) {
+    chunked_vector<errc> results;
+    results.reserve(n);
+    for (size_t i = 0; i < n; ++i) {
+        results.push_back(err);
+    }
+    return results;
+}
+
 security_frontend::security_frontend(
   model::node_id self,
   controller* controller,
@@ -173,17 +182,17 @@ ss::future<std::error_code> security_frontend::update_role(
     co_return co_await replicate_and_wait(_stm, _as, std::move(cmd), tout);
 }
 
-ss::future<std::vector<errc>> security_frontend::create_acls(
+ss::future<chunked_vector<errc>> security_frontend::create_acls(
   chunked_vector<security::acl_binding> bindings,
   model::timeout_clock::duration timeout) {
     if (unlikely(bindings.empty())) {
-        co_return std::vector<errc>{};
+        co_return chunked_vector<errc>{};
     }
 
     auto leader = _leaders.local().get_leader(model::controller_ntp);
 
     if (!leader) {
-        co_return std::vector<errc>(
+        co_return make_create_acls_error_results(
           bindings.size(), errc::no_leader_controller);
     }
 
@@ -195,7 +204,8 @@ ss::future<std::vector<errc>> security_frontend::create_acls(
       leader.value(), std::move(bindings), timeout);
 }
 
-ss::future<std::vector<errc>> security_frontend::dispatch_create_acls_to_leader(
+ss::future<chunked_vector<errc>>
+security_frontend::dispatch_create_acls_to_leader(
   model::node_id leader,
   chunked_vector<security::acl_binding> bindings,
   model::timeout_clock::duration timeout) {
@@ -216,13 +226,14 @@ ss::future<std::vector<errc>> security_frontend::dispatch_create_acls_to_leader(
       .then(&rpc::get_ctx_data<create_acls_reply>)
       .then([num_bindings](result<create_acls_reply> r) {
           if (r.has_error()) {
-              return std::vector<errc>(num_bindings, map_errc(r.error()));
+              return make_create_acls_error_results(
+                num_bindings, map_errc(r.error()));
           }
           return std::move(r.value().results);
       });
 }
 
-ss::future<std::vector<errc>> security_frontend::do_create_acls(
+ss::future<chunked_vector<errc>> security_frontend::do_create_acls(
   chunked_vector<security::acl_binding> bindings,
   model::timeout_clock::duration timeout) {
     const auto num_bindings = bindings.size();
@@ -281,9 +292,7 @@ ss::future<std::vector<errc>> security_frontend::do_create_acls(
         }
     }
 
-    std::vector<errc> result;
-    result.assign(num_bindings, err);
-    co_return result;
+    co_return make_create_acls_error_results(num_bindings, err);
 }
 
 ss::future<chunked_vector<delete_acls_result>>

--- a/src/v/cluster/security_frontend.h
+++ b/src/v/cluster/security_frontend.h
@@ -166,7 +166,7 @@ public:
      * command to the leader node automatically.
      */
     ss::future<std::vector<errc>> create_acls(
-      std::vector<security::acl_binding>, model::timeout_clock::duration);
+      chunked_vector<security::acl_binding>, model::timeout_clock::duration);
 
     /**
      * Remove ACL bindings matching the provided filters from the authorizer
@@ -214,11 +214,11 @@ private:
       get_leader_committed(model::timeout_clock::duration);
 
     ss::future<std::vector<errc>> do_create_acls(
-      std::vector<security::acl_binding>, model::timeout_clock::duration);
+      chunked_vector<security::acl_binding>, model::timeout_clock::duration);
 
     ss::future<std::vector<errc>> dispatch_create_acls_to_leader(
       model::node_id,
-      std::vector<security::acl_binding>,
+      chunked_vector<security::acl_binding>,
       model::timeout_clock::duration);
 
     ss::future<chunked_vector<delete_acls_result>> do_delete_acls(

--- a/src/v/cluster/security_frontend.h
+++ b/src/v/cluster/security_frontend.h
@@ -160,12 +160,13 @@ public:
      * Add ACL bindings to the authorizer
      *
      * Returns:
-     *   A vector of cluster::errc, one for each of the requested bindings.
+     *   A chunked_vector of cluster::errc, one for each of the requested
+     *   bindings.
      *
      * May be called from any node; handles routing the underlying controller
      * command to the leader node automatically.
      */
-    ss::future<std::vector<errc>> create_acls(
+    ss::future<chunked_vector<errc>> create_acls(
       chunked_vector<security::acl_binding>, model::timeout_clock::duration);
 
     /**
@@ -213,10 +214,10 @@ private:
     ss::future<result<model::offset>>
       get_leader_committed(model::timeout_clock::duration);
 
-    ss::future<std::vector<errc>> do_create_acls(
+    ss::future<chunked_vector<errc>> do_create_acls(
       chunked_vector<security::acl_binding>, model::timeout_clock::duration);
 
-    ss::future<std::vector<errc>> dispatch_create_acls_to_leader(
+    ss::future<chunked_vector<errc>> dispatch_create_acls_to_leader(
       model::node_id,
       chunked_vector<security::acl_binding>,
       model::timeout_clock::duration);

--- a/src/v/cluster/security_frontend.h
+++ b/src/v/cluster/security_frontend.h
@@ -13,6 +13,7 @@
 
 #include "cluster/controller_stm.h"
 #include "cluster/fwd.h"
+#include "container/chunked_vector.h"
 #include "model/timeout_clock.h"
 #include "security/scram_credential.h"
 
@@ -171,14 +172,14 @@ public:
      * Remove ACL bindings matching the provided filters from the authorizer
      *
      * Returns:
-     *   std::vector<delete_acls_result> (i.e. {cluster::errc, acl_binding})
+     *   chunked_vector<delete_acls_result> (i.e. {cluster::errc, acl_binding})
      *     one for each binding that matched one of the provided filters
      *
      * May be called from any node; handles routing the underlying controller
      * command to the leader node automatically.
      */
-    ss::future<std::vector<delete_acls_result>> delete_acls(
-      std::vector<security::acl_binding_filter>,
+    ss::future<chunked_vector<delete_acls_result>> delete_acls(
+      chunked_vector<security::acl_binding_filter>,
       model::timeout_clock::duration);
 
     /**
@@ -220,14 +221,15 @@ private:
       std::vector<security::acl_binding>,
       model::timeout_clock::duration);
 
-    ss::future<std::vector<delete_acls_result>> do_delete_acls(
-      std::vector<security::acl_binding_filter>,
+    ss::future<chunked_vector<delete_acls_result>> do_delete_acls(
+      chunked_vector<security::acl_binding_filter>,
       model::timeout_clock::duration);
 
-    ss::future<std::vector<delete_acls_result>> dispatch_delete_acls_to_leader(
-      model::node_id,
-      std::vector<security::acl_binding_filter>,
-      model::timeout_clock::duration);
+    ss::future<chunked_vector<delete_acls_result>>
+      dispatch_delete_acls_to_leader(
+        model::node_id,
+        chunked_vector<security::acl_binding_filter>,
+        model::timeout_clock::duration);
 
     model::node_id _self;
     controller* _controller;

--- a/src/v/cluster/security_manager.cc
+++ b/src/v/cluster/security_manager.cc
@@ -177,8 +177,8 @@ ss::future<std::error_code> security_manager::dispatch_updates_to_cores(
           ret.reserve(ss::smp::count);
           return ss::parallel_for_each(
                    boost::irange(0, (int)ss::smp::count),
-                   [&ret, cmd = std::move(cmd), &service](int shard) mutable {
-                       return do_apply(shard, cmd, service)
+                   [&ret, &cmd, &service](int shard) {
+                       return do_apply(shard, copy_cmd(cmd), service)
                          .then([&ret](std::error_code r) { ret.push_back(r); });
                    })
             .then([&ret] { return std::move(ret); })

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -266,7 +266,7 @@ service::create_acls(create_acls_request request, rpc::streaming_context&) {
                  return _security_frontend.local().create_acls(
                    std::move(r.data.bindings), r.timeout);
              })
-      .then([](std::vector<errc> results) {
+      .then([](chunked_vector<errc> results) {
           return create_acls_reply{.results = std::move(results)};
       });
 }

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -279,7 +279,7 @@ service::delete_acls(delete_acls_request request, rpc::streaming_context&) {
                  return _security_frontend.local().delete_acls(
                    std::move(r.data.filters), r.timeout);
              })
-      .then([](std::vector<delete_acls_result> results) {
+      .then([](chunked_vector<delete_acls_result> results) {
           return delete_acls_reply{.results = std::move(results)};
       });
 }

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -924,7 +924,7 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         for (auto i = 0, mi = random_generators::get_int(5, 25); i < mi; ++i) {
             data.bindings.push_back(tests::random_acl_binding());
         }
-        roundtrip_test(data);
+        roundtrip_test(std::move(data));
     }
     {
         cluster::delete_acls_cmd_data data;
@@ -1488,8 +1488,8 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
             create_acls_data.bindings.push_back(tests::random_acl_binding());
         }
         cluster::create_acls_request data{
-          create_acls_data, random_timeout_clock_duration()};
-        roundtrip_test(data);
+          std::move(create_acls_data), random_timeout_clock_duration()};
+        roundtrip_test(std::move(data));
     }
     {
         std::vector<cluster::errc> results;

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -468,22 +468,10 @@ struct adl<partition_status_v1> {
 };
 } // namespace reflection
 
-/*
- * Specialize for types that cannot be copied.
- */
 template<typename T>
 std::pair<T, T> compat_copy(T t) {
-    return {t, t};
-}
-
-template<typename T>
-concept ExplicitCopyable = requires(T a) {
-    { a.copy() } -> std::same_as<T>;
-};
-
-template<ExplicitCopyable T>
-std::pair<T, T> compat_copy(T t) {
-    return {t.copy(), std::move(t)};
+    auto copy = cluster::copy_cmd(t);
+    return {std::move(copy), std::move(t)};
 }
 
 template<typename T>
@@ -945,7 +933,7 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
               tests::random_acl_binding_filter(
                 tests::serialization_format::serde));
         }
-        roundtrip_test(data);
+        roundtrip_test(std::move(data));
     }
     {
         cluster::config_status status;
@@ -1519,37 +1507,37 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
                 tests::serialization_format::serde));
         }
         cluster::delete_acls_request data{
-          delete_acls_data, random_timeout_clock_duration()};
-        roundtrip_test(data);
+          std::move(delete_acls_data), random_timeout_clock_duration()};
+        roundtrip_test(std::move(data));
     }
     {
-        std::vector<security::acl_binding> bindings;
+        chunked_vector<security::acl_binding> bindings;
         for (auto i = 0, mi = random_generators::get_int(20); i < mi; ++i) {
             bindings.push_back(tests::random_acl_binding());
         }
         cluster::delete_acls_result data{
           .error = cluster::errc::join_request_dispatch_error,
-          .bindings = bindings,
+          .bindings = std::move(bindings),
         };
-        roundtrip_test(data);
+        roundtrip_test(std::move(data));
     }
     {
-        std::vector<cluster::delete_acls_result> results;
+        chunked_vector<cluster::delete_acls_result> results;
         for (auto i = 0, mi = random_generators::get_int(20); i < mi; ++i) {
-            std::vector<security::acl_binding> bindings;
+            chunked_vector<security::acl_binding> bindings;
             for (auto j = 0, mj = random_generators::get_int(20); j < mj; ++j) {
                 bindings.push_back(tests::random_acl_binding());
             }
             results.push_back(
               cluster::delete_acls_result{
                 .error = cluster::errc::join_request_dispatch_error,
-                .bindings = bindings,
+                .bindings = std::move(bindings),
               });
         }
         cluster::delete_acls_reply data{
-          .results = results,
+          .results = std::move(results),
         };
-        roundtrip_test(data);
+        roundtrip_test(std::move(data));
     }
     {
         cluster::decommission_node_request data{
@@ -2047,50 +2035,48 @@ ss::future<model::record_batch> serialize_cmd(Cmd cmd) {
       });
 }
 
-template<typename Cmd, typename Key, typename Value>
-void serde_roundtrip_cmd(Key key, Value value) {
-    auto cmd = Cmd(std::move(key), std::move(value));
-    auto batch = cluster::serde_serialize_cmd(cmd);
+template<typename Cmd>
+void serde_roundtrip_cmd(Cmd cmd) {
+    auto expected = cluster::copy_cmd(cmd);
+    auto batch = cluster::serde_serialize_cmd(std::move(cmd));
     auto deserialized = cluster::deserialize(
                           std::move(batch), cluster::make_commands_list<Cmd>())
                           .get();
-
-    auto deserialized_cmd = std::get<Cmd>(deserialized);
-
-    BOOST_REQUIRE(deserialized_cmd.key == cmd.key);
-    if constexpr (std::equality_comparable<Value>) {
-        BOOST_REQUIRE(deserialized_cmd.value == cmd.value);
+    auto deserialized_cmd = std::get<Cmd>(std::move(deserialized));
+    BOOST_REQUIRE(deserialized_cmd.key == expected.key);
+    if constexpr (std::equality_comparable<typename Cmd::value_t>) {
+        BOOST_REQUIRE(deserialized_cmd.value == expected.value);
     }
 }
 
-template<typename Cmd, typename Key, typename Value>
-void adl_roundtrip_cmd(Key key, Value value) {
-    auto cmd = Cmd(std::move(key), std::move(value));
-    auto batch = serialize_cmd(cmd).get();
+template<typename Cmd>
+void adl_roundtrip_cmd(Cmd cmd) {
+    auto expected = cluster::copy_cmd(cmd);
+    auto batch = serialize_cmd(std::move(cmd)).get();
     auto deserialized = cluster::deserialize(
                           std::move(batch), cluster::make_commands_list<Cmd>())
                           .get();
-    auto deserialized_cmd = std::get<Cmd>(deserialized);
-
-    BOOST_REQUIRE_EQUAL(deserialized_cmd.key, cmd.key);
-
-    if constexpr (std::equality_comparable<Value>) {
-        BOOST_REQUIRE(deserialized_cmd.value == cmd.value);
+    auto deserialized_cmd = std::get<Cmd>(std::move(deserialized));
+    BOOST_REQUIRE(deserialized_cmd.key == expected.key);
+    if constexpr (std::equality_comparable<typename Cmd::value_t>) {
+        BOOST_REQUIRE(deserialized_cmd.value == expected.value);
     }
 }
 
 template<typename Cmd, typename Key, typename Value>
 void roundtrip_cmd(Key key, Value value) {
-    adl_roundtrip_cmd<Cmd>(key, value);
-    serde_roundtrip_cmd<Cmd>(key, value);
+    auto cmd = Cmd(std::move(key), std::move(value));
+    adl_roundtrip_cmd(cluster::copy_cmd(cmd));
+    serde_roundtrip_cmd(std::move(cmd));
 }
 
 SEASTAR_THREAD_TEST_CASE(commands_serialization_test) {
     for (int i = 0; i < 50; ++i) {
-        serde_roundtrip_cmd<cluster::create_topic_cmd>(
-          model::random_topic_namespace(),
-          cluster::topic_configuration_assignment(
-            random_topic_configuration(), random_partition_assignments()));
+        serde_roundtrip_cmd(
+          cluster::create_topic_cmd(
+            model::random_topic_namespace(),
+            cluster::topic_configuration_assignment(
+              random_topic_configuration(), random_partition_assignments())));
 
         roundtrip_cmd<cluster::delete_topic_cmd>(
           model::random_topic_namespace(), model::random_topic_namespace());

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1492,12 +1492,11 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         roundtrip_test(std::move(data));
     }
     {
-        std::vector<cluster::errc> results;
-        for (int i = 0, mi = random_generators::get_int(20); i < mi; i++) {
-            results.push_back(cluster::errc::invalid_node_operation);
-        }
         cluster::create_acls_reply data;
-        roundtrip_test(data);
+        for (int i = 0, mi = random_generators::get_int(20); i < mi; i++) {
+            data.results.push_back(cluster::errc::invalid_node_operation);
+        }
+        roundtrip_test(std::move(data));
     }
     {
         cluster::delete_acls_cmd_data delete_acls_data{};

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -1212,7 +1212,7 @@ adl<cluster::create_acls_cmd_data>::from(iobuf_parser& in) {
       "Unexpected create acls cmd version {} (expected {})",
       version,
       cluster::create_acls_cmd_data::current_version);
-    auto bindings = adl<std::vector<security::acl_binding>>().from(in);
+    auto bindings = adl<chunked_vector<security::acl_binding>>().from(in);
     return cluster::create_acls_cmd_data{
       .bindings = std::move(bindings),
     };

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -1232,7 +1232,7 @@ adl<cluster::delete_acls_cmd_data>::from(iobuf_parser& in) {
       "Unexpected delete acls cmd version {} (expected {})",
       version,
       cluster::delete_acls_cmd_data::current_version);
-    auto filters = adl<std::vector<security::acl_binding_filter>>().from(in);
+    auto filters = adl<chunked_vector<security::acl_binding_filter>>().from(in);
     return cluster::delete_acls_cmd_data{
       .filters = std::move(filters),
     };

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1510,7 +1510,13 @@ struct delete_acls_cmd_data
       serde::version<0>,
       serde::compat_version<0>> {
     static constexpr int8_t current_version = 1;
-    std::vector<security::acl_binding_filter> filters;
+    chunked_vector<security::acl_binding_filter> filters;
+
+    delete_acls_cmd_data copy() const {
+        return delete_acls_cmd_data{
+          .filters = filters.copy(),
+        };
+    }
 
     friend bool operator==(
       const delete_acls_cmd_data&, const delete_acls_cmd_data&) = default;
@@ -1531,7 +1537,14 @@ struct delete_acls_result
       serde::version<0>,
       serde::compat_version<0>> {
     errc error;
-    std::vector<security::acl_binding> bindings;
+    chunked_vector<security::acl_binding> bindings;
+
+    delete_acls_result copy() const {
+        return delete_acls_result{
+          .error = error,
+          .bindings = bindings.copy(),
+        };
+    }
 
     friend bool
     operator==(const delete_acls_result&, const delete_acls_result&) = default;
@@ -1559,6 +1572,10 @@ struct delete_acls_request
       : data(std::move(data))
       , timeout(timeout) {}
 
+    delete_acls_request copy() const {
+        return delete_acls_request{data.copy(), timeout};
+    }
+
     friend bool operator==(
       const delete_acls_request&, const delete_acls_request&) = default;
 
@@ -1574,7 +1591,16 @@ struct delete_acls_request
 struct delete_acls_reply
   : serde::
       envelope<delete_acls_reply, serde::version<0>, serde::compat_version<0>> {
-    std::vector<delete_acls_result> results;
+    chunked_vector<delete_acls_result> results;
+
+    delete_acls_reply copy() const {
+        chunked_vector<delete_acls_result> results_copy;
+        results_copy.reserve(results.size());
+        for (const auto& r : results) {
+            results_copy.push_back(r.copy());
+        }
+        return delete_acls_reply{.results = std::move(results_copy)};
+    }
 
     friend bool
     operator==(const delete_acls_reply&, const delete_acls_reply&) = default;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1500,7 +1500,11 @@ struct create_acls_request
 struct create_acls_reply
   : serde::
       envelope<create_acls_reply, serde::version<0>, serde::compat_version<0>> {
-    std::vector<errc> results;
+    chunked_vector<errc> results;
+
+    create_acls_reply copy() const {
+        return create_acls_reply{.results = results.copy()};
+    }
 
     friend bool
     operator==(const create_acls_reply&, const create_acls_reply&) = default;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1447,7 +1447,13 @@ struct create_acls_cmd_data
       serde::version<0>,
       serde::compat_version<0>> {
     static constexpr int8_t current_version = 1;
-    std::vector<security::acl_binding> bindings;
+    chunked_vector<security::acl_binding> bindings;
+
+    create_acls_cmd_data copy() const {
+        return create_acls_cmd_data{
+          .bindings = bindings.copy(),
+        };
+    }
 
     friend bool operator==(
       const create_acls_cmd_data&, const create_acls_cmd_data&) = default;
@@ -1474,6 +1480,10 @@ struct create_acls_request
       create_acls_cmd_data data, model::timeout_clock::duration timeout)
       : data(std::move(data))
       , timeout(timeout) {}
+
+    create_acls_request copy() const {
+        return create_acls_request{data.copy(), timeout};
+    }
 
     friend bool operator==(
       const create_acls_request&, const create_acls_request&) = default;

--- a/src/v/cluster_link/BUILD
+++ b/src/v/cluster_link/BUILD
@@ -172,6 +172,7 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         ":logger",
+        "//src/v/container:chunked_vector",
         "//src/v/kafka/server:security",
         "//src/v/security",
     ],

--- a/src/v/cluster_link/deps.cc
+++ b/src/v/cluster_link/deps.cc
@@ -26,7 +26,7 @@ public:
     explicit security_impl(ss::sharded<cluster::security_frontend>* security_fe)
       : _security_fe(security_fe) {}
     ss::future<std::vector<cluster::errc>> create_acls(
-      std::vector<security::acl_binding> bindings,
+      chunked_vector<security::acl_binding> bindings,
       ::model::timeout_clock::duration timeout) final {
         return _security_fe->local().create_acls(std::move(bindings), timeout);
     }

--- a/src/v/cluster_link/deps.cc
+++ b/src/v/cluster_link/deps.cc
@@ -25,7 +25,7 @@ class security_impl : public security_service {
 public:
     explicit security_impl(ss::sharded<cluster::security_frontend>* security_fe)
       : _security_fe(security_fe) {}
-    ss::future<std::vector<cluster::errc>> create_acls(
+    ss::future<chunked_vector<cluster::errc>> create_acls(
       chunked_vector<security::acl_binding> bindings,
       ::model::timeout_clock::duration timeout) final {
         return _security_fe->local().create_acls(std::move(bindings), timeout);

--- a/src/v/cluster_link/deps.h
+++ b/src/v/cluster_link/deps.h
@@ -192,7 +192,7 @@ public:
     static std::unique_ptr<security_service>
     make_default(ss::sharded<cluster::security_frontend>*);
 
-    virtual ss::future<std::vector<cluster::errc>> create_acls(
+    virtual ss::future<chunked_vector<cluster::errc>> create_acls(
       chunked_vector<security::acl_binding>,
       ::model::timeout_clock::duration) = 0;
 };

--- a/src/v/cluster_link/deps.h
+++ b/src/v/cluster_link/deps.h
@@ -14,6 +14,7 @@
 #include "cluster_link/errc.h"
 #include "cluster_link/fwd.h"
 #include "cluster_link/model/types.h"
+#include "container/chunked_vector.h"
 #include "kafka/client/cluster.h"
 #include "kafka/data/rpc/deps.h"
 #include "kafka/data/rpc/fwd.h"
@@ -192,7 +193,8 @@ public:
     make_default(ss::sharded<cluster::security_frontend>*);
 
     virtual ss::future<std::vector<cluster::errc>> create_acls(
-      std::vector<security::acl_binding>, ::model::timeout_clock::duration) = 0;
+      chunked_vector<security::acl_binding>,
+      ::model::timeout_clock::duration) = 0;
 };
 
 class kafka_rpc_client_service {

--- a/src/v/cluster_link/security_migrator.cc
+++ b/src/v/cluster_link/security_migrator.cc
@@ -218,7 +218,7 @@ to_acl_bindings(const kafka::describe_acls_resource& r) {
       r.name,
       kafka::details::to_pattern_type(r.pattern_type));
 
-    std::vector<security::acl_entry> entries;
+    chunked_vector<security::acl_entry> entries;
     entries.reserve(r.acls.size());
 
     std::ranges::transform(

--- a/src/v/cluster_link/security_migrator.cc
+++ b/src/v/cluster_link/security_migrator.cc
@@ -206,7 +206,7 @@ filter_to_request_data(const model::acl_filter& filter) {
     return data;
 }
 
-std::vector<security::acl_binding>
+chunked_vector<security::acl_binding>
 to_acl_bindings(const kafka::describe_acls_resource& r) {
     if (r.name.empty()) {
         throw security::acl_conversion_error("Empty resource name");
@@ -232,7 +232,7 @@ to_acl_bindings(const kafka::describe_acls_resource& r) {
             kafka::details::to_acl_permission(acl.permission_type));
       });
 
-    std::vector<security::acl_binding> bindings;
+    chunked_vector<security::acl_binding> bindings;
     bindings.reserve(entries.size());
     std::ranges::transform(
       entries,
@@ -244,9 +244,9 @@ to_acl_bindings(const kafka::describe_acls_resource& r) {
     return bindings;
 }
 
-std::vector<security::acl_binding> to_acl_bindings(
+chunked_vector<security::acl_binding> to_acl_bindings(
   const chunked_vector<kafka::describe_acls_resource>& resources) {
-    std::vector<security::acl_binding> bindings;
+    chunked_vector<security::acl_binding> bindings;
     bindings.reserve(resources.size());
     for (const auto& r : resources) {
         auto resource_bindings = to_acl_bindings(r);
@@ -382,7 +382,7 @@ security_migrator::run_impl(ss::abort_source& as) {
           .reason = "Security migrator task run successfully"};
     }
 
-    std::vector<security::acl_binding> bindings;
+    chunked_vector<security::acl_binding> bindings;
     try {
         bindings = to_acl_bindings(acls);
     } catch (const std::exception& e) {

--- a/src/v/cluster_link/tests/BUILD
+++ b/src/v/cluster_link/tests/BUILD
@@ -16,6 +16,7 @@ redpanda_test_cc_library(
         "//src/v/cluster_link:utils",
         "//src/v/cluster_link/replication/tests:deps_test_impl",
         "//src/v/config",
+        "//src/v/container:chunked_vector",
         "//src/v/kafka/client/test:cluster_mock",
         "//src/v/kafka/data/rpc",
         "//src/v/kafka/data/rpc/test:test_deps",

--- a/src/v/cluster_link/tests/deps.h
+++ b/src/v/cluster_link/tests/deps.h
@@ -17,6 +17,7 @@
 #include "cluster_link/replication/tests/deps_test_impl.h"
 #include "cluster_link/utils.h"
 #include "config/mock_property.h"
+#include "container/chunked_vector.h"
 #include "kafka/client/test/cluster_mock.h"
 #include "kafka/data/rpc/deps.h"
 #include "kafka/data/rpc/test/deps.h"
@@ -580,7 +581,7 @@ private:
 class fake_security_service : public security_service {
 public:
     ss::future<std::vector<cluster::errc>> create_acls(
-      std::vector<security::acl_binding> bindings,
+      chunked_vector<security::acl_binding> bindings,
       ::model::timeout_clock::duration) final {
         std::vector<cluster::errc> results;
         results.reserve(bindings.size());

--- a/src/v/cluster_link/tests/deps.h
+++ b/src/v/cluster_link/tests/deps.h
@@ -580,10 +580,10 @@ private:
 
 class fake_security_service : public security_service {
 public:
-    ss::future<std::vector<cluster::errc>> create_acls(
+    ss::future<chunked_vector<cluster::errc>> create_acls(
       chunked_vector<security::acl_binding> bindings,
       ::model::timeout_clock::duration) final {
-        std::vector<cluster::errc> results;
+        chunked_vector<cluster::errc> results;
         results.reserve(bindings.size());
         for (auto& binding : bindings) {
             auto& entries = _acls[binding.pattern()];

--- a/src/v/kafka/client/test/BUILD
+++ b/src/v/kafka/client/test/BUILD
@@ -318,6 +318,7 @@ redpanda_cc_btest(
     ],
     deps = [
         "//src/v/cluster",
+        "//src/v/container:chunked_vector",
         "//src/v/kafka/client",
         "//src/v/kafka/client/test:fixture",
         "//src/v/kafka/client/test:utils",

--- a/src/v/kafka/client/test/metadata.cc
+++ b/src/v/kafka/client/test/metadata.cc
@@ -10,6 +10,7 @@
 #include "kafka/protocol/metadata.h"
 
 #include "cluster/security_frontend.h"
+#include "container/chunked_vector.h"
 #include "kafka/client/client.h"
 #include "kafka/client/test/fixture.h"
 #include "kafka/server/handlers/details/security.h"
@@ -70,7 +71,7 @@ FIXTURE_TEST(test_authz_response, metadata_fixture) {
     enable_sasl();
     auto disable_sasl_defer = ss::defer([this] { disable_sasl(); });
 
-    std::vector<security::acl_binding> cluster_bindings{
+    chunked_vector<security::acl_binding> cluster_bindings{
       security::acl_binding(
         security::resource_pattern(
           security::resource_type::cluster,

--- a/src/v/kafka/client/test/metadata.cc
+++ b/src/v/kafka/client/test/metadata.cc
@@ -98,7 +98,7 @@ FIXTURE_TEST(test_authz_response, metadata_fixture) {
                         .create_acls(std::move(cluster_bindings), 1s)
                         .get();
     const auto errors_in_acl_results =
-      [](const std::vector<cluster::errc>& errs) {
+      [](const chunked_vector<cluster::errc>& errs) {
           return std::ranges::any_of(errs, [](const cluster::errc& e) {
               return e != cluster::errc::success;
           });

--- a/src/v/kafka/server/handlers/delete_acls.cc
+++ b/src/v/kafka/server/handlers/delete_acls.cc
@@ -30,8 +30,8 @@ using namespace std::chrono_literals;
 
 namespace kafka {
 
-static std::vector<delete_acls_matching_acl>
-bindings_to_delete_result(const std::vector<security::acl_binding>& bindings) {
+static std::vector<delete_acls_matching_acl> bindings_to_delete_result(
+  const chunked_vector<security::acl_binding>& bindings) {
     std::vector<delete_acls_matching_acl> res;
 
     for (auto& binding : bindings) {
@@ -70,7 +70,7 @@ ss::future<response_ptr> delete_acls_handler::handle(
     result_index.reserve(request.data.filters.size());
 
     // binding filters to delete. optimized for common case
-    std::vector<security::acl_binding_filter> filters;
+    chunked_vector<security::acl_binding_filter> filters;
     filters.reserve(request.data.filters.size());
 
     for (const auto& request_filter : request.data.filters) {
@@ -87,7 +87,7 @@ ss::future<response_ptr> delete_acls_handler::handle(
         }
     }
 
-    auto return_filters = [&filters]() { return filters; };
+    auto return_filters = [&filters]() { return filters.copy(); };
 
     auto authz = ctx.authorized(
       security::acl_operation::alter,

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -367,9 +367,7 @@ public:
         return resp;
     }
 
-    template<
-      typename T,
-      security::audit::returns_auditable_resource_vector Func>
+    template<typename T, security::audit::returns_auditable_resources Func>
     bool authorized(
       security::acl_operation operation,
       const T& name,

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -23,6 +23,7 @@
 #include "config/node_config.h"
 #include "config/sasl_mechanisms.h"
 #include "container/chunked_hash_map.h"
+#include "container/chunked_vector.h"
 #include "features/enterprise_feature_messages.h"
 #include "features/feature_table.h"
 #include "kafka/protocol/errors.h"
@@ -1977,7 +1978,7 @@ ss::future<response_ptr> create_acls_handler::handle(
     result_index.reserve(request.data.creations.size());
 
     // bindings to create. optimized for common case
-    std::vector<security::acl_binding> bindings;
+    chunked_vector<security::acl_binding> bindings;
     bindings.reserve(request.data.creations.size());
 
     for (const auto& acl : request.data.creations) {
@@ -1999,7 +2000,7 @@ ss::future<response_ptr> create_acls_handler::handle(
     // so we have access to the parsed data for auditing.  May result in
     // unecessary cycles if auditing fails or if the operation isn't authorized.
 
-    auto get_bindings = [&bindings] { return bindings; };
+    auto get_bindings = [&bindings] { return bindings.copy(); };
 
     bool authz = ctx.authorized(
       security::acl_operation::alter,

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -620,6 +620,7 @@ redpanda_cc_btest(
     ],
     deps = [
         "//src/v/cluster",
+        "//src/v/container:chunked_vector",
         "//src/v/kafka/client:transport",
         "//src/v/kafka/protocol",
         "//src/v/kafka/protocol:create_topics",
@@ -870,6 +871,7 @@ redpanda_cc_bench(
     memory = "4GiB",
     deps = [
         "//src/v/base",
+        "//src/v/container:chunked_vector",
         "//src/v/kafka/client:types",
         "//src/v/kafka/protocol",
         "//src/v/kafka/protocol:fetch",
@@ -933,6 +935,7 @@ redpanda_cc_btest(
     env = {"RP_FIXTURE_ENV": "1"},
     deps = [
         "//src/v/cluster",
+        "//src/v/container:chunked_vector",
         "//src/v/kafka/protocol",
         "//src/v/kafka/protocol:describe_user_scram_credentials",
         "//src/v/kafka/server",
@@ -955,6 +958,7 @@ redpanda_cc_btest(
     env = {"RP_FIXTURE_ENV": "1"},
     deps = [
         "//src/v/cluster",
+        "//src/v/container:chunked_vector",
         "//src/v/kafka/protocol",
         "//src/v/kafka/protocol:alter_user_scram_credentials",
         "//src/v/kafka/server",

--- a/src/v/kafka/server/tests/alter_user_scram_credentials_test.cc
+++ b/src/v/kafka/server/tests/alter_user_scram_credentials_test.cc
@@ -9,6 +9,7 @@
 
 #include "cluster/controller.h"
 #include "cluster/security_frontend.h"
+#include "container/chunked_vector.h"
 #include "kafka/protocol/alter_user_scram_credentials.h"
 #include "kafka/protocol/types.h"
 #include "kafka/server/handlers/details/security.h"
@@ -139,18 +140,19 @@ FIXTURE_TEST(
 
     auto disable_sasl_defer = ss::defer([this] { disable_sasl(); });
 
-    std::vector<security::acl_binding> cluster_bindings{security::acl_binding(
-      security::resource_pattern(
-        security::resource_type::cluster,
-        security::default_cluster_name,
-        security::pattern_type::literal),
+    chunked_vector<security::acl_binding> cluster_bindings{
+      security::acl_binding(
+        security::resource_pattern(
+          security::resource_type::cluster,
+          security::default_cluster_name,
+          security::pattern_type::literal),
 
-      security::acl_entry(
-        kafka::details::to_acl_principal(
-          ssx::sformat("User:{}", user_name_256)),
-        security::acl_host::wildcard_host(),
-        security::acl_operation::alter,
-        security::acl_permission::allow))};
+        security::acl_entry(
+          kafka::details::to_acl_principal(
+            ssx::sformat("User:{}", user_name_256)),
+          security::acl_host::wildcard_host(),
+          security::acl_operation::alter,
+          security::acl_permission::allow))};
 
     auto acl_result = app.controller->get_security_frontend()
                         .local()
@@ -662,7 +664,7 @@ FIXTURE_TEST(
             security::acl_operation::alter,
             security::acl_permission::allow));
     };
-    std::vector<security::acl_binding> cluster_bindings{
+    chunked_vector<security::acl_binding> cluster_bindings{
       make_acl_binding(user_name_256),
       make_acl_binding(user_name_512),
     };
@@ -781,7 +783,7 @@ FIXTURE_TEST(
             security::acl_operation::alter,
             security::acl_permission::allow));
     };
-    std::vector<security::acl_binding> cluster_bindings{
+    chunked_vector<security::acl_binding> cluster_bindings{
       make_acl_binding(user_name_256),
       make_acl_binding(user_name_512),
     };

--- a/src/v/kafka/server/tests/alter_user_scram_credentials_test.cc
+++ b/src/v/kafka/server/tests/alter_user_scram_credentials_test.cc
@@ -160,7 +160,7 @@ FIXTURE_TEST(
                         .get();
 
     const auto errors_in_acl_results =
-      [](const std::vector<cluster::errc>& errs) {
+      [](const chunked_vector<cluster::errc>& errs) {
           return std::ranges::any_of(errs, [](const cluster::errc& e) {
               return e != cluster::errc::success;
           });
@@ -675,7 +675,7 @@ FIXTURE_TEST(
                         .get();
 
     const auto errors_in_acl_results =
-      [](const std::vector<cluster::errc>& errs) {
+      [](const chunked_vector<cluster::errc>& errs) {
           return std::ranges::any_of(errs, [](const cluster::errc& e) {
               return e != cluster::errc::success;
           });
@@ -794,7 +794,7 @@ FIXTURE_TEST(
                         .get();
 
     const auto errors_in_acl_results =
-      [](const std::vector<cluster::errc>& errs) {
+      [](const chunked_vector<cluster::errc>& errs) {
           return std::ranges::any_of(errs, [](const cluster::errc& e) {
               return e != cluster::errc::success;
           });

--- a/src/v/kafka/server/tests/consumer_groups_test.cc
+++ b/src/v/kafka/server/tests/consumer_groups_test.cc
@@ -119,8 +119,8 @@ struct consumer_offsets_fixture : public redpanda_thread_fixture {
         app.controller->get_security_frontend()
           .local()
           .create_acls(
-            resources | std::views::transform(make_binding)
-              | std::ranges::to<std::vector>(),
+            chunked_vector<security::acl_binding>(
+              std::from_range, resources | std::views::transform(make_binding)),
             5s)
           .get();
     }

--- a/src/v/kafka/server/tests/describe_user_scram_credentials_test.cc
+++ b/src/v/kafka/server/tests/describe_user_scram_credentials_test.cc
@@ -138,7 +138,7 @@ FIXTURE_TEST(
                         .get();
 
     const auto errors_in_acl_results =
-      [](const std::vector<cluster::errc>& errs) {
+      [](const chunked_vector<cluster::errc>& errs) {
           return std::ranges::any_of(errs, [](const cluster::errc& e) {
               return e != cluster::errc::success;
           });

--- a/src/v/kafka/server/tests/describe_user_scram_credentials_test.cc
+++ b/src/v/kafka/server/tests/describe_user_scram_credentials_test.cc
@@ -9,6 +9,7 @@
 
 #include "cluster/controller.h"
 #include "cluster/security_frontend.h"
+#include "container/chunked_vector.h"
 #include "kafka/protocol/describe_user_scram_credentials.h"
 #include "kafka/protocol/types.h"
 #include "kafka/server/handlers/details/security.h"
@@ -117,18 +118,19 @@ FIXTURE_TEST(
 
     auto disable_sasl_defer = ss::defer([this] { disable_sasl(); });
 
-    std::vector<security::acl_binding> cluster_bindings{security::acl_binding(
-      security::resource_pattern(
-        security::resource_type::cluster,
-        security::default_cluster_name,
-        security::pattern_type::literal),
+    chunked_vector<security::acl_binding> cluster_bindings{
+      security::acl_binding(
+        security::resource_pattern(
+          security::resource_type::cluster,
+          security::default_cluster_name,
+          security::pattern_type::literal),
 
-      security::acl_entry(
-        kafka::details::to_acl_principal(
-          ssx::sformat("User:{}", user_name_256)),
-        security::acl_host::wildcard_host(),
-        security::acl_operation::describe,
-        security::acl_permission::allow))};
+        security::acl_entry(
+          kafka::details::to_acl_principal(
+            ssx::sformat("User:{}", user_name_256)),
+          security::acl_host::wildcard_host(),
+          security::acl_operation::describe,
+          security::acl_permission::allow))};
 
     auto acl_result = app.controller->get_security_frontend()
                         .local()

--- a/src/v/kafka/server/tests/fetch_plan_bench.cc
+++ b/src/v/kafka/server/tests/fetch_plan_bench.cc
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 #include "base/seastarx.h"
+#include "container/chunked_vector.h"
 #include "kafka/client/types.h"
 #include "kafka/protocol/fetch.h"
 #include "kafka/protocol/schemata/fetch_request.h"
@@ -90,7 +91,7 @@ struct fetch_plan : redpanda_thread_fixture {
           security::resource_pattern::wildcard,
           security::pattern_type::literal);
 
-        std::vector<security::acl_binding> bindings{
+        chunked_vector<security::acl_binding> bindings{
           security::acl_binding{resource, acl}};
         return bindings;
     }

--- a/src/v/kafka/server/tests/metadata_test.cc
+++ b/src/v/kafka/server/tests/metadata_test.cc
@@ -234,7 +234,7 @@ FIXTURE_TEST(metadata_v9_authz_acl, metadata_fixture) {
                         .get();
 
     const auto errors_in_acl_results =
-      [](const std::vector<cluster::errc>& errs) {
+      [](const chunked_vector<cluster::errc>& errs) {
           return std::ranges::any_of(errs, [](const cluster::errc& e) {
               return e != cluster::errc::success;
           });

--- a/src/v/kafka/server/tests/metadata_test.cc
+++ b/src/v/kafka/server/tests/metadata_test.cc
@@ -11,6 +11,7 @@
 #include "cluster/controller.h"
 #include "cluster/security_frontend.h"
 #include "cluster/topic_configuration.h"
+#include "container/chunked_vector.h"
 #include "kafka/client/transport.h"
 #include "kafka/protocol/create_topics.h"
 #include "kafka/protocol/errors.h"
@@ -215,16 +216,17 @@ FIXTURE_TEST(metadata_v9_authz_acl, metadata_fixture) {
     auto disable_sasl_defer = ss::defer([this] { disable_sasl(); });
 
     // Start by creating just describe ACLs for the cluster for the user
-    std::vector<security::acl_binding> cluster_bindings{security::acl_binding(
-      security::resource_pattern(
-        security::resource_type::cluster,
-        security::default_cluster_name,
-        security::pattern_type::literal),
-      security::acl_entry(
-        kafka::details::to_acl_principal(test_acl_principal),
-        security::acl_host::wildcard_host(),
-        security::acl_operation::describe,
-        security::acl_permission::allow))};
+    chunked_vector<security::acl_binding> cluster_bindings{
+      security::acl_binding(
+        security::resource_pattern(
+          security::resource_type::cluster,
+          security::default_cluster_name,
+          security::pattern_type::literal),
+        security::acl_entry(
+          kafka::details::to_acl_principal(test_acl_principal),
+          security::acl_host::wildcard_host(),
+          security::acl_operation::describe,
+          security::acl_permission::allow))};
 
     auto acl_result = app.controller->get_security_frontend()
                         .local()
@@ -263,7 +265,7 @@ FIXTURE_TEST(metadata_v9_authz_acl, metadata_fixture) {
     BOOST_CHECK(resp.data.topics.empty());
 
     // Now allow the user to see the test topic
-    std::vector<security::acl_binding> topic_bindings{security::acl_binding(
+    chunked_vector<security::acl_binding> topic_bindings{security::acl_binding(
       security::resource_pattern(
         security::resource_type::topic,
         test_topic_name,

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -1401,7 +1401,7 @@ post_security_acls(server::request_t rq, server::reply_t rp) {
     auto raw_acls = co_await rjson_parse(
       *rq.req, acl_handler<>{acl_handler<>::require_fields::yes});
 
-    std::vector<security::acl_binding> bindings;
+    chunked_vector<security::acl_binding> bindings;
     bindings.reserve(raw_acls.size());
 
     for (const auto& acl : raw_acls) {
@@ -1423,7 +1423,8 @@ post_security_acls(server::request_t rq, server::reply_t rp) {
 
     check_feature_ready(rq);
 
-    auto err_vec = co_await security_frontend.create_acls(bindings, 5s);
+    auto err_vec = co_await security_frontend.create_acls(
+      std::move(bindings), 5s);
 
     auto it = std::find_if(err_vec.begin(), err_vec.end(), [](const auto& err) {
         return err != cluster::errc::success;

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -1451,7 +1451,7 @@ delete_security_acls(server::request_t rq, server::reply_t rp) {
     auto raw_acls = co_await rjson_parse(
       *rq.req, acl_handler<>{acl_handler<>::require_fields::no});
 
-    std::vector<security::acl_binding_filter> filters;
+    chunked_vector<security::acl_binding_filter> filters;
     filters.reserve(raw_acls.size());
 
     for (const auto& acl : raw_acls) {
@@ -1472,7 +1472,7 @@ delete_security_acls(server::request_t rq, server::reply_t rp) {
       std::move(filters), 5s);
 
     auto res = chunked_vector<acl>{};
-    std::ranges::for_each(deleted, [&res](cluster::delete_acls_result r) {
+    std::ranges::for_each(deleted, [&res](cluster::delete_acls_result& r) {
         if (r.error != cluster::errc::success) {
             throw exception(
               error_code::internal_server_error,

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -16,6 +16,7 @@
 #include "cluster/security_frontend.h"
 #include "config/broker_authn_endpoint.h"
 #include "config/configuration.h"
+#include "container/chunked_vector.h"
 #include "kafka/client/client_fetch_batch_reader.h"
 #include "kafka/client/config_utils.h"
 #include "kafka/client/exceptions.h"
@@ -635,7 +636,7 @@ ss::future<> service::do_start() {
 }
 
 ss::future<> create_acls(cluster::security_frontend& security_fe) {
-    std::vector<security::acl_binding> princpal_acl_binding{
+    static const chunked_vector<security::acl_binding> princpal_acl_binding{
       security::acl_binding{
         security::resource_pattern{
           security::resource_type::topic,
@@ -647,7 +648,8 @@ ss::future<> create_acls(cluster::security_frontend& security_fe) {
           security::acl_operation::all,
           security::acl_permission::allow}}};
 
-    auto err_vec = co_await security_fe.create_acls(princpal_acl_binding, 5s);
+    auto err_vec = co_await security_fe.create_acls(
+      princpal_acl_binding.copy(), 5s);
     auto it = std::find_if(err_vec.begin(), err_vec.end(), [](const auto& err) {
         return err != cluster::errc::success;
     });

--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -278,9 +278,9 @@ std::vector<std::vector<acl_binding>> acl_store::remove_bindings(
     return res;
 }
 
-std::vector<acl_binding>
+chunked_vector<acl_binding>
 acl_store::acls(const acl_binding_filter& filter) const {
-    std::vector<acl_binding> result;
+    chunked_vector<acl_binding> result;
     for (const auto& acl : _acls) {
         for (const auto& entry : acl.second) {
             acl_binding binding(acl.first, entry);

--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -186,14 +186,14 @@ acl_store::find(resource_type resource, const ss::sstring& name) const {
     return acl_matches(wildcards, literals, std::move(prefixes));
 }
 
-std::vector<chunked_vector<acl_binding>> acl_store::remove_bindings(
+chunked_vector<chunked_vector<acl_binding>> acl_store::remove_bindings(
   const chunked_vector<acl_binding_filter>& filters, bool dry_run) {
     // the pair<filter, size_t> is used to record the index of the filter in the
     // input so that returned set of matching binding is organized in the same
     // order as the input filters. this is a property needed by the kafka api.
     absl::flat_hash_map<
       resource_pattern,
-      std::vector<std::pair<acl_binding_filter, size_t>>>
+      chunked_vector<std::pair<acl_binding_filter, size_t>>>
       resources;
 
     // collect binding filters that match resources
@@ -268,8 +268,11 @@ std::vector<chunked_vector<acl_binding>> acl_store::remove_bindings(
         maybe_roles.clear();
     }
 
-    std::vector<chunked_vector<acl_binding>> res;
-    res.resize(filters.size());
+    chunked_vector<chunked_vector<acl_binding>> res;
+    res.reserve(filters.size());
+    for (size_t i = 0; i < filters.size(); ++i) {
+        res.emplace_back();
+    }
 
     for (const auto& binding : deleted) {
         res[binding.second].push_back(binding.first);

--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -186,8 +186,8 @@ acl_store::find(resource_type resource, const ss::sstring& name) const {
     return acl_matches(wildcards, literals, std::move(prefixes));
 }
 
-std::vector<std::vector<acl_binding>> acl_store::remove_bindings(
-  const std::vector<acl_binding_filter>& filters, bool dry_run) {
+std::vector<chunked_vector<acl_binding>> acl_store::remove_bindings(
+  const chunked_vector<acl_binding_filter>& filters, bool dry_run) {
     // the pair<filter, size_t> is used to record the index of the filter in the
     // input so that returned set of matching binding is organized in the same
     // order as the input filters. this is a property needed by the kafka api.
@@ -268,8 +268,8 @@ std::vector<std::vector<acl_binding>> acl_store::remove_bindings(
         maybe_roles.clear();
     }
 
-    std::vector<std::vector<acl_binding>> res;
-    res.assign(filters.size(), {});
+    std::vector<chunked_vector<acl_binding>> res;
+    res.resize(filters.size());
 
     for (const auto& binding : deleted) {
         res[binding.second].push_back(binding.first);

--- a/src/v/security/acl_store.h
+++ b/src/v/security/acl_store.h
@@ -42,7 +42,7 @@ public:
     // remove bindings according the input filters and return the bindings that
     // matched in the same order. the `dry_run` flag will identify all of the
     // bindings to be removed but not perform the destructive operation.
-    std::vector<chunked_vector<acl_binding>> remove_bindings(
+    chunked_vector<chunked_vector<acl_binding>> remove_bindings(
       const chunked_vector<acl_binding_filter>&, bool dry_run = false);
 
     chunked_vector<acl_binding> acls(const acl_binding_filter&) const;

--- a/src/v/security/acl_store.h
+++ b/src/v/security/acl_store.h
@@ -31,7 +31,7 @@ public:
     acl_store& operator=(const acl_store&) = delete;
     ~acl_store() noexcept = default;
 
-    void add_bindings(const std::vector<acl_binding>& bindings) {
+    void add_bindings(const chunked_vector<acl_binding>& bindings) {
         for (auto& binding : bindings) {
             auto& entries = _acls[binding.pattern()];
             entries.insert(binding.entry());

--- a/src/v/security/acl_store.h
+++ b/src/v/security/acl_store.h
@@ -42,8 +42,8 @@ public:
     // remove bindings according the input filters and return the bindings that
     // matched in the same order. the `dry_run` flag will identify all of the
     // bindings to be removed but not perform the destructive operation.
-    std::vector<std::vector<acl_binding>> remove_bindings(
-      const std::vector<acl_binding_filter>&, bool dry_run = false);
+    std::vector<chunked_vector<acl_binding>> remove_bindings(
+      const chunked_vector<acl_binding_filter>&, bool dry_run = false);
 
     chunked_vector<acl_binding> acls(const acl_binding_filter&) const;
 

--- a/src/v/security/acl_store.h
+++ b/src/v/security/acl_store.h
@@ -45,7 +45,7 @@ public:
     std::vector<std::vector<acl_binding>> remove_bindings(
       const std::vector<acl_binding_filter>&, bool dry_run = false);
 
-    std::vector<acl_binding> acls(const acl_binding_filter&) const;
+    chunked_vector<acl_binding> acls(const acl_binding_filter&) const;
 
     /**
      * WARNING: The acl_matches returned from this function may contain

--- a/src/v/security/audit/audit_log_manager.h
+++ b/src/v/security/audit/audit_log_manager.h
@@ -84,7 +84,7 @@ public:
 
     template<
       typename T,
-      security::audit::returns_auditable_resource_vector Func,
+      security::audit::returns_auditable_resources Func,
       typename... Args>
     bool enqueue_authz_audit_event(
       kafka::api_key api,
@@ -380,7 +380,7 @@ private:
 
     audit_probe& probe() { return _probe; }
 
-    template<security::audit::returns_auditable_resource_vector Func>
+    template<security::audit::returns_auditable_resources Func>
     auto restrict_topics(Func&& func) const noexcept {
         auto result = func();
         if constexpr (

--- a/src/v/security/audit/schemas/application_activity.h
+++ b/src/v/security/audit/schemas/application_activity.h
@@ -72,7 +72,7 @@ public:
       , _status_id(status_id)
       , _unmapped(std::move(unmapped)) {}
 
-    template<typename T>
+    template<std::ranges::range Range>
     static size_t hash(
       std::string_view operation_name,
       const security::auth_result& auth_result,
@@ -81,7 +81,8 @@ public:
       ss::net::inet_address client_addr,
       uint16_t client_port,
       std::optional<std::string_view> client_id,
-      const std::vector<T>& additional_resources) {
+      const Range& additional_resources) {
+        using T = std::ranges::range_value_t<Range>;
         size_t h = api_activity_event_base_hash(
           operation_name,
           auth_result,
@@ -131,7 +132,7 @@ public:
       std::optional<std::string_view> reason,
       const chunked_vector<resource_detail>& resources);
 
-    template<typename T>
+    template<std::ranges::range Range>
     static api_activity construct(
       std::string_view operation_name,
       const security::auth_result& auth_result,
@@ -140,8 +141,8 @@ public:
       ss::net::inet_address client_addr,
       uint16_t client_port,
       std::optional<std::string_view> client_id,
-      std::vector<T> additional_resources) {
-        auto new_ars = create_resource_details(std::move(additional_resources));
+      Range additional_resources) {
+        auto new_ars = create_resource_details(additional_resources);
         auto crud = op_to_crud(auth_result.operation);
         auto actor = result_to_actor(auth_result);
         new_ars.emplace_back(

--- a/src/v/security/audit/schemas/utils.h
+++ b/src/v/security/audit/schemas/utils.h
@@ -24,6 +24,7 @@
 #include <seastar/http/request.hh>
 
 #include <iterator>
+#include <ranges>
 #include <type_traits>
 
 namespace security::audit {
@@ -139,9 +140,9 @@ resource_detail transform_to_resource_detail(const T& v) {
     };
 }
 
-template<AuditableResource T>
-std::vector<resource_detail>
-create_resource_details(const std::vector<T>& resources) {
+template<std::ranges::sized_range Range>
+requires AuditableResource<std::ranges::range_value_t<Range>>
+std::vector<resource_detail> create_resource_details(const Range& resources) {
     std::vector<resource_detail> resource_details;
     resource_details.reserve(resources.size());
     std::transform(
@@ -154,14 +155,11 @@ create_resource_details(const std::vector<T>& resources) {
 }
 
 template<typename Func>
-concept returns_auditable_resource_vector = requires(Func func) {
-    {
-        func()
-    } -> std::same_as<
-      std::vector<typename std::remove_cvref_t<decltype(func())>::value_type>>;
+concept returns_auditable_resources = requires(Func func) {
+    requires std::ranges::range<std::remove_cvref_t<decltype(func())>>;
 
     requires AuditableResource<
-      typename std::remove_cvref_t<decltype(func())>::value_type>;
+      std::ranges::range_value_t<std::remove_cvref_t<decltype(func())>>>;
 };
 
 } // namespace security::audit

--- a/src/v/security/authorizer.cc
+++ b/src/v/security/authorizer.cc
@@ -115,7 +115,7 @@ void authorizer::add_bindings(const chunked_vector<acl_binding>& bindings) {
     store().add_bindings(bindings);
 }
 
-std::vector<chunked_vector<acl_binding>> authorizer::remove_bindings(
+chunked_vector<chunked_vector<acl_binding>> authorizer::remove_bindings(
   const chunked_vector<acl_binding_filter>& filters, bool dry_run) {
     return store().remove_bindings(filters, dry_run);
 }

--- a/src/v/security/authorizer.cc
+++ b/src/v/security/authorizer.cc
@@ -104,7 +104,7 @@ authorizer::authorizer(
     _superusers_conf.watch([this]() { update_superusers(); });
 }
 
-void authorizer::add_bindings(const std::vector<acl_binding>& bindings) {
+void authorizer::add_bindings(const chunked_vector<acl_binding>& bindings) {
     if (
       unlikely(
         seclog.is_shard_zero() && seclog.is_enabled(ss::log_level::debug))) {

--- a/src/v/security/authorizer.cc
+++ b/src/v/security/authorizer.cc
@@ -115,8 +115,8 @@ void authorizer::add_bindings(const std::vector<acl_binding>& bindings) {
     store().add_bindings(bindings);
 }
 
-std::vector<std::vector<acl_binding>> authorizer::remove_bindings(
-  const std::vector<acl_binding_filter>& filters, bool dry_run) {
+std::vector<chunked_vector<acl_binding>> authorizer::remove_bindings(
+  const chunked_vector<acl_binding_filter>& filters, bool dry_run) {
     return store().remove_bindings(filters, dry_run);
 }
 

--- a/src/v/security/authorizer.cc
+++ b/src/v/security/authorizer.cc
@@ -120,7 +120,7 @@ std::vector<std::vector<acl_binding>> authorizer::remove_bindings(
     return store().remove_bindings(filters, dry_run);
 }
 
-std::vector<acl_binding>
+chunked_vector<acl_binding>
 authorizer::acls(const acl_binding_filter& filter) const {
     return store().acls(filter);
 }

--- a/src/v/security/authorizer.h
+++ b/src/v/security/authorizer.h
@@ -255,7 +255,7 @@ public:
     /*
      * Add ACL bindings to the authorizer.
      */
-    void add_bindings(const std::vector<acl_binding>& bindings);
+    void add_bindings(const chunked_vector<acl_binding>& bindings);
 
     /*
      * Remove ACL bindings that match the filter(s).

--- a/src/v/security/authorizer.h
+++ b/src/v/security/authorizer.h
@@ -260,8 +260,8 @@ public:
     /*
      * Remove ACL bindings that match the filter(s).
      */
-    std::vector<std::vector<acl_binding>> remove_bindings(
-      const std::vector<acl_binding_filter>& filters, bool dry_run = false);
+    std::vector<chunked_vector<acl_binding>> remove_bindings(
+      const chunked_vector<acl_binding_filter>& filters, bool dry_run = false);
 
     /*
      * Retrieve ACL bindings that match the filter.

--- a/src/v/security/authorizer.h
+++ b/src/v/security/authorizer.h
@@ -260,7 +260,7 @@ public:
     /*
      * Remove ACL bindings that match the filter(s).
      */
-    std::vector<chunked_vector<acl_binding>> remove_bindings(
+    chunked_vector<chunked_vector<acl_binding>> remove_bindings(
       const chunked_vector<acl_binding_filter>& filters, bool dry_run = false);
 
     /*

--- a/src/v/security/authorizer.h
+++ b/src/v/security/authorizer.h
@@ -266,7 +266,7 @@ public:
     /*
      * Retrieve ACL bindings that match the filter.
      */
-    std::vector<acl_binding> acls(const acl_binding_filter& filter) const;
+    chunked_vector<acl_binding> acls(const acl_binding_filter& filter) const;
 
     /*
      * Authorize an operation on a resource. The type of resource is deduced by

--- a/src/v/security/tests/BUILD
+++ b/src/v/security/tests/BUILD
@@ -75,6 +75,7 @@ redpanda_cc_gtest(
     ],
     deps = [
         "//src/v/config",
+        "//src/v/container:chunked_vector",
         "//src/v/pandaproxy/schema_registry:types",
         "//src/v/random:generators",
         "//src/v/security",

--- a/src/v/security/tests/authorizer_test.cc
+++ b/src/v/security/tests/authorizer_test.cc
@@ -1156,7 +1156,7 @@ TEST(AUTHORIZER_TEST, authz_acl_filter) {
     auto auth = make_test_instance();
     auth.add_bindings({acl1, acl2, acl3, acl4});
 
-    auto to_set = [](std::vector<acl_binding> bindings) {
+    auto to_set = [](chunked_vector<acl_binding> bindings) {
         absl::flat_hash_set<acl_binding> ret(bindings.begin(), bindings.end());
         return ret;
     };

--- a/src/v/security/tests/authorizer_test.cc
+++ b/src/v/security/tests/authorizer_test.cc
@@ -739,7 +739,7 @@ TEST(AUTHORIZER_TEST, authz_remove_acl_wildcard_resource) {
     auth.add_bindings(bindings);
 
     {
-        std::vector<acl_binding_filter> filters;
+        chunked_vector<acl_binding_filter> filters;
         filters.emplace_back(wildcard_resource, allow_read_acl);
         auth.remove_bindings(filters);
     }
@@ -756,7 +756,7 @@ TEST(AUTHORIZER_TEST, authz_remove_all_acl_wildcard_resource) {
     auth.add_bindings(bindings);
 
     {
-        std::vector<acl_binding_filter> filters;
+        chunked_vector<acl_binding_filter> filters;
         filters.emplace_back(wildcard_resource, acl_entry_filter::any());
         auth.remove_bindings(filters);
     }
@@ -813,7 +813,7 @@ TEST(AUTHORIZER_TEST, authz_remove_acl_prefixed_resource) {
     auth.add_bindings(bindings);
 
     {
-        std::vector<acl_binding_filter> filters;
+        chunked_vector<acl_binding_filter> filters;
         filters.emplace_back(prefixed_resource, allow_read_acl);
         auth.remove_bindings(filters);
     }
@@ -830,7 +830,7 @@ TEST(AUTHORIZER_TEST, authz_remove_all_acl_prefixed_resource) {
     auth.add_bindings(bindings);
 
     {
-        std::vector<acl_binding_filter> filters;
+        chunked_vector<acl_binding_filter> filters;
         filters.emplace_back(prefixed_resource, acl_entry_filter::any());
         auth.remove_bindings(filters);
     }
@@ -1094,7 +1094,7 @@ TEST(AUTHORIZER_TEST, authz_get_acls_principal) {
     ASSERT_EQ(get_acls(auth, user).size(), 1);
 
     {
-        std::vector<acl_binding_filter> filters;
+        chunked_vector<acl_binding_filter> filters;
         filters.emplace_back(default_resource, acl_entry_filter::any());
         auth.remove_bindings(filters);
     }
@@ -1740,7 +1740,7 @@ TEST(AUTHORIZER_TEST, role_authz_get_acls_principal) {
     ASSERT_EQ(get_acls(auth, role).size(), 1);
 
     {
-        std::vector<acl_binding_filter> filters;
+        chunked_vector<acl_binding_filter> filters;
         filters.emplace_back(default_resource, acl_entry_filter::any());
         auth.remove_bindings(filters);
     }
@@ -1905,7 +1905,7 @@ TEST(AUTHORIZER_TEST, role_authz_remove_binding_multiple_match) {
     auth.add_bindings(bindings);
 
     {
-        std::vector<acl_binding_filter> filters;
+        chunked_vector<acl_binding_filter> filters;
         filters.emplace_back(wildcard_resource, allow_read_acl);
         filters.emplace_back(wildcard_resource, allow_write_acl);
         auth.remove_bindings(filters);
@@ -2713,7 +2713,7 @@ TEST(AUTHORIZER_TEST, group_authz_remove_bindings_with_groups) {
 
     // Remove only group1's read permission
     {
-        std::vector<acl_binding_filter> filters;
+        chunked_vector<acl_binding_filter> filters;
         filters.emplace_back(default_resource, group1_read);
         auth.remove_bindings(filters);
     }

--- a/src/v/security/tests/authorizer_test.cc
+++ b/src/v/security/tests/authorizer_test.cc
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0
 #include "absl/container/flat_hash_set.h"
 #include "config/mock_property.h"
+#include "container/chunked_vector.h"
 #include "pandaproxy/schema_registry/types.h"
 #include "random/generators.h"
 #include "security/acl.h"
@@ -137,7 +138,7 @@ TEST(AUTHORIZER_TEST, authz_empty_resource_name) {
       acl_operation::read,
       acl_permission::allow);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::group, resource_pattern::wildcard, pattern_type::literal);
     bindings.emplace_back(resource, acl);
@@ -177,7 +178,7 @@ TEST(AUTHORIZER_TEST, authz_deny_applies_first) {
 
     acl_entry deny(user, host, acl_operation::all, acl_permission::deny);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, resource_pattern::wildcard, pattern_type::literal);
     bindings.emplace_back(resource, allow);
@@ -215,7 +216,7 @@ TEST(AUTHORIZER_TEST, authz_allow_all) {
       acl_operation::all,
       acl_permission::allow);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, resource_pattern::wildcard, pattern_type::literal);
     bindings.emplace_back(resource, acl);
@@ -255,7 +256,7 @@ TEST(AUTHORIZER_TEST, authz_super_user_allow) {
       acl_operation::all,
       acl_permission::deny);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, resource_pattern::wildcard, pattern_type::literal);
     bindings.emplace_back(resource, acl);
@@ -406,7 +407,7 @@ TEST(AUTHORIZER_TEST, authz_wildcards) {
     acl_entry read_acl(
       user1, host1, acl_operation::read, acl_permission::allow);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern wildcard_resource(
       resource_type::topic, resource_pattern::wildcard, pattern_type::literal);
     bindings.emplace_back(wildcard_resource, read_acl);
@@ -534,7 +535,7 @@ static void do_implied_acls(
         auto auth = make_test_instance(
           authorizer::allow_empty_matches::no, roles);
 
-        std::vector<acl_binding> bindings;
+        chunked_vector<acl_binding> bindings;
         resource_pattern resource(
           resource_type::cluster, default_cluster_name, pattern_type::literal);
         bindings.emplace_back(resource, acl);
@@ -603,7 +604,7 @@ static void do_implied_acls(
         auto auth = make_test_instance(
           authorizer::allow_empty_matches::no, roles);
 
-        std::vector<acl_binding> bindings;
+        chunked_vector<acl_binding> bindings;
         resource_pattern resource(
           resource_type::cluster, default_cluster_name, pattern_type::literal);
         bindings.emplace_back(resource, deny);
@@ -704,7 +705,7 @@ TEST(AUTHORIZER_TEST, authz_allow_for_all_wildcard_resource) {
 
     auto auth = make_test_instance();
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, resource_pattern::wildcard, pattern_type::literal);
     bindings.emplace_back(resource, acl);
@@ -733,7 +734,7 @@ TEST(AUTHORIZER_TEST, authz_allow_for_all_wildcard_resource) {
 TEST(AUTHORIZER_TEST, authz_remove_acl_wildcard_resource) {
     auto auth = make_test_instance();
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     bindings.emplace_back(wildcard_resource, allow_read_acl);
     bindings.emplace_back(wildcard_resource, allow_write_acl);
     auth.add_bindings(bindings);
@@ -751,7 +752,7 @@ TEST(AUTHORIZER_TEST, authz_remove_acl_wildcard_resource) {
 TEST(AUTHORIZER_TEST, authz_remove_all_acl_wildcard_resource) {
     auto auth = make_test_instance();
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     bindings.emplace_back(wildcard_resource, allow_read_acl);
     auth.add_bindings(bindings);
 
@@ -778,7 +779,7 @@ TEST(AUTHORIZER_TEST, authz_allow_for_all_prefixed_resource) {
 
     auto auth = make_test_instance();
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, "foo", pattern_type::prefixed);
     bindings.emplace_back(resource, acl);
@@ -807,7 +808,7 @@ TEST(AUTHORIZER_TEST, authz_allow_for_all_prefixed_resource) {
 TEST(AUTHORIZER_TEST, authz_remove_acl_prefixed_resource) {
     auto auth = make_test_instance();
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     bindings.emplace_back(prefixed_resource, allow_read_acl);
     bindings.emplace_back(prefixed_resource, allow_write_acl);
     auth.add_bindings(bindings);
@@ -825,7 +826,7 @@ TEST(AUTHORIZER_TEST, authz_remove_acl_prefixed_resource) {
 TEST(AUTHORIZER_TEST, authz_remove_all_acl_prefixed_resource) {
     auto auth = make_test_instance();
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     bindings.emplace_back(prefixed_resource, allow_read_acl);
     auth.add_bindings(bindings);
 
@@ -843,7 +844,7 @@ TEST(AUTHORIZER_TEST, authz_remove_all_acl_prefixed_resource) {
 TEST(AUTHORIZER_TEST, authz_acls_on_literal_resource) {
     auto auth = make_test_instance();
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     bindings.emplace_back(default_resource, allow_read_acl);
     bindings.emplace_back(default_resource, allow_write_acl);
     auth.add_bindings(bindings);
@@ -879,7 +880,7 @@ TEST(AUTHORIZER_TEST, authz_acls_on_literal_resource) {
 TEST(AUTHORIZER_TEST, authz_acls_on_wildcard_resource) {
     auto auth = make_test_instance();
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     bindings.emplace_back(wildcard_resource, allow_read_acl);
     bindings.emplace_back(wildcard_resource, allow_write_acl);
     auth.add_bindings(bindings);
@@ -905,7 +906,7 @@ TEST(AUTHORIZER_TEST, authz_acls_on_wildcard_resource) {
 TEST(AUTHORIZER_TEST, authz_acls_on_prefixed_resource) {
     auto auth = make_test_instance();
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     bindings.emplace_back(prefixed_resource, allow_read_acl);
     bindings.emplace_back(prefixed_resource, allow_write_acl);
     auth.add_bindings(bindings);
@@ -935,7 +936,7 @@ TEST(AUTHORIZER_TEST, authz_auth_prefix_resource) {
     auto auth = make_test_instance();
 
     auto add_acl = [&auth](ss::sstring name, pattern_type type) {
-        std::vector<acl_binding> bindings;
+        chunked_vector<acl_binding> bindings;
         bindings.emplace_back(
           resource_pattern(resource_type::topic, name, type), deny_read_acl);
         auth.add_bindings(bindings);
@@ -979,7 +980,7 @@ TEST(AUTHORIZER_TEST, authz_auth_prefix_resource) {
     ASSERT_EQ(result.resource_type, security::resource_type::topic);
     ASSERT_EQ(result.resource_name, default_resource.name());
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     bindings.emplace_back(prefixed_resource, allow_read_acl);
     auth.add_bindings(bindings);
 
@@ -1008,7 +1009,7 @@ TEST(AUTHORIZER_TEST, authz_single_char) {
 
     auto auth = make_test_instance();
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource{resource_type::topic, "f", pattern_type::literal};
     bindings.emplace_back(resource, allow_read_acl);
     auth.add_bindings(bindings);
@@ -1081,7 +1082,7 @@ TEST(AUTHORIZER_TEST, authz_get_acls_principal) {
 
     auto auth = make_test_instance();
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     bindings.emplace_back(
       default_resource,
       acl_entry(
@@ -1215,7 +1216,7 @@ TEST(AUTHORIZER_TEST, authz_topic_acl) {
     acl_entry acl7(
       user3, acl_wildcard_host, acl_operation::write, acl_permission::allow);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, "topic1", pattern_type::literal);
     bindings.emplace_back(resource, acl1);
@@ -1367,7 +1368,7 @@ TEST(AUTHORIZER_TEST, authz_topic_acl) {
 TEST(AUTHORIZER_TEST, authz_topic_group_same_name) {
     auto auth = make_test_instance();
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
 
     resource_pattern resource(
       resource_type::topic, "topic-foo", pattern_type::prefixed);
@@ -1451,7 +1452,7 @@ TEST(AUTHORIZER_TEST, role_authz_simple_allow) {
     acl_entry acl3(
       user4, host_any, acl_operation::write, acl_permission::allow);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
 
     resource_pattern resource(
       resource_type::topic, topic1(), pattern_type::literal);
@@ -1576,7 +1577,7 @@ TEST(AUTHORIZER_TEST, role_authz_user_deny_applies_first) {
       acl_operation::all,
       acl_permission::allow);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, default_topic(), pattern_type::literal);
     bindings.emplace_back(resource, deny_user);
@@ -1659,7 +1660,7 @@ TEST(AUTHORIZER_TEST, role_authz_role_deny_applies_first) {
       acl_operation::write,
       acl_permission::deny);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, default_topic(), pattern_type::literal);
     bindings.emplace_back(resource, allow_user);
@@ -1729,7 +1730,7 @@ TEST(AUTHORIZER_TEST, role_authz_get_acls_principal) {
 
     auto auth = make_test_instance();
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     bindings.emplace_back(
       default_resource,
       acl_entry(
@@ -1776,7 +1777,7 @@ TEST(AUTHORIZER_TEST, role_authz_wildcard_no_auth) {
 
     // NOTE(oren): again, note that this usage would be rejected at Kafka layer,
     // but it's probably a good idea to codify expected behavior somewhere.
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     bindings.emplace_back(
       resource_pattern{
         resource_type::topic, default_topic(), pattern_type::literal},
@@ -1827,7 +1828,7 @@ TEST(AUTHORIZER_TEST, role_authz_user_same_name) {
       acl_operation::read,
       acl_permission::deny);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, default_topic(), pattern_type::literal);
     bindings.emplace_back(resource, allow_user);
@@ -1899,7 +1900,7 @@ TEST(AUTHORIZER_TEST, role_authz_remove_binding_multiple_match) {
     static const acl_entry allow_write_acl(
       user_p, acl_wildcard_host, acl_operation::write, acl_permission::allow);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     bindings.emplace_back(wildcard_resource, allow_read_acl);
     bindings.emplace_back(wildcard_resource, allow_write_acl);
     auth.add_bindings(bindings);
@@ -1944,7 +1945,7 @@ TEST(AUTHORIZER_TEST, authz_filter_out_non_kafka_resources) {
       acl_operation::describe,
       acl_permission::allow);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern subject_resource(
       resource_type::sr_subject, "model-", pattern_type::prefixed);
     resource_pattern registry_resource(
@@ -2043,7 +2044,7 @@ TEST(AUTHORIZER_TEST, authz_superuser_required) {
       acl_operation::all,
       acl_permission::allow);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, resource_pattern::wildcard, pattern_type::literal);
     bindings.emplace_back(resource, acl);
@@ -2121,7 +2122,7 @@ TEST(AUTHORIZER_TEST, group_authz_simple_allow) {
     acl_entry acl1(
       group1, host_any, acl_operation::read, acl_permission::allow);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, topic1(), pattern_type::literal);
 
@@ -2163,7 +2164,7 @@ TEST(AUTHORIZER_TEST, group_authz_user_deny_applies_first) {
       acl_operation::all,
       acl_permission::allow);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, default_topic(), pattern_type::literal);
     bindings.emplace_back(resource, deny_user);
@@ -2218,7 +2219,7 @@ TEST(AUTHORIZER_TEST, group_authz_group_deny_applies_first) {
       acl_operation::write,
       acl_permission::deny);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, default_topic(), pattern_type::literal);
     bindings.emplace_back(resource, allow_user);
@@ -2274,7 +2275,7 @@ TEST(AUTHORIZER_TEST, group_authz_multiple_groups_deny_precedence) {
       acl_operation::write,
       acl_permission::deny);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, default_topic(), pattern_type::literal);
     bindings.emplace_back(resource, allow_all_group);
@@ -2382,7 +2383,7 @@ TEST(AUTHORIZER_TEST, group_authz_empty_groups_no_auth) {
       acl_operation::read,
       acl_permission::allow);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, default_topic(), pattern_type::literal);
     bindings.emplace_back(resource, allow_group);
@@ -2415,7 +2416,7 @@ TEST(AUTHORIZER_TEST, group_authz_host_specific) {
     acl_entry allow_group_host1(
       group1, host1, acl_operation::read, acl_permission::allow);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, default_topic(), pattern_type::literal);
     bindings.emplace_back(resource, allow_group_host1);
@@ -2472,7 +2473,7 @@ TEST(AUTHORIZER_TEST, group_authz_roles_and_groups_priority) {
       acl_operation::read,
       acl_permission::deny);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, default_topic(), pattern_type::literal);
     bindings.emplace_back(resource, allow_role);
@@ -2517,7 +2518,7 @@ TEST(AUTHORIZER_TEST, group_authz_different_resource_types) {
       acl_operation::write,
       acl_permission::allow);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern topic_resource(
       resource_type::topic, default_topic(), pattern_type::literal);
     resource_pattern group_resource(
@@ -2586,7 +2587,7 @@ TEST(AUTHORIZER_TEST, group_authz_prefixed_and_wildcard_resources) {
       acl_operation::write,
       acl_permission::allow);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern prefixed_resource(
       resource_type::topic, "test-", pattern_type::prefixed);
     resource_pattern wildcard_resource(
@@ -2639,7 +2640,7 @@ TEST(AUTHORIZER_TEST, group_authz_get_acls_by_group_principal) {
     acl_entry group2_acl(
       group2, acl_wildcard_host, acl_operation::write, acl_permission::allow);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     bindings.emplace_back(default_resource, group1_acl);
     bindings.emplace_back(default_resource, group2_acl);
     auth.add_bindings(bindings);
@@ -2671,7 +2672,7 @@ TEST(AUTHORIZER_TEST, group_authz_superuser_overrides_group_deny) {
     acl_entry deny_group(
       group1, acl_wildcard_host, acl_operation::all, acl_permission::deny);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, resource_pattern::wildcard, pattern_type::literal);
     bindings.emplace_back(resource, deny_group);
@@ -2705,7 +2706,7 @@ TEST(AUTHORIZER_TEST, group_authz_remove_bindings_with_groups) {
     acl_entry group2_read(
       group2, acl_wildcard_host, acl_operation::read, acl_permission::allow);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     bindings.emplace_back(default_resource, group1_read);
     bindings.emplace_back(default_resource, group1_write);
     bindings.emplace_back(default_resource, group2_read);
@@ -2732,7 +2733,7 @@ TEST(AUTHORIZER_TEST, group_authz_large_number_of_groups) {
 
     // Create many groups (simulate realistic scenario)
     chunked_vector<acl_principal> many_groups;
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
 
     for (int i = 0; i < 50; ++i) {
         acl_principal group(principal_type::group, fmt::format("group{}", i));
@@ -2782,7 +2783,7 @@ TEST(AUTHORIZER_TEST, group_role_authz_simple_allow) {
       acl_operation::read,
       acl_permission::allow);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, default_topic(), pattern_type::literal);
     bindings.emplace_back(resource, allow_role);
@@ -2828,7 +2829,7 @@ TEST(AUTHORIZER_TEST, group_role_authz_deny_takes_precedence) {
       acl_operation::read,
       acl_permission::allow);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, default_topic(), pattern_type::literal);
     bindings.emplace_back(resource, deny_role);
@@ -2869,7 +2870,7 @@ TEST(AUTHORIZER_TEST, group_role_authz_multiple_groups_one_in_role) {
       acl_operation::read,
       acl_permission::allow);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, default_topic(), pattern_type::literal);
     bindings.emplace_back(resource, allow_role);
@@ -2910,7 +2911,7 @@ TEST(AUTHORIZER_TEST, group_role_authz_group_not_in_role) {
       acl_operation::read,
       acl_permission::allow);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, default_topic(), pattern_type::literal);
     bindings.emplace_back(resource, allow_role);
@@ -2957,7 +2958,7 @@ TEST(AUTHORIZER_TEST, group_role_authz_user_and_group_in_different_roles) {
       acl_operation::read,
       acl_permission::allow);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, default_topic(), pattern_type::literal);
     bindings.emplace_back(resource, deny_user_role);
@@ -3005,7 +3006,7 @@ TEST(AUTHORIZER_TEST, group_role_authz_group_deny_via_role) {
       acl_operation::read,
       acl_permission::deny);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, default_topic(), pattern_type::literal);
     bindings.emplace_back(resource, allow_user);
@@ -3055,7 +3056,7 @@ TEST(AUTHORIZER_TEST, group_role_authz_multiple_roles_for_group) {
       acl_operation::write,
       acl_permission::allow);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, default_topic(), pattern_type::literal);
     bindings.emplace_back(resource, allow_role1);
@@ -3109,7 +3110,7 @@ TEST(AUTHORIZER_TEST, group_role_authz_implied_operations) {
       acl_operation::read,
       acl_permission::allow);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     resource_pattern resource(
       resource_type::topic, default_topic(), pattern_type::literal);
     bindings.emplace_back(resource, allow_role);
@@ -3281,7 +3282,7 @@ TEST(AUTHORIZER_TEST, authorize_with_group_principal_acls) {
     // Create resource and binding
     resource_pattern resource(
       resource_type::topic, topic(), pattern_type::literal);
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     bindings.emplace_back(resource, allow_read);
 
     // Setup authorizer
@@ -3337,7 +3338,7 @@ TEST(AUTHORIZER_TEST, group_principal_acl_deny_precedence) {
     // Create resource and bindings
     resource_pattern resource(
       resource_type::topic, topic(), pattern_type::literal);
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     bindings.emplace_back(resource, deny_write);
     bindings.emplace_back(resource, allow_write);
 

--- a/src/v/security/tests/role_store_bench.cc
+++ b/src/v/security/tests/role_store_bench.cc
@@ -327,7 +327,7 @@ size_t run_authz(
           perm);
     }
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     for (const auto& acl : acls) {
         resource_pattern resource(
           resource_type::topic, topic1(), pattern_type::prefixed);
@@ -475,7 +475,7 @@ PERF_TEST(role_store_bench, role_authz_empty_store) {
     acl_entry acl3(
       user1, acl_host::wildcard_host(), acl_operation::describe, perm);
 
-    std::vector<acl_binding> bindings;
+    chunked_vector<acl_binding> bindings;
     for (const auto& acl : {acl1, acl2, acl3}) {
         resource_pattern resource(
           resource_type::topic, topic1(), pattern_type::prefixed);


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30368
Resolves https://github.com/redpanda-data/redpanda/issues/30388

## Manual conflict resolutions

The original PR was authored against `dev` after two header refactors that have not been backported to `v26.1.x`:

- `ec9daf55ac` ("cluster: extraction logical changes") carved `cluster/security_types.h` out of `cluster/types.h`. Hunks from commits 3, 4, and 8 that targeted `security_types.h` were retargeted to `cluster/types.h` (where the equivalent `create_acls_*` / `delete_acls_*` types still live on `v26.1.x`).
- `7cc333f969` ("sr: Introduce kafka_client_transport") moved the schema-registry `create_acls` callsite into `pandaproxy/schema_registry/kafka_client_transport.cc`. The equivalent change in commit 4 was applied to `pandaproxy/schema_registry/service.cc` instead, where the callsite still lives on `v26.1.x` (preserving the existing `princpal_acl_binding` typo).
- BUILD-file conflicts in `kafka/client/test/BUILD`, `kafka/server/tests/BUILD`, `pandaproxy/schema_registry/BUILD`, and `security/tests/BUILD` came from dev's later split of the `:cluster` monolith into fine-grained Bazel targets. v26.1.x consumers still depend on the monolithic `//src/v/cluster`, so only the `//src/v/container:chunked_vector` dep additions were kept and the new `:cluster:*` fine-grained deps were dropped. The `:transport` and `:kafka_client_transport` library declarations from dev's `pandaproxy/schema_registry/BUILD` were also dropped (their source files don't exist on `v26.1.x`).

## Review guidance

You can see the range-diff between the original PR and this backport PR here: [`git range-diff 555462fc98^..82cb0bc8d4 upstream/v26.1.x..efa3c6bf6a`](https://gist.github.com/pgellert/c8df7a92cb330589e0e531ff42690e26)