### PR TITLE
http: fix get_connected hot retry loop on fast connect failures

### DIFF
--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -911,7 +911,7 @@ abs_client::abs_client(
   const abs_configuration& conf,
   const net::base_transport::configuration& transport_conf,
   ss::shared_ptr<client_probe> probe,
-  const ss::abort_source& as,
+  ss::abort_source& as,
   ss::lw_shared_ptr<const cloud_roles::apply_credentials> apply_credentials)
   : client(std::move(upstream_ptr))
   , _data_lake_v2_client_config(

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -212,7 +212,7 @@ public:
       const abs_configuration& conf,
       const net::base_transport::configuration& transport_conf,
       ss::shared_ptr<client_probe> probe,
-      const ss::abort_source& as,
+      ss::abort_source& as,
       ss::lw_shared_ptr<const cloud_roles::apply_credentials>
         apply_credentials);
 

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -900,7 +900,7 @@ s3_client::s3_client(
   const s3_configuration& conf,
   const net::base_transport::configuration& transport_conf,
   ss::shared_ptr<client_probe> probe,
-  const ss::abort_source& as,
+  ss::abort_source& as,
   ss::lw_shared_ptr<const cloud_roles::apply_credentials> apply_credentials)
   : client(std::move(upstream_ptr))
   , _requestor(conf, std::move(apply_credentials))
@@ -1540,7 +1540,7 @@ gcs_client::gcs_client(
   const s3_configuration& conf,
   const net::base_transport::configuration& transport_conf,
   ss::shared_ptr<client_probe> probe,
-  const ss::abort_source& as,
+  ss::abort_source& as,
   ss::lw_shared_ptr<const cloud_roles::apply_credentials> apply_credentials)
   : s3_client(
       std::move(upstream_ptr),

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -195,7 +195,7 @@ public:
       const s3_configuration& conf,
       const net::base_transport::configuration& transport_conf,
       ss::shared_ptr<client_probe> probe,
-      const ss::abort_source& as,
+      ss::abort_source& as,
       ss::lw_shared_ptr<const cloud_roles::apply_credentials>
         apply_credentials);
 
@@ -387,7 +387,7 @@ public:
       const s3_configuration& conf,
       const net::base_transport::configuration& transport_conf,
       ss::shared_ptr<client_probe> probe,
-      const ss::abort_source& as,
+      ss::abort_source& as,
       ss::lw_shared_ptr<const cloud_roles::apply_credentials>
         apply_credentials);
 

--- a/src/v/http/BUILD
+++ b/src/v/http/BUILD
@@ -41,6 +41,7 @@ redpanda_cc_library(
         "//src/v/bytes:iobuf",
         "//src/v/config",
         "//src/v/net",
+        "//src/v/ssx:abort_source",
         "//src/v/ssx:sformat",
         "//src/v/utils:prefix_logger",
         "@boost//:asio",

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -295,7 +295,19 @@ ss::future<reconnect_result_t> client::get_connected(
         if (current < attempt_deadline) {
             const auto backoff = attempt_deadline - current;
             if (_as != nullptr) {
-                co_await ss::sleep_abortable<ss::lowres_clock>(backoff, *_as);
+                try {
+                    co_await ss::sleep_abortable<ss::lowres_clock>(
+                      backoff, *_as);
+                } catch (const ss::sleep_aborted&) {
+                    // sleep_abortable throws a generic sleep_aborted when _as
+                    // is already aborted at subscribe time (here: the abort
+                    // landed during the connect attempt). Surface the abort
+                    // source's own exception instead, matching the _as->check()
+                    // above and not masking a custom one set via
+                    // request_abort_ex. See scylladb/seastar#3452.
+                    _as->check();
+                    throw;
+                }
             } else {
                 co_await ss::sleep<ss::lowres_clock>(backoff);
             }

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -16,6 +16,7 @@
 #include "bytes/iobuf.h"
 #include "config/base_property.h"
 #include "http/logger.h"
+#include "ssx/abort_source.h"
 #include "ssx/sformat.h"
 
 #include <seastar/core/abort_source.hh>
@@ -225,8 +226,14 @@ ss::future<client::request_response_t> client::make_request(
 
 ss::future<reconnect_result_t> client::get_connected(
   ss::lowres_clock::duration timeout, prefix_logger ctxlog) {
-    auto clear_shutdown_signal = ss::defer(
-      [this]() noexcept { _shutdown_now = false; });
+    // Exposed to shutdown_now() (via _reconnect_abort) so it can interrupt the
+    // backoff sleep below; reset on exit so the dangling pointer isn't reused.
+    ss::abort_source reconnect_abort;
+    _reconnect_abort = &reconnect_abort;
+    auto clear_shutdown_signal = ss::defer([this]() noexcept {
+        _shutdown_now = false;
+        _reconnect_abort = nullptr;
+    });
     if (unlikely(_stopped)) {
         co_await ss::coroutine::return_exception(
           std::runtime_error("client is stopped"));
@@ -294,22 +301,26 @@ ss::future<reconnect_result_t> client::get_connected(
         current = ss::lowres_clock::now();
         if (current < attempt_deadline) {
             const auto backoff = attempt_deadline - current;
-            if (_as != nullptr) {
-                try {
+            try {
+                if (_as != nullptr) {
+                    // Wake on either the external abort source or shutdown_now.
+                    ssx::composite_abort_source cas{*_as, reconnect_abort};
                     co_await ss::sleep_abortable<ss::lowres_clock>(
-                      backoff, *_as);
-                } catch (const ss::sleep_aborted&) {
-                    // sleep_abortable throws a generic sleep_aborted when _as
-                    // is already aborted at subscribe time (here: the abort
-                    // landed during the connect attempt). Surface the abort
-                    // source's own exception instead, matching the _as->check()
-                    // above and not masking a custom one set via
-                    // request_abort_ex. See scylladb/seastar#3452.
-                    _as->check();
-                    throw;
+                      backoff, cas.as());
+                } else {
+                    co_await ss::sleep_abortable<ss::lowres_clock>(
+                      backoff, reconnect_abort);
                 }
-            } else {
-                co_await ss::sleep<ss::lowres_clock>(backoff);
+            } catch (const ss::sleep_aborted&) {
+                // Woke before the backoff elapsed. If the external abort source
+                // fired, surface its own exception (also covers
+                // scylladb/seastar#3452, where an already-aborted source makes
+                // sleep_abortable throw a bare sleep_aborted). Otherwise
+                // shutdown_now() fired: fall through so the _shutdown_now check
+                // on the next iteration stops the loop promptly.
+                if (_as != nullptr) {
+                    _as->check();
+                }
             }
             current = ss::lowres_clock::now();
         }

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -85,18 +85,18 @@ client::client(const net::base_transport::configuration& cfg)
   : client(cfg, nullptr, nullptr, default_max_idle_time) {}
 
 client::client(
-  const net::base_transport::configuration& cfg, const ss::abort_source& as)
+  const net::base_transport::configuration& cfg, ss::abort_source& as)
   : client(cfg, &as, nullptr, default_max_idle_time) {}
 
 client::client(
   const net::base_transport::configuration& cfg,
-  const ss::abort_source* as,
+  ss::abort_source* as,
   ss::shared_ptr<client_probe> probe)
   : client(cfg, as, std::move(probe), default_max_idle_time) {}
 
 client::client(
   const net::base_transport::configuration& cfg,
-  const ss::abort_source* as,
+  ss::abort_source* as,
   ss::shared_ptr<client_probe> probe,
   ss::lowres_clock::duration max_idle_time)
   : net::base_transport(cfg, &http_log)

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -25,6 +25,7 @@
 #include <seastar/core/loop.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/core/sleep.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/core/timed_out_error.hh>
 #include <seastar/coroutine/exception.hh>
@@ -239,11 +240,12 @@ ss::future<reconnect_result_t> client::get_connected(
       _dispatch_gate.is_closed());
     auto current = ss::lowres_clock::now();
     const auto deadline = current + timeout;
-    const auto interval = 1s; // 500ms;
+    const auto interval = 1s;
     while (!_connect_gate.is_closed() && current < deadline) {
         if (_as != nullptr) {
             _as->check();
         }
+        const auto attempt_deadline = current + interval;
         // Reconnect attempts have to stop if:
         // - shutdown method was called
         // - abort was requested
@@ -256,7 +258,7 @@ ss::future<reconnect_result_t> client::get_connected(
             // _dispatcher_gate is already closed. We need to synchronize
             // this loop with the `stop` call.
             ss::gate::holder gg(_connect_gate);
-            co_await connect(current + interval);
+            co_await connect(attempt_deadline);
             break;
         } catch (const std::system_error& err) {
             vlog(ctxlog.trace, "connection refused {}", err);
@@ -278,7 +280,27 @@ ss::future<reconnect_result_t> client::get_connected(
             }
             co_return reconnect_result_t::timed_out;
         }
+        // If a spaced retry would land at or past the overall deadline there's
+        // no room for another attempt, so stop now rather than sleep only to
+        // fall out of the loop on the next deadline check.
+        if (attempt_deadline >= deadline) {
+            break;
+        }
+        // Some connection attemps return effectively immediately after burning
+        // CPU only, (e.g. ECONNREFUSED/ENETUNREACH against an unreachable
+        // endpoint). In that case, we wait the remainder of the interval in
+        // order not to slam the reactor with connection attemps at a very high
+        // rate (starving other work).
         current = ss::lowres_clock::now();
+        if (current < attempt_deadline) {
+            const auto backoff = attempt_deadline - current;
+            if (_as != nullptr) {
+                co_await ss::sleep_abortable<ss::lowres_clock>(backoff, *_as);
+            } else {
+                co_await ss::sleep<ss::lowres_clock>(backoff);
+            }
+            current = ss::lowres_clock::now();
+        }
         // Any TLS error have to be propagated because it's not
         // transient. It won't help to try once again.
     }

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -133,6 +133,12 @@ public:
      */
     void shutdown_now() noexcept {
         _shutdown_now = true;
+        // Wake an in-flight get_connected backoff sleep so tear down is prompt;
+        // the backoff is otherwise only interrupted by the external abort
+        // source, which shutdown_now() does not touch.
+        if (_reconnect_abort != nullptr) {
+            _reconnect_abort->request_abort();
+        }
         shutdown();
     }
 
@@ -321,6 +327,9 @@ private:
     std::string _host_with_port;
     ss::gate _connect_gate;
     ss::abort_source* _as;
+    // Points at a get_connected-local abort source while a reconnect loop is
+    // running, so shutdown_now() can wake its backoff sleep; null otherwise.
+    ss::abort_source* _reconnect_abort{nullptr};
     ss::shared_ptr<http::client_probe> _probe;
     // Stores point in time when the last response was received
     // from the server.

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -102,16 +102,14 @@ public:
     using verb = boost::beast::http::verb;
 
     explicit client(const net::base_transport::configuration& cfg);
+    client(const net::base_transport::configuration& cfg, ss::abort_source& as);
     client(
       const net::base_transport::configuration& cfg,
-      const ss::abort_source& as);
-    client(
-      const net::base_transport::configuration& cfg,
-      const ss::abort_source* as,
+      ss::abort_source* as,
       ss::shared_ptr<client_probe> probe);
     client(
       const net::base_transport::configuration& cfg,
-      const ss::abort_source* as,
+      ss::abort_source* as,
       ss::shared_ptr<client_probe> probe,
       ss::lowres_clock::duration max_idle_time);
 
@@ -322,7 +320,7 @@ private:
     bool _shutdown_now{false};
     std::string _host_with_port;
     ss::gate _connect_gate;
-    const ss::abort_source* _as;
+    ss::abort_source* _as;
     ss::shared_ptr<http::client_probe> _probe;
     // Stores point in time when the last response was received
     // from the server.

--- a/src/v/http/tests/http_client_test.cc
+++ b/src/v/http/tests/http_client_test.cc
@@ -871,6 +871,32 @@ SEASTAR_THREAD_TEST_CASE(test_http_cancel_reconnect) {
     BOOST_REQUIRE_THROW(fut.get(), ss::abort_requested_exception);
 }
 
+// When the abort fires while the first connect attempt is still in flight (so
+// the abort source is already aborted by the time the backoff sleep subscribes
+// to it), get_connected must surface the abort source's own exception. The bare
+// sleep_abortable() throws a generic sleep_aborted in that case, which would
+// mask a custom exception installed via request_abort_ex(); translating it back
+// through _as->check() keeps the externally-visible exception consistent with
+// the top-of-loop check.
+namespace {
+struct custom_abort_error : std::exception {
+    const char* what() const noexcept override { return "custom_abort_error"; }
+};
+} // namespace
+
+SEASTAR_THREAD_TEST_CASE(test_http_reconnect_abort_surfaces_source_exception) {
+    auto config = transport_configuration();
+    ss::abort_source as;
+    http::client client(config, as);
+    auto fut = client.get_connected(
+      10s, prefix_logger(http::http_log, "test-url"));
+    // The coroutine has run up to `co_await connect(...)` and suspended; abort
+    // with a custom exception now, before the reactor resumes it into the
+    // backoff sleep.
+    as.request_abort_ex(custom_abort_error{});
+    BOOST_REQUIRE_THROW(fut.get(), custom_abort_error);
+}
+
 SEASTAR_THREAD_TEST_CASE(test_http_reconnect_graceful_shutdown) {
     auto config = transport_configuration();
     ss::abort_source as;


### PR DESCRIPTION
`http::client::get_connected` retries `connect()` until it succeeds, the
timeout is reached, or an unrecoverable error occurs. It passed
`current + interval` as the per-attempt connect *deadline* but never slept
between attempts, perhaps assuming a failed connect consumes ~`interval` (a
slow timeout). That holds when a connect hangs, but breaks when it fails
synchronously: an unreachable/refused endpoint returns
`ECONNREFUSED`/`ENETUNREACH` almost immediately, so the loop retried as fast
as the reactor could cycle for the whole timeout window - pegging the
shard's CPU and flooding the log, starving other work on that shard.
(`co_await connect()` still yields each iteration, so the deadline is
honored and the loop is not infinite; the harm is the CPU/log churn for the
duration of the timeout.)

This affects any http client whose endpoint is down (cloud_storage,
cloud_roles). It was discovered while adding cloud instance-type capacity
metrics (#30742), whose startup IMDS probe connects to `169.254.169.254`:
on a non-cloud host (e.g. CI) that address is unreachable and refuses
instantly, so the probe drove this loop to spin - a single CI run racked up
well over a million connect attempts per test and produced ~two dozen test
timeouts before the runner was killed. That PR worked around it locally with
a one-shot bounded connect probe; this change fixes the shared client.

The fix sleeps the remainder of `interval` after a failed attempt so
attempts are spaced ~`interval` apart; the sleep is abortable via the
client's abort source when present. If spacing the next attempt would reach
the overall deadline there is no room for another try, so it breaks rather
than sleeping only to fall out of the loop. Spacing reconnect attempts is
the right behavior regardless of how this surfaced - hammering a refused
endpoint as fast as possible is never useful, and it matches the original
`interval = 1s` intent.

The first commit is a no-op prep that takes the `abort_source` by non-const
reference end-to-end (it was already non-const at every caller), so the
client can subscribe to it via `sleep_abortable` without a `const_cast`.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none