### PR TITLE
[CORE-16622] `kafka`: handle shutdown errors in `mitigate_error()`

### DIFF
--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -150,6 +150,12 @@ ss::future<> client::mitigate_error(std::exception_ptr ex) {
     return external_mitigate_error(ex).handle_exception(
       [this](std::exception_ptr ex) {
           _gate.check();
+          // Early log & exit on shutdown exceptions
+          if (ssx::is_shutdown_exception(ex)) {
+              vlog(_logger.debug, "shutdown exception {}", ex);
+              return ss::make_exception_future(ex);
+          }
+
           try {
               std::rethrow_exception(ex);
           } catch (const broker_error& ex) {
@@ -202,8 +208,6 @@ ss::future<> client::mitigate_error(std::exception_ptr ex) {
                   vlog(_logger.warn, "topic_error: {}", ex);
                   return ss::make_exception_future(ex);
               }
-          } catch (const ss::gate_closed_exception&) {
-              vlog(_logger.debug, "gate_closed_exception");
           } catch (const std::system_error& ex) {
               if (net::is_reconnect_error(ex)) {
                   vlog(_logger.debug, "system_error: {}", ex);
@@ -212,8 +216,6 @@ ss::future<> client::mitigate_error(std::exception_ptr ex) {
                   vlog(_logger.warn, "system_error: {}", ex);
                   return ss::make_exception_future(ex);
               }
-          } catch (const ss::abort_requested_exception& ex) {
-              vlog(_logger.debug, "abort_requested_exception: {}", ex);
           } catch (const std::exception& ex) {
               // TODO(Ben): Probably vassert
               vlog(_logger.error, "unknown exception: {}", ex);


### PR DESCRIPTION
We were writing all of these cases individually when in reality, all shutdown errors probably require nothing more than a `DEBUG` log line and an early return. Commit 6e297d20055cd4e1f2a684ff51f4590599c0c36f resulted in a new `broken_named_semaphore` exception being propagated through this path, leading to `ERROR`s in this path due to the unknown exception route being taken.

Future proof by checking `ssx::is_shutdown_exception()` and logging & early returning.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
