### PR TITLE
[CORE-15886] cfr_tests: deflake controller recovery wait

### DIFF
--- a/tests/rptest/cfr_tests/cfr_test_base.py
+++ b/tests/rptest/cfr_tests/cfr_test_base.py
@@ -32,9 +32,6 @@ from rptest.services.redpanda import TLSProvider
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import wait_until_result
 
-# Sentinel returned by the admin API when no leader exists for a partition.
-NO_LEADER = -1
-
 
 # ── Shared data types ────────────────────────────────────────────────────
 
@@ -232,24 +229,21 @@ class ControllerForcedReconfigurationTestBase(RedpandaTest):
             err_msg="Partition has a leader",
         )
 
-    def _controller_recovered(self, killed_ids: list[int]) -> bool:
-        """True when a controller leader exists that is NOT one of the
-        killed nodes.  Uses the authenticated admin client."""
-        admin = self.redpanda._admin
-        for node in self.redpanda.started_nodes():
-            try:
-                info = admin.get_partitions(
-                    namespace="redpanda",
-                    topic="controller",
-                    partition=0,
-                    node=node,
-                )
-                leader_id = info.get("leader_id", NO_LEADER)
-                if leader_id != NO_LEADER and leader_id not in killed_ids:
-                    return True
-            except Exception:
-                continue
-        return False
+    def _controller_recovered(
+        self,
+        killed_ids: list[int],
+        timeout: TimeoutConfig,
+    ) -> int:
+        """Wait until all living nodes agree on a controller leader not in ``killed_ids``."""
+        return self.redpanda._admin.await_stable_leader(
+            topic="controller",
+            partition=0,
+            namespace="redpanda",
+            timeout_s=timeout.timeout_s,
+            backoff_s=timeout.backoff_s,
+            hosts=self._living_hostnames(),
+            check=lambda node_id: node_id not in killed_ids,
+        )
 
     # ── cluster splitting ────────────────────────────────────────────────
 

--- a/tests/rptest/cfr_tests/controller_forced_reconfiguration_script_test.py
+++ b/tests/rptest/cfr_tests/controller_forced_reconfiguration_script_test.py
@@ -266,12 +266,7 @@ class ControllerForcedReconfigurationBasicTest(
         operational."""
         surviving_count = len(survivors)
 
-        wait_until(
-            lambda: self._controller_recovered(killed_ids),
-            timeout_sec=REALLY_LONG_TIMEOUT.timeout_s,
-            backoff_sec=REALLY_LONG_TIMEOUT.backoff_s,
-            err_msg="Controller did not recover after CFR",
-        )
+        self._controller_recovered(killed_ids, REALLY_LONG_TIMEOUT)
 
         self._bulk_toggle_recovery_mode(
             nodes=survivors,
@@ -279,12 +274,7 @@ class ControllerForcedReconfigurationBasicTest(
             recovery_mode_enabled=False,
         )
 
-        wait_until(
-            lambda: self._controller_recovered(killed_ids),
-            timeout_sec=MEDIUM_TIMEOUT.timeout_s,
-            backoff_sec=MEDIUM_TIMEOUT.backoff_s,
-            err_msg="Controller did not recover after exiting recovery mode",
-        )
+        self._controller_recovered(killed_ids, MEDIUM_TIMEOUT)
 
         # Pass the service's internal TLS client cert (None when TLS is off)
         # along with explicit SASL credentials.  Both are needed because

--- a/tests/rptest/cfr_tests/controller_forced_reconfiguration_test.py
+++ b/tests/rptest/cfr_tests/controller_forced_reconfiguration_test.py
@@ -164,17 +164,8 @@ class ControllerForcedReconfigurationApiTestBase(
     ) -> bool:
         """check that no partition currently has quorum loss"""
 
-        def controller_available() -> bool:
-            controller = self.redpanda.controller()
-            return controller is not None and bool(self.redpanda.node_id(controller))
-
         try:
-            wait_until(
-                controller_available,
-                timeout_sec=timeout.timeout_s,
-                backoff_sec=timeout.backoff_s,
-                err_msg="Controller not available",
-            )
+            self._controller_recovered(killed_ids=dead_node_ids, timeout=timeout)
             lost_majority = (
                 self.redpanda._admin.get_majority_lost_partitions_from_nodes(
                     dead_brokers=dead_node_ids,
@@ -392,19 +383,9 @@ class ControllerForcedReconfiguration_SmokeTest(
             surviving_node_count=1,
         )
 
-        def controller_available():
-            controller = self.redpanda.controller()
-            return (
-                controller is not None
-                and self.redpanda.node_id(controller) not in killed_node_ids
-            )
-
         self.redpanda.logger.debug("waiting for controller to recover")
-        wait_until(
-            lambda: controller_available(),
-            timeout_sec=REALLY_LONG_TIMEOUT.timeout_s,
-            backoff_sec=REALLY_LONG_TIMEOUT.backoff_s,
-            err_msg="Controller never came back",
+        self._controller_recovered(
+            killed_ids=killed_node_ids, timeout=REALLY_LONG_TIMEOUT
         )
         self.redpanda.logger.debug("controller recovered")
 
@@ -607,21 +588,9 @@ class ControllerForcedReconfiguration_Size5(
             surviving_node_count=len(designated_survivors),
         )
 
-        def controller_available():
-            controller = self.redpanda.controller()
-            return (
-                controller is not None
-                and self.redpanda.node_id(controller) not in killed_node_ids
-            )
-
         self.redpanda.logger.debug("waiting for controller to recover")
         recovery_timeout = TimeoutConfig(timeout_s=240, backoff_s=10)
-        wait_until(
-            lambda: controller_available(),
-            timeout_sec=recovery_timeout.timeout_s,
-            backoff_sec=recovery_timeout.backoff_s,
-            err_msg="Controller never came back",
-        )
+        self._controller_recovered(killed_ids=killed_node_ids, timeout=recovery_timeout)
         self.redpanda.logger.debug("controller recovered")
 
         """ meat 4: join new nodes until the cluster recovers to original node count"""
@@ -635,9 +604,7 @@ class ControllerForcedReconfiguration_Size5(
             self.redpanda.started_nodes(), MEDIUM_TIMEOUT, recovery_mode_enabled=False
         )
 
-        wait_until(
-            controller_available, MEDIUM_TIMEOUT.timeout_s, MEDIUM_TIMEOUT.backoff_s
-        )
+        self._controller_recovered(killed_ids=killed_node_ids, timeout=MEDIUM_TIMEOUT)
 
         """ meat 6: nodewise recovery"""
         self.redpanda.logger.debug(f"recovering from: {killed_node_ids}")
@@ -819,20 +786,8 @@ class ControllerForcedReconfiguration_Size6(
             surviving_node_count=len(step_f_survivor_ids),
         )
 
-        def controller_available():
-            controller = self.redpanda.controller()
-            return (
-                controller is not None
-                and self.redpanda.node_id(controller) not in step_f_dead_ids
-            )
-
         self.redpanda.logger.debug("waiting for controller to recover")
-        wait_until(
-            lambda: controller_available(),
-            timeout_sec=LONG_TIMEOUT.timeout_s,
-            backoff_sec=LONG_TIMEOUT.backoff_s,
-            err_msg="Controller never came back",
-        )
+        self._controller_recovered(killed_ids=step_f_dead_ids, timeout=LONG_TIMEOUT)
         self.redpanda.logger.debug("controller recovered")
 
         """ step G: ensure 'some' is in the topic list """


### PR DESCRIPTION
Changes the wait for controller recovery to instead wait for a stable controller leader. This makes the test more durable against stale controller leader reports and against leadership transfer storms

Answers [CORE-15886](https://redpandadata.atlassian.net/browse/CORE-15886)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
* None

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-15886]: https://redpandadata.atlassian.net/browse/CORE-15886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ