### PR TITLE
bazel: add empty noop.bzl to trigger CI

### DIFF
--- a/bazel/noop.bzl
+++ b/bazel/noop.bzl
@@ -1,0 +1,1 @@
+# Intentionally empty - no-op file to trigger a CI build.


### PR DESCRIPTION
Add an empty `bazel/noop.bzl` so that CI runs on this branch without
actually changing any build behavior. Used as a vehicle to exercise a
debug-only build via `/dt`.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none