### PR TITLE
[v26.1.x] [CORE-13874] `storage`: add `translation_out_of_range` exception and catch it in `archival`

### DIFF
--- a/src/v/cluster/archival/upload_housekeeping_service.cc
+++ b/src/v/cluster/archival/upload_housekeeping_service.cc
@@ -16,6 +16,7 @@
 #include "cluster/archival/types.h"
 #include "config/configuration.h"
 #include "ssx/future-util.h"
+#include "storage/exceptions.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/lowres_clock.hh>
@@ -409,6 +410,18 @@ ss::future<> housekeeping_workflow::run_jobs_bg() {
                 jobs_executed++;
                 quota = res.remaining;
                 maybe_update_probe(res);
+            } catch (const translation_offset_out_of_range& e) {
+                // This exception is most commonly experienced in the
+                // `adjacent_segment_merger::run()` path- the reupload candidate
+                // references a log offset that local retention has already
+                // trimmed away, so it can no longer be translated and
+                // reuploaded from the local log. This races with GC and can be
+                // expected.
+                vlog(
+                  archival_log.debug,
+                  "Reupload candidate is no longer translatable in the local "
+                  "log (trimmed by retention), skipping: {}",
+                  e.what());
             } catch (...) {
                 auto eptr = std::current_exception();
                 if (ssx::is_shutdown_exception(eptr)) {

--- a/src/v/storage/exceptions.h
+++ b/src/v/storage/exceptions.h
@@ -16,6 +16,7 @@
 #include <seastar/core/sstring.hh>
 
 #include <exception>
+#include <stdexcept>
 #include <utility>
 
 class malformed_batch_stream_exception : public std::exception {
@@ -49,4 +50,12 @@ public:
 
 private:
     ss::sstring _msg;
+};
+
+/// Thrown by `offset_translator_state` when an offset to translate falls
+/// outside the range currently covered by the translator state.
+class translation_offset_out_of_range : public std::runtime_error {
+public:
+    explicit translation_offset_out_of_range(const ss::sstring& s)
+      : std::runtime_error(s.c_str()) {}
 };

--- a/src/v/storage/offset_translator_state.cc
+++ b/src/v/storage/offset_translator_state.cc
@@ -19,6 +19,7 @@
 #include "serde/rw/rw.h"
 #include "serde/rw/scalar.h"
 #include "serde/rw/vector.h"
+#include "storage/exceptions.h"
 #include "storage/logger.h"
 
 #include <iterator>
@@ -54,7 +55,7 @@ int64_t offset_translator_state::delta(model::offset o) const {
           o,
           model::next_offset(_last_offset2batch.begin()->first));
 
-        throw std::runtime_error{fmt::format(
+        throw translation_offset_out_of_range{fmt::format(
           "ntp {}: log offset {} is outside the translation range (starting at "
           "{})",
           _ntp,
@@ -108,7 +109,7 @@ model::offset offset_translator_state::to_log_offset(
       = min_log_offset
         - model::offset(_last_offset2batch.begin()->second.next_delta);
     if (data_offset < min_data_offset) {
-        throw std::runtime_error{fmt::format(
+        throw translation_offset_out_of_range{fmt::format(
           "ntp {}: data offset {} is outside the translation range (starting "
           "at {})",
           _ntp,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30717

- Command: git cherry-pick -x 7d54d216fe 2c8b67ad4c
- Commits backported: 2
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-30717-v26.1.x-1781021740

## Conflict details

- 7d54d216fe (src/v/storage/offset_translator_state.cc): include block conflicted because the target branch lacks the `// NOLINT(misc-include-cleaner)` comment on the `serde/rw/vector.h` include that exists on dev. Kept the target branch's `#include "serde/rw/vector.h"` line and added the commit's new `#include "storage/exceptions.h"`.
