### PR TITLE
cl/test: rnot: add cloud topic workloads

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -1250,92 +1250,143 @@ ss::future<result<raft::replicate_result>> frontend::replicate_at_offset(
   model::timeout_clock::duration timeout,
   std::optional<std::reference_wrapper<ss::abort_source>> as,
   ss::shared_ptr<kafka::write_at_offset_stm> stm) {
-    chunked_vector<model::record_batch_header> headers;
-    headers.reserve(batches.size());
-    for (const auto& batch : batches) {
-        headers.push_back(batch.header());
-    }
-
-    auto min_epoch = cluster_epoch(_partition->get_topic_revision_id());
-
-    // Use the std::max trick from the normal produce path to reduce
-    // the likelihood of fencing errors when shards are on different
-    // epochs.
-    auto accepted_min = _ctp_stm_api->get_max_seen_epoch(_partition->term());
-    if (!accepted_min) {
-        accepted_min = _ctp_stm_api->get_max_epoch();
-    }
-    if (accepted_min) {
-        min_epoch = std::max(min_epoch, *accepted_min);
-    }
-
-    vassert(
-      min_epoch() > 0L,
-      "Unexpected invalid min epoch {} for {}",
-      min_epoch,
-      ntp());
-
-    auto staged = co_await _data_plane->stage_write(std::move(batches));
-    if (!staged.has_value()) {
-        co_return staged.error();
-    }
-
-    auto deadline = model::timeout_clock::now() + timeout;
-    auto res = co_await _data_plane->execute_write(
-      ntp(), min_epoch, std::move(staged.value()), deadline);
-
-    if (!res.has_value()) {
-        co_return res.error();
-    }
-
-    auto batch_epoch = res.value().extents.front().id.epoch;
-
-    auto fence_fut = co_await ss::coroutine::as_future(
-      _ctp_stm_api->fence_epoch(batch_epoch));
-    if (fence_fut.failed()) {
-        auto not_leader = !_partition->is_leader();
-        auto e = fence_fut.get_exception();
-        if (not_leader) {
-            vlog(
-              cd_log.debug,
-              "Failed to fence epoch {} for ntp {}, not a leader",
-              batch_epoch,
-              ntp());
+    // Only user data batches (raft_data with !is_control()) are uploaded
+    // to L0 and wrapped as ctp_placeholders. Transactional control batches
+    // (raft_data with is_control(), i.e. transaction commit/abort markers)
+    // carry their payload in the record key/value and must be passed
+    // through to the local raft log unchanged - otherwise the placeholder
+    // encoding strips the key and downstream consumers like rm_stm cannot
+    // parse them. No other batch types are expected on this path.
+    chunked_vector<model::record_batch_header> data_headers;
+    chunked_vector<model::record_batch> data_batches;
+    chunked_vector<model::record_batch> control_batches;
+    const size_t input_count = batches.size();
+    for (auto&& batch : batches) {
+        const auto& hdr = batch.header();
+        vassert(
+          hdr.type == model::record_batch_type::raft_data,
+          "Unexpected batch type {} for {} in replicate_at_offset; only "
+          "raft_data batches (data and transactional control) are supported",
+          hdr.type,
+          ntp());
+        const bool is_data = !hdr.attrs.is_control();
+        if (is_data) {
+            data_headers.push_back(hdr);
+            data_batches.push_back(std::move(batch));
         } else {
-            vlogl(
-              cd_log,
-              ssx::is_shutdown_exception(e) ? ss::log_level::debug
-                                            : ss::log_level::warn,
-              "Failed to fence epoch {} for ntp {}, error: {}",
-              batch_epoch,
-              ntp(),
-              e);
+            control_batches.push_back(std::move(batch));
         }
-        co_await ss::coroutine::return_exception_ptr(std::move(e));
     }
-    auto fence = std::move(fence_fut.get());
-    if (!fence.has_value()) {
-        vlog(
-          cd_log.warn,
-          "Failed to fence epoch {} for ntp {}, ctp latest seen epoch "
-          "is [{}, {}]",
-          batch_epoch,
-          ntp(),
-          fence.error().window_min,
-          fence.error().window_max);
-        co_return raft::errc::not_leader;
-    }
-
-    auto placeholders = co_await convert_to_placeholders(
-      res.value().extents, headers);
+    batches.clear();
 
     chunked_vector<model::record_batch> placeholder_batches;
-    for (auto&& batch : placeholders.batches) {
-        placeholder_batches.push_back(std::move(batch));
+
+    if (!data_batches.empty()) {
+        auto min_epoch = cluster_epoch(_partition->get_topic_revision_id());
+
+        // Use the std::max trick from the normal produce path to reduce
+        // the likelihood of fencing errors when shards are on different
+        // epochs.
+        auto accepted_min = _ctp_stm_api->get_max_seen_epoch(
+          _partition->term());
+        if (!accepted_min) {
+            accepted_min = _ctp_stm_api->get_max_epoch();
+        }
+        if (accepted_min) {
+            min_epoch = std::max(min_epoch, *accepted_min);
+        }
+
+        vassert(
+          min_epoch() > 0L,
+          "Unexpected invalid min epoch {} for {}",
+          min_epoch,
+          ntp());
+
+        auto staged = co_await _data_plane->stage_write(
+          std::move(data_batches));
+        if (!staged.has_value()) {
+            co_return staged.error();
+        }
+
+        auto deadline = model::timeout_clock::now() + timeout;
+        auto res = co_await _data_plane->execute_write(
+          ntp(), min_epoch, std::move(staged.value()), deadline);
+
+        if (!res.has_value()) {
+            co_return res.error();
+        }
+
+        auto batch_epoch = res.value().extents.front().id.epoch;
+
+        auto fence_fut = co_await ss::coroutine::as_future(
+          _ctp_stm_api->fence_epoch(batch_epoch));
+        if (fence_fut.failed()) {
+            auto not_leader = !_partition->is_leader();
+            auto e = fence_fut.get_exception();
+            if (not_leader) {
+                vlog(
+                  cd_log.debug,
+                  "Failed to fence epoch {} for ntp {}, not a leader",
+                  batch_epoch,
+                  ntp());
+            } else {
+                vlogl(
+                  cd_log,
+                  ssx::is_shutdown_exception(e) ? ss::log_level::debug
+                                                : ss::log_level::warn,
+                  "Failed to fence epoch {} for ntp {}, error: {}",
+                  batch_epoch,
+                  ntp(),
+                  e);
+            }
+            std::rethrow_exception(e);
+        }
+        auto fence = std::move(fence_fut.get());
+        if (!fence.has_value()) {
+            vlog(
+              cd_log.warn,
+              "Failed to fence epoch {} for ntp {}, ctp latest seen epoch "
+              "is [{}, {}]",
+              batch_epoch,
+              ntp(),
+              fence.error().window_min,
+              fence.error().window_max);
+            co_return raft::errc::not_leader;
+        }
+
+        auto placeholders = co_await convert_to_placeholders(
+          res.value().extents, data_headers);
+        placeholder_batches = chunked_vector<model::record_batch>(
+          std::make_move_iterator(placeholders.batches.begin()),
+          std::make_move_iterator(placeholders.batches.end()));
+    }
+
+    // Restore the original input order by 2-way merging placeholders and
+    // control batches on their base offsets. Both inputs preserve their
+    // relative order from `batches`, and each batch already has a unique
+    // base_offset assigned, so a merge on base_offset reproduces the
+    // original interleaving without an auxiliary order tracker.
+    chunked_vector<model::record_batch> final_batches;
+    final_batches.reserve(input_count);
+    auto ph_it = placeholder_batches.begin();
+    auto ctl_it = control_batches.begin();
+    while (ph_it != placeholder_batches.end()
+           && ctl_it != control_batches.end()) {
+        if (ph_it->base_offset() < ctl_it->base_offset()) {
+            final_batches.push_back(std::move(*ph_it++));
+        } else {
+            final_batches.push_back(std::move(*ctl_it++));
+        }
+    }
+    for (; ph_it != placeholder_batches.end(); ++ph_it) {
+        final_batches.push_back(std::move(*ph_it));
+    }
+    for (; ctl_it != control_batches.end(); ++ctl_it) {
+        final_batches.push_back(std::move(*ctl_it));
     }
 
     auto stages = stm->replicate(
-      std::move(placeholder_batches),
+      std::move(final_batches),
       std::move(expected_base_offsets),
       prev_log_offset,
       timeout,

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -58,6 +58,8 @@ from rptest.services.tls import CertificateAuthority, Certificate, TLSCertManage
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.util import bg_thread_cm, wait_until_result
 from rptest.utils.node_operations import FailureInjectorBackgroundThread
+import threading
+from logging import Logger
 from threading import Lock
 from urllib3.exceptions import ProtocolError
 
@@ -117,6 +119,60 @@ CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST = [
     # or immediately after leadership changes.
     re.compile(r".*ctp_stm\.cc.*Sync timeout"),
 ]
+
+
+class StorageModeFlipper:
+    """Background thread that periodically rotates `redpanda.storage.mode` of
+    a topic between a list of modes. Useful for stress-testing transitions
+    between cloud / tiered_cloud / disk storage modes while a workload is
+    running. Transient errors during the alter call (e.g. leadership changes
+    or partition movement) are logged and retried on the next tick.
+    """
+
+    def __init__(
+        self,
+        rpk: RpkTool,
+        topic: str,
+        modes: list[str],
+        interval_seconds: float,
+        logger: Logger,
+    ):
+        self._rpk = rpk
+        self._topic = topic
+        self._modes = modes
+        self._interval = interval_seconds
+        self._logger = logger
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        if not self._modes:
+            return
+        self._thread = threading.Thread(
+            target=self._run,
+            daemon=True,
+            name=f"flipper-{self._topic}",
+        )
+        self._thread.start()
+
+    def stop(self, timeout: float = 30) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+            self._thread = None
+
+    def _run(self) -> None:
+        idx = 0
+        while not self._stop.wait(self._interval):
+            mode = self._modes[idx % len(self._modes)]
+            idx += 1
+            try:
+                self._rpk.alter_topic_config(self._topic, "redpanda.storage.mode", mode)
+                self._logger.debug(f"Flipped storage mode of {self._topic} to {mode}")
+            except Exception as e:
+                self._logger.warning(
+                    f"Failed to flip storage mode of {self._topic} to {mode}: {e}"
+                )
 
 
 class ClusterLinkingTLSProvider(TLSProvider):

--- a/tests/rptest/tests/shadow_linking_rnot_test.py
+++ b/tests/rptest/tests/shadow_linking_rnot_test.py
@@ -15,6 +15,7 @@ from typing import Any
 
 
 from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
 from rptest.services.cluster import TestContext, cluster
 from rptest.services.multi_cluster_services import (
     Cluster,
@@ -22,11 +23,13 @@ from rptest.services.multi_cluster_services import (
     SecondaryClusterArgs,
 )
 from rptest.services.redpanda import (
+    CLOUD_TOPICS_CONFIG_STR,
     PandaproxyConfig,
     SISettings,
     SchemaRegistryConfig,
 )
 from rptest.tests.cluster_linking_test_base import (
+    CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST,
     ClusterLinkingProgressVerifier,
     ShadowLinkTestBase,
 )
@@ -247,7 +250,7 @@ class ShadowLinkingRandomOpsTest(ShadowLinkTestBase):
         super().__init__(
             test_ctx,
             num_brokers=5,
-            num_prealloc_nodes=3,
+            num_prealloc_nodes=5,
             secondary_cluster_args=SecondaryClusterArgs(
                 # TODO: enable when DR of schemas is supported
                 # schema_registry_config=SchemaRegistryConfig(),
@@ -260,6 +263,7 @@ class ShadowLinkingRandomOpsTest(ShadowLinkTestBase):
                 ),
                 extra_rp_conf={
                     "group_new_member_join_timeout": 3000,
+                    CLOUD_TOPICS_CONFIG_STR: True,
                 },
             ),
             extra_rp_conf={
@@ -276,6 +280,7 @@ class ShadowLinkingRandomOpsTest(ShadowLinkTestBase):
                 "retention_local_trim_interval": 5000,
                 "partition_autobalancing_tick_interval_ms": 2000,
                 "group_new_member_join_timeout": 3000,
+                CLOUD_TOPICS_CONFIG_STR: True,
             },
             schema_registry_config=SchemaRegistryConfig(),
             pandaproxy_config=PandaproxyConfig(),
@@ -312,10 +317,142 @@ class ShadowLinkingRandomOpsTest(ShadowLinkTestBase):
             self.total_node_ops = 5
             self.partition_count = 12
 
-    @cluster(num_nodes=11)
-    @matrix(failures=[False, True])
-    def test_node_operations(self, failures: bool):
+    def _basic_workload_specs(self) -> list[ClusterLinkingWorkloadSpec]:
+        return [
+            ClusterLinkingWorkloadSpec(
+                topic="si-topic",
+                topic_properties={
+                    "cleanup.policy": "delete",
+                    "retention.bytes": "1024000",
+                    "segment.bytes": f"{1024 * 1024}",
+                },
+                partition_count=self.partition_count,
+                msg_count=self.msg_count,
+                msg_size=self.msg_size,
+            ),
+            ClusterLinkingWorkloadSpec(
+                topic="compacted-topic",
+                topic_properties={
+                    "cleanup.policy": "compact",
+                    "segment.bytes": f"{1024 * 1024}",
+                },
+                partition_count=self.partition_count,
+                msg_count=self.msg_count,
+                msg_size=self.msg_size,
+                producer_properties={
+                    "key_set_cardinality": 600,
+                    "tombstone_probability": 0.4,
+                },
+                consumer_properties={
+                    "compacted": True,
+                },
+                use_compaction=True,
+            ),
+            ClusterLinkingWorkloadSpec(
+                topic="topic-txns",
+                # transactions, use a smaller topic to avoid long test times
+                msg_count=math.floor(self.msg_count / 10),
+                msg_size=self.msg_size,
+                partition_count=1,
+                use_transactions=True,
+                producer_properties={
+                    "transaction_abort_rate": 0.1,
+                    "msgs_per_transaction": 50,
+                    "debug_logs": True,
+                },
+                consumer_properties={},
+                validate_number_of_messages_on_target=True,
+            ),
+            ClusterLinkingWorkloadSpec(
+                topic="cloud-topic",
+                topic_properties={
+                    TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD,
+                    "segment.bytes": f"{1024 * 1024}",
+                },
+                partition_count=self.partition_count,
+                msg_count=self.msg_count,
+                msg_size=self.msg_size,
+            ),
+            ClusterLinkingWorkloadSpec(
+                topic="tiered-cloud-topic",
+                topic_properties={
+                    TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_TIERED_CLOUD,
+                    "segment.bytes": f"{1024 * 1024}",
+                },
+                partition_count=self.partition_count,
+                msg_count=self.msg_count,
+                msg_size=self.msg_size,
+            ),
+        ]
+
+    def _cloud_combo_workload_specs(self) -> list[ClusterLinkingWorkloadSpec]:
+        specs: list[ClusterLinkingWorkloadSpec] = []
+        for mode, mode_label in (
+            (TopicSpec.STORAGE_MODE_CLOUD, "cloud"),
+            (TopicSpec.STORAGE_MODE_TIERED_CLOUD, "tiered-cloud"),
+        ):
+            specs.append(
+                ClusterLinkingWorkloadSpec(
+                    topic=f"{mode_label}-compacted-topic",
+                    topic_properties={
+                        TopicSpec.PROPERTY_STORAGE_MODE: mode,
+                        "cleanup.policy": "compact",
+                        "segment.bytes": f"{1024 * 1024}",
+                    },
+                    partition_count=self.partition_count,
+                    msg_count=self.msg_count,
+                    msg_size=self.msg_size,
+                    producer_properties={
+                        "key_set_cardinality": 600,
+                        "tombstone_probability": 0.4,
+                    },
+                    consumer_properties={
+                        "compacted": True,
+                    },
+                    use_compaction=True,
+                )
+            )
+            specs.append(
+                ClusterLinkingWorkloadSpec(
+                    topic=f"{mode_label}-topic-txns",
+                    topic_properties={
+                        TopicSpec.PROPERTY_STORAGE_MODE: mode,
+                    },
+                    msg_count=math.floor(self.msg_count / 10),
+                    msg_size=self.msg_size,
+                    partition_count=1,
+                    use_transactions=True,
+                    producer_properties={
+                        "transaction_abort_rate": 0.1,
+                        "msgs_per_transaction": 50,
+                        "debug_logs": True,
+                    },
+                    consumer_properties={},
+                    validate_number_of_messages_on_target=True,
+                )
+            )
+        return specs
+
+    @cluster(
+        num_nodes=13,
+        log_allow_list=CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST,
+    )
+    @matrix(
+        failures=[False, True],
+        workload_set=["basic", "cloud_combos"],
+    )
+    def test_node_operations(self, failures: bool, workload_set: str):
         self.setup_scale()
+
+        # tiered_cloud_topics is an explicit-only feature and must be
+        # enabled on both clusters before any tiered_cloud topic can be
+        # created.
+        self.source_cluster.service.set_feature_active(
+            "tiered_cloud_topics", True, timeout_sec=30
+        )
+        self.target_cluster.service.set_feature_active(
+            "tiered_cloud_topics", True, timeout_sec=30
+        )
 
         req = self.create_default_link_request("rnot-link")
         for prop in ALL_TOPIC_PROPERTIES:
@@ -336,56 +473,16 @@ class ShadowLinkingRandomOpsTest(ShadowLinkTestBase):
             )
             self.fi.start()
 
+        if workload_set == "basic":
+            workload_specs = self._basic_workload_specs()
+        else:
+            workload_specs = self._cloud_combo_workload_specs()
+
         manager = ClusterLinkingWorkloadManager(
             self.test_context,
             self.source_cluster,
             self.target_cluster,
-            [
-                ClusterLinkingWorkloadSpec(
-                    topic="si-topic",
-                    topic_properties={
-                        "cleanup.policy": "delete",
-                        "retention.bytes": "1024000",
-                        "segment.bytes": f"{1024 * 1024}",
-                    },
-                    partition_count=self.partition_count,
-                    msg_count=self.msg_count,
-                    msg_size=self.msg_size,
-                ),
-                ClusterLinkingWorkloadSpec(
-                    topic="compacted-topic",
-                    topic_properties={
-                        "cleanup.policy": "compact",
-                        "segment.bytes": f"{1024 * 1024}",
-                    },
-                    partition_count=self.partition_count,
-                    msg_count=self.msg_count,
-                    msg_size=self.msg_size,
-                    producer_properties={
-                        "key_set_cardinality": 600,
-                        "tombstone_probability": 0.4,
-                    },
-                    consumer_properties={
-                        "compacted": True,
-                    },
-                    use_compaction=True,
-                ),
-                ClusterLinkingWorkloadSpec(
-                    topic="topic-txns",
-                    # transactions, use a smaller topic to avoid long test times
-                    msg_count=math.floor(self.msg_count / 10),
-                    msg_size=self.msg_size,
-                    partition_count=1,
-                    use_transactions=True,
-                    producer_properties={
-                        "transaction_abort_rate": 0.1,
-                        "msgs_per_transaction": 50,
-                        "debug_logs": True,
-                    },
-                    consumer_properties={},
-                    validate_number_of_messages_on_target=True,
-                ),
-            ],
+            workload_specs,
             self.preallocated_nodes,
             self.logger,
         )

--- a/tests/rptest/tests/shadow_linking_rnot_test.py
+++ b/tests/rptest/tests/shadow_linking_rnot_test.py
@@ -32,6 +32,7 @@ from rptest.tests.cluster_linking_test_base import (
     CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST,
     ClusterLinkingProgressVerifier,
     ShadowLinkTestBase,
+    StorageModeFlipper,
 )
 from rptest.tests.idempotency_stress_test import matrix
 from rptest.services.admin_ops_fuzzer import AdminOperationsFuzzer
@@ -64,6 +65,8 @@ class ClusterLinkingWorkloadSpec:
         validate_number_of_messages_on_target: bool = True,
         use_transactions: bool = False,
         use_compaction: bool = False,
+        flip_storage_modes: list[str] | None = None,
+        flip_interval_seconds: float = 3.0,
     ):
         self.topic = topic
         self.topic_properties = topic_properties
@@ -78,6 +81,8 @@ class ClusterLinkingWorkloadSpec:
         )
         self.use_transactions = use_transactions
         self.use_compaction = use_compaction
+        self.flip_storage_modes = flip_storage_modes
+        self.flip_interval_seconds = flip_interval_seconds
 
     def __str__(self) -> str:
         return (
@@ -143,6 +148,13 @@ class ClusterLinkingWorkloadWorker:
 
     def start_and_verify(self, progress_timeout: int = 60):
         self.logger.info(f"Starting workload: {self.spec}")
+        flipper = StorageModeFlipper(
+            rpk=self.source_rpk,
+            topic=self.spec.topic,
+            modes=self.spec.flip_storage_modes or [],
+            interval_seconds=self.spec.flip_interval_seconds,
+            logger=self.logger,
+        )
         try:
             self.source_rpk.create_topic(
                 self.spec.topic,
@@ -157,6 +169,7 @@ class ClusterLinkingWorkloadWorker:
                 err_msg=f"Topic {self.spec.topic} did not appear on target cluster within {progress_timeout} seconds",
             )
             self.verifier.start()
+            flipper.start()
             success, error = self.verifier.wait_and_verify(
                 progress_timeout=progress_timeout
             )
@@ -164,6 +177,8 @@ class ClusterLinkingWorkloadWorker:
             self.logger.error(f"Workload for topic: {self.spec.topic} failed: {e}")
             success = False
             error = str(e)
+        finally:
+            flipper.stop()
         return ClusterLinkingWorkloadResult(self.spec.topic, success, error)
 
 
@@ -385,6 +400,25 @@ class ShadowLinkingRandomOpsTest(ShadowLinkTestBase):
             ),
         ]
 
+    def _flipping_workload_specs(self) -> list[ClusterLinkingWorkloadSpec]:
+        return [
+            ClusterLinkingWorkloadSpec(
+                topic="flipping-storage-topic",
+                topic_properties={
+                    TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD,
+                    "segment.bytes": f"{1024 * 1024}",
+                },
+                partition_count=self.partition_count,
+                msg_count=self.msg_count,
+                msg_size=self.msg_size,
+                flip_storage_modes=[
+                    TopicSpec.STORAGE_MODE_CLOUD,
+                    TopicSpec.STORAGE_MODE_TIERED_CLOUD,
+                ],
+                flip_interval_seconds=3.0,
+            ),
+        ]
+
     def _cloud_combo_workload_specs(self) -> list[ClusterLinkingWorkloadSpec]:
         specs: list[ClusterLinkingWorkloadSpec] = []
         for mode, mode_label in (
@@ -439,7 +473,7 @@ class ShadowLinkingRandomOpsTest(ShadowLinkTestBase):
     )
     @matrix(
         failures=[False, True],
-        workload_set=["basic", "cloud_combos"],
+        workload_set=["basic", "cloud_combos", "flipping"],
     )
     def test_node_operations(self, failures: bool, workload_set: str):
         self.setup_scale()
@@ -475,8 +509,10 @@ class ShadowLinkingRandomOpsTest(ShadowLinkTestBase):
 
         if workload_set == "basic":
             workload_specs = self._basic_workload_specs()
-        else:
+        elif workload_set == "cloud_combos":
             workload_specs = self._cloud_combo_workload_specs()
+        else:
+            workload_specs = self._flipping_workload_specs()
 
         manager = ClusterLinkingWorkloadManager(
             self.test_context,

--- a/tools/type-checking/type-check-strictness.json
+++ b/tools/type-checking/type-check-strictness.json
@@ -423,6 +423,7 @@
         "rptest/tests/shadow_indexing_admin_api_test.py",
         "rptest/tests/shadow_indexing_compacted_topic_test.py",
         "rptest/tests/shadow_indexing_tx_test.py",
+        "rptest/tests/shadow_linking_rnot_test.py",
         "rptest/tests/shard_placement_test.py",
         "rptest/tests/simple_e2e_test.py",
         "rptest/tests/storage_resources_test.py",


### PR DESCRIPTION
Adds cloud-topic and tiered-cloud-topic workloads to the shadow linking random node ops test so we exercise plain cloud and tiered_cloud storage modes alongside the existing si, compacted, and transactional workloads. Enables the explicit-only tiered_cloud_topics feature on both clusters and CLOUD_TOPICS_CONFIG_STR cluster-wide; allow-lists the expected cloud-topics shutdown warnings.

Fixes the bug in the write-at-offset code path in the cloud topics frontend. The frontend was converting batches of all types as placeholders. This caused the stall in the target cluster. The second commit in the PR fixes this.

Finally, the test adds new workload that constantly flips between `cloud` and `tiered_cloud` modes. The goal is to have a mix of `raft_data` and `ct_placeholder` batches in the partition which is being shadowed. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none