### PR TITLE
dt/tests: bump librdkafka to v2.14.1 and confluent-kafka to v2.14.0

### DIFF
--- a/tests/docker/ducktape-deps/librdkafka
+++ b/tests/docker/ducktape-deps/librdkafka
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 mkdir /opt/librdkafka
-curl -SL "https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.11.1.tar.gz" | tar -xz --strip-components=1 -C /opt/librdkafka
+curl -SL "https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.14.1.tar.gz" | tar -xz --strip-components=1 -C /opt/librdkafka
 cd /opt/librdkafka
 ./configure --enable-gssapi --enable-curl
 make -j$(nproc)

--- a/tests/rptest/remote_scripts/python_librdkafka_serde_client.py
+++ b/tests/rptest/remote_scripts/python_librdkafka_serde_client.py
@@ -268,10 +268,15 @@ class SerdeClient:
         }
 
     def produce(self, count: int):
+        delivery_error_code: int | None = None
+
         def increment(err: KafkaError | None, msg: Message | None):
+            nonlocal delivery_error_code
             if err is not None:
                 self.logger.error(f"Produce err: {err}")
-                sys.exit(err.code())
+                if delivery_error_code is None:
+                    delivery_error_code = err.code()
+                return
             assert msg is not None
             if self.first_ack is None:
                 self.first_ack = msg.offset()
@@ -319,6 +324,13 @@ class SerdeClient:
 
         self.logger.info("Flushing records...")
         producer.flush()
+        # confluent-kafka 2.13+ strictly propagates exceptions raised inside C
+        # callbacks, which turns a `sys.exit(int)` from on_delivery
+        # into a `SystemError: ... <class 'int'> is not a BaseException
+        # subclass`. Stash the error code in the callback and exit here, after
+        # flush() has returned control to Python.
+        if delivery_error_code is not None:
+            sys.exit(delivery_error_code)  # pyright: ignore[reportUnreachable]
         self.logger.info("Records flushed: %d", self.produced)
         while self.acked < count:
             producer.poll(0.01)

--- a/tests/rptest/tests/redpanda_oauth_test.py
+++ b/tests/rptest/tests/redpanda_oauth_test.py
@@ -666,9 +666,11 @@ class RedpandaOIDCTestMethods(RedpandaOIDCTestBase):
         self.redpanda.logger.debug("starting producer")
         producer.poll(1.0)
         wait_until(
-            lambda: set(producer.list_topics(timeout=10).topics.keys())
-            == expected_topics,
+            lambda: expected_topics.issubset(
+                producer.list_topics(timeout=10).topics.keys()
+            ),
             timeout_sec=5,
+            err_msg=f"Expected topics {expected_topics} to be a subset of producer topics",
         )
 
         def consume_one():
@@ -792,10 +794,11 @@ class RedpandaOIDCTestMethods(RedpandaOIDCTestBase):
         self.redpanda.logger.debug("starting producer")
         producer.poll(1.0)
         wait_until(
-            lambda: set(producer.list_topics(timeout=10).topics.keys())
-            == expected_topics,
+            lambda: expected_topics.issubset(
+                producer.list_topics(timeout=10).topics.keys()
+            ),
             timeout_sec=5,
-            err_msg=f"Producer topics do not match expected topics: {expected_topics}",
+            err_msg=f"Expected topics {expected_topics} to be a subset of producer topics",
         )
 
         def consume_one():

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -8570,7 +8570,12 @@ class SchemaRegistryConfluentClient(SchemaRegistryEndpoints):
 
         # Replace the Redpanda SR client.
         self._base_uri = self.sr_client.base_uri()
-        self.sr_client = SchemaRegistryClient({"url": self._base_uri})
+        # cache.latest.ttl.sec=0 disables confluent-kafka 2.14's get_latest_version
+        # cache, which is not invalidated on register_schema and would otherwise
+        # return stale results in tests that register multiple versions back-to-back.
+        self.sr_client = SchemaRegistryClient(
+            {"url": self._base_uri, "cache.latest.ttl.sec": 0}
+        )
 
     @cluster(num_nodes=3)
     @matrix(normalize_schemas=[True, False])
@@ -8642,7 +8647,9 @@ class SchemaRegistryConfluentClient(SchemaRegistryEndpoints):
         assert result == [1], f"Result: {result}"
 
         # reinitialize client to drop the cache
-        self.sr_client = SchemaRegistryClient({"url": self._base_uri})
+        self.sr_client = SchemaRegistryClient(
+            {"url": self._base_uri, "cache.latest.ttl.sec": 0}
+        )
         with expect_exception(SchemaRegistryError, lambda e: True):
             self.sr_client.get_version(test_subject, 2)
 
@@ -8697,6 +8704,11 @@ class SchemaRegistryConfluentClient(SchemaRegistryEndpoints):
         result = self.sr_client.get_schema(1)
         assert result == schema1, f"Result: {result}"
 
+        if permanent:
+            # confluent-kafka 2.14's delete_subject(permanent=True) only issues the
+            # hard-delete request; the server requires a prior soft delete.
+            soft_result = self.sr_client.delete_subject(test_subject)
+            assert soft_result == [1], f"Result: {soft_result}"
         result = self.sr_client.delete_subject(test_subject, permanent=permanent)
         assert result == [1], f"Result: {result}"
 
@@ -8757,17 +8769,20 @@ class SchemaRegistryConfluentClient(SchemaRegistryEndpoints):
         result = self.sr_client.register_schema(validate_subject, validate_schema)
         assert result == 4, f"Result: {result}"
 
-        result = self.sr_client.get_schema(1)
-        assert result == simple_schema, f"Result: {result}"
+        # The schema registry canonicalizes the proto source on parse — it
+        # adjusts whitespace, prefixes referenced types with `.` to make them
+        # fully qualified, and so on — so Schema dataclass `==` fails on
+        # schema_str even though the schemas are semantically identical. This
+        # test is about reference round-tripping; assert on schema_type and
+        # references and leave schema_str equivalence to tests focused on it.
+        def _assert_schema_round_trip(actual: Schema, expected: Schema) -> None:
+            assert actual.schema_type == expected.schema_type, f"Result: {actual}"
+            assert actual.references == expected.references, f"Result: {actual}"
 
-        result = self.sr_client.get_schema(2)
-        assert result == imported_schema, f"Result: {result}"
-
-        result = self.sr_client.get_schema(3)
-        assert result == well_known_schema, f"Result: {result}"
-
-        result = self.sr_client.get_schema(4)
-        assert result == validate_schema, f"Result: {result}"
+        _assert_schema_round_trip(self.sr_client.get_schema(1), simple_schema)
+        _assert_schema_round_trip(self.sr_client.get_schema(2), imported_schema)
+        _assert_schema_round_trip(self.sr_client.get_schema(3), well_known_schema)
+        _assert_schema_round_trip(self.sr_client.get_schema(4), validate_schema)
 
 
 # dataset for SchemaRegistryCompatibilityModes: schemas is a list of 3 schemas compatible for `mode`, `antimode` is a suitable mode that will make the compat check for schemas fail

--- a/tests/rptest/transactions/transactions_test.py
+++ b/tests/rptest/transactions/transactions_test.py
@@ -536,7 +536,6 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
                 "test-post-expire",
                 "test-post-expire",
                 partition=0,
-                on_delivery=self.on_delivery,
             )
             producer.flush()
             assert False, "tx is expected to be expired"

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -16,7 +16,7 @@ setup(
         "prometheus-client==0.9.0",
         "kafka-python==2.0.6",
         "crc32c==2.2",
-        "confluent-kafka==2.6.1",
+        "confluent-kafka[avro,json,protobuf]==2.14.0",
         "types-confluent-kafka==1.4.0",
         "zstandard==0.23.0",
         "xxhash==3.5.0",
@@ -43,7 +43,7 @@ setup(
         "python-keycloak==5.8.1",
         "z3-solver==4.12.6",
         "hypothesis==6.82",
-        "jsonschema==4.10.0",
+        "jsonschema==4.26.0",
         "redpanda-polaris-catalog-python==1.0.0.post3",  # See: .github/workflows/publish-apache-polaris-python-client.yml
         # PyIceberg: Use an official release once the next major (1.0) is out.
         #   Using a hash to unreleased version because we depend on new


### PR DESCRIPTION
Bumps the system librdkafka pin from v2.11.1 to v2.14.1 and the
Python wrapper from 2.6.1 to 2.14.0, aligning the non-Java client
test surface with Kafka 4.latest (part of ENG-1185).

The 2.13/2.14 line introduced behavior changes in C-callback
semantics, SchemaRegistryClient caching/deletion/canonicalization,
and producer metadata that affected our serde-client script and a
few transactions/OIDC tests. Each precursor commit adapts one of
these surfaces forward-compatibly so the bump itself stays atomic.

confluent-kafka 2.14 also moves schema-registry serializer deps
(orjson, authlib, httpx, cachetools, ...) out of the core install,
so we pin `confluent-kafka[avro,json,protobuf]==2.14.0` to bring
them back. jsonschema is bumped 4.10 to 4.26 because 2.14's
`json_schema` module uses the `referencing` API introduced in 4.18.

Fixes [CORE-16239](https://redpandadata.atlassian.net/browse/CORE-16239).

## Backports Required
- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
* none


[CORE-16239]: https://redpandadata.atlassian.net/browse/CORE-16239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ