### PR TITLE
`rptest`: enable cloud-mode compaction shadow-linking test

### DIFF
--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -2395,9 +2395,12 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
     )
     @matrix(storage_mode=ALL_STORAGE_MODES)
     def test_replication_with_compaction(self, storage_mode):
-        if storage_mode != TopicSpec.STORAGE_MODE_LOCAL:
+        if storage_mode not in (
+            TopicSpec.STORAGE_MODE_LOCAL,
+            TopicSpec.STORAGE_MODE_CLOUD,
+        ):
             # Compaction on shadow topics is not yet supported with
-            # tiered / cloud / tiered_cloud storage modes.
+            # tiered / tiered_cloud storage modes.
             _ = self.preallocated_nodes
             self.logger.info(
                 f"Skipping compaction test for storage_mode={storage_mode}"

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -544,6 +544,13 @@ class ShadowLinkTestBase(PreallocNodesTest):
             kwargs["extra_rp_conf"].update(
                 {
                     "enable_cluster_metadata_upload_loop": False,
+                    # Background compaction for cloud topics runs on this
+                    # interval (default 30s). Tests that wait ~30s for
+                    # compaction / tombstone removal to make progress race
+                    # with the default tick; shrink it so removal lands well
+                    # within the wait window. The shadow topic is compacted on
+                    # this (target) cluster.
+                    "cloud_topics_compaction_interval_ms": 1000,
                 }
             )
 
@@ -559,6 +566,18 @@ class ShadowLinkTestBase(PreallocNodesTest):
                 sec_extra.update(
                     {
                         "enable_cluster_metadata_upload_loop": False,
+                        # Produce acks block until the L0 upload completes,
+                        # so the default 250ms upload interval caps produce
+                        # throughput at ~1 msg/interval and makes these
+                        # workloads time out. The producer writes to this
+                        # (source) cluster, so shrink it here for faster
+                        # test runs.
+                        "cloud_topics_produce_upload_interval": 25,
+                        # The final compaction-consistency check also expects
+                        # the source to have removed its tombstones, so shrink
+                        # the compaction tick here too (see the primary cluster
+                        # config above).
+                        "cloud_topics_compaction_interval_ms": 1000,
                     }
                 )
                 sec_kwargs["extra_rp_conf"] = sec_extra


### PR DESCRIPTION
Enable `test_replication_with_compaction` for the `cloud` storage mode
in addition to `local`. The test was previously skipped for all
non-local storage modes.

In cloud topics, produce acks block until the L0 upload to object
storage completes. The upload is driven by a periodic timer
(`cloud_topics_produce_upload_interval`, default 250ms), so produce
throughput was effectively capped at ~1 batch per interval — slow
enough that the compaction workload timed out. To make the test
complete in time, the upload interval is lowered to 25ms on the source
cluster (where the producer writes); the target keeps the default.

`tiered` and `tiered_cloud` modes remain skipped (compaction on shadow
topics is not yet supported there).

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
