### PR TITLE
cluster: expose cluster_health_* "overview" metrics

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -31,25 +31,31 @@
 #include "config/property.h"
 #include "container/chunked_hash_map.h"
 #include "features/feature_table.h"
+#include "metrics/metrics.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "raft/fwd.h"
 #include "rpc/connection_cache.h"
 #include "rpc/types.h"
 #include "ssx/async_algorithm.h"
+#include "ssx/future-util.h"
 
 #include <seastar/core/lowres_clock.hh>
+#include <seastar/core/metrics.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/timed_out_error.hh>
+#include <seastar/core/timer.hh>
 #include <seastar/core/with_timeout.hh>
 #include <seastar/util/log.hh>
 
+#include <fmt/chrono.h>
 #include <fmt/format.h>
 
 #include <algorithm>
 #include <chrono>
 #include <iterator>
+#include <limits>
 #include <optional>
 #include <ranges>
 #include <utility>
@@ -57,6 +63,72 @@
 using namespace cluster::health_monitor_backend_details;
 
 namespace cluster {
+
+// Exports the cluster "health overview" (the cluster-wide aggregate
+// returned by the /v1/cluster/health_overview admin endpoint - distinct
+// from the per-node "health reports" each broker ships up) as Prometheus
+// metrics on both the public and internal endpoints.
+//
+// Two metric groups, both under the `cluster_health` prefix:
+//
+//  - The "meta" group is registered at startup and is always emitted.
+//    It carries `metadata_age_seconds` (age of the most recent
+//    successful refresh of the local per-node health-report cache,
+//    INT32_MAX if no refresh has happened yet) and a `refreshes_total`
+//    counter.
+//
+//  - The "overview" group exports the cluster_health_overview fields
+//    (nodes_down, leaderless_partitions, ...). It is NOT registered
+//    until the probe has cached a real overview, so Prometheus simply
+//    sees no series for these until real data is available.
+//
+// A `refresh_interval` timer periodically re-fetches the overview to keep
+// the cache fresh independently of how often Prometheus scrapes.
+class health_monitor_backend::health_probe {
+public:
+    explicit health_probe(health_monitor_backend& parent);
+    ~health_probe();
+    health_probe(const health_probe&) = delete;
+    health_probe& operator=(const health_probe&) = delete;
+    health_probe(health_probe&&) = delete;
+    health_probe& operator=(health_probe&&) = delete;
+
+    // Cache the given overview. The first call also registers the
+    // overview metric group; subsequent calls just update the cache.
+    void update_cache(cluster_health_overview overview);
+
+private:
+    // Re-fetch the overview, refresh the cache, and re-arm the refresh timer.
+    void tick();
+    // Register the always-on meta metrics (metadata age, refresh count).
+    void setup_meta_metrics();
+    // Register the cluster_health_* overview metric group, deferred until the
+    // first usable overview is cached (see update_cache()).
+    void setup_overview_metrics();
+
+    // Cadence on which the probe re-fetches the cluster health overview
+    // to keep its cache fresh. Resolved once at construction as a fixed
+    // multiple of `health_monitor_max_metadata_age` (zero = disabled, when
+    // `health_monitor_metrics_enabled` is false).
+    std::chrono::milliseconds refresh_interval() const {
+        return _refresh_interval;
+    }
+    // Max ticks to defer registering the overview metrics waiting for a
+    // complete view.
+    static constexpr int defer_max_attempts = 2;
+
+    health_monitor_backend& _parent;
+    cluster_health_overview _cache;
+    metrics::all_metrics_groups _metrics;
+    bool _overview_registered{false};
+    ss::timer<ss::lowres_clock> _refresh_timer;
+    std::chrono::milliseconds _refresh_interval{0};
+    // Number of overviews seen so far that were too incomplete to register
+    // the overview metrics with. Once we either see a complete overview or
+    // hit defer_max_attempts, the metrics are registered and this counter
+    // is no longer updated.
+    int _overview_attempts{0};
+};
 
 health_monitor_backend::health_monitor_backend(
   ss::lw_shared_ptr<raft::consensus> raft0,
@@ -84,7 +156,12 @@ health_monitor_backend::health_monitor_backend(
   , _node_status_table(node_status_table)
   , _reports{ss::make_lw_shared<report_cache_t>()}
   , _local_monitor(local_monitor)
-  , _self(_raft0->self().id()) {}
+  , _self(_raft0->self().id())
+  , _health_probe(std::make_unique<health_probe>(*this)) {}
+
+// Defined out-of-line because health_probe is an incomplete type
+// in the header.
+health_monitor_backend::~health_monitor_backend() = default;
 
 cluster::notification_id_type
 health_monitor_backend::register_node_callback(health_node_cb_t cb) {
@@ -125,6 +202,10 @@ ss::future<> health_monitor_backend::stop() {
         _refresh_request.release();
     }
     co_await std::move(f);
+    // Destroy the probe only after the gate has drained: an in-flight
+    // tick fiber holds a reference to it. Ticks firing after the gate
+    // close are no-ops and the timer is never re-armed.
+    _health_probe.reset();
 }
 
 cluster_health_report health_monitor_backend::build_cluster_report(
@@ -736,6 +817,11 @@ health_monitor_backend::collect_remote_node_health(model::node_id id) {
         })
       .then(&rpc::get_ctx_data<get_node_health_reply>)
       .then([this, id](result<get_node_health_reply> reply) {
+          vlog(
+            clusterlog.trace,
+            "collect_remote_node_health: reply from node {} (ok={})",
+            id,
+            !reply.has_error());
           return process_node_reply(id, std::move(reply));
       });
 }
@@ -803,6 +889,11 @@ ss::future<std::error_code> health_monitor_backend::collect_cluster_health() {
     vlog(clusterlog.debug, "collecting cluster health statistics");
     // collect all reports
     auto ids = _members.local().node_ids();
+    vlog(
+      clusterlog.trace,
+      "collect_cluster_health: dispatching to {} members: {}",
+      ids.size(),
+      ids);
     auto collected_reports
       = co_await ssx::async_transform<std::vector<result<node_health_report>>>(
         ids.begin(), ids.end(), [this](model::node_id id) {
@@ -812,6 +903,10 @@ ss::future<std::error_code> health_monitor_backend::collect_cluster_health() {
             }
             return collect_remote_node_health(id);
         });
+    vlog(
+      clusterlog.trace,
+      "collect_cluster_health: gathered {} results",
+      collected_reports.size());
     auto new_reports = ss::make_lw_shared<report_cache_t>();
 
     // update nodes reports and cache cluster-level data disk health
@@ -881,6 +976,7 @@ ss::future<std::error_code> health_monitor_backend::collect_cluster_health() {
     _reports = std::move(new_reports);
     _restart_risks_collected = node_restart_risks_available;
     _last_refresh = ss::lowres_clock::now();
+    ++_refresh_count;
     co_return errc::success;
 }
 
@@ -1217,6 +1313,222 @@ health_monitor_backend::aggregate_reports(const report_cache_t& reports) {
       .under_replicated = urp.to_ntp_set(),
       .leaderless_count = leaderless.count(),
       .under_replicated_count = urp.count()};
+}
+
+health_monitor_backend::health_probe::health_probe(
+  health_monitor_backend& parent)
+  : _parent(parent) {
+    if (!config::shard_local_cfg().health_monitor_metrics_enabled()) {
+        vlog(
+          clusterlog.info,
+          "health_probe: health_monitor_metrics_enabled is false; "
+          "cluster_health_* metrics are disabled");
+        return;
+    }
+    // Scale the refresh cadence with the metadata age so operators can tune
+    // both with a single knob (health_monitor_max_metadata_age), clamped
+    // below at 1s so a tiny metadata age can't drive a runaway refresh rate.
+    constexpr int refresh_interval_multiplier = 10;
+    // Clamp below by 1s in case the hmm setting is very low for some reason.
+    constexpr std::chrono::milliseconds min_refresh_interval{1000};
+    _refresh_interval = std::max(
+      min_refresh_interval,
+      refresh_interval_multiplier
+        * config::shard_local_cfg().health_monitor_max_metadata_age());
+    vlog(
+      clusterlog.info,
+      "health_probe: registering meta metrics and arming refresh timer "
+      "(interval={})",
+      _refresh_interval);
+    setup_meta_metrics();
+    _refresh_timer.set_callback([this] { tick(); });
+    // Fire the first tick immediately so the overview metrics start
+    // populating without waiting a full interval.
+    _refresh_timer.arm(ss::lowres_clock::duration::zero());
+}
+
+health_monitor_backend::health_probe::~health_probe() {
+    if (_refresh_timer.armed()) {
+        _refresh_timer.cancel();
+    }
+}
+
+void health_monitor_backend::health_probe::update_cache(
+  cluster_health_overview overview) {
+    _cache = std::move(overview);
+    const auto& ov = _cache;
+    if (_overview_registered) {
+        vlog(
+          clusterlog.trace,
+          "health_probe: overview cache updated (refresh_failed={}, "
+          "all_members_reported={}, nodes_down={}, unhealthy_reasons={})",
+          ov.refresh_failed,
+          ov.all_members_reported,
+          ov.nodes_down.size(),
+          ov.unhealthy_reasons.size());
+        return;
+    }
+    // Overview metrics not yet registered: only publish once we have a
+    // complete view, or after defer_max_attempts ticks (handles the
+    // legitimate "a peer is permanently down" case).
+    ++_overview_attempts;
+    if (ov.all_members_reported || _overview_attempts >= defer_max_attempts) {
+        vlog(
+          clusterlog.trace,
+          "health_probe: first overview cached after {} tick(s) ({}), "
+          "registering cluster_health_* overview metrics",
+          _overview_attempts,
+          ov.all_members_reported ? "all members reported"
+                                  : "max startup attempts reached");
+        setup_overview_metrics();
+        _overview_registered = true;
+    } else {
+        vlog(
+          clusterlog.trace,
+          "health_probe: first overview not yet usable (refresh_failed={}, "
+          "all_members_reported={}, nodes_down={}); will retry",
+          ov.refresh_failed,
+          ov.all_members_reported,
+          ov.nodes_down.size());
+    }
+}
+
+void health_monitor_backend::health_probe::tick() {
+    if (_parent._gate.is_closed()) {
+        return;
+    }
+    ssx::spawn_with_gate(_parent._gate, [this](this auto) -> ss::future<> {
+        vlog(clusterlog.trace, "health_probe: tick - refreshing overview");
+        try {
+            auto overview = co_await _parent.get_cluster_health_overview(
+              model::time_from_now(_parent.max_metadata_age()));
+            update_cache(std::move(overview));
+        } catch (const ss::abort_requested_exception&) {
+            // shutting down
+        } catch (...) {
+            vlog(
+              clusterlog.warn,
+              "health_probe: failed to refresh cluster health overview: {}",
+              std::current_exception());
+        }
+        if (!_parent._gate.is_closed()) {
+            _refresh_timer.arm(
+              std::chrono::duration_cast<ss::lowres_clock::duration>(
+                refresh_interval()));
+        }
+    });
+}
+
+void health_monitor_backend::health_probe::setup_meta_metrics() {
+    namespace sm = ss::metrics;
+    _metrics.add_group(
+      "cluster_health",
+      {
+        sm::make_gauge(
+          "metadata_age_seconds",
+          [this]() -> double {
+              if (_parent._refresh_count == 0) {
+                  // never refreshed: report "infinitely stale" so that
+                  // age > threshold alerts fire
+                  return std::numeric_limits<int32_t>::max();
+              }
+              auto age = ss::lowres_clock::now() - _parent._last_refresh;
+              return std::chrono::duration_cast<std::chrono::duration<double>>(
+                       age)
+                .count();
+          },
+          sm::description(
+            "Seconds since the local health monitor last successfully "
+            "refreshed its _status/_reports metadata cache. 2^31-1 if "
+            "no refresh has happened yet."))
+          .aggregate({sm::shard_label}),
+        sm::make_counter(
+          "refreshes_total",
+          [this] { return _parent._refresh_count; },
+          sm::description(
+            "Total successful health-report refreshes "
+            "performed by this node since startup."))
+          .aggregate({sm::shard_label}),
+      });
+}
+
+void health_monitor_backend::health_probe::setup_overview_metrics() {
+    namespace sm = ss::metrics;
+    _metrics.add_group(
+      "cluster_health",
+      {
+        sm::make_gauge(
+          "unhealthy_reasons",
+          [this] { return _cache.unhealthy_reasons.size(); },
+          sm::description(
+            "Count of reasons the cluster is currently considered unhealthy. "
+            "0 if the cluster is healthy; equals the size of "
+            "cluster_health_overview.unhealthy_reasons."))
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "nodes_down",
+          [this] { return _cache.nodes_down.size(); },
+          sm::description(
+            "Number of cluster members not responding to "
+            "liveness checks. 0 if healthy."))
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "high_disk_usage_nodes",
+          [this] { return _cache.high_disk_usage_nodes.size(); },
+          sm::description(
+            "Number of cluster members whose data disk has exceeded the "
+            "configured storage space alert threshold. 0 if healthy."))
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "leaderless_partitions",
+          [this] { return _cache.leaderless_count; },
+          sm::description(
+            "Number of partitions without an elected leader. 0 if healthy."))
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "under_replicated_partitions",
+          [this] { return _cache.under_replicated_count; },
+          sm::description(
+            "Number of partitions with at least one "
+            "under-replicated replica. 0 if healthy."))
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "no_elected_controller",
+          [this] { return _cache.controller_id.has_value() ? 0 : 1; },
+          sm::description(
+            "1 if no controller (raft0) leader is currently elected, else 0."))
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "no_health_report",
+          [this] { return _cache.refresh_failed ? 1 : 0; },
+          sm::description(
+            "1 if the last attempt to refresh the cluster "
+            "health report failed, else 0."))
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "nodes_in_recovery_mode",
+          [this] { return _cache.nodes_in_recovery_mode.size(); },
+          sm::description(
+            "Informational: count of nodes booted in recovery "
+            "mode. Does NOT contribute to cluster health "
+            "status."))
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "cluster_size",
+          [this] { return _cache.all_nodes.size(); },
+          sm::description(
+            "Informational: total number of known cluster members. Does NOT "
+            "contribute to cluster health status."))
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "bytes_in_cloud_storage",
+          [this] { return _cache.bytes_in_cloud_storage.value_or(0); },
+          sm::description(
+            "Informational: total bytes stored in cloud (tiered) storage "
+            "across the cluster, or 0 if unavailable. Does NOT contribute "
+            "to cluster health status."))
+          .aggregate({sm::shard_label}),
+      });
 }
 
 ss::future<cluster_health_overview>

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -1308,9 +1308,19 @@ health_monitor_backend::get_cluster_health_overview(
     // cluster is not healthy if the health report can't be obtained
     if (ec) {
         ret.unhealthy_reasons.emplace_back("no_health_report");
+        ret.refresh_failed = true;
     }
 
     ret.bytes_in_cloud_storage = _bytes_in_cloud_storage;
+
+    // True only when every known member produced a successful health
+    // report. Distinct from refresh_failed, which only catches errors
+    // from maybe_refresh_cluster_health itself - per-peer RPC failures
+    // (e.g., during boot before connections are established) do NOT set
+    // ec, but they do leave _reports incomplete.
+    ret.all_members_reported = !ec
+                               && reports().size()
+                                    == _members.local().nodes().size();
 
     co_return ret;
 }

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -29,6 +29,7 @@
 #include <seastar/core/shared_ptr.hh>
 
 #include <chrono>
+#include <memory>
 #include <vector>
 namespace cluster {
 
@@ -123,6 +124,8 @@ public:
     ss::future<result<std::optional<kafka::offset>>>
       get_partition_high_watermark(
         model::topic_namespace_view, model::partition_id);
+
+    ~health_monitor_backend(); // defined in .cc (incomplete PIMPL type)
 
 private:
     /**
@@ -241,6 +244,10 @@ private:
     ss::sharded<node_status_table>& _node_status_table;
 
     ss::lowres_clock::time_point _last_refresh;
+    // Number of times collect_cluster_health() has completed without
+    // throwing. Exposed as the `refreshes` counter and gates the
+    // `metadata_age_seconds` gauge (returns -1 while this is 0).
+    uint64_t _refresh_count{0};
     ss::lw_shared_ptr<abortable_refresh_request> _refresh_request;
 
     status_cache_t _status;
@@ -262,6 +269,11 @@ private:
     cluster::notification_id_type _next_callback_id{0};
 
     ssx::mutex _report_collection_mutex{"health_report_collection"};
+
+    // Probe for the cluster_health_overview metrics; defined in .cc.
+    class health_probe;
+    friend class health_probe;
+    std::unique_ptr<health_probe> _health_probe;
 
     friend struct health_report_accessor;
 };

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -358,7 +358,8 @@ fmt::iterator cluster_health_overview::format_to(fmt::iterator it) const {
       "high_disk_usage_nodes: {}, nodes_in_recovery_mode: {}, "
       "bytes_in_cloud_storage: {}, leaderless_count: {}, "
       "under_replicated_count: {}, leaderless_partitions: {}, "
-      "under_replicated_partitions: {}}}",
+      "under_replicated_partitions: {}, refresh_failed: {}, "
+      "all_members_reported: {}}}",
       controller_id,
       all_nodes,
       unhealthy_reasons,
@@ -369,7 +370,9 @@ fmt::iterator cluster_health_overview::format_to(fmt::iterator it) const {
       leaderless_count,
       under_replicated_count,
       leaderless_partitions,
-      under_replicated_partitions);
+      under_replicated_partitions,
+      refresh_failed,
+      all_members_reported);
 }
 
 } // namespace cluster

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -476,6 +476,17 @@ struct cluster_health_overview {
     std::vector<model::ntp> under_replicated_partitions;
     size_t under_replicated_count{};
     std::optional<size_t> bytes_in_cloud_storage;
+    // True if the refresh attempted at assembly time errored. False on
+    // success, or if no refresh was needed (cache fresh enough to skip).
+    // Also surfaced as "no_health_report" in unhealthy_reasons.
+    bool refresh_failed{false};
+    // True if, at overview-assembly time, the local _reports cache holds a
+    // health report for every known cluster member (and refresh_failed is
+    // false). Signals that this overview reflects a fully-collected view
+    // rather than a partial one. The underlying refresh may have happened
+    // earlier - this is a property of the cache state, not of a single
+    // refresh attempt.
+    bool all_members_reported{false};
 
     fmt::iterator format_to(fmt::iterator it) const;
 };

--- a/src/v/cluster/tests/health_bench.cc
+++ b/src/v/cluster/tests/health_bench.cc
@@ -76,6 +76,7 @@ struct health_bench : health_report_accessor {
 
         perf_tests::start_measuring_time();
         auto res = aggr_fn(reports);
+        perf_tests::do_not_optimize(res);
         perf_tests::stop_measuring_time();
     }
 };

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3562,6 +3562,16 @@ configuration::configuration()
       "non-controller broker.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       10s)
+  , health_monitor_metrics_enabled(
+      *this,
+      "health_monitor_metrics_enabled",
+      "Whether the cluster_health_* metrics are exported. When enabled, each "
+      "broker refreshes them on an interval of 10x "
+      "`health_monitor_max_metadata_age`, so the two scale together. "
+      "Refreshing "
+      "increases CPU usage and network traffic. Disabled by default.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      false)
   , storage_space_alert_free_threshold_percent(
       *this,
       "storage_space_alert_free_threshold_percent",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -611,6 +611,7 @@ struct configuration final : public config_store {
     // health monitor
     property<std::chrono::milliseconds> health_monitor_tick_interval;
     property<std::chrono::milliseconds> health_monitor_max_metadata_age;
+    property<bool> health_monitor_metrics_enabled;
     bounded_property<unsigned> storage_space_alert_free_threshold_percent;
     bounded_property<size_t> storage_space_alert_free_threshold_bytes;
     bounded_property<size_t> storage_min_free_bytes;

--- a/tests/rptest/tests/cluster_health_overview_test.py
+++ b/tests/rptest/tests/cluster_health_overview_test.py
@@ -7,26 +7,141 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import math
 import random
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable
 
 from ducktape.utils.util import wait_until
 
 from ducktape.cluster.cluster import ClusterNode
+from ducktape.tests.test import TestContext
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
+from rptest.services.redpanda import (
+    RESTART_LOG_ALLOW_LIST,
+    MetricsEndpoint,
+)
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import repeat_check, wait_until_result
 
 
-class ClusterHealthOverviewTest(RedpandaTest):
-    def __init__(self, test_context):
-        super(ClusterHealthOverviewTest, self).__init__(
+# Single source of truth for the redpanda_cluster_health_* / vectorized_cluster_health_*
+# metrics exposed by CORE-16394. Each entry encodes the metric's short name
+# (suffix after the prefix), its kind (status-contributing vs verdict vs
+# informational), an optional predictor that derives the expected value
+# from the admin GET /v1/cluster/health_overview response, and an optional
+# constraint for cases where we can't predict exactly. All groupings the
+# test cares about (status-only, all metrics, etc.) are derived from this
+# table.
+class _MetricKind(Enum):
+    INPUT_STATUS = "input_status"  # contributes to unhealthy_reasons
+    VERDICT = "verdict"  # the final unhealthy_reasons gauge
+    INFORMATIONAL = "informational"  # exposed but does not gate health
+
+
+HovDict = dict[str, Any]
+Predictor = Callable[[HovDict], float]
+Constraint = Callable[[float], bool]
+
+
+def _nonneg(v: float) -> bool:
+    return v >= 0
+
+
+@dataclass(frozen=True)
+class _HealthMetric:
+    suffix: str
+    kind: _MetricKind
+    # Returns the expected metric value derived from the admin endpoint
+    # response. None when we can't predict exactly (in which case
+    # `constraint` is used).
+    predictor: Predictor | None = None
+    # Looser validation when `predictor` is None. Default: value >= 0.
+    constraint: Constraint = field(default=_nonneg)
+
+
+def _expected_no_elected_controller(hov: HovDict) -> float:
+    # The admin endpoint emits controller_id=-1 when no leader is elected.
+    controller_id = hov.get("controller_id")
+    return 0 if controller_id is not None and controller_id >= 0 else 1
+
+
+_HEALTH_METRICS: list[_HealthMetric] = [
+    # Status inputs that gate cluster health.
+    _HealthMetric(
+        "nodes_down", _MetricKind.INPUT_STATUS, predictor=lambda h: len(h["nodes_down"])
+    ),
+    _HealthMetric(
+        "high_disk_usage_nodes",
+        _MetricKind.INPUT_STATUS,
+        predictor=lambda h: len(h["high_disk_usage_nodes"]),
+    ),
+    _HealthMetric(
+        "leaderless_partitions",
+        _MetricKind.INPUT_STATUS,
+        predictor=lambda h: int(h["leaderless_count"]),
+    ),
+    _HealthMetric(
+        "under_replicated_partitions",
+        _MetricKind.INPUT_STATUS,
+        predictor=lambda h: int(h["under_replicated_count"]),
+    ),
+    _HealthMetric(
+        "no_elected_controller",
+        _MetricKind.INPUT_STATUS,
+        predictor=_expected_no_elected_controller,
+    ),
+    # no_health_report is hard to deterministically trigger from a
+    # ducktape test; we can't predict the exact value, only that it's
+    # a 0/1 gauge. It still counts toward the unhealthy_reasons invariant.
+    _HealthMetric(
+        "no_health_report", _MetricKind.INPUT_STATUS, constraint=lambda v: v in (0, 1)
+    ),
+    # Final verdict: the size of unhealthy_reasons.
+    _HealthMetric(
+        "unhealthy_reasons",
+        _MetricKind.VERDICT,
+        predictor=lambda h: len(h["unhealthy_reasons"]),
+    ),
+    # Informational metrics that do NOT gate cluster health.
+    _HealthMetric(
+        "nodes_in_recovery_mode",
+        _MetricKind.INFORMATIONAL,
+        predictor=lambda h: len(h["nodes_in_recovery_mode"]),
+    ),
+    _HealthMetric(
+        "cluster_size",
+        _MetricKind.INFORMATIONAL,
+        predictor=lambda h: len(h["all_nodes"]),
+    ),
+    _HealthMetric("bytes_in_cloud_storage", _MetricKind.INFORMATIONAL),
+]
+
+_INPUT_STATUS_METRICS = [
+    m for m in _HEALTH_METRICS if m.kind == _MetricKind.INPUT_STATUS
+]
+_VERDICT_METRIC = next(m for m in _HEALTH_METRICS if m.kind == _MetricKind.VERDICT)
+_ALL_HEALTH_METRICS = [m.suffix for m in _HEALTH_METRICS]
+
+_PUBLIC_PREFIX = "redpanda_cluster_health_"
+_INTERNAL_PREFIX = "vectorized_cluster_health_"
+
+
+class ClusterHealthOverviewTestBase(RedpandaTest):
+    def __init__(self, test_context: TestContext, num_brokers: int):
+        super().__init__(
             test_context=test_context,
-            num_brokers=5,
+            num_brokers=num_brokers,
             extra_rp_conf={
+                # The metric refresh interval is 10x this, i.e. 1s, kept small
+                # so the metric cache tracks the admin endpoint within the
+                # test's wait windows.
                 "health_monitor_max_metadata_age": 100,  # ms
+                "health_monitor_metrics_enabled": True,
                 # Work around bug where leadership transfers cause bad health reports
                 # https://github.com/redpanda-data/redpanda/issues/5253
                 "enable_leader_balancer": False,
@@ -51,7 +166,23 @@ class ClusterHealthOverviewTest(RedpandaTest):
 
     def get_health(self, node: ClusterNode | None = None):
         """Wrapper around admin.get_cluster_health_overview which validates some invariants
-        about each health report"""
+        about each health report, and cross-checks the
+        redpanda_cluster_health_* Prometheus metrics against the admin
+        endpoint response.
+
+        Every node emits the cluster_health_* gauges; the cross-check
+        compares the response from whichever node we queried against the
+        metrics scraped from that same node, so we exercise non-controller
+        emitters too.
+        """
+
+        # Pin the admin call to a specific started node so we can scrape
+        # metrics from the same node for the cross-check. Mirrors the
+        # node selection that admin._request does internally for node=None.
+        if node is None:
+            started = self.redpanda.started_nodes()
+            assert started, "no started nodes to query"
+            node = random.choice(started)
 
         hov = self.admin.get_cluster_health_overview(node=node)
 
@@ -74,14 +205,139 @@ class ClusterHealthOverviewTest(RedpandaTest):
                 len(hov["under_replicated_partitions"]) == hov["under_replicated_count"]
             )
 
+        # Cross-check the metrics emission against the admin endpoint on
+        # the same node.
+        self._check_health_metrics(node)
+
         return hov
 
-    def wait_until_healthy(self):
-        def is_healthy():
-            res = self.get_health()
-            return res["is_healthy"] == True and len(res["all_nodes"]) == 5
+    def _scrape_health_metrics(
+        self,
+        node: ClusterNode,
+        endpoint: MetricsEndpoint,
+    ) -> dict[str, tuple[float, dict[str, str]]]:
+        """Scrape every redpanda_cluster_health_* metric from the given
+        node and endpoint. Returns a {short_name: (value, labels)} dict.
+        Short name is the metric name with the endpoint-specific prefix
+        stripped. Every node emits exactly one sample per metric (shard 0
+        only).
+        """
+        prefix = (
+            _PUBLIC_PREFIX
+            if endpoint == MetricsEndpoint.PUBLIC_METRICS
+            else _INTERNAL_PREFIX
+        )
+        full_names = [prefix + s for s in _ALL_HEALTH_METRICS]
 
-        wait_until(is_healthy, 30, 2)
+        def try_scrape() -> tuple[bool, dict[str, tuple[float, dict[str, str]]]]:
+            scraped: dict[str, tuple[float, dict[str, str]]] = {}
+            samples_by_name = self.redpanda.metrics_samples(
+                nodes=[node],
+                metrics_endpoint=endpoint,
+                names=full_names,
+            )
+            for short_name, full_name in zip(_ALL_HEALTH_METRICS, full_names):
+                ms = samples_by_name.get(full_name)
+                # The overview metrics aren't registered until the probe
+                # has cached its first real overview; treat absence as
+                # "not ready yet".
+                if ms is None or not ms.samples:
+                    return False, {}
+                s = ms.samples[0]
+                scraped[short_name] = (s.value, s.labels)
+            return True, scraped
+
+        return wait_until_result(
+            try_scrape,
+            timeout_sec=15,
+            backoff_sec=1,
+            err_msg=(
+                f"Timed out waiting for cluster health metrics on {endpoint} "
+                f"endpoint of node {node.account.hostname}"
+            ),
+        )
+
+    def _check_health_metrics(self, node: ClusterNode) -> None:
+        # The admin endpoint and the metric scrape are two independent
+        # network round-trips; an in-flight async update can publish a
+        # snapshot of a slightly different cluster state between them.
+        # Re-issue the matched pair on the SAME node and retry briefly to
+        # absorb the race. If the node was stopped between selection and
+        # the call, re-pick from currently-started nodes on retry.
+        deadline = time.time() + 15
+        while True:
+            try:
+                node_hov = self.admin.get_cluster_health_overview(node=node)
+                metrics = self._scrape_health_metrics(
+                    node, MetricsEndpoint.PUBLIC_METRICS
+                )
+                self._assert_metrics_match(node_hov, metrics)
+                return
+            except (AssertionError, ConnectionError, TimeoutError):
+                if time.time() >= deadline:
+                    raise
+                started = self.redpanda.started_nodes()
+                if started:
+                    node = random.choice(started)
+                time.sleep(0.5)
+
+    def _assert_metrics_match(
+        self,
+        hov: dict[str, Any],
+        metrics: dict[str, tuple[float, dict[str, str]]],
+    ) -> None:
+        for m in _HEALTH_METRICS:
+            actual, _ = metrics[m.suffix]
+            assert not math.isnan(actual), f"metric {m.suffix} should not be NaN"
+            if m.predictor is not None:
+                expected = m.predictor(hov)
+                assert actual == expected, (
+                    f"metric {m.suffix}={actual} but admin endpoint implies "
+                    f"{expected} (hov={hov})"
+                )
+            else:
+                assert m.constraint(actual), (
+                    f"metric {m.suffix}={actual} failed constraint"
+                )
+
+        # Verdict invariant: unhealthy_reasons equals the count of input-
+        # status metrics whose value is >0 (including no_health_report).
+        unhealthy_metric = int(metrics[_VERDICT_METRIC.suffix][0])
+        nonzero_inputs = sum(
+            1 for m in _INPUT_STATUS_METRICS if metrics[m.suffix][0] > 0
+        )
+        assert unhealthy_metric == nonzero_inputs, (
+            f"{_VERDICT_METRIC.suffix} metric={unhealthy_metric} but counted "
+            f"{nonzero_inputs} input-status metrics >0 (metrics={metrics})"
+        )
+
+        # And cross-check the verdict against the admin endpoint's
+        # unhealthy_reasons list length.
+        assert unhealthy_metric == len(hov["unhealthy_reasons"]), (
+            f"{_VERDICT_METRIC.suffix} metric={unhealthy_metric} but admin "
+            f"endpoint reports {len(hov['unhealthy_reasons'])} reasons "
+            f"({hov['unhealthy_reasons']})"
+        )
+
+    def wait_until_healthy(self) -> HovDict:
+        """Wait until a node reports the cluster healthy and return that
+        healthy overview. Note this is one node's view at one moment;
+        another node may still serve a stale (or fresher) view afterwards.
+        """
+
+        def is_healthy() -> tuple[bool, HovDict]:
+            res = self.get_health()
+            ok = res["is_healthy"] == True and len(res["all_nodes"]) == len(
+                self.redpanda.nodes
+            )
+            return ok, res
+
+        return wait_until_result(is_healthy, 30, 2)
+
+
+class ClusterHealthOverviewTest(ClusterHealthOverviewTestBase):
+    def __init__(self, test_context: TestContext):
+        super().__init__(test_context, num_brokers=5)
 
     @cluster(num_nodes=5, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def cluster_health_overview_baseline_test(self):
@@ -90,10 +346,20 @@ class ClusterHealthOverviewTest(RedpandaTest):
         # in initial state after all nodes joined cluster should be healthy
         self.wait_until_healthy()
 
-        # stop one node, cluster should become unhealthy with one node down
-        # reported and no leaderless partitions
-
-        first_down = random.choice(self.redpanda.nodes)
+        # Stop the current controller specifically. This deterministically
+        # forces a controller-down -> re-election transition, so
+        # _check_health_metrics exercises both the brief no-controller
+        # window (canonical = lowest alive id, controller=1 nowhere) AND
+        # the post-election state (both labels true on the new controller).
+        hov = self.get_health()
+        controller_id = hov["controller_id"]
+        assert controller_id is not None and controller_id >= 0, (
+            f"expected an elected controller before first stop, got {hov}"
+        )
+        first_down = self.redpanda.get_node_by_id(controller_id)
+        assert first_down is not None, (
+            f"could not resolve controller node from id {controller_id}"
+        )
         self.redpanda.stop_node(first_down)
 
         # when one node is down some partitions with replication factor of 1
@@ -190,3 +456,81 @@ class ClusterHealthOverviewTest(RedpandaTest):
             {"storage_space_alert_free_threshold_percent": 5}
         )
         self.wait_until_healthy()
+
+
+class ClusterHealthMetricsTest(ClusterHealthOverviewTestBase):
+    def __init__(self, test_context: TestContext):
+        super().__init__(test_context, num_brokers=4)
+
+    @cluster(num_nodes=4)
+    def cluster_health_metrics_test(self):
+        """Smoke test for the redpanda_cluster_health_* metrics. Asserts
+        that on a healthy cluster every status metric is 0, the metrics
+        are registered on both the public and internal endpoints, and
+        that the values from both endpoints agree."""
+
+        self.create_topics()
+
+        # Use the healthy overview returned by the wait itself: re-reading
+        # health from another (randomly chosen) node right after the wait
+        # can race with that node's own cache and flap back to unhealthy.
+        hov = self.wait_until_healthy()
+
+        controller_id = hov["controller_id"]
+        assert controller_id is not None
+        controller_node = self.redpanda.get_node_by_id(controller_id)
+        assert controller_node is not None
+
+        # Each node refreshes its metric cache on the metrics refresh
+        # interval (10x health_monitor_max_metadata_age), so the controller's
+        # gauges may still reflect a pre-healthy snapshot (e.g. a
+        # partition that was briefly leaderless during topic creation)
+        # even though wait_until_healthy() saw a healthy cluster,
+        # possibly on another node. Retry until the controller's cache
+        # catches up.
+        wait_until(
+            lambda: self._assert_healthy_metrics(controller_node),
+            timeout_sec=20,
+            backoff_sec=1,
+            err_msg="timed out waiting for healthy cluster_health_* metrics",
+            retry_on_exc=True,
+        )
+
+    def _assert_healthy_metrics(self, controller_node: ClusterNode) -> bool:
+        public_metrics = self._scrape_health_metrics(
+            controller_node, MetricsEndpoint.PUBLIC_METRICS
+        )
+        internal_metrics = self._scrape_health_metrics(
+            controller_node, MetricsEndpoint.METRICS
+        )
+
+        # Both endpoints must expose every metric.
+        for name in _ALL_HEALTH_METRICS:
+            assert name in public_metrics, (
+                f"metric {_PUBLIC_PREFIX}{name} missing on public endpoint"
+            )
+            assert name in internal_metrics, (
+                f"metric {_INTERNAL_PREFIX}{name} missing on internal endpoint"
+            )
+
+        # And the values must agree between the two endpoints.
+        for name in _ALL_HEALTH_METRICS:
+            pub_val, _ = public_metrics[name]
+            internal_val, _ = internal_metrics[name]
+            assert pub_val == internal_val, (
+                f"metric {name} disagrees between endpoints: "
+                f"public={pub_val} internal={internal_val}"
+            )
+
+        # All status/verdict metrics should be 0 in a healthy cluster.
+        for m in _HEALTH_METRICS:
+            if m.kind == _MetricKind.INFORMATIONAL:
+                continue
+            value, _ = public_metrics[m.suffix]
+            assert value == 0, f"healthy cluster: expected {m.suffix} == 0, got {value}"
+
+        # cluster_size matches broker count.
+        assert public_metrics["cluster_size"][0] == len(self.redpanda.nodes)
+        assert public_metrics["nodes_in_recovery_mode"][0] == 0
+        assert public_metrics["bytes_in_cloud_storage"][0] >= 0
+        return True


### PR DESCRIPTION
Exposes the inputs of `rpk cluster health` (and the final unhealthy/healthy
verdict) as Prometheus metrics, so an operator can alert on or graph cluster
health directly from Prometheus instead of polling the
`/v1/cluster/health_overview` admin endpoint.

A new PIMPL `health_probe` inside `health_monitor_backend` periodically
reassembles the `cluster_health_overview` and caches it; lambda-bound seastar
gauges read from the cache, so a Prometheus scrape never blocks on a
fan-out RPC. Two metric groups under `cluster:health` are emitted on both the
public and internal endpoints:

- `metadata_age_seconds` and `refreshes_total` are registered up front, so
  operators can confirm the cache is being refreshed even before a full
  overview is available. `metadata_age_seconds` returns 2^31-1 until the first
  successful refresh.
- The remaining gauges (`nodes_down`, `leaderless_partitions`,
  `under_replicated_partitions`, `unhealthy_reasons`, `no_elected_controller`,
  `no_health_report`, ...) are deferred until either every peer has reported
  in or a small number of refresh attempts have elapsed, so the metrics don't
  publish spurious zeros while the cluster is still coming up.

The probe is gated by the new boolean cluster property
`health_monitor_metrics_enabled` (default disabled, `needs_restart`). When
enabled, the cache is refreshed every 10x `health_monitor_max_metadata_age`
(clamped below at 1s), so the two settings scale together: raising the
metadata age to reduce refresh load also slows the metric refresh.

Commits:

1. `cluster: do_not_optimize aggregate result in health_bench` keeps the
   compiler from elidating the benchmark's payload.
2. `cluster: track refresh_failed and all_members_reported on
   cluster_health_overview` adds two new fields to the overview so the probe
   can tell a partial-but-OK assembly from a fully-collected one.
3. `config: add health_monitor_metrics_enabled property` adds the new boolean
   cluster property described above.
4. `cluster: export cluster_health_overview as Prometheus metrics` is the
   main change: introduces the `health_probe` PIMPL inside
   `health_monitor_backend` and registers the metrics described above.
5. `rptest: cross-check cluster_health_* metrics in
   cluster_health_overview_test` adds a ducktape test that scrapes both the
   public and internal metrics endpoints on every node, compares against the
   admin overview on the same node, and exercises the deferred-registration
   path.

Closes CORE-16394.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Features

- Added `redpanda_cluster_health_*` Prometheus metrics (public and internal endpoints) that expose the same inputs as `rpk cluster health`, including `nodes_down`, `leaderless_partitions`, `under_replicated_partitions`, `unhealthy_reasons`, and a `metadata_age_seconds` freshness gauge. Disabled by default; enable by setting the new boolean `health_monitor_metrics_enabled` cluster property to `true`. When enabled, metrics refresh every 10x `health_monitor_max_metadata_age`.
