### PR TITLE
`ct/l1`: add `leveling_range_builder` and `metastore` leveling interfaces

### DIFF
--- a/src/v/cloud_topics/level_one/domain/BUILD
+++ b/src/v/cloud_topics/level_one/domain/BUILD
@@ -116,6 +116,7 @@ redpanda_cc_library(
     implementation_deps = [
         "//src/v/cloud_topics:logger",
         "//src/v/cloud_topics/level_one/metastore:domain_uuid",
+        "//src/v/cloud_topics/level_one/metastore:leveling_range_builder",
         "//src/v/cloud_topics/level_one/metastore:state_update",
         "//src/v/cloud_topics/level_one/metastore/lsm:garbage_collector",
         "//src/v/cloud_topics/level_one/metastore/lsm:keys",

--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -11,6 +11,7 @@
 
 #include "cloud_topics/level_one/common/object_id.h"
 #include "cloud_topics/level_one/metastore/domain_uuid.h"
+#include "cloud_topics/level_one/metastore/leveling_range_builder.h"
 #include "cloud_topics/level_one/metastore/lsm/garbage_collector.h"
 #include "cloud_topics/level_one/metastore/lsm/keys.h"
 #include "cloud_topics/level_one/metastore/lsm/state_reader.h"
@@ -1393,6 +1394,94 @@ db_domain_manager::get_compaction_infos(rpc::get_compaction_infos_request req) {
 
     co_return rpc::get_compaction_infos_reply{
       .responses = std::move(compaction_infos)};
+}
+
+ss::future<rpc::get_leveling_info_reply>
+db_domain_manager::do_get_leveling_info(
+  const gate_read_lock&,
+  state_reader& reader,
+  rpc::get_leveling_info_request req) {
+    auto metadata_res = co_await reader.get_metadata(req.tp);
+    if (!metadata_res.has_value()) {
+        co_return rpc::get_leveling_info_reply{
+          .ec = log_and_convert(
+            metadata_res.error(), "Error getting metadata: "),
+        };
+    }
+    if (!metadata_res.value().has_value()) {
+        co_return rpc::get_leveling_info_reply{
+          .ec = rpc::errc::missing_ntp,
+        };
+    }
+    const auto& metadata = **metadata_res;
+    const auto start_offset = metadata.start_offset;
+    const auto next_offset = metadata.next_offset;
+
+    // Check for empty log.
+    if (start_offset >= next_offset) {
+        co_return rpc::get_leveling_info_reply{
+          .ec = rpc::errc::ok,
+          .ranges = {},
+          .epoch = metadata.compaction_epoch,
+        };
+    }
+
+    auto extents_res = co_await reader.get_inclusive_extents(
+      req.tp, std::nullopt, std::nullopt);
+    if (!extents_res.has_value()) {
+        co_return rpc::get_leveling_info_reply{
+          .ec = log_and_convert(extents_res.error(), "Error getting extents: "),
+        };
+    }
+    leveling_range_builder builder{req.min_acceptable_extent_bytes};
+    if (extents_res.value().has_value()) {
+        auto gen = (*extents_res)->get_rows();
+        while (auto row_opt = co_await gen()) {
+            const auto& row = row_opt->get();
+            if (!row.has_value()) {
+                co_return rpc::get_leveling_info_reply{
+                  .ec = log_and_convert(
+                    row.error(), "Error iterating through extents: "),
+                };
+            }
+            const auto& extent = *row;
+            auto key = extent_row_key::decode(extent.key);
+            auto base = key->base_offset;
+            if (base < start_offset) {
+                // The extent is partially truncated.
+                base = start_offset;
+            }
+            builder.process_extent(
+              base, extent.val.last_offset, extent.val.len);
+        }
+    }
+    co_return rpc::get_leveling_info_reply{
+      .ec = rpc::errc::ok,
+      .ranges = std::move(builder).finalize(),
+      .epoch = metadata.compaction_epoch,
+    };
+}
+
+ss::future<rpc::get_leveling_infos_reply>
+db_domain_manager::get_leveling_infos(rpc::get_leveling_infos_request req) {
+    auto gl_res = co_await gate_and_open_reads();
+    if (!gl_res.has_value()) {
+        co_return rpc::get_leveling_infos_reply{
+          .ec = gl_res.error(),
+        };
+    }
+
+    auto reader = state_reader(db_->db().create_snapshot());
+    chunked_hash_map<model::topic_id_partition, rpc::get_leveling_info_reply>
+      leveling_infos;
+    for (auto& log_req : req.logs) {
+        auto log_info = co_await do_get_leveling_info(
+          gl_res.value(), reader, log_req);
+        leveling_infos.insert_or_assign(log_req.tp, std::move(log_info));
+    }
+
+    co_return rpc::get_leveling_infos_reply{
+      .responses = std::move(leveling_infos)};
 }
 
 ss::future<rpc::get_extent_metadata_reply>

--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.h
@@ -89,6 +89,9 @@ public:
     ss::future<rpc::get_compaction_infos_reply>
       get_compaction_infos(rpc::get_compaction_infos_request) override;
 
+    ss::future<rpc::get_leveling_infos_reply>
+      get_leveling_infos(rpc::get_leveling_infos_request) override;
+
     ss::future<rpc::get_extent_metadata_reply>
       get_extent_metadata(rpc::get_extent_metadata_request) override;
 
@@ -227,6 +230,9 @@ private:
     do_remove_topics(const entity_locks&, chunked_vector<model::topic_id>);
 
     ss::future<> expire_preregistered_objects(chunked_vector<object_id>);
+
+    ss::future<rpc::get_leveling_info_reply> do_get_leveling_info(
+      const gate_read_lock&, state_reader&, rpc::get_leveling_info_request);
 
     ss::gate gate_;
     ss::abort_source as_;

--- a/src/v/cloud_topics/level_one/domain/domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.h
@@ -97,6 +97,9 @@ public:
     virtual ss::future<rpc::get_compaction_infos_reply>
       get_compaction_infos(rpc::get_compaction_infos_request) = 0;
 
+    virtual ss::future<rpc::get_leveling_infos_reply>
+      get_leveling_infos(rpc::get_leveling_infos_request) = 0;
+
     virtual ss::future<rpc::get_extent_metadata_reply>
       get_extent_metadata(rpc::get_extent_metadata_request) = 0;
 

--- a/src/v/cloud_topics/level_one/domain/simple_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/simple_domain_manager.cc
@@ -693,6 +693,51 @@ simple_domain_manager::get_compaction_infos(
       .responses = std::move(compaction_infos)};
 }
 
+rpc::get_leveling_info_reply simple_domain_manager::do_get_leveling_info(
+  const state& stm_state, rpc::get_leveling_info_request req) {
+    auto get_res = simple_metastore::get_leveling_info(
+      stm_state,
+      metastore::leveling_info_spec{
+        .tidp = req.tp,
+        .min_acceptable_extent_bytes = req.min_acceptable_extent_bytes});
+    if (!get_res.has_value()) {
+        return rpc::get_leveling_info_reply{
+          .ec = convert_metastore_errc(get_res.error()),
+        };
+    }
+    return rpc::get_leveling_info_reply{
+      .ec = rpc::errc::ok,
+      .ranges = std::move(get_res->ranges),
+      .epoch = partition_state::compaction_epoch_t{get_res->epoch()},
+    };
+}
+
+ss::future<rpc::get_leveling_infos_reply>
+simple_domain_manager::get_leveling_infos(rpc::get_leveling_infos_request req) {
+    auto gate = maybe_gate();
+    if (!gate.has_value()) {
+        co_return rpc::get_leveling_infos_reply{
+          .ec = rpc::errc::not_leader,
+        };
+    }
+    auto sync_res = co_await stm_->sync(10s);
+    if (!sync_res.has_value()) {
+        co_return rpc::get_leveling_infos_reply{
+          .ec = convert_stm_errc(sync_res.error()),
+        };
+    }
+    auto& stm_state = stm_->state();
+
+    chunked_hash_map<model::topic_id_partition, rpc::get_leveling_info_reply>
+      leveling_infos;
+    for (auto& log_req : req.logs) {
+        auto log_info = do_get_leveling_info(stm_state, log_req);
+        leveling_infos.insert_or_assign(log_req.tp, std::move(log_info));
+    }
+    co_return rpc::get_leveling_infos_reply{
+      .responses = std::move(leveling_infos)};
+}
+
 ss::future<rpc::get_extent_metadata_reply>
 simple_domain_manager::get_extent_metadata(
   rpc::get_extent_metadata_request req) {

--- a/src/v/cloud_topics/level_one/domain/simple_domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/simple_domain_manager.h
@@ -72,6 +72,9 @@ public:
     ss::future<rpc::get_compaction_infos_reply>
       get_compaction_infos(rpc::get_compaction_infos_request) override;
 
+    ss::future<rpc::get_leveling_infos_reply>
+      get_leveling_infos(rpc::get_leveling_infos_request) override;
+
     ss::future<rpc::get_extent_metadata_reply>
       get_extent_metadata(rpc::get_extent_metadata_request) override;
 
@@ -106,6 +109,9 @@ private:
 
     rpc::get_compaction_info_reply
     do_get_compaction_info(const state&, rpc::get_compaction_info_request);
+
+    rpc::get_leveling_info_reply
+    do_get_leveling_info(const state&, rpc::get_leveling_info_request);
 
     config::binding<std::chrono::milliseconds> gc_interval_;
     // This semaphore is used as a way to signal a change to

--- a/src/v/cloud_topics/level_one/metastore/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/BUILD
@@ -23,6 +23,18 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "leveling_range_builder",
+    hdrs = [
+        "leveling_range_builder.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":offset_interval_set",
+        "//src/v/model",
+    ],
+)
+
+redpanda_cc_library(
     name = "metastore_manifest",
     hdrs = [
         "metastore_manifest.h",

--- a/src/v/cloud_topics/level_one/metastore/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/BUILD
@@ -29,8 +29,10 @@ redpanda_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        ":offset_interval_set",
+        "//src/v/container:chunked_vector",
         "//src/v/model",
+        "//src/v/serde",
+        "@fmt",
     ],
 )
 
@@ -145,6 +147,7 @@ redpanda_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":leveling_range_builder",
         ":metastore_manifest",
         ":offset_interval_set",
         "//src/v/base",
@@ -205,6 +208,7 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":domain_uuid",
+        ":leveling_range_builder",
         ":offset_interval_set",
         ":state_update",
         "//src/v/cloud_topics/level_one/common:object_id",
@@ -223,6 +227,7 @@ redpanda_cc_library(
         "simple_metastore.h",
     ],
     implementation_deps = [
+        ":leveling_range_builder",
         ":state_update",
         "//src/v/cloud_topics:logger",
     ],

--- a/src/v/cloud_topics/level_one/metastore/leader_router.cc
+++ b/src/v/cloud_topics/level_one/metastore/leader_router.cc
@@ -185,6 +185,17 @@ ss::future<rpc::get_compaction_infos_reply> do_get_compaction_infos(
     co_return co_await domain_mgr->get_compaction_infos(std::move(req));
 }
 
+ss::future<rpc::get_leveling_infos_reply> do_get_leveling_infos(
+  domain_supervisor& domain_supervisor,
+  const model::ntp& ntp,
+  rpc::get_leveling_infos_request req) {
+    auto domain_mgr = domain_supervisor.get(ntp);
+    if (!domain_mgr) {
+        co_return rpc::get_leveling_infos_reply{.ec = rpc::errc::not_leader};
+    }
+    co_return co_await domain_mgr->get_leveling_infos(std::move(req));
+}
+
 ss::future<rpc::get_extent_metadata_reply> do_get_extent_metadata(
   domain_supervisor& domain_supervisor,
   const model::ntp& ntp,
@@ -807,6 +818,27 @@ ss::future<rpc::get_compaction_infos_reply> leader_router::get_compaction_infos(
     co_return co_await process<
       &leader_router::get_compaction_infos_locally,
       &client::get_compaction_infos>(std::move(request), bool(local_only_exec));
+}
+
+ss::future<rpc::get_leveling_infos_reply>
+leader_router::get_leveling_infos_locally(
+  rpc::get_leveling_infos_request request,
+  const model::ntp& metastore_ntp,
+  ss::shard_id shard) {
+    co_return co_await container().invoke_on(
+      shard,
+      [metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
+          return do_get_leveling_infos(
+            *(fe._domain_supervisor), metastore_ntp, std::move(req));
+      });
+}
+
+ss::future<rpc::get_leveling_infos_reply> leader_router::get_leveling_infos(
+  rpc::get_leveling_infos_request request, local_only local_only_exec) {
+    auto holder = _gate.hold();
+    co_return co_await process<
+      &leader_router::get_leveling_infos_locally,
+      &client::get_leveling_infos>(std::move(request), bool(local_only_exec));
 }
 
 ss::future<rpc::get_extent_metadata_reply>

--- a/src/v/cloud_topics/level_one/metastore/leader_router.h
+++ b/src/v/cloud_topics/level_one/metastore/leader_router.h
@@ -100,6 +100,9 @@ public:
     ss::future<rpc::get_compaction_infos_reply> get_compaction_infos(
       rpc::get_compaction_infos_request, local_only = local_only::no);
 
+    ss::future<rpc::get_leveling_infos_reply> get_leveling_infos(
+      rpc::get_leveling_infos_request, local_only = local_only::no);
+
     ss::future<rpc::get_extent_metadata_reply> get_extent_metadata(
       rpc::get_extent_metadata_request, local_only = local_only::no);
 
@@ -215,6 +218,11 @@ private:
 
     ss::future<rpc::get_compaction_infos_reply> get_compaction_infos_locally(
       rpc::get_compaction_infos_request,
+      const model::ntp& metastore_ntp,
+      ss::shard_id);
+
+    ss::future<rpc::get_leveling_infos_reply> get_leveling_infos_locally(
+      rpc::get_leveling_infos_request,
       const model::ntp& metastore_ntp,
       ss::shard_id);
 

--- a/src/v/cloud_topics/level_one/metastore/leveling_range_builder.h
+++ b/src/v/cloud_topics/level_one/metastore/leveling_range_builder.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "container/chunked_vector.h"
+#include "model/fundamental.h"
+#include "serde/envelope.h"
+#include "serde/rw/envelope.h"
+
+#include <fmt/core.h>
+
+#include <optional>
+
+namespace cloud_topics::l1 {
+
+// A contiguous range of offsets in a partition that should be rewritten,
+// together with per-range stats the scheduler can use to plan work.
+struct levelable_range
+  : serde::
+      envelope<levelable_range, serde::version<0>, serde::compat_version<0>> {
+    bool operator==(const levelable_range&) const = default;
+
+    auto serde_fields() {
+        return std::tie(base_offset, last_offset, size_bytes);
+    }
+
+    kafka::offset base_offset;
+    kafka::offset last_offset;
+    // Sum of the undersized extents' bytes within this range.
+    size_t size_bytes{0};
+
+    fmt::iterator format_to(fmt::iterator it) const {
+        return fmt::format_to(
+          it,
+          "{{base:{}, last:{}, size_bytes:{}}}",
+          base_offset,
+          last_offset,
+          size_bytes);
+    }
+};
+
+// Builds a sequence of `levelable_range`s eligible for leveling from extents
+// provided via `process_extent`, returning them from `finalize()`. An extent
+// is considered undersized when its length is strictly less than
+// `min_acceptable_extent_bytes`.
+//
+// We only consider rewriting a *run* of consecutive undersized extents.
+// Healthy extents close the active run. We never include a healthy extent in
+// a leveling range, as those have per-byte rewrite cost without corresponding
+// extent-count savings.
+//
+//   - Undersized extent: extend (or open) the active range.
+//   - Healthy extent: close the active range.
+//   - On close: commit the range only if it contains more than one
+//     extent (K > 1), as singleton runs can't reduce extent count.
+class leveling_range_builder {
+public:
+    explicit leveling_range_builder(size_t min_acceptable_extent_bytes)
+      : _min_acceptable_extent_bytes(min_acceptable_extent_bytes) {}
+
+    // Processes a single extent.
+    void process_extent(kafka::offset base, kafka::offset last, size_t len) {
+        if (len >= _min_acceptable_extent_bytes) {
+            // A healthy extent closes any active run.
+            maybe_commit_range();
+            return;
+        }
+        if (!_range.has_value()) {
+            _range.emplace(base, last, len, 1);
+            return;
+        }
+        _range->last = last;
+        _range->bytes += len;
+        _range->extent_count += 1;
+    }
+
+    // Commit any pending range and return the accumulated ranges. Must
+    // be called after all extents have been processed.
+    chunked_vector<levelable_range> finalize() && {
+        maybe_commit_range();
+        return std::move(_ranges);
+    }
+
+private:
+    struct in_progress_range {
+        kafka::offset base;
+        kafka::offset last;
+        size_t bytes;
+        size_t extent_count;
+    };
+
+    void maybe_commit_range() {
+        if (!_range.has_value()) {
+            return;
+        }
+        if (_range->extent_count > 1) {
+            _ranges.push_back(
+              levelable_range{
+                .base_offset = _range->base,
+                .last_offset = _range->last,
+                .size_bytes = _range->bytes,
+              });
+        }
+        _range.reset();
+    }
+
+    size_t _min_acceptable_extent_bytes;
+    std::optional<in_progress_range> _range;
+    chunked_vector<levelable_range> _ranges;
+};
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -11,6 +11,7 @@
 
 #include "base/seastarx.h"
 #include "cloud_topics/level_one/common/object_id.h"
+#include "cloud_topics/level_one/metastore/leveling_range_builder.h"
 #include "cloud_topics/level_one/metastore/metastore_manifest.h"
 #include "cloud_topics/level_one/metastore/offset_interval_set.h"
 #include "container/chunked_hash_map.h"
@@ -450,6 +451,35 @@ public:
     // Vectorized RPC for obtaining compaction state for a number of partitions.
     virtual ss::future<std::expected<compaction_info_map, errc>>
     get_compaction_infos(const chunked_vector<compaction_info_spec>&) = 0;
+
+    // Identifies offset ranges that should be rewritten because they contain
+    // runs of undersized extents whose length is below the threshold.
+    struct leveling_info_spec {
+        model::topic_id_partition tidp;
+        // An extent shorter than this is considered undersized and eligible
+        // for leveling.
+        size_t min_acceptable_extent_bytes;
+    };
+
+    struct leveling_info_response {
+        // Offset ranges that should be rewritten, with per-range stats the
+        // scheduler can use to plan work (e.g. pick a subset, cap per-job
+        // size). Ranges are disjoint and sorted by ascending offset.
+        chunked_vector<levelable_range> ranges;
+        // The partition's current compaction epoch at the time of the query.
+        compaction_epoch epoch;
+
+        fmt::iterator format_to(fmt::iterator it) const {
+            return fmt::format_to(it, "{{ranges:{}, epoch:{}}}", ranges, epoch);
+        }
+    };
+
+    using leveling_info_map = chunked_hash_map<
+      model::topic_id_partition,
+      std::expected<leveling_info_response, errc>>;
+
+    virtual ss::future<std::expected<leveling_info_map, errc>>
+    get_leveling_infos(const chunked_vector<leveling_info_spec>&) = 0;
 
     struct extent_object_info {
         object_id oid;

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -915,6 +915,76 @@ replicated_metastore::get_compaction_infos(
     co_return resp;
 }
 
+ss::future<std::expected<metastore::leveling_info_map, metastore::errc>>
+replicated_metastore::get_leveling_infos(
+  const chunked_vector<leveling_info_spec>& specs) {
+    chunked_hash_map<model::partition_id, rpc::get_leveling_infos_request>
+      partitioned_reqs;
+    metastore::leveling_info_map resp;
+    for (const auto& spec : specs) {
+        const auto& tp = spec.tidp;
+        auto metastore_partition = fe_.metastore_partition(tp);
+        if (!metastore_partition) {
+            vlog(cd_log.warn, "Unable to get metastore partition for {}", tp);
+            resp.insert_or_assign(tp, std::unexpected(errc::transport_error));
+            continue;
+        }
+        auto [it, inserted] = partitioned_reqs.try_emplace(
+          metastore_partition.value(),
+          rpc::get_leveling_infos_request{
+            .metastore_partition = metastore_partition.value()});
+        auto& req = it->second;
+
+        req.logs.push_back(
+          rpc::get_leveling_info_request{
+            .tp = tp,
+            .min_acceptable_extent_bytes = spec.min_acceptable_extent_bytes});
+    }
+
+    static constexpr auto max_rpc_concurrency = 10;
+    auto fut = co_await ss::coroutine::as_future(
+      ss::max_concurrent_for_each(
+        partitioned_reqs,
+        max_rpc_concurrency,
+        [this, &resp](auto& partition_and_request) {
+            auto& request = partition_and_request.second;
+            auto logs = request.logs.copy();
+            return fe_.get_leveling_infos(std::move(request))
+              .then([&resp, logs = std::move(logs)](
+                      rpc::get_leveling_infos_reply reply) {
+                  if (reply.ec != rpc::errc::ok) {
+                      for (const auto& l : logs) {
+                          resp[l.tp] = std::unexpected(
+                            rpc_to_meta_errc(reply.ec));
+                      }
+                      return;
+                  }
+
+                  for (auto& [log, log_reply] : reply.responses) {
+                      if (log_reply.ec == rpc::errc::ok) {
+                          metastore::leveling_info_response log_resp{
+                            .ranges = std::move(log_reply.ranges),
+                            .epoch = metastore::compaction_epoch{
+                              log_reply.epoch()}};
+                          resp.insert_or_assign(log, std::move(log_resp));
+                      } else {
+                          resp.insert_or_assign(
+                            log,
+                            std::unexpected(rpc_to_meta_errc(log_reply.ec)));
+                      }
+                  }
+              });
+        }));
+
+    if (fut.failed()) {
+        auto e = fut.get_exception();
+        vlog(cd_log.warn, "Error while sending leveling info requests: {}", e);
+        co_return std::unexpected(metastore::errc::transport_error);
+    }
+
+    co_return resp;
+}
+
 ss::future<std::expected<metastore::extent_metadata_response, metastore::errc>>
 replicated_metastore::get_extent_metadata_forwards(
   const model::topic_id_partition& tidp,

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
@@ -84,6 +84,9 @@ public:
     ss::future<std::expected<compaction_info_map, errc>>
     get_compaction_infos(const chunked_vector<compaction_info_spec>&) override;
 
+    ss::future<std::expected<leveling_info_map, errc>>
+    get_leveling_infos(const chunked_vector<leveling_info_spec>&) override;
+
     ss::future<std::expected<extent_metadata_response, errc>>
     get_extent_metadata_forwards(
       const model::topic_id_partition&,

--- a/src/v/cloud_topics/level_one/metastore/rpc.json
+++ b/src/v/cloud_topics/level_one/metastore/rpc.json
@@ -82,6 +82,11 @@
             "output_type": "get_compaction_infos_reply"
         },
         {
+            "name": "get_leveling_infos",
+            "input_type": "get_leveling_infos_request",
+            "output_type": "get_leveling_infos_reply"
+        },
+        {
             "name": "get_extent_metadata",
             "input_type": "get_extent_metadata_request",
             "output_type": "get_extent_metadata_reply"

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -11,6 +11,7 @@
 
 #include "cloud_topics/level_one/common/object_id.h"
 #include "cloud_topics/level_one/metastore/domain_uuid.h"
+#include "cloud_topics/level_one/metastore/leveling_range_builder.h"
 #include "cloud_topics/level_one/metastore/offset_interval_set.h"
 #include "cloud_topics/level_one/metastore/state_update.h"
 #include "model/fundamental.h"
@@ -416,6 +417,53 @@ struct get_compaction_infos_request
 
     model::partition_id metastore_partition;
     chunked_vector<get_compaction_info_request> logs;
+};
+
+struct get_leveling_info_reply
+  : serde::envelope<
+      get_leveling_info_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    auto serde_fields() { return std::tie(ec, ranges, epoch); }
+
+    errc ec;
+    chunked_vector<levelable_range> ranges;
+    partition_state::compaction_epoch_t epoch{};
+};
+struct get_leveling_info_request
+  : serde::envelope<
+      get_leveling_info_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using resp_t = get_leveling_info_reply;
+    auto serde_fields() { return std::tie(tp, min_acceptable_extent_bytes); }
+
+    model::topic_id_partition tp;
+    size_t min_acceptable_extent_bytes;
+};
+
+struct get_leveling_infos_reply
+  : serde::envelope<
+      get_leveling_infos_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    auto serde_fields() { return std::tie(ec, responses); }
+
+    errc ec;
+
+    chunked_hash_map<model::topic_id_partition, get_leveling_info_reply>
+      responses;
+};
+struct get_leveling_infos_request
+  : serde::envelope<
+      get_leveling_infos_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using resp_t = get_leveling_infos_reply;
+    auto serde_fields() { return std::tie(metastore_partition, logs); }
+
+    model::partition_id metastore_partition;
+    chunked_vector<get_leveling_info_request> logs;
 };
 
 struct get_extent_metadata_reply

--- a/src/v/cloud_topics/level_one/metastore/service.cc
+++ b/src/v/cloud_topics/level_one/metastore/service.cc
@@ -106,6 +106,12 @@ ss::future<get_compaction_infos_reply> service::get_compaction_infos(
       std::move(request), leader_router::local_only::yes);
 }
 
+ss::future<get_leveling_infos_reply> service::get_leveling_infos(
+  get_leveling_infos_request request, ::rpc::streaming_context&) {
+    return _leader_router->local().get_leveling_infos(
+      std::move(request), leader_router::local_only::yes);
+}
+
 ss::future<get_extent_metadata_reply> service::get_extent_metadata(
   get_extent_metadata_request request, ::rpc::streaming_context&) {
     return _leader_router->local().get_extent_metadata(

--- a/src/v/cloud_topics/level_one/metastore/service.h
+++ b/src/v/cloud_topics/level_one/metastore/service.h
@@ -68,6 +68,9 @@ public:
     ss::future<get_compaction_infos_reply> get_compaction_infos(
       get_compaction_infos_request, ::rpc::streaming_context&) override;
 
+    ss::future<get_leveling_infos_reply> get_leveling_infos(
+      get_leveling_infos_request, ::rpc::streaming_context&) override;
+
     ss::future<get_extent_metadata_reply> get_extent_metadata(
       get_extent_metadata_request, ::rpc::streaming_context&) override;
 

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -10,6 +10,7 @@
 #include "cloud_topics/level_one/metastore/simple_metastore.h"
 
 #include "cloud_topics/level_one/common/object_id.h"
+#include "cloud_topics/level_one/metastore/leveling_range_builder.h"
 #include "cloud_topics/level_one/metastore/offset_interval_set.h"
 #include "cloud_topics/level_one/metastore/state.h"
 #include "cloud_topics/level_one/metastore/state_update.h"
@@ -792,6 +793,46 @@ simple_metastore::get_compaction_infos(
     compaction_info_map infos;
     for (const auto& log : logs) {
         infos.emplace(log.tidp, co_await get_compaction_info(log));
+    }
+    co_return infos;
+}
+
+std::expected<metastore::leveling_info_response, metastore::errc>
+simple_metastore::get_leveling_info(
+  const state& state, const leveling_info_spec& spec) {
+    auto prt_ref = state.partition_state(spec.tidp);
+    if (!prt_ref.has_value()) {
+        return std::unexpected(errc::missing_ntp);
+    }
+
+    const auto& prt = prt_ref->get();
+
+    leveling_info_response resp;
+    resp.epoch = compaction_epoch{prt.compaction_epoch()};
+
+    if (prt.start_offset >= prt.next_offset) {
+        // The log is empty, nothing to level.
+        return resp;
+    }
+
+    leveling_range_builder builder{spec.min_acceptable_extent_bytes};
+    for (const auto& ext : prt.extents) {
+        if (ext.base_offset < prt.start_offset) {
+            continue;
+        }
+        const auto base = std::max(ext.base_offset, prt.start_offset);
+        builder.process_extent(base, ext.last_offset, ext.len);
+    }
+    resp.ranges = std::move(builder).finalize();
+    return resp;
+}
+
+ss::future<std::expected<metastore::leveling_info_map, metastore::errc>>
+simple_metastore::get_leveling_infos(
+  const chunked_vector<leveling_info_spec>& specs) {
+    leveling_info_map infos;
+    for (const auto& spec : specs) {
+        infos.emplace(spec.tidp, get_leveling_info(state_, spec));
     }
     co_return infos;
 }

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -114,6 +114,9 @@ public:
     ss::future<std::expected<compaction_info_map, errc>>
     get_compaction_infos(const chunked_vector<compaction_info_spec>&) override;
 
+    ss::future<std::expected<leveling_info_map, errc>>
+    get_leveling_infos(const chunked_vector<leveling_info_spec>&) override;
+
     ss::future<std::expected<extent_metadata_response, errc>>
     get_extent_metadata_forwards(
       const model::topic_id_partition&,
@@ -164,6 +167,8 @@ private:
     get_compaction_epoch(const state&, const model::topic_id_partition&);
     static std::expected<compaction_info_response, errc> get_compaction_info(
       const state&, const model::topic_id_partition&, model::timestamp);
+    static std::expected<leveling_info_response, errc>
+    get_leveling_info(const state&, const leveling_info_spec&);
     static std::expected<kafka::offset, errc> get_end_offset_for_term(
       const state&, const model::topic_id_partition&, model::term_id);
     static std::expected<model::term_id, errc> get_term_for_offset(

--- a/src/v/cloud_topics/level_one/metastore/tests/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/tests/BUILD
@@ -47,6 +47,20 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "leveling_range_builder_test",
+    timeout = "short",
+    srcs = [
+        "leveling_range_builder_test.cc",
+    ],
+    deps = [
+        "//src/v/cloud_topics/level_one/metastore:leveling_range_builder",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "garbage_collector_test",
     timeout = "short",
     srcs = [

--- a/src/v/cloud_topics/level_one/metastore/tests/leveling_range_builder_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/leveling_range_builder_test.cc
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/metastore/leveling_range_builder.h"
+#include "model/fundamental.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace cloud_topics;
+using namespace cloud_topics::l1;
+
+namespace {
+
+kafka::offset operator""_o(unsigned long long o) {
+    return kafka::offset{static_cast<int64_t>(o)};
+}
+
+struct test_extent {
+    kafka::offset base;
+    kafka::offset last;
+    size_t size;
+};
+
+struct test_case {
+    std::string name;
+    std::vector<test_extent> extents;
+    size_t min_acceptable;
+    std::vector<levelable_range> expected_ranges;
+};
+
+class LevelingRangeBuilderTest : public ::testing::TestWithParam<test_case> {};
+
+} // namespace
+
+TEST_P(LevelingRangeBuilderTest, ProducesExpectedRanges) {
+    const auto& c = GetParam();
+    leveling_range_builder builder{c.min_acceptable};
+
+    for (const auto& ext : c.extents) {
+        builder.process_extent(ext.base, ext.last, ext.size);
+    }
+    auto ranges = std::move(builder).finalize();
+
+    EXPECT_THAT(ranges, ::testing::ElementsAreArray(c.expected_ranges));
+}
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(
+  Cases,
+  LevelingRangeBuilderTest,
+  ::testing::Values(
+    // No undersized extents; nothing to level.
+    test_case{
+      .name = "NoUndersizedExtents",
+      .extents = {{0_o, 9_o, 100},
+                  {10_o, 19_o, 100},
+                  {20_o, 29_o, 100}},
+      .min_acceptable = 50,
+      .expected_ranges = {},
+    },
+    // No extents at all; empty input.
+    test_case{
+      .name = "Empty",
+      .extents = {},
+      .min_acceptable = 50,
+      .expected_ranges = {},
+    },
+    // Two undersized runs: a singleton at obj 1 (discarded, K=1) and
+    // an adjacent pair at objs 3->4 (committed, K=2). The healthy obj 2
+    // closes the first run; the trailing healthy obj 5 closes the second.
+    test_case{
+      .name = "SmallSandwichedBetweenLarge",
+      .extents
+      = {{0_o, 9_o, 100},
+         {10_o, 19_o, 2},
+         {20_o, 29_o, 100},
+         {30_o, 39_o, 15},
+         {40_o, 49_o, 2},
+         {50_o, 59_o, 100}},
+      .min_acceptable = 50,
+      .expected_ranges = {{.base_offset = 30_o, .last_offset = 49_o, .size_bytes = 17}},
+    },
+    // Single isolated small surrounded by healthies. A K=1 singleton
+    // run that finalize() discards on close.
+    test_case{
+      .name = "IsolatedSmallSingleton",
+      .extents = {{0_o, 9_o, 100},
+                  {10_o, 19_o, 2},
+                  {20_o, 29_o, 100}},
+      .min_acceptable = 50,
+      .expected_ranges = {},
+    },
+    // Two smalls separated by two healthies. We never level across a
+    // healthy sized object, so each small is a K=1 singleton run
+    // and neither commits.
+    test_case{
+      .name = "TwoSmallsSeparatedByHealthies",
+      .extents
+      = {{0_o, 9_o, 100},
+         {10_o, 19_o, 2},
+         {20_o, 29_o, 100},
+         {30_o, 39_o, 100},
+         {40_o, 49_o, 2},
+         {50_o, 59_o, 100}},
+      .min_acceptable = 50,
+      .expected_ranges = {},
+    },
+    // The pathological case we naturally avoid: two tiny smalls
+    // separated by 8 healthies. A cross-tier merge would rewrite all
+    // 804 bytes to save 1 object. As it is, we leave each small as its
+    // own K=1 singleton and commit nothing.
+    test_case{
+      .name = "DistantSmallsAreNotMerged",
+      .extents
+      = {{0_o, 9_o, 2},
+         {10_o, 19_o, 100},
+         {20_o, 29_o, 100},
+         {30_o, 39_o, 100},
+         {40_o, 49_o, 100},
+         {50_o, 59_o, 100},
+         {60_o, 69_o, 100},
+         {70_o, 79_o, 100},
+         {80_o, 89_o, 100},
+         {90_o, 99_o, 2}},
+      .min_acceptable = 50,
+      .expected_ranges = {},
+    },
+    // All extents undersized: one range covers everything, rewritten as
+    // one tiny object.
+    test_case{
+      .name = "AllSmall",
+      .extents = {{0_o, 9_o, 2},
+                  {10_o, 19_o, 2},
+                  {20_o, 29_o, 2}},
+      .min_acceptable = 50,
+      .expected_ranges = {{.base_offset = 0_o, .last_offset = 29_o, .size_bytes = 6}},
+    },
+    // Leading healthies are no-ops (no active range to close). Range
+    // opens at obj 2, extends to obj 3, and closes on the trailing
+    // healthy at obj 4. K=2, commits objs 2..3 (4 bytes).
+    test_case{
+      .name = "LeadingHealthyExtentsUntouched",
+      .extents
+      = {{0_o, 9_o, 100},
+         {10_o, 19_o, 100},
+         {20_o, 29_o, 2},
+         {30_o, 39_o, 2},
+         {40_o, 49_o, 100}},
+      .min_acceptable = 50,
+      .expected_ranges = {{.base_offset = 20_o, .last_offset = 39_o, .size_bytes = 4}},
+    },
+    // Smalls separated by a healthy: pure size-tier never bridges across
+    // a healthy extent, so each small is a singleton run with no saving.
+    // No leveling.
+    test_case{
+      .name = "SmallsAcrossHealthyAreNotMerged",
+      .extents
+      = {{0_o, 9_o, 100},
+         {10_o, 19_o, 30},
+         {20_o, 29_o, 100},
+         {30_o, 39_o, 30},
+         {40_o, 49_o, 100}},
+      .min_acceptable = 50,
+      .expected_ranges = {},
+    },
+    // A single trailing small with no neighbors. The active range
+    // (K=1) reaches finalize() and gets discarded. Guards against
+    // finalize() accidentally committing a trivial one-extent run.
+    test_case{
+      .name = "TrailingSmallAlone",
+      .extents = {{0_o, 9_o, 100},
+                  {10_o, 19_o, 100},
+                  {20_o, 29_o, 2}},
+      .min_acceptable = 50,
+      .expected_ranges = {},
+    },
+    // A single leading small followed by healthies. The first healthy
+    // closes the K=1 singleton run, which is then discarded.
+    test_case{
+      .name = "LeadingSmallSingleton",
+      .extents = {{0_o, 9_o, 2},
+                  {10_o, 19_o, 100},
+                  {20_o, 29_o, 100}},
+      .min_acceptable = 50,
+      .expected_ranges = {},
+    },
+    // Threshold below ALL object sizes, nothing eligible.
+    test_case{
+      .name = "NoEligibleExtents",
+      .extents = {{0_o, 9_o, 200},
+                  {10_o, 19_o, 200},
+                  {20_o, 29_o, 200}},
+      .min_acceptable = 50,
+      .expected_ranges = {},
+    },
+    // Two-island scenario: the first three smalls are separated from
+    // each other by healthies (no merge), but the last two are adjacent
+    // and get consolidated. One range commits.
+    test_case{
+      .name = "AdjacentSmallsConsolidate",
+      .extents = {{0_o, 9_o, 100},
+                  {10_o, 19_o, 30},
+                  {20_o, 29_o, 100},
+                  {30_o, 39_o, 30},
+                  {40_o, 49_o, 100},
+                  {50_o, 59_o, 100},
+                  {60_o, 69_o, 30},
+                  {70_o, 79_o, 30},
+                  {80_o, 89_o, 100}},
+      .min_acceptable = 50,
+      .expected_ranges = {{.base_offset = 60_o, .last_offset = 79_o, .size_bytes = 60}},
+    },
+    // Variable extent widths: the algorithm should depend only on size
+    // and offset ordering, not on each extent's offset width. Same shape
+    // as SmallSandwichedBetweenLarge but with non-uniform offset ranges.
+    test_case{
+      .name = "NonUniformOffsetWidths",
+      .extents
+      = {{0_o, 49_o, 100},
+         {50_o, 51_o, 2},
+         {52_o, 151_o, 100},
+         {152_o, 200_o, 15},
+         {201_o, 202_o, 2},
+         {203_o, 999_o, 100}},
+      .min_acceptable = 50,
+      .expected_ranges = {{.base_offset = 152_o, .last_offset = 202_o, .size_bytes = 17}},
+    },
+    // Boundary: extents exactly at min_acceptable. Since the undersized
+    // check is `< min_acceptable` (strict), 50 is not undersized; no
+    // leveling.
+    test_case{
+      .name = "ExactlyAtMinAcceptable",
+      .extents = {{0_o, 9_o, 50},
+                  {10_o, 19_o, 50},
+                  {20_o, 29_o, 50}},
+      .min_acceptable = 50,
+      .expected_ranges = {},
+    },
+    // Boundary: extents just below min_acceptable. All undersized, fully
+    // consolidated. Verifies that `size = min_acceptable - 1` IS treated
+    // as undersized.
+    test_case{
+      .name = "JustBelowMinAcceptable",
+      .extents = {{0_o, 9_o, 49},
+                  {10_o, 19_o, 49},
+                  {20_o, 29_o, 49}},
+      .min_acceptable = 50,
+      .expected_ranges = {{.base_offset = 0_o, .last_offset = 29_o, .size_bytes = 147}},
+    },
+    // Boundary: mixed sizes at and just below min_acceptable. Only the
+    // 49-byte extents are undersized; the 50-byte ones (== min_acceptable)
+    // are healthy. Range opens at obj 1, extends to obj 2 (both 49),
+    // then closes on the healthy 50 at obj 3. K=2, commits objs 1..2.
+    test_case{
+      .name = "MixedAtMinAcceptableBoundary",
+      .extents
+      = {{0_o, 9_o, 50},
+         {10_o, 19_o, 49},
+         {20_o, 29_o, 49},
+         {30_o, 39_o, 50},
+         {40_o, 49_o, 100}},
+      .min_acceptable = 50,
+      .expected_ranges = {{.base_offset = 10_o, .last_offset = 29_o, .size_bytes = 98}},
+    }),
+  [](const auto& info) { return info.param.name; });
+// clang-format on

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -1273,6 +1273,121 @@ TEST_P(ReplicatedMetastoreTest, TestCompactObjectsBumpsEpochAndRejectsStale) {
     EXPECT_EQ(stale_res.error(), metastore::errc::invalid_request);
 }
 
+namespace {
+
+struct leveling_case {
+    std::string name;
+    std::vector<size_t> object_sizes;
+    size_t min_acceptable;
+    std::vector<levelable_range> expected_ranges;
+};
+
+} // namespace
+
+TEST_P(ReplicatedMetastoreTest, TestGetLevelingInfo) {
+    auto& app = get_ct_app(model::node_id{0});
+    auto& meta = app.get_sharded_replicated_metastore()->local();
+
+    const std::vector<leveling_case> cases = {
+      {.name = "NoUndersizedExtents",
+       .object_sizes = {100, 100, 100},
+       .min_acceptable = 50,
+       .expected_ranges = {}},
+      {.name = "SmallSandwichedBetweenLarge",
+       .object_sizes = {100, 2, 100, 15, 2, 100},
+       .min_acceptable = 50,
+       .expected_ranges
+       = {{.base_offset = o{30}, .last_offset = o{49}, .size_bytes = 17}}},
+      {.name = "IsolatedSmallSingleton",
+       .object_sizes = {100, 2, 100},
+       .min_acceptable = 50,
+       .expected_ranges = {}},
+      {.name = "SmallFollowedByManyHealthy",
+       .object_sizes = {100, 2, 100, 100, 100, 100},
+       .min_acceptable = 50,
+       .expected_ranges = {}},
+      {.name = "TwoSmallsSeparatedByHealthies",
+       .object_sizes = {100, 2, 100, 100, 2, 100},
+       .min_acceptable = 50,
+       .expected_ranges = {}},
+      {.name = "AllSmall",
+       .object_sizes = {2, 2, 2},
+       .min_acceptable = 50,
+       .expected_ranges
+       = {{.base_offset = o{0}, .last_offset = o{29}, .size_bytes = 6}}},
+      {.name = "LeadingHealthyExtentsUntouched",
+       .object_sizes = {100, 100, 2, 2, 100},
+       .min_acceptable = 50,
+       .expected_ranges
+       = {{.base_offset = o{20}, .last_offset = o{39}, .size_bytes = 4}}},
+      {.name = "SmallsAcrossHealthyAreNotMerged",
+       .object_sizes = {100, 30, 100, 30, 100},
+       .min_acceptable = 50,
+       .expected_ranges = {}},
+      {.name = "LeadingSmallSingleton",
+       .object_sizes = {2, 100, 100},
+       .min_acceptable = 50,
+       .expected_ranges = {}},
+      {.name = "ThresholdBelowAllSizes",
+       .object_sizes = {200, 200, 200},
+       .min_acceptable = 50,
+       .expected_ranges = {}},
+    };
+
+    // Stage every case's objects in a single builder, then commit them
+    // all atomically via add_objects.
+    auto obj_builder = meta.object_builder().get().value();
+    metastore::term_offset_map_t terms;
+    for (size_t case_idx = 0; case_idx < cases.size(); ++case_idx) {
+        const auto& c = cases[case_idx];
+        auto tp = make_tp(static_cast<int>(case_idx));
+        for (size_t i = 0; i < c.object_sizes.size(); ++i) {
+            auto oid = obj_builder->get_or_create_object_for(tp).get().value();
+            auto add_res = obj_builder->add(
+              oid,
+              metastore::object_metadata::ntp_metadata{
+                .tidp = tp,
+                .base_offset = o{static_cast<int64_t>(i * 10)},
+                .last_offset = o{static_cast<int64_t>(i * 10 + 9)},
+                .max_timestamp = ts{static_cast<int64_t>((i + 1) * 1000)},
+                .pos = 0,
+                .size = c.object_sizes[i],
+              });
+            ASSERT_TRUE(add_res.has_value())
+              << c.name << ": " << add_res.error();
+            auto fin_res = obj_builder->finish(
+              oid, c.object_sizes[i], c.object_sizes[i]);
+            ASSERT_TRUE(fin_res.has_value())
+              << c.name << ": " << fin_res.error();
+        }
+        terms[tp].emplace_back(
+          metastore::term_offset{
+            .term = model::term_id{0}, .first_offset = o{0}});
+    }
+    auto add_res = meta.add_objects(*obj_builder, terms).get();
+    ASSERT_TRUE(add_res.has_value());
+
+    // Query each partition's leveling info and verify the result.
+    for (size_t case_idx = 0; case_idx < cases.size(); ++case_idx) {
+        const auto& c = cases[case_idx];
+        auto tp = make_tp(static_cast<int>(case_idx));
+        chunked_vector<metastore::leveling_info_spec> specs;
+        specs.push_back(
+          {.tidp = tp, .min_acceptable_extent_bytes = c.min_acceptable});
+        auto infos_res = meta.get_leveling_infos(specs).get();
+        ASSERT_TRUE(infos_res.has_value())
+          << c.name << ": " << static_cast<int>(infos_res.error());
+        auto it = infos_res->find(tp);
+        ASSERT_NE(it, infos_res->end()) << c.name;
+        ASSERT_TRUE(it->second.has_value())
+          << c.name << ": " << static_cast<int>(it->second.error());
+        const auto& res = it->second.value();
+
+        EXPECT_THAT(res.ranges, ::testing::ElementsAreArray(c.expected_ranges))
+          << c.name;
+    }
+}
+
 INSTANTIATE_TEST_SUITE_P(
   MetastoreBackends,
   ReplicatedMetastoreTest,

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -2797,3 +2797,152 @@ TEST(SimpleMetastoreTest, CompactObjectsBumpsEpochAndRejectsStale) {
     ASSERT_FALSE(compact2.has_value());
     EXPECT_EQ(compact2.error(), metastore::errc::invalid_request);
 }
+
+namespace {
+
+// A scenario for the leveling-range algorithm. Each entry in
+// `object_sizes` becomes one extent under `tid_a` covering 10 offsets
+// (so extent `i` covers offsets [i*10, i*10+9]) and `object_sizes[i]`
+// bytes, backed by a distinct object of size `object_sizes[i]`. The
+// algorithm runs against this layout and the response's `ranges` is
+// asserted to equal `expected_ranges`.
+struct leveling_case {
+    std::string name;
+    std::vector<size_t> object_sizes;
+    size_t min_acceptable;
+    std::vector<levelable_range> expected_ranges;
+};
+
+class SimpleMetastoreLevelingAlgoTest
+  : public ::testing::TestWithParam<leveling_case> {};
+
+} // namespace
+
+TEST_P(SimpleMetastoreLevelingAlgoTest, ComputesExpectedRanges) {
+    const auto& c = GetParam();
+    simple_metastore m;
+
+    om_list_t objects;
+    chunked_vector<object_id> oids;
+    for (size_t i = 0; i < c.object_sizes.size(); ++i) {
+        const auto oid = l1::create_object_id();
+        oids.push_back(oid);
+        const auto base = kafka::offset(static_cast<int64_t>(i * 10));
+        const auto last = kafka::offset(static_cast<int64_t>(i * 10 + 9));
+        const auto ts = model::timestamp(static_cast<int64_t>((i + 1) * 100));
+        objects.push_back(om_builder(oid, 0, c.object_sizes[i])
+                            .add(tid_a, base, last, ts, 0, c.object_sizes[i])
+                            .build());
+    }
+    m.preregister_objects(oids);
+    auto add_res = m.add_objects(
+                      objects, terms_builder().add(tid_a, 0_tm, 0_o).build())
+                     .get();
+    ASSERT_TRUE(add_res.has_value()) << int(add_res.error());
+
+    const auto tp = model::topic_id_partition::from(tid_a);
+    chunked_vector<metastore::leveling_info_spec> specs;
+    specs.push_back(
+      {.tidp = tp, .min_acceptable_extent_bytes = c.min_acceptable});
+    auto infos_res = m.get_leveling_infos(specs).get();
+    ASSERT_TRUE(infos_res.has_value()) << int(infos_res.error());
+    auto it = infos_res->find(tp);
+    ASSERT_NE(it, infos_res->end());
+    ASSERT_TRUE(it->second.has_value()) << int(it->second.error());
+    const auto& res = it->second.value();
+
+    EXPECT_THAT(res.ranges, ::testing::ElementsAreArray(c.expected_ranges));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  Cases,
+  SimpleMetastoreLevelingAlgoTest,
+  ::testing::Values(
+    // No undersized extents, nothing to level.
+    leveling_case{
+      .name = "NoUndersizedExtents",
+      .object_sizes = {100, 100, 100},
+      .min_acceptable = 50,
+      .expected_ranges = {},
+    },
+    // Small extents sandwiched between healthy ones.
+    // Two undersized runs, with a singleton at obj 1 (discarded, K=1) and
+    // an adjacent pair at objs 3->4 (committed, K=2). The healthy
+    // obj 2 closes the first run; the trailing healthy obj 5 closes
+    // the second.
+    leveling_case{
+      .name = "SmallSandwichedBetweenLarge",
+      .object_sizes = {100, 2, 100, 15, 2, 100},
+      .min_acceptable = 50,
+      .expected_ranges
+      = {{.base_offset = 30_o, .last_offset = 49_o, .size_bytes = 17}},
+    },
+    // A single isolated small surrounded by healthies, a K=1 singleton
+    // run that finalize() discards on close.
+    leveling_case{
+      .name = "IsolatedSmallSingleton",
+      .object_sizes = {100, 2, 100},
+      .min_acceptable = 50,
+      .expected_ranges = {},
+    },
+    // A small followed by a long healthy run. The first healthy closes
+    // the K=1 singleton run, which is discarded; the rest are no-ops.
+    leveling_case{
+      .name = "SmallFollowedByManyHealthy",
+      .object_sizes = {100, 2, 100, 100, 100, 100},
+      .min_acceptable = 50,
+      .expected_ranges = {},
+    },
+    // Two smalls separated by two healthies. Pure size-tier never
+    // bridges across a healthy, so each small is a K=1 singleton run
+    // and neither commits.
+    leveling_case{
+      .name = "TwoSmallsSeparatedByHealthies",
+      .object_sizes = {100, 2, 100, 100, 2, 100},
+      .min_acceptable = 50,
+      .expected_ranges = {},
+    },
+    // All extents undersized. Rewrites cleanly into a single 6-byte
+    // object, 3 extents become 1, saving 2.
+    leveling_case{
+      .name = "AllSmall",
+      .object_sizes = {2, 2, 2},
+      .min_acceptable = 50,
+      .expected_ranges
+      = {{.base_offset = 0_o, .last_offset = 29_o, .size_bytes = 6}},
+    },
+    // Leading healthies are no-ops (no active range to close). Range
+    // opens at obj 2, extends to obj 3, and closes on the trailing
+    // healthy at obj 4. K=2, commits objs 2->3 (4 bytes).
+    leveling_case{
+      .name = "LeadingHealthyExtentsUntouched",
+      .object_sizes = {100, 100, 2, 2, 100},
+      .min_acceptable = 50,
+      .expected_ranges
+      = {{.base_offset = 20_o, .last_offset = 39_o, .size_bytes = 4}},
+    },
+    // Smalls separated by a healthy: pure size-tier never bridges
+    // across a healthy, so each small is its own K=1 singleton run and
+    // neither commits.
+    leveling_case{
+      .name = "SmallsAcrossHealthyAreNotMerged",
+      .object_sizes = {100, 30, 100, 30, 100},
+      .min_acceptable = 50,
+      .expected_ranges = {},
+    },
+    // A single leading small followed by healthies. The first healthy
+    // closes the K=1 singleton run, which is then discarded.
+    leveling_case{
+      .name = "LeadingSmallSingleton",
+      .object_sizes = {2, 100, 100},
+      .min_acceptable = 50,
+      .expected_ranges = {},
+    },
+    // Threshold below ALL object sizes, nothing eligible.
+    leveling_case{
+      .name = "ThresholdBelowAllSizes",
+      .object_sizes = {200, 200, 200},
+      .min_acceptable = 50,
+      .expected_ranges = {},
+    }),
+  [](const auto& info) { return info.param.name; });

--- a/src/v/cloud_topics/read_replica/snapshot_metastore.cc
+++ b/src/v/cloud_topics/read_replica/snapshot_metastore.cc
@@ -243,6 +243,12 @@ snapshot_metastore::get_compaction_infos(
     co_return std::unexpected(errc::invalid_request);
 }
 
+ss::future<std::expected<l1::metastore::leveling_info_map, l1::metastore::errc>>
+snapshot_metastore::get_leveling_infos(
+  const chunked_vector<leveling_info_spec>&) {
+    co_return std::unexpected(errc::invalid_request);
+}
+
 ss::future<
   std::expected<l1::metastore::extent_metadata_response, l1::metastore::errc>>
 snapshot_metastore::get_extent_metadata_forwards(

--- a/src/v/cloud_topics/read_replica/snapshot_metastore.h
+++ b/src/v/cloud_topics/read_replica/snapshot_metastore.h
@@ -79,6 +79,9 @@ public:
     ss::future<std::expected<compaction_info_map, errc>>
     get_compaction_infos(const chunked_vector<compaction_info_spec>&) override;
 
+    ss::future<std::expected<leveling_info_map, errc>>
+    get_leveling_infos(const chunked_vector<leveling_info_spec>&) override;
+
     ss::future<std::expected<extent_metadata_response, errc>>
     get_extent_metadata_forwards(
       const model::topic_id_partition&,


### PR DESCRIPTION
* Adds the `leveling_range_builder`, which processes extents within the `metastore` and provides an `offset_interval_set` of ranges which were deemed by callers as eligible for leveling.
* Adds the `metastore::get_leveling_infos()` API. So far, we determine eligibilty for leveling on a partition basis within L1 objects. The reason for this being, if you think about the "perfectly" leveled form of a log, it would be the log represented in L1 objects entirely `target` size with no other partitions' data in it. Therefore, the heuristic is best formed by summing up the total number of bytes per partition in an object, and comparing that to a `target` size.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
