### PR TITLE
bazel: ignore `.claude/worktrees` during package discovery

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,3 +1,4 @@
 build
 vbuild
 vtools
+.claude/worktrees


### PR DESCRIPTION
Claude Code creates git worktrees under `.claude/worktrees/` (e.g.; `claude --worktree`), each a full copy of the repo with its own BUILD files and bazel-* symlinks. Without this entry, workspace-wide queries (e.g. `bazel run //:cc_gen`) descend into them and discover phantom packages whose absolute `//src/v/...` deps resolve against the main workspace but are not visible from the worktree package path, producing visibility errors.

The entry only affects builds invoked from the main workspace root; each worktree is its own Bazel workspace, so builds run from within a worktree are unaffected.

Example failure before the fix:
```
% bazel run //:cc_gen
...
ERROR: /home/gellertnagy/code/redpanda/.claude/worktrees/ethereal-drifting-treasure/src/v/iceberg/tests/BUILD:471:18: in cc_test rule //.claude/worktrees/ethereal-drifting-treasure/src/v/iceberg/tests:transform_utils_test: Visibility error:
target '//src/v/iceberg:transform_utils' is not visible from
target '//.claude/worktrees/ethereal-drifting-treasure/src/v/iceberg/tests:transform_utils_test'
Recommendation: modify the visibility declaration if you think the dependency is legitimate. For more info see https://bazel.build/concepts/visibility
ERROR: /home/gellertnagy/code/redpanda/.claude/worktrees/ethereal-drifting-treasure/src/v/iceberg/tests/BUILD:471:18: Analysis of target '//.claude/worktrees/ethereal-drifting-treasure/src/v/iceberg/tests:transform_utils_test' (config: b5f32f1) failed
ERROR: /home/gellertnagy/code/redpanda/.claude/worktrees/memoized-popping-lantern/bazel-memoized-popping-lantern/src/v/iceberg/tests/BUILD:471:18: Analysis of target '//.claude/worktrees/memoized-popping-lantern/bazel-memoized-popping-lantern/src/v/iceberg/tests:transform_utils_test' (config: b5f32f1) failed
...
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
