### PR TITLE
[CORE-14033] dt/tests: increase producer concurrency for ct-delete and ct-compact

### DIFF
--- a/tests/rptest/tests/random_node_operations_smoke_test.py
+++ b/tests/rptest/tests/random_node_operations_smoke_test.py
@@ -320,6 +320,7 @@ class RandomNodeOperationsBase(PreallocNodesTest):
             tolerate_data_loss: bool = False,
             iceberg_enabled: bool = False,
             catalog_service: CatalogService | None = None,
+            max_buffered_records: int | None = None,
         ):
             self.test_context = test_context
             self.logger = logger
@@ -335,6 +336,7 @@ class RandomNodeOperationsBase(PreallocNodesTest):
             self.tolerate_data_loss = tolerate_data_loss
             self.iceberg_enabled = iceberg_enabled
             self.catalog_service = catalog_service
+            self.max_buffered_records = max_buffered_records
 
         def _start_producer(self, clean: bool):
             self.producer = KgoVerifierProducer(
@@ -347,6 +349,7 @@ class RandomNodeOperationsBase(PreallocNodesTest):
                 rate_limit_bps=self.rate_limit_bps,
                 key_set_cardinality=self.key_set_cardinality,
                 tolerate_data_loss=self.tolerate_data_loss,
+                max_buffered_records=self.max_buffered_records,
             )
 
             self.producer.start(clean=clean)
@@ -668,6 +671,7 @@ class RandomNodeOperationsBase(PreallocNodesTest):
             compaction_enabled=False,
             iceberg_enabled=with_iceberg,
             catalog_service=self.catalog_service,
+            max_buffered_records=10240,
         )
 
         cloud_topics_compact_consumer = RandomNodeOperationsBase.producer_consumer(
@@ -683,6 +687,7 @@ class RandomNodeOperationsBase(PreallocNodesTest):
             compaction_enabled=True,
             iceberg_enabled=with_iceberg,
             catalog_service=self.catalog_service,
+            max_buffered_records=10240,
         )
 
         tiered_cloud_delete_consumer = RandomNodeOperationsBase.producer_consumer(


### PR DESCRIPTION
random_node_operations_smoke_tests.py consistently times out on s3 with ct-delete and ct-compat at around 70% complete.

With the default value of 1024 records at 1k each outstanding per topic and two partitions (likely on different nodes), the write_request_scheduler only sees around 512 records at a time for around 512k total.  This isn't enough to hit the default max_buffer_size threshhold of 4MB, so we always wait for the default 250ms scheduling_interval.

Combined with 80-160ms of s3 put latency, we see produce latencies of 400ms+ even without failure injection for a sustained throughput of around 2600 msgs/s.  At that rate, the default 5242880 records take around 33 minutes, more than the duration at which the test times out.

This patch addresses the issue by increasing max_buffered_records for the client to 10240, 10x the default.  This should be enough to hit the 4MB threshhold on each partition on each topic.

In s3, this is sufficient to increase throughput to close to 10k msgs/sec resulting in ct-compact and ct-delete finishing 2-3 minutes after the other topics, well within the timeout.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
