### PR TITLE
serde/variant: allow appending alternatives compatibly

### DIFF
--- a/src/v/serde/rw/variant.h
+++ b/src/v/serde/rw/variant.h
@@ -29,10 +29,23 @@ namespace serde {
 //
 // # Variant Wire Compatibility:
 //
-// Variant is treated as a primitive atomic type, that means that *any* changes
-// to the variant itself is not backwards compatible. `serde::variant` should
-// always be wrapped in another `serde::envelope` to allow for changing the
-// variant, and that wrapper struct needs to handle changes to the variant.
+// The wire format is: [variant size][active index][active alternative].
+// Compatibility is positional: the active index must map to the same type in
+// every definition that may read or write the value.
+//
+// Compatible changes:
+//   - Append alternatives to the end. Existing indexes keep their meaning, so
+//     readers can read values whose active index they know, even if the
+//     serialized variant size differs.
+//     Note: writing a newly appended alternative still requires rollout gating;
+//     older readers cannot read an active index that is not in their
+//     definition.
+//
+// Incompatible changes:
+//   - Reordering alternatives.
+//   - Inserting alternatives before existing alternatives.
+//   - Removing alternatives that may appear on the wire.
+//   - Changing the type at an existing index.
 template<typename... Types>
 struct variant : public std::variant<Types...> {
     using type = std::variant<Types...>;
@@ -141,29 +154,25 @@ void tag_invoke(
     using Type = std::decay_t<decltype(t)>;
     using UnderlyingType = Type::type;
 
-    auto size = read_nested<size_t>(in, bytes_left_limit);
+    // The serialized size is intentionally *not* required to match the current
+    // variant size: appending alternatives keeps the index -> type mapping
+    // stable, so a differing size is expected when reading across versions. We
+    // only validate that the active index is known to the current definition.
+    auto serialized_size = read_nested<size_t>(in, bytes_left_limit);
     auto index = read_nested<size_t>(in, bytes_left_limit);
 
-    if (size != std::variant_size_v<UnderlyingType>) [[unlikely]] {
-        throw serde_exception(fmt_with_ctx(
-          ssx::sformat,
-          "reading type {} of size {}: {} bytes left - unexpected variant "
-          "size: {}, current variant size: {}, likely backwards compat issues.",
-          type_str<Type>(),
-          sizeof(Type),
-          in.bytes_left(),
-          size,
-          std::variant_size_v<UnderlyingType>));
-    }
     if (index >= std::variant_size_v<UnderlyingType>) [[unlikely]] {
         throw serde_exception(fmt_with_ctx(
           ssx::sformat,
-          "reading type {} of size {}: {} bytes left - unexpected variant "
-          "index: {}, variant size: {}",
+          "reading type {} of size {}: {} bytes left - variant index {} is out "
+          "of range for the current definition (serialized variant size: {}, "
+          "current variant size: {}); the active alternative is not known to "
+          "this binary, likely a compatibility issue.",
           type_str<Type>(),
           sizeof(Type),
           in.bytes_left(),
           index,
+          serialized_size,
           std::variant_size_v<UnderlyingType>));
     }
     constexpr detail::variant_factory<UnderlyingType> factory{};

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -1149,16 +1149,44 @@ SEASTAR_THREAD_TEST_CASE(variant) {
     static_assert(!std::is_nothrow_copy_constructible_v<my_variant>);
     static_assert(
       std::is_nothrow_copy_constructible_v<serde::variant<int, bool>>);
+}
 
-    serde::variant<int, bool> v0 = false;
-    serde::variant<int, bool, ss::sstring> v1 = "foo";
-    // It's not valid to read variants of different types or sizes.
-    BOOST_CHECK_THROW(
-      serde::from_iobuf<decltype(v0)>(serde::to_iobuf(v1)),
-      serde::serde_exception);
-    BOOST_CHECK_THROW(
-      serde::from_iobuf<decltype(v1)>(serde::to_iobuf(v0)),
-      serde::serde_exception);
+// Characterizes the cross-version read matrix for evolving a serde::variant by
+// *appending* an alternative. We model evolving
+//
+//     old = serde::variant<T0>   ->   new = serde::variant<T0, T1>
+//
+// where T0 = int (index 0) and T1 = ss::sstring (index 1). The three writer
+// shapes are: old writer (always index 0), new writer holding T0 ("I0",
+// index 0), and new writer holding T1 ("I1", index 1).
+SEASTAR_THREAD_TEST_CASE(variant_append_compat) {
+    using old_variant = serde::variant<int>;
+    using new_variant = serde::variant<int, ss::sstring>;
+
+    const old_variant old_writer = 7;                    // index 0 (T0)
+    const new_variant new_writer_i0 = 7;                 // index 0 (T0)
+    const new_variant new_writer_i1 = ss::sstring{"hi"}; // index 1 (T1)
+
+    const auto read_old = [](const auto& w) {
+        return serde::from_iobuf<old_variant>(serde::to_iobuf(w));
+    };
+    const auto read_new = [](const auto& w) {
+        return serde::from_iobuf<new_variant>(serde::to_iobuf(w));
+    };
+
+    // old reader <- old writer: reads T0.
+    BOOST_REQUIRE(read_old(old_writer) == old_variant{7});
+    // old reader <- new writer I0: throws, serialized size 2 != reader size 1.
+    BOOST_CHECK_THROW(read_old(new_writer_i0), serde::serde_exception);
+    // old reader <- new writer I1: throws, serialized size 2 != reader size 1.
+    BOOST_CHECK_THROW(read_old(new_writer_i1), serde::serde_exception);
+
+    // new reader <- old writer: throws, serialized size 1 != reader size 2.
+    BOOST_CHECK_THROW(read_new(old_writer), serde::serde_exception);
+    // new reader <- new writer I0: reads T0.
+    BOOST_REQUIRE(read_new(new_writer_i0) == new_variant{7});
+    // new reader <- new writer I1: reads T1.
+    BOOST_REQUIRE(read_new(new_writer_i1) == new_variant{ss::sstring{"hi"}});
 }
 
 SEASTAR_THREAD_TEST_CASE(pair_test) {

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -1176,13 +1176,13 @@ SEASTAR_THREAD_TEST_CASE(variant_append_compat) {
 
     // old reader <- old writer: reads T0.
     BOOST_REQUIRE(read_old(old_writer) == old_variant{7});
-    // old reader <- new writer I0: throws, serialized size 2 != reader size 1.
-    BOOST_CHECK_THROW(read_old(new_writer_i0), serde::serde_exception);
-    // old reader <- new writer I1: throws, serialized size 2 != reader size 1.
+    // old reader <- new writer I0: reads T0 (newly allowed by the relaxation).
+    BOOST_REQUIRE(read_old(new_writer_i0) == old_variant{7});
+    // old reader <- new writer I1: throws, T1's index is unknown to old reader.
     BOOST_CHECK_THROW(read_old(new_writer_i1), serde::serde_exception);
 
-    // new reader <- old writer: throws, serialized size 1 != reader size 2.
-    BOOST_CHECK_THROW(read_new(old_writer), serde::serde_exception);
+    // new reader <- old writer: reads T0 (newly allowed by the relaxation).
+    BOOST_REQUIRE(read_new(old_writer) == new_variant{7});
     // new reader <- new writer I0: reads T0.
     BOOST_REQUIRE(read_new(new_writer_i0) == new_variant{7});
     // new reader <- new writer I1: reads T1.


### PR DESCRIPTION
### Motivation

This allows us to extend `serde::variant` types by appending new types at the end, starting at 26.3.1.

The read path rejected any serialized variant whose size differed from the current definition, so adding a new alternative forced callers through a manual versioning shim (see cluster::client_quota_serde and others) just to keep old data readable and for brokers interoperable mid-upgrade, even if they only ever wrote values with the old set of alternatives of the variant. This forced us multiple times to write complex serde code with double-writing to handle the most common evolution type of a `serde::variant`, which is appending a new type to it.

I would argue that removing this serde size check does not change the forward/backward compatibility guarantees of the type, because what matters for `serde::variant` types in terms of compatibility is that the `index -> type` mapping for the subset of alternatives that are being serialized/deserialized is stable and shared across older and newer readers and writers. This property is independent of the size of the `serde::variant`, since you can change the type mapping without changing the size of the type, so this check was "best effort" regardless.

As an alternative, an ideal serialization protocol could instead maintain the types of each index being used, or, similar to protobuf's `oneof`, use explicit tags for each alternative. Both of these seem larger deviations from the current serialization behaviour, so I opted to adjust the behaviour of the current serialization logic instead.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
