### PR TITLE
ct: Serialize writes in db_s3_imposter handler

### DIFF
--- a/src/v/cloud_io/tests/BUILD
+++ b/src/v/cloud_io/tests/BUILD
@@ -55,6 +55,7 @@ redpanda_test_cc_library(
     implementation_deps = [
         "//src/v/http:utils",
         "//src/v/lsm/io:disk_persistence",
+        "//src/v/ssx:mutex",
         "//src/v/utils:unresolved_address",
         "@abseil-cpp//absl/container:btree",
     ],

--- a/src/v/cloud_io/tests/db_s3_imposter_fixture.cc
+++ b/src/v/cloud_io/tests/db_s3_imposter_fixture.cc
@@ -18,6 +18,7 @@
 #include "http/utils.h"
 #include "lsm/io/disk_persistence.h"
 #include "lsm/lsm.h"
+#include "ssx/mutex.h"
 #include "utils/unresolved_address.h"
 
 #include <seastar/net/socket_defs.hh>
@@ -71,6 +72,10 @@ struct db_s3_imposter_fixture::handler : ss::httpd::handler_base {
     lsm::database& db;
     lsm::sequence_number& seqno;
     const cloud_storage_clients::bucket_name& bucket;
+    // Serializes the seqno-bump-then-apply critical section so that
+    // concurrent requests cannot interleave across a suspension in
+    // db.apply() and reach memtable::merge() out of seqno order.
+    ssx::mutex write_mu{"db_s3_imposter::handler::write_mu"};
 
     handler(
       lsm::database& db,
@@ -172,6 +177,7 @@ struct db_s3_imposter_fixture::handler : ss::httpd::handler_base {
     ss::future<>
     handle_put(const ss::http::request& req, ss::http::reply& repl) {
         vlog(dbfixt_log.trace, "PUT {}", req._url);
+        auto units = co_await write_mu.get_units();
         auto batch = db.create_write_batch();
 
         auto upload_id = req.get_query_param("uploadId");
@@ -194,6 +200,7 @@ struct db_s3_imposter_fixture::handler : ss::httpd::handler_base {
     ss::future<>
     handle_delete(const ss::http::request& req, ss::http::reply& repl) {
         vlog(dbfixt_log.trace, "DELETE {}", req._url);
+        auto units = co_await write_mu.get_units();
         auto batch = db.create_write_batch();
 
         // S3 AbortMultipartUpload: DELETE with ?uploadId removes
@@ -235,6 +242,7 @@ struct db_s3_imposter_fixture::handler : ss::httpd::handler_base {
 
     ss::future<>
     handle_post(const ss::http::request& req, ss::http::reply& repl) {
+        auto units = co_await write_mu.get_units();
         // S3 DeleteObjects: POST /<bucket>/?delete with XML body
         // listing <Key> elements to remove.
         if (req.has_query_param("delete")) {


### PR DESCRIPTION
The S3 imposter assigned sequence numbers via a shared counter and then called db.apply() without holding any lock. db.apply() suspends inside make_room_for_write(), so two concurrent HTTP requests could interleave like this:

```
  A: ++seqno  -> N
  A: co_await db.apply()           // suspends in make_room_for_write
  B: ++seqno  -> N+1
  B: co_await db.apply()           // races through, reaches merge first
  B: _mem->merge(batch_N+1)         // _last_seqno = N+1
  A: resumes, _mem->merge(batch_N)  // FAILS: _last_seqno(N+1) < N
```

memtable::merge asserts that the incoming batch's last_seqno is strictly greater than the memtable's _last_seqno. The assertion fired on release-arm64 in CI (build 84717) where the tighter timing made the race likely; debug builds happened to not suspend in make_room_for_write under the same workload and so masked the bug.

Add an ssx::mutex to the handler and acquire it at the entry of every write path (handle_put, handle_delete, handle_post) so the seqno-bump-then-apply pair is atomic per shard. Read paths (handle_get, handle_head, handle_list) are unaffected.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none