### PR TITLE
bytes: fix io_iterator_consumer::begin() on empty leading fragments

### DIFF
--- a/src/v/bytes/details/io_byte_iterator.h
+++ b/src/v/bytes/details/io_byte_iterator.h
@@ -36,14 +36,8 @@ public:
             _frag_index = _frag->get();
             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             _frag_index_end = _frag->get() + _frag->size();
-            // handle an empty fragment
-            if (_frag_index == _frag_index_end) {
-                next_fragment();
-            }
-        } else {
-            _frag_index = nullptr;
-            _frag_index_end = nullptr;
         }
+        skip_empty_fragment();
     }
     io_byte_iterator(
       const io_const_iterator& begin,
@@ -53,7 +47,9 @@ public:
       : _frag(begin)
       , _frag_end(end)
       , _frag_index(frag_index)
-      , _frag_index_end(frag_index_end) {}
+      , _frag_index_end(frag_index_end) {
+        skip_empty_fragment();
+    }
 
     pointer get() const { return _frag_index; }
     reference operator*() const noexcept { return *_frag_index; }
@@ -79,6 +75,14 @@ public:
     }
 
 private:
+    // If the current fragment is empty or exhausted, advance to the first
+    // non-empty fragment. The _frag != _frag_end guard makes this a no-op for
+    // the end sentinel, where _frag must not be dereferenced.
+    void skip_empty_fragment() {
+        if (_frag != _frag_end && _frag_index == _frag_index_end) {
+            next_fragment();
+        }
+    }
     void next_fragment() {
         while (true) {
             ++_frag;

--- a/src/v/bytes/tests/iobuf_tests.cc
+++ b/src/v/bytes/tests/iobuf_tests.cc
@@ -44,6 +44,25 @@ SEASTAR_THREAD_TEST_CASE(test_copy_equal) {
     BOOST_CHECK_EQUAL(buf, copy);
 }
 
+SEASTAR_THREAD_TEST_CASE(test_iterator_consumer_begin_skips_empty_fragment) {
+    auto empty = std::make_unique<details::io_fragment>(0);
+    ss::temporary_buffer<char> data("hello", 5);
+    auto non_empty = std::make_unique<details::io_fragment>(std::move(data));
+
+    iobuf buf;
+    buf.append(std::move(empty));
+    buf.append(std::move(non_empty));
+
+    auto consumer = details::io_iterator_consumer(buf.cbegin(), buf.cend());
+
+    std::string result;
+    for (auto byte : consumer) {
+        result.push_back(byte);
+    }
+
+    BOOST_REQUIRE_EQUAL(result, "hello");
+}
+
 SEASTAR_THREAD_TEST_CASE(test_lt) {
     BOOST_CHECK_LT(iobuf::from(""), iobuf::from("cat"));
     BOOST_CHECK_LT(iobuf::from("cat"), iobuf::from("dog"));


### PR DESCRIPTION
io_byte_iterator constructed with the four-argument form did not skip
empty fragments the way the two-argument constructor did. When
io_iterator_consumer::begin() was called on an iobuf whose first
fragment was empty, the returned iterator pointed past the end of that
fragment, causing a use-after-free/heap-buffer-overflow when the
caller dereferenced it. This is reachable from production code through
vint::deserialize() used by iobuf_parser_base::read_varlong() and
read_unsigned_varint().

Fix the four-argument constructor to advance to the first non-empty
fragment when the current fragment is empty, but only when not already
at the end sentinel, to avoid null-deref for end(). Add a regression
test.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
