### PR TITLE
[CORE-16339]: dt/scale/sr: split SR scale tests by transport

### DIFF
--- a/tests/rptest/scale_tests/schema_registry_scale_test.py
+++ b/tests/rptest/scale_tests/schema_registry_scale_test.py
@@ -24,13 +24,16 @@ from rptest.utils.mode_checks import skip_debug_mode
 from typing import Any
 
 
-class SchemaRegistryScaleTest(SchemaRegistryEndpoints):
+class SchemaRegistryScaleTestBase(SchemaRegistryEndpoints):
     """
     Test class for schema registry scaling tests.
+
+    Base class. Use SchemaRegistryScaleTest (Kafka client)
+    or SchemaRegistryScaleRpcTransportTest (RPC).
     """
 
     def __init__(self, context: TestContext, **kwargs: Any) -> None:
-        super(SchemaRegistryScaleTest, self).__init__(context, **kwargs)
+        super(SchemaRegistryScaleTestBase, self).__init__(context, **kwargs)
 
     @cluster(num_nodes=1)
     @skip_debug_mode
@@ -175,15 +178,40 @@ class SchemaRegistryScaleTest(SchemaRegistryEndpoints):
         assert len(result_raw.json()) == iterations
 
 
-class SchemaRegistryModeMutableScaleTest(SchemaRegistryEndpoints):
+class SchemaRegistryScaleTest(SchemaRegistryScaleTestBase):
+    """Kafka client transport variant of the schema registry scale tests."""
+
+    def __init__(self, context: TestContext, **kwargs: Any) -> None:
+        super().__init__(
+            context,
+            extra_rp_conf={"schema_registry_use_rpc": False},
+            **kwargs,
+        )
+
+
+class SchemaRegistryScaleRpcTransportTest(SchemaRegistryScaleTestBase):
+    """RPC transport variant of the schema registry scale tests."""
+
+    def __init__(self, context: TestContext, **kwargs: Any) -> None:
+        super().__init__(
+            context,
+            extra_rp_conf={"schema_registry_use_rpc": True},
+            **kwargs,
+        )
+
+
+class SchemaRegistryModeMutableScaleTestBase(SchemaRegistryEndpoints):
     """
     Test class for schema registry subject mode scaling tests.
+
+    Base class. Use SchemaRegistryModeMutableScaleTest (Kafka client)
+    or SchemaRegistryModeMutableScaleRpcTransportTest (RPC).
     """
 
     def __init__(self, context: TestContext, **kwargs: Any) -> None:
         self.schema_registry_config = SchemaRegistryConfig()
         self.schema_registry_config.mode_mutability = True
-        super(SchemaRegistryModeMutableScaleTest, self).__init__(
+        super(SchemaRegistryModeMutableScaleTestBase, self).__init__(
             context, schema_registry_config=self.schema_registry_config, **kwargs
         )
 
@@ -214,3 +242,27 @@ class SchemaRegistryModeMutableScaleTest(SchemaRegistryEndpoints):
         result_raw = self.sr_client.delete_mode_subject(subject=subject)
         assert result_raw.status_code == requests.codes.ok
         assert result_raw.json()["mode"] == mode
+
+
+class SchemaRegistryModeMutableScaleTest(SchemaRegistryModeMutableScaleTestBase):
+    """Kafka client transport variant of the mode-mutable scale tests."""
+
+    def __init__(self, context: TestContext, **kwargs: Any) -> None:
+        super().__init__(
+            context,
+            extra_rp_conf={"schema_registry_use_rpc": False},
+            **kwargs,
+        )
+
+
+class SchemaRegistryModeMutableScaleRpcTransportTest(
+    SchemaRegistryModeMutableScaleTestBase
+):
+    """RPC transport variant of the mode-mutable scale tests."""
+
+    def __init__(self, context: TestContext, **kwargs: Any) -> None:
+        super().__init__(
+            context,
+            extra_rp_conf={"schema_registry_use_rpc": True},
+            **kwargs,
+        )


### PR DESCRIPTION
The schema registry scale tests inherit from SchemaRegistryEndpoints, which since 2af7072cde requires every subclass to set schema_registry_use_rpc explicitly. They were missed in that commit and fail the construction-time assertion.

Mirror the *TestBase pattern used by the unit tests: hoist test methods into SchemaRegistryScaleTestBase / SchemaRegistryModeMutableScaleTestBase and add Kafka-client and RPC leaf variants for each. Ducktape's loader discovers only leaf subclasses, so the bases are skipped automatically.

[**Proof**](https://buildkite.com/redpanda/redpanda/builds/84776#019e4811-9ca0-491d-877e-2ec23b7e8951)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
