### PR TITLE
[CORE-16414] cl/test: compare shadow-link hwms by partition id, not position

### DIFF
--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -339,45 +339,120 @@ class ClusterLinkingProgressVerifier:
         )
 
     def check_topic_hwms(self, timeout: int = 120, debug_only: bool = False):
-        # describe target first to make sure the lag is always greater than or equal to 0
+        """Verify the target topic's high watermarks have caught up to the source.
+
+        Describes the topic on both clusters and compares the per-partition high
+        watermark; any partition whose watermarks differ is counted as lagging.
+        With debug_only=True discrepancies are only logged (used to dump
+        diagnostics when the workload stalls); otherwise a lagging or mismatched
+        partition fails verification.
+
+        describe_topics() retries until source and target agree on the partition
+        set and every partition has a readable high watermark on both sides, so
+        the comparison never races against transient leadership churn. See
+        CORE-16414 for the failure this guards against.
+        """
+
         def describe_topics():
+            last_log = None
+
+            def log_once(message):
+                # Throttle to distinct states: a persistent condition leaves one
+                # line per transition rather than spamming on every backoff.
+                nonlocal last_log
+                if message != last_log:
+                    last_log = message
+                    self.logger.warning(message)
+
             def describe_once():
-                target = list(self.target_rpk.describe_topic(self.topic))
-                source = list(self.source_rpk.describe_topic(self.topic))
-                if len(source) != len(target):
+                # tolerant=True keeps momentarily-leaderless partitions in the
+                # result (with high_watermark=None) instead of dropping them,
+                # which separates two concerns the default describe conflates:
+                #
+                #   1. Structural: the set of partition ids is fixed for a
+                #      provisioned topic and is reported in metadata regardless
+                #      of leadership. Source and target must agree on it; a
+                #      persistent mismatch is a real (shadow-link) bug, surfaced
+                #      via the timeout below.
+                #   2. Transient: an individual partition may briefly have no
+                #      leader (e.g. during failure injection) and thus no
+                #      readable high watermark. We wait for liveness rather than
+                #      silently skipping the partition.
+                #
+                # Logging both (throttled) keeps the signal alive even when a
+                # transient condition is waited out and the test passes.
+                #
+                # Target is described before source so that, for a partition
+                # still replicating, target_hw <= source_hw and the lag computed
+                # below stays non-negative.
+                target = {
+                    p.id: p
+                    for p in self.target_rpk.describe_topic(self.topic, tolerant=True)
+                }
+                source = {
+                    p.id: p
+                    for p in self.source_rpk.describe_topic(self.topic, tolerant=True)
+                }
+
+                if not source or source.keys() != target.keys():
+                    log_once(
+                        f"Partition set mismatch (structural) for {self.topic} "
+                        f"while computing lag: source={sorted(source.keys())} "
+                        f"target={sorted(target.keys())}; retrying"
+                    )
                     return False, None
+
+                not_ready = [
+                    pid
+                    for pid in sorted(source.keys())
+                    if source[pid].high_watermark is None
+                    or target[pid].high_watermark is None
+                ]
+                if not_ready:
+                    log_once(
+                        f"Partitions without a readable high watermark for "
+                        f"{self.topic}: {not_ready}; retrying"
+                    )
+                    return False, None
+
                 return True, (target, source)
 
             return wait_until_result(
                 describe_once,
                 timeout_sec=timeout,
                 backoff_sec=0.5,
-                err_msg=f"Failed to describe topics for lag calculation in {timeout} seconds",
+                err_msg=f"Source and target did not converge on a comparable set of partitions for lag calculation in {timeout} seconds",
             )
 
         try:
             (target, source) = describe_topics()
-            assert len(target) == len(source), (
-                "Verification failed, Topic partitions count mismatch between source and target"
+            # Postcondition of describe_topics(): the partition sets match and
+            # every high watermark is non-None on both sides, so partitions line
+            # up by id and the subtraction below cannot see None. The assert
+            # documents (and defensively re-checks) that invariant.
+            assert source.keys() == target.keys(), (
+                "Verification failed, Topic partitions mismatch between source and target"
             )
             partitions_with_lag = 0
-            for source_partition, target_partition in zip(source, target):
-                assert source_partition.id == target_partition.id, (
-                    f"Partition id mismatch {source_partition.id} != {target_partition.id}"
-                )
+            for pid in sorted(source.keys()):
+                source_partition = source[pid]
+                target_partition = target[pid]
                 if target_partition.high_watermark != source_partition.high_watermark:
                     lag = (
                         source_partition.high_watermark
                         - target_partition.high_watermark
                     )
                     self.logger.debug(
-                        f"Partition {self.topic}/{source_partition.id} - source: ({source_partition}), target: ({target_partition}) lag: {lag}"
+                        f"Partition {self.topic}/{pid} - source: ({source_partition}), target: ({target_partition}) lag: {lag}"
                     )
                     partitions_with_lag += 1
-                assert debug_only or partitions_with_lag == 0, (
-                    f"Verification failed, {partitions_with_lag} partitions do not have synced high watermarks"
-                )
+            assert debug_only or partitions_with_lag == 0, (
+                f"Verification failed, {partitions_with_lag} partitions do not have synced high watermarks"
+            )
         except Exception as e:
+            # debug_only callers (e.g. the workload-stall diagnostic dump) want a
+            # best-effort snapshot, so swallow failures; real verification
+            # propagates them.
             self.logger.warning(f"Verification failed: {e}")
             if not debug_only:
                 raise


### PR DESCRIPTION
check_topic_hwms() verified replication progress by zipping the source and target partition lists together and asserting equal ids per pair, guarded only by a length pre-check. This was flaky:

  AssertionError('Verification failed: Partition id mismatch 0 != 1')

Theory: RpkTool.describe_topic() defaults to tolerant=False, which silently omits any partition lacking full metadata -- e.g. one that is momentarily leaderless during the failure injection this test performs. rpk itself sorts partitions by id, so ordering was never the problem; the omission was. Source and target can each drop a different partition and still report equal counts, so the length pre-check passes while the lists no longer line up: zip then pairs source id 0 against target id 1. A partition leaderless on both sides was worse -- dropped from both, counts still matched, and its high watermark was silently never compared.

Solution: separate the two concerns describe was conflating.

  - Structural: the partition id set is fixed for a provisioned topic and metadata reports it regardless of leadership. Describe with tolerant=True and require source and target to agree on the id set, indexing by id instead of zipping by position. A persistent mismatch is a real bug and now fails via timeout rather than a confusing positional assert.
  - Transient: a partition may briefly have no leader and thus no readable high watermark. Wait for liveness on both sides before comparing, instead of dropping the partition.

Both conditions are logged (throttled to distinct states) before retrying, so a transient blip that is waited out still leaves an investigable trail on otherwise-green runs.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
