### PR TITLE
bazel: update seastar to b0a44a81

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -352,7 +352,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "2IIb8XYNS/A1Go2jQ03h//LdRaADbs6oixnIproAT/4=",
+        "bzlTransitiveDigest": "rWt8G3JLne5lK/1kx58Hoe4x8pFmgwV5uv1C1wY/kUA=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedInputs": [
           "REPO_MAPPING:,bazel_tools bazel_tools"
@@ -521,9 +521,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "da641ed98ed2853a0ae6440e23c8679579ea823c0660d10893ce7a5f12e77213",
-              "strip_prefix": "seastar-0dd1a13c11d8573481180deab69eb7ca0b345b74",
-              "url": "https://github.com/redpanda-data/seastar/archive/0dd1a13c11d8573481180deab69eb7ca0b345b74.tar.gz"
+              "sha256": "d4081a2cf5ecc2e92db827860d0a004f87ca09e8f2ba98256b540e9d0564e870",
+              "strip_prefix": "seastar-b0a44a81fa8d1308fef28dd47ddccdb618755c53",
+              "url": "https://github.com/redpanda-data/seastar/archive/b0a44a81fa8d1308fef28dd47ddccdb618755c53.tar.gz"
             }
           },
           "unordered_dense": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -156,13 +156,13 @@ def data_dependency():
         url = "https://github.com/redpanda-data/CRoaring/archive/c433d1c70c10fb2e40f049e019e2abbcafa6e69d.tar.gz",
     )
 
-    # branch: v26.2.x (rebased) — https://github.com/redpanda-data/seastar/pull/277
+    # branch: v26.2.x
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "da641ed98ed2853a0ae6440e23c8679579ea823c0660d10893ce7a5f12e77213",
-        strip_prefix = "seastar-0dd1a13c11d8573481180deab69eb7ca0b345b74",
-        url = "https://github.com/redpanda-data/seastar/archive/0dd1a13c11d8573481180deab69eb7ca0b345b74.tar.gz",
+        sha256 = "d4081a2cf5ecc2e92db827860d0a004f87ca09e8f2ba98256b540e9d0564e870",
+        strip_prefix = "seastar-b0a44a81fa8d1308fef28dd47ddccdb618755c53",
+        url = "https://github.com/redpanda-data/seastar/archive/b0a44a81fa8d1308fef28dd47ddccdb618755c53.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Update Seastar from `0dd1a13c11d8` to `b0a44a81fa8d` (v26.2.x branch).

Changes:
- coroutine/generator: fix setup of generator's waiting task

Compare: https://github.com/redpanda-data/seastar/compare/0dd1a13c11d8573481180deab69eb7ca0b345b74...b0a44a81fa8d1308fef28dd47ddccdb618755c53

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none