### PR TITLE
[CORE-15989] quotas: add per-principal quota metrics

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1401,6 +1401,15 @@ configuration::configuration()
       "Fail-safe maximum throttle delay on Kafka requests.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       30'000ms)
+  , kafka_per_entity_quota_metrics(
+      *this,
+      "kafka_per_entity_quota_metrics",
+      "Enable per-entity labels on quota throttle time and throughput "
+      "metrics. Metric series are registered only when an entity is actively "
+      "being throttled and deregistered after the quota GC window. Opt-in "
+      "due to cardinality and performance implications.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      false)
   , kafka_max_bytes_per_fetch(
       *this,
       "kafka_max_bytes_per_fetch",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -291,6 +291,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> kvstore_flush_interval;
     property<size_t> kvstore_max_segment_size;
     property<std::chrono::milliseconds> max_kafka_throttle_delay_ms;
+    property<bool> kafka_per_entity_quota_metrics;
     property<size_t> kafka_max_bytes_per_fetch;
     property<std::chrono::milliseconds> raft_io_timeout_ms;
     property<std::chrono::milliseconds> join_retry_timeout_ms;

--- a/src/v/kafka/server/quota_manager.cc
+++ b/src/v/kafka/server/quota_manager.cc
@@ -26,6 +26,7 @@
 #include <seastar/core/metrics.hh>
 #include <seastar/core/shard_id.hh>
 #include <seastar/util/later.hh>
+#include <seastar/util/variant_utils.hh>
 
 #include <fmt/chrono.h>
 
@@ -150,6 +151,130 @@ private:
     metrics_container_t _metrics{};
 };
 
+class quota_manager::per_entity_probe {
+public:
+    per_entity_probe() = default;
+    // The registered counters reference _throttle_time_ms / _throughput, so the
+    // probe must never move once setup() has run.
+    per_entity_probe(const per_entity_probe&) = delete;
+    per_entity_probe& operator=(const per_entity_probe&) = delete;
+    per_entity_probe(per_entity_probe&&) = delete;
+    per_entity_probe& operator=(per_entity_probe&&) = delete;
+    ~per_entity_probe() = default;
+
+    void setup(const tracker_key& key, client_quota_type qt) {
+        namespace sm = ss::metrics;
+
+        auto maybe_labels = make_labels(key, qt);
+        if (!maybe_labels) {
+            return;
+        }
+        auto labels = *std::move(maybe_labels);
+
+        auto group_name = prometheus_sanitize::metrics_name("kafka:quotas");
+        _metrics.add_group(
+          group_name,
+          {sm::make_counter(
+             "client_quota_throttle_time_ms_by_entity",
+             _throttle_time_ms,
+             sm::description("Total per-entity quota throttling delay (ms)"),
+             labels)
+             .aggregate({sm::shard_label}),
+           sm::make_counter(
+             "client_quota_throughput_by_entity",
+             _throughput,
+             sm::description(
+               "Per-entity quota throughput (bytes for produce/fetch, "
+               "partition "
+               "mutations for partition-mutation quotas)"),
+             labels)
+             .aggregate({sm::shard_label})});
+    }
+
+    void record_throttle(clock::duration d) {
+        _throttle_time_ms
+          += std::chrono::duration_cast<std::chrono::milliseconds>(d).count();
+    }
+
+    void record_throughput(uint64_t bytes) { _throughput += bytes; }
+
+private:
+    using labels_t = std::vector<ss::metrics::label_instance>;
+
+    // Each identity component gets its own label, emitted only when present.
+    // Distinct tracker_keys therefore map to distinct sets of component labels,
+    // so no separate discriminator label is needed (and single-element keys
+    // carry no empty labels). The quota_type label separates the produce/fetch/
+    // partition-mutation series of a single identity, which can share one
+    // tracker_key but are tracked and rate limited independently.
+    std::optional<labels_t>
+    make_labels(const tracker_key& key, client_quota_type qt) const {
+        auto user = metrics::make_namespaced_label("quota_user");
+        auto client_id = metrics::make_namespaced_label("quota_client_id");
+        auto group = metrics::make_namespaced_label("quota_group_name");
+        auto type = metrics::make_namespaced_label("quota_type")(
+          fmt::format("{}", qt));
+        return ss::visit(
+          key,
+          [&](const std::pair<k_user, k_client_id>& p)
+            -> std::optional<labels_t> {
+              return labels_t{user(p.first()), client_id(p.second()), type};
+          },
+          [&](const std::pair<k_user, k_group_name>& p)
+            -> std::optional<labels_t> {
+              return labels_t{user(p.first()), group(p.second()), type};
+          },
+          [&](const k_user& u) -> std::optional<labels_t> {
+              return labels_t{user(u()), type};
+          },
+          [&](const k_client_id& c) -> std::optional<labels_t> {
+              return labels_t{client_id(c()), type};
+          },
+          [&](const k_group_name& g) -> std::optional<labels_t> {
+              return labels_t{group(g()), type};
+          },
+          [](const k_not_applicable&) { return std::optional<labels_t>{}; });
+    }
+
+    metrics::all_metrics_groups _metrics;
+    uint64_t _throttle_time_ms{0U};
+    uint64_t _throughput{0U};
+};
+
+quota_manager::local_quota_entry::local_quota_entry(
+  std::shared_ptr<client_quota> q) noexcept
+  : quota(std::move(q)) {}
+
+void quota_manager::ensure_entity_probe(
+  const tracker_key& key,
+  client_quota_type qt,
+  const quota_manager::entity_probe_callback_t& cb) {
+    auto it = _local_map.find(key);
+    if (it == _local_map.end()) {
+        return;
+    }
+    auto& probe = it->second.probes[qt];
+    if (!probe) {
+        probe = std::make_unique<per_entity_probe>();
+        probe->setup(key, qt);
+    }
+    cb(*probe);
+}
+
+void quota_manager::with_entity_probe(
+  const tracker_key& key,
+  client_quota_type qt,
+  const quota_manager::entity_probe_callback_t& cb) {
+    auto it = _local_map.find(key);
+    if (it == _local_map.end()) {
+        return;
+    }
+    auto probe_it = it->second.probes.find(qt);
+    if (probe_it != it->second.probes.end() && probe_it->second) {
+        cb(*probe_it->second);
+    }
+}
+
 using clock = quota_manager::clock;
 
 quota_manager::quota_manager(
@@ -160,7 +285,9 @@ quota_manager::quota_manager(
       config::shard_local_cfg().kafka_throughput_replenish_threshold.bind())
   , _translator{client_quota_store}
   , _gc_freq(config::shard_local_cfg().quota_manager_gc_sec.bind())
-  , _max_delay(config::shard_local_cfg().max_kafka_throttle_delay_ms.bind()) {
+  , _max_delay(config::shard_local_cfg().max_kafka_throttle_delay_ms.bind())
+  , _per_entity_metrics(
+      config::shard_local_cfg().kafka_per_entity_quota_metrics.bind()) {
     if (seastar::this_shard_id() == quotas_shard) {
         _global_map = global_map_t{};
 
@@ -174,6 +301,7 @@ quota_manager::~quota_manager() { _gc_timer.cancel(); }
 ss::future<> quota_manager::stop() {
     _gc_timer.cancel();
     co_await _gate.close();
+    _local_map.clear();
     _probe.reset();
 }
 
@@ -186,6 +314,13 @@ ss::future<> quota_manager::start() {
         auto update_quotas = [this]() { update_client_quotas(); };
         _translator.watch(update_quotas);
     }
+    _per_entity_metrics.watch([this] {
+        if (!_per_entity_metrics()) {
+            for (auto& [_, entry] : _local_map) {
+                entry.probes.clear();
+            }
+        }
+    });
     return ss::now();
 }
 
@@ -200,13 +335,13 @@ ss::future<clock::duration> quota_manager::maybe_add_and_retrieve_quota(
 
         vlog(
           client_quota_log.trace, "Inserting new key into local map: {}", qid);
-        it = _local_map.emplace(qid, std::move(new_q)).first;
+        it = _local_map.try_emplace(qid, std::move(new_q)).first;
     } else {
         // bump to prevent gc
-        it->second->last_seen_ms.local() = now;
+        it->second.quota->last_seen_ms.local() = now;
     }
 
-    co_return cb(*it->second);
+    co_return cb(*it->second.quota);
 }
 
 ss::future<std::shared_ptr<quota_manager::client_quota>>
@@ -360,6 +495,18 @@ ss::future<std::chrono::milliseconds> quota_manager::record_partition_mutations(
 
     auto capped_delay = cap_to_max_delay(key, delay);
     _probe->record_throttle_time(value.rule, ctx.q_type, capped_delay);
+    if (_per_entity_metrics()) {
+        if (capped_delay > clock::duration::zero()) {
+            ensure_entity_probe(key, ctx.q_type, [&](per_entity_probe& probe) {
+                probe.record_throttle(capped_delay);
+                probe.record_throughput(mutations);
+            });
+        } else {
+            with_entity_probe(key, ctx.q_type, [&](per_entity_probe& probe) {
+                probe.record_throughput(mutations);
+            });
+        }
+    }
     vlog(
       client_quota_log.trace,
       "request: ctx:{}, key:{}, value:{}, mutations: {}, delay:{}, "
@@ -432,6 +579,18 @@ ss::future<clock::duration> quota_manager::record_produce_tp_and_throttle(
 
     auto capped_delay = cap_to_max_delay(key, delay);
     _probe->record_throttle_time(value.rule, ctx.q_type, capped_delay);
+    if (_per_entity_metrics()) {
+        if (capped_delay > clock::duration::zero()) {
+            ensure_entity_probe(key, ctx.q_type, [&](per_entity_probe& probe) {
+                probe.record_throttle(capped_delay);
+                probe.record_throughput(bytes);
+            });
+        } else {
+            with_entity_probe(key, ctx.q_type, [&](per_entity_probe& probe) {
+                probe.record_throughput(bytes);
+            });
+        }
+    }
     vlog(
       client_quota_log.trace,
       "request: ctx:{}, key:{}, value:{}, bytes: {}, delay:{}, "
@@ -479,6 +638,15 @@ ss::future<> quota_manager::record_fetch_tp(
           fetch_tracker.record(bytes);
           return clock::duration::zero();
       });
+
+    // with_entity_probe never creates a probe - throttle_fetch_tp is the
+    // sole creator, so series are registered only for throttled entities (the
+    // cardinality bound), not for every entity that fetches.
+    if (_per_entity_metrics()) {
+        with_entity_probe(key, ctx.q_type, [&](per_entity_probe& probe) {
+            probe.record_throughput(bytes);
+        });
+    }
 }
 
 ss::future<clock::duration> quota_manager::throttle_fetch_tp(
@@ -519,6 +687,11 @@ ss::future<clock::duration> quota_manager::throttle_fetch_tp(
 
     auto capped_delay = cap_to_max_delay(key, delay);
     _probe->record_throttle_time(value.rule, ctx.q_type, capped_delay);
+    if (_per_entity_metrics() && capped_delay > clock::duration::zero()) {
+        ensure_entity_probe(key, ctx.q_type, [&](per_entity_probe& probe) {
+            probe.record_throttle(capped_delay);
+        });
+    }
     vlog(
       client_quota_log.trace,
       "throttle request: ctx:{}, key:{}, value:{}, delay:{}, "
@@ -593,7 +766,7 @@ ss::future<> quota_manager::do_global_gc() {
 ss::future<> quota_manager::do_local_gc(clock::time_point expire_threshold) {
     for (auto it = _local_map.begin(); it != _local_map.end();) {
         auto& [key, value] = *it;
-        if (value->last_seen_ms.local() < expire_threshold) {
+        if (value.quota->last_seen_ms.local() < expire_threshold) {
             vlog(client_quota_log.trace, "Local GC expiring key: {}", key);
             it = _local_map.erase(it);
         } else {

--- a/src/v/kafka/server/quota_manager.h
+++ b/src/v/kafka/server/quota_manager.h
@@ -28,6 +28,8 @@
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/util/shared_token_bucket.hh>
 
+#include <absl/container/flat_hash_map.h>
+
 #include <chrono>
 #include <memory>
 #include <optional>
@@ -78,9 +80,6 @@ public:
     // std::shared_ptr<> on shard 0 and (2) we need a way to keep track of a
     // reference count across multiple shards, which is exactly what
     // std::shared_ptr<> is meant for.
-    using local_map_t
-      = chunked_hash_map<tracker_key, std::shared_ptr<client_quota>>;
-
     using global_map_t
       = chunked_hash_map<tracker_key, std::shared_ptr<client_quota>>;
 
@@ -132,6 +131,41 @@ private:
       = ss::noncopyable_function<clock::duration(client_quota&)>;
 
     class client_quotas_probe;
+    class per_entity_probe;
+
+    // Per-shard local map entry. Pairs the shared quota state (rate trackers)
+    // with shard-local metric probes that are populated only when the entity
+    // is actively being throttled.
+    struct local_quota_entry {
+        explicit local_quota_entry(std::shared_ptr<client_quota> q) noexcept;
+
+        std::shared_ptr<client_quota> quota;
+        // One probe per quota type, registered lazily on first throttle. A
+        // single tracker_key can be shared across produce/fetch/partition
+        // mutation quotas, so each type needs its own series. The unique_ptr
+        // keeps the probe address stable across rehashes, which its registered
+        // counters depend on.
+        absl::
+          flat_hash_map<client_quota_type, std::unique_ptr<per_entity_probe>>
+            probes;
+    };
+
+    using local_map_t = chunked_hash_map<tracker_key, local_quota_entry>;
+
+    using entity_probe_callback_t
+      = ss::noncopyable_function<void(per_entity_probe&)>;
+
+    // Runs `cb` with the probe for (`key`, `qt`), creating and registering it
+    // on first use (reusing an existing one otherwise). No-op if `key` has no
+    // local-map entry.
+    void ensure_entity_probe(
+      const tracker_key&, client_quota_type, const entity_probe_callback_t&);
+
+    // Runs `cb` with the probe for (`key`, `qt`) only if one is already
+    // registered; never creates one (used on paths that must not register a
+    // series).
+    void with_entity_probe(
+      const tracker_key&, client_quota_type, const entity_probe_callback_t&);
 
     clock::duration cap_to_max_delay(const tracker_key&, clock::duration);
 
@@ -162,6 +196,7 @@ private:
     ss::timer<> _gc_timer;
     config::binding<std::chrono::milliseconds> _gc_freq;
     config::binding<std::chrono::milliseconds> _max_delay;
+    config::binding<bool> _per_entity_metrics;
     ss::gate _gate;
     std::optional<ssx::mutex> _global_map_mutex; // Only on shard 0
 };

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -783,6 +783,7 @@ redpanda_cc_btest(
         "//src/v/cluster:client_quota_store",
         "//src/v/config",
         "//src/v/kafka/server",
+        "//src/v/test_utils:metrics",
         "//src/v/test_utils:seastar_boost",
         "@boost//:test",
         "@seastar",

--- a/src/v/kafka/server/tests/quota_manager_test.cc
+++ b/src/v/kafka/server/tests/quota_manager_test.cc
@@ -13,9 +13,11 @@
 #include "kafka/server/client_quota_translator.h"
 #include "kafka/server/quota_manager.h"
 #include "test_utils/async.h"
+#include "test_utils/metrics.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/metrics_api.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/testing/thread_test_case.hh>
@@ -25,6 +27,7 @@
 
 #include <array>
 #include <chrono>
+#include <string_view>
 
 using namespace std::chrono_literals;
 using cluster::client_quota::entity_key;
@@ -578,4 +581,519 @@ SEASTAR_THREAD_TEST_CASE(test_increasing_specificity) {
         }
     }
 }
+
+namespace {
+
+/// Maps a single-component key type to the component label that carries
+/// its value (e.g. "client_id" -> "redpanda_quota_client_id").
+ss::sstring component_label_for(std::string_view key_type) {
+    if (key_type == "user") {
+        return "redpanda_quota_user";
+    }
+    if (key_type == "client_id") {
+        return "redpanda_quota_client_id";
+    }
+    if (key_type == "group_name") {
+        return "redpanda_quota_group_name";
+    }
+    return {};
+}
+
+/// Value of a per-entity counter (`metric_name`) for a single-component
+/// entity (user/client_id/group_name) and quota_type, or nullopt if no such
+/// series exists. The shard label is added automatically by find_metric_value.
+std::optional<uint64_t> entity_metric_value(
+  std::string_view metric_name,
+  std::string_view key_type,
+  std::string_view key_value,
+  std::string_view quota_type) {
+    return test_utils::find_metric_value<uint64_t>(
+      metric_name,
+      ss::metrics::default_handle(),
+      {{"redpanda_quota_type", ss::sstring(quota_type)},
+       {component_label_for(key_type), ss::sstring(key_value)}});
+}
+
+std::optional<uint64_t> entity_throughput(
+  std::string_view key_type,
+  std::string_view key_value,
+  std::string_view quota_type) {
+    return entity_metric_value(
+      "kafka_quotas_client_quota_throughput_by_entity",
+      key_type,
+      key_value,
+      quota_type);
+}
+
+std::optional<uint64_t> entity_throttle_time_ms(
+  std::string_view key_type,
+  std::string_view key_value,
+  std::string_view quota_type) {
+    return entity_metric_value(
+      "kafka_quotas_client_quota_throttle_time_ms_by_entity",
+      key_type,
+      key_value,
+      quota_type);
+}
+
+/// True if a per-entity throttle-time series exists for the given entity and
+/// quota_type.
+bool has_entity_throttle_metric(
+  std::string_view key_type,
+  std::string_view key_value,
+  std::string_view quota_type) {
+    return entity_throttle_time_ms(key_type, key_value, quota_type).has_value();
+}
+
+/// Issues produce requests for (user, cid) at a fixed timestamp until one is
+/// throttled, which is when the per-entity probe is created. Fails the test
+/// if no throttle occurs within the timeout.
+void produce_until_throttled(
+  quota_manager& qm, quota_manager::clock::time_point now) {
+    tests::cooperative_spin_wait_with_timeout(
+      5s,
+      [now, &qm](this auto) -> ss::future<bool> {
+          auto delay = co_await qm.record_produce_tp_and_throttle(
+            user, cid, 10000, now);
+          co_return delay > quota_manager::clock::duration::zero();
+      })
+      .get();
+}
+
+/// Issues partition-mutation requests for (user, cid) at a fixed timestamp
+/// until one is throttled, which is when the per-entity probe is created.
+/// Fails the test if no throttle occurs within the timeout.
+void mutate_until_throttled(
+  quota_manager& qm, quota_manager::clock::time_point now) {
+    tests::cooperative_spin_wait_with_timeout(
+      5s,
+      [now, &qm](this auto) -> ss::future<bool> {
+          auto delay = co_await qm.record_partition_mutations(
+            user, cid, 1000, now);
+          co_return delay > quota_manager::clock::duration::zero();
+      })
+      .get();
+}
+
+} // namespace
+
+// When kafka_per_entity_quota_metrics is off (the default), no per-entity
+// metric series are registered even when a entity is actively throttled.
+SEASTAR_THREAD_TEST_CASE(per_entity_metrics_not_registered_when_disabled) {
+    set_config([](config::configuration& conf) {
+        conf.kafka_per_entity_quota_metrics.set_value(false);
+    }).get();
+
+    fixture f;
+
+    auto default_values = entity_value{.producer_byte_rate = 100};
+    f.quota_store.local().set_quota(default_key, default_values);
+
+    auto& qm = f.sqm.local();
+    const auto now = quota_manager::clock::now();
+
+    quota_manager::clock::duration delay;
+    tests::cooperative_spin_wait_with_timeout(
+      5s,
+      [now, &qm, &delay](this auto) -> ss::future<bool> {
+          delay = co_await qm.record_produce_tp_and_throttle(
+            user, cid, 10000, now);
+          co_return delay > quota_manager::clock::duration::zero();
+      })
+      .get();
+
+    BOOST_CHECK(
+      !has_entity_throttle_metric("client_id", "franz-go", "produce_quota"));
+}
+
+// With the flag enabled, no metric series is registered until a throttle
+// actually fires.
+SEASTAR_THREAD_TEST_CASE(per_entity_metrics_not_registered_before_throttle) {
+    set_config([](config::configuration& conf) {
+        conf.kafka_per_entity_quota_metrics.set_value(true);
+    }).get();
+
+    fixture f;
+
+    // A quota large enough that a single 1-byte record won't exhaust it
+    auto default_values = entity_value{.producer_byte_rate = 1000000};
+    f.quota_store.local().set_quota(default_key, default_values);
+
+    auto& qm = f.sqm.local();
+    const auto now = quota_manager::clock::now();
+
+    const auto delay
+      = qm.record_produce_tp_and_throttle(user, cid, 1, now).get();
+
+    BOOST_CHECK_EQUAL(delay, quota_manager::clock::duration::zero());
+    BOOST_CHECK(
+      !has_entity_throttle_metric("client_id", "franz-go", "produce_quota"));
+
+    set_config([](config::configuration& conf) {
+        conf.kafka_per_entity_quota_metrics.set_value(false);
+    }).get();
+}
+
+// Calling record_fetch_tp without a subsequent throttle_fetch_tp never
+// creates a per-entity metric series, even when the bucket is exhausted.
+SEASTAR_THREAD_TEST_CASE(record_fetch_tp_alone_does_not_register_probe) {
+    set_config([](config::configuration& conf) {
+        conf.kafka_per_entity_quota_metrics.set_value(true);
+    }).get();
+
+    fixture f;
+
+    auto default_values = entity_value{.consumer_byte_rate = 100};
+    f.quota_store.local().set_quota(default_key, default_values);
+
+    auto& qm = f.sqm.local();
+    const auto now = quota_manager::clock::now();
+
+    for (int i = 0; i < 10; ++i) {
+        qm.record_fetch_tp(user, cid, 10000, now).get();
+    }
+
+    BOOST_CHECK(
+      !has_entity_throttle_metric("client_id", "franz-go", "produce_quota"));
+
+    set_config([](config::configuration& conf) {
+        conf.kafka_per_entity_quota_metrics.set_value(false);
+    }).get();
+}
+
+// After GC expires the local map entry the per-entity probe is destroyed
+// and the metric series is deregistered. A stale timestamp is passed so
+// last_seen_ms is already past the expire threshold (now - 10 * full_window)
+// the first time GC fires.
+SEASTAR_THREAD_TEST_CASE(per_entity_probe_deregistered_on_gc) {
+    set_config([](config::configuration& conf) {
+        conf.kafka_per_entity_quota_metrics.set_value(true);
+        conf.quota_manager_gc_sec.set_value(std::chrono::milliseconds{10});
+        conf.default_window_sec.set_value(std::chrono::milliseconds{1});
+        conf.default_num_windows.set_value(static_cast<int16_t>(1));
+    }).get();
+
+    fixture f;
+
+    auto default_values = entity_value{.producer_byte_rate = 100};
+    f.quota_store.local().set_quota(default_key, default_values);
+
+    auto& qm = f.sqm.local();
+    // 1 s in the past puts last_seen_ms well beyond expire_threshold
+    // (clock::now() - 10 * 1ms = clock::now() - 10ms).
+    const auto stale_now = quota_manager::clock::now() - 1s;
+
+    quota_manager::clock::duration delay;
+    tests::cooperative_spin_wait_with_timeout(
+      5s,
+      [stale_now, &qm, &delay](this auto) -> ss::future<bool> {
+          delay = co_await qm.record_produce_tp_and_throttle(
+            user, cid, 10000, stale_now);
+          co_return delay > quota_manager::clock::duration::zero();
+      })
+      .get();
+
+    BOOST_REQUIRE(
+      has_entity_throttle_metric("client_id", "franz-go", "produce_quota"));
+
+    // No more quota calls - last_seen_ms stays stale. GC fires at ~10ms
+    // intervals; the entry is immediately eligible and the probe is destroyed.
+    tests::cooperative_spin_wait_with_timeout(
+      2s,
+      [](this auto) -> ss::future<bool> {
+          co_return !has_entity_throttle_metric(
+            "client_id", "franz-go", "produce_quota");
+      })
+      .get();
+
+    BOOST_CHECK(
+      !has_entity_throttle_metric("client_id", "franz-go", "produce_quota"));
+
+    set_config([](config::configuration& conf) {
+        conf.kafka_per_entity_quota_metrics.set_value(false);
+    }).get();
+}
+
+// Toggling kafka_per_entity_quota_metrics off immediately clears all
+// per-entity probes without waiting for the GC cycle.
+SEASTAR_THREAD_TEST_CASE(per_entity_probe_cleared_on_config_toggle_off) {
+    set_config([](config::configuration& conf) {
+        conf.kafka_per_entity_quota_metrics.set_value(true);
+    }).get();
+
+    fixture f;
+
+    auto default_values = entity_value{.producer_byte_rate = 100};
+    f.quota_store.local().set_quota(default_key, default_values);
+
+    auto& qm = f.sqm.local();
+    const auto now = quota_manager::clock::now();
+
+    quota_manager::clock::duration delay;
+    tests::cooperative_spin_wait_with_timeout(
+      5s,
+      [now, &qm, &delay](this auto) -> ss::future<bool> {
+          delay = co_await qm.record_produce_tp_and_throttle(
+            user, cid, 10000, now);
+          co_return delay > quota_manager::clock::duration::zero();
+      })
+      .get();
+
+    BOOST_REQUIRE(
+      has_entity_throttle_metric("client_id", "franz-go", "produce_quota"));
+
+    set_config([](config::configuration& conf) {
+        conf.kafka_per_entity_quota_metrics.set_value(false);
+    }).get();
+
+    BOOST_CHECK(
+      !has_entity_throttle_metric("client_id", "franz-go", "produce_quota"));
+}
+
+// A produce throttle registers the per-entity series and records the
+// entity's throughput; a later produce that does not throttle (probe already
+// exists) keeps accumulating it.
+SEASTAR_THREAD_TEST_CASE(per_entity_produce_records_throughput) {
+    set_config([](config::configuration& conf) {
+        conf.kafka_per_entity_quota_metrics.set_value(true);
+    }).get();
+
+    fixture f;
+
+    auto default_values = entity_value{.producer_byte_rate = 100};
+    f.quota_store.local().set_quota(default_key, default_values);
+
+    auto& qm = f.sqm.local();
+    const auto now = quota_manager::clock::now();
+
+    produce_until_throttled(qm, now);
+
+    BOOST_CHECK(
+      has_entity_throttle_metric("client_id", "franz-go", "produce_quota"));
+
+    auto throttle_ms = entity_throttle_time_ms(
+      "client_id", "franz-go", "produce_quota");
+    BOOST_REQUIRE(throttle_ms.has_value());
+    BOOST_CHECK(*throttle_ms > 0);
+
+    auto throttled = entity_throughput(
+      "client_id", "franz-go", "produce_quota");
+    BOOST_REQUIRE(throttled.has_value());
+    BOOST_CHECK(*throttled > 0);
+
+    // Far enough in the future that the rate window has fully replenished, so
+    // this produce is not throttled but still records throughput because the
+    // probe already exists (the else-if branch).
+    const auto later = now + 1h;
+    auto later_delay
+      = qm.record_produce_tp_and_throttle(user, cid, 50, later).get();
+    BOOST_CHECK_EQUAL(later_delay, quota_manager::clock::duration::zero());
+
+    auto after = entity_throughput("client_id", "franz-go", "produce_quota");
+    BOOST_REQUIRE(after.has_value());
+    BOOST_CHECK_EQUAL(*after - *throttled, 50);
+
+    set_config([](config::configuration& conf) {
+        conf.kafka_per_entity_quota_metrics.set_value(false);
+    }).get();
+}
+
+// Once a fetch throttle has created the probe, record_fetch_tp accumulates the
+// entity's fetch throughput.
+SEASTAR_THREAD_TEST_CASE(per_entity_fetch_records_throughput) {
+    set_config([](config::configuration& conf) {
+        conf.kafka_per_entity_quota_metrics.set_value(true);
+    }).get();
+
+    fixture f;
+
+    auto default_values = entity_value{.consumer_byte_rate = 100};
+    f.quota_store.local().set_quota(default_key, default_values);
+
+    auto& qm = f.sqm.local();
+    const auto now = quota_manager::clock::now();
+
+    qm.record_fetch_tp(user, cid, 10000, now).get();
+    quota_manager::clock::duration delay;
+    tests::cooperative_spin_wait_with_timeout(
+      5s,
+      [now, &qm, &delay](this auto) -> ss::future<bool> {
+          delay = co_await qm.throttle_fetch_tp(user, cid, now);
+          co_return delay > quota_manager::clock::duration::zero();
+      })
+      .get();
+
+    BOOST_REQUIRE(
+      has_entity_throttle_metric("client_id", "franz-go", "fetch_quota"));
+    // Bytes recorded before the probe existed are dropped, so the counter
+    // starts at 0 here.
+    auto before
+      = entity_throughput("client_id", "franz-go", "fetch_quota").value_or(0);
+
+    qm.record_fetch_tp(user, cid, 1234, now).get();
+
+    auto after = entity_throughput("client_id", "franz-go", "fetch_quota");
+    BOOST_REQUIRE(after.has_value());
+    BOOST_CHECK_EQUAL(*after - before, 1234);
+
+    set_config([](config::configuration& conf) {
+        conf.kafka_per_entity_quota_metrics.set_value(false);
+    }).get();
+}
+
+// A throttled partition-mutation request registers the per-entity series for
+// the partition_mutation_quota type and records the entity's throttle time and
+// mutation count (throughput is in mutations, not bytes, for this quota type).
+SEASTAR_THREAD_TEST_CASE(per_entity_partition_mutations_record_throughput) {
+    set_config([](config::configuration& conf) {
+        conf.kafka_per_entity_quota_metrics.set_value(true);
+    }).get();
+
+    fixture f;
+
+    f.quota_store.local().set_quota(
+      default_key, entity_value{.controller_mutation_rate = 100});
+
+    auto& qm = f.sqm.local();
+    const auto now = quota_manager::clock::now();
+    mutate_until_throttled(qm, now);
+
+    BOOST_CHECK(has_entity_throttle_metric(
+      "client_id", "franz-go", "partition_mutation_quota"));
+
+    auto throttle_ms = entity_throttle_time_ms(
+      "client_id", "franz-go", "partition_mutation_quota");
+    BOOST_REQUIRE(throttle_ms.has_value());
+    BOOST_CHECK(*throttle_ms > 0);
+
+    auto throttled = entity_throughput(
+      "client_id", "franz-go", "partition_mutation_quota");
+    BOOST_REQUIRE(throttled.has_value());
+    BOOST_CHECK(*throttled > 0);
+
+    // Far enough in the future that the rate window has fully replenished, so
+    // this mutation is not throttled but still records throughput because the
+    // probe already exists (the else branch).
+    const auto later = now + 1h;
+    auto later_delay = qm.record_partition_mutations(user, cid, 5, later).get();
+    BOOST_CHECK_EQUAL(later_delay, 0ms);
+
+    auto after = entity_throughput(
+      "client_id", "franz-go", "partition_mutation_quota");
+    BOOST_REQUIRE(after.has_value());
+    BOOST_CHECK_EQUAL(*after - *throttled, 5);
+
+    set_config([](config::configuration& conf) {
+        conf.kafka_per_entity_quota_metrics.set_value(false);
+    }).get();
+}
+
+// A user-scoped quota produces a k_user tracker key, labelled with the user in
+// quota_user and quota_type=produce_quota.
+SEASTAR_THREAD_TEST_CASE(per_entity_user_quota_labels) {
+    set_config([](config::configuration& conf) {
+        conf.kafka_per_entity_quota_metrics.set_value(true);
+    }).get();
+
+    fixture f;
+
+    f.quota_store.local().set_quota(
+      entity_key{entity_key::user_match{user}},
+      entity_value{.producer_byte_rate = 100});
+
+    auto& qm = f.sqm.local();
+    produce_until_throttled(qm, quota_manager::clock::now());
+
+    BOOST_CHECK(has_entity_throttle_metric("user", user, "produce_quota"));
+
+    set_config([](config::configuration& conf) {
+        conf.kafka_per_entity_quota_metrics.set_value(false);
+    }).get();
+}
+
+// A client-id-prefix (group) quota produces a k_group_name tracker key,
+// labelled with the prefix in quota_group_name and quota_type=produce_quota.
+SEASTAR_THREAD_TEST_CASE(per_entity_group_quota_labels) {
+    set_config([](config::configuration& conf) {
+        conf.kafka_per_entity_quota_metrics.set_value(true);
+    }).get();
+
+    fixture f;
+
+    f.quota_store.local().set_quota(
+      franz_go_key, entity_value{.producer_byte_rate = 100});
+
+    auto& qm = f.sqm.local();
+    produce_until_throttled(qm, quota_manager::clock::now());
+
+    BOOST_CHECK(
+      has_entity_throttle_metric("group_name", "franz-go", "produce_quota"));
+
+    set_config([](config::configuration& conf) {
+        conf.kafka_per_entity_quota_metrics.set_value(false);
+    }).get();
+}
+
+// A (user, client-id) quota produces a pair tracker key carrying both the
+// quota_user and quota_client_id labels - the case the old single-value label
+// format could collide on. find_metric_value matches the labels exactly.
+SEASTAR_THREAD_TEST_CASE(per_entity_user_client_id_quota_labels) {
+    set_config([](config::configuration& conf) {
+        conf.kafka_per_entity_quota_metrics.set_value(true);
+    }).get();
+
+    fixture f;
+
+    f.quota_store.local().set_quota(
+      entity_key{
+        entity_key::user_match{user}, entity_key::client_id_match{cid}},
+      entity_value{.producer_byte_rate = 100});
+
+    auto& qm = f.sqm.local();
+    produce_until_throttled(qm, quota_manager::clock::now());
+
+    auto series = test_utils::find_metric_value<uint64_t>(
+      "kafka_quotas_client_quota_throughput_by_entity",
+      ss::metrics::default_handle(),
+      {{"redpanda_quota_user", user},
+       {"redpanda_quota_client_id", cid},
+       {"redpanda_quota_type", "produce_quota"}});
+    BOOST_CHECK(series.has_value());
+
+    set_config([](config::configuration& conf) {
+        conf.kafka_per_entity_quota_metrics.set_value(false);
+    }).get();
+}
+
+// A (user, client-id-prefix) quota produces a pair tracker key carrying both
+// the quota_user and quota_group_name labels.
+SEASTAR_THREAD_TEST_CASE(per_entity_user_group_quota_labels) {
+    set_config([](config::configuration& conf) {
+        conf.kafka_per_entity_quota_metrics.set_value(true);
+    }).get();
+
+    fixture f;
+
+    f.quota_store.local().set_quota(
+      entity_key{
+        entity_key::user_match{user},
+        entity_key::client_id_prefix_match{"franz-go"}},
+      entity_value{.producer_byte_rate = 100});
+
+    auto& qm = f.sqm.local();
+    produce_until_throttled(qm, quota_manager::clock::now());
+
+    auto series = test_utils::find_metric_value<uint64_t>(
+      "kafka_quotas_client_quota_throughput_by_entity",
+      ss::metrics::default_handle(),
+      {{"redpanda_quota_user", user},
+       {"redpanda_quota_group_name", "franz-go"},
+       {"redpanda_quota_type", "produce_quota"}});
+    BOOST_CHECK(series.has_value());
+
+    set_config([](config::configuration& conf) {
+        conf.kafka_per_entity_quota_metrics.set_value(false);
+    }).get();
+}
+
 } // namespace kafka


### PR DESCRIPTION
Quota throttling was previously only observable via TRACE-level logging
in `quota_manager`, which is not usable in production - an operator could
see that *some* entity was being throttled but not *which* one or how
much throughput it was driving.

This adds two per-entity quota metrics so operators can answer "entity X
is being throttled and is pushing Y bytes/s":

  - `client_quota_throttle_time_ms_by_entity` (counter, total ms)
  - `client_quota_throughput_by_entity` (counter; bytes for produce/fetch
    quotas, partition mutations for partition-mutation quotas)

Both cover produce, fetch and partition-mutation quotas, and live under
the existing `kafka:quotas` metric group. They are labeled with the quota
identity components from the `tracker_key` - `quota_user`,
`quota_client_id`, `quota_group_name` - each emitted as its own label and
only when present, so distinct keys never collide into one series and no
separate discriminator label is needed. A `quota_type` label
(produce/fetch/partition_mutation) keeps the series of a single identity
separate, since one tracker_key can be shared across quota types that are
tracked and rate limited independently.

The throttle-time metric is a counter of total throttling delay in
milliseconds, mirroring Kafka's `ThrottleTimeMs`, rather than a histogram,
to keep a single series per entity.

To keep cardinality bounded:
  - an entity's metric series are registered lazily, only once it is
    actually throttled (`capped_delay > 0`);
  - they are torn down by the existing quota GC after the entity goes
    idle, and immediately when the feature is disabled;
  - the whole feature is gated behind the new
    `kafka_per_entity_quota_metrics` cluster config (default `false`, no
    restart required).

Throughput is recorded on every request once an entity has been throttled
(not only on throttled requests), so `rate()` reflects the entity's actual
throughput.

## Backports Required


- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Features

* Added opt-in per-entity Kafka quota metrics. Set the
  `kafka_per_entity_quota_metrics` cluster config to `true` (default
  `false`, no restart) to expose
  `redpanda_kafka_quotas_client_quota_throttle_time_ms_by_entity` (total
  throttling delay in milliseconds) and
  `redpanda_kafka_quotas_client_quota_throughput_by_entity` (bytes for
  produce/fetch quotas, partition mutations for partition-mutation
  quotas), both counters labeled per entity via `quota_user`/
  `quota_client_id`/`quota_group_name` plus a `quota_type` label
  (`produce`/`fetch`/`partition_mutation`) that separates the series of a
  shared identity. Series are registered only while an entity is actively
  throttled and removed after the quota GC window; the config is opt-in
  because of the cardinality and performance implications.