### PR TITLE
kafka: make produce_partition_bench idempotent-only

### DIFF
--- a/src/v/kafka/server/tests/produce_partition_bench.cc
+++ b/src/v/kafka/server/tests/produce_partition_bench.cc
@@ -40,6 +40,7 @@ struct produce_partition_fixture : redpanda_thread_fixture {
     static constexpr size_t total_partition_count = 1;
 
     model::topic t;
+    int32_t idempotent_seq{0};
 
     produce_partition_fixture() {
         BOOST_TEST_CHECKPOINT("before leadership");
@@ -79,6 +80,13 @@ produce_partition_fixture::run_test(size_t data_size, measured_region region) {
     }
 
     auto batch = std::move(builder).build();
+
+    // Make it idempotent
+    batch.header().producer_id = 1;
+    batch.header().producer_epoch = 0;
+    batch.header().base_sequence = idempotent_seq;
+    idempotent_seq += num_records;
+    batch.header().reset_size_checksum_metadata(batch.data());
 
     // Reproduce the iobuf fragment layout of a real produce request: serialize
     // the batch to the kafka wire format and decode it through the batch


### PR DESCRIPTION
Enable idempotency in the produce bench. That's the interesting and most important path.

Also it entails the non-idempotent branch.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes


* none

