### PR TITLE
[CORE-16370] rptest/datalake: gate duckdb e2e test on docker-only S3

### DIFF
--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -45,7 +45,10 @@ from rptest.tests.datalake.catalog_service_factory import (
 )
 from rptest.tests.datalake.datalake_services import DatalakeServices
 from rptest.tests.datalake.query_engine_base import QueryEngineType
-from rptest.tests.datalake.utils import supported_storage_types
+from rptest.tests.datalake.utils import (
+    duckdb_supported_storage_types,
+    supported_storage_types,
+)
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.utils.mode_checks import skip_debug_mode
 
@@ -771,7 +774,7 @@ class DatalakeE2ETests(RedpandaTest):
     # split keeps `--fail-bad-cluster-utilization` happy.
     @cluster(num_nodes=2)
     @matrix(
-        cloud_storage_type=[CloudStorageType.S3],
+        cloud_storage_type=duckdb_supported_storage_types(),
         catalog_type=[CatalogType.REST_JDBC],
     )
     def test_avro_all_iceberg_types_duckdb(self, cloud_storage_type, catalog_type):

--- a/tests/rptest/tests/datalake/duckdb_test.py
+++ b/tests/rptest/tests/datalake/duckdb_test.py
@@ -9,24 +9,13 @@
 
 from ducktape.mark import matrix
 
-from rptest.context.cloud_storage import CloudStorageType
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import SISettings, get_cloud_provider
+from rptest.services.redpanda import SISettings
 from rptest.tests.datalake.catalog_service_factory import filesystem_catalog_type
 from rptest.tests.datalake.datalake_services import DatalakeServices
 from rptest.tests.datalake.query_engine_base import QueryEngineType
+from rptest.tests.datalake.utils import duckdb_supported_storage_types
 from rptest.tests.redpanda_test import RedpandaTest
-
-
-def duckdb_supported_storage_types():
-    """
-    Run only in docker environment with S3 storage type.
-    TODO: extend support.
-    """
-    if get_cloud_provider() == "docker":
-        return [CloudStorageType.S3]
-    else:
-        return []
 
 
 class DuckDBTest(RedpandaTest):

--- a/tests/rptest/tests/datalake/utils.py
+++ b/tests/rptest/tests/datalake/utils.py
@@ -29,3 +29,19 @@ def supported_storage_types():
     supported_storage = map(lambda x: x[1], supported_variants)
     unique = list(set(supported_storage))
     return unique
+
+
+def duckdb_supported_storage_types() -> list[CloudStorageType]:
+    """
+    Run only in docker environment with S3 storage type.
+
+    DuckDBPy requires explicit S3 access key / secret credentials, which we
+    only set up in docker. In other environments S3 access is brokered via
+    IAM roles, which DuckDBPy doesn't support.
+
+    TODO: extend support.
+    """
+    if get_cloud_provider() == "docker":
+        return [CloudStorageType.S3]
+    else:
+        return []


### PR DESCRIPTION
`test_avro_all_iceberg_types_duckdb` ran with `cloud_storage_type=[CloudStorageType.S3]` on every cloud provider, but DuckDBPy needs explicit access key / secret credentials, which we only wire up in docker. In ec2/gcp CI the test asserts during setup with `DuckDBPy query service is implemented only for S3 credentials`.

Reuse the existing `duckdb_supported_storage_types()` helper (lifted from `duckdb_test.py` into `tests/rptest/tests/datalake/utils.py` alongside `supported_storage_types`) so the test is skipped outside docker.

Fixes CORE-16370

## Backports Required

- [x] none - papercut/not impactful enough to backport

## Release Notes

* none