### PR TITLE
[v25.3.x] build/deps: upgrade openssl to 3.5.7

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -302,7 +302,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "8/fyDLg88L1eYtk4wPIHWceqoMyn4eLGPxBkntM1n1o=",
+        "bzlTransitiveDigest": "P3vXABDRfuWOrIEjK1bcDRF1+RwwoJrEAin8TUkD8F8=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -447,9 +447,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:openssl.BUILD",
-              "sha256": "c80a01dfc70ece4dc21168932c37739042d404d46ccc81a5986dd75314ecda6f",
-              "strip_prefix": "openssl-3.0.20",
-              "url": "https://github.com/openssl/openssl/releases/download/openssl-3.0.20/openssl-3.0.20.tar.gz"
+              "sha256": "617e29af8e421f46649484a4937e48c685e47f46488167c982f88bc4ec1d522f",
+              "strip_prefix": "openssl-3.0.21",
+              "url": "https://github.com/openssl/openssl/releases/download/openssl-3.0.21/openssl-3.0.21.tar.gz"
             }
           },
           "openssl-fips": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -141,9 +141,9 @@ def data_dependency():
     http_archive(
         name = "openssl",
         build_file = "//bazel/thirdparty:openssl.BUILD",
-        sha256 = "c80a01dfc70ece4dc21168932c37739042d404d46ccc81a5986dd75314ecda6f",
-        strip_prefix = "openssl-3.0.20",
-        url = "https://github.com/openssl/openssl/releases/download/openssl-3.0.20/openssl-3.0.20.tar.gz",
+        sha256 = "617e29af8e421f46649484a4937e48c685e47f46488167c982f88bc4ec1d522f",
+        strip_prefix = "openssl-3.0.21",
+        url = "https://github.com/openssl/openssl/releases/download/openssl-3.0.21/openssl-3.0.21.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30797

v25.3.x uses the OpenSSL 3.0.x branch rather than 3.5.x, so this
applies the equivalent upgrade: 3.0.20 to 3.0.21, which was released
on the same date (2026-06-09) and contains the same CVE fixes for
the 3.0.x series.

The FIPS provider remains pinned to OpenSSL 3.0.9 (CMVP cert #4282).

Closes https://github.com/redpanda-data/redpanda/issues/30810

## Backports Required

- [ ] none - this is a backport

## Release Notes

### Bug Fixes

* Upgraded OpenSSL from 3.0.20 to 3.0.21 to resolve CVEs fixed in
  the 3.0.21 release (2026-06-09).