### PR TITLE
`cloud_storage`: remove `zlib.h` include

### DIFF
--- a/src/v/cloud_storage/inventory/report_parser.h
+++ b/src/v/cloud_storage/inventory/report_parser.h
@@ -18,8 +18,6 @@
 
 #include <seastar/core/iostream.hh>
 
-#include <zlib.h>
-
 namespace cloud_storage::inventory {
 
 using is_gzip_compressed = ss::bool_class<struct gzip_compressed_tag>;


### PR DESCRIPTION
```
bazel-out/k8-fastbuild/bin/src/v/cloud_storage/_virtual_includes/cloud_storage/cloud_storage/inventory/repor
  t_parser.h:21:10: error: use of private header from outside its module: 'zlib.h' [-Wprivate-header]
     21 | #include <zlib.h>
        |
```

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
