### PR TITLE
`security`: some `acl` optimizations

### DIFF
--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -33,6 +33,7 @@
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future-util.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 
 #include <algorithm>
 #include <iterator>
@@ -281,38 +282,54 @@ static metadata_response::topic make_topic_response(
     return res;
 }
 
+static ss::future<chunked_vector<metadata_response::topic>>
+get_all_topic_metadata(
+  request_context& ctx,
+  metadata_request& request,
+  const is_node_isolated_or_decommissioned is_node_isolated) {
+    // snapshot the topic names: the topic table is not iterator stable and
+    // we yield below while authorizing/building responses
+    chunked_vector<model::topic_namespace> topic_names;
+    for (const auto& [tp_ns, md] : ctx.metadata_cache().all_topics_metadata()) {
+        // only serve topics from the kafka namespace
+        if (tp_ns.ns == model::kafka_namespace) {
+            topic_names.push_back(tp_ns);
+        }
+    }
+
+    chunked_vector<metadata_response::topic> res;
+    for (auto& tp_ns : topic_names) {
+        /*
+         * quiet authz failures. this isn't checking for a specifically
+         * requested topic, but rather checking visibility of all topics.
+         */
+        if (!ctx.authorized(
+              security::acl_operation::describe, tp_ns.tp, authz_quiet{true})) {
+            continue;
+        }
+        // the topic may have been deleted while we yielded
+        auto md = ctx.metadata_cache().get_topic_metadata_ref(tp_ns);
+        if (!md) {
+            continue;
+        }
+        res.push_back(
+          make_topic_response(ctx, request, md->get(), is_node_isolated));
+        co_await ss::coroutine::maybe_yield();
+    }
+
+    co_return res;
+}
+
 static ss::future<chunked_vector<metadata_response::topic>> get_topic_metadata(
   request_context& ctx,
   metadata_request& request,
   const is_node_isolated_or_decommissioned is_node_isolated) {
-    chunked_vector<metadata_response::topic> res;
-
     // request can be served from whatever happens to be in the cache
     if (request.list_all_topics) {
-        auto& topics_md = ctx.metadata_cache().all_topics_metadata();
-        for (const auto& [tp_ns, md] : topics_md) {
-            // only serve topics from the kafka namespace
-            if (tp_ns.ns != model::kafka_namespace) {
-                continue;
-            }
-            /*
-             * quiet authz failures. this isn't checking for a specifically
-             * requested topic, but rather checking visibility of all topics.
-             */
-            if (!ctx.authorized(
-                  security::acl_operation::describe,
-                  tp_ns.tp,
-                  authz_quiet{true})) {
-                continue;
-            }
-            res.push_back(make_topic_response(
-              ctx, request, md.get_metadata(), is_node_isolated));
-        }
-
-        return ss::make_ready_future<chunked_vector<metadata_response::topic>>(
-          std::move(res));
+        return get_all_topic_metadata(ctx, request, is_node_isolated);
     }
 
+    chunked_vector<metadata_response::topic> res;
     std::vector<model::topic> topics_to_be_created;
     std::vector<ss::future<metadata_response::topic>> new_topics;
 

--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -162,17 +162,17 @@ std::optional<security::acl_match> acl_matches::find(
 acl_matches
 acl_store::find(resource_type resource, const ss::sstring& name) const {
     using opt_entry_set = std::optional<acl_matches::entry_set_ref>;
+    const std::string_view name_view{name.data(), name.size()};
 
-    const resource_pattern wildcard_pattern(
+    const resource_pattern_probe wildcard_pattern(
       resource, resource_pattern::wildcard, pattern_type::literal);
-
     opt_entry_set wildcards;
     if (const auto it = _acls.find(wildcard_pattern); it != _acls.end()) {
         wildcards = {it->first, it->second};
     }
 
-    const resource_pattern literal_pattern(
-      resource, name, pattern_type::literal);
+    const resource_pattern_probe literal_pattern(
+      resource, name_view, pattern_type::literal);
 
     opt_entry_set literals;
     if (const auto it = _acls.find(literal_pattern); it != _acls.end()) {
@@ -188,10 +188,12 @@ acl_store::find(resource_type resource, const ss::sstring& name) const {
      * as possible.
      */
     acl_matches::prefix_vector prefixes;
-    auto it = _acls.lower_bound(
-      resource_pattern(resource, name, pattern_type::prefixed));
-    const auto end = _acls.upper_bound(
-      resource_pattern(resource, name.substr(0, 1), pattern_type::prefixed));
+    const resource_pattern_probe full_name_pattern(
+      resource, name_view, pattern_type::prefixed);
+    auto it = _acls.lower_bound(full_name_pattern);
+    const resource_pattern_probe first_char_pattern(
+      resource, name_view.substr(0, 1), pattern_type::prefixed);
+    const auto end = _acls.upper_bound(first_char_pattern);
     for (; it != end; ++it) {
         if (std::string_view(name).starts_with(it->first.name())) {
             prefixes.push_back({it->first, it->second});

--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -179,8 +179,24 @@ acl_store::find(resource_type resource, const ss::sstring& name) const {
         literals = {it->first, it->second};
     }
 
-    auto prefixes = get_prefix_view<acl_matches::entry_set_ref>(
-      _acls, resource, name);
+    /*
+     * The btree range below spans every prefixed pattern (for this resource
+     * type) whose name falls between the full resource name and its first
+     * character: a superset of the actual prefix matches. Filter it down to
+     * the real matches once here- calls to `acl_matches::find()` (of
+     * which a single authorization request can make several) should be as cheap
+     * as possible.
+     */
+    acl_matches::prefix_vector prefixes;
+    auto it = _acls.lower_bound(
+      resource_pattern(resource, name, pattern_type::prefixed));
+    const auto end = _acls.upper_bound(
+      resource_pattern(resource, name.substr(0, 1), pattern_type::prefixed));
+    for (; it != end; ++it) {
+        if (std::string_view(name).starts_with(it->first.name())) {
+            prefixes.push_back({it->first, it->second});
+        }
+    }
 
     return acl_matches(wildcards, literals, std::move(prefixes));
 }

--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -24,6 +24,8 @@
 #include <container/chunked_vector.h>
 #include <fmt/format.h>
 
+#include <iterator>
+
 namespace security {
 
 namespace {
@@ -180,23 +182,64 @@ acl_store::find(resource_type resource, const ss::sstring& name) const {
     }
 
     /*
-     * The btree range below spans every prefixed pattern (for this resource
-     * type) whose name falls between the full resource name and its first
-     * character: a superset of the actual prefix matches. Filter it down to
-     * the real matches once here- calls to `acl_matches::find()` (of
-     * which a single authorization request can make several) should be as cheap
-     * as possible.
+     * A prefixed pattern matches the resource name iff its name is a prefix
+     * of it, so the only matches are the name's own prefixes. The btree range
+     * below spans every prefixed pattern (for this resource type) whose name
+     * sorts between the full name and its first character: a superset of those
+     * matches that also contains unrelated prefixed patterns sharing the
+     * name's first character.
+     *
+     * Example: for name "tz-events" the matches are its prefixes "t", "tz",
+     * "tz-", ..., "tz-events". The scanned range (names from "tz-events" down
+     * to "t") also holds unrelated patterns that merely start with 't'. E.g.,
+     * "ta", "tom", "topic-0001", which are in range but rejected because
+     * "tz-events" does not start with them.
+     *
+     * A legitimate match range holds at most `name.size()` entries (one per
+     * prefix length), so the strategy is decided by whether the range exceeds
+     * that bound:
+     *  - within bound: scan linearly (cheap, range is small).
+     *  - over bound: the range also holds many of those non-matching
+     *    same-first-character patterns so instead look up the name's prefixes
+     *    ("t", "tz", "tz-", ...) one by one.
+     *
+     * Either path materializes the matches longest-prefix-first, preserving
+     * the reverse-name ordering, so the several `acl_matches::find()` calls
+     * per authorization stay cheap.
      */
     acl_matches::prefix_vector prefixes;
     const resource_pattern_probe full_name_pattern(
       resource, name_view, pattern_type::prefixed);
-    auto it = _acls.lower_bound(full_name_pattern);
+    const auto begin = _acls.lower_bound(full_name_pattern);
     const resource_pattern_probe first_char_pattern(
       resource, name_view.substr(0, 1), pattern_type::prefixed);
     const auto end = _acls.upper_bound(first_char_pattern);
-    for (; it != end; ++it) {
-        if (std::string_view(name).starts_with(it->first.name())) {
-            prefixes.push_back({it->first, it->second});
+
+    // Decide between the two strategies by sizing the range against
+    // `name.size()` without walking its (potentially huge) tail: advance a
+    // cursor by up to `name.size()` steps, stopping early if it hits `end`.
+    // If it reaches `end`, the range holds at most `name.size()` entries, so
+    // scan linearly. If it does not, the range also holds prefixed
+    // patterns that share the name's first character but are not prefixes of it
+    // (which a scan would visit and discard one by one), so enumerate the
+    // name's prefixes instead.
+    auto probe = begin;
+    std::ranges::advance(probe, name_view.size(), end);
+    const bool enumerate_prefixes = probe != end;
+
+    if (enumerate_prefixes) {
+        for (size_t len = name_view.size(); len >= 1; --len) {
+            const resource_pattern_probe prefix_pattern{
+              resource, name_view.substr(0, len), pattern_type::prefixed};
+            if (const auto it = _acls.find(prefix_pattern); it != _acls.end()) {
+                prefixes.push_back({it->first, it->second});
+            }
+        }
+    } else {
+        for (auto it = begin; it != end; ++it) {
+            if (name_view.starts_with(it->first.name())) {
+                prefixes.push_back({it->first, it->second});
+            }
         }
     }
 

--- a/src/v/security/acl_store.h
+++ b/src/v/security/acl_store.h
@@ -14,6 +14,8 @@
 #include "security/acl.h"
 #include "security/acl_entry_set.h"
 
+#include <string_view>
+
 namespace security {
 
 /*
@@ -59,6 +61,16 @@ public:
     ss::future<> reset_bindings(const chunked_vector<acl_binding>& bindings);
 
 private:
+    /// A lightweight, non-owning key for heterogeneous btree lookups
+    struct resource_pattern_probe {
+        resource_type _resource;
+        std::string_view _name;
+        pattern_type _pattern;
+        resource_type resource() const { return _resource; }
+        std::string_view name() const { return _name; }
+        pattern_type pattern() const { return _pattern; }
+    };
+
     /*
      * resource pattern ordering:
      *
@@ -67,15 +79,23 @@ private:
      *  3. name (in reverse order)
      */
     struct resource_pattern_compare {
-        bool
-        operator()(const resource_pattern& a, const resource_pattern& b) const {
+        using is_transparent = void;
+
+        template<typename L, typename R>
+        bool operator()(const L& a, const R& b) const {
             if (a.resource() != b.resource()) {
                 return a.resource() < b.resource();
             }
             if (a.pattern() != b.pattern()) {
                 return a.pattern() < b.pattern();
             }
-            return b.name() < a.name();
+            return as_view(b.name()) < as_view(a.name());
+        }
+
+    private:
+        static std::string_view as_view(std::string_view s) { return s; }
+        static std::string_view as_view(const ss::sstring& s) {
+            return {s.data(), s.size()};
         }
     };
 

--- a/src/v/security/acl_store.h
+++ b/src/v/security/acl_store.h
@@ -14,8 +14,6 @@
 #include "security/acl.h"
 #include "security/acl_entry_set.h"
 
-#include <ranges>
-
 namespace security {
 
 /*
@@ -84,40 +82,6 @@ private:
     using container_type = absl::
       btree_map<resource_pattern, acl_entry_set, resource_pattern_compare>;
     container_type _acls;
-
-    /**
-     * WARNING: The view returned by this function contains iterators into a
-     * container which is NOT iterator stable. Use of this view across a yield
-     * point or acl_store update of any kind may (and likely will) result in
-     * UNDEFINED BEHAVIOR.
-     */
-    template<typename RefT>
-    static auto get_prefix_view(
-      const container_type& acls,
-      resource_type resource,
-      const ss::sstring& name) {
-        auto it = acls.lower_bound(
-          resource_pattern(resource, name, pattern_type::prefixed));
-
-        auto end = acls.upper_bound(resource_pattern(
-          resource, name.substr(0, 1), pattern_type::prefixed));
-
-        return std::ranges::subrange(it, end)
-               | std::views::filter([name](const auto& e) {
-                     return std::string_view(name).starts_with(e.first.name());
-                 })
-               | std::views::transform(
-                 [](const auto& e) { return RefT{e.first, e.second}; });
-    }
-
-public:
-    template<
-      typename RefT,
-      typename ViewT = decltype(get_prefix_view<RefT>(
-        std::declval<container_type>(),
-        std::declval<resource_type>(),
-        std::declval<ss::sstring>()))>
-    using prefix_view = ViewT;
 };
 
 /*
@@ -135,10 +99,12 @@ public:
 
     using entry_set_ref = acl_entry_set_match;
 
+    using prefix_vector = chunked_vector<entry_set_ref>;
+
     acl_matches(
       std::optional<entry_set_ref> wildcards,
       std::optional<entry_set_ref> literals,
-      acl_store::prefix_view<entry_set_ref> prefixes)
+      prefix_vector prefixes)
       : wildcards(wildcards)
       , literals(literals)
       , prefixes(std::move(prefixes)) {}
@@ -168,10 +134,7 @@ public:
 private:
     std::optional<entry_set_ref> wildcards;
     std::optional<entry_set_ref> literals;
-    // NOTE(oren): mutable because filter_view & transform_view don't support
-    // const iterators as of C++20. Both are slated for C++23, so we can remove
-    // the mutable specifier when we bump compilers.
-    mutable acl_store::prefix_view<entry_set_ref> prefixes;
+    prefix_vector prefixes;
 };
 
 } // namespace security

--- a/src/v/security/tests/BUILD
+++ b/src/v/security/tests/BUILD
@@ -220,6 +220,22 @@ redpanda_cc_btest(
 )
 
 redpanda_cc_bench(
+    name = "authorizer_bench_rpbench",
+    srcs = [
+        "authorizer_bench.cc",
+    ],
+    deps = [
+        "//src/v/config",
+        "//src/v/model",
+        "//src/v/random:generators",
+        "//src/v/security",
+        "@fmt",
+        "@seastar",
+        "@seastar//:benchmark",
+    ],
+)
+
+redpanda_cc_bench(
     name = "role_store_bench_rpbench",
     srcs = [
         "role_store_bench.cc",

--- a/src/v/security/tests/authorizer_bench.cc
+++ b/src/v/security/tests/authorizer_bench.cc
@@ -1,0 +1,403 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "config/mock_property.h"
+#include "model/fundamental.h"
+#include "security/authorizer.h"
+#include "security/role_store.h"
+
+#include <seastar/testing/perf_tests.hh>
+
+#include <fmt/format.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace {
+
+using namespace security;
+
+// The queried topic. Prefixed-ACL candidates are every prefixed pattern
+// sharing this name's first character; actual matches are prefixes of it
+// ("t", "tz", "tz-", ...).
+const model::topic query_topic("tz-some-workload-topic");
+
+constexpr size_t inner_iters = 32;
+
+/// Shape of the ACL store for one benchmark case. "Noise" bindings never
+/// match the queried topic; the booleans add specific bindings that do.
+struct acl_shape {
+    /// prefixed patterns "topic-NNNNNN": share the query's first character,
+    /// so they fall inside the scanned btree range but never prefix-match
+    size_t noise_prefixed_same_letter = 0;
+    /// prefixed patterns spread across other first characters: outside the
+    /// scanned range entirely (realistic multi-team namespaces)
+    size_t noise_prefixed_spread = 0;
+    /// literal patterns "topic-NNNNNN": per-topic grants, found via point
+    /// lookup, never scanned
+    size_t noise_literal = 0;
+    /// extra principals with entries on the matching prefix "tz-": grows one
+    /// entry set rather than the number of matching patterns
+    size_t principals_on_matching_prefix = 0;
+    /// nested matching prefixes of the query name ("t", "tz", "tz-", ...)
+    /// owned by another principal: each is a distinct matching pattern
+    size_t nested_matching_prefixes = 0;
+    /// prefixed "tz" owned by another principal: matches the query and sorts
+    /// before the same-letter noise (names are ordered in reverse), so every
+    /// find() must scan past the entire noise range after inspecting it
+    bool overlapping_prefix_acl = false;
+    /// prefixed "tz" deny for the querying principal: authorization resolves
+    /// at the first scanned element (adversarial best case for lazy
+    /// evaluation)
+    bool immediate_prefix_deny = false;
+    /// prefixed "tz-" allow describe for the querying principal
+    bool matching_prefix_allow = false;
+    /// literal "*" allow describe for the querying principal
+    bool wildcard_allow = false;
+    /// literal binding on the queried topic for the querying principal
+    bool literal_allow = false;
+};
+
+const acl_principal alice(principal_type::user, "alice");
+
+std::unique_ptr<authorizer> make_authorizer(const acl_shape& shape) {
+    static role_store roles;
+    auto superusers = config::mock_binding<std::vector<ss::sstring>>(
+      std::vector<ss::sstring>{});
+    auto auth = std::make_unique<authorizer>(
+      authorizer::allow_empty_matches::no, std::move(superusers), &roles);
+
+    const auto any_host = acl_host::wildcard_host();
+    const acl_principal bob(principal_type::user, "bob");
+
+    chunked_vector<acl_binding> bindings;
+    auto add = [&](
+                 resource_pattern pattern,
+                 acl_principal principal,
+                 acl_operation op,
+                 acl_permission perm) {
+        bindings.emplace_back(
+          std::move(pattern),
+          acl_entry(std::move(principal), any_host, op, perm));
+    };
+
+    for (size_t i = 0; i < shape.noise_prefixed_same_letter; ++i) {
+        add(
+          {resource_type::topic,
+           fmt::format("topic-{:06}", i),
+           pattern_type::prefixed},
+          {principal_type::user, fmt::format("noise-user-{}", i)},
+          acl_operation::all,
+          acl_permission::allow);
+    }
+
+    constexpr std::string_view other_letters = "abcdefghijklmnopqrsuvwxyz";
+    for (size_t i = 0; i < shape.noise_prefixed_spread; ++i) {
+        add(
+          {resource_type::topic,
+           fmt::format(
+             "{}-team-{:06}", other_letters[i % other_letters.size()], i),
+           pattern_type::prefixed},
+          {principal_type::user, fmt::format("noise-user-{}", i)},
+          acl_operation::all,
+          acl_permission::allow);
+    }
+
+    for (size_t i = 0; i < shape.noise_literal; ++i) {
+        add(
+          {resource_type::topic,
+           fmt::format("topic-{:06}", i),
+           pattern_type::literal},
+          {principal_type::user, fmt::format("noise-user-{}", i)},
+          acl_operation::all,
+          acl_permission::allow);
+    }
+
+    for (size_t i = 0; i < shape.principals_on_matching_prefix; ++i) {
+        add(
+          {resource_type::topic, "tz-", pattern_type::prefixed},
+          {principal_type::user, fmt::format("ns-user-{}", i)},
+          acl_operation::all,
+          acl_permission::allow);
+    }
+
+    for (size_t len = 1; len <= shape.nested_matching_prefixes; ++len) {
+        add(
+          {resource_type::topic,
+           query_topic().substr(0, len),
+           pattern_type::prefixed},
+          bob,
+          acl_operation::write,
+          acl_permission::allow);
+    }
+
+    if (shape.overlapping_prefix_acl) {
+        add(
+          {resource_type::topic, "tz", pattern_type::prefixed},
+          bob,
+          acl_operation::write,
+          acl_permission::allow);
+    }
+
+    if (shape.immediate_prefix_deny) {
+        add(
+          {resource_type::topic, "tz", pattern_type::prefixed},
+          alice,
+          acl_operation::describe,
+          acl_permission::deny);
+    }
+
+    if (shape.matching_prefix_allow) {
+        add(
+          {resource_type::topic, "tz-", pattern_type::prefixed},
+          alice,
+          acl_operation::describe,
+          acl_permission::allow);
+    }
+
+    if (shape.wildcard_allow) {
+        add(
+          {resource_type::topic,
+           resource_pattern::wildcard,
+           pattern_type::literal},
+          alice,
+          acl_operation::describe,
+          acl_permission::allow);
+    }
+
+    if (shape.literal_allow) {
+        add(
+          {resource_type::topic, query_topic(), pattern_type::literal},
+          alice,
+          acl_operation::describe,
+          acl_permission::allow);
+    }
+
+    auth->add_bindings(bindings);
+    return auth;
+}
+
+size_t run_describe_authz(
+  authorizer& auth, const chunked_vector<acl_principal>& groups = {}) {
+    const acl_host host("192.168.1.1");
+    perf_tests::start_measuring_time();
+    for (size_t i = 0; i < inner_iters; ++i) {
+        auto result = auth.authorized(
+          query_topic,
+          acl_operation::describe,
+          alice,
+          host,
+          superuser_required::no,
+          groups);
+        perf_tests::do_not_optimize(result);
+    }
+    perf_tests::stop_measuring_time();
+    return inner_iters;
+}
+
+// Deny-position sweep. `immediate_prefix_deny` places the deny at the front of
+// the scanned range: a lazy deny check could stop almost immediately, so it was
+// the best case for the old lazy view. To show that advantage is *positional*
+// (and that the materialized path is position-independent), place a matching
+// deny at controllable points in the scanned range.
+//
+// The query is a run of identical characters, so its prefixes ("a", "aa", ...)
+// sort contiguously. Each noise pattern "<L 'a's>0<i>" sorts just above the
+// length-L prefix and is never a prefix of the query, spread across lengths
+// [2, len). A deny on the length-d prefix therefore has every noise pattern of
+// length >= d scanned before it is reached: d == len -> none precede it
+// (front); d == 2 -> all precede it (back).
+constexpr size_t deny_query_len = 22;
+const model::topic deny_query(std::string(deny_query_len, 'a'));
+
+std::unique_ptr<authorizer>
+make_deny_position_authorizer(size_t noise, size_t deny_prefix_len) {
+    static role_store roles;
+    auto superusers = config::mock_binding<std::vector<ss::sstring>>(
+      std::vector<ss::sstring>{});
+    auto auth = std::make_unique<authorizer>(
+      authorizer::allow_empty_matches::no, std::move(superusers), &roles);
+
+    const auto any_host = acl_host::wildcard_host();
+    chunked_vector<acl_binding> bindings;
+
+    for (size_t i = 0; i < noise; ++i) {
+        const size_t len = 2 + (i % (deny_query_len - 2));
+        bindings.emplace_back(
+          resource_pattern{
+            resource_type::topic,
+            std::string(len, 'a') + "0" + std::to_string(i),
+            pattern_type::prefixed},
+          acl_entry(
+            {principal_type::user, fmt::format("noise-user-{}", i)},
+            any_host,
+            acl_operation::all,
+            acl_permission::allow));
+    }
+
+    // the only matching prefix for the query: a deny for the querying principal
+    bindings.emplace_back(
+      resource_pattern{
+        resource_type::topic,
+        std::string(deny_prefix_len, 'a'),
+        pattern_type::prefixed},
+      acl_entry(
+        alice, any_host, acl_operation::describe, acl_permission::deny));
+
+    auth->add_bindings(bindings);
+    return auth;
+}
+
+size_t run_deny_position_authz(authorizer& auth) {
+    const acl_host host("192.168.1.1");
+    perf_tests::start_measuring_time();
+    for (size_t i = 0; i < inner_iters; ++i) {
+        auto result = auth.authorized(
+          deny_query,
+          acl_operation::describe,
+          alice,
+          host,
+          superuser_required::no,
+          {});
+        perf_tests::do_not_optimize(result);
+    }
+    perf_tests::stop_measuring_time();
+    return inner_iters;
+}
+
+} // namespace
+
+/*
+ * Expected ACL shapes: the configurations real deployments use.
+ */
+
+// the most common deployment: a single wildcard grant
+PERF_TEST(authorizer_bench, describe_wildcard_only) {
+    auto auth = make_authorizer({.wildcard_allow = true});
+    return run_describe_authz(*auth);
+}
+
+// per-topic literal grants at scale: point lookups, no range scan involved
+PERF_TEST(authorizer_bench, describe_literal_grants_10k) {
+    auto auth = make_authorizer(
+      {.noise_literal = 10240, .literal_allow = true});
+    return run_describe_authz(*auth);
+}
+
+// many team prefixes spread across the namespace: only same-first-letter
+// patterns fall inside the scanned range
+PERF_TEST(authorizer_bench, describe_team_prefixes_1k_spread) {
+    auto auth = make_authorizer(
+      {.noise_prefixed_spread = 1024, .matching_prefix_allow = true});
+    return run_describe_authz(*auth);
+}
+
+// deeply nested namespace conventions: 8 distinct matching prefixes, which
+// exceeds the inline capacity of acl_matches::prefix_vector
+PERF_TEST(authorizer_bench, describe_nested_prefixes_8) {
+    auto auth = make_authorizer(
+      {.nested_matching_prefixes = 8, .matching_prefix_allow = true});
+    return run_describe_authz(*auth);
+}
+
+// per-user grants on a shared namespace prefix: one matching pattern whose
+// entry set holds 1k entries (entry-set search cost, not pattern-scan cost)
+PERF_TEST(authorizer_bench, describe_shared_prefix_1k_principals) {
+    auto auth = make_authorizer(
+      {.principals_on_matching_prefix = 1000, .matching_prefix_allow = true});
+    return run_describe_authz(*auth);
+}
+
+/*
+ * Pathological shapes: many prefixed patterns sharing the queried topic's
+ * first character, all scanned as candidates on every lookup.
+ */
+
+PERF_TEST(authorizer_bench, describe_16_prefix_acls) {
+    auto auth = make_authorizer(
+      {.noise_prefixed_same_letter = 16, .overlapping_prefix_acl = true});
+    return run_describe_authz(*auth);
+}
+
+PERF_TEST(authorizer_bench, describe_1k_prefix_acls_no_match) {
+    auto auth = make_authorizer({.noise_prefixed_same_letter = 1024});
+    return run_describe_authz(*auth);
+}
+
+PERF_TEST(authorizer_bench, describe_1k_prefix_acls) {
+    auto auth = make_authorizer(
+      {.noise_prefixed_same_letter = 1024, .overlapping_prefix_acl = true});
+    return run_describe_authz(*auth);
+}
+
+PERF_TEST(authorizer_bench, describe_10k_prefix_acls_no_match) {
+    auto auth = make_authorizer({.noise_prefixed_same_letter = 10240});
+    return run_describe_authz(*auth);
+}
+
+PERF_TEST(authorizer_bench, describe_10k_prefix_acls) {
+    auto auth = make_authorizer(
+      {.noise_prefixed_same_letter = 10240, .overlapping_prefix_acl = true});
+    return run_describe_authz(*auth);
+}
+
+PERF_TEST(authorizer_bench, describe_10k_prefix_acls_allowed) {
+    auto auth = make_authorizer(
+      {.noise_prefixed_same_letter = 10240,
+       .overlapping_prefix_acl = true,
+       .matching_prefix_allow = true});
+    return run_describe_authz(*auth);
+}
+
+// authorization resolves at the first scanned element: the best case for
+// lazy evaluation (which could stop there) vs eager materialization (which
+// scans the full range regardless)
+PERF_TEST(authorizer_bench, describe_10k_immediate_deny) {
+    auto auth = make_authorizer(
+      {.noise_prefixed_same_letter = 10240, .immediate_prefix_deny = true});
+    return run_describe_authz(*auth);
+}
+
+// group principals multiply the number of deny/allow checks per
+// authorization; each check re-scans under lazy evaluation
+PERF_TEST(authorizer_bench, describe_10k_prefix_acls_two_groups) {
+    auto auth = make_authorizer(
+      {.noise_prefixed_same_letter = 10240, .overlapping_prefix_acl = true});
+    chunked_vector<acl_principal> groups;
+    groups.emplace_back(principal_type::group, "g-eng");
+    groups.emplace_back(principal_type::group, "g-data");
+    return run_describe_authz(*auth, groups);
+}
+
+PERF_TEST(authorizer_bench, describe_50k_prefix_acls) {
+    auto auth = make_authorizer(
+      {.noise_prefixed_same_letter = 51200, .overlapping_prefix_acl = true});
+    return run_describe_authz(*auth);
+}
+
+// Deny-position sweep over 10k prefixed ACLs. Lazy evaluation's cost tracked
+// how far the deny sat from the front of the scan (front == cheap); the
+// materialized path pays the same regardless. `describe_10k_deny_front` is the
+// equivalent of `describe_10k_immediate_deny`.
+PERF_TEST(authorizer_bench, describe_10k_deny_front) {
+    auto auth = make_deny_position_authorizer(10240, deny_query_len);
+    return run_deny_position_authz(*auth);
+}
+
+PERF_TEST(authorizer_bench, describe_10k_deny_middle) {
+    auto auth = make_deny_position_authorizer(10240, deny_query_len / 2);
+    return run_deny_position_authz(*auth);
+}
+
+PERF_TEST(authorizer_bench, describe_10k_deny_back) {
+    auto auth = make_deny_position_authorizer(10240, 2);
+    return run_deny_position_authz(*auth);
+}

--- a/src/v/security/tests/authorizer_test.cc
+++ b/src/v/security/tests/authorizer_test.cc
@@ -19,6 +19,7 @@
 
 #include <seastar/util/defer.hh>
 
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 
 namespace security {
@@ -3438,6 +3439,73 @@ TEST(AUTHORIZER_TEST, group_principal_acl_deny_precedence) {
     EXPECT_TRUE(bool(result_without_group));
     EXPECT_EQ(result_without_group.acl, allow_write);
     EXPECT_FALSE(result_without_group.group.has_value());
+}
+
+// acl_store::find() scans the candidate prefix range when it is small and
+// switches to per-prefix lookups once the range exceeds the resource name's
+// length. Both paths must surface the same prefix matches: add a matching
+// prefix ACL plus a varying amount of non-matching, same-first-character noise
+// that straddles that threshold (the query name is 22 chars), and assert
+// authorization is unaffected by which path runs.
+TEST(AUTHORIZER_TEST, authz_prefix_match_across_scan_enumerate_threshold) {
+    const acl_principal user(principal_type::user, "alice");
+    const acl_host host("192.168.0.1");
+    const model::topic topic("tz-some-workload-topic"); // 22 chars
+
+    const resource_pattern match(
+      resource_type::topic, "tz-", pattern_type::prefixed);
+
+    // counts below and above the name length exercise the scan and enumerate
+    // paths respectively
+    for (size_t noise : {size_t{0}, size_t{8}, size_t{100}}) {
+        auto auth = make_test_instance();
+
+        chunked_vector<acl_binding> bindings;
+        bindings.emplace_back(
+          match,
+          acl_entry(user, host, acl_operation::read, acl_permission::allow));
+
+        // prefixed patterns that share the topic's first character ('t') but
+        // are never a prefix of it: they fall in the scanned range yet must
+        // never match
+        for (size_t i = 0; i < noise; ++i) {
+            bindings.emplace_back(
+              resource_pattern(
+                resource_type::topic,
+                fmt::format("to-noise-{:06}", i),
+                pattern_type::prefixed),
+              acl_entry(
+                acl_principal(principal_type::user, fmt::format("u{}", i)),
+                acl_wildcard_host,
+                acl_operation::read,
+                acl_permission::allow));
+        }
+        auth.add_bindings(bindings);
+
+        // granted via the "tz-" prefix regardless of the noise / code path
+        auto granted = auth.authorized(
+          topic,
+          acl_operation::read,
+          user,
+          host,
+          security::superuser_required::no,
+          {});
+        EXPECT_TRUE(granted.authorized) << "noise=" << noise;
+        EXPECT_EQ(granted.resource_pattern, match) << "noise=" << noise;
+
+        // a topic the "tz-" prefix does not cover is never granted, even though
+        // the noise shares its first character
+        EXPECT_FALSE(auth
+                       .authorized(
+                         model::topic("to-uncovered"),
+                         acl_operation::read,
+                         user,
+                         host,
+                         security::superuser_required::no,
+                         {})
+                       .authorized)
+          << "noise=" << noise;
+    }
 }
 
 } // namespace security


### PR DESCRIPTION
Recent logs from a production cluster showed some reactor stalls with backtraces leading to the `kafka` metadata layer and ACL authorizations: https://gist.github.com/WillemKauf/907a6d3cf67fe240013c352e477e7fd7

This PR makes some changes to address pathological cases in the authorization path:
* Yield if processing all topics in `get_topic_metadata()`, as this loop must call `ctx.authorized()` for each topic in the cluster. In clusters with a large amount of topics & ACLs, this can quickly lead to reactor stalls.
* Materialize prefix matches in `acl_store::find()`- the commit message has a lot of context to describe the motivation & effect of this change.
* Add a `resource_pattern_probe` type and make `resource_pattern_compare` a transparent hashing type to avoid a copy of `ss::sstring`s needed for lookup.
* Add a hybrid scanning approach to `acl_store::find()` that either maintains the current behavior of linearly scanning over all matched ACLs of the underlying `_acls` btree-map (iff the number of matches is small), or switching to enumerating over the prefixes of the resource name and performing direct point lookups if the number of matches is high (e.g. there are many unrelated ACL rules in the range between the first character of the resource and the full resource).

Results from benchmarking are good in common cases, and more importantly, kept bounded in pathological cases.

```
  ┌─────────────────────────────┬─────────────────┬───────────────┬───────────────┬──────────────────┬──────────────────────┐
  │            case             │ baseline (lazy) │ + materialize │    + probe    │ + hybrid (final) │      base→final      │
  ├─────────────────────────────┼─────────────────┼───────────────┼───────────────┼──────────────────┼──────────────────────┤
  │ wildcard_only               │ 162 ns / 11     │ 109 ns / 4    │ 94 ns / 2     │ 94 ns / 2        │ 1.7×                 │
  ├─────────────────────────────┼─────────────────┼───────────────┼───────────────┼──────────────────┼──────────────────────┤
  │ literal_grants_10k          │ 308 ns / 11     │ 264 ns / 4    │ 225 ns / 2    │ 220 ns / 2       │ 1.4×                 │
  ├─────────────────────────────┼─────────────────┼───────────────┼───────────────┼──────────────────┼──────────────────────┤
  │ team_prefixes_1k_spread     │ 255 ns / 11     │ 209 ns / 6    │ 198 ns / 4    │ 196 ns / 4       │ 1.3×                 │
  ├─────────────────────────────┼─────────────────┼───────────────┼───────────────┼──────────────────┼──────────────────────┤
  │ nested_prefixes_8           │ 312 ns / 11     │ 268 ns / 8    │ 251 ns / 6    │ 249 ns / 6       │ 1.2×                 │
  ├─────────────────────────────┼─────────────────┼───────────────┼───────────────┼──────────────────┼──────────────────────┤
  │ shared_prefix_1k_principals │ 5.62 µs / 11    │ 4.36 µs / 6   │ 5.03 µs / 4   │ 4.94 µs / 4      │ ~1.1× (noise)        │
  ├─────────────────────────────┼─────────────────┼───────────────┼───────────────┼──────────────────┼──────────────────────┤
  │ 16_prefix_acls              │ 537 ns / 10     │ 239 ns / 5    │ 221 ns / 3    │ 226 ns / 3       │ 2.4×                 │
  ├─────────────────────────────┼─────────────────┼───────────────┼───────────────┼──────────────────┼──────────────────────┤
  │ 1k_prefix_acls_no_match     │ 3.98 µs / 10    │ 3.30 µs / 3   │ 3.09 µs / 1   │ 1.20 µs / 1      │ 3.3×                 │
  ├─────────────────────────────┼─────────────────┼───────────────┼───────────────┼──────────────────┼──────────────────────┤
  │ 1k_prefix_acls              │ 20.55 µs / 10   │ 3.29 µs / 5   │ 3.22 µs / 3   │ 1.15 µs / 3      │ 18×                  │
  ├─────────────────────────────┼─────────────────┼───────────────┼───────────────┼──────────────────┼──────────────────────┤
  │ 10k_prefix_acls_no_match    │ 34.87 µs / 10   │ 29.51 µs / 3  │ 28.84 µs / 1  │ 5.71 µs / 1      │ 6.1×                 │
  ├─────────────────────────────┼─────────────────┼───────────────┼───────────────┼──────────────────┼──────────────────────┤
  │ 10k_prefix_acls             │ 197.14 µs / 10  │ 29.66 µs / 5  │ 28.19 µs / 3  │ 5.83 µs / 3      │ 34×                  │
  ├─────────────────────────────┼─────────────────┼───────────────┼───────────────┼──────────────────┼──────────────────────┤
  │ 10k_prefix_acls_allowed     │ 34.80 µs / 11   │ 30.12 µs / 6  │ 27.78 µs / 4  │ 5.84 µs / 4      │ 6.0×                 │
  ├─────────────────────────────┼─────────────────┼───────────────┼───────────────┼──────────────────┼──────────────────────┤
  │ 10k_prefix_acls_two_groups  │ 601.63 µs / 10  │ 29.93 µs / 5  │ 27.85 µs / 3  │ 5.96 µs / 3      │ 101×                 │
  ├─────────────────────────────┼─────────────────┼───────────────┼───────────────┼──────────────────┼──────────────────────┤
  │ 50k_prefix_acls             │ 1.01 ms / 10    │ 166.42 µs / 5 │ 149.64 µs / 3 │ 55.43 µs / 3     │ 18×                  │
  ├─────────────────────────────┼─────────────────┼───────────────┼───────────────┼──────────────────┼──────────────────────┤
  │ 10k_immediate_deny          │ 289 ns / 11     │ 29.50 µs / 6  │ 27.57 µs / 4  │ 5.76 µs / 4      │ 0.05× (20× slower) ⚠ │
  ├─────────────────────────────┼─────────────────┼───────────────┼───────────────┼──────────────────┼──────────────────────┤
  │ 10k_deny_front              │ 279 ns / 11     │ 35.83 µs / 6  │ 35.77 µs / 4  │ 8.01 µs / 4      │ 0.03× (29× slower) ⚠ │
  ├─────────────────────────────┼─────────────────┼───────────────┼───────────────┼──────────────────┼──────────────────────┤
  │ 10k_deny_middle             │ 16.31 µs / 11   │ 36.19 µs / 6  │ 35.65 µs / 4  │ 7.98 µs / 4      │ 2.0×                 │
  ├─────────────────────────────┼─────────────────┼───────────────┼───────────────┼──────────────────┼──────────────────────┤
  │ 10k_deny_back               │ 34.96 µs / 11   │ 35.46 µs / 6  │ 36.46 µs / 4  │ 8.00 µs / 4      │ 4.4×                 │
  └─────────────────────────────┴─────────────────┴───────────────┴───────────────┴──────────────────┴──────────────────────┘
```

The timescales are all quite low here, so these optimizations are purely targetting pathological cases and tail latencies that would cause reactor stalls such as the ones seen in the above backtrace.


## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Improvements

* Optimize the ACL authorization path for all callers (Kafka handlers, schema registry, Pandaproxy & Iceberg)