### PR TITLE
tools: add spark-sql and duckdb helpers for Iceberg REST catalog

### DIFF
--- a/tools/duckdb.sh
+++ b/tools/duckdb.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+#
+# Launch the DuckDB CLI pre-wired to the local Iceberg REST catalog and
+# MinIO started by tools/dev_cluster.py. Starts in ~1s vs ~30s for
+# tools/spark-sql.sh; full SQL (reads and writes) via DuckDB's iceberg
+# extension.
+#
+# Override defaults via env, e.g.:
+#   REST_URI=http://localhost:8181 S3_ENDPOINT=http://localhost:9000 \
+#   WAREHOUSE=s3://panda-bucket/iceberg ./tools/duckdb.sh
+
+set -euo pipefail
+
+REST_URI="${REST_URI:-http://localhost:8181}"
+S3_ENDPOINT="${S3_ENDPOINT:-http://localhost:9000}"
+WAREHOUSE="${WAREHOUSE:-s3://panda-bucket/iceberg}"
+S3_ACCESS_KEY="${S3_ACCESS_KEY:-minioadmin}"
+S3_SECRET_KEY="${S3_SECRET_KEY:-minioadmin}"
+S3_REGION="${S3_REGION:-panda-region}"
+CATALOG_NAME="${CATALOG_NAME:-rp}"
+NAMESPACE="${NAMESPACE:-redpanda}"
+
+DUCKDB_VERSION="${DUCKDB_VERSION:-v1.5.3}"
+
+DATA_DIR="${DATA_DIR:-${BUILD_WORKSPACE_DIRECTORY:-$PWD}/data}"
+DUCKDB_DIR="$DATA_DIR/duckdb"
+mkdir -p "$DUCKDB_DIR"
+
+# DuckDB's S3 secret endpoint is host:port (no scheme).
+s3_endpoint_host="${S3_ENDPOINT#http://}"
+s3_endpoint_host="${s3_endpoint_host#https://}"
+s3_use_ssl="false"
+[[ $S3_ENDPOINT == https://* ]] && s3_use_ssl="true"
+
+case "$(uname -m)" in
+  x86_64) duckdb_asset="duckdb_cli-linux-amd64.zip" ;;
+  aarch64) duckdb_asset="duckdb_cli-linux-arm64.zip" ;;
+  *)
+    echo "unsupported architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+DOWNLOAD_TMP=
+INIT_SQL=
+cleanup() {
+  [[ -n $DOWNLOAD_TMP ]] && rm -rf "$DOWNLOAD_TMP"
+  [[ -n $INIT_SQL ]] && rm -f "$INIT_SQL"
+}
+trap cleanup EXIT
+
+DUCKDB_BIN="$DUCKDB_DIR/duckdb-$DUCKDB_VERSION"
+if [[ ! -x $DUCKDB_BIN ]]; then
+  echo "downloading DuckDB $DUCKDB_VERSION..." >&2
+  DOWNLOAD_TMP=$(mktemp -d)
+  curl -fsSL -o "$DOWNLOAD_TMP/duckdb.zip" \
+    "https://github.com/duckdb/duckdb/releases/download/$DUCKDB_VERSION/$duckdb_asset"
+  unzip -q "$DOWNLOAD_TMP/duckdb.zip" -d "$DOWNLOAD_TMP"
+  mv "$DOWNLOAD_TMP/duckdb" "$DUCKDB_BIN"
+fi
+
+# Write the init script containing S3 credentials to a private temp file
+# (mode 0600 via mktemp), rather than persisting secrets under $DATA_DIR.
+INIT_SQL=$(mktemp)
+cat >"$INIT_SQL" <<EOF
+.bail on
+INSTALL iceberg;
+LOAD iceberg;
+
+CREATE OR REPLACE SECRET s3_minio (
+    TYPE s3,
+    KEY_ID '$S3_ACCESS_KEY',
+    SECRET '$S3_SECRET_KEY',
+    ENDPOINT '$s3_endpoint_host',
+    REGION '$S3_REGION',
+    URL_STYLE 'path',
+    USE_SSL $s3_use_ssl
+);
+
+ATTACH '$WAREHOUSE' AS $CATALOG_NAME (
+    TYPE iceberg,
+    ENDPOINT '$REST_URI',
+    AUTHORIZATION_TYPE 'none',
+    ACCESS_DELEGATION_MODE 'none'
+);
+
+USE $CATALOG_NAME.$NAMESPACE;
+EOF
+
+if [[ $# -gt 0 ]]; then
+  "$DUCKDB_BIN" -init "$INIT_SQL" -c "$*"
+else
+  "$DUCKDB_BIN" -init "$INIT_SQL"
+fi

--- a/tools/spark-sql.sh
+++ b/tools/spark-sql.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+#
+# Launch spark-sql in Docker connected to the local Iceberg REST catalog
+# started by tools/dev_cluster.py (defaults: REST on :8181, MinIO on :9000,
+# warehouse s3://panda-bucket/iceberg).
+#
+# Override via env, e.g.:
+#   REST_URI=http://localhost:8181 S3_ENDPOINT=http://localhost:9000 \
+#   WAREHOUSE=s3://panda-bucket/iceberg ./tools/spark-sql.sh
+
+set -euo pipefail
+
+REST_URI="${REST_URI:-http://localhost:8181}"
+S3_ENDPOINT="${S3_ENDPOINT:-http://localhost:9000}"
+WAREHOUSE="${WAREHOUSE:-s3://panda-bucket/iceberg}"
+S3_ACCESS_KEY="${S3_ACCESS_KEY:-minioadmin}"
+S3_SECRET_KEY="${S3_SECRET_KEY:-minioadmin}"
+S3_REGION="${S3_REGION:-panda-region}"
+CATALOG_NAME="${CATALOG_NAME:-rp}"
+
+SPARK_IMAGE="${SPARK_IMAGE:-apache/spark:4.0.2}"
+ICEBERG_VERSION="${ICEBERG_VERSION:-1.10.1}"
+ICEBERG_SPARK_RUNTIME="${ICEBERG_SPARK_RUNTIME:-iceberg-spark-runtime-4.0_2.13}"
+
+# Match dev_cluster.py's data directory resolution so spark state (ivy/maven
+# cache, hive history) lives alongside the cluster's data and persists across
+# runs.
+DATA_DIR="${DATA_DIR:-${BUILD_WORKSPACE_DIRECTORY:-$PWD}/data}"
+SPARK_STATE_DIR="${SPARK_STATE_DIR:-$DATA_DIR/spark-home}"
+mkdir -p "$SPARK_STATE_DIR"
+# apache/spark runs as uid 185 (spark) with HOME=/nonexistent; make the
+# mount writable without --user, which breaks Hadoop's JAAS unix login.
+# Only the top-level dir needs to be world-writable — files created inside
+# by the container are already owned by uid 185 and accessible to it.
+chmod 777 "$SPARK_STATE_DIR"
+
+# spark.sql.catalogImplementation=in-memory skips Hive metastore (Derby)
+# init — unused, and otherwise emits warnings.
+# spark.ui.enabled=false skips the Web UI on :4040 — interactive REPL
+# doesn't need it.
+exec docker run --rm -it \
+  --network host \
+  -v "$SPARK_STATE_DIR:/home/spark" \
+  "$SPARK_IMAGE" \
+  /opt/spark/bin/spark-sql \
+  --driver-java-options "-Duser.home=/home/spark" \
+  --conf spark.jars.ivy=/home/spark/.ivy2 \
+  --packages "org.apache.iceberg:${ICEBERG_SPARK_RUNTIME}:${ICEBERG_VERSION},org.apache.iceberg:iceberg-aws-bundle:${ICEBERG_VERSION}" \
+  --conf spark.sql.catalogImplementation=in-memory \
+  --conf spark.ui.enabled=false \
+  --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
+  --conf "spark.sql.catalog.${CATALOG_NAME}=org.apache.iceberg.spark.SparkCatalog" \
+  --conf "spark.sql.catalog.${CATALOG_NAME}.type=rest" \
+  --conf "spark.sql.catalog.${CATALOG_NAME}.cache-enabled=false" \
+  --conf "spark.sql.catalog.${CATALOG_NAME}.uri=${REST_URI}" \
+  --conf "spark.sql.catalog.${CATALOG_NAME}.warehouse=${WAREHOUSE}" \
+  --conf "spark.sql.catalog.${CATALOG_NAME}.io-impl=org.apache.iceberg.aws.s3.S3FileIO" \
+  --conf "spark.sql.catalog.${CATALOG_NAME}.s3.endpoint=${S3_ENDPOINT}" \
+  --conf "spark.sql.catalog.${CATALOG_NAME}.s3.path-style-access=true" \
+  --conf "spark.sql.catalog.${CATALOG_NAME}.s3.access-key-id=${S3_ACCESS_KEY}" \
+  --conf "spark.sql.catalog.${CATALOG_NAME}.s3.secret-access-key=${S3_SECRET_KEY}" \
+  --conf "spark.sql.catalog.${CATALOG_NAME}.client.region=${S3_REGION}" \
+  --conf "spark.sql.defaultCatalog=${CATALOG_NAME}"


### PR DESCRIPTION
Adds two helper scripts that pre-wire SQL CLIs against the local Iceberg
REST catalog and MinIO started by `tools/dev_cluster.py`, so it's a
one-liner to poke at tables produced by a local cluster:

- `tools/spark-sql.sh` — runs `apache/spark` in Docker. Slow start (full
  Spark session), but supports the full Iceberg SQL surface including
  writes.
- `tools/duckdb.sh` — downloads the static DuckDB CLI on first run.
  Sub-second start. Full SQL (reads and writes) via the iceberg extension.

Persistent state lives under the dev cluster's data directory:
- Spark's ivy/maven cache and hive history under `$DATA_DIR/spark-home`
- The DuckDB CLI binary under `$DATA_DIR/duckdb`

All catalog/S3 endpoints and credentials are overridable via env vars.

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none