### PR TITLE
cloud_topics: prep for compaction-driven local retention

### DIFF
--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -101,6 +101,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics/level_one/metastore:flush_loop",
         "//src/v/cloud_topics/level_one/metastore:topic_purger",
         "//src/v/cloud_topics/level_zero/gc:level_zero_gc",
+        "//src/v/cloud_topics/level_zero/notifier:level_zero_notifier",
         "//src/v/cloud_topics/manager",
         "//src/v/cloud_topics/read_replica:metadata_manager",
         "//src/v/cloud_topics/read_replica:snapshot_manager",

--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -18,6 +18,7 @@
 #include "cloud_topics/level_one/metastore/flush_loop.h"
 #include "cloud_topics/level_one/metastore/topic_purger.h"
 #include "cloud_topics/level_zero/gc/level_zero_gc.h"
+#include "cloud_topics/level_zero/notifier/level_zero_notifier.h"
 #include "cloud_topics/logger.h"
 #include "cloud_topics/manager/manager.h"
 #include "cloud_topics/read_replica/metadata_manager.h"
@@ -181,6 +182,11 @@ ss::future<> app::construct(
     co_await construct_service(housekeeper_manager, ss::sharded_parameter([&] {
                                    return &replicated_metastore.local();
                                }));
+
+    co_await construct_service(
+      l0_notifier,
+      &controller->get_shard_table(),
+      &controller->get_partition_manager());
 
     co_await construct_service(
       topic_manifest_upload_mgr, std::ref(*remote), bucket);

--- a/src/v/cloud_topics/app.h
+++ b/src/v/cloud_topics/app.h
@@ -42,6 +42,7 @@ class cloud_topics_manager;
 template<class>
 class level_zero_gc_t;
 class housekeeper_manager;
+class level_zero_notifier;
 class topic_manifest_upload_manager;
 
 namespace l1 {
@@ -115,6 +116,7 @@ private:
     ss::sharded<cloud_topics_manager> manager;
     ss::sharded<level_zero_gc_t<ss::lowres_clock>> l0_gc;
     ss::sharded<housekeeper_manager> housekeeper_manager;
+    ss::sharded<level_zero_notifier> l0_notifier;
     ss::sharded<topic_manifest_upload_manager> topic_manifest_upload_mgr;
     std::unique_ptr<l1::compaction_scheduler> compaction_scheduler;
     ss::sharded<l0::cluster_services> cluster_services;

--- a/src/v/cloud_topics/level_zero/notifier/BUILD
+++ b/src/v/cloud_topics/level_zero/notifier/BUILD
@@ -1,0 +1,22 @@
+load("//bazel:build.bzl", "redpanda_cc_library")
+
+package(default_visibility = ["//src/v/cloud_topics:__subpackages__"])
+
+redpanda_cc_library(
+    name = "level_zero_notifier",
+    srcs = ["level_zero_notifier.cc"],
+    hdrs = ["level_zero_notifier.h"],
+    deps = [
+        "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics/level_zero/stm:ctp_stm",
+        "//src/v/cloud_topics/level_zero/stm:ctp_stm_api",
+        "//src/v/cluster",
+        "//src/v/cluster:fwd",
+        "//src/v/cluster:shard_table",
+        "//src/v/cluster:state_machine_registry",
+        "//src/v/model",
+        "//src/v/ssx:future_util",
+        "//src/v/ssx:semaphore",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_zero/notifier/level_zero_notifier.cc
+++ b/src/v/cloud_topics/level_zero/notifier/level_zero_notifier.cc
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_zero/notifier/level_zero_notifier.h"
+
+#include "cloud_topics/level_zero/stm/ctp_stm.h"
+#include "cloud_topics/level_zero/stm/ctp_stm_api.h"
+#include "cloud_topics/logger.h"
+#include "cluster/partition.h"
+#include "cluster/partition_manager.h"
+#include "cluster/shard_table.h"
+#include "model/timeout_clock.h"
+#include "ssx/future-util.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/sleep.hh>
+
+namespace cloud_topics {
+
+namespace {
+constexpr auto replicate_timeout = std::chrono::seconds{30};
+} // namespace
+
+level_zero_notifier::level_zero_notifier(
+  ss::sharded<cluster::shard_table>* shard_table,
+  ss::sharded<cluster::partition_manager>* partition_manager,
+  std::chrono::milliseconds retry_backoff)
+  : _shard_table(shard_table)
+  , _partition_manager(partition_manager)
+  , _retry_backoff(retry_backoff) {}
+
+ss::future<> level_zero_notifier::stop() {
+    _as.request_abort();
+    _inflight.broken();
+    co_await _gate.close();
+}
+
+ss::future<std::expected<void, ctp_stm_api_errc>>
+level_zero_notifier::set_min_allowed_local_threshold(
+  model::ntp ntp, kafka::offset new_floor) {
+    vlog(
+      cd_log.debug,
+      "{} set_min_allowed_local_threshold called, the new floor {}",
+      ntp,
+      new_floor);
+
+    auto shard = _shard_table->local().shard_for(ntp);
+    if (!shard.has_value()) {
+        // Partition is not hosted on this node: nothing to replicate.
+        co_return std::unexpected(ctp_stm_api_errc::not_leader);
+    }
+    auto fut = co_await ss::coroutine::as_future(
+      container().invoke_on(
+        *shard, [ntp, new_floor](level_zero_notifier& self) mutable {
+            return self.replicate_on_home_shard(std::move(ntp), new_floor);
+        }));
+
+    if (fut.failed()) {
+        auto err = fut.get_exception();
+        auto errc = ctp_stm_api_errc::failure;
+        if (ssx::is_shutdown_exception(err)) {
+            vlog(
+              cd_log.debug,
+              "{} set_min_allowed_local_threshold failed due to shutdown for "
+              "new floor "
+              "{}",
+              ntp,
+              new_floor);
+            errc = ctp_stm_api_errc::shutdown;
+        } else {
+            vlog(
+              cd_log.warn,
+              "{} set_min_allowed_local_threshold failed for new floor {}, "
+              "error {}",
+              ntp,
+              new_floor,
+              err);
+        }
+        co_return std::unexpected(errc);
+    }
+    co_return fut.get();
+}
+
+ss::future<std::expected<void, ctp_stm_api_errc>>
+level_zero_notifier::replicate_on_home_shard(
+  model::ntp ntp, kafka::offset new_floor) {
+    auto holder = _gate.hold();
+    auto units = co_await ss::get_units(_inflight, 1);
+
+    auto partition = _partition_manager->local().get(ntp);
+    if (!partition) {
+        vlog(cd_log.info, "{} replicate_on_home_shard: partition moved", ntp);
+        // Partition moved away after the shard lookup, this can happen
+        // due to a race condition.
+        co_return std::unexpected(ctp_stm_api_errc::failure);
+    }
+    auto stm = partition->raft()->stm_manager()->get<ctp_stm>();
+    if (!stm) {
+        vlog(cd_log.error, "{} replicate_on_home_shard: not a CTP", ntp);
+        // Not a cloud-topic partition
+        co_return std::unexpected(ctp_stm_api_errc::failure);
+    }
+    ctp_stm_api api(stm);
+    co_return co_await replicate_with_retries(ntp, api, new_floor);
+}
+
+ss::future<std::expected<void, ctp_stm_api_errc>>
+level_zero_notifier::replicate_with_retries(
+  model::ntp ntp, ctp_stm_api& api, kafka::offset new_floor) {
+    auto last_error = ctp_stm_api_errc::timeout;
+    for (int attempt = 0; attempt < max_attempts && !_as.abort_requested();
+         ++attempt) {
+        auto res = co_await api.set_min_allowed_local_threshold(
+          new_floor, model::timeout_clock::now() + replicate_timeout, _as);
+        if (res.has_value()) {
+            co_return std::expected<void, ctp_stm_api_errc>{};
+        }
+        last_error = res.error();
+        if (
+          last_error == ctp_stm_api_errc::shutdown
+          || last_error == ctp_stm_api_errc::not_leader) {
+            vlog(
+              cd_log.debug,
+              "{} replicate_with_retries {} error: {}",
+              ntp,
+              last_error,
+              last_error);
+            // The stm is shutting down; retrying will not help.
+            co_return std::unexpected(last_error);
+        }
+        vlog(
+          cd_log.debug,
+          "{} replicate_with_retries attempt {} failed: {}",
+          ntp,
+          attempt,
+          last_error);
+        if (attempt + 1 < max_attempts) {
+            try {
+                co_await ss::sleep_abortable<ss::lowres_clock>(
+                  _retry_backoff, _as);
+            } catch (const ss::sleep_aborted&) {
+                co_return std::unexpected(ctp_stm_api_errc::shutdown);
+            }
+        }
+    }
+    vlog(
+      cd_log.warn,
+      "{} replicate_with_retries giving up after {} attempts, last error: {}",
+      ntp,
+      max_attempts,
+      last_error);
+    co_return std::unexpected(last_error);
+}
+
+} // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/notifier/level_zero_notifier.h
+++ b/src/v/cloud_topics/level_zero/notifier/level_zero_notifier.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_topics/level_zero/stm/ctp_stm_api.h"
+#include "cluster/fwd.h"
+#include "model/fundamental.h"
+#include "ssx/semaphore.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/sharded.hh>
+
+#include <chrono>
+#include <expected>
+
+namespace cloud_topics {
+
+/// Per-shard service that replicates post-compaction local-retention floor
+/// (min_allowed_local_threshold) updates to the partition that owns them.
+///
+/// L1 compaction (running on the maintenance shard) hands the new floor for a
+/// partition to set_min_allowed_local_threshold. The service resolves the
+/// partition's home shard, hops there via container().invoke_on, and
+/// replicates the floor through ctp_stm_api, retrying transient failures up to
+/// max_attempts. The replication result is returned to the caller, which
+/// decides whether a failure is fatal -- the call is not fire-and-forget.
+class level_zero_notifier
+  : public ss::peering_sharded_service<level_zero_notifier> {
+public:
+    /// Maximum number of replication attempts before giving up.
+    static constexpr int max_attempts = 3;
+
+    /// Default backoff between replication attempts.
+    static constexpr auto default_retry_backoff = std::chrono::seconds{5};
+
+    /// Maximum number of floor replications in flight on a single shard.
+    static constexpr size_t max_concurrent_replications = 16;
+
+    level_zero_notifier(
+      ss::sharded<cluster::shard_table>* shard_table,
+      ss::sharded<cluster::partition_manager>* partition_manager,
+      std::chrono::milliseconds retry_backoff = default_retry_backoff);
+
+    ss::future<> stop();
+
+    /// Resolve the partition's home shard, hop there, and replicate the new
+    /// min_allowed_local_threshold floor through ctp_stm_api. Returns the
+    /// replication result; a partition that is not hosted on this node (or has
+    /// no ctp_stm) is reported as not-leader error.
+    ss::future<std::expected<void, ctp_stm_api_errc>>
+    set_min_allowed_local_threshold(model::ntp ntp, kafka::offset new_floor);
+
+    /// Replicate new_floor through `api`, retrying transient failures up to
+    /// max_attempts with the configured backoff. Exposed for testing against a
+    /// raft_fixture-backed ctp_stm.
+    ss::future<std::expected<void, ctp_stm_api_errc>> replicate_with_retries(
+      model::ntp ntp, ctp_stm_api& api, kafka::offset new_floor);
+
+private:
+    // Runs on the partition's home shard: look up the ctp_stm via
+    // partition_manager and replicate under the per-shard concurrency limit.
+    ss::future<std::expected<void, ctp_stm_api_errc>>
+    replicate_on_home_shard(model::ntp ntp, kafka::offset new_floor);
+
+    ss::sharded<cluster::shard_table>* _shard_table;
+    ss::sharded<cluster::partition_manager>* _partition_manager;
+    std::chrono::milliseconds _retry_backoff;
+    ssx::semaphore _inflight{
+      max_concurrent_replications, "level_zero_notifier::inflight"};
+    ss::gate _gate;
+    ss::abort_source _as;
+};
+
+} // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/notifier/tests/BUILD
+++ b/src/v/cloud_topics/level_zero/notifier/tests/BUILD
@@ -1,0 +1,22 @@
+load("//bazel:test.bzl", "redpanda_cc_gtest")
+
+redpanda_cc_gtest(
+    name = "level_zero_notifier_test",
+    timeout = "short",
+    srcs = [
+        "level_zero_notifier_test.cc",
+    ],
+    deps = [
+        "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics/level_zero/notifier:level_zero_notifier",
+        "//src/v/cloud_topics/level_zero/stm:ctp_stm",
+        "//src/v/cloud_topics/level_zero/stm:ctp_stm_api",
+        "//src/v/cloud_topics/level_zero/stm:ctp_stm_factory",
+        "//src/v/cluster:state_machine_registry",
+        "//src/v/model",
+        "//src/v/raft/tests:raft_fixture",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_zero/notifier/tests/level_zero_notifier_test.cc
+++ b/src/v/cloud_topics/level_zero/notifier/tests/level_zero_notifier_test.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_zero/notifier/level_zero_notifier.h"
+#include "cloud_topics/level_zero/stm/ctp_stm.h"
+#include "cloud_topics/level_zero/stm/ctp_stm_api.h"
+#include "cloud_topics/logger.h"
+#include "model/fundamental.h"
+#include "raft/tests/raft_fixture.h"
+#include "test_utils/test.h"
+
+#include <chrono>
+
+namespace ct = cloud_topics;
+using namespace std::chrono_literals;
+
+namespace {
+constexpr auto tiny_backoff = std::chrono::milliseconds(1);
+const model::ntp
+  test_ntp(model::ns("kafka"), model::topic("tp"), model::partition_id(0));
+} // namespace
+
+class level_zero_notifier_fixture : public raft::stm_raft_fixture<ct::ctp_stm> {
+public:
+    ss::future<> start() {
+        enable_offset_translation();
+        co_await initialize_state_machines();
+    }
+
+    stm_shptrs_t create_stms(
+      raft::state_machine_manager_builder& builder,
+      raft::raft_node_instance& node) override {
+        return builder.create_stm<ct::ctp_stm>(ct::cd_log, node.raft().get());
+    }
+
+    ct::ctp_stm_api api(raft::raft_node_instance& node) {
+        return ct::ctp_stm_api(get_stm<0>(node));
+    }
+};
+
+// Replicating to the leader succeeds on the first attempt.
+TEST_F_CORO(level_zero_notifier_fixture, replicate_to_leader_succeeds) {
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+
+    ct::level_zero_notifier notifier(nullptr, nullptr, tiny_backoff);
+    auto leader_api = api(node(*get_leader()));
+    auto res = co_await notifier.replicate_with_retries(
+      test_ntp, leader_api, kafka::offset(42));
+    co_await notifier.stop();
+
+    ASSERT_TRUE_CORO(res.has_value());
+}
+
+// Replicating to a follower hits not_leader, which the notifier treats as
+// non-retriable: it gives up immediately and returns the error to the caller
+// (not fire-and-forget).
+TEST_F_CORO(level_zero_notifier_fixture, gives_up_on_follower) {
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+
+    auto leader = *get_leader();
+    raft::raft_node_instance* follower = nullptr;
+    for (auto& [id, n] : nodes()) {
+        if (id != leader) {
+            follower = n.get();
+            break;
+        }
+    }
+    ASSERT_TRUE_CORO(follower != nullptr);
+
+    ct::level_zero_notifier notifier(nullptr, nullptr, tiny_backoff);
+    auto follower_api = api(*follower);
+    auto res = co_await notifier.replicate_with_retries(
+      test_ntp, follower_api, kafka::offset(7));
+    co_await notifier.stop();
+
+    ASSERT_FALSE_CORO(res.has_value());
+}

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -306,8 +306,8 @@ ss::future<> ctp_stm::do_apply(const model::record_batch& batch) {
               case ctp_stm_key::reset_state:
                   apply_reset_state(std::move(r));
                   return ss::stop_iteration::no;
-              case ctp_stm_key::set_allowed_local_start_offset:
-                  apply_set_allowed_local_start_offset(std::move(r));
+              case ctp_stm_key::set_min_allowed_local_threshold:
+                  apply_set_min_allowed_local_threshold(std::move(r));
                   return ss::stop_iteration::no;
               }
               throw std::runtime_error(fmt_with_ctx(
@@ -350,11 +350,11 @@ void ctp_stm::apply_reset_state(model::record record) {
     _state = std::move(cmd.state);
 }
 
-void ctp_stm::apply_set_allowed_local_start_offset(model::record record) {
-    auto cmd = serde::from_iobuf<set_allowed_local_start_offset_cmd>(
+void ctp_stm::apply_set_min_allowed_local_threshold(model::record record) {
+    auto cmd = serde::from_iobuf<set_min_allowed_local_threshold_cmd>(
       record.release_value());
-    vlog(_log.debug, "Applying set_allowed_local_start_offset: {}", cmd.value);
-    _state.set_allowed_local_start_offset(cmd.value);
+    vlog(_log.debug, "Applying set_min_allowed_local_threshold: {}", cmd.value);
+    _state.set_min_allowed_local_threshold(cmd.value);
     _lro_advanced.signal();
 }
 
@@ -530,7 +530,7 @@ model::offset ctp_stm::prefix_truncate_target() {
     // and LRLO, so it's the upper bound. The hint, when set, pulls the
     // target down so older data stays local.
     auto cap = max_removable_local_log_offset();
-    auto hint = _state.get_allowed_local_start_offset();
+    auto hint = _state.get_min_allowed_local_threshold();
     auto target = cap;
     if (hint.has_value()) {
         // Translate the kafka::offset hint to a log offset. to_log_offset

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -131,7 +131,7 @@ private:
     void apply_set_start_offset(model::record);
     void apply_advance_epoch(model::record, model::offset base_offset);
     void apply_reset_state(model::record);
-    void apply_set_allowed_local_start_offset(model::record);
+    void apply_set_min_allowed_local_threshold(model::record);
 
     ss::future<raft::local_snapshot_applied>
     apply_local_snapshot(raft::stm_snapshot_header, iobuf&&) override;

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
@@ -184,18 +184,18 @@ ctp_stm_api::set_start_offset(
 }
 
 ss::future<std::expected<std::monostate, ctp_stm_api_errc>>
-ctp_stm_api::set_allowed_local_start_offset(
+ctp_stm_api::set_min_allowed_local_threshold(
   std::optional<kafka::offset> value,
   model::timeout_clock::time_point deadline,
   ss::abort_source& as) {
     // Idempotency: skip replication if the cached value already matches.
-    if (_stm->state().get_allowed_local_start_offset() == value) {
+    if (_stm->state().get_min_allowed_local_threshold() == value) {
         co_return std::monostate{};
     }
 
     vlog(
       _log.debug,
-      "Replicating ctp_stm_cmd::set_allowed_local_start_offset{{{}}}",
+      "Replicating ctp_stm_cmd::set_min_allowed_local_threshold{{{}}}",
       value);
 
     // Capture the leader's term up front so the replicate fails fast if
@@ -205,8 +205,8 @@ ctp_stm_api::set_allowed_local_start_offset(
     storage::record_batch_builder builder(
       model::record_batch_type::ctp_stm_command, model::offset(0));
     builder.add_raw_kv(
-      serde::to_iobuf(set_allowed_local_start_offset_cmd::key),
-      serde::to_iobuf(set_allowed_local_start_offset_cmd(value)));
+      serde::to_iobuf(set_min_allowed_local_threshold_cmd::key),
+      serde::to_iobuf(set_min_allowed_local_threshold_cmd(value)));
 
     auto batch = std::move(builder).build();
     auto apply_result = co_await replicated_apply(

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.h
@@ -79,10 +79,10 @@ public:
       model::timeout_clock::time_point deadline,
       ss::abort_source& as);
 
-    /// Replicate a set_allowed_local_start_offset_cmd. The STM stores the
+    /// Replicate a set_min_allowed_local_threshold_cmd. The STM stores the
     /// value as a hint for prefix_truncate_below_lro.
     ss::future<std::expected<std::monostate, ctp_stm_api_errc>>
-    set_allowed_local_start_offset(
+    set_min_allowed_local_threshold(
       std::optional<kafka::offset> value,
       model::timeout_clock::time_point deadline,
       ss::abort_source& as);

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_commands.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_commands.h
@@ -110,22 +110,22 @@ struct reset_state_cmd
     ctp_stm_state state;
 };
 
-/// Sets the cached `allowed_local_start_offset` hint on ctp_stm.
+/// Sets the cached `min_allowed_local_threshold` hint on ctp_stm.
 ///
 /// The reconciler replicates this command after computing the offset
 /// from local segment stats and effective local-retention targets.
 /// nullopt clears the hint (used when storage.mode != tiered_cloud or
 /// when compaction is enabled on the topic).
-struct set_allowed_local_start_offset_cmd
+struct set_min_allowed_local_threshold_cmd
   : public serde::envelope<
-      set_allowed_local_start_offset_cmd,
+      set_min_allowed_local_threshold_cmd,
       serde::version<0>,
       serde::compat_version<0>> {
     static constexpr cmd_key key = cmd_key(
-      std::to_underlying(ctp_stm_key::set_allowed_local_start_offset));
+      std::to_underlying(ctp_stm_key::set_min_allowed_local_threshold));
 
-    set_allowed_local_start_offset_cmd() noexcept = default;
-    explicit set_allowed_local_start_offset_cmd(
+    set_min_allowed_local_threshold_cmd() noexcept = default;
+    explicit set_min_allowed_local_threshold_cmd(
       std::optional<kafka::offset> v) noexcept
       : value(v) {}
 

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
@@ -180,14 +180,14 @@ kafka::offset ctp_stm_state::start_offset() const noexcept {
     return _start_offset;
 }
 
-void ctp_stm_state::set_allowed_local_start_offset(
+void ctp_stm_state::set_min_allowed_local_threshold(
   std::optional<kafka::offset> offset) noexcept {
-    _allowed_local_start_offset = offset;
+    _min_allowed_local_threshold = offset;
 }
 
 std::optional<kafka::offset>
-ctp_stm_state::get_allowed_local_start_offset() const noexcept {
-    return _allowed_local_start_offset;
+ctp_stm_state::get_min_allowed_local_threshold() const noexcept {
+    return _min_allowed_local_threshold;
 }
 
 fmt::iterator ctp_stm_state::format_to(fmt::iterator it) const {

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
@@ -130,17 +130,17 @@ public:
     std::optional<model::offset>
     get_last_reconciled_log_offset() const noexcept;
 
-    /// Set the allowed local start offset hint.
+    /// Set the min allowed local threshold hint.
     ///
     /// This value is produced by the reconciler and indicates the lower bound
     /// of kafka offsets that may be retained locally. The STM caches it but
     /// does not enforce truncation directly; a separate path applies it as a
     /// prefix-truncate target on the raft log.
-    void set_allowed_local_start_offset(std::optional<kafka::offset>) noexcept;
+    void set_min_allowed_local_threshold(std::optional<kafka::offset>) noexcept;
 
-    /// Get the allowed local start offset hint, if any.
+    /// Get the min allowed local threshold hint, if any.
     std::optional<kafka::offset>
-    get_allowed_local_start_offset() const noexcept;
+    get_min_allowed_local_threshold() const noexcept;
 
     auto serde_fields() {
         return std::tie(
@@ -152,7 +152,7 @@ public:
           _previous_applied_epoch,
           _start_offset,
           _size_estimator,
-          _allowed_local_start_offset);
+          _min_allowed_local_threshold);
     }
 
     /// Max collectible offset is defined by the LRO.
@@ -233,9 +233,9 @@ private:
     // Estimates total cloud data bytes addressable by the surviving log.
     size_estimator _size_estimator;
 
-    /// Allowed local start offset hint, produced by the reconciler.
+    /// Min allowed local threshold hint, produced by the reconciler.
     /// Cached state only; truncation is applied elsewhere.
-    std::optional<kafka::offset> _allowed_local_start_offset;
+    std::optional<kafka::offset> _min_allowed_local_threshold;
 };
 
 }; // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
@@ -471,27 +471,28 @@ TEST(ctp_stm_state_test, l0_simulation) {
     }
 }
 
-TEST(ctp_stm_state_test, allowed_local_start_offset_defaults_to_nullopt) {
+TEST(ctp_stm_state_test, min_allowed_local_threshold_defaults_to_nullopt) {
     ct::ctp_stm_state s;
-    EXPECT_FALSE(s.get_allowed_local_start_offset().has_value());
+    EXPECT_FALSE(s.get_min_allowed_local_threshold().has_value());
 }
 
-TEST(ctp_stm_state_test, set_then_get_allowed_local_start_offset) {
+TEST(ctp_stm_state_test, set_then_get_min_allowed_local_threshold) {
     ct::ctp_stm_state s;
-    s.set_allowed_local_start_offset(kafka::offset{42});
-    ASSERT_TRUE(s.get_allowed_local_start_offset().has_value());
-    EXPECT_EQ(*s.get_allowed_local_start_offset(), kafka::offset{42});
-    s.set_allowed_local_start_offset(std::nullopt);
-    EXPECT_FALSE(s.get_allowed_local_start_offset().has_value());
+    s.set_min_allowed_local_threshold(kafka::offset{42});
+    ASSERT_TRUE(s.get_min_allowed_local_threshold().has_value());
+    EXPECT_EQ(*s.get_min_allowed_local_threshold(), kafka::offset{42});
+    s.set_min_allowed_local_threshold(std::nullopt);
+    EXPECT_FALSE(s.get_min_allowed_local_threshold().has_value());
 }
 
-TEST(ctp_stm_state_test, allowed_local_start_offset_round_trips_through_serde) {
+TEST(
+  ctp_stm_state_test, min_allowed_local_threshold_round_trips_through_serde) {
     ct::ctp_stm_state s;
-    s.set_allowed_local_start_offset(kafka::offset{1234});
+    s.set_min_allowed_local_threshold(kafka::offset{1234});
     auto buf = serde::to_iobuf(s);
     auto s2 = serde::from_iobuf<ct::ctp_stm_state>(std::move(buf));
-    ASSERT_TRUE(s2.get_allowed_local_start_offset().has_value());
-    EXPECT_EQ(*s2.get_allowed_local_start_offset(), kafka::offset{1234});
+    ASSERT_TRUE(s2.get_min_allowed_local_threshold().has_value());
+    EXPECT_EQ(*s2.get_min_allowed_local_threshold(), kafka::offset{1234});
 }
 
 } // anonymous namespace

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -156,13 +156,13 @@ public:
     }
 
     ss::future<std::expected<model::offset, ct::ctp_stm_api_errc>>
-    replicate_set_allowed_local_start_offset(
+    replicate_set_min_allowed_local_threshold(
       raft::raft_node_instance& node, std::optional<kafka::offset> value) {
         storage::record_batch_builder builder(
           model::record_batch_type::ctp_stm_command, model::offset{0});
         builder.add_raw_kv(
-          serde::to_iobuf(ct::set_allowed_local_start_offset_cmd::key),
-          serde::to_iobuf(ct::set_allowed_local_start_offset_cmd(value)));
+          serde::to_iobuf(ct::set_min_allowed_local_threshold_cmd::key),
+          serde::to_iobuf(ct::set_min_allowed_local_threshold_cmd(value)));
         co_return co_await replicate_record_batch(
           node, std::move(builder).build());
     }
@@ -1361,7 +1361,7 @@ TEST_F_CORO(ctp_stm_fixture, test_reset_state_cmd) {
       << "LRO should be cleared after reset";
 }
 
-TEST_F_CORO(ctp_stm_fixture, apply_set_allowed_local_start_offset_some) {
+TEST_F_CORO(ctp_stm_fixture, apply_set_min_allowed_local_threshold_some) {
     co_await start();
     co_await wait_for_leader(raft::default_timeout());
 
@@ -1369,39 +1369,41 @@ TEST_F_CORO(ctp_stm_fixture, apply_set_allowed_local_start_offset_some) {
     auto stm = get_stm<0>(leader);
 
     ASSERT_FALSE_CORO(
-      stm->state().get_allowed_local_start_offset().has_value());
+      stm->state().get_min_allowed_local_threshold().has_value());
 
-    auto res = co_await replicate_set_allowed_local_start_offset(
+    auto res = co_await replicate_set_min_allowed_local_threshold(
       leader, kafka::offset{100});
     ASSERT_TRUE_CORO(res.has_value());
 
-    ASSERT_TRUE_CORO(stm->state().get_allowed_local_start_offset().has_value());
+    ASSERT_TRUE_CORO(
+      stm->state().get_min_allowed_local_threshold().has_value());
     ASSERT_EQ_CORO(
-      stm->state().get_allowed_local_start_offset().value(),
+      stm->state().get_min_allowed_local_threshold().value(),
       kafka::offset{100});
 }
 
-TEST_F_CORO(ctp_stm_fixture, apply_set_allowed_local_start_offset_clear) {
+TEST_F_CORO(ctp_stm_fixture, apply_set_min_allowed_local_threshold_clear) {
     co_await start();
     co_await wait_for_leader(raft::default_timeout());
 
     auto& leader = node(*get_leader());
     auto stm = get_stm<0>(leader);
 
-    auto res = co_await replicate_set_allowed_local_start_offset(
+    auto res = co_await replicate_set_min_allowed_local_threshold(
       leader, kafka::offset{50});
     ASSERT_TRUE_CORO(res.has_value());
     ASSERT_EQ_CORO(
-      stm->state().get_allowed_local_start_offset().value(), kafka::offset{50});
+      stm->state().get_min_allowed_local_threshold().value(),
+      kafka::offset{50});
 
-    res = co_await replicate_set_allowed_local_start_offset(
+    res = co_await replicate_set_min_allowed_local_threshold(
       leader, std::nullopt);
     ASSERT_TRUE_CORO(res.has_value());
     ASSERT_FALSE_CORO(
-      stm->state().get_allowed_local_start_offset().has_value());
+      stm->state().get_min_allowed_local_threshold().has_value());
 }
 
-TEST_F_CORO(ctp_stm_fixture, set_allowed_local_start_offset_replicates_some) {
+TEST_F_CORO(ctp_stm_fixture, set_min_allowed_local_threshold_replicates_some) {
     co_await start();
     co_await wait_for_leader(raft::default_timeout());
     auto& leader = node(*get_leader());
@@ -1409,61 +1411,66 @@ TEST_F_CORO(ctp_stm_fixture, set_allowed_local_start_offset_replicates_some) {
     auto leader_api = api(leader);
 
     ASSERT_FALSE_CORO(
-      stm->state().get_allowed_local_start_offset().has_value());
+      stm->state().get_min_allowed_local_threshold().has_value());
 
-    auto res = co_await leader_api.set_allowed_local_start_offset(
+    auto res = co_await leader_api.set_min_allowed_local_threshold(
       kafka::offset{77}, model::no_timeout, as);
     ASSERT_TRUE_CORO(res.has_value());
 
-    ASSERT_TRUE_CORO(stm->state().get_allowed_local_start_offset().has_value());
+    ASSERT_TRUE_CORO(
+      stm->state().get_min_allowed_local_threshold().has_value());
     ASSERT_EQ_CORO(
-      stm->state().get_allowed_local_start_offset().value(), kafka::offset{77});
+      stm->state().get_min_allowed_local_threshold().value(),
+      kafka::offset{77});
 }
 
 TEST_F_CORO(
-  ctp_stm_fixture, set_allowed_local_start_offset_replicates_nullopt) {
+  ctp_stm_fixture, set_min_allowed_local_threshold_replicates_nullopt) {
     co_await start();
     co_await wait_for_leader(raft::default_timeout());
     auto& leader = node(*get_leader());
     auto stm = get_stm<0>(leader);
     auto leader_api = api(leader);
 
-    auto res = co_await leader_api.set_allowed_local_start_offset(
+    auto res = co_await leader_api.set_min_allowed_local_threshold(
       kafka::offset{50}, model::no_timeout, as);
     ASSERT_TRUE_CORO(res.has_value());
     ASSERT_EQ_CORO(
-      stm->state().get_allowed_local_start_offset().value(), kafka::offset{50});
+      stm->state().get_min_allowed_local_threshold().value(),
+      kafka::offset{50});
 
-    res = co_await leader_api.set_allowed_local_start_offset(
+    res = co_await leader_api.set_min_allowed_local_threshold(
       std::nullopt, model::no_timeout, as);
     ASSERT_TRUE_CORO(res.has_value());
     ASSERT_FALSE_CORO(
-      stm->state().get_allowed_local_start_offset().has_value());
+      stm->state().get_min_allowed_local_threshold().has_value());
 }
 
 TEST_F_CORO(
-  ctp_stm_fixture, set_allowed_local_start_offset_idempotent_when_unchanged) {
+  ctp_stm_fixture, set_min_allowed_local_threshold_idempotent_when_unchanged) {
     co_await start();
     co_await wait_for_leader(raft::default_timeout());
     auto& leader = node(*get_leader());
     auto stm = get_stm<0>(leader);
     auto leader_api = api(leader);
 
-    auto res = co_await leader_api.set_allowed_local_start_offset(
+    auto res = co_await leader_api.set_min_allowed_local_threshold(
       kafka::offset{50}, model::no_timeout, as);
     ASSERT_TRUE_CORO(res.has_value());
     ASSERT_EQ_CORO(
-      stm->state().get_allowed_local_start_offset().value(), kafka::offset{50});
+      stm->state().get_min_allowed_local_threshold().value(),
+      kafka::offset{50});
 
     // A second call with the same value should be a no-op: no new batch is
     // replicated, so the raft dirty_offset should not advance.
     auto dirty_before = leader.raft()->dirty_offset();
-    res = co_await leader_api.set_allowed_local_start_offset(
+    res = co_await leader_api.set_min_allowed_local_threshold(
       kafka::offset{50}, model::no_timeout, as);
     ASSERT_TRUE_CORO(res.has_value());
     ASSERT_EQ_CORO(leader.raft()->dirty_offset(), dirty_before);
     ASSERT_EQ_CORO(
-      stm->state().get_allowed_local_start_offset().value(), kafka::offset{50});
+      stm->state().get_min_allowed_local_threshold().value(),
+      kafka::offset{50});
 }
 
 TEST_F_CORO(ctp_stm_fixture, prefix_truncate_target_returns_lrlo_when_no_hint) {
@@ -1483,7 +1490,7 @@ TEST_F_CORO(ctp_stm_fixture, prefix_truncate_target_returns_lrlo_when_no_hint) {
     auto lrlo = accessor.max_removable_local_log_offset(*stm);
     ASSERT_EQ_CORO(accessor.prefix_truncate_target(*stm), lrlo);
     ASSERT_FALSE_CORO(
-      stm->state().get_allowed_local_start_offset().has_value());
+      stm->state().get_min_allowed_local_threshold().has_value());
 }
 
 TEST_F_CORO(
@@ -1506,7 +1513,7 @@ TEST_F_CORO(
     auto lrlo = accessor.max_removable_local_log_offset(*stm);
 
     // Apply hint=60 below LRO=99.
-    auto res = co_await replicate_set_allowed_local_start_offset(
+    auto res = co_await replicate_set_min_allowed_local_threshold(
       leader, kafka::offset{60});
     ASSERT_TRUE_CORO(res.has_value());
 
@@ -1537,7 +1544,7 @@ TEST_F_CORO(
     auto lrlo = accessor.max_removable_local_log_offset(*stm);
 
     // Hint above LRO -> should fall back to LRLO.
-    auto res = co_await replicate_set_allowed_local_start_offset(
+    auto res = co_await replicate_set_min_allowed_local_threshold(
       leader, kafka::offset{40});
     ASSERT_TRUE_CORO(res.has_value());
 
@@ -1562,13 +1569,13 @@ TEST_F_CORO(
     ct::ctp_stm_accessor accessor;
     auto lrlo = accessor.max_removable_local_log_offset(*stm);
 
-    auto res = co_await replicate_set_allowed_local_start_offset(
+    auto res = co_await replicate_set_min_allowed_local_threshold(
       leader, kafka::offset{50});
     ASSERT_TRUE_CORO(res.has_value());
     ASSERT_NE_CORO(accessor.prefix_truncate_target(*stm), lrlo);
 
     // Clear the hint.
-    res = co_await replicate_set_allowed_local_start_offset(
+    res = co_await replicate_set_min_allowed_local_threshold(
       leader, std::nullopt);
     ASSERT_TRUE_CORO(res.has_value());
     ASSERT_EQ_CORO(accessor.prefix_truncate_target(*stm), lrlo);

--- a/src/v/cloud_topics/level_zero/stm/types.cc
+++ b/src/v/cloud_topics/level_zero/stm/types.cc
@@ -24,8 +24,8 @@ auto fmt::formatter<cloud_topics::ctp_stm_key>::format(
         return fmt::format_to(ctx.out(), "advance_epoch");
     case cloud_topics::ctp_stm_key::reset_state:
         return fmt::format_to(ctx.out(), "reset_state");
-    case cloud_topics::ctp_stm_key::set_allowed_local_start_offset:
-        return fmt::format_to(ctx.out(), "set_allowed_local_start_offset");
+    case cloud_topics::ctp_stm_key::set_min_allowed_local_threshold:
+        return fmt::format_to(ctx.out(), "set_min_allowed_local_threshold");
     }
     return fmt::format_to(
       ctx.out(), "unknown ctp_stm_key({})", static_cast<int>(key));

--- a/src/v/cloud_topics/level_zero/stm/types.h
+++ b/src/v/cloud_topics/level_zero/stm/types.h
@@ -23,7 +23,7 @@ enum class ctp_stm_key : uint8_t {
     set_start_offset = 2,
     advance_epoch = 3,
     reset_state = 4,
-    set_allowed_local_start_offset = 5,
+    set_min_allowed_local_threshold = 5,
 };
 
 struct [[nodiscard]] cluster_epoch_fence {

--- a/src/v/raft/tests/failure_injectable_log.cc
+++ b/src/v/raft/tests/failure_injectable_log.cc
@@ -256,6 +256,11 @@ failure_injectable_log::retention_offset(storage::gc_config cfg) const {
     return _underlying_log->retention_offset(cfg);
 }
 
+ss::future<std::optional<model::offset>>
+failure_injectable_log::compute_gc_offset(storage::gc_config cfg) {
+    return _underlying_log->compute_gc_offset(cfg);
+}
+
 ssize_t failure_injectable_log::dirty_segment_bytes() const {
     return _underlying_log->dirty_segment_bytes();
 }

--- a/src/v/raft/tests/failure_injectable_log.h
+++ b/src/v/raft/tests/failure_injectable_log.h
@@ -139,6 +139,9 @@ public:
     std::optional<model::offset>
       retention_offset(storage::gc_config) const final;
 
+    ss::future<std::optional<model::offset>>
+      compute_gc_offset(storage::gc_config) final;
+
     ssize_t dirty_segment_bytes() const final;
     ssize_t closed_segment_bytes() const final;
 

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1226,8 +1226,11 @@ disk_log_impl::maybe_apply_local_storage_overrides(gc_config cfg) const {
         return cfg;
     }
 
-    // cloud_retention is disabled, do not override
-    if (!is_cloud_retention_active()) {
+    // cloud_retention is disabled, do not override. Cloud-topic partitions
+    // (storage.mode in {cloud, tiered_cloud}) bypass this gate:
+    // is_cloud_retention_active() is false for them, but ctp_stm still needs
+    // the local-target override to engage under retention_local_strict.
+    if (!is_cloud_retention_active() && !config().cloud_topic_enabled()) {
         return cfg;
     }
 
@@ -1809,7 +1812,7 @@ ss::future<std::optional<model::offset>> disk_log_impl::do_gc(gc_config cfg) {
       config().ntp(),
       cfg);
 
-    auto max_offset = co_await maybe_adjusted_retention_offset(cfg);
+    auto max_offset = co_await compute_gc_offset(cfg);
 
     if (max_offset) {
         co_return request_eviction_until_offset(*max_offset);
@@ -1904,6 +1907,24 @@ ss::future<> disk_log_impl::maybe_adjust_retention_timestamps() {
 ss::future<std::optional<model::offset>>
 disk_log_impl::maybe_adjusted_retention_offset(gc_config cfg) {
     co_await maybe_adjust_retention_timestamps();
+    co_return retention_offset(cfg);
+}
+
+ss::future<std::optional<model::offset>>
+disk_log_impl::compute_gc_offset(gc_config cfg) {
+    // Single GC-offset computation shared by gc() housekeeping and by
+    // ctp_stm for cloud-topic partitions. The offset is retention-driven
+    // unless space management has pinned _cloud_gc_offset, which then takes
+    // precedence. maybe_apply_local_storage_overrides
+    // bypasses the is_cloud_retention_active() gate for cloud-topic partitions
+    // (the gate is false for storage.mode in {cloud, tiered_cloud}), so the
+    // local-target override engages there under retention_local_strict.
+    cfg = apply_kafka_retention_overrides(cfg);
+    if (_cloud_gc_offset.has_value()) {
+        co_return _cloud_gc_offset;
+    }
+    co_await maybe_adjust_retention_timestamps();
+    cfg = maybe_apply_local_storage_overrides(cfg);
     co_return retention_offset(cfg);
 }
 

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -207,6 +207,15 @@ public:
 
     std::optional<model::offset> retention_offset(gc_config) const final;
 
+    /// Applies retention overrides (callers need not pre-apply them) and
+    /// adjusts bogus (future) retention timestamps, mutating segment indexes
+    /// when an entire segment is bogus, then returns the offset GC would
+    /// evict to -- usually derived from local retention, but when space
+    /// management has set _cloud_gc_offset that offset is returned instead
+    /// (without resetting it -- that is do_gc's responsibility).
+    ss::future<std::optional<model::offset>>
+    compute_gc_offset(gc_config cfg) final;
+
     // Collects an iterable list of segments over which to perform sliding
     // window compaction. This can include segments which have already had their
     // keys de-duplicated in every segment between the start of the log and

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -234,6 +234,17 @@ public:
     get_reclaimable_offsets(gc_config cfg) = 0;
     virtual void set_cloud_gc_offset(model::offset) = 0;
 
+    /// Prepare for GC-driven prefix truncation: do whatever work `gc_config`
+    /// implies and return the offset that GC would evict up to (std::nullopt
+    /// when no eviction is warranted). The offset is usually derived from
+    /// local retention, but not always: space management may have pinned it
+    /// via set_cloud_gc_offset. This is not a pure query -- it may mutate the
+    /// underlying log -- which is why it is async. It does NOT request
+    /// eviction itself. Shared by disk_log_impl::do_gc and cloud-topic
+    /// ctp_stm housekeeping.
+    virtual ss::future<std::optional<model::offset>>
+    compute_gc_offset(gc_config cfg) = 0;
+
     virtual const segment_set& segments() const = 0;
     virtual segment_set& segments() = 0;
 


### PR DESCRIPTION
This is PR 1 of 3 in a series that ties cloud topics local retention to L1
compaction, and then teaches the tiered_cloud read path to pivot to L1 when the
local log has been truncated below the resulting threshold.

This first PR is groundwork with no behavior change on its own:

- **stm**: rename `allowed_local_start_offset` to `min_allowed_local_threshold`
  across the CTP STM so the name reflects its new role as a compaction floor
  (set in PR 2).
- **storage**: add an `adjusted_retention_offset` query to the log API, used by
  later PRs to compute a retention point that accounts for the threshold.
- **level_zero**: add `level_zero_notifier`, a standalone component constructed
  in the cloud_topics app that the L1 maintenance worker consumes in PR 2 to
  learn when compaction advances the threshold.

## Stack

This PR is part of a 3-PR stack — please review/merge in order:

1. #30756 — cloud_topics: prep for compaction-driven local retention
2. #30757 — cloud_topics: make min local threshold a compaction floor
3. #30758 — cloud_topics: pivot tiered_cloud reads on the local log start

**This is PR 1 of 3.** All three target `dev`, so GitHub shows this PR's diff
against `dev`; it includes commits from earlier PRs in the stack until those
merge. Review only the commits owned by this PR.

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none
