### PR TITLE
cloud_topics/l1: fix UB in db_domain_manager error-logging paths

### DIFF
--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -683,7 +683,7 @@ db_domain_manager::get_first_offset_for_bytes(
     if (!extents_res.has_value()) {
         co_return rpc::get_first_offset_for_bytes_reply{
           .ec = log_and_convert(
-            metadata_res.error(), "Error getting backwards iterator: "),
+            extents_res.error(), "Error getting backwards iterator: "),
         };
     }
     if (!extents_res.value().has_value()) {
@@ -699,7 +699,7 @@ db_domain_manager::get_first_offset_for_bytes(
         if (!row.has_value()) {
             co_return rpc::get_first_offset_for_bytes_reply{
               .ec = log_and_convert(
-                metadata_res.error(), "Error iterating through extents: "),
+                row.error(), "Error iterating through extents: "),
             };
         }
         const auto& extent = row.value();
@@ -811,7 +811,7 @@ db_domain_manager::do_get_compaction_info(
     if (!compaction_res.has_value()) {
         co_return rpc::get_compaction_info_reply{
           .ec = log_and_convert(
-            metadata_res.error(), "Error getting compaction metadata: "),
+            compaction_res.error(), "Error getting compaction metadata: "),
         };
     }
 
@@ -992,7 +992,7 @@ db_domain_manager::get_end_offset_for_term(
     auto end_res = co_await reader.get_term_end(req.tp, req.term);
     if (!end_res.has_value()) {
         co_return rpc::get_end_offset_for_term_reply{
-          .ec = log_and_convert(metadata_res.error(), "Error getting term: "),
+          .ec = log_and_convert(end_res.error(), "Error getting term: "),
         };
     }
     if (!end_res.value().has_value()) {


### PR DESCRIPTION
Four call sites read .error() from a std::expected that had already been checked has_value() == true earlier in the function. Reading .error() in the value state is UB; libc++ reinterprets the value bytes as the error type, producing a 'phantom' detailed_error whose forward_list<sstring> is filled with garbage. The garbage sstring is then passed to fmt::format_to(), which crashes inside basic_string_view::remove_prefix() on a corrupted view.

This is benign until the second co_await on the read path actually fails -- which happens easily under disruption (broker restart, leadership transfer, network block). Build 84506 surfaced two SIGSEGVs from this in get_first_offset_for_bytes alone.

Fix each site to read the error from the expected whose has_value() check just failed:

  get_first_offset_for_bytes:
    extents_res error path -> extents_res.error()  (was metadata_res.error())
    row iteration error    -> row.error()          (was metadata_res.error())
  do_get_compaction_info:
    compaction_res error   -> compaction_res.error() (was metadata_res.error())
  get_end_offset_for_term:
    end_res error path     -> end_res.error()      (was metadata_res.error())

Found by analysing build 84506 CI crash backtraces; both crashes matched the same fmt formatter / sstring failure inside the L1 RPC read paths.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none