### PR TITLE
gha: backport — quote title to force exact-phrase search

### DIFF
--- a/.github/workflows/scripts/backport-command/create_issue.sh
+++ b/.github/workflows/scripts/backport-command/create_issue.sh
@@ -49,5 +49,6 @@ if [[ -z $backport_issue_url ]]; then
     --body "Backport $ORIG_ISSUE_URL to branch $BACKPORT_BRANCH. $additional_body"
 else
   msg="Backport issue already exists: $backport_issue_url"
+  echo "$msg"
   echo "BACKPORT_ERROR=$msg" >>"$GITHUB_ENV"
 fi

--- a/.github/workflows/scripts/backport-command/gh_wrapper.sh
+++ b/.github/workflows/scripts/backport-command/gh_wrapper.sh
@@ -35,7 +35,7 @@ gh_issue_url() {
   done
   shift $((OPTIND - 1))
 
-  search=${search-"[$BACKPORT_BRANCH] $ORIG_TITLE in:title"}
+  search=${search-"\"[$BACKPORT_BRANCH] $ORIG_TITLE\" in:title"}
   milestone=${milestone-$TARGET_MILESTONE}
   repo=${repo-$TARGET_ORG/$TARGET_REPO}
 


### PR DESCRIPTION
## Summary

The existing-issue check in `gh_issue_url()` used GitHub's relevance-ranked full-text search:

```bash
search="[$BACKPORT_BRANCH] $ORIG_TITLE in:title"
```

That's not an exact title match — GitHub tokenizes the title (`v25.3.x`, `dcv`, `Remove`, `DCV`, …) and matches any open issue with overlapping tokens. When an unrelated backport issue for the same target branch is open, it can be picked up as a "duplicate," and the script silently skips creating a real tracking issue.

This actually happened on PR #30410: both v26.1.x and v25.3.x cherry-picks failed (expected), but only #30412 (v26.1.x) got a tracking issue. The v25.3.x search was matched by #30404 (`[v25.3.x] tests: Remove DCV DT support`), which shares the tokens `v25.3.x`, `Remove`, `DCV`. See the [DEVPROD-4205 analysis](https://redpandadata.atlassian.net/browse/DEVPROD-4205?focusedCommentId=150260) for the full root-cause walkthrough.

The fix is to wrap the title in double quotes so GitHub treats it as an exact phrase.

## Verification

```
$ gh issue list --state all --search '[v25.3.x] dcv: Remove DCV in:title' \
    --milestone v25.3.x-next --repo redpanda-data/redpanda --json number,title
[{"number":30404,"title":"[v25.3.x] tests: Remove DCV DT support"}]   # ← false positive

$ gh issue list --state all --search '"[v25.3.x] dcv: Remove DCV" in:title' \
    --milestone v25.3.x-next --repo redpanda-data/redpanda --json number,title
[]                                                                     # ← correct after fix

$ gh issue list --state all --search '"[v26.1.x] dcv: Remove DCV" in:title' \
    --milestone v26.1.x-next --repo redpanda-data/redpanda --json number,title
[{"number":30412,"title":"[v26.1.x] dcv: Remove DCV"}]                # ← exact match still found
```

[DEVPROD-4205]

## Test plan

- [ ] Wait for next failed backport to confirm the script creates a tracking issue.

[DEVPROD-4205]: https://redpandadata.atlassian.net/browse/DEVPROD-4205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Release Notes

* none
