### PR TITLE
[CORE-16301] cloud_io/cache: fix ENOENT race in put and invalidate cleanup

### DIFF
--- a/src/v/cloud_io/cache_service.cc
+++ b/src/v/cloud_io/cache_service.cc
@@ -1311,18 +1311,26 @@ ss::future<> cache::put(
               "Removing temporary file {}. Exception during copy: {}",
               tmp_filepath.native(),
               eptr);
-            auto delete_tmp_fut = co_await ss::coroutine::as_future(
-              delete_file_and_empty_parents(tmp_filepath.native()));
-            if (delete_tmp_fut.failed()) {
-                auto e = delete_tmp_fut.get_exception();
-                if (!ssx::is_shutdown_exception(e)) {
-                    vlog(
-                      log.error,
-                      "Failed to delete tmp file {}: {}",
-                      tmp_filepath.native(),
-                      e);
-                }
-            }
+            co_await ss::remove_file(tmp_filepath.native())
+              .handle_exception_type(
+                [&](const std::filesystem::filesystem_error& e) {
+                    if (e.code() != std::errc::no_such_file_or_directory) {
+                        vlog(
+                          log.error,
+                          "Failed to delete tmp file {}: {}",
+                          tmp_filepath.native(),
+                          e);
+                    }
+                })
+              .handle_exception([&](std::exception_ptr e) {
+                  if (!ssx::is_shutdown_exception(e)) {
+                      vlog(
+                        log.error,
+                        "Failed to delete tmp file {}: {}",
+                        tmp_filepath.native(),
+                        e);
+                  }
+              });
         }
 
         if (no_space_on_device) {
@@ -1398,11 +1406,22 @@ ss::future<> cache::_invalidate(const std::filesystem::path& key) {
     auto guard = _gate.hold();
     vlog(
       log.debug, "Trying to invalidate {} from archival cache.", key.native());
+    auto normal_path = (_cache_dir / key).lexically_normal();
+    auto normal_cache_dir = _cache_dir.lexically_normal();
+    auto [p1, p2] = std::mismatch(
+      normal_cache_dir.begin(), normal_cache_dir.end(), normal_path.begin());
+    if (p1 != normal_cache_dir.end()) {
+        throw std::invalid_argument(fmt_with_ctx(
+          fmt::format,
+          "Tried to invalidate {}, which is outside of cache_dir {}.",
+          normal_path.native(),
+          normal_cache_dir.native()));
+    }
     try {
-        auto path = (_cache_dir / key).native();
+        auto path = normal_path.native();
         auto stat = co_await ss::file_stat(path);
         _access_time_tracker.remove(key.native());
-        co_await delete_file_and_empty_parents(path);
+        co_await ss::remove_file(path);
         _current_cache_size -= stat.size;
         _current_cache_objects -= 1;
         probe.set_size(_current_cache_size);

--- a/src/v/cloud_io/tests/cache_test.cc
+++ b/src/v/cloud_io/tests/cache_test.cc
@@ -213,10 +213,6 @@ FIXTURE_TEST(invalidate_cleans_directory, cache_test_fixture) {
 
     BOOST_CHECK(
       !ss::file_exists((CACHE_DIR / unique_prefix_key).native()).get());
-    BOOST_CHECK(
-      !ss::file_exists((CACHE_DIR / "unique_prefix/test_topic").native())
-         .get());
-    BOOST_CHECK(!ss::file_exists((CACHE_DIR / "unique_prefix").native()).get());
     BOOST_CHECK(ss::file_exists(CACHE_DIR.native()).get());
 }
 


### PR DESCRIPTION
_cleanup_sm serializes trim, but _invalidate and put()'s failure
cleanup both call delete_file_and_empty_parents without holding it.
That function co_awaits ss::remove_file at each step of its upward
walk, yielding between the leaf deletion and each parent rmdir.

The race: trim deletes a chunk file and yields before rmdiring its
_chunks/ parent.  Concurrently, put()'s failure cleanup deletes its
own tmp file in the same _chunks/ directory, finds it empty, and
rmdirs it.  Trim resumes, tries the same rmdir, gets ENOENT, which
propagates through remove_segment_full's catch-all as an ERROR log.

Fix: restrict rmdir to trim, which already owns it under _cleanup_sm.
Non-trim callers only delete the leaf.

_invalidate already catches ENOENT from the whole try block, so a
concurrent trim deleting the file between the file_stat and remove_file
is handled correctly: accounting is skipped, which is right since trim
already decremented it.

For put() failure, ENOENT on the tmp file is silently ignored;
shutdown exceptions are swallowed; other errors are logged.

Fixes CORE-16301

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [X] v25.3.x
- [X] v25.2.x

## Release Notes

* none
