### PR TITLE
ct/l1: remove unused lazy_abort_source in read_object

### DIFF
--- a/src/v/cloud_topics/level_one/common/file_io.cc
+++ b/src/v/cloud_topics/level_one/common/file_io.cc
@@ -169,10 +169,6 @@ file_io::read_object(
     static constexpr auto timeout = 10s;
     static constexpr auto backoff = 100ms;
     retry_chain_node root(*as, ss::lowres_clock::now() + timeout, backoff);
-    lazy_abort_source las{[as] {
-        return as->abort_requested() ? std::make_optional("abort requested")
-                                     : std::nullopt;
-    }};
     // TODO(cloud_topics): Optimize the cache such that it understands partial
     // objects? Or we assert somehow there are no overlaps (or just live with
     // them).


### PR DESCRIPTION
`file_io::read_object` constructed a `lazy_abort_source` that was never
passed to any call, so it had no effect. Aborts are already observed by
`download_stream` through the `retry_chain_node`. This removes the dead
code.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none