### PR TITLE
[CORE-16287] cloud_io/cache: tolerate already-removed file during trim

### DIFF
--- a/src/v/cloud_io/cache_service.cc
+++ b/src/v/cloud_io/cache_service.cc
@@ -168,6 +168,14 @@ cache::delete_file_and_empty_parents(const std::string_view& key) {
             if (e.code() == std::errc::directory_not_empty) {
                 // we stop when we find a non-empty directory
                 co_return deletions > 1;
+            } else if (e.code() == std::errc::no_such_file_or_directory) {
+                // The path is already gone. This is expected for hot chunks
+                // that get concurrently evicted and re-hydrated: the trimmer
+                // can select a chunk that another path (or an earlier trim)
+                // has already removed. The desired end state (absent) is
+                // already satisfied, so treat it as removed and keep cleaning
+                // up empty parents rather than throwing, which would surface
+                // a spurious "trim: couldn't delete" error.
             } else {
                 throw;
             }

--- a/src/v/cloud_io/tests/cache_test.cc
+++ b/src/v/cloud_io/tests/cache_test.cc
@@ -242,6 +242,32 @@ FIXTURE_TEST(eviction_cleans_directory, cache_test_fixture) {
     BOOST_CHECK(ss::file_exists(CACHE_DIR.native()).get());
 }
 
+// Regression test for CORE-16287: a hot chunk can be concurrently evicted and
+// re-hydrated, so the trimmer may try to delete a chunk file that another path
+// has already removed. delete_file_and_empty_parents must treat the
+// already-absent file as removed and keep cleaning up empty parents, instead of
+// throwing (which surfaced a spurious "trim: couldn't delete ... No such file
+// or directory" ERROR and failed tests via the bad-log-lines check).
+FIXTURE_TEST(delete_already_removed_file_is_tolerated, cache_test_fixture) {
+    auto data_string = create_data_string('a', 1_MiB);
+    const std::filesystem::path key{"unique_prefix/test_topic/seg_chunks/0"};
+    put_into_cache(data_string, key);
+
+    // Simulate a concurrent deleter removing the chunk file out of band.
+    ss::remove_file((CACHE_DIR / key).native()).get();
+    BOOST_REQUIRE(!ss::file_exists((CACHE_DIR / key).native()).get());
+
+    // Deleting the now-absent file must not throw, and must still clean up the
+    // empty parent directories left behind.
+    BOOST_CHECK_NO_THROW(
+      delete_file_and_empty_parents((CACHE_DIR / key).native()));
+
+    BOOST_CHECK(!ss::file_exists(
+                   (CACHE_DIR / "unique_prefix/test_topic/seg_chunks").native())
+                   .get());
+    BOOST_CHECK(ss::file_exists(CACHE_DIR.native()).get());
+}
+
 FIXTURE_TEST(invalidate_outside_cache_dir_throws, cache_test_fixture) {
     // make sure the cache directory is empty to get reliable results
     ss::recursive_touch_directory(CACHE_DIR.native()).get();

--- a/src/v/cloud_io/tests/cache_test_fixture.h
+++ b/src/v/cloud_io/tests/cache_test_fixture.h
@@ -130,6 +130,16 @@ public:
         sharded_cache.local().trim_carryover(size_limit, object_limit).get();
     }
 
+    bool delete_file_and_empty_parents(std::string_view path) {
+        return sharded_cache
+          .invoke_on(
+            ss::shard_id{0},
+            [path](cloud_io::cache& c) {
+                return c.delete_file_and_empty_parents(path);
+            })
+          .get();
+    }
+
     void set_trim_thresholds(
       double size_limit_percent,
       double object_limit_percent,


### PR DESCRIPTION
The cache trimmer can select a chunk file that has already been removed by another path (a hot chunk that was concurrently evicted and re-hydrated). delete_file_and_empty_parents only tolerated directory_not_empty and rethrew no_such_file_or_directory, which propagated to the generic catch in remove_segment_full and logged "trim: couldn't delete ...: No such file or directory" at ERROR.

In tiered-storage tests that error trips the bad-log-lines check and fails the run (e.g. TieredStorageIoStressTest.test_io_stress with small segments). The already-absent file is the desired end state, so treat it as removed and continue cleaning up empty parents, matching the existing ENOENT handling for the sibling tx/index deletions.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
* none


