### PR TITLE
iceberg/transforms: return date value from day transform

### DIFF
--- a/src/v/datalake/partition_key_path.cc
+++ b/src/v/datalake/partition_key_path.cc
@@ -173,14 +173,21 @@ struct primitive_formatting_visitor {
 template<typename DurationT>
 checked<ss::sstring, partition_key_error>
 format_time_transform_key(const iceberg::primitive_value& value) {
-    if (!std::holds_alternative<iceberg::int_value>(value)) {
-        return partition_key_error("time transform expects an integer value");
+    // Per the Iceberg spec, the `day` transform produces a date value;
+    // year/month/hour transforms produce int values. Both wrap an int32_t.
+    int32_t raw_val{};
+    if (std::holds_alternative<iceberg::int_value>(value)) {
+        raw_val = std::get<iceberg::int_value>(value).val;
+    } else if (std::holds_alternative<iceberg::date_value>(value)) {
+        raw_val = std::get<iceberg::date_value>(value).val;
+    } else {
+        return partition_key_error(
+          "time transform expects an integer or date value");
     }
-    auto v = std::get<iceberg::int_value>(value);
 
     std::chrono::system_clock::time_point tp{std::chrono::milliseconds(0)};
     // offset epoch by the given duration
-    tp += DurationT(v.val);
+    tp += DurationT(raw_val);
 
     if constexpr (std::is_same_v<std::chrono::years, DurationT>) {
         return ssx::sformat("{:%Y}", tp);

--- a/src/v/datalake/tests/partitioning_writer_test.cc
+++ b/src/v/datalake/tests/partitioning_writer_test.cc
@@ -47,6 +47,7 @@ iceberg::struct_type default_type_with_columns(size_t extra_columns) {
 static constexpr auto schema_id = iceberg::schema::id_t{0};
 
 static constexpr auto ms_per_hr = 3600 * 1000;
+static constexpr int64_t ms_per_day = int64_t{24} * ms_per_hr;
 
 // Create a bunch of records spread over multiple hours.
 chunked_vector<struct_value> generate_values(
@@ -58,6 +59,22 @@ chunked_vector<struct_value> generate_values(
             vals.emplace_back(val_with_timestamp(
               schema_field,
               model::timestamp{start_time.value() + h * ms_per_hr + i}));
+        }
+    }
+    return vals;
+}
+
+// Create records spread across multiple UTC days, anchored to a deterministic
+// midnight so the test is not sensitive to wall-clock time of day.
+chunked_vector<struct_value> generate_values_over_days(
+  const field_type& schema_field, int num_days, int records_per_day) {
+    const int64_t midnight = (model::timestamp::now().value() / ms_per_day)
+                             * ms_per_day;
+    chunked_vector<struct_value> vals;
+    for (int d = 0; d < num_days; d++) {
+        for (int i = 0; i < records_per_day; i++) {
+            vals.emplace_back(val_with_timestamp(
+              schema_field, model::timestamp{midnight + d * ms_per_day + i}));
         }
     }
     return vals;
@@ -188,6 +205,55 @@ TEST(PartitioningWriterTest, TestEmptyKey) {
     const auto& file = files[0];
     ASSERT_EQ(file.partition_spec_id, spec_id);
     ASSERT_EQ(file.partition_key.val->fields.size(), 0);
+}
+
+TEST(PartitioningWriterTest, TestDayTransform) {
+    auto writer_factory = std::make_unique<datalake::test_data_writer_factory>(
+      false);
+    auto field = field_type{default_type_with_columns(0)};
+    auto& default_type = std::get<struct_type>(field);
+    auto pspec = partition_spec::resolve(day_partition_spec(), default_type);
+    ASSERT_TRUE(pspec.has_value());
+    partitioning_writer writer(
+      *writer_factory,
+      schema_id,
+      default_type.copy(),
+      pspec.value().copy(),
+      {});
+
+    static constexpr int num_days = 4;
+    static constexpr int records_per_day = 5;
+    auto source_vals = generate_values_over_days(
+      field, num_days, records_per_day);
+
+    for (auto& v : source_vals) {
+        auto err = writer.add_data(std::move(v), /*approx_size=*/0, as).get();
+        EXPECT_EQ(err, writer_error::ok);
+    }
+
+    auto res = std::move(writer).finish().get();
+    ASSERT_FALSE(res.has_error()) << res.error();
+    const auto& files = res.value();
+    ASSERT_EQ(num_days, files.size());
+
+    int32_t min_day = std::numeric_limits<int32_t>::max();
+    int32_t max_day = std::numeric_limits<int32_t>::min();
+    size_t total_records = 0;
+    for (const auto& f : files) {
+        total_records += f.local_file.row_count;
+        ASSERT_EQ(f.partition_key.val->fields.size(), 1);
+        const auto& key_field = f.partition_key.val->fields[0];
+        ASSERT_TRUE(key_field.has_value());
+        const auto& prim = std::get<primitive_value>(key_field.value());
+        // Per the Iceberg spec, the day transform produces a date value, not
+        // an int value.
+        ASSERT_TRUE(std::holds_alternative<date_value>(prim));
+        int32_t day = get_day(f.partition_key);
+        min_day = std::min(day, min_day);
+        max_day = std::max(day, max_day);
+    }
+    EXPECT_EQ(num_days - 1, max_day - min_day);
+    EXPECT_EQ(total_records, records_per_day * num_days);
 }
 
 TEST(PartitioningWriterTest, TestCompositeKey) {

--- a/src/v/datalake/tests/test_utils.cc
+++ b/src/v/datalake/tests/test_utils.cc
@@ -29,6 +29,18 @@ iceberg::unresolved_partition_spec hour_partition_spec() {
     };
 }
 
+iceberg::unresolved_partition_spec day_partition_spec() {
+    chunked_vector<iceberg::unresolved_partition_spec::field> fields;
+    fields.push_back({
+      .source_name = {"redpanda", "timestamp"},
+      .transform = iceberg::day_transform{},
+      .name = "redpanda.timestamp_day",
+    });
+    return {
+      .fields = std::move(fields),
+    };
+}
+
 direct_table_creator::direct_table_creator(
   type_resolver& tr, schema_manager& sm)
   : type_resolver_(tr)

--- a/src/v/datalake/tests/test_utils.h
+++ b/src/v/datalake/tests/test_utils.h
@@ -18,6 +18,9 @@ namespace datalake {
 // Hourly partitioning on the redpanda.timestamp field.
 iceberg::unresolved_partition_spec hour_partition_spec();
 
+// Daily partitioning on the redpanda.timestamp field.
+iceberg::unresolved_partition_spec day_partition_spec();
+
 // Creates or alters the table by interfacing directly with a catalog.
 class direct_table_creator : public table_creator {
 public:

--- a/src/v/iceberg/partition_key.cc
+++ b/src/v/iceberg/partition_key.cc
@@ -72,4 +72,10 @@ int get_hour(const iceberg::partition_key& pk) {
       .val;
 }
 
+int32_t get_day(const iceberg::partition_key& pk) {
+    return std::get<iceberg::date_value>(
+             std::get<iceberg::primitive_value>(pk.val->fields.at(0).value()))
+      .val;
+}
+
 } // namespace iceberg

--- a/src/v/iceberg/partition_key.h
+++ b/src/v/iceberg/partition_key.h
@@ -44,6 +44,10 @@ bool operator==(const partition_key&, const partition_key&);
 // value.
 int get_hour(const iceberg::partition_key&);
 
+// Helper for daily partitioning. Assumes that the key contains a single
+// `date_value` (days since epoch) as the first field.
+int32_t get_day(const iceberg::partition_key&);
+
 } // namespace iceberg
 
 namespace std {

--- a/src/v/iceberg/partition_key_type.cc
+++ b/src/v/iceberg/partition_key_type.cc
@@ -41,7 +41,7 @@ struct transform_result_type_visitor {
     }
     field_type operator()(const year_transform&) { return int_type(); }
     field_type operator()(const month_transform&) { return int_type(); }
-    field_type operator()(const day_transform&) { return int_type(); }
+    field_type operator()(const day_transform&) { return date_type(); }
     field_type operator()(const hour_transform&) { return int_type(); }
     field_type operator()(const void_transform&) {
         // TODO: the spec also says the result may also be the source type.

--- a/src/v/iceberg/tests/partition_key_type_test.cc
+++ b/src/v/iceberg/tests/partition_key_type_test.cc
@@ -155,7 +155,7 @@ INSTANTIATE_TEST_SUITE_P(
     transform_expectation{
       .source_field_id = 1,
       .transform = day_transform{},
-      .expected_transformed_type = int_type{},
+      .expected_transformed_type = date_type{},
     },
     transform_expectation{
       .source_field_id = 1,

--- a/src/v/iceberg/tests/transform_utils_test.cc
+++ b/src/v/iceberg/tests/transform_utils_test.cc
@@ -165,20 +165,29 @@ struct TestTimeTransforms
 struct TestDateTransforms
   : public testing::TestWithParam<time_transform_test_case> {};
 
+namespace {
+int32_t get_int32_result(const transform& tr, const value& transformed) {
+    EXPECT_TRUE(std::holds_alternative<primitive_value>(transformed));
+    const auto& pval = std::get<primitive_value>(transformed);
+    // Per the Iceberg spec, `day` returns a date; other time transforms
+    // return an int representing the number of units since epoch.
+    if (std::holds_alternative<day_transform>(tr)) {
+        EXPECT_TRUE(std::holds_alternative<date_value>(pval));
+        return std::get<date_value>(pval).val;
+    }
+    EXPECT_TRUE(std::holds_alternative<int_value>(pval));
+    return std::get<int_value>(pval).val;
+}
+} // namespace
+
 TEST_P(TestTimeTransforms, TestConversion) {
     auto test_case = GetParam();
 
     auto transformed = apply_transform(
                          make_timestamp_val(test_case.time_shift), test_case.tr)
                          .value();
-    ASSERT_TRUE(std::holds_alternative<primitive_value>(transformed));
-    ASSERT_TRUE(
-      std::holds_alternative<int_value>(
-        std::get<primitive_value>(transformed)));
-    auto transformed_val = std::get<int_value>(
-      std::get<primitive_value>(transformed));
-
-    ASSERT_EQ(transformed_val.val, test_case.expected_result);
+    ASSERT_EQ(
+      get_int32_result(test_case.tr, transformed), test_case.expected_result);
 }
 
 TEST_P(TestDateTransforms, TestConversion) {
@@ -187,14 +196,8 @@ TEST_P(TestDateTransforms, TestConversion) {
     auto transformed = apply_transform(
                          make_date_val(test_case.time_shift), test_case.tr)
                          .value();
-    ASSERT_TRUE(std::holds_alternative<primitive_value>(transformed));
-    ASSERT_TRUE(
-      std::holds_alternative<int_value>(
-        std::get<primitive_value>(transformed)));
-    auto transformed_val = std::get<int_value>(
-      std::get<primitive_value>(transformed));
-
-    ASSERT_EQ(transformed_val.val, test_case.expected_result);
+    ASSERT_EQ(
+      get_int32_result(test_case.tr, transformed), test_case.expected_result);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/v/iceberg/transform_utils.cc
+++ b/src/v/iceberg/transform_utils.cc
@@ -41,7 +41,7 @@ struct transform_applying_visitor {
     }
 
     std::optional<value> operator()(const day_transform&) {
-        int_value v{
+        date_value v{
           std::visit(time_transform_visitor<std::chrono::days>{}, source_val_)};
         return v;
     }


### PR DESCRIPTION
Align the `day` partition transform with the [Iceberg spec][1]: it now
produces a `date` value (and the partition column type is `date`), not
an `int`. The underlying `int32` (days since epoch) is unchanged, so
on-disk data formats are unaffected; only the surfaced Iceberg type
changes, which matters for interoperability with spec-conformant
catalogs and readers.

The change is split into two bisectable commits so the tree stays
green at every step:

1. `datalake/partition_key_path`: make the time-transform path
   formatter accept both `int_value` and `date_value` for the day
   bucket count. This is backwards-compatible on its own.
2. `iceberg/transforms`: switch `apply_transform(day_transform)` to
   return `date_value` and `partition_key_type` to declare the column
   as `date_type`. Existing unit tests are updated in the same commit.

[1]: https://github.com/apache/iceberg/blob/e1705f4956f4b92bb6f00b593c8287bdbf61aa6c/api/src/main/java/org/apache/iceberg/transforms/Days.java#L47

## Backports Required

- [x] v26.1.x
- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Bug Fixes

* The `day` partition transform now produces a `date`-typed partition
  column (matching the Iceberg spec) instead of `int`.
