### PR TITLE
strings/utf8: sanitize fragment-wise without linearizing

### DIFF
--- a/src/v/strings/tests/BUILD
+++ b/src/v/strings/tests/BUILD
@@ -64,6 +64,7 @@ redpanda_cc_gtest(
         "utf8_sanitize_test.cc",
     ],
     deps = [
+        "//src/v/base",
         "//src/v/bytes:iobuf",
         "//src/v/strings:utf8",
         "@googletest//:gtest",

--- a/src/v/strings/tests/BUILD
+++ b/src/v/strings/tests/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:test.bzl", "redpanda_cc_btest_no_seastar", "redpanda_cc_gtest")
+load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_btest_no_seastar", "redpanda_cc_gtest")
 
 redpanda_cc_btest_no_seastar(
     name = "strings_test",
@@ -39,6 +39,21 @@ redpanda_cc_gtest(
         "//src/v/strings:utf8",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
+    ],
+)
+
+redpanda_cc_bench(
+    name = "utf8_sanitize_rpbench",
+    srcs = [
+        "utf8_sanitize_bench.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/random:generators",
+        "//src/v/strings:utf8",
+        "@seastar",
+        "@seastar//:benchmark",
     ],
 )
 

--- a/src/v/strings/tests/utf8_sanitize_bench.cc
+++ b/src/v/strings/tests/utf8_sanitize_bench.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "base/units.h"
+#include "bytes/iobuf.h"
+#include "random/generators.h"
+#include "strings/utf8.h"
+
+#include <seastar/testing/perf_tests.hh>
+
+#include <string>
+#include <string_view>
+
+namespace {
+
+constexpr size_t input_size = 16_KiB;
+
+// Valid UTF-8 mixing 1-4 byte code points: "redpanda é 中 😀 ".
+std::string make_valid_string() {
+    constexpr std::string_view pattern
+      = "redpanda \xC3\xA9 \xE4\xB8\xAD \xF0\x9F\x98\x80 ";
+    std::string s;
+    s.reserve(input_size);
+    while (s.size() + pattern.size() <= input_size) {
+        s.append(pattern);
+    }
+    s.append(input_size - s.size(), 'a');
+    return s;
+}
+
+// Deterministic uniformly random bytes; a large share is ill-formed, so the
+// rescue path replaces heavily.
+std::string make_random_string() {
+    std::string s;
+    s.reserve(input_size);
+    for (size_t i = 0; i < input_size; ++i) {
+        s.push_back(static_cast<char>(random_generators::get_int<int>(0, 255)));
+    }
+    return s;
+}
+
+// Valid UTF-8 with 1% of bytes overwritten with 0xFF (never valid in UTF-8):
+// the rescue path copies mostly-valid data with sparse replacements.
+std::string make_one_percent_invalid_string() {
+    std::string s = make_valid_string();
+    for (size_t i = 0; i < s.size(); i += 100) {
+        s[i] = '\xFF';
+    }
+    return s;
+}
+
+void sanitize_bench(iobuf input) {
+    perf_tests::start_measuring_time();
+    perf_tests::do_not_optimize(utf8_sanitize(std::move(input)));
+    perf_tests::stop_measuring_time();
+}
+
+} // namespace
+
+PERF_TEST(utf8_sanitize, valid_16k) {
+    sanitize_bench(iobuf::from(make_valid_string()));
+}
+
+// All-ASCII input, the common case for payloads like JSON: every byte is a
+// single-byte code point, so this stays on the fast path without ever
+// decoding a multi-byte sequence.
+PERF_TEST(utf8_sanitize, ascii_16k) {
+    sanitize_bench(
+      iobuf::from(random_generators::gen_alphanum_string(input_size)));
+}
+
+PERF_TEST(utf8_sanitize, random_16k) {
+    sanitize_bench(iobuf::from(make_random_string()));
+}
+
+PERF_TEST(utf8_sanitize, one_percent_invalid_16k) {
+    sanitize_bench(iobuf::from(make_one_percent_invalid_string()));
+}

--- a/src/v/strings/tests/utf8_sanitize_test.cc
+++ b/src/v/strings/tests/utf8_sanitize_test.cc
@@ -9,21 +9,33 @@
  * by the Apache License, Version 2.0
  */
 
+#include "base/vassert.h"
 #include "strings/utf8.h"
-
-#include <seastar/core/temporary_buffer.hh>
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
+#include <initializer_list>
+#include <iterator>
 #include <string>
 #include <string_view>
 
-// Build an iobuf with two distinct fragments to exercise state-machine
-// boundary handling in is_valid_utf8.
-static iobuf make_split_iobuf(std::string_view a, std::string_view b) {
+// Build an iobuf with distinct fragments to exercise state-machine boundary
+// handling in is_valid_utf8 and the slow-path rescue.
+static iobuf
+make_fragmented_iobuf(std::initializer_list<std::string_view> parts) {
     iobuf buf;
-    buf.append(ss::temporary_buffer<char>(a.data(), a.size()));
-    buf.append(ss::temporary_buffer<char>(b.data(), b.size()));
+    for (auto part : parts) {
+        // append_fragments preserves fragment boundaries; a plain append
+        // would copy-pack small buffers into a single fragment.
+        buf.append_fragments(iobuf::from(part));
+    }
+    auto n_frags = std::distance(buf.begin(), buf.end());
+    vassert(
+      n_frags == static_cast<std::ptrdiff_t>(parts.size()),
+      "expected {} fragments, got {}",
+      parts.size(),
+      n_frags);
     return buf;
 }
 
@@ -42,28 +54,24 @@ static std::string iobuf_to_string(iobuf buf) {
 
 TEST(Utf8Sanitize, ValidEmpty) {
     auto r = utf8_sanitize(iobuf::from(""));
-    ASSERT_TRUE(r.has_value());
-    EXPECT_EQ(iobuf_to_string(std::move(*r)), "");
+    EXPECT_EQ(iobuf_to_string(std::move(r)), "");
 }
 
 TEST(Utf8Sanitize, ValidAscii) {
     auto r = utf8_sanitize(iobuf::from("hello world"));
-    ASSERT_TRUE(r.has_value());
-    EXPECT_EQ(iobuf_to_string(std::move(*r)), "hello world");
+    EXPECT_EQ(iobuf_to_string(std::move(r)), "hello world");
 }
 
 TEST(Utf8Sanitize, Valid2Byte) {
     // U+00E9 LATIN SMALL LETTER E WITH ACUTE: C3 A9
     auto r = utf8_sanitize(iobuf::from("\xC3\xA9"));
-    ASSERT_TRUE(r.has_value());
-    EXPECT_EQ(iobuf_to_string(std::move(*r)), "\xC3\xA9");
+    EXPECT_EQ(iobuf_to_string(std::move(r)), "\xC3\xA9");
 }
 
 TEST(Utf8Sanitize, ValidFragmentSplitMultiByte) {
     // C3 | A9 — pending=1 carries into second fragment
-    auto r = utf8_sanitize(make_split_iobuf("\xC3", "\xA9"));
-    ASSERT_TRUE(r.has_value());
-    EXPECT_EQ(iobuf_to_string(std::move(*r)), "\xC3\xA9");
+    auto r = utf8_sanitize(make_fragmented_iobuf({"\xC3", "\xA9"}));
+    EXPECT_EQ(iobuf_to_string(std::move(r)), "\xC3\xA9");
 }
 
 // ---------------------------------------------------------------------------
@@ -73,107 +81,132 @@ TEST(Utf8Sanitize, ValidFragmentSplitMultiByte) {
 TEST(Utf8Sanitize, InvalidBareContinuation) {
     // 0x80 alone — one U+FFFD
     auto r = utf8_sanitize(iobuf::from("\x80"));
-    ASSERT_TRUE(r.has_value());
-    EXPECT_EQ(iobuf_to_string(std::move(*r)), "\xEF\xBF\xBD");
+    EXPECT_EQ(iobuf_to_string(std::move(r)), "\xEF\xBF\xBD");
 }
 
 TEST(Utf8Sanitize, InvalidTruncated3Byte) {
     // E4 B8 at end of string — two U+FFFD (one per ill-formed byte)
     auto r = utf8_sanitize(iobuf::from("\xE4\xB8"));
-    ASSERT_TRUE(r.has_value());
-    EXPECT_EQ(iobuf_to_string(std::move(*r)), "\xEF\xBF\xBD\xEF\xBF\xBD");
+    EXPECT_EQ(iobuf_to_string(std::move(r)), "\xEF\xBF\xBD\xEF\xBF\xBD");
 }
 
 TEST(Utf8Sanitize, InvalidTruncated4Byte) {
     // F0 9F 98 at end of string — three U+FFFD (one per ill-formed byte)
     auto r = utf8_sanitize(iobuf::from("\xF0\x9F\x98"));
-    ASSERT_TRUE(r.has_value());
     EXPECT_EQ(
-      iobuf_to_string(std::move(*r)), "\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD");
+      iobuf_to_string(std::move(r)), "\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD");
+}
+
+TEST(Utf8Sanitize, InvalidTruncated4ByteThenAscii) {
+    // F0 9F followed by an ASCII byte — the aborted sequence yields one
+    // U+FFFD per consumed byte and the ASCII byte is preserved.
+    auto r = utf8_sanitize(
+      iobuf::from(
+        "\xF0\x9F"
+        "A"));
+    EXPECT_EQ(
+      iobuf_to_string(std::move(r)),
+      "\xEF\xBF\xBD\xEF\xBF\xBD"
+      "A");
+}
+
+TEST(Utf8Sanitize, InvalidTruncated3ByteThenValid2Byte) {
+    // E1 80 (aborted 3-byte sequence) followed by C2 80 (valid U+0080) —
+    // one U+FFFD per consumed byte of the aborted sequence, then the valid
+    // sequence is preserved. Pins advance-1-on-error semantics: the
+    // maximal-subpart strategy would emit a single U+FFFD for E1 80.
+    auto r = utf8_sanitize(iobuf::from("\xE1\x80\xC2\x80"));
+    EXPECT_EQ(
+      iobuf_to_string(std::move(r)), "\xEF\xBF\xBD\xEF\xBF\xBD\xC2\x80");
 }
 
 TEST(Utf8Sanitize, InvalidSurrogate) {
     // U+D800 encoded as UTF-8: ED A0 80 — three U+FFFD.
-    // utf8proc rejects the lead byte ED A0 as a surrogate; each subsequent
+    // The lead byte ED A0 is rejected as a surrogate; each subsequent
     // continuation byte is then a bare continuation.
     auto r = utf8_sanitize(iobuf::from("\xED\xA0\x80"));
-    ASSERT_TRUE(r.has_value());
     EXPECT_EQ(
-      iobuf_to_string(std::move(*r)), "\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD");
+      iobuf_to_string(std::move(r)), "\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD");
 }
 
 TEST(Utf8Sanitize, InvalidMixed) {
     // Valid prefix + bare continuation + valid suffix
     auto r = utf8_sanitize(iobuf::from("hello\x80world"));
-    ASSERT_TRUE(r.has_value());
-    EXPECT_EQ(iobuf_to_string(std::move(*r)), "hello\xEF\xBF\xBDworld");
+    EXPECT_EQ(iobuf_to_string(std::move(r)), "hello\xEF\xBF\xBDworld");
 }
 
 TEST(Utf8Sanitize, InvalidContinuationMidSequence) {
     // C3 expects one continuation, but gets another lead byte — two U+FFFD.
     auto r = utf8_sanitize(iobuf::from("\xC3\xC3"));
-    ASSERT_TRUE(r.has_value());
-    EXPECT_EQ(iobuf_to_string(std::move(*r)), "\xEF\xBF\xBD\xEF\xBF\xBD");
+    EXPECT_EQ(iobuf_to_string(std::move(r)), "\xEF\xBF\xBD\xEF\xBF\xBD");
 }
 
 TEST(Utf8Sanitize, InvalidOverlong2Byte) {
     // C0 80 — overlong encoding of U+0000, two U+FFFD.
     auto r = utf8_sanitize(iobuf::from("\xC0\x80"));
-    ASSERT_TRUE(r.has_value());
-    EXPECT_EQ(iobuf_to_string(std::move(*r)), "\xEF\xBF\xBD\xEF\xBF\xBD");
+    EXPECT_EQ(iobuf_to_string(std::move(r)), "\xEF\xBF\xBD\xEF\xBF\xBD");
 }
 
 TEST(Utf8Sanitize, InvalidOverlong3Byte) {
     // E0 9F 80 — overlong (first continuation 0x9F < 0xA0), three U+FFFD.
     auto r = utf8_sanitize(iobuf::from("\xE0\x9F\x80"));
-    ASSERT_TRUE(r.has_value());
     EXPECT_EQ(
-      iobuf_to_string(std::move(*r)), "\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD");
+      iobuf_to_string(std::move(r)), "\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD");
 }
 
 TEST(Utf8Sanitize, InvalidOutOfRangeLead) {
     // 0xF5 and above are not valid UTF-8 lead bytes (would exceed U+10FFFF).
     auto r = utf8_sanitize(iobuf::from("\xF5"));
-    ASSERT_TRUE(r.has_value());
-    EXPECT_EQ(iobuf_to_string(std::move(*r)), "\xEF\xBF\xBD");
+    EXPECT_EQ(iobuf_to_string(std::move(r)), "\xEF\xBF\xBD");
 }
+
+// ---------------------------------------------------------------------------
+// Invalid inputs with fragment boundaries — slow path carry handling
+// ---------------------------------------------------------------------------
 
 TEST(Utf8Sanitize, InvalidSurrogateFragmentSplit) {
     // ED | A0 80 — surrogate split across fragment boundary; verifies that
     // max_cont=0x9F carries over from the first fragment.
-    auto r = utf8_sanitize(make_split_iobuf("\xED", "\xA0\x80"));
-    ASSERT_TRUE(r.has_value());
+    auto r = utf8_sanitize(make_fragmented_iobuf({"\xED", "\xA0\x80"}));
     EXPECT_EQ(
-      iobuf_to_string(std::move(*r)), "\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD");
+      iobuf_to_string(std::move(r)), "\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD");
+}
+
+TEST(Utf8Sanitize, InvalidThenFragmentSplitValid) {
+    // 80 C3 | A9 — the slow path commits the C3 A9 sequence spanning the
+    // fragment boundary.
+    auto r = utf8_sanitize(make_fragmented_iobuf({"\x80\xC3", "\xA9"}));
+    EXPECT_EQ(iobuf_to_string(std::move(r)), "\xEF\xBF\xBD\xC3\xA9");
+}
+
+TEST(Utf8Sanitize, InvalidThenValid4ByteAcross3Fragments) {
+    // 80 F0 | 9F | 98 80 — a 4-byte sequence spanning three fragments is
+    // carried and committed by the slow path.
+    auto r = utf8_sanitize(
+      make_fragmented_iobuf({"\x80\xF0", "\x9F", "\x98\x80"}));
+    EXPECT_EQ(iobuf_to_string(std::move(r)), "\xEF\xBF\xBD\xF0\x9F\x98\x80");
+}
+
+TEST(Utf8Sanitize, InvalidTruncatedFragmentSplit) {
+    // E4 | B8 — sequence split across fragments and never completed: one
+    // U+FFFD per byte.
+    auto r = utf8_sanitize(make_fragmented_iobuf({"\xE4", "\xB8"}));
+    EXPECT_EQ(iobuf_to_string(std::move(r)), "\xEF\xBF\xBD\xEF\xBF\xBD");
 }
 
 // ---------------------------------------------------------------------------
-// Size limit checks
+// Large inputs — the slow path does not linearize, so size is unrestricted
 // ---------------------------------------------------------------------------
 
-TEST(Utf8Sanitize, OversizedValid) {
-    // A valid string larger than max_bytes passes through unchanged (fast
-    // path).
+TEST(Utf8Sanitize, LargeValid) {
     std::string big(iobuf::max_linearize_size + 1, 'a');
     auto r = utf8_sanitize(iobuf::from(big));
-    ASSERT_TRUE(r.has_value());
-    EXPECT_EQ(r->size_bytes(), big.size());
+    EXPECT_EQ(r.size_bytes(), big.size());
 }
 
-TEST(Utf8Sanitize, OversizedInvalid) {
-    // An invalid string larger than max_bytes → input_too_large.
+TEST(Utf8Sanitize, LargeInvalid) {
+    // Larger than the linearize limit; each 0x80 → 3-byte U+FFFD.
     std::string big(iobuf::max_linearize_size + 1, '\x80');
     auto r = utf8_sanitize(iobuf::from(big));
-    ASSERT_FALSE(r.has_value());
-    EXPECT_EQ(r.error(), utf8_sanitize_error::input_too_large);
-}
-
-TEST(Utf8Sanitize, ExactlyAtLimitInvalid) {
-    // size_bytes() == max_linearize_size: the slow path should proceed (the
-    // check is strictly >, not >=).
-    std::string at_limit(iobuf::max_linearize_size, '\x80');
-    auto r = utf8_sanitize(iobuf::from(at_limit));
-    ASSERT_TRUE(r.has_value());
-    EXPECT_EQ(
-      r->size_bytes(), at_limit.size() * 3); // each 0x80 → 3-byte U+FFFD
+    EXPECT_EQ(r.size_bytes(), big.size() * 3);
 }

--- a/src/v/strings/utf8.cc
+++ b/src/v/strings/utf8.cc
@@ -11,6 +11,7 @@
 
 #include "strings/utf8.h"
 
+#include <array>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -83,27 +84,6 @@ namespace {
 
 constexpr std::string_view replacement_char = "\xEF\xBF\xBD";
 
-// Replace ill-formed bytes in `raw` with U+FFFD (advance-1-on-error strategy:
-// one replacement per ill-formed byte).
-iobuf replace_invalid_utf8(std::string_view raw) {
-    iobuf result;
-    const auto* data = reinterpret_cast<const utf8proc_uint8_t*>(raw.data());
-    auto len = static_cast<utf8proc_ssize_t>(raw.size());
-    utf8proc_ssize_t i = 0;
-    while (i < len) {
-        utf8proc_int32_t cp;
-        utf8proc_ssize_t n = utf8proc_iterate(data + i, len - i, &cp);
-        if (n > 0) {
-            result.append(raw.data() + i, static_cast<size_t>(n));
-            i += n;
-        } else {
-            result.append(replacement_char.data(), replacement_char.size());
-            ++i;
-        }
-    }
-    return result;
-}
-
 // Incremental UTF-8 validation state. `pending` counts the continuation
 // bytes still expected; `min_cont`/`max_cont` bound the next continuation
 // byte (tightened after an E0/ED/F0/F4 lead to reject overlongs, surrogates,
@@ -175,6 +155,56 @@ inline bool accept_utf8_byte(utf8_scan_state& s, uint8_t b) {
     return true;
 }
 
+// Replace ill-formed bytes in `input` with U+FFFD (advance-1-on-error
+// strategy: one replacement per ill-formed byte). Bytes of the current code
+// point are buffered in `seq` and copied once the code point completes, so
+// fragment boundaries need no special handling.
+iobuf replace_invalid_utf8(const iobuf& input) {
+    iobuf result;
+    result.reserve_memory(input.size_bytes());
+    utf8_scan_state state;
+    std::array<char, 4> seq{};
+    size_t seq_len = 0;
+
+    // Appends one at a time on purpose: n is almost always 0 or 1, and a
+    // constant-size append compiles to direct stores; a single runtime-size
+    // append from a prepared buffer measured slower.
+    auto emit_replacements = [&result](size_t n) {
+        for (size_t i = 0; i < n; ++i) {
+            result.append(replacement_char.data(), replacement_char.size());
+        }
+    };
+
+    auto sanitize_byte = [&](uint8_t b) {
+        if (!accept_utf8_byte(state, b)) {
+            // Abort any partial sequence: its lead is ill-formed and each
+            // consumed continuation is then a bare continuation — one U+FFFD
+            // per byte. Then re-examine `b` with fresh state.
+            emit_replacements(seq_len);
+            seq_len = 0;
+            state = utf8_scan_state{};
+            if (!accept_utf8_byte(state, b)) {
+                emit_replacements(1);
+                return;
+            }
+        }
+        seq[seq_len++] = static_cast<char>(b);
+        if (state.pending == 0) {
+            result.append(seq.data(), seq_len);
+            seq_len = 0;
+        }
+    };
+
+    for (const auto& frag : input) {
+        for (size_t i = 0; i < frag.size(); ++i) {
+            sanitize_byte(static_cast<uint8_t>(frag.get()[i]));
+        }
+    }
+    // Input ended mid-sequence: one U+FFFD per leftover byte.
+    emit_replacements(seq_len);
+    return result;
+}
+
 } // namespace
 
 bool is_valid_utf8(const iobuf& buf) {
@@ -189,14 +219,9 @@ bool is_valid_utf8(const iobuf& buf) {
     return state.pending == 0;
 }
 
-std::expected<iobuf, utf8_sanitize_error>
-utf8_sanitize(iobuf input, size_t max_bytes) {
-    max_bytes = std::min(max_bytes, iobuf::max_linearize_size);
+iobuf utf8_sanitize(iobuf input) {
     if (is_valid_utf8(input)) {
-        return std::move(input);
+        return input;
     }
-    if (input.size_bytes() > max_bytes) {
-        return std::unexpected(utf8_sanitize_error::input_too_large);
-    }
-    return replace_invalid_utf8(input.linearize_to_string());
+    return replace_invalid_utf8(input);
 }

--- a/src/v/strings/utf8.cc
+++ b/src/v/strings/utf8.cc
@@ -109,15 +109,50 @@ iobuf replace_invalid_utf8(std::string_view raw) {
 // byte (tightened after an E0/ED/F0/F4 lead to reject overlongs, surrogates,
 // and code points above U+10FFFF).
 struct utf8_scan_state {
-    int pending = 0;
+    int8_t pending = 0;
     uint8_t min_cont = 0x80;
     uint8_t max_cont = 0xBF;
 };
 
+// Table that maps bytes to scanner states; pending == -1 marks bytes that
+// can never start a sequence. Avoids branch mispredictions on random input.
+constexpr auto utf8_lead_table = [] {
+    std::array<utf8_scan_state, 256> t{};
+    for (int b = 0; b < 256; ++b) {
+        utf8_scan_state s{.pending = -1, .min_cont = 0x80, .max_cont = 0xBF};
+        if (b < 0x80) {
+            s.pending = 0; // ASCII
+        } else if (b < 0xC2) {
+            // bare continuation or overlong 2-byte start: never a lead
+        } else if (b < 0xE0) {
+            s.pending = 1;
+        } else if (b < 0xF0) {
+            s.pending = 2;
+            if (b == 0xE0) {
+                s.min_cont = 0xA0; // exclude overlong
+            }
+            if (b == 0xED) {
+                s.max_cont = 0x9F; // exclude surrogates
+            }
+        } else if (b < 0xF5) {
+            s.pending = 3;
+            if (b == 0xF0) {
+                s.min_cont = 0x90; // exclude overlong
+            }
+            if (b == 0xF4) {
+                s.max_cont = 0x8F; // exclude > U+10FFFF
+            }
+        }
+        t[b] = s;
+    }
+    return t;
+}();
+
 // Advance the state machine by one byte. Returns false if `b` is not valid
-// UTF-8 at the current position.
+// UTF-8 at the current position; the state is then unchanged and must be
+// reset before feeding more bytes.
 inline bool accept_utf8_byte(utf8_scan_state& s, uint8_t b) {
-    if (s.pending > 0) {
+    if (s.pending > 0) [[unlikely]] {
         if (b < s.min_cont || b > s.max_cont) {
             return false;
         }
@@ -125,33 +160,18 @@ inline bool accept_utf8_byte(utf8_scan_state& s, uint8_t b) {
         // Range constraints apply only to the first continuation byte.
         s.min_cont = 0x80;
         s.max_cont = 0xBF;
-    } else {
-        if (b < 0x80) {
-            // ASCII
-        } else if (b < 0xC2) {
-            return false; // bare continuation or overlong 2-byte start
-        } else if (b < 0xE0) {
-            s.pending = 1;
-        } else if (b == 0xE0) {
-            s.pending = 2;
-            s.min_cont = 0xA0; // exclude overlong
-        } else if (b == 0xED) {
-            s.pending = 2;
-            s.max_cont = 0x9F; // exclude surrogates
-        } else if (b < 0xF0) {
-            s.pending = 2;
-        } else if (b == 0xF0) {
-            s.pending = 3;
-            s.min_cont = 0x90; // exclude overlong
-        } else if (b == 0xF4) {
-            s.pending = 3;
-            s.max_cont = 0x8F; // exclude > U+10FFFF
-        } else if (b < 0xF5) { // 0xF1..0xF3
-            s.pending = 3;
-        } else {
-            return false; // 0xF5..0xFF
-        }
+        return true;
     }
+    if (b < 0x80) {
+        // ASCII: a complete code point. At pending == 0 the state already
+        // holds the boundary defaults, so skip the table load.
+        return true;
+    }
+    const auto lead = utf8_lead_table[b];
+    if (lead.pending < 0) {
+        return false;
+    }
+    s = lead;
     return true;
 }
 

--- a/src/v/strings/utf8.cc
+++ b/src/v/strings/utf8.cc
@@ -104,53 +104,69 @@ iobuf replace_invalid_utf8(std::string_view raw) {
     return result;
 }
 
-} // namespace
-
-bool is_valid_utf8(const iobuf& buf) {
+// Incremental UTF-8 validation state. `pending` counts the continuation
+// bytes still expected; `min_cont`/`max_cont` bound the next continuation
+// byte (tightened after an E0/ED/F0/F4 lead to reject overlongs, surrogates,
+// and code points above U+10FFFF).
+struct utf8_scan_state {
     int pending = 0;
     uint8_t min_cont = 0x80;
     uint8_t max_cont = 0xBF;
+};
+
+// Advance the state machine by one byte. Returns false if `b` is not valid
+// UTF-8 at the current position.
+inline bool accept_utf8_byte(utf8_scan_state& s, uint8_t b) {
+    if (s.pending > 0) {
+        if (b < s.min_cont || b > s.max_cont) {
+            return false;
+        }
+        --s.pending;
+        // Range constraints apply only to the first continuation byte.
+        s.min_cont = 0x80;
+        s.max_cont = 0xBF;
+    } else {
+        if (b < 0x80) {
+            // ASCII
+        } else if (b < 0xC2) {
+            return false; // bare continuation or overlong 2-byte start
+        } else if (b < 0xE0) {
+            s.pending = 1;
+        } else if (b == 0xE0) {
+            s.pending = 2;
+            s.min_cont = 0xA0; // exclude overlong
+        } else if (b == 0xED) {
+            s.pending = 2;
+            s.max_cont = 0x9F; // exclude surrogates
+        } else if (b < 0xF0) {
+            s.pending = 2;
+        } else if (b == 0xF0) {
+            s.pending = 3;
+            s.min_cont = 0x90; // exclude overlong
+        } else if (b == 0xF4) {
+            s.pending = 3;
+            s.max_cont = 0x8F; // exclude > U+10FFFF
+        } else if (b < 0xF5) { // 0xF1..0xF3
+            s.pending = 3;
+        } else {
+            return false; // 0xF5..0xFF
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+bool is_valid_utf8(const iobuf& buf) {
+    utf8_scan_state state;
     for (const auto& frag : buf) {
         for (size_t i = 0; i < frag.size(); ++i) {
-            const auto b = static_cast<uint8_t>(frag.get()[i]);
-            if (pending > 0) {
-                if (b < min_cont || b > max_cont) {
-                    return false;
-                }
-                --pending;
-                // Range constraints apply only to the first continuation byte.
-                min_cont = 0x80;
-                max_cont = 0xBF;
-            } else {
-                if (b < 0x80) {
-                    // ASCII
-                } else if (b < 0xC2) {
-                    return false; // bare continuation or overlong 2-byte start
-                } else if (b < 0xE0) {
-                    pending = 1;
-                } else if (b == 0xE0) {
-                    pending = 2;
-                    min_cont = 0xA0; // exclude overlong
-                } else if (b == 0xED) {
-                    pending = 2;
-                    max_cont = 0x9F; // exclude surrogates
-                } else if (b < 0xF0) {
-                    pending = 2;
-                } else if (b == 0xF0) {
-                    pending = 3;
-                    min_cont = 0x90; // exclude overlong
-                } else if (b == 0xF4) {
-                    pending = 3;
-                    max_cont = 0x8F;   // exclude > U+10FFFF
-                } else if (b < 0xF5) { // 0xF1..0xF3
-                    pending = 3;
-                } else {
-                    return false; // 0xF5..0xFF
-                }
+            if (!accept_utf8_byte(state, static_cast<uint8_t>(frag.get()[i]))) {
+                return false;
             }
         }
     }
-    return pending == 0;
+    return state.pending == 0;
 }
 
 std::expected<iobuf, utf8_sanitize_error>

--- a/src/v/strings/utf8.h
+++ b/src/v/strings/utf8.h
@@ -19,7 +19,6 @@
 #include <boost/locale/encoding_utf.hpp>
 #include <boost/locale/utf.hpp>
 
-#include <expected>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -191,12 +190,6 @@ std::string_view utf8_truncate_min(std::string_view s, size_t max_bytes);
 std::optional<std::string>
 utf8_truncate_max(std::string_view s, size_t max_bytes);
 
-enum class utf8_sanitize_error {
-    /// Input is invalid and size_bytes() > max_bytes; linearization not
-    /// attempted.
-    input_too_large,
-};
-
 /// Fragment-aware UTF-8 validation with no allocation.
 ///
 /// Returns false if \p buf contains any byte sequence that is not valid
@@ -207,12 +200,6 @@ bool is_valid_utf8(const iobuf& buf);
 ///
 /// Fast path: if \p input is already valid UTF-8, returns it unchanged
 /// (zero copy, no allocation).
-/// Slow path: if invalid and size_bytes() <= \p max_bytes, linearizes the
-/// input and replaces each ill-formed byte with U+FFFD; output is at most
-/// 3x the input size.
-/// Returns an error if the input exceeds \p max_bytes.
-///
-/// \p max_bytes is silently capped to iobuf::max_linearize_size; values
-/// larger than that cannot be linearized.
-std::expected<iobuf, utf8_sanitize_error>
-utf8_sanitize(iobuf input, size_t max_bytes = iobuf::max_linearize_size);
+/// Slow path: copies replacing each ill-formed byte with U+FFFD
+/// (advance-1-on-error strategy); output is at most 3x the input size.
+iobuf utf8_sanitize(iobuf input);


### PR DESCRIPTION
Rewrite the rescue path on top of the utf8 validation state machine:
bytes of the current code point are buffered (at most 4) and copied
once it completes, so sequences spanning fragment boundaries need no
special handling and the input no longer has to be linearized. The
advance-1-on-error replacement semantics are unchanged: an aborted
partial sequence yields one U+FFFD per consumed byte.

With linearization gone the size limit and its error path disappear,
simplifying the API to iobuf -> iobuf.

Tests cover rescue-path sequences spanning two and three fragments,
an aborted sequence followed by ASCII, and inputs larger than the
old linearize limit.

```
//src/v/strings/tests:utf8_sanitize_rpbench  · --config=release
  baseline  d468d2ca72 (clean)  "strings/utf8: add utf8_sanitize benchmark"  runs=5
  current   0072020f1d (clean)  runs=5

case                                           inst (Δ)     runtime med±mad (Δ)   allocs  tasks  verdict
───────────────────────────────────────────────────────────────────────────────────────────────────────────
utf8_sanitize.ascii_16k                148.14K  -0.0% =   11.34±0.01µs  -0.0% =      0 =    0 =  ≈ noise
utf8_sanitize.one_percent_invalid_16k  739.34K  -7.0% ▼   73.31±0.03µs  -7.0% ▼  2 -13 ▼    0 =  ✓ improved
utf8_sanitize.random_16k               838.04K  -6.7% ▼  248.58±0.05µs  +9.2% ▲  2 -15 ▼    0 =  ✓ improved
utf8_sanitize.valid_16k                185.58K  -6.3% ▼  17.86±0.07µs  -28.4% ▼      0 =    0 =  ✓ improved
  3 improved · 1 noise      primary metric: inst
```
## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none