### PR TITLE
[v26.1.x] `cloud_storage`: fast-path append-only `segment_meta_cstore` inserts

### DIFF
--- a/src/v/cloud_storage/segment_meta_cstore.cc
+++ b/src/v/cloud_storage/segment_meta_cstore.cc
@@ -335,6 +335,7 @@ public:
             return;
         }
 
+        static constexpr auto end_index = std::numeric_limits<size_t>::max();
         // construct a column_store with the frames and hints that are before
         // the replacements
         auto first_replacement_index = [&] {
@@ -348,11 +349,22 @@ public:
             if (candidate.is_end()) {
                 // replacements are append only, return an index that will
                 // signal this
-                return std::numeric_limits<size_t>::max();
+                return end_index;
             }
             // replacements are in the middle of current store
             return candidate.index();
         }();
+
+        if (first_replacement_index == end_index) {
+            // Append-only: every entry in [offset_seg_it, offset_seg_end)
+            // lands strictly past the current tail, so no segment in *this is
+            // replaced.
+            for (; offset_seg_it != offset_seg_end; ++offset_seg_it) {
+                append(offset_seg_it->second);
+            }
+            return;
+        }
+
         // tuple of [begin, end] iterators to std::list<frame_t>
         auto to_clone_frames = std::apply(
           [&](auto&... col) {

--- a/src/v/cloud_storage/tests/segment_meta_cstore_bench.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_bench.cc
@@ -420,3 +420,34 @@ PERF_TEST(cstore_bench, cs_iteration_precompute_end_test_10000) {
     segment_meta_cstore store;
     cs_iteration_precompute_end_test(store, 10000);
 }
+
+/// Simulates the `partition_manifest::add()` access pattern: each add
+/// runs `move_aligned_offset_range()` which calls `_segments.lower_bound()`
+/// before the insert lands, flushing the write buffer between every write.
+/// Measures the steady-state cost of appending to a pre-populated cstore.
+void cs_append_with_intervening_lookup_test(
+  size_t pre_populate, size_t append_n) {
+    auto manifest = generate_metadata(pre_populate + append_n);
+
+    segment_meta_cstore store;
+    for (size_t i = 0; i < pre_populate; ++i) {
+        store.insert(manifest[i]);
+    }
+    store.flush_write_buffer();
+
+    perf_tests::start_measuring_time();
+    for (size_t i = pre_populate; i < pre_populate + append_n; ++i) {
+        auto it = store.lower_bound(manifest[i].base_offset);
+        perf_tests::do_not_optimize(it);
+        store.insert(manifest[i]);
+    }
+    perf_tests::stop_measuring_time();
+}
+
+PERF_TEST(cstore_bench, column_store_append_with_intervening_lookup_10k_1k) {
+    cs_append_with_intervening_lookup_test(10000, 1000);
+}
+
+PERF_TEST(cstore_bench, column_store_append_with_intervening_lookup_100k_1k) {
+    cs_append_with_intervening_lookup_test(100000, 1000);
+}


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30601
