### PR TITLE
rptest: make ABSClient.create_bucket idempotent

### DIFF
--- a/tests/rptest/archival/abs_client.py
+++ b/tests/rptest/archival/abs_client.py
@@ -4,6 +4,7 @@ from itertools import islice
 from logging import Logger
 from typing import Iterator, Optional, cast
 
+from azure.core.exceptions import ResourceExistsError
 from azure.storage.blob import BlobClient, BlobServiceClient, BlobType, ContainerClient
 from rptest.archival.s3_client import ObjectMetadata
 from rptest.archival.shared_client_utils import key_to_topic
@@ -67,7 +68,10 @@ class ABSClient:
 
     def create_bucket(self, name: str):
         blob_service = BlobServiceClient.from_connection_string(self.conn_str)
-        blob_service.create_container(name)
+        try:
+            blob_service.create_container(name)
+        except ResourceExistsError:
+            self.logger.debug(f"Container {name} already exists")
 
     def empty_and_delete_bucket(self, name: str, parallel: bool = False) -> None:
         """


### PR DESCRIPTION
Make `ABSClient.create_bucket` idempotent: swallow `ResourceExistsError`
so repeated cluster setup against the Azurite (ABS) emulator doesn't fail
when the container already exists, mirroring `s3_client`'s `create_bucket`.

Azure container names are scoped to the storage account we authenticate
as (account name + shared key), so `ContainerAlreadyExists` can only mean
a container we already own — there is no cross-account namespace and thus
no ownership to distinguish, making it safe to swallow without inspecting
the error.

Ref: https://redpandadata.atlassian.net/browse/DEVPROD-1902

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
