### PR TITLE
[CORE-16324] Auto finalize real upgrade test

### DIFF
--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -1198,6 +1198,22 @@ PERTURB_TOPIC_PARTITIONS = 5
 PERTURB_RECORDS_PER_TOPIC = 100
 PERTURB_RECORD_SIZE = 128
 
+# Features the per-step perturbations exercise / deliberately skip, accumulated
+# across upgrade steps (today only v26.1 -> v26.2). The coverage guard
+# (_assert_feature_coverage) cross-checks these against the live feature table,
+# so a newly gated feature cannot be added -- in any major -- without either an
+# exercise or an explicit acknowledgement. Add a feature's name here when you
+# cover it or knowingly skip it; entries for features no longer gated by the
+# current upgrade are harmless extras, so no per-major pruning is needed.
+PERTURB_EXERCISED_FEATURES = frozenset({"tiered_cloud_topics"})
+PERTURB_ACKNOWLEDGED_FEATURES = frozenset(
+    {
+        # Cluster-linking features, out of scope for this single-cluster test.
+        "shadow_link_sr_api_sync",
+        "batch_mirror_topic_status",
+    }
+)
+
 
 class ManualFinalizationUpgradeTest(FeaturesTestBase):
     """
@@ -1337,6 +1353,10 @@ class ManualFinalizationUpgradeTest(FeaturesTestBase):
         this grows for v26.3 and beyond."""
         self.logger.info(f"perturb: phase={phase}")
         self._perturb_common(phase)
+        if "upgraded" in phase:
+            # Generic across majors: every feature gated by the upgrade under
+            # test must be exercised or acknowledged.
+            self._assert_feature_coverage()
         self._perturb_v26_1_to_v26_2(phase)
 
     def _perturb_common(self, phase):
@@ -1483,6 +1503,34 @@ class ManualFinalizationUpgradeTest(FeaturesTestBase):
             if f["name"] == name:
                 return f["state"]
         return None
+
+    def _assert_feature_coverage(self):
+        """Cross-check the perturbation's coverage against the live feature
+        table. Major-agnostic: it never names a specific release.
+
+        While the upgrade is unfinalized the active version is held at the old
+        release, so the features gated by the upgrade under test are exactly
+        those the features endpoint reports `unavailable`: they require the
+        not-yet-active version of the binary we upgraded to, and a binary never
+        carries features for a major beyond its own, so this is precisely the
+        immediate next-major set (features further out cannot exist here).
+
+        Every such feature must be exercised or explicitly acknowledged; fail --
+        with an actionable message -- if any is in neither registry, so a newly
+        gated feature cannot slip in untested. The registries are cumulative
+        across upgrade steps, so a feature no longer gated by the current step is
+        a harmless extra and needs no pruning."""
+        gated = {
+            f["name"]
+            for f in self.admin.get_features()["features"]
+            if f["state"] == "unavailable"
+        }
+        uncovered = gated - (PERTURB_EXERCISED_FEATURES | PERTURB_ACKNOWLEDGED_FEATURES)
+        assert not uncovered, (
+            f"the upgrade under test gates feature(s) {sorted(uncovered)} with no "
+            "perturbation coverage: add an exercise in the matching _perturb_* "
+            "step, or acknowledge them in PERTURB_ACKNOWLEDGED_FEATURES"
+        )
 
     def _disable_auto_finalization(self):
         self.redpanda.set_cluster_config({"features_auto_finalization": False})
@@ -1729,9 +1777,11 @@ class ManualFinalizationUpgradeTest(FeaturesTestBase):
         back to the prior release if a problem is found -- repeatedly -- before
         the upgrade is eventually finalized.
 
-        Foundation only: the perturbation applied in each state is a no-op
-        placeholder (see _perturb); what we do to stress the system is defined
-        later.
+        In each state the cluster is perturbed (see _perturb): a fixed set of
+        topics is seeded once and re-read after every transition -- and after an
+        in-place restart -- to confirm data survives, and on the upgraded
+        (unfinalized) binary the v26.2 feature gates are exercised and checked
+        for coverage.
         """
         self._start_at_old()
         self._disable_auto_finalization()

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -1610,51 +1610,19 @@ class ManualFinalizationUpgradeTest(FeaturesTestBase):
         )
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
-    def test_manual_request_triggers_advance(self):
-        """
-        Real-upgrade analogue of
-        ManualFinalizationTest.test_manual_request_triggers_advance.
-
-        After a real upgrade with auto-finalization off, an explicit
-        FinalizeUpgrade RPC drives cluster_version forward to the version
-        reported uniformly by all members.
-        """
-        self._start_at_old()
-        self._disable_auto_finalization()
-
-        self._restart_at_new(self.redpanda.nodes)
-
-        # Confirm the cluster reached the deferred state before triggering:
-        # READY_TO_FINALIZE proves the controller saw the completed upgrade and
-        # held the version rather than advancing it.
-        ready = self._wait_for_status_state(
-            features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE
-        )
-        assert self.admin.get_features()["cluster_version"] == self.old_logical
-        assert ready.version_after_finalization == self.new_logical
-
-        self._finalize()
-
-        self._wait_for_version_everywhere(self.new_logical)
-
-        # Once the advance lands, the status flips to finalized and the active
-        # version (the downgrade floor) catches up to the binaries.
-        finalized = self._wait_for_status_state(
-            features_pb2.FINALIZATION_STATE_FINALIZED
-        )
-        assert finalized.active_version == self.new_logical
-        assert finalized.version_after_finalization == self.new_logical
-
-    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_get_upgrade_status_reports_lifecycle(self):
         """
-        Real-upgrade analogue of
-        ManualFinalizationTest.test_get_upgrade_status_reports_lifecycle.
+        Real-upgrade analogue of two merged ManualFinalizationTest scenarios:
+        test_get_upgrade_status_reports_lifecycle and
+        test_manual_request_triggers_advance. A real upgrade is expensive, and
+        walking the lifecycle already exercises the manual-triggered advance, so
+        a single upgrade covers both: the v2 status reporting and the advance
+        that an explicit FinalizeUpgrade drives.
 
         The old release has no v2 RPCs, so (unlike the synthetic test) the
         FINALIZED-at-rest state cannot be observed before the upgrade; the
         lifecycle is observed from READY_TO_FINALIZE (post-upgrade) through
-        FINALIZED.
+        FINALIZED, checked against both the v2 status and the v1 features API.
         """
         self._start_at_old()
         self._disable_auto_finalization()
@@ -1668,6 +1636,9 @@ class ManualFinalizationUpgradeTest(FeaturesTestBase):
         )
         assert status.active_version == self.old_logical
         assert status.version_after_finalization == self.new_logical
+        # The v1 features API agrees with the v2 status: the advance is deferred,
+        # so cluster_version is still held at the old (downgrade-floor) version.
+        assert self.admin.get_features()["cluster_version"] == self.old_logical
         assert len(status.members) == len(self.redpanda.nodes)
         assert all(m.version_known and m.alive for m in status.members)
         assert all(m.logical_version == self.new_logical for m in status.members)

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -1211,6 +1211,9 @@ PERTURB_ACKNOWLEDGED_FEATURES = frozenset(
         # Cluster-linking features, out of scope for this single-cluster test.
         "shadow_link_sr_api_sync",
         "batch_mirror_topic_status",
+        # Iceberg extended-mode topic-config gate; exercising it needs Iceberg
+        # topic setup orthogonal to the finalization behavior under test.
+        "iceberg_extended_mode_config",
     }
 )
 

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -18,6 +18,8 @@ from requests.exceptions import HTTPError
 
 from rptest.clients.admin.proto.redpanda.core.admin.v2 import features_pb2
 from rptest.clients.admin.v2 import Admin as AdminV2
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.rpk import RpkTool
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
@@ -1188,6 +1190,13 @@ MANUAL_FINALIZE_HOLD_DWELL_SEC = 20
 # finalizing -- the core capability the unfinalized-upgrade feature provides.
 DOWNGRADE_ROLLBACK_CYCLES = 2
 
+# Baseline perturbation: a fixed set of topics, seeded once, then re-read in
+# every state to confirm data survives the upgrade/downgrade transitions.
+PERTURB_TOPIC_COUNT = 10
+PERTURB_TOPIC_PARTITIONS = 5
+PERTURB_RECORDS_PER_TOPIC = 100
+PERTURB_RECORD_SIZE = 128
+
 
 class ManualFinalizationUpgradeTest(FeaturesTestBase):
     """
@@ -1218,6 +1227,9 @@ class ManualFinalizationUpgradeTest(FeaturesTestBase):
         self.old_logical = None
         self.new_logical = None
         self.old_release = None
+        # Topics created by _perturb_common on its first call; persisted across
+        # upgrade/downgrade transitions so data survival can be re-checked.
+        self._perturb_topics: list[str] = []
 
     def setUp(self):
         # Defer cluster start: the old release must be installed before the
@@ -1316,15 +1328,91 @@ class ManualFinalizationUpgradeTest(FeaturesTestBase):
         self._wait_for_cluster_settled()
 
     def _perturb(self, phase):
-        """Hook for stressing the cluster while it sits in a given state (e.g.
-        upgraded-but-unfinalized, or downgraded) -- produce/consume, topic and
-        config churn, leadership moves, etc. -- for a while.
+        """Perturb the cluster while it sits in `phase` (e.g.
+        "...-upgraded-unfinalized" on the new binary, or "...-downgraded" after a
+        rollback). Structured as 1 + N parts: shared baseline work, then one
+        function per supported unfinalized-upgrade step. Today N=1 -- the
+        v26.1 -> v26.2 step. See the note above the per-step functions for how
+        this grows for v26.3 and beyond."""
+        self.logger.info(f"perturb: phase={phase}")
+        self._perturb_common(phase)
+        self._perturb_v26_1_to_v26_2(phase)
 
-        Intentionally left empty for now: this commit establishes the
-        upgrade/downgrade groundwork only. The perturbation is fleshed out in a
-        later commit; until then this is a no-op so the skeleton can be exercised
-        on its own."""
-        self.logger.info(f"perturb (intentionally empty for now): phase={phase}")
+    def _perturb_common(self, phase):
+        """Baseline data-plane perturbation, run in every state. On the first
+        call it creates a fixed set of topics and seeds each with records. Every
+        call then reads all records back, restarts the whole cluster in place
+        (same binary), waits for it to return healthy, and reads the records
+        again. The topics persist across the upgrade/downgrade transitions, so
+        the read-backs confirm data produced on one binary stays intact in the
+        other and survives an in-place restart -- a feature-agnostic integrity
+        signal that holds regardless of which features are active."""
+        rpk = RpkTool(self.redpanda)
+        if not self._perturb_topics:
+            kafka = KafkaCliTools(self.redpanda)
+            for i in range(PERTURB_TOPIC_COUNT):
+                name = f"perturb-{i}"
+                rpk.create_topic(name, partitions=PERTURB_TOPIC_PARTITIONS)
+                kafka.produce(
+                    name, PERTURB_RECORDS_PER_TOPIC, PERTURB_RECORD_SIZE, acks=-1
+                )
+                self._perturb_topics.append(name)
+
+        self._perturb_verify_data(f"{phase} pre-restart")
+
+        # Restart the whole cluster in place (same binary) and confirm it comes
+        # back healthy with the data still readable.
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        self._wait_for_cluster_settled()
+        self._perturb_verify_data(f"{phase} post-restart")
+
+    def _perturb_verify_data(self, label):
+        """Read every record back from each perturbation topic and assert the
+        full count is still present."""
+        rpk = RpkTool(self.redpanda)
+        for name in self._perturb_topics:
+            consumed = rpk.consume(
+                name,
+                n=PERTURB_RECORDS_PER_TOPIC,
+                offset="start",
+                quiet=True,
+                timeout=30,
+            )
+            got = sum(1 for line in consumed.splitlines() if line)
+            assert got == PERTURB_RECORDS_PER_TOPIC, (
+                f"{name}: expected {PERTURB_RECORDS_PER_TOPIC} records intact "
+                f"({label}), read {got}"
+            )
+
+    # NOTE: growing this beyond the v26.1 -> v26.2 step.
+    #
+    # When v26.2 is released and v26.3 development begins, two things change:
+    #   1. Add a new per-step function, e.g. _perturb_v26_2_to_v26_3, exercising
+    #      the features gated by the unfinalized v26.2 -> v26.3 upgrade, and call
+    #      it from _perturb alongside the existing one.
+    #   2. Extend the harness to perform CHAINED unfinalized upgrades: an
+    #      unfinalized upgrade v26.1 -> v26.2, then a further unfinalized upgrade
+    #      v26.2 -> v26.3, perturbing (and exercising downgrade) at each step
+    #      instead of a single old -> HEAD hop.
+    # Keep older step functions and their harness coverage for as long as the
+    # support window allows upgrading from those releases; drop a step once its
+    # source release leaves the supported upgrade matrix.
+    def _perturb_v26_1_to_v26_2(self, phase):
+        """Per-step perturbation for the v26.1 -> v26.2 unfinalized upgrade (the
+        N=1 part of the 1 + N structure).
+
+        INTENTIONALLY EMPTY for now. As v26.2 development proceeds, fill this in
+        with operations that exercise the features GATED BY the unfinalized v26.2
+        upgrade -- behaviour that becomes available once the binaries are on
+        v26.2 but before finalization. The aim is to confirm those features
+        behave correctly (or are correctly unavailable) while unfinalized, and
+        that exercising them does not break a subsequent downgrade to v26.1.
+
+        `phase` tells you the current state: branch on it so v26.2-only
+        behaviour is driven only in the upgraded states ("...-upgraded-..."),
+        while the downgraded states ("...-downgraded") confirm v26.1 semantics
+        have returned."""
+        pass
 
     def _disable_auto_finalization(self):
         self.redpanda.set_cluster_config({"features_auto_finalization": False})

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -1166,6 +1166,264 @@ class ManualFinalizationTest(FeaturesTestBase):
         ]
 
 
+# The `features_auto_finalization` knob was backported to v26.1.9, so the real
+# upgrade below must start from a released patch that already has it. The knob
+# lets a cluster opt out of auto-finalization *before* upgrading to a HEAD build
+# that ships the gating logic and the admin v2 RPCs.
+MANUAL_FINALIZE_MIN_OLD_RELEASE = (26, 1, 9)
+
+# How long to dwell after the cluster reports READY_TO_FINALIZE before
+# re-checking that the active version is still held. Guards against a late,
+# incorrect advance on a subsequent gating-loop tick.
+MANUAL_FINALIZE_HOLD_DWELL_SEC = 20
+
+
+class ManualFinalizationUpgradeTest(FeaturesTestBase):
+    """
+    Real-upgrade counterpart to ManualFinalizationTest.
+
+    ManualFinalizationTest fakes the version bump with
+    `__REDPANDA_LATEST_LOGICAL_VERSION`; this test performs an actual binary
+    upgrade from the latest released patch of the prior feature line (which must
+    include the backported `features_auto_finalization` knob, i.e.
+    >= v26.1.9) up to the HEAD build that ships the manual-finalization gating
+    logic and the admin v2 RPCs.
+
+    It mirrors three ManualFinalizationTest scenarios end to end:
+      - auto-finalization disabled blocks the post-upgrade advance,
+      - an explicit FinalizeUpgrade drives the advance, and
+      - GetUpgradeStatus reports the finalization lifecycle.
+
+    The old release has neither the gating logic nor the v2 RPCs, so the opt-out
+    is set on the old binary (which also exercises the backported knob) and the
+    status/finalize RPCs are only invoked once every node is on HEAD.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, num_brokers=3, **kwargs)
+        self.admin_v2 = AdminV2(self.redpanda)
+        # Logical versions are discovered from the running binaries at runtime
+        # rather than hard-coded as in the synthetic test.
+        self.old_logical = None
+        self.new_logical = None
+
+    def setUp(self):
+        # Defer cluster start: the old release must be installed before the
+        # first boot. FeaturesTestBase.setUp assumes a HEAD cluster (it asserts
+        # active == latest == original), so we deliberately skip it.
+        pass
+
+    def _start_at_old(self):
+        """Install and boot the whole cluster on the old released version."""
+        old_release = self.installer.highest_from_prior_feature_version(
+            RedpandaInstaller.HEAD
+        )
+        assert old_release >= MANUAL_FINALIZE_MIN_OLD_RELEASE, (
+            f"prior feature version {old_release} predates the "
+            f"features_auto_finalization backport "
+            f"{MANUAL_FINALIZE_MIN_OLD_RELEASE}; cannot opt out before upgrade"
+        )
+        self.logger.info(f"Starting cluster on old release {old_release}")
+        self.installer.install(self.redpanda.nodes, old_release)
+        self.redpanda.start()
+
+        self.old_logical = self.admin.get_features()["cluster_version"]
+        self.logger.info(
+            f"Old release {old_release} reports logical version {self.old_logical}"
+        )
+
+    def _restart_at_new(self, nodes):
+        """Upgrade `nodes` to the HEAD build and restart them in place."""
+        self.installer.install(nodes, RedpandaInstaller.HEAD)
+        self.redpanda.restart_nodes(nodes)
+        self._wait_for_cluster_settled()
+
+        self.new_logical = self._node_latest_logical_version(nodes[0])
+        self.logger.info(f"HEAD build reports logical version {self.new_logical}")
+        assert self.new_logical > self.old_logical, (
+            f"expected HEAD logical version {self.new_logical} to exceed the old "
+            f"version {self.old_logical}; the upgrade did not raise the version"
+        )
+
+    def _node_latest_logical_version(self, node):
+        """Read a (possibly just-restarted) node's latest logical version,
+        tolerating the brief window before it is serving the admin API."""
+
+        def query():
+            return self.admin.get_features(node=node).get("node_latest_version")
+
+        return wait_until_result(
+            query,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="node did not report node_latest_version after upgrade",
+        )
+
+    def _wait_for_cluster_settled(self, timeout_sec=90):
+        """Wait for the cluster to settle after a restart: every broker has
+        rejoined and no under-replicated partitions remain. `start_node` only
+        waits for per-node readiness (the v1 ready probe), not cluster
+        convergence -- so without this a "did not advance" assertion could pass
+        merely because the controller has not yet observed the upgrade."""
+        self.redpanda.wait_for_membership(first_start=False)
+        wait_until(
+            self.redpanda.healthy,
+            timeout_sec=timeout_sec,
+            backoff_sec=2,
+            err_msg="cluster did not become healthy after restart",
+        )
+
+    def _disable_auto_finalization(self):
+        self.redpanda.set_cluster_config({"features_auto_finalization": False})
+
+    def _call_with_leader_retry(self, call, timeout_sec=30):
+        """Retry a controller-leader-routed admin v2 call through the transient
+        UNAVAILABLE window after restarts/leadership changes. See the identical
+        helper in ManualFinalizationTest for the rationale."""
+        deadline = time.time() + timeout_sec
+        while True:
+            try:
+                return call()
+            except ConnectError as e:
+                if e.code != ConnectErrorCode.UNAVAILABLE or time.time() >= deadline:
+                    raise
+                time.sleep(1)
+
+    def _finalize(self):
+        return self._call_with_leader_retry(
+            lambda: self.admin_v2.features().finalize_upgrade(
+                features_pb2.FinalizeUpgradeRequest()
+            )
+        )
+
+    def _get_upgrade_status(self):
+        return self._call_with_leader_retry(
+            lambda: self.admin_v2.features().get_upgrade_status(
+                features_pb2.GetUpgradeStatusRequest()
+            )
+        )
+
+    def _wait_for_status_state(self, state, timeout_sec=30):
+        """Wait until GetUpgradeStatus reports `state`; return that status."""
+        wait_until(
+            lambda: self._get_upgrade_status().state == state,
+            timeout_sec=timeout_sec,
+            backoff_sec=1,
+        )
+        return self._get_upgrade_status()
+
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_auto_finalization_disabled_blocks_advance(self):
+        """
+        Real-upgrade analogue of
+        ManualFinalizationTest.test_auto_finalization_disabled_blocks_advance.
+
+        With `features_auto_finalization=false` set on the old release before
+        the upgrade, a completed rolling upgrade to HEAD must not auto-advance
+        cluster_version. The opt-out, written on the old binary, has to survive
+        the version boundary and be honored by the HEAD gating logic.
+        """
+        self._start_at_old()
+        self._disable_auto_finalization()
+
+        self._restart_at_new(self.redpanda.nodes)
+
+        # Reaching READY_TO_FINALIZE is positive proof that the controller
+        # observed every node at the new version and chose to defer the advance,
+        # rather than a fixed sleep that could pass before the gating loop has
+        # even run. The active version is held at the old (downgrade floor)
+        # version, with the uniform higher version available to finalize.
+        status = self._wait_for_status_state(
+            features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE
+        )
+        assert self.admin.get_features()["cluster_version"] == self.old_logical
+        assert status.active_version == self.old_logical
+        assert status.version_after_finalization == self.new_logical
+        assert not status.auto_finalization_enabled
+
+        # Dwell and re-check: the version must stay held across subsequent
+        # gating-loop ticks, not advance late.
+        time.sleep(MANUAL_FINALIZE_HOLD_DWELL_SEC)
+        assert self.admin.get_features()["cluster_version"] == self.old_logical
+        assert (
+            self._get_upgrade_status().state
+            == features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE
+        )
+
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_manual_request_triggers_advance(self):
+        """
+        Real-upgrade analogue of
+        ManualFinalizationTest.test_manual_request_triggers_advance.
+
+        After a real upgrade with auto-finalization off, an explicit
+        FinalizeUpgrade RPC drives cluster_version forward to the version
+        reported uniformly by all members.
+        """
+        self._start_at_old()
+        self._disable_auto_finalization()
+
+        self._restart_at_new(self.redpanda.nodes)
+
+        # Confirm the cluster reached the deferred state before triggering:
+        # READY_TO_FINALIZE proves the controller saw the completed upgrade and
+        # held the version rather than advancing it.
+        ready = self._wait_for_status_state(
+            features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE
+        )
+        assert self.admin.get_features()["cluster_version"] == self.old_logical
+        assert ready.version_after_finalization == self.new_logical
+
+        self._finalize()
+
+        self._wait_for_version_everywhere(self.new_logical)
+
+        # Once the advance lands, the status flips to finalized and the active
+        # version (the downgrade floor) catches up to the binaries.
+        finalized = self._wait_for_status_state(
+            features_pb2.FINALIZATION_STATE_FINALIZED
+        )
+        assert finalized.active_version == self.new_logical
+        assert finalized.version_after_finalization == self.new_logical
+
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_get_upgrade_status_reports_lifecycle(self):
+        """
+        Real-upgrade analogue of
+        ManualFinalizationTest.test_get_upgrade_status_reports_lifecycle.
+
+        The old release has no v2 RPCs, so (unlike the synthetic test) the
+        FINALIZED-at-rest state cannot be observed before the upgrade; the
+        lifecycle is observed from READY_TO_FINALIZE (post-upgrade) through
+        FINALIZED.
+        """
+        self._start_at_old()
+        self._disable_auto_finalization()
+
+        # Roll every node to HEAD. Auto-finalization is off, so the active
+        # version holds and the cluster becomes READY_TO_FINALIZE.
+        self._restart_at_new(self.redpanda.nodes)
+
+        status = self._wait_for_status_state(
+            features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE
+        )
+        assert status.active_version == self.old_logical
+        assert status.version_after_finalization == self.new_logical
+        assert len(status.members) == len(self.redpanda.nodes)
+        assert all(m.version_known and m.alive for m in status.members)
+        assert all(m.logical_version == self.new_logical for m in status.members)
+        # release_version is plumbed through from the per-node health report.
+        assert all(m.release_version for m in status.members)
+
+        # Finalize: the active version catches up; no downgrade after this.
+        self._finalize()
+        self._wait_for_version_everywhere(self.new_logical)
+
+        status = self._wait_for_status_state(features_pb2.FINALIZATION_STATE_FINALIZED)
+        assert status.active_version == self.new_logical
+        assert status.version_after_finalization == self.new_logical
+
+
 class ManualFinalizationLicenseTest(RedpandaTest):
     """
     Verifies that disabling `features_auto_finalization` is rejected by the

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -1172,6 +1172,11 @@ class ManualFinalizationTest(FeaturesTestBase):
 # that ships the gating logic and the admin v2 RPCs.
 MANUAL_FINALIZE_MIN_OLD_RELEASE = (26, 1, 9)
 
+# The same knob was also backported to v25.3.15, the oldest release from which a
+# multi-hop upgrade (v25.3 -> v26.1 -> HEAD) can carry the opt-out through every
+# hop with the flag set only once.
+MANUAL_FINALIZE_MIN_OLDEST_RELEASE = (25, 3, 15)
+
 # How long to dwell after the cluster reports READY_TO_FINALIZE before
 # re-checking that the active version is still held. Guards against a late,
 # incorrect advance on a subsequent gating-loop tick.
@@ -1258,6 +1263,25 @@ class ManualFinalizationUpgradeTest(FeaturesTestBase):
             backoff_sec=1,
             err_msg="node did not report node_latest_version after upgrade",
         )
+
+    def _upgrade_all_to(self, version):
+        """Install `version` on every node, restart in place, and return the
+        binary's latest logical version."""
+        self.installer.install(self.redpanda.nodes, version)
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        self._wait_for_cluster_settled()
+        return self._node_latest_logical_version(self.redpanda.nodes[0])
+
+    def _wait_for_cluster_version(self, target, timeout_sec=60):
+        """Wait until every node reports cluster_version == target."""
+
+        def check():
+            return all(
+                self.admin.get_features(node=n)["cluster_version"] == target
+                for n in self.redpanda.nodes
+            )
+
+        wait_until(check, timeout_sec=timeout_sec, backoff_sec=1)
 
     def _wait_for_cluster_settled(self, timeout_sec=90):
         """Wait for the cluster to settle after a restart: every broker has
@@ -1422,6 +1446,92 @@ class ManualFinalizationUpgradeTest(FeaturesTestBase):
         status = self._wait_for_status_state(features_pb2.FINALIZATION_STATE_FINALIZED)
         assert status.active_version == self.new_logical
         assert status.version_after_finalization == self.new_logical
+
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_config_passes_through_multi_hop_upgrade(self):
+        """
+        Lock in that `features_auto_finalization`, set once on the oldest
+        release, survives a multi-hop upgrade (v25.3.x -> v26.1.x -> HEAD) and
+        is still honored by the final binary's gating logic.
+
+        The knob was backported to both v25.3.15 and v26.1.9, so every
+        intermediate binary recognizes the property and carries it through the
+        controller log unchanged. Only HEAD consumes the knob, so the
+        deferred-advance behavior appears only after the final hop -- the
+        intermediate v26.1 hop advances the active version normally.
+        """
+        oldest, _ = self.installer.latest_for_line((25, 3))
+        assert oldest >= MANUAL_FINALIZE_MIN_OLDEST_RELEASE, (
+            f"latest v25.3 patch {oldest} predates the features_auto_finalization "
+            f"backport {MANUAL_FINALIZE_MIN_OLDEST_RELEASE}"
+        )
+        mid, _ = self.installer.latest_for_line((26, 1))
+        assert mid >= MANUAL_FINALIZE_MIN_OLD_RELEASE, (
+            f"latest v26.1 patch {mid} predates the backport "
+            f"{MANUAL_FINALIZE_MIN_OLD_RELEASE}"
+        )
+
+        # Hop 0: boot the oldest release and opt out of auto-finalization once.
+        # Setting the flag here is a convenience (set-it-once-early), NOT a
+        # guarantee of multi-hop downgradability: a multi-hop upgrade does not
+        # preserve the ability to downgrade across every hop. Only the gated hop
+        # (to HEAD) keeps its downgrade open -- see the assertions below.
+        self.logger.info(f"Booting oldest release {oldest}")
+        self.installer.install(self.redpanda.nodes, oldest)
+        self.redpanda.start()
+        self._disable_auto_finalization()
+
+        # Hop 1: upgrade to the latest v26.1 patch. v26.1 has the knob but not
+        # the gating logic, so it auto-advances the active version to its own
+        # latest; the flag rides along in the controller log untouched.
+        self.logger.info(f"Upgrading to intermediate release {mid}")
+        mid_logical = self._upgrade_all_to(mid)
+        self._wait_for_cluster_version(mid_logical)
+        held_version = mid_logical
+
+        # The v26.1 hop was NOT gated, so the active version -- which doubles as
+        # the downgrade floor -- has advanced to the v26.1 logical version.
+        # Downgrade back to v25.3 is no longer possible from here: the flag set
+        # on v25.3 did not (and cannot) protect this ungated hop.
+        assert self.admin.get_features()["cluster_version"] == held_version
+
+        # Hop 2: upgrade to HEAD, which DOES consume the knob. Because the flag
+        # survived both hops, the final advance must be deferred.
+        self.logger.info("Upgrading to HEAD")
+        head_logical = self._upgrade_all_to(RedpandaInstaller.HEAD)
+        assert head_logical > held_version, (
+            f"HEAD logical {head_logical} should exceed the held version {held_version}"
+        )
+
+        # READY_TO_FINALIZE proves HEAD observed the completed upgrade and
+        # deferred the advance (stronger than a fixed sleep that could pass
+        # before the gating loop runs).
+        status = self._wait_for_status_state(
+            features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE
+        )
+        # The active version (downgrade floor) is held at the v26.1 version, so
+        # downgrade from v26.2 back to v26.1 IS preserved: this gated hop is the
+        # only one whose downgrade the flag keeps open.
+        assert self.admin.get_features()["cluster_version"] == held_version
+        assert status.active_version == held_version
+        assert status.version_after_finalization == head_logical
+        # The decisive passthrough check: HEAD sees auto-finalization as
+        # disabled even though the flag was set only once, on the oldest release.
+        assert not status.auto_finalization_enabled
+
+        # Dwell and re-check: the version must stay held across subsequent
+        # gating-loop ticks, not advance late.
+        time.sleep(MANUAL_FINALIZE_HOLD_DWELL_SEC)
+        assert self.admin.get_features()["cluster_version"] == held_version
+
+        # The explicit finalize still drives the advance to the head version.
+        self._finalize()
+        self._wait_for_version_everywhere(head_logical)
+        finalized = self._wait_for_status_state(
+            features_pb2.FINALIZATION_STATE_FINALIZED
+        )
+        assert finalized.active_version == head_logical
+        assert finalized.version_after_finalization == head_logical
 
 
 class ManualFinalizationLicenseTest(RedpandaTest):

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -19,7 +19,8 @@ from requests.exceptions import HTTPError
 from rptest.clients.admin.proto.redpanda.core.admin.v2 import features_pb2
 from rptest.clients.admin.v2 import Admin as AdminV2
 from rptest.clients.kafka_cli_tools import KafkaCliTools
-from rptest.clients.rpk import RpkTool
+from rptest.clients.rpk import RpkException, RpkTool
+from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
@@ -1401,18 +1402,87 @@ class ManualFinalizationUpgradeTest(FeaturesTestBase):
         """Per-step perturbation for the v26.1 -> v26.2 unfinalized upgrade (the
         N=1 part of the 1 + N structure).
 
-        INTENTIONALLY EMPTY for now. As v26.2 development proceeds, fill this in
-        with operations that exercise the features GATED BY the unfinalized v26.2
-        upgrade -- behaviour that becomes available once the binaries are on
-        v26.2 but before finalization. The aim is to confirm those features
-        behave correctly (or are correctly unavailable) while unfinalized, and
-        that exercising them does not break a subsequent downgrade to v26.1.
+        Exercises the code paths gated by the v26.2 feature flags. While the
+        upgrade is unfinalized the active version is held at v26.1, so these
+        features are still unavailable and their gates are in force -- which is
+        what keeps a downgrade safe. Each feature's check is feature-specific
+        (see the helpers); the shared harness separately confirms the system
+        stays functional after the up/downgrade, and _verify_v26_2_features_working
+        confirms the features actually work once finalized.
 
-        `phase` tells you the current state: branch on it so v26.2-only
-        behaviour is driven only in the upgraded states ("...-upgraded-..."),
-        while the downgraded states ("...-downgraded") confirm v26.1 semantics
-        have returned."""
-        pass
+        Only runs on the v26.2 binary: on the rolled-back v26.1 binary these code
+        paths and config values do not exist, so there is nothing to exercise."""
+        if "upgraded" not in phase:
+            return
+        self._exercise_tiered_cloud_topics()
+        # The other two v26.2-gated features are not exercised by this
+        # single-cluster perturbation: shadow_link_sr_api_sync and
+        # batch_mirror_topic_status are both cluster-linking features
+        # (batch_mirror_topic_status additionally needs a second cluster).
+
+    def _exercise_tiered_cloud_topics(self):
+        """tiered_cloud_topics gate: creating a topic with storage mode
+        `tiered_cloud` is refused until the feature is active. Drive that
+        validator path while unfinalized and confirm the feature is unavailable
+        and the create is rejected. The topic is never created, so exercising
+        the gate cannot leave state that would block a downgrade."""
+        assert self._feature_state("tiered_cloud_topics") == "unavailable", (
+            "tiered_cloud_topics should be unavailable while the upgrade is unfinalized"
+        )
+        try:
+            RpkTool(self.redpanda).create_topic(
+                "perturb-tiered-cloud",
+                partitions=1,
+                config={
+                    TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_TIERED_CLOUD
+                },
+            )
+        except RpkException as e:
+            # Confirm the create failed via the storage-mode gate, not an
+            # unrelated rpk/controller error (timeout, UNAVAILABLE, controller
+            # not ready) that would otherwise read as a false "gate worked". The
+            # HEAD validator rejects with INVALID_CONFIG and this distinctive
+            # message; the create only ever runs on the HEAD binary, so the
+            # string is stable.
+            assert "Invalid storage mode" in str(e), (
+                f"tiered_cloud create failed, but not via the storage-mode gate: {e}"
+            )
+        else:
+            raise AssertionError(
+                "creating a tiered_cloud topic should be gated while unfinalized"
+            )
+
+    def _verify_tiered_cloud_topics_working(self):
+        """After finalize the active version has advanced past the feature's
+        require_version, so the gate opens: the feature moves from unavailable to
+        available (it is explicit_only, so it does not auto-activate) and can
+        then be enabled to active -- the simple signal that it now works.
+        (Creating an actual tiered_cloud topic additionally needs cloud storage,
+        which this test does not configure.)"""
+        wait_until(
+            lambda: self._feature_state("tiered_cloud_topics") == "available",
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="tiered_cloud_topics did not become available after finalize",
+        )
+        self.admin.put_feature("tiered_cloud_topics", {"state": "active"})
+        wait_until(
+            lambda: self._feature_state("tiered_cloud_topics") == "active",
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="tiered_cloud_topics did not activate after being enabled",
+        )
+
+    def _verify_v26_2_features_working(self):
+        """After the upgrade is finalized, confirm each v26.2 feature's gate has
+        opened and the feature actually works (simple per-feature predicates)."""
+        self._verify_tiered_cloud_topics_working()
+
+    def _feature_state(self, name):
+        for f in self.admin.get_features()["features"]:
+            if f["name"] == name:
+                return f["state"]
+        return None
 
     def _disable_auto_finalization(self):
         self.redpanda.set_cluster_config({"features_auto_finalization": False})
@@ -1707,6 +1777,10 @@ class ManualFinalizationUpgradeTest(FeaturesTestBase):
         )
         assert finalized.active_version == self.new_logical
         assert finalized.version_after_finalization == self.new_logical
+
+        # With the upgrade finalized, the v26.2 feature gates have opened:
+        # confirm the features actually work.
+        self._verify_v26_2_features_working()
 
     @cluster(
         num_nodes=3,

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -1182,6 +1182,12 @@ MANUAL_FINALIZE_MIN_OLDEST_RELEASE = (25, 3, 15)
 # incorrect advance on a subsequent gating-loop tick.
 MANUAL_FINALIZE_HOLD_DWELL_SEC = 20
 
+# Number of upgrade -> perturb -> downgrade rollback cycles to run before the
+# final upgrade is finalized. Each cycle simulates discovering a problem after
+# upgrading the binaries and rolling back to the prior release without
+# finalizing -- the core capability the unfinalized-upgrade feature provides.
+DOWNGRADE_ROLLBACK_CYCLES = 2
+
 
 class ManualFinalizationUpgradeTest(FeaturesTestBase):
     """
@@ -1211,6 +1217,7 @@ class ManualFinalizationUpgradeTest(FeaturesTestBase):
         # rather than hard-coded as in the synthetic test.
         self.old_logical = None
         self.new_logical = None
+        self.old_release = None
 
     def setUp(self):
         # Defer cluster start: the old release must be installed before the
@@ -1228,6 +1235,7 @@ class ManualFinalizationUpgradeTest(FeaturesTestBase):
             f"features_auto_finalization backport "
             f"{MANUAL_FINALIZE_MIN_OLD_RELEASE}; cannot opt out before upgrade"
         )
+        self.old_release = old_release
         self.logger.info(f"Starting cluster on old release {old_release}")
         self.installer.install(self.redpanda.nodes, old_release)
         self.redpanda.start()
@@ -1296,6 +1304,27 @@ class ManualFinalizationUpgradeTest(FeaturesTestBase):
             backoff_sec=2,
             err_msg="cluster did not become healthy after restart",
         )
+
+    def _downgrade_all_to(self, release):
+        """Roll every node back to `release` (an older binary) without
+        finalizing, then wait for the cluster to come back healthy. This is the
+        rollback the unfinalized-upgrade feature is meant to preserve: because
+        the active version was never advanced, the older binary can still run on
+        the existing on-disk data."""
+        self.installer.install(self.redpanda.nodes, release)
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        self._wait_for_cluster_settled()
+
+    def _perturb(self, phase):
+        """Hook for stressing the cluster while it sits in a given state (e.g.
+        upgraded-but-unfinalized, or downgraded) -- produce/consume, topic and
+        config churn, leadership moves, etc. -- for a while.
+
+        Intentionally left empty for now: this commit establishes the
+        upgrade/downgrade groundwork only. The perturbation is fleshed out in a
+        later commit; until then this is a no-op so the skeleton can be exercised
+        on its own."""
+        self.logger.info(f"perturb (intentionally empty for now): phase={phase}")
 
     def _disable_auto_finalization(self):
         self.redpanda.set_cluster_config({"features_auto_finalization": False})
@@ -1532,6 +1561,113 @@ class ManualFinalizationUpgradeTest(FeaturesTestBase):
         )
         assert finalized.active_version == head_logical
         assert finalized.version_after_finalization == head_logical
+
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_downgrade_before_finalize(self):
+        """
+        Exercise the core promise of the unfinalized-upgrade feature: after
+        upgrading the binaries with auto-finalization disabled, the cluster runs
+        unfinalized (giving up post-finalization features) and can be downgraded
+        back to the prior release if a problem is found -- repeatedly -- before
+        the upgrade is eventually finalized.
+
+        Foundation only: the perturbation applied in each state is a no-op
+        placeholder (see _perturb); what we do to stress the system is defined
+        later.
+        """
+        self._start_at_old()
+        self._disable_auto_finalization()
+        old_release = self.old_release
+        old_logical = self.old_logical
+
+        for cycle in range(DOWNGRADE_ROLLBACK_CYCLES):
+            self.logger.info(f"rollback cycle {cycle}: upgrade -> perturb -> downgrade")
+
+            # Upgrade every binary to HEAD. With auto-finalization off the active
+            # version is held at the old version (READY_TO_FINALIZE), which is
+            # what keeps the downgrade available.
+            self._restart_at_new(self.redpanda.nodes)
+            status = self._wait_for_status_state(
+                features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE
+            )
+            assert self.admin.get_features()["cluster_version"] == old_logical
+            assert not status.auto_finalization_enabled
+
+            self._perturb(f"cycle{cycle}-upgraded-unfinalized")
+
+            # Roll back to the old release WITHOUT finalizing, simulating that an
+            # issue was found. The cluster must return healthy on the old binary
+            # with the active version unchanged.
+            self._downgrade_all_to(old_release)
+            assert self.admin.get_features()["cluster_version"] == old_logical
+            assert all(
+                self.admin.get_features(node=n)["node_latest_version"] == old_logical
+                for n in self.redpanda.nodes
+            ), "not all nodes report the old binary's logical version after downgrade"
+
+            self._perturb(f"cycle{cycle}-downgraded")
+
+        # Final attempt: upgrade once more, and this time complete it by
+        # finalizing. The active version advances to the head version.
+        self.logger.info("final attempt: upgrade -> finalize")
+        self._restart_at_new(self.redpanda.nodes)
+        self._wait_for_status_state(features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE)
+        self._finalize()
+        self._wait_for_version_everywhere(self.new_logical)
+        finalized = self._wait_for_status_state(
+            features_pb2.FINALIZATION_STATE_FINALIZED
+        )
+        assert finalized.active_version == self.new_logical
+        assert finalized.version_after_finalization == self.new_logical
+
+    @cluster(
+        num_nodes=3,
+        log_allow_list=RESTART_LOG_ALLOW_LIST
+        + [
+            # The old binary aborts via vassert when it detects the cluster
+            # advanced past the version it supports. Allow the rejection message
+            # plus the generic crash artifacts the intentional abort emits.
+            "Incompatible downgrade detected",
+            "assert - Backtrace:",
+            "Recorded crash reason to crash file",
+        ],
+    )
+    def test_downgrade_rejected_after_finalize(self):
+        """
+        The flip side of test_downgrade_before_finalize: once the upgrade is
+        finalized the active version has advanced to the new version, so the old
+        binary can no longer run on the (now finalized) data. Rolling a node back
+        must fail at startup with the "Incompatible downgrade detected" guard --
+        this is what makes finalization the point of no return.
+        """
+        self._start_at_old()
+        self._disable_auto_finalization()
+        old_release = self.old_release
+
+        # Upgrade and this time finalize, advancing the active version past what
+        # the old binary supports.
+        self._restart_at_new(self.redpanda.nodes)
+        self._wait_for_status_state(features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE)
+        self._finalize()
+        self._wait_for_version_everywhere(self.new_logical)
+        self._wait_for_status_state(features_pb2.FINALIZATION_STATE_FINALIZED)
+
+        # Attempt to roll a single node back to the old release. The old binary
+        # reads the persisted feature table, sees the cluster advanced past the
+        # version it supports, and aborts startup rather than corrupt state.
+        victim = self.redpanda.nodes[-1]
+        self.redpanda.stop_node(victim)
+        self.installer.install([victim], old_release)
+        self.redpanda.start_node(victim, expect_fail=True)
+        assert self.redpanda.search_log_node(
+            victim, "Incompatible downgrade detected"
+        ), "old binary should refuse to start after finalization"
+
+        # The data is intact and only the too-old binary was rejected: restoring
+        # HEAD lets the node rejoin healthy, leaving a clean cluster for teardown.
+        self.redpanda.stop_node(victim, forced=True)
+        self.installer.install([victim], RedpandaInstaller.HEAD)
+        self.redpanda.start_node(victim)
 
 
 class ManualFinalizationLicenseTest(RedpandaTest):


### PR DESCRIPTION
This PR introduces two kinds of tests. First, it reproduces some of the synthetic tests for unfinalized upgrades which used a special environment variable to "fake" the upgrades, and the reproductions use real 25.3 and 26.1 minor releases that contain the correct configuration. So, "real" unfinalized upgrade test.

The second kind of test is more of a framework. The framework is for building a test which upgrades a cluster without finalizing, perturbs the system (X), downgrades, then repeats the process, but this time finalizes the upgrade and verifies the system looks like it is in a good state.

X: what goes into the perturbation step? Ideally it is some set of tests that exercise the features that are intended to be feature gated for a release. This PR adds the framework, and a very simple test for one 26.1 feature. More to come later

Fixes: CORE-16324
Fixes: CORE-16325

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
