### PR TITLE
rpk: add --skip-cluster flag to 'rpk version'

### DIFF
--- a/src/go/rpk/pkg/cli/version/versioncmd/BUILD
+++ b/src/go/rpk/pkg/cli/version/versioncmd/BUILD
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "versioncmd",
@@ -13,5 +13,16 @@ go_library(
         "@com_github_spf13_afero//:afero",
         "@com_github_spf13_cobra//:cobra",
         "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "versioncmd_test",
+    srcs = ["versioncmd_test.go"],
+    deps = [
+        ":versioncmd",
+        "//src/go/rpk/pkg/config",
+        "@com_github_spf13_afero//:afero",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/src/go/rpk/pkg/cli/version/versioncmd/versioncmd.go
+++ b/src/go/rpk/pkg/cli/version/versioncmd/versioncmd.go
@@ -38,18 +38,20 @@ type redpandaVersion struct {
 type redpandaVersions []redpandaVersion
 
 func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var skipCluster bool
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Prints the current rpk and Redpanda version",
 		Long: `Prints the current rpk and Redpanda version.
 
-This command prints the current rpk version and allows you to list the Redpanda 
+This command prints the current rpk version and allows you to list the Redpanda
 version running on each node in your cluster.
 
 To list the Redpanda version of each node in your cluster you may pass the
 Admin API hosts using flags, profile, or environment variables.
 
-To get only the rpk version, use 'rpk --version'.`,
+To print only the rpk version without contacting a cluster, use the
+'--skip-cluster' flag or run 'rpk --version'.`,
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, _ []string) {
 			rv := rpkVersion{
@@ -67,6 +69,13 @@ To get only the rpk version, use 'rpk --version'.`,
 					printClusterVersions(&rows)
 				}
 			}()
+
+			// When --skip-cluster is set we only report the rpk
+			// version and do not reach out to a cluster.
+			if skipCluster {
+				printCV = false
+				return
+			}
 
 			p, err := p.LoadVirtualProfile(fs)
 			if err != nil {
@@ -102,6 +111,7 @@ To get only the rpk version, use 'rpk --version'.`,
 			}
 		},
 	}
+	cmd.Flags().BoolVar(&skipCluster, "skip-cluster", false, "Skip contacting the cluster and only print the rpk version")
 	return cmd
 }
 


### PR DESCRIPTION
`rpk version` prints the rpk version and then reaches out to the cluster over
the Admin API to list each node's Redpanda version. For users who only want to
verify their installed `rpk` version — especially `rpk connect` users who may
not run a Redpanda cluster at all — that connection attempt is unnecessary and
the resulting `Unreachable` cluster output is confusing (the motivation in the
linked issue).

This PR adds a `--skip-cluster` flag that prints only the rpk version and skips
contacting the cluster. The default behaviour is unchanged.

```
$ rpk version --skip-cluster
rpk version: v24.1.4
Git ref:     1a0b1acf74
Build date:  2024-05-29T17:31:07Z
OS/Arch:     darwin/arm64
Go version:  go1.22.2
```

Unlike `rpk --version`, this keeps the full, detailed `rpk version` output while
omitting the cluster section.

Fixes #18715

## Backports Required

- [x] none - not a bug fix

## Release Notes

### Improvements

* `rpk version --skip-cluster` prints only the rpk version without attempting to contact a cluster.
