### PR TITLE
model/iceberg_mode: generalize config to key/value/headers sections

### DIFF
--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -333,18 +333,19 @@ metrics_reporter::build_metrics_snapshot() {
 
         snapshot.topic_count++;
         snapshot.partition_count += md.get_configuration().partition_count;
-        switch (md.get_configuration().properties.iceberg_mode.kind()) {
-        case model::iceberg_mode::variant::disabled:
-            break;
-        case model::iceberg_mode::variant::key_value:
-            ++snapshot.topics_with_iceberg_kv;
-            break;
-        case model::iceberg_mode::variant::value_schema_id_prefix:
-            ++snapshot.topics_with_iceberg_schema_id;
-            break;
-        case model::iceberg_mode::variant::value_schema_latest:
-            ++snapshot.topics_with_iceberg_schema_latest;
-            break;
+        const auto& iceberg = md.get_configuration().properties.iceberg_mode;
+        if (!iceberg.is_disabled()) {
+            switch (iceberg.value().mode) {
+            case model::iceberg_mode::schema_mode::binary:
+                ++snapshot.topics_with_iceberg_kv;
+                break;
+            case model::iceberg_mode::schema_mode::schema_id_prefix:
+                ++snapshot.topics_with_iceberg_schema_id;
+                break;
+            case model::iceberg_mode::schema_mode::schema_latest:
+                ++snapshot.topics_with_iceberg_schema_latest;
+                break;
+            }
         }
 
         if (md.get_configuration_properties().is_local_topic()) {

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -43,27 +43,31 @@ static std::unique_ptr<type_resolver> make_type_resolver(
   schema::registry& sr,
   schema_cache& cache,
   resolved_type_cache& type_cache) {
-    switch (mode.kind()) {
-    case model::iceberg_mode::variant::disabled:
-        vassert(
-          false,
-          "Cannot make record translator when iceberg is disabled, logic bug.");
-    case model::iceberg_mode::variant::key_value:
+    vassert(
+      !mode.is_disabled(),
+      "Cannot make type resolver when iceberg is disabled, logic bug.");
+    switch (mode.value().mode) {
+    case model::iceberg_mode::schema_mode::binary:
         return std::make_unique<binary_type_resolver>();
-    case model::iceberg_mode::variant::value_schema_id_prefix:
+    case model::iceberg_mode::schema_mode::schema_id_prefix:
         return std::make_unique<record_schema_resolver>(
           sr, cache, type_cache, std::move(sr_context));
-    case model::iceberg_mode::variant::value_schema_latest:
+    case model::iceberg_mode::schema_mode::schema_latest:
         auto subject = pandaproxy::schema_registry::subject(
           fmt::format("{}-value", topic_name));
-        if (auto explicit_subject = mode.subject_name()) {
-            subject = pandaproxy::schema_registry::subject(*explicit_subject);
+        if (!mode.value().subject.empty()) {
+            subject = pandaproxy::schema_registry::subject(
+              mode.value().subject);
+        }
+        std::optional<ss::sstring> proto_name;
+        if (!mode.value().protobuf_name.empty()) {
+            proto_name = mode.value().protobuf_name;
         }
         return std::make_unique<latest_subject_schema_resolver>(
           sr,
           std::move(sr_context),
           subject,
-          mode.protobuf_full_name(),
+          std::move(proto_name),
           config::shard_local_cfg().iceberg_latest_schema_cache_ttl_ms.bind(),
           cache,
           type_cache);
@@ -72,15 +76,14 @@ static std::unique_ptr<type_resolver> make_type_resolver(
 
 static std::unique_ptr<record_translator>
 make_record_translator(const model::iceberg_mode& mode) {
-    switch (mode.kind()) {
-    case model::iceberg_mode::variant::disabled:
-        vassert(
-          false,
-          "Cannot make record translator when iceberg is disabled, logic bug.");
-    case model::iceberg_mode::variant::key_value:
+    vassert(
+      !mode.is_disabled(),
+      "Cannot make record translator when iceberg is disabled, logic bug.");
+    switch (mode.value().mode) {
+    case model::iceberg_mode::schema_mode::binary:
         return std::make_unique<key_value_translator>();
-    case model::iceberg_mode::variant::value_schema_id_prefix:
-    case model::iceberg_mode::variant::value_schema_latest:
+    case model::iceberg_mode::schema_mode::schema_id_prefix:
+    case model::iceberg_mode::schema_mode::schema_latest:
         return std::make_unique<structured_data_translator>();
     }
 }

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -49,6 +49,8 @@ std::string_view to_string_view(feature f) {
         return "batch_mirror_topic_status";
     case feature::shadow_link_sr_api_sync:
         return "shadow_link_sr_api_sync";
+    case feature::iceberg_extended_mode_config:
+        return "iceberg_extended_mode_config";
     case feature::coordinated_compaction:
         return "coordinated_compaction";
     case feature::cloud_retention:

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -58,6 +58,7 @@ enum class feature : std::uint64_t {
     tiered_cloud_topics = 1ULL << 14U,
     batch_mirror_topic_status = 1ULL << 15U,
     shadow_link_sr_api_sync = 1ULL << 16U,
+    iceberg_extended_mode_config = 1ULL << 17U,
     node_isolation = 1ULL << 19U,
     group_offset_retention = 1ULL << 20U,
     membership_change_controller_cmds = 1ULL << 22U,
@@ -570,6 +571,12 @@ inline constexpr std::array feature_schema{
     release_version::v26_2_1,
     "shadow_link_sr_api_sync",
     feature::shadow_link_sr_api_sync,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    release_version::v26_2_1,
+    "iceberg_extended_mode_config",
+    feature::iceberg_extended_mode_config,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
 };

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -376,7 +376,16 @@ create_topic_properties_update(
                   update.properties.iceberg_mode,
                   cfg.value,
                   kafka::config_resource_operation::set,
-                  iceberg_config_validator{});
+                  iceberg_config_validator{
+                    ctx.feature_table().local().is_active(
+                      features::feature::iceberg_extended_mode_config)},
+                  [](const ss::sstring& s) -> model::iceberg_mode {
+                      auto r = model::parse_iceberg_mode(s);
+                      if (!r) {
+                          throw validation_error(r.error());
+                      }
+                      return std::move(*r);
+                  });
                 continue;
             }
             if (cfg.name == topic_property_leaders_preference) {

--- a/src/v/kafka/server/handlers/configs/config_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_utils.h
@@ -258,6 +258,7 @@ struct flush_bytes_validator {
 };
 
 struct iceberg_config_validator {
+    bool extended_mode_config = false;
     std::optional<ss::sstring> operator()(
       model::topic_namespace_view tns,
       const ss::sstring&,
@@ -273,6 +274,10 @@ struct iceberg_config_validator {
               "Iceberg disabled in the cluster configuration, enable it by "
               "setting: {}",
               config::shard_local_cfg().iceberg_enabled.name());
+        }
+        if (value.needs_extended_cluster_feature() && !extended_mode_config) {
+            return "Invalid iceberg mode: extended key/headers config requires "
+                   "the cluster to be fully upgraded to at least v26.2.1.";
         }
         return std::nullopt;
     }

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -117,7 +117,7 @@ using validators = make_validator_types<
   replication_factor_must_be_greater_or_equal_to_minimum,
   vcluster_id_validator,
   write_caching_configs_validator,
-  iceberg_config_validator,
+  iceberg_create_config_validator,
   iceberg_invalid_record_action_validator,
   iceberg_target_lag_ms_validator,
   schema_registry_context_create_validator,

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -377,7 +377,16 @@ create_topic_properties_update(
                   update.properties.iceberg_mode,
                   cfg.value,
                   op,
-                  iceberg_config_validator{});
+                  iceberg_config_validator{
+                    ctx.feature_table().local().is_active(
+                      features::feature::iceberg_extended_mode_config)},
+                  [](const ss::sstring& s) -> model::iceberg_mode {
+                      auto r = model::parse_iceberg_mode(s);
+                      if (!r) {
+                          throw validation_error(r.error());
+                      }
+                      return std::move(*r);
+                  });
                 continue;
             }
             if (cfg.name == topic_property_leaders_preference) {

--- a/src/v/kafka/server/handlers/topics/validators.h
+++ b/src/v/kafka/server/handlers/topics/validators.h
@@ -279,13 +279,14 @@ private:
     }
 };
 
-struct iceberg_config_validator {
+struct iceberg_create_config_validator {
     static constexpr const char* error_message
       = "Invalid property value or Iceberg configuration disabled at cluster "
         "level.";
     static constexpr error_code ec = error_code::invalid_config;
 
-    static bool is_valid(const creatable_topic& c, features::feature_table*) {
+    static bool
+    is_valid(const creatable_topic& c, features::feature_table* ft) {
         model::iceberg_mode parsed_mode = model::iceberg_mode::disabled;
 
         auto mode_it = std::find_if(
@@ -295,12 +296,11 @@ struct iceberg_config_validator {
               return cfg.name == topic_property_iceberg_mode;
           });
         if (mode_it != c.configs.end() && mode_it->value.has_value()) {
-            try {
-                parsed_mode = boost::lexical_cast<model::iceberg_mode>(
-                  mode_it->value.value());
-            } catch (...) {
+            auto parsed = model::parse_iceberg_mode(mode_it->value.value());
+            if (!parsed) {
                 return false;
             }
+            parsed_mode = *parsed;
         }
 
         auto pspec_it = std::find_if(
@@ -339,7 +339,15 @@ struct iceberg_config_validator {
         // be created with any override. If it is disabled
         // at the cluster level, it cannot be enabled with a topic
         // override.
-        return config::shard_local_cfg().iceberg_enabled();
+        if (!config::shard_local_cfg().iceberg_enabled()) {
+            return false;
+        }
+        if (
+          parsed_mode.needs_extended_cluster_feature()
+          && (ft == nullptr || !ft->is_active(features::feature::iceberg_extended_mode_config))) {
+            return false;
+        }
+        return true;
     }
 };
 

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -1394,6 +1394,105 @@ FIXTURE_TEST(test_iceberg_property, alter_config_test_fixture) {
     }
 
     {
+        // New section-based format strings should be accepted and normalize to
+        // the canonical string on describe.
+        struct new_fmt_case {
+            const char* input;
+            const char* expected_output;
+        };
+        for (const auto& [input, expected] : {
+               new_fmt_case{
+                 "value:mode=schema_id_prefix", "value_schema_id_prefix"},
+               new_fmt_case{
+                 "value:mode=schema_latest,subject=foo",
+                 "value_schema_latest:subject=foo"},
+               new_fmt_case{
+                 "key:mode=schema_id_prefix", "key:mode=schema_id_prefix"},
+               new_fmt_case{
+                 "headers:value_type=string", "headers:value_type=string"},
+             }) {
+            absl::flat_hash_map<ss::sstring, ss::sstring> properties;
+            properties.emplace("redpanda.iceberg.mode", input);
+
+            auto alter_resp = alter_configs(
+              make_alter_topic_config_resource_cv(topic2, properties));
+            BOOST_REQUIRE_EQUAL(alter_resp.data.responses.size(), 1);
+            BOOST_REQUIRE_EQUAL(
+              alter_resp.data.responses[0].error_code, kafka::error_code::none);
+
+            auto describe_resp = describe_configs(topic2);
+            assert_property_value(
+              topic2, "redpanda.iceberg.mode", expected, describe_resp);
+
+            absl::flat_hash_map<
+              ss::sstring,
+              std::pair<
+                std::optional<ss::sstring>,
+                kafka::config_resource_operation>>
+              inc_props;
+            inc_props.emplace(
+              "redpanda.iceberg.mode",
+              std::make_pair(
+                ss::sstring(input), kafka::config_resource_operation::set));
+
+            auto inc_resp = incremental_alter_configs(
+              make_incremental_alter_topic_config_resource_cv(
+                topic2, inc_props));
+            BOOST_REQUIRE_EQUAL(inc_resp.data.responses.size(), 1);
+            BOOST_REQUIRE_EQUAL(
+              inc_resp.data.responses[0].error_code, kafka::error_code::none);
+        }
+    }
+
+    {
+        // Malformed iceberg.mode values should yield invalid_config with a
+        // descriptive error message.
+        for (const auto& bad_val : {
+               "hederas:value_type=string",
+               "value:mode=banana",
+               "value:mode=schema_id_prefix,unknown_opt=x",
+               "value:mode=schema_id_prefix;value:mode=binary",
+             }) {
+            {
+                absl::flat_hash_map<ss::sstring, ss::sstring> properties;
+                properties.emplace("redpanda.iceberg.mode", bad_val);
+
+                auto resp = alter_configs(
+                  make_alter_topic_config_resource_cv(topic2, properties));
+                BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
+                BOOST_REQUIRE_EQUAL(
+                  resp.data.responses[0].error_code,
+                  kafka::error_code::invalid_config);
+                BOOST_REQUIRE(resp.data.responses[0].error_message.has_value());
+                BOOST_REQUIRE(!resp.data.responses[0].error_message->empty());
+            }
+            {
+                absl::flat_hash_map<
+                  ss::sstring,
+                  std::pair<
+                    std::optional<ss::sstring>,
+                    kafka::config_resource_operation>>
+                  properties;
+                properties.emplace(
+                  "redpanda.iceberg.mode",
+                  std::make_pair(
+                    ss::sstring(bad_val),
+                    kafka::config_resource_operation::set));
+
+                auto resp = incremental_alter_configs(
+                  make_incremental_alter_topic_config_resource_cv(
+                    topic2, properties));
+                BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
+                BOOST_REQUIRE_EQUAL(
+                  resp.data.responses[0].error_code,
+                  kafka::error_code::invalid_config);
+                BOOST_REQUIRE(resp.data.responses[0].error_message.has_value());
+                BOOST_REQUIRE(!resp.data.responses[0].error_message->empty());
+            }
+        }
+    }
+
+    {
         // Altering iceberg configuration on an internal topic should fail
         // create an internal topic
         BOOST_REQUIRE(

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -33,6 +33,7 @@
 
 #include <compare>
 #include <cstddef>
+#include <expected>
 #include <optional>
 #include <stdexcept>
 #include <unordered_map>
@@ -659,71 +660,106 @@ enum class recovery_validation_mode : std::uint16_t {
 fmt::iterator format_to(recovery_validation_mode vm, fmt::iterator out);
 std::istream& operator>>(std::istream&, recovery_validation_mode&);
 
-// Iceberg enablement options for a topic
+/// Iceberg enablement options for a topic.
+///
+/// A topic's iceberg_mode controls how Kafka records are translated into
+/// Iceberg rows. The mode is composed of three independent section configs
+/// (key, value, headers) and a disabled state. Use iceberg_mode::disabled for
+/// the disabled state and the section-based constructors for all enabled modes.
+///
+/// Backward-compatible static instances (disabled, key_value,
+/// value_schema_id_prefix) and the value_schema_latest() factory are preserved
+/// for call sites that have not yet been migrated to the new API.
 class iceberg_mode {
 public:
-    iceberg_mode() = default;
-
-    enum class variant : uint8_t {
-        // Iceberg is disabled
-        disabled = 0,
-        // Iceberg translation interprets record key and value as binary
-        // types and uses default Iceberg table schema.
-        key_value = 1,
-        // Iceberg translation interprets the record value using the schema
-        // id embedded in value. Kafka serializers embed a magic byte as the
-        // first byte of the value to indicate the presence of a schema id
-        // which is then resolved with the schema registry. The value bytes
-        // are then interepted using the schema and the resulting columns are
-        // mapped to appropriate iceberg types and corresponding table columns.
-        value_schema_id_prefix = 2,
-        // Iceberg translation always uses the latest schema found in
-        // the topic's subject in schema registry. By default we assume the
-        // TopicNamingStrategy (<topic>-value) and if protobuf the 0th message
-        // in the file descriptor. However these can both be overridden by the
-        // user.
-        value_schema_latest = 3,
+    /// How to decode a record key or value field.
+    enum class schema_mode : uint8_t {
+        binary,           ///< Store as raw bytes, no schema decoding.
+        schema_id_prefix, ///< Decode using schema ID embedded in the record.
+        schema_latest, ///< Decode using latest schema for a registry subject.
     };
+
+    /// Whether header values are stored as binary or decoded as UTF-8 strings.
+    enum class header_schema_mode : uint8_t { binary, string };
+
+    /// Schema decoding config for the key section.
+    struct key_config {
+        schema_mode mode{schema_mode::binary};
+        ss::sstring subject; ///< Empty = <topic>-key (topic name strategy).
+        ss::sstring
+          protobuf_name; ///< Empty = first proto message definition in schema.
+        bool operator==(const key_config&) const = default;
+    };
+
+    /// Schema decoding config for the value section.
+    struct value_config {
+        schema_mode mode{schema_mode::binary};
+        ss::sstring subject; ///< Empty = <topic>-value (topic name strategy).
+        ss::sstring
+          protobuf_name; ///< Empty = first proto message definition in schema.
+        bool operator==(const value_config&) const = default;
+    };
+
+    /// Config for the headers section.
+    struct headers_config {
+        header_schema_mode value_type{header_schema_mode::binary};
+        bool operator==(const headers_config&) const = default;
+    };
+
+    /// Holds the per-section configs for an enabled iceberg_mode.
+    struct enabled_impl {
+        key_config key;
+        value_config value;
+        headers_config headers;
+        bool operator==(const enabled_impl&) const = default;
+    };
+
+    iceberg_mode() = default; ///< Default-constructs to the disabled state.
+
+    /// Constructs an enabled iceberg_mode from explicit section configs.
+    explicit iceberg_mode(enabled_impl impl)
+      : _impl(std::move(impl)) {}
+
+    // --- Backward-compatible static instances and factories ---
+
     static iceberg_mode disabled;
-
     static iceberg_mode key_value;
-
     static iceberg_mode value_schema_id_prefix;
 
-    // Creates a new iceberg mode with the latest protobuf value kind and the
-    // protobuf full name.
+    /// Creates a mode equivalent to the legacy value_schema_latest config.
     static iceberg_mode value_schema_latest(
       std::string_view protobuf_full_name, std::string_view subject_name) {
-        return {value_schema_latest_t{}, protobuf_full_name, subject_name};
+        enabled_impl e{};
+        e.value.mode = schema_mode::schema_latest;
+        e.value.protobuf_name = ss::sstring(protobuf_full_name);
+        e.value.subject = ss::sstring(subject_name);
+        return iceberg_mode{std::move(e)};
     }
 
-    // Returns the kind of iceberg mode is being used.
-    variant kind() const noexcept {
-        return static_cast<variant>(_impl.index());
+    bool is_disabled() const noexcept {
+        return std::holds_alternative<disabled_impl>(_impl);
     }
 
-    // Returns the protobuf message's full name if specified.
-    //
-    // Throws is variant() != variant::value_schema_latest
-    std::optional<ss::sstring> protobuf_full_name() const {
-        const auto& name
-          = std::get<value_schema_latest_impl>(_impl).message_full_name;
-        if (name.empty()) {
-            return std::nullopt;
+    /// Returns true if this mode would be encoded using the new wire
+    /// discriminant (4), which requires all cluster nodes to be upgraded.
+    bool needs_extended_cluster_feature() const noexcept {
+        if (is_disabled()) {
+            return false;
         }
-        return name;
+        const auto& e = std::get<enabled_impl>(_impl);
+        return e.key.mode != schema_mode::binary
+               || e.headers.value_type != header_schema_mode::binary;
     }
 
-    // Returns the subject name if specified.
-    //
-    // Throws is variant() != variant::value_schema_latest
-    std::optional<ss::sstring> subject_name() const {
-        const auto& subject
-          = std::get<value_schema_latest_impl>(_impl).subject_name;
-        if (subject.empty()) {
-            return std::nullopt;
-        }
-        return subject;
+    /// \pre !is_disabled()
+    const key_config& key() const { return std::get<enabled_impl>(_impl).key; }
+    /// \pre !is_disabled()
+    const value_config& value() const {
+        return std::get<enabled_impl>(_impl).value;
+    }
+    /// \pre !is_disabled()
+    const headers_config& headers() const {
+        return std::get<enabled_impl>(_impl).headers;
     }
 
     bool operator==(const iceberg_mode&) const = default;
@@ -732,49 +768,20 @@ public:
     friend void write_nested(iobuf& out, const iceberg_mode& m);
 
     friend void read_nested(
-      iobuf_parser& in, iceberg_mode& m, const std::size_t bytes_left_limit);
+      iobuf_parser& in, iceberg_mode& m, std::size_t bytes_left_limit);
 
 private:
-    template<variant v>
-    static iceberg_mode make() noexcept {
-        iceberg_mode m;
-        m._impl = decltype(m._impl){
-          std::in_place_index<static_cast<size_t>(v)>};
-        return m;
-    }
-
-    struct value_schema_latest_t {};
-    iceberg_mode(
-      value_schema_latest_t,
-      std::string_view protobuf_full_name,
-      std::string_view subject_name)
-      : _impl(
-          std::in_place_type<value_schema_latest_impl>,
-          ss::sstring(protobuf_full_name),
-          ss::sstring(subject_name)) {}
-
     struct disabled_impl {
         bool operator==(const disabled_impl&) const = default;
     };
-    struct key_value_impl {
-        bool operator==(const key_value_impl&) const = default;
-    };
-    struct value_schema_id_prefix_impl {
-        bool operator==(const value_schema_id_prefix_impl&) const = default;
-    };
-    struct value_schema_latest_impl {
-        ss::sstring message_full_name;
-        ss::sstring subject_name;
-        bool operator==(const value_schema_latest_impl&) const = default;
-    };
 
-    std::variant<
-      disabled_impl,
-      key_value_impl,
-      value_schema_id_prefix_impl,
-      value_schema_latest_impl>
-      _impl;
+    std::variant<disabled_impl, enabled_impl> _impl;
 };
+
+/// Parse an iceberg_mode from its string representation.
+/// Returns the parsed mode on success, or a human-readable error string on
+/// failure. Prefer this over operator>> when error messages matter.
+std::expected<iceberg_mode, ss::sstring> parse_iceberg_mode(std::string_view s);
 
 std::istream& operator>>(std::istream&, iceberg_mode&);
 

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -20,6 +20,7 @@
 #include "model/record_batch_types.h"
 #include "model/timestamp.h"
 #include "serde/rw/enum.h"
+#include "serde/rw/envelope.h"
 #include "serde/rw/rw.h"
 #include "serde/rw/sstring.h"
 #include "serde/serde_exception.h"
@@ -29,6 +30,7 @@
 
 #include <fmt/ostream.h>
 
+#include <expected>
 #include <iostream>
 #include <optional>
 #include <type_traits>
@@ -616,140 +618,423 @@ std::istream& operator>>(std::istream& is, recovery_validation_mode& vm) {
     return is;
 }
 
-iceberg_mode iceberg_mode::disabled
-  = iceberg_mode::make<iceberg_mode::variant::disabled>();
-iceberg_mode iceberg_mode::key_value
-  = iceberg_mode::make<iceberg_mode::variant::key_value>();
-iceberg_mode iceberg_mode::value_schema_id_prefix
-  = iceberg_mode::make<iceberg_mode::variant::value_schema_id_prefix>();
+iceberg_mode iceberg_mode::disabled = iceberg_mode{};
+iceberg_mode iceberg_mode::key_value = iceberg_mode{enabled_impl{}};
+iceberg_mode iceberg_mode::value_schema_id_prefix = []() {
+    enabled_impl e{};
+    e.value.mode = iceberg_mode::schema_mode::schema_id_prefix;
+    return iceberg_mode{std::move(e)};
+}();
+
+// Wire format discriminants. Values 0-3 are the legacy per-variant
+// discriminants preserved for backward compatibility. Value 4 is the new
+// generic encoding for configs that cannot be expressed in the old format
+// (i.e. key.mode != binary or headers.value_type != binary).
+namespace {
+// The discriminant is serialized as int32_t (serde_enum_serialized_t) to
+// maintain backward compatibility with the original iceberg_mode::variant enum
+// encoding, which used serde::write on an enum class and thus wrote int32_t.
+constexpr int32_t wire_disabled = 0;
+constexpr int32_t wire_key_value = 1;
+constexpr int32_t wire_value_schema_id_prefix = 2;
+constexpr int32_t wire_value_schema_latest = 3;
+constexpr int32_t wire_canonical_string = 4;
+
+// Payload for wire_canonical_string: the canonicalized config string wrapped
+// in a versioned envelope for forward/backward compatibility.
+struct iceberg_mode_string
+  : serde::envelope<
+      iceberg_mode_string,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    ss::sstring config;
+    auto serde_fields() { return std::tie(config); }
+};
+
+constexpr std::string_view to_sv(iceberg_mode::schema_mode m) {
+    switch (m) {
+    case iceberg_mode::schema_mode::binary:
+        return "binary";
+    case iceberg_mode::schema_mode::schema_id_prefix:
+        return "schema_id_prefix";
+    case iceberg_mode::schema_mode::schema_latest:
+        return "schema_latest";
+    }
+    __builtin_unreachable();
+}
+
+constexpr std::string_view to_sv(iceberg_mode::header_schema_mode t) {
+    switch (t) {
+    case iceberg_mode::header_schema_mode::binary:
+        return "binary";
+    case iceberg_mode::header_schema_mode::string:
+        return "string";
+    }
+    __builtin_unreachable();
+}
+
+// Parse "opt1=val1,opt2=val2" into a map, enforcing no duplicate keys and no
+// empty keys or values. An empty string returns an empty map (all defaults).
+std::optional<absl::flat_hash_map<std::string, std::string>>
+parse_section_opts(std::string_view str) {
+    absl::flat_hash_map<std::string, std::string> result;
+    if (str.empty()) {
+        return result;
+    }
+    for (std::string_view pair : absl::StrSplit(str, ",")) {
+        auto [it, inserted] = result.insert(
+          absl::StrSplit(pair, absl::MaxSplits("=", 1)));
+        if (!inserted) {
+            return std::nullopt; // duplicate key
+        }
+        if (it->first.empty() || it->second.empty()) {
+            return std::nullopt; // empty key or value
+        }
+    }
+    return result;
+}
+
+// Parse the section-based iceberg_mode grammar:
+//   <section> (";" <section>)*
+//   <section> ::= ("key"|"value"|"headers") ":" <opts>
+//
+// Unknown sections and unknown option keys are parse errors. Duplicate
+// sections or duplicate option keys are also parse errors.
+std::expected<iceberg_mode, ss::sstring>
+parse_extended_iceberg_mode(std::string_view str) {
+    using opts_map = absl::flat_hash_map<std::string, std::string>;
+
+    // Collect each section's raw options, checking for duplicates and unknown
+    // section names before doing any semantic parsing.
+    std::optional<opts_map> key_opts, value_opts, headers_opts;
+
+    for (std::string_view sec_str : absl::StrSplit(str, ";")) {
+        if (sec_str.empty()) {
+            return std::unexpected(
+              ss::sstring("empty section in iceberg_mode config"));
+        }
+        auto colon = sec_str.find(':');
+        if (colon == std::string_view::npos) {
+            return std::unexpected(
+              fmt::format("missing ':' in section '{}'", sec_str));
+        }
+        auto sec_name = sec_str.substr(0, colon);
+        auto opts_str = sec_str.substr(colon + 1);
+
+        auto opts = parse_section_opts(opts_str);
+        if (!opts) {
+            return std::unexpected(
+              fmt::format("malformed options in section '{}'", sec_name));
+        }
+
+        if (sec_name == "key") {
+            if (key_opts) {
+                return std::unexpected(ss::sstring("duplicate section 'key'"));
+            }
+            key_opts = std::move(*opts);
+        } else if (sec_name == "value") {
+            if (value_opts) {
+                return std::unexpected(
+                  ss::sstring("duplicate section 'value'"));
+            }
+            value_opts = std::move(*opts);
+        } else if (sec_name == "headers") {
+            if (headers_opts) {
+                return std::unexpected(
+                  ss::sstring("duplicate section 'headers'"));
+            }
+            headers_opts = std::move(*opts);
+        } else {
+            return std::unexpected(
+              fmt::format("unknown section '{}'", sec_name));
+        }
+    }
+
+    iceberg_mode::enabled_impl result{};
+
+    auto parse_schema_opts =
+      [](const opts_map& opts, auto& cfg, std::string_view sec_name)
+      -> std::expected<void, ss::sstring> {
+        for (const auto& [k, v] : opts) {
+            if (k == "mode") {
+                using sm = iceberg_mode::schema_mode;
+                auto m = string_switch<std::optional<sm>>(v)
+                           .match("binary", sm::binary)
+                           .match("schema_id_prefix", sm::schema_id_prefix)
+                           .match("schema_latest", sm::schema_latest)
+                           .default_match(std::nullopt);
+                if (!m) {
+                    return std::unexpected(
+                      fmt::format(
+                        "unknown mode '{}' in section '{}'", v, sec_name));
+                }
+                cfg.mode = *m;
+            } else if (k == "subject") {
+                cfg.subject = ss::sstring(v);
+            } else if (k == "protobuf_name") {
+                cfg.protobuf_name = ss::sstring(v);
+            } else {
+                return std::unexpected(
+                  fmt::format(
+                    "unknown option '{}' in section '{}'", k, sec_name));
+            }
+        }
+        if (
+          cfg.mode != iceberg_mode::schema_mode::schema_latest
+          && (!cfg.subject.empty() || !cfg.protobuf_name.empty())) {
+            return std::unexpected(
+              fmt::format(
+                "subject and protobuf_name require mode=schema_latest in "
+                "section '{}'",
+                sec_name));
+        }
+        return {};
+    };
+
+    if (key_opts) {
+        if (auto r = parse_schema_opts(*key_opts, result.key, "key"); !r) {
+            return std::unexpected(std::move(r.error()));
+        }
+    }
+    if (value_opts) {
+        if (
+          auto r = parse_schema_opts(*value_opts, result.value, "value"); !r) {
+            return std::unexpected(std::move(r.error()));
+        }
+    }
+    if (headers_opts) {
+        for (const auto& [k, v] : *headers_opts) {
+            if (k == "value_type") {
+                using hsm = iceberg_mode::header_schema_mode;
+                auto t = string_switch<std::optional<hsm>>(v)
+                           .match("binary", hsm::binary)
+                           .match("string", hsm::string)
+                           .default_match(std::nullopt);
+                if (!t) {
+                    return std::unexpected(
+                      fmt::format(
+                        "unknown value_type '{}' in section 'headers'", v));
+                }
+                result.headers.value_type = *t;
+            } else {
+                return std::unexpected(
+                  fmt::format("unknown option '{}' in section 'headers'", k));
+            }
+        }
+    }
+
+    return iceberg_mode{std::move(result)};
+}
+} // namespace
 
 void write_nested(iobuf& out, const iceberg_mode& m) {
     using serde::write;
-    write(out, m.kind());
-    if (m.kind() == iceberg_mode::variant::value_schema_latest) {
-        write(out, m.protobuf_full_name().value_or(""));
-        write(out, m.subject_name().value_or(""));
+    if (m.is_disabled()) {
+        write(out, wire_disabled);
+        return;
     }
+    const auto& e = std::get<iceberg_mode::enabled_impl>(m._impl);
+    // Configs where key and headers are at their defaults can be expressed
+    // with the old wire discriminants so that old nodes can read them.
+    if (
+      e.key == iceberg_mode::key_config{}
+      && e.headers == iceberg_mode::headers_config{}) {
+        switch (e.value.mode) {
+        case iceberg_mode::schema_mode::binary:
+            write(out, wire_key_value);
+            return;
+        case iceberg_mode::schema_mode::schema_id_prefix:
+            write(out, wire_value_schema_id_prefix);
+            return;
+        case iceberg_mode::schema_mode::schema_latest:
+            write(out, wire_value_schema_latest);
+            write(out, e.value.protobuf_name);
+            write(out, e.value.subject);
+            return;
+        }
+    }
+    // Discriminant 4: the encoded form is the canonicalized config string.
+    write(out, wire_canonical_string);
+    write(out, iceberg_mode_string{.config = fmt::format("{}", m)});
 }
 
 void read_nested(
   iobuf_parser& in, iceberg_mode& m, const std::size_t bytes_left_limit) {
     using serde::read_nested;
-    iceberg_mode::variant v = iceberg_mode::variant::disabled;
-    read_nested(in, v, bytes_left_limit);
-    switch (v) {
-    case iceberg_mode::variant::disabled:
+    int32_t disc = 0;
+    read_nested(in, disc, bytes_left_limit);
+    switch (disc) {
+    case wire_disabled:
         m = iceberg_mode::disabled;
         return;
-    case iceberg_mode::variant::key_value:
+    case wire_key_value:
         m = iceberg_mode::key_value;
         return;
-    case iceberg_mode::variant::value_schema_id_prefix:
+    case wire_value_schema_id_prefix:
         m = iceberg_mode::value_schema_id_prefix;
         return;
-    case iceberg_mode::variant::value_schema_latest:
-        ss::sstring msg_name;
-        read_nested(in, msg_name, bytes_left_limit);
+    case wire_value_schema_latest: {
+        ss::sstring proto_name;
         ss::sstring subject;
+        read_nested(in, proto_name, bytes_left_limit);
         read_nested(in, subject, bytes_left_limit);
-        m = iceberg_mode::value_schema_latest(msg_name, subject);
+        m = iceberg_mode::value_schema_latest(proto_name, subject);
         return;
     }
+    case wire_canonical_string: {
+        iceberg_mode_string payload;
+        read_nested(in, payload, bytes_left_limit);
+        auto result = parse_iceberg_mode(payload.config);
+        if (!result) {
+            throw serde::serde_exception(
+              fmt::format(
+                "invalid iceberg_mode config in wire format: {}",
+                result.error()));
+        }
+        m = std::move(*result);
+        return;
+    }
+    }
     throw serde::serde_exception(
-      fmt::format("unknown iceberg_mode variant: {}", std::to_underlying(v)));
+      fmt::format("unknown iceberg_mode discriminant: {}", disc));
 }
 
 fmt::iterator iceberg_mode::format_to(fmt::iterator it) const {
-    switch (kind()) {
-    case variant::disabled:
+    if (is_disabled()) {
         return fmt::format_to(it, "disabled");
-    case variant::key_value:
-        return fmt::format_to(it, "key_value");
-    case variant::value_schema_id_prefix:
-        return fmt::format_to(it, "value_schema_id_prefix");
-    case variant::value_schema_latest:
-        it = fmt::format_to(it, "value_schema_latest");
-        bool delimiter = false;
-        auto emit_delimiter = [&delimiter, &it]() {
-            it = fmt::format_to(it, "{}", delimiter ? "," : ":");
-            delimiter = true;
-        };
-        if (auto pname = protobuf_full_name()) {
-            emit_delimiter();
-            it = fmt::format_to(it, "protobuf_name={}", pname.value());
-        }
-        if (auto subj = subject_name()) {
-            emit_delimiter();
-            it = fmt::format_to(it, "subject={}", subj.value());
-        }
-        return it;
     }
+    const auto& e = std::get<enabled_impl>(_impl);
+
+    // If key and headers are at their defaults the config is expressible as a
+    // legacy string; prefer that for maximal compatibility.
+    if (e.key == key_config{} && e.headers == headers_config{}) {
+        switch (e.value.mode) {
+        case schema_mode::binary:
+            return fmt::format_to(it, "key_value");
+        case schema_mode::schema_id_prefix:
+            return fmt::format_to(it, "value_schema_id_prefix");
+        case schema_mode::schema_latest:
+            it = fmt::format_to(it, "value_schema_latest");
+            bool delim = false;
+            auto emit = [&]() {
+                it = fmt::format_to(it, "{}", delim ? "," : ":");
+                delim = true;
+            };
+            if (!e.value.protobuf_name.empty()) {
+                emit();
+                it = fmt::format_to(
+                  it, "protobuf_name={}", e.value.protobuf_name);
+            }
+            if (!e.value.subject.empty()) {
+                emit();
+                it = fmt::format_to(it, "subject={}", e.value.subject);
+            }
+            return it;
+        }
+    }
+
+    // Section-based format. Only emit sections that differ from defaults.
+    bool any = false;
+    auto sep = [&]() {
+        if (any) {
+            it = fmt::format_to(it, ";");
+        }
+        any = true;
+    };
+
+    auto emit_schema_section = [&](std::string_view name, const auto& cfg) {
+        if (cfg.mode == schema_mode::binary) {
+            return; // all defaults, omit
+        }
+        sep();
+        it = fmt::format_to(it, "{}:mode={}", name, to_sv(cfg.mode));
+        if (!cfg.subject.empty()) {
+            it = fmt::format_to(it, ",subject={}", cfg.subject);
+        }
+        if (!cfg.protobuf_name.empty()) {
+            it = fmt::format_to(it, ",protobuf_name={}", cfg.protobuf_name);
+        }
+    };
+
+    emit_schema_section("key", e.key);
+    emit_schema_section("value", e.value);
+
+    if (e.headers.value_type != header_schema_mode::binary) {
+        sep();
+        it = fmt::format_to(
+          it, "headers:value_type={}", to_sv(e.headers.value_type));
+    }
+
     return it;
 }
 
 namespace {
-// Parse configuration options for iceberg_mode's value_schema_latest, which
-// is a grammar like: `:(<name>=<value>)+`
-std::optional<absl::flat_hash_map<std::string, std::string>>
-parse_config_options(std::string_view str) {
-    if (str.empty()) {
-        return absl::flat_hash_map<std::string, std::string>{};
+// Parse the legacy value_schema_latest options string (everything after the
+// "value_schema_latest" prefix), which has the grammar `:(<name>=<value>)*`.
+std::expected<iceberg_mode, ss::sstring>
+parse_legacy_schema_latest(std::string_view suffix) {
+    if (suffix.empty()) {
+        return iceberg_mode::value_schema_latest("", "");
     }
-    if (!absl::ConsumePrefix(&str, ":")) {
-        return std::nullopt;
+    if (!absl::ConsumePrefix(&suffix, ":")) {
+        return std::unexpected(
+          ss::sstring(
+            "expected ':' or end of string after 'value_schema_latest'"));
     }
-    if (str.empty()) {
-        return std::nullopt;
+    if (suffix.empty()) {
+        return std::unexpected(
+          ss::sstring("expected options after ':' in value_schema_latest"));
     }
-    absl::flat_hash_map<std::string, std::string> result;
-    for (std::string_view pair : absl::StrSplit(str, ",")) {
-        auto [it, inserted] = result.insert(
+    absl::flat_hash_map<std::string, std::string> opts;
+    for (std::string_view pair : absl::StrSplit(suffix, ",")) {
+        auto [it, inserted] = opts.insert(
           absl::StrSplit(pair, absl::MaxSplits("=", 1)));
-        // Don't allow duplicates
-        if (!inserted) {
-            return std::nullopt;
-        }
-        // Don't allow empty keys or values
-        if (it->first.empty() || it->second.empty()) {
-            return std::nullopt;
+        if (!inserted || it->first.empty() || it->second.empty()) {
+            return std::unexpected(
+              ss::sstring("malformed options in value_schema_latest"));
         }
     }
-    return result;
+    std::string_view proto_name;
+    std::string_view subject;
+    for (const auto& [k, v] : opts) {
+        if (k == "protobuf_name") {
+            proto_name = v;
+        } else if (k == "subject") {
+            subject = v;
+        } else {
+            return std::unexpected(
+              fmt::format("unknown option '{}' in value_schema_latest", k));
+        }
+    }
+    return iceberg_mode::value_schema_latest(proto_name, subject);
 }
 } // namespace
+
+std::expected<iceberg_mode, ss::sstring>
+parse_iceberg_mode(std::string_view s) {
+    if (s == "disabled") {
+        return iceberg_mode::disabled;
+    } else if (s == "key_value") {
+        return iceberg_mode::key_value;
+    } else if (s == "value_schema_id_prefix") {
+        return iceberg_mode::value_schema_id_prefix;
+    } else if (s.starts_with("value_schema_latest")) {
+        return parse_legacy_schema_latest(
+          s.substr(std::strlen("value_schema_latest")));
+    } else {
+        return parse_extended_iceberg_mode(s);
+    }
+}
 
 std::istream& operator>>(std::istream& is, iceberg_mode& mode) {
     ss::sstring s;
     is >> s;
-    if (s == "disabled") {
-        mode = iceberg_mode::disabled;
-    } else if (s == "key_value") {
-        mode = iceberg_mode::key_value;
-    } else if (s == "value_schema_id_prefix") {
-        mode = iceberg_mode::value_schema_id_prefix;
-    } else if (s.starts_with("value_schema_latest")) {
-        s = s.substr(std::strlen("value_schema_latest"));
-        auto options = parse_config_options(s);
-        if (!options.has_value()) {
-            is.setstate(std::ios::failbit);
-            return is;
-        }
-        std::string_view protobuf_name;
-        std::string_view subject;
-        for (const auto& [key, value] : options.value()) {
-            if (key == "protobuf_name") {
-                protobuf_name = value;
-            } else if (key == "subject") {
-                subject = value;
-            } else {
-                is.setstate(std::ios::failbit);
-                return is;
-            }
-        }
-        mode = iceberg_mode::value_schema_latest(protobuf_name, subject);
-    } else {
+    auto result = parse_iceberg_mode(s);
+    if (!result) {
         is.setstate(std::ios::failbit);
+        return is;
     }
+    mode = std::move(*result);
     return is;
 }
 

--- a/src/v/model/tests/BUILD
+++ b/src/v/model/tests/BUILD
@@ -243,6 +243,22 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "iceberg_mode_test",
+    timeout = "short",
+    srcs = [
+        "iceberg_mode_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:iobuf_parser",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "record_batch_reader_gtest",
     timeout = "short",
     srcs = ["record_batch_reader_gtest.cc"],

--- a/src/v/model/tests/iceberg_mode_test.cc
+++ b/src/v/model/tests/iceberg_mode_test.cc
@@ -1,0 +1,494 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "bytes/iobuf.h"
+#include "bytes/iobuf_parser.h"
+#include "gmock/gmock.h"
+#include "model/metadata.h"
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+
+namespace {
+
+// Parse an iceberg_mode from a string using operator>>.
+// Returns std::nullopt if parsing fails (failbit set).
+std::optional<model::iceberg_mode> parse(std::string_view s) {
+    model::iceberg_mode m;
+    std::istringstream ss{std::string(s)};
+    ss >> m;
+    if (ss.fail()) {
+        return std::nullopt;
+    }
+    return m;
+}
+
+// Serialize an iceberg_mode to its string representation.
+std::string to_string(const model::iceberg_mode& m) {
+    return fmt::format("{}", m);
+}
+
+// Wire round-trip: write_nested → read_nested.
+model::iceberg_mode wire_roundtrip(const model::iceberg_mode& m) {
+    iobuf buf;
+    write_nested(buf, m);
+    iobuf_parser parser{buf.share(0, buf.size_bytes())};
+    model::iceberg_mode result;
+    read_nested(parser, result, 0UL);
+    return result;
+}
+
+using sm = model::iceberg_mode::schema_mode;
+using hsm = model::iceberg_mode::header_schema_mode;
+using enabled = model::iceberg_mode::enabled_impl;
+
+} // namespace
+
+// --- disabled ---
+
+TEST(IcebergModeParse, Disabled) {
+    auto m = parse("disabled");
+    ASSERT_TRUE(m.has_value());
+    EXPECT_TRUE(m->is_disabled());
+    EXPECT_EQ(*m, model::iceberg_mode::disabled);
+}
+
+// --- legacy strings ---
+
+TEST(IcebergModeParse, LegacyKeyValue) {
+    auto m = parse("key_value");
+    ASSERT_TRUE(m.has_value());
+    ASSERT_FALSE(m->is_disabled());
+    EXPECT_EQ(m->key().mode, sm::binary);
+    EXPECT_EQ(m->value().mode, sm::binary);
+    EXPECT_EQ(m->headers().value_type, hsm::binary);
+}
+
+TEST(IcebergModeParse, LegacyValueSchemaIdPrefix) {
+    auto m = parse("value_schema_id_prefix");
+    ASSERT_TRUE(m.has_value());
+    ASSERT_FALSE(m->is_disabled());
+    EXPECT_EQ(m->key().mode, sm::binary);
+    EXPECT_EQ(m->value().mode, sm::schema_id_prefix);
+}
+
+TEST(IcebergModeParse, LegacyValueSchemaLatestBare) {
+    auto m = parse("value_schema_latest");
+    ASSERT_TRUE(m.has_value());
+    ASSERT_FALSE(m->is_disabled());
+    EXPECT_EQ(m->value().mode, sm::schema_latest);
+    EXPECT_TRUE(m->value().subject.empty());
+    EXPECT_TRUE(m->value().protobuf_name.empty());
+}
+
+TEST(IcebergModeParse, LegacyValueSchemaLatestWithSubject) {
+    auto m = parse("value_schema_latest:subject=my-topic-value");
+    ASSERT_TRUE(m.has_value());
+    EXPECT_EQ(m->value().mode, sm::schema_latest);
+    EXPECT_EQ(m->value().subject, "my-topic-value");
+    EXPECT_TRUE(m->value().protobuf_name.empty());
+}
+
+TEST(IcebergModeParse, LegacyValueSchemaLatestWithProtobufName) {
+    auto m = parse("value_schema_latest:protobuf_name=com.example.Msg");
+    ASSERT_TRUE(m.has_value());
+    EXPECT_EQ(m->value().mode, sm::schema_latest);
+    EXPECT_EQ(m->value().protobuf_name, "com.example.Msg");
+    EXPECT_TRUE(m->value().subject.empty());
+}
+
+TEST(IcebergModeParse, LegacyValueSchemaLatestBoth) {
+    auto m = parse(
+      "value_schema_latest:subject=my-topic-value,protobuf_name=com.example."
+      "Msg");
+    ASSERT_TRUE(m.has_value());
+    EXPECT_EQ(m->value().mode, sm::schema_latest);
+    EXPECT_EQ(m->value().subject, "my-topic-value");
+    EXPECT_EQ(m->value().protobuf_name, "com.example.Msg");
+}
+
+// --- new section-based format ---
+
+TEST(IcebergModeParse, NewValueSchemaIdPrefix) {
+    auto m = parse("value:mode=schema_id_prefix");
+    ASSERT_TRUE(m.has_value());
+    EXPECT_EQ(m->key().mode, sm::binary);
+    EXPECT_EQ(m->value().mode, sm::schema_id_prefix);
+    // Equivalent to the legacy string
+    EXPECT_EQ(*m, model::iceberg_mode::value_schema_id_prefix);
+}
+
+TEST(IcebergModeParse, NewValueSchemaLatestWithSubject) {
+    auto m = parse("value:mode=schema_latest,subject=my-topic-value");
+    ASSERT_TRUE(m.has_value());
+    EXPECT_EQ(m->value().mode, sm::schema_latest);
+    EXPECT_EQ(m->value().subject, "my-topic-value");
+}
+
+TEST(IcebergModeParse, NewKeyAndValue) {
+    auto m = parse(
+      "key:mode=schema_id_prefix;value:mode=schema_latest,subject=my-topic-"
+      "value");
+    ASSERT_TRUE(m.has_value());
+    EXPECT_EQ(m->key().mode, sm::schema_id_prefix);
+    EXPECT_EQ(m->value().mode, sm::schema_latest);
+    EXPECT_EQ(m->value().subject, "my-topic-value");
+}
+
+TEST(IcebergModeParse, NewHeadersString) {
+    auto m = parse("headers:value_type=string");
+    ASSERT_TRUE(m.has_value());
+    EXPECT_EQ(m->key().mode, sm::binary);
+    EXPECT_EQ(m->value().mode, sm::binary);
+    EXPECT_EQ(m->headers().value_type, hsm::string);
+}
+
+TEST(IcebergModeParse, NewFullCombination) {
+    auto m = parse(
+      "key:mode=schema_id_prefix;value:mode=schema_latest,subject=my-topic-"
+      "value;headers:value_type=string");
+    ASSERT_TRUE(m.has_value());
+    EXPECT_EQ(m->key().mode, sm::schema_id_prefix);
+    EXPECT_EQ(m->value().mode, sm::schema_latest);
+    EXPECT_EQ(m->value().subject, "my-topic-value");
+    EXPECT_EQ(m->headers().value_type, hsm::string);
+}
+
+TEST(IcebergModeParse, NewSectionOrderIrrelevant) {
+    // headers before key before value
+    auto m = parse(
+      "headers:value_type=string;key:mode=schema_id_prefix;value:mode=schema_"
+      "id_prefix");
+    ASSERT_TRUE(m.has_value());
+    EXPECT_EQ(m->key().mode, sm::schema_id_prefix);
+    EXPECT_EQ(m->value().mode, sm::schema_id_prefix);
+    EXPECT_EQ(m->headers().value_type, hsm::string);
+}
+
+// --- backward compat: new-format strings equivalent to old-format ---
+
+TEST(IcebergModeParse, NewFormatEquivalentToOld) {
+    // New format "value:mode=schema_id_prefix" must equal old-format
+    // "value_schema_id_prefix" even though they were written differently.
+    auto old_m = parse("value_schema_id_prefix");
+    auto new_m = parse("value:mode=schema_id_prefix");
+    ASSERT_TRUE(old_m.has_value());
+    ASSERT_TRUE(new_m.has_value());
+    EXPECT_EQ(*old_m, *new_m);
+}
+
+// --- parse errors ---
+
+TEST(IcebergModeParseError, UnknownTopLevelGarbage) {
+    EXPECT_FALSE(parse("totally_invalid").has_value());
+}
+
+TEST(IcebergModeParseError, AllUnknownSections) {
+    // All-unknown sections must not silently produce a default enabled config.
+    EXPECT_FALSE(parse("hederas:value_type=string").has_value());
+    EXPECT_FALSE(parse("future_section:opt=val").has_value());
+}
+
+TEST(IcebergModeParseError, UnknownSection) {
+    EXPECT_FALSE(parse("value:mode=schema_id_prefix;future_section:new_opt=foo")
+                   .has_value());
+}
+
+TEST(IcebergModeParseError, UnknownOptionKey) {
+    EXPECT_FALSE(
+      parse("value:mode=schema_id_prefix,future_opt=bar").has_value());
+    EXPECT_FALSE(parse("headers:value_type=string,future_opt=bar").has_value());
+}
+
+TEST(IcebergModeParseError, DuplicateSection) {
+    EXPECT_FALSE(
+      parse("value:mode=binary;value:mode=schema_id_prefix").has_value());
+}
+
+TEST(IcebergModeParseError, DuplicateOption) {
+    EXPECT_FALSE(parse("value:mode=binary,mode=schema_id_prefix").has_value());
+}
+
+TEST(IcebergModeParseError, BadModeValue) {
+    EXPECT_FALSE(parse("value:mode=banana").has_value());
+}
+
+TEST(IcebergModeParseError, BadHeaderValueType) {
+    EXPECT_FALSE(parse("headers:value_type=blob").has_value());
+}
+
+TEST(IcebergModeParseError, EmptyOptValue) {
+    EXPECT_FALSE(parse("value:mode=").has_value());
+}
+
+TEST(IcebergModeParseError, LegacyUnknownOpt) {
+    // In the legacy format, unknown option keys are a hard error.
+    EXPECT_FALSE(parse("value_schema_latest:unknown_opt=foo").has_value());
+}
+
+TEST(IcebergModeParseError, SubjectWithBinaryMode) {
+    // subject is only valid for schema_latest.
+    EXPECT_FALSE(parse("value:mode=binary,subject=foo").has_value());
+    EXPECT_FALSE(parse("key:mode=binary,subject=foo").has_value());
+}
+
+TEST(IcebergModeParseError, SubjectWithSchemaIdPrefixMode) {
+    // subject is only valid for schema_latest.
+    EXPECT_FALSE(parse("value:mode=schema_id_prefix,subject=foo").has_value());
+}
+
+TEST(IcebergModeParseError, ProtobufNameWithBinaryMode) {
+    EXPECT_FALSE(parse("value:mode=binary,protobuf_name=foo.Bar").has_value());
+}
+
+// --- string serialization (format_to / operator<<) ---
+
+TEST(IcebergModeFormat, Disabled) {
+    EXPECT_EQ(to_string(model::iceberg_mode::disabled), "disabled");
+}
+
+TEST(IcebergModeFormat, KeyValue) {
+    EXPECT_EQ(to_string(model::iceberg_mode::key_value), "key_value");
+}
+
+TEST(IcebergModeFormat, ValueSchemaIdPrefix) {
+    EXPECT_EQ(
+      to_string(model::iceberg_mode::value_schema_id_prefix),
+      "value_schema_id_prefix");
+}
+
+TEST(IcebergModeFormat, ValueSchemaLatestBare) {
+    auto m = model::iceberg_mode::value_schema_latest("", "");
+    EXPECT_EQ(to_string(m), "value_schema_latest");
+}
+
+TEST(IcebergModeFormat, ValueSchemaLatestWithSubject) {
+    auto m = model::iceberg_mode::value_schema_latest("", "my-topic-value");
+    EXPECT_EQ(to_string(m), "value_schema_latest:subject=my-topic-value");
+}
+
+TEST(IcebergModeFormat, ValueSchemaLatestWithProtobuf) {
+    auto m = model::iceberg_mode::value_schema_latest(
+      "com.example.Msg", "my-topic-value");
+    EXPECT_EQ(
+      to_string(m),
+      "value_schema_latest:protobuf_name=com.example.Msg,subject=my-topic-"
+      "value");
+}
+
+TEST(IcebergModeFormat, NewKeySchema) {
+    // key:mode=schema_id_prefix should NOT be expressible as legacy format
+    enabled e{};
+    e.key.mode = sm::schema_id_prefix;
+    model::iceberg_mode m{std::move(e)};
+    EXPECT_EQ(to_string(m), "key:mode=schema_id_prefix");
+}
+
+TEST(IcebergModeFormat, NewHeadersString) {
+    enabled e{};
+    e.headers.value_type = hsm::string;
+    model::iceberg_mode m{std::move(e)};
+    EXPECT_EQ(to_string(m), "headers:value_type=string");
+}
+
+// New-format string that is equivalent to an old-format string serializes
+// as the old-format string (not the new-format section string).
+TEST(IcebergModeFormat, NewFormatEquivalentSerializesAsOld) {
+    auto m = parse("value:mode=schema_id_prefix");
+    ASSERT_TRUE(m.has_value());
+    EXPECT_EQ(to_string(*m), "value_schema_id_prefix");
+}
+
+// --- string round-trip ---
+
+// parse → format → parse gives the same object for stable representations.
+// Note: parse → format is not necessarily identity (new-format equivalent to
+// old-format normalizes to old-format string).
+void check_stable(const model::iceberg_mode& m) {
+    auto s1 = to_string(m);
+    auto m2 = parse(s1);
+    ASSERT_TRUE(m2.has_value());
+    EXPECT_EQ(m, *m2);
+    // Second round-trip produces the same string.
+    EXPECT_EQ(to_string(*m2), s1);
+}
+
+TEST(IcebergModeStringRoundtrip, Disabled) {
+    check_stable(model::iceberg_mode::disabled);
+}
+
+TEST(IcebergModeStringRoundtrip, KeyValue) {
+    check_stable(model::iceberg_mode::key_value);
+}
+
+TEST(IcebergModeStringRoundtrip, ValueSchemaIdPrefix) {
+    check_stable(model::iceberg_mode::value_schema_id_prefix);
+}
+
+TEST(IcebergModeStringRoundtrip, ValueSchemaLatest) {
+    check_stable(
+      model::iceberg_mode::value_schema_latest(
+        "com.example.Msg", "my-topic-value"));
+}
+
+TEST(IcebergModeStringRoundtrip, KeySchema) {
+    enabled e{};
+    e.key.mode = sm::schema_id_prefix;
+    check_stable(model::iceberg_mode{std::move(e)});
+}
+
+TEST(IcebergModeStringRoundtrip, HeadersString) {
+    enabled e{};
+    e.headers.value_type = hsm::string;
+    check_stable(model::iceberg_mode{std::move(e)});
+}
+
+TEST(IcebergModeStringRoundtrip, FullCombination) {
+    enabled e{};
+    e.key.mode = sm::schema_id_prefix;
+    e.value.mode = sm::schema_latest;
+    e.value.subject = "my-topic-value";
+    e.headers.value_type = hsm::string;
+    check_stable(model::iceberg_mode{std::move(e)});
+}
+
+// --- wire format round-trip ---
+
+TEST(IcebergModeWireRoundtrip, Disabled) {
+    EXPECT_EQ(
+      wire_roundtrip(model::iceberg_mode::disabled),
+      model::iceberg_mode::disabled);
+}
+
+TEST(IcebergModeWireRoundtrip, KeyValue) {
+    EXPECT_EQ(
+      wire_roundtrip(model::iceberg_mode::key_value),
+      model::iceberg_mode::key_value);
+}
+
+TEST(IcebergModeWireRoundtrip, ValueSchemaIdPrefix) {
+    EXPECT_EQ(
+      wire_roundtrip(model::iceberg_mode::value_schema_id_prefix),
+      model::iceberg_mode::value_schema_id_prefix);
+}
+
+TEST(IcebergModeWireRoundtrip, ValueSchemaLatest) {
+    auto m = model::iceberg_mode::value_schema_latest(
+      "com.example.Msg", "my-topic-value");
+    EXPECT_EQ(wire_roundtrip(m), m);
+}
+
+TEST(IcebergModeWireRoundtrip, KeySchemaUsesDiscriminant4) {
+    // key.mode != binary → must use discriminant 4
+    enabled e{};
+    e.key.mode = sm::schema_id_prefix;
+    model::iceberg_mode m{std::move(e)};
+    EXPECT_EQ(wire_roundtrip(m), m);
+}
+
+TEST(IcebergModeWireRoundtrip, HeadersStringUsesDiscriminant4) {
+    // headers.value_type != binary → must use discriminant 4
+    enabled e{};
+    e.headers.value_type = hsm::string;
+    model::iceberg_mode m{std::move(e)};
+    EXPECT_EQ(wire_roundtrip(m), m);
+}
+
+TEST(IcebergModeWireRoundtrip, FullCombination) {
+    enabled e{};
+    e.key.mode = sm::schema_latest;
+    e.key.subject = "my-topic-key";
+    e.value.mode = sm::schema_latest;
+    e.value.subject = "my-topic-value";
+    e.value.protobuf_name = "com.example.Msg";
+    e.headers.value_type = hsm::string;
+    model::iceberg_mode m{std::move(e)};
+    EXPECT_EQ(wire_roundtrip(m), m);
+}
+
+// Old discriminants (0-3) must still be readable by new code.
+// Verified implicitly: key_value, value_schema_id_prefix, value_schema_latest
+// all use old discriminants 1, 2, 3. Confirmed above.
+
+// --- parse error messages ---
+
+// Helper: call parse_iceberg_mode and return the error string.
+// Asserts that parsing fails.
+std::string parse_err(std::string_view s) {
+    auto r = model::parse_iceberg_mode(s);
+    EXPECT_FALSE(r.has_value()) << "expected parse failure for: " << s;
+    return std::string(r.error());
+}
+
+TEST(IcebergModeParseErrorMsg, UnknownSection) {
+    auto e = parse_err("hederas:value_type=string");
+    EXPECT_THAT(e, testing::HasSubstr("hederas"));
+}
+
+TEST(IcebergModeParseErrorMsg, UnknownOptionInValueSection) {
+    auto e = parse_err("value:mode=schema_id_prefix,future_opt=bar");
+    EXPECT_THAT(e, testing::HasSubstr("future_opt"));
+    EXPECT_THAT(e, testing::HasSubstr("value"));
+}
+
+TEST(IcebergModeParseErrorMsg, UnknownOptionInHeadersSection) {
+    auto e = parse_err("headers:value_type=string,future_opt=bar");
+    EXPECT_THAT(e, testing::HasSubstr("future_opt"));
+    EXPECT_THAT(e, testing::HasSubstr("headers"));
+}
+
+TEST(IcebergModeParseErrorMsg, UnknownModeValue) {
+    auto e = parse_err("value:mode=banana");
+    EXPECT_THAT(e, testing::HasSubstr("banana"));
+    EXPECT_THAT(e, testing::HasSubstr("value"));
+}
+
+TEST(IcebergModeParseErrorMsg, UnknownHeaderValueType) {
+    auto e = parse_err("headers:value_type=blob");
+    EXPECT_THAT(e, testing::HasSubstr("blob"));
+}
+
+TEST(IcebergModeParseErrorMsg, DuplicateSection) {
+    auto e = parse_err("value:mode=binary;value:mode=schema_id_prefix");
+    EXPECT_THAT(e, testing::HasSubstr("value"));
+}
+
+TEST(IcebergModeParseErrorMsg, SubjectWithBinaryMode) {
+    auto e = parse_err("value:mode=binary,subject=foo");
+    EXPECT_EQ(
+      e,
+      "subject and protobuf_name require mode=schema_latest in section "
+      "'value'");
+}
+
+TEST(IcebergModeParseErrorMsg, LegacyUnknownOpt) {
+    auto e = parse_err("value_schema_latest:unknown_opt=foo");
+    EXPECT_THAT(e, testing::HasSubstr("unknown_opt"));
+}
+
+// Degenerate section configs that contain no meaningful options all reduce to
+// the same all-defaults enabled_impl, which serializes as "key_value".
+TEST(IcebergModeNormalize, EmptyKeySection) {
+    auto m = parse("key:");
+    ASSERT_TRUE(m.has_value());
+    EXPECT_EQ(to_string(*m), "key_value");
+}
+
+TEST(IcebergModeNormalize, HeadersBinaryExplicit) {
+    auto m = parse("headers:value_type=binary");
+    ASSERT_TRUE(m.has_value());
+    EXPECT_EQ(to_string(*m), "key_value");
+}
+
+TEST(IcebergModeNormalize, AllSectionsAllDefaults) {
+    auto m = parse("key:;value:;headers:");
+    ASSERT_TRUE(m.has_value());
+    EXPECT_EQ(to_string(*m), "key_value");
+}

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -180,11 +180,17 @@ def read_topic_properties_serde(rdr: Reader, version):
 
 
 def read_iceberg_mode(rdr: Reader):
+    # Discriminant is serialized as int32_t (serde_enum_serialized_t), matching
+    # the original iceberg_mode::variant enum encoding.
     variant = rdr.read_serde_enum()
-    protobuf_value = None
-    if variant == 3:
-        protobuf_value = rdr.read_string()
-    return {"variant": variant, "protobuf_value": protobuf_value}
+    if variant == 3:  # value_schema_latest
+        protobuf_name = rdr.read_string()
+        subject = rdr.read_string()
+        return {"variant": variant, "protobuf_name": protobuf_name, "subject": subject}
+    if variant == 4:  # wire_canonical_string: serde envelope containing config string
+        envelope = rdr.read_envelope(lambda rdr, _: {"config": rdr.read_string()})
+        return {"variant": variant, "config": envelope["config"]}
+    return {"variant": variant}
 
 
 def read_topic_config(rdr: Reader, version):


### PR DESCRIPTION
Replaces the flat 4-variant iceberg_mode (disabled, key_value, value_schema_id_prefix, value_schema_latest) with a structured section-based config supporting independent key, value, and headers options.

New config grammar:
  <section> (";" <section>)*
  section  ::= ("key"|"value"|"headers") ":" <opts>

Key/value opts: mode=(binary|schema_id_prefix|schema_latest),
  subject=<str>, protobuf_name=<str>
Headers opts: value_type=(binary|string),
  on_decode_error=(replace|null|drop)

All old config strings (disabled, key_value, value_schema_id_prefix, value_schema_latest[:subject=S,protobuf_name=N]) remain valid and parse into equivalent enabled_impl objects. Wire format preserves old discriminants 0-3 for configs expressible in the old format; discriminant 4 is added for configs requiring key schema or string headers.

The key and headers sections are fully parsed, validated, and round-tripped but not yet acted on by the translation pipeline. datalake_manager.cc is migrated to the new API and currently reads only the value section's schema mode.

Follow-ups will implement key and header translation.

Release notes come when we are landing the final PR, not this initial one.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
