### PR TITLE
[v26.1.x] config: add features_auto_finalization enterprise property

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3579,6 +3579,23 @@ configuration::configuration()
       "wait for manual activation via the Admin API (false).",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       true)
+  , features_auto_finalization(
+      *this,
+      false, /* restricted value: license required to disable */
+      "features_auto_finalization",
+      "Whether the cluster active logical version is advanced automatically "
+      "once all nodes have been upgraded (true), or only in response to an "
+      "explicit request via the Admin API (false). When false, the cluster "
+      "remains able to downgrade to the previous version until finalization "
+      "is requested. Setting this to false is an Enterprise feature and "
+      "requires a valid license. Note: if upgrade was performed with this "
+      "set to false and the cluster is ready to finalize, flipping this to "
+      "true does not reliably trigger finalization. Leave this set to false "
+      "and use the Admin API to finalize; once the upgrade is complete this "
+      "can be set back to true to restore automatic finalization for future "
+      "upgrades.",
+      meta{.needs_restart = needs_restart::no, .visibility = visibility::user},
+      true)
   , enable_rack_awareness(
       *this,
       "enable_rack_awareness",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -620,6 +620,7 @@ struct configuration final : public config_store {
     property<ss::sstring> metrics_reporter_url;
 
     property<bool> features_auto_enable;
+    enterprise<property<bool>> features_auto_finalization;
 
     // enables rack aware replica assignment
     property<bool> enable_rack_awareness;


### PR DESCRIPTION
Manual backport of commit 90cfd44 from PR #30324, scoped to just the
`features_auto_finalization` cluster configuration option.

Backporting only the configuration knob (not the gating logic that
consumes it) lets operators on earlier releases set
`features_auto_finalization=false` before upgrading to v26.2, where
the manual-finalization flow ships. Without this backport, customers
would have to upgrade to v26.2 first and would lose the ability to
defer the active version advance before reaching the new minor.

Note that customers must be running this minor (or later) before the
major upgrade to v26.2 in order to make use of the manual
finalization flow.

Tracked in [CORE-16305](https://redpandadata.atlassian.net/browse/CORE-16305).
Original PR: #30324.

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Improvements

* Backport `features_auto_finalization` cluster configuration option to allow opting out of automatic upgrade finalization before upgrading to v26.2.

[CORE-16305]: https://redpandadata.atlassian.net/browse/CORE-16305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ