### PR TITLE
datalake: trace schema evolution inputs

### DIFF
--- a/src/v/datalake/catalog_schema_manager.cc
+++ b/src/v/datalake/catalog_schema_manager.cc
@@ -119,6 +119,16 @@ checked<schema_update_required, schema_manager::errc> apply_evolution_rules(
           table_id);
         return schema_manager::errc::failed;
     }
+
+    vlog(
+      datalake_log.trace,
+      "check_schema_compat table={} dest={} source={} spec={} norm={}",
+      table_id,
+      dest_type,
+      schema.schema_struct,
+      *cur_spec,
+      norm);
+
     auto compat_res = check_schema_compat(
       dest_type, schema.schema_struct.copy(), *cur_spec, norm);
     if (compat_res.has_error()) {
@@ -235,6 +245,14 @@ catalog_schema_manager::ensure_table_schema(
           table_id);
         co_return errc::failed;
     }
+
+    vlog(
+      datalake_log.trace,
+      "Current schema for table {}: id={} struct={}, writer struct: {}",
+      table_id,
+      current_schema->schema_id,
+      current_schema->schema_struct,
+      writer_struct_type);
 
     std::optional<iceberg::struct_type> new_schema;
     if (use_schema_merging) {


### PR DESCRIPTION
Add trace logs for the current schema, writer struct, and the inputs to the iceberg compatibility check (dest/source/spec/norm). These make it possible to reconstruct, from logs alone, why a schema evolution attempt produced a given outcome for a specific table.

## Backports Required

- [x] v26.1.x
- [x] v25.3.x
- [ ] v25.2.x

## Release Notes

* none