### PR TITLE
treewide: remove owner_shard from record batch header context

### DIFF
--- a/src/v/kafka/protocol/kafka_batch_adapter.cc
+++ b/src/v/kafka/protocol/kafka_batch_adapter.cc
@@ -88,7 +88,6 @@ model::record_batch_header kafka_batch_adapter::read_header(iobuf_parser& in) {
             internal::kafka_header_size,
             total_bytes_consumed));
     }
-    header.ctx.owner_shard = ss::this_shard_id();
     return header;
 }
 

--- a/src/v/model/adl_serde.h
+++ b/src/v/model/adl_serde.h
@@ -213,6 +213,6 @@ adl<model::record_batch_header>::parse_from(Parser& in) {
       .producer_epoch = producer_epoch,
       .base_sequence = base_sequence,
       .record_count = record_count,
-      .ctx = model::record_batch_header::context(term_id, ss::this_shard_id())};
+      .ctx = model::record_batch_header::context(term_id)};
 }
 } // namespace reflection

--- a/src/v/model/batch_builder.cc
+++ b/src/v/model/batch_builder.cc
@@ -77,7 +77,6 @@ record_batch_header batch_builder::build_header() {
                       : timestamp_type::create_time);
     record_batch_header::context ctx;
     ctx.term = _term;
-    ctx.owner_shard = ss::this_shard_id();
     return {
       .header_crc = 0, // set later in reset_size_checksum_metadata
       .size_bytes = static_cast<int32_t>(

--- a/src/v/model/batch_utils.h
+++ b/src/v/model/batch_utils.h
@@ -40,7 +40,7 @@ make_placeholder_batch(offset start_offset, offset end_offset, term_id term) {
       .producer_epoch = -1,
       .base_sequence = -1,
       .record_count = static_cast<int32_t>(delta() + 1),
-      .ctx = model::record_batch_header::context(term, ss::this_shard_id())};
+      .ctx = model::record_batch_header::context(term)};
 
     model::record_batch batch(
       header, model::record_batch::compressed_records{});

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -145,12 +145,12 @@ fmt::iterator record_batch_attributes::format_to(fmt::iterator it) const {
 }
 
 fmt::iterator record_batch_header::format_to(fmt::iterator it) const {
-    it = fmt::format_to(
+    return fmt::format_to(
       it,
       "{{header_crc:{}, size_bytes:{}, base_offset:{}, type:{}, crc:{}, "
       "attrs:{}, last_offset_delta:{}, first_timestamp:{}, "
       "max_timestamp:{}, producer_id:{}, producer_epoch:{}, "
-      "base_sequence:{}, record_count:{}, ctx:{{term:{}, owner_shard:",
+      "base_sequence:{}, record_count:{}, ctx:{{term:{}}}}}",
       header_crc,
       size_bytes,
       base_offset,
@@ -165,12 +165,6 @@ fmt::iterator record_batch_header::format_to(fmt::iterator it) const {
       base_sequence,
       record_count,
       ctx.term);
-    if (ctx.owner_shard) {
-        it = fmt::format_to(it, "{}}}}}", *ctx.owner_shard);
-    } else {
-        it = fmt::format_to(it, "nullopt}}}}");
-    }
-    return it;
 }
 
 fmt::iterator record_batch::format_to(fmt::iterator it) const {

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -476,9 +476,8 @@ struct record_batch_header
     struct context
       : serde::envelope<context, serde::version<0>, serde::compat_version<0>> {
         context() noexcept = default;
-        context(model::term_id t, ss::shard_id i)
-          : term(t)
-          , owner_shard(i) {}
+        explicit context(model::term_id t)
+          : term(t) {}
 
         /*
          * term isn't part of the upstream kafka batch format, but we use it
@@ -502,20 +501,8 @@ struct record_batch_header
          * end-to-end test works.
          */
         model::term_id term;
-        std::optional<ss::shard_id> owner_shard;
 
-        void serde_write(iobuf& out) const {
-            // serialize with serde a serde-only type
-            using serde::write;
-            write(out, term);
-        }
-
-        void serde_read(iobuf_parser& in, const serde::header& h) {
-            // deserialize with serde a serde-only type
-            using serde::read_nested;
-            term = read_nested<model::term_id>(in, h._bytes_left_limit);
-            owner_shard = ss::this_shard_id();
-        }
+        auto serde_fields() { return std::tie(term); }
 
         friend bool operator==(
           const record_batch_header::context&,
@@ -578,11 +565,7 @@ struct record_batch_header
     offset last_offset() const {
         return base_offset + offset(last_offset_delta);
     }
-    record_batch_header copy() const {
-        record_batch_header h = *this;
-        h.ctx.owner_shard = ss::this_shard_id();
-        return h;
-    }
+    record_batch_header copy() const { return *this; }
     bool operator==(const record_batch_header& other) const {
         return header_crc == other.header_crc && size_bytes == other.size_bytes
                && base_offset == other.base_offset && crc == other.crc

--- a/src/v/model/tests/random_batch.cc
+++ b/src/v/model/tests/random_batch.cc
@@ -181,8 +181,7 @@ model::record_batch make_random_batch(record_batch_spec spec) {
     }
     rs.clear();
     // TODO: expose term setting
-    header.ctx = model::record_batch_header::context(
-      model::term_id(0), ss::this_shard_id());
+    header.ctx = model::record_batch_header::context(model::term_id(0));
     header.size_bytes = static_cast<int32_t>(
       model::packed_record_batch_header_size + body.size_bytes());
     auto batch = model::record_batch(

--- a/src/v/model/transform.cc
+++ b/src/v/model/transform.cc
@@ -292,7 +292,6 @@ model::record_batch transformed_data::make_batch(
 
     model::record_batch_header header;
     header.type = record_batch_type::raft_data;
-    header.ctx.owner_shard = ss::this_shard_id();
     // mark the batch as created with broker time
     header.attrs.set_timestamp_type(model::timestamp_type::append_time);
     header.first_timestamp = timestamp;

--- a/src/v/storage/record_batch_builder.cc
+++ b/src/v/storage/record_batch_builder.cc
@@ -98,8 +98,7 @@ model::record_batch_header record_batch_builder::build_header() const {
       .producer_epoch = _producer_epoch,
       .base_sequence = -1,
       .record_count = _offset_delta,
-      .ctx = model::record_batch_header::context(
-        model::term_id(0), ss::this_shard_id())};
+      .ctx = model::record_batch_header::context(model::term_id(0))};
     if (_is_control_type) {
         header.attrs.set_control_type();
     }

--- a/src/v/storage/record_batch_utils.cc
+++ b/src/v/storage/record_batch_utils.cc
@@ -77,7 +77,6 @@ model::record_batch_header batch_header_from_disk_iobuf(iobuf b) {
       .producer_epoch = producer_epoch,
       .base_sequence = base_sequence,
       .record_count = record_count};
-    hdr.ctx.owner_shard = ss::this_shard_id();
     return hdr;
 }
 

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -529,11 +529,6 @@ ss::future<> segment::compaction_index_batch(const model::record_batch& b) {
 
 ss::future<append_result> segment::do_append(const model::record_batch& b) {
     check_segment_not_closed("append()");
-    vassert(
-      b.header().ctx.owner_shard,
-      "Shard not set when writing to: {} - header: {}",
-      *this,
-      b.header());
     if (unlikely(b.base_offset() > b.last_offset())) {
         return ss::make_exception_future<append_result>(std::runtime_error(
           fmt::format(

--- a/src/v/storage/tests/batch_generators.h
+++ b/src/v/storage/tests/batch_generators.h
@@ -111,8 +111,7 @@ struct linear_int_kv_batch_generator {
         }
         rs.clear();
         // TODO: expose term setting
-        header.ctx = model::record_batch_header::context(
-          model::term_id(0), ss::this_shard_id());
+        header.ctx = model::record_batch_header::context(model::term_id(0));
         header.size_bytes = static_cast<int32_t>(
           model::packed_record_batch_header_size + body.size_bytes());
         auto batch = model::record_batch(


### PR DESCRIPTION
The `owner_shard` field was set on every batch creation and only used by a vassert in `segment::do_append` and a debug-format string. Drop the field along with the custom serde_write/serde_read it required (we can now use the default serde_fields).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
