### PR TITLE
[CORE-15927] rptest/htt: clamp segment size to per-tier allowed range

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -229,8 +229,10 @@ DEFAULT_MESSAGE_SIZE = 4 * KiB
 
 class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
     msg_size = DEFAULT_MESSAGE_SIZE
-    # Min segment size across all tiers
-    min_segment_size = 14 * MiB
+    # Preferred (smallest) segment size for generating many segments. Clamped
+    # at runtime to the tier's allowed range [log_segment_size_min,
+    # log_segment_size_max], which varies per tier.
+    min_segment_size = 16 * MiB
     unavailable_timeout = 60
     # default message count to check
     msg_count = 100000
@@ -257,6 +259,19 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
 
         self._num_brokers = config_profile["nodes_count"]
         self._cluster_config_log_segment_size = int(cluster_config["log_segment_size"])
+        # Cloud tiers restrict segment.bytes to [log_segment_size_min,
+        # log_segment_size_max], and the range differs per tier. Read the live
+        # bounds so segment sizes can be clamped into range, rather than
+        # hardcoding a value that is only valid on some tiers.
+        self._log_segment_size_min, self._log_segment_size_max = (
+            self._segment_size_bounds()
+        )
+        self.min_segment_size = self._clamp_segment_size(self.min_segment_size)
+        self.logger.info(
+            f"Tier segment size bounds: "
+            f"[{self._log_segment_size_min}, {self._log_segment_size_max}]; "
+            f"using min_segment_size={self.min_segment_size}"
+        )
         self._memory_per_broker = get_machine_info(
             config_profile["machine_type"]
         ).memory
@@ -480,6 +495,30 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         self.adjust_topic_segment_properties(
             self._cluster_config_log_segment_size // 2, retention_bytes
         )
+
+    def _segment_size_bounds(self) -> tuple[int, int | None]:
+        """Query the tier's allowed segment-size range from the live cluster config.
+
+        Cloud tiers set log_segment_size_min/max and reject segment.bytes
+        outside that range with INVALID_CONFIG. The bounds differ per tier, so
+        they must be read at runtime. The admin port isn't reachable from the
+        test runner, so rpk is run inside the cluster (same pattern as
+        config_profile_verify_test). Returns (min, max); an unset bound is
+        reported as a permissive default (1 for min, None for max).
+        """
+        live_config = json.loads(
+            self.redpanda.kubectl.exec("rpk redpanda admin config print --host 0")
+        )
+        seg_min = live_config.get("log_segment_size_min")
+        seg_max = live_config.get("log_segment_size_max")
+        return (int(seg_min) if seg_min else 1, int(seg_max) if seg_max else None)
+
+    def _clamp_segment_size(self, segment_bytes: int) -> int:
+        """Clamp a desired segment size into the tier's allowed [min, max] range."""
+        clamped = max(self._log_segment_size_min, segment_bytes)
+        if self._log_segment_size_max is not None:
+            clamped = min(clamped, self._log_segment_size_max)
+        return clamped
 
     def adjust_topic_segment_properties(
         self, segment_bytes: int, retention_local_bytes: int
@@ -1848,7 +1887,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
 
         self.logger.info("Starting stage_tiered_storage_consuming")
 
-        segment_size = 128 * MiB  # 128 MiB
+        segment_size = self._clamp_segment_size(128 * MiB)
         consume_rate = 1 * GiB  # 1 GiB/s
 
         # create a new topic with low local retention.


### PR DESCRIPTION
## Description

`HighThroughputTest` hardcoded `min_segment_size` (and a 128 MiB segment in `stage_tiered_storage_consuming`). Cloud tiers enforce `segment.bytes` within `[log_segment_size_min, log_segment_size_max]`, and that range differs per tier — e.g. one tier allows only `[14 MiB, 14 MiB]`, another `[16 MiB, 128 MiB]`. No fixed constant is valid on every tier, so `alter_topic_config` fails with `INVALID_CONFIG` depending on where the test runs:

```
INVALID_CONFIG: segment size 14680064 is outside of allowed range [16777216, 134217728]
```

This supersedes #30613, which moved `min_segment_size` from 16 MiB to 14 MiB — that just relocated the failure to tiers requiring ≥ 16 MiB.

Instead, query the live bounds at runtime and clamp segment sizes into range:

- `_segment_size_bounds()` reads `log_segment_size_min`/`max` from the live cluster config (`rpk redpanda admin config print` run inside the cluster, since the admin port isn't reachable from the test runner — same pattern as `config_profile_verify_test`).
- `_clamp_segment_size()` clamps a desired size to `[min, max]`.
- `min_segment_size` is derived from the lower bound, which keeps every `adjust_topic_segment_properties` caller in range; the hardcoded 128 MiB segment is clamped for the symmetric upper-bound case.

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
