### PR TITLE
`ct/l1`: add `offset_interval_map`

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/BUILD
@@ -23,6 +23,20 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "offset_interval_map",
+    hdrs = [
+        "offset_interval_map.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+        "//src/v/container:chunked_vector",
+        "//src/v/container:interval_map",
+        "//src/v/model",
+    ],
+)
+
+redpanda_cc_library(
     name = "leveling_range_builder",
     hdrs = [
         "leveling_range_builder.h",

--- a/src/v/cloud_topics/level_one/metastore/offset_interval_map.h
+++ b/src/v/cloud_topics/level_one/metastore/offset_interval_map.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "base/vassert.h"
+#include "container/chunked_vector.h"
+#include "container/interval_map.h"
+#include "model/fundamental.h"
+
+#include <utility>
+
+namespace cloud_topics::l1 {
+
+// Wrapper around an interval_map, but with an interface that makes it
+// conducive to using inclusive offset ranges. The map analog of
+// `offset_interval_set`: it associates a value with each range and, unlike the
+// set, does not coalesce adjacent ranges.
+template<typename V>
+class offset_interval_map {
+public:
+    using imap_t = interval_map<kafka::offset::type, V>;
+
+    struct interval {
+        kafka::offset base_offset;
+        kafka::offset last_offset;
+        V value;
+    };
+
+    class stream {
+    public:
+        explicit stream(const imap_t& underlying)
+          : map_(underlying)
+          , iter_(map_.begin())
+          , end_(map_.end()) {}
+
+        bool has_next() const noexcept { return iter_ != end_; }
+        interval next() {
+            vassert(has_next(), "next() called while has_next() is false");
+            interval ret{
+              .base_offset = kafka::offset(iter_->first.start),
+              .last_offset = kafka::offset(iter_->first.end - 1),
+              .value = iter_->second,
+            };
+            ++iter_;
+            return ret;
+        }
+
+    private:
+        const imap_t& map_;
+        typename imap_t::const_iterator iter_;
+        typename imap_t::const_iterator end_;
+    };
+
+    bool empty() const { return map_.empty(); }
+    size_t size() const { return map_.size(); }
+
+    // Inserts the inclusive range [base, last] mapped to `value`. Returns true
+    // if it was inserted, or false if the range is empty or overlaps a range
+    // already present, in which case nothing is inserted.
+    bool insert(kafka::offset base, kafka::offset last, V value) {
+        auto len = last() - base() + 1;
+        return map_
+          .insert(typename imap_t::interval{base(), len}, std::move(value))
+          .second;
+    }
+
+    bool contains(kafka::offset offset) const {
+        return map_.find(offset()) != map_.end();
+    }
+
+    // Returns whether every offset in the inclusive range [start, last] is
+    // present. Because ranges are not coalesced, [start, last] may span
+    // several contiguous ranges, so walk them until the range is covered or a
+    // gap is found.
+    bool covers(kafka::offset start, kafka::offset last) const {
+        if (start > last) {
+            return false;
+        }
+        auto next = start();
+        while (next <= last()) {
+            auto it = map_.find(next);
+            if (it == map_.end()) {
+                return false;
+            }
+            // `end` is exclusive, so it is the first offset past this range
+            // and the next offset that must be covered.
+            next = it->first.end;
+        }
+        return true;
+    }
+
+    stream make_stream() const { return stream(map_); }
+
+    chunked_vector<interval> to_vec() const {
+        chunked_vector<interval> ret;
+        ret.reserve(map_.size());
+        auto s = make_stream();
+        while (s.has_next()) {
+            ret.emplace_back(s.next());
+        }
+        return ret;
+    }
+
+private:
+    imap_t map_;
+};
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/tests/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/tests/BUILD
@@ -205,6 +205,20 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "offset_interval_map_test",
+    timeout = "short",
+    srcs = [
+        "offset_interval_map_test.cc",
+    ],
+    deps = [
+        "//src/v/cloud_topics/level_one/metastore:offset_interval_map",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "partition_validator_test",
     timeout = "short",
     srcs = [

--- a/src/v/cloud_topics/level_one/metastore/tests/offset_interval_map_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/offset_interval_map_test.cc
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "cloud_topics/level_one/metastore/offset_interval_map.h"
+#include "model/fundamental.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <optional>
+
+using namespace cloud_topics::l1;
+using o = kafka::offset;
+
+namespace {
+MATCHER_P3(MatchesEntry, base, last, value, "") {
+    return arg.base_offset == base && arg.last_offset == last
+           && arg.value == value;
+}
+} // namespace
+
+TEST(OffsetIntervalMapTest, TestEmpty) {
+    offset_interval_map<int> m;
+    ASSERT_TRUE(m.empty());
+    ASSERT_EQ(m.size(), 0u);
+    ASSERT_TRUE(m.insert(o{0}, o{1}, 5));
+    ASSERT_FALSE(m.empty());
+    ASSERT_EQ(m.size(), 1u);
+}
+
+TEST(OffsetIntervalMapTest, TestInsertEmptyRangeFails) {
+    offset_interval_map<int> m;
+    // last < base is an empty range and must not be inserted.
+    ASSERT_FALSE(m.insert(o{5}, o{4}, 1));
+    ASSERT_TRUE(m.empty());
+}
+
+TEST(OffsetIntervalMapTest, TestInsertRejectsOverlap) {
+    offset_interval_map<int> m;
+    ASSERT_TRUE(m.insert(o{1}, o{5}, 1));
+
+    // The same range, partial overlaps on either side, a contained range, and
+    // a superset all overlap an existing interval and are rejected.
+    ASSERT_FALSE(m.insert(o{1}, o{5}, 2));
+    ASSERT_FALSE(m.insert(o{0}, o{1}, 2));
+    ASSERT_FALSE(m.insert(o{5}, o{10}, 2));
+    ASSERT_FALSE(m.insert(o{2}, o{3}, 2));
+    ASSERT_FALSE(m.insert(o{0}, o{10}, 2));
+
+    // A failed insert leaves the existing range and value untouched.
+    EXPECT_THAT(m.to_vec(), testing::ElementsAre(MatchesEntry(o{1}, o{5}, 1)));
+}
+
+TEST(OffsetIntervalMapTest, TestInsertIntoGapSucceeds) {
+    offset_interval_map<int> m;
+    ASSERT_TRUE(m.insert(o{0}, o{2}, 1));
+    ASSERT_TRUE(m.insert(o{10}, o{12}, 2));
+
+    // A range that fits entirely in the gap between two existing ranges is
+    // inserted.
+    ASSERT_TRUE(m.insert(o{5}, o{7}, 3));
+    EXPECT_THAT(
+      m.to_vec(),
+      testing::ElementsAre(
+        MatchesEntry(o{0}, o{2}, 1),
+        MatchesEntry(o{5}, o{7}, 3),
+        MatchesEntry(o{10}, o{12}, 2)));
+}
+
+TEST(OffsetIntervalMapTest, TestInsertAdjacentAtBoundarySucceeds) {
+    // Ranges that touch at a boundary (next base == prev last + 1) do not
+    // overlap, so both insert; a range sharing the boundary offset overlaps
+    // and is rejected.
+    offset_interval_map<int> m;
+    ASSERT_TRUE(m.insert(o{1}, o{5}, 1));
+    ASSERT_FALSE(m.insert(o{5}, o{10}, 2));
+    ASSERT_TRUE(m.insert(o{6}, o{10}, 3));
+    EXPECT_THAT(
+      m.to_vec(),
+      testing::ElementsAre(
+        MatchesEntry(o{1}, o{5}, 1), MatchesEntry(o{6}, o{10}, 3)));
+}
+
+TEST(OffsetIntervalMapTest, TestEmptyMapQueries) {
+    offset_interval_map<int> m;
+    ASSERT_TRUE(m.empty());
+    ASSERT_FALSE(m.contains(o{0}));
+    ASSERT_FALSE(m.covers(o{0}, o{0}));
+    EXPECT_THAT(m.to_vec(), testing::ElementsAre());
+    ASSERT_FALSE(m.make_stream().has_next());
+}
+
+TEST(OffsetIntervalMapTest, TestInsertDoesNotCoalesceAdjacent) {
+    // Unlike offset_interval_set, adjacent ranges are not merged: each keeps
+    // its own value.
+    offset_interval_map<int> m;
+    ASSERT_TRUE(m.insert(o{1}, o{2}, 10));
+    ASSERT_TRUE(m.insert(o{3}, o{4}, 20));
+    EXPECT_THAT(
+      m.to_vec(),
+      testing::ElementsAre(
+        MatchesEntry(o{1}, o{2}, 10), MatchesEntry(o{3}, o{4}, 20)));
+}
+
+TEST(OffsetIntervalMapTest, TestContains) {
+    offset_interval_map<int> m;
+    ASSERT_TRUE(m.insert(o{1}, o{2}, 1));
+    ASSERT_FALSE(m.contains(o{0}));
+    ASSERT_TRUE(m.contains(o{1}));
+    ASSERT_TRUE(m.contains(o{2}));
+    ASSERT_FALSE(m.contains(o{3}));
+
+    ASSERT_TRUE(m.insert(o{4}, o{6}, 2));
+    ASSERT_TRUE(m.contains(o{5}));
+    ASSERT_FALSE(m.contains(o{3}));
+}
+
+TEST(OffsetIntervalMapTest, TestCovers) {
+    offset_interval_map<int> m;
+    ASSERT_FALSE(m.covers(o{0}, o{0}));
+
+    ASSERT_TRUE(m.insert(o{1}, o{5}, 1));
+    ASSERT_TRUE(m.covers(o{1}, o{5}));
+    ASSERT_TRUE(m.covers(o{2}, o{4}));
+    ASSERT_FALSE(m.covers(o{0}, o{5}));
+    ASSERT_FALSE(m.covers(o{1}, o{6}));
+    ASSERT_FALSE(m.covers(o{6}, o{10}));
+}
+
+TEST(OffsetIntervalMapTest, TestCoversDisjointIntervals) {
+    offset_interval_map<int> m;
+    ASSERT_TRUE(m.insert(o{0}, o{5}, 1));
+    ASSERT_TRUE(m.insert(o{10}, o{20}, 2));
+
+    ASSERT_TRUE(m.covers(o{0}, o{5}));
+    ASSERT_TRUE(m.covers(o{10}, o{20}));
+    // Spanning the gap between the two ranges is not covered.
+    ASSERT_FALSE(m.covers(o{4}, o{11}));
+    ASSERT_FALSE(m.covers(o{0}, o{20}));
+    ASSERT_FALSE(m.covers(o{5}, o{10}));
+}
+
+TEST(OffsetIntervalMapTest, TestCoversSpansContiguousRanges) {
+    // Ranges are not coalesced, so a query may span several contiguous ones.
+    // Every offset in [0, 10] is present across [0, 4] and [5, 10], so it is
+    // covered even though no single range spans it.
+    offset_interval_map<int> m;
+    ASSERT_TRUE(m.insert(o{0}, o{4}, 1));
+    ASSERT_TRUE(m.insert(o{5}, o{10}, 2));
+
+    ASSERT_TRUE(m.covers(o{0}, o{10}));
+    ASSERT_TRUE(m.covers(o{3}, o{8}));
+    ASSERT_TRUE(m.covers(o{4}, o{5}));
+
+    EXPECT_FALSE(m.covers(o{10}, o{5})); // inverted range
+
+    // A gap anywhere in the queried range breaks coverage.
+    ASSERT_TRUE(m.insert(o{12}, o{15}, 3));
+    ASSERT_FALSE(m.covers(o{0}, o{15}));
+    ASSERT_FALSE(m.covers(o{8}, o{12}));
+}
+
+TEST(OffsetIntervalMapTest, TestStreamOrdersByOffset) {
+    offset_interval_map<int> m;
+    EXPECT_THAT(m.to_vec(), testing::ElementsAre());
+
+    ASSERT_TRUE(m.insert(o{10}, o{12}, 100));
+    ASSERT_TRUE(m.insert(o{1}, o{3}, 200));
+    ASSERT_TRUE(m.insert(o{5}, o{5}, 300));
+
+    // Streamed in ascending base-offset order, values preserved.
+    EXPECT_THAT(
+      m.to_vec(),
+      testing::ElementsAre(
+        MatchesEntry(o{1}, o{3}, 200),
+        MatchesEntry(o{5}, o{5}, 300),
+        MatchesEntry(o{10}, o{12}, 100)));
+}

--- a/src/v/container/BUILD
+++ b/src/v/container/BUILD
@@ -54,6 +54,17 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "interval_map",
+    hdrs = [
+        "interval_map.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@abseil-cpp//absl/container:btree",
+    ],
+)
+
+redpanda_cc_library(
     name = "contiguous_range_map",
     hdrs = [
         "contiguous_range_map.h",

--- a/src/v/container/interval_map.h
+++ b/src/v/container/interval_map.h
@@ -15,8 +15,6 @@
 #include <concepts>
 #include <utility>
 
-namespace experimental::io {
-
 /**
  * A container that maps intervals to values.
  *
@@ -236,5 +234,3 @@ template<std::integral T, typename V>
 size_t interval_map<T, V>::size() const {
     return map_.size();
 }
-
-} // namespace experimental::io

--- a/src/v/container/tests/BUILD
+++ b/src/v/container/tests/BUILD
@@ -63,6 +63,20 @@ redpanda_cc_gtest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "interval_map_test",
+    timeout = "short",
+    srcs = [
+        "interval_map_test.cc",
+    ],
+    deps = [
+        "//src/v/container:interval_map",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
 redpanda_cc_btest(
     name = "chunked_vector_async_test",
     timeout = "short",

--- a/src/v/container/tests/interval_map_test.cc
+++ b/src/v/container/tests/interval_map_test.cc
@@ -8,7 +8,7 @@
  * the Business Source License, use of this software will be governed
  * by the Apache License, Version 2.0
  */
-#include "io/interval_map.h"
+#include "container/interval_map.h"
 
 #include <seastar/util/later.hh>
 
@@ -16,9 +16,7 @@
 
 #include <random>
 
-namespace io = experimental::io;
-
-using imap = io::interval_map<uint64_t, uint64_t>;
+using imap = interval_map<uint64_t, uint64_t>;
 
 TEST(IntervalMap, InsertZeroLengthInterval) {
     imap map;

--- a/src/v/io/BUILD
+++ b/src/v/io/BUILD
@@ -14,7 +14,6 @@ redpanda_cc_library(
         "persistence.cc",
     ],
     hdrs = [
-        "interval_map.h",
         "io_queue.h",
         "page.h",
         "page_cache.h",
@@ -26,6 +25,7 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/base",
+        "//src/v/container:interval_map",
         "//src/v/container:intrusive",
         "//src/v/ssx:future_util",
         "//src/v/ssx:semaphore",

--- a/src/v/io/page_set.h
+++ b/src/v/io/page_set.h
@@ -10,7 +10,7 @@
  */
 #pragma once
 
-#include "io/interval_map.h"
+#include "container/interval_map.h"
 #include "io/page.h"
 
 #include <seastar/core/shared_ptr.hh>

--- a/src/v/io/tests/BUILD
+++ b/src/v/io/tests/BUILD
@@ -29,18 +29,6 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
-    name = "interval_map_test",
-    timeout = "short",
-    srcs = ["interval_map_test.cc"],
-    deps = [
-        ":testing",
-        "//src/v/io",
-        "@googletest//:gtest",
-        "@seastar",
-    ],
-)
-
-redpanda_cc_gtest(
     name = "persistence_test",
     timeout = "moderate",
     srcs = ["persistence_test.cc"],


### PR DESCRIPTION
It seems this data structure will be required for leveling for some range based book keeping.

Move `interval_map` from `io` to `container` and add the `offset_interval_map` wrapper on top.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
