### PR TITLE
[v25.3.x] iceberg: don't reject new fields with required descendants

### DIFF
--- a/src/v/iceberg/compatibility.cc
+++ b/src/v/iceberg/compatibility.cc
@@ -463,18 +463,37 @@ schema_transform_result validate_schema_transform(
         return schema_evolution_errc::partition_spec_conflict;
     }
     auto state = annotate_res.value();
-    if (auto res = for_each_field(
-          dest,
-          [&state, &spec](nested_field* f) {
-              vassert(
-                f->has_evolution_metadata(),
-                "Should have visited every destination field");
-              return std::visit(
-                validate_transform_visitor{f, state, spec}, f->meta);
-          });
-        res.has_error()) {
-        return res.error();
+
+    chunked_vector<nested_field*> stack;
+    reverse_field_collecting_visitor{stack}(dest);
+
+    while (!stack.empty()) {
+        auto* field = stack.back();
+        stack.pop_back();
+        if (field == nullptr) {
+            return schema_evolution_errc::null_nested_field;
+        }
+        vassert(
+          field->has_evolution_metadata(),
+          "Should have visited every destination field");
+        const bool is_new_field = std::holds_alternative<nested_field::is_new>(
+          field->meta);
+        if (auto res = std::visit(
+              validate_transform_visitor{field, state, spec}, field->meta);
+            res.has_error()) {
+            return res.error();
+        }
+        if (is_new_field) {
+            // Treat a new field's substructure as part of the new type
+            // definition. Required descendants (map keys, list elements
+            // declared required, struct fields declared required) must not
+            // trigger new_required_field; that check applies only to
+            // top-level new columns.
+            continue;
+        }
+        std::visit(reverse_field_collecting_visitor(stack), field->type);
     }
+
     return state;
 }
 

--- a/src/v/iceberg/tests/compatibility_test.cc
+++ b/src/v/iceberg/tests/compatibility_test.cc
@@ -461,6 +461,112 @@ static const std::vector<struct_evolution_test_case> valid_cases{
       },
   },
   struct_evolution_test_case{
+    .description = "we can add a new field with required descendants "
+                   "(map key is structurally required)",
+    .generator =
+      [](unique_id_generator& ids) {
+          struct_type s{};
+          s.fields.emplace_back(
+            nested_field::create(
+              ids.get_one(), "foo", field_required::yes, int_type{}));
+          return s;
+      },
+    .update =
+      [](struct_type& s) {
+          s.fields.emplace_back(
+            nested_field::create(
+              0,
+              "a_map",
+              field_required::no,
+              map_type::create(
+                0, string_type{}, 0, field_required::no, long_type{})));
+      },
+    .validator =
+      [](const struct_type& src, const struct_type& dst) {
+          if (dst.fields.size() != 2) {
+              return false;
+          }
+          const auto& new_map_field = dst.fields.back();
+          if (!added(*new_map_field)) {
+              return false;
+          }
+          const auto& new_map = get<map_type>(new_map_field);
+          return updated(*src.fields.front(), *dst.fields.front())
+                 && added(*new_map.key_field) && added(*new_map.value_field);
+      },
+  },
+  struct_evolution_test_case{
+    .description = "we can add a new field with required descendants "
+                   "(list element declared required)",
+    .generator =
+      [](unique_id_generator& ids) {
+          struct_type s{};
+          s.fields.emplace_back(
+            nested_field::create(
+              ids.get_one(), "foo", field_required::yes, int_type{}));
+          return s;
+      },
+    .update =
+      [](struct_type& s) {
+          s.fields.emplace_back(
+            nested_field::create(
+              0,
+              "a_list",
+              field_required::no,
+              list_type::create(0, field_required::yes, long_type{})));
+      },
+    .validator =
+      [](const struct_type& src, const struct_type& dst) {
+          if (dst.fields.size() != 2) {
+              return false;
+          }
+          const auto& new_list_field = dst.fields.back();
+          if (!added(*new_list_field)) {
+              return false;
+          }
+          const auto& new_list = get<list_type>(new_list_field);
+          return updated(*src.fields.front(), *dst.fields.front())
+                 && added(*new_list.element_field);
+      },
+  },
+  struct_evolution_test_case{
+    .description = "we can add a new field with required descendants "
+                   "(struct subfield declared required)",
+    .generator =
+      [](unique_id_generator& ids) {
+          struct_type s{};
+          s.fields.emplace_back(
+            nested_field::create(
+              ids.get_one(), "foo", field_required::yes, int_type{}));
+          return s;
+      },
+    .update =
+      [](struct_type& s) {
+          struct_type inner{};
+          inner.fields.emplace_back(
+            nested_field::create(0, "inner", field_required::yes, int_type{}));
+          s.fields.emplace_back(
+            nested_field::create(
+              0, "a_struct", field_required::no, std::move(inner)));
+      },
+    .validator =
+      [](const struct_type& src, const struct_type& dst) {
+          if (dst.fields.size() != 2) {
+              return false;
+          }
+          const auto& new_struct_field = dst.fields.back();
+          if (!added(*new_struct_field)) {
+              return false;
+          }
+          const auto& new_struct = get<struct_type>(new_struct_field);
+          if (new_struct.fields.size() != 1) {
+              return false;
+          }
+          return updated(*src.fields.front(), *dst.fields.front())
+                 && added(*new_struct.fields.front());
+      },
+  },
+  struct_evolution_test_case{
     .description = "we can 'add' nested fields",
     .generator = [](unique_id_generator&) { return struct_type{}; },
     .update =


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30585

- Command: git cherry-pick -x 07afd257d7
- Commits backported: 1
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-30585-v25.3.x-1779471711

## Conflict details

- 07afd257d7 (src/v/iceberg/compatibility.cc): `validate_schema_transform` on v25.3.x still used the `for_each_field`-with-lambda traversal; the PR replaces it with a stack-based walk that stops descending once an `is_new` ancestor is reached. Took the incoming side verbatim (helpers `chunked_vector` and `reverse_field_collecting_visitor` are already available via the existing `compatibility_utils.h` include), preserving the intended bug fix.
