### PR TITLE
[CORE-16392] `cluster`: alert `feature_manager` on `members_table` update

### DIFF
--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -183,6 +183,20 @@ feature_manager::start(std::vector<model::node_id>&& cluster_founder_nodes) {
             }
         });
 
+    // Wake the background loop on any membership change. The active-
+    // version check in do_maybe_update_active_version is gated on the
+    // set of current members (members_table::node_ids()); when a node
+    // is fully removed (e.g. its decommission completes) no health
+    // report or leader change re-triggers the loop, so without this
+    // notification the active version can stay stuck below the
+    // cluster's actual minimum until the next leader change.
+    _members_notify_handle
+      = _members.local().register_members_updated_notification(
+        [this](model::node_id, model::membership_state) {
+            _members_changed = true;
+            _update_wait.signal();
+        });
+
     // Detach fiber for active version updater.
     // The writes of active version run in the background, because we
     // do it in response to callbacks (e.g. node version change from
@@ -214,6 +228,8 @@ ss::future<> feature_manager::stop() {
     _group_manager.local().unregister_leadership_notification(
       _leader_notify_handle);
     _hm_backend.local().unregister_node_callback(_health_notify_handle);
+    _members.local().unregister_members_updated_notification(
+      _members_notify_handle);
     _update_wait.broken();
     _verified_enterprise_license.broken();
     co_await _gate.close();
@@ -568,6 +584,11 @@ feature_manager::do_maybe_update_active_version(bool& failed_barrier) {
     // re-issues) when auto-finalization is disabled.
     const bool was_manual_finalize_pending = std::exchange(
       _manual_finalize_pending, false);
+
+    // Clear the membership-change wake bit before evaluating, so any
+    // change that races our read of members_table re-sets it and
+    // triggers another pass.
+    _members_changed = false;
 
     if (!_is_leader_of.has_value()) {
         // Drop accumulated updates to bound memory while we're not

--- a/src/v/cluster/feature_manager.h
+++ b/src/v/cluster/feature_manager.h
@@ -162,7 +162,7 @@ private:
         if (!_is_leader_of.has_value()) {
             return false;
         }
-        if (!_updates.empty() || _manual_finalize_pending) {
+        if (!_updates.empty() || _manual_finalize_pending || _members_changed) {
             return true;
         }
         return !auto_activate_features(
@@ -209,6 +209,8 @@ private:
       notification_id_type_invalid};
     cluster::notification_id_type _health_notify_handle{
       notification_id_type_invalid};
+    cluster::notification_id_type _members_notify_handle{
+      notification_id_type_invalid};
 
     // Barriers are only populated on shard 0
     feature_barrier_state<ss::lowres_clock> _barrier_state;
@@ -240,6 +242,18 @@ private:
     // before the loop replicates the advance loses the request. Cleared
     // on leadership change and consumed (one-shot) by the loop body.
     bool _manual_finalize_pending{false};
+
+    // Whether the cluster's membership has changed since the loop last
+    // evaluated the active version. Set from the members_table
+    // notification and consumed (one-shot) by the loop body. Required
+    // because do_maybe_update_active_version reads
+    // members_table::node_ids() to decide whether all members are at the
+    // candidate version: when a node is fully removed (e.g. its
+    // decommission completes), health reports cease and no leader
+    // change fires, so without this signal the loop never re-evaluates
+    // and the active version stays pinned to the just-removed node's
+    // version.
+    bool _members_changed{false};
 
     // Blocks cluster upgrades until the enterprise license has been verified
     ssx::semaphore _verified_enterprise_license{

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -24,6 +24,7 @@ from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 from rptest.services.redpanda_installer import RedpandaInstaller, wait_for_num_versions
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import expect_exception, wait_until_result
+from rptest.utils.node_operations import NodeDecommissionWaiter
 from rptest.utils.rpenv import sample_license, sample_license_v1
 
 FEATURE_ALPHA_NAME = "__test_alpha"
@@ -1025,3 +1026,134 @@ class ManualFinalizationLicenseTest(RedpandaTest):
             raise RuntimeError(
                 "Expected patch_cluster_config to fail without an enterprise license"
             )
+
+
+class FeatureManagerDecommissionRegressionTest(FeaturesTestBase):
+    """
+    Regression test for the bug where feature_manager fails to advance
+    cluster_version after the last version-blocking node is fully
+    decommissioned.
+
+    Mirrors a production-observed scenario: a cluster of v_old nodes is
+    upgraded by adding v_high nodes that join because their earliest
+    tolerates v_old, then the v_old nodes are decommissioned.
+    cluster_version must auto-advance to v_high once the v_old nodes
+    leave the members table.
+
+    The bug: feature_manager's background loop is parked on
+    _update_wait after the last health-report tick. Health reports
+    cease once a node is fully removed, and no leader change is
+    guaranteed, so without an explicit wake-up from members_table
+    changes the loop never re-evaluates and cluster_version stays
+    pinned at v_old indefinitely.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, num_brokers=5, **kwargs)
+
+    def setUp(self):
+        super().setUp()
+        # We will bootstrap by hand with controlled per-node logical
+        # versions. Stop the cluster that the base setUp started and
+        # wipe persistent state so the next start is a fresh
+        # bootstrap at the synthetic v_old below.
+        self.redpanda.stop()
+        for node in self.redpanda.nodes:
+            self.redpanda.clean_node(node, preserve_current_install=True)
+
+    @cluster(num_nodes=5)
+    def test_decommission_advances_cluster_version(self):
+        v_high = self.head_latest_logical_version
+        v_old = v_high - 1
+        assert v_old >= 1, f"v_high={v_high} too low to synthesize a v_old below it"
+
+        old_nodes = self.redpanda.nodes[0:2]
+        new_nodes = self.redpanda.nodes[2:5]
+
+        # Step 1: bootstrap a fresh 2-node cluster reporting v_old.
+        self.redpanda.set_environment(
+            {
+                "__REDPANDA_LATEST_LOGICAL_VERSION": f"{v_old}",
+                "__REDPANDA_EARLIEST_LOGICAL_VERSION": f"{v_old}",
+            }
+        )
+        self.redpanda.start(old_nodes)
+        wait_until(
+            lambda: self.admin.get_features(node=old_nodes[0])["cluster_version"]
+            == v_old,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"cluster_version did not reach v_old={v_old} after bootstrap",
+        )
+
+        # Step 2: add 3 new nodes reporting v_high. Their earliest
+        # tolerates v_old so they join the existing cluster.
+        self.redpanda.set_environment(
+            {
+                "__REDPANDA_LATEST_LOGICAL_VERSION": f"{v_high}",
+                "__REDPANDA_EARLIEST_LOGICAL_VERSION": f"{v_old}",
+            }
+        )
+        for node in new_nodes:
+            self.redpanda.start_node(node)
+
+        # Wait for all five brokers to be present and alive from the
+        # leader's perspective. is_alive is computed by the leader's
+        # health monitor from received reports, and feature_manager's
+        # node callback fires off the same reports — so when this
+        # predicate holds, feature_manager has observed v_high from
+        # every new node and has had its chance to attempt an advance.
+        def cluster_at_steady_state():
+            brokers = self.admin.get_brokers(node=new_nodes[0])
+            return len(brokers) == 5 and all(b.get("is_alive", False) for b in brokers)
+
+        wait_until(
+            cluster_at_steady_state,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="cluster did not reach a 5-broker alive steady state",
+        )
+
+        # With v_old members still present, the correct decision is
+        # to hold cluster_version at v_old. Assert that's where we
+        # are before triggering the decommission.
+        assert self.admin.get_features(node=new_nodes[0])["cluster_version"] == v_old, (
+            "cluster_version advanced before v_old nodes were decommissioned"
+        )
+
+        # Step 3: decommission both v_old nodes via a v_high node,
+        # sequentially. raft0 only has two voters in this bootstrap
+        # cluster, so the first decommission must complete (replicas
+        # rebalanced onto v_high nodes) before the second is safe.
+        # Tell the waiter to exclude *both* v_old node ids from
+        # progress queries: while one is being removed the other is
+        # still a member but is the only remaining v_old node and is
+        # busy with raft0/partition rebalancing, so picking it for
+        # status queries causes transient 503s in the waiter loop.
+        old_ids = [self.redpanda.node_id(n) for n in old_nodes]
+        for old_id in old_ids:
+            self.admin.decommission_broker(old_id, node=new_nodes[0])
+            waiter = NodeDecommissionWaiter(
+                self.redpanda,
+                old_id,
+                self.logger,
+                progress_timeout=60,
+                decommissioned_node_ids=old_ids,
+            )
+            waiter.wait_for_removal()
+
+        # Step 4: with both v_old nodes gone, cluster_version must
+        # advance to v_high. Pre-fix, feature_manager's loop is parked
+        # on _update_wait and no event source wakes it on member
+        # removal, so the advance never lands and this times out.
+        wait_until(
+            lambda: self.admin.get_features(node=new_nodes[0])["cluster_version"]
+            == v_high,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg=(
+                f"cluster_version stuck at v_old={v_old} after decommissioning "
+                f"all v_old nodes; expected v_high={v_high}. "
+                "feature_manager likely failed to wake on member removal."
+            ),
+        )


### PR DESCRIPTION
`do_maybe_update_active_version()` reads `members_table::node_ids()` to gate whether the active version can advance, but the background loop only wakes on health reports or leader changes.

When a node is fully removed by decommission, neither fires, so we never bother to wake up and attempt to bump the `cluster_version`. As a result, it is pinned to the just-removed node's version indefinitely, even though every remaining member is newer.

Subscribe to `members_table` updates and signal `_update_wait` so the loop re-evaluates whenever membership changes.

This bug was discovered in production, and the added test case mirrors the situation there (2 nodes on a previous version, 3 nodes added, 2 old nodes are decomissioned, we need to observe the `cluster_version` bumped at this point).

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [X] v25.3.x
- [x] v25.2.x

## Release Notes

### Bug Fixes

* Fixes a bug in the `feature_table` in which nodes which are holding back the cluster-wide `cluster_version`, when decommissioned, result in the `cluster_version` never being updated until a restart/controller leadership move is forced.