### PR TITLE
raft: reset heartbeats_failed on force-reconnect

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -3939,6 +3939,14 @@ void consensus::update_heartbeat_status(vnode id, bool success) {
     }
 }
 
+void consensus::reset_heartbeat_failures(model::node_id node) {
+    for (auto& [vn, fstate] : _fstates) {
+        if (vn.id() == node) {
+            fstate.heartbeats_failed = 0;
+        }
+    }
+}
+
 bool consensus::should_reconnect_follower(
   const follower_index_metadata& f_meta) {
     if (_heartbeat_disconnect_failures == 0) {

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -488,6 +488,10 @@ public:
 
     void update_heartbeat_status(vnode, bool);
 
+    /// Zero `heartbeats_failed` for followers matching `node_id`. Called
+    /// after `ensure_disconnect` replaces the cached transport.
+    void reset_heartbeat_failures(model::node_id);
+
     bool should_reconnect_follower(const follower_index_metadata&);
 
     std::vector<follower_metrics> get_follower_metrics() const;

--- a/src/v/raft/follower_states.h
+++ b/src/v/raft/follower_states.h
@@ -60,6 +60,8 @@ struct follower_index_metadata {
     // timestamp of last append_entries_rpc call
     clock_type::time_point last_sent_append_entries_req_timestamp;
     clock_type::time_point last_received_reply_timestamp;
+    /// Heartbeat failures observed on the current cached transport.
+    /// Reset on a successful reply or when we force a reconnect.
     uint32_t heartbeats_failed{0};
     // The pair of sequences used to track append entries requests sent and
     // received by the follower. Every time append entries request is created

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -276,6 +276,12 @@ ss::future<> heartbeat_manager::do_dispatch_heartbeats() {
         if (co_await _client_protocol.ensure_disconnect(node_id)) {
             vlog(
               hbeatlog.info, "Closed unresponsive connection to {}", node_id);
+            // Clear failures attributed to the replaced transport.
+            co_await ssx::async_for_each<loop_traits>(
+              _consensus_groups,
+              [node_id](ss::lw_shared_ptr<consensus>& raft_group) {
+                  raft_group->reset_heartbeat_failures(node_id);
+              });
         };
     }
 

--- a/src/v/raft/tests/basic_raft_fixture_test.cc
+++ b/src/v/raft/tests/basic_raft_fixture_test.cc
@@ -107,6 +107,52 @@ TEST_F_CORO(raft_fixture, test_stuck_append_entries) {
     ASSERT_EQ_CORO(term_before, raft->term());
 }
 
+// After ensure_disconnect replaces the cached transport for a peer,
+// reset_heartbeat_failures must zero heartbeats_failed for every follower of
+// this group whose node_id matches; failure history on the prior transport
+// must not carry over to the fresh one. See should_reconnect_follower.
+TEST_F_CORO(raft_fixture, test_reset_heartbeat_failures) {
+    co_await create_simple_group(3);
+    auto leader_id = co_await wait_for_leader(10s);
+    auto leader = node(leader_id).raft();
+
+    auto& fstates = leader->get_follower_states();
+    ASSERT_GE_CORO(fstates.size(), 2u);
+    auto it = fstates.begin();
+    auto follower_a = it->first;
+    ++it;
+    auto follower_b = it->first;
+
+    constexpr size_t kFailuresA = 5;
+    constexpr size_t kFailuresB = 3;
+    for (size_t i = 0; i < kFailuresA; ++i) {
+        leader->update_heartbeat_status(follower_a, false);
+    }
+    for (size_t i = 0; i < kFailuresB; ++i) {
+        leader->update_heartbeat_status(follower_b, false);
+    }
+    ASSERT_EQ_CORO(
+      leader->get_follower_states().get(follower_a).heartbeats_failed,
+      kFailuresA);
+    ASSERT_EQ_CORO(
+      leader->get_follower_states().get(follower_b).heartbeats_failed,
+      kFailuresB);
+
+    // Reset only follower_a's node. follower_b must be untouched.
+    leader->reset_heartbeat_failures(follower_a.id());
+    ASSERT_EQ_CORO(
+      leader->get_follower_states().get(follower_a).heartbeats_failed, 0u);
+    ASSERT_EQ_CORO(
+      leader->get_follower_states().get(follower_b).heartbeats_failed,
+      kFailuresB);
+
+    // Reset_heartbeat_failures on an unknown node_id is a no-op.
+    leader->reset_heartbeat_failures(model::node_id{999});
+    ASSERT_EQ_CORO(
+      leader->get_follower_states().get(follower_b).heartbeats_failed,
+      kFailuresB);
+}
+
 struct test_parameters {
     consistency_level c_lvl;
     bool write_caching;


### PR DESCRIPTION
After `ensure_disconnect` replaces the cached transport for a peer, zero `heartbeats_failed` so the counter only reflects failures on the current transport. Otherwise the next dispatch immediately force-closes the fresh transport based on the prior transport's failure history, preempting heartbeats before their replies can arrive and freezing the counter past threshold indefinitely.

Fixes [CORE-16312](https://redpandadata.atlassian.net/browse/CORE-16312)
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes
### Bug Fixes
* Fixes an issue that prevented raft followers across high-RTT links from establishing connections long enough to receive heartbeat request replies. 
 

[CORE-16312]: https://redpandadata.atlassian.net/browse/CORE-16312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ