### PR TITLE
[v26.1.x] [CORE-16432] `kafka`: use `chunked_vector` in `group_metadata`

### DIFF
--- a/src/v/kafka/server/group_metadata.cc
+++ b/src/v/kafka/server/group_metadata.cc
@@ -184,7 +184,7 @@ group_metadata_value group_metadata_value::decode(protocol::decoder& reader) {
         ret.state_timestamp = model::timestamp(reader.read_int64());
     }
 
-    ret.members = reader.read_array(
+    ret.members = reader.read_array<chunked_vector>(
       [](protocol::decoder& reader) { return member_state::decode(reader); });
 
     return ret;

--- a/src/v/kafka/server/group_metadata.h
+++ b/src/v/kafka/server/group_metadata.h
@@ -12,6 +12,7 @@
 
 #include "base/seastarx.h"
 #include "bytes/iobuf.h"
+#include "container/chunked_vector.h"
 #include "kafka/protocol/wire.h"
 #include "model/adl_serde.h"
 #include "model/fundamental.h"
@@ -89,7 +90,7 @@ struct group_metadata_value {
     std::optional<kafka::protocol_name> protocol;
     std::optional<kafka::member_id> leader;
     model::timestamp state_timestamp{-1};
-    std::vector<member_state> members;
+    chunked_vector<member_state> members;
 
     group_metadata_value copy() const {
         group_metadata_value ret{

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -237,6 +237,7 @@ redpanda_cc_gtest(
     deps = [
         "//src/v/container:chunked_circular_buffer",
         "//src/v/container:chunked_hash_map",
+        "//src/v/container:chunked_vector",
         "//src/v/kafka/protocol",
         "//src/v/kafka/server",
         "//src/v/model",

--- a/src/v/kafka/server/tests/consumer_group_recovery_test.cc
+++ b/src/v/kafka/server/tests/consumer_group_recovery_test.cc
@@ -11,6 +11,7 @@
 #include "absl/strings/str_split.h"
 #include "container/chunked_circular_buffer.h"
 #include "container/chunked_hash_map.h"
+#include "container/chunked_vector.h"
 #include "kafka/protocol/types.h"
 #include "kafka/server/group_metadata.h"
 #include "kafka/server/group_recovery_consumer.h"
@@ -84,7 +85,7 @@ struct cg_recovery_test_fixture : seastar_test {
       std::optional<protocol_name> p_name,
       std::optional<member_id> leader,
       model::timestamp ts,
-      std::vector<member_state> members) {
+      chunked_vector<member_state> members) {
         group_metadata_kv kv;
         kv.key = group_metadata_key{group_id(g_name)};
         kv.value = group_metadata_value{
@@ -249,7 +250,7 @@ struct cg_recovery_test_fixture : seastar_test {
           protocol_name("proto-name"),
           member_id("member-1"),
           model::timestamp::now(),
-          std::vector<member_state>{});
+          chunked_vector<member_state>{});
 
         g_1_metadata.value->members.push_back(make_member_state(
           member_id("m-1"),
@@ -301,7 +302,7 @@ TEST_F_CORO(cg_recovery_test_fixture, test_tombstone_recovery) {
       protocol_name("proto-name"),
       member_id("member-1"),
       model::timestamp::now(),
-      std::vector<member_state>{});
+      chunked_vector<member_state>{});
 
     auto g_2_metadata = make_group_metadata(
       "g-2",
@@ -310,7 +311,7 @@ TEST_F_CORO(cg_recovery_test_fixture, test_tombstone_recovery) {
       protocol_name("proto-name-2"),
       member_id("member-1"),
       model::timestamp::now(),
-      std::vector<member_state>{});
+      chunked_vector<member_state>{});
 
     g_2_metadata.value->members.push_back(make_member_state(
       member_id("m-1"),


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30744
