### PR TITLE
tests/ExampleRunner: kill example process when worker exits

### DIFF
--- a/tests/rptest/services/compatibility/example_runner.py
+++ b/tests/rptest/services/compatibility/example_runner.py
@@ -61,6 +61,10 @@ class ExampleRunner(BackgroundThreadService):
                     line = line.strip()
                     self.logger.debug(line)
                 except RemoteCommandError as e:
+                    if self._stopping.is_set():
+                        # Killing the process on stop makes ssh_capture exit
+                        # non-zero; that's expected, not a failure.
+                        break
                     self.logger.exception(f"Command {cmd} returned an error: {e}")
                     self._error = e
                     # No retries: thread is complete, test will fail when

--- a/tests/rptest/services/compatibility/example_runner.py
+++ b/tests/rptest/services/compatibility/example_runner.py
@@ -48,31 +48,46 @@ class ExampleRunner(BackgroundThreadService):
 
         start_time = time.time()
 
-        while True:
-            # Terminate loop on timeout or stop_node
-            if time.time() > start_time + self._timeout:
-                break
-            if self._stopping.is_set():
-                break
+        try:
+            while True:
+                # Terminate loop on timeout or stop_node
+                if time.time() > start_time + self._timeout:
+                    break
+                if self._stopping.is_set():
+                    break
 
+                try:
+                    line = next(output_iter)
+                    line = line.strip()
+                    self.logger.debug(line)
+                except RemoteCommandError as e:
+                    self.logger.exception(f"Command {cmd} returned an error: {e}")
+                    self._error = e
+                    # No retries: thread is complete, test will fail when
+                    # it calls condition_met and sees the error.
+                    break
+
+                # Take first line as pid
+                if not self._pid:
+                    self._pid = line
+                else:
+                    # Call to example.condition will automatically
+                    # store result in a boolean variable
+                    self._example.condition(line)
+        finally:
+            # The example (e.g. a long-running Kafka Streams app) keeps
+            # running after we stop reading its output. Kill it when the
+            # worker exits rather than relying only on stop_node: a leaked
+            # client can otherwise survive teardown and, because ducktape
+            # recycles docker hostnames, reconnect to an unrelated cluster
+            # and corrupt it (e.g. auto-create __consumer_offsets on a
+            # freshly-started node).
             try:
-                line = next(output_iter)
-                line = line.strip()
-                self.logger.debug(line)
+                self._kill_node(node)
             except RemoteCommandError as e:
-                self.logger.exception(f"Command {cmd} returned an error: {e}")
-                self._error = e
-                # No retries: thread is complete, test will fail when it calls
-                # condition_met and sees the error.
-                break
-
-            # Take first line as pid
-            if not self._pid:
-                self._pid = line
-            else:
-                # Call to example.condition will automatically
-                # store result in a boolean variable
-                self._example.condition(line)
+                self.logger.warning(
+                    f"Error killing example process on {node.name}: {e}"
+                )
 
     def condition_met(self):
         if self._error:
@@ -85,7 +100,9 @@ class ExampleRunner(BackgroundThreadService):
 
     def stop_node(self, node, **_):
         self._stopping.set()
+        self._kill_node(node)
 
+    def _kill_node(self, node):
         try:
             if self._pid:
                 node.account.signal(self._pid, 9, allow_fail=True)


### PR DESCRIPTION
The example process (e.g. a long-running Kafka Streams app) kept running after the worker loop exited and was killed only by stop_node during teardown. If teardown was skipped or delayed, the client survived and, because the ducktape docker backend recycles container hostnames, reconnected to an unrelated freshly-started cluster and corrupted it: its find_coordinator auto-creates __consumer_offsets, which trips the storage-init check of whichever test owns that cluster.

Kill the process in a finally block as soon as the worker exits, in addition to stop_node, via a shared _kill_node helper. The worker's kill is best-effort (logs on failure) so cleanup never crashes the thread.

Hopefully this provides a fix for https://redpandadata.atlassian.net/browse/CORE-16230 (where there were a bunch of repeated similar cases)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
