### PR TITLE
rptest: serialize openssl invocations to fix concurrent signing race

### DIFF
--- a/tests/rptest/services/tls.py
+++ b/tests/rptest/services/tls.py
@@ -4,6 +4,7 @@ import random
 import string
 import subprocess
 import tempfile
+import threading
 import typing
 from enum import Enum, IntEnum
 from typing import NamedTuple
@@ -350,6 +351,7 @@ class TLSCertManager:
         # In order to attempt to cover more code paths, we will randomly select
         # between RSA and ECDSA if the key type is not specified
         self._key_type: TLSKeyType = key_type or random.choice(list(TLSKeyType))
+        self._exec_lock = threading.Lock()
         self._ca = self._create_ca()
         self.certs: dict[str, Certificate] = {}
 
@@ -368,9 +370,16 @@ class TLSCertManager:
         output = None
         while True:
             try:
-                output = subprocess.check_output(
-                    cmd.split(), cwd=self._dir.name, stderr=subprocess.STDOUT
-                )
+                # openssl ca is not safe to run concurrently against a shared
+                # CA database (index.txt / serial.txt). create_cert is called
+                # across nodes concurrently via for_nodes' thread pool sharing
+                # one manager, so serialize the openssl process itself: a single
+                # invocation is atomic w.r.t. the DB, so only the exec needs the
+                # lock, not the surrounding retry/logging.
+                with self._exec_lock:
+                    output = subprocess.check_output(
+                        cmd.split(), cwd=self._dir.name, stderr=subprocess.STDOUT
+                    )
                 self._logger.debug(f"openssl output: {output}")
                 return output.decode("utf-8")
             except subprocess.CalledProcessError as e:
@@ -554,6 +563,7 @@ class TLSChainCACertManager(TLSCertManager):
         # In order to attempt to cover more code paths, we will randomly select
         # between RSA and ECDSA if the key type is not specified
         self._key_type: TLSKeyType = key_type or random.choice(list(TLSKeyType))
+        self._exec_lock = threading.Lock()
         self._cas: list[CertificateAuthority] = []
         self._cas.append(
             self._create_ca(


### PR DESCRIPTION
## What

Add a per-instance `threading.Lock` to `TLSCertManager` (and its subclass `TLSChainCACertManager`) and acquire it inside `_exec`, so only one `openssl` process runs per cert manager at a time.

## Why

`rpk_start_test.py::test_rpc_tls_start` (and other tests) call `for_nodes(self.redpanda.nodes, setup_cluster)`, where `for_nodes` runs the callback across all nodes **concurrently** via a `ThreadPoolExecutor`. Each thread calls `create_cert` on the **same shared `TLSCertManager`**, which runs `openssl ca` against the **one** CA directory — the same `index.txt` (database) and `serial.txt`.

`openssl ca` is **not safe to run concurrently** on a shared database. Parallel invocations race on reading/incrementing `serial.txt` and appending to `index.txt`, leaving the DB inconsistent, so `openssl ca` exits non-zero. There was no lock anywhere in `tls.py`. The `_exec` retry loop (3×) can't recover once `index.txt` is corrupted, so it fails all retries.

### Why now

The race was always present but silently swallowed. It only became visible after commit `88f0b8b53c` ("test: fix silent ignore of openssl failure"), which stopped the retry loop from swallowing openssl failures. The `tls.py:_exec` failure group starts right after. The profile matches a race exactly: intermittent, every architecture (amd64+arm64), every environment (vm/docker/byoc), ~weekly cadence.

## Why lock in `_exec`

- One place, trivially correct: "serialize all openssl for this manager."
- `TLSChainCACertManager(TLSCertManager)` inherits `_exec` and has the same race at its own `openssl ca` sites — a base-class `_exec` lock fixes both classes with a single change.
- The only shared mutable state is the CA dir; per-cert key/CSR/crt files are uniquely named. Serializing CPU-bound key generation too is negligible (per-manager, typically 3-5 nodes).
- No recursion in `_exec`, so a plain `Lock` is deadlock-free.

`TLSChainCACertManager.__init__` does **not** chain to `super().__init__()` (it reimplements the body), so the lock is initialized in both constructors.

## Scope

This targets only the TLS/openssl failure family filed under [DEVPROD-1907](https://redpandadata.atlassian.net/browse/DEVPROD-1907). The `tsh ssh` / `kubectl exec` cloud-infra failures grouped under the same umbrella ticket (they share the generic `subprocess.py:run` signature) are unrelated and tracked separately.

## Backports Required

- [x] none - not a (product) bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEVPROD-1907]: https://redpandadata.atlassian.net/browse/DEVPROD-1907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
