### PR TITLE
admin: always include nodes_in_recovery_mode in health overview

### DIFF
--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -4118,6 +4118,7 @@ void admin_server::register_cluster_routes() {
                 ret.all_nodes._set = true;
                 ret.nodes_down._set = true;
                 ret.high_disk_usage_nodes._set = true;
+                ret.nodes_in_recovery_mode._set = true;
                 ret.leaderless_partitions._set = true;
                 ret.under_replicated_partitions._set = true;
 


### PR DESCRIPTION
The `cluster_health_overview` JSON handler for `GET /v1/cluster/health_overview` was assigning `ret.nodes_in_recovery_mode` but never setting its `_set = true` flag. The swagger serializer's `operator=` calls `push()` per element (which is what flips `_set`), so the field was emitted correctly when the list was non-empty but silently omitted when it was empty - inconsistent with every other array on the response (`unhealthy_reasons`, `all_nodes`, `nodes_down`, `high_disk_usage_nodes`, `leaderless_partitions`, `under_replicated_partitions`) and with `cluster.json`'s schema, which declares it as a plain (non-optional) array.

In practice the bug is mostly invisible: rpk's `Nodes in recovery mode:` line coincidentally renders `[]` either way (missing key → Go zero-value `[]int` → same output as an empty array). But strict consumers that read the key unconditionally trip on a `KeyError` in the empty case — in particular this is what a new ducktape test added on another branch hits when it cross-checks the admin endpoint against `cluster_health_*` metrics.

Bug has been present since the field was added in v23.3.1 (d95d750068, Oct 2023). Fix is one line, mirroring the existing `_set = true` lines for the sibling arrays.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Bug Fixes

- admin: \`GET /v1/cluster/health_overview\` now always includes \`nodes_in_recovery_mode\`, even when empty