### PR TITLE
[v25.3.x] datalake: stop bucketing unknown_error as file_io_error

### DIFF
--- a/src/v/datalake/translation/deps.cc
+++ b/src/v/datalake/translation/deps.cc
@@ -50,6 +50,8 @@ map_error_code(datalake::translation_task::errc errc) {
         return translation_errc::out_of_disk;
     case datalake::translation_task::errc::type_resolution_error:
         return translation_errc::type_resolution_error;
+    case datalake::translation_task::errc::unknown_error:
+        return translation_errc::unknown_error;
     }
 }
 } // namespace
@@ -454,6 +456,8 @@ std::ostream& operator<<(std::ostream& o, translation_errc ec) {
         return o << "translation_errc::out_of_disk";
     case type_resolution_error:
         return o << "translation_errc::type_resolution_error";
+    case unknown_error:
+        return o << "translation_errc::unknown_error";
     }
 }
 

--- a/src/v/datalake/translation/deps.h
+++ b/src/v/datalake/translation/deps.h
@@ -216,6 +216,7 @@ enum translation_errc {
     shutting_down,
     out_of_disk,
     type_resolution_error,
+    unknown_error,
 };
 
 std::ostream& operator<<(std::ostream&, translation_errc);

--- a/src/v/datalake/translation_task.cc
+++ b/src/v/datalake/translation_task.cc
@@ -55,7 +55,7 @@ translation_task::errc map_error_code(writer_error errc) {
     case writer_error::out_of_disk:
         return translation_task::errc::out_of_disk;
     case writer_error::unknown_error:
-        return translation_task::errc::file_io_error;
+        return translation_task::errc::unknown_error;
     case writer_error::retryable_type_resolution_error:
         return translation_task::errc::type_resolution_error;
     }
@@ -428,6 +428,8 @@ std::ostream& operator<<(std::ostream& o, translation_task::errc ec) {
         return o << "disk exhausted";
     case translation_task::errc::type_resolution_error:
         return o << "type resolution error";
+    case translation_task::errc::unknown_error:
+        return o << "unknown error";
     }
 }
 } // namespace datalake

--- a/src/v/datalake/translation_task.h
+++ b/src/v/datalake/translation_task.h
@@ -55,6 +55,7 @@ public:
         shutting_down,
         out_of_disk,
         type_resolution_error,
+        unknown_error,
     };
 
     using custom_partitioning_enabled


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30600

- Command: git cherry-pick -x 75e1fada8b
- Commits backported: 1
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-30600-v25.3.x-1779909354

## Conflict details

- 75e1fada8b (src/v/datalake/translation/deps.h, src/v/datalake/translation_task.h): dev replaced the `operator<<` stream overload with an inline `format_to` member; v25.3.x still uses `operator<<` declared in the header and defined in the `.cc`. Kept the target branch's `operator<<` declarations and instead added the new `unknown_error` case to the existing `operator<<` definitions in `src/v/datalake/translation/deps.cc` and `src/v/datalake/translation_task.cc` so the switch over the enum stays exhaustive.
