### PR TITLE
Remove a couple of batch copies on the produce path

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -107,14 +107,14 @@ static void update_batch_base_offset(
     src.header().reset_size_checksum_metadata(src.data());
 }
 
-static ss::future<chunked_vector<model::record_batch>>
-clone_batches(const chunked_vector<model::record_batch>& src) {
+static chunked_vector<model::record_batch>
+shared_batches(chunked_vector<model::record_batch>& src) {
     chunked_vector<model::record_batch> res;
+    res.reserve(src.size());
     for (auto& s : src) {
-        res.push_back(s.copy());
-        co_await ss::coroutine::maybe_yield();
+        res.push_back(s.share());
     }
-    co_return res;
+    return res;
 }
 
 /// Write proper offsets into the record batches
@@ -817,7 +817,7 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
 
     chunked_vector<model::record_batch> rb_copy;
     if (cache_enabled()) {
-        rb_copy = co_await clone_batches(batches);
+        rb_copy = shared_batches(batches);
     }
 
     /*
@@ -946,7 +946,7 @@ raft::replicate_stages frontend::replicate(
     chunked_vector<model::record_batch> batch_vec, to_cache;
     batch_vec.push_back(std::move(batch));
     if (cache_enabled()) {
-        to_cache.push_back(batch_vec.front().copy());
+        to_cache.push_back(batch_vec.front().share());
     }
     raft::replicate_stages out(raft::errc::success);
     ss::promise<result<raft::replicate_result>> result;

--- a/src/v/storage/batch_cache.cc
+++ b/src/v/storage/batch_cache.cc
@@ -99,12 +99,49 @@ batch_cache::range::add(const model::record_batch& b, is_dirty_entry dirty) {
     auto offset = _arena.size_bytes();
     reflection::adl<model::record_batch_header>{}.to(_arena, b.header().copy());
     _size += serialized_header_size;
-    // if there is not enough space left in last arena fragment we
-    // trim it and append existing fragments directly to the arena
-    // iobuf
+
+    // 128 KiB is the maximum size iobuf's own allocator produces
+    // (io_allocation_size::max_chunk_size). At this size there should be no
+    // memory amplification from sharing it.
+    //
+    // In the future this threshold can likely be lowered to avoid additional
+    // copying at the cost of potential memory fragmentation.
+    static constexpr size_t share_threshold = 128 * 1024;
+
     if (_arena.rbegin()->available_bytes() < b.data().size_bytes()) {
         _size += b.data().size_bytes();
-        _arena.append_fragments(b.data().copy());
+        auto& fragments = const_cast<iobuf&>(b.data());
+        for (auto& f : fragments) {
+            if (f.size() >= share_threshold) {
+                _arena.append(std::make_unique<iobuf::fragment>(f.share()));
+            } else {
+                // Copy into an exact-sized fragment so the arena's
+                // capacity stays close to its used bytes (the cache's
+                // waste budget). Going through iobuf::append(char*, n)
+                // here would use the growth heuristic and over-allocate.
+                //
+                // Both Seastar's input_stream and the segment reader use a
+                // 128 KiB read buffer by default, and the iobuf::append
+                // heuristic produces records iobufs of shape
+                // [partial, 128K, 128K, ..., 128K, partial] (preserved
+                // through kafka_batch_adapter's slicing). Under that shape
+                // this branch fires at most twice per batch (for the
+                // leading and trailing partials), so the per-source-fragment
+                // copy doesn't produce a long tail of small arena fragments
+                // in practice.
+                //
+                // The worst case here is a batch that straddles the 128 KiB
+                // source-fragment boundary. This results an iobuf with the
+                // shape of [partial, partial] with no middle fragment. The old
+                // code coalesced them into a single fragment that was appended
+                // to the arena. The current code results in two fragments being
+                // appended to the arena.
+                ss::temporary_buffer<char> buf(f.size());
+                std::copy_n(f.get(), f.size(), buf.get_write());
+                _arena.append(
+                  std::make_unique<iobuf::fragment>(std::move(buf)));
+            }
+        }
     } else {
         // if there is enough space in arena just copy data into
         // existing fragment


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
  Two related changes that drop redundant deep copies on the produce path
  into the record batch cache:
  * `storage/batch_cache`: fragments at `max_chunk_size` (128 KiB) are
    shared into the arena instead of memcpy'd. Smaller fragments are still
    copied (into exact-sized buffers) to keep the arena's waste budget.
    Under the typical produce-path shape `[partial, 128K, ..., partial]`
    this means only the leading/trailing partials are copied.

  * `ct/frontend`: `shared_batches` uses `record_batch::share()` instead
    of `copy()`. The cached batches only have their headers mutated; the
    records iobuf is read-only, so the share is safe. Helper is no longer
    a coroutine.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
### Improvements
* Remove deep batch copying when inserting into the batch cache when batch fragments are equal to 128KiB.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
