### PR TITLE
CORE-16409 Schema Registry: implement internal client for schema syncing

### DIFF
--- a/src/v/cluster/BUILD
+++ b/src/v/cluster/BUILD
@@ -2449,6 +2449,7 @@ redpanda_cc_library(
         "//src/v/net:tls",
         "//src/v/net:types",
         "//src/v/pandaproxy/schema_registry:config",
+        "//src/v/pandaproxy/schema_registry:fwd",
         "//src/v/pandaproxy/schema_registry:subject_name_strategy",
         "//src/v/pandaproxy/schema_registry:types",
         "//src/v/raft",

--- a/src/v/cluster/cluster_link/frontend.cc
+++ b/src/v/cluster/cluster_link/frontend.cc
@@ -22,6 +22,7 @@
 #include "config/configuration.h"
 #include "model/namespace.h"
 #include "model/validation.h"
+#include "pandaproxy/schema_registry/types.h"
 #include "rpc/connection_cache.h"
 #include "ssx/when_all.h"
 
@@ -39,6 +40,7 @@ using ::cluster_link::model::name_t;
 using ::cluster_link::model::update_cluster_link_configuration_cmd;
 using ::cluster_link::model::update_mirror_topic_properties_cmd;
 using ::cluster_link::model::update_mirror_topic_status_cmd;
+namespace ppsr = pandaproxy::schema_registry;
 
 namespace {
 errc map_errc(std::error_code ec) {
@@ -317,38 +319,58 @@ ss::future<chunked_vector<topic_result>> frontend::delete_mirror_topics(
       std::move(futures));
 }
 
+namespace {
+
+bool link_shadows_schema_registry_topic(
+  const ::cluster_link::model::metadata& md) {
+    const auto& mirror_topics = md.state.mirror_topics;
+    auto topic_it = mirror_topics.find(
+      ::model::schema_registry_internal_tp.topic);
+    if (topic_it != mirror_topics.end()) {
+        return !is_topic_mutable(topic_it->second.status);
+    }
+    // Topic mode owns _schemas even before the mirror topic appears.
+    return md.configuration.schema_registry_sync_cfg.is_topic_mode();
+}
+
+bool link_disables_schema_registry_writes(
+  const ::cluster_link::model::metadata& md, ppsr::write_source source) {
+    switch (source) {
+    case ppsr::write_source::client:
+        return link_shadows_schema_registry_topic(md)
+               || md.configuration.schema_registry_sync_cfg.api_mode()
+                    != nullptr;
+    case ppsr::write_source::schema_registry_sync:
+        return link_shadows_schema_registry_topic(md);
+    }
+    __builtin_unreachable();
+}
+
+} // namespace
+
 bool frontend::schema_registry_shadowing_active() const {
+    return schema_registry_writes_disabled(ppsr::write_source::client);
+}
+
+bool frontend::schema_registry_writes_disabled(
+  ppsr::write_source source) const {
     if (!cluster_link_active()) {
-        // If not shadow links are active then quick exit
         return false;
     }
 
     auto link_ids = get_all_link_ids();
-    return std::ranges::any_of(link_ids, [this](id_t link_id) -> bool {
+    return std::ranges::any_of(link_ids, [this, source](id_t link_id) -> bool {
         const auto md = find_link_by_id(link_id);
         if (!md) {
             return false;
         }
-        // Check to see if the schema registry topic is in the mirror topic list
-        const auto& mirror_topics = md->state.mirror_topics;
-        auto topic_it = mirror_topics.find(
-          ::model::schema_registry_internal_tp.topic);
-        if (topic_it != mirror_topics.end()) {
-            // If it is, return whether or not it is mutable based on its status
-            return !is_topic_mutable(topic_it->second.status);
-        }
-        // A shadowing mode is engaged but there is no (mutable) mirror topic:
-        // either topic mode before the _schemas mirror topic appears, or API
-        // mode which has no mirror topic at all. In both cases local writes
-        // must be blocked so they cannot conflict with subjects, versions,
-        // IDs, modes, and configs the sync imports from the source.
-        const auto& sr_cfg = md->configuration.schema_registry_sync_cfg;
-        if (sr_cfg.is_topic_mode() || sr_cfg.api_mode() != nullptr) {
-            return true;
-        }
-
-        return false;
+        return link_disables_schema_registry_writes(*md, source);
     });
+}
+
+bool frontend::schema_registry_internal_topic_creation_blocked() const {
+    return schema_registry_writes_disabled(
+      ppsr::write_source::schema_registry_sync);
 }
 
 ss::future<errc> frontend::do_mutation(

--- a/src/v/cluster/cluster_link/frontend.h
+++ b/src/v/cluster/cluster_link/frontend.h
@@ -21,6 +21,7 @@
 #include "features/feature_table.h"
 #include "features/fwd.h"
 #include "model/timeout_clock.h"
+#include "pandaproxy/schema_registry/fwd.h"
 #include "rpc/connection_cache.h"
 #include "rpc/fwd.h"
 
@@ -143,10 +144,16 @@ public:
     ss::future<chunked_vector<topic_result>> delete_mirror_topics(
       chunked_vector<model::topic>, model::timeout_clock::time_point);
 
-    /**
-     * @brief Returns true if schema registry topic is being shadowed
-     */
+    /// True if any Schema Registry shadowing mode is active.
     bool schema_registry_shadowing_active() const;
+
+    /// True if Schema Registry writes from this source must be rejected.
+    bool schema_registry_writes_disabled(
+      pandaproxy::schema_registry::write_source) const;
+
+    /// True if this node must not create a local _schemas topic because
+    /// topic-mode shadowing owns it.
+    bool schema_registry_internal_topic_creation_blocked() const;
 
 private:
     ss::future<errc>

--- a/src/v/datalake/tests/record_schema_resolver_test.cc
+++ b/src/v/datalake/tests/record_schema_resolver_test.cc
@@ -613,6 +613,47 @@ public:
         return _registry.create_schema(std::move(unparsed));
     }
 
+    ss::future<pandaproxy::schema_registry::context_schema_id> import_schema(
+      pandaproxy::schema_registry::stored_schema imported) override {
+        return _registry.import_schema(std::move(imported));
+    }
+
+    ss::future<bool> soft_delete_schema(
+      pandaproxy::schema_registry::context_subject sub,
+      pandaproxy::schema_registry::schema_version version) override {
+        return _registry.soft_delete_schema(std::move(sub), version);
+    }
+
+    ss::future<chunked_vector<pandaproxy::schema_registry::schema_version>>
+    permanent_delete_schema(
+      pandaproxy::schema_registry::context_subject sub,
+      std::optional<pandaproxy::schema_registry::schema_version> version)
+      override {
+        return _registry.permanent_delete_schema(std::move(sub), version);
+    }
+
+    ss::future<bool> write_mode(
+      pandaproxy::schema_registry::context_subject sub,
+      pandaproxy::schema_registry::mode mode) override {
+        return _registry.write_mode(std::move(sub), mode);
+    }
+
+    ss::future<bool>
+    delete_mode(pandaproxy::schema_registry::context_subject sub) override {
+        return _registry.delete_mode(std::move(sub));
+    }
+
+    ss::future<bool> write_config(
+      pandaproxy::schema_registry::context_subject sub,
+      pandaproxy::schema_registry::compatibility_level compat) override {
+        return _registry.write_config(std::move(sub), compat);
+    }
+
+    ss::future<bool>
+    delete_config(pandaproxy::schema_registry::context_subject sub) override {
+        return _registry.delete_config(std::move(sub));
+    }
+
     const std::vector<pandaproxy::schema_registry::stored_schema>& get_all() {
         return _registry.get_all();
     }

--- a/src/v/pandaproxy/schema_registry/api.cc
+++ b/src/v/pandaproxy/schema_registry/api.cc
@@ -154,10 +154,10 @@ public:
       std::unique_ptr<cluster::controller>& c)
       : _controller(c) {}
 
-    writes_disabled_t writes_disabled() const final {
-        return writes_disabled_t{_controller->get_cluster_link_frontend()
-                                   .local()
-                                   .schema_registry_shadowing_active()};
+    writes_disabled_t writes_disabled(write_source source) const final {
+        auto& frontend = _controller->get_cluster_link_frontend().local();
+        return writes_disabled_t{
+          frontend.schema_registry_writes_disabled(source)};
     }
 
 private:

--- a/src/v/pandaproxy/schema_registry/fwd.h
+++ b/src/v/pandaproxy/schema_registry/fwd.h
@@ -26,4 +26,6 @@ class transport;
 class kafka_client_transport;
 class rpc_transport;
 
+enum class write_source;
+
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -114,7 +114,10 @@ ss::future<> seq_writer::read_sync() {
 }
 
 ss::future<> seq_writer::check_mutable(
-  const context& ctx, const std::optional<subject>& sub) {
+  const context& ctx, const std::optional<subject>& sub, write_source src) {
+    if (bypasses_write_policy(src)) {
+        co_return;
+    }
     auto mode = sub ? co_await _store.get_mode(
                         {ctx, *sub}, default_to_global::yes)
                     : co_await _store.get_mode(ctx, default_to_global::yes);
@@ -398,11 +401,15 @@ seq_writer::write_subject_version_imported(stored_schema schema) {
       [&schema](model::offset write_at, seq_writer& seq) {
           return seq.do_write_subject_version_imported(
             schema.share(), write_at);
-      });
+      },
+      write_source::schema_registry_sync);
 }
 
 ss::future<std::optional<bool>> seq_writer::do_write_config(
-  context_subject sub, compatibility_level compat, model::offset write_at) {
+  context_subject sub,
+  compatibility_level compat,
+  model::offset write_at,
+  write_source src) {
     vlog(
       srlog.debug,
       "write_config sub={} compat={} offset={}",
@@ -412,7 +419,7 @@ ss::future<std::optional<bool>> seq_writer::do_write_config(
 
     auto sub_opt = sub.is_context_only() ? std::nullopt
                                          : std::make_optional(sub.sub);
-    co_await check_mutable(sub.ctx, sub_opt);
+    co_await check_mutable(sub.ctx, sub_opt, src);
 
     try {
         // Check for no-op case
@@ -445,21 +452,23 @@ ss::future<std::optional<bool>> seq_writer::do_write_config(
     }
 }
 
-ss::future<bool>
-seq_writer::write_config(context_subject ctx_sub, compatibility_level compat) {
-    return sequenced_write([ctx_sub{std::move(ctx_sub)},
-                            compat](model::offset write_at, seq_writer& seq) {
-        return seq.do_write_config(ctx_sub, compat, write_at);
-    });
+ss::future<bool> seq_writer::write_config(
+  context_subject ctx_sub, compatibility_level compat, write_source src) {
+    return sequenced_write(
+      [ctx_sub{std::move(ctx_sub)}, compat, src](
+        model::offset write_at, seq_writer& seq) {
+          return seq.do_write_config(ctx_sub, compat, write_at, src);
+      },
+      src);
 }
 
 ss::future<std::optional<bool>>
-seq_writer::do_delete_config(context_subject ctx_sub) {
+seq_writer::do_delete_config(context_subject ctx_sub, write_source src) {
     vlog(srlog.debug, "delete config sub={}", ctx_sub);
 
     auto sub_opt = ctx_sub.is_context_only() ? std::nullopt
                                              : std::make_optional(ctx_sub.sub);
-    co_await check_mutable(ctx_sub.ctx, sub_opt);
+    co_await check_mutable(ctx_sub.ctx, sub_opt, src);
 
     chunked_vector<seq_marker> sequences;
     try {
@@ -486,15 +495,21 @@ seq_writer::do_delete_config(context_subject ctx_sub) {
     }
 }
 
-ss::future<bool> seq_writer::delete_config(context_subject ctx_sub) {
+ss::future<bool>
+seq_writer::delete_config(context_subject ctx_sub, write_source src) {
     return sequenced_write(
-      [ctx_sub{std::move(ctx_sub)}](model::offset, seq_writer& seq) {
-          return seq.do_delete_config(ctx_sub);
-      });
+      [ctx_sub{std::move(ctx_sub)}, src](model::offset, seq_writer& seq) {
+          return seq.do_delete_config(ctx_sub, src);
+      },
+      src);
 }
 
 ss::future<std::optional<bool>> seq_writer::do_write_mode(
-  context_subject ctx_sub, mode m, force f, model::offset write_at) {
+  context_subject ctx_sub,
+  mode m,
+  force f,
+  model::offset write_at,
+  write_source src) {
     vlog(
       srlog.debug,
       "write_mode sub={} mode={} force={} offset={}",
@@ -503,7 +518,7 @@ ss::future<std::optional<bool>> seq_writer::do_write_mode(
       f,
       write_at);
 
-    _store.check_mode_mutability(force::no);
+    _store.check_mode_mutable(src);
 
     try {
         // Check for no-op case
@@ -569,18 +584,20 @@ ss::future<std::optional<bool>> seq_writer::do_write_mode(
     }
 }
 
-ss::future<bool>
-seq_writer::write_mode(context_subject ctx_sub, mode mode, force f) {
-    return sequenced_write([ctx_sub{std::move(ctx_sub)}, mode, f](
-                             model::offset write_at, seq_writer& seq) {
-        return seq.do_write_mode(ctx_sub, mode, f, write_at);
-    });
+ss::future<bool> seq_writer::write_mode(
+  context_subject ctx_sub, mode mode, force f, write_source src) {
+    return sequenced_write(
+      [ctx_sub{std::move(ctx_sub)}, mode, f, src](
+        model::offset write_at, seq_writer& seq) {
+          return seq.do_write_mode(ctx_sub, mode, f, write_at, src);
+      },
+      src);
 }
 
-ss::future<std::optional<bool>>
-seq_writer::do_delete_mode(context_subject ctx_sub, model::offset write_at) {
+ss::future<std::optional<bool>> seq_writer::do_delete_mode(
+  context_subject ctx_sub, model::offset write_at, write_source src) {
     vlog(srlog.debug, "delete mode sub={} offset={}", ctx_sub, write_at);
-    _store.check_mode_mutability(force::no);
+    _store.check_mode_mutable(src);
 
     chunked_vector<seq_marker> sequences;
     try {
@@ -606,11 +623,14 @@ seq_writer::do_delete_mode(context_subject ctx_sub, model::offset write_at) {
     }
 }
 
-ss::future<bool> seq_writer::delete_mode(context_subject ctx_sub) {
+ss::future<bool>
+seq_writer::delete_mode(context_subject ctx_sub, write_source src) {
     return sequenced_write(
-      [ctx_sub{std::move(ctx_sub)}](model::offset write_at, seq_writer& seq) {
-          return seq.do_delete_mode(ctx_sub, write_at);
-      });
+      [ctx_sub{std::move(ctx_sub)},
+       src](model::offset write_at, seq_writer& seq) {
+          return seq.do_delete_mode(ctx_sub, write_at, src);
+      },
+      src);
 }
 
 ss::future<std::optional<bool>>
@@ -651,8 +671,11 @@ ss::future<> seq_writer::delete_context(context ctx) {
 
 /// Impermanent delete: update a version with is_deleted=true
 ss::future<std::optional<bool>> seq_writer::do_delete_subject_version(
-  context_subject sub, schema_version version, model::offset write_at) {
-    co_await check_mutable(sub.ctx, sub.sub);
+  context_subject sub,
+  schema_version version,
+  model::offset write_at,
+  write_source src) {
+    co_await check_mutable(sub.ctx, sub.sub, src);
 
     if (co_await _store.is_referenced(sub, version)) {
         throw as_exception(has_references(sub, version));
@@ -690,17 +713,19 @@ ss::future<std::optional<bool>> seq_writer::do_delete_subject_version(
 }
 
 ss::future<bool> seq_writer::delete_subject_version(
-  context_subject sub, schema_version version) {
+  context_subject sub, schema_version version, write_source src) {
     return sequenced_write(
-      [sub{std::move(sub)}, version](model::offset write_at, seq_writer& seq) {
-          return seq.do_delete_subject_version(sub, version, write_at);
-      });
+      [sub{std::move(sub)}, version, src](
+        model::offset write_at, seq_writer& seq) {
+          return seq.do_delete_subject_version(sub, version, write_at, src);
+      },
+      src);
 }
 
 ss::future<std::optional<chunked_vector<schema_version>>>
 seq_writer::do_delete_subject_impermanent(
-  context_subject sub, model::offset write_at) {
-    co_await check_mutable(sub.ctx, sub.sub);
+  context_subject sub, model::offset write_at, write_source src) {
+    co_await check_mutable(sub.ctx, sub.sub, src);
 
     // Grab the versions before they're gone.
     auto versions = co_await _store.get_versions(sub, include_deleted::no);
@@ -748,12 +773,13 @@ seq_writer::do_delete_subject_impermanent(
 }
 
 ss::future<chunked_vector<schema_version>>
-seq_writer::delete_subject_impermanent(context_subject sub) {
+seq_writer::delete_subject_impermanent(context_subject sub, write_source src) {
     vlog(srlog.debug, "delete_subject_impermanent sub={}", sub);
     return sequenced_write(
-      [sub{std::move(sub)}](model::offset write_at, seq_writer& seq) {
-          return seq.do_delete_subject_impermanent(sub, write_at);
-      });
+      [sub{std::move(sub)}, src](model::offset write_at, seq_writer& seq) {
+          return seq.do_delete_subject_impermanent(sub, write_at, src);
+      },
+      src);
 }
 
 /// Permanent deletions (i.e. writing tombstones for previous sequenced
@@ -761,16 +787,21 @@ seq_writer::delete_subject_impermanent(context_subject sub) {
 /// Include a version if we are only to hard delete that version, otherwise
 /// will hard-delete the whole subject.
 ss::future<chunked_vector<schema_version>> seq_writer::delete_subject_permanent(
-  context_subject sub, std::optional<schema_version> version) {
+  context_subject sub,
+  std::optional<schema_version> version,
+  write_source src) {
     return sequenced_write(
-      [sub{std::move(sub)}, version](model::offset, seq_writer& seq) {
-          return seq.delete_subject_permanent_inner(sub, version);
-      });
+      [sub{std::move(sub)}, version, src](model::offset, seq_writer& seq) {
+          return seq.delete_subject_permanent_inner(sub, version, src);
+      },
+      src);
 }
 
 ss::future<std::optional<chunked_vector<schema_version>>>
 seq_writer::delete_subject_permanent_inner(
-  context_subject sub, std::optional<schema_version> version) {
+  context_subject sub,
+  std::optional<schema_version> version,
+  write_source src) {
     chunked_vector<seq_marker> sequences;
     batch_builder rb{model::offset{0}};
 
@@ -778,7 +809,7 @@ seq_writer::delete_subject_permanent_inner(
     /// within these store functions (will throw a 404-equivalent if so)
     vlog(srlog.debug, "delete_subject_permanent sub={}", sub);
 
-    co_await check_mutable(sub.ctx, sub.sub);
+    co_await check_mutable(sub.ctx, sub.sub, src);
 
     if (version.has_value()) {
         // Check version first to see if the version exists

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -25,7 +25,9 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 
+#include <algorithm>
 #include <exception>
+#include <limits>
 #include <optional>
 
 using namespace std::chrono_literals;
@@ -280,6 +282,122 @@ seq_writer::write_subject_version(stored_schema schema) {
     co_return co_await sequenced_write(
       [&schema](model::offset write_at, seq_writer& seq) {
           return seq.do_write_subject_version(schema.share(), write_at);
+      });
+}
+
+ss::future<std::optional<sharded_store::insert_result>>
+seq_writer::do_write_subject_version_imported(
+  stored_schema schema, model::offset write_at) {
+    // schema.schema is moved below; keep an owning subject copy.
+    const auto sub = schema.schema.sub();
+
+    // Imported ids and versions are external input; the store later
+    // computes id + 1 and version + 1, which must stay representable.
+    constexpr auto max_imported_id = schema_id{
+      std::numeric_limits<schema_id::type>::max() - 1};
+    if (schema.id < schema_id{1} || schema.id > max_imported_id) {
+        throw as_exception(invalid_schema(
+          fmt::format("Imported schema id {} is not valid", schema.id())));
+    }
+    constexpr auto max_imported_version = schema_version{
+      std::numeric_limits<schema_version::type>::max() - 1};
+    if (
+      schema.version < schema_version{1}
+      || schema.version > max_imported_version) {
+        throw as_exception(
+          error_info{
+            error_code::schema_version_invalid,
+            fmt::format(
+              "Imported schema version {} is not valid", schema.version())});
+    }
+
+    const auto ctx_id = context_schema_id{sub.ctx, schema.id};
+    auto existing_definition = co_await _store.maybe_get_schema_definition(
+      ctx_id);
+    if (
+      existing_definition.has_value()
+      && existing_definition.value() != schema.schema.def()) {
+        throw as_exception(overwrite_schema_with_id_not_permitted(schema.id));
+    }
+
+    auto versions = co_await _store.get_subject_versions(
+      sub, include_deleted::yes);
+    auto existing_version = std::ranges::find(
+      versions, schema.version, &subject_version_entry::version);
+    if (existing_version != versions.end()) {
+        if (existing_version->id != schema.id) {
+            throw as_exception(
+              error_info{
+                error_code::subject_version_schema_id_already_exists,
+                fmt::format(
+                  "Subject {} version {} is already registered with schema "
+                  "id {}, not imported schema id {}",
+                  sub,
+                  schema.version(),
+                  existing_version->id(),
+                  schema.id())});
+        }
+        if (
+          existing_definition.has_value()
+          && existing_version->deleted == schema.deleted) {
+            co_return sharded_store::insert_result{
+              .version = schema.version, .id = schema.id, .inserted = false};
+        }
+    }
+
+    auto canonical = std::move(schema.schema);
+    const auto version = schema.version;
+    const auto id = schema.id;
+    const auto deleted = schema.deleted;
+
+    vlog(
+      srlog.debug,
+      "seq_writer::write_subject_version_imported offset={} subject={} "
+      "schema={} version={} deleted={}",
+      write_at,
+      sub,
+      id,
+      version,
+      static_cast<bool>(deleted));
+
+    batch_builder rb(write_at);
+    auto record_offset = write_at;
+
+    if (
+      auto is_materialized = co_await _store.is_context_materialized(sub.ctx);
+      !is_materialized) {
+        vlog(srlog.debug, "Writing CONTEXT record for ctx={}", sub.ctx);
+        auto ctx_key = context_key{
+          .seq{record_offset}, .node{_node_id}, .ctx{sub.ctx}};
+        auto ctx_value = context_value{.ctx{sub.ctx}};
+        rb(std::move(ctx_key), std::move(ctx_value));
+        ++record_offset;
+    }
+
+    auto key = schema_key{
+      .seq{record_offset}, .node{_node_id}, .sub{sub}, .version{version}};
+    auto value = schema_value{
+      .schema{std::move(canonical)},
+      .version{version},
+      .id{id},
+      .deleted = deleted};
+    rb(std::move(key), std::move(value));
+
+    if (co_await produce_and_apply(write_at, std::move(rb).build())) {
+        co_return sharded_store::insert_result{
+          .version = version,
+          .id = id,
+          .inserted = existing_version == versions.end()};
+    }
+    co_return std::nullopt;
+}
+
+ss::future<sharded_store::insert_result>
+seq_writer::write_subject_version_imported(stored_schema schema) {
+    co_return co_await sequenced_write(
+      [&schema](model::offset write_at, seq_writer& seq) {
+          return seq.do_write_subject_version_imported(
+            schema.share(), write_at);
       });
 }
 

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -69,6 +69,12 @@ public:
     ss::future<sharded_store::insert_result>
     write_subject_version(stored_schema schema);
 
+    /// Internal sync path for importing a subject version with caller-supplied
+    /// schema ID, version, and deleted state. Bypasses client write guards
+    /// such as read-only mode and mode_mutability.
+    ss::future<sharded_store::insert_result>
+    write_subject_version_imported(stored_schema schema);
+
     ss::future<bool>
     write_config(context_subject ctx_sub, compatibility_level compat);
 
@@ -101,6 +107,10 @@ private:
 
     ss::future<std::optional<sharded_store::insert_result>>
     do_write_subject_version(stored_schema schema, model::offset write_at);
+
+    ss::future<std::optional<sharded_store::insert_result>>
+    do_write_subject_version_imported(
+      stored_schema schema, model::offset write_at);
 
     ss::future<std::optional<bool>> do_write_config(
       context_subject ctx_sub,

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -33,7 +33,7 @@ public:
     sequence_state_checker& operator=(sequence_state_checker&&) = delete;
 
     using writes_disabled_t = ss::bool_class<struct writes_disabled_tag>;
-    virtual writes_disabled_t writes_disabled() const = 0;
+    virtual writes_disabled_t writes_disabled(write_source) const = 0;
 };
 
 using namespace std::chrono_literals;
@@ -60,8 +60,10 @@ public:
     ss::future<> read_sync();
 
     // Throws 42205 if the subject cannot be modified
-    ss::future<>
-    check_mutable(const context& ctx, const std::optional<subject>& sub);
+    ss::future<> check_mutable(
+      const context& ctx,
+      const std::optional<subject>& sub,
+      write_source src = write_source::client);
 
     // API for readers: notify us when they have read and applied an offset
     ss::future<> advance_offset(model::offset offset);
@@ -75,25 +77,39 @@ public:
     ss::future<sharded_store::insert_result>
     write_subject_version_imported(stored_schema schema);
 
-    ss::future<bool>
-    write_config(context_subject ctx_sub, compatibility_level compat);
+    ss::future<bool> write_config(
+      context_subject ctx_sub,
+      compatibility_level compat,
+      write_source src = write_source::client);
 
-    ss::future<bool> delete_config(context_subject ctx_sub);
+    ss::future<bool> delete_config(
+      context_subject ctx_sub, write_source src = write_source::client);
 
-    ss::future<bool> write_mode(context_subject ctx_sub, mode m, force f);
+    /// \param f bypasses only the import-mode emptiness check, never
+    /// mode_mutability.
+    ss::future<bool> write_mode(
+      context_subject ctx_sub,
+      mode m,
+      force f,
+      write_source src = write_source::client);
 
-    ss::future<bool> delete_mode(context_subject ctx_sub);
+    ss::future<bool> delete_mode(
+      context_subject ctx_sub, write_source src = write_source::client);
 
     ss::future<> delete_context(context ctx);
 
-    ss::future<bool>
-    delete_subject_version(context_subject sub, schema_version version);
+    ss::future<bool> delete_subject_version(
+      context_subject sub,
+      schema_version version,
+      write_source src = write_source::client);
 
-    ss::future<chunked_vector<schema_version>>
-    delete_subject_impermanent(context_subject sub);
+    ss::future<chunked_vector<schema_version>> delete_subject_impermanent(
+      context_subject sub, write_source src = write_source::client);
 
     ss::future<chunked_vector<schema_version>> delete_subject_permanent(
-      context_subject sub, std::optional<schema_version> version);
+      context_subject sub,
+      std::optional<schema_version> version,
+      write_source src = write_source::client);
 
 private:
     ss::smp_submit_to_options _smp_opts;
@@ -115,36 +131,48 @@ private:
     ss::future<std::optional<bool>> do_write_config(
       context_subject ctx_sub,
       compatibility_level compat,
-      model::offset write_at);
-
-    ss::future<std::optional<bool>> do_delete_config(context_subject ctx_sub);
-
-    ss::future<std::optional<bool>> do_write_mode(
-      context_subject ctx_sub, mode m, force f, model::offset write_at);
+      model::offset write_at,
+      write_source src);
 
     ss::future<std::optional<bool>>
-    do_delete_mode(context_subject ctx_sub, model::offset write_at);
+    do_delete_config(context_subject ctx_sub, write_source src);
+
+    ss::future<std::optional<bool>> do_write_mode(
+      context_subject ctx_sub,
+      mode m,
+      force f,
+      model::offset write_at,
+      write_source src);
+
+    ss::future<std::optional<bool>> do_delete_mode(
+      context_subject ctx_sub, model::offset write_at, write_source src);
 
     ss::future<std::optional<bool>>
     do_delete_context(context ctx, model::offset write_at);
 
     ss::future<std::optional<bool>> do_delete_subject_version(
-      context_subject sub, schema_version version, model::offset write_at);
+      context_subject sub,
+      schema_version version,
+      model::offset write_at,
+      write_source src);
 
     ss::future<std::optional<chunked_vector<schema_version>>>
-    do_delete_subject_impermanent(context_subject sub, model::offset write_at);
+    do_delete_subject_impermanent(
+      context_subject sub, model::offset write_at, write_source src);
 
     ss::future<std::optional<chunked_vector<schema_version>>>
     delete_subject_permanent_inner(
-      context_subject sub, std::optional<schema_version> version);
+      context_subject sub,
+      std::optional<schema_version> version,
+      write_source src);
 
     simple_time_jitter<ss::lowres_clock> _jitter{std::chrono::milliseconds{50}};
 
     /// Helper for write paths that use sequence+retry logic to synchronize
     /// multiple writing nodes.
     template<typename F>
-    auto sequenced_write(F f) {
-        if (_state_checker->writes_disabled()) [[unlikely]] {
+    auto sequenced_write(F f, write_source src = write_source::client) {
+        if (_state_checker->writes_disabled(src)) [[unlikely]] {
             throw as_exception(writes_disabled());
         }
         auto base_backoff = _jitter.next_duration();

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -672,7 +672,11 @@ ss::future<> service::create_internal_topic() {
     // If shadow linking is active and a link is actively mirroring the
     // schema registry topic, then we will not create the topic and we will
     // throw an error.  This is so the oneshot doesn't become 'completed'.
-    if (active_sr_mirroring()) {
+    // API sync needs a local _schemas topic; topic mirroring does not.
+    if (
+      _controller->get_cluster_link_frontend()
+        .local()
+        .schema_registry_internal_topic_creation_blocked()) {
         throw std::runtime_error(
           "Shadow Linking actively mirroring schema "
           "registry topic.  Topic will not be created");
@@ -750,12 +754,6 @@ ss::future<> service::fetch_internal_topic() {
     // reprocess them once now that the whole topic has been read, in case
     // they have a reference to a schema declared later in the topic.
     co_await _store.process_marked_schemas();
-}
-
-bool service::active_sr_mirroring() const {
-    return _controller->get_cluster_link_frontend()
-      .local()
-      .schema_registry_shadowing_active();
 }
 
 service::service(

--- a/src/v/pandaproxy/schema_registry/service.h
+++ b/src/v/pandaproxy/schema_registry/service.h
@@ -69,7 +69,6 @@ private:
     ss::future<> do_start();
     ss::future<> create_internal_topic();
     ss::future<> fetch_internal_topic();
-    bool active_sr_mirroring() const;
     configuration _config;
     ssx::semaphore _mem_sem;
     adjustable_semaphore _inflight_sem;

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -911,8 +911,12 @@ ss::future<compatibility_result> sharded_store::do_is_compatible(
     co_return result;
 }
 
-void sharded_store::check_mode_mutability(force f) const {
-    _store.local().check_mode_mutability(f).value();
+void sharded_store::check_mode_mutable(write_source src) const {
+    // Internal sync bypasses the operator mode_mutability lockout.
+    _store.local()
+      .check_mode_mutability(
+        bypasses_write_policy(src) ? force::yes : force::no)
+      .value();
 }
 
 ss::future<bool> sharded_store::has_version(

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -227,8 +227,8 @@ public:
 
     ss::future<bool> has_version(context_subject, schema_id, include_deleted);
 
-    //// \brief Throw if the store is not mutable
-    void check_mode_mutability(force f) const;
+    //// \brief Throw if mode changes are not allowed for this write source.
+    void check_mode_mutable(write_source src) const;
 
     ///\brief Look up the id of a schema by definition
     ss::future<std::optional<schema_id>>

--- a/src/v/pandaproxy/schema_registry/test/BUILD
+++ b/src/v/pandaproxy/schema_registry/test/BUILD
@@ -232,6 +232,7 @@ redpanda_cc_btest(
     cpu = 1,
     deps = [
         ":utils",
+        "//src/v/bytes:iobuf_parser",
         "//src/v/model",
         "//src/v/pandaproxy/schema_registry:avro",
         "//src/v/pandaproxy/schema_registry:seq_writer",

--- a/src/v/pandaproxy/schema_registry/test/BUILD
+++ b/src/v/pandaproxy/schema_registry/test/BUILD
@@ -488,6 +488,34 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "internal_writes_test",
+    timeout = "short",
+    srcs = [
+        "internal_writes.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/cluster:cluster_utils",
+        "//src/v/cluster:controller_log_limiter",
+        "//src/v/cluster:data_migration_table",
+        "//src/v/cluster:feature_backend",
+        "//src/v/cluster:fwd",
+        "//src/v/cluster:leader_balancer_strategy",
+        "//src/v/cluster:node_status_backend",
+        "//src/v/cluster:self_test",
+        "//src/v/cluster:topic_metrics_watcher",
+        "//src/v/pandaproxy/schema_registry:exceptions",
+        "//src/v/pandaproxy/schema_registry:types",
+        "//src/v/redpanda/tests:fixture",
+        "//src/v/schema:registry",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
 redpanda_cc_btest(
     name = "delete_subject_endpoints",
     timeout = "short",

--- a/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
@@ -16,6 +16,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "bytes/iobuf_parser.h"
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "pandaproxy/schema_registry/avro.h"
@@ -281,6 +282,278 @@ SEASTAR_THREAD_TEST_CASE(test_writes_disabled) {
           pps::context_subject{pps::default_context, pps::subject{""}},
           pps::mode::read_only,
           pps::force::no)
+        .get(),
+      pps::exception,
+      [](pps::exception e) {
+          return e.code() == pps::error_code::writes_disabled;
+      });
+}
+
+SEASTAR_THREAD_TEST_CASE(test_sync_writes_allowed_while_client_blocked) {
+    pps::sharded_store s;
+    s.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&s]() { s.stop().get(); });
+
+    accepting_transport transport;
+
+    ss::sharded<pps::seq_writer> seq;
+    seq
+      .start(
+        model::node_id{0},
+        ss::default_smp_service_group(),
+        std::ref(transport),
+        std::reference_wrapper(s),
+        ss::sharded_parameter([] {
+            return std::make_unique<sequence_state_checker_test>(
+              pps::sequence_state_checker::writes_disabled_t::yes,
+              pps::sequence_state_checker::writes_disabled_t::no);
+        }))
+      .get();
+    auto stop_seq = ss::defer([&seq]() { seq.stop().get(); });
+
+    BOOST_REQUIRE_EXCEPTION(
+      seq.local()
+        .write_mode(
+          pps::context_subject{pps::default_context, pps::subject{""}},
+          pps::mode::read_only,
+          pps::force::no)
+        .get(),
+      pps::exception,
+      [](pps::exception e) {
+          return e.code() == pps::error_code::writes_disabled;
+      });
+    BOOST_REQUIRE(transport.produced.empty());
+
+    BOOST_REQUIRE(
+      seq.local()
+        .write_mode(
+          pps::context_subject{pps::default_context, pps::subject{""}},
+          pps::mode::read_only,
+          pps::force::no,
+          pps::write_source::schema_registry_sync)
+        .get());
+    BOOST_REQUIRE_EQUAL(transport.produced.size(), 1);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_client_force_cannot_bypass_mode_mutability) {
+    pps::sharded_store s;
+    s.start(pps::is_mutable::no, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&s]() { s.stop().get(); });
+
+    accepting_transport transport;
+
+    ss::sharded<pps::seq_writer> seq;
+    seq
+      .start(
+        model::node_id{0},
+        ss::default_smp_service_group(),
+        std::ref(transport),
+        std::reference_wrapper(s),
+        ss::sharded_parameter(
+          [] { return std::make_unique<sequence_state_checker_test>(); }))
+      .get();
+    auto stop_seq = ss::defer([&seq]() { seq.stop().get(); });
+
+    BOOST_REQUIRE_EXCEPTION(
+      seq.local()
+        .write_mode(
+          pps::context_subject{pps::default_context, pps::subject{""}},
+          pps::mode::read_only,
+          pps::force::yes,
+          pps::write_source::client)
+        .get(),
+      pps::exception,
+      [](pps::exception e) {
+          return e.code()
+                 == pps::error_code::subject_version_operation_not_permitted;
+      });
+    BOOST_REQUIRE(transport.produced.empty());
+
+    BOOST_REQUIRE(
+      seq.local()
+        .write_mode(
+          pps::context_subject{pps::default_context, pps::subject{""}},
+          pps::mode::read_only,
+          pps::force::yes,
+          pps::write_source::schema_registry_sync)
+        .get());
+    BOOST_REQUIRE_EQUAL(transport.produced.size(), 1);
+
+    BOOST_REQUIRE_EXCEPTION(
+      seq.local()
+        .delete_mode(
+          pps::context_subject{pps::default_context, pps::subject{""}},
+          pps::write_source::client)
+        .get(),
+      pps::exception,
+      [](pps::exception e) {
+          return e.code()
+                 == pps::error_code::subject_version_operation_not_permitted;
+      });
+
+    BOOST_REQUIRE(
+      seq.local()
+        .delete_mode(
+          pps::context_subject{pps::default_context, pps::subject{""}},
+          pps::write_source::schema_registry_sync)
+        .get());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_sync_bypasses_read_only_mode) {
+    pps::sharded_store s;
+    s.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&s]() { s.stop().get(); });
+
+    accepting_transport transport;
+
+    ss::sharded<pps::seq_writer> seq;
+    seq
+      .start(
+        model::node_id{0},
+        ss::default_smp_service_group(),
+        std::ref(transport),
+        std::reference_wrapper(s),
+        ss::sharded_parameter(
+          [] { return std::make_unique<sequence_state_checker_test>(); }))
+      .get();
+    auto stop_seq = ss::defer([&seq]() { seq.stop().get(); });
+
+    auto global = pps::context_subject{pps::default_context, pps::subject{""}};
+    BOOST_REQUIRE(seq.local()
+                    .write_mode(global, pps::mode::read_only, pps::force::no)
+                    .get());
+    auto subject1 = pps::context_subject::unqualified("subject1");
+    for (const auto& sub : {subject0, subject1}) {
+        seq.local()
+          .write_subject_version_imported(
+            pps::stored_schema{
+              .schema = {sub, int_def0.share()},
+              .version = version1,
+              .id = id1,
+              .deleted = pps::is_deleted::no})
+          .get();
+    }
+
+    auto require_readonly = [](auto fut) {
+        BOOST_REQUIRE_EXCEPTION(
+          fut.get(), pps::exception, [](pps::exception e) {
+              return e.code()
+                     == pps::error_code::
+                       subject_version_operation_not_permitted;
+          });
+    };
+
+    require_readonly(seq.local().write_config(
+      global, pps::compatibility_level::full, pps::write_source::client));
+    BOOST_REQUIRE(seq.local()
+                    .write_config(
+                      global,
+                      pps::compatibility_level::full,
+                      pps::write_source::schema_registry_sync)
+                    .get());
+
+    require_readonly(
+      seq.local().delete_config(global, pps::write_source::client));
+    BOOST_REQUIRE(
+      seq.local()
+        .delete_config(global, pps::write_source::schema_registry_sync)
+        .get());
+
+    require_readonly(seq.local().delete_subject_impermanent(
+      subject1, pps::write_source::client));
+    auto soft_deleted = seq.local()
+                          .delete_subject_impermanent(
+                            subject1, pps::write_source::schema_registry_sync)
+                          .get();
+    BOOST_REQUIRE_EQUAL(soft_deleted.size(), 1);
+
+    require_readonly(seq.local().delete_subject_version(
+      subject0, version1, pps::write_source::client));
+    BOOST_REQUIRE(
+      seq.local()
+        .delete_subject_version(
+          subject0, version1, pps::write_source::schema_registry_sync)
+        .get());
+
+    require_readonly(seq.local().delete_subject_permanent(
+      subject0, version1, pps::write_source::client));
+    auto deleted = seq.local()
+                     .delete_subject_permanent(
+                       subject0,
+                       version1,
+                       pps::write_source::schema_registry_sync)
+                     .get();
+    BOOST_REQUIRE_EQUAL(deleted.size(), 1);
+    BOOST_REQUIRE_EQUAL(deleted.front(), version1);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_imported_write_keys_carry_subject) {
+    pps::sharded_store s;
+    s.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&s]() { s.stop().get(); });
+
+    accepting_transport transport;
+
+    ss::sharded<pps::seq_writer> seq;
+    seq
+      .start(
+        model::node_id{0},
+        ss::default_smp_service_group(),
+        std::ref(transport),
+        std::reference_wrapper(s),
+        ss::sharded_parameter(
+          [] { return std::make_unique<sequence_state_checker_test>(); }))
+      .get();
+    auto stop_seq = ss::defer([&seq]() { seq.stop().get(); });
+
+    auto result = seq.local()
+                    .write_subject_version_imported(
+                      pps::stored_schema{
+                        .schema = {subject0, int_def0.share()},
+                        .version = version1,
+                        .id = id1,
+                        .deleted = pps::is_deleted::no})
+                    .get();
+    BOOST_REQUIRE_EQUAL(result.id, id1);
+
+    // Store apply reads the subject from the value; compaction uses the key.
+    BOOST_REQUIRE_EQUAL(transport.produced.size(), 1);
+    auto records = transport.produced.front().copy_records();
+    BOOST_REQUIRE(!records.empty());
+    iobuf_parser key_parser{records.back().key().copy()};
+    auto key = std::string{key_parser.read_string(key_parser.bytes_left())};
+    BOOST_REQUIRE(key.find("subject0") != std::string::npos);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_sync_writes_disabled) {
+    pps::sharded_store s;
+    s.start(pps::is_mutable::no, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&s]() { s.stop().get(); });
+
+    noop_transport dummy_transport;
+
+    ss::sharded<pps::seq_writer> seq;
+    seq
+      .start(
+        model::node_id{0},
+        ss::default_smp_service_group(),
+        std::ref(dummy_transport),
+        std::reference_wrapper(s),
+        ss::sharded_parameter([] {
+            return std::make_unique<sequence_state_checker_test>(
+              pps::sequence_state_checker::writes_disabled_t::yes,
+              pps::sequence_state_checker::writes_disabled_t::yes);
+        }))
+      .get();
+    auto stop_seq = ss::defer([&seq]() { seq.stop().get(); });
+
+    BOOST_REQUIRE_EXCEPTION(
+      seq.local()
+        .write_mode(
+          pps::context_subject{pps::default_context, pps::subject{""}},
+          pps::mode::read_only,
+          pps::force::no,
+          pps::write_source::schema_registry_sync)
         .get(),
       pps::exception,
       [](pps::exception e) {

--- a/src/v/pandaproxy/schema_registry/test/internal_writes.cc
+++ b/src/v/pandaproxy/schema_registry/test/internal_writes.cc
@@ -1,0 +1,281 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "pandaproxy/schema_registry/error.h"
+#include "pandaproxy/schema_registry/exceptions.h"
+#include "pandaproxy/schema_registry/types.h"
+#include "redpanda/tests/fixture.h"
+#include "schema/registry.h"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <optional>
+
+namespace pps = pandaproxy::schema_registry;
+
+class internal_writes_fixture
+  : public redpanda_thread_fixture
+  , public ::testing::Test {
+public:
+    internal_writes_fixture() {
+        wait_for_controller_leadership().get();
+        registry = schema::registry::make_default(app.schema_registry().get());
+    }
+
+    pps::context_schema_id import(pps::stored_schema schema) {
+        return registry->import_schema(std::move(schema)).get();
+    }
+
+    std::error_code import_error_code(pps::stored_schema schema) {
+        try {
+            registry->import_schema(std::move(schema)).get();
+        } catch (const pps::exception& e) {
+            return e.code();
+        }
+        ADD_FAILURE() << "import_schema unexpectedly succeeded";
+        return {};
+    }
+
+    std::error_code get_subject_schema_error(
+      pps::context_subject sub, std::optional<pps::schema_version> version) {
+        try {
+            registry->get_subject_schema(std::move(sub), version).get();
+        } catch (const pps::exception& e) {
+            return e.code();
+        }
+        ADD_FAILURE() << "get_subject_schema unexpectedly succeeded";
+        return {};
+    }
+
+    std::unique_ptr<schema::registry> registry;
+};
+
+TEST_F(internal_writes_fixture, imports_id_and_version) {
+    auto subject = pps::context_subject::unqualified("internal-import");
+    auto schema_def = pps::schema_definition(
+      R"({"type":"record","name":"r1","fields":[{"name":"f1","type":"string"}]})",
+      pps::schema_type::avro);
+
+    ASSERT_TRUE(registry->write_mode(subject, pps::mode::read_only).get());
+
+    auto ctx_id = registry
+                    ->import_schema(
+                      pps::stored_schema{
+                        .schema = {subject, schema_def.share()},
+                        .version = pps::schema_version{7},
+                        .id = pps::schema_id{42},
+                        .deleted = pps::is_deleted::no})
+                    .get();
+    ASSERT_TRUE(ctx_id.ctx == pps::default_context);
+    ASSERT_EQ(ctx_id.id, pps::schema_id{42});
+
+    auto stored
+      = registry->get_subject_schema(subject, pps::schema_version{7}).get();
+    ASSERT_EQ(stored.version, pps::schema_version{7});
+    ASSERT_EQ(stored.id, pps::schema_id{42});
+    ASSERT_TRUE(stored.deleted == pps::is_deleted::no);
+
+    auto duplicate = registry
+                       ->import_schema(
+                         pps::stored_schema{
+                           .schema = {subject, schema_def.share()},
+                           .version = pps::schema_version{7},
+                           .id = pps::schema_id{42},
+                           .deleted = pps::is_deleted::no})
+                       .get();
+    ASSERT_EQ(duplicate.id, pps::schema_id{42});
+}
+
+TEST_F(internal_writes_fixture, import_rejects_conflicts) {
+    auto subject = pps::context_subject::unqualified("internal-conflict");
+    auto schema_def = pps::schema_definition(
+      R"("int")", pps::schema_type::avro);
+    auto other_def = pps::schema_definition(
+      R"("string")", pps::schema_type::avro);
+
+    registry
+      ->import_schema(
+        pps::stored_schema{
+          .schema = {subject, schema_def.share()},
+          .version = pps::schema_version{1},
+          .id = pps::schema_id{9},
+          .deleted = pps::is_deleted::no})
+      .get();
+
+    ASSERT_EQ(
+      import_error_code(
+        pps::stored_schema{
+          .schema = {subject, schema_def.share()},
+          .version = pps::schema_version{1},
+          .id = pps::schema_id{10},
+          .deleted = pps::is_deleted::no}),
+      pps::error_code::subject_version_schema_id_already_exists);
+
+    ASSERT_EQ(
+      import_error_code(pps::stored_schema{
+        .schema
+        = {pps::context_subject::unqualified("internal-conflict-other"),
+           other_def.share()},
+        .version = pps::schema_version{1},
+        .id = pps::schema_id{9},
+        .deleted = pps::is_deleted::no}),
+      pps::error_code::subject_version_operation_not_permitted);
+}
+
+TEST_F(internal_writes_fixture, import_rejects_invalid_ids) {
+    auto subject = pps::context_subject::unqualified("internal-invalid-id");
+    auto schema_def = pps::schema_definition(
+      R"("int")", pps::schema_type::avro);
+
+    // Ids come from an external Schema Registry: non-positive ids must be
+    // rejected, as must INT32_MAX, whose successor is not representable.
+    for (auto id :
+         {pps::schema_id{-1},
+          pps::schema_id{0},
+          pps::schema_id{std::numeric_limits<pps::schema_id::type>::max()}}) {
+        ASSERT_EQ(
+          import_error_code(
+            pps::stored_schema{
+              .schema = {subject, schema_def.share()},
+              .version = pps::schema_version{1},
+              .id = id,
+              .deleted = pps::is_deleted::no}),
+          pps::error_code::schema_invalid);
+    }
+
+    // Versions are equally external input: valid versions are
+    // 1..INT32_MAX-1, since later writes to the subject compute version + 1.
+    for (auto version :
+         {pps::schema_version{0},
+          pps::schema_version{-1},
+          pps::schema_version{
+            std::numeric_limits<pps::schema_version::type>::max()}}) {
+        ASSERT_EQ(
+          import_error_code(
+            pps::stored_schema{
+              .schema = {subject, schema_def.share()},
+              .version = version,
+              .id = pps::schema_id{1},
+              .deleted = pps::is_deleted::no}),
+          pps::error_code::schema_version_invalid);
+    }
+
+    try {
+        registry->get_subject_schema(subject, std::nullopt).get();
+        FAIL() << "expected subject_not_found";
+    } catch (const pps::exception& e) {
+        ASSERT_EQ(e.code(), pps::error_code::subject_not_found);
+    }
+
+    // Boundary acceptance: the largest valid id and version are accepted.
+    constexpr auto max_id = pps::schema_id{
+      std::numeric_limits<pps::schema_id::type>::max() - 1};
+    constexpr auto max_version = pps::schema_version{
+      std::numeric_limits<pps::schema_version::type>::max() - 1};
+    auto boundary_subject = pps::context_subject::unqualified(
+      "internal-boundary-id");
+    auto ctx_id = registry
+                    ->import_schema(
+                      pps::stored_schema{
+                        .schema = {boundary_subject, schema_def.share()},
+                        .version = max_version,
+                        .id = max_id,
+                        .deleted = pps::is_deleted::no})
+                    .get();
+    ASSERT_EQ(ctx_id.id, max_id);
+    auto stored
+      = registry->get_subject_schema(boundary_subject, max_version).get();
+    ASSERT_EQ(stored.id, max_id);
+}
+
+TEST_F(internal_writes_fixture, deletes_bypass_readonly) {
+    auto subject = pps::context_subject::unqualified("internal-delete");
+    auto schema_def = pps::schema_definition(
+      R"("int")", pps::schema_type::avro);
+
+    registry
+      ->import_schema(
+        pps::stored_schema{
+          .schema = {subject, schema_def.share()},
+          .version = pps::schema_version{1},
+          .id = pps::schema_id{77},
+          .deleted = pps::is_deleted::no})
+      .get();
+    registry->write_mode(subject, pps::mode::read_only).get();
+
+    ASSERT_TRUE(
+      registry->soft_delete_schema(subject, pps::schema_version{1}).get());
+    auto deleted = registry
+                     ->permanent_delete_schema(subject, pps::schema_version{1})
+                     .get();
+    ASSERT_EQ(deleted.size(), 1);
+    ASSERT_EQ(deleted.front(), pps::schema_version{1});
+
+    ASSERT_THROW(
+      registry->get_subject_schema(subject, pps::schema_version{1}).get(),
+      pps::exception);
+}
+
+TEST_F(internal_writes_fixture, imports_preserve_deleted_state) {
+    auto subject = pps::context_subject::unqualified("internal-deleted-state");
+    auto schema_def = pps::schema_definition(
+      R"("int")", pps::schema_type::avro);
+    auto other_def = pps::schema_definition(
+      R"("string")", pps::schema_type::avro);
+
+    // Import a version that was already soft-deleted at the source.
+    import(
+      pps::stored_schema{
+        .schema = {subject, schema_def.share()},
+        .version = pps::schema_version{1},
+        .id = pps::schema_id{5},
+        .deleted = pps::is_deleted::yes});
+
+    // Soft-deleted versions are invisible to ordinary reads: the subject's only
+    // version is deleted, so the subject itself reads as not found.
+    ASSERT_EQ(
+      get_subject_schema_error(subject, pps::schema_version{1}),
+      pps::error_code::subject_not_found);
+
+    // ...but the id slot stays occupied: reusing the same subject/version/id
+    // with a different definition must conflict, even while soft-deleted.
+    ASSERT_EQ(
+      import_error_code(
+        pps::stored_schema{
+          .schema = {subject, other_def.share()},
+          .version = pps::schema_version{1},
+          .id = pps::schema_id{5},
+          .deleted = pps::is_deleted::yes}),
+      pps::error_code::subject_version_operation_not_permitted);
+
+    // Source un-deletes the version: re-importing with deleted::no makes it
+    // readable again under the same id.
+    import(
+      pps::stored_schema{
+        .schema = {subject, schema_def.share()},
+        .version = pps::schema_version{1},
+        .id = pps::schema_id{5},
+        .deleted = pps::is_deleted::no});
+    auto stored
+      = registry->get_subject_schema(subject, pps::schema_version{1}).get();
+    ASSERT_EQ(stored.id, pps::schema_id{5});
+    ASSERT_TRUE(stored.deleted == pps::is_deleted::no);
+
+    // Source soft-deletes again: the version disappears from ordinary reads.
+    import(
+      pps::stored_schema{
+        .schema = {subject, schema_def.share()},
+        .version = pps::schema_version{1},
+        .id = pps::schema_id{5},
+        .deleted = pps::is_deleted::yes});
+    ASSERT_EQ(
+      get_subject_schema_error(subject, pps::schema_version{1}),
+      pps::error_code::subject_not_found);
+}

--- a/src/v/pandaproxy/schema_registry/test/utils.h
+++ b/src/v/pandaproxy/schema_registry/test/utils.h
@@ -17,17 +17,29 @@ class sequence_state_checker_test
   : public pandaproxy::schema_registry::sequence_state_checker {
 public:
     explicit sequence_state_checker_test(
-      writes_disabled_t wd = writes_disabled_t::no)
-      : _wd(wd) {}
-    writes_disabled_t writes_disabled() const final { return _wd; }
+      writes_disabled_t client_writes_disabled = writes_disabled_t::no,
+      writes_disabled_t sync_writes_disabled = writes_disabled_t::no)
+      : _client_writes_disabled(client_writes_disabled)
+      , _sync_writes_disabled(sync_writes_disabled) {}
+
+    writes_disabled_t writes_disabled(
+      pandaproxy::schema_registry::write_source source) const final {
+        switch (source) {
+        case pandaproxy::schema_registry::write_source::client:
+            return _client_writes_disabled;
+        case pandaproxy::schema_registry::write_source::schema_registry_sync:
+            return _sync_writes_disabled;
+        }
+    }
 
 private:
-    writes_disabled_t _wd;
+    writes_disabled_t _client_writes_disabled;
+    writes_disabled_t _sync_writes_disabled;
 };
 
-/// No-op transport used in tests where seq_writer is only instantiated to
-/// receive consume_to_store offset updates.
-class noop_transport final : public pandaproxy::schema_registry::transport {
+/// Transport whose operations all throw, for tests where the transport
+/// must not be reached.
+class noop_transport : public pandaproxy::schema_registry::transport {
 public:
     ss::future<> stop() final { return ss::now(); }
     ss::future<pandaproxy::schema_registry::produce_result>
@@ -54,4 +66,23 @@ public:
         throw std::runtime_error(
           "noop_transport::create_topic not implemented");
     }
+};
+
+/// Transport that applies writes and records produced batches.
+class accepting_transport final : public noop_transport {
+public:
+    ss::future<pandaproxy::schema_registry::produce_result>
+    produce(model::record_batch batch) override {
+        auto base = batch.base_offset();
+        produced.push_back(std::move(batch));
+        return ss::make_ready_future<
+          pandaproxy::schema_registry::produce_result>(
+          pandaproxy::schema_registry::produce_result{.base_offset = base});
+    }
+
+    ss::future<model::offset> get_high_watermark() override {
+        return ss::make_ready_future<model::offset>(model::offset{0});
+    }
+
+    chunked_vector<model::record_batch> produced;
 };

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -43,6 +43,24 @@ using verbose = ss::bool_class<struct verbose_tag>;
 using is_qualified = ss::bool_class<struct is_qualified_tag>;
 using is_config_or_mode = ss::bool_class<struct is_config_or_mode_tag>;
 
+/// Identifies the write path for shadowing write policy. The
+/// schema_registry_sync source also bypasses destination write policy
+/// (read-only mode and the mode_mutability lockout); \ref force stays
+/// independent, carrying only Confluent `?force=` semantics.
+enum class write_source {
+    /// Public write paths: HTTP handlers and other client-facing callers.
+    client,
+    /// The internal Schema Registry sync importer (shadow link API sync).
+    schema_registry_sync,
+};
+
+/// Internal Schema Registry sync replicates a source cluster's
+/// already-accepted writes, so it bypasses destination write policy
+/// (read-only mode and the mode_mutability lockout). Client writes do not.
+inline bool bypasses_write_policy(write_source src) {
+    return src == write_source::schema_registry_sync;
+}
+
 template<typename E>
 std::enable_if_t<std::is_enum_v<E>, std::optional<E>>
   from_string_view(std::string_view);

--- a/src/v/schema/registry.cc
+++ b/src/v/schema/registry.cc
@@ -89,6 +89,79 @@ public:
         co_return ppsr::context_schema_id{std::move(ctx), result.id};
     }
 
+    ss::future<ppsr::context_schema_id>
+    import_schema(ppsr::stored_schema schema) override {
+        auto ctx = schema.schema.sub().ctx;
+        auto [reader, writer] = co_await service();
+        co_await writer->read_sync();
+        auto parsed = co_await reader->make_canonical_schema(
+          std::move(schema.schema),
+          ppsr::normalize::no,
+          /*consider_always_normalize_config=*/false);
+        co_await reader->validate_schema(parsed.share());
+        schema.schema = std::move(parsed);
+        auto result = co_await writer->write_subject_version_imported(
+          std::move(schema));
+        _last_sync_time = ss::lowres_clock::now();
+        co_return ppsr::context_schema_id{std::move(ctx), result.id};
+    }
+
+    ss::future<bool> soft_delete_schema(
+      ppsr::context_subject sub, ppsr::schema_version version) override {
+        auto [_, writer] = co_await service();
+        auto result = co_await writer->delete_subject_version(
+          std::move(sub), version, ppsr::write_source::schema_registry_sync);
+        _last_sync_time = ss::lowres_clock::now();
+        co_return result;
+    }
+
+    ss::future<chunked_vector<ppsr::schema_version>> permanent_delete_schema(
+      ppsr::context_subject sub,
+      std::optional<ppsr::schema_version> version) override {
+        auto [_, writer] = co_await service();
+        auto result = co_await writer->delete_subject_permanent(
+          std::move(sub), version, ppsr::write_source::schema_registry_sync);
+        _last_sync_time = ss::lowres_clock::now();
+        co_return result;
+    }
+
+    ss::future<bool>
+    write_mode(ppsr::context_subject sub, ppsr::mode m) override {
+        auto [_, writer] = co_await service();
+        auto result = co_await writer->write_mode(
+          std::move(sub),
+          m,
+          ppsr::force::yes,
+          ppsr::write_source::schema_registry_sync);
+        _last_sync_time = ss::lowres_clock::now();
+        co_return result;
+    }
+
+    ss::future<bool> delete_mode(ppsr::context_subject sub) override {
+        auto [_, writer] = co_await service();
+        auto result = co_await writer->delete_mode(
+          std::move(sub), ppsr::write_source::schema_registry_sync);
+        _last_sync_time = ss::lowres_clock::now();
+        co_return result;
+    }
+
+    ss::future<bool> write_config(
+      ppsr::context_subject sub, ppsr::compatibility_level compat) override {
+        auto [_, writer] = co_await service();
+        auto result = co_await writer->write_config(
+          std::move(sub), compat, ppsr::write_source::schema_registry_sync);
+        _last_sync_time = ss::lowres_clock::now();
+        co_return result;
+    }
+
+    ss::future<bool> delete_config(ppsr::context_subject sub) override {
+        auto [_, writer] = co_await service();
+        auto result = co_await writer->delete_config(
+          std::move(sub), ppsr::write_source::schema_registry_sync);
+        _last_sync_time = ss::lowres_clock::now();
+        co_return result;
+    }
+
 private:
     ss::future<std::pair<ppsr::sharded_store*, ppsr::seq_writer*>>
     service() const {
@@ -131,6 +204,38 @@ public:
     }
     ss::future<ppsr::context_schema_id>
     create_schema(ppsr::subject_schema) override {
+        throw std::logic_error(
+          "invalid attempted usage of a disabled schema registry");
+    }
+    ss::future<ppsr::context_schema_id>
+    import_schema(ppsr::stored_schema) override {
+        throw std::logic_error(
+          "invalid attempted usage of a disabled schema registry");
+    }
+    ss::future<bool>
+    soft_delete_schema(ppsr::context_subject, ppsr::schema_version) override {
+        throw std::logic_error(
+          "invalid attempted usage of a disabled schema registry");
+    }
+    ss::future<chunked_vector<ppsr::schema_version>> permanent_delete_schema(
+      ppsr::context_subject, std::optional<ppsr::schema_version>) override {
+        throw std::logic_error(
+          "invalid attempted usage of a disabled schema registry");
+    }
+    ss::future<bool> write_mode(ppsr::context_subject, ppsr::mode) override {
+        throw std::logic_error(
+          "invalid attempted usage of a disabled schema registry");
+    }
+    ss::future<bool> delete_mode(ppsr::context_subject) override {
+        throw std::logic_error(
+          "invalid attempted usage of a disabled schema registry");
+    }
+    ss::future<bool>
+    write_config(ppsr::context_subject, ppsr::compatibility_level) override {
+        throw std::logic_error(
+          "invalid attempted usage of a disabled schema registry");
+    }
+    ss::future<bool> delete_config(ppsr::context_subject) override {
         throw std::logic_error(
           "invalid attempted usage of a disabled schema registry");
     }

--- a/src/v/schema/registry.h
+++ b/src/v/schema/registry.h
@@ -70,5 +70,50 @@ public:
         std::optional<pandaproxy::schema_registry::schema_version>) const = 0;
     virtual ss::future<pandaproxy::schema_registry::context_schema_id>
       create_schema(pandaproxy::schema_registry::subject_schema) = 0;
+
+    /// \name Internal sync/import API
+    ///
+    /// Used by shadow-link Schema Registry API sync. These calls preserve
+    /// source ids/versions and bypass public REST write guards: read-only mode,
+    /// mode_mutability, and the API-sync client write blocker. They remain
+    /// blocked while _schemas itself is topic-shadowed.
+    ///
+    /// Deletes are not as idempotent as imports: reference checks still
+    /// apply and permanently deleting an already-deleted target throws, so
+    /// deletes must be replayed in source order.
+    ///
+    /// Do not call these on behalf of a client request.
+    ///@{
+
+    /// Import a schema with source id/version. Identical imports are no-ops;
+    /// conflicts throw.
+    virtual ss::future<pandaproxy::schema_registry::context_schema_id>
+      import_schema(pandaproxy::schema_registry::stored_schema) = 0;
+
+    virtual ss::future<bool> soft_delete_schema(
+      pandaproxy::schema_registry::context_subject,
+      pandaproxy::schema_registry::schema_version) = 0;
+
+    virtual ss::future<
+      chunked_vector<pandaproxy::schema_registry::schema_version>>
+      permanent_delete_schema(
+        pandaproxy::schema_registry::context_subject,
+        std::optional<pandaproxy::schema_registry::schema_version>) = 0;
+
+    virtual ss::future<bool> write_mode(
+      pandaproxy::schema_registry::context_subject,
+      pandaproxy::schema_registry::mode) = 0;
+
+    virtual ss::future<bool>
+      delete_mode(pandaproxy::schema_registry::context_subject) = 0;
+
+    virtual ss::future<bool> write_config(
+      pandaproxy::schema_registry::context_subject,
+      pandaproxy::schema_registry::compatibility_level) = 0;
+
+    virtual ss::future<bool>
+      delete_config(pandaproxy::schema_registry::context_subject) = 0;
+
+    ///@}
 };
 } // namespace schema

--- a/src/v/schema/tests/BUILD
+++ b/src/v/schema/tests/BUILD
@@ -13,6 +13,7 @@ redpanda_test_cc_library(
         "//src/v/base",
         "//src/v/pandaproxy/schema_registry:types",
         "//src/v/schema:registry",
+        "@fmt",
         "@seastar",
     ],
 )

--- a/src/v/schema/tests/fake_registry.cc
+++ b/src/v/schema/tests/fake_registry.cc
@@ -18,6 +18,11 @@
 #include <seastar/core/future.hh>
 #include <seastar/util/log.hh>
 
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <utility>
+
 namespace {
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables,cert-err58-cpp)
 static ss::logger dummy_logger("schema_test_logger");
@@ -125,6 +130,120 @@ schema::fake_registry::create_schema(ppsr::subject_schema unparsed) {
     });
     co_return _store.schemas.back().context_id();
 }
+
+ss::future<ppsr::context_schema_id>
+schema::fake_registry::import_schema(ppsr::stored_schema imported) {
+    maybe_throw_injected_failure();
+
+    for (const auto& s : _store.schemas) {
+        if (
+          s.context_id() == imported.context_id()
+          && s.schema.def() != imported.schema.def()) {
+            throw as_exception(
+              ppsr::overwrite_schema_with_id_not_permitted(imported.id));
+        }
+    }
+
+    for (auto& s : _store.schemas) {
+        if (
+          s.schema.sub() == imported.schema.sub()
+          && s.version == imported.version) {
+            if (s.id != imported.id) {
+                throw as_exception(
+                  ppsr::error_info{
+                    ppsr::error_code::subject_version_schema_id_already_exists,
+                    fmt::format(
+                      "Subject {} version {} is already registered with "
+                      "schema id {}, not imported schema id {}",
+                      imported.schema.sub(),
+                      imported.version(),
+                      s.id(),
+                      imported.id())});
+            }
+            s = imported.share();
+            co_return s.context_id();
+        }
+    }
+
+    _store.schemas.push_back(imported.share());
+    co_return imported.context_id();
+}
+
+ss::future<bool> schema::fake_registry::soft_delete_schema(
+  ppsr::context_subject sub, ppsr::schema_version version) {
+    maybe_throw_injected_failure();
+    for (auto& s : _store.schemas) {
+        if (s.schema.sub() == sub && s.version == version) {
+            auto was_deleted = std::exchange(s.deleted, ppsr::is_deleted::yes);
+            co_return was_deleted == ppsr::is_deleted::no;
+        }
+    }
+    throw as_exception(ppsr::not_found(sub, version));
+}
+
+ss::future<chunked_vector<ppsr::schema_version>>
+schema::fake_registry::permanent_delete_schema(
+  ppsr::context_subject sub, std::optional<ppsr::schema_version> version) {
+    maybe_throw_injected_failure();
+    chunked_vector<ppsr::schema_version> deleted;
+    std::erase_if(_store.schemas, [&](const ppsr::stored_schema& schema) {
+        const auto matches
+          = schema.schema.sub() == sub
+            && (!version.has_value() || schema.version == *version);
+        if (matches) {
+            deleted.push_back(schema.version);
+        }
+        return matches;
+    });
+    if (deleted.empty()) {
+        throw as_exception(
+          version.has_value() ? ppsr::not_found(sub, *version)
+                              : ppsr::not_found(sub));
+    }
+    co_return deleted;
+}
+
+ss::future<bool>
+schema::fake_registry::write_mode(ppsr::context_subject sub, ppsr::mode mode) {
+    maybe_throw_injected_failure();
+    auto it = _modes.find(sub);
+    if (it == _modes.end()) {
+        _modes.emplace(std::move(sub), mode);
+        co_return true;
+    }
+    if (it->second == mode) {
+        co_return false;
+    }
+    it->second = mode;
+    co_return true;
+}
+
+ss::future<bool> schema::fake_registry::delete_mode(ppsr::context_subject sub) {
+    maybe_throw_injected_failure();
+    co_return _modes.erase(sub) > 0;
+}
+
+ss::future<bool> schema::fake_registry::write_config(
+  ppsr::context_subject sub, ppsr::compatibility_level compat) {
+    maybe_throw_injected_failure();
+    auto it = _configs.find(sub);
+    if (it == _configs.end()) {
+        _configs.emplace(std::move(sub), compat);
+        co_return true;
+    }
+    if (it->second == compat) {
+        co_return false;
+    }
+    it->second = compat;
+    co_return true;
+}
+
+ss::future<bool>
+schema::fake_registry::delete_config(ppsr::context_subject sub) {
+    maybe_throw_injected_failure();
+    co_return _configs.erase(sub) > 0;
+}
+
 const std::vector<ppsr::stored_schema>& schema::fake_registry::get_all() {
     maybe_throw_injected_failure();
     return _store.schemas;

--- a/src/v/schema/tests/fake_registry.h
+++ b/src/v/schema/tests/fake_registry.h
@@ -15,6 +15,8 @@
 
 #include <seastar/core/future.hh>
 
+#include <map>
+
 namespace schema {
 
 struct fake_store : public pandaproxy::schema_registry::schema_getter {
@@ -64,6 +66,33 @@ public:
     ss::future<pandaproxy::schema_registry::context_schema_id> create_schema(
       pandaproxy::schema_registry::subject_schema unparsed) override;
 
+    ss::future<pandaproxy::schema_registry::context_schema_id>
+    import_schema(pandaproxy::schema_registry::stored_schema imported) override;
+
+    ss::future<bool> soft_delete_schema(
+      pandaproxy::schema_registry::context_subject sub,
+      pandaproxy::schema_registry::schema_version version) override;
+
+    ss::future<chunked_vector<pandaproxy::schema_registry::schema_version>>
+    permanent_delete_schema(
+      pandaproxy::schema_registry::context_subject sub,
+      std::optional<pandaproxy::schema_registry::schema_version> version)
+      override;
+
+    ss::future<bool> write_mode(
+      pandaproxy::schema_registry::context_subject sub,
+      pandaproxy::schema_registry::mode mode) override;
+
+    ss::future<bool>
+    delete_mode(pandaproxy::schema_registry::context_subject sub) override;
+
+    ss::future<bool> write_config(
+      pandaproxy::schema_registry::context_subject sub,
+      pandaproxy::schema_registry::compatibility_level compat) override;
+
+    ss::future<bool>
+    delete_config(pandaproxy::schema_registry::context_subject sub) override;
+
     const std::vector<pandaproxy::schema_registry::stored_schema>& get_all();
 
     void set_inject_failures(const std::exception_ptr& injected) {
@@ -75,5 +104,13 @@ private:
 
     std::exception_ptr _injected_failure;
     mutable fake_store _store;
+    std::map<
+      pandaproxy::schema_registry::context_subject,
+      pandaproxy::schema_registry::mode>
+      _modes;
+    std::map<
+      pandaproxy::schema_registry::context_subject,
+      pandaproxy::schema_registry::compatibility_level>
+      _configs;
 };
 } // namespace schema


### PR DESCRIPTION
This extends the internal client interface `schema::registry` to support write operations for syncing schemas / configs / modes, to be used by the upcoming shadow linking schema syncing task.

The key design choice is that this PR introduces a `write_source` type that distinguishes writes from clients through the HTTP API handlers and internal schema syncing writes, which are handled differently internally for the purposes of bypassing internal checks such as those imposed by the mode of the subject (READONLY / READWRITE / IMPORT).

Fixes https://redpandadata.atlassian.net/browse/CORE-16409

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
