### PR TITLE
cluster: synthesize removed_at for deleted NTPs on bootstrap

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -432,6 +432,15 @@ ss::future<> controller_backend::start() {
 ss::future<> controller_backend::bootstrap_controller_backend() {
     for (const auto& [ntp, _] : _shard_placement.shard_local_states()) {
         notify_reconciliation(ntp);
+        if (!_topics.local().get_replicas_view(ntp)) {
+            // The topic was deleted while this node was down. The "removed"
+            // delta fired during controller log replay before our listener
+            // was registered, so removed_at was never set. Without it the
+            // reconcile loop skips cleanup. Synthesize it here so
+            // finish_delete runs and clears the shard_placement kvstore key.
+            _states.at(ntp)->removed_at
+              = _topics.local().last_applied_revision();
+        }
     }
 
     _topic_table_notify_handle


### PR DESCRIPTION
If a node is stopped between a failed delete_partition attempt and its retry, the shard_placement current_state kvstore key survives the restart. The "removed" delta for the deleted topic fires during controller log replay before controller_backend registers its listener, so removed_at is never set. Without it, the reconcile loop returns stop_iteration::yes and marks the NTP reconciled without calling finish_delete, leaving the kvstore key permanently.

Fix by checking, during bootstrap_controller_backend, whether each NTP in shard_local_states is still present in the topic table. If not, synthesize removed_at from last_applied_revision so the reconcile loop calls delete_partition and finish_delete on restart.

Fixes CORE-16306

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [X] v25.3.x
- [X] v25.2.x

## Release Notes

* none
