### PR TITLE
[CORE-16375] `redpanda`: move `cloud_topics_app` shutdown location

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -211,12 +211,6 @@ void application::shutdown() {
         });
     }
 
-    // NOTE: we must shut down the partitions first above to ensure in-flight
-    // replication is stopped, as it may cause cloud topics shutdown to hang.
-    if (cloud_topics_app) {
-        shutdown_with_watchdog(
-          cloud_topics_app, [](auto& app) { return app->stop(); });
-    }
     // Wait for all requests to finish before destructing services that may be
     // used by pending requests.
     if (_kafka_server.ref().local_is_initialized()) {
@@ -227,6 +221,16 @@ void application::shutdown() {
             return kafka_server.stop();
         });
     }
+
+    // Shutdown cloud topics _after_ partitions have been shut down to ensure
+    // in-flight replication is stopped, and _after_ the kafka server in order
+    // to ensure we don't serve any last minute requests with cloud topics
+    // machinery mid tear-down.
+    if (cloud_topics_app) {
+        shutdown_with_watchdog(
+          cloud_topics_app, [](auto& app) { return app->stop(); });
+    }
+
     if (_kafka_conn_quotas.local_is_initialized()) {
         shutdown_with_watchdog(_kafka_conn_quotas, [](auto& conn_quotas) {
             return conn_quotas.stop();


### PR DESCRIPTION
Shutting down cloud topics _before_ stopping the `kafka_server` means any last minute in flight requests might be handled by cloud topics machinery mid-tear down- resulting in undefined behavior and potentially leading to some sort of crash.

Move the `cloud_topics_app` shutdown location till after the kafka server has been shutdown with all of its requests trained to ensure we don't have any race conditions during broker shutdown.

Discovered in a CI run with a segmentation fault present here: https://redpandadata.atlassian.net/browse/CORE-16375

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
