### PR TITLE
[v25.3.x] `kafka`/`cluster_link`: fix deadlocks with `kafka::cluster`

### DIFF
--- a/src/v/cluster_link/link.cc
+++ b/src/v/cluster_link/link.cc
@@ -143,6 +143,11 @@ ss::future<> link::stop() noexcept {
       _config->uuid);
     _task_reconciler.cancel();
     _as.request_abort();
+    // Shutdown input within the `_cluster` first before trying to close any
+    // `gate`s. Otherwise, there is the potential to deadlock (`gate` waiting on
+    // hung request, hung request waiting on `_cluster`'s `abort_source`,
+    // `abort_source` waiting for `gate` to be closed).
+    _cluster_connection->shutdown_input();
     co_await _replication_mgr.stop();
     co_await _gate.close();
 
@@ -174,7 +179,7 @@ ss::future<> link::stop() noexcept {
     }
 
     try {
-        co_await _cluster_connection->stop();
+        co_await _cluster_connection->drain();
     } catch (const std::exception& e) {
         vlog(cllog.warn, "Error shutting down cluster connection: {}", e);
     }

--- a/src/v/cluster_link/tests/link_test.cc
+++ b/src/v/cluster_link/tests/link_test.cc
@@ -494,4 +494,105 @@ TEST_F_CORO(evil_link_test, test_evil_link_start_stop) {
       << "Link should be removed after reconciler loop";
 }
 
+namespace {
+
+/// A task that refreshes metadata from the source cluster, mirroring the
+/// first step of source_topic_syncer::run_impl. request_metadata_update()
+/// takes no abort source: its waits (metadata update lock, seed reconnect
+/// backoff) answer only to the kafka::client::cluster's internal abort
+/// source.
+class metadata_refresh_task : public task {
+public:
+    static constexpr auto task_name = "metadata_refresh_task";
+    explicit metadata_refresh_task(link* link)
+      : task(link, 100ms, task_name) {}
+
+    bool should_start_impl(ss::shard_id, ::model::node_id) const override {
+        return true;
+    }
+    bool should_stop_impl(ss::shard_id, ::model::node_id) const override {
+        return false;
+    }
+    void update_config(const model::metadata&) override {}
+    model::enabled_t is_enabled() const final { return model::enabled_t::yes; }
+
+    ss::future<state_transition> run_impl(ss::abort_source&) override {
+        try {
+            co_await get_link()
+              ->get_cluster_connection()
+              .request_metadata_update();
+        } catch (const std::exception& e) {
+            co_return state_transition{
+              .desired_state = model::task_state::link_unavailable,
+              .reason = ssx::sformat(
+                "Failed to update metadata: {}", e.what())};
+        }
+        co_return state_transition{
+          .desired_state = model::task_state::active, .reason = "ok"};
+    }
+};
+
+class metadata_refresh_task_factory : public task_factory {
+public:
+    std::string_view created_task_name() const noexcept override {
+        return metadata_refresh_task::task_name;
+    }
+    std::unique_ptr<task> create_task(link* link) override {
+        return std::make_unique<metadata_refresh_task>(link);
+    }
+};
+
+} // namespace
+
+// Regression test for deadlock between `link::stop()` and `cluster::stop()`.
+TEST_F_CORO(
+  link_test_manager_started,
+  stop_completes_with_task_wedged_in_source_cluster) {
+    auto link_uuid = model::uuid_t(::uuid_t::create());
+    auto md = ss::make_lw_shared<const model::metadata>(model::metadata{
+      .name = model::name_t("wedged_link"),
+      .uuid = link_uuid,
+      .connection = model::connection_config{}});
+
+    // A source cluster connection with no seed brokers: start() succeeds
+    // vacuously (nothing to connect to).
+    auto wedged_link = std::make_unique<link>(
+      ::model::node_id(0),
+      model::id_t(1),
+      _manager.get(),
+      1s,
+      md,
+      std::make_unique<kafka::client::cluster>(
+        kafka::client::connection_configuration{
+          .client_id = "wedge-test",
+        }),
+      std::make_unique<default_config_provider>(),
+      std::make_unique<data_src_factory>(),
+      std::make_unique<data_sink_factory>());
+    co_await wedged_link->start();
+
+    // Now point it at a seed broker that refuses connections, with a large
+    // connection_timeout so the reconnect loop parks in long backoff
+    // sleeps — the production wedge for a link whose source cluster is
+    // unreachable.
+    wedged_link->get_cluster_connection().update_configuration(
+      kafka::client::connection_configuration{
+        .initial_brokers = {net::unresolved_address{"127.0.0.1", 1}},
+        .client_id = "wedge-test",
+        .connection_timeout = 10min,
+      });
+
+    metadata_refresh_task_factory tf;
+    auto res = co_await wedged_link->register_task(&tf);
+    ASSERT_TRUE_CORO(res.has_value());
+
+    // Let the task run into the wedge: connect to the dead seed, fail,
+    // and park in the reconnect backoff.
+    co_await ss::sleep(1s);
+
+    // Stopping the link must complete even with the task fiber wedged in
+    // the source cluster's reconnect backoff.
+    co_await wedged_link->stop();
+}
+
 } // namespace cluster_link::tests

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -152,6 +152,12 @@ ss::future<> client::mitigate_error(std::exception_ptr ex) {
     return external_mitigate_error(ex).handle_exception(
       [this](std::exception_ptr ex) {
           _gate.check();
+          // Early log & exit on shutdown exceptions
+          if (ssx::is_shutdown_exception(ex)) {
+              vlog(_logger.debug, "shutdown exception {}", ex);
+              return ss::make_exception_future(ex);
+          }
+
           try {
               std::rethrow_exception(ex);
           } catch (const broker_error& ex) {
@@ -204,8 +210,6 @@ ss::future<> client::mitigate_error(std::exception_ptr ex) {
                   vlog(_logger.warn, "topic_error: {}", ex);
                   return ss::make_exception_future(ex);
               }
-          } catch (const ss::gate_closed_exception&) {
-              vlog(_logger.debug, "gate_closed_exception");
           } catch (const std::system_error& ex) {
               if (net::is_reconnect_error(ex)) {
                   vlog(_logger.debug, "system_error: {}", ex);
@@ -214,8 +218,6 @@ ss::future<> client::mitigate_error(std::exception_ptr ex) {
                   vlog(_logger.warn, "system_error: {}", ex);
                   return ss::make_exception_future(ex);
               }
-          } catch (const ss::abort_requested_exception& ex) {
-              vlog(_logger.debug, "abort_requested_exception: {}", ex);
           } catch (const std::exception& ex) {
               // TODO(Ben): Probably vassert
               vlog(_logger.error, "unknown exception: {}", ex);

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -93,6 +93,11 @@ ss::future<> client::stop() noexcept {
         co_return;
     }
     _as.request_abort();
+    // Shutdown input within the `_cluster` first before trying to close any
+    // `gate`s. Otherwise, there is the potential to deadlock (`gate` waiting on
+    // hung request, hung request waiting on `_cluster`'s `abort_source`,
+    // `abort_source` waiting for `gate` to be closed).
+    _cluster->shutdown_input();
     co_await catch_and_log(_logger, [this]() { return _producer.stop(); });
     _cluster->unregister_metadata_cb(_metadata_callback_id);
     co_await _gate.close();
@@ -106,7 +111,7 @@ ss::future<> client::stop() noexcept {
             });
         }
     }
-    co_await catch_and_log(_logger, [this]() { return _cluster->stop(); });
+    co_await catch_and_log(_logger, [this]() { return _cluster->drain(); });
 }
 
 void client::on_metadata_update(const metadata_update& res) {

--- a/src/v/kafka/client/cluster.cc
+++ b/src/v/kafka/client/cluster.cc
@@ -113,14 +113,24 @@ void cluster::update_timer_callback() {
           });
     });
 }
-ss::future<> cluster::stop() {
-    vlog(_logger.info, "Stopping");
+void cluster::shutdown_input() {
+    vlog(_logger.info, "Shutting down input");
     _as.request_abort();
     _metadata_update_timer.cancel();
     _update_lock.broken();
+}
+
+ss::future<> cluster::drain() {
+    vlog(_logger.info, "Draining");
     co_await _update_config_queue.shutdown();
     co_await _gate.close();
     co_await _brokers.stop();
+}
+
+ss::future<> cluster::stop() {
+    vlog(_logger.info, "Stopping");
+    shutdown_input();
+    co_await drain();
 }
 
 ss::future<> cluster::update_metadata(

--- a/src/v/kafka/client/cluster.h
+++ b/src/v/kafka/client/cluster.h
@@ -42,6 +42,14 @@ public:
     ~cluster() noexcept = default;
 
     ss::future<> start();
+
+    /// Abort in-flight work without draining it. Synchronous.
+    void shutdown_input();
+
+    /// Drain background work and stop the brokers.
+    ss::future<> drain();
+
+    /// Equivalent to shutdown_input() followed by drain().
     ss::future<> stop();
 
     /**

--- a/src/v/kafka/client/test/BUILD
+++ b/src/v/kafka/client/test/BUILD
@@ -455,3 +455,22 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "client_stop_test",
+    timeout = "short",
+    srcs = [
+        "client_stop_test.cc",
+    ],
+    deps = [
+        ":utils",
+        "//src/v/kafka/client",
+        "//src/v/kafka/client:configuration",
+        "//src/v/kafka/protocol:metadata",
+        "//src/v/model",
+        "//src/v/test_utils:async",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/kafka/client/test/client_stop_test.cc
+++ b/src/v/kafka/client/test/client_stop_test.cc
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "kafka/client/client.h"
+#include "kafka/client/configuration.h"
+#include "kafka/client/test/utils.h"
+#include "kafka/protocol/metadata.h"
+#include "model/fundamental.h"
+#include "test_utils/async.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/sleep.hh>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+using namespace kafka::client;
+using namespace std::chrono_literals;
+
+namespace {
+
+client_configuration make_config() {
+    // A seed broker that refuses connections: nothing listens on this
+    // port. The large connection_timeout makes the broker reconnect loop
+    // park in long sleep_abortable backoffs (connection_timeout / 20 per
+    // sleep) tied to the *cluster's* abort source, not the client's.
+    client_configuration cfg{};
+    cfg.connection_cfg = connection_configuration{
+      .initial_brokers = {net::unresolved_address{"127.0.0.1", 1}},
+      .client_id = "client-stop-test",
+      .connection_timeout = 10min,
+    };
+    cfg.producer_cfg = producer_configuration{
+      .batch_record_count = 1,
+      .batch_size_bytes = 1,
+      .batch_delay = 0ms,
+      .compression_type = model::compression::none,
+      .shutdown_delay = 0ms,
+      .ack_level = acks_all,
+    };
+    // A tiny retry backoff so a failed request proceeds immediately into
+    // its mitigation (update_metadata -> seed reconnect) rather than
+    // parking in the retry sleep, which the client/producer abort sources
+    // already cover. The wedge under test is the cluster-layer reconnect
+    // backoff above.
+    cfg.retries_cfg = retries_configuration{
+      .max_retries = 3,
+      .retry_base_backoff = 1ms,
+    };
+    return cfg;
+}
+
+} // namespace
+
+// Reproduces a shutdown deadlock: a request fiber holds the client gate
+// while parked inside the cluster metadata layer (seed-broker reconnect
+// backoff, guarded by the cluster's abort source). client::stop() waits on
+// _gate.close() before anything aborts the cluster layer, and the only
+// call that does (cluster::stop()) is sequenced after the gate close — so
+// stop() can never complete.
+//
+// The request path that wedges: dispatch -> no brokers -> broker_error ->
+// mitigate_error -> update_metadata -> take _update_lock ->
+// initialize_metadata_with_seed -> connect to (dead) seed ->
+// sleep_abortable(backoff, cluster::_as).
+TEST_CORO(client_stop, stop_completes_with_wedged_metadata_request) {
+    client c{make_config(), std::nullopt};
+
+    auto req = c.dispatch([]() { return kafka::metadata_request{}; });
+
+    co_await tests::drain_task_queue();
+    ASSERT_FALSE_CORO(req.available());
+
+    // stop() must complete promptly even though a request is wedged in the
+    // cluster layer.
+    co_await c.stop();
+
+    // The wedged request must have been unwound exceptionally.
+    ASSERT_TRUE_CORO(req.available());
+    EXPECT_THROW(req.get(), std::exception);
+}
+
+// The produce-path variant: the wedged fiber holds the *producer's* gate
+// (send -> unknown leader -> mitigate_error -> update_metadata -> seed
+// reconnect backoff), and producer::stop() awaits that gate before
+// client::stop() reaches the gate close that the dispatch test exercises.
+// Catches a regression of cluster shutdown_input() being sequenced after
+// _producer.stop().
+TEST_CORO(client_stop, stop_completes_with_wedged_produce) {
+    client c{make_config(), std::nullopt};
+
+    auto req = c.produce_record_batch(
+      model::topic_partition{model::topic{"t"}, model::partition_id{0}},
+      make_batch(model::offset{0}, 1));
+
+    // A real sleep, not just a task-queue drain: the batcher hands the
+    // batch to send() off a timer, and the send must fail its first
+    // attempt and enter the seed-reconnect backoff for the fiber to be
+    // wedged in the cluster layer.
+    co_await ss::sleep(500ms);
+    ASSERT_FALSE_CORO(req.available());
+
+    co_await c.stop();
+
+    ASSERT_TRUE_CORO(req.available());
+}


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30784
