### PR TITLE
[CORE-13874] `storage`: add `translation_out_of_range` exception and catch it in `archival`

### DIFF
--- a/src/v/cluster/archival/upload_housekeeping_service.cc
+++ b/src/v/cluster/archival/upload_housekeeping_service.cc
@@ -17,6 +17,7 @@
 #include "cluster/archival/types.h"
 #include "config/configuration.h"
 #include "ssx/future-util.h"
+#include "storage/exceptions.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/lowres_clock.hh>
@@ -403,6 +404,18 @@ ss::future<> housekeeping_workflow::run_jobs_bg() {
                 jobs_executed++;
                 quota = res.remaining;
                 maybe_update_probe(res);
+            } catch (const translation_offset_out_of_range& e) {
+                // This exception is most commonly experienced in the
+                // `adjacent_segment_merger::run()` path- the reupload candidate
+                // references a log offset that local retention has already
+                // trimmed away, so it can no longer be translated and
+                // reuploaded from the local log. This races with GC and can be
+                // expected.
+                vlog(
+                  archival_log.debug,
+                  "Reupload candidate is no longer translatable in the local "
+                  "log (trimmed by retention), skipping: {}",
+                  e.what());
             } catch (...) {
                 auto eptr = std::current_exception();
                 if (ssx::is_shutdown_exception(eptr)) {

--- a/src/v/storage/exceptions.h
+++ b/src/v/storage/exceptions.h
@@ -16,6 +16,7 @@
 #include <seastar/core/sstring.hh>
 
 #include <exception>
+#include <stdexcept>
 #include <utility>
 
 class malformed_batch_stream_exception : public std::exception {
@@ -49,4 +50,12 @@ public:
 
 private:
     ss::sstring _msg;
+};
+
+/// Thrown by `offset_translator_state` when an offset to translate falls
+/// outside the range currently covered by the translator state.
+class translation_offset_out_of_range : public std::runtime_error {
+public:
+    explicit translation_offset_out_of_range(const ss::sstring& s)
+      : std::runtime_error(s.c_str()) {}
 };

--- a/src/v/storage/offset_translator_state.cc
+++ b/src/v/storage/offset_translator_state.cc
@@ -19,6 +19,7 @@
 #include "serde/rw/rw.h"
 #include "serde/rw/scalar.h"
 #include "serde/rw/vector.h" // NOLINT(misc-include-cleaner) serde specialization
+#include "storage/exceptions.h"
 #include "storage/logger.h"
 
 #include <iterator>
@@ -54,7 +55,7 @@ int64_t offset_translator_state::delta(model::offset o) const {
           o,
           model::next_offset(_last_offset2batch.begin()->first));
 
-        throw std::runtime_error{fmt::format(
+        throw translation_offset_out_of_range{fmt::format(
           "ntp {}: log offset {} is outside the translation range (starting at "
           "{})",
           _ntp,
@@ -108,7 +109,7 @@ model::offset offset_translator_state::to_log_offset(
       = min_log_offset
         - model::offset(_last_offset2batch.begin()->second.next_delta);
     if (data_offset < min_data_offset) {
-        throw std::runtime_error{fmt::format(
+        throw translation_offset_out_of_range{fmt::format(
           "ntp {}: data offset {} is outside the translation range (starting "
           "at {})",
           _ntp,


### PR DESCRIPTION
* Add `translation_out_of_range` exception type (given the pervasiveness of this failure path in our codebase)
* Catch it in `adjacent_segment_merger` (since it indicates a benign, concurrency error for the current `adjacent_segment_merger` run, but is retriable on future runs).

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
