### PR TITLE
[v26.1.x] Decom can cancel simple node add raft0 reconfigurations

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -81,6 +81,7 @@
 #include "model/timeout_clock.h"
 #include "raft/fundamental.h"
 #include "raft/fwd.h"
+#include "raft/types.h"
 #include "security/acl.h"
 #include "security/authorizer.h"
 #include "security/credential_store.h"
@@ -294,7 +295,10 @@ ss::future<> controller::start(
       _partition_manager,
       _shard_table,
       config::node().data_directory().as_sstring(),
-      seed_nodes);
+      seed_nodes,
+      config::shard_local_cfg().controller_log_learner_recovery_rate_enabled()
+        ? raft::with_learner_recovery_throttle::yes
+        : raft::with_learner_recovery_throttle::no);
 
     co_await _partition_leaders.start(std::ref(_tp_state), std::ref(_as));
     co_await _drain_manager.start(std::ref(_partition_manager));

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -694,8 +694,9 @@ ss::future<std::error_code> members_backend::update_raft0_configuration(
     if (cfg.revision_id() > model::revision_id(update.offset)) {
         co_return errc::success;
     }
+    const auto updated_vnode = raft::vnode(update.id, raft0_revision);
     if (update.type == node_update_type::added) {
-        if (cfg.contains(raft::vnode(update.id, raft0_revision))) {
+        if (cfg.contains(updated_vnode)) {
             vlog(
               clusterlog.debug,
               "node {} is already part of raft0 configuration",
@@ -704,12 +705,37 @@ ss::future<std::error_code> members_backend::update_raft0_configuration(
         }
         co_return co_await add_to_raft0(update.id, revision);
     } else if (update.type == node_update_type::removed) {
-        if (!cfg.contains(raft::vnode(update.id, raft0_revision))) {
+        if (!cfg.contains(updated_vnode)) {
             vlog(
               clusterlog.debug,
               "node {} is already removed from raft0 configuration",
               update.id);
             co_return errc::success;
+        }
+
+        // add node foo -> remove node foo should simply be cancel on node add
+        const auto& in_flight = cfg.get_configuration_update();
+        const bool should_cancel = in_flight.has_value()
+                                   && in_flight->is_to_add(updated_vnode);
+
+        if (should_cancel) {
+            // members backend currently only allows single node add, or single
+            // node removal, if this ever changes, refuse to cancel a
+            // configuration which may have unintended side effects
+            const bool cancellation_has_no_side_effects
+              = in_flight->replicas_to_add.size() == 1
+                && in_flight->replicas_to_remove.empty();
+            if (cancellation_has_no_side_effects) {
+                co_return co_await cancel_raft0_add(update.id, revision);
+            }
+            vlog(
+              clusterlog.warn,
+              "cannot cancel raft0 configuration which adds node {} because in "
+              "flight reconfiguration carries operations other than node {} "
+              "addition. configuration: {}",
+              updated_vnode,
+              updated_vnode,
+              cfg);
         }
 
         co_return co_await remove_from_raft0(update.id, revision);
@@ -739,6 +765,17 @@ ss::future<std::error_code> members_backend::remove_from_raft0(
       raft::vnode(id, raft0_revision), revision);
 }
 
+ss::future<std::error_code> members_backend::cancel_raft0_add(
+  model::node_id id, model::revision_id revision) {
+    if (!_raft0->is_leader()) {
+        co_return errc::not_leader;
+    }
+    vlog(
+      clusterlog.info,
+      "cancelling in-flight raft0 reconfiguration that is adding node {}",
+      id);
+    co_return co_await _raft0->cancel_configuration_change(revision);
+}
 std::ostream&
 operator<<(std::ostream& o, const members_backend::partition_reallocation& r) {
     fmt::print(

--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -102,6 +102,8 @@ private:
       add_to_raft0(model::node_id, model::revision_id);
     ss::future<std::error_code>
       remove_from_raft0(model::node_id, model::revision_id);
+    ss::future<std::error_code>
+      cancel_raft0_add(model::node_id, model::revision_id);
 
     ss::future<> reconcile_raft0_updates();
     ss::future<std::error_code> do_remove_node(model::node_id);

--- a/src/v/cluster/raft0_utils.h
+++ b/src/v/cluster/raft0_utils.h
@@ -18,6 +18,7 @@
 #include "model/fundamental.h"
 #include "model/namespace.h"
 #include "raft/fundamental.h"
+#include "raft/types.h"
 
 #include <vector>
 namespace cluster {
@@ -26,7 +27,8 @@ inline ss::future<consensus_ptr> create_raft0(
   ss::sharded<partition_manager>& pm,
   ss::sharded<shard_table>& st,
   const ss::sstring& data_directory,
-  const std::vector<model::node_id>& initial_nodes) {
+  const std::vector<model::node_id>& initial_nodes,
+  raft::with_learner_recovery_throttle enable_learner_recovery_throttle) {
     if (!initial_nodes.empty()) {
         vlog(clusterlog.info, "Current node is a cluster founder");
     }
@@ -46,7 +48,7 @@ inline ss::future<consensus_ptr> create_raft0(
           model::controller_ntp, data_directory, std::move(overrides)),
         raft::group_id(0),
         std::move(initial_vnodes),
-        raft::with_learner_recovery_throttle::no,
+        enable_learner_recovery_throttle,
         raft::keep_snapshotted_log::no,
         std::nullopt)
       .then([&st](consensus_ptr p) {

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1270,6 +1270,16 @@ configuration::configuration()
       "only be used to debug unexpected problems.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       false)
+  , controller_log_learner_recovery_rate_enabled(
+      *this,
+      "controller_log_learner_recovery_rate_enabled",
+      "Whether the controller raft group (raft0) honors "
+      "`raft_learner_recovery_rate`. When `false` (default) the controller log "
+      "replicates to new learners without throttling. When `true`, "
+      "controller-log recovery is subject to the same per-node recovery bucket "
+      "as user partitions.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      false)
   , raft_smp_max_non_local_requests(
       *this,
       "raft_smp_max_non_local_requests",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -273,6 +273,7 @@ struct configuration final : public config_store {
     property<size_t> raft_replicate_batch_window_size;
     property<size_t> raft_learner_recovery_rate;
     property<bool> raft_recovery_throttle_disable_dynamic_mode;
+    property<bool> controller_log_learner_recovery_rate_enabled;
     property<std::optional<uint32_t>> raft_smp_max_non_local_requests;
     enum_property<model::write_caching_mode> write_caching_default;
 

--- a/tests/rptest/tests/throttled_raft0_test.py
+++ b/tests/rptest/tests/throttled_raft0_test.py
@@ -1,0 +1,302 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+"""
+Regression tests which require a throttled raft0 recovery.
+"""
+
+import re
+import signal
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from ducktape.tests.test import TestContext
+from ducktape.utils.util import wait_until
+
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.utils.node_operations import NodeDecommissionWaiter
+
+
+class GroupConfigurationState(Enum):
+    # no reconfiguration ongoing
+    SIMPLE = "simple"
+    # node being added
+    TRANSITIONAL = "transitional"
+    # node being removed
+    JOINT = "joint"
+
+
+# regex for determining group state, the cpp is inconsistent with spacing so made to be whitespace agnostic.
+# An empty std::optional renders as "none" with fmt>=10 (dev) but as "{nullopt}"
+# with the fmt 9.1 used on this release branch, so accept both spellings.
+_EMPTY_OPTIONAL = r"(?:none|\{nullopt\})"
+_GROUP_CFG_OLD_UNSET_PATTERN = re.compile(
+    rf"old\s*:\s*{_EMPTY_OPTIONAL}\s*,\s*revision\s*:"
+)
+_GROUP_CFG_UPDATE_UNSET_PATTERN = re.compile(
+    rf"update\s*:\s*{_EMPTY_OPTIONAL}\s*,\s*version\s*:"
+)
+
+
+def is_old_config_set(cfg: str) -> bool:
+    """given a raft configuration, do we have an old configuration"""
+    return _GROUP_CFG_OLD_UNSET_PATTERN.search(cfg) is None
+
+
+def is_configuration_update_set(cfg: str) -> bool:
+    """given a raft configuration is there an update (new nodes)"""
+    return _GROUP_CFG_UPDATE_UNSET_PATTERN.search(cfg) is None
+
+
+def raft_configuration_to_configuration_state(cfg: str) -> GroupConfigurationState:
+    """parse a config into the group configuration state"""
+    has_old_config = is_old_config_set(cfg)
+    has_update = is_configuration_update_set(cfg)
+    if has_old_config:
+        return GroupConfigurationState.JOINT
+    if has_update:
+        return GroupConfigurationState.TRANSITIONAL
+    return GroupConfigurationState.SIMPLE
+
+
+@dataclass
+class TimeoutConfig:
+    timeout_s: int
+    backoff_s: int
+
+
+SHORT_TIMEOUT = TimeoutConfig(timeout_s=30, backoff_s=2)
+MEDIUM_TIMEOUT = TimeoutConfig(timeout_s=60, backoff_s=2)
+LONG_TIMEOUT = TimeoutConfig(timeout_s=120, backoff_s=2)
+
+
+class StuckRaft0LearnerTest(RedpandaTest):
+    """Decommissioning a dead learner cancels the in-flight raft0 add."""
+
+    INITIAL_CLUSTER_SIZE = 3
+    # Seeds are [1,2,3] joiner is then 4
+    JOINER_NODE_ID = 4
+
+    def __init__(self, test_context: TestContext, *args: Any, **kwargs: Any):
+        # 4 nodes: 3 initial seeds + 1 joiner held in reserve.
+        super().__init__(
+            test_context,
+            num_brokers=4,
+            *args,
+            **kwargs,
+        )
+
+    def setUp(self) -> None:
+        # Manual start so we can hold the joiner in reserve.
+        pass
+
+    # ── helpers ─────────────────────────────────────────────────────────
+
+    def _controller_state(self) -> GroupConfigurationState | None:
+        """get the controller group configuration state from the controller leader"""
+        for node in self.redpanda.started_nodes():
+            try:
+                state = self.redpanda._admin.get_partition_state(
+                    "redpanda", "controller", 0, node=node
+                )
+            except Exception:
+                continue
+
+            for replica in state.get("replicas", []):
+                raft_state = replica.get("raft_state", {})
+                # only consider the leaders perspective
+                if not raft_state.get("is_leader"):
+                    continue
+                cfg = raft_state.get("group_configuration", "")
+                return raft_configuration_to_configuration_state(cfg)
+        return None
+
+    def _node_in_raft0(self, node_id: int) -> bool:
+        """True if ``node_id`` is in the leader's raft0 group configuration"""
+        for node in self.redpanda.started_nodes():
+            try:
+                state = self.redpanda._admin.get_partition_state(
+                    "redpanda", "controller", 0, node=node
+                )
+            except Exception:
+                continue
+            for replica in state.get("replicas", []):
+                rs = replica.get("raft_state", {})
+                # only consider the leader's perspective
+                if not rs.get("is_leader"):
+                    continue
+                cfg = rs.get("group_configuration", "")
+                if not isinstance(cfg, str):
+                    continue
+                return f"id: {node_id}" in cfg
+        return False
+
+    # ── test ────────────────────────────────────────────────────────────
+
+    @cluster(num_nodes=4)
+    def test_decommission_cancels_in_flight_raft0_add(self):
+        """
+        Decommissioning a raft0 learner should cancel the underlying raft0 reconfiguration rather than waiting for it to complete and then decommissioning.
+        Without this, a lost learner can lock membership changes.
+
+        Steps:
+        1. start a 3 node cluster with throttled raft0 learner rate
+        2. push controller commands to fill the log past snapshot
+        3. join node 4
+        4. wait for / assert we see node 4 as a learner
+        5. kill node 4
+        6. decommission node 4
+        7. wait for / assert raft0 returns to simple
+        8. assert clean removal of 4
+        """
+        # 1. Start the first 3 of 4 allocated nodes; the 4th is the joiner.
+        seed_nodes = self.redpanda.nodes[: self.INITIAL_CLUSTER_SIZE]
+        joiner = self.redpanda.nodes[self.INITIAL_CLUSTER_SIZE]
+
+        self.logger.info(
+            f"[raft0-cancel] step 1: starting {len(seed_nodes)}-node "
+            f"cluster (seeds: {[n.name for n in seed_nodes]}); "
+            f"holding {joiner.name} in reserve"
+        )
+        self.redpanda.set_seed_servers(seed_nodes)
+
+        self.redpanda.add_extra_rp_conf(
+            {
+                "internal_topic_replication_factor": self.INITIAL_CLUSTER_SIZE,
+                "raft_learner_recovery_rate": 0,
+                "controller_log_learner_recovery_rate_enabled": True,
+            }
+        )
+        self.redpanda.start(nodes=seed_nodes, omit_seeds_on_idx_one=False)
+        self.logger.info("[raft0-cancel] cluster up")
+
+        # 2. Add some non-bootstrap state to the controller log so that
+        #    catch-up actually has data to ship
+        self.logger.info("[raft0-cancel] step 2: creating test topic")
+        topic = TopicSpec(replication_factor=3, partition_count=10)
+        self.client().create_topic(topic)
+
+        # Sanity: raft0 is `simple` on a healthy 3-node cluster.
+        wait_until(
+            lambda: self._controller_state() == GroupConfigurationState.SIMPLE,
+            timeout_sec=SHORT_TIMEOUT.timeout_s,
+            backoff_sec=SHORT_TIMEOUT.backoff_s,
+            err_msg="raft0 did not start in simple state",
+        )
+        self.logger.info("[raft0-cancel] raft0 confirmed `simple`")
+
+        # 3. Start the joiner
+        self.logger.info(
+            f"[raft0-cancel] step 3: starting joiner {joiner.name} "
+            f"with skip_readiness_check=True"
+        )
+        self.redpanda.start_node(joiner, skip_readiness_check=True)
+
+        def joiner_in_brokers() -> bool:
+            for survivor in seed_nodes:
+                try:
+                    brokers = self.redpanda._admin.get_brokers(node=survivor)
+                except Exception:
+                    continue
+                return any(b.get("node_id") == self.JOINER_NODE_ID for b in brokers)
+            return False
+
+        wait_until(
+            joiner_in_brokers,
+            timeout_sec=LONG_TIMEOUT.timeout_s,
+            backoff_sec=LONG_TIMEOUT.backoff_s,
+            err_msg="joiner never appeared in the leader's broker list",
+        )
+        joiner_id = self.JOINER_NODE_ID
+        self.logger.info(
+            f"[raft0-cancel] joiner appeared in cluster as node_id={joiner_id}"
+        )
+
+        # 4. Wait for raft0 to enter `transitional` with the joiner as
+        #    the in-flight learner addition.
+        self.logger.info(
+            "[raft0-cancel] step 4: waiting for raft0 to enter `transitional`"
+        )
+        wait_until(
+            lambda: (
+                self._controller_state() == GroupConfigurationState.TRANSITIONAL
+                and self._node_in_raft0(joiner_id)
+            ),
+            timeout_sec=MEDIUM_TIMEOUT.timeout_s,
+            backoff_sec=MEDIUM_TIMEOUT.backoff_s,
+            err_msg="raft0 never entered transitional state with joiner present",
+        )
+        self.logger.info(
+            "[raft0-cancel] raft0 is `transitional` (learner pending promotion)"
+        )
+
+        # 5. kill the joiner while it is still a learner.
+        self.logger.info(
+            f"[raft0-cancel] step 5: SIGKILLing joiner node_id={joiner_id} "
+            f"mid-promotion"
+        )
+        self.redpanda.remove_from_started_nodes(
+            joiner, "intentionally killed mid-promotion"
+        )
+        self.redpanda.signal_redpanda(joiner, signal=signal.SIGKILL, idempotent=True)
+
+        # 6. Decommission the dead joiner, should un-add from learners
+        self.logger.info(f"[raft0-cancel] step 6: decommissioning node_id={joiner_id}")
+        survivor = self.redpanda.controller()
+        assert survivor is not None, "no controller leader to send decommission to"
+        self.redpanda._admin.decommission_broker(joiner_id, node=survivor)
+
+        # 7. Wait for raft0 to return to `simple` with the joiner removed
+        #    from raft0's group_configuration.
+        self.logger.info(
+            "[raft0-cancel] step 7: waiting for raft0 to return to `simple` "
+            "with joiner removed"
+        )
+        wait_until(
+            lambda: (
+                self._controller_state() == GroupConfigurationState.SIMPLE
+                and not self._node_in_raft0(joiner_id)
+            ),
+            timeout_sec=LONG_TIMEOUT.timeout_s,
+            backoff_sec=LONG_TIMEOUT.backoff_s,
+            err_msg=(
+                "raft0 did not return to simple with joiner removed — "
+                "decommission appears stalled on configuration_change_in_progress"
+            ),
+        )
+        self.logger.info(
+            "[raft0-cancel] raft0 returned to `simple`; joiner removed from raft0"
+        )
+
+        # 8. And the broker should be fully removed from cluster
+        #    membership.
+        self.logger.info(
+            "[raft0-cancel] step 8: waiting for broker removal from membership"
+        )
+        recovery_waiter = NodeDecommissionWaiter(
+            self.redpanda,
+            joiner_id,
+            self.logger,
+            progress_timeout=MEDIUM_TIMEOUT.timeout_s,
+        )
+        recovery_waiter.wait_for_removal()
+        self.logger.info("[raft0-cancel] joiner removed from cluster membership")
+
+        # Final sanity.
+        assert self._controller_state() == GroupConfigurationState.SIMPLE
+        assert not self._node_in_raft0(joiner_id), (
+            f"joiner {joiner_id} still in raft0 after decommission completed"
+        )
+        assert not joiner_in_brokers(), (
+            f"joiner {joiner_id} still in broker list after decommission completed"
+        )
+        self.logger.info("[raft0-cancel] all assertions passed — test PASSED")


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30377

- Command: git cherry-pick -x 1f884b8250 6ad1fe90ce 8edf586a3f 3c6dbbba35
- Commits backported: 4
- Conflicts resolved: 2
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-30377-v26.1.x-1780336619

## Conflict details

- 1f884b8250 (src/v/cluster/members_backend.cc): bottom of the file diverged because dev refactored `partition_reallocation`'s stream operator into a `format_to` member, while v26.1.x still has the `operator<<` form. Kept the v26.1.x `operator<<` definition unchanged and inserted the new `cancel_raft0_add` member function ahead of it — that placement preserves the commit's intent of introducing the helper next to the other raft0 helpers without dragging in the unrelated stream→format_to refactor.
- 6ad1fe90ce (src/v/cluster/controller.cc): include-block conflict where dev added `#include "raft/types.h"` after `raft/fwd.h` while v26.1.x has `#include "security/acl.h"` in that slot. Resolved by keeping both, in alphabetical order (`raft/types.h` then `security/acl.h`).
