### PR TITLE
cluster/feature_manager: gate version updates on per-term raft0 barrier

### DIFF
--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -432,8 +432,9 @@ ss::future<> feature_manager::maybe_update_feature_table() {
 
     vlog(clusterlog.debug, "Checking for active version update...");
     bool failed = false;
+    bool failed_barrier = false;
     try {
-        co_await do_maybe_update_active_version();
+        co_await do_maybe_update_active_version(failed_barrier);
     } catch (...) {
         // This is fine: exceptions can result from unavailability of
         // raft0 for writes, or unavailability of health monitor
@@ -448,8 +449,14 @@ ss::future<> feature_manager::maybe_update_feature_table() {
     try {
         // Even if we didn't advance our logical version, we might have some
         // features to activate due to policy changes across different redpanda
-        // binaries with the same logical version
-        co_await do_maybe_activate_features();
+        // binaries with the same logical version.
+        //
+        // since do_maybe_activate_features also controls feature activation
+        // based on configuration options, we skip it if the step above failed
+        // to enforce a lineariable barrier.
+        if (!failed_barrier) {
+            co_await do_maybe_activate_features();
+        }
     } catch (...) {
         vlog(
           clusterlog.debug,
@@ -553,7 +560,8 @@ void feature_manager::update_node_version(
  * This function is allowed to throw: throwing an exception indicates
  * a transient error that the caller should retry after a backoff.
  */
-ss::future<> feature_manager::do_maybe_update_active_version() {
+ss::future<>
+feature_manager::do_maybe_update_active_version(bool& failed_barrier) {
     vassert(ss::this_shard_id() == backend_shard, "Wrong shard!");
 
     // One-shot consume of the manual-finalization request: every
@@ -596,6 +604,7 @@ ss::future<> feature_manager::do_maybe_update_active_version() {
         auto barrier = co_await _stm.local().insert_linearizable_barrier(
           deadline);
         if (!barrier) {
+            failed_barrier = true;
             throw std::runtime_error(
               fmt::format("Linearizable barrier failed: {}", barrier.error()));
         }
@@ -622,6 +631,7 @@ ss::future<> feature_manager::do_maybe_update_active_version() {
               "during barrier (was term {}, now {})",
               target_term,
               _is_leader_of);
+            failed_barrier = true;
             co_return;
         }
         _caught_up_for_term = target_term;

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -147,12 +147,8 @@ feature_manager::start(std::vector<model::node_id>&& cluster_founder_nodes) {
 
             vlog(
               clusterlog.debug, "Controller leader notification term {}", term);
-            _am_controller_leader = leader_id == *config::node().node_id();
-            if (_am_controller_leader) {
-                _leader_term = term;
-            } else {
-                _leader_term.reset();
-            }
+            const bool am_leader = leader_id == *config::node().node_id();
+            _is_leader_of = am_leader ? std::optional{term} : std::nullopt;
             // Force the background loop to re-establish a linearizable
             // barrier on every leadership transition: cluster-config
             // values it consults must not be read until we have applied
@@ -168,7 +164,7 @@ feature_manager::start(std::vector<model::node_id>&& cluster_founder_nodes) {
             if (
               _feature_table.local().get_active_version()
                 != features::feature_table::get_latest_logical_version()
-              && _am_controller_leader) {
+              && am_leader) {
                 // When I become leader for first time (i.e. when active
                 // version is not known yet, proactively persist it)
                 vlog(
@@ -179,7 +175,7 @@ feature_manager::start(std::vector<model::node_id>&& cluster_founder_nodes) {
                 update_node_version(
                   *config::node().node_id(),
                   features::feature_table::get_latest_logical_version());
-            } else if (_am_controller_leader) {
+            } else if (am_leader) {
                 // In any case, kick the background update loop when
                 // we gain leadership, in case there is work to do like
                 // auto-activating some features.
@@ -567,7 +563,7 @@ ss::future<> feature_manager::do_maybe_update_active_version() {
     const bool was_manual_finalize_pending = std::exchange(
       _manual_finalize_pending, false);
 
-    if (!_am_controller_leader) {
+    if (!_is_leader_of.has_value()) {
         // Drop accumulated updates to bound memory while we're not
         // the leader; updates_pending() already short-circuits when
         // not leader, so this isn't load-bearing for the loop's
@@ -588,10 +584,13 @@ ss::future<> feature_manager::do_maybe_update_active_version() {
     // sleeps status_retry before retrying (avoiding a tight spin when
     // the barrier fails synchronously), and so that _updates is
     // preserved for the next attempt.
-    if (
-      !_caught_up_for_term.has_value() || _caught_up_for_term != _leader_term) {
-        vassert(_leader_term.has_value(), "leader without term");
-        const auto target_term = *_leader_term;
+    // Need a fresh barrier when we have no record of one, or when the
+    // recorded barrier was for a different term than the one we now
+    // hold leadership for.
+    const bool need_barrier = !_caught_up_for_term.has_value()
+                              || *_caught_up_for_term != *_is_leader_of;
+    if (need_barrier) {
+        const auto target_term = *_is_leader_of;
         auto deadline = model::timeout_clock::now() + status_retry;
         auto barrier = co_await _stm.local().insert_linearizable_barrier(
           deadline);
@@ -599,13 +598,18 @@ ss::future<> feature_manager::do_maybe_update_active_version() {
             throw std::runtime_error(
               fmt::format("Linearizable barrier failed: {}", barrier.error()));
         }
-        if (!_am_controller_leader || _leader_term != target_term) {
+        // Leadership may have changed during the co_await above:
+        // either we lost it (no longer leader) or it bounced to a
+        // newer term.
+        const bool leadership_changed = !_is_leader_of.has_value()
+                                        || *_is_leader_of != target_term;
+        if (leadership_changed) {
             // Leadership changed mid-barrier. Don't throw — this isn't
             // a transient error to retry against, it's a state change.
             // The next loop iteration handles it cleanly: if we're no
-            // longer leader, the !_am_controller_leader branch above
-            // drains _updates and returns; if we're leader in a fresh
-            // term, the leadership notification handler already reset
+            // longer leader, the !_is_leader_of branch above drains
+            // _updates and returns; if we're leader in a fresh term,
+            // the leadership notification handler already reset
             // _caught_up_for_term, so we re-run the barrier for the
             // new term before draining and applying updates. We
             // deliberately do not set _caught_up_for_term here: the
@@ -616,7 +620,7 @@ ss::future<> feature_manager::do_maybe_update_active_version() {
               "Deferring active version update: leadership changed "
               "during barrier (was term {}, now {})",
               target_term,
-              _leader_term);
+              _is_leader_of);
             co_return;
         }
         _caught_up_for_term = target_term;
@@ -749,7 +753,7 @@ ss::future<feature_manager::finalize_status>
 feature_manager::submit_manual_finalize_request() {
     vassert(ss::this_shard_id() == backend_shard, "Wrong shard!");
 
-    if (!_am_controller_leader) {
+    if (!_is_leader_of.has_value()) {
         co_return finalize_status::not_leader;
     }
 
@@ -763,7 +767,7 @@ feature_manager::submit_manual_finalize_request() {
 }
 
 ss::future<> feature_manager::do_maybe_activate_features() {
-    if (!_am_controller_leader) {
+    if (!_is_leader_of.has_value()) {
         co_return;
     }
 

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -509,8 +509,8 @@ feature_manager::auto_activate_features(
     return result;
 }
 
-ss::future<>
-feature_manager::replicate_feature_update_cmd(feature_update_cmd_data data) {
+ss::future<> feature_manager::replicate_feature_update_cmd(
+  feature_update_cmd_data data, std::optional<model::term_id> term) {
     auto new_version = data.logical_version;
     auto cmd = feature_update_cmd(
       std::move(data),
@@ -518,7 +518,8 @@ feature_manager::replicate_feature_update_cmd(feature_update_cmd_data data) {
     );
 
     auto timeout = model::timeout_clock::now() + status_retry;
-    auto err = co_await replicate_and_wait(_stm, _as, std::move(cmd), timeout);
+    auto err = co_await replicate_and_wait(
+      _stm, _as, std::move(cmd), timeout, term);
     if (err == errc::not_leader) {
         // Harmless, we lost leadership so the new controller
         // leader is responsible for picking up where we left off.
@@ -589,8 +590,8 @@ ss::future<> feature_manager::do_maybe_update_active_version() {
     // hold leadership for.
     const bool need_barrier = !_caught_up_for_term.has_value()
                               || *_caught_up_for_term != *_is_leader_of;
+    const auto target_term = *_is_leader_of;
     if (need_barrier) {
-        const auto target_term = *_is_leader_of;
         auto deadline = model::timeout_clock::now() + status_retry;
         auto barrier = co_await _stm.local().insert_linearizable_barrier(
           deadline);
@@ -744,7 +745,7 @@ ss::future<> feature_manager::do_maybe_update_active_version() {
             .action = feature_update_action::action_t::activate});
     }
 
-    co_await replicate_feature_update_cmd(std::move(data));
+    co_await replicate_feature_update_cmd(std::move(data), target_term);
 
     vlog(clusterlog.info, "Updated cluster (logical version {})", max_version);
 }

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -148,6 +148,17 @@ feature_manager::start(std::vector<model::node_id>&& cluster_founder_nodes) {
             vlog(
               clusterlog.debug, "Controller leader notification term {}", term);
             _am_controller_leader = leader_id == *config::node().node_id();
+            if (_am_controller_leader) {
+                _leader_term = term;
+            } else {
+                _leader_term.reset();
+            }
+            // Force the background loop to re-establish a linearizable
+            // barrier on every leadership transition: cluster-config
+            // values it consults must not be read until we have applied
+            // every controller log entry committed at the time we took
+            // leadership.
+            _caught_up_for_term.reset();
 
             // This hook avoids the need for the controller leader to receive
             // its own health report to generate a call to update_node_version.
@@ -556,14 +567,70 @@ ss::future<> feature_manager::do_maybe_update_active_version() {
     const bool was_manual_finalize_pending = std::exchange(
       _manual_finalize_pending, false);
 
-    // Consume any accumulated updates.  Important to do this even if
-    // not leader, so that we drain it and allow maybe_update_active_version
-    // to sleep on _update_wait.
-    auto updates = std::exchange(_updates, {});
-
     if (!_am_controller_leader) {
+        // Drop accumulated updates to bound memory while we're not
+        // the leader; updates_pending() already short-circuits when
+        // not leader, so this isn't load-bearing for the loop's
+        // sleep on _update_wait.
+        _updates.clear();
         co_return;
     }
+
+    // The controller replays committed entries through the muxed
+    // config_manager concurrently with this loop, so without a barrier
+    // we can observe intermediate cluster-config states mid-replay —
+    // for example a transient value of features_auto_finalization
+    // before the operator's override has been applied. Wait once per
+    // term for the STM to apply through a linearizable barrier offset;
+    // while leadership is held, subsequent committed entries replicate
+    // through us, so per-tick barriers aren't needed. On transient
+    // barrier failure we throw rather than return so the outer loop
+    // sleeps status_retry before retrying (avoiding a tight spin when
+    // the barrier fails synchronously), and so that _updates is
+    // preserved for the next attempt.
+    if (
+      !_caught_up_for_term.has_value() || _caught_up_for_term != _leader_term) {
+        vassert(_leader_term.has_value(), "leader without term");
+        const auto target_term = *_leader_term;
+        auto deadline = model::timeout_clock::now() + status_retry;
+        auto barrier = co_await _stm.local().insert_linearizable_barrier(
+          deadline);
+        if (!barrier) {
+            throw std::runtime_error(
+              fmt::format("Linearizable barrier failed: {}", barrier.error()));
+        }
+        if (!_am_controller_leader || _leader_term != target_term) {
+            // Leadership changed mid-barrier. Don't throw — this isn't
+            // a transient error to retry against, it's a state change.
+            // The next loop iteration handles it cleanly: if we're no
+            // longer leader, the !_am_controller_leader branch above
+            // drains _updates and returns; if we're leader in a fresh
+            // term, the leadership notification handler already reset
+            // _caught_up_for_term, so we re-run the barrier for the
+            // new term before draining and applying updates. We
+            // deliberately do not set _caught_up_for_term here: the
+            // offset we observed was acknowledged under the old term
+            // and is not safe to treat as caught-up for the new one.
+            vlog(
+              clusterlog.debug,
+              "Deferring active version update: leadership changed "
+              "during barrier (was term {}, now {})",
+              target_term,
+              _leader_term);
+            co_return;
+        }
+        _caught_up_for_term = target_term;
+        vlog(
+          clusterlog.debug,
+          "Controller STM caught up to barrier offset {} in term {}",
+          barrier.value().first,
+          target_term);
+    }
+
+    // Consume accumulated updates now that the barrier has confirmed
+    // we are caught up. Deferring the drain until here means a
+    // transient barrier failure doesn't discard pending updates.
+    auto updates = std::exchange(_updates, {});
 
     // Apply updates into _node_versions
     for (const auto& i : updates) {

--- a/src/v/cluster/feature_manager.h
+++ b/src/v/cluster/feature_manager.h
@@ -159,7 +159,7 @@ private:
 
     /// Whether there is work to do in maybe_update_feature_table
     bool updates_pending() {
-        if (!_am_controller_leader) {
+        if (!_is_leader_of.has_value()) {
             return false;
         }
         if (!_updates.empty() || _manual_finalize_pending) {
@@ -217,18 +217,15 @@ private:
     // the controller leader.
     version_map _node_versions;
 
-    // Keep track of whether this node is the controller leader
-    // via leadership notifications
-    bool _am_controller_leader{false};
-
     // The raft0 term this node currently believes itself to be the
-    // controller leader for. Updated from the leadership notification
-    // alongside _am_controller_leader.
-    std::optional<model::term_id> _leader_term;
+    // controller leader for, or nullopt if it isn't. Updated from
+    // the leadership notification handler; has_value() is the
+    // canonical "am I the controller leader" check.
+    std::optional<model::term_id> _is_leader_of;
 
     // The most recent term for which we have completed a linearizable
     // barrier against raft0 and waited for the controller STM to apply
-    // through the barrier offset. Until this matches _leader_term, the
+    // through the barrier offset. Until this matches _is_leader_of, the
     // background loop must not consult cluster-config values whose
     // intermediate replay state could cause incorrect decisions (e.g.
     // features_auto_finalization racing a freshly-elected leader's

--- a/src/v/cluster/feature_manager.h
+++ b/src/v/cluster/feature_manager.h
@@ -151,7 +151,7 @@ private:
     ss::future<> maybe_update_feature_table();
 
     /// Consume _updates and evaluate whether the cluster version may advance
-    ss::future<> do_maybe_update_active_version();
+    ss::future<> do_maybe_update_active_version(bool&);
 
     /// Check _feature_table for any features that are elegible to auto
     /// activate but not yet active.

--- a/src/v/cluster/feature_manager.h
+++ b/src/v/cluster/feature_manager.h
@@ -178,7 +178,9 @@ private:
 
     // Compose a command struct, replicate it via raft and wait for apply.
     // Silently swallow not_leader errors, raise on other errors;
-    ss::future<> replicate_feature_update_cmd(feature_update_cmd_data data);
+    ss::future<> replicate_feature_update_cmd(
+      feature_update_cmd_data data,
+      std::optional<model::term_id> term = std::nullopt);
 
     // Discover features that may now be auto-activated: usually this happens
     // when we activate a new logical version, but it may also happen if we

--- a/src/v/cluster/feature_manager.h
+++ b/src/v/cluster/feature_manager.h
@@ -221,6 +221,20 @@ private:
     // via leadership notifications
     bool _am_controller_leader{false};
 
+    // The raft0 term this node currently believes itself to be the
+    // controller leader for. Updated from the leadership notification
+    // alongside _am_controller_leader.
+    std::optional<model::term_id> _leader_term;
+
+    // The most recent term for which we have completed a linearizable
+    // barrier against raft0 and waited for the controller STM to apply
+    // through the barrier offset. Until this matches _leader_term, the
+    // background loop must not consult cluster-config values whose
+    // intermediate replay state could cause incorrect decisions (e.g.
+    // features_auto_finalization racing a freshly-elected leader's
+    // controller log replay).
+    std::optional<model::term_id> _caught_up_for_term;
+
     // Whether an operator has issued a manual finalization request that
     // has not yet been honored by the background loop. In-memory only:
     // not persisted to the controller log, so a leader change or crash


### PR DESCRIPTION
Summary: This effectively makes the auto-finalization check pessimistic in that we don't allow any upgrades (but most importantly we don't check the auto-finalization flag) until we are sure tha thte controller log has been replayed recently so that we get the most recent value.

A freshly-elected controller leader's background update loop can race the controller STM's replay of entries committed before leadership was taken. The loop reads cluster-config bindings such as features_auto_finalization to decide whether to auto-advance the cluster active version; an intermediate replay state where the binding still holds its default before the operator's disabling write has been applied can drive unwanted finalization.

Track the leader term from the leadership notification and run a once-per-term linearizable barrier via the controller STM before consulting config. The barrier confirms heartbeat quorum and waits for the STM (and the muxed config_manager) to apply through the barrier offset; while leadership is held, subsequent committed entries replicate through us, so per-tick barriers aren't needed.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
