### PR TITLE
raft: expose controller leader_for gauge on public metrics

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -205,11 +205,37 @@ void consensus::setup_metrics() {
 }
 
 void consensus::setup_public_metrics() {
+    namespace sm = ss::metrics;
+
     if (config::shard_local_cfg().disable_public_metrics()) {
         return;
     }
 
     _probe->setup_public_metrics(_log->config().ntp());
+
+    // Expose the leadership gauge for the controller group on the public
+    // endpoint so external consumers can identify the controller leader.
+    // Restricted to the controller to avoid a per-partition public series for
+    // every raft group.
+    if (_log->config().ntp() != model::controller_ntp) {
+        return;
+    }
+
+    // Public metrics carry redpanda_-prefixed label names, unlike the internal
+    // (bare) labels used by setup_metrics.
+    const auto& ntp = _log->config().ntp();
+    auto labels = {
+      metrics::make_namespaced_label("namespace")(ntp.ns()),
+      metrics::make_namespaced_label("topic")(ntp.tp.topic()),
+      metrics::make_namespaced_label("partition")(ntp.tp.partition())};
+    _public_metrics.add_group(
+      prometheus_sanitize::metrics_name("raft"),
+      {sm::make_gauge(
+         "leader_for",
+         [this] { return is_elected_leader(); },
+         sm::description("Indicates if this node is the controller leader"),
+         labels)
+         .aggregate({sm::shard_label})});
 }
 
 void consensus::do_step_down(std::string_view ctx) {

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -935,6 +935,7 @@ private:
     std::chrono::milliseconds _recovery_append_timeout;
     size_t _heartbeat_disconnect_failures;
     metrics::internal_metric_groups _metrics;
+    metrics::public_metric_groups _public_metrics;
     storage::api& _storage;
     std::optional<std::reference_wrapper<coordinated_recovery_throttle>>
       _recovery_throttle;

--- a/tests/rptest/tests/cluster_metrics_test.py
+++ b/tests/rptest/tests/cluster_metrics_test.py
@@ -171,6 +171,72 @@ class ClusterMetricsTest(RedpandaTest):
 
             self._assert_cluster_metrics(node, expect_metrics=False)
 
+    def _controller_leader_for(
+        self, node: ClusterNode, endpoint: MetricsEndpoint
+    ) -> float | None:
+        """
+        The raft `leader_for` gauge for the controller group as scraped from
+        `node` on `endpoint`, or None if the series is absent. Absence is never
+        expected: every node in the controller group registers the gauge, so
+        returning None (rather than 0.0) lets the caller distinguish "missing"
+        from "present and 0". Internal labels are unprefixed; public labels
+        carry the `redpanda_` prefix.
+        """
+        ns_label, topic_label = (
+            ("redpanda_namespace", "redpanda_topic")
+            if endpoint == MetricsEndpoint.PUBLIC_METRICS
+            else ("namespace", "topic")
+        )
+        samples = self.redpanda.metrics_sample(
+            sample_pattern="raft_leader_for",
+            nodes=[node],
+            metrics_endpoint=endpoint,
+        )
+        if samples is None:
+            return None
+        # label_filter only applies the first key, so chain to filter on both
+        # namespace and topic and isolate the controller group.
+        controller = samples.label_filter({ns_label: "redpanda"}).label_filter(
+            {topic_label: "controller"}
+        )
+        if not controller.samples:
+            return None
+        return sum(s.value for s in controller.samples)
+
+    def _assert_controller_leader_metric(
+        self, current_controller: Optional[ClusterNode]
+    ):
+        """
+        The raft `leader_for` gauge for the controller group must read 1 on the
+        controller leader and 0 on every other running node, on both the
+        internal and public metrics endpoints. With no leader, every node
+        reads 0.
+        """
+
+        def check() -> bool:
+            for endpoint in (
+                MetricsEndpoint.METRICS,
+                MetricsEndpoint.PUBLIC_METRICS,
+            ):
+                for node in self.redpanda.started_nodes():
+                    expected = 1.0 if node == current_controller else 0.0
+                    actual = self._controller_leader_for(node, endpoint)
+                    if actual != expected:
+                        self.logger.debug(
+                            f"controller raft_leader_for on {node.name} via "
+                            f"{endpoint.value} = {actual}, expected {expected}"
+                        )
+                        return False
+            return True
+
+        wait_until(
+            check,
+            timeout_sec=15,
+            backoff_sec=1,
+            err_msg="controller raft_leader_for gauge never matched the "
+            "expected controller leadership",
+        )
+
     @cluster(num_nodes=3)
     def cluster_metrics_reported_only_by_leader_test(self):
         """
@@ -180,20 +246,24 @@ class ClusterMetricsTest(RedpandaTest):
         # Assert metrics are reported once in a fresh, three node cluster
         controller = self._wait_until_controller_leader_is_stable()
         self._assert_reported_by_controller(controller)
+        self._assert_controller_leader_metric(controller)
 
         # Restart the controller node and assert.
         controller = self._restart_controller_node()
         self._assert_reported_by_controller(controller)
+        self._assert_controller_leader_metric(controller)
 
         # Stop the controller node and assert.
         controller = self._failover()
         self._assert_reported_by_controller(controller)
+        self._assert_controller_leader_metric(controller)
 
         # Stop the controller node and assert again.
         # This time the metrics should not be reported as a controller
         # couldn't be elected due to lack of quorum.
         self._stop_controller_node()
         self._assert_reported_by_controller(None)
+        self._assert_controller_leader_metric(None)
 
     @cluster(num_nodes=3)
     def cluster_metrics_correctness_test(self):


### PR DESCRIPTION
The raft `leader_for` 0/1 leadership gauge is only registered on the internal
metrics endpoint (`vectorized_raft_leader_for`). There is no public-metrics
signal for which node is the controller leader, so external consumers
(dashboards, alerts) that only scrape `/public_metrics` cannot identify the
controller leader.

This exposes the gauge on the public endpoint as `redpanda_raft_leader_for`,
restricted to the controller group so we don't add a per-partition public
series for every raft group. The registration lives in
`consensus::setup_public_metrics()` next to where the internal `leader_for`
gauge is set up, using a `consensus`-owned public metrics handle and the
`redpanda_`-prefixed public label names. A value of 1 on a node means that node
is the controller leader; 0 otherwise.

The ducktape test `cluster_metrics_reported_only_by_leader_test` is extended to
assert the controller `leader_for` gauge reads 1 on the leader and 0 on every
other running node, on both the internal and public endpoints, across the
restart, failover, and no-quorum transitions the test already drives.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Improvements

* The controller leader is now observable on the public metrics endpoint via the new `redpanda_raft_leader_for` gauge (1 on the controller leader, 0 otherwise).