### PR TITLE
[CORE-16320] Cloud Topics: L1 I/O Improvements: In-flight L1 read merging

### DIFF
--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -70,6 +70,7 @@ ss::future<> app::construct(
       config::node().l1_staging_path().string());
 
     co_await construct_service(_l1_reader_probe);
+    co_await construct_service(_l1_file_io_probe);
 
     co_await construct_service(
       _l1_reader_cache,
@@ -87,7 +88,8 @@ ss::future<> app::construct(
       config::node().l1_staging_path(),
       ss::sharded_parameter([&remote] { return &remote->local(); }),
       bucket,
-      ss::sharded_parameter([&cloud_cache] { return &cloud_cache->local(); }));
+      ss::sharded_parameter([&cloud_cache] { return &cloud_cache->local(); }),
+      ss::sharded_parameter([this] { return &_l1_file_io_probe.local(); }));
 
     co_await construct_service(
       domain_supervisor,
@@ -118,7 +120,8 @@ ss::future<> app::construct(
       rr_snapshot_manager_,
       config::node().l1_staging_path(),
       ss::sharded_parameter([&remote] { return &remote->local(); }),
-      ss::sharded_parameter([&cloud_cache] { return &cloud_cache->local(); }));
+      ss::sharded_parameter([&cloud_cache] { return &cloud_cache->local(); }),
+      ss::sharded_parameter([this] { return &_l1_file_io_probe.local(); }));
 
     co_await construct_service(
       rr_metadata_manager_,
@@ -141,6 +144,7 @@ ss::future<> app::construct(
       ss::sharded_parameter(
         [&metadata_cache] { return &metadata_cache->local(); }),
       ss::sharded_parameter([this] { return &_l1_reader_probe.local(); }),
+      ss::sharded_parameter([this] { return &_l1_file_io_probe.local(); }),
       ss::sharded_parameter([this] { return &_l1_reader_cache.local(); }),
       ss::sharded_parameter([this] { return &rr_metadata_manager_.local(); }),
       ss::sharded_parameter([this] { return &rr_snapshot_manager_.local(); }));

--- a/src/v/cloud_topics/app.h
+++ b/src/v/cloud_topics/app.h
@@ -102,6 +102,7 @@ private:
 
     ss::sstring _logger_name;
     ss::sharded<level_one_reader_probe> _l1_reader_probe;
+    ss::sharded<l1::file_io_probe> _l1_file_io_probe;
     ss::sharded<l1_reader_cache> _l1_reader_cache;
     std::unique_ptr<data_plane_api> data_plane;
     ss::sharded<state_accessors> state;

--- a/src/v/cloud_topics/level_one/common/BUILD
+++ b/src/v/cloud_topics/level_one/common/BUILD
@@ -86,6 +86,18 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "single_flight",
+    srcs = ["single_flight.cc"],
+    hdrs = ["single_flight.h"],
+    deps = [
+        ":abstract_io",
+        "//src/v/base",
+        "//src/v/container:chunked_hash_map",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "file_io",
     srcs = ["file_io.cc"],
     hdrs = ["file_io.h"],

--- a/src/v/cloud_topics/level_one/common/BUILD
+++ b/src/v/cloud_topics/level_one/common/BUILD
@@ -110,6 +110,8 @@ redpanda_cc_library(
         ":abstract_io",
         ":object_id",
         ":object_utils",
+        ":single_flight",
+        "//src/v/base",
         "//src/v/cloud_io:cache",
         "//src/v/cloud_io:io_result",
         "//src/v/cloud_io:remote",
@@ -117,6 +119,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics:logger",
         "//src/v/config",
         "//src/v/model",
+        "//src/v/utils:retry_chain_node",
         "@seastar",
     ],
 )

--- a/src/v/cloud_topics/level_one/common/BUILD
+++ b/src/v/cloud_topics/level_one/common/BUILD
@@ -99,8 +99,17 @@ redpanda_cc_library(
 
 redpanda_cc_library(
     name = "file_io",
-    srcs = ["file_io.cc"],
-    hdrs = ["file_io.h"],
+    srcs = [
+        "file_io.cc",
+        "file_io_probe.cc",
+    ],
+    hdrs = [
+        "file_io.h",
+        "file_io_probe.h",
+    ],
+    implementation_deps = [
+        "//src/v/base",
+    ],
     visibility = [
         "//src/v/cloud_topics:__pkg__",
         "//src/v/cloud_topics/level_one:__subpackages__",
@@ -118,6 +127,7 @@ redpanda_cc_library(
         "//src/v/cloud_storage_clients",
         "//src/v/cloud_topics:logger",
         "//src/v/config",
+        "//src/v/metrics",
         "//src/v/model",
         "//src/v/utils:retry_chain_node",
         "@seastar",

--- a/src/v/cloud_topics/level_one/common/file_io.cc
+++ b/src/v/cloud_topics/level_one/common/file_io.cc
@@ -10,6 +10,7 @@
 
 #include "cloud_topics/level_one/common/file_io.h"
 
+#include "base/vassert.h"
 #include "cloud_io/io_result.h"
 #include "cloud_io/remote.h"
 #include "cloud_storage_clients/client.h"
@@ -23,6 +24,7 @@
 #include <seastar/core/fstream.hh>
 
 #include <memory>
+#include <optional>
 
 using namespace std::chrono_literals;
 
@@ -99,6 +101,17 @@ file_io::file_io(
   , _staging_dir(std::move(staging_dir))
   , _cache(cache) {}
 
+ss::future<> file_io::stop() { return _gate.close(); }
+
+std::filesystem::path file_io::cache_key(const object_extent& extent) {
+    return std::filesystem::path(
+      fmt::format(
+        "l1_{}_position_{}_size_{}.partial",
+        extent.id,
+        extent.position,
+        extent.size));
+}
+
 ss::future<std::expected<std::unique_ptr<staging_file>, io::errc>>
 file_io::create_tmp_file() {
     co_return std::make_unique<staging_file_impl>(
@@ -163,26 +176,84 @@ ss::future<uint64_t> file_io::save_to_cache(
     co_return content_length;
 }
 
+ss::future<std::expected<void, io::errc>> file_io::do_download_to_cache(
+  const object_extent& extent,
+  const std::filesystem::path& cache_key,
+  retry_chain_node& root,
+  ss::abort_source& as,
+  cloud_io::group_id gid) {
+    // TODO(cloud_topics): reserving space should also take an abort_source
+    auto reservation_fut
+      = co_await ss::coroutine::as_future<cloud_io::space_reservation_guard>(
+        _cache->reserve_space(extent.size, 1));
+    if (reservation_fut.failed()) {
+        auto ex = reservation_fut.get_exception();
+        vlog(
+          cd_log.warn,
+          "Error reserving cache space for download of {}: {}",
+          extent,
+          ex);
+        co_return std::unexpected(io::errc::file_io_error);
+    }
+    cloud_io::try_consume_stream consumer =
+      [this, r = reservation_fut.get(), &cache_key](
+        uint64_t content_length, ss::input_stream<char> stream) mutable {
+          return save_to_cache(
+            std::move(stream), &r, cache_key, content_length);
+      };
+    auto result_fut
+      = co_await ss::coroutine::as_future<cloud_io::download_result>(
+        _remote->download_stream(
+          cloud_io::transfer_details{
+            .bucket = _bucket,
+            .key = object_path_factory::level_one_path(extent.id),
+            .parent_rtc = root,
+          },
+          consumer,
+          "l1_file_download",
+          /*acquire_hydration_units=*/true,
+          cloud_storage_clients::http_byte_range{
+            extent.position, extent.position + extent.size - 1},
+          {},
+          gid));
+    if (result_fut.failed()) {
+        auto ex = result_fut.get_exception();
+        vlog(cd_log.warn, "Error downloading object {}: {}", extent, ex);
+        // Map abort to cloud_op_timeout so a leader-abort and a
+        // merger-abort produce the same errc for the same event.
+        co_return std::unexpected(
+          as.abort_requested() ? io::errc::cloud_op_timeout
+                               : io::errc::cloud_op_error);
+    }
+    switch (result_fut.get()) {
+    case cloud_io::download_result::success:
+        co_return std::expected<void, io::errc>{};
+    case cloud_io::download_result::notfound:
+        co_return std::unexpected(io::errc::cloud_missing_object);
+    case cloud_io::download_result::timedout:
+        co_return std::unexpected(io::errc::cloud_op_timeout);
+    case cloud_io::download_result::failed:
+        co_return std::unexpected(io::errc::cloud_op_error);
+    }
+    std::unreachable();
+}
+
 ss::future<std::expected<ss::input_stream<char>, io::errc>>
 file_io::read_object(
   object_extent extent, ss::abort_source* as, cloud_io::group_id gid) {
+    if (_gate.is_closed()) {
+        co_return std::unexpected(io::errc::file_io_error);
+    }
+    auto holder = _gate.hold();
     static constexpr auto timeout = 10s;
     static constexpr auto backoff = 100ms;
     retry_chain_node root(*as, ss::lowres_clock::now() + timeout, backoff);
-    lazy_abort_source las{[as] {
-        return as->abort_requested() ? std::make_optional("abort requested")
-                                     : std::nullopt;
-    }};
     // TODO(cloud_topics): Optimize the cache such that it understands partial
     // objects? Or we assert somehow there are no overlaps (or just live with
     // them).
     // TODO(cloud_topics): If reading just a footer, we should skip the cache.
     // Maybe we need another method for that which is iobuf based?
-    std::filesystem::path cache_key = fmt::format(
-      "l1_{}_position_{}_size_{}.partial",
-      extent.id,
-      extent.position,
-      extent.size);
+    auto cache_key = file_io::cache_key(extent);
     while (true) {
         auto stream_fut = co_await ss::coroutine::as_future<
           std::optional<cloud_io::cache_item_stream>>(_cache->get_stream(
@@ -199,56 +270,25 @@ file_io::read_object(
         if (stream) {
             co_return std::move(stream->body);
         }
-        // TODO(cloud_topics): reserving space should also take an abort_source
-        auto reservation_fut = co_await ss::coroutine::as_future<
-          cloud_io::space_reservation_guard>(
-          _cache->reserve_space(extent.size, 1));
-        if (reservation_fut.failed()) {
-            auto ex = reservation_fut.get_exception();
-            vlog(
-              cd_log.warn,
-              "Error reserving cache space for download of {}: {}",
-              extent,
-              ex);
-            co_return std::unexpected(io::errc::file_io_error);
+
+        // single_flight dedups concurrent downloads for this extent.
+        auto r = co_await _single_flight.run(
+          cache_key,
+          *as,
+          [this, &extent, &cache_key, &root, as, gid]() {
+              return do_download_to_cache(extent, cache_key, root, *as, gid);
+          },
+          &cd_log);
+
+        if (!r.has_value()) {
+            // TODO(cloud_topics): on a transient errc, a merger whose own
+            // abort_source hasn't fired could re-loop as its own leader
+            // instead of inheriting the leader's failure.
+            co_return std::unexpected(r.error());
         }
-        cloud_io::try_consume_stream consumer =
-          [this, r = reservation_fut.get(), &cache_key](
-            uint64_t content_length, ss::input_stream<char> stream) mutable {
-              return save_to_cache(
-                std::move(stream), &r, cache_key, content_length);
-          };
-        auto result_fut
-          = co_await ss::coroutine::as_future<cloud_io::download_result>(
-            _remote->download_stream(
-              cloud_io::transfer_details{
-                .bucket = _bucket,
-                .key = object_path_factory::level_one_path(extent.id),
-                .parent_rtc = root,
-              },
-              consumer,
-              "l1_file_download",
-              /*acquire_hydration_units=*/true,
-              cloud_storage_clients::http_byte_range{
-                extent.position, extent.position + extent.size - 1},
-              {},
-              gid));
-        if (result_fut.failed()) {
-            auto ex = result_fut.get_exception();
-            vlog(cd_log.warn, "Error downloading object {}: {}", extent, ex);
-            co_return std::unexpected(io::errc::cloud_op_error);
+        if (r.value()) {
+            vlog(cd_log.debug, "Merged L1 read for {}", extent);
         }
-        switch (result_fut.get()) {
-        case cloud_io::download_result::success:
-            continue; // Now that it's in the cache the lookup should succeed.
-        case cloud_io::download_result::notfound:
-            co_return std::unexpected(io::errc::cloud_missing_object);
-        case cloud_io::download_result::timedout:
-            co_return std::unexpected(io::errc::cloud_op_timeout);
-        case cloud_io::download_result::failed:
-            co_return std::unexpected(io::errc::cloud_op_error);
-        }
-        std::unreachable();
     }
 }
 

--- a/src/v/cloud_topics/level_one/common/file_io.cc
+++ b/src/v/cloud_topics/level_one/common/file_io.cc
@@ -95,11 +95,13 @@ file_io::file_io(
   std::filesystem::path staging_dir,
   cloud_io::remote* remote,
   cloud_storage_clients::bucket_name bucket,
-  cloud_io::cache* cache)
+  cloud_io::cache* cache,
+  file_io_probe* probe)
   : _remote(remote)
   , _bucket(std::move(bucket))
   , _staging_dir(std::move(staging_dir))
-  , _cache(cache) {}
+  , _cache(cache)
+  , _probe(probe) {}
 
 ss::future<> file_io::stop() { return _gate.close(); }
 
@@ -245,6 +247,9 @@ file_io::read_object(
         co_return std::unexpected(io::errc::file_io_error);
     }
     auto holder = _gate.hold();
+    if (_probe) {
+        _probe->register_read();
+    }
     static constexpr auto timeout = 10s;
     static constexpr auto backoff = 100ms;
     retry_chain_node root(*as, ss::lowres_clock::now() + timeout, backoff);
@@ -271,6 +276,10 @@ file_io::read_object(
             co_return std::move(stream->body);
         }
 
+        if (_probe) {
+            _probe->register_cache_miss();
+        }
+
         // single_flight dedups concurrent downloads for this extent.
         auto r = co_await _single_flight.run(
           cache_key,
@@ -288,6 +297,9 @@ file_io::read_object(
         }
         if (r.value()) {
             vlog(cd_log.debug, "Merged L1 read for {}", extent);
+            if (_probe) {
+                _probe->register_concurrent_read_merge();
+            }
         }
     }
 }

--- a/src/v/cloud_topics/level_one/common/file_io.h
+++ b/src/v/cloud_topics/level_one/common/file_io.h
@@ -13,8 +13,15 @@
 #include "cloud_io/cache_service.h"
 #include "cloud_io/remote.h"
 #include "cloud_topics/level_one/common/abstract_io.h"
+#include "cloud_topics/level_one/common/file_io_probe.h"
 #include "cloud_topics/level_one/common/object_id.h"
+#include "cloud_topics/level_one/common/single_flight.h"
 #include "model/fundamental.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/gate.hh>
+
+#include <optional>
 
 namespace cloud_topics::l1 {
 
@@ -32,6 +39,12 @@ public:
       cloud_io::remote* remote,
       cloud_storage_clients::bucket_name bucket,
       cloud_io::cache* cache);
+
+    ss::future<> stop();
+
+    /// Cloud-cache disk key for an (oid, position, size) extent.
+    static std::filesystem::path cache_key(const object_extent& extent);
+
     ss::future<std::expected<std::unique_ptr<staging_file>, errc>>
     create_tmp_file() override;
 
@@ -55,10 +68,27 @@ private:
       std::filesystem::path,
       uint64_t content_length);
 
+    /// Reserve cache space, run the S3 GET, and stream the bytes into
+    /// the cloud cache under `cache_key`. Succeeds, or fails with the
+    /// mapped errc on reservation / download failure.
+    ss::future<std::expected<void, errc>> do_download_to_cache(
+      const object_extent& extent,
+      const std::filesystem::path& cache_key,
+      retry_chain_node& root,
+      ss::abort_source& as,
+      cloud_io::group_id gid);
+
     cloud_io::remote* _remote;
     cloud_storage_clients::bucket_name _bucket;
     std::filesystem::path _staging_dir;
     cloud_io::cache* _cache;
+
+    ss::gate _gate;
+
+    // Per-shard single-flight coordinator. Helps avoid redundant cloud
+    // storage I/O when two readers miss the cloud cache on the same
+    // extent.
+    single_flight _single_flight;
 };
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/file_io.h
+++ b/src/v/cloud_topics/level_one/common/file_io.h
@@ -31,14 +31,17 @@ namespace cloud_topics::l1 {
 // For writing this persists the file to the local disk, then writes it
 // to object storage.
 //
-// Reads are cached locally on disk in the cloud cache before being returned.
+// Reads are cached locally on disk in the cloud cache before being
+// returned.
 class file_io : public io {
 public:
+    /// `probe` is nullable so tests can opt out.
     file_io(
       std::filesystem::path staging_dir,
       cloud_io::remote* remote,
       cloud_storage_clients::bucket_name bucket,
-      cloud_io::cache* cache);
+      cloud_io::cache* cache,
+      file_io_probe* probe = nullptr);
 
     ss::future<> stop();
 
@@ -89,6 +92,9 @@ private:
     // storage I/O when two readers miss the cloud cache on the same
     // extent.
     single_flight _single_flight;
+
+    // Non-owning.
+    file_io_probe* _probe;
 };
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/file_io_probe.cc
+++ b/src/v/cloud_topics/level_one/common/file_io_probe.cc
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/common/file_io_probe.h"
+
+#include "config/configuration.h"
+#include "metrics/prometheus_sanitize.h"
+
+#include <seastar/core/metrics.hh>
+
+namespace cloud_topics::l1 {
+
+file_io_probe::file_io_probe() { setup_metrics(); }
+
+void file_io_probe::setup_metrics() {
+    if (config::shard_local_cfg().disable_metrics()) {
+        return;
+    }
+
+    namespace sm = ss::metrics;
+    _metrics.add_group(
+      prometheus_sanitize::metrics_name("cloud_topics_level_one_file_io"),
+      {
+        sm::make_counter(
+          "reads",
+          [this] { return _reads; },
+          sm::description("L1 read_object calls on this shard.")),
+        sm::make_counter(
+          "cache_misses",
+          [this] { return _cache_misses; },
+          sm::description("L1 cloud cache lookup misses on this shard.")),
+        sm::make_counter(
+          "concurrent_read_merges",
+          [this] { return _concurrent_read_merges; },
+          sm::description(
+            "Cache misses that joined an in-flight download for the "
+            "same extent.")),
+      });
+}
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/file_io_probe.h
+++ b/src/v/cloud_topics/level_one/common/file_io_probe.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "metrics/metrics.h"
+
+#include <cstdint>
+
+namespace cloud_topics::l1 {
+
+/// Per-shard L1 file_io metrics.
+class file_io_probe {
+public:
+    file_io_probe();
+
+    void register_read() { ++_reads; }
+    void register_cache_miss() { ++_cache_misses; }
+    void register_concurrent_read_merge() { ++_concurrent_read_merges; }
+
+private:
+    void setup_metrics();
+
+    uint64_t _reads{0};
+    uint64_t _cache_misses{0};
+    uint64_t _concurrent_read_merges{0};
+
+    metrics::internal_metric_groups _metrics;
+};
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/single_flight.cc
+++ b/src/v/cloud_topics/level_one/common/single_flight.cc
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/common/single_flight.h"
+
+#include "base/vassert.h"
+
+namespace cloud_topics::l1 {
+
+single_flight::join_result single_flight::join_or_lead(
+  const std::filesystem::path& cache_key, ss::abort_source& as) {
+    // NOTE: Keep this function synchronous to ensure entries map integrity.
+    if (auto it = _entries.find(cache_key); it != _entries.end()) {
+        return {
+          .kind = join_kind::merger,
+          .merge_future = it->second.get_shared_future(as)};
+    }
+
+    if (_entries.size() >= _max_entries) {
+        return {.kind = join_kind::at_capacity, .merge_future = std::nullopt};
+    }
+
+    auto [it, inserted] = _entries.emplace(
+      cache_key, ss::shared_promise<outcome>{});
+    vassert(
+      inserted, "single_flight: concurrent insert for {}", cache_key.native());
+    return {.kind = join_kind::leader, .merge_future = std::nullopt};
+}
+
+void single_flight::release_leader(
+  const std::filesystem::path& cache_key, outcome o) noexcept {
+    auto it = _entries.find(cache_key);
+    vassert(
+      it != _entries.end(),
+      "single_flight: entry for {} erased outside release_leader",
+      cache_key.native());
+    it->second.set_value(o);
+    _entries.erase(it);
+}
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/single_flight.h
+++ b/src/v/cloud_topics/level_one/common/single_flight.h
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "base/vlog.h"
+#include "cloud_topics/level_one/common/abstract_io.h"
+#include "container/chunked_hash_map.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/shared_future.hh>
+#include <seastar/coroutine/as_future.hh>
+#include <seastar/util/log.hh>
+
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <type_traits>
+
+namespace cloud_topics::l1 {
+
+/// Per-shard single-flight coordinator: dedups concurrent operations
+/// that share a cloud cache key so only one "leader" caller runs the
+/// work and the rest merge onto a shared future for the leader's
+/// outcome.
+///
+/// The optimization is opportunistic, so the map size is bounded.
+/// Beyond max_entries, callers run their work uncoordinated. Whatever
+/// operation the work performs should have its own concurrency control
+/// mechanism downstream.
+class single_flight {
+public:
+    /// Internal promise/future payload: the work succeeded, or it
+    /// failed with this errc.
+    using outcome = std::expected<void, io::errc>;
+
+    /// What a caller of run() observes.
+    ///
+    /// Success branch: bool -- true iff this caller joined an
+    /// existing leader (did not run work itself). False in the leader
+    /// and uncoordinated (at-capacity) cases.
+    ///
+    /// Error branch: the work's errc. Could be any of:
+    ///  - a merger whose abort_source fired while waiting
+    ///  - a merger whose leader failed
+    ///  - a worker (leader or uncoordinated) that failed
+    /// In any of these cases, callers should treat this result as failed work
+    /// and take appropriate measures to retry, propagate the error, etc.
+    using run_result = std::expected<bool, io::errc>;
+
+    /// Default bound on concurrent distinct keys tracked per shard.
+    static constexpr size_t default_max_entries = 4096;
+
+    explicit single_flight(size_t max_entries = default_max_entries) noexcept
+      : _max_entries(max_entries) {}
+
+    /// Run work under single-flight coordination for cache_key.
+    ///
+    /// - If no caller on this shard is currently running work for
+    ///   cache_key, become the leader: insert an entry, run work,
+    ///   publish its outcome to any concurrent mergers, then erase
+    ///   the entry. Returns success(false).
+    /// - If another caller is already running work for cache_key,
+    ///   await the leader's outcome and return success(true).
+    /// - If the map is at max_entries, run work uncoordinated (no
+    ///   entry inserted, no mergers possible). Returns success(false).
+    /// - On any work failure (leader's own, inherited by mergers, or
+    ///   merger-side abort), returns unexpected(errc).
+    ///
+    /// run never throws and reports every failure through run_result's
+    /// error branch. If work's returned future fails, we propagate
+    /// errc::file_io_error to this caller and any waiting mergers, and
+    /// log the exception via logger, if present.
+    ///
+    /// work must be invocable as ss::future<outcome>(). It runs
+    /// at most once per call to run.
+    ///
+    /// cache_key is the cloud cache path the work reads/writes, not
+    /// the remote object id. It encodes the byte range, so distinct
+    /// ranges of one object are distinct keys and don't coalesce into
+    /// one flight.
+    template<typename WorkFn>
+    requires std::is_invocable_r_v<ss::future<outcome>, WorkFn>
+    ss::future<run_result> run(
+      std::filesystem::path cache_key,
+      ss::abort_source& as,
+      WorkFn work,
+      ss::logger* logger = nullptr) noexcept;
+
+    size_t in_flight() const noexcept { return _entries.size(); }
+    size_t capacity() const noexcept { return _max_entries; }
+
+private:
+    /// Outcome of the synchronous lookup-or-insert step inside run.
+    enum class join_kind { leader, merger, at_capacity };
+    struct join_result {
+        join_kind kind;
+        /// Engaged iff kind == merger. ss::future is not default
+        /// constructible, hence the optional wrapper.
+        std::optional<ss::future<outcome>> merge_future;
+    };
+
+    /// Synchronous lookup-or-insert step.
+    join_result
+    join_or_lead(const std::filesystem::path& cache_key, ss::abort_source& as);
+
+    /// Publish an outcome to mergers waiting on cache_key and erase the
+    /// entry. Called only the leader fiber, exactly once per flight.
+    void
+    release_leader(const std::filesystem::path& cache_key, outcome o) noexcept;
+
+    chunked_hash_map<std::filesystem::path, ss::shared_promise<outcome>>
+      _entries;
+    size_t _max_entries;
+};
+
+template<typename WorkFn>
+requires std::is_invocable_r_v<ss::future<single_flight::outcome>, WorkFn>
+ss::future<single_flight::run_result> single_flight::run(
+  std::filesystem::path cache_key,
+  ss::abort_source& as,
+  WorkFn work,
+  ss::logger* logger) noexcept {
+    auto j = join_or_lead(cache_key, as);
+
+    if (j.kind == join_kind::merger) {
+        auto fut = co_await ss::coroutine::as_future(
+          std::move(*j.merge_future));
+        if (fut.failed()) {
+            // The merger's own abort_source fired while waiting on
+            // the leader. The leader will still publish its outcome
+            // later; we just surface cloud_op_timeout to this caller.
+            fut.ignore_ready_future();
+            co_return std::unexpected(io::errc::cloud_op_timeout);
+        }
+        // Inherit the leader's outcome: propagate its errc, or report
+        // a successful merge.
+        auto leader_outcome = fut.get();
+        if (!leader_outcome.has_value()) {
+            co_return std::unexpected(leader_outcome.error());
+        }
+        co_return true; // success (merged onto an existing leader)
+    }
+
+    // Leader or at-capacity uncoordinated: this caller runs work.
+    const bool is_leader = j.kind == join_kind::leader;
+    outcome work_outcome = std::unexpected(io::errc::file_io_error);
+
+    auto work_fut = co_await ss::coroutine::as_future(work());
+    if (work_fut.failed()) {
+        // work is meant to encode failure in its outcome, not raise. If
+        // it does raise, leave work_outcome at file_io_error so callers
+        // see one failure channel and the leader still releases mergers.
+        auto eptr = work_fut.get_exception();
+        if (logger != nullptr) {
+            vlog(
+              logger->warn,
+              "single_flight work for {} raised: {}",
+              cache_key,
+              eptr);
+        }
+    } else {
+        work_outcome = work_fut.get();
+    }
+
+    if (is_leader) {
+        release_leader(cache_key, work_outcome);
+    }
+    if (!work_outcome.has_value()) {
+        co_return std::unexpected(work_outcome.error());
+    }
+    co_return false; // work succeeded, did not merge
+}
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/tests/BUILD
+++ b/src/v/cloud_topics/level_one/common/tests/BUILD
@@ -30,3 +30,18 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "single_flight_test",
+    timeout = "short",
+    srcs = [
+        "single_flight_test.cc",
+    ],
+    deps = [
+        "//src/v/cloud_topics/level_one/common:abstract_io",
+        "//src/v/cloud_topics/level_one/common:single_flight",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_one/common/tests/single_flight_test.cc
+++ b/src/v/cloud_topics/level_one/common/tests/single_flight_test.cc
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/common/abstract_io.h"
+#include "cloud_topics/level_one/common/single_flight.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+#include <seastar/coroutine/as_future.hh>
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+
+using namespace cloud_topics::l1;
+
+namespace {
+
+// outcome constructors: success carries no value, failure carries an errc.
+single_flight::outcome ok() { return {}; }
+single_flight::outcome fail(io::errc e) { return std::unexpected(e); }
+
+ss::future<single_flight::outcome> ready(single_flight::outcome o) {
+    return ss::make_ready_future<single_flight::outcome>(std::move(o));
+}
+
+// Work that fails the test if invoked. Used as the merger's work
+// argument: the merger must never run its own work.
+ss::future<single_flight::outcome> work_never_runs() {
+    ADD_FAILURE() << "merger work invoked";
+    return ready(fail(io::errc::file_io_error));
+}
+
+} // namespace
+
+TEST_CORO(SingleFlightTest, ColdRunBecomesLeader) {
+    single_flight map;
+    ASSERT_EQ_CORO(map.in_flight(), 0u);
+
+    ss::abort_source as;
+    bool work_ran = false;
+    auto r = co_await map.run("/a", as, [&] {
+        work_ran = true;
+        // Entry exists for the duration of work().
+        EXPECT_EQ(map.in_flight(), 1u);
+        return ready(ok());
+    });
+
+    ASSERT_TRUE_CORO(work_ran);
+    ASSERT_TRUE_CORO(r.has_value());
+    ASSERT_FALSE_CORO(*r); // ran work, did not merge
+    ASSERT_EQ_CORO(map.in_flight(), 0u);
+}
+
+TEST_CORO(SingleFlightTest, ConcurrentRunsLeaderPublishesSuccess) {
+    single_flight map;
+    ss::promise<single_flight::outcome> leader_p;
+
+    ss::abort_source leader_as;
+    auto leader_fut = map.run(
+      "/a", leader_as, [&] { return leader_p.get_future(); });
+    // Leader has inserted its entry and suspended on the work future.
+    ASSERT_EQ_CORO(map.in_flight(), 1u);
+
+    ss::abort_source merger_as;
+    auto merger_fut = map.run("/a", merger_as, work_never_runs);
+    // Merger joined the existing leader; no second entry.
+    ASSERT_EQ_CORO(map.in_flight(), 1u);
+
+    leader_p.set_value(ok());
+
+    auto leader_r = co_await std::move(leader_fut);
+    auto merger_r = co_await std::move(merger_fut);
+
+    ASSERT_TRUE_CORO(leader_r.has_value());
+    ASSERT_FALSE_CORO(*leader_r);
+
+    ASSERT_TRUE_CORO(merger_r.has_value());
+    ASSERT_TRUE_CORO(*merger_r); // merged
+
+    ASSERT_EQ_CORO(map.in_flight(), 0u);
+}
+
+TEST_CORO(SingleFlightTest, MergerInheritsLeaderErrc) {
+    single_flight map;
+    ss::promise<single_flight::outcome> leader_p;
+
+    ss::abort_source leader_as;
+    auto leader_fut = map.run(
+      "/a", leader_as, [&] { return leader_p.get_future(); });
+
+    ss::abort_source merger_as;
+    auto merger_fut = map.run("/a", merger_as, work_never_runs);
+
+    leader_p.set_value(fail(io::errc::cloud_op_error));
+
+    auto leader_r = co_await std::move(leader_fut);
+    auto merger_r = co_await std::move(merger_fut);
+
+    ASSERT_FALSE_CORO(leader_r.has_value());
+    ASSERT_EQ_CORO(leader_r.error(), io::errc::cloud_op_error);
+
+    ASSERT_FALSE_CORO(merger_r.has_value());
+    ASSERT_EQ_CORO(merger_r.error(), io::errc::cloud_op_error);
+}
+
+// The merger's own abort_source fires while it waits. This manifests as a
+// cloud_op_timeout in the merger's result.
+TEST_CORO(SingleFlightTest, MergerAbortSurfacesAsTimeout) {
+    single_flight map;
+    ss::promise<single_flight::outcome> leader_p;
+
+    ss::abort_source leader_as;
+    auto leader_fut = map.run(
+      "/a", leader_as, [&] { return leader_p.get_future(); });
+
+    ss::abort_source merger_as;
+    auto merger_fut = map.run("/a", merger_as, work_never_runs);
+
+    merger_as.request_abort();
+
+    auto merger_r = co_await std::move(merger_fut);
+    ASSERT_FALSE_CORO(merger_r.has_value());
+    ASSERT_EQ_CORO(merger_r.error(), io::errc::cloud_op_timeout);
+
+    // Leader still has to publish; assert it completes cleanly as a
+    // (non-merged) leader success.
+    leader_p.set_value(ok());
+    auto leader_r = co_await std::move(leader_fut);
+    ASSERT_TRUE_CORO(leader_r.has_value());
+    ASSERT_FALSE_CORO(*leader_r); // led, did not merge
+}
+
+// If the leader's work raises, run() never rethrows: it maps the
+// exception to file_io_error for the leader and any mergers, and
+// releases the entry.
+TEST_CORO(SingleFlightTest, LeaderWorkThrowsReportsFileIoError) {
+    single_flight map;
+    ss::promise<single_flight::outcome> leader_p;
+
+    ss::abort_source leader_as;
+    auto leader_fut = map.run(
+      "/a", leader_as, [&](this auto) -> ss::future<single_flight::outcome> {
+          co_await leader_p.get_future();
+          throw std::runtime_error("boom");
+      });
+
+    ss::abort_source merger_as;
+    auto merger_fut = map.run("/a", merger_as, work_never_runs);
+
+    leader_p.set_value(ok());
+
+    auto leader_r = co_await std::move(leader_fut);
+    ASSERT_FALSE_CORO(leader_r.has_value());
+    ASSERT_EQ_CORO(leader_r.error(), io::errc::file_io_error);
+
+    auto merger_r = co_await std::move(merger_fut);
+    ASSERT_FALSE_CORO(merger_r.has_value());
+    ASSERT_EQ_CORO(merger_r.error(), io::errc::file_io_error);
+
+    ASSERT_EQ_CORO(map.in_flight(), 0u);
+}
+
+// At max_entries, additional callers run work uncoordinated. They
+// observe merged=false and do not insert into the map.
+TEST_CORO(SingleFlightTest, AtCapacityRunsUncoordinated) {
+    single_flight map(/*max_entries=*/2);
+    ss::promise<single_flight::outcome> p_a;
+    ss::promise<single_flight::outcome> p_b;
+
+    ss::abort_source as_a;
+    ss::abort_source as_b;
+    auto fut_a = map.run("/a", as_a, [&] { return p_a.get_future(); });
+    auto fut_b = map.run("/b", as_b, [&] { return p_b.get_future(); });
+    ASSERT_EQ_CORO(map.in_flight(), 2u);
+
+    // Two concurrent callers for the same key /c, both held open. At
+    // capacity each runs its own work rather than one joining the other.
+    ss::promise<single_flight::outcome> p_c1;
+    ss::promise<single_flight::outcome> p_c2;
+    bool c1_ran = false;
+    bool c2_ran = false;
+    ss::abort_source as_c1;
+    ss::abort_source as_c2;
+    auto fut_c1 = map.run("/c", as_c1, [&] {
+        c1_ran = true;
+        return p_c1.get_future();
+    });
+    auto fut_c2 = map.run("/c", as_c2, [&] {
+        c2_ran = true;
+        return p_c2.get_future();
+    });
+    // Both ran their own work; neither registered (map still full).
+    ASSERT_TRUE_CORO(c1_ran);
+    ASSERT_TRUE_CORO(c2_ran);
+    ASSERT_EQ_CORO(map.in_flight(), 2u);
+
+    p_c1.set_value(ok());
+    p_c2.set_value(ok());
+    auto r_c1 = co_await std::move(fut_c1);
+    auto r_c2 = co_await std::move(fut_c2);
+    ASSERT_TRUE_CORO(r_c1.has_value());
+    ASSERT_TRUE_CORO(r_c2.has_value());
+    ASSERT_FALSE_CORO(*r_c1); // ran uncoordinated, did not merge
+    ASSERT_FALSE_CORO(*r_c2); // ran uncoordinated, did not merge
+
+    p_a.set_value(ok());
+    p_b.set_value(ok());
+    co_await std::move(fut_a);
+    co_await std::move(fut_b);
+    ASSERT_EQ_CORO(map.in_flight(), 0u);
+}
+
+// After a leader releases, the slot it held is free for a new key.
+TEST_CORO(SingleFlightTest, SlotReusableAfterLeaderRelease) {
+    single_flight map(/*max_entries=*/1);
+
+    {
+        ss::abort_source as;
+        co_await map.run("/a", as, [] { return ready(ok()); });
+    }
+    ASSERT_EQ_CORO(map.in_flight(), 0u);
+
+    // /b takes the freed slot as a leader and holds it open.
+    ss::promise<single_flight::outcome> p_b;
+    ss::abort_source leader_as;
+    auto leader_fut = map.run(
+      "/b", leader_as, [&] { return p_b.get_future(); });
+    ASSERT_EQ_CORO(map.in_flight(), 1u);
+
+    // A concurrent /b joins the leader rather than running its own work,
+    // proving the slot is live and /b is joinable.
+    ss::abort_source merger_as;
+    auto merger_fut = map.run("/b", merger_as, work_never_runs);
+    ASSERT_EQ_CORO(map.in_flight(), 1u);
+
+    p_b.set_value(ok());
+    auto leader_r = co_await std::move(leader_fut);
+    auto merger_r = co_await std::move(merger_fut);
+    ASSERT_TRUE_CORO(leader_r.has_value());
+    ASSERT_FALSE_CORO(*leader_r); // led
+    ASSERT_TRUE_CORO(merger_r.has_value());
+    ASSERT_TRUE_CORO(*merger_r); // merged -> /b was joinable
+}

--- a/src/v/cloud_topics/read_replica/snapshot_manager.cc
+++ b/src/v/cloud_topics/read_replica/snapshot_manager.cc
@@ -120,6 +120,7 @@ ss::future<> database_refresher::stop_and_wait() {
     if (db_) {
         co_await db_->close();
     }
+    co_await io_->stop();
     vlog(logger_.debug, "Stopped");
 }
 

--- a/src/v/cloud_topics/read_replica/snapshot_manager.cc
+++ b/src/v/cloud_topics/read_replica/snapshot_manager.cc
@@ -37,6 +37,7 @@ public:
       cloud_storage_clients::bucket_name bucket,
       cloud_io::remote* remote,
       cloud_io::cache* cache,
+      l1::file_io_probe* probe,
       l1::domain_uuid);
 
     void start();
@@ -96,6 +97,7 @@ database_refresher::database_refresher(
   cloud_storage_clients::bucket_name bucket,
   cloud_io::remote* remote,
   cloud_io::cache* cache,
+  l1::file_io_probe* probe,
   l1::domain_uuid domain_uuid)
   : bucket_(std::move(bucket))
   , remote_(remote)
@@ -105,7 +107,7 @@ database_refresher::database_refresher(
       cd_log, fmt::format("database_refresher {}, {}", domain_uuid_, bucket_))
   , io_(
       std::make_unique<l1::file_io>(
-        std::move(staging_directory), remote_, bucket_, cache_)) {}
+        std::move(staging_directory), remote_, bucket_, cache_, probe)) {}
 
 void database_refresher::start() {
     ssx::spawn_with_gate(gate_, [this] { return run_loop(); });
@@ -249,10 +251,12 @@ database_refresher::get_newer_snapshot(
 snapshot_manager::snapshot_manager(
   std::filesystem::path staging_dir,
   cloud_io::remote* remote,
-  cloud_io::cache* cache)
+  cloud_io::cache* cache,
+  l1::file_io_probe* probe)
   : staging_dir_(std::move(staging_dir))
   , remote_(remote)
-  , cache_(cache) {}
+  , cache_(cache)
+  , probe_(probe) {}
 
 ss::future<std::expected<snapshot_handle, snapshot_manager::error>>
 snapshot_manager::get_snapshot(
@@ -272,7 +276,7 @@ snapshot_manager::get_snapshot(
 
         auto& entry = it->second;
         entry.refresher = std::make_unique<database_refresher>(
-          staging_dir_, bucket, remote_, cache_, domain_uuid);
+          staging_dir_, bucket, remote_, cache_, probe_, domain_uuid);
 
         // Set up the timer so that when it fires (after enough of an idle
         // period) it cleans up the database.

--- a/src/v/cloud_topics/read_replica/snapshot_manager.h
+++ b/src/v/cloud_topics/read_replica/snapshot_manager.h
@@ -29,13 +29,20 @@ class remote;
 class cache;
 } // namespace cloud_io
 
+namespace cloud_topics::l1 {
+class file_io_probe;
+} // namespace cloud_topics::l1
+
 namespace cloud_topics::read_replica {
 
 class database_refresher;
 class snapshot_manager : public snapshot_provider {
 public:
     explicit snapshot_manager(
-      std::filesystem::path, cloud_io::remote*, cloud_io::cache*);
+      std::filesystem::path,
+      cloud_io::remote*,
+      cloud_io::cache*,
+      l1::file_io_probe* probe = nullptr);
 
     ss::future<std::expected<snapshot_handle, error>> get_snapshot(
       l1::domain_uuid,
@@ -56,6 +63,7 @@ private:
     const std::filesystem::path staging_dir_;
     cloud_io::remote* remote_;
     cloud_io::cache* cache_;
+    l1::file_io_probe* probe_;
 
     struct database_entry {
         database_entry() = default;

--- a/src/v/cloud_topics/state_accessors.h
+++ b/src/v/cloud_topics/state_accessors.h
@@ -23,6 +23,7 @@ class l1_reader_cache;
 namespace l1 {
 class metastore;
 class io;
+class file_io_probe;
 } // namespace l1
 
 namespace read_replica {
@@ -42,6 +43,7 @@ public:
       l1::io* io,
       cluster::metadata_cache* metadata_cache,
       level_one_reader_probe* l1_reader_probe,
+      l1::file_io_probe* l1_file_io_probe,
       l1_reader_cache* l1_reader_cache,
       read_replica::metadata_provider* rr_metadata_provider,
       read_replica::snapshot_provider* rr_snapshot_provider)
@@ -50,6 +52,7 @@ public:
       , l1_io(io)
       , metadata_cache(metadata_cache)
       , l1_reader_probe(l1_reader_probe)
+      , l1_file_io_probe(l1_file_io_probe)
       , l1_reader_cache_(l1_reader_cache)
       , rr_metadata_provider_(rr_metadata_provider)
       , rr_snapshot_provider_(rr_snapshot_provider) {}
@@ -58,6 +61,7 @@ public:
     l1::metastore* get_l1_metastore() { return l1_metastore; }
     l1::io* get_l1_io() { return l1_io; }
     level_one_reader_probe* get_l1_reader_probe() { return l1_reader_probe; }
+    l1::file_io_probe* get_l1_file_io_probe() { return l1_file_io_probe; }
     l1_reader_cache* get_l1_reader_cache() { return l1_reader_cache_; }
     cluster::metadata_cache* get_metadata_cache() { return metadata_cache; }
     read_replica::metadata_provider* get_rr_metadata_provider() {
@@ -73,6 +77,7 @@ private:
     l1::io* l1_io;
     cluster::metadata_cache* metadata_cache;
     level_one_reader_probe* l1_reader_probe;
+    l1::file_io_probe* l1_file_io_probe;
     l1_reader_cache* l1_reader_cache_;
     read_replica::metadata_provider* rr_metadata_provider_;
     read_replica::snapshot_provider* rr_snapshot_provider_;


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

  Concurrent L1 reads missing the cloud cache on the same extent each issue their own S3
  GET. This coalesces them: one download per extent per shard, the rest wait on its
  result.

  - single_flight: per-shard coordinator. run(key, as, work) runs work once on the
  leader, merges later callers onto its outcome. Bounded at 4096 keys/shard; over that,
  uncoordinated.
  - file_io::read_object routes its cold-miss download through it. A gate drains
  in-flight reads before destruction.
  - file_io_probe: per-shard reads / cache_misses / concurrent_read_merges counters,
  plumbed through app and read-replica refreshers.

  Per-shard scope. Mergers take the leader's result rather than running the download
  themselves, so a single failed (or aborted) leader fails all the readers merged onto it
  instead of each retrying independently. This is the same tradeoff L0's read_merge
  makes

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
