### PR TITLE
tests/audit_log: cover admin v2 FinalizeUpgrade

### DIFF
--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -24,7 +24,10 @@ from ducktape.errors import TimeoutError
 from ducktape.mark import matrix
 from keycloak import KeycloakOpenID
 
-from rptest.clients.admin.proto.redpanda.core.admin.v2 import security_pb2
+from rptest.clients.admin.proto.redpanda.core.admin.v2 import (
+    features_pb2,
+    security_pb2,
+)
 from rptest.clients.admin.v2 import Admin as AdminV2
 from rptest.clients.default import DefaultClient
 from rptest.clients.kcl import KCL
@@ -1071,6 +1074,54 @@ class AuditLogTestAdminApi(AuditLogTestBase):
             upsert={"audit_enabled_event_types": ["heartbeat"]}
         )
         wait_for_version_sync(self.admin, self.redpanda, patch_result["config_version"])
+
+    @skip_fips_mode
+    @cluster(num_nodes=5)
+    def test_admin_v2_finalize_upgrade(self):
+        """
+        Verifies that calls to the admin v2 FeaturesService.FinalizeUpgrade
+        RPC produce an api_activity audit record when the "admin" event
+        type is enabled. The audit entry is emitted at the auth boundary,
+        so it appears regardless of whether the service handler later
+        rejects the request — here it does, with FAILED_PRECONDITION,
+        because features_auto_finalization defaults to true.
+        """
+        self.modify_audit_event_types(["admin"])
+
+        admin_v2 = AdminV2(
+            self.redpanda,
+            auth=(
+                self.redpanda.SUPERUSER_CREDENTIALS[0],
+                self.redpanda.SUPERUSER_CREDENTIALS[1],
+            ),
+        )
+
+        try:
+            admin_v2.features().finalize_upgrade(features_pb2.FinalizeUpgradeRequest())
+        except Exception as e:
+            self.logger.debug(f"FinalizeUpgrade returned (expected failure): {e}")
+
+        def is_finalize_upgrade_record(record):
+            if (
+                record["class_uid"] != 6003
+                or record["dst_endpoint"]["svc_name"] != self.admin_audit_svc_name
+            ):
+                return False
+            url = record["http_request"]["url"]["url_string"]
+            return "FeaturesService/FinalizeUpgrade" in url
+
+        records = self.find_matching_record(
+            is_finalize_upgrade_record,
+            lambda count: count >= 1,
+            "admin v2 FinalizeUpgrade audit record",
+        )
+
+        assert len(records) >= 1, (
+            f"Expected at least one record, got {len(records)}: {records}"
+        )
+        actor = records[0]["actor"]["user"]["name"]
+        expected = self.redpanda.SUPERUSER_CREDENTIALS[0]
+        assert actor == expected, f"Expected actor user {expected}, got {actor}"
 
 
 class AuditLogTestAdminAuthApi(AuditLogTestBase):


### PR DESCRIPTION
Turns out this one was easy mode.

FeaturesService.FinalizeUpgrade is already audited via the shared apply_auth<> path that admin_server registers for every admin v2 route in add_service(): audit_authn and audit_authz fire at the auth boundary before the service handler runs. Lock that in with a test that drives the RPC and asserts an api_activity record with the expected URL and actor user.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
