### PR TITLE
[v25.3.x] CORE-16246 schema_registry/avro: collapse primitive type objects

### DIFF
--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -322,6 +322,95 @@ void unqualify_type_reference(json::Value& val, sanitize_context& ctx) {
     }
 }
 
+bool try_collapse_primitive_object(json::Value& v, sanitize_context& ctx) {
+    if (!v.IsObject()) {
+        return false;
+    }
+    auto o = v.GetObject();
+    if (o.MemberCount() != 1) {
+        return false;
+    }
+    auto it = o.FindMember("type");
+    if (it == o.MemberEnd() || !it->value.IsString()) {
+        return false;
+    }
+    std::string_view type{it->value.GetString(), it->value.GetStringLength()};
+    if (!string_switch<bool>(type)
+           .match("null", true)
+           .match("boolean", true)
+           .match("int", true)
+           .match("long", true)
+           .match("float", true)
+           .match("double", true)
+           .match("bytes", true)
+           .match("string", true)
+           .default_match(false)) {
+        return false;
+    }
+
+    // SetString frees v's storage (which backs `type`); copy first.
+    ss::sstring type_name{type};
+    v.SetString(type_name.data(), type_name.length(), ctx.alloc);
+    return true;
+}
+
+// Walk only Avro schema-bearing positions, leaving arbitrary custom metadata
+// untouched even when it happens to look like a schema object.
+void collapse_primitive_schema_objects(json::Value& v, sanitize_context& ctx) {
+    if (v.IsArray()) {
+        for (auto& e : v.GetArray()) {
+            collapse_primitive_schema_objects(e, ctx);
+        }
+        return;
+    }
+    if (!v.IsObject()) {
+        return;
+    }
+    auto o = v.GetObject();
+    if (try_collapse_primitive_object(v, ctx)) {
+        return;
+    }
+
+    auto type_it = o.FindMember("type");
+    if (type_it == o.MemberEnd()) {
+        return;
+    }
+    auto& type_v = type_it->value;
+    if (type_v.IsObject() || type_v.IsArray()) {
+        collapse_primitive_schema_objects(type_v, ctx);
+        return;
+    }
+    if (!type_v.IsString()) {
+        return;
+    }
+
+    std::string_view type_sv{type_v.GetString(), type_v.GetStringLength()};
+    if (type_sv == "record") {
+        auto fields_it = o.FindMember("fields");
+        if (fields_it == o.MemberEnd() || !fields_it->value.IsArray()) {
+            return;
+        }
+        for (auto& f : fields_it->value.GetArray()) {
+            if (!f.IsObject()) {
+                continue;
+            }
+            auto field_o = f.GetObject();
+            auto field_type_it = field_o.FindMember("type");
+            if (field_type_it != field_o.MemberEnd()) {
+                collapse_primitive_schema_objects(field_type_it->value, ctx);
+            }
+        }
+    } else if (type_sv == "array") {
+        if (auto it = o.FindMember("items"); it != o.MemberEnd()) {
+            collapse_primitive_schema_objects(it->value, ctx);
+        }
+    } else if (type_sv == "map") {
+        if (auto it = o.FindMember("values"); it != o.MemberEnd()) {
+            collapse_primitive_schema_objects(it->value, ctx);
+        }
+    }
+}
+
 result<void>
 sanitize_union_symbol_name(json::Value& name, sanitize_context& ctx) {
     // A name should have the leading dot stripped iff it's the only one
@@ -839,6 +928,7 @@ sanitize_avro_schema_definition(schema_definition def) {
             res.assume_error().message(),
             p.read_string(p.bytes_left()))};
     }
+    collapse_primitive_schema_objects(doc, ctx);
 
     json::chunked_buffer buf;
     json::Writer<json::chunked_buffer> w{buf};

--- a/src/v/pandaproxy/schema_registry/test/sanitize_avro.cc
+++ b/src/v/pandaproxy/schema_registry/test/sanitize_avro.cc
@@ -443,3 +443,144 @@ BOOST_AUTO_TEST_CASE(test_sanitize_avro_no_normalize_without_namespace) {
       pps::schema_type::avro};
     BOOST_REQUIRE_EQUAL(sanitized, expected);
 }
+
+const pps::schema_definition top_level_primitive_object_form{
+  R"({"type":"string"})", pps::schema_type::avro};
+
+const pps::schema_definition top_level_primitive_simple_form{
+  R"("string")", pps::schema_type::avro};
+
+BOOST_AUTO_TEST_CASE(test_sanitize_avro_collapse_top_level_primitive_object) {
+    BOOST_REQUIRE_EQUAL(
+      pps::sanitize_avro_schema_definition(
+        top_level_primitive_object_form.share())
+        .value(),
+      top_level_primitive_simple_form);
+}
+
+// CORE-16247 regression: nested `{"type":"<primitive>"}` collapses to bare
+// form. Covers all 8 Avro primitives across record-field, array-items,
+// map-values, and union-branch positions.
+const pps::schema_definition primitive_object_forms{
+  R"({"type":"record","name":"R","fields":[)"
+  R"({"name":"f_null","type":{"type":"null"}},)"
+  R"({"name":"f_bool","type":{"type":"boolean"}},)"
+  R"({"name":"f_int","type":{"type":"int"}},)"
+  R"({"name":"f_long","type":{"type":"long"}},)"
+  R"({"name":"f_float","type":{"type":"float"}},)"
+  R"({"name":"f_double","type":{"type":"double"}},)"
+  R"({"name":"f_bytes","type":{"type":"bytes"}},)"
+  R"({"name":"f_string","type":{"type":"string"}},)"
+  R"({"name":"f_array","type":{"type":"array","items":{"type":"string"}}},)"
+  R"({"name":"f_map","type":{"type":"map","values":{"type":"int"}}},)"
+  R"({"name":"f_union","type":["null",{"type":"string"}]})"
+  R"(]})",
+  pps::schema_type::avro};
+
+const pps::schema_definition primitive_object_forms_sanitized{
+  R"({"type":"record","name":"R","fields":[)"
+  R"({"name":"f_null","type":"null"},)"
+  R"({"name":"f_bool","type":"boolean"},)"
+  R"({"name":"f_int","type":"int"},)"
+  R"({"name":"f_long","type":"long"},)"
+  R"({"name":"f_float","type":"float"},)"
+  R"({"name":"f_double","type":"double"},)"
+  R"({"name":"f_bytes","type":"bytes"},)"
+  R"({"name":"f_string","type":"string"},)"
+  R"({"name":"f_array","type":{"type":"array","items":"string"}},)"
+  R"({"name":"f_map","type":{"type":"map","values":"int"}},)"
+  R"({"name":"f_union","type":["null","string"]})"
+  R"(]})",
+  pps::schema_type::avro};
+
+BOOST_AUTO_TEST_CASE(test_sanitize_avro_collapse_primitive_object_form) {
+    BOOST_REQUIRE_EQUAL(
+      pps::sanitize_avro_schema_definition(primitive_object_forms.share())
+        .value(),
+      primitive_object_forms_sanitized);
+}
+
+const pps::schema_definition core_16246_verbose{
+  R"({"type":"record","name":"TestRecord","namespace":"test","fields":[)"
+  R"({"name":"tags","type":["null",{"type":"array","items":{"type":"string"}}],"default":null})"
+  R"(]})",
+  pps::schema_type::avro};
+
+const pps::schema_definition core_16246_bare{
+  R"({"type":"record","name":"TestRecord","namespace":"test","fields":[)"
+  R"({"name":"tags","type":["null",{"type":"array","items":"string"}],"default":null})"
+  R"(]})",
+  pps::schema_type::avro};
+
+BOOST_AUTO_TEST_CASE(test_sanitize_avro_verbose_and_bare_equivalent) {
+    BOOST_REQUIRE_EQUAL(
+      pps::sanitize_avro_schema_definition(core_16246_verbose.share()).value(),
+      pps::sanitize_avro_schema_definition(core_16246_bare.share()).value());
+}
+
+// A primitive object carrying additional attributes is not equivalent to
+// primitive simple form and must be preserved.
+const pps::schema_definition logical_type_preserved{
+  R"({"type":"record","name":"R","fields":[)"
+  R"({"name":"t","type":{"type":"long","logicalType":"timestamp-millis"}})"
+  R"(]})",
+  pps::schema_type::avro};
+
+BOOST_AUTO_TEST_CASE(test_sanitize_avro_logical_type_preserved) {
+    BOOST_REQUIRE_EQUAL(
+      pps::sanitize_avro_schema_definition(logical_type_preserved.share())
+        .value(),
+      logical_type_preserved);
+}
+
+// A `{"type":"<non-primitive>"}` object (here a named-type reference) is
+// not equivalent to primitive simple form and must be preserved.
+const pps::schema_definition named_ref_object_form{
+  R"({"type":"record","name":"Outer","fields":[)"
+  R"({"name":"f","type":{"type":"Outer"}})"
+  R"(]})",
+  pps::schema_type::avro};
+
+BOOST_AUTO_TEST_CASE(test_sanitize_avro_named_ref_object_not_collapsed) {
+    BOOST_REQUIRE_EQUAL(
+      pps::sanitize_avro_schema_definition(named_ref_object_form.share())
+        .value(),
+      named_ref_object_form);
+}
+
+// A `{"type":[...]}` (a union in the type position) is single-member but
+// its type value is not a string, so the collapser must skip it.
+const pps::schema_definition union_in_type_field{
+  R"({"type":["null","string"]})", pps::schema_type::avro};
+
+BOOST_AUTO_TEST_CASE(test_sanitize_avro_union_in_type_not_collapsed) {
+    BOOST_REQUIRE_EQUAL(
+      pps::sanitize_avro_schema_definition(union_in_type_field.share()).value(),
+      union_in_type_field);
+}
+
+// Custom metadata may contain JSON that incidentally has the same shape as
+// primitive schemas. Only real schema values should be collapsed.
+const pps::schema_definition primitive_like_metadata_preserved{
+  R"({"type":"record","name":"R","fields":[)"
+  R"({"name":"a","type":{"type":"array","items":"string",)"
+  R"("x-meta":{"type":"int"}}},)"
+  R"({"name":"b","type":{"type":"array","items":"string",)"
+  R"("x-meta":[{"type":"int"}]}}]})",
+  pps::schema_type::avro};
+
+BOOST_AUTO_TEST_CASE(test_sanitize_avro_primitive_like_metadata_preserved) {
+    BOOST_REQUIRE_EQUAL(
+      pps::sanitize_avro_schema_definition(
+        primitive_like_metadata_preserved.share())
+        .value(),
+      primitive_like_metadata_preserved);
+}
+
+BOOST_AUTO_TEST_CASE(test_sanitize_avro_primitive_collapse_idempotent) {
+    auto once = pps::sanitize_avro_schema_definition(
+                  primitive_object_forms.share())
+                  .value();
+    auto twice = pps::sanitize_avro_schema_definition(once.share()).value();
+    BOOST_REQUIRE_EQUAL(once, twice);
+}


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30565
