### PR TITLE
net: Revert unconditional tcp nodelay

### DIFF
--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -211,6 +211,7 @@ ss::future<client::request_response_t> client::make_request(
               .count = tcp_keepalive_probes,
             });
           set_keepalive(true);
+          set_nodelay(true);
           return ss::make_ready_future<request_response_t>(
             std::make_tuple(req, res));
       })

--- a/src/v/net/transport.cc
+++ b/src/v/net/transport.cc
@@ -205,7 +205,6 @@ ss::future<> base_transport::do_connect(clock_type::time_point timeout) {
         vlog(_log->trace, "Resolved address {}", resolved_address);
         ss::connected_socket fd = co_await connect_with_timeout(
           resolved_address, timeout, _log);
-        fd.set_nodelay(true);
 
         if (_proxy.has_value() && _proxy->credentials) {
             // https:// proxy: TLS-wrap to the proxy before CONNECT.

--- a/src/v/net/transport.cc
+++ b/src/v/net/transport.cc
@@ -282,6 +282,12 @@ void base_transport::set_keepalive(bool keepalive) {
     }
 }
 
+void base_transport::set_nodelay(bool nodelay) {
+    if (_fd) {
+        _fd->set_nodelay(nodelay);
+    }
+}
+
 ss::future<>
 base_transport::connect(clock_type::time_point connection_timeout) {
     // in order to hold concurrency correctness invariants we must guarantee 3

--- a/src/v/net/transport.h
+++ b/src/v/net/transport.h
@@ -118,6 +118,7 @@ public:
 
     void set_keepalive_parameters(const ss::net::keepalive_params& params);
     void set_keepalive(bool);
+    // Set TCP_NODELAY on the socket
     void set_nodelay(bool);
 
     [[gnu::always_inline]] bool is_valid() const {

--- a/src/v/net/transport.h
+++ b/src/v/net/transport.h
@@ -118,6 +118,7 @@ public:
 
     void set_keepalive_parameters(const ss::net::keepalive_params& params);
     void set_keepalive(bool);
+    void set_nodelay(bool);
 
     [[gnu::always_inline]] bool is_valid() const {
         return _fd && !_shutdown && (_in && !in().eof());


### PR DESCRIPTION
This reverts commit https://github.com/redpanda-data/redpanda/commit/f3169e63a6463fd68be762b16617aebd7cc822e8.

The commit set TCP_NODELAY on the base client and hence it affected all
forms of clients.

This includes the internal RPC client.

In CPD we saw a throughput performance regression:

```
RedPandaOpenMessagingBenchmarkPerf pub50pct -1%
RpkBenchmarkPerf requests_per_sec -7%
```

Looking at metrics it becomes clear why. Avg reactor util is up ~5%.
recvfrom syscalls are up ~20%.

The delayed sending causes implicit batching on the TCP level when
multiple append entry requests are in flight at the same time. This
reduces recv calls on the followers and probably also has higher
efficiency at the application level (even if the amount of actual append
entry requests is unchanged or even increased).

While this sort of implicit reliance on NODELAY isn't great the
performance impact can't be neglected. Hence revert.

Longer team we'd probably want to replace this with more explicit
batching.

Set it only for HTTP.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

