### PR TITLE
redpanda/tests: split wait_for_partition_offset into committed-offset and lso variants

### DIFF
--- a/src/v/kafka/client/test/consumer_group.cc
+++ b/src/v/kafka/client/test/consumer_group.cc
@@ -82,7 +82,7 @@ FIXTURE_TEST(consumer_group, kafka_client_fixture) {
     for (int t = 0; t < topic_count; ++t) {
         for (int p = 0; p < partition_count; ++p) {
             const auto& tp_ns = topics_namespaces[t];
-            wait_for_partition_offset(
+            wait_for_lso(
               model::ntp(tp_ns.ns, tp_ns.tp, model::partition_id{p}),
               model::offset{0})
               .get();

--- a/src/v/kafka/client/test/fetch.cc
+++ b/src/v/kafka/client/test/fetch.cc
@@ -52,7 +52,7 @@ FIXTURE_TEST(fetch, kafka_client_fixture) {
     auto ntp = model::ntp(tp_ns.ns, tp_ns.tp, model::partition_id{0});
 
     info("Waiting for topic data");
-    wait_for_partition_offset(ntp, model::offset{1}).get();
+    wait_for_lso(ntp, model::offset{1}).get();
 
     {
         info("Fetching from nonempty known topic");

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -53,7 +53,7 @@ public:
         ss::parallel_for_each(
           boost::irange(0, partitions),
           [this, tp_ns](int i) {
-              return wait_for_partition_offset(
+              return wait_for_committed_offset(
                 model::ntp(tp_ns.ns, tp_ns.tp, model::partition_id(i)),
                 model::offset(0));
           })

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -436,7 +436,7 @@ FIXTURE_TEST(fetch_empty, redpanda_thread_fixture) {
     wait_for_controller_leadership().get();
     add_topic(model::topic_namespace_view(ntp)).get();
 
-    wait_for_partition_offset(ntp, model::offset(0)).get();
+    wait_for_lso(ntp, model::offset(0)).get();
 
     kafka::fetch_request no_topics;
     no_topics.data.max_bytes = std::numeric_limits<int32_t>::max();
@@ -475,7 +475,7 @@ FIXTURE_TEST(fetch_leader_epoch, redpanda_thread_fixture) {
     wait_for_controller_leadership().get();
     add_topic(model::topic_namespace_view(ntp)).get();
 
-    wait_for_partition_offset(ntp, model::offset(0)).get();
+    wait_for_lso(ntp, model::offset(0)).get();
 
     const auto shard = app.shard_table.local().shard_for(ntp);
     app.partition_manager
@@ -683,7 +683,7 @@ FIXTURE_TEST(fetch_multi_partitions_debounce, redpanda_thread_fixture) {
 
     for (int i = 0; i < 6; ++i) {
         auto ntp = make_default_ntp(topic, model::partition_id(i));
-        wait_for_partition_offset(ntp, model::offset(0)).get();
+        wait_for_lso(ntp, model::offset(0)).get();
     }
 
     kafka::fetch_request req;
@@ -763,7 +763,7 @@ FIXTURE_TEST(fetch_leader_ack, redpanda_thread_fixture) {
     wait_for_controller_leadership().get();
 
     add_topic(model::topic_namespace_view(ntp)).get();
-    wait_for_partition_offset(ntp, model::offset(0)).get();
+    wait_for_lso(ntp, model::offset(0)).get();
 
     kafka::fetch_request req;
     req.data.max_bytes = std::numeric_limits<int32_t>::max();
@@ -825,7 +825,7 @@ FIXTURE_TEST(fetch_one_debounce, redpanda_thread_fixture) {
     wait_for_controller_leadership().get();
 
     add_topic(model::topic_namespace_view(ntp)).get();
-    wait_for_partition_offset(ntp, model::offset(0)).get();
+    wait_for_lso(ntp, model::offset(0)).get();
 
     kafka::fetch_request req;
     req.data.max_bytes = std::numeric_limits<int32_t>::max();
@@ -892,11 +892,11 @@ FIXTURE_TEST(fetch_multi_topics, redpanda_thread_fixture) {
     // topic 1
     for (int i = 0; i < 6; ++i) {
         ntps.push_back(make_default_ntp(topic_1, model::partition_id(i)));
-        wait_for_partition_offset(ntps.back(), model::offset(0)).get();
+        wait_for_lso(ntps.back(), model::offset(0)).get();
     }
     // topic 2
     ntps.push_back(make_default_ntp(topic_2, model::partition_id(0)));
-    wait_for_partition_offset(ntps.back(), model::offset(0)).get();
+    wait_for_lso(ntps.back(), model::offset(0)).get();
 
     // request
     kafka::fetch_request req;
@@ -981,7 +981,7 @@ FIXTURE_TEST(fetch_request_max_bytes, redpanda_thread_fixture) {
     wait_for_controller_leadership().get();
 
     add_topic(model::topic_namespace_view(ntp)).get();
-    wait_for_partition_offset(ntp, model::offset(0)).get();
+    wait_for_lso(ntp, model::offset(0)).get();
     // append some data
     auto shard = app.shard_table.local().shard_for(ntp);
     app.partition_manager
@@ -1049,7 +1049,7 @@ FIXTURE_TEST(fetch_offset_out_of_range, redpanda_thread_fixture) {
     wait_for_controller_leadership().get();
 
     add_topic(model::topic_namespace_view(ntp)).get();
-    wait_for_partition_offset(ntp, model::offset(0)).get();
+    wait_for_lso(ntp, model::offset(0)).get();
     // append some data
     auto shard = app.shard_table.local().shard_for(ntp);
     app.partition_manager
@@ -1141,7 +1141,7 @@ FIXTURE_TEST(fetch_response_bytes_eq_units, redpanda_thread_fixture) {
     wait_for_controller_leadership().get();
     add_topic(model::topic_namespace_view(ntp)).get();
 
-    wait_for_partition_offset(ntp, model::offset(0)).get();
+    wait_for_lso(ntp, model::offset(0)).get();
 
     // append some data
     auto shard = app.shard_table.local().shard_for(ntp);
@@ -1161,7 +1161,7 @@ FIXTURE_TEST(fetch_response_bytes_eq_units, redpanda_thread_fixture) {
               });
         })
       .get();
-    wait_for_partition_offset(ntp, model::offset(20)).get();
+    wait_for_lso(ntp, model::offset(20)).get();
 
     auto conn_context = make_connection_context();
     conn_context->start().get();
@@ -1220,7 +1220,7 @@ FIXTURE_TEST(
 
     wait_for_controller_leadership().get();
     add_topic(model::topic_namespace_view(ntp)).get();
-    wait_for_partition_offset(ntp, model::offset(0)).get();
+    wait_for_lso(ntp, model::offset(0)).get();
 
     // Produce some data
     auto shard = app.shard_table.local().shard_for(ntp);
@@ -1336,7 +1336,7 @@ FIXTURE_TEST(
 
     for (int i = 0; i < num_partitions; ++i) {
         auto ntp = make_default_ntp(topic, model::partition_id(i));
-        wait_for_partition_offset(ntp, model::offset(0)).get();
+        wait_for_lso(ntp, model::offset(0)).get();
     }
 
     // Write data to all partitions.

--- a/src/v/kafka/server/tests/list_offsets_test.cc
+++ b/src/v/kafka/server/tests/list_offsets_test.cc
@@ -211,7 +211,7 @@ FIXTURE_TEST(list_offsets_by_time, redpanda_thread_fixture) {
       model::partition_id(0));
 
     add_topic(model::topic_namespace_view{ntp}, 1).get();
-    wait_for_partition_offset(ntp, model::offset(0)).get();
+    wait_for_lso(ntp, model::offset(0)).get();
 
     auto client = make_kafka_client().get();
     client.connect().get();

--- a/src/v/kafka/server/tests/partition_reassignments_test.cc
+++ b/src/v/kafka/server/tests/partition_reassignments_test.cc
@@ -35,7 +35,7 @@ public:
         ss::parallel_for_each(
           boost::irange(0, partitions),
           [this, tp_ns](int i) {
-              return wait_for_partition_offset(
+              return wait_for_committed_offset(
                 model::ntp(tp_ns.ns, tp_ns.tp, model::partition_id(i)),
                 model::offset(0));
           })

--- a/src/v/redpanda/tests/fixture.cc
+++ b/src/v/redpanda/tests/fixture.cc
@@ -648,20 +648,42 @@ redpanda_thread_fixture::delete_topic(model::topic_namespace tp_ns) {
       });
 }
 
-ss::future<> redpanda_thread_fixture::wait_for_partition_offset(
-  model::ntp ntp, model::offset o, model::timeout_clock::duration tout) {
+namespace {
+ss::future<> do_wait_for_partition_offset(
+  application& app,
+  model::ntp ntp,
+  model::offset o,
+  model::timeout_clock::duration tout,
+  bool wait_lso) {
     RPTEST_REQUIRE_EVENTUALLY_CORO(
-      tout, [this, ntp = std::move(ntp), o]() mutable {
+      tout, [&app, ntp = std::move(ntp), o, wait_lso]() mutable {
           auto shard = app.shard_table.local().shard_for(ntp);
           if (!shard) {
               return ss::make_ready_future<bool>(false);
           }
           return app.partition_manager.invoke_on(
-            *shard, [ntp, o](cluster::partition_manager& mgr) {
+            *shard, [ntp, o, wait_lso](cluster::partition_manager& mgr) {
                 auto partition = mgr.get(ntp);
-                return partition && partition->committed_offset() >= o;
+                if (!partition) {
+                    return false;
+                }
+                return wait_lso ? partition->last_stable_offset() >= o
+                                : partition->committed_offset() >= o;
             });
       });
+}
+} // namespace
+
+ss::future<> redpanda_thread_fixture::wait_for_committed_offset(
+  model::ntp ntp, model::offset o, model::timeout_clock::duration tout) {
+    return do_wait_for_partition_offset(
+      app, std::move(ntp), o, tout, /*wait_lso=*/false);
+}
+
+ss::future<> redpanda_thread_fixture::wait_for_lso(
+  model::ntp ntp, model::offset o, model::timeout_clock::duration tout) {
+    return do_wait_for_partition_offset(
+      app, std::move(ntp), o, tout, /*wait_lso=*/true);
 }
 
 ss::future<model::offset>

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -197,7 +197,39 @@ public:
 
     ss::future<> delete_topic(model::topic_namespace tp_ns);
 
-    ss::future<> wait_for_partition_offset(
+    /// Wait until the partition's raft committed offset reaches \p o.
+    ///
+    /// This is a barrier on raft state only — it does not wait for any STMs
+    /// (e.g. rm_stm) layered on top of the partition to catch up. Tests that
+    /// subsequently issue Kafka requests which consult `last_stable_offset()`
+    /// (fetch, list_offsets, etc.) should prefer wait_for_lso() instead, since
+    /// rm_stm bootstrap is asynchronous with respect to the raft commit
+    /// barrier and can briefly return invalid_lso even after committed_offset
+    /// has advanced.
+    ///
+    /// Polls until the condition holds or \p tout elapses. On timeout the
+    /// surrounding test case is failed via RPTEST_FAIL_CORO — callers do not
+    /// need to assert the wait themselves.
+    ss::future<> wait_for_committed_offset(
+      model::ntp ntp,
+      model::offset o,
+      model::timeout_clock::duration tout = 3s);
+
+    /// Wait until the partition's last stable offset (LSO) reaches \p o.
+    ///
+    /// Stronger than wait_for_committed_offset(): also ensures any STM atop
+    /// the partition (rm_stm, present whenever idempotence or transactions
+    /// are enabled) has finished bootstrapping and applied entries up to \p
+    /// o. Use this for tests that subsequently issue Kafka requests
+    /// dispatched through the broker (fetch, list_offsets, produce via the
+    /// kafka client transport), since those consult `last_stable_offset()`
+    /// and will surface `offset_not_available` while rm_stm is still
+    /// bootstrapping.
+    ///
+    /// Polls until the condition holds or \p tout elapses. On timeout the
+    /// surrounding test case is failed via RPTEST_FAIL_CORO — callers do not
+    /// need to assert the wait themselves.
+    ss::future<> wait_for_lso(
       model::ntp ntp,
       model::offset o,
       model::timeout_clock::duration tout = 3s);


### PR DESCRIPTION
The original `wait_for_partition_offset` only waited on the partition's raft `committed_offset`, but several callers immediately follow it with kafka requests that consult `last_stable_offset()` (fetch, list_offsets, produce through the broker). `rm_stm` bootstrap is asynchronous w.r.t. the raft commit barrier, so those tests could observe `offset_not_available` even after raft state was caught up.

Concretely, this is the race behind the recurring flake of `fetch_multi_partitions_debounce`:

- See [BK build 84119](https://buildkite.com/redpanda/redpanda/builds/84119#019dff36-bb7c-43c6-88b7-cee27c74bb8e) for the failure on debug-arm64 that triggered this investigation. The same flake was previously observed and auto-triaged shut as [CORE-13066](https://redpandadata.atlassian.net/browse/CORE-13066) (also debug-arm64) without a fix.
- Same diagnosis from @dotnwat on [PR #30391](https://github.com/redpanda-data/redpanda/pull/30391#issuecomment-4392817026): "rm_stm::last_stable_offset has at least one case where it's waiting for the STM to replay … looks like the test needs a retry or some kind of wait-until-cool barrier."
- I confirmed the race by injecting `co_await ss::sleep_abortable(500ms, _as)` into `rm_stm::bootstrap_committed_offset()`: 10/10 fail without this fix, 10/10 pass with it.

This PR replaces `wait_for_partition_offset` with two named entry points sharing a private helper:

- `wait_for_committed_offset` — raft barrier only, equivalent to the previous behavior.
- `wait_for_lso` — additionally requires `last_stable_offset() >= o`, so any STM atop the partition (rm_stm, present whenever idempotence or transactions are enabled) has finished bootstrapping and applied entries up to `o`.

Routed each existing caller to the appropriate variant based on whether the test subsequently dispatches a kafka request that goes through the LSO path. The bulk of fetch/list_offsets/kafka client tests use `wait_for_lso`; alter-config and partition-reassignments tests stay on `wait_for_committed_offset`.

Tracked in [CORE-16254](https://redpandadata.atlassian.net/browse/CORE-16254). Closes [CORE-13066](https://redpandadata.atlassian.net/browse/CORE-13066) as a duplicate.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

[CORE-13066]: https://redpandadata.atlassian.net/browse/CORE-13066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-16254]: https://redpandadata.atlassian.net/browse/CORE-16254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ