### PR TITLE
metrics: honor disable_metrics flags in all_metrics_groups

### DIFF
--- a/src/v/metrics/metrics.cc
+++ b/src/v/metrics/metrics.cc
@@ -73,8 +73,13 @@ internal_metric_groups& internal_metric_groups::add_group(
 all_metrics_groups& all_metrics_groups::add_group(
   const ss::metrics::group_name_type& name,
   const std::initializer_list<ss::metrics::metric_definition>& l) {
-    _internal.add_group(name, l);
-    _public.add_group(name, l);
+    const auto& cfg = config::shard_local_cfg();
+    if (!cfg.disable_metrics()) {
+        _internal.add_group(name, l);
+    }
+    if (!cfg.disable_public_metrics()) {
+        _public.add_group(name, l);
+    }
     return *this;
 }
 

--- a/src/v/metrics/metrics.cc
+++ b/src/v/metrics/metrics.cc
@@ -70,4 +70,12 @@ internal_metric_groups& internal_metric_groups::add_group(
     return *this;
 }
 
+all_metrics_groups& all_metrics_groups::add_group(
+  const ss::metrics::group_name_type& name,
+  const std::initializer_list<ss::metrics::metric_definition>& l) {
+    _internal.add_group(name, l);
+    _public.add_group(name, l);
+    return *this;
+}
+
 } // namespace metrics

--- a/src/v/metrics/metrics.h
+++ b/src/v/metrics/metrics.h
@@ -218,7 +218,10 @@ public:
      * @brief Adds the given metric group to public and internal metrics.
      *
      * The behavior is same as ss::metrics::metric_groups::add_group but for
-     * both metric endpoints.
+     * both metric endpoints. The `disable_metrics` and `disable_public_metrics`
+     * config flags are honored, so callers do not need to check them
+     * themselves: if the internal endpoint is disabled the group is not
+     * registered on `_internal`, and likewise for the public endpoint.
      */
     all_metrics_groups& add_group(
       const seastar::metrics::group_name_type& name,

--- a/src/v/metrics/metrics.h
+++ b/src/v/metrics/metrics.h
@@ -222,11 +222,7 @@ public:
      */
     all_metrics_groups& add_group(
       const seastar::metrics::group_name_type& name,
-      const std::initializer_list<seastar::metrics::metric_definition>& l) {
-        _internal.add_group(name, l);
-        _public.add_group(name, l);
-        return *this;
-    };
+      const std::initializer_list<seastar::metrics::metric_definition>& l);
 };
 
 } // namespace metrics


### PR DESCRIPTION
The `metrics::all_metrics_groups` wrapper registers a metric group on
both the internal and public metrics endpoints in a single call. Until
now it did so unconditionally, ignoring the `disable_metrics` and
`disable_public_metrics` config flags. Callers that wanted the flags
respected had to check them by hand, and some did not - for example
`available_memory` guarded only `disable_public_metrics`, so its
internal metric was still registered even when `disable_metrics` was
set.

This PR makes the wrapper honor both flags itself:

- `metrics: move all_metrics_groups::add_group out of line` moves the
  definition into `metrics.cc` (no functional change) so the follow-up
  can pull in `configuration.h` without adding it to the header.
- `metrics: honor disable_metrics flags in all_metrics_groups` skips
  registering on `_internal` when `disable_metrics` is set and on
  `_public` when `disable_public_metrics` is set.

With this in place, callers using the wrapper no longer need to check
the flags themselves, and the flags take effect uniformly for every
group registered through it.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none