### PR TITLE
CORE-16416 SR Shadowing: define feature, types and proto convertes

### DIFF
--- a/src/v/cluster/cluster_link/frontend.cc
+++ b/src/v/cluster/cluster_link/frontend.cc
@@ -337,15 +337,13 @@ bool frontend::schema_registry_shadowing_active() const {
             // If it is, return whether or not it is mutable based on its status
             return !is_topic_mutable(topic_it->second.status);
         }
-        // If mirror_schema_registry_topic option is set and the topic is not
-        // yet in the mirror topic list, then shadowing for SR is active
+        // A shadowing mode is engaged but there is no (mutable) mirror topic:
+        // either topic mode before the _schemas mirror topic appears, or API
+        // mode which has no mirror topic at all. In both cases local writes
+        // must be blocked so they cannot conflict with subjects, versions,
+        // IDs, modes, and configs the sync imports from the source.
         const auto& sr_cfg = md->configuration.schema_registry_sync_cfg;
-        if (
-          sr_cfg.sync_schema_registry_topic_mode.has_value()
-          && std::holds_alternative<
-            ::cluster_link::model::schema_registry_sync_config::
-              shadow_entire_schema_registry>(
-            sr_cfg.sync_schema_registry_topic_mode.value())) {
+        if (sr_cfg.is_topic_mode() || sr_cfg.api_mode() != nullptr) {
             return true;
         }
 

--- a/src/v/cluster_link/model/tests/BUILD
+++ b/src/v/cluster_link/model/tests/BUILD
@@ -8,6 +8,7 @@ redpanda_cc_gtest(
     ],
     deps = [
         "//src/v/cluster_link/model",
+        "//src/v/serde",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
     ],

--- a/src/v/cluster_link/model/tests/test_model.cc
+++ b/src/v/cluster_link/model/tests/test_model.cc
@@ -10,10 +10,33 @@
  */
 
 #include "cluster_link/model/types.h"
+#include "serde/rw/rw.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 namespace cluster_link::model::tests {
+namespace {
+template<typename To, typename From>
+To serde_to(const From& from) {
+    auto b = serde::to_iobuf(from);
+    return serde::from_iobuf<To>(std::move(b));
+}
+
+struct schema_registry_sync_config_v0
+  : serde::envelope<
+      schema_registry_sync_config_v0,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using shadow_schema_registry_mode_t = serde::variant<
+      schema_registry_sync_config::shadow_entire_schema_registry>;
+
+    std::optional<shadow_schema_registry_mode_t>
+      sync_schema_registry_topic_mode;
+
+    auto serde_fields() { return std::tie(sync_schema_registry_topic_mode); }
+};
+} // namespace
 
 TEST(test_model, test_no_leak_private_data) {
     scram_credentials creds{
@@ -47,5 +70,110 @@ TEST(test_model, test_no_leak_private_data) {
     EXPECT_TRUE(fmt.contains("password: ****"));
     // verify key is not printed
     EXPECT_TRUE(values_fmt.contains("key: {value: ****}"));
+}
+
+TEST(test_model, schema_registry_sync_config_reads_v0_topic_mode) {
+    schema_registry_sync_config_v0 legacy;
+    legacy.sync_schema_registry_topic_mode
+      = schema_registry_sync_config::shadow_entire_schema_registry{};
+
+    auto cfg = serde_to<schema_registry_sync_config>(legacy);
+
+    EXPECT_TRUE(cfg.is_topic_mode());
+    EXPECT_EQ(cfg.api_mode(), nullptr);
+}
+
+TEST(test_model, schema_registry_sync_config_round_trips_api_mode) {
+    schema_registry_sync_config::shadow_schema_registry_api api;
+    api.source_url = "https://schema-registry.example.com";
+    api.auth_config = schema_registry_sync_config::basic_auth{
+      .username = "sr-api-key",
+      .password = "sr-api-secret",
+      .password_last_updated = ::model::timestamp{1759193250080}};
+    api.filter.contexts = {".", ".prod"};
+    api.filter.subjects = {"orders-value", ":.prod:payments-value"};
+    api.destination = schema_registry_sync_config::identity_context_mapping{};
+    api.feature_policy
+      = schema_registry_sync_config::unsupported_feature_policy::remove;
+
+    schema_registry_sync_config cfg;
+    cfg.sync_mode = api.copy();
+
+    auto roundtrip = serde_to<schema_registry_sync_config>(cfg);
+
+    EXPECT_FALSE(roundtrip.is_topic_mode());
+    const auto* roundtrip_api_ptr = roundtrip.api_mode();
+    ASSERT_NE(roundtrip_api_ptr, nullptr);
+    const auto& roundtrip_api = *roundtrip_api_ptr;
+    EXPECT_EQ(roundtrip_api.source_url, api.source_url);
+    ASSERT_THAT(
+      roundtrip_api.auth_config,
+      testing::Optional(
+        testing::VariantWith<schema_registry_sync_config::basic_auth>(
+          testing::AllOf(
+            testing::Field(
+              &schema_registry_sync_config::basic_auth::username,
+              ss::sstring{"sr-api-key"}),
+            testing::Field(
+              &schema_registry_sync_config::basic_auth::password,
+              ss::sstring{"sr-api-secret"}),
+            testing::Field(
+              &schema_registry_sync_config::basic_auth::password_last_updated,
+              ::model::timestamp{1759193250080})))));
+    EXPECT_EQ(roundtrip_api.filter.contexts, api.filter.contexts);
+    EXPECT_EQ(roundtrip_api.filter.subjects, api.filter.subjects);
+    ASSERT_TRUE(roundtrip_api.destination.has_value());
+    EXPECT_TRUE(
+      std::holds_alternative<
+        schema_registry_sync_config::identity_context_mapping>(
+        *roundtrip_api.destination));
+    EXPECT_EQ(
+      roundtrip_api.feature_policy,
+      schema_registry_sync_config::unsupported_feature_policy::remove);
+}
+
+TEST(test_model, schema_registry_sync_config_round_trips_topic_mode) {
+    schema_registry_sync_config cfg;
+    cfg.sync_mode
+      = schema_registry_sync_config::shadow_entire_schema_registry{};
+
+    auto roundtrip = serde_to<schema_registry_sync_config>(cfg);
+
+    EXPECT_TRUE(roundtrip.is_topic_mode());
+    EXPECT_EQ(roundtrip.api_mode(), nullptr);
+}
+
+// Mid-upgrade safety: a freshly-upgraded node writes the existing topic-mode
+// field with the v1 schema, and a not-yet-upgraded node must still recover the
+// field it understands while skipping any trailing fields added in v1.
+TEST(test_model, schema_registry_sync_config_legacy_reads_v1_topic_mode) {
+    schema_registry_sync_config cfg;
+    cfg.sync_mode
+      = schema_registry_sync_config::shadow_entire_schema_registry{};
+
+    auto legacy = serde_to<schema_registry_sync_config_v0>(cfg);
+
+    ASSERT_TRUE(legacy.sync_schema_registry_topic_mode.has_value());
+    EXPECT_TRUE(
+      std::holds_alternative<
+        schema_registry_sync_config::shadow_entire_schema_registry>(
+        *legacy.sync_schema_registry_topic_mode));
+}
+
+// Mid-upgrade safety: a not-yet-upgraded node decoding an API-mode record (a
+// v1-only field) finds no topic-mode field and degrades to "no Schema Registry
+// sync" rather than failing to decode. API mode is feature-gated until the
+// cluster is fully upgraded, so this state should not arise in practice, but
+// the wire format must still tolerate it.
+TEST(test_model, schema_registry_sync_config_legacy_skips_v1_api_mode) {
+    schema_registry_sync_config::shadow_schema_registry_api api;
+    api.source_url = "https://schema-registry.example.com";
+
+    schema_registry_sync_config cfg;
+    cfg.sync_mode = std::move(api);
+
+    auto legacy = serde_to<schema_registry_sync_config_v0>(cfg);
+
+    EXPECT_FALSE(legacy.sync_schema_registry_topic_mode.has_value());
 }
 } // namespace cluster_link::model::tests

--- a/src/v/cluster_link/model/types.cc
+++ b/src/v/cluster_link/model/types.cc
@@ -12,6 +12,7 @@
 #include "cluster_link/model/types.h"
 
 #include "base/format_to.h"
+#include "base/vassert.h"
 #include "model/timestamp.h"
 #include "ssx/async_algorithm.h"
 #include "utils/to_string.h"
@@ -180,12 +181,117 @@ security_settings_sync_config security_settings_sync_config::copy() const {
     return copy;
 }
 
+schema_registry_sync_config::source_filter
+schema_registry_sync_config::source_filter::copy() const {
+    source_filter copy;
+    copy.contexts = contexts.copy();
+    copy.subjects = subjects.copy();
+    return copy;
+}
+
+schema_registry_sync_config::exact_context_mapping
+schema_registry_sync_config::exact_context_mapping::copy() const {
+    exact_context_mapping copy;
+    copy.mappings.reserve(mappings.size());
+    for (const auto& [source, destination] : mappings) {
+        copy.mappings.emplace(source, destination);
+    }
+    return copy;
+}
+
+schema_registry_sync_config::shadow_schema_registry_api
+schema_registry_sync_config::shadow_schema_registry_api::copy() const {
+    shadow_schema_registry_api copy;
+    copy.source_url = source_url;
+    copy.auth_config = auth_config;
+    copy.tls_enabled = tls_enabled;
+    copy.cert = cert;
+    copy.key = key;
+    copy.ca = ca;
+    copy.tls_provide_sni = tls_provide_sni;
+    copy.tail_interval = tail_interval;
+    copy.full_sync_interval = full_sync_interval;
+    copy.max_source_requests_per_second = max_source_requests_per_second;
+    copy.filter = filter.copy();
+    if (destination.has_value()) {
+        ss::visit(
+          *destination,
+          [&copy](const identity_context_mapping&) {
+              copy.destination = identity_context_mapping{};
+          },
+          [&copy](const exact_context_mapping& exact) {
+              copy.destination = exact.copy();
+          });
+    }
+    copy.feature_policy = feature_policy;
+    return copy;
+}
+
+schema_registry_sync_config schema_registry_sync_config::copy() const {
+    schema_registry_sync_config copy;
+    if (sync_mode.has_value()) {
+        ss::visit(
+          *sync_mode,
+          [&copy](const shadow_entire_schema_registry&) {
+              copy.sync_mode = shadow_entire_schema_registry{};
+          },
+          [&copy](const shadow_schema_registry_api& api) {
+              copy.sync_mode = api.copy();
+          });
+    }
+    return copy;
+}
+
+void schema_registry_sync_config::serde_write(iobuf& out) const {
+    using serde::write;
+    // Preserve the released v0 two-field wire layout: field 0 is the
+    // topic-mode variant, field 1 (added in v1) is the API-mode config. The
+    // in-memory variant guarantees at most one is engaged.
+    using wire_topic_mode_t = serde::variant<shadow_entire_schema_registry>;
+    std::optional<wire_topic_mode_t> topic_mode;
+    std::optional<shadow_schema_registry_api> api_mode;
+    if (sync_mode.has_value()) {
+        ss::visit(
+          *sync_mode,
+          [&topic_mode](const shadow_entire_schema_registry&) {
+              topic_mode.emplace(shadow_entire_schema_registry{});
+          },
+          [&api_mode](const shadow_schema_registry_api& api) {
+              api_mode = api.copy();
+          });
+    }
+    write(out, std::move(topic_mode));
+    write(out, std::move(api_mode));
+}
+
+void schema_registry_sync_config::serde_read(
+  iobuf_parser& in, const serde::header& h) {
+    using serde::read_nested;
+    using wire_topic_mode_t = serde::variant<shadow_entire_schema_registry>;
+
+    auto topic_mode = read_nested<std::optional<wire_topic_mode_t>>(
+      in, h._bytes_left_limit);
+    std::optional<shadow_schema_registry_api> api_mode;
+    if (h._version >= 1) {
+        api_mode = read_nested<std::optional<shadow_schema_registry_api>>(
+          in, h._bytes_left_limit);
+    }
+
+    if (api_mode.has_value()) {
+        sync_mode.emplace(std::move(*api_mode));
+    } else if (topic_mode.has_value()) {
+        sync_mode.emplace(shadow_entire_schema_registry{});
+    } else {
+        sync_mode.reset();
+    }
+}
+
 link_configuration link_configuration::copy() const {
     link_configuration copy;
     copy.topic_metadata_mirroring_cfg = topic_metadata_mirroring_cfg.copy();
     copy.consumer_groups_mirroring_cfg = consumer_groups_mirroring_cfg.copy();
     copy.security_settings_sync_cfg = security_settings_sync_cfg.copy();
-    copy.schema_registry_sync_cfg = schema_registry_sync_cfg;
+    copy.schema_registry_sync_cfg = schema_registry_sync_cfg.copy();
     return copy;
 }
 
@@ -269,15 +375,103 @@ schema_registry_sync_config::shadow_entire_schema_registry::format_to(
     return fmt::format_to(it, "{{ shadow_entire_schema_registry }}");
 }
 
-fmt::iterator schema_registry_sync_config::format_to(fmt::iterator it) const {
-    if (sync_schema_registry_topic_mode.has_value()) {
-        return ss::visit(
-          *sync_schema_registry_topic_mode, [&it](const auto& mode) {
-              return fmt::format_to(
-                it, "{{ sync_schema_registry_topic_mode: {} }}", mode);
-          });
+fmt::iterator
+schema_registry_sync_config::basic_auth::format_to(fmt::iterator it) const {
+    auto time = std::format(
+      "{:%FT%H:%M:%S}", ::model::to_time_point(password_last_updated));
+    return fmt::format_to(
+      it,
+      "{{ basic_auth: {{ username: {}, password: ****, "
+      "password_last_updated: {} }} }}",
+      username,
+      time);
+}
+
+fmt::iterator
+schema_registry_sync_config::source_filter::format_to(fmt::iterator it) const {
+    return fmt::format_to(
+      it, "{{ contexts: {}, subjects: {} }}", contexts, subjects);
+}
+
+fmt::iterator schema_registry_sync_config::identity_context_mapping::format_to(
+  fmt::iterator it) const {
+    return fmt::format_to(it, "{{ identity_context_mapping }}");
+}
+
+fmt::iterator schema_registry_sync_config::exact_context_mapping::format_to(
+  fmt::iterator it) const {
+    return fmt::format_to(it, "{{ mappings: {} }}", mappings);
+}
+
+namespace {
+std::string_view to_string_view(
+  cluster_link::model::schema_registry_sync_config::unsupported_feature_policy
+    policy) {
+    using policy_t = cluster_link::model::schema_registry_sync_config::
+      unsupported_feature_policy;
+    switch (policy) {
+    case policy_t::fail:
+        return "fail";
+    case policy_t::remove:
+        return "remove";
     }
-    return fmt::format_to(it, "{{ sync_schema_registry_topic_mode: none }}");
+    vunreachable(
+      "Unknown unsupported_feature_policy {}", static_cast<int>(policy));
+}
+} // namespace
+
+fmt::iterator
+schema_registry_sync_config::shadow_schema_registry_api::format_to(
+  fmt::iterator it) const {
+    std::string auth = auth_config.has_value()
+                         ? ss::visit(
+                             *auth_config,
+                             [](const auto& authn) {
+                                 return fmt::format("{}", authn);
+                             })
+                         : std::string{"none"};
+    std::string destination_mapping
+      = destination.has_value()
+          ? ss::visit(
+              *destination,
+              [](const auto& mapping) { return fmt::format("{}", mapping); })
+          : std::string{"preserve-source-contexts"};
+    return fmt::format_to(
+      it,
+      "{{ shadow_schema_registry_api: {{ source_url: {}, auth_config: {}, "
+      "tls_enabled: {}, cert: {}, key: {:s}, ca: {}, tls_provide_sni: {}, "
+      "tail_interval: {}, full_sync_interval: {}, "
+      "max_source_requests_per_second: {}, source_filter: {}, destination: {}, "
+      "unsupported_schema_feature_policy: {} }} }}",
+      source_url,
+      auth,
+      tls_enabled,
+      cert,
+      key,
+      ca,
+      tls_provide_sni,
+      tail_interval,
+      full_sync_interval,
+      max_source_requests_per_second,
+      filter,
+      destination_mapping,
+      to_string_view(feature_policy));
+}
+
+fmt::iterator schema_registry_sync_config::format_to(fmt::iterator it) const {
+    if (!sync_mode.has_value()) {
+        return fmt::format_to(it, "{{ sync_mode: none }}");
+    }
+    return ss::visit(
+      *sync_mode,
+      [&it](const shadow_entire_schema_registry& mode) {
+          return fmt::format_to(
+            it, "{{ sync_schema_registry_topic_mode: {} }}", mode);
+      },
+      [&it](const shadow_schema_registry_api& api) {
+          return fmt::format_to(
+            it, "{{ sync_schema_registry_api_mode: {} }}", api);
+      });
 }
 } // namespace cluster_link::model
 

--- a/src/v/cluster_link/model/types.h
+++ b/src/v/cluster_link/model/types.h
@@ -519,7 +519,7 @@ struct topic_metadata_mirroring_config
 struct schema_registry_sync_config
   : serde::envelope<
       schema_registry_sync_config,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
     struct shadow_entire_schema_registry
       : serde::envelope<
@@ -535,17 +535,195 @@ struct schema_registry_sync_config
         fmt::iterator format_to(fmt::iterator) const;
     };
 
-    using shadow_schema_registry_mode_t
-      = serde::variant<shadow_entire_schema_registry>;
+    struct basic_auth
+      : serde::
+          envelope<basic_auth, serde::version<0>, serde::compat_version<0>> {
+        ss::sstring username;
+        ss::sstring password;
+        ::model::timestamp password_last_updated;
 
-    std::optional<shadow_schema_registry_mode_t>
-      sync_schema_registry_topic_mode;
+        friend bool operator==(const basic_auth&, const basic_auth&) = default;
 
-    auto serde_fields() { return std::tie(sync_schema_registry_topic_mode); }
+        auto serde_fields() {
+            return std::tie(username, password, password_last_updated);
+        }
+
+        fmt::iterator format_to(fmt::iterator) const;
+    };
+
+    using auth_config_t = serde::variant<basic_auth>;
+
+    struct source_filter
+      : serde::
+          envelope<source_filter, serde::version<0>, serde::compat_version<0>> {
+        chunked_vector<ss::sstring> contexts;
+        chunked_vector<ss::sstring> subjects;
+
+        friend bool
+        operator==(const source_filter&, const source_filter&) = default;
+
+        auto serde_fields() { return std::tie(contexts, subjects); }
+
+        source_filter copy() const;
+
+        fmt::iterator format_to(fmt::iterator) const;
+    };
+
+    struct identity_context_mapping
+      : serde::envelope<
+          identity_context_mapping,
+          serde::version<0>,
+          serde::compat_version<0>> {
+        friend bool operator==(
+          const identity_context_mapping&,
+          const identity_context_mapping&) = default;
+
+        auto serde_fields() { return std::tie(); }
+
+        fmt::iterator format_to(fmt::iterator) const;
+    };
+
+    struct exact_context_mapping
+      : serde::envelope<
+          exact_context_mapping,
+          serde::version<0>,
+          serde::compat_version<0>> {
+        // Source context name -> destination context name. The shadowing API
+        // requires every source context in scope to have exactly one mapping,
+        // so a map keyed by source encodes that uniqueness invariant and gives
+        // O(1) destination lookup during sync.
+        chunked_hash_map<ss::sstring, ss::sstring> mappings;
+
+        friend bool operator==(
+          const exact_context_mapping&, const exact_context_mapping&) = default;
+
+        auto serde_fields() { return std::tie(mappings); }
+
+        exact_context_mapping copy() const;
+
+        fmt::iterator format_to(fmt::iterator) const;
+    };
+
+    using destination_mapping_t
+      = serde::variant<identity_context_mapping, exact_context_mapping>;
+
+    enum class unsupported_feature_policy : uint8_t {
+        fail,
+        remove,
+    };
+
+    struct shadow_schema_registry_api
+      : serde::envelope<
+          shadow_schema_registry_api,
+          serde::version<0>,
+          serde::compat_version<0>> {
+        ss::sstring source_url;
+        std::optional<auth_config_t> auth_config;
+
+        connection_config::tls_enabled_t tls_enabled{
+          connection_config::tls_enabled_t::no};
+        std::optional<tls_file_or_value> cert;
+        std::optional<tls_file_or_value> key;
+        std::optional<tls_file_or_value> ca;
+        connection_config::tls_provide_sni_t tls_provide_sni{
+          connection_config::tls_provide_sni_t::yes};
+
+        std::optional<ss::lowres_clock::duration> tail_interval;
+        static constexpr auto default_tail_interval = std::chrono::seconds(10);
+        std::optional<ss::lowres_clock::duration> full_sync_interval;
+        static constexpr auto default_full_sync_interval = std::chrono::minutes(
+          5);
+        std::optional<int32_t> max_source_requests_per_second;
+        static constexpr auto default_max_source_requests_per_second = 30;
+
+        source_filter filter;
+        std::optional<destination_mapping_t> destination;
+        unsupported_feature_policy feature_policy{
+          unsupported_feature_policy::fail};
+
+        ss::lowres_clock::duration get_tail_interval() const {
+            return tail_interval.value_or(default_tail_interval);
+        }
+
+        ss::lowres_clock::duration get_full_sync_interval() const {
+            return full_sync_interval.value_or(default_full_sync_interval);
+        }
+
+        int32_t get_max_source_requests_per_second() const {
+            return max_source_requests_per_second.value_or(
+              default_max_source_requests_per_second);
+        }
+
+        friend bool operator==(
+          const shadow_schema_registry_api&,
+          const shadow_schema_registry_api&) = default;
+
+        auto serde_fields() {
+            return std::tie(
+              source_url,
+              auth_config,
+              tls_enabled,
+              cert,
+              key,
+              ca,
+              tls_provide_sni,
+              tail_interval,
+              full_sync_interval,
+              max_source_requests_per_second,
+              filter,
+              destination,
+              feature_policy);
+        }
+
+        shadow_schema_registry_api copy() const;
+
+        fmt::iterator format_to(fmt::iterator) const;
+    };
+
+    // At most one shadowing mode may be engaged. Modelling the two modes as a
+    // single variant makes the "both modes set" state unrepresentable. The
+    // on-wire layout still serializes as two separate optional fields (see
+    // serde_write/serde_read) to stay backwards compatible with v0 topic-mode
+    // records.
+    using shadow_schema_registry_mode_t = serde::
+      variant<shadow_entire_schema_registry, shadow_schema_registry_api>;
+
+    std::optional<shadow_schema_registry_mode_t> sync_mode;
+
+    /// Returns the API-based shadowing config when API mode is engaged, else
+    /// nullptr.
+    const shadow_schema_registry_api* api_mode() const {
+        if (
+          sync_mode.has_value()
+          && std::holds_alternative<shadow_schema_registry_api>(*sync_mode)) {
+            return &std::get<shadow_schema_registry_api>(*sync_mode);
+        }
+        return nullptr;
+    }
+    shadow_schema_registry_api* api_mode() {
+        if (
+          sync_mode.has_value()
+          && std::holds_alternative<shadow_schema_registry_api>(*sync_mode)) {
+            return &std::get<shadow_schema_registry_api>(*sync_mode);
+        }
+        return nullptr;
+    }
+
+    /// True when shadowing the entire Schema Registry via topic replication.
+    bool is_topic_mode() const {
+        return sync_mode.has_value()
+               && std::holds_alternative<shadow_entire_schema_registry>(
+                 *sync_mode);
+    }
+
+    void serde_write(iobuf&) const;
+    void serde_read(iobuf_parser&, const serde::header&);
 
     friend bool operator==(
       const schema_registry_sync_config&,
       const schema_registry_sync_config&) = default;
+
+    schema_registry_sync_config copy() const;
 
     fmt::iterator format_to(fmt::iterator) const;
 };

--- a/src/v/cluster_link/source_topic_syncer.cc
+++ b/src/v/cluster_link/source_topic_syncer.cc
@@ -188,11 +188,7 @@ std::optional<ss::sstring> is_valid_topic(
 }
 
 bool shadowing_entire_sr(const model::schema_registry_sync_config& cfg) {
-    return cfg.sync_schema_registry_topic_mode.has_value()
-           && std::holds_alternative<
-             ::cluster_link::model::schema_registry_sync_config::
-               shadow_entire_schema_registry>(
-             *cfg.sync_schema_registry_topic_mode);
+    return cfg.is_topic_mode();
 }
 
 bool select_topic(
@@ -214,11 +210,11 @@ source_topic_syncer::source_topic_syncer(
       config.configuration.topic_metadata_mirroring_cfg.get_task_interval(),
       source_topic_syncer::task_name)
   , _config(config.configuration.topic_metadata_mirroring_cfg.copy())
-  , _sr_config(config.configuration.schema_registry_sync_cfg) {}
+  , _sr_config(config.configuration.schema_registry_sync_cfg.copy()) {}
 
 void source_topic_syncer::update_config(const model::metadata& config) {
     _config = config.configuration.topic_metadata_mirroring_cfg.copy();
-    _sr_config = config.configuration.schema_registry_sync_cfg;
+    _sr_config = config.configuration.schema_registry_sync_cfg.copy();
     set_run_interval(
       config.configuration.topic_metadata_mirroring_cfg.get_task_interval());
 }

--- a/src/v/cluster_link/tests/source_topic_syncer_test.cc
+++ b/src/v/cluster_link/tests/source_topic_syncer_test.cc
@@ -225,8 +225,7 @@ TEST_F_CORO(source_topic_syncer_test, schema_registry_test) {
 
     // Now enable schema registry topic mirroring and ensure that it shows up
     auto update = co_await link_metadata->copy();
-    update.configuration.schema_registry_sync_cfg
-      .sync_schema_registry_topic_mode
+    update.configuration.schema_registry_sync_cfg.sync_mode
       = model::schema_registry_sync_config::shadow_entire_schema_registry{};
     auto link_id = fixture()->find_link_id_by_name(model::name_t("test_link"));
     ASSERT_TRUE_CORO(link_id.has_value());
@@ -258,7 +257,7 @@ TEST_F_CORO(source_topic_syncer_test, schema_registry_exists_but_empty) {
       cluster::errc::success);
 
     auto md = get_default_metadata();
-    md.configuration.schema_registry_sync_cfg.sync_schema_registry_topic_mode
+    md.configuration.schema_registry_sync_cfg.sync_mode
       = model::schema_registry_sync_config::shadow_entire_schema_registry{};
     co_await fixture()->upsert_link(std::move(md));
 
@@ -291,7 +290,7 @@ TEST_F_CORO(source_topic_syncer_test, schema_registry_exists_not_empty) {
       ::model::schema_registry_internal_tp, kafka::offset(10));
 
     auto md = get_default_metadata();
-    md.configuration.schema_registry_sync_cfg.sync_schema_registry_topic_mode
+    md.configuration.schema_registry_sync_cfg.sync_mode
       = model::schema_registry_sync_config::shadow_entire_schema_registry{};
     co_await fixture()->upsert_link(std::move(md));
 

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -47,6 +47,8 @@ std::string_view to_string_view(feature f) {
         return "shadow_linking";
     case feature::batch_mirror_topic_status:
         return "batch_mirror_topic_status";
+    case feature::shadow_link_sr_api_sync:
+        return "shadow_link_sr_api_sync";
     case feature::coordinated_compaction:
         return "coordinated_compaction";
     case feature::cloud_retention:

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -57,6 +57,7 @@ enum class feature : std::uint64_t {
     cloud_topics = 1ULL << 13U,
     tiered_cloud_topics = 1ULL << 14U,
     batch_mirror_topic_status = 1ULL << 15U,
+    shadow_link_sr_api_sync = 1ULL << 16U,
     node_isolation = 1ULL << 19U,
     group_offset_retention = 1ULL << 20U,
     membership_change_controller_cmds = 1ULL << 22U,
@@ -563,6 +564,12 @@ inline constexpr std::array feature_schema{
     release_version::v26_2_1,
     "batch_mirror_topic_status",
     feature::batch_mirror_topic_status,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    release_version::v26_2_1,
+    "shadow_link_sr_api_sync",
+    feature::shadow_link_sr_api_sync,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
 };

--- a/src/v/redpanda/admin/services/shadow_link/BUILD
+++ b/src/v/redpanda/admin/services/shadow_link/BUILD
@@ -56,6 +56,7 @@ redpanda_cc_library(
         "//src/v/cluster:partition_leaders_table",
         "//src/v/cluster_link:fwd",
         "//src/v/cluster_link/model",
+        "//src/v/features",
         "//src/v/redpanda/admin/proxy:client",
         "//src/v/serde/protobuf:rpc",
         "@seastar",

--- a/src/v/redpanda/admin/services/shadow_link/BUILD
+++ b/src/v/redpanda/admin/services/shadow_link/BUILD
@@ -5,11 +5,13 @@ redpanda_cc_library(
     srcs = ["converter.cc"],
     hdrs = ["converter.h"],
     implementation_deps = [
+        "//src/v/base",
         "//src/v/bytes:iobuf_parser",
         "//src/v/config",
         "//src/v/crypto",
         "//src/v/serde/protobuf:rpc",
         "//src/v/utils:base64",
+        "@abseil-cpp//absl/container:flat_hash_set",
         "@seastar",
     ],
     visibility = ["//src/v/redpanda/admin/services/shadow_link:__subpackages__"],

--- a/src/v/redpanda/admin/services/shadow_link/converter.cc
+++ b/src/v/redpanda/admin/services/shadow_link/converter.cc
@@ -11,6 +11,7 @@
 
 #include "redpanda/admin/services/shadow_link/converter.h"
 
+#include "base/vassert.h"
 #include "bytes/iobuf_parser.h"
 #include "cluster_link/model/types.h"
 #include "crypto/crypto.h"
@@ -18,6 +19,8 @@
 #include "utils/base64.h"
 
 #include <seastar/core/memory.hh>
+
+#include <absl/container/flat_hash_set.h>
 
 #include <algorithm>
 #include <new>
@@ -34,11 +37,19 @@ using proto::admin::acl_resource_filter;
 using proto::admin::authentication_configuration;
 using proto::admin::consumer_offset_sync_options;
 using proto::admin::create_shadow_link_request;
+using proto::admin::http_basic_auth_options;
 using proto::admin::name_filter;
 using proto::admin::plain_config;
+using proto::admin::schema_registry_auth_options;
+using proto::admin::schema_registry_context_destination;
+using proto::admin::schema_registry_context_map;
+using proto::admin::schema_registry_exact_context_mappings;
+using proto::admin::schema_registry_identity_context_mapping;
+using proto::admin::schema_registry_source_filter;
 using proto::admin::schema_registry_sync_options;
 using proto::admin::schema_registry_sync_options_shadow_schema_registry_api;
 using proto::admin::schema_registry_sync_options_shadow_schema_registry_topic;
+using proto::admin::schema_registry_sync_status;
 using proto::admin::scram_config;
 using proto::admin::scram_mechanism;
 using proto::admin::security_settings_sync_options;
@@ -54,6 +65,7 @@ using proto::admin::topic_metadata_sync_options;
 using proto::admin::topic_metadata_sync_options_earliest_offset;
 using proto::admin::topic_metadata_sync_options_latest_offset;
 using proto::admin::topic_partition_information;
+using proto::admin::unsupported_schema_feature_policy;
 using proto::admin::update_shadow_link_request;
 using proto::common::acl_operation;
 using proto::common::acl_pattern;
@@ -190,6 +202,215 @@ create_topic_metadata_mirroring_config(
     return config;
 }
 
+cluster_link::model::schema_registry_sync_config::auth_config_t
+create_schema_registry_auth_config(
+  const schema_registry_auth_options& options) {
+    return options.visit_auth_options(
+      [](const http_basic_auth_options& basic)
+        -> cluster_link::model::schema_registry_sync_config::auth_config_t {
+          if (basic.get_username().empty() || basic.get_password().empty()) {
+              throw std::invalid_argument(
+                "When setting Schema Registry HTTP Basic auth, must provide "
+                "username and password");
+          }
+          return cluster_link::model::schema_registry_sync_config::basic_auth{
+            .username = basic.get_username(), .password = basic.get_password()};
+      },
+      [](std::monostate)
+        -> cluster_link::model::schema_registry_sync_config::auth_config_t {
+          throw std::invalid_argument(
+            "schema_registry auth_options is set but not provided");
+      });
+}
+
+void set_schema_registry_tls_settings(
+  cluster_link::model::schema_registry_sync_config::shadow_schema_registry_api&
+    config,
+  const tls_settings& tls) {
+    config.tls_enabled = cluster_link::model::connection_config::tls_enabled_t{
+      tls.get_enabled()};
+    tls.visit_tls_settings(
+      [&config](const tls_file_settings& file) {
+          if (!file.get_ca_path().empty()) {
+              config.ca = cluster_link::model::tls_file_path(
+                file.get_ca_path());
+          }
+          if (!file.get_key_path().empty()) {
+              config.key = cluster_link::model::tls_file_path(
+                file.get_key_path());
+          }
+          if (!file.get_cert_path().empty()) {
+              config.cert = cluster_link::model::tls_file_path(
+                file.get_cert_path());
+          }
+          if (config.key.has_value() != config.cert.has_value()) {
+              throw std::invalid_argument(
+                "Must provide both key and cert or neither");
+          }
+      },
+      [&config](const tlspem_settings& pem) {
+          if (!pem.get_ca().empty()) {
+              config.ca = cluster_link::model::tls_value(
+                iobuf_to_string(pem.get_ca()));
+          }
+          if (!pem.get_key().empty()) {
+              config.key = cluster_link::model::tls_value(
+                iobuf_to_string(pem.get_key()));
+          }
+          if (!pem.get_cert().empty()) {
+              config.cert = cluster_link::model::tls_value(
+                iobuf_to_string(pem.get_cert()));
+          }
+          if (config.key.has_value() != config.cert.has_value()) {
+              throw std::invalid_argument(
+                "Must provide both key and cert or neither");
+          }
+      },
+      [](std::monostate) {});
+
+    config.tls_provide_sni
+      = cluster_link::model::connection_config::tls_provide_sni_t{
+        !tls.get_do_not_set_sni_hostname()};
+}
+
+cluster_link::model::schema_registry_sync_config::source_filter
+create_schema_registry_source_filter(
+  const schema_registry_source_filter& proto_filter) {
+    cluster_link::model::schema_registry_sync_config::source_filter filter;
+    filter.contexts = proto_filter.get_contexts().copy();
+    filter.subjects = proto_filter.get_subjects().copy();
+    return filter;
+}
+
+cluster_link::model::schema_registry_sync_config::destination_mapping_t
+create_context_destination(
+  const schema_registry_context_destination& destination) {
+    return destination.visit_mapping(
+      [](const schema_registry_identity_context_mapping&)
+        -> cluster_link::model::schema_registry_sync_config::
+          destination_mapping_t {
+              return cluster_link::model::schema_registry_sync_config::
+                identity_context_mapping{};
+          },
+      [](const schema_registry_exact_context_mappings& mappings)
+        -> cluster_link::model::schema_registry_sync_config::
+          destination_mapping_t {
+              cluster_link::model::schema_registry_sync_config::
+                exact_context_mapping exact;
+              exact.mappings.reserve(mappings.get_mappings().size());
+              absl::flat_hash_set<ss::sstring> seen_destinations;
+              seen_destinations.reserve(mappings.get_mappings().size());
+              for (const auto& mapping : mappings.get_mappings()) {
+                  auto [_, inserted] = exact.mappings.emplace(
+                    mapping.get_source(), mapping.get_destination());
+                  if (!inserted) {
+                      throw std::invalid_argument(
+                        fmt::format(
+                          "duplicate source context '{}' in exact context "
+                          "mapping",
+                          mapping.get_source()));
+                  }
+                  if (!seen_destinations.insert(mapping.get_destination())
+                         .second) {
+                      throw std::invalid_argument(
+                        fmt::format(
+                          "duplicate destination context '{}' in exact context "
+                          "mapping; each source context must map to a distinct "
+                          "destination context",
+                          mapping.get_destination()));
+                  }
+              }
+              return exact;
+          },
+      [](std::monostate)
+        -> cluster_link::model::schema_registry_sync_config::
+          destination_mapping_t {
+              throw std::invalid_argument(
+                "schema_registry destination is set but not provided");
+          });
+}
+
+cluster_link::model::schema_registry_sync_config::unsupported_feature_policy
+to_unsupported_feature_policy(unsupported_schema_feature_policy policy) {
+    using model_policy = cluster_link::model::schema_registry_sync_config::
+      unsupported_feature_policy;
+    switch (policy) {
+    case unsupported_schema_feature_policy::unspecified:
+    case unsupported_schema_feature_policy::fail:
+        return model_policy::fail;
+    case unsupported_schema_feature_policy::remove:
+        return model_policy::remove;
+    }
+    throw std::invalid_argument(
+      fmt::format(
+        "unknown unsupported_schema_feature_policy {}",
+        static_cast<int>(policy)));
+}
+
+cluster_link::model::schema_registry_sync_config::shadow_schema_registry_api
+create_shadow_schema_registry_api_config(
+  const schema_registry_sync_options_shadow_schema_registry_api& api) {
+    if (api.get_source_url().empty()) {
+        throw std::invalid_argument(
+          "schema_registry_api source_url must not be empty");
+    }
+
+    cluster_link::model::schema_registry_sync_config::shadow_schema_registry_api
+      config;
+    config.source_url = api.get_source_url();
+
+    if (api.get_auth_options().has_basic()) {
+        config.auth_config = create_schema_registry_auth_config(
+          api.get_auth_options());
+    }
+
+    if (api.has_tls_settings()) {
+        set_schema_registry_tls_settings(config, api.get_tls_settings());
+    }
+
+    if (api.get_tail_interval() < absl::ZeroDuration()) {
+        throw std::invalid_argument(
+          "schema_registry_api tail_interval must not be negative");
+    }
+    if (api.get_tail_interval() > absl::ZeroDuration()) {
+        config.tail_interval = absl::ToChronoNanoseconds(
+          api.get_tail_interval());
+    }
+
+    if (api.get_full_sync_interval() < absl::ZeroDuration()) {
+        throw std::invalid_argument(
+          "schema_registry_api full_sync_interval must not be negative");
+    }
+    if (api.get_full_sync_interval() > absl::ZeroDuration()) {
+        config.full_sync_interval = absl::ToChronoNanoseconds(
+          api.get_full_sync_interval());
+    }
+
+    if (api.get_max_source_requests_per_second() < 0) {
+        throw std::invalid_argument(
+          "schema_registry_api max_source_requests_per_second must not be "
+          "negative");
+    }
+    if (api.get_max_source_requests_per_second() > 0) {
+        config.max_source_requests_per_second
+          = api.get_max_source_requests_per_second();
+    }
+
+    config.filter = create_schema_registry_source_filter(
+      api.get_source_filter());
+
+    if (
+      api.get_destination().has_identity()
+      || api.get_destination().has_exact()) {
+        config.destination = create_context_destination(api.get_destination());
+    }
+
+    config.feature_policy = to_unsupported_feature_policy(
+      api.get_unsupported_schema_feature_policy());
+
+    return config;
+}
+
 cluster_link::model::schema_registry_sync_config
 create_schema_registry_sync_config(
   const schema_registry_sync_options& options) {
@@ -198,16 +419,14 @@ create_schema_registry_sync_config(
     options.visit_schema_registry_shadowing_mode(
       [&config](
         const schema_registry_sync_options_shadow_schema_registry_topic&) {
-          config.sync_schema_registry_topic_mode = cluster_link::model::
-            schema_registry_sync_config::shadow_entire_schema_registry{};
+          config.sync_mode = cluster_link::model::schema_registry_sync_config::
+            shadow_entire_schema_registry{};
       },
-      [](const schema_registry_sync_options_shadow_schema_registry_api&) {
-          throw std::invalid_argument(
-            "Schema Registry API shadowing is not supported");
+      [&config](
+        const schema_registry_sync_options_shadow_schema_registry_api& api) {
+          config.sync_mode = create_shadow_schema_registry_api_config(api);
       },
-      [&config](std::monostate) {
-          config.sync_schema_registry_topic_mode = std::nullopt;
-      });
+      [&config](std::monostate) { config.sync_mode = std::nullopt; });
 
     return config;
 }
@@ -699,6 +918,35 @@ tls_settings create_tls_settings(const cluster_link::model::metadata& md) {
     return tls;
 }
 
+tls_settings create_tls_settings(
+  const cluster_link::model::schema_registry_sync_config::
+    shadow_schema_registry_api& cfg) {
+    tls_settings tls;
+    tls.set_enabled(bool(cfg.tls_enabled));
+    if (cfg.ca.has_value()) {
+        ss::visit(
+          cfg.ca.value(),
+          [&tls](const cluster_link::model::tls_file_path& path) {
+              tls_file_settings file_settings;
+              file_settings.set_ca_path(ss::sstring{path});
+              tls.set_tls_file_settings(std::move(file_settings));
+          },
+          [&tls](const cluster_link::model::tls_value& value) {
+              tlspem_settings pem_settings;
+              pem_settings.set_ca(iobuf::from(value()));
+              tls.set_tls_pem_settings(std::move(pem_settings));
+          });
+    }
+
+    if (cfg.key.has_value() && cfg.cert.has_value()) {
+        std::visit(tls_visitor(&tls), cfg.key.value(), cfg.cert.value());
+    }
+
+    tls.set_do_not_set_sni_hostname(!bool(cfg.tls_provide_sni));
+
+    return tls;
+}
+
 shadow_link_client_options
 create_shadow_link_client_options(const cluster_link::model::metadata& md) {
     shadow_link_client_options options;
@@ -1001,18 +1249,137 @@ consumer_offset_sync_options create_consumer_offset_sync_options(
     return options;
 }
 
+schema_registry_auth_options create_schema_registry_auth_options(
+  const cluster_link::model::schema_registry_sync_config::auth_config_t&
+    auth_config) {
+    schema_registry_auth_options options;
+    ss::visit(
+      auth_config,
+      [&options](
+        const cluster_link::model::schema_registry_sync_config::basic_auth&
+          basic) {
+          http_basic_auth_options basic_options;
+          basic_options.set_username(ss::sstring{basic.username});
+          basic_options.set_password_set(true);
+          basic_options.set_password_set_at(
+            absl::FromChrono(
+              model::to_time_point(basic.password_last_updated)));
+          options.set_basic(std::move(basic_options));
+      });
+    return options;
+}
+
+schema_registry_source_filter create_schema_registry_source_filter(
+  const cluster_link::model::schema_registry_sync_config::source_filter&
+    filter) {
+    schema_registry_source_filter proto_filter;
+    proto_filter.set_contexts(filter.contexts.copy());
+    proto_filter.set_subjects(filter.subjects.copy());
+    return proto_filter;
+}
+
+schema_registry_context_destination create_context_destination(
+  const cluster_link::model::schema_registry_sync_config::destination_mapping_t&
+    destination) {
+    schema_registry_context_destination proto_destination;
+    ss::visit(
+      destination,
+      [&proto_destination](
+        const cluster_link::model::schema_registry_sync_config::
+          identity_context_mapping&) {
+          proto_destination.set_identity(
+            schema_registry_identity_context_mapping{});
+      },
+      [&proto_destination](
+        const cluster_link::model::schema_registry_sync_config::
+          exact_context_mapping& exact) {
+          schema_registry_exact_context_mappings exact_mappings;
+          chunked_vector<schema_registry_context_map> mappings;
+          mappings.reserve(exact.mappings.size());
+          for (const auto& [source, destination] : exact.mappings) {
+              schema_registry_context_map proto_mapping;
+              proto_mapping.set_source(ss::sstring{source});
+              proto_mapping.set_destination(ss::sstring{destination});
+              mappings.emplace_back(std::move(proto_mapping));
+          }
+          // The model stores mappings in an unordered map; sort by source so
+          // the API response is deterministic across reads.
+          std::ranges::sort(mappings, std::ranges::less{}, [](const auto& m) {
+              return m.get_source();
+          });
+          exact_mappings.set_mappings(std::move(mappings));
+          proto_destination.set_exact(std::move(exact_mappings));
+      });
+    return proto_destination;
+}
+
+unsupported_schema_feature_policy to_proto_unsupported_feature_policy(
+  cluster_link::model::schema_registry_sync_config::unsupported_feature_policy
+    policy) {
+    using model_policy = cluster_link::model::schema_registry_sync_config::
+      unsupported_feature_policy;
+    switch (policy) {
+    case model_policy::fail:
+        return unsupported_schema_feature_policy::fail;
+    case model_policy::remove:
+        return unsupported_schema_feature_policy::remove;
+    }
+    vunreachable(
+      "Unknown unsupported_feature_policy {}", static_cast<int>(policy));
+}
+
+schema_registry_sync_options_shadow_schema_registry_api
+create_shadow_schema_registry_api_options(
+  const cluster_link::model::schema_registry_sync_config::
+    shadow_schema_registry_api& cfg) {
+    schema_registry_sync_options_shadow_schema_registry_api api;
+    api.set_source_url(ss::sstring{cfg.source_url});
+
+    if (cfg.auth_config.has_value()) {
+        api.set_auth_options(
+          create_schema_registry_auth_options(*cfg.auth_config));
+    }
+
+    if (
+      cfg.tls_enabled || cfg.ca.has_value() || cfg.cert.has_value()
+      || cfg.key.has_value()) {
+        api.set_tls_settings(create_tls_settings(cfg));
+    }
+
+    api.set_tail_interval(
+      absl::FromChrono(
+        cfg.tail_interval.value_or(ss::lowres_clock::duration::zero())));
+    api.set_effective_tail_interval(absl::FromChrono(cfg.get_tail_interval()));
+    api.set_full_sync_interval(
+      absl::FromChrono(
+        cfg.full_sync_interval.value_or(ss::lowres_clock::duration::zero())));
+    api.set_effective_full_sync_interval(
+      absl::FromChrono(cfg.get_full_sync_interval()));
+    api.set_max_source_requests_per_second(
+      cfg.max_source_requests_per_second.value_or(0));
+    api.set_effective_max_source_requests_per_second(
+      cfg.get_max_source_requests_per_second());
+    api.set_source_filter(create_schema_registry_source_filter(cfg.filter));
+
+    if (cfg.destination.has_value()) {
+        api.set_destination(create_context_destination(*cfg.destination));
+    }
+
+    api.set_unsupported_schema_feature_policy(
+      to_proto_unsupported_feature_policy(cfg.feature_policy));
+
+    return api;
+}
+
 schema_registry_sync_options create_schema_registry_sync_options(
   const cluster_link::model::schema_registry_sync_config& cfg) {
     schema_registry_sync_options options;
-    if (cfg.sync_schema_registry_topic_mode.has_value()) {
-        ss::visit(
-          *cfg.sync_schema_registry_topic_mode,
-          [&options](
-            const cluster_link::model::schema_registry_sync_config::
-              shadow_entire_schema_registry&) {
-              options.set_shadow_schema_registry_topic(
-                schema_registry_sync_options_shadow_schema_registry_topic{});
-          });
+    if (const auto* api = cfg.api_mode(); api != nullptr) {
+        options.set_shadow_schema_registry_api(
+          create_shadow_schema_registry_api_options(*api));
+    } else if (cfg.is_topic_mode()) {
+        options.set_shadow_schema_registry_topic(
+          schema_registry_sync_options_shadow_schema_registry_topic{});
     }
 
     return options;
@@ -1127,6 +1494,12 @@ shadow_link_status create_shadow_link_status(
 
     std::ranges::sort(properties_synced);
     status.set_synced_shadow_topic_properties(std::move(properties_synced));
+
+    const auto& sr_cfg = md.configuration.schema_registry_sync_cfg;
+    if (sr_cfg.api_mode() != nullptr) {
+        status.set_schema_registry_sync_status(schema_registry_sync_status{});
+    }
+
     return status;
 }
 
@@ -1191,6 +1564,55 @@ void merge_input_only_fields(
             }
         }
     }
+
+    auto& schema_registry_options
+      = to.get_configurations().get_schema_registry_sync_options();
+    if (!schema_registry_options.has_shadow_schema_registry_api()) {
+        return;
+    }
+    auto& to_api = schema_registry_options.get_shadow_schema_registry_api();
+
+    const auto& from_sr_cfg = from.configuration.schema_registry_sync_cfg;
+    const auto* from_api_ptr = from_sr_cfg.api_mode();
+    if (from_api_ptr == nullptr) {
+        return;
+    }
+    const auto& from_api = *from_api_ptr;
+
+    if (
+      to_api.get_auth_options().has_basic() && from_api.auth_config.has_value()
+      && std::holds_alternative<
+        cluster_link::model::schema_registry_sync_config::basic_auth>(
+        *from_api.auth_config)) {
+        auto& to_basic = to_api.get_auth_options().get_basic();
+        if (
+          to_basic.get_password().empty() && !to_basic.get_username().empty()) {
+            const auto& from_basic = std::get<
+              cluster_link::model::schema_registry_sync_config::basic_auth>(
+              *from_api.auth_config);
+            to_basic.set_password(ss::sstring{from_basic.password});
+        }
+    }
+
+    if (
+      to_api.has_tls_settings()
+      && to_api.get_tls_settings().has_tls_pem_settings()) {
+        auto& to_pem = to_api.get_tls_settings().get_tls_pem_settings();
+        if (to_pem.get_key().empty() && !to_pem.get_cert().empty()) {
+            if (from_api.key.has_value()) {
+                ss::visit(
+                  from_api.key.value(),
+                  [&to_pem](
+                    const cluster_link::model::tls_value& value) mutable {
+                      to_pem.set_key(iobuf::from(value()));
+                  },
+                  [](const auto&) {
+                      throw std::invalid_argument(
+                        "Inconsistent Schema Registry TLS type used in update");
+                  });
+            }
+        }
+    }
 }
 
 // Used to merge in output only fields that are not set during conversion of
@@ -1201,14 +1623,56 @@ void merge_output_only_fields(
     to.connection.client_id = from.connection.client_id;
 }
 
+cluster_link::model::schema_registry_sync_config::shadow_schema_registry_api*
+schema_registry_api(cluster_link::model::metadata& md) {
+    return md.configuration.schema_registry_sync_cfg.api_mode();
+}
+
+const cluster_link::model::schema_registry_sync_config::
+  shadow_schema_registry_api*
+  schema_registry_api(const cluster_link::model::metadata& md) {
+    return md.configuration.schema_registry_sync_cfg.api_mode();
+}
+
+cluster_link::model::schema_registry_sync_config::basic_auth*
+schema_registry_basic_auth(
+  cluster_link::model::schema_registry_sync_config::shadow_schema_registry_api&
+    api) {
+    if (
+      !api.auth_config.has_value()
+      || !std::holds_alternative<
+         cluster_link::model::schema_registry_sync_config::basic_auth>(
+        *api.auth_config)) {
+        return nullptr;
+    }
+    return &std::get<
+      cluster_link::model::schema_registry_sync_config::basic_auth>(
+      *api.auth_config);
+}
+
+const cluster_link::model::schema_registry_sync_config::basic_auth*
+schema_registry_basic_auth(
+  const cluster_link::model::schema_registry_sync_config::
+    shadow_schema_registry_api& api) {
+    if (
+      !api.auth_config.has_value()
+      || !std::holds_alternative<
+         cluster_link::model::schema_registry_sync_config::basic_auth>(
+        *api.auth_config)) {
+        return nullptr;
+    }
+    return &std::get<
+      cluster_link::model::schema_registry_sync_config::basic_auth>(
+      *api.auth_config);
+}
+
 // Used to update any "change on" timestamps, e.g. the "password_set_at" field
 void update_timestamps(
   const cluster_link::model::metadata& from,
   cluster_link::model::metadata& to) {
-    if (from.connection.authn_config != to.connection.authn_config) {
-        if (!to.connection.authn_config.has_value()) {
-            return;
-        }
+    if (
+      from.connection.authn_config != to.connection.authn_config
+      && to.connection.authn_config.has_value()) {
         ss::visit(
           *to.connection.authn_config,
           [&from](cluster_link::model::scram_credentials& c) {
@@ -1237,21 +1701,52 @@ void update_timestamps(
               }
           });
     }
+
+    auto* to_api = schema_registry_api(to);
+    if (to_api == nullptr) {
+        return;
+    }
+    auto* to_basic = schema_registry_basic_auth(*to_api);
+    if (to_basic == nullptr) {
+        return;
+    }
+    const auto* from_api = schema_registry_api(from);
+    const auto* from_basic = from_api == nullptr
+                               ? nullptr
+                               : schema_registry_basic_auth(*from_api);
+    if (from_basic == nullptr) {
+        if (!to_basic->password.empty()) {
+            to_basic->password_last_updated = model::timestamp::now();
+        }
+        return;
+    }
+    to_basic->password_last_updated = from_basic->password_last_updated;
+    if (from_basic->password != to_basic->password) {
+        to_basic->password_last_updated = model::timestamp::now();
+    }
 }
 
 // Used to update the timestamps for metadata fields
 void update_timestamps(cluster_link::model::metadata& to) {
-    if (!to.connection.authn_config.has_value()) {
+    if (to.connection.authn_config.has_value()) {
+        ss::visit(
+          *to.connection.authn_config,
+          [](cluster_link::model::scram_credentials& c) {
+              if (c.password.empty()) {
+                  return;
+              }
+              c.password_last_updated = model::timestamp::now();
+          });
+    }
+
+    auto* api = schema_registry_api(to);
+    if (api == nullptr) {
         return;
     }
-    ss::visit(
-      *to.connection.authn_config,
-      [](cluster_link::model::scram_credentials& c) {
-          if (c.password.empty()) {
-              return;
-          }
-          c.password_last_updated = model::timestamp::now();
-      });
+    auto* basic = schema_registry_basic_auth(*api);
+    if (basic != nullptr && !basic->password.empty()) {
+        basic->password_last_updated = model::timestamp::now();
+    }
 }
 
 chunked_vector<topic_partition_information> status_to_partition_information(

--- a/src/v/redpanda/admin/services/shadow_link/shadow_link.cc
+++ b/src/v/redpanda/admin/services/shadow_link/shadow_link.cc
@@ -13,6 +13,7 @@
 
 #include "cluster/metadata_cache.h"
 #include "cluster_link/service.h"
+#include "features/feature_table.h"
 #include "redpanda/admin/services/shadow_link/converter.h"
 #include "redpanda/admin/services/shadow_link/err.h"
 #include "redpanda/admin/services/utils.h"
@@ -21,13 +22,30 @@
 namespace admin {
 ss::logger sllog("shadow_link_service");
 
+namespace {
+void check_sr_api_sync_supported(
+  const cluster_link::model::schema_registry_sync_config& cfg,
+  const features::feature_table& feature_table) {
+    if (cfg.api_mode() == nullptr) {
+        return;
+    }
+    if (!feature_table.is_active(features::feature::shadow_link_sr_api_sync)) {
+        throw serde::pb::rpc::failed_precondition_exception(
+          "Schema Registry API sync mode cannot be configured until the "
+          "cluster is fully upgraded");
+    }
+}
+} // namespace
+
 shadow_link_service_impl::shadow_link_service_impl(
   admin::proxy::client proxy_client,
   ss::sharded<cluster_link::service>* service,
-  ss::sharded<cluster::metadata_cache>* md_cache)
+  ss::sharded<cluster::metadata_cache>* md_cache,
+  ss::sharded<features::feature_table>* feature_table)
   : _proxy_client(std::move(proxy_client))
   , _service(service)
-  , _md_cache(md_cache) {}
+  , _md_cache(md_cache)
+  , _feature_table(feature_table) {}
 
 ss::future<proto::admin::create_shadow_link_response>
 shadow_link_service_impl::create_shadow_link(
@@ -46,6 +64,8 @@ shadow_link_service_impl::create_shadow_link(
     }
     vlog(sllog.info, "create_shadow_link: {}", req);
     auto md = convert_create_to_metadata(std::move(req));
+    check_sr_api_sync_supported(
+      md.configuration.schema_registry_sync_cfg, _feature_table->local());
     auto get_resp = _service->local().get_cluster_link(md.name);
     if (get_resp.has_value()) {
         throw serde::pb::rpc::already_exists_exception(
@@ -167,6 +187,8 @@ shadow_link_service_impl::update_shadow_link(
 
     auto update_cmd = create_update_cluster_link_config_cmd(
       std::move(req), std::move(current_link));
+    check_sr_api_sync_supported(
+      update_cmd.link_config.schema_registry_sync_cfg, _feature_table->local());
 
     auto updated_md = handle_error(
       co_await _service->local().update_cluster_link(

--- a/src/v/redpanda/admin/services/shadow_link/shadow_link.h
+++ b/src/v/redpanda/admin/services/shadow_link/shadow_link.h
@@ -14,6 +14,7 @@
 #include "cluster/fwd.h"
 #include "cluster_link/fwd.h"
 #include "cluster_link/model/types.h"
+#include "features/fwd.h"
 #include "proto/redpanda/core/admin/v2/shadow_link.proto.h"
 #include "redpanda/admin/proxy/client.h"
 
@@ -25,7 +26,8 @@ public:
     shadow_link_service_impl(
       admin::proxy::client proxy_client,
       ss::sharded<cluster_link::service>* service,
-      ss::sharded<cluster::metadata_cache>* md_cache);
+      ss::sharded<cluster::metadata_cache>* md_cache,
+      ss::sharded<features::feature_table>* feature_table);
 
     ss::future<proto::admin::create_shadow_link_response> create_shadow_link(
       serde::pb::rpc::context,
@@ -77,5 +79,6 @@ private:
 
     ss::sharded<cluster_link::service>* _service;
     ss::sharded<cluster::metadata_cache>* _md_cache;
+    ss::sharded<features::feature_table>* _feature_table;
 };
 } // namespace admin

--- a/src/v/redpanda/admin/services/shadow_link/tests/converter_test.cc
+++ b/src/v/redpanda/admin/services/shadow_link/tests/converter_test.cc
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include <optional>
 #include <utility>
 
 using namespace std::chrono_literals;
@@ -599,13 +600,7 @@ TEST(converter_test, create_with_metadata_sync_options) {
       md.configuration.topic_metadata_mirroring_cfg.topic_name_filters.size(),
       2);
     EXPECT_TRUE(md.configuration.topic_metadata_mirroring_cfg.exclude_default);
-    ASSERT_TRUE(md.configuration.schema_registry_sync_cfg
-                  .sync_schema_registry_topic_mode.has_value());
-    EXPECT_TRUE(
-      std::holds_alternative<cluster_link::model::schema_registry_sync_config::
-                               shadow_entire_schema_registry>(
-        *md.configuration.schema_registry_sync_cfg
-           .sync_schema_registry_topic_mode));
+    EXPECT_TRUE(md.configuration.schema_registry_sync_cfg.is_topic_mode());
 
     chunked_vector<cluster_link::model::resource_name_filter_pattern> expected{
       cluster_link::model::resource_name_filter_pattern{
@@ -948,9 +943,8 @@ TEST(converter_test, metadata_to_shadow_link_topic_mirroring_cfg) {
       }};
     md->configuration.topic_metadata_mirroring_cfg.exclude_default = true;
 
-    md->configuration.schema_registry_sync_cfg.sync_schema_registry_topic_mode
-      = cluster_link::model::schema_registry_sync_config::
-        shadow_entire_schema_registry{};
+    md->configuration.schema_registry_sync_cfg.sync_mode = cluster_link::model::
+      schema_registry_sync_config::shadow_entire_schema_registry{};
 
     auto sl = admin::metadata_to_shadow_link(std::move(md), {});
     const auto& topic_metadata_sync_options
@@ -1429,7 +1423,529 @@ proto::admin::create_shadow_link_request create_base_link() {
 
     return req;
 }
+
+proto::admin::schema_registry_sync_options_shadow_schema_registry_api
+create_schema_registry_api_options(
+  ss::sstring username = "sr-api-key",
+  std::optional<ss::sstring> password = ss::sstring{"sr-api-secret"}) {
+    proto::admin::http_basic_auth_options basic_auth;
+    basic_auth.set_username(std::move(username));
+    if (password.has_value()) {
+        basic_auth.set_password(std::move(*password));
+    }
+    proto::admin::schema_registry_auth_options auth_options;
+    auth_options.set_basic(std::move(basic_auth));
+
+    proto::admin::schema_registry_sync_options_shadow_schema_registry_api api;
+    api.set_source_url("https://schema-registry.example.com");
+    api.set_auth_options(std::move(auth_options));
+    return api;
+}
+
+cluster_link::model::metadata
+create_metadata_with_schema_registry_api_basic_auth(
+  ss::sstring password, model::timestamp password_last_updated) {
+    cluster_link::model::metadata md;
+    md.name = cluster_link::model::name_t{"test-link"};
+    md.uuid = cluster_link::model::uuid_t{uuid_t::create()};
+    md.connection.bootstrap_servers = {
+      net::unresolved_address("localhost", 9092)};
+
+    cluster_link::model::schema_registry_sync_config::shadow_schema_registry_api
+      api;
+    api.source_url = "https://schema-registry.example.com";
+    api.auth_config
+      = cluster_link::model::schema_registry_sync_config::basic_auth{
+        .username = "sr-api-key",
+        .password = std::move(password),
+        .password_last_updated = password_last_updated};
+    md.configuration.schema_registry_sync_cfg.sync_mode = std::move(api);
+    admin::set_client_id(md);
+    return md;
+}
+
+ss::lw_shared_ptr<cluster_link::model::metadata>
+copy_metadata_for_update(const cluster_link::model::metadata& md) {
+    return ss::make_lw_shared<cluster_link::model::metadata>({
+      .name = md.name,
+      .uuid = md.uuid,
+      .connection = md.connection,
+      .configuration = md.configuration.copy(),
+    });
+}
+
+proto::admin::update_shadow_link_request create_schema_registry_api_update(
+  proto::admin::schema_registry_sync_options_shadow_schema_registry_api api) {
+    proto::admin::update_shadow_link_request req;
+    req.get_shadow_link()
+      .get_configurations()
+      .get_schema_registry_sync_options()
+      .set_shadow_schema_registry_api(std::move(api));
+
+    serde::pb::field_mask mask;
+    mask.paths.emplace_back(
+      serde::pb::field_mask::path{
+        "configurations", "schema_registry_sync_options"});
+    req.set_update_mask(std::move(mask));
+
+    return req;
+}
 } // namespace
+
+TEST(converter_test, create_with_schema_registry_api_sync_options) {
+    auto req = create_base_link();
+
+    proto::admin::http_basic_auth_options basic_auth;
+    basic_auth.set_username("sr-api-key");
+    basic_auth.set_password("sr-api-secret");
+    proto::admin::schema_registry_auth_options auth_options;
+    auth_options.set_basic(std::move(basic_auth));
+
+    proto::common::tls_file_settings file_settings;
+    file_settings.set_ca_path("/etc/redpanda/sr-ca.crt");
+    file_settings.set_cert_path("/etc/redpanda/sr-client.crt");
+    file_settings.set_key_path("/etc/redpanda/sr-client.key");
+    proto::common::tls_settings tls_settings;
+    tls_settings.set_enabled(true);
+    tls_settings.set_tls_file_settings(std::move(file_settings));
+
+    proto::admin::schema_registry_source_filter source_filter;
+    source_filter.set_contexts({".", ".prod"});
+    source_filter.set_subjects({"orders-value", ":.prod:payments-value"});
+
+    proto::admin::schema_registry_context_map prod_mapping;
+    prod_mapping.set_source(".prod");
+    prod_mapping.set_destination(".shadow-prod");
+    chunked_vector<proto::admin::schema_registry_context_map> mappings;
+    mappings.emplace_back(std::move(prod_mapping));
+    proto::admin::schema_registry_exact_context_mappings exact_mappings;
+    exact_mappings.set_mappings(std::move(mappings));
+    proto::admin::schema_registry_context_destination destination;
+    destination.set_exact(std::move(exact_mappings));
+
+    proto::admin::schema_registry_sync_options_shadow_schema_registry_api api;
+    api.set_source_url("https://schema-registry.example.com");
+    api.set_auth_options(std::move(auth_options));
+    api.set_tls_settings(std::move(tls_settings));
+    api.set_tail_interval(absl::Seconds(17));
+    api.set_full_sync_interval(absl::Minutes(7));
+    api.set_max_source_requests_per_second(77);
+    api.set_source_filter(std::move(source_filter));
+    api.set_destination(std::move(destination));
+    api.set_unsupported_schema_feature_policy(
+      proto::admin::unsupported_schema_feature_policy::remove);
+
+    req.get_shadow_link()
+      .get_configurations()
+      .get_schema_registry_sync_options()
+      .set_shadow_schema_registry_api(std::move(api));
+
+    auto now = model::to_time_point(model::timestamp::now());
+    auto md = admin::convert_create_to_metadata(std::move(req));
+
+    EXPECT_FALSE(md.configuration.schema_registry_sync_cfg.is_topic_mode());
+    const auto* mode = md.configuration.schema_registry_sync_cfg.api_mode();
+    ASSERT_NE(mode, nullptr);
+
+    const auto& sr_api = *mode;
+    EXPECT_EQ(sr_api.source_url, "https://schema-registry.example.com");
+    ASSERT_TRUE(sr_api.auth_config.has_value());
+    ASSERT_TRUE(
+      std::holds_alternative<
+        cluster_link::model::schema_registry_sync_config::basic_auth>(
+        *sr_api.auth_config));
+    const auto& auth
+      = std::get<cluster_link::model::schema_registry_sync_config::basic_auth>(
+        *sr_api.auth_config);
+    EXPECT_EQ(auth.username, "sr-api-key");
+    EXPECT_EQ(auth.password, "sr-api-secret");
+    auto pwd_updated = model::to_time_point(auth.password_last_updated);
+    EXPECT_GE(pwd_updated, now - 5s);
+    EXPECT_LE(pwd_updated, now + 5s);
+
+    EXPECT_TRUE(sr_api.tls_enabled);
+    ASSERT_TRUE(sr_api.ca.has_value());
+    ASSERT_TRUE(
+      std::holds_alternative<cluster_link::model::tls_file_path>(*sr_api.ca));
+    EXPECT_EQ(
+      std::get<cluster_link::model::tls_file_path>(*sr_api.ca)(),
+      "/etc/redpanda/sr-ca.crt");
+    ASSERT_TRUE(sr_api.cert.has_value());
+    ASSERT_TRUE(
+      std::holds_alternative<cluster_link::model::tls_file_path>(*sr_api.cert));
+    EXPECT_EQ(
+      std::get<cluster_link::model::tls_file_path>(*sr_api.cert)(),
+      "/etc/redpanda/sr-client.crt");
+    ASSERT_TRUE(sr_api.key.has_value());
+    ASSERT_TRUE(
+      std::holds_alternative<cluster_link::model::tls_file_path>(*sr_api.key));
+    EXPECT_EQ(
+      std::get<cluster_link::model::tls_file_path>(*sr_api.key)(),
+      "/etc/redpanda/sr-client.key");
+
+    EXPECT_EQ(sr_api.tail_interval, 17s);
+    EXPECT_EQ(sr_api.full_sync_interval, 7min);
+    EXPECT_EQ(sr_api.max_source_requests_per_second, 77);
+    EXPECT_EQ(
+      sr_api.filter.contexts, chunked_vector<ss::sstring>({".", ".prod"}));
+    EXPECT_EQ(
+      sr_api.filter.subjects,
+      chunked_vector<ss::sstring>({"orders-value", ":.prod:payments-value"}));
+
+    ASSERT_TRUE(sr_api.destination.has_value());
+    ASSERT_TRUE(
+      std::holds_alternative<cluster_link::model::schema_registry_sync_config::
+                               exact_context_mapping>(*sr_api.destination));
+    const auto& exact = std::get<
+      cluster_link::model::schema_registry_sync_config::exact_context_mapping>(
+      *sr_api.destination);
+    ASSERT_EQ(exact.mappings.size(), 1);
+    auto prod = exact.mappings.find(".prod");
+    ASSERT_NE(prod, exact.mappings.end());
+    EXPECT_EQ(prod->second, ".shadow-prod");
+    EXPECT_EQ(
+      sr_api.feature_policy,
+      cluster_link::model::schema_registry_sync_config::
+        unsupported_feature_policy::remove);
+}
+
+// The proto contract requires every source context to have exactly one
+// destination mapping; the model stores mappings keyed by source, so a
+// duplicate source in the request must be rejected rather than silently
+// collapsed.
+TEST(converter_test, create_with_duplicate_exact_context_mapping_rejected) {
+    auto req = create_base_link();
+
+    proto::admin::schema_registry_context_map first;
+    first.set_source(".prod");
+    first.set_destination(".shadow-prod");
+    proto::admin::schema_registry_context_map duplicate;
+    duplicate.set_source(".prod");
+    duplicate.set_destination(".other-prod");
+    chunked_vector<proto::admin::schema_registry_context_map> mappings;
+    mappings.emplace_back(std::move(first));
+    mappings.emplace_back(std::move(duplicate));
+    proto::admin::schema_registry_exact_context_mappings exact_mappings;
+    exact_mappings.set_mappings(std::move(mappings));
+    proto::admin::schema_registry_context_destination destination;
+    destination.set_exact(std::move(exact_mappings));
+
+    proto::admin::schema_registry_sync_options_shadow_schema_registry_api api;
+    api.set_source_url("https://schema-registry.example.com");
+    api.set_destination(std::move(destination));
+
+    req.get_shadow_link()
+      .get_configurations()
+      .get_schema_registry_sync_options()
+      .set_shadow_schema_registry_api(std::move(api));
+
+    EXPECT_THROW(
+      admin::convert_create_to_metadata(std::move(req)),
+      serde::pb::rpc::invalid_argument_exception);
+}
+
+// The proto contract requires each source context to map to a distinct
+// destination context. Two distinct sources mapping to the same destination
+// would merge unrelated source contexts in the destination Schema Registry, so
+// the request must be rejected.
+TEST(converter_test, create_with_colliding_exact_destination_rejected) {
+    auto req = create_base_link();
+
+    proto::admin::schema_registry_context_map prod;
+    prod.set_source(".prod");
+    prod.set_destination(".shared");
+    proto::admin::schema_registry_context_map staging;
+    staging.set_source(".staging");
+    staging.set_destination(".shared");
+    chunked_vector<proto::admin::schema_registry_context_map> mappings;
+    mappings.emplace_back(std::move(prod));
+    mappings.emplace_back(std::move(staging));
+    proto::admin::schema_registry_exact_context_mappings exact_mappings;
+    exact_mappings.set_mappings(std::move(mappings));
+    proto::admin::schema_registry_context_destination destination;
+    destination.set_exact(std::move(exact_mappings));
+
+    proto::admin::schema_registry_sync_options_shadow_schema_registry_api api;
+    api.set_source_url("https://schema-registry.example.com");
+    api.set_destination(std::move(destination));
+
+    req.get_shadow_link()
+      .get_configurations()
+      .get_schema_registry_sync_options()
+      .set_shadow_schema_registry_api(std::move(api));
+
+    EXPECT_THROW(
+      admin::convert_create_to_metadata(std::move(req)),
+      serde::pb::rpc::invalid_argument_exception);
+}
+
+TEST(converter_test, create_with_schema_registry_api_sync_options_invalid) {
+    {
+        auto req = create_base_link();
+        proto::admin::schema_registry_sync_options_shadow_schema_registry_api
+          api;
+        req.get_shadow_link()
+          .get_configurations()
+          .get_schema_registry_sync_options()
+          .set_shadow_schema_registry_api(std::move(api));
+
+        EXPECT_THROW(
+          admin::convert_create_to_metadata(std::move(req)),
+          serde::pb::rpc::invalid_argument_exception);
+    }
+    {
+        auto req = create_base_link();
+        auto api = create_schema_registry_api_options();
+        api.set_tail_interval(absl::Seconds(-1));
+        req.get_shadow_link()
+          .get_configurations()
+          .get_schema_registry_sync_options()
+          .set_shadow_schema_registry_api(std::move(api));
+
+        EXPECT_THROW(
+          admin::convert_create_to_metadata(std::move(req)),
+          serde::pb::rpc::invalid_argument_exception);
+    }
+    {
+        auto req = create_base_link();
+        auto api = create_schema_registry_api_options();
+        api.set_full_sync_interval(absl::Seconds(-1));
+        req.get_shadow_link()
+          .get_configurations()
+          .get_schema_registry_sync_options()
+          .set_shadow_schema_registry_api(std::move(api));
+
+        EXPECT_THROW(
+          admin::convert_create_to_metadata(std::move(req)),
+          serde::pb::rpc::invalid_argument_exception);
+    }
+    {
+        auto req = create_base_link();
+        auto api = create_schema_registry_api_options();
+        api.set_max_source_requests_per_second(-1);
+        req.get_shadow_link()
+          .get_configurations()
+          .get_schema_registry_sync_options()
+          .set_shadow_schema_registry_api(std::move(api));
+
+        EXPECT_THROW(
+          admin::convert_create_to_metadata(std::move(req)),
+          serde::pb::rpc::invalid_argument_exception);
+    }
+    {
+        auto req = create_base_link();
+        auto api = create_schema_registry_api_options();
+        api.set_unsupported_schema_feature_policy(
+          static_cast<proto::admin::unsupported_schema_feature_policy>(123));
+        req.get_shadow_link()
+          .get_configurations()
+          .get_schema_registry_sync_options()
+          .set_shadow_schema_registry_api(std::move(api));
+
+        EXPECT_THROW(
+          admin::convert_create_to_metadata(std::move(req)),
+          serde::pb::rpc::invalid_argument_exception);
+    }
+    {
+        auto req = create_base_link();
+        auto api = create_schema_registry_api_options(
+          ss::sstring{}, ss::sstring{"sr-api-secret"});
+        req.get_shadow_link()
+          .get_configurations()
+          .get_schema_registry_sync_options()
+          .set_shadow_schema_registry_api(std::move(api));
+
+        EXPECT_THROW(
+          admin::convert_create_to_metadata(std::move(req)),
+          serde::pb::rpc::invalid_argument_exception);
+    }
+    {
+        auto req = create_base_link();
+        auto api = create_schema_registry_api_options(
+          "sr-api-key", ss::sstring{});
+        req.get_shadow_link()
+          .get_configurations()
+          .get_schema_registry_sync_options()
+          .set_shadow_schema_registry_api(std::move(api));
+
+        EXPECT_THROW(
+          admin::convert_create_to_metadata(std::move(req)),
+          serde::pb::rpc::invalid_argument_exception);
+    }
+    {
+        auto req = create_base_link();
+        auto api = create_schema_registry_api_options();
+        proto::common::tls_file_settings file_settings;
+        file_settings.set_cert_path("/etc/redpanda/sr-client.crt");
+        proto::common::tls_settings tls_settings;
+        tls_settings.set_tls_file_settings(std::move(file_settings));
+        api.set_tls_settings(std::move(tls_settings));
+        req.get_shadow_link()
+          .get_configurations()
+          .get_schema_registry_sync_options()
+          .set_shadow_schema_registry_api(std::move(api));
+
+        EXPECT_THROW(
+          admin::convert_create_to_metadata(std::move(req)),
+          serde::pb::rpc::invalid_argument_exception);
+    }
+}
+
+TEST(converter_test, update_schema_registry_basic_auth_preserves_password) {
+    auto password_last_updated = model::timestamp{1759193250080};
+    auto current_md = create_metadata_with_schema_registry_api_basic_auth(
+      "old-password", password_last_updated);
+    auto req = create_schema_registry_api_update(
+      create_schema_registry_api_options("sr-api-key", std::nullopt));
+
+    auto update_cmd = admin::create_update_cluster_link_config_cmd(
+      std::move(req), copy_metadata_for_update(current_md));
+
+    const auto* api
+      = update_cmd.link_config.schema_registry_sync_cfg.api_mode();
+    ASSERT_NE(api, nullptr);
+    ASSERT_TRUE(api->auth_config.has_value());
+    const auto& basic
+      = std::get<cluster_link::model::schema_registry_sync_config::basic_auth>(
+        *api->auth_config);
+    EXPECT_EQ(basic.username, "sr-api-key");
+    EXPECT_EQ(basic.password, "old-password");
+    EXPECT_EQ(basic.password_last_updated, password_last_updated);
+}
+
+TEST(
+  converter_test,
+  update_schema_registry_basic_auth_preserves_timestamp_for_same_password) {
+    auto password_last_updated = model::timestamp{1759193250080};
+    auto current_md = create_metadata_with_schema_registry_api_basic_auth(
+      "old-password", password_last_updated);
+    auto req = create_schema_registry_api_update(
+      create_schema_registry_api_options(
+        "sr-api-key", ss::sstring{"old-password"}));
+
+    auto update_cmd = admin::create_update_cluster_link_config_cmd(
+      std::move(req), copy_metadata_for_update(current_md));
+
+    const auto* api
+      = update_cmd.link_config.schema_registry_sync_cfg.api_mode();
+    ASSERT_NE(api, nullptr);
+    ASSERT_TRUE(api->auth_config.has_value());
+    const auto& basic
+      = std::get<cluster_link::model::schema_registry_sync_config::basic_auth>(
+        *api->auth_config);
+    EXPECT_EQ(basic.password, "old-password");
+    EXPECT_EQ(basic.password_last_updated, password_last_updated);
+}
+
+TEST(
+  converter_test,
+  update_schema_registry_basic_auth_updates_timestamp_for_changed_password) {
+    auto current_md = create_metadata_with_schema_registry_api_basic_auth(
+      "old-password", model::timestamp{1759193250080});
+    auto req = create_schema_registry_api_update(
+      create_schema_registry_api_options(
+        "sr-api-key", ss::sstring{"new-password"}));
+
+    auto now = model::to_time_point(model::timestamp::now());
+    auto update_cmd = admin::create_update_cluster_link_config_cmd(
+      std::move(req), copy_metadata_for_update(current_md));
+
+    const auto* api
+      = update_cmd.link_config.schema_registry_sync_cfg.api_mode();
+    ASSERT_NE(api, nullptr);
+    ASSERT_TRUE(api->auth_config.has_value());
+    const auto& basic
+      = std::get<cluster_link::model::schema_registry_sync_config::basic_auth>(
+        *api->auth_config);
+    EXPECT_EQ(basic.password, "new-password");
+    auto pwd_updated = model::to_time_point(basic.password_last_updated);
+    EXPECT_GE(pwd_updated, now - 5s);
+    EXPECT_LE(pwd_updated, now + 5s);
+}
+
+TEST(converter_test, metadata_to_shadow_link_schema_registry_api_options) {
+    auto uuid = uuid_t::create();
+    auto md = ss::make_lw_shared<cluster_link::model::metadata>();
+    md->name = cluster_link::model::name_t{"test-link"};
+    md->uuid = cluster_link::model::uuid_t(uuid);
+    md->connection.bootstrap_servers = {
+      net::unresolved_address("localhost", 9092)};
+    cluster_link::model::schema_registry_sync_config::shadow_schema_registry_api
+      api;
+    api.source_url = "https://schema-registry.example.com";
+    api.auth_config
+      = cluster_link::model::schema_registry_sync_config::basic_auth{
+        .username = "sr-api-key",
+        .password = "sr-api-secret",
+        .password_last_updated = model::timestamp{1759193250080}};
+    api.tls_enabled
+      = cluster_link::model::connection_config::tls_enabled_t::yes;
+    api.ca = cluster_link::model::tls_file_path{"/etc/redpanda/sr-ca.crt"};
+    api.cert = cluster_link::model::tls_file_path{
+      "/etc/redpanda/sr-client.crt"};
+    api.key = cluster_link::model::tls_file_path{"/etc/redpanda/sr-client.key"};
+    api.tail_interval = 17s;
+    api.full_sync_interval = 7min;
+    api.max_source_requests_per_second = 77;
+    api.filter.contexts = {".", ".prod"};
+    api.filter.subjects = {"orders-value", ":.prod:payments-value"};
+    api.destination = cluster_link::model::schema_registry_sync_config::
+      identity_context_mapping{};
+    api.feature_policy = cluster_link::model::schema_registry_sync_config::
+      unsupported_feature_policy::remove;
+    md->configuration.schema_registry_sync_cfg.sync_mode = std::move(api);
+
+    auto sl = admin::metadata_to_shadow_link(std::move(md), {});
+
+    const auto& options
+      = sl.get_configurations().get_schema_registry_sync_options();
+    ASSERT_TRUE(options.has_shadow_schema_registry_api());
+    const auto& proto_api = options.get_shadow_schema_registry_api();
+    EXPECT_EQ(
+      proto_api.get_source_url(), "https://schema-registry.example.com");
+    ASSERT_TRUE(proto_api.get_auth_options().has_basic());
+    EXPECT_EQ(
+      proto_api.get_auth_options().get_basic().get_username(), "sr-api-key");
+    EXPECT_TRUE(
+      proto_api.get_auth_options().get_basic().get_password().empty());
+    EXPECT_TRUE(proto_api.get_auth_options().get_basic().get_password_set());
+    EXPECT_EQ(
+      proto_api.get_auth_options().get_basic().get_password_set_at(),
+      absl::FromUnixMillis(1759193250080));
+
+    ASSERT_TRUE(proto_api.has_tls_settings());
+    ASSERT_TRUE(proto_api.get_tls_settings().has_tls_file_settings());
+    const auto& tls_file_settings
+      = proto_api.get_tls_settings().get_tls_file_settings();
+    EXPECT_TRUE(proto_api.get_tls_settings().get_enabled());
+    EXPECT_EQ(tls_file_settings.get_ca_path(), "/etc/redpanda/sr-ca.crt");
+    EXPECT_EQ(tls_file_settings.get_cert_path(), "/etc/redpanda/sr-client.crt");
+    EXPECT_EQ(tls_file_settings.get_key_path(), "/etc/redpanda/sr-client.key");
+
+    EXPECT_EQ(proto_api.get_tail_interval(), absl::Seconds(17));
+    EXPECT_EQ(proto_api.get_effective_tail_interval(), absl::Seconds(17));
+    EXPECT_EQ(proto_api.get_full_sync_interval(), absl::Minutes(7));
+    EXPECT_EQ(proto_api.get_effective_full_sync_interval(), absl::Minutes(7));
+    EXPECT_EQ(proto_api.get_max_source_requests_per_second(), 77);
+    EXPECT_EQ(proto_api.get_effective_max_source_requests_per_second(), 77);
+    EXPECT_EQ(
+      proto_api.get_source_filter().get_contexts(),
+      chunked_vector<ss::sstring>({".", ".prod"}));
+    EXPECT_EQ(
+      proto_api.get_source_filter().get_subjects(),
+      chunked_vector<ss::sstring>({"orders-value", ":.prod:payments-value"}));
+    EXPECT_TRUE(proto_api.get_destination().has_identity());
+    EXPECT_EQ(
+      proto_api.get_unsupported_schema_feature_policy(),
+      proto::admin::unsupported_schema_feature_policy::remove);
+
+    EXPECT_EQ(
+      sl.get_status()
+        .get_schema_registry_sync_status()
+        .get_current_sync()
+        .get_sync_type(),
+      proto::admin::schema_registry_sync_type::unspecified);
+}
 
 TEST(converter_test, test_convert_timestamp) {
     {

--- a/src/v/redpanda/application_admin.cc
+++ b/src/v/redpanda/application_admin.cc
@@ -83,7 +83,10 @@ void application::configure_admin_server(model::node_id node_id) {
           // Add RPC services
           s.add_service(
             std::make_unique<admin::shadow_link_service_impl>(
-              create_client(), &_cluster_link_service, &metadata_cache));
+              create_client(),
+              &_cluster_link_service,
+              &metadata_cache,
+              &controller->get_feature_table()));
           s.add_service(
             std::make_unique<admin::debug_service_impl>(
               create_client(), stress_fiber_manager));

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -200,6 +200,13 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
     def _expect_connect_error(self, expected_code: ConnectErrorCode):
         return expect_exception(ConnectError, lambda e: e.code == expected_code)
 
+    def _schema_registry_api_sync_options(
+        self,
+    ) -> shadow_link_pb2.SchemaRegistrySyncOptions.ShadowSchemaRegistryApi:
+        return shadow_link_pb2.SchemaRegistrySyncOptions.ShadowSchemaRegistryApi(
+            source_url="http://schema-registry.example.com:8081"
+        )
+
     def _topics_are_present_in_target_cluster(self, topics):
         target_rpk = RpkTool(self.target_cluster.service)
         topics_in_target = {t for t in target_rpk.list_topics()}
@@ -211,6 +218,39 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
                 return False
 
         return True
+
+    @cluster(num_nodes=6)
+    def test_schema_registry_api_sync_rejected_when_feature_inactive(self):
+        self.target_cluster_service.set_feature_active("shadow_link_sr_api_sync", False)
+
+        create_req = self.create_default_link_request(
+            link_name="sr-api-link",
+            mirror_all_acls=False,
+            mirror_all_groups=False,
+            mirror_all_topics=False,
+        )
+        create_req.shadow_link.configurations.schema_registry_sync_options.shadow_schema_registry_api.CopyFrom(
+            self._schema_registry_api_sync_options()
+        )
+
+        with self._expect_connect_error(ConnectErrorCode.FAILED_PRECONDITION):
+            self.create_link_with_request(req=create_req)
+
+        shadow_link = self.create_link(
+            "test-link",
+            mirror_all_acls=False,
+            mirror_all_groups=False,
+            mirror_all_topics=False,
+        )
+        shadow_link.configurations.schema_registry_sync_options.shadow_schema_registry_api.CopyFrom(
+            self._schema_registry_api_sync_options()
+        )
+        update_mask = google.protobuf.field_mask_pb2.FieldMask(
+            paths=["configurations.schema_registry_sync_options"]
+        )
+
+        with self._expect_connect_error(ConnectErrorCode.FAILED_PRECONDITION):
+            self.update_link(shadow_link=shadow_link, update_mask=update_mask)
 
     @cluster(num_nodes=6)
     def test_create_default_link(self):


### PR DESCRIPTION
This PR introduces:
- base model types with serde to represent the new schema registry shadowing configurations
- a feature that activates in 26.2 to ensure that we don't allow configuring this new shadowing configuration mid-upgrade
- converters and validation logic to convert between the protobuf types and the internal model types

https://redpandadata.atlassian.net/browse/CORE-16416

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
