### PR TITLE
[CORE-9092] `rptest`: bump nessie startup timeout

### DIFF
--- a/tests/rptest/services/nessie_catalog.py
+++ b/tests/rptest/services/nessie_catalog.py
@@ -173,7 +173,7 @@ class NessieCatalog(CatalogService):
     def _nessie_iceberg_path(self, node):
         return f"{self._nessie_base_path(node)}/iceberg"
 
-    def start_node(self, node, timeout_sec=60, **kwargs):
+    def start_node(self, node, timeout_sec=180, **kwargs):
         node.account.ssh(
             "mkdir -p %s" % NessieCatalog.PERSISTENT_ROOT, allow_fail=False
         )


### PR DESCRIPTION
Nessie startup on Azure CI VMs routinely takes ~60s (slow JVM boot/class loading), so give it ample headroom.

See CORE-9092.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
