### PR TITLE
bazel/avro: make avrogen header include guard deterministic

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -352,7 +352,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "yZROfZgIs0LcoLF6ANflyVgdZWDFiY86XvceRey/k1U=",
+        "bzlTransitiveDigest": "sEIE/cj3N8I1IHROjK3AdXZTTBeDOkBtEX1mgrcGJas=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedInputs": [
           "REPO_MAPPING:,bazel_tools bazel_tools"
@@ -375,7 +375,8 @@
               "url": "https://github.com/redpanda-data/avro/archive/46fe1e36f680d75219cba46368de38321f1810ed.tar.gz",
               "patches": [
                 "@@//bazel/thirdparty:avro-snappy-includes.patch",
-                "@@//bazel/thirdparty:avro-fmt-const.patch"
+                "@@//bazel/thirdparty:avro-fmt-const.patch",
+                "@@//bazel/thirdparty:avrogen-stable-include-guard.patch"
               ],
               "patch_args": [
                 "-p1"

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -28,6 +28,7 @@ def data_dependency():
         patches = [
             "//bazel/thirdparty:avro-snappy-includes.patch",
             "//bazel/thirdparty:avro-fmt-const.patch",
+            "//bazel/thirdparty:avrogen-stable-include-guard.patch",
         ],
         patch_args = ["-p1"],
     )

--- a/bazel/thirdparty/avrogen-stable-include-guard.patch
+++ b/bazel/thirdparty/avrogen-stable-include-guard.patch
@@ -1,0 +1,28 @@
+From: Travis Downs <travis.downs@redpanda.com>
+Subject: [PATCH] avrogencpp: use deterministic include guard
+
+The generated header's include guard was suffixed with the output of a
+`boost::mt19937` seeded from `::time(nullptr)`, which produced a different
+guard on every avrogen invocation. That made every consumer of the generated
+header (e.g. `manifest_list_avro.cc`) see a different input digest on each
+build, breaking Bazel's remote cache for the entire dependency chain even
+on byte-identical schemas.
+
+`headerFile_` is already a unique-per-output path; `makeCanonical(h, true)`
+canonicalizes it into a valid identifier ending in `_H` (from the `.h`
+extension). Dropping the random number leaves a stable, still-unique guard.
+
+Tracks CORE-16317.
+
+diff --git a/lang/c++/impl/avrogencpp.cc b/lang/c++/impl/avrogencpp.cc
+--- a/lang/c++/impl/avrogencpp.cc
++++ b/lang/c++/impl/avrogencpp.cc
+@@ -793,7 +793,7 @@
+ string CodeGen::guard() {
+     string h = headerFile_;
+     makeCanonical(h, true);
+-    return h + "_" + lexical_cast<string>(random_()) + "_H";
++    return h + "_H";
+ }
+
+ void CodeGen::generate(const ValidSchema &schema) {


### PR DESCRIPTION
## Summary

- Patches the upstream Apache Avro `avrogencpp` tool (via `bazel/thirdparty/avrogen-stable-include-guard.patch`) so the generated header's include guard no longer carries a time-seeded random suffix.
- Drops the `boost::mt19937` random number from `lang/c++/impl/avrogencpp.cc:796` — the canonicalized `headerFile_` is already path-unique.

## Why

The current avrogen produces a guard like `BAZEL_OUT_..._MANIFEST_FILE_AVROGEN_H_<random>_H` where `<random>` comes from a `boost::mt19937` seeded with `::time(nullptr)`. Two invocations on the same schema produce headers with different bytes, so every consumer of the generated header (`manifest_list_avro.cc`) sees a different input digest on every build. That blows the bazel remote cache for the entire downstream chain — `iceberg` lib → `redpanda` binary → `//tools:redpanda_package_for_pgo` — even when the schema is byte-identical.

Identified via the `beptool walkback` analysis of two-output-base builds of `//tools:redpanda_package_for_pgo`: it's one of only two persistent root causes (the other being `make_tool`, [CORE-16315](https://redpandadata.atlassian.net/browse/CORE-16315)) that infect that target across overnight runs. Fixing this is half of the work to make the PGO instrument tar reproducible, which would let the ~1956 PGO-optimize compile actions in the overnight builds (84428–84432) actually hit the remote cache instead of re-executing locally on every run.

Tracks [CORE-16317](https://redpandadata.atlassian.net/browse/CORE-16317).

## Validation

```
bazel --output_base=/tmp/run1 build //src/v/iceberg:manifest_file_genrule
bazel --output_base=/tmp/run2 build //src/v/iceberg:manifest_file_genrule
sha256sum /tmp/run{1,2}/execroot/_main/bazel-out/k8-fastbuild/bin/src/v/iceberg/manifest_file.avrogen.h
```

Before this patch the two hashes differed. After:

```
df2e1bf5be81d8f068f1e1c982c302a18a284b77bd981563865618c7001ef22e  run1/.../manifest_file.avrogen.h
df2e1bf5be81d8f068f1e1c982c302a18a284b77bd981563865618c7001ef22e  run2/.../manifest_file.avrogen.h
```

New include guard: `BAZEL_OUT_K8_FASTBUILD_BIN_SRC_V_ICEBERG_MANIFEST_FILE_AVROGEN_H_H` (deterministic; the trailing `_H_H` is cosmetic — could be simplified to just `h` if reviewers prefer).

## Upstream

I'll open a corresponding PR against `apache/avro` so other users of avrogen with hermetic build systems (Bazel, Nix, etc.) get the fix.

## Test plan

- [x] Two-output-base builds of `//src/v/iceberg:manifest_file_genrule` produce byte-identical headers
- [ ] CI green (bazel build + test)
- [ ] Confirm `//tools:redpanda_package_for_pgo` tar diverges only on the remaining `make_tool` root after this lands

[CORE-16315]: https://redpandadata.atlassian.net/browse/CORE-16315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ