### PR TITLE
test: adjust segment size in high throughput test

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -230,7 +230,7 @@ DEFAULT_MESSAGE_SIZE = 4 * KiB
 class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
     msg_size = DEFAULT_MESSAGE_SIZE
     # Min segment size across all tiers
-    min_segment_size = 16 * MiB
+    min_segment_size = 14 * MiB
     unavailable_timeout = 60
     # default message count to check
     msg_count = 100000


### PR DESCRIPTION
Fixes this. The test itself on some cloud tests is failing because the test infrastructure is restricting the segment size

rptest.clients.rpk.RpkException: RpkException<Unexpected output, expected 'topic-cesqbumulz\s+OK' got 'topic-cesqbumulz  INVALID_CONFIG: segment size 16777216 is outside of allowed range [14680064, 14680064]' on setting topic-cesqbumulz segment.bytes=16777216>

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
