### PR TITLE
bazel: remove --experimental_remote_repo_contents_cache startup flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,10 +1,6 @@
 common --registry=https://bcr.bazel.build
 common --extra_toolchains=@current_llvm_toolchain//:all
 
-# Store repositories also in the remote cache to speed up fetches and avoid
-# flakiness due to Github
-startup --experimental_remote_repo_contents_cache
-
 # Triple repo downloader retries to try working around github flakiness.
 common --experimental_repository_downloader_retries=15
 common --http_connector_attempts=24


### PR DESCRIPTION
Remove the `startup --experimental_remote_repo_contents_cache` line from `.bazelrc`.

This experimental flag caches reproducible repo-rule results in the remote cache. It is not clear that it serves a purpose.

It is implicated in the `toolchains_llvm` "could not find clang" failure surfacing in the CORE-16343 work to switch the remote cache from HTTP to gRPCS (vtools PR #4275).

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none