### PR TITLE
ducktape: install elixir from precompiled release for ocsf-server

### DIFF
--- a/tests/docker/ducktape-deps/ocsf-server
+++ b/tests/docker/ducktape-deps/ocsf-server
@@ -32,11 +32,26 @@ rm ${OCSF_SERVER_VERSION}.tar.gz
 mv ocsf-server-${OCSF_SERVER_VERSION} /opt/ocsf-server
 
 retry_apt apt-get update
-retry_apt apt-get install -qq software-properties-common
+retry_apt apt-get install -qq software-properties-common unzip
 
 retry_apt add-apt-repository -y ppa:rabbitmq/rabbitmq-erlang
 retry_apt apt-get update
-retry_apt apt-get install -qq elixir erlang-dev erlang-xmerl
+retry_apt apt-get install -qq erlang erlang-dev erlang-xmerl
+
+# Ubuntu's `elixir` package is 1.12, but ocsf-server's mix.exs requires
+# `~> 1.14`. Install Elixir from the official precompiled release, matching
+# the OTP 26 the rabbitmq erlang PPA provides.
+ELIXIR_VERSION=1.15.7
+ELIXIR_OTP=26
+ELIXIR_SHA256=10370b04df55fcd93fd016125d5c9bbe1aab5a7ffa99691f6197e3829e32af34
+wget "https://github.com/elixir-lang/elixir/releases/download/v${ELIXIR_VERSION}/elixir-otp-${ELIXIR_OTP}.zip"
+echo "${ELIXIR_SHA256}  elixir-otp-${ELIXIR_OTP}.zip" | sha256sum -c -
+mkdir -p /opt/elixir
+unzip -q -d /opt/elixir "elixir-otp-${ELIXIR_OTP}.zip"
+rm "elixir-otp-${ELIXIR_OTP}.zip"
+for bin in elixir elixirc iex mix; do
+  ln -sf "/opt/elixir/bin/${bin}" "/usr/local/bin/${bin}"
+done
 
 mix local.hex --force && mix local.rebar --force
 


### PR DESCRIPTION
## Summary

Ubuntu's `elixir` apt package is 1.12, but ocsf-server's [`mix.exs`](https://github.com/redpanda-data/ocsf-server/blob/d3b26de39df9eb33c6d63e34a126c77c0811c7a0/mix.exs#L24) declares `elixir: "~> 1.14"`, which breaks the `redpanda-testing` AMI build with:

```
** (Mix) You're trying to run :schema_server on Elixir v1.12.2 but it has
declared in its mix.exs file it supports only Elixir ~> 1.14
```

This installs Elixir 1.15.7 from the official precompiled release (matching the OTP 26 that the rabbitmq erlang PPA provides) instead of relying on the stale Ubuntu package. 1.15 matches the version the upstream ocsf-server Dockerfile uses (`elixir:1.15-alpine`).

Fixes [DEVPROD-4191](https://redpandadata.atlassian.net/browse/DEVPROD-4191).

## Test plan

- [ ] AMI build (`redpanda-testing`) succeeds on Buildkite
- [ ] Audit log ducktape tests using ocsf-server still pass

[DEVPROD-4191]: https://redpandadata.atlassian.net/browse/DEVPROD-4191

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes

* none