### PR TITLE
`rptest`: `retry_on_exc` in `group_membership_test`

### DIFF
--- a/tests/rptest/tests/group_membership_test.py
+++ b/tests/rptest/tests/group_membership_test.py
@@ -326,6 +326,7 @@ class GroupMetricsTest(RedpandaTest):
             timeout_sec=10,
             backoff_sec=1,
             err_msg="Initial check metric failed",
+            retry_on_exc=True,
         )
 
         self.client().delete_topic(topic)
@@ -342,6 +343,7 @@ class GroupMetricsTest(RedpandaTest):
             timeout_sec=10,
             backoff_sec=1,
             err_msg="Topic recreation check metric failed",
+            retry_on_exc=True,
         )
 
     @cluster(num_nodes=7)


### PR DESCRIPTION
This test can flake if the rpk produce call in `check_metric()` throws, e.g. due to unestablished leadership right after creating the topic used in the test.

Add `retry_on_exc` to prevent any flakes here.

(For some reason no JIRA but I saw this flake in https://github.com/redpanda-data/redpanda/pull/30816)

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
