### PR TITLE
[v26.1.x] rpk/topic: fix typo in trim-prefix help text

### DIFF
--- a/src/go/rpk/pkg/cli/topic/trim.go
+++ b/src/go/rpk/pkg/cli/topic/trim.go
@@ -42,7 +42,7 @@ func newTrimPrefixCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 
 This command allows you to trim records from topics, to trim the topics Redpanda
 sets the LogStartOffset for partitions to the requested offset. All segments
-whose base offset is less then the requested offset are deleted, and any records
+whose base offset is less than the requested offset are deleted, and any records
 within the segment before the requested offset can no longer be read.
 
 The --offset/-o flag allows you to indicate which index you want to set the


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30676
Fixes: https://github.com/redpanda-data/redpanda/issues/30708,