### PR TITLE
fix: reset _authentication_state to none

### DIFF
--- a/src/v/kafka/client/broker.cc
+++ b/src/v/kafka/client/broker.cc
@@ -159,6 +159,7 @@ ss::future<> remote_broker::maybe_authenticate() {
         co_await do_authenticate();
         _authentication_state = auth_state::authenticated;
     } catch (...) {
+        _authentication_state = auth_state::none;
         vlog(
           _logger.warn, "Authentication error - {}", std::current_exception());
         throw;

--- a/src/v/kafka/client/test/reconnect.cc
+++ b/src/v/kafka/client/test/reconnect.cc
@@ -166,3 +166,106 @@ FIXTURE_TEST(password_change_live_client, kafka_client_fixture) {
     info("Stopping kafka client");
     kafka_client.stop().get();
 }
+
+FIXTURE_TEST(auth_failure_does_not_get_stuck_in_progress, kafka_client_fixture) {
+    using namespace std::chrono_literals;
+    ss::sstring username{"admin"};
+    ss::sstring correct_password{"correct_pass"};
+    ss::sstring wrong_password{"wrong_pass"};
+
+    info("Enable SASL and restart");
+    enable_sasl_and_restart(username);
+    auto disable_sasl = ss::defer([this] {
+        info("Disable SASL and restart");
+        disable_sasl_and_restart();
+    });
+    info("Waiting for leadership");
+    wait_for_controller_leadership().get();
+
+    info("Create superuser");
+    ss::sstring user_body = fmt::format(
+      R"({{"username": "{}", "password": "{}","algorithm": "SCRAM-SHA-256"}})",
+      username,
+      correct_password);
+    auto body = iobuf();
+    body.append(user_body.data(), user_body.size());
+    auto admin_client = make_admin_client();
+    auto res = http_request(
+      admin_client,
+      "/v1/security/users",
+      std::move(body),
+      boost::beast::http::verb::post);
+    BOOST_REQUIRE_EQUAL(res.headers.result(), boost::beast::http::status::ok);
+
+    // Connect successfully with correct credentials first so the cluster is
+    // started and brokers are discovered.
+    auto kafka_client = make_client();
+    kafka_client.set_retry_base_backoff(10ms);
+    kafka_client.set_max_retries(size_t(0));
+    kafka_client.set_credentials(
+      kc::sasl_configuration{
+        .mechanism = "SCRAM-SHA-256",
+        .username = username,
+        .password = correct_password,
+      });
+    kafka_client.connect().get();
+
+    // Now swap in wrong credentials and force a reconnect by dispatching a
+    // request. The broker will reconnect and attempt authentication with the
+    // wrong password, leaving _authentication_state in a failed state.
+    // Before the fix, the state was left as in_progress, which caused
+    // needs_authentication() to return false on the next attempt, silently
+    // skipping re-authentication and making all subsequent requests fail.
+    info("Swapping to wrong credentials");
+    kafka_client.set_credentials(
+      kc::sasl_configuration{
+        .mechanism = "SCRAM-SHA-256",
+        .username = username,
+        .password = wrong_password,
+      });
+
+    // Force the broker to reconnect and hit the bad auth path. Allow 1 retry
+    // so transient disconnect/broker_not_available after restart does not make
+    // the test flaky before it reaches the SASL auth path.
+    restart(true);
+    wait_for_controller_leadership().get();
+    kafka_client.set_max_retries(size_t(1));
+    BOOST_REQUIRE_EXCEPTION(
+      kafka_client.dispatch(make_list_topics_req()).get(),
+      kc::broker_error,
+      [](const kc::broker_error& e) {
+          return e.error == kafka::error_code::sasl_authentication_failed;
+      });
+
+    // Restore correct credentials. With the fix, _authentication_state was
+    // reset to none on failure, so the next dispatch re-attempts auth and
+    // succeeds. Without the fix it stays in_progress and the request fails.
+    info("Restoring correct credentials");
+    kafka_client.set_credentials(
+      kc::sasl_configuration{
+        .mechanism = "SCRAM-SHA-256",
+        .username = username,
+        .password = correct_password,
+      });
+    kafka_client.set_max_retries(size_t(3));
+
+    {
+        info("Adding a known topic to verify authenticated request succeeds");
+        auto tp = model::topic_partition(
+          model::topic("t"), model::partition_id(0));
+        auto ntp = make_default_ntp(tp.topic, tp.partition);
+        add_topic(model::topic_namespace_view(ntp)).get();
+
+        info("Verifying client recovers after auth failure");
+        auto result = kafka_client.dispatch(make_list_topics_req()).get();
+        BOOST_REQUIRE_EQUAL(result.data.topics.size(), 1);
+        static_assert(
+          kc::api_version_for(kafka::metadata_request::api_type::key)
+            < kafka::api_version(12),
+          "topic::name is nullable in v12+");
+        BOOST_REQUIRE_EQUAL((*result.data.topics[0].name)(), "t");
+    }
+
+    info("Stopping kafka client");
+    kafka_client.stop().get();
+}


### PR DESCRIPTION
I am not a C++ developer (good memories from college 😆 ), but I was investigating [this issue I faced](https://github.com/redpanda-data/redpanda/issues/30385) and then I discovered this...

When the schema registry client tries to connect to a broker, it calls `connect_with_retries()` → `connect()` → `do_connect()`, which opens a TCP+TLS connection and stores it in `_fd`. Then `maybe_authenticate()` is called and throws `sasl_authentication_failed`.

State after auth failure:

`_fd` = non-null (TLS socket open, TCP alive) →` is_valid()` = true
`_authentication_state` = `in_progress` (never reset to none)

Every subsequent retry (every ~20s):
- `maybe_initialize_connection()` checks: `is_valid()`==true AND `needs_authentication()`==false (state is in_progress, not none)
- Returns early. The broker is permanently stuck, it thinks it has a valid connection that doesn't need authentication, but authentication never succeeded.

The TCP connection eventually drops (keepalive timeout). Then `is_valid()` = false, `connect_with_retries()` proceeds, allocates a new connection, auth fails again, and the cycle repeats. The broker never successfully authenticates.

What call is missing: the catch block in `maybe_authenticate()` needs to reset `_authentication_state` to none so that the next retry actually attempts to reconnect and re-authenticate.

The TLDR; We do the code change so the next call to maybe_initialize_connection() sees needs_authentication()==true and retries the full reconnect+authenticate sequence instead of returning early.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required
<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes
### Bug Fixes
* Fix Kafka client broker getting stuck in `in_progress` authentication state after a SASL authentication failure, preventing subsequent retries from re-attempting authentication.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
