### PR TITLE
metrics: honor disable_public_metrics in three leaking gauges

### DIFF
--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -61,11 +61,11 @@ ss::future<> members_backend::stop() {
 }
 
 void members_backend::setup_metrics() {
-    if (config::shard_local_cfg().disable_metrics()) {
+    if (config::shard_local_cfg().disable_public_metrics()) {
         return;
     }
     namespace sm = ss::metrics;
-    _metrics.add_group(
+    _public_metrics.add_group(
       prometheus_sanitize::metrics_name("cluster:members:backend"),
       {
         sm::make_gauge(

--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -128,7 +128,7 @@ private:
     ss::circular_buffer<members_manager::node_update> _raft0_updates;
     std::chrono::milliseconds _retry_timeout;
     ss::condition_variable _new_updates;
-    metrics::public_metric_groups _metrics;
+    metrics::public_metric_groups _public_metrics;
     config::binding<size_t> _max_concurrent_reallocations;
 };
 

--- a/src/v/cluster/partition_balancer_state.cc
+++ b/src/v/cluster/partition_balancer_state.cc
@@ -137,13 +137,17 @@ partition_balancer_state::apply_snapshot(const controller_snapshot& snap) {
 
 partition_balancer_state::probe::probe(const partition_balancer_state& parent)
   : _parent(parent) {
-    if (
-      config::shard_local_cfg().disable_metrics() || ss::this_shard_id() != 0) {
+    if (ss::this_shard_id() != 0) {
         return;
     }
 
-    setup_metrics(_metrics);
-    setup_metrics(_public_metrics);
+    const auto& cfg = config::shard_local_cfg();
+    if (!cfg.disable_metrics()) {
+        setup_metrics(_metrics);
+    }
+    if (!cfg.disable_public_metrics()) {
+        setup_metrics(_public_metrics);
+    }
 }
 
 void partition_balancer_state::probe::setup_metrics(

--- a/src/v/raft/group_manager.cc
+++ b/src/v/raft/group_manager.cc
@@ -209,31 +209,33 @@ void group_manager::trigger_leadership_notification(
 }
 
 void group_manager::setup_metrics() {
-    if (config::shard_local_cfg().disable_metrics()) {
-        return;
-    }
-
     namespace sm = ss::metrics;
 
-    _metrics.add_group(
-      prometheus_sanitize::metrics_name("raft"),
-      {sm::make_gauge(
-         "group_count",
-         [this] { return _groups.size(); },
-         sm::description("Number of raft groups")),
-       sm::make_gauge(
-         "learners_gap_bytes",
-         [this] { return _learners_gap_bytes; },
-         sm::description(
-           "Total numbers of bytes that must be delivered to learners"))});
+    const auto& cfg = config::shard_local_cfg();
 
-    _public_metrics.add_group(
-      prometheus_sanitize::metrics_name("raft"),
-      {sm::make_gauge(
-        "learners_gap_bytes",
-        [this] { return _learners_gap_bytes; },
-        sm::description(
-          "Total numbers of bytes that must be delivered to learners"))});
+    if (!cfg.disable_metrics()) {
+        _metrics.add_group(
+          prometheus_sanitize::metrics_name("raft"),
+          {sm::make_gauge(
+             "group_count",
+             [this] { return _groups.size(); },
+             sm::description("Number of raft groups")),
+           sm::make_gauge(
+             "learners_gap_bytes",
+             [this] { return _learners_gap_bytes; },
+             sm::description(
+               "Total numbers of bytes that must be delivered to learners"))});
+    }
+
+    if (!cfg.disable_public_metrics()) {
+        _public_metrics.add_group(
+          prometheus_sanitize::metrics_name("raft"),
+          {sm::make_gauge(
+            "learners_gap_bytes",
+            [this] { return _learners_gap_bytes; },
+            sm::description(
+              "Total numbers of bytes that must be delivered to learners"))});
+    }
 }
 
 void group_manager::trigger_config_update_notification() {

--- a/tests/rptest/tests/metrics_test.py
+++ b/tests/rptest/tests/metrics_test.py
@@ -16,7 +16,6 @@ from rptest.clients.default import DefaultClient
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import MetricsEndpoint, make_redpanda_service
-from rptest.tests.redpanda_test import RedpandaTest
 
 BOOTSTRAP_CONFIG = {
     "disable_metrics": False,
@@ -84,11 +83,11 @@ class MetricsTest(Test):
         assert len(metrics_pre_change) == len(metrics_pre_chanage_again)
 
 
-class DisableMetricsTest(RedpandaTest):
-    # Allowlist of Seastar metric group prefixes that are expected to
-    # remain on the internal endpoint even with disable_metrics=True.
-    # Any metric family not matching is a Redpanda application metric
-    # and should not be present.
+class DisableMetricsTest(Test):
+    # Group-name prefixes for metrics that Seastar registers on the internal
+    # endpoint and that legitimately remain even with disable_metrics=True.
+    # Any internal family not matching this is a Redpanda application metric
+    # and must not be present.
     SEASTAR_METRIC_RE = re.compile(
         r"^vectorized_("
         r"alien|"
@@ -102,47 +101,104 @@ class DisableMetricsTest(RedpandaTest):
         r")_"
     )
 
-    def __init__(self, test_ctx):
-        super().__init__(
-            test_ctx,
+    # Redpanda-owned metrics that match SEASTAR_METRIC_RE only because they
+    # share a group name with Seastar (available_memory registers under the
+    # "memory" group, see src/v/resource_mgmt/available_memory.cc). They are
+    # still Redpanda metrics and must obey the disable flags, so they count
+    # as leaks if present on a disabled endpoint despite matching the regex.
+    REDPANDA_METRICS_MATCHING_SEASTAR_RE = {
+        "vectorized_memory_available_memory",
+        "vectorized_memory_available_memory_low_water_mark",
+    }
+
+    def __init__(self, test_ctx, *args, **kwargs):
+        self.ctx = test_ctx
+        self.redpanda = None
+        super().__init__(test_ctx, *args, **kwargs)
+
+    def setUp(self):
+        pass
+
+    def start_redpanda(self, disable_metrics, disable_public_metrics):
+        self.redpanda = make_redpanda_service(
+            self.ctx,
             num_brokers=1,
             extra_rp_conf={
-                "disable_metrics": True,
-                "disable_public_metrics": True,
+                "disable_metrics": disable_metrics,
+                "disable_public_metrics": disable_public_metrics,
             },
+        )
+        self.redpanda.start()
+
+    def _is_allowed_internal(self, name):
+        return (
+            bool(self.SEASTAR_METRIC_RE.match(name))
+            and name not in self.REDPANDA_METRICS_MATCHING_SEASTAR_RE
+        )
+
+    def _redpanda_metrics(self, node, endpoint):
+        """Names of the Redpanda-owned metric families present on `endpoint`.
+
+        On the internal endpoint Seastar metrics legitimately remain, so they
+        are filtered out; the public endpoint only ever carries Redpanda
+        metrics, so every non-empty family counts.
+        """
+        families = self.redpanda.metrics(node, endpoint)
+        if endpoint == MetricsEndpoint.METRICS:
+            return [
+                f.name
+                for f in families
+                if f.samples and not self._is_allowed_internal(f.name)
+            ]
+        return [f.name for f in families if f.samples]
+
+    def _verify_endpoint_disabled(self, disabled_endpoint):
+        """Disable a single metrics endpoint and verify it is the only one
+        affected: it must carry no Redpanda metrics, while the other endpoint
+        keeps exposing them."""
+        enabled_endpoint = (
+            MetricsEndpoint.PUBLIC_METRICS
+            if disabled_endpoint == MetricsEndpoint.METRICS
+            else MetricsEndpoint.METRICS
+        )
+        self.start_redpanda(
+            disable_metrics=disabled_endpoint == MetricsEndpoint.METRICS,
+            disable_public_metrics=disabled_endpoint == MetricsEndpoint.PUBLIC_METRICS,
+        )
+        node = self.redpanda.nodes[0]
+
+        leaked = self._redpanda_metrics(node, disabled_endpoint)
+        for name in leaked:
+            self.redpanda.logger.debug(
+                f"leaked Redpanda metric on disabled "
+                f"{disabled_endpoint.value} endpoint: {name}"
+            )
+        assert len(leaked) == 0, (
+            f"disabling the {disabled_endpoint.value} endpoint did not suppress "
+            f"Redpanda metrics; leaked {len(leaked)} families: {leaked[:10]}"
+        )
+
+        present = self._redpanda_metrics(node, enabled_endpoint)
+        assert len(present) > 0, (
+            f"expected Redpanda metrics to remain on the "
+            f"{enabled_endpoint.value} endpoint, but found none"
         )
 
     @cluster(num_nodes=1)
-    def test_disable_metrics(self):
+    def test_disable_internal_metrics(self):
         """
-        Verify that starting Redpanda with both disable_metrics and
-        disable_public_metrics causes the internal endpoint to contain
-        only Seastar metrics (no Redpanda application metrics) and the
-        public endpoint to be completely empty.
+        With disable_metrics=True (and public metrics still enabled), the
+        internal /metrics endpoint must expose only Seastar metrics - no
+        Redpanda application metrics - while the public endpoint is
+        unaffected and still exposes Redpanda metrics.
         """
-        node = self.redpanda.nodes[0]
+        self._verify_endpoint_disabled(MetricsEndpoint.METRICS)
 
-        # Check internal metrics: only Seastar metrics should remain.
-        internal_families = self.redpanda.metrics(node, MetricsEndpoint.METRICS)
-        non_seastar = [
-            f.name
-            for f in internal_families
-            if f.samples and not self.SEASTAR_METRIC_RE.match(f.name)
-        ]
-        for name in non_seastar:
-            self.redpanda.logger.debug(f"unexpected internal metric family: {name}")
-        assert len(non_seastar) == 0, (
-            f"Expected only Seastar metrics on internal endpoint, "
-            f"got {len(non_seastar)} Redpanda metric families: "
-            f"{non_seastar[:10]}"
-        )
-
-        # Check public metrics: should be completely empty.
-        public_families = self.redpanda.metrics(node, MetricsEndpoint.PUBLIC_METRICS)
-        non_empty = [f.name for f in public_families if f.samples]
-        for name in non_empty:
-            self.redpanda.logger.debug(f"unexpected public metric family: {name}")
-        assert len(non_empty) == 0, (
-            f"Expected no public metrics, got {len(non_empty)} "
-            f"families: {non_empty[:10]}"
-        )
+    @cluster(num_nodes=1)
+    def test_disable_public_metrics(self):
+        """
+        With disable_public_metrics=True (and internal metrics still
+        enabled), the public endpoint must be completely empty while the
+        internal endpoint is unaffected and still exposes Redpanda metrics.
+        """
+        self._verify_endpoint_disabled(MetricsEndpoint.PUBLIC_METRICS)


### PR DESCRIPTION
Three Redpanda gauges were registered on the public metrics endpoint
without checking `disable_public_metrics`, so they kept appearing there
even when an operator disabled public metrics. In each case
`setup_metrics` either gated the public registration on the wrong flag
(`disable_metrics`) or did not gate it at all:

- `raft_learners_gap_bytes` (`group_manager`)
- `cluster_members_backend_queued_node_operations` (`members_backend`)
- `cluster_partition_num_with_broken_rack_constraint` (`partition_balancer_state`)

Each leak is fixed in its own commit by gating the internal and public
groups on their respective flags.

The final commit rewrites `DisableMetricsTest` into two per-endpoint
cases (`test_disable_internal_metrics` / `test_disable_public_metrics`):
each disables a single endpoint and asserts it carries no Redpanda
metrics while the other endpoint still exposes them. That is what
surfaced these three leaks - the previous test set both disable flags at
once and only checked the internal endpoint, so it passed for the wrong
reason. The test also tracks the `available_memory` gauges that share
Seastar's `memory` group, so a leak under that shared name is counted
rather than hidden by the allowlist.

Verified locally with `tools/dt`: both cases pass (2/2).

### FYI (no action required)

- @bharathv - FYI, includes a fix on the partition balancer (`partition_balancer_state`, `num_with_broken_rack_constraint`) and on raft (`group_manager`, `learners_gap_bytes`).

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Bug Fixes

- Metrics that previously ignored `disable_public_metrics` (`raft_learners_gap_bytes`, `cluster_members_backend_queued_node_operations`, `cluster_partition_num_with_broken_rack_constraint`) now honor it.