### PR TITLE
kafka/server: cache disabled partition lookup in fetch planner

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -1323,6 +1323,8 @@ class simple_fetch_planner final : public fetch_planner::impl {
               const auto max_batch_size
                 = topic_cfg.properties.batch_max_bytes.value_or(
                   metadata_cache.get_default_batch_max_bytes());
+              const auto* disabled_set = metadata_cache.get_topic_disabled_set(
+                tn_view);
 
               for (const kafka::fetch_session_partition& fp : partitions) {
                   // if this is not an initial fetch we are allowed to skip
@@ -1343,7 +1345,8 @@ class simple_fetch_planner final : public fetch_planner::impl {
 
                   if (
                     unlikely(
-                      metadata_cache.is_disabled(tn_view, partition_id))) {
+                      disabled_set
+                      && disabled_set->is_disabled(partition_id))) {
                       resp_it->set(
                         make_partition_response_error(
                           partition_id, error_code::replica_not_available),


### PR DESCRIPTION
Cache disable set lookup across partitions.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

