### PR TITLE
`cluster`: validate topic properties before creating partitions

### DIFF
--- a/src/v/cluster/BUILD
+++ b/src/v/cluster/BUILD
@@ -1961,6 +1961,8 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":types",
+        "//src/v/config",
+        "//src/v/model",
     ],
 )
 

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -26,6 +26,7 @@
 #include "cluster/partition_manager.h"
 #include "cluster/shard_table.h"
 #include "cluster/topic_table.h"
+#include "cluster/topic_validators.h"
 #include "cluster/topics_frontend.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
@@ -1441,6 +1442,22 @@ ss::future<std::error_code> controller_backend::create_partition(
 
     // no partition exists, create one
     if (likely(!partition)) {
+        // Refuse to host a replica whose topic uses features that are not
+        // enabled on this node (e.g. tiered storage when cloud_storage_enabled
+        // is false locally). The reconcile loop retries, so this heals
+        // automatically once the operator fixes the local config.
+        if (
+          auto failure = validate_topic_properties(
+            cfg.properties, node_can_host_partition_validators{});
+          failure.has_value()) {
+            vlog(
+              clusterlog.warn,
+              "Refusing to create partition {}: {}",
+              ntp,
+              failure->error_message);
+            co_return failure->ec;
+        }
+
         std::optional<cloud_storage_clients::bucket_name> read_replica_bucket;
         if (cfg.is_read_replica()) {
             read_replica_bucket = cloud_storage_clients::bucket_name(

--- a/src/v/cluster/topic_validators.h
+++ b/src/v/cluster/topic_validators.h
@@ -11,6 +11,11 @@
 
 #pragma once
 #include "cluster/types.h"
+#include "config/configuration.h"
+#include "model/metadata.h"
+
+#include <concepts>
+#include <optional>
 
 namespace cluster {
 
@@ -42,5 +47,94 @@ struct schema_id_validation_validator {
                  p.record_value_subject_name_strategy_compat);
     }
 };
+
+template<typename T>
+concept TopicPropertyValidator = requires(const topic_properties& p) {
+    { T::is_valid(p) } -> std::same_as<bool>;
+    { T::ec } -> std::convertible_to<const errc&>;
+    { T::error_message } -> std::convertible_to<const char*>;
+};
+
+template<typename... Ts>
+struct topic_property_validator_list {};
+
+template<typename... Validators>
+requires(TopicPropertyValidator<Validators> && ...)
+using make_topic_property_validators
+  = topic_property_validator_list<Validators...>;
+
+struct validation_failure {
+    errc ec;
+    const char* error_message;
+};
+
+/// Runs each validator in declaration order against `p`. Returns the first
+/// failure or std::nullopt if all validators pass.
+template<typename... Validators>
+std::optional<validation_failure> validate_topic_properties(
+  const topic_properties& p, topic_property_validator_list<Validators...>) {
+    std::optional<validation_failure> fail;
+    (
+      [&] {
+          if (!fail.has_value() && !Validators::is_valid(p)) {
+              fail = validation_failure{
+                Validators::ec, Validators::error_message};
+          }
+      }(),
+      ...);
+    return fail;
+}
+
+/// Returns true if the topic's cloud-storage-related properties (tiered
+/// storage, shadow indexing, recovery, read replica) are compatible with the
+/// local node's cloud_storage_enabled setting.
+struct cloud_storage_supported_validator {
+    static constexpr const char* error_message
+      = "Topic requires cloud storage but cloud_storage_enabled is disabled "
+        "on this node";
+    static constexpr errc ec = errc::feature_disabled;
+
+    static bool is_valid(const cluster::topic_properties& p) {
+        const bool requires_cloud_storage = p.is_archival_enabled()
+                                            || p.is_remote_fetch_enabled();
+        return !requires_cloud_storage
+               || config::shard_local_cfg().cloud_storage_enabled();
+    }
+};
+
+/// Returns true if the topic's iceberg_mode is compatible with the local
+/// node's iceberg_enabled setting.
+struct iceberg_supported_validator {
+    static constexpr const char* error_message
+      = "Topic requires iceberg but iceberg_enabled is disabled on this node";
+    static constexpr errc ec = errc::feature_disabled;
+
+    static bool is_valid(const cluster::topic_properties& p) {
+        return p.iceberg_mode == model::iceberg_mode::disabled
+               || config::shard_local_cfg().iceberg_enabled();
+    }
+};
+
+/// Returns true if the topic's storage_mode (cloud or tiered_cloud) is
+/// compatible with the local node's cloud_topics_enabled setting.
+struct cloud_topics_supported_validator {
+    static constexpr const char* error_message
+      = "Topic requires cloud topics but cloud_topics_enabled is disabled on "
+        "this node";
+    static constexpr errc ec = errc::feature_disabled;
+
+    static bool is_valid(const cluster::topic_properties& p) {
+        return !p.is_cloud_topic()
+               || config::shard_local_cfg().cloud_topics_enabled();
+    }
+};
+
+/// Validators a node runs on each partition replica it is asked to host. If
+/// any fails, the partition is not created on this node and the reconciliation
+/// loop will retry, healing automatically once the local config is fixed.
+using node_can_host_partition_validators = make_topic_property_validators<
+  cloud_storage_supported_validator,
+  iceberg_supported_validator,
+  cloud_topics_supported_validator>;
 
 } // namespace cluster

--- a/tests/rptest/tests/cloud_topics/needs_restart_test.py
+++ b/tests/rptest/tests/cloud_topics/needs_restart_test.py
@@ -1,0 +1,200 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.cluster.cluster import ClusterNode
+from ducktape.tests.test import TestContext
+from ducktape.utils.util import wait_until
+
+from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import CLOUD_TOPICS_CONFIG_STR, SISettings
+from rptest.tests.cluster_config_test import wait_for_version_status_sync
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.util import expect_timeout, wait_until_result
+
+
+class CloudTopicNeedsRestartTest(RedpandaTest):
+    """
+    cloud_topics_enabled is a needs_restart=yes property. A partial restart
+    after enabling it leaves the cluster with the property in active on some
+    nodes and only in pending on others. Cloud topic creation goes through the
+    restarted controller leader and succeeds, but partition_manager on the
+    unrestarted nodes must refuse to materialize the replica (no ctp_stm) until
+    those nodes restart. This test exercises the node-local validator added in
+    controller_backend::create_partition.
+    """
+
+    def __init__(self, test_context: TestContext):
+        super().__init__(
+            test_context, num_brokers=3, si_settings=SISettings(test_context)
+        )
+        self.admin = Admin(self.redpanda)
+        self.rpk = RpkTool(self.redpanda)
+
+    def setUp(self):
+        # Skip starting redpanda, so that the test can explicitly start
+        # it with some override_cfg_params.
+        pass
+
+    def _local_replica_stms(
+        self, node: ClusterNode, topic_name: str, partition: int
+    ) -> set[str] | None:
+        """
+        Return the set of stm names registered for `topic_name`/`partition` on
+        `node`'s local replica, or None if the replica has not materialized yet.
+        Suitable for passing to wait_until_result.
+        """
+        node_id = self.redpanda.node_id(node)
+        state = self.admin.get_partition_state(
+            "kafka", topic_name, partition, node=node
+        )
+        for r in state.get("replicas", []):
+            if r.get("raft_state", {}).get("node_id") == node_id:
+                return {s["name"] for s in r["raft_state"].get("stms", [])}
+        return None
+
+    @cluster(num_nodes=3)
+    def test_cloud_topic_with_partial_restart(self):
+        all_nodes = self.redpanda.nodes
+        self.redpanda.start(all_nodes)
+        wait_until(
+            lambda: len(self.admin.get_cluster_config_status()) == 3,
+            timeout_sec=30,
+            backoff_sec=1,
+        )
+
+        original_leader_id = self.admin.await_stable_leader(
+            "controller",
+            partition=0,
+            namespace="redpanda",
+            timeout_s=60,
+            backoff_s=2,
+        )
+        original_leader = self.redpanda.get_node(original_leader_id)
+        other_nodes = [n for n in all_nodes if n is not original_leader]
+
+        # Enable cloud_topics_enabled cluster-wide. All three nodes
+        # should observe restart=true since this is a
+        # needs_restart=yes property.
+        new_setting = (CLOUD_TOPICS_CONFIG_STR, True)
+        patch_result = self.admin.patch_cluster_config(upsert=dict([new_setting]))
+        new_version = patch_result["config_version"]
+        wait_for_version_status_sync(
+            self.admin, self.redpanda, new_version, nodes=all_nodes
+        )
+        status = self.admin.get_cluster_config_status()
+        for s in status:
+            assert s["restart"] is True, (
+                f"Expected all nodes to need restart, got {status}"
+            )
+
+        # Restart ONLY the original controller leader. The other
+        # two nodes intentionally stay with cloud_topics_enabled
+        # pending.
+        self.redpanda.restart_nodes(original_leader)
+        wait_until(
+            lambda: any(
+                s["restart"] is False
+                for s in self.admin.get_cluster_config_status()
+                if s["node_id"] == original_leader_id
+            ),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="restart flag did not clear on restarted controller leader",
+        )
+
+        # Transfer controller leadership back to the (now
+        # restarted) original leader so it serves the cloud topic
+        # create RPC and the active-config validation passes there.
+        self.admin.partition_transfer_leadership(
+            namespace="redpanda",
+            topic="controller",
+            partition=0,
+            target_id=original_leader_id,
+        )
+        new_leader_id = self.admin.await_stable_leader(
+            "controller",
+            partition=0,
+            namespace="redpanda",
+            timeout_s=60,
+            backoff_s=2,
+        )
+        assert new_leader_id == original_leader_id, (
+            f"Expected controller leadership back on node "
+            f"{original_leader_id}, got {new_leader_id}"
+        )
+
+        # Create a cloud topic with rf=3 so every node hosts a
+        # replica.
+        topic_name = "tapioca_partial"
+        self.rpk.create_topic(
+            topic=topic_name,
+            partitions=1,
+            replicas=3,
+            config={
+                TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD,
+            },
+        )
+
+        # The restarted leader has cloud_topics_enabled in active,
+        # so its replica should have ctp_stm registered.
+        leader_stms = wait_until_result(
+            lambda: self._local_replica_stms(original_leader, topic_name, 0),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"{topic_name} replica never materialized on "
+            f"restarted controller leader {original_leader_id}",
+        )
+        assert "ctp_stm" in leader_stms, (
+            f"ctp_stm missing on restarted controller leader "
+            f"{original_leader_id}; got stms {leader_stms}"
+        )
+
+        # The unrestarted nodes still have cloud_topics_enabled
+        # only in pending, so the partition_manager should refuse to manage the partition.
+        for n in other_nodes:
+            n_id = self.redpanda.node_id(n)
+            with expect_timeout():
+                wait_until_result(
+                    lambda node=n: self._local_replica_stms(node, topic_name, 0),
+                    timeout_sec=10,
+                    backoff_sec=1,
+                    err_msg=f"{topic_name} replica never materialized on "
+                    f"unrestarted node {n_id}",
+                )
+
+        # Now restart the remaining nodes so cloud_topics_enabled moves
+        # from pending to active there too. The reconciliation loop in
+        # controller_backend will retry create_partition; this time the
+        # validator passes and the partition_manager materializes the
+        # replica with ctp_stm registered.
+        self.redpanda.restart_nodes(other_nodes)
+        wait_until(
+            lambda: all(
+                s["restart"] is False for s in self.admin.get_cluster_config_status()
+            ),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="restart flag did not clear on all nodes after restart",
+        )
+
+        for n in other_nodes:
+            n_id = self.redpanda.node_id(n)
+            stm_names = wait_until_result(
+                lambda node=n: self._local_replica_stms(node, topic_name, 0),
+                timeout_sec=30,
+                backoff_sec=1,
+                err_msg=f"{topic_name} replica never materialized on "
+                f"restarted node {n_id}",
+            )
+            assert "ctp_stm" in stm_names, (
+                f"ctp_stm missing on restarted node {n_id}; got stms {stm_names}"
+            )

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -18,6 +18,7 @@ from typing import Any, NamedTuple, Protocol
 
 import requests
 import yaml
+from ducktape.cluster.cluster import ClusterNode
 from ducktape.mark import matrix, parametrize
 from ducktape.utils.util import wait_until
 
@@ -116,7 +117,12 @@ def wait_for_version_sync(admin, redpanda, version):
     )
 
 
-def wait_for_version_status_sync(admin, redpanda, version, nodes=None):
+def wait_for_version_status_sync(
+    admin: Admin,
+    redpanda: RedpandaService,
+    version: int,
+    nodes: list[ClusterNode] | None = None,
+) -> None:
     """
     Stricter than _wait_for_version_sync: this requires not only that
     the config version has propagated to all nodes, but also that the


### PR DESCRIPTION
In the case that a node locally has certain cluster configs disabled (notable examples such as `iceberg_enabled`, `cloud_topics_enabled`, etc.) and a requested partition has these features enabled, we need to refuse to create such partitions. Otherwise, doing so could lead to divergence and all sorts of undefined behavior (for example, consider a cloud topic partition hosted without any sort of `ctp_stm` attached).

Add a validation step to `controller_backend::create_partition()` for three notable properties - `iceberg_enabled`, `cloud_topics_enabled` and `cloud_storage_enabled` to ensure that any required STMs will be affixed to the partition when it is created, and we avoid any sort of divergence/undefined behavior with this replica's copy of the partition.

While the partition might be under-replicated for some time, this seems preferable to the alternative in which partitions are created with silently divergent behavior.

We will log a `WARN` level line, the reconciliation loop will retry, and eventually succeed to create the partition (typically post restart, since these notable properties require a restart).


## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Bug Fixes

* Fixes a bug in which replicas of partitions with certain features could be constructed and hosted on nodes with those features disabled.