### PR TITLE
`ct/l1`: guard `stop_collecting_logs()` on `local_is_initialized()`

### DIFF
--- a/src/v/cloud_topics/level_one/maintenance/log_collector.cc
+++ b/src/v/cloud_topics/level_one/maintenance/log_collector.cc
@@ -52,9 +52,14 @@ ss::future<> partition_leader_log_collector::start_collecting_logs() {
 
 ss::future<> partition_leader_log_collector::stop_collecting_logs() {
     auto close_fut = _gate.close();
-    _topic_table->local().unregister_ntp_delta_notification(_ntp_notify_handle);
-    _leaders->local().unregister_leadership_change_notification(
-      _leader_notify_handle);
+    if (_topic_table->local_is_initialized()) {
+        _topic_table->local().unregister_ntp_delta_notification(
+          _ntp_notify_handle);
+    }
+    if (_leaders->local_is_initialized()) {
+        _leaders->local().unregister_leadership_change_notification(
+          _leader_notify_handle);
+    }
     co_await std::move(close_fut);
     co_return;
 }


### PR DESCRIPTION
If startup fails before `cloud_topics::app::start()` runs, the `ss::defer` guard in `application::run` unwinds and invokes `application::shutdown()`, which eventually calls `compaction_scheduler::stop()` and reaches `partition_leader_log_collector::stop_collecting_logs()`. The unconditional `_leaders->local()` and `_topic_table->local()` calls assert because the underlying sharded services were never started on this shard, which aborts the process inside the defer's destructor and prevents the `catch (...)` in `application.cc` from logging the real startup failure.

I hit this while toying with a `dev_cluster`.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none