### PR TITLE
`config`: deprecate `cloud_topics_enabled()`

### DIFF
--- a/src/v/cloud_topics/test_fixture_cfg.h
+++ b/src/v/cloud_topics/test_fixture_cfg.h
@@ -17,6 +17,10 @@ struct test_fixture_cfg {
     bool use_lsm_metastore{true};
     bool skip_flush_loop{false};
     bool skip_level_zero_gc{false};
+    bool disable_cloud_topics{false};
 };
+
+static constexpr test_fixture_cfg disable_cloud_topics_test_cfg{
+  .disable_cloud_topics = true};
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/tests/cluster_fixture.h
+++ b/src/v/cloud_topics/tests/cluster_fixture.h
@@ -58,7 +58,6 @@ public:
           cs_conf,
           /*legacy_upload_mode_enabled=*/true,
           /*iceberg_enabled=*/false,
-          /*cloud_topics_enabled=*/true,
           /*cluster_linking_enabled=*/false,
           /*seed_node_id=*/model::node_id{0},
           ct_test_cfg);

--- a/src/v/cloud_topics/tests/read_replica_test.cc
+++ b/src/v/cloud_topics/tests/read_replica_test.cc
@@ -114,7 +114,6 @@ public:
           false, // enable_data_transforms
           true,  // enable_legacy_upload_mode
           false, // iceberg_enabled
-          true,  // enable_cloud_topics
           false, // development_cluster_linking_enabled
           ct_cfg);
         replica->wait_for_controller_leadership().get();

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -282,9 +282,6 @@ feature_manager::report_enterprise_features() const {
       features::license_required_feature::shadow_linking,
       cfg.enable_shadow_linking());
     report.set(
-      features::license_required_feature::cloud_topics,
-      cfg.cloud_topics_enabled());
-    report.set(
       features::license_required_feature::topic_deletion_disabled,
       !cfg.delete_topic_enable());
     return report;

--- a/src/v/cluster/tests/cluster_test_fixture.h
+++ b/src/v/cluster/tests/cluster_test_fixture.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "absl/container/flat_hash_map.h"
+#include "cloud_topics/test_fixture_cfg.h"
 #include "cluster/fwd.h"
 #include "cluster/tests/utils.h"
 #include "cluster/types.h"
@@ -120,9 +121,9 @@ public:
       std::optional<cloud_storage::configuration> cloud_cfg = std::nullopt,
       bool enable_legacy_upload_mode = true,
       bool iceberg_enabled = false,
-      bool cloud_topics_enabled = false,
       bool cluster_linking_enabled = false,
-      cloud_topics::test_fixture_cfg ct_test_cfg = {}) {
+      cloud_topics::test_fixture_cfg ct_test_cfg
+      = cloud_topics::disable_cloud_topics_test_cfg) {
         return std::make_unique<redpanda_thread_fixture>(
           node_id,
           kafka_port,
@@ -140,7 +141,6 @@ public:
           false,
           enable_legacy_upload_mode,
           iceberg_enabled,
-          cloud_topics_enabled,
           cluster_linking_enabled,
           ct_test_cfg);
     }
@@ -161,9 +161,9 @@ public:
       std::optional<cloud_storage::configuration> cloud_cfg = std::nullopt,
       bool enable_legacy_upload_mode = true,
       bool iceberg_enabled = false,
-      bool cloud_topics_enabled = false,
       bool cluster_linking_enabled = false,
-      cloud_topics::test_fixture_cfg ct_test_cfg = {}) {
+      cloud_topics::test_fixture_cfg ct_test_cfg
+      = cloud_topics::disable_cloud_topics_test_cfg) {
         _instances.emplace(
           node_id,
           make_redpanda_fixture(
@@ -180,7 +180,6 @@ public:
             cloud_cfg,
             enable_legacy_upload_mode,
             iceberg_enabled,
-            cloud_topics_enabled,
             cluster_linking_enabled,
             ct_test_cfg));
     }
@@ -222,10 +221,10 @@ public:
       std::optional<cloud_storage::configuration> cloud_cfg = std::nullopt,
       bool legacy_upload_mode_enabled = true,
       bool iceberg_enabled = false,
-      bool cloud_topics_enabled = false,
       bool cluster_linking_enabled = false,
       model::node_id seed_node_id = model::node_id{0},
-      cloud_topics::test_fixture_cfg ct_test_cfg = {}) {
+      cloud_topics::test_fixture_cfg ct_test_cfg
+      = cloud_topics::disable_cloud_topics_test_cfg) {
         std::vector<config::seed_server> seeds = {};
         if (!empty_seed_starts_cluster_val || node_id != 0) {
             seeds.push_back(
@@ -248,7 +247,6 @@ public:
           cloud_cfg,
           legacy_upload_mode_enabled,
           iceberg_enabled,
-          cloud_topics_enabled,
           cluster_linking_enabled,
           ct_test_cfg);
         return get_node_application(node_id);

--- a/src/v/cluster/tests/controller_forced_reconfiguration_test.cc
+++ b/src/v/cluster/tests/controller_forced_reconfiguration_test.cc
@@ -81,7 +81,6 @@ public:
           std::nullopt,
           true,
           false,
-          false,
           true,
           survivor);
     }

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -85,6 +85,9 @@ get_enterprise_features(const cluster::topic_configuration& cfg) {
         if (cfg.is_read_replica()) {
             features.emplace_back("remote read replicas");
         }
+        if (cfg.is_cloud_topic()) {
+            features.emplace_back("cloud topics");
+        }
     }
 
     // Only enforce schema ID validation topic configs if Schema ID validation
@@ -107,11 +110,6 @@ get_enterprise_features(const cluster::topic_configuration& cfg) {
     if (config::shard_local_cfg().iceberg_enabled.is_restricted()) {
         if (cfg.properties.iceberg_mode != model::iceberg_mode::disabled) {
             features.emplace_back("iceberg");
-        }
-    }
-    if (config::shard_local_cfg().cloud_topics_enabled.is_restricted()) {
-        if (cfg.is_cloud_topic()) {
-            features.emplace_back("cloud topics");
         }
     }
     return features;
@@ -147,6 +145,9 @@ std::vector<std::string_view> get_enterprise_features(
           || (old_storage_mode != tiered && new_storage_mode == tiered)
           || (properties.remote_delete < updated_properties.remote_delete)) {
             features.emplace_back("tiered storage");
+        }
+        if (updated_properties.is_cloud_topic()) {
+            features.emplace_back("cloud topics");
         }
     }
 
@@ -217,11 +218,6 @@ std::vector<std::string_view> get_enterprise_features(
     if (config::shard_local_cfg().iceberg_enabled.is_restricted()) {
         if (properties.iceberg_mode != model::iceberg_mode::disabled) {
             features.emplace_back("iceberg");
-        }
-    }
-    if (config::shard_local_cfg().cloud_topics_enabled.is_restricted()) {
-        if (properties.is_cloud_topic()) {
-            features.emplace_back("cloud topics");
         }
     }
     return features;
@@ -648,15 +644,14 @@ topic_result topics_frontend::validate_topic_configuration(
           errc::topic_invalid_config, "Tiered storage is not enabled");
     }
 
-    // the only way that cloud topics can be enabled on a topic is if the cloud
-    // topics development feature is also enabled.
-    if (!config::shard_local_cfg().cloud_topics_enabled()) {
+    // the only way that cloud topics can be enabled on a topic is if cloud
+    // storage is also enabled.
+    if (!config::shard_local_cfg().cloud_storage_enabled()) {
         if (
           assignable_config.cfg.properties.storage_mode
           == model::redpanda_storage_mode::cloud) {
             auto msg = ssx::sformat(
-              "Cloud storage mode on {} is set but development feature is "
-              "disabled",
+              "Cloud storage mode on {} is set but cloud storage is disabled",
               assignable_config.cfg.tp_ns);
             vlog(clusterlog.error, "{}", msg);
             return make_result(errc::topic_invalid_config, std::move(msg));

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4619,13 +4619,7 @@ configuration::configuration()
       "Default timeout for RPC requests between Redpanda nodes.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       10s)
-  , cloud_topics_enabled(
-      *this,
-      true,
-      "cloud_topics_enabled",
-      "Enable cloud topics.",
-      meta{.needs_restart = needs_restart::yes, .visibility = visibility::user},
-      false)
+  , cloud_topics_enabled(*this, "cloud_topics_enabled")
   , cloud_topics_produce_batching_size_threshold(
       *this,
       "cloud_topics_produce_batching_size_threshold",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -787,7 +787,7 @@ struct configuration final : public config_store {
     error_map_t load(const YAML::Node& root_node);
 
 public:
-    enterprise<property<bool>> cloud_topics_enabled;
+    deprecated_property cloud_topics_enabled;
     property<size_t> cloud_topics_produce_batching_size_threshold;
     property<std::chrono::milliseconds> cloud_topics_produce_upload_interval;
     property<size_t> cloud_topics_produce_cardinality_threshold;

--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -470,18 +470,18 @@ validate_default_redpanda_storage_mode(const configuration& config) {
 
     if (
       mode == model::redpanda_storage_mode::cloud
-      && !config.cloud_topics_enabled()) {
+      && !config.cloud_storage_enabled()) {
         return fmt::format(
           "default_redpanda_storage_mode cannot be set to cloud when "
-          "cloud_topics_enabled is false");
+          "cloud_storage_enabled is false");
     }
 
     if (
       mode == model::redpanda_storage_mode::tiered_cloud
-      && !config.cloud_topics_enabled()) {
+      && !config.cloud_storage_enabled()) {
         return fmt::format(
           "default_redpanda_storage_mode cannot be set to tiered_cloud when "
-          "cloud_topics_enabled is false");
+          "cloud_storage_enabled is false");
     }
 
     return std::nullopt;

--- a/src/v/features/enterprise_features.h
+++ b/src/v/features/enterprise_features.h
@@ -33,7 +33,6 @@ enum class license_required_feature {
     datalake_iceberg,
     leadership_pinning,
     shadow_linking,
-    cloud_topics,
     topic_deletion_disabled,
 };
 
@@ -63,8 +62,6 @@ inline fmt::iterator format_to(license_required_feature f, fmt::iterator out) {
         return fmt::format_to(out, "leadership_pinning");
     case license_required_feature::shadow_linking:
         return fmt::format_to(out, "shadow_linking");
-    case license_required_feature::cloud_topics:
-        return fmt::format_to(out, "cloud_topics");
     case license_required_feature::topic_deletion_disabled:
         return fmt::format_to(out, "topic_deletion_disabled");
     }
@@ -100,7 +97,6 @@ public:
     // | Cluster     | `enable_schema_id_validation`   | `compat`      |
     // | Cluster     | `iceberg_enabled`               | `true`        |
     // | Cluster     | `enable_shadow_linking`         | `true`        |
-    // | Cluster     | `cloud_topics_enabled`          | `true`        |
     // | Cluster     | `delete_topic_enable`           | `false`       |
     // | Node        | `fips_mode`                     | `enabled`     |
     // | Node        | `fips_mode`                     | `permissive`  |

--- a/src/v/kafka/client/direct_consumer/tests/direct_consumer_fixture.cc
+++ b/src/v/kafka/client/direct_consumer/tests/direct_consumer_fixture.cc
@@ -365,7 +365,6 @@ application* consumer_fixture::create_node_application(model::node_id node_id) {
       std::nullopt,
       true,
       false,
-      false,
       /* cluster_linking_enabled */ true);
 }
 

--- a/src/v/kafka/server/handlers/topics/validators.h
+++ b/src/v/kafka/server/handlers/topics/validators.h
@@ -538,14 +538,14 @@ struct min_max_compaction_lag_ms_validator {
 
 /*
  * Validates that storage_mode is compatible with the cluster configuration:
- * - 'cloud' mode requires cloud_topics_enabled()
+ * - 'cloud' mode requires cloud_storage_enabled()
  * - 'tiered' mode requires cloud_storage_enabled()
  * - 'local' mode is always allowed
  */
 struct storage_mode_config_validator {
     static constexpr const char* error_message
-      = "Invalid storage mode: 'cloud' requires cloud topics to be enabled and "
-        "the cluster to be fully upgraded to at least v26.1.1, "
+      = "Invalid storage mode: 'cloud' requires cloud storage to be enabled "
+        "and the cluster to be fully upgraded to at least v26.1.1, "
         "'tiered_cloud' additionally requires the tiered_cloud_topics feature "
         "to be explicitly enabled, "
         "'tiered' requires cloud storage to be enabled.";
@@ -577,14 +577,14 @@ struct storage_mode_config_validator {
               || !ft->is_active(features::feature::cloud_topics)) {
                 return false;
             }
-            return config::shard_local_cfg().cloud_topics_enabled();
+            return config::shard_local_cfg().cloud_storage_enabled();
         case model::redpanda_storage_mode::tiered_cloud:
             if (
               ft == nullptr || !ft->is_active(features::feature::cloud_topics)
               || !ft->is_active(features::feature::tiered_cloud_topics)) {
                 return false;
             }
-            return config::shard_local_cfg().cloud_topics_enabled();
+            return config::shard_local_cfg().cloud_storage_enabled();
         case model::redpanda_storage_mode::unset:
             // unset is always valid - actual behavior depends on
             // shadow_indexing

--- a/src/v/redpanda/application_rpc.cc
+++ b/src/v/redpanda/application_rpc.cc
@@ -177,7 +177,7 @@ void application::add_runtime_rpc_services(
             smp_service_groups.datalake_sg(),
             &_datalake_coordinator_fe));
     }
-    if (config::shard_local_cfg().cloud_topics_enabled() && cloud_topics_app) {
+    if (config::shard_local_cfg().cloud_storage_enabled() && cloud_topics_app) {
         runtime_services.push_back(
           std::make_unique<cloud_topics::l1::rpc::service>(
             scheduling_groups::instance().cloud_topics_metastore_sg(),

--- a/src/v/redpanda/application_services.cc
+++ b/src/v/redpanda/application_services.cc
@@ -280,7 +280,9 @@ void application::wire_up_redpanda_services(
     producer_manager.invoke_on_all(&cluster::tx::producer_state_manager::start)
       .get();
 
-    if (config::shard_local_cfg().cloud_topics_enabled()) {
+    if (
+      config::shard_local_cfg().cloud_topics_enabled()
+      && !ct_test_cfg.disable_cloud_topics) {
         vassert(
           archival_storage_enabled(),
           "cloud topics currently requires archival storage to be enabled");

--- a/src/v/redpanda/application_services.cc
+++ b/src/v/redpanda/application_services.cc
@@ -281,7 +281,7 @@ void application::wire_up_redpanda_services(
       .get();
 
     if (
-      config::shard_local_cfg().cloud_topics_enabled()
+      config::shard_local_cfg().cloud_storage_enabled()
       && !ct_test_cfg.disable_cloud_topics) {
         vassert(
           archival_storage_enabled(),

--- a/src/v/redpanda/application_start.cc
+++ b/src/v/redpanda/application_start.cc
@@ -88,7 +88,9 @@ void application::start_runtime_services(
           pm.register_factory<datalake::coordinator::stm_factory>();
           pm.register_factory<datalake::translation::stm_factory>(
             config::shard_local_cfg().iceberg_enabled());
-          if (config::shard_local_cfg().cloud_topics_enabled()) {
+          if (
+            config::shard_local_cfg().cloud_topics_enabled()
+            && !ct_test_cfg.disable_cloud_topics) {
               pm.register_factory<cloud_topics::l0::ctp_stm_factory>();
               pm.register_factory<cloud_topics::read_replica::stm_factory>();
               if (ct_test_cfg.use_lsm_metastore) {

--- a/src/v/redpanda/application_start.cc
+++ b/src/v/redpanda/application_start.cc
@@ -89,7 +89,7 @@ void application::start_runtime_services(
           pm.register_factory<datalake::translation::stm_factory>(
             config::shard_local_cfg().iceberg_enabled());
           if (
-            config::shard_local_cfg().cloud_topics_enabled()
+            config::shard_local_cfg().cloud_storage_enabled()
             && !ct_test_cfg.disable_cloud_topics) {
               pm.register_factory<cloud_topics::l0::ctp_stm_factory>();
               pm.register_factory<cloud_topics::read_replica::stm_factory>();

--- a/src/v/redpanda/tests/fixture.cc
+++ b/src/v/redpanda/tests/fixture.cc
@@ -88,7 +88,6 @@ redpanda_thread_fixture::redpanda_thread_fixture(
   bool enable_data_transforms,
   bool enable_legacy_upload_mode,
   bool iceberg_enabled,
-  bool enable_cloud_topics,
   bool development_cluster_linking_enabled,
   cloud_topics::test_fixture_cfg ct_test_cfg)
   : app(ssx::sformat("redpanda-{}", node_id()))
@@ -112,7 +111,6 @@ redpanda_thread_fixture::redpanda_thread_fixture(
       enable_data_transforms,
       enable_legacy_upload_mode,
       iceberg_enabled,
-      enable_cloud_topics,
       development_cluster_linking_enabled);
     try {
         app.initialize(
@@ -206,7 +204,8 @@ redpanda_thread_fixture::redpanda_thread_fixture(
   init_cloud_storage_tag,
   std::optional<uint16_t> port,
   cloud_storage_clients::s3_url_style url_style,
-  model::node_id node_id)
+  model::node_id node_id,
+  cloud_topics::test_fixture_cfg ct_test_cfg)
   : redpanda_thread_fixture(
       node_id,
       9092,
@@ -218,7 +217,14 @@ redpanda_thread_fixture::redpanda_thread_fixture(
       true,
       get_s3_config(port, url_style),
       get_archival_config(),
-      get_cloud_config(port, url_style)) {}
+      get_cloud_config(port, url_style),
+      configure_node_id::yes,
+      empty_seed_starts_cluster::yes,
+      false,
+      true,
+      false,
+      false,
+      ct_test_cfg) {}
 
 // Start redpanda with shadow indexing enabled
 redpanda_thread_fixture::redpanda_thread_fixture(
@@ -244,14 +250,14 @@ redpanda_thread_fixture::redpanda_thread_fixture(
       false,
       true,
       false,
-      true,
       false,
       ct_test_cfg) {}
 
 redpanda_thread_fixture::redpanda_thread_fixture(
   init_cloud_storage_no_archiver_tag,
   std::optional<uint16_t> port,
-  cloud_storage_clients::s3_url_style url_style)
+  cloud_storage_clients::s3_url_style url_style,
+  cloud_topics::test_fixture_cfg ct_test_cfg)
   : redpanda_thread_fixture(
       model::node_id(1),
       9092,
@@ -263,7 +269,14 @@ redpanda_thread_fixture::redpanda_thread_fixture(
       true,
       get_s3_config(port, url_style),
       get_archival_config(),
-      std::nullopt) {}
+      std::nullopt,
+      configure_node_id::yes,
+      empty_seed_starts_cluster::yes,
+      false,
+      true,
+      false,
+      false,
+      ct_test_cfg) {}
 
 redpanda_thread_fixture::~redpanda_thread_fixture() {
     shutdown();
@@ -351,7 +364,6 @@ void redpanda_thread_fixture::configure(
   bool data_transforms_enabled,
   bool legacy_upload_mode_enabled,
   bool iceberg_enabled,
-  bool cloud_topics_enabled,
   bool development_cluster_linking_enabled) {
     auto base_path = std::filesystem::path(data_dir);
     ss::smp::invoke_on_all([=]() {
@@ -448,11 +460,6 @@ void redpanda_thread_fixture::configure(
         config.get("cloud_storage_disable_archiver_manager")
           .set_value(legacy_upload_mode_enabled);
         config.get("iceberg_enabled").set_value(iceberg_enabled);
-
-        if (cloud_topics_enabled) {
-            config.get(config::shard_local_cfg().cloud_topics_enabled.name())
-              .set_value(true);
-        }
 
         config.get("enable_shadow_linking")
           .set_value(development_cluster_linking_enabled);

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -86,9 +86,9 @@ public:
       bool enable_data_transforms = false,
       bool enable_legacy_upload_mode = true,
       bool iceberg_enabled = false,
-      bool enable_cloud_topics = false,
       bool development_cluster_linking_enabled = false,
-      cloud_topics::test_fixture_cfg ct_test_cfg = {});
+      cloud_topics::test_fixture_cfg ct_test_cfg
+      = cloud_topics::disable_cloud_topics_test_cfg);
 
     // creates single node with default configuration
     redpanda_thread_fixture();
@@ -103,7 +103,9 @@ public:
       init_cloud_storage_tag,
       std::optional<uint16_t> port = std::nullopt,
       cloud_storage_clients::s3_url_style url_style = default_url_style,
-      model::node_id node_id = model::node_id(1));
+      model::node_id node_id = model::node_id(1),
+      cloud_topics::test_fixture_cfg ct_test_cfg
+      = cloud_topics::disable_cloud_topics_test_cfg);
 
     struct init_cloud_topics_tag {};
 
@@ -123,7 +125,9 @@ public:
     explicit redpanda_thread_fixture(
       init_cloud_storage_no_archiver_tag,
       std::optional<uint16_t> port = std::nullopt,
-      cloud_storage_clients::s3_url_style url_style = default_url_style);
+      cloud_storage_clients::s3_url_style url_style = default_url_style,
+      cloud_topics::test_fixture_cfg ct_test_cfg
+      = cloud_topics::disable_cloud_topics_test_cfg);
 
     ~redpanda_thread_fixture();
 
@@ -159,7 +163,6 @@ public:
       bool data_transforms_enabled = false,
       bool legacy_upload_mode_enabled = true,
       bool iceberg_enabled = false,
-      bool enable_cloud_topics = false,
       bool development_cluster_linking_enabled = false);
 
     YAML::Node proxy_config(uint16_t proxy_port = 8082);
@@ -324,5 +327,6 @@ public:
     ss::sharded<kafka::server> proto;
     bool remove_on_shutdown;
     std::unique_ptr<::stop_signal> app_signal;
-    cloud_topics::test_fixture_cfg ct_test_cfg{};
+    cloud_topics::test_fixture_cfg ct_test_cfg{
+      cloud_topics::disable_cloud_topics_test_cfg};
 };

--- a/src/v/resource_mgmt/memory_groups.cc
+++ b/src/v/resource_mgmt/memory_groups.cc
@@ -29,8 +29,8 @@ bool datalake_enabled() {
     return config::shard_local_cfg().iceberg_enabled.value();
 }
 
-bool cloud_topics_enabled() {
-    return config::shard_local_cfg().cloud_topics_enabled();
+bool cloud_storage_enabled() {
+    return config::shard_local_cfg().cloud_storage_enabled();
 }
 
 struct memory_shares {
@@ -45,7 +45,7 @@ struct memory_shares {
     constexpr static size_t cloud_topics = 10;
 
     static size_t
-    total_shares(bool with_wasm, bool with_datalake, bool with_cloud_topics) {
+    total_shares(bool with_wasm, bool with_datalake, bool with_cloud_storage) {
         size_t total = chunk_cache + kafka + rpc + recovery + tiered_storage
                        + admin;
         if (with_wasm) {
@@ -54,7 +54,7 @@ struct memory_shares {
         if (with_datalake) {
             total += datalake;
         }
-        if (with_cloud_topics) {
+        if (with_cloud_storage) {
             total += cloud_topics;
         }
         return total;
@@ -81,7 +81,7 @@ system_memory_groups::system_memory_groups(
   cloud_topics_reconciler_memory_reservation cloud_topics_reconciler,
   bool wasm_enabled,
   bool datalake_enabled,
-  bool cloud_topics_enabled,
+  bool cloud_storage_enabled,
   partitions_memory_reservation partitions)
   : _compaction_reserved_memory(
       compaction.reserved_bytes(total_available_memory))
@@ -97,7 +97,7 @@ system_memory_groups::system_memory_groups(
       - _cloud_topics_reconciler_reserved_memory - _partitions_reserved_memory)
   , _wasm_enabled(wasm_enabled)
   , _datalake_enabled(datalake_enabled)
-  , _cloud_topics_enabled(cloud_topics_enabled) {}
+  , _cloud_storage_enabled(cloud_storage_enabled) {}
 
 size_t system_memory_groups::chunk_cache_min_memory() const {
     return chunk_cache_max_memory() / 3;
@@ -142,7 +142,7 @@ size_t system_memory_groups::datalake_max_memory() const {
 }
 
 size_t system_memory_groups::cloud_topics_memory() const {
-    if (!_cloud_topics_enabled) {
+    if (!_cloud_storage_enabled) {
         return 0;
     }
     return subsystem_memory<memory_shares::cloud_topics>();
@@ -163,7 +163,7 @@ size_t system_memory_groups::subsystem_memory() const {
                               / memory_shares::total_shares(
                                 _wasm_enabled,
                                 _datalake_enabled,
-                                _cloud_topics_enabled);
+                                _cloud_storage_enabled);
     return per_share_amount * shares;
 }
 
@@ -233,7 +233,7 @@ system_memory_groups& memory_groups() {
       cloud_topics_reconciler,
       wasm,
       datalake_enabled(),
-      cloud_topics_enabled(),
+      cloud_storage_enabled(),
       partitions);
     return *groups;
 }

--- a/src/v/resource_mgmt/memory_groups.h
+++ b/src/v/resource_mgmt/memory_groups.h
@@ -78,7 +78,7 @@ public:
       cloud_topics_reconciler_memory_reservation cloud_topics_reconciler,
       bool wasm_enabled,
       bool datalake_enabled,
-      bool cloud_topics_enabled,
+      bool cloud_storage_enabled,
       partitions_memory_reservation partitions);
 
     size_t kafka_total_memory() const;
@@ -155,7 +155,7 @@ private:
     size_t _total_system_memory;
     bool _wasm_enabled;
     bool _datalake_enabled;
-    bool _cloud_topics_enabled;
+    bool _cloud_storage_enabled;
 
     friend class testing::system_memory_groups_accessor;
 };

--- a/src/v/resource_mgmt/tests/memory_groups_test.cc
+++ b/src/v/resource_mgmt/tests/memory_groups_test.cc
@@ -19,7 +19,7 @@
 static constexpr size_t total_shares_without_optionals = 87;
 static constexpr size_t total_wasm_shares = 10;
 static constexpr size_t total_datalake_shares = 10;
-static constexpr size_t total_cloud_topic_shares = 10;
+static constexpr size_t total_cloud_storage_shares = 10;
 
 // It's not really useful to know the exact byte values for each of these
 // numbers so we just make sure we're within a MB
@@ -43,7 +43,7 @@ public:
     bool compaction_enabled() const { return std::get<0>(GetParam()); }
     bool wasm_enabled() const { return std::get<1>(GetParam()); }
     bool datalake_enabled() const { return std::get<2>(GetParam()); }
-    bool cloud_topics_enabled() const { return std::get<3>(GetParam()); }
+    bool cloud_storage_enabled() const { return std::get<3>(GetParam()); }
 };
 
 TEST_P(MemoryGroupSharesTest, DividesSharesCorrectly) {
@@ -73,7 +73,7 @@ TEST_P(MemoryGroupSharesTest, DividesSharesCorrectly) {
       /*cloud_topics_reconciler_memory_reservation=*/{},
       wasm_enabled(),
       datalake_enabled(),
-      cloud_topics_enabled(),
+      cloud_storage_enabled(),
       partitions);
     auto total_shares = total_shares_without_optionals;
     if (wasm_enabled()) {
@@ -82,8 +82,8 @@ TEST_P(MemoryGroupSharesTest, DividesSharesCorrectly) {
     if (datalake_enabled()) {
         total_shares += total_datalake_shares;
     }
-    if (cloud_topics_enabled()) {
-        total_shares += total_cloud_topic_shares;
+    if (cloud_storage_enabled()) {
+        total_shares += total_cloud_storage_shares;
     }
     EXPECT_THAT(
       groups.chunk_cache_min_memory(),
@@ -155,7 +155,7 @@ TEST(MemoryGroups, CompactionMemoryBytes) {
           /*cloud_topics_reconciler_memory_reservation=*/{},
           /*wasm_enabled=*/false,
           /*datalake_enabled=*/false,
-          /*cloud_topics_enabled=*/false,
+          /*cloud_storage_enabled=*/false,
           {
             .max_limit_pct = 20,
           });
@@ -174,7 +174,7 @@ TEST(MemoryGroups, CompactionMemoryBytes) {
           /*cloud_topics_reconciler_memory_reservation=*/{},
           /*wasm_enabled=*/false,
           /*datalake_enabled=*/false,
-          /*cloud_topics_enabled=*/false,
+          /*cloud_storage_enabled=*/false,
           {
             .max_limit_pct = 20,
           });

--- a/tests/rptest/scale_tests/cloud_topics_compaction_scale_test.py
+++ b/tests/rptest/scale_tests/cloud_topics_compaction_scale_test.py
@@ -23,7 +23,6 @@ from rptest.services.kgo_verifier_services import (
 )
 from rptest.services.admin import Admin
 from rptest.services.redpanda import (
-    CLOUD_TOPICS_CONFIG_STR,
     MetricsEndpoint,
     SISettings,
 )
@@ -73,7 +72,6 @@ class CloudTopicsCompactionScaleTest(PreallocNodesTest):
         )
 
         extra_rp_conf = {
-            CLOUD_TOPICS_CONFIG_STR: True,
             "enable_cluster_metadata_upload_loop": False,
             "cloud_topics_compaction_interval_ms": self.COMPACTION_INTERVAL_MS,
             "cloud_topics_compaction_key_map_memory": self.KEY_MAP_MEMORY,

--- a/tests/rptest/scale_tests/large_messages_test.py
+++ b/tests/rptest/scale_tests/large_messages_test.py
@@ -26,7 +26,6 @@ from rptest.services.cluster import cluster
 from rptest.services.consumer_swarm import ConsumerSwarm
 from rptest.services.producer_swarm import ProducerSwarm
 from rptest.services.redpanda import (
-    CLOUD_TOPICS_CONFIG_STR,
     RESTART_LOG_ALLOW_LIST,
     LoggingConfig,
     MetricsEndpoint,
@@ -634,7 +633,6 @@ class LargeMessagesTest(RedpandaTest):
         self.redpanda.set_si_settings(si_settings)
         self.redpanda.add_extra_rp_conf(
             {
-                CLOUD_TOPICS_CONFIG_STR: True,
                 "enable_cluster_metadata_upload_loop": False,
             }
         )

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -32,7 +32,6 @@ from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark
 from rptest.services.openmessaging_benchmark_configs import OMBSampleConfigurations
 from rptest.clients.types import TopicSpec
 from rptest.services.redpanda import (
-    CLOUD_TOPICS_CONFIG_STR,
     RESTART_LOG_ALLOW_LIST,
     LoggingConfig,
     SISettings,
@@ -1020,9 +1019,6 @@ class ManyPartitionsTest(PreallocNodesTest):
                 "topic_partitions_memory_allocation_percent": DEFAULT_PARTITIONS_MEMORY_ALLOCATION_PERCENT,
             }
         )
-
-        if cloud_topics_enabled:
-            self.redpanda.add_extra_rp_conf({CLOUD_TOPICS_CONFIG_STR: True})
 
         self.redpanda.start()
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -6091,7 +6091,7 @@ class RedpandaService(Service, RedpandaServiceABC):
         if not self.started_nodes():
             return
 
-        admin = AdminV2(self)
+        admin = AdminV2(self, auth=(self._superuser.username, self._superuser.password))
         all_anomalies: list[str] = []
         max_retries = 5
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -338,8 +338,6 @@ OIDC_ALLOW_LIST = [
     re.compile("security - .* - Error updating"),
 ]
 
-CLOUD_TOPICS_CONFIG_STR = "cloud_topics_enabled"
-
 
 class RemoteClusterNode(Protocol):
     account: RemoteAccount

--- a/tests/rptest/tests/cloud_topics/e2e_test.py
+++ b/tests/rptest/tests/cloud_topics/e2e_test.py
@@ -28,7 +28,6 @@ from rptest.services.redpanda import (
     SISettings,
     make_redpanda_service,
     MetricsEndpoint,
-    CLOUD_TOPICS_CONFIG_STR,
 )
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.util import Scale
@@ -62,7 +61,6 @@ class EndToEndCloudTopicsBase(EndToEndTest):
         self.topic = self.s3_topic_name
 
         conf = {
-            CLOUD_TOPICS_CONFIG_STR: True,
             "enable_cluster_metadata_upload_loop": False,
         }
 

--- a/tests/rptest/tests/cloud_topics/l0_gc_test.py
+++ b/tests/rptest/tests/cloud_topics/l0_gc_test.py
@@ -34,7 +34,6 @@ from rptest.services.cluster import cluster
 from rptest.services.redpanda import (
     SISettings,
     get_cloud_storage_type,
-    CLOUD_TOPICS_CONFIG_STR,
 )
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import expect_exception, wait_until_with_progress_check
@@ -60,7 +59,6 @@ class CloudTopicsL0GCTestBase(RedpandaTest):
             fast_uploads=True,
         )
         extra_rp_conf = {
-            CLOUD_TOPICS_CONFIG_STR: True,
             "cloud_topics_reconciliation_min_interval": 2000,
             "cloud_topics_reconciliation_max_interval": 2000,
             "cloud_topics_epoch_service_epoch_increment_interval": 5000,

--- a/tests/rptest/tests/cloud_topics/partial_restart_test.py
+++ b/tests/rptest/tests/cloud_topics/partial_restart_test.py
@@ -20,7 +20,7 @@ from rptest.services.kgo_verifier_services import (
     KgoVerifierProducer,
     KgoVerifierSeqConsumer,
 )
-from rptest.services.redpanda import CLOUD_TOPICS_CONFIG_STR, SISettings
+from rptest.services.redpanda import SISettings
 from rptest.tests.cluster_config_test import wait_for_version_status_sync
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.util import expect_exception, wait_until_result
@@ -63,7 +63,7 @@ class CloudTopicsPartialRestartTest(PreallocNodesTest):
     def test_cloud_topic_with_partial_restart(self):
         """
         If only the controller leader is restarted after enabling
-        cloud_topics_enabled (a needs_restart=yes property), the
+        cloud_storage_enabled (a needs_restart=yes property), the
         restarted node has the property in active but the other
         two nodes still have it pending. Creating a cloud topic
         via the restarted controller leader then validates against
@@ -77,6 +77,12 @@ class CloudTopicsPartialRestartTest(PreallocNodesTest):
         and replicated through the traditional raft log.
         """
         all_nodes = self.redpanda.nodes
+        # Start with cloud_storage_enabled=False so the property is in its
+        # default state on every node. SISettings would otherwise turn it
+        # on at startup; override it back off here. The test will flip it
+        # on via patch_cluster_config to reproduce the partial-restart
+        # inconsistency.
+        self.redpanda.add_extra_rp_conf({"cloud_storage_enabled": False})
         self.redpanda.start(all_nodes)
         wait_until(
             lambda: len(self.admin.get_cluster_config_status()) == 3,
@@ -94,10 +100,10 @@ class CloudTopicsPartialRestartTest(PreallocNodesTest):
         original_leader = self.redpanda.get_node(original_leader_id)
         other_nodes = [n for n in all_nodes if n is not original_leader]
 
-        # Enable cloud_topics_enabled cluster-wide. All three nodes
+        # Enable cloud_storage_enabled cluster-wide. All three nodes
         # should observe restart=true since this is a
         # needs_restart=yes property.
-        new_setting = (CLOUD_TOPICS_CONFIG_STR, True)
+        new_setting = ("cloud_storage_enabled", True)
         patch_result = self.admin.patch_cluster_config(upsert=dict([new_setting]))
         new_version = patch_result["config_version"]
         wait_for_version_status_sync(
@@ -110,7 +116,7 @@ class CloudTopicsPartialRestartTest(PreallocNodesTest):
             )
 
         # Restart ONLY the original controller leader. The other
-        # two nodes intentionally stay with cloud_topics_enabled
+        # two nodes intentionally stay with cloud_storage_enabled
         # pending.
         self.redpanda.restart_nodes(original_leader)
         wait_until(
@@ -157,7 +163,7 @@ class CloudTopicsPartialRestartTest(PreallocNodesTest):
             },
         )
 
-        # The restarted leader has cloud_topics_enabled in active,
+        # The restarted leader has cloud_storage_enabled in active,
         # so its replica should have ctp_stm registered.
         leader_stms = wait_until_result(
             lambda: self._local_replica_stms(original_leader, topic_name, 0),
@@ -171,7 +177,7 @@ class CloudTopicsPartialRestartTest(PreallocNodesTest):
             f"{original_leader_id}; got stms {leader_stms}"
         )
 
-        # The unrestarted nodes still have cloud_topics_enabled
+        # The unrestarted nodes still have cloud_storage_enabled
         # only in pending, so partition_manager builds the
         # partition without ctp_stm. The stms set is fixed at
         # partition construction, so a single read after the
@@ -188,7 +194,7 @@ class CloudTopicsPartialRestartTest(PreallocNodesTest):
             assert "ctp_stm" not in stm_names, (
                 f"ctp_stm unexpectedly present on unrestarted node "
                 f"{n_id}; got stms {stm_names}. The node should not "
-                f"have applied cloud_topics_enabled to active yet."
+                f"have applied cloud_storage_enabled to active yet."
             )
 
         broken_leader = other_nodes[0]
@@ -225,7 +231,7 @@ class CloudTopicsPartialRestartTest(PreallocNodesTest):
                 timeout_sec=15,
             )
 
-        # Complete the rolling restart. Once cloud_topics_enabled is in
+        # Complete the rolling restart. Once cloud_storage_enabled is in
         # active on every node, partition_manager rebuilds this
         # partition's replicas with ctp_stm and the cluster reaches a
         # consistent state.

--- a/tests/rptest/tests/cloud_topics/upgrade_test.py
+++ b/tests/rptest/tests/cloud_topics/upgrade_test.py
@@ -15,7 +15,6 @@ from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import (
-    CLOUD_TOPICS_CONFIG_STR,
     PREV_VERSION_LOG_ALLOW_LIST,
     RESTART_LOG_ALLOW_LIST,
     SISettings,
@@ -41,7 +40,6 @@ class CloudTopicsUpgradeTest(RedpandaTest):
         )
 
         extra_rp_conf = {
-            CLOUD_TOPICS_CONFIG_STR: True,
             "enable_cluster_metadata_upload_loop": False,
         }
 
@@ -140,13 +138,12 @@ class CloudTopicsUpgradeTest(RedpandaTest):
         # Wait for the cloud_topics feature to become active.
         self._wait_for_feature_active("cloud_topics")
 
-        # The cloud_topics_enabled config was set in extra_rp_conf, but
-        # v25.3.x doesn't know this property so it was never propagated to
-        # the cluster config store. Explicitly set it now that all nodes
-        # are on a version that recognizes the property. This is a
-        # restart-required property, so restart after setting it.
+        # The NEW_VERSION binary still gates cloud-mode topic creation on the
+        # `cloud_topics_enabled` cluster property. For redpanda v26.2 and beyond,
+        # this property is deprecated and ignored, but the upgrade target here is
+        # the latest release in the v26.1 line.
         self.redpanda.set_cluster_config(
-            {CLOUD_TOPICS_CONFIG_STR: True}, expect_restart=True
+            {"cloud_topics_enabled": True}, expect_restart=True
         )
         self.redpanda.restart_nodes(self.redpanda.nodes)
 

--- a/tests/rptest/tests/cloud_topics_test.py
+++ b/tests/rptest/tests/cloud_topics_test.py
@@ -16,7 +16,6 @@ from rptest.services.cluster import cluster
 from rptest.services.redpanda import (
     SISettings,
     get_cloud_storage_type,
-    CLOUD_TOPICS_CONFIG_STR,
 )
 from rptest.tests.redpanda_test import RedpandaTest
 
@@ -31,17 +30,9 @@ class CloudTopicsTest(RedpandaTest):
 
     def __create_initial_topics(self, storage_mode):
         """
-        Create initial initial test topics with cloud topic enabled. This needs
-        to be done after development feature support has been enabled, and nodes
-        have been restarted so that development services start at bootup.
+        Create initial test topics. Cloud topics are gated by cloud storage,
+        which is already configured via SISettings.
         """
-        self.redpanda.set_cluster_config(
-            values={
-                CLOUD_TOPICS_CONFIG_STR: True,
-            },
-            expect_restart=True,
-        )
-        self.redpanda.restart_nodes(self.redpanda.nodes)
         if storage_mode == TopicSpec.STORAGE_MODE_TIERED_CLOUD:
             self.redpanda.set_feature_active(
                 "tiered_cloud_topics", True, timeout_sec=30

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -37,7 +37,6 @@ from rptest.services.redpanda import (
     RedpandaService,
     SISettings,
     get_cloud_storage_type,
-    CLOUD_TOPICS_CONFIG_STR,
 )
 from rptest.services.redpanda_installer import (
     RedpandaInstaller,
@@ -714,10 +713,9 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
                 "iceberg_rest_catalog_crl_file",
             ]
         )
-        # Cloud storage, cloud topics, and iceberg depend on properly
-        # configured cloud IO. Skip them to avoid breaking the test.
+        # Cloud storage and iceberg depend on properly configured cloud IO.
+        # Skip them to avoid breaking the test.
         exclude_settings.add("cloud_storage_enabled")
-        exclude_settings.add(CLOUD_TOPICS_CONFIG_STR)
         exclude_settings.add("iceberg_enabled")
         exclude_settings.add("default_redpanda_storage_mode")
 

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -52,7 +52,6 @@ from rptest.services.multi_cluster_services import (
     Service as MultiService,
 )
 from rptest.services.redpanda import (
-    CLOUD_TOPICS_CONFIG_STR,
     RESTART_LOG_ALLOW_LIST,
     MetricSamples,
     MetricsEndpoint,
@@ -4519,13 +4518,11 @@ class ShadowLinkingCloudTopicReplicationTests(ShadowLinkPreAllocTestBase):
             test_context,
             si_settings=si_settings,
             extra_rp_conf={
-                CLOUD_TOPICS_CONFIG_STR: True,
                 "enable_cluster_metadata_upload_loop": False,
             },
             secondary_cluster_args=SecondaryClusterArgs(
                 si_settings=si_settings,
                 extra_rp_conf={
-                    CLOUD_TOPICS_CONFIG_STR: True,
                     "enable_shadow_linking": True,
                     "enable_cluster_metadata_upload_loop": False,
                 },

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -49,7 +49,6 @@ from rptest.services.multi_cluster_services import (
     SecondaryClusterSpec,
 )
 from rptest.services.redpanda import (
-    CLOUD_TOPICS_CONFIG_STR,
     LoggingConfig,
     SISettings,
     TLSProvider,
@@ -488,7 +487,6 @@ class ShadowLinkTestBase(PreallocNodesTest):
         if needs_cloud_topics:
             kwargs["extra_rp_conf"].update(
                 {
-                    CLOUD_TOPICS_CONFIG_STR: True,
                     "enable_cluster_metadata_upload_loop": False,
                 }
             )
@@ -504,7 +502,6 @@ class ShadowLinkTestBase(PreallocNodesTest):
                 sec_extra = dict(sec_kwargs.get("extra_rp_conf", {}))
                 sec_extra.update(
                     {
-                        CLOUD_TOPICS_CONFIG_STR: True,
                         "enable_cluster_metadata_upload_loop": False,
                     }
                 )

--- a/tests/rptest/tests/cluster_linking_topic_syncing_test.py
+++ b/tests/rptest/tests/cluster_linking_topic_syncing_test.py
@@ -17,7 +17,6 @@ from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
 from rptest.services.multi_cluster_services import SecondaryClusterArgs
 from rptest.services.redpanda import (
-    CLOUD_TOPICS_CONFIG_STR,
     LoggingConfig,
     SchemaRegistryConfig,
     SecurityConfig,
@@ -1641,13 +1640,11 @@ class ClusterLinkingCloudTopicSync(ShadowLinkTestBase):
             test_context,
             si_settings=si_settings,
             extra_rp_conf={
-                CLOUD_TOPICS_CONFIG_STR: True,
                 "enable_cluster_metadata_upload_loop": False,
             },
             secondary_cluster_args=SecondaryClusterArgs(
                 si_settings=si_settings,
                 extra_rp_conf={
-                    CLOUD_TOPICS_CONFIG_STR: True,
                     "enable_shadow_linking": True,
                     "enable_cluster_metadata_upload_loop": False,
                 },

--- a/tests/rptest/tests/cluster_recovery_test.py
+++ b/tests/rptest/tests/cluster_recovery_test.py
@@ -26,7 +26,7 @@ from rptest.clients.rpk import RPKACLInput, RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
-from rptest.services.redpanda import SISettings, CLOUD_TOPICS_CONFIG_STR
+from rptest.services.redpanda import SISettings
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.admin.v2 import Admin, metastore_pb, ntp_pb
 from connectrpc.errors import ConnectError, ConnectErrorCode
@@ -1000,8 +1000,6 @@ class CloudTopicsClusterRecoveryTest(RedpandaTest):
         )
 
         extra_rp_conf = {
-            # Enable cloud topics
-            CLOUD_TOPICS_CONFIG_STR: True,
             # Enable cluster metadata upload for recovery
             "enable_cluster_metadata_upload_loop": True,
             "cloud_storage_cluster_metadata_upload_interval_ms": 1000,

--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -1543,11 +1543,6 @@ class DataMigrationsApiTest(DataMigrationTestMixin):
         Verify that cloud topics cannot be unmounted. Cloud topics use a
         different storage backend and don't support mount/unmount operations.
         """
-        # Enable cloud topics feature
-        self.redpanda.set_cluster_config(
-            {"cloud_topics_enabled": True}, expect_restart=True
-        )
-
         # Create a cloud topic
         rpk = RpkTool(self.redpanda)
         topic_name = "cloud-topic-test-unmount"

--- a/tests/rptest/tests/enterprise_features_license_test.py
+++ b/tests/rptest/tests/enterprise_features_license_test.py
@@ -15,7 +15,6 @@ from rptest.services.cluster import cluster
 from rptest.services.redpanda import (
     SchemaRegistryConfig,
     SecurityConfig,
-    CLOUD_TOPICS_CONFIG_STR,
 )
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import expect_exception
@@ -47,8 +46,7 @@ class Feature(IntEnum):
     gssapi_override = 11
     oidc_override = 12
     shadow_linking = 13
-    cloud_topics = 14
-    topic_deletion_disabled = 15
+    topic_deletion_disabled = 14
 
 
 def to_enterprise_feature(feature):
@@ -80,7 +78,6 @@ FEATURE_DEPENDENT_CONFIG = {
     Feature.gssapi_override: "sasl_mechanisms_overrides",
     Feature.oidc_override: "sasl_mechanisms_overrides",
     Feature.shadow_linking: "enable_shadow_linking",
-    Feature.cloud_topics: CLOUD_TOPICS_CONFIG_STR,
     Feature.topic_deletion_disabled: "delete_topic_enable",
 }
 
@@ -88,7 +85,6 @@ SKIP_FEATURES = [
     Feature.cloud_storage,  # TODO(oren): initially omitted because it's a bit complicated to initialize infra
     Feature.datalake_iceberg,  # TODO: also depends on cloud infra
     Feature.fips,  # NOTE(oren): omit because it's too much of a pain for CDT
-    Feature.cloud_topics,  # TODO: also depends on cloud infra
 ]
 
 
@@ -257,8 +253,6 @@ class EnterpriseFeaturesTest(EnterpriseFeaturesTestBase):
             )
         elif feature == Feature.shadow_linking:
             self.redpanda.set_cluster_config({"enable_shadow_linking": "true"})
-        elif feature == Feature.cloud_topics:
-            self.redpanda.set_cluster_config({CLOUD_TOPICS_CONFIG_STR: "true"})
         elif feature == Feature.topic_deletion_disabled:
             self.redpanda.set_cluster_config({"delete_topic_enable": "false"})
         else:

--- a/tests/rptest/tests/follower_fetching_test.py
+++ b/tests/rptest/tests/follower_fetching_test.py
@@ -20,7 +20,7 @@ from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.kafka_cli_consumer import KafkaCliConsumer
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
-from rptest.services.redpanda import SISettings, CLOUD_TOPICS_CONFIG_STR
+from rptest.services.redpanda import SISettings
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.util import wait_for_local_storage_truncate, wait_until_result
 from rptest.utils.mode_checks import skip_debug_mode
@@ -75,7 +75,6 @@ class FollowerFetchingTest(PreallocNodesTest):
                 "enable_rack_awareness": True,
                 # disable leader balancer to prevent leaders from moving and causing additional client retries
                 "enable_leader_balancer": False,
-                CLOUD_TOPICS_CONFIG_STR: True,
             },
             si_settings=si_settings,
         )

--- a/tests/rptest/tests/license_enforcement_test.py
+++ b/tests/rptest/tests/license_enforcement_test.py
@@ -15,7 +15,7 @@ from rptest.clients.rpk import RpkException, RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import LoggingConfig, SISettings, CLOUD_TOPICS_CONFIG_STR
+from rptest.services.redpanda import LoggingConfig, SISettings
 from rptest.services.redpanda_installer import RedpandaInstaller
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.utils.mode_checks import skip_fips_mode
@@ -347,34 +347,10 @@ class LicenseEnforcementPermittedTopicParams(RedpandaTest):
         assert cfgs["redpanda.iceberg.mode"][0] == "key_value", cfgs
 
     @cluster(num_nodes=1)
-    def test_cloud_topics_enabled_cluster_property(self):
-        si_settings = SISettings(self.test_context)
-        self.redpanda.set_si_settings(si_settings)
-        super().setUp()
-        self.redpanda.set_environment(
-            {"__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE": True}
-        )
-        self.redpanda.restart_nodes(self.redpanda.nodes)
-        self.redpanda.wait_until(
-            self.redpanda.healthy,
-            timeout_sec=60,
-            backoff_sec=1,
-            err_msg="The cluster hasn't stabilized",
-        )
-        # We shouldn't be able to set cloud_topics_enabled without a license.
-        try:
-            self.rpk.cluster_config_set(CLOUD_TOPICS_CONFIG_STR, "true")
-            assert False, "Enabling cloud_topics_enabled must fail without the license"
-        except RpkException:
-            pass
-
-    @cluster(num_nodes=1)
     def test_cloud_topics_topic_property(self):
         si_settings = SISettings(self.test_context)
         self.redpanda.set_si_settings(si_settings)
         super().setUp()
-
-        self.rpk.cluster_config_set(CLOUD_TOPICS_CONFIG_STR, "true")
 
         self.redpanda.set_environment(
             {"__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE": True}

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -31,7 +31,6 @@ from rptest.services.redpanda import (
     RESTART_LOG_ALLOW_LIST,
     RedpandaService,
     SISettings,
-    CLOUD_TOPICS_CONFIG_STR,
 )
 from rptest.services.redpanda_installer import RedpandaInstaller
 from rptest.tests.prealloc_nodes import PreallocNodesTest
@@ -61,8 +60,6 @@ class NodesDecommissioningTest(PreallocNodesTest):
             enable_cluster_metadata_upload_loop=False,
             retention_local_trim_interval=5_000,
         )
-
-        extra_rp_conf[CLOUD_TOPICS_CONFIG_STR] = True
 
         super(NodesDecommissioningTest, self).__init__(
             test_context=test_context,

--- a/tests/rptest/tests/offset_for_leader_epoch_read_replica_test.py
+++ b/tests/rptest/tests/offset_for_leader_epoch_read_replica_test.py
@@ -41,12 +41,10 @@ class OffsetForLeaderEpochReadReplicaTest(EndToEndTest):
         test_context,
         mode: ReadReplicaSourceMode = ReadReplicaSourceMode.TIERED_STORAGE,
     ):
-        # Enable cloud_topics on both clusters regardless of mode
         self.extra_rp_conf = {
             "enable_leader_balancer": False,
             "log_compaction_interval_ms": 1000,
             "cloud_topics_long_term_flush_interval": 1000,
-            "cloud_topics_enabled": True,
         }
         super(OffsetForLeaderEpochReadReplicaTest, self).__init__(
             test_context=test_context,
@@ -71,7 +69,6 @@ class OffsetForLeaderEpochReadReplicaTest(EndToEndTest):
             "enable_cluster_metadata_upload_loop": False,
             "cloud_topics_disable_metastore_flush_loop_for_tests": True,
             "cloud_topics_disable_level_zero_gc_for_tests": True,
-            "cloud_topics_enabled": True,
         }
 
         self.rr_settings = SISettings(

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -26,7 +26,6 @@ from rptest.services.cluster import cluster
 from rptest.services.honey_badger import HoneyBadger
 from rptest.services.kaf_producer import KafProducer
 from rptest.services.redpanda import (
-    CLOUD_TOPICS_CONFIG_STR,
     PREV_VERSION_LOG_ALLOW_LIST,
     RESTART_LOG_ALLOW_LIST,
     SISettings,
@@ -1019,8 +1018,6 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
             self.test_context.cluster.alloc(ClusterSpec.simple_linux(5))
             return
         extra_rp_conf: dict = {}
-        if with_cloud_topics:
-            extra_rp_conf = {CLOUD_TOPICS_CONFIG_STR: True}
 
         throughput, records, moves, partitions = self._get_scale_params()
         install_opts = InstallOptions(install_previous_version=test_mixed_versions)
@@ -1087,8 +1084,6 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
             self.test_context.cluster.alloc(ClusterSpec.simple_linux(5))
             return
         extra_rp_conf: dict = {}
-        if with_cloud_topics:
-            extra_rp_conf = {CLOUD_TOPICS_CONFIG_STR: True}
 
         throughput, records, moves, partitions = self._get_scale_params()
 

--- a/tests/rptest/tests/random_node_operations_smoke_test.py
+++ b/tests/rptest/tests/random_node_operations_smoke_test.py
@@ -44,7 +44,6 @@ from rptest.services.redpanda import (
     SISettings,
     SchemaRegistryConfig,
     get_cloud_storage_type,
-    CLOUD_TOPICS_CONFIG_STR,
 )
 from rptest.services.redpanda_installer import RedpandaInstaller
 from rptest.tests.datalake.utils import supported_storage_types
@@ -239,7 +238,6 @@ class RandomNodeOperationsBase(PreallocNodesTest):
         if with_cloud_topics:
             self.redpanda.add_extra_rp_conf(
                 {
-                    CLOUD_TOPICS_CONFIG_STR: True,
                     # Set both compaction intervals for cloud topics compaction tests
                     "log_compaction_interval_ms": 5000,
                     "cloud_topics_compaction_interval_ms": 5000,

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -181,11 +181,9 @@ class TestReadReplicaService(EndToEndTest):
         test_context: TestContext,
         mode: ReadReplicaSourceMode = ReadReplicaSourceMode.TIERED_STORAGE,
     ):
-        # Enable cloud_topics on both clusters regardless of mode
         extra_rp_conf = dict(
             cloud_storage_spillover_manifest_size=None,
             cloud_topics_long_term_flush_interval=1000,
-            cloud_topics_enabled=True,
         )
         super(TestReadReplicaService, self).__init__(
             test_context=test_context,
@@ -214,7 +212,6 @@ class TestReadReplicaService(EndToEndTest):
             enable_cluster_metadata_upload_loop=False,
             cloud_topics_disable_metastore_flush_loop_for_tests=True,
             cloud_topics_disable_level_zero_gc_for_tests=True,
-            cloud_topics_enabled=True,
         )
 
         self.rr_settings = SISettings(

--- a/tests/rptest/tests/storage_mode_test.py
+++ b/tests/rptest/tests/storage_mode_test.py
@@ -15,7 +15,6 @@ from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import (
     RESTART_LOG_ALLOW_LIST,
-    CLOUD_TOPICS_CONFIG_STR,
     SISettings,
 )
 from rptest.services.redpanda_installer import (
@@ -428,7 +427,7 @@ class StorageModeTransitionTest(StorageModeTestBase):
         - local -> tiered_cloud
 
         Note: cloud <-> tiered_cloud transitions are tested in
-        StorageModeCloudTransitionTest (requires cloud_topics_enabled).
+        StorageModeCloudTransitionTest (requires cloud_storage_enabled).
         """
         rpk = RpkTool(self.redpanda)
 
@@ -615,8 +614,7 @@ class StorageModeTransitionTest(StorageModeTestBase):
 class StorageModeValidationTest(RedpandaTest):
     """
     Test that the default_redpanda_storage_mode cluster config validation
-    correctly enforces dependencies on cloud_storage_enabled and
-    cloud_topics_enabled.
+    correctly enforces dependencies on cloud_storage_enabled.
     """
 
     def __init__(self, test_context: TestContext):
@@ -631,7 +629,8 @@ class StorageModeValidationTest(RedpandaTest):
         """
         Test that default_redpanda_storage_mode validation enforces:
         - 'tiered' requires cloud_storage_enabled=true
-        - 'cloud' requires cloud_topics_enabled=true
+        - 'cloud' requires cloud_storage_enabled=true
+        - 'tiered_cloud' requires cloud_storage_enabled=true
         """
         admin = Admin(self.redpanda)
 
@@ -639,9 +638,6 @@ class StorageModeValidationTest(RedpandaTest):
         config = admin.get_cluster_config()
         assert config["cloud_storage_enabled"] is False, (
             "cloud_storage_enabled should be false for this test"
-        )
-        assert config["cloud_topics_enabled"] is False, (
-            "cloud_topics_enabled should be false for this test"
         )
 
         # Test: setting 'tiered' should fail without cloud_storage_enabled
@@ -654,7 +650,7 @@ class StorageModeValidationTest(RedpandaTest):
             "default_redpanda_storage_mode should not be tiered"
         )
 
-        # Test: setting 'cloud' should fail without cloud_topics_enabled
+        # Test: setting 'cloud' should fail without cloud_storage_enabled
         with expect_http_error(400):
             admin.patch_cluster_config(
                 upsert={"default_redpanda_storage_mode": "cloud"}
@@ -664,7 +660,7 @@ class StorageModeValidationTest(RedpandaTest):
             "default_redpanda_storage_mode should not be cloud"
         )
 
-        # Test: setting 'tiered_cloud' should fail without cloud_topics_enabled
+        # Test: setting 'tiered_cloud' should fail without cloud_storage_enabled
         with expect_http_error(400):
             admin.patch_cluster_config(
                 upsert={"default_redpanda_storage_mode": "tiered_cloud"}
@@ -692,9 +688,6 @@ class StorageModeCloudTransitionTest(StorageModeTestBase):
             test_context=test_context,
             num_brokers=3,
             si_settings=si_settings,
-            extra_rp_conf={
-                CLOUD_TOPICS_CONFIG_STR: True,
-            },
         )
 
     def setUp(self):

--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -719,7 +719,6 @@ class CloudTopicsTimeQueryTest(RedpandaTest):
     def _set_up_cluster(self):
         self.redpanda.set_extra_rp_conf(
             {
-                "cloud_topics_enabled": True,
                 "enable_cluster_metadata_upload_loop": False,
                 "cloud_topics_long_term_flush_interval": 1000,
                 "cloud_topics_reconciliation_max_object_size": self.max_object_size,
@@ -887,10 +886,8 @@ class TestReadReplicaTimeQuery(RedpandaTest):
         test_context,
         mode: ReadReplicaSourceMode = ReadReplicaSourceMode.TIERED_STORAGE,
     ):
-        # Enable cloud_topics on both clusters regardless of mode
         extra_rp_conf = {
             "cloud_topics_long_term_flush_interval": 1000,
-            "cloud_topics_enabled": True,
         }
 
         super(TestReadReplicaTimeQuery, self).__init__(
@@ -911,7 +908,6 @@ class TestReadReplicaTimeQuery(RedpandaTest):
             "enable_cluster_metadata_upload_loop": False,
             "cloud_topics_disable_metastore_flush_loop_for_tests": True,
             "cloud_topics_disable_level_zero_gc_for_tests": True,
-            "cloud_topics_enabled": True,
         }
 
         self.rr_settings = SISettings(

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -430,6 +430,7 @@ class CreateTopicsTest(RedpandaTest):
                         "type" in r.keys()
                         and r["type"] == "topic_management_cmd"
                         and r["data"]["type"] == 0
+                        and r["data"]["key"]["namespace"] == "kafka"
                     )
 
                 create_topic_cmds = list(filter(is_create_topic_cmd, records))

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -30,7 +30,6 @@ from rptest.services.producer_swarm import ProducerSwarm
 from rptest.services.redpanda import (
     ResourceSettings,
     SISettings,
-    CLOUD_TOPICS_CONFIG_STR,
 )
 from rptest.services.rpk_producer import RpkProducer
 from rptest.tests.cluster_config_test import wait_for_version_sync
@@ -55,7 +54,6 @@ class RapidTopicRecreateTest(RedpandaTest):
             ),
             extra_rp_conf={
                 "iceberg_enabled": True,  # to create relevant STMs
-                CLOUD_TOPICS_CONFIG_STR: True,
             },
         )
         self.rpk = RpkTool(self.redpanda)
@@ -129,7 +127,6 @@ class TopicRecreateTest(RedpandaTest):
             extra_rp_conf={
                 "auto_create_topics_enabled": False,
                 "max_compacted_log_segment_size": 5 * (2 << 20),
-                CLOUD_TOPICS_CONFIG_STR: True,
             },
         )
 

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -73,6 +73,17 @@ def get_kvstore_topic_key_counts(redpanda):
         else:
             internal_group_ids.add(p["raft_group_id"])
 
+    # `kafka_internal/ct_l1_domain` is auto-created by the cloud_topics
+    # subsystem whenever cloud storage is enabled, with N partitions. Pull
+    # in every partition's raft group so its shard_placement kvstore keys
+    # are filtered out as internal.
+    try:
+        for p in admin.get_partitions(topic="ct_l1_domain", namespace="kafka_internal"):
+            internal_group_ids.add(p["raft_group_id"])
+    except HTTPError as e:
+        if e.response.status_code != 404:
+            raise
+
     result = {}
     for n in redpanda.nodes:
         kvstore_data = viewer.read_kvstore(node=n)

--- a/tests/rptest/transactions/tx_verifier_test.py
+++ b/tests/rptest/transactions/tx_verifier_test.py
@@ -20,7 +20,6 @@ from rptest.services.cluster import cluster
 from rptest.services.redpanda import (
     SISettings,
     get_cloud_storage_type,
-    CLOUD_TOPICS_CONFIG_STR,
 )
 from rptest.tests.redpanda_test import RedpandaTest
 
@@ -43,7 +42,6 @@ class TxVerifierTest(RedpandaTest):
             "default_topic_partitions": 1,
             "enable_leader_balancer": False,
             "partition_autobalancing_mode": "off",
-            CLOUD_TOPICS_CONFIG_STR: True,
         }
 
         super(TxVerifierTest, self).__init__(

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -729,12 +729,28 @@ class PathMatcher:
     def is_controller_snapshot(self, o: ObjectMetadata) -> bool:
         return o.key.endswith("/controller.snapshot")
 
+    def is_metastore_manifest(self, o: ObjectMetadata) -> bool:
+        return o.key.startswith("level_one/") and o.key.endswith("/manifest.bin")
+
+    def is_cloud_topics_object(self, o: ObjectMetadata) -> bool:
+        # Anything written by the cloud_topics subsystem. Includes L0 extents
+        # under `level_zero/`, L1 extents under `level_one/data/`, per-domain
+        # LSM state under `level_one/meta/domain/`, and the metastore
+        # manifest under `level_one/meta/metastore/`.
+        return o.key.startswith("level_zero/") or o.key.startswith("level_one/")
+
     def is_partition_manifest(self, o: ObjectMetadata) -> bool:
+        if self.is_metastore_manifest(o):
+            return False
+
         return (
             o.key.endswith("/manifest.json") or o.key.endswith("/manifest.bin")
         ) and self._match_partition_manifest(o.key)
 
     def is_spillover_manifest(self, o: ObjectMetadata) -> bool:
+        if self.is_metastore_manifest(o):
+            return False
+
         return "/manifest.bin." in o.key and self._match_partition_manifest(o.key)
 
     def is_topic_manifest(self, o: ObjectMetadata) -> bool:
@@ -1142,6 +1158,12 @@ class BucketView:
                 self._load_cluster_metadata_manifest(o.key)
             elif self.path_matcher.is_controller_snapshot(o):
                 self._load_controller_snapshot_size(o.key)
+            elif self.path_matcher.is_cloud_topics_object(o):
+                # cloud_topics infrastructure objects (level_one/ and
+                # level_zero/) live alongside tiered-storage objects in the
+                # bucket and are not surprising — don't count them as
+                # ignored.
+                pass
             else:
                 self._state.ignored_objects += 1
         if self._scan_segments:


### PR DESCRIPTION
`cloud_storage_enabled()` now dictates whether a cluster/node has cloud topics capabilities. Our feature flag for `cloud_topics` is still here though.

This means users may allocate and spin-up cloud topics infrastructure even though they are only used tiered topics via `cloud_storage_enabled()`, but this is considered okay.

## Backports Required


- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
