### PR TITLE
[CORE-15483] `config`: remove `legacy_default` on `log_compaction_tx_batch_removal_enabled`

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1138,8 +1138,7 @@ configuration::configuration()
       "allows compaction.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       true,
-      property<bool>::noop_validator,
-      legacy_default<bool>(false, legacy_version{17}))
+      property<bool>::noop_validator)
   , retention_bytes(
       *this,
       "retention_bytes",


### PR DESCRIPTION
Enable this by default for all clusters, new and old.

This feature was always intended for a more public release once it spent some time marinating in new clusters and in CI in `v25.3.1` and `v26.1`, but we now want it on by default for all users new and old moving forward.

It is worth mentioning that this also property won't have an observable effect until a user properly configures `delete.retention.ms` on their local, `compact`-enabled topic.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
