### PR TITLE
`rptest`: some shadow indexing & linking CI fixes

### DIFF
--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -1774,12 +1774,18 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             err_msg=f"Topic {topic.name} not found in target cluster",
         )
 
+        cloud_backed = storage_mode in (
+            TopicSpec.STORAGE_MODE_CLOUD,
+            TopicSpec.STORAGE_MODE_TIERED_CLOUD,
+        )
+        progress_timeout = 120 if cloud_backed else 60
+
         with self.producer_consumer(topic=topic.name, msg_size=128, msg_cnt=100000):
             with (
                 self.create_source_failure_injector(),
                 self.create_target_failure_injector(),
             ):
-                self.verify()
+                self.verify(progress_timeout=progress_timeout)
 
         self.logger.info("Starting cycle looking for shadow topic status")
         wait_until(

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -1164,7 +1164,9 @@ class ShadowLinkPreAllocTestBase(ShadowLinkTestBase):
         finally:
             self.verifier.stop_kgo_services()
 
-    def verify(self):
-        success, error = self.verifier.wait_and_verify()
+    def verify(self, progress_timeout: int = 60):
+        success, error = self.verifier.wait_and_verify(
+            progress_timeout=progress_timeout
+        )
 
         assert success, f"Verification failed: {error}"

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -795,6 +795,15 @@ class EndToEndShadowIndexingTestCompactedTopic(EndToEndShadowIndexingBase):
         ),
     )
 
+    def __init__(self, test_context):
+        super().__init__(
+            test_context,
+            extra_rp_conf={
+                "enable_leader_balancer": False,
+                "partition_autobalancing_mode": "off",
+            },
+        )
+
     def _prime_compacted_topic(self, segment_count):
         # Set compaction interval high at first, so we can get enough segments in log
         rpk_client = RpkTool(self.redpanda)

--- a/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
+++ b/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
@@ -294,11 +294,21 @@ class TSWithAlreadyCompactedTopic(EndToEndTest):
         )
         self.producer.stop()
 
+        def topic_segments_size(stats):
+            return [
+                size
+                for path, size in stats
+                if path.suffix == ".log"
+                and len(path.parts) >= 2
+                and path.parts[0] == "kafka"
+                and path.parts[1] == topic_name
+            ]
+
         # Collect original file sizes
         original_per_node_stat = {}
         for node in self.redpanda.nodes:
             stats = self.redpanda.data_stat(node)
-            total = sum([size for path, size in stats if path.suffix == ".log"])
+            total = sum(topic_segments_size(stats))
             original_per_node_stat[node] = total
             self.logger.info(f"Size before compaction {total}")
             assert total > 0, "No data found in the data dir"
@@ -313,9 +323,7 @@ class TSWithAlreadyCompactedTopic(EndToEndTest):
             worst_ratio = 0.0
             for node in self.redpanda.nodes:
                 new_stats = self.redpanda.data_stat(node)
-                new_size = sum(
-                    [size for path, size in new_stats if path.suffix == ".log"]
-                )
+                new_size = sum(topic_segments_size(new_stats))
                 old_size = original_per_node_stat[node]
                 ratio = new_size / old_size
                 worst_ratio = max(worst_ratio, ratio)


### PR DESCRIPTION
See commits.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
