### PR TITLE
dl/coordinator: fix double-get of fibers in concurrent add test

### DIFF
--- a/src/v/datalake/coordinator/tests/coordinator_test.cc
+++ b/src/v/datalake/coordinator/tests/coordinator_test.cc
@@ -512,19 +512,35 @@ TEST_P(CoordinatorTestWithParams, TestConcurrentAddFiles) {
     }
     auto stop = ss::defer([&] {
         done = true;
-        for (auto& f : adders) {
-            f.get();
+        // Join any fibers not yet joined below. Pop as we go so we never
+        // get() a future twice (a second get() dereferences a detached, null
+        // promise). Swallow errors: this runs in a destructor, which must
+        // not throw.
+        while (!adders.empty()) {
+            try {
+                adders.back().get();
+            } catch (...) {
+            }
+            adders.pop_back();
         }
         if (chaos) {
-            chaos->get();
+            try {
+                chaos->get();
+            } catch (...) {
+            }
+            chaos.reset();
         }
     });
     RPTEST_REQUIRE_EVENTUALLY(60s, [&done] { return done; });
-    for (auto& f : adders) {
+    while (!adders.empty()) {
+        auto f = std::move(adders.back());
+        adders.pop_back();
         EXPECT_NO_FATAL_FAILURE(f.get());
     }
     if (chaos) {
-        EXPECT_NO_FATAL_FAILURE(chaos->get());
+        auto chaos_fut = std::move(*chaos);
+        chaos.reset();
+        EXPECT_NO_FATAL_FAILURE(chaos_fut.get());
     }
     stop.cancel();
     opt_ref leader_opt;


### PR DESCRIPTION
TestConcurrentAddFiles joined the adder/chaos fibers both in the stop defer and in the test body. If a body join rethrew (a fiber resolving exceptionally) or the test exited early, the defer would get() futures the body had already consumed. A second get() on a consumed future dereferences a detached null promise in future_base::do_wait(), aborting with a confusing UBSAN null-pointer-use instead of the real failure.

Join each fiber exactly once: pop futures as they are joined so the defer only joins the remainder, and swallow errors in the defer since it can run while unwinding.

Fixes the cause for UBSAN but does not fix the test failure itself which is unclear https://redpandadata.atlassian.net/browse/CORE-16382

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
