### PR TITLE
kafka/server: avoid type erasure in produce validation

### DIFF
--- a/src/v/kafka/server/handlers/produce_validation.cc
+++ b/src/v/kafka/server/handlers/produce_validation.cc
@@ -147,16 +147,15 @@ void maybe_set_max_timestamp(
 // Invoking this function shows that iteration over the records within the batch
 // is possible (i.e format validation). For corrupted batches, an
 // `INVALID_RECORD` error code and message are returned.
+template<typename Func>
 std::optional<error_code_and_msg> iterate_over_records(
-  const model::record_batch& b,
-  ss::noncopyable_function<ss::stop_iteration(model::record_metadata)>&& f,
-  bool is_strict_validation = false) {
+  const model::record_batch& b, Func&& f, bool is_strict_validation = false) {
     dassert(
       !b.compressed(),
       "Cannot iterate over records within a compressed batch.");
 
     try {
-        b.for_each_record_metadata(std::move(f), is_strict_validation);
+        b.for_each_record_metadata(std::forward<Func>(f), is_strict_validation);
     } catch (const std::exception& e) {
         vlog(
           klog.error,


### PR DESCRIPTION
produce_partition_bench 1_KiB_produced (release):
  allocs 106.291 -> 105.284 (-1.007)
  inst   58661.4 -> 58519.7 (-141.8)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
