### PR TITLE
`ct/l1`: invalidate cached `l1` readers during compaction

### DIFF
--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -196,7 +196,8 @@ ss::future<> app::construct(
         .partition_manager = &controller->get_partition_manager()},
       &l1_io,
       &replicated_metastore,
-      &_l1_reader_probe);
+      &_l1_reader_probe,
+      &_l1_reader_cache);
 
     // Must be last to register so it will be first to be stopped in
     // `app::stop`. This is to ensure that stopped services don't receive

--- a/src/v/cloud_topics/level_one/frontend_reader/BUILD
+++ b/src/v/cloud_topics/level_one/frontend_reader/BUILD
@@ -29,6 +29,7 @@ redpanda_cc_library(
         ":reader",
         "//src/v/cloud_topics:log_reader_config",
         "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics/level_one/metastore:offset_interval_set",
         "//src/v/config",
         "//src/v/container:intrusive",
         "//src/v/model",

--- a/src/v/cloud_topics/level_one/frontend_reader/l1_reader_cache.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/l1_reader_cache.cc
@@ -215,6 +215,24 @@ bool l1_reader_cache::over_size_limit() const {
            && _readers.size() + _in_use.size() > _target_max_size();
 }
 
+void l1_reader_cache::invalidate_range(
+  const model::topic_id_partition& tidp,
+  const l1::offset_interval_set& evict_ranges) {
+    auto invalidate_if_match = [&](entry& e) {
+        if (
+          e.reader->tidp() == tidp
+          && evict_ranges.contains(e.reader->next_read_lower_bound())) {
+            e.reader->invalidate();
+        }
+    };
+    for (auto& e : _readers) {
+        invalidate_if_match(e);
+    }
+    for (auto& e : _in_use) {
+        invalidate_if_match(e);
+    }
+}
+
 void l1_reader_cache::maybe_evict_size() {
     if (!over_size_limit()) [[likely]] {
         return;

--- a/src/v/cloud_topics/level_one/frontend_reader/l1_reader_cache.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/l1_reader_cache.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "cloud_topics/level_one/frontend_reader/level_one_reader.h"
+#include "cloud_topics/level_one/metastore/offset_interval_set.h"
 #include "cloud_topics/log_reader_config.h"
 #include "config/property.h"
 #include "container/intrusive_list_helpers.h"
@@ -60,6 +61,13 @@ public:
     put(std::unique_ptr<level_one_log_reader_impl> reader);
 
     stats get_stats() const;
+
+    /// Invalidate cached readers for the given partition whose next read
+    /// position falls within any of the ranges. This marks any matching in-use
+    /// or idle readers as non-reusable.
+    void invalidate_range(
+      const model::topic_id_partition& tidp,
+      const l1::offset_interval_set& evict_ranges);
 
     ss::future<> stop();
 

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -537,7 +537,8 @@ void level_one_log_reader_impl::reset_config(
 }
 
 bool level_one_log_reader_impl::is_reusable() const {
-    return _current_stream.has_value() || !_lookahead_buffer.empty();
+    return !_invalidated
+           && (_current_stream.has_value() || !_lookahead_buffer.empty());
 }
 
 bool level_one_log_reader_impl::is_over_limit_with_bytes(size_t size) const {

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
@@ -104,6 +104,9 @@ public:
     /// Whether the reader has state worth preserving in the cache.
     bool is_reusable() const;
 
+    /// Mark this reader as non-reusable for the cache.
+    void invalidate() noexcept { _invalidated = true; }
+
     const model::ntp& ntp() const { return _ntp; }
     const model::topic_id_partition& tidp() const { return _tidp; }
 
@@ -191,6 +194,7 @@ private:
 
     void set_end_of_stream();
     bool _end_of_stream{false};
+    bool _invalidated{false};
 
     cloud_topic_log_reader_config _config;
     model::ntp _ntp;

--- a/src/v/cloud_topics/level_one/frontend_reader/tests/BUILD
+++ b/src/v/cloud_topics/level_one/frontend_reader/tests/BUILD
@@ -36,6 +36,7 @@ redpanda_cc_gtest(
         "//src/v/cloud_topics:log_reader_config",
         "//src/v/cloud_topics/level_one/frontend_reader:l1_reader_cache",
         "//src/v/cloud_topics/level_one/frontend_reader:reader",
+        "//src/v/cloud_topics/level_one/metastore:offset_interval_set",
         "//src/v/config",
         "//src/v/model",
         "//src/v/model/tests:random",

--- a/src/v/cloud_topics/level_one/frontend_reader/tests/l1_reader_cache_test.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/tests/l1_reader_cache_test.cc
@@ -374,4 +374,181 @@ TEST_F(l1_reader_cache_test, byte_limited_reader_is_reusable) {
     EXPECT_EQ(data1.size() + data2.size(), expected_count);
 }
 
+TEST_F(l1_reader_cache_test, evict_partition_removes_cached_reader_in_range) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+    auto batches
+      = model::test::make_random_batches(model::offset{0}, /*count=*/5).get();
+
+    std::vector<tidp_batches_t> tb;
+    tb.emplace_back(tidp, std::move(batches));
+    make_l1_objects(std::move(tb)).get();
+
+    // Read one batch with byte limit so the reader stays reusable.
+    auto r = make_reader_impl(
+      ntp,
+      tidp,
+      kafka::offset{0},
+      kafka::offset::max(),
+      /*max_bytes=*/1,
+      /*strict_max_bytes=*/true);
+    auto wrapped = _cache->put(std::move(r));
+    auto data = model::consume_reader_to_memory(
+                  std::move(wrapped), model::no_timeout)
+                  .get();
+    ASSERT_EQ(data.size(), 1);
+    ASSERT_EQ(_cache->get_stats().cached_readers, 1);
+
+    // Evict with a range that includes the reader's current position (near 0).
+    offset_interval_set evict_range;
+    evict_range.insert(kafka::offset{0}, kafka::offset{10000});
+    _cache->invalidate_range(tidp, evict_range);
+
+    // The reader is invalidated and will not be served; it stays in the
+    // list until the eviction timer fires (is_reusable() == false).
+    auto cfg = make_test_config(kafka::offset{0}, kafka::offset::max());
+    EXPECT_FALSE(_cache->get_reader(tidp, cfg).has_value());
+}
+
+TEST_F(
+  l1_reader_cache_test, evict_partition_spares_cached_reader_outside_range) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+    auto batches
+      = model::test::make_random_batches(model::offset{0}, /*count=*/5).get();
+
+    std::vector<tidp_batches_t> tb;
+    tb.emplace_back(tidp, std::move(batches));
+    make_l1_objects(std::move(tb)).get();
+
+    auto r = make_reader_impl(
+      ntp,
+      tidp,
+      kafka::offset{0},
+      kafka::offset::max(),
+      /*max_bytes=*/1,
+      /*strict_max_bytes=*/true);
+    auto wrapped = _cache->put(std::move(r));
+    auto data = model::consume_reader_to_memory(
+                  std::move(wrapped), model::no_timeout)
+                  .get();
+    ASSERT_EQ(data.size(), 1);
+    ASSERT_EQ(_cache->get_stats().cached_readers, 1);
+
+    // Evict with a range that is far above the reader's position (near 0).
+    offset_interval_set evict_range;
+    evict_range.insert(kafka::offset{10000}, kafka::offset{20000});
+    _cache->invalidate_range(tidp, evict_range);
+
+    EXPECT_EQ(_cache->get_stats().cached_readers, 1);
+}
+
+TEST_F(l1_reader_cache_test, evict_partition_spares_different_partition) {
+    auto [ntp1, tidp1] = make_ntidp("topic_a");
+    auto [ntp2, tidp2] = make_ntidp("topic_b");
+
+    for (auto& [ntp, tidp] : {
+           std::pair{ntp1, tidp1},
+           std::pair{ntp2, tidp2},
+         }) {
+        auto batches = model::test::make_random_batches(
+                         model::offset{0}, /*count=*/3)
+                         .get();
+        std::vector<tidp_batches_t> tb;
+        tb.emplace_back(tidp, std::move(batches));
+        make_l1_objects(std::move(tb)).get();
+
+        auto r = make_reader_impl(
+          ntp,
+          tidp,
+          kafka::offset{0},
+          kafka::offset::max(),
+          /*max_bytes=*/1,
+          /*strict_max_bytes=*/true);
+        auto wrapped = _cache->put(std::move(r));
+        model::consume_reader_to_memory(std::move(wrapped), model::no_timeout)
+          .get();
+    }
+    ASSERT_EQ(_cache->get_stats().cached_readers, 2);
+
+    // Evict tidp1 only.
+    offset_interval_set evict_range;
+    evict_range.insert(kafka::offset{0}, kafka::offset{10000});
+    _cache->invalidate_range(tidp1, evict_range);
+
+    // Both readers stay in the list (invalidate() doesn't remove them);
+    // tidp1's is marked non-reusable so get_reader won't serve it.
+    EXPECT_EQ(_cache->get_stats().cached_readers, 2);
+    auto cfg = make_test_config(kafka::offset{0}, kafka::offset::max());
+    EXPECT_FALSE(_cache->get_reader(tidp1, cfg).has_value());
+}
+
+TEST_F(
+  l1_reader_cache_test, evict_partition_invalidates_in_use_reader_in_range) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+    auto batches
+      = model::test::make_random_batches(model::offset{0}, /*count=*/5).get();
+
+    std::vector<tidp_batches_t> tb;
+    tb.emplace_back(tidp, std::move(batches));
+    make_l1_objects(std::move(tb)).get();
+
+    // Put reader (byte-limited so it would normally be reusable after one
+    // batch).
+    auto r = make_reader_impl(
+      ntp,
+      tidp,
+      kafka::offset{0},
+      kafka::offset::max(),
+      /*max_bytes=*/1,
+      /*strict_max_bytes=*/true);
+    auto wrapped = _cache->put(std::move(r));
+    ASSERT_EQ(_cache->get_stats().in_use_readers, 1);
+
+    // Evict while in-use. Reader is at next_read_lower_bound() == 0, in range.
+    offset_interval_set evict_range;
+    evict_range.insert(kafka::offset{0}, kafka::offset{10000});
+    _cache->invalidate_range(tidp, evict_range);
+
+    // Consume. Reader is invalidated so it is disposed, not re-cached.
+    auto data = model::consume_reader_to_memory(
+                  std::move(wrapped), model::no_timeout)
+                  .get();
+    ASSERT_EQ(data.size(), 1);
+
+    EXPECT_EQ(_cache->get_stats().cached_readers, 0);
+    EXPECT_EQ(_cache->get_stats().in_use_readers, 0);
+}
+
+TEST_F(
+  l1_reader_cache_test, evict_partition_spares_in_use_reader_outside_range) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+    auto batches
+      = model::test::make_random_batches(model::offset{0}, /*count=*/5).get();
+
+    std::vector<tidp_batches_t> tb;
+    tb.emplace_back(tidp, std::move(batches));
+    make_l1_objects(std::move(tb)).get();
+
+    auto r = make_reader_impl(
+      ntp,
+      tidp,
+      kafka::offset{0},
+      kafka::offset::max(),
+      /*max_bytes=*/1,
+      /*strict_max_bytes=*/true);
+    auto wrapped = _cache->put(std::move(r));
+
+    // Evict with range that does not include offset 0 (reader's position).
+    offset_interval_set evict_range;
+    evict_range.insert(kafka::offset{10000}, kafka::offset{20000});
+    _cache->invalidate_range(tidp, evict_range);
+
+    // Reader is not invalidated so it returns to cache after consumption.
+    auto data = model::consume_reader_to_memory(
+                  std::move(wrapped), model::no_timeout)
+                  .get();
+    ASSERT_EQ(data.size(), 1);
+
+    EXPECT_EQ(_cache->get_stats().cached_readers, 1);
+}
+
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/maintenance/compaction/BUILD
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/BUILD
@@ -44,6 +44,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics:log_reader_config",
         "//src/v/cloud_topics/level_one/common:abstract_io",
         "//src/v/cloud_topics/level_one/common:object",
+        "//src/v/cloud_topics/level_one/frontend_reader:l1_reader_cache",
         "//src/v/cloud_topics/level_one/frontend_reader:level_one_reader_probe",
         "//src/v/cloud_topics/level_one/frontend_reader:reader",
         "//src/v/cloud_topics/level_one/maintenance:l1_object_sink",

--- a/src/v/cloud_topics/level_one/maintenance/compaction/compaction_sink.cc
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/compaction_sink.cc
@@ -209,6 +209,12 @@ ss::future<> compaction_sink::finalize(bool success) {
         co_return;
     }
 
+    if (_reader_cache) {
+        co_await _reader_cache->invoke_on_all([this](l1_reader_cache& cache) {
+            cache.invalidate_range(_tp, _processed_extents);
+        });
+    }
+
     if (_any_object_failed) {
         co_await compact_objects_without_update();
     } else {

--- a/src/v/cloud_topics/level_one/maintenance/compaction/compaction_sink.cc
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/compaction_sink.cc
@@ -11,6 +11,7 @@
 #include "cloud_topics/level_one/maintenance/compaction/compaction_sink.h"
 
 #include "cloud_topics/level_one/common/object.h"
+#include "cloud_topics/level_one/frontend_reader/l1_reader_cache.h"
 #include "cloud_topics/level_one/maintenance/compaction/compaction_source.h"
 #include "cloud_topics/level_one/maintenance/l1_object_sink.h"
 #include "cloud_topics/level_one/metastore/offset_interval_set.h"
@@ -80,7 +81,8 @@ compaction_sink::compaction_sink(
   config::binding<size_t> max_object_size,
   size_t upload_part_size,
   prefix_logger& ctxlog,
-  object_builder::options opts)
+  object_builder::options opts,
+  ss::sharded<cloud_topics::l1_reader_cache>* reader_cache)
   : l1_object_sink(
       std::move(tp),
       io,
@@ -93,7 +95,8 @@ compaction_sink::compaction_sink(
   , _dirty_range_intervals(dirty_range_intervals)
   , _removable_tombstone_ranges(removable_tombstone_ranges)
   , _expected_compaction_epoch(expected_compaction_epoch)
-  , _start_offset(start_offset) {}
+  , _start_offset(start_offset)
+  , _reader_cache(reader_cache) {}
 
 ss::future<bool>
 compaction_sink::initialize(compaction::sliding_window_reducer::source& src) {

--- a/src/v/cloud_topics/level_one/maintenance/compaction/compaction_sink.h
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/compaction_sink.h
@@ -19,6 +19,12 @@
 #include "model/fundamental.h"
 #include "utils/prefix_logger.h"
 
+#include <seastar/core/sharded.hh>
+
+namespace cloud_topics {
+class l1_reader_cache;
+} // namespace cloud_topics
+
 namespace cloud_topics::l1 {
 
 class compaction_sink : public l1_object_sink {
@@ -35,7 +41,8 @@ public:
       config::binding<size_t>,
       size_t,
       prefix_logger&,
-      object_builder::options = {});
+      object_builder::options = {},
+      ss::sharded<cloud_topics::l1_reader_cache>* = nullptr);
 
     ss::future<bool>
     initialize(compaction::sliding_window_reducer::source&) final;
@@ -78,6 +85,8 @@ private:
     // `map_deduplication_iteration`.
     chunked_vector<metastore::compaction_update::cleaned_range>
       _new_cleaned_ranges;
+
+    ss::sharded<cloud_topics::l1_reader_cache>* _reader_cache{nullptr};
 
 private:
     friend class throwing_compaction_sink;

--- a/src/v/cloud_topics/level_one/maintenance/compaction/compaction_source.cc
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/compaction_source.cc
@@ -317,6 +317,13 @@ ss::future<ss::stop_iteration> compaction_source::deduplication_iteration(
         }
 
         _probe.add_stats(stats);
+    } else {
+        vlog(
+          _ctxlog.trace,
+          "Skipping compaction of extent {}, ineligible per "
+          "min.compaction.lag.ms: {}",
+          extent,
+          _min_compaction_lag_ms);
     }
 
     co_return ss::stop_iteration::no;

--- a/src/v/cloud_topics/level_one/maintenance/compaction/tests/BUILD
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/tests/BUILD
@@ -47,6 +47,8 @@ redpanda_cc_gtest(
         "//src/v/cloud_topics/level_one/common:object",
         "//src/v/cloud_topics/level_one/common:object_id",
         "//src/v/cloud_topics/level_one/common:object_utils",
+        "//src/v/cloud_topics/level_one/frontend_reader:l1_reader_cache",
+        "//src/v/cloud_topics/level_one/frontend_reader:reader",
         "//src/v/cloud_topics/level_one/frontend_reader/tests:l1_reader_fixture",
         "//src/v/cloud_topics/level_one/maintenance:logger",
         "//src/v/cloud_topics/level_one/maintenance:meta",

--- a/src/v/cloud_topics/level_one/maintenance/compaction/tests/reducer_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/tests/reducer_test.cc
@@ -13,6 +13,8 @@
 #include "bytes/iostream.h"
 #include "cloud_topics/level_one/common/object.h"
 #include "cloud_topics/level_one/common/object_id.h"
+#include "cloud_topics/level_one/frontend_reader/l1_reader_cache.h"
+#include "cloud_topics/level_one/frontend_reader/level_one_reader.h"
 #include "cloud_topics/level_one/frontend_reader/tests/l1_reader_fixture.h"
 #include "cloud_topics/level_one/maintenance/compaction/compaction_sink.h"
 #include "cloud_topics/level_one/maintenance/compaction/compaction_source.h"
@@ -100,7 +102,8 @@ ss::future<> do_compact(
   l1::metastore* metastore,
   l1::io* io,
   std::chrono::milliseconds min_compaction_lag_ms = 0ms,
-  kafka::offset max_compactible_offset = kafka::offset::max()) {
+  kafka::offset max_compactible_offset = kafka::offset::max(),
+  ss::sharded<cloud_topics::l1_reader_cache>* reader_cache = nullptr) {
     ss::abort_source as;
     auto state = l1::compaction_job_state::running;
     auto map = compaction::simple_key_offset_map();
@@ -133,7 +136,9 @@ ss::future<> do_compact(
       as,
       config::mock_binding<size_t>(128_MiB),
       16_MiB,
-      logger);
+      logger,
+      l1::object_builder::options{},
+      reader_cache);
     auto reducer = compaction::sliding_window_reducer(
       std::move(src), std::move(sink));
 
@@ -1084,4 +1089,79 @@ TEST_F(ReducerTestFixture, ExceptionalFinalizePartialExtent) {
           << " physical last offset does not match metadata last offset: "
           << physical_last_offset << " != " << extent.last_offset;
     }
+}
+
+class CompactionSinkCacheTest : public ReducerTestFixture {
+public:
+    ss::future<> SetUpAsync() override {
+        co_await _cache.start(
+          config::mock_binding(std::chrono::milliseconds{60000}),
+          config::mock_binding<size_t>(128));
+    }
+
+    ss::future<> TearDownAsync() override { co_await _cache.stop(); }
+
+protected:
+    ss::sharded<cloud_topics::l1_reader_cache> _cache;
+};
+
+// Verifies that running compaction_sink with a sharded l1_reader_cache causes
+// every cached reader whose position falls inside the compacted range to be
+// invalidated before the metastore commit.
+TEST_F(CompactionSinkCacheTest, CompactionSinkInvalidatesCachedReaders) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+    int num_batches = 5;
+    int cardinality = 5;
+    auto batches = generate_batches(num_batches, cardinality);
+    std::vector<tidp_batches_t> tb;
+    tb.emplace_back(tidp, std::move(batches));
+    make_l1_objects(std::move(tb)).get();
+
+    // Byte-limit a read so the reader stays reusable and is cached at
+    // next_read_lower_bound() somewhere inside the dirty range [0, N].
+    auto read_cfg = make_test_config(
+      kafka::offset{0},
+      kafka::offset::max(),
+      /*max_bytes=*/1,
+      /*strict_max_bytes=*/true);
+    auto reader_impl
+      = std::make_unique<cloud_topics::level_one_log_reader_impl>(
+        read_cfg, ntp, tidp, &_metastore, &_io);
+    auto wrapped = _cache.local().put(std::move(reader_impl));
+    auto data = model::consume_reader_to_memory(
+                  std::move(wrapped), model::no_timeout)
+                  .get();
+    ASSERT_EQ(data.size(), 1);
+    ASSERT_EQ(_cache.local().get_stats().cached_readers, 1);
+
+    // The reader is cached at the offset immediately after the first batch.
+    auto next_offset = kafka::offset(data.back().last_offset()() + 1);
+    auto lookup_cfg = make_test_config(next_offset, kafka::offset::max());
+
+    // Before compaction the reader is accessible at its current position.
+    EXPECT_TRUE(_cache.local().get_reader(tidp, lookup_cfg).has_value());
+
+    auto info_spec = l1::metastore::compaction_info_spec{
+      .tidp = tidp,
+      .tombstone_removal_upper_bound_ts = model::timestamp::max()};
+    auto compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    ASSERT_FALSE(compaction_info->offsets_response.dirty_ranges.empty());
+
+    do_compact(
+      tidp,
+      ntp,
+      std::move(compaction_info->offsets_response),
+      compaction_info->compaction_epoch,
+      compaction_info->start_offset,
+      &_metastore,
+      &_io,
+      0ms,
+      kafka::offset::max(),
+      &_cache)
+      .get();
+
+    // The cached reader was inside the dirty range. After compaction the
+    // reader is invalidated (non-reusable) and no longer served by get_reader.
+    EXPECT_FALSE(_cache.local().get_reader(tidp, lookup_cfg).has_value());
 }

--- a/src/v/cloud_topics/level_one/maintenance/scheduler.cc
+++ b/src/v/cloud_topics/level_one/maintenance/scheduler.cc
@@ -25,7 +25,8 @@ compaction_scheduler::compaction_scheduler(
   compaction_cluster_state state,
   ss::sharded<file_io>* io,
   ss::sharded<l1::replicated_metastore>* metastore,
-  ss::sharded<level_one_reader_probe>* l1_reader_probe)
+  ss::sharded<level_one_reader_probe>* l1_reader_probe,
+  ss::sharded<l1_reader_cache>* reader_cache)
   : _io(io)
   , _metastore(metastore)
   , _log_collector(make_default_log_collector(
@@ -50,7 +51,8 @@ compaction_scheduler::compaction_scheduler(
       metastore,
       state.metadata_cache,
       _probe,
-      l1_reader_probe)
+      l1_reader_probe,
+      reader_cache)
   , _compaction_interval(
       config::shard_local_cfg().cloud_topics_compaction_interval_ms.bind())
   , _compaction_queue(_scheduling_policy->get_comparator()) {
@@ -61,7 +63,7 @@ compaction_scheduler::compaction_scheduler(log_info_collector info_collector)
   : _log_info_collector(std::move(info_collector))
   , _scheduling_policy(make_default_scheduling_policy())
   , _worker_manager(
-      _compaction_queue, nullptr, nullptr, nullptr, _probe, nullptr)
+      _compaction_queue, nullptr, nullptr, nullptr, _probe, nullptr, nullptr)
   , _compaction_interval(
       config::shard_local_cfg().cloud_topics_compaction_interval_ms.bind())
   , _compaction_queue(_scheduling_policy->get_comparator()) {

--- a/src/v/cloud_topics/level_one/maintenance/scheduler.h
+++ b/src/v/cloud_topics/level_one/maintenance/scheduler.h
@@ -12,6 +12,10 @@
 
 #include "cloud_topics/level_one/common/file_io.h"
 #include "cloud_topics/level_one/frontend_reader/level_one_reader_probe.h"
+
+namespace cloud_topics {
+class l1_reader_cache;
+} // namespace cloud_topics
 #include "cloud_topics/level_one/maintenance/log_collector.h"
 #include "cloud_topics/level_one/maintenance/log_info_collector.h"
 #include "cloud_topics/level_one/maintenance/meta.h"
@@ -49,7 +53,8 @@ public:
       compaction_cluster_state,
       ss::sharded<file_io>*,
       ss::sharded<l1::replicated_metastore>*,
-      ss::sharded<level_one_reader_probe>*);
+      ss::sharded<level_one_reader_probe>*,
+      ss::sharded<cloud_topics::l1_reader_cache>*);
 
     // Starts the contained `_log_collector`, `_worker_manager`, and the
     // backgrounded scheduling loop.

--- a/src/v/cloud_topics/level_one/maintenance/tests/scheduler_fixture.h
+++ b/src/v/cloud_topics/level_one/maintenance/tests/scheduler_fixture.h
@@ -66,6 +66,7 @@ public:
           ss::sharded_parameter([this] { return &_metastore; }),
           nullptr,
           ss::default_scheduling_group(),
+          nullptr,
           nullptr);
         co_await scheduler->_worker_manager._workers.invoke_on_all(
           &l1::compaction_worker::start);

--- a/src/v/cloud_topics/level_one/maintenance/tests/worker_manager_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/tests/worker_manager_test.cc
@@ -34,6 +34,7 @@ public:
           nullptr,
           nullptr,
           ss::default_scheduling_group(),
+          nullptr,
           nullptr);
         co_await manager._workers.invoke_on_all(&l1::compaction_worker::start);
     }
@@ -57,7 +58,8 @@ public:
 TEST_F(WorkerManagerTestFixture, PauseAndResumeWorkers) {
     l1::compaction_scheduler_probe probe;
     l1::log_compaction_queue pq;
-    l1::worker_manager manager(pq, nullptr, nullptr, nullptr, probe, nullptr);
+    l1::worker_manager manager(
+      pq, nullptr, nullptr, nullptr, probe, nullptr, nullptr);
     start_workers(manager).get();
     auto stop_manager = ss::defer([&manager] { manager.stop().get(); });
     using worker_state = l1::compaction_worker::worker_state;
@@ -88,7 +90,8 @@ TEST_F(WorkerManagerTestFixture, AcquireWork) {
     l1::compaction_scheduler_probe probe;
     l1::log_compaction_queue pq(std::move(cmp_func));
     l1::log_list_t list;
-    l1::worker_manager manager(pq, nullptr, nullptr, nullptr, probe, nullptr);
+    l1::worker_manager manager(
+      pq, nullptr, nullptr, nullptr, probe, nullptr, nullptr);
     auto stop_manager = ss::defer([&manager] { manager.stop().get(); });
 
     const auto test_ntp = model::ntp(

--- a/src/v/cloud_topics/level_one/maintenance/worker.cc
+++ b/src/v/cloud_topics/level_one/maintenance/worker.cc
@@ -35,7 +35,8 @@ compaction_worker::compaction_worker(
   metastore* metastore,
   cluster::metadata_cache* metadata_cache,
   ss::scheduling_group compaction_sg,
-  level_one_reader_probe* l1_reader_probe)
+  level_one_reader_probe* l1_reader_probe,
+  ss::sharded<cloud_topics::l1_reader_cache>* reader_cache)
   : _worker_update_queue([](const std::exception_ptr& ex) {
       vlog(
         compaction_log.error,
@@ -50,7 +51,8 @@ compaction_worker::compaction_worker(
   , _metastore(metastore)
   , _metadata_cache(metadata_cache)
   , _compaction_sg(compaction_sg)
-  , _l1_reader_probe(l1_reader_probe) {
+  , _l1_reader_probe(l1_reader_probe)
+  , _reader_cache(reader_cache) {
     _poll_interval.watch([this]() { _compaction_cv.signal(); });
 }
 
@@ -251,7 +253,8 @@ ss::future<> compaction_worker::compact_log(log_compaction_meta* log) {
       l1::object_builder::options{
         .indexing_interval
         = config::shard_local_cfg().cloud_topics_l1_indexing_interval(),
-      });
+      },
+      _reader_cache);
     auto reducer = compaction::sliding_window_reducer(
       std::move(src), std::move(sink));
 

--- a/src/v/cloud_topics/level_one/maintenance/worker.h
+++ b/src/v/cloud_topics/level_one/maintenance/worker.h
@@ -12,6 +12,10 @@
 
 #include "cloud_topics/level_one/common/abstract_io.h"
 #include "cloud_topics/level_one/frontend_reader/level_one_reader_probe.h"
+
+namespace cloud_topics {
+class l1_reader_cache;
+} // namespace cloud_topics
 #include "cloud_topics/level_one/maintenance/compaction/compaction_source.h"
 #include "cloud_topics/level_one/maintenance/meta.h"
 #include "cloud_topics/level_one/maintenance/worker_probe.h"
@@ -22,6 +26,7 @@
 #include "ssx/work_queue.h"
 
 #include <seastar/core/scheduling.hh>
+#include <seastar/core/sharded.hh>
 
 class WorkerManagerTestFixture;
 
@@ -46,7 +51,8 @@ public:
       metastore*,
       cluster::metadata_cache*,
       ss::scheduling_group,
-      level_one_reader_probe*);
+      level_one_reader_probe*,
+      ss::sharded<cloud_topics::l1_reader_cache>*);
 
     // Launches background loop.
     ss::future<> start();
@@ -209,6 +215,9 @@ private:
 
     // Owned by `app`.
     level_one_reader_probe* _l1_reader_probe;
+
+    // Owned by `app`.
+    ss::sharded<cloud_topics::l1_reader_cache>* _reader_cache;
 };
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/maintenance/worker_manager.cc
+++ b/src/v/cloud_topics/level_one/maintenance/worker_manager.cc
@@ -21,18 +21,20 @@
 namespace cloud_topics::l1 {
 
 worker_manager::worker_manager(
-  log_compaction_queue& work_queue,
+  log_compaction_queue& compaction_queue,
   ss::sharded<file_io>* io,
   ss::sharded<replicated_metastore>* metastore,
   ss::sharded<cluster::metadata_cache>* metadata_cache,
   compaction_scheduler_probe& probe,
-  ss::sharded<level_one_reader_probe>* l1_reader_probe)
-  : _compaction_queue(work_queue)
+  ss::sharded<level_one_reader_probe>* l1_reader_probe,
+  ss::sharded<l1_reader_cache>* reader_cache)
+  : _compaction_queue(compaction_queue)
   , _io(io)
   , _metastore(metastore)
   , _metadata_cache(metadata_cache)
   , _probe(probe)
-  , _l1_reader_probe(l1_reader_probe) {}
+  , _l1_reader_probe(l1_reader_probe)
+  , _reader_cache(reader_cache) {}
 
 ss::future<> worker_manager::start() {
     co_await _workers.start(
@@ -41,7 +43,8 @@ ss::future<> worker_manager::start() {
       ss::sharded_parameter([this] { return &_metastore->local(); }),
       ss::sharded_parameter([this] { return &_metadata_cache->local(); }),
       scheduling_groups::instance().cloud_topics_compaction_sg(),
-      ss::sharded_parameter([this] { return &_l1_reader_probe->local(); }));
+      ss::sharded_parameter([this] { return &_l1_reader_probe->local(); }),
+      _reader_cache);
     co_await _workers.invoke_on_all(&compaction_worker::start);
 }
 

--- a/src/v/cloud_topics/level_one/maintenance/worker_manager.h
+++ b/src/v/cloud_topics/level_one/maintenance/worker_manager.h
@@ -12,6 +12,10 @@
 
 #include "cloud_topics/level_one/common/file_io.h"
 #include "cloud_topics/level_one/maintenance/logger.h"
+
+namespace cloud_topics {
+class l1_reader_cache;
+} // namespace cloud_topics
 #include "cloud_topics/level_one/maintenance/meta.h"
 #include "cloud_topics/level_one/maintenance/scheduler_probe.h"
 #include "cloud_topics/level_one/maintenance/worker.h"
@@ -45,7 +49,8 @@ public:
       ss::sharded<replicated_metastore>*,
       ss::sharded<cluster::metadata_cache>*,
       compaction_scheduler_probe&,
-      ss::sharded<level_one_reader_probe>*);
+      ss::sharded<level_one_reader_probe>*,
+      ss::sharded<cloud_topics::l1_reader_cache>*);
 
     // Starts the pool of workers, making them available for compaction jobs.
     ss::future<> start();
@@ -108,6 +113,9 @@ private:
 
     // Owned by `app`.
     ss::sharded<level_one_reader_probe>* _l1_reader_probe;
+
+    // Owned by `app`.
+    ss::sharded<cloud_topics::l1_reader_cache>* _reader_cache;
 
     // A sharded pool of compaction workers.
     ss::sharded<compaction_worker> _workers;


### PR DESCRIPTION
Adds an API to `l1_reader_cache` that allows callers to invalidate offset ranges for a given CTP. If any readers currently in use (present in `_in_use`) or idle (present in `_readers`) reach into this offset range, they are marked as invalidated - meaning they will not be returned to the cache after use, nor will they be served by `get_reader()` requests, and will be lazily evicted next time `_eviction_timer` ticks.

The current motivation for this API is being able to evict readers in offset ranges that have been re-written by compaction, in order to avoid a race condition with tombstone removal. For example, without range invalidation,

1. A cached reader may serve a stale read of keys that have been more recently removed by compaction to a consumer.
2. A tombstone later in the log for one of those keys may be removed by compaction.
3. The consumer eventually catches up to the end of the log and has not seen the tombstone, causing the key to seem like it has re-appeared.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
