### PR TITLE
DNM: no-op build to test gRPC remote cache

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -519,3 +519,5 @@ filegroup(
     strip_prefix = "JSONTestSuite-1ef36fa01286573e846ac449e8683f8833c5b26a",
     urls = ["https://github.com/nst/JSONTestSuite/archive/1ef36fa01286573e846ac449e8683f8833c5b26a.tar.gz"],
 )
+
+# No-op change to trigger a CI build for testing the gRPC remote cache path.


### PR DESCRIPTION
**Do not merge / do not review.**

No-op change (a single comment in `MODULE.bazel`) whose only purpose is to trigger a CI build so we can exercise and validate the gRPC remote-cache path (`bazel_cache_mode=grpc`, CORE-16380). The bazel-file edit is needed because the build pipeline is path-filtered and would otherwise be skipped on a docs/comment-only change.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none