### PR TITLE
[v25.2.x] iceberg: purge data files when dropping table with purge=true

### DIFF
--- a/src/v/iceberg/filesystem_catalog.cc
+++ b/src/v/iceberg/filesystem_catalog.cc
@@ -102,23 +102,42 @@ filesystem_catalog::load_table(const table_identifier& table_ident) {
 }
 
 ss::future<checked<void, catalog::errc>>
-filesystem_catalog::drop_table(const table_identifier& table_id, bool) {
+filesystem_catalog::drop_table(const table_identifier& table_id, bool purge) {
     // Check that the table exists.
     auto current_tmeta = co_await read_table_meta(table_id);
     if (current_tmeta.has_error()) {
         co_return current_tmeta.error();
     }
 
-    // delete metadata
-    auto delete_res = co_await table_io_.delete_all_metadata(
-      metadata_location_path{
-        fmt::format("{}/metadata/", table_location(table_id))});
-    if (delete_res.has_error()) {
-        vlog(log.warn, "dropping table {} failed", table_id);
-        co_return to_catalog_errc(delete_res.error());
+    // When purging, delete everything under the table location (metadata,
+    // manifests, manifest lists, and data files). Otherwise only remove
+    // the catalog metadata so data files are left intact.
+    if (purge) {
+        auto res = co_await table_io_.delete_all_table_files(
+          table_location_path{fmt::format("{}/", table_location(table_id))});
+        if (res.has_error()) {
+            vlog(
+              log.warn,
+              "dropping table {} failed (purge={}, errc={})",
+              table_id,
+              purge,
+              static_cast<int>(res.error()));
+            co_return to_catalog_errc(res.error());
+        }
+    } else {
+        auto res = co_await table_io_.delete_all_metadata(
+          metadata_location_path{
+            fmt::format("{}/metadata/", table_location(table_id))});
+        if (res.has_error()) {
+            vlog(
+              log.warn,
+              "dropping table {} failed (purge={}, errc={})",
+              table_id,
+              purge,
+              static_cast<int>(res.error()));
+            co_return to_catalog_errc(res.error());
+        }
     }
-
-    // TODO: support purging data
 
     co_return outcome::success();
 }

--- a/src/v/iceberg/table_io.cc
+++ b/src/v/iceberg/table_io.cc
@@ -64,7 +64,7 @@ table_io::version_hint_exists(const version_hint_path& path) {
 }
 
 ss::future<checked<std::nullopt_t, metadata_io::errc>>
-table_io::delete_all_metadata(const metadata_location_path& path) {
+table_io::delete_objects_with_prefix(const std::filesystem::path& prefix) {
     retry_chain_node root_rcn(
       io_.as(),
       ss::lowres_clock::duration{30s},
@@ -76,7 +76,7 @@ table_io::delete_all_metadata(const metadata_location_path& path) {
                            const std::exception_ptr& ex, std::string_view ctx) {
         auto level = ssx::is_shutdown_exception(ex) ? ss::log_level::debug
                                                     : ss::log_level::warn;
-        vlogl(ctxlog, level, "exception while {} in {}: {}", ctx, path, ex);
+        vlogl(ctxlog, level, "exception while {} in {}: {}", ctx, prefix, ex);
     };
 
     // deleting may require several iterations if list_objects doesn't return
@@ -84,7 +84,7 @@ table_io::delete_all_metadata(const metadata_location_path& path) {
     while (true) {
         retry_chain_node list_rcn(10ms, retry_strategy::backoff, &root_rcn);
         auto list_fut = co_await ss::coroutine::as_future(io_.list_objects(
-          bucket_, list_rcn, cloud_storage_clients::object_key{path}));
+          bucket_, list_rcn, cloud_storage_clients::object_key{prefix}));
         if (list_fut.failed()) {
             log_exception(list_fut.get_exception(), "listing objects");
             co_return errc::failed;
@@ -98,7 +98,7 @@ table_io::delete_all_metadata(const metadata_location_path& path) {
         chunked_vector<cloud_storage_clients::object_key> to_delete;
         to_delete.reserve(list_res.value().contents.size());
         for (auto& obj : list_res.value().contents) {
-            vlog(ctxlog.debug, "deleting metadata object {}", obj.key);
+            vlog(ctxlog.debug, "deleting object {}", obj.key);
             to_delete.emplace_back(std::move(obj.key));
         }
 
@@ -134,6 +134,16 @@ table_io::delete_all_metadata(const metadata_location_path& path) {
     }
 
     co_return std::nullopt;
+}
+
+ss::future<checked<std::nullopt_t, metadata_io::errc>>
+table_io::delete_all_metadata(const metadata_location_path& path) {
+    return delete_objects_with_prefix(path());
+}
+
+ss::future<checked<std::nullopt_t, metadata_io::errc>>
+table_io::delete_all_table_files(const table_location_path& path) {
+    return delete_objects_with_prefix(path());
 }
 
 } // namespace iceberg

--- a/src/v/iceberg/table_io.h
+++ b/src/v/iceberg/table_io.h
@@ -17,6 +17,9 @@
 
 namespace iceberg {
 
+// /<table-location>/
+using table_location_path
+  = named_type<std::filesystem::path, struct table_location_path_tag>;
 // /<table-location>/metadata/
 using metadata_location_path
   = named_type<std::filesystem::path, struct metadata_location_path_tag>;
@@ -49,6 +52,13 @@ public:
 
     ss::future<checked<std::nullopt_t, metadata_io::errc>>
     delete_all_metadata(const metadata_location_path& path);
+
+    ss::future<checked<std::nullopt_t, metadata_io::errc>>
+    delete_all_table_files(const table_location_path& path);
+
+private:
+    ss::future<checked<std::nullopt_t, metadata_io::errc>>
+    delete_objects_with_prefix(const std::filesystem::path& prefix);
 };
 
 } // namespace iceberg

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -117,6 +117,7 @@ redpanda_cc_gtest(
         "//src/v/iceberg:transform",
         "//src/v/json",
         "//src/v/test_utils:gtest",
+        "//src/v/utils:retry_chain_node",
         "@googletest//:gtest",
     ],
 )

--- a/src/v/iceberg/tests/filesystem_catalog_test.cc
+++ b/src/v/iceberg/tests/filesystem_catalog_test.cc
@@ -20,6 +20,7 @@
 #include "iceberg/tests/test_schemas.h"
 #include "iceberg/transform.h"
 #include "json/document.h"
+#include "utils/retry_chain_node.h"
 
 #include <gtest/gtest.h>
 
@@ -268,5 +269,108 @@ TEST_F(FileSystemCatalogTest, TestDrop) {
           = catalog.create_table(id, schema{}, partition_spec{}).get();
         ASSERT_FALSE(create_res.has_error());
         ASSERT_EQ(create_res.value().last_sequence_number, sequence_number{0});
+    }
+}
+
+TEST_F(FileSystemCatalogTest, TestDropWithoutPurgePreservesDataFiles) {
+    const table_identifier id{.ns = {"ns"}, .table = "table"};
+    auto create_res
+      = catalog.create_table(id, schema{}, partition_spec{}).get();
+    ASSERT_FALSE(create_res.has_error());
+
+    // Upload a fake data file under the table's data/ directory.
+    const ss::sstring data_file_key{"test/ns/table/data/fake-0.parquet"};
+    ss::abort_source never_abort;
+    retry_chain_node retry(never_abort, 10s, 1s);
+    auto ul_res = remote()
+                    .upload_object({
+                      .transfer_details = cloud_io::transfer_details{
+                        .bucket = bucket_name,
+                        .key = cloud_storage_clients::object_key{data_file_key},
+                        .parent_rtc = retry,
+                      },
+                      .display_str = "fake data file",
+                      .payload = iobuf::from("fake parquet data"),
+                    })
+                    .get();
+    ASSERT_EQ(ul_res, cloud_io::upload_result::success);
+
+    // Drop without purge should remove the catalog entry but leave data alone.
+    {
+        auto res = catalog.drop_table(id, /*purge=*/false).get();
+        ASSERT_FALSE(res.has_error());
+    }
+
+    // The table should be gone from the catalog.
+    {
+        auto load_res = catalog.load_table(id).get();
+        ASSERT_TRUE(load_res.has_error());
+        ASSERT_EQ(load_res.error(), catalog::errc::not_found);
+    }
+
+    // But the data file should still be present.
+    {
+        auto exists = remote()
+                        .object_exists(
+                          bucket_name,
+                          cloud_storage_clients::object_key{data_file_key},
+                          retry,
+                          "fake data file")
+                        .get();
+        ASSERT_EQ(exists, cloud_io::download_result::success);
+    }
+}
+
+TEST_F(FileSystemCatalogTest, TestDropPurgesDataFiles) {
+    const table_identifier id{.ns = {"ns"}, .table = "table"};
+    auto create_res
+      = catalog.create_table(id, schema{}, partition_spec{}).get();
+    ASSERT_FALSE(create_res.has_error());
+
+    // Upload a fake data file under the table's data/ directory.
+    const ss::sstring data_file_key{"test/ns/table/data/fake-0.parquet"};
+    ss::abort_source never_abort;
+    retry_chain_node retry(never_abort, 10s, 1s);
+    auto ul_res = remote()
+                    .upload_object({
+                      .transfer_details = cloud_io::transfer_details{
+                        .bucket = bucket_name,
+                        .key = cloud_storage_clients::object_key{data_file_key},
+                        .parent_rtc = retry,
+                      },
+                      .display_str = "fake data file",
+                      .payload = iobuf::from("fake parquet data"),
+                    })
+                    .get();
+    ASSERT_EQ(ul_res, cloud_io::upload_result::success);
+
+    // Verify the data file exists before drop.
+    {
+        auto exists = remote()
+                        .object_exists(
+                          bucket_name,
+                          cloud_storage_clients::object_key{data_file_key},
+                          retry,
+                          "fake data file")
+                        .get();
+        ASSERT_EQ(exists, cloud_io::download_result::success);
+    }
+
+    // Drop with purge=true should delete everything including data files.
+    {
+        auto res = catalog.drop_table(id, /*purge=*/true).get();
+        ASSERT_FALSE(res.has_error());
+    }
+
+    // Verify the data file is gone.
+    {
+        auto exists = remote()
+                        .object_exists(
+                          bucket_name,
+                          cloud_storage_clients::object_key{data_file_key},
+                          retry,
+                          "fake data file")
+                        .get();
+        ASSERT_EQ(exists, cloud_io::download_result::notfound);
     }
 }

--- a/tests/rptest/tests/datalake/datalake_table_name_test.py
+++ b/tests/rptest/tests/datalake/datalake_table_name_test.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import pyhive.exc
 from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
 
@@ -159,12 +160,23 @@ class DatalakeTableNameTest(RedpandaTest):
                 timeout_sec=30,
                 err_msg=f"Topic {topic} was not deleted",
             )
+
+            def dlq_table_gone() -> bool:
+                try:
+                    return expected_dlq_table not in [
+                        row[1]
+                        for row in spark.run_query_fetch_all("SHOW TABLES IN redpanda")
+                    ]
+                except pyhive.exc.OperationalError as e:
+                    if "NoSuchNamespaceException" in str(e):
+                        # Purging the last table deletes all files under the
+                        # namespace prefix in S3, so the namespace disappears.
+                        # An absent namespace means the table is gone too.
+                        return True
+                    raise
+
             wait_until(
-                lambda: expected_dlq_table
-                not in [
-                    row[1]
-                    for row in spark.run_query_fetch_all("SHOW TABLES IN redpanda")
-                ],
+                dlq_table_gone,
                 timeout_sec=30,
                 err_msg=f"DLQ table {expected_dlq_table} was not deleted",
             )


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30691

- Command: git cherry-pick -x 3b6585ead7
- Commits backported: 1
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-30691-v25.2.x-1780501962

## Conflict details

- 3b6585ead7 (src/v/iceberg/tests/filesystem_catalog_test.cc): include-block conflict — the target branch already had `iceberg/transform.h` and `json/document.h` includes while the commit added `utils/retry_chain_node.h`. Resolved by keeping all three includes in sorted order; the new test bodies applied cleanly.
