### PR TITLE
bazel: ignore .claude directory

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,3 +1,4 @@
 build
 vbuild
 vtools
+.claude


### PR DESCRIPTION
AI tooling may create git worktrees under `.claude/worktrees`. Bazel's recursive target patterns (`//...`, used e.g. by `bazel run //:cc_gen`) descend into them and fail trying to load the nested repository copy as packages of the main repository. Add `.claude` to `.bazelignore`, same as the existing `build`/`vbuild`/`vtools` entries.

## Backports Required

- [x] none - papercut/not impactful enough to backport

## Release Notes

* none