### PR TITLE
iceberg-rest-catalog: use http_archive gradle, silence on success

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -479,6 +479,14 @@ http_archive(
 )
 
 http_archive(
+    name = "gradle_dist",
+    build_file = "//bazel/thirdparty:gradle.BUILD",
+    integrity = "sha256-nZJnhwZqCBc56CAIWDOLSmnoN8OoIaM6yp2wndSkECY=",
+    strip_prefix = "gradle-8.5",
+    urls = ["https://services.gradle.org/distributions/gradle-8.5-bin.zip"],
+)
+
+http_archive(
     name = "omb",
     add_prefix = "omb",
     build_file = "//bazel/thirdparty:omb.BUILD",

--- a/bazel/thirdparty/gradle.BUILD
+++ b/bazel/thirdparty/gradle.BUILD
@@ -1,0 +1,7 @@
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)
+
+exports_files(["bin/gradle"])

--- a/tests/java/iceberg-rest-catalog/BUILD
+++ b/tests/java/iceberg-rest-catalog/BUILD
@@ -22,7 +22,11 @@ genrule(
         SRC_DIR=$$(dirname $(location build.gradle))
         export GRADLE_USER_HOME=$$(mktemp -d)
         cd $$SRC_DIR
-        "$$GRADLE_BIN" --no-daemon shadowJar
+        LOG=$$(mktemp)
+        if ! "$$GRADLE_BIN" --no-daemon shadowJar >$$LOG 2>&1; then
+            cat $$LOG >&2
+            exit 1
+        fi
         cp build/libs/iceberg-rest-catalog-all.jar $$OUT_PATH
     """,
     tags = ["requires-network"],

--- a/tests/java/iceberg-rest-catalog/BUILD
+++ b/tests/java/iceberg-rest-catalog/BUILD
@@ -7,15 +7,22 @@ genrule(
             "build/**",
             ".gradle/**",
             "README.md",
+            "gradlew",
+            "gradlew.bat",
+            "gradle/**",
         ],
-    ),
+    ) + [
+        "@gradle_dist//:all_files",
+        "@gradle_dist//:bin/gradle",
+    ],
     outs = ["iceberg-rest-catalog-all.jar"],
     cmd = """
         OUT_PATH=$$(realpath $(OUTS))
-        SRC_DIR=$$(dirname $(location gradlew))
+        GRADLE_BIN="$$PWD/$(location @gradle_dist//:bin/gradle)"
+        SRC_DIR=$$(dirname $(location build.gradle))
+        export GRADLE_USER_HOME=$$(mktemp -d)
         cd $$SRC_DIR
-        export GRADLE_USER_HOME="$$(pwd)/.gradle-home"
-        ./gradlew --no-daemon shadowJar
+        "$$GRADLE_BIN" --no-daemon shadowJar
         cp build/libs/iceberg-rest-catalog-all.jar $$OUT_PATH
     """,
     tags = ["requires-network"],

--- a/tests/java/iceberg-rest-catalog/gradle/wrapper/gradle-wrapper.properties
+++ b/tests/java/iceberg-rest-catalog/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+# The bazel build doesn't use gradle, so the version should be kept in sync with
+# gradle_dist in MODULE.bazel
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true


### PR DESCRIPTION
The `iceberg-rest-catalog` genrule was invoking `./gradlew`, which downloads the gradle distribution from `services.gradle.org` at action time. That download happens inside the action with no declared checksum or declared dependency, so Bazel cannot validate, cache, or reason about it.

Additionally, gradle's normal task progress (download messages, `> Task :compileJava`, the `shadowJar` banner, etc.) is echoed by Bazel under `INFO: From Executing genrule …` on every successful build, which is noisy given Bazel does not suppress genrule stdout/stderr on success.

This PR:

1. Adds `@gradle_dist` as a checksummed `http_archive` pinned to gradle 8.5 (matching the existing `gradle-wrapper.properties`) and rewires the genrule to invoke `bin/gradle` from that archive directly. `GRADLE_USER_HOME` is moved to a per-action `mktemp -d` since `$(pwd)/.gradle-home` is read-only inside the sandbox once `gradlew` is no longer in the picture. The wrapper files (`gradlew`, `gradle/**`) are dropped from `srcs` since they are no longer consumed.
2. Captures gradle's combined stdout+stderr to a temp log and only dumps it to stderr on non-zero exit, so a successful build is quiet.

This does not make the build fully hermetic: gradle still reaches out to resolve the project's own dependencies (hence `requires-network` stays), and the resulting shadow jar embeds timestamps so its hash is not byte-stable across runs. It is, however, a step better than the prior state where gradle itself was an undeclared, unchecksummed network fetch.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none