### PR TITLE
rpk/registry: skip admin API context check on cloud profiles

### DIFF
--- a/src/go/rpk/pkg/cli/registry/context/context.go
+++ b/src/go/rpk/pkg/cli/registry/context/context.go
@@ -50,6 +50,9 @@ func ListContexts(ctx context.Context, cl *sr.Client) ([]string, error) {
 // schema_registry_enable_qualified_subjects config set to true via the
 // Admin API.
 func checkQualifiedSubjectsEnabled(ctx context.Context, fs afero.Fs, profile *config.RpkProfile) error {
+	if profile.FromCloud {
+		return fmt.Errorf("unable to verify schema context support: admin API is not available on cloud clusters\nUse --skip-context-check to skip this verification")
+	}
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	cl, err := adminapi.NewClient(ctx, fs, profile)

--- a/src/go/rpk/pkg/cli/registry/context/context_test.go
+++ b/src/go/rpk/pkg/cli/registry/context/context_test.go
@@ -305,6 +305,27 @@ func TestAdminAPICheckFlagEnabled(t *testing.T) {
 	require.NotContains(t, output, ":.ctx1:")
 }
 
+func TestAdminAPICheckSkippedForCloudProfile(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	cfgBody := `current_profile: test
+profiles:
+    - name: test
+      from_cloud: true
+      cloud_cluster:
+        cluster_id: test123
+        cluster_type: TYPE_DEDICATED
+      admin_api: {}
+`
+	require.NoError(t, afero.WriteFile(fs, "/tmp/rpk.yaml", []byte(cfgBody), 0o644))
+	p := &config.Params{ConfigFlag: "/tmp/rpk.yaml"}
+	profile, err := p.LoadVirtualProfile(fs)
+	require.NoError(t, err)
+
+	err = srcontext.IsContextSupported(context.Background(), fs, profile, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "admin API is not available on cloud clusters")
+}
+
 func TestAdminAPICheckFlagDisabled(t *testing.T) {
 	admin := fakeAdminAPI(t, map[string]any{
 		"schema_registry_enable_qualified_subjects": false,


### PR DESCRIPTION
Fixes #30626

When a cloud profile (`from_cloud: true`) is active, `rpk registry` commands
attempt an Admin API call to check `schema_registry_enable_qualified_subjects`.
The Admin API is not exposed on Cloud Dedicated clusters, so rpk infers the
address from the Kafka seed broker hostname with port 9644, which is
unreachable. This causes a 10-second timeout on every `rpk registry` command
before the actual Schema Registry call proceeds.

This patch skips the Admin API context check entirely when the profile is a
cloud profile, matching the established pattern from 5f5eebd573 which blocks
Admin API access on cloud profiles for explicit admin commands.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v26.2.x

## UX Changes

* `rpk registry` commands on cloud profiles no longer attempt an Admin API
  call that times out for 10 seconds before proceeding.

## Release Notes

### Bug Fixes

* Fix rpk registry commands hanging for 10 seconds on Redpanda Cloud
  clusters due to an unreachable Admin API context check.