### PR TITLE
`misc`: revamp some exception handling in coroutines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,16 @@ lambda object, decoupling capture lifetime from the lambda's lifetime.
 This is distinct from the recursive-lambda use case—here this auto is required
 for memory safety in coroutines, not self-reference.
 
+### Exception handling
+
+- Read the "Exceptions in coroutines" section within [tutorial.md](external/+non_module_dependencies+seastar/doc/tutorial.md)
+  to best understand how exceptions should be handled in Redpanda.
+- `throw` and `std::rethrow_exception()` may have an effect on performance, especially in hot paths.
+  There are several `seastar` utilities that should be preferred to explicitly throwing exceptions.
+  Namely, `ss::coroutine::try_future()`, `ss::coroutine::as_future()`, `ss::coroutine::return_exception()`,
+  and `ss::coroutine::return_exception_ptr()`. This is only a brief summary of the content in the tutorial above,
+  which must be read to fully understand exception handling in Redpanda.
+
 ### C++ coding style
 
 - Use snake_case for identifiers. Use CamelCase for concepts.

--- a/src/v/cloud_storage/async_manifest_materializer.cc
+++ b/src/v/cloud_storage/async_manifest_materializer.cc
@@ -16,6 +16,7 @@
 #include "ssx/future-util.h"
 
 #include <seastar/core/fstream.hh>
+#include <seastar/coroutine/exception.hh>
 
 namespace cloud_storage {
 
@@ -308,7 +309,8 @@ async_manifest_materializer::do_materialize_manifest(
             }
             co_await res->body.close();
             if (update_err) {
-                std::rethrow_exception(update_err);
+                co_await ss::coroutine::return_exception_ptr(
+                  std::move(update_err));
             }
         } break;
         }

--- a/src/v/cloud_storage/async_manifest_view.cc
+++ b/src/v/cloud_storage/async_manifest_view.cc
@@ -25,6 +25,7 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/loop.hh>
+#include <seastar/coroutine/exception.hh>
 
 #include <exception>
 #include <functional>
@@ -123,7 +124,8 @@ ss::future<> async_manifest_view_cursor::maybe_sync_manifest() {
     if (manifest_needs_sync()) {
         auto res = co_await seek(_stm_start_offset.value());
         if (res.has_failure()) {
-            throw std::system_error(res.error());
+            co_await ss::coroutine::return_exception(
+              std::system_error(res.error()));
         }
         if (!res.value()) {
             vlog(_view._ctxlog.error, "Can't sync manifest");
@@ -290,7 +292,8 @@ async_manifest_view_cursor::next() {
 ss::future<ss::stop_iteration> async_manifest_view_cursor::next_iter() {
     auto res = co_await next();
     if (res.has_failure()) {
-        throw std::system_error(res.error());
+        co_await ss::coroutine::return_exception(
+          std::system_error(res.error()));
     }
     co_return res.value() == eof::yes ? ss::stop_iteration::yes
                                       : ss::stop_iteration::no;

--- a/src/v/cloud_storage/inventory/utils.cc
+++ b/src/v/cloud_storage/inventory/utils.cc
@@ -20,6 +20,7 @@
 #include <seastar/core/fstream.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
 
 namespace {
 
@@ -46,7 +47,7 @@ write_hashes_to_file(ss::file& f, chunked_vector<uint64_t> hashes) {
       write_hashes_to_file(stream, std::move(hashes)));
     co_await stream.close();
     if (res.failed()) {
-        std::rethrow_exception(res.get_exception());
+        co_await ss::coroutine::return_exception_ptr(res.get_exception());
     }
 }
 

--- a/src/v/cloud_storage/offset_translation_layer.cc
+++ b/src/v/cloud_storage/offset_translation_layer.cc
@@ -15,6 +15,8 @@
 #include "storage/parser.h"
 #include "utils/retry_chain_node.h"
 
+#include <seastar/coroutine/exception.hh>
+
 namespace cloud_storage {
 
 ss::future<stream_stats> offset_translator::copy_stream(
@@ -39,7 +41,8 @@ ss::future<stream_stats> offset_translator::copy_stream(
     auto len = co_await storage::transform_stream(
       std::move(src), std::move(dst), pred, _as);
     if (len.has_error()) {
-        throw std::system_error(len.error());
+        co_await ss::coroutine::return_exception(
+          std::system_error(len.error()));
     }
     co_return stream_stats{
       .min_offset = min_offset,

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -1911,7 +1911,7 @@ ss::future<> partition_manifest::update(
     }
     co_await is.close();
     if (e_ptr) {
-        std::rethrow_exception(e_ptr);
+        co_await ss::coroutine::return_exception_ptr(std::move(e_ptr));
     }
 
     switch (serialization_format) {

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -34,6 +34,7 @@
 #include <seastar/core/loop.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/coroutine/exception.hh>
 
 #include <boost/range/adaptor/reversed.hpp>
 
@@ -510,7 +511,8 @@ public:
             co_await set_end_of_stream();
         }
         if (unknown_exception_ptr) {
-            std::rethrow_exception(unknown_exception_ptr);
+            co_await ss::coroutine::return_exception_ptr(
+              std::move(unknown_exception_ptr));
         }
 
         vlog(
@@ -1043,10 +1045,10 @@ ss::future<std::optional<kafka::offset>>
 remote_partition::get_term_last_offset(model::term_id term) const {
     const auto res = co_await _manifest_view->get_term_last_offset(term);
     if (res.has_error()) {
-        throw std::system_error(res.error());
-    } else {
-        co_return res.value();
+        co_await ss::coroutine::return_exception(
+          std::system_error(res.error()));
     }
+    co_return res.value();
 }
 
 ss::future<std::vector<model::tx_range>>
@@ -1095,15 +1097,17 @@ remote_partition::aborted_transactions(offset_range offsets) {
         auto cur_res = co_await _manifest_view->get_cursor(offsets.begin);
         if (cur_res.has_failure()) {
             if (cur_res.error() == error_outcome::shutting_down) {
-                throw std::runtime_error("Async manifest view shutting down");
+                co_await ss::coroutine::return_exception(
+                  std::runtime_error("Async manifest view shutting down"));
             }
 
             vlog(
               _ctxlog.error,
               "Failed to traverse archive part of the log: {}",
               cur_res.error());
-            throw std::runtime_error(fmt_with_ctx(
-              fmt::format, "Failed to get the cursor {}", cur_res.error()));
+            co_await ss::coroutine::return_exception(
+              std::runtime_error(fmt_with_ctx(
+                fmt::format, "Failed to get the cursor {}", cur_res.error())));
         }
         auto cursor = std::move(cur_res.value());
         co_await for_each_manifest(

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -414,7 +414,7 @@ ss::future<uint64_t> remote_segment::put_segment_in_cache_and_create_index(
           _ctxlog.warn,
           "Failed to write a segment file to cache, error: {}",
           put_exception);
-        std::rethrow_exception(put_exception);
+        co_await ss::coroutine::return_exception_ptr(std::move(put_exception));
     }
     if (index_prepared) {
         auto index_reservation = co_await _cache.reserve_space(
@@ -495,7 +495,8 @@ ss::future<> remote_segment::do_hydrate_segment() {
           "invoked",
           _path,
           _wait_list.size());
-        throw download_exception(res, _path);
+        co_await ss::coroutine::return_exception(
+          download_exception(res, _path));
     }
 }
 
@@ -516,7 +517,8 @@ ss::future<> remote_segment::do_hydrate_index() {
       _bucket, remote_segment_path{_index_path}, ix, local_rtc);
 
     if (result != download_result::success) {
-        throw download_exception(result, _index_path);
+        co_await ss::coroutine::return_exception(
+          download_exception(result, _index_path));
     }
 
     _index = std::move(ix);
@@ -563,7 +565,8 @@ ss::future<> remote_segment::do_hydrate_txrange() {
 
         if (
           res != download_result::success && res != download_result::notfound) {
-            throw download_exception(res, _path);
+            co_await ss::coroutine::return_exception(
+              download_exception(res, _path));
         }
 
         auto [stream, size] = co_await manifest.serialize();

--- a/src/v/cloud_storage/segment_chunk_data_source.cc
+++ b/src/v/cloud_storage/segment_chunk_data_source.cc
@@ -13,6 +13,8 @@
 
 #include "cloud_storage/remote_segment.h"
 
+#include <seastar/coroutine/exception.hh>
+
 namespace cloud_storage {
 
 chunk_data_source_impl::chunk_data_source_impl(
@@ -119,7 +121,7 @@ ss::future<> chunk_data_source_impl::load_stream_for_chunk(
           "Closed stream after error {} while hydrating chunk start {}",
           eptr,
           chunk_start);
-        std::rethrow_exception(eptr);
+        co_await ss::coroutine::return_exception_ptr(std::move(eptr));
     }
 
     // Decrement the required_by_readers_in_future count by 1, we have acquired

--- a/src/v/cloud_storage_clients/multipart_upload.cc
+++ b/src/v/cloud_storage_clients/multipart_upload.cc
@@ -15,6 +15,7 @@
 #include "ssx/future-util.h"
 
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
 
 namespace cloud_storage_clients {
 
@@ -140,7 +141,7 @@ ss::future<> multipart_upload::complete() {
               "Multipart upload final part failed, aborting: {}",
               ex);
             co_await abort_on_error();
-            std::rethrow_exception(ex);
+            co_await ss::coroutine::return_exception_ptr(std::move(ex));
         }
     }
     // Complete the multipart upload
@@ -159,7 +160,7 @@ ss::future<> multipart_upload::complete() {
           "Multipart upload completion failed, aborting: {}",
           ex);
         co_await abort_on_error();
-        std::rethrow_exception(ex);
+        co_await ss::coroutine::return_exception_ptr(std::move(ex));
     }
 }
 

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -46,6 +46,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
 
 #include <chrono>
 #include <expected>
@@ -872,7 +873,7 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
               ntp(),
               e);
         }
-        std::rethrow_exception(e);
+        co_await ss::coroutine::return_exception_ptr(std::move(e));
     }
     auto fence = std::move(fence_fut.get());
     if (!fence.has_value()) {
@@ -1306,7 +1307,7 @@ ss::future<result<raft::replicate_result>> frontend::replicate_at_offset(
               ntp(),
               e);
         }
-        std::rethrow_exception(e);
+        co_await ss::coroutine::return_exception_ptr(std::move(e));
     }
     auto fence = std::move(fence_fut.get());
     if (!fence.has_value()) {

--- a/src/v/cloud_topics/level_one/common/object.cc
+++ b/src/v/cloud_topics/level_one/common/object.cc
@@ -21,6 +21,7 @@
 #include <seastar/core/fstream.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
 #include <fmt/format.h>
@@ -287,11 +288,12 @@ footer footer::copy() const {
 
 ss::future<std::variant<footer, size_t>> footer::read(iobuf buf) {
     if (buf.size_bytes() < sizeof(uint32_t)) {
-        throw std::runtime_error(
-          fmt::format(
-            "expected at least {} bytes in footer, got: {}",
-            sizeof(uint32_t),
-            buf.size_bytes()));
+        co_await ss::coroutine::return_exception(
+          std::runtime_error(
+            fmt::format(
+              "expected at least {} bytes in footer, got: {}",
+              sizeof(uint32_t),
+              buf.size_bytes())));
     }
     iobuf_const_parser parser(buf);
     auto footer_size
@@ -302,18 +304,21 @@ ss::future<std::variant<footer, size_t>> footer::read(iobuf buf) {
         auto dt = static_cast<data_type>(
           p.consume_type<std::underlying_type_t<data_type>>());
         if (dt != data_type::footer) {
-            throw std::runtime_error(
-              fmt::format(
-                "expected footer data type, got: {}", std::to_underlying(dt)));
+            co_await ss::coroutine::return_exception(
+              std::runtime_error(
+                fmt::format(
+                  "expected footer data type, got: {}",
+                  std::to_underlying(dt))));
         }
         auto size = p.consume_type<uint32_t>();
         if (size != p.bytes_left()) {
-            throw std::runtime_error(
-              fmt::format(
-                "expected footer size to match the remaining bytes, "
-                "got: {}, expected: {}",
-                p.bytes_left(),
-                size));
+            co_await ss::coroutine::return_exception(
+              std::runtime_error(
+                fmt::format(
+                  "expected footer size to match the remaining bytes, "
+                  "got: {}, expected: {}",
+                  p.bytes_left(),
+                  size)));
         }
         co_return co_await serde::read_async<footer>(p);
     }
@@ -489,11 +494,12 @@ public:
             co_return *_peeked;
         }
         if (dt_buf.size() != sizeof(data_type)) {
-            throw std::runtime_error(
-              fmt::format(
-                "expected {} bytes for data type, got: {}",
-                sizeof(data_type),
-                dt_buf.size()));
+            co_await ss::coroutine::return_exception(
+              std::runtime_error(
+                fmt::format(
+                  "expected {} bytes for data type, got: {}",
+                  sizeof(data_type),
+                  dt_buf.size())));
         }
         auto dt = from_bytes<data_type>(dt_buf.get());
         switch (dt) {
@@ -509,9 +515,10 @@ public:
             _peeked = footer_tag{};
             co_return *_peeked;
         }
-        throw std::runtime_error(
-          fmt::format(
-            "unknown data type in object: {}", std::to_underlying(dt)));
+        co_await ss::coroutine::return_exception(
+          std::runtime_error(
+            fmt::format(
+              "unknown data type in object: {}", std::to_underlying(dt))));
     }
 
     ss::future<result> read_next() final {
@@ -661,10 +668,13 @@ close_all_streams(combine_objects_parameters parameters, bool quiet) {
     if (fut.failed()) {
         ex = fut.get_exception();
     }
-    if (ex && !quiet) {
-        std::rethrow_exception(ex);
+    if (ex) {
+        if (quiet) {
+            std::ignore = ex;
+        } else {
+            co_await ss::coroutine::return_exception_ptr(std::move(ex));
+        }
     }
-    std::ignore = ex;
 }
 
 } // namespace
@@ -692,7 +702,7 @@ combine_objects(combine_objects_parameters parameters) {
             co_await close_all_streams(
               std::move(parameters),
               /*quiet=*/true);
-            std::rethrow_exception(ex);
+            co_return ss::coroutine::exception(std::move(ex));
         }
         written += n;
     }
@@ -703,7 +713,7 @@ combine_objects(combine_objects_parameters parameters) {
     if (footer_write_fut.failed()) {
         auto ex = footer_write_fut.get_exception();
         co_await close_all_streams(std::move(parameters), /*quiet=*/true);
-        std::rethrow_exception(ex);
+        co_return ss::coroutine::exception(std::move(ex));
     }
     auto footer_size = footer_write_fut.get();
     auto footer_size_data = as_bytes<uint32_t>(footer_size);
@@ -712,7 +722,7 @@ combine_objects(combine_objects_parameters parameters) {
     if (fut.failed()) {
         auto ex = fut.get_exception();
         co_await close_all_streams(std::move(parameters), /*quiet=*/true);
-        std::rethrow_exception(ex);
+        co_return ss::coroutine::exception(std::move(ex));
     }
     co_await close_all_streams(std::move(parameters), /*quiet=*/false);
     co_return object_builder::object_info{

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -17,6 +17,7 @@
 #include "utils/retry_chain_node.h"
 
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
 
 #include <exception>
 #include <utility>
@@ -455,10 +456,11 @@ level_one_log_reader_impl::materialize_batches_from_object_offset(
           object.oid,
           offset,
           reader_result.error());
-        throw std::runtime_error(_log.format(
-          "Failed to open stream for L1 object {}: {}",
-          object.oid,
-          reader_result.error()));
+        co_await ss::coroutine::return_exception(
+          std::runtime_error(_log.format(
+            "Failed to open stream for L1 object {}: {}",
+            object.oid,
+            reader_result.error())));
     }
 
     // _current_stream is now populated by open_reader_at.
@@ -468,7 +470,7 @@ level_one_log_reader_impl::materialize_batches_from_object_offset(
         auto ex = read_fut.get_exception();
         vlog(_log.error, "Exception reading L1 object {}: {}", object.oid, ex);
         co_await close_current_stream();
-        std::rethrow_exception(ex);
+        co_await ss::coroutine::return_exception_ptr(std::move(ex));
     }
 
     auto batches = read_fut.get();

--- a/src/v/cloud_topics/level_one/metastore/lsm/replicated_persistence.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/replicated_persistence.cc
@@ -20,6 +20,8 @@
 #include "lsm/proto/manifest.proto.h"
 #include "model/batch_builder.h"
 
+#include <seastar/coroutine/exception.hh>
+
 namespace cloud_topics::l1 {
 
 namespace {
@@ -43,33 +45,39 @@ public:
             using enum stm::errc;
             switch (term_result.error()) {
             case shutting_down:
-                throw lsm::abort_requested_exception(
-                  "shutting down while syncing STM when loading manifest");
+                co_await ss::coroutine::return_exception(
+                  lsm::abort_requested_exception(
+                    "shutting down while syncing STM when loading manifest"));
+                break;
             case not_leader:
             case raft_error:
-                throw lsm::io_error_exception(
-                  "failed to sync STM when loading manifest: {}",
-                  term_result.error());
+                co_await ss::coroutine::return_exception(
+                  lsm::io_error_exception(
+                    "failed to sync STM when loading manifest: {}",
+                    term_result.error()));
+                break;
             }
         }
         if (_stm->state().domain_uuid != _expected_domain_uuid) {
             // Caller needs to rebuild the metadata persistence with the
             // appropriate prefix.
-            throw lsm::io_error_exception(
-              "Domain UUID has changed, likely due to domain recovery, "
-              "expected {}, got {}",
-              _expected_domain_uuid,
-              _stm->state().domain_uuid);
+            co_await ss::coroutine::return_exception(
+              lsm::io_error_exception(
+                "Domain UUID has changed, likely due to domain recovery, "
+                "expected {}, got {}",
+                _expected_domain_uuid,
+                _stm->state().domain_uuid));
         }
         auto term = term_result.value();
         auto stm_epoch = _stm->state().to_epoch(term);
         if (stm_epoch > max_epoch) {
             // Callers are expected to have opened the database with an epoch
             // at or higher than what is in the STM.
-            throw lsm::io_error_exception(
-              "Can't load manifest above current epoch {}, STM epoch: {}",
-              max_epoch(),
-              stm_epoch);
+            co_await ss::coroutine::return_exception(
+              lsm::io_error_exception(
+                "Can't load manifest above current epoch {}, STM epoch: {}",
+                max_epoch(),
+                stm_epoch));
         }
         if (!_stm->state().persisted_manifest.has_value()) {
             // There is no persisted manifest.
@@ -96,8 +104,9 @@ public:
         auto update_res = persist_manifest_update::build(
           _stm->state(), _expected_domain_uuid, std::move(serialized_man));
         if (!update_res.has_value()) {
-            throw lsm::io_error_exception(
-              "Invalid persist_manifest update: {}", update_res.error());
+            co_await ss::coroutine::return_exception(
+              lsm::io_error_exception(
+                "Invalid persist_manifest update: {}", update_res.error()));
         }
         model::batch_builder builder;
         builder.set_batch_type(model::record_batch_type::l1_stm);

--- a/src/v/cloud_topics/level_one/metastore/lsm/state.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state.cc
@@ -19,6 +19,7 @@
 #include "serde/rw/vector.h"
 
 #include <seastar/core/future.hh>
+#include <seastar/coroutine/exception.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
 namespace cloud_topics::l1 {
@@ -39,10 +40,11 @@ std::deque<volatile_row> share_rows(std::deque<volatile_row>& rows) {
 template<typename Vec>
 ss::future<> write_vector_async(iobuf& out, Vec t) {
     if (unlikely(t.size() > std::numeric_limits<serde::serde_size_t>::max())) {
-        throw serde::serde_exception(fmt_with_ctx(
-          ssx::sformat,
-          "serde: vector size {} exceeds serde_size_t",
-          t.size()));
+        co_await ss::coroutine::return_exception(
+          serde::serde_exception(fmt_with_ctx(
+            ssx::sformat,
+            "serde: vector size {} exceeds serde_size_t",
+            t.size())));
     }
     serde::write(out, static_cast<serde::serde_size_t>(t.size()));
     for (auto& el : t) {

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -21,6 +21,7 @@
 #include "model/timeout_clock.h"
 #include "ssx/future-util.h"
 
+#include <seastar/coroutine/exception.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
 #include <chrono>
@@ -171,12 +172,13 @@ level_zero_log_reader_impl::read_some(
             if (_bytes_consumed >= _config.min_bytes) {
                 co_return model::record_batch_reader::storage_t{};
             }
-            throw ss::timed_out_error();
+            co_await ss::coroutine::return_exception(ss::timed_out_error());
         }
-        throw std::runtime_error(fmt_with_ctx(
-          fmt::format,
-          "Reader experienced unhandled error: {}",
-          maybe_batches.error()));
+        co_await ss::coroutine::return_exception(
+          std::runtime_error(fmt_with_ctx(
+            fmt::format,
+            "Reader experienced unhandled error: {}",
+            maybe_batches.error())));
     }
 
     auto batches = std::move(maybe_batches).value();
@@ -404,27 +406,30 @@ level_zero_log_reader_impl::materialize_batches(
         if (!mat_res.has_value()) {
             if (mat_res.error() == errc::shutting_down) {
                 vlog(_log.debug, "Materialize aborted due to shutdown");
-                throw ss::abort_requested_exception();
+                co_await ss::coroutine::return_exception(
+                  ss::abort_requested_exception());
             }
             if (mat_res.error() == errc::timeout) {
                 vlog(_log.debug, "Materialize aborted due to timeout");
                 co_return std::unexpected(errc::timeout);
             }
-            throw std::runtime_error(fmt_with_ctx(
-              fmt::format,
-              "Failed to materialize batches from the cloud storage: {}",
-              mat_res.error().message()));
+            co_await ss::coroutine::return_exception(
+              std::runtime_error(fmt_with_ctx(
+                fmt::format,
+                "Failed to materialize batches from the cloud storage: {}",
+                mat_res.error().message())));
         }
         batches = std::move(mat_res.value());
         auto count_ok = bool(_config.allow_mat_failure)
                           ? batches.size() <= materialize_count
                           : batches.size() == materialize_count;
         if (!count_ok) {
-            throw std::runtime_error(fmt_with_ctx(
-              fmt::format,
-              "Materialized unexpected number of batches: {}, expected: {}",
-              batches.size(),
-              materialize_count));
+            co_await ss::coroutine::return_exception(
+              std::runtime_error(fmt_with_ctx(
+                fmt::format,
+                "Materialized unexpected number of batches: {}, expected: {}",
+                batches.size(),
+                materialize_count)));
         }
     }
     // Merge our selected subset of unhydrated batches with the materialized

--- a/src/v/compression/async_stream_zstd.cc
+++ b/src/v/compression/async_stream_zstd.cc
@@ -15,6 +15,7 @@
 #include "bytes/ioarray.h"
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/exception.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
 #include <fmt/format.h>
@@ -215,8 +216,8 @@ ss::future<iobuf> async_stream_zstd::compress(iobuf i_buf) {
 
 ss::future<iobuf> async_stream_zstd::uncompress(iobuf i_buf) {
     if (unlikely(i_buf.empty())) {
-        throw std::runtime_error(
-          "Asked to stream_zstd::uncompress empty buffer");
+        co_await ss::coroutine::return_exception(
+          std::runtime_error("Asked to stream_zstd::uncompress empty buffer"));
     }
 
     ss::abort_source as;
@@ -250,7 +251,8 @@ ss::future<iobuf> async_stream_zstd::uncompress(iobuf i_buf) {
     }
 
     if (last_zstd_ret != 0) {
-        throw std::runtime_error("Input truncated before reading epilog");
+        co_await ss::coroutine::return_exception(
+          std::runtime_error("Input truncated before reading epilog"));
     }
 
     co_return ret_buf;
@@ -258,8 +260,8 @@ ss::future<iobuf> async_stream_zstd::uncompress(iobuf i_buf) {
 
 ss::future<ioarray> async_stream_zstd::uncompress(ioarray i_arr) {
     if (unlikely(i_arr.empty())) {
-        throw std::runtime_error(
-          "Asked to stream_zstd::uncompress empty array");
+        co_await ss::coroutine::return_exception(
+          std::runtime_error("Asked to stream_zstd::uncompress empty array"));
     }
 
     ss::abort_source as;
@@ -313,7 +315,8 @@ ss::future<ioarray> async_stream_zstd::uncompress(ioarray i_arr) {
     }
 
     if (last_zstd_ret != 0) {
-        throw std::runtime_error("Input truncated before reading epilog");
+        co_await ss::coroutine::return_exception(
+          std::runtime_error("Input truncated before reading epilog"));
     }
 
     auto out = ioarray::from_sized_buffers(obufs);

--- a/src/v/compression/gzip_stream_decompression.cc
+++ b/src/v/compression/gzip_stream_decompression.cc
@@ -11,6 +11,8 @@
 
 #include "compression/gzip_stream_decompression.h"
 
+#include <seastar/coroutine/exception.hh>
+
 namespace compression {
 
 gzip_stream_decompressor::gzip_stream_decompressor(
@@ -94,8 +96,8 @@ ss::future<std::optional<iobuf>> gzip_stream_decompressor::next() {
         if (
           auto code = inflate(&_zs, Z_NO_FLUSH);
           code != Z_OK && code != Z_STREAM_END) {
-            throw stream_decompression_error(
-              fmt::format("Failed to decompress chunk: {}", zError(code)));
+            co_await ss::coroutine::return_exception(stream_decompression_error(
+              fmt::format("Failed to decompress chunk: {}", zError(code))));
         }
 
         // It is possible for the avail_in field not to change, if the

--- a/src/v/datalake/datalake_usage_aggregator.cc
+++ b/src/v/datalake/datalake_usage_aggregator.cc
@@ -17,6 +17,7 @@
 #include "utils/retry_chain_node.h"
 
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
 
 #include <ranges>
 
@@ -166,7 +167,7 @@ default_datalake_usage_api_impl::compute_usage(ss::abort_source& as) {
     rcn.check_abort();
     if (last_exception) {
         // last retry resulted in an exception, let the caller handle it
-        std::rethrow_exception(last_exception);
+        co_await ss::coroutine::return_exception_ptr(std::move(last_exception));
     }
     usage_stats stats;
     stats.missing_reason

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -27,6 +27,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/core/timed_out_error.hh>
+#include <seastar/coroutine/exception.hh>
 #include <seastar/net/api.hh>
 #include <seastar/net/tls.hh>
 #include <seastar/util/defer.hh>
@@ -225,7 +226,8 @@ ss::future<reconnect_result_t> client::get_connected(
     auto clear_shutdown_signal = ss::defer(
       [this]() noexcept { _shutdown_now = false; });
     if (unlikely(_stopped)) {
-        throw std::runtime_error("client is stopped");
+        co_await ss::coroutine::return_exception(
+          std::runtime_error("client is stopped"));
     }
     vlog(
       ctxlog.debug,

--- a/src/v/kafka/data/cloud_topic_read_replica.cc
+++ b/src/v/kafka/data/cloud_topic_read_replica.cc
@@ -24,6 +24,8 @@
 #include "storage/log_reader.h"
 #include "storage/translating_reader.h"
 
+#include <seastar/coroutine/exception.hh>
+
 namespace cloud_topics::read_replica {
 
 namespace {
@@ -157,8 +159,9 @@ ss::future<storage::translating_reader>
 partition_proxy::make_reader(kafka::log_reader_config cfg) {
     auto snap_res = co_await get_snapshot();
     if (!snap_res.has_value()) {
-        throw std::runtime_error(
-          fmt::format("make_reader failed: {}", snap_res.error()));
+        co_await ss::coroutine::return_exception(
+          std::runtime_error(
+            fmt::format("make_reader failed: {}", snap_res.error())));
     }
     co_return co_await make_reader(std::move(snap_res.value()), cfg);
 }

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -190,7 +190,7 @@ static ss::future<read_result> read_from_partition(
     co_await std::move(rdr.reader).release()->finally();
 
     if (e) {
-        std::rethrow_exception(e);
+        co_await ss::coroutine::return_exception_ptr(std::move(e));
     }
 
     co_return read_result(

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -23,6 +23,8 @@
 #include "ssx/future-util.h"
 #include "ssx/when_all.h"
 
+#include <seastar/coroutine/exception.hh>
+
 namespace kafka {
 
 void list_offsets_request::compute_duplicate_topics() {
@@ -155,7 +157,7 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
               ktp.get_partition(), error_code::not_leader_for_partition);
         }
         // Not expecting any other kinds of exceptions -- just rethrow.
-        std::rethrow_exception(ex);
+        co_await ss::coroutine::return_exception_ptr(std::move(ex));
     }
     auto id = ktp.get_partition();
     auto res = res_fut.get();

--- a/src/v/lsm/db/compaction_task.cc
+++ b/src/v/lsm/db/compaction_task.cc
@@ -15,6 +15,7 @@
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
 
 #include <exception>
 
@@ -59,7 +60,8 @@ struct compaction_state {
         uint64_t current_bytes = b->file_size();
         closes.emplace_back(std::move(*b));
         if (finish_fut.failed()) {
-            std::rethrow_exception(finish_fut.get_exception());
+            co_await ss::coroutine::return_exception_ptr(
+              finish_fut.get_exception());
         }
         current_output().file_size = current_bytes;
         total_bytes += current_bytes;
@@ -85,7 +87,7 @@ struct compaction_state {
             }
         }
         if (err) {
-            std::rethrow_exception(err);
+            co_await ss::coroutine::return_exception_ptr(std::move(err));
         }
     }
 

--- a/src/v/lsm/db/impl.cc
+++ b/src/v/lsm/db/impl.cc
@@ -25,6 +25,7 @@
 
 #include <seastar/core/sleep.hh>
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
 #include <seastar/coroutine/switch_to.hh>
 
 #include <chrono>
@@ -63,7 +64,7 @@ ss::future<std::unique_ptr<impl>> impl::open(
     if (fut.failed()) {
         auto ex = fut.get_exception();
         co_await db->close().handle_exception([](const std::exception_ptr&) {});
-        std::rethrow_exception(ex);
+        co_await ss::coroutine::return_exception_ptr(std::move(ex));
     }
     // If we're readonly, we don't need to start any compaction loop.
     if (db->_opts->readonly) {
@@ -78,8 +79,8 @@ ss::future<std::unique_ptr<impl>> impl::open(
 
 ss::future<> impl::apply(ss::lw_shared_ptr<memtable> batch) {
     if (_opts->readonly) [[unlikely]] {
-        throw invalid_argument_exception(
-          "attempted to write to a readonly database");
+        co_await ss::coroutine::return_exception(invalid_argument_exception(
+          "attempted to write to a readonly database"));
     }
     if (batch->empty()) {
         co_return;
@@ -218,17 +219,17 @@ impl::create_internal_iterator() {
 
 ss::future<> impl::flush(ssx::instant deadline) {
     if (_opts->readonly) [[unlikely]] {
-        throw invalid_argument_exception(
-          "attempted to flush a readonly database");
+        co_await ss::coroutine::return_exception(
+          invalid_argument_exception("attempted to flush a readonly database"));
     }
     auto applied_seqno = max_applied_seqno();
     while (applied_seqno > max_persisted_seqno()) {
         if (ssx::lowres_steady_clock().now() > deadline) {
-            throw io_error_exception(
+            co_await ss::coroutine::return_exception(io_error_exception(
               "failed to persist up to seqno {} in time: current persisted "
               "seqno {}",
               applied_seqno.value_or(internal::sequence_number(0)),
-              max_persisted_seqno().value_or(internal::sequence_number(0)));
+              max_persisted_seqno().value_or(internal::sequence_number(0))));
         }
         if (_imm) {
             co_await _background_work_finished_signal.wait(
@@ -246,8 +247,8 @@ ss::future<> impl::flush() {
 
 ss::future<bool> impl::refresh() {
     if (!_opts->readonly) {
-        throw invalid_argument_exception(
-          "refresh() can only be called on a read-only database");
+        co_await ss::coroutine::return_exception(invalid_argument_exception(
+          "refresh() can only be called on a read-only database"));
     }
     co_return co_await _versions->refresh();
 }
@@ -391,7 +392,7 @@ ss::future<> impl::apply_edits(ss::lw_shared_ptr<version_edit> edit) {
     if (fut.failed()) {
         auto ex = fut.get_exception();
         vlog(log.warn, "apply_edits_end error=\"{}\"", ex);
-        std::rethrow_exception(ex);
+        co_await ss::coroutine::return_exception_ptr(std::move(ex));
     }
     vlog(
       log.trace, "apply_edits_end seqno={}", _versions->last_seqno().value());

--- a/src/v/lsm/db/version_set.cc
+++ b/src/v/lsm/db/version_set.cc
@@ -23,6 +23,7 @@
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
 
 #include <algorithm>
 #include <exception>
@@ -637,16 +638,16 @@ ss::future<bool> version_set::refresh() {
     }
 
     if (m->next_file_id < _next_file_id) {
-        throw corruption_exception(
+        co_await ss::coroutine::return_exception(corruption_exception(
           "manifest next_file_id {} is less than current {}",
           m->next_file_id(),
-          _next_file_id());
+          _next_file_id()));
     }
     if (_last_seqno.has_value() && m->last_seqno < _last_seqno.value()) {
-        throw corruption_exception(
+        co_await ss::coroutine::return_exception(corruption_exception(
           "manifest last_seqno {} is less than current {}",
           m->last_seqno(),
-          _last_seqno.value()());
+          _last_seqno.value()()));
     }
 
     if (m->next_file_id == _next_file_id && m->last_seqno == _last_seqno) {

--- a/src/v/lsm/io/memory_persistence.cc
+++ b/src/v/lsm/io/memory_persistence.cc
@@ -16,6 +16,7 @@
 #include "lsm/core/internal/files.h"
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/exception.hh>
 
 #include <map>
 #include <memory>
@@ -54,19 +55,20 @@ public:
 
     ss::future<ioarray> read(size_t offset, size_t n) override {
         if ((offset + n) > _state->data.size_bytes()) {
-            throw io_error_exception(
+            co_await ss::coroutine::return_exception(io_error_exception(
               "tried to read out of bounds of the file: "
               "{{offset:{},length:{},file_size:{}}}",
               offset,
               n,
-              _state->data.size_bytes());
+              _state->data.size_bytes()));
         }
         co_return ioarray::copy_from(_state->data.share(offset, n));
     }
 
     ss::future<> close() override {
         if (_closed) {
-            throw io_error_exception("double close of file");
+            co_await ss::coroutine::return_exception(
+              io_error_exception("double close of file"));
         }
         _closed = true;
         --_state->open_read_handles;
@@ -108,7 +110,8 @@ public:
     }
     ss::future<> close() override {
         if (_closed) {
-            throw io_error_exception("double close of file");
+            co_await ss::coroutine::return_exception(
+              io_error_exception("double close of file"));
         }
         _closed = true;
         --_state->open_write_handles;
@@ -132,7 +135,8 @@ public:
     ss::future<optional_pointer<random_access_file_reader>>
     open_random_access_reader(internal::file_handle h) override {
         if (_controller && _controller->should_fail) {
-            throw io_error_exception("injected error");
+            co_await ss::coroutine::return_exception(
+              io_error_exception("injected error"));
         }
         auto it = _data.find(h);
         std::unique_ptr<random_access_file_reader> ptr;
@@ -146,12 +150,14 @@ public:
     ss::future<std::unique_ptr<sequential_file_writer>>
     open_sequential_writer(internal::file_handle h) override {
         if (_controller && _controller->should_fail) {
-            throw io_error_exception("injected error");
+            co_await ss::coroutine::return_exception(
+              io_error_exception("injected error"));
         }
         auto [it, inserted] = _data.try_emplace(
           h, ss::make_lw_shared<memory_file_state>(h));
         if (!inserted) {
-            throw io_error_exception("file already exists: {}", h);
+            co_await ss::coroutine::return_exception(
+              io_error_exception("file already exists: {}", h));
         }
         co_return std::make_unique<memory_sequential_file_writer>(it->second);
     }

--- a/src/v/lsm/sst/reader.cc
+++ b/src/v/lsm/sst/reader.cc
@@ -21,6 +21,7 @@
 #include "lsm/sst/footer.h"
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/exception.hh>
 
 #include <sys/uio.h>
 
@@ -50,12 +51,12 @@ read_block(io::random_access_file_reader* file, block::handle handle) {
         actual_crc.extend(static_cast<char*>(chunk.iov_base), chunk.iov_len);
     }
     if (expected_crc != actual_crc.value()) {
-        throw corruption_exception(
+        co_await ss::coroutine::return_exception(corruption_exception(
           "unexpected crc, got: {}, want: {} for handle {} and file {}",
           actual_crc.value(),
           expected_crc,
           handle,
-          *file);
+          *file));
     }
     data.trim_back(sizeof(compression_type));
     if (compression != compression_type::none) {

--- a/src/v/model/record_batch_reader.cc
+++ b/src/v/model/record_batch_reader.cc
@@ -17,6 +17,7 @@
 #include <seastar/core/sharded.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
 #include <seastar/util/variant_utils.hh>
 
 #include <exception>
@@ -211,7 +212,8 @@ make_readahead_record_batch_reader(record_batch_reader&& reader) {
             if (fut.failed()) {
                 // Don't issue readahead if the future fails, this allows the
                 // caller to decide what should happen.
-                std::rethrow_exception(fut.get_exception());
+                co_await ss::coroutine::return_exception_ptr(
+                  fut.get_exception());
             }
             auto slice = std::move(fut.get());
             if (!_underlying->is_end_of_stream()) {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -47,6 +47,7 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/metrics.hh>
 #include <seastar/core/semaphore.hh>
+#include <seastar/coroutine/exception.hh>
 #include <seastar/coroutine/switch_to.hh>
 #include <seastar/util/defer.hh>
 
@@ -2484,7 +2485,7 @@ consensus::read_snapshot_metadata() {
     }
     co_await snapshot_reader->close();
     if (eptr) {
-        std::rethrow_exception(eptr);
+        co_await ss::coroutine::return_exception_ptr(std::move(eptr));
     }
     co_return metadata;
 }

--- a/src/v/raft/state_machine_manager.cc
+++ b/src/v/raft/state_machine_manager.cc
@@ -32,6 +32,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/core/with_scheduling_group.hh>
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/coroutine/switch_to.hh>
 #include <seastar/util/later.hh>
@@ -395,12 +396,12 @@ ss::future<> state_machine_manager::apply_raft_snapshot() {
     _next = std::max(max_next_offset(), _next);
     co_await snapshot->reader.close();
     if (fut.failed()) {
-        const auto e = fut.get_exception();
+        auto e = fut.get_exception();
         // do not log known shutdown exceptions as errors
         if (!ssx::is_shutdown_exception(e)) {
             vlog(_log.error, "error applying raft snapshot - {}", e);
         }
-        std::rethrow_exception(e);
+        co_await ss::coroutine::return_exception_ptr(std::move(e));
     }
 }
 
@@ -828,7 +829,7 @@ state_machine_manager::read_initial_recovery_snapshot() {
           "failed to read initial recovery snapshot metadata: {}",
           e);
         co_await reader->close();
-        std::rethrow_exception(e);
+        co_await ss::coroutine::return_exception_ptr(std::move(e));
     }
 
     auto snap_sz_f = co_await ss::coroutine::as_future(
@@ -838,7 +839,7 @@ state_machine_manager::read_initial_recovery_snapshot() {
         vlog(
           _log.error, "failed to read initial recovery snapshot size: {}", e);
         co_await reader->close();
-        std::rethrow_exception(e);
+        co_await ss::coroutine::return_exception_ptr(std::move(e));
     }
     auto snapshot_content_f = co_await ss::coroutine::as_future(
       read_iobuf_exactly(reader->input(), snap_sz_f.get()));
@@ -847,7 +848,7 @@ state_machine_manager::read_initial_recovery_snapshot() {
         auto e = snapshot_content_f.get_exception();
         vlog(_log.error, "failed to read recovery snapshot: {}", e);
         co_await reader->close();
-        std::rethrow_exception(e);
+        co_await ss::coroutine::return_exception_ptr(std::move(e));
     }
     co_await reader->close();
 

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -51,6 +51,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/when_all.hh>
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
 #include <seastar/util/defer.hh>
 
 #include <algorithm>
@@ -1394,7 +1395,7 @@ ss::future<> disk_log_impl::housekeeping(housekeeping_config cfg) {
             leftovers.erase(first_leftover);
         }
         if (fut.failed()) {
-            std::rethrow_exception(fut.get_exception());
+            co_await ss::coroutine::return_exception_ptr(fut.get_exception());
         }
     }
 }
@@ -1451,7 +1452,7 @@ ss::future<> disk_log_impl::do_compact(
               config().ntp());
             co_return;
         }
-        std::rethrow_exception(eptr);
+        co_await ss::coroutine::return_exception_ptr(std::move(eptr));
     }
 }
 
@@ -1685,7 +1686,7 @@ ss::future<> disk_log_impl::rewrite_segment_with_offset_map(
     co_await compacted_idx_writer->close();
     co_await appender->close();
     if (eptr) {
-        std::rethrow_exception(eptr);
+        co_await ss::coroutine::return_exception_ptr(std::move(eptr));
     }
 
     vlog(

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -25,6 +25,7 @@
 #include "storage/types.h"
 
 #include <seastar/core/metrics.hh>
+#include <seastar/coroutine/exception.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/util/log.hh>
 
@@ -454,7 +455,7 @@ ss::future<> kvstore::load_snapshot() {
 
     co_await reader->close();
     if (ex) {
-        std::rethrow_exception(ex);
+        co_await ss::coroutine::return_exception_ptr(std::move(ex));
     }
 
     co_await _snap.remove_partial_snapshots();

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -50,6 +50,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/timer.hh>
 #include <seastar/core/with_scheduling_group.hh>
+#include <seastar/coroutine/exception.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/util/file.hh>
 #include <seastar/util/later.hh>
@@ -899,8 +900,9 @@ ss::future<ss::shared_ptr<log>> log_manager::do_manage(
   raft::group_id group,
   std::vector<model::record_batch_type> translator_batch_types) {
     if (_config.base_dir.empty()) {
-        throw std::runtime_error(
-          "log_manager:: cannot have empty config.base_dir");
+        co_await ss::coroutine::return_exception(
+          std::runtime_error(
+            "log_manager:: cannot have empty config.base_dir"));
     }
 
     vassert(

--- a/src/v/storage/offset_to_filepos.cc
+++ b/src/v/storage/offset_to_filepos.cc
@@ -19,6 +19,7 @@
 #include "utils/null_output_stream.h"
 
 #include <seastar/core/iostream.hh>
+#include <seastar/coroutine/exception.hh>
 
 namespace storage {
 
@@ -122,7 +123,8 @@ ss::future<result<offset_to_file_pos_result>> convert_begin_offset_to_file_pos(
 
     if (res.has_error()) {
         vlog(stlog.error, "Can't read segment file, error: {}", res.error());
-        throw std::system_error(res.error());
+        co_await ss::coroutine::return_exception(
+          std::system_error(res.error()));
     }
 
     if (!offset_found && fail_on_missing_offset) {
@@ -237,7 +239,8 @@ ss::future<result<offset_to_file_pos_result>> convert_end_offset_to_file_pos(
 
     if (res.has_error()) {
         vlog(stlog.error, "Can't read segment file, error: {}", res.error());
-        throw std::system_error(res.error());
+        co_await ss::coroutine::return_exception(
+          std::system_error(res.error()));
     }
 
     if (!offset_found && fail_on_missing_offset) {

--- a/src/v/storage/parser.cc
+++ b/src/v/storage/parser.cc
@@ -22,6 +22,7 @@
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/when_all.hh>
+#include <seastar/coroutine/exception.hh>
 
 #include <algorithm>
 #include <exception>
@@ -349,10 +350,10 @@ public:
             vlog(stlog.error, "Output stram close error: {}", ex);
         }
         if (fo.failed()) {
-            std::rethrow_exception(fo.get_exception());
+            co_await ss::coroutine::return_exception_ptr(fo.get_exception());
         }
         if (fi.failed()) {
-            std::rethrow_exception(fi.get_exception());
+            co_await ss::coroutine::return_exception_ptr(fi.get_exception());
         }
     }
 

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -29,6 +29,7 @@
 #include <seastar/core/seastar.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
 
 #include <exception>
 #include <optional>
@@ -94,7 +95,7 @@ ss::future<bool> build_offset_map_for_segment(
           "Error building offset map for segment {}: {}",
           seg.path(),
           eptr);
-        std::rethrow_exception(eptr);
+        co_await ss::coroutine::return_exception_ptr(std::move(eptr));
     }
     bool fully_indexed = true;
     co_await rdr.for_each_async(

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -49,6 +49,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/when_all.hh>
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
 
 #include <fmt/core.h>
 #include <roaring/roaring.hh>
@@ -221,7 +222,7 @@ ss::future<size_t> copy_filtered_entries(
     co_await writer->close();
 
     if (eptr) {
-        std::rethrow_exception(eptr);
+        co_await ss::coroutine::return_exception_ptr(std::move(eptr));
     }
 
     co_return writer->size_bytes();
@@ -264,7 +265,7 @@ ss::future<size_t> write_clean_compacted_index(
     }
 
     if (fut.failed()) {
-        std::rethrow_exception(fut.get_exception());
+        co_await ss::coroutine::return_exception_ptr(fut.get_exception());
     }
 
     co_return fut.get();
@@ -590,7 +591,7 @@ ss::future<compaction_result> do_self_compact_segment(
     auto segment_generation = s->get_generation_id();
 
     if (s->is_closed()) {
-        throw segment_closed_exception();
+        co_await ss::coroutine::return_exception(segment_closed_exception());
     }
 
     // broker_timestamp is used for retention.ms, but it's only in the index,
@@ -632,7 +633,7 @@ ss::future<compaction_result> do_self_compact_segment(
     }
 
     if (s->is_closed()) {
-        throw segment_closed_exception();
+        co_await ss::coroutine::return_exception(segment_closed_exception());
     }
 
     co_await s->index().drop_all_data();
@@ -713,7 +714,7 @@ ss::future<> rebuild_compaction_index(
     pb.corrupted_compaction_index();
     auto h = co_await s->read_lock();
     if (s->is_closed()) {
-        throw segment_closed_exception();
+        co_await ss::coroutine::return_exception(segment_closed_exception());
     }
     // TODO: Improve memory management here, eg: ton of aborted txs?
     auto aborted_txs = co_await stm_hookset->aborted_tx_ranges(
@@ -749,7 +750,8 @@ ss::future<compacted_index::recovery_state> maybe_rebuild_compaction_index(
               gclog.debug,
               "Stopping in maybe_rebuild_compaction_index, segment closed: {}",
               s->filename());
-            throw segment_closed_exception();
+            co_await ss::coroutine::return_exception(
+              segment_closed_exception());
         }
         // Check the index state while the read lock is held, preventing e.g.
         // concurrent truncations, which removes the index.
@@ -877,7 +879,8 @@ make_concatenated_segment(
     // happened to be racing with an operation like truncation or shutdown.
     for (const auto& segment : segments) {
         if (unlikely(segment->is_closed())) {
-            throw segment_closed_exception();
+            co_await ss::coroutine::return_exception(
+              segment_closed_exception());
         }
     }
 
@@ -1280,15 +1283,18 @@ ss::future<compaction_result> concatenate_and_rebuild_target_segment(
     for (const auto& segment : segments) {
         // check generation id under write lock
         if (unlikely(segment->get_generation_id() != *gen_it)) {
-            throw generation_id_mismatch_exception(
-              fmt::format(
-                "Aborting compaction of a segment: {}. Generation id mismatch, "
-                "previous generation: {}",
-                *segment,
-                *gen_it));
+            co_await ss::coroutine::return_exception(
+              generation_id_mismatch_exception(
+                fmt::format(
+                  "Aborting compaction of a segment: {}. Generation id "
+                  "mismatch, "
+                  "previous generation: {}",
+                  *segment,
+                  *gen_it)));
         }
         if (unlikely(segment->is_closed())) {
-            throw segment_closed_exception();
+            co_await ss::coroutine::return_exception(
+              segment_closed_exception());
         }
         ++gen_it;
     }

--- a/src/v/transform/api.cc
+++ b/src/v/transform/api.cc
@@ -48,6 +48,7 @@
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/util/optimized_optional.hh>
 
@@ -79,10 +80,11 @@ public:
         auto ec = co_await _client->produce(
           {_topic, partition}, std::move(batches));
         if (ec != cluster::errc::success) {
-            throw std::runtime_error(
-              ss::format(
-                "failure to produce transform data: {}",
-                cluster::error_category().message(int(ec))));
+            co_await ss::coroutine::return_exception(
+              std::runtime_error(
+                ss::format(
+                  "failure to produce transform data: {}",
+                  cluster::error_category().message(int(ec)))));
         }
     }
 

--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -42,6 +42,7 @@
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/util/bool_class.hh>
 #include <seastar/util/defer.hh>
@@ -762,8 +763,8 @@ private:
           wasi::preview_1_start_function_name.size(),
           &start);
         if (!ok || start.kind != WASMTIME_EXTERN_FUNC) {
-            throw wasm_exception(
-              "Missing wasi _start function", errc::user_code_failure);
+            co_await ss::coroutine::return_exception(wasm_exception(
+              "Missing wasi _start function", errc::user_code_failure));
         }
         vlog(wasm_log.info, "starting wasm vm {}", _meta.name());
         std::exception_ptr ex;


### PR DESCRIPTION
A series of commits that prefer `co_await ss::coroutine::return_exception()` to `throw` and `ss::coroutine::return_exception_ptr()` to `std::rethrow_exception()` per guidance in https://github.com/scylladb/seastar/blob/master/doc/tutorial.md.

In coroutines, this does not make a difference to callers, since `throw`s get converted to exceptional futures anyways- however, by not directly calling `throw` or `std::rethrow_exception()`, we get to avoid potential copies of exception objects and the cost of stack unwinding, as well as some noiser logging in `seastar`'s `exception` logger at `DEBUG` level.

The changes here shouldn't have any functional changes, but may have a positive impact on performance.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
