### PR TITLE
ci: upgrade GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
@@ -69,7 +69,7 @@ jobs:
       BACKPORT_BRANCH: ${{ needs.backport-type.outputs.backport_branch }}
     steps:
       - uses: actions/checkout@v6
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}

--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
-      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
             ,sdlc/prod/github/actions_bot_token
@@ -73,7 +73,7 @@ jobs:
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
-      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
             ,sdlc/prod/github/actions_bot_token

--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -45,7 +45,7 @@ jobs:
         run: $SCRIPT_DIR/get_backport_type.sh
         shell: bash
       - name: Failed reaction
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         if: failure()
         with:
           token: ${{ env.ACTIONS_BOT_TOKEN }}
@@ -265,7 +265,7 @@ jobs:
         shell: bash
       - name: Add reaction
         if: steps.pr_details.outcome == 'success' || steps.load_ai_handoff.outcome == 'success'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -273,7 +273,7 @@ jobs:
           reactions: hooray
       - name: Failed reaction
         if: always() && steps.pr_details.outcome == 'failure' && steps.load_ai_handoff.outcome != 'success'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/backport-on-merge.yml
+++ b/.github/workflows/backport-on-merge.yml
@@ -25,7 +25,7 @@ jobs:
         if: success() && steps.findPr.outputs.number
         env:
           PR: ${{ steps.findPr.outputs.pr }}
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}

--- a/.github/workflows/backport-on-merge.yml
+++ b/.github/workflows/backport-on-merge.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
-      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
             ,sdlc/prod/github/actions_bot_token

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -62,7 +62,7 @@ jobs:
     needs: validate  # Only run after validation passes
     runs-on: ubuntu-latest
     steps:
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
-      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
             ,sdlc/prod/github/buf_token

--- a/.github/workflows/buildkite-slash-commands.yml
+++ b/.github/workflows/buildkite-slash-commands.yml
@@ -20,7 +20,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}

--- a/.github/workflows/buildkite-slash-commands.yml
+++ b/.github/workflows/buildkite-slash-commands.yml
@@ -49,7 +49,7 @@ jobs:
           buildkite_pipeline: redpanda
           command: ${{ github.event.client_payload.slash_command.command }}
       - name: Success reaction
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/buildkite-slash-commands.yml
+++ b/.github/workflows/buildkite-slash-commands.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
-      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
             ,sdlc/prod/github/actions_bot_token

--- a/.github/workflows/check-ducktape-protos.yml
+++ b/.github/workflows/check-ducktape-protos.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: bazel-contrib/setup-bazel@0.15.0
         with:
           bazelisk-cache: true

--- a/.github/workflows/check-ducktape-protos.yml
+++ b/.github/workflows/check-ducktape-protos.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - uses: bazel-contrib/setup-bazel@0.15.0
+      - uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
           repository-cache: true

--- a/.github/workflows/check-ducktape-protos.yml
+++ b/.github/workflows/check-ducktape-protos.yml
@@ -48,7 +48,7 @@ jobs:
           CI: false
         run: bazel fetch --lockfile_mode=off //proto/...
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.2.0
       - name: Regenerate ducktape proto bindings
         env:
           CI: false

--- a/.github/workflows/close-backport-issues.yml
+++ b/.github/workflows/close-backport-issues.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
     steps:
       - name: Close backport issues and PRs
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const version = '${{ github.event.inputs.version }}';

--- a/.github/workflows/cloud-installpack-bk-trigger.yml
+++ b/.github/workflows/cloud-installpack-bk-trigger.yml
@@ -10,7 +10,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}

--- a/.github/workflows/cloud-installpack-bk-trigger.yml
+++ b/.github/workflows/cloud-installpack-bk-trigger.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
-      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
             ,sdlc/prod/github/actions_bot_token

--- a/.github/workflows/dispatch-docs-updates.yml
+++ b/.github/workflows/dispatch-docs-updates.yml
@@ -22,7 +22,7 @@ jobs:
           echo "Draft:      ${{ github.event.release.draft }}"
 
       # Assume AWS role and fetch ACTIONS_BOT_TOKEN
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}

--- a/.github/workflows/dispatch-docs-updates.yml
+++ b/.github/workflows/dispatch-docs-updates.yml
@@ -54,7 +54,7 @@ jobs:
       # Dispatch to api-docs repo if latest
       - name: Dispatch to api-docs repo
         if: steps.latest.outputs.is_latest == 'true'
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           repository: redpanda-data/api-docs
@@ -65,7 +65,7 @@ jobs:
       # Dispatch to docs repo for property docs generation if latest
       - name: Dispatch property docs generation to docs repo
         if: steps.latest.outputs.is_latest == 'true'
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           repository: redpanda-data/docs

--- a/.github/workflows/dispatch-docs-updates.yml
+++ b/.github/workflows/dispatch-docs-updates.yml
@@ -28,7 +28,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
 
       - id: ghsecrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
             ,sdlc/prod/github/actions_bot_token

--- a/.github/workflows/lint-bazel-dependency-graph.yml
+++ b/.github/workflows/lint-bazel-dependency-graph.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - uses: bazel-contrib/setup-bazel@0.15.0
+      - uses: bazel-contrib/setup-bazel@0.19.0
         with:
           # Avoid downloading Bazel every time.
           bazelisk-cache: true

--- a/.github/workflows/lint-bazel-pkg-tool.yml
+++ b/.github/workflows/lint-bazel-pkg-tool.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: stable
           cache: false

--- a/.github/workflows/lint-bazel-pkg-tool.yml
+++ b/.github/workflows/lint-bazel-pkg-tool.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           go-version: stable
           cache: false
-      - uses: golangci/golangci-lint-action@v8
+      - uses: golangci/golangci-lint-action@v9
         with:
           version: latest
           args: --timeout 10m --verbose tool.go

--- a/.github/workflows/lint-cpp.yml
+++ b/.github/workflows/lint-cpp.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - uses: bazel-contrib/setup-bazel@0.15.0
+      - uses: bazel-contrib/setup-bazel@0.19.0
         with:
           # Avoid downloading Bazel every time.
           bazelisk-cache: true

--- a/.github/workflows/lint-golang.yml
+++ b/.github/workflows/lint-golang.yml
@@ -49,7 +49,7 @@ jobs:
           go mod tidy
           git diff --exit-code -- go.mod go.sum
       - name: Check goreleaser configuration file
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: v1.24.0
           args: check src/go/.goreleaser.yaml

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -22,12 +22,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Ruff format --check
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@v4.0.0
         with:
           args: "format --check --diff"
           version: "0.12.10"
       - name: Ruff check (/tests only)
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@v4.0.0
         with:
           args: "check --output-format=github"
           src: "./tests"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -9,6 +9,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -10,7 +10,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
-      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
             ,sdlc/prod/github/buildkite_token

--- a/.github/workflows/publish-apache-polaris-python-client.yml
+++ b/.github/workflows/publish-apache-polaris-python-client.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           repository: 'apache/polaris'
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
       - name: Generate client

--- a/.github/workflows/publish-apache-polaris-python-client.yml
+++ b/.github/workflows/publish-apache-polaris-python-client.yml
@@ -52,7 +52,7 @@ jobs:
             -e 's/"polaris\/\*\*"/"polaris\/\*\*\/\*\.py"/' \
             -e 's/boto3==/boto3>=/' pyproject.toml
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.2.0
       - name: Build distribution packages
         working-directory: client/python
         run: uv build

--- a/.github/workflows/release-rp-storage-tool.yml
+++ b/.github/workflows/release-rp-storage-tool.yml
@@ -19,7 +19,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}

--- a/.github/workflows/render-pr-body-release-notes.yml
+++ b/.github/workflows/render-pr-body-release-notes.yml
@@ -22,7 +22,7 @@ jobs:
           curl -s -S -f -L -o rpchangelog/requirements.txt https://vectorized-public.s3.us-west-2.amazonaws.com/rpchangelog/requirements.txt
           curl -s -S -f -L -o rpchangelog/rpchangelog.py https://vectorized-public.s3.us-west-2.amazonaws.com/rpchangelog/rpchangelog.py
           chmod +x rpchangelog/rpchangelog.py
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'

--- a/.github/workflows/rp-storage-tool-checks.yml
+++ b/.github/workflows/rp-storage-tool-checks.yml
@@ -22,16 +22,9 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v6
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path tools/rp_storage_tool/Cargo.toml
+        run: cargo check --manifest-path tools/rp_storage_tool/Cargo.toml
   test:
     name: Unit tests
     runs-on: ubuntu-latest
@@ -39,13 +32,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v6
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path tools/rp_storage_tool/Cargo.toml
+        run: cargo test --manifest-path tools/rp_storage_tool/Cargo.toml

--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: stable
           cache-dependency-path: 'src/go/rpk/go.sum'
@@ -57,7 +57,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: stable
           cache-dependency-path: 'src/go/rpk/go.sum'
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: stable
       - uses: bufbuild/buf-action@v1

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -19,7 +19,7 @@ jobs:
           secret-ids: |
             ,sdlc/prod/github/actions_bot_token
           parse-json-secrets: true
-      - uses: peter-evans/slash-command-dispatch@v4
+      - uses: peter-evans/slash-command-dispatch@v5
         with:
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           permission: read

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -10,7 +10,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
-      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
             ,sdlc/prod/github/actions_bot_token

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 90  # 3 months

--- a/.github/workflows/transform-sdk-build.yml
+++ b/.github/workflows/transform-sdk-build.yml
@@ -46,7 +46,7 @@ jobs:
           GOTOOLCHAIN: auto
         run: go test -c -o ./wasm-integration-test
       - name: Upload integration test binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wasm-integration-test
           path: src/transform-sdk/tests/wasm-integration-test

--- a/.github/workflows/transform-sdk-build.yml
+++ b/.github/workflows/transform-sdk-build.yml
@@ -236,7 +236,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
       - name: Build integration tests

--- a/.github/workflows/transform-sdk-build.yml
+++ b/.github/workflows/transform-sdk-build.yml
@@ -86,7 +86,7 @@ jobs:
           tinygo build -scheduler=none -target=wasi -o tee.wasm ./tee
           tinygo build -scheduler=none -target=wasi -o sr.wasm ./schema-registry
       - name: Download integration test suite
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wasm-integration-test
           path: src/transform-sdk/go/transform/internal/testdata
@@ -140,7 +140,7 @@ jobs:
             --example=tee \
             --example=schema_registry
       - name: Download integration test suite
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wasm-integration-test
           path: src/transform-sdk/rust
@@ -187,7 +187,7 @@ jobs:
         working-directory: src/transform-sdk/cpp/examples
         run: cmake -B build && cmake --build build
       - name: Download integration test suite
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wasm-integration-test
           path: src/transform-sdk/cpp/examples
@@ -264,7 +264,7 @@ jobs:
             -mvp --enable-simd --enable-bulk-memory --enable-multimemory \
             -o sr.wasm
       - name: Download integration test suite
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wasm-integration-test
           path: src/transform-sdk/js

--- a/.github/workflows/transform-sdk-build.yml
+++ b/.github/workflows/transform-sdk-build.yml
@@ -33,12 +33,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: src/transform-sdk/go/transform/go.sum
       - name: Build integration tests
         working-directory: src/transform-sdk/tests
+        env:
+          # setup-go@v6 defaults GOTOOLCHAIN=local; this module's go.mod
+          # requires a newer Go than the pinned GO_VERSION, so allow the
+          # toolchain to be fetched as it was under v5.
+          GOTOOLCHAIN: auto
         run: go test -c -o ./wasm-integration-test
       - name: Upload integration test binary
         uses: actions/upload-artifact@v4
@@ -51,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: src/transform-sdk/go/transform/go.sum
@@ -69,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: src/transform-sdk/go/transform/go.sum

--- a/.github/workflows/transform-sdk-build.yml
+++ b/.github/workflows/transform-sdk-build.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Run tests
         working-directory: src/transform-sdk/go/transform
         run: go test -v ./...
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v9
         with:
           version: latest
           args: --timeout 5m

--- a/.github/workflows/transform-sdk-release.yml
+++ b/.github/workflows/transform-sdk-release.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Set up Rust
         run: rustup update stable --no-self-update && rustup default stable
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
@@ -82,7 +82,7 @@ jobs:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
       - uses: actions/checkout@v6
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}

--- a/.github/workflows/transform-sdk-release.yml
+++ b/.github/workflows/transform-sdk-release.yml
@@ -25,7 +25,7 @@ jobs:
           cache-dependency-path: src/transform-sdk/go/transform/go.sum
       - name: Create golang specific tag
         id: gotag
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const version = '${{github.ref_name}}'.slice('transform-sdk/'.length);

--- a/.github/workflows/transform-sdk-release.yml
+++ b/.github/workflows/transform-sdk-release.yml
@@ -19,7 +19,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: 1.22
           cache-dependency-path: src/transform-sdk/go/transform/go.sum

--- a/.github/workflows/transform-sdk-release.yml
+++ b/.github/workflows/transform-sdk-release.yml
@@ -77,7 +77,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/transform-sdk-release.yml
+++ b/.github/workflows/transform-sdk-release.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
-      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
             ,sdlc/prod/github/cargo_registry_token
@@ -86,7 +86,7 @@ jobs:
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
-      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
             ,sdlc/prod/github/npm_token

--- a/.github/workflows/trigger-snyk.yml
+++ b/.github/workflows/trigger-snyk.yml
@@ -15,7 +15,7 @@ jobs:
   gh:
     runs-on: ubuntu-24.04
     steps:
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}

--- a/.github/workflows/trigger-snyk.yml
+++ b/.github/workflows/trigger-snyk.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
-      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
             ,sdlc/prod/github/actions_bot_token

--- a/.github/workflows/type-check-python.yaml
+++ b/.github/workflows/type-check-python.yaml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
       - uses: docker/build-push-action@v7
         with:
           context: "tests"

--- a/.github/workflows/type-check-python.yaml
+++ b/.github/workflows/type-check-python.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: "tests"
           file: tools/type-checking/Dockerfile


### PR DESCRIPTION
## Summary

GitHub is [deprecating Node 20](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) on Actions runners — JavaScript actions are forced onto Node 24 by default starting **2026-06-16**, and Node 20 is removed from runners on **2026-09-16**. This upgrades every external action in `.github/workflows/` that still declared a Node 20 (or older) runtime to a Node 24-ready version — **one commit per action** so each can be reviewed and reverted independently. Each commit body links the upstream release notes.

After this PR, a scan of every referenced action's `action.yml` shows **no `node20`/`node12` actions remain**.

## Upgrades

| Action | From | To |
|---|---|---|
| `actions/checkout` | `v4` | [`v6`](https://github.com/actions/checkout/releases/tag/v6.0.0) |
| `actions/download-artifact` | `v4` | [`v8`](https://github.com/actions/download-artifact/releases/tag/v8.0.0) |
| `actions/github-script` | `v7` | [`v8`](https://github.com/actions/github-script/releases/tag/v8) |
| `actions/labeler` | `v5` | [`v6`](https://github.com/actions/labeler/releases/tag/v6.0.0) |
| `actions/setup-go` | `v5` | [`v6`](https://github.com/actions/setup-go/releases/tag/v6.0.0) |
| `actions/setup-node` | `v4` | [`v6`](https://github.com/actions/setup-node/releases/tag/v6.0.0) |
| `actions/setup-python` | `v5` | [`v6`](https://github.com/actions/setup-python/releases/tag/v6.0.0) |
| `actions/stale` | `v9` | [`v10`](https://github.com/actions/stale/releases/tag/v10.0.0) |
| `actions/upload-artifact` | `v4` | [`v7`](https://github.com/actions/upload-artifact/releases/tag/v7.0.0) |
| `astral-sh/ruff-action` | `v3` | [`v4.0.0`](https://github.com/astral-sh/ruff-action/releases/tag/v4.0.0) |
| `astral-sh/setup-uv` | `v6` | [`v8.2.0`](https://github.com/astral-sh/setup-uv/releases/tag/v8.0.0) |
| `aws-actions/aws-secretsmanager-get-secrets` | `v2` | [`v3`](https://github.com/aws-actions/aws-secretsmanager-get-secrets/releases/tag/v3.0.0) |
| `aws-actions/configure-aws-credentials` | `v4` | [`v6`](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v6.0.0) |
| `bazel-contrib/setup-bazel` | `0.15.0` | [`0.19.0`](https://github.com/bazel-contrib/setup-bazel/releases/tag/0.19.0) |
| `docker/build-push-action` | `v6` | [`v7`](https://github.com/docker/build-push-action/releases/tag/v7.0.0) |
| `docker/setup-buildx-action` | `v3` | [`v4`](https://github.com/docker/setup-buildx-action/releases/tag/v4.0.0) |
| `golangci/golangci-lint-action` | `v6` & `v8` | [`v9`](https://github.com/golangci/golangci-lint-action/releases/tag/v9.0.0) |
| `goreleaser/goreleaser-action` | `v5` | [`v7`](https://github.com/goreleaser/goreleaser-action/releases/tag/v7.0.0) |
| `peter-evans/create-or-update-comment` | `v4` | [`v5`](https://github.com/peter-evans/create-or-update-comment/releases/tag/v5.0.0) |
| `peter-evans/repository-dispatch` | `v3` | [`v4`](https://github.com/peter-evans/repository-dispatch/releases/tag/v4.0.0) |
| `peter-evans/slash-command-dispatch` | `v4` | [`v5`](https://github.com/peter-evans/slash-command-dispatch/releases/tag/v5.0.0) |

Plus two changes that aren't plain version bumps:

- **`actions/setup-go@v6`** defaults `GOTOOLCHAIN=local`. The `transform-sdk-build` integration-test build runs in a module whose `go.mod` requires a newer Go than the pinned `GO_VERSION`, and its sibling TinyGo jobs must stay on Go 1.22 — so that one step gets `GOTOOLCHAIN: auto` to keep fetching the toolchain as it did under v5. (Rides in the `setup-go` commit.)
- **`actions-rs/toolchain` + `actions-rs/cargo`** (Node 12; the `actions-rs` org has been archived since 2023, so no Node 24 release will ever ship) are replaced in `rp-storage-tool-checks.yml` with the maintained [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain) (a composite action, no Node runtime) plus direct `cargo` invocations.

## Pinning notes

- `astral-sh/ruff-action` (`@v4.0.0`) and `astral-sh/setup-uv` (`@v8.2.0`) use full semver pins — Astral stopped publishing floating major tags at these majors.
- `bazel-contrib/setup-bazel` (`@0.19.0`) has always used a full version pin.

## Review focus

These bumps carry behavior changes beyond the Node runtime; CI on this branch is the real test:

- **`golangci/golangci-lint-action` v6→v9 in `transform-sdk-build`** crosses golangci-lint v1→v2 for that module (`version: latest`, no `.golangci.yml`). The rest of the repo already runs golangci-lint v2 (`lint-golang`, rpk), so this completes the migration — but watch for new lint findings on the transform-sdk Go module.
- **`goreleaser/goreleaser-action` v5→v7** — the step pins `version: v1.24.0` against a v1-format config, which overrides v6's new `~> v2` default, so `check` should still validate the v1 config.
- **`aws-actions/configure-aws-credentials` v4→v6 / `aws-secretsmanager-get-secrets` v2→v3** — verify OIDC/role-assumption still works across the 11 workflows that use them.

## Verification

- `verify_actions.py .github/workflows`: **0 version-mismatches**. The 15 `unknown` entries are actions absent from that tool's allowlist (`github-script`, `setup-node`, `labeler`, `docker/*`, `bufbuild/buf-action`, `jwalton/gh-find-current-pr`, `pypa/gh-action-pypi-publish`, `dtolnay/rust-toolchain`), each independently verified Node 24 / composite / docker.
- All 30 workflow files parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes

* none
