### PR TITLE
Some alloc improvements

### DIFF
--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -356,7 +356,7 @@ ss::future<produce_response::partition> do_produce_topic_partition(
         auto dur = std::chrono::steady_clock::now() - start;
         octx.rctx.connection()->server().update_produce_latency(dur);
     } else {
-        m->cancel();
+        m.cancel();
     }
     co_return p;
 }

--- a/src/v/kafka/server/kafka_probe.h
+++ b/src/v/kafka/server/kafka_probe.h
@@ -159,8 +159,8 @@ public:
     // log_message_timestamp_alert_before_ms
     void produce_bad_create_time() { _produce_bad_create_time++; }
 
-    std::unique_ptr<hist_t::measurement> auto_produce_measurement() {
-        return _produce_latency.auto_measure();
+    hist_t::measurement auto_produce_measurement() {
+        return hist_t::measurement(_produce_latency);
     }
 
     void record_fetch_latency(std::chrono::microseconds micros) {

--- a/src/v/raft/BUILD
+++ b/src/v/raft/BUILD
@@ -174,6 +174,7 @@ redpanda_cc_library(
         "@abseil-cpp//absl/container:btree",
         "@abseil-cpp//absl/container:flat_hash_map",
         "@abseil-cpp//absl/container:flat_hash_set",
+        "@abseil-cpp//absl/container:inlined_vector",
         "@abseil-cpp//absl/container:node_hash_map",
         "@boost//:container",
         "@boost//:range",

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -3152,14 +3152,22 @@ ss::future<> consensus::maybe_commit_configuration(ssx::semaphore_units u) {
         co_return;
     }
 
-    auto latest_cfg = _configuration_manager.get_latest();
-
-    /**
-     * current config still contains learners, do nothing
-     */
-    if (unlikely(!latest_cfg.current_config().learners.empty())) {
-        co_return;
+    // Inspect the committed configuration by reference first. The common case
+    // is a stable, simple configuration that needs no work, so return before
+    // copying the configuration - only finishing a transition (the rare
+    // transitional/joint states) needs a mutable copy.
+    {
+        const auto& committed_cfg = _configuration_manager.get_latest();
+        // current config still contains learners, do nothing
+        if (unlikely(!committed_cfg.current_config().learners.empty())) {
+            co_return;
+        }
+        if (committed_cfg.get_state() == configuration_state::simple) {
+            co_return;
+        }
     }
+
+    auto latest_cfg = _configuration_manager.get_latest();
     switch (latest_cfg.get_state()) {
     case configuration_state::simple:
         co_return;

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -3141,32 +3141,34 @@ void consensus::maybe_update_leader_commit_idx() {
  * state transition is decided and executed
  */
 ss::future<> consensus::maybe_commit_configuration(ssx::semaphore_units u) {
+    // The checks here are synchronous and almost always conclude that there
+    // is nothing to do (a stable, simple configuration), so perform them
+    // before allocating a coroutine frame for the rare transition handling.
+
     // we are not a leader, do nothing
     if (_vstate != vote_state::leader) {
-        co_return;
+        return ss::now();
     }
 
-    auto latest_offset = _configuration_manager.get_latest_offset();
     // no configurations were committed
-    if (latest_offset > _commit_index) {
-        co_return;
+    if (_configuration_manager.get_latest_offset() > _commit_index) {
+        return ss::now();
     }
 
-    // Inspect the committed configuration by reference first. The common case
-    // is a stable, simple configuration that needs no work, so return before
-    // copying the configuration - only finishing a transition (the rare
-    // transitional/joint states) needs a mutable copy.
-    {
-        const auto& committed_cfg = _configuration_manager.get_latest();
-        // current config still contains learners, do nothing
-        if (unlikely(!committed_cfg.current_config().learners.empty())) {
-            co_return;
-        }
-        if (committed_cfg.get_state() == configuration_state::simple) {
-            co_return;
-        }
+    const auto& committed_cfg = _configuration_manager.get_latest();
+    // current config still contains learners, do nothing
+    if (unlikely(!committed_cfg.current_config().learners.empty())) {
+        return ss::now();
+    }
+    if (committed_cfg.get_state() == configuration_state::simple) {
+        return ss::now();
     }
 
+    return do_commit_configuration_transition(std::move(u));
+}
+
+ss::future<>
+consensus::do_commit_configuration_transition(ssx::semaphore_units u) {
     auto latest_cfg = _configuration_manager.get_latest();
     switch (latest_cfg.get_state()) {
     case configuration_state::simple:

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -717,6 +717,7 @@ private:
       interrupt_configuration_change(model::revision_id, Func);
 
     ss::future<> maybe_commit_configuration(ssx::semaphore_units);
+    ss::future<> do_commit_configuration_transition(ssx::semaphore_units);
     void maybe_promote_to_voter(vnode);
 
     ss::future<model::record_batch_reader>

--- a/src/v/raft/group_configuration.h
+++ b/src/v/raft/group_configuration.h
@@ -16,6 +16,7 @@
 #include "reflection/adl.h"
 #include "serde/rw/vector.h"
 
+#include <absl/container/inlined_vector.h>
 #include <boost/range/join.hpp>
 
 #include <optional>
@@ -447,7 +448,10 @@ auto quorum_match(ValueProvider&& f, Range&& range) {
         return ret_t{};
     }
 
-    std::vector<ret_t> values;
+    // quorum_match runs on every commit index update i.e. on every replicate
+    // round, so keep the voter values inline for any realistic replication
+    // factor instead of allocating.
+    absl::InlinedVector<ret_t, 5> values;
     values.reserve(range.size());
     std::transform(
       std::cbegin(range),

--- a/src/v/raft/replicate_batcher.cc
+++ b/src/v/raft/replicate_batcher.cc
@@ -112,7 +112,7 @@ replicate_batcher::cache_and_wait_for_result(
     item_ptr item;
     try {
         auto holder = _bg.hold();
-        item = co_await do_cache(std::move(r), opts);
+        item = co_await do_cache_with_backpressure(std::move(r), opts);
 
         // now request is already enqueued, we can release first
         // stage future
@@ -169,24 +169,15 @@ ss::future<> replicate_batcher::stop() {
     });
 }
 
-ss::future<replicate_batcher::item_ptr> replicate_batcher::do_cache(
-  chunked_vector<model::record_batch> batches, replicate_options opts) {
-    size_t bytes = std::accumulate(
-      batches.cbegin(),
-      batches.cend(),
-      size_t{0},
-      [](size_t sum, const model::record_batch& b) {
-          return sum + b.size_bytes();
-      });
-    co_return co_await do_cache_with_backpressure(
-      std::move(batches), bytes, opts);
-}
-
 ss::future<replicate_batcher::item_ptr>
 replicate_batcher::do_cache_with_backpressure(
-  chunked_vector<model::record_batch> batches,
-  size_t bytes,
-  replicate_options opts) {
+  chunked_vector<model::record_batch> batches, replicate_options opts) {
+    size_t bytes = 0;
+    size_t record_count = 0;
+    for (const auto& b : batches) {
+        bytes += b.size_bytes();
+        record_count += b.record_count();
+    }
     /**
      * Produce a message larger than the internal raft batch accumulator
      * (default 1Mb) the semaphore can't be acquired. Closing
@@ -210,10 +201,6 @@ replicate_batcher::do_cache_with_backpressure(
           _max_batch_size_sem, std::min(bytes, _max_batch_size));
     }
 
-    size_t record_count = 0;
-    for (auto& b : batches) {
-        record_count += b.record_count();
-    }
     auto i = ss::make_lw_shared<item>(
       record_count, std::move(batches), std::move(u), opts);
 

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -105,11 +105,8 @@ private:
       std::vector<ssx::semaphore_units>,
       absl::flat_hash_map<vnode, follower_req_seq>);
 
-    ss::future<item_ptr>
-      do_cache(chunked_vector<model::record_batch>, replicate_options);
-
     ss::future<replicate_batcher::item_ptr> do_cache_with_backpressure(
-      chunked_vector<model::record_batch>, size_t, replicate_options);
+      chunked_vector<model::record_batch>, replicate_options);
 
     ss::future<result<replicate_result>> cache_and_wait_for_result(
       ss::promise<> enqueued,

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -34,8 +34,8 @@ ss::future<chunked_vector<model::record_batch>>
 replicate_entries_stm::share_batches() {
     // one extra copy is needed for retries
     chunked_vector<model::record_batch> batches;
-    batches.reserve(_batches->size());
-    co_await ssx::async_for_each(*_batches, [&batches](model::record_batch& b) {
+    batches.reserve(_batches.size());
+    co_await ssx::async_for_each(_batches, [&batches](model::record_batch& b) {
         batches.push_back(b.share());
     });
 
@@ -279,7 +279,7 @@ ss::future<result<replicate_result>> replicate_entries_stm::apply(units_t u) {
         // Wait until all RPCs will be dispatched
         return _dispatch_sem.wait(_requests_count).then([this] {
             // release memory reservations, and destroy data
-            _batches.reset();
+            _batches = {};
             _units.release();
         });
     });
@@ -368,9 +368,7 @@ replicate_entries_stm::replicate_entries_stm(
   , _meta(r.metadata())
   , _is_flush_required(r.is_flush_required())
   , _batches_size(r.batches_size())
-  , _batches(
-      std::make_unique<chunked_vector<model::record_batch>>(
-        std::move(r).release_batches()))
+  , _batches(std::move(r).release_batches())
   , _followers_seq(std::move(seqs))
   , _ctxlog(_ptr->_ctxlog) {}
 

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -42,15 +42,6 @@ replicate_entries_stm::share_batches() {
     co_return batches;
 }
 
-ss::future<> replicate_entries_stm::flush_log() {
-    auto flush_f = ss::now();
-    if (_is_flush_required) {
-        flush_f = _ptr->flush_log().discard_result();
-    }
-    _dispatch_sem.signal();
-    return flush_f;
-}
-
 clock_type::time_point replicate_entries_stm::append_entries_timeout() {
     return raft::clock_type::now() + _ptr->_replicate_append_timeout;
 }
@@ -96,13 +87,25 @@ replicate_entries_stm::send_append_entries_request(
 }
 
 ss::future<> replicate_entries_stm::dispatch_one(vnode id) {
-    return ss::with_gate(
-             _req_bg,
-             [this, id]() mutable {
-                 return id == _ptr->self() ? flush_log()
-                                           : dispatch_remote_append_entries(id);
-             })
-      .handle_exception_type([](const ss::gate_closed_exception&) {});
+    try {
+        auto holder = _req_bg.hold();
+        if (id == _ptr->self()) {
+            // self dispatch means flushing the leader log
+            if (_is_flush_required) {
+                // start the flush before signalling the dispatch semaphore,
+                // the dispatcher only waits for the flush to be started, not
+                // to finish
+                auto flush_f = _ptr->flush_log();
+                _dispatch_sem.signal();
+                co_await std::move(flush_f);
+            } else {
+                _dispatch_sem.signal();
+            }
+        } else {
+            co_await dispatch_remote_append_entries(id);
+        }
+    } catch (const ss::gate_closed_exception&) {
+    }
 }
 
 ss::future<> replicate_entries_stm::dispatch_remote_append_entries(vnode id) {

--- a/src/v/raft/replicate_entries_stm.h
+++ b/src/v/raft/replicate_entries_stm.h
@@ -116,7 +116,7 @@ private:
     protocol_metadata _meta;
     flush_after_append _is_flush_required;
     size_t _batches_size;
-    std::unique_ptr<chunked_vector<model::record_batch>> _batches;
+    chunked_vector<model::record_batch> _batches;
     absl::flat_hash_map<vnode, follower_req_seq> _followers_seq;
     absl::flat_hash_map<vnode, consensus::inflight_appends_guard>
       _inflight_appends;

--- a/src/v/raft/replicate_entries_stm.h
+++ b/src/v/raft/replicate_entries_stm.h
@@ -123,7 +123,9 @@ private:
       _inflight_appends;
     ssx::semaphore _dispatch_sem{0, "raft/repl-dispatch"};
     ss::gate _req_bg;
-    ctx_log _ctxlog;
+    // Reference to the consensus instance's logger (which outlives this
+    // single-shot stm) to avoid copying its ntp on every replicate.
+    ctx_log& _ctxlog;
     model::offset _dirty_offset;
     model::offset _initial_committed_offset;
     ss::lw_shared_ptr<std::vector<ssx::semaphore_units>> _units;

--- a/src/v/raft/replicate_entries_stm.h
+++ b/src/v/raft/replicate_entries_stm.h
@@ -98,7 +98,6 @@ private:
 
     ss::future<> dispatch_one(vnode);
     ss::future<> dispatch_remote_append_entries(vnode);
-    ss::future<> flush_log();
 
     ss::future<result<append_entries_reply>>
       send_append_entries_request(vnode, chunked_vector<model::record_batch>);


### PR DESCRIPTION
As discussed, a bag of some minor filtered alloc reductions from the vibeman.

I left a few coroutine ones in but only where it was beneficial for code readability or the win was bigger than just a single alloc.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
