### PR TITLE
metrics: add any_enabled() predicate

### DIFF
--- a/src/v/metrics/metrics.cc
+++ b/src/v/metrics/metrics.cc
@@ -19,6 +19,11 @@ const ss::metrics::label namespace_label{"namespace"};
 const ss::metrics::label topic_label{"topic"};
 const ss::metrics::label partition_label{"partition"};
 
+bool any_enabled() {
+    const auto& cfg = config::shard_local_cfg();
+    return !cfg.disable_metrics() || !cfg.disable_public_metrics();
+}
+
 internal_metric_groups& internal_metric_groups::add_group(
   const ss::metrics::group_name_type& name,
   std::vector<ss::metrics::impl::metric_definition_impl> metrics,

--- a/src/v/metrics/metrics.h
+++ b/src/v/metrics/metrics.h
@@ -33,6 +33,13 @@ extern const ss::metrics::label partition_label;
 // endpoint.
 const auto public_metrics_handle = ss::metrics::default_handle() + 1;
 
+/// True if at least one of the internal or public metrics endpoints is enabled
+/// (i.e. `all_metrics_groups::add_group` would register at least one series).
+///
+/// Use this to skip expensive work that only feeds metrics when no endpoint is
+/// enabled.
+bool any_enabled();
+
 // A thin wrapper around ss::metrics::metric_groups that isn't moveable.
 //
 // The standard usage pattern for metric_groups_base (and children) is as a

--- a/src/v/metrics/tests/BUILD
+++ b/src/v/metrics/tests/BUILD
@@ -14,3 +14,17 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "metrics_test",
+    timeout = "short",
+    srcs = [
+        "metrics_test.cc",
+    ],
+    deps = [
+        "//src/v/metrics",
+        "//src/v/test_utils:gtest",
+        "//src/v/test_utils:scoped_config",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/metrics/tests/metrics_test.cc
+++ b/src/v/metrics/tests/metrics_test.cc
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "metrics/metrics.h"
+#include "test_utils/scoped_config.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+// any_enabled() is the logical OR of "internal endpoint enabled" and "public
+// endpoint enabled", so it is only false when both endpoints are disabled.
+void set_disabled(scoped_config& sc, bool internal, bool pub) {
+    sc.get("disable_metrics").set_value(internal);
+    sc.get("disable_public_metrics").set_value(pub);
+}
+
+} // namespace
+
+TEST(metrics_enabled, both_enabled) {
+    scoped_config sc{};
+    set_disabled(sc, /*internal=*/false, /*pub=*/false);
+    EXPECT_TRUE(metrics::any_enabled());
+}
+
+TEST(metrics_enabled, only_internal_enabled) {
+    scoped_config sc{};
+    set_disabled(sc, /*internal=*/false, /*pub=*/true);
+    EXPECT_TRUE(metrics::any_enabled());
+}
+
+TEST(metrics_enabled, only_public_enabled) {
+    scoped_config sc{};
+    set_disabled(sc, /*internal=*/true, /*pub=*/false);
+    EXPECT_TRUE(metrics::any_enabled());
+}
+
+TEST(metrics_enabled, both_disabled) {
+    scoped_config sc{};
+    set_disabled(sc, /*internal=*/true, /*pub=*/true);
+    EXPECT_FALSE(metrics::any_enabled());
+}


### PR DESCRIPTION
Adds a small `metrics::any_enabled()` helper that returns true when at least one of the internal or public metrics endpoints is enabled (i.e. when `all_metrics_groups::add_group` would register at least one series).

The intent is to give callers a cheap way to skip work that only exists to feed metrics when both endpoints are disabled (`disable_metrics` and `disable_public_metrics` both set). The predicate is the logical OR of the two endpoint-enabled states, so it is only false when both are disabled.

This commit adds the predicate and its declaration only; there are no callers yet. A unit test exercises all four combinations of the two disable flags.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none