### PR TITLE
metrics: trim host_metrics_watcher dual-publish comment

### DIFF
--- a/src/v/metrics/host_metrics_watcher.h
+++ b/src/v/metrics/host_metrics_watcher.h
@@ -162,10 +162,7 @@ private:
     // /proc/net/snmp
     metrics_file_info<snmp_stats> _snmp_stats;
 
-    // Dual handle: every family this watcher registers (host_diskstats_*,
-    // host_netstat_*, host_snmp_*, host_metrics_info, io_queue_config_*) is
-    // published on both /metrics (vectorized_*) and /public_metrics
-    // (redpanda_*). The SLF dashboard consumes the public variants.
+    // Published on both /metrics and /public_metrics for the SLF dashboard.
     metrics::all_metrics_groups _metrics;
 };
 


### PR DESCRIPTION
Follow-up to #30827. [Stephan flagged](https://github.com/redpanda-data/redpanda/pull/30827#discussion_r3430020945) the four-line comment on `_metrics` in `host_metrics_watcher.h` as too verbose. This trims it to a single line, keeping the one non-obvious bit: the families are published on both `/metrics` and `/public_metrics` for the SLF dashboard.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none