### PR TITLE
strings/utf8: add utf8_sanitize for iobuf values

### DIFF
--- a/src/v/bytes/iobuf.cc
+++ b/src/v/bytes/iobuf.cc
@@ -305,8 +305,7 @@ iobuf::placeholder iobuf::reserve(size_t sz) {
 }
 
 ss::sstring iobuf::linearize_to_string() const {
-    constexpr static size_t max_size = 128_KiB;
-    if (size_bytes() > max_size) {
+    if (size_bytes() > max_linearize_size) {
         throw std::runtime_error(
           fmt::format("string too big: {}", size_bytes()));
     }

--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -13,6 +13,7 @@
 #include "base/format_to.h"
 #include "base/likely.h"
 #include "base/seastarx.h"
+#include "base/units.h"
 #include "bytes/details/io_allocation_size.h"
 #include "bytes/details/io_byte_iterator.h"
 #include "bytes/details/io_fragment.h"
@@ -88,6 +89,9 @@ public:
     using iterator_consumer = details::io_iterator_consumer;
     using byte_iterator = details::io_byte_iterator;
     using placeholder = details::io_placeholder;
+
+    /// Maximum size accepted by linearize_to_string().
+    static constexpr size_t max_linearize_size = 128_KiB;
 
     static iobuf from(std::string_view view) {
         iobuf i;

--- a/src/v/strings/BUILD
+++ b/src/v/strings/BUILD
@@ -11,6 +11,7 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/base",
+        "//src/v/bytes:iobuf",
         "@boost//:locale",
         "@utf8proc",
     ],

--- a/src/v/strings/tests/BUILD
+++ b/src/v/strings/tests/BUILD
@@ -41,3 +41,18 @@ redpanda_cc_gtest(
         "@googletest//:gtest_main",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "utf8_sanitize_test",
+    timeout = "short",
+    srcs = [
+        "utf8_sanitize_test.cc",
+    ],
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/strings:utf8",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@seastar",
+    ],
+)

--- a/src/v/strings/tests/utf8_sanitize_test.cc
+++ b/src/v/strings/tests/utf8_sanitize_test.cc
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "strings/utf8.h"
+
+#include <seastar/core/temporary_buffer.hh>
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <string_view>
+
+// Build an iobuf with two distinct fragments to exercise state-machine
+// boundary handling in is_valid_utf8.
+static iobuf make_split_iobuf(std::string_view a, std::string_view b) {
+    iobuf buf;
+    buf.append(ss::temporary_buffer<char>(a.data(), a.size()));
+    buf.append(ss::temporary_buffer<char>(b.data(), b.size()));
+    return buf;
+}
+
+static std::string iobuf_to_string(iobuf buf) {
+    std::string s;
+    s.reserve(buf.size_bytes());
+    for (const auto& frag : buf) {
+        s.append(frag.get(), frag.size());
+    }
+    return s;
+}
+
+// ---------------------------------------------------------------------------
+// Valid inputs — fast path, zero copy
+// ---------------------------------------------------------------------------
+
+TEST(Utf8Sanitize, ValidEmpty) {
+    auto r = utf8_sanitize(iobuf::from(""));
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(iobuf_to_string(std::move(*r)), "");
+}
+
+TEST(Utf8Sanitize, ValidAscii) {
+    auto r = utf8_sanitize(iobuf::from("hello world"));
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(iobuf_to_string(std::move(*r)), "hello world");
+}
+
+TEST(Utf8Sanitize, Valid2Byte) {
+    // U+00E9 LATIN SMALL LETTER E WITH ACUTE: C3 A9
+    auto r = utf8_sanitize(iobuf::from("\xC3\xA9"));
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(iobuf_to_string(std::move(*r)), "\xC3\xA9");
+}
+
+TEST(Utf8Sanitize, ValidFragmentSplitMultiByte) {
+    // C3 | A9 — pending=1 carries into second fragment
+    auto r = utf8_sanitize(make_split_iobuf("\xC3", "\xA9"));
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(iobuf_to_string(std::move(*r)), "\xC3\xA9");
+}
+
+// ---------------------------------------------------------------------------
+// Invalid inputs — slow path replacement (advance-1-on-error)
+// ---------------------------------------------------------------------------
+
+TEST(Utf8Sanitize, InvalidBareContinuation) {
+    // 0x80 alone — one U+FFFD
+    auto r = utf8_sanitize(iobuf::from("\x80"));
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(iobuf_to_string(std::move(*r)), "\xEF\xBF\xBD");
+}
+
+TEST(Utf8Sanitize, InvalidTruncated3Byte) {
+    // E4 B8 at end of string — two U+FFFD (one per ill-formed byte)
+    auto r = utf8_sanitize(iobuf::from("\xE4\xB8"));
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(iobuf_to_string(std::move(*r)), "\xEF\xBF\xBD\xEF\xBF\xBD");
+}
+
+TEST(Utf8Sanitize, InvalidTruncated4Byte) {
+    // F0 9F 98 at end of string — three U+FFFD (one per ill-formed byte)
+    auto r = utf8_sanitize(iobuf::from("\xF0\x9F\x98"));
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(
+      iobuf_to_string(std::move(*r)), "\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD");
+}
+
+TEST(Utf8Sanitize, InvalidSurrogate) {
+    // U+D800 encoded as UTF-8: ED A0 80 — three U+FFFD.
+    // utf8proc rejects the lead byte ED A0 as a surrogate; each subsequent
+    // continuation byte is then a bare continuation.
+    auto r = utf8_sanitize(iobuf::from("\xED\xA0\x80"));
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(
+      iobuf_to_string(std::move(*r)), "\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD");
+}
+
+TEST(Utf8Sanitize, InvalidMixed) {
+    // Valid prefix + bare continuation + valid suffix
+    auto r = utf8_sanitize(iobuf::from("hello\x80world"));
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(iobuf_to_string(std::move(*r)), "hello\xEF\xBF\xBDworld");
+}
+
+TEST(Utf8Sanitize, InvalidContinuationMidSequence) {
+    // C3 expects one continuation, but gets another lead byte — two U+FFFD.
+    auto r = utf8_sanitize(iobuf::from("\xC3\xC3"));
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(iobuf_to_string(std::move(*r)), "\xEF\xBF\xBD\xEF\xBF\xBD");
+}
+
+TEST(Utf8Sanitize, InvalidOverlong2Byte) {
+    // C0 80 — overlong encoding of U+0000, two U+FFFD.
+    auto r = utf8_sanitize(iobuf::from("\xC0\x80"));
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(iobuf_to_string(std::move(*r)), "\xEF\xBF\xBD\xEF\xBF\xBD");
+}
+
+TEST(Utf8Sanitize, InvalidOverlong3Byte) {
+    // E0 9F 80 — overlong (first continuation 0x9F < 0xA0), three U+FFFD.
+    auto r = utf8_sanitize(iobuf::from("\xE0\x9F\x80"));
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(
+      iobuf_to_string(std::move(*r)), "\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD");
+}
+
+TEST(Utf8Sanitize, InvalidOutOfRangeLead) {
+    // 0xF5 and above are not valid UTF-8 lead bytes (would exceed U+10FFFF).
+    auto r = utf8_sanitize(iobuf::from("\xF5"));
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(iobuf_to_string(std::move(*r)), "\xEF\xBF\xBD");
+}
+
+TEST(Utf8Sanitize, InvalidSurrogateFragmentSplit) {
+    // ED | A0 80 — surrogate split across fragment boundary; verifies that
+    // max_cont=0x9F carries over from the first fragment.
+    auto r = utf8_sanitize(make_split_iobuf("\xED", "\xA0\x80"));
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(
+      iobuf_to_string(std::move(*r)), "\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD");
+}
+
+// ---------------------------------------------------------------------------
+// Size limit checks
+// ---------------------------------------------------------------------------
+
+TEST(Utf8Sanitize, OversizedValid) {
+    // A valid string larger than max_bytes passes through unchanged (fast
+    // path).
+    std::string big(iobuf::max_linearize_size + 1, 'a');
+    auto r = utf8_sanitize(iobuf::from(big));
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(r->size_bytes(), big.size());
+}
+
+TEST(Utf8Sanitize, OversizedInvalid) {
+    // An invalid string larger than max_bytes → input_too_large.
+    std::string big(iobuf::max_linearize_size + 1, '\x80');
+    auto r = utf8_sanitize(iobuf::from(big));
+    ASSERT_FALSE(r.has_value());
+    EXPECT_EQ(r.error(), utf8_sanitize_error::input_too_large);
+}
+
+TEST(Utf8Sanitize, ExactlyAtLimitInvalid) {
+    // size_bytes() == max_linearize_size: the slow path should proceed (the
+    // check is strictly >, not >=).
+    std::string at_limit(iobuf::max_linearize_size, '\x80');
+    auto r = utf8_sanitize(iobuf::from(at_limit));
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(
+      r->size_bytes(), at_limit.size() * 3); // each 0x80 → 3-byte U+FFFD
+}

--- a/src/v/strings/utf8.cc
+++ b/src/v/strings/utf8.cc
@@ -78,3 +78,89 @@ utf8_truncate_max(std::string_view s, size_t max_bytes) {
     }
     return std::nullopt;
 }
+
+namespace {
+
+constexpr std::string_view replacement_char = "\xEF\xBF\xBD";
+
+// Replace ill-formed bytes in `raw` with U+FFFD (advance-1-on-error strategy:
+// one replacement per ill-formed byte).
+iobuf replace_invalid_utf8(std::string_view raw) {
+    iobuf result;
+    const auto* data = reinterpret_cast<const utf8proc_uint8_t*>(raw.data());
+    auto len = static_cast<utf8proc_ssize_t>(raw.size());
+    utf8proc_ssize_t i = 0;
+    while (i < len) {
+        utf8proc_int32_t cp;
+        utf8proc_ssize_t n = utf8proc_iterate(data + i, len - i, &cp);
+        if (n > 0) {
+            result.append(raw.data() + i, static_cast<size_t>(n));
+            i += n;
+        } else {
+            result.append(replacement_char.data(), replacement_char.size());
+            ++i;
+        }
+    }
+    return result;
+}
+
+} // namespace
+
+bool is_valid_utf8(const iobuf& buf) {
+    int pending = 0;
+    uint8_t min_cont = 0x80;
+    uint8_t max_cont = 0xBF;
+    for (const auto& frag : buf) {
+        for (size_t i = 0; i < frag.size(); ++i) {
+            const auto b = static_cast<uint8_t>(frag.get()[i]);
+            if (pending > 0) {
+                if (b < min_cont || b > max_cont) {
+                    return false;
+                }
+                --pending;
+                // Range constraints apply only to the first continuation byte.
+                min_cont = 0x80;
+                max_cont = 0xBF;
+            } else {
+                if (b < 0x80) {
+                    // ASCII
+                } else if (b < 0xC2) {
+                    return false; // bare continuation or overlong 2-byte start
+                } else if (b < 0xE0) {
+                    pending = 1;
+                } else if (b == 0xE0) {
+                    pending = 2;
+                    min_cont = 0xA0; // exclude overlong
+                } else if (b == 0xED) {
+                    pending = 2;
+                    max_cont = 0x9F; // exclude surrogates
+                } else if (b < 0xF0) {
+                    pending = 2;
+                } else if (b == 0xF0) {
+                    pending = 3;
+                    min_cont = 0x90; // exclude overlong
+                } else if (b == 0xF4) {
+                    pending = 3;
+                    max_cont = 0x8F;   // exclude > U+10FFFF
+                } else if (b < 0xF5) { // 0xF1..0xF3
+                    pending = 3;
+                } else {
+                    return false; // 0xF5..0xFF
+                }
+            }
+        }
+    }
+    return pending == 0;
+}
+
+std::expected<iobuf, utf8_sanitize_error>
+utf8_sanitize(iobuf input, size_t max_bytes) {
+    max_bytes = std::min(max_bytes, iobuf::max_linearize_size);
+    if (is_valid_utf8(input)) {
+        return std::move(input);
+    }
+    if (input.size_bytes() > max_bytes) {
+        return std::unexpected(utf8_sanitize_error::input_too_large);
+    }
+    return replace_invalid_utf8(input.linearize_to_string());
+}

--- a/src/v/strings/utf8.h
+++ b/src/v/strings/utf8.h
@@ -13,11 +13,13 @@
 
 #include "base/likely.h"
 #include "base/seastarx.h"
+#include "bytes/iobuf.h"
 
 #include <boost/locale.hpp>
 #include <boost/locale/encoding_utf.hpp>
 #include <boost/locale/utf.hpp>
 
+#include <expected>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -188,3 +190,29 @@ std::string_view utf8_truncate_min(std::string_view s, size_t max_bytes);
 /// byte length.
 std::optional<std::string>
 utf8_truncate_max(std::string_view s, size_t max_bytes);
+
+enum class utf8_sanitize_error {
+    /// Input is invalid and size_bytes() > max_bytes; linearization not
+    /// attempted.
+    input_too_large,
+};
+
+/// Fragment-aware UTF-8 validation with no allocation.
+///
+/// Returns false if \p buf contains any byte sequence that is not valid
+/// UTF-8, including surrogates, overlong encodings, and truncated sequences.
+bool is_valid_utf8(const iobuf& buf);
+
+/// Replace invalid UTF-8 byte sequences with U+FFFD (EF BF BD).
+///
+/// Fast path: if \p input is already valid UTF-8, returns it unchanged
+/// (zero copy, no allocation).
+/// Slow path: if invalid and size_bytes() <= \p max_bytes, linearizes the
+/// input and replaces each ill-formed byte with U+FFFD; output is at most
+/// 3x the input size.
+/// Returns an error if the input exceeds \p max_bytes.
+///
+/// \p max_bytes is silently capped to iobuf::max_linearize_size; values
+/// larger than that cannot be linearized.
+std::expected<iobuf, utf8_sanitize_error>
+utf8_sanitize(iobuf input, size_t max_bytes = iobuf::max_linearize_size);


### PR DESCRIPTION
Adds utf8_sanitize(iobuf, max_bytes), which sanitizes bytes with potentially invalid UTF-8 using a "scan-and-rescue" strategy.

Scan AKA fast path: scan the iobuf for invalid sequences. On success the input is returned unchanged.

Rescue AKA slow path: linearizes via iobuf::linearize_to_string and replaces each ill-formed byte with U+FFFD using utf8proc_iterate with the advance-1-on-error strategy. If the iobuf is too long to linearize, returns an error instead.

This implementation strikes a balance between simplicity (no complex carrying of bytes between fragments) and efficiency (no copy in the valid case, but a full copy if the bytes are not valid UTF-8).

This will be used to sanitize header values in translation.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
