### PR TITLE
datalake: fix translation probe leak

### DIFF
--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -626,7 +626,9 @@ ss::future<> datalake_manager::handle_translator_state_change(
              != model::iceberg_mode::disabled;
 
     if (!requires_active_translator) {
-        // no active translator needed, so nothing to do
+        // no active translator needed, so drop the probe to avoid leaking its
+        // metrics
+        _translation_probe_by_ntp.erase(ntp);
         co_return;
     }
 

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -1850,6 +1850,57 @@ class DatalakeMetricsTest(RedpandaTest):
                 backoff_sec=1,
             )
 
+    def _probe_metric_series(self) -> list:
+        # The lag gauge is owned by the per-partition translation_probe, so its
+        # presence tracks the probe's lifetime. Partition/shard labels are
+        # aggregated away, leaving one series per (node, topic).
+        samples = self.redpanda.metrics_sample(
+            DatalakeMetricsTest.translation_lag,
+            self.redpanda.nodes,
+            MetricsEndpoint.PUBLIC_METRICS,
+        )
+        if samples is None:
+            return []
+        return samples.label_filter({"redpanda_topic": self.topic_name}).samples
+
+    @cluster(num_nodes=5)
+    @matrix(cloud_storage_type=supported_storage_types())
+    def test_probe_removed_on_topic_deletion(self, cloud_storage_type):
+        """The per-partition translation_probe must be destroyed whenever the
+        partition no longer requires an active translator (lost leadership,
+        iceberg disabled, replica moved off the shard), otherwise the probe and
+        the metric series it owns leak for the lifetime of the process. This
+        test uses topic deletion as a deterministic way to trigger probe
+        cleanup."""
+        with DatalakeServices(
+            self.test_ctx,
+            redpanda=self.redpanda,
+            include_query_engines=[],
+            catalog_type=supported_catalog_types()[0],
+        ) as dl:
+            dl.create_iceberg_enabled_topic(self.topic_name, partitions=1, replicas=3)
+            dl.produce_to_topic(self.topic_name, 1, msg_count=randint(12, 21))
+
+            # The probe is created lazily when the partition gets an active
+            # translator (leader + iceberg enabled).
+            wait_until(
+                lambda: len(self._probe_metric_series()) > 0,
+                timeout_sec=30,
+                backoff_sec=1,
+                err_msg="Timed out waiting for translation probe metrics to appear",
+            )
+
+            RpkTool(self.redpanda).delete_topic(self.topic_name)
+
+            # Once the partition is unassigned from every shard the probe, and
+            # thus its metric series, must be gone.
+            wait_until(
+                lambda: len(self._probe_metric_series()) == 0,
+                timeout_sec=30,
+                backoff_sec=1,
+                err_msg="translation probe metrics leaked after topic deletion",
+            )
+
 
 class DatalakeDelayedEnablementTest(RedpandaTest):
     def __init__(self, test_ctx, *args, **kwargs):


### PR DESCRIPTION
The per-partition `translation_probe` was no longer removed when a
partition stopped needing an active translator, so probes — and the
public metrics they own — accumulated without bound, leaking for the
lifetime of the process.

The cleanup was originally added in #25062 and inadvertently dropped
when `datalake_manager` was ported to the notifications API in #26929.
This restores it (the probe is now erased whenever no active translator
is needed) and adds a ducktape regression test that asserts the probe
metrics disappear after a topic is deleted.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [ ] v25.2.x

## Release Notes

### Bug Fixes

* Fixed a leak in the Iceberg translation subsystem where per-partition
  metrics were not released after a partition was removed from a broker.
