### PR TITLE
lsm/io: round read buffer by max of memory/disk DMA alignment

### DIFF
--- a/src/v/lsm/io/file_io.cc
+++ b/src/v/lsm/io/file_io.cc
@@ -15,6 +15,8 @@
 
 #include <seastar/core/reactor.hh>
 
+#include <algorithm>
+
 namespace lsm::io {
 
 disk_file_reader::disk_file_reader(std::filesystem::path path, ss::file file)
@@ -24,10 +26,13 @@ disk_file_reader::disk_file_reader(std::filesystem::path path, ss::file file)
 ss::future<ioarray> disk_file_reader::read(size_t offset, size_t n) {
     size_t memory_alignment = _file.memory_dma_alignment();
     size_t disk_alignment = _file.disk_read_dma_alignment();
+    // ioarray requires its size to be a multiple of its alignment, so use the
+    // max of the two seastar alignments.
+    size_t max_alignment = std::max(memory_alignment, disk_alignment);
     size_t adjusted_offset = ss::align_down(offset, disk_alignment);
     size_t offset_delta = offset - adjusted_offset;
     auto array = ioarray::aligned(
-      memory_alignment, ss::align_up(n + offset_delta, disk_alignment));
+      memory_alignment, ss::align_up(n + offset_delta, max_alignment));
     try {
         size_t amt = co_await _file.dma_read(adjusted_offset, array.as_iovec());
         if (amt < offset_delta + n) {


### PR DESCRIPTION
`disk_file_reader::read` passes `memory_dma_alignment()` to
`ioarray::aligned()` as the alignment, but rounds the buffer size by
`disk_read_dma_alignment()`. `ioarray::aligned()`'s precondition is
`size % alignment == 0`, which is only met when those two seastar
alignments are equal — which they have been on every current
configuration, so the latent bug never fired.

**Exposed by the seastar v26.2.x rebase.** Upstream commit
[`15adc3ce5` "file: Apply physical_block_size override to filesystem
files"](https://github.com/scylladb/seastar/commit/15adc3ce5)
unconditionally runs a new `filesystem_alignments()` path on every
posix file, which hardcodes `disk_read = 512` (the O_DIRECT minimum)
for non-XFS filesystems while leaving `memory_dma_alignment` at its
prior default. XFS goes through its own override path that sets both
`memory` and `disk_read` from the device's logical sector size, so XFS
is unaffected.

Confirmed locally with a small `open_file_dma` probe built against
both the old and new seastar SHAs:

| Mount | FS | old (a0b4f2a6) | new (097536ff) |
|---|---|---|---|
| /mnt/bazel | xfs                  | `memory=512,  disk_read=512`  | `memory=512,  disk_read=512`  (unchanged) |
| /mnt/xfs   | xfs                  | `memory=512,  disk_read=512`  | `memory=512,  disk_read=512`  (unchanged) |
| /tmp       | ext4                 | `memory=4096, disk_read=4096` | `memory=4096, disk_read=512`  |
| /home/td   | ext4 (fscrypt — probably behaves like overlayfs etc.) | `memory=4096, disk_read=4096` | `memory=4096, disk_read=512`  |

With `memory > disk_read`, the precondition fires:

    Assert failure: (src/v/bytes/ioarray.cc:59) 'size % alignment == 0'
    size 512 must be a multiple of alignment 4096

across 5 `//src/v/lsm/...` and `//src/v/cloud_topics/...` tests in
PR #30428's `build-debug-clang-arm64` job (whose bazel sandbox lives on
a non-XFS filesystem). The failure doesn't reproduce on x86_64 hosts
whose bazel sandbox is on XFS, because there `memory == disk_read == 512`
and every `align_up(n, 512)` trivially divides 512.

Round the size up by `std::max(memory_alignment, disk_alignment)` so
the ioarray precondition holds while still over-allocating only by the
gap between the two alignments.

Tracked as [CORE-16295](https://redpandadata.atlassian.net/browse/CORE-16295).

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

[CORE-16295]: https://redpandadata.atlassian.net/browse/CORE-16295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ