### PR TITLE
`rptest`: remove `CLOUD_TOPICS_CONFIG_STR` from `shadow_linking_rnot_test`

### DIFF
--- a/tests/rptest/tests/shadow_linking_rnot_test.py
+++ b/tests/rptest/tests/shadow_linking_rnot_test.py
@@ -23,7 +23,6 @@ from rptest.services.multi_cluster_services import (
     SecondaryClusterArgs,
 )
 from rptest.services.redpanda import (
-    CLOUD_TOPICS_CONFIG_STR,
     PandaproxyConfig,
     SISettings,
     SchemaRegistryConfig,
@@ -278,7 +277,6 @@ class ShadowLinkingRandomOpsTest(ShadowLinkTestBase):
                 ),
                 extra_rp_conf={
                     "group_new_member_join_timeout": 3000,
-                    CLOUD_TOPICS_CONFIG_STR: True,
                 },
             ),
             extra_rp_conf={
@@ -295,7 +293,6 @@ class ShadowLinkingRandomOpsTest(ShadowLinkTestBase):
                 "retention_local_trim_interval": 5000,
                 "partition_autobalancing_tick_interval_ms": 2000,
                 "group_new_member_join_timeout": 3000,
-                CLOUD_TOPICS_CONFIG_STR: True,
             },
             schema_registry_config=SchemaRegistryConfig(),
             pandaproxy_config=PandaproxyConfig(),

--- a/tools/type-checking/type-check-strictness.json
+++ b/tools/type-checking/type-check-strictness.json
@@ -424,7 +424,6 @@
         "rptest/tests/shadow_indexing_admin_api_test.py",
         "rptest/tests/shadow_indexing_compacted_topic_test.py",
         "rptest/tests/shadow_indexing_tx_test.py",
-        "rptest/tests/shadow_linking_rnot_test.py",
         "rptest/tests/shard_placement_test.py",
         "rptest/tests/simple_e2e_test.py",
         "rptest/tests/storage_resources_test.py",


### PR DESCRIPTION
Merge race (https://github.com/redpanda-data/redpanda/pull/30435 and https://github.com/redpanda-data/redpanda/pull/30508). This was removed in a prior commit, and isn't required for the cloud topics testing anymore.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
