### PR TITLE
bazel: silence noisy warnings from external/* sources

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -113,6 +113,18 @@ build --per_file_copt=.*\\.pb\\.cc@-Wno-deprecated-declarations
 build --per_file_copt=external/protobuf.*@-Wno-deprecated-declarations
 build --host_per_file_copt=external/protobuf.*@-Wno-deprecated-declarations
 
+# Suppress -Wunused-variable in all external modules: we don't control their
+# sources, and the noise crowds out warnings from our own code. host_per_file_copt
+# covers exec-config (tool) builds like ragel.
+build --per_file_copt=external/.*@-Wno-unused-variable
+build --host_per_file_copt=external/.*@-Wno-unused-variable
+build --per_file_copt=external/.*@-Wno-unused-but-set-variable
+build --host_per_file_copt=external/.*@-Wno-unused-but-set-variable
+
+# ragel/colm: assert(false) at end of non-void function (e.g. lookup.cc:50) — UB under NDEBUG but unreachable in practice; unfixed upstream
+build --per_file_copt=external/ragel.*@-Wno-return-type
+build --host_per_file_copt=external/ragel.*@-Wno-return-type
+
 # -base configs generally aren't meant to be used directly but are
 # helpers to DRY later user-facing configs
 


### PR DESCRIPTION
We don't own external dependencies' sources, so warnings emitted while compiling them aren't actionable from this repo and we are playing whack-a-mole supressing them one by one. These categories come up frequently across third-party modules, so suppress them project-wide for anything under `external/`.

Categories suppressed for **all** external modules (`external/.*`):

- `-Wunused-variable` — e.g.
  ```
  external/ragel+/src/redfsm.cc:123:6: warning: unused variable 'stateListLen' [-Wunused-variable]
  ```
- `-Wunused-but-set-variable`

Suppressed only for ragel (`external/ragel.*`), since it's a host-config tool and the path is unreachable in practice:

- `-Wreturn-type` — `assert(false)` at the end of a non-void function in `external/ragel+/src/lookup.cc:50`, which is UB under `NDEBUG` but only fires if a `typeId` is added without updating the dispatch. Unfixed upstream (`adrian-thurston/colm-suite@main` still has the same pattern).

All entries use both `--per_file_copt` and `--host_per_file_copt`, since the noisiest case (ragel) is an exec-config tool build.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none