### PR TITLE
bazel/stamp: override some status variables when non-full stamping to prevent cross-agent cache misses

### DIFF
--- a/bazel/stamp_vars.sh
+++ b/bazel/stamp_vars.sh
@@ -32,12 +32,26 @@ WORKSPACE_DIR="${SCRIPT_DIR}/.."
 git_tag=$(git -C "$WORKSPACE_DIR" describe --tags --always --abbrev=0 --match='v*')
 echo "STABLE_GIT_LATEST_TAG ${git_tag}"
 
-# For CI builds we don't want to use the commit hash as that prevents caching of binaries,
-# ducktape generally only needs the tag anyways, so the hash we omit for everything except
-# full release builds.
+# Override Bazel's hardwired BUILD_HOST/BUILD_USER builtins with constants so
+# that stamped action keys are stable across different CI agents. Without this,
+# every agent's hostname and username leak into stable-status.txt, causing
+# cache misses for any stamped target (e.g. rpk GoLink) even when source is
+# identical — which cascades to cache misses for pgo_profile.
+echo "BUILD_HOST fixed-stamp-host"
+echo "BUILD_USER fixed-stamp-user"
+
 if [[ $1 != "full" ]]; then
+  # Non-full stamps, means add some stamp stuff that changes less frequently
+  # E.g. for most CI builds we don't want to use the commit hash as that prevents caching of binaries,
+  # ducktape generally only needs the tag anyways, so the hash we omit for everything except
+  # full release builds.
   echo "STABLE_GIT_COMMIT 000000"
   echo "STABLE_GIT_TREE_DIRTY "
+
+  # also omit the build timestamp and formatted date, which would otherwise force
+  # each rpk build to produce a unique output binary as it consumes FORMATTED_DATE
+  echo "BUILD_TIMESTAMP 0"
+  echo "FORMATTED_DATE 1970-01-01"
   exit 0
 fi
 


### PR DESCRIPTION
Bazel unconditionally writes several variables into status files when
\`--stamp\` is used:

- `BUILD_HOST` / `BUILD_USER` → `stable-status.txt` (stable)
- `BUILD_TIMESTAMP` / `FORMATTED_DATE` → `volatile-status.txt` (volatile)

These variables cause stamped targets to miss the cache in different ways:

- **Stable variables** (`BUILD_HOST`, `BUILD_USER`): because Bazel hashes
  `stable-status.txt` into every stamped action's cache key, different CI
  agents produce different keys for identical source — triggering disk-cache
  and remote-cache misses.
- **Volatile variables** (`BUILD_TIMESTAMP`, `FORMATTED_DATE`): Bazel's
  local action cache treats `volatile-status.txt` as non-invalidating, but
  **remote caches** (including the S3-backed HTTP cache used here) hash *all*
  declared inputs, so `GoLink` always misses the remote cache even when the
  source is unchanged.

In practice both paths cause rpk's `GoLink` action to re-run on every
stamped build. That embeds a fresh `FORMATTED_DATE` into the rpk binary,
which changes its content digest, which invalidates `pgo_profile`'s action
key, causing `train_pgo` to re-run on every overnight build (≥160 s of
unnecessary work per run, confirmed in builds 84428–84432).

Fix: emit constant values for all four variables from `stamp_vars.sh` when
invoked in non-full mode (`--config=stamp`). The workspace_status_command
output takes precedence over Bazel's auto-detected values (confirmed via
[bazelbuild/bazel#10177](https://github.com/bazelbuild/bazel/issues/10177)).
The fix is deliberately scoped to `--config=stamp` only — `--config=stamp-full`
(used for nightly and release builds) still emits real hostnames and
timestamps in the shipped artifacts.

None of `BUILD_HOST`, `BUILD_USER`, `BUILD_TIMESTAMP`, or `FORMATTED_DATE`
is referenced anywhere in the codebase outside the rpk binary's Go embed
(`x_defs`), which is exactly the source of the cache churn we're fixing.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none