### PR TITLE
Deflake round 2 nodewise recovery

### DIFF
--- a/src/v/cloud_topics/level_one/domain/domain_supervisor.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_supervisor.cc
@@ -54,7 +54,7 @@ public:
         _probe.setup_metrics();
         if (ss::this_shard_id() == 0) {
             _as = {};
-            _loop = do_topic_reconciliation_loop();
+            _loop = ensure_domains_topic();
         }
         co_return;
     }
@@ -118,18 +118,6 @@ public:
     }
 
 private:
-    ss::future<> do_topic_reconciliation_loop() {
-        while (!_as.abort_requested()) {
-            co_await ensure_domains_topic();
-
-            bool aborted = co_await loop_sleep(10min);
-            if (aborted) {
-                // If we were aborted, we exit the loop.
-                co_return;
-            }
-        }
-    }
-
     ss::future<> ensure_domains_topic() {
         auto backoff = make_exponential_backoff_policy<ss::lowres_clock>(
           1s, 10s);
@@ -137,13 +125,12 @@ private:
             if (
               _controller->get_topics_state().local().contains(
                 model::l1_metastore_nt)) {
-                if (co_await ensure_domains_replication_factor()) {
-                    break;
-                }
-            } else {
-                if (co_await create_domains_topic()) {
-                    break;
-                }
+                // Topic exists; the health_manager reconciles its replication
+                // factor alongside the other internal topics.
+                break;
+            }
+            if (co_await create_domains_topic()) {
+                break;
             }
             backoff.next_backoff();
             if (co_await loop_sleep(backoff.current_backoff_duration())) {
@@ -165,36 +152,6 @@ private:
         }
     }
 
-    ss::future<bool> ensure_domains_replication_factor() {
-        auto tp_ns = model::l1_metastore_nt;
-        auto rf = _controller->get_topics_state()
-                    .local()
-                    .get_topic_replication_factor(tp_ns);
-        if (!rf) {
-            vlog(cd_log.warn, "unable to find {} replication factor", tp_ns);
-            co_return false;
-        }
-        auto target_rf = cluster::replication_factor(
-          _controller->internal_topic_replication());
-        if (*rf != target_rf) {
-            vlog(
-              cd_log.info,
-              "updating {} replication factor to {}",
-              tp_ns,
-              target_rf);
-            cluster::topic_properties_update update{tp_ns};
-            update.custom_properties.replication_factor.op
-              = cluster::incremental_update_operation::set;
-            update.custom_properties.replication_factor.value = target_rf;
-            co_await update_topic(std::move(update));
-            co_return false;
-        } else {
-            vlog(
-              cd_log.trace, "replication factor for {} is already set", tp_ns);
-            co_return true;
-        }
-    }
-
     ss::future<bool>
     create_domains_topic(std::optional<int> num_partitions = std::nullopt) {
         auto tp_ns = model::l1_metastore_nt;
@@ -212,29 +169,6 @@ private:
           num_partitions.value_or(
             config::shard_local_cfg().cloud_topics_num_metastore_partitions()),
           topic_props);
-    }
-
-    ss::future<> update_topic(cluster::topic_properties_update update) {
-        cluster::errc ec{};
-        try {
-            auto res = co_await _controller->get_topics_frontend()
-                         .local()
-                         .update_topic_properties(
-                           {update},
-                           ss::lowres_clock::now()
-                             + config::shard_local_cfg()
-                                 .internal_rpc_request_timeout_ms());
-            vassert(res.size() == 1, "expected a single result");
-            ec = res[0].ec;
-        } catch (const std::exception& ex) {
-            vlog(
-              cd_log.warn, "unable to update topic {}: {}", update.tp_ns, ex);
-            co_return;
-        }
-        if (ec != cluster::errc::success) {
-            vlog(
-              cd_log.warn, "failed to update topic {}: {}", update.tp_ns, ec);
-        }
     }
 
     ss::future<bool> create_topic(

--- a/src/v/cluster/BUILD
+++ b/src/v/cluster/BUILD
@@ -2501,6 +2501,7 @@ redpanda_cc_library(
         "//src/v/ssx:rate_limited_function",
         "//src/v/ssx:semaphore",
         "//src/v/ssx:sformat",
+        "//src/v/ssx:single_fiber_executor",
         "//src/v/ssx:single_sharded",
         "//src/v/ssx:sleep_abortable",
         "//src/v/ssx:when_all",

--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -80,45 +80,70 @@ ss::future<> health_manager::stop() {
 
 ss::future<> health_manager::ensure_topic_replication(
   model::topic_namespace_view topic, ss::abort_source& as) {
-    if (as.abort_requested()) {
-        co_return;
-    }
-    auto tp_metadata = _topics.local().get_topic_metadata_ref(topic);
-    if (!tp_metadata.has_value()) {
-        vlog(clusterlog.debug, "Health manager: topic {} not found", topic);
-        co_return;
-    }
+    while (!as.abort_requested()) {
+        auto tp_metadata = _topics.local().get_topic_metadata_ref(topic);
+        if (!tp_metadata.has_value()) {
+            vlog(clusterlog.debug, "Health manager: topic {} not found", topic);
+            co_return;
+        }
 
-    auto current_replication_factor
-      = tp_metadata.value().get().get_replication_factor();
-    if (current_replication_factor() >= _target_replication_factor) {
-        vlog(
-          clusterlog.debug,
-          "Health manager: topic {} with replication {} reached target "
-          "{}",
-          topic,
-          current_replication_factor,
-          _target_replication_factor);
-        co_return;
-    }
+        auto current_replication_factor
+          = tp_metadata.value().get().get_replication_factor();
+        if (current_replication_factor() >= _target_replication_factor) {
+            vlog(
+              clusterlog.debug,
+              "Health manager: topic {} with replication {} reached target "
+              "{}",
+              topic,
+              current_replication_factor,
+              _target_replication_factor);
+            co_return;
+        }
 
-    if (
-      _topics.local().updates_in_progress().size() >= _max_concurrent_moves()) {
-        vlog(
-          clusterlog.info,
-          "Health manager: max number of reconfigurations reached");
-        co_return;
-    }
+        if (
+          _topics.local().updates_in_progress().size()
+          >= _max_concurrent_moves()) {
+            vlog(
+              clusterlog.info,
+              "Health manager: max number of reconfigurations reached");
+            co_return;
+        }
 
-    topic_properties_update properties_update(model::topic_namespace{topic});
-    properties_update.custom_properties.replication_factor.op
-      = incremental_update_operation::set;
-    properties_update.custom_properties.replication_factor.value
-      = replication_factor(_target_replication_factor);
-    auto res = co_await _topics_frontend.local().do_update_topic_properties(
-      std::move(properties_update),
-      model::timeout_clock::now() + set_replicas_timeout);
-    if (res.ec != errc::success) {
+        topic_properties_update properties_update(
+          model::topic_namespace{topic});
+        properties_update.custom_properties.replication_factor.op
+          = incremental_update_operation::set;
+        properties_update.custom_properties.replication_factor.value
+          = replication_factor(_target_replication_factor);
+        auto res = co_await _topics_frontend.local().do_update_topic_properties(
+          std::move(properties_update),
+          model::timeout_clock::now() + set_replicas_timeout);
+        if (res.ec == errc::success) {
+            vlog(clusterlog.info, "Increased replication factor for {}", topic);
+            co_return;
+        }
+
+        // Right after cluster bootstrap the target replicas may not be
+        // allocatable yet (brokers are still joining), so the update fails
+        // transiently. Waiting for the next reconcile tick could leave an
+        // internal topic born at a reduced replication factor (e.g. the
+        // cloud-topics metastore, created r=1 before a quorum of brokers
+        // joined) under-replicated for minutes. Retry promptly instead.
+        if (
+          res.ec == errc::no_eligible_allocation_nodes
+          || res.ec == errc::topic_invalid_replication_factor) {
+            vlog(
+              clusterlog.info,
+              "Health manager: transient error increasing replication factor "
+              "for {}: {}; retrying",
+              topic,
+              res.ec);
+            if (co_await sleep_or_aborted(std::chrono::seconds{1}, as)) {
+                co_return;
+            }
+            continue;
+        }
+
         vlog(
           clusterlog.warn,
           "Health manager: error updating properties for {}: {}",
@@ -126,8 +151,6 @@ ss::future<> health_manager::ensure_topic_replication(
           res.ec);
         co_return;
     }
-
-    vlog(clusterlog.info, "Increased replication factor for {}", topic);
 }
 
 void health_manager::submit_reconcile() {

--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -128,47 +128,46 @@ ss::future<> health_manager::do_tick() {
 
     // Only ensure replication if we have a big enough cluster, to avoid
     // spamming log with replication complaints on single node cluster
-    if (_members.local().node_count() >= 3) {
-        /*
-         * we try to be conservative here. if something goes wrong we'll
-         * back off and wait before trying to fix replication for any
-         * other internal topics.
-         */
-        auto ok = co_await ensure_topic_replication(
-          model::kafka_consumer_offsets_nt);
+    if (_members.local().node_count() < 3) {
+        _timer.arm(_tick_interval);
+        co_return;
+    }
 
-        if (ok) {
-            ok = co_await ensure_topic_replication(model::id_allocator_nt);
-        }
+    /*
+     * we try to be conservative here. if something goes wrong we'll
+     * back off and wait before trying to fix replication for any
+     * other internal topics.
+     */
+    auto ok = co_await ensure_topic_replication(
+      model::kafka_consumer_offsets_nt);
 
-        if (ok) {
-            ok = co_await ensure_topic_replication(model::tx_manager_nt);
-        }
+    if (ok) {
+        ok = co_await ensure_topic_replication(model::id_allocator_nt);
+    }
 
-        if (ok) {
-            const model::topic_namespace schema_registry_nt{
-              model::kafka_namespace, model::schema_registry_internal_tp.topic};
-            ok = co_await ensure_topic_replication(schema_registry_nt);
-        }
+    if (ok) {
+        ok = co_await ensure_topic_replication(model::tx_manager_nt);
+    }
 
-        if (ok) {
-            ok = co_await ensure_topic_replication(
-              model::topic_namespace_view(model::wasm_binaries_internal_ntp));
-        }
+    if (ok) {
+        ok = co_await ensure_topic_replication(model::schema_registry_nt);
+    }
 
-        if (ok) {
-            ok = co_await ensure_topic_replication(model::transform_offsets_nt);
-        }
+    if (ok) {
+        ok = co_await ensure_topic_replication(model::wasm_binaries_nt);
+    }
 
-        if (ok) {
-            ok = co_await ensure_topic_replication(
-              model::kafka_audit_logging_nt);
-        }
+    if (ok) {
+        ok = co_await ensure_topic_replication(model::transform_offsets_nt);
+    }
 
-        if (ok) {
-            ok = co_await ensure_topic_replication(
-              model::transform_log_internal_nt);
-        }
+    if (ok) {
+        ok = co_await ensure_topic_replication(model::kafka_audit_logging_nt);
+    }
+
+    if (ok) {
+        ok = co_await ensure_topic_replication(
+          model::transform_log_internal_nt);
     }
 
     _timer.arm(_tick_interval);

--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -47,6 +47,8 @@ health_manager::health_manager(
   , _as(as) {}
 
 ss::future<> health_manager::start() {
+    _as_sub = _as.local().subscribe(
+      [this]() noexcept { _reconciliation_executor.request_abort(); });
     submit_reconcile();
     co_return;
 }
@@ -109,6 +111,9 @@ health_manager::ensure_topic_replication(model::topic_namespace_view topic) {
 }
 
 void health_manager::submit_reconcile() {
+    if (_as.local().abort_requested()) {
+        return;
+    }
     ssx::background = _reconciliation_executor.submit(
       [this](ss::abort_source& executor_as) {
           return reconcile_loop(executor_as);

--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -73,18 +73,20 @@ ss::future<> health_manager::stop() {
       _members_notification_id);
     _leaders.local().unregister_leadership_change_notification(
       model::controller_ntp, _leadership_notification_id);
+    // drain() aborts the in-flight task, aborts any enqueued task, blocks new
+    // submits, and waits for both to resolve.
     co_await _reconciliation_executor.drain();
 }
 
-ss::future<bool> health_manager::ensure_topic_replication(
+ss::future<> health_manager::ensure_topic_replication(
   model::topic_namespace_view topic, ss::abort_source& as) {
     if (as.abort_requested()) {
-        co_return false;
+        co_return;
     }
     auto tp_metadata = _topics.local().get_topic_metadata_ref(topic);
     if (!tp_metadata.has_value()) {
         vlog(clusterlog.debug, "Health manager: topic {} not found", topic);
-        co_return true;
+        co_return;
     }
 
     auto current_replication_factor
@@ -97,7 +99,7 @@ ss::future<bool> health_manager::ensure_topic_replication(
           topic,
           current_replication_factor,
           _target_replication_factor);
-        co_return true;
+        co_return;
     }
 
     if (
@@ -105,7 +107,7 @@ ss::future<bool> health_manager::ensure_topic_replication(
         vlog(
           clusterlog.info,
           "Health manager: max number of reconfigurations reached");
-        co_return false;
+        co_return;
     }
 
     topic_properties_update properties_update(model::topic_namespace{topic});
@@ -122,11 +124,10 @@ ss::future<bool> health_manager::ensure_topic_replication(
           "Health manager: error updating properties for {}: {}",
           topic,
           res.ec);
-        co_return false;
+        co_return;
     }
 
     vlog(clusterlog.info, "Increased replication factor for {}", topic);
-    co_return true;
 }
 
 void health_manager::submit_reconcile() {
@@ -181,7 +182,7 @@ ss::future<> health_manager::do_reconcile(ss::abort_source& as) {
       model::l1_metastore_nt,
     };
 
-    std::vector<ss::future<bool>> reconciles;
+    std::vector<ss::future<>> reconciles;
     reconciles.reserve(internal_topics.size());
     for (auto topic : internal_topics) {
         reconciles.push_back(ensure_topic_replication(topic, as));

--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -22,7 +22,7 @@
 #include "model/transform.h"
 
 #include <seastar/core/sleep.hh>
-#include <seastar/core/timer.hh>
+#include <seastar/coroutine/as_future.hh>
 
 namespace cluster {
 
@@ -44,18 +44,16 @@ health_manager::health_manager(
   , _topics_frontend(topics_frontend)
   , _leaders(leaders)
   , _members(members)
-  , _as(as)
-  , _timer([this] { tick(); }) {}
+  , _as(as) {}
 
 ss::future<> health_manager::start() {
-    _timer.arm(_tick_interval);
+    submit_reconcile();
     co_return;
 }
 
 ss::future<> health_manager::stop() {
     vlog(clusterlog.info, "Stopping Health Manager...");
-    _timer.cancel();
-    return _gate.close();
+    co_await _reconciliation_executor.drain();
 }
 
 ss::future<bool>
@@ -110,26 +108,42 @@ health_manager::ensure_topic_replication(model::topic_namespace_view topic) {
     co_return true;
 }
 
-void health_manager::tick() {
-    ssx::background = ssx::spawn_with_gate_then(_gate, [this] {
-                          return do_tick();
-                      }).handle_exception([this](const std::exception_ptr& e) {
-        vlog(clusterlog.info, "Health manager caught error {}", e);
-        _timer.arm(_tick_interval * 2);
-    });
+void health_manager::submit_reconcile() {
+    ssx::background = _reconciliation_executor.submit(
+      [this](ss::abort_source& executor_as) {
+          return reconcile_loop(executor_as);
+      });
 }
 
-ss::future<> health_manager::do_tick() {
-    auto cluster_leader = _leaders.local().get_leader(model::controller_ntp);
-    if (cluster_leader != _self) {
-        vlog(clusterlog.trace, "Health: skipping tick as non-leader");
-        co_return;
-    }
+ss::future<> health_manager::reconcile_loop(ss::abort_source& executor_as) {
+    while (!executor_as.abort_requested()) {
+        auto cluster_leader = _leaders.local().get_leader(
+          model::controller_ntp);
+        if (cluster_leader != _self) {
+            vlog(clusterlog.trace, "Health: skipping reconcile as non-leader");
+            if (co_await sleep_or_aborted(_tick_interval, executor_as)) {
+                co_return;
+            }
+            continue;
+        }
 
+        try {
+            co_await do_reconcile();
+        } catch (...) {
+            auto e = std::current_exception();
+            vlog(clusterlog.info, "Health manager caught error {}", e);
+        }
+
+        if (co_await sleep_or_aborted(_tick_interval, executor_as)) {
+            co_return;
+        }
+    }
+}
+
+ss::future<> health_manager::do_reconcile() {
     // Only ensure replication if we have a big enough cluster, to avoid
     // spamming log with replication complaints on single node cluster
     if (_members.local().node_count() < 3) {
-        _timer.arm(_tick_interval);
         co_return;
     }
 
@@ -169,8 +183,17 @@ ss::future<> health_manager::do_tick() {
         ok = co_await ensure_topic_replication(
           model::transform_log_internal_nt);
     }
+}
 
-    _timer.arm(_tick_interval);
+ss::future<bool> health_manager::sleep_or_aborted(
+  std::chrono::milliseconds duration, ss::abort_source& executor_as) {
+    auto slept = co_await ss::coroutine::as_future(
+      ss::sleep_abortable<clock_type>(duration, executor_as));
+    if (slept.failed()) {
+        slept.ignore_ready_future();
+        co_return true;
+    }
+    co_return false;
 }
 
 } // namespace cluster

--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -49,12 +49,30 @@ health_manager::health_manager(
 ss::future<> health_manager::start() {
     _as_sub = _as.local().subscribe(
       [this]() noexcept { _reconciliation_executor.request_abort(); });
+
+    // Reconcile promptly on leadership/membership changes; runs are gated on
+    // controller leadership, so notifications on non-leaders are no-ops.
+    _leadership_notification_id
+      = _leaders.local().register_leadership_change_notification(
+        model::controller_ntp,
+        [this](const model::ntp&, model::term_id, model::node_id) {
+            submit_reconcile();
+        });
+    _members_notification_id
+      = _members.local().register_members_updated_notification(
+        [this](model::node_id, model::membership_state) {
+            submit_reconcile();
+        });
     submit_reconcile();
     co_return;
 }
 
 ss::future<> health_manager::stop() {
     vlog(clusterlog.info, "Stopping Health Manager...");
+    _members.local().unregister_members_updated_notification(
+      _members_notification_id);
+    _leaders.local().unregister_leadership_change_notification(
+      model::controller_ntp, _leadership_notification_id);
     co_await _reconciliation_executor.drain();
 }
 
@@ -128,10 +146,7 @@ ss::future<> health_manager::reconcile_loop(ss::abort_source& executor_as) {
           model::controller_ntp);
         if (cluster_leader != _self) {
             vlog(clusterlog.trace, "Health: skipping reconcile as non-leader");
-            if (co_await sleep_or_aborted(next_pass, executor_as)) {
-                co_return;
-            }
-            continue;
+            co_return;
         }
 
         try {

--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -38,7 +38,7 @@ health_manager::health_manager(
   ss::sharded<ss::abort_source>& as)
   : _self(self)
   , _target_replication_factor(target_replication_factor)
-  , _tick_interval(tick_interval)
+  , _tick_jitter(tick_interval)
   , _max_concurrent_moves(std::move(max_concurrent_moves))
   , _topics(topics)
   , _topics_frontend(topics_frontend)
@@ -117,11 +117,12 @@ void health_manager::submit_reconcile() {
 
 ss::future<> health_manager::reconcile_loop(ss::abort_source& executor_as) {
     while (!executor_as.abort_requested()) {
+        auto next_pass = _tick_jitter.next_duration();
         auto cluster_leader = _leaders.local().get_leader(
           model::controller_ntp);
         if (cluster_leader != _self) {
             vlog(clusterlog.trace, "Health: skipping reconcile as non-leader");
-            if (co_await sleep_or_aborted(_tick_interval, executor_as)) {
+            if (co_await sleep_or_aborted(next_pass, executor_as)) {
                 co_return;
             }
             continue;
@@ -134,7 +135,7 @@ ss::future<> health_manager::reconcile_loop(ss::abort_source& executor_as) {
             vlog(clusterlog.info, "Health manager caught error {}", e);
         }
 
-        if (co_await sleep_or_aborted(_tick_interval, executor_as)) {
+        if (co_await sleep_or_aborted(next_pass, executor_as)) {
             co_return;
         }
     }

--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -105,8 +105,6 @@ health_manager::ensure_topic_replication(model::topic_namespace_view topic) {
     }
 
     vlog(clusterlog.info, "Increased replication factor for {}", topic);
-    // short delay for things to stablize
-    co_await ss::sleep_abortable(stabilize_delay, _as.local());
     co_return true;
 }
 

--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -169,7 +169,7 @@ ss::future<> health_manager::do_reconcile(ss::abort_source& as) {
         co_return;
     }
 
-    const std::array<model::topic_namespace_view, 8> internal_topics{
+    const std::array<model::topic_namespace_view, 9> internal_topics{
       model::kafka_consumer_offsets_nt,
       model::id_allocator_nt,
       model::tx_manager_nt,
@@ -178,6 +178,7 @@ ss::future<> health_manager::do_reconcile(ss::abort_source& as) {
       model::transform_offsets_nt,
       model::kafka_audit_logging_nt,
       model::transform_log_internal_nt,
+      model::l1_metastore_nt,
     };
 
     std::vector<ss::future<bool>> reconciles;

--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -154,43 +154,23 @@ ss::future<> health_manager::do_reconcile(ss::abort_source& as) {
         co_return;
     }
 
-    /*
-     * we try to be conservative here. if something goes wrong we'll
-     * back off and wait before trying to fix replication for any
-     * other internal topics.
-     */
-    auto ok = co_await ensure_topic_replication(
-      model::kafka_consumer_offsets_nt, as);
+    const std::array<model::topic_namespace_view, 8> internal_topics{
+      model::kafka_consumer_offsets_nt,
+      model::id_allocator_nt,
+      model::tx_manager_nt,
+      model::schema_registry_nt,
+      model::wasm_binaries_nt,
+      model::transform_offsets_nt,
+      model::kafka_audit_logging_nt,
+      model::transform_log_internal_nt,
+    };
 
-    if (ok) {
-        ok = co_await ensure_topic_replication(model::id_allocator_nt, as);
+    std::vector<ss::future<bool>> reconciles;
+    reconciles.reserve(internal_topics.size());
+    for (auto topic : internal_topics) {
+        reconciles.push_back(ensure_topic_replication(topic, as));
     }
-
-    if (ok) {
-        ok = co_await ensure_topic_replication(model::tx_manager_nt, as);
-    }
-
-    if (ok) {
-        ok = co_await ensure_topic_replication(model::schema_registry_nt, as);
-    }
-
-    if (ok) {
-        ok = co_await ensure_topic_replication(model::wasm_binaries_nt, as);
-    }
-
-    if (ok) {
-        ok = co_await ensure_topic_replication(model::transform_offsets_nt, as);
-    }
-
-    if (ok) {
-        ok = co_await ensure_topic_replication(
-          model::kafka_audit_logging_nt, as);
-    }
-
-    if (ok) {
-        ok = co_await ensure_topic_replication(
-          model::transform_log_internal_nt, as);
-    }
+    co_await ss::when_all_succeed(reconciles.begin(), reconciles.end());
 }
 
 ss::future<bool> health_manager::sleep_or_aborted(

--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -58,8 +58,11 @@ ss::future<> health_manager::stop() {
     co_await _reconciliation_executor.drain();
 }
 
-ss::future<bool>
-health_manager::ensure_topic_replication(model::topic_namespace_view topic) {
+ss::future<bool> health_manager::ensure_topic_replication(
+  model::topic_namespace_view topic, ss::abort_source& as) {
+    if (as.abort_requested()) {
+        co_return false;
+    }
     auto tp_metadata = _topics.local().get_topic_metadata_ref(topic);
     if (!tp_metadata.has_value()) {
         vlog(clusterlog.debug, "Health manager: topic {} not found", topic);
@@ -132,7 +135,7 @@ ss::future<> health_manager::reconcile_loop(ss::abort_source& executor_as) {
         }
 
         try {
-            co_await do_reconcile();
+            co_await do_reconcile(executor_as);
         } catch (...) {
             auto e = std::current_exception();
             vlog(clusterlog.info, "Health manager caught error {}", e);
@@ -144,7 +147,7 @@ ss::future<> health_manager::reconcile_loop(ss::abort_source& executor_as) {
     }
 }
 
-ss::future<> health_manager::do_reconcile() {
+ss::future<> health_manager::do_reconcile(ss::abort_source& as) {
     // Only ensure replication if we have a big enough cluster, to avoid
     // spamming log with replication complaints on single node cluster
     if (_members.local().node_count() < 3) {
@@ -157,35 +160,36 @@ ss::future<> health_manager::do_reconcile() {
      * other internal topics.
      */
     auto ok = co_await ensure_topic_replication(
-      model::kafka_consumer_offsets_nt);
+      model::kafka_consumer_offsets_nt, as);
 
     if (ok) {
-        ok = co_await ensure_topic_replication(model::id_allocator_nt);
+        ok = co_await ensure_topic_replication(model::id_allocator_nt, as);
     }
 
     if (ok) {
-        ok = co_await ensure_topic_replication(model::tx_manager_nt);
+        ok = co_await ensure_topic_replication(model::tx_manager_nt, as);
     }
 
     if (ok) {
-        ok = co_await ensure_topic_replication(model::schema_registry_nt);
+        ok = co_await ensure_topic_replication(model::schema_registry_nt, as);
     }
 
     if (ok) {
-        ok = co_await ensure_topic_replication(model::wasm_binaries_nt);
+        ok = co_await ensure_topic_replication(model::wasm_binaries_nt, as);
     }
 
     if (ok) {
-        ok = co_await ensure_topic_replication(model::transform_offsets_nt);
-    }
-
-    if (ok) {
-        ok = co_await ensure_topic_replication(model::kafka_audit_logging_nt);
+        ok = co_await ensure_topic_replication(model::transform_offsets_nt, as);
     }
 
     if (ok) {
         ok = co_await ensure_topic_replication(
-          model::transform_log_internal_nt);
+          model::kafka_audit_logging_nt, as);
+    }
+
+    if (ok) {
+        ok = co_await ensure_topic_replication(
+          model::transform_log_internal_nt, as);
     }
 }
 

--- a/src/v/cluster/health_manager.h
+++ b/src/v/cluster/health_manager.h
@@ -29,8 +29,6 @@ namespace cluster {
 class health_manager {
     using clock_type = ss::lowres_clock;
     static constexpr std::chrono::seconds set_replicas_timeout = 15s;
-    // after changing replica set introduce a short cooling off delay
-    static constexpr std::chrono::seconds stabilize_delay = 10s;
 
 public:
     static constexpr ss::shard_id shard = 0;

--- a/src/v/cluster/health_manager.h
+++ b/src/v/cluster/health_manager.h
@@ -11,6 +11,7 @@
 #pragma once
 #include "base/seastarx.h"
 #include "cluster/fwd.h"
+#include "cluster/notification.h"
 #include "config/property.h"
 #include "model/metadata.h"
 #include "random/simple_time_jitter.h"
@@ -67,6 +68,8 @@ private:
     ss::sharded<partition_leaders_table>& _leaders;
     ss::sharded<members_table>& _members;
     ss::sharded<ss::abort_source>& _as;
+    notification_id_type _leadership_notification_id{};
+    notification_id_type _members_notification_id{};
     ssx::single_fiber_executor<
       ss::noncopyable_function<ss::future<>(ss::abort_source&)>>
       _reconciliation_executor;

--- a/src/v/cluster/health_manager.h
+++ b/src/v/cluster/health_manager.h
@@ -13,11 +13,11 @@
 #include "cluster/fwd.h"
 #include "config/property.h"
 #include "model/metadata.h"
+#include "ssx/single_fiber_executor.h"
 
 #include <seastar/core/abort_source.hh>
-#include <seastar/core/gate.hh>
 #include <seastar/core/sharded.hh>
-#include <seastar/core/timer.hh>
+#include <seastar/util/noncopyable_function.hh>
 
 #include <chrono>
 
@@ -50,8 +50,13 @@ public:
 
 private:
     ss::future<bool> ensure_topic_replication(model::topic_namespace_view);
-    void tick();
-    ss::future<> do_tick();
+    // Submits a fresh reconcile run, interrupting any run in flight.
+    void submit_reconcile();
+    ss::future<> reconcile_loop(ss::abort_source&);
+    ss::future<> do_reconcile();
+    // Returns true if interrupted via the abort source.
+    ss::future<bool>
+    sleep_or_aborted(std::chrono::milliseconds, ss::abort_source&);
 
     model::node_id _self;
     size_t _target_replication_factor;
@@ -62,8 +67,9 @@ private:
     ss::sharded<partition_leaders_table>& _leaders;
     ss::sharded<members_table>& _members;
     ss::sharded<ss::abort_source>& _as;
-    ss::gate _gate;
-    ss::timer<clock_type> _timer;
+    ssx::single_fiber_executor<
+      ss::noncopyable_function<ss::future<>(ss::abort_source&)>>
+      _reconciliation_executor;
 };
 
 } // namespace cluster

--- a/src/v/cluster/health_manager.h
+++ b/src/v/cluster/health_manager.h
@@ -48,11 +48,12 @@ public:
     ss::future<> stop();
 
 private:
-    ss::future<bool> ensure_topic_replication(model::topic_namespace_view);
+    ss::future<bool>
+    ensure_topic_replication(model::topic_namespace_view, ss::abort_source&);
     // Submits a fresh reconcile run, interrupting any run in flight.
     void submit_reconcile();
     ss::future<> reconcile_loop(ss::abort_source&);
-    ss::future<> do_reconcile();
+    ss::future<> do_reconcile(ss::abort_source&);
     // Returns true if interrupted via the abort source.
     ss::future<bool>
     sleep_or_aborted(std::chrono::milliseconds, ss::abort_source&);

--- a/src/v/cluster/health_manager.h
+++ b/src/v/cluster/health_manager.h
@@ -71,6 +71,8 @@ private:
     ssx::single_fiber_executor<
       ss::noncopyable_function<ss::future<>(ss::abort_source&)>>
       _reconciliation_executor;
+    // Declared last: unsubscribed before the executor its callback references.
+    ss::optimized_optional<ss::abort_source::subscription> _as_sub;
 };
 
 } // namespace cluster

--- a/src/v/cluster/health_manager.h
+++ b/src/v/cluster/health_manager.h
@@ -49,7 +49,7 @@ public:
     ss::future<> stop();
 
 private:
-    ss::future<bool>
+    ss::future<>
     ensure_topic_replication(model::topic_namespace_view, ss::abort_source&);
     // Submits a fresh reconcile run, interrupting any run in flight.
     void submit_reconcile();

--- a/src/v/cluster/health_manager.h
+++ b/src/v/cluster/health_manager.h
@@ -13,6 +13,7 @@
 #include "cluster/fwd.h"
 #include "config/property.h"
 #include "model/metadata.h"
+#include "random/simple_time_jitter.h"
 #include "ssx/single_fiber_executor.h"
 
 #include <seastar/core/abort_source.hh>
@@ -60,7 +61,7 @@ private:
 
     model::node_id _self;
     size_t _target_replication_factor;
-    std::chrono::milliseconds _tick_interval;
+    simple_time_jitter<clock_type, std::chrono::milliseconds> _tick_jitter;
     config::binding<size_t> _max_concurrent_moves;
     ss::sharded<topic_table>& _topics;
     ss::sharded<topics_frontend>& _topics_frontend;

--- a/src/v/model/namespace.h
+++ b/src/v/model/namespace.h
@@ -76,10 +76,16 @@ inline const model::ntp schema_registry_internal_ntp(
   schema_registry_internal_tp.topic,
   schema_registry_internal_tp.partition);
 
+inline const model::topic_namespace
+  schema_registry_nt(model::kafka_namespace, schema_registry_internal_tp.topic);
+
 inline const model::ntp wasm_binaries_internal_ntp(
   model::kafka_internal_namespace,
   model::topic("wasm_binaries"),
   model::partition_id(0));
+
+inline const model::topic_namespace wasm_binaries_nt(
+  model::kafka_internal_namespace, wasm_binaries_internal_ntp.tp.topic);
 
 inline const model::topic
   transform_log_internal_topic("_redpanda.transform_logs");

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -493,6 +493,23 @@ class Admin:
     the successful HTTP response object is returned.
     """
 
+    # Internal topics whose replication factor the health manager reconciles up
+    # to internal_topic_replication_factor. Keep in sync with the
+    # `internal_topics` array in src/v/cluster/health_manager.cc. All but the
+    # cloud-topics metastore (ct_l1_domain) are created lazily, so callers wait
+    # only on the ones that exist.
+    HEALTH_MANAGER_INTERNAL_TOPICS: list[tuple[str, str]] = [
+        ("kafka", "__consumer_offsets"),
+        ("kafka_internal", "id_allocator"),
+        ("kafka_internal", "tx"),
+        ("kafka", "_schemas"),
+        ("kafka_internal", "wasm_binaries"),
+        ("kafka_internal", "transform_offsets"),
+        ("kafka", "_redpanda.audit_log"),
+        ("kafka", "_redpanda.transform_logs"),
+        ("kafka_internal", "ct_l1_domain"),
+    ]
+
     def __init__(
         self,
         redpanda: RedpandaServiceProto,
@@ -1212,6 +1229,70 @@ class Admin:
         self, ns: str, topic: str, id: int, node: MaybeNode = None
     ) -> dict[str, Any]:
         return self._request("GET", f"partitions/{ns}/{topic}/{id}", node=node).json()
+
+    def internal_topic_replication_factor(self, node: MaybeNode = None) -> int:
+        """The configured target replication factor for internal topics."""
+        return int(
+            self.get_cluster_config(node=node, include_defaults=True)[
+                "internal_topic_replication_factor"
+            ]
+        )
+
+    def all_partitions_have_replicas(
+        self,
+        topic: str,
+        replication_factor: int,
+        *,
+        namespace: str | None = None,
+        node: MaybeNode = None,
+    ) -> bool:
+        """True if every partition of `topic` has at least `replication_factor`
+        replicas. Vacuously true if the topic does not exist yet (e.g. a
+        lazily-created internal topic)."""
+        try:
+            partitions = self.get_partitions(
+                topic=topic, namespace=namespace, node=node
+            )
+        except HTTPError as e:
+            if e.response is not None and e.response.status_code == 404:
+                return True
+            raise
+        return all(len(p["replicas"]) >= replication_factor for p in partitions)
+
+    def wait_for_internal_topic_replication(
+        self,
+        *,
+        timeout_sec: float = 180,
+        backoff_sec: float = 2,
+        node: MaybeNode = None,
+    ) -> None:
+        """Wait until every existing health-manager-managed internal topic is
+        fully replicated at the target replication factor, i.e. its move has
+        completed and every replica is a voter. get_partitions reports the
+        target replica set as soon as a move is issued, so we also require the
+        topic to have no in-flight reconfiguration. Reconfigurations of other
+        topics are ignored."""
+        rf = self.internal_topic_replication_factor(node=node)
+
+        def replicated() -> bool:
+            reconfiguring = {
+                (r["ns"], r["topic"]) for r in self.list_reconfigurations(node=node)
+            }
+            return all(
+                (ns, topic) not in reconfiguring
+                and self.all_partitions_have_replicas(
+                    topic, rf, namespace=ns, node=node
+                )
+                for ns, topic in self.HEALTH_MANAGER_INTERNAL_TOPICS
+            )
+
+        wait_until(
+            replicated,
+            timeout_sec=timeout_sec,
+            backoff_sec=backoff_sec,
+            err_msg=f"internal topics did not reach replication factor {rf}",
+            retry_on_exc=True,
+        )
 
     def get_transactions(
         self, topic: str, partition: int, namespace: str, node: MaybeNode = None

--- a/tests/rptest/tests/shadow_linking_rnot_test.py
+++ b/tests/rptest/tests/shadow_linking_rnot_test.py
@@ -34,6 +34,7 @@ from rptest.tests.cluster_linking_test_base import (
     StorageModeFlipper,
 )
 from rptest.tests.idempotency_stress_test import matrix
+from rptest.services.admin import Admin
 from rptest.services.admin_ops_fuzzer import AdminOperationsFuzzer
 from rptest.utils.node_operations import NodeOpsExecutor
 from rptest.utils.mode_checks import is_debug_mode
@@ -547,6 +548,10 @@ class ShadowLinkingRandomOpsTest(ShadowLinkTestBase):
             lock,
             progress_timeout=120,
         )
+
+        # Wait for internal topics to bootstrap to full replication factor or
+        # decommission will stall.
+        Admin(self.redpanda).wait_for_internal_topic_replication(timeout_sec=120)
 
         for i, op in enumerate(
             generate_random_workload(available_nodes=active_node_idxs)


### PR DESCRIPTION
Fixes my prior attempted deflake of nodewise recovery.

The issue is as follows:
Clusters bootstrap with 1 node initially, and then grow to their target size by joining new nodes.
Cloud topic internal topics start eagerly rather than lazily like other topics.

The cloud topics internal topics may bootstrap while the cluster is still single node, at which point rather than honoring internal_replication, they fall back to rf=1.

The issue, though, is that reconciliation of the cloud topics internal topics happens only once every (hardcoded) 10 minutes, and does NOT shortcut on membership changes.

As a result, if the cloud topics internal topic bootstraps with rf=1, it will be stuck like that for 10 minutes.

My prior change modified the nodewise recover test to wait for the cluster to be 'settled' aka for there to be no reconfigurations and for the cloud topics internal topics to have reached rf=3: this settling evidently could take up to 10 minutes, which way overwhelmed the timeout of 2 minutes I had assigned.

This PR rectifies the above by having internal reconciliation shortcut when membership changes and moving cloud topics internal topic over to the health manager which reconciles the others

This involved a few other changes and cleanups:
1. internal topic reconciliation is now performed in a single_fiber_executor so we can cancel and re-submit reconciliation without accidentally running 2 at the same time
2. internal topic reconciliation now cancels and spawns a new reconciliation loop on raft0 changes to allow the above to work properly
3. parallelizes the reconciliation of all the topics
4. adds a little jitter to the timing

Addendum:
Adds in a similar fix to what was in nodewise recovery tests to shadow linking chaos tests.
Adds the admin function to wait for internal topic replication before launching into a bunch of node decommissions.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
### Improvements

* cloud topics more quickly reach their target replication factor on bootstrap

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
