### PR TITLE
[CORE-16238] Add unfinalized upgrade observability

### DIFF
--- a/proto/redpanda/core/admin/v2/features.proto
+++ b/proto/redpanda/core/admin/v2/features.proto
@@ -48,6 +48,24 @@ service FeaturesService {
             authz: SUPERUSER
         };
     }
+
+    // GetUpgradeStatus
+    //
+    // Reports observability for the upgrade-finalization lifecycle: the
+    // cluster's active logical version, the logical version each member
+    // reports (i.e. what its binary supports), whether the cluster is
+    // eligible to finalize, and the active version that a
+    // FinalizeUpgrade would produce. Read-only; intended to be polled
+    // before and after FinalizeUpgrade.
+    //
+    // The response reflects the controller leader's view; the request is
+    // transparently redirected there.
+    rpc GetUpgradeStatus(GetUpgradeStatusRequest)
+        returns (GetUpgradeStatusResponse) {
+        option (pbgen.rpc) = {
+            authz: SUPERUSER
+        };
+    }
 }
 
 // FinalizeUpgradeRequest takes no parameters: the target version is
@@ -59,3 +77,86 @@ message FinalizeUpgradeRequest {}
 // leader's background loop; poll the cluster's active version (via
 // `GET /v1/features`) to confirm.
 message FinalizeUpgradeResponse {}
+
+// GetUpgradeStatusRequest takes no parameters.
+message GetUpgradeStatusRequest {}
+
+// FinalizationState summarizes where the cluster sits in the
+// upgrade-finalization lifecycle. It is derived from the per-member
+// logical versions using the same preconditions the controller applies
+// when deciding whether to advance the active version.
+enum FinalizationState {
+    FINALIZATION_STATE_UNSPECIFIED = 0;
+
+    // The active version already equals the logical version uniformly
+    // supported by all members. Nothing to finalize, and no downgrade is
+    // possible (the downgrade floor equals the current version).
+    FINALIZATION_STATE_FINALIZED = 1;
+
+    // All members report the same logical version, higher than the
+    // active version, and all are alive: the cluster can be finalized
+    // (via FinalizeUpgrade, or automatically when
+    // features_auto_finalization is enabled). A downgrade back to the
+    // active version remains possible until finalization happens.
+    FINALIZATION_STATE_READY_TO_FINALIZE = 2;
+
+    // Members report differing logical versions, or some member has not
+    // reported a version yet or is not alive. Finalization is not yet
+    // possible. A downgrade back to the active version remains possible.
+    FINALIZATION_STATE_UPGRADE_IN_PROGRESS = 3;
+}
+
+// MemberVersion is one cluster member's reported version state, as seen
+// by the controller leader.
+message MemberVersion {
+    // Broker / node id.
+    int32 node_id = 1;
+
+    // Latest logical version this member reports, i.e. the highest
+    // version its binary supports. Meaningful only when version_known is
+    // true.
+    int64 logical_version = 2;
+
+    // False when the controller leader has not yet received a version
+    // report for this member (e.g. freshly added, or restarting).
+    bool version_known = 3;
+
+    // Liveness of this member per the controller leader's health
+    // monitor.
+    bool alive = 4;
+
+    // Human-readable Redpanda release version (e.g. "v25.2.1") reported
+    // by this member, when known. Distinct from logical_version:
+    // multiple releases can share one logical version.
+    string release_version = 5;
+}
+
+// GetUpgradeStatusResponse describes the cluster's upgrade-finalization
+// state.
+message GetUpgradeStatusResponse {
+    // High-level lifecycle state derived from the per-member versions
+    // below.
+    FinalizationState state = 1;
+
+    // The cluster's current active logical version. This is also the
+    // downgrade floor: the cluster can still roll back to a binary that
+    // supports this version. When state is FINALIZATION_STATE_FINALIZED
+    // this equals version_after_finalization (no downgrade possible).
+    int64 active_version = 2;
+
+    // The active version that a FinalizeUpgrade would produce right now.
+    // Greater than active_version only when state is
+    // FINALIZATION_STATE_READY_TO_FINALIZE; otherwise equal to
+    // active_version (finalizing would be a no-op).
+    int64 version_after_finalization = 3;
+
+    // Whether the cluster advances the active version automatically once
+    // all members agree (the features_auto_finalization cluster config).
+    // When false, an explicit FinalizeUpgrade is required.
+    bool auto_finalization_enabled = 4;
+
+    // Per-member reported version state. Compare logical_version across
+    // members to see whether all nodes are on the same version (ready to
+    // finalize) or still differ (upgrade in progress).
+    repeated MemberVersion members = 5;
+}

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -774,6 +774,88 @@ feature_manager::submit_manual_finalize_request() {
     co_return finalize_status::ok;
 }
 
+ss::future<feature_manager::upgrade_status>
+feature_manager::get_upgrade_status() {
+    vassert(ss::this_shard_id() == backend_shard, "Wrong shard!");
+
+    upgrade_status status;
+    status.active_version = _feature_table.local().get_active_version();
+    status.auto_finalization_enabled
+      = config::shard_local_cfg().features_auto_finalization();
+
+    // The version a finalize would aim for: the highest logical version
+    // reported by any node. Matches do_maybe_update_active_version.
+    cluster_version max_version = invalid_version;
+    for (const auto& i : _node_versions) {
+        max_version = std::max(i.second, max_version);
+    }
+
+    // Best-effort enrichment: map node -> human-readable release version
+    // from the cached cluster health report. Exclude per-partition health
+    // (include_partitions::no): we only need each node's reported
+    // redpanda_version, and pulling partition metadata would make this
+    // pollable read-only RPC needlessly expensive on large clusters. A
+    // fetch failure just leaves release_version empty; the version
+    // observability below does not depend on it.
+    std::map<model::node_id, ss::sstring> release_by_node;
+    auto health = co_await _hm_frontend.local().get_cluster_health(
+      cluster_report_filter{
+        .node_report_filter
+        = node_report_filter{.include_partitions = include_partitions_info::no}},
+      force_refresh::no,
+      model::timeout_clock::now() + health_monitor_frontend::default_timeout);
+    if (health) {
+        for (const auto& report : health.value().node_reports) {
+            release_by_node.emplace(
+              report->id, report->local_state.redpanda_version());
+        }
+    }
+
+    // Gather per-member version + liveness, mirroring the precondition
+    // checks in do_maybe_update_active_version (all members known, all
+    // versions >= max_version, all alive). Kept as a read-only mirror
+    // rather than sharing code with that safety-critical loop; the raw
+    // per-member fields below are authoritative even if the rolled-up
+    // state lags a change to the loop's predicate.
+    bool all_known = true;
+    bool all_sufficient = true;
+    bool all_alive = true;
+    for (const auto& node_id : _members.local().node_ids()) {
+        upgrade_status::member m;
+        m.id = node_id;
+        if (
+          auto it = _node_versions.find(node_id); it != _node_versions.end()) {
+            m.version_known = true;
+            m.logical_version = it->second;
+            all_sufficient &= it->second >= max_version;
+        } else {
+            all_known = false;
+        }
+        m.alive = _hm_frontend.local().is_alive(node_id) == alive::yes;
+        all_alive &= m.alive;
+        if (
+          auto it = release_by_node.find(node_id);
+          it != release_by_node.end()) {
+            m.release_version = it->second;
+        }
+        status.members.push_back(std::move(m));
+    }
+
+    using state = upgrade_status::finalization_state;
+    if (max_version <= status.active_version) {
+        status.state = state::finalized;
+        status.version_after_finalization = status.active_version;
+    } else if (all_known && all_sufficient && all_alive) {
+        status.state = state::ready_to_finalize;
+        status.version_after_finalization = max_version;
+    } else {
+        status.state = state::upgrade_in_progress;
+        status.version_after_finalization = status.active_version;
+    }
+
+    co_return status;
+}
+
 ss::future<> feature_manager::do_maybe_activate_features() {
     if (!_is_leader_of.has_value()) {
         co_return;

--- a/src/v/cluster/feature_manager.h
+++ b/src/v/cluster/feature_manager.h
@@ -126,6 +126,48 @@ public:
     /// \c backend_shard.
     ss::future<finalize_status> submit_manual_finalize_request();
 
+    /// Observability snapshot of the upgrade-finalization lifecycle,
+    /// returned by \ref get_upgrade_status.
+    struct upgrade_status {
+        enum class finalization_state {
+            /// active_version already equals the version uniformly
+            /// supported by all members; nothing to finalize.
+            finalized,
+            /// All members report the same version > active_version and
+            /// are alive: finalizable now.
+            ready_to_finalize,
+            /// Members differ, or a member's version is unknown, or a
+            /// member is not alive: not finalizable yet.
+            upgrade_in_progress,
+        };
+
+        /// One member's reported version state.
+        struct member {
+            model::node_id id;
+            cluster_version logical_version{invalid_version};
+            bool version_known{false};
+            bool alive{false};
+            ss::sstring release_version;
+        };
+
+        finalization_state state{finalization_state::finalized};
+        cluster_version active_version{invalid_version};
+        cluster_version version_after_finalization{invalid_version};
+        bool auto_finalization_enabled{false};
+        std::vector<member> members;
+    };
+
+    /// Snapshot the cluster's upgrade-finalization state for
+    /// observability: per-member logical versions (from health reports)
+    /// and liveness, the active version, and the version a finalize
+    /// would advance to. The per-member preconditions mirror those
+    /// \ref do_maybe_update_active_version applies; the raw per-member
+    /// fields are authoritative even if the rolled-up \c state lags a
+    /// change to that loop. Reflects the controller leader's view, so
+    /// callers should invoke this on the leader. Must run on
+    /// \c backend_shard.
+    ss::future<upgrade_status> get_upgrade_status();
+
     features::enterprise_feature_report report_enterprise_features() const;
 
     /**

--- a/src/v/redpanda/admin/services/features.cc
+++ b/src/v/redpanda/admin/services/features.cc
@@ -27,6 +27,21 @@ namespace {
 // NOLINTNEXTLINE(*-non-const-global-variables,cert-err58-*)
 ss::logger featureslog{"admin_api_server/features_service"};
 
+proto::admin::finalization_state
+to_proto(cluster::feature_manager::upgrade_status::finalization_state s) {
+    using in_t = cluster::feature_manager::upgrade_status::finalization_state;
+    using out_t = proto::admin::finalization_state;
+    switch (s) {
+    case in_t::finalized:
+        return out_t::finalized;
+    case in_t::ready_to_finalize:
+        return out_t::ready_to_finalize;
+    case in_t::upgrade_in_progress:
+        return out_t::upgrade_in_progress;
+    }
+    return out_t::unspecified;
+}
+
 } // namespace
 
 features_service_impl::features_service_impl(
@@ -80,6 +95,47 @@ features_service_impl::finalize_upgrade(
           "request");
     }
     vunreachable("unhandled finalize_status: {}", static_cast<int>(status));
+}
+
+ss::future<proto::admin::get_upgrade_status_response>
+features_service_impl::get_upgrade_status(
+  serde::pb::rpc::context ctx, proto::admin::get_upgrade_status_request req) {
+    vlog(featureslog.trace, "get_upgrade_status: {}", req);
+
+    const auto redirect_node = utils::redirect_to_leader(
+      _md_cache.local(), model::controller_ntp, _proxy_client.self_node_id());
+
+    if (redirect_node) {
+        vlog(
+          featureslog.debug,
+          "Redirecting to leader of {}: {}",
+          model::controller_ntp,
+          *redirect_node);
+        co_return co_await _proxy_client
+          .make_client_for_node<proto::admin::features_service_client>(
+            *redirect_node)
+          .get_upgrade_status(ctx, std::move(req));
+    }
+
+    auto& fm = _controller->get_feature_manager();
+    auto status = co_await fm.invoke_on(
+      cluster::feature_manager::backend_shard,
+      [](cluster::feature_manager& fm) { return fm.get_upgrade_status(); });
+
+    proto::admin::get_upgrade_status_response resp;
+    resp.set_state(to_proto(status.state));
+    resp.set_active_version(status.active_version());
+    resp.set_version_after_finalization(status.version_after_finalization());
+    resp.set_auto_finalization_enabled(status.auto_finalization_enabled);
+    for (auto& m : status.members) {
+        auto& mv = resp.get_members().emplace_back();
+        mv.set_node_id(m.id());
+        mv.set_logical_version(m.logical_version());
+        mv.set_version_known(m.version_known);
+        mv.set_alive(m.alive);
+        mv.set_release_version(std::move(m.release_version));
+    }
+    co_return resp;
 }
 
 } // namespace admin

--- a/src/v/redpanda/admin/services/features.h
+++ b/src/v/redpanda/admin/services/features.h
@@ -27,6 +27,10 @@ public:
     ss::future<proto::admin::finalize_upgrade_response> finalize_upgrade(
       serde::pb::rpc::context, proto::admin::finalize_upgrade_request) override;
 
+    ss::future<proto::admin::get_upgrade_status_response> get_upgrade_status(
+      serde::pb::rpc::context,
+      proto::admin::get_upgrade_status_request) override;
+
 private:
     admin::proxy::client _proxy_client;
     cluster::controller* _controller;

--- a/tests/rptest/clients/admin/proto/redpanda/core/admin/v2/features_pb2.py
+++ b/tests/rptest/clients/admin/proto/redpanda/core/admin/v2/features_pb2.py
@@ -8,7 +8,7 @@ _runtime_version.ValidateProtobufRuntimeVersion(_runtime_version.Domain.PUBLIC, 
 _sym_db = _symbol_database.Default()
 from ......proto.redpanda.core.pbgen import options_pb2 as proto_dot_redpanda_dot_core_dot_pbgen_dot_options__pb2
 from ......proto.redpanda.core.pbgen import rpc_pb2 as proto_dot_redpanda_dot_core_dot_pbgen_dot_rpc__pb2
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n+proto/redpanda/core/admin/v2/features.proto\x12\x16redpanda.core.admin.v2\x1a\'proto/redpanda/core/pbgen/options.proto\x1a#proto/redpanda/core/pbgen/rpc.proto"\x18\n\x16FinalizeUpgradeRequest"\x19\n\x17FinalizeUpgradeResponse2\x8d\x01\n\x0fFeaturesService\x12z\n\x0fFinalizeUpgrade\x12..redpanda.core.admin.v2.FinalizeUpgradeRequest\x1a/.redpanda.core.admin.v2.FinalizeUpgradeResponse"\x06\xea\x92\x19\x02\x10\x03B\x10\xea\x92\x19\x0cproto::adminb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n+proto/redpanda/core/admin/v2/features.proto\x12\x16redpanda.core.admin.v2\x1a\'proto/redpanda/core/pbgen/options.proto\x1a#proto/redpanda/core/pbgen/rpc.proto"\x18\n\x16FinalizeUpgradeRequest"\x19\n\x17FinalizeUpgradeResponse"\x19\n\x17GetUpgradeStatusRequest"x\n\rMemberVersion\x12\x0f\n\x07node_id\x18\x01 \x01(\x05\x12\x17\n\x0flogical_version\x18\x02 \x01(\x03\x12\x15\n\rversion_known\x18\x03 \x01(\x08\x12\r\n\x05alive\x18\x04 \x01(\x08\x12\x17\n\x0frelease_version\x18\x05 \x01(\t"\xeb\x01\n\x18GetUpgradeStatusResponse\x128\n\x05state\x18\x01 \x01(\x0e2).redpanda.core.admin.v2.FinalizationState\x12\x16\n\x0eactive_version\x18\x02 \x01(\x03\x12"\n\x1aversion_after_finalization\x18\x03 \x01(\x03\x12!\n\x19auto_finalization_enabled\x18\x04 \x01(\x08\x126\n\x07members\x18\x05 \x03(\x0b2%.redpanda.core.admin.v2.MemberVersion*\xaf\x01\n\x11FinalizationState\x12"\n\x1eFINALIZATION_STATE_UNSPECIFIED\x10\x00\x12 \n\x1cFINALIZATION_STATE_FINALIZED\x10\x01\x12(\n$FINALIZATION_STATE_READY_TO_FINALIZE\x10\x02\x12*\n&FINALIZATION_STATE_UPGRADE_IN_PROGRESS\x10\x032\x8c\x02\n\x0fFeaturesService\x12z\n\x0fFinalizeUpgrade\x12..redpanda.core.admin.v2.FinalizeUpgradeRequest\x1a/.redpanda.core.admin.v2.FinalizeUpgradeResponse"\x06\xea\x92\x19\x02\x10\x03\x12}\n\x10GetUpgradeStatus\x12/.redpanda.core.admin.v2.GetUpgradeStatusRequest\x1a0.redpanda.core.admin.v2.GetUpgradeStatusResponse"\x06\xea\x92\x19\x02\x10\x03B\x10\xea\x92\x19\x0cproto::adminb\x06proto3')
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'proto.redpanda.core.admin.v2.features_pb2', _globals)
@@ -17,9 +17,19 @@ if not _descriptor._USE_C_DESCRIPTORS:
     _globals['DESCRIPTOR']._serialized_options = b'\xea\x92\x19\x0cproto::admin'
     _globals['_FEATURESSERVICE'].methods_by_name['FinalizeUpgrade']._loaded_options = None
     _globals['_FEATURESSERVICE'].methods_by_name['FinalizeUpgrade']._serialized_options = b'\xea\x92\x19\x02\x10\x03'
+    _globals['_FEATURESSERVICE'].methods_by_name['GetUpgradeStatus']._loaded_options = None
+    _globals['_FEATURESSERVICE'].methods_by_name['GetUpgradeStatus']._serialized_options = b'\xea\x92\x19\x02\x10\x03'
+    _globals['_FINALIZATIONSTATE']._serialized_start = 590
+    _globals['_FINALIZATIONSTATE']._serialized_end = 765
     _globals['_FINALIZEUPGRADEREQUEST']._serialized_start = 149
     _globals['_FINALIZEUPGRADEREQUEST']._serialized_end = 173
     _globals['_FINALIZEUPGRADERESPONSE']._serialized_start = 175
     _globals['_FINALIZEUPGRADERESPONSE']._serialized_end = 200
-    _globals['_FEATURESSERVICE']._serialized_start = 203
-    _globals['_FEATURESSERVICE']._serialized_end = 344
+    _globals['_GETUPGRADESTATUSREQUEST']._serialized_start = 202
+    _globals['_GETUPGRADESTATUSREQUEST']._serialized_end = 227
+    _globals['_MEMBERVERSION']._serialized_start = 229
+    _globals['_MEMBERVERSION']._serialized_end = 349
+    _globals['_GETUPGRADESTATUSRESPONSE']._serialized_start = 352
+    _globals['_GETUPGRADESTATUSRESPONSE']._serialized_end = 587
+    _globals['_FEATURESSERVICE']._serialized_start = 768
+    _globals['_FEATURESSERVICE']._serialized_end = 1036

--- a/tests/rptest/clients/admin/proto/redpanda/core/admin/v2/features_pb2.pyi
+++ b/tests/rptest/clients/admin/proto/redpanda/core/admin/v2/features_pb2.pyi
@@ -15,7 +15,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import builtins
+import collections.abc
 import google.protobuf.descriptor
+import google.protobuf.internal.containers
+import google.protobuf.internal.enum_type_wrapper
 import google.protobuf.message
 import sys
 import typing
@@ -24,6 +28,35 @@ if sys.version_info >= (3, 10):
 else:
     import typing_extensions
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor
+
+class _FinalizationState:
+    ValueType = typing.NewType('ValueType', builtins.int)
+    V: typing_extensions.TypeAlias = ValueType
+
+class _FinalizationStateEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_FinalizationState.ValueType], builtins.type):
+    DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor
+    FINALIZATION_STATE_UNSPECIFIED: _FinalizationState.ValueType
+    FINALIZATION_STATE_FINALIZED: _FinalizationState.ValueType
+    'The active version already equals the logical version uniformly\n    supported by all members. Nothing to finalize, and no downgrade is\n    possible (the downgrade floor equals the current version).\n    '
+    FINALIZATION_STATE_READY_TO_FINALIZE: _FinalizationState.ValueType
+    'All members report the same logical version, higher than the\n    active version, and all are alive: the cluster can be finalized\n    (via FinalizeUpgrade, or automatically when\n    features_auto_finalization is enabled). A downgrade back to the\n    active version remains possible until finalization happens.\n    '
+    FINALIZATION_STATE_UPGRADE_IN_PROGRESS: _FinalizationState.ValueType
+    'Members report differing logical versions, or some member has not\n    reported a version yet or is not alive. Finalization is not yet\n    possible. A downgrade back to the active version remains possible.\n    '
+
+class FinalizationState(_FinalizationState, metaclass=_FinalizationStateEnumTypeWrapper):
+    """FinalizationState summarizes where the cluster sits in the
+    upgrade-finalization lifecycle. It is derived from the per-member
+    logical versions using the same preconditions the controller applies
+    when deciding whether to advance the active version.
+    """
+FINALIZATION_STATE_UNSPECIFIED: FinalizationState.ValueType
+FINALIZATION_STATE_FINALIZED: FinalizationState.ValueType
+'The active version already equals the logical version uniformly\nsupported by all members. Nothing to finalize, and no downgrade is\npossible (the downgrade floor equals the current version).\n'
+FINALIZATION_STATE_READY_TO_FINALIZE: FinalizationState.ValueType
+'All members report the same logical version, higher than the\nactive version, and all are alive: the cluster can be finalized\n(via FinalizeUpgrade, or automatically when\nfeatures_auto_finalization is enabled). A downgrade back to the\nactive version remains possible until finalization happens.\n'
+FINALIZATION_STATE_UPGRADE_IN_PROGRESS: FinalizationState.ValueType
+'Members report differing logical versions, or some member has not\nreported a version yet or is not alive. Finalization is not yet\npossible. A downgrade back to the active version remains possible.\n'
+Global___FinalizationState: typing_extensions.TypeAlias = FinalizationState
 
 @typing.final
 class FinalizeUpgradeRequest(google.protobuf.message.Message):
@@ -48,3 +81,75 @@ class FinalizeUpgradeResponse(google.protobuf.message.Message):
     def __init__(self) -> None:
         ...
 Global___FinalizeUpgradeResponse: typing_extensions.TypeAlias = FinalizeUpgradeResponse
+
+@typing.final
+class GetUpgradeStatusRequest(google.protobuf.message.Message):
+    """GetUpgradeStatusRequest takes no parameters."""
+    DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+    def __init__(self) -> None:
+        ...
+Global___GetUpgradeStatusRequest: typing_extensions.TypeAlias = GetUpgradeStatusRequest
+
+@typing.final
+class MemberVersion(google.protobuf.message.Message):
+    """MemberVersion is one cluster member's reported version state, as seen
+    by the controller leader.
+    """
+    DESCRIPTOR: google.protobuf.descriptor.Descriptor
+    NODE_ID_FIELD_NUMBER: builtins.int
+    LOGICAL_VERSION_FIELD_NUMBER: builtins.int
+    VERSION_KNOWN_FIELD_NUMBER: builtins.int
+    ALIVE_FIELD_NUMBER: builtins.int
+    RELEASE_VERSION_FIELD_NUMBER: builtins.int
+    node_id: builtins.int
+    'Broker / node id.'
+    logical_version: builtins.int
+    'Latest logical version this member reports, i.e. the highest\n    version its binary supports. Meaningful only when version_known is\n    true.\n    '
+    version_known: builtins.bool
+    'False when the controller leader has not yet received a version\n    report for this member (e.g. freshly added, or restarting).\n    '
+    alive: builtins.bool
+    "Liveness of this member per the controller leader's health\n    monitor.\n    "
+    release_version: builtins.str
+    'Human-readable Redpanda release version (e.g. "v25.2.1") reported\n    by this member, when known. Distinct from logical_version:\n    multiple releases can share one logical version.\n    '
+
+    def __init__(self, *, node_id: builtins.int=..., logical_version: builtins.int=..., version_known: builtins.bool=..., alive: builtins.bool=..., release_version: builtins.str=...) -> None:
+        ...
+
+    def ClearField(self, field_name: typing.Literal['alive', b'alive', 'logical_version', b'logical_version', 'node_id', b'node_id', 'release_version', b'release_version', 'version_known', b'version_known']) -> None:
+        ...
+Global___MemberVersion: typing_extensions.TypeAlias = MemberVersion
+
+@typing.final
+class GetUpgradeStatusResponse(google.protobuf.message.Message):
+    """GetUpgradeStatusResponse describes the cluster's upgrade-finalization
+    state.
+    """
+    DESCRIPTOR: google.protobuf.descriptor.Descriptor
+    STATE_FIELD_NUMBER: builtins.int
+    ACTIVE_VERSION_FIELD_NUMBER: builtins.int
+    VERSION_AFTER_FINALIZATION_FIELD_NUMBER: builtins.int
+    AUTO_FINALIZATION_ENABLED_FIELD_NUMBER: builtins.int
+    MEMBERS_FIELD_NUMBER: builtins.int
+    state: Global___FinalizationState.ValueType
+    'High-level lifecycle state derived from the per-member versions\n    below.\n    '
+    active_version: builtins.int
+    "The cluster's current active logical version. This is also the\n    downgrade floor: the cluster can still roll back to a binary that\n    supports this version. When state is FINALIZATION_STATE_FINALIZED\n    this equals version_after_finalization (no downgrade possible).\n    "
+    version_after_finalization: builtins.int
+    'The active version that a FinalizeUpgrade would produce right now.\n    Greater than active_version only when state is\n    FINALIZATION_STATE_READY_TO_FINALIZE; otherwise equal to\n    active_version (finalizing would be a no-op).\n    '
+    auto_finalization_enabled: builtins.bool
+    'Whether the cluster advances the active version automatically once\n    all members agree (the features_auto_finalization cluster config).\n    When false, an explicit FinalizeUpgrade is required.\n    '
+
+    @property
+    def members(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[Global___MemberVersion]:
+        """Per-member reported version state. Compare logical_version across
+        members to see whether all nodes are on the same version (ready to
+        finalize) or still differ (upgrade in progress).
+        """
+
+    def __init__(self, *, state: Global___FinalizationState.ValueType=..., active_version: builtins.int=..., version_after_finalization: builtins.int=..., auto_finalization_enabled: builtins.bool=..., members: collections.abc.Iterable[Global___MemberVersion] | None=...) -> None:
+        ...
+
+    def ClearField(self, field_name: typing.Literal['active_version', b'active_version', 'auto_finalization_enabled', b'auto_finalization_enabled', 'members', b'members', 'state', b'state', 'version_after_finalization', b'version_after_finalization']) -> None:
+        ...
+Global___GetUpgradeStatusResponse: typing_extensions.TypeAlias = GetUpgradeStatusResponse

--- a/tests/rptest/clients/admin/proto/redpanda/core/admin/v2/features_pb2_connect.py
+++ b/tests/rptest/clients/admin/proto/redpanda/core/admin/v2/features_pb2_connect.py
@@ -49,6 +49,21 @@ class FeaturesServiceClient:
             raise ConnectProtocolError('missing response message')
         return msg
 
+    def call_get_upgrade_status(self, req: proto.redpanda.core.admin.v2.features_pb2.GetUpgradeStatusRequest, extra_headers: HeaderInput | None=None, timeout_seconds: float | None=None) -> UnaryOutput[proto.redpanda.core.admin.v2.features_pb2.GetUpgradeStatusResponse]:
+        """Low-level method to call GetUpgradeStatus, granting access to errors and metadata"""
+        url = self.base_url + '/redpanda.core.admin.v2.FeaturesService/GetUpgradeStatus'
+        return self._connect_client.call_unary(url, req, proto.redpanda.core.admin.v2.features_pb2.GetUpgradeStatusResponse, extra_headers, timeout_seconds)
+
+    def get_upgrade_status(self, req: proto.redpanda.core.admin.v2.features_pb2.GetUpgradeStatusRequest, extra_headers: HeaderInput | None=None, timeout_seconds: float | None=None) -> proto.redpanda.core.admin.v2.features_pb2.GetUpgradeStatusResponse:
+        response = self.call_get_upgrade_status(req, extra_headers, timeout_seconds)
+        err = response.error()
+        if err is not None:
+            raise err
+        msg = response.message()
+        if msg is None:
+            raise ConnectProtocolError('missing response message')
+        return msg
+
 class AsyncFeaturesServiceClient:
 
     def __init__(self, base_url: str, http_client: aiohttp.ClientSession, protocol: ConnectProtocol=ConnectProtocol.CONNECT_PROTOBUF):
@@ -70,14 +85,33 @@ class AsyncFeaturesServiceClient:
             raise ConnectProtocolError('missing response message')
         return msg
 
+    async def call_get_upgrade_status(self, req: proto.redpanda.core.admin.v2.features_pb2.GetUpgradeStatusRequest, extra_headers: HeaderInput | None=None, timeout_seconds: float | None=None) -> UnaryOutput[proto.redpanda.core.admin.v2.features_pb2.GetUpgradeStatusResponse]:
+        """Low-level method to call GetUpgradeStatus, granting access to errors and metadata"""
+        url = self.base_url + '/redpanda.core.admin.v2.FeaturesService/GetUpgradeStatus'
+        return await self._connect_client.call_unary(url, req, proto.redpanda.core.admin.v2.features_pb2.GetUpgradeStatusResponse, extra_headers, timeout_seconds)
+
+    async def get_upgrade_status(self, req: proto.redpanda.core.admin.v2.features_pb2.GetUpgradeStatusRequest, extra_headers: HeaderInput | None=None, timeout_seconds: float | None=None) -> proto.redpanda.core.admin.v2.features_pb2.GetUpgradeStatusResponse:
+        response = await self.call_get_upgrade_status(req, extra_headers, timeout_seconds)
+        err = response.error()
+        if err is not None:
+            raise err
+        msg = response.message()
+        if msg is None:
+            raise ConnectProtocolError('missing response message')
+        return msg
+
 @typing.runtime_checkable
 class FeaturesServiceProtocol(typing.Protocol):
 
     def finalize_upgrade(self, req: ClientRequest[proto.redpanda.core.admin.v2.features_pb2.FinalizeUpgradeRequest]) -> ServerResponse[proto.redpanda.core.admin.v2.features_pb2.FinalizeUpgradeResponse]:
+        ...
+
+    def get_upgrade_status(self, req: ClientRequest[proto.redpanda.core.admin.v2.features_pb2.GetUpgradeStatusRequest]) -> ServerResponse[proto.redpanda.core.admin.v2.features_pb2.GetUpgradeStatusResponse]:
         ...
 FEATURES_SERVICE_PATH_PREFIX = '/redpanda.core.admin.v2.FeaturesService'
 
 def wsgi_features_service(implementation: FeaturesServiceProtocol) -> WSGIApplication:
     app = ConnectWSGI()
     app.register_unary_rpc('/redpanda.core.admin.v2.FeaturesService/FinalizeUpgrade', implementation.finalize_upgrade, proto.redpanda.core.admin.v2.features_pb2.FinalizeUpgradeRequest)
+    app.register_unary_rpc('/redpanda.core.admin.v2.FeaturesService/GetUpgradeStatus', implementation.get_upgrade_status, proto.redpanda.core.admin.v2.features_pb2.GetUpgradeStatusRequest)
     return app

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -1123,6 +1123,58 @@ class AuditLogTestAdminApi(AuditLogTestBase):
         expected = self.redpanda.SUPERUSER_CREDENTIALS[0]
         assert actor == expected, f"Expected actor user {expected}, got {actor}"
 
+    @skip_fips_mode
+    @cluster(num_nodes=5)
+    def test_admin_v2_get_upgrade_status(self):
+        """
+        Verifies that calls to the admin v2 FeaturesService.GetUpgradeStatus
+        RPC produce an api_activity audit record when the "admin" event type
+        is enabled. Unlike FinalizeUpgrade this RPC is read-only (USER authz)
+        and succeeds; the audit entry is emitted at the auth boundary either
+        way.
+        """
+        self.modify_audit_event_types(["admin"])
+
+        admin_v2 = AdminV2(
+            self.redpanda,
+            auth=(
+                self.redpanda.SUPERUSER_CREDENTIALS[0],
+                self.redpanda.SUPERUSER_CREDENTIALS[1],
+            ),
+        )
+
+        # The audit record is emitted at the auth boundary, so it appears even
+        # if the handler transiently returns UNAVAILABLE (e.g. no controller
+        # leader during the election window under parallel load).
+        try:
+            admin_v2.features().get_upgrade_status(
+                features_pb2.GetUpgradeStatusRequest()
+            )
+        except Exception as e:
+            self.logger.debug(f"GetUpgradeStatus returned: {e}")
+
+        def is_get_upgrade_status_record(record):
+            if (
+                record["class_uid"] != 6003
+                or record["dst_endpoint"]["svc_name"] != self.admin_audit_svc_name
+            ):
+                return False
+            url = record["http_request"]["url"]["url_string"]
+            return "FeaturesService/GetUpgradeStatus" in url
+
+        records = self.find_matching_record(
+            is_get_upgrade_status_record,
+            lambda count: count >= 1,
+            "admin v2 GetUpgradeStatus audit record",
+        )
+
+        assert len(records) >= 1, (
+            f"Expected at least one record, got {len(records)}: {records}"
+        )
+        actor = records[0]["actor"]["user"]["name"]
+        expected = self.redpanda.SUPERUSER_CREDENTIALS[0]
+        assert actor == expected, f"Expected actor user {expected}, got {actor}"
+
 
 class AuditLogTestAdminAuthApi(AuditLogTestBase):
     """

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -785,10 +785,45 @@ class ManualFinalizationTest(FeaturesTestBase):
     def _disable_auto_finalization(self):
         self.redpanda.set_cluster_config({"features_auto_finalization": False})
 
+    def _call_with_leader_retry(self, call, timeout_sec=30):
+        """Invoke a controller-leader-routed admin v2 call, retrying through
+        the transient UNAVAILABLE ("controller has no leader") window that can
+        occur during or after node restarts and leadership transfers --
+        notably under parallel load, where elections take longer. Unlike the
+        v1 Admin client, the v2 connect client does not retry leadership
+        itself. Only UNAVAILABLE is retried; other errors (e.g.
+        FAILED_PRECONDITION) propagate immediately."""
+        deadline = time.time() + timeout_sec
+        while True:
+            try:
+                return call()
+            except ConnectError as e:
+                if e.code != ConnectErrorCode.UNAVAILABLE or time.time() >= deadline:
+                    raise
+                time.sleep(1)
+
     def _finalize(self):
-        return self.admin_v2.features().finalize_upgrade(
-            features_pb2.FinalizeUpgradeRequest()
+        return self._call_with_leader_retry(
+            lambda: self.admin_v2.features().finalize_upgrade(
+                features_pb2.FinalizeUpgradeRequest()
+            )
         )
+
+    def _get_upgrade_status(self):
+        return self._call_with_leader_retry(
+            lambda: self.admin_v2.features().get_upgrade_status(
+                features_pb2.GetUpgradeStatusRequest()
+            )
+        )
+
+    def _wait_for_status_state(self, state, timeout_sec=30):
+        """Wait until GetUpgradeStatus reports `state`; return that status."""
+        wait_until(
+            lambda: self._get_upgrade_status().state == state,
+            timeout_sec=timeout_sec,
+            backoff_sec=1,
+        )
+        return self._get_upgrade_status()
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_auto_finalization_disabled_blocks_advance(self):
@@ -810,6 +845,16 @@ class ManualFinalizationTest(FeaturesTestBase):
             self.admin.get_features()["cluster_version"] == MANUAL_FINALIZE_OLD_VERSION
         )
 
+        # The observability RPC reports the same situation: a uniform higher
+        # version is available, but the cluster is held at the old (downgrade
+        # floor) version pending an explicit finalize.
+        status = self._wait_for_status_state(
+            features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE
+        )
+        assert status.active_version == MANUAL_FINALIZE_OLD_VERSION
+        assert status.version_after_finalization == MANUAL_FINALIZE_NEW_VERSION
+        assert not status.auto_finalization_enabled
+
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_manual_request_triggers_advance(self):
         """
@@ -828,9 +873,23 @@ class ManualFinalizationTest(FeaturesTestBase):
             self.admin.get_features()["cluster_version"] == MANUAL_FINALIZE_OLD_VERSION
         )
 
+        # Uniformly upgraded but deferred: the cluster is ready to finalize.
+        ready = self._wait_for_status_state(
+            features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE
+        )
+        assert ready.version_after_finalization == MANUAL_FINALIZE_NEW_VERSION
+
         self._finalize()
 
         self._wait_for_version_everywhere(MANUAL_FINALIZE_NEW_VERSION)
+
+        # Once the advance lands, the status flips to finalized and the active
+        # version (the downgrade floor) catches up to the binaries.
+        finalized = self._wait_for_status_state(
+            features_pb2.FINALIZATION_STATE_FINALIZED
+        )
+        assert finalized.active_version == MANUAL_FINALIZE_NEW_VERSION
+        assert finalized.version_after_finalization == MANUAL_FINALIZE_NEW_VERSION
 
     @cluster(num_nodes=3)
     def test_manual_request_rejected_when_auto_enabled(self):
@@ -846,6 +905,12 @@ class ManualFinalizationTest(FeaturesTestBase):
             lambda e: e.code == ConnectErrorCode.FAILED_PRECONDITION,
         ):
             self._finalize()
+
+        # The read-only status RPC is not gated on auto-finalization: it
+        # succeeds and reflects that automatic finalization is enabled.
+        status = self._get_upgrade_status()
+        assert status.state == features_pb2.FINALIZATION_STATE_FINALIZED, status.state
+        assert status.auto_finalization_enabled
 
     @cluster(num_nodes=3)
     def test_manual_request_idempotent_when_no_advance_pending(self):
@@ -866,6 +931,11 @@ class ManualFinalizationTest(FeaturesTestBase):
 
         time.sleep(2)
         assert self.admin.get_features()["cluster_version"] == version_before
+
+        status = self._get_upgrade_status()
+        assert status.state == features_pb2.FINALIZATION_STATE_FINALIZED, status.state
+        assert status.active_version == version_before
+        assert status.version_after_finalization == version_before
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_manual_request_does_not_advance_on_mixed_version(self):
@@ -892,6 +962,18 @@ class ManualFinalizationTest(FeaturesTestBase):
         assert (
             self.admin.get_features()["cluster_version"] == MANUAL_FINALIZE_OLD_VERSION
         )
+
+        # The status RPC exposes the mixed versions and keeps
+        # version_after_finalization pinned to the (unchanged) active version.
+        status = self._wait_for_status_state(
+            features_pb2.FINALIZATION_STATE_UPGRADE_IN_PROGRESS
+        )
+        assert status.version_after_finalization == MANUAL_FINALIZE_OLD_VERSION
+        assert sorted(m.logical_version for m in status.members) == [
+            MANUAL_FINALIZE_OLD_VERSION,
+            MANUAL_FINALIZE_NEW_VERSION,
+            MANUAL_FINALIZE_NEW_VERSION,
+        ]
 
     @cluster(
         num_nodes=3,
@@ -931,6 +1013,22 @@ class ManualFinalizationTest(FeaturesTestBase):
         time.sleep(15)
         assert (
             self.admin.get_features()["cluster_version"] == MANUAL_FINALIZE_OLD_VERSION
+        )
+
+        # The status RPC surfaces the liveness gap: every node is on the new
+        # version, but the stopped node reports not-alive, so the cluster is
+        # not finalizable.
+        victim_id = self.redpanda.node_id(victim)
+        status = self._wait_for_status_state(
+            features_pb2.FINALIZATION_STATE_UPGRADE_IN_PROGRESS
+        )
+        assert status.version_after_finalization == MANUAL_FINALIZE_OLD_VERSION
+        members = {m.node_id: m for m in status.members}
+        assert not members[victim_id].alive, f"victim {victim_id} should be dead"
+        assert all(
+            members[self.redpanda.node_id(n)].alive
+            for n in self.redpanda.nodes
+            if self.redpanda.node_id(n) != victim_id
         )
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
@@ -986,6 +1084,85 @@ class ManualFinalizationTest(FeaturesTestBase):
         # landed; otherwise this is the call that drives the advance.
         self._finalize()
         self._wait_for_version_everywhere(MANUAL_FINALIZE_NEW_VERSION)
+
+        # The new leader serves the status RPC and reports the finalized state.
+        finalized = self._wait_for_status_state(
+            features_pb2.FINALIZATION_STATE_FINALIZED
+        )
+        assert finalized.active_version == MANUAL_FINALIZE_NEW_VERSION
+
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_get_upgrade_status_reports_lifecycle(self):
+        """
+        GetUpgradeStatus reflects the finalization lifecycle: FINALIZED at
+        rest, READY_TO_FINALIZE once all nodes report a higher version under
+        `features_auto_finalization=false`, then FINALIZED again after an
+        explicit FinalizeUpgrade. active_version doubles as the downgrade
+        floor: it equals version_after_finalization (no downgrade possible)
+        only in the FINALIZED states.
+        """
+        self._start_at_old()
+        self._disable_auto_finalization()
+
+        # At rest: nothing to finalize, no downgrade possible.
+        status = self._get_upgrade_status()
+        assert status.state == features_pb2.FINALIZATION_STATE_FINALIZED, status.state
+        assert status.active_version == MANUAL_FINALIZE_OLD_VERSION
+        assert status.version_after_finalization == MANUAL_FINALIZE_OLD_VERSION
+        assert not status.auto_finalization_enabled
+        assert len(status.members) == len(self.redpanda.nodes)
+        assert all(m.version_known and m.alive for m in status.members)
+        assert all(
+            m.logical_version == MANUAL_FINALIZE_OLD_VERSION for m in status.members
+        )
+        # release_version is plumbed through from the per-node health report.
+        assert all(m.release_version for m in status.members)
+
+        # Roll every node to the new version. Auto-finalization is off, so the
+        # active version holds and the cluster becomes READY_TO_FINALIZE.
+        self._restart_at_new(self.redpanda.nodes)
+
+        status = self._wait_for_status_state(
+            features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE
+        )
+        assert status.active_version == MANUAL_FINALIZE_OLD_VERSION
+        assert status.version_after_finalization == MANUAL_FINALIZE_NEW_VERSION
+        assert all(
+            m.logical_version == MANUAL_FINALIZE_NEW_VERSION for m in status.members
+        )
+
+        # Finalize: the active version catches up; no downgrade after this.
+        self._finalize()
+        self._wait_for_version_everywhere(MANUAL_FINALIZE_NEW_VERSION)
+
+        status = self._wait_for_status_state(features_pb2.FINALIZATION_STATE_FINALIZED)
+        assert status.active_version == MANUAL_FINALIZE_NEW_VERSION
+        assert status.version_after_finalization == MANUAL_FINALIZE_NEW_VERSION
+
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_get_upgrade_status_reports_in_progress(self):
+        """
+        With a partial rolling upgrade (mixed logical versions),
+        GetUpgradeStatus reports UPGRADE_IN_PROGRESS and holds
+        version_after_finalization at the unchanged active version, while
+        the per-member list exposes the version spread.
+        """
+        self._start_at_old()
+        self._disable_auto_finalization()
+
+        # Upgrade only two of three nodes; the third stays at OLD_VERSION.
+        self._restart_at_new(self.redpanda.nodes[:2])
+
+        status = self._wait_for_status_state(
+            features_pb2.FINALIZATION_STATE_UPGRADE_IN_PROGRESS
+        )
+        assert status.active_version == MANUAL_FINALIZE_OLD_VERSION
+        assert status.version_after_finalization == MANUAL_FINALIZE_OLD_VERSION
+        assert sorted(m.logical_version for m in status.members) == [
+            MANUAL_FINALIZE_OLD_VERSION,
+            MANUAL_FINALIZE_NEW_VERSION,
+            MANUAL_FINALIZE_NEW_VERSION,
+        ]
 
 
 class ManualFinalizationLicenseTest(RedpandaTest):


### PR DESCRIPTION
Add an adminv2 interface that will report on the state of the cluster as it pertains to upgrades and upgrade finalization. It will show for example what version nodes are at, what version is available for upgrade, and can be used to determine if the upgrade finalized or the cluster can be downgraded.

Some of the metadata is duplicated in other APIs, but this centralizes all the information relevant for upgrade finalization workflows for ease of use.

Corresponds to `[REQ-ID2] Upgrade Status: cluster state visibility` in the PRD.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
