### PR TITLE
bazel: route flaky upstream deps through vectorized-public s3 mirror

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,6 +9,10 @@ startup --experimental_remote_repo_contents_cache
 common --experimental_repository_downloader_retries=15
 common --http_connector_attempts=24
 
+# Try our s3 mirror as the primary fetch path for known-flaky upstream URLs.
+# See bazel/dependency-mirroring.md for how to add an entry.
+common --downloader_config=bazel_downloader.cfg
+
 # Bazel 9 removes native C++ rule symbols. Autoload them for external rulesets
 # that have not migrated all generated BUILD/Starlark files to explicit loads.
 common --incompatible_autoload_externally=+@rules_cc

--- a/bazel/dependency-mirroring.md
+++ b/bazel/dependency-mirroring.md
@@ -1,0 +1,132 @@
+# Mirroring flaky external Bazel dependencies
+
+Bazel doesn't retry on HTTP 4xx and only sparingly on 5xx, so a single
+failed GET against an upstream host (most often `github.com`) aborts the
+whole build. Examples from the
+[#core-build thread](https://redpandadata.slack.com/archives/C0794GQ5NL9/p1773340892133739):
+`zlib` returned 502, `rules_boost` returned 404, `tar.bzl` returned 502
+— each took down a round of CI.
+
+To absorb these flakes we route known-flaky URLs through our own s3
+mirror at `https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/`,
+falling back to the upstream URL if s3 is somehow down. Bazel's
+[`--downloader_config`](https://bazel.build/reference/command-line-reference#flag--downloader_config)
+flag (set in `.bazelrc`) points at the rewrite rules in
+[`bazel_downloader.cfg`](../bazel_downloader.cfg) at the repo root.
+
+## How it works
+
+Two layers:
+
+1. **vtools `dependencies.csv`** — adding a row to
+   `scripts/vectorized-public-dependencies/dependencies.csv` in the
+   `redpanda-data/vtools` repo causes the `upload-deps.yml` workflow to
+   fetch the upstream URL, verify its sha256, and copy it into the
+   `vectorized-public/dependencies/` s3 bucket.
+
+2. **redpanda `bazel_downloader.cfg`** — a per-artifact pair of
+   `rewrite` rules:
+   ```
+   # mirror first
+   rewrite UPSTREAM_REGEX_WITH_FILENAME_CAPTURE s3.url/dependencies/$1
+   # identity fallback
+   rewrite (UPSTREAM_FULL_REGEX) $1
+   ```
+   The first line substitutes the upstream URL with the s3 mirror URL.
+   The second rewrites the upstream URL to itself (`$1`) — required
+   because Bazel's `rewrite` is **substitutive**: once any rewrite line
+   matches a URL, the original is dropped from the candidate list (see
+   [`UrlRewriter.java`](https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriter.java)).
+   Without the identity rewrite, the upstream URL would never be tried.
+
+   Bazel attempts candidates in the order they appear in the file, so
+   listing the mirror first makes s3 the primary fetch path. sha256 is
+   verified by Bazel against `MODULE.bazel` / `http_archive(...)` on
+   whichever candidate succeeded, so a corrupt mirror cannot poison the
+   build.
+
+## Adding a new mirror
+
+Use this when an upstream URL has flaked CI (or you can see it's likely
+to). One PR per repo:
+
+### 1. vtools — upload to s3
+
+In `redpanda-data/vtools`, run [`/rp-mirror-artifact`](https://github.com/redpanda-data/vtools/blob/main/scripts/vectorized-public-dependencies/README.md)
+or by hand: add a row to `scripts/vectorized-public-dependencies/dependencies.csv`
+in alphabetical order by s3 filename:
+
+```
+<s3_filename>,<upstream_url>,<sha256_hex>
+```
+
+The `upload-deps.yml` PR check validates the URL is reachable and the
+sha256 matches before merge. After merge, the file is uploaded to
+`https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/<s3_filename>`.
+
+The s3 filename usually mirrors the upstream basename. Prefix it
+(`rules_boost-<sha>.tar.gz` rather than just `<sha>.tar.gz`) when the
+basename is opaque or could collide with another package.
+
+### 2. redpanda — add the rewrite
+
+After the vtools PR merges and the artifact is in s3, add a paired
+rewrite to `bazel_downloader.cfg`:
+
+```
+# mylib v1.2.3 (BCR | archive_override | http_archive in MODULE.bazel)
+rewrite host\.example\.com/path/(mylib-1\.2\.3\.tar\.gz) vectorized-public.s3.us-west-2.amazonaws.com/dependencies/$1
+rewrite (host\.example\.com/path/mylib-1\.2\.3\.tar\.gz) $1
+```
+
+Notes on the regex:
+
+- **Java regex with `$N` backrefs.** Escape `.` literals as `\.`.
+- **Match by exact path**, not blanket `host.example.com/*`. Catching
+  unmirrored URLs would silently break their fetch (s3 would 404, then
+  the identity rewrite isn't there to save us — the original URL is
+  already gone after the first match).
+- The `rewrite` line **does not include the URL scheme** — match starts
+  at the host.
+
+### 3. Verify
+
+Locally, confirm Bazel actually exercises the mirror with
+`bazel fetch <repo> --output_base=/tmp/test-ob --repository_cache=/tmp/test-rc`
+(fresh output_base + repo cache forces a real download). Then check the
+repo cache:
+```
+find /tmp/test-rc -name "*<expected-sha256-prefix>*"
+```
+
+If the expected sha256 file shows up and there are no warnings about
+download failures from the s3 host in the bazel output, the mirror is
+the URL Bazel hit.
+
+For higher-stakes verification, deliberately introduce a typo (regex or
+filename) and confirm: a typo'd regex leaves rustc/zlib/etc untouched
+(no s3 attempt visible), a typo'd s3 filename causes a `404` warning
+and a fallback to the upstream URL — both prove the chain is wired
+correctly.
+
+## Why we don't just `block` upstream hosts
+
+We could pair each `rewrite` with a `block` to force traffic exclusively
+through s3. We don't, because:
+
+- An s3 outage with no fallback would take CI down hard.
+- Mirror-first + identity fallback gives the same speed/reliability win
+  on the happy path and self-heals when s3 is the one that hiccups.
+- It's incremental: forgetting to mirror something doesn't break the
+  build, it just continues fetching from upstream as before.
+
+## When **not** to add a mirror
+
+- Single-source artifacts already served only from `vectorized-public`
+  (`@openssl`, `@hwloc`, etc. in [`bazel/repositories.bzl`](repositories.bzl))
+  don't need a downloader rewrite — the URL in `http_archive(...)` is
+  already s3.
+- Tiny one-off downloads from rarely-flaky CDNs aren't worth the bucket
+  storage. The bucket isn't free; rule of thumb is ≥1 observed CI flake
+  on that URL.
+- Files behind a license that forbids redistribution. Don't.

--- a/bazel_downloader.cfg
+++ b/bazel_downloader.cfg
@@ -1,0 +1,32 @@
+# Bazel downloader config: redirect known-flaky upstream fetches through
+# our s3 mirror at https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/.
+#
+# See bazel/dependency-mirroring.md for the full how-to (when to add an
+# entry, how to upload to the bucket via vtools, regex syntax).
+#
+# Each artifact has a paired rewrite: mirror first (so s3 is the primary
+# fetch path), then an identity rewrite (REGEX -> $1) so the upstream URL
+# is kept as a fallback. `rewrite` is substitutive in Bazel — once any
+# rewrite matches, the original URL is dropped from the candidate list,
+# so the identity line is required for fallback. sha256 is verified by
+# Bazel against MODULE.bazel / http_archive(...) regardless of which
+# candidate succeeded, so a corrupted mirror cannot poison the build.
+#
+# Match upstream URLs by exact path (not blanket `github.com/*`) to keep
+# unmirrored deps fetching from their original location.
+
+# rustc 1.91.0 toolchains (rules_rust toolchain extension).
+rewrite static\.rust-lang\.org/dist/(rustc-1\.91\.0-(?:x86_64|aarch64)-unknown-linux-gnu\.tar\.xz) vectorized-public.s3.us-west-2.amazonaws.com/dependencies/$1
+rewrite (static\.rust-lang\.org/dist/rustc-1\.91\.0-(?:x86_64|aarch64)-unknown-linux-gnu\.tar\.xz) $1
+
+# zlib 1.3.1 (BCR @ zlib/1.3.1.bcr.8).
+rewrite github\.com/madler/zlib/releases/download/v1\.3\.1/(zlib-1\.3\.1\.tar\.gz) vectorized-public.s3.us-west-2.amazonaws.com/dependencies/$1
+rewrite (github\.com/madler/zlib/releases/download/v1\.3\.1/zlib-1\.3\.1\.tar\.gz) $1
+
+# rules_boost (archive_override in MODULE.bazel).
+rewrite github\.com/nelhage/rules_boost/archive/(f5b0f8c904f2487d8f5a9a956d4388724e627210\.tar\.gz) vectorized-public.s3.us-west-2.amazonaws.com/dependencies/rules_boost-$1
+rewrite (github\.com/nelhage/rules_boost/archive/f5b0f8c904f2487d8f5a9a956d4388724e627210\.tar\.gz) $1
+
+# tar.bzl v0.6.0 (BCR transitive).
+rewrite github\.com/bazel-contrib/tar\.bzl/releases/download/v0\.6\.0/(tar\.bzl-v0\.6\.0\.tar\.gz) vectorized-public.s3.us-west-2.amazonaws.com/dependencies/$1
+rewrite (github\.com/bazel-contrib/tar\.bzl/releases/download/v0\.6\.0/tar\.bzl-v0\.6\.0\.tar\.gz) $1


### PR DESCRIPTION
This is basically a test. If it seems to work, then I could suggest that we just do one of:

1) use a general rewrite for github, for example, and use _only_ s3 (not with the GH fallback), which means everything needs to be mirrored. We can have a skill that makes this process relatively smooth.

2) the general re-write but with GH fallback, but a CI check that we have uploaded all the s3 files.

3) the general re-write + GH fallback, but no enforcemnet, but have a script/skill which makes bulk upload mirroring easy (I've already checked this seems possible)

4) Have something like the vtools-side uploader here on the rp repo which can auto-add new artifacts. Because of "timing" I guess this works best with the GH fallback (since for the PR run itself the upload presumably hasn't happened).

---

Bazel does not retry on HTTP 4xx and is sparing on 5xx, so a single transient github outage at the dep-fetch step aborts the whole build. Recent examples in #core-build ([slack thread](https://redpandadata.slack.com/archives/C0794GQ5NL9/p1773340892133739)): `rules_boost` returned 404, `zlib` returned 502, `tar.bzl` returned 502 — each took down a round of CI. `--experimental_remote_repo_contents_cache` (#30341) didn't help because most rules don't meet its preconditions; #30399 was a "bandaid".

This PR adds a per-artifact downloader-rewrite layer ([Aspect blog](https://blog.aspect.build/configuring-bazels-downloader)) that routes known-flaky upstream URLs through our existing s3 mirror at `vectorized-public.s3.us-west-2.amazonaws.com/dependencies/`. The vtools side that uploaded the four mirrored files merged in [vtools#4234](https://github.com/redpanda-data/vtools/pull/4234).

The mechanism uses **paired** rewrite rules per artifact:

```
# mirror first
rewrite host\.example\.com/path/(file\.tar\.gz) vectorized-public.s3.us-west-2.amazonaws.com/dependencies/$1
# identity fallback
rewrite (host\.example\.com/path/file\.tar\.gz) $1
```

Bazel's `rewrite` is *substitutive* — once any rewrite matches, the original URL is dropped from the candidate list (per [`UrlRewriter.java`](https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriter.java)). The identity rewrite (`REGEX → $1`) is required to keep the upstream URL reachable as a fallback. Mirror-first ordering makes s3 the primary fetch path; the upstream URL is tried only if s3 returns non-200. sha256 is verified against `MODULE.bazel`/`http_archive(...)` regardless of which candidate succeeded, so a corrupt mirror cannot poison the build.

Initial set of mirrored artifacts:

- `rustc-1.91.0-{x86_64,aarch64}-unknown-linux-gnu.tar.xz` (rules_rust toolchain extension)
- `zlib-1.3.1.tar.gz` (BCR `zlib/1.3.1.bcr.8`)
- `rules_boost-f5b0f8c904f2487d8f5a9a956d4388724e627210.tar.gz` (`archive_override` in MODULE.bazel)
- `tar.bzl-v0.6.0.tar.gz` (BCR transitive)

Adoption is incremental — to mirror a new flaky URL, follow the recipe in `bazel/dependency-mirroring.md`: add a row to vtools `dependencies.csv` (uploads to s3 via the `upload-deps` workflow), then add a paired `rewrite` to `bazel_downloader.cfg`. Forgetting to mirror something doesn't break the build, it just keeps fetching from upstream.

Verified locally with a fresh output_base + repository_cache:

- `@@rules_rust++rust+rust_linux_x86_64...stable_tools` — rustc 1.91.0 (78 MB) and rules_boost (35 KB) fetched silently from s3 with sha256 matches in the repo cache.
- `@@zlib+//:all` — zlib (1.5 MB) fetched silently from s3 with sha256 match.
- Pre-merge dry run with the s3 mirror still empty (404) confirmed the identity-fallback path: `WARNING: Download from https://vectorized-public...rules_boost...failed: GET returned 404 Not Found` followed by a successful github fetch — fallback chain works as designed.

CORE-16255

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none