### PR TITLE
dt/tests: bump kafka-python and clean up 2.0.6 workarounds

### DIFF
--- a/tests/rptest/tests/cluster_quota_test.py
+++ b/tests/rptest/tests/cluster_quota_test.py
@@ -202,9 +202,7 @@ class ClusterRateQuotaTest(RedpandaTest):
         )
 
     def check_producer_throttled(self, producer, ignore_max_throttle=False):
-        throttle_ms = producer.metrics()["producer-metrics"][
-            "produce-throttle-time-max"
-        ]
+        throttle_ms = producer.metrics()["producer-metrics"]["throttle-time-max"]
         assert throttle_ms > 0, f"Expected throttle > 0. Got {throttle_ms} ms"
         if not ignore_max_throttle:
             assert throttle_ms <= self.max_throttle_time, (
@@ -212,23 +210,17 @@ class ClusterRateQuotaTest(RedpandaTest):
             )
 
     def check_producer_not_throttled(self, producer):
-        throttle_ms = producer.metrics()["producer-metrics"][
-            "produce-throttle-time-max"
-        ]
+        throttle_ms = producer.metrics()["producer-metrics"]["throttle-time-max"]
         assert throttle_ms == 0, f"Expected 0 ms throttle. Got {throttle_ms} ms"
 
     def check_consumer_throttled(self, consumer):
-        throttle_ms = consumer.metrics()["consumer-fetch-manager-metrics"][
-            "fetch-throttle-time-max"
-        ]
+        throttle_ms = consumer.metrics()["consumer-metrics"]["throttle-time-max"]
         assert throttle_ms > 0 and throttle_ms <= self.max_throttle_time, (
             f"Expected throttle in range (0, {self.max_throttle_time}]. Got {throttle_ms}"
         )
 
     def check_consumer_not_throttled(self, consumer):
-        throttle_ms = consumer.metrics()["consumer-fetch-manager-metrics"][
-            "fetch-throttle-time-max"
-        ]
+        throttle_ms = consumer.metrics()["consumer-metrics"]["throttle-time-max"]
         assert throttle_ms == 0, f"Expected 0 ms throttle. Got {throttle_ms} ms"
 
     def produce(self, producer, amount, message=None, timeout_sec=10):
@@ -257,6 +249,15 @@ class ClusterRateQuotaTest(RedpandaTest):
             retries=2,
             request_timeout_ms=60000,
             client_id=client_id,
+            # kafka-python 2.3.1 enables KIP-219 client-side throttle
+            # enforcement when the broker advertises api_version >= 2.0,
+            # but its sender does not factor throttle_delay into the
+            # poll timeout — once a connection is throttled the sender
+            # stalls until the next external wakeup. Pin the api_version
+            # below 2.0 so the client treats throttle_time_ms as
+            # advisory and lets the broker enforce the quota
+            # server-side, which is what this test is exercising.
+            api_version=(1, 1),
             *args,
             **kwargs,
         )

--- a/tests/rptest/tests/connection_virtualizing_test.py
+++ b/tests/rptest/tests/connection_virtualizing_test.py
@@ -12,7 +12,7 @@ from types import MethodType
 
 from ducktape.mark import matrix
 from kafka import KafkaClient, KafkaConsumer
-from kafka.protocol.admin import ApiVersionRequest
+from kafka.protocol.api_versions import ApiVersionsRequest
 from kafka.protocol.fetch import FetchRequest
 from kafka.protocol.produce import ProduceRequest
 from kafka.record.memory_records import MemoryRecordsBuilder
@@ -55,7 +55,7 @@ class MpxMockClient:
         return ready
 
     def _api_versions_request(self):
-        return ApiVersionRequest[1]()
+        return ApiVersionsRequest[1]()
 
     def _create_record_batch(self):
         # we do not need any special type of batch, using single record batch without compression

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -591,7 +591,10 @@ class ConsumerGroupTest(RedpandaTest):
                     )
                     try:
                         consumer.subscribe([self.topic_spec.name])
-                        consumer.poll(1)
+                        # poll() must run long enough for JoinGroup to
+                        # complete so the group is registered; kafka-python
+                        # 2.3.1's coordinator poll honors this timeout.
+                        consumer.poll(timeout_ms=5000)
                     finally:
                         consumer.close(autocommit=True)
                 except Exception as e:
@@ -970,10 +973,12 @@ class ConsumerGroupTest(RedpandaTest):
 
         self.logger.info("Waiting for group to become stable")
         wait_until(
-            lambda: self.admin_client.describe_consumer_groups(group_ids=[group])[group]
-            .result()
-            .state
-            == ConsumerGroupState.STABLE,
+            lambda: (
+                self.admin_client.describe_consumer_groups(group_ids=[group])[group]
+                .result()
+                .state
+                == ConsumerGroupState.STABLE
+            ),
             20,
             1,
             retry_on_exc=True,
@@ -1171,10 +1176,12 @@ class ConsumerGroupTest(RedpandaTest):
         moved = move_partition(topic="__consumer_offsets", partition=0)
         assert moved, "Failed to move coordinator"
         wait_until(
-            lambda: self.admin_client.describe_consumer_groups(group_ids=[group])[group]
-            .result()
-            .state
-            == ConsumerGroupState.STABLE,
+            lambda: (
+                self.admin_client.describe_consumer_groups(group_ids=[group])[group]
+                .result()
+                .state
+                == ConsumerGroupState.STABLE
+            ),
             20,
             1,
             retry_on_exc=True,

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -13,11 +13,7 @@ from contextlib import closing
 import random
 import threading
 import time
-from collections import namedtuple
-from dataclasses import dataclass
-from typing import Dict, List
 
-import kafka.protocol.types as types
 import pytest
 from confluent_kafka import (
     Consumer,
@@ -30,10 +26,7 @@ from confluent_kafka.admin import AdminClient
 from ducktape.mark import ignore, parametrize
 from ducktape.utils.util import wait_until
 from kafka import KafkaConsumer
-from kafka import errors as kerr
 from kafka.admin import KafkaAdminClient
-from kafka.protocol.api import Request, Response
-from kafka.protocol.commit import OffsetFetchRequest_v3
 
 from rptest.clients.default import DefaultClient
 from rptest.clients.kcl import RawKCL
@@ -48,7 +41,6 @@ from rptest.services.redpanda import (
     RESTART_LOG_ALLOW_LIST,
     LoggingConfig,
     MetricsEndpoint,
-    RedpandaService,
 )
 from rptest.services.rpk_producer import RpkProducer
 from rptest.services.verifiable_consumer import VerifiableConsumer
@@ -446,16 +438,16 @@ class ConsumerGroupTest(RedpandaTest):
         self.consumer.start()
         self.consumer.wait()
 
-        test_admin = KafkaTestAdminClient(self.redpanda)
-        offsets = test_admin.list_offsets(
-            group_id, [TopicPartition(self.topic_spec.name, 0)]
+        admin = KafkaAdminClient(bootstrap_servers=self.redpanda.brokers())
+        offsets = admin.list_consumer_group_offsets(
+            group_id, partitions=[(self.topic_spec.name, 0)]
         )
 
         # Test that the consumer committed what we expected.
         self.logger.info(f"Got offsets: {offsets}")
         assert len(offsets) == 1
-        assert offsets[TestTopicPartition(self.topic_spec.name, 0)].offset == 1000
-        assert offsets[TestTopicPartition(self.topic_spec.name, 0)].leader_epoch > 0
+        assert offsets[(self.topic_spec.name, 0)].offset == 1000
+        assert offsets[(self.topic_spec.name, 0)].leader_epoch > 0
 
         # Remember the old offsets to compare them after the restart.
         prev_offsets = offsets
@@ -467,9 +459,9 @@ class ConsumerGroupTest(RedpandaTest):
         # Validate that the group state is recovered.
         def try_list_offsets():
             try:
-                test_admin = KafkaTestAdminClient(self.redpanda)
-                return test_admin.list_offsets(
-                    group_id, [TopicPartition(self.topic_spec.name, 0)]
+                admin = KafkaAdminClient(bootstrap_servers=self.redpanda.brokers())
+                return admin.list_consumer_group_offsets(
+                    group_id, partitions=[(self.topic_spec.name, 0)]
                 )
             except Exception as e:
                 self.logger.debug(f"Failed to list offsets: {e}")
@@ -1203,93 +1195,6 @@ class ConsumerGroupTest(RedpandaTest):
 
         for consumer in consumers:
             consumer.close()
-
-
-@dataclass
-class OffsetAndMetadata:
-    offset: int
-    leader_epoch: int
-    metadata: str
-
-
-TestTopicPartition = namedtuple("TestTopicPartition", ["topic", "partition"])
-
-
-class KafkaTestAdminClient:
-    """
-    A wrapper around KafkaAdminClient with support for newer Kafka versions.
-    At the time of writing, KafkaAdminClient doesn't support KIP-320
-    (leader epoch) for consumer groups.
-    """
-
-    def __init__(self, redpanda: RedpandaService):
-        self._bootstrap_servers = redpanda.brokers()
-        self._admin = KafkaAdminClient(bootstrap_servers=self._bootstrap_servers)
-
-    def list_offsets(
-        self, group_id: str, partitions: List[TopicPartition]
-    ) -> Dict[TestTopicPartition, OffsetAndMetadata]:
-        coordinator = self._admin._find_coordinator_ids([group_id])[group_id]
-        future = self._list_offsets_send_request(group_id, coordinator, partitions)
-        self._admin._wait_for_futures([future])
-        response = future.value
-        return self._list_offsets_send_process_response(response)
-
-    def _list_offsets_send_request(
-        self, group_id: str, coordinator: int, partitions: List[TopicPartition]
-    ):
-        request = OffsetFetchRequest_v5(
-            consumer_group=group_id,
-            topics=[(p.topic, [p.partition]) for p in partitions],
-        )
-        return self._admin._send_request_to_node(coordinator, request)
-
-    def _list_offsets_send_process_response(self, response):
-        error_type = kerr.for_code(response.error_code)
-        if error_type is not kerr.NoError:
-            raise error_type("Error in list_offsets response")
-
-        offsets = {}
-        for topic, partitions in response.topics:
-            for partition, offset, leader_epoch, metadata, error_code in partitions:
-                if error_code != 0:
-                    raise Exception(f"Error code: {error_code}")
-                offsets[(topic, partition)] = OffsetAndMetadata(
-                    offset, leader_epoch, metadata
-                )
-        return offsets
-
-
-class OffsetFetchResponse_v5(Response):
-    API_KEY = 9
-    API_VERSION = 5
-    SCHEMA = types.Schema(
-        ("throttle_time_ms", types.Int32),
-        (
-            "topics",
-            types.Array(
-                ("topic", types.String("utf-8")),
-                (
-                    "partitions",
-                    types.Array(
-                        ("partition", types.Int32),
-                        ("offset", types.Int64),
-                        ("leader_epoch", types.Int32),
-                        ("metadata", types.String("utf-8")),
-                        ("error_code", types.Int16),
-                    ),
-                ),
-            ),
-        ),
-        ("error_code", types.Int16),
-    )
-
-
-class OffsetFetchRequest_v5(Request):
-    API_KEY = 9
-    API_VERSION = 5
-    RESPONSE_TYPE = OffsetFetchResponse_v5
-    SCHEMA = OffsetFetchRequest_v3.SCHEMA
 
 
 class TestConsumer:

--- a/tests/rptest/tests/list_offsets_epoch_test.py
+++ b/tests/rptest/tests/list_offsets_epoch_test.py
@@ -12,10 +12,10 @@ import tempfile
 import time
 from typing import Any
 
-import kafka.protocol.types as types
 from kafka import errors as kerr
 from kafka.admin import KafkaAdminClient
-from kafka.protocol.api import Request, Response
+from kafka.protocol.commit import OffsetFetchRequest_v5
+from kafka.protocol.list_offsets import ListOffsetsRequest_v4
 
 from ducktape.mark.resource import cluster as ducktape_cluster
 from ducktape.tests.test import Test
@@ -32,103 +32,6 @@ from rptest.services.kafka import KafkaServiceAdapter
 from rptest.services.rpk_consumer import RpkConsumer
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import wait_until_result
-
-
-# --- ListOffsets v4 (API key 2) ---
-# v4 is the first version with leader_epoch in the response.
-
-
-class ListOffsetsResponse_v4(Response):
-    API_KEY = 2
-    API_VERSION = 4
-    SCHEMA = types.Schema(
-        ("throttle_time_ms", types.Int32),
-        (
-            "topics",
-            types.Array(
-                ("topic", types.String("utf-8")),
-                (
-                    "partitions",
-                    types.Array(
-                        ("partition", types.Int32),
-                        ("error_code", types.Int16),
-                        ("timestamp", types.Int64),
-                        ("offset", types.Int64),
-                        ("leader_epoch", types.Int32),
-                    ),
-                ),
-            ),
-        ),
-    )
-
-
-class ListOffsetsRequest_v4(Request):
-    API_KEY = 2
-    API_VERSION = 4
-    RESPONSE_TYPE = ListOffsetsResponse_v4
-    SCHEMA = types.Schema(
-        ("replica_id", types.Int32),
-        ("isolation_level", types.Int8),
-        (
-            "topics",
-            types.Array(
-                ("topic", types.String("utf-8")),
-                (
-                    "partitions",
-                    types.Array(
-                        ("partition", types.Int32),
-                        ("current_leader_epoch", types.Int32),
-                        ("timestamp", types.Int64),
-                    ),
-                ),
-            ),
-        ),
-    )
-
-
-# --- OffsetFetch v5 (API key 9) ---
-# v5 is the first version with committed_leader_epoch in the response.
-
-
-class OffsetFetchResponse_v5(Response):
-    API_KEY = 9
-    API_VERSION = 5
-    SCHEMA = types.Schema(
-        ("throttle_time_ms", types.Int32),
-        (
-            "topics",
-            types.Array(
-                ("topic", types.String("utf-8")),
-                (
-                    "partitions",
-                    types.Array(
-                        ("partition", types.Int32),
-                        ("offset", types.Int64),
-                        ("leader_epoch", types.Int32),
-                        ("metadata", types.String("utf-8")),
-                        ("error_code", types.Int16),
-                    ),
-                ),
-            ),
-        ),
-        ("error_code", types.Int16),
-    )
-
-
-class OffsetFetchRequest_v5(Request):
-    API_KEY = 9
-    API_VERSION = 5
-    RESPONSE_TYPE = OffsetFetchResponse_v5
-    SCHEMA = types.Schema(
-        ("consumer_group", types.String("utf-8")),
-        (
-            "topics",
-            types.Array(
-                ("topic", types.String("utf-8")),
-                ("partitions", types.Array(types.Int32)),
-            ),
-        ),
-    )
 
 
 TOPIC_NAME = "epoch-test"

--- a/tests/rptest/tests/write_caching_fi_test.py
+++ b/tests/rptest/tests/write_caching_fi_test.py
@@ -430,6 +430,7 @@ class KafkaTestAdminClient:
         self._admin._wait_for_futures([f])
 
         response = f.value
+        assert response is not None
 
         error_type = kerr.for_code(response.error_code)
         if error_type is not kerr.NoError:

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         "ducktape@git+https://github.com/redpanda-data/ducktape.git@c5a2f1ea5023c25f79d01b6733d5119ad150f5e2",
         "prometheus-client==0.9.0",
-        "kafka-python==2.0.6",
+        "kafka-python==2.3.1",
         "crc32c==2.2",
         "confluent-kafka[avro,json,protobuf]==2.14.0",
         "types-confluent-kafka==1.4.0",

--- a/tools/consumer_offsets_recovery/main.py
+++ b/tools/consumer_offsets_recovery/main.py
@@ -48,14 +48,21 @@ def seek_to_file(path, cfg, dry_run):
             if l == "":
                 continue
 
-            topic, partition, offset = tuple([p.strip() for p in l.split(",")])
+            topic, partition, offset, leader_epoch = tuple(
+                [p.strip() for p in l.split(",")]
+            )
             logger.debug(
-                f"group: {group} partition: {topic}/{partition} offset: {offset}"
+                f"group: {group} partition: {topic}/{partition} offset: {offset} leader_epoch: {leader_epoch}"
             )
             tp = TopicPartition(topic=topic, partition=int(partition))
 
-            offsets[tp] = OffsetAndMetadata(offset=int(offset), metadata="")
+            offsets[tp] = OffsetAndMetadata(
+                offset=int(offset),
+                metadata="",
+                leader_epoch=int(leader_epoch),
+            )
     if not dry_run:
+        assert consumer is not None
         consumer.commit(offsets=offsets)
 
 
@@ -82,8 +89,8 @@ def query_offsets(offsets_path, cfg):
             f.write(f"{group_id}\n")
             for tp, md in offsets.items():
                 topic, partition = tp
-                offset, _ = md
-                f.write(f"{topic},{partition},{offset}\n")
+                offset, _, leader_epoch = md
+                f.write(f"{topic},{partition},{offset},{leader_epoch}\n")
 
 
 def recreate_topic(partitions, replication_factor, cfg):


### PR DESCRIPTION
Bumps `kafka-python` pin in `tests/setup.py` from 2.0.6 (June 2020) to 2.3.1 (April 2026).

Two follow-on cleanups remove scaffolding that existed only because of 2.0.6's gaps:

- `dt/tests/list_offsets_epoch`: kafka-python 2.3.1 ships `ListOffsetsRequest_v4` and `OffsetFetchRequest_v5` natively; swap to upstream imports.
- `dt/tests/consumer_group`: `KafkaAdminClient.list_consumer_group_offsets()` now negotiates OffsetFetch v5 internally and returns `OffsetAndMetadata` with `leader_epoch` populated, making the local `KafkaTestAdminClient` wrapper redundant.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none