### PR TITLE
serde/parquet: add split-block bloom filter support

### DIFF
--- a/src/v/serde/parquet/BUILD
+++ b/src/v/serde/parquet/BUILD
@@ -100,6 +100,18 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "bloom_filter",
+    srcs = ["bloom_filter.cc"],
+    hdrs = ["bloom_filter.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/serde/thrift:compact",
+        "//src/v/utils:vint",
+    ],
+)
+
+redpanda_cc_library(
     name = "column_writer",
     srcs = [
         "column_stats_collector.cc",
@@ -110,6 +122,7 @@ redpanda_cc_library(
         "column_writer.h",
     ],
     deps = [
+        ":bloom_filter",
         ":encoding",
         ":metadata",
         ":schema",
@@ -120,6 +133,7 @@ redpanda_cc_library(
         "//src/v/compression",
         "//src/v/container:chunked_vector",
         "//src/v/hashing:crc32",
+        "//src/v/hashing:xx",
         "//src/v/strings:utf8",
         "@abseil-cpp//absl/numeric:int128",
         "@seastar",

--- a/src/v/serde/parquet/bloom_filter.cc
+++ b/src/v/serde/parquet/bloom_filter.cc
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/parquet/bloom_filter.h"
+
+#include "serde/thrift/compact.h"
+#include "utils/vint.h"
+
+#include <algorithm>
+#include <bit>
+#include <cmath>
+
+namespace serde::parquet {
+
+namespace {
+
+// From the Apache Parquet split-block Bloom filter specification.
+// NOLINTNEXTLINE(*magic-number*)
+constexpr uint32_t salt[8] = {
+  0x47b6137bu,
+  0x44974d91u,
+  0x8824ad5bu,
+  0xa2b7289du,
+  0x705495c7u,
+  0x2df1424bu,
+  0x9efc4947u,
+  0x5c6bfb31u,
+};
+
+void block_insert(uint32_t* block, uint32_t item_hash) {
+    for (int i = 0; i < 8; ++i) {
+        uint32_t bit = (item_hash * salt[i]) >> 27u;
+        block[i] |= (1u << bit);
+    }
+}
+
+bool block_check(const uint32_t* block, uint32_t item_hash) {
+    for (int i = 0; i < 8; ++i) {
+        uint32_t bit = (item_hash * salt[i]) >> 27u;
+        if (!(block[i] & (1u << bit))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Encode a Thrift union with its first variant selected as an empty struct
+// (the pattern used by BloomFilterAlgorithm, BloomFilterHash,
+// and BloomFilterCompression in the Parquet spec).
+iobuf encode_first_variant_selected() {
+    thrift::struct_encoder inner;
+    inner.write_field(
+      thrift::field_id(1),
+      thrift::field_type::structure,
+      thrift::struct_encoder::empty_struct);
+    return std::move(inner).write_stop();
+}
+
+} // namespace
+
+// static
+size_t bloom_filter::num_words_for_ndv(size_t ndv) {
+    // Optimal bits per item for ~1% FPP: -ln(0.01) / ln(2)^2 ≈ 9.585.
+    // Round up to the nearest whole block (8 words = 256 bits = 32 bytes).
+    constexpr double bits_per_item = 9.585;
+    size_t num_bits = static_cast<size_t>(
+      std::ceil(static_cast<double>(ndv) * bits_per_item));
+    size_t num_blocks = std::max<size_t>(1, (num_bits + 255) / 256);
+    return num_blocks * 8;
+}
+
+bloom_filter::bloom_filter(size_t expected_ndv)
+  : _bitset(num_words_for_ndv(expected_ndv), 0) {}
+
+void bloom_filter::insert(uint64_t hash) {
+    size_t num_blocks = _bitset.size() / 8;
+    auto h_lo = static_cast<uint32_t>(hash);
+    auto h_hi = static_cast<uint32_t>(hash >> 32u);
+    size_t block_index = (static_cast<uint64_t>(h_hi) * num_blocks) >> 32u;
+    block_insert(&_bitset[block_index * 8], h_lo);
+}
+
+bool bloom_filter::check(uint64_t hash) const {
+    size_t num_blocks = _bitset.size() / 8;
+    auto h_lo = static_cast<uint32_t>(hash);
+    auto h_hi = static_cast<uint32_t>(hash >> 32u);
+    size_t block_index = (static_cast<uint64_t>(h_hi) * num_blocks) >> 32u;
+    return block_check(&_bitset[block_index * 8], h_lo);
+}
+
+void bloom_filter::reset() { std::fill(_bitset.begin(), _bitset.end(), 0u); }
+
+double bloom_filter::fill_ratio() const {
+    size_t set_bits = 0;
+    for (uint32_t w : _bitset) {
+        set_bits += std::popcount(w);
+    }
+    return static_cast<double>(set_bits)
+           / static_cast<double>(_bitset.size() * 32);
+}
+
+void bloom_filter::serialize(iobuf& out) const {
+    // BloomFilterHeader: numBytes, algorithm=BLOCK, hash=XXHASH,
+    // compression=UNCOMPRESSED.
+    thrift::struct_encoder header;
+    header.write_field(
+      thrift::field_id(1),
+      thrift::field_type::i32,
+      vint::to_bytes(static_cast<int64_t>(size_bytes())));
+    header.write_field(
+      thrift::field_id(2),
+      thrift::field_type::structure,
+      encode_first_variant_selected());
+    header.write_field(
+      thrift::field_id(3),
+      thrift::field_type::structure,
+      encode_first_variant_selected());
+    header.write_field(
+      thrift::field_id(4),
+      thrift::field_type::structure,
+      encode_first_variant_selected());
+    out.append(std::move(header).write_stop());
+
+    // Raw bitset bytes. The split-block algorithm operates on little-endian
+    // 32-bit words; on little-endian hosts (x86-64, aarch64 LE) this is a
+    // direct copy of the in-memory representation, which is the expected
+    // layout for Parquet readers.
+    static_assert(
+      std::endian::native == std::endian::little,
+      "bloom filter serialization assumes little-endian word layout; "
+      "insert byteswap per word for big-endian support");
+    out.append(
+      // NOLINTNEXTLINE(*reinterpret-cast*)
+      reinterpret_cast<const uint8_t*>(_bitset.data()),
+      _bitset.size() * sizeof(uint32_t));
+}
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/bloom_filter.h
+++ b/src/v/serde/parquet/bloom_filter.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace serde::parquet {
+
+/// Split-block Bloom filter as specified by the Apache Parquet format.
+///
+/// Uses xxHash64 (seed=0) as the hash function. One filter instance covers a
+/// single column in a single row group. After flush, call reset() to reuse the
+/// filter for the next row group without reallocating.
+///
+/// Serialization format: BloomFilterHeader (Thrift compact) followed
+/// immediately by the raw bitset bytes, appended into a caller-provided iobuf.
+///
+/// See: https://parquet.apache.org/docs/file-format/bloomfilter/
+class bloom_filter {
+public:
+    /// Construct a filter sized for `expected_ndv` distinct values,
+    /// targeting ~1% false positive probability.
+    explicit bloom_filter(size_t expected_ndv);
+
+    /// Insert a precomputed xxHash64 value into the filter.
+    void insert(uint64_t hash);
+
+    /// Check whether a hash may be in the filter. Always returns true if the
+    /// value was inserted. May return true for values that were not (false
+    /// positive). Intended for use in tests only.
+    bool check(uint64_t hash) const;
+
+    /// Reset the filter to empty, keeping the same capacity.
+    void reset();
+
+    /// Append [BloomFilterHeader (Thrift compact)][bitset bytes] to `out`.
+    void serialize(iobuf& out) const;
+
+    size_t size_bytes() const { return _bitset.size() * sizeof(uint32_t); }
+
+    /// Returns the fraction of bits set. The estimated FPP for the
+    /// split-block algorithm is approximately fill_ratio()^8; at the
+    /// designed NDV this is ~56%. Callers may discard the filter when
+    /// fill_ratio() exceeds a useful threshold (e.g. 0.75 ≈ 10% FPP).
+    double fill_ratio() const;
+
+private:
+    static size_t num_words_for_ndv(size_t ndv);
+
+    // _bitset is fixed-size, allocated at construction based on expected_ndv:
+    // ~9.6 bits per expected distinct value, rounded up to 8-word (256-bit)
+    // block boundaries. At ~1% target FPP: 10K NDV → ~12 KiB, 100K NDV →
+    // ~120 KiB. There is no dynamic resizing; inserting significantly more
+    // distinct values than expected_ndv increases fill_ratio() and degrades
+    // FPP. Once fill_ratio() exceeds a useful threshold (e.g. 0.75, ≈ 10%
+    // FPP), callers should discard rather than emit the filter.
+    std::vector<uint32_t> _bitset;
+};
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/column_writer.cc
+++ b/src/v/serde/parquet/column_writer.cc
@@ -16,13 +16,17 @@
 #include "compression/compression.h"
 #include "container/chunked_vector.h"
 #include "hashing/crc32.h"
+#include "hashing/xx.h"
+#include "serde/parquet/bloom_filter.h"
 #include "serde/parquet/column_stats_collector.h"
 #include "serde/parquet/encoding.h"
 #include "strings/utf8.h"
 
+#include <seastar/core/byteorder.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/util/variant_utils.hh>
 
+#include <bit>
 #include <limits>
 #include <stdexcept>
 #include <type_traits>
@@ -123,11 +127,55 @@ crc::crc32 compute_crc32(Args&&... args) {
     return crc;
 }
 
+// Hash a parquet value to uint64_t using xxHash64 (seed=0), as required by
+// the Parquet bloom filter spec. Fixed-size values are hashed as their
+// little-endian byte representation; variable-length values are hashed
+// directly over their bytes.
+uint64_t hash_for_bloom(int32_value v) {
+    auto le = ss::cpu_to_le(v.val);
+    return xxhash_64(reinterpret_cast<const char*>(&le), sizeof(le));
+}
+uint64_t hash_for_bloom(int64_value v) {
+    auto le = ss::cpu_to_le(v.val);
+    return xxhash_64(reinterpret_cast<const char*>(&le), sizeof(le));
+}
+uint64_t hash_for_bloom(float32_value v) {
+    auto bits = ss::cpu_to_le(std::bit_cast<uint32_t>(v.val));
+    return xxhash_64(reinterpret_cast<const char*>(&bits), sizeof(bits));
+}
+uint64_t hash_for_bloom(float64_value v) {
+    auto bits = ss::cpu_to_le(std::bit_cast<uint64_t>(v.val));
+    return xxhash_64(reinterpret_cast<const char*>(&bits), sizeof(bits));
+}
+uint64_t hash_for_bloom(const byte_array_value& v) {
+    incremental_xxhash64 h;
+    for (const auto& frag : v.val) {
+        h.update(frag.get(), frag.size());
+    }
+    return h.digest();
+}
+uint64_t hash_for_bloom(const fixed_byte_array_value& v) {
+    incremental_xxhash64 h;
+    for (const auto& frag : v.val) {
+        h.update(frag.get(), frag.size());
+    }
+    return h.digest();
+}
+// Boolean columns never have bloom filters (see constructor below).
+// This overload exists only so the template compiles for boolean_value.
+uint64_t hash_for_bloom(boolean_value) {
+    vassert(false, "unreachable: boolean columns are never bloom-filtered");
+}
+
 template<typename value_type, auto comparator>
 class buffered_column_writer final : public column_writer::impl {
 public:
     buffered_column_writer(const schema_element& schema_element, options opts)
-      : _max_rep_level(schema_element.max_repetition_level)
+      : _bloom_filter(
+          opts.bloom_filter_ndv > 0
+            ? std::make_optional<bloom_filter>(opts.bloom_filter_ndv)
+            : std::nullopt)
+      , _max_rep_level(schema_element.max_repetition_level)
       , _max_def_level(schema_element.max_definition_level)
       , _opts(opts) {}
 
@@ -150,6 +198,9 @@ public:
                   value_memory_usage = sizeof(value_type);
               }
               _current_page_stats.record_value(v);
+              if (_bloom_filter) {
+                  _bloom_filter->insert(hash_for_bloom(v));
+              }
               _value_buffer.add_value(std::move(v));
           },
           [this](null_value) {
@@ -316,15 +367,30 @@ public:
         }
         _flushed_stats.reset();
         _total_memory_usage = 0;
+        iobuf bf;
+        if (_bloom_filter) {
+            // Discard the filter if it is too full: FPP ≈ fill_ratio()^8,
+            // so the default threshold of 0.75 corresponds to ~10% FPP,
+            // at which point the filter is unlikely to be useful for
+            // skipping row groups.
+            if (
+              _bloom_filter->fill_ratio()
+              <= _opts.bloom_filter_max_fill_ratio) {
+                _bloom_filter->serialize(bf);
+            }
+            _bloom_filter->reset();
+        }
         co_return flushed_pages{
           .pages = std::exchange(_flushed_pages, {}),
           .stats = std::move(full_stats),
+          .bloom_filter = std::move(bf),
         };
     }
 
 private:
     column_stats_collector<value_type, comparator> _current_page_stats;
     column_stats_collector<value_type, comparator> _flushed_stats;
+    std::optional<bloom_filter> _bloom_filter;
     int64_t _total_memory_usage = 0;
     plain_encoder<value_type> _value_buffer;
     chunked_vector<def_level> _def_levels;

--- a/src/v/serde/parquet/column_writer.h
+++ b/src/v/serde/parquet/column_writer.h
@@ -37,6 +37,9 @@ struct flushed_pages {
     chunked_vector<data_page> pages;
     // Stats for all flushed pages
     statistics stats;
+    // Serialized bloom filter for this column. Empty when bloom filters are
+    // disabled (bloom_filter_ndv == 0) or for boolean columns.
+    iobuf bloom_filter;
 };
 
 // A writer for a single column of parquet data.
@@ -55,6 +58,13 @@ public:
         // When true, truncation respects UTF-8 character boundaries so that
         // truncated bounds are always valid UTF-8 strings.
         bool is_utf8_string = false;
+        // Expected number of distinct values per row group for bloom filter
+        // sizing. 0 disables bloom filters for this column.
+        size_t bloom_filter_ndv = 0;
+        // Bloom filter fill ratio above which the filter is discarded at flush
+        // rather than emitted. FPP ≈ fill_ratio^8; the default 0.75
+        // corresponds to ~10% FPP.
+        double bloom_filter_max_fill_ratio = 0.75;
     };
 
     explicit column_writer(const schema_element&, options);

--- a/src/v/serde/parquet/metadata.cc
+++ b/src/v/serde/parquet/metadata.cc
@@ -485,6 +485,8 @@ iobuf encode(const column_meta_data& metadata) {
     constexpr auto index_page_offset_field_id = thrift::field_id(10);
     constexpr auto dictionary_page_offset_field_id = thrift::field_id(11);
     constexpr auto stats_field_id = thrift::field_id(12);
+    constexpr auto bloom_filter_offset_field_id = thrift::field_id(14);
+    constexpr auto bloom_filter_length_field_id = thrift::field_id(15);
     thrift::struct_encoder encoder;
     enum physical_type : int8_t {
         boolean = 0,
@@ -609,6 +611,18 @@ iobuf encode(const column_meta_data& metadata) {
           stats_field_id,
           thrift::field_type::structure,
           encode(*metadata.stats));
+    }
+    if (metadata.bloom_filter_offset) {
+        encoder.write_field(
+          bloom_filter_offset_field_id,
+          thrift::field_type::i64,
+          vint::to_bytes(*metadata.bloom_filter_offset));
+    }
+    if (metadata.bloom_filter_length) {
+        encoder.write_field(
+          bloom_filter_length_field_id,
+          thrift::field_type::i32,
+          vint::to_bytes(static_cast<int64_t>(*metadata.bloom_filter_length)));
     }
     return std::move(encoder).write_stop();
 }

--- a/src/v/serde/parquet/metadata.h
+++ b/src/v/serde/parquet/metadata.h
@@ -385,6 +385,12 @@ struct column_meta_data {
 
     /** optional statistics for this column chunk */
     std::optional<statistics> stats;
+
+    /** Byte offset from beginning of file to bloom filter data **/
+    std::optional<int64_t> bloom_filter_offset;
+
+    /** Length of bloom filter data (header + bitset) in bytes **/
+    std::optional<int32_t> bloom_filter_length;
 };
 
 struct column_chunk {

--- a/src/v/serde/parquet/tests/BUILD
+++ b/src/v/serde/parquet/tests/BUILD
@@ -176,6 +176,23 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "bloom_filter_test",
+    timeout = "short",
+    srcs = [
+        "bloom_filter_test.cc",
+    ],
+    cpu = 1,
+    memory = "64MiB",
+    deps = [
+        "//src/v/hashing:xx",
+        "//src/v/serde/parquet:bloom_filter",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "column_stats_collector_test",
     timeout = "short",
     srcs = [

--- a/src/v/serde/parquet/tests/bloom_filter_test.cc
+++ b/src/v/serde/parquet/tests/bloom_filter_test.cc
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "hashing/xx.h"
+#include "serde/parquet/bloom_filter.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string_view>
+#include <unordered_set>
+
+using serde::parquet::bloom_filter;
+
+// Parquet bloom filters mandate xxHash64 (seed=0) specifically — not xxHash3,
+// not xxHash32. This known-answer test locks in the correct hash function so
+// that accidental substitution is caught immediately.
+//
+// Test vector: XXH64("", 0 bytes, seed=0) = 0xEF46DB3751D8E999
+// Source: https://github.com/Cyan4973/xxHash/blob/dev/cli/xxhsum.c test suite
+TEST(BloomFilter, HashKAT) {
+    EXPECT_EQ(xxhash_64("", static_cast<size_t>(0)), 0xEF46DB3751D8E999ULL);
+}
+
+// Hash a uint64_t index to a realistic xxHash64 value for use in filter tests.
+// Using raw sequential integers as "hashes" is a degenerate case: small values
+// have h_hi == 0, causing all inserts to set identical bits in block 0.
+static uint64_t h(uint64_t i) {
+    return xxhash_64(reinterpret_cast<const char*>(&i), sizeof(i));
+}
+
+TEST(BloomFilter, NoFalseNegatives) {
+    bloom_filter f(1000);
+    for (uint64_t i = 0; i < 1000; ++i) {
+        f.insert(h(i));
+    }
+    for (uint64_t i = 0; i < 1000; ++i) {
+        EXPECT_TRUE(f.check(h(i)));
+    }
+}
+
+TEST(BloomFilter, ReasonableFalsePositiveRate) {
+    constexpr size_t ndv = 10'000;
+    bloom_filter f(ndv);
+    for (uint64_t i = 0; i < ndv; ++i) {
+        f.insert(h(i));
+    }
+    // Probe with values that were not inserted. Count false positives.
+    size_t false_positives = 0;
+    constexpr size_t probe_count = 10'000;
+    for (uint64_t i = ndv; i < ndv + probe_count; ++i) {
+        if (f.check(h(i))) {
+            ++false_positives;
+        }
+    }
+    // Target FPP is ~1%; allow up to 5% to keep the test non-flaky.
+    // NOLINTNEXTLINE(*magic-number*)
+    EXPECT_LT(false_positives, probe_count / 20);
+}
+
+TEST(BloomFilter, Reset) {
+    bloom_filter f(100);
+    for (uint64_t i = 0; i < 100; ++i) {
+        f.insert(h(i));
+    }
+    f.reset();
+    for (uint64_t i = 0; i < 100; ++i) {
+        EXPECT_FALSE(f.check(h(i)));
+    }
+}
+
+TEST(BloomFilter, SerializeNonEmpty) {
+    bloom_filter f(1000);
+    f.insert(xxhash_64("hello", 5));
+    f.insert(xxhash_64("world", 5));
+
+    iobuf out;
+    f.serialize(out);
+
+    // Must have written something: Thrift header + bitset.
+    EXPECT_GT(out.size_bytes(), f.size_bytes());
+}
+
+TEST(BloomFilter, SerializeContainsBitset) {
+    bloom_filter f(1000);
+    f.insert(42);
+
+    iobuf out;
+    f.serialize(out);
+
+    // The total serialized size must be at least the bitset size.
+    EXPECT_GE(out.size_bytes(), f.size_bytes());
+}
+
+// A filter sized for ndv distinct values but filled with 10× that many
+// should have fill_ratio() well above the 0.75 discard threshold used by
+// the column writer. This validates that the discard path is reachable for
+// realistic over-NDV scenarios.
+TEST(BloomFilter, FillRatioExceedsDiscardThresholdWhenOverfull) {
+    constexpr size_t ndv = 100;
+    bloom_filter f(ndv);
+    for (uint64_t i = 0; i < ndv * 10; ++i) {
+        f.insert(h(i));
+    }
+    EXPECT_GT(f.fill_ratio(), 0.75);
+}

--- a/src/v/serde/parquet/tests/generate_file.cc
+++ b/src/v/serde/parquet/tests/generate_file.cc
@@ -77,6 +77,7 @@ struct testcase {
     schema_element schema;
     std::vector<value> rows;
     iobuf parquet_file;
+    size_t bloom_filter_ndv = 0;
 };
 
 iobuf json(const testcase& tc) {
@@ -91,6 +92,8 @@ iobuf json(const testcase& tc) {
         json(w, tc.schema, row);
     }
     w.EndArray();
+    w.Key("bloom_filter_ndv");
+    w.Uint64(tc.bloom_filter_ndv);
     w.EndObject();
     return std::move(buf).as_iobuf();
 }
@@ -339,17 +342,23 @@ ss::future<iobuf> serialize_testcase(size_t test_case) {
           });
     }
     iobuf file;
+    size_t num_rows = test_case * 100;
+    // The all_types_schema has a repeated nested group with up to 64 elements
+    // per top-level row. Size the bloom filter NDV to account for the maximum
+    // number of leaf values in those nested columns, otherwise the filter fills
+    // past the discard threshold and is dropped.
+    size_t bloom_filter_ndv = num_rows * 64 + 50;
     writer w(
       {
         .schema = all_types_schema(),
         .metadata = {{"foo", "bar"}},
         .compress = test_case % 2 == 0,
+        .bloom_filter_ndv = bloom_filter_ndv,
       },
       make_iobuf_ref_output_stream(file));
     co_await w.init();
     auto schema = all_types_schema();
     std::vector<value> rows;
-    size_t num_rows = test_case * 100;
     for (size_t i = 0; i < num_rows; ++i) {
         auto v = generate_value(schema);
         rows.push_back(copy(v));
@@ -365,6 +374,7 @@ ss::future<iobuf> serialize_testcase(size_t test_case) {
         .schema = all_types_schema(),
         .rows = std::move(rows),
         .parquet_file = std::move(file),
+        .bloom_filter_ndv = bloom_filter_ndv,
       });
 }
 // NOLINTEND(*magic-number*)

--- a/src/v/serde/parquet/writer.cc
+++ b/src/v/serde/parquet/writer.cc
@@ -19,7 +19,11 @@
 #include "serde/parquet/metadata.h"
 #include "serde/parquet/shredder.h"
 
+#include <seastar/coroutine/exception.hh>
+
 #include <algorithm>
+#include <limits>
+#include <stdexcept>
 
 namespace serde::parquet {
 
@@ -50,6 +54,7 @@ public:
             if (!element.is_leaf()) {
                 return;
             }
+            bool is_bool = std::holds_alternative<bool_type>(element.type);
             _columns.emplace(
               element.position,
               column{
@@ -60,6 +65,7 @@ public:
                     .compress = _opts.compress,
                     .max_stats_truncate_length
                     = _opts.max_stats_truncate_length,
+                    .bloom_filter_ndv = is_bool ? 0 : _opts.bloom_filter_ndv,
                   }),
               });
         });
@@ -151,6 +157,20 @@ public:
             rg.num_rows = row_count;
             rg.total_byte_size += chunk.meta_data.total_uncompressed_size;
             rg.total_compressed_size += chunk.meta_data.total_compressed_size;
+            if (flushed.bloom_filter.size_bytes() > 0) {
+                chunk.meta_data.bloom_filter_offset = _flushed_bytes;
+                auto bf_size = flushed.bloom_filter.size_bytes();
+                if (
+                  bf_size
+                  > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
+                    co_await ss::coroutine::return_exception(
+                      std::runtime_error(
+                        "bloom filter exceeds int32 size limit"));
+                }
+                chunk.meta_data.bloom_filter_length = static_cast<int32_t>(
+                  bf_size);
+                co_await write_iobuf(std::move(flushed.bloom_filter));
+            }
             rg.columns.push_back(std::move(chunk));
         }
         if (page_count == 0) {

--- a/src/v/serde/parquet/writer.h
+++ b/src/v/serde/parquet/writer.h
@@ -64,6 +64,15 @@ public:
         // Matches Arrow's DEFAULT_MAX_STATISTICS_SIZE.
         static constexpr int32_t default_max_stats_length = 4096;
         int32_t max_stats_truncate_length = default_max_stats_length;
+
+        // Expected number of distinct values per column per row group, used
+        // to size bloom filters for non-boolean columns. 0 disables bloom
+        // filters. When enabled, default_bloom_filter_ndv (~12 KiB per
+        // column) is a reasonable starting point: filters are automatically
+        // discarded at flush if the fill ratio indicates FPP > ~10%, which
+        // occurs at roughly 1.5× the configured NDV (~15K for the default).
+        static constexpr size_t default_bloom_filter_ndv = 10'000;
+        size_t bloom_filter_ndv = 0;
     };
 
     // Create a new parquet file writer using the given options that

--- a/src/v/test_utils/go/parquet_verifier/main.go
+++ b/src/v/test_utils/go/parquet_verifier/main.go
@@ -29,8 +29,9 @@ import (
 )
 
 type TestCase struct {
-	File []byte `json:"file"`
-	Rows []any  `json:"rows"`
+	File           []byte `json:"file"`
+	Rows           []any  `json:"rows"`
+	BloomFilterNDV int    `json:"bloom_filter_ndv"`
 }
 
 func main() {
@@ -246,6 +247,51 @@ func main() {
 					i, j, omax, rmin,
 				)
 			}
+		}
+	}
+
+	log.Println("validating bloom filters")
+	for i, rg := range originalFile.RowGroups() {
+		for j, col := range rg.ColumnChunks() {
+			fcc := col.(*parquet.FileColumnChunk)
+			isBool := fcc.Type().Kind() == parquet.Boolean
+			bf := fcc.BloomFilter()
+			if testCase.BloomFilterNDV == 0 || isBool {
+				if bf != nil {
+					log.Fatalf("❌ unexpected bloom filter in row group %d column %d\n", i, j)
+				}
+				continue
+			}
+			if bf == nil {
+				log.Fatalf("❌ missing bloom filter in row group %d column %d (NDV=%d)\n", i, j, testCase.BloomFilterNDV)
+			}
+			pages := fcc.Pages()
+			for {
+				page, err := pages.ReadPage()
+				if errors.Is(err, io.EOF) {
+					break
+				} else if err != nil {
+					log.Fatalln("❌ unable to read parquet page for bloom filter check:", err)
+				}
+				vals := make([]parquet.Value, page.NumValues())
+				n, err := page.Values().ReadValues(vals)
+				if n != len(vals) || (err != nil && !errors.Is(err, io.EOF)) {
+					log.Fatalf("❌ unable to read all page values for bloom filter check row group %d column %d: %v\n", i, j, err)
+				}
+				for _, v := range vals {
+					if v.IsNull() {
+						continue
+					}
+					ok, err := bf.Check(v)
+					if err != nil {
+						log.Fatalf("❌ bloom filter check error for row group %d column %d: %v\n", i, j, err)
+					}
+					if !ok {
+						log.Fatalf("❌ bloom filter false negative in row group %d column %d: value=%v\n", i, j, v)
+					}
+				}
+			}
+			_ = pages.Close()
 		}
 	}
 


### PR DESCRIPTION
Implements write-only Parquet split-block Bloom filters (spec §8.5.3). Each non-boolean leaf column gets a filter when bloom_filter_ndv > 0 in the writer options (disabled by default). The filter is sized for ~1% FPP at the expected NDV, written after the column pages, and its offset/length are recorded in column metadata fields 14/15.

Hashing follows the Parquet spec: xxHash64 (seed=0) over the LE byte representation for fixed-size types, raw bytes for variable-length.

Integration tests now enable bloom filters on all generated test cases (cases 1-63 with varying NDV; case 0 left at NDV=0 to verify absence) and the Go parquet verifier checks for no false negatives on every non-boolean column and verifies absence when NDV=0.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
