### PR TITLE
rpk/topic: fix typo in trim-prefix help text

### DIFF
--- a/src/go/rpk/pkg/cli/topic/trim.go
+++ b/src/go/rpk/pkg/cli/topic/trim.go
@@ -42,7 +42,7 @@ func newTrimPrefixCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 
 This command allows you to trim records from topics, to trim the topics Redpanda
 sets the LogStartOffset for partitions to the requested offset. All segments
-whose base offset is less then the requested offset are deleted, and any records
+whose base offset is less than the requested offset are deleted, and any records
 within the segment before the requested offset can no longer be read.
 
 The --offset/-o flag allows you to indicate which index you want to set the


### PR DESCRIPTION
## Summary
- Fix typo "less then" → "less than" in `rpk topic trim-prefix` command help text

## Test plan
- [x] Verified the typo exists in current help text
- [x] Verified the fix corrects the typo

Fixes #30675

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
* none
