### PR TITLE
[DNM] dt: bump franz-bench and client-swarm to current versions

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -159,6 +159,11 @@ ENV PATH="${PATH}:/root/.cargo/bin"
 
 FROM rust AS client-swarm
 
+# librdkafka-sys 4.10+ (used by rdkafka 0.39+) generates Rust bindings via
+# bindgen at build time, which requires libclang.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends libclang-dev
+
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/client-swarm /
 RUN /client-swarm && \
     rm /client-swarm

--- a/tests/docker/ducktape-deps/client-swarm
+++ b/tests/docker/ducktape-deps/client-swarm
@@ -6,7 +6,7 @@ pushd /tmp
 git clone https://github.com/redpanda-data/client-swarm.git
 
 pushd client-swarm
-git reset --hard 7a2d3837ac926047098232b7ec87afb32a319690
+git reset --hard 9f343b16a88a263e21a701b7e1ca5488f5507b1b
 cargo build --config 'term.verbose=true' --config 'net.retry=6' --release
 cp target/release/client-swarm /usr/local/bin
 popd

--- a/tests/docker/ducktape-deps/franz-bench
+++ b/tests/docker/ducktape-deps/franz-bench
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-git -C /opt clone -b v1.5.0 --single-branch https://github.com/twmb/franz-go.git
+git -C /opt clone -b v1.20.7 --single-branch https://github.com/twmb/franz-go.git
 cd /opt/franz-go/examples/bench
 go mod tidy
 go build

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -189,9 +189,22 @@ class TopicRecreateTest(RedpandaTest):
 
         for i in range(1, 20):
             rf = 3 if i % 2 == 0 else 1
+            # Restart the producer swarm each iteration so each
+            # client-swarm process attaches a fresh librdkafka client to
+            # the new topic. Without this, librdkafka 2.10+ preserves
+            # per-partition state (leader_epoch cache, idempotent
+            # producer_id and sequence numbers) across the topic
+            # delete+recreate window, which then conflicts with the new
+            # topic's fresh broker-side state and stalls produces until
+            # librdkafka's drain/reset path catches up. Pre-2.10
+            # librdkafka tore that state down on topic deletion; this
+            # restart restores the equivalent behavior for the test.
+            swarm.stop()
+            swarm.wait()
             self.client().delete_topic(spec.name)
             spec.replication_factor = rf
             self.client().create_topic(spec)
+            swarm.start()
             wait_until(topic_is_healthy, 30, 2, err_msg=f"Topic {spec.name} health")
             sleep(5)
 


### PR DESCRIPTION
Update: Replaced by this PR: https://github.com/redpanda-data/redpanda/pull/30622

---

Part of the effort to bring our test clients up to Kafka 4.x support
(ENG-1185):

- **franz-bench**: franz-go pin `v1.5.0` → `v1.20.7`.
- **client-swarm**: rdkafka `0.37.0` → `0.39.0` (bundled librdkafka 2.12),
  plus a workaround in `topic_creation_test.py` for a librdkafka
  leader_epoch behavior gap that the bump exposes.

See the commit messages for more details.

[DNM] because the client-swarm SHA currently pins the [`bump-rdkafka-0.39`](https://github.com/redpanda-data/client-swarm/pull/31)
branch on `redpanda-data/client-swarm`. The client-swarm bump's commit
will be amended with a real main-branch SHA once that branch lands; this
PR shouldn't merge before that.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none