### PR TITLE
iceberg: don't reject new fields with required descendants

### DIFF
--- a/src/v/iceberg/compatibility.cc
+++ b/src/v/iceberg/compatibility.cc
@@ -477,19 +477,38 @@ schema_transform_result validate_schema_transform(
         return schema_evolution_errc::partition_spec_conflict;
     }
     auto state = annotate_res.value();
-    if (
-      auto res = for_each_field(
-        dest,
-        [&state, &spec](nested_field* f) {
-            vassert(
-              f->has_evolution_metadata(),
-              "Should have visited every destination field");
-            return std::visit(
-              validate_transform_visitor{f, state, spec}, f->meta);
-        });
-      res.has_error()) {
-        return res.error();
+
+    chunked_vector<nested_field*> stack;
+    reverse_field_collecting_visitor{stack}(dest);
+
+    while (!stack.empty()) {
+        auto* field = stack.back();
+        stack.pop_back();
+        if (field == nullptr) {
+            return schema_evolution_errc::null_nested_field;
+        }
+        vassert(
+          field->has_evolution_metadata(),
+          "Should have visited every destination field");
+        const bool is_new_field = std::holds_alternative<nested_field::is_new>(
+          field->meta);
+        if (
+          auto res = std::visit(
+            validate_transform_visitor{field, state, spec}, field->meta);
+          res.has_error()) {
+            return res.error();
+        }
+        if (is_new_field) {
+            // Treat a new field's substructure as part of the new type
+            // definition. Required descendants (map keys, list elements
+            // declared required, struct fields declared required) must not
+            // trigger new_required_field; that check applies only to
+            // top-level new columns.
+            continue;
+        }
+        std::visit(reverse_field_collecting_visitor(stack), field->type);
     }
+
     return state;
 }
 

--- a/src/v/iceberg/tests/compatibility_test.cc
+++ b/src/v/iceberg/tests/compatibility_test.cc
@@ -460,6 +460,112 @@ static const std::vector<struct_evolution_test_case> valid_cases{
       },
   },
   struct_evolution_test_case{
+    .description = "we can add a new field with required descendants "
+                   "(map key is structurally required)",
+    .generator =
+      [](unique_id_generator& ids) {
+          struct_type s{};
+          s.fields.emplace_back(
+            nested_field::create(
+              ids.get_one(), "foo", field_required::yes, int_type{}));
+          return s;
+      },
+    .update =
+      [](struct_type& s) {
+          s.fields.emplace_back(
+            nested_field::create(
+              0,
+              "a_map",
+              field_required::no,
+              map_type::create(
+                0, string_type{}, 0, field_required::no, long_type{})));
+      },
+    .validator =
+      [](const struct_type& src, const struct_type& dst) {
+          if (dst.fields.size() != 2) {
+              return false;
+          }
+          const auto& new_map_field = dst.fields.back();
+          if (!added(*new_map_field)) {
+              return false;
+          }
+          const auto& new_map = get<map_type>(new_map_field);
+          return updated(*src.fields.front(), *dst.fields.front())
+                 && added(*new_map.key_field) && added(*new_map.value_field);
+      },
+  },
+  struct_evolution_test_case{
+    .description = "we can add a new field with required descendants "
+                   "(list element declared required)",
+    .generator =
+      [](unique_id_generator& ids) {
+          struct_type s{};
+          s.fields.emplace_back(
+            nested_field::create(
+              ids.get_one(), "foo", field_required::yes, int_type{}));
+          return s;
+      },
+    .update =
+      [](struct_type& s) {
+          s.fields.emplace_back(
+            nested_field::create(
+              0,
+              "a_list",
+              field_required::no,
+              list_type::create(0, field_required::yes, long_type{})));
+      },
+    .validator =
+      [](const struct_type& src, const struct_type& dst) {
+          if (dst.fields.size() != 2) {
+              return false;
+          }
+          const auto& new_list_field = dst.fields.back();
+          if (!added(*new_list_field)) {
+              return false;
+          }
+          const auto& new_list = get<list_type>(new_list_field);
+          return updated(*src.fields.front(), *dst.fields.front())
+                 && added(*new_list.element_field);
+      },
+  },
+  struct_evolution_test_case{
+    .description = "we can add a new field with required descendants "
+                   "(struct subfield declared required)",
+    .generator =
+      [](unique_id_generator& ids) {
+          struct_type s{};
+          s.fields.emplace_back(
+            nested_field::create(
+              ids.get_one(), "foo", field_required::yes, int_type{}));
+          return s;
+      },
+    .update =
+      [](struct_type& s) {
+          struct_type inner{};
+          inner.fields.emplace_back(
+            nested_field::create(0, "inner", field_required::yes, int_type{}));
+          s.fields.emplace_back(
+            nested_field::create(
+              0, "a_struct", field_required::no, std::move(inner)));
+      },
+    .validator =
+      [](const struct_type& src, const struct_type& dst) {
+          if (dst.fields.size() != 2) {
+              return false;
+          }
+          const auto& new_struct_field = dst.fields.back();
+          if (!added(*new_struct_field)) {
+              return false;
+          }
+          const auto& new_struct = get<struct_type>(new_struct_field);
+          if (new_struct.fields.size() != 1) {
+              return false;
+          }
+          return updated(*src.fields.front(), *dst.fields.front())
+                 && added(*new_struct.fields.front());
+      },
+  },
+  struct_evolution_test_case{
     .description = "we can 'add' nested fields",
     .generator = [](unique_id_generator&) { return struct_type{}; },
     .update =


### PR DESCRIPTION
validate_schema_transform incorrectly rejected adding a new optional
column whose nested type contains structurally-required descendants
(e.g. an optional map, whose keys are always required). The walk
visited every annotated field and triggered new_required_field on the
nested required key/element.

Stop descending into a subtree once an is_new ancestor is encountered:
the substructure is part of the new type's definition, not a separate
top-level addition. The same reasoning applies to required list
elements and required struct subfields, though in practice only the
map-key case arises today. The datalake record translator coerces
all incoming schema fields to optional (see record_translator.cc),
leaving map keys as the only structurally-required descendants. The
list and struct cases are covered by regression tests for
completeness.

https://redpandadata.atlassian.net/browse/CORE-16367

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [ ] v25.2.x

## Release Notes

### Bug Fixes

* Fix schema evolution incorrectly rejecting new optional Iceberg columns whose nested types contain structurally-required fields (e.g. maps, whose keys are always required).


<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Fix schema evolution incorrectly rejecting new optional Iceberg columns whose nested types contain structurally-required fields (e.g. maps, whose keys are always required).

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
