### PR TITLE
cloud_storage: preserve hints when cloning the first frame in cstore rebuild

### DIFF
--- a/src/v/cloud_storage/segment_meta_cstore.cc
+++ b/src/v/cloud_storage/segment_meta_cstore.cc
@@ -700,6 +700,8 @@ public:
         _hints.erase(it, _hints.end());
     }
 
+    size_t hints_size() const { return _hints.size(); }
+
     /// Return two values: inflated size (size without compression) followed
     /// by the actual size that takes compression into account.
     std::pair<size_t, size_t> inflated_actual_size() const {
@@ -1054,6 +1056,11 @@ public:
         return _col.size();
     }
 
+    size_t hints_size() const {
+        flush_write_buffer();
+        return _col.hints_size();
+    }
+
     bool empty() const { return _write_buffer.empty() && _col.empty(); }
 
     bool contains(model::offset o) {
@@ -1171,6 +1178,8 @@ bool segment_meta_cstore::contains(model::offset o) const {
 bool segment_meta_cstore::empty() const { return _impl->empty(); }
 
 size_t segment_meta_cstore::size() const { return _impl->size(); }
+
+size_t segment_meta_cstore::hints_size() const { return _impl->hints_size(); }
 
 segment_meta_cstore::const_iterator
 segment_meta_cstore::upper_bound(model::offset o) const {

--- a/src/v/cloud_storage/segment_meta_cstore.cc
+++ b/src/v/cloud_storage/segment_meta_cstore.cc
@@ -384,10 +384,13 @@ public:
                 // no hint will be saved
                 return _hints.end();
             }
-            --frame_it; // go back to last frame that will be cloned
-            for (; frame_it != _base_offset._frames.begin(); --frame_it) {
-                // go back until we have a non-empty frame. this should be just
-                // an iteration
+            // walk back from the first frame that is *not* cloned until we
+            // find a non-empty cloned frame, then map its last value to the
+            // hint range we want to preserve. The loop has to include
+            // _frames.begin() itself, otherwise the single-cloned-frame case
+            // falls through and drops every hint in the cloned region.
+            do {
+                --frame_it;
                 if (auto frame_max_offset = frame_it->last_value()) {
                     auto to_clone_hint = _hints.lower_bound(
                       frame_max_offset.value());
@@ -399,7 +402,7 @@ public:
                       frame_max_offset.value());
                     return to_clone_hint;
                 }
-            }
+            } while (frame_it != _base_offset._frames.begin());
             return _hints.end();
         }();
 

--- a/src/v/cloud_storage/segment_meta_cstore.h
+++ b/src/v/cloud_storage/segment_meta_cstore.h
@@ -153,6 +153,9 @@ public:
 
     void flush_write_buffer();
 
+    /// Number of base-offset hints currently stored. Test-only inspection.
+    size_t hints_size() const;
+
     // Access individual columns
     const gauge_col_t& get_size_bytes_column() const;
     const counter_col_t& get_base_offset_column() const;

--- a/src/v/cloud_storage/segment_meta_cstore.h
+++ b/src/v/cloud_storage/segment_meta_cstore.h
@@ -23,8 +23,9 @@ namespace cloud_storage {
 // each frame contains up to #cstore_max_frame_size elements, compressed with
 // deltafor
 constexpr size_t cstore_max_frame_size = 0x400;
-// every #cstore_sampling_rate element inserted, the byte position in the
-// compressed buffer is recorded to speed up random access
+// Every #cstore_sampling_rate FOR (frame-of-reference), the byte position in
+// the outer frame is recorded to speed up random access. The distance in
+// elements between consecutive hints is FOR size * cstore_sampling_rate.
 inline constexpr size_t cstore_sampling_rate = 8;
 
 /// Column-store iterator

--- a/src/v/cloud_storage/segment_meta_cstore.h
+++ b/src/v/cloud_storage/segment_meta_cstore.h
@@ -22,7 +22,7 @@ namespace cloud_storage {
 
 // each frame contains up to #cstore_max_frame_size elements, compressed with
 // deltafor
-constexpr size_t cstore_max_frame_size = 0x400;
+inline constexpr size_t cstore_max_frame_size = 1024;
 // Every #cstore_sampling_rate FOR (frame-of-reference), the byte position in
 // the outer frame is recorded to speed up random access. The distance in
 // elements between consecutive hints is FOR size * cstore_sampling_rate.

--- a/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
@@ -807,3 +807,72 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_append_retrieve_edge_case) {
       = metadata[cloud_storage::cstore_max_frame_size * 2].base_offset;
     BOOST_CHECK_NO_THROW(store.lower_bound(last_frame_first_offset));
 }
+
+// Regression test for the slow-path `last_hint_tosave` computation in
+// column_store::insert_entries. When the rebuild path clones the first frame
+// and the replacement region begins in the second frame, the code that
+// extracts hints from the to-be-cloned frames walks frames back-to-front with
+// a loop bound that excludes _frames.begin(), so the only cloned frame
+// (frame 0) is never inspected and every hint that belongs to it is dropped.
+//
+// Triggering conditions:
+//   1. Two or more frames exist (column has > cstore_max_frame_size
+//      elements).
+//   2. An insert lands strictly inside the second frame, forcing the slow
+//      rebuild path (the append-only fast path does not apply).
+BOOST_AUTO_TEST_CASE(slow_path_drops_hints_from_cloned_frame) {
+    auto make_segment = [](int64_t base) {
+        segment_meta s{};
+        s.is_compacted = false;
+        s.size_bytes = 100;
+        s.base_offset = model::offset(base);
+        s.committed_offset = model::offset(base);
+        s.delta_offset = model::offset_delta(0);
+        s.archiver_term = model::term_id(1);
+        s.segment_term = model::term_id(1);
+        s.delta_offset_end = model::offset_delta(0);
+        s.sname_format = segment_name_format::v2;
+        return s;
+    };
+
+    // A hint is emitted at the start of every row of
+    // FOR_buffer_depth * cstore_sampling_rate entries.
+    constexpr size_t hint_stride = details::FOR_buffer_depth
+                                   * cstore_sampling_rate;
+    // Fill frame 0 completely and a partial frame 1 that holds fewer than
+    // hint_stride entries, so frame 1 carries exactly one hint at its first
+    // element.
+    constexpr size_t frame_1_fill = hint_stride - 1;
+    constexpr size_t populate_n = cstore_max_frame_size + frame_1_fill;
+    // Frame 0 contributes cstore_max_frame_size / hint_stride hints at row
+    // boundaries; frame 1 contributes one hint at its first element.
+    constexpr size_t expected_hints = cstore_max_frame_size / hint_stride + 1;
+
+    segment_meta_cstore store;
+    for (size_t i = 0; i < populate_n; ++i) {
+        store.insert(make_segment(static_cast<int64_t>(i)));
+    }
+    store.flush_write_buffer();
+    const auto hints_before = store.hints_size();
+
+    // Replacement lands strictly inside frame 1, which forces
+    // insert_entries down the slow rebuild path (the entry is not
+    // append-only and not in frame 0) and exercises the buggy
+    // `last_hint_tosave` computation.
+    auto replacement = make_segment(
+      static_cast<int64_t>(cstore_max_frame_size) + 1);
+    replacement.size_bytes = 999; // distinguish from the original
+    store.insert(replacement);
+    store.flush_write_buffer();
+    const auto hints_after = store.hints_size();
+
+    BOOST_TEST_MESSAGE(
+      "hints_before=" << hints_before << " hints_after=" << hints_after);
+
+    // Captures the current (buggy) state: the rebuild walks frame 0 as a
+    // shared frame but drops every hint that belonged to it; only the
+    // single hint re-emitted at the start of frame 1 when rebuilding it
+    // survives.
+    BOOST_REQUIRE_EQUAL(hints_before, expected_hints);
+    BOOST_REQUIRE_EQUAL(hints_after, 1);
+}

--- a/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
@@ -869,10 +869,9 @@ BOOST_AUTO_TEST_CASE(slow_path_drops_hints_from_cloned_frame) {
     BOOST_TEST_MESSAGE(
       "hints_before=" << hints_before << " hints_after=" << hints_after);
 
-    // Captures the current (buggy) state: the rebuild walks frame 0 as a
-    // shared frame but drops every hint that belonged to it; only the
-    // single hint re-emitted at the start of frame 1 when rebuilding it
-    // survives.
+    // Frame 0's hints survive the share_frame clone; frame 1's first-element
+    // hint is re-emitted when frame 1 is rebuilt by re-appending its
+    // segments. Total is unchanged by the replacement.
     BOOST_REQUIRE_EQUAL(hints_before, expected_hints);
-    BOOST_REQUIRE_EQUAL(hints_after, 1);
+    BOOST_REQUIRE_EQUAL(hints_after, expected_hints);
 }


### PR DESCRIPTION
`column_store::insert_entries` walks back through the to-be-cloned frames
to find the largest valid `last_value`, then uses `_hints.lower_bound`
to determine which hints belong to the cloned region. The loop bound
`frame_it != _frames.begin()` excluded `_frames.begin()` itself, so when
only the first frame is cloned (e.g. a replacement that lands in frame 1
of a two-frame store) the loop body never ran and every hint that
belonged to the cloned frame was discarded. The append-only fast path
added in 4c3732db54 sidesteps this code path when every entry lands past
the tail, so the bug only surfaces on replacement workloads.

The fix restructures the loop as a do/while that always inspects at
least one frame.

Commits:

1. Regression test that exercises the slow rebuild path and observes
   `hints_size()` collapse from 9 to 1.
2. The do/while fix; the regression test now expects 9.
3. Drive-by: correct the `cstore_sampling_rate` doc comment (the rate
   counts compressed rows, not individual elements) and expand it to
   describe what a hint actually contains and how it is used.
4. Drive-by: make `cstore_max_frame_size` `inline constexpr` and use
   decimal `1024`.

Hint loss is a performance concern (lookups fall back to decoding from
the frame start), not a correctness issue.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
