### PR TITLE
ct: Local retention for `tiered_v2` (pt3)

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -254,8 +254,30 @@ frontend::make_reader(cloud_topic_log_reader_config cfg) {
 
     const auto lro = _ctp_stm_api->get_last_reconciled_offset();
 
-    const auto level_one = lro > kafka::offset::min()
-                           && cfg.start_offset <= lro;
+    auto level_one = lro > kafka::offset::min() && cfg.start_offset <= lro;
+
+    // In tiered_cloud mode the local log may extend below LRO (its prefix
+    // truncation is held back by allowed_local_start_offset). Serve the
+    // request locally when the local log still covers the requested range.
+    //
+    // Skip this fast path for compacted topics: compaction operates on L1
+    // below LRO and rewrites values, so the local copy below LRO can be
+    // stale relative to the canonical compacted view. The reconciler also
+    // clears allowed_local_start_offset when compaction is enabled, but the
+    // read-side decision must not depend on that having happened yet.
+    //
+    // In `cloud` mode the local log is prefix-truncated up to LRO so this
+    // check is a no-op and the existing behavior is preserved.
+    if (
+      level_one && _partition->log()->config().is_tiered_cloud()
+      && !_partition->log()->config().is_remotely_compacted()) {
+        auto ot_state = _partition->get_offset_translator_state();
+        auto local_start_kafka = model::offset_cast(
+          ot_state->from_log_offset(_partition->raft_start_offset()));
+        if (cfg.start_offset >= local_start_kafka) {
+            level_one = false;
+        }
+    }
 
     vlog(
       cd_log.debug,

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -542,6 +542,15 @@ model::offset ctp_stm::prefix_truncate_target() {
             target = std::min(cap, hint_log);
         }
     }
+
+    // Space management may have published a more aggressive GC offset to
+    // free disk; honour it by raising the target (still capped so we never
+    // truncate unreconciled data or data needed by an active reader).
+    // Cloud_topics partitions are exempt from disk_log_impl's housekeeping,
+    // so this is the only place the cloud_gc value is consumed for them.
+    if (auto cloud_gc = _raft->log()->cloud_gc_offset(); cloud_gc.has_value()) {
+        target = std::min(cap, std::max(target, *cloud_gc));
+    }
     return target;
 }
 

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -161,6 +161,12 @@ ss::future<> ctp_stm::prefix_truncate_below_lro() {
               ex);
             continue;
         }
+        // We have acted on any pending cloud_gc offset; clear it so the
+        // next space-management round can publish a fresh decision (mirrors
+        // disk_log_impl::do_gc, which is bypassed for cloud_topics).
+        if (_raft->log()->cloud_gc_offset().has_value()) {
+            _raft->log()->reset_cloud_gc_offset();
+        }
         // If we successfully truncated our log, then wait a bit before
         // truncating it again so if LRO is making lots of rapid but small
         // progress we aren't snapshotting too much.

--- a/src/v/cloud_topics/level_zero/stm/tests/BUILD
+++ b/src/v/cloud_topics/level_zero/stm/tests/BUILD
@@ -55,6 +55,7 @@ redpanda_cc_gtest(
         "//src/v/model",
         "//src/v/raft/tests:raft_fixture",
         "//src/v/ssx:when_all",
+        "//src/v/storage",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
     ],

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -19,9 +19,25 @@
 #include "model/timestamp.h"
 #include "raft/tests/raft_fixture.h"
 #include "ssx/when_all.h"
+#include "storage/disk_log_impl.h"
 #include "test_utils/async.h"
 
 #include <optional>
+
+namespace storage {
+// Test-only accessor to bypass the eligibility gate in
+// disk_log_impl::set_cloud_gc_offset so cloud_topics fixtures (whose
+// ntp_config has no overrides) can drive the offset directly.
+struct disk_log_test_accessor {
+    static void
+    set_cloud_gc_offset_unchecked(disk_log_impl& l, model::offset o) {
+        l._cloud_gc_offset = o;
+    }
+    static void clear_cloud_gc_offset(disk_log_impl& l) {
+        l._cloud_gc_offset.reset();
+    }
+};
+} // namespace storage
 
 namespace ct = cloud_topics;
 using namespace std::chrono_literals;
@@ -1572,4 +1588,107 @@ TEST_F_CORO(
       leader, std::nullopt);
     ASSERT_TRUE_CORO(res.has_value());
     ASSERT_EQ_CORO(accessor.prefix_truncate_target(*stm), lrlo);
+}
+
+TEST_F_CORO(
+  ctp_stm_fixture, prefix_truncate_target_respects_cloud_gc_above_hint) {
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+    auto& leader = node(*get_leader());
+    auto stm = get_stm<0>(leader);
+    auto leader_api = api(leader);
+
+    for (int o = 0; o < 100; ++o) {
+        co_await replicate_record_batch(
+          leader, make_record_batch(ct::cluster_epoch{1}, model::offset{o}, 0));
+    }
+    co_await leader_api.advance_reconciled_offset(
+      kafka::offset{99}, model::no_timeout, as);
+
+    ct::ctp_stm_accessor accessor;
+    auto lrlo = accessor.max_removable_local_log_offset(*stm);
+
+    // Hint=20 would, on its own, hold the truncate target back to
+    // log_offset(kafka=20).
+    auto res = co_await replicate_set_allowed_local_start_offset(
+      leader, kafka::offset{20});
+    ASSERT_TRUE_CORO(res.has_value());
+    auto hint_log = leader.raft()->log()->to_log_offset(
+      kafka::offset_cast(kafka::offset{20}));
+    ASSERT_EQ_CORO(accessor.prefix_truncate_target(*stm), hint_log);
+
+    // Space management drives cloud_gc above the hint. The truncate target
+    // must rise to cloud_gc (more aggressive eviction), capped by LRLO.
+    auto cloud_gc = leader.raft()->log()->to_log_offset(
+      kafka::offset_cast(kafka::offset{60}));
+    auto* impl = dynamic_cast<storage::disk_log_impl*>(
+      leader.underlying_log().get());
+    ASSERT_NE_CORO(impl, nullptr);
+    storage::disk_log_test_accessor::set_cloud_gc_offset_unchecked(
+      *impl, cloud_gc);
+
+    ASSERT_EQ_CORO(accessor.prefix_truncate_target(*stm), cloud_gc);
+    // max_removable_local_log_offset() must still report LRLO.
+    ASSERT_EQ_CORO(accessor.max_removable_local_log_offset(*stm), lrlo);
+}
+
+TEST_F_CORO(ctp_stm_fixture, prefix_truncate_target_clamps_cloud_gc_to_lrlo) {
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+    auto& leader = node(*get_leader());
+    auto stm = get_stm<0>(leader);
+    auto leader_api = api(leader);
+
+    for (int o = 0; o < 50; ++o) {
+        co_await replicate_record_batch(
+          leader, make_record_batch(ct::cluster_epoch{1}, model::offset{o}, 0));
+    }
+    co_await leader_api.advance_reconciled_offset(
+      kafka::offset{10}, model::no_timeout, as);
+
+    ct::ctp_stm_accessor accessor;
+    auto lrlo = accessor.max_removable_local_log_offset(*stm);
+
+    // cloud_gc above LRLO — must clamp.
+    auto* impl = dynamic_cast<storage::disk_log_impl*>(
+      leader.underlying_log().get());
+    ASSERT_NE_CORO(impl, nullptr);
+    storage::disk_log_test_accessor::set_cloud_gc_offset_unchecked(
+      *impl, lrlo + model::offset{100});
+
+    ASSERT_EQ_CORO(accessor.prefix_truncate_target(*stm), lrlo);
+}
+
+TEST_F_CORO(
+  ctp_stm_fixture, prefix_truncate_target_uses_hint_when_cloud_gc_below) {
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+    auto& leader = node(*get_leader());
+    auto stm = get_stm<0>(leader);
+    auto leader_api = api(leader);
+
+    for (int o = 0; o < 100; ++o) {
+        co_await replicate_record_batch(
+          leader, make_record_batch(ct::cluster_epoch{1}, model::offset{o}, 0));
+    }
+    co_await leader_api.advance_reconciled_offset(
+      kafka::offset{99}, model::no_timeout, as);
+
+    ct::ctp_stm_accessor accessor;
+
+    auto res = co_await replicate_set_allowed_local_start_offset(
+      leader, kafka::offset{60});
+    ASSERT_TRUE_CORO(res.has_value());
+
+    auto hint_log = leader.raft()->log()->to_log_offset(
+      kafka::offset_cast(kafka::offset{60}));
+    // cloud_gc below the hint — hint wins (less aggressive truncation).
+    auto cloud_gc_below = hint_log - model::offset{20};
+    auto* impl = dynamic_cast<storage::disk_log_impl*>(
+      leader.underlying_log().get());
+    ASSERT_NE_CORO(impl, nullptr);
+    storage::disk_log_test_accessor::set_cloud_gc_offset_unchecked(
+      *impl, cloud_gc_below);
+
+    ASSERT_EQ_CORO(accessor.prefix_truncate_target(*stm), hint_log);
 }

--- a/src/v/cloud_topics/reconciler/BUILD
+++ b/src/v/cloud_topics/reconciler/BUILD
@@ -70,10 +70,13 @@ redpanda_cc_library(
         "//src/v/cloud_topics/level_zero/stm:ctp_stm",
         "//src/v/cloud_topics/level_zero/stm:ctp_stm_api",
         "//src/v/cluster:fwd",
+        "//src/v/cluster:topic_configuration",
         "//src/v/config",
         "//src/v/kafka/utils:txn_reader",
         "//src/v/metrics",
+        "//src/v/storage",
         "//src/v/utils:retry_chain_node",
+        "//src/v/utils:tristate",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -411,6 +411,22 @@ ss::future<> reconciler<Clock>::reconcile() {
               sched_it->second.last_reconciled = now;
           }
       });
+
+    // Per-tick local-retention evaluator pass: visit every attached source
+    // (not just those reconciled this round) so the time + shape-mismatch
+    // triggers fire even for idle / caught-up partitions. Bytes trigger has
+    // already been incremented in build_object().
+    chunked_vector<ss::shared_ptr<source>> due_for_eval;
+    for (auto& [_, src] : _sources) {
+        if (local_retention_eval_due(src)) {
+            due_for_eval.push_back(src);
+        }
+    }
+    static constexpr size_t max_concurrent_evals = 32;
+    co_await ss::max_concurrent_for_each(
+      due_for_eval, max_concurrent_evals, [this](ss::shared_ptr<source> src) {
+          return evaluate_local_retention_hint(std::move(src));
+      });
 }
 
 template<class Clock>
@@ -722,8 +738,15 @@ reconciler<Clock>::build_object(
         ctx.size_budget = current_size >= max_size ? 0
                                                    : max_size - current_size;
         auto start_offset = kafka::next_offset(src->last_reconciled_offset());
+        auto size_before = current_size;
         auto read_result = co_await add_source_to_object(
           ctx, src, start_offset);
+        // Approximate bytes contributed by this source to the in-progress
+        // object — used to drive the local-retention bytes trigger.
+        auto size_after = ctx.builder->file_size();
+        if (size_after > size_before) {
+            src->add_local_retention_bytes(size_after - size_before);
+        }
 
         if (!read_result.has_value()) {
             // Log an error, we don't want a single stuck partition to
@@ -991,6 +1014,36 @@ reconciler<Clock>::commit_objects(
             return std::unexpected(std::move(err));
         })
       .value_or(std::expected<void, reconcile_error>{});
+}
+
+template<class Clock>
+bool reconciler<Clock>::local_retention_eval_due(
+  const ss::shared_ptr<source>& src) const {
+    static const cluster::topic_properties empty_props;
+    const auto* props = &empty_props;
+    std::optional<cluster::topic_configuration> topic_cfg;
+    if (_metadata_cache != nullptr) {
+        topic_cfg = _metadata_cache->get_topic_cfg(
+          model::topic_namespace_view{src->ntp()});
+        if (!topic_cfg.has_value()) {
+            return false;
+        }
+        props = &topic_cfg->properties;
+    }
+    if (!src->is_local_retention_shape_in_sync(*props)) {
+        // Shape mismatch (including "never published"): force evaluation.
+        return true;
+    }
+    auto last = src->local_retention_last_eval_time();
+    if (!last.has_value()) {
+        return true;
+    }
+    if ((ss::lowres_clock::now() - *last) >= std::chrono::seconds(60)) {
+        return true;
+    }
+    auto seg_bytes = src->local_retention_segment_size_bytes(
+      props->segment_size);
+    return src->local_retention_bytes_since_eval() >= seg_bytes;
 }
 
 template<class Clock>

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -993,6 +993,55 @@ reconciler<Clock>::commit_objects(
       .value_or(std::expected<void, reconcile_error>{});
 }
 
+template<class Clock>
+ss::future<>
+reconciler<Clock>::evaluate_local_retention_hint(ss::shared_ptr<source> src) {
+    static const cluster::topic_properties empty_props;
+    const auto* props = &empty_props;
+    std::optional<cluster::topic_configuration> topic_cfg;
+    if (_metadata_cache != nullptr) {
+        topic_cfg = _metadata_cache->get_topic_cfg(
+          model::topic_namespace_view{src->ntp()});
+        if (!topic_cfg.has_value()) {
+            src->set_local_retention_last_eval_time(ss::lowres_clock::now());
+            src->reset_local_retention_eval_counter();
+            co_return;
+        }
+        props = &topic_cfg->properties;
+    }
+    auto target_opt = co_await src->compute_local_retention_target(*props);
+    if (!target_opt.has_value()) {
+        // Not eligible to evaluate the hint (e.g., not leader, no config).
+        // Still update the eval state so the time-trigger backoff applies
+        // and we don't re-check this source on every reconcile tick.
+        src->set_local_retention_last_eval_time(ss::lowres_clock::now());
+        src->reset_local_retention_eval_counter();
+        co_return;
+    }
+    auto target = target_opt.value();
+
+    auto last_pub = src->local_retention_last_published();
+    if (last_pub.has_value() && *last_pub == target) {
+        // Idempotent: no change needed.
+        src->set_local_retention_last_eval_time(ss::lowres_clock::now());
+        src->reset_local_retention_eval_counter();
+        co_return;
+    }
+
+    auto res = co_await src->publish_local_retention_target(target, _as);
+    if (!res.has_value()) {
+        vlog(
+          lg.warn,
+          "{}: failed to publish allowed_local_start_offset: {}",
+          src->ntp(),
+          res.error());
+        co_return;
+    }
+    src->set_local_retention_last_published(target);
+    src->set_local_retention_last_eval_time(ss::lowres_clock::now());
+    src->reset_local_retention_eval_counter();
+}
+
 // Explicit template instantiations.
 template class reconciler<ss::lowres_clock>;
 template class reconciler<ss::manual_clock>;

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -124,6 +124,14 @@ public:
      */
     ss::future<> reconcile();
 
+    /*
+     * Evaluate the local-retention hint for one source, publishing the
+     * resulting `allowed_local_start_offset` value via ctp_stm if it
+     * differs from the last published value. Idempotent when the value
+     * is unchanged.
+     */
+    ss::future<> evaluate_local_retention_hint(ss::shared_ptr<source>);
+
 private:
     // NB: Partition attachment is the only part using ntps instead of
     //     topic id partitions.

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -124,6 +124,16 @@ public:
      */
     ss::future<> reconcile();
 
+    /// Returns true if evaluate_local_retention_hint should run now for src.
+    ///
+    /// Triggers (any of):
+    ///   * config-shape mismatch (cached published value disagrees with what
+    ///     storage.mode + cleanup.policy + local-retention limits would imply),
+    ///   * never evaluated before,
+    ///   * 60s elapsed since last evaluation,
+    ///   * `local_retention_bytes_since_eval()` >= the effective segment size.
+    bool local_retention_eval_due(const ss::shared_ptr<source>& src) const;
+
     /*
      * Evaluate the local-retention hint for one source, publishing the
      * resulting `allowed_local_start_offset` value via ctp_stm if it

--- a/src/v/cloud_topics/reconciler/reconciliation_source.cc
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.cc
@@ -38,6 +38,30 @@ namespace cloud_topics::reconciler {
 
 namespace {
 
+// True when the topic config implies the reconciler should publish a
+// non-null allowed_local_start_offset (i.e. tiered_cloud mode with a
+// non-compact cleanup policy and an engaged local retention limit).
+// Used by both compute_local_retention_target and
+// is_local_retention_shape_in_sync to avoid duplicating the predicate.
+bool tiered_cloud_with_local_limit(const cluster::topic_properties& props) {
+    const auto mode = props.storage_mode;
+    if (mode != model::redpanda_storage_mode::tiered_cloud) {
+        return false;
+    }
+    const bool compact
+      = props.cleanup_policy_bitflags.has_value()
+        && ((*props.cleanup_policy_bitflags & model::cleanup_policy_bitflags::compaction) == model::cleanup_policy_bitflags::compaction);
+    if (compact) {
+        return false;
+    }
+    const bool has_local_limit
+      = (!props.retention_local_target_bytes.is_disabled()
+         && props.retention_local_target_bytes.has_optional_value())
+        || (!props.retention_local_target_ms.is_disabled()
+            && props.retention_local_target_ms.has_optional_value());
+    return has_local_limit;
+}
+
 class aborted_transaction_tracker_impl
   : public kafka::aborted_transaction_tracker {
 public:
@@ -259,6 +283,27 @@ public:
             target = std::min(kafka_off, lro);
         }
         co_return target;
+    }
+
+    bool is_local_retention_shape_in_sync(
+      const cluster::topic_properties& props) const override {
+        if (!_partition || !_partition->is_leader()) {
+            return true;
+        }
+        auto cached = local_retention_last_published();
+        if (!cached.has_value()) {
+            return false;
+        }
+        if (tiered_cloud_with_local_limit(props)) {
+            return cached->has_value();
+        }
+        return !cached->has_value();
+    }
+
+    size_t local_retention_segment_size_bytes(
+      std::optional<size_t> topic_override) const override {
+        return topic_override.value_or(
+          config::shard_local_cfg().log_segment_size());
     }
 
     ss::future<std::expected<void, errc>> publish_local_retention_target(

--- a/src/v/cloud_topics/reconciler/reconciliation_source.cc
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.cc
@@ -16,15 +16,23 @@
 #include "cloud_topics/level_zero/stm/ctp_stm_api.h"
 #include "cloud_topics/log_reader_config.h"
 #include "cloud_topics/logger.h"
+#include "cluster/metadata_cache.h"
 #include "cluster/partition.h"
+#include "cluster/topic_properties.h"
 #include "config/configuration.h"
 #include "kafka/utils/txn_reader.h"
 #include "model/fundamental.h"
+#include "model/namespace.h"
 #include "model/record_batch_reader.h"
 #include "model/timeout_clock.h"
+#include "storage/log.h"
+#include "storage/types.h"
 
+#include <chrono>
 #include <expected>
 #include <utility>
+
+using namespace std::chrono_literals;
 
 namespace cloud_topics::reconciler {
 
@@ -160,6 +168,118 @@ public:
         co_return model::make_readahead_record_batch_reader(
           model::make_record_batch_reader<kafka::read_committed_reader>(
             std::move(tracker), std::move(reader.reader)));
+    }
+
+    ss::future<std::optional<std::optional<kafka::offset>>>
+    compute_local_retention_target(
+      const cluster::topic_properties& props) override {
+        if (!_partition || !_partition->is_leader()) {
+            co_return std::nullopt;
+        }
+        const auto mode = props.storage_mode;
+        const bool compact
+          = props.cleanup_policy_bitflags.has_value()
+            && ((*props.cleanup_policy_bitflags & model::cleanup_policy_bitflags::compaction) == model::cleanup_policy_bitflags::compaction);
+
+        if (mode != model::redpanda_storage_mode::tiered_cloud || compact) {
+            co_return std::optional<kafka::offset>(std::nullopt);
+        }
+
+        auto log = _partition->log();
+        if (!log) {
+            co_return std::nullopt;
+        }
+
+        // Mirror disk_log_impl::apply_overrides(default_cfg). Build the
+        // effective retention cfg the way tiered storage would for this
+        // partition.
+        auto max_bytes = config::shard_local_cfg().retention_bytes();
+        auto default_ret_ms = config::shard_local_cfg().log_retention_ms();
+        auto upper_ts = default_ret_ms.has_value()
+                          ? model::to_timestamp(
+                              model::timestamp_clock::now() - *default_ret_ms)
+                          : model::timestamp::min();
+
+        if (props.retention_bytes.is_disabled()) {
+            max_bytes = std::nullopt;
+        } else if (props.retention_bytes.has_optional_value()) {
+            max_bytes = props.retention_bytes.value();
+        }
+        if (props.retention_duration.is_disabled()) {
+            upper_ts = model::timestamp::min();
+        } else if (props.retention_duration.has_optional_value()) {
+            upper_ts = model::to_timestamp(
+              model::timestamp_clock::now() - props.retention_duration.value());
+        }
+
+        const bool strict_local
+          = config::shard_local_cfg().retention_local_strict()
+            && config::shard_local_cfg().retention_local_strict_override();
+        if (strict_local) {
+            auto local_bytes_tri = props.retention_local_target_bytes;
+            auto local_ms_tri = props.retention_local_target_ms;
+            if (
+              !local_bytes_tri.is_disabled()
+              && !local_bytes_tri.has_optional_value()) {
+                local_bytes_tri = tristate<size_t>(
+                  config::shard_local_cfg()
+                    .retention_local_target_bytes_default());
+            }
+            if (!local_ms_tri.is_engaged()) {
+                local_ms_tri = tristate<std::chrono::milliseconds>(
+                  config::shard_local_cfg()
+                    .retention_local_target_ms_default());
+            }
+            if (local_bytes_tri.has_optional_value()) {
+                if (max_bytes.has_value()) {
+                    max_bytes = std::min(
+                      local_bytes_tri.value(), max_bytes.value());
+                } else {
+                    max_bytes = local_bytes_tri.value();
+                }
+            }
+            if (local_ms_tri.has_optional_value()) {
+                upper_ts = std::max(
+                  model::to_timestamp(
+                    model::timestamp_clock::now() - local_ms_tri.value()),
+                  upper_ts);
+            }
+        }
+
+        storage::gc_config cfg(upper_ts, max_bytes);
+
+        ctp_stm_api api(_partition->raft()->stm_manager()->get<ctp_stm>());
+        auto lro = api.get_last_reconciled_offset();
+        auto retention_log_offset = log->retention_offset(cfg);
+
+        std::optional<kafka::offset> target;
+        if (retention_log_offset.has_value()) {
+            auto kafka_off = model::offset_cast(
+              log->from_log_offset(*retention_log_offset));
+            target = std::min(kafka_off, lro);
+        }
+        co_return target;
+    }
+
+    ss::future<std::expected<void, errc>> publish_local_retention_target(
+      std::optional<kafka::offset> value, ss::abort_source& as) override {
+        ctp_stm_api api(_partition->raft()->stm_manager()->get<ctp_stm>());
+        auto deadline = model::timeout_clock::now() + 5s;
+        auto res = co_await api.set_allowed_local_start_offset(
+          value, deadline, as);
+        if (!res.has_value()) {
+            switch (res.error()) {
+            case ctp_stm_api_errc::timeout:
+                co_return std::unexpected(errc::timeout);
+            case ctp_stm_api_errc::not_leader:
+                co_return std::unexpected(errc::not_leader);
+            case ctp_stm_api_errc::shutdown:
+                co_return std::unexpected(errc::shutdown);
+            case ctp_stm_api_errc::failure:
+                co_return std::unexpected(errc::failure);
+            }
+        }
+        co_return std::expected<void, errc>();
     }
 
 private:

--- a/src/v/cloud_topics/reconciler/reconciliation_source.h
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.h
@@ -15,9 +15,11 @@
 #include "model/fundamental.h"
 #include "model/record_batch_reader.h"
 
+#include <seastar/core/lowres_clock.hh>
 #include <seastar/core/shared_ptr.hh>
 
 #include <expected>
+#include <optional>
 
 namespace cluster {
 class partition;
@@ -94,10 +96,43 @@ public:
     virtual ss::future<model::record_batch_reader>
       make_reader(reader_config) = 0;
 
+    // Per-partition bookkeeping for the local-retention evaluator.
+    size_t local_retention_bytes_since_eval() const noexcept {
+        return _local_retention_bytes_since_eval;
+    }
+    void add_local_retention_bytes(size_t n) noexcept {
+        _local_retention_bytes_since_eval += n;
+    }
+    void reset_local_retention_eval_counter() noexcept {
+        _local_retention_bytes_since_eval = 0;
+    }
+
+    std::optional<ss::lowres_clock::time_point>
+    local_retention_last_eval_time() const noexcept {
+        return _local_retention_last_eval_time;
+    }
+    void set_local_retention_last_eval_time(
+      ss::lowres_clock::time_point t) noexcept {
+        _local_retention_last_eval_time = t;
+    }
+
+    std::optional<std::optional<kafka::offset>>
+    local_retention_last_published() const noexcept {
+        return _local_retention_last_published;
+    }
+    void set_local_retention_last_published(
+      std::optional<kafka::offset> o) noexcept {
+        _local_retention_last_published = o;
+    }
+
 private:
     model::ntp _ntp;
     model::topic_id_partition _tidp;
     source_probe _probe;
+
+    size_t _local_retention_bytes_since_eval{0};
+    std::optional<ss::lowres_clock::time_point> _local_retention_last_eval_time;
+    std::optional<std::optional<kafka::offset>> _local_retention_last_published;
 };
 
 // Make a reconciliation source from L0 components (data plane) and the cluster

--- a/src/v/cloud_topics/reconciler/reconciliation_source.h
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.h
@@ -22,7 +22,6 @@
 #include <optional>
 
 namespace cluster {
-class metadata_cache;
 class partition;
 struct topic_properties;
 } // namespace cluster
@@ -117,6 +116,28 @@ public:
     virtual ss::future<std::expected<void, errc>>
     publish_local_retention_target(
       std::optional<kafka::offset>, ss::abort_source&) = 0;
+
+    // Returns true if the cached `local_retention_last_published()` value
+    // matches the shape that the current topic configuration would imply.
+    //
+    // Concretely:
+    //  - For tiered_cloud + !compact topics with at least one local-retention
+    //    limit engaged, the expected shape is Some(Some(_)).
+    //  - For all other cases (cloud mode, compacted, or no local-retention
+    //    limits), the expected shape is Some(nullopt).
+    //
+    // If the cached value is missing (never published) or does not match the
+    // expected shape, returns false, which forces re-evaluation of the hint.
+    // If the source is not eligible for evaluation at all (e.g., not leader,
+    // missing topic config), returns true to avoid spurious wake-ups.
+    virtual bool is_local_retention_shape_in_sync(
+      const cluster::topic_properties&) const = 0;
+
+    // Effective segment size in bytes for the bytes-trigger threshold:
+    // topic-level `segment_size` if set, otherwise the cluster default
+    // `log_segment_size`.
+    virtual size_t local_retention_segment_size_bytes(
+      std::optional<size_t> topic_override) const = 0;
 
     // Per-partition bookkeeping for the local-retention evaluator.
     size_t local_retention_bytes_since_eval() const noexcept {

--- a/src/v/cloud_topics/reconciler/reconciliation_source.h
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.h
@@ -22,8 +22,10 @@
 #include <optional>
 
 namespace cluster {
+class metadata_cache;
 class partition;
-}
+struct topic_properties;
+} // namespace cluster
 
 namespace cloud_topics::reconciler {
 
@@ -95,6 +97,26 @@ public:
     // It *is* valid for this reader to outlive `source`.
     virtual ss::future<model::record_batch_reader>
       make_reader(reader_config) = 0;
+
+    // Compute the target value for the allowed_local_start_offset hint.
+    //
+    // Returns:
+    // - std::nullopt outer: the hint should not be evaluated/published (e.g.,
+    //   not leader, topic config missing, or this isn't a tiered_cloud topic).
+    // - std::optional<kafka::offset> inner: when present, the target value of
+    //   the hint that should be published via ctp_stm:
+    //     * Some(offset): clamp local log to this kafka offset.
+    //     * nullopt: clear the hint (no local-retention behavior).
+    //
+    // The outer optional disambiguates "do not touch the hint at all" from
+    // "publish a value (possibly nullopt)".
+    virtual ss::future<std::optional<std::optional<kafka::offset>>>
+    compute_local_retention_target(const cluster::topic_properties&) = 0;
+
+    // Replicate the allowed_local_start_offset hint value via ctp_stm.
+    virtual ss::future<std::expected<void, errc>>
+    publish_local_retention_target(
+      std::optional<kafka::offset>, ss::abort_source&) = 0;
 
     // Per-partition bookkeeping for the local-retention evaluator.
     size_t local_retention_bytes_since_eval() const noexcept {

--- a/src/v/cloud_topics/reconciler/tests/BUILD
+++ b/src/v/cloud_topics/reconciler/tests/BUILD
@@ -78,6 +78,22 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "reconciliation_source_test",
+    timeout = "short",
+    srcs = [
+        "reconciliation_source_test.cc",
+    ],
+    deps = [
+        ":test_utils",
+        "//src/v/cloud_topics/reconciler",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "reconciler_metrics_test",
     timeout = "short",
     srcs = [

--- a/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
@@ -713,6 +713,88 @@ TEST_F(ReconcilerTest, OnlyDueTopicIsReconciled) {
     EXPECT_EQ(src1->last_reconciled_offset(), kafka::offset{19});
 }
 
+// --- evaluate_local_retention_hint tests ---
+
+TEST_F(ReconcilerTest, EvaluatorModeCloudClearsHint) {
+    // Source where compute_target returns Some(nullopt) (e.g. mode==cloud).
+    auto src = add_source();
+    src->set_compute_target(std::optional<kafka::offset>(std::nullopt));
+
+    // Initially no published value: should publish nullopt once.
+    _reconciler.evaluate_local_retention_hint(src).get();
+
+    ASSERT_EQ(src->published_values().size(), 1u);
+    EXPECT_EQ(src->published_values().back(), std::nullopt);
+    ASSERT_TRUE(src->local_retention_last_published().has_value());
+    EXPECT_EQ(*src->local_retention_last_published(), std::nullopt);
+
+    // Second call: idempotent, no new publish.
+    _reconciler.evaluate_local_retention_hint(src).get();
+    EXPECT_EQ(src->published_values().size(), 1u);
+}
+
+TEST_F(ReconcilerTest, EvaluatorModeTieredCloudCompactClearsHint) {
+    // Compaction enabled => target nullopt.
+    auto src = add_source();
+    // First publish an offset to simulate prior tiered_cloud delete state.
+    src->set_compute_target(kafka::offset{100});
+    _reconciler.evaluate_local_retention_hint(src).get();
+    ASSERT_EQ(src->published_values().size(), 1u);
+    EXPECT_EQ(src->published_values().back(), kafka::offset{100});
+
+    // Now switch to compaction (target -> nullopt) and expect a clearing
+    // publish.
+    src->set_compute_target(std::optional<kafka::offset>(std::nullopt));
+    _reconciler.evaluate_local_retention_hint(src).get();
+    ASSERT_EQ(src->published_values().size(), 2u);
+    EXPECT_EQ(src->published_values().back(), std::nullopt);
+}
+
+TEST_F(ReconcilerTest, EvaluatorModeTieredCloudDeletePublishesOffset) {
+    auto src = add_source();
+    src->set_compute_target(kafka::offset{42});
+
+    _reconciler.evaluate_local_retention_hint(src).get();
+
+    ASSERT_EQ(src->published_values().size(), 1u);
+    EXPECT_EQ(src->published_values().back(), kafka::offset{42});
+    ASSERT_TRUE(src->local_retention_last_published().has_value());
+    EXPECT_EQ(*src->local_retention_last_published(), kafka::offset{42});
+
+    // Recompute the same value: idempotent.
+    _reconciler.evaluate_local_retention_hint(src).get();
+    EXPECT_EQ(src->published_values().size(), 1u);
+
+    // Recompute a different value: publish again.
+    src->set_compute_target(kafka::offset{99});
+    _reconciler.evaluate_local_retention_hint(src).get();
+    ASSERT_EQ(src->published_values().size(), 2u);
+    EXPECT_EQ(src->published_values().back(), kafka::offset{99});
+}
+
+TEST_F(ReconcilerTest, EvaluatorSkipsWhenNotEligible) {
+    // compute returns outer-nullopt (e.g. not leader): no publish.
+    auto src = add_source();
+    src->set_compute_target(std::nullopt);
+    _reconciler.evaluate_local_retention_hint(src).get();
+    EXPECT_TRUE(src->published_values().empty());
+    EXPECT_FALSE(src->local_retention_last_published().has_value());
+}
+
+TEST_F(ReconcilerTest, EvaluatorPublishFailureDoesNotUpdateBookkeeping) {
+    auto src = add_source();
+    src->set_compute_target(kafka::offset{10});
+    src->fail_publish(true);
+    _reconciler.evaluate_local_retention_hint(src).get();
+    EXPECT_TRUE(src->published_values().empty());
+    EXPECT_FALSE(src->local_retention_last_published().has_value());
+
+    src->fail_publish(false);
+    _reconciler.evaluate_local_retention_hint(src).get();
+    ASSERT_EQ(src->published_values().size(), 1u);
+    EXPECT_EQ(src->published_values().back(), kafka::offset{10});
+}
+
 // Regression test: detaching a source during reconciliation (e.g. due to a
 // leadership change) must not leave an orphaned topic scheduler. Before the
 // fix, get_or_create_topic_scheduler in the post-reconciliation path would

--- a/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
@@ -795,6 +795,73 @@ TEST_F(ReconcilerTest, EvaluatorPublishFailureDoesNotUpdateBookkeeping) {
     EXPECT_EQ(src->published_values().back(), kafka::offset{10});
 }
 
+// --- local_retention_eval_due trigger predicate tests ---
+
+TEST_F(ReconcilerTest, EvalDueNeverEvaluatedFires) {
+    auto src = add_source();
+    // Default: shape-in-sync=true, no prior eval. Predicate must still fire
+    // because the eval has never happened.
+    EXPECT_TRUE(_reconciler.local_retention_eval_due(src));
+}
+
+TEST_F(ReconcilerTest, EvalDueBytesThresholdFires) {
+    auto src = add_source();
+    src->set_segment_size_bytes(1024);
+    // Seed last_eval_time so the time/never-evaluated triggers don't fire.
+    src->set_local_retention_last_eval_time(ss::lowres_clock::now());
+
+    EXPECT_FALSE(_reconciler.local_retention_eval_due(src));
+
+    src->add_local_retention_bytes(512);
+    EXPECT_FALSE(_reconciler.local_retention_eval_due(src));
+
+    src->add_local_retention_bytes(512);
+    EXPECT_TRUE(_reconciler.local_retention_eval_due(src));
+}
+
+TEST_F(ReconcilerTest, EvalDueTimeThresholdFires) {
+    auto src = add_source();
+    src->set_segment_size_bytes(1ULL << 40); // out of reach
+    // Seed last_eval_time = 90s ago.
+    src->set_local_retention_last_eval_time(
+      ss::lowres_clock::now() - std::chrono::seconds(90));
+    EXPECT_TRUE(_reconciler.local_retention_eval_due(src));
+
+    // Recent eval shouldn't fire.
+    src->set_local_retention_last_eval_time(ss::lowres_clock::now());
+    EXPECT_FALSE(_reconciler.local_retention_eval_due(src));
+}
+
+TEST_F(ReconcilerTest, EvalDueConfigMismatchForcesEval) {
+    auto src = add_source();
+    src->set_segment_size_bytes(1ULL << 40);
+    src->set_local_retention_last_eval_time(ss::lowres_clock::now());
+    src->set_shape_in_sync(false);
+    // Shape mismatch overrides time + bytes.
+    EXPECT_TRUE(_reconciler.local_retention_eval_due(src));
+
+    src->set_shape_in_sync(true);
+    EXPECT_FALSE(_reconciler.local_retention_eval_due(src));
+}
+
+TEST_F(ReconcilerTest, EvalDueNoSignalDoesNotFire) {
+    auto src = add_source();
+    src->set_segment_size_bytes(1ULL << 40);
+    src->set_local_retention_last_eval_time(ss::lowres_clock::now());
+    src->set_shape_in_sync(true);
+    EXPECT_FALSE(_reconciler.local_retention_eval_due(src));
+}
+
+TEST_F(ReconcilerTest, ReconcileWiresLocalRetentionEvaluator) {
+    // A source eligible to publish (Some(nullopt)) should have the evaluator
+    // invoked during reconcile() because it has never been evaluated.
+    auto src = add_source();
+    src->set_compute_target(std::optional<kafka::offset>(std::nullopt));
+    reconcile();
+    ASSERT_EQ(src->published_values().size(), 1u);
+    EXPECT_EQ(src->published_values().back(), std::nullopt);
+}
+
 // Regression test: detaching a source during reconciliation (e.g. due to a
 // leadership change) must not leave an orphaned topic scheduler. Before the
 // fix, get_or_create_topic_scheduler in the post-reconciliation path would

--- a/src/v/cloud_topics/reconciler/tests/reconciliation_source_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciliation_source_test.cc
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "cloud_topics/reconciler/tests/test_utils.h"
+#include "model/fundamental.h"
+
+#include <seastar/core/lowres_clock.hh>
+
+#include <gtest/gtest.h>
+
+#include <optional>
+
+using cloud_topics::reconciler::test::fake_source;
+
+namespace {
+
+ss::shared_ptr<fake_source> make_test_source() {
+    auto ntp = model::ntp(
+      model::ns("test"), model::topic("t"), model::partition_id(0));
+    auto tidp = model::topic_id_partition(
+      model::topic_id::create(), model::partition_id(0));
+    return ss::make_shared<fake_source>(std::move(ntp), tidp);
+}
+
+} // namespace
+
+TEST(reconciliation_source, local_retention_state_defaults) {
+    auto src = make_test_source();
+    EXPECT_EQ(src->local_retention_bytes_since_eval(), 0u);
+    EXPECT_FALSE(src->local_retention_last_eval_time().has_value());
+    EXPECT_FALSE(src->local_retention_last_published().has_value());
+}
+
+TEST(reconciliation_source, local_retention_bytes_mutators) {
+    auto src = make_test_source();
+    src->add_local_retention_bytes(100);
+    src->add_local_retention_bytes(50);
+    EXPECT_EQ(src->local_retention_bytes_since_eval(), 150u);
+    src->reset_local_retention_eval_counter();
+    EXPECT_EQ(src->local_retention_bytes_since_eval(), 0u);
+}
+
+TEST(reconciliation_source, local_retention_last_eval_time_mutator) {
+    auto src = make_test_source();
+    auto now = ss::lowres_clock::now();
+    src->set_local_retention_last_eval_time(now);
+    ASSERT_TRUE(src->local_retention_last_eval_time().has_value());
+    EXPECT_EQ(*src->local_retention_last_eval_time(), now);
+}
+
+TEST(reconciliation_source, local_retention_last_published_mutator) {
+    auto src = make_test_source();
+    src->set_local_retention_last_published(kafka::offset{42});
+    ASSERT_TRUE(src->local_retention_last_published().has_value());
+    EXPECT_TRUE(src->local_retention_last_published()->has_value());
+    EXPECT_EQ(**src->local_retention_last_published(), kafka::offset{42});
+
+    src->set_local_retention_last_published(std::nullopt);
+    ASSERT_TRUE(src->local_retention_last_published().has_value());
+    EXPECT_FALSE(src->local_retention_last_published()->has_value());
+}

--- a/src/v/cloud_topics/reconciler/tests/test_utils.h
+++ b/src/v/cloud_topics/reconciler/tests/test_utils.h
@@ -107,12 +107,42 @@ public:
         _on_make_reader = std::move(cb);
     }
 
+    // Local-retention evaluator hooks for tests.
+    void
+    set_compute_target(std::optional<std::optional<kafka::offset>> target) {
+        _compute_target = target;
+    }
+
+    void fail_publish(bool fail) { _fail_publish = fail; }
+
+    const std::vector<std::optional<kafka::offset>>& published_values() const {
+        return _published_values;
+    }
+
+    ss::future<std::optional<std::optional<kafka::offset>>>
+    compute_local_retention_target(const cluster::topic_properties&) override {
+        co_return _compute_target;
+    }
+
+    ss::future<std::expected<void, errc>> publish_local_retention_target(
+      std::optional<kafka::offset> value, ss::abort_source&) override {
+        if (_fail_publish) {
+            co_return std::unexpected(errc::failure);
+        }
+        _published_values.push_back(value);
+        co_return std::expected<void, errc>{};
+    }
+
 private:
     kafka::offset _lro;
     chunked_vector<model::record_batch> _source_log;
     bool _fail_set_lro = false;
     bool _fail_make_reader = false;
     std::function<void()> _on_make_reader;
+
+    std::optional<std::optional<kafka::offset>> _compute_target;
+    bool _fail_publish = false;
+    std::vector<std::optional<kafka::offset>> _published_values;
 };
 
 class unreliable_metastore : public l1::simple_metastore {

--- a/src/v/cloud_topics/reconciler/tests/test_utils.h
+++ b/src/v/cloud_topics/reconciler/tests/test_utils.h
@@ -133,6 +133,19 @@ public:
         co_return std::expected<void, errc>{};
     }
 
+    void set_shape_in_sync(bool v) { _shape_in_sync = v; }
+    void set_segment_size_bytes(size_t v) { _segment_size_bytes = v; }
+
+    bool is_local_retention_shape_in_sync(
+      const cluster::topic_properties&) const override {
+        return _shape_in_sync;
+    }
+
+    size_t
+    local_retention_segment_size_bytes(std::optional<size_t>) const override {
+        return _segment_size_bytes;
+    }
+
 private:
     kafka::offset _lro;
     chunked_vector<model::record_batch> _source_log;
@@ -143,6 +156,10 @@ private:
     std::optional<std::optional<kafka::offset>> _compute_target;
     bool _fail_publish = false;
     std::vector<std::optional<kafka::offset>> _published_values;
+    // Default: shape "in sync" so existing tests that don't care don't trigger
+    // forced evaluation.
+    bool _shape_in_sync = true;
+    size_t _segment_size_bytes = 128_MiB;
 };
 
 class unreliable_metastore : public l1::simple_metastore {

--- a/src/v/raft/tests/failure_injectable_log.cc
+++ b/src/v/raft/tests/failure_injectable_log.cc
@@ -236,6 +236,10 @@ std::optional<model::offset> failure_injectable_log::cloud_gc_offset() const {
     return _underlying_log->cloud_gc_offset();
 }
 
+void failure_injectable_log::reset_cloud_gc_offset() {
+    _underlying_log->reset_cloud_gc_offset();
+}
+
 const storage::segment_set& failure_injectable_log::segments() const {
     return _underlying_log->segments();
 }

--- a/src/v/raft/tests/failure_injectable_log.cc
+++ b/src/v/raft/tests/failure_injectable_log.cc
@@ -232,6 +232,10 @@ void failure_injectable_log::set_cloud_gc_offset(model::offset o) {
     return _underlying_log->set_cloud_gc_offset(o);
 }
 
+std::optional<model::offset> failure_injectable_log::cloud_gc_offset() const {
+    return _underlying_log->cloud_gc_offset();
+}
+
 const storage::segment_set& failure_injectable_log::segments() const {
     return _underlying_log->segments();
 }

--- a/src/v/raft/tests/failure_injectable_log.h
+++ b/src/v/raft/tests/failure_injectable_log.h
@@ -126,6 +126,7 @@ public:
     get_reclaimable_offsets(storage::gc_config cfg) final;
 
     void set_cloud_gc_offset(model::offset) final;
+    std::optional<model::offset> cloud_gc_offset() const final;
 
     const storage::segment_set& segments() const final;
     storage::segment_set& segments() final;

--- a/src/v/raft/tests/failure_injectable_log.h
+++ b/src/v/raft/tests/failure_injectable_log.h
@@ -127,6 +127,7 @@ public:
 
     void set_cloud_gc_offset(model::offset) final;
     std::optional<model::offset> cloud_gc_offset() const final;
+    void reset_cloud_gc_offset() final;
 
     const storage::segment_set& segments() const final;
     storage::segment_set& segments() final;

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -289,7 +289,11 @@ eviction_policy::collect_reclaimable_offsets() {
      */
     chunked_vector<ss::lw_shared_ptr<cluster::partition>> partitions;
     for (const auto& p : _pm->local().partitions()) {
-        if (!p.second->remote_partition()) {
+        // Include partitions whose data is mirrored to cloud storage —
+        // either classic tiered storage or a cloud_topics partition. Both
+        // keep data locally that the space manager may need to evict.
+        const auto& cfg = p.second->get_ntp_config();
+        if (!cfg.is_tiered_storage() && !cfg.cloud_topic_enabled()) {
             continue;
         }
         partitions.push_back(p.second);

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1312,6 +1312,10 @@ bool disk_log_impl::is_cloud_retention_active() const {
            && (config().is_archival_enabled());
 }
 
+bool disk_log_impl::is_cloud_backed() const {
+    return is_cloud_retention_active() || config().cloud_topic_enabled();
+}
+
 /*
  * applies overrides for non-cloud storage settings
  */
@@ -3901,7 +3905,7 @@ disk_log_impl::disk_usage_and_reclaimable_space(gc_config input_cfg) {
           && seg->offsets().get_dirty_offset() <= retention_offset.value()) {
             retention_segments.push_back(seg);
         } else if (
-          is_cloud_retention_active()
+          is_cloud_backed()
           && seg->offsets().get_dirty_offset() <= max_removable) {
             available_segments.push_back(seg);
         } else {
@@ -3917,8 +3921,8 @@ disk_log_impl::disk_usage_and_reclaimable_space(gc_config input_cfg) {
          * get_reclaimable_offsets is going to be merged together.
          */
         if (
-          !config().is_read_replica_mode_enabled()
-          && is_cloud_retention_active() && seg != _segs.back()
+          !config().is_read_replica_mode_enabled() && is_cloud_backed()
+          && seg != _segs.back()
           && seg->offsets().get_dirty_offset() <= max_removable
           && local_retention_offset.has_value()
           && seg->offsets().get_dirty_offset()
@@ -4293,7 +4297,7 @@ disk_log_impl::cloud_gc_eligible_segments() {
 }
 
 void disk_log_impl::set_cloud_gc_offset(model::offset offset) {
-    if (!is_cloud_retention_active()) {
+    if (!is_cloud_backed()) {
         vlog(
           stlog.debug,
           "Ignoring request to set GC offset on non-cloud enabled partition "
@@ -4318,7 +4322,7 @@ disk_log_impl::get_reclaimable_offsets(gc_config cfg) {
 
     reclaimable_offsets res;
 
-    if (!is_cloud_retention_active()) {
+    if (!is_cloud_backed()) {
         vlog(
           stlog.debug,
           "Reporting no reclaimable offsets for non-cloud partition {}",
@@ -4520,7 +4524,7 @@ size_t disk_log_impl::reclaimable_size_bytes() const {
      * local retention size may change. catch these before reporting potentially
      * stale information.
      */
-    if (!is_cloud_retention_active()) {
+    if (!is_cloud_backed()) {
         return 0;
     }
     if (config().is_read_replica_mode_enabled()) {

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -191,6 +191,9 @@ public:
     auto& gate() { return _compaction_housekeeping_gate; }
     chunked_vector<ss::lw_shared_ptr<segment>> cloud_gc_eligible_segments();
     void set_cloud_gc_offset(model::offset) override;
+    std::optional<model::offset> cloud_gc_offset() const override {
+        return _cloud_gc_offset;
+    }
 
     ss::future<reclaimable_offsets>
     get_reclaimable_offsets(gc_config cfg) override;
@@ -333,7 +336,8 @@ private:
     friend class disk_log_appender; // for multi-term appends
     friend class disk_log_builder;  // for tests
     friend ::storage_e2e_fixture;
-    friend ::reupload_fixture; // for tests
+    friend ::reupload_fixture;             // for tests
+    friend struct disk_log_test_accessor; // for tests
 
     ss::future<model::record_batch_reader>
       make_unchecked_reader(local_log_reader_config);

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -194,6 +194,7 @@ public:
     std::optional<model::offset> cloud_gc_offset() const override {
         return _cloud_gc_offset;
     }
+    void reset_cloud_gc_offset() override { _cloud_gc_offset.reset(); }
 
     ss::future<reclaimable_offsets>
     get_reclaimable_offsets(gc_config cfg) override;
@@ -336,7 +337,7 @@ private:
     friend class disk_log_appender; // for multi-term appends
     friend class disk_log_builder;  // for tests
     friend ::storage_e2e_fixture;
-    friend ::reupload_fixture;             // for tests
+    friend ::reupload_fixture;            // for tests
     friend struct disk_log_test_accessor; // for tests
 
     ss::future<model::record_batch_reader>
@@ -417,6 +418,12 @@ private:
     gc_config apply_local_storage_overrides(gc_config) const;
 
     bool is_cloud_retention_active() const;
+    // True for partitions whose data is durably mirrored in cloud storage —
+    // either classic tiered storage or a cloud_topics partition. Used to gate
+    // surfaces that the space manager needs to drive on either kind of
+    // partition (set_cloud_gc_offset, get_reclaimable_offsets, available
+    // reclaim accounting).
+    bool is_cloud_backed() const;
 
     // returns retention_offset(cfg) but may also first apply adjustments to
     // future timestamps if this option is turned on in configuration.

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -241,11 +241,15 @@ public:
     /// retention boundary. Consumed by the regular do_gc housekeeping path
     /// in disk_log_impl. cloud_topics partitions are exempt from that
     /// housekeeping and must read this value through their own truncation
-    /// loop.
+    /// loop, then clear it via reset_cloud_gc_offset.
     virtual std::optional<model::offset> cloud_gc_offset() const {
         return std::nullopt;
     }
 
+    /// Clear a previously-set cloud_gc offset. Used by consumers (ctp_stm,
+    /// disk_log_impl::do_gc) after they have acted on the value so the next
+    /// space-management round can publish a fresh decision.
+    virtual void reset_cloud_gc_offset() {}
 
     virtual const segment_set& segments() const = 0;
     virtual segment_set& segments() = 0;

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -234,6 +234,19 @@ public:
     get_reclaimable_offsets(gc_config cfg) = 0;
     virtual void set_cloud_gc_offset(model::offset) = 0;
 
+    /// Pending cloud-driven GC offset, if any.
+    ///
+    /// Set by space management via set_cloud_gc_offset to communicate disk
+    /// pressure that should drive eviction beyond the partition's normal
+    /// retention boundary. Consumed by the regular do_gc housekeeping path
+    /// in disk_log_impl. cloud_topics partitions are exempt from that
+    /// housekeeping and must read this value through their own truncation
+    /// loop.
+    virtual std::optional<model::offset> cloud_gc_offset() const {
+        return std::nullopt;
+    }
+
+
     virtual const segment_set& segments() const = 0;
     virtual segment_set& segments() = 0;
 

--- a/tests/rptest/tests/tiered_cloud_local_retention_test.py
+++ b/tests/rptest/tests/tiered_cloud_local_retention_test.py
@@ -285,6 +285,52 @@ class TieredCloudLocalRetentionTest(EndToEndCloudTopicsBase):
         )
 
     @cluster(num_nodes=4)
+    def test_space_manager_reclaim_under_pressure(self):
+        """
+        Even though the reconciler hint asks tiered_cloud partitions to keep
+        retention.local.target.bytes locally, the space manager must still be
+        able to reclaim from those partitions when the cluster-wide local
+        target capacity is tight. This relies on
+        ctp_stm::max_removable_local_log_offset() not being gated by the hint,
+        so resource_mgmt/storage.cc can drive prefix-truncation past the
+        cached hint without waiting for a new reconciliation pass.
+        """
+        self._create_topic(storage_mode=TopicSpec.STORAGE_MODE_TIERED_CLOUD)
+        self._wait_for_partition_info()
+
+        self._produce(self.bytes_to_produce)
+        self.wait_until_reconciled(topic=self.topic_name, partition=0)
+
+        # First, confirm the hint took effect and we are holding meaningful
+        # local data above one segment.
+        replication = 3
+        self._wait_local_at_least(
+            floor_bytes=replication * self.local_target_bytes // 2,
+            timeout_sec=120,
+        )
+
+        # Now apply tight cluster-wide disk pressure. retention_local_strict
+        # makes the space manager treat retention_local_target_capacity_bytes
+        # as a hard ceiling and reclaim aggressively from any partition,
+        # regardless of per-topic retention.local.target.bytes or the
+        # reconciler-published hint.
+        tight_capacity = 2 * self.segment_size
+        assert self.redpanda is not None
+        self.redpanda.set_cluster_config(
+            {
+                "retention_local_strict": True,
+                "retention_local_target_capacity_bytes": tight_capacity,
+            }
+        )
+
+        # Local footprint should shrink well below the per-topic local target,
+        # proving the space manager reclaimed past the reconciler's hint.
+        self._wait_local_below(
+            ceiling_bytes=replication * 3 * self.segment_size,
+            timeout_sec=180,
+        )
+
+    @cluster(num_nodes=4)
     def test_compact_topic_clears_hint(self):
         """
         Enabling compaction on a tiered_cloud topic should make the reconciler

--- a/tests/rptest/tests/tiered_cloud_local_retention_test.py
+++ b/tests/rptest/tests/tiered_cloud_local_retention_test.py
@@ -1,0 +1,323 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+"""
+End-to-end coverage for the tiered_cloud local-retention hint produced by the
+reconciler (see docs/superpowers/specs/2026-05-15-tiered-cloud-local-retention-design.md).
+
+When a partition is in storage.mode=tiered_cloud with cleanup.policy=delete, the
+reconciler should publish an allowed_local_start_offset hint that lets local data
+stay around up to retention.local.target.bytes, even when retention.bytes is much
+larger than the local target. Flipping back to storage.mode=cloud, or enabling
+compaction, should clear the hint and cause local data to collapse to LRO again.
+"""
+
+from ducktape.tests.test import TestContext
+from ducktape.utils.util import wait_until
+
+from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
+from rptest.tests.cloud_topics.e2e_test import EndToEndCloudTopicsBase
+
+
+class TieredCloudLocalRetentionTest(EndToEndCloudTopicsBase):
+    """
+    Verify that tiered_cloud partitions honor retention.local.target.bytes
+    (via the reconciler hint), and that flipping back to cloud mode or
+    enabling compaction restores the original LRO-collapsing behavior.
+    """
+
+    topic_name = "tc_local_retention"
+
+    # Override base class topics - we create them per test with custom configs.
+    topics = ()
+
+    # Sizes are deliberately small so the test runs quickly. The local
+    # target is a few segments; retention.bytes is large enough that
+    # regular size-based retention does not trigger.
+    segment_size = 1 * 1024 * 1024  # 1 MiB
+    local_target_bytes = 4 * segment_size  # 4 MiB
+    retention_bytes = 1024 * 1024 * 1024  # 1 GiB - effectively unlimited
+    bytes_to_produce = 32 * segment_size  # 32 MiB - well above local target
+    msg_size = 16 * 1024  # 16 KiB
+
+    def __init__(self, test_context: TestContext):
+        extra_rp_conf = {
+            # Fast reconciliation so the hint is published quickly.
+            "cloud_topics_reconciliation_min_interval": 1000,  # 1s
+            "cloud_topics_reconciliation_max_interval": 2000,  # 2s
+            # Fast housekeeping/GC so prefix-truncate and local eviction
+            # happen on test timescales.
+            "cloud_storage_housekeeping_interval_ms": 2000,  # 2s
+            "log_compaction_interval_ms": 2000,  # 2s
+            # Use the configured segment size for all topics.
+            "log_segment_size": self.segment_size,
+            "log_segment_size_min": self.segment_size,
+            # Short trim interval so the space manager's control loop
+            # fires within the lifetime of fast tests.
+            "retention_local_trim_interval": 2000,  # 2s
+            # The reconciler only publishes an allowed_local_start_offset
+            # hint when local retention is treated as a hard cap (mirrors
+            # disk_log_impl::maybe_apply_local_storage_overrides). Tests
+            # in this file rely on the hint to keep local data around.
+            "retention_local_strict": True,
+            "retention_local_strict_override": True,
+        }
+
+        super().__init__(
+            test_context=test_context,
+            extra_rp_conf=extra_rp_conf,
+        )
+
+    def setUp(self):
+        # Start the cluster with cloud topics enabled. We will create our
+        # own topics inside each test so we can pick storage_mode and
+        # cleanup.policy explicitly.
+        assert self.redpanda
+        self.redpanda.start()
+        self.redpanda.set_feature_active("tiered_cloud_topics", True, timeout_sec=30)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _create_topic(
+        self,
+        storage_mode: str,
+        cleanup_policy: str = TopicSpec.CLEANUP_DELETE,
+        partitions: int = 1,
+    ):
+        rpk = RpkTool(self.redpanda)
+        config = {
+            TopicSpec.PROPERTY_STORAGE_MODE: storage_mode,
+            "cleanup.policy": cleanup_policy,
+            "retention.bytes": str(self.retention_bytes),
+            "retention.local.target.bytes": str(self.local_target_bytes),
+            "segment.bytes": str(self.segment_size),
+        }
+        rpk.create_topic(
+            topic=self.topic_name,
+            partitions=partitions,
+            replicas=3,
+            config=config,
+        )
+
+    def _produce(self, bytes_to_produce: int):
+        msg_count = bytes_to_produce // self.msg_size
+        KgoVerifierProducer.oneshot(
+            self.test_context,
+            self.redpanda,
+            self.topic_name,
+            msg_size=self.msg_size,
+            msg_count=msg_count,
+            timeout_sec=180,
+        )
+
+    def _local_partition_bytes(self, topic: str | None = None) -> int:
+        """
+        Sum the on-disk footprint of all replicas of the topic across all
+        nodes, using the partition_size Prometheus metric exposed by each
+        broker. This is what the space manager / local-retention path is
+        actually shrinking.
+        """
+        if topic is None:
+            topic = self.topic_name
+        total = 0
+        assert self.redpanda is not None
+        samples = self.redpanda.metrics_sample("partition_size")
+        if samples is None:
+            return 0
+        for s in samples.samples:
+            if s.labels.get("topic") == topic:
+                total += int(s.value)
+        return total
+
+    def _wait_local_below(self, ceiling_bytes: int, timeout_sec: int = 120):
+        last = [-1]
+
+        def cond() -> bool:
+            size = self._local_partition_bytes()
+            last[0] = size
+            self.logger.info(
+                f"local partition_size sum = {size}, ceiling = {ceiling_bytes}"
+            )
+            return size <= ceiling_bytes
+
+        wait_until(
+            cond,
+            timeout_sec=timeout_sec,
+            backoff_sec=3,
+            err_msg=lambda: (
+                f"local footprint did not drop below {ceiling_bytes} "
+                f"(last observed: {last[0]})"
+            ),
+        )
+
+    def _wait_local_at_least(self, floor_bytes: int, timeout_sec: int = 60):
+        last = [-1]
+
+        def cond() -> bool:
+            size = self._local_partition_bytes()
+            last[0] = size
+            self.logger.info(
+                f"local partition_size sum = {size}, floor = {floor_bytes}"
+            )
+            return size >= floor_bytes
+
+        wait_until(
+            cond,
+            timeout_sec=timeout_sec,
+            backoff_sec=3,
+            err_msg=lambda: (
+                f"local footprint did not reach {floor_bytes} "
+                f"(last observed: {last[0]})"
+            ),
+        )
+
+    def _wait_for_partition_info(self, timeout_sec: int = 60):
+        """Wait until rpk can describe the partition (i.e. it is replicated)."""
+        rpk = RpkTool(self.redpanda)
+
+        def has_partition() -> bool:
+            try:
+                parts = list(rpk.describe_topic(self.topic_name))
+                return len(parts) > 0
+            except Exception:
+                return False
+
+        wait_until(
+            has_partition,
+            timeout_sec=timeout_sec,
+            backoff_sec=2,
+            err_msg=f"topic {self.topic_name} did not become describable",
+        )
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+
+    @cluster(num_nodes=4)
+    def test_local_data_grows_in_tiered_cloud(self):
+        """
+        In tiered_cloud mode with retention.bytes >> retention.local.target.bytes,
+        the local footprint should converge near retention.local.target.bytes,
+        not collapse to LRO (segment_size or smaller).
+
+        Replication factor is 3, so the cluster-wide sum of partition_size is
+        roughly 3 * per-replica retention.
+        """
+        self._create_topic(storage_mode=TopicSpec.STORAGE_MODE_TIERED_CLOUD)
+        self._wait_for_partition_info()
+
+        self._produce(self.bytes_to_produce)
+        self.wait_until_reconciled(topic=self.topic_name, partition=0)
+
+        # We expect each replica to hold somewhere between roughly the local
+        # target and a few segments above it (segment boundaries + pacing).
+        # With 3 replicas, the cluster sum should land in [3*target, 9*target]
+        # ish. Use generous bounds: at least target (proves we are not
+        # collapsing to LRO), at most 12*target (proves retention.bytes is
+        # not the effective limit).
+        replication = 3
+        per_replica_floor = self.local_target_bytes
+        per_replica_ceiling = 6 * self.local_target_bytes
+
+        self._wait_local_at_least(
+            floor_bytes=replication * per_replica_floor // 2,
+            timeout_sec=120,
+        )
+        self._wait_local_below(
+            ceiling_bytes=replication * per_replica_ceiling,
+            timeout_sec=180,
+        )
+
+        final = self._local_partition_bytes()
+        self.logger.info(f"final local footprint: {final}")
+        # And critically: it must not have collapsed to ~segment_size, which
+        # would mean LRO-only retention.
+        assert final > replication * self.segment_size, (
+            f"local footprint collapsed to LRO-only ({final} bytes); "
+            f"expected near {replication * self.local_target_bytes} bytes"
+        )
+
+    @cluster(num_nodes=4)
+    def test_flip_back_to_cloud_evicts_aggressively(self):
+        """
+        Starting in tiered_cloud with a healthy local footprint, flipping the
+        topic's storage.mode back to cloud should clear the hint, so prefix
+        truncation targets LRO again and the local footprint shrinks to
+        roughly one segment.
+        """
+        self._create_topic(storage_mode=TopicSpec.STORAGE_MODE_TIERED_CLOUD)
+        self._wait_for_partition_info()
+
+        self._produce(self.bytes_to_produce)
+        self.wait_until_reconciled(topic=self.topic_name, partition=0)
+
+        # Confirm we accumulated meaningful local data (not just LRO).
+        replication = 3
+        self._wait_local_at_least(
+            floor_bytes=replication * self.local_target_bytes // 2,
+            timeout_sec=120,
+        )
+
+        # Flip back to cloud.
+        rpk = RpkTool(self.redpanda)
+        rpk.alter_topic_config(
+            self.topic_name,
+            TopicSpec.PROPERTY_STORAGE_MODE,
+            TopicSpec.STORAGE_MODE_CLOUD,
+        )
+
+        # Local should collapse to roughly one segment per replica (LRO-only).
+        # Use a generous ceiling of 3 segments per replica to absorb pacing.
+        self._wait_local_below(
+            ceiling_bytes=replication * 3 * self.segment_size,
+            timeout_sec=180,
+        )
+
+    @cluster(num_nodes=4)
+    def test_compact_topic_clears_hint(self):
+        """
+        Enabling compaction on a tiered_cloud topic should make the reconciler
+        stop publishing the local-retention hint (the trigger predicate only
+        fires for cleanup.policy=delete). Existing hints should be cleared,
+        and local data should evict aggressively again.
+        """
+        self._create_topic(
+            storage_mode=TopicSpec.STORAGE_MODE_TIERED_CLOUD,
+            cleanup_policy=TopicSpec.CLEANUP_DELETE,
+        )
+        self._wait_for_partition_info()
+
+        self._produce(self.bytes_to_produce)
+        self.wait_until_reconciled(topic=self.topic_name, partition=0)
+
+        replication = 3
+        self._wait_local_at_least(
+            floor_bytes=replication * self.local_target_bytes // 2,
+            timeout_sec=120,
+        )
+
+        # Switch the topic to compacted. The reconciler should drop the
+        # allowed_local_start_offset hint, returning prefix truncation to
+        # the LRO target.
+        rpk = RpkTool(self.redpanda)
+        rpk.alter_topic_config(
+            self.topic_name,
+            "cleanup.policy",
+            TopicSpec.CLEANUP_COMPACT,
+        )
+
+        self._wait_local_below(
+            ceiling_bytes=replication * 3 * self.segment_size,
+            timeout_sec=180,
+        )


### PR DESCRIPTION
This is a last PR of the series.

More tests and integration with the space management.

The first PR: https://github.com/redpanda-data/redpanda/pull/30543
The previous PR: https://github.com/redpanda-data/redpanda/pull/30544

## Summary

Add a single optional hint, `allowed_local_start_offset`, replicated into
`ctp_stm` state. The **reconciler** is the sole writer of the hint. On each
tick it inspects the partition's topic config and the data it has reconciled,
computes a retention offset from `retention.local.target.{ms,bytes}` exactly
like `disk_log_impl::housekeeping` would, and publishes it (it takes into account
topic config, cluster level config, and retention_local_strict).

`ctp_stm`'s truncate loop then uses
`prefix_truncate_target = min(LRLO, log_offset(hint))` instead of just LRLO.
That is the only consumer of the hint.

For `cloud` mode (or compacted topics), the reconciler publishes `nullopt` and
behaviour is unchanged — aggressive eviction up to LRO.

The housekeeping in `the ctp_stm` is already tracking active L0 readers so the
races with the local eviction are not possible.

## Local retention rules

| `storage.mode` | compaction | cached value | Action |
|---|---|---|---|
| `tiered_cloud` | off | `nullopt` | re-evaluate → publish `Some(offset)` |
| `tiered_cloud` | off | `Some(_)` | re-evaluate at normal cadence |
| `tiered_cloud` | on | `Some(_)` | publish `nullopt` |
| `cloud` | any | `Some(_)` | publish `nullopt` |
| `cloud` | any | `nullopt` | no-op |

## Space manager: no changes needed

The space manager already publishes a `cloud_gc` offset on the log when disk
pressure rises. In classic tiered, `disk_log_impl::housekeeping` reads and
clears it. For cloud topics:

- `ctp_stm::prefix_truncate_below_lro` already consults `cloud_gc` when
  computing its truncation target, so the space manager can push the local
  footprint *below* the reconciler's hint under pressure.
- `cloud_gc` is cleared by `ctp_stm` (since `disk_log_impl::housekeeping`
  doesn't run).
- The only space-manager change is allowing it to *run* against cloud topic
  partitions; the GC mechanism is identical to tiered.
- `max_removable_local_log_offset()` is intentionally **unchanged** (returns
  LRLO), so the reclaim path is not gated by the reconciler's hint.

Net result: the reconciler steers the steady-state local footprint, and the
space manager retains the ability to reclaim further on demand. The retention
*logic* (how much to keep) is the same as in classic tiered storage; only the
*executor* differs.

## Component interactions

```
                  topic config                disk pressure
                       │                            │
                       ▼                            ▼
              ┌─────────────────┐         ┌────────────────────┐
              │   reconciler    │         │   space_manager    │
              │ (evaluates per  │         │ (resource_mgmt/    │
              │  source / tick) │         │   storage.cc)      │
              └────────┬────────┘         └─────────┬──────────┘
                       │                            │
   set_allowed_local_  │                            │ set cloud_gc offset
   start_offset_cmd    │                            │ (on the log object)
                       ▼                            ▼
              ┌─────────────────┐         ┌────────────────────┐
              │     ctp_stm     │◄────────│  log (cloud_gc)    │
              │  (hint cached   │         └────────────────────┘
              │   in state)     │
              └────────┬────────┘
                       │ truncate target =
                       │   min(LRLO,
                       │       log_offset(hint),
                       │       cloud_gc)
                       ▼
            prefix_truncate_below_lro
                       │
                       ▼
              ┌─────────────────┐
              │ local segments  │
              │   on disk       │
              └─────────────────┘

  Contrast — classic tiered storage:

           space_manager ──cloud_gc──► disk_log_impl::housekeeping ──► evict
                                       (also evaluates retention.local.target.*
                                        and clears cloud_gc after GC)
```

## Summary

|                              | Classic tiered          | `tiered_cloud`                           |
|------------------------------|-------------------------|------------------------------------------|
| Retention executor           | `disk_log_impl::housekeeping` | `ctp_stm::prefix_truncate_below_lro` |
| Who computes retention?      | `housekeeping` itself   | `reconciler` (publishes hint via STM cmd) |
| Space-manager mechanism      | `cloud_gc` on log       | `cloud_gc` on log (same)                 |
| Who clears `cloud_gc`?       | `housekeeping`          | `ctp_stm`                                |
| Retention *logic*            | `retention.local.target.{ms,bytes}` → offset | identical             |




<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Features

* Local storage retention in `tiered_cloud` storage mode matches tiered-storage