### PR TITLE
`ct/l1`: add new `compaction_queue` implementation

### DIFF
--- a/src/v/cloud_topics/level_one/maintenance/BUILD
+++ b/src/v/cloud_topics/level_one/maintenance/BUILD
@@ -108,6 +108,20 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "keyed_priority_queue",
+    hdrs = [
+        "keyed_priority_queue.h",
+    ],
+    visibility = [
+        "//src/v/cloud_topics/level_one:__subpackages__",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/container:chunked_hash_map",
+    ],
+)
+
+redpanda_cc_library(
     name = "log_collector",
     srcs = [
         "log_collector.cc",

--- a/src/v/cloud_topics/level_one/maintenance/BUILD
+++ b/src/v/cloud_topics/level_one/maintenance/BUILD
@@ -66,6 +66,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics/level_one/common:abstract_io",
         "//src/v/cloud_topics/level_one/common:file_io",
         "//src/v/cloud_topics/level_one/frontend_reader:level_one_reader_probe",
+        "//src/v/cloud_topics/level_one/maintenance/compaction:compaction_queue",
         "//src/v/cloud_topics/level_one/maintenance/compaction:compaction_source_and_sink",
         "//src/v/cloud_topics/level_one/metastore",
         "//src/v/cloud_topics/level_one/metastore:replicated_metastore",
@@ -167,6 +168,7 @@ redpanda_cc_library(
     deps = [
         ":logger",
         ":meta",
+        "//src/v/cloud_topics/level_one/maintenance/compaction:compaction_queue",
         "//src/v/cloud_topics/level_one/maintenance/leveling:leveling_queue",
         "//src/v/cloud_topics/level_one/metastore",
         "//src/v/cluster",
@@ -227,6 +229,7 @@ redpanda_cc_library(
         ":worker",
         "//src/v/cloud_topics/level_one/common:file_io",
         "//src/v/cloud_topics/level_one/frontend_reader:level_one_reader_probe",
+        "//src/v/cloud_topics/level_one/maintenance/compaction:compaction_queue",
         "//src/v/cloud_topics/level_one/metastore:replicated_metastore",
         "//src/v/cluster:fwd",
         "//src/v/cluster:members_table",

--- a/src/v/cloud_topics/level_one/maintenance/compaction/BUILD
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/BUILD
@@ -3,6 +3,19 @@ load("//bazel:build.bzl", "redpanda_cc_library")
 package(default_visibility = ["//src/v/cloud_topics/level_one:__subpackages__"])
 
 redpanda_cc_library(
+    name = "compaction_queue",
+    hdrs = [
+        "compaction_queue.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/cloud_topics/level_one/maintenance:keyed_priority_queue",
+        "//src/v/cloud_topics/level_one/maintenance:meta",
+        "//src/v/model",
+    ],
+)
+
+redpanda_cc_library(
     name = "compaction_filter",
     srcs = [
         "compaction_filter.cc",

--- a/src/v/cloud_topics/level_one/maintenance/compaction/compaction_queue.h
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/compaction_queue.h
@@ -15,34 +15,36 @@
 
 namespace cloud_topics::l1 {
 
-/// \brief A scheduling queue of CTPs awaiting compaction, ordered best-first by
-/// a caller-supplied `cmp_t`.
+/// \brief A scheduling queue of compaction jobs, ordered best-first by a
+/// caller-supplied `compaction_cmp_t`.
 ///
-/// Keyed on `topic_id_partition`, so each CTP has at most one entry: re-queuing
-/// a CTP updates its position in place rather than appending a duplicate, and
-/// `clear(tidp)` evicts a CTP's entry when it is unmanaged.
+/// Keyed on `topic_id_partition`, so each CTP has at most one queued job:
+/// re-queuing a CTP (e.g. after a fresh metastore sample) replaces its job in
+/// place rather than appending a duplicate, and `clear(tidp)` evicts a CTP's
+/// job when it is unmanaged. Analogous to `leveling_queue`, but with a single
+/// job per CTP.
 class compaction_queue {
 public:
     explicit compaction_queue(compaction_cmp_t cmp)
       : _queue(std::move(cmp)) {}
 
-    /// Enqueue `meta`, or update its position in place if its CTP is already
-    /// queued. The owning CTP is taken from the meta.
-    void push(log_compaction_meta_ptr meta) {
-        const auto tidp = meta->tidp;
-        _queue.upsert(tidp, std::move(meta));
+    /// Enqueue `job`, or replace the existing job for its CTP in place. The
+    /// owning CTP is taken from the job's meta.
+    void push(compaction_job_ptr job) {
+        const auto tidp = job->meta->tidp;
+        _queue.upsert(tidp, std::move(job));
     }
 
-    /// The highest-priority queued log. Precondition: non-empty.
-    const log_compaction_meta_ptr& top() const { return _queue.top().second; }
+    /// The highest-priority queued job. Precondition: non-empty.
+    const compaction_job_ptr& top() const { return _queue.top().second; }
 
-    /// Remove the highest-priority queued log. Precondition: non-empty.
+    /// Remove the highest-priority queued job. Precondition: non-empty.
     void pop() {
         auto tidp = _queue.top().first;
         _queue.erase(tidp);
     }
 
-    /// Drop the queued entry for `tidp`, if any (e.g. when a CTP is unmanaged).
+    /// Drop the queued job for `tidp`, if any (e.g. when a CTP is unmanaged).
     /// No-op if the CTP has nothing queued.
     void clear(const model::topic_id_partition& tidp) {
         if (_queue.contains(tidp)) {
@@ -59,7 +61,7 @@ public:
 private:
     keyed_priority_queue<
       model::topic_id_partition,
-      log_compaction_meta_ptr,
+      compaction_job_ptr,
       compaction_cmp_t>
       _queue;
 };

--- a/src/v/cloud_topics/level_one/maintenance/compaction/compaction_queue.h
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/compaction_queue.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "cloud_topics/level_one/maintenance/keyed_priority_queue.h"
+#include "cloud_topics/level_one/maintenance/meta.h"
+#include "model/fundamental.h"
+
+namespace cloud_topics::l1 {
+
+/// \brief A scheduling queue of CTPs awaiting compaction, ordered best-first by
+/// a caller-supplied `cmp_t`.
+///
+/// Keyed on `topic_id_partition`, so each CTP has at most one entry: re-queuing
+/// a CTP updates its position in place rather than appending a duplicate, and
+/// `clear(tidp)` evicts a CTP's entry when it is unmanaged.
+class compaction_queue {
+public:
+    explicit compaction_queue(compaction_cmp_t cmp)
+      : _queue(std::move(cmp)) {}
+
+    /// Enqueue `meta`, or update its position in place if its CTP is already
+    /// queued. The owning CTP is taken from the meta.
+    void push(log_compaction_meta_ptr meta) {
+        const auto tidp = meta->tidp;
+        _queue.upsert(tidp, std::move(meta));
+    }
+
+    /// The highest-priority queued log. Precondition: non-empty.
+    const log_compaction_meta_ptr& top() const { return _queue.top().second; }
+
+    /// Remove the highest-priority queued log. Precondition: non-empty.
+    void pop() {
+        auto tidp = _queue.top().first;
+        _queue.erase(tidp);
+    }
+
+    /// Drop the queued entry for `tidp`, if any (e.g. when a CTP is unmanaged).
+    /// No-op if the CTP has nothing queued.
+    void clear(const model::topic_id_partition& tidp) {
+        if (_queue.contains(tidp)) {
+            _queue.erase(tidp);
+        }
+    }
+
+    bool empty() const { return _queue.empty(); }
+    size_t size() const { return _queue.size(); }
+    bool contains(const model::topic_id_partition& tidp) const {
+        return _queue.contains(tidp);
+    }
+
+private:
+    keyed_priority_queue<
+      model::topic_id_partition,
+      log_compaction_meta_ptr,
+      compaction_cmp_t>
+      _queue;
+};
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/maintenance/compaction/tests/BUILD
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/tests/BUILD
@@ -1,5 +1,23 @@
 load("//bazel:test.bzl", "redpanda_cc_gtest", "redpanda_test_cc_library")
 
+redpanda_cc_gtest(
+    name = "compaction_queue_test",
+    timeout = "short",
+    srcs = [
+        "compaction_queue_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/cloud_topics/level_one/maintenance:meta",
+        "//src/v/cloud_topics/level_one/maintenance/compaction:compaction_queue",
+        "//src/v/cloud_topics/level_one/metastore",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
 redpanda_test_cc_library(
     name = "throwing_compaction_sink",
     hdrs = [

--- a/src/v/cloud_topics/level_one/maintenance/compaction/tests/compaction_queue_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/tests/compaction_queue_test.cc
@@ -29,30 +29,30 @@ model::topic_id_partition tidp(int p) {
     return model::topic_id_partition(test_topic, model::partition_id(p));
 }
 
-// Builds a meta for partition `p`, carrying `ratio` as its compaction score.
-log_compaction_meta_ptr mk_meta(int p, double ratio) {
+// Builds a compaction job for partition `p`, carrying `ratio` as its score.
+compaction_job_ptr mk_job(int p, double ratio) {
     auto ntp = model::ntp(
       model::ns("test"), model::topic("t"), model::partition_id(p));
     auto meta = ss::make_lw_shared<log_compaction_meta>(
       tidp(p), std::move(ntp));
-    meta->compaction.info_and_ts = compaction_info_and_timestamp{
-      .info = {.dirty_ratio = ratio},
-      .collected_at = model::timestamp::now(),
-      .max_compactible_offset = kafka::offset::max(),
-    };
-    return meta;
+    return ss::make_lw_shared<compaction_job>(
+      std::move(meta),
+      compaction_info_and_timestamp{
+        .info = {.dirty_ratio = ratio},
+        .collected_at = model::timestamp::now(),
+        .max_compactible_offset = kafka::offset::max(),
+      });
 }
 
 compaction_cmp_t by_dirty_ratio() {
-    return
-      [](const log_compaction_meta_ptr& a, const log_compaction_meta_ptr& b) {
-          return a->compaction.info_and_ts->info.dirty_ratio
-                 < b->compaction.info_and_ts->info.dirty_ratio;
-      };
+    return [](const compaction_job_ptr& a, const compaction_job_ptr& b) {
+        return a->info_and_ts.info.dirty_ratio
+               < b->info_and_ts.info.dirty_ratio;
+    };
 }
 
 double top_ratio(const compaction_queue& q) {
-    return q.top()->compaction.info_and_ts->info.dirty_ratio;
+    return q.top()->info_and_ts.info.dirty_ratio;
 }
 
 TEST(CompactionQueueTest, EmptyQueue) {
@@ -67,9 +67,9 @@ TEST(CompactionQueueTest, EmptyQueue) {
 
 TEST(CompactionQueueTest, OrdersHighestRatioFirst) {
     compaction_queue q(by_dirty_ratio());
-    q.push(mk_meta(0, 0.1));
-    q.push(mk_meta(1, 0.9));
-    q.push(mk_meta(2, 0.5));
+    q.push(mk_job(0, 0.1));
+    q.push(mk_job(1, 0.9));
+    q.push(mk_job(2, 0.5));
     EXPECT_EQ(q.size(), 3u);
 
     std::vector<double> got;
@@ -85,14 +85,14 @@ TEST(CompactionQueueTest, OrdersHighestRatioFirst) {
 // duplicate: the queue holds at most one entry per `topic_id_partition`.
 TEST(CompactionQueueTest, PushSameCtpUpdatesInPlace) {
     compaction_queue q(by_dirty_ratio());
-    q.push(mk_meta(0, 0.5));
+    q.push(mk_job(0, 0.5));
     EXPECT_EQ(q.size(), 1u);
 
-    q.push(mk_meta(0, 0.9)); // same CTP, higher ratio
+    q.push(mk_job(0, 0.9)); // same CTP, higher ratio
     EXPECT_EQ(q.size(), 1u);
     EXPECT_DOUBLE_EQ(top_ratio(q), 0.9);
 
-    q.push(mk_meta(0, 0.1)); // same CTP, lower ratio
+    q.push(mk_job(0, 0.1)); // same CTP, lower ratio
     EXPECT_EQ(q.size(), 1u);
     EXPECT_DOUBLE_EQ(top_ratio(q), 0.1);
 
@@ -124,8 +124,8 @@ TEST(CompactionQueueTest, RepushReprioritizesAmongOtherCtps) {
 
 TEST(CompactionQueueTest, ClearEvictsQueuedCtp) {
     compaction_queue q(by_dirty_ratio());
-    q.push(mk_meta(0, 0.9));
-    q.push(mk_meta(1, 0.1));
+    q.push(mk_job(0, 0.9));
+    q.push(mk_job(1, 0.1));
     EXPECT_EQ(q.size(), 2u);
 
     q.clear(tidp(0));
@@ -138,7 +138,7 @@ TEST(CompactionQueueTest, ClearEvictsQueuedCtp) {
 
 TEST(CompactionQueueTest, ClearAbsentCtpIsNoop) {
     compaction_queue q(by_dirty_ratio());
-    q.push(mk_meta(0, 0.5));
+    q.push(mk_job(0, 0.5));
     EXPECT_EQ(q.size(), 1u);
 
     q.clear(tidp(7)); // never queued
@@ -150,9 +150,9 @@ TEST(CompactionQueueTest, ClearAbsentCtpIsNoop) {
 // backing set), with ties broken by `topic_id_partition`.
 TEST(CompactionQueueTest, EqualRatiosRetainedAndTieBrokenByTidp) {
     compaction_queue q(by_dirty_ratio());
-    q.push(mk_meta(0, 0.5));
-    q.push(mk_meta(1, 0.5));
-    q.push(mk_meta(2, 0.5));
+    q.push(mk_job(0, 0.5));
+    q.push(mk_job(1, 0.5));
+    q.push(mk_job(2, 0.5));
     EXPECT_EQ(q.size(), 3u);
 
     // Among equal ratios the largest tidp (largest partition id) is the top.
@@ -167,12 +167,12 @@ TEST(CompactionQueueTest, EqualRatiosRetainedAndTieBrokenByTidp) {
 
 TEST(CompactionQueueTest, ReusableAfterDrainingToEmpty) {
     compaction_queue q(by_dirty_ratio());
-    q.push(mk_meta(0, 0.5));
+    q.push(mk_job(0, 0.5));
     q.pop();
     EXPECT_TRUE(q.empty());
 
     // Re-queuing the same CTP after it drained behaves like a fresh insert.
-    q.push(mk_meta(0, 0.3));
+    q.push(mk_job(0, 0.3));
     EXPECT_EQ(q.size(), 1u);
     EXPECT_TRUE(q.contains(tidp(0)));
     EXPECT_DOUBLE_EQ(top_ratio(q), 0.3);

--- a/src/v/cloud_topics/level_one/maintenance/compaction/tests/compaction_queue_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/tests/compaction_queue_test.cc
@@ -1,0 +1,183 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+#include "cloud_topics/level_one/maintenance/compaction/compaction_queue.h"
+#include "cloud_topics/level_one/maintenance/meta.h"
+#include "model/fundamental.h"
+#include "model/timestamp.h"
+
+#include <seastar/core/shared_ptr.hh>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace cloud_topics::l1 {
+
+namespace {
+
+const model::topic_id test_topic = model::topic_id::create();
+
+// A single topic with varying partition ids, so that `topic_id_partition`
+// ordering (topic first, then partition) reduces to ordering by partition id.
+model::topic_id_partition tidp(int p) {
+    return model::topic_id_partition(test_topic, model::partition_id(p));
+}
+
+// Builds a meta for partition `p`, carrying `ratio` as its compaction score.
+log_compaction_meta_ptr mk_meta(int p, double ratio) {
+    auto ntp = model::ntp(
+      model::ns("test"), model::topic("t"), model::partition_id(p));
+    auto meta = ss::make_lw_shared<log_compaction_meta>(
+      tidp(p), std::move(ntp));
+    meta->compaction.info_and_ts = compaction_info_and_timestamp{
+      .info = {.dirty_ratio = ratio},
+      .collected_at = model::timestamp::now(),
+      .max_compactible_offset = kafka::offset::max(),
+    };
+    return meta;
+}
+
+compaction_cmp_t by_dirty_ratio() {
+    return
+      [](const log_compaction_meta_ptr& a, const log_compaction_meta_ptr& b) {
+          return a->compaction.info_and_ts->info.dirty_ratio
+                 < b->compaction.info_and_ts->info.dirty_ratio;
+      };
+}
+
+double top_ratio(const compaction_queue& q) {
+    return q.top()->compaction.info_and_ts->info.dirty_ratio;
+}
+
+TEST(CompactionQueueTest, EmptyQueue) {
+    compaction_queue q(by_dirty_ratio());
+    EXPECT_TRUE(q.empty());
+    EXPECT_EQ(q.size(), 0u);
+    EXPECT_FALSE(q.contains(tidp(0)));
+    // Clearing an absent CTP on an empty queue is a no-op.
+    q.clear(tidp(0));
+    EXPECT_TRUE(q.empty());
+}
+
+TEST(CompactionQueueTest, OrdersHighestRatioFirst) {
+    compaction_queue q(by_dirty_ratio());
+    q.push(mk_meta(0, 0.1));
+    q.push(mk_meta(1, 0.9));
+    q.push(mk_meta(2, 0.5));
+    EXPECT_EQ(q.size(), 3u);
+
+    std::vector<double> got;
+    while (!q.empty()) {
+        got.push_back(top_ratio(q));
+        q.pop();
+    }
+    EXPECT_EQ(got, (std::vector<double>{0.9, 0.5, 0.1}));
+    EXPECT_TRUE(q.empty());
+}
+
+// Re-pushing the same CTP updates its entry in place rather than appending a
+// duplicate: the queue holds at most one entry per `topic_id_partition`.
+TEST(CompactionQueueTest, PushSameCtpUpdatesInPlace) {
+    compaction_queue q(by_dirty_ratio());
+    q.push(mk_meta(0, 0.5));
+    EXPECT_EQ(q.size(), 1u);
+
+    q.push(mk_meta(0, 0.9)); // same CTP, higher ratio
+    EXPECT_EQ(q.size(), 1u);
+    EXPECT_DOUBLE_EQ(top_ratio(q), 0.9);
+
+    q.push(mk_meta(0, 0.1)); // same CTP, lower ratio
+    EXPECT_EQ(q.size(), 1u);
+    EXPECT_DOUBLE_EQ(top_ratio(q), 0.1);
+
+    q.pop();
+    EXPECT_TRUE(q.empty());
+}
+
+// Re-pushing a CTP with a fresher (higher) score must reposition its single
+// entry relative to other CTPs, not append a duplicate.
+TEST(CompactionQueueTest, RepushReprioritizesAmongOtherCtps) {
+    compaction_queue q(by_dirty_ratio());
+    q.push(mk_job(0, 0.2));
+    q.push(mk_job(1, 0.5));
+    EXPECT_EQ(q.size(), 2u);
+    EXPECT_EQ(q.top()->meta->tidp, tidp(1)); // 0.5 > 0.2
+
+    // Re-push CTP 0 with a higher ratio: it overtakes CTP 1, and the queue
+    // still holds exactly two entries (no duplicate for CTP 0).
+    q.push(mk_job(0, 0.8));
+    EXPECT_EQ(q.size(), 2u);
+    EXPECT_EQ(q.top()->meta->tidp, tidp(0));
+    EXPECT_DOUBLE_EQ(top_ratio(q), 0.8);
+
+    // CTP 1 follows once CTP 0 is popped.
+    q.pop();
+    EXPECT_EQ(q.size(), 1u);
+    EXPECT_EQ(q.top()->meta->tidp, tidp(1));
+}
+
+TEST(CompactionQueueTest, ClearEvictsQueuedCtp) {
+    compaction_queue q(by_dirty_ratio());
+    q.push(mk_meta(0, 0.9));
+    q.push(mk_meta(1, 0.1));
+    EXPECT_EQ(q.size(), 2u);
+
+    q.clear(tidp(0));
+    EXPECT_EQ(q.size(), 1u);
+    EXPECT_FALSE(q.contains(tidp(0)));
+    EXPECT_TRUE(q.contains(tidp(1)));
+    // The evicted (higher-ratio) CTP no longer surfaces as the top.
+    EXPECT_DOUBLE_EQ(top_ratio(q), 0.1);
+}
+
+TEST(CompactionQueueTest, ClearAbsentCtpIsNoop) {
+    compaction_queue q(by_dirty_ratio());
+    q.push(mk_meta(0, 0.5));
+    EXPECT_EQ(q.size(), 1u);
+
+    q.clear(tidp(7)); // never queued
+    EXPECT_EQ(q.size(), 1u);
+    EXPECT_TRUE(q.contains(tidp(0)));
+}
+
+// Distinct CTPs with equal scores must all be retained (not collapsed by the
+// backing set), with ties broken by `topic_id_partition`.
+TEST(CompactionQueueTest, EqualRatiosRetainedAndTieBrokenByTidp) {
+    compaction_queue q(by_dirty_ratio());
+    q.push(mk_meta(0, 0.5));
+    q.push(mk_meta(1, 0.5));
+    q.push(mk_meta(2, 0.5));
+    EXPECT_EQ(q.size(), 3u);
+
+    // Among equal ratios the largest tidp (largest partition id) is the top.
+    EXPECT_TRUE(q.contains(tidp(2)));
+    q.pop();
+    EXPECT_FALSE(q.contains(tidp(2)));
+    EXPECT_TRUE(q.contains(tidp(1)));
+    q.pop();
+    EXPECT_TRUE(q.contains(tidp(0)));
+    EXPECT_EQ(q.size(), 1u);
+}
+
+TEST(CompactionQueueTest, ReusableAfterDrainingToEmpty) {
+    compaction_queue q(by_dirty_ratio());
+    q.push(mk_meta(0, 0.5));
+    q.pop();
+    EXPECT_TRUE(q.empty());
+
+    // Re-queuing the same CTP after it drained behaves like a fresh insert.
+    q.push(mk_meta(0, 0.3));
+    EXPECT_EQ(q.size(), 1u);
+    EXPECT_TRUE(q.contains(tidp(0)));
+    EXPECT_DOUBLE_EQ(top_ratio(q), 0.3);
+}
+
+} // namespace
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/maintenance/keyed_priority_queue.h
+++ b/src/v/cloud_topics/level_one/maintenance/keyed_priority_queue.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "base/vassert.h"
+#include "container/chunked_hash_map.h"
+
+#include <set>
+#include <utility>
+
+namespace cloud_topics::l1 {
+
+/// \brief An addressable max-priority queue: holds at most one entry per key,
+/// each carrying a `Value`, and supports updating or removing a key's entry
+/// *in place*. Entries are ordered by `Compare` applied to their values, with
+/// ties broken by key for a strict total order; `top()` is the key of the
+/// greatest entry.
+///
+/// Operations are O(log N) where N is the number of distinct keys; `_pos`
+/// addresses a key's slot in the ordered set without a key-comparison search.
+template<typename Key, typename Value, typename Compare>
+class keyed_priority_queue {
+private:
+    struct entry {
+        Key key;
+        Value value;
+    };
+
+    struct entry_compare {
+        // `cmp` is a strict weak ordering over `Value`; extend it to a
+        // strict total order over `entry`. Entries with equivalent values have
+        // ties broken by comparing keys (which is required to ensure that we
+        // don't silently drop entries with differing keys just because their
+        // values are identical).
+        bool operator()(const entry& a, const entry& b) const {
+            if (cmp(a.value, b.value)) {
+                return true;
+            }
+            if (cmp(b.value, a.value)) {
+                return false;
+            }
+            return a.key < b.key;
+        }
+        Compare cmp;
+    };
+    using set_t = std::set<entry, entry_compare>;
+
+public:
+    explicit keyed_priority_queue(Compare cmp)
+      : _ordered_entries(entry_compare{std::move(cmp)}) {}
+
+    bool empty() const { return _ordered_entries.empty(); }
+    size_t size() const { return _ordered_entries.size(); }
+    bool contains(const Key& k) const { return _entry_it_by_key.contains(k); }
+
+    /// Insert `key` with `value`, or update it in place if already present.
+    void upsert(const Key& key, Value value) {
+        auto [pos, inserted] = _entry_it_by_key.try_emplace(key);
+        if (!inserted) {
+            // `key` was already present: `pos->second` points at its current
+            // (now stale) slot. std::set can't re-key an element in place, so
+            // drop the old slot before reinserting at the new value.
+            _ordered_entries.erase(pos->second);
+        }
+        pos->second
+          = _ordered_entries.insert(entry{key, std::move(value)}).first;
+    }
+
+    /// Remove `key` from `_ordered_entries` and `_key_to_slot`.
+    void erase(const Key& key) {
+        auto it = _entry_it_by_key.find(key);
+        vassert(
+          it != _entry_it_by_key.end(),
+          "keyed_priority_queue::erase of an absent key");
+        _ordered_entries.erase(it->second);
+        _entry_it_by_key.erase(it);
+    }
+
+    /// The greatest-priority (key, value) pair. Precondition: non-empty.
+    std::pair<const Key&, const Value&> top() const {
+        vassert(
+          !_ordered_entries.empty(),
+          "keyed_priority_queue::top on an empty queue");
+        const auto& e = *_ordered_entries.rbegin();
+        return {e.key, e.value};
+    }
+
+private:
+    set_t _ordered_entries;
+    // Maps a key to its slot in `_ordered_entries`. std::set iterators are
+    // stable across unrelated inserts/erases, so caching them here is safe.
+    chunked_hash_map<Key, typename set_t::iterator> _entry_it_by_key;
+};
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/maintenance/leveling/BUILD
+++ b/src/v/cloud_topics/level_one/maintenance/leveling/BUILD
@@ -11,6 +11,7 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/base",
+        "//src/v/cloud_topics/level_one/maintenance:keyed_priority_queue",
         "//src/v/cloud_topics/level_one/maintenance:meta",
         "//src/v/container:chunked_hash_map",
         "//src/v/container:chunked_vector",

--- a/src/v/cloud_topics/level_one/maintenance/leveling/leveling_queue.h
+++ b/src/v/cloud_topics/level_one/maintenance/leveling/leveling_queue.h
@@ -10,98 +10,15 @@
 #pragma once
 
 #include "base/vassert.h"
+#include "cloud_topics/level_one/maintenance/keyed_priority_queue.h"
 #include "cloud_topics/level_one/maintenance/meta.h"
 #include "container/chunked_hash_map.h"
 #include "container/chunked_vector.h"
 #include "model/fundamental.h"
 
 #include <queue>
-#include <set>
-#include <utility>
 
 namespace cloud_topics::l1 {
-
-/// \brief An addressable max-priority queue: holds at most one entry per key,
-/// each carrying a `Value`, and supports updating or removing a key's entry
-/// *in place*. Entries are ordered by `Compare` applied to their values, with
-/// ties broken by key for a strict total order; `top()` is the key of the
-/// greatest entry.
-///
-/// Operations are O(log N) where N is the number of distinct keys; `_pos`
-/// addresses a key's slot in the ordered set without a key-comparison search.
-template<typename Key, typename Value, typename Compare>
-class keyed_priority_queue {
-private:
-    struct entry {
-        Key key;
-        Value value;
-    };
-
-    struct entry_compare {
-        // `cmp` is a strict weak ordering over `Value`; extend it to a
-        // strict total order over `entry`. Entries with equivalent values have
-        // ties broken by comparing keys (which is required to ensure that we
-        // don't silently drop entries with differing keys just because their
-        // values are identical).
-        bool operator()(const entry& a, const entry& b) const {
-            if (cmp(a.value, b.value)) {
-                return true;
-            }
-            if (cmp(b.value, a.value)) {
-                return false;
-            }
-            return a.key < b.key;
-        }
-        Compare cmp;
-    };
-    using set_t = std::set<entry, entry_compare>;
-
-public:
-    explicit keyed_priority_queue(Compare cmp)
-      : _ordered_entries(entry_compare{std::move(cmp)}) {}
-
-    bool empty() const { return _ordered_entries.empty(); }
-    size_t size() const { return _ordered_entries.size(); }
-    bool contains(const Key& k) const { return _entry_it_by_key.contains(k); }
-
-    /// Insert `key` with `value`, or update it in place if already present.
-    void upsert(const Key& key, Value value) {
-        auto [pos, inserted] = _entry_it_by_key.try_emplace(key);
-        if (!inserted) {
-            // `key` was already present: `pos->second` points at its current
-            // (now stale) slot. std::set can't re-key an element in place, so
-            // drop the old slot before reinserting at the new value.
-            _ordered_entries.erase(pos->second);
-        }
-        pos->second
-          = _ordered_entries.insert(entry{key, std::move(value)}).first;
-    }
-
-    /// Remove `key` from `_ordered_entries` and `_key_to_slot`.
-    void erase(const Key& key) {
-        auto it = _entry_it_by_key.find(key);
-        vassert(
-          it != _entry_it_by_key.end(),
-          "keyed_priority_queue::erase of an absent key");
-        _ordered_entries.erase(it->second);
-        _entry_it_by_key.erase(it);
-    }
-
-    /// The greatest-priority (key, value) pair. Precondition: non-empty.
-    std::pair<const Key&, const Value&> top() const {
-        vassert(
-          !_ordered_entries.empty(),
-          "keyed_priority_queue::top on an empty queue");
-        const auto& e = *_ordered_entries.rbegin();
-        return {e.key, e.value};
-    }
-
-private:
-    set_t _ordered_entries;
-    // Maps a key to its slot in `_ordered_entries`. std::set iterators are
-    // stable across unrelated inserts/erases, so caching them here is safe.
-    chunked_hash_map<Key, typename set_t::iterator> _entry_it_by_key;
-};
 
 /// \brief A two-level scheduling queue for leveling jobs that performs a k-way
 /// merge across partitions.

--- a/src/v/cloud_topics/level_one/maintenance/leveling/tests/leveling_queue_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/leveling/tests/leveling_queue_test.cc
@@ -257,61 +257,6 @@ TEST(LevelingQueueTest, ReusableAfterDrainingToEmpty) {
     EXPECT_EQ(q.top()->meta->tidp, tidp(2));
 }
 
-// --- keyed_priority_queue (the addressable outer structure) directly ---
-
-TEST(KeyedPriorityQueueTest, UpsertUpdatesInPlace) {
-    keyed_priority_queue<int, int, std::less<int>> kpq{std::less<int>{}};
-    kpq.upsert(1, 5);
-    kpq.upsert(2, 7);
-    EXPECT_EQ(kpq.size(), 2);
-    EXPECT_EQ(kpq.top().first, 2); // value 7
-
-    kpq.upsert(1, 10); // bump key 1 above key 2; size unchanged (no duplicate)
-    EXPECT_EQ(kpq.size(), 2);
-    EXPECT_EQ(kpq.top().first, 1);
-    EXPECT_EQ(kpq.top().second, 10);
-
-    kpq.upsert(1, 1); // lower it back down
-    EXPECT_EQ(kpq.size(), 2);
-    EXPECT_EQ(kpq.top().first, 2);
-}
-
-TEST(KeyedPriorityQueueTest, EraseRemovesKey) {
-    keyed_priority_queue<int, int, std::less<int>> kpq{std::less<int>{}};
-    kpq.upsert(1, 5);
-    kpq.upsert(2, 7);
-    kpq.erase(2);
-    EXPECT_EQ(kpq.size(), 1);
-    EXPECT_FALSE(kpq.contains(2));
-    EXPECT_EQ(kpq.top().first, 1);
-}
-
-TEST(KeyedPriorityQueueTest, EqualValuesRetainedAndTieBrokenByKey) {
-    // The backing std::set ranks elements by value first, key second, and
-    // treats two as duplicates when neither sorts below the other. Without the
-    // key tie-break, equal-valued entries would compare equivalent and the
-    // unique set would drop all but one. All three keys must therefore be kept;
-    // among equal values the largest key is the top.
-    keyed_priority_queue<int, int, std::less<int>> kpq{std::less<int>{}};
-    kpq.upsert(1, 5);
-    kpq.upsert(2, 5);
-    kpq.upsert(3, 5);
-    EXPECT_EQ(kpq.size(), 3); // not collapsed to 1
-    EXPECT_EQ(kpq.top().first, 3);
-    EXPECT_EQ(kpq.top().second, 5);
-
-    // Erasing the top reveals the next key in tie-break order.
-    kpq.erase(3);
-    EXPECT_EQ(kpq.size(), 2);
-    EXPECT_EQ(kpq.top().first, 2);
-
-    // Re-upserting an existing key at the same value re-keys its slot without
-    // creating a duplicate or disturbing the order.
-    kpq.upsert(2, 5);
-    EXPECT_EQ(kpq.size(), 2);
-    EXPECT_EQ(kpq.top().first, 2);
-}
-
 } // namespace
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/maintenance/log_info_collector.cc
+++ b/src/v/cloud_topics/level_one/maintenance/log_info_collector.cc
@@ -401,15 +401,13 @@ void log_info_collector::populate_logs_with_leveling_info(
         }
 
         log->has_seen_reconciled_data = true;
-        log->leveling.info_and_ts = leveling_info_and_timestamp{
-          .info = std::move(leveling_info).value(),
-          .collected_at = collection_timestamp};
+        auto info = std::move(leveling_info).value();
 
         vlog(
           compaction_log.debug,
           "Leveling info for CTP {} returned {}",
           log->ntp,
-          log->leveling.info_and_ts->info);
+          info);
 
         // This fresh metastore sample supersedes whatever we previously queued
         // for the CTP, so drop its existing queue and rebuild it below from the
@@ -438,7 +436,6 @@ void log_info_collector::populate_logs_with_leveling_info(
         }
         inflight = std::move(retained);
 
-        auto& info = log->leveling.info_and_ts->info;
         for (auto& range : info.ranges) {
             // Skip any range that overlaps one already inflight; its rewrite
             // has not yet committed, so the metastore still reports it as
@@ -447,9 +444,8 @@ void log_info_collector::populate_logs_with_leveling_info(
                 continue;
             }
             auto job = ss::make_lw_shared<leveling_job>(log, range, info.epoch);
-            leveling_queue.push(job);
+            leveling_queue.push(std::move(job));
         }
-        info.ranges.clear();
     }
 }
 

--- a/src/v/cloud_topics/level_one/maintenance/log_info_collector.cc
+++ b/src/v/cloud_topics/level_one/maintenance/log_info_collector.cc
@@ -26,7 +26,7 @@ namespace cloud_topics::l1 {
 namespace {
 
 inline bool needs_compaction(
-  const log_compaction_meta& log,
+  const metastore::compaction_info_response& info,
   const cluster::topic_configuration& topic_cfg) {
     auto& topic_mcdr = topic_cfg.properties.min_cleanable_dirty_ratio;
     auto min_cleanable_dirty_ratio
@@ -39,9 +39,9 @@ inline bool needs_compaction(
           ? topic_mcl.value()
           : config::shard_local_cfg().max_compaction_lag_ms();
     return compaction::log_needs_compaction(
-      log.compaction.info_and_ts->info.dirty_ratio,
+      info.dirty_ratio,
       min_cleanable_dirty_ratio,
-      log.compaction.info_and_ts->info.earliest_dirty_ts,
+      info.earliest_dirty_ts,
       max_compaction_lag_ms);
 }
 
@@ -181,7 +181,7 @@ log_info_collector::build_compaction_specs(
     specs.reserve(size);
 
     for (const auto& log : logs_list) {
-        if (log.compaction.s == log_compaction_state::status::inflight) {
+        if (log.compaction.inflight_shard.has_value()) {
             // No need to sample inflight logs
             vlog(
               compaction_log.debug,
@@ -241,7 +241,7 @@ void log_info_collector::populate_logs_with_compaction_info(
     ntp_to_max_compactible_offset,
   model::timestamp collection_timestamp) const {
     for (auto& log : logs_list) {
-        if (log.compaction.s == log_compaction_state::status::inflight) {
+        if (log.compaction.inflight_shard.has_value()) {
             // Don't step on compaction info that is actively being used.
             continue;
         }
@@ -284,7 +284,7 @@ void log_info_collector::populate_logs_with_compaction_info(
         auto max_compactible_offset = offset_it->second;
 
         log.has_seen_reconciled_data = true;
-        log.compaction.info_and_ts = compaction_info_and_timestamp{
+        auto info_and_ts = compaction_info_and_timestamp{
           .info = std::move(compaction_info).value(),
           .collected_at = collection_timestamp,
           .max_compactible_offset = max_compactible_offset};
@@ -294,13 +294,8 @@ void log_info_collector::populate_logs_with_compaction_info(
           "Compaction info for CTP {} returned {} with max_compactible_offset: "
           "{}",
           log.ntp,
-          log.compaction.info_and_ts->info,
+          info_and_ts.info,
           max_compactible_offset);
-
-        if (log.compaction.s != log_compaction_state::status::idle) {
-            // We don't need to queue an already queued log.
-            continue;
-        }
 
         auto topic_cfg_opt = _topic_metadata_provider->get_topic_cfg(
           model::topic_namespace_view(log.ntp));
@@ -311,13 +306,22 @@ void log_info_collector::populate_logs_with_compaction_info(
 
         const auto& topic_cfg = topic_cfg_opt.value().get();
 
-        if (needs_compaction(log, topic_cfg)) {
-            auto ptr_it = logs_set.find(log.tidp);
-            if (ptr_it != logs_set.end()) {
-                log.compaction.s = log_compaction_state::status::queued;
-                compaction_queue.push(*ptr_it);
-            }
+        if (!needs_compaction(info_and_ts.info, topic_cfg)) {
+            continue;
         }
+
+        auto ptr_it = logs_set.find(log.tidp);
+        if (ptr_it == logs_set.end()) {
+            continue;
+        }
+
+        // (Re)build the job from this fresh sample and enqueue it. If the CTP
+        // is already queued, `push` replaces its job in place at the new
+        // priority; an inflight CTP is skipped above, so its job is never
+        // disturbed.
+        auto job = ss::make_lw_shared<compaction_job>(
+          *ptr_it, std::move(info_and_ts));
+        compaction_queue.push(std::move(job));
     }
 }
 

--- a/src/v/cloud_topics/level_one/maintenance/log_info_collector.cc
+++ b/src/v/cloud_topics/level_one/maintenance/log_info_collector.cc
@@ -123,7 +123,7 @@ log_info_collector::log_info_collector(
 ss::future<> log_info_collector::collect_compaction_info(
   log_set_t& logs_set,
   log_list_t& logs_list,
-  log_compaction_queue& compaction_queue) const {
+  compaction_queue& compaction_queue) const {
     auto now = model::timestamp::now();
 
     auto specs = build_compaction_specs(logs_list, logs_set.size(), now);
@@ -236,7 +236,7 @@ void log_info_collector::populate_logs_with_compaction_info(
   metastore::compaction_info_map& compaction_infos,
   log_set_t& logs_set,
   log_list_t& logs_list,
-  log_compaction_queue& compaction_queue,
+  compaction_queue& compaction_queue,
   const chunked_hash_map<model::ntp, kafka::offset>&
     ntp_to_max_compactible_offset,
   model::timestamp collection_timestamp) const {

--- a/src/v/cloud_topics/level_one/maintenance/log_info_collector.h
+++ b/src/v/cloud_topics/level_one/maintenance/log_info_collector.h
@@ -95,13 +95,10 @@ public:
     ss::future<>
     collect_compaction_info(log_set_t&, log_list_t&, compaction_queue&) const;
 
-    // Populates `leveling.info_and_ts` within `log_compaction_meta`s from the
-    // provided `log_list_t` by collecting each log's leveling info from the
-    // metastore. Logs are skipped if `leveling.info_and_ts` is still fresh.
-    // For each freshly-sampled log, its queue in the `leveling_queue` is
-    // overwritten from the newly collected ranges, skipping any that overlap a
-    // range already inflight for the CTP. The transient `info.ranges` is
-    // cleared after queueing.
+    // Collects each managed log's leveling info from the metastore. For each
+    // freshly-sampled log, its existing jobs in the `leveling_queue` are
+    // dropped and rebuilt from the newly collected ranges, skipping any that
+    // overlap a range already inflight for the CTP.
     ss::future<>
     collect_leveling_info(log_set_t&, log_list_t&, leveling_queue&) const;
 

--- a/src/v/cloud_topics/level_one/maintenance/log_info_collector.h
+++ b/src/v/cloud_topics/level_one/maintenance/log_info_collector.h
@@ -85,18 +85,13 @@ public:
       std::unique_ptr<topic_cfg_provider>,
       std::unique_ptr<max_compactible_offset_provider>);
 
-    // Populates `compaction.info_and_ts` within `log_compaction_meta`s from
-    // the provided `log_list_t` by collecting each log's compaction info from
-    // the metastore. It is not guaranteed that every log present in
-    // `log_list_t` will have its `compaction.info_and_ts` set e.g. due to
-    // concurrent removal or metastore errors. If a log already has
-    // `compaction.info_and_ts` set, it will not be collected again until an
-    // interval has elapsed and the current `compaction.info_and_ts` is
-    // determined stale. Additionally, logs that have an inflight compaction in
-    // process do not need to be collected. Logs that have their information
-    // collected and deemed eligible for compaction will also have their
-    // `lw_shared_ptr` copied into the `compaction_queue` for future
-    // compaction.
+    // Collects each managed log's compaction info from the metastore and, for
+    // every log deemed eligible for compaction, enqueues a `compaction_job`
+    // carrying that sample into the `compaction_queue`. Re-queuing a log that
+    // is already queued replaces its job in place with the fresher sample. Not
+    // every log in `log_list_t` is sampled or enqueued e.g. due to concurrent
+    // removal, metastore errors, the metastore's own sampling interval, or the
+    // log being skipped because it has an inflight compaction.
     ss::future<>
     collect_compaction_info(log_set_t&, log_list_t&, compaction_queue&) const;
 

--- a/src/v/cloud_topics/level_one/maintenance/log_info_collector.h
+++ b/src/v/cloud_topics/level_one/maintenance/log_info_collector.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "cloud_topics/level_one/maintenance/compaction/compaction_queue.h"
 #include "cloud_topics/level_one/maintenance/leveling/leveling_queue.h"
 #include "cloud_topics/level_one/maintenance/meta.h"
 #include "cloud_topics/level_one/metastore/metastore.h"
@@ -94,10 +95,10 @@ public:
     // determined stale. Additionally, logs that have an inflight compaction in
     // process do not need to be collected. Logs that have their information
     // collected and deemed eligible for compaction will also have their
-    // `lw_shared_ptr` copied into the `log_compaction_queue` for future
+    // `lw_shared_ptr` copied into the `compaction_queue` for future
     // compaction.
-    ss::future<> collect_compaction_info(
-      log_set_t&, log_list_t&, log_compaction_queue&) const;
+    ss::future<>
+    collect_compaction_info(log_set_t&, log_list_t&, compaction_queue&) const;
 
     // Populates `leveling.info_and_ts` within `log_compaction_meta`s from the
     // provided `log_list_t` by collecting each log's leveling info from the
@@ -122,12 +123,12 @@ private:
 
     // Sets compaction info state within the input logs per the
     // `compaction_info_map` collected from the metastore and pushes logs
-    // eligible for compaction to the provided `log_compaction_queue`.
+    // eligible for compaction to the provided `compaction_queue`.
     void populate_logs_with_compaction_info(
       metastore::compaction_info_map&,
       log_set_t&,
       log_list_t&,
-      log_compaction_queue&,
+      compaction_queue&,
       const chunked_hash_map<model::ntp, kafka::offset>&,
       model::timestamp) const;
 

--- a/src/v/cloud_topics/level_one/maintenance/meta.h
+++ b/src/v/cloud_topics/level_one/maintenance/meta.h
@@ -34,13 +34,6 @@ struct compaction_info_and_timestamp {
     kafka::offset max_compactible_offset;
 };
 
-// Contains leveling information collected from the metastore and the time at
-// which it was obtained.
-struct leveling_info_and_timestamp {
-    metastore::leveling_info_response info;
-    model::timestamp collected_at;
-};
-
 // Per-CTP state for the compaction maintenance subsystem.
 struct log_compaction_state {
     // If set, the worker shard on which this CTP is currently undergoing an
@@ -53,10 +46,6 @@ struct log_compaction_state {
 
 // Per-CTP state for the leveling maintenance subsystem.
 struct log_leveling_state {
-    // If set, leveling metadata obtained from the metastore at
-    // `collected_at` time.
-    std::optional<leveling_info_and_timestamp> info_and_ts{std::nullopt};
-
     // Refcount of inflight leveling ranges per worker shard for this CTP.
     chunked_hash_map<ss::shard_id, size_t> inflight_shards;
 

--- a/src/v/cloud_topics/level_one/maintenance/meta.h
+++ b/src/v/cloud_topics/level_one/maintenance/meta.h
@@ -43,20 +43,11 @@ struct leveling_info_and_timestamp {
 
 // Per-CTP state for the compaction maintenance subsystem.
 struct log_compaction_state {
-    // Whether this log is:
-    // 1. `idle` (not yet queued for compaction)
-    // 2. `queued` (present in the scheduler's `log_compaction_queue`)
-    // 3. `inflight` (currently undergoing a compaction on a worker shard)
-    enum class status { idle, queued, inflight };
-    status s{status::idle};
-
-    // If set, this is cached compaction metadata obtained from the metastore
-    // at the `collected_at` time. Guaranteed to have a value if
-    // `s == queued` or `s == inflight`.
-    std::optional<compaction_info_and_timestamp> info_and_ts{std::nullopt};
-
-    // If set, this is the shard on which the log is currently undergoing an
-    // inflight compaction. Guaranteed to have a value if `s == inflight`.
+    // If set, the worker shard on which this CTP is currently undergoing an
+    // inflight compaction. A CTP's scheduling state is derived rather than
+    // stored: it is `inflight` iff this has a value, `queued` iff the
+    // scheduler's `compaction_queue` holds a job for it, and `idle` otherwise.
+    // Mutated only on `worker_manager_shard`.
     std::optional<ss::shard_id> inflight_shard{std::nullopt};
 };
 
@@ -99,8 +90,6 @@ struct log_compaction_meta {
 };
 
 using log_compaction_meta_ptr = ss::lw_shared_ptr<log_compaction_meta>;
-using foreign_log_compaction_meta_ptr
-  = ss::foreign_ptr<log_compaction_meta_ptr>;
 
 struct log_compaction_meta_hash {
     using is_transparent = void;
@@ -145,8 +134,24 @@ using log_set_t = chunked_hash_set<
 using log_list_t
   = intrusive_list<log_compaction_meta, &log_compaction_meta::link>;
 
-using compaction_cmp_t = std::function<bool(
-  const log_compaction_meta_ptr&, const log_compaction_meta_ptr&)>;
+// A compaction of a single CTP, scheduled as a job. Holds the owning CTP's
+// meta (for identity and inflight bookkeeping) alongside the metastore sample
+// the compaction will run against.
+struct compaction_job {
+    compaction_job(
+      log_compaction_meta_ptr meta, compaction_info_and_timestamp info_and_ts)
+      : meta(std::move(meta))
+      , info_and_ts(std::move(info_and_ts)) {}
+
+    log_compaction_meta_ptr meta;
+    compaction_info_and_timestamp info_and_ts;
+};
+
+using compaction_job_ptr = ss::lw_shared_ptr<compaction_job>;
+using foreign_compaction_job_ptr = ss::foreign_ptr<compaction_job_ptr>;
+
+using compaction_cmp_t
+  = std::function<bool(const compaction_job_ptr&, const compaction_job_ptr&)>;
 
 // A single levelable range scheduled as an independent job. Holds a
 // back-link to the per-CTP meta so the worker_manager can find inflight

--- a/src/v/cloud_topics/level_one/maintenance/meta.h
+++ b/src/v/cloud_topics/level_one/maintenance/meta.h
@@ -147,10 +147,6 @@ using log_list_t
 
 using compaction_cmp_t = std::function<bool(
   const log_compaction_meta_ptr&, const log_compaction_meta_ptr&)>;
-using log_compaction_queue = std::priority_queue<
-  log_compaction_meta_ptr,
-  chunked_vector<log_compaction_meta_ptr>,
-  cmp_t>;
 
 // A single levelable range scheduled as an independent job. Holds a
 // back-link to the per-CTP meta so the worker_manager can find inflight

--- a/src/v/cloud_topics/level_one/maintenance/meta.h
+++ b/src/v/cloud_topics/level_one/maintenance/meta.h
@@ -145,7 +145,7 @@ using log_set_t = chunked_hash_set<
 using log_list_t
   = intrusive_list<log_compaction_meta, &log_compaction_meta::link>;
 
-using cmp_t = std::function<bool(
+using compaction_cmp_t = std::function<bool(
   const log_compaction_meta_ptr&, const log_compaction_meta_ptr&)>;
 using log_compaction_queue = std::priority_queue<
   log_compaction_meta_ptr,

--- a/src/v/cloud_topics/level_one/maintenance/scheduler.cc
+++ b/src/v/cloud_topics/level_one/maintenance/scheduler.cc
@@ -111,8 +111,13 @@ void compaction_scheduler::unmanage_partition(
 
     auto handle = std::move(handle_opt).value();
 
+    // Evict any queued (non-inflight) compaction entry for this CTP so it does
+    // not linger in the queue holding the meta alive. An inflight log is not in
+    // the queue (it was popped on dispatch); it is stopped below.
+    _compaction_queue.clear(tidp);
+
     // Manually unlink here to ensure that if the handle also exists in the
-    // `log_compaction_queue`, `is_linked()` still returns `false` when it is
+    // `compaction_queue`, `is_linked()` still returns `false` when it is
     // eventually considered for compaction.
     handle->link.unlink();
 

--- a/src/v/cloud_topics/level_one/maintenance/scheduler.h
+++ b/src/v/cloud_topics/level_one/maintenance/scheduler.h
@@ -127,9 +127,8 @@ private:
     // compaction jobs for.
     log_list_t _logs_list;
 
-    // Container of pointers to logs in `_logs/_logs_list` which have sampled
-    // metadata available and are available for compaction- i.e
-    // `log->compaction.info_and_ts` is guaranteed to have a value.
+    // Jobs for logs in `_logs/_logs_list` that have a sampled metastore info
+    // and are eligible for compaction, ordered by the scheduling policy.
     compaction_queue _compaction_queue;
 
     // TODO: remove this once more cluster objects speak `topic_id_partition`.

--- a/src/v/cloud_topics/level_one/maintenance/scheduler.h
+++ b/src/v/cloud_topics/level_one/maintenance/scheduler.h
@@ -12,6 +12,7 @@
 
 #include "cloud_topics/level_one/common/file_io.h"
 #include "cloud_topics/level_one/frontend_reader/level_one_reader_probe.h"
+#include "cloud_topics/level_one/maintenance/compaction/compaction_queue.h"
 #include "cloud_topics/level_one/maintenance/log_collector.h"
 #include "cloud_topics/level_one/maintenance/log_info_collector.h"
 #include "cloud_topics/level_one/maintenance/meta.h"
@@ -129,7 +130,7 @@ private:
     // Container of pointers to logs in `_logs/_logs_list` which have sampled
     // metadata available and are available for compaction- i.e
     // `log->compaction.info_and_ts` is guaranteed to have a value.
-    log_compaction_queue _compaction_queue;
+    compaction_queue _compaction_queue;
 
     // TODO: remove this once more cluster objects speak `topic_id_partition`.
     chunked_hash_map<model::ntp, model::topic_id_partition> _ntp_to_tidp;

--- a/src/v/cloud_topics/level_one/maintenance/scheduling_policies.cc
+++ b/src/v/cloud_topics/level_one/maintenance/scheduling_policies.cc
@@ -12,11 +12,13 @@
 
 namespace cloud_topics::l1 {
 
-cmp_t dirty_ratio_scheduling_policy::get_comparator() const noexcept {
+compaction_cmp_t
+dirty_ratio_scheduling_policy::get_comparator() const noexcept {
     return sort_policy{};
 }
 
-cmp_t compaction_lag_scheduling_policy::get_comparator() const noexcept {
+compaction_cmp_t
+compaction_lag_scheduling_policy::get_comparator() const noexcept {
     return sort_policy{};
 }
 

--- a/src/v/cloud_topics/level_one/maintenance/scheduling_policies.h
+++ b/src/v/cloud_topics/level_one/maintenance/scheduling_policies.h
@@ -40,15 +40,9 @@ public:
 private:
     struct sort_policy {
         static bool operator()(
-          const log_compaction_meta_ptr& a,
-          const log_compaction_meta_ptr& b) noexcept {
-            vassert(
-              a->compaction.info_and_ts.has_value()
-                && b->compaction.info_and_ts.has_value(),
-              "Sorting policy applied to logs without compaction.info_and_ts "
-              "assigned- concurrency issue?");
-            return a->compaction.info_and_ts->info.dirty_ratio
-                   < b->compaction.info_and_ts->info.dirty_ratio;
+          const compaction_job_ptr& a, const compaction_job_ptr& b) noexcept {
+            return a->info_and_ts.info.dirty_ratio
+                   < b->info_and_ts.info.dirty_ratio;
         }
     };
 };
@@ -62,15 +56,9 @@ public:
 private:
     struct sort_policy {
         static bool operator()(
-          const log_compaction_meta_ptr& a,
-          const log_compaction_meta_ptr& b) noexcept {
-            vassert(
-              a->compaction.info_and_ts.has_value()
-                && b->compaction.info_and_ts.has_value(),
-              "Sorting policy applied to logs without compaction.info_and_ts "
-              "assigned- concurrency issue?");
-            return a->compaction.info_and_ts->info.earliest_dirty_ts
-                   > b->compaction.info_and_ts->info.earliest_dirty_ts;
+          const compaction_job_ptr& a, const compaction_job_ptr& b) noexcept {
+            return a->info_and_ts.info.earliest_dirty_ts
+                   > b->info_and_ts.info.earliest_dirty_ts;
         }
     };
 };

--- a/src/v/cloud_topics/level_one/maintenance/scheduling_policies.h
+++ b/src/v/cloud_topics/level_one/maintenance/scheduling_policies.h
@@ -28,14 +28,14 @@ public:
     scheduling_policy& operator=(scheduling_policy&&) noexcept = default;
     virtual ~scheduling_policy() = default;
 
-    virtual cmp_t get_comparator() const noexcept = 0;
+    virtual compaction_cmp_t get_comparator() const noexcept = 0;
 };
 
 // Compacts partitions from highest dirty ratio (the ratio of unclean bytes in
 // the log to the total log size) to lowest.
 class dirty_ratio_scheduling_policy : public scheduling_policy {
 public:
-    cmp_t get_comparator() const noexcept final;
+    compaction_cmp_t get_comparator() const noexcept final;
 
 private:
     struct sort_policy {
@@ -57,7 +57,7 @@ private:
 // the first uncompacted record) to lowest.
 class compaction_lag_scheduling_policy : public scheduling_policy {
 public:
-    cmp_t get_comparator() const noexcept final;
+    compaction_cmp_t get_comparator() const noexcept final;
 
 private:
     struct sort_policy {

--- a/src/v/cloud_topics/level_one/maintenance/tests/BUILD
+++ b/src/v/cloud_topics/level_one/maintenance/tests/BUILD
@@ -1,6 +1,21 @@
 load("//bazel:test.bzl", "redpanda_cc_gtest", "redpanda_test_cc_library")
 
 redpanda_cc_gtest(
+    name = "keyed_priority_queue_test",
+    timeout = "short",
+    srcs = [
+        "keyed_priority_queue_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/cloud_topics/level_one/maintenance:keyed_priority_queue",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "worker_manager_test",
     timeout = "short",
     srcs = [

--- a/src/v/cloud_topics/level_one/maintenance/tests/BUILD
+++ b/src/v/cloud_topics/level_one/maintenance/tests/BUILD
@@ -26,6 +26,7 @@ redpanda_cc_gtest(
         "//src/v/cloud_topics/level_one/maintenance:scheduler_probe",
         "//src/v/cloud_topics/level_one/maintenance:scheduling_policies",
         "//src/v/cloud_topics/level_one/maintenance:worker",
+        "//src/v/cloud_topics/level_one/maintenance/compaction:compaction_queue",
         "//src/v/cloud_topics/level_one/maintenance/leveling:leveling_queue",
         "//src/v/cluster:fwd",
         "//src/v/cluster:members_table",

--- a/src/v/cloud_topics/level_one/maintenance/tests/keyed_priority_queue_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/tests/keyed_priority_queue_test.cc
@@ -1,0 +1,74 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+#include "cloud_topics/level_one/maintenance/keyed_priority_queue.h"
+
+#include <gtest/gtest.h>
+
+#include <functional>
+
+namespace cloud_topics::l1 {
+
+namespace {
+
+TEST(KeyedPriorityQueueTest, UpsertUpdatesInPlace) {
+    keyed_priority_queue<int, int, std::less<int>> kpq{std::less<int>{}};
+    kpq.upsert(1, 5);
+    kpq.upsert(2, 7);
+    EXPECT_EQ(kpq.size(), 2);
+    EXPECT_EQ(kpq.top().first, 2); // value 7
+
+    kpq.upsert(1, 10); // bump key 1 above key 2; size unchanged (no duplicate)
+    EXPECT_EQ(kpq.size(), 2);
+    EXPECT_EQ(kpq.top().first, 1);
+    EXPECT_EQ(kpq.top().second, 10);
+
+    kpq.upsert(1, 1); // lower it back down
+    EXPECT_EQ(kpq.size(), 2);
+    EXPECT_EQ(kpq.top().first, 2);
+}
+
+TEST(KeyedPriorityQueueTest, EraseRemovesKey) {
+    keyed_priority_queue<int, int, std::less<int>> kpq{std::less<int>{}};
+    kpq.upsert(1, 5);
+    kpq.upsert(2, 7);
+    kpq.erase(2);
+    EXPECT_EQ(kpq.size(), 1);
+    EXPECT_FALSE(kpq.contains(2));
+    EXPECT_EQ(kpq.top().first, 1);
+}
+
+TEST(KeyedPriorityQueueTest, EqualValuesRetainedAndTieBrokenByKey) {
+    // The backing std::set ranks elements by value first, key second, and
+    // treats two as duplicates when neither sorts below the other. Without the
+    // key tie-break, equal-valued entries would compare equivalent and the
+    // unique set would drop all but one. All three keys must therefore be kept;
+    // among equal values the largest key is the top.
+    keyed_priority_queue<int, int, std::less<int>> kpq{std::less<int>{}};
+    kpq.upsert(1, 5);
+    kpq.upsert(2, 5);
+    kpq.upsert(3, 5);
+    EXPECT_EQ(kpq.size(), 3); // not collapsed to 1
+    EXPECT_EQ(kpq.top().first, 3);
+    EXPECT_EQ(kpq.top().second, 5);
+
+    // Erasing the top reveals the next key in tie-break order.
+    kpq.erase(3);
+    EXPECT_EQ(kpq.size(), 2);
+    EXPECT_EQ(kpq.top().first, 2);
+
+    // Re-upserting an existing key at the same value re-keys its slot without
+    // creating a duplicate or disturbing the order.
+    kpq.upsert(2, 5);
+    EXPECT_EQ(kpq.size(), 2);
+    EXPECT_EQ(kpq.top().first, 2);
+}
+
+} // namespace
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/maintenance/tests/log_info_collector_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/tests/log_info_collector_test.cc
@@ -172,10 +172,6 @@ TEST_F(LogInfoCollectorTestFixture, TestSampleLevelingInfo) {
 
     log_info_collector.collect_leveling_info(logs_set, logs_list, queue).get();
 
-    ASSERT_TRUE(log_ptr->leveling.info_and_ts.has_value());
-    // info.ranges is cleared after queueing; only the timestamp cookie is
-    // retained for the next tick.
-    ASSERT_TRUE(log_ptr->leveling.info_and_ts->info.ranges.empty());
     ASSERT_GT(queue.size(), 0u);
     size_t total_size_bytes = 0;
     while (!queue.empty()) {

--- a/src/v/cloud_topics/level_one/maintenance/tests/log_info_collector_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/tests/log_info_collector_test.cc
@@ -105,9 +105,9 @@ TEST_F(LogInfoCollectorTestFixture, TestInfoCollector) {
     std::vector<tidp_batches_t> tidp_batches;
     l1::log_set_t logs;
     l1::compaction_queue cached_metadata(
-      [](
-        const l1::log_compaction_meta_ptr& a,
-        const l1::log_compaction_meta_ptr& b) { return a->ntp < b->ntp; });
+      [](const l1::compaction_job_ptr& a, const l1::compaction_job_ptr& b) {
+          return a->meta->ntp < b->meta->ntp;
+      });
     l1::log_list_t logs_list;
     for (const auto& [ntp, tidp] : ntidps) {
         auto [it, success] = logs.emplace(
@@ -125,10 +125,8 @@ TEST_F(LogInfoCollectorTestFixture, TestInfoCollector) {
     while (!cached_metadata.empty()) {
         auto sample = cached_metadata.top();
         cached_metadata.pop();
-        ASSERT_TRUE(sample->compaction.info_and_ts.has_value());
-        ASSERT_FLOAT_EQ(sample->compaction.info_and_ts->info.dirty_ratio, 1.0);
-        ASSERT_TRUE(
-          sample->compaction.info_and_ts->info.earliest_dirty_ts.has_value());
+        ASSERT_FLOAT_EQ(sample->info_and_ts.info.dirty_ratio, 1.0);
+        ASSERT_TRUE(sample->info_and_ts.info.earliest_dirty_ts.has_value());
     }
 }
 

--- a/src/v/cloud_topics/level_one/maintenance/tests/log_info_collector_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/tests/log_info_collector_test.cc
@@ -104,7 +104,7 @@ TEST_F(LogInfoCollectorTestFixture, TestInfoCollector) {
 
     std::vector<tidp_batches_t> tidp_batches;
     l1::log_set_t logs;
-    l1::log_compaction_queue cached_metadata(
+    l1::compaction_queue cached_metadata(
       [](
         const l1::log_compaction_meta_ptr& a,
         const l1::log_compaction_meta_ptr& b) { return a->ntp < b->ntp; });

--- a/src/v/cloud_topics/level_one/maintenance/tests/scheduler_fixture.h
+++ b/src/v/cloud_topics/level_one/maintenance/tests/scheduler_fixture.h
@@ -79,8 +79,9 @@ public:
     void enqueue_for_compaction(const model::topic_id_partition& tidp) {
         auto it = scheduler->_logs.find(tidp);
         vassert(it != scheduler->_logs.end(), "CTP {} is not managed", tidp);
-        (*it)->compaction.s = l1::log_compaction_state::status::queued;
-        scheduler->_compaction_queue.push(*it);
+        scheduler->_compaction_queue.push(
+          ss::make_lw_shared<l1::compaction_job>(
+            *it, l1::compaction_info_and_timestamp{}));
     }
 
     bool compaction_queue_contains(const model::topic_id_partition& tidp) {

--- a/src/v/cloud_topics/level_one/maintenance/tests/scheduler_fixture.h
+++ b/src/v/cloud_topics/level_one/maintenance/tests/scheduler_fixture.h
@@ -8,6 +8,7 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 
+#include "base/vassert.h"
 #include "cloud_topics/level_one/frontend_reader/tests/l1_reader_fixture.h"
 #include "cloud_topics/level_one/maintenance/log_info_collector.h"
 #include "cloud_topics/level_one/maintenance/scheduler.h"
@@ -71,6 +72,23 @@ public:
           &l1::compaction_worker::start);
         scheduler->start_bg_loop();
         co_return;
+    }
+
+    // Marks a managed CTP as queued for compaction and pushes it into the
+    // scheduler's compaction queue, as the info collector would.
+    void enqueue_for_compaction(const model::topic_id_partition& tidp) {
+        auto it = scheduler->_logs.find(tidp);
+        vassert(it != scheduler->_logs.end(), "CTP {} is not managed", tidp);
+        (*it)->compaction.s = l1::log_compaction_state::status::queued;
+        scheduler->_compaction_queue.push(*it);
+    }
+
+    bool compaction_queue_contains(const model::topic_id_partition& tidp) {
+        return scheduler->_compaction_queue.contains(tidp);
+    }
+
+    size_t compaction_queue_size() {
+        return scheduler->_compaction_queue.size();
     }
 
     ss::future<> pause_worker(ss::shard_id shard) {

--- a/src/v/cloud_topics/level_one/maintenance/tests/scheduler_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/tests/scheduler_test.cc
@@ -21,6 +21,22 @@
 using namespace cloud_topics;
 using namespace std::chrono_literals;
 
+// Unmanaging a CTP that is queued for compaction should evict its entry from
+// the `compaction_queue`, rather than leaving a stale pointer to linger until
+// it eventually bubbles to the top.
+TEST_F(SchedulerTestFixture, UnmanageEvictsQueuedEntry) {
+    auto [ntp, tidp] = make_ntidp("evict-me");
+    scheduler->manage_partition(ntp, tidp, "test");
+
+    // Simulate the info collector having enqueued this CTP for compaction.
+    enqueue_for_compaction(tidp);
+    ASSERT_TRUE(compaction_queue_contains(tidp));
+
+    scheduler->unmanage_partition(ntp, "test");
+    ASSERT_FALSE(compaction_queue_contains(tidp));
+    ASSERT_EQ(compaction_queue_size(), 0u);
+}
+
 // This test produces data and stresses concurrent addition and removal of ntps
 // to the compaction_scheduler, as well as pausing and resuming of a single
 // worker (test is built with cpu = 1).

--- a/src/v/cloud_topics/level_one/maintenance/tests/worker_manager_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/tests/worker_manager_test.cc
@@ -56,11 +56,10 @@ public:
 };
 
 TEST_F(WorkerManagerTestFixture, PauseAndResumeWorkers) {
-    auto cmp_func = [](
-                      const l1::log_compaction_meta_ptr& a,
-                      const l1::log_compaction_meta_ptr& b) {
-        return a->ntp < b->ntp;
-    };
+    auto cmp_func =
+      [](const l1::compaction_job_ptr& a, const l1::compaction_job_ptr& b) {
+          return a->meta->ntp < b->meta->ntp;
+      };
 
     l1::compaction_scheduler_probe probe;
     l1::compaction_queue pq(std::move(cmp_func));
@@ -86,11 +85,10 @@ TEST_F(WorkerManagerTestFixture, PauseAndResumeWorkers) {
 }
 
 TEST_F(WorkerManagerTestFixture, AcquireWork) {
-    auto cmp_func = [](
-                      const l1::log_compaction_meta_ptr& a,
-                      const l1::log_compaction_meta_ptr& b) {
-        return a->ntp < b->ntp;
-    };
+    auto cmp_func =
+      [](const l1::compaction_job_ptr& a, const l1::compaction_job_ptr& b) {
+          return a->meta->ntp < b->meta->ntp;
+      };
 
     l1::compaction_scheduler_probe probe;
     l1::compaction_queue pq(std::move(cmp_func));
@@ -105,28 +103,27 @@ TEST_F(WorkerManagerTestFixture, AcquireWork) {
     auto meta = ss::make_lw_shared<l1::log_compaction_meta>(
       test_tidp, test_ntp);
     list.push_back(*meta);
-    using status = l1::log_compaction_state::status;
-    meta->compaction.s = status::queued;
-    pq.push(meta);
+    auto job = ss::make_lw_shared<l1::compaction_job>(
+      meta, l1::compaction_info_and_timestamp{});
+    pq.push(job);
 
     auto work_opt = manager.try_acquire_compaction_work(ss::this_shard_id());
     ASSERT_TRUE(work_opt.has_value());
-    ASSERT_EQ(work_opt.value()->ntp, test_ntp);
-    ASSERT_EQ(work_opt.value()->tidp, test_tidp);
-    ASSERT_TRUE(work_opt.value()->compaction.inflight_shard.has_value());
-    ASSERT_EQ(work_opt.value()->compaction.s, status::inflight);
+    ASSERT_EQ(work_opt.value()->meta->ntp, test_ntp);
+    ASSERT_EQ(work_opt.value()->meta->tidp, test_tidp);
+    ASSERT_TRUE(work_opt.value()->meta->compaction.inflight_shard.has_value());
     ASSERT_EQ(
-      work_opt.value()->compaction.inflight_shard.value(), ss::this_shard_id());
+      work_opt.value()->meta->compaction.inflight_shard.value(),
+      ss::this_shard_id());
 
     manager.complete_compaction_work(work_opt.value().get());
-    ASSERT_FALSE(work_opt.value()->compaction.inflight_shard.has_value());
-    ASSERT_EQ(work_opt.value()->compaction.s, status::idle);
+    ASSERT_FALSE(work_opt.value()->meta->compaction.inflight_shard.has_value());
 }
 
 // Verifies that `dirty_ratio_scheduling_policy` orders partitions from
 // highest `dirty_ratio` to lowest.
 TEST(DirtyRatioSchedulingPolicyTest, OrdersHighestDirtyRatioFirst) {
-    auto make_meta = [](std::string_view topic_name, double ratio) {
+    auto make_job = [](std::string_view topic_name, double ratio) {
         auto ntp = model::ntp(
           model::ns("kafka"),
           model::topic(ss::sstring{topic_name}),
@@ -134,17 +131,18 @@ TEST(DirtyRatioSchedulingPolicyTest, OrdersHighestDirtyRatioFirst) {
         auto tidp = model::topic_id_partition(
           model::topic_id(uuid_t::create()), ntp.tp.partition);
         auto m = ss::make_lw_shared<l1::log_compaction_meta>(tidp, ntp);
-        m->compaction.info_and_ts = l1::compaction_info_and_timestamp{
-          .info = {.dirty_ratio = ratio},
-          .collected_at = model::timestamp::now(),
-          .max_compactible_offset = kafka::offset::max(),
-        };
-        return m;
+        return ss::make_lw_shared<l1::compaction_job>(
+          std::move(m),
+          l1::compaction_info_and_timestamp{
+            .info = {.dirty_ratio = ratio},
+            .collected_at = model::timestamp::now(),
+            .max_compactible_offset = kafka::offset::max(),
+          });
     };
 
-    auto low = make_meta("low", 0.1);
-    auto mid = make_meta("mid", 0.5);
-    auto high = make_meta("high", 0.9);
+    auto low = make_job("low", 0.1);
+    auto mid = make_job("mid", 0.5);
+    auto high = make_job("high", 0.9);
 
     l1::dirty_ratio_scheduling_policy policy;
     l1::compaction_queue q(policy.get_comparator());
@@ -153,17 +151,17 @@ TEST(DirtyRatioSchedulingPolicyTest, OrdersHighestDirtyRatioFirst) {
     q.push(high);
 
     // Pop order should be: most dirty -> least dirty.
-    ASSERT_DOUBLE_EQ(q.top()->compaction.info_and_ts->info.dirty_ratio, 0.9);
+    ASSERT_DOUBLE_EQ(q.top()->info_and_ts.info.dirty_ratio, 0.9);
     q.pop();
-    ASSERT_DOUBLE_EQ(q.top()->compaction.info_and_ts->info.dirty_ratio, 0.5);
+    ASSERT_DOUBLE_EQ(q.top()->info_and_ts.info.dirty_ratio, 0.5);
     q.pop();
-    ASSERT_DOUBLE_EQ(q.top()->compaction.info_and_ts->info.dirty_ratio, 0.1);
+    ASSERT_DOUBLE_EQ(q.top()->info_and_ts.info.dirty_ratio, 0.1);
 }
 
 // Verifies that `compaction_lag_scheduling_policy` orders partitions from
 // highest lag (oldest `earliest_dirty_ts`) to lowest (most recent).
 TEST(CompactionLagSchedulingPolicyTest, OrdersHighestLagFirst) {
-    auto make_meta = [](std::string_view topic_name, model::timestamp ts) {
+    auto make_job = [](std::string_view topic_name, model::timestamp ts) {
         auto ntp = model::ntp(
           model::ns("kafka"),
           model::topic(ss::sstring{topic_name}),
@@ -171,18 +169,19 @@ TEST(CompactionLagSchedulingPolicyTest, OrdersHighestLagFirst) {
         auto tidp = model::topic_id_partition(
           model::topic_id(uuid_t::create()), ntp.tp.partition);
         auto m = ss::make_lw_shared<l1::log_compaction_meta>(tidp, ntp);
-        m->compaction.info_and_ts = l1::compaction_info_and_timestamp{
-          .info = {.earliest_dirty_ts = ts},
-          .collected_at = model::timestamp::now(),
-          .max_compactible_offset = kafka::offset::max(),
-        };
-        return m;
+        return ss::make_lw_shared<l1::compaction_job>(
+          std::move(m),
+          l1::compaction_info_and_timestamp{
+            .info = {.earliest_dirty_ts = ts},
+            .collected_at = model::timestamp::now(),
+            .max_compactible_offset = kafka::offset::max(),
+          });
     };
 
     // Smaller timestamp = older = higher lag.
-    auto old_log = make_meta("old", model::timestamp{1000});
-    auto mid_log = make_meta("mid", model::timestamp{5000});
-    auto new_log = make_meta("new", model::timestamp{9000});
+    auto old_log = make_job("old", model::timestamp{1000});
+    auto mid_log = make_job("mid", model::timestamp{5000});
+    auto new_log = make_job("new", model::timestamp{9000});
 
     l1::compaction_lag_scheduling_policy policy;
     l1::compaction_queue q(policy.get_comparator());
@@ -192,16 +191,13 @@ TEST(CompactionLagSchedulingPolicyTest, OrdersHighestLagFirst) {
 
     // Pop order should be: oldest (highest lag) -> newest (lowest lag).
     ASSERT_EQ(
-      q.top()->compaction.info_and_ts->info.earliest_dirty_ts,
-      model::timestamp{1000});
+      q.top()->info_and_ts.info.earliest_dirty_ts, model::timestamp{1000});
     q.pop();
     ASSERT_EQ(
-      q.top()->compaction.info_and_ts->info.earliest_dirty_ts,
-      model::timestamp{5000});
+      q.top()->info_and_ts.info.earliest_dirty_ts, model::timestamp{5000});
     q.pop();
     ASSERT_EQ(
-      q.top()->compaction.info_and_ts->info.earliest_dirty_ts,
-      model::timestamp{9000});
+      q.top()->info_and_ts.info.earliest_dirty_ts, model::timestamp{9000});
 }
 
 // Verifies that `leveling_extent_reclamation_policy` orders jobs by

--- a/src/v/cloud_topics/level_one/maintenance/tests/worker_manager_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/tests/worker_manager_test.cc
@@ -8,6 +8,7 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 
+#include "cloud_topics/level_one/maintenance/compaction/compaction_queue.h"
 #include "cloud_topics/level_one/maintenance/leveling/leveling_queue.h"
 #include "cloud_topics/level_one/maintenance/meta.h"
 #include "cloud_topics/level_one/maintenance/scheduler_probe.h"
@@ -55,8 +56,14 @@ public:
 };
 
 TEST_F(WorkerManagerTestFixture, PauseAndResumeWorkers) {
+    auto cmp_func = [](
+                      const l1::log_compaction_meta_ptr& a,
+                      const l1::log_compaction_meta_ptr& b) {
+        return a->ntp < b->ntp;
+    };
+
     l1::compaction_scheduler_probe probe;
-    l1::log_compaction_queue pq;
+    l1::compaction_queue pq(std::move(cmp_func));
     l1::worker_manager manager(pq, nullptr, nullptr, nullptr, probe, nullptr);
     start_workers(manager).get();
     auto stop_manager = ss::defer([&manager] { manager.stop().get(); });
@@ -86,7 +93,7 @@ TEST_F(WorkerManagerTestFixture, AcquireWork) {
     };
 
     l1::compaction_scheduler_probe probe;
-    l1::log_compaction_queue pq(std::move(cmp_func));
+    l1::compaction_queue pq(std::move(cmp_func));
     l1::log_list_t list;
     l1::worker_manager manager(pq, nullptr, nullptr, nullptr, probe, nullptr);
     auto stop_manager = ss::defer([&manager] { manager.stop().get(); });
@@ -100,7 +107,7 @@ TEST_F(WorkerManagerTestFixture, AcquireWork) {
     list.push_back(*meta);
     using status = l1::log_compaction_state::status;
     meta->compaction.s = status::queued;
-    pq.emplace(meta);
+    pq.push(meta);
 
     auto work_opt = manager.try_acquire_compaction_work(ss::this_shard_id());
     ASSERT_TRUE(work_opt.has_value());
@@ -140,7 +147,7 @@ TEST(DirtyRatioSchedulingPolicyTest, OrdersHighestDirtyRatioFirst) {
     auto high = make_meta("high", 0.9);
 
     l1::dirty_ratio_scheduling_policy policy;
-    l1::log_compaction_queue q(policy.get_comparator());
+    l1::compaction_queue q(policy.get_comparator());
     q.push(low);
     q.push(mid);
     q.push(high);
@@ -178,7 +185,7 @@ TEST(CompactionLagSchedulingPolicyTest, OrdersHighestLagFirst) {
     auto new_log = make_meta("new", model::timestamp{9000});
 
     l1::compaction_lag_scheduling_policy policy;
-    l1::log_compaction_queue q(policy.get_comparator());
+    l1::compaction_queue q(policy.get_comparator());
     q.push(mid_log);
     q.push(new_log);
     q.push(old_log);

--- a/src/v/cloud_topics/level_one/maintenance/worker.cc
+++ b/src/v/cloud_topics/level_one/maintenance/worker.cc
@@ -114,7 +114,7 @@ ss::future<> compaction_worker::compaction_work_loop() {
 
             auto work = std::move(maybe_work).value();
 
-            auto ntp = work->ntp;
+            auto ntp = work->meta->ntp;
 
             auto compact_fut = co_await ss::coroutine::as_future(
               compact_log(work.get()));
@@ -143,7 +143,7 @@ ss::future<> compaction_worker::clear_work_fut() {
     }
 }
 
-ss::future<> compaction_worker::compact_log(log_compaction_meta* log) {
+ss::future<> compaction_worker::compact_log(compaction_job* job) {
     if (!is_active()) {
         co_return;
     }
@@ -157,43 +157,32 @@ ss::future<> compaction_worker::compact_log(log_compaction_meta* log) {
         co_return;
     }
 
-    if (!log) {
+    if (!job) {
         co_return;
     }
 
-    if (!log->link.is_linked()) {
+    if (!job->meta->link.is_linked()) {
         co_return;
     }
 
-    auto tidp = log->tidp;
-    auto ntp = log->ntp;
+    auto tidp = job->meta->tidp;
+    auto ntp = job->meta->ntp;
 
     auto ctxlog = prefix_logger(compaction_log, fmt::format("{}", ntp));
-
-    if (!log->compaction.info_and_ts.has_value()) {
-        vlog(
-          ctxlog.error,
-          "Log in compaction process did not have metastore information "
-          "set. Concurrency issue?");
-        co_return;
-    }
 
     vlog(ctxlog.info, "Compacting CTP");
 
     _compaction_job_state = compaction_job_state::running;
     _inflight_ntp = ntp;
 
+    const auto& info_and_ts = job->info_and_ts;
     auto compaction_offsets = metastore::compaction_offsets_response{
-      .dirty_ranges
-      = log->compaction.info_and_ts->info.offsets_response.dirty_ranges,
+      .dirty_ranges = info_and_ts.info.offsets_response.dirty_ranges,
       .removable_tombstone_ranges
-      = log->compaction.info_and_ts->info.offsets_response
-          .removable_tombstone_ranges};
-    auto expected_compaction_epoch
-      = log->compaction.info_and_ts->info.compaction_epoch;
-    auto start_offset = log->compaction.info_and_ts->info.start_offset;
-    auto max_compactible_offset
-      = log->compaction.info_and_ts->max_compactible_offset;
+      = info_and_ts.info.offsets_response.removable_tombstone_ranges};
+    auto expected_compaction_epoch = info_and_ts.info.compaction_epoch;
+    auto start_offset = info_and_ts.info.start_offset;
+    auto max_compactible_offset = info_and_ts.max_compactible_offset;
 
     // Lazy initialization of offset map.
     if (!_map) {
@@ -278,7 +267,7 @@ ss::future<> compaction_worker::compact_log(log_compaction_meta* log) {
     _inflight_ntp.reset();
 }
 
-ss::future<std::optional<foreign_log_compaction_meta_ptr>>
+ss::future<std::optional<foreign_compaction_job_ptr>>
 compaction_worker::try_acquire_compaction_work_from_manager() {
     co_return co_await ss::smp::submit_to(
       worker_manager::worker_manager_shard,
@@ -288,12 +277,12 @@ compaction_worker::try_acquire_compaction_work_from_manager() {
 }
 
 ss::future<> compaction_worker::complete_compaction_work_on_manager(
-  foreign_log_compaction_meta_ptr log) {
+  foreign_compaction_job_ptr job) {
     co_return co_await ss::smp::submit_to(
-      worker_manager::worker_manager_shard, [this, log = std::move(log)] {
-          _worker_manager->complete_compaction_work(log.get());
+      worker_manager::worker_manager_shard, [this, job = std::move(job)] {
+          _worker_manager->complete_compaction_work(job.get());
           // Destruct foreign_ptr on owning shard by moving it into closure.
-          std::ignore = std::move(log);
+          std::ignore = std::move(job);
       });
 }
 

--- a/src/v/cloud_topics/level_one/maintenance/worker.h
+++ b/src/v/cloud_topics/level_one/maintenance/worker.h
@@ -113,19 +113,19 @@ private:
     // `paused`, this function is a no-op.
     ss::future<> do_resume_worker();
 
-    // Requests a compaction of the provided CTP and its `compaction_offsets`
-    // as obtained from the `metastore`.
-    ss::future<> compact_log(log_compaction_meta*);
+    // Requests a compaction of the provided job's CTP against the metastore
+    // sample it carries.
+    ss::future<> compact_log(compaction_job*);
 
     // Retrieves a job from the `_worker_manager`, if there is one available.
-    ss::future<std::optional<foreign_log_compaction_meta_ptr>>
+    ss::future<std::optional<foreign_compaction_job_ptr>>
     try_acquire_compaction_work_from_manager();
 
     // After completing a compaction job, go back to the `worker_manager` shard
-    // to mark the work as "complete" (i.e reset the `meta->inflight` value to
+    // to mark the work as "complete" (i.e reset the CTP's `inflight_shard` to
     // indicate there is no longer an in-process compaction occurring).
     ss::future<>
-      complete_compaction_work_on_manager(foreign_log_compaction_meta_ptr);
+      complete_compaction_work_on_manager(foreign_compaction_job_ptr);
 
     // Performs lazy initialization of the `compaction::key_offset_map` using
     // its reserved memory, if it is uninitialized.

--- a/src/v/cloud_topics/level_one/maintenance/worker_manager.cc
+++ b/src/v/cloud_topics/level_one/maintenance/worker_manager.cc
@@ -50,7 +50,7 @@ ss::future<> worker_manager::stop() {
     co_await _workers.stop();
 }
 
-std::optional<foreign_log_compaction_meta_ptr>
+std::optional<foreign_compaction_job_ptr>
 worker_manager::try_acquire_compaction_work(ss::shard_id shard) {
     vassert(
       ss::this_shard_id() == worker_manager_shard,
@@ -63,30 +63,28 @@ worker_manager::try_acquire_compaction_work(ss::shard_id shard) {
         return std::nullopt;
     }
 
-    auto log = _compaction_queue.top();
+    auto job = _compaction_queue.top();
     _compaction_queue.pop();
 
-    if (!log) {
+    if (!job) {
         return std::nullopt;
     }
 
     // An unmanaged CTP is evicted from the queue by
-    // `compaction_scheduler::unmanage_partition`, so a queued entry is always
-    // still linked into the scheduler's managed-log list.
+    // `compaction_scheduler::unmanage_partition`, so a queued job's meta is
+    // always still linked into the scheduler's managed-log list.
     dassert(
-      log->link.is_linked(),
+      job->meta->link.is_linked(),
       "Acquired compaction work for an unmanaged CTP {}",
-      log->ntp);
+      job->meta->ntp);
 
-    dassert(
-      log->compaction.s == log_compaction_state::status::queued,
-      "Expected log state to be queued when acquiring work");
-    log->compaction.s = log_compaction_state::status::inflight;
-    log->compaction.inflight_shard = shard;
-    return ss::make_foreign(log);
+    // Marking the CTP inflight (and skipping inflight CTPs during sampling)
+    // is how a CTP is kept out of the queue while being compacted.
+    job->meta->compaction.inflight_shard = shard;
+    return ss::make_foreign(job);
 }
 
-void worker_manager::complete_compaction_work(log_compaction_meta* log) {
+void worker_manager::complete_compaction_work(compaction_job* job) {
     vassert(
       ss::this_shard_id() == worker_manager_shard,
       "Expected calls to worker_manager::complete_compaction_work() to always "
@@ -95,11 +93,10 @@ void worker_manager::complete_compaction_work(log_compaction_meta* log) {
       worker_manager_shard);
 
     dassert(
-      log->compaction.s == log_compaction_state::status::inflight,
-      "Expected log state to be inflight when completing work");
-    log->compaction.s = log_compaction_state::status::idle;
-    log->compaction.inflight_shard.reset();
-    log->compaction.info_and_ts.reset();
+      job->meta->compaction.inflight_shard.has_value(),
+      "Expected CTP {} to be inflight when completing work",
+      job->meta->ntp);
+    job->meta->compaction.inflight_shard.reset();
 
     _probe.log_compacted();
 }

--- a/src/v/cloud_topics/level_one/maintenance/worker_manager.cc
+++ b/src/v/cloud_topics/level_one/maintenance/worker_manager.cc
@@ -21,7 +21,7 @@
 namespace cloud_topics::l1 {
 
 worker_manager::worker_manager(
-  log_compaction_queue& work_queue,
+  compaction_queue& work_queue,
   ss::sharded<file_io>* io,
   ss::sharded<replicated_metastore>* metastore,
   ss::sharded<cluster::metadata_cache>* metadata_cache,
@@ -70,9 +70,13 @@ worker_manager::try_acquire_compaction_work(ss::shard_id shard) {
         return std::nullopt;
     }
 
-    if (!log->link.is_linked()) {
-        return std::nullopt;
-    }
+    // An unmanaged CTP is evicted from the queue by
+    // `compaction_scheduler::unmanage_partition`, so a queued entry is always
+    // still linked into the scheduler's managed-log list.
+    dassert(
+      log->link.is_linked(),
+      "Acquired compaction work for an unmanaged CTP {}",
+      log->ntp);
 
     dassert(
       log->compaction.s == log_compaction_state::status::queued,

--- a/src/v/cloud_topics/level_one/maintenance/worker_manager.h
+++ b/src/v/cloud_topics/level_one/maintenance/worker_manager.h
@@ -57,14 +57,14 @@ public:
     // be invoked during application shutdown.
     ss::future<> stop();
 
-    // Returns the top entry of `_compaction_queue`, if it is not empty, and
-    // sets inflight state for the provided shard & CTP. Returns `std::nullopt`
+    // Returns the top job of `_compaction_queue`, if it is not empty, and marks
+    // the provided shard as compacting that job's CTP. Returns `std::nullopt`
     // if the `_compaction_queue` is empty.
-    std::optional<foreign_log_compaction_meta_ptr>
+    std::optional<foreign_compaction_job_ptr>
       try_acquire_compaction_work(ss::shard_id);
 
-    // Resets inflight state for the provided CTP.
-    void complete_compaction_work(log_compaction_meta*);
+    // Clears the inflight shard for the completed job's CTP.
+    void complete_compaction_work(compaction_job*);
 
     // If an inflight compaction job for the provided log exists, a signal is
     // sent to the worker shard on which the job is occurring to request an

--- a/src/v/cloud_topics/level_one/maintenance/worker_manager.h
+++ b/src/v/cloud_topics/level_one/maintenance/worker_manager.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cloud_topics/level_one/common/file_io.h"
+#include "cloud_topics/level_one/maintenance/compaction/compaction_queue.h"
 #include "cloud_topics/level_one/maintenance/logger.h"
 #include "cloud_topics/level_one/maintenance/meta.h"
 #include "cloud_topics/level_one/maintenance/scheduler_probe.h"
@@ -40,7 +41,7 @@ public:
     static constexpr ss::shard_id worker_manager_shard = 0;
 
     worker_manager(
-      log_compaction_queue&,
+      compaction_queue&,
       ss::sharded<file_io>*,
       ss::sharded<replicated_metastore>*,
       ss::sharded<cluster::metadata_cache>*,
@@ -93,7 +94,7 @@ private:
     friend class ::SchedulerTestFixture;
 
     // Owned by `scheduler`.
-    log_compaction_queue& _compaction_queue;
+    compaction_queue& _compaction_queue;
 
     // Owned by `app`.
     ss::sharded<file_io>* _io;


### PR DESCRIPTION
A new `compaction_queue` implementation intended to supersede the plain `std::priority_queue` currently being used for scheduling. Built on top of the `keyed_priority_queue` added for use within the `leveling_queue`, but just as easily applied to compaction itself.

The motivating reason for the change here is to be able to de-queue logs efficiently when they are unmanaged (e.g. during leadership transfer).

Before, this would require an entire scan/re-population of the `compaction_queue`, since it was a plain `std::priority_queue`. Now, we can simply look the partition up by `topic_id_partition` and clear it from the list of `_ordered_entries` in the `keyed_partition_queue`.

Finally, we rework an asymmetry that currently exists between the representation of compaction jobs and leveling jobs- previously, a compaction job was represented directly by a `log_compaction_meta_ptr`, whereas a `leveling_job` was represented by a struct that encapsulated a `log_compaction_meta_ptr`. To make things simpler, add a new `compaction_job` struct that is a similar structure to that of the `leveling_job`.  This drastically simplifes the state
representation of `log_compaction_meta` and concurrent gotchas. We get to remove a ton of sanity checking asserts, and drop the `log_compaction_state::status` enum. We can now upsert fresh compaction jobs for a partition in the `compaction_queue` and prevent queuing a partition with an inflight compaction simply by checking `inflight_shard`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
