### PR TITLE
`cluster`: defer `config_cache` persistence until after `controller_stm` snapshot

### DIFF
--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -838,18 +838,8 @@ void config_manager::merge_apply_result(
     }
 }
 
-/**
- * Update persistent local cache of config.
- *
- * This cache is for early loading during startup.  It is NOT required
- * to be strictly up to date when we finish processing a delta.
- *
- * @param version
- * @param data
- * @return
- */
-ss::future<>
-config_manager::store_delta(const cluster_config_delta_cmd_data& data) {
+void config_manager::update_raw_values(
+  const cluster_config_delta_cmd_data& data) {
     auto& cfg = config::shard_local_cfg();
 
     for (const auto& u : data.upsert) {
@@ -878,8 +868,6 @@ config_manager::store_delta(const cluster_config_delta_cmd_data& data) {
     for (const auto& d : data.remove) {
         _raw_values.erase(d);
     }
-
-    return write_local_cache(_seen_version, _raw_values);
 }
 
 ss::future<> config_manager::write_local_cache(
@@ -988,7 +976,8 @@ config_manager::apply_delta(cluster_config_delta_cmd&& cmd_in) {
 
     // Store the raw values (irrespective of any issues applying them) for
     // early replay on next startup.
-    co_await store_delta(data);
+    update_raw_values(data);
+    co_await write_local_cache(_seen_version, _raw_values);
 
     // Signal status update loop to wake up
     _reconcile_wait.signal();

--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -977,12 +977,38 @@ config_manager::apply_delta(cluster_config_delta_cmd&& cmd_in) {
     // Store the raw values (irrespective of any issues applying them) for
     // early replay on next startup.
     update_raw_values(data);
-    co_await write_local_cache(_seen_version, _raw_values);
+
+    // Mark the cache as out-of-date. The actual on-disk write is deferred
+    // to the controller STM's snapshot path:
+    //   - `controller_stm::maybe_make_snapshot` calls
+    //     `capture_pending_cache_data` under the apply mutex to snapshot
+    //     `_seen_version` / `_raw_values` consistent with the snapshot
+    //     being built.
+    //   - `controller_stm::snapshot_timer_callback` calls
+    //     `flush_pending_cache_write` after the snapshot is durable.
+    // This preserves the invariant that the on-disk cache offset never
+    // advances past the on-disk snapshot offset.
+    _pending_cache_write = true;
 
     // Signal status update loop to wake up
     _reconcile_wait.signal();
 
     co_return errc::success;
+}
+
+void config_manager::capture_pending_cache_data() {
+    if (!std::exchange(_pending_cache_write, false)) {
+        return;
+    }
+    _pending_cache_data = {_seen_version, _raw_values};
+}
+
+ss::future<> config_manager::flush_pending_cache_write() {
+    if (!_pending_cache_data) {
+        co_return;
+    }
+    auto data = std::exchange(_pending_cache_data, std::nullopt);
+    co_await write_local_cache(data->version, data->raw_values);
 }
 
 ss::future<std::error_code>
@@ -1083,6 +1109,12 @@ config_manager::apply_snapshot(model::offset, const controller_snapshot& snap) {
           "Failed to apply config_manager part of controller snapshot: {} ({})",
           ec.message(),
           ec));
+    }
+
+    // `apply_delta` set `_pending_cache_write`. Persist the cache here
+    // rather than waiting for the snapshot timer.
+    if (std::exchange(_pending_cache_write, false)) {
+        co_await write_local_cache(_seen_version, _raw_values);
     }
 
     // Snapshot application is a wholesale state replacement — promote

--- a/src/v/cluster/config_manager.h
+++ b/src/v/cluster/config_manager.h
@@ -95,6 +95,13 @@ public:
         }
     }
 
+    /**
+     * Update persistent local cache of config.
+     *
+     * This cache is for early loading during startup.  It is NOT required
+     * to be strictly up to date when we finish processing a delta.
+     *
+     */
     static ss::future<> write_local_cache(
       config_version, const std::map<ss::sstring, ss::sstring>&);
 
@@ -107,7 +114,12 @@ private:
     bool should_send_status();
     ss::future<> reconcile_status();
     ss::future<std::error_code> apply_delta(cluster_config_delta_cmd&&);
-    ss::future<> store_delta(const cluster_config_delta_cmd_data& data);
+    /**
+     * Merge a delta into the in-memory _raw_values map. Mirrors how
+     * apply_local updates the live config: after this returns, _raw_values
+     * reflects the same state that has just been applied across shards.
+     */
+    void update_raw_values(const cluster_config_delta_cmd_data& data);
 
     bool _bootstrap_complete{false};
     void start_bootstrap();

--- a/src/v/cluster/config_manager.h
+++ b/src/v/cluster/config_manager.h
@@ -22,6 +22,9 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/sharded.hh>
 
+#include <map>
+#include <optional>
+
 namespace YAML {
 class Node;
 }
@@ -73,6 +76,15 @@ public:
     ss::future<std::error_code> apply_update(model::record_batch);
     ss::future<> fill_snapshot(controller_snapshot&) const;
     ss::future<> apply_snapshot(model::offset, const controller_snapshot&);
+
+    /// Copy the current `_seen_version` and `_raw_values` into a pending
+    /// buffer for a deferred cache write, if `_pending_cache_write` is set.
+    // `flush_pending_cache_write()` can later persist it.
+    void capture_pending_cache_data();
+
+    /// Persist any data captured by `capture_pending_cache_data()` to the
+    /// on-disk cache.
+    ss::future<> flush_pending_cache_write();
 
     // Result of trying to apply a delta to a configuration
     struct apply_result {
@@ -153,6 +165,23 @@ private:
     ss::condition_variable _reconcile_wait;
     ss::sharded<ss::abort_source>& _as;
     ss::sharded<cluster_recovery_table>& _recovery_table;
+
+    // Set by `apply_delta()` to signal that `_raw_values` has diverged from
+    // the on-disk cache. Cleared by `capture_pending_cache_data()`, which
+    // moves the current state into `_pending_cache_data` so the deferred cache
+    // write reflects state consistent with the snapshot being built.
+    bool _pending_cache_write{false};
+
+    // `_seen_version` and `_raw_values` captured atomically with the
+    // state in the controller snapshot, waiting to be written to disk.
+    // Populated by `capture_pending_cache_data()` and drained by
+    // `flush_pending_cache_write()` after the snapshot is durable.
+    struct pending_cache_data {
+        config_version version;
+        std::map<ss::sstring, ss::sstring> raw_values;
+    };
+    std::optional<pending_cache_data> _pending_cache_data;
+
     ss::gate _gate;
 };
 

--- a/src/v/cluster/controller_stm.cc
+++ b/src/v/cluster/controller_stm.cc
@@ -50,10 +50,13 @@ ss::future<> controller_stm::stop() { co_return; }
 void controller_stm::snapshot_timer_callback() {
     ssx::background
       = ssx::spawn_with_gate_then(_gate, [this] {
-            return maybe_write_snapshot().then([](bool written) {
+            return maybe_write_snapshot().then([this](bool written) {
                 if (!written) {
                     vlog(clusterlog.info, "skipped writing snapshot");
+                    return ss::now();
                 }
+                return std::get<config_manager&>(_state)
+                  .flush_pending_cache_write();
             });
         }).handle_exception([](const std::exception_ptr& e) {
             vlog(clusterlog.warn, "failed to write snapshot: {}", e);
@@ -132,6 +135,11 @@ controller_stm::maybe_make_snapshot(ssx::semaphore_units apply_mtx_holder) {
     std::apply(
       [call_stm_fill](auto&&... stms) { (call_stm_fill(stms), ...); }, _state);
     co_await std::move(fill_fut);
+
+    // While still under _apply_mtx, snapshot config_manager's state into a
+    // pending-cache buffer if a delta has landed since the last capture. The
+    // cached state will be flushed after this snapshot is written.
+    std::get<config_manager&>(_state).capture_pending_cache_data();
 
     vlog(
       clusterlog.info,


### PR DESCRIPTION
Enforces the invariant that the on-disk config cache offset is never ahead of the latest controller-STM-snapshot offset.

This prevents bugs like the following:

Imagine the local controller log looks like this:

```
---S-A----B
0  3 5   10
```

where the entry `S` at offset `3` is the `controller_stm`'s last snapshot, `A` at offset `5` is some sort of cluster command, and `B` is some `cluster_config_delta_cmd` which has _some_ sort of effect on `A`.

The way this could currently be handled is:

1. When `B` was replicated to the local log, `config_manager::apply_delta()` invoked `config_manager::store_delta()`, storing the result of `B` in the local `config_cache.yaml`.
2. Next time the broker is restarted, this config cache is read, and the effects of `B` are immediately persisted in the broker's `shard_local_cfg()`.
3. After bootstrapping, the controller snapshot `S` at offset `3` is re-read, and the log is replayed from that point onwards.
4. The _effects of the update `B` at offset 10 are now applied before the command `A` at offset `5` has been re-applied_. We have a potentially divergent behavior from what the state originally was before the node restarted.

To fix this issue, simply enforce that a `controller_stm` snapshot is taken _before_ the local `config_cache.yaml` file is rewritten- that way, there is no possible way for any command `A` which has an implicit dependency on some later config update `B` to be applied in a divergent fashion, since now `S >= B`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
