### PR TITLE
raft: append in-memory batches without a streaming reader 

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2952,27 +2952,10 @@ ss::future<storage::append_result> consensus::disk_append(
       storage::log_append_config::fsync::no,
       model::timeout_clock::now() + _disk_timeout()};
 
-    class consumer {
-    public:
-        consumer(storage::log_appender appender)
-          : _appender(std::move(appender)) {}
-
-        ss::future<ss::stop_iteration> operator()(model::record_batch& batch) {
-            auto ret = co_await _appender(batch);
-            co_return ret;
-        }
-
-        auto end_of_stream() { return _appender.end_of_stream(); }
-
-    private:
-        storage::log_appender _appender;
-    };
-
     return details::for_each_ref_extract_configuration(
              _log->offsets().dirty_offset,
-             model::make_chunked_memory_record_batch_reader(std::move(batches)),
-             consumer(_log->make_appender(cfg)),
-             cfg.timeout)
+             std::move(batches),
+             _log->make_appender(cfg))
       .then([this, should_update_last_quorum_idx](
               std::tuple<ret_t, chunked_vector<offset_configuration>> t) {
           auto& [ret, configurations] = t;

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2949,8 +2949,7 @@ ss::future<storage::append_result> consensus::disk_append(
     auto cfg = storage::log_append_config{
       // no fsync explicit on a per write, we verify at the end to
       // batch fsync
-      storage::log_append_config::fsync::no,
-      model::timeout_clock::now() + _disk_timeout()};
+      storage::log_append_config::fsync::no};
 
     return details::for_each_ref_extract_configuration(
              _log->offsets().dirty_offset,

--- a/src/v/raft/consensus_utils.h
+++ b/src/v/raft/consensus_utils.h
@@ -21,8 +21,12 @@
 #include "storage/snapshot.h"
 
 #include <seastar/core/abort_source.hh>
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/core/sstring.hh>
+
+#include <tuple>
+#include <utility>
 
 namespace raft::details {
 /// copy all record batch readers into N containers using the
@@ -129,55 +133,67 @@ public:
     Func _f;
 };
 
+template<typename ReferenceConsumer>
+struct configuration_extracting_consumer {
+    ss::future<ss::stop_iteration> operator()(model::record_batch& batch) {
+        if (
+          batch.header().type == model::record_batch_type::raft_configuration) {
+            iobuf_parser parser(batch.copy_records().begin()->release_value());
+            configurations.emplace_back(
+              next_offset, deserialize_configuration(parser));
+        }
+
+        // we have to calculate offsets manually because the batch may not
+        // yet have the base offset assigned.
+        next_offset += model::offset(batch.header().last_offset_delta)
+                       + model::offset(1);
+
+        return wrapped(batch);
+    }
+
+    auto end_of_stream() {
+        return ss::futurize_invoke([this] { return wrapped.end_of_stream(); })
+          .then([confs = std::move(configurations)](auto ret) mutable {
+              return std::make_tuple(std::move(ret), std::move(confs));
+          });
+    }
+
+    ReferenceConsumer wrapped;
+    model::offset next_offset;
+    chunked_vector<offset_configuration> configurations;
+};
+
+template<typename ReferenceConsumer>
+using configuration_extracting_consumer_result_t = typename ss::futurize<
+  decltype(std::declval<ReferenceConsumer&>().end_of_stream())>::value_type;
+
 /**
- * Function that allow consuming batches with given consumer while lazily
- * extracting raft::group_configuration from the reader.
+ * Consumes all batches with the given consumer while lazily extracting
+ * raft::group_configuration batches.
  *
- * returns tuple<consumer_result, std::vector<offset_configuration>>
+ * returns tuple<consumer_result, chunked_vector<offset_configuration>>
  */
 template<typename ReferenceConsumer>
-auto for_each_ref_extract_configuration(
+requires model::ReferenceBatchReaderConsumer<ReferenceConsumer>
+ss::future<std::tuple<
+  configuration_extracting_consumer_result_t<ReferenceConsumer>,
+  chunked_vector<offset_configuration>>>
+for_each_ref_extract_configuration(
   model::offset base_offset,
-  model::record_batch_reader&& rdr,
-  ReferenceConsumer c,
-  model::timeout_clock::time_point tm) {
-    struct extracting_consumer {
-        ss::future<ss::stop_iteration> operator()(model::record_batch& batch) {
-            if (
-              batch.header().type
-              == model::record_batch_type::raft_configuration) {
-                iobuf_parser parser(
-                  batch.copy_records().begin()->release_value());
-                configurations.emplace_back(
-                  next_offset, deserialize_configuration(parser));
-            }
-
-            // we have to calculate offsets manually because the batch may not
-            // yet have the base offset assigned.
-            next_offset += model::offset(batch.header().last_offset_delta)
-                           + model::offset(1);
-
-            return wrapped(batch);
+  chunked_vector<model::record_batch> batches,
+  ReferenceConsumer c) {
+    auto consumer = configuration_extracting_consumer<ReferenceConsumer>{
+      .wrapped = std::move(c), .next_offset = model::next_offset(base_offset)};
+    for (auto& batch : batches) {
+        // move the batch out so that its memory is released as soon as it has
+        // been consumed instead of holding all batches alive until the whole
+        // append completes
+        auto b = std::move(batch);
+        if (co_await consumer(b) == ss::stop_iteration::yes) {
+            break;
         }
-
-        auto end_of_stream() {
-            return ss::futurize_invoke(
-                     [this] { return wrapped.end_of_stream(); })
-              .then([confs = std::move(configurations)](auto ret) mutable {
-                  return std::make_tuple(std::move(ret), std::move(confs));
-              });
-        }
-
-        ReferenceConsumer wrapped;
-        model::offset next_offset;
-        chunked_vector<offset_configuration> configurations;
-    };
-
-    return std::move(rdr).for_each_ref(
-      extracting_consumer{
-        .wrapped = std::move(c),
-        .next_offset = model::next_offset(base_offset)},
-      tm);
+    }
+    co_return co_await consumer.end_of_stream();
 }
 
 bytes serialize_group_key(raft::group_id, metadata_key);

--- a/src/v/raft/tests/BUILD
+++ b/src/v/raft/tests/BUILD
@@ -299,6 +299,7 @@ redpanda_cc_btest(
     deps = [
         "//src/v/bytes:iobuf_parser",
         "//src/v/container:chunked_circular_buffer",
+        "//src/v/container:chunked_vector",
         "//src/v/model",
         "//src/v/model/tests:random",
         "//src/v/raft",

--- a/src/v/raft/tests/bootstrap_configuration_test.cc
+++ b/src/v/raft/tests/bootstrap_configuration_test.cc
@@ -58,15 +58,15 @@ struct bootstrap_fixture : raft::simple_record_fixture {
 
     std::vector<storage::append_result> write_n(const std::size_t n) {
         const auto cfg = storage::log_append_config{
-          storage::log_append_config::fsync::no, model::no_timeout};
+          storage::log_append_config::fsync::no};
         std::vector<storage::append_result> res;
         res.push_back(
           datas(n)
-            .for_each_ref(get_log()->make_appender(cfg), cfg.timeout)
+            .for_each_ref(get_log()->make_appender(cfg), model::no_timeout)
             .get());
         res.push_back(
           configs(n, raft::group_configuration::v_6)
-            .for_each_ref(get_log()->make_appender(cfg), cfg.timeout)
+            .for_each_ref(get_log()->make_appender(cfg), model::no_timeout)
             .get());
         get_log()->flush().get();
         return res;
@@ -107,19 +107,19 @@ FIXTURE_TEST(write_configs, bootstrap_fixture) {
 }
 FIXTURE_TEST(mixed_config_versions, bootstrap_fixture) {
     const storage::log_append_config append_cfg{
-      storage::log_append_config::fsync::no, model::no_timeout};
+      storage::log_append_config::fsync::no};
 
     datas(20)
-      .for_each_ref(get_log()->make_appender(append_cfg), append_cfg.timeout)
+      .for_each_ref(get_log()->make_appender(append_cfg), model::no_timeout)
       .get();
     configs(3, raft::group_configuration::v_4)
-      .for_each_ref(get_log()->make_appender(append_cfg), append_cfg.timeout)
+      .for_each_ref(get_log()->make_appender(append_cfg), model::no_timeout)
       .get();
     configs(2, raft::group_configuration::v_5)
-      .for_each_ref(get_log()->make_appender(append_cfg), append_cfg.timeout)
+      .for_each_ref(get_log()->make_appender(append_cfg), model::no_timeout)
       .get();
     configs(5, raft::group_configuration::v_6)
-      .for_each_ref(get_log()->make_appender(append_cfg), append_cfg.timeout)
+      .for_each_ref(get_log()->make_appender(append_cfg), model::no_timeout)
       .get();
     get_log()->flush().get();
 

--- a/src/v/raft/tests/configuration_serialization_test.cc
+++ b/src/v/raft/tests/configuration_serialization_test.cc
@@ -9,6 +9,7 @@
 
 #include "bytes/iobuf_parser.h"
 #include "container/chunked_circular_buffer.h"
+#include "container/chunked_vector.h"
 #include "model/adl_serde.h"
 #include "model/metadata.h"
 #include "model/tests/random_batch.h"
@@ -132,11 +133,11 @@ struct test_consumer {
     std::vector<model::offset> _config_offsets;
 };
 
-SEASTAR_THREAD_TEST_CASE(test_config_extracting_reader) {
+SEASTAR_THREAD_TEST_CASE(test_config_extracting) {
     auto cfg_1 = random_configuration();
     auto cfg_2 = random_configuration();
     using batches_t = chunked_circular_buffer<model::record_batch>;
-    chunked_circular_buffer<model::record_batch> all_batches;
+    chunked_vector<model::record_batch> all_batches;
 
     // serialize to batches
     // use adl
@@ -168,9 +169,8 @@ SEASTAR_THREAD_TEST_CASE(test_config_extracting_reader) {
 
     raft::details::for_each_ref_extract_configuration(
       model::offset(100),
-      model::make_memory_record_batch_reader(std::move(all_batches)),
-      test_consumer(model::offset(100)),
-      model::no_timeout)
+      std::move(all_batches),
+      test_consumer(model::offset(100)))
       .then([&cfg_1, &cfg_2](auto res) {
           auto& [offsets, configurations] = res;
           BOOST_REQUIRE_EQUAL(offsets[0], model::offset(101));

--- a/src/v/raft/tests/foreign_entry_test.cc
+++ b/src/v/raft/tests/foreign_entry_test.cc
@@ -152,8 +152,10 @@ extract_configuration(model::record_batch_reader&& rdr) {
         int end_of_stream() { return 0; }
     };
 
+    auto batches = co_await model::consume_reader_to_chunked_vector(
+      std::move(rdr), model::no_timeout);
     auto [_, cfgs] = co_await raft::details::for_each_ref_extract_configuration(
-      model::offset(0), std::move(rdr), noop_consumer{}, model::no_timeout);
+      model::offset(0), std::move(batches), noop_consumer{});
     BOOST_REQUIRE(!cfgs.empty());
     co_return cfgs.begin()->cfg;
 }

--- a/src/v/raft/tests/foreign_entry_test.cc
+++ b/src/v/raft/tests/foreign_entry_test.cc
@@ -66,15 +66,15 @@ struct foreign_entry_fixture {
 
     std::vector<storage::append_result> write_n(const std::size_t n) {
         auto cfg = storage::log_append_config{
-          storage::log_append_config::fsync::no, model::no_timeout};
+          storage::log_append_config::fsync::no};
         std::vector<storage::append_result> res;
         res.push_back(
           gen_data_record_batch_reader(n)
-            .for_each_ref(get_log()->make_appender(cfg), cfg.timeout)
+            .for_each_ref(get_log()->make_appender(cfg), model::no_timeout)
             .get());
         res.push_back(
           gen_config_record_batch_reader(n)
-            .for_each_ref(get_log()->make_appender(cfg), cfg.timeout)
+            .for_each_ref(get_log()->make_appender(cfg), model::no_timeout)
             .get());
         get_log()->flush().get();
         return res;

--- a/src/v/redpanda/tests/fixture.cc
+++ b/src/v/redpanda/tests/fixture.cc
@@ -789,9 +789,7 @@ redpanda_thread_fixture::make_data(std::optional<model::timestamp> base_ts) {
             model::offset(0),
             20,
             maybe_compress_batches::yes,
-            log_append_config{
-              .should_fsync = log_append_config::fsync::yes,
-              .timeout = model::no_timeout},
+            log_append_config{.should_fsync = log_append_config::fsync::yes},
             disk_log_builder::should_flush_after::yes,
             base_ts)
           | stop();

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2090,7 +2090,6 @@ model::offset get_next_append_offset(const offset_stats& offsets) {
 }
 } // namespace
 
-// config timeout is for the one calling reader consumer
 log_appender disk_log_impl::make_appender(log_append_config cfg) {
     throw_if_closed();
     auto now = log_clock::now();

--- a/src/v/storage/opfuzz/opfuzz.cc
+++ b/src/v/storage/opfuzz/opfuzz.cc
@@ -112,7 +112,7 @@ struct append_op final : opfuzz::op {
     const char* name() const final { return "append"; }
     ss::future<> invoke(opfuzz::op_context ctx) final {
         storage::log_append_config append_cfg{
-          storage::log_append_config::fsync::no, model::no_timeout};
+          storage::log_append_config::fsync::no};
         auto batches = co_await model::test::make_random_batches(
           model::offset(0), 10);
         vlog(
@@ -168,7 +168,7 @@ struct append_op_foreign final : opfuzz::op {
               return ss::smp::submit_to(
                 0, [rdr = std::move(p.first), cnt = p.second, ctx]() mutable {
                     storage::log_append_config append_cfg{
-                      storage::log_append_config::fsync::no, model::no_timeout};
+                      storage::log_append_config::fsync::no};
                     auto validator = append_offsets_validator(
                       ctx.log, cnt, false);
                     return std::move(rdr)
@@ -185,7 +185,7 @@ struct append_multi_term_op final : opfuzz::op {
     const char* name() const final { return "append_with_multiple_terms"; }
     ss::future<> invoke(opfuzz::op_context ctx) final {
         storage::log_append_config append_cfg{
-          storage::log_append_config::fsync::no, model::no_timeout};
+          storage::log_append_config::fsync::no};
         auto batches = co_await model::test::make_random_batches(
           model::offset(0), 10);
         const size_t mid = batches.size() / 2;

--- a/src/v/storage/tests/offset_translator_tests.cc
+++ b/src/v/storage/tests/offset_translator_tests.cc
@@ -346,8 +346,7 @@ struct fuzz_checker {
               : _self(self)
               , _appender(self._log->make_appender(
                   storage::log_append_config{
-                    .should_fsync = storage::log_append_config::fsync::no,
-                    .timeout = model::no_timeout})) {}
+                    .should_fsync = storage::log_append_config::fsync::no})) {}
 
             ss::future<ss::stop_iteration>
             operator()(model::record_batch& batch) {

--- a/src/v/storage/tests/produce_consume_test.cc
+++ b/src/v/storage/tests/produce_consume_test.cc
@@ -22,8 +22,7 @@ TEST(ProduceConsumeTest, produce_consume_concurrency) {
     builder | storage::start();
 
     storage::log_append_config app_cfg{
-      .should_fsync = storage::log_append_config::fsync::no,
-      .timeout = model::no_timeout};
+      .should_fsync = storage::log_append_config::fsync::no};
     auto log = builder.get_log();
     auto range = boost::irange(0, 1000);
 

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -480,10 +480,10 @@ TEST_F(storage_test_fixture, test_append_batches_from_multiple_terms) {
           std::back_inserter(batches));
     }
     storage::log_append_config append_cfg{
-      storage::log_append_config::fsync::yes, model::no_timeout};
+      storage::log_append_config::fsync::yes};
     auto reader = model::make_memory_record_batch_reader(std::move(batches));
     std::move(reader)
-      .for_each_ref(log->make_appender(append_cfg), append_cfg.timeout)
+      .for_each_ref(log->make_appender(append_cfg), model::no_timeout)
       .get();
     log->flush().get();
 
@@ -547,11 +547,10 @@ void append_custom_timestamp_batches(
           {std::move(batch)});
         storage::log_append_config cfg{
           .should_fsync = storage::log_append_config::fsync::no,
-          .timeout = model::no_timeout,
         };
 
         std::move(reader)
-          .for_each_ref(log->make_appender(cfg), cfg.timeout)
+          .for_each_ref(log->make_appender(cfg), model::no_timeout)
           .get();
         current_ts = model::timestamp(current_ts() + 1);
     }
@@ -583,11 +582,10 @@ TEST_F(
           {std::move(batch)});
         storage::log_append_config cfg{
           .should_fsync = storage::log_append_config::fsync::no,
-          .timeout = model::no_timeout,
         };
 
         std::move(reader)
-          .for_each_ref(log->make_appender(cfg), cfg.timeout)
+          .for_each_ref(log->make_appender(cfg), model::no_timeout)
           .get();
         current_ts = model::timestamp(current_ts() + 1);
     };
@@ -877,7 +875,7 @@ ss::future<storage::append_result> append_exactly(
       model::packed_record_batch_header_size,
       batch_sz);
     storage::log_append_config append_cfg{
-      storage::log_append_config::fsync::no, model::no_timeout};
+      storage::log_append_config::fsync::no};
 
     chunked_circular_buffer<model::record_batch> batches;
     auto val_sz = batch_sz - model::packed_record_batch_header_size;
@@ -1123,8 +1121,7 @@ TEST_F(storage_test_fixture, empty_segment_recovery) {
     model::record_batch_type bt = model::record_batch_type::raft_data;
     using should_flush_t = storage::disk_log_builder::should_flush_after;
     storage::log_append_config appender_cfg{
-      .should_fsync = storage::log_append_config::fsync::no,
-      .timeout = model::no_timeout};
+      .should_fsync = storage::log_append_config::fsync::no};
     builder | storage::start(ntp) | storage::add_segment(0)
       | storage::add_random_batch(
         0,
@@ -1183,8 +1180,7 @@ TEST_F(storage_test_fixture, empty_segment_recovery) {
     // Append single batch
     storage::log_appender appender = log->make_appender(
       storage::log_append_config{
-        .should_fsync = storage::log_append_config::fsync::no,
-        .timeout = model::no_timeout});
+        .should_fsync = storage::log_append_config::fsync::no});
     chunked_circular_buffer<model::record_batch> batches;
     batches.push_back(
       model::test::make_random_batch(model::offset(0), 1, false));
@@ -1213,8 +1209,7 @@ TEST_F(storage_test_fixture, test_compaction_preserve_state) {
     model::record_batch_type bt = model::record_batch_type::raft_configuration;
     using should_flush_t = storage::disk_log_builder::should_flush_after;
     storage::log_append_config appender_cfg{
-      .should_fsync = storage::log_append_config::fsync::no,
-      .timeout = model::no_timeout};
+      .should_fsync = storage::log_append_config::fsync::no};
 
     // single segment
     builder | storage::start(ntp) | storage::add_segment(0)
@@ -1263,8 +1258,7 @@ TEST_F(storage_test_fixture, test_compaction_preserve_state) {
     // Append single batch
     storage::log_appender appender = log->make_appender(
       storage::log_append_config{
-        .should_fsync = storage::log_append_config::fsync::no,
-        .timeout = model::no_timeout});
+        .should_fsync = storage::log_append_config::fsync::no});
 
     chunked_circular_buffer<model::record_batch> batches;
     batches.push_back(
@@ -1313,11 +1307,10 @@ ss::future<> append_single_record_batch_coro(
           {std::move(batch)});
         storage::log_append_config cfg{
           .should_fsync = storage::log_append_config::fsync::no,
-          .timeout = model::no_timeout,
         };
 
         co_await std::move(reader).for_each_ref(
-          log->make_appender(cfg), cfg.timeout);
+          log->make_appender(cfg), model::no_timeout);
     }
 }
 
@@ -2377,8 +2370,7 @@ TEST_F(storage_test_fixture, committed_offset_updates) {
         // Append single batch
         storage::log_appender appender = log->make_appender(
           storage::log_append_config{
-            .should_fsync = storage::log_append_config::fsync::no,
-            .timeout = model::no_timeout});
+            .should_fsync = storage::log_append_config::fsync::no});
 
         chunked_circular_buffer<model::record_batch> batches;
         batches.push_back(
@@ -2498,11 +2490,10 @@ TEST_F(storage_test_fixture, changing_cleanup_policy_back_and_forth) {
                   {std::move(batch)});
                 storage::log_append_config cfg{
                   .should_fsync = storage::log_append_config::fsync::no,
-                  .timeout = model::no_timeout,
                 };
 
                 std::move(reader)
-                  .for_each_ref(log->make_appender(cfg), cfg.timeout)
+                  .for_each_ref(log->make_appender(cfg), model::no_timeout)
                   .get();
             }
         } while (log->segments().back()->size_bytes() < size);
@@ -2674,10 +2665,11 @@ void write_batch(
     auto reader = model::make_memory_record_batch_reader({std::move(batch)});
     storage::log_append_config cfg{
       .should_fsync = storage::log_append_config::fsync::no,
-      .timeout = model::no_timeout,
     };
 
-    std::move(reader).for_each_ref(log->make_appender(cfg), cfg.timeout).get();
+    std::move(reader)
+      .for_each_ref(log->make_appender(cfg), model::no_timeout)
+      .get();
 }
 
 absl::
@@ -2811,14 +2803,13 @@ TEST_F(storage_test_fixture, read_write_truncate) {
 
           storage::log_append_config cfg{
             .should_fsync = storage::log_append_config::fsync::no,
-            .timeout = model::no_timeout,
           };
           SUCCEED() << "append";
           return log_mutex
             .with([reader = std::move(reader), cfg, &log]() mutable {
                 SUCCEED() << "append_lock";
                 return std::move(reader).for_each_ref(
-                  log->make_appender(cfg), cfg.timeout);
+                  log->make_appender(cfg), model::no_timeout);
             })
             .then([](storage::append_result res) {
                 SUCCEED() << fmt::format("append_result: {}", res.last_offset);
@@ -2934,12 +2925,11 @@ TEST_F(storage_test_fixture, write_truncate_compact) {
 
               storage::log_append_config cfg{
                 .should_fsync = storage::log_append_config::fsync::no,
-                .timeout = model::no_timeout,
               };
               return log_mutex
                 .with([reader = std::move(reader), cfg, &log]() mutable {
                     return std::move(reader).for_each_ref(
-                      log->make_appender(cfg), cfg.timeout);
+                      log->make_appender(cfg), model::no_timeout);
                 })
                 .then([](storage::append_result res) {
                     SUCCEED()
@@ -3111,7 +3101,6 @@ TEST_F(storage_test_fixture, compaction_non_raft_batches_regression_test) {
 
     storage::log_append_config appender_cfg{
       .should_fsync = storage::log_append_config::fsync::no,
-      .timeout = model::no_timeout,
     };
 
     auto append_random_batch = [&](model::record_batch_type bt) {
@@ -3236,7 +3225,6 @@ TEST_F(storage_test_fixture, compaction_truncation_corner_cases) {
 
           storage::log_append_config appender_cfg{
             .should_fsync = storage::log_append_config::fsync::no,
-            .timeout = model::no_timeout,
           };
 
           std::move(reader)
@@ -3569,11 +3557,10 @@ do_compact_test(const compact_test_args args, storage_test_fixture& f) {
           {std::move(batch)});
         storage::log_append_config cfg{
           .should_fsync = storage::log_append_config::fsync::no,
-          .timeout = model::no_timeout,
         };
 
         std::move(reader)
-          .for_each_ref(log->make_appender(cfg), cfg.timeout)
+          .for_each_ref(log->make_appender(cfg), model::no_timeout)
           .get();
     };
 
@@ -3951,14 +3938,13 @@ TEST_F(storage_test_fixture, issue_8091) {
 
           storage::log_append_config cfg{
             .should_fsync = storage::log_append_config::fsync::no,
-            .timeout = model::no_timeout,
           };
           SUCCEED() << "append";
           return log_mutex
             .with([reader = std::move(reader), cfg, &log]() mutable {
                 SUCCEED() << "append_lock";
                 return std::move(reader)
-                  .for_each_ref(log->make_appender(cfg), cfg.timeout)
+                  .for_each_ref(log->make_appender(cfg), model::no_timeout)
                   .then([](storage::append_result res) {
                       SUCCEED()
                         << fmt::format("append_result: {}", res.last_offset);

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -176,7 +176,7 @@ public:
       = storage::log_append_config::fsync::no,
       bool flush_after_append = true) {
         auto lstats = log->offsets();
-        storage::log_append_config append_cfg{sync, model::no_timeout};
+        storage::log_append_config append_cfg{sync};
 
         model::offset base_offset = lstats.dirty_offset < model::offset(0)
                                       ? model::offset(0)
@@ -205,7 +205,7 @@ public:
               std::move(batches));
             auto res = std::move(reader)
                          .for_each_ref(
-                           log->make_appender(append_cfg), append_cfg.timeout)
+                           log->make_appender(append_cfg), model::no_timeout)
                          .get();
             if (flush_after_append) {
                 log->flush().get();
@@ -227,7 +227,7 @@ public:
           batch.header().last_offset_delta);
         buffer.push_back(std::move(batch));
         storage::log_append_config append_cfg{
-          storage::log_append_config::fsync::no, model::no_timeout};
+          storage::log_append_config::fsync::no};
 
         model::offset old_dirty_offset = log->offsets().dirty_offset;
         model::offset base_offset = old_dirty_offset < model::offset(0)

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -239,7 +239,7 @@ ss::future<> disk_log_builder::write(
     disk_log_appender appender(
       get_disk_log_impl(), config, log_clock::now(), base_offset);
     return std::move(reader)
-      .for_each_ref(std::move(appender), config.timeout)
+      .for_each_ref(std::move(appender), model::no_timeout)
       .then([this, flush](storage::append_result ar) {
           _bytes_written += ar.byte_size;
           if (flush) {

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -47,8 +47,7 @@ inline local_log_reader_config reader_config() {
 
 inline log_append_config append_config() {
     return log_append_config{
-      .should_fsync = storage::log_append_config::fsync::yes,
-      .timeout = model::no_timeout};
+      .should_fsync = storage::log_append_config::fsync::yes};
 }
 
 inline model::ntp log_builder_ntp() {

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -296,7 +296,6 @@ struct offset_stats {
 struct log_append_config {
     using fsync = ss::bool_class<class skip_tag>;
     fsync should_fsync;
-    model::timeout_clock::time_point timeout;
 };
 struct append_result {
     log_clock::time_point append_time;

--- a/src/v/test_utils/logs.h
+++ b/src/v/test_utils/logs.h
@@ -65,11 +65,11 @@ static inline ss::future<> persist_log_file(
                       ss::shared_ptr<storage::log> log) mutable {
                   log->stm_hookset()->start();
                   storage::log_append_config cfg{
-                    storage::log_append_config::fsync::yes, model::no_timeout};
+                    storage::log_append_config::fsync::yes};
                   auto reader = model::make_memory_record_batch_reader(
                     std::move(b));
                   return std::move(reader)
-                    .for_each_ref(log->make_appender(cfg), cfg.timeout)
+                    .for_each_ref(log->make_appender(cfg), model::no_timeout)
                     .then([log](storage::append_result) mutable {
                         return log->flush();
                     })


### PR DESCRIPTION
Meta:
 - I recommend to review with w=1 / ignore-whitespace
 - First commit is the actual one. Second is just cleanup
---


consensus::disk_append() held the batches to append in a chunked_vector
but fed them to the log appender by wrapping them in a
make_chunked_memory_record_batch_reader() and driving them through
for_each_ref_extract_configuration(). For batches already materialized in
memory this pays for the streaming reader machinery on every append: a
heap-allocated reader impl, per-iteration std::variant visitation
(is_slice_empty/is_end_of_stream) and the ss::repeat/futurize driving
loop, all to walk a vector we already hold. Profiles of the produce and
replicate paths (with payload kept small so it doesn't dominate) showed
this reader machinery as a hotspot in allocations and task scheduling.

Iterate the batches directly into the appender instead, extracting raft
configuration batches inline exactly as the reader-based path did. This
runs on every raft append, on every replica.

Move each batch out of the vector as soon as it has been consumed so
that its memory is released eagerly, matching the streaming reader path
which dropped every batch right after the appender was done with it
instead of holding the whole vector alive until the append completes.

The record_batch_reader overload of for_each_ref_extract_configuration
is left without production callers: remove it and migrate its two test
users to the batch vector overload, which also gives the new path
direct unit test coverage. Constrain the consumer with
model::ReferenceBatchReaderConsumer, previously enforced via
record_batch_reader::for_each_ref.

raft_replicate_bench quorum_ack_replicate_16KiB (release):
  inst   253466 -> 241675 (-4.7%)
  allocs 444.7  -> 417.7  (-27)
  tasks  221.1  -> 206.1  (-15)

produce_partition_bench 1_produced, one record/batch (release):
  inst   60148  -> 59452  (-1.2%)
  allocs 116.4  -> 111.4  (-5)
  tasks  40.1   -> 40.1   (0)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
