### PR TITLE
[CORE-16422] rptest: disable cloud topics metastore flush in ClusterConfigTest

### DIFF
--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -280,6 +280,13 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
         # with cloud configs and prevent uploads from succeeding.
         rp_conf["enable_cluster_metadata_upload_loop"] = False
 
+        # Cloud topics infrastructure now starts whenever cloud_storage_enabled
+        # is true. Tests that point cloud storage at a fake bucket (e.g.
+        # test_cloud_validation) would otherwise have the L1 metastore flush loop
+        # make real object-storage PUTs that fail with a hard S3 error and trip
+        # the bad-log-lines check.
+        rp_conf["cloud_topics_disable_metastore_flush_loop_for_tests"] = True
+
         super(ClusterConfigTest, self).__init__(*args, extra_rp_conf=rp_conf, **kwargs)
 
         self.admin = Admin(self.redpanda)


### PR DESCRIPTION
## Summary

`ClusterConfigTest.test_cloud_validation` has been intermittently failing in CDT
([vtools 29560](https://buildkite.com/redpanda/vtools/builds/29560#019e91a6-e175-4a15-96a7-b2a5b0fc7eee)).
The test logic passes; it fails the post-test `BadLogLines` check after redpanda logs a hard S3 error:

```
ERROR s3 - s3_client.cc:876 - Accessing level_one/meta/metastore/<uuid>/manifest.bin
  in dearliza, unexpected REST API error "Unsupported Authorization Type" detected,
  code: InvalidArgument, request_id: W1CBYQYFY48N1BVZ
```

## Root cause

`test_cloud_validation` enables cloud storage with a **fake bucket** (`dearliza`) and
mismatched credentials purely to validate config acceptance/rejection. Since #30508 /
`4997b30167` (*"config: deprecate cloud_topics_enabled()"*), cloud topics now start
whenever `cloud_storage_enabled` is true instead of requiring a separate flag. That spins
up the L1 metastore (`kafka_internal/ct_l1_domain`), whose flush loop makes a **real
object-storage PUT** of `l1::metastore_manifest` even with no user data.

In CDT, `virtual_host` url-style makes `dearliza` resolve to a real AWS endpoint that
actively rejects the request, so `s3_client.cc` takes the non-retryable ERROR path →
`BadLogLines` → FAIL. The test's existing `IAM_ROLES_API_CALL_ALLOW_LIST` only covers
`cloud_roles` credential errors, not this `s3` error.

- **Why CDT-only:** the `s3_client.cc:877` ERROR path is reached only when a *reachable*
  server returns a non-retryable REST error. Locally / with an unreachable endpoint, the
  request fails with a transport error that `BadLogLines` doesn't flag.
- **Why intermittent:** it needs a metastore flush PUT to land in the brief window of a
  boot whose credentials get *actively* rejected (a GCP metadata token sent to AWS →
  "Unsupported Authorization Type"; or `config_file` bogus keys → SignatureDoesNotMatch).

## Fix

Disable the cloud-topics metastore flush loop for the suite via
`cloud_topics_disable_metastore_flush_loop_for_tests`, mirroring the existing treatment of
`enable_cluster_metadata_upload_loop` (disabled in the same `__init__` for the same reason
— these tests intentionally point cloud storage at fake buckets). The flag flows to
`ct_cfg.skip_flush_loop`, which gates construction of the `flush_loop_manager`
(`application_services.cc` / `app.cc:154`), so `metastore->flush()` — the manifest upload
that failed — never runs.

## Verification

- `tools/dt run ... test_cloud_validation` passes with the fix.
- Boot banner + config import confirm `cloud_topics_disable_metastore_flush_loop_for_tests:true` is applied.
- Usage stats show `cloud_storage_puts: 0`; node logs show zero `l1::metastore_manifest` activity.
- Code path confirms the flush loop (and thus the failing upload) is not constructed when the flag is set.
- **Caveat:** the CDT failure does **not** reproduce locally — docker initializes cloud
  topics but the short, restart-heavy test never gives the metastore a stable window to
  flush, and the fake bucket isn't a reachable rejecting endpoint. Verification rests on
  the config-applied evidence + the code path, not an end-to-end local repro.

## Other options considered

1. **Extend the allow-list** with the `s3 ... unexpected REST API error` pattern — smaller
   diff, but broadly suppresses real S3 errors and weakens `BadLogLines`.
2. **Product-side:** reconsider whether a brand-new, empty metastore's first flush failure
   should log at ERROR, and/or expose `disable_cloud_topics` as a cluster property (today
   it is a C++-only `test_fixture_cfg` knob; only the flush-loop / L0-GC / reconciliation
   loops are individually settable from cluster config).

@WillemKauf — flagging you since this falls out of the `cloud_topics_enabled` deprecation
(#30508). The fix here is test-only, but the broader behavior — any cluster/test that
enables cloud storage against an unreachable or non-owned bucket now emits a hard `s3`
ERROR from the metastore flush loop — may be worth a look on the product side (option 2).

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
