### PR TITLE
raft: refresh election timer on recovery-path append_entries (pre-vote livelock)

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2052,6 +2052,8 @@ consensus::do_append_entries(append_entries_request&& r) {
     // follower (§5.2)
     maybe_update_leader(r.source_node());
 
+    auto refresh_hbeat = ss::defer([this] { _hbeat = clock_type::now(); });
+
     // raft.pdf: Reply false if log doesn’t contain an entry at
     // prevLogIndex whose term matches prevLogTerm (§5.3)
     // broken into 3 sections
@@ -2307,11 +2309,6 @@ consensus::do_append_entries(append_entries_request&& r) {
     // success. copy entries for each subsystem
 
     try {
-        auto deferred = ss::defer([this] {
-            // we do not want to include our disk flush latency into
-            // the leader vote timeout
-            _hbeat = clock_type::now();
-        });
         validate_offset_translator_delta(request_metadata, lstats);
 
         // simulate disk error


### PR DESCRIPTION
A follower that is behind a live leader can get stuck in a perpetual pre-vote storm. `should_skip_vote` suppresses elections only while `_hbeat` (the follower election timer) is within one election timeout, but `_hbeat` is refreshed only on the successful batch-append path in `do_append_entries`. The two early returns taken by a recovering follower, a log gap (`prev_log_index > last_log_offset`) and a prev-log-term mismatch, call `maybe_update_leader` and reply to the leader but never refresh `_hbeat`.

So a follower in continuous contact with the current-term leader, but not yet caught up, lets its election timer expire, starts a (pre-)vote that deterministically fails the longest-log check, rearms, and repeats. The storm burns CPU that further starves recovery, a self-reinforcing livelock that leaves partitions under-replicated and stalls `acks=all` produce with `REQUEST_TIMED_OUT`.

`do_append_entries` defers the refresh. Right after `maybe_update_leader` it registers `auto refresh_hbeat = ss::defer([this] { _hbeat = clock_type::now(); })`, so every return path below (including the two recovery early-returns) counts as leader contact, and because the defer runs at scope exit it still lands after the flush on the success path. That lets it replace the separate success-path defer that previously kept disk-flush latency out of the vote timeout, leaving a single refresh point. Liveness is preserved. If the leader is gone, no `append_entries` arrive, the defer never runs, `_hbeat` goes stale, and elections proceed as before. The defer is only registered after the term check confirms the request is from a leader at term >= our own.

Validated on a throwaway 3-broker v26.1.10 cluster under identical load plus six rounds of partition-move reconfiguration churn, with this patch as the only variable:

| Metric (120s steady-state) | Stock v26.1.10 | This patch |
|---|---|---|
| vote_stm log lines per broker | 1265 to 1806 | 0 |
| Cluster Healthy | false | true |
| Leaderless partitions | 16 | 0 |
| Under-replicated partitions | 32 | 0 |

Fixes #30815

## Backports Required

- [x] v26.1.x

## Release Notes

### Bug Fixes

* Fixed a raft pre-vote livelock where a follower recovering behind a live leader could repeatedly start elections, leaving partitions under-replicated and stalling `acks=all` produce with request timeouts.
