### PR TITLE
metrics: replicate seastar core families to public endpoint

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -540,7 +540,11 @@ void application::setup_public_metrics() {
        {"io_queue_total_bytes", metrics::public_metrics_handle},
        {"io_queue_disk_queue_length", metrics::public_metrics_handle},
        {"network_bytes_received", metrics::public_metrics_handle},
-       {"network_bytes_sent", metrics::public_metrics_handle}})
+       {"network_bytes_sent", metrics::public_metrics_handle},
+       {"reactor_aio_reads", metrics::public_metrics_handle},
+       {"reactor_aio_writes", metrics::public_metrics_handle},
+       {"reactor_aio_bytes_read", metrics::public_metrics_handle},
+       {"reactor_aio_bytes_write", metrics::public_metrics_handle}})
       .get();
 
     _public_metrics.start().get();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -538,7 +538,9 @@ void application::setup_public_metrics() {
        {"memory_free_memory", metrics::public_metrics_handle},
        {"io_queue_consumption", metrics::public_metrics_handle},
        {"io_queue_total_bytes", metrics::public_metrics_handle},
-       {"io_queue_disk_queue_length", metrics::public_metrics_handle}})
+       {"io_queue_disk_queue_length", metrics::public_metrics_handle},
+       {"network_bytes_received", metrics::public_metrics_handle},
+       {"network_bytes_sent", metrics::public_metrics_handle}})
       .get();
 
     _public_metrics.start().get();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -535,7 +535,8 @@ void application::setup_public_metrics() {
       {{"io_queue_total_read_ops", metrics::public_metrics_handle},
        {"io_queue_total_write_ops", metrics::public_metrics_handle},
        {"memory_allocated_memory", metrics::public_metrics_handle},
-       {"memory_free_memory", metrics::public_metrics_handle}})
+       {"memory_free_memory", metrics::public_metrics_handle},
+       {"io_queue_consumption", metrics::public_metrics_handle}})
       .get();
 
     _public_metrics.start().get();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -536,7 +536,9 @@ void application::setup_public_metrics() {
        {"io_queue_total_write_ops", metrics::public_metrics_handle},
        {"memory_allocated_memory", metrics::public_metrics_handle},
        {"memory_free_memory", metrics::public_metrics_handle},
-       {"io_queue_consumption", metrics::public_metrics_handle}})
+       {"io_queue_consumption", metrics::public_metrics_handle},
+       {"io_queue_total_bytes", metrics::public_metrics_handle},
+       {"io_queue_disk_queue_length", metrics::public_metrics_handle}})
       .get();
 
     _public_metrics.start().get();


### PR DESCRIPTION
The SLF (single load factor) dashboard is being made to work on public
metrics (CORE-16633). It reads several seastar core families that are
already present on the internal `/metrics` endpoint but were never
exposed publicly, so the public-metrics dashboard variant cannot see
them.

Each commit adds one ticket's families to the existing
`replicate_metric_families` call in `setup_public_metrics()`, copying the
internal family to `/public_metrics` unchanged (same name -> `redpanda_*`,
same label set), next to the io_queue/memory families already replicated
there:

- CORE-16637: `io_queue_consumption`
- CORE-16638: `io_queue_total_bytes`, `io_queue_disk_queue_length`
- CORE-16639: `network_bytes_received`, `network_bytes_sent`
- CORE-16640: `reactor_aio_reads`, `reactor_aio_writes`,
  `reactor_aio_bytes_read`, `reactor_aio_bytes_write`

The io_queue/network families keep their per-class / per-scheduling-group
labels (matching the already-public `io_queue_total_read_ops`); the
reactor_aio counters are one series per shard.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none