### PR TITLE
rptest: enable cloud-mode transactional replication test

### DIFF
--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -1892,13 +1892,20 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
     )
     @matrix(storage_mode=ALL_STORAGE_MODES)
     def test_replication_with_transactions(self, storage_mode):
-        if storage_mode == TopicSpec.STORAGE_MODE_CLOUD:
-            # Transactional replication with cloud storage mode is too
-            # slow and times out; skip until performance is improved.
-            _ = self.preallocated_nodes
-            self.logger.info("Skipping transactions test for cloud storage mode")
-            return
         topic = TopicSpec(name="source-topic", partition_count=1, replication_factor=3)
+
+        # Cloud-topic produce uploads are time-driven (250 ms default) when
+        # neither size nor cardinality thresholds fire. With a single-partition
+        # transactional workload that's the only firing condition, so lower
+        # the interval to keep this test from spending the entire run in the
+        # cloud-topics linger.
+        if storage_mode in (
+            TopicSpec.STORAGE_MODE_CLOUD,
+            TopicSpec.STORAGE_MODE_TIERED_CLOUD,
+        ):
+            self.source_cluster_service.set_cluster_config(
+                {"cloud_topics_produce_upload_interval": 25}
+            )
 
         self.create_source_topic(topic, storage_mode)
         self.create_link("test-link")
@@ -1915,7 +1922,10 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             msg_size=128,
             msg_cnt=10000,
             use_transactions=True,
-            producer_properties={"transaction_abort_rate": "0.3"},
+            producer_properties={
+                "transaction_abort_rate": "0.3",
+                "msgs_per_transaction": 50,
+            },
         ):
             self.verify()
 


### PR DESCRIPTION
`test_replication_with_transactions` was skipped for `storage_mode=cloud` because the default `msgs-per-transaction=1` in kgo-verifier combined with the 250ms `cloud_topics_produce_upload_interval` made every produce wait a full linger cycle; 10K such transactions did not finish within the 30-minute timeout.

Two changes restore the coverage: bump `msgs_per_transaction` to 50 (matching the cloud_combos workload spec used elsewhere), and lower the upload interval to 25ms for the cloud/tiered_cloud variants. Both variants now complete in about a minute.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none
