### PR TITLE
`cluster`: prevent oversized alloc in `cloudcheck`

### DIFF
--- a/src/v/cluster/self_test/cloudcheck.cc
+++ b/src/v/cluster/self_test/cloudcheck.cc
@@ -253,7 +253,7 @@ ss::future<std::vector<self_test_result>> cloudcheck::run_benchmarks() {
 
 iobuf cloudcheck::make_random_payload(size_t size) const {
     iobuf payload;
-    constexpr size_t chunk_size = 128_KiB;
+    constexpr size_t chunk_size = 64_KiB;
     for (size_t amt = 0; amt < size; amt += chunk_size) {
         size_t remaining = size - amt;
         const auto random_data = random_generators::gen_alphanum_string(


### PR DESCRIPTION
This chunk size of `128_KiB` actually gets rounded up (since there is an intermediate `ss::sstring` being used here) to `132_KiB` by the internal seastar allocator, making this large enough to trigger an oversized allocation warning.

Reduce the chunk size used in the `cloudcheck` self-test to `64_KiB` to avoid this.

WARN  2026-05-17 04:00:08,500 [shard 0:st  ] seastar_memory - oversized allocation: 135168 bytes. This is non-fatal, but could lead to latency and/or fragmentation issues. Please report: at 0x730acb4 0x730b0df 0x7161274 0x7163248 0x71659d0 0x7109f6d 0x710a0df 0x4921e9d 0x492cfdf 0x4930894 0x492bd0a 0x493d81e 0x48e556d 0x71c10ed 0x71c271a 0x71c256b 0x71c3c9d 0x71c2c19 0x711bf80 0x711b36d 0x240f874 0x240398d /home/willem/redpanda/vbuild/bazel-out/redpanda/bin/../lib/libc.so.6+0x29d8f /home/willem/redpanda/vbuild/bazel-out/redpanda/bin/../lib/libc.so.6+0x29e3f 0x2400024

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
