### PR TITLE
[v26.1.x] compaction: swap std::count() for cursor approach (MANUAL BACKPORT)

### DIFF
--- a/src/v/compaction/BUILD
+++ b/src/v/compaction/BUILD
@@ -108,6 +108,7 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         ":utils",
+        "//src/v/base",
         "//src/v/model:batch_compression",
     ],
     visibility = ["//visibility:public"],

--- a/src/v/compaction/filter.cc
+++ b/src/v/compaction/filter.cc
@@ -9,6 +9,7 @@
 
 #include "filter.h"
 
+#include "base/vassert.h"
 #include "compaction/utils.h"
 #include "container/chunked_vector.h"
 #include "model/batch_compression.h"
@@ -16,7 +17,7 @@
 
 #include <seastar/core/coroutine.hh>
 
-#include <vector>
+#include <algorithm>
 
 namespace compaction {
 
@@ -67,17 +68,22 @@ ss::future<std::optional<filter::filtered_batch>> filter::do_filter_batch(
     int32_t rec_count = 0;
     std::optional<int64_t> first_timestamp_delta;
     int64_t last_timestamp_delta;
+    // We expect and enforce that offset_deltas is sorted.
+    dassert(
+      std::ranges::is_sorted(offset_deltas),
+      "offset_deltas must be ascending in record-iteration order");
+    size_t keep_idx = 0;
     co_await b.for_each_record_async([&rec_count,
                                       &first_timestamp_delta,
                                       &last_timestamp_delta,
                                       &ret,
+                                      &keep_idx,
                                       &offset_deltas](model::record record) {
         // contains the key
         if (
-          std::count(
-            offset_deltas.begin(),
-            offset_deltas.end(),
-            record.offset_delta())) {
+          keep_idx < offset_deltas.size()
+          && offset_deltas[keep_idx] == record.offset_delta()) {
+            ++keep_idx;
             /*
              * TODO when we further optimize lazy record materialization ot
              * make use of views we can avoid this re-encoding by copying or

--- a/src/v/compaction/tests/reducer_test.cc
+++ b/src/v/compaction/tests/reducer_test.cc
@@ -23,6 +23,9 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
+#include <vector>
+
 static const auto test_ntp = model::ntp(
   model::ns("kafka"), model::topic("tapioca"), model::partition_id(0));
 
@@ -44,6 +47,94 @@ TEST(CompactionReducerTest, SimpleReducer) {
     ASSERT_EQ(output_batches.size(), num_batches);
     linear_int_kv_batch_generator::validate_post_compaction(
       std::move(output_batches));
+}
+
+namespace {
+// Runs the filter over a single uncompressed batch of `num_records` unique
+// integer keys [0, num_records), removing the records whose key is in
+// `removed` (by indexing them in the map at a higher offset). Returns the
+// integer keys of the records present in the output, in order.
+std::vector<int>
+filter_kept_keys(model::record_batch batch, const std::vector<int>& removed) {
+    compaction::simple_key_offset_map map{};
+    for (int i : removed) {
+        auto key = compaction::compaction_key{
+          iobuf_to_bytes(reflection::to_iobuf(i))};
+        // Index at an offset strictly above any record offset so the record is
+        // treated as superseded and dropped.
+        map.put(key, model::offset(std::numeric_limits<int>::max())).get();
+    }
+
+    chunked_circular_buffer<model::record_batch> output;
+    compaction::simple_sink sink(output);
+    compaction::simple_map_filter filter(sink, map, test_ntp);
+    filter(std::move(batch)).get();
+
+    std::vector<int> kept;
+    if (!output.empty()) {
+        output.front().for_each_record([&kept](model::record r) {
+            kept.push_back(reflection::from_iobuf<int>(r.key().copy()));
+        });
+    }
+    return kept;
+}
+
+model::record_batch make_int_key_batch(int num_records) {
+    storage::record_batch_builder builder(
+      model::record_batch_type::raft_data, model::offset(0));
+    for (int i = 0; i < num_records; ++i) {
+        builder.add_raw_kv(reflection::to_iobuf(i), reflection::to_iobuf(i));
+    }
+    return std::move(builder).build();
+}
+} // namespace
+
+// The rebuild loop matches records against the kept-deltas vector with an
+// advancing cursor. Exercise the cases that distinguish a correct subsequence
+// match from a position-based one: removing the first, middle, last, and
+// non-contiguous sets of records.
+TEST(CompactionReducerTest, FilterKeepsCorrectRecordsAfterRemoval) {
+    constexpr int n = 8;
+    using vec = std::vector<int>;
+    EXPECT_EQ(
+      filter_kept_keys(make_int_key_batch(n), {}),
+      (vec{0, 1, 2, 3, 4, 5, 6, 7}));
+    EXPECT_EQ(
+      filter_kept_keys(make_int_key_batch(n), {0}), (vec{1, 2, 3, 4, 5, 6, 7}));
+    EXPECT_EQ(
+      filter_kept_keys(make_int_key_batch(n), {7}), (vec{0, 1, 2, 3, 4, 5, 6}));
+    EXPECT_EQ(
+      filter_kept_keys(make_int_key_batch(n), {3, 4}), (vec{0, 1, 2, 5, 6, 7}));
+    EXPECT_EQ(
+      filter_kept_keys(make_int_key_batch(n), {0, 2, 4, 6}), (vec{1, 3, 5, 7}));
+    EXPECT_EQ(
+      filter_kept_keys(make_int_key_batch(n), {0, 1, 2, 3, 4, 5, 6}), (vec{7}));
+}
+
+// A batch that has already been compacted carries non-contiguous offset deltas;
+// the surviving records keep their original deltas. Feeding such a batch back
+// through must match on those sparse deltas, not on record positions.
+TEST(CompactionReducerTest, FilterKeepsCorrectRecordsWithNonContiguousDeltas) {
+    using vec = std::vector<int>;
+    // First pass removes the middle records {3, 4}, leaving keys/deltas
+    // {0, 1, 2, 5, 6, 7}.
+    chunked_circular_buffer<model::record_batch> output;
+    {
+        compaction::simple_key_offset_map map{};
+        for (int i : {3, 4}) {
+            auto key = compaction::compaction_key{
+              iobuf_to_bytes(reflection::to_iobuf(i))};
+            map.put(key, model::offset(std::numeric_limits<int>::max())).get();
+        }
+        compaction::simple_sink sink(output);
+        compaction::simple_map_filter filter(sink, map, test_ntp);
+        filter(make_int_key_batch(8)).get();
+    }
+    ASSERT_EQ(output.size(), 1);
+
+    // Second pass over the sparse batch removes key 5 (delta 5).
+    EXPECT_EQ(
+      filter_kept_keys(std::move(output.front()), {5}), (vec{0, 1, 2, 6, 7}));
 }
 
 // When filtering removes nothing from a compressed batch, the filter should

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -237,17 +237,22 @@ copy_data_segment_reducer::filter(model::record_batch batch) {
     int32_t rec_count = 0;
     std::optional<int64_t> first_timestamp_delta;
     int64_t last_timestamp_delta;
+    // We expect and enforce that offset_deltas is sorted.
+    dassert(
+      std::ranges::is_sorted(offset_deltas),
+      "offset_deltas must be ascending in record-iteration order");
+    size_t keep_idx = 0;
     batch.for_each_record([&rec_count,
                            &first_timestamp_delta,
                            &last_timestamp_delta,
                            &ret,
+                           &keep_idx,
                            &offset_deltas](model::record record) {
         // contains the key
         if (
-          std::count(
-            offset_deltas.begin(),
-            offset_deltas.end(),
-            record.offset_delta())) {
+          keep_idx < offset_deltas.size()
+          && offset_deltas[keep_idx] == record.offset_delta()) {
+            ++keep_idx;
             /*
              * TODO when we further optimize lazy record materialization ot
              * make use of views we can avoid this re-encoding by copying or


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda/pull/30740. `cherry-pick` conflict due to rearranged `maintenance` directory in `dev`. Dropped benchmark file additions.

Fixes https://github.com/redpanda-data/redpanda/issues/30759.

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Improvements

* Optimize compaction logic, especially for large batches.
