### PR TITLE
rpk: bump Go toolchain to 1.26.4 (Snyk findings)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -233,20 +233,20 @@ COMPILERS = {
 # Go Toolchain
 # ====================================
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk", dev_dependency = True)
-go_sdk.download(version = "1.26.3")
+go_sdk.download(version = "1.26.4")
 
 # The microsoft compiler versions can be listed at their github release under the `asset.json` file
 go_sdk.download(
     name = "go_sdk_with_systemcrypto",
     experiments = ["systemcrypto"],
     sdks = {
-        "linux_amd64": ("450d56d408a0b49c0d3a8ba15a0a810d/go1.26.3-20260508.1.linux-amd64.tar.gz", "e09fedd6e53dfe835ea00b38bb678388965417ecdd28b02231fc868d4a9064c8"),
-        "linux_arm64": ("b9189bfbbd3c981361dc32f42bc57edb/go1.26.3-20260508.1.linux-arm64.tar.gz", "782eb2cfeb1c2e21d604d810a3e81a1c7112ba1ca7b1b2aee6131ab0353c8278"),
-        "darwin_amd64": ("75619db85ab8b5467af699f2a5206013/go1.26.3-20260508.1.darwin-amd64.tar.gz", "656c8680be43c2fa64ba1e044c446185264ba056191e62029d1d3e7ac88b0f00"),
-        "darwin_arm64": ("cf9e99b59a4cf1b7826ed21dcf627f4b/go1.26.3-20260508.1.darwin-arm64.tar.gz", "48601476ef9883c84c82d05c13ebb50154825b1c0093186403c011f91eb96bf4"),
+        "linux_amd64": ("30d6f3c908b93744d77f0cfcc29a8d0b/go1.26.4-20260602.8.linux-amd64.tar.gz", "fe7d72e1e83e15633d0a99bd67ce5ffbb67d8a5f71dcea309ff274457ef3c927"),
+        "linux_arm64": ("4c37d72249bf2963ca1588c288cb547b/go1.26.4-20260602.8.linux-arm64.tar.gz", "9c1c8660dd3cec69415c476232ffb32d529e158d2b2deca4038804f1766f2f78"),
+        "darwin_amd64": ("b4fd14d59150fa3fff40bec803473350/go1.26.4-20260602.8.darwin-amd64.tar.gz", "2ae7f888d38d04e891cc5512622da48cadb3c24afc96a3634723ee71ff35042c"),
+        "darwin_arm64": ("c8a11ca9a3d0828665e27739dce2a60a/go1.26.4-20260602.8.darwin-arm64.tar.gz", "396705207e67a387f9052d789ac9d0bd2ddfaf5fe57f4bc720ba9881567f8e42"),
     },
-    urls = ["https://download.visualstudio.microsoft.com/download/pr/2b5f4cfa-e528-4781-92cb-dbdb5effb00c/{}"],
-    version = "1.26.3",
+    urls = ["https://download.visualstudio.microsoft.com/download/pr/88c9f950-d0f1-46ac-90d0-8e8b4095e743/{}"],
+    version = "1.26.4",
 )
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2760,162 +2760,162 @@
           "27bab004c72b3d7bd05a69b6ec0fc54a309b4b78cc569dd963d8b3ec28bfdb8c"
         ]
       },
-      "1.26.3": {
+      "1.26.4": {
         "aix_ppc64": [
-          "go1.26.3.aix-ppc64.tar.gz",
-          "9fd8b45c4aa58fa6adf7f347343a3b50c02b17a4b5c43381dd9bf87be563183d"
+          "go1.26.4.aix-ppc64.tar.gz",
+          "881bf44c07203fc1759d477412c2dfae425e5d2023acdd79299d5de5b4de8e77"
         ],
         "darwin_amd64": [
-          "go1.26.3.darwin-amd64.tar.gz",
-          "278d580b32e299fe4a9c990fcf2d02acfe538c7e551a6ee18f9c7164573d2c63"
+          "go1.26.4.darwin-amd64.tar.gz",
+          "05dc9b5f9997744520aaebb3d5deaa7c755371aebbfb7f97c2511a9f3367538d"
         ],
         "darwin_arm64": [
-          "go1.26.3.darwin-arm64.tar.gz",
-          "875cf54a15311eee2c99b9dd67c68c4a49351d489ab622bf2cfd28c8f2078d3c"
+          "go1.26.4.darwin-arm64.tar.gz",
+          "b62ad2b6d7d2464f12a5bcad7ff47f19d08325773b5efd21610e445a05a9bf53"
         ],
         "dragonfly_amd64": [
-          "go1.26.3.dragonfly-amd64.tar.gz",
-          "6bfeaae407b12affd477cd48674e51d34931b6d98afc59de0f50ef93523ea4bf"
+          "go1.26.4.dragonfly-amd64.tar.gz",
+          "bcc3ee1cfb6dd03a2d5abf07174212df1764ae54406c389b71a7fd2d05a8f0c8"
         ],
         "freebsd_386": [
-          "go1.26.3.freebsd-386.tar.gz",
-          "270df83863a4fbeb716565e91915f54af4ed911ec503651fbce6c14f9e00018c"
+          "go1.26.4.freebsd-386.tar.gz",
+          "f4325e0f9a5894e79c60b5e692af55a1e6f261b8ea73dcd20eced8372ad08233"
         ],
         "freebsd_amd64": [
-          "go1.26.3.freebsd-amd64.tar.gz",
-          "2a5a3b0265f24cdf3878bbab19bb1086f71ae5d29566f238214847d1e3745b4e"
+          "go1.26.4.freebsd-amd64.tar.gz",
+          "e91e96c0d3bd8f770e5a0facaf21d010a84e1c9440d830210cb3c223f0b7fb50"
         ],
         "freebsd_arm": [
-          "go1.26.3.freebsd-arm.tar.gz",
-          "db3700f0173ef7d15b96b4a2fa34c7fce90455e3125491183d751c9270b63d96"
+          "go1.26.4.freebsd-arm.tar.gz",
+          "36e45b3a843087f0f95a71f2ed453ea7e1727e684644d13f8b4c6c93fd977d41"
         ],
         "freebsd_arm64": [
-          "go1.26.3.freebsd-arm64.tar.gz",
-          "07431d472522d3e3b9fce3f5d1ea825e2fbb14d7b0b7fbfa548726654217127c"
+          "go1.26.4.freebsd-arm64.tar.gz",
+          "34aee1071d74cc23703d1b415c5fa44f840d29fd3733dac34944d83cfada3ff3"
         ],
         "illumos_amd64": [
-          "go1.26.3.illumos-amd64.tar.gz",
-          "2c5bc6a2c7c43e09a91b19117fa18ce9012393a9f42fc0d153cad345fd328dad"
+          "go1.26.4.illumos-amd64.tar.gz",
+          "27603bcd431afab272a5ed81cc951146181e8139640c46ed2ea5b560e1097038"
         ],
         "linux_386": [
-          "go1.26.3.linux-386.tar.gz",
-          "0ef3626a149b5811c813838c62b7d6618d03ea36047b32c90b0e4851cc42b1fa"
+          "go1.26.4.linux-386.tar.gz",
+          "5ca0982791791559d11a0eba939617a94c3f37c21aa514a55c415b9167efc658"
         ],
         "linux_amd64": [
-          "go1.26.3.linux-amd64.tar.gz",
-          "2b2cfc7148493da5e73981bffbf3353af381d5f93e789c82c79aff64962eb556"
+          "go1.26.4.linux-amd64.tar.gz",
+          "1153d3d50e0ac764b447adfe05c2bcf08e889d42a02e0fe0259bd47f6733ad7f"
         ],
         "linux_arm64": [
-          "go1.26.3.linux-arm64.tar.gz",
-          "9d89a3ea57d141c2b22d70083f2c8459ba3890f2d9e818e7e933b75614936565"
+          "go1.26.4.linux-arm64.tar.gz",
+          "ef758ae7c6cf9267c9c0ef080b8965f453d89ab2d25d9eb22de4405925238768"
         ],
         "linux_armv6l": [
-          "go1.26.3.linux-armv6l.tar.gz",
-          "d44133d4c66b1451a1e247da26db7716f76a081c0169a75e6c84e1871e394320"
+          "go1.26.4.linux-armv6l.tar.gz",
+          "8db458e995f18a9427a745cefe7a3323962fa2548c4715148963311f300d3b1a"
         ],
         "linux_loong64": [
-          "go1.26.3.linux-loong64.tar.gz",
-          "05215802b85a33dcfdb933a6c3ab881f4f0405587ee6581d33f34cc5c2ab740c"
+          "go1.26.4.linux-loong64.tar.gz",
+          "9f6d288d8972dd649ff3ecfdd3ed98e0664b5efb432e841408c054c25af26ed3"
         ],
         "linux_mips": [
-          "go1.26.3.linux-mips.tar.gz",
-          "76800ce7007d5eacabfe25d038e0a99e73a0fb70c4dd13f8a9662045fb4a52a7"
+          "go1.26.4.linux-mips.tar.gz",
+          "3435d0d8424562dfcf12517040b6a2388ee0f6f20b9d66b2349a6c5034d57997"
         ],
         "linux_mips64": [
-          "go1.26.3.linux-mips64.tar.gz",
-          "f2c755d17c6834dd3ae805d815a1b9e2eda66375de6ca910efb903a257ff3a3d"
+          "go1.26.4.linux-mips64.tar.gz",
+          "691263ab84943aff78d1422dfae66f352d907fc67560e66e7ceec3898fb7d5e6"
         ],
         "linux_mips64le": [
-          "go1.26.3.linux-mips64le.tar.gz",
-          "54f7b00bf2d5cf4b21734cc8eb3c61c51a76177d3d20cd667e4b1ba8fb3343d5"
+          "go1.26.4.linux-mips64le.tar.gz",
+          "23946b019b118ed85676090fd9110cfa091667c8c52d3d5276b73f3dd46d31f4"
         ],
         "linux_mipsle": [
-          "go1.26.3.linux-mipsle.tar.gz",
-          "31f7d8c886136b725d36880f6ee16fe22a7243751839a2de2ea2da3cb4fd3fe1"
+          "go1.26.4.linux-mipsle.tar.gz",
+          "4436df043e2a448f8937d1f944a3cd786d815c872fdce38dd892269845c1c54f"
         ],
         "linux_ppc64": [
-          "go1.26.3.linux-ppc64.tar.gz",
-          "459746b1b06eb24836d1e4699c6568220c95e82de9b1b155c74eb4fdfd711532"
+          "go1.26.4.linux-ppc64.tar.gz",
+          "d7c3970c1818d63b7b3473a01b9f5f208da1e793a902d3b2e26d5e5174eb6026"
         ],
         "linux_ppc64le": [
-          "go1.26.3.linux-ppc64le.tar.gz",
-          "dbd82b50530ead2beb1fd72215117380df3cb16332b51467116dc35b3691dd75"
+          "go1.26.4.linux-ppc64le.tar.gz",
+          "53f49b8c7eace2d30389327b4a516b13321f90377fdf5929a6b63174609bc22e"
         ],
         "linux_riscv64": [
-          "go1.26.3.linux-riscv64.tar.gz",
-          "3b8fd5112340b72587e42c619f43270f1bc21f63cfdb587e6b72e0336580727c"
+          "go1.26.4.linux-riscv64.tar.gz",
+          "2b9ba137baaa3031fd74330cb36ab54c5abe380867ca9fbab7c552f3db740555"
         ],
         "linux_s390x": [
-          "go1.26.3.linux-s390x.tar.gz",
-          "5c0605b7175449f1c8e8cb02efaba2695caab914fad4dcedc764c2f4c6dfe6ca"
+          "go1.26.4.linux-s390x.tar.gz",
+          "1e12a2318f3dd4c57027c865f6cb51f5d1e36b02d10f3e6316ce7b61a27b3ca1"
         ],
         "netbsd_386": [
-          "go1.26.3.netbsd-386.tar.gz",
-          "15c74255bb23fe9690faac4e489c654cea35d5059a59744e0afd0f78a29a6e53"
+          "go1.26.4.netbsd-386.tar.gz",
+          "67a172e4780d1b2a5412b73e86798937f2eb2f85aba6d740df4fbe6d6b555fa2"
         ],
         "netbsd_amd64": [
-          "go1.26.3.netbsd-amd64.tar.gz",
-          "a622ef5f3a6d42661ca75bdc939d8cb0468bb1a4418755b6d8c1b4acb82dd03c"
+          "go1.26.4.netbsd-amd64.tar.gz",
+          "3321f16e91c7d6d9c8df556690fbe8aef028aac9a0d6d466af9d3c20bd599503"
         ],
         "netbsd_arm": [
-          "go1.26.3.netbsd-arm.tar.gz",
-          "696df9d8562ac0118c3b8fd6578978d1c4e35583fe2d655e18b6520da7508ec9"
+          "go1.26.4.netbsd-arm.tar.gz",
+          "a3830f9f0f9fb00648346508d4d2c6fa2d7c1cd4c478fb88051ff6f1b49f0610"
         ],
         "netbsd_arm64": [
-          "go1.26.3.netbsd-arm64.tar.gz",
-          "faca070ad7866db5f5a085fe4380408394e2427e093e9770146620c0db508251"
+          "go1.26.4.netbsd-arm64.tar.gz",
+          "f240a98583a12f16cd6ea4799d29e5ccdc96892314263c0065e6511c783e26ab"
         ],
         "openbsd_386": [
-          "go1.26.3.openbsd-386.tar.gz",
-          "a29ad1b1f1a0a3a0f7e70a579f8ab1a26c03778bdcae4f58bd5a29f303104af9"
+          "go1.26.4.openbsd-386.tar.gz",
+          "c0c892180ebc9038637f158a010bdc2d962d303d9c0346ae5856fcd2088b16c7"
         ],
         "openbsd_amd64": [
-          "go1.26.3.openbsd-amd64.tar.gz",
-          "b2d952b8f0b74a6d2c1a01251aca75ec8eb00a505ebc993f192b792c6762c800"
+          "go1.26.4.openbsd-amd64.tar.gz",
+          "cd33f8f7f103cc9151d69795a7f20482335a88cf4eb76a3c56c12afbb5b1b2f0"
         ],
         "openbsd_arm": [
-          "go1.26.3.openbsd-arm.tar.gz",
-          "1038789f09e31a6b7b5cd7a5e5b3f65cb88ceefb68e34875a7e41b1a28fe2fb7"
+          "go1.26.4.openbsd-arm.tar.gz",
+          "5ab1a54a1dc4f425006101b81c12cd88a457b22496add2bb8b6f6e73b58cf1f1"
         ],
         "openbsd_arm64": [
-          "go1.26.3.openbsd-arm64.tar.gz",
-          "1e2df1dc7a4af8bf2a937e7641f300b855bf12bb84a01c44d00a2d68ec18ce26"
+          "go1.26.4.openbsd-arm64.tar.gz",
+          "cf8b0f5d6a043771df53fe70054d2b2b792f4c7693ad6cd5a891c252d813bc33"
         ],
         "openbsd_ppc64": [
-          "go1.26.3.openbsd-ppc64.tar.gz",
-          "42ac85fff0f26a1121ba94d7677f6c51cf3d92b53ad2980e54d80f0b196d57a9"
+          "go1.26.4.openbsd-ppc64.tar.gz",
+          "dcf7c6962c43ff67a0d804b989589fe4f3fd574c92b932659c95b1bb32c66f82"
         ],
         "openbsd_riscv64": [
-          "go1.26.3.openbsd-riscv64.tar.gz",
-          "c3ada901258530e4ccb58d58537fb9203733ef76155e589125fd2de2e33e857a"
+          "go1.26.4.openbsd-riscv64.tar.gz",
+          "e6ba2daf626770f7d453e7974058dee4b85cb198613ecbb97048a730dc1d5497"
         ],
         "plan9_386": [
-          "go1.26.3.plan9-386.tar.gz",
-          "0c5ee46c1345f16edb9ed7317050c20178fdb2b67f0adc2d7f5cf9339147bee5"
+          "go1.26.4.plan9-386.tar.gz",
+          "003b912f269786612ad01088178ffcb6f03421fdd61cc4d8b71922571aabd09a"
         ],
         "plan9_amd64": [
-          "go1.26.3.plan9-amd64.tar.gz",
-          "d672908489ef1982b63110597e1804656a5a9519544337af382233a171a1c96e"
+          "go1.26.4.plan9-amd64.tar.gz",
+          "663871da0f2263d6553828e695be5346f816015f1a6fe7ead22db538ebb6b293"
         ],
         "plan9_arm": [
-          "go1.26.3.plan9-arm.tar.gz",
-          "8ff8f45a52b4900febf8ecf0aa9ac0d49233c76fa4efe405e6ff0d81a6a50749"
+          "go1.26.4.plan9-arm.tar.gz",
+          "9b350fc94bb0c17fe30604e41c7573a9a70bbab258646f0e262a4c6851e4d2b8"
         ],
         "solaris_amd64": [
-          "go1.26.3.solaris-amd64.tar.gz",
-          "e9c5eab8d081c57fad50895b99e18faf78cccbbe957dea231eba3a32c964d7e7"
+          "go1.26.4.solaris-amd64.tar.gz",
+          "92eb3f7e224e5dd7ac9e0fb9455f8619c3999faf1e350a9505bb2ed5f7e41b7e"
         ],
         "windows_386": [
-          "go1.26.3.windows-386.zip",
-          "cefec7bd234f57dcc22e2ad2b2e98e45840d998770c5b10b22daddf728dc7cac"
+          "go1.26.4.windows-386.zip",
+          "2064a4a249fd2ee2db23e7080dc19b42768969f2830541841d0f7a9c80996946"
         ],
         "windows_amd64": [
-          "go1.26.3.windows-amd64.zip",
-          "20d2ceafb4ed41b96b879010927b28bc92a5be57a7c1801ce365a9ca51d3224a"
+          "go1.26.4.windows-amd64.zip",
+          "3ca8fb4630b07c419cbdd51f754e31363cfcfb83b3a5354d9e895c90be2cc345"
         ],
         "windows_arm64": [
-          "go1.26.3.windows-arm64.zip",
-          "95cd63bc6b0da77409ba819215afea9ddf5702c55a3b20af3dd90ea95c7b130c"
+          "go1.26.4.windows-arm64.zip",
+          "62247f56fb7d7b827d237152c4e3fcd69a24d0fa9430dc73dbda7593ae82bc8d"
         ]
       }
     }

--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda/src/go/rpk
 
-go 1.26.3
+go 1.26.4
 
 require (
 	buf.build/gen/go/redpandadata/ai-gateway/connectrpc/go v1.19.1-20260203101113-1c7702ddb57a.2


### PR DESCRIPTION
## What
Bumps rpk's Go toolchain to **1.26.4**:
- `src/go/rpk/go.mod` go directive → 1.26.4
- `MODULE.bazel` stock `go_sdk` → 1.26.4
- `MODULE.bazel` `go_sdk_with_systemcrypto` (Microsoft FIPS) → 1.26.4 (all four arch path-hashes + SHA256s + base-guid updated; URLs verified reachable)

## Why
Clears two stdlib HIGH Snyk findings on `src/go/rpk/go.mod`:
- **CVE-2026-27145** / GO-2026-5037 — `crypto/x509` resource exhaustion
- **CVE-2026-42504** / GO-2026-5038 — `net/mime` resource exhaustion

Both fixed in go1.26.4. (Also resolves the same finding on the published `redpanda` image's rpk once rebuilt, and the lingering idna CRITICAL from the prior x/net bump #30735.)

## Dependencies
- vtools S3 binary registration: redpanda-data/vtools#4305 (**merged**, binaries live on S3)
- vtools `GOLANG_VERSION` consumer bump: redpanda-data/vtools#4308

## Note
`MODULE.bazel.lock` facts for the `go_sdk` extension may need regenerating to satisfy strict lockfile validation; will update from the `bazel-clang-tidy` CI result if it flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none