### PR TITLE
rptest: route user/ACL ops to data plane API

### DIFF
--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -409,14 +409,13 @@ class CloudCluster:
         return _users
 
     def _get_cluster_users(self):
-        _r = self.rpcloud._http_get(
-            base_url=self.current.consoleUrl,
-            endpoint="/api/users",
+        _r = self.public_api._http_get(
+            base_url=self._get_dataplane_api_url(),
+            endpoint="/v1/users",
         )
         if _r is None:
             return []
-        else:
-            return _r["users"]
+        return [u["name"] for u in _r.get("users", [])]
 
     def cloudUserExists(self, username):
         _users = self._get_cloud_users()
@@ -1103,46 +1102,49 @@ class CloudCluster:
             )
             self._logger.debug(f"resp: {json.dumps(resp)}")
 
+    @staticmethod
+    def _to_sasl_mechanism(algorithm: str) -> str:
+        # The data plane API expects the proto enum form, e.g.
+        # 'SCRAM-SHA-256' -> 'SASL_MECHANISM_SCRAM_SHA_256'.
+        return f"SASL_MECHANISM_{algorithm.replace('-', '_')}"
+
     def _create_user(self, user: SaslCredentials):
         """Create SASL user"""
         payload = {
-            "mechanism": user.algorithm,
+            "mechanism": self._to_sasl_mechanism(user.algorithm),
+            "name": user.username,
             "password": user.password,
-            "username": user.username,
         }
-        # use the console api url to create sasl users; uses the same auth token
-        return self.rpcloud._http_post(
-            base_url=self.current.consoleUrl, endpoint="/api/users", json=payload
+        return self.public_api._http_post(
+            base_url=self._get_dataplane_api_url(),
+            endpoint="/v1/users",
+            json=payload,
         )
 
     def _create_acls(self, username):
-        """Create ACLs for user"""
-
-        base_url = self._get_cluster_console_url()
-        for rt in ("Topic", "Group", "TransactionalID"):
+        """Create ACLs for user via the data plane API"""
+        dataplane_url = self._get_dataplane_api_url()
+        principal = f"User:{username}"
+        # (resource_type, resource_name) pairs; CLUSTER uses the fixed
+        # 'kafka-cluster' resource name.
+        for resource_type, resource_name in (
+            ("RESOURCE_TYPE_TOPIC", "*"),
+            ("RESOURCE_TYPE_GROUP", "*"),
+            ("RESOURCE_TYPE_TRANSACTIONAL_ID", "*"),
+            ("RESOURCE_TYPE_CLUSTER", "kafka-cluster"),
+        ):
             payload = {
                 "host": "*",
-                "operation": "All",
-                "permissionType": "Allow",
-                "principal": f"User:{username}",
-                "resourceName": "*",
-                "resourcePatternType": "Literal",
-                "resourceType": rt,
+                "operation": "OPERATION_ALL",
+                "permission_type": "PERMISSION_TYPE_ALLOW",
+                "principal": principal,
+                "resource_name": resource_name,
+                "resource_pattern_type": "RESOURCE_PATTERN_TYPE_LITERAL",
+                "resource_type": resource_type,
             }
-            self.rpcloud._http_post(
-                base_url=base_url, endpoint="/api/acls", json=payload
+            self.public_api._http_post(
+                base_url=dataplane_url, endpoint="/v1/acls", json=payload
             )
-
-        payload = {
-            "host": "*",
-            "operation": "All",
-            "permissionType": "Allow",
-            "principal": f"User:{username}",
-            "resourceName": "kafka-cluster",
-            "resourcePatternType": "Literal",
-            "resourceType": "Cluster",
-        }
-        self.rpcloud._http_post(base_url=base_url, endpoint="/api/acls", json=payload)
 
     def get_broker_address(self):
         cluster = self.rpcloud.get_cluster(self.current.cluster_id)
@@ -1695,7 +1697,12 @@ class CloudCluster:
         return response
 
     def _get_dataplane_api_url(self):
-        cluster = self.rpcloud.get_cluster(self.current.cluster_id)
+        # Serverless and BYOC/dedicated clusters are fetched via different
+        # control-plane endpoints, but both expose dataplane_api.url.
+        is_serverless = self.config.type == "SERVERLESS"
+        cluster = self._get_cluster(
+            self.current.cluster_id, is_serverless_cluster=is_serverless
+        )
         return cluster["dataplane_api"]["url"]
 
     def wait_for_operation_complete(


### PR DESCRIPTION
Console removed its legacy REST endpoints
(/api/users, /api/acls) after migrating its
frontend to ConnectRPC. Calling them now
returns 404, breaking update_cluster_acls
in cloud tests.

Route _get_cluster_users, _create_user, and
_create_acls to the data plane API
(/v1/users, /v1/acls) via self.public_api,
the data-plane HTTP client already used by
other operations in this class.

Payload field names change from camelCase to
the proto-transcoding snake_case form, and
the SASL mechanism value becomes a proto enum
string (e.g. SASL_MECHANISM_SCRAM_SHA_256).
ACL resource type and permission fields
follow the same convention.

Also fix _get_dataplane_api_url to resolve
the cluster via the serverless-aware
_get_cluster helper so the method works for
both BYOC/dedicated and serverless clusters.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes


* none
