### PR TITLE
tests: close confluent_kafka consumers deterministically (CORE-16410)

### DIFF
--- a/tests/rptest/clients/ping_pong.py
+++ b/tests/rptest/clients/ping_pong.py
@@ -103,6 +103,24 @@ class LogReader:
                 if check(offset, key, value):
                     return
 
+    def close(self) -> None:
+        # Break the stream_gen generator -> frame -> self reference cycle so the
+        # Consumer is reclaimed promptly by refcounting, then close it
+        # deterministically. An unclosed Consumer is only collected by the
+        # cyclic GC, and its C destructor (rd_kafka_destroy) can deadlock when
+        # it runs from a GC finalizer while a partition leader is unreachable
+        # (CORE-16410, librdkafka rk_lock/toppar lock-order inversion).
+        self.stream = None
+        if self.consumer is not None:
+            self.consumer.close()
+            self.consumer = None
+
+    def __enter__(self) -> "LogReader":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
 
 def expect(offset: int, key: str, value: str) -> Callable[[int, str, str], bool]:
     def check(ro: int, rk: str, rv: str) -> bool:
@@ -182,3 +200,12 @@ class PingPong:
         self.logger.info(
             f"ping_pong produced and consumed {key}={value}@{offset} in {(latency) * 1000.0:.2f} ms"
         )
+
+    def close(self) -> None:
+        self.consumer.close()
+
+    def __enter__(self) -> "PingPong":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()

--- a/tests/rptest/clients/python_librdkafka.py
+++ b/tests/rptest/clients/python_librdkafka.py
@@ -8,6 +8,8 @@
 # by the Apache License, Version 2.0
 import functools
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any, Optional, cast
 
 import requests
@@ -17,6 +19,20 @@ from confluent_kafka.admin import AdminClient, NewTopic
 from rptest.services import tls
 from rptest.services.keycloak import OAuthConfig
 from rptest.services.redpanda_types import KafkaClientSecurity
+
+
+@contextmanager
+def ck_consumer(config: dict[str, Any], **kwargs: Any) -> Iterator[Consumer]:
+    """A confluent_kafka ``Consumer`` that is closed deterministically on exit.
+
+    Prefer this over a bare ``Consumer(...)``: an unclosed consumer destroyed
+    later by the GC can deadlock (CORE-16410).
+    """
+    consumer = Consumer(config, **kwargs)
+    try:
+        yield consumer
+    finally:
+        consumer.close()
 
 
 class PythonLibrdkafka:

--- a/tests/rptest/tests/basic_kafka_compat_test.py
+++ b/tests/rptest/tests/basic_kafka_compat_test.py
@@ -18,6 +18,7 @@ from ducktape.mark import parametrize
 from kafkatest.services.kafka import KafkaService
 
 from rptest.clients.default import DefaultClient
+from rptest.clients.python_librdkafka import ck_consumer
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
 from rptest.services.kafka import KafkaServiceAdapter
@@ -128,31 +129,28 @@ class TxKafkaCompatTest(KafkaCompatTest):
 
             producer_2.commit_transaction()
 
-            consumer = ck.Consumer(
-                {
-                    "bootstrap.servers": broker_service.brokers(),
-                    "group.id": "group-1",
-                    "auto.offset.reset": "earliest",
-                    "enable.auto.commit": True,
-                    "isolation.level": "read_committed",
-                },
-                logger=self.logger,
-            )
-            consumer.subscribe([topic.name])
+            config = {
+                "bootstrap.servers": broker_service.brokers(),
+                "group.id": "group-1",
+                "auto.offset.reset": "earliest",
+                "enable.auto.commit": True,
+                "isolation.level": "read_committed",
+            }
+            with ck_consumer(config, logger=self.logger) as consumer:
+                consumer.subscribe([topic.name])
 
-            msgs = []
-            timeout = time.time() + 30
-            while len(msgs) < 10:
-                msg = consumer.poll(timeout=1)
-                if time.time() > timeout:
-                    break
+                msgs = []
+                timeout = time.time() + 30
+                while len(msgs) < 10:
+                    msg = consumer.poll(timeout=1)
+                    if time.time() > timeout:
+                        break
 
-                if msg:
-                    self.logger.info(
-                        f"consumed: {msg.value()} at offset: {msg.offset()}"
-                    )
-                    msgs.append(msg.value().decode("utf-8"))
-            consumer.close()
+                    if msg:
+                        self.logger.info(
+                            f"consumed: {msg.value()} at offset: {msg.offset()}"
+                        )
+                        msgs.append(msg.value().decode("utf-8"))
             return msgs
 
         self._compat_test_case(test_case)
@@ -207,25 +205,22 @@ class KafkaTimestampCompatTest(KafkaCompatTest):
                 producer.produce(topic.name, key="k", value=f"value-{ts}", timestamp=ts)
                 producer.flush()
 
-            consumer = ck.Consumer(
-                {
-                    "bootstrap.servers": broker_service.brokers(),
-                    "group.id": "group",
-                },
-                logger=self.logger,
-            )
-            consumer.subscribe([topic.name])
+            config = {
+                "bootstrap.servers": broker_service.brokers(),
+                "group.id": "group",
+            }
+            with ck_consumer(config, logger=self.logger) as consumer:
+                consumer.subscribe([topic.name])
 
-            msgs = []
-            timeout = time.time() + 5
-            while len(msgs) < num_messages:
-                msg = consumer.poll(timeout=1)
-                if time.time() > timeout:
-                    break
+                msgs = []
+                timeout = time.time() + 5
+                while len(msgs) < num_messages:
+                    msg = consumer.poll(timeout=1)
+                    if time.time() > timeout:
+                        break
 
-                if msg:
-                    msgs.append(msg.value().decode("utf-8"))
-            consumer.close()
+                    if msg:
+                        msgs.append(msg.value().decode("utf-8"))
             return msgs
 
         validation_modes = [

--- a/tests/rptest/tests/consumer_offsets_batch_cache_test.py
+++ b/tests/rptest/tests/consumer_offsets_batch_cache_test.py
@@ -38,7 +38,7 @@ class ConsumerOffsetsCacheTest(RedpandaTest):
         self.logger.info(f"Read metrics: {_sum_metric_value(read_metrics)}")
         return cache_read / total_read if total_read > 0 else None
 
-    def _commit_random_offsets(self, topic: str, partition: int):
+    def _commit_random_offsets(self, topic: str):
         # Create a consumer that will commit random offsets without consuming
         config = {
             "bootstrap.servers": self.redpanda.brokers(),
@@ -65,7 +65,7 @@ class ConsumerOffsetsCacheTest(RedpandaTest):
         topic = TopicSpec(name="test-topic", partition_count=1, replication_factor=3)
 
         DefaultClient(self.redpanda).create_topic(topic)
-        self._commit_random_offsets(topic.name, 0)
+        self._commit_random_offsets(topic.name)
 
         ratio_no_cache = self._consumer_offsets_cache_hit_ratio()
         assert ratio_no_cache == 0.0, (
@@ -77,7 +77,7 @@ class ConsumerOffsetsCacheTest(RedpandaTest):
             },
             expect_restart=True,
         )
-        self._commit_random_offsets(topic.name, 0)
+        self._commit_random_offsets(topic.name)
         hit_ratio = self._consumer_offsets_cache_hit_ratio()
         # hit ratio is not exactly 1.0 as the topic is read once during the
         # startup, the cache is cold during that operation

--- a/tests/rptest/tests/consumer_offsets_batch_cache_test.py
+++ b/tests/rptest/tests/consumer_offsets_batch_cache_test.py
@@ -8,8 +8,9 @@
 # by the Apache License, Version 2.0
 import random
 
-from confluent_kafka import Consumer, TopicPartition
+from confluent_kafka import TopicPartition
 
+from rptest.clients.python_librdkafka import ck_consumer
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import DefaultClient, RedpandaTest
@@ -39,17 +40,15 @@ class ConsumerOffsetsCacheTest(RedpandaTest):
 
     def _commit_random_offsets(self, topic: str, partition: int):
         # Create a consumer that will commit random offsets without consuming
-        consumer = Consumer(
-            {
-                "bootstrap.servers": self.redpanda.brokers(),
-                "group.id": "test-consumer-group",
-                "enable.auto.commit": False,
-                "auto.offset.reset": "earliest",
-            }
-        )
+        config = {
+            "bootstrap.servers": self.redpanda.brokers(),
+            "group.id": "test-consumer-group",
+            "enable.auto.commit": False,
+            "auto.offset.reset": "earliest",
+        }
 
         # Commit random offsets for the topic partition
-        try:
+        with ck_consumer(config) as consumer:
             partition = 0
             for _ in range(100):
                 # Generate a random offset between 0 and 1000
@@ -60,8 +59,6 @@ class ConsumerOffsetsCacheTest(RedpandaTest):
                     offsets=[TopicPartition(topic, partition, offset=random_offset)],
                     asynchronous=False,
                 )
-        finally:
-            consumer.close()
 
     @cluster(num_nodes=3)
     def test_enabling_consumer_offsets_cache_test(self):

--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -21,6 +21,7 @@ from ducktape.mark import matrix
 from ducktape.tests.test import TestContext
 from ducktape.utils.util import wait_until
 
+from rptest.clients.python_librdkafka import ck_consumer as ck_consumer_cm
 from rptest.clients.rpk import RpkGroup, RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import (
@@ -180,22 +181,18 @@ class DataMigrationsApiTest(DataMigrationTestMixin):
         if group is None:
             self.last_consumer_id += 1
             group = f"group-{self.last_consumer_id}"
-        consumer = ck.Consumer(
-            {
-                "debug": "all",
-                "log_level": 7,
-                "logger": self.logger,
-                "session.timeout.ms": 6000,
-                "group.id": group,
-                "bootstrap.servers": self.redpanda.brokers(),
-                "auto.offset.reset": "earliest",
-                "isolation.level": "read_committed",
-            }
-        )
-        try:
+        config = {
+            "debug": "all",
+            "log_level": 7,
+            "logger": self.logger,
+            "session.timeout.ms": 6000,
+            "group.id": group,
+            "bootstrap.servers": self.redpanda.brokers(),
+            "auto.offset.reset": "earliest",
+            "isolation.level": "read_committed",
+        }
+        with ck_consumer_cm(config) as consumer:
             yield consumer
-        finally:
-            consumer.close()
 
     @contextmanager
     def flaky_admin_cm(self, other_cm):

--- a/tests/rptest/tests/isolated_decommissioned_node_test.py
+++ b/tests/rptest/tests/isolated_decommissioned_node_test.py
@@ -11,10 +11,11 @@ from rptest.services.cluster import cluster
 from rptest.services.admin import Admin
 from ducktape.cluster.cluster import ClusterNode
 from ducktape.utils.util import wait_until
+from rptest.clients.python_librdkafka import ck_consumer
 from rptest.clients.types import TopicSpec
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.util import firewall_blocked
-from confluent_kafka import KafkaError, admin, Producer, KafkaException, Consumer
+from confluent_kafka import KafkaError, admin, Producer, KafkaException
 from ducktape.mark import parametrize
 
 import confluent_kafka as ck
@@ -59,36 +60,32 @@ class IsolatedDecommissionedNodeTest(PreallocNodesTest):
         max_retries = 5
         retries_count = 0
 
-        consumer = Consumer(
-            {
-                "bootstrap.servers": self.redpanda.brokers(),
-                "group.id": f"consumer-{uuid.uuid4()}",
-                "auto.offset.reset": "earliest",
-                "isolation.level": "read_committed",
-            }
-        )
+        config = {
+            "bootstrap.servers": self.redpanda.brokers(),
+            "group.id": f"consumer-{uuid.uuid4()}",
+            "auto.offset.reset": "earliest",
+            "isolation.level": "read_committed",
+        }
+        with ck_consumer(config) as consumer:
+            consumer.subscribe([topic_name])
+            num_consumed = 0
+            prev_rec = bytes("0", "UTF-8")
 
-        consumer.subscribe([topic_name])
-        num_consumed = 0
-        prev_rec = bytes("0", "UTF-8")
+            while num_consumed != self.max_records and retries_count < max_retries:
+                max_consume_records = 10
+                timeout = 10
+                records = consumer.consume(max_consume_records, timeout)
 
-        while num_consumed != self.max_records and retries_count < max_retries:
-            max_consume_records = 10
-            timeout = 10
-            records = consumer.consume(max_consume_records, timeout)
+                if len(records) == 0:
+                    retries_count += 1
+                    time.sleep(3)
 
-            if len(records) == 0:
-                retries_count += 1
-                time.sleep(3)
+                for record in records:
+                    retries_count = 0
+                    assert prev_rec == record.key(), f"{prev_rec}, {record.key()}"
+                    prev_rec = bytes(str(int(prev_rec) + 1), "UTF-8")
 
-            for record in records:
-                retries_count = 0
-                assert prev_rec == record.key(), f"{prev_rec}, {record.key()}"
-                prev_rec = bytes(str(int(prev_rec) + 1), "UTF-8")
-
-            num_consumed += len(records)
-
-        consumer.close()
+                num_consumed += len(records)
 
         assert num_consumed == self.max_records, (
             f"Can not consume all data. Consumed: {num_consumed}, expected: {self.max_records}"

--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -103,7 +103,8 @@ class RaftAvailabilityTest(RedpandaTest):
     def _is_available(self, timeout_s=5):
         try:
             # Should fail
-            self.ping_pong().ping_pong(timeout_s)
+            with self.ping_pong() as pp:
+                pp.ping_pong(timeout_s)
         except Exception:
             return False
         else:
@@ -112,14 +113,16 @@ class RaftAvailabilityTest(RedpandaTest):
     def _expect_unavailable(self):
         try:
             # Should fail
-            self.ping_pong().ping_pong()
+            with self.ping_pong() as pp:
+                pp.ping_pong()
         except Exception:
             self.logger.exception("Cluster is unavailable as expected")
         else:
             assert False, "ping_pong should not have worked "
 
     def _expect_available(self):
-        self.ping_pong().ping_pong()
+        with self.ping_pong() as pp:
+            pp.ping_pong()
         self.logger.info("Cluster is available as expected")
 
     def _transfer_leadership(
@@ -288,7 +291,8 @@ class RaftAvailabilityTest(RedpandaTest):
         # Find which node is the leader
         initial_leader_id, replicas = self._wait_for_leader()
 
-        self.ping_pong().ping_pong()
+        with self.ping_pong() as pp:
+            pp.ping_pong()
 
         leader_node = self.redpanda.get_node_by_id(initial_leader_id)
         other_node_id = (set(replicas) - {initial_leader_id}).pop()
@@ -581,10 +585,10 @@ class RaftAvailabilityTest(RedpandaTest):
             )
 
             # expect messages to be produced and consumed without a timeout
-            connection = self.ping_pong()
-            connection.ping_pong(timeout_s=10, retries=10)
-            for i in range(0, 127):
-                connection.ping_pong()
+            with self.ping_pong() as connection:
+                connection.ping_pong(timeout_s=10, retries=10)
+                for i in range(0, 127):
+                    connection.ping_pong()
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_id_allocator_leader_isolation(self):
@@ -618,10 +622,10 @@ class RaftAvailabilityTest(RedpandaTest):
             )
 
             # expect messages to be produced and consumed without a timeout
-            connection = self.ping_pong()
-            connection.ping_pong(timeout_s=10, retries=10)
-            for i in range(0, 127):
-                connection.ping_pong()
+            with self.ping_pong() as connection:
+                connection.ping_pong(timeout_s=10, retries=10)
+                for i in range(0, 127):
+                    connection.ping_pong()
 
     @cluster(num_nodes=3)
     def test_initial_leader_stability(self):
@@ -700,7 +704,7 @@ class RaftAvailabilityTest(RedpandaTest):
                     check=lambda node_id: node_id != controller_id,
                 )
 
-        connection = self.ping_pong()
-        connection.ping_pong(timeout_s=10, retries=10)
-        for i in range(0, 127):
-            connection.ping_pong()
+        with self.ping_pong() as connection:
+            connection.ping_pong(timeout_s=10, retries=10)
+            for i in range(0, 127):
+                connection.ping_pong()

--- a/tests/rptest/transactions/transactions_test.py
+++ b/tests/rptest/transactions/transactions_test.py
@@ -19,6 +19,7 @@ from ducktape.utils.util import wait_until
 
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.offline_log_viewer import OfflineLogViewer
+from rptest.clients.python_librdkafka import ck_consumer
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
@@ -176,79 +177,76 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
             }
         )
 
-        consumer1 = ck.Consumer(
-            {
-                "bootstrap.servers": self.redpanda.brokers(),
-                "group.id": "test",
-                "auto.offset.reset": "earliest",
-                "enable.auto.commit": False,
-            }
-        )
+        config1 = {
+            "bootstrap.servers": self.redpanda.brokers(),
+            "group.id": "test",
+            "auto.offset.reset": "earliest",
+            "enable.auto.commit": False,
+        }
+        with ck_consumer(config1) as consumer1:
+            producer.init_transactions()
 
-        producer.init_transactions()
+            consumer1.subscribe([self.input_t])
 
-        consumer1.subscribe([self.input_t])
+            num_consumed_records = 0
+            consumed_from_input_topic = []
+            while num_consumed_records != self.max_records:
+                # Imagine that consume got broken, we read the same record twice and overshoot the condition
+                assert num_consumed_records < self.max_records
 
-        num_consumed_records = 0
-        consumed_from_input_topic = []
-        while num_consumed_records != self.max_records:
-            # Imagine that consume got broken, we read the same record twice and overshoot the condition
-            assert num_consumed_records < self.max_records
+                records = self.consume(consumer1)
 
-            records = self.consume(consumer1)
+                producer.begin_transaction()
 
-            producer.begin_transaction()
+                for record in records:
+                    assert record.error() is None
+                    consumed_from_input_topic.append(record)
+                    producer.produce(
+                        self.output_t.name,
+                        record.value(),
+                        record.key(),
+                        on_delivery=self.on_delivery,
+                    )
 
-            for record in records:
-                assert record.error() is None
-                consumed_from_input_topic.append(record)
-                producer.produce(
-                    self.output_t.name,
-                    record.value(),
-                    record.key(),
-                    on_delivery=self.on_delivery,
+                producer.send_offsets_to_transaction(
+                    consumer1.position(consumer1.assignment()),
+                    consumer1.consumer_group_metadata(),
                 )
 
-            producer.send_offsets_to_transaction(
-                consumer1.position(consumer1.assignment()),
-                consumer1.consumer_group_metadata(),
-            )
+                producer.commit_transaction()
 
-            producer.commit_transaction()
+                num_consumed_records += len(records)
 
-            num_consumed_records += len(records)
-
-        producer.flush()
-        consumer1.close()
+            producer.flush()
         assert len(consumed_from_input_topic) == self.max_records
 
-        consumer2 = ck.Consumer(
-            {
-                "group.id": "testtest",
-                "bootstrap.servers": self.redpanda.brokers(),
-                "auto.offset.reset": "earliest",
-            }
-        )
-        consumer2.subscribe([self.output_t])
+        config2 = {
+            "group.id": "testtest",
+            "bootstrap.servers": self.redpanda.brokers(),
+            "auto.offset.reset": "earliest",
+        }
+        with ck_consumer(config2) as consumer2:
+            consumer2.subscribe([self.output_t])
 
-        index_from_input = 0
+            index_from_input = 0
 
-        while index_from_input < self.max_records:
-            records = self.consume(consumer2)
+            while index_from_input < self.max_records:
+                records = self.consume(consumer2)
 
-            for record in records:
-                assert (
-                    record.key() == consumed_from_input_topic[index_from_input].key()
-                ), (
-                    f"Records key does not match from input {consumed_from_input_topic[index_from_input].key()}, from output {record.key()}"
-                )
-                assert (
-                    record.value()
-                    == consumed_from_input_topic[index_from_input].value()
-                ), (
-                    f"Records value does not match from input {consumed_from_input_topic[index_from_input].value()}, from output {record.value()}"
-                )
-                index_from_input += 1
+                for record in records:
+                    assert (
+                        record.key()
+                        == consumed_from_input_topic[index_from_input].key()
+                    ), (
+                        f"Records key does not match from input {consumed_from_input_topic[index_from_input].key()}, from output {record.key()}"
+                    )
+                    assert (
+                        record.value()
+                        == consumed_from_input_topic[index_from_input].value()
+                    ), (
+                        f"Records value does not match from input {consumed_from_input_topic[index_from_input].value()}, from output {record.value()}"
+                    )
+                    index_from_input += 1
 
         log_viewer = OfflineLogViewer(self.redpanda)
         for node in self.redpanda.started_nodes():
@@ -617,15 +615,13 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
         # Issue a commit
         producer.commit_transaction()
 
-        consumer = ck.Consumer(
-            {
-                "bootstrap.servers": self.redpanda.brokers(),
-                "group.id": "test",
-                "auto.offset.reset": "earliest",
-                "enable.auto.commit": False,
-            }
-        )
-        try:
+        config = {
+            "bootstrap.servers": self.redpanda.brokers(),
+            "group.id": "test",
+            "auto.offset.reset": "earliest",
+            "enable.auto.commit": False,
+        }
+        with ck_consumer(config) as consumer:
             consumer.subscribe([self.input_t])
             records = []
             while len(records) != count:
@@ -633,8 +629,6 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
             assert len(records) == count, f"Not all records consumed, expected {count}"
             keys = set([int(r.key()) for r in records])
             assert all(i in keys for i in range(0, count)), f"Missing records {keys}"
-        finally:
-            consumer.close()
 
     @cluster(num_nodes=3)
     def graceful_leadership_transfer_tx_coordinator_test(self):
@@ -715,15 +709,13 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
             producers[p].commit_transaction()
 
         # Verify that all the records are ingested correctly.
-        consumer = ck.Consumer(
-            {
-                "bootstrap.servers": self.redpanda.brokers(),
-                "group.id": "test",
-                "auto.offset.reset": "earliest",
-                "enable.auto.commit": False,
-            }
-        )
-        try:
+        config = {
+            "bootstrap.servers": self.redpanda.brokers(),
+            "group.id": "test",
+            "auto.offset.reset": "earliest",
+            "enable.auto.commit": False,
+        }
+        with ck_consumer(config) as consumer:
             consumer.subscribe([self.input_t])
             records = []
             while len(records) != count:
@@ -731,8 +723,6 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
             assert len(records) == count, f"Not all records consumed, expected {count}"
             keys = set([int(r.key()) for r in records])
             assert all(i in keys for i in range(0, count)), f"Missing records {keys}"
-        finally:
-            consumer.close()
 
     @cluster(num_nodes=3)
     def delete_topic_with_active_txns_test(self):

--- a/tests/rptest/transactions/tx_streams_test.py
+++ b/tests/rptest/transactions/tx_streams_test.py
@@ -12,6 +12,7 @@ import random
 import confluent_kafka as ck
 
 from rptest.clients.offline_log_viewer import OfflineLogViewer
+from rptest.clients.python_librdkafka import ck_consumer
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
@@ -70,34 +71,34 @@ class TransactionsStreamsTest(RedpandaTest, TransactionsMixin):
             "auto.offset.reset": "earliest",
             "enable.auto.commit": False,
         }
-        consumer = ck.Consumer(consumer_conf)
-        consumer.subscribe([self.input_t.name])
+        with ck_consumer(consumer_conf) as consumer:
+            consumer.subscribe([self.input_t.name])
 
-        producer.init_transactions()
-        consumed = 0
-        while consumed != input_records:
-            records = self.consume(consumer)
-            producer.begin_transaction()
-            for record in records:
-                producer.produce(
-                    self.output_t.name,
-                    record.value(),
-                    record.key(),
-                    on_delivery=self.on_delivery,
+            producer.init_transactions()
+            consumed = 0
+            while consumed != input_records:
+                records = self.consume(consumer)
+                producer.begin_transaction()
+                for record in records:
+                    producer.produce(
+                        self.output_t.name,
+                        record.value(),
+                        record.key(),
+                        on_delivery=self.on_delivery,
+                    )
+
+                producer.send_offsets_to_transaction(
+                    consumer.position(consumer.assignment()),
+                    consumer.consumer_group_metadata(),
                 )
 
-            producer.send_offsets_to_transaction(
-                consumer.position(consumer.assignment()),
-                consumer.consumer_group_metadata(),
-            )
+                producer.flush()
 
-            producer.flush()
-
-            if random.randint(0, 9) < 5:
-                producer.commit_transaction()
-            else:
-                producer.abort_transaction()
-            consumed += len(records)
+                if random.randint(0, 9) < 5:
+                    producer.commit_transaction()
+                else:
+                    producer.abort_transaction()
+                consumed += len(records)
 
         log_viewer = OfflineLogViewer(self.redpanda)
         for node in self.redpanda.started_nodes():


### PR DESCRIPTION
## Summary

Test-only change. Ducktape tests construct `confluent_kafka.Consumer`s and frequently leave them to be reclaimed by the garbage collector. An unclosed consumer's C destructor (`rd_kafka_destroy`) can deadlock when it runs from a GC finalizer while a partition leader is unreachable, which wedges the whole interpreter and escalates a per-test timeout into a runner-unresponsive whole-shard kill. See CORE-16410 (and the upstream librdkafka rk_lock/toppar lock-order inversion, confluentinc/librdkafka#5476) for the full root cause.

This makes the affected consumers close deterministically while idle, which takes the orderly consumer-close path and avoids the deadlock window.

Three commits:

1. **Add a shared `ck_consumer` context manager** in `rptest.clients.python_librdkafka` (moved out of `DataMigrationsApiTest`), so any test can construct a Consumer that is guaranteed to be closed on exit.
2. **Convert direct `Consumer(...)` sites** that build a config dict over to `ck_consumer`. This also fixes several sites that leaked on exception or never closed at all (`transactions_test` consumer2, `tx_streams`, etc.). Sites that do not fit the plain helper (consumer lists needing an `ExitStack`, a `sasl_consumer` helper, a `DeserializingConsumer`) are left as-is.
3. **Make `PingPong`/`LogReader` context managers** with a real `close()`. `LogReader` held a Consumer for its lifetime and never closed it; the `stream` generator forms a reference cycle that makes it cyclic-GC-only. `raft_availability_test` now uses `with self.ping_pong() as ...:` at every call site. This is the test that reproduces CORE-16410 (it isolates a partition leader, the exact unreachable-broker condition the deadlock needs).

## Validation

`RaftAvailabilityTest.test_id_allocator_leader_isolation` is the test CORE-16410 originally hung in. Re-run repeatedly on debug/arm64 with `dt-repeat=500`:

- **Before the fix:** CORE-16410 measured ~2 hangs per 1000 iterations (~0.2%, roughly 1 in 500). Each hang wedged the interpreter during the debug-only post-test metrics scrape and killed the entire ducktape shard (exit 201), taking all sibling test results down with it.
- **After the fix:** both validation builds passed, with every `ducktape-build-debug-clang-arm64` job and `test-results` green and no shard kill: build [85257](https://buildkite.com/redpanda/redpanda/builds/85257) (`/ci-repeat 2`, 2 x 500 = 1000 iterations) and build [85275](https://buildkite.com/redpanda/redpanda/builds/85275) (`/ci-repeat 4`, 4 x 500 = 2000 iterations).

## Backports Required

- [x] none - test-only

## Release Notes

- none
