### PR TITLE
iceberg: harden case_fold and add non-null-term coverage

### DIFF
--- a/src/v/iceberg/tests/unicode_test.cc
+++ b/src/v/iceberg/tests/unicode_test.cc
@@ -13,6 +13,8 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+#include <stdexcept>
 #include <string_view>
 
 using namespace iceberg;
@@ -66,4 +68,25 @@ TEST(NamesEqualNonASCII, Unicode) {
     // folding produces i + U+0307 COMBINING DOT ABOVE (a 1:many mapping).
     EXPECT_TRUE(names_equal("\xC4\xB0", "\x69\xCC\x87", fnn::lower_case));
     EXPECT_FALSE(names_equal("\xC4\xB0", "\x69", fnn::lower_case));
+}
+
+// A std::string_view is not required to be null-terminated; case folding must
+// respect the view's size and not read past the end.
+TEST(NamesEqualNonNullTerm, RespectsLength) {
+    constexpr std::array<char, 6> buffer{'f', 'o', 'o', 'b', 'a', 'r'};
+    std::string_view a{buffer.data(), 3};
+    EXPECT_TRUE(names_equal(a, "foo", fnn::lower_case));
+    EXPECT_TRUE(names_equal(a, "FOO", fnn::lower_case));
+    EXPECT_FALSE(names_equal(a, "foobar", fnn::lower_case));
+}
+
+// Invalid UTF-8 is surfaced as std::runtime_error in lower_case mode (case
+// folding can't proceed) but verbatim mode is a byte compare and must not
+// throw.
+TEST(NamesEqualInvalidUtf8, Throws) {
+    // \xC4 is a 2-byte UTF-8 lead with no continuation byte.
+    constexpr std::string_view bad = "\xC4";
+    EXPECT_THROW(names_equal(bad, "x", fnn::lower_case), std::runtime_error);
+    EXPECT_THROW(names_equal("x", bad, fnn::lower_case), std::runtime_error);
+    EXPECT_NO_THROW(names_equal(bad, "x", fnn::verbatim));
 }

--- a/src/v/iceberg/unicode.cc
+++ b/src/v/iceberg/unicode.cc
@@ -11,36 +11,68 @@
 #include "iceberg/unicode.h"
 
 #include <cstdlib>
+#include <memory>
+#include <new>
+#include <stdexcept>
 #include <utf8proc.h>
 
 namespace iceberg {
 
 namespace {
-std::string case_fold(std::string_view s) {
+struct free_deleter {
+    void operator()(uint8_t* p) const noexcept {
+        // utf8proc_map allocates the output buffer with malloc; we own it.
+        // NOLINTNEXTLINE
+        free(p);
+    }
+};
+
+/// Owning wrapper around a utf8proc_map result buffer. The view is valid for
+/// the lifetime of this object.
+class folded_string {
+public:
+    folded_string() noexcept = default;
+    folded_string(uint8_t* data, size_t size) noexcept
+      : owner_(data)
+      , size_(size) {}
+
+    std::string_view view() const noexcept {
+        return {reinterpret_cast<const char*>(owner_.get()), size_};
+    }
+
+private:
+    std::unique_ptr<uint8_t, free_deleter> owner_;
+    size_t size_ = 0;
+};
+
+/// Case-fold \p s using utf8proc. Throws std::bad_alloc on allocation failure
+/// or std::runtime_error (with utf8proc_errmsg) on other utf8proc errors such
+/// as invalid UTF-8.
+folded_string case_fold(std::string_view s) {
     uint8_t* result = nullptr;
     const utf8proc_ssize_t len = utf8proc_map(
       reinterpret_cast<const uint8_t*>(s.data()),
       static_cast<utf8proc_ssize_t>(s.size()),
       &result,
-      static_cast<utf8proc_option_t>(
-        UTF8PROC_CASEFOLD | UTF8PROC_COMPOSE | UTF8PROC_NULLTERM));
-    if (len < 0) {
-        return std::string{s};
+      static_cast<utf8proc_option_t>(UTF8PROC_CASEFOLD | UTF8PROC_COMPOSE));
+    if (len == UTF8PROC_ERROR_NOMEM) {
+        throw std::bad_alloc{};
     }
-    std::string out(reinterpret_cast<char*>(result), static_cast<size_t>(len));
-    // utf8proc_map allocates the output buffer; we own it and must free it.
-    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
-    free(result);
-    return out;
+    if (len < 0) {
+        throw std::runtime_error(utf8proc_errmsg(len));
+    }
+    return {result, static_cast<size_t>(len)};
 }
 } // namespace
 
 bool names_equal(
   std::string_view a, std::string_view b, field_name_comparison norm) {
-    if (norm == field_name_comparison::lower_case) {
-        return case_fold(a) == case_fold(b);
+    switch (norm) {
+    case field_name_comparison::verbatim:
+        return a == b;
+    case field_name_comparison::lower_case:
+        return case_fold(a).view() == case_fold(b).view();
     }
-    return a == b;
 }
 
 } // namespace iceberg

--- a/src/v/iceberg/unicode.h
+++ b/src/v/iceberg/unicode.h
@@ -22,6 +22,10 @@ namespace iceberg {
 /// (UTF8PROC_CASEFOLD | COMPOSE) before comparison. This handles all Unicode
 /// case mappings including 1:many (e.g. İ U+0130 → i + U+0307 COMBINING DOT
 /// ABOVE) and is fully deterministic regardless of system locale.
+///
+/// In lower_case mode, throws std::runtime_error if \p a or \p b is not valid
+/// UTF-8, or std::bad_alloc if utf8proc fails to allocate. The verbatim mode
+/// is a pure byte comparison and does not throw.
 bool names_equal(
   std::string_view a, std::string_view b, field_name_comparison norm);
 


### PR DESCRIPTION
## Summary

Several related improvements to the Unicode case-folding used by `field_name_comparison::lower_case` in `iceberg::names_equal`:

- **Drop `UTF8PROC_NULLTERM` from `utf8proc_map`.** With that flag the size argument is ignored and utf8proc reads until it finds a NUL, which is unsafe for arbitrary `string_view` inputs. Added a regression test using a non-null-terminated view.
- **Stop copying the folded result into a `std::string`.** `utf8proc_map` allocates the buffer with `malloc`; it's now wrapped in a `unique_ptr` with a `free_deleter` and exposed via a small RAII `folded_string` class. `names_equal` compares views into those owners directly.
- **Surface errors instead of silently mis-comparing.** Throws `std::runtime_error` carrying `utf8proc_errmsg` on invalid UTF-8 and `std::bad_alloc` on allocation failure. The contract is documented in the public header.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none