### PR TITLE
[v26.1.x] build/deps: upgrade openssl to 3.5.7

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -306,7 +306,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "CRQ2/f1w91O4a4z9jL6+XpMUJRhIjwEAqi6JJbQuOME=",
+        "bzlTransitiveDigest": "DSuSw0nO1r/I6ODX2tHB9IZfgX4M8YarJo/Gcd6gUT0=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -451,9 +451,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:openssl.BUILD",
-              "sha256": "deae7c80cba99c4b4f940ecadb3c3338b13cb77418409238e57d7f31f2a3b736",
-              "strip_prefix": "openssl-3.5.6",
-              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/openssl-3.5.6.tar.gz"
+              "sha256": "a8c0d28a529ca480f9f36cf5792e2cd21984552a3c8e4aa11a24aa31aeac98e8",
+              "strip_prefix": "openssl-3.5.7",
+              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/openssl-3.5.7.tar.gz"
             }
           },
           "openssl-fips": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -141,9 +141,9 @@ def data_dependency():
     http_archive(
         name = "openssl",
         build_file = "//bazel/thirdparty:openssl.BUILD",
-        sha256 = "deae7c80cba99c4b4f940ecadb3c3338b13cb77418409238e57d7f31f2a3b736",
-        strip_prefix = "openssl-3.5.6",
-        url = "https://vectorized-public.s3.amazonaws.com/dependencies/openssl-3.5.6.tar.gz",
+        sha256 = "a8c0d28a529ca480f9f36cf5792e2cd21984552a3c8e4aa11a24aa31aeac98e8",
+        strip_prefix = "openssl-3.5.7",
+        url = "https://vectorized-public.s3.amazonaws.com/dependencies/openssl-3.5.7.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30797

Supersedes #30811, which was closed because the cherry-picked MODULE.bazel.lock
was taken from the dev branch rather than regenerated for v26.1.x. This PR
includes a correctly regenerated lock file (`bazel mod tidy` on v26.1.x).

## Backports Required

- [ ] none - this is a backport

## Release Notes

* none