### PR TITLE
[v26.1.x] iceberg/avro: fix decimal encode/decode for non-16-byte payloads

### DIFF
--- a/bazel/thirdparty/requirements.in
+++ b/bazel/thirdparty/requirements.in
@@ -7,3 +7,4 @@ jinja2
 aioboto3
 PyYAML
 psutil
+avro==1.12.0

--- a/bazel/thirdparty/requirements.txt
+++ b/bazel/thirdparty/requirements.txt
@@ -113,6 +113,10 @@ attrs==22.2.0 \
     # via
     #   aiohttp
     #   jsonschema
+avro==1.12.0 \
+    --hash=sha256:9a255c72e1837341dd4f6ff57b2b6f68c0f0cecdef62dd04962e10fd33bec05b \
+    --hash=sha256:cad9c53b23ceed699c7af6bddced42e2c572fd6b408c257a7d4fc4e8cf2e2d6b
+    # via -r requirements.in
 boto3==1.37.1 \
     --hash=sha256:4320441f904435a1b85e6ecb81793192e522c737cc9ed6566014e29f0a11cb22 \
     --hash=sha256:96d18f7feb0c1fcb95f8837b74b6c8880e1b4e35ce5f8a8f8cb243a090c278ed

--- a/src/v/iceberg/avro_decimal.h
+++ b/src/v/iceberg/avro_decimal.h
@@ -24,53 +24,84 @@
  * See the Iceberg spec: "decimal(P, S) ... precision must be 38 or less"
  * https://iceberg.apache.org/spec/#primitive-types
  *
- * The encoder always emits exactly 16 bytes (Java `BigInteger.toByteArray()`
- * style, suitable for Avro `fixed[16]`), while the decoder accepts payloads
- * of 0..16 bytes and sign-extends as required by Avro's variable-width
- * `bytes` representation of `decimal`.
+ * Iceberg's Avro mapping (https://iceberg.apache.org/spec/#avro) requires
+ * `decimal(P, S)` to be stored as `fixed[minBytesRequired(P)]` — the
+ * minimum number of bytes needed to represent the given precision. In
+ * practice the same requirement applies to Iceberg manifest serialization.
+ * The encoder produces exactly that many bytes, big-endian two's-complement,
+ * with the value sign-extended on the left. The decoder accepts 0..16 byte
+ * payloads, covering both the `fixed` and `bytes` Avro forms of `decimal`,
+ * and sign-extends from the MSB of the first byte.
  */
 
 #include "absl/numeric/int128.h"
 #include "bytes/bytes.h"
 #include "bytes/iobuf.h"
 
+#include <seastar/core/byteorder.hh>
+
 #include <array>
+#include <climits>
 #include <cstring>
+#include <stdexcept>
 
 namespace iceberg {
 
-/// Byte width of an Avro `decimal` value once represented as `absl::int128`:
-/// 128 bits / 8 = 16 bytes. Used as both the fixed encoded width and the
-/// upper bound on accepted decode payloads.
+/// Width of an `absl::int128`, in bytes — the upper bound on both encoded
+/// payload sizes and accepted decode payloads.
 constexpr size_t max_decimal_bytes = 16;
 
 /**
- * Converts a decimal into an array of bytes (big endian), this works the same
- * way as the Java's BigInteger.toByteArray() method.
- */
-inline bytes encode_avro_decimal(absl::int128 decimal) {
-    auto high_half = ss::cpu_to_be(absl::Uint128High64(decimal));
-    auto low_half = ss::cpu_to_be(absl::Uint128Low64(decimal));
-
-    bytes decimal_bytes(bytes::initialized_zero{}, max_decimal_bytes);
-
-    for (int i = 0; i < 8; i++) {
-        // NOLINTNEXTLINE(hicpp-signed-bitwise)
-        decimal_bytes[i] = (high_half >> (i * 8)) & 0xFF;
-        // NOLINTNEXTLINE(hicpp-signed-bitwise)
-        decimal_bytes[i + 8] = (low_half >> (i * 8)) & 0xFF;
-    }
-
-    return decimal_bytes;
-}
-/**
- * Decodes a big-endian two's-complement byte sequence into an absl::int128,
- * matching Avro's `decimal` wire format.
+ * Encode `decimal` as exactly `size` bytes of big-endian two's-complement —
+ * the Iceberg / Avro wire format for `fixed[size]` decimals. The output
+ * matches Java's reference encoder, which pads `BigInteger.toByteArray()`
+ * on the left with the sign byte to reach `size`; we get there by
+ * serializing the full 16-byte sign-extended representation and returning
+ * its rightmost `size` bytes.
  *
- * Avro uses the minimum number of bytes required to preserve the sign — e.g.
- * `0`, `1`, and `-1` each fit in a single byte, while `128` needs a leading
- * `0x00` to avoid being read as `-128`. The MSB of the first byte is
- * sign-extended into the high bits of the result.
+ * Throws if `size` is outside `[1, max_decimal_bytes]` or if `decimal` does
+ * not fit in a signed `size`-byte integer.
+ */
+inline bytes encode_avro_fixed_decimal(absl::int128 decimal, size_t size) {
+    if (size == 0 || size > max_decimal_bytes) {
+        throw std::invalid_argument(
+          fmt::format(
+            "Decimal size must be in [1, {}], got {}",
+            max_decimal_bytes,
+            size));
+    }
+    // Range check: a signed `size`-byte integer holds values in
+    // [-2^(8*size-1), 2^(8*size-1) - 1]. At max_decimal_bytes the limit
+    // would overflow int128 and every value fits anyway, so skip the check.
+    if (size < max_decimal_bytes) {
+        const auto shift = static_cast<int>(CHAR_BIT * size - 1);
+        const absl::int128 limit = absl::int128{1} << shift;
+        if (decimal < -limit || decimal >= limit) {
+            throw std::invalid_argument(
+              fmt::format("decimal value does not fit in {} bytes", size));
+        }
+    }
+    // Serialize as a 16-byte big-endian two's-complement integer; the
+    // sign-extending leading bytes are redundant once range-checked, so
+    // return only the rightmost `size` bytes.
+    const auto hi = ss::cpu_to_be(absl::Uint128High64(decimal));
+    const auto lo = ss::cpu_to_be(absl::Uint128Low64(decimal));
+    std::array<uint8_t, max_decimal_bytes> full{};
+    std::memcpy(full.data(), &hi, sizeof(hi));
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    std::memcpy(full.data() + sizeof(hi), &lo, sizeof(lo));
+    return {full.begin() + (max_decimal_bytes - size), full.end()};
+}
+
+/**
+ * Decode a big-endian two's-complement byte sequence into an absl::int128.
+ *
+ * Handles both Avro encodings of `decimal`: the fixed-width `fixed[N]` form
+ * (value already sign-extended to fill N bytes) and the variable-width
+ * `bytes` form (minimum bytes needed to preserve the sign — e.g. `0`, `1`,
+ * and `-1` each fit in one byte, while `128` needs a leading `0x00` to
+ * avoid being read as `-128`). The MSB of the first byte is sign-extended
+ * into the high bits of the result.
  *
  * Accepts 0..16 byte payloads; longer inputs are rejected.
  */
@@ -105,20 +136,11 @@ inline absl::int128 decode_avro_decimal(bytes input) {
       static_cast<int64_t>(ss::be_to_cpu(hi)), ss::be_to_cpu(lo));
 }
 
-inline iobuf avro_decimal_to_iobuf(absl::int128 decimal, size_t max_size) {
-    if (max_size > max_decimal_bytes) {
-        throw std::invalid_argument(
-          "Decimal iobuf can not be larger than 16 bytes");
-    }
-    return bytes_to_iobuf(encode_avro_decimal(decimal));
+inline iobuf avro_fixed_decimal_to_iobuf(absl::int128 decimal, size_t size) {
+    return bytes_to_iobuf(encode_avro_fixed_decimal(decimal, size));
 }
 
 inline absl::int128 iobuf_to_avro_decimal(iobuf buf) {
-    if (buf.size_bytes() > max_decimal_bytes) {
-        throw std::invalid_argument(
-          "Decimal iobuf can not be larger than 16 bytes");
-    }
-
     return decode_avro_decimal(iobuf_to_bytes(buf));
 }
 } // namespace iceberg

--- a/src/v/iceberg/avro_decimal.h
+++ b/src/v/iceberg/avro_decimal.h
@@ -9,12 +9,6 @@
  */
 #pragma once
 
-#include "absl/numeric/int128.h"
-#include "bytes/bytes.h"
-#include "bytes/iobuf.h"
-
-#include <array>
-namespace iceberg {
 /**
  * @file
  * Helpers for encoding and decoding Avro `decimal` logical type values as
@@ -36,6 +30,20 @@ namespace iceberg {
  * `bytes` representation of `decimal`.
  */
 
+#include "absl/numeric/int128.h"
+#include "bytes/bytes.h"
+#include "bytes/iobuf.h"
+
+#include <array>
+#include <cstring>
+
+namespace iceberg {
+
+/// Byte width of an Avro `decimal` value once represented as `absl::int128`:
+/// 128 bits / 8 = 16 bytes. Used as both the fixed encoded width and the
+/// upper bound on accepted decode payloads.
+constexpr size_t max_decimal_bytes = 16;
+
 /**
  * Converts a decimal into an array of bytes (big endian), this works the same
  * way as the Java's BigInteger.toByteArray() method.
@@ -44,7 +52,7 @@ inline bytes encode_avro_decimal(absl::int128 decimal) {
     auto high_half = ss::cpu_to_be(absl::Uint128High64(decimal));
     auto low_half = ss::cpu_to_be(absl::Uint128Low64(decimal));
 
-    bytes decimal_bytes(bytes::initialized_zero{}, 16);
+    bytes decimal_bytes(bytes::initialized_zero{}, max_decimal_bytes);
 
     for (int i = 0; i < 8; i++) {
         // NOLINTNEXTLINE(hicpp-signed-bitwise)
@@ -56,22 +64,49 @@ inline bytes encode_avro_decimal(absl::int128 decimal) {
     return decimal_bytes;
 }
 /**
- * Converts an array of big endian encoded bytes to an absl::int128
+ * Decodes a big-endian two's-complement byte sequence into an absl::int128,
+ * matching Avro's `decimal` wire format.
+ *
+ * Avro uses the minimum number of bytes required to preserve the sign — e.g.
+ * `0`, `1`, and `-1` each fit in a single byte, while `128` needs a leading
+ * `0x00` to avoid being read as `-128`. The MSB of the first byte is
+ * sign-extended into the high bits of the result.
+ *
+ * Accepts 0..16 byte payloads; longer inputs are rejected.
  */
-inline absl::int128 decode_avro_decimal(bytes bytes) {
-    int64_t high_half = 0;
-    uint64_t low_half = 0;
-    for (size_t i = 0; i < 8; i++) {
-        // NOLINTNEXTLINE(hicpp-signed-bitwise)
-        high_half |= static_cast<int64_t>(bytes[i]) << i * 8;
-        low_half |= static_cast<uint64_t>(bytes[i + 8]) << i * 8;
+inline absl::int128 decode_avro_decimal(bytes input) {
+    if (input.size() > max_decimal_bytes) {
+        throw std::invalid_argument(
+          "Decimal bytes cannot be larger than 16 bytes");
     }
+    if (input.empty()) {
+        return 0;
+    }
+    // Right-align the payload in a 16-byte big-endian buffer and sign-extend
+    // the leading bytes from the MSB of input[0], then read it as two
+    // byteswapped 64-bit halves.
+    std::array<uint8_t, max_decimal_bytes> buf{};
+    buf.fill((input[0] & 0x80U) == 0 ? 0x00 : 0xFF);
 
-    return absl::MakeInt128(ss::be_to_cpu(high_half), ss::be_to_cpu(low_half));
+    std::memcpy(
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      buf.data() + (buf.size() - input.size()),
+      input.data(),
+      input.size());
+
+    uint64_t hi = 0;
+    uint64_t lo = 0;
+
+    std::memcpy(&hi, buf.data(), sizeof(hi));
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    std::memcpy(&lo, buf.data() + sizeof(hi), sizeof(lo));
+
+    return absl::MakeInt128(
+      static_cast<int64_t>(ss::be_to_cpu(hi)), ss::be_to_cpu(lo));
 }
 
 inline iobuf avro_decimal_to_iobuf(absl::int128 decimal, size_t max_size) {
-    if (max_size > 16) {
+    if (max_size > max_decimal_bytes) {
         throw std::invalid_argument(
           "Decimal iobuf can not be larger than 16 bytes");
     }
@@ -79,7 +114,7 @@ inline iobuf avro_decimal_to_iobuf(absl::int128 decimal, size_t max_size) {
 }
 
 inline absl::int128 iobuf_to_avro_decimal(iobuf buf) {
-    if (buf.size_bytes() > 16) {
+    if (buf.size_bytes() > max_decimal_bytes) {
         throw std::invalid_argument(
           "Decimal iobuf can not be larger than 16 bytes");
     }

--- a/src/v/iceberg/avro_decimal.h
+++ b/src/v/iceberg/avro_decimal.h
@@ -16,6 +16,27 @@
 #include <array>
 namespace iceberg {
 /**
+ * @file
+ * Helpers for encoding and decoding Avro `decimal` logical type values as
+ * big-endian two's-complement integers.
+ *
+ * Precision is capped at 128 bits (i.e. up to the range of `absl::int128`).
+ * Avro itself does not bound the precision of a `decimal`, but our
+ * downstream consumer Iceberg restricts it to at most 38 digits, and
+ * 10^38 - 1 fits comfortably within a signed 128-bit integer
+ * (ceil(log2(10^38)) = 127 bits). No representable value is lost when data
+ * destined for this downstream consumer passes through `absl::int128`.
+ *
+ * See the Iceberg spec: "decimal(P, S) ... precision must be 38 or less"
+ * https://iceberg.apache.org/spec/#primitive-types
+ *
+ * The encoder always emits exactly 16 bytes (Java `BigInteger.toByteArray()`
+ * style, suitable for Avro `fixed[16]`), while the decoder accepts payloads
+ * of 0..16 bytes and sign-extends as required by Avro's variable-width
+ * `bytes` representation of `decimal`.
+ */
+
+/**
  * Converts a decimal into an array of bytes (big endian), this works the same
  * way as the Java's BigInteger.toByteArray() method.
  */

--- a/src/v/iceberg/conversion/tests/iceberg_avro_tests.cc
+++ b/src/v/iceberg/conversion/tests/iceberg_avro_tests.cc
@@ -787,7 +787,8 @@ AssertionResult value_matches(
 
 // convert iceberg decimal to vector of bytes, big endian
 std::vector<uint8_t> decimal_to_vector(absl::int128 decimal) {
-    auto array = iceberg::encode_avro_decimal(decimal);
+    auto array = iceberg::encode_avro_fixed_decimal(
+      decimal, iceberg::max_decimal_bytes);
     return {array.begin(), array.end()};
 }
 

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -34,6 +34,7 @@ redpanda_test_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//src/v/base",
         "//src/v/iceberg:datatypes",
         "//src/v/iceberg:values",
         "//src/v/random:generators",

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -540,6 +540,7 @@ redpanda_cc_gtest(
         "//src/v/iceberg:values_avro",
         "//src/v/random:generators",
         "//src/v/test_utils:gtest",
+        "@avro",
         "@googletest//:gtest",
     ],
 )

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -1,3 +1,4 @@
+load("@rules_python//python:defs.bzl", "py_binary")
 load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_gtest", "redpanda_test_cc_library")
 
 redpanda_test_cc_library(
@@ -539,6 +540,39 @@ redpanda_cc_gtest(
         "//src/v/iceberg:values_avro",
         "//src/v/random:generators",
         "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
+py_binary(
+    name = "avro_decimal_interop_gen",
+    srcs = ["avro_decimal_interop_gen.py"],
+    main = "avro_decimal_interop_gen.py",
+    deps = ["@python_deps//avro"],
+)
+
+genrule(
+    name = "decimal_cases_avro",
+    outs = ["decimal_cases.avro"],
+    cmd = "$(execpath :avro_decimal_interop_gen) $@",
+    toolchains = ["@rules_python//python:current_py_toolchain"],
+    tools = [":avro_decimal_interop_gen"],
+)
+
+redpanda_cc_gtest(
+    name = "avro_decimal_interop_test",
+    timeout = "short",
+    srcs = [
+        "avro_decimal_interop_test.cc",
+    ],
+    data = [":decimal_cases.avro"],
+    deps = [
+        "//src/v/bytes",
+        "//src/v/iceberg:avro_decimal",
+        "//src/v/test_utils:gtest",
+        "//src/v/test_utils:runfiles",
+        "@abseil-cpp//absl/numeric:int128",
+        "@avro",
         "@googletest//:gtest",
     ],
 )

--- a/src/v/iceberg/tests/avro_decimal_interop_gen.py
+++ b/src/v/iceberg/tests/avro_decimal_interop_gen.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+"""Generate an Avro container file with decimal cases for interop testing.
+
+The C++ side (avro_decimal_interop_test.cc) reads the file and asserts that
+our `decode_avro_decimal` recovers the int128 value the reference Avro
+encoder packed into each record's `payload` field.
+
+Case names are the contract with the C++ test: mismatches surface as a
+test failure naming the missing or extra case.
+
+Usage: avro_decimal_interop_gen.py <output_path>
+"""
+
+from __future__ import annotations
+
+import decimal
+import json
+import sys
+from pathlib import Path
+
+import avro.datafile
+import avro.io
+import avro.schema
+
+# Iceberg caps decimal precision at 38, so the largest in-spec magnitude is
+# 10**38 - 1. That value needs 127 bits (ceil(log2(10**38)) == 127) and still
+# encodes as a full 16-byte payload, so we use it to exercise the int128
+# boundary instead of the unrestricted ±2**127 range.
+PRECISION = 38
+PRECISION_MAX = 10**PRECISION - 1
+
+SCHEMA = {
+    "type": "record",
+    "namespace": "redpanda.test",
+    "name": "DecimalCase",
+    "fields": [
+        {"name": "name", "type": "string"},
+        {
+            "name": "payload",
+            "type": {
+                "type": "bytes",
+                "logicalType": "decimal",
+                "precision": PRECISION,
+                "scale": 0,
+            },
+        },
+    ],
+}
+
+# Mirrors the expected_values() table in avro_decimal_interop_test.cc.
+# Names exercise wire payload lengths from 1 byte up to the 16-byte int128
+# boundary, spanning sign-change points where the avro encoder must add a
+# leading 0x00 or 0xFF byte to preserve the two's-complement sign.
+CASES: list[tuple[str, int]] = [
+    ("zero", 0),
+    ("one", 1),
+    ("neg_one", -1),
+    ("127", 127),
+    ("128", 128),  # 2 bytes: 0x00 0x80
+    ("neg_128", -128),  # 1 byte: 0x80
+    ("neg_129", -129),  # 2 bytes: 0xFF 0x7F
+    ("12345", 12345),
+    ("neg_12345", -12345),
+    ("65536", 65536),
+    ("two_pow_40", 2**40),
+    ("neg_two_pow_40", -(2**40)),
+    ("int64_max", 2**63 - 1),
+    ("int64_min", -(2**63)),
+    ("two_pow_64", 2**64),  # crosses the int64/int128 high-half boundary
+    ("precision_38_max", PRECISION_MAX),  # full 16-byte payload, positive
+    ("neg_precision_38_max", -PRECISION_MAX),  # full 16-byte payload, negative
+]
+
+
+def main(output_path: str) -> None:
+    schema = avro.schema.parse(json.dumps(SCHEMA))
+    with Path(output_path).open("wb") as f:
+        writer = avro.datafile.DataFileWriter(f, avro.io.DatumWriter(), schema)
+        try:
+            for name, value in CASES:
+                writer.append({"name": name, "payload": decimal.Decimal(value)})
+        finally:
+            writer.close()
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/src/v/iceberg/tests/avro_decimal_interop_test.cc
+++ b/src/v/iceberg/tests/avro_decimal_interop_test.cc
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "absl/numeric/int128.h"
+#include "bytes/bytes.h"
+#include "iceberg/avro_decimal.h"
+#include "test_utils/runfiles.h"
+
+#include <avro/DataFile.hh>
+#include <avro/Generic.hh>
+#include <avro/GenericDatum.hh>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+// 10^38 - 1, the largest in-spec magnitude for an Iceberg decimal with
+// precision 38. ceil(log2(10^38)) == 127, so this still encodes as a full
+// 16-byte payload — exercising the int128 boundary without exceeding spec.
+constexpr absl::int128 k10Pow19{10'000'000'000'000'000'000ULL};
+const absl::int128 kPrecision38Max = k10Pow19 * k10Pow19 - 1;
+
+// Mirrors CASES in avro_decimal_interop_gen.py. Asserts that our decoder
+// recovers each int128 from the bytes the reference Apache `avro` Python
+// library produced.
+const std::unordered_map<std::string, absl::int128>& expected_values() {
+    static const auto& kCases
+      = *new std::unordered_map<std::string, absl::int128>{
+        {"zero", absl::int128(0)},
+        {"one", absl::int128(1)},
+        {"neg_one", absl::int128(-1)},
+        {"127", absl::int128(127)},
+        {"128", absl::int128(128)},
+        {"neg_128", absl::int128(-128)},
+        {"neg_129", absl::int128(-129)},
+        {"12345", absl::int128(12345)},
+        {"neg_12345", absl::int128(-12345)},
+        {"65536", absl::int128(65536)},
+        {"two_pow_40", absl::int128(1) << 40},
+        {"neg_two_pow_40", -(absl::int128(1) << 40)},
+        {"int64_max", absl::int128(std::numeric_limits<int64_t>::max())},
+        {"int64_min", absl::int128(std::numeric_limits<int64_t>::min())},
+        {"two_pow_64", absl::int128(1) << 64},
+        {"precision_38_max", kPrecision38Max},
+        {"neg_precision_38_max", -kPrecision38Max},
+      };
+    return kCases;
+}
+
+} // namespace
+
+TEST(AvroDecimalInteropTest, ReferenceEncoderRoundTrips) {
+    const auto path = test_utils::get_runfile_path(
+      "src/v/iceberg/tests/decimal_cases.avro");
+    avro::DataFileReader<avro::GenericDatum> reader(path.c_str());
+
+    std::unordered_map<std::string, absl::int128> decoded;
+    while (true) {
+        avro::GenericDatum datum(reader.dataSchema());
+        if (!reader.read(datum)) {
+            break;
+        }
+        ASSERT_EQ(datum.type(), avro::AVRO_RECORD);
+        const auto& record = datum.value<avro::GenericRecord>();
+
+        const auto& name = record.field("name").value<std::string>();
+        const auto& payload
+          = record.field("payload").value<std::vector<uint8_t>>();
+
+        bytes payload_bytes(payload.begin(), payload.end());
+        auto value = iceberg::decode_avro_decimal(std::move(payload_bytes));
+        auto [_, inserted] = decoded.emplace(name, value);
+        ASSERT_TRUE(inserted) << "duplicate case name in fixture: " << name;
+    }
+
+    const auto& expected = expected_values();
+    EXPECT_EQ(decoded.size(), expected.size())
+      << "case count differs between fixture and expectations table";
+    for (const auto& [name, exp] : expected) {
+        auto it = decoded.find(name);
+        ASSERT_NE(it, decoded.end()) << "case missing from fixture: " << name;
+        EXPECT_EQ(it->second, exp) << "decoded mismatch for case: " << name;
+    }
+}

--- a/src/v/iceberg/tests/value_generator.cc
+++ b/src/v/iceberg/tests/value_generator.cc
@@ -9,6 +9,7 @@
  */
 #include "iceberg/tests/value_generator.h"
 
+#include "base/vassert.h"
 #include "iceberg/datatypes.h"
 #include "iceberg/values.h"
 #include "random/generators.h"
@@ -55,12 +56,28 @@ struct generating_primitive_value_visitor {
         return double_value{static_cast<double>(
           spec_.forced_num_val.value_or(generate_numeric_val()))};
     }
-    value operator()(const decimal_type&) {
+    value operator()(const decimal_type& t) {
         if (spec_.forced_num_val) {
             return decimal_value{absl::int128{spec_.forced_num_val.value()}};
         }
-        return decimal_value{
-          absl::MakeInt128(generate_numeric_val(), generate_numeric_val())};
+        switch (spec_.pattern) {
+        case value_pattern::zeros:
+            return decimal_value{absl::int128{0}};
+        case value_pattern::random: {
+            // Keep the magnitude within the column's declared precision:
+            // |value| <= 10^precision - 1.
+            vassert(
+              t.precision <= 38,
+              "decimal precision {} exceeds Iceberg max of 38",
+              t.precision);
+            absl::int128 mag{0};
+            for (uint32_t i = 0; i < t.precision; ++i) {
+                mag = mag * 10 + random_generators::get_int(0, 9);
+            }
+            const bool neg = random_generators::get_int(0, 1) == 1;
+            return decimal_value{neg ? -mag : mag};
+        }
+        }
     }
     value operator()(const date_type&) {
         return date_value{static_cast<int>(

--- a/src/v/iceberg/tests/value_generator.cc
+++ b/src/v/iceberg/tests/value_generator.cc
@@ -57,7 +57,7 @@ struct generating_primitive_value_visitor {
     }
     value operator()(const decimal_type&) {
         if (spec_.forced_num_val) {
-            return decimal_value{absl::MakeInt128(0, generate_numeric_val())};
+            return decimal_value{absl::int128{spec_.forced_num_val.value()}};
         }
         return decimal_value{
           absl::MakeInt128(generate_numeric_val(), generate_numeric_val())};

--- a/src/v/iceberg/tests/values_avro_test.cc
+++ b/src/v/iceberg/tests/values_avro_test.cc
@@ -16,6 +16,9 @@
 #include "iceberg/values_avro.h"
 #include "random/generators.h"
 
+#include <avro/GenericDatum.hh>
+#include <avro/LogicalType.hh>
+#include <avro/Schema.hh>
 #include <gtest/gtest.h>
 
 using namespace iceberg;
@@ -75,9 +78,10 @@ TEST(ValuesAvroTest, TestDecimal) {
         return ret;
     };
 
+    // Values must fit decimal(10,2): magnitude < 10^10.
     for (auto& v : {
-           make_struct(std::numeric_limits<absl::int128>::max()),
-           make_struct(std::numeric_limits<absl::int128>::max()),
+           make_struct(9999999999),
+           make_struct(-9999999999),
            make_struct(0),
            make_struct(-1),
            make_struct(1),
@@ -100,35 +104,40 @@ TEST(ValuesAvroTest, TestDecimalConversions) {
 
         auto decimal = absl::MakeInt128(high_half, low_half);
 
-        ASSERT_EQ(decimal, decode_avro_decimal(encode_avro_decimal(decimal)));
         ASSERT_EQ(
-          decimal, iobuf_to_avro_decimal(avro_decimal_to_iobuf(decimal, 16)));
+          decimal,
+          decode_avro_decimal(
+            encode_avro_fixed_decimal(decimal, max_decimal_bytes)));
+        ASSERT_EQ(
+          decimal,
+          iobuf_to_avro_decimal(
+            avro_fixed_decimal_to_iobuf(decimal, max_decimal_bytes)));
     }
 }
 
 TEST(ValuesAvroTest, TestDecimalConversionsLimitedSize) {
-    auto high_half = 0;
-    auto low_half = random_generators::get_int<uint64_t>();
-
-    auto decimal = absl::MakeInt128(high_half, low_half);
+    // Value must fit in a signed 8-byte slot — pick from int64_t range.
+    absl::int128 decimal{random_generators::get_int<int64_t>()};
 
     ASSERT_EQ(
-      decimal, iobuf_to_avro_decimal(avro_decimal_to_iobuf(decimal, 8)));
+      decimal, iobuf_to_avro_decimal(avro_fixed_decimal_to_iobuf(decimal, 8)));
 }
 
 TEST(ValuesAvroTest, TestDecimalConversionAgainstJavaBigInteger) {
     // value of 65536
     ASSERT_EQ(
-      encode_avro_decimal(absl::MakeInt128(0, 65536)),
+      encode_avro_fixed_decimal(absl::MakeInt128(0, 65536), max_decimal_bytes),
       bytes({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0}));
     // value of 35209893291843950283695459221
     ASSERT_EQ(
-      encode_avro_decimal(absl::MakeInt128(1908732140, 89247320981)),
+      encode_avro_fixed_decimal(
+        absl::MakeInt128(1908732140, 89247320981), max_decimal_bytes),
       bytes({0, 0, 0, 0, 113, 196, 240, 236, 0, 0, 0, 20, 199, 142, 11, 149}));
 
     // value of -18218949492341193300753118315
     ASSERT_EQ(
-      encode_avro_decimal(absl::MakeInt128(-987651231, 89247320981)),
+      encode_avro_fixed_decimal(
+        absl::MakeInt128(-987651231, 89247320981), max_decimal_bytes),
       bytes(
         {255,
          255,
@@ -146,4 +155,59 @@ TEST(ValuesAvroTest, TestDecimalConversionAgainstJavaBigInteger) {
          142,
          11,
          149}));
+}
+
+// Decode a decimal value packed in an Avro fixed[N] payload where N is the
+// minimum byte width for the column's precision (Iceberg spec). Hand-craft
+// the datum so the decoder is exercised independently of the encoder.
+namespace {
+avro::GenericDatum make_decimal_fixed_datum(
+  const decimal_type& dt, const std::vector<uint8_t>& payload) {
+    auto n = static_cast<int>(payload.size());
+    auto schema = avro::FixedSchema(n, "decimal");
+    avro::LogicalType l_type(avro::LogicalType::DECIMAL);
+    l_type.setPrecision(static_cast<int>(dt.precision));
+    l_type.setScale(static_cast<int>(dt.scale));
+    schema.root()->setLogicalType(l_type);
+    return {schema.root(), avro::GenericFixed(schema.root(), payload)};
+}
+} // namespace
+
+TEST(ValuesAvroTest, TestEncodeAvroFixedDecimalThrows) {
+    EXPECT_THROW(encode_avro_fixed_decimal(0, 0), std::invalid_argument);
+    EXPECT_THROW(
+      encode_avro_fixed_decimal(0, max_decimal_bytes + 1),
+      std::invalid_argument);
+    // 128 does not fit in a signed 1-byte slot (range [-128, 127]).
+    EXPECT_THROW(encode_avro_fixed_decimal(128, 1), std::invalid_argument);
+    EXPECT_THROW(encode_avro_fixed_decimal(-129, 1), std::invalid_argument);
+    // -128 is the inclusive lower bound and must succeed.
+    EXPECT_NO_THROW(encode_avro_fixed_decimal(-128, 1));
+    EXPECT_NO_THROW(encode_avro_fixed_decimal(127, 1));
+}
+
+TEST(ValuesAvroTest, TestDecodeIcebergFixedDecimal) {
+    // decimal(10,2) → fixed[5]. 1234567 (=12345.67) and -1234567 (=-12345.67)
+    // both fit in 3 bytes but must be sign-extended to 5 to fill the slot.
+    const decimal_type dt{.precision = 10, .scale = 2};
+    field_type expected_type{dt};
+
+    struct case_t {
+        absl::int128 value;
+        std::vector<uint8_t> fixed5;
+    };
+    const std::array cases{
+      case_t{1234567, {0x00, 0x00, 0x12, 0xD6, 0x87}},
+      case_t{-1234567, {0xFF, 0xFF, 0xED, 0x29, 0x79}},
+      case_t{0, {0x00, 0x00, 0x00, 0x00, 0x00}},
+      case_t{-1, {0xFF, 0xFF, 0xFF, 0xFF, 0xFF}},
+    };
+    for (const auto& c : cases) {
+        auto datum = make_decimal_fixed_datum(dt, c.fixed5);
+        auto parsed = val_from_avro(datum, expected_type, field_required::yes);
+        ASSERT_TRUE(parsed.has_value());
+        const auto& dv = std::get<decimal_value>(
+          std::get<primitive_value>(*parsed));
+        ASSERT_EQ(dv.val, c.value);
+    }
 }

--- a/src/v/iceberg/values_avro.cc
+++ b/src/v/iceberg/values_avro.cc
@@ -135,11 +135,12 @@ struct primitive_value_avro_visitor {
         return {data};
     }
     avro::GenericDatum operator()(const decimal_value& v) {
-        auto bytes = encode_avro_decimal(v.val);
-
+        maybe_throw_invalid_schema(avro_schema_, avro::AVRO_FIXED);
+        auto encoded = encode_avro_fixed_decimal(
+          v.val, avro_schema_->fixedSize());
         return {
           avro_schema_,
-          avro::GenericFixed(avro_schema_, {bytes.begin(), bytes.end()})};
+          avro::GenericFixed(avro_schema_, {encoded.begin(), encoded.end()})};
     }
     avro::GenericDatum operator()(const fixed_value& fixed) {
         std::vector<uint8_t> bytes(fixed.val.size_bytes());
@@ -368,18 +369,8 @@ struct primitive_value_parsing_visitor {
         lt.setScale(dt.scale);
         maybe_throw_wrong_logical_type(data_.logicalType(), lt);
         const auto& v = data_.value<avro::GenericFixed>().value();
-        if (v.size() > 16) {
-            throw std::invalid_argument(
-              fmt::format(
-                "decimals with more than 16 bytes are not supported, current "
-                "value size: {}",
-                v.size()));
-        }
-        bytes decimal_bytes(bytes::initialized_zero{}, 16);
-
-        std::copy(v.begin(), v.end(), decimal_bytes.begin());
-
-        return decimal_value{.val = decode_avro_decimal(decimal_bytes)};
+        return decimal_value{
+          .val = decode_avro_decimal(bytes{v.begin(), v.end()})};
     }
 };
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30516
