### PR TITLE
[v25.3.x] .gitignore: ignore claude worktrees dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,4 @@ bazel_cc_flags.json
 
 # claude local settings
 **/.claude/settings.local.json
+**/.claude/worktrees/


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30278

- Command: git cherry-pick -x 4c5c2ab3e2
- Commits backported: 1
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-30278-v25.3.x-1781290160

## Conflict details

- 4c5c2ab3e2 (.gitignore): the commit adds `**/.claude/worktrees/` after the `**/.claude/settings.local.json` line. On v25.3.x that line is the end of the file, while the source branch had trailing `# perf` / `perf.data*` / `# rpk binary` sections that this commit did not introduce. Resolved by applying only the commit's intent — appending `**/.claude/worktrees/` — and dropping the unrelated source-only context lines.
