### PR TITLE
`config`: use `static_metadata` in `property`

### DIFF
--- a/src/v/config/BUILD
+++ b/src/v/config/BUILD
@@ -55,6 +55,7 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/base",
+        "//src/v/container:chunked_hash_map",
         "//src/v/container:intrusive",
         "//src/v/features:enterprise_feature_messages",
         "//src/v/json",

--- a/src/v/config/base_property.cc
+++ b/src/v/config/base_property.cc
@@ -11,18 +11,42 @@
 
 #include "base/vassert.h"
 #include "config/config_store.h"
+#include "container/chunked_hash_map.h"
+
+#include <memory>
 
 namespace config {
+namespace {
+
+/// Deduplicate `meta` keyed by `name`, returning a canonical pointer that is
+/// stable for the lifetime of the process.
+const base_property::metadata* intern_metadata(
+  std::string_view name, std::string_view desc, base_property::metadata meta) {
+    static thread_local chunked_hash_map<
+      std::string_view,
+      std::unique_ptr<const base_property::metadata>>
+      metadata_table;
+    if (auto it = metadata_table.find(name); it != metadata_table.end()) {
+        return it->second.get();
+    }
+    meta.name = name;
+    meta.desc = desc;
+    auto up = std::make_unique<const base_property::metadata>(std::move(meta));
+    const auto* raw = up.get();
+    metadata_table.emplace(name, std::move(up));
+    return raw;
+}
+
+} // namespace
+
 base_property::base_property(
   config_store& conf,
   std::string_view name,
   std::string_view desc,
   base_property::metadata meta)
-  : _name(name)
-  , _desc(desc)
-  , _meta(std::move(meta)) {
-    conf._properties.emplace(name, this);
-    for (const auto& alias : _meta.aliases) {
+  : _meta(intern_metadata(name, desc, std::move(meta))) {
+    conf._properties.emplace(_meta->name, this);
+    for (const auto& alias : _meta->aliases) {
         auto [_, inserted] = conf._aliases.emplace(alias, this);
 
         vassert(inserted, "Two properties tried to register the same alias");
@@ -51,7 +75,7 @@ fmt::iterator format_to(visibility v, fmt::iterator out) {
  */
 void base_property::assert_live_settable() const {
     vassert(
-      _meta.needs_restart == needs_restart::no,
+      _meta->needs_restart == needs_restart::no,
       "Property {} must be be marked as needs_restart::no",
       name());
 }

--- a/src/v/config/base_property.h
+++ b/src/v/config/base_property.h
@@ -119,6 +119,9 @@ fmt::iterator format_to(visibility v, fmt::iterator);
 class base_property {
 public:
     struct metadata {
+        std::string_view name;
+        std::string_view desc;
+
         required required{required::no};
         needs_restart needs_restart{needs_restart::yes};
         std::optional<ss::sstring> example{std::nullopt};
@@ -145,17 +148,17 @@ public:
       std::string_view desc,
       metadata meta);
 
-    const std::string_view& name() const { return _name; }
-    const std::string_view& desc() const { return _desc; }
+    std::string_view name() const { return _meta->name; }
+    std::string_view desc() const { return _meta->desc; }
 
-    const required is_required() const { return _meta.required; }
-    bool needs_restart() const { return bool(_meta.needs_restart); }
-    visibility get_visibility() const { return _meta.visibility; }
-    bool is_secret() const { return bool(_meta.secret); }
+    const required is_required() const { return _meta->required; }
+    bool needs_restart() const { return bool(_meta->needs_restart); }
+    visibility get_visibility() const { return _meta->visibility; }
+    bool is_secret() const { return bool(_meta->secret); }
     const std::vector<std::string_view>& aliases() const {
-        return _meta.aliases;
+        return _meta->aliases;
     }
-    bool gets_restored() const { return bool(_meta.gets_restored); }
+    bool gets_restored() const { return bool(_meta->gets_restored); }
 
     /// Serialize the property value to JSON. A full configuration
     /// serialization is performed in config_store::to_json where the JSON
@@ -279,12 +282,8 @@ public:
      */
     virtual void notify_original_version(legacy_version) = 0;
 
-private:
-    std::string_view _name;
-    std::string_view _desc;
-
 protected:
-    metadata _meta;
+    const metadata* _meta;
     void assert_live_settable() const;
 };
 }; // namespace config

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -279,8 +279,8 @@ public:
     }
 
     std::optional<std::string_view> example() const override {
-        if (_meta.example.has_value()) {
-            return _meta.example;
+        if (_meta->example.has_value()) {
+            return _meta->example;
         } else {
             if constexpr (std::is_same_v<value_type, bool>) {
                 // Provide an example that is the opposite of the default


### PR DESCRIPTION
Our properties contain, for the most part, metadata that is entirely static for a given property. Currently, whenever a `configuration` object or `property` is constructed, these pieces of metadata are reconstructed as well. Things like the property name, the description, whether the property needs a restart, etc.

Also, containing all of this metadata inline within the `property` object itself can bloat it, and as a symptom, bloat the `configuration` object. We are currently (at time of commit) sitting at `~545` properties in our `configuration` object, which results in an object size of `~130KiB`.

This results in a large contiguous allocation everytime we call `make_config()`- while this isn't usually the case in steady operations in `redpanda`, it DOES occur in two places where we are validating/updating cluster properties (in the `kafka` layer and in the `admin` layer).

To solve these problems, Move `name` and `desc` into `metadata` and have each `property` hold a pointer to a deduplicated copy of it. A `static thread_local` table in `base_property.cc` interns by property name: the first construction on a given shard allocates the metadata; subsequent constructions on that shard (notably repeated `make_config()` calls) reuse the existing pointer. By getting `property` to store a pointer to this static metadata object instead of storing it inline, we get to shrink the size of a `property` by `88B`, and more importantly, the `configuration` object.

```
  ┌──────────────────────────────────┬───────────┬───────────────────────────┬
  │              Metric              │ Original  │   After static metadata   │
  ├──────────────────────────────────┼───────────┼───────────────────────────┼
  │ sizeof(configuration)            │ 132,656 B │           84,544 B (−36%) │
  ├──────────────────────────────────┼───────────┼───────────────────────────┼
  │ sizeof(property<bool>)           │       200 │                       112 │
  ├──────────────────────────────────┼───────────┼───────────────────────────┼
  │ sizeof(property<size_t>)         │       224 │                       136 │
  ├──────────────────────────────────┼───────────┼───────────────────────────┼
  │ sizeof(property<sstring>)        │       256 │                       168 │
  ├──────────────────────────────────┼───────────┼───────────────────────────┼
  │ sizeof(bounded_property<size_t>) │       296 │                       208 │
  └──────────────────────────────────┴───────────┴───────────────────────────┴
```

For now, this drops the `configuration` object well below the oversized allocation threshold. However, there are future optimizations potentially worth investigating at the `property` layer:

* Swapping out `ss::noncopyable_function` (40 bytes) for a function pointer (8 bytes). Most `property`s have a no-op validator, yet we are paying the cost for a `noop_validator` in every property. This would further reduce the `configuration` object to `67,072B`, a total reduction of 51% from the original `configuration` object (but only a 13% drop from the previous, static metadata `configuration` object). The obvious drawback here is that a function ptr must be stateless, so lambdas that capture must be re-written (this would be a non-trivial reworking of derived `property`s and would impose limitations on the shape of future validators)
* Move `_default` and `_legacy_default` into the static metadata helper, since these also don't change. This would require some new `base_metadata`/`metadata<T>` classes with type erasure since those values would require a type.

These changes are a bit more non-trivial and buy us less in terms of byte savings, so they aren't included in this PR.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
