### PR TITLE
[CORE-12531] schema_registry: surface schema count metric by type

### DIFF
--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -14,6 +14,7 @@
 #include "absl/algorithm/container.h"
 #include "absl/container/btree_map.h"
 #include "absl/container/btree_set.h"
+#include "absl/container/flat_hash_map.h"
 #include "absl/container/node_hash_map.h"
 #include "config/configuration.h"
 #include "container/chunked_vector.h"
@@ -819,20 +820,21 @@ public:
     insert_schema_result
     insert_schema(const context& ctx, schema_definition def) {
         if (auto id = get_schema_id(ctx, def); id.has_value()) {
-            return {*id, false};
+            return {.id = *id, .inserted = false};
         }
 
         const auto id = _schemas.empty()
                           ? schema_id{1}
                           : std::prev(_schemas.end())->first.id + 1;
-        auto [_, inserted] = _schemas.try_emplace(
+        auto [it, inserted] = _schemas.try_emplace(
           context_schema_id{ctx, id}, std::move(def));
 
         if (inserted) {
-            get_or_create_context_store(ctx).increment_schema_count();
+            get_or_create_context_store(ctx).increment_schema_count(
+              it->second.definition.type());
         }
 
-        return {id, inserted};
+        return {.id = id, .inserted = inserted};
     }
 
     bool upsert_schema(
@@ -844,7 +846,8 @@ public:
           std::move(id), schema_entry(std::move(def)));
 
         if (inserted) {
-            get_or_create_context_store(it->first.ctx).increment_schema_count();
+            get_or_create_context_store(it->first.ctx)
+              .increment_schema_count(it->second.definition.type());
         }
 
         return inserted;
@@ -855,7 +858,8 @@ public:
         if (it != _schemas.end()) {
             auto ctx_it = _context_stores.find(id.ctx);
             if (ctx_it != _context_stores.end()) {
-                ctx_it->second.decrement_schema_count();
+                ctx_it->second.decrement_schema_count(
+                  it->second.definition.type());
             }
             _schemas.erase(it);
         }
@@ -1185,15 +1189,22 @@ private:
         schema_id _next_schema_id{1};
         bool _materialized{false};
 
-        void increment_schema_count() { _schema_count++; }
+        void increment_schema_count(const schema_type type) {
+            _schema_counts[type]++;
+        }
 
-        void decrement_schema_count() {
-            if (_schema_count > 0) {
-                _schema_count--;
+        void decrement_schema_count(const schema_type type) {
+            auto& count = _schema_counts[type];
+            if (count > 0) {
+                count--;
             }
         }
 
-        void clear_schema_count() { _schema_count = 0; }
+        void clear_schema_count() {
+            for (auto& [_, count] : _schema_counts) {
+                count = 0;
+            }
+        }
 
         void increment_subject_count(is_deleted deleted) {
             if (deleted == is_deleted::yes) {
@@ -1234,7 +1245,10 @@ private:
     private:
         metrics::internal_metric_groups _metrics;
         metrics::public_metric_groups _public_metrics;
-        size_t _schema_count{0};
+        absl::flat_hash_map<schema_type, size_t> _schema_counts{
+          {schema_type::avro, 0},
+          {schema_type::json, 0},
+          {schema_type::protobuf, 0}};
         size_t _subject_count_not_deleted{0};
         size_t _subject_count_deleted{0};
 
@@ -1243,12 +1257,13 @@ private:
             auto group_name = prometheus_sanitize::metrics_name(
               "schema_registry_cache");
 
-            const auto make_schema_count = [this, &ctx]() {
+            const auto make_schema_count = [this, &ctx](schema_type type) {
                 return sm::make_gauge(
                   "schema_count",
-                  [this] { return _schema_count; },
-                  sm::description("The number of schemas in the store"),
-                  {sm::label{"context"}(ctx)});
+                  [this, type] { return _schema_counts.at(type); },
+                  sm::description("The number of schemas in the store by type"),
+                  {sm::label{"context"}(ctx),
+                   sm::label{"type"}(to_string_view(type))});
             };
 
             const auto make_subject_count = [this, &ctx](is_deleted deleted) {
@@ -1266,7 +1281,9 @@ private:
             if (!config::shard_local_cfg().disable_metrics()) {
                 _metrics.add_group(
                   group_name,
-                  {make_schema_count(),
+                  {make_schema_count(schema_type::avro),
+                   make_schema_count(schema_type::json),
+                   make_schema_count(schema_type::protobuf),
                    make_subject_count(is_deleted::no),
                    make_subject_count(is_deleted::yes)},
                   {},
@@ -1276,7 +1293,12 @@ private:
             if (!config::shard_local_cfg().disable_public_metrics()) {
                 _public_metrics.add_group(
                   group_name,
-                  {make_schema_count().aggregate({sm::shard_label}),
+                  {make_schema_count(schema_type::avro)
+                     .aggregate({sm::shard_label}),
+                   make_schema_count(schema_type::json)
+                     .aggregate({sm::shard_label}),
+                   make_schema_count(schema_type::protobuf)
+                     .aggregate({sm::shard_label}),
                    make_subject_count(is_deleted::no)
                      .aggregate({sm::shard_label}),
                    make_subject_count(is_deleted::yes)

--- a/src/v/pandaproxy/schema_registry/test/BUILD
+++ b/src/v/pandaproxy/schema_registry/test/BUILD
@@ -147,6 +147,7 @@ redpanda_cc_btest(
         ":compatibility_avro",
         "//src/v/pandaproxy/schema_registry:store",
         "//src/v/pandaproxy/schema_registry:types",
+        "//src/v/test_utils:metrics",
         "//src/v/test_utils:seastar_boost",
         "@boost//:test",
         "@seastar//:testing",

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -13,6 +13,7 @@
 #include "pandaproxy/schema_registry/test/compatibility_avro.h"
 #include "pandaproxy/schema_registry/types.h"
 #include "pandaproxy/schema_registry/util.h"
+#include "test_utils/metrics.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -1232,4 +1233,47 @@ BOOST_AUTO_TEST_CASE(test_store_context_materialized) {
     contexts = s.get_materialized_contexts();
     BOOST_REQUIRE_EQUAL(contexts.size(), 1);
     BOOST_REQUIRE_EQUAL(contexts[0], pps::default_context);
+}
+
+BOOST_AUTO_TEST_CASE(test_store_schema_count_metrics) {
+    pps::store s;
+
+    auto schema_count = [](pps::schema_type type) {
+        auto val = test_utils::find_metric_value<uint64_t>(
+          "schema_registry_cache_schema_count",
+          ss::metrics::default_handle(),
+          {{"context", "."}, {"type", ss::sstring(pps::to_string_view(type))}});
+        BOOST_REQUIRE(val.has_value());
+        return *val;
+    };
+
+    const auto json_def = pps::schema_definition{
+      pps::schema_definition::raw_string{R"({})"}, pps::schema_type::json};
+    const auto proto_def = pps::schema_definition{
+      pps::schema_definition::raw_string{R"(syntax = "proto3";)"},
+      pps::schema_type::protobuf};
+
+    // Insert one AVRO schema; only the AVRO counter increments.
+    s.insert({subject0, string_def0.share()});
+    BOOST_CHECK_EQUAL(schema_count(pps::schema_type::avro), 1u);
+    BOOST_CHECK_EQUAL(schema_count(pps::schema_type::json), 0u);
+    BOOST_CHECK_EQUAL(schema_count(pps::schema_type::protobuf), 0u);
+
+    // A duplicate insert (same schema, different subject) does not increment.
+    s.insert({subject1, string_def0.share()});
+    BOOST_CHECK_EQUAL(schema_count(pps::schema_type::avro), 1u);
+
+    // Insert JSON and PROTOBUF schemas; each counter increments independently.
+    s.insert({subject1, json_def.share()});
+    BOOST_CHECK_EQUAL(schema_count(pps::schema_type::json), 1u);
+
+    s.insert({subject2, proto_def.share()});
+    BOOST_CHECK_EQUAL(schema_count(pps::schema_type::protobuf), 1u);
+    BOOST_CHECK_EQUAL(schema_count(pps::schema_type::avro), 1u);
+
+    // Deleting a schema decrements only its type counter.
+    s.delete_schema({pps::default_context, pps::schema_id{1}});
+    BOOST_CHECK_EQUAL(schema_count(pps::schema_type::avro), 0u);
+    BOOST_CHECK_EQUAL(schema_count(pps::schema_type::json), 1u);
+    BOOST_CHECK_EQUAL(schema_count(pps::schema_type::protobuf), 1u);
 }


### PR DESCRIPTION
The `schema_count` gauge in `schema_registry_cache` previously reported a single total count per context. This change splits it into one gauge per schema type (AVRO, JSON, PROTOBUF) by adding a `type` label, giving operators visibility into how schemas are distributed across types.

The internal `_schema_count: size_t` in `context_store` is replaced by `_schema_counts: absl::flat_hash_map<schema_type, size_t>` with one entry per type. `increment_schema_count` and `decrement_schema_count` now take a `schema_type` argument, threaded through from the insertion and deletion call sites in `insert_schema`, `upsert_schema`, and `delete_schema`.

The `setup_metrics` lambda is parameterised on `schema_type` and registers three gauges per context for both internal and public metric groups. Existing consumers that aggregate over all type-label series (e.g. the ducktape integration test) continue to get the correct total.

## Backports Required


- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Features

* The `schema_registry_cache_schema_count` metric now includes a type label (`AVRO`, `JSON`, `PROTOBUF`), replacing the single per-context gauge with one gauge per schema type per context. Dashboards or alerts that query this metric without filtering on `type` should be updated to sum across the label, e.g. `sum by (context) (redpanda_schema_registry_cache_schema_count)`.

