### PR TITLE
`config`: deprecate `space_management_enable_override`

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2873,13 +2873,7 @@ configuration::configuration()
       "disabled following an upgrade.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       true)
-  , space_management_enable_override(
-      *this,
-      "space_management_enable_override",
-      "Enable automatic space management. This option is ignored and "
-      "deprecated in versions >= v23.3.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      false)
+  , space_management_enable_override(*this, "space_management_enable_override")
   , disk_reservation_percent(
       *this,
       "disk_reservation_percent",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -503,7 +503,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> retention_local_trim_interval;
     property<double> retention_local_trim_overage_coeff;
     property<bool> space_management_enable;
-    property<bool> space_management_enable_override;
+    deprecated_property space_management_enable_override;
     bounded_property<double, numeric_bounds> disk_reservation_percent;
     bounded_property<uint16_t> space_management_max_log_concurrency;
     bounded_property<uint16_t> space_management_max_segment_concurrency;

--- a/src/v/redpanda/application_services.cc
+++ b/src/v/redpanda/application_services.cc
@@ -695,7 +695,6 @@ void application::wire_up_redpanda_services(
     construct_single_service(
       space_manager,
       config::shard_local_cfg().space_management_enable.bind(),
-      config::shard_local_cfg().space_management_enable_override.bind(),
       config::shard_local_cfg().retention_local_target_capacity_bytes.bind(),
       config::shard_local_cfg().retention_local_target_capacity_percent.bind(),
       config::shard_local_cfg().disk_reservation_percent.bind(),

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -28,7 +28,6 @@ namespace storage {
 
 disk_space_manager::disk_space_manager(
   config::binding<bool> enabled,
-  config::binding<bool> enabled_override,
   config::binding<std::optional<uint64_t>> retention_target_capacity_bytes,
   config::binding<std::optional<double>> retention_target_capacity_pct,
   config::binding<double> disk_reservation_percent,
@@ -38,7 +37,6 @@ disk_space_manager::disk_space_manager(
   ss::sharded<cloud_io::cache>* cache,
   ss::sharded<cluster::partition_manager>* pm)
   : _enabled(std::move(enabled))
-  , _enabled_override(std::move(enabled_override))
   , _local_monitor(local_monitor)
   , _storage(storage)
   , _storage_node(storage_node)

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -222,7 +222,6 @@ class disk_space_manager {
 public:
     disk_space_manager(
       config::binding<bool> enabled,
-      config::binding<bool> enabled_override,
       config::binding<std::optional<uint64_t>> retention_target_capacity_bytes,
       config::binding<std::optional<double>> retention_target_capacity_percent,
       config::binding<double> disk_reservation_percent,
@@ -363,7 +362,6 @@ private:
     };
 
     config::binding<bool> _enabled;
-    config::binding<bool> _enabled_override;
     ss::sharded<cluster::node::local_monitor>* _local_monitor;
     ss::sharded<storage::api>* _storage;
     ss::sharded<storage::node>* _storage_node;


### PR DESCRIPTION
Un-used and commented as deprecated. Mark it as a `deprecated_property`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
