### PR TITLE
[CORE-16286] [CORE-15930] [CORE-14631] [CORE-14630] [CORE-13673] [CORE-14807] [CORE-13712] [CORE-13347] `cluster`: remove `shard` aggregation for `leader_id` and `under_replicated_replicas`

### DIFF
--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -82,9 +82,7 @@ void replicated_partition_probe::setup_internal_metrics(const model::ntp& ntp) {
              return _partition.raft()->get_under_replicated().value_or(0);
          },
          sm::description("Number of under replicated replicas"),
-         labels)},
-      {},
-      {sm::shard_label});
+         labels)});
 
     _metrics.add_group(
       cluster_metrics_name,


### PR DESCRIPTION
Aggregating these across shards doesn't reduce the number of metric series, but it does cause an oversized allocation in the `metric_aggregate_by_labels` object, since an `std::unordered_map` is used there to aggregate.

Remove the `shard` label to prevent this oversized allocation.

Fixes: https://redpandadata.atlassian.net/browse/CORE-16286, https://redpandadata.atlassian.net/browse/CORE-15930, https://redpandadata.atlassian.net/browse/CORE-14631, https://redpandadata.atlassian.net/browse/CORE-14630, https://redpandadata.atlassian.net/browse/CORE-13673, https://redpandadata.atlassian.net/browse/CORE-14807, https://redpandadata.atlassian.net/browse/CORE-13712, https://redpandadata.atlassian.net/browse/CORE-13347

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
