### PR TITLE
c/tests: bump leader_balancer_simulation_test timeout to moderate

### DIFF
--- a/src/v/cluster/tests/BUILD
+++ b/src/v/cluster/tests/BUILD
@@ -311,7 +311,7 @@ redpanda_cc_btest(
 
 redpanda_cc_gtest(
     name = "leader_balancer_simulation_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "leader_balancer_simulation_test.cc",
     ],


### PR DESCRIPTION
The bazel test target `//src/v/cluster/tests:leader_balancer_simulation_test`
is declared with `timeout = "short"` (60s) but its two test cases combined
take ~72s in debug builds on x86 (I guess it's faster on arm since it doens't
usually time out):

```
[ RUN      ] LeaderBalancerSimulation.CompareMovesCount3
[       OK ] LeaderBalancerSimulation.CompareMovesCount3 (32906 ms)
[ RUN      ] LeaderBalancerSimulation.CompareMovesCount7
-- Test timed out at 2026-05-13 21:08:38 UTC --
[       OK ] LeaderBalancerSimulation.CompareMovesCount7 (39134 ms)
[----------] 2 tests from LeaderBalancerSimulation (72041 ms total)
```

This is a deterministic mis-configuration, not a flake — the target was added
in ffd0796efc under `"short"` and has drifted over the 60s budget. Bump to
`"moderate"` (300s) to give the run comfortable headroom.

Fixes CORE-16309.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none