### PR TITLE
rpk: add rpk generate skill command

### DIFF
--- a/src/go/rpk/pkg/cli/generate/BUILD
+++ b/src/go/rpk/pkg/cli/generate/BUILD
@@ -9,6 +9,7 @@ go_library(
         "grafana.go",
         "license.go",
         "prometheus.go",
+        "skill.go",
     ],
     embedsrcs = [
         "app-templates/go-produce-consume.tar.gz",
@@ -51,6 +52,7 @@ go_test(
         "app_test.go",
         "grafana_test.go",
         "prometheus_test.go",
+        "skill_test.go",
     ],
     embed = [":generate"],
     deps = [

--- a/src/go/rpk/pkg/cli/generate/generate.go
+++ b/src/go/rpk/pkg/cli/generate/generate.go
@@ -28,6 +28,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		newLicenseCommand(fs, p),
 		newPrometheusConfigCmd(fs, p),
 		newShellCompletionCommand(),
+		newSkillCmd(fs),
 	)
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/generate/skill.go
+++ b/src/go/rpk/pkg/cli/generate/skill.go
@@ -1,0 +1,343 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package generate
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/httpapi"
+	rpkos "github.com/redpanda-data/redpanda/src/go/rpk/pkg/osutil"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+const (
+	skillsRepo      = "redpanda-data/skills"
+	skillsRepoURL   = "https://github.com/" + skillsRepo
+	defaultProvider = "claude"
+)
+
+// skillProvider describes where an AI coding assistant loads skills from and
+// how to refer to it in output.
+type skillProvider struct {
+	name        string   // canonical flag value
+	displayName string   // human-friendly
+	dir         []string // install path segments under the user home dir
+}
+
+var skillProviders = map[string]skillProvider{
+	"claude": {
+		name:        "claude",
+		displayName: "Claude Code",
+		dir:         []string{".claude", "skills"},
+	},
+}
+
+// defaultDir resolves the provider's skills directory under the user home.
+func (p skillProvider) defaultDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("unable to determine your home directory: %v", err)
+	}
+	return filepath.Join(append([]string{home}, p.dir...)...), nil
+}
+
+func sortedProviderNames() []string {
+	p := slices.Collect(maps.Keys(skillProviders))
+	slices.Sort(p)
+	return p
+}
+
+func newSkillCmd(fs afero.Fs) *cobra.Command {
+	var (
+		provider string
+		branch   string
+		dir      string
+		skills   string
+		all      bool
+	)
+	cmd := &cobra.Command{
+		Use:   "skill",
+		Short: "Install Redpanda rpk skills for your AI coding assistant",
+		Long: `Install Redpanda rpk skills for your AI coding assistant.
+
+This downloads the skills published at ` + skillsRepoURL + `
+and installs them into your AI coding assistant's personal skills directory,
+where the assistant loads them automatically. The assistant is selected with
+--provider (Default 'claude').
+
+By default only the rpk-related skills are installed. Use --all to install
+every Redpanda skill (Streaming, SQL, Connect, Cloud, etc.).
+
+Use --skills for finer control over which skills to install. It accepts a regex
+matched against the available skill names, or the keyword 'list' (print the
+available skills and exit) or 'select' (interactively choose skills). When set,
+--skills selects from the full catalog.`,
+		Example: `
+Install the rpk skills for the default provider:
+  rpk generate skill
+
+Install the rpk skills for a specific provider:
+  rpk generate skill --provider claude
+
+Install every Redpanda skill to a custom directory:
+  rpk generate skill --all --dir /path/to/skills
+
+List the available skills:
+  rpk generate skill --skills list
+
+Interactively select skills to install:
+  rpk generate skill --skills select
+
+Install skills matching a regex:
+  rpk generate skill --skills 'rpk-(topic|group)'
+`,
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
+			prov, ok := skillProviders[provider]
+			if !ok {
+				out.Die("unsupported provider %q; supported providers: %s", provider, strings.Join(sortedProviderNames(), ", "))
+			}
+			if dir == "" {
+				var err error
+				dir, err = prov.defaultDir()
+				out.MaybeDieErr(err)
+			}
+
+			spinner := out.NewSpinner(cmd.Context(), fmt.Sprintf("Downloading skills from github.com/%s@%s...", skillsRepo, branch), out.WithElapsedTime())
+			tgz, err := downloadSkillsTarball(cmd.Context(), branch)
+			if err != nil {
+				spinner.Fail("Failed to download skills")
+				out.MaybeDieErr(err)
+			}
+			catalog, err := parseSkills(bytes.NewReader(tgz))
+			if err != nil {
+				spinner.Fail("Failed to read skills")
+				out.MaybeDieErr(err)
+			}
+			spinner.Success("Skills downloaded")
+
+			match, install, err := resolveSkillMatch(skills, all, catalog.names())
+			out.MaybeDieErr(err)
+			if !install {
+				return
+			}
+
+			installed, err := extractSkills(fs, catalog, dir, match)
+			out.MaybeDieErr(err)
+			if len(installed) == 0 {
+				if all {
+					out.Die("no skills found in github.com/%s", skillsRepo)
+				}
+				out.Die("no rpk skills found in github.com/%s", skillsRepo)
+			}
+
+			tw := out.NewTable("skill")
+			for _, s := range installed {
+				tw.Print(s)
+			}
+			tw.Flush()
+			fmt.Printf("\nInstalled %d skill(s) into %s.\nThey are now available in %s.\n", len(installed), dir, prov.displayName)
+		},
+	}
+	f := cmd.Flags()
+	f.StringVar(&provider, "provider", defaultProvider, "AI coding assistant to install skills for (e.g. claude)")
+	f.StringVar(&branch, "branch", "main", "Repository branch to install skills from")
+	f.StringVar(&dir, "dir", "", "Destination directory (default is the provider's skills directory)")
+	f.StringVar(&skills, "skills", "", "Skills to install: a regex matched against skill names, or the keyword 'list' or 'select'")
+	f.BoolVar(&all, "all", false, "Install all Redpanda skills instead of only the rpk skills")
+
+	cmd.MarkFlagsMutuallyExclusive("skills", "all")
+	cmd.RegisterFlagCompletionFunc("provider", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+		return sortedProviderNames(), cobra.ShellCompDirectiveDefault
+	})
+	return cmd
+}
+
+// resolveSkillMatch handles the --skills flag. The 'list' and 'select' keywords
+// are reserved words; any other non-empty value is treated as a regex (matched
+// against the skill names), and an empty value falls back to the default
+// rpk/--all filter.
+//
+// The returned install bool is false when the flag fully handled the request
+// and there is nothing to install (the 'list' catalog was printed, or 'select'
+// was canceled with no choice).
+func resolveSkillMatch(skills string, all bool, available []string) (match func(name string) bool, install bool, err error) {
+	switch {
+	case skills == "list":
+		tw := out.NewTable("skill")
+		for _, s := range available {
+			tw.Print(s)
+		}
+		tw.Flush()
+		return nil, false, nil
+	case skills == "select":
+		chosen, err := out.PickMultiple(available, "Select the skills to install")
+		if err != nil {
+			return nil, false, err
+		}
+		if len(chosen) == 0 {
+			fmt.Println("No skills selected.")
+			return nil, false, nil
+		}
+		chosenSet := make(map[string]bool, len(chosen))
+		for _, c := range chosen {
+			chosenSet[c] = true
+		}
+		return func(name string) bool { return chosenSet[name] }, true, nil
+	case skills != "":
+		re, err := regexp.Compile(skills)
+		if err != nil {
+			return nil, false, fmt.Errorf("invalid --skills regex %q: %v", skills, err)
+		}
+		if len(matchSkills(available, re)) == 0 {
+			return nil, false, fmt.Errorf("no skills in github.com/%s match %q; available skills: %s", skillsRepo, skills, strings.Join(available, ", "))
+		}
+		return re.MatchString, true, nil
+	default:
+		return func(name string) bool { return wantSkill(name, all) }, true, nil
+	}
+}
+
+func downloadSkillsTarball(ctx context.Context, branch string) ([]byte, error) {
+	url := fmt.Sprintf("https://codeload.github.com/%s/tar.gz/refs/heads/%s", skillsRepo, branch)
+	cl := httpapi.NewClient(
+		httpapi.HTTPClient(&http.Client{Timeout: 2 * time.Minute}),
+	)
+	var buf bytes.Buffer
+	if err := cl.Get(ctx, url, nil, &buf); err != nil {
+		return nil, fmt.Errorf("unable to download skills from %s: %w", url, err)
+	}
+	return buf.Bytes(), nil
+}
+
+func wantSkill(name string, all bool) bool {
+	return all || name == "rpk" || strings.HasPrefix(name, "rpk-")
+}
+
+// matchSkills returns the subset of available skill names matching re.
+func matchSkills(available []string, re *regexp.Regexp) []string {
+	var matched []string
+	for _, n := range available {
+		if re.MatchString(n) {
+			matched = append(matched, n)
+		}
+	}
+	return matched
+}
+
+// walkSkillFiles iterates the regular files of the skills repository tarball,
+// invoking fn for each file under "skills/<name>/<rel>". GitHub tarballs nest
+// everything under a "<repo>-<branch>/" directory, which is stripped here.
+func walkSkillFiles(tarGz io.Reader, fn func(name, rel string, h *tar.Header, tr *tar.Reader) error) error {
+	gzr, err := gzip.NewReader(tarGz)
+	if err != nil {
+		return fmt.Errorf("unable to read skills archive: %w", err)
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+	for {
+		h, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			return fmt.Errorf("unable to read skills archive: %w", err)
+		}
+		if h.Typeflag != tar.TypeReg {
+			continue
+		}
+		rel := strings.TrimPrefix(path.Clean(h.Name), "/")
+		parts := strings.SplitN(rel, "/", 4)
+		if len(parts) < 4 || parts[1] != "skills" {
+			continue
+		}
+		if err := fn(parts[2], parts[3], h, tr); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// skillFile is one regular file belonging to a skill.
+type skillFile struct {
+	rel  string      // path within the skill directory
+	mode os.FileMode // original file mode from the archive
+	data []byte
+}
+
+// skillCatalog maps a skill name to its files, decoded from the skills tarball.
+type skillCatalog map[string][]skillFile
+
+// names returns the catalog's skill names, sorted.
+func (c skillCatalog) names() []string {
+	result := slices.Collect(maps.Keys(c))
+	slices.Sort(result)
+	return result
+}
+
+// parseSkills decodes the skills repository tarball into a catalog keyed by
+// skill name. The archive is decompressed once; both listing the available
+// skills and installing the selected ones operate on the returned catalog.
+func parseSkills(tarGz io.Reader) (skillCatalog, error) {
+	catalog := make(skillCatalog)
+	err := walkSkillFiles(tarGz, func(name, rel string, h *tar.Header, tr *tar.Reader) error {
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			return fmt.Errorf("unable to read %q from skills archive: %w", h.Name, err)
+		}
+		catalog[name] = append(catalog[name], skillFile{rel: rel, mode: h.FileInfo().Mode(), data: data})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return catalog, nil
+}
+
+// extractSkills writes the catalog skills for which match returns true under
+// destDir, returning the sorted list of installed skill names.
+func extractSkills(fs afero.Fs, catalog skillCatalog, destDir string, match func(name string) bool) ([]string, error) {
+	var installed []string
+	for _, name := range catalog.names() {
+		if !match(name) {
+			continue
+		}
+		// Clear any stale files from a prior install before rewriting.
+		skillDir := filepath.Join(destDir, name)
+		if err := fs.RemoveAll(skillDir); err != nil {
+			return nil, fmt.Errorf("unable to remove existing skill %q: %w", name, err)
+		}
+		for _, f := range catalog[name] {
+			dst := filepath.Join(skillDir, filepath.FromSlash(f.rel))
+			if err := rpkos.ReplaceFile(fs, dst, f.data, f.mode); err != nil {
+				return nil, fmt.Errorf("unable to write %q: %w", dst, err)
+			}
+		}
+		installed = append(installed, name)
+	}
+	return installed, nil
+}

--- a/src/go/rpk/pkg/cli/generate/skill.go
+++ b/src/go/rpk/pkg/cli/generate/skill.go
@@ -38,6 +38,11 @@ const (
 	skillsRepo      = "redpanda-data/skills"
 	skillsRepoURL   = "https://github.com/" + skillsRepo
 	defaultProvider = "claude"
+
+	// maxSkillDownloadBytes caps the compressed tarball we buffer from GitHub.
+	maxSkillDownloadBytes = 64 << 20 // 64 MiB
+	// maxSkillUnpackedBytes caps the total decompressed archive size.
+	maxSkillUnpackedBytes = 256 << 20 // 256 MiB
 )
 
 // skillProvider describes where an AI coding assistant loads skills from and
@@ -228,10 +233,26 @@ func downloadSkillsTarball(ctx context.Context, branch string) ([]byte, error) {
 		httpapi.HTTPClient(&http.Client{Timeout: 2 * time.Minute}),
 	)
 	var buf bytes.Buffer
-	if err := cl.Get(ctx, url, nil, &buf); err != nil {
+	if err := cl.Get(ctx, url, nil, &limitedWriter{w: &buf, n: maxSkillDownloadBytes}); err != nil {
 		return nil, fmt.Errorf("unable to download skills from %s: %w", url, err)
 	}
 	return buf.Bytes(), nil
+}
+
+// limitedWriter writes through to w until more than its byte budget is used,
+// then fails. It guards against an oversized download exhausting memory.
+type limitedWriter struct {
+	w io.Writer
+	n int64 // remaining bytes allowed
+}
+
+func (lw *limitedWriter) Write(p []byte) (int, error) {
+	if int64(len(p)) > lw.n {
+		return 0, fmt.Errorf("download exceeds maximum size of %d bytes", maxSkillDownloadBytes)
+	}
+	n, err := lw.w.Write(p)
+	lw.n -= int64(n)
+	return n, err
 }
 
 func wantSkill(name string, all bool) bool {
@@ -249,6 +270,25 @@ func matchSkills(available []string, re *regexp.Regexp) []string {
 	return matched
 }
 
+// cappedReader fails once more than its byte budget has been read. It guards
+// against a decompression bomb when reading the (gzip-expanded) tar stream.
+type cappedReader struct {
+	r io.Reader
+	n int64 // remaining bytes allowed
+}
+
+func (c *cappedReader) Read(p []byte) (int, error) {
+	if c.n <= 0 {
+		return 0, fmt.Errorf("skills archive exceeds maximum unpacked size of %d bytes", maxSkillUnpackedBytes)
+	}
+	if int64(len(p)) > c.n {
+		p = p[:c.n]
+	}
+	n, err := c.r.Read(p)
+	c.n -= int64(n)
+	return n, err
+}
+
 // walkSkillFiles iterates the regular files of the skills repository tarball,
 // invoking fn for each file under "skills/<name>/<rel>". GitHub tarballs nest
 // everything under a "<repo>-<branch>/" directory, which is stripped here.
@@ -259,7 +299,7 @@ func walkSkillFiles(tarGz io.Reader, fn func(name, rel string, h *tar.Header, tr
 	}
 	defer gzr.Close()
 
-	tr := tar.NewReader(gzr)
+	tr := tar.NewReader(&cappedReader{r: gzr, n: maxSkillUnpackedBytes})
 	for {
 		h, err := tr.Next()
 		if errors.Is(err, io.EOF) {

--- a/src/go/rpk/pkg/cli/generate/skill_test.go
+++ b/src/go/rpk/pkg/cli/generate/skill_test.go
@@ -1,0 +1,238 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package generate
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+// buildSkillsTarball builds an in-memory gzip+tar mimicking a GitHub repo
+// tarball: every file is nested under "<repo>-<branch>/".
+func buildSkillsTarball(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzw)
+	for name, content := range files {
+		hdr := &tar.Header{
+			Name:     "skills-main/" + name,
+			Typeflag: tar.TypeReg,
+			Mode:     0o644,
+			Size:     int64(len(content)),
+		}
+		require.NoError(t, tw.WriteHeader(hdr))
+		_, err := tw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, gzw.Close())
+	return buf.Bytes()
+}
+
+func TestSkillExtract(t *testing.T) {
+	files := map[string]string{
+		"README.md":                        "top-level readme, ignored",
+		"skills/rpk/SKILL.md":              "rpk skill",
+		"skills/rpk/references/topics.md":  "rpk reference",
+		"skills/rpk-topic/SKILL.md":        "rpk-topic skill",
+		"skills/streaming/SKILL.md":        "streaming skill",
+		"skills/sql/references/queries.md": "sql reference",
+	}
+
+	rpkOnly := func(n string) bool { return wantSkill(n, false) }
+	allSkills := func(n string) bool { return wantSkill(n, true) }
+
+	parse := func(t *testing.T) skillCatalog {
+		t.Helper()
+		catalog, err := parseSkills(bytes.NewReader(buildSkillsTarball(t, files)))
+		require.NoError(t, err)
+		return catalog
+	}
+
+	t.Run("default installs only rpk skills", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		got, err := extractSkills(fs, parse(t), "/dest", rpkOnly)
+		require.NoError(t, err)
+		require.Equal(t, []string{"rpk", "rpk-topic"}, got)
+
+		// rpk files land at the expected paths with their content.
+		b, err := afero.ReadFile(fs, filepath.Join("/dest", "rpk", "SKILL.md"))
+		require.NoError(t, err)
+		require.Equal(t, "rpk skill", string(b))
+		b, err = afero.ReadFile(fs, filepath.Join("/dest", "rpk", "references", "topics.md"))
+		require.NoError(t, err)
+		require.Equal(t, "rpk reference", string(b))
+
+		// Non-rpk skills are not installed.
+		exists, err := afero.DirExists(fs, filepath.Join("/dest", "streaming"))
+		require.NoError(t, err)
+		require.False(t, exists)
+		exists, err = afero.DirExists(fs, filepath.Join("/dest", "sql"))
+		require.NoError(t, err)
+		require.False(t, exists)
+	})
+
+	t.Run("all installs every skill", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		got, err := extractSkills(fs, parse(t), "/dest", allSkills)
+		require.NoError(t, err)
+		require.Equal(t, []string{"rpk", "rpk-topic", "sql", "streaming"}, got)
+	})
+
+	t.Run("membership predicate installs exactly that set", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		want := map[string]bool{"rpk-topic": true, "sql": true}
+		got, err := extractSkills(fs, parse(t), "/dest", func(n string) bool { return want[n] })
+		require.NoError(t, err)
+		require.Equal(t, []string{"rpk-topic", "sql"}, got)
+	})
+
+	t.Run("no match returns empty, no error", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		got, err := extractSkills(fs, parse(t), "/dest", func(string) bool { return false })
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+
+	t.Run("stale files are cleared", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		stale := filepath.Join("/dest", "rpk", "old.md")
+		require.NoError(t, afero.WriteFile(fs, stale, []byte("stale"), 0o644))
+
+		_, err := extractSkills(fs, parse(t), "/dest", rpkOnly)
+		require.NoError(t, err)
+
+		exists, err := afero.Exists(fs, stale)
+		require.NoError(t, err)
+		require.False(t, exists)
+	})
+}
+
+func TestSkillList(t *testing.T) {
+	files := map[string]string{
+		"README.md":                        "ignored",
+		"skills/rpk/SKILL.md":              "rpk skill",
+		"skills/rpk/references/topics.md":  "rpk reference",
+		"skills/rpk-topic/SKILL.md":        "rpk-topic skill",
+		"skills/streaming/SKILL.md":        "streaming skill",
+		"skills/sql/references/queries.md": "sql reference",
+	}
+	catalog, err := parseSkills(bytes.NewReader(buildSkillsTarball(t, files)))
+	require.NoError(t, err)
+	require.Equal(t, []string{"rpk", "rpk-topic", "sql", "streaming"}, catalog.names())
+}
+
+func TestSkillMatch(t *testing.T) {
+	available := []string{"rpk", "rpk-topic", "rpk-group", "sql", "streaming"}
+	for _, tc := range []struct {
+		name    string
+		pattern string
+		want    []string
+	}{
+		{"regex matches subset", `rpk-.*`, []string{"rpk-topic", "rpk-group"}},
+		{"anchored alternation", `^rpk-(topic|group)$`, []string{"rpk-topic", "rpk-group"}},
+		{"no match returns empty", `nomatch-xyz`, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchSkills(available, regexp.MustCompile(tc.pattern))
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestResolveSkillMatch(t *testing.T) {
+	available := []string{"rpk", "rpk-topic", "sql", "streaming"}
+	for _, tc := range []struct {
+		name        string
+		skills      string
+		all         bool
+		wantErr     bool
+		wantInstall bool     // expected install return
+		wantMatch   []string // names in available the predicate should select
+	}{
+		{
+			name:        "default uses rpk filter",
+			wantInstall: true,
+			wantMatch:   []string{"rpk", "rpk-topic"},
+		},
+		{
+			name:        "default with all installs everything",
+			all:         true,
+			wantInstall: true,
+			wantMatch:   []string{"rpk", "rpk-topic", "sql", "streaming"},
+		},
+		{
+			name:        "regex selects matching skills",
+			skills:      `^rpk-`,
+			wantInstall: true,
+			wantMatch:   []string{"rpk-topic"},
+		},
+		{
+			name:    "invalid regex errors",
+			skills:  "(",
+			wantErr: true,
+		},
+		{
+			name:    "no regex match errors",
+			skills:  "nomatch-xyz",
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			match, install, err := resolveSkillMatch(tc.skills, tc.all, available)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantInstall, install)
+
+			want := make(map[string]bool, len(tc.wantMatch))
+			for _, n := range tc.wantMatch {
+				want[n] = true
+			}
+			for _, n := range available {
+				require.Equal(t, want[n], match(n), "match(%q)", n)
+			}
+		})
+	}
+}
+
+func TestSkillProvider(t *testing.T) {
+	t.Run("default provider is claude", func(t *testing.T) {
+		prov, ok := skillProviders[defaultProvider]
+		require.True(t, ok)
+		require.Equal(t, "claude", prov.name)
+
+		home, err := os.UserHomeDir()
+		require.NoError(t, err)
+		dir, err := prov.defaultDir()
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(home, ".claude", "skills"), dir)
+	})
+
+	t.Run("unknown provider is not registered", func(t *testing.T) {
+		_, ok := skillProviders["bogus"]
+		require.False(t, ok)
+	})
+
+	t.Run("sorted provider names", func(t *testing.T) {
+		require.Equal(t, []string{"claude"}, sortedProviderNames())
+	})
+}

--- a/src/go/rpk/pkg/cli/generate/skill_test.go
+++ b/src/go/rpk/pkg/cli/generate/skill_test.go
@@ -13,9 +13,11 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -234,5 +236,46 @@ func TestSkillProvider(t *testing.T) {
 
 	t.Run("sorted provider names", func(t *testing.T) {
 		require.Equal(t, []string{"claude"}, sortedProviderNames())
+	})
+}
+
+func TestLimitedWriter(t *testing.T) {
+	t.Run("within budget passes through", func(t *testing.T) {
+		var buf bytes.Buffer
+		lw := &limitedWriter{w: &buf, n: 8}
+		n, err := lw.Write([]byte("abcd"))
+		require.NoError(t, err)
+		require.Equal(t, 4, n)
+		n, err = lw.Write([]byte("efgh"))
+		require.NoError(t, err)
+		require.Equal(t, 4, n)
+		require.Equal(t, "abcdefgh", buf.String())
+	})
+
+	t.Run("write crossing budget errors and does not exceed cap", func(t *testing.T) {
+		var buf bytes.Buffer
+		lw := &limitedWriter{w: &buf, n: 4}
+		_, err := lw.Write([]byte("abc"))
+		require.NoError(t, err)
+		_, err = lw.Write([]byte("de"))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "download exceeds maximum size")
+		require.LessOrEqual(t, buf.Len(), 4)
+	})
+}
+
+func TestCappedReader(t *testing.T) {
+	t.Run("within budget reads fully", func(t *testing.T) {
+		c := &cappedReader{r: strings.NewReader("hello"), n: 16}
+		got, err := io.ReadAll(c)
+		require.NoError(t, err)
+		require.Equal(t, "hello", string(got))
+	})
+
+	t.Run("exceeding budget errors", func(t *testing.T) {
+		c := &cappedReader{r: strings.NewReader(strings.Repeat("x", 100)), n: 10}
+		_, err := io.ReadAll(c)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds maximum unpacked size")
 	})
 }

--- a/src/go/rpk/pkg/out/out.go
+++ b/src/go/rpk/pkg/out/out.go
@@ -117,6 +117,20 @@ func PickIndex(options []string, msg string, args ...any) (int, error) {
 	return selected, nil
 }
 
+// PickMultiple prompts the user to select zero or more options, returning the
+// selected options or an error.
+func PickMultiple(options []string, msg string, args ...any) ([]string, error) {
+	var selected []string
+	err := survey.AskOne(&survey.MultiSelect{
+		Message: fmt.Sprintf(msg, args...),
+		Options: options,
+	}, &selected)
+	if err != nil {
+		return nil, err
+	}
+	return selected, nil
+}
+
 // Prompt prompts the user for input, returning the input or an error.
 func Prompt(msg string, args ...any) (string, error) {
 	return PromptWithSuggestion("", msg, args...)


### PR DESCRIPTION
Installing Redpanda's Claude Code skills previously required the claude CLI and knowledge of the
marketplace and plugin names:

```
  claude plugin marketplace add redpanda-data/skills
  claude plugin install redpanda@redpanda-skills
```

This makes rpk do the equivalent natively. The command downloads the redpanda-data/skills repo tarball over HTTP, extracts it in memory, and writes the matching skills into the Claude Code personal skills directory (~/.claude/skills), where they are loaded automatically. By default only the rpk skills are installed; --all installs every Redpanda skill.

### Example:
```
$ rpk generate skill --all
✓ Skills downloaded
SKILL
ai
cloud-byoc
cloud-dedicated
cloud-serverless
connect
connect-cdc-dynamodb
connect-cdc-mongodb
connect-cdc-mysql
connect-cdc-oracle
connect-cdc-postgres
connect-cdc-salesforce
connect-cdc-spanner
connect-cdc-sqlserver
connect-debugging
rpk
rpk-cloud
rpk-cluster
rpk-debug
rpk-group
rpk-registry
rpk-security
rpk-topic
rpk-transform
sql
sql-admin-api
sql-debugging
sql-federated-queries
streaming
streaming-admin-api
streaming-debugging

Installed 30 skill(s) into /Users/foo/.claude/skills.
They are now available in Claude Code.
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Features

* `rpk generate skill`: let you download Redpanda skills for your AI agent
