### PR TITLE
lsm/db: close in-flight compaction builder on any error

### DIFF
--- a/src/v/lsm/db/BUILD
+++ b/src/v/lsm/db/BUILD
@@ -297,6 +297,7 @@ redpanda_cc_library(
         "//src/v/lsm/core:exceptions",
         "//src/v/lsm/core/internal:logger",
         "//src/v/lsm/sst:builder",
+        "//src/v/ssx:future_util",
         "//src/v/ssx:when_all",
     ],
     deps = [

--- a/src/v/lsm/db/compaction_task.cc
+++ b/src/v/lsm/db/compaction_task.cc
@@ -12,6 +12,7 @@
 #include "lsm/core/exceptions.h"
 #include "lsm/core/internal/logger.h"
 #include "lsm/sst/builder.h"
+#include "ssx/future-util.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/as_future.hh>
@@ -233,8 +234,8 @@ ss::future<ss::lw_shared_ptr<version_edit>> do_run_compaction_task(
             }
             co_await input->next();
         }
-    } catch (const base_exception& ex) {
-        state.err = std::make_exception_ptr(ex);
+    } catch (...) {
+        state.err = std::current_exception();
     }
     co_await state.finish();
     auto edit = compaction->edit();
@@ -270,13 +271,22 @@ ss::future<ss::lw_shared_ptr<version_edit>> run_compaction_task(
   ss::lw_shared_ptr<internal::options> opts,
   compaction* compaction,
   ss::abort_source* as) {
+    std::exception_ptr ex;
+    auto level = ss::log_level::error;
     try {
         co_return co_await do_run_compaction_task(
           persistence, snapshots, versions, std::move(opts), compaction, as);
+    } catch (const io_error_exception&) {
+        ex = std::current_exception();
+        level = ss::log_level::warn;
     } catch (...) {
-        vlog(log.warn, "compaction_end error=\"{}\"", std::current_exception());
-        throw;
+        ex = std::current_exception();
+        if (is_abort_exception(ex) || ssx::is_shutdown_exception(ex)) {
+            level = ss::log_level::debug;
+        }
     }
+    vlogl(log, level, "compaction_end error=\"{}\"", ex);
+    std::rethrow_exception(ex);
 }
 
 } // namespace lsm::db

--- a/src/v/lsm/db/tests/BUILD
+++ b/src/v/lsm/db/tests/BUILD
@@ -123,16 +123,13 @@ redpanda_cc_gtest(
         "version_set_test.cc",
     ],
     deps = [
+        ":db_test_base",
         "//src/v/base",
         "//src/v/lsm/core/internal:files",
         "//src/v/lsm/core/internal:keys",
         "//src/v/lsm/core/internal:options",
-        "//src/v/lsm/db:table_cache",
         "//src/v/lsm/db:version_edit",
         "//src/v/lsm/db:version_set",
-        "//src/v/lsm/io:memory_persistence",
-        "//src/v/lsm/sst:block_cache",
-        "//src/v/lsm/sst:builder",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
         "@seastar",
@@ -211,6 +208,28 @@ redpanda_test_cc_library(
     hdrs = ["immutable_tree.h"],
     deps = [
         "//src/v/base",
+        "@seastar",
+    ],
+)
+
+redpanda_test_cc_library(
+    name = "db_test_base",
+    hdrs = ["db_test_base.h"],
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/lsm/core:probe",
+        "//src/v/lsm/core/internal:files",
+        "//src/v/lsm/core/internal:keys",
+        "//src/v/lsm/core/internal:options",
+        "//src/v/lsm/db:table_cache",
+        "//src/v/lsm/db:version_edit",
+        "//src/v/lsm/db:version_set",
+        "//src/v/lsm/io:memory_persistence",
+        "//src/v/lsm/io:persistence",
+        "//src/v/lsm/sst:block_cache",
+        "//src/v/lsm/sst:builder",
+        "@googletest//:gtest",
         "@seastar",
     ],
 )

--- a/src/v/lsm/db/tests/BUILD
+++ b/src/v/lsm/db/tests/BUILD
@@ -137,6 +137,29 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "compaction_task_test",
+    timeout = "short",
+    srcs = [
+        "compaction_task_test.cc",
+    ],
+    deps = [
+        ":db_test_base",
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/lsm/core/internal:files",
+        "//src/v/lsm/core/internal:keys",
+        "//src/v/lsm/core/internal:options",
+        "//src/v/lsm/db:compaction_task",
+        "//src/v/lsm/db:snapshot",
+        "//src/v/lsm/io:memory_persistence",
+        "//src/v/lsm/io:persistence",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "iter_test",
     timeout = "short",
     srcs = [

--- a/src/v/lsm/db/tests/compaction_task_test.cc
+++ b/src/v/lsm/db/tests/compaction_task_test.cc
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "bytes/iobuf.h"
+#include "lsm/core/internal/files.h"
+#include "lsm/core/internal/options.h"
+#include "lsm/db/compaction_task.h"
+#include "lsm/db/snapshot.h"
+#include "lsm/db/tests/db_test_base.h"
+#include "lsm/io/memory_persistence.h"
+#include "lsm/io/persistence.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+#include <seastar/coroutine/generator.hh>
+#include <seastar/util/later.hh>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+using namespace lsm::db;
+
+using lsm::internal::operator""_level;
+using lsm::internal::operator""_file_id;
+using lsm::internal::operator""_key;
+
+namespace {
+
+// Tracks the close/destruction lifecycle of a single output writer handed out
+// by the fault-injecting persistence layer below.
+struct writer_close_tracker {
+    bool appended = false;
+    bool closed = false;
+    bool destroyed_without_close = false;
+};
+
+// A writer that fails its first append with ss::timed_out_error, mimicking a
+// cloud staging file that times out waiting for a cache reservation. Crucially
+// the exception is *not* an lsm::base_exception, so it escapes the compaction
+// loop's catch and exercises the coroutine-unwind cleanup path.
+//
+// On destruction it records whether close() was ever called. In production the
+// equivalent leak aborts via the seastar output_stream "was this stream
+// properly closed?" assertion; here we observe it without crashing the test.
+class timing_out_file_writer final : public lsm::io::sequential_file_writer {
+public:
+    explicit timing_out_file_writer(writer_close_tracker* tracker)
+      : _tracker(tracker) {}
+
+    ~timing_out_file_writer() override {
+        if (!_closed) {
+            _tracker->destroyed_without_close = true;
+        }
+    }
+
+    ss::future<> append(iobuf) override {
+        _tracker->appended = true;
+        return ss::make_exception_future<>(ss::timed_out_error());
+    }
+
+    ss::future<> close() override {
+        _closed = true;
+        _tracker->closed = true;
+        return ss::now();
+    }
+
+    fmt::iterator format_to(fmt::iterator it) const override {
+        return fmt::format_to(it, "{{timing_out_file_writer}}");
+    }
+
+private:
+    bool _closed = false;
+    writer_close_tracker* _tracker;
+};
+
+// Wraps an in-memory data_persistence. Reads, removals, and (when not armed)
+// writes delegate to the inner layer so we can build real input SSTs. Once
+// fail_next_writers() is called, every newly opened writer fails its first
+// append, letting us drive the compaction task into its error-unwind path.
+class fault_injecting_data_persistence final
+  : public lsm::io::data_persistence {
+public:
+    fault_injecting_data_persistence()
+      : _inner(lsm::io::make_memory_data_persistence()) {}
+
+    void fail_next_writers() { _fail_writers = true; }
+    const writer_close_tracker& last_output_writer() const {
+        return _last_output_writer;
+    }
+
+    ss::future<lsm::io::optional_pointer<lsm::io::random_access_file_reader>>
+    open_random_access_reader(lsm::internal::file_handle h) override {
+        return _inner->open_random_access_reader(h);
+    }
+
+    ss::future<std::unique_ptr<lsm::io::sequential_file_writer>>
+    open_sequential_writer(lsm::internal::file_handle h) override {
+        if (_fail_writers) {
+            _last_output_writer = {};
+            co_return std::make_unique<timing_out_file_writer>(
+              &_last_output_writer);
+        }
+        co_return co_await _inner->open_sequential_writer(h);
+    }
+
+    ss::future<> remove_file(lsm::internal::file_handle h) override {
+        return _inner->remove_file(h);
+    }
+
+    ss::coroutine::experimental::generator<lsm::internal::file_handle>
+    list_files() override {
+        auto gen = _inner->list_files();
+        while (auto fh = co_await gen()) {
+            co_yield fh->get();
+        }
+    }
+
+    ss::future<> close() override { return _inner->close(); }
+
+private:
+    std::unique_ptr<lsm::io::data_persistence> _inner;
+    bool _fail_writers = false;
+    writer_close_tracker _last_output_writer;
+};
+
+class CompactionTaskTest : public db_test_base {
+public:
+    CompactionTaskTest()
+      : db_test_base(std::make_unique<fault_injecting_data_persistence>()) {
+        // A single L0 file is enough to trigger compaction, keeping the setup
+        // minimal.
+        _options->level_one_compaction_trigger = 1;
+        // Force the output builder to flush (and thus append to the writer) on
+        // the very first key so the injected failure happens inside the
+        // compaction loop, while compaction_state::builder is still set.
+        _options->sst_block_size = 1;
+        _options->levels = lsm::internal::options::make_levels(
+          {
+            .max_total_bytes = 10000,
+            .max_file_size = 1000,
+          },
+          /*multiplier=*/10,
+          /*max_level=*/6_level);
+    }
+
+    fault_injecting_data_persistence& faults() {
+        return static_cast<fault_injecting_data_persistence&>(
+          *_data_persistence);
+    }
+
+protected:
+    snapshot_list _snapshots;
+};
+
+} // namespace
+
+// Regression test for a compaction lifetime bug: when an output writer fails
+// mid-compaction with a non-lsm exception (e.g. a cloud staging file timing
+// out under cache pressure), the compaction coroutine unwinds. If the in-flight
+// builder is destroyed without first being closed, its staging file/output
+// stream is torn down without close() and aborts the process.
+//
+// The task must instead always close the in-flight output writer before its
+// state is destroyed, and surface the original failure.
+TEST_F(CompactionTaskTest, InFlightOutputWriterClosedWhenAppendFails) {
+    // One L0 file plus an overlapping L1 file produce a non-trivial L0->L1
+    // compaction (a trivial move would never open an output builder).
+    add_sst(
+      {.id = 1_file_id, .level = 0_level, .keys = {"d@1"_key, "e@1"_key}});
+    add_sst(
+      {.id = 10_file_id, .level = 1_level, .keys = {"a@1"_key, "z@1"_key}});
+
+    // Arm the persistence so the compaction's output writer fails on append.
+    faults().fail_next_writers();
+
+    auto maybe_c = version_set().pick_compaction();
+    ASSERT_TRUE(maybe_c);
+    auto& c = *maybe_c;
+    ASSERT_FALSE(c->is_trivial_move());
+
+    ss::abort_source as;
+    // The injected failure must surface as the task's result...
+    EXPECT_THROW(
+      run_compaction_task(
+        &faults(), &_snapshots, &version_set(), _options, c.get(), &as)
+        .get(),
+      ss::timed_out_error);
+
+    // ...and the in-flight output writer must have been closed rather than
+    // leaked during the coroutine unwind.
+    const auto& w = faults().last_output_writer();
+    ASSERT_TRUE(w.appended);
+    EXPECT_TRUE(w.closed);
+    EXPECT_FALSE(w.destroyed_without_close);
+}

--- a/src/v/lsm/db/tests/db_test_base.h
+++ b/src/v/lsm/db/tests/db_test_base.h
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "lsm/core/internal/files.h"
+#include "lsm/core/internal/keys.h"
+#include "lsm/core/internal/options.h"
+#include "lsm/core/probe.h"
+#include "lsm/db/table_cache.h"
+#include "lsm/db/version_edit.h"
+#include "lsm/db/version_set.h"
+#include "lsm/io/memory_persistence.h"
+#include "lsm/io/persistence.h"
+#include "lsm/sst/block_cache.h"
+#include "lsm/sst/builder.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+namespace lsm::db {
+
+using internal::operator""_seqno;
+
+// Describes an SST to materialize via db_test_base::add_sst.
+struct sst_spec {
+    internal::file_id id;
+    internal::level level;
+    std::vector<internal::key> keys;
+};
+
+// Common fixture for tests that need a version_set backed by a table_cache and
+// persistence layer.
+class db_test_base : public testing::Test {
+public:
+    constexpr static size_t default_max_entries = 10;
+
+    explicit db_test_base(
+      std::unique_ptr<io::data_persistence> data_persistence
+      = io::make_memory_data_persistence())
+      : _data_persistence(std::move(data_persistence)) {}
+
+    void TearDown() override {
+        _table_cache.close().get();
+        _data_persistence->close().get();
+        _metadata_persistence->close().get();
+    }
+
+    const internal::options& options() { return *_options; }
+    db::version_set& version_set() { return *_version_set; }
+
+    // Build a real SST from the spec's keys and register it in the version.
+    void add_sst(sst_spec spec) {
+        auto writer
+          = _data_persistence->open_sequential_writer({.id = spec.id}).get();
+        sst::builder builder(std::move(writer), {});
+        std::ranges::sort(spec.keys);
+        for (const auto& key : spec.keys) {
+            builder
+              .add(
+                key,
+                iobuf::from(
+                  fmt::format("value for {} on level {}", key, spec.level)))
+              .get();
+        }
+        builder.finish().get();
+        size_t file_size = builder.file_size();
+        builder.close().get();
+        auto edit = _version_set->new_edit();
+        auto min_seqno = std::ranges::min_element(
+                           spec.keys,
+                           std::less<>(),
+                           [](internal::key_view k) { return k.seqno(); })
+                           ->seqno();
+        auto max_seqno = std::ranges::max_element(
+                           spec.keys,
+                           std::less<>(),
+                           [](internal::key_view k) { return k.seqno(); })
+                           ->seqno();
+        edit->add_file({
+          .level = spec.level,
+          .file_handle = {.id = spec.id},
+          .file_size = file_size,
+          .smallest = spec.keys.front(),
+          .largest = spec.keys.back(),
+          .oldest_seqno = min_seqno,
+          .newest_seqno = max_seqno,
+        });
+        edit->set_last_seqno(max_seqno);
+        _version_set->log_and_apply(std::move(edit)).get();
+    }
+
+    // Add a file to the version using only metadata (no actual SST file).
+    void add_file(
+      internal::level level,
+      internal::file_id id,
+      internal::key smallest,
+      internal::key largest,
+      uint64_t file_size = 100) {
+        auto edit = _version_set->new_edit();
+        edit->add_file({
+          .level = level,
+          .file_handle = {.id = id},
+          .file_size = file_size,
+          .smallest = smallest,
+          .largest = largest,
+          .oldest_seqno = 0_seqno,
+          .newest_seqno = 0_seqno,
+        });
+        edit->set_last_seqno(0_seqno);
+        _version_set->log_and_apply(std::move(edit)).get();
+    }
+
+protected:
+    ss::lw_shared_ptr<internal::options> _options
+      = ss::make_lw_shared<internal::options>();
+    std::unique_ptr<io::data_persistence> _data_persistence;
+    std::unique_ptr<io::metadata_persistence> _metadata_persistence
+      = io::make_memory_metadata_persistence();
+    table_cache _table_cache{
+      _data_persistence.get(),
+      default_max_entries,
+      ss::make_lw_shared<probe>(),
+      ss::make_lw_shared<sst::block_cache>(1_MiB, ss::make_lw_shared<probe>())};
+    ss::lw_shared_ptr<db::version_set> _version_set
+      = ss::make_lw_shared<db::version_set>(
+        _metadata_persistence.get(), &_table_cache, _options);
+};
+
+} // namespace lsm::db

--- a/src/v/lsm/db/tests/version_set_test.cc
+++ b/src/v/lsm/db/tests/version_set_test.cc
@@ -7,18 +7,16 @@
 // Modifications copyright 2025 Redpanda Data, Inc.
 
 #include "lsm/core/internal/files.h"
+#include "lsm/core/internal/keys.h"
 #include "lsm/core/internal/options.h"
-#include "lsm/db/table_cache.h"
+#include "lsm/db/tests/db_test_base.h"
 #include "lsm/db/version_edit.h"
 #include "lsm/db/version_set.h"
-#include "lsm/io/memory_persistence.h"
-#include "lsm/sst/block_cache.h"
-#include "lsm/sst/builder.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <algorithm>
+#include <vector>
 
 namespace {
 
@@ -31,12 +29,6 @@ using testing::ElementsAre;
 using testing::IsEmpty;
 using testing::UnorderedElementsAre;
 
-struct sst_spec {
-    lsm::internal::file_id id;
-    lsm::internal::level level;
-    std::vector<lsm::internal::key> keys;
-};
-
 MATCHER_P2(IsLookupValue, key, level, "is a value") {
     auto expected = iobuf::from(
       fmt::format("value for {} on level {}", key, level));
@@ -46,88 +38,19 @@ MATCHER_P2(IsLookupValue, key, level, "is a value") {
 MATCHER(IsMissing, "is missing") { return arg.is_missing(); }
 MATCHER(IsTombstone, "is a tombstone") { return arg.is_tombstone(); }
 
-class VersionSetTest : public testing::Test {
+class VersionSetTest : public lsm::db::db_test_base {
 public:
-    constexpr static size_t default_max_entries = 10;
-    void TearDown() override {
-        _table_cache.close().get();
-        _data_persistence->close().get();
-        _metadata_persistence->close().get();
-    }
-
-    const lsm::internal::options& options() { return *_options; }
-    lsm::db::version_set& version_set() { return *_version_set; }
-
     void recover() {
         _version_set = nullptr;
         _version_set = ss::make_lw_shared<lsm::db::version_set>(
           _metadata_persistence.get(), &_table_cache, _options);
         _version_set->recover().get();
     }
-
-    void add_sst(sst_spec spec) {
-        auto writer
-          = _data_persistence->open_sequential_writer({.id = spec.id}).get();
-        lsm::sst::builder builder(std::move(writer), {});
-        std::ranges::sort(spec.keys);
-        for (const auto& key : spec.keys) {
-            builder
-              .add(
-                key,
-                iobuf::from(
-                  fmt::format("value for {} on level {}", key, spec.level)))
-              .get();
-        }
-        builder.finish().get();
-        size_t file_size = builder.file_size();
-        builder.close().get();
-        auto edit = _version_set->new_edit();
-        auto min_seqno = std::ranges::min_element(
-                           spec.keys,
-                           std::less<>(),
-                           [](lsm::internal::key_view k) { return k.seqno(); })
-                           ->seqno();
-        auto max_seqno = std::ranges::max_element(
-                           spec.keys,
-                           std::less<>(),
-                           [](lsm::internal::key_view k) { return k.seqno(); })
-                           ->seqno();
-        edit->add_file({
-          .level = spec.level,
-          .file_handle = {.id = spec.id},
-          .file_size = file_size,
-          .smallest = spec.keys.front(),
-          .largest = spec.keys.back(),
-          .oldest_seqno = min_seqno,
-          .newest_seqno = max_seqno,
-        });
-        edit->set_last_seqno(max_seqno);
-        _version_set->log_and_apply(std::move(edit)).get();
-    }
-
-private:
-    ss::lw_shared_ptr<lsm::internal::options> _options
-      = ss::make_lw_shared<lsm::internal::options>();
-    std::unique_ptr<lsm::io::data_persistence> _data_persistence
-      = lsm::io::make_memory_data_persistence();
-    std::unique_ptr<lsm::io::metadata_persistence> _metadata_persistence
-      = lsm::io::make_memory_metadata_persistence();
-    lsm::db::table_cache _table_cache{
-      _data_persistence.get(),
-      default_max_entries,
-      ss::make_lw_shared<lsm::probe>(),
-      ss::make_lw_shared<lsm::sst::block_cache>(
-        1_MiB, ss::make_lw_shared<lsm::probe>())};
-    ss::lw_shared_ptr<lsm::db::version_set> _version_set
-      = ss::make_lw_shared<lsm::db::version_set>(
-        _metadata_persistence.get(), &_table_cache, _options);
 };
 
 // Fixture for compaction tests that only uses file metadata.
-class CompactionTest : public testing::Test {
+class CompactionTest : public lsm::db::db_test_base {
 public:
-    constexpr static size_t default_max_entries = 10;
-
     CompactionTest() {
         // Use small sizes that are easier to reason about
         _options->level_one_compaction_trigger = 4;
@@ -140,36 +63,6 @@ public:
           },
           /*multiplier=*/10,
           /*max_level=*/6_level);
-    }
-
-    void TearDown() override {
-        _table_cache.close().get();
-        _data_persistence->close().get();
-        _metadata_persistence->close().get();
-    }
-
-    const lsm::internal::options& options() { return *_options; }
-    lsm::db::version_set& version_set() { return *_version_set; }
-
-    // Add a file to the version using only metadata (no actual SST file).
-    void add_file(
-      lsm::internal::level level,
-      lsm::internal::file_id id,
-      lsm::internal::key smallest,
-      lsm::internal::key largest,
-      uint64_t file_size = 100) {
-        auto edit = _version_set->new_edit();
-        edit->add_file({
-          .level = level,
-          .file_handle = {.id = id},
-          .file_size = file_size,
-          .smallest = smallest,
-          .largest = largest,
-          .oldest_seqno = 0_seqno,
-          .newest_seqno = 0_seqno,
-        });
-        edit->set_last_seqno(0_seqno);
-        _version_set->log_and_apply(std::move(edit)).get();
     }
 
     // Extract file IDs from compaction inputs at the specified level.
@@ -193,23 +86,6 @@ public:
     output_file_ids(const lsm::db::compaction& c) {
         return input_file_ids(c, lsm::db::compaction::output_level);
     }
-
-private:
-    ss::lw_shared_ptr<lsm::internal::options> _options
-      = ss::make_lw_shared<lsm::internal::options>();
-    std::unique_ptr<lsm::io::data_persistence> _data_persistence
-      = lsm::io::make_memory_data_persistence();
-    std::unique_ptr<lsm::io::metadata_persistence> _metadata_persistence
-      = lsm::io::make_memory_metadata_persistence();
-    lsm::db::table_cache _table_cache{
-      _data_persistence.get(),
-      default_max_entries,
-      ss::make_lw_shared<lsm::probe>(),
-      ss::make_lw_shared<lsm::sst::block_cache>(
-        1_MiB, ss::make_lw_shared<lsm::probe>())};
-    ss::lw_shared_ptr<lsm::db::version_set> _version_set
-      = ss::make_lw_shared<lsm::db::version_set>(
-        _metadata_persistence.get(), &_table_cache, _options);
 };
 
 } // namespace

--- a/src/v/lsm/io/cloud_cache_persistence.cc
+++ b/src/v/lsm/io/cloud_cache_persistence.cc
@@ -158,7 +158,8 @@ public:
           _staging.append(std::move(b), deadline));
         if (fut.failed()) {
             _failed = true;
-            std::rethrow_exception(fut.get_exception());
+            throw_as_lsm_ex(
+              fut.get_exception(), "failed to append to staging file");
         }
     }
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
First commit is a test refactor.

Second commit:

    do_run_compaction_task only caught base_exception around its main loop.
    The drain-and-close logic lives in state.finish(), which runs after that
    catch. So any non-lsm exception escaped the catch, skipped finish(), and
    let compaction_state be destroyed with state.builder still set,
    resulting in a crash.

    For example, under cloud-cache pressure a staging file's append() times
    out and throws ss::timed_out_error, and crashes.

    Catch all exceptions and route them through finish(). finish() already
    handles a pre-set err correctly: it moves the in-flight builder into the
    closes vector (whose closing_builder kicks off close()), drains the
    close futures, and re-surfaces the original error. So the only change
    needed is widening the catch; no new cleanup machinery.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Bug Fixes

* Fixes a crash that could occur in the Cloud Topics metastore upon certain errors from during metastore database compaction.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
