### PR TITLE
`cluster`: remove shard aggregation for `max_offset` and `under_replicated_partitions`

### DIFF
--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -250,8 +250,7 @@ void replicated_partition_probe::setup_public_metrics(const model::ntp& ntp) {
           },
           sm::description(
             "Latest readable offset of the partition (i.e. high watermark)"),
-          labels)
-          .aggregate({sm::shard_label}),
+          labels),
         sm::make_gauge(
           "under_replicated_replicas",
           [this] {
@@ -266,8 +265,7 @@ void replicated_partition_probe::setup_public_metrics(const model::ntp& ntp) {
           sm::description(
             "Number of under replicated replicas (i.e. replicas "
             "that are live, but not at the latest offest)"),
-          labels)
-          .aggregate({sm::shard_label}),
+          labels),
         // Topic Level Metrics
         sm::make_total_bytes(
           "request_bytes_total",


### PR DESCRIPTION
Missed removing the `sm::shard_label` on these in 263a0e80f.

Aggregating these across shards doesn't reduce the number of metric series, but it does cause an oversized allocation in the `metric_aggregate_by_labels` object, since an `std::unordered_map` is used there to aggregate.

Remove the shard label to prevent this oversized allocation.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
