### PR TITLE
rptest: drop wait() after stop() in cloud cleanup

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -469,7 +469,6 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
             )
         finally:
             producer.stop()
-            producer.wait(timeout_sec=600)
 
         # Once some segments are generated, configure the topic to use more
         # realistic sizes.
@@ -1238,7 +1237,6 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
 
         finally:
             producer.stop()
-            producer.wait(timeout_sec=600)
 
         self.redpanda.assert_cluster_is_reusable()
 
@@ -1348,7 +1346,6 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
 
         finally:
             producer.stop()
-            producer.wait(timeout_sec=600)
 
         self.redpanda.assert_cluster_is_reusable()
 
@@ -1457,7 +1454,6 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
             finally:
                 self.logger.info("Stopping thrashing consumers")
                 consumer.stop()
-                consumer.wait(timeout_sec=600)
 
             final_cloud_storage_cache_op_put = self.redpanda.metric_sum(
                 "redpanda_cloud_storage_cache_op_put_total",
@@ -1515,7 +1511,6 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
 
         finally:
             producer.stop()
-            producer.wait(timeout_sec=600)
             self.free_preallocated_nodes()
 
         self.redpanda.assert_cluster_is_reusable()
@@ -1642,7 +1637,6 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
 
         finally:
             producer.stop()
-            producer.wait(timeout_sec=600)
             self.free_preallocated_nodes()
 
         self.redpanda.assert_cluster_is_reusable()


### PR DESCRIPTION
`KgoVerifierService.wait_node()` asserts `not _stopped` as its first line, *before* the `_status_thread is None` early-return. So every `finally: stop(); wait()` cleanup block in `high_throughput_test.py` trips an `AssertionError` on the success path, masking the real failure and preventing the affected tests from passing at all.

That assert was added in #27298 (commit 243fbfc614, 2025-09-19); before it, `stop()`-then-`wait()` quietly fell through the early-return and returned `True`. The cleanup ordering in these tests only became invalid once #27298 merged.

`stop_node()` already stops the status thread, calls `raise_on_error()`, and re-raises producer-side errors, so the trailing `wait()` surfaced nothing extra -- it only waited on the intentionally over-provisioned producer. Drop it from all six cleanup blocks (`load_many_segments` plus five tests).

Notably `test_add_and_decommission` had a second `stop()`/`wait()` of its own beyond the one in `load_many_segments`, so fixing only the helper would not have been enough for that test.

Second of two PRs to fix DEVPROD-4327 (first: #30823).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
