### PR TITLE
security/oidc: support authenticated (HTTP Basic) forward proxies

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -203,6 +203,14 @@ ss::future<> controller::wire_up() {
                 return config::shard_local_cfg().oidc_http_proxy_url.bind();
             }),
             ss::sharded_parameter([] {
+                return config::shard_local_cfg()
+                  .oidc_http_proxy_username.bind();
+            }),
+            ss::sharded_parameter([] {
+                return config::shard_local_cfg()
+                  .oidc_http_proxy_password.bind();
+            }),
+            ss::sharded_parameter([] {
                 return config::shard_local_cfg().oidc_token_audience.bind();
             }),
             ss::sharded_parameter([] {

--- a/src/v/config/BUILD
+++ b/src/v/config/BUILD
@@ -76,6 +76,7 @@ redpanda_cc_library(
         "//src/v/utils:unresolved_address",
         "@abseil-cpp//absl/container:flat_hash_set",
         "@abseil-cpp//absl/container:node_hash_set",
+        "@abseil-cpp//absl/strings",
         "@boost//:algorithm",
         "@boost//:filesystem",
         "@boost//:lexical_cast",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -9,6 +9,7 @@
 
 #include "config/configuration.h"
 
+#include "absl/strings/ascii.h"
 #include "base/units.h"
 #include "cluster/scheduling/topic_memory_per_partition_default.h"
 #include "config/base_property.h"
@@ -28,6 +29,7 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/core/thread.hh>
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <optional>
@@ -3976,6 +3978,45 @@ configuration::configuration()
           auto res = security::oidc::parse_url(*v);
           if (res.has_error()) {
               return res.error().message();
+          }
+          return std::nullopt;
+      })
+  , oidc_http_proxy_username(
+      *this,
+      "oidc_http_proxy_username",
+      "Username for HTTP Basic authentication to the OIDC forward proxy "
+      "(oidc_http_proxy_url). Leave unset for an unauthenticated proxy. "
+      "Both username and password must be set for credentials to be sent.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt,
+      [](const auto& v) -> std::optional<ss::sstring> {
+          if (!v.has_value()) {
+              return std::nullopt;
+          }
+          if (v->find(':') != ss::sstring::npos) {
+              return "must not contain ':' (RFC 7617)";
+          }
+          if (std::ranges::any_of(*v, absl::ascii_iscntrl)) {
+              return "must not contain control characters";
+          }
+          return std::nullopt;
+      })
+  , oidc_http_proxy_password(
+      *this,
+      "oidc_http_proxy_password",
+      "Password for HTTP Basic authentication to the OIDC forward proxy "
+      "(oidc_http_proxy_url). Leave unset for an unauthenticated proxy. "
+      "Both username and password must be set for credentials to be sent.",
+      {.needs_restart = needs_restart::no,
+       .visibility = visibility::user,
+       .secret = is_secret::yes},
+      std::nullopt,
+      [](const auto& v) -> std::optional<ss::sstring> {
+          if (!v.has_value()) {
+              return std::nullopt;
+          }
+          if (std::ranges::any_of(*v, absl::ascii_iscntrl)) {
+              return "must not contain control characters";
           }
           return std::nullopt;
       })

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -692,6 +692,8 @@ struct configuration final : public config_store {
     // oidc authentication
     property<ss::sstring> oidc_discovery_url;
     property<std::optional<ss::sstring>> oidc_http_proxy_url;
+    property<std::optional<ss::sstring>> oidc_http_proxy_username;
+    property<std::optional<ss::sstring>> oidc_http_proxy_password;
     property<ss::sstring> oidc_token_audience;
     property<std::chrono::seconds> oidc_clock_skew_tolerance;
     property<ss::sstring> oidc_principal_mapping;

--- a/src/v/config/tests/configuration_test.cc
+++ b/src/v/config/tests/configuration_test.cc
@@ -41,4 +41,40 @@ TEST(ConfigurationTest, Roundtrip) {
     }
 }
 
+TEST(oidc_http_proxy_credentials, password_is_secret) {
+    auto& cfg = config::shard_local_cfg();
+    EXPECT_TRUE(cfg.oidc_http_proxy_password.is_secret());
+    EXPECT_FALSE(cfg.oidc_http_proxy_username.is_secret());
+}
+
+TEST(oidc_http_proxy_credentials, username_rejects_colon_and_control) {
+    auto& cfg = config::shard_local_cfg();
+    EXPECT_EQ(
+      cfg.oidc_http_proxy_username.validate(std::optional<ss::sstring>{}),
+      std::nullopt);
+    EXPECT_EQ(
+      cfg.oidc_http_proxy_username.validate(std::optional<ss::sstring>{"svc"}),
+      std::nullopt);
+    EXPECT_TRUE(cfg.oidc_http_proxy_username
+                  .validate(std::optional<ss::sstring>{"has:colon"})
+                  .has_value());
+    EXPECT_TRUE(cfg.oidc_http_proxy_username
+                  .validate(std::optional<ss::sstring>{"has\nnewline"})
+                  .has_value());
+}
+
+TEST(oidc_http_proxy_credentials, password_allows_colon_rejects_control) {
+    auto& cfg = config::shard_local_cfg();
+    EXPECT_EQ(
+      cfg.oidc_http_proxy_password.validate(std::optional<ss::sstring>{}),
+      std::nullopt);
+    EXPECT_EQ(
+      cfg.oidc_http_proxy_password.validate(
+        std::optional<ss::sstring>{"p@ss:word/ok"}),
+      std::nullopt);
+    EXPECT_TRUE(cfg.oidc_http_proxy_password
+                  .validate(std::optional<ss::sstring>{"bad\rcr"})
+                  .has_value());
+}
+
 }; // namespace config

--- a/src/v/net/BUILD
+++ b/src/v/net/BUILD
@@ -79,6 +79,7 @@ redpanda_cc_library(
         "@abseil-cpp//absl/container:flat_hash_map",
         "@abseil-cpp//absl/container:node_hash_map",
         "@abseil-cpp//absl/hash",
+        "@abseil-cpp//absl/strings",
         "@boost//:intrusive",
         "@boost//:lexical_cast",
         "@fmt",

--- a/src/v/net/tests/connect_authority_test.cc
+++ b/src/v/net/tests/connect_authority_test.cc
@@ -36,3 +36,35 @@ TEST(format_connect_authority, already_bracketed_ipv6_left_alone) {
     EXPECT_EQ(
       net::detail::format_connect_authority("[::1]", 8443), "[::1]:8443");
 }
+
+TEST(format_connect_request, no_authorization) {
+    auto req = net::detail::format_connect_request(
+      "example.com:443", std::nullopt);
+    EXPECT_EQ(
+      req,
+      "CONNECT example.com:443 HTTP/1.1\r\n"
+      "Host: example.com:443\r\n"
+      "\r\n");
+}
+
+TEST(format_connect_request, with_authorization) {
+    auto req = net::detail::format_connect_request(
+      "example.com:443", ss::sstring{"Basic YWxhZGRpbjpvcGVuc2VzYW1l"});
+    EXPECT_EQ(
+      req,
+      "CONNECT example.com:443 HTTP/1.1\r\n"
+      "Host: example.com:443\r\n"
+      "Proxy-Authorization: Basic YWxhZGRpbjpvcGVuc2VzYW1l\r\n"
+      "\r\n");
+}
+
+TEST(format_connect_request, rejects_control_chars_in_authorization) {
+    EXPECT_THROW(
+      net::detail::format_connect_request(
+        "example.com:443", ss::sstring{"Basic abc\r\nX-Injected: 1"}),
+      std::invalid_argument);
+    EXPECT_THROW(
+      net::detail::format_connect_request(
+        "example.com:443", ss::sstring{"Basic ab\tc"}),
+      std::invalid_argument);
+}

--- a/src/v/net/transport.cc
+++ b/src/v/net/transport.cc
@@ -1,5 +1,6 @@
 #include "net/transport.h"
 
+#include "absl/strings/ascii.h"
 #include "base/compiler_utils.h"
 #include "base/vassert.h"
 #include "base/vlog.h"
@@ -9,6 +10,7 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/core/with_timeout.hh>
 
+#include <algorithm>
 #include <string_view>
 #include <system_error>
 
@@ -61,17 +63,14 @@ ss::future<> send_connect_and_read_response(
   ss::input_stream<char>& in,
   const net::unresolved_address& origin,
   const net::unresolved_address& proxy,
+  const std::optional<ss::sstring>& authorization,
   seastar::logger* log) {
     // IPv6 literals must be bracketed in request authority
     // (RFC 9112 §3.2 / RFC 3986 §3.2.2); see format_connect_authority.
     auto authority = net::detail::format_connect_authority(
       origin.host(), origin.port());
-    auto request = fmt::format(
-      "CONNECT {} HTTP/1.1\r\n"
-      "Host: {}\r\n"
-      "\r\n",
-      authority,
-      authority);
+    auto request = net::detail::format_connect_request(
+      authority, authorization);
 
     vlog(
       log->trace, "Sending CONNECT to proxy {} for origin {}", proxy, origin);
@@ -129,6 +128,24 @@ std::string format_connect_authority(std::string_view host, uint16_t port) {
                                  host.starts_with('[') && host.ends_with(']'));
     return is_unbracketed_ipv6 ? fmt::format("[{}]:{}", host, port)
                                : fmt::format("{}:{}", host, port);
+}
+
+std::string format_connect_request(
+  std::string_view authority, const std::optional<ss::sstring>& authorization) {
+    auto request = fmt::format(
+      "CONNECT {} HTTP/1.1\r\n"
+      "Host: {}\r\n",
+      authority,
+      authority);
+    if (authorization.has_value()) {
+        if (std::ranges::any_of(*authorization, absl::ascii_iscntrl)) {
+            throw std::invalid_argument(
+              "Proxy-Authorization value must not contain control characters");
+        }
+        request += fmt::format("Proxy-Authorization: {}\r\n", *authorization);
+    }
+    request += "\r\n";
+    return request;
 }
 
 ss::future<connect_response_parser::result_t>
@@ -232,7 +249,12 @@ ss::future<> base_transport::do_connect(clock_type::time_point timeout) {
             _proxy_out.emplace(fd.output());
             auto proxy_in = fd.input();
             co_await send_connect_and_read_response(
-              *_proxy_out, proxy_in, server_address(), _proxy->address, _log);
+              *_proxy_out,
+              proxy_in,
+              server_address(),
+              _proxy->address,
+              _proxy->authorization,
+              _log);
         }
 
         if (_creds) {

--- a/src/v/net/transport.h
+++ b/src/v/net/transport.h
@@ -80,6 +80,11 @@ public:
             /// to the origin TLS handshake inside the CONNECT tunnel.
             /// SNI for the TLS handshake is derived from address.host().
             ss::shared_ptr<ss::tls::certificate_credentials> credentials;
+            /// Opaque Proxy-Authorization header value (e.g.
+            /// "Basic <base64>") sent on the CONNECT request. The
+            /// transport emits it verbatim and does not interpret it.
+            /// std::nullopt means no Proxy-Authorization header is sent.
+            std::optional<ss::sstring> authorization;
         };
 
         unresolved_address server_addr;
@@ -190,6 +195,12 @@ namespace detail {
 /// §3.2.2. Hosts already bracketed (e.g. `[::1]`) are left alone; a
 /// colon in an unbracketed host is treated as an IPv6 literal marker.
 std::string format_connect_authority(std::string_view host, uint16_t port);
+
+/// Builds the CONNECT request line + headers for `authority`
+/// (host:port). When `authorization` is set, includes a
+/// Proxy-Authorization header. Terminated with the blank line.
+std::string format_connect_request(
+  std::string_view authority, const std::optional<ss::sstring>& authorization);
 
 /// Consumes an HTTP CONNECT response in a single pass, capturing the
 /// status line and discarding header values. Bounds per-line length

--- a/src/v/security/BUILD
+++ b/src/v/security/BUILD
@@ -19,7 +19,9 @@ redpanda_cc_library(
         "oidc_url_parser.h",
     ],
     implementation_deps = [
+        "//src/v/bytes",
         "//src/v/strings:string_switch",
+        "//src/v/utils:base64",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/v/security/config_rcl.cc
+++ b/src/v/security/config_rcl.cc
@@ -8,6 +8,7 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 
+#include "bytes/bytes.h"
 #include "re2/re2.h"
 #include "security/config.h"
 #include "security/gssapi_rule.h"
@@ -17,6 +18,7 @@
 #include "security/oidc_url_parser.h"
 #include "ssx/sformat.h"
 #include "strings/string_switch.h"
+#include "utils/base64.h"
 
 #include <ada.h>
 #include <charconv>
@@ -165,6 +167,13 @@ result<parsed_url> parse_url(std::string_view url_view) {
       "{}{}{}", url->get_pathname(), url->get_search(), url->get_hash());
 
     return result;
+}
+
+ss::sstring make_basic_proxy_authorization(
+  std::string_view username, std::string_view password) {
+    auto creds = ssx::sformat("{}:{}", username, password);
+    auto encoded = bytes_to_base64(bytes::from_string(creds));
+    return ssx::sformat("Basic {}", encoded);
 }
 
 static constexpr std::string_view mapping_rule_pattern

--- a/src/v/security/oidc_service.cc
+++ b/src/v/security/oidc_service.cc
@@ -77,9 +77,14 @@ template<typename... Args>
 /// For https:// proxies, attaches the caller-supplied TLS credentials
 /// (the OIDC service's system-trust creds, shared with the origin
 /// handshake) and sets SNI to the proxy hostname.
+/// When both `username` and `password` are non-empty, sets an HTTP Basic
+/// `Proxy-Authorization` header on the returned config (for both http://
+/// and https:// proxies).
 result<net::base_transport::configuration::proxy_config> parse_proxy_url(
   std::string_view url_str,
-  ss::shared_ptr<ss::tls::certificate_credentials> system_creds) {
+  ss::shared_ptr<ss::tls::certificate_credentials> system_creds,
+  std::string_view username,
+  std::string_view password) {
     auto parsed = parse_url(url_str);
     if (parsed.has_error()) {
         return errc::metadata_invalid;
@@ -91,6 +96,9 @@ result<net::base_transport::configuration::proxy_config> parse_proxy_url(
         cfg.credentials = std::move(system_creds);
     } else if (url.scheme != "http") {
         return errc::metadata_invalid;
+    }
+    if (!username.empty() && !password.empty()) {
+        cfg.authorization = make_basic_proxy_authorization(username, password);
     }
     return cfg;
 }
@@ -192,6 +200,8 @@ struct service::impl {
       config::binding<std::vector<ss::sstring>> http_authentication,
       config::binding<ss::sstring> discovery_url,
       config::binding<std::optional<ss::sstring>> http_proxy_url,
+      config::binding<std::optional<ss::sstring>> http_proxy_username,
+      config::binding<std::optional<ss::sstring>> http_proxy_password,
       config::binding<ss::sstring> token_audience,
       config::binding<std::chrono::seconds> clock_skew_tolerance,
       config::binding<ss::sstring> mapping,
@@ -204,6 +214,8 @@ struct service::impl {
       , _http_authentication{std::move(http_authentication)}
       , _discovery_url{std::move(discovery_url)}
       , _http_proxy_url{std::move(http_proxy_url)}
+      , _http_proxy_username{std::move(http_proxy_username)}
+      , _http_proxy_password{std::move(http_proxy_password)}
       , _token_audience{std::move(token_audience)}
       , _clock_skew_tolerance{std::move(clock_skew_tolerance)}
       , _mapping{std::move(mapping)}
@@ -227,6 +239,15 @@ struct service::impl {
             ssx::spawn_with_gate(_gate, [this] { return update(); });
         });
         _http_proxy_url.watch([this]() {
+            check_proxy_config_warnings();
+            ssx::spawn_with_gate(_gate, [this] { return update(); });
+        });
+        _http_proxy_username.watch([this]() {
+            check_proxy_config_warnings();
+            ssx::spawn_with_gate(_gate, [this] { return update(); });
+        });
+        _http_proxy_password.watch([this]() {
+            check_proxy_config_warnings();
             ssx::spawn_with_gate(_gate, [this] { return update(); });
         });
         _mapping.watch([this]() { update_rule(); });
@@ -234,6 +255,7 @@ struct service::impl {
         _group_claim_path.watch([this]() { update_group_claim_policy(); });
         _nested_group_behavior.watch([this]() { update_group_claim_policy(); });
         update_group_claim_policy();
+        check_proxy_config_warnings();
         _jwks_refresh_interval.watch([this]() {
             if (_gate.is_closed()) {
                 return;
@@ -395,6 +417,33 @@ struct service::impl {
         arm_duration = _jwks_refresh_interval();
     }
 
+    void check_proxy_config_warnings() {
+        const auto& url = _http_proxy_url();
+        bool has_user = _http_proxy_username().has_value()
+                        && !_http_proxy_username()->empty();
+        bool has_pass = _http_proxy_password().has_value()
+                        && !_http_proxy_password()->empty();
+        if (has_user != has_pass) {
+            vlog(
+              seclog.warn,
+              "oidc_http_proxy: only one of username/password is set; Basic "
+              "proxy authentication is disabled until both are set");
+        } else if (has_user && has_pass && !url.has_value()) {
+            vlog(
+              seclog.warn,
+              "oidc_http_proxy: credentials are set but oidc_http_proxy_url is "
+              "empty; the credentials are ignored");
+        } else if (has_user && has_pass && url.has_value()) {
+            auto parsed = security::oidc::parse_url(*url);
+            if (!parsed.has_error() && parsed.assume_value().scheme == "http") {
+                vlog(
+                  seclog.warn,
+                  "oidc_http_proxy: credentials are sent unencrypted over a "
+                  "plaintext http:// proxy; prefer an https:// proxy");
+            }
+        }
+    }
+
     void update_rule() {
         if (auto r = parse_principal_mapping_rule(_mapping()); r.has_error()) {
             vlog(seclog.error, "Rule failed to parse: {}", _mapping());
@@ -424,6 +473,8 @@ struct service::impl {
         // watcher across coroutine suspension points. A local copy keeps
         // the scheme check and the error detail consistent.
         auto proxy_url = _http_proxy_url();
+        auto proxy_username = _http_proxy_username().value_or("");
+        auto proxy_password = _http_proxy_password().value_or("");
         auto is_https = url.scheme == "https";
 
         // Reject plaintext origins through the proxy; see the
@@ -473,10 +524,11 @@ struct service::impl {
         if (proxy_url.has_value()) {
             // _creds is always initialized here: we've already rejected
             // proxy + plaintext origin above, and the is_https branch
-            // built _creds. parse_proxy_url only consumes the creds for
-            // https:// proxy URLs; http:// proxies leave credentials
-            // null on the resulting proxy_config.
-            auto parsed = parse_proxy_url(*proxy_url, _creds);
+            // built _creds. parse_proxy_url sets TLS credentials only for
+            // https:// proxy URLs; the Basic auth authorization header is
+            // set for both schemes when username+password are non-empty.
+            auto parsed = parse_proxy_url(
+              *proxy_url, _creds, proxy_username, proxy_password);
             if (parsed.has_error()) {
                 co_await return_exception(
                   parsed.assume_error(),
@@ -532,6 +584,8 @@ struct service::impl {
     config::binding<std::vector<ss::sstring>> _http_authentication;
     config::binding<ss::sstring> _discovery_url;
     config::binding<std::optional<ss::sstring>> _http_proxy_url;
+    config::binding<std::optional<ss::sstring>> _http_proxy_username;
+    config::binding<std::optional<ss::sstring>> _http_proxy_password;
     config::binding<ss::sstring> _token_audience;
     config::binding<std::chrono::seconds> _clock_skew_tolerance;
     config::binding<ss::sstring> _mapping;
@@ -555,6 +609,8 @@ service::service(
   config::binding<std::vector<ss::sstring>> http_authentication,
   config::binding<ss::sstring> discovery_url,
   config::binding<std::optional<ss::sstring>> http_proxy_url,
+  config::binding<std::optional<ss::sstring>> http_proxy_username,
+  config::binding<std::optional<ss::sstring>> http_proxy_password,
   config::binding<ss::sstring> token_audience,
   config::binding<std::chrono::seconds> clock_skew_tolerance,
   config::binding<ss::sstring> mapping,
@@ -567,6 +623,8 @@ service::service(
       std::move(http_authentication),
       std::move(discovery_url),
       std::move(http_proxy_url),
+      std::move(http_proxy_username),
+      std::move(http_proxy_password),
       std::move(token_audience),
       std::move(clock_skew_tolerance),
       std::move(mapping),

--- a/src/v/security/oidc_service.h
+++ b/src/v/security/oidc_service.h
@@ -31,6 +31,8 @@ public:
       config::binding<std::vector<ss::sstring>> http_authentication,
       config::binding<ss::sstring> discovery_url,
       config::binding<std::optional<ss::sstring>> http_proxy_url,
+      config::binding<std::optional<ss::sstring>> http_proxy_username,
+      config::binding<std::optional<ss::sstring>> http_proxy_password,
       config::binding<ss::sstring> token_audience,
       config::binding<std::chrono::seconds> clock_skew_tolerance,
       config::binding<ss::sstring> mapping,

--- a/src/v/security/oidc_url_parser.h
+++ b/src/v/security/oidc_url_parser.h
@@ -30,4 +30,10 @@ struct parsed_url {
 };
 result<parsed_url> parse_url(std::string_view);
 
+/// Builds an HTTP Basic Proxy-Authorization header value:
+/// "Basic " + base64(username + ":" + password). Caller must ensure
+/// username contains no ':' (RFC 7617); validated at config-commit.
+ss::sstring make_basic_proxy_authorization(
+  std::string_view username, std::string_view password);
+
 } // namespace security::oidc

--- a/src/v/security/tests/url_test.cc
+++ b/src/v/security/tests/url_test.cc
@@ -68,3 +68,11 @@ BOOST_DATA_TEST_CASE(test_parse_url, bdata::make(url_data), d) {
         BOOST_REQUIRE_EQUAL(res.assume_error(), d.url.assume_error());
     }
 }
+
+BOOST_AUTO_TEST_CASE(make_basic_proxy_authorization_rfc7617_example) {
+    // RFC 7617 canonical example: base64("aladdin:opensesame")
+    // == "YWxhZGRpbjpvcGVuc2VzYW1l".
+    BOOST_REQUIRE_EQUAL(
+      security::oidc::make_basic_proxy_authorization("aladdin", "opensesame"),
+      "Basic YWxhZGRpbjpvcGVuc2VzYW1l");
+}

--- a/tests/rptest/services/mitmproxy.py
+++ b/tests/rptest/services/mitmproxy.py
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import shlex
+
 from ducktape.services.service import Service
 from ducktape.utils.util import wait_until
 
@@ -43,6 +45,7 @@ class MitmproxyService(Service):
     def __init__(self, context):
         super().__init__(context, num_nodes=1)
         self._server_cert = None
+        self._proxy_auth = None
 
     @property
     def node(self):
@@ -54,6 +57,13 @@ class MitmproxyService(Service):
         certificate). Must be called before start().
         """
         self._server_cert = cert
+
+    def set_proxy_auth(self, username: str, password: str) -> None:
+        """Require HTTP Basic proxy authentication. Must be called
+        before start(). Clients must send Proxy-Authorization: Basic
+        base64(user:pass) on the CONNECT request or get a 407.
+        """
+        self._proxy_auth = f"{username}:{password}"
 
     def proxy_url(self) -> str:
         scheme = "https" if self._server_cert is not None else "http"
@@ -73,6 +83,9 @@ class MitmproxyService(Service):
                 allow_fail=False,
             )
             extra_args = f"--certs '*={CERT_PEM_PATH}' "
+
+        if self._proxy_auth is not None:
+            extra_args += f"--set {shlex.quote('proxyauth=' + self._proxy_auth)} "
 
         # PYTHONUNBUFFERED + stdbuf -oL: mitmdump writes progress to
         # stdout, and Python's default block-buffering means the file

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -59,6 +59,7 @@ SECRET_CONFIG_NAMES = frozenset(
         "iceberg_rest_catalog_client_secret",
         "iceberg_rest_catalog_token",
         "iceberg_rest_catalog_aws_secret_key",
+        "oidc_http_proxy_password",
     ]
 )
 

--- a/tests/rptest/tests/redpanda_oauth_proxy_test.py
+++ b/tests/rptest/tests/redpanda_oauth_proxy_test.py
@@ -24,6 +24,9 @@ from rptest.tests.redpanda_oauth_test import (
 )
 from rptest.util import firewall_blocked
 
+PROXY_USER = "proxyuser"
+PROXY_PASS = "proxypass"
+
 # Emitted whenever an OIDC discovery / JWKS refresh fails to reach the
 # IdP (blocked egress, unreachable proxy, rejected CONNECT, ...). Several
 # tests deliberately provoke a failed refresh and must whitelist these.
@@ -350,3 +353,110 @@ class OIDCProxyRejectedAtConfigCommitTest(RedpandaOIDCTestBase):
                 )
             },
         )
+
+
+class OIDCAuthenticatedProxyTestBase(OIDCViaProxyTestBase):
+    """Base for authenticated-proxy variants where the broker is
+    configured with matching credentials.
+
+    Subclasses test different proxy-listener configurations (http://
+    vs https://) while sharing the broker-credential setup. The
+    negative test (OIDCAuthenticatedProxyMissingCredsTest) must NOT
+    inherit this class because it deliberately omits broker credentials.
+    """
+
+    def _prepare_mitmproxy(self):
+        # super() handles the https:// listener cert (if any) based on
+        # the injected proxy_scheme; this layer adds Basic proxy auth.
+        super()._prepare_mitmproxy()
+        self.mitmproxy.set_proxy_auth(PROXY_USER, PROXY_PASS)
+
+    def setUp(self):
+        super().setUp()
+        self.redpanda.add_extra_rp_conf(
+            {
+                "oidc_http_proxy_username": PROXY_USER,
+                "oidc_http_proxy_password": PROXY_PASS,
+            }
+        )
+
+
+class OIDCViaAuthenticatedProxyTest(OIDCAuthenticatedProxyTestBase):
+    """Forward proxy that requires HTTP Basic auth. Redpanda must send
+    Proxy-Authorization built from oidc_http_proxy_username/password for
+    the CONNECT to succeed.
+
+    proxy_scheme=https additionally wraps the proxy connection in TLS:
+    Redpanda TLS-handshakes with mitmproxy's listener, then sends the
+    authenticated CONNECT inside that tunnel, exercising the
+    authenticated-proxy path end-to-end over a TLS-wrapped connection.
+    """
+
+    @cluster(num_nodes=5)
+    @matrix(proxy_scheme=["http", "https"])
+    def test_oidc_discovery_via_authenticated_proxy(self, proxy_scheme):
+        self._run_oidc_discovery_via_proxy()
+
+
+class OIDCAuthenticatedProxyMissingCredsTest(OIDCViaProxyTestBase):
+    """Inherits OIDCViaProxyTestBase (not OIDCAuthenticatedProxyTestBase)
+    precisely so the broker starts with no oidc_http_proxy_username/
+    password, letting the test observe the 407 failure state.
+    """
+
+    def _prepare_mitmproxy(self):
+        # super() handles the https:// listener cert (if any); add proxy
+        # auth without configuring matching broker credentials.
+        super()._prepare_mitmproxy()
+        self.mitmproxy.set_proxy_auth(PROXY_USER, PROXY_PASS)
+
+    @cluster(num_nodes=5, log_allow_list=OIDC_REFRESH_ERROR_LOGS)
+    @matrix(proxy_scheme=["http", "https"])
+    def test_proxy_creds_live_reload(self, proxy_scheme):
+        with firewall_blocked(self.redpanda.nodes, KC_HTTPS_PORT):
+            self._start_broker()
+            cfg = self._setup_oauth_principal_and_topic()
+
+            # Confirm we are in the failed state first: the proxy rejects
+            # the unauthenticated CONNECT, so OIDC cannot complete until
+            # credentials are supplied.
+            wait_until(
+                lambda: self.redpanda.search_log_any(
+                    "407 Proxy Authentication Required"
+                ),
+                timeout_sec=30,
+                backoff_sec=1,
+                err_msg=(
+                    "expected the proxy to reject the unauthenticated CONNECT "
+                    "with 407 before credentials are PATCHed in"
+                ),
+            )
+
+            # Live-reload both credentials. The username/password watch
+            # hookups must spawn a fresh update() so the next discovery +
+            # JWKS refresh sends Proxy-Authorization and succeeds; without
+            # that binding the new credentials would only take effect on
+            # broker restart.
+            admin = Admin(self.redpanda)
+            result = admin.patch_cluster_config(
+                upsert={
+                    "oidc_http_proxy_username": PROXY_USER,
+                    "oidc_http_proxy_password": PROXY_PASS,
+                }
+            )
+            wait_for_version_sync(admin, self.redpanda, result["config_version"])
+
+            producer = self._make_oauth_producer(cfg)
+            self._wait_for_oauth_auth(
+                producer,
+                err_msg=(
+                    "OAUTHBEARER auth did not succeed after PATCHing "
+                    "oidc_http_proxy_username/password; the watch() hookup "
+                    "likely failed to re-trigger the discovery + JWKS fetch "
+                    "with the new proxy credentials."
+                ),
+            )
+
+            # Confirms the post-PATCH OIDC fetch actually reached Keycloak
+            # through the now-authenticated proxy.
+            self.mitmproxy.assert_proxied_host(self._keycloak_host)

--- a/tests/rptest/tests/redpanda_oauth_proxy_test.py
+++ b/tests/rptest/tests/redpanda_oauth_proxy_test.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
 from requests.exceptions import HTTPError
 
@@ -22,6 +23,14 @@ from rptest.tests.redpanda_oauth_test import (
     RedpandaOIDCTestBase,
 )
 from rptest.util import firewall_blocked
+
+# Emitted whenever an OIDC discovery / JWKS refresh fails to reach the
+# IdP (blocked egress, unreachable proxy, rejected CONNECT, ...). Several
+# tests deliberately provoke a failed refresh and must whitelist these.
+OIDC_REFRESH_ERROR_LOGS = [
+    "Error updating metadata",
+    "Error updating jwks",
+]
 
 
 class OIDCViaProxyTestBase(RedpandaOIDCTestBase):
@@ -41,9 +50,34 @@ class OIDCViaProxyTestBase(RedpandaOIDCTestBase):
         super().__init__(test_context, use_ssl=True, **kwargs)
         self.mitmproxy = MitmproxyService(test_context)
 
+    def _proxy_scheme(self) -> str:
+        # Driven by @matrix(proxy_scheme=...) on the test method; read
+        # here rather than as a method arg because the scheme has to be
+        # known in setUp, before the test body runs. Defaults to http
+        # for unparametrized subclasses (e.g. live-reload).
+        return (self.test_context.injected_args or {}).get("proxy_scheme", "http")
+
+    def _enable_tls_listener(self) -> None:
+        # mitmproxy's regular-mode listener autodetects plaintext HTTP
+        # vs TLS and presents this cert, so Redpanda connects via
+        # https:// before issuing CONNECT (the "HTTPS proxy" scheme).
+        # The cert is signed by the same TLSCertManager CA already
+        # installed into each broker's system trust by
+        # RedpandaOIDCTestBase when use_ssl=True (always passed by this
+        # base), so Redpanda's OIDC system-trust credentials validate it.
+        assert self.tls is not None
+        hostname = self.mitmproxy.node.account.hostname
+        cert = self.tls.create_cert(
+            hostname, common_name=hostname, name="mitmproxy-server"
+        )
+        self.mitmproxy.set_server_cert(cert)
+
     def _prepare_mitmproxy(self):
-        """Hook for subclasses to enable a TLS listener before start."""
-        pass
+        # Enable the TLS listener for the https:// proxy variant; the
+        # plaintext variant needs no listener setup. proxy_url() then
+        # reports the matching scheme.
+        if self._proxy_scheme() == "https":
+            self._enable_tls_listener()
 
     def setUp(self):
         # Skips super().setUp(): broker start is deferred to
@@ -128,40 +162,18 @@ class OIDCViaProxyTestBase(RedpandaOIDCTestBase):
 
 
 class OIDCViaProxyTest(OIDCViaProxyTestBase):
-    """Plaintext http:// proxy variant: mitmproxy's listener is
-    unwrapped, Redpanda TCP-connects directly and issues CONNECT.
+    """OIDC discovery routed through an unauthenticated forward proxy.
+
+    proxy_scheme=http  - mitmproxy's listener is unwrapped; Redpanda
+        TCP-connects directly and issues CONNECT.
+    proxy_scheme=https - nested TLS; Redpanda TLS-handshakes with
+        mitmproxy's listener, sends CONNECT through the wrapped socket,
+        then TLS-handshakes with Keycloak inside the tunnel.
     """
 
     @cluster(num_nodes=5)
-    def test_oidc_discovery_via_http_proxy(self):
-        self._run_oidc_discovery_via_proxy()
-
-
-class OIDCViaHttpsProxyTest(OIDCViaProxyTestBase):
-    """TLS https:// proxy variant (nested TLS): Redpanda
-    TLS-handshakes with mitmproxy's listener, sends CONNECT through
-    the wrapped socket, then TLS-handshakes with Keycloak inside the
-    tunnel.
-
-    mitmproxy's regular-mode listener autodetects plaintext HTTP vs
-    TLS and presents the cert configured via --certs. That cert is
-    signed by the same TLSCertManager CA already installed into each
-    broker's system trust by RedpandaOIDCTestBase when use_ssl=True,
-    so Redpanda's OIDC system-trust credentials validate it.
-    """
-
-    def _prepare_mitmproxy(self):
-        # self.tls is populated by RedpandaOIDCTestBase when use_ssl=True,
-        # which the parent class always passes.
-        assert self.tls is not None
-        hostname = self.mitmproxy.node.account.hostname
-        cert = self.tls.create_cert(
-            hostname, common_name=hostname, name="mitmproxy-server"
-        )
-        self.mitmproxy.set_server_cert(cert)
-
-    @cluster(num_nodes=5)
-    def test_oidc_discovery_via_http_proxy(self):
+    @matrix(proxy_scheme=["http", "https"])
+    def test_oidc_discovery_via_proxy(self, proxy_scheme):
         self._run_oidc_discovery_via_proxy()
 
 
@@ -174,14 +186,9 @@ class OIDCProxyLiveReloadTest(OIDCViaProxyTestBase):
 
     SET_PROXY_URL_AT_STARTUP = False
 
-    # Pre-PATCH discovery + JWKS fetches error out because direct
-    # egress is blocked and no proxy is configured yet.
-    EXPECTED_ERROR_LOGS = [
-        "Error updating metadata",
-        "Error updating jwks",
-    ]
-
-    @cluster(num_nodes=5, log_allow_list=EXPECTED_ERROR_LOGS)
+    # Pre-PATCH discovery + JWKS fetches error out because direct egress
+    # is blocked and no proxy is configured yet.
+    @cluster(num_nodes=5, log_allow_list=OIDC_REFRESH_ERROR_LOGS)
     def test_proxy_url_live_reload(self):
         with firewall_blocked(self.redpanda.nodes, KC_HTTPS_PORT):
             self._start_broker()
@@ -282,14 +289,6 @@ class OIDCProxyRejectedAtConfigCommitTest(RedpandaOIDCTestBase):
     triggers the check.
     """
 
-    # Unreachable proxy URL → OIDC refresh logs ERROR. Not the
-    # behaviour under test; whitelist rather than contrive a
-    # reachable dummy proxy.
-    EXPECTED_ERROR_LOGS = [
-        "Error updating metadata",
-        "Error updating jwks",
-    ]
-
     def __init__(self, test_context, **kwargs):
         # use_ssl=False so the discovery URL starts as http://.
         super().__init__(test_context, use_ssl=False, **kwargs)
@@ -320,7 +319,9 @@ class OIDCProxyRejectedAtConfigCommitTest(RedpandaOIDCTestBase):
             admin, upsert={"oidc_http_proxy_url": "http://proxy.example:8888"}
         )
 
-    @cluster(num_nodes=4, log_allow_list=EXPECTED_ERROR_LOGS)
+    # Unreachable proxy URL → OIDC refresh logs ERROR. Not the behaviour
+    # under test; whitelist rather than contrive a reachable dummy proxy.
+    @cluster(num_nodes=4, log_allow_list=OIDC_REFRESH_ERROR_LOGS)
     def test_rejects_reverting_discovery_to_http_while_proxy_set(self):
         # Direction 2: reach a valid (proxy set, https discovery) state
         # via admin PATCH, then try to revert discovery to http.


### PR DESCRIPTION
Adds HTTP Basic authentication to the OIDC forward proxy. `oidc_http_proxy_url`
(v26.1.7, #30268) only supported anonymous proxies, so deployments whose only
egress to the IdP is an authenticated corporate proxy could not use OIDC: the
discovery/JWKS CONNECT was rejected with HTTP 407.

Two new live-reloadable cluster configs, `oidc_http_proxy_username` and
`oidc_http_proxy_password` (password secret/redacted), make the OIDC service send
`Proxy-Authorization: Basic base64(user:pass)` on the CONNECT when both are set,
for both `http://` and `https://` proxies. Over an `http://` proxy the credentials
are sent unencrypted (a warning is logged).

Fixes https://redpandadata.atlassian.net/browse/CORE-16439

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Features

* New live-reloadable cluster configs `oidc_http_proxy_username` /
  `oidc_http_proxy_password` add HTTP Basic authentication to the OIDC forward
  proxy (`oidc_http_proxy_url`); set both to authenticate, leave unset for an
  anonymous proxy. The password is secret.
