### PR TITLE
[v26.1.x] rpk/debug/bundle: dedup admin addresses across host forms

### DIFF
--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
@@ -99,7 +99,7 @@ func executeK8SBundle(ctx context.Context, bp bundleParams) error {
 	if err := checkK8sPermissions(ctx, bp.namespace); err != nil {
 		errs = multierror.Append(
 			errs,
-			fmt.Errorf("skipping log collection and Kubernetes resource collection (such as Pods and Services) in the namespace %q. To enable this, grant additional permissions to your Service Account. For more information, visit https://docs.redpanda.com/current/manage/kubernetes/troubleshooting/k-diagnostics-bundle/", err),
+			fmt.Errorf("skipping log collection and Kubernetes resource collection (such as Pods and Services) in the namespace %q: %v. To enable this, grant additional permissions to your Service Account. For more information, visit https://docs.redpanda.com/current/manage/kubernetes/troubleshooting/k-diagnostics-bundle/", bp.namespace, err),
 		)
 	} else {
 		steps = append(steps, []step{
@@ -149,18 +149,61 @@ func executeK8SBundle(ctx context.Context, bp bundleParams) error {
 	return nil
 }
 
-// adminAddressesUnion returns the union of two slices of adminAddresses.
+// adminAddressesUnion returns the union of two slices of admin addresses,
+// treating two entries as the same broker iff they share the same leftmost
+// DNS label of the host portion and the same port. This collapses pairs like
+//
+//	"cluster-third-0.default:9644"                                   (rpk profile, short form)
+//	"cluster-third-0.cluster.default.svc.cluster.local.:9644"        (K8s discovery, FQDN)
+//
+// which the previous implementation treated as distinct strings, causing the
+// local broker to be queried twice (once per host form) when the rpk profile
+// and the K8s discovery disagree on the DNS suffix — common in setups where
+// the operator renders short-form addresses but rpk reconstructs FQDNs from a
+// headless Service. IP literals are not collapsed: only the leftmost label of
+// non-IP hostnames is used as the dedup key.
+//
+// Order is preserved; the first occurrence of each broker wins.
 func adminAddressesUnion(a, b []string) []string {
-	m := make(map[string]struct{}) // track unique addresses.
-	for _, v := range a {
-		m[v] = struct{}{}
+	seen := make(map[string]struct{}, len(a)+len(b))
+	out := make([]string, 0, len(a)+len(b))
+	for _, addr := range a {
+		appendUnique(addr, seen, &out)
 	}
-	for _, v := range b {
-		if _, ok := m[v]; !ok {
-			a = append(a, v)
-		}
+	for _, addr := range b {
+		appendUnique(addr, seen, &out)
 	}
-	return a
+	return out
+}
+
+func appendUnique(addr string, seen map[string]struct{}, out *[]string) {
+	key := adminAddressKey(addr)
+	if _, ok := seen[key]; ok {
+		return
+	}
+	seen[key] = struct{}{}
+	*out = append(*out, addr)
+}
+
+// adminAddressKey returns a canonical key used to detect that two admin
+// address strings refer to the same broker. The key is the leftmost label of
+// the host portion (stripped of any trailing dot) plus the port. For IP
+// literals the full address is used so different hosts in the same subnet
+// don't collapse. If the input isn't a valid host:port, the original string
+// is returned so behavior degrades to exact-string equality.
+func adminAddressKey(addr string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr
+	}
+	host = strings.TrimSuffix(host, ".")
+	if net.ParseIP(host) != nil {
+		return host + ":" + port
+	}
+	if i := strings.IndexByte(host, '.'); i >= 0 {
+		host = host[:i]
+	}
+	return host + ":" + port
 }
 
 func k8sClientset() (*kubernetes.Clientset, error) {

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_test.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_test.go
@@ -344,3 +344,74 @@ func TestSliceControllerDir(t *testing.T) {
 		})
 	}
 }
+
+func TestAdminAddressesUnion(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		a, b []string
+		want []string
+	}{
+		{
+			name: "no overlap",
+			a:    []string{"a:9644", "b:9644"},
+			b:    []string{"c:9644"},
+			want: []string{"a:9644", "b:9644", "c:9644"},
+		},
+		{
+			name: "exact duplicate across sources",
+			a:    []string{"broker-0.svc.ns.svc.cluster.local:9644"},
+			b:    []string{"broker-0.svc.ns.svc.cluster.local:9644"},
+			want: []string{"broker-0.svc.ns.svc.cluster.local:9644"},
+		},
+		{
+			name: "short form vs FQDN — same broker, profile wins",
+			a:    []string{"cluster-third-0.default:9644"},
+			b:    []string{"cluster-third-0.cluster.default.svc.cluster.local.:9644"},
+			want: []string{"cluster-third-0.default:9644"},
+		},
+		{
+			name: "trailing dot is normalized",
+			a:    []string{"broker-0.ns.svc.cluster.local:9644"},
+			b:    []string{"broker-0.ns.svc.cluster.local.:9644"},
+			want: []string{"broker-0.ns.svc.cluster.local:9644"},
+		},
+		{
+			name: "different brokers in same headless service stay separate",
+			a:    []string{"broker-0.cluster.default.svc.cluster.local.:9644"},
+			b:    []string{"broker-1.cluster.default.svc.cluster.local.:9644"},
+			want: []string{
+				"broker-0.cluster.default.svc.cluster.local.:9644",
+				"broker-1.cluster.default.svc.cluster.local.:9644",
+			},
+		},
+		{
+			name: "IPv4 literals are not collapsed by leading octet",
+			a:    []string{"10.0.0.1:9644"},
+			b:    []string{"10.0.0.2:9644"},
+			want: []string{"10.0.0.1:9644", "10.0.0.2:9644"},
+		},
+		{
+			name: "different ports for same host stay separate",
+			a:    []string{"broker-0.default:9644"},
+			b:    []string{"broker-0.default:9645"},
+			want: []string{"broker-0.default:9644", "broker-0.default:9645"},
+		},
+		{
+			name: "duplicates within a single slice are also collapsed",
+			a:    []string{"broker-0.default:9644", "broker-0.cluster.default.svc.cluster.local.:9644"},
+			b:    nil,
+			want: []string{"broker-0.default:9644"},
+		},
+		{
+			name: "unparseable addresses fall back to exact-string compare",
+			a:    []string{"not-a-valid-addr"},
+			b:    []string{"not-a-valid-addr", "also-bogus"},
+			want: []string{"not-a-valid-addr", "also-bogus"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := adminAddressesUnion(tc.a, tc.b)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30403

- Command: git cherry-pick -x 04f0cd0104 d6f7d8a5bd
- Commits backported: 2
- Conflicts resolved: 1
- Commits skipped (already on target): 1
- Backport branch: ai-backport-pr-30403-v26.1.x-1778176299

## Conflict details

- 04f0cd0104 (src/go/rpk/pkg/cli/debug/bundle/bundle_test.go): conflict
  appeared because the new `TestAdminAddressesUnion` was anchored after
  `TestSaveProcFileSampled`, which exists on dev but not on v26.1.x. Verified
  that `saveProcFileSampled` is not defined anywhere on v26.1.x — pulling in
  the unrelated test would not compile. Resolved by appending only
  `TestAdminAddressesUnion` after `TestSliceControllerDir` and dropping the
  `TestSaveProcFileSampled` block from the incoming side. The auto-merged
  `bundle_k8s_linux.go` changes (`adminAddressesUnion` rewrite plus the
  `bp.namespace` fix in the `checkK8sPermissions` error message) match the
  source commit exactly.
- d6f7d8a5bd: skipped — this is the "Merge branch 'dev' into ..." commit
  from the original PR; cherry-picking a merge into a release branch is not
  meaningful and its substantive contents are already represented by the
  preceding commit (04f0cd0104).
