### PR TITLE
dt/tests: bump kcl test client to v0.18

### DIFF
--- a/tests/docker/ducktape-deps/kcl
+++ b/tests/docker/ducktape-deps/kcl
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
-go install github.com/twmb/kcl@v0.16.0
+go install github.com/twmb/kcl@4658a75b0a61830262473a5e7d45caef6121bd4e
 mv /root/go/bin/kcl /usr/local/bin/

--- a/tests/rptest/clients/default.py
+++ b/tests/rptest/clients/default.py
@@ -151,7 +151,7 @@ class DefaultClient:
         incremental: bool,
         *,
         broker: typing.Optional[int] = None,
-    ):
+    ) -> dict[str, typing.Any]:
         kcl = KCL(self._redpanda)
         return kcl.alter_broker_config(values, incremental, broker)
 

--- a/tests/rptest/clients/kcl.py
+++ b/tests/rptest/clients/kcl.py
@@ -20,11 +20,18 @@ from typing import Any, NamedTuple
 from ducktape.utils.util import wait_until
 
 
+# Kafka API error codes referenced by tests. Full list:
+# https://kafka.apache.org/protocol#protocol_error_codes
+KAFKA_ERROR_INVALID_CONFIG = 40
+KAFKA_ERROR_THROTTLING_QUOTA_EXCEEDED = 89
+
+
 class KclPartitionOffset(NamedTuple):
     broker: str
     topic: str
     partition: int
     start_offset: int
+    stable_offset: int
     end_offset: int
     error: str
 
@@ -136,7 +143,7 @@ class KCL:
         ret: list[KclPartitionOffset] = []
         for l in lines:
             m = re.match(
-                r" *(?P<broker>\d+) +(?P<topic>.+?) +(?P<partition>\d+) +(?P<start>-?\d*?) +(?P<end>-?\d*?) +(?P<error>.*) *",
+                r" *(?P<broker>\d+) +(?P<topic>.+?) +(?P<partition>\d+) +(?P<start>-?\d*?) +(?P<stable>-?\d*?) +(?P<end>-?\d*?) +(?P<error>.*) *",
                 l,
             )
             if m:
@@ -146,6 +153,7 @@ class KCL:
                         m["topic"],
                         int(m["partition"]),
                         int(m["start"]) if m["start"] else -1,
+                        int(m["stable"]) if m["stable"] else -1,
                         int(m["end"]) if m["end"] else -1,
                         m["error"],
                     )
@@ -182,15 +190,17 @@ class KCL:
         entity_type: str,
         entity: Any,
         node: Any | None = None,
-    ) -> str:
+    ) -> dict[str, Any]:
         """
         :param broker: node id.
         :param values: dict of property name to new value
         :param incremental: if true, use incremental kafka APIs
         :param entity_type: one of 'broker', 'topic'
         :param entity: string-izable entity, or None to omit
+        :return: the single per-entity result from kcl's JSON envelope, with
+            at minimum an `error` (int kafka code) and `error_message` (str).
         """
-        cmd = ["admin", "configs", "alter"]
+        cmd = ["--format=json", "admin", "configs", "alter"]
 
         if entity_type == "broker":
             cmd.append("-tb")
@@ -201,25 +211,26 @@ class KCL:
 
         if incremental:
             cmd.append("-i")
+            for k, v in values.items():
+                cmd.extend(["-s", f"{k}={v}"])
         else:
             # By default, non-incremental AlterConfig will prompt on stdin (and hang)
-            cmd.append("--no-confirm")
-        for k, v in values.items():
-            cmd.extend(["-k", f"s:{k}={v}" if incremental else f"{k}={v}"])
+            cmd.append("--yes")
+            # `-k` is the only way to reach the legacy AlterConfigs API (key 33);
+            # `--set` and `--delete` auto-enable the incremental API (key 44).
+            for k, v in values.items():
+                cmd.extend(["-k", f"{k}={v}"])
 
         if entity:
             # cmd needs to be string, so handle things like broker=1
             cmd.append(str(entity))
 
         r = self._cmd(cmd, attempts=1, node=node)
-        if "OK" not in r:
-            raise RuntimeError(r)
-        else:
-            return r
+        return json.loads(r)["results"][0]
 
     def alter_broker_config(
         self, values: dict[str, Any], incremental: bool, broker: Any | None = None
-    ) -> str:
+    ) -> dict[str, Any]:
         return self._alter_config(values, incremental, "broker", broker)
 
     def alter_topic_config(
@@ -228,7 +239,7 @@ class KCL:
         incremental: bool,
         topic: str,
         node: Any | None = None,
-    ) -> str:
+    ) -> dict[str, Any]:
         return self._alter_config(values, incremental, "topic", topic, node=node)
 
     def delete_broker_config(self, keys: list[str], incremental: bool) -> str:
@@ -241,7 +252,7 @@ class KCL:
         if incremental:
             cmd.append("-i")
         for k in keys:
-            cmd.extend(["-k", f"d:{k}" if incremental else k])
+            cmd.extend(["--delete", k])
 
         return self._cmd(cmd, attempts=1)
 
@@ -264,7 +275,15 @@ class KCL:
         if with_types:
             cmd.append("--with-types")
 
-        return self._cmd(cmd, attempts=1, node=node)
+        # describe puts the property table on stdout and (when --with-docs is
+        # set) the doc-strings on stderr; merge so callers get one blob.
+        stderr = subprocess.STDOUT if with_docs else subprocess.PIPE
+        output = self._cmd(cmd, attempts=1, node=node, stderr=stderr)
+        # Drop the "KEY TYPE VALUE SOURCE" header row prefixing the table.
+        first_line, sep, rest = output.partition("\n")
+        if sep and first_line.lstrip().startswith("KEY"):
+            output = rest
+        return output
 
     def offset_delete(
         self, group: str, topic_partitions: dict[str, list[int]]
@@ -290,8 +309,15 @@ class KCL:
             )
         )
 
-        cmd = ["group", "offset-delete", "-j", group] + request_args_w_flags
-        return json.loads(self._cmd(cmd, attempts=5))
+        # offset-delete exits non-zero on per-item failures but still emits
+        # valid JSON on stdout; parse e.output so callers can inspect
+        # per-item errors.
+        cmd = ["--format=json", "group", "offset-delete", group] + request_args_w_flags
+        try:
+            raw = self._cmd(cmd, attempts=1)
+        except subprocess.CalledProcessError as e:
+            raw = e.output
+        return json.loads(raw)
 
     def sasl_options(self) -> list[str]:
         if self.sasl_enabled():
@@ -351,6 +377,10 @@ class KCL:
         def do_alter_partitions() -> bool:
             nonlocal lines
             lines = self._cmd(cmd).splitlines()
+            # Drop the "TOPIC PARTITION STATUS DETAIL" header row so callers
+            # see only data rows.
+            if lines and lines[0].lstrip().startswith("TOPIC"):
+                lines = lines[1:]
 
             # Check for errors here instead of outside the KCL wrapper
             # because test writers can use method params to account for their expectations
@@ -449,11 +479,28 @@ class KCL:
         input: str | None = None,
         attempts: int = 5,
         node: Any | None = None,
+        stderr: int = subprocess.PIPE,
     ) -> str:
         """
 
         :param attempts: how many times to try before giving up (1 for no retries)
-        :return: stdout string
+        :param stderr: passed through to ``subprocess.check_output``. The
+                              default (``subprocess.PIPE``) captures stderr
+                              separately so ``CalledProcessError.stderr``
+                              carries kcl's error text (kcl puts server-side
+                              messages like "CLUSTER_AUTHORIZATION_FAILED" on
+                              stderr; tests reading ``e.stderr`` pick those
+                              up). Pass ``subprocess.STDOUT`` for the rare
+                              command whose successful output is split across
+                              streams (``admin configs describe --with-docs``
+                              puts the property table on stdout and the doc
+                              strings on stderr); the merged blob is then
+                              returned as the function's result.
+        :return: stdout (or stdout+stderr merged, depending on ``stderr``).
+                 ``group offset-delete`` exits non-zero on per-item failures
+                 while still emitting a valid JSON body on stdout; that call
+                 site wraps this helper in ``try/except CalledProcessError``
+                 and reads the response from ``e.output``.
         """
         brokers = node.name if node is not None else self._redpanda.brokers()
         cmd = (
@@ -466,7 +513,10 @@ class KCL:
         for retry in reversed(range(attempts)):
             try:
                 res = subprocess.check_output(
-                    cmd, text=True, input=input, stderr=subprocess.STDOUT
+                    cmd,
+                    text=True,
+                    input=input,
+                    stderr=stderr,
                 )
                 self._redpanda.logger.debug(res)
                 return res
@@ -521,6 +571,17 @@ class RawKCL(KCL):
         except Exception:
             return []
 
+    @staticmethod
+    def _unwrap_raw_response(raw_json: str) -> Any:
+        """kcl wraps ``misc raw-req`` output in
+        ``{"_command": ..., "_version": ..., "response": ...}``; return just
+        the response payload so callers don't need to know about the envelope.
+        """
+        parsed: dict[str, Any] = json.loads(raw_json)
+        if "_command" in parsed and "response" in parsed:
+            return parsed["response"]
+        return parsed
+
     def raw_create_topics(
         self,
         version: int,
@@ -543,10 +604,11 @@ class RawKCL(KCL):
                 for t in topics
             ],
         }
-        return self._cmd(
+        res = self._cmd(
             ["misc", "raw-req", "-b", str(self._controller_id()), "-k", "19"],
             input=json.dumps(create_topics_request),
         )
+        return json.dumps(self._unwrap_raw_response(res))
 
     def raw_delete_topics(self, version: int, topics: list[str]) -> str:
         assert version >= 0 and version <= 5, (
@@ -557,10 +619,11 @@ class RawKCL(KCL):
             "TimeoutMillis": 15000,
             "TopicNames": topics,
         }
-        return self._cmd(
+        res = self._cmd(
             ["misc", "raw-req", "-b", str(self._controller_id()), "-k", "20"],
             input=json.dumps(delete_topics_request),
         )
+        return json.dumps(self._unwrap_raw_response(res))
 
     def raw_create_partitions(
         self, version: int, topics: list[KclCreatePartitionsRequestTopic]
@@ -574,10 +637,11 @@ class RawKCL(KCL):
             "TimeoutMillis": 15000,
             "Topics": [{"Topic": t.name, "Count": t.num_partitions} for t in topics],
         }
-        return self._cmd(
+        res = self._cmd(
             ["misc", "raw-req", "-b", str(self._controller_id()), "-k", "37"],
             input=json.dumps(create_partitions_request),
         )
+        return json.dumps(self._unwrap_raw_response(res))
 
     def raw_alter_topic_config(
         self, version: int, topic: str, configs: dict[str, Any]
@@ -599,10 +663,11 @@ class RawKCL(KCL):
         ]
 
         self._redpanda.logger.info(f"DBG: {json.dumps(alter_configs_request)}")
-        return self._cmd(
+        res = self._cmd(
             ["misc", "raw-req", "-b", str(self._controller_id()), "-k", "33"],
             input=json.dumps(alter_configs_request),
         )
+        return json.dumps(self._unwrap_raw_response(res))
 
     def raw_alter_quotas(
         self, body: dict[str, Any], node: Any | None = None
@@ -612,26 +677,25 @@ class RawKCL(KCL):
             input=json.dumps(body),
             node=node,
         )
-        return json.loads(res)
+        return self._unwrap_raw_response(res)
 
     def raw_describe_quotas(self, body: dict[str, Any]) -> dict[str, Any]:
         res = self._cmd(
             ["misc", "raw-req", "-b", str(self._controller_id()), "-k", "48"],
             input=json.dumps(body),
         )
-        return json.loads(res)
+        return self._unwrap_raw_response(res)
 
     def raw_find_coordinator(self, body: dict[str, Any]) -> dict[str, Any]:
         res = self._cmd(["misc", "raw-req", "-k", "10"], input=json.dumps(body))
-        return json.loads(res)
+        return self._unwrap_raw_response(res)
 
     def raw_join_group(self, body: dict[str, Any]) -> dict[str, Any]:
         res = self.raw_find_coordinator(
             {"Version": 3, "CoordinatorKey": body["Group"], "CoordinatorType": 0}
         )
-
         res = self._cmd(
             ["misc", "raw-req", "-b", str(res["NodeID"]), "-k", "11"],
             input=json.dumps(body),
         )
-        return json.loads(res)
+        return self._unwrap_raw_response(res)

--- a/tests/rptest/clients/kcl.py
+++ b/tests/rptest/clients/kcl.py
@@ -262,12 +262,12 @@ class KCL:
         with_docs: bool = False,
         with_types: bool = False,
         node: Any | None = None,
-    ) -> str:
+    ) -> list[str]:
         """
         :param topic: the name of the topic to describe
         :param with_docs: if true, include documention strings in the response
         :param with_types: if true, include config type information in the reponse
-        :return: stdout string
+        :return: output lines
         """
         cmd = ["admin", "configs", "describe", topic, "--type", "topic"]
         if with_docs:
@@ -278,12 +278,11 @@ class KCL:
         # describe puts the property table on stdout and (when --with-docs is
         # set) the doc-strings on stderr; merge so callers get one blob.
         stderr = subprocess.STDOUT if with_docs else subprocess.PIPE
-        output = self._cmd(cmd, attempts=1, node=node, stderr=stderr)
+        lines = self._cmd(cmd, attempts=1, node=node, stderr=stderr).splitlines()
         # Drop the "KEY TYPE VALUE SOURCE" header row prefixing the table.
-        first_line, sep, rest = output.partition("\n")
-        if sep and first_line.lstrip().startswith("KEY"):
-            output = rest
-        return output
+        if lines and lines[0].lstrip().startswith("KEY"):
+            lines = lines[1:]
+        return lines
 
     def offset_delete(
         self, group: str, topic_partitions: dict[str, list[int]]

--- a/tests/rptest/tests/alter_topic_configuration_test.py
+++ b/tests/rptest/tests/alter_topic_configuration_test.py
@@ -569,7 +569,7 @@ class AlterConfigMixedNodeTest(EndToEndTest):
             for node in self.redpanda.nodes:
                 desc = kcl.describe_topic(topic, node=node)
                 props = set()
-                for line in desc.split("\n"):
+                for line in desc:
                     line = line.rstrip()
                     # normalize spaces/tabs from outputs across nodes
                     line = " ".join(line.split())
@@ -673,7 +673,7 @@ class AlterConfigMixedNodeTest(EndToEndTest):
                 remote_read_valid = False
                 remote_write_valid = False
                 desc = kcl.describe_topic(topic, node=node)
-                for line in desc.split("\n"):
+                for line in desc:
                     line = line.rstrip()
                     if "redpanda.remote.read" in line:
                         remote_read_valid = remote_read in line

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -23,6 +23,7 @@ from ducktape.mark import matrix, parametrize
 from ducktape.utils.util import wait_until
 
 from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.kcl import KAFKA_ERROR_INVALID_CONFIG
 from rptest.clients.rpk import RpkException, RpkTool
 from rptest.clients.rpk_remote import RpkRemoteTool
 from rptest.clients.types import TopicSpec
@@ -1635,19 +1636,16 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
         out = self.client().alter_broker_config(
             {"log_message_timestamp_type": "CreateTime"}, incremental
         )
-        # kcl does not set an error exist status when config set fails, so must
-        # read its output text to validate that calls are successful
-        assert "OK" in out
+        assert out["error"] == 0, out
 
         out = self.client().alter_broker_config(
             {"log_message_timestamp_type": "LogAppendTime"}, incremental
         )
-        assert "OK" in out
+        assert out["error"] == 0, out
         if incremental:
             self.client().delete_broker_config(
                 ["log_message_timestamp_type"], incremental
             )
-            assert "OK" in out
 
         # Set a property by its Kafka-interop names and values
         kafka_props = {
@@ -1659,28 +1657,30 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
         for property, value_list in kafka_props.items():
             for value in value_list:
                 out = self.client().alter_broker_config({property: value}, incremental)
-                assert "OK" in out
+                assert out["error"] == 0, out
 
         # Set a nonexistent property
-        with expect_exception(RuntimeError, lambda e: "INVALID_CONFIG" in str(e)):
-            self.client().alter_broker_config({"does_not_exist": "avalue"}, incremental)
+        out = self.client().alter_broker_config(
+            {"does_not_exist": "avalue"}, incremental
+        )
+        assert out["error"] == KAFKA_ERROR_INVALID_CONFIG, out
 
         # Set a malformed property
-        with expect_exception(RuntimeError, lambda e: "INVALID_CONFIG" in str(e)):
-            self.client().alter_broker_config(
-                {"log_message_timestamp_type": "BadValue"}, incremental
-            )
+        out = self.client().alter_broker_config(
+            {"log_message_timestamp_type": "BadValue"}, incremental
+        )
+        assert out["error"] == KAFKA_ERROR_INVALID_CONFIG, out
 
         # Set a property on a named broker: should fail because this
         # interface is only for cluster-wide properties
-        with expect_exception(
-            RuntimeError,
-            lambda e: "INVALID_CONFIG" in str(e)
-            and "Setting broker properties on named brokers is unsupported" in str(e),
-        ):
-            self.client().alter_broker_config(
-                {"log_message_timestamp_type": "CreateTime"}, incremental, broker=1
-            )
+        out = self.client().alter_broker_config(
+            {"log_message_timestamp_type": "CreateTime"}, incremental, broker=1
+        )
+        assert out["error"] == KAFKA_ERROR_INVALID_CONFIG, out
+        assert (
+            "Setting broker properties on named brokers is unsupported"
+            in out["error_message"]
+        ), out
 
     @cluster(num_nodes=3)
     def test_alter_configs(self):
@@ -1689,14 +1689,14 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
         are correctly handled with an 'unsupported' response.
         """
 
-        with expect_exception(
-            RuntimeError,
-            lambda e: "INVALID_CONFIG" in str(e)
-            and "changing broker properties isn't supported via this API" in str(e),
-        ):
-            self.client().alter_broker_config(
-                {"log_message_timestamp_type": "CreateTime"}, incremental=False
-            )
+        result = self.client().alter_broker_config(
+            {"log_message_timestamp_type": "CreateTime"}, incremental=False
+        )
+        assert result["error"] == KAFKA_ERROR_INVALID_CONFIG, result
+        assert (
+            "changing broker properties isn't supported via this API"
+            in result["error_message"]
+        ), result
 
     # Note: "shared_key" is base64 encoded. It is decoded and that is the password used
     ABS_STATIC_CFG = {

--- a/tests/rptest/tests/controller_log_limiting_test.py
+++ b/tests/rptest/tests/controller_log_limiting_test.py
@@ -16,7 +16,11 @@ from requests.exceptions import HTTPError
 
 from rptest.clients.default import DefaultClient
 from rptest.clients.kafka_cli_tools import KafkaCliTools
-from rptest.clients.kcl import KclCreateTopicsRequestTopic, RawKCL
+from rptest.clients.kcl import (
+    KAFKA_ERROR_THROTTLING_QUOTA_EXCEEDED,
+    KclCreateTopicsRequestTopic,
+    RawKCL,
+)
 from rptest.clients.rpk import RpkException, RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
@@ -189,19 +193,16 @@ class ControllerConfigLimitTest(RedpandaTest):
             backoff_sec=1,
         )
         for i in range(requests_amount):
-            try:
-                self.client().alter_broker_config(
-                    {"controller_log_accummulation_rps_capacity_topic_operations": i},
-                    incremental=True,
-                )
-            except RuntimeError as e:
-                if "THROTTLING_QUOTA_EXCEEDED" in str(e):
-                    quota_error_amount += 1
-                else:
-                    # unexpected error type
-                    raise
-            else:
+            result = self.client().alter_broker_config(
+                {"controller_log_accummulation_rps_capacity_topic_operations": i},
+                incremental=True,
+            )
+            if result["error"] == 0:
                 success_amount += 1
+            elif result["error"] == KAFKA_ERROR_THROTTLING_QUOTA_EXCEEDED:
+                quota_error_amount += 1
+            else:
+                raise RuntimeError(f"unexpected alter_broker_config result: {result}")
             time.sleep(0.1)
         assert quota_error_amount > 0
         assert success_amount > 0
@@ -236,9 +237,9 @@ class ControllerConfigLimitTest(RedpandaTest):
                 {"controller_log_accummulation_rps_capacity_topic_operations": i + 25},
                 incremental=True,
             )
-            if "THROTTLING_QUOTA_EXCEEDED" in out:
+            if out["error"] == KAFKA_ERROR_THROTTLING_QUOTA_EXCEEDED:
                 quota_error_amount += 1
-            if "OK" in out:
+            elif out["error"] == 0:
                 success_amount += 1
         assert quota_error_amount == 0
         assert success_amount > 0

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -348,11 +348,12 @@ class DescribeTopicsTest(RedpandaTest):
         tp_spec = TopicSpec()
         self.client().create_topic([tp_spec])
         kcl = KCL(self.redpanda)
-        output = (
-            kcl.describe_topic(tp_spec.name, with_docs=True, with_types=True)
-            .lower()
-            .splitlines()
-        )
+        output = [
+            line.lower()
+            for line in kcl.describe_topic(
+                tp_spec.name, with_docs=True, with_types=True
+            )
+        ]
 
         # The output format from topic describe has the following structure
         #

--- a/tests/rptest/tests/partition_reassignments_test.py
+++ b/tests/rptest/tests/partition_reassignments_test.py
@@ -501,7 +501,7 @@ class PartitionReassignmentsTest(RedpandaTest):
             kcl.alter_partition_reassignments({})
             assert "alter partition reassignments should have failed"
         except subprocess.CalledProcessError as e:
-            assert "AlterPartitionReassignment API is disabled. See" in e.output
+            assert "AlterPartitionReassignment API is disabled. See" in e.stderr
 
     @cluster(num_nodes=6)
     def test_add_partitions_with_inprogress_reassignments(self):
@@ -671,7 +671,7 @@ class PartitionReassignmentsACLsTest(RedpandaTest):
                 f"AlterPartition with user {username} passed. Expected fail."
             )
         except subprocess.CalledProcessError as e:
-            if e.output.startswith("CLUSTER_AUTHORIZATION_FAILED"):
+            if e.stderr.startswith("CLUSTER_AUTHORIZATION_FAILED"):
                 pass
             else:
                 raise
@@ -683,7 +683,7 @@ class PartitionReassignmentsACLsTest(RedpandaTest):
                 f"ListPartition with user {username} passed. Expected fail."
             )
         except subprocess.CalledProcessError as e:
-            if e.output.startswith("CLUSTER_AUTHORIZATION_FAILED"):
+            if e.stderr.startswith("CLUSTER_AUTHORIZATION_FAILED"):
                 pass
             else:
                 raise

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -20,7 +20,7 @@ from ducktape.utils.util import wait_until
 from rptest.clients.default import DefaultClient
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.clients.kafka_cli_tools import KafkaCliTools
-from rptest.clients.kcl import KCL, RawKCL
+from rptest.clients.kcl import KAFKA_ERROR_INVALID_CONFIG, KCL, RawKCL
 from rptest.clients.offline_log_viewer import OfflineLogViewer
 from rptest.clients.rpk import RpkException, RpkTool
 from rptest.clients.types import TopicSpec
@@ -911,10 +911,10 @@ class CreateSITopicsTest(RedpandaTest):
                 )
 
         # As a control, confirm that if we did pass an invalid property, we would have got an error
-        with expect_exception(RuntimeError, lambda e: "invalid" in str(e)):
-            kcl.alter_topic_config(
-                {"redpanda.invalid.property": "true"}, incremental=False, topic=topic
-            )
+        result = kcl.alter_topic_config(
+            {"redpanda.invalid.property": "true"}, incremental=False, topic=topic
+        )
+        assert result["error"] == KAFKA_ERROR_INVALID_CONFIG, result
 
 
 # When quickly recreating topics after deleting them, redpanda's topic

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -684,7 +684,7 @@ class CreateTopicsResponseTest(RedpandaTest):
         topic_response = create_topics_response[0]
 
         res = self.kcl_client.describe_topic(topic_name)
-        describe_configs = [line.split() for line in res.strip().split("\n")]
+        describe_configs = [line.split() for line in res]
 
         for key, value, source in describe_configs:
             topic_config = self.get_config_by_name(topic_response, key)


### PR DESCRIPTION
Bumps the kcl test CLI in the ducktape image to v0.18 for
franz-go v1.21.0 (Kafka 4.x). Pinned to twmb/kcl master commit
`4658a75b` rather than the v0.18.0 tag because the tag predates
twmb/kcl#55, a `raw-req` fix needed for upgrade tests against
pre-Metadata-v13 brokers. `tests/rptest/clients/kcl.py` is
adapted for v0.18's CLI changes (renamed flags, new tabular
output, JSON envelope on `misc raw-req`, stderr/stdout
separation). Per-area details in the commit body.

Tracked as [CORE-16359](https://redpandadata.atlassian.net/browse/CORE-16359),
a sub-ticket of [ENG-1185](https://redpandadata.atlassian.net/browse/ENG-1185).

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

[CORE-16359]: https://redpandadata.atlassian.net/browse/CORE-16359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-1185]: https://redpandadata.atlassian.net/browse/ENG-1185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ