### PR TITLE
`storage`: move call to `transactional_stm_type()` out of `noexcept` c-tor

### DIFF
--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -254,6 +254,7 @@ public:
     explicit tx_reducer(
       model::ntp ntp,
       ss::lw_shared_ptr<storage::stm_hookset> stm_mgr,
+      std::optional<storage::stm_type> transactional_stm_type,
       chunked_vector<model::tx_range>&& txs,
       compacted_index_writer* w,
       bool tx_batch_compaction_enabled) noexcept
@@ -261,7 +262,7 @@ public:
       , _delegate(index_rebuilder_reducer(w))
       , _aborted_txs(model::tx_range_cmp(), std::move(txs))
       , _stm_mgr(stm_mgr)
-      , _transactional_stm_type(stm_mgr->transactional_stm_type())
+      , _transactional_stm_type(transactional_stm_type)
       , _tx_batch_compaction_enabled(tx_batch_compaction_enabled) {
         _stats.num_aborted_txes = _aborted_txs.size();
     }

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -257,7 +257,7 @@ public:
       std::optional<storage::stm_type> transactional_stm_type,
       chunked_vector<model::tx_range>&& txs,
       compacted_index_writer* w,
-      bool tx_batch_compaction_enabled) noexcept
+      bool tx_batch_compaction_enabled)
       : _ntp(std::move(ntp))
       , _delegate(index_rebuilder_reducer(w))
       , _aborted_txs(model::tx_range_cmp(), std::move(txs))

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -660,11 +660,13 @@ ss::future<> build_compaction_index(
   compaction::compaction_config cfg,
   storage_resources& resources,
   bool tx_batch_compaction_enabled) {
+    auto transactional_stm_type = stm_hookset->transactional_stm_type();
     auto w = storage::make_file_backed_compacted_index(
       p, false, resources, cfg.sanitizer_config);
     auto reducer = tx_reducer(
       p.get_ntp(),
       stm_hookset,
+      transactional_stm_type,
       std::move(aborted_txs),
       w.get(),
       tx_batch_compaction_enabled);


### PR DESCRIPTION
This function call, `transactional_stm_type()`, used to just check the `_tx_stm`status - however, now it performs a `check_status()` call, which will throw a `gate_closed_exception()` if the `_status` is `status::shutting_down`: f935a808700.

Because of this change, when this function throws (i.e. during shutdown), the previously truly `noexcept` constructor now causes an abort of the program.

Move the call to outside of the `noexcept` constructor to prevent this race from terminating the program.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
