### PR TITLE
`ct/l1`: fix reversed scheduling policies

### DIFF
--- a/src/v/cloud_topics/level_one/maintenance/scheduling_policies.h
+++ b/src/v/cloud_topics/level_one/maintenance/scheduling_policies.h
@@ -44,10 +44,9 @@ private:
               a->compaction_info_and_ts.has_value()
                 && b->compaction_info_and_ts.has_value(),
               "Sorting policy applied to logs without compaction_info_and_ts "
-              "assigned- "
-              "concurrency issue?");
+              "assigned- concurrency issue?");
             return a->compaction_info_and_ts->info.dirty_ratio
-                   > b->compaction_info_and_ts->info.dirty_ratio;
+                   < b->compaction_info_and_ts->info.dirty_ratio;
         }
     };
 };
@@ -67,10 +66,9 @@ private:
               a->compaction_info_and_ts.has_value()
                 && b->compaction_info_and_ts.has_value(),
               "Sorting policy applied to logs without compaction_info_and_ts "
-              "assigned- "
-              "concurrency issue?");
+              "assigned- concurrency issue?");
             return a->compaction_info_and_ts->info.earliest_dirty_ts
-                   < b->compaction_info_and_ts->info.earliest_dirty_ts;
+                   > b->compaction_info_and_ts->info.earliest_dirty_ts;
         }
     };
 };

--- a/src/v/cloud_topics/level_one/maintenance/tests/BUILD
+++ b/src/v/cloud_topics/level_one/maintenance/tests/BUILD
@@ -9,6 +9,7 @@ redpanda_cc_gtest(
     deps = [
         "//src/v/cloud_topics/level_one/maintenance:meta",
         "//src/v/cloud_topics/level_one/maintenance:scheduler_probe",
+        "//src/v/cloud_topics/level_one/maintenance:scheduling_policies",
         "//src/v/cloud_topics/level_one/maintenance:worker",
         "//src/v/cluster:fwd",
         "//src/v/cluster:members_table",

--- a/src/v/cloud_topics/level_one/maintenance/tests/worker_manager_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/tests/worker_manager_test.cc
@@ -10,6 +10,7 @@
 
 #include "cloud_topics/level_one/maintenance/meta.h"
 #include "cloud_topics/level_one/maintenance/scheduler_probe.h"
+#include "cloud_topics/level_one/maintenance/scheduling_policies.h"
 #include "cloud_topics/level_one/maintenance/worker.h"
 #include "cloud_topics/level_one/maintenance/worker_manager.h"
 #include "model/fundamental.h"
@@ -110,4 +111,85 @@ TEST_F(WorkerManagerTestFixture, AcquireWork) {
     manager.complete_work(work_opt.value().get());
     ASSERT_FALSE(work_opt.value()->inflight_shard.has_value());
     ASSERT_EQ(work_opt.value()->state, state::idle);
+}
+
+// Verifies that `dirty_ratio_scheduling_policy` orders partitions from
+// highest `dirty_ratio` to lowest.
+TEST(DirtyRatioSchedulingPolicyTest, OrdersHighestDirtyRatioFirst) {
+    auto make_meta = [](std::string_view topic_name, double ratio) {
+        auto ntp = model::ntp(
+          model::ns("kafka"),
+          model::topic(ss::sstring{topic_name}),
+          model::partition_id(0));
+        auto tidp = model::topic_id_partition(
+          model::topic_id(uuid_t::create()), ntp.tp.partition);
+        auto m = ss::make_lw_shared<l1::log_compaction_meta>(tidp, ntp);
+        m->compaction_info_and_ts = l1::compaction_info_and_timestamp{
+          .info = {.dirty_ratio = ratio},
+          .collected_at = model::timestamp::now(),
+          .max_compactible_offset = kafka::offset::max(),
+        };
+        return m;
+    };
+
+    auto low = make_meta("low", 0.1);
+    auto mid = make_meta("mid", 0.5);
+    auto high = make_meta("high", 0.9);
+
+    l1::dirty_ratio_scheduling_policy policy;
+    l1::log_compaction_queue q(policy.get_comparator());
+    q.push(low);
+    q.push(mid);
+    q.push(high);
+
+    // Pop order should be: most dirty -> least dirty.
+    ASSERT_DOUBLE_EQ(q.top()->compaction_info_and_ts->info.dirty_ratio, 0.9);
+    q.pop();
+    ASSERT_DOUBLE_EQ(q.top()->compaction_info_and_ts->info.dirty_ratio, 0.5);
+    q.pop();
+    ASSERT_DOUBLE_EQ(q.top()->compaction_info_and_ts->info.dirty_ratio, 0.1);
+}
+
+// Verifies that `compaction_lag_scheduling_policy` orders partitions from
+// highest lag (oldest `earliest_dirty_ts`) to lowest (most recent).
+TEST(CompactionLagSchedulingPolicyTest, OrdersHighestLagFirst) {
+    auto make_meta = [](std::string_view topic_name, model::timestamp ts) {
+        auto ntp = model::ntp(
+          model::ns("kafka"),
+          model::topic(ss::sstring{topic_name}),
+          model::partition_id(0));
+        auto tidp = model::topic_id_partition(
+          model::topic_id(uuid_t::create()), ntp.tp.partition);
+        auto m = ss::make_lw_shared<l1::log_compaction_meta>(tidp, ntp);
+        m->compaction_info_and_ts = l1::compaction_info_and_timestamp{
+          .info = {.earliest_dirty_ts = ts},
+          .collected_at = model::timestamp::now(),
+          .max_compactible_offset = kafka::offset::max(),
+        };
+        return m;
+    };
+
+    // Smaller timestamp = older = higher lag.
+    auto old_log = make_meta("old", model::timestamp{1000});
+    auto mid_log = make_meta("mid", model::timestamp{5000});
+    auto new_log = make_meta("new", model::timestamp{9000});
+
+    l1::compaction_lag_scheduling_policy policy;
+    l1::log_compaction_queue q(policy.get_comparator());
+    q.push(mid_log);
+    q.push(new_log);
+    q.push(old_log);
+
+    // Pop order should be: oldest (highest lag) -> newest (lowest lag).
+    ASSERT_EQ(
+      q.top()->compaction_info_and_ts->info.earliest_dirty_ts,
+      model::timestamp{1000});
+    q.pop();
+    ASSERT_EQ(
+      q.top()->compaction_info_and_ts->info.earliest_dirty_ts,
+      model::timestamp{5000});
+    q.pop();
+    ASSERT_EQ(
+      q.top()->compaction_info_and_ts->info.earliest_dirty_ts,
+      model::timestamp{9000});
 }


### PR DESCRIPTION
Oops. These accidentally sorted in the opposite order as claimed/intended.

:facepalm: 

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
