### PR TITLE
[v25.2.x] .gitignore: ignore claude worktrees dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -283,3 +283,4 @@ bazel_cc_flags.json
 
 # claude local settings
 **/.claude/settings.local.json
+**/.claude/worktrees/


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30278

- Command: git cherry-pick -x 4c5c2ab3e2
- Commits backported: 1
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-30278-v25.2.x-1781290179

## Conflict details

- 4c5c2ab3e2 (.gitignore): the surrounding context diverged between branches (target v25.2.x carries a `# rpk CLAUDE.md` section and lacks the `# perf`/`# rpk binary` sections present on dev). Applied the commit's intent by adding `**/.claude/worktrees/` after `**/.claude/settings.local.json`, preserving the target branch's existing structure and not introducing the dev-only context lines.
