### PR TITLE
[CORE-16427] Improve diagnostics for KeyCloak CI failures

### DIFF
--- a/tests/rptest/services/keycloak.py
+++ b/tests/rptest/services/keycloak.py
@@ -400,6 +400,29 @@ class KeycloakService(Service):
             "https-port": self.https_port,
         }
 
+    def _dump_startup_failure(self, node):
+        """Log Keycloak's process state and log file into the test log.
+
+        Called when startup fails, before teardown's clean_node() removes
+        KC_LOG_FILE. A failure during start_node happens in a test's
+        constructor or setUp, where ducktape does not collect the service's
+        declared logs, so the cause of the failure is otherwise lost. Logging
+        it here preserves it in the always-collected test log."""
+        try:
+            alive = self.alive(node)
+        except Exception as e:
+            alive = f"<unknown: {e!r}>"
+        try:
+            log = node.account.ssh_output(
+                f"cat {KC_LOG_FILE}", allow_fail=True, combine_stderr=True
+            ).decode("utf-8", errors="replace")
+        except Exception as e:
+            log = f"<failed to read {KC_LOG_FILE}: {e!r}>"
+        self.logger.error(
+            f"Keycloak failed to start (quarkus process alive={alive}). "
+            f"Contents of {KC_LOG_FILE}:\n{log}"
+        )
+
     def start_node(self, node, access_token_lifespan_s=DEFAULT_AT_LIFESPAN_S, **kwargs):
         scheme = "https" if self.using_tls else "http"
         extra_cfg = {
@@ -417,9 +440,13 @@ class KeycloakService(Service):
         self.logger.debug(f"Starting Keycloak service {cfg_writer.rep}")
 
         with node.account.monitor_log(KC_LOG_FILE) as monitor:
-            node.account.ssh(f"{KC} build", allow_fail=False)
-            node.account.ssh_capture(self._start_cmd(), allow_fail=False)
-            monitor.wait_until("(main) Profile dev activated.", timeout_sec=30)
+            try:
+                node.account.ssh(f"{KC} build", allow_fail=False)
+                node.account.ssh_capture(self._start_cmd(), allow_fail=False)
+                monitor.wait_until("(main) Profile dev activated.", timeout_sec=30)
+            except Exception:
+                self._dump_startup_failure(node)
+                raise
 
         self.logger.debug(f"Keycloak PIDs: {self.pids(node)}")
 

--- a/tests/rptest/services/keycloak.py
+++ b/tests/rptest/services/keycloak.py
@@ -443,7 +443,7 @@ class KeycloakService(Service):
             try:
                 node.account.ssh(f"{KC} build", allow_fail=False)
                 node.account.ssh_capture(self._start_cmd(), allow_fail=False)
-                monitor.wait_until("(main) Profile dev activated.", timeout_sec=30)
+                monitor.wait_until("(main) Profile dev activated.", timeout_sec=60)
             except Exception:
                 self._dump_startup_failure(node)
                 raise

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -2352,7 +2352,7 @@ class AuditLogTestOauth(AuditLogTestBase):
         try:
             self.keycloak.start_node(kc_node)
         except Exception as e:
-            self.logger.error(f"{e}")
+            self.logger.exception("Keycloak failed to start")
             self.keycloak.clean_node(kc_node)
             assert False, f"Keycloak failed to start: {e}"
 

--- a/tests/rptest/tests/debug_bundle_test.py
+++ b/tests/rptest/tests/debug_bundle_test.py
@@ -877,8 +877,8 @@ class DebugBundleOAuthBearerAuthn(DebugBundleTestBase):
         kc_node = self.keycloak.nodes[0]
         try:
             self.keycloak.start_node(kc_node)
-        except Exception as e:
-            self.logger.error(f"Keycloak failed to start: {e}")
+        except Exception:
+            self.logger.exception("Keycloak failed to start")
             self.keycloak.clean_node(kc_node)
             raise
 

--- a/tests/rptest/tests/redpanda_oauth_test.py
+++ b/tests/rptest/tests/redpanda_oauth_test.py
@@ -125,8 +125,8 @@ class RedpandaOIDCTestBase(Test):
             self.keycloak.start_node(
                 kc_node, access_token_lifespan_s=access_token_lifespan
             )
-        except Exception as e:
-            self.logger.error(f"{e}")
+        except Exception:
+            self.logger.exception("Keycloak failed to start")
             self.keycloak.clean_node(kc_node)
             assert False, "Keycloak failed to start"
 


### PR DESCRIPTION
Tests using KeyCload fail hard and we get no logs. This PR does two things:

1. It improves log collection to try to get some useful information to help us debug why things fail
2. Doubles the start-up time limit from 30s to 60s. Claude analyzed one failure and claimed that just part of the keycloak startup process had been observed to be 15 seconds, so that's half the entire budget for the entire startup procedure. So it could be a real occasional slow startup issue.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

