### PR TITLE
[v25.3.x] rpk: add high disk usage report on 'cluster health'

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.65.0
 	github.com/redpanda-data/common-go/proto v0.0.0-20250820120127-9b518fca5ecf
-	github.com/redpanda-data/common-go/rpadmin v0.2.1
+	github.com/redpanda-data/common-go/rpadmin v0.2.2
 	github.com/redpanda-data/common-go/rpsr v0.1.2
 	github.com/redpanda-data/protoc-gen-go-mcp v0.0.0-20250812151819-7e5d5fef8241
 	github.com/rs/xid v1.6.0

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -253,8 +253,8 @@ github.com/redpanda-data/common-go/net v0.1.0 h1:JnJioRJuL961r1QXiJQ1tW9+yEaJfu8
 github.com/redpanda-data/common-go/net v0.1.0/go.mod h1:iOdNkjxM7a1T8F3cYHTaKIPFCHzzp/ia6TN+Z+7Tt5w=
 github.com/redpanda-data/common-go/proto v0.0.0-20250820120127-9b518fca5ecf h1:Oe0Sc3+/37Xgdpze7klkWyvB6eAt/nuUhrn93Rd4ESA=
 github.com/redpanda-data/common-go/proto v0.0.0-20250820120127-9b518fca5ecf/go.mod h1:GMoRcdMz6CIpr+8vKrSJvr8fJDlojETRV45BD6A0DvU=
-github.com/redpanda-data/common-go/rpadmin v0.2.1 h1:N3GUI3d1h661Nta6Jc4MyaVKWxRIg28yO4MG912gCXQ=
-github.com/redpanda-data/common-go/rpadmin v0.2.1/go.mod h1:qmu76v7RRKgEXLS3UXxZ8KDpObtSNq6RinOIejJNWzw=
+github.com/redpanda-data/common-go/rpadmin v0.2.2 h1:xD31YJBkUs9Z/KkZUIkVRHKk/EQ6MrPAvgiFUVcFFu0=
+github.com/redpanda-data/common-go/rpadmin v0.2.2/go.mod h1:qmu76v7RRKgEXLS3UXxZ8KDpObtSNq6RinOIejJNWzw=
 github.com/redpanda-data/common-go/rpsr v0.1.2 h1:DThUeyfBH8fkL9WoP1sEbRhT2NVV22zmsTpcCtzfusQ=
 github.com/redpanda-data/common-go/rpsr v0.1.2/go.mod h1:2j2416onosg5FKaKz52NooRE+q/9EJqQn0kyTcTXWHc=
 github.com/redpanda-data/go-avro/v2 v2.0.0-20240405204525-77b1144dc525 h1:vskZrV6q8W8flL0Ud23AJUYAd8ZgTadO45+loFnG2G0=

--- a/src/go/rpk/pkg/cli/cluster/health.go
+++ b/src/go/rpk/pkg/cli/cluster/health.go
@@ -37,6 +37,7 @@ type healthResponse struct {
 	LeaderlessCount           *int     `json:"leaderless_count,omitempty" yaml:"leaderless_count,omitempty"`
 	UnderReplicatedCount      *int     `json:"under_replicated_count,omitempty" yaml:"under_replicated_count,omitempty"`
 	UnderReplicatedPartitions []string `json:"under_replicated_partitions" yaml:"under_replicated_partitions"`
+	HighDiskUsageNodes        []int    `json:"high_disk_usage_nodes" yaml:"high_disk_usage_nodes"`
 }
 
 func newHealthOverviewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
@@ -148,6 +149,7 @@ func buildHealthResponses(hov *rpadmin.ClusterHealthOverview, clusterUUID *strin
 		LeaderlessCount:           hov.LeaderlessCount,
 		UnderReplicatedCount:      hov.UnderReplicatedCount,
 		UnderReplicatedPartitions: hov.UnderReplicatedPartitions,
+		HighDiskUsageNodes:        hov.HighDiskUsageNodes,
 	}
 }
 
@@ -182,6 +184,7 @@ func printHealthOverview(hr healthResponse) {
 	if hr.NodesInRecoveryMode != nil {
 		tw.Print("Nodes in recovery mode:", hr.NodesInRecoveryMode)
 	}
+	tw.Print("Nodes with high disk usage:", hr.HighDiskUsageNodes)
 	tw.Print(lp, hr.LeaderlessPartitions)
 	tw.Print(urp, hr.UnderReplicatedPartitions)
 	if hr.ClusterUUID != nil {


### PR DESCRIPTION
This was introduced in 5b5286f and already
released in 25.3.5

(cherry picked from commit 9b48d17457608de1b235f57b0a8a3df09ab16b22)

Fixes #29567

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes


* none
