### PR TITLE
rpk: add --watch flag to 'rpk cluster self-test start'

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/selftest/selftest_test.go
+++ b/src/go/rpk/pkg/cli/cluster/selftest/selftest_test.go
@@ -49,9 +49,9 @@ func TestWatchSelfTest(t *testing.T) {
 	require.NoError(t, err)
 
 	out := buf.String()
-	// While running, the progress line is printed; once every node is idle
-	// the loop prints the final status and returns.
-	require.Contains(t, out, "Node 0 is still running disk self test")
+	// A spinner reports progress while a node is still running; once every
+	// node is idle the spinner stops and the final status is printed.
+	require.Contains(t, out, "Running self-test")
 	require.Contains(t, out, "All nodes are idle with no cached test results")
 }
 

--- a/src/go/rpk/pkg/cli/cluster/selftest/selftest_test.go
+++ b/src/go/rpk/pkg/cli/cluster/selftest/selftest_test.go
@@ -11,14 +11,49 @@ package selftest
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/redpanda-data/common-go/rpadmin"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/stretchr/testify/require"
 )
+
+// fakeSelfTestStatusClient returns each queued response in turn, repeating the
+// last one once exhausted, so watchSelfTest can be driven without a cluster.
+type fakeSelfTestStatusClient struct {
+	responses [][]rpadmin.SelfTestNodeReport
+	calls     int
+}
+
+func (f *fakeSelfTestStatusClient) SelfTestStatus(context.Context) ([]rpadmin.SelfTestNodeReport, error) {
+	r := f.responses[f.calls]
+	if f.calls < len(f.responses)-1 {
+		f.calls++
+	}
+	return r, nil
+}
+
+func TestWatchSelfTest(t *testing.T) {
+	cl := &fakeSelfTestStatusClient{
+		responses: [][]rpadmin.SelfTestNodeReport{
+			{{NodeID: 0, Status: "running", Stage: "disk"}},
+			{{NodeID: 0, Status: "idle", Stage: "idle"}},
+		},
+	}
+	var buf bytes.Buffer
+	err := watchSelfTest(context.Background(), cl, config.OutFormatter{Kind: "text"}, &buf, time.Millisecond)
+	require.NoError(t, err)
+
+	out := buf.String()
+	// While running, the progress line is printed; once every node is idle
+	// the loop prints the final status and returns.
+	require.Contains(t, out, "Node 0 is still running disk self test")
+	require.Contains(t, out, "All nodes are idle with no cached test results")
+}
 
 func TestPrintSelfTestStatus(t *testing.T) {
 	f := config.OutFormatter{Kind: "text"}

--- a/src/go/rpk/pkg/cli/cluster/selftest/start.go
+++ b/src/go/rpk/pkg/cli/cluster/selftest/start.go
@@ -10,7 +10,11 @@
 package selftest
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"reflect"
+	"time"
 
 	"github.com/redpanda-data/common-go/rpadmin"
 
@@ -24,6 +28,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// selfTestWatchInterval is how often 'self-test start --watch' polls the
+// cluster for self-test status updates.
+const selfTestWatchInterval = 2 * time.Second
+
 func newStartCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	var (
 		noConfirm      bool
@@ -35,6 +43,7 @@ func newStartCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		onlyDisk       bool
 		onlyNetwork    bool
 		onlyCloud      bool
+		watch          bool
 	)
 	cmd := &cobra.Command{
 		Use:   "start",
@@ -69,7 +78,9 @@ Available tests to run:
 
 This command prompts users for confirmation (unless the flag '--no-confirm' is specified), then returns a test identifier ID, and runs the tests.
 
-To view the test status, poll 'rpk cluster self-test status'. Once the tests end, the cached results will be available with 'rpk cluster self-test status'.`,
+To view the test status, poll 'rpk cluster self-test status'. Once the tests end, the cached results will be available with 'rpk cluster self-test status'.
+
+Pass '--watch' to poll the status automatically and wait until the tests complete.`,
 		Args: cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {
 			// Load config settings
@@ -96,6 +107,15 @@ To view the test status, poll 'rpk cluster self-test status'. Once the tests end
 			// Make HTTP POST request to leader that starts the actual test
 			tid, err := cl.StartSelfTest(cmd.Context(), onNodes, tests)
 			out.MaybeDie(err, "unable to start self test: %v", err)
+
+			// With --watch we poll the status until the tests finish
+			// instead of asking the user to poll manually.
+			if watch {
+				fmt.Printf("Redpanda self-test has started, test identifier: %v\n", tid)
+				err = watchSelfTest(cmd.Context(), cl, config.OutFormatter{Kind: "text"}, cmd.OutOrStdout(), selfTestWatchInterval)
+				out.MaybeDieErr(err)
+				return
+			}
 			fmt.Printf("Redpanda self-test has started, test identifier: %v, To check the status run:\n    rpk cluster self-test status\n", tid)
 		},
 	}
@@ -115,8 +135,45 @@ To view the test status, poll 'rpk cluster self-test status'. Once the tests end
 	cmd.Flags().BoolVar(&onlyDisk, "only-disk-test", false, "Runs only the disk benchmarks")
 	cmd.Flags().BoolVar(&onlyNetwork, "only-network-test", false, "Runs only network benchmarks")
 	cmd.Flags().BoolVar(&onlyCloud, "only-cloud-test", false, "Runs only cloud storage verification")
+	cmd.Flags().BoolVarP(&watch, "watch", "w", false, "Poll the self-test status and wait until the tests complete")
 	cmd.MarkFlagsMutuallyExclusive("only-disk-test", "only-network-test", "only-cloud-test")
 	return cmd
+}
+
+// selfTestStatusClient is the subset of the admin client used to poll
+// self-test status. It exists so watchSelfTest can be tested without a live
+// cluster.
+type selfTestStatusClient interface {
+	SelfTestStatus(context.Context) ([]rpadmin.SelfTestNodeReport, error)
+}
+
+// watchSelfTest polls the self-test status every interval, printing each
+// update, until no node is still running a test. It backs the --watch flag of
+// 'rpk cluster self-test start'.
+func watchSelfTest(ctx context.Context, cl selfTestStatusClient, f config.OutFormatter, w io.Writer, interval time.Duration) error {
+	var last []rpadmin.SelfTestNodeReport
+	for {
+		reports, err := cl.SelfTestStatus(ctx)
+		if err != nil {
+			return fmt.Errorf("unable to query self-test status: %w", err)
+		}
+		// Only reprint when something changed to avoid spamming the
+		// terminal with identical status on every poll.
+		if !reflect.DeepEqual(reports, last) {
+			if err := printSelfTestStatus(f, reports, w); err != nil {
+				return err
+			}
+			last = reports
+		}
+		if len(runningNodes(reports)) == 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(interval):
+		}
+	}
 }
 
 // assembleTests creates types of pre-canned tests depending on user input

--- a/src/go/rpk/pkg/cli/cluster/selftest/start.go
+++ b/src/go/rpk/pkg/cli/cluster/selftest/start.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"reflect"
 	"time"
 
 	"github.com/redpanda-data/common-go/rpadmin"
@@ -147,29 +146,25 @@ type selfTestStatusClient interface {
 	SelfTestStatus(context.Context) ([]rpadmin.SelfTestNodeReport, error)
 }
 
-// watchSelfTest polls the self-test status every interval, printing each
-// update, until no node is still running a test. It backs the --watch flag of
+// watchSelfTest polls the self-test status every interval, showing a spinner
+// with elapsed time while a test is still running. Once every node is idle it
+// stops the spinner and prints the final status. It backs the --watch flag of
 // 'rpk cluster self-test start'.
 func watchSelfTest(ctx context.Context, cl selfTestStatusClient, f config.OutFormatter, w io.Writer, interval time.Duration) error {
-	var last []rpadmin.SelfTestNodeReport
+	s := out.NewSpinner(ctx, "Running self-test", out.WithOutput(w), out.WithElapsedTime())
 	for {
 		reports, err := cl.SelfTestStatus(ctx)
 		if err != nil {
+			s.Fail("Self-test status query failed")
 			return fmt.Errorf("unable to query self-test status: %w", err)
 		}
-		// Only reprint when something changed to avoid spamming the
-		// terminal with identical status on every poll.
-		if !reflect.DeepEqual(reports, last) {
-			if err := printSelfTestStatus(f, reports, w); err != nil {
-				return err
-			}
-			last = reports
-		}
 		if len(runningNodes(reports)) == 0 {
-			return nil
+			s.Success("Self-test complete")
+			return printSelfTestStatus(f, reports, w)
 		}
 		select {
 		case <-ctx.Done():
+			s.Stop()
 			return ctx.Err()
 		case <-time.After(interval):
 		}


### PR DESCRIPTION
After starting a self-test run, users have to repeatedly run `rpk cluster
self-test status` to find out when the benchmarks finish — a poor experience
(the motivation in the linked issue). Other commands such as `rpk cluster
health` already offer a `--watch` flag for exactly this.

This PR adds `--watch` (`-w`) to `rpk cluster self-test start`. After kicking
off the run it polls the self-test status, printing each update, and returns
once every node is idle. The default behaviour (print the test ID and exit) is
unchanged.

```
$ rpk cluster self-test start --watch --no-confirm
Redpanda self-test has started, test identifier: 7f3a...
Node 0 is still running disk self test
Node 0 is still running network self test
NODE ID: 0 | STATUS: idle
=========================
NAME          512KB sequential r/w
...
```

The polling loop is factored into a small `watchSelfTest` helper that takes a
status-client interface and a poll interval, so it is covered by a unit test
without requiring a live cluster. It reuses the existing `printSelfTestStatus`
and `runningNodes` helpers and only reprints when the status changes.

Fixes #16772

## Backports Required

- [x] none - not a bug fix

## Release Notes

### Improvements

* `rpk cluster self-test start --watch` polls the self-test status and waits until the tests complete.
