### PR TITLE
rpk: add k8s managed plugin command (rpk k8s) [K8S-851]

### DIFF
--- a/src/go/rpk/pkg/cli/BUILD
+++ b/src/go/rpk/pkg/cli/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//src/go/rpk/pkg/cli/debug",
         "//src/go/rpk/pkg/cli/generate",
         "//src/go/rpk/pkg/cli/group",
+        "//src/go/rpk/pkg/cli/k8s",
         "//src/go/rpk/pkg/cli/plugin",
         "//src/go/rpk/pkg/cli/profile",
         "//src/go/rpk/pkg/cli/registry",

--- a/src/go/rpk/pkg/cli/k8s/BUILD
+++ b/src/go/rpk/pkg/cli/k8s/BUILD
@@ -1,0 +1,42 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "k8s",
+    srcs = [
+        "client.go",
+        "hook.go",
+        "install.go",
+        "k8s.go",
+        "uninstall.go",
+        "upgrade.go",
+    ],
+    importpath = "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/k8s",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/go/rpk/pkg/cobraext",
+        "//src/go/rpk/pkg/config",
+        "//src/go/rpk/pkg/fips",
+        "//src/go/rpk/pkg/osutil",
+        "//src/go/rpk/pkg/out",
+        "//src/go/rpk/pkg/plugin",
+        "//src/go/rpk/pkg/redpanda",
+        "@com_github_spf13_afero//:afero",
+        "@com_github_spf13_cobra//:cobra",
+        "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "k8s_test",
+    srcs = [
+        "hook_test.go",
+        "install_test.go",
+    ],
+    embed = [":k8s"],
+    deps = [
+        "//src/go/rpk/pkg/config",
+        "@com_github_spf13_afero//:afero",
+        "@com_github_spf13_cobra//:cobra",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/src/go/rpk/pkg/cli/k8s/BUILD
+++ b/src/go/rpk/pkg/cli/k8s/BUILD
@@ -31,10 +31,12 @@ go_test(
     srcs = [
         "hook_test.go",
         "install_test.go",
+        "shadow_test.go",
     ],
     embed = [":k8s"],
     deps = [
         "//src/go/rpk/pkg/config",
+        "//src/go/rpk/pkg/plugin",
         "@com_github_spf13_afero//:afero",
         "@com_github_spf13_cobra//:cobra",
         "@com_github_stretchr_testify//require",

--- a/src/go/rpk/pkg/cli/k8s/client.go
+++ b/src/go/rpk/pkg/cli/k8s/client.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package k8s
+
+import "github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
+
+// pluginSlug is the on-disk + manifest-path identifier for the rpk k8s
+// plugin: the binary lands at ~/.local/bin/.rpk.managed-k8s and the manifest
+// lives at <repo>/k8s/manifest.json.
+const (
+	pluginSlug  = "k8s"
+	displayName = "Redpanda Kubernetes plugin"
+)
+
+func newRepoClient() (*plugin.RepoClient, error) {
+	return plugin.NewRepoClient(pluginSlug, displayName)
+}

--- a/src/go/rpk/pkg/cli/k8s/hook.go
+++ b/src/go/rpk/pkg/cli/k8s/hook.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package k8s
+
+import (
+	"slices"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cobraext"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+// parseFlags splits args into plugin args + rpk-global flags consumed by rpk,
+// parses the rpk-global flags so the logger and config loader pick them up,
+// and forwards --help to the plugin so it can render its own help. The k8s
+// plugin reads kubeconfig itself (kubectl-style), so unlike the ai plugin we
+// inject no cloud token/endpoint.
+func parseFlags(p *config.Params, cmd *cobra.Command, args []string) ([]string, error) {
+	f := cmd.Flags()
+	keepForPlugin, stripForRpk := cobraext.StripFlagset(args, f)
+	if err := f.Parse(stripForRpk); err != nil {
+		return nil, err
+	}
+	zap.ReplaceGlobals(p.BuildLogger())
+
+	if cobraext.LongFlagValue(args, f, "help", "h") == "true" && !slices.Contains(keepForPlugin, "--help") {
+		keepForPlugin = append(keepForPlugin, "--help")
+	}
+	return keepForPlugin, nil
+}

--- a/src/go/rpk/pkg/cli/k8s/hook_test.go
+++ b/src/go/rpk/pkg/cli/k8s/hook_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package k8s
+
+import (
+	"testing"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFlags_StripsRpkGlobals(t *testing.T) {
+	root := &cobra.Command{Use: "rpk"}
+	pf := root.PersistentFlags()
+	pf.String("config", "", "")
+	pf.String("profile", "", "")
+	pf.StringArrayP("config-opt", "X", nil, "")
+	pf.BoolP("verbose", "v", false, "")
+
+	var got []string
+	var gotErr error
+	k8sCmd := &cobra.Command{
+		Use:                "k8s",
+		DisableFlagParsing: true,
+		Args:               cobra.MinimumNArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			got, gotErr = parseFlags(new(config.Params), cmd, args)
+		},
+	}
+	k8sCmd.Flags().BoolP("help", "h", false, "")
+	root.AddCommand(k8sCmd)
+
+	root.SetArgs([]string{"k8s", "--config", "/foo", "-X", "k=v", "multicluster", "status", "--kubeconfig=/kc"})
+	require.NoError(t, root.Execute())
+	require.NoError(t, gotErr)
+	require.Equal(t, []string{"multicluster", "status", "--kubeconfig=/kc"}, got)
+}

--- a/src/go/rpk/pkg/cli/k8s/install.go
+++ b/src/go/rpk/pkg/cli/k8s/install.go
@@ -57,6 +57,14 @@ You may force the installation using the --force flag.
 			out.MaybeDie(err, "unable to install the rpk k8s plugin: %v; if running in an air-gapped environment you may install it manually", err)
 
 			fmt.Printf("Redpanda Kubernetes plugin %v successfully installed.\n", installedVersion)
+
+			// The managed binary is written as .rpk.managed-k8s, which does not
+			// replace a self-managed .rpk-k8s. If such a copy exists it keeps
+			// winning resolution, so `rpk k8s` would run the stale binary
+			// despite this "successfully installed" message — warn the user.
+			if shadow, shadowed := shadowingSelfManaged(fs); shadowed {
+				fmt.Printf("WARNING: a self-managed Redpanda Kubernetes plugin at %q shadows the version just installed; 'rpk k8s' will keep using it. Remove it (e.g. 'rpk k8s uninstall --force', or delete %q) to use the rpk-managed version.\n", shadow, shadow)
+			}
 		},
 	}
 	cmd.Flags().BoolVar(&force, "force", false, "Force install of the Redpanda Kubernetes plugin")
@@ -127,6 +135,19 @@ func validateVersion(version string) error {
 		return fmt.Errorf("provided version %q is not valid. Ensure it is either 'latest' or it follows the format MAJOR.MINOR.PATCH (e.g., 25.3.5)", version)
 	}
 	return nil
+}
+
+// shadowingSelfManaged reports the path of a self-managed k8s plugin that
+// shadows the rpk-managed binary, if any. The managed binary is written as
+// .rpk.managed-k8s; a self-managed .rpk-k8s in the same directory sorts first
+// and therefore wins resolution, so callers can warn that the freshly
+// installed managed binary will not actually be the one rpk executes.
+func shadowingSelfManaged(fs afero.Fs) (string, bool) {
+	k, ok := plugin.ListPlugins(fs, plugin.UserPaths()).Find(pluginSlug)
+	if !ok || k.Managed {
+		return "", false
+	}
+	return k.Path, true
 }
 
 // maybeExitFIPS exits with a clear error if FIPS is enabled; the rpk k8s

--- a/src/go/rpk/pkg/cli/k8s/install.go
+++ b/src/go/rpk/pkg/cli/k8s/install.go
@@ -1,0 +1,138 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/fips"
+	rpkos "github.com/redpanda-data/redpanda/src/go/rpk/pkg/osutil"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+func installCommand(fs afero.Fs) *cobra.Command {
+	var (
+		version string
+		force   bool
+	)
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Install the Redpanda Kubernetes plugin",
+		Long: `Install the Redpanda Kubernetes plugin.
+
+This command installs the latest version by default.
+
+Alternatively, you may specify a version using the --plugin-version flag.
+
+You may force the installation using the --force flag.
+`,
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
+			maybeExitFIPS()
+			version = strings.ToLower(version)
+			err := validateVersion(version)
+			out.MaybeDieErr(err)
+			_, installed := plugin.ListPlugins(fs, plugin.UserPaths()).Find(pluginSlug)
+			if installed && !force {
+				if version != "latest" {
+					out.Exit("The Redpanda Kubernetes plugin is already installed. Use --force to force installation, or delete the current version with 'rpk k8s uninstall' first")
+				}
+				out.Exit("The Redpanda Kubernetes plugin is already installed.\nIf you want to upgrade to the latest version, please run 'rpk k8s upgrade'")
+			}
+			_, installedVersion, err := installK8sPlugin(cmd.Context(), fs, version)
+			out.MaybeDie(err, "unable to install the rpk k8s plugin: %v; if running in an air-gapped environment you may install it manually", err)
+
+			fmt.Printf("Redpanda Kubernetes plugin %v successfully installed.\n", installedVersion)
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "Force install of the Redpanda Kubernetes plugin")
+	cmd.Flags().StringVar(&version, "plugin-version", "latest", "Plugin version to install (e.g. 25.3.5)")
+	return cmd
+}
+
+func installK8sPlugin(ctx context.Context, fs afero.Fs, version string) (path, installedVersion string, err error) {
+	pluginDir, err := plugin.DefaultBinPath()
+	if err != nil {
+		return "", "", fmt.Errorf("unable to determine plugin default path: %v", err)
+	}
+	art, ver, err := getK8sPluginArtifact(ctx, version)
+	if err != nil {
+		return "", "", err
+	}
+	path, err = downloadAndInstallK8sPlugin(ctx, fs, pluginDir, art.Path, art.Sha256)
+	return path, ver, err
+}
+
+func getK8sPluginArtifact(ctx context.Context, version string) (plugin.RepoArtifact, string, error) {
+	plCl, err := newRepoClient()
+	if err != nil {
+		return plugin.RepoArtifact{}, "", err
+	}
+	manifest, err := plCl.Manifest(ctx)
+	if err != nil {
+		return plugin.RepoArtifact{}, "", err
+	}
+	if version == "latest" || version == "" {
+		return manifest.LatestArtifact(displayName)
+	}
+	art, err := manifest.ArtifactVersion(displayName, version)
+	if err != nil {
+		return plugin.RepoArtifact{}, "", err
+	}
+	return art, version, nil
+}
+
+func downloadAndInstallK8sPlugin(ctx context.Context, fs afero.Fs, installPath, downloadURL, expShaPrefix string) (string, error) {
+	bin, err := plugin.Download(ctx, downloadURL, true, expShaPrefix)
+	if err != nil {
+		return "", fmt.Errorf("unable to download the Redpanda Kubernetes plugin from %q: %v", downloadURL, err)
+	}
+	if exists, _ := afero.DirExists(fs, installPath); !exists {
+		if rpkos.IsRunningSudo() {
+			return "", fmt.Errorf("detected rpk is running with sudo; please execute this command without sudo to avoid saving the plugin as a root owned binary in %s", installPath)
+		}
+		if err := fs.MkdirAll(installPath, 0o755); err != nil {
+			return "", fmt.Errorf("unable to create plugin directory %s: %v", installPath, err)
+		}
+	}
+	zap.L().Sugar().Debugf("writing rpk k8s plugin to %v", installPath)
+	path, err := plugin.WriteBinary(fs, pluginSlug, installPath, bin, false, true)
+	if err != nil {
+		return "", fmt.Errorf("unable to write rpk k8s plugin: %v", err)
+	}
+	return path, nil
+}
+
+// validateVersion accepts 'latest' or a MAJOR.MINOR.PATCH prefix (optionally
+// v-prefixed); the manifest is the source of truth for what is published.
+func validateVersion(version string) error {
+	if version == "latest" {
+		return nil
+	}
+	if !regexp.MustCompile(`^v?\d{1,2}\.\d{1,2}\.\d{1,2}`).MatchString(version) {
+		return fmt.Errorf("provided version %q is not valid. Ensure it is either 'latest' or it follows the format MAJOR.MINOR.PATCH (e.g., 25.3.5)", version)
+	}
+	return nil
+}
+
+// maybeExitFIPS exits with a clear error if FIPS is enabled; the rpk k8s
+// plugin does not yet ship a FIPS build (tracked separately, see K8S-851).
+func maybeExitFIPS() {
+	if fips.IsEnabled() {
+		out.Die("the Redpanda Kubernetes plugin is not yet available in FIPS mode")
+	}
+}

--- a/src/go/rpk/pkg/cli/k8s/install_test.go
+++ b/src/go/rpk/pkg/cli/k8s/install_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package k8s
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func fakeK8sTarGz(t *testing.T, inner []byte) ([]byte, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "rpk-k8s", Mode: 0o755, Size: int64(len(inner))}))
+	_, err := tw.Write(inner)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+	sum := sha256.Sum256(inner)
+	return buf.Bytes(), hex.EncodeToString(sum[:])
+}
+
+func installServer(t *testing.T, tarGz []byte, sha string) *httptest.Server {
+	t.Helper()
+	osArch := runtime.GOOS + "-" + runtime.GOARCH
+	mux := http.NewServeMux()
+	mux.HandleFunc("/k8s.tar.gz", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		w.Write(tarGz)
+	})
+	var manifestBody string
+	mux.HandleFunc("/k8s/manifest.json", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, manifestBody)
+	})
+	ts := httptest.NewServer(mux)
+	manifestBody = fmt.Sprintf(`{
+  "archives": [{
+    "version": "25.3.5",
+    "is_latest": true,
+    "artifacts": {"%s": {"path": "%s/k8s.tar.gz", "sha256": "%s"}}
+  }]
+}`, osArch, ts.URL, sha)
+	return ts
+}
+
+func TestInstallK8s_Download(t *testing.T) {
+	t.Setenv("HOME", "/home/testuser")
+	innerBin := []byte("fake-rpk-k8s-binary")
+	tarGz, sha := fakeK8sTarGz(t, innerBin)
+	ts := installServer(t, tarGz, sha)
+	defer ts.Close()
+	t.Setenv("RPK_PLUGIN_REPOSITORY", ts.URL)
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/home/testuser/.local/bin", 0o755))
+
+	path, version, err := installK8sPlugin(t.Context(), fs, "latest")
+	require.NoError(t, err)
+	require.Equal(t, "25.3.5", version)
+	require.Equal(t, "/home/testuser/.local/bin/.rpk.managed-k8s", path)
+
+	got, err := afero.ReadFile(fs, path)
+	require.NoError(t, err)
+	require.Equal(t, innerBin, got)
+}
+
+func TestInstallK8s_SHAMismatch(t *testing.T) {
+	t.Setenv("HOME", "/home/testuser")
+	innerBin := []byte("payload")
+	tarGz, _ := fakeK8sTarGz(t, innerBin)
+	ts := installServer(t, tarGz, "0000000000000000")
+	defer ts.Close()
+	t.Setenv("RPK_PLUGIN_REPOSITORY", ts.URL)
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/home/testuser/.local/bin", 0o755))
+
+	_, _, err := installK8sPlugin(t.Context(), fs, "latest")
+	require.Error(t, err)
+	require.True(t,
+		strings.Contains(err.Error(), "checksum") || strings.Contains(err.Error(), "does not contain expected"),
+		"expected checksum error, got: %v", err)
+}
+
+func TestValidateVersion(t *testing.T) {
+	for _, ok := range []string{"latest", "25.3.5", "v25.3.5", "25.3.5-rc1"} {
+		require.NoError(t, validateVersion(ok), ok)
+	}
+	for _, bad := range []string{"", "abc", "25", "garbage"} {
+		require.Error(t, validateVersion(bad), bad)
+	}
+}

--- a/src/go/rpk/pkg/cli/k8s/k8s.go
+++ b/src/go/rpk/pkg/cli/k8s/k8s.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// Package k8s wires the Redpanda Kubernetes CLI into rpk as a managed plugin.
+// Users interact with it as `rpk k8s ...`; on-disk the binary is the standard
+// rpk managed-plugin layout under ~/.local/bin.
+package k8s
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+func init() {
+	// When a `rpk k8s <subcommand>` managed-plugin leaf is dispatched, strip
+	// rpk global flags before the child process is exec'd. The k8s plugin
+	// reads kubeconfig itself, so no env/cloud injection is required.
+	plugin.RegisterManaged(pluginSlug, []string{"k8s"}, func(cmd *cobra.Command, _ afero.Fs, p *config.Params) *cobra.Command {
+		run := cmd.Run
+		cmd.Run = func(cmd *cobra.Command, args []string) {
+			pluginArgs, err := parseFlags(p, cmd, args)
+			out.MaybeDie(err, "unable to prepare rpk k8s invocation: %v", err)
+			run(cmd, pluginArgs)
+		}
+		return cmd
+	})
+}
+
+// NewCommand returns the top-level `rpk k8s` cobra command. If the plugin is
+// installed, `rpk k8s <sub>` hands off to it; otherwise we auto-install on
+// first subcommand use, matching the rpk ai/connect pattern.
+func NewCommand(fs afero.Fs, p *config.Params, execFn func(string, []string) error) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                "k8s",
+		Short:              "Interact with Redpanda clusters running on Kubernetes",
+		DisableFlagParsing: true,
+		Args:               cobra.MinimumNArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			pluginArgs, err := parseFlags(p, cmd, args)
+			out.MaybeDie(err, "unable to prepare rpk k8s invocation: %v", err)
+
+			k, pluginExists := plugin.ListPlugins(fs, plugin.UserPaths()).Find(pluginSlug)
+
+			var isSubcommand, isVersion bool
+			for _, arg := range pluginArgs {
+				switch {
+				case arg == "--version":
+					isVersion = true
+				case strings.HasPrefix(arg, "--") || strings.HasPrefix(arg, "-"):
+					continue
+				default:
+					isSubcommand = true
+				}
+			}
+			if !pluginExists && isVersion {
+				fmt.Println("cannot get version: the rpk k8s plugin is not installed; run 'rpk k8s install'")
+				return
+			}
+			if !isSubcommand && !isVersion {
+				cmd.Help()
+				return
+			}
+
+			var pluginPath string
+			if !pluginExists {
+				maybeExitFIPS()
+				fmt.Fprintln(os.Stderr, "Downloading latest Redpanda Kubernetes plugin")
+				path, _, err := installK8sPlugin(cmd.Context(), fs, "latest")
+				out.MaybeDie(err, "unable to install the rpk k8s plugin: %v; if running in an air-gapped environment you may install it manually", err)
+				pluginPath = path
+			} else {
+				pluginPath = k.Path
+				if !k.Managed {
+					zap.L().Sugar().Warn("rpk is using a self-managed version of the rpk k8s plugin. If you want rpk to manage it, run 'rpk k8s uninstall && rpk k8s install'. To continue managing it manually, keep using your existing install.")
+				}
+			}
+			zap.L().Debug("executing rpk k8s plugin", zap.String("path", pluginPath), zap.Strings("args", pluginArgs))
+			err = execFn(pluginPath, pluginArgs)
+			out.MaybeDie(err, "unable to execute the rpk k8s plugin: %v", err)
+		},
+	}
+	cmd.AddCommand(
+		installCommand(fs),
+		uninstallCommand(fs),
+		upgradeCommand(fs),
+	)
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/k8s/shadow_test.go
+++ b/src/go/rpk/pkg/cli/k8s/shadow_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package k8s
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func writeExec(t *testing.T, fs afero.Fs, path, contents string) {
+	t.Helper()
+	require.NoError(t, fs.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, afero.WriteFile(fs, path, []byte(contents), 0o755))
+}
+
+// TestResolution_SelfManagedShadowsManaged documents the shadowing the
+// hardening guards against: with both a self-managed .rpk-k8s and the
+// rpk-managed .rpk.managed-k8s in the same directory, the self-managed copy
+// sorts first and wins resolution, demoting the managed binary to a shadow.
+func TestResolution_SelfManagedShadowsManaged(t *testing.T) {
+	t.Setenv("HOME", "/home/testuser")
+	t.Setenv("PATH", "")
+	binDir := "/home/testuser/.local/bin"
+
+	fs := afero.NewMemMapFs()
+	writeExec(t, fs, filepath.Join(binDir, ".rpk-k8s"), "self-managed")
+	writeExec(t, fs, filepath.Join(binDir, ".rpk.managed-k8s"), "managed")
+
+	k, ok := plugin.ListPlugins(fs, plugin.UserPaths()).Find(pluginSlug)
+	require.True(t, ok)
+	require.False(t, k.Managed, "self-managed copy should win resolution")
+	require.Equal(t, filepath.Join(binDir, ".rpk-k8s"), k.Path)
+	require.Contains(t, k.ShadowedPaths, filepath.Join(binDir, ".rpk.managed-k8s"))
+}
+
+// TestShadowingSelfManaged covers the install-time warning predicate: after
+// installing the managed binary, a self-managed copy that shadows it must be
+// reported so the user knows `rpk k8s` will still run the stale binary.
+func TestShadowingSelfManaged(t *testing.T) {
+	t.Setenv("HOME", "/home/testuser")
+	t.Setenv("PATH", "")
+	binDir := "/home/testuser/.local/bin"
+
+	t.Run("self-managed shadows freshly installed managed", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		writeExec(t, fs, filepath.Join(binDir, ".rpk-k8s"), "self-managed")
+		writeExec(t, fs, filepath.Join(binDir, ".rpk.managed-k8s"), "managed")
+
+		path, shadowed := shadowingSelfManaged(fs)
+		require.True(t, shadowed)
+		require.Equal(t, filepath.Join(binDir, ".rpk-k8s"), path)
+	})
+
+	t.Run("only managed present is not shadowed", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		writeExec(t, fs, filepath.Join(binDir, ".rpk.managed-k8s"), "managed")
+
+		_, shadowed := shadowingSelfManaged(fs)
+		require.False(t, shadowed)
+	})
+
+	t.Run("no plugin present is not shadowed", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		_, shadowed := shadowingSelfManaged(fs)
+		require.False(t, shadowed)
+	})
+}
+
+// TestRefuseSelfManaged covers the uninstall guard: rpk refuses to delete a
+// plugin it did not install unless --force is given, but always proceeds for
+// the rpk-managed binary.
+func TestRefuseSelfManaged(t *testing.T) {
+	managed := &plugin.Plugin{Path: "/b/.rpk.managed-k8s", Managed: true}
+	self := &plugin.Plugin{Path: "/b/.rpk-k8s", Managed: false}
+
+	require.Empty(t, refuseSelfManaged(managed, false), "managed plugin removed without --force")
+	require.Empty(t, refuseSelfManaged(managed, true))
+	require.NotEmpty(t, refuseSelfManaged(self, false), "self-managed refused without --force")
+	require.Empty(t, refuseSelfManaged(self, true), "--force overrides the self-managed refusal")
+}

--- a/src/go/rpk/pkg/cli/k8s/uninstall.go
+++ b/src/go/rpk/pkg/cli/k8s/uninstall.go
@@ -10,25 +10,49 @@
 package k8s
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 )
 
 func uninstallCommand(fs afero.Fs) *cobra.Command {
+	var (
+		force           bool
+		includeShadowed bool
+	)
 	cmd := &cobra.Command{
 		Use:   "uninstall",
 		Short: "Uninstall the Redpanda Kubernetes plugin",
-		Args:  cobra.NoArgs,
+		Long: `Uninstall the Redpanda Kubernetes plugin.
+
+By default this removes only the rpk-managed plugin binary
+(~/.local/bin/.rpk.managed-k8s). If the resolved plugin was not installed by
+rpk (a self-managed copy, e.g. one you downloaded or installed via a package
+manager), rpk refuses to remove it unless you pass --force.
+
+If the resolved plugin shadows other k8s plugin copies elsewhere on your PATH,
+those are left in place unless you pass --include-shadowed.
+`,
+		Args: cobra.NoArgs,
 		Run: func(_ *cobra.Command, _ []string) {
 			k, pluginExists := plugin.ListPlugins(fs, plugin.UserPaths()).Find(pluginSlug)
 			if !pluginExists {
 				out.Exit("The Redpanda Kubernetes plugin is not installed!")
 			}
-			ops, anyFailed := k.Uninstall(true)
+
+			if refusal := refuseSelfManaged(k, force); refusal != "" {
+				out.Die("%s", refusal)
+			}
+			if len(k.ShadowedPaths) > 0 && !includeShadowed {
+				zap.L().Sugar().Warnf("The Redpanda Kubernetes plugin shadows %d other copy/copies left in place: %v. Re-run with --include-shadowed to remove them too.", len(k.ShadowedPaths), k.ShadowedPaths)
+			}
+
+			ops, anyFailed := k.Uninstall(includeShadowed)
 			tw := out.NewTable("PATH", "MESSAGE")
 			defer func() {
 				tw.Flush()
@@ -41,5 +65,18 @@ func uninstallCommand(fs afero.Fs) *cobra.Command {
 			}
 		},
 	}
+	cmd.Flags().BoolVar(&force, "force", false, "Remove the plugin even if it was not installed by rpk (self-managed)")
+	cmd.Flags().BoolVar(&includeShadowed, "include-shadowed", false, "Also remove other k8s plugin copies shadowed by the resolved one")
 	return cmd
+}
+
+// refuseSelfManaged returns a non-empty refusal message when the resolved
+// plugin was not installed by rpk and --force was not supplied. rpk should not
+// silently delete a binary it did not install (e.g. a manual rollback copy or
+// a package-managed install).
+func refuseSelfManaged(p *plugin.Plugin, force bool) string {
+	if p.Managed || force {
+		return ""
+	}
+	return fmt.Sprintf("the resolved Redpanda Kubernetes plugin at %q was not installed by rpk (self-managed); refusing to remove it. Re-run with --force to remove it anyway.", p.Path)
 }

--- a/src/go/rpk/pkg/cli/k8s/uninstall.go
+++ b/src/go/rpk/pkg/cli/k8s/uninstall.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package k8s
+
+import (
+	"os"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func uninstallCommand(fs afero.Fs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Uninstall the Redpanda Kubernetes plugin",
+		Args:  cobra.NoArgs,
+		Run: func(_ *cobra.Command, _ []string) {
+			k, pluginExists := plugin.ListPlugins(fs, plugin.UserPaths()).Find(pluginSlug)
+			if !pluginExists {
+				out.Exit("The Redpanda Kubernetes plugin is not installed!")
+			}
+			ops, anyFailed := k.Uninstall(true)
+			tw := out.NewTable("PATH", "MESSAGE")
+			defer func() {
+				tw.Flush()
+				if anyFailed {
+					os.Exit(1)
+				}
+			}()
+			for _, o := range ops {
+				tw.Print(o.Path, o.Message)
+			}
+		},
+	}
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/k8s/upgrade.go
+++ b/src/go/rpk/pkg/cli/k8s/upgrade.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/redpanda"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func upgradeCommand(fs afero.Fs) *cobra.Command {
+	var noConfirm bool
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Upgrade to the latest Redpanda Kubernetes plugin version",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
+			maybeExitFIPS()
+			pluginDir, err := plugin.DefaultBinPath()
+			out.MaybeDie(err, "unable to determine managed plugin path: %v", err)
+			k, pluginExists := plugin.ListPlugins(fs, plugin.UserPaths()).Find(pluginSlug)
+			if !pluginExists {
+				out.Die("unable to find the Redpanda Kubernetes plugin. You may install it running 'rpk k8s install'")
+			}
+			if !k.Managed {
+				out.Die("found a self-managed Redpanda Kubernetes plugin; unfortunately, we cannot upgrade it with this installation. Run 'rpk k8s uninstall && rpk k8s install', or to keep managing it manually, keep using the version you installed")
+			}
+			art, version, err := getK8sPluginArtifact(cmd.Context(), "latest")
+			out.MaybeDieErr(err)
+
+			currentSha, err := plugin.Sha256Path(fs, k.Path)
+			out.MaybeDie(err, "unable to determine the sha256sum of the current Redpanda Kubernetes plugin %q: %v", k.Path, err)
+			if strings.HasPrefix(currentSha, art.Sha256) {
+				out.Exit("Redpanda Kubernetes plugin already up-to-date")
+			}
+			currentVersion, err := k8sPluginVersion(cmd.Context(), k.Path)
+			out.MaybeDie(err, "unable to determine current version of the Redpanda Kubernetes plugin: %v", err)
+
+			if !noConfirm {
+				latestVersion, err := redpanda.VersionFromString(version)
+				out.MaybeDie(err, "unable to parse latest version of the Redpanda Kubernetes plugin: %v", err)
+				if latestVersion.Major > currentVersion.Major {
+					confirmed, err := out.Confirm("Confirm major version upgrade from %v to %v?", currentVersion.String(), latestVersion.String())
+					out.MaybeDie(err, "unable to confirm upgrade: %v", err)
+					if !confirmed {
+						out.Exit("Upgrade canceled.")
+					}
+				}
+			}
+
+			_, err = downloadAndInstallK8sPlugin(cmd.Context(), fs, pluginDir, art.Path, art.Sha256)
+			out.MaybeDieErr(err)
+			fmt.Printf("Redpanda Kubernetes plugin successfully upgraded from %v to the latest version (%v).\n", currentVersion.String(), version)
+		},
+	}
+	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Disable confirmation prompt for major version upgrades")
+	return cmd
+}
+
+// k8sPluginVersion runs the installed plugin with the `version` subcommand and
+// parses the version. The operator-built plugin prints "Version: X.Y.Z".
+func k8sPluginVersion(ctx context.Context, pluginPath string) (redpanda.Version, error) {
+	versionCmd := exec.CommandContext(ctx, pluginPath, "version")
+	var sb strings.Builder
+	versionCmd.Stdout = &sb
+	if err := versionCmd.Run(); err != nil {
+		return redpanda.Version{}, err
+	}
+	var versionStr string
+	for l := range strings.SplitSeq(sb.String(), "\n") {
+		l = strings.TrimSpace(l)
+		if after, ok := strings.CutPrefix(l, "Version: "); ok {
+			versionStr = strings.TrimSpace(after)
+			break
+		}
+	}
+	version, err := redpanda.VersionFromString(strings.TrimSpace(versionStr))
+	if err != nil {
+		return redpanda.Version{}, fmt.Errorf("unable to determine Redpanda Kubernetes plugin version from %q: %v", versionStr, err)
+	}
+	return version, nil
+}

--- a/src/go/rpk/pkg/cli/root.go
+++ b/src/go/rpk/pkg/cli/root.go
@@ -31,6 +31,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/debug"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/generate"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/group"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/k8s"
 	plugincmd "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/plugin"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/profile"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/registry"
@@ -142,6 +143,7 @@ Use --print-tree to emit the full command tree as JSON.`,
 		container.NewCommand(fs, p),
 		check.NewCommand(fs, p, osExec),
 		connect.NewCommand(fs, p, osExec),
+		k8s.NewCommand(fs, p, osExec),
 		profile.NewCommand(fs, p),
 		debug.NewCommand(fs, p),
 		generate.NewCommand(fs, p),


### PR DESCRIPTION
Adds `rpk k8s` as a **managed rpk plugin** (slug `k8s`), modeled on the existing `rpk ai` plugin. Today the Kubernetes CLI ships only inside the redpanda-operator repo; this makes it discoverable and installable straight from `rpk`. On the first `rpk k8s <subcommand>`, rpk downloads the matching binary from `https://rpk-plugins.redpanda.com/k8s/manifest.json`, verifies its sha256, caches it at `~/.local/bin/.rpk.managed-k8s`, and execs it. The binaries + manifest are published by the paired operator PR: redpanda-data/redpanda-operator#1611.

New package `src/go/rpk/pkg/cli/k8s/` (replacing a stale, never-wired `package connect` scaffold):
- `client.go` — slug `k8s`, repo client.
- `k8s.go` — `init()` registers the managed plugin (`plugin.RegisterManaged`); `NewCommand` auto-installs on first subcommand and execs the plugin; adds `install`/`uninstall`/`upgrade`.
- `hook.go` — flag-strip only. Unlike `rpk ai`, the k8s plugin reads kubeconfig itself (kubectl-style), so **no** cloud token/endpoint/env is injected.
- `install.go` / `upgrade.go` / `uninstall.go` — lifecycle: manifest lookup, download+verify, `--plugin-version`, `--force`, `--no-confirm`. FIPS is gated (no FIPS build yet; tracked separately under K8S-851).
- Wired into `root.go`; BUILD files added.

Pairs with redpanda-data/redpanda-operator#1611. Refs K8S-851.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## UX Changes

* New top-level command `rpk k8s` for interacting with Redpanda clusters on Kubernetes. The plugin binary is downloaded and managed automatically on first use; it can also be managed explicitly with `rpk k8s install` (`--plugin-version`, `--force`), `rpk k8s upgrade` (`--no-confirm`), and `rpk k8s uninstall`.
* The plugin's own subcommands (e.g. `rpk k8s multicluster ...`, `rpk k8s version`) are provided by the downloaded binary.
* Not available on FIPS builds of rpk: `rpk k8s install` exits with a clear "not yet available in FIPS mode" message.

## Release Notes

### Features

* Add `rpk k8s`, a managed plugin for interacting with Redpanda clusters running on Kubernetes. On first use rpk auto-downloads, checksum-verifies, and caches the plugin from the Redpanda plugin repository; manage it explicitly with `rpk k8s install` / `upgrade` / `uninstall`.