### PR TITLE
datalake: stop bucketing unknown_error as file_io_error

### DIFF
--- a/src/v/datalake/translation/deps.cc
+++ b/src/v/datalake/translation/deps.cc
@@ -51,6 +51,8 @@ map_error_code(datalake::translation_task::errc errc) {
         return translation_errc::out_of_disk;
     case datalake::translation_task::errc::type_resolution_error:
         return translation_errc::type_resolution_error;
+    case datalake::translation_task::errc::unknown_error:
+        return translation_errc::unknown_error;
     }
 }
 } // namespace

--- a/src/v/datalake/translation/deps.h
+++ b/src/v/datalake/translation/deps.h
@@ -214,6 +214,7 @@ enum translation_errc {
     shutting_down,
     out_of_disk,
     type_resolution_error,
+    unknown_error,
 };
 
 inline fmt::iterator format_to(translation_errc ec, fmt::iterator out) {
@@ -238,6 +239,8 @@ inline fmt::iterator format_to(translation_errc ec, fmt::iterator out) {
         return fmt::format_to(out, "translation_errc::out_of_disk");
     case type_resolution_error:
         return fmt::format_to(out, "translation_errc::type_resolution_error");
+    case unknown_error:
+        return fmt::format_to(out, "translation_errc::unknown_error");
     }
 }
 

--- a/src/v/datalake/translation_task.cc
+++ b/src/v/datalake/translation_task.cc
@@ -55,7 +55,7 @@ translation_task::errc map_error_code(writer_error errc) {
     case writer_error::out_of_disk:
         return translation_task::errc::out_of_disk;
     case writer_error::unknown_error:
-        return translation_task::errc::file_io_error;
+        return translation_task::errc::unknown_error;
     case writer_error::retryable_type_resolution_error:
         return translation_task::errc::type_resolution_error;
     }

--- a/src/v/datalake/translation_task.h
+++ b/src/v/datalake/translation_task.h
@@ -58,6 +58,7 @@ public:
         shutting_down,
         out_of_disk,
         type_resolution_error,
+        unknown_error,
     };
 
     using custom_partitioning_enabled
@@ -129,6 +130,8 @@ private:
             return fmt::format_to(out, "disk exhausted");
         case errc::type_resolution_error:
             return fmt::format_to(out, "type resolution error");
+        case errc::unknown_error:
+            return fmt::format_to(out, "unknown error");
         }
     }
 


### PR DESCRIPTION
Avoid misleading error logs like:

```
Error ensuring table schema for record 42: table_creator::errc::failed
Translation attempt ran into an unexpected exception: std::runtime_error (Error flushing in-progress translation: local file IO error)
```

where the underlying cause has nothing to do with local file IO. A new `unknown_error` variant is plumbed through `translation_task::errc` and `translation_errc` so unclassified writer errors keep their identity instead of being relabelled as file IO errors.

## Backports Required

- [x] v26.1.x
- [x] v25.3.x

## Release Notes

* none