### PR TITLE
[v25.2.x] ci: upgrade actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -27,7 +27,7 @@ jobs:
       target_milestone: ${{ steps.get_backport_type.outputs.target_milestone }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
@@ -68,7 +68,7 @@ jobs:
     env:
       BACKPORT_BRANCH: ${{ needs.backport-type.outputs.backport_branch }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
@@ -119,7 +119,7 @@ jobs:
         run: |
           backport_commits=$(gh api "repos/$TARGET_FULL_REPO/pulls/$BACKPORT_PR_NUMBER/commits" --paginate --jq '[.[].sha[0:10]]|join(" ")')
           echo "backport_commits=$backport_commits" >> $GITHUB_OUTPUT
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: needs.backport-type.outputs.commented_on == 'pr'
         with:
           repository: ${{ steps.user.outputs.username }}/${{ steps.user.outputs.repo }}

--- a/.github/workflows/backport-on-merge.yml
+++ b/.github/workflows/backport-on-merge.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # Find the PR associated with this push, if there is one.
       - uses: jwalton/gh-find-current-pr@v1
         id: findPr

--- a/.github/workflows/buildkite-slash-commands.yml
+++ b/.github/workflows/buildkite-slash-commands.yml
@@ -30,7 +30,7 @@ jobs:
             ,sdlc/prod/github/actions_bot_token
             ,sdlc/prod/github/buildkite_token
           parse-json-secrets: true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: redpanda-data/sparse-checkout
           token: ${{ env.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/cloud-installpack-bk-trigger.yml
+++ b/.github/workflows/cloud-installpack-bk-trigger.yml
@@ -20,7 +20,7 @@ jobs:
             ,sdlc/prod/github/actions_bot_token
             ,sdlc/prod/github/buildkite_token
           parse-json-secrets: true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: redpanda-data/sparse-checkout
           token: ${{ env.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/lint-bazel-pkg-tool.yml
+++ b/.github/workflows/lint-bazel-pkg-tool.yml
@@ -16,7 +16,7 @@ jobs:
   golangci-lint:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: stable

--- a/.github/workflows/lint-cpp.yml
+++ b/.github/workflows/lint-cpp.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Baselisk
         run: |
           mkdir -v -p $HOME/.local/bin

--- a/.github/workflows/lint-golang.yml
+++ b/.github/workflows/lint-golang.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: astral-sh/ruff-action@v3
         with:
           args: "format --check --diff"

--- a/.github/workflows/lint-sh.yml
+++ b/.github/workflows/lint-sh.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install shfmt
         env:
           SHFMT_VER: 3.6.0

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -14,5 +14,5 @@ jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: yamllint -f github .yamllint .github/workflows/*.yml

--- a/.github/workflows/p.yml
+++ b/.github/workflows/p.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Compile
         working-directory: tests/models
         run: ../../tools/p/p compile

--- a/.github/workflows/release-rp-storage-tool.yml
+++ b/.github/workflows/release-rp-storage-tool.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build binary
         run: |
           export DOCKER_BUILDKIT=1

--- a/.github/workflows/rp-storage-tool-checks.yml
+++ b/.github/workflows/rp-storage-tool-checks.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -33,7 +33,7 @@ jobs:
             goarch: arm64
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: stable
@@ -46,7 +46,7 @@ jobs:
         runner: [ubuntu-24.04, macos-15]
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: stable

--- a/.github/workflows/transform-sdk-build.yml
+++ b/.github/workflows/transform-sdk-build.yml
@@ -30,7 +30,7 @@ jobs:
     name: Build integration tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -48,7 +48,7 @@ jobs:
     name: Test Golang Transform SDK
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -66,7 +66,7 @@ jobs:
     needs: [test-golang, build-integration-tests]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -102,7 +102,7 @@ jobs:
     name: Test Rust Transform SDK
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Rust
         run: |
           rustup update --no-self-update ${{ env.RUST_VERSION }}
@@ -122,7 +122,7 @@ jobs:
     needs: [test-rust, build-integration-tests]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Rust
         run: |
           rustup update --no-self-update ${{ env.RUST_VERSION }}
@@ -158,7 +158,7 @@ jobs:
     container:
       image: fedora:40
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Clang
         run: dnf install -y clang clang-tools-extra libcxx libcxxabi libcxx-devel libcxxabi-devel cmake
       - name: Run tests
@@ -180,7 +180,7 @@ jobs:
     container:
       image: ghcr.io/webassembly/wasi-sdk:wasi-sdk-24
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build integration tests
         working-directory: src/transform-sdk/cpp/examples
         run: cmake -B build && cmake --build build
@@ -205,7 +205,7 @@ jobs:
     container:
       image: fedora:40
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Clang
         run: dnf install -y clang clang-tools-extra libcxx libcxxabi libcxx-devel libcxxabi-devel cmake git
       - name: Run tests
@@ -227,7 +227,7 @@ jobs:
     container:
       image: ghcr.io/webassembly/wasi-sdk:wasi-sdk-24
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/transform-sdk-release.yml
+++ b/.github/workflows/transform-sdk-release.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: 1.22
@@ -49,7 +49,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Rust
         run: rustup update stable --no-self-update && rustup default stable
       - uses: aws-actions/configure-aws-credentials@v4
@@ -81,7 +81,7 @@ jobs:
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/29551

- Command: git cherry-pick -x 0d8ae68e7c
- Commits backported: 1
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-29551-v25.2.x-1779302907

Fixes #30522

## Conflict details

- 0d8ae68e7c (.github/workflows/buf.yml): file does not exist on v25.2.x; dropped from the cherry-pick (kept deleted on the target branch).
- 0d8ae68e7c (.github/workflows/lint-bazel-dependency-graph.yml): file does not exist on v25.2.x; dropped from the cherry-pick.
- 0d8ae68e7c (.github/workflows/publish-apache-polaris-python-client.yml): file does not exist on v25.2.x; dropped from the cherry-pick.
- 0d8ae68e7c (.github/workflows/type-check-python.yaml): file does not exist on v25.2.x; dropped from the cherry-pick.
- 0d8ae68e7c (.github/workflows/lint-cpp.yml): v25.2.x uses a `wget`-based "Install Baselisk" step where dev has switched to `bazel-contrib/setup-bazel@0.15.0`; preserved v25.2.x file shape and applied only the v4 -> v6 checkout bump, which is the source commit's sole intent.
- 0d8ae68e7c (.github/workflows/lint-golang.yml): only the `actions/checkout` version line differed; kept v25.2.x file shape and applied the v4 -> v6 bump.
- 0d8ae68e7c (.github/workflows/lint-python.yml): v25.2.x lacks the `Ruff format --check` step name that exists on dev; preserved v25.2.x style (single `- uses: astral-sh/ruff-action@v3` line) and applied only the v4 -> v6 checkout bump.
- 0d8ae68e7c (.github/workflows/rpk-build.yml): v25.2.x lacks the `check-proto-gen` job that exists on dev; preserved v25.2.x job set and applied only the v4 -> v6 checkout bump.