### PR TITLE
Switch to Seastar API v10

### DIFF
--- a/bazel/thirdparty/seastar.BUILD
+++ b/bazel/thirdparty/seastar.BUILD
@@ -68,7 +68,7 @@ bool_flag(
 
 int_flag(
     name = "api_level",
-    build_setting_default = 9,
+    build_setting_default = 10,
     make_variable = "API_LEVEL",
 )
 

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -1002,7 +1002,7 @@ s3_client::self_configure_test(const plain_bucket_name& bucket) {
     // request.
     auto list_objects_result = co_await list_objects(
       bucket, std::nullopt, std::nullopt, 1);
-    co_return list_objects_result;
+    co_return bool(list_objects_result);
 }
 
 ss::future<> s3_client::stop() { return _client.stop(); }

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -903,11 +903,14 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
     if (!result) {
         co_return std::unexpected(result.error());
     }
-    auto ret_offset = model::offset(result.value().last_offset());
+    auto ret_offset = result.value().last_offset;
     if (!rb_copy.empty()) {
         auto tidp = topic_id_partition();
         if (tidp) {
-            update_batches(rb_copy, ret_offset, result.value().last_term);
+            update_batches(
+              rb_copy,
+              kafka::offset_cast(ret_offset),
+              result.value().last_term);
             _data_plane->cache_put_ordered(*tidp, std::move(rb_copy));
         }
     }
@@ -1000,7 +1003,8 @@ frontend::get_leader_epoch_last_offset(model::term_id term) const {
     if (term >= first_local_term) {
         auto last_offset = _partition->get_term_last_offset(term);
         if (last_offset) {
-            co_return ot_state->from_log_offset(*last_offset);
+            co_return model::offset_cast(
+              ot_state->from_log_offset(*last_offset));
         }
     }
 

--- a/src/v/cloud_topics/level_one/metastore/lsm/replicated_db.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/replicated_db.cc
@@ -105,7 +105,8 @@ replicated_database::open(
               "Failed to replicate set_domain_uuid batch"));
         }
         if (s->state().domain_uuid().is_nil()) {
-            co_return std::unexpected(errc::replication_error);
+            co_return std::unexpected(
+              replicated_database::error{errc::replication_error});
         }
     }
     auto domain_uuid = s->state().domain_uuid;

--- a/src/v/cluster/ephemeral_credential_service.cc
+++ b/src/v/cluster/ephemeral_credential_service.cc
@@ -17,7 +17,7 @@ ss::future<put_ephemeral_credential_reply>
 ephemeral_credential_service::put_ephemeral_credential(
   put_ephemeral_credential_request r, rpc::streaming_context&) {
     co_await _fe.local().put(r.principal, r.user, r.credential);
-    co_return errc::success;
+    co_return put_ephemeral_credential_reply{errc::success};
 }
 
 } // namespace cluster

--- a/src/v/cluster/self_test/cloudcheck.cc
+++ b/src/v/cluster/self_test/cloudcheck.cc
@@ -291,12 +291,12 @@ ss::future<cloudcheck::verify_upload_result> cloudcheck::verify_upload(
   cloud_storage_clients::bucket_name bucket,
   cloud_storage_clients::object_key key,
   const iobuf& payload) {
-    auto result = self_test_result{
+    self_test_result result{
       .name = _opts.name, .info = "Put", .test_type = "cloud"};
 
     if (_cancelled) {
         result.warning = "Run was manually cancelled.";
-        co_return result;
+        co_return {result};
     }
 
     try {
@@ -322,13 +322,13 @@ ss::future<cloudcheck::verify_upload_result> cloudcheck::verify_upload(
         result.error = e.what();
     }
 
-    co_return result;
+    co_return {result};
 }
 
 ss::future<cloudcheck::verify_list_result> cloudcheck::verify_list(
   cloud_storage_clients::bucket_name bucket,
   std::optional<cloud_storage_clients::object_key> prefix) {
-    auto result = self_test_result{
+    self_test_result result{
       .name = _opts.name, .info = "List", .test_type = "cloud"};
 
     if (_cancelled) {
@@ -359,18 +359,18 @@ ss::future<cloudcheck::verify_list_result> cloudcheck::verify_list(
 ss::future<cloudcheck::verify_head_result> cloudcheck::verify_head(
   cloud_storage_clients::bucket_name bucket,
   std::optional<cloud_storage_clients::object_key> key) {
-    auto result = self_test_result{
+    self_test_result result{
       .name = _opts.name, .info = "Head", .test_type = "cloud"};
 
     if (_cancelled) {
         result.warning = "Run was manually cancelled.";
-        co_return result;
+        co_return {result};
     }
 
     if (!key) {
         result.warning = "Could not download from cloud storage (no file was "
                          "found in the bucket).";
-        co_return result;
+        co_return {result};
     }
 
     try {
@@ -398,13 +398,13 @@ ss::future<cloudcheck::verify_head_result> cloudcheck::verify_head(
         result.error = e.what();
     }
 
-    co_return result;
+    co_return {result};
 }
 
 ss::future<cloudcheck::verify_download_result> cloudcheck::verify_download(
   cloud_storage_clients::bucket_name bucket,
   std::optional<cloud_storage_clients::object_key> key) {
-    auto result = self_test_result{
+    self_test_result result{
       .name = _opts.name, .info = "Get", .test_type = "cloud"};
 
     if (_cancelled) {
@@ -454,12 +454,12 @@ ss::future<cloudcheck::verify_download_result> cloudcheck::verify_download(
 ss::future<cloudcheck::verify_delete_result> cloudcheck::verify_delete(
   cloud_storage_clients::bucket_name bucket,
   cloud_storage_clients::object_key key) {
-    auto result = self_test_result{
+    self_test_result result{
       .name = _opts.name, .info = "Delete", .test_type = "cloud"};
 
     if (_cancelled) {
         result.warning = "Run was manually cancelled.";
-        co_return result;
+        co_return {result};
     }
 
     try {
@@ -482,17 +482,17 @@ ss::future<cloudcheck::verify_delete_result> cloudcheck::verify_delete(
         result.error = e.what();
     }
 
-    co_return result;
+    co_return {result};
 }
 
 ss::future<cloudcheck::verify_deletes_result> cloudcheck::verify_deletes(
   cloud_storage_clients::bucket_name bucket, size_t num_objects) {
-    auto result = self_test_result{
+    self_test_result result{
       .name = _opts.name, .info = "Plural Delete", .test_type = "cloud"};
 
     if (_cancelled) {
         result.warning = "Run was manually cancelled.";
-        co_return result;
+        co_return {result};
     }
 
     std::vector<cloud_storage_clients::object_key> keys(num_objects);
@@ -525,19 +525,19 @@ ss::future<cloudcheck::verify_deletes_result> cloudcheck::verify_deletes(
         result.error = e.what();
     }
 
-    co_return result;
+    co_return {result};
 }
 
 ss::future<cloudcheck::verify_multipart_upload_result>
 cloudcheck::verify_multipart_upload(
   cloud_storage_clients::bucket_name bucket,
   cloud_storage_clients::object_key key) {
-    auto result = self_test_result{
+    self_test_result result{
       .name = _opts.name, .info = "Multipart Put", .test_type = "cloud"};
 
     if (_cancelled) {
         result.warning = "Run was manually cancelled.";
-        co_return result;
+        co_return {result};
     }
 
     try {
@@ -550,7 +550,7 @@ cloudcheck::verify_multipart_upload(
 
         if (!upload_result) {
             result.error = "Failed to initiate multipart upload.";
-            co_return result;
+            co_return {result};
         }
 
         auto upload = std::move(upload_result.value());
@@ -577,7 +577,7 @@ cloudcheck::verify_multipart_upload(
         result.error = e.what();
     }
 
-    co_return result;
+    co_return {result};
 }
 
 } // namespace cluster::self_test

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -2843,8 +2843,8 @@ ss::future<result<tx_metadata, tx::errc>> tx_gateway_frontend::describe_tx(
     auto term = sync_result.value();
     const auto timeout
       = config::shard_local_cfg().internal_rpc_request_timeout_ms();
-    co_return co_await find_and_try_progressing_transaction(
-      term, stm, tid, timeout);
+    co_return result<tx_metadata, tx::errc>(
+      co_await find_and_try_progressing_transaction(term, stm, tid, timeout));
 }
 
 ss::future<try_abort_reply>

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -38,6 +38,7 @@
 #include "kafka/data/partition_proxy.h"
 #include "kafka/server/group_router.h"
 #include "kafka/server/snc_quota_manager.h"
+#include "model/fundamental.h"
 
 #include <seastar/coroutine/switch_to.hh>
 
@@ -815,7 +816,7 @@ private:
               partition.error_code);
             co_return std::nullopt;
         }
-        co_return partition.offset;
+        co_return ::model::offset_cast(partition.offset);
     }
 
     ss::future<std::optional<kafka::offset>> fetch_offset_for_timestamp(

--- a/src/v/cluster_link/tests/BUILD
+++ b/src/v/cluster_link/tests/BUILD
@@ -10,6 +10,7 @@ redpanda_test_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//src/v/cluster:cluster_link_errc",
         "//src/v/cluster:cluster_link_rpc_types",
         "//src/v/cluster:cluster_link_table",
         "//src/v/cluster:types",

--- a/src/v/cluster_link/tests/deps.h
+++ b/src/v/cluster_link/tests/deps.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cluster/cluster_link/errc.h"
 #include "cluster/cluster_link/table.h"
 #include "cluster/cluster_link/tests/utils.h"
 #include "cluster_link/manager.h"
@@ -82,8 +83,7 @@ public:
       model::metadata md, ::model::timeout_clock::time_point) override {
         auto batch = ::cluster::cluster_link::testing::create_upsert_command(
           _last_offset++, std::move(md));
-        auto ec = co_await _table->apply_update(std::move(batch));
-        co_return ec.value();
+        co_return co_await apply_update(std::move(batch));
     }
 
     ss::future<::cluster::cluster_link::errc> delete_link(
@@ -92,8 +92,7 @@ public:
       ::model::timeout_clock::time_point) override {
         auto batch = ::cluster::cluster_link::testing::create_remove_command(
           std::move(name), force);
-        auto ec = co_await _table->apply_update(std::move(batch));
-        co_return ec.value();
+        co_return co_await apply_update(std::move(batch));
     }
 
     model::metadata_ptr find_link_by_id(model::id_t id) const override {
@@ -130,9 +129,7 @@ public:
         auto batch
           = ::cluster::cluster_link::testing::create_add_mirror_topic_command(
             id, std::move(cmd));
-
-        auto ec = co_await _table->apply_update(std::move(batch));
-        co_return ec.value();
+        co_return co_await apply_update(std::move(batch));
     }
 
     ss::future<::cluster::cluster_link::errc> update_mirror_topic_state(
@@ -145,9 +142,7 @@ public:
         }
         auto batch = ::cluster::cluster_link::testing::
           create_update_mirror_topic_status_command(id, std::move(cmd));
-
-        auto ec = co_await _table->apply_update(std::move(batch));
-        co_return ec.value();
+        co_return co_await apply_update(std::move(batch));
     }
 
     ss::future<::cluster::cluster_link::errc> update_mirror_topic_properties(
@@ -160,8 +155,7 @@ public:
         }
         auto batch = ::cluster::cluster_link::testing::
           create_update_mirror_topic_properties_command(id, std::move(cmd));
-        auto ec = co_await _table->apply_update(std::move(batch));
-        co_return ec.value();
+        co_return co_await apply_update(std::move(batch));
     }
 
     std::optional<chunked_hash_map<
@@ -193,8 +187,7 @@ public:
         }
         auto batch = ::cluster::cluster_link::testing::
           create_update_cluster_link_configuration_command(id, std::move(cmd));
-        auto ec = co_await _table->apply_update(std::move(batch));
-        co_return ec.value();
+        co_return co_await apply_update(std::move(batch));
     }
 
     ss::future<std::expected<
@@ -240,14 +233,23 @@ public:
         }
         auto batch = ::cluster::cluster_link::testing::
           create_delete_mirror_topic_command(id, std::move(cmd));
-        auto ec = co_await _table->apply_update(std::move(batch));
-        co_return ec.value();
+        co_return co_await apply_update(std::move(batch));
     }
 
 private:
+    ss::future<::cluster::cluster_link::errc>
+    apply_update(::model::record_batch&& batch) {
+        auto ec = co_await _table->apply_update(std::move(batch));
+        vassert(
+          ec.category() == cluster::cluster_link::error_category(),
+          "Unexpected error category");
+        co_return ::cluster::cluster_link::errc(ec.value());
+    }
+
     cluster::cluster_link::table* _table;
     ::model::offset _last_offset{0};
 };
+
 class fake_partition_manager_proxy {
 public:
     std::optional<ss::shard_id> shard_owner(const ::model::ktp& ktp) {

--- a/src/v/datalake/coordinator/frontend.cc
+++ b/src/v/datalake/coordinator/frontend.cc
@@ -52,7 +52,7 @@ ss::future<ensure_table_exists_reply> do_ensure_table_exists(
     auto ret = co_await crd->sync_ensure_table_exists(
       req.topic, req.topic_revision, std::move(req.schema_components));
     if (ret.has_error()) {
-        co_return to_rpc_errc(ret.error());
+        co_return ensure_table_exists_reply{to_rpc_errc(ret.error())};
     }
     co_return ensure_table_exists_reply{errc::ok};
 }
@@ -67,7 +67,7 @@ ss::future<ensure_dlq_table_exists_reply> do_ensure_dlq_table_exists(
     auto ret = co_await crd->sync_ensure_dlq_table_exists(
       req.topic, req.topic_revision);
     if (ret.has_error()) {
-        co_return to_rpc_errc(ret.error());
+        co_return ensure_dlq_table_exists_reply{to_rpc_errc(ret.error())};
     }
     co_return ensure_dlq_table_exists_reply{errc::ok};
 }
@@ -82,7 +82,7 @@ ss::future<add_translated_data_files_reply> add_files(
     auto ret = co_await crd->sync_add_files(
       req.tp, req.topic_revision, std::move(req.ranges));
     if (ret.has_error()) {
-        co_return to_rpc_errc(ret.error());
+        co_return add_translated_data_files_reply{to_rpc_errc(ret.error())};
     }
     co_return add_translated_data_files_reply{errc::ok};
 }
@@ -97,7 +97,8 @@ ss::future<fetch_latest_translated_offset_reply> fetch_latest_offset(
     auto ret = co_await crd->sync_get_last_added_offsets(
       req.tp, req.topic_revision);
     if (ret.has_error()) {
-        co_return to_rpc_errc(ret.error());
+        co_return fetch_latest_translated_offset_reply{
+          to_rpc_errc(ret.error())};
     }
     auto& val = ret.value();
     co_return fetch_latest_translated_offset_reply{

--- a/src/v/iceberg/conversion/values_avro.cc
+++ b/src/v/iceberg/conversion/values_avro.cc
@@ -226,7 +226,8 @@ struct parsed_msg_visitor {
     }
     ss::future<optional_value_outcome>
     operator()(serde::avro::parsed::primitive v) {
-        co_return std::visit(primitive_visitor{node}, std::move(v));
+        co_return optional_value_outcome{
+          std::visit(primitive_visitor{node}, std::move(v))};
     }
     avro::NodePtr node;
 };

--- a/src/v/iceberg/conversion/values_protobuf.cc
+++ b/src/v/iceberg/conversion/values_protobuf.cc
@@ -122,7 +122,7 @@ ss::future<value_outcome> convert_repeated_elements(
         }
         ret->elements.push_back(std::move(result.value()));
     };
-    co_return value_outcome{std::move(ret)};
+    co_return std::move(ret);
 }
 
 ss::future<optional_value_outcome> convert_repeated(
@@ -241,7 +241,7 @@ convert_timestamp(std::unique_ptr<parsed::message> message) {
     if (it != message->fields.end()) {
         ts += absl::Nanoseconds(std::get<int32_t>(std::move(it->second)));
     }
-    co_return value_outcome{iceberg::timestamptz_value{absl::ToUnixMicros(ts)}};
+    co_return iceberg::timestamptz_value{absl::ToUnixMicros(ts)};
 }
 
 // Forward declaration for recursive calls
@@ -361,7 +361,7 @@ ss::future<optional_value_outcome> convert_struct_to_json(
     if (result.has_error()) {
         co_return result.error();
     }
-    co_return value_outcome{iceberg::string_value{std::move(writer).finish()}};
+    co_return iceberg::string_value{std::move(writer).finish()};
 }
 
 ss::future<optional_value_outcome> convert_value_to_json(
@@ -377,7 +377,7 @@ ss::future<optional_value_outcome> convert_value_to_json(
     if (result.has_error()) {
         co_return result.error();
     }
-    co_return value_outcome{iceberg::string_value{std::move(writer).finish()}};
+    co_return iceberg::string_value{std::move(writer).finish()};
 }
 
 ss::future<optional_value_outcome> convert_list_value_to_json(
@@ -393,7 +393,7 @@ ss::future<optional_value_outcome> convert_list_value_to_json(
     if (result.has_error()) {
         co_return result.error();
     }
-    co_return value_outcome{iceberg::string_value{std::move(writer).finish()}};
+    co_return iceberg::string_value{std::move(writer).finish()};
 }
 ss::future<optional_value_outcome>
 convert_date(std::unique_ptr<parsed::message> message) {
@@ -409,7 +409,7 @@ convert_date(std::unique_ptr<parsed::message> message) {
     }
     int32_t date = std::get<int32_t>(std::move(it->second));
 
-    co_return value_outcome{iceberg::date_value{date}};
+    co_return iceberg::date_value{date};
 }
 
 ss::future<optional_value_outcome> message_field_to_value(
@@ -627,10 +627,10 @@ deserialize_protobuf(iobuf buffer, const pb::Descriptor& type_descriptor) {
         co_return co_await proto_parsed_message_to_value(
           std::move(msg_ptr), type_descriptor);
     } catch (...) {
-        co_return value_outcome(value_conversion_exception(
+        co_return value_conversion_exception(
           fmt::format(
             "exception thrown while parsing protobuf - {}",
-            std::current_exception())));
+            std::current_exception()));
     }
 }
 

--- a/src/v/iceberg/rest_catalog.cc
+++ b/src/v/iceberg/rest_catalog.cc
@@ -13,6 +13,8 @@
 #include "iceberg/rest_client/catalog_client.h"
 #include "iceberg/rest_client/error.h"
 #include "iceberg/table_requests.h"
+
+#include <string>
 namespace iceberg {
 
 namespace {
@@ -81,6 +83,19 @@ table_update::update copy(const table_update::update& update) {
       update, [](const auto& u) { return table_update::update{u.copy()}; });
 }
 
+template<typename T, typename TransformFn>
+checked<table_metadata, catalog::errc> transform_to_metadata(
+  rest_client::expected<T>&& result,
+  TransformFn&& value_transform,
+  std::string_view error_context) {
+    return checked<table_metadata, catalog::errc>(
+      std::move(result)
+        .transform(std::forward<TransformFn>(value_transform))
+        .transform_error([error_context](const rest_client::domain_error& err) {
+            return map_error(error_context, err);
+        }));
+}
+
 } // namespace
 
 rest_catalog::rest_catalog(
@@ -109,11 +124,10 @@ rest_catalog::load_table(const table_identifier& t_id) {
     auto rtc = create_rtc();
     auto h = co_await lock_.get_units();
 
-    co_return (co_await client_->load_table(t_id.ns, t_id.table, rtc))
-      .transform(get_metadata)
-      .transform_error([](const rest_client::domain_error& err) {
-          return map_error("load_table", err);
-      });
+    co_return transform_to_metadata(
+      co_await client_->load_table(t_id.ns, t_id.table, rtc),
+      get_metadata,
+      "load_table");
 }
 
 ss::future<checked<table_metadata, catalog::errc>> rest_catalog::create_table(
@@ -167,12 +181,12 @@ ss::future<checked<table_metadata, catalog::errc>> rest_catalog::create_table(
     set_table_location_if_needed(retry_request, t_id);
 
     auto table_retry_rtc = retry_chain_node(&parent_rtc);
-    co_return (co_await client_->create_table(
-                 t_id.ns, std::move(retry_request), table_retry_rtc))
-      .transform(get_metadata)
-      .transform_error([](const rest_client::domain_error& err) {
-          return map_error("create_table_retry", err);
-      });
+
+    co_return transform_to_metadata(
+      co_await client_->create_table(
+        t_id.ns, std::move(retry_request), table_retry_rtc),
+      get_metadata,
+      "create_table_retry");
 }
 
 ss::future<checked<void, catalog::errc>>
@@ -218,13 +232,10 @@ rest_catalog::commit_txn(const table_identifier& t_id, transaction txn) {
         req.updates.push_back(copy(u));
     }
     auto h = co_await lock_.get_units();
-    co_return (co_await client_->commit_table_update(std::move(req), rtc))
-      .transform([](commit_table_response&& ctr) {
-          return std::move(ctr.table_metadata);
-      })
-      .transform_error([](const rest_client::domain_error& err) {
-          return map_error("commit_txn", err);
-      });
+    co_return transform_to_metadata(
+      co_await client_->commit_table_update(std::move(req), rtc),
+      [](commit_table_response&& ctr) { return std::move(ctr.table_metadata); },
+      "commit_txn");
 }
 
 ss::future<checked<void, catalog_describe_error>>

--- a/src/v/kafka/data/rpc/test/deps.h
+++ b/src/v/kafka/data/rpc/test/deps.h
@@ -137,8 +137,8 @@ public:
                 break;
             }
         }
-        co_return model::make_memory_record_batch_reader(
-          std::move(read_batches));
+        co_return storage::translating_reader(
+          model::make_memory_record_batch_reader(std::move(read_batches)));
     }
     ss::future<std::optional<storage::timequery_result>>
     timequery(storage::timequery_config) final {

--- a/src/v/kafka/protocol/flex_versions.cc
+++ b/src/v/kafka/protocol/flex_versions.cc
@@ -142,7 +142,7 @@ parse_tags(ss::input_stream<char>& src, size_t max_bytes) {
               fmt::format("duplicate tag id detected: {}", id));
         }
     }
-    co_return std::make_pair(std::move(tags), total_bytes_read);
+    co_return {{tagged_fields{std::move(tags)}}, total_bytes_read};
 }
 
 namespace {

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1833,24 +1833,6 @@ group::commit_tx(cluster::commit_group_tx_request r) {
     co_return co_await do_commit(r.group_id, r.pid, r.tx_seq);
 }
 
-cluster::begin_group_tx_reply make_begin_tx_reply(cluster::tx::errc ec) {
-    cluster::begin_group_tx_reply reply;
-    reply.ec = ec;
-    return reply;
-}
-
-cluster::commit_group_tx_reply make_commit_tx_reply(cluster::tx::errc ec) {
-    cluster::commit_group_tx_reply reply;
-    reply.ec = ec;
-    return reply;
-}
-
-cluster::abort_group_tx_reply make_abort_tx_reply(cluster::tx::errc ec) {
-    cluster::abort_group_tx_reply reply;
-    reply.ec = ec;
-    return reply;
-}
-
 ss::future<cluster::begin_group_tx_reply>
 group::begin_tx(cluster::begin_group_tx_request r) {
     vlog(_ctx_txlog.trace, "processing begin tx request: {}", r);
@@ -1862,7 +1844,7 @@ group::begin_tx(cluster::begin_group_tx_request r) {
           r,
           _term,
           _partition->term());
-        co_return make_begin_tx_reply(cluster::tx::errc::stale);
+        co_return cluster::begin_group_tx_reply(cluster::tx::errc::stale);
     }
 
     auto it = _producers.find(r.pid.get_id());
@@ -1876,7 +1858,7 @@ group::begin_tx(cluster::begin_group_tx_request r) {
               "current fence epoch: {}",
               r.pid,
               producer.epoch);
-            co_return make_begin_tx_reply(cluster::tx::errc::fenced);
+            co_return cluster::begin_group_tx_reply(cluster::tx::errc::fenced);
         } else if (r.pid.get_epoch() > producer.epoch) {
             // there is a fence, it might be that tm_stm failed, forget about
             // an ongoing transaction, assigned next pid for the same tx.id and
@@ -1898,7 +1880,8 @@ group::begin_tx(cluster::begin_group_tx_request r) {
                   r,
                   old_pid,
                   ar);
-                co_return make_begin_tx_reply(cluster::tx::errc::stale);
+                co_return cluster::begin_group_tx_reply(
+                  cluster::tx::errc::stale);
             }
         }
         if (producer.transaction) {
@@ -1910,7 +1893,7 @@ group::begin_tx(cluster::begin_group_tx_request r) {
                   "transaction with different sequence number: {}",
                   r,
                   producer_tx.tx_seq);
-                co_return make_begin_tx_reply(
+                co_return cluster::begin_group_tx_reply(
                   cluster::tx::errc::unknown_server_error);
             }
 
@@ -1920,7 +1903,7 @@ group::begin_tx(cluster::begin_group_tx_request r) {
                   "begin tx request {} failed - transaction is already ongoing "
                   "and accepted offset commits",
                   r);
-                co_return make_begin_tx_reply(
+                co_return cluster::begin_group_tx_reply(
                   cluster::tx::errc::unknown_server_error);
             }
             // begin_tx request is idempotent, return success
@@ -1953,7 +1936,8 @@ group::begin_tx(cluster::begin_group_tx_request r) {
           && _partition->raft()->term() == _term) {
             co_await _partition->raft()->step_down("group begin_tx failed");
         }
-        co_return map_tx_replication_error(result.error());
+        co_return cluster::begin_group_tx_reply(
+          map_tx_replication_error(result.error()));
     }
     auto [producer_it, _] = _producers.try_emplace(
       r.pid.get_id(), r.pid.get_epoch());
@@ -2320,7 +2304,7 @@ group::offset_commit_stages group::store_offsets(offset_commit_request&& r) {
 ss::future<cluster::commit_group_tx_reply>
 group::handle_commit_tx(cluster::commit_group_tx_request r) {
     if (in_state(group_state::dead)) {
-        co_return make_commit_tx_reply(
+        co_return cluster::commit_group_tx_reply(
           cluster::tx::errc::coordinator_not_available);
     } else if (
       in_state(group_state::empty) || in_state(group_state::stable)
@@ -2331,11 +2315,11 @@ group::handle_commit_tx(cluster::commit_group_tx_request r) {
               return commit_tx(std::move(r));
           });
     } else if (in_state(group_state::completing_rebalance)) {
-        co_return make_commit_tx_reply(
+        co_return cluster::commit_group_tx_reply(
           cluster::tx::errc::rebalance_in_progress);
     } else {
         vlog(_ctx_txlog.error, "Unexpected group state");
-        co_return make_commit_tx_reply(cluster::tx::errc::timeout);
+        co_return cluster::commit_group_tx_reply(cluster::tx::errc::timeout);
     }
 }
 
@@ -2404,9 +2388,8 @@ group::handle_txn_offset_commit(txn_offset_commit_request r) {
 ss::future<cluster::begin_group_tx_reply>
 group::handle_begin_tx(cluster::begin_group_tx_request r) {
     if (in_state(group_state::dead)) {
-        cluster::begin_group_tx_reply reply;
-        reply.ec = cluster::tx::errc::coordinator_not_available;
-        co_return reply;
+        co_return cluster::begin_group_tx_reply(
+          cluster::tx::errc::coordinator_not_available);
     } else if (
       in_state(group_state::empty) || in_state(group_state::stable)
       || in_state(group_state::preparing_rebalance)) {
@@ -2422,23 +2405,19 @@ group::handle_begin_tx(cluster::begin_group_tx_request r) {
          * generation change, in this case return an error instructing client to
          * retry.
          */
-        cluster::begin_group_tx_reply reply;
-        reply.ec = cluster::tx::errc::concurrent_transactions;
-        co_return reply;
+        co_return cluster::begin_group_tx_reply(
+          cluster::tx::errc::concurrent_transactions);
     } else {
         vlog(_ctx_txlog.error, "Unexpected group state");
-        cluster::begin_group_tx_reply reply;
-        reply.ec = cluster::tx::errc::timeout;
-        co_return reply;
+        co_return cluster::begin_group_tx_reply(cluster::tx::errc::timeout);
     }
 }
 
 ss::future<cluster::abort_group_tx_reply>
 group::handle_abort_tx(cluster::abort_group_tx_request r) {
     if (in_state(group_state::dead)) {
-        cluster::abort_group_tx_reply reply;
-        reply.ec = cluster::tx::errc::coordinator_not_available;
-        co_return reply;
+        co_return cluster::abort_group_tx_reply(
+          cluster::tx::errc::coordinator_not_available);
     } else if (
       in_state(group_state::stable) || in_state(group_state::empty)
       || in_state(group_state::preparing_rebalance)) {
@@ -2448,14 +2427,11 @@ group::handle_abort_tx(cluster::abort_group_tx_request r) {
               return abort_tx(std::move(r));
           });
     } else if (in_state(group_state::completing_rebalance)) {
-        cluster::abort_group_tx_reply reply;
-        reply.ec = cluster::tx::errc::concurrent_transactions;
-        co_return reply;
+        co_return cluster::abort_group_tx_reply(
+          cluster::tx::errc::concurrent_transactions);
     } else {
         vlog(_ctx_txlog.error, "Unexpected group state");
-        cluster::abort_group_tx_reply reply;
-        reply.ec = cluster::tx::errc::timeout;
-        co_return reply;
+        co_return cluster::abort_group_tx_reply(cluster::tx::errc::timeout);
     }
 }
 
@@ -2941,7 +2917,7 @@ ss::future<cluster::abort_group_tx_reply> group::do_abort(
           _partition->term(),
           pid,
           tx_seq);
-        co_return make_abort_tx_reply(cluster::tx::errc::stale);
+        co_return cluster::abort_group_tx_reply(cluster::tx::errc::stale);
     }
     auto it = _producers.find(pid.get_id());
     if (it == _producers.end() || it->second.transaction == nullptr) {
@@ -2957,7 +2933,7 @@ ss::future<cluster::abort_group_tx_reply> group::do_abort(
           "{}, assuming already aborted.",
           pid,
           tx_seq);
-        co_return make_abort_tx_reply(cluster::tx::errc::none);
+        co_return cluster::abort_group_tx_reply(cluster::tx::errc::none);
     }
     auto& producer = it->second;
     if (pid.get_epoch() != producer.epoch) {
@@ -2967,7 +2943,8 @@ ss::future<cluster::abort_group_tx_reply> group::do_abort(
           "{}",
           pid,
           producer.epoch);
-        co_return make_abort_tx_reply(cluster::tx::errc::request_rejected);
+        co_return cluster::abort_group_tx_reply(
+          cluster::tx::errc::request_rejected);
     }
 
     if (producer.transaction == nullptr) {
@@ -2975,7 +2952,7 @@ ss::future<cluster::abort_group_tx_reply> group::do_abort(
           _ctx_txlog.trace,
           "unable to find transaction for {}, probably already aborted",
           pid);
-        co_return make_abort_tx_reply(cluster::tx::errc::none);
+        co_return cluster::abort_group_tx_reply(cluster::tx::errc::none);
     }
     auto& producer_tx = *producer.transaction;
     if (producer_tx.tx_seq > tx_seq) {
@@ -2992,7 +2969,7 @@ ss::future<cluster::abort_group_tx_reply> group::do_abort(
           pid,
           producer_tx.tx_seq,
           tx_seq);
-        co_return make_abort_tx_reply(cluster::tx::errc::none);
+        co_return cluster::abort_group_tx_reply(cluster::tx::errc::none);
     }
 
     if (producer_tx.tx_seq != tx_seq) {
@@ -3003,7 +2980,8 @@ ss::future<cluster::abort_group_tx_reply> group::do_abort(
           pid,
           producer_tx.tx_seq,
           tx_seq);
-        co_return make_abort_tx_reply(cluster::tx::errc::request_rejected);
+        co_return cluster::abort_group_tx_reply(
+          cluster::tx::errc::request_rejected);
     }
     auto tx = group_tx::abort_metadata{.group_id = group_id, .tx_seq = tx_seq};
 
@@ -3028,13 +3006,14 @@ ss::future<cluster::abort_group_tx_reply> group::do_abort(
           && _partition->raft()->term() == _term) {
             co_await _partition->raft()->step_down("group do abort failed");
         }
-        co_return map_tx_replication_error(result.error());
+        co_return cluster::abort_group_tx_reply(
+          map_tx_replication_error(result.error()));
     }
     it = _producers.find(pid.get_id());
     if (it != _producers.end()) {
         it->second.transaction.reset();
     }
-    co_return make_abort_tx_reply(cluster::tx::errc::none);
+    co_return cluster::abort_group_tx_reply(cluster::tx::errc::none);
 }
 
 ss::future<cluster::commit_group_tx_reply> group::do_commit(
@@ -3055,7 +3034,7 @@ ss::future<cluster::commit_group_tx_reply> group::do_commit(
           pid,
           _term,
           _partition->term());
-        co_return make_commit_tx_reply(cluster::tx::errc::stale);
+        co_return cluster::commit_group_tx_reply(cluster::tx::errc::stale);
     }
     auto it = _producers.find(pid.get_id());
     if (it == _producers.end() || it->second.transaction == nullptr) {
@@ -3071,7 +3050,7 @@ ss::future<cluster::commit_group_tx_reply> group::do_commit(
           "{}, assuming already committed.",
           pid,
           sequence);
-        co_return make_commit_tx_reply(cluster::tx::errc::none);
+        co_return cluster::commit_group_tx_reply(cluster::tx::errc::none);
     }
     auto& producer = it->second;
     if (pid.get_epoch() != producer.epoch) {
@@ -3081,7 +3060,8 @@ ss::future<cluster::commit_group_tx_reply> group::do_commit(
           "producer epoch: {}",
           pid,
           producer.epoch);
-        co_return make_commit_tx_reply(cluster::tx::errc::request_rejected);
+        co_return cluster::commit_group_tx_reply(
+          cluster::tx::errc::request_rejected);
     }
 
     if (producer.transaction == nullptr) {
@@ -3091,7 +3071,7 @@ ss::future<cluster::commit_group_tx_reply> group::do_commit(
           "ongoing transaction, it was "
           "most likely already committed",
           pid);
-        co_return make_commit_tx_reply(cluster::tx::errc::none);
+        co_return cluster::commit_group_tx_reply(cluster::tx::errc::none);
     }
     auto& producer_tx = *producer.transaction;
     if (producer_tx.tx_seq > sequence) {
@@ -3108,7 +3088,7 @@ ss::future<cluster::commit_group_tx_reply> group::do_commit(
           pid,
           sequence,
           producer_tx.tx_seq);
-        co_return make_commit_tx_reply(cluster::tx::errc::none);
+        co_return cluster::commit_group_tx_reply(cluster::tx::errc::none);
     }
     if (producer_tx.tx_seq != sequence) {
         vlog(
@@ -3118,7 +3098,8 @@ ss::future<cluster::commit_group_tx_reply> group::do_commit(
           pid,
           sequence,
           producer_tx.tx_seq);
-        co_return make_commit_tx_reply(cluster::tx::errc::request_rejected);
+        co_return cluster::commit_group_tx_reply(
+          cluster::tx::errc::request_rejected);
     }
     auto& ongoing_tx = *it->second.transaction;
     // It is fix for https://github.com/redpanda-data/redpanda/issues/5163.
@@ -3180,7 +3161,8 @@ ss::future<cluster::commit_group_tx_reply> group::do_commit(
           && _partition->raft()->term() == _term) {
             co_await _partition->raft()->step_down("group tx commit failed");
         }
-        co_return map_tx_replication_error(result.error());
+        co_return cluster::commit_group_tx_reply(
+          map_tx_replication_error(result.error()));
     }
 
     it = _producers.find(pid.get_id());
@@ -3189,7 +3171,8 @@ ss::future<cluster::commit_group_tx_reply> group::do_commit(
           _ctx_txlog.error,
           "unable to find ongoing transaction for producer: {}",
           pid);
-        co_return make_commit_tx_reply(cluster::tx::errc::unknown_server_error);
+        co_return cluster::commit_group_tx_reply(
+          cluster::tx::errc::unknown_server_error);
     }
 
     for (const auto& [tp, md] : it->second.transaction->offsets) {
@@ -3207,7 +3190,7 @@ ss::future<cluster::commit_group_tx_reply> group::do_commit(
 
     it->second.transaction.reset();
 
-    co_return make_commit_tx_reply(cluster::tx::errc::none);
+    co_return cluster::commit_group_tx_reply(cluster::tx::errc::none);
 }
 
 void group::abort_old_txes() {

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -131,9 +131,6 @@ inline fmt::iterator format_to(group_state gs, fmt::iterator out) {
 
 ss::sstring group_state_to_kafka_name(group_state);
 std::optional<group_state> group_state_from_kafka_name(std::string_view);
-cluster::begin_group_tx_reply make_begin_tx_reply(cluster::tx::errc);
-cluster::commit_group_tx_reply make_commit_tx_reply(cluster::tx::errc);
-cluster::abort_group_tx_reply make_abort_tx_reply(cluster::tx::errc);
 kafka::error_code map_store_offset_error_code(std::error_code);
 
 /// \brief A Kafka group.

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -1618,7 +1618,7 @@ group_manager::commit_tx(cluster::commit_group_tx_request&& r) {
     auto p = get_attached_partition(r.ntp);
     if (!p || !p->partition->is_leader()) {
         return ss::make_ready_future<cluster::commit_group_tx_reply>(
-          make_commit_tx_reply(cluster::tx::errc::not_coordinator));
+          cluster::commit_group_tx_reply(cluster::tx::errc::not_coordinator));
     }
     auto maybe_holder = p->catchup_lock->try_hold_read_lock();
     if (!maybe_holder) {
@@ -1628,7 +1628,7 @@ group_manager::commit_tx(cluster::commit_group_tx_request&& r) {
           cluster::txlog.trace,
           "can't process a tx: coordinator_load_in_progress");
         return ss::make_ready_future<cluster::commit_group_tx_reply>(
-          make_commit_tx_reply(
+          cluster::commit_group_tx_reply(
             cluster::tx::errc::coordinator_load_in_progress));
     }
     auto error = validate_group_status(
@@ -1636,17 +1636,18 @@ group_manager::commit_tx(cluster::commit_group_tx_request&& r) {
     if (error != error_code::none) {
         if (error == error_code::not_coordinator) {
             return ss::make_ready_future<cluster::commit_group_tx_reply>(
-              make_commit_tx_reply(cluster::tx::errc::not_coordinator));
+              cluster::commit_group_tx_reply(
+                cluster::tx::errc::not_coordinator));
         } else {
             return ss::make_ready_future<cluster::commit_group_tx_reply>(
-              make_commit_tx_reply(cluster::tx::errc::timeout));
+              cluster::commit_group_tx_reply(cluster::tx::errc::timeout));
         }
     }
 
     auto group = get_group(r.group_id);
     if (!group) {
         return ss::make_ready_future<cluster::commit_group_tx_reply>(
-          make_commit_tx_reply(cluster::tx::errc::timeout));
+          cluster::commit_group_tx_reply(cluster::tx::errc::timeout));
     }
 
     return group->handle_commit_tx(std::move(r))
@@ -1658,7 +1659,7 @@ group_manager::begin_tx(cluster::begin_group_tx_request&& r) {
     auto p = get_attached_partition(r.ntp);
     if (!p || !p->partition->is_leader()) {
         return ss::make_ready_future<cluster::begin_group_tx_reply>(
-          make_begin_tx_reply(cluster::tx::errc::not_coordinator));
+          cluster::begin_group_tx_reply(cluster::tx::errc::not_coordinator));
     }
     auto maybe_holder = p->catchup_lock->try_hold_read_lock();
     if (!maybe_holder) {
@@ -1668,7 +1669,8 @@ group_manager::begin_tx(cluster::begin_group_tx_request&& r) {
           cluster::txlog.trace,
           "can't process a tx: coordinator_load_in_progress");
         return ss::make_ready_future<cluster::begin_group_tx_reply>(
-          make_begin_tx_reply(cluster::tx::errc::coordinator_load_in_progress));
+          cluster::begin_group_tx_reply(
+            cluster::tx::errc::coordinator_load_in_progress));
     }
 
     auto error = validate_group_status(
@@ -1678,7 +1680,7 @@ group_manager::begin_tx(cluster::begin_group_tx_request&& r) {
                     ? cluster::tx::errc::not_coordinator
                     : cluster::tx::errc::timeout;
         return ss::make_ready_future<cluster::begin_group_tx_reply>(
-          make_begin_tx_reply(ec));
+          cluster::begin_group_tx_reply(ec));
     }
 
     auto group = get_group(r.group_id);
@@ -1705,7 +1707,7 @@ group_manager::abort_tx(cluster::abort_group_tx_request&& r) {
     auto p = get_attached_partition(r.ntp);
     if (!p || !p->partition->is_leader()) {
         return ss::make_ready_future<cluster::abort_group_tx_reply>(
-          make_abort_tx_reply(cluster::tx::errc::not_coordinator));
+          cluster::abort_group_tx_reply(cluster::tx::errc::not_coordinator));
     }
     auto maybe_holder = p->catchup_lock->try_hold_read_lock();
     if (!maybe_holder) {
@@ -1715,7 +1717,8 @@ group_manager::abort_tx(cluster::abort_group_tx_request&& r) {
           cluster::txlog.trace,
           "can't process a tx: coordinator_load_in_progress");
         return ss::make_ready_future<cluster::abort_group_tx_reply>(
-          make_abort_tx_reply(cluster::tx::errc::coordinator_load_in_progress));
+          cluster::abort_group_tx_reply(
+            cluster::tx::errc::coordinator_load_in_progress));
     }
 
     auto error = validate_group_status(
@@ -1725,13 +1728,13 @@ group_manager::abort_tx(cluster::abort_group_tx_request&& r) {
                     ? cluster::tx::errc::not_coordinator
                     : cluster::tx::errc::timeout;
         return ss::make_ready_future<cluster::abort_group_tx_reply>(
-          make_abort_tx_reply(ec));
+          cluster::abort_group_tx_reply(ec));
     }
 
     auto group = get_group(r.group_id);
     if (!group) {
         return ss::make_ready_future<cluster::abort_group_tx_reply>(
-          make_abort_tx_reply(cluster::tx::errc::timeout));
+          cluster::abort_group_tx_reply(cluster::tx::errc::timeout));
     }
 
     return group->handle_abort_tx(std::move(r))

--- a/src/v/net/tls.cc
+++ b/src/v/net/tls.cc
@@ -36,7 +36,7 @@ ss::future<std::optional<ss::sstring>> find_ca_file() {
 
     for (auto ca_loc : ca_cert_locations) {
         if (co_await ss::file_exists(ca_loc)) {
-            co_return ca_loc;
+            co_return ss::sstring{ca_loc};
         }
     }
     co_return std::nullopt;

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -195,7 +195,7 @@ class append_entries_request_serde_wrapper
       serde::version<0>,
       serde::compat_version<0>> {
 public:
-    explicit append_entries_request_serde_wrapper(append_entries_request req)
+    append_entries_request_serde_wrapper(append_entries_request req)
       : _request(std::move(req)) {}
 
     append_entries_request release() && { return std::move(_request); }

--- a/src/v/ssx/single_fiber_executor.h
+++ b/src/v/ssx/single_fiber_executor.h
@@ -201,7 +201,7 @@ private:
             } else {
                 if constexpr (std::is_same_v<ret_value_t, void>) {
                     std::move(f).get();
-                    p.set_value();
+                    p.emplace_value();
                 } else {
                     p.set_value(std::move(f).get());
                 }


### PR DESCRIPTION
Seastar API v10 assures stricter type checking in co_return and the like, to match plain return semantics. Adopt it to avoid unintended conversions, fix existing sites.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
