### PR TITLE
[v26.1.x] raft: reset heartbeats_failed on force-reconnect

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -3945,6 +3945,14 @@ void consensus::update_heartbeat_status(vnode id, bool success) {
     }
 }
 
+void consensus::reset_heartbeat_failures(model::node_id node) {
+    for (auto& [vn, fstate] : _fstates) {
+        if (vn.id() == node) {
+            fstate.heartbeats_failed = 0;
+        }
+    }
+}
+
 bool consensus::should_reconnect_follower(
   const follower_index_metadata& f_meta) {
     if (_heartbeat_disconnect_failures == 0) {

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -487,6 +487,10 @@ public:
 
     void update_heartbeat_status(vnode, bool);
 
+    /// Zero `heartbeats_failed` for followers matching `node_id`. Called
+    /// after `ensure_disconnect` replaces the cached transport.
+    void reset_heartbeat_failures(model::node_id);
+
     bool should_reconnect_follower(const follower_index_metadata&);
 
     std::vector<follower_metrics> get_follower_metrics() const;

--- a/src/v/raft/follower_states.h
+++ b/src/v/raft/follower_states.h
@@ -59,6 +59,8 @@ struct follower_index_metadata {
     // timestamp of last append_entries_rpc call
     clock_type::time_point last_sent_append_entries_req_timestamp;
     clock_type::time_point last_received_reply_timestamp;
+    /// Heartbeat failures observed on the current cached transport.
+    /// Reset on a successful reply or when we force a reconnect.
     uint32_t heartbeats_failed{0};
     // The pair of sequences used to track append entries requests sent and
     // received by the follower. Every time append entries request is created

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -280,6 +280,12 @@ ss::future<> heartbeat_manager::do_dispatch_heartbeats() {
         if (co_await _client_protocol.ensure_disconnect(node_id)) {
             vlog(
               hbeatlog.info, "Closed unresponsive connection to {}", node_id);
+            // Clear failures attributed to the replaced transport.
+            co_await ssx::async_for_each<loop_traits>(
+              _consensus_groups,
+              [node_id](ss::lw_shared_ptr<consensus>& raft_group) {
+                  raft_group->reset_heartbeat_failures(node_id);
+              });
         };
     }
 

--- a/src/v/raft/tests/basic_raft_fixture_test.cc
+++ b/src/v/raft/tests/basic_raft_fixture_test.cc
@@ -109,6 +109,52 @@ TEST_F_CORO(raft_fixture, test_stuck_append_entries) {
     ASSERT_EQ_CORO(term_before, raft->term());
 }
 
+// After ensure_disconnect replaces the cached transport for a peer,
+// reset_heartbeat_failures must zero heartbeats_failed for every follower of
+// this group whose node_id matches; failure history on the prior transport
+// must not carry over to the fresh one. See should_reconnect_follower.
+TEST_F_CORO(raft_fixture, test_reset_heartbeat_failures) {
+    co_await create_simple_group(3);
+    auto leader_id = co_await wait_for_leader(10s);
+    auto leader = node(leader_id).raft();
+
+    auto& fstates = leader->get_follower_states();
+    ASSERT_GE_CORO(fstates.size(), 2u);
+    auto it = fstates.begin();
+    auto follower_a = it->first;
+    ++it;
+    auto follower_b = it->first;
+
+    constexpr size_t kFailuresA = 5;
+    constexpr size_t kFailuresB = 3;
+    for (size_t i = 0; i < kFailuresA; ++i) {
+        leader->update_heartbeat_status(follower_a, false);
+    }
+    for (size_t i = 0; i < kFailuresB; ++i) {
+        leader->update_heartbeat_status(follower_b, false);
+    }
+    ASSERT_EQ_CORO(
+      leader->get_follower_states().get(follower_a).heartbeats_failed,
+      kFailuresA);
+    ASSERT_EQ_CORO(
+      leader->get_follower_states().get(follower_b).heartbeats_failed,
+      kFailuresB);
+
+    // Reset only follower_a's node. follower_b must be untouched.
+    leader->reset_heartbeat_failures(follower_a.id());
+    ASSERT_EQ_CORO(
+      leader->get_follower_states().get(follower_a).heartbeats_failed, 0u);
+    ASSERT_EQ_CORO(
+      leader->get_follower_states().get(follower_b).heartbeats_failed,
+      kFailuresB);
+
+    // Reset_heartbeat_failures on an unknown node_id is a no-op.
+    leader->reset_heartbeat_failures(model::node_id{999});
+    ASSERT_EQ_CORO(
+      leader->get_follower_states().get(follower_b).heartbeats_failed,
+      kFailuresB);
+}
+
 struct test_parameters {
     consistency_level c_lvl;
     bool write_caching;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30486
