### PR TITLE
wcr: use conventional retry settings for offsets upload router

### DIFF
--- a/src/v/cluster/cloud_metadata/offsets_upload_router.h
+++ b/src/v/cluster/cloud_metadata/offsets_upload_router.h
@@ -74,10 +74,9 @@ public:
           leaders,
           _handler,
           node_id,
+          config::shard_local_cfg().metadata_dissemination_retries.value(),
           config::shard_local_cfg()
-            .cloud_storage_cluster_metadata_retries.value(),
-          config::shard_local_cfg()
-            .cloud_storage_cluster_metadata_upload_timeout_ms.value())
+            .metadata_dissemination_retry_delay_ms.value())
       , _handler(uploader) {}
 
     ss::future<> start() { co_return; }

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -1645,7 +1645,7 @@ class Admin:
     def get_peer_status(self, node: ClusterNode, peer_id: int) -> dict[str, Any]:
         return self._request("GET", f"debug/peer_status/{peer_id}", node=node).json()
 
-    def get_controller_status(self, node: MaybeNode) -> dict[str, Any]:
+    def get_controller_status(self, node: MaybeNode = None) -> dict[str, Any]:
         return self._request("GET", "debug/controller_status", node=node).json()
 
     def get_cluster_uuid(self, node: MaybeNode = None) -> str | None:

--- a/tests/rptest/tests/cluster_recovery_test.py
+++ b/tests/rptest/tests/cluster_recovery_test.py
@@ -6,6 +6,7 @@
 #
 # https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
 
+import json
 import random
 import string
 import time
@@ -26,7 +27,7 @@ from rptest.clients.rpk import RPKACLInput, RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
-from rptest.services.redpanda import SISettings
+from rptest.services.redpanda import RedpandaService, SISettings
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.admin.v2 import Admin, metastore_pb, ntp_pb
 from connectrpc.errors import ConnectError, ConnectErrorCode
@@ -39,6 +40,44 @@ MiB = KiB * KiB
 
 def random_string(length):
     return "".join([random.choice(string.ascii_lowercase) for i in range(0, length)])
+
+
+def latest_manifest_caught_up(redpanda: RedpandaService, target_offset: int) -> bool:
+    """Whether WCR's restore source -- the highest-metadata_id cluster metadata
+    manifest -- references a controller snapshot at or beyond target_offset.
+
+    The manifest is read directly rather than via BucketView: the uploader
+    rotates manifests about once a second, and BucketView eagerly downloads
+    every listed object, so it loses the list/get race. A False result may also
+    mean the chosen manifest was rotated out between the list and the get (a
+    transient race, logged at debug) -- callers should poll.
+    """
+    cluster_uuid = redpanda._admin.get_cluster_uuid()
+    if cluster_uuid is None:
+        return False
+    bucket = redpanda.si_settings.cloud_storage_bucket
+    client = redpanda.cloud_storage_client
+    prefix = f"cluster_metadata/{cluster_uuid}/manifests/"
+    keys = [
+        o.key
+        for o in client.list_objects(bucket, prefix=prefix)
+        if o.key.endswith("/cluster_manifest.json")
+    ]
+    if not keys:
+        return False
+    # Highest metadata_id is the manifest WCR restores from.
+    latest = max(keys, key=lambda k: int(k.split("/")[-2]))
+    try:
+        manifest = json.loads(client.get_object_data(bucket, latest))
+    except Exception:
+        redpanda.logger.debug(f"Manifest {latest} rotated out between list and get")
+        return False
+    snapshot_offset = manifest.get("controller_snapshot_offset", -1)
+    redpanda.logger.debug(
+        f"Latest manifest {latest}: "
+        f"controller_snapshot_offset={snapshot_offset} (target {target_offset})"
+    )
+    return snapshot_offset >= target_offset
 
 
 class ClusterRecoveryTest(RedpandaTest):
@@ -919,8 +958,22 @@ class ClusterRecoveryWithNameTest(RedpandaTest):
         )
 
     def _wait_for_metadata_upload(self):
-        self.redpanda.wait_for_controller_snapshot(self.redpanda.nodes[0])
-        time.sleep(5)
+        controller = wait_until_result(
+            self.redpanda.controller,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Timed out waiting for a controller leader",
+        )
+        target_offset = self.redpanda._admin.get_controller_status(controller)[
+            "committed_index"
+        ]
+        wait_until(
+            lambda: latest_manifest_caught_up(self.redpanda, target_offset),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Timed out waiting for the latest uploaded manifest to "
+            "reference a controller snapshot that includes the current state",
+        )
 
     def _stop_and_recreate_cluster(
         self, config: dict[str, Any], *, expect_fail: bool = False


### PR DESCRIPTION
`ClusterRecoveryWithNameTest.test_bootstrap_with_recovery` is flaky. The root
cause is a "product bug": the offsets upload `leader_router` was constructed with
the 60s cluster-metadata upload timeout as its retry delay instead of a short
interval. After whole cluster recovery, the cluster-metadata upload loop's
consumer-offsets step can run before the `__consumer_offsets` leader is in the
local leaders cache; the router then waited 60s before retrying, stalling
publication of the controller snapshot manifest. A subsequent restore of the
same cluster name then read a manifest that predated the recovered topics and
restored none.

- `wcr: use conventional retry settings for offsets upload router` uses the
  metadata dissemination retry tunables (matching `id_allocator_frontend`), so
  the offsets upload no longer blocks the controller snapshot manifest publish.
- `rptest/cluster_recovery: wait for uploaded snapshot in WCR test` replaces a
  fixed sleep with a poll that waits until the latest uploaded cluster metadata
  manifest references a controller snapshot at or beyond the post-recovery
  controller offset, de-flaking the test and guarding the regression.

https://redpandadata.atlassian.net/browse/CORE-16369

## Backports Required

- [x] none - papercut/not impactful enough to backport

## Release Notes

* none
