### PR TITLE
[v25.3.x] `cloud_roles`: plumb `metrics_tag` through `refresh_credentials` impls

### DIFF
--- a/src/v/cloud_roles/aws_refresh_impl.cc
+++ b/src/v/cloud_roles/aws_refresh_impl.cc
@@ -62,9 +62,14 @@ aws_refresh_impl::aws_refresh_impl(
   aws_service_name service,
   aws_region_name region,
   ss::abort_source& as,
-  retry_params retry_params)
+  retry_params retry_params,
+  ss::sstring metrics_tag)
   : refresh_credentials::impl(
-      std::move(address), std::move(region), as, retry_params)
+      std::move(address),
+      std::move(region),
+      as,
+      retry_params,
+      std::move(metrics_tag))
   , _service(std::move(service)) {}
 
 bool aws_refresh_impl::is_fallback_required(const api_request_error& response) {

--- a/src/v/cloud_roles/aws_refresh_impl.h
+++ b/src/v/cloud_roles/aws_refresh_impl.h
@@ -24,7 +24,8 @@ public:
       aws_service_name service,
       aws_region_name region,
       ss::abort_source& as,
-      retry_params retry_params = default_retry_params);
+      retry_params retry_params = default_retry_params,
+      ss::sstring metrics_tag = "");
     ss::future<api_response> fetch_credentials() override;
 
     std::ostream& print(std::ostream& os) const override;

--- a/src/v/cloud_roles/aws_sts_refresh_impl.cc
+++ b/src/v/cloud_roles/aws_sts_refresh_impl.cc
@@ -81,9 +81,14 @@ aws_sts_refresh_impl::aws_sts_refresh_impl(
   aws_service_name service,
   aws_region_name region,
   ss::abort_source& as,
-  retry_params retry_params)
+  retry_params retry_params,
+  ss::sstring metrics_tag)
   : refresh_credentials::impl(
-      std::move(address), std::move(region), as, retry_params)
+      std::move(address),
+      std::move(region),
+      as,
+      retry_params,
+      std::move(metrics_tag))
   , _role{load_from_env(aws_injected_env_vars::role_arn)}
   , _token_file_path{load_from_env(aws_injected_env_vars::token_file_path)}
   , _service(std::move(service)) {}

--- a/src/v/cloud_roles/aws_sts_refresh_impl.h
+++ b/src/v/cloud_roles/aws_sts_refresh_impl.h
@@ -24,7 +24,8 @@ public:
       aws_service_name service,
       aws_region_name region,
       ss::abort_source& as,
-      retry_params retry_params = default_retry_params);
+      retry_params retry_params = default_retry_params,
+      ss::sstring metrics_tag = "");
     ss::future<api_response> fetch_credentials() override;
 
     std::ostream& print(std::ostream& os) const override;

--- a/src/v/cloud_roles/azure_aks_refresh_impl.cc
+++ b/src/v/cloud_roles/azure_aks_refresh_impl.cc
@@ -54,7 +54,8 @@ azure_aks_refresh_impl::azure_aks_refresh_impl(
   aws_service_name, // Ignored for Azure AKS
   aws_region_name region,
   ss::abort_source& as,
-  retry_params retry_params)
+  retry_params retry_params,
+  ss::sstring metrics_tag)
   : refresh_credentials::impl(
       [&] {
           if (!address.host().empty()) {
@@ -79,7 +80,8 @@ azure_aks_refresh_impl::azure_aks_refresh_impl(
       }(),
       std::move(region),
       as,
-      retry_params)
+      retry_params,
+      std::move(metrics_tag))
   , client_id_{load_from_env(env_var_azure_client_id)}
   , tenant_id_{load_from_env(env_var_azure_tenant_id)}
   , federated_token_file_{load_from_env(env_var_azure_federated_token_file)} {}

--- a/src/v/cloud_roles/azure_aks_refresh_impl.h
+++ b/src/v/cloud_roles/azure_aks_refresh_impl.h
@@ -28,7 +28,8 @@ public:
       aws_service_name service,
       aws_region_name region,
       ss::abort_source& as,
-      retry_params retry_params);
+      retry_params retry_params,
+      ss::sstring metrics_tag = "");
 
     /// Fetches credentials from api, the result can be iobuf or an error
     /// encountered during the fetch operation

--- a/src/v/cloud_roles/azure_vm_refresh_impl.cc
+++ b/src/v/cloud_roles/azure_vm_refresh_impl.cc
@@ -23,9 +23,14 @@ azure_vm_refresh_impl::azure_vm_refresh_impl(
   aws_service_name, // Ignored for Azure VM
   aws_region_name region,
   ss::abort_source& as,
-  retry_params retry_params)
+  retry_params retry_params,
+  ss::sstring metrics_tag)
   : refresh_credentials::impl(
-      std::move(address), std::move(region), as, retry_params) {}
+      std::move(address),
+      std::move(region),
+      as,
+      retry_params,
+      std::move(metrics_tag)) {}
 
 std::ostream& azure_vm_refresh_impl::print(std::ostream& os) const {
     fmt::print(os, "azure_vm_refresh_impl{{address:{}}}", address());

--- a/src/v/cloud_roles/azure_vm_refresh_impl.h
+++ b/src/v/cloud_roles/azure_vm_refresh_impl.h
@@ -27,7 +27,8 @@ public:
       aws_service_name service,
       aws_region_name region,
       ss::abort_source& as,
-      retry_params retry_params = default_retry_params);
+      retry_params retry_params = default_retry_params,
+      ss::sstring metrics_tag = "");
     ss::future<api_response> fetch_credentials() override;
 
     std::ostream& print(std::ostream& os) const override;

--- a/src/v/cloud_roles/gcp_refresh_impl.cc
+++ b/src/v/cloud_roles/gcp_refresh_impl.cc
@@ -40,9 +40,14 @@ gcp_refresh_impl::gcp_refresh_impl(
   aws_service_name, // Ignored for GCP
   aws_region_name region,
   ss::abort_source& as,
-  retry_params retry_params)
+  retry_params retry_params,
+  ss::sstring metrics_tag)
   : refresh_credentials::impl(
-      std::move(address), std::move(region), as, retry_params) {}
+      std::move(address),
+      std::move(region),
+      as,
+      retry_params,
+      std::move(metrics_tag)) {}
 
 ss::future<api_response> gcp_refresh_impl::fetch_credentials() {
     http::client::request_header oauth_req;

--- a/src/v/cloud_roles/gcp_refresh_impl.h
+++ b/src/v/cloud_roles/gcp_refresh_impl.h
@@ -24,7 +24,8 @@ public:
       aws_service_name service,
       aws_region_name region,
       ss::abort_source& as,
-      retry_params retry_params = default_retry_params);
+      retry_params retry_params = default_retry_params,
+      ss::sstring metrics_tag = "");
     ss::future<api_response> fetch_credentials() override;
 
     std::ostream& print(std::ostream& os) const override;

--- a/src/v/cloud_roles/refresh_credentials.cc
+++ b/src/v/cloud_roles/refresh_credentials.cc
@@ -23,6 +23,7 @@
 #include "net/tls.h"
 #include "net/tls_certificate_probe.h"
 #include "ssx/future-util.h"
+#include "ssx/sformat.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/gate.hh>
@@ -160,11 +161,13 @@ refresh_credentials::impl::impl(
   net::unresolved_address address,
   aws_region_name region,
   ss::abort_source& as,
-  retry_params retry_params)
+  retry_params retry_params,
+  ss::sstring metrics_tag)
   : _address{std::move(address)}
   , _region{std::move(region)}
   , _as{as}
-  , _retry_params{retry_params} {
+  , _retry_params{retry_params}
+  , _metrics_tag{std::move(metrics_tag)} {
     if (auto address_override = load_and_validate_env_var(override_address);
         address_override) {
         auto address = parse_address(address_override.value());
@@ -395,9 +398,13 @@ ss::future<> refresh_credentials::impl::init_tls_certs(ss::sstring name) {
       .require_client_auth = false,
     });
 
+    auto detail = _metrics_tag.empty()
+                    ? std::move(name)
+                    : ssx::sformat("{}_{}", name, _metrics_tag);
+
     _tls_certs = co_await net::build_reloadable_credentials_with_probe<
       ss::tls::certificate_credentials>(
-      std::move(builder), "cloud_provider_client", std::move(name));
+      std::move(builder), "cloud_provider_client", std::move(detail));
 }
 
 refresh_credentials make_refresh_credentials(

--- a/src/v/cloud_roles/refresh_credentials.h
+++ b/src/v/cloud_roles/refresh_credentials.h
@@ -39,7 +39,8 @@ public:
           net::unresolved_address address,
           aws_region_name region,
           ss::abort_source& as,
-          retry_params retry_params);
+          retry_params retry_params,
+          ss::sstring metrics_tag = "");
         impl(impl&&) noexcept = default;
 
         impl& operator=(impl&&) noexcept = delete;
@@ -125,6 +126,12 @@ public:
         retry_params _retry_params;
         ss::shared_ptr<ss::tls::certificate_credentials> _tls_certs = nullptr;
         mutable std::optional<ss::abort_source> _per_sleep_as;
+
+        /// Identifier of the owning subsystem (e.g. "datalake"). Appended to
+        /// the TLS certificate probe's `detail` label so multiple
+        /// `refresh_credentials` instances using the same credential type
+        /// register distinct metrics.
+        ss::sstring _metrics_tag;
     };
 
     refresh_credentials(
@@ -213,7 +220,8 @@ refresh_credentials make_refresh_credentials(
       service,
       region,
       as,
-      retry_params);
+      retry_params,
+      metrics_tag);
     return refresh_credentials{
       std::move(impl),
       as,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30489

- Command: git cherry-pick -x 4f0f029c50
- Commits backported: 1
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-30489-v25.3.x-1778874959

## Conflict details

- 4f0f029c50 (src/v/cloud_roles/refresh_credentials.cc): the `impl` constructor initializer list and following `if`-statement formatting diverged between dev and v25.3.x. Kept v25.3.x's compact `if (auto ...; cond)` single-line formatting while adding the new `_metrics_tag{std::move(metrics_tag)}` initializer that is the actual intent of the commit.


Fixes: https://github.com/redpanda-data/redpanda/issues/30504,
