### PR TITLE
`ct/l1`: add `{bytes/objects}_{committed/rejected}` for maintenance jobs

### DIFF
--- a/src/v/cloud_topics/level_one/maintenance/compaction/compaction_sink.cc
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/compaction_sink.cc
@@ -93,6 +93,7 @@ compaction_sink::compaction_sink(
   ss::abort_source& as,
   config::binding<size_t> max_object_size,
   size_t upload_part_size,
+  compaction_worker_probe& probe,
   prefix_logger& ctxlog,
   object_builder::options opts,
   cloud_topics::level_zero_notifier* notifier)
@@ -109,6 +110,7 @@ compaction_sink::compaction_sink(
   , _removable_tombstone_ranges(removable_tombstone_ranges)
   , _expected_compaction_epoch(expected_compaction_epoch)
   , _start_offset(start_offset)
+  , _probe(probe)
   , _notifier(notifier) {}
 
 ss::future<bool>
@@ -178,9 +180,13 @@ ss::future<> compaction_sink::compact_objects_without_update() {
     compact_map.emplace(_tp, std::move(compaction_update));
     auto replace_res = co_await do_compact_objects(std::move(compact_map));
     if (replace_res.has_value()) {
+        _probe.add_compaction_objects_committed(_output_objects);
+        _probe.add_compaction_bytes_committed(_output_bytes);
         vlog(
           _ctxlog.info, "Finalized job without a compaction metadata update");
     } else {
+        _probe.add_compaction_objects_rejected(_output_objects);
+        _probe.add_compaction_bytes_rejected(_output_bytes);
         vlog(_ctxlog.warn, "Could not finalize job: {}.", replace_res.error());
     }
 }
@@ -201,6 +207,8 @@ ss::future<> compaction_sink::compact_objects_with_update(
     auto commit_res = co_await do_compact_objects(std::move(compact_map));
 
     if (commit_res.has_value()) {
+        _probe.add_compaction_objects_committed(_output_objects);
+        _probe.add_compaction_bytes_committed(_output_bytes);
         vlog(
           _ctxlog.info,
           "Finalized job with compaction metadata update: {}",
@@ -247,6 +255,8 @@ ss::future<> compaction_sink::finalize(bool success) {
             auto res = co_await _notifier->set_min_allowed_local_threshold(
               _tp, *new_floor);
             if (!res.has_value()) {
+                _probe.add_compaction_objects_rejected(_output_objects);
+                _probe.add_compaction_bytes_rejected(_output_bytes);
                 vlog(
                   _ctxlog.warn,
                   "[{}] skipping compaction commit: failed to advance "

--- a/src/v/cloud_topics/level_one/maintenance/compaction/compaction_sink.h
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/compaction_sink.h
@@ -13,6 +13,7 @@
 #include "cloud_topics/level_one/common/abstract_io.h"
 #include "cloud_topics/level_one/common/object.h"
 #include "cloud_topics/level_one/maintenance/l1_object_sink.h"
+#include "cloud_topics/level_one/maintenance/worker_probe.h"
 #include "cloud_topics/level_one/metastore/metastore.h"
 #include "cloud_topics/level_zero/notifier/level_zero_notifier.h"
 #include "config/property.h"
@@ -35,6 +36,7 @@ public:
       ss::abort_source&,
       config::binding<size_t>,
       size_t,
+      compaction_worker_probe&,
       prefix_logger&,
       object_builder::options = {},
       cloud_topics::level_zero_notifier* = nullptr);
@@ -75,6 +77,8 @@ private:
 
     // The start offset of the log.
     kafka::offset _start_offset;
+
+    compaction_worker_probe& _probe;
 
     // Dirty ranges returned by the `metastore` that were indexed during
     // `map_deduplication_iteration`.

--- a/src/v/cloud_topics/level_one/maintenance/compaction/tests/reducer_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/tests/reducer_test.cc
@@ -133,6 +133,7 @@ ss::future<> do_compact(
       as,
       config::mock_binding<size_t>(128_MiB),
       16_MiB,
+      probe,
       logger);
     auto reducer = compaction::sliding_window_reducer(
       std::move(src), std::move(sink));
@@ -186,6 +187,7 @@ ss::future<> do_compact_with_throwing_sink(
       as,
       config::mock_binding<size_t>(128_MiB),
       16_MiB,
+      probe,
       logger);
     auto sink = std::make_unique<l1::throwing_compaction_sink>(
       std::move(inner_sink), std::move(should_roll), std::move(should_throw));

--- a/src/v/cloud_topics/level_one/maintenance/l1_object_sink.cc
+++ b/src/v/cloud_topics/level_one/maintenance/l1_object_sink.cc
@@ -196,6 +196,7 @@ ss::future<> l1_object_sink::flush(kafka::offset object_last_offset) {
     }
 
     ++_output_objects;
+    _output_bytes += object_info.size_bytes;
 }
 
 ss::future<> l1_object_sink::prepare_iteration(kafka::offset next_extent_base) {

--- a/src/v/cloud_topics/level_one/maintenance/l1_object_sink.h
+++ b/src/v/cloud_topics/level_one/maintenance/l1_object_sink.h
@@ -89,8 +89,9 @@ protected:
     bool _any_object_failed{false};
 
     // Number of output L1 objects successfully registered with the metadata
-    // builder.
+    // builder, and their total size in bytes.
     size_t _output_objects{0};
+    size_t _output_bytes{0};
 
     // The L1 object currently being built via multipart upload.
     struct inflight_object_t {

--- a/src/v/cloud_topics/level_one/maintenance/leveling/leveling_sink.cc
+++ b/src/v/cloud_topics/level_one/maintenance/leveling/leveling_sink.cc
@@ -103,6 +103,8 @@ ss::future<> leveling_sink::finalize(bool success) {
                            ? _input_extents - _output_objects
                            : size_t{0};
         _probe.add_leveling_extents_reclaimed(reclaimed);
+        _probe.add_leveling_objects_committed(_output_objects);
+        _probe.add_leveling_bytes_committed(_output_bytes);
         vlog(
           _ctxlog.info,
           "Finalized leveling with {} extents reclaimed ({}->{})",
@@ -110,6 +112,8 @@ ss::future<> leveling_sink::finalize(bool success) {
           _input_extents,
           _output_objects);
     } else {
+        _probe.add_leveling_objects_rejected(_output_objects);
+        _probe.add_leveling_bytes_rejected(_output_bytes);
         vlog(
           _ctxlog.warn,
           "Could not commit object replacement during leveling: {}.",

--- a/src/v/cloud_topics/level_one/maintenance/worker.cc
+++ b/src/v/cloud_topics/level_one/maintenance/worker.cc
@@ -392,6 +392,7 @@ ss::future<> compaction_worker::compact_log(compaction_job* job) {
       _as,
       config::shard_local_cfg().cloud_topics_compaction_max_object_size.bind(),
       _upload_part_size,
+      _probe,
       ctxlog,
       l1::object_builder::options{
         .indexing_interval

--- a/src/v/cloud_topics/level_one/maintenance/worker_probe.cc
+++ b/src/v/cloud_topics/level_one/maintenance/worker_probe.cc
@@ -71,6 +71,60 @@ void compaction_worker_probe::setup_metrics() {
             "Net reduction in object/extent count from committed leveling "
             "ranges (input extents minus output objects) across all cloud "
             "topic partitions on this shard")),
+        sm::make_counter(
+          "compaction_objects_committed_total",
+          [this] { return _compaction_objects_committed; },
+          sm::description(
+            "Number of new L1 objects uploaded by committed compaction jobs "
+            "across all cloud topic partitions on this shard")),
+        sm::make_counter(
+          "compaction_bytes_committed_total",
+          [this] { return _compaction_bytes_committed; },
+          sm::description(
+            "Total size in bytes of new L1 objects uploaded by committed "
+            "compaction jobs across all cloud topic partitions on this "
+            "shard")),
+        sm::make_counter(
+          "leveling_objects_committed_total",
+          [this] { return _leveling_objects_committed; },
+          sm::description(
+            "Number of new L1 objects uploaded by committed leveling jobs "
+            "across all cloud topic partitions on this shard")),
+        sm::make_counter(
+          "leveling_bytes_committed_total",
+          [this] { return _leveling_bytes_committed; },
+          sm::description(
+            "Total size in bytes of new L1 objects uploaded by committed "
+            "leveling jobs across all cloud topic partitions on this "
+            "shard")),
+        sm::make_counter(
+          "compaction_objects_rejected_total",
+          [this] { return _compaction_objects_rejected; },
+          sm::description(
+            "Number of new L1 objects uploaded by compaction jobs whose "
+            "commit did not succeed (uploaded but not committed) "
+            "across all cloud topic partitions on this shard")),
+        sm::make_counter(
+          "compaction_bytes_rejected_total",
+          [this] { return _compaction_bytes_rejected; },
+          sm::description(
+            "Total size in bytes of new L1 objects uploaded by compaction "
+            "jobs whose commit did not succeed (uploaded but not "
+            "committed) across all cloud topic partitions on this shard")),
+        sm::make_counter(
+          "leveling_objects_rejected_total",
+          [this] { return _leveling_objects_rejected; },
+          sm::description(
+            "Number of new L1 objects uploaded by leveling jobs whose "
+            "commit did not succeed (uploaded but not committed) "
+            "across all cloud topic partitions on this shard")),
+        sm::make_counter(
+          "leveling_bytes_rejected_total",
+          [this] { return _leveling_bytes_rejected; },
+          sm::description(
+            "Total size in bytes of new L1 objects uploaded by leveling jobs "
+            "whose commit did not succeed (uploaded but not "
+            "committed) across all cloud topic partitions on this shard")),
       });
 }
 

--- a/src/v/cloud_topics/level_one/maintenance/worker_probe.h
+++ b/src/v/cloud_topics/level_one/maintenance/worker_probe.h
@@ -55,6 +55,36 @@ public:
         _leveling_extents_reclaimed += reclaimed;
     }
 
+    void add_compaction_objects_committed(uint64_t objects) {
+        _compaction_objects_committed += objects;
+    }
+    void add_compaction_bytes_committed(uint64_t bytes) {
+        _compaction_bytes_committed += bytes;
+    }
+
+    void add_leveling_objects_committed(uint64_t objects) {
+        _leveling_objects_committed += objects;
+    }
+    void add_leveling_bytes_committed(uint64_t bytes) {
+        _leveling_bytes_committed += bytes;
+    }
+
+    // Output objects/bytes that a maintenance job uploaded to object storage
+    // but whose metastore commit did not succeed.
+    void add_compaction_objects_rejected(uint64_t objects) {
+        _compaction_objects_rejected += objects;
+    }
+    void add_compaction_bytes_rejected(uint64_t bytes) {
+        _compaction_bytes_rejected += bytes;
+    }
+
+    void add_leveling_objects_rejected(uint64_t objects) {
+        _leveling_objects_rejected += objects;
+    }
+    void add_leveling_bytes_rejected(uint64_t bytes) {
+        _leveling_bytes_rejected += bytes;
+    }
+
 private:
     hist_t _compaction_runs;
     hist_t _leveling_runs;
@@ -64,6 +94,14 @@ private:
     uint64_t _records_removed{0};
     uint64_t _tombstones_removed{0};
     uint64_t _leveling_extents_reclaimed{0};
+    uint64_t _compaction_objects_committed{0};
+    uint64_t _compaction_bytes_committed{0};
+    uint64_t _leveling_objects_committed{0};
+    uint64_t _leveling_bytes_committed{0};
+    uint64_t _compaction_objects_rejected{0};
+    uint64_t _compaction_bytes_rejected{0};
+    uint64_t _leveling_objects_rejected{0};
+    uint64_t _leveling_bytes_rejected{0};
 
     metrics::internal_metric_groups _metrics;
 };


### PR DESCRIPTION
These counters indicate the total number of objects/bytes that were produced by maintenance jobs (either leveling or compaction) and were either committed to the `metastore` (live bytes) or rejected (dead bytes). The dead bytes will be eventually cleaned up (since they were pre-registered with the `metastore`).

These metrics should be helpful (along with log lines) to track any issues with leveling/compaction. It is expected that committed bytes/objects should grow consistently overtime, whereas the rejected counters might go up due to transient object storage issues from time to time (but should not be consistently growing).

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
