### PR TITLE
config: refresh iceberg_enabled docstring

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4091,12 +4091,10 @@ configuration::configuration()
       *this,
       true,
       "iceberg_enabled",
-      "Enables the translation of topic data into Iceberg tables. Setting "
-      "iceberg_enabled to true activates the feature at the cluster level, but "
-      "each topic must also set the redpanda.iceberg.enabled topic-level "
-      "property to true to use it. If iceberg_enabled is set to false, the "
-      "feature is disabled for all topics in the cluster, overriding any "
-      "topic-level settings.",
+      "Enables Apache Iceberg integration for storing topic data in the "
+      "Iceberg open table format. Setting iceberg_enabled to true activates "
+      "the feature at the cluster level, but each topic must also configure "
+      "the redpanda.iceberg.mode topic-level property to use it.",
       meta{
         .needs_restart = needs_restart::yes,
         .visibility = visibility::user,


### PR DESCRIPTION
Updates the `iceberg_enabled` cluster property description to:

- point users at the current `redpanda.iceberg.mode` topic property
  (the previous text referenced the obsolete `redpanda.iceberg.enabled`
  boolean);
- use wording consistent with the public Iceberg topics documentation
  ("Apache Iceberg integration", "Iceberg open table format").

Docstring-only change; no behavior change.

## Backports Required

- [ ] none - not a bug fix
- [x] v26.1.x
- [x] v25.3.x

## Release Notes

* none