### PR TITLE
[CORE-16420 ] `rptest`: anchor compacted shadow-link consume with a sentinel record

### DIFF
--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -2409,6 +2409,16 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         self.logger.info(
             "Create a topic with compaction settings set but without compaction and tombstone removal enabled"
         )
+        # `rpk consume -o :end` blocks until the consumer reaches the high
+        # watermark, which never decreases. Once tombstone removal deletes the
+        # record(s) at the tail of the compacted log, those tail offsets become
+        # unreachable and the consume hangs until it times out. Anchor the tail
+        # with a sentinel record that has a unique, non-tombstone key: it
+        # survives both compaction (latest record per key is kept) and tombstone
+        # removal (not a tombstone), so the highest offset always holds a live
+        # record and `:end` stays reachable. The sentinel is excluded from the
+        # key/tombstone counts below.
+        sentinel_key = "sentinel-anchor"
         topic = TopicSpec(
             name="compacted-topic",
             partition_count=1,
@@ -2444,6 +2454,11 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         ):
             self.verify()
 
+        # Produce the tail anchor (see sentinel_key comment above) to the source
+        # and wait for it to replicate, so the highest offset on the target
+        # holds a live record before compaction and tombstone removal begin.
+        self.source_cluster_rpk.produce(topic.name, key=sentinel_key, msg="anchor")
+
         def get_compaction_progress(
             rpk: RpkTool = self.target_cluster_rpk,
         ) -> tuple[int, int]:
@@ -2455,6 +2470,8 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
                 format="%k,%v\n",
             ).splitlines():
                 key, value = line.split(",", maxsplit=1)
+                if key == sentinel_key:
+                    continue
                 keys += [key]
                 if value == "":
                     tombstones += 1
@@ -2463,6 +2480,19 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
                 f"Data read from target topic: {len(keys)=}, {keys[:5]=}, {tombstones=}"
             )
             return len(keys), tombstones
+
+        self.logger.info("Waiting for the sentinel record to replicate to the target")
+        wait_until(
+            lambda: sentinel_key
+            in self.target_cluster_rpk.consume(
+                topic=topic.name,
+                offset=":end",
+                format="%k\n",
+            ).split(),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Sentinel record did not replicate to the target cluster",
+        )
 
         self.logger.info("Verifying that replicated records can be compacted")
         pre_compaction_keys, _ = get_compaction_progress()


### PR DESCRIPTION
`test_replication_with_compaction` (storage_mode=cloud) fails
deterministically in CI (e.g. build 85447, 4/4 attempts) during the
tombstone-removal wait.

The test reads the compacted topic with `rpk consume -o :end`, which
blocks until the consumer reaches the high watermark. The high watermark
never decreases, so once tombstone removal deletes the record(s) at the
tail of the log, those tail offsets become unreachable: the consumer
drains all surviving records, parks below the high watermark, and hangs
until rpk's 30s client timeout fires (server-side fetches return
`error_code: none` with `high_watermark` pinned and zero records — the
broker is healthy, there is simply nothing left to serve at the tail).

This fix produces a sentinel record with a unique, non-tombstone key
after the workload. Its key is unique so compaction keeps it (latest
record per key), and it is not a tombstone so `delete.retention` never
removes it. The highest offset therefore always holds a live record and
`:end` stays reachable. The test waits for the sentinel to replicate to
the target before enabling compaction, and excludes it from the
key/tombstone counts so the assertions are unchanged.

## Backports Required

- [x] none - issue does not exist in previous branches

## Release Notes

* none