### PR TITLE
bazel: make GNU make 4.4.1 toolchain reproducible

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -48,6 +48,14 @@ single_version_override(
 bazel_dep(name = "re2", version = "2024-07-02.bcr.1")
 bazel_dep(name = "rules_cc", version = "0.2.17")
 bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
+single_version_override(
+    module_name = "rules_foreign_cc",
+    patch_strip = 1,
+    patches = [
+        "//bazel/thirdparty:rules_foreign_cc-make441-reproducible.patch",
+    ],
+)
+
 bazel_dep(name = "rules_go", version = "0.59.0")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "rules_proto", version = "7.1.0")

--- a/bazel/thirdparty/rules_foreign_cc-make441-reproducible.patch
+++ b/bazel/thirdparty/rules_foreign_cc-make441-reproducible.patch
@@ -1,0 +1,36 @@
+Pin LIBDIR / INCLUDEDIR / LOCALEDIR in make 4.4.1's Makefile.in so the
+built `make` binary is byte-reproducible across sandbox directories.
+
+rules_foreign_cc already does this for make 4.3 via
+toolchains/patches/make-reproducible-bootstrap.patch, but no equivalent
+patch is wired in for the 4.4 / 4.4.1 versions and the current default
+(4.4.1) leaks the sandbox-derived $$INSTALLDIR$$ value into the make ELF
+through autoconf's -DLIBDIR / -DINCLUDEDIR / -DLOCALEDIR macros.
+
+That non-determinism cascades to every foreign_cc-built dependency
+(openssl, krb5, hwloc, libxml2, ...) because the make binary appears as
+an input to those rules. See CORE-16315.
+
+The fix here uses http_archive's patch_cmds (rather than adding a
+separate .patch file inside rules_foreign_cc) to keep the override to a
+single-file diff against built_toolchains.bzl.
+
+diff --git a/toolchains/built_toolchains.bzl b/toolchains/built_toolchains.bzl
+--- a/toolchains/built_toolchains.bzl
++++ b/toolchains/built_toolchains.bzl
+@@ -85,7 +85,15 @@ def _make_toolchain(version, register_toolchains):
+     if version == "4.4.1":
+         maybe(
+             http_archive,
+             name = "gnumake_src",
++            patch_cmds = [
++                # Pin LIBDIR / INCLUDEDIR / LOCALEDIR so the built make
++                # binary is byte-reproducible across sandbox dirs.
++                # Mirrors toolchains/patches/make-reproducible-bootstrap.patch
++                # (which only applies to make 4.3). See CORE-16315.
++                r"""sed -i 's|-DINCLUDEDIR=\\"$(includedir)\\"|-DINCLUDEDIR=\\".\\"|' Makefile.in""",
++                r"""sed -i 's|-DLIBDIR=\\"$(libdir)\\" -DLOCALEDIR=\\"$(localedir)\\"|-DLIBDIR=\\".\\" -DLOCALEDIR=\\".\\"|' Makefile.in""",
++            ],
+             build_file_content = _ALL_CONTENT,
+             sha256 = "dd16fb1d67bfab79a72f5e8390735c49e3e8e70b4945a15ab1f81ddb78658fb3",
+             strip_prefix = "make-4.4.1",


### PR DESCRIPTION
## Motivation

The `make` binary built by `rules_foreign_cc`'s internal toolchain (used to drive every foreign_cc dependency build: openssl, krb5, hwloc, libxml2, ...) is **not byte-reproducible across back to back same repo root builds**. The make ELF embeds three autoconf-substituted macros — `-DLIBDIR=\"$(libdir)\"`, `-DINCLUDEDIR=\"$(includedir)\"`, `-DLOCALEDIR=\"$(localedir)\"` — all derived from `--prefix=$$INSTALLDIR$$`, which is the sandbox-derived install dir and therefore differs every build.

That non-determinism cascades: the make binary's content digest is part of every foreign_cc dependency's action key, so any sandbox-path change invalidates the remote cache for openssl, krb5, hwloc, libxml2, etc. on every overnight CI run. Walk-back analysis on the overnight `redpanda_package_for_pgo.tar` build identified this as one of two root causes that make the redpanda binary itself non-deterministic (alongside CORE-16317).

## Why upstream missed it

`rules_foreign_cc` already addresses this for make 4.3 via [`toolchains/patches/make-reproducible-bootstrap.patch`](https://github.com/bazel-contrib/rules_foreign_cc/blob/main/toolchains/patches/make-reproducible-bootstrap.patch) (Fabian Meumertzheim, [PR #817](https://github.com/bazel-contrib/rules_foreign_cc/pull/817), Nov 2021). When make 4.4 and 4.4.1 were added later ([PR #980](https://github.com/bazel-contrib/rules_foreign_cc/pull/980), [PR #1167](https://github.com/bazel-contrib/rules_foreign_cc/pull/1167)), the new `http_archive(...)` blocks were copied without the `patches=...` attribute. Upstream HEAD as of today still has this gap — only 4.3 is patched. The current default version is 4.4.1.

## How this PR addresses it

Apply a `single_version_override` patch against `rules_foreign_cc`'s `toolchains/built_toolchains.bzl` that adds `patch_cmds` to the 4.4.1 `gnumake_src` http_archive. The patch_cmds run two `sed` invocations during repo extraction, rewriting `-DLIBDIR=\"$(libdir)\"` etc. in `Makefile.in` to `-DLIBDIR=\".\"` — same convention as the existing 4.3 patch.

These paths are never consulted by make at runtime (foreign_cc always invokes make with explicit MAKEFLAGS), so pinning them is safe.

## Validation

Built `@@rules_foreign_cc+//toolchains/private:make_tool` twice with different `--output_base` directories (`/tmp/h-make/run{1,2}`):

```
sha256sum .../bin/make
18c675f5762048fedb8500609655770043325ea27d3c91005b5533be00187e6d  run1/.../bin/make
18c675f5762048fedb8500609655770043325ea27d3c91005b5533be00187e6d  run2/.../bin/make

strings -a .../bin/make | grep -E '/tmp/h-make|sandbox|execroot'
(zero matches)
```

Byte-identical. Without the patch the two binaries diverge on three literal sandbox-path strings (libdir/includedir/localedir).

## Followups

- File an upstream PR re-wiring the patch into rules_foreign_cc's 4.4 and 4.4.1 blocks (CORE-16315 has the diff ready). This local override can be dropped once that lands and we bump the rules_foreign_cc version.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none