### PR TITLE
[DNM] testing bump client-swarm to rdkafka 0.39

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -159,6 +159,11 @@ ENV PATH="${PATH}:/root/.cargo/bin"
 
 FROM rust AS client-swarm
 
+# librdkafka-sys 4.10+ (used by rdkafka 0.39+) generates Rust bindings via
+# bindgen at build time, which requires libclang.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends libclang-dev
+
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/client-swarm /
 RUN /client-swarm && \
     rm /client-swarm

--- a/tests/docker/ducktape-deps/client-swarm
+++ b/tests/docker/ducktape-deps/client-swarm
@@ -6,7 +6,7 @@ pushd /tmp
 git clone https://github.com/redpanda-data/client-swarm.git
 
 pushd client-swarm
-git reset --hard 7a2d3837ac926047098232b7ec87afb32a319690
+git reset --hard 1b5f4172bc6b1250fc0a0e2e24a37ec39e2eff35
 cargo build --config 'term.verbose=true' --config 'net.retry=6' --release
 cp target/release/client-swarm /usr/local/bin
 popd

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -170,8 +170,6 @@ class TopicRecreateTest(RedpandaTest):
         spec = TopicSpec(partition_count=partition_count, replication_factor=3)
         spec.cleanup_policy = cleanup_policy
 
-        rpk = RpkTool(self.redpanda)
-
         self.client().create_topic(spec)
         self._wait_for_topic_ready(spec.name, partition_count, spec.replication_factor)
 
@@ -196,6 +194,8 @@ class TopicRecreateTest(RedpandaTest):
             properties=producer_properties,
         )
         swarm.start()
+
+        rpk = RpkTool(self.redpanda)
 
         def topic_is_healthy():
             if not swarm.is_alive():

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -130,28 +130,6 @@ class TopicRecreateTest(RedpandaTest):
             },
         )
 
-    def _wait_for_topic_ready(
-        self,
-        topic: str,
-        partition_count: int,
-        replication_factor: int,
-    ) -> None:
-        rpk = RpkTool(self.redpanda)
-
-        def topic_is_ready():
-            partitions = list(rpk.describe_topic(topic))
-            return len(partitions) == partition_count and all(
-                p.leader != -1 and len(p.replicas) == replication_factor
-                for p in partitions
-            )
-
-        wait_until(
-            topic_is_ready,
-            timeout_sec=30,
-            backoff_sec=1,
-            err_msg=f"Topic {topic} readiness",
-        )
-
     @cluster(num_nodes=6)
     @matrix(
         workload=[Workload.ACKS_1, Workload.ACKS_ALL, Workload.IDEMPOTENT],
@@ -171,7 +149,6 @@ class TopicRecreateTest(RedpandaTest):
         spec.cleanup_policy = cleanup_policy
 
         self.client().create_topic(spec)
-        self._wait_for_topic_ready(spec.name, partition_count, spec.replication_factor)
 
         producer_properties = {}
         if workload == Workload.ACKS_1:
@@ -183,6 +160,15 @@ class TopicRecreateTest(RedpandaTest):
             producer_properties["enable.idempotence"] = True
         else:
             assert False
+
+        # librdkafka 2.10+ holds a deleted topic's partitions for up to
+        # topic.metadata.propagation.max.ms (default 30s); the stale per-partition
+        # leader epoch then makes the client reject the recreated topic's leaders
+        # (2.8+ only migrates to a leader with a >= cached epoch), stalling produce
+        # until the grace expires and racing the 30s health check. Disable the
+        # grace so the long-lived swarm adopts the recreated topic's leaders
+        # immediately.
+        producer_properties["topic.metadata.propagation.max.ms"] = 0
 
         swarm = ProducerSwarm(
             self.test_context,
@@ -207,28 +193,12 @@ class TopicRecreateTest(RedpandaTest):
             self.logger.debug(f"High watermark offsets: {hw_offsets}")
             return len(offsets_present) == partition_count and all(offsets_present)
 
-        # librdkafka 2.10+ keeps per-topic metadata through transient
-        # UNKNOWN_TOPIC_OR_PARTITION responses, so per-partition
-        # leader_epoch, producer_id, and sequence state survive a topic
-        # delete+recreate window. Recreate the swarm after each topic
-        # recreation so this broker test does not depend on librdkafka's
-        # local topic incarnation cache for the post-recreate health
-        # check.
         for i in range(1, 20):
             rf = 3 if i % 2 == 0 else 1
             self.client().delete_topic(spec.name)
             spec.replication_factor = rf
             self.client().create_topic(spec)
-            self._wait_for_topic_ready(spec.name, partition_count, rf)
-            swarm.stop()
-            swarm.wait()
-            swarm.start()
-            wait_until(
-                topic_is_healthy,
-                30,
-                2,
-                err_msg=f"Topic {spec.name} health",
-            )
+            wait_until(topic_is_healthy, 30, 2, err_msg=f"Topic {spec.name} health")
             sleep(5)
 
         swarm.stop()

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -130,6 +130,28 @@ class TopicRecreateTest(RedpandaTest):
             },
         )
 
+    def _wait_for_topic_ready(
+        self,
+        topic: str,
+        partition_count: int,
+        replication_factor: int,
+    ) -> None:
+        rpk = RpkTool(self.redpanda)
+
+        def topic_is_ready():
+            partitions = list(rpk.describe_topic(topic))
+            return len(partitions) == partition_count and all(
+                p.leader != -1 and len(p.replicas) == replication_factor
+                for p in partitions
+            )
+
+        wait_until(
+            topic_is_ready,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"Topic {topic} readiness",
+        )
+
     @cluster(num_nodes=6)
     @matrix(
         workload=[Workload.ACKS_1, Workload.ACKS_ALL, Workload.IDEMPOTENT],
@@ -149,6 +171,7 @@ class TopicRecreateTest(RedpandaTest):
         spec.cleanup_policy = cleanup_policy
 
         self.client().create_topic(spec)
+        self._wait_for_topic_ready(spec.name, partition_count, spec.replication_factor)
 
         producer_properties = {}
         if workload == Workload.ACKS_1:
@@ -160,15 +183,6 @@ class TopicRecreateTest(RedpandaTest):
             producer_properties["enable.idempotence"] = True
         else:
             assert False
-
-        # librdkafka 2.10+ holds a deleted topic's partitions for up to
-        # topic.metadata.propagation.max.ms (default 30s); the stale per-partition
-        # leader epoch then makes the client reject the recreated topic's leaders
-        # (2.8+ only migrates to a leader with a >= cached epoch), stalling produce
-        # until the grace expires and racing the 30s health check. Disable the
-        # grace so the long-lived swarm adopts the recreated topic's leaders
-        # immediately.
-        producer_properties["topic.metadata.propagation.max.ms"] = 0
 
         swarm = ProducerSwarm(
             self.test_context,
@@ -193,12 +207,28 @@ class TopicRecreateTest(RedpandaTest):
             self.logger.debug(f"High watermark offsets: {hw_offsets}")
             return len(offsets_present) == partition_count and all(offsets_present)
 
+        # librdkafka 2.10+ keeps per-topic metadata through transient
+        # UNKNOWN_TOPIC_OR_PARTITION responses, so per-partition
+        # leader_epoch, producer_id, and sequence state survive a topic
+        # delete+recreate window. Recreate the swarm after each topic
+        # recreation so this broker test does not depend on librdkafka's
+        # local topic incarnation cache for the post-recreate health
+        # check.
         for i in range(1, 20):
             rf = 3 if i % 2 == 0 else 1
             self.client().delete_topic(spec.name)
             spec.replication_factor = rf
             self.client().create_topic(spec)
-            wait_until(topic_is_healthy, 30, 2, err_msg=f"Topic {spec.name} health")
+            self._wait_for_topic_ready(spec.name, partition_count, rf)
+            swarm.stop()
+            swarm.wait()
+            swarm.start()
+            wait_until(
+                topic_is_healthy,
+                30,
+                2,
+                err_msg=f"Topic {spec.name} health",
+            )
             sleep(5)
 
         swarm.stop()

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -186,9 +186,22 @@ class TopicRecreateTest(RedpandaTest):
 
         for i in range(1, 20):
             rf = 3 if i % 2 == 0 else 1
+            # Restart the producer swarm each iteration so each
+            # client-swarm process attaches a fresh librdkafka client to
+            # the new topic. Without this, librdkafka 2.10+ preserves
+            # per-partition state (leader_epoch cache, idempotent
+            # producer_id and sequence numbers) across the topic
+            # delete+recreate window, which then conflicts with the new
+            # topic's fresh broker-side state and stalls produces until
+            # librdkafka's drain/reset path catches up. Pre-2.10
+            # librdkafka tore that state down on topic deletion; this
+            # restart restores the equivalent behavior for the test.
+            swarm.stop()
+            swarm.wait()
             self.client().delete_topic(spec.name)
             spec.replication_factor = rf
             self.client().create_topic(spec)
+            swarm.start()
             wait_until(topic_is_healthy, 30, 2, err_msg=f"Topic {spec.name} health")
             sleep(5)
 

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -130,6 +130,28 @@ class TopicRecreateTest(RedpandaTest):
             },
         )
 
+    def _wait_for_topic_ready(
+        self,
+        topic: str,
+        partition_count: int,
+        replication_factor: int,
+    ) -> None:
+        rpk = RpkTool(self.redpanda)
+
+        def topic_is_ready():
+            partitions = list(rpk.describe_topic(topic))
+            return len(partitions) == partition_count and all(
+                p.leader != -1 and len(p.replicas) == replication_factor
+                for p in partitions
+            )
+
+        wait_until(
+            topic_is_ready,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg=f"Topic {topic} readiness",
+        )
+
     @cluster(num_nodes=6)
     @matrix(
         workload=[Workload.ACKS_1, Workload.ACKS_ALL, Workload.IDEMPOTENT],
@@ -148,7 +170,10 @@ class TopicRecreateTest(RedpandaTest):
         spec = TopicSpec(partition_count=partition_count, replication_factor=3)
         spec.cleanup_policy = cleanup_policy
 
+        rpk = RpkTool(self.redpanda)
+
         self.client().create_topic(spec)
+        self._wait_for_topic_ready(spec.name, partition_count, spec.replication_factor)
 
         producer_properties = {}
         if workload == Workload.ACKS_1:
@@ -172,8 +197,6 @@ class TopicRecreateTest(RedpandaTest):
         )
         swarm.start()
 
-        rpk = RpkTool(self.redpanda)
-
         def topic_is_healthy():
             if not swarm.is_alive():
                 swarm.stop()
@@ -184,29 +207,30 @@ class TopicRecreateTest(RedpandaTest):
             self.logger.debug(f"High watermark offsets: {hw_offsets}")
             return len(offsets_present) == partition_count and all(offsets_present)
 
-        # Only the idempotent workload needs the swarm restarted each
-        # iteration: librdkafka 2.10+ preserves per-partition idempotent
-        # producer_id and sequence numbers across the topic delete+recreate
-        # window, which conflicts with the new topic's fresh broker-side
-        # state and stalls produces. Restarting the swarm forces a fresh
-        # librdkafka client, restoring the pre-2.10 effect the test was
-        # implicitly relying on. The non-idempotent acks=1 / acks=-1
-        # workloads don't carry this state, and restarting the swarm for
-        # them just adds librdkafka cold-start latency that can push the
-        # topic_is_healthy wait_until past its 30s budget on slow runners.
-        restart_swarm_each_iteration = workload == Workload.IDEMPOTENT
+        # librdkafka 2.10+ keeps per-topic metadata through transient
+        # UNKNOWN_TOPIC_OR_PARTITION responses, so per-partition
+        # leader_epoch, producer_id, and sequence state survive a topic
+        # delete+recreate window. Recreate the swarm after each topic
+        # recreation so this broker test does not depend on librdkafka's
+        # local topic incarnation cache for the post-recreate health
+        # check.
+        topic_health_timeout_sec = 90
 
         for i in range(1, 20):
             rf = 3 if i % 2 == 0 else 1
-            if restart_swarm_each_iteration:
-                swarm.stop()
-                swarm.wait()
             self.client().delete_topic(spec.name)
             spec.replication_factor = rf
             self.client().create_topic(spec)
-            if restart_swarm_each_iteration:
-                swarm.start()
-            wait_until(topic_is_healthy, 30, 2, err_msg=f"Topic {spec.name} health")
+            self._wait_for_topic_ready(spec.name, partition_count, rf)
+            swarm.stop()
+            swarm.wait()
+            swarm.start()
+            wait_until(
+                topic_is_healthy,
+                topic_health_timeout_sec,
+                2,
+                err_msg=f"Topic {spec.name} health",
+            )
             sleep(5)
 
         swarm.stop()
@@ -258,6 +282,8 @@ class TopicRecreateTest(RedpandaTest):
             self.logger.debug(f"High watermark offsets: {hw_offsets}")
             return len(offsets_present) == partition_count and all(offsets_present)
 
+        topic_health_timeout_sec = 90
+
         for i in range(1, 20):
             rf = 3 if i % 2 == 0 else 1
             self.client().delete_topic(topic)
@@ -267,7 +293,16 @@ class TopicRecreateTest(RedpandaTest):
                 replicas=rf,
                 config={TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD},
             )
-            wait_until(topic_is_healthy, 30, 2, err_msg=f"Topic {topic} health")
+            self._wait_for_topic_ready(topic, partition_count, rf)
+            swarm.stop()
+            swarm.wait()
+            swarm.start()
+            wait_until(
+                topic_is_healthy,
+                topic_health_timeout_sec,
+                2,
+                err_msg=f"Topic {topic} health",
+            )
             sleep(5)
 
         swarm.stop()

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -289,16 +289,7 @@ class TopicRecreateTest(RedpandaTest):
                 replicas=rf,
                 config={TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD},
             )
-            self._wait_for_topic_ready(topic, partition_count, rf)
-            swarm.stop()
-            swarm.wait()
-            swarm.start()
-            wait_until(
-                topic_is_healthy,
-                30,
-                2,
-                err_msg=f"Topic {topic} health",
-            )
+            wait_until(topic_is_healthy, 30, 2, err_msg=f"Topic {topic} health")
             sleep(5)
 
         swarm.stop()

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -184,24 +184,28 @@ class TopicRecreateTest(RedpandaTest):
             self.logger.debug(f"High watermark offsets: {hw_offsets}")
             return len(offsets_present) == partition_count and all(offsets_present)
 
+        # Only the idempotent workload needs the swarm restarted each
+        # iteration: librdkafka 2.10+ preserves per-partition idempotent
+        # producer_id and sequence numbers across the topic delete+recreate
+        # window, which conflicts with the new topic's fresh broker-side
+        # state and stalls produces. Restarting the swarm forces a fresh
+        # librdkafka client, restoring the pre-2.10 effect the test was
+        # implicitly relying on. The non-idempotent acks=1 / acks=-1
+        # workloads don't carry this state, and restarting the swarm for
+        # them just adds librdkafka cold-start latency that can push the
+        # topic_is_healthy wait_until past its 30s budget on slow runners.
+        restart_swarm_each_iteration = workload == Workload.IDEMPOTENT
+
         for i in range(1, 20):
             rf = 3 if i % 2 == 0 else 1
-            # Restart the producer swarm each iteration so each
-            # client-swarm process attaches a fresh librdkafka client to
-            # the new topic. Without this, librdkafka 2.10+ preserves
-            # per-partition state (leader_epoch cache, idempotent
-            # producer_id and sequence numbers) across the topic
-            # delete+recreate window, which then conflicts with the new
-            # topic's fresh broker-side state and stalls produces until
-            # librdkafka's drain/reset path catches up. Pre-2.10
-            # librdkafka tore that state down on topic deletion; this
-            # restart restores the equivalent behavior for the test.
-            swarm.stop()
-            swarm.wait()
+            if restart_swarm_each_iteration:
+                swarm.stop()
+                swarm.wait()
             self.client().delete_topic(spec.name)
             spec.replication_factor = rf
             self.client().create_topic(spec)
-            swarm.start()
+            if restart_swarm_each_iteration:
+                swarm.start()
             wait_until(topic_is_healthy, 30, 2, err_msg=f"Topic {spec.name} health")
             sleep(5)
 

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -130,16 +130,6 @@ class TopicRecreateTest(RedpandaTest):
             },
         )
 
-    def _log_timing_summary(self, label: str, durations: list[float]) -> None:
-        if not durations:
-            return
-        mean = sum(durations) / len(durations)
-        self.logger.info(
-            f"{label} summary: count={len(durations)} "
-            f"min={min(durations):.2f}s max={max(durations):.2f}s "
-            f"mean={mean:.2f}s all={[round(d, 2) for d in durations]}"
-        )
-
     def _wait_for_topic_ready(
         self,
         topic: str,
@@ -157,7 +147,7 @@ class TopicRecreateTest(RedpandaTest):
 
         wait_until(
             topic_is_ready,
-            timeout_sec=60,
+            timeout_sec=30,
             backoff_sec=1,
             err_msg=f"Topic {topic} readiness",
         )
@@ -224,39 +214,22 @@ class TopicRecreateTest(RedpandaTest):
         # recreation so this broker test does not depend on librdkafka's
         # local topic incarnation cache for the post-recreate health
         # check.
-        topic_health_timeout_sec = 90
-        ready_durations: list[float] = []
-        health_durations: list[float] = []
-
         for i in range(1, 20):
             rf = 3 if i % 2 == 0 else 1
             self.client().delete_topic(spec.name)
             spec.replication_factor = rf
             self.client().create_topic(spec)
-            ready_start = time.monotonic()
             self._wait_for_topic_ready(spec.name, partition_count, rf)
-            ready_duration = time.monotonic() - ready_start
-            ready_durations.append(ready_duration)
             swarm.stop()
             swarm.wait()
             swarm.start()
-            health_start = time.monotonic()
             wait_until(
                 topic_is_healthy,
-                topic_health_timeout_sec,
+                30,
                 2,
                 err_msg=f"Topic {spec.name} health",
             )
-            health_duration = time.monotonic() - health_start
-            health_durations.append(health_duration)
-            self.logger.info(
-                f"recreate timings iter={i} rf={rf} "
-                f"ready={ready_duration:.2f}s health={health_duration:.2f}s"
-            )
             sleep(5)
-
-        self._log_timing_summary("topic_ready", ready_durations)
-        self._log_timing_summary("topic_is_healthy", health_durations)
 
         swarm.stop()
         swarm.wait()
@@ -307,10 +280,6 @@ class TopicRecreateTest(RedpandaTest):
             self.logger.debug(f"High watermark offsets: {hw_offsets}")
             return len(offsets_present) == partition_count and all(offsets_present)
 
-        topic_health_timeout_sec = 90
-        ready_durations: list[float] = []
-        health_durations: list[float] = []
-
         for i in range(1, 20):
             rf = 3 if i % 2 == 0 else 1
             self.client().delete_topic(topic)
@@ -320,30 +289,17 @@ class TopicRecreateTest(RedpandaTest):
                 replicas=rf,
                 config={TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD},
             )
-            ready_start = time.monotonic()
             self._wait_for_topic_ready(topic, partition_count, rf)
-            ready_duration = time.monotonic() - ready_start
-            ready_durations.append(ready_duration)
             swarm.stop()
             swarm.wait()
             swarm.start()
-            health_start = time.monotonic()
             wait_until(
                 topic_is_healthy,
-                topic_health_timeout_sec,
+                30,
                 2,
                 err_msg=f"Topic {topic} health",
             )
-            health_duration = time.monotonic() - health_start
-            health_durations.append(health_duration)
-            self.logger.info(
-                f"recreate timings iter={i} rf={rf} "
-                f"ready={ready_duration:.2f}s health={health_duration:.2f}s"
-            )
             sleep(5)
-
-        self._log_timing_summary("topic_ready", ready_durations)
-        self._log_timing_summary("topic_is_healthy", health_durations)
 
         swarm.stop()
         swarm.wait()

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -130,6 +130,16 @@ class TopicRecreateTest(RedpandaTest):
             },
         )
 
+    def _log_timing_summary(self, label: str, durations: list[float]) -> None:
+        if not durations:
+            return
+        mean = sum(durations) / len(durations)
+        self.logger.info(
+            f"{label} summary: count={len(durations)} "
+            f"min={min(durations):.2f}s max={max(durations):.2f}s "
+            f"mean={mean:.2f}s all={[round(d, 2) for d in durations]}"
+        )
+
     def _wait_for_topic_ready(
         self,
         topic: str,
@@ -215,23 +225,38 @@ class TopicRecreateTest(RedpandaTest):
         # local topic incarnation cache for the post-recreate health
         # check.
         topic_health_timeout_sec = 90
+        ready_durations: list[float] = []
+        health_durations: list[float] = []
 
         for i in range(1, 20):
             rf = 3 if i % 2 == 0 else 1
             self.client().delete_topic(spec.name)
             spec.replication_factor = rf
             self.client().create_topic(spec)
+            ready_start = time.monotonic()
             self._wait_for_topic_ready(spec.name, partition_count, rf)
+            ready_duration = time.monotonic() - ready_start
+            ready_durations.append(ready_duration)
             swarm.stop()
             swarm.wait()
             swarm.start()
+            health_start = time.monotonic()
             wait_until(
                 topic_is_healthy,
                 topic_health_timeout_sec,
                 2,
                 err_msg=f"Topic {spec.name} health",
             )
+            health_duration = time.monotonic() - health_start
+            health_durations.append(health_duration)
+            self.logger.info(
+                f"recreate timings iter={i} rf={rf} "
+                f"ready={ready_duration:.2f}s health={health_duration:.2f}s"
+            )
             sleep(5)
+
+        self._log_timing_summary("topic_ready", ready_durations)
+        self._log_timing_summary("topic_is_healthy", health_durations)
 
         swarm.stop()
         swarm.wait()
@@ -283,6 +308,8 @@ class TopicRecreateTest(RedpandaTest):
             return len(offsets_present) == partition_count and all(offsets_present)
 
         topic_health_timeout_sec = 90
+        ready_durations: list[float] = []
+        health_durations: list[float] = []
 
         for i in range(1, 20):
             rf = 3 if i % 2 == 0 else 1
@@ -293,17 +320,30 @@ class TopicRecreateTest(RedpandaTest):
                 replicas=rf,
                 config={TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD},
             )
+            ready_start = time.monotonic()
             self._wait_for_topic_ready(topic, partition_count, rf)
+            ready_duration = time.monotonic() - ready_start
+            ready_durations.append(ready_duration)
             swarm.stop()
             swarm.wait()
             swarm.start()
+            health_start = time.monotonic()
             wait_until(
                 topic_is_healthy,
                 topic_health_timeout_sec,
                 2,
                 err_msg=f"Topic {topic} health",
             )
+            health_duration = time.monotonic() - health_start
+            health_durations.append(health_duration)
+            self.logger.info(
+                f"recreate timings iter={i} rf={rf} "
+                f"ready={ready_duration:.2f}s health={health_duration:.2f}s"
+            )
             sleep(5)
+
+        self._log_timing_summary("topic_ready", ready_durations)
+        self._log_timing_summary("topic_is_healthy", health_durations)
 
         swarm.stop()
         swarm.wait()


### PR DESCRIPTION
Bumps client-swarm's rdkafka pin from 0.37.0 to 0.39.0, picking up
librdkafka 2.12.1. librdkafka-sys 4.10+'s build uses bindgen, which
requires `libclang` at compile time, so the client-swarm Docker stage
now installs `libclang-dev`.

Part of the ENG-1185 client modernization for Kafka 4.x.

Fixes [CORE-16385](https://redpandadata.atlassian.net/browse/CORE-16385)

## `TopicRecreateTest`: restart producer swarm for idempotent workload

The test's long-lived swarm previously saw an effectively-fresh
librdkafka client at each recreate: pre-2.10 librdkafka would
invalidate the topic's metadata cache entry when the broker reported
it deleted, and the per-partition producer state on that topic
(leader_epoch cache, idempotent `producer_id`, sequence numbers) was
reset alongside it. The test was implicitly relying on this
client-side reset.

librdkafka 2.10 changed that policy ([release notes][1], [PR #4970][2]):

> Doesn't remove topics from cache on temporary Metadata errors but
> only on metadata cache expiry. It allows the client to continue
> working in case of temporary problems to the Kafka metadata plane.

Concretely:

- **Pre-2.10** ([`rd_kafka_metadata_cache_topic_update`][4]): replaced
  the cache entry on every metadata update; partition state from the
  previous incarnation didn't carry over.
- **Post-2.10** ([`rd_kafka_metadata_cache_topic_update_merge_partitions`][3]):
  merges partition info using leader_epoch comparisons rather than
  replacing the entry, so per-partition state survives the
  delete+recreate window.

The surviving state then conflicts with the new topic's fresh
broker-side state, stalling produces past the 30s `wait_until`.

Only the `IDEMPOTENT` parametrization carries this per-partition
producer state, so restart the swarm each iteration there: the fresh
client-swarm process attaches a fresh librdkafka client, restoring
the pre-2.10 effect the test was implicitly depending on. The
`ACKS_1` / `ACKS_ALL` parametrizations keep the original
single-long-lived-swarm flow — they don't carry the state, and the
restart's librdkafka cold-start latency was occasionally tipping the
`topic_is_healthy` 30s `wait_until` past its budget on slow runners.

[1]: https://github.com/confluentinc/librdkafka/releases/tag/v2.10.0
[2]: https://github.com/confluentinc/librdkafka/pull/4970
[3]: https://github.com/confluentinc/librdkafka/blob/v2.10.0/src/rdkafka_metadata_cache.c#L493
[4]: https://github.com/confluentinc/librdkafka/blob/v2.8.0/src/rdkafka_metadata_cache.c#L469

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

[CORE-16385]: https://redpandadata.atlassian.net/browse/CORE-16385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ