### PR TITLE
`ct/l1`: collect leveling info in `log_info_collector`

### DIFF
--- a/src/v/cloud_topics/level_one/maintenance/leveling/leveling_source.cc
+++ b/src/v/cloud_topics/level_one/maintenance/leveling/leveling_source.cc
@@ -22,7 +22,7 @@ namespace cloud_topics::l1 {
 namespace {
 
 /// A passthrough consumer that forwards batches directly to the sink
-/// without decompression or filtering.
+/// without decompression or use of a compaction::filter for deduplication.
 struct passthrough_consumer {
     compaction::sliding_window_reducer::sink& sink;
 

--- a/src/v/cloud_topics/level_one/maintenance/log_info_collector.cc
+++ b/src/v/cloud_topics/level_one/maintenance/log_info_collector.cc
@@ -343,6 +343,64 @@ void log_info_collector::populate_log_infos(
     }
 }
 
+ss::future<> log_info_collector::collect_leveling_info(
+  chunked_vector<log_compaction_meta_ptr> logs) const {
+    if (logs.empty()) {
+        co_return;
+    }
+
+    auto target_size
+      = config::shard_local_cfg().cloud_topics_reconciliation_max_object_size();
+    // TODO: Replace with cluster config.
+    constexpr double leveling_object_size_threshold = 0.5;
+    auto min_acceptable = static_cast<size_t>(
+      static_cast<double>(target_size) * leveling_object_size_threshold);
+
+    chunked_vector<metastore::leveling_info_spec> specs;
+    specs.reserve(logs.size());
+    for (const auto& log : logs) {
+        specs.emplace_back(
+          metastore::leveling_info_spec{log->tidp, min_acceptable});
+    }
+
+    auto leveling_infos_res = co_await _metastore->get_leveling_infos(specs);
+    if (!leveling_infos_res.has_value()) {
+        vlog(
+          compaction_log.warn,
+          "Failed to retrieve leveling info from metastore: {}",
+          leveling_infos_res.error());
+        co_return;
+    }
+
+    auto& leveling_infos = leveling_infos_res.value();
+    auto now = model::timestamp::now();
+    for (const auto& log : logs) {
+        auto it = leveling_infos.find(log->tidp);
+        if (it == leveling_infos.end()) {
+            continue;
+        }
+
+        auto& result = it->second;
+        if (!result.has_value()) {
+            vlog(
+              compaction_log.warn,
+              "Failed to collect leveling info for CTP {}: {}",
+              log->ntp,
+              result.error());
+            continue;
+        }
+
+        log->leveling_info_and_ts = leveling_info_and_timestamp{
+          .info = std::move(result).value(), .collected_at = now};
+
+        vlog(
+          compaction_log.debug,
+          "Leveling info for CTP {} returned {}",
+          log->ntp,
+          log->leveling_info_and_ts->info);
+    }
+}
+
 log_info_collector make_default_log_info_collector(
   metastore* metastore,
   cluster::metadata_cache* metadata_cache,

--- a/src/v/cloud_topics/level_one/maintenance/log_info_collector.cc
+++ b/src/v/cloud_topics/level_one/maintenance/log_info_collector.cc
@@ -39,9 +39,9 @@ inline bool needs_compaction(
           ? topic_mcl.value()
           : config::shard_local_cfg().max_compaction_lag_ms();
     return compaction::log_needs_compaction(
-      log.info_and_ts->info.dirty_ratio,
+      log.compaction_info_and_ts->info.dirty_ratio,
       min_cleanable_dirty_ratio,
-      log.info_and_ts->info.earliest_dirty_ts,
+      log.compaction_info_and_ts->info.earliest_dirty_ts,
       max_compaction_lag_ms);
 }
 
@@ -190,11 +190,12 @@ log_info_collector::get_logs_to_collect(
             continue;
         }
 
-        if (log.info_and_ts.has_value()) {
+        if (log.compaction_info_and_ts.has_value()) {
             auto sample_interval
               = config::shard_local_cfg().cloud_topics_compaction_interval_ms();
             auto delta = to_time_point(collection_timestamp)
-                         - to_time_point(log.info_and_ts->collected_at);
+                         - to_time_point(
+                           log.compaction_info_and_ts->collected_at);
             if (delta <= sample_interval) {
                 vlog(
                   compaction_log.debug,
@@ -305,7 +306,7 @@ void log_info_collector::populate_log_infos(
         auto max_compactible_offset = offset_it->second;
 
         log.has_seen_reconciled_data = true;
-        log.info_and_ts = compaction_info_and_timestamp{
+        log.compaction_info_and_ts = compaction_info_and_timestamp{
           .info = std::move(compaction_info).value(),
           .collected_at = collection_timestamp,
           .max_compactible_offset = max_compactible_offset};
@@ -315,7 +316,7 @@ void log_info_collector::populate_log_infos(
           "Compaction info for CTP {} returned {} with max_compactible_offset: "
           "{}",
           log.ntp,
-          log.info_and_ts->info,
+          log.compaction_info_and_ts->info,
           max_compactible_offset);
 
         if (log.state != log_compaction_meta::log_state::idle) {

--- a/src/v/cloud_topics/level_one/maintenance/log_info_collector.h
+++ b/src/v/cloud_topics/level_one/maintenance/log_info_collector.h
@@ -98,6 +98,12 @@ public:
     ss::future<>
     collect_info_for_logs(log_set_t&, log_list_t&, log_compaction_queue&) const;
 
+    // Issues a batched get_leveling_infos RPC for the provided logs and
+    // populates each log's leveling_info_and_ts field. Skips logs whose
+    // info cannot be obtained this round.
+    ss::future<>
+    collect_leveling_info(chunked_vector<log_compaction_meta_ptr> logs) const;
+
 private:
     // Returns a container of `compaction_info_spec` to sample the metastore
     // with based on the input `log_list_t`.

--- a/src/v/cloud_topics/level_one/maintenance/log_info_collector.h
+++ b/src/v/cloud_topics/level_one/maintenance/log_info_collector.h
@@ -83,16 +83,18 @@ public:
       std::unique_ptr<topic_cfg_provider>,
       std::unique_ptr<max_compactible_offset_provider>);
 
-    // Populates `info_and_ts` within `log_compaction_meta`s from the provided
-    // `log_list_t` by collecting each log's compaction info from the metastore.
-    // It is not guaranteed that every log present in `log_list_t` will have its
-    // `info_and_ts` set e.g. due to concurrent removal or metastore errors.
-    // If a log already has `info_and_ts` set, it will not be collected again
-    // until an interval has elapsed and the current `info_and_ts` is determined
-    // stale. Additionally, logs that have an inflight compaction in process do
-    // not need to be collected. Logs that have their information collected and
-    // deemed eligible for compaction will also have their `lw_shared_ptr`
-    // copied into the `log_compaction_queue` for future compaction.
+    // Populates `compaction_info_and_ts` within `log_compaction_meta`s from
+    // the provided `log_list_t` by collecting each log's compaction info from
+    // the metastore. It is not guaranteed that every log present in
+    // `log_list_t` will have its `compaction_info_and_ts` set e.g. due to
+    // concurrent removal or metastore errors. If a log already has
+    // `compaction_info_and_ts` set, it will not be collected again until an
+    // interval has elapsed and the current `compaction_info_and_ts` is
+    // determined stale. Additionally, logs that have an inflight compaction in
+    // process do not need to be collected. Logs that have their information
+    // collected and deemed eligible for compaction will also have their
+    // `lw_shared_ptr` copied into the `log_compaction_queue` for future
+    // compaction.
     ss::future<>
     collect_info_for_logs(log_set_t&, log_list_t&, log_compaction_queue&) const;
 

--- a/src/v/cloud_topics/level_one/maintenance/meta.h
+++ b/src/v/cloud_topics/level_one/maintenance/meta.h
@@ -33,6 +33,13 @@ struct compaction_info_and_timestamp {
     kafka::offset max_compactible_offset;
 };
 
+// Contains leveling information collected from the metastore and the time at
+// which it was obtained.
+struct leveling_info_and_timestamp {
+    metastore::leveling_info_response info;
+    model::timestamp collected_at;
+};
+
 struct log_compaction_meta {
     log_compaction_meta(model::topic_id_partition tidp, model::ntp ntp)
       : tidp(std::move(tidp))
@@ -49,6 +56,11 @@ struct log_compaction_meta {
     // the `collected_at` time. Guaranteed to have a value if `state == queued`
     // or `state == inflight`.
     std::optional<compaction_info_and_timestamp> compaction_info_and_ts{
+      std::nullopt};
+    // If set, leveling metadata for this log obtained from the metastore at
+    // `collected_at` time. Guaranteed to have a value if this log is queued
+    // or inflight as a leveling job.
+    std::optional<leveling_info_and_timestamp> leveling_info_and_ts{
       std::nullopt};
     // If set, this is the shard on which the log is currently undergoing an
     // inflight compaction. Guaranteed to have a value if `state == inflight`.

--- a/src/v/cloud_topics/level_one/maintenance/meta.h
+++ b/src/v/cloud_topics/level_one/maintenance/meta.h
@@ -48,7 +48,8 @@ struct log_compaction_meta {
     // If set, this is cached compaction metadata obtained from the metastore at
     // the `collected_at` time. Guaranteed to have a value if `state == queued`
     // or `state == inflight`.
-    std::optional<compaction_info_and_timestamp> info_and_ts{std::nullopt};
+    std::optional<compaction_info_and_timestamp> compaction_info_and_ts{
+      std::nullopt};
     // If set, this is the shard on which the log is currently undergoing an
     // inflight compaction. Guaranteed to have a value if `state == inflight`.
     std::optional<ss::shard_id> inflight_shard{std::nullopt};

--- a/src/v/cloud_topics/level_one/maintenance/scheduler.h
+++ b/src/v/cloud_topics/level_one/maintenance/scheduler.h
@@ -128,7 +128,7 @@ private:
 
     // Container of pointers to logs in `_logs/_logs_list` which have sampled
     // metadata available and are available for compaction- i.e
-    // `log->info_and_ts` is guaranteed to have a value.
+    // `log->compaction_info_and_ts` is guaranteed to have a value.
     log_compaction_queue _compaction_queue;
 
     // TODO: remove this once more cluster objects speak `topic_id_partition`.

--- a/src/v/cloud_topics/level_one/maintenance/scheduling_policies.h
+++ b/src/v/cloud_topics/level_one/maintenance/scheduling_policies.h
@@ -41,11 +41,13 @@ private:
           const log_compaction_meta_ptr& a,
           const log_compaction_meta_ptr& b) noexcept {
             vassert(
-              a->info_and_ts.has_value() && b->info_and_ts.has_value(),
-              "Sorting policy applied to logs without info_and_ts assigned- "
+              a->compaction_info_and_ts.has_value()
+                && b->compaction_info_and_ts.has_value(),
+              "Sorting policy applied to logs without compaction_info_and_ts "
+              "assigned- "
               "concurrency issue?");
-            return a->info_and_ts->info.dirty_ratio
-                   > b->info_and_ts->info.dirty_ratio;
+            return a->compaction_info_and_ts->info.dirty_ratio
+                   > b->compaction_info_and_ts->info.dirty_ratio;
         }
     };
 };
@@ -62,11 +64,13 @@ private:
           const log_compaction_meta_ptr& a,
           const log_compaction_meta_ptr& b) noexcept {
             vassert(
-              a->info_and_ts.has_value() && b->info_and_ts.has_value(),
-              "Sorting policy applied to logs without info_and_ts assigned- "
+              a->compaction_info_and_ts.has_value()
+                && b->compaction_info_and_ts.has_value(),
+              "Sorting policy applied to logs without compaction_info_and_ts "
+              "assigned- "
               "concurrency issue?");
-            return a->info_and_ts->info.earliest_dirty_ts
-                   < b->info_and_ts->info.earliest_dirty_ts;
+            return a->compaction_info_and_ts->info.earliest_dirty_ts
+                   < b->compaction_info_and_ts->info.earliest_dirty_ts;
         }
     };
 };

--- a/src/v/cloud_topics/level_one/maintenance/tests/log_info_collector_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/tests/log_info_collector_test.cc
@@ -84,3 +84,49 @@ TEST_F(LogInfoCollectorTestFixture, TestInfoCollector) {
           sample->compaction_info_and_ts->info.earliest_dirty_ts.has_value());
     }
 }
+
+TEST_F(LogInfoCollectorTestFixture, TestSampleLevelingInfo) {
+    auto cfg_provider = std::make_unique<fake_cfg_provider>();
+    auto offset_provider = std::make_unique<fake_offset_provider>();
+    l1::log_info_collector log_info_collector(
+      &_metastore, std::move(cfg_provider), std::move(offset_provider));
+
+    auto [ntp, tidp] = make_ntidp("leveling_topic");
+    auto log_ptr = ss::make_lw_shared<l1::log_compaction_meta>(tidp, ntp);
+
+    // Seed the metastore with two small objects for this partition. With the
+    // default config (max_object_size=80MiB, threshold=0.5 =>
+    // min_acceptable=40MiB), each object is undersized. The leveling range
+    // builder only emits a range when it sees a run of *two or more*
+    // consecutive undersized extents (singletons can't reduce extent count),
+    // so we need at least two objects to produce a non-empty range.
+    model::offset o{0};
+    {
+        auto batches = model::test::make_random_batches(o, 10).get();
+        o = model::next_offset(batches.back().last_offset());
+        std::vector<tidp_batches_t> bs;
+        bs.emplace_back(tidp, std::move(batches));
+        make_l1_objects(std::move(bs)).get();
+    }
+
+    {
+        auto batches = model::test::make_random_batches(o, 10).get();
+        std::vector<tidp_batches_t> bs;
+        bs.emplace_back(tidp, std::move(batches));
+        make_l1_objects(std::move(bs)).get();
+    }
+
+    chunked_vector<l1::log_compaction_meta_ptr> logs;
+    logs.push_back(log_ptr);
+
+    log_info_collector.collect_leveling_info(std::move(logs)).get();
+
+    ASSERT_TRUE(log_ptr->leveling_info_and_ts.has_value());
+    const auto& ranges = log_ptr->leveling_info_and_ts->info.ranges;
+    ASSERT_FALSE(ranges.empty());
+    size_t total_size_bytes = 0;
+    for (const auto& r : ranges) {
+        total_size_bytes += r.size_bytes;
+    }
+    ASSERT_GT(total_size_bytes, 0u);
+}

--- a/src/v/cloud_topics/level_one/maintenance/tests/log_info_collector_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/tests/log_info_collector_test.cc
@@ -78,8 +78,9 @@ TEST_F(LogInfoCollectorTestFixture, TestInfoCollector) {
     while (!cached_metadata.empty()) {
         auto sample = cached_metadata.top();
         cached_metadata.pop();
-        ASSERT_TRUE(sample->info_and_ts.has_value());
-        ASSERT_FLOAT_EQ(sample->info_and_ts->info.dirty_ratio, 1.0);
-        ASSERT_TRUE(sample->info_and_ts->info.earliest_dirty_ts.has_value());
+        ASSERT_TRUE(sample->compaction_info_and_ts.has_value());
+        ASSERT_FLOAT_EQ(sample->compaction_info_and_ts->info.dirty_ratio, 1.0);
+        ASSERT_TRUE(
+          sample->compaction_info_and_ts->info.earliest_dirty_ts.has_value());
     }
 }

--- a/src/v/cloud_topics/level_one/maintenance/worker.cc
+++ b/src/v/cloud_topics/level_one/maintenance/worker.cc
@@ -169,7 +169,7 @@ ss::future<> compaction_worker::compact_log(log_compaction_meta* log) {
 
     auto ctxlog = prefix_logger(compaction_log, fmt::format("{}", ntp));
 
-    if (!log->info_and_ts.has_value()) {
+    if (!log->compaction_info_and_ts.has_value()) {
         vlog(
           ctxlog.error,
           "Log in compaction process did not have metastore information "
@@ -183,12 +183,16 @@ ss::future<> compaction_worker::compact_log(log_compaction_meta* log) {
     _inflight_ntp = ntp;
 
     auto compaction_offsets = metastore::compaction_offsets_response{
-      .dirty_ranges = log->info_and_ts->info.offsets_response.dirty_ranges,
+      .dirty_ranges
+      = log->compaction_info_and_ts->info.offsets_response.dirty_ranges,
       .removable_tombstone_ranges
-      = log->info_and_ts->info.offsets_response.removable_tombstone_ranges};
-    auto expected_compaction_epoch = log->info_and_ts->info.compaction_epoch;
-    auto start_offset = log->info_and_ts->info.start_offset;
-    auto max_compactible_offset = log->info_and_ts->max_compactible_offset;
+      = log->compaction_info_and_ts->info.offsets_response
+          .removable_tombstone_ranges};
+    auto expected_compaction_epoch
+      = log->compaction_info_and_ts->info.compaction_epoch;
+    auto start_offset = log->compaction_info_and_ts->info.start_offset;
+    auto max_compactible_offset
+      = log->compaction_info_and_ts->max_compactible_offset;
 
     // Lazy initialization of offset map.
     if (!_map) {

--- a/src/v/cloud_topics/level_one/maintenance/worker_manager.cc
+++ b/src/v/cloud_topics/level_one/maintenance/worker_manager.cc
@@ -93,7 +93,7 @@ void worker_manager::complete_work(log_compaction_meta* log) {
       "Expected log state to be inflight when completing work");
     log->state = log_compaction_meta::log_state::idle;
     log->inflight_shard.reset();
-    log->info_and_ts.reset();
+    log->compaction_info_and_ts.reset();
 
     _probe.log_compacted();
 }


### PR DESCRIPTION
Add a `leveling_info_and_ts` sibling field on `log_compaction_meta` and `log_info_collector::collect_leveling_info()` which issues a batched `get_leveling_infos` RPC and populates the new field for the provided logs.

## Backports Required


- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
