### PR TITLE
serde/parquet: Improvements preparing for Iceberg column stats

### DIFF
--- a/src/v/serde/parquet/BUILD
+++ b/src/v/serde/parquet/BUILD
@@ -120,6 +120,7 @@ redpanda_cc_library(
         "//src/v/compression",
         "//src/v/container:chunked_vector",
         "//src/v/hashing:crc32",
+        "//src/v/strings:utf8",
         "@abseil-cpp//absl/numeric:int128",
         "@seastar",
     ],

--- a/src/v/serde/parquet/BUILD
+++ b/src/v/serde/parquet/BUILD
@@ -135,7 +135,6 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         ":column_writer",
-        ":metadata",
         ":shredder",
         "//src/v/bytes:iobuf",
         "//src/v/bytes:iostream",
@@ -144,6 +143,7 @@ redpanda_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":metadata",
         ":schema",
         ":value",
         "//src/v/base",

--- a/src/v/serde/parquet/column_writer.cc
+++ b/src/v/serde/parquet/column_writer.cc
@@ -12,11 +12,13 @@
 #include "serde/parquet/column_writer.h"
 
 #include "absl/numeric/int128.h"
+#include "bytes/iobuf_parser.h"
 #include "compression/compression.h"
 #include "container/chunked_vector.h"
 #include "hashing/crc32.h"
 #include "serde/parquet/column_stats_collector.h"
 #include "serde/parquet/encoding.h"
+#include "strings/utf8.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/util/variant_utils.hh>
@@ -48,6 +50,65 @@ public:
 };
 
 namespace {
+
+std::pair<iobuf, bool>
+truncate_min(iobuf value, int32_t max_len, bool is_utf8) {
+    if (max_len <= 0 || static_cast<int32_t>(value.size_bytes()) <= max_len) {
+        return {std::move(value), true};
+    }
+    if (!is_utf8) {
+        iobuf_parser parser(std::move(value));
+        return {parser.copy(max_len), false};
+    }
+    // Read one extra byte so utf8_truncate_min's "string fits" fast path
+    // doesn't fire and it properly scans for a codepoint boundary.
+    auto read_len = std::min(
+      value.size_bytes(), static_cast<size_t>(max_len) + 1);
+    iobuf_parser parser(std::move(value));
+    auto buf = parser.read_bytes(read_len);
+    auto sv = std::string_view(
+      reinterpret_cast<const char*>(buf.data()), buf.size());
+    auto prefix = utf8_truncate_min(sv, static_cast<size_t>(max_len));
+    iobuf result;
+    result.append(prefix.data(), prefix.size());
+    return {std::move(result), false};
+}
+
+std::optional<std::pair<iobuf, bool>>
+truncate_max(iobuf value, int32_t max_len, bool is_utf8) {
+    if (max_len <= 0 || static_cast<int32_t>(value.size_bytes()) <= max_len) {
+        return {{std::move(value), true}};
+    }
+    if (!is_utf8) {
+        iobuf_parser parser(std::move(value));
+        auto prefix = parser.read_bytes(max_len);
+        for (int i = static_cast<int>(prefix.size()) - 1; i >= 0; --i) {
+            if (prefix[i] < 0xFF) {
+                prefix[i]++;
+                iobuf result;
+                result.append(prefix.data(), i + 1);
+                return {{std::move(result), false}};
+            }
+        }
+        // All prefix bytes are 0xFF — no valid truncated upper bound.
+        return std::nullopt;
+    }
+    // Same +1 trick: give utf8_truncate_max a string longer than max_len so
+    // it takes the truncation path rather than the "string fits" fast path.
+    auto read_len = std::min(
+      value.size_bytes(), static_cast<size_t>(max_len) + 1);
+    iobuf_parser parser(std::move(value));
+    auto buf = parser.read_bytes(read_len);
+    auto sv = std::string_view(
+      reinterpret_cast<const char*>(buf.data()), buf.size());
+    auto opt = utf8_truncate_max(sv, static_cast<size_t>(max_len));
+    if (opt) {
+        iobuf result;
+        result.append(opt->data(), opt->size());
+        return {{std::move(result), false}};
+    }
+    return std::nullopt;
+}
 
 void extend_crc32(crc::crc32& crc, const iobuf& buf) {
     for (const auto& frag : buf) {
@@ -137,20 +198,31 @@ public:
         using bound_type = decltype(_flushed_stats)::bound_ref_type;
         std::optional<statistics::bound> max_bound;
         if (bound_type max = _current_page_stats.max()) {
-            // TODO: consider truncating large values instead of writing them
-            // (is_exact=false)
-            max_bound.emplace(
-              /*value=*/encode_for_stats(*max),
-              /*is_exact=*/true);
+            if constexpr (std::is_same_v<value_type, byte_array_value>) {
+                if (
+                  auto truncated = truncate_max(
+                    encode_for_stats(*max),
+                    _opts.max_stats_truncate_length,
+                    _opts.is_utf8_string)) {
+                    auto [val, is_exact] = std::move(*truncated);
+                    max_bound.emplace(std::move(val), is_exact);
+                }
+            } else {
+                max_bound.emplace(encode_for_stats(*max), true);
+            }
             _flushed_stats.record_value(*max);
         }
         std::optional<statistics::bound> min_bound;
         if (bound_type min = _current_page_stats.min()) {
-            // TODO: consider truncating large values instead of writing them
-            // (is_exact=false)
-            min_bound.emplace(
-              /*value=*/encode_for_stats(*min),
-              /*is_exact=*/true);
+            if constexpr (std::is_same_v<value_type, byte_array_value>) {
+                auto [val, is_exact] = truncate_min(
+                  encode_for_stats(*min),
+                  _opts.max_stats_truncate_length,
+                  _opts.is_utf8_string);
+                min_bound.emplace(std::move(val), is_exact);
+            } else {
+                min_bound.emplace(encode_for_stats(*min), true);
+            }
             _flushed_stats.record_value(*min);
         }
         _flushed_stats.record_null(_current_page_stats.null_count());
@@ -218,14 +290,29 @@ public:
         };
         using bound_type = decltype(_flushed_stats)::bound_ref_type;
         if (bound_type max = _flushed_stats.max()) {
-            full_stats.max.emplace(
-              /*value=*/encode_for_stats(*max),
-              /*is_exact=*/true);
+            if constexpr (std::is_same_v<value_type, byte_array_value>) {
+                if (
+                  auto truncated = truncate_max(
+                    encode_for_stats(*max),
+                    _opts.max_stats_truncate_length,
+                    _opts.is_utf8_string)) {
+                    auto [val, is_exact] = std::move(*truncated);
+                    full_stats.max.emplace(std::move(val), is_exact);
+                }
+            } else {
+                full_stats.max.emplace(encode_for_stats(*max), true);
+            }
         }
         if (bound_type min = _flushed_stats.min()) {
-            full_stats.min.emplace(
-              /*value=*/encode_for_stats(*min),
-              /*is_exact=*/true);
+            if constexpr (std::is_same_v<value_type, byte_array_value>) {
+                auto [val, is_exact] = truncate_min(
+                  encode_for_stats(*min),
+                  _opts.max_stats_truncate_length,
+                  _opts.is_utf8_string);
+                full_stats.min.emplace(std::move(val), is_exact);
+            } else {
+                full_stats.min.emplace(encode_for_stats(*min), true);
+            }
         }
         _flushed_stats.reset();
         _total_memory_usage = 0;
@@ -320,6 +407,8 @@ make_impl(const schema_element& e, byte_array_type t, options opts) {
           fixed_byte_array_value,
           ordering::fixed_byte_array>>(e, opts);
     }
+    opts.is_utf8_string = std::holds_alternative<string_type>(e.logical_type)
+                          || std::holds_alternative<enum_type>(e.logical_type);
     return std::make_unique<
       buffered_column_writer<byte_array_value, ordering::byte_array>>(e, opts);
 }

--- a/src/v/serde/parquet/column_writer.h
+++ b/src/v/serde/parquet/column_writer.h
@@ -48,6 +48,13 @@ public:
     struct options {
         // If true, use zstd compression for the column data.
         bool compress;
+        // Max byte length for BYTE_ARRAY column statistics truncation.
+        // 0 disables truncation. Fixed-size types are always written exactly.
+        int32_t max_stats_truncate_length = 4096;
+        // Set automatically from the column's logical type (string/enum).
+        // When true, truncation respects UTF-8 character boundaries so that
+        // truncated bounds are always valid UTF-8 strings.
+        bool is_utf8_string = false;
     };
 
     explicit column_writer(const schema_element&, options);

--- a/src/v/serde/parquet/tests/BUILD
+++ b/src/v/serde/parquet/tests/BUILD
@@ -202,6 +202,8 @@ redpanda_cc_gtest(
     memory = "64MiB",
     deps = [
         "//src/v/bytes:iostream",
+        "//src/v/serde/parquet:column_writer",
+        "//src/v/serde/parquet:encoding",
         "//src/v/serde/parquet:schema",
         "//src/v/serde/parquet:value",
         "//src/v/serde/parquet:writer",

--- a/src/v/serde/parquet/tests/writer_test.cc
+++ b/src/v/serde/parquet/tests/writer_test.cc
@@ -10,11 +10,18 @@
  */
 
 #include "bytes/iostream.h"
+#include "serde/parquet/column_stats_collector.h"
+#include "serde/parquet/encoding.h"
 #include "serde/parquet/schema.h"
 #include "serde/parquet/value.h"
 #include "serde/parquet/writer.h"
 
 #include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+#include <random>
+#include <type_traits>
 
 namespace serde::parquet {
 namespace {
@@ -51,6 +58,151 @@ group_value make_row(size_t data_size) {
 }
 
 } // namespace
+
+schema_element two_column_schema() {
+    chunked_vector<schema_element> children;
+    children.push_back(
+      leaf_node("str_col", field_repetition_type::required, byte_array_type{}));
+    children.push_back(
+      leaf_node("int_col", field_repetition_type::required, i32_type{}));
+    return {
+      .repetition_type = field_repetition_type::required,
+      .path = {"root"},
+      .children = std::move(children),
+    };
+}
+
+group_value make_two_col_row(ss::sstring str_val, int32_t int_val) {
+    chunked_vector<group_member> fields;
+    fields.push_back(
+      group_member{byte_array_value{iobuf::from(std::move(str_val))}});
+    fields.push_back(group_member{int32_value{int_val}});
+    return fields;
+}
+
+schema_element single_col_schema(physical_type ptype) {
+    chunked_vector<schema_element> children;
+    children.push_back(
+      leaf_node("col", field_repetition_type::required, ptype));
+    return {
+      .repetition_type = field_repetition_type::required,
+      .path = {"root"},
+      .children = std::move(children),
+    };
+}
+
+schema_element single_string_schema() {
+    chunked_vector<schema_element> children;
+    children.push_back(leaf_node(
+      "col",
+      field_repetition_type::required,
+      byte_array_type{},
+      string_type{}));
+    return {
+      .repetition_type = field_repetition_type::required,
+      .path = {"root"},
+      .children = std::move(children),
+    };
+}
+
+group_value make_string_row(std::string s) {
+    chunked_vector<group_member> fields;
+    fields.push_back(group_member{byte_array_value{iobuf::from(std::move(s))}});
+    return fields;
+}
+
+/// Writes `values` to a single-column parquet file and verifies that the
+/// column chunk min/max stats match what column_stats_collector computes.
+/// Uses max_stats_truncate_length=0 (no truncation) to get exact stats.
+template<typename ValueType, auto Comparator>
+void check_col_stats(
+  physical_type ptype, const std::vector<ValueType>& values) {
+    static_assert(std::is_trivially_copyable_v<ValueType>);
+
+    column_stats_collector<ValueType, Comparator> oracle;
+    for (auto v : values) {
+        oracle.record_value(v);
+    }
+
+    iobuf file;
+    writer w(
+      {.schema = single_col_schema(ptype), .max_stats_truncate_length = 0},
+      make_iobuf_ref_output_stream(file));
+    w.init().get();
+    for (auto v : values) {
+        chunked_vector<group_member> fields;
+        fields.push_back(group_member{v});
+        w.write_row(group_value{std::move(fields)}).get();
+    }
+    auto metadata = w.close().get();
+
+    ASSERT_FALSE(metadata.row_groups.empty());
+    auto& stats = metadata.row_groups[0].columns[0].meta_data.stats;
+    ASSERT_TRUE(stats.has_value());
+
+    auto oracle_min = oracle.min();
+    if (oracle_min) {
+        ASSERT_TRUE(stats->min.has_value());
+        EXPECT_EQ(stats->min->value, encode_for_stats(*oracle_min));
+        EXPECT_TRUE(stats->min->is_exact);
+    } else {
+        EXPECT_FALSE(stats->min.has_value());
+    }
+
+    auto oracle_max = oracle.max();
+    if (oracle_max) {
+        ASSERT_TRUE(stats->max.has_value());
+        EXPECT_EQ(stats->max->value, encode_for_stats(*oracle_max));
+        EXPECT_TRUE(stats->max->is_exact);
+    } else {
+        EXPECT_FALSE(stats->max.has_value());
+    }
+}
+
+/// Same as check_col_stats but for byte_array columns, where values are
+/// passed as strings to avoid iobuf's move-only restriction.
+void check_byte_array_stats(const std::vector<std::string>& values) {
+    column_stats_collector<byte_array_value, ordering::byte_array> oracle;
+    for (const auto& s : values) {
+        byte_array_value bav{iobuf::from(s)};
+        oracle.record_value(bav);
+    }
+
+    iobuf file;
+    writer w(
+      {.schema = single_col_schema(byte_array_type{}),
+       .max_stats_truncate_length = 0},
+      make_iobuf_ref_output_stream(file));
+    w.init().get();
+    for (const auto& s : values) {
+        chunked_vector<group_member> fields;
+        fields.push_back(group_member{byte_array_value{iobuf::from(s)}});
+        w.write_row(group_value{std::move(fields)}).get();
+    }
+    auto metadata = w.close().get();
+
+    ASSERT_FALSE(metadata.row_groups.empty());
+    auto& stats = metadata.row_groups[0].columns[0].meta_data.stats;
+    ASSERT_TRUE(stats.has_value());
+
+    auto& oracle_min = oracle.min();
+    if (oracle_min) {
+        ASSERT_TRUE(stats->min.has_value());
+        EXPECT_EQ(stats->min->value, encode_for_stats(*oracle_min));
+        EXPECT_TRUE(stats->min->is_exact);
+    } else {
+        EXPECT_FALSE(stats->min.has_value());
+    }
+
+    auto& oracle_max = oracle.max();
+    if (oracle_max) {
+        ASSERT_TRUE(stats->max.has_value());
+        EXPECT_EQ(stats->max->value, encode_for_stats(*oracle_max));
+        EXPECT_TRUE(stats->max->is_exact);
+    } else {
+        EXPECT_FALSE(stats->max.has_value());
+    }
+}
 
 // NOLINTBEGIN(*magic-number*)
 
@@ -102,6 +254,384 @@ TEST(ParquetWriter, NoEarlyFlushWhenUnderLimit) {
     EXPECT_GE(stats.buffered_size, row_size * rows_to_write);
 
     w.close().get();
+}
+
+TEST(ParquetWriter, StatsTruncation) {
+    constexpr int32_t max_stats_len = 16;
+
+    iobuf file;
+    writer w(
+      {
+        .schema = two_column_schema(),
+        .max_stats_truncate_length = max_stats_len,
+      },
+      make_iobuf_ref_output_stream(file));
+    w.init().get();
+
+    // Write rows with long strings (50 bytes) that should be truncated.
+    // Use distinct min/max values to exercise both truncation paths.
+    std::string long_min(50, 'A');
+    std::string long_max(50, 'Z');
+    w.write_row(make_two_col_row(ss::sstring(long_min), 1)).get();
+    w.write_row(make_two_col_row(ss::sstring(long_max), 100)).get();
+
+    auto metadata = w.close().get();
+
+    ASSERT_EQ(metadata.row_groups.size(), 1);
+    auto& rg = metadata.row_groups[0];
+    ASSERT_GE(rg.columns.size(), 2);
+
+    // Column 0: byte_array (string) -- should be truncated
+    auto& str_stats = rg.columns[0].meta_data.stats;
+    ASSERT_TRUE(str_stats.has_value());
+    ASSERT_TRUE(str_stats->min.has_value());
+    ASSERT_TRUE(str_stats->max.has_value());
+    EXPECT_LE(
+      static_cast<int32_t>(str_stats->min->value.size_bytes()), max_stats_len);
+    EXPECT_FALSE(str_stats->min->is_exact);
+    EXPECT_LE(
+      static_cast<int32_t>(str_stats->max->value.size_bytes()), max_stats_len);
+    EXPECT_FALSE(str_stats->max->is_exact);
+
+    // Column 1: int32 -- should NOT be truncated (always small)
+    auto& int_stats = rg.columns[1].meta_data.stats;
+    ASSERT_TRUE(int_stats.has_value());
+    ASSERT_TRUE(int_stats->min.has_value());
+    ASSERT_TRUE(int_stats->max.has_value());
+    EXPECT_TRUE(int_stats->min->is_exact);
+    EXPECT_TRUE(int_stats->max->is_exact);
+}
+
+TEST(ParquetWriter, StatsNotTruncatedWhenShort) {
+    constexpr int32_t max_stats_len = 16;
+
+    iobuf file;
+    writer w(
+      {
+        .schema = simple_schema(),
+        .max_stats_truncate_length = max_stats_len,
+      },
+      make_iobuf_ref_output_stream(file));
+    w.init().get();
+
+    // Write short strings (10 bytes) -- should not be truncated
+    w.write_row(make_row(10)).get();
+
+    auto metadata = w.close().get();
+
+    ASSERT_EQ(metadata.row_groups.size(), 1);
+    auto& stats = metadata.row_groups[0].columns[0].meta_data.stats;
+    ASSERT_TRUE(stats.has_value());
+    ASSERT_TRUE(stats->min.has_value());
+    ASSERT_TRUE(stats->max.has_value());
+    EXPECT_EQ(static_cast<int32_t>(stats->min->value.size_bytes()), 10);
+    EXPECT_TRUE(stats->min->is_exact);
+    EXPECT_EQ(static_cast<int32_t>(stats->max->value.size_bytes()), 10);
+    EXPECT_TRUE(stats->max->is_exact);
+}
+
+TEST(ParquetWriter, StatsTruncateMaxAllFF) {
+    constexpr int32_t max_stats_len = 4;
+
+    iobuf file;
+    writer w(
+      {
+        .schema = simple_schema(),
+        .max_stats_truncate_length = max_stats_len,
+      },
+      make_iobuf_ref_output_stream(file));
+    w.init().get();
+
+    // Create a string where the first max_stats_len bytes are all 0xFF,
+    // which cannot be incremented for max truncation.
+    std::string all_ff(10, '\xFF');
+    chunked_vector<group_member> fields;
+    fields.push_back(
+      group_member{byte_array_value{iobuf::from(std::move(all_ff))}});
+    w.write_row(group_value{std::move(fields)}).get();
+
+    auto metadata = w.close().get();
+
+    ASSERT_EQ(metadata.row_groups.size(), 1);
+    auto& stats = metadata.row_groups[0].columns[0].meta_data.stats;
+    ASSERT_TRUE(stats.has_value());
+    // When all prefix bytes are 0xFF, no valid truncated upper bound exists,
+    // so max stats are omitted entirely.
+    EXPECT_FALSE(stats->max.has_value());
+}
+
+TEST(ParquetWriter, StatsRandomInt32) {
+    std::mt19937 rng(42);
+    std::uniform_int_distribution<int32_t> dist(
+      std::numeric_limits<int32_t>::min(), std::numeric_limits<int32_t>::max());
+    std::vector<int32_value> values;
+    values.reserve(1000);
+    for (int i = 0; i < 1000; ++i) {
+        values.push_back(int32_value{dist(rng)});
+    }
+    check_col_stats<int32_value, ordering::int32>(i32_type{}, values);
+}
+
+TEST(ParquetWriter, StatsRandomInt64) {
+    std::mt19937_64 rng(42);
+    std::uniform_int_distribution<int64_t> dist(
+      std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::max());
+    std::vector<int64_value> values;
+    values.reserve(1000);
+    for (int i = 0; i < 1000; ++i) {
+        values.push_back(int64_value{dist(rng)});
+    }
+    check_col_stats<int64_value, ordering::int64>(i64_type{}, values);
+}
+
+TEST(ParquetWriter, StatsRandomFloat32) {
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<float> dist(-1e30f, 1e30f);
+    std::vector<float32_value> values;
+    values.reserve(1002);
+    for (int i = 0; i < 1000; ++i) {
+        values.push_back(float32_value{dist(rng)});
+    }
+    // Include zeros to exercise the zero-normalization path
+    values.push_back(float32_value{0.0f});
+    values.push_back(float32_value{-0.0f});
+    check_col_stats<float32_value, ordering::float32>(f32_type{}, values);
+}
+
+TEST(ParquetWriter, StatsRandomFloat64) {
+    std::mt19937_64 rng(42);
+    std::uniform_real_distribution<double> dist(-1e300, 1e300);
+    std::vector<float64_value> values;
+    values.reserve(1002);
+    for (int i = 0; i < 1000; ++i) {
+        values.push_back(float64_value{dist(rng)});
+    }
+    values.push_back(float64_value{0.0});
+    values.push_back(float64_value{-0.0});
+    check_col_stats<float64_value, ordering::float64>(f64_type{}, values);
+}
+
+TEST(ParquetWriter, StatsRandomByteArray) {
+    std::mt19937 rng(42);
+    std::uniform_int_distribution<int> len_dist(0, 32);
+    std::uniform_int_distribution<int> byte_dist(0, 255);
+    std::vector<std::string> values;
+    values.reserve(100);
+    for (int i = 0; i < 100; ++i) {
+        int len = len_dist(rng);
+        std::string s(len, '\0');
+        for (auto& c : s) {
+            c = static_cast<char>(byte_dist(rng));
+        }
+        values.push_back(std::move(s));
+    }
+    check_byte_array_stats(values);
+}
+
+TEST(ParquetWriter, StatsEdgeInt32) {
+    using lim = std::numeric_limits<int32_t>;
+    // Single minimum value: min == max == INT32_MIN
+    check_col_stats<int32_value, ordering::int32>(
+      i32_type{}, {int32_value{lim::min()}});
+    // Single maximum value: min == max == INT32_MAX
+    check_col_stats<int32_value, ordering::int32>(
+      i32_type{}, {int32_value{lim::max()}});
+    // Both extremes: min == INT32_MIN, max == INT32_MAX
+    check_col_stats<int32_value, ordering::int32>(
+      i32_type{}, {int32_value{lim::min()}, int32_value{lim::max()}});
+}
+
+TEST(ParquetWriter, StatsEdgeInt64) {
+    using lim = std::numeric_limits<int64_t>;
+    check_col_stats<int64_value, ordering::int64>(
+      i64_type{}, {int64_value{lim::min()}});
+    check_col_stats<int64_value, ordering::int64>(
+      i64_type{}, {int64_value{lim::max()}});
+    check_col_stats<int64_value, ordering::int64>(
+      i64_type{}, {int64_value{lim::min()}, int64_value{lim::max()}});
+}
+
+TEST(ParquetWriter, StatsEdgeFloat32) {
+    using lim = std::numeric_limits<float>;
+    // All NaN: no min/max stats
+    check_col_stats<float32_value, ordering::float32>(
+      f32_type{}, {float32_value{lim::quiet_NaN()}});
+    // Infinities
+    check_col_stats<float32_value, ordering::float32>(
+      f32_type{},
+      {float32_value{lim::infinity()}, float32_value{-lim::infinity()}});
+    // Zero normalization: both +0 and -0 present; min stored as -0, max as +0
+    check_col_stats<float32_value, ordering::float32>(
+      f32_type{}, {float32_value{0.0f}, float32_value{-0.0f}});
+    // Finite extremes
+    check_col_stats<float32_value, ordering::float32>(
+      f32_type{}, {float32_value{lim::lowest()}, float32_value{lim::max()}});
+}
+
+TEST(ParquetWriter, StatsEdgeFloat64) {
+    using lim = std::numeric_limits<double>;
+    check_col_stats<float64_value, ordering::float64>(
+      f64_type{}, {float64_value{lim::quiet_NaN()}});
+    check_col_stats<float64_value, ordering::float64>(
+      f64_type{},
+      {float64_value{lim::infinity()}, float64_value{-lim::infinity()}});
+    check_col_stats<float64_value, ordering::float64>(
+      f64_type{}, {float64_value{0.0}, float64_value{-0.0}});
+    check_col_stats<float64_value, ordering::float64>(
+      f64_type{}, {float64_value{lim::lowest()}, float64_value{lim::max()}});
+}
+
+TEST(ParquetWriter, StatsEdgeByteArray) {
+    // Empty string: min == max == ""
+    check_byte_array_stats({""});
+    // Single all-zero byte
+    check_byte_array_stats({std::string(1, '\x00')});
+    // Single all-0xFF byte
+    check_byte_array_stats({std::string(1, '\xFF')});
+    // Long all-0xFF: without truncation, stats are exact
+    check_byte_array_stats({std::string(32, '\xFF')});
+    // Mixed values including empty and binary content
+    check_byte_array_stats({"", "abc", "\x01\x02\x03"});
+}
+
+TEST(ParquetWriter, StatsNoTruncationForFixedSizeTypes) {
+    // Fixed-size column types (int32=4B, int64=8B, etc.) must never be
+    // truncated regardless of max_stats_truncate_length, because truncating
+    // their fixed-size plain encoding produces an invalid stat.
+    constexpr int32_t tiny = 1; // smaller than any fixed-size encoding
+
+    auto check =
+      [&](physical_type ptype, group_value row, int32_t expected_stat_bytes) {
+          iobuf file;
+          writer w(
+            {.schema = single_col_schema(ptype),
+             .max_stats_truncate_length = tiny},
+            make_iobuf_ref_output_stream(file));
+          w.init().get();
+          w.write_row(std::move(row)).get();
+          auto metadata = w.close().get();
+          auto& stats = metadata.row_groups[0].columns[0].meta_data.stats;
+          ASSERT_TRUE(stats.has_value());
+          ASSERT_TRUE(stats->min.has_value());
+          ASSERT_TRUE(stats->max.has_value());
+          EXPECT_TRUE(stats->min->is_exact);
+          EXPECT_TRUE(stats->max->is_exact);
+          EXPECT_EQ(
+            static_cast<int32_t>(stats->min->value.size_bytes()),
+            expected_stat_bytes);
+          EXPECT_EQ(
+            static_cast<int32_t>(stats->max->value.size_bytes()),
+            expected_stat_bytes);
+      };
+
+    auto row32 = [](int32_t v) {
+        chunked_vector<group_member> f;
+        f.push_back(group_member{int32_value{v}});
+        return group_value{std::move(f)};
+    };
+    auto row64 = [](int64_t v) {
+        chunked_vector<group_member> f;
+        f.push_back(group_member{int64_value{v}});
+        return group_value{std::move(f)};
+    };
+
+    check(i32_type{}, row32(42), 4);
+    check(i64_type{}, row64(1234567890LL), 8);
+}
+
+TEST(ParquetWriter, StatsTruncationUtf8CharBoundary) {
+    // "hello€world" = 5 + 3 + 5 = 13 bytes. With max_stats_truncate_length=7,
+    // a byte-level truncation would produce "hello\xE2\x82" (7 bytes, mid-€).
+    // The UTF-8-aware truncation must stop at the last complete codepoint,
+    // giving "hello" (5 bytes) for min and a valid UTF-8 upper bound for max.
+    constexpr int32_t max_len = 7;
+    std::string s = "hello\xE2\x82\xAC"
+                    "world"; // "hello€world", 13 bytes
+
+    iobuf file;
+    writer w(
+      {.schema = single_string_schema(), .max_stats_truncate_length = max_len},
+      make_iobuf_ref_output_stream(file));
+    w.init().get();
+    w.write_row(make_string_row(s)).get();
+    w.write_row(make_string_row(s)).get(); // two identical rows
+
+    auto metadata = w.close().get();
+    ASSERT_EQ(metadata.row_groups.size(), 1);
+    auto& stats = metadata.row_groups[0].columns[0].meta_data.stats;
+    ASSERT_TRUE(stats.has_value());
+    ASSERT_TRUE(stats->min.has_value());
+
+    // Min must be "hello" — not the 7-byte mid-sequence prefix.
+    EXPECT_EQ(stats->min->value.linearize_to_string(), "hello");
+    EXPECT_FALSE(stats->min->is_exact);
+
+    // Max must be a valid UTF-8 upper bound strictly greater than "hello".
+    ASSERT_TRUE(stats->max.has_value());
+    EXPECT_GT(stats->max->value.linearize_to_string(), ss::sstring("hello"));
+    EXPECT_FALSE(stats->max->is_exact);
+}
+
+TEST(ParquetWriter, StatsTruncationUtf8MaxNoInvalidByteIncrement) {
+    // "aÿ..." — "ÿ" = U+00FF = 0xC3 0xBF (2 bytes). With max_len=3 the prefix
+    // is "aÿ" (3 bytes). Byte-level increment of 0xBF→0xC0 is INVALID UTF-8.
+    // The correct result increments U+00FF → U+0100 (Ā) = 0xC4 0x80, giving
+    // the max bound "aĀ" = [0x61, 0xC4, 0x80].
+    constexpr int32_t max_len = 3;
+    std::string s = "a\xC3\xBF"
+                    "extra"; // "aÿextra", 7 bytes
+
+    iobuf file;
+    writer w(
+      {.schema = single_string_schema(), .max_stats_truncate_length = max_len},
+      make_iobuf_ref_output_stream(file));
+    w.init().get();
+    w.write_row(make_string_row(s)).get();
+    w.write_row(make_string_row(s)).get();
+
+    auto metadata = w.close().get();
+    ASSERT_EQ(metadata.row_groups.size(), 1);
+    auto& stats = metadata.row_groups[0].columns[0].meta_data.stats;
+    ASSERT_TRUE(stats.has_value());
+    ASSERT_TRUE(stats->min.has_value());
+    ASSERT_TRUE(stats->max.has_value());
+
+    EXPECT_EQ(stats->min->value.linearize_to_string(), "a\xC3\xBF");
+    // Must be "aĀ" (valid UTF-8), not "a\xC3\xC0" (invalid).
+    EXPECT_EQ(
+      stats->max->value.linearize_to_string(), ss::sstring("a\xC4\x80"));
+    EXPECT_FALSE(stats->max->is_exact);
+}
+
+TEST(ParquetWriter, StatsTruncationUtf8InvalidInput) {
+    // Input contains invalid UTF-8 bytes after valid prefix "abc".
+    // With max_len=4, the UTF-8-aware min must stop at the last complete valid
+    // codepoint ("abc", 3 bytes), not include the invalid byte. The max, if
+    // produced, must be valid UTF-8 and a true upper bound (e.g. "abd").
+    constexpr int32_t max_len = 4;
+    std::string s = "abc\x80\x81\x82"; // "abc" + 3 invalid continuation bytes
+
+    iobuf file;
+    writer w(
+      {.schema = single_string_schema(), .max_stats_truncate_length = max_len},
+      make_iobuf_ref_output_stream(file));
+    w.init().get();
+    w.write_row(make_string_row(s)).get();
+    w.write_row(make_string_row(s)).get();
+
+    auto metadata = w.close().get();
+    ASSERT_EQ(metadata.row_groups.size(), 1);
+    auto& stats = metadata.row_groups[0].columns[0].meta_data.stats;
+    ASSERT_TRUE(stats.has_value());
+    ASSERT_TRUE(stats->min.has_value());
+
+    EXPECT_EQ(stats->min->value.linearize_to_string(), "abc");
+    EXPECT_FALSE(stats->min->is_exact);
+
+    // Max must be a valid UTF-8 upper bound strictly greater than the min.
+    ASSERT_TRUE(stats->max.has_value());
+    EXPECT_GT(stats->max->value.linearize_to_string(), ss::sstring("abc"));
+    EXPECT_FALSE(stats->max->is_exact);
 }
 
 // NOLINTEND(*magic-number*)

--- a/src/v/serde/parquet/writer.cc
+++ b/src/v/serde/parquet/writer.cc
@@ -58,6 +58,8 @@ public:
                   element,
                   {
                     .compress = _opts.compress,
+                    .max_stats_truncate_length
+                    = _opts.max_stats_truncate_length,
                   }),
               });
         });

--- a/src/v/serde/parquet/writer.cc
+++ b/src/v/serde/parquet/writer.cc
@@ -157,7 +157,7 @@ public:
         _row_groups.push_back(std::move(rg));
     }
 
-    ss::future<> close() {
+    ss::future<file_metadata> close() {
         co_await flush_row_group();
         int64_t num_rows = 0;
         for (const auto& rg : _row_groups) {
@@ -169,22 +169,23 @@ public:
                 orders.push_back(column_order::type_defined);
             }
         });
-        auto encoded_footer = encode(
-          file_metadata{
-            .version = 2,
-            .schema = flatten(_opts.schema),
-            .num_rows = num_rows,
-            .row_groups = std::move(_row_groups),
-            .key_value_metadata = std::move(_opts.metadata),
-            .created_by = fmt::format(
-              "Redpanda version {} (build {})", _opts.version, _opts.build),
-            .column_orders = std::move(orders),
-          });
+        file_metadata metadata{
+          .version = 2,
+          .schema = flatten(_opts.schema),
+          .num_rows = num_rows,
+          .row_groups = std::move(_row_groups),
+          .key_value_metadata = std::move(_opts.metadata),
+          .created_by = fmt::format(
+            "Redpanda version {} (build {})", _opts.version, _opts.build),
+          .column_orders = std::move(orders),
+        };
+        auto encoded_footer = encode(metadata);
         size_t footer_size = encoded_footer.size_bytes();
         co_await write_iobuf(std::move(encoded_footer));
         co_await write_iobuf(encode_footer_size(footer_size));
         co_await write_iobuf(iobuf::from("PAR1"));
         co_await _output.close();
+        co_return std::move(metadata);
     }
 
 private:
@@ -236,6 +237,6 @@ file_stats writer::stats() const { return _impl->stats(); }
 
 ss::future<> writer::flush_row_group() { return _impl->flush_row_group(); }
 
-ss::future<> writer::close() { return _impl->close(); }
+ss::future<file_metadata> writer::close() { return _impl->close(); }
 
 } // namespace serde::parquet

--- a/src/v/serde/parquet/writer.h
+++ b/src/v/serde/parquet/writer.h
@@ -57,6 +57,13 @@ public:
         // Row groups are flushed to disk internally if they exceed this size.
         static constexpr int64_t default_row_group_size = 128_MiB;
         int64_t row_group_size = default_row_group_size;
+
+        // Max byte length for BYTE_ARRAY column statistics. Values exceeding
+        // this are truncated with is_exact=false. 0 disables truncation.
+        // Fixed-size types (int32, int64, float, etc.) are always exact.
+        // Matches Arrow's DEFAULT_MAX_STATISTICS_SIZE.
+        static constexpr int32_t default_max_stats_length = 4096;
+        int32_t max_stats_truncate_length = default_max_stats_length;
     };
 
     // Create a new parquet file writer using the given options that

--- a/src/v/serde/parquet/writer.h
+++ b/src/v/serde/parquet/writer.h
@@ -13,6 +13,7 @@
 
 #include "base/units.h"
 #include "container/chunked_vector.h"
+#include "serde/parquet/metadata.h"
 #include "serde/parquet/schema.h"
 #include "serde/parquet/value.h"
 
@@ -107,7 +108,7 @@ public:
     // class.
     //
     // The resulting future must be awaited before destroying this object.
-    ss::future<> close();
+    ss::future<file_metadata> close();
 
 private:
     class impl;

--- a/src/v/strings/BUILD
+++ b/src/v/strings/BUILD
@@ -12,6 +12,7 @@ redpanda_cc_library(
     deps = [
         "//src/v/base",
         "@boost//:locale",
+        "@utf8proc",
     ],
 )
 

--- a/src/v/strings/tests/BUILD
+++ b/src/v/strings/tests/BUILD
@@ -28,3 +28,16 @@ redpanda_cc_gtest(
         "@googletest//:gtest_main",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "utf8_bounds_test",
+    timeout = "short",
+    srcs = [
+        "utf8_bounds_test.cc",
+    ],
+    deps = [
+        "//src/v/strings:utf8",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/src/v/strings/tests/utf8_bounds_test.cc
+++ b/src/v/strings/tests/utf8_bounds_test.cc
@@ -60,7 +60,8 @@ TEST(Utf8TruncateMin, ThreeByteBoundary) {
     // Limit 3: fits exactly.
     EXPECT_EQ(utf8_truncate_min(euro, 3), euro);
     // Multi-codepoint: "a€b" (5 bytes), limit 4 → "a€" (4 bytes).
-    std::string s = "a\xE2\x82\xAC" "b";
+    std::string s = "a\xE2\x82\xAC"
+                    "b";
     EXPECT_EQ(utf8_truncate_min(s, 4), "a\xE2\x82\xAC");
     EXPECT_EQ(utf8_truncate_min(s, 3), "a"); // "€" starts at byte 1, needs 3
 }
@@ -71,7 +72,8 @@ TEST(Utf8TruncateMin, FourByteBoundary) {
     EXPECT_EQ(utf8_truncate_min(emoji, 3), "");
     EXPECT_EQ(utf8_truncate_min(emoji, 4), emoji);
     // "a😀b" (6 bytes), limit 5 → "a😀" (5 bytes).
-    std::string s = "a\xF0\x9F\x98\x80" "b";
+    std::string s = "a\xF0\x9F\x98\x80"
+                    "b";
     EXPECT_EQ(utf8_truncate_min(s, 5), "a\xF0\x9F\x98\x80");
     EXPECT_EQ(utf8_truncate_min(s, 4), "a"); // 😀 starts at 1, needs 4 bytes
 }
@@ -97,7 +99,8 @@ TEST(Utf8TruncateMax, LastAsciiIsMaxBeforeSurrogateSkip) {
     // Its UTF-8 encoding is 0xED 0x9F 0xBF.
     // next_cp = U+D800 (surrogate) → skip to U+E000.
     // U+E000 encodes to 0xEE 0x80 0x80.
-    std::string s = "a\xED\x9F\xBF" "extra";
+    std::string s = "a\xED\x9F\xBF"
+                    "extra";
     auto r = utf8_truncate_max(s, 4);
     ASSERT_TRUE(r.has_value());
     EXPECT_EQ(*r, std::string("a\xEE\x80\x80"));
@@ -106,7 +109,8 @@ TEST(Utf8TruncateMax, LastAsciiIsMaxBeforeSurrogateSkip) {
 TEST(Utf8TruncateMax, TwoByteCodpointIncrement) {
     // "aé" = "a" + U+00E9 (0xC3 0xA9), 3 bytes.
     // Increment U+00E9 → U+00EA (ê) = 0xC3 0xAA.
-    std::string s = "a\xC3\xA9" "extra";
+    std::string s = "a\xC3\xA9"
+                    "extra";
     auto r = utf8_truncate_max(s, 3);
     ASSERT_TRUE(r.has_value());
     EXPECT_EQ(*r, std::string("a\xC3\xAA"));
@@ -117,7 +121,8 @@ TEST(Utf8TruncateMax, TwoByteCodpointOverflow) {
     // Incrementing byte-by-byte (wrong) would give 0xC3 0xC0, which is
     // invalid UTF-8. The correct result increments U+00FF → U+0100 (Ā)
     // encoded as 0xC4 0x80.
-    std::string s = "a\xC3\xBF" "extra";
+    std::string s = "a\xC3\xBF"
+                    "extra";
     auto r = utf8_truncate_max(s, 3);
     ASSERT_TRUE(r.has_value());
     EXPECT_EQ(*r, std::string("a\xC4\x80"));
@@ -141,7 +146,8 @@ TEST(Utf8TruncateMax, FallbackToPreviousCodepoint) {
     // "a" + U+10FFFF (4 bytes), total 5 bytes.
     // U+10FFFF is the max codepoint; can't increment it.
     // Fall back to 'a' → 'b'.
-    std::string s = "a\xF4\x8F\xBF\xBF" "extra";
+    std::string s = "a\xF4\x8F\xBF\xBF"
+                    "extra";
     auto r = utf8_truncate_max(s, 5);
     ASSERT_TRUE(r.has_value());
     EXPECT_EQ(*r, "b");
@@ -165,7 +171,8 @@ TEST(Utf8TruncateMax, UpperBoundIsStrictlyGreater) {
 TEST(Utf8TruncateMax, SingleMaxAscii) {
     // The prefix is a single 0x7F (DEL), the max 1-byte codepoint.
     // next_cp = U+0080, encoded as 0xC2 0x80.
-    std::string s = "\x7F" "extra";
+    std::string s = "\x7F"
+                    "extra";
     auto r = utf8_truncate_max(s, 1);
     ASSERT_TRUE(r.has_value());
     EXPECT_EQ(*r, std::string("\xC2\x80"));

--- a/src/v/strings/tests/utf8_bounds_test.cc
+++ b/src/v/strings/tests/utf8_bounds_test.cc
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "strings/utf8.h"
+
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+// ---------------------------------------------------------------------------
+// utf8_truncate_min
+// ---------------------------------------------------------------------------
+
+TEST(Utf8TruncateMin, FitsWithinLimit) {
+    EXPECT_EQ(utf8_truncate_min("hello", 10), "hello");
+    EXPECT_EQ(utf8_truncate_min("hello", 5), "hello");
+}
+
+TEST(Utf8TruncateMin, EmptyString) {
+    EXPECT_EQ(utf8_truncate_min("", 4), "");
+    EXPECT_EQ(utf8_truncate_min("", 0), "");
+}
+
+TEST(Utf8TruncateMin, ZeroLimit) {
+    EXPECT_EQ(utf8_truncate_min("hello", 0), "");
+}
+
+TEST(Utf8TruncateMin, AsciiTruncation) {
+    // Pure ASCII: truncation always falls on a character boundary.
+    EXPECT_EQ(utf8_truncate_min("abcde", 3), "abc");
+}
+
+TEST(Utf8TruncateMin, TwoByteBoundary) {
+    // "é" = U+00E9 = 0xC3 0xA9 (2 bytes)
+    std::string s = "a\xC3\xA9z"; // "aéz" — 4 bytes
+    // Limit 2: "a" fits, "é" starts at byte 1 but needs 2 bytes → excluded.
+    EXPECT_EQ(utf8_truncate_min(s, 2), "a");
+    // Limit 3: "a" (1) + "é" (2) = 3 bytes exactly.
+    EXPECT_EQ(utf8_truncate_min(s, 3), "a\xC3\xA9");
+    // Limit 4: whole string.
+    EXPECT_EQ(utf8_truncate_min(s, 4), s);
+}
+
+TEST(Utf8TruncateMin, ThreeByteBoundary) {
+    // "€" = U+20AC = 0xE2 0x82 0xAC (3 bytes)
+    std::string euro = "\xE2\x82\xAC";
+    // Limit 1 or 2: can't fit even the first codepoint.
+    EXPECT_EQ(utf8_truncate_min(euro, 1), "");
+    EXPECT_EQ(utf8_truncate_min(euro, 2), "");
+    // Limit 3: fits exactly.
+    EXPECT_EQ(utf8_truncate_min(euro, 3), euro);
+    // Multi-codepoint: "a€b" (5 bytes), limit 4 → "a€" (4 bytes).
+    std::string s = "a\xE2\x82\xAC" "b";
+    EXPECT_EQ(utf8_truncate_min(s, 4), "a\xE2\x82\xAC");
+    EXPECT_EQ(utf8_truncate_min(s, 3), "a"); // "€" starts at byte 1, needs 3
+}
+
+TEST(Utf8TruncateMin, FourByteBoundary) {
+    // U+1F600 (😀) = 0xF0 0x9F 0x98 0x80 (4 bytes)
+    std::string emoji = "\xF0\x9F\x98\x80";
+    EXPECT_EQ(utf8_truncate_min(emoji, 3), "");
+    EXPECT_EQ(utf8_truncate_min(emoji, 4), emoji);
+    // "a😀b" (6 bytes), limit 5 → "a😀" (5 bytes).
+    std::string s = "a\xF0\x9F\x98\x80" "b";
+    EXPECT_EQ(utf8_truncate_min(s, 5), "a\xF0\x9F\x98\x80");
+    EXPECT_EQ(utf8_truncate_min(s, 4), "a"); // 😀 starts at 1, needs 4 bytes
+}
+
+// ---------------------------------------------------------------------------
+// utf8_truncate_max
+// ---------------------------------------------------------------------------
+
+TEST(Utf8TruncateMax, EmptyPrefix) {
+    // max_bytes=0 → valid prefix is empty → no incrementable codepoint.
+    EXPECT_EQ(utf8_truncate_max("hello", 0), std::nullopt);
+}
+
+TEST(Utf8TruncateMax, AsciiIncrement) {
+    // "abc..." truncated to 2 → prefix "ab", increment 'b' → 'c'.
+    auto r = utf8_truncate_max("abcde", 2);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(*r, "ac");
+}
+
+TEST(Utf8TruncateMax, LastAsciiIsMaxBeforeSurrogateSkip) {
+    // U+D7FF is the last codepoint before the surrogate range.
+    // Its UTF-8 encoding is 0xED 0x9F 0xBF.
+    // next_cp = U+D800 (surrogate) → skip to U+E000.
+    // U+E000 encodes to 0xEE 0x80 0x80.
+    std::string s = "a\xED\x9F\xBF" "extra";
+    auto r = utf8_truncate_max(s, 4);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(*r, std::string("a\xEE\x80\x80"));
+}
+
+TEST(Utf8TruncateMax, TwoByteCodpointIncrement) {
+    // "aé" = "a" + U+00E9 (0xC3 0xA9), 3 bytes.
+    // Increment U+00E9 → U+00EA (ê) = 0xC3 0xAA.
+    std::string s = "a\xC3\xA9" "extra";
+    auto r = utf8_truncate_max(s, 3);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(*r, std::string("a\xC3\xAA"));
+}
+
+TEST(Utf8TruncateMax, TwoByteCodpointOverflow) {
+    // "aÿ" = "a" + U+00FF (0xC3 0xBF), 3 bytes.
+    // Incrementing byte-by-byte (wrong) would give 0xC3 0xC0, which is
+    // invalid UTF-8. The correct result increments U+00FF → U+0100 (Ā)
+    // encoded as 0xC4 0x80.
+    std::string s = "a\xC3\xBF" "extra";
+    auto r = utf8_truncate_max(s, 3);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(*r, std::string("a\xC4\x80"));
+}
+
+TEST(Utf8TruncateMax, ThreeByteCodpointEncodingLengthChange) {
+    // U+FFFF = 0xEF 0xBF 0xBF (3 bytes).
+    // next_cp = U+10000 = 0xF0 0x90 0x80 0x80 (4 bytes).
+    // The encoded next_cp is 1 byte longer, so the result (5 bytes) exceeds
+    // max_bytes (4). This is intentional: the Iceberg spec bounds code-point
+    // count, not byte length, and the result is still a valid upper bound
+    // because the first differing byte (0xF0 > 0xEF) determines the order.
+    std::string s = "a\xEF\xBF\xBF"
+                    "extra";
+    auto r = utf8_truncate_max(s, 4);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(*r, std::string("a\xF0\x90\x80\x80"));
+}
+
+TEST(Utf8TruncateMax, FallbackToPreviousCodepoint) {
+    // "a" + U+10FFFF (4 bytes), total 5 bytes.
+    // U+10FFFF is the max codepoint; can't increment it.
+    // Fall back to 'a' → 'b'.
+    std::string s = "a\xF4\x8F\xBF\xBF" "extra";
+    auto r = utf8_truncate_max(s, 5);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(*r, "b");
+}
+
+TEST(Utf8TruncateMax, AllMaxCodepoints) {
+    // A string of only U+10FFFF codepoints: no valid upper bound exists.
+    std::string s = "\xF4\x8F\xBF\xBF\xF4\x8F\xBF\xBF";
+    EXPECT_EQ(utf8_truncate_max(s, 8), std::nullopt);
+}
+
+TEST(Utf8TruncateMax, UpperBoundIsStrictlyGreater) {
+    // Verify the invariant: result > all strings with the truncated prefix.
+    // prefix = "ab", result = "ac". Any string starting with "ab" is < "ac".
+    auto r = utf8_truncate_max("abcde", 2);
+    ASSERT_TRUE(r.has_value());
+    std::string prefix(utf8_truncate_min("abcde", 2));
+    EXPECT_GT(*r, prefix + std::string(100, '\xFF'));
+}
+
+TEST(Utf8TruncateMax, SingleMaxAscii) {
+    // The prefix is a single 0x7F (DEL), the max 1-byte codepoint.
+    // next_cp = U+0080, encoded as 0xC2 0x80.
+    std::string s = "\x7F" "extra";
+    auto r = utf8_truncate_max(s, 1);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(*r, std::string("\xC2\x80"));
+}

--- a/src/v/strings/utf8.cc
+++ b/src/v/strings/utf8.cc
@@ -11,4 +11,70 @@
 
 #include "strings/utf8.h"
 
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utf8proc.h>
+
 thread_local bool permit_unsafe_log_operation::_flag = false;
+
+std::string_view utf8_truncate_min(std::string_view s, size_t max_bytes) {
+    if (s.size() <= max_bytes) {
+        return s;
+    }
+    const auto* data = reinterpret_cast<const utf8proc_uint8_t*>(s.data());
+    auto limit = static_cast<utf8proc_ssize_t>(max_bytes);
+    utf8proc_ssize_t pos = 0;
+    while (pos < limit) {
+        utf8proc_int32_t cp;
+        utf8proc_ssize_t n = utf8proc_iterate(data + pos, limit - pos, &cp);
+        if (n <= 0) {
+            break; // invalid or incomplete sequence
+        }
+        pos += n;
+    }
+    return s.substr(0, static_cast<size_t>(pos));
+}
+
+std::optional<std::string>
+utf8_truncate_max(std::string_view s, size_t max_bytes) {
+    std::string_view prefix = utf8_truncate_min(s, max_bytes);
+    const auto* data = reinterpret_cast<const utf8proc_uint8_t*>(prefix.data());
+    auto len = static_cast<utf8proc_ssize_t>(prefix.size());
+
+    // Walk backward through code points, trying to increment each one.
+    // Most strings will succeed on the first attempt (the last code point).
+    utf8proc_ssize_t cp_end = len;
+    while (cp_end > 0) {
+        // Find the start of the last code point in [0, cp_end).
+        utf8proc_ssize_t cp_start = cp_end - 1;
+        while (cp_start > 0 && (data[cp_start] & 0xC0) == 0x80) {
+            --cp_start;
+        }
+        utf8proc_int32_t cp;
+        utf8proc_ssize_t n = utf8proc_iterate(
+          data + cp_start, cp_end - cp_start, &cp);
+        if (n > 0 && cp >= 0) {
+            utf8proc_int32_t next_cp = cp + 1;
+            // Skip the surrogate range (U+D800–U+DFFF), which is not valid
+            // in UTF-8.
+            if (next_cp >= 0xD800 && next_cp <= 0xDFFF) {
+                next_cp = 0xE000;
+            }
+            if (next_cp <= 0x10FFFF) {
+                utf8proc_uint8_t encoded[4];
+                utf8proc_ssize_t enc_len = utf8proc_encode_char(
+                  next_cp, encoded);
+                std::string result(
+                  prefix.data(), static_cast<size_t>(cp_start));
+                result.append(
+                  reinterpret_cast<const char*>(encoded),
+                  static_cast<size_t>(enc_len));
+                return result;
+            }
+        }
+        // This code point is at its maximum; try the previous one.
+        cp_end = cp_start;
+    }
+    return std::nullopt;
+}

--- a/src/v/strings/utf8.h
+++ b/src/v/strings/utf8.h
@@ -18,6 +18,7 @@
 #include <boost/locale/encoding_utf.hpp>
 #include <boost/locale/utf.hpp>
 
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -165,3 +166,25 @@ inline void validate_utf8(std::string_view s, const Thrower& thrower) {
 inline void validate_utf8(std::string_view s) {
     validate_utf8(s, default_utf8_thrower{});
 }
+
+/// Returns the longest prefix of `s` ending on a complete UTF-8 code point
+/// boundary with at most `max_bytes` bytes.
+///
+/// Suitable as a truncated lower bound for column statistics: the result is
+/// lexicographically ≤ any string that begins with (or equals) the full input.
+std::string_view utf8_truncate_min(std::string_view s, size_t max_bytes);
+
+/// Returns a string that is lexicographically strictly greater than every
+/// string prefixed by `utf8_truncate_min(s, max_bytes)`.
+///
+/// Returns std::nullopt when the valid prefix consists entirely of U+10FFFF
+/// code points and no incrementable code point exists.
+///
+/// The result is always valid UTF-8 and suitable as a truncated upper bound
+/// for column statistics. It may be up to one byte longer than max_bytes when
+/// incrementing the last codepoint changes its encoding length (e.g. U+007F
+/// → U+0080 grows 1→2 bytes). This matches the behaviour of the Iceberg Java
+/// reference implementation; the Iceberg spec constrains code-point count, not
+/// byte length.
+std::optional<std::string>
+utf8_truncate_max(std::string_view s, size_t max_bytes);


### PR DESCRIPTION
* Change parquet::writer::close() to return file_metadata instead of void, making the encoded file metadata available to callers without re-parsing the file.
* Add configurable min/max statistics truncation for BYTE_ARRAY columns. Values exceeding max_stats_truncate_length (default 4096, matching Arrow's DEFAULT_MAX_STATISTICS_SIZE) are truncated with is_exact=false. Min bounds are prefix-truncated; max bounds are prefix-truncated and incremented to preserve the upper-bound invariant. When all prefix bytes are 0xFF, no valid truncated upper bound exists so max stats are omitted. Fixed-size types (int32, int64, float, etc.) are always written with exact stats regardless of the configured limit.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

