### PR TITLE
docs: document type-checking workflow and fix README CLI flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,12 @@ for memory safety in coroutines, not self-reference.
 
 - Avoid catching bare `except:` as this can hide system exceptions, including exceptions
   raised by a signal when a test is being forcibly timed out. Instead use `except Exception:`.
+- After modifying files under `tests/rptest`, run type checking via
+  `tools/type-checking/type-check.sh check <files...>` (paths positional, relative to `tests/`)
+  to scope it to your changes. Do not invoke `type-check.py` directly.
+  See `tools/type-checking/README.md` for more details: the per-file
+  strictness levels in `type-check-strictness.json` and how to promote
+  files to stricter levels after adding type hints.
 
 ### Instructions for type hints
 

--- a/tools/type-checking/README.md
+++ b/tools/type-checking/README.md
@@ -20,6 +20,8 @@ The main type checking orchestration script. Provides multiple commands:
 - **`promotion-check`** - Identify files that can be promoted to stricter type checking levels
 - **`fruit`** - Show files with fewest errors at each target level (low-hanging fruit for type checking improvements)
 - **`ci`** - Run both `check` and `promotion-check` and decorates the results (used in CI)
+- **`check-sorted`** - Verify that `type-check-strictness.json` is sorted
+- **`pre-commit`** - Run `check` on changed files (intended for use as a pre-commit hook); accepts paths rooted at repo root (`tests/...`) and strips the prefix internally
 
 ### `type-check-strictness.json`
 
@@ -88,8 +90,8 @@ task rp:type-check -- promotion-check --update
 # Run CI checks (both check and promotion-check)
 task rp:type-check -- ci
 
-# Check specific files
-task rp:type-check -- check --input-files "rptest/tests/my_test.py"
+# Check specific files (paths/globs are positional, relative to tests/)
+task rp:type-check -- check rptest/tests/my_test.py
 
 # Force all files to be checked at a specific level
 task rp:type-check -- check --force-level strict
@@ -151,7 +153,7 @@ git commit -m "chore: update type checking strictness"
 
 - `--tests-root PATH` - Path to tests directory (auto-detected by default)
 - `--config PATH` - Path to pyrightconfig.json
-- `--input-files GLOB` - Glob pattern for files to check (default: `rptest/**/*.py`)
+- `input_files` - Positional paths/globs of files to check, relative to `tests/` (default: `rptest/**/*.py`)
 - `--force-level LEVEL` - Override strictness levels and check all files at specified level
 - `--no-venv` - Don't use virtual environment when running pyright
 - `--verbose [LEVEL]` - Enable verbose output (0=off, 1=verbose, 2=very verbose)


### PR DESCRIPTION
Two small docs fixes around the ducktape type-checking tooling:

1. The `tools/type-checking/README.md` referenced a `--input-files GLOB`
   flag that no longer exists (input files are positional now), and was
   missing two commands that have since been added to the script
   (`check-sorted`, `pre-commit`). Fix the example, the option list,
   and the command list so the README matches the current CLI.

2. `CLAUDE.md` had no guidance about type checking after modifying
   files under `tests/rptest`. Add a short instruction pointing at
   `tools/type-checking/type-check.sh check <files...>` as the way to
   scope a check to changed files, with a pointer to the README for
   the strictness-level workflow.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none