### PR TITLE
cluster_link/replication: don't floor prefix truncation at resume offset

### DIFF
--- a/src/v/cluster_link/replication/partition_replicator.cc
+++ b/src/v/cluster_link/replication/partition_replicator.cc
@@ -59,6 +59,7 @@ ss::future<> partition_replicator::start() {
         // Sink has not replicated anything yet.
         // We will start from configured start offset.
         _start_offset = co_await _config_provider.start_offset(_ntp, _as);
+        _truncation_floor = _start_offset;
         vlog(
           _log.debug,
           "Starting replication from configured start offset {}",
@@ -369,7 +370,7 @@ ss::future<> partition_replicator::maybe_synchronize_start_offset() {
         co_return;
     }
 
-    auto truncate_offset = std::max(_start_offset, source_start_offset);
+    auto truncate_offset = std::max(_truncation_floor, source_start_offset);
     vlog(
       _log.debug,
       "Truncating shadow partition from {} -> {}",

--- a/src/v/cluster_link/replication/partition_replicator.h
+++ b/src/v/cluster_link/replication/partition_replicator.h
@@ -112,8 +112,17 @@ private:
     std::unique_ptr<data_sink> _sink;
     ss::scheduling_group _scheduling_group;
     // set in start.
-    // The original start offset configured for this replicator.
+    // The offset replication begins from: the configured link start offset
+    // when the sink is empty, or the resume position (next offset after the
+    // last replicated one) otherwise.
     kafka::offset _start_offset{};
+    // Floor for prefix-truncating the shadow partition. Only a fresh start
+    // from the configured link start offset establishes a floor: the shadow
+    // partition has no data below it. A resumed replicator must not floor
+    // truncation at its resume position -- that would advance the shadow
+    // start offset past the source's when the source trims below the resume
+    // point (set in start).
+    kafka::offset _truncation_floor{kafka::offset::min()};
     // to pipeline multiple replicate requests in parallel
     static constexpr ssize_t max_in_flight_requests = 5;
     ssx::semaphore _max_requests{

--- a/src/v/cluster_link/replication/tests/partition_replicator_tests.cc
+++ b/src/v/cluster_link/replication/tests/partition_replicator_tests.cc
@@ -85,14 +85,22 @@ public:
     std::optional<data_source::source_partition_offsets_report>
     get_offsets() final {
         source_partition_offsets_report ret;
-        ret.source_start_offset = _start_offset.value_or(kafka::offset{-1});
+        ret.source_start_offset = _reported_start_offset.value_or(
+          _start_offset.value_or(kafka::offset{-1}));
         ret.source_hwm = _next_to_consume;
         ret.source_lso = _next_to_consume;
         return ret;
     }
 
+    // Simulate a prefix trim on the source: subsequent offset reports
+    // advertise `o` as the source start offset.
+    void set_reported_start_offset(kafka::offset o) {
+        _reported_start_offset = o;
+    }
+
 private:
     std::optional<kafka::offset> _start_offset{};
+    std::optional<kafka::offset> _reported_start_offset{};
     kafka::offset _next_to_consume;
     kafka::offset _last_reset_offset;
     int _num_fetches = 0;
@@ -191,6 +199,13 @@ public:
 
     kafka::offset committed_offset() const { return _committed_offset; }
 
+    // Seed the sink with already-replicated data so a replicator built on
+    // top of it resumes from next_offset(o) instead of starting fresh.
+    void seed_replicated(kafka::offset o) {
+        _last_replicated_offset = o;
+        _committed_offset = o;
+    }
+
 private:
     model::ntp _ntp{"kafka", "test", model::partition_id(0)};
     ssx::mutex _replication_mu{"test_replication"};
@@ -231,8 +246,6 @@ protected:
     test_data_sink* _sink;
     std::unique_ptr<partition_replicator> _replicator;
     model::ntp _ntp{"kafka", "test", 0};
-
-private:
     std::unique_ptr<link_configuration_provider> _config_provider;
 };
 
@@ -353,6 +366,46 @@ TEST_F_CORO(PartitionReplicatorFixture, TestOffsetMonotonicityOnFailure) {
         return _sink->last_replicated_offset() == kafka::offset(109)
                && _source->num_resets() == 1;
     });
+}
+
+// Test that a replicator resuming from a previously replicated position
+// (e.g. after a shadow partition leadership change) follows the source start
+// offset exactly when synchronizing. Flooring the truncation at the resume
+// position would advance the shadow partition start offset past a source
+// prefix trim that landed below the resume point.
+TEST_F_CORO(PartitionReplicatorFixture, TestNoStartOffsetOvershootOnResume) {
+    // Replicate offsets [0, 99] with the initial replicator, then stop it,
+    // simulating a leadership change.
+    for (int i = 0; i < 10; ++i) {
+        co_await push_data();
+    }
+    RPTEST_REQUIRE_EVENTUALLY_CORO(
+      5s, [&] { return _sink->last_replicated_offset() == kafka::offset(99); });
+    co_await _replicator->stop();
+
+    // New term: the sink already holds [0, 99], so the new replicator
+    // resumes from offset 100.
+    auto source = std::make_unique<test_data_source>();
+    auto sink = std::make_unique<test_data_sink>();
+    sink->seed_replicated(kafka::offset(99));
+    _source = source.get();
+    _sink = sink.get();
+    _replicator = std::make_unique<partition_replicator>(
+      _ntp,
+      model::term_id(1),
+      *_config_provider,
+      std::move(source),
+      std::move(sink));
+    co_await _replicator->start();
+
+    // The source was prefix-trimmed to offset 50, below the resume point.
+    _source->set_reported_start_offset(kafka::offset(50));
+    co_await push_data();
+
+    // The shadow partition start offset must land on the source's, not on
+    // the resume position (100).
+    RPTEST_REQUIRE_EVENTUALLY_CORO(
+      5s, [&] { return _sink->start_offset() == kafka::offset(50); });
 }
 
 } // namespace cluster_link::replication


### PR DESCRIPTION
`partition_replicator::maybe_synchronize_start_offset` floors the shadow
partition prefix truncation at `_start_offset`. That member is the
configured link start offset only when the sink is empty; on a resumed
replicator (e.g. after a shadow partition leadership change) it is the
fetch resume position. Flooring at the resume position advances the
shadow partition start offset past a source prefix trim that lands below
the resume point, removing records from the shadow that still exist on
the source.

Observed in CI as `ShadowLinkingReplicationTests.test_auto_prefix_trimming`
failures: after a mid-test leadership change the target partition
reported a start offset far past the trim point (e.g. 3382 instead of
1000) and the test, which waits for exact equality, could never converge.

The fix tracks the truncation floor separately from the replication
position: only a fresh start from the configured link start offset
establishes a floor (the shadow has no data below it); a resumed
replicator follows the source start offset exactly. A new unit test
resumes a replicator over a seeded sink and verifies a source trim below
the resume point is followed exactly (it fails against the previous
code).

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Bug Fixes

* Fixed shadow link replication advancing the shadow partition start
  offset past the source partition's start offset when a replicator
  resumes after a shadow partition leadership change.
