### PR TITLE
dt: upgrade client-swarm to rdkafka 0.39

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -159,6 +159,12 @@ ENV PATH="${PATH}:/root/.cargo/bin"
 
 FROM rust AS client-swarm
 
+# The rdkafka 0.39 bump upgrades the transitive zstd-sys dep (rdkafka's
+# zstd support) to a version that builds its bindings with bindgen,
+# which needs libclang.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends libclang-dev
+
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/client-swarm /
 RUN /client-swarm && \
     rm /client-swarm

--- a/tests/docker/ducktape-deps/client-swarm
+++ b/tests/docker/ducktape-deps/client-swarm
@@ -6,7 +6,7 @@ pushd /tmp
 git clone https://github.com/redpanda-data/client-swarm.git
 
 pushd client-swarm
-git reset --hard 7a2d3837ac926047098232b7ec87afb32a319690
+git reset --hard 1b5f4172bc6b1250fc0a0e2e24a37ec39e2eff35
 cargo build --config 'term.verbose=true' --config 'net.retry=6' --release
 cp target/release/client-swarm /usr/local/bin
 popd

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -130,6 +130,29 @@ class TopicRecreateTest(RedpandaTest):
             },
         )
 
+    def _wait_for_topic_ready(
+        self,
+        topic: str,
+        partition_count: int,
+        replication_factor: int,
+    ) -> None:
+        rpk = RpkTool(self.redpanda)
+
+        def topic_is_ready():
+            partitions = list(rpk.describe_topic(topic))
+            return len(partitions) == partition_count and all(
+                p.leader != -1 and len(p.replicas) == replication_factor
+                for p in partitions
+            )
+
+        wait_until(
+            topic_is_ready,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"Topic {topic} readiness",
+            retry_on_exc=True,
+        )
+
     @cluster(num_nodes=6)
     @matrix(
         workload=[Workload.ACKS_1, Workload.ACKS_ALL, Workload.IDEMPOTENT],
@@ -149,6 +172,7 @@ class TopicRecreateTest(RedpandaTest):
         spec.cleanup_policy = cleanup_policy
 
         self.client().create_topic(spec)
+        self._wait_for_topic_ready(spec.name, partition_count, spec.replication_factor)
 
         producer_properties = {}
         if workload == Workload.ACKS_1:
@@ -184,12 +208,25 @@ class TopicRecreateTest(RedpandaTest):
             self.logger.debug(f"High watermark offsets: {hw_offsets}")
             return len(offsets_present) == partition_count and all(offsets_present)
 
+        # Long-lived librdkafka 2.12.1 producers stall after a topic
+        # delete+recreate, so recreate the swarm (fresh client) and wait
+        # for the new topic to be ready each iteration.
+        # See https://github.com/confluentinc/librdkafka/issues/4898
         for i in range(1, 20):
             rf = 3 if i % 2 == 0 else 1
             self.client().delete_topic(spec.name)
             spec.replication_factor = rf
             self.client().create_topic(spec)
-            wait_until(topic_is_healthy, 30, 2, err_msg=f"Topic {spec.name} health")
+            self._wait_for_topic_ready(spec.name, partition_count, rf)
+            swarm.stop()
+            swarm.wait()
+            swarm.start()
+            wait_until(
+                topic_is_healthy,
+                30,
+                2,
+                err_msg=f"Topic {spec.name} health",
+            )
             sleep(5)
 
         swarm.stop()
@@ -241,6 +278,10 @@ class TopicRecreateTest(RedpandaTest):
             self.logger.debug(f"High watermark offsets: {hw_offsets}")
             return len(offsets_present) == partition_count and all(offsets_present)
 
+        # Long-lived librdkafka 2.12.1 producers stall after a topic
+        # delete+recreate, so recreate the swarm (fresh client) and wait
+        # for the new topic to be ready each iteration.
+        # See https://github.com/confluentinc/librdkafka/issues/4898
         for i in range(1, 20):
             rf = 3 if i % 2 == 0 else 1
             self.client().delete_topic(topic)
@@ -250,6 +291,10 @@ class TopicRecreateTest(RedpandaTest):
                 replicas=rf,
                 config={TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD},
             )
+            self._wait_for_topic_ready(topic, partition_count, rf)
+            swarm.stop()
+            swarm.wait()
+            swarm.start()
             wait_until(topic_is_healthy, 30, 2, err_msg=f"Topic {topic} health")
             sleep(5)
 


### PR DESCRIPTION
Bumps client-swarm's `rdkafka` pin from 0.37.0 to 0.39.0, moving the
bundled librdkafka from 2.3.0 to 2.12.1. Part of the [ENG-1185](https://redpandadata.atlassian.net/browse/ENG-1185) client
modernization for Kafka 4.x.

The bump also upgrades a transitive dependency that requires
`libclang-dev` to be installed in the client-swarm build stage.

### `TopicRecreateTest` fix

The upgrade surfaced a flake that only shows up under CI load: a
long-lived producer swarm intermittently stalls producing after the
topic is deleted and recreated, timing out the 30s health check.

We believe the cause is a client-side librdkafka behavior. For a short
window after a topic is deleted, librdkafka keeps the old partition
objects alive, treating the "topic gone" report as a transient metadata
blip rather than a real delete. When the topic is recreated, its
partitions legitimately come back with a lower Kafka `leader_epoch` (the
broker resets it when the topic is deleted and recreated), but librdkafka
assumes `leader_epoch` only ever increases for a given `(topic,
partition)`, so it treats the new, lower value as stale and ignores it.
The producer then never re-points at the recreated topic's leader and
produce stalls. We think the right fix is in librdkafka itself (it should
drop its cached epoch when a topic is recreated), but it does not do that
today.

The test's intent is to exercise broker-side delete/recreate behavior,
so the fix keeps it scoped there: recreate the swarm each iteration (a
fresh client carries no stale cached epoch) and wait for the recreated
topic to report a valid leader and full replica set before producing.

Fixes [CORE-16385](https://redpandadata.atlassian.net/browse/CORE-16385)

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none


[CORE-16385]: https://redpandadata.atlassian.net/browse/CORE-16385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ENG-1185]: https://redpandadata.atlassian.net/browse/ENG-1185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ