### PR TITLE
produce microbench: Tweaks to make it more realistic

### DIFF
--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -1077,6 +1077,7 @@ redpanda_cc_bench(
         "//src/v/cluster:self_test",
         "//src/v/cluster:topic_metrics_watcher",
         "//src/v/container:chunked_vector",
+        "//src/v/kafka/protocol",
         "//src/v/kafka/protocol/schemata:produce_request",
         "//src/v/kafka/server",
         "//src/v/model",

--- a/src/v/kafka/server/tests/produce_partition_bench.cc
+++ b/src/v/kafka/server/tests/produce_partition_bench.cc
@@ -10,6 +10,7 @@
  */
 #include "container/chunked_vector.h"
 #include "kafka/protocol/schemata/produce_request.h"
+#include "kafka/protocol/wire.h"
 #include "kafka/server/handlers/produce.h"
 #include "model/fundamental.h"
 #include "random/generators.h"
@@ -79,11 +80,25 @@ produce_partition_fixture::run_test(size_t data_size, measured_region region) {
 
     auto batch = std::move(builder).build();
 
+    // Reproduce the iobuf fragment layout of a real produce request: serialize
+    // the batch to the kafka wire format and decode it through the batch
+    // adapter, exactly as the produce request decode path does. The records
+    // then live in a contiguous slice of the request buffer (as they do in
+    // production) rather than in the per-record fragments that
+    // record_batch_builder produces.
+    iobuf wire;
+    kafka::protocol::encoder writer(wire);
+    kafka::protocol::writer_serialize_batch(writer, std::move(batch));
+    auto records = kafka::produce_request_record_data(
+      std::make_optional(wire.copy()), kafka::produce_handler::max_supported);
+    vassert(
+      records.adapter.valid_crc, "batch must round-trip with a valid crc");
+
     chunked_vector<kafka::produce_request::partition> partitions;
     partitions.push_back(
       kafka::produce_request::partition{
         .partition_index{model::partition_id(0)},
-        .records = kafka::produce_request_record_data(std::move(batch))});
+        .records = std::move(records)});
 
     chunked_vector<kafka::produce_request::topic> topics;
     topics.push_back(

--- a/src/v/kafka/server/tests/produce_partition_bench.cc
+++ b/src/v/kafka/server/tests/produce_partition_bench.cc
@@ -73,7 +73,7 @@ produce_partition_fixture::run_test(size_t data_size, measured_region region) {
     storage::record_batch_builder builder(
       model::record_batch_type::raft_data, model::offset{0});
 
-    constexpr size_t num_records = 100;
+    constexpr size_t num_records = 1;
     for (size_t i = 0; i < num_records; ++i) {
         builder.add_raw_kv(iobuf{}, rand_iobuf(data_size));
     }


### PR DESCRIPTION
Two tweaks to make the produce microbench more realistic:

 - Better reproduce iobuf layout
 - Drop per batch record count to put focus on the whole pipeline overhead instead of memcopying.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

