### PR TITLE
bazel: investigate rpk GoLink cache miss in pgo-instrument config

### DIFF
--- a/bazel/noop.bzl
+++ b/bazel/noop.bzl
@@ -1,0 +1,1 @@
+# Intentionally empty - no-op file to trigger a CI build.


### PR DESCRIPTION
Draft PR to run a PGO CI build for diagnosing the rpk GoLink remote cache miss described in the PGO overnight build investigation.

The `pgo_profile` genrule always re-runs because `//src/go/rpk/cmd/rpk:rpk` re-links on every run under `--config=pgo-instrument`. This PR exists to trigger a PGO-enabled CI run (via `vtools_gitref=td-pgo-on-prs`) so we can observe whether:
1. The rpk action key is stable across independent runs (just needs a warm-up), or
2. There is a genuine non-hermeticity in the Go link step under pgo-instrument config.