### PR TITLE
dt/tests: bump franz-bench franz-go to v1.20.7

### DIFF
--- a/tests/docker/ducktape-deps/franz-bench
+++ b/tests/docker/ducktape-deps/franz-bench
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-git -C /opt clone -b v1.5.0 --single-branch https://github.com/twmb/franz-go.git
+git -C /opt clone -b v1.20.7 --single-branch https://github.com/twmb/franz-go.git
 cd /opt/franz-go/examples/bench
 go mod tidy
 go build


### PR DESCRIPTION
Bumps `franz-bench`'s franz-go pin from v1.5.0 to v1.20.7, matching the
v1.20.x version used by kgo-verifier and transform-verifier.

Part of the ENG-1185 client modernization for Kafka 4.x.

Fixes [CORE-16384](https://redpandadata.atlassian.net/browse/CORE-16384)

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

[CORE-16384]: https://redpandadata.atlassian.net/browse/CORE-16384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ