### PR TITLE
kgo-verifier: default metadata-max-age to 15s (was franz-go's 5m)

### DIFF
--- a/tests/go/kgo-verifier/cmd/kgo-verifier/main.go
+++ b/tests/go/kgo-verifier/cmd/kgo-verifier/main.go
@@ -80,12 +80,15 @@ var (
 	validateLatestValues  = flag.Bool("validate-latest-values", false, "If true, values consumed by a worker will be validated against the last produced value by a producer. This value should only be set if compaction has been allowed to fully de-duplicate the entirety of the log before consuming.")
 
 	produceRandomBytes = flag.Bool("produce-random-bytes", false, "If true, when generating random values, generate random bytes rather than random ascii")
+
+	metadataMaxAge = flag.Duration("metadata-max-age", 15*time.Second, "kgo MetadataMaxAge; 0 uses franz-go's default. See WorkerConfig.MetadataMaxAge.")
 )
 
 func makeWorkerConfig() worker.WorkerConfig {
 	c := worker.WorkerConfig{
 		Brokers:               *brokers,
 		Trace:                 *trace,
+		MetadataMaxAge:        *metadataMaxAge,
 		Topic:                 *topic,
 		Linger:                *linger,
 		MaxBufferedRecords:    *maxBufferedRecords,

--- a/tests/go/kgo-verifier/pkg/worker/worker.go
+++ b/tests/go/kgo-verifier/pkg/worker/worker.go
@@ -200,6 +200,12 @@ type WorkerConfig struct {
 	TolerateFailedProduce bool
 	Continuous            bool
 	ValidateLatestValues  bool
+
+	// MetadataMaxAge sets kgo.MetadataMaxAge (0 = franz-go's 5m default). Defaults to 15s: franz-go
+	// only re-checks for a log rewind (KIP-320) when metadata shows a new leader epoch, and after an
+	// all-nodes-crash leaderless window the next refresh is otherwise up to 5m away (past test
+	// timeouts), so the consumer stalls. https://redpandadata.atlassian.net/browse/CORE-13458
+	MetadataMaxAge time.Duration
 }
 
 func CompressionCodecFromString(s string) (kgo.CompressionCodec, error) {
@@ -296,6 +302,10 @@ func (wc *WorkerConfig) MakeKgoOpts() []kgo.Opt {
 		opts = append(opts, kgo.WithLogger(kgo.BasicLogger(os.Stderr, kgo.LogLevelDebug, func() string {
 			return fmt.Sprintf("time=\"%s\" name=%s", time.Now().UTC().Format(time.RFC3339), wc.Name)
 		})))
+	}
+
+	if wc.MetadataMaxAge > 0 {
+		opts = append(opts, kgo.MetadataMaxAge(wc.MetadataMaxAge))
 	}
 
 	return opts

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -973,6 +973,7 @@ class KgoVerifierSeqConsumer(AbstractConsumer):
         use_transactions: bool | None = False,
         compacted: bool | None = False,
         validate_latest_values: bool | None = False,
+        metadata_max_age_ms: int | None = None,
     ):
         super().__init__(
             context,
@@ -994,6 +995,7 @@ class KgoVerifierSeqConsumer(AbstractConsumer):
         self._use_transactions = use_transactions
         self._compacted = compacted
         self._validate_latest_values = validate_latest_values
+        self._metadata_max_age_ms = metadata_max_age_ms
 
     def start_node(self, node: ClusterNode, clean: bool = False, **kwargs) -> None:
         assert not kwargs, f"Unexpected kwargs: {kwargs}"
@@ -1015,6 +1017,8 @@ class KgoVerifierSeqConsumer(AbstractConsumer):
             cmd += f" --consume-throughput-mb {self._max_throughput_mb}"
         if self._continuous:
             cmd += " --continuous"
+        if self._metadata_max_age_ms is not None:
+            cmd += f" --metadata-max-age {self._metadata_max_age_ms}ms"
         if self._tolerate_data_loss:
             cmd += " --tolerate-data-loss"
         if self._use_transactions:


### PR DESCRIPTION
`WriteCachingFailureInjectionE2ETest.test_crash_all` is a long-standing flake ([CORE-13458](https://redpandadata.atlassian.net/browse/CORE-13458)): it times out in roughly 30% of local runs and recurs daily in CI.

The "root" cause is in the franz-go Kafka client used by `kgo-verifier`, not in redpanda. The test crashes all brokers between produce rounds; with write caching the unflushed tail is lost and the log is rewritten at the same offsets under a new leader epoch, so the continuous consumer must detect the rewind via KIP-320 (`OffsetForLeaderEpoch`). franz-go only runs that validation when it observes a new leader epoch in metadata. During the all-nodes-down recovery window the broker advertises `leader_epoch = -1` (no leader yet); franz-go counts each `-1` as a leader-epoch rewind and, after `maxEpochRewinds=5` (~1-2s of rapid retries), accepts `-1` and skips validation. From then on only the next periodic metadata refresh can re-trigger detection, and franz-go's default `MetadataMaxAge` is 5m, far past the test's 60s wait, so the consumer stalls and the test times out. Upstream franz-go issue: twmb/franz-go#1331.

This change defaults `kgo-verifier`'s `kgo.MetadataMaxAge` to 15s (via a new `--metadata-max-age` flag; pass 0 for franz-go's default), wired through `WorkerConfig` with an optional `metadata_max_age_ms` override on the ducktape `KgoVerifierService`. A 15s refresh re-triggers KIP-320 detection well within typical test timeouts, so recovery completes in time for every test that uses the verifier.

Validation: ~30% baseline failure rate dropped to 0 failures across 65 consecutive local runs (a clean 50/50 repeat run plus 15 earlier confirmation runs) at the 15s setting.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

[CORE-13458]: https://redpandadata.atlassian.net/browse/CORE-13458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ