### PR TITLE
[CORE-16320] Cloud Topics: L1 I/O Improvements: in-flight L1 read merging + per-reader footer cache

### DIFF
--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -70,6 +70,7 @@ ss::future<> app::construct(
       config::node().l1_staging_path().string());
 
     co_await construct_service(_l1_reader_probe);
+    co_await construct_service(_l1_file_io_probe);
 
     co_await construct_service(
       _l1_reader_cache,
@@ -87,7 +88,8 @@ ss::future<> app::construct(
       config::node().l1_staging_path(),
       ss::sharded_parameter([&remote] { return &remote->local(); }),
       bucket,
-      ss::sharded_parameter([&cloud_cache] { return &cloud_cache->local(); }));
+      ss::sharded_parameter([&cloud_cache] { return &cloud_cache->local(); }),
+      ss::sharded_parameter([this] { return &_l1_file_io_probe.local(); }));
 
     co_await construct_service(
       domain_supervisor,
@@ -141,6 +143,7 @@ ss::future<> app::construct(
       ss::sharded_parameter(
         [&metadata_cache] { return &metadata_cache->local(); }),
       ss::sharded_parameter([this] { return &_l1_reader_probe.local(); }),
+      ss::sharded_parameter([this] { return &_l1_file_io_probe.local(); }),
       ss::sharded_parameter([this] { return &_l1_reader_cache.local(); }),
       ss::sharded_parameter([this] { return &rr_metadata_manager_.local(); }),
       ss::sharded_parameter([this] { return &rr_snapshot_manager_.local(); }));

--- a/src/v/cloud_topics/app.h
+++ b/src/v/cloud_topics/app.h
@@ -102,6 +102,7 @@ private:
 
     ss::sstring _logger_name;
     ss::sharded<level_one_reader_probe> _l1_reader_probe;
+    ss::sharded<l1::file_io_probe> _l1_file_io_probe;
     ss::sharded<l1_reader_cache> _l1_reader_cache;
     std::unique_ptr<data_plane_api> data_plane;
     ss::sharded<state_accessors> state;

--- a/src/v/cloud_topics/level_one/common/BUILD
+++ b/src/v/cloud_topics/level_one/common/BUILD
@@ -89,6 +89,9 @@ redpanda_cc_library(
     name = "file_io",
     srcs = ["file_io.cc"],
     hdrs = ["file_io.h"],
+    implementation_deps = [
+        "//src/v/base",
+    ],
     visibility = [
         "//src/v/cloud_topics:__pkg__",
         "//src/v/cloud_topics/level_one:__subpackages__",
@@ -104,6 +107,7 @@ redpanda_cc_library(
         "//src/v/cloud_storage_clients",
         "//src/v/cloud_topics:logger",
         "//src/v/config",
+        "//src/v/container:chunked_hash_map",
         "//src/v/model",
         "@seastar",
     ],

--- a/src/v/cloud_topics/level_one/common/BUILD
+++ b/src/v/cloud_topics/level_one/common/BUILD
@@ -87,8 +87,14 @@ redpanda_cc_library(
 
 redpanda_cc_library(
     name = "file_io",
-    srcs = ["file_io.cc"],
-    hdrs = ["file_io.h"],
+    srcs = [
+        "file_io.cc",
+        "file_io_probe.cc",
+    ],
+    hdrs = [
+        "file_io.h",
+        "file_io_probe.h",
+    ],
     implementation_deps = [
         "//src/v/base",
     ],
@@ -108,6 +114,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics:logger",
         "//src/v/config",
         "//src/v/container:chunked_hash_map",
+        "//src/v/metrics",
         "//src/v/model",
         "@seastar",
     ],

--- a/src/v/cloud_topics/level_one/common/file_io.cc
+++ b/src/v/cloud_topics/level_one/common/file_io.cc
@@ -96,11 +96,13 @@ file_io::file_io(
   std::filesystem::path staging_dir,
   cloud_io::remote* remote,
   cloud_storage_clients::bucket_name bucket,
-  cloud_io::cache* cache)
+  cloud_io::cache* cache,
+  file_io_probe* probe)
   : _remote(remote)
   , _bucket(std::move(bucket))
   , _staging_dir(std::move(staging_dir))
-  , _cache(cache) {}
+  , _cache(cache)
+  , _probe(probe) {}
 
 ss::future<> file_io::stop() { return _gate.close(); }
 
@@ -225,10 +227,16 @@ file_io::read_object(
               cd_log.debug,
               "Merging L1 read for {} into in-flight download",
               extent);
+            if (_probe) {
+                _probe->register_concurrent_read_merge();
+            }
             auto fut = co_await ss::coroutine::as_future(
               it->second.get_shared_future(*as));
             if (fut.failed()) {
                 fut.ignore_ready_future();
+                if (_probe) {
+                    _probe->register_merged_read_abort();
+                }
                 // Matches the cold-miss path's abort->timeout convention.
                 co_return std::unexpected(io::errc::cloud_op_timeout);
             }

--- a/src/v/cloud_topics/level_one/common/file_io.cc
+++ b/src/v/cloud_topics/level_one/common/file_io.cc
@@ -10,6 +10,7 @@
 
 #include "cloud_topics/level_one/common/file_io.h"
 
+#include "base/vassert.h"
 #include "cloud_io/io_result.h"
 #include "cloud_io/remote.h"
 #include "cloud_storage_clients/client.h"
@@ -21,8 +22,10 @@
 
 #include <seastar/core/file.hh>
 #include <seastar/core/fstream.hh>
+#include <seastar/util/defer.hh>
 
 #include <memory>
+#include <optional>
 
 using namespace std::chrono_literals;
 
@@ -99,6 +102,17 @@ file_io::file_io(
   , _staging_dir(std::move(staging_dir))
   , _cache(cache) {}
 
+ss::future<> file_io::stop() { return _gate.close(); }
+
+std::filesystem::path file_io::cache_key(const object_extent& extent) {
+    return std::filesystem::path(
+      fmt::format(
+        "l1_{}_position_{}_size_{}.partial",
+        extent.id,
+        extent.position,
+        extent.size));
+}
+
 ss::future<std::expected<std::unique_ptr<staging_file>, io::errc>>
 file_io::create_tmp_file() {
     co_return std::make_unique<staging_file_impl>(
@@ -166,6 +180,10 @@ ss::future<uint64_t> file_io::save_to_cache(
 ss::future<std::expected<ss::input_stream<char>, io::errc>>
 file_io::read_object(
   object_extent extent, ss::abort_source* as, cloud_io::group_id gid) {
+    if (_gate.is_closed()) {
+        co_return std::unexpected(io::errc::file_io_error);
+    }
+    auto holder = _gate.hold();
     static constexpr auto timeout = 10s;
     static constexpr auto backoff = 100ms;
     retry_chain_node root(*as, ss::lowres_clock::now() + timeout, backoff);
@@ -178,11 +196,7 @@ file_io::read_object(
     // them).
     // TODO(cloud_topics): If reading just a footer, we should skip the cache.
     // Maybe we need another method for that which is iobuf based?
-    std::filesystem::path cache_key = fmt::format(
-      "l1_{}_position_{}_size_{}.partial",
-      extent.id,
-      extent.position,
-      extent.size);
+    std::filesystem::path cache_key = file_io::cache_key(extent);
     while (true) {
         auto stream_fut = co_await ss::coroutine::as_future<
           std::optional<cloud_io::cache_item_stream>>(_cache->get_stream(
@@ -199,6 +213,66 @@ file_io::read_object(
         if (stream) {
             co_return std::move(stream->body);
         }
+
+        // Cache miss. If another caller on this shard is already
+        // downloading this exact extent, wait for it rather than
+        // triggering a duplicate S3 GET + cache write. Mirrors the
+        // L0 read_merge pattern.
+        if (
+          auto it = _inflight_downloads.find(cache_key);
+          it != _inflight_downloads.end()) {
+            vlog(
+              cd_log.debug,
+              "Merging L1 read for {} into in-flight download",
+              extent);
+            auto fut = co_await ss::coroutine::as_future(
+              it->second.get_shared_future(*as));
+            if (fut.failed()) {
+                fut.ignore_ready_future();
+                // Matches the cold-miss path's abort->timeout convention.
+                co_return std::unexpected(io::errc::cloud_op_timeout);
+            }
+            auto result = fut.get();
+            if (result.has_value()) {
+                // In-flight download failed; propagate the same
+                // error rather than racing on a fresh attempt.
+                co_return std::unexpected(*result);
+            }
+            // Download succeeded; the cache now has the data.
+            if (_probe) {
+                _probe->register_concurrent_read_merge();
+            }
+            continue;
+        }
+
+        // cold miss — no preexisting download in progress, kick
+        // one off.
+        auto [_, inserted] = _inflight_downloads.emplace(
+          cache_key, ss::shared_promise<std::optional<io::errc>>{});
+        vassert(
+          inserted,
+          "concurrent insert into _inflight_downloads for {}",
+          cache_key.native());
+        // Default to a real error so any future co_return that forgets
+        // to assign falls through to a failure signal rather than
+        // resolving merged reads with spurious success. The success
+        // arm below explicitly clears this to std::nullopt.
+        std::optional<io::errc> failure_errc = io::errc::file_io_error;
+        auto cleanup = ss::defer([this, cache_key, &failure_errc]() {
+            // This defer is the only eraser for cache_key.
+            // Resolve the enclosed promise unconditionally with the captured
+            // errc (or nullopt on success) so merged reads can propagate a real
+            // outcome.
+            auto it = _inflight_downloads.find(cache_key);
+            vassert(
+              it != _inflight_downloads.end(),
+              "_inflight_downloads entry for {} was erased outside the "
+              "defer",
+              cache_key.native());
+            it->second.set_value(failure_errc);
+            _inflight_downloads.erase(it);
+        });
+
         // TODO(cloud_topics): reserving space should also take an abort_source
         auto reservation_fut = co_await ss::coroutine::as_future<
           cloud_io::space_reservation_guard>(
@@ -236,16 +310,25 @@ file_io::read_object(
         if (result_fut.failed()) {
             auto ex = result_fut.get_exception();
             vlog(cd_log.warn, "Error downloading object {}: {}", extent, ex);
-            co_return std::unexpected(io::errc::cloud_op_error);
+            // Map abort to cloud_op_timeout so leader-abort and
+            // merger-abort produce the same errc for the same event.
+            auto e = as->abort_requested() ? io::errc::cloud_op_timeout
+                                           : io::errc::cloud_op_error;
+            failure_errc = e;
+            co_return std::unexpected(e);
         }
         switch (result_fut.get()) {
         case cloud_io::download_result::success:
-            continue; // Now that it's in the cache the lookup should succeed.
+            failure_errc = std::nullopt;
+            continue;
         case cloud_io::download_result::notfound:
+            failure_errc = io::errc::cloud_missing_object;
             co_return std::unexpected(io::errc::cloud_missing_object);
         case cloud_io::download_result::timedout:
+            failure_errc = io::errc::cloud_op_timeout;
             co_return std::unexpected(io::errc::cloud_op_timeout);
         case cloud_io::download_result::failed:
+            failure_errc = io::errc::cloud_op_error;
             co_return std::unexpected(io::errc::cloud_op_error);
         }
         std::unreachable();

--- a/src/v/cloud_topics/level_one/common/file_io.h
+++ b/src/v/cloud_topics/level_one/common/file_io.h
@@ -33,6 +33,8 @@ namespace cloud_topics::l1 {
 //
 // Reads are cached locally on disk in the cloud cache before being returned.
 class file_io : public io {
+    friend class file_io_test_fixture;
+
 public:
     /// `probe` is an externally-owned per-shard probe. Nullable:
     /// secondary per-shard file_io instances (read-replica refreshers,

--- a/src/v/cloud_topics/level_one/common/file_io.h
+++ b/src/v/cloud_topics/level_one/common/file_io.h
@@ -14,7 +14,13 @@
 #include "cloud_io/remote.h"
 #include "cloud_topics/level_one/common/abstract_io.h"
 #include "cloud_topics/level_one/common/object_id.h"
+#include "container/chunked_hash_map.h"
 #include "model/fundamental.h"
+
+#include <seastar/core/gate.hh>
+#include <seastar/core/shared_future.hh>
+
+#include <optional>
 
 namespace cloud_topics::l1 {
 
@@ -32,6 +38,15 @@ public:
       cloud_io::remote* remote,
       cloud_storage_clients::bucket_name bucket,
       cloud_io::cache* cache);
+
+    /// Drain in-flight reads. Must be co_awaited before destruction so
+    /// the read_object defer-cleanup never touches a destroyed map.
+    ss::future<> stop();
+
+    /// Cloud-cache disk key for an (oid, position, size) extent. Shared
+    /// between `read_object` and tests so the format stays in lockstep.
+    static std::filesystem::path cache_key(const object_extent& extent);
+
     ss::future<std::expected<std::unique_ptr<staging_file>, errc>>
     create_tmp_file() override;
 
@@ -59,6 +74,23 @@ private:
     cloud_storage_clients::bucket_name _bucket;
     std::filesystem::path _staging_dir;
     cloud_io::cache* _cache;
+
+    // Gates all read_object calls so destruction can wait for any
+    // suspended fibers whose defer-cleanup would otherwise touch a
+    // destroyed `_inflight_downloads`.
+    ss::gate _gate;
+
+    // If two reads on the same shard miss the cloud cache on the same
+    // extent, only one triggers a download. Subsequent reads merge
+    // into the in-flight download via the shared promise.
+    // Promise resolves to nullopt on success (merged reads can expect
+    // a warm cache); otherwise it carries the errc to propagate as if
+    // the download came from each merged read's own fiber.
+    // Loosely mirrors the L0 read_merge pattern.
+    chunked_hash_map<
+      std::filesystem::path,
+      ss::shared_promise<std::optional<errc>>>
+      _inflight_downloads;
 };
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/file_io.h
+++ b/src/v/cloud_topics/level_one/common/file_io.h
@@ -13,6 +13,7 @@
 #include "cloud_io/cache_service.h"
 #include "cloud_io/remote.h"
 #include "cloud_topics/level_one/common/abstract_io.h"
+#include "cloud_topics/level_one/common/file_io_probe.h"
 #include "cloud_topics/level_one/common/object_id.h"
 #include "container/chunked_hash_map.h"
 #include "model/fundamental.h"
@@ -33,11 +34,16 @@ namespace cloud_topics::l1 {
 // Reads are cached locally on disk in the cloud cache before being returned.
 class file_io : public io {
 public:
+    /// `probe` is an externally-owned per-shard probe. Nullable:
+    /// secondary per-shard file_io instances (read-replica refreshers,
+    /// etc.) pass nullptr and their IO activity is not counted on the
+    /// shared probe.
     file_io(
       std::filesystem::path staging_dir,
       cloud_io::remote* remote,
       cloud_storage_clients::bucket_name bucket,
-      cloud_io::cache* cache);
+      cloud_io::cache* cache,
+      file_io_probe* probe = nullptr);
 
     /// Drain in-flight reads. Must be co_awaited before destruction so
     /// the read_object defer-cleanup never touches a destroyed map.
@@ -91,6 +97,10 @@ private:
       std::filesystem::path,
       ss::shared_promise<std::optional<errc>>>
       _inflight_downloads;
+
+    // Non-owning. Null for secondary per-shard file_io instances whose
+    // IO activity is intentionally not counted on the shared probe.
+    file_io_probe* _probe;
 };
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/file_io_probe.cc
+++ b/src/v/cloud_topics/level_one/common/file_io_probe.cc
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/common/file_io_probe.h"
+
+#include "config/configuration.h"
+#include "metrics/prometheus_sanitize.h"
+
+#include <seastar/core/metrics.hh>
+
+namespace cloud_topics::l1 {
+
+file_io_probe::file_io_probe() { setup_metrics(); }
+
+void file_io_probe::setup_metrics() {
+    if (config::shard_local_cfg().disable_metrics()) {
+        return;
+    }
+
+    namespace sm = ss::metrics;
+    _metrics.add_group(
+      prometheus_sanitize::metrics_name("cloud_topics_level_one_file_io"),
+      {
+        sm::make_counter(
+          "concurrent_read_merges",
+          [this] { return _concurrent_read_merges; },
+          sm::description(
+            "L1 reads that joined an already-in-flight download for the "
+            "same extent on this shard and resolved with a cache hit on "
+            "retry (an avoided S3 GET). Excludes joins that aborted or "
+            "saw the in-flight download fail. Sustained rate indicates "
+            "concurrent demand on hot extents.")),
+        sm::make_counter(
+          "merged_read_aborts",
+          [this] { return _merged_read_aborts; },
+          sm::description(
+            "L1 reads that joined an in-flight download and were "
+            "aborted before the download resolved.")),
+      });
+}
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/file_io_probe.h
+++ b/src/v/cloud_topics/level_one/common/file_io_probe.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "metrics/metrics.h"
+
+#include <cstdint>
+
+namespace cloud_topics::l1 {
+
+/// Per-shard metrics for file_io. `concurrent_read_merges` counts L1
+/// reads that joined an already-in-flight download and got the
+/// cached bytes on retry (an avoided S3 GET on this shard);
+/// `merged_read_aborts` counts joined reads whose await was aborted
+/// before the in-flight download resolved. Together they're a
+/// per-shard signal of concurrent demand on hot extents and
+/// cancellation pressure on consumers.
+class file_io_probe {
+public:
+    file_io_probe();
+
+    void register_concurrent_read_merge() { ++_concurrent_read_merges; }
+    void register_merged_read_abort() { ++_merged_read_aborts; }
+
+private:
+    void setup_metrics();
+
+    uint64_t _concurrent_read_merges{0};
+    uint64_t _merged_read_aborts{0};
+
+    metrics::internal_metric_groups _metrics;
+};
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/tests/BUILD
+++ b/src/v/cloud_topics/level_one/common/tests/BUILD
@@ -30,3 +30,24 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "file_io_test",
+    timeout = "short",
+    srcs = [
+        "file_io_test.cc",
+    ],
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:iostream",
+        "//src/v/cloud_io/tests:cloud_io_cache_fixture",
+        "//src/v/cloud_storage_clients",
+        "//src/v/cloud_topics/level_one/common:abstract_io",
+        "//src/v/cloud_topics/level_one/common:file_io",
+        "//src/v/cloud_topics/level_one/common:object_id",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_one/common/tests/file_io_test.cc
+++ b/src/v/cloud_topics/level_one/common/tests/file_io_test.cc
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "bytes/iobuf.h"
+#include "bytes/iostream.h"
+#include "cloud_io/tests/cache_test_fixture.h"
+#include "cloud_topics/level_one/common/abstract_io.h"
+#include "cloud_topics/level_one/common/file_io.h"
+#include "cloud_topics/level_one/common/object_id.h"
+#include "model/fundamental.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/sleep.hh>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <filesystem>
+
+using namespace cloud_topics;
+using namespace std::chrono_literals;
+
+namespace cloud_topics::l1 {
+
+// White-box fixture combining cloud_io::cache_test_fixture (real cache,
+// no remote) with seastar_test (gtest + coroutine support). file_io is
+// constructed with a null remote so tests can exercise the byte-range
+// read-merge path without touching object storage. The cold-miss
+// download path is bench-validated, not unit-tested here.
+class file_io_test_fixture
+  : public cloud_io::cache_test_fixture
+  , public seastar_test {
+public:
+    file_io_test_fixture() {
+        _staging_dir = test_dir.get_path() / "staging";
+        std::filesystem::create_directories(_staging_dir);
+        _bucket = cloud_storage_clients::bucket_name("test-bucket");
+        _file_io = std::make_unique<file_io>(
+          _staging_dir, /*remote*/ nullptr, _bucket, &sharded_cache.local());
+    }
+
+    ss::future<> TearDownAsync() override {
+        if (_file_io) {
+            co_await _file_io->stop();
+        }
+    }
+
+    auto& inflight_downloads() { return _file_io->_inflight_downloads; }
+    file_io& io() { return *_file_io; }
+
+    void put_byte_range(
+      const object_id& id, size_t pos, size_t size, char fill_char) {
+        auto key = byte_range_key(id, pos, size);
+        put_into_cache(create_data_string(fill_char, size), key);
+    }
+
+    static std::filesystem::path
+    byte_range_key(const object_id& id, size_t pos, size_t size) {
+        return file_io::cache_key(
+          object_extent{.id = id, .position = pos, .size = size});
+    }
+
+private:
+    std::filesystem::path _staging_dir;
+    cloud_storage_clients::bucket_name _bucket;
+    std::unique_ptr<file_io> _file_io;
+};
+
+namespace {
+
+// Read the first byte from the stream and close it. Helps assert which
+// of two same-sized payloads we got.
+ss::future<char>
+read_first_byte_and_close(ss::input_stream<char> stream, size_t total_size) {
+    auto buf = co_await read_iobuf_exactly(stream, total_size);
+    co_await stream.close();
+    iobuf::iterator_consumer cons{buf.cbegin(), buf.cend()};
+    char first = 0;
+    cons.consume_to(1, &first);
+    co_return first;
+}
+
+} // namespace
+
+// A read that finds an in-flight download for its (oid, pos, size)
+// joins it, awaits the shared promise, and on resolve returns the
+// cached bytes.
+TEST_F_CORO(file_io_test_fixture, MergedReadHitsCacheAfterSuccess) {
+    auto id = create_object_id();
+    constexpr size_t pos = 100;
+    constexpr size_t size = 256;
+    auto br_key = byte_range_key(id, pos, size);
+
+    // Synthesize an in-flight download by inserting into the map
+    // before the merged read starts; we'll resolve the promise by
+    // hand below.
+    auto [it, inserted] = inflight_downloads().emplace(
+      br_key, ss::shared_promise<std::optional<io::errc>>{});
+    ASSERT_TRUE_CORO(inserted);
+
+    object_extent extent{.id = id, .position = pos, .size = size};
+    ss::abort_source as;
+    auto fut = io().read_object(
+      extent, &as, cloud_io::group_id::consumer_fetch);
+
+    // Stand in for the in-flight download: warm the cache, then
+    // resolve.
+    put_byte_range(id, pos, size, 'X');
+    co_await ss::sleep(5ms);
+    it->second.set_value(std::nullopt);
+    inflight_downloads().erase(it);
+
+    auto result = co_await std::move(fut);
+    ASSERT_TRUE_CORO(result.has_value());
+    auto first = co_await read_first_byte_and_close(
+      std::move(result.value()), extent.size);
+    ASSERT_EQ_CORO(first, 'X');
+}
+
+// A merged read whose in-flight download fails must propagate that
+// errc rather than racing on a fresh attempt.
+TEST_F_CORO(file_io_test_fixture, MergedReadPropagatesError) {
+    auto id = create_object_id();
+    constexpr size_t pos = 100;
+    constexpr size_t size = 256;
+    auto br_key = byte_range_key(id, pos, size);
+
+    auto [it, inserted] = inflight_downloads().emplace(
+      br_key, ss::shared_promise<std::optional<io::errc>>{});
+    ASSERT_TRUE_CORO(inserted);
+
+    object_extent extent{.id = id, .position = pos, .size = size};
+    ss::abort_source as;
+    auto fut = io().read_object(
+      extent, &as, cloud_io::group_id::consumer_fetch);
+
+    // Download failed; merged reads propagate the same errc.
+    co_await ss::sleep(5ms);
+    it->second.set_value(io::errc::cloud_op_error);
+    inflight_downloads().erase(it);
+
+    auto result = co_await std::move(fut);
+    ASSERT_FALSE_CORO(result.has_value());
+    ASSERT_EQ_CORO(result.error(), io::errc::cloud_op_error);
+}
+
+// Aborting a merged read while it's suspended on the shared promise
+// must surface as cloud_op_timeout (the abort_source-aware contract
+// on the shared_future), not hang.
+TEST_F_CORO(file_io_test_fixture, MergedReadAborted) {
+    auto id = create_object_id();
+    constexpr size_t pos = 100;
+    constexpr size_t size = 256;
+    auto br_key = byte_range_key(id, pos, size);
+
+    auto [it, inserted] = inflight_downloads().emplace(
+      br_key, ss::shared_promise<std::optional<io::errc>>{});
+    ASSERT_TRUE_CORO(inserted);
+
+    object_extent extent{.id = id, .position = pos, .size = size};
+    ss::abort_source as;
+    auto fut = io().read_object(
+      extent, &as, cloud_io::group_id::consumer_fetch);
+
+    co_await ss::sleep(5ms);
+    as.request_abort();
+
+    auto result = co_await std::move(fut);
+    ASSERT_FALSE_CORO(result.has_value());
+    ASSERT_EQ_CORO(result.error(), io::errc::cloud_op_timeout);
+
+    // Clean up so the synthesized in-flight entry doesn't outlive the
+    // fixture.
+    it->second.set_value(std::nullopt);
+    inflight_downloads().erase(it);
+}
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -296,8 +296,30 @@ level_one_log_reader_impl::lookup_object_for_offset(
     };
 }
 
-ss::future<l1::footer> level_one_log_reader_impl::read_footer(
+ss::future<ss::lw_shared_ptr<const l1::footer>>
+level_one_log_reader_impl::read_footer(
   l1::object_id oid, size_t footer_pos, size_t object_size) {
+    if (_cached_footer && _cached_footer->oid == oid) {
+        // Footers are immutable once an L1 object commits, so (pos,
+        // size) are uniquely determined by oid. Catch invariant
+        // violations in debug builds without paying for the check in
+        // release.
+        dassert(
+          _cached_footer->footer_pos == footer_pos
+            && _cached_footer->object_size == object_size,
+          "cached footer for {} has stale (pos {}, size {}) vs requested "
+          "(pos {}, size {})",
+          oid,
+          _cached_footer->footer_pos,
+          _cached_footer->object_size,
+          footer_pos,
+          object_size);
+        if (_probe != nullptr) {
+            _probe->register_footer_cache_hit();
+        }
+        co_return _cached_footer->footer;
+    }
+
     size_t footer_total_size = object_size - footer_pos;
     if (_probe != nullptr) {
         _probe->register_footer_read(footer_total_size);
@@ -364,7 +386,15 @@ ss::future<l1::footer> level_one_log_reader_impl::read_footer(
           object_size));
     }
 
-    co_return std::get<l1::footer>(std::move(footer_result));
+    auto wrapped = ss::make_lw_shared<const l1::footer>(
+      std::get<l1::footer>(std::move(footer_result)));
+    _cached_footer = cached_footer{
+      .oid = oid,
+      .footer_pos = footer_pos,
+      .object_size = object_size,
+      .footer = wrapped,
+    };
+    co_return wrapped;
 }
 
 ss::future<chunked_circular_buffer<model::record_batch>>
@@ -424,12 +454,12 @@ level_one_log_reader_impl::materialize_batches_from_object_offset(
     // must hold, so we start at whichever position is further into the
     // file.
     auto seek_res = [&] {
-        auto offset_seek = object.footer.file_position_before_kafka_offset(
+        auto offset_seek = object.footer->file_position_before_kafka_offset(
           _tidp, offset);
         if (!_config.first_timestamp) {
             return offset_seek;
         }
-        auto time_seek = object.footer.file_position_before_max_timestamp(
+        auto time_seek = object.footer->file_position_before_max_timestamp(
           _tidp, *_config.first_timestamp);
         if (time_seek == l1::footer::npos) {
             return offset_seek;

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
@@ -17,6 +17,8 @@
 #include "model/record_batch_reader.h"
 #include "utils/prefix_logger.h"
 
+#include <seastar/core/shared_ptr.hh>
+
 #include <deque>
 #include <expected>
 #include <variant>
@@ -110,7 +112,7 @@ public:
 private:
     struct object_info {
         l1::object_id oid;
-        l1::footer footer;
+        ss::lw_shared_ptr<const l1::footer> footer;
         kafka::offset last_offset;
     };
 
@@ -160,7 +162,12 @@ private:
     ss::future<chunked_circular_buffer<model::record_batch>>
     read_batches(l1::object_reader& reader);
 
-    ss::future<l1::footer>
+    /// Fetch and parse the L1 object's footer. Caches the most recent
+    /// footer on the reader; subsequent calls for the same `oid` are
+    /// served from the stash (the common case for sequential read +
+    /// next-L1 prefetch within a single reader). A miss replaces the
+    /// stash. Auto-evicted when the reader closes.
+    ss::future<ss::lw_shared_ptr<const l1::footer>>
     read_footer(l1::object_id oid, size_t footer_pos, size_t object_size);
 
     /*
@@ -212,6 +219,15 @@ private:
     // Consumed front-to-back as the reader advances through objects.
     // Populated with 1 entry (no prefetch) or N entries (prefetch).
     std::deque<l1::metastore::object_response> _lookahead_buffer;
+
+    // Per-reader footer stash. Single entry; replaced on miss.
+    struct cached_footer {
+        l1::object_id oid;
+        size_t footer_pos;
+        size_t object_size;
+        ss::lw_shared_ptr<const l1::footer> footer;
+    };
+    std::optional<cached_footer> _cached_footer;
 };
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader_probe.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader_probe.cc
@@ -31,7 +31,15 @@ void level_one_reader_probe::setup_metrics() {
         sm::make_counter(
           "footer_read_bytes",
           [this] { return _footer_bytes_read; },
-          sm::description("Number of footer bytes read by L1 readers.")),
+          sm::description(
+            "Number of footer bytes fetched from object storage by L1 "
+            "readers (cache hits not counted; see footer_cache_hits).")),
+        sm::make_counter(
+          "footer_cache_hits",
+          [this] { return _footer_cache_hits; },
+          sm::description(
+            "L1 reader footer-stash hits: read_footer calls that "
+            "returned the cached parse instead of fetching.")),
         sm::make_counter(
           "read_bytes",
           [this] { return _bytes_read; },

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader_probe.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader_probe.h
@@ -21,6 +21,8 @@ public:
         _footer_bytes_read += bytes_requested;
     }
 
+    void register_footer_cache_hit() { ++_footer_cache_hits; }
+
     void register_bytes_read(size_t bytes_read) { _bytes_read += bytes_read; }
 
     void register_bytes_skipped(size_t bytes_skipped) {
@@ -31,6 +33,7 @@ private:
     void setup_metrics();
 
     uint64_t _footer_bytes_read{0};
+    uint64_t _footer_cache_hits{0};
     uint64_t _bytes_read{0};
     uint64_t _bytes_skipped{0};
 

--- a/src/v/cloud_topics/read_replica/snapshot_manager.cc
+++ b/src/v/cloud_topics/read_replica/snapshot_manager.cc
@@ -120,6 +120,7 @@ ss::future<> database_refresher::stop_and_wait() {
     if (db_) {
         co_await db_->close();
     }
+    co_await io_->stop();
     vlog(logger_.debug, "Stopped");
 }
 

--- a/src/v/cloud_topics/state_accessors.h
+++ b/src/v/cloud_topics/state_accessors.h
@@ -23,6 +23,7 @@ class l1_reader_cache;
 namespace l1 {
 class metastore;
 class io;
+class file_io_probe;
 } // namespace l1
 
 namespace read_replica {
@@ -42,6 +43,7 @@ public:
       l1::io* io,
       cluster::metadata_cache* metadata_cache,
       level_one_reader_probe* l1_reader_probe,
+      l1::file_io_probe* l1_file_io_probe,
       l1_reader_cache* l1_reader_cache,
       read_replica::metadata_provider* rr_metadata_provider,
       read_replica::snapshot_provider* rr_snapshot_provider)
@@ -50,6 +52,7 @@ public:
       , l1_io(io)
       , metadata_cache(metadata_cache)
       , l1_reader_probe(l1_reader_probe)
+      , l1_file_io_probe(l1_file_io_probe)
       , l1_reader_cache_(l1_reader_cache)
       , rr_metadata_provider_(rr_metadata_provider)
       , rr_snapshot_provider_(rr_snapshot_provider) {}
@@ -58,6 +61,7 @@ public:
     l1::metastore* get_l1_metastore() { return l1_metastore; }
     l1::io* get_l1_io() { return l1_io; }
     level_one_reader_probe* get_l1_reader_probe() { return l1_reader_probe; }
+    l1::file_io_probe* get_l1_file_io_probe() { return l1_file_io_probe; }
     l1_reader_cache* get_l1_reader_cache() { return l1_reader_cache_; }
     cluster::metadata_cache* get_metadata_cache() { return metadata_cache; }
     read_replica::metadata_provider* get_rr_metadata_provider() {
@@ -73,6 +77,7 @@ private:
     l1::io* l1_io;
     cluster::metadata_cache* metadata_cache;
     level_one_reader_probe* l1_reader_probe;
+    l1::file_io_probe* l1_file_io_probe;
     l1_reader_cache* l1_reader_cache_;
     read_replica::metadata_provider* rr_metadata_provider_;
     read_replica::snapshot_provider* rr_snapshot_provider_;


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Two small, related changes to the L1 read path:

  - file_io::read_object in-flight dedup — when concurrent reads on the same shard miss the cache on the same (oid, position, size) extent, only one triggers an S3 GET; the others merge into the in-flight download via a shared promise and either retry the now-warm cache or propagate the download's errc. Mirrors L0's read_merge pattern. Probe exposes concurrent_read_merges and merged_read_aborts counters.
  - Per-reader footer stash — replaces the per-shard l1_footer_cache proposed in #30618 with a single-entry cache on level_one_log_reader_impl. Sequential reads within a reader (and the follow-on next-L1 prefetch path) reuse the parsed footer instead of re-fetching. Auto-evicted when the reader closes

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
