### PR TITLE
`ct/l1`: allow for toggling of `compaction` and `leveling`

### DIFF
--- a/src/v/cloud_topics/level_one/maintenance/BUILD
+++ b/src/v/cloud_topics/level_one/maintenance/BUILD
@@ -250,6 +250,7 @@ redpanda_cc_library(
         "//src/v/container:intrusive",
         "//src/v/model",
         "//src/v/ssx:semaphore",
+        "//src/v/ssx:work_queue",
         "@seastar",
     ],
 )

--- a/src/v/cloud_topics/level_one/maintenance/compaction/compaction_queue.h
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/compaction_queue.h
@@ -52,6 +52,9 @@ public:
         }
     }
 
+    /// Clear all entries in the queue.
+    void clear_all() { _queue.clear(); }
+
     bool empty() const { return _queue.empty(); }
     size_t size() const { return _queue.size(); }
     bool contains(const model::topic_id_partition& tidp) const {

--- a/src/v/cloud_topics/level_one/maintenance/keyed_priority_queue.h
+++ b/src/v/cloud_topics/level_one/maintenance/keyed_priority_queue.h
@@ -92,6 +92,11 @@ public:
         return {e.key, e.value};
     }
 
+    void clear() {
+        _ordered_entries.clear();
+        _entry_it_by_key.clear();
+    }
+
 private:
     set_t _ordered_entries;
     // Maps a key to its slot in `_ordered_entries`. std::set iterators are

--- a/src/v/cloud_topics/level_one/maintenance/leveling/leveling_queue.h
+++ b/src/v/cloud_topics/level_one/maintenance/leveling/leveling_queue.h
@@ -91,6 +91,13 @@ public:
         _heads.erase(tidp);
     }
 
+    /// Clear all entries across both levels of the queue.
+    void clear_all() {
+        _queues.clear();
+        _heads.clear();
+        _size = 0;
+    }
+
     /// Total number of queued jobs across all partitions.
     size_t size() const { return _size; }
     bool empty() const { return _size == 0; }

--- a/src/v/cloud_topics/level_one/maintenance/scheduler.cc
+++ b/src/v/cloud_topics/level_one/maintenance/scheduler.cc
@@ -56,12 +56,19 @@ compaction_scheduler::compaction_scheduler(
       config::shard_local_cfg().cloud_topics_compaction_interval_ms.bind())
   , _leveling_interval(
       config::shard_local_cfg().cloud_topics_leveling_interval_ms.bind())
+  , _compaction_disabled(
+      config::shard_local_cfg().cloud_topics_compaction_disabled.bind())
+  , _leveling_disabled(
+      config::shard_local_cfg().cloud_topics_leveling_disabled.bind())
   , _compaction_queue(_scheduling_policy->get_comparator())
   , _leveling_queue(
       leveling_extent_reclamation_policy{
         config::shard_local_cfg()
           .cloud_topics_reconciliation_max_object_size.bind()}
-        .get_comparator()) {
+        .get_comparator())
+  , _scheduler_update_queue([](const std::exception_ptr& ex) {
+      vlog(compaction_log.error, "Scheduler loop update queue error: {}", ex);
+  }) {
     _compaction_interval.watch([this]() { _compaction_sem.signal(); });
     _leveling_interval.watch([this]() { _leveling_sem.signal(); });
 }
@@ -81,12 +88,19 @@ compaction_scheduler::compaction_scheduler(log_info_collector info_collector)
       config::shard_local_cfg().cloud_topics_compaction_interval_ms.bind())
   , _leveling_interval(
       config::shard_local_cfg().cloud_topics_leveling_interval_ms.bind())
+  , _compaction_disabled(
+      config::shard_local_cfg().cloud_topics_compaction_disabled.bind())
+  , _leveling_disabled(
+      config::shard_local_cfg().cloud_topics_leveling_disabled.bind())
   , _compaction_queue(_scheduling_policy->get_comparator())
   , _leveling_queue(
       leveling_extent_reclamation_policy{
         config::shard_local_cfg()
           .cloud_topics_reconciliation_max_object_size.bind()}
-        .get_comparator()) {
+        .get_comparator())
+  , _scheduler_update_queue([](const std::exception_ptr& ex) {
+      vlog(compaction_log.error, "Scheduler loop update queue error: {}", ex);
+  }) {
     _compaction_interval.watch([this]() { _compaction_sem.signal(); });
     _leveling_interval.watch([this]() { _leveling_sem.signal(); });
 }
@@ -152,97 +166,232 @@ void compaction_scheduler::unmanage_partition(
     _probe.set_log_count(_logs.size());
 }
 
-void compaction_scheduler::start_bg_loop() {
-    ssx::repeat_until_gate_closed_or_aborted(_gate, _as, [this] {
-        return compaction_scheduling_loop().handle_exception(
-          [](const std::exception_ptr& e) {
-              auto log_level = ssx::is_shutdown_exception(e)
-                                 ? ss::log_level::debug
-                                 : ss::log_level::error;
-              vlogl(
-                compaction_log,
-                log_level,
-                "Encountered exception in compaction scheduling loop: {}",
-                e);
-          });
+void compaction_scheduler::watch_config_changes() {
+    _compaction_disabled.watch([this] {
+        _scheduler_update_queue.submit([this] {
+            return _compaction_disabled() ? pause_compaction_loop()
+                                          : resume_compaction_loop();
+        });
     });
-    ssx::repeat_until_gate_closed_or_aborted(_gate, _as, [this] {
-        return leveling_scheduling_loop().handle_exception(
-          [](const std::exception_ptr& e) {
-              auto log_level = ssx::is_shutdown_exception(e)
-                                 ? ss::log_level::debug
-                                 : ss::log_level::error;
-              vlogl(
-                compaction_log,
-                log_level,
-                "Encountered exception in leveling scheduling loop: {}",
-                e);
-          });
+    _leveling_disabled.watch([this] {
+        _scheduler_update_queue.submit([this] {
+            return _leveling_disabled() ? pause_leveling_loop()
+                                        : resume_leveling_loop();
+        });
     });
+}
+
+bool compaction_scheduler::should_run_compaction_loop() const {
+    return !_gate.is_closed() && !_as.abort_requested()
+           && _compaction_target_loop_state == loop_state::active;
+}
+
+bool compaction_scheduler::should_run_leveling_loop() const {
+    return !_gate.is_closed() && !_as.abort_requested()
+           && _leveling_target_loop_state == loop_state::active;
+}
+
+ss::future<> compaction_scheduler::resume_compaction_loop() {
+    if (_compaction_target_loop_state == loop_state::stopped) {
+        co_return;
+    }
+    _compaction_target_loop_state = loop_state::active;
+    if (_compaction_loop_fut.has_value()) {
+        co_return;
+    }
+    // Bring the per-shard compaction fibers back before feeding them
+    // work.
+    co_await _worker_manager.resume_all_workers(
+      maintenance_job_type::compaction);
+    _compaction_loop_fut = ssx::spawn_with_gate_then(
+      _gate, [this] { return compaction_scheduling_loop(); });
+}
+
+ss::future<> compaction_scheduler::pause_compaction_loop() {
+    if (_compaction_target_loop_state == loop_state::stopped) {
+        co_return;
+    }
+    _compaction_target_loop_state = loop_state::paused;
+    if (!_compaction_loop_fut.has_value()) {
+        co_return;
+    }
+
+    vlog(compaction_log.info, "Compaction disabled; pausing compaction loop");
+
+    _compaction_sem.signal();
+    co_await clear_compaction_loop_fut();
+
+    co_await _worker_manager.pause_all_workers(
+      maintenance_job_type::compaction);
+
+    _compaction_queue.clear_all();
+    _probe.set_compaction_queue_length(0);
+}
+
+ss::future<> compaction_scheduler::clear_compaction_loop_fut() {
+    if (_compaction_loop_fut.has_value()) {
+        co_await std::move(_compaction_loop_fut).value();
+        _compaction_loop_fut.reset();
+    }
+}
+
+ss::future<> compaction_scheduler::resume_leveling_loop() {
+    if (_leveling_target_loop_state == loop_state::stopped) {
+        co_return;
+    }
+    _leveling_target_loop_state = loop_state::active;
+    if (_leveling_loop_fut.has_value()) {
+        co_return;
+    }
+    // Bring the per-shard leveling fibers back before feeding them
+    // work.
+    co_await _worker_manager.resume_all_workers(maintenance_job_type::leveling);
+    _leveling_loop_fut = ssx::spawn_with_gate_then(
+      _gate, [this] { return leveling_scheduling_loop(); });
+}
+
+ss::future<> compaction_scheduler::pause_leveling_loop() {
+    if (_leveling_target_loop_state == loop_state::stopped) {
+        co_return;
+    }
+    _leveling_target_loop_state = loop_state::paused;
+    if (!_leveling_loop_fut.has_value()) {
+        co_return;
+    }
+
+    vlog(compaction_log.info, "Leveling disabled; pausing leveling loop");
+
+    _leveling_sem.signal();
+    co_await clear_leveling_loop_fut();
+
+    co_await _worker_manager.pause_all_workers(maintenance_job_type::leveling);
+
+    _leveling_queue.clear_all();
+    _probe.set_leveling_queue_length(0);
+}
+
+ss::future<> compaction_scheduler::clear_leveling_loop_fut() {
+    if (_leveling_loop_fut.has_value()) {
+        co_await std::move(_leveling_loop_fut).value();
+        _leveling_loop_fut.reset();
+    }
 }
 
 ss::future<> compaction_scheduler::compaction_scheduling_loop() {
     vlog(compaction_log.debug, "Starting compaction scheduling loop");
-    while (!_gate.is_closed() && !_as.abort_requested()) {
-        auto compaction_interval = _compaction_interval();
+    while (should_run_compaction_loop()) {
         try {
-            co_await _compaction_sem.wait(
-              _compaction_interval(),
-              std::max(_compaction_sem.current(), size_t(1)));
-        } catch (const ss::semaphore_timed_out&) {
-            // Fall through
+            co_await do_compaction_scheduling();
+        } catch (...) {
+            auto e = std::current_exception();
+            vlogl(
+              compaction_log,
+              ssx::is_shutdown_exception(e) ? ss::log_level::debug
+                                            : ss::log_level::warn,
+              "Compaction scheduling iteration failed: {}",
+              e);
         }
-
-        if (compaction_interval != _compaction_interval()) {
-            // Cluster config was changed while waiting.
-            continue;
-        }
-
-        co_await _log_info_collector.collect_compaction_info(
-          _logs, _logs_list, _compaction_queue);
-
-        _probe.set_compaction_queue_length(_compaction_queue.size());
-
-        co_await _worker_manager.alert_compaction_workers();
     }
+}
+
+ss::future<> compaction_scheduler::do_compaction_scheduling() {
+    auto compaction_interval = _compaction_interval();
+    try {
+        co_await _compaction_sem.wait(
+          _compaction_interval(),
+          std::max(_compaction_sem.current(), size_t(1)));
+    } catch (const ss::semaphore_timed_out&) {
+        // Fall through
+    }
+
+    if (!should_run_compaction_loop()) {
+        co_return;
+    }
+
+    if (compaction_interval != _compaction_interval()) {
+        // Cluster config was changed while waiting.
+        co_return;
+    }
+
+    co_await _log_info_collector.collect_compaction_info(
+      _logs, _logs_list, _compaction_queue);
+
+    _probe.set_compaction_queue_length(_compaction_queue.size());
+
+    co_await _worker_manager.alert_compaction_workers();
 }
 
 ss::future<> compaction_scheduler::leveling_scheduling_loop() {
     vlog(compaction_log.debug, "Starting leveling scheduling loop");
-    while (!_gate.is_closed() && !_as.abort_requested()) {
-        auto leveling_interval = _leveling_interval();
+    while (should_run_leveling_loop()) {
         try {
-            co_await _leveling_sem.wait(
-              _leveling_interval(),
-              std::max(_leveling_sem.current(), size_t(1)));
-        } catch (const ss::semaphore_timed_out&) {
-            // Fall through
+            co_await do_leveling_scheduling();
+        } catch (...) {
+            auto e = std::current_exception();
+            vlogl(
+              compaction_log,
+              ssx::is_shutdown_exception(e) ? ss::log_level::debug
+                                            : ss::log_level::warn,
+              "Leveling scheduling iteration failed: {}",
+              e);
         }
-
-        if (leveling_interval != _leveling_interval()) {
-            // Cluster config was changed while waiting.
-            continue;
-        }
-
-        co_await _log_info_collector.collect_leveling_info(
-          _logs, _logs_list, _leveling_queue);
-
-        _probe.set_leveling_queue_length(_leveling_queue.size());
-
-        co_await _worker_manager.alert_leveling_workers();
     }
+}
+
+ss::future<> compaction_scheduler::do_leveling_scheduling() {
+    auto leveling_interval = _leveling_interval();
+    try {
+        co_await _leveling_sem.wait(
+          _leveling_interval(), std::max(_leveling_sem.current(), size_t(1)));
+    } catch (const ss::semaphore_timed_out&) {
+        // Fall through
+    }
+
+    if (!should_run_leveling_loop()) {
+        co_return;
+    }
+
+    if (leveling_interval != _leveling_interval()) {
+        co_return;
+    }
+
+    co_await _log_info_collector.collect_leveling_info(
+      _logs, _logs_list, _leveling_queue);
+
+    _probe.set_leveling_queue_length(_leveling_queue.size());
+
+    co_await _worker_manager.alert_leveling_workers();
 }
 
 ss::future<> compaction_scheduler::start() {
     _probe.setup_metrics();
     co_await _worker_manager.start();
     co_await _log_collector->start();
-    start_bg_loop();
+    // Arm the config watches before launching the loops, and route the
+    // initial launches through `_scheduler_update_queue` like any other
+    // transition. Each task reads the live binding when it runs, so a toggle
+    // landing at any point during startup is either observed directly or
+    // serialized behind it as a watch task.
+    watch_config_changes();
+    if (!_compaction_disabled()) {
+        _scheduler_update_queue.submit(
+          [this] { return resume_compaction_loop(); });
+    }
+    if (!_leveling_disabled()) {
+        _scheduler_update_queue.submit(
+          [this] { return resume_leveling_loop(); });
+    }
 }
 
 ss::future<> compaction_scheduler::stop() {
     vlog(compaction_log.debug, "Stopping compaction scheduling loop");
     _as.request_abort();
+
+    co_await _scheduler_update_queue.shutdown();
+
+    _compaction_target_loop_state = loop_state::stopped;
+    _leveling_target_loop_state = loop_state::stopped;
+
     _compaction_sem.broken();
     _leveling_sem.broken();
 
@@ -259,6 +408,9 @@ ss::future<> compaction_scheduler::stop() {
 
     // Stop workers and inflight compactions.
     co_await _worker_manager.stop();
+
+    co_await clear_compaction_loop_fut();
+    co_await clear_leveling_loop_fut();
 
     co_await std::move(close_fut);
 }

--- a/src/v/cloud_topics/level_one/maintenance/scheduler.h
+++ b/src/v/cloud_topics/level_one/maintenance/scheduler.h
@@ -24,6 +24,7 @@
 #include "config/property.h"
 #include "model/fundamental.h"
 #include "ssx/semaphore.h"
+#include "ssx/work_queue.h"
 
 class SchedulerTestFixture;
 
@@ -80,16 +81,44 @@ public:
     void unmanage_partition(const model::ntp&, std::string_view);
 
 private:
-    // Starts the backgrounded scheduling loops.
-    void start_bg_loop();
+    // Registers binding watches that drive disabling/enabling maintenance
+    // fibers by submitting start/stop jobs to `_scheduler_update_queue`.
+    void watch_config_changes();
 
-    // The compaction scheduling loop. Invoked in a background fiber until `_as`
-    // has an abort requested or the `_gate` is closed.
+    // The compaction scheduling loop.
     ss::future<> compaction_scheduling_loop();
 
-    // The leveling scheduling loop. Invoked in a background fiber until `_as`
-    // has an abort requested or the `_gate` is closed.
+    // The leveling scheduling loop.
     ss::future<> leveling_scheduling_loop();
+
+    // A single scheduling iteration called from above loops.
+    ss::future<> do_compaction_scheduling();
+    ss::future<> do_leveling_scheduling();
+
+    // True iff the corresponding loop should keep running: the gate is open,
+    // the scheduler-wide abort has not fired, and the loop's target state is
+    // `active`.
+    bool should_run_compaction_loop() const;
+    bool should_run_leveling_loop() const;
+
+    // Sets `_*_target_loop_state = active` and drives the loop toward it:
+    // launches the background maintenance fiber, assigning a value to
+    // `_*_loop_fut` while resuming underlying workers. No-ops once the
+    // scheduler is shutting down.
+    ss::future<> resume_compaction_loop();
+    ss::future<> resume_leveling_loop();
+
+    // Sets `_*_target_loop_state = paused` and drives the loop toward it:
+    // tears down the background maintenance fiber, clearing `_*_loop_fut`
+    // while pausing underlying workers. No-ops once the scheduler is shutting
+    // down.
+    ss::future<> pause_compaction_loop();
+    ss::future<> pause_leveling_loop();
+
+    // Join a loop's fiber and clear its future (no-op if not running). Mirrors
+    // the per-shard worker's `clear_*_work_fut`.
+    ss::future<> clear_compaction_loop_fut();
+    ss::future<> clear_leveling_loop_fut();
 
 private:
     // Pointer to sharded `file_io` held by `app`. Used by the `worker_manager`
@@ -119,6 +148,9 @@ private:
     // The interval on which the leveling loop is executed.
     config::binding<std::chrono::milliseconds> _leveling_interval;
 
+    config::binding<bool> _compaction_disabled;
+    config::binding<bool> _leveling_disabled;
+
     // This semaphore is used as a way to signal a change to
     // `cloud_topics_compaction_interval_ms` during the `wait()` operation in
     // the compaction scheduling loop.
@@ -147,6 +179,27 @@ private:
     // leveling fiber on any worker shard, ordered by expected extent
     // reclamation.
     leveling_queue _leveling_queue;
+
+    // Linearizes enable/disable transitions of the scheduling loops so that a
+    // rapid disable/enable can't race the asynchronous teardown of a loop.
+    ssx::work_queue _scheduler_update_queue;
+
+    // Per-loop *target* lifecycle state: what we want the loop to become, not
+    // what it currently is. Each linearized transition task records the new
+    // desire here as its first act and then drives the loop toward it; the
+    // loop's fiber keeps running only while the target remains `active`. The
+    // actual state is derived: the fiber is up iff `_*_loop_fut` is engaged.
+    // * `active`: the loop should be running and scheduling work.
+    // * `paused`: disabled via the disablement configs. The fiber is torn
+    //    down (`_loop_fut == std::nullopt`) until re-enabled.
+    // * `stopped`: the scheduler is shutting down; terminal.
+    enum class loop_state { active, paused, stopped };
+    loop_state _compaction_target_loop_state{loop_state::paused};
+    loop_state _leveling_target_loop_state{loop_state::paused};
+
+    // The scheduling-loop fibers, if running.
+    std::optional<ss::future<>> _compaction_loop_fut;
+    std::optional<ss::future<>> _leveling_loop_fut;
 
     // TODO: remove this once more cluster objects speak `topic_id_partition`.
     chunked_hash_map<model::ntp, model::topic_id_partition> _ntp_to_tidp;

--- a/src/v/cloud_topics/level_one/maintenance/tests/scheduler_fixture.h
+++ b/src/v/cloud_topics/level_one/maintenance/tests/scheduler_fixture.h
@@ -70,7 +70,8 @@ public:
           nullptr);
         co_await scheduler->_worker_manager._workers.invoke_on_all(
           &l1::compaction_worker::start);
-        scheduler->start_bg_loop();
+        co_await scheduler->resume_compaction_loop();
+        co_await scheduler->resume_leveling_loop();
         co_return;
     }
 
@@ -99,6 +100,42 @@ public:
     ss::future<> resume_worker(ss::shard_id shard) {
         co_await scheduler->_worker_manager.resume_worker(shard);
     }
+
+    // ── Scheduling-loop disable/enable accessors ────────────────────
+    // The scheduler's loop lifecycle is private; the fixture is a friend.
+
+    using loop_state = l1::compaction_scheduler::loop_state;
+
+    loop_state compaction_loop_state() {
+        return scheduler->_compaction_target_loop_state;
+    }
+    loop_state leveling_loop_state() {
+        return scheduler->_leveling_target_loop_state;
+    }
+    bool compaction_loop_running() {
+        return scheduler->_compaction_loop_fut.has_value();
+    }
+    bool leveling_loop_running() {
+        return scheduler->_leveling_loop_fut.has_value();
+    }
+
+    ss::future<> pause_compaction_loop() {
+        return scheduler->pause_compaction_loop();
+    }
+    ss::future<> resume_compaction_loop() {
+        return scheduler->resume_compaction_loop();
+    }
+    ss::future<> pause_leveling_loop() {
+        return scheduler->pause_leveling_loop();
+    }
+    ss::future<> resume_leveling_loop() {
+        return scheduler->resume_leveling_loop();
+    }
+
+    // Arms the `cloud_topics_{compaction,leveling}_disabled` config watches.
+    // The real `start()` does this; `start_scheduler()` above launches the
+    // loops directly without it, so tests exercising the config path call this.
+    void arm_config_watches() { scheduler->watch_config_changes(); }
 
     ss::future<> TearDownAsync() override { co_await scheduler->stop(); }
 

--- a/src/v/cloud_topics/level_one/maintenance/tests/scheduler_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/tests/scheduler_test.cc
@@ -14,6 +14,7 @@
 #include "model/tests/random_batch.h"
 #include "random/generators.h"
 #include "storage/tests/batch_generators.h"
+#include "test_utils/async.h"
 #include "test_utils/scoped_config.h"
 
 #include <gtest/gtest.h>
@@ -35,6 +36,85 @@ TEST_F(SchedulerTestFixture, UnmanageEvictsQueuedEntry) {
     scheduler->unmanage_partition(ntp, "test");
     ASSERT_FALSE(compaction_queue_contains(tidp));
     ASSERT_EQ(compaction_queue_size(), 0u);
+}
+
+// Disabling the compaction loop tears down its fiber and flips it to `paused`,
+// independently of leveling; re-enabling brings it back to `active`.
+TEST_F(SchedulerTestFixture, DisableEnableCompactionLoop) {
+    // start_scheduler() launched both loops.
+    ASSERT_EQ(compaction_loop_state(), loop_state::active);
+    ASSERT_TRUE(compaction_loop_running());
+
+    pause_compaction_loop().get();
+    ASSERT_EQ(compaction_loop_state(), loop_state::paused);
+    ASSERT_FALSE(compaction_loop_running());
+    // Leveling is unaffected.
+    ASSERT_EQ(leveling_loop_state(), loop_state::active);
+    ASSERT_TRUE(leveling_loop_running());
+
+    resume_compaction_loop().get();
+    ASSERT_EQ(compaction_loop_state(), loop_state::active);
+    ASSERT_TRUE(compaction_loop_running());
+}
+
+// Symmetric to the above: leveling disable/enable leaves compaction running.
+TEST_F(SchedulerTestFixture, DisableEnableLevelingLoop) {
+    ASSERT_EQ(leveling_loop_state(), loop_state::active);
+    ASSERT_TRUE(leveling_loop_running());
+
+    pause_leveling_loop().get();
+    ASSERT_EQ(leveling_loop_state(), loop_state::paused);
+    ASSERT_FALSE(leveling_loop_running());
+    ASSERT_EQ(compaction_loop_state(), loop_state::active);
+    ASSERT_TRUE(compaction_loop_running());
+
+    resume_leveling_loop().get();
+    ASSERT_EQ(leveling_loop_state(), loop_state::active);
+    ASSERT_TRUE(leveling_loop_running());
+}
+
+// Disabling drops any queued (not-yet-dispatched) work, so resumed/other
+// workers don't pick up stale jobs.
+TEST_F(SchedulerTestFixture, DisableDrainsCompactionQueue) {
+    auto [ntp, tidp] = make_ntidp("drain-me");
+    scheduler->manage_partition(ntp, tidp, "test");
+    enqueue_for_compaction(tidp);
+    ASSERT_EQ(compaction_queue_size(), 1u);
+
+    pause_compaction_loop().get();
+    ASSERT_EQ(compaction_queue_size(), 0u);
+}
+
+// Redundant disable/enable calls are no-ops, not a crash, double-spawn, or
+// double-join.
+TEST_F(SchedulerTestFixture, DisableEnableIdempotent) {
+    pause_compaction_loop().get();
+    pause_compaction_loop().get(); // already paused
+    ASSERT_FALSE(compaction_loop_running());
+    ASSERT_EQ(compaction_loop_state(), loop_state::paused);
+
+    resume_compaction_loop().get();
+    resume_compaction_loop().get(); // already running
+    ASSERT_TRUE(compaction_loop_running());
+    ASSERT_EQ(compaction_loop_state(), loop_state::active);
+}
+
+// Drives the real path: `cloud_topics_compaction_disabled` -> binding watch ->
+// `_scheduler_update_queue` -> pause/resume of the loop.
+TEST_F(SchedulerTestFixture, DisableEnableViaConfig) {
+    arm_config_watches();
+    scoped_config cfg;
+
+    cfg.get("cloud_topics_compaction_disabled").set_value(true);
+    RPTEST_REQUIRE_EVENTUALLY(
+      5s, [this] { return !compaction_loop_running(); });
+    ASSERT_EQ(compaction_loop_state(), loop_state::paused);
+    // Leveling stays up: the switches are independent.
+    ASSERT_TRUE(leveling_loop_running());
+
+    cfg.get("cloud_topics_compaction_disabled").set_value(false);
+    RPTEST_REQUIRE_EVENTUALLY(5s, [this] { return compaction_loop_running(); });
+    ASSERT_EQ(compaction_loop_state(), loop_state::active);
 }
 
 // This test produces data and stresses concurrent addition and removal of ntps

--- a/src/v/cloud_topics/level_one/maintenance/tests/worker_manager_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/tests/worker_manager_test.cc
@@ -37,7 +37,10 @@ public:
           nullptr,
           ss::default_scheduling_group(),
           nullptr);
-        co_await manager._workers.invoke_on_all(&l1::compaction_worker::start);
+        co_await manager._workers.invoke_on_all(
+          &l1::compaction_worker::resume_compaction_work_loop);
+        co_await manager._workers.invoke_on_all(
+          &l1::compaction_worker::resume_leveling_work_loop);
     }
 
     ss::future<l1::compaction_worker::worker_state>

--- a/src/v/cloud_topics/level_one/maintenance/tests/worker_manager_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/tests/worker_manager_test.cc
@@ -41,10 +41,19 @@ public:
     }
 
     ss::future<l1::compaction_worker::worker_state>
-    get_worker_state(l1::worker_manager& manager, ss::shard_id shard) {
+    get_compaction_state(l1::worker_manager& manager, ss::shard_id shard) {
         return manager._workers.invoke_on(
-          shard,
-          [](l1::compaction_worker& worker) { return worker._worker_state; });
+          shard, [](l1::compaction_worker& worker) {
+              return worker._worker_target_compaction_state;
+          });
+    }
+
+    ss::future<l1::compaction_worker::worker_state>
+    get_leveling_state(l1::worker_manager& manager, ss::shard_id shard) {
+        return manager._workers.invoke_on(
+          shard, [](l1::compaction_worker& worker) {
+              return worker._worker_target_leveling_state;
+          });
     }
 
     ss::future<bool>
@@ -116,18 +125,40 @@ TEST_F(WorkerManagerTestFixture, PauseAndResumeWorkers) {
     auto stop_manager = ss::defer([&manager] { manager.stop().get(); });
     using worker_state = l1::compaction_worker::worker_state;
     for (ss::shard_id i = 0; i < ss::this_smp_shard_count(); ++i) {
-        // Workers start in active state
-        ASSERT_EQ(get_worker_state(manager, i).get(), worker_state::active);
+        // Both kinds start active with both loop fibers running.
+        ASSERT_EQ(get_compaction_state(manager, i).get(), worker_state::active);
+        ASSERT_EQ(get_leveling_state(manager, i).get(), worker_state::active);
         ASSERT_TRUE(work_fut_has_value(manager, i).get());
 
-        // Pause workers and expect to see state reflect that.
-        manager.pause_worker(i).get();
-        ASSERT_EQ(get_worker_state(manager, i).get(), worker_state::paused);
+        // Pausing only compaction leaves leveling running.
+        manager.pause_worker(i, l1::maintenance_job_type::compaction).get();
+        ASSERT_EQ(get_compaction_state(manager, i).get(), worker_state::paused);
+        ASSERT_EQ(get_leveling_state(manager, i).get(), worker_state::active);
+
+        // Pausing leveling too tears down both loop fibers.
+        manager.pause_worker(i, l1::maintenance_job_type::leveling).get();
+        ASSERT_EQ(get_compaction_state(manager, i).get(), worker_state::paused);
+        ASSERT_EQ(get_leveling_state(manager, i).get(), worker_state::paused);
         ASSERT_FALSE(work_fut_has_value(manager, i).get());
 
-        // Resume workers and expect to see active state.
+        // A whole-worker resume brings both kinds back to active.
         manager.resume_worker(i).get();
-        ASSERT_EQ(get_worker_state(manager, i).get(), worker_state::active);
+        ASSERT_EQ(get_compaction_state(manager, i).get(), worker_state::active);
+        ASSERT_EQ(get_leveling_state(manager, i).get(), worker_state::active);
+        ASSERT_TRUE(work_fut_has_value(manager, i).get());
+
+        // A whole-worker pause followed by per-kind resumes round-trips.
+        manager.pause_worker(i).get();
+        ASSERT_EQ(get_compaction_state(manager, i).get(), worker_state::paused);
+        ASSERT_EQ(get_leveling_state(manager, i).get(), worker_state::paused);
+
+        manager.resume_worker(i, l1::maintenance_job_type::leveling).get();
+        ASSERT_EQ(get_compaction_state(manager, i).get(), worker_state::paused);
+        ASSERT_EQ(get_leveling_state(manager, i).get(), worker_state::active);
+
+        manager.resume_worker(i, l1::maintenance_job_type::compaction).get();
+        ASSERT_EQ(get_compaction_state(manager, i).get(), worker_state::active);
+        ASSERT_EQ(get_leveling_state(manager, i).get(), worker_state::active);
         ASSERT_TRUE(work_fut_has_value(manager, i).get());
     }
 }
@@ -392,7 +423,8 @@ TEST_F(WorkerManagerTestFixture, PauseWaitsForInflightLevelingJobs) {
     // Once the job winds down, pause must complete.
     drain_inflight_leveling(manager, shard).get();
     std::move(pause_fut).get();
-    ASSERT_EQ(get_worker_state(manager, shard).get(), worker_state::paused);
+    ASSERT_EQ(get_compaction_state(manager, shard).get(), worker_state::paused);
+    ASSERT_EQ(get_leveling_state(manager, shard).get(), worker_state::paused);
 }
 
 // Verifies that `dirty_ratio_scheduling_policy` orders partitions from

--- a/src/v/cloud_topics/level_one/maintenance/worker.cc
+++ b/src/v/cloud_topics/level_one/maintenance/worker.cc
@@ -83,23 +83,29 @@ compaction_worker::compaction_worker(
 
 ss::future<> compaction_worker::start() {
     _probe.setup_metrics();
-    start_work_loop();
+    resume_compaction_work_loop();
+    resume_leveling_work_loop();
     co_return;
 }
 
 ss::future<> compaction_worker::stop() {
-    terminate_compaction_job();
-    terminate_leveling_jobs();
-    _worker_state = worker_state::stopped;
     _as.request_abort();
-    _compaction_cv.broken();
-    _leveling_cv.broken();
 
     co_await _worker_update_queue.shutdown();
 
+    _worker_target_compaction_state = worker_state::stopped;
+    _worker_target_leveling_state = worker_state::stopped;
+
+    _compaction_cv.broken();
+    _leveling_cv.broken();
+
+    terminate_compaction_job();
+    terminate_leveling_jobs();
+
     auto close_fut = _gate.close();
 
-    co_await clear_work_futs();
+    co_await clear_compaction_work_fut();
+    co_await clear_leveling_work_fut();
 
     if (_map) {
         co_await _map->initialize(0);
@@ -109,22 +115,71 @@ ss::future<> compaction_worker::stop() {
     co_await std::move(close_fut);
 }
 
-void compaction_worker::start_work_loop() {
-    vassert(
-      !_compaction_work_fut.has_value() && !_leveling_work_fut.has_value(),
-      "Cannot start work loops when either is already running.");
+void compaction_worker::resume_compaction_work_loop() {
+    if (_worker_target_compaction_state == worker_state::stopped) {
+        return;
+    }
+    _worker_target_compaction_state = worker_state::active;
+    if (_compaction_work_fut.has_value()) {
+        return;
+    }
     _compaction_work_fut = ssx::spawn_with_gate_then(_gate, [this]() {
         return ss::with_scheduling_group(
           _compaction_sg, [this]() { return compaction_work_loop(); });
     });
+}
+
+void compaction_worker::resume_leveling_work_loop() {
+    if (_worker_target_leveling_state == worker_state::stopped) {
+        return;
+    }
+    _worker_target_leveling_state = worker_state::active;
+    if (_leveling_work_fut.has_value()) {
+        return;
+    }
     _leveling_work_fut = ssx::spawn_with_gate_then(_gate, [this]() {
         return ss::with_scheduling_group(
           _compaction_sg, [this]() { return leveling_work_loop(); });
     });
 }
 
+ss::future<> compaction_worker::pause_compaction_work_loop() {
+    if (_worker_target_compaction_state == worker_state::stopped) {
+        co_return;
+    }
+    _worker_target_compaction_state = worker_state::paused;
+    if (!_compaction_work_fut.has_value()) {
+        co_return;
+    }
+    vlog(compaction_log.info, "Pausing compaction loop on worker");
+    interrupt_compaction_job();
+    alert_compaction_fiber();
+    co_await clear_compaction_work_fut();
+}
+
+ss::future<> compaction_worker::pause_leveling_work_loop() {
+    if (_worker_target_leveling_state == worker_state::stopped) {
+        co_return;
+    }
+    _worker_target_leveling_state = worker_state::paused;
+    if (!_leveling_work_fut.has_value()) {
+        co_return;
+    }
+    vlog(compaction_log.info, "Pausing leveling loop on worker");
+    interrupt_leveling_jobs();
+    alert_leveling_fiber();
+    co_await clear_leveling_work_fut();
+
+    // `clear_leveling_work_fut` only awaits the loop future. Leveling jobs
+    // are backgrounded, and leveling is not effectively paused until they
+    // resolve.
+    co_await _leveling_drained_cv.wait(
+      [this] { return _inflight_leveling.empty(); });
+}
+
 ss::future<> compaction_worker::compaction_work_loop() {
-    while (is_active()) {
+    vlog(compaction_log.info, "Started compaction work loop");
+    while (should_run_compaction()) {
         auto poll_interval = _compaction_poll_interval();
         try {
             co_await _compaction_cv.wait(_compaction_poll_interval());
@@ -137,7 +192,7 @@ ss::future<> compaction_worker::compaction_work_loop() {
             continue;
         }
 
-        while (is_active()) {
+        while (should_run_compaction()) {
             auto maybe_work
               = co_await try_acquire_compaction_work_from_manager();
 
@@ -191,7 +246,8 @@ ss::future<> compaction_worker::level_range(
 }
 
 ss::future<> compaction_worker::leveling_work_loop() {
-    while (is_active()) {
+    vlog(compaction_log.info, "Started leveling work loop");
+    while (should_run_leveling()) {
         auto poll_interval = _leveling_poll_interval();
         try {
             co_await _leveling_cv.wait(poll_interval);
@@ -204,7 +260,7 @@ ss::future<> compaction_worker::leveling_work_loop() {
             continue;
         }
 
-        while (is_active()) {
+        while (should_run_leveling()) {
             auto units_opt = _leveling_sem.try_get_units(1);
             if (!units_opt.has_value()) {
                 break;
@@ -228,11 +284,14 @@ ss::future<> compaction_worker::leveling_work_loop() {
     }
 }
 
-ss::future<> compaction_worker::clear_work_futs() {
+ss::future<> compaction_worker::clear_compaction_work_fut() {
     if (_compaction_work_fut.has_value()) {
         co_await std::move(_compaction_work_fut).value();
         _compaction_work_fut.reset();
     }
+}
+
+ss::future<> compaction_worker::clear_leveling_work_fut() {
     if (_leveling_work_fut.has_value()) {
         co_await std::move(_leveling_work_fut).value();
         _leveling_work_fut.reset();
@@ -240,7 +299,7 @@ ss::future<> compaction_worker::clear_work_futs() {
 }
 
 ss::future<> compaction_worker::compact_log(compaction_job* job) {
-    if (!is_active()) {
+    if (!should_run_compaction()) {
         co_return;
     }
 
@@ -364,7 +423,7 @@ ss::future<> compaction_worker::compact_log(compaction_job* job) {
 }
 
 ss::future<> compaction_worker::do_level_range(leveling_job* job) {
-    if (!is_active()) {
+    if (!should_run_leveling()) {
         co_return;
     }
 
@@ -490,9 +549,14 @@ ss::future<> compaction_worker::complete_leveling_work_on_manager(
       });
 }
 
-bool compaction_worker::is_active() const {
+bool compaction_worker::should_run_compaction() const {
     return !_gate.is_closed() && !_as.abort_requested()
-           && _worker_state == worker_state::active;
+           && _worker_target_compaction_state == worker_state::active;
+}
+
+bool compaction_worker::should_run_leveling() const {
+    return !_gate.is_closed() && !_as.abort_requested()
+           && _worker_target_leveling_state == worker_state::active;
 }
 
 void compaction_worker::interrupt_compaction_job() {
@@ -515,67 +579,58 @@ void compaction_worker::terminate_compaction_job() {
     _compaction_job_state = compaction_job_state::hard_stop;
 }
 
-ss::future<> compaction_worker::pause_worker() {
+void compaction_worker::interrupt_leveling_jobs() {
+    for (auto& [_, handle] : _inflight_leveling) {
+        handle->state = compaction_job_state::soft_stop;
+    }
+}
+
+ss::future<> compaction_worker::pause_worker(maintenance_job_type kind) {
     ss::promise<> p;
-    _worker_update_queue.submit(
-      [&, this] { return do_pause_worker().finally([&] { p.set_value(); }); });
+    _worker_update_queue.submit([&, this] {
+        return do_pause_worker(kind).finally([&] { p.set_value(); });
+    });
     co_await p.get_future();
 }
 
-ss::future<> compaction_worker::do_pause_worker() {
-    // If worker is `stopped`, we shouldn't be able to resume it. If it is
-    // already `paused`, this is a no-op.
-    if (_worker_state != worker_state::active) {
-        co_return;
+ss::future<> compaction_worker::do_pause_worker(maintenance_job_type kind) {
+    const bool pause_compaction = kind == maintenance_job_type::compaction
+                                  || kind == maintenance_job_type::all;
+    const bool pause_leveling = kind == maintenance_job_type::leveling
+                                || kind == maintenance_job_type::all;
+
+    if (pause_compaction) {
+        co_await pause_compaction_work_loop();
     }
 
-    vlog(
-      compaction_log.info,
-      "Pausing compaction worker on shard {}",
-      ss::this_shard_id());
-
-    interrupt_compaction_job();
-    interrupt_leveling_jobs();
-
-    _worker_state = worker_state::paused;
-    // Signal both fibers in case they are currently waiting.
-    alert_compaction_fiber();
-    alert_leveling_fiber();
-    co_await clear_work_futs();
-
-    // `clear_work_futs` only awaits the loop futures. Leveling jobs are
-    // backgrounded, and the worker is not effectively paused until they
-    // resolve.
-    co_await _leveling_drained_cv.wait(
-      [this] { return _inflight_leveling.empty(); });
-
-    vlog(
-      compaction_log.info,
-      "Paused compaction worker on shard {}",
-      ss::this_shard_id());
+    if (pause_leveling) {
+        co_await pause_leveling_work_loop();
+    }
 }
 
-ss::future<> compaction_worker::resume_worker() {
+ss::future<> compaction_worker::resume_worker(maintenance_job_type kind) {
     ss::promise<> p;
-    _worker_update_queue.submit(
-      [&, this] { return do_resume_worker().finally([&] { p.set_value(); }); });
+    _worker_update_queue.submit([&, this] {
+        return do_resume_worker(kind).finally([&] { p.set_value(); });
+    });
     co_await p.get_future();
 }
 
-ss::future<> compaction_worker::do_resume_worker() {
-    // If worker is `stopped`, we shouldn't be able to resume it. If it is
-    // already `active`, this is a no-op.
-    if (_worker_state != worker_state::paused) {
-        co_return;
+ss::future<> compaction_worker::do_resume_worker(maintenance_job_type kind) {
+    const bool resume_compaction = kind == maintenance_job_type::compaction
+                                   || kind == maintenance_job_type::all;
+    const bool resume_leveling = kind == maintenance_job_type::leveling
+                                 || kind == maintenance_job_type::all;
+
+    if (resume_compaction) {
+        resume_compaction_work_loop();
     }
 
-    // Set state back to active and start a new background loop.
-    _worker_state = worker_state::active;
-    start_work_loop();
-    vlog(
-      compaction_log.info,
-      "Resumed compaction worker on shard {}",
-      ss::this_shard_id());
+    if (resume_leveling) {
+        resume_leveling_work_loop();
+    }
+
+    co_return;
 }
 
 void compaction_worker::alert_compaction_fiber() { _compaction_cv.signal(); }
@@ -585,12 +640,6 @@ void compaction_worker::alert_leveling_fiber() { _leveling_cv.signal(); }
 void compaction_worker::terminate_leveling_jobs() {
     for (auto& [_, handle] : _inflight_leveling) {
         handle->state = compaction_job_state::hard_stop;
-    }
-}
-
-void compaction_worker::interrupt_leveling_jobs() {
-    for (auto& [_, handle] : _inflight_leveling) {
-        handle->state = compaction_job_state::soft_stop;
     }
 }
 

--- a/src/v/cloud_topics/level_one/maintenance/worker.cc
+++ b/src/v/cloud_topics/level_one/maintenance/worker.cc
@@ -83,8 +83,6 @@ compaction_worker::compaction_worker(
 
 ss::future<> compaction_worker::start() {
     _probe.setup_metrics();
-    resume_compaction_work_loop();
-    resume_leveling_work_loop();
     co_return;
 }
 

--- a/src/v/cloud_topics/level_one/maintenance/worker.h
+++ b/src/v/cloud_topics/level_one/maintenance/worker.h
@@ -34,6 +34,9 @@ namespace cloud_topics::l1 {
 
 class worker_manager;
 
+// Selects which job(s) of maintenance work a pause/resume applies to.
+enum class maintenance_job_type { compaction, leveling, all };
+
 // A per-shard worker that accepts compaction and leveling jobs and performs
 // either de-duplication (for compaction) or rewrites (for leveling) using a
 // `sink`, `source`, and `reducer`. Can be pre-empted to either cancel or stop
@@ -58,10 +61,10 @@ public:
     // Launches background loop.
     ss::future<> start();
 
-    // Closes concurrency primitives and sets `_compaction_job_state` and
-    // `_worker_state` to `stopped` to indicate to a potential inflight
-    // compaction job that it should exit early before waiting on and clearing
-    // `_compaction_work_fut`.
+    // Closes concurrency primitives and sets `_compaction_job_state` and both
+    // per-job worker states to `stopped` to indicate to a potential inflight
+    // compaction/leveling job that it should exit early before waiting on and
+    // clearing the `*_work_fut`s.
     ss::future<> stop();
 
     // Sets `_state = compaction_job_state::soft_stop`. This is a request to
@@ -85,11 +88,14 @@ public:
     // after this function is called.
     void terminate_compaction_job();
 
-    // Submits a `do_pause_worker()` job to the `_worker_update_queue`.
-    ss::future<> pause_worker();
+    // Submits a `do_pause_worker()` job to the `_worker_update_queue`, pausing
+    // the requested type(s) of work (compaction, leveling, or all) on this
+    // worker.
+    ss::future<> pause_worker(maintenance_job_type);
 
-    // Submits a `do_resume_worker()` job to the `_worker_update_queue`.
-    ss::future<> resume_worker();
+    // Submits a `do_resume_worker()` job to the `_worker_update_queue`,
+    // resuming the requested type(s) of work on this worker.
+    ss::future<> resume_worker(maintenance_job_type);
 
     // Alert the compaction fiber that new compaction work may be available.
     void alert_compaction_fiber();
@@ -100,17 +106,17 @@ public:
     // Hard-stops every inflight leveling job for every tidp on this worker.
     void terminate_leveling_jobs();
 
-    // Soft-stops every inflight leveling job on this worker, requesting a
-    // graceful wind-down. Used on pause, mirroring `interrupt_compaction_job`.
-    void interrupt_leveling_jobs();
-
     // Hard-stops every inflight leveling job for the given tidp on this worker.
     void terminate_leveling_jobs_for_tidp(model::topic_id_partition);
 
 private:
-    // Kicks off the two backgrounded loops held in `_compaction_work_fut` and
-    // `_leveling_work_fut`.
-    void start_work_loop();
+    // Launches a single backgrounded loop into its `*_work_fut`, if not
+    // already running.
+    void resume_compaction_work_loop();
+    void resume_leveling_work_loop();
+
+    ss::future<> pause_compaction_work_loop();
+    ss::future<> pause_leveling_work_loop();
 
     // The compaction loop which waits for jobs to become available.
     ss::future<> compaction_work_loop();
@@ -120,21 +126,23 @@ private:
     // via an `adjustable_semaphore` slot pool.
     ss::future<> leveling_work_loop();
 
-    // Waits for both background loops to resolve and clears their values.
-    ss::future<> clear_work_futs();
+    // Joins a single loop's future and clears it.
+    ss::future<> clear_compaction_work_fut();
+    ss::future<> clear_leveling_work_fut();
 
-    // Pauses the compaction worker by setting `_worker_state` to `paused` and
-    // waits for the backgrounded `_compaction_work_fut` to complete.
-    // `_compaction_work_fut` is left as `std::nullopt` as a result of this
-    // function- no new compaction jobs will be processed until the worker is
-    // resumed. If `_worker_state` is not `active`, this function is a no-op.
-    ss::future<> do_pause_worker();
+    // Soft-stops every inflight leveling job on this worker (a graceful
+    // wind-down request), e.g. when leveling is paused.
+    void interrupt_leveling_jobs();
 
-    // Resumes the compaction worker by setting `_worker_state` to `active` and
-    // launches a new backgrounded job held in `_compaction_work_fut`, allowing
-    // this worker to process new compaction jobs. If `_worker_state` is not
-    // `paused`, this function is a no-op.
-    ss::future<> do_resume_worker();
+    // Pauses the requested type(s) of work: interrupts the inflight job(s),
+    // marks the job as paused so its loop won't run, and joins the loop fiber,
+    // leaving the corresponding `*_work_fut` as `std::nullopt`. No new jobs of
+    // that kind are processed until resumed.
+    ss::future<> do_pause_worker(maintenance_job_type);
+
+    // Resumes the requested type(s) of work: clears the paused mark and
+    // relaunches the loop fiber.
+    ss::future<> do_resume_worker(maintenance_job_type);
 
     // Requests a compaction of the provided job's CTP against the metastore
     // sample it carries.
@@ -174,7 +182,8 @@ private:
     // Returns `true` iff the worker is currently in an `active` state. That is,
     // the worker has not been `paused`, nor has it been `stopped` or is in the
     // process of shutdown.
-    bool is_active() const;
+    bool should_run_compaction() const;
+    bool should_run_leveling() const;
 
 private:
     friend class ::WorkerManagerTestFixture;
@@ -191,17 +200,17 @@ private:
     // jobs.
     compaction_job_state _compaction_job_state{compaction_job_state::idle};
 
-    // The state of the worker, which is `active`, `paused`, or `stopped`.
-    // * A worker in an `active` state should have an active
-    // `_compaction_work_fut` value
-    //   which is accepting and completing compaction jobs.
-    // * A worker in a `paused` state has `_compaction_work_fut == std::nullopt`
-    // and is not
-    //   accepting compaction jobs.
+    // The state(s) of the worker, which are `active`, `paused`, or `stopped`.
+    // Compaction and leveling are independent.
+    // * A worker in an `active` state should have an active `_*_work_fut` value
+    //   which is accepting and completing maintenance jobs.
+    // * A worker in a `paused` state has `_*_work_fut == std::nullopt`
+    //   and is not accepting maintenance jobs.
     // * A worker in a `stopped` state is in the process of shutting down and
     //   therefore has its concurrency primitives closed and is not accepting
-    //   compaction jobs.
-    worker_state _worker_state{worker_state::active};
+    //   maintenance jobs.
+    worker_state _worker_target_compaction_state{worker_state::paused};
+    worker_state _worker_target_leveling_state{worker_state::paused};
 
     std::optional<model::ntp> _inflight_ntp;
 

--- a/src/v/cloud_topics/level_one/maintenance/worker_manager.cc
+++ b/src/v/cloud_topics/level_one/maintenance/worker_manager.cc
@@ -234,16 +234,32 @@ ss::future<> worker_manager::alert_leveling_workers() {
       [](compaction_worker& worker) { worker.alert_leveling_fiber(); });
 }
 
-ss::future<> worker_manager::pause_worker(ss::shard_id worker) {
+ss::future<>
+worker_manager::pause_worker(ss::shard_id worker, maintenance_job_type kind) {
     auto guard = _gate.hold();
-    co_await _workers.invoke_on(
-      worker, [](compaction_worker& worker) { return worker.pause_worker(); });
+    co_await _workers.invoke_on(worker, [kind](compaction_worker& worker) {
+        return worker.pause_worker(kind);
+    });
 }
 
-ss::future<> worker_manager::resume_worker(ss::shard_id worker) {
+ss::future<>
+worker_manager::resume_worker(ss::shard_id worker, maintenance_job_type kind) {
     auto guard = _gate.hold();
-    co_await _workers.invoke_on(
-      worker, [](compaction_worker& worker) { return worker.resume_worker(); });
+    co_await _workers.invoke_on(worker, [kind](compaction_worker& worker) {
+        return worker.resume_worker(kind);
+    });
+}
+
+ss::future<> worker_manager::pause_all_workers(maintenance_job_type kind) {
+    auto guard = _gate.hold();
+    co_await _workers.invoke_on_all(
+      [kind](compaction_worker& worker) { return worker.pause_worker(kind); });
+}
+
+ss::future<> worker_manager::resume_all_workers(maintenance_job_type kind) {
+    auto guard = _gate.hold();
+    co_await _workers.invoke_on_all(
+      [kind](compaction_worker& worker) { return worker.resume_worker(kind); });
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/maintenance/worker_manager.h
+++ b/src/v/cloud_topics/level_one/maintenance/worker_manager.h
@@ -106,11 +106,17 @@ public:
     // available in the `_leveling_queue`.
     ss::future<> alert_leveling_workers();
 
-    // Pauses the worker on the provided shard.
-    ss::future<> pause_worker(ss::shard_id);
+    // Pauses/resumes the given kind(s) of maintenance work on the worker at
+    // the provided shard.
+    ss::future<> pause_worker(
+      ss::shard_id, maintenance_job_type = maintenance_job_type::all);
+    ss::future<> resume_worker(
+      ss::shard_id, maintenance_job_type = maintenance_job_type::all);
 
-    // Resumes the worker on the provided shard.
-    ss::future<> resume_worker(ss::shard_id);
+    // Pauses/resumes the given kind(s) of maintenance work on every worker
+    // shard.
+    ss::future<> pause_all_workers(maintenance_job_type);
+    ss::future<> resume_all_workers(maintenance_job_type);
 
 private:
     friend class ::WorkerManagerTestFixture;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4817,6 +4817,18 @@ configuration::configuration()
       "in time and blast radius. Lower values mean more, smaller jobs.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1_GiB)
+  , cloud_topics_compaction_disabled(
+      *this,
+      "cloud_topics_compaction_disabled",
+      "When true, completely disables compaction of cloud topics.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      false)
+  , cloud_topics_leveling_disabled(
+      *this,
+      "cloud_topics_leveling_disabled",
+      "When true, completely disables leveling of cloud topics.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      false)
   , cloud_topics_compaction_key_map_memory(
       *this,
       "cloud_topics_compaction_key_map_memory",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -817,6 +817,8 @@ public:
     bounded_property<double, numeric_bounds>
       cloud_topics_leveling_min_extent_size_ratio;
     property<size_t> cloud_topics_leveling_max_range_bytes;
+    property<bool> cloud_topics_compaction_disabled;
+    property<bool> cloud_topics_leveling_disabled;
     bounded_property<uint64_t> cloud_topics_compaction_key_map_memory;
     property<std::chrono::milliseconds>
       cloud_topics_long_term_garbage_collection_interval;

--- a/tests/rptest/tests/cloud_topics/compaction_stress_test.py
+++ b/tests/rptest/tests/cloud_topics/compaction_stress_test.py
@@ -19,7 +19,6 @@ from rptest.services.kgo_verifier_services import (
     KgoVerifierProducer,
     KgoVerifierSeqConsumer,
 )
-from rptest.services.redpanda import MetricsEndpoint
 from rptest.tests.cloud_topics.e2e_test import EndToEndCloudTopicsBase
 from rptest.utils.mode_checks import is_debug_mode
 
@@ -55,40 +54,7 @@ class CompactionStressBase(EndToEndCloudTopicsBase):
             environment=environment,
         )
 
-    # ── Metric helpers ──────────────────────────────────────────────
-
-    def _metric_sum(self, metric_name: str) -> float:
-        assert self.redpanda
-        return self.redpanda.metric_sum(
-            metric_name=metric_name,
-            metrics_endpoint=MetricsEndpoint.METRICS,
-            expect_metric=True,
-        )
-
-    def get_log_compactions(self) -> float:
-        return self._metric_sum(
-            "vectorized_cloud_topics_compaction_scheduler_log_compactions"
-        )
-
-    def get_records_removed(self) -> float:
-        return self._metric_sum(
-            "vectorized_cloud_topics_compaction_worker_records_removed"
-        )
-
-    def get_managed_logs(self) -> float:
-        return self._metric_sum(
-            "vectorized_cloud_topics_compaction_scheduler_managed_log_count"
-        )
-
     # ── Wait helpers ────────────────────────────────────────────────
-
-    def wait_for_managed_logs(self, timeout_sec: int = 60):
-        wait_until(
-            lambda: self.get_managed_logs() > 0,
-            timeout_sec=timeout_sec,
-            backoff_sec=1,
-            err_msg="Did not see management of compact-enabled CTPs.",
-        )
 
     def wait_for_compaction_rounds(
         self,
@@ -120,53 +86,6 @@ class CompactionStressBase(EndToEndCloudTopicsBase):
                 f"Expected >= {min_removed} records removed, "
                 f"got {self.get_records_removed()}"
             ),
-        )
-
-    def wait_for_compaction_quiesce(
-        self,
-        stable_sec: int = 30,
-        timeout_sec: int = 360,
-    ):
-        """
-        Wait for records_removed to stabilize, meaning compaction has
-        converged and there is nothing left to remove. The metric must
-        remain unchanged for `stable_sec` consecutive seconds.
-        """
-        import time
-
-        # First wait for at least one removal so we know compaction started.
-        wait_until(
-            lambda: self.get_records_removed() > 0,
-            timeout_sec=60,
-            backoff_sec=2,
-            err_msg="Compaction never started removing records",
-        )
-
-        prev = self.get_records_removed()
-        stable_since = time.time()
-
-        def _stable() -> bool:
-            nonlocal prev, stable_since
-            now_removed = self.get_records_removed()
-            if now_removed != prev:
-                self.logger.info(
-                    f"Compaction still active: records_removed {prev} -> {now_removed}"
-                )
-                prev = now_removed
-                stable_since = time.time()
-            return time.time() - stable_since >= stable_sec
-
-        wait_until(
-            _stable,
-            timeout_sec=timeout_sec,
-            backoff_sec=5,
-            err_msg=lambda: (
-                f"Compaction did not quiesce within {timeout_sec}s "
-                f"(records_removed={self.get_records_removed()})"
-            ),
-        )
-        self.logger.info(
-            f"Compaction quiesced: {self.get_records_removed()} records removed"
         )
 
     def produce_and_wait(

--- a/tests/rptest/tests/cloud_topics/e2e_test.py
+++ b/tests/rptest/tests/cloud_topics/e2e_test.py
@@ -13,7 +13,7 @@ from ducktape.tests.test import TestContext
 from typing import Any
 from ducktape.utils.util import wait_until
 from ducktape.mark import matrix
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.rpk import RpkTool
@@ -163,6 +163,150 @@ class EndToEndCloudTopicsBase(EndToEndTest):
         for topic in topics or self.topics:
             for partition in range(topic.partition_count):
                 self.wait_until_reconciled(topic=topic.name, partition=partition)
+
+    # ── L1 maintenance metric helpers ───────────────────────────────
+
+    def _metric_sum(self, metric_name: str) -> float:
+        assert self.redpanda
+        return self.redpanda.metric_sum(
+            metric_name=metric_name,
+            metrics_endpoint=MetricsEndpoint.METRICS,
+            expect_metric=True,
+        )
+
+    def get_managed_logs(self) -> float:
+        return self._metric_sum(
+            "vectorized_cloud_topics_compaction_scheduler_managed_log_count"
+        )
+
+    def get_log_compactions(self) -> float:
+        return self._metric_sum(
+            "vectorized_cloud_topics_compaction_scheduler_log_compactions_total"
+        )
+
+    def get_records_removed(self) -> float:
+        return self._metric_sum(
+            "vectorized_cloud_topics_compaction_worker_records_removed_total"
+        )
+
+    def get_leveling_completed(self) -> float:
+        return self._metric_sum(
+            "vectorized_cloud_topics_compaction_scheduler_leveling_ranges_completed_total"
+        )
+
+    def get_leveling_queue_length(self) -> float:
+        return self._metric_sum(
+            "vectorized_cloud_topics_compaction_scheduler_leveling_queue_length"
+        )
+
+    def get_extents_reclaimed(self) -> float:
+        """Net object/extent-count reduction from committed leveling ranges."""
+        return self._metric_sum(
+            "vectorized_cloud_topics_compaction_worker_leveling_extents_reclaimed_total"
+        )
+
+    # ── L1 maintenance wait helpers ─────────────────────────────────
+
+    def wait_for_managed_logs(self, timeout_sec: int = 60):
+        wait_until(
+            lambda: self.get_managed_logs() > 0,
+            timeout_sec=timeout_sec,
+            backoff_sec=1,
+            err_msg="Did not see management of cloud-topic partitions.",
+        )
+
+    def _wait_for_maintenance_quiesce(
+        self,
+        kind: str,
+        get_progress: Callable[[], float],
+        get_queue_length: Callable[[], float] | None,
+        stable_sec: int,
+        timeout_sec: int,
+    ):
+        """Wait for one kind of L1 maintenance to start and then converge.
+
+        The progress counter must stop advancing for `stable_sec` consecutive
+        seconds AND (when a queue getter is given) the scheduler queue must be
+        drained. Polling `queue_length == 0` alone is unreliable: the
+        collector refills the queue every interval, and work that has been
+        dequeued but not yet committed is not counted there, so the queue can
+        read 0 mid-flight.
+        """
+        # First wait for the maintenance kind to actually start doing work.
+        wait_until(
+            lambda: get_progress() > 0,
+            timeout_sec=60,
+            backoff_sec=2,
+            err_msg=f"{kind} never made any progress",
+        )
+
+        def status() -> str:
+            s = f"progress={get_progress()}"
+            if get_queue_length is not None:
+                s += f", queue_length={get_queue_length()}"
+            return s
+
+        prev = get_progress()
+        stable_since = time.time()
+
+        def _quiesced() -> bool:
+            nonlocal prev, stable_since
+            progress = get_progress()
+            if progress != prev:
+                self.logger.info(f"{kind} still active: {prev} -> {progress}")
+                prev = progress
+                stable_since = time.time()
+                return False
+            # Progress is stable; also require the queue to be empty.
+            if get_queue_length is not None and get_queue_length() != 0:
+                return False
+            return time.time() - stable_since >= stable_sec
+
+        wait_until(
+            _quiesced,
+            timeout_sec=timeout_sec,
+            backoff_sec=5,
+            err_msg=lambda: (
+                f"{kind} did not quiesce within {timeout_sec}s ({status()})"
+            ),
+        )
+        self.logger.info(f"{kind} quiesced ({status()})")
+
+    def wait_for_compaction_quiesce(
+        self,
+        stable_sec: int = 30,
+        timeout_sec: int = 360,
+    ):
+        """
+        Wait for records_removed to stabilize, meaning compaction has
+        converged and there is nothing left to remove.
+        """
+        self._wait_for_maintenance_quiesce(
+            "Compaction",
+            self.get_records_removed,
+            None,
+            stable_sec,
+            timeout_sec,
+        )
+
+    def wait_for_leveling_quiesce(
+        self,
+        stable_sec: int = 30,
+        timeout_sec: int = 360,
+    ):
+        """
+        Wait for leveling to converge: the reclaimed-extents counter must stop
+        changing for `stable_sec` consecutive seconds AND the leveling queue
+        must be drained. Together these mean leveling has folded everything it
+        is going to and there is no pending work.
+        """
+        self._wait_for_maintenance_quiesce(
+            "Leveling",
+            self.get_extents_reclaimed,
+            self.get_leveling_queue_length,
+            stable_sec,
+            timeout_sec,
+        )
 
 
 class EndToEndCloudTopicsTest(EndToEndCloudTopicsBase):
@@ -475,29 +619,6 @@ class EndToEndCloudTopicsCompactionTest(EndToEndCloudTopicsBase):
         self.key_set_cardinality = 100
         self.tombstone_probability = 0.5
 
-    def _metric_sum(self, metric_name):
-        assert self.redpanda
-        return self.redpanda.metric_sum(
-            metric_name=metric_name,
-            metrics_endpoint=MetricsEndpoint.METRICS,
-            expect_metric=True,
-        )
-
-    def get_removed_records(self):
-        return self._metric_sum(
-            "vectorized_cloud_topics_compaction_worker_records_removed_total"
-        )
-
-    def get_log_compactions(self):
-        return self._metric_sum(
-            "vectorized_cloud_topics_compaction_scheduler_log_compactions_total"
-        )
-
-    def get_managed_logs(self):
-        return self._metric_sum(
-            "vectorized_cloud_topics_compaction_scheduler_managed_log_count"
-        )
-
     def produce(self):
         assert self.redpanda
         assert self.topic
@@ -542,15 +663,7 @@ class EndToEndCloudTopicsCompactionTest(EndToEndCloudTopicsBase):
     @cluster(num_nodes=4)
     @matrix(cloud_topics_compaction_key_map_memory_kb=[3, 10, 128 * 1024])
     def test_compact(self, cloud_topics_compaction_key_map_memory_kb):
-        def seen_managed_logs():
-            return self.get_managed_logs() > 0
-
-        wait_until(
-            seen_managed_logs,
-            timeout_sec=60,
-            backoff_sec=1,
-            err_msg="Did not see management of compact-enabled CTPs.",
-        )
+        self.wait_for_managed_logs()
 
         num_rounds = 1
         self.prev_log_compactions = 0.0
@@ -572,7 +685,7 @@ class EndToEndCloudTopicsCompactionTest(EndToEndCloudTopicsBase):
             )
 
             def seen_removed_records():
-                removed_records = self.get_removed_records()
+                removed_records = self.get_records_removed()
                 res = removed_records > self.prev_removed_records
                 self.prev_removed_records = removed_records
                 return res
@@ -646,24 +759,6 @@ class EndToEndCloudTopicsLevelingTest(EndToEndCloudTopicsBase):
         self.msg_size = 4096
         self.msg_count = 20000
 
-    def _metric_sum(self, metric_name):
-        assert self.redpanda
-        return self.redpanda.metric_sum(
-            metric_name=metric_name,
-            metrics_endpoint=MetricsEndpoint.METRICS,
-            expect_metric=True,
-        )
-
-    def get_leveling_queue_length(self):
-        return self._metric_sum(
-            "vectorized_cloud_topics_compaction_scheduler_leveling_queue_length"
-        )
-
-    def get_leveling_completed(self):
-        return self._metric_sum(
-            "vectorized_cloud_topics_compaction_scheduler_leveling_ranges_completed_total"
-        )
-
     def produce(self):
         assert self.redpanda
         assert self.topic
@@ -699,40 +794,6 @@ class EndToEndCloudTopicsLevelingTest(EndToEndCloudTopicsBase):
         finally:
             self.kgo_consumer.stop()
 
-    def wait_for_leveling_quiesce(self, stable_sec: int = 10, timeout_sec: int = 120):
-        """Wait for leveling to converge.
-
-        The completed-ranges counter must stop advancing for `stable_sec`
-        consecutive seconds AND the queue must be empty. Polling
-        `queue_length == 0` alone is unreliable: the collector refills the
-        queue every interval, and ranges that have been dequeued but not yet
-        committed are not counted there, so the queue can read 0 mid-flight.
-        """
-        prev = self.get_leveling_completed()
-        stable_since = time.time()
-
-        def quiesced() -> bool:
-            nonlocal prev, stable_since
-            completed = self.get_leveling_completed()
-            if completed != prev:
-                prev = completed
-                stable_since = time.time()
-                return False
-            if self.get_leveling_queue_length() != 0:
-                return False
-            return time.time() - stable_since >= stable_sec
-
-        wait_until(
-            quiesced,
-            timeout_sec=timeout_sec,
-            backoff_sec=2,
-            err_msg=lambda: (
-                f"Leveling did not quiesce "
-                f"(completed={self.get_leveling_completed()}, "
-                f"queue_length={self.get_leveling_queue_length()})"
-            ),
-        )
-
     @cluster(num_nodes=4)
     def test_per_range_leveling(self):
         self.produce()
@@ -751,3 +812,4 @@ class EndToEndCloudTopicsLevelingTest(EndToEndCloudTopicsBase):
 
         # Read all records back to verify data integrity.
         self.consume()
+

--- a/tests/rptest/tests/cloud_topics/e2e_test.py
+++ b/tests/rptest/tests/cloud_topics/e2e_test.py
@@ -813,3 +813,176 @@ class EndToEndCloudTopicsLevelingTest(EndToEndCloudTopicsBase):
         # Read all records back to verify data integrity.
         self.consume()
 
+
+class EndToEndCloudTopicsMaintenanceToggleTest(EndToEndCloudTopicsBase):
+    """Rapidly flip the compaction and leveling configs
+    (`cloud_topics_compaction_disabled` / `cloud_topics_leveling_disabled`)
+    on and off while a rate-limited producer keeps a compacted topic busy.
+    """
+
+    topics = (
+        TopicSpec(
+            name=EndToEndCloudTopicsBase.s3_topic_name,
+            partition_count=4,
+            replication_factor=3,
+            cleanup_policy=TopicSpec.CLEANUP_COMPACT,
+            min_cleanable_dirty_ratio=0.0,
+            delete_retention_ms=3000,
+        ),
+    )
+
+    kgo_producer: KgoVerifierProducer
+    kgo_consumer: KgoVerifierSeqConsumer
+
+    COMPACTION_INTERVAL_MS = 2000
+    LEVELING_INTERVAL_MS = 2000
+    MAX_CONCURRENT = 4
+    MIN_EXTENT_RATIO = 0.8
+    RECONCILIATION_MAX_OBJECT_SIZE = 4 * 1024 * 1024
+    TARGET_FILL_RATIO = 0.2
+
+    def __init__(self, test_context):
+        extra_rp_conf = {
+            "cloud_topics_compaction_interval_ms": self.COMPACTION_INTERVAL_MS,
+            "cloud_topics_compaction_key_map_memory": 128 * 1024 * 1024,
+            "cloud_topics_leveling_interval_ms": self.LEVELING_INTERVAL_MS,
+            "cloud_topics_max_concurrent_leveling_jobs_per_shard": self.MAX_CONCURRENT,
+            "cloud_topics_leveling_min_extent_size_ratio": self.MIN_EXTENT_RATIO,
+            "cloud_topics_reconciliation_max_object_size": self.RECONCILIATION_MAX_OBJECT_SIZE,
+            "cloud_topics_reconciliation_target_fill_ratio": self.TARGET_FILL_RATIO,
+        }
+        environment = {"__REDPANDA_TEST_DISABLE_BOUNDED_PROPERTY_CHECKS": "ON"}
+        super(EndToEndCloudTopicsMaintenanceToggleTest, self).__init__(
+            test_context,
+            extra_rp_conf,
+            environment,
+        )
+        self.msg_size = 4096
+        # Size the workload (with the rate limit) so the producer is still
+        # sending throughout the toggle window, while keeping the key count
+        # low enough that the topic can fully compact afterwards.
+        self.msg_count = 20_000
+        self.key_set_cardinality = 100
+        self.tombstone_probability = 0.5
+        self.rate_limit_bps = 1024 * 1024  # 1 MB/s (~256 msg/s)
+        self.toggle_duration_sec = 75
+        self.toggle_interval_sec = 2
+
+    def set_maintenance_configs(
+        self, compaction_disabled: bool, leveling_disabled: bool
+    ):
+        assert self.redpanda
+        self.redpanda.set_cluster_config(
+            {
+                "cloud_topics_compaction_disabled": compaction_disabled,
+                "cloud_topics_leveling_disabled": leveling_disabled,
+            }
+        )
+
+    def consume(self, traffic_node):
+        assert self.redpanda
+        assert self.topic
+        self.kgo_consumer = KgoVerifierSeqConsumer(
+            self.test_context,
+            self.redpanda,
+            self.topic,
+            self.msg_size,
+            loop=False,
+            compacted=True,
+            validate_latest_values=True,
+            nodes=[traffic_node],
+        )
+        try:
+            self.kgo_consumer.start(clean=False)
+            self.kgo_consumer.wait()
+        finally:
+            self.kgo_consumer.stop()
+
+    @cluster(num_nodes=4)
+    def test_toggle_maintenance(self):
+        assert self.redpanda is not None
+        assert self.topic is not None
+
+        self.kgo_producer = KgoVerifierProducer(
+            self.test_context,
+            self.redpanda,
+            self.topic,
+            msg_size=self.msg_size,
+            msg_count=self.msg_count,
+            key_set_cardinality=self.key_set_cardinality,
+            tombstone_probability=self.tombstone_probability,
+            rate_limit_bps=self.rate_limit_bps,
+            validate_latest_values=True,
+            tolerate_failed_produce=True,
+        )
+        producer = self.kgo_producer
+        try:
+            producer.start()
+            producer.wait_for_latest_value_map()
+
+            # Flip the two kill switches on independent cadences (every tick
+            # for compaction, every third tick for leveling) so every
+            # combination of enabled/disabled is hit while work is inflight.
+            start = time.time()
+            i = 0
+            while time.time() - start < self.toggle_duration_sec:
+                time.sleep(self.toggle_interval_sec)
+                compaction_disabled = (i % 2) == 0
+                leveling_disabled = (i % 3) == 0
+                self.set_maintenance_configs(compaction_disabled, leveling_disabled)
+                self.logger.info(
+                    f"toggled kill switches: compaction_disabled="
+                    f"{compaction_disabled}, leveling_disabled={leveling_disabled} "
+                    f"(acked={producer.produce_status.acked})"
+                )
+                i += 1
+
+            # Re-enable both kinds so maintenance can drain, then let the
+            # producer run to completion. Stop it before consuming so the
+            # consumer can reuse the (single) traffic node.
+            self.set_maintenance_configs(
+                compaction_disabled=False, leveling_disabled=False
+            )
+            producer.wait(timeout_sec=10 * 60)
+            self.logger.info(
+                f"producer finished with acked={producer.produce_status.acked}, "
+                f"bad_offsets={producer.produce_status.bad_offsets}"
+            )
+            traffic_node = producer.nodes[0]
+        finally:
+            producer.stop()
+
+        # Both kinds had enabled phases during the toggle window, so the
+        # cumulative counters must be nonzero: the toggling never wedged
+        # maintenance outright.
+        assert self.get_log_compactions() > 0, "no compaction rounds ran"
+        assert self.get_leveling_completed() > 0, "no leveling ranges completed"
+
+        # With both kinds re-enabled and the workload finished, maintenance
+        # must converge: drain whatever eligible work remains and stop making
+        # progress. The producer may finish well before the toggle window does
+        # (tombstones halve the average message size under the byte rate
+        # limit), so demanding progress beyond a post-re-enable baseline would
+        # race with maintenance having already drained all eligible work
+        # during the enabled phases of the window; quiescence is the property
+        # the final re-enable actually guarantees.
+        self.wait_for_compaction_quiesce()
+        self.wait_for_leveling_quiesce()
+
+        # Reading the whole compacted log back with latest-value validation
+        # only succeeds once compaction has fully de-duplicated each key, so
+        # retry until the post-chaos topic converges. This both proves data
+        # integrity and that compaction recovers after the toggling.
+        def consumed_latest_values():
+            try:
+                self.consume(traffic_node)
+                return True
+            except Exception:
+                return False
+
+        wait_until(
+            consumed_latest_values,
+            timeout_sec=360,
+            backoff_sec=1,
+            err_msg="Did not see a fully compacted CTP log after toggling",
+        )

--- a/tests/rptest/tests/cloud_topics/leveling_stress_test.py
+++ b/tests/rptest/tests/cloud_topics/leveling_stress_test.py
@@ -7,7 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-import time
 from typing import Any
 
 from ducktape.tests.test import TestContext
@@ -19,7 +18,6 @@ from rptest.services.kgo_verifier_services import (
     KgoVerifierProducer,
     KgoVerifierSeqConsumer,
 )
-from rptest.services.redpanda import MetricsEndpoint
 from rptest.tests.cloud_topics.e2e_test import EndToEndCloudTopicsBase
 from rptest.utils.mode_checks import is_debug_mode
 
@@ -71,47 +69,7 @@ class LevelingStressBase(EndToEndCloudTopicsBase):
             environment=environment,
         )
 
-    # ── Metric helpers ──────────────────────────────────────────────
-
-    def _metric_sum(self, metric_name: str) -> float:
-        assert self.redpanda
-        return self.redpanda.metric_sum(
-            metric_name=metric_name,
-            metrics_endpoint=MetricsEndpoint.METRICS,
-            expect_metric=True,
-        )
-
-    def get_managed_logs(self) -> float:
-        return self._metric_sum(
-            "vectorized_cloud_topics_compaction_scheduler_managed_log_count"
-        )
-
-    def get_leveling_queue_length(self) -> float:
-        return self._metric_sum(
-            "vectorized_cloud_topics_compaction_scheduler_leveling_queue_length"
-        )
-
-    def get_leveling_completed(self) -> float:
-        return self._metric_sum(
-            "vectorized_cloud_topics_compaction_scheduler_"
-            "leveling_ranges_completed_total"
-        )
-
-    def get_extents_reclaimed(self) -> float:
-        """Net object/extent-count reduction from committed leveling ranges."""
-        return self._metric_sum(
-            "vectorized_cloud_topics_compaction_worker_leveling_extents_reclaimed_total"
-        )
-
     # ── Wait helpers ────────────────────────────────────────────────
-
-    def wait_for_managed_logs(self, timeout_sec: int = 60):
-        wait_until(
-            lambda: self.get_managed_logs() > 0,
-            timeout_sec=timeout_sec,
-            backoff_sec=1,
-            err_msg="Did not see management of cloud-topic partitions.",
-        )
 
     def wait_for_extents_reclaimed(
         self,
@@ -127,58 +85,6 @@ class LevelingStressBase(EndToEndCloudTopicsBase):
                 f"Expected >= {min_reclaimed} extents reclaimed, "
                 f"got {self.get_extents_reclaimed()}"
             ),
-        )
-
-    def wait_for_leveling_quiesce(
-        self,
-        stable_sec: int = 30,
-        timeout_sec: int = 360,
-    ):
-        """
-        Wait for leveling to converge: the reclaimed-extents counter must stop
-        changing for `stable_sec` consecutive seconds AND the leveling queue
-        must be drained. Together these mean leveling has folded everything it
-        is going to and there is no pending work.
-        """
-        # First wait for leveling to actually start doing work.
-        wait_until(
-            lambda: self.get_extents_reclaimed() > 0,
-            timeout_sec=60,
-            backoff_sec=2,
-            err_msg="Leveling never reclaimed any extents",
-        )
-
-        prev = self.get_extents_reclaimed()
-        stable_since = time.time()
-
-        def _quiesced() -> bool:
-            nonlocal prev, stable_since
-            now_reclaimed = self.get_extents_reclaimed()
-            if now_reclaimed != prev:
-                self.logger.info(
-                    f"Leveling still active: extents_reclaimed "
-                    f"{prev} -> {now_reclaimed}"
-                )
-                prev = now_reclaimed
-                stable_since = time.time()
-                return False
-            # Counter is stable; also require the queue to be empty.
-            if self.get_leveling_queue_length() != 0:
-                return False
-            return time.time() - stable_since >= stable_sec
-
-        wait_until(
-            _quiesced,
-            timeout_sec=timeout_sec,
-            backoff_sec=5,
-            err_msg=lambda: (
-                f"Leveling did not quiesce within {timeout_sec}s "
-                f"(extents_reclaimed={self.get_extents_reclaimed()}, "
-                f"queue_length={self.get_leveling_queue_length()})"
-            ),
-        )
-        self.logger.info(
-            f"Leveling quiesced: {self.get_extents_reclaimed()} extents reclaimed"
         )
 
     # ── Workflow helpers ────────────────────────────────────────────


### PR DESCRIPTION
* Make `worker::pause/resume` functionalities per maintenance job type
* Add cluster configs `cloud_topics_compaction_disabled`/`cloud_topics_leveling_disabled` which act as off/on switches for all of scheduling and underlying workers for those maintenance jobs in cloud topics
* Add `EndToEndCloudTopicsMaintenanceToggleTest` to stress these levers

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
