### PR TITLE
pandaproxy/rest: return every partition in iceberg translation state

### DIFF
--- a/src/v/pandaproxy/rest/iceberg_handlers.cc
+++ b/src/v/pandaproxy/rest/iceberg_handlers.cc
@@ -182,13 +182,23 @@ get_translation_state(proxy::server::request_t rq, proxy::server::reply_t rp) {
 
         chunked_hash_map<int32_t, proto::pandaproxy::partition_state>
           pb_partitions;
-        for (const auto& [pid, pstate] : state.pid_to_pending_files) {
-            proto::pandaproxy::partition_state pb_pstate;
-            if (pstate.last_committed.has_value()) {
-                pb_pstate.set_last_catalog_committed_offset(
-                  pstate.last_committed.value()());
+        auto p_ids = state.pid_to_pending_files | std::views::keys;
+        auto max_it = std::ranges::max_element(p_ids);
+        int32_t max_partition_id = max_it == std::ranges::end(p_ids)
+                                     ? -1
+                                     : (*max_it)();
+        auto partition_count = std::max<int32_t>(
+          tp_md->get().get_configuration().partition_count,
+          max_partition_id + 1);
+        for (int32_t pid = 0; pid < partition_count; ++pid) {
+            auto it = state.pid_to_pending_files.find(model::partition_id{pid});
+            auto& partition_state = pb_partitions[pid];
+            if (
+              it != state.pid_to_pending_files.end()
+              && it->second.last_committed.has_value()) {
+                partition_state.set_last_catalog_committed_offset(
+                  it->second.last_committed.value()());
             }
-            pb_partitions.emplace(pid(), std::move(pb_pstate));
         }
         pb_state.set_partition_states(std::move(pb_partitions));
         pb_topic_states.emplace(topic(), std::move(pb_state));

--- a/tests/rptest/tests/datalake/iceberg_translation_state_test.py
+++ b/tests/rptest/tests/datalake/iceberg_translation_state_test.py
@@ -147,6 +147,13 @@ class IcebergTranslationStateTest(RedpandaTest):
             assert state.dlq_table_name == f"{topic_name}~dlq", (
                 f"Expected DLQ table name '{topic_name}~dlq', got '{state.dlq_table_name}'"
             )
+            assert len(state.partition_states) == 3, (
+                f"Expected 3 partition states, got {len(state.partition_states)}: "
+                f"{dict(state.partition_states)}"
+            )
+            assert set(state.partition_states.keys()) == {0, 1, 2}, (
+                f"Expected partition ids 0,1,2, got {sorted(state.partition_states.keys())}"
+            )
             self.logger.info(f"Translation state for {topic_name}: {state}")
 
             # Requesting with an empty topics_filter must return 400


### PR DESCRIPTION
Make the iceberg translation state REST response carry complete
per-topic information so callers can size their per-partition
processing without a separate metadata lookup:

* Iterate over every partition of the topic when building
  `partition_states`, not only those the datalake coordinator has
  already seen pending files for. Partitions without a known committed
  offset are returned with `last_catalog_committed_offset` unset.
* Add a `partition_count` field to `TopicState` and populate it from
  the topic configuration.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Improvements

* The iceberg translation state REST endpoint now returns a partition
  state entry for every partition of the topic and reports the topic's
  `partition_count`.
