### PR TITLE
config: allow sts with iceberg aws_sigv4

### DIFF
--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -325,10 +325,12 @@ validate_iceberg_rest_catalog_auth_mode(const config::configuration& config) {
               ? config.iceberg_rest_catalog_aws_credentials_source().value()
               : config.cloud_storage_credentials_source();
 
-        // When using aws_instance_metadata, AWS credentials are not required
+        // When using aws_instance_metadata or sts, AWS credentials are not
+        // required
         if (
           effective_creds_source
-          == model::cloud_credentials_source::aws_instance_metadata) {
+            == model::cloud_credentials_source::aws_instance_metadata
+          || effective_creds_source == model::cloud_credentials_source::sts) {
             // We still require the region of the Glue endpoint.
             auto effective_region
               = config.iceberg_rest_catalog_aws_region().has_value()
@@ -337,7 +339,7 @@ validate_iceberg_rest_catalog_auth_mode(const config::configuration& config) {
             if (!effective_region.has_value()) {
                 return fmt::format(
                   "Must set AWS region when using SigV4 authentication with "
-                  "aws_instance_metadata credentials source.");
+                  "aws_instance_metadata or sts credentials source.");
             }
         } else {
             auto effective_access_key


### PR DESCRIPTION
The validator for `iceberg_rest_catalog_authentication_mode=aws_sigv4` required either `aws_instance_metadata` or explicit access/secret keys, which excluded combining `aws_sigv4` with the `sts` credentials source.

Treat `sts` the same as `aws_instance_metadata` for the purposes of this check: credentials are obtained externally, only the AWS region needs to be configured.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [ ] v25.2.x

## Release Notes

### Bug Fixes

* Allow combining `aws_sigv4` Iceberg REST catalog authentication with the `sts` cloud credentials source.