### PR TITLE
dev_cluster: default to 2 cores per node

### DIFF
--- a/tools/dev_cluster.py
+++ b/tools/dev_cluster.py
@@ -989,11 +989,12 @@ async def main() -> None:
 
     cores = args.cores
     if cores is None:
-        # Use 75% of cores for redpanda.  e.g. 3 node cluster on a 16 node system
-        # gives each node 4 cores.
-        cpu_count = psutil.cpu_count(logical=False)
-        assert cpu_count
-        cores = max((3 * (cpu_count // 4)) // args.nodes, 1)
+        # Default to 2 cores per node rather than scaling with the host's core
+        # count. The per-node memory default is capped at 4 GB (see below), and
+        # Redpanda requires at least 1 GB per core. 2 cores keeps the 2 GB
+        # minimum comfortably within that 4 GB cap while staying lightweight
+        # regardless of machine size. Pass --cores to use more.
+        cores = 2
     env = os.environ.copy()
     if "ASAN_OPTIONS" not in env:
         env["ASAN_OPTIONS"] = "disable_coredump=0:abort_on_error=1"


### PR DESCRIPTION
When `--cores` is not provided, `dev_cluster.py` previously scaled the per-node core count with the host's physical core count (75% of cores split across nodes). On large machines this produced unnecessarily heavyweight dev clusters.

This PR defaults the per-node core count to 2 instead.

**Why 2?** The per-node memory default is capped at 4 GB, and Redpanda requires at least 1 GB of memory per core. Defaulting to 2 cores keeps the resulting 2 GB minimum comfortably within that 4 GB cap, while keeping the cluster lightweight regardless of machine size. Pass `--cores` to use more.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
