### PR TITLE
rptest: harden wait_for_internal_scrub against leader/replica changes

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -6349,19 +6349,48 @@ class RedpandaService(Service, RedpandaServiceABC):
             tolerate_stopped_nodes=True,
         )
 
+        # Per-partition: the leader we last reset scrubbing metadata on.
+        # Populated by the initial setup loop below and updated whenever
+        # the polling loop notices leadership has moved (via a 307 redirect
+        # from the anomalies endpoint) and rediscovers + resets on the new
+        # leader.
+        last_leader: dict[CloudStoragePartition, ClusterNode] = {}
         unavailable: set[CloudStoragePartition] = set()
+        scrubbed: set[CloudStoragePartition] = set()
+        all_anomalies: list[dict[str, Any]] = []
+
+        # Initial setup: find a leader and reset scrubbing metadata for
+        # every partition. Done outside wait_until so its time (up to
+        # ~10s per partition for await_stable_leader) doesn't count
+        # against the scrub-completion polling budget below. Partitions
+        # where we can't get this far are logged and added to
+        # `unavailable` so the polling loop just skips them.
         for p in cloud_storage_partitions:
             try:
                 leader_id = self._admin.await_stable_leader(
                     topic=p.topic, partition=p.index
                 )
-
+                leader = self.get_node_by_id(leader_id)
+                if leader is None:
+                    self.logger.warning(
+                        f"kafka/{p.topic}/{p.index}: leader id {leader_id} "
+                        f"not in started nodes, skipping scrub for this partition"
+                    )
+                    unavailable.add(p)
+                    continue
                 self._admin.reset_scrubbing_metadata(
                     namespace="kafka",
                     topic=p.topic,
                     partition=p.index,
-                    node=self.get_node_by_id(leader_id),
+                    node=leader,
                 )
+                last_leader[p] = leader
+            except TimeoutError as e:
+                self.logger.warning(
+                    f"kafka/{p.topic}/{p.index}: could not find stable "
+                    f"leader during scrub setup ({e}); skipping this partition"
+                )
+                unavailable.add(p)
             except HTTPError as he:
                 if he.response.status_code == 404:
                     # Old redpanda, doesn't have this endpoint.  We can't
@@ -6370,10 +6399,6 @@ class RedpandaService(Service, RedpandaServiceABC):
                     continue
                 else:
                     raise
-
-        cloud_storage_partitions -= unavailable
-        scrubbed: set[CloudStoragePartition] = set()
-        all_anomalies: list[dict[str, Any]] = []
 
         allowed_keys = set(
             ["ns", "topic", "partition", "revision_id", "last_complete_scrub_at"]
@@ -6416,14 +6441,55 @@ class RedpandaService(Service, RedpandaServiceABC):
                             detected.pop("segment_metadata_anomalies", None)
 
         def all_partitions_scrubbed():
-            waiting_for = cloud_storage_partitions - scrubbed
+            waiting_for = cloud_storage_partitions - scrubbed - unavailable
             self.logger.info(
                 f"Waiting for {len(waiting_for)} partitions to be scrubbed"
             )
             for p in waiting_for:
-                result = self._admin.get_cloud_storage_anomalies(
-                    namespace="kafka", topic=p.topic, partition=p.index
+                # Recovery branch: the polling loop previously cleared
+                # last_leader[p] because the anomalies endpoint returned
+                # a 307 (leader moved). Rediscover a stable leader and
+                # re-issue the reset on it. By the time we're polling
+                # the partition was already healthy enough to set up
+                # initially, so failures here are real (not just a
+                # transient setup race) and we let them propagate -
+                # wait_until's retry_on_exc=True will retry within the
+                # overall timeout and the assert message is preserved
+                # as the cause of the eventual TimeoutError.
+                if p not in last_leader:
+                    leader_id = self._admin.await_stable_leader(
+                        topic=p.topic, partition=p.index
+                    )
+                    leader = self.get_node_by_id(leader_id)
+                    assert leader is not None, (
+                        f"kafka/{p.topic}/{p.index}: stable leader id "
+                        f"{leader_id} did not map to a started node"
+                    )
+                    self._admin.reset_scrubbing_metadata(
+                        namespace="kafka",
+                        topic=p.topic,
+                        partition=p.index,
+                        node=leader,
+                    )
+                    last_leader[p] = leader
+                    continue
+
+                # Query anomalies on the known leader. Target it directly
+                # and disable redirect-following so a 307 (leader moved)
+                # surfaces as is_redirect == True instead of being
+                # transparently followed - which is our cue to forget the
+                # leader and rediscover next round. See CORE-15146.
+                r = self._admin._request(
+                    "GET",
+                    f"cloud_storage/anomalies/kafka/{p.topic}/{p.index}",
+                    node=last_leader[p],
+                    allow_redirects=False,
                 )
+                if r.is_redirect:
+                    last_leader.pop(p, None)
+                    continue
+
+                result = r.json()
                 if "last_complete_scrub_at" in result:
                     scrubbed.add(p)
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -6337,6 +6337,14 @@ class RedpandaService(Service, RedpandaServiceABC):
                 # Leadership moves may perturb the scrub, so disable it to
                 # streamline the actions below.
                 "enable_leader_balancer": False,
+                # Replica-set reassignments by the partition autobalancer
+                # (triggered by e.g. a recent decommission) can move a
+                # partition off the leader that just completed a full
+                # scrub, dropping `last_complete_scrub` from the new
+                # leader's manifest view and causing the polling loop
+                # below to time out. Disable replica autobalancing for
+                # the duration of the scrub. See CORE-15146.
+                "partition_autobalancing_mode": "off",
             },
             tolerate_stopped_nodes=True,
         )


### PR DESCRIPTION
The `wait_for_internal_scrub` ducktape helper (run from
`maybe_do_internal_scrub` in every cloud-storage test's post-test
checks) times out intermittently on `wait_until(all_partitions_scrubbed)`
when a partition's leader or replica set moves between the initial
`reset_scrubbing_metadata` and the polling that watches for
`last_complete_scrub_at`. The new leader's manifest doesn't carry
`_detected_anomalies.last_complete_scrub`, its scrubber timer thinks
the partition was recently scrubbed and won't re-scrub on its own,
and the helper polls forever. Logs from a recent failure on
buildkite #84969 (PR 30602) match the same root cause.

Two independent hardenings, one commit each:

1. **Disable the partition autobalancer for the duration of the
   scrub** alongside the existing `enable_leader_balancer: False`.
   `wait_for_internal_scrub` already tries to hold leadership in
   place but did nothing about *replica-set* moves, which the
   autobalancer happily schedules whenever the test body has just
   decommissioned a broker.

2. **Detect leader changes from inside the polling loop** by
   sending the anomalies GET directly to the known leader with
   `allow_redirects=False`. The admin endpoint returns 307 with
   `Location: http://<new-leader>:9644/...` when called on a
   follower, so `r.is_redirect` is enough to know leadership has
   moved -- no extra round-trip needed. On a 307 we drop the
   partition from `last_leader`; the recovery branch then
   rediscovers via `await_stable_leader` and re-issues
   `reset_scrubbing_metadata` on the new leader, which puts its
   scrubber back into a "first_scrub" state so it runs a fresh
   full scrub on the next housekeeping tick.

   The initial setup loop stays outside `wait_until` so its
   `await_stable_leader` calls (up to ~10s per partition) don't
   eat into the scrub-completion polling budget. It is made
   tolerant of per-partition setup failures: a `TimeoutError`
   from `await_stable_leader` or a stale node id returned by
   `get_node_by_id` is logged and the partition is added to
   `unavailable`, so a single stuck partition doesn't abort scrub
   for the rest. The HTTPError handling is unchanged from the
   original (only 404 from `reset_scrubbing_metadata` is treated
   as "old redpanda, skip"; other HTTPErrors propagate). The
   recovery branch inside `wait_until` is intentionally strict --
   it asserts on a stale leader id -- because the partition was
   already healthy enough to set up initially, so failures here
   are real; `wait_until`'s `retry_on_exc=True` retries within
   the outer timeout and preserves the assert message as the
   cause of the eventual TimeoutError.

(1) prevents the specific class of moves that's causing the recent
CI failures; (2) is the more general fix that handles any
leader/replica-set change mid-scrub (force-reconfig, node failure,
manual `set_partition_replicas`, etc), so the two are complementary
rather than redundant.

The 307+`Location` behavior was validated empirically: a probe
test confirms the admin endpoint returns 307 with
`Location: http://<new-leader-host>:9644/...` after a leadership
transfer when called on the former leader with
`allow_redirects=False`. A smoke test (healthy 1-partition tiered
storage topic, no leader churn) was also run end-to-end against
both commits: the setup loop finds the leader cleanly, the
polling loop sees `last_complete_scrub_at` and exits in ~10s, and
none of the new defensive branches (skip-and-add-to-unavailable,
assert, 307 recovery) fire on the happy path.

## Related tickets

All three open tickets share the same `wait_for_internal_scrub`
TimeoutError stack and should be helped by this PR. None are
unassigned, so I'm leaving the existing assignees in place:

- [CORE-15146] (In Review, Evgeny Lazin) - same symptom in
  `TieredStorageCacheStressTest.streaming_cache_test`. This is
  the primary ticket this PR targets.
- [CORE-14686] (Will not implement, Oren Leiman) - same symptom
  in `ShadowIndexingManyPartitionsTest.test_many_partitions_recovery`.
  Closed as Won't Do; mentioning in case it's worth reopening
  once this lands.
- [CORE-14838] (Backlogged, Nicolae Vartolomei) - same symptom
  in `NodeWiseRecoveryTest.test_node_wise_recovery` (sibling test
  of the one that failed on the build we triaged).

Related but not directly fixed by this PR:
- [CORE-16373] (Backlogged, Joe Miller) - the test-body flake
  (`wait_for_no_reconfigurations` timeout) in
  `NodeWiseRecoveryTest.test_recovery_local_data_missing` that I
  hit during local repro; different failure mode, not in scope.

Refs [CORE-15146].

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

[CORE-15146]: https://redpandadata.atlassian.net/browse/CORE-15146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ