### PR TITLE
[v26.1.x] cloud_io: clear scheduling group bw cap when throttling is disabled

### DIFF
--- a/src/v/cloud_io/io_resources.cc
+++ b/src/v/cloud_io/io_resources.cc
@@ -232,6 +232,8 @@ ss::future<> io_resources::set_disk_max_bandwidth(size_t tput) {
     try {
         if (tput == 0 || tput == std::numeric_limits<size_t>::max()) {
             _throttling_disabled = true;
+            co_await _scheduling_group.update_io_bandwidth(
+              effectively_unlimited_bw);
             vlog(
               log.info,
               "Scheduling group's {} bandwidth is not limited",

--- a/src/v/cloud_io/io_resources.h
+++ b/src/v/cloud_io/io_resources.h
@@ -28,6 +28,13 @@ class io_resources {
     friend class throttled_dl_source;
 
 public:
+    // Workaround for scylladb/seastar#3370: there is no API to clear the cap
+    // set by scheduling_group::update_io_bandwidth. Pass a value that is
+    // "effectively unlimited" and below the internal max_rate threshold so it
+    // does not throw. 1 PiB/s is well above any real device and comfortably
+    // below the ~1.31 EB/s ceiling computed from shared_token_bucket::max_rate.
+    static constexpr uint64_t effectively_unlimited_bw = uint64_t{1} << 50u;
+
     explicit io_resources(seastar::scheduling_group);
 
     ss::future<> start();

--- a/src/v/cloud_io/tests/BUILD
+++ b/src/v/cloud_io/tests/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_btest", "redpanda_test_cc_library")
+load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_btest", "redpanda_cc_gtest", "redpanda_test_cc_library")
 
 redpanda_test_cc_library(
     name = "scoped_remote",
@@ -99,6 +99,21 @@ redpanda_cc_bench(
         "@abseil-cpp//absl/container:btree",
         "@seastar",
         "@seastar//:benchmark",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "io_resources_test",
+    timeout = "short",
+    srcs = [
+        "io_resources_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/cloud_io:io_resources",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
     ],
 )
 

--- a/src/v/cloud_io/tests/io_resources_test.cc
+++ b/src/v/cloud_io/tests/io_resources_test.cc
@@ -26,7 +26,7 @@ TEST_CORO(io_resources, effectively_unlimited_bw_does_not_throw) {
 
     co_await ss::destroy_scheduling_group(sg);
 
-    EXPECT_FALSE(fut.failed());
+    EXPECT_FALSE(fut.failed()) << fmt::format("e: {}", fut.get_exception());
     if (fut.failed()) {
         std::rethrow_exception(fut.get_exception());
     }

--- a/src/v/cloud_io/tests/io_resources_test.cc
+++ b/src/v/cloud_io/tests/io_resources_test.cc
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "base/seastarx.h"
+#include "cloud_io/io_resources.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/scheduling.hh>
+#include <seastar/coroutine/as_future.hh>
+
+TEST_CORO(io_resources, effectively_unlimited_bw_does_not_throw) {
+    auto sg = co_await ss::create_scheduling_group("cloud_io_test", 100);
+
+    // Passing the "effectively unlimited" bandwidth must be a valid way to
+    // disable throttling. Regression test for scylladb/seastar#3370.
+    auto fut = co_await ss::coroutine::as_future(
+      sg.update_io_bandwidth(cloud_io::io_resources::effectively_unlimited_bw));
+
+    co_await ss::destroy_scheduling_group(sg);
+
+    EXPECT_FALSE(fut.failed());
+    if (fut.failed()) {
+        std::rethrow_exception(fut.get_exception());
+    }
+}


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30319

- Command: git cherry-pick -x 1e49391558 af31719251
- Commits backported: 2
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-30319-v26.1.x-1778769612

## Conflict details

- 1e49391558 (src/v/cloud_io/tests/BUILD): the incoming commit added a `redpanda_cc_gtest` `io_resources_test` block after an existing `db_s3_imposter_test` `redpanda_cc_gtest` block that exists on dev but not on v26.1.x, which produced a context conflict. Resolved by adding `redpanda_cc_gtest` to the `load("//bazel:test.bzl", ...)` symbols (it was not previously imported on v26.1.x) and inserting only the new `io_resources_test` block after `cache_rpbench` and before `directory_walker_test`. The unrelated `db_s3_imposter_test` block was not introduced here.
