### PR TITLE
lsm: chunk cloud reads of larger SST files

### DIFF
--- a/src/v/cloud_io/tests/db_s3_imposter_fixture.cc
+++ b/src/v/cloud_io/tests/db_s3_imposter_fixture.cc
@@ -63,6 +63,13 @@ ss::future<> write_iobuf_to_stream(iobuf buf, ss::output_stream<char> out) {
     co_await out.close();
 }
 
+// Bodies up to this size are inlined into the reply's sstring content,
+// which causes seastar's httpd to set Content-Length automatically.
+// cloud_io::remote::download_stream requires Content-Length, so any test
+// that drives it through this imposter must keep payloads under this cap.
+// Larger bodies are streamed via chunked transfer encoding.
+inline constexpr size_t k_small_response_threshold = 100 * 1024;
+
 } // namespace
 
 // Async HTTP handler backed by the LSM database. Holds references to
@@ -164,8 +171,18 @@ struct db_s3_imposter_fixture::handler : ss::httpd::handler_base {
             result->trim_back(result->size_bytes() - (end - start + 1));
         }
 
-        // Stream the body from the iobuf fragments rather than
-        // linearizing to sstring (which has a 128KiB size limit).
+        repl.set_content_type("xml");
+
+        // For bodies that fit in an sstring, inline them so seastar's httpd
+        // sets Content-Length automatically; download_stream consumers (e.g.
+        // range GETs) require Content-Length and don't accept chunked
+        // transfer encoding. Larger bodies fall through to streaming chunked
+        // encoding -- tests using such payloads must use download_object, not
+        // download_stream.
+        if (result->size_bytes() <= k_small_response_threshold) {
+            repl._content = result->linearize_to_string();
+            co_return;
+        }
         repl.write_body(
           "xml",
           ss::http::body_writer_type([result = std::move(*result)](

--- a/src/v/cloud_io/tests/db_s3_imposter_test.cc
+++ b/src/v/cloud_io/tests/db_s3_imposter_test.cc
@@ -124,6 +124,41 @@ public:
           .get();
     }
 
+    // Downloads via download_stream (rather than download_object), reading
+    // the streamed body to a string. download_stream requires a
+    // Content-Length on the response.
+    std::pair<download_result, ss::sstring> download_via_stream(
+      std::string_view key,
+      std::optional<cloud_storage_clients::http_byte_range> range
+      = std::nullopt) {
+        retry_chain_node rtc(never_abort, 5s, 100ms);
+        ss::sstring out;
+        auto res = remote()
+                     .download_stream(
+                       {.bucket = bucket_name,
+                        .key = object_key(key),
+                        .parent_rtc = rtc},
+                       [&out](
+                         this auto,
+                         uint64_t content_length,
+                         ss::input_stream<char> in) -> ss::future<uint64_t> {
+                           while (true) {
+                               auto buf = co_await in.read();
+                               if (buf.empty()) {
+                                   break;
+                               }
+                               out.append(buf.get(), buf.size());
+                           }
+                           co_await in.close();
+                           co_return content_length;
+                       },
+                       "test-download-stream",
+                       /*acquire_hydration_units=*/true,
+                       range)
+                     .get();
+        return {res, out};
+    }
+
 private:
     std::unique_ptr<scoped_remote> _scoped;
 };
@@ -324,4 +359,22 @@ TEST_F(db_s3_imposter_test, concurrent_open_multipart_uploads) {
     ASSERT_EQ(res_b, download_result::success);
     EXPECT_EQ(content_b.size(), part_size);
     EXPECT_EQ(content_b[0], 'B');
+}
+
+// download_stream needs a Content-Length, which the imposter can only set on
+// its small-body inline path -- see k_small_response_threshold in
+// db_s3_imposter_fixture.cc for why. These keep payloads small to stay on it.
+TEST_F(db_s3_imposter_test, download_stream_whole_object) {
+    ASSERT_EQ(upload("ds/whole", "hello world"), upload_result::success);
+    auto [res, content] = download_via_stream("ds/whole");
+    EXPECT_EQ(res, download_result::success);
+    EXPECT_EQ(content, "hello world");
+}
+
+TEST_F(db_s3_imposter_test, download_stream_byte_range) {
+    ASSERT_EQ(upload("ds/range", "0123456789"), upload_result::success);
+    auto [res, content] = download_via_stream(
+      "ds/range", cloud_storage_clients::http_byte_range{2, 5});
+    EXPECT_EQ(res, download_result::success);
+    EXPECT_EQ(content, "2345");
 }

--- a/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
+++ b/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
@@ -232,16 +232,22 @@ void flush_as_manifest(
   term_state_update_t new_terms) {
     auto domain_prefix = cloud_storage_clients::object_key{
       domain_cloud_prefix(uuid)};
-    auto cloud_db = lsm::database::open(
-                      {.database_epoch = db_epoch},
-                      lsm::io::persistence{
-                        .data = lsm::io::open_cloud_cache_data_persistence(
-                                  cache, remote, bucket, domain_prefix)
-                                  .get(),
-                        .metadata = lsm::io::open_cloud_metadata_persistence(
-                                      remote, bucket, domain_prefix)
-                                      .get()})
-                      .get();
+    auto cloud_db
+      = lsm::database::open(
+          {.database_epoch = db_epoch},
+          lsm::io::persistence{
+            .data = lsm::io::open_cloud_cache_data_persistence(
+                      cache,
+                      remote,
+                      bucket,
+                      domain_prefix,
+                      config::shard_local_cfg()
+                        .cloud_topics_metastore_sst_chunk_size.bind())
+                      .get(),
+            .metadata = lsm::io::open_cloud_metadata_persistence(
+                          remote, bucket, domain_prefix)
+                          .get()})
+          .get();
 
     // Pre-register the object IDs before building the add_objects rows.
     preregister_objects_db_update prereg_update;

--- a/src/v/cloud_topics/level_one/metastore/lsm/replicated_db.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/replicated_db.cc
@@ -115,7 +115,12 @@ replicated_database::open(
 
     auto data_persist_fut = co_await ss::coroutine::as_future(
       lsm::io::open_cloud_cache_data_persistence(
-        cache, remote, bucket, domain_prefix, cloud_io::group_id::metastore));
+        cache,
+        remote,
+        bucket,
+        domain_prefix,
+        config::shard_local_cfg().cloud_topics_metastore_sst_chunk_size.bind(),
+        cloud_io::group_id::metastore));
     if (data_persist_fut.failed()) {
         co_return std::unexpected(wrap_failed_future(
           data_persist_fut.get_exception(), "Failed to open data persistence"));

--- a/src/v/cloud_topics/level_one/metastore/lsm/tests/replicated_db_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/tests/replicated_db_test.cc
@@ -252,7 +252,9 @@ public:
                           &test_cache.local(),
                           &sr->remote.local(),
                           bucket_name,
-                          domain_prefix)
+                          domain_prefix,
+                          config::shard_local_cfg()
+                            .cloud_topics_metastore_sst_chunk_size.bind())
                           .get(),
                 .metadata = lsm::io::open_cloud_metadata_persistence(
                               &sr->remote.local(), bucket_name, domain_prefix)

--- a/src/v/cloud_topics/read_replica/snapshot_manager.cc
+++ b/src/v/cloud_topics/read_replica/snapshot_manager.cc
@@ -138,7 +138,12 @@ ss::future<> database_refresher::open_or_refresh() {
     cloud_storage_clients::object_key domain_prefix{
       domain_cloud_prefix(domain_uuid_)};
     auto data_persist = co_await lsm::io::open_cloud_cache_data_persistence(
-      cache_, remote_, bucket_, domain_prefix, cloud_io::group_id::metastore);
+      cache_,
+      remote_,
+      bucket_,
+      domain_prefix,
+      config::shard_local_cfg().cloud_topics_metastore_sst_chunk_size.bind(),
+      cloud_io::group_id::metastore);
     auto meta_persist = co_await lsm::io::open_cloud_metadata_persistence(
       remote_, bucket_, domain_prefix, cloud_io::group_id::metastore);
     lsm::io::persistence io{

--- a/src/v/cloud_topics/read_replica/tests/db_utils.h
+++ b/src/v/cloud_topics/read_replica/tests/db_utils.h
@@ -17,6 +17,7 @@
 #include "cloud_topics/level_one/metastore/lsm/state_reader.h"
 #include "cloud_topics/level_one/metastore/lsm/state_update.h"
 #include "cloud_topics/level_one/metastore/lsm/write_batch_row.h"
+#include "config/configuration.h"
 #include "container/chunked_hash_map.h"
 #include "lsm/io/cloud_cache_persistence.h"
 #include "lsm/lsm.h"
@@ -49,7 +50,11 @@ inline ss::future<lsm::database*> get_or_create_writer_db(
     cloud_storage_clients::object_key domain_prefix{cloud_prefix};
 
     auto data_persist = co_await lsm::io::open_cloud_cache_data_persistence(
-      cache, remote, bucket, domain_prefix);
+      cache,
+      remote,
+      bucket,
+      domain_prefix,
+      config::shard_local_cfg().cloud_topics_metastore_sst_chunk_size.bind());
     auto meta_persist = co_await lsm::io::open_cloud_metadata_persistence(
       remote, bucket, domain_prefix);
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -5100,6 +5100,18 @@ configuration::configuration()
       {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
       3,
       {.min = 1})
+  , cloud_topics_metastore_sst_chunk_size(
+      *this,
+      "cloud_topics_metastore_sst_chunk_size",
+      "Size of the byte ranges used to read metastore LSM SST files from "
+      "object storage into the local cache. Reads hydrate only the chunks they "
+      "cover, and a read spanning several uncached chunks fetches them in "
+      "parallel. Smaller chunks reduce read and cache amplification for point "
+      "reads; larger chunks reduce request count for scans. Changing the value "
+      "invalidates previously cached chunks.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      24_MiB,
+      {.min = 1_MiB})
   , cloud_topics_produce_write_inflight_limit(
       *this,
       "cloud_topics_produce_write_inflight_limit",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -862,6 +862,7 @@ public:
     property<std::chrono::milliseconds>
       cloud_topics_long_term_file_deletion_delay;
     bounded_property<int32_t> cloud_topics_num_metastore_partitions;
+    bounded_property<size_t> cloud_topics_metastore_sst_chunk_size;
 
     bounded_property<size_t> cloud_topics_produce_write_inflight_limit;
     bounded_property<size_t> cloud_topics_produce_no_pid_concurrency;

--- a/src/v/lsm/block/tests/contents_test.cc
+++ b/src/v/lsm/block/tests/contents_test.cc
@@ -26,7 +26,8 @@ TEST_CORO(Contents, StringView) {
         co_await file->append(b.share());
         co_await file->close();
     }
-    auto file = co_await persistence->open_random_access_reader({});
+    auto file = co_await persistence->open_random_access_reader(
+      {}, b.size_bytes());
     ASSERT_TRUE_CORO(bool(file));
     for (auto offset : std::to_array<size_t>({0, 1, 2, 3, 4, 5, 10, 64_KiB})) {
         auto buf = b.share(offset, b.size_bytes() - offset);
@@ -79,7 +80,8 @@ TEST_CORO(Contents, IobufShare) {
         co_await file->append(b.share());
         co_await file->close();
     }
-    auto file = co_await persistence->open_random_access_reader({});
+    auto file = co_await persistence->open_random_access_reader(
+      {}, b.size_bytes());
     ASSERT_TRUE_CORO(bool(file));
     for (auto offset : std::to_array<size_t>({0, 1, 2, 3, 4, 5, 10, 64_KiB})) {
         auto buf = b.share(offset, b.size_bytes() - offset);

--- a/src/v/lsm/db/table_cache.cc
+++ b/src/v/lsm/db/table_cache.cc
@@ -310,7 +310,8 @@ private:
 
     ss::future<ss::lw_shared_ptr<sst::reader>>
     open_reader(internal::file_handle h, uint64_t file_size) {
-        auto file = co_await _persistence->open_random_access_reader(h);
+        auto file = co_await _persistence->open_random_access_reader(
+          h, file_size);
         if (!file) {
             throw invalid_argument_exception("file for ID {} is not found", h);
         }

--- a/src/v/lsm/db/tests/compaction_task_test.cc
+++ b/src/v/lsm/db/tests/compaction_task_test.cc
@@ -99,8 +99,9 @@ public:
     }
 
     ss::future<lsm::io::optional_pointer<lsm::io::random_access_file_reader>>
-    open_random_access_reader(lsm::internal::file_handle h) override {
-        return _inner->open_random_access_reader(h);
+    open_random_access_reader(
+      lsm::internal::file_handle h, uint64_t file_size) override {
+        return _inner->open_random_access_reader(h, file_size);
     }
 
     ss::future<std::unique_ptr<lsm::io::sequential_file_writer>>

--- a/src/v/lsm/db/tests/impl_test.cc
+++ b/src/v/lsm/db/tests/impl_test.cc
@@ -33,8 +33,8 @@ public:
       : _p(p) {}
 
     ss::future<io::optional_pointer<io::random_access_file_reader>>
-    open_random_access_reader(file_handle h) override {
-        return _p->open_random_access_reader(h);
+    open_random_access_reader(file_handle h, uint64_t file_size) override {
+        return _p->open_random_access_reader(h, file_size);
     }
 
     ss::future<std::unique_ptr<io::sequential_file_writer>>
@@ -84,9 +84,9 @@ public:
       : _underlying(underlying) {}
 
     ss::future<io::optional_pointer<io::random_access_file_reader>>
-    open_random_access_reader(file_handle h) override {
+    open_random_access_reader(file_handle h, uint64_t file_size) override {
         _opened_files.insert(h);
-        return _underlying->open_random_access_reader(h);
+        return _underlying->open_random_access_reader(h, file_size);
     }
 
     ss::future<std::unique_ptr<io::sequential_file_writer>>

--- a/src/v/lsm/io/BUILD
+++ b/src/v/lsm/io/BUILD
@@ -71,6 +71,31 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "chunked_remote_file_reader",
+    srcs = ["chunked_remote_file_reader.cc"],
+    hdrs = ["chunked_remote_file_reader.h"],
+    implementation_deps = [
+        ":file_io",
+        "//src/v/cloud_io:io_result",
+        "//src/v/container:chunked_vector",
+        "//src/v/lsm/core:exceptions",
+        "@fmt",
+    ],
+    deps = [
+        ":persistence",
+        "//src/v/base",
+        "//src/v/bytes:ioarray",
+        "//src/v/cloud_io:cache",
+        "//src/v/cloud_io:remote",
+        "//src/v/cloud_io:scheduler_types",
+        "//src/v/cloud_storage_clients",
+        "//src/v/container:chunked_hash_map",
+        "//src/v/utils:retry_chain_node",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "readahead_file_reader",
     srcs = ["readahead_file_reader.cc"],
     hdrs = ["readahead_file_reader.h"],

--- a/src/v/lsm/io/BUILD
+++ b/src/v/lsm/io/BUILD
@@ -52,9 +52,9 @@ redpanda_cc_library(
     srcs = ["cloud_cache_persistence.cc"],
     hdrs = ["cloud_cache_persistence.h"],
     implementation_deps = [
+        ":chunked_remote_file_reader",
         ":file_io",
         "//src/v/cloud_io:io_result",
-        "//src/v/config",
         "//src/v/lsm/core:exceptions",
         "//src/v/lsm/core/internal:files",
         "//src/v/ssx:future_util",
@@ -66,6 +66,7 @@ redpanda_cc_library(
         "//src/v/cloud_io:cache",
         "//src/v/cloud_io:remote",
         "//src/v/cloud_storage_clients",
+        "//src/v/config",
         "@seastar",
     ],
 )

--- a/src/v/lsm/io/chunked_remote_file_reader.cc
+++ b/src/v/lsm/io/chunked_remote_file_reader.cc
@@ -1,0 +1,342 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "lsm/io/chunked_remote_file_reader.h"
+
+#include "base/vassert.h"
+#include "cloud_io/io_result.h"
+#include "container/chunked_vector.h"
+#include "lsm/core/exceptions.h"
+#include "lsm/io/file_io.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/shared_future.hh>
+#include <seastar/core/when_all.hh>
+
+#include <algorithm>
+#include <exception>
+#include <ranges>
+#include <utility>
+
+namespace lsm::io {
+
+namespace {
+
+// Rethrows an exception from a chunk operation as an lsm io error, mirroring
+// disk_file_reader::read: pass an existing lsm io error through, preserve the
+// error code of a system_error, and wrap anything else.
+[[noreturn]] void rethrow_as_io_error(
+  std::exception_ptr eptr, const chunked_remote_file_reader& self) {
+    try {
+        std::rethrow_exception(eptr);
+    } catch (const std::system_error& err) {
+        throw io_error_exception(
+          err.code(), "io error reading {}: {}", self, err);
+    } catch (const io_error_exception&) {
+        throw;
+    } catch (...) {
+        throw io_error_exception("io error reading {}: {}", self, eptr);
+    }
+}
+
+} // namespace
+
+chunked_remote_file_reader::chunked_remote_file_reader(
+  cloud_io::cache* cache,
+  cloud_io::remote* remote,
+  cloud_storage_clients::bucket_name bucket,
+  cloud_storage_clients::object_key key,
+  std::filesystem::path cache_key_prefix,
+  uint64_t file_size,
+  uint64_t chunk_size,
+  ss::lowres_clock::duration retry_timeout,
+  ss::lowres_clock::duration retry_backoff,
+  ss::abort_source& as,
+  cloud_io::group_id gid)
+  : _cache(cache)
+  , _remote(remote)
+  , _bucket(std::move(bucket))
+  , _key(std::move(key))
+  , _cache_key_prefix(std::move(cache_key_prefix))
+  , _file_size(file_size)
+  , _chunk_size(chunk_size)
+  , _retry_timeout(retry_timeout)
+  , _retry_backoff(retry_backoff)
+  , _as(as)
+  , _gid(gid) {}
+
+chunked_remote_file_reader::~chunked_remote_file_reader() {
+    vassert(
+      _gate.is_closed(),
+      "chunked_remote_file_reader destroyed without close() ({})",
+      _key);
+    vassert(
+      _in_flight.empty(), "in-flight map not empty: {}", _in_flight.size());
+}
+
+ss::future<std::optional<std::unique_ptr<chunked_remote_file_reader>>>
+chunked_remote_file_reader::open(
+  cloud_io::cache* cache,
+  cloud_io::remote* remote,
+  cloud_storage_clients::bucket_name bucket,
+  cloud_storage_clients::object_key key,
+  std::filesystem::path cache_key_prefix,
+  uint64_t file_size,
+  uint64_t chunk_size,
+  ss::lowres_clock::duration retry_timeout,
+  ss::lowres_clock::duration retry_backoff,
+  ss::abort_source& as,
+  cloud_io::group_id gid) {
+    std::unique_ptr<chunked_remote_file_reader> reader(
+      new chunked_remote_file_reader(
+        cache,
+        remote,
+        std::move(bucket),
+        std::move(key),
+        std::move(cache_key_prefix),
+        file_size,
+        chunk_size,
+        retry_timeout,
+        retry_backoff,
+        as,
+        gid));
+
+    // Prove existence by fetching the tail chunk. A common pattern is for SST
+    // readers to read the back of the file (for footers, indexes, filters,
+    // etc), so fetching the tail chunk serves two purposes: confirming object
+    // existence, and warming cache with the back of the file.
+    retry_chain_node rtc(as, retry_timeout, retry_backoff);
+    auto tail_chunk = reader->chunk_for_offset(file_size - 1);
+    auto probe = co_await ss::coroutine::as_future(
+      reader->ensure_chunk_cached(tail_chunk, rtc));
+    if (probe.failed()) {
+        co_await reader->close();
+        rethrow_as_io_error(probe.get_exception(), *reader);
+    }
+    auto handle = std::move(probe).get();
+    if (!handle) {
+        co_await reader->close();
+        co_return std::nullopt;
+    }
+    co_await handle->close();
+    co_return reader;
+}
+
+chunked_remote_file_reader::aligned_chunk
+chunked_remote_file_reader::chunk_for_offset(uint64_t offset) const {
+    if (offset >= _file_size) {
+        throw io_error_exception(
+          "trying to read offset {} of {} in {}", offset, _file_size, _key);
+    }
+
+    const uint64_t head_size = _file_size % _chunk_size;
+    if (offset < head_size) {
+        return {0, head_size};
+    }
+    // Everything past the head is a full chunk on a grid aligned starting at
+    // head_size, bounded by the full file size.
+    const uint64_t start = head_size
+                           + (offset - head_size) / _chunk_size * _chunk_size;
+    const uint64_t end = std::min(start + _chunk_size, _file_size);
+    return {start, end};
+}
+
+std::filesystem::path
+chunked_remote_file_reader::chunk_cache_key(aligned_chunk chunk) const {
+    return _cache_key_prefix / fmt::format("c={}", _chunk_size)
+           / fmt::format("{}", chunk.start);
+}
+
+ss::future<std::optional<ss::file>>
+chunked_remote_file_reader::ensure_chunk_cached(
+  aligned_chunk chunk, retry_chain_node& parent) {
+    auto key = chunk_cache_key(chunk);
+
+    while (true) {
+        if (auto item = co_await _cache->get(key); item.has_value()) {
+            // Already on disk (either from this loop, or a previous read()
+            // call). Return the ss::file so even if the cache evicts it we can
+            // still read.
+            co_return std::move(item->body);
+        }
+        if (auto it = _in_flight.find(chunk.start); it != _in_flight.end()) {
+            auto found_fut = it->second.get_future();
+            // A download is already in flight. Wait for it, then re-open in
+            // the next iteration.
+            if (!co_await std::move(found_fut)) {
+                co_return std::nullopt;
+            }
+        } else {
+            // There isn't an in-flight download; kick one off and publish a
+            // shared future.
+            ss::shared_promise<bool> sp;
+            _in_flight.emplace(chunk.start, sp.get_shared_future());
+            auto fetched = co_await ss::coroutine::as_future(
+              download_chunk(chunk, parent));
+            _in_flight.erase(chunk.start);
+            if (fetched.failed()) {
+                auto eptr = fetched.get_exception();
+                sp.set_exception(eptr);
+                std::rethrow_exception(eptr);
+            }
+            bool found = fetched.get();
+            sp.set_value(found);
+            if (!found) {
+                co_return std::nullopt;
+            }
+        }
+
+        // We've determined the chunk exists in object storage, and should now
+        // exist in the cache -- fallthrough to get() it. With enough cache
+        // churn, we may repeatedly download and miss the cache lookup, so
+        // bound the repetition with a deadline.
+        if (ss::lowres_clock::now() >= parent.get_deadline()) {
+            throw io_error_exception(
+              "chunk {} of {} repeatedly evicted from cache after fetch",
+              chunk.start,
+              _key);
+        }
+    }
+}
+
+ss::future<bool> chunked_remote_file_reader::download_chunk(
+  aligned_chunk chunk, retry_chain_node& parent) {
+    auto key = chunk_cache_key(chunk);
+    // http_byte_range is a [start, end] inclusive pair.
+    cloud_storage_clients::http_byte_range byte_range{
+      chunk.start, chunk.end - 1};
+
+    auto result = co_await _remote->download_stream(
+      {.bucket = _bucket, .key = _key, .parent_rtc = parent},
+      [this,
+       &key](uint64_t content_length, ss::input_stream<char> input_stream) {
+          return save_chunk_to_cache(
+            content_length, std::move(input_stream), key);
+      },
+      "chunked SST chunk download",
+      /*acquire_hydration_units=*/true,
+      byte_range,
+      /*throttle_metric_ms_cb=*/{},
+      _gid);
+
+    switch (result) {
+    case cloud_io::download_result::success:
+        co_return true;
+    case cloud_io::download_result::notfound:
+        co_return false;
+    case cloud_io::download_result::timedout:
+        throw io_error_exception(
+          "timeout fetching chunk {} of {}", chunk.start, _key);
+    case cloud_io::download_result::failed:
+        throw io_error_exception(
+          "failed to fetch chunk {} of {}", chunk.start, _key);
+    }
+}
+
+ss::future<uint64_t> chunked_remote_file_reader::save_chunk_to_cache(
+  uint64_t content_length,
+  ss::input_stream<char> input_stream,
+  const std::filesystem::path& key) {
+    std::exception_ptr ex;
+    try {
+        auto reservation = co_await _cache->reserve_space(content_length, 1);
+        co_await _cache->put(key, input_stream, reservation);
+    } catch (...) {
+        ex = std::current_exception();
+    }
+    co_await input_stream.close();
+    if (ex) {
+        std::rethrow_exception(ex);
+    }
+    co_return content_length;
+}
+
+ss::future<ioarray> chunked_remote_file_reader::read(size_t offset, size_t n) {
+    if (n == 0) {
+        co_return ioarray{};
+    }
+    if (offset >= _file_size || n > _file_size - offset) {
+        throw io_error_exception(
+          "read of {} bytes at offset {} is out of range for {} (size {})",
+          n,
+          offset,
+          _key,
+          _file_size);
+    }
+    auto gate_hold = _gate.hold();
+    retry_chain_node rtc(_as, _retry_timeout, _retry_backoff);
+
+    chunked_vector<aligned_chunk> chunks;
+    size_t pos = offset;
+    size_t end_offset = offset + n;
+    while (pos < end_offset) {
+        auto chunk = chunk_for_offset(pos);
+        chunks.push_back(chunk);
+        pos = chunk.end;
+    }
+
+    // Kick off the cloud IO and subsequent reads in parallel (bounded by
+    // client pool capacity) to lower read latencies.
+    chunked_vector<ioarray> slices;
+    slices.reserve(chunks.size());
+    for (size_t i = 0; i < chunks.size(); ++i) {
+        slices.emplace_back();
+    }
+    auto max_concurrent = std::min(_remote->concurrency(), size_t{10});
+    auto indices = std::views::iota(size_t{0}, chunks.size());
+    auto read_chunks = co_await ss::coroutine::as_future(
+      ss::max_concurrent_for_each(
+        indices,
+        max_concurrent,
+        [this, &chunks, &slices, &rtc, offset, n](
+          this auto, size_t i) -> ss::future<> {
+            const auto& chunk = chunks[i];
+            auto handle = co_await ensure_chunk_cached(chunk, rtc);
+            if (!handle) {
+                throw io_error_exception(
+                  "underlying object {} no longer present in cloud storage",
+                  *this);
+            }
+            // Account for when the range of data being read isn't chunk
+            // aligned; this may snip off part of the first and last chunks.
+            const size_t slice_begin = std::max<size_t>(offset, chunk.start);
+            const size_t slice_end = std::min<size_t>(offset + n, chunk.end);
+            const size_t offset_in_chunk = slice_begin - chunk.start;
+            const size_t length = slice_end - slice_begin;
+            auto piece = co_await ss::coroutine::as_future(
+              aligned_dma_read(*handle, offset_in_chunk, length));
+            co_await handle->close().handle_exception(
+              [](const std::exception_ptr&) {});
+            slices[i] = std::move(piece).get();
+        }));
+    if (read_chunks.failed()) {
+        rethrow_as_io_error(read_chunks.get_exception(), *this);
+    }
+    ioarray result;
+    for (auto& slice : slices) {
+        result = ioarray::concat(std::move(result), std::move(slice));
+    }
+    co_return result;
+}
+
+ss::future<> chunked_remote_file_reader::close() { return _gate.close(); }
+
+fmt::iterator chunked_remote_file_reader::format_to(fmt::iterator it) const {
+    return fmt::format_to(
+      it,
+      "{{chunked_remote_file_reader key={} file_size={} chunk_size={}}}",
+      _key,
+      _file_size,
+      _chunk_size);
+}
+
+} // namespace lsm::io

--- a/src/v/lsm/io/chunked_remote_file_reader.h
+++ b/src/v/lsm/io/chunked_remote_file_reader.h
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "cloud_io/cache_service.h"
+#include "cloud_io/remote.h"
+#include "cloud_io/scheduler_types.h"
+#include "cloud_storage_clients/types.h"
+#include "container/chunked_hash_map.h"
+#include "lsm/io/persistence.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/file.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/shared_future.hh>
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <optional>
+
+namespace lsm::io {
+
+/// A random_access_file_reader for an SST stored as a cloud object, read in
+/// fixed-size chunks hydrated into the cloud_io disk cache on demand.
+///
+/// Chunks are aligned to the end of the file, so the SST's trailing
+/// footer/index/filter land in the tail chunk and open() costs one range GET.
+///
+/// The cloud_io disk cache owns residency (which chunk bytes stay local). This
+/// reader holds chunk handles only for the duration of a read() -- it opens
+/// the covering chunks, reads them, and closes them before returning -- so
+/// open fds are bounded by in-flight reads, with no persistent handle map.
+///
+/// Concurrent reads that miss the same uncached chunk coalesce their cloud
+/// fetch behind a shared future, so a burst of readers for a cold SST issues
+/// one range GET per chunk rather than one per reader.
+class chunked_remote_file_reader final : public random_access_file_reader {
+public:
+    /// Open the SST. Probes existence by ensuring the tail chunk is cached
+    /// (one range GET, which also warms the footer/index for the first reads);
+    /// returns nullopt if the object does not exist (404). Throws on other I/O
+    /// errors.
+    static ss::future<
+      std::optional<std::unique_ptr<chunked_remote_file_reader>>>
+    open(
+      cloud_io::cache* cache,
+      cloud_io::remote* remote,
+      cloud_storage_clients::bucket_name bucket,
+      cloud_storage_clients::object_key key,
+      std::filesystem::path cache_key_prefix,
+      uint64_t file_size,
+      uint64_t chunk_size,
+      ss::lowres_clock::duration retry_timeout,
+      ss::lowres_clock::duration retry_backoff,
+      ss::abort_source& as,
+      cloud_io::group_id gid);
+
+    chunked_remote_file_reader(const chunked_remote_file_reader&) = delete;
+    chunked_remote_file_reader&
+    operator=(const chunked_remote_file_reader&) = delete;
+    chunked_remote_file_reader(chunked_remote_file_reader&&) = delete;
+    chunked_remote_file_reader&
+    operator=(chunked_remote_file_reader&&) = delete;
+    ~chunked_remote_file_reader() override;
+
+    ss::future<ioarray> read(size_t offset, size_t n) override;
+    ss::future<> close() override;
+    fmt::iterator format_to(fmt::iterator it) const override;
+
+    uint64_t file_size() const { return _file_size; }
+    uint64_t chunk_size() const { return _chunk_size; }
+
+private:
+    chunked_remote_file_reader(
+      cloud_io::cache* cache,
+      cloud_io::remote* remote,
+      cloud_storage_clients::bucket_name bucket,
+      cloud_storage_clients::object_key key,
+      std::filesystem::path cache_key_prefix,
+      uint64_t file_size,
+      uint64_t chunk_size,
+      ss::lowres_clock::duration retry_timeout,
+      ss::lowres_clock::duration retry_backoff,
+      ss::abort_source& as,
+      cloud_io::group_id gid);
+
+    /// A half-open byte range [start, end) within the file. Fixed to
+    /// _chunk_size in size (except potentially for the first chunk) and
+    /// end-aligned to the end of the file (_file_size).
+    struct aligned_chunk {
+        uint64_t start;
+        uint64_t end;
+    };
+    /// The chunk containing `offset`, end-aligned to the file end.
+    aligned_chunk chunk_for_offset(uint64_t offset) const;
+
+    /// Cache key for `chunk`. Encodes the chunk size so changing it between
+    /// runs invalidates rather than collides.
+    std::filesystem::path chunk_cache_key(aligned_chunk chunk) const;
+
+    /// Ensure `chunk` is in the disk cache and return an open handle to it.
+    /// The caller owns the handle and must close() it. Returns nullopt if the
+    /// object does not exist (404). Concurrent calls for the same chunk
+    /// coalesce the fetch.
+    ss::future<std::optional<ss::file>>
+    ensure_chunk_cached(aligned_chunk chunk, retry_chain_node& parent);
+
+    /// Range-GET a single chunk into the cache. true on success, false on 404.
+    ss::future<bool>
+    download_chunk(aligned_chunk chunk, retry_chain_node& parent);
+
+    /// Reserve space and stream the response body into the cache. Always
+    /// closes `input_stream`; returns the content length.
+    ss::future<uint64_t> save_chunk_to_cache(
+      uint64_t content_length,
+      ss::input_stream<char> input_stream,
+      const std::filesystem::path& key);
+
+    cloud_io::cache* _cache;
+    cloud_io::remote* _remote;
+    cloud_storage_clients::bucket_name _bucket;
+    cloud_storage_clients::object_key _key;
+    std::filesystem::path _cache_key_prefix;
+    uint64_t _file_size;
+    uint64_t _chunk_size;
+    ss::lowres_clock::duration _retry_timeout;
+    ss::lowres_clock::duration _retry_backoff;
+    ss::abort_source& _as;
+    cloud_io::group_id _gid;
+
+    // In-flight chunk fetches keyed by chunk start. An entry exists only while
+    // a download is in progress; the value is true if the object exists, false
+    // on 404. Coalesces concurrent fetches of the same chunk.
+    chunked_hash_map<uint64_t, ss::shared_future<bool>> _in_flight;
+    ss::gate _gate;
+};
+
+} // namespace lsm::io

--- a/src/v/lsm/io/cloud_cache_persistence.cc
+++ b/src/v/lsm/io/cloud_cache_persistence.cc
@@ -247,7 +247,8 @@ public:
       , _gid(gid) {}
 
     ss::future<optional_pointer<random_access_file_reader>>
-    open_random_access_reader(internal::file_handle h) override {
+    open_random_access_reader(
+      internal::file_handle h, uint64_t /*file_size*/) override {
         _as.check();
         auto _ = _gate.hold();
         auto filename = internal::sst_file_name(h);

--- a/src/v/lsm/io/cloud_cache_persistence.cc
+++ b/src/v/lsm/io/cloud_cache_persistence.cc
@@ -15,6 +15,7 @@
 #include "config/configuration.h"
 #include "lsm/core/exceptions.h"
 #include "lsm/core/internal/files.h"
+#include "lsm/io/chunked_remote_file_reader.h"
 #include "lsm/io/file_io.h"
 #include "ssx/future-util.h"
 #include "utils/retry_chain_node.h"
@@ -33,11 +34,14 @@ namespace {
 
 static constexpr auto reservation_timeout = std::chrono::seconds(30);
 
+static constexpr auto cloud_op_timeout = std::chrono::seconds(10);
+
+std::chrono::milliseconds cloud_op_backoff() {
+    return config::shard_local_cfg().cloud_storage_initial_backoff_ms.value();
+}
+
 retry_chain_node make_cloud_rtc(ss::abort_source& as) {
-    constexpr auto timeout = std::chrono::seconds(10);
-    auto backoff
-      = config::shard_local_cfg().cloud_storage_initial_backoff_ms.value();
-    return retry_chain_node{as, timeout, backoff};
+    return retry_chain_node{as, cloud_op_timeout, cloud_op_backoff()};
 }
 
 bool check_cloud_result(cloud_io::download_result result) {
@@ -239,53 +243,50 @@ public:
       cloud_io::remote* remote,
       cloud_storage_clients::bucket_name bucket,
       cloud_storage_clients::object_key prefix,
+      config::binding<size_t> chunk_size,
       cloud_io::group_id gid)
       : _cache(cache)
       , _remote(remote)
       , _bucket(std::move(bucket))
       , _prefix(std::move(prefix))
+      , _chunk_size(std::move(chunk_size))
       , _gid(gid) {}
 
     ss::future<optional_pointer<random_access_file_reader>>
     open_random_access_reader(
-      internal::file_handle h, uint64_t /*file_size*/) override {
+      internal::file_handle h, uint64_t file_size) override {
         _as.check();
         auto _ = _gate.hold();
         auto filename = internal::sst_file_name(h);
-        auto key = cache_key(filename);
 
-        auto root = make_cloud_rtc(_as);
-        while (true) {
-            auto reader = co_await open_cached_reader(key);
-            if (reader) {
-                co_return reader;
-            }
-
-            auto dl_fut = co_await ss::coroutine::as_future(
-              _remote->download_stream(
-                {
-                  .bucket = _bucket,
-                  .key = cloud_key(filename),
-                  .parent_rtc = root,
-                },
-                [this,
-                 &key](uint64_t content_length, ss::input_stream<char> stream) {
-                    return save_to_cache(
-                      content_length, std::move(stream), key);
-                },
-                "SST file download",
-                /*acquire_hydration_units=*/true,
-                /*byte_range=*/std::nullopt,
-                /*throttle_metric_ms_cb=*/{},
-                _gid));
-            if (dl_fut.failed()) {
-                throw_as_lsm_ex(
-                  dl_fut.get_exception(), "error downloading file");
-            }
-            if (!check_cloud_result(dl_fut.get())) {
-                co_return std::nullopt;
-            }
+        auto cached = co_await open_cached_reader(cache_key(filename));
+        if (cached) {
+            // The whole object is already local -- e.g. just written through
+            // by the cache-staged writer. Serve it directly rather than
+            // re-fetching it from the cloud in chunks.
+            co_return cached;
         }
+
+        // Hydrate chunks on demand. Chunk entries live in a sibling
+        // subdirectory so they can never collide with the whole-file key
+        // probed above.
+        auto reader = co_await chunked_remote_file_reader::open(
+          _cache,
+          _remote,
+          _bucket,
+          cloud_key(filename),
+          chunk_cache_prefix(filename),
+          file_size,
+          _chunk_size(),
+          config::shard_local_cfg().cloud_storage_hydration_timeout_ms(),
+          cloud_op_backoff(),
+          _as,
+          _gid);
+        if (!reader) {
+            co_return std::nullopt;
+        }
+        std::unique_ptr<random_access_file_reader> ptr = std::move(*reader);
+        co_return ptr;
     }
 
     ss::future<std::unique_ptr<sequential_file_writer>>
@@ -403,9 +404,9 @@ private:
                 co_return std::nullopt;
             }
             auto local_path = _cache->get_local_path(key);
-            std::unique_ptr<random_access_file_reader> ptr;
-            ptr = std::make_unique<disk_file_reader>(
-              std::move(local_path), std::move(item->body));
+            std::unique_ptr<random_access_file_reader> ptr
+              = std::make_unique<disk_file_reader>(
+                std::move(local_path), std::move(item->body));
             co_return ptr;
         } catch (const std::system_error& e) {
             if (e.code() == std::errc::no_such_file_or_directory) {
@@ -423,27 +424,14 @@ private:
         }
     }
 
-    ss::future<uint64_t> save_to_cache(
-      uint64_t content_length,
-      ss::input_stream<char> input_stream,
-      const std::filesystem::path& key) {
-        std::exception_ptr ex;
-        try {
-            auto reservation = co_await _cache->reserve_space(
-              content_length, 1);
-            co_await _cache->put(key, input_stream, reservation);
-        } catch (...) {
-            ex = std::current_exception();
-        }
-        co_await input_stream.close();
-        if (ex) {
-            std::rethrow_exception(ex);
-        }
-        co_return content_length;
-    }
-
     std::filesystem::path cache_key(std::string_view name) {
         return std::filesystem::path("lsm") / _prefix() / name;
+    }
+
+    // Where the chunked reader caches its chunks for `name`: a sibling of the
+    // whole-file key so the two never share a path.
+    std::filesystem::path chunk_cache_prefix(std::string_view name) {
+        return cache_key(fmt::format("{}.chunks", name));
     }
 
     cloud_storage_clients::object_key cloud_key(std::string_view name) {
@@ -454,6 +442,7 @@ private:
     cloud_io::remote* _remote;
     cloud_storage_clients::bucket_name _bucket;
     cloud_storage_clients::object_key _prefix;
+    config::binding<size_t> _chunk_size;
     cloud_io::group_id _gid;
     ss::abort_source _as;
     ss::gate _gate;
@@ -600,9 +589,15 @@ ss::future<std::unique_ptr<data_persistence>> open_cloud_cache_data_persistence(
   cloud_io::remote* remote,
   cloud_storage_clients::bucket_name bucket,
   cloud_storage_clients::object_key prefix,
+  config::binding<size_t> sst_chunk_size,
   cloud_io::group_id gid) {
     co_return std::make_unique<cloud_cache_data_persistence>(
-      cache, remote, std::move(bucket), std::move(prefix), gid);
+      cache,
+      remote,
+      std::move(bucket),
+      std::move(prefix),
+      std::move(sst_chunk_size),
+      gid);
 }
 
 ss::future<std::unique_ptr<metadata_persistence>>

--- a/src/v/lsm/io/cloud_cache_persistence.h
+++ b/src/v/lsm/io/cloud_cache_persistence.h
@@ -13,18 +13,22 @@
 #include "cloud_io/cache_service.h"
 #include "cloud_io/remote.h"
 #include "cloud_storage_clients/types.h"
+#include "config/property.h"
 #include "lsm/io/persistence.h"
 
 namespace lsm::io {
 
 /// Open a data persistence backed by the cloud cache and cloud storage.
-/// `gid` tags every cloud operation this persistence issues for the
-/// cloud_io scheduler; defaults to default_group.
+/// SST files are read from object storage in chunks of `sst_chunk_size`
+/// bytes, hydrated into the cache on demand; the binding is read per open so
+/// the size can change at runtime. `gid` tags every cloud operation this
+/// persistence issues for the cloud_io scheduler; defaults to default_group.
 ss::future<std::unique_ptr<data_persistence>> open_cloud_cache_data_persistence(
   cloud_io::cache* cache,
   cloud_io::remote* remote,
   cloud_storage_clients::bucket_name bucket,
   cloud_storage_clients::object_key prefix,
+  config::binding<size_t> sst_chunk_size,
   cloud_io::group_id gid = cloud_io::group_id::default_group);
 
 /// Open a metadata persistence backed by cloud storage. `gid` tags every

--- a/src/v/lsm/io/disk_persistence.cc
+++ b/src/v/lsm/io/disk_persistence.cc
@@ -41,7 +41,8 @@ public:
     ~impl() override = default;
 
     ss::future<optional_pointer<random_access_file_reader>>
-    open_random_access_reader(internal::file_handle h) override {
+    open_random_access_reader(
+      internal::file_handle h, uint64_t /*file_size*/) override {
         try {
             auto filepath = path(internal::sst_file_name(h));
             auto file = co_await ss::open_file_dma(

--- a/src/v/lsm/io/file_io.cc
+++ b/src/v/lsm/io/file_io.cc
@@ -19,13 +19,9 @@
 
 namespace lsm::io {
 
-disk_file_reader::disk_file_reader(std::filesystem::path path, ss::file file)
-  : _path(std::move(path))
-  , _file(std::move(file)) {}
-
-ss::future<ioarray> disk_file_reader::read(size_t offset, size_t n) {
-    size_t memory_alignment = _file.memory_dma_alignment();
-    size_t disk_alignment = _file.disk_read_dma_alignment();
+ss::future<ioarray> aligned_dma_read(ss::file& file, size_t offset, size_t n) {
+    size_t memory_alignment = file.memory_dma_alignment();
+    size_t disk_alignment = file.disk_read_dma_alignment();
     // ioarray requires its size to be a multiple of its alignment, so use the
     // max of the two seastar alignments.
     size_t max_alignment = std::max(memory_alignment, disk_alignment);
@@ -33,20 +29,24 @@ ss::future<ioarray> disk_file_reader::read(size_t offset, size_t n) {
     size_t offset_delta = offset - adjusted_offset;
     auto array = ioarray::aligned(
       memory_alignment, ss::align_up(n + offset_delta, max_alignment));
+    size_t amt = co_await file.dma_read(adjusted_offset, array.as_iovec());
+    if (amt < offset_delta + n) {
+        throw io_error_exception(
+          "short read: requested {} bytes at offset {}, got {} bytes",
+          n,
+          offset,
+          amt > offset_delta ? amt - offset_delta : 0);
+    }
+    co_return array.share(offset_delta, n);
+}
+
+disk_file_reader::disk_file_reader(std::filesystem::path path, ss::file file)
+  : _path(std::move(path))
+  , _file(std::move(file)) {}
+
+ss::future<ioarray> disk_file_reader::read(size_t offset, size_t n) {
     try {
-        size_t amt = co_await _file.dma_read(adjusted_offset, array.as_iovec());
-        if (amt < offset_delta + n) {
-            throw io_error_exception(
-              "short read {}: failed to read {} bytes from block at offset "
-              "{}, "
-              "got: "
-              "{}",
-              *this,
-              array.size(),
-              adjusted_offset,
-              amt);
-        }
-        co_return array.share(offset_delta, n);
+        co_return co_await aligned_dma_read(_file, offset, n);
     } catch (const std::system_error& err) {
         throw io_error_exception(
           err.code(), "io error reading {}: {}", *this, err);

--- a/src/v/lsm/io/file_io.h
+++ b/src/v/lsm/io/file_io.h
@@ -18,6 +18,18 @@
 
 namespace lsm::io {
 
+/// Reads `n` bytes from `file` starting at `offset`, returning the bytes as
+/// an ioarray.
+///
+/// Handles the DMA alignment dance internally: callers pass natural byte
+/// coordinates and get back exactly the requested slice. Internally the
+/// read is widened to disk alignment and the result trimmed.
+///
+/// Throws io_error_exception on short read (file is shorter than the
+/// requested range). Propagates std::system_error from the underlying
+/// file::dma_read on I/O failures.
+ss::future<ioarray> aligned_dma_read(ss::file& file, size_t offset, size_t n);
+
 // A disk based file reader
 class disk_file_reader : public random_access_file_reader {
 public:

--- a/src/v/lsm/io/memory_persistence.cc
+++ b/src/v/lsm/io/memory_persistence.cc
@@ -133,7 +133,8 @@ public:
       : _controller(controller) {}
 
     ss::future<optional_pointer<random_access_file_reader>>
-    open_random_access_reader(internal::file_handle h) override {
+    open_random_access_reader(
+      internal::file_handle h, uint64_t /*file_size*/) override {
         if (_controller && _controller->should_fail) {
             co_await ss::coroutine::return_exception(
               io_error_exception("injected error"));

--- a/src/v/lsm/io/persistence.h
+++ b/src/v/lsm/io/persistence.h
@@ -111,12 +111,15 @@ public:
     virtual ~data_persistence() = default;
 
     // Create a reader that supports random access reads the file with the
-    // specified name.
+    // specified name. `file_size` is the size of the file in bytes; the LSM
+    // already knows it via the manifest's file_meta_data and threads it
+    // through here so cloud-backed implementations can compute byte ranges
+    // without an extra round-trip.
     //
     // If the file does not exist then the implementation should return
     // `std::nullopt`.
     virtual ss::future<optional_pointer<random_access_file_reader>>
-      open_random_access_reader(internal::file_handle) = 0;
+    open_random_access_reader(internal::file_handle, uint64_t file_size) = 0;
 
     // Create a writer that writes to a new file with the specified name.
     // The file_handle must be unique — callers must not write to a handle

--- a/src/v/lsm/io/tests/BUILD
+++ b/src/v/lsm/io/tests/BUILD
@@ -1,6 +1,32 @@
 load("//bazel:test.bzl", "redpanda_cc_gtest")
 
 redpanda_cc_gtest(
+    name = "chunked_remote_file_reader_test",
+    timeout = "short",
+    srcs = [
+        "chunked_remote_file_reader_test.cc",
+    ],
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/cloud_io:cache",
+        "//src/v/cloud_io:io_result",
+        "//src/v/cloud_io:remote",
+        "//src/v/cloud_io/tests:cloud_io_cache_fixture",
+        "//src/v/cloud_io/tests:db_s3_imposter",
+        "//src/v/cloud_io/tests:scoped_remote",
+        "//src/v/cloud_storage_clients",
+        "//src/v/container:chunked_vector",
+        "//src/v/lsm/io:chunked_remote_file_reader",
+        "//src/v/lsm/io:memory_persistence",
+        "//src/v/random:generators",
+        "//src/v/test_utils:gtest",
+        "//src/v/utils:retry_chain_node",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "readahead_file_reader_test",
     timeout = "short",
     srcs = [

--- a/src/v/lsm/io/tests/chunked_remote_file_reader_test.cc
+++ b/src/v/lsm/io/tests/chunked_remote_file_reader_test.cc
@@ -1,0 +1,335 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "bytes/iobuf.h"
+#include "cloud_io/io_result.h"
+#include "cloud_io/remote.h"
+#include "cloud_io/tests/cache_test_fixture.h"
+#include "cloud_io/tests/db_s3_imposter_fixture.h"
+#include "cloud_io/tests/scoped_remote.h"
+#include "container/chunked_vector.h"
+#include "lsm/io/chunked_remote_file_reader.h"
+#include "lsm/io/memory_persistence.h"
+#include "random/generators.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/when_all.hh>
+#include <seastar/util/defer.hh>
+
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+ss::abort_source g_never_abort;
+constexpr uint64_t k_chunk_size = 16ULL * 1024ULL;
+constexpr auto k_retry_timeout = std::chrono::seconds(10);
+constexpr auto k_retry_backoff = std::chrono::milliseconds(10);
+
+std::string ioarray_to_string(ioarray a) {
+    std::string out;
+    out.reserve(a.size());
+    for (auto c : a.as_range()) {
+        out.push_back(c);
+    }
+    return out;
+}
+
+// A random payload so that a read returning the wrong chunk's bytes is
+// detected: over any range, two distinct positions almost never hold the same
+// bytes, so a positional bug shows up as a content mismatch.
+std::string random_payload(size_t size) {
+    auto s = random_generators::gen_alphanum_string(size);
+    return {s.begin(), s.end()};
+}
+
+} // namespace
+
+class chunked_remote_file_reader_test
+  : public cloud_io::cache_test_fixture
+  , public ::db_s3_imposter_fixture
+  , public seastar_test {
+public:
+    void SetUp() override {
+        ::db_s3_imposter_fixture::start().get();
+        _scoped = cloud_io::scoped_remote::create(1, conf);
+    }
+
+    void TearDown() override {
+        _scoped->request_stop();
+        _scoped.reset();
+        ::db_s3_imposter_fixture::stop().get();
+    }
+
+    void upload(std::string_view key, std::string_view body) {
+        retry_chain_node rtc(g_never_abort, 30s, 100ms);
+        auto okey = cloud_storage_clients::object_key{ss::sstring{key}};
+        auto r = remote()
+                   .upload_object(
+                     {.transfer_details
+                      = {.bucket = bucket_name, .key = okey, .parent_rtc = rtc},
+                      .display_str = "test-upload",
+                      .payload = iobuf::from(body)})
+                   .get();
+        ASSERT_EQ(r, cloud_io::upload_result::success);
+    }
+
+    cloud_io::remote& remote() { return _scoped->remote.local(); }
+    cloud_io::cache& cache() { return sharded_cache.local(); }
+
+    // Opens a reader via the factory. The object must already exist, since
+    // open() probes the tail chunk for existence.
+    std::unique_ptr<lsm::io::chunked_remote_file_reader> open_reader(
+      std::string_view object_key,
+      uint64_t file_size,
+      uint64_t chunk_size = k_chunk_size,
+      std::string_view cache_prefix = "test") {
+        auto r = lsm::io::chunked_remote_file_reader::open(
+                   &cache(),
+                   &remote(),
+                   bucket_name,
+                   cloud_storage_clients::object_key{ss::sstring{object_key}},
+                   std::filesystem::path{std::string{cache_prefix}},
+                   file_size,
+                   chunk_size,
+                   k_retry_timeout,
+                   k_retry_backoff,
+                   g_never_abort,
+                   cloud_io::group_id::default_group)
+                   .get();
+        EXPECT_TRUE(r.has_value());
+        return std::move(r.value());
+    }
+
+    // Mirrors chunked_remote_file_reader::chunk_cache_key with the test's
+    // cache_key_prefix ("test") and chunk size.
+    static std::filesystem::path expected_chunk_key(uint64_t chunk_start) {
+        return std::filesystem::path("test") / fmt::format("c={}", k_chunk_size)
+               / fmt::format("{}", chunk_start);
+    }
+
+private:
+    std::unique_ptr<cloud_io::scoped_remote> _scoped;
+};
+
+TEST_F(chunked_remote_file_reader_test, OpenNotFound) {
+    // No object uploaded: the tail probe 404s and open() yields nullopt.
+    auto r = lsm::io::chunked_remote_file_reader::open(
+               &cache(),
+               &remote(),
+               bucket_name,
+               cloud_storage_clients::object_key{ss::sstring{"obj-missing"}},
+               "test",
+               /*file_size=*/1024,
+               k_chunk_size,
+               k_retry_timeout,
+               k_retry_backoff,
+               g_never_abort,
+               cloud_io::group_id::default_group)
+               .get();
+    EXPECT_FALSE(r.has_value());
+}
+
+TEST_F(chunked_remote_file_reader_test, ReadEmpty) {
+    upload("obj-empty", random_payload(1024));
+    auto reader = open_reader("obj-empty", 1024);
+    auto result = reader->read(0, 0).get();
+    EXPECT_EQ(result.size(), 0u);
+    reader->close().get();
+}
+
+TEST_F(chunked_remote_file_reader_test, ReadWithinSingleChunk) {
+    constexpr size_t file_size = 1024;
+    auto payload = random_payload(file_size);
+    upload("obj-single", payload);
+
+    auto reader = open_reader("obj-single", file_size);
+    auto result = reader->read(50, 100).get();
+    ASSERT_EQ(result.size(), 100u);
+    EXPECT_EQ(ioarray_to_string(std::move(result)), payload.substr(50, 100));
+
+    reader->close().get();
+}
+
+TEST_F(chunked_remote_file_reader_test, ReadAcrossChunkBoundary) {
+    // 50 KiB file, 16 KiB chunks -> end-aligned chunks at
+    // [0,2K), [2K,18K), [18K,34K), [34K,50K). A read from offset 16 KiB of
+    // length 4 KiB straddles chunks 1 and 2.
+    constexpr size_t file_size = 50 * 1024;
+    auto payload = random_payload(file_size);
+    upload("obj-cross", payload);
+
+    auto reader = open_reader("obj-cross", file_size);
+    auto result = reader->read(16 * 1024, 4 * 1024).get();
+    ASSERT_EQ(result.size(), 4u * 1024);
+    EXPECT_EQ(
+      ioarray_to_string(std::move(result)),
+      payload.substr(16 * 1024, 4 * 1024));
+
+    reader->close().get();
+}
+
+TEST_F(chunked_remote_file_reader_test, ReadWholeFileSpanningChunks) {
+    constexpr size_t file_size = 50 * 1024;
+    auto payload = random_payload(file_size);
+    upload("obj-whole", payload);
+
+    auto reader = open_reader("obj-whole", file_size);
+    auto result = reader->read(0, file_size).get();
+    ASSERT_EQ(result.size(), file_size);
+    EXPECT_EQ(ioarray_to_string(std::move(result)), payload);
+
+    reader->close().get();
+}
+
+TEST_F(chunked_remote_file_reader_test, OpenWarmsOnlyTailChunk) {
+    // open() probes the tail, so only the tail chunk [34 KiB, 50 KiB) should
+    // be cached afterwards -- not the head.
+    constexpr size_t file_size = 50 * 1024;
+    upload("obj-tail", random_payload(file_size));
+
+    auto reader = open_reader("obj-tail", file_size);
+    EXPECT_EQ(
+      cache().is_cached(expected_chunk_key(34 * 1024)).get(),
+      cloud_io::cache_element_status::available);
+    EXPECT_EQ(
+      cache().is_cached(expected_chunk_key(0)).get(),
+      cloud_io::cache_element_status::not_available);
+
+    reader->close().get();
+}
+
+TEST_F(chunked_remote_file_reader_test, ReadAfterCacheWarmReusesCachedChunks) {
+    constexpr size_t file_size = 50 * 1024;
+    auto payload = random_payload(file_size);
+    upload("obj-warm", payload);
+
+    auto reader = open_reader("obj-warm", file_size);
+    auto first = reader->read(0, file_size).get();
+    EXPECT_EQ(first.size(), file_size);
+
+    auto second = reader->read(16 * 1024, 4 * 1024).get();
+    EXPECT_EQ(
+      ioarray_to_string(std::move(second)),
+      payload.substr(16 * 1024, 4 * 1024));
+
+    reader->close().get();
+}
+
+TEST_F(chunked_remote_file_reader_test, ConcurrentColdReadsAreCorrect) {
+    // Two concurrent reads of the same cold object exercise the fetch
+    // coalescing path; both must return correct data.
+    constexpr size_t file_size = 50 * 1024;
+    auto payload = random_payload(file_size);
+    upload("obj-concurrent", payload);
+
+    auto reader = open_reader("obj-concurrent", file_size);
+    chunked_vector<ss::future<ioarray>> reads;
+    reads.push_back(reader->read(0, file_size));
+    reads.push_back(reader->read(0, file_size));
+    auto results = ss::when_all_succeed(reads.begin(), reads.end()).get();
+    for (auto& r : results) {
+        EXPECT_EQ(ioarray_to_string(std::move(r)), payload);
+    }
+
+    reader->close().get();
+}
+
+TEST_F(chunked_remote_file_reader_test, ReadsMatchNonChunked) {
+    struct shape {
+        uint64_t file_size;
+        uint64_t chunk_size;
+    };
+    // Shapes hit every structural edge of the end-aligned partition: file
+    // smaller than / equal to a chunk, a 1-byte head, head_size == 0, and a
+    // partial head. Sizes are tiny so we can exhaustively read every
+    // (start, end) pair.
+    const std::vector<shape> shapes = {
+      {1, 16},  // single 1-byte chunk
+      {7, 16},  // file < chunk
+      {16, 16}, // file == chunk: a single full chunk
+      {17, 16}, // 1-byte head + 1 full
+      {31, 16}, // 15-byte head + 1 full
+      {32, 16}, // head_size == 0: two full chunks
+      {33, 16}, // 1-byte head + two full
+      {48, 16}, // head_size == 0: three full chunks
+    };
+
+    int idx = 0;
+    for (const auto& s : shapes) {
+        auto key = fmt::format("obj-shape-{}", idx++);
+        auto payload = random_payload(s.file_size);
+        upload(key, payload);
+
+        // Each shape gets its own cache prefix (mirroring the per-SST prefix in
+        // production) so chunk keys don't collide across shapes here.
+        auto chunked = open_reader(key, s.file_size, s.chunk_size, key);
+        auto chunked_closer = ss::defer([&] { chunked->close().get(); });
+
+        // The oracle is a non-chunked, in-memory reader over the same bytes,
+        // backed by a memory persistence. It shares neither the chunking nor
+        // the DMA path, so any divergence is a real bug in the chunked reader.
+        auto mem = lsm::io::make_memory_data_persistence();
+        auto mem_closer = ss::defer([&] { mem->close().get(); });
+        {
+            auto w = mem->open_sequential_writer({}).get();
+            w->append(iobuf::from(payload)).get();
+            w->close().get();
+        }
+        auto oracle_opt = mem->open_random_access_reader({}, s.file_size).get();
+        ASSERT_TRUE(bool(oracle_opt));
+        auto oracle = std::move(*oracle_opt);
+        auto oracle_closer = ss::defer([&] { oracle->close().get(); });
+
+        // Every (start, end) pair, including zero-length and reads to EOF.
+        for (uint64_t start = 0; start <= s.file_size; ++start) {
+            for (uint64_t end = start; end <= s.file_size; ++end) {
+                auto n = end - start;
+                std::string got;
+                std::string want;
+                try {
+                    got = ioarray_to_string(chunked->read(start, n).get());
+                    want = ioarray_to_string(oracle->read(start, n).get());
+                } catch (const std::exception& e) {
+                    FAIL() << "read threw: " << e.what()
+                           << " file=" << s.file_size
+                           << " chunk=" << s.chunk_size << " start=" << start
+                           << " end=" << end;
+                }
+                ASSERT_EQ(got, want)
+                  << "file=" << s.file_size << " chunk=" << s.chunk_size
+                  << " start=" << start << " end=" << end;
+            }
+        }
+    }
+}
+
+TEST_F(chunked_remote_file_reader_test, OutOfRangeReadsThrow) {
+    constexpr size_t file_size = 250;
+    upload("obj-oob", random_payload(file_size));
+    auto reader = open_reader("obj-oob", file_size, /*chunk_size=*/64);
+
+    EXPECT_ANY_THROW(reader->read(file_size, 1).get());     // at EOF
+    EXPECT_ANY_THROW(reader->read(file_size + 5, 1).get()); // past EOF
+    EXPECT_ANY_THROW(reader->read(0, file_size + 1).get()); // length past EOF
+    EXPECT_ANY_THROW(
+      reader->read(file_size - 1, 2).get()); // last byte + 1 over
+
+    // The exact-to-EOF read at the last byte is in range.
+    EXPECT_NO_THROW(reader->read(file_size - 1, 1).get());
+
+    reader->close().get();
+}

--- a/src/v/lsm/io/tests/persistence_test.cc
+++ b/src/v/lsm/io/tests/persistence_test.cc
@@ -68,7 +68,7 @@ TEST_P(PersistenceTest, CanWriteAndReadAFile) {
         w->append(iobuf::from("world")).get();
     }
     {
-        auto maybe_r = persistence->open_random_access_reader({}).get();
+        auto maybe_r = persistence->open_random_access_reader({}, 0).get();
         ASSERT_TRUE(bool(maybe_r));
         auto r = std::move(*maybe_r);
         auto _ = ss::defer([&r] { r->close().get(); });
@@ -114,7 +114,7 @@ TEST_P(PersistenceTest, DuplicateWritePreservesOriginal) {
     } catch (...) {
         // Expected for backends that use O_EXCL.
     }
-    auto maybe_r = persistence->open_random_access_reader({}).get();
+    auto maybe_r = persistence->open_random_access_reader({}, 0).get();
     ASSERT_TRUE(bool(maybe_r));
     auto r = std::move(*maybe_r);
     auto _ = ss::defer([&r] { r->close().get(); });
@@ -124,7 +124,7 @@ TEST_P(PersistenceTest, DuplicateWritePreservesOriginal) {
 }
 
 TEST_P(PersistenceTest, ReadNonExisting) {
-    auto maybe_r = persistence->open_random_access_reader({}).get();
+    auto maybe_r = persistence->open_random_access_reader({}, 0).get();
     EXPECT_FALSE(bool(maybe_r));
 }
 
@@ -156,7 +156,7 @@ TEST_P(PersistenceTest, RandomAccessReaderComprehensive) {
     }
 
     // Open reader for all tests
-    auto maybe_r = persistence->open_random_access_reader({}).get();
+    auto maybe_r = persistence->open_random_access_reader({}, 0).get();
     ASSERT_TRUE(bool(maybe_r));
     auto r = std::move(*maybe_r);
 
@@ -285,8 +285,9 @@ public:
     }
 
     ss::future<optional_pointer<random_access_file_reader>>
-    open_random_access_reader(lsm_internal::file_handle handle) override {
-        return impl_->open_random_access_reader(handle);
+    open_random_access_reader(
+      lsm_internal::file_handle handle, uint64_t file_size) override {
+        return impl_->open_random_access_reader(handle, file_size);
     }
 
     ss::future<> remove_file(lsm_internal::file_handle handle) override {

--- a/src/v/lsm/io/tests/persistence_test.cc
+++ b/src/v/lsm/io/tests/persistence_test.cc
@@ -68,7 +68,8 @@ TEST_P(PersistenceTest, CanWriteAndReadAFile) {
         w->append(iobuf::from("world")).get();
     }
     {
-        auto maybe_r = persistence->open_random_access_reader({}, 0).get();
+        auto maybe_r
+          = persistence->open_random_access_reader({}, /*file_size=*/10).get();
         ASSERT_TRUE(bool(maybe_r));
         auto r = std::move(*maybe_r);
         auto _ = ss::defer([&r] { r->close().get(); });
@@ -114,7 +115,8 @@ TEST_P(PersistenceTest, DuplicateWritePreservesOriginal) {
     } catch (...) {
         // Expected for backends that use O_EXCL.
     }
-    auto maybe_r = persistence->open_random_access_reader({}, 0).get();
+    auto maybe_r
+      = persistence->open_random_access_reader({}, /*file_size=*/13).get();
     ASSERT_TRUE(bool(maybe_r));
     auto r = std::move(*maybe_r);
     auto _ = ss::defer([&r] { r->close().get(); });
@@ -124,7 +126,10 @@ TEST_P(PersistenceTest, DuplicateWritePreservesOriginal) {
 }
 
 TEST_P(PersistenceTest, ReadNonExisting) {
-    auto maybe_r = persistence->open_random_access_reader({}, 0).get();
+    // A nonzero size is required by backends that probe the object on open;
+    // the file does not exist, so the result is still nullopt.
+    auto maybe_r
+      = persistence->open_random_access_reader({}, /*file_size=*/16).get();
     EXPECT_FALSE(bool(maybe_r));
 }
 
@@ -156,7 +161,7 @@ TEST_P(PersistenceTest, RandomAccessReaderComprehensive) {
     }
 
     // Open reader for all tests
-    auto maybe_r = persistence->open_random_access_reader({}, 0).get();
+    auto maybe_r = persistence->open_random_access_reader({}, file_size).get();
     ASSERT_TRUE(bool(maybe_r));
     auto r = std::move(*maybe_r);
 
@@ -359,7 +364,8 @@ INSTANTIATE_TEST_SUITE_P(
           &cache->local(),
           &sr->remote.local(),
           fixture->bucket_name,
-          cloud_storage_clients::object_key("test-prefix"));
+          cloud_storage_clients::object_key("test-prefix"),
+          config::mock_binding<size_t>(1_MiB));
 
         co_return std::make_unique<mock_cloud_cache_data_persistence>(
           std::move(fixture),

--- a/src/v/lsm/sst/tests/iterator_test.cc
+++ b/src/v/lsm/sst/tests/iterator_test.cc
@@ -36,8 +36,9 @@ public:
             builder.close().get();
             file_size = builder.file_size();
         }
-        auto file
-          = _persistence->open_random_access_reader({.id = filename}).get();
+        auto file = _persistence
+                      ->open_random_access_reader({.id = filename}, file_size)
+                      .get();
         auto reader = lsm::sst::reader::open(
                         std::move(*file),
                         lsm::internal::file_id{_counter},

--- a/src/v/lsm/sst/tests/sst_test.cc
+++ b/src/v/lsm/sst/tests/sst_test.cc
@@ -44,7 +44,7 @@ TEST_P(SSTTest, CanCreateAndReadFile) {
         builder.close().get();
         file_size = builder.file_size();
     }
-    auto file = _persistence->open_random_access_reader({}).get();
+    auto file = _persistence->open_random_access_reader({}, file_size).get();
     auto reader = lsm::sst::reader::open(
                     std::move(*file),
                     lsm::internal::file_id{0},


### PR DESCRIPTION
The cloud cache LSM persistence was previously reading SSTs whole. At
scale, this meant that when the LSM grew to include some L3 or L4
objects (O(GiBs) each), readers could be hit with minutes of latency.
Worse yet, often times the reads only need to read some few MiBs
(footers, bloom filters, indexes) to actually serve the incoming
metastore request.

This adds the new chunked file reader to the cloud_cache_persistence,
though it still attempts to read the full file from the cache if it
exists (e.g. if the object was there from previous versions of Redpanda,
or if it was written to the cache on the SST upload path).

The default chunk size is 24MiB, 1.5x the default SST size of L0, so
that by default L0 files are read whole (empirically they didn't seem
problematic being downloaded whole).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
