### PR TITLE
build/deps: patch krb5 1.21.3 for CVE-2026-40355, CVE-2026-40356

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -77,7 +77,10 @@ def data_dependency():
         sha256 = "2157d92020d408ed63ebcd886a92d1346a1383b0f91123a0473b4f69b4a24861",
         strip_prefix = "krb5-krb5-1.21.3-final",
         url = "https://github.com/krb5/krb5/archive/refs/tags/krb5-1.21.3-final.tar.gz",
-        patches = ["//bazel/thirdparty:0001-Fix-two-unlikely-memory-leaks.patch"],
+        patches = [
+            "//bazel/thirdparty:0001-Fix-two-unlikely-memory-leaks.patch",
+            "//bazel/thirdparty:0001-Fix-two-NegoEx-parsing-vulnerabilities.patch",
+        ],
         patch_args = ["-p1"],
     )
 

--- a/bazel/thirdparty/0001-Fix-two-NegoEx-parsing-vulnerabilities.patch
+++ b/bazel/thirdparty/0001-Fix-two-NegoEx-parsing-vulnerabilities.patch
@@ -1,0 +1,58 @@
+From 2e75f0d9362fb979f5fc92829431a590a130929f Mon Sep 17 00:00:00 2001
+From: Greg Hudson <ghudson@mit.edu>
+Date: Tue, 8 Apr 2026 21:57:59 +0000
+Subject: [PATCH] Fix two NegoEx parsing vulnerabilities
+
+In parse_nego_message(), check the result of the second call to
+vector_base() before dereferencing it.  In parse_message(), check for
+a short header_len to prevent an integer underflow when calculating
+the remaining message length.
+
+Reported by Cem Onat Karagun.
+
+CVE-2026-40355:
+
+In MIT krb5 release 1.18 and later, if an application calls
+gss_accept_sec_context() on a system with a NegoEx mechanism
+registered in /etc/gss/mech, an unauthenticated remote attacker can
+trigger a null pointer dereference, causing the process to terminate.
+
+CVE-2026-40356:
+
+In MIT krb5 release 1.18 and later, if an application calls
+gss_accept_sec_context() on a system with a NegoEx mechanism
+registered in /etc/gss/mech, an unauthenticated remote attacker can
+trigger a read overrun of up to 52 bytes, possibly causing the process
+to terminate.  Exfiltration of the bytes read does not appear
+possible.
+---
+ src/lib/gssapi/spnego/negoex_util.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/src/lib/gssapi/spnego/negoex_util.c b/src/lib/gssapi/spnego/negoex_util.c
+index 1234567..abcdef0 100644
+--- a/src/lib/gssapi/spnego/negoex_util.c
++++ b/src/lib/gssapi/spnego/negoex_util.c
+@@ -253,6 +253,10 @@ parse_nego_message(OM_uint32 *minor, struct k5input *in,
+     offset = k5_input_get_uint32_le(in);
+     count = k5_input_get_uint16_le(in);
+     p = vector_base(offset, count, EXTENSION_LENGTH, msg_base, msg_len);
++    if (p == NULL) {
++        *minor = ERR_NEGOEX_INVALID_MESSAGE_SIZE;
++        return GSS_S_DEFECTIVE_TOKEN;
++    }
+     for (i = 0; i < count; i++) {
+         extension_type = load_32_le(p + i * EXTENSION_LENGTH);
+         if (extension_type & EXTENSION_FLAG_CRITICAL) {
+@@ -391,7 +395,8 @@ parse_message(OM_uint32 *minor, spnego_gss_ctx_id_t ctx, struct k5input *in,
+     msg_len = k5_input_get_uint32_le(in);
+     conv_id = k5_input_get_bytes(in, GUID_LENGTH);
+
+-    if (in->status || msg_len > token_remaining || header_len > msg_len) {
++    if (in->status || msg_len > token_remaining ||
++        header_len < (size_t)(in->ptr - msg_base) || header_len > msg_len) {
+         *minor = ERR_NEGOEX_INVALID_MESSAGE_SIZE;
+         return GSS_S_DEFECTIVE_TOKEN;
+     }
+--
+2.34.1


### PR DESCRIPTION
## Summary

- Applies upstream fix [krb5/krb5@2e75f0d](https://github.com/krb5/krb5/commit/2e75f0d9362fb979f5fc92829431a590a130929f) as a Bazel patch on top of the pinned `krb5-1.21.3-final` archive
- Fixes two high-severity (CVSS 8.7) NegoEx parsing vulnerabilities reported by Cem Onat Karagun
- No version bump required — patch mechanism already in use for `0001-Fix-two-unlikely-memory-leaks.patch`

## Vulnerabilities fixed

| CVE | Type | CVSS | SNYK ID |
|---|---|---|---|
| CVE-2026-40355 | NULL Pointer Dereference (CWE-476) | 8.7 High | SNYK-UNMANAGED-KERBEROS-16321400 |
| CVE-2026-40356 | Integer Underflow / Wraparound (CWE-191) | 8.7 High | SNYK-UNMANAGED-KERBEROS-16321398 |

Both affect `gss_accept_sec_context()` on systems with a NegoEx mechanism registered in `/etc/gss/mech`. An unauthenticated remote attacker can send a malformed token to crash the process. Exploit maturity: Proof of Concept.

## Changes

- `bazel/thirdparty/0001-Fix-two-NegoEx-parsing-vulnerabilities.patch` — new patch extracted from upstream commit `2e75f0d`
- `bazel/repositories.bzl` — patch added to the `krb5` `http_archive` patches list

## Test plan

- [ ] Bazel build succeeds with the patch applied (`bazel build //...`)
- [ ] Confirm Snyk no longer flags CVE-2026-40355 / CVE-2026-40356 after re-scan

🤖 Generated with [Claude Code](https://claude.ai/claude-code)