### PR TITLE
[CORE-15498] `ct`: fix flake in `l0_object_size_distribution_test`

### DIFF
--- a/src/v/cloud_topics/level_zero/tests/BUILD
+++ b/src/v/cloud_topics/level_zero/tests/BUILD
@@ -19,6 +19,7 @@ redpanda_cc_gtest(
         "//src/v/config",
         "//src/v/model",
         "//src/v/model/tests:random",
+        "//src/v/test_utils:async",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
         "@seastar",

--- a/src/v/cloud_topics/level_zero/tests/l0_object_size_distribution_test.cc
+++ b/src/v/cloud_topics/level_zero/tests/l0_object_size_distribution_test.cc
@@ -16,6 +16,7 @@
 #include "model/namespace.h"
 #include "model/record.h"
 #include "model/tests/random_batch.h"
+#include "test_utils/async.h"
 #include "test_utils/test.h"
 
 #include <seastar/core/abort_source.hh>
@@ -218,8 +219,18 @@ TEST_F(L0ObjectSizeDistFixture, ThreeToOne) {
           .discard_result();
     });
 
-    // Allow requests to be propagated to the scheduler
-    ss::sleep(5ms).get();
+    // Wait until every shard has registered its write_request in the first
+    // pipeline stage.
+    RPTEST_REQUIRE_EVENTUALLY(5s, [&](this auto) -> ss::future<bool> {
+        size_t bytes = co_await pipeline.map_reduce0(
+          [](auto& p) {
+              const auto* counter = p.stage_bytes_ref_by_index(0);
+              return counter ? counter->load() : size_t{0};
+          },
+          size_t{0},
+          std::plus<>{});
+        co_return bytes >= total_size;
+    });
 
     // Advance time to trigger the scheduler
     ss::manual_clock::advance(300ms);


### PR DESCRIPTION
This test's `ss::sleep(5ms)` was race-y, since cross-shard `invoke_on_all()` pipeline delivery runs on wall-clock time, not on the manual clock. Under ASan, or on a loaded CI runner, one shard's lambda can run later than 5ms after dispatch. When that happens, the manual clock advances with only two shards' write requests registered; the scheduler does its single batching pass and uploads. The third shard's `write_request` then lands in the pipeline with nothing left to drain it, since the manual clock never advances again to fire its deadline-based flush, and the test hangs on `write_fut.get()` until the test-runner timeout (~5 minutes) kills it. Even if we didn't hang, we would likely observe two uploads here.

Replace the real-time sleep with `cooperative_spin_wait_with_timeout` polling `stage_bytes_ref_by_index(0)` (the scheduler's ingress counter) summed across shards until the total equals `total_size`, indicating that all three shards have observably entered the pipeline.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
