### PR TITLE
rpk: report active mode when 'redpanda mode' runs without an argument

### DIFF
--- a/src/go/rpk/pkg/cli/redpanda/mode.go
+++ b/src/go/rpk/pkg/cli/redpanda/mode.go
@@ -85,7 +85,7 @@ This command allows you to set one of the following modes: Development,
 Production, or Recovery.
 
 Running the command without a MODE argument prints the mode that is currently
-active in your redpanda.yaml.
+set in your redpanda.yaml.
 
 PRODUCTION
 

--- a/src/go/rpk/pkg/cli/redpanda/mode.go
+++ b/src/go/rpk/pkg/cli/redpanda/mode.go
@@ -24,9 +24,9 @@ import (
 func NewModeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mode [MODE]",
-		Short: "Enable a default configuration mode",
+		Short: "Enable or display the configuration mode",
 		Long:  modeHelpText,
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		ValidArgsFunction: func(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			// We complete "dev" and "prod", but if the user is typing
 			// the full word, we switch to completing that.
@@ -47,6 +47,14 @@ func NewModeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			return complete, cobra.ShellCompDirectiveDefault
 		},
 		Run: func(_ *cobra.Command, args []string) {
+			// With no argument we report the currently active mode
+			// instead of changing it.
+			if len(args) == 0 {
+				mode, err := currentMode(fs, p)
+				out.MaybeDieErr(err)
+				fmt.Printf("Current mode: %q.\n", mode)
+				return
+			}
 			err := executeMode(fs, p, args[0])
 			out.MaybeDieErr(err)
 			fmt.Printf("Successfully set mode to %q.\n", args[0])
@@ -63,10 +71,21 @@ func executeMode(fs afero.Fs, p *config.Params, mode string) error {
 	return cfg.SetMode(fs, mode)
 }
 
-const modeHelpText = `Enable a default configuration mode
+func currentMode(fs afero.Fs, p *config.Params) (string, error) {
+	cfg, err := p.Load(fs)
+	if err != nil {
+		return "", fmt.Errorf("rpk unable to load config: %v", err)
+	}
+	return cfg.ActualRedpandaYamlOrDefaults().Mode(), nil
+}
+
+const modeHelpText = `Enable or display the configuration mode
 
 This command allows you to set one of the following modes: Development,
 Production, or Recovery.
+
+Running the command without a MODE argument prints the mode that is currently
+active in your redpanda.yaml.
 
 PRODUCTION
 

--- a/src/go/rpk/pkg/cli/redpanda/mode_test.go
+++ b/src/go/rpk/pkg/cli/redpanda/mode_test.go
@@ -46,6 +46,30 @@ func fillRpkNodeConfig(path, mode string) *config.RedpandaYaml {
 	return y
 }
 
+func TestCurrentMode(t *testing.T) {
+	configPath := "/etc/redpanda/redpanda.yaml"
+	tests := []struct {
+		name string
+		mode string
+		exp  string
+	}{
+		{name: "reports prod", mode: config.ModeProd, exp: config.ModeProd},
+		{name: "reports dev", mode: config.ModeDev, exp: config.ModeDev},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			bs, err := yaml.Marshal(fillRpkNodeConfig(configPath, tt.mode))
+			require.NoError(t, err)
+			require.NoError(t, afero.WriteFile(fs, configPath, bs, 0o644))
+
+			got, err := currentMode(fs, new(config.Params))
+			require.NoError(t, err)
+			require.Equal(t, tt.exp, got)
+		})
+	}
+}
+
 func TestModeCommand(t *testing.T) {
 	configPath := "/etc/redpanda/redpanda.yaml"
 	tests := []struct {

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -225,6 +225,21 @@ const (
 	ModeRecovery = "recovery"
 )
 
+// Mode returns the configuration mode that is currently active in the given
+// redpanda.yaml node configuration. Recovery takes precedence because it can be
+// enabled on top of dev or prod; otherwise the mode is dev or prod depending on
+// whether developer_mode is set.
+func (y *RedpandaYaml) Mode() string {
+	switch {
+	case y.Redpanda.RecoveryModeEnabled:
+		return ModeRecovery
+	case y.Redpanda.DeveloperMode:
+		return ModeDev
+	default:
+		return ModeProd
+	}
+}
+
 func (c *Config) SetMode(fs afero.Fs, mode string) error {
 	yRedpanda := c.ActualRedpandaYamlOrDefaults()
 	switch {

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -768,6 +768,27 @@ schema_registry: {}
 	}
 }
 
+func TestMode(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		developer bool
+		recovery  bool
+		exp       string
+	}{
+		{name: "prod by default", exp: ModeProd},
+		{name: "developer_mode reports dev", developer: true, exp: ModeDev},
+		{name: "recovery reports recovery", recovery: true, exp: ModeRecovery},
+		{name: "recovery takes precedence over dev", developer: true, recovery: true, exp: ModeRecovery},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			y := DevDefault()
+			y.Redpanda.DeveloperMode = tt.developer
+			y.Redpanda.RecoveryModeEnabled = tt.recovery
+			require.Equal(t, tt.exp, y.Mode())
+		})
+	}
+}
+
 func TestSetMode(t *testing.T) {
 	fillRpkNodeConfig := func(mode string) func() *RedpandaYaml {
 		return func() *RedpandaYaml {


### PR DESCRIPTION
`rpk redpanda mode` previously required a `MODE` argument and could only *set*
the mode. There was no way to ask which mode is currently active, which is
confusing when verifying how a node is configured (the original customer
feedback in the linked issue).

This PR makes the `MODE` argument optional. When it is omitted, the command
prints the mode that is currently active in `redpanda.yaml`, derived from
`recovery_mode_enabled` and `developer_mode` (recovery takes precedence, then
dev, otherwise prod). Setting a mode is unchanged.

```
$ rpk redpanda mode
Current mode: "dev".

$ rpk redpanda mode prod
Successfully set mode to "prod".

$ rpk redpanda mode
Current mode: "prod".
```

The mode derivation is factored into a small `(*RedpandaYaml).Mode()` helper so
it can be unit-tested independently; tests cover the helper and the no-argument
command path.

Fixes #16069

## Backports Required

- [x] none - not a bug fix

## Release Notes

### Improvements

* `rpk redpanda mode` now prints the currently active mode when run without a `MODE` argument.
