### PR TITLE
datalake: route iceberg aws_instance_metadata through STS when IRSA env is present

### DIFF
--- a/src/v/cloud_roles/aws_sts_refresh_impl.cc
+++ b/src/v/cloud_roles/aws_sts_refresh_impl.cc
@@ -26,17 +26,6 @@ static constexpr std::string_view response_node_credential_path
   = "AssumeRoleWithWebIdentityResponse.AssumeRoleWithWebIdentityResult."
     "Credentials";
 
-/// These variables injected by the AWS operator must be present on the redpanda
-/// pod to ensure we can get credentials from STS.
-/// ref:
-/// https://docs.amazonaws.cn/en_us/eks/latest/userguide/specify-service-account-role.html
-struct aws_injected_env_vars {
-    static constexpr std::string_view role_arn = "AWS_ROLE_ARN";
-
-    static constexpr std::string_view token_file_path
-      = "AWS_WEB_IDENTITY_TOKEN_FILE";
-};
-
 struct sts_params {
     static constexpr std::string_view role_session_name = "redpanda_si";
 

--- a/src/v/cloud_roles/aws_sts_refresh_impl.h
+++ b/src/v/cloud_roles/aws_sts_refresh_impl.h
@@ -14,6 +14,17 @@
 
 namespace cloud_roles {
 
+/// These variables injected by the AWS operator must be present on the redpanda
+/// pod to ensure we can get credentials from STS.
+/// ref:
+/// https://docs.amazonaws.cn/en_us/eks/latest/userguide/specify-service-account-role.html
+struct aws_injected_env_vars {
+    static constexpr std::string_view role_arn = "AWS_ROLE_ARN";
+
+    static constexpr std::string_view token_file_path
+      = "AWS_WEB_IDENTITY_TOKEN_FILE";
+};
+
 class aws_sts_refresh_impl final : public refresh_credentials::impl {
 public:
     static constexpr std::string_view default_host = "sts.amazonaws.com";

--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -132,6 +132,7 @@ redpanda_cc_library(
         "//src/v/cloud_storage_clients",
         "//src/v/config",
         "//src/v/hashing:secure",
+        "//src/v/model",
         "//src/v/net",
         "@boost//:beast",
         "@seastar",

--- a/src/v/datalake/credential_manager.cc
+++ b/src/v/datalake/credential_manager.cc
@@ -10,11 +10,14 @@
 
 #include "datalake/credential_manager.h"
 
+#include "cloud_roles/aws_sts_refresh_impl.h"
 #include "cloud_roles/types.h"
 #include "cloud_storage_clients/configuration.h"
 #include "config/configuration.h"
 #include "datalake/logger.h"
 #include "hashing/secure.h"
+
+#include <cstdlib>
 
 namespace datalake {
 
@@ -69,17 +72,12 @@ create_gcp_configuration(const config::configuration&) {
     return cloud_storage_clients::client_configuration{s3_config};
 }
 
-model::cloud_credentials_source
-get_credentials_source(const config::configuration& cfg) {
-    if (
-      cfg.iceberg_rest_catalog_authentication_mode()
-      == config::datalake_catalog_auth_mode::gcp) {
-        return model::cloud_credentials_source::gcp_instance_metadata;
-    }
-
-    return cfg.iceberg_rest_catalog_aws_credentials_source().has_value()
-             ? cfg.iceberg_rest_catalog_aws_credentials_source().value()
-             : cfg.cloud_storage_credentials_source();
+bool irsa_env_present() {
+    return std::getenv(cloud_roles::aws_injected_env_vars::role_arn.data())
+             != nullptr
+           && std::getenv(
+                cloud_roles::aws_injected_env_vars::token_file_path.data())
+                != nullptr;
 }
 
 // Build the client configuration for refreshing credentials.
@@ -114,6 +112,33 @@ ss::sstring compute_sha256_hex(const iobuf& data) {
 }
 
 } // anonymous namespace
+
+model::cloud_credentials_source
+resolve_credentials_source(const config::configuration& cfg) {
+    if (
+      cfg.iceberg_rest_catalog_authentication_mode()
+      == config::datalake_catalog_auth_mode::gcp) {
+        return model::cloud_credentials_source::gcp_instance_metadata;
+    }
+
+    auto source = cfg.iceberg_rest_catalog_aws_credentials_source().has_value()
+                    ? cfg.iceberg_rest_catalog_aws_credentials_source().value()
+                    : cfg.cloud_storage_credentials_source();
+
+    if (
+      source == model::cloud_credentials_source::aws_instance_metadata
+      && irsa_env_present()) {
+        vlog(
+          datalake_log.info,
+          "IRSA env vars detected ({}, {}); resolving iceberg credentials "
+          "source aws_instance_metadata to sts",
+          cloud_roles::aws_injected_env_vars::role_arn,
+          cloud_roles::aws_injected_env_vars::token_file_path);
+        return model::cloud_credentials_source::sts;
+    }
+
+    return source;
+}
 
 credential_manager::credential_manager() = default;
 
@@ -233,17 +258,18 @@ void credential_manager::start_auth_refresh_if_needed() {
         return;
     }
 
+    auto credentials_source = resolve_credentials_source(cfg);
     auto config_source
       = cloud_storage_clients::build_refresh_credentials_source(
         *client_config,
-        get_credentials_source(cfg),
+        credentials_source,
         cfg.iceberg_rest_catalog_credentials_host());
 
     auth_refresh_bg_op_.emplace(
       datalake_log,
       gate_,
       auth_refresh_as_,
-      get_credentials_source(cfg),
+      credentials_source,
       std::move(config_source));
 
     auth_refresh_bg_op_->maybe_start_auth_refresh_op(

--- a/src/v/datalake/credential_manager.h
+++ b/src/v/datalake/credential_manager.h
@@ -13,6 +13,8 @@
 #include "cloud_roles/apply_credentials.h"
 #include "cloud_roles/auth_refresh_bg_op.h"
 #include "cloud_roles/types.h"
+#include "config/configuration.h"
+#include "model/metadata.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/condition-variable.hh>
@@ -23,6 +25,21 @@
 #include <boost/beast/http/message.hpp>
 
 namespace datalake {
+
+/// Resolves the credentials source for the iceberg REST catalog from
+/// configuration.
+///
+/// In addition to the property fallback chain
+/// (`iceberg_rest_catalog_aws_credentials_source` →
+/// `cloud_storage_credentials_source`), this also implements IRSA
+/// auto-detection: when the resolved source is `aws_instance_metadata` and
+/// the AWS-injected IRSA env vars (`AWS_ROLE_ARN` and
+/// `AWS_WEB_IDENTITY_TOKEN_FILE`) are both present, the source is overridden
+/// to `sts`. This mirrors the AWS SDK default credential provider chain and
+/// unblocks BYOC EKS pods where the Glue policy is attached to the IRSA role
+/// rather than the EC2 node role.
+model::cloud_credentials_source
+resolve_credentials_source(const config::configuration& cfg);
 
 // Service responsible for managing credential refresh for datalake components.
 // Provides shared credential management for both datalake_manager and

--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -440,6 +440,7 @@ redpanda_cc_gtest(
         "//src/v/datalake:credential_manager",
         "//src/v/hashing:secure",
         "//src/v/http",
+        "//src/v/model",
         "//src/v/test_utils:gtest",
         "//src/v/test_utils:scoped_config",
         "@boost//:beast",

--- a/src/v/datalake/tests/credential_manager_test.cc
+++ b/src/v/datalake/tests/credential_manager_test.cc
@@ -9,16 +9,19 @@
  */
 
 #include "cloud_roles/apply_credentials.h"
+#include "cloud_roles/aws_sts_refresh_impl.h"
 #include "cloud_roles/types.h"
 #include "config/types.h"
 #include "datalake/credential_manager.h"
 #include "hashing/secure.h"
 #include "http/client.h"
+#include "model/metadata.h"
 #include "test_utils/scoped_config.h"
 
 #include <boost/beast/http/message.hpp>
 #include <gtest/gtest.h>
 
+#include <cstdlib>
 #include <string_view>
 
 namespace datalake {
@@ -325,6 +328,135 @@ TEST_F(CredentialManagerTest, GCP) {
     // GCP mode should not set the x-amz-content-sha256 header (that's only for
     // AWS)
     EXPECT_FALSE(req.count("x-amz-content-sha256"));
+}
+
+class ResolveCredentialsSourceTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        unsetenv(cloud_roles::aws_injected_env_vars::role_arn.data());
+        unsetenv(cloud_roles::aws_injected_env_vars::token_file_path.data());
+    }
+
+    void TearDown() override {
+        unsetenv(cloud_roles::aws_injected_env_vars::role_arn.data());
+        unsetenv(cloud_roles::aws_injected_env_vars::token_file_path.data());
+    }
+
+    static void set_role_arn() {
+        setenv(
+          cloud_roles::aws_injected_env_vars::role_arn.data(),
+          "arn:aws:iam::123:role/test",
+          1);
+    }
+
+    static void set_token_file() {
+        setenv(
+          cloud_roles::aws_injected_env_vars::token_file_path.data(),
+          "/var/run/secrets/eks.amazonaws.com/serviceaccount/token",
+          1);
+    }
+};
+
+TEST_F(ResolveCredentialsSourceTest, IrsaEnvOverridesAwsInstanceMetadata) {
+    scoped_config cfg;
+    cfg.get("iceberg_rest_catalog_authentication_mode")
+      .set_value(config::datalake_catalog_auth_mode::aws_sigv4);
+    cfg.get("iceberg_rest_catalog_credentials_source")
+      .set_value(
+        std::make_optional(
+          model::cloud_credentials_source::aws_instance_metadata));
+    set_role_arn();
+    set_token_file();
+
+    EXPECT_EQ(
+      resolve_credentials_source(config::shard_local_cfg()),
+      model::cloud_credentials_source::sts);
+}
+
+TEST_F(ResolveCredentialsSourceTest, AwsInstanceMetadataWithoutEnvStays) {
+    scoped_config cfg;
+    cfg.get("iceberg_rest_catalog_authentication_mode")
+      .set_value(config::datalake_catalog_auth_mode::aws_sigv4);
+    cfg.get("iceberg_rest_catalog_credentials_source")
+      .set_value(
+        std::make_optional(
+          model::cloud_credentials_source::aws_instance_metadata));
+
+    EXPECT_EQ(
+      resolve_credentials_source(config::shard_local_cfg()),
+      model::cloud_credentials_source::aws_instance_metadata);
+}
+
+TEST_F(ResolveCredentialsSourceTest, OnlyRoleArnDoesNotOverride) {
+    scoped_config cfg;
+    cfg.get("iceberg_rest_catalog_authentication_mode")
+      .set_value(config::datalake_catalog_auth_mode::aws_sigv4);
+    cfg.get("iceberg_rest_catalog_credentials_source")
+      .set_value(
+        std::make_optional(
+          model::cloud_credentials_source::aws_instance_metadata));
+    set_role_arn();
+
+    EXPECT_EQ(
+      resolve_credentials_source(config::shard_local_cfg()),
+      model::cloud_credentials_source::aws_instance_metadata);
+}
+
+TEST_F(ResolveCredentialsSourceTest, OnlyTokenFileDoesNotOverride) {
+    scoped_config cfg;
+    cfg.get("iceberg_rest_catalog_authentication_mode")
+      .set_value(config::datalake_catalog_auth_mode::aws_sigv4);
+    cfg.get("iceberg_rest_catalog_credentials_source")
+      .set_value(
+        std::make_optional(
+          model::cloud_credentials_source::aws_instance_metadata));
+    set_token_file();
+
+    EXPECT_EQ(
+      resolve_credentials_source(config::shard_local_cfg()),
+      model::cloud_credentials_source::aws_instance_metadata);
+}
+
+TEST_F(ResolveCredentialsSourceTest, ExplicitStsUnchanged) {
+    scoped_config cfg;
+    cfg.get("iceberg_rest_catalog_authentication_mode")
+      .set_value(config::datalake_catalog_auth_mode::aws_sigv4);
+    cfg.get("iceberg_rest_catalog_credentials_source")
+      .set_value(std::make_optional(model::cloud_credentials_source::sts));
+    set_role_arn();
+    set_token_file();
+
+    EXPECT_EQ(
+      resolve_credentials_source(config::shard_local_cfg()),
+      model::cloud_credentials_source::sts);
+}
+
+TEST_F(ResolveCredentialsSourceTest, GcpAuthModeReturnsGcpInstanceMetadata) {
+    scoped_config cfg;
+    cfg.get("iceberg_rest_catalog_authentication_mode")
+      .set_value(config::datalake_catalog_auth_mode::gcp);
+    // IRSA env present should not affect the GCP path.
+    set_role_arn();
+    set_token_file();
+
+    EXPECT_EQ(
+      resolve_credentials_source(config::shard_local_cfg()),
+      model::cloud_credentials_source::gcp_instance_metadata);
+}
+
+TEST_F(ResolveCredentialsSourceTest, FallbackToCloudStorageWithIrsaOverride) {
+    scoped_config cfg;
+    cfg.get("iceberg_rest_catalog_authentication_mode")
+      .set_value(config::datalake_catalog_auth_mode::aws_sigv4);
+    // iceberg-specific source is unset; fall back to cloud_storage source.
+    cfg.get("cloud_storage_credentials_source")
+      .set_value(model::cloud_credentials_source::aws_instance_metadata);
+    set_role_arn();
+    set_token_file();
+
+    EXPECT_EQ(
+      resolve_credentials_source(config::shard_local_cfg()),
+      model::cloud_credentials_source::sts);
 }
 
 } // namespace datalake


### PR DESCRIPTION
## Summary

`iceberg_rest_catalog_credentials_source=aws_instance_metadata` currently always fetches credentials from the EC2 Instance Metadata Service (IMDS, `169.254.169.254`). On EKS, pods are typically configured with **IRSA (IAM Roles for Service Accounts)**: AWS injects `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` into the container, and the pod is expected to call STS `AssumeRoleWithWebIdentity` to obtain credentials for the pod's IAM role. IMDS, by contrast, returns the credentials of the underlying EC2 node's role — a different identity.

This matters because users typically grant permissions to the pod role (via IRSA), not the node role. With the current behavior the broker authenticates as the node and the operation fails with access-denied errors, even though the user followed the documented configuration.

The AWS SDKs handle this transparently via the [default credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html): when the IRSA environment variables are present, the SDK uses STS web-identity; otherwise it falls back to IMDS. This PR makes `aws_instance_metadata` behave the same way.

**What changes:** when the resolved iceberg credentials source is `aws_instance_metadata` and both `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` are set at refresh-start time, the source is overridden to `sts` and the existing `aws_sts_refresh_impl` (`AssumeRoleWithWebIdentity`) is used. No new providers are introduced — both the IMDS and STS refresh implementations already exist and are exercised in production today.

Scope is intentionally limited:

- Iceberg-only path; no other credential sources are touched.
- No new configuration knobs; one info log line is emitted when the override fires.

Commits:

- `cloud_roles: expose IRSA env var names in header` — moves the existing `aws_injected_env_vars` constants from the .cc to the .h so the iceberg path can reference them. Pure refactor.
- `datalake: auto-detect IRSA env for aws_instance_metadata` — the behavior change, plus lifting `get_credentials_source` to a public `resolve_credentials_source` helper so the branches are unit-testable.
- `datalake/tests: cover IRSA env-based source resolution` — new gtest cases for each branch (env present, env absent, only one of two env vars, explicit `sts`, GCP auth mode, fallback path).

## Test plan

- [ ] `bazel test //src/v/datalake/tests:credential_manager_test` passes (new and existing cases).
- [ ] `bazel test //src/v/cloud_roles/tests:categorization_tests //src/v/cloud_roles/tests:fetch_credentials_tests` pass (regression check on the existing `sts` source path).
- [ ] `bazel build //src/v/datalake/... //src/v/cloud_roles/...` clean.
- [ ] `bazel run //tools:clang_format -- --check` clean on the changed files.
- [ ] Manual on an EKS cluster: with `AWS_ROLE_ARN` / `AWS_WEB_IDENTITY_TOKEN_FILE` set and `iceberg_rest_catalog_credentials_source=aws_instance_metadata`, broker logs `created credentials refresh implementation based on credentials source sts: aws_sts_refresh_impl{...}` and iceberg catalog operations succeed.
- [ ] Manual negative branch: with both env vars unset, broker falls back to `aws_refresh_impl{address:{host: 169.254.169.254, ...}}`.

## Release notes

### Improvements

- Iceberg REST catalog: `iceberg_rest_catalog_credentials_source=aws_instance_metadata` now matches the AWS SDK default credential provider chain on EKS — when `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` are injected into the pod (IRSA), the broker authenticates via STS `AssumeRoleWithWebIdentity` instead of unconditionally using IMDS. Previously the broker would obtain the EC2 node role identity, which is typically not the identity granted permissions on the catalog.
