### PR TITLE
bazel: update avro to 6821e2b

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -352,7 +352,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "yZROfZgIs0LcoLF6ANflyVgdZWDFiY86XvceRey/k1U=",
+        "bzlTransitiveDigest": "2IIb8XYNS/A1Go2jQ03h//LdRaADbs6oixnIproAT/4=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedInputs": [
           "REPO_MAPPING:,bazel_tools bazel_tools"
@@ -370,9 +370,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:avro.BUILD",
-              "sha256": "791d9f163f458d0ba4c94251f58ef5af9157952a9569ce0968d89aeb585af34f",
-              "strip_prefix": "avro-46fe1e36f680d75219cba46368de38321f1810ed",
-              "url": "https://github.com/redpanda-data/avro/archive/46fe1e36f680d75219cba46368de38321f1810ed.tar.gz",
+              "sha256": "1c09dd94cc8fcac0fa99359254507cfd538c527bcb8b5066d16b6289ac87ea93",
+              "strip_prefix": "avro-6821e2b454401308d4e3819c0569d0fe7f2a66fa",
+              "url": "https://github.com/redpanda-data/avro/archive/6821e2b454401308d4e3819c0569d0fe7f2a66fa.tar.gz",
               "patches": [
                 "@@//bazel/thirdparty:avro-snappy-includes.patch",
                 "@@//bazel/thirdparty:avro-fmt-const.patch"

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -22,9 +22,9 @@ def data_dependency():
     http_archive(
         name = "avro",
         build_file = "//bazel/thirdparty:avro.BUILD",
-        sha256 = "791d9f163f458d0ba4c94251f58ef5af9157952a9569ce0968d89aeb585af34f",
-        strip_prefix = "avro-46fe1e36f680d75219cba46368de38321f1810ed",
-        url = "https://github.com/redpanda-data/avro/archive/46fe1e36f680d75219cba46368de38321f1810ed.tar.gz",
+        sha256 = "1c09dd94cc8fcac0fa99359254507cfd538c527bcb8b5066d16b6289ac87ea93",
+        strip_prefix = "avro-6821e2b454401308d4e3819c0569d0fe7f2a66fa",
+        url = "https://github.com/redpanda-data/avro/archive/6821e2b454401308d4e3819c0569d0fe7f2a66fa.tar.gz",
         patches = [
             "//bazel/thirdparty:avro-snappy-includes.patch",
             "//bazel/thirdparty:avro-fmt-const.patch",


### PR DESCRIPTION
Bumps the `redpanda-data/avro` pin from `46fe1e36` (tip of `release-1.12.0-redpanda` before this change) to `6821e2b` (new tip), bringing in two C++ commits:

- `avrogencpp`: emit deterministic include guard — replaces the `boost::mt19937`/`time(nullptr)`-seeded random suffix with a hash derived from the schema file path and contents, making avrogen output reproducible across builds
- Remove now-unused `random_` member and its dead includes

The motivation is Bazel build hermeticity: the non-deterministic include guard was one of two root causes making `//tools:redpanda_package_for_pgo` non-reproducible across independent build roots.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none