### PR TITLE
`compaction`: swap `std::count()` for cursor approach and add benchmarks

### DIFF
--- a/src/v/cloud_topics/level_one/maintenance/compaction/tests/BUILD
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/tests/BUILD
@@ -1,4 +1,28 @@
-load("//bazel:test.bzl", "redpanda_cc_gtest", "redpanda_test_cc_library")
+load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_gtest", "redpanda_test_cc_library")
+
+redpanda_cc_bench(
+    name = "filter_rpbench",
+    timeout = "moderate",
+    srcs = [
+        "filter_bench.cc",
+    ],
+    deps = [
+        "//src/v/bytes",
+        "//src/v/cloud_topics/level_one/maintenance/compaction:compaction_filter",
+        "//src/v/cloud_topics/level_one/metastore:offset_interval_set",
+        "//src/v/compaction:key",
+        "//src/v/compaction:key_offset_map",
+        "//src/v/compaction/tests:simple_reducer",
+        "//src/v/container:chunked_circular_buffer",
+        "//src/v/model",
+        "//src/v/model:batch_compression",
+        "//src/v/random:generators",
+        "//src/v/reflection:adl",
+        "//src/v/storage:record_batch_builder",
+        "@seastar",
+        "@seastar//:benchmark",
+    ],
+)
 
 redpanda_cc_gtest(
     name = "compaction_queue_test",

--- a/src/v/cloud_topics/level_one/maintenance/compaction/tests/filter_bench.cc
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/tests/filter_bench.cc
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "bytes/bytes.h"
+#include "cloud_topics/level_one/maintenance/compaction/compaction_filter.h"
+#include "cloud_topics/level_one/metastore/offset_interval_set.h"
+#include "compaction/key.h"
+#include "compaction/key_offset_map.h"
+#include "compaction/tests/simple_reducer.h"
+#include "container/chunked_circular_buffer.h"
+#include "model/batch_compression.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "random/generators.h"
+#include "reflection/adl.h"
+#include "storage/record_batch_builder.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/testing/perf_tests.hh>
+
+#include <cstddef>
+#include <map>
+#include <optional>
+
+namespace cloud_topics::l1 {
+
+namespace {
+
+const auto test_ntp = model::ntp(
+  model::ns("kafka"), model::topic("tapioca"), model::partition_id(0));
+
+// A semi-compressible payload: a short random block repeated to `size`, so that
+// (de)compression performs realistic work rather than operating on either
+// trivially-compressible zeros or wholly-incompressible noise.
+iobuf gen_value(size_t size) {
+    const auto block = random_generators::gen_alphanum_string(64);
+    iobuf buf;
+    size_t remaining = size;
+    while (remaining > 0) {
+        const auto step = std::min(remaining, block.size());
+        buf.append(block.data(), step);
+        remaining -= step;
+    }
+    return buf;
+}
+
+// How records in the generated batch are made eligible for removal, exercising
+// the two distinct removal mechanisms of the cloud-topics (L1) filter.
+enum class removal_mode : uint8_t {
+    // No records removed: a compressed batch is reused verbatim (the path added
+    // in 57e62ea1a7). Records are unique, non-tombstone, and nothing is in the
+    // removable tombstone set.
+    none,
+    // A fraction of records share a key indexed at a higher offset and are
+    // dropped by key de-duplication, forcing a rebuild + re-compression.
+    key_dedup,
+    // A fraction of records are tombstones whose offsets fall in the removable
+    // tombstone range, forcing a rebuild + re-compression. This path is unique
+    // to cloud topics.
+    tombstone,
+    // Every record is a tombstone but the removable set is empty (e.g.
+    // delete.retention.ms has not yet elapsed). Nothing is removed; measures
+    // the cost of the per-record removability probe when it cannot fire.
+    tombstone_empty_set,
+    // Every record is a tombstone and the removable set is non-empty but
+    // disjoint from the batch's offset span. Nothing is removed; measures the
+    // cost of the per-record probe when a batch-level overlap test could have
+    // skipped it.
+    tombstone_no_overlap,
+};
+
+// A removable set of `n_intervals` singleton intervals, all disjoint from (and
+// above) a batch span of `batch_records`. Built once per size and cached: the
+// large sets are expensive to construct and must not be rebuilt per bench
+// iteration. Single-threaded bench, so a plain static is fine.
+const offset_interval_set&
+cached_disjoint_set(int n_intervals, int batch_records) {
+    static std::map<int, offset_interval_set> cache;
+    auto it = cache.find(n_intervals);
+    if (it == cache.end()) {
+        offset_interval_set s;
+        for (int i = 0; i < n_intervals; ++i) {
+            // Stride by 2 with singleton intervals so they don't coalesce.
+            const auto base = kafka::offset(batch_records + 10 + (i * 2));
+            s.insert(base, base);
+        }
+        it = cache.emplace(n_intervals, std::move(s)).first;
+    }
+    return it->second;
+}
+
+} // namespace
+
+// Exercises `cloud_topics::l1::compaction_filter` over a single batch. The
+// `mode`/`removal_frac` parameters select which removal mechanism (if any) is
+// triggered; `none` is the optimization-under-test path.
+class l1_compaction_filter_bench {
+public:
+    ss::future<size_t> bench(
+      model::compression codec,
+      int n_records,
+      size_t value_size,
+      removal_mode mode,
+      double removal_frac,
+      int n_removable_intervals = 0) {
+        const int n_removed = static_cast<int>(n_records * removal_frac);
+        const bool all_tombstones = mode == removal_mode::tombstone_empty_set
+                                    || mode
+                                         == removal_mode::tombstone_no_overlap;
+
+        // Build and (optionally) compress the input batch outside the timed
+        // region; we only want to measure the filter pass.
+        storage::record_batch_builder builder(
+          model::record_batch_type::raft_data, model::offset(0));
+        for (int i = 0; i < n_records; ++i) {
+            // Tombstone records carry a null value.
+            const bool tombstone
+              = all_tombstones
+                || (mode == removal_mode::tombstone && i < n_removed);
+            std::optional<iobuf> value = tombstone ? std::nullopt
+                                                   : std::optional<iobuf>(
+                                                       gen_value(value_size));
+            builder.add_raw_kv(reflection::to_iobuf(i), std::move(value));
+        }
+        auto batch = std::move(builder).build();
+        if (codec != model::compression::none) {
+            batch = model::compress_batch_sync(codec, std::move(batch));
+        }
+        const auto input_bytes = batch.size_bytes();
+
+        // Key de-duplication: index the first `n_removed` keys at an offset
+        // strictly higher than any record so the filter drops them.
+        compaction::simple_key_offset_map map{};
+        if (mode == removal_mode::key_dedup) {
+            for (int i = 0; i < n_removed; ++i) {
+                auto key = compaction::compaction_key{
+                  iobuf_to_bytes(reflection::to_iobuf(i))};
+                co_await map.put(key, model::offset(n_records));
+            }
+        }
+
+        // Tombstone removal: mark the first `n_removed` offsets as removable.
+        // For the no-overlap sweep, reference a cached set of the requested
+        // size that is disjoint from the batch span.
+        offset_interval_set local_removable;
+        const offset_interval_set* removable = &local_removable;
+        if (mode == removal_mode::tombstone && n_removed > 0) {
+            local_removable.insert(
+              kafka::offset(0), kafka::offset(n_removed - 1));
+        } else if (mode == removal_mode::tombstone_no_overlap) {
+            removable = &cached_disjoint_set(n_removable_intervals, n_records);
+        }
+
+        chunked_circular_buffer<model::record_batch> output;
+        compaction::simple_sink sink(output);
+        compaction_filter filter(sink, map, test_ntp, *removable);
+
+        perf_tests::start_measuring_time();
+        co_await filter(std::move(batch));
+        perf_tests::stop_measuring_time();
+
+        perf_tests::do_not_optimize(output);
+        co_return input_bytes;
+    }
+};
+
+namespace {
+
+constexpr int default_records = 100;
+constexpr size_t default_value = 512;
+
+} // namespace
+
+// Optimization path: nothing removed, compressed payload reused verbatim.
+
+PERF_TEST_CN(l1_compaction_filter_bench, zstd_unchanged) {
+    return bench(
+      model::compression::zstd,
+      default_records,
+      default_value,
+      removal_mode::none,
+      0.0);
+}
+
+PERF_TEST_CN(l1_compaction_filter_bench, lz4_unchanged) {
+    return bench(
+      model::compression::lz4,
+      default_records,
+      default_value,
+      removal_mode::none,
+      0.0);
+}
+
+// Control: key de-duplication forces rebuild + re-compression.
+
+PERF_TEST_CN(l1_compaction_filter_bench, zstd_keys_deduped) {
+    return bench(
+      model::compression::zstd,
+      default_records,
+      default_value,
+      removal_mode::key_dedup,
+      0.5);
+}
+
+// Cloud-specific: tombstone-range removal forces rebuild + re-compression.
+
+PERF_TEST_CN(l1_compaction_filter_bench, zstd_tombstones_removed) {
+    return bench(
+      model::compression::zstd,
+      default_records,
+      default_value,
+      removal_mode::tombstone,
+      0.5);
+}
+
+// Nothing removed, but every record is a tombstone, so the per-record
+// removability probe runs for each one. These two are the cases the empty-set
+// guard and the batch-level overlap pre-check target: both should collapse to
+// the `zstd_unchanged` cost (all kept -> compressed batch reused verbatim).
+
+PERF_TEST_CN(l1_compaction_filter_bench, zstd_tombstones_empty_set) {
+    return bench(
+      model::compression::zstd,
+      default_records,
+      default_value,
+      removal_mode::tombstone_empty_set,
+      0.0);
+}
+
+// No-overlap sweep over removable-set size. Without the guard, every record
+// pays a btree lookup against this set; as the set grows past cache, that
+// lookup becomes memory-bound. With the guard it is a single per-batch
+// overlap() call regardless of set size. The gap widens with set size.
+
+PERF_TEST_CN(l1_compaction_filter_bench, zstd_no_overlap_1k) {
+    return bench(
+      model::compression::zstd,
+      default_records,
+      default_value,
+      removal_mode::tombstone_no_overlap,
+      0.0,
+      1'024);
+}
+
+PERF_TEST_CN(l1_compaction_filter_bench, zstd_no_overlap_256k) {
+    return bench(
+      model::compression::zstd,
+      default_records,
+      default_value,
+      removal_mode::tombstone_no_overlap,
+      0.0,
+      262'144);
+}
+
+PERF_TEST_CN(l1_compaction_filter_bench, zstd_no_overlap_8m) {
+    return bench(
+      model::compression::zstd,
+      default_records,
+      default_value,
+      removal_mode::tombstone_no_overlap,
+      0.0,
+      8'388'608);
+}
+
+} // namespace cloud_topics::l1

--- a/src/v/compaction/BUILD
+++ b/src/v/compaction/BUILD
@@ -108,6 +108,7 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         ":utils",
+        "//src/v/base",
         "//src/v/model:batch_compression",
     ],
     visibility = ["//visibility:public"],

--- a/src/v/compaction/filter.cc
+++ b/src/v/compaction/filter.cc
@@ -9,12 +9,15 @@
 
 #include "filter.h"
 
+#include "base/vassert.h"
 #include "compaction/utils.h"
 #include "container/chunked_vector.h"
 #include "model/batch_compression.h"
 #include "model/record.h"
 
 #include <seastar/core/coroutine.hh>
+
+#include <algorithm>
 
 namespace compaction {
 
@@ -65,17 +68,22 @@ ss::future<std::optional<filter::filtered_batch>> filter::do_filter_batch(
     int32_t rec_count = 0;
     std::optional<int64_t> first_timestamp_delta;
     int64_t last_timestamp_delta;
+    // We expect and enforce that offset_deltas is sorted.
+    dassert(
+      std::ranges::is_sorted(offset_deltas),
+      "offset_deltas must be ascending in record-iteration order");
+    size_t keep_idx = 0;
     co_await b.for_each_record_async([&rec_count,
                                       &first_timestamp_delta,
                                       &last_timestamp_delta,
                                       &ret,
+                                      &keep_idx,
                                       &offset_deltas](model::record record) {
         // contains the key
         if (
-          std::count(
-            offset_deltas.begin(),
-            offset_deltas.end(),
-            record.offset_delta())) {
+          keep_idx < offset_deltas.size()
+          && offset_deltas[keep_idx] == record.offset_delta()) {
+            ++keep_idx;
             /*
              * TODO when we further optimize lazy record materialization ot
              * make use of views we can avoid this re-encoding by copying or

--- a/src/v/compaction/tests/BUILD
+++ b/src/v/compaction/tests/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:test.bzl", "redpanda_cc_gtest", "redpanda_test_cc_library")
+load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_gtest", "redpanda_test_cc_library")
 
 redpanda_test_cc_library(
     name = "simple_reducer",
@@ -30,6 +30,27 @@ redpanda_cc_gtest(
         "//src/v/compaction:key_offset_map",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
+    ],
+)
+
+redpanda_cc_bench(
+    name = "filter_rpbench",
+    srcs = [
+        "filter_bench.cc",
+    ],
+    deps = [
+        ":simple_reducer",
+        "//src/v/bytes",
+        "//src/v/compaction:key",
+        "//src/v/compaction:key_offset_map",
+        "//src/v/container:chunked_circular_buffer",
+        "//src/v/model",
+        "//src/v/model:batch_compression",
+        "//src/v/random:generators",
+        "//src/v/reflection:adl",
+        "//src/v/storage:record_batch_builder",
+        "@seastar",
+        "@seastar//:benchmark",
     ],
 )
 

--- a/src/v/compaction/tests/filter_bench.cc
+++ b/src/v/compaction/tests/filter_bench.cc
@@ -1,0 +1,153 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "bytes/bytes.h"
+#include "compaction/key.h"
+#include "compaction/key_offset_map.h"
+#include "compaction/tests/simple_reducer.h"
+#include "container/chunked_circular_buffer.h"
+#include "model/batch_compression.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "random/generators.h"
+#include "reflection/adl.h"
+#include "storage/record_batch_builder.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/testing/perf_tests.hh>
+
+#include <cstddef>
+
+namespace {
+
+const auto test_ntp = model::ntp(
+  model::ns("kafka"), model::topic("tapioca"), model::partition_id(0));
+
+// A semi-compressible payload: a short random block repeated to `size` so that
+// (de)compression performs realistic work rather than operating on either
+// trivially-compressible zeros or wholly-incompressible noise.
+iobuf gen_value(size_t size) {
+    const auto block = random_generators::gen_alphanum_string(64);
+    iobuf buf;
+    size_t remaining = size;
+    while (remaining > 0) {
+        const auto step = std::min(remaining, block.size());
+        buf.append(block.data(), step);
+        remaining -= step;
+    }
+    return buf;
+}
+
+// Exercises `compaction::filter` over a single batch. The `removal_frac`
+// parameter controls the optimization under test: when it is 0.0 nothing is
+// filtered out, so a compressed source batch is reused verbatim (the path added
+// in 57e62ea1a7). Any value > 0.0 forces the batch to be rebuilt and
+// re-compressed, serving as the control.
+class compaction_filter_bench {
+public:
+    ss::future<size_t> bench(
+      model::compression codec,
+      int n_records,
+      size_t value_size,
+      double removal_frac) {
+        // Build and (optionally) compress the input batch outside the timed
+        // region; we only want to measure the filter pass.
+        storage::record_batch_builder builder(
+          model::record_batch_type::raft_data, model::offset(0));
+        for (int i = 0; i < n_records; ++i) {
+            builder.add_raw_kv(reflection::to_iobuf(i), gen_value(value_size));
+        }
+        auto batch = std::move(builder).build();
+        if (codec != model::compression::none) {
+            batch = model::compress_batch_sync(codec, std::move(batch));
+        }
+        const auto input_bytes = batch.size_bytes();
+
+        // Index the keys of the records we want removed at an offset strictly
+        // higher than any record in the batch, so the filter drops them. The
+        // remaining keys are left unindexed and are therefore kept. With
+        // `removal_frac == 0.0` the map is empty and the batch passes through
+        // unchanged.
+        compaction::simple_key_offset_map map{};
+        const int n_removed = static_cast<int>(n_records * removal_frac);
+        for (int i = 0; i < n_removed; ++i) {
+            auto key = compaction::compaction_key{
+              iobuf_to_bytes(reflection::to_iobuf(i))};
+            co_await map.put(key, model::offset(n_records));
+        }
+
+        chunked_circular_buffer<model::record_batch> output;
+        compaction::simple_sink sink(output);
+        compaction::simple_map_filter filter(sink, map, test_ntp);
+
+        perf_tests::start_measuring_time();
+        co_await filter(std::move(batch));
+        perf_tests::stop_measuring_time();
+
+        perf_tests::do_not_optimize(output);
+        co_return input_bytes;
+    }
+};
+
+constexpr int default_records = 100;
+constexpr size_t small_value = 512;
+constexpr size_t large_value = 4096;
+// Small values so the per-record rebuild work (not payload size) dominates,
+// exposing the rebuild loop's record-vs-kept-set matching cost.
+constexpr size_t tiny_value = 32;
+
+} // namespace
+
+// --- zstd ---------------------------------------------------------------
+
+PERF_TEST_CN(compaction_filter_bench, zstd_unchanged) {
+    return bench(model::compression::zstd, default_records, small_value, 0.0);
+}
+
+PERF_TEST_CN(compaction_filter_bench, zstd_half_removed) {
+    return bench(model::compression::zstd, default_records, small_value, 0.5);
+}
+
+PERF_TEST_CN(compaction_filter_bench, zstd_unchanged_large) {
+    return bench(model::compression::zstd, default_records, large_value, 0.0);
+}
+
+PERF_TEST_CN(compaction_filter_bench, zstd_half_removed_large) {
+    return bench(model::compression::zstd, default_records, large_value, 0.5);
+}
+
+// --- lz4 ----------------------------------------------------------------
+
+PERF_TEST_CN(compaction_filter_bench, lz4_unchanged) {
+    return bench(model::compression::lz4, default_records, small_value, 0.0);
+}
+
+PERF_TEST_CN(compaction_filter_bench, lz4_half_removed) {
+    return bench(model::compression::lz4, default_records, small_value, 0.5);
+}
+
+// --- uncompressed (floor; optimization is a no-op here) -----------------
+
+PERF_TEST_CN(compaction_filter_bench, none_unchanged) {
+    return bench(model::compression::none, default_records, small_value, 0.0);
+}
+
+PERF_TEST_CN(compaction_filter_bench, none_half_removed) {
+    return bench(model::compression::none, default_records, small_value, 0.5);
+}
+
+// --- many records, rebuild path (exposes O(N) vs O(N^2) record matching) ----
+
+PERF_TEST_CN(compaction_filter_bench, none_half_removed_2k) {
+    return bench(model::compression::none, 2'000, tiny_value, 0.5);
+}
+
+PERF_TEST_CN(compaction_filter_bench, none_half_removed_8k) {
+    return bench(model::compression::none, 8'000, tiny_value, 0.5);
+}

--- a/src/v/compaction/tests/reducer_test.cc
+++ b/src/v/compaction/tests/reducer_test.cc
@@ -23,6 +23,9 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
+#include <vector>
+
 static const auto test_ntp = model::ntp(
   model::ns("kafka"), model::topic("tapioca"), model::partition_id(0));
 
@@ -44,6 +47,94 @@ TEST(CompactionReducerTest, SimpleReducer) {
     ASSERT_EQ(output_batches.size(), num_batches);
     linear_int_kv_batch_generator::validate_post_compaction(
       std::move(output_batches));
+}
+
+namespace {
+// Runs the filter over a single uncompressed batch of `num_records` unique
+// integer keys [0, num_records), removing the records whose key is in
+// `removed` (by indexing them in the map at a higher offset). Returns the
+// integer keys of the records present in the output, in order.
+std::vector<int>
+filter_kept_keys(model::record_batch batch, const std::vector<int>& removed) {
+    compaction::simple_key_offset_map map{};
+    for (int i : removed) {
+        auto key = compaction::compaction_key{
+          iobuf_to_bytes(reflection::to_iobuf(i))};
+        // Index at an offset strictly above any record offset so the record is
+        // treated as superseded and dropped.
+        map.put(key, model::offset(std::numeric_limits<int>::max())).get();
+    }
+
+    chunked_circular_buffer<model::record_batch> output;
+    compaction::simple_sink sink(output);
+    compaction::simple_map_filter filter(sink, map, test_ntp);
+    filter(std::move(batch)).get();
+
+    std::vector<int> kept;
+    if (!output.empty()) {
+        output.front().for_each_record([&kept](model::record r) {
+            kept.push_back(reflection::from_iobuf<int>(r.key().copy()));
+        });
+    }
+    return kept;
+}
+
+model::record_batch make_int_key_batch(int num_records) {
+    storage::record_batch_builder builder(
+      model::record_batch_type::raft_data, model::offset(0));
+    for (int i = 0; i < num_records; ++i) {
+        builder.add_raw_kv(reflection::to_iobuf(i), reflection::to_iobuf(i));
+    }
+    return std::move(builder).build();
+}
+} // namespace
+
+// The rebuild loop matches records against the kept-deltas vector with an
+// advancing cursor. Exercise the cases that distinguish a correct subsequence
+// match from a position-based one: removing the first, middle, last, and
+// non-contiguous sets of records.
+TEST(CompactionReducerTest, FilterKeepsCorrectRecordsAfterRemoval) {
+    constexpr int n = 8;
+    using vec = std::vector<int>;
+    EXPECT_EQ(
+      filter_kept_keys(make_int_key_batch(n), {}),
+      (vec{0, 1, 2, 3, 4, 5, 6, 7}));
+    EXPECT_EQ(
+      filter_kept_keys(make_int_key_batch(n), {0}), (vec{1, 2, 3, 4, 5, 6, 7}));
+    EXPECT_EQ(
+      filter_kept_keys(make_int_key_batch(n), {7}), (vec{0, 1, 2, 3, 4, 5, 6}));
+    EXPECT_EQ(
+      filter_kept_keys(make_int_key_batch(n), {3, 4}), (vec{0, 1, 2, 5, 6, 7}));
+    EXPECT_EQ(
+      filter_kept_keys(make_int_key_batch(n), {0, 2, 4, 6}), (vec{1, 3, 5, 7}));
+    EXPECT_EQ(
+      filter_kept_keys(make_int_key_batch(n), {0, 1, 2, 3, 4, 5, 6}), (vec{7}));
+}
+
+// A batch that has already been compacted carries non-contiguous offset deltas;
+// the surviving records keep their original deltas. Feeding such a batch back
+// through must match on those sparse deltas, not on record positions.
+TEST(CompactionReducerTest, FilterKeepsCorrectRecordsWithNonContiguousDeltas) {
+    using vec = std::vector<int>;
+    // First pass removes the middle records {3, 4}, leaving keys/deltas
+    // {0, 1, 2, 5, 6, 7}.
+    chunked_circular_buffer<model::record_batch> output;
+    {
+        compaction::simple_key_offset_map map{};
+        for (int i : {3, 4}) {
+            auto key = compaction::compaction_key{
+              iobuf_to_bytes(reflection::to_iobuf(i))};
+            map.put(key, model::offset(std::numeric_limits<int>::max())).get();
+        }
+        compaction::simple_sink sink(output);
+        compaction::simple_map_filter filter(sink, map, test_ntp);
+        filter(make_int_key_batch(8)).get();
+    }
+    ASSERT_EQ(output.size(), 1);
+
+    // Second pass over the sparse batch removes key 5 (delta 5).
+    EXPECT_EQ(
+      filter_kept_keys(std::move(output.front()), {5}), (vec{0, 1, 2, 6, 7}));
 }
 
 // When filtering removes nothing from a compressed batch, the filter should

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -232,17 +232,22 @@ copy_data_segment_reducer::filter(model::record_batch batch) {
     int32_t rec_count = 0;
     std::optional<int64_t> first_timestamp_delta;
     int64_t last_timestamp_delta;
+    // We expect and enforce that offset_deltas is sorted.
+    dassert(
+      std::ranges::is_sorted(offset_deltas),
+      "offset_deltas must be ascending in record-iteration order");
+    size_t keep_idx = 0;
     batch.for_each_record([&rec_count,
                            &first_timestamp_delta,
                            &last_timestamp_delta,
                            &ret,
+                           &keep_idx,
                            &offset_deltas](model::record record) {
         // contains the key
         if (
-          std::count(
-            offset_deltas.begin(),
-            offset_deltas.end(),
-            record.offset_delta())) {
+          keep_idx < offset_deltas.size()
+          && offset_deltas[keep_idx] == record.offset_delta()) {
+            ++keep_idx;
             /*
              * TODO when we further optimize lazy record materialization ot
              * make use of views we can avoid this re-encoding by copying or


### PR DESCRIPTION
Because `offset_deltas` are expected to be sorted in offset order, we can replace our use of `std::count()` with a cursor approach, leading to a reduction in algorithmic complexity from O(N²) → O(N) for our filtering logic. 

The performance improvement is seen in some newly added benchmarks below:

```
  ┌─────────┬────────────────────────────┬──────────────────────────┬──────────┐
  │ records │     before (std::count)    │       after (cursor)     │ Δ instr  │
  ├─────────┼────────────────────────────┼──────────────────────────┼──────────┤
  │ 10      │  6.20 ns/B ·  105.0 instr/B│  6.51 ns/B ·104.0 instr/B│   ~0%    │
  │ 50      │  5.22 ns/B ·  110.6 instr/B│  5.24 ns/B ·105.7 instr/B│   −4%    │
  │ 100     │  5.28 ns/B ·  117.3 instr/B│  5.08 ns/B ·107.6 instr/B│   −8%    │
  │ 2k      │ 12.41 ns/B ·  307.0 instr/B│  5.42 ns/B ·114.0 instr/B│  −63%    │
  │ 8k      │ 53.47 ns/B · 1473.0 instr/B│  5.61 ns/B ·120.0 instr/B│  −92%    │
  └─────────┴────────────────────────────┴──────────────────────────┴──────────┘
```

At low record counts per batch, there is no quantifiable improvement, but as the number of records in batches scale upwards, the now linear scaling makes a great deal of difference from the previous `std::count()` implementation.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Improvements

* Optimize compaction logic, especially for large batches.