### PR TITLE
[CORE-16356] Base framework for SR HTTP client

### DIFF
--- a/src/v/http/BUILD
+++ b/src/v/http/BUILD
@@ -61,7 +61,9 @@ redpanda_cc_library(
     ],
     deps = [
         "//src/v/base",
+        "//src/v/bytes",
         "//src/v/http:utils",
+        "//src/v/utils:base64",
         "//src/v/utils:named_type",
         "@abseil-cpp//absl/container:flat_hash_map",
         "@abseil-cpp//absl/container:flat_hash_set",

--- a/src/v/http/request_builder.cc
+++ b/src/v/http/request_builder.cc
@@ -11,7 +11,9 @@
 
 #include "http/request_builder.h"
 
+#include "bytes/bytes.h"
 #include "http/utils.h"
+#include "utils/base64.h"
 
 #include <boost/algorithm/string/join.hpp>
 
@@ -96,6 +98,14 @@ request_builder& request_builder::with_content_length(size_t content_length) {
 
 request_builder& request_builder::with_bearer_auth(std::string_view token) {
     _request.set(bh::field::authorization, fmt::format("Bearer {}", token));
+    return *this;
+}
+
+request_builder& request_builder::with_basic_auth(
+  std::string_view username, std::string_view password) {
+    auto credentials = fmt::format("{}:{}", username, password);
+    auto encoded = bytes_to_base64(bytes::from_string(credentials));
+    _request.set(bh::field::authorization, fmt::format("Basic {}", encoded));
     return *this;
 }
 

--- a/src/v/http/request_builder.h
+++ b/src/v/http/request_builder.h
@@ -71,6 +71,12 @@ public:
     // Adds a Bearer auth token header
     request_builder& with_bearer_auth(std::string_view token);
 
+    // Adds an HTTP Basic auth header (RFC 7617): the value is
+    // "Basic " + base64(username + ":" + password). The caller must ensure the
+    // username contains no ':'.
+    request_builder&
+    with_basic_auth(std::string_view username, std::string_view password);
+
     request_builder& with_content_type(std::string_view content_type);
 
     // Builds a final HTTP request, the returned type is an error variant if the

--- a/src/v/http/tests/request_builder_test.cc
+++ b/src/v/http/tests/request_builder_test.cc
@@ -68,6 +68,16 @@ TEST(request_builder, test_with_everything) {
     EXPECT_EQ(sorted, expected);
 }
 
+TEST(request_builder, with_basic_auth) {
+    auto req = http::request_builder{}
+                 .host("http://a.b")
+                 .with_basic_auth("user", "pass")
+                 .build();
+    ASSERT_TRUE(req.has_value());
+    // base64("user:pass") == "dXNlcjpwYXNz"
+    EXPECT_EQ(req.value()[bh::field::authorization], "Basic dXNlcjpwYXNz");
+}
+
 TEST(request_builder, test_invalid_host) {
     http::request_builder rb;
     const auto bad_host = "foobar.xyz";

--- a/src/v/pandaproxy/schema_registry/rest_client/BUILD
+++ b/src/v/pandaproxy/schema_registry/rest_client/BUILD
@@ -54,3 +54,43 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "credentials",
+    hdrs = [
+        "credentials.h",
+    ],
+    deps = [
+        "//src/v/base",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
+    name = "client",
+    srcs = [
+        "client.cc",
+    ],
+    hdrs = [
+        "client.h",
+    ],
+    implementation_deps = [
+        ":parse",
+        "//src/v/http:request_builder",
+        "//src/v/pandaproxy:logger",
+        "//src/v/ssx:future_util",
+        "@boost//:beast",
+    ],
+    deps = [
+        ":credentials",
+        ":error",
+        ":retry_policy",
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/container:chunked_vector",
+        "//src/v/http",
+        "//src/v/pandaproxy/schema_registry:types",
+        "//src/v/utils:retry_chain_node",
+        "@seastar",
+    ],
+)

--- a/src/v/pandaproxy/schema_registry/rest_client/BUILD
+++ b/src/v/pandaproxy/schema_registry/rest_client/BUILD
@@ -47,6 +47,10 @@ redpanda_cc_library(
     hdrs = [
         "retry_policy.h",
     ],
+    implementation_deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/pandaproxy:logger",
+    ],
     deps = [
         ":error",
         "//src/v/http",

--- a/src/v/pandaproxy/schema_registry/rest_client/BUILD
+++ b/src/v/pandaproxy/schema_registry/rest_client/BUILD
@@ -22,3 +22,35 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "error",
+    hdrs = [
+        "error.h",
+    ],
+    deps = [
+        ":parse",
+        "//src/v/base",
+        "//src/v/http:request_builder",
+        "//src/v/pandaproxy/schema_registry:types",
+        "//src/v/utils:named_type",
+        "@boost//:beast",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
+    name = "retry_policy",
+    srcs = [
+        "retry_policy.cc",
+    ],
+    hdrs = [
+        "retry_policy.h",
+    ],
+    deps = [
+        ":error",
+        "//src/v/http",
+        "//src/v/net",
+        "@seastar",
+    ],
+)

--- a/src/v/pandaproxy/schema_registry/rest_client/BUILD
+++ b/src/v/pandaproxy/schema_registry/rest_client/BUILD
@@ -1,0 +1,24 @@
+load("//bazel:build.bzl", "redpanda_cc_library")
+
+package(default_visibility = ["//src/v/pandaproxy:__subpackages__"])
+
+redpanda_cc_library(
+    name = "parse",
+    srcs = [
+        "parse.cc",
+    ],
+    hdrs = [
+        "parse.h",
+    ],
+    implementation_deps = [
+        "//src/v/serde/json:parser",
+        "//src/v/ssx:sformat",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/container:chunked_vector",
+        "//src/v/pandaproxy/schema_registry:types",
+        "@seastar",
+    ],
+)

--- a/src/v/pandaproxy/schema_registry/rest_client/BUILD
+++ b/src/v/pandaproxy/schema_registry/rest_client/BUILD
@@ -79,7 +79,6 @@ redpanda_cc_library(
         "client.h",
     ],
     implementation_deps = [
-        ":parse",
         "//src/v/http:request_builder",
         "//src/v/http:utils",
         "//src/v/pandaproxy:logger",
@@ -89,6 +88,7 @@ redpanda_cc_library(
     deps = [
         ":credentials",
         ":error",
+        ":parse",
         ":retry_policy",
         "//src/v/base",
         "//src/v/bytes:iobuf",

--- a/src/v/pandaproxy/schema_registry/rest_client/BUILD
+++ b/src/v/pandaproxy/schema_registry/rest_client/BUILD
@@ -40,6 +40,17 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "logger",
+    hdrs = [
+        "logger.h",
+    ],
+    deps = [
+        "//src/v/base",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "retry_policy",
     srcs = [
         "retry_policy.cc",
@@ -48,8 +59,8 @@ redpanda_cc_library(
         "retry_policy.h",
     ],
     implementation_deps = [
+        ":logger",
         "//src/v/bytes:iobuf",
-        "//src/v/pandaproxy:logger",
     ],
     deps = [
         ":error",
@@ -79,9 +90,9 @@ redpanda_cc_library(
         "client.h",
     ],
     implementation_deps = [
+        ":logger",
         "//src/v/http:request_builder",
         "//src/v/http:utils",
-        "//src/v/pandaproxy:logger",
         "//src/v/ssx:future_util",
         "@boost//:beast",
     ],

--- a/src/v/pandaproxy/schema_registry/rest_client/BUILD
+++ b/src/v/pandaproxy/schema_registry/rest_client/BUILD
@@ -77,6 +77,7 @@ redpanda_cc_library(
     implementation_deps = [
         ":parse",
         "//src/v/http:request_builder",
+        "//src/v/http:utils",
         "//src/v/pandaproxy:logger",
         "//src/v/ssx:future_util",
         "@boost//:beast",

--- a/src/v/pandaproxy/schema_registry/rest_client/client.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.cc
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "pandaproxy/schema_registry/rest_client/client.h"
+
+#include "bytes/iobuf.h"
+#include "http/request_builder.h"
+#include "pandaproxy/logger.h"
+#include "pandaproxy/schema_registry/rest_client/parse.h"
+#include "ssx/future-util.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/coroutine/as_future.hh>
+
+#include <boost/beast/http/verb.hpp>
+
+#include <utility>
+#include <variant>
+
+namespace pandaproxy::schema_registry::rest_client {
+
+namespace {
+
+constexpr std::string_view accept_json = "application/json";
+
+// If the terminal error carries an http_status_error, parse its (already
+// collected) response body for the Schema Registry error_code and attach it.
+// Tolerant: leaves the error unchanged when no integer error_code is present.
+ss::future<domain_error> attach_error_code(domain_error err) {
+    auto* call = std::get_if<http_call_error>(&err);
+    if (call == nullptr) {
+        co_return std::move(err);
+    }
+    auto* status = std::get_if<http_status_error>(call);
+    if (status == nullptr) {
+        co_return std::move(err);
+    }
+    auto parsed = co_await parse_error_body(iobuf::from(status->body));
+    if (parsed.has_value()) {
+        status->error_code = parsed->error_code;
+    }
+    co_return std::move(err);
+}
+
+} // namespace
+
+client::client(
+  std::unique_ptr<http::abstract_client> http_client,
+  ss::sstring endpoint,
+  std::optional<basic_auth_credentials> credentials,
+  qualified_subjects_enabled qualified,
+  std::unique_ptr<retry_policy> retry_policy)
+  : _http_client(std::move(http_client))
+  , _endpoint(std::move(endpoint))
+  , _credentials(std::move(credentials))
+  , _qualified(qualified)
+  , _retry_policy(
+      retry_policy ? std::move(retry_policy)
+                   : std::make_unique<default_retry_policy>()) {}
+
+ss::future<> client::shutdown() {
+    auto gate_closed = _gate.close();
+    co_await _http_client->shutdown_and_stop();
+    co_await std::move(gate_closed);
+}
+
+expected<ss::gate::holder> client::maybe_gate() {
+    if (_gate.is_closed()) {
+        return std::unexpected(
+          domain_error{aborted_error{"client gate is closed"}});
+    }
+    return _gate.hold();
+}
+
+void client::maybe_add_basic_auth(http::request_builder& request) {
+    if (_credentials.has_value()) {
+        request.with_basic_auth(_credentials->username, _credentials->password);
+    }
+}
+
+ss::future<expected<iobuf>> client::perform_request(
+  retry_chain_node& parent_rtc,
+  http::request_builder builder,
+  std::optional<iobuf> payload) {
+    if (payload.has_value()) {
+        builder.with_content_length(payload.value().size_bytes());
+    }
+    retry_chain_node rtc(&parent_rtc);
+    std::vector<error_kind> retriable_errors;
+    std::optional<http_call_error> last_error;
+
+    while (true) {
+        retry_permit permit{};
+        try {
+            permit = rtc.retry();
+        } catch (...) {
+            auto ex = std::current_exception();
+            auto msg = fmt::format("{}", ex);
+            if (ssx::is_shutdown_exception(ex)) {
+                vlog(srlog.debug, "shutting down during request: {}", msg);
+                co_return std::unexpected(domain_error{aborted_error{msg}});
+            }
+            // We only expect shutdown exceptions here; treat anything else
+            // conservatively as exhausted rather than aborted.
+            vlog(srlog.warn, "schema registry request gave up: {}", msg);
+            co_return std::unexpected(
+              domain_error{retries_exhausted{
+                .reasons = std::move(retriable_errors),
+                .last_error = std::move(last_error)}});
+        }
+        if (!permit.is_allowed) {
+            co_return std::unexpected(
+              domain_error{retries_exhausted{
+                .reasons = std::move(retriable_errors),
+                .last_error = std::move(last_error)}});
+        }
+
+        auto request = builder.host(_endpoint).build();
+        if (!request.has_value()) {
+            co_return std::unexpected(domain_error{request.error()});
+        }
+
+        auto response_f = co_await ss::coroutine::as_future(
+          _http_client->request_and_collect_response(
+            std::move(request.value()),
+            payload.has_value() ? std::make_optional(payload->copy())
+                                : std::nullopt));
+
+        auto call_res = _retry_policy->should_retry(std::move(response_f));
+        if (call_res.has_value()) {
+            co_return std::move(call_res->body);
+        }
+
+        auto& error = call_res.error();
+        if (error.kind == error_kind::aborted) {
+            co_return std::unexpected(
+              domain_error{
+                aborted_error{"shutting down while evaluating retry"}});
+        }
+        if (!is_retriable(error.kind)) {
+            vlog(srlog.warn, "schema registry request failed: {}", error.err);
+            co_return std::unexpected(
+              co_await attach_error_code(domain_error{std::move(error.err)}));
+        }
+
+        retriable_errors.push_back(error.kind);
+        last_error.emplace(std::move(error.err));
+        auto sleep_fut = co_await ss::coroutine::as_future(
+          ss::sleep_abortable(permit.delay, rtc.root_abort_source()));
+        if (sleep_fut.failed()) {
+            auto msg = fmt::format(
+              "exception during retry sleep: {}", sleep_fut.get_exception());
+            vlog(srlog.debug, "{}", msg);
+            co_return std::unexpected(domain_error{aborted_error{msg}});
+        }
+    }
+}
+
+ss::future<expected<chunked_vector<context_subject>>>
+client::list_subjects(retry_chain_node& rtc) {
+    auto gate = maybe_gate();
+    if (!gate.has_value()) {
+        co_return std::unexpected(std::move(gate.error()));
+    }
+    // TODO: support query params for pagination (offset/limit) and filtering
+    // (deleted/deletedOnly, subjectPrefix); v1 lists all live subjects across
+    // all contexts.
+    auto request = http::request_builder{}
+                     .method(boost::beast::http::verb::get)
+                     .path("/subjects")
+                     .header("accept", accept_json);
+    maybe_add_basic_auth(request);
+
+    auto response = co_await perform_request(rtc, std::move(request));
+    if (!response.has_value()) {
+        co_return std::unexpected(std::move(response.error()));
+    }
+    auto parsed = co_await parse_subjects(
+      std::move(response.value()), _qualified);
+    if (!parsed.has_value()) {
+        co_return std::unexpected(domain_error{std::move(parsed.error())});
+    }
+    co_return std::move(parsed.value());
+}
+
+} // namespace pandaproxy::schema_registry::rest_client

--- a/src/v/pandaproxy/schema_registry/rest_client/client.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.cc
@@ -289,7 +289,7 @@ client::list_subject_versions(
     co_return std::move(parsed.value());
 }
 
-ss::future<std::expected<stored_schema, domain_error>>
+ss::future<std::expected<parsed_schema, domain_error>>
 client::get_schema_by_version(
   const context_subject& subject,
   schema_version version,

--- a/src/v/pandaproxy/schema_registry/rest_client/client.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.cc
@@ -118,7 +118,7 @@ ss::future<> client::shutdown() {
     co_await std::move(gate_closed);
 }
 
-expected<ss::gate::holder> client::maybe_gate() {
+std::expected<ss::gate::holder, domain_error> client::maybe_gate() {
     if (_gate.is_closed()) {
         return std::unexpected(
           domain_error{aborted_error{"client gate is closed"}});
@@ -132,7 +132,7 @@ void client::maybe_add_basic_auth(http::request_builder& request) {
     }
 }
 
-ss::future<expected<iobuf>> client::perform_request(
+ss::future<std::expected<iobuf, domain_error>> client::perform_request(
   retry_chain_node& parent_rtc,
   http::request_builder builder,
   std::optional<iobuf> payload) {
@@ -210,7 +210,7 @@ ss::future<expected<iobuf>> client::perform_request(
     }
 }
 
-ss::future<expected<chunked_vector<context_subject>>>
+ss::future<std::expected<chunked_vector<context_subject>, domain_error>>
 client::list_subjects(retry_chain_node& rtc) {
     auto gate = maybe_gate();
     if (!gate.has_value()) {
@@ -237,7 +237,7 @@ client::list_subjects(retry_chain_node& rtc) {
     co_return std::move(parsed.value());
 }
 
-ss::future<expected<chunked_vector<schema_version>>>
+ss::future<std::expected<chunked_vector<schema_version>, domain_error>>
 client::list_subject_versions(
   const context_subject& subject, retry_chain_node& rtc) {
     auto gate = maybe_gate();
@@ -266,7 +266,8 @@ client::list_subject_versions(
     co_return std::move(parsed.value());
 }
 
-ss::future<expected<stored_schema>> client::get_schema_by_version(
+ss::future<std::expected<stored_schema, domain_error>>
+client::get_schema_by_version(
   const context_subject& subject,
   schema_version version,
   retry_chain_node& rtc) {

--- a/src/v/pandaproxy/schema_registry/rest_client/client.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.cc
@@ -156,6 +156,9 @@ ss::future<std::expected<iobuf, domain_error>> client::perform_request(
     retry_chain_node rtc(&parent_rtc);
     std::vector<error_kind> retriable_errors;
     std::optional<http_call_error> last_error;
+    // Target (path + query) of the most recent attempt, for the failure logs
+    // below. Empty until the first request is built.
+    ss::sstring request_target;
 
     while (true) {
         retry_permit permit{};
@@ -170,7 +173,11 @@ ss::future<std::expected<iobuf, domain_error>> client::perform_request(
             }
             // We only expect shutdown exceptions here; treat anything else
             // conservatively as exhausted rather than aborted.
-            vlog(srlog.warn, "schema registry request gave up: {}", msg);
+            vlog(
+              srlog.warn,
+              "schema registry request gave up [{}]: {}",
+              request_target,
+              msg);
             co_return std::unexpected(
               domain_error{retries_exhausted{
                 .reasons = std::move(retriable_errors),
@@ -187,6 +194,8 @@ ss::future<std::expected<iobuf, domain_error>> client::perform_request(
         if (!request.has_value()) {
             co_return std::unexpected(domain_error{request.error()});
         }
+        request_target = ss::sstring{
+          request->target().begin(), request->target().end()};
 
         auto response_f = co_await ss::coroutine::as_future(
           _http_client->request_and_collect_response(
@@ -206,14 +215,19 @@ ss::future<std::expected<iobuf, domain_error>> client::perform_request(
                 aborted_error{"shutting down while evaluating retry"}});
         }
         if (!is_retriable(error.kind)) {
-            vlog(srlog.warn, "schema registry request failed: {}", error.err);
+            vlog(
+              srlog.warn,
+              "schema registry request failed [{}]: {}",
+              request_target,
+              error.err);
             co_return std::unexpected(
               co_await attach_error_code(domain_error{std::move(error.err)}));
         }
 
         vlog(
           srlog.trace,
-          "schema registry request failed, retrying in {}ms: {}",
+          "schema registry request failed [{}], retrying in {}ms: {}",
+          request_target,
           std::chrono::duration_cast<std::chrono::milliseconds>(permit.delay)
             .count(),
           error.err);

--- a/src/v/pandaproxy/schema_registry/rest_client/client.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.cc
@@ -34,8 +34,9 @@ namespace {
 
 constexpr std::string_view accept_json = "application/json";
 
-// Schema Registry error_code for the subject-not-found condition.
+// Schema Registry error_codes for the not-found conditions.
 constexpr int32_t error_code_subject_not_found = 40401;
+constexpr int32_t error_code_version_not_found = 40402;
 
 // Percent-encode a subject for use as a single path segment. The qualified wire
 // form ":.ctx:sub" contains ':' which must be encoded ("%3A"); uri_encode also
@@ -46,11 +47,14 @@ ss::sstring encode_subject(const context_subject& subject) {
     return http::uri_encode(subject.to_string(), http::uri_encode_slash::yes);
 }
 
-// Translate a terminal 404 into subject_not_found using the error_code that
-// perform_request attached. Anything else (other statuses, unrecognized codes)
-// passes through unchanged.
-domain_error
-translate_not_found(domain_error err, const context_subject& subject) {
+// Translate a terminal 404 into a typed not-found error using the error_code
+// that perform_request attached. Anything else (other statuses, unrecognized
+// codes) passes through unchanged. version is set only for
+// get_schema_by_version (40402 is meaningless for the subject listing).
+domain_error translate_not_found(
+  domain_error err,
+  const context_subject& subject,
+  std::optional<schema_version> version) {
     auto* call = std::get_if<http_call_error>(&err);
     if (call == nullptr) {
         return err;
@@ -59,10 +63,16 @@ translate_not_found(domain_error err, const context_subject& subject) {
     if (status == nullptr) {
         return err;
     }
-    if (
-      status->status == boost::beast::http::status::not_found
-      && status->error_code == error_code_subject_not_found) {
+    if (status->status != boost::beast::http::status::not_found) {
+        return err;
+    }
+    if (status->error_code == error_code_subject_not_found) {
         return domain_error{subject_not_found{subject}};
+    }
+    if (
+      version.has_value()
+      && status->error_code == error_code_version_not_found) {
+        return domain_error{version_not_found{subject, *version}};
     }
     return err;
 }
@@ -246,10 +256,40 @@ client::list_subject_versions(
 
     auto response = co_await perform_request(rtc, std::move(request));
     if (!response.has_value()) {
-        co_return std::unexpected(
-          translate_not_found(std::move(response.error()), subject));
+        co_return std::unexpected(translate_not_found(
+          std::move(response.error()), subject, std::nullopt));
     }
     auto parsed = co_await parse_subject_versions(std::move(response.value()));
+    if (!parsed.has_value()) {
+        co_return std::unexpected(domain_error{std::move(parsed.error())});
+    }
+    co_return std::move(parsed.value());
+}
+
+ss::future<expected<stored_schema>> client::get_schema_by_version(
+  const context_subject& subject,
+  schema_version version,
+  retry_chain_node& rtc) {
+    auto gate = maybe_gate();
+    if (!gate.has_value()) {
+        co_return std::unexpected(std::move(gate.error()));
+    }
+    auto request
+      = http::request_builder{}
+          .method(boost::beast::http::verb::get)
+          .path(
+            fmt::format(
+              "/subjects/{}/versions/{}", encode_subject(subject), version()))
+          .header("accept", accept_json);
+    maybe_add_basic_auth(request);
+
+    auto response = co_await perform_request(rtc, std::move(request));
+    if (!response.has_value()) {
+        co_return std::unexpected(
+          translate_not_found(std::move(response.error()), subject, version));
+    }
+    auto parsed = co_await parse_subject_version(
+      std::move(response.value()), _qualified);
     if (!parsed.has_value()) {
         co_return std::unexpected(domain_error{std::move(parsed.error())});
     }

--- a/src/v/pandaproxy/schema_registry/rest_client/client.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.cc
@@ -13,7 +13,7 @@
 #include "bytes/iobuf.h"
 #include "http/request_builder.h"
 #include "http/utils.h"
-#include "pandaproxy/logger.h"
+#include "pandaproxy/schema_registry/rest_client/logger.h"
 #include "pandaproxy/schema_registry/rest_client/parse.h"
 #include "ssx/future-util.h"
 
@@ -168,13 +168,13 @@ ss::future<std::expected<iobuf, domain_error>> client::perform_request(
             auto ex = std::current_exception();
             auto msg = fmt::format("{}", ex);
             if (ssx::is_shutdown_exception(ex)) {
-                vlog(srlog.debug, "shutting down during request: {}", msg);
+                vlog(srclog.debug, "shutting down during request: {}", msg);
                 co_return std::unexpected(domain_error{aborted_error{msg}});
             }
             // We only expect shutdown exceptions here; treat anything else
             // conservatively as exhausted rather than aborted.
             vlog(
-              srlog.warn,
+              srclog.warn,
               "schema registry request gave up [{}]: {}",
               request_target,
               msg);
@@ -216,7 +216,7 @@ ss::future<std::expected<iobuf, domain_error>> client::perform_request(
         }
         if (!is_retriable(error.kind)) {
             vlog(
-              srlog.warn,
+              srclog.warn,
               "schema registry request failed [{}]: {}",
               request_target,
               error.err);
@@ -225,7 +225,7 @@ ss::future<std::expected<iobuf, domain_error>> client::perform_request(
         }
 
         vlog(
-          srlog.trace,
+          srclog.trace,
           "schema registry request failed [{}], retrying in {}ms: {}",
           request_target,
           std::chrono::duration_cast<std::chrono::milliseconds>(permit.delay)
@@ -238,7 +238,7 @@ ss::future<std::expected<iobuf, domain_error>> client::perform_request(
         if (sleep_fut.failed()) {
             auto msg = fmt::format(
               "exception during retry sleep: {}", sleep_fut.get_exception());
-            vlog(srlog.debug, "{}", msg);
+            vlog(srclog.debug, "{}", msg);
             co_return std::unexpected(domain_error{aborted_error{msg}});
         }
     }

--- a/src/v/pandaproxy/schema_registry/rest_client/client.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.cc
@@ -48,6 +48,16 @@ ss::sstring encode_subject(const context_subject& subject) {
     return http::uri_encode(subject.to_string(), http::uri_encode_slash::yes);
 }
 
+// Append ?deleted=true when soft-deleted entries should be included. Omitted
+// otherwise, so the default request shape and behavior are unchanged. The
+// Schema Registry parses the value as true when it equals "true" or "1".
+void add_deleted_param(
+  http::request_builder& request, include_deleted deleted) {
+    if (deleted) {
+        request.query_param_kv("deleted", "true");
+    }
+}
+
 // Translate a terminal 404 into a typed not-found error using the error_code
 // that perform_request attached. Anything else (other statuses, unrecognized
 // codes) passes through unchanged. version is set only for
@@ -221,18 +231,19 @@ ss::future<std::expected<iobuf, domain_error>> client::perform_request(
 }
 
 ss::future<std::expected<chunked_vector<context_subject>, domain_error>>
-client::list_subjects(retry_chain_node& rtc) {
+client::list_subjects(retry_chain_node& rtc, include_deleted deleted) {
     auto gate = maybe_gate();
     if (!gate.has_value()) {
         co_return std::unexpected(std::move(gate.error()));
     }
-    // TODO: support query params for pagination (offset/limit) and filtering
-    // (deleted/deletedOnly, subjectPrefix); v1 lists all live subjects across
-    // all contexts.
+    // TODO: offset/limit pagination, deletedOnly, and subjectPrefix filtering
+    // are unimplemented. Redpanda SR doesn't support deletedOnly/offset/limit;
+    // subjectPrefix is a deferred source-filtering optimization.
     auto request = http::request_builder{}
                      .method(boost::beast::http::verb::get)
                      .path("/subjects")
                      .header("accept", accept_json);
+    add_deleted_param(request, deleted);
     maybe_add_basic_auth(request);
 
     auto response = co_await perform_request(rtc, std::move(request));
@@ -249,19 +260,21 @@ client::list_subjects(retry_chain_node& rtc) {
 
 ss::future<std::expected<chunked_vector<schema_version>, domain_error>>
 client::list_subject_versions(
-  const context_subject& subject, retry_chain_node& rtc) {
+  const context_subject& subject,
+  retry_chain_node& rtc,
+  include_deleted deleted) {
     auto gate = maybe_gate();
     if (!gate.has_value()) {
         co_return std::unexpected(std::move(gate.error()));
     }
-    // TODO: support query params for filtering (deleted/deletedOnly,
-    // deletedAsNegative) and pagination (offset/limit); v1 lists live versions
-    // only.
+    // TODO: offset/limit pagination, deletedOnly, and deletedAsNegative are
+    // unimplemented (Redpanda SR doesn't support them).
     auto request
       = http::request_builder{}
           .method(boost::beast::http::verb::get)
           .path(fmt::format("/subjects/{}/versions", encode_subject(subject)))
           .header("accept", accept_json);
+    add_deleted_param(request, deleted);
     maybe_add_basic_auth(request);
 
     auto response = co_await perform_request(rtc, std::move(request));
@@ -280,7 +293,8 @@ ss::future<std::expected<stored_schema, domain_error>>
 client::get_schema_by_version(
   const context_subject& subject,
   schema_version version,
-  retry_chain_node& rtc) {
+  retry_chain_node& rtc,
+  include_deleted deleted) {
     auto gate = maybe_gate();
     if (!gate.has_value()) {
         co_return std::unexpected(std::move(gate.error()));
@@ -292,6 +306,7 @@ client::get_schema_by_version(
             fmt::format(
               "/subjects/{}/versions/{}", encode_subject(subject), version()))
           .header("accept", accept_json);
+    add_deleted_param(request, deleted);
     maybe_add_basic_auth(request);
 
     auto response = co_await perform_request(rtc, std::move(request));

--- a/src/v/pandaproxy/schema_registry/rest_client/client.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.cc
@@ -93,6 +93,9 @@ ss::future<domain_error> attach_error_code(domain_error err) {
     auto parsed = co_await parse_error_body(iobuf::from(status->body));
     if (parsed.has_value()) {
         status->error_code = parsed->error_code;
+        if (!parsed->message.empty()) {
+            status->message = std::move(parsed->message);
+        }
     }
     co_return std::move(err);
 }

--- a/src/v/pandaproxy/schema_registry/rest_client/client.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.cc
@@ -12,6 +12,7 @@
 
 #include "bytes/iobuf.h"
 #include "http/request_builder.h"
+#include "http/utils.h"
 #include "pandaproxy/logger.h"
 #include "pandaproxy/schema_registry/rest_client/parse.h"
 #include "ssx/future-util.h"
@@ -20,8 +21,10 @@
 #include <seastar/core/sleep.hh>
 #include <seastar/coroutine/as_future.hh>
 
+#include <boost/beast/http/status.hpp>
 #include <boost/beast/http/verb.hpp>
 
+#include <optional>
 #include <utility>
 #include <variant>
 
@@ -30,6 +33,39 @@ namespace pandaproxy::schema_registry::rest_client {
 namespace {
 
 constexpr std::string_view accept_json = "application/json";
+
+// Schema Registry error_code for the subject-not-found condition.
+constexpr int32_t error_code_subject_not_found = 40401;
+
+// Percent-encode a subject for use as a single path segment. The qualified wire
+// form ":.ctx:sub" contains ':' which must be encoded ("%3A"); uri_encode also
+// encodes an interior '/' ("%2F") so the subject stays within one segment.
+// request_builder/ada leave the resulting "%XX" intact (verified), so the
+// subject is encoded exactly once.
+ss::sstring encode_subject(const context_subject& subject) {
+    return http::uri_encode(subject.to_string(), http::uri_encode_slash::yes);
+}
+
+// Translate a terminal 404 into subject_not_found using the error_code that
+// perform_request attached. Anything else (other statuses, unrecognized codes)
+// passes through unchanged.
+domain_error
+translate_not_found(domain_error err, const context_subject& subject) {
+    auto* call = std::get_if<http_call_error>(&err);
+    if (call == nullptr) {
+        return err;
+    }
+    auto* status = std::get_if<http_status_error>(call);
+    if (status == nullptr) {
+        return err;
+    }
+    if (
+      status->status == boost::beast::http::status::not_found
+      && status->error_code == error_code_subject_not_found) {
+        return domain_error{subject_not_found{subject}};
+    }
+    return err;
+}
 
 // If the terminal error carries an http_status_error, parse its (already
 // collected) response body for the Schema Registry error_code and attach it.
@@ -185,6 +221,35 @@ client::list_subjects(retry_chain_node& rtc) {
     }
     auto parsed = co_await parse_subjects(
       std::move(response.value()), _qualified);
+    if (!parsed.has_value()) {
+        co_return std::unexpected(domain_error{std::move(parsed.error())});
+    }
+    co_return std::move(parsed.value());
+}
+
+ss::future<expected<chunked_vector<schema_version>>>
+client::list_subject_versions(
+  const context_subject& subject, retry_chain_node& rtc) {
+    auto gate = maybe_gate();
+    if (!gate.has_value()) {
+        co_return std::unexpected(std::move(gate.error()));
+    }
+    // TODO: support query params for filtering (deleted/deletedOnly,
+    // deletedAsNegative) and pagination (offset/limit); v1 lists live versions
+    // only.
+    auto request
+      = http::request_builder{}
+          .method(boost::beast::http::verb::get)
+          .path(fmt::format("/subjects/{}/versions", encode_subject(subject)))
+          .header("accept", accept_json);
+    maybe_add_basic_auth(request);
+
+    auto response = co_await perform_request(rtc, std::move(request));
+    if (!response.has_value()) {
+        co_return std::unexpected(
+          translate_not_found(std::move(response.error()), subject));
+    }
+    auto parsed = co_await parse_subject_versions(std::move(response.value()));
     if (!parsed.has_value()) {
         co_return std::unexpected(domain_error{std::move(parsed.error())});
     }

--- a/src/v/pandaproxy/schema_registry/rest_client/client.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.cc
@@ -24,6 +24,7 @@
 #include <boost/beast/http/status.hpp>
 #include <boost/beast/http/verb.hpp>
 
+#include <chrono>
 #include <optional>
 #include <utility>
 #include <variant>
@@ -197,6 +198,12 @@ ss::future<std::expected<iobuf, domain_error>> client::perform_request(
               co_await attach_error_code(domain_error{std::move(error.err)}));
         }
 
+        vlog(
+          srlog.trace,
+          "schema registry request failed, retrying in {}ms: {}",
+          std::chrono::duration_cast<std::chrono::milliseconds>(permit.delay)
+            .count(),
+          error.err);
         retriable_errors.push_back(error.kind);
         last_error.emplace(std::move(error.err));
         auto sleep_fut = co_await ss::coroutine::as_future(

--- a/src/v/pandaproxy/schema_registry/rest_client/client.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.h
@@ -16,6 +16,7 @@
 #include "http/client.h"
 #include "pandaproxy/schema_registry/rest_client/credentials.h"
 #include "pandaproxy/schema_registry/rest_client/error.h"
+#include "pandaproxy/schema_registry/rest_client/parse.h"
 #include "pandaproxy/schema_registry/rest_client/retry_policy.h"
 #include "pandaproxy/schema_registry/types.h"
 #include "utils/retry_chain_node.h"
@@ -83,7 +84,12 @@ public:
     /// subject's schema. With \p deleted set to yes, a soft-deleted version can
     /// be fetched. A missing subject yields subject_not_found; a missing
     /// version (of an existing subject) yields version_not_found.
-    ss::future<std::expected<stored_schema, domain_error>>
+    ///
+    /// The result wraps the schema together with the names of any response
+    /// fields the client did not model (parsed_schema::unknown_fields); a
+    /// caller that needs fidelity can inspect them and apply its own strictness
+    /// policy.
+    ss::future<std::expected<parsed_schema, domain_error>>
     get_schema_by_version(
       const context_subject& subject,
       schema_version version,

--- a/src/v/pandaproxy/schema_registry/rest_client/client.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "base/seastarx.h"
+#include "bytes/iobuf.h"
+#include "container/chunked_vector.h"
+#include "http/client.h"
+#include "pandaproxy/schema_registry/rest_client/credentials.h"
+#include "pandaproxy/schema_registry/rest_client/error.h"
+#include "pandaproxy/schema_registry/rest_client/retry_policy.h"
+#include "pandaproxy/schema_registry/types.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/sstring.hh>
+
+#include <memory>
+#include <optional>
+
+namespace http {
+class request_builder;
+} // namespace http
+
+namespace pandaproxy::schema_registry::rest_client {
+
+/// A reusable client for the Schema Registry REST API, usable against both
+/// Redpanda's own Schema Registry and third-party Confluent-compatible
+/// registries. The HTTP transport is injected (http::abstract_client) so it can
+/// be mocked in tests. A client is lightweight; create one per registry
+/// endpoint. shutdown() must be called before destruction.
+class client {
+public:
+    /// \param http_client the HTTP transport to issue requests on
+    /// \param endpoint the registry's scheme+host (e.g. "https://sr:8081")
+    /// \param credentials optional HTTP Basic auth credentials; absent means no
+    ///        Authorization header is sent
+    /// \param qualified policy for interpreting context-qualified subject
+    ///        strings in responses (see context_subject::from_string); supplied
+    ///        by the caller so parsing does not depend on this node's config
+    /// \param retry_policy classifies failures as retriable/permanent; defaults
+    ///        to default_retry_policy when null. The retry budget/backoff comes
+    ///        from the per-call retry_chain_node, not this policy.
+    client(
+      std::unique_ptr<http::abstract_client> http_client,
+      ss::sstring endpoint,
+      std::optional<basic_auth_credentials> credentials = std::nullopt,
+      qualified_subjects_enabled qualified = qualified_subjects_enabled::no,
+      std::unique_ptr<retry_policy> retry_policy = nullptr);
+
+    client(const client&) = delete;
+    client& operator=(const client&) = delete;
+    client(client&&) = delete;
+    client& operator=(client&&) = delete;
+    ~client() = default;
+
+    /// GET /subjects — list all subjects across all contexts.
+    ss::future<expected<chunked_vector<context_subject>>>
+    list_subjects(retry_chain_node& rtc);
+
+    /// Stops the transport and drains in-flight requests. Must be called before
+    /// destroying the client.
+    ss::future<> shutdown();
+
+private:
+    expected<ss::gate::holder> maybe_gate();
+    void maybe_add_basic_auth(http::request_builder& request);
+
+    // Builds and issues the request against _endpoint, retrying according to
+    // the retry policy and the supplied retry_chain_node, and returns the
+    // collected response body. A permanent http_status_error is enriched with
+    // the parsed error_code before being returned.
+    ss::future<expected<iobuf>> perform_request(
+      retry_chain_node& parent_rtc,
+      http::request_builder builder,
+      std::optional<iobuf> payload = std::nullopt);
+
+    ss::gate _gate;
+    std::unique_ptr<http::abstract_client> _http_client;
+    ss::sstring _endpoint;
+    std::optional<basic_auth_credentials> _credentials;
+    qualified_subjects_enabled _qualified;
+    std::unique_ptr<retry_policy> _retry_policy;
+};
+
+} // namespace pandaproxy::schema_registry::rest_client

--- a/src/v/pandaproxy/schema_registry/rest_client/client.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.h
@@ -72,6 +72,14 @@ public:
     ss::future<expected<chunked_vector<schema_version>>> list_subject_versions(
       const context_subject& subject, retry_chain_node& rtc);
 
+    /// GET /subjects/{subject}/versions/{version} — fetch one version of a
+    /// subject's schema. A missing subject yields subject_not_found; a missing
+    /// version (of an existing subject) yields version_not_found.
+    ss::future<expected<stored_schema>> get_schema_by_version(
+      const context_subject& subject,
+      schema_version version,
+      retry_chain_node& rtc);
+
     /// Stops the transport and drains in-flight requests. Must be called before
     /// destroying the client.
     ss::future<> shutdown();

--- a/src/v/pandaproxy/schema_registry/rest_client/client.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.h
@@ -24,6 +24,7 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/sstring.hh>
 
+#include <expected>
 #include <memory>
 #include <optional>
 
@@ -64,18 +65,20 @@ public:
     ~client() = default;
 
     /// GET /subjects — list all subjects across all contexts.
-    ss::future<expected<chunked_vector<context_subject>>>
+    ss::future<std::expected<chunked_vector<context_subject>, domain_error>>
     list_subjects(retry_chain_node& rtc);
 
     /// GET /subjects/{subject}/versions — list the (live) version numbers
     /// registered under \p subject. A missing subject yields subject_not_found.
-    ss::future<expected<chunked_vector<schema_version>>> list_subject_versions(
+    ss::future<std::expected<chunked_vector<schema_version>, domain_error>>
+    list_subject_versions(
       const context_subject& subject, retry_chain_node& rtc);
 
     /// GET /subjects/{subject}/versions/{version} — fetch one version of a
     /// subject's schema. A missing subject yields subject_not_found; a missing
     /// version (of an existing subject) yields version_not_found.
-    ss::future<expected<stored_schema>> get_schema_by_version(
+    ss::future<std::expected<stored_schema, domain_error>>
+    get_schema_by_version(
       const context_subject& subject,
       schema_version version,
       retry_chain_node& rtc);
@@ -85,14 +88,14 @@ public:
     ss::future<> shutdown();
 
 private:
-    expected<ss::gate::holder> maybe_gate();
+    std::expected<ss::gate::holder, domain_error> maybe_gate();
     void maybe_add_basic_auth(http::request_builder& request);
 
     // Builds and issues the request against _endpoint, retrying according to
     // the retry policy and the supplied retry_chain_node, and returns the
     // collected response body. A permanent http_status_error is enriched with
     // the parsed error_code before being returned.
-    ss::future<expected<iobuf>> perform_request(
+    ss::future<std::expected<iobuf, domain_error>> perform_request(
       retry_chain_node& parent_rtc,
       http::request_builder builder,
       std::optional<iobuf> payload = std::nullopt);

--- a/src/v/pandaproxy/schema_registry/rest_client/client.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.h
@@ -67,6 +67,11 @@ public:
     ss::future<expected<chunked_vector<context_subject>>>
     list_subjects(retry_chain_node& rtc);
 
+    /// GET /subjects/{subject}/versions — list the (live) version numbers
+    /// registered under \p subject. A missing subject yields subject_not_found.
+    ss::future<expected<chunked_vector<schema_version>>> list_subject_versions(
+      const context_subject& subject, retry_chain_node& rtc);
+
     /// Stops the transport and drains in-flight requests. Must be called before
     /// destroying the client.
     ss::future<> shutdown();

--- a/src/v/pandaproxy/schema_registry/rest_client/client.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.h
@@ -64,24 +64,31 @@ public:
     client& operator=(client&&) = delete;
     ~client() = default;
 
-    /// GET /subjects — list all subjects across all contexts.
+    /// GET /subjects — list all subjects across all contexts. With \p deleted
+    /// set to yes, soft-deleted subjects are included in the listing.
     ss::future<std::expected<chunked_vector<context_subject>, domain_error>>
-    list_subjects(retry_chain_node& rtc);
+    list_subjects(
+      retry_chain_node& rtc, include_deleted deleted = include_deleted::no);
 
-    /// GET /subjects/{subject}/versions — list the (live) version numbers
-    /// registered under \p subject. A missing subject yields subject_not_found.
+    /// GET /subjects/{subject}/versions — list the version numbers registered
+    /// under \p subject. With \p deleted set to yes, soft-deleted versions are
+    /// included. A missing subject yields subject_not_found.
     ss::future<std::expected<chunked_vector<schema_version>, domain_error>>
     list_subject_versions(
-      const context_subject& subject, retry_chain_node& rtc);
+      const context_subject& subject,
+      retry_chain_node& rtc,
+      include_deleted deleted = include_deleted::no);
 
     /// GET /subjects/{subject}/versions/{version} — fetch one version of a
-    /// subject's schema. A missing subject yields subject_not_found; a missing
+    /// subject's schema. With \p deleted set to yes, a soft-deleted version can
+    /// be fetched. A missing subject yields subject_not_found; a missing
     /// version (of an existing subject) yields version_not_found.
     ss::future<std::expected<stored_schema, domain_error>>
     get_schema_by_version(
       const context_subject& subject,
       schema_version version,
-      retry_chain_node& rtc);
+      retry_chain_node& rtc,
+      include_deleted deleted = include_deleted::no);
 
     /// Stops the transport and drains in-flight requests. Must be called before
     /// destroying the client.

--- a/src/v/pandaproxy/schema_registry/rest_client/credentials.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/credentials.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "base/seastarx.h"
+
+#include <seastar/core/sstring.hh>
+
+namespace pandaproxy::schema_registry::rest_client {
+
+/// Credentials for HTTP Basic authentication (RFC 7617) to a Schema Registry.
+/// The client holds these as std::optional; an absent value means no
+/// Authorization header is sent (an unauthenticated deployment).
+struct basic_auth_credentials {
+    ss::sstring username;
+    ss::sstring password;
+};
+
+} // namespace pandaproxy::schema_registry::rest_client

--- a/src/v/pandaproxy/schema_registry/rest_client/error.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/error.h
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "base/external_fmt.h"
+#include "base/format_to.h"
+#include "base/seastarx.h"
+#include "http/request_builder.h"
+#include "pandaproxy/schema_registry/rest_client/parse.h"
+#include "pandaproxy/schema_registry/types.h"
+#include "utils/named_type.h"
+
+#include <seastar/core/sstring.hh>
+#include <seastar/util/variant_utils.hh>
+
+#include <boost/beast/http/status.hpp>
+#include <fmt/ranges.h>
+
+#include <cstdint>
+#include <optional>
+#include <variant>
+#include <vector>
+
+namespace pandaproxy::schema_registry::rest_client {
+
+struct http_status_error {
+    boost::beast::http::status status;
+    ss::sstring body;
+    // The Schema Registry `error_code` from the response body, when one could
+    // be parsed. It is finer-grained than the HTTP status: e.g. a 404 may carry
+    // 40401 (subject not found) or 40402 (version not found). Left empty when
+    // there is no parseable body.
+    std::optional<int32_t> error_code;
+
+    fmt::iterator format_to(fmt::iterator it) const {
+        it = fmt::format_to(it, "{}", status);
+        if (error_code.has_value()) {
+            it = fmt::format_to(it, " (error_code={})", *error_code);
+        }
+        if (!body.empty()) {
+            it = fmt::format_to(it, ": {}", body);
+        }
+        return it;
+    }
+};
+
+// An error seen during an http call, represented either by a status code with
+// response body, or a string in case of an exception.
+using http_call_error = std::variant<http_status_error, ss::sstring>;
+
+enum class error_kind {
+    permanent_failure,
+    aborted,
+    retriable_http_status,
+    network_error,
+    timeout,
+};
+
+constexpr std::string_view to_string_view(error_kind r) {
+    using enum error_kind;
+    switch (r) {
+    case permanent_failure:
+        return "permanent_failure";
+    case aborted:
+        return "aborted";
+    case retriable_http_status:
+        return "retriable_http_status";
+    case network_error:
+        return "network_error";
+    case timeout:
+        return "timeout";
+    }
+}
+
+inline fmt::iterator format_to(error_kind r, fmt::iterator out) {
+    return fmt::format_to(out, "{}", to_string_view(r));
+}
+
+constexpr bool is_retriable(error_kind r) {
+    switch (r) {
+    case error_kind::retriable_http_status:
+    case error_kind::network_error:
+    case error_kind::timeout:
+        return true;
+    case error_kind::permanent_failure:
+    case error_kind::aborted:
+        return false;
+    }
+}
+
+struct retries_exhausted {
+    std::vector<error_kind> reasons;
+    std::optional<http_call_error> last_error;
+};
+
+// Error returned when the underlying subsystems are being shut down.
+using aborted_error = named_type<ss::sstring, struct aborted_tag>;
+
+// The requested subject does not exist (HTTP 404 / error_code 40401).
+struct subject_not_found {
+    context_subject subject;
+
+    fmt::iterator format_to(fmt::iterator it) const {
+        return fmt::format_to(it, "subject not found: {}", subject);
+    }
+};
+
+// The requested version of an existing subject does not exist
+// (HTTP 404 / error_code 40402).
+struct version_not_found {
+    context_subject subject;
+    schema_version version;
+
+    fmt::iterator format_to(fmt::iterator it) const {
+        return fmt::format_to(
+          it, "version not found: subject={} version={}", subject, version());
+    }
+};
+
+// Represents the sum of all error types which can be encountered during
+// rest-client operations. The JSON-decode arm reuses parse_error from parse.h.
+using domain_error = std::variant<
+  http::url_build_error,
+  parse_error,
+  http_call_error,
+  retries_exhausted,
+  subject_not_found,
+  version_not_found,
+  aborted_error>;
+
+// The core result type used by all operations in the SR rest-client which can
+// fail. Uses std::expected for consistency with the response parsers.
+template<typename T>
+using expected = std::expected<T, domain_error>;
+
+} // namespace pandaproxy::schema_registry::rest_client
+
+template<>
+struct fmt::formatter<pandaproxy::schema_registry::rest_client::http_call_error>
+  : fmt::formatter<std::string_view> {
+    auto format(
+      const pandaproxy::schema_registry::rest_client::http_call_error& err,
+      fmt::format_context& ctx) const -> decltype(ctx.out()) {
+        return std::visit(
+          [&ctx](const auto& value) {
+              return fmt::format_to(ctx.out(), "http_call_error: {}", value);
+          },
+          err);
+    }
+};
+
+template<>
+struct fmt::formatter<pandaproxy::schema_registry::rest_client::domain_error>
+  : fmt::formatter<std::string_view> {
+    auto format(
+      const pandaproxy::schema_registry::rest_client::domain_error& err,
+      fmt::format_context& ctx) const -> decltype(ctx.out()) {
+        namespace rc = pandaproxy::schema_registry::rest_client;
+        return ss::visit(
+          err,
+          [&](const http::url_build_error& value) {
+              return fmt::format_to(ctx.out(), "url_build_error: {}", value);
+          },
+          [&](const rc::parse_error& value) {
+              return fmt::format_to(ctx.out(), "parse_error: {}", value.reason);
+          },
+          [&](const rc::http_call_error& value) {
+              return fmt::format_to(ctx.out(), "{}", value);
+          },
+          [&](const rc::retries_exhausted& value) {
+              auto it = fmt::format_to(
+                ctx.out(),
+                "retries_exhausted:[reasons=[{}]",
+                fmt::join(value.reasons, ", "));
+              if (value.last_error.has_value()) {
+                  it = fmt::format_to(it, ", last_error={}", *value.last_error);
+              }
+              return fmt::format_to(it, "]");
+          },
+          [&](const rc::subject_not_found& value) {
+              return fmt::format_to(ctx.out(), "{}", value);
+          },
+          [&](const rc::version_not_found& value) {
+              return fmt::format_to(ctx.out(), "{}", value);
+          },
+          [&](const rc::aborted_error& value) {
+              return fmt::format_to(ctx.out(), "aborted_error: {}", value);
+          });
+    }
+};

--- a/src/v/pandaproxy/schema_registry/rest_client/error.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/error.h
@@ -136,11 +136,6 @@ using domain_error = std::variant<
   version_not_found,
   aborted_error>;
 
-// The core result type used by all operations in the SR rest-client which can
-// fail. Uses std::expected for consistency with the response parsers.
-template<typename T>
-using expected = std::expected<T, domain_error>;
-
 } // namespace pandaproxy::schema_registry::rest_client
 
 template<>

--- a/src/v/pandaproxy/schema_registry/rest_client/error.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/error.h
@@ -39,6 +39,13 @@ struct http_status_error {
     // 40401 (subject not found) or 40402 (version not found). Left empty when
     // there is no parseable body.
     std::optional<int32_t> error_code;
+    // The human-readable `message` from the Schema Registry error body, when
+    // one was present (typically a fixed string templated on the
+    // subject/context/version/id). Captured so the available detail is
+    // discoverable from the interface; note the raw `body` above is what
+    // currently gets logged. Empty when there is no parseable body or no
+    // `message` field.
+    std::optional<ss::sstring> message;
 
     fmt::iterator format_to(fmt::iterator it) const {
         it = fmt::format_to(it, "{}", status);

--- a/src/v/pandaproxy/schema_registry/rest_client/logger.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/logger.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+
+#include <seastar/util/log.hh>
+
+namespace pandaproxy::schema_registry::rest_client {
+// Separate from the main "schemaregistry" logger so this client's traffic can
+// be enabled independently of the rest of the schema registry.
+inline ss::logger srclog("schemaregistry/client");
+} // namespace pandaproxy::schema_registry::rest_client

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "pandaproxy/schema_registry/rest_client/parse.h"
+
+#include "serde/json/parser.h"
+#include "ssx/sformat.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace pandaproxy::schema_registry::rest_client {
+
+ss::future<std::expected<chunked_vector<context_subject>, parse_error>>
+parse_subjects(iobuf body, qualified_subjects_enabled qualified) {
+    using token = serde::json::token;
+    // Firewall exceptions from the parser: malformed input is reported via the
+    // returned std::expected, not thrown.
+    try {
+        serde::json::parser p(std::move(body));
+
+        if (!co_await p.next() || p.token() != token::start_array) {
+            co_return std::unexpected(
+              parse_error{.reason = "expected a JSON array of subjects"});
+        }
+
+        chunked_vector<context_subject> subjects;
+        while (co_await p.next()) {
+            switch (p.token()) {
+            case token::end_array:
+                // The body is exactly a JSON array of strings: reject any
+                // trailing content rather than ignoring it.
+                co_await p.next();
+                if (p.token() != token::eof) {
+                    co_return std::unexpected(
+                      parse_error{
+                        .reason = "trailing content after subjects array"});
+                }
+                co_return std::move(subjects);
+            case token::value_string:
+                subjects.push_back(
+                  context_subject::from_string(
+                    p.value_string().linearize_to_string(), qualified));
+                break;
+            default:
+                co_return std::unexpected(
+                  parse_error{
+                    .reason = "expected a string element in subjects array"});
+            }
+        }
+
+        // next() returned false before the closing ']' was seen.
+        co_return std::unexpected(
+          parse_error{.reason = "truncated or malformed JSON"});
+    } catch (const std::exception& e) {
+        co_return std::unexpected(
+          parse_error{
+            .reason = ssx::sformat("failed to parse subjects: {}", e.what())});
+    }
+}
+
+} // namespace pandaproxy::schema_registry::rest_client

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.cc
@@ -361,4 +361,58 @@ parse_subject_version(iobuf body, qualified_subjects_enabled qualified) {
     }
 }
 
+ss::future<std::optional<error_body>> parse_error_body(iobuf body) {
+    using token = serde::json::token;
+    // Tolerant: any structural problem yields nullopt rather than an error;
+    // the caller then falls back to the HTTP status.
+    try {
+        serde::json::parser p(std::move(body));
+
+        if (!co_await p.next() || p.token() != token::start_object) {
+            co_return std::nullopt;
+        }
+
+        std::optional<int32_t> code;
+        ss::sstring message;
+        while (co_await p.next()) {
+            if (p.token() == token::end_object) {
+                // Require the object to be the entire body: a complete object
+                // followed by trailing content, or one carrying no integer
+                // error_code, yields nullopt (the caller falls back to the
+                // HTTP status).
+                co_await p.next();
+                if (p.token() != token::eof || !code.has_value()) {
+                    co_return std::nullopt;
+                }
+                co_return error_body{
+                  .error_code = *code, .message = std::move(message)};
+            }
+            if (p.token() != token::key) {
+                co_return std::nullopt;
+            }
+            auto key = p.value_string().linearize_to_string();
+            if (!co_await p.next()) {
+                co_return std::nullopt;
+            }
+            if (key == "error_code" && p.token() == token::value_int) {
+                auto v = p.value_int();
+                if (
+                  v >= std::numeric_limits<int32_t>::min()
+                  && v <= std::numeric_limits<int32_t>::max()) {
+                    code = static_cast<int32_t>(v);
+                }
+            } else if (key == "message" && p.token() == token::value_string) {
+                message = p.value_string().linearize_to_string();
+            } else {
+                co_await p.skip_value();
+            }
+        }
+
+        // next() returned false before the closing '}'.
+        co_return std::nullopt;
+    } catch (const std::exception&) {
+        co_return std::nullopt;
+    }
+}
+
 } // namespace pandaproxy::schema_registry::rest_client

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.cc
@@ -223,7 +223,7 @@ parse_references(serde::json::parser& p, qualified_subjects_enabled qualified) {
 
 } // namespace
 
-ss::future<std::expected<stored_schema, parse_error>>
+ss::future<std::expected<parsed_schema, parse_error>>
 parse_subject_version(iobuf body, qualified_subjects_enabled qualified) {
     using token = serde::json::token;
     // Firewall exceptions from the parser: malformed input is reported via the
@@ -243,6 +243,7 @@ parse_subject_version(iobuf body, qualified_subjects_enabled qualified) {
         schema_type type{schema_type::avro};
         schema_definition::references refs;
         is_deleted deleted{false};
+        chunked_vector<ss::sstring> unknown_fields;
 
         while (co_await p.next()) {
             if (p.token() == token::end_object) {
@@ -255,19 +256,22 @@ parse_subject_version(iobuf body, qualified_subjects_enabled qualified) {
                         .reason = "trailing content after schema object"});
                 }
                 // Absent fields fall back to defaults/sentinels; completeness
-                // is a higher-layer concern.
-                co_return stored_schema{
-                  .schema = subject_schema{
-                    subject.value_or(invalid_subject),
-                    schema_definition{
-                      schema_definition::raw_string{
-                        std::move(schema).value_or(iobuf{})},
-                      type,
-                      std::move(refs),
-                      std::nullopt}},
-                  .version = version.value_or(invalid_schema_version),
-                  .id = id.value_or(invalid_schema_id),
-                  .deleted = deleted};
+                // is a higher-layer concern. Unmodeled fields were recorded in
+                // unknown_fields above for the caller to act on.
+                co_return parsed_schema{
+                  .schema = stored_schema{
+                    .schema = subject_schema{
+                      subject.value_or(invalid_subject),
+                      schema_definition{
+                        schema_definition::raw_string{
+                          std::move(schema).value_or(iobuf{})},
+                        type,
+                        std::move(refs),
+                        std::nullopt}},
+                    .version = version.value_or(invalid_schema_version),
+                    .id = id.value_or(invalid_schema_id),
+                    .deleted = deleted},
+                  .unknown_fields = std::move(unknown_fields)};
             }
             if (p.token() != token::key) {
                 co_return std::unexpected(
@@ -346,7 +350,10 @@ parse_subject_version(iobuf body, qualified_subjects_enabled qualified) {
                 refs = std::move(*r);
             } else {
                 // Unknown / not-yet-modeled field (guid, ts, ruleSet,
-                // schemaTags, metadata, ...): ignore it.
+                // schemaTags, metadata, ...): skip its value, but record the
+                // top-level key so the caller can decide whether dropping it is
+                // acceptable.
+                unknown_fields.push_back(std::move(key));
                 co_await p.skip_value();
             }
         }

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.cc
@@ -17,6 +17,8 @@
 
 #include <cstdint>
 #include <limits>
+#include <optional>
+#include <utility>
 
 namespace pandaproxy::schema_registry::rest_client {
 
@@ -126,6 +128,236 @@ parse_subject_versions(iobuf body) {
         co_return std::unexpected(
           parse_error{
             .reason = ssx::sformat("failed to parse versions: {}", e.what())});
+    }
+}
+
+namespace {
+
+// A present version must be a positive value representable as int32; this also
+// keeps a present value from aliasing invalid_schema_version (-1).
+std::optional<int32_t> checked_positive_i32(int64_t v) {
+    if (v < 1 || v > std::numeric_limits<int32_t>::max()) {
+        return std::nullopt;
+    }
+    return static_cast<int32_t>(v);
+}
+
+// A present id may be 0 (upstream permits id 0 on import), so it must be a
+// non-negative value representable as int32; this keeps a present value from
+// aliasing invalid_schema_id (-1).
+std::optional<int32_t> checked_nonnegative_i32(int64_t v) {
+    if (v < 0 || v > std::numeric_limits<int32_t>::max()) {
+        return std::nullopt;
+    }
+    return static_cast<int32_t>(v);
+}
+
+// Parse a JSON array of {name, subject, version} reference objects. Entered
+// with the current token at the array start; leaves the parser at the end_array
+// token. Lenient: unknown keys within a reference are skipped, absent fields
+// take defaults; only wrong-typed values are rejected.
+ss::future<std::expected<schema_definition::references, parse_error>>
+parse_references(serde::json::parser& p, qualified_subjects_enabled qualified) {
+    using token = serde::json::token;
+    schema_definition::references refs;
+    while (co_await p.next()) {
+        if (p.token() == token::end_array) {
+            co_return refs;
+        }
+        if (p.token() != token::start_object) {
+            co_return std::unexpected(
+              parse_error{.reason = "schema reference must be an object"});
+        }
+        ss::sstring name;
+        std::optional<context_subject_reference> sub;
+        std::optional<schema_version> version;
+        while (co_await p.next() && p.token() != token::end_object) {
+            auto key = p.value_string().linearize_to_string();
+            if (!co_await p.next()) {
+                co_return std::unexpected(
+                  parse_error{.reason = "truncated JSON in schema reference"});
+            }
+            if (key == "name") {
+                if (p.token() != token::value_string) {
+                    co_return std::unexpected(
+                      parse_error{
+                        .reason = "schema reference name must be a string"});
+                }
+                name = p.value_string().linearize_to_string();
+            } else if (key == "subject") {
+                if (p.token() != token::value_string) {
+                    co_return std::unexpected(
+                      parse_error{
+                        .reason = "schema reference subject must be a string"});
+                }
+                sub = context_subject_reference::from_string(
+                  p.value_string().linearize_to_string(), qualified);
+            } else if (key == "version") {
+                if (p.token() != token::value_int) {
+                    co_return std::unexpected(
+                      parse_error{
+                        .reason
+                        = "schema reference version must be an integer"});
+                }
+                auto v = checked_positive_i32(p.value_int());
+                if (!v) {
+                    co_return std::unexpected(
+                      parse_error{
+                        .reason = "schema reference version out of range"});
+                }
+                version = schema_version{*v};
+            } else {
+                co_await p.skip_value();
+            }
+        }
+        refs.push_back(
+          schema_reference{
+            .name = std::move(name),
+            .sub = sub.value_or(
+              context_subject_reference{invalid_subject, is_qualified::no}),
+            .version = version.value_or(invalid_schema_version)});
+    }
+    co_return std::unexpected(
+      parse_error{.reason = "truncated or malformed references array"});
+}
+
+} // namespace
+
+ss::future<std::expected<stored_schema, parse_error>>
+parse_subject_version(iobuf body, qualified_subjects_enabled qualified) {
+    using token = serde::json::token;
+    // Firewall exceptions from the parser: malformed input is reported via the
+    // returned std::expected, not thrown.
+    try {
+        serde::json::parser p(std::move(body));
+
+        if (!co_await p.next() || p.token() != token::start_object) {
+            co_return std::unexpected(
+              parse_error{.reason = "expected a JSON object"});
+        }
+
+        std::optional<context_subject> subject;
+        std::optional<schema_version> version;
+        std::optional<schema_id> id;
+        std::optional<iobuf> schema;
+        schema_type type{schema_type::avro};
+        schema_definition::references refs;
+        is_deleted deleted{false};
+
+        while (co_await p.next()) {
+            if (p.token() == token::end_object) {
+                // The body is exactly one JSON object: reject any trailing
+                // content rather than ignoring it.
+                co_await p.next();
+                if (p.token() != token::eof) {
+                    co_return std::unexpected(
+                      parse_error{
+                        .reason = "trailing content after schema object"});
+                }
+                // Absent fields fall back to defaults/sentinels; completeness
+                // is a higher-layer concern.
+                co_return stored_schema{
+                  .schema = subject_schema{
+                    subject.value_or(invalid_subject),
+                    schema_definition{
+                      schema_definition::raw_string{
+                        std::move(schema).value_or(iobuf{})},
+                      type,
+                      std::move(refs),
+                      std::nullopt}},
+                  .version = version.value_or(invalid_schema_version),
+                  .id = id.value_or(invalid_schema_id),
+                  .deleted = deleted};
+            }
+            if (p.token() != token::key) {
+                co_return std::unexpected(
+                  parse_error{.reason = "expected an object key"});
+            }
+            auto key = p.value_string().linearize_to_string();
+            if (!co_await p.next()) {
+                co_return std::unexpected(
+                  parse_error{.reason = "truncated JSON after key"});
+            }
+            if (key == "subject") {
+                if (p.token() != token::value_string) {
+                    co_return std::unexpected(
+                      parse_error{.reason = "subject must be a string"});
+                }
+                subject = context_subject::from_string(
+                  p.value_string().linearize_to_string(), qualified);
+            } else if (key == "version") {
+                if (p.token() != token::value_int) {
+                    co_return std::unexpected(
+                      parse_error{.reason = "version must be an integer"});
+                }
+                auto v = checked_positive_i32(p.value_int());
+                if (!v) {
+                    co_return std::unexpected(
+                      parse_error{.reason = "version out of range"});
+                }
+                version = schema_version{*v};
+            } else if (key == "id") {
+                if (p.token() != token::value_int) {
+                    co_return std::unexpected(
+                      parse_error{.reason = "id must be an integer"});
+                }
+                auto v = checked_nonnegative_i32(p.value_int());
+                if (!v) {
+                    co_return std::unexpected(
+                      parse_error{.reason = "id out of range"});
+                }
+                id = schema_id{*v};
+            } else if (key == "schema") {
+                if (p.token() != token::value_string) {
+                    co_return std::unexpected(
+                      parse_error{.reason = "schema must be a string"});
+                }
+                schema = p.value_string();
+            } else if (key == "schemaType") {
+                if (p.token() != token::value_string) {
+                    co_return std::unexpected(
+                      parse_error{.reason = "schemaType must be a string"});
+                }
+                auto st = from_string_view<schema_type>(
+                  p.value_string().linearize_to_string());
+                if (!st) {
+                    co_return std::unexpected(
+                      parse_error{.reason = "unknown schemaType"});
+                }
+                type = *st;
+            } else if (key == "deleted") {
+                if (p.token() == token::value_true) {
+                    deleted = is_deleted::yes;
+                } else if (p.token() == token::value_false) {
+                    deleted = is_deleted::no;
+                } else {
+                    co_return std::unexpected(
+                      parse_error{.reason = "deleted must be a boolean"});
+                }
+            } else if (key == "references") {
+                if (p.token() != token::start_array) {
+                    co_return std::unexpected(
+                      parse_error{.reason = "references must be an array"});
+                }
+                auto r = co_await parse_references(p, qualified);
+                if (!r) {
+                    co_return std::unexpected(std::move(r.error()));
+                }
+                refs = std::move(*r);
+            } else {
+                // Unknown / not-yet-modeled field (guid, ts, ruleSet,
+                // schemaTags, metadata, ...): ignore it.
+                co_await p.skip_value();
+            }
+        }
+
+        // next() returned false before the closing '}'.
+        co_return std::unexpected(
+          parse_error{.reason = "truncated or malformed JSON"});
+    } catch (const std::exception& e) {
+        co_return std::unexpected(
+          parse_error{
+            .reason = ssx::sformat("failed to parse schema: {}", e.what())});
     }
 }
 

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.cc
@@ -15,6 +15,9 @@
 
 #include <seastar/core/coroutine.hh>
 
+#include <cstdint>
+#include <limits>
+
 namespace pandaproxy::schema_registry::rest_client {
 
 ss::future<std::expected<chunked_vector<context_subject>, parse_error>>
@@ -62,6 +65,67 @@ parse_subjects(iobuf body, qualified_subjects_enabled qualified) {
         co_return std::unexpected(
           parse_error{
             .reason = ssx::sformat("failed to parse subjects: {}", e.what())});
+    }
+}
+
+ss::future<std::expected<chunked_vector<schema_version>, parse_error>>
+parse_subject_versions(iobuf body) {
+    using token = serde::json::token;
+    // Firewall exceptions from the parser: malformed input is reported via the
+    // returned std::expected, not thrown.
+    try {
+        serde::json::parser p(std::move(body));
+
+        if (!co_await p.next() || p.token() != token::start_array) {
+            co_return std::unexpected(
+              parse_error{.reason = "expected a JSON array of versions"});
+        }
+
+        chunked_vector<schema_version> versions;
+        while (co_await p.next()) {
+            switch (p.token()) {
+            case token::end_array:
+                // The body is exactly a JSON array of integers: reject any
+                // trailing content rather than ignoring it.
+                co_await p.next();
+                if (p.token() != token::eof) {
+                    co_return std::unexpected(
+                      parse_error{
+                        .reason = "trailing content after versions array"});
+                }
+                co_return std::move(versions);
+            case token::value_int: {
+                auto v = p.value_int();
+                if (v < 0) {
+                    // Only the deletedAsNegative mode produces negatives, which
+                    // this client does not request; modeling soft-deleted
+                    // versions is future work.
+                    co_return std::unexpected(
+                      parse_error{
+                        .reason = "negative version number; deletedAsNegative "
+                                  "mode is not supported"});
+                }
+                if (v < 1 || v > std::numeric_limits<int32_t>::max()) {
+                    co_return std::unexpected(
+                      parse_error{.reason = "version number out of range"});
+                }
+                versions.push_back(schema_version{static_cast<int32_t>(v)});
+                break;
+            }
+            default:
+                co_return std::unexpected(
+                  parse_error{
+                    .reason = "expected an integer element in versions array"});
+            }
+        }
+
+        // next() returned false before the closing ']' was seen.
+        co_return std::unexpected(
+          parse_error{.reason = "truncated or malformed JSON"});
+    } catch (const std::exception& e) {
+        co_return std::unexpected(
+          parse_error{
+            .reason = ssx::sformat("failed to parse versions: {}", e.what())});
     }
 }
 

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.cc
@@ -22,6 +22,29 @@
 
 namespace pandaproxy::schema_registry::rest_client {
 
+namespace {
+
+// A present version must be a positive value representable as int32; this also
+// keeps a present value from aliasing invalid_schema_version (-1).
+std::optional<int32_t> checked_positive_i32(int64_t v) {
+    if (v < 1 || v > std::numeric_limits<int32_t>::max()) {
+        return std::nullopt;
+    }
+    return static_cast<int32_t>(v);
+}
+
+// A present id may be 0 (upstream permits id 0 on import), so it must be a
+// non-negative value representable as int32; this keeps a present value from
+// aliasing invalid_schema_id (-1).
+std::optional<int32_t> checked_nonnegative_i32(int64_t v) {
+    if (v < 0 || v > std::numeric_limits<int32_t>::max()) {
+        return std::nullopt;
+    }
+    return static_cast<int32_t>(v);
+}
+
+} // namespace
+
 ss::future<std::expected<chunked_vector<context_subject>, parse_error>>
 parse_subjects(iobuf body, qualified_subjects_enabled qualified) {
     using token = serde::json::token;
@@ -97,8 +120,8 @@ parse_subject_versions(iobuf body) {
                 }
                 co_return std::move(versions);
             case token::value_int: {
-                auto v = p.value_int();
-                if (v < 0) {
+                auto raw = p.value_int();
+                if (raw < 0) {
                     // Only the deletedAsNegative mode produces negatives, which
                     // this client does not request; modeling soft-deleted
                     // versions is future work.
@@ -107,11 +130,12 @@ parse_subject_versions(iobuf body) {
                         .reason = "negative version number; deletedAsNegative "
                                   "mode is not supported"});
                 }
-                if (v < 1 || v > std::numeric_limits<int32_t>::max()) {
+                auto v = checked_positive_i32(raw);
+                if (!v) {
                     co_return std::unexpected(
                       parse_error{.reason = "version number out of range"});
                 }
-                versions.push_back(schema_version{static_cast<int32_t>(v)});
+                versions.push_back(schema_version{*v});
                 break;
             }
             default:
@@ -132,25 +156,6 @@ parse_subject_versions(iobuf body) {
 }
 
 namespace {
-
-// A present version must be a positive value representable as int32; this also
-// keeps a present value from aliasing invalid_schema_version (-1).
-std::optional<int32_t> checked_positive_i32(int64_t v) {
-    if (v < 1 || v > std::numeric_limits<int32_t>::max()) {
-        return std::nullopt;
-    }
-    return static_cast<int32_t>(v);
-}
-
-// A present id may be 0 (upstream permits id 0 on import), so it must be a
-// non-negative value representable as int32; this keeps a present value from
-// aliasing invalid_schema_id (-1).
-std::optional<int32_t> checked_nonnegative_i32(int64_t v) {
-    if (v < 0 || v > std::numeric_limits<int32_t>::max()) {
-        return std::nullopt;
-    }
-    return static_cast<int32_t>(v);
-}
 
 // Parse a JSON array of {name, subject, version} reference objects. Entered
 // with the current token at the array start; leaves the parser at the end_array

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.cc
@@ -226,6 +226,89 @@ parse_references(serde::json::parser& p, qualified_subjects_enabled qualified) {
       parse_error{.reason = "truncated or malformed references array"});
 }
 
+// The result of parsing a metadata object: the modeled portion plus the names
+// of any sub-keys we don't model.
+struct parsed_metadata {
+    schema_metadata metadata;
+    // Unmodeled keys found directly inside `metadata` (e.g. `tags`,
+    // `sensitive`), unqualified; the caller qualifies and propagates them.
+    chunked_vector<ss::sstring> unknown_fields;
+};
+
+// Parse a metadata object of the form {"properties": {<str>: <str>}, ...}.
+// Entered with the current token at the object start; leaves the parser at the
+// end_object token. Only `properties` is modeled; its values are stored as
+// strings, with numbers and booleans coerced to strings to match the write
+// path. Any other key (e.g. `tags`, `sensitive`) is returned, unqualified, in
+// parsed_metadata::unknown_fields for the caller to record.
+ss::future<std::expected<parsed_metadata, parse_error>>
+parse_metadata(serde::json::parser& p) {
+    using token = serde::json::token;
+    parsed_metadata result;
+    while (co_await p.next()) {
+        if (p.token() == token::end_object) {
+            co_return result;
+        }
+        auto key = p.value_string().linearize_to_string();
+        if (!co_await p.next()) {
+            co_return std::unexpected(
+              parse_error{.reason = "truncated JSON in schema metadata"});
+        }
+        if (key != "properties") {
+            result.unknown_fields.push_back(std::move(key));
+            co_await p.skip_value();
+            continue;
+        }
+        if (p.token() == token::value_null) {
+            continue;
+        }
+        if (p.token() != token::start_object) {
+            co_return std::unexpected(
+              parse_error{
+                .reason = "schema metadata properties must be an object"});
+        }
+        auto& props = result.metadata.properties.emplace();
+        while (co_await p.next()) {
+            if (p.token() == token::end_object) {
+                break;
+            }
+            auto prop_key = p.value_string().linearize_to_string();
+            if (!co_await p.next()) {
+                co_return std::unexpected(
+                  parse_error{
+                    .reason = "truncated JSON in schema metadata properties"});
+            }
+            switch (p.token()) {
+            case token::value_string:
+                props.insert_or_assign(
+                  std::move(prop_key), p.value_string().linearize_to_string());
+                break;
+            case token::value_int:
+                props.insert_or_assign(
+                  std::move(prop_key), ssx::sformat("{}", p.value_int()));
+                break;
+            case token::value_double:
+                props.insert_or_assign(
+                  std::move(prop_key), ssx::sformat("{}", p.value_double()));
+                break;
+            case token::value_true:
+                props.insert_or_assign(std::move(prop_key), "true");
+                break;
+            case token::value_false:
+                props.insert_or_assign(std::move(prop_key), "false");
+                break;
+            default:
+                co_return std::unexpected(
+                  parse_error{
+                    .reason = "schema metadata property value must be a "
+                              "string, number, or boolean"});
+            }
+        }
+    }
+    co_return std::unexpected(
+      parse_error{.reason = "truncated or malformed schema metadata object"});
+}
+
 } // namespace
 
 ss::future<std::expected<parsed_schema, parse_error>>
@@ -248,6 +331,7 @@ parse_subject_version(iobuf body, qualified_subjects_enabled qualified) {
         schema_type type{schema_type::avro};
         schema_definition::references refs;
         is_deleted deleted{false};
+        std::optional<schema_metadata> metadata;
         chunked_vector<ss::sstring> unknown_fields;
 
         while (co_await p.next()) {
@@ -272,7 +356,7 @@ parse_subject_version(iobuf body, qualified_subjects_enabled qualified) {
                           std::move(schema).value_or(iobuf{})},
                         type,
                         std::move(refs),
-                        std::nullopt}},
+                        std::move(metadata)}},
                     .version = version.value_or(invalid_schema_version),
                     .id = id.value_or(invalid_schema_id),
                     .deleted = deleted},
@@ -353,10 +437,30 @@ parse_subject_version(iobuf body, qualified_subjects_enabled qualified) {
                     co_return std::unexpected(std::move(r.error()));
                 }
                 refs = std::move(*r);
+            } else if (key == "metadata") {
+                // Partially modeled: parse_metadata captures `properties` and
+                // returns any other sub-key (e.g. `tags`), which we qualify
+                // with a `metadata.` prefix into unknown_fields. A null
+                // metadata is treated as absent; any other non-object is
+                // unrepresentable.
+                if (p.token() == token::start_object) {
+                    auto m = co_await parse_metadata(p);
+                    if (!m) {
+                        co_return std::unexpected(std::move(m.error()));
+                    }
+                    metadata = std::move(m->metadata);
+                    for (const auto& sub : m->unknown_fields) {
+                        unknown_fields.push_back(
+                          ssx::sformat("metadata.{}", sub));
+                    }
+                } else if (p.token() != token::value_null) {
+                    co_return std::unexpected(
+                      parse_error{.reason = "metadata must be an object"});
+                }
             } else {
                 // Unknown / not-yet-modeled field (guid, ts, ruleSet,
-                // schemaTags, metadata, ...): skip its value, but record the
-                // top-level key so the caller can decide whether dropping it is
+                // schemaTags, ...): skip its value, but record the top-level
+                // key so the caller can decide whether dropping it is
                 // acceptable.
                 unknown_fields.push_back(std::move(key));
                 co_await p.skip_value();

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.h
@@ -64,15 +64,34 @@ parse_subjects(iobuf body, qualified_subjects_enabled qualified);
 ss::future<std::expected<chunked_vector<schema_version>, parse_error>>
 parse_subject_versions(iobuf body);
 
+/// The outcome of parsing a get-schema-by-version response: the schema, plus
+/// the names of any top-level response fields the parser did not model.
+///
+/// parse_subject_version is deliberately lenient — it never rejects a response
+/// merely for carrying fields it doesn't model; it skips them and records their
+/// names here. This lets a caller that needs fidelity (e.g. schema migration)
+/// apply its own policy — reject, warn, or ignore — while a caller that doesn't
+/// care simply disregards the list. Only top-level keys are recorded; an
+/// unmodeled key nested inside a modeled field (e.g. within a reference) is
+/// skipped without being reported. It is therefore a best-effort signal that
+/// content was dropped, not a proof of a lossless round-trip.
+struct parsed_schema {
+    stored_schema schema;
+    chunked_vector<ss::sstring> unknown_fields;
+};
+
 /// Parse the body of a `GET /subjects/{subject}/versions/{version}` response
-/// into a stored_schema.
+/// into a parsed_schema (the schema plus the names of any unmodeled top-level
+/// fields).
 ///
 /// This is a faithful, lenient deserialization (the lowest layer): unknown or
 /// not-yet-modeled fields (`guid`, `ts`, `ruleSet`, `schemaTags`, `metadata`,
-/// ...) are ignored, and absent fields take their default/sentinel (absent
-/// `schemaType` -> AVRO, `deleted` -> false, `references` -> empty, and absent
-/// `subject`/`version`/`id`/`schema` -> the invalid sentinels). It does NOT
-/// enforce completeness — whether an incomplete response is acceptable (a
+/// ...) are skipped — their names are collected in
+/// parsed_schema::unknown_fields for the caller to act on — and absent fields
+/// take their default/sentinel (absent `schemaType` -> AVRO, `deleted` ->
+/// false, `references` -> empty, and absent `subject`/`version`/`id`/`schema`
+/// -> the invalid sentinels). It does NOT enforce completeness or reject for
+/// unmodeled fields — whether an incomplete or lossy response is acceptable (a
 /// strict mode) is a higher-layer concern. It rejects only inputs it cannot
 /// represent: a non-object body, malformed JSON, a present modeled field with a
 /// wrong-typed or out-of-range value, or an unknown `schemaType`.
@@ -80,7 +99,7 @@ parse_subject_versions(iobuf body);
 /// \p qualified is the caller-supplied policy for interpreting
 /// context-qualified subject strings (the response `subject` and each
 /// reference's `subject`). The function does not throw.
-ss::future<std::expected<stored_schema, parse_error>>
+ss::future<std::expected<parsed_schema, parse_error>>
 parse_subject_version(iobuf body, qualified_subjects_enabled qualified);
 
 /// The structured error body Schema Registry returns on failures:

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.h
@@ -18,7 +18,9 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/sstring.hh>
 
+#include <cstdint>
 #include <expected>
+#include <optional>
 
 namespace pandaproxy::schema_registry::rest_client {
 
@@ -80,5 +82,21 @@ parse_subject_versions(iobuf body);
 /// reference's `subject`). The function does not throw.
 ss::future<std::expected<stored_schema, parse_error>>
 parse_subject_version(iobuf body, qualified_subjects_enabled qualified);
+
+/// The structured error body Schema Registry returns on failures:
+/// `{"error_code": <int>, "message": "<text>"}`. `error_code` is finer-grained
+/// than the HTTP status (e.g. a 404 may carry 40401 subject-not-found vs 40402
+/// version-not-found).
+struct error_body {
+    int32_t error_code{0};
+    ss::sstring message;
+};
+
+/// Tolerantly parse a Schema Registry error response body. Returns nullopt when
+/// the body is empty, not a JSON object, not valid JSON, or carries no integer
+/// `error_code` — an auth proxy in front of the registry may return an HTML or
+/// empty body, in which case the caller falls back to the HTTP status. Unknown
+/// fields are ignored. The function does not throw.
+ss::future<std::optional<error_body>> parse_error_body(iobuf body);
 
 } // namespace pandaproxy::schema_registry::rest_client

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "base/seastarx.h"
+#include "bytes/iobuf.h"
+#include "container/chunked_vector.h"
+#include "pandaproxy/schema_registry/types.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/sstring.hh>
+
+#include <expected>
+
+namespace pandaproxy::schema_registry::rest_client {
+
+/// Describes why a schema registry response body could not be parsed into the
+/// expected native type.
+struct parse_error {
+    ss::sstring reason;
+};
+
+/// Parse the body of a `GET /subjects` response into a list of subjects.
+///
+/// The response is a JSON array of subject-name strings (see the Schema
+/// Registry REST API); each element is decoded with
+/// context_subject::from_string. \p qualified selects whether a
+/// ":.context:subject" element is interpreted as context-qualified; the caller
+/// supplies this policy so that parsing a remote registry's response does not
+/// depend on this node's cluster config.
+///
+/// The body must be exactly a JSON array of strings: a non-array, a non-string
+/// element, or any trailing content after the array yields a parse_error rather
+/// than a partial or lenient result. (Tolerance toward unmodeled fields is
+/// reserved for richer Schema Registry responses that carry optional fields;
+/// the subjects listing has a single fixed shape.) The function does not throw:
+/// malformed input is reported via the returned std::expected.
+ss::future<std::expected<chunked_vector<context_subject>, parse_error>>
+parse_subjects(iobuf body, qualified_subjects_enabled qualified);
+
+} // namespace pandaproxy::schema_registry::rest_client

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.h
@@ -62,4 +62,23 @@ parse_subjects(iobuf body, qualified_subjects_enabled qualified);
 ss::future<std::expected<chunked_vector<schema_version>, parse_error>>
 parse_subject_versions(iobuf body);
 
+/// Parse the body of a `GET /subjects/{subject}/versions/{version}` response
+/// into a stored_schema.
+///
+/// This is a faithful, lenient deserialization (the lowest layer): unknown or
+/// not-yet-modeled fields (`guid`, `ts`, `ruleSet`, `schemaTags`, `metadata`,
+/// ...) are ignored, and absent fields take their default/sentinel (absent
+/// `schemaType` -> AVRO, `deleted` -> false, `references` -> empty, and absent
+/// `subject`/`version`/`id`/`schema` -> the invalid sentinels). It does NOT
+/// enforce completeness — whether an incomplete response is acceptable (a
+/// strict mode) is a higher-layer concern. It rejects only inputs it cannot
+/// represent: a non-object body, malformed JSON, a present modeled field with a
+/// wrong-typed or out-of-range value, or an unknown `schemaType`.
+///
+/// \p qualified is the caller-supplied policy for interpreting
+/// context-qualified subject strings (the response `subject` and each
+/// reference's `subject`). The function does not throw.
+ss::future<std::expected<stored_schema, parse_error>>
+parse_subject_version(iobuf body, qualified_subjects_enabled qualified);
+
 } // namespace pandaproxy::schema_registry::rest_client

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.h
@@ -46,4 +46,20 @@ struct parse_error {
 ss::future<std::expected<chunked_vector<context_subject>, parse_error>>
 parse_subjects(iobuf body, qualified_subjects_enabled qualified);
 
+/// Parse the body of a `GET /subjects/{subject}/versions` response into a list
+/// of versions.
+///
+/// The body must be exactly a JSON array of integers, each a version number in
+/// [1, INT32_MAX]; a non-array, a non-integer or out-of-range element, or any
+/// trailing content after the array yields a parse_error (same strict, fixed
+/// shape as parse_subjects).
+///
+/// Negative values are rejected. The Schema Registry `deletedAsNegative` mode
+/// encodes soft-deleted versions as negative numbers, but this client does not
+/// request that mode; modeling per-version deletion state is future work to add
+/// only if a client feature needs it. The function does not throw: malformed
+/// input is reported via the returned std::expected.
+ss::future<std::expected<chunked_vector<schema_version>, parse_error>>
+parse_subject_versions(iobuf body);
+
 } // namespace pandaproxy::schema_registry::rest_client

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.h
@@ -71,10 +71,13 @@ parse_subject_versions(iobuf body);
 /// merely for carrying fields it doesn't model; it skips them and records their
 /// names here. This lets a caller that needs fidelity (e.g. schema migration)
 /// apply its own policy — reject, warn, or ignore — while a caller that doesn't
-/// care simply disregards the list. Only top-level keys are recorded; an
-/// unmodeled key nested inside a modeled field (e.g. within a reference) is
-/// skipped without being reported. It is therefore a best-effort signal that
-/// content was dropped, not a proof of a lossless round-trip.
+/// care simply disregards the list. Recorded names are top-level keys, with one
+/// exception: `metadata` is only partially modeled (just `metadata.properties`
+/// is captured), so an unmodeled key directly under it is reported with a
+/// `metadata.` prefix (e.g. `metadata.tags`). An unmodeled key nested inside
+/// any other modeled field (e.g. within a reference) is skipped without being
+/// reported. It is therefore a best-effort signal that content was dropped, not
+/// a proof of a lossless round-trip.
 struct parsed_schema {
     stored_schema schema;
     chunked_vector<ss::sstring> unknown_fields;
@@ -85,16 +88,20 @@ struct parsed_schema {
 /// fields).
 ///
 /// This is a faithful, lenient deserialization (the lowest layer): unknown or
-/// not-yet-modeled fields (`guid`, `ts`, `ruleSet`, `schemaTags`, `metadata`,
-/// ...) are skipped — their names are collected in
-/// parsed_schema::unknown_fields for the caller to act on — and absent fields
-/// take their default/sentinel (absent `schemaType` -> AVRO, `deleted` ->
-/// false, `references` -> empty, and absent `subject`/`version`/`id`/`schema`
-/// -> the invalid sentinels). It does NOT enforce completeness or reject for
-/// unmodeled fields — whether an incomplete or lossy response is acceptable (a
-/// strict mode) is a higher-layer concern. It rejects only inputs it cannot
-/// represent: a non-object body, malformed JSON, a present modeled field with a
-/// wrong-typed or out-of-range value, or an unknown `schemaType`.
+/// not-yet-modeled fields (`guid`, `ts`, `ruleSet`, `schemaTags`, ...) are
+/// skipped — their names are collected in parsed_schema::unknown_fields for the
+/// caller to act on. `metadata` is partially modeled: `metadata.properties` is
+/// captured into the schema's metadata (values are stringified, matching the
+/// write path), while any other key under `metadata` (e.g. `metadata.tags`) is
+/// reported in unknown_fields under a `metadata.` prefix. Absent fields take
+/// their default/sentinel (absent `schemaType` -> AVRO, `deleted` -> false,
+/// `references` -> empty, `metadata` -> absent, and absent
+/// `subject`/`version`/`id`/`schema` -> the invalid sentinels). It does NOT
+/// enforce completeness or reject for unmodeled fields — whether an incomplete
+/// or lossy response is acceptable (a strict mode) is a higher-layer concern.
+/// It rejects only inputs it cannot represent: a non-object body, malformed
+/// JSON, a present modeled field with a wrong-typed or out-of-range value, or
+/// an unknown `schemaType`.
 ///
 /// \p qualified is the caller-supplied policy for interpreting
 /// context-qualified subject strings (the response `subject` and each

--- a/src/v/pandaproxy/schema_registry/rest_client/retry_policy.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/retry_policy.cc
@@ -11,7 +11,9 @@
 
 #include "pandaproxy/schema_registry/rest_client/retry_policy.h"
 
+#include "bytes/iobuf.h"
 #include "net/connection.h"
+#include "pandaproxy/logger.h"
 
 #include <exception>
 
@@ -83,6 +85,19 @@ default_retry_policy::should_retry(http::downloaded_response response) const {
                     != retriable_statuses.end()
                   ? error_kind::retriable_http_status
                   : error_kind::permanent_failure;
+    // The error surfaced to callers truncates the body (below) to keep error
+    // messages bounded. Log the full body at trace level so it can be recovered
+    // when 400 bytes is not enough to diagnose a failure. Capped at the
+    // linearize limit since linearize_to_string() throws above it; share()
+    // clamps to the available size, so this is safe for any body size.
+    if (srlog.is_enabled(ss::log_level::trace)) {
+        vlog(
+          srlog.trace,
+          "schema registry error response (status={}): {}",
+          status,
+          response.body.share(0, iobuf::max_linearize_size)
+            .linearize_to_string());
+    }
     constexpr size_t max_body_size = 400;
     auto body = response.body.share(0, max_body_size).linearize_to_string();
     return std::unexpected(

--- a/src/v/pandaproxy/schema_registry/rest_client/retry_policy.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/retry_policy.cc
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "pandaproxy/schema_registry/rest_client/retry_policy.h"
+
+#include "net/connection.h"
+
+#include <exception>
+
+namespace {
+
+using pandaproxy::schema_registry::rest_client::error_kind;
+using pandaproxy::schema_registry::rest_client::request_error;
+
+request_error aborted(std::string_view msg) {
+    return {.kind = error_kind::aborted, .err = ss::sstring{msg}};
+}
+
+request_error make_permanent_failure(std::string_view msg) {
+    return {.kind = error_kind::permanent_failure, .err = ss::sstring{msg}};
+}
+
+request_error retriable(error_kind kind, std::string_view msg) {
+    return {.kind = kind, .err = ss::sstring{msg}};
+}
+
+using enum boost::beast::http::status;
+constexpr auto retriable_statuses = std::to_array(
+  {internal_server_error,
+   bad_gateway,
+   service_unavailable,
+   gateway_timeout,
+   request_timeout,
+   too_many_requests});
+
+bool is_abort_or_gate_close_exception(const std::exception_ptr& ex) {
+    try {
+        std::rethrow_exception(ex);
+    } catch (const ss::abort_requested_exception&) {
+        return true;
+    } catch (const ss::gate_closed_exception&) {
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+} // namespace
+
+namespace pandaproxy::schema_registry::rest_client {
+
+retry_policy::result_t default_retry_policy::should_retry(
+  ss::future<http::downloaded_response> response_f) const {
+    vassert(response_f.available(), "future is not resolved");
+    if (!response_f.failed()) {
+        // future resolved successfully, check the status code
+        return should_retry(response_f.get());
+    } else {
+        // future failed, check the exception kind
+        return std::unexpected(should_retry(response_f.get_exception()));
+    }
+}
+
+retry_policy::result_t
+default_retry_policy::should_retry(http::downloaded_response response) const {
+    const auto status = response.status;
+    // the successful status class contains all status codes starting with 2
+    if (
+      boost::beast::http::to_status_class(status)
+      == boost::beast::http::status_class::successful) {
+        return response;
+    }
+
+    auto kind = std::ranges::find(retriable_statuses, status)
+                    != retriable_statuses.end()
+                  ? error_kind::retriable_http_status
+                  : error_kind::permanent_failure;
+    constexpr size_t max_body_size = 400;
+    auto body = response.body.share(0, max_body_size).linearize_to_string();
+    return std::unexpected(
+      request_error{
+        .kind = kind,
+        .err = http_status_error{.status = status, .body = std::move(body)}});
+}
+
+request_error default_retry_policy::should_retry(std::exception_ptr ex) const {
+    try {
+        std::rethrow_exception(ex);
+    } catch (const std::system_error& err) {
+        if (net::is_reconnect_error(err)) {
+            return retriable(error_kind::network_error, err.what());
+        }
+        return make_permanent_failure(err.what());
+    } catch (const ss::timed_out_error& err) {
+        return retriable(error_kind::timeout, err.what());
+    } catch (const boost::system::system_error& err) {
+        if (
+          err.code() != boost::beast::http::error::end_of_stream
+          && err.code() != boost::beast::http::error::partial_message) {
+            return make_permanent_failure(err.what());
+        }
+        return retriable(error_kind::network_error, err.what());
+    } catch (const ss::gate_closed_exception&) {
+        return aborted(fmt::format("{}", std::current_exception()));
+    } catch (const ss::abort_requested_exception&) {
+        return aborted(fmt::format("{}", std::current_exception()));
+    } catch (const ss::nested_exception& nested) {
+        if (
+          is_abort_or_gate_close_exception(nested.inner)
+          || is_abort_or_gate_close_exception(nested.outer)) {
+            return aborted(fmt::format("{}", std::current_exception()));
+        };
+        return make_permanent_failure(
+          fmt::format(
+            "{} [outer: {}, inner: {}]",
+            nested.what(),
+            nested.outer,
+            nested.inner));
+    } catch (...) {
+        return make_permanent_failure(
+          fmt::format("{}", std::current_exception()));
+    }
+}
+
+} // namespace pandaproxy::schema_registry::rest_client

--- a/src/v/pandaproxy/schema_registry/rest_client/retry_policy.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/retry_policy.cc
@@ -13,7 +13,7 @@
 
 #include "bytes/iobuf.h"
 #include "net/connection.h"
-#include "pandaproxy/logger.h"
+#include "pandaproxy/schema_registry/rest_client/logger.h"
 
 #include <exception>
 
@@ -90,9 +90,9 @@ default_retry_policy::should_retry(http::downloaded_response response) const {
     // when 400 bytes is not enough to diagnose a failure. Capped at the
     // linearize limit since linearize_to_string() throws above it; share()
     // clamps to the available size, so this is safe for any body size.
-    if (srlog.is_enabled(ss::log_level::trace)) {
+    if (srclog.is_enabled(ss::log_level::trace)) {
         vlog(
-          srlog.trace,
+          srclog.trace,
           "schema registry error response (status={}): {}",
           status,
           response.body.share(0, iobuf::max_linearize_size)

--- a/src/v/pandaproxy/schema_registry/rest_client/retry_policy.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/retry_policy.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "http/client.h"
+#include "pandaproxy/schema_registry/rest_client/error.h"
+
+#include <seastar/core/future.hh>
+
+#include <exception>
+#include <expected>
+
+namespace pandaproxy::schema_registry::rest_client {
+
+struct request_error {
+    error_kind kind;
+    http_call_error err;
+};
+
+struct retry_policy {
+    using result_t = std::expected<http::downloaded_response, request_error>;
+
+    // Given a ready future which will yield a downloaded_response, judges
+    // whether it is:
+    // 1. successful
+    // 2. has failed and can be retried
+    // 3. has failed and cannot be retried
+    virtual result_t
+    should_retry(ss::future<http::downloaded_response> response_f) const = 0;
+
+    // If the ready future did not fail, this method checks the response http
+    // status
+    virtual result_t should_retry(http::downloaded_response response) const = 0;
+
+    // Handles the case where the future failed with an exception. Shutdown
+    // related errors are returned indicating so, all other errors are
+    // classified into retriable or permanent_failure.
+    virtual request_error should_retry(std::exception_ptr ex) const = 0;
+    virtual ~retry_policy() = default;
+};
+
+struct default_retry_policy : public retry_policy {
+    result_t
+    should_retry(ss::future<http::downloaded_response> response_f) const final;
+    result_t should_retry(http::downloaded_response response) const final;
+    request_error should_retry(std::exception_ptr ex) const final;
+};
+
+} // namespace pandaproxy::schema_registry::rest_client

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/BUILD
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/BUILD
@@ -17,3 +17,17 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "retry_policy_test",
+    timeout = "short",
+    srcs = [
+        "retry_policy_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/pandaproxy/schema_registry/rest_client:retry_policy",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/BUILD
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/BUILD
@@ -1,0 +1,19 @@
+load("//bazel:test.bzl", "redpanda_cc_gtest")
+
+redpanda_cc_gtest(
+    name = "parse_test",
+    timeout = "short",
+    srcs = [
+        "parse_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/pandaproxy/schema_registry:types",
+        "//src/v/pandaproxy/schema_registry/rest_client:parse",
+        "//src/v/ssx:sformat",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/BUILD
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/BUILD
@@ -31,3 +31,23 @@ redpanda_cc_gtest(
         "@googletest//:gtest",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "client_test",
+    timeout = "short",
+    srcs = [
+        "client_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/http",
+        "//src/v/pandaproxy/schema_registry:types",
+        "//src/v/pandaproxy/schema_registry/rest_client:client",
+        "//src/v/pandaproxy/schema_registry/rest_client:error",
+        "//src/v/test_utils:gtest",
+        "//src/v/utils:retry_chain_node",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/BUILD
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:test.bzl", "redpanda_cc_gtest")
+load("//bazel:test.bzl", "redpanda_cc_btest", "redpanda_cc_gtest")
 
 redpanda_cc_gtest(
     name = "parse_test",
@@ -49,5 +49,37 @@ redpanda_cc_gtest(
         "//src/v/utils:retry_chain_node",
         "@googletest//:gtest",
         "@seastar",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "client_integration_test",
+    timeout = "short",
+    srcs = [
+        "client_integration_test.cc",
+    ],
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/cluster:client_quota_backend",
+        "//src/v/cluster:cluster_utils",
+        "//src/v/cluster:controller_log_limiter",
+        "//src/v/cluster:data_migration_table",
+        "//src/v/cluster:feature_backend",
+        "//src/v/cluster:leader_balancer_strategy",
+        "//src/v/cluster:node_status_backend",
+        "//src/v/cluster:self_test",
+        "//src/v/cluster:topic_metrics_watcher",
+        "//src/v/http",
+        "//src/v/pandaproxy/schema_registry:types",
+        "//src/v/pandaproxy/schema_registry/rest_client:client",
+        "//src/v/pandaproxy/schema_registry/rest_client:error",
+        "//src/v/pandaproxy/test:fixture",
+        "//src/v/pandaproxy/test:utils",
+        "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:retry_chain_node",
+        "@boost//:beast",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
     ],
 )

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_integration_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_integration_test.cc
@@ -134,11 +134,14 @@ FIXTURE_TEST(sr_rest_client_integration, pandaproxy_test_fixture) {
         auto res
           = sut.get_schema_by_version(multi, pps::schema_version{2}, rtc).get();
         BOOST_REQUIRE(res.has_value());
-        BOOST_REQUIRE_EQUAL(res->schema.sub(), multi);
-        BOOST_REQUIRE_EQUAL(res->version, pps::schema_version{2});
-        BOOST_REQUIRE_GE(res->id(), 1);
-        BOOST_REQUIRE(res->schema.def().type() == pps::schema_type::avro);
-        BOOST_REQUIRE(!res->schema.def().raw()().linearize_to_string().empty());
+        // Redpanda's SR emits only fields we model, so nothing is dropped.
+        BOOST_REQUIRE(res->unknown_fields.empty());
+        const auto& s = res->schema;
+        BOOST_REQUIRE_EQUAL(s.schema.sub(), multi);
+        BOOST_REQUIRE_EQUAL(s.version, pps::schema_version{2});
+        BOOST_REQUIRE_GE(s.id(), 1);
+        BOOST_REQUIRE(s.schema.def().type() == pps::schema_type::avro);
+        BOOST_REQUIRE(!s.schema.def().raw()().linearize_to_string().empty());
     }
 
     info("get_schema_by_version reaches a context-qualified subject (%3A)");
@@ -147,8 +150,9 @@ FIXTURE_TEST(sr_rest_client_integration, pandaproxy_test_fixture) {
           = sut.get_schema_by_version(ctx_sub, pps::schema_version{1}, rtc)
               .get();
         BOOST_REQUIRE(res.has_value());
-        BOOST_REQUIRE_EQUAL(res->schema.sub(), ctx_sub);
-        BOOST_REQUIRE_EQUAL(res->version, pps::schema_version{1});
+        const auto& s = res->schema;
+        BOOST_REQUIRE_EQUAL(s.schema.sub(), ctx_sub);
+        BOOST_REQUIRE_EQUAL(s.version, pps::schema_version{1});
     }
 
     info("a missing subject yields subject_not_found (real 40401)");
@@ -223,10 +227,10 @@ FIXTURE_TEST(sr_rest_client_integration, pandaproxy_test_fixture) {
                              pps::include_deleted::yes)
                            .get();
             BOOST_REQUIRE(found.has_value());
-            BOOST_REQUIRE_EQUAL(found->version, pps::schema_version{1});
+            BOOST_REQUIRE_EQUAL(found->schema.version, pps::schema_version{1});
             // Only the per-version response carries an explicit deleted flag;
             // confirm it round-trips into stored_schema.
-            BOOST_REQUIRE(found->deleted == pps::is_deleted::yes);
+            BOOST_REQUIRE(found->schema.deleted == pps::is_deleted::yes);
         }
 
         info("list_subjects hides a fully-deleted subject without deleted");

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_integration_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_integration_test.cc
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "bytes/iobuf.h"
+#include "http/client.h"
+#include "pandaproxy/schema_registry/rest_client/client.h"
+#include "pandaproxy/schema_registry/rest_client/error.h"
+#include "pandaproxy/schema_registry/types.h"
+#include "pandaproxy/test/pandaproxy_fixture.h"
+#include "pandaproxy/test/utils.h"
+#include "test_utils/boost_fixture.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/abort_source.hh>
+
+#include <boost/beast/http/status.hpp>
+#include <boost/beast/http/verb.hpp>
+#include <boost/test/tools/old/interface.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+#include <string_view>
+#include <variant>
+
+namespace rc = pandaproxy::schema_registry::rest_client;
+namespace pps = pandaproxy::schema_registry;
+namespace bh = boost::beast::http;
+using namespace std::chrono_literals;
+
+namespace {
+
+// A backward-compatible Avro record evolution: v2 adds a field with a default,
+// so it registers under the default (backward) compatibility after v1.
+constexpr std::string_view schema_v1
+  = R"({"schema": "{\"type\": \"record\", \"name\": \"r1\", \"fields\": [{\"name\": \"f1\", \"type\": \"string\"}]}", "schemaType": "AVRO"})";
+constexpr std::string_view schema_v2
+  = R"({"schema": "{\"type\": \"record\", \"name\": \"r1\", \"fields\": [{\"name\": \"f1\", \"type\": \"string\"}, {\"name\": \"f2\", \"type\": \"string\", \"default\": \"\"}]}", "schemaType": "AVRO"})";
+
+rc::client make_rest_client(uint16_t port) {
+    net::base_transport::configuration cfg;
+    cfg.server_addr = net::unresolved_address{"localhost", port};
+    return rc::client{
+      std::make_unique<http::client>(cfg),
+      fmt::format("http://localhost:{}", port),
+      std::nullopt,
+      pps::qualified_subjects_enabled::yes};
+}
+
+// POST a schema under subject_path (the wire form, raw) via the seed client.
+void register_schema(
+  http::client& client, std::string_view subject_path, std::string_view body) {
+    auto res = http_request(
+      client,
+      fmt::format("/subjects/{}/versions", subject_path),
+      iobuf::from(body),
+      bh::verb::post,
+      serialization_format::schema_registry_v1_json,
+      serialization_format::schema_registry_v1_json);
+    BOOST_REQUIRE_EQUAL(res.headers.result(), bh::status::ok);
+}
+
+} // namespace
+
+// Drives the rest_client against the in-tree Schema Registry server: seeds
+// schemas over the real REST API, then exercises all three read calls plus the
+// real not-found (40401/40402) responses through a real http::client. This is
+// the fidelity counterpart to the mock-based client_test — it proves the wire
+// shape, qualified-subject %3A path encoding, and error-code classification
+// against actual server responses. (References are covered by the parser unit
+// tests; this test keeps to default- and context-qualified subjects.)
+FIXTURE_TEST(sr_rest_client_integration, pandaproxy_test_fixture) {
+    info("Seeding subjects via the real REST API");
+    auto seed = make_schema_reg_client();
+    register_schema(seed, "multi", schema_v1);
+    register_schema(seed, "multi", schema_v2);
+    register_schema(seed, "solo", schema_v1);
+    // Qualified subjects are enabled by default; this exercises the client's
+    // %3A path encoding end-to-end against the real server.
+    register_schema(seed, ":.myctx:ctx-sub", schema_v1);
+
+    auto sut = make_rest_client(*schema_reg_port);
+    ss::abort_source as;
+    retry_chain_node rtc(as, 10s, 100ms);
+
+    const auto multi = pps::context_subject::unqualified("multi");
+    const auto solo = pps::context_subject::unqualified("solo");
+    const auto ctx_sub = pps::context_subject{
+      pps::context{".myctx"}, pps::subject{"ctx-sub"}};
+
+    info("list_subjects returns the seeded subjects");
+    {
+        auto res = sut.list_subjects(rtc).get();
+        BOOST_REQUIRE(res.has_value());
+        const auto& subs = res.value();
+        auto contains = [&subs](const pps::context_subject& s) {
+            return std::ranges::find(subs, s) != subs.end();
+        };
+        BOOST_REQUIRE(contains(multi));
+        BOOST_REQUIRE(contains(solo));
+        BOOST_REQUIRE(contains(ctx_sub));
+    }
+
+    info("list_subject_versions returns [1, 2]");
+    {
+        auto res = sut.list_subject_versions(multi, rtc).get();
+        BOOST_REQUIRE(res.has_value());
+        BOOST_REQUIRE_EQUAL(res->size(), 2U);
+        BOOST_REQUIRE_EQUAL((*res)[0], pps::schema_version{1});
+        BOOST_REQUIRE_EQUAL((*res)[1], pps::schema_version{2});
+    }
+
+    info("get_schema_by_version returns the stored schema");
+    {
+        auto res
+          = sut.get_schema_by_version(multi, pps::schema_version{2}, rtc).get();
+        BOOST_REQUIRE(res.has_value());
+        BOOST_REQUIRE_EQUAL(res->schema.sub(), multi);
+        BOOST_REQUIRE_EQUAL(res->version, pps::schema_version{2});
+        BOOST_REQUIRE_GE(res->id(), 1);
+        BOOST_REQUIRE(res->schema.def().type() == pps::schema_type::avro);
+        BOOST_REQUIRE(!res->schema.def().raw()().linearize_to_string().empty());
+    }
+
+    info("get_schema_by_version reaches a context-qualified subject (%3A)");
+    {
+        auto res
+          = sut.get_schema_by_version(ctx_sub, pps::schema_version{1}, rtc)
+              .get();
+        BOOST_REQUIRE(res.has_value());
+        BOOST_REQUIRE_EQUAL(res->schema.sub(), ctx_sub);
+        BOOST_REQUIRE_EQUAL(res->version, pps::schema_version{1});
+    }
+
+    info("a missing subject yields subject_not_found (real 40401)");
+    {
+        const auto missing = pps::context_subject::unqualified("missing");
+        auto versions = sut.list_subject_versions(missing, rtc).get();
+        BOOST_REQUIRE(!versions.has_value());
+        BOOST_REQUIRE(
+          std::holds_alternative<rc::subject_not_found>(versions.error()));
+
+        auto schema
+          = sut.get_schema_by_version(missing, pps::schema_version{1}, rtc)
+              .get();
+        BOOST_REQUIRE(!schema.has_value());
+        BOOST_REQUIRE(
+          std::holds_alternative<rc::subject_not_found>(schema.error()));
+    }
+
+    info("a missing version yields version_not_found (real 40402)");
+    {
+        auto res = sut
+                     .get_schema_by_version(multi, pps::schema_version{99}, rtc)
+                     .get();
+        BOOST_REQUIRE(!res.has_value());
+        BOOST_REQUIRE(
+          std::holds_alternative<rc::version_not_found>(res.error()));
+    }
+
+    sut.shutdown().get();
+}

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_integration_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_integration_test.cc
@@ -44,6 +44,11 @@ constexpr std::string_view schema_v1
   = R"({"schema": "{\"type\": \"record\", \"name\": \"r1\", \"fields\": [{\"name\": \"f1\", \"type\": \"string\"}]}", "schemaType": "AVRO"})";
 constexpr std::string_view schema_v2
   = R"({"schema": "{\"type\": \"record\", \"name\": \"r1\", \"fields\": [{\"name\": \"f1\", \"type\": \"string\"}, {\"name\": \"f2\", \"type\": \"string\", \"default\": \"\"}]}", "schemaType": "AVRO"})";
+// Same shape as schema_v1 but carries metadata.properties. Redpanda's SR models
+// only metadata.properties (not e.g. tags), so the read path parses it back and
+// reports nothing as unknown.
+constexpr std::string_view schema_with_metadata
+  = R"({"schema": "{\"type\": \"record\", \"name\": \"r1\", \"fields\": [{\"name\": \"f1\", \"type\": \"string\"}]}", "schemaType": "AVRO", "metadata": {"properties": {"owner": "team-a", "tier": "gold"}}})";
 
 rc::client make_rest_client(uint16_t port) {
     net::base_transport::configuration cfg;
@@ -94,6 +99,7 @@ FIXTURE_TEST(sr_rest_client_integration, pandaproxy_test_fixture) {
     register_schema(seed, "multi", schema_v1);
     register_schema(seed, "multi", schema_v2);
     register_schema(seed, "solo", schema_v1);
+    register_schema(seed, "withmeta", schema_with_metadata);
     // Qualified subjects are enabled by default; this exercises the client's
     // %3A path encoding end-to-end against the real server.
     register_schema(seed, ":.myctx:ctx-sub", schema_v1);
@@ -104,6 +110,7 @@ FIXTURE_TEST(sr_rest_client_integration, pandaproxy_test_fixture) {
 
     const auto multi = pps::context_subject::unqualified("multi");
     const auto solo = pps::context_subject::unqualified("solo");
+    const auto withmeta = pps::context_subject::unqualified("withmeta");
     const auto ctx_sub = pps::context_subject{
       pps::context{".myctx"}, pps::subject{"ctx-sub"}};
 
@@ -142,6 +149,24 @@ FIXTURE_TEST(sr_rest_client_integration, pandaproxy_test_fixture) {
         BOOST_REQUIRE_GE(s.id(), 1);
         BOOST_REQUIRE(s.schema.def().type() == pps::schema_type::avro);
         BOOST_REQUIRE(!s.schema.def().raw()().linearize_to_string().empty());
+    }
+
+    info("get_schema_by_version round-trips metadata.properties");
+    {
+        auto res
+          = sut.get_schema_by_version(withmeta, pps::schema_version{1}, rtc)
+              .get();
+        BOOST_REQUIRE(res.has_value());
+        // metadata.properties is modeled, so it parses back in full and nothing
+        // is reported as unknown.
+        BOOST_REQUIRE(res->unknown_fields.empty());
+        const auto& def = res->schema.schema.def();
+        BOOST_REQUIRE(def.meta().has_value());
+        BOOST_REQUIRE(def.meta()->properties.has_value());
+        const auto& props = def.meta()->properties.value();
+        BOOST_REQUIRE_EQUAL(props.size(), 2U);
+        BOOST_REQUIRE_EQUAL(props.at("owner"), "team-a");
+        BOOST_REQUIRE_EQUAL(props.at("tier"), "gold");
     }
 
     info("get_schema_by_version reaches a context-qualified subject (%3A)");

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_integration_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_integration_test.cc
@@ -68,6 +68,17 @@ void register_schema(
     BOOST_REQUIRE_EQUAL(res.headers.result(), bh::status::ok);
 }
 
+// Issue a soft (impermanent) DELETE against subject_path via the seed client.
+void soft_delete(http::client& client, std::string_view subject_path) {
+    auto res = http_request(
+      client,
+      fmt::format("/subjects/{}", subject_path),
+      bh::verb::delete_,
+      serialization_format::schema_registry_v1_json,
+      serialization_format::schema_registry_v1_json);
+    BOOST_REQUIRE_EQUAL(res.headers.result(), bh::status::ok);
+}
+
 } // namespace
 
 // Drives the rest_client against the in-tree Schema Registry server: seeds
@@ -164,6 +175,71 @@ FIXTURE_TEST(sr_rest_client_integration, pandaproxy_test_fixture) {
         BOOST_REQUIRE(!res.has_value());
         BOOST_REQUIRE(
           std::holds_alternative<rc::version_not_found>(res.error()));
+    }
+
+    info("deleted=true surfaces soft-deleted versions and subjects");
+    {
+        // Soft-delete version 1 of "multi" (v2 remains, so the subject stays
+        // live) and the whole single-version "solo" subject.
+        soft_delete(seed, "multi/versions/1");
+        soft_delete(seed, "solo");
+
+        auto contains = [](const auto& range, const pps::context_subject& s) {
+            return std::ranges::find(range, s) != range.end();
+        };
+
+        info(
+          "list_subject_versions hides v1 by default, shows it with deleted");
+        {
+            auto live = sut.list_subject_versions(multi, rtc).get();
+            BOOST_REQUIRE(live.has_value());
+            BOOST_REQUIRE_EQUAL(live->size(), 1U);
+            BOOST_REQUIRE_EQUAL((*live)[0], pps::schema_version{2});
+
+            auto all
+              = sut.list_subject_versions(multi, rtc, pps::include_deleted::yes)
+                  .get();
+            BOOST_REQUIRE(all.has_value());
+            BOOST_REQUIRE_EQUAL(all->size(), 2U);
+            BOOST_REQUIRE_EQUAL((*all)[0], pps::schema_version{1});
+            BOOST_REQUIRE_EQUAL((*all)[1], pps::schema_version{2});
+        }
+
+        info(
+          "get_schema_by_version reaches a soft-deleted version with deleted");
+        {
+            auto missing
+              = sut.get_schema_by_version(multi, pps::schema_version{1}, rtc)
+                  .get();
+            BOOST_REQUIRE(!missing.has_value());
+            BOOST_REQUIRE(
+              std::holds_alternative<rc::version_not_found>(missing.error()));
+
+            auto found = sut
+                           .get_schema_by_version(
+                             multi,
+                             pps::schema_version{1},
+                             rtc,
+                             pps::include_deleted::yes)
+                           .get();
+            BOOST_REQUIRE(found.has_value());
+            BOOST_REQUIRE_EQUAL(found->version, pps::schema_version{1});
+            // Only the per-version response carries an explicit deleted flag;
+            // confirm it round-trips into stored_schema.
+            BOOST_REQUIRE(found->deleted == pps::is_deleted::yes);
+        }
+
+        info("list_subjects hides a fully-deleted subject without deleted");
+        {
+            auto live = sut.list_subjects(rtc).get();
+            BOOST_REQUIRE(live.has_value());
+            BOOST_REQUIRE(!contains(live.value(), solo));
+            BOOST_REQUIRE(contains(live.value(), multi));
+
+            auto all = sut.list_subjects(rtc, pps::include_deleted::yes).get();
+            BOOST_REQUIRE(all.has_value());
+            BOOST_REQUIRE(contains(all.value(), solo));
+        }
     }
 
     sut.shutdown().get();

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "bytes/iobuf.h"
+#include "http/client.h"
+#include "pandaproxy/schema_registry/rest_client/client.h"
+#include "pandaproxy/schema_registry/rest_client/error.h"
+#include "pandaproxy/schema_registry/types.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/abort_source.hh>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <variant>
+
+namespace rc = pandaproxy::schema_registry::rest_client;
+namespace pps = pandaproxy::schema_registry;
+namespace bh = boost::beast::http;
+using namespace std::chrono_literals;
+using namespace testing;
+
+namespace {
+
+constexpr auto endpoint = "http://localhost:8081";
+
+class mock_client : public http::abstract_client {
+public:
+    MOCK_METHOD(
+      ss::future<http::downloaded_response>,
+      request_and_collect_response,
+      (bh::request_header<>&&,
+       std::optional<iobuf>,
+       ss::lowres_clock::duration),
+      (override));
+    MOCK_METHOD(ss::future<>, shutdown_and_stop, (), (override));
+};
+
+std::unique_ptr<http::abstract_client>
+make_http_client(std::function<void(mock_client&)> set_expectations) {
+    auto client = std::make_unique<NiceMock<mock_client>>();
+    ON_CALL(*client, shutdown_and_stop()).WillByDefault([] {
+        return ss::make_ready_future<>();
+    });
+    set_expectations(*client);
+    return client;
+}
+
+// A response action yielding a fixed status and body.
+auto respond(bh::status status, std::string_view body) {
+    return [status, body = ss::sstring{body}](
+             bh::request_header<>&&,
+             std::optional<iobuf>,
+             ss::lowres_clock::duration) {
+        return ss::make_ready_future<http::downloaded_response>(
+          http::downloaded_response{
+            .status = status, .body = iobuf::from(body)});
+    };
+}
+
+} // namespace
+
+TEST(rest_client, list_subjects_request_shape_and_success) {
+    auto check_and_respond = [](
+                               bh::request_header<>&& r,
+                               std::optional<iobuf>,
+                               ss::lowres_clock::duration) {
+        EXPECT_EQ(r.method(), bh::verb::get);
+        EXPECT_EQ(r.target(), "/subjects");
+        EXPECT_EQ(r.at(bh::field::accept), "application/json");
+        // base64("user:pass") == "dXNlcjpwYXNz"
+        EXPECT_EQ(r.at(bh::field::authorization), "Basic dXNlcjpwYXNz");
+        return ss::make_ready_future<http::downloaded_response>(
+          http::downloaded_response{
+            .status = bh::status::ok,
+            .body = iobuf::from(R"(["s1", ":.ctx:s2"])")});
+    };
+    rc::client client{
+      make_http_client([&](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(check_and_respond);
+      }),
+      endpoint,
+      rc::basic_auth_credentials{.username = "user", .password = "pass"},
+      pps::qualified_subjects_enabled::yes};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.list_subjects(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_THAT(
+      *res,
+      ElementsAre(
+        pps::context_subject::unqualified("s1"),
+        pps::context_subject(pps::context{".ctx"}, pps::subject{"s2"})));
+}
+
+TEST(rest_client, list_subjects_no_credentials_omits_auth_header) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce([](
+                        bh::request_header<>&& r,
+                        std::optional<iobuf>,
+                        ss::lowres_clock::duration) {
+                EXPECT_EQ(r.count(bh::field::authorization), 0);
+                return ss::make_ready_future<http::downloaded_response>(
+                  http::downloaded_response{
+                    .status = bh::status::ok, .body = iobuf::from("[]")});
+            });
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.list_subjects(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_THAT(*res, IsEmpty());
+}
+
+TEST(rest_client, list_subjects_retries_then_succeeds) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(bh::status::service_unavailable, "busy"))
+            .WillOnce(respond(bh::status::ok, R"(["s1"])"));
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 30s, 10ms);
+    auto res = client.list_subjects(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_THAT(*res, SizeIs(1));
+}
+
+TEST(rest_client, list_subjects_retries_exhausted) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillRepeatedly(respond(bh::status::service_unavailable, "busy"));
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 100ms, 10ms);
+    auto res = client.list_subjects(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::retries_exhausted>(res.error()));
+}
+
+TEST(rest_client, list_subjects_transport_exception_is_permanent) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce([](
+                        bh::request_header<>&&,
+                        std::optional<iobuf>,
+                        ss::lowres_clock::duration) {
+                return ss::make_exception_future<http::downloaded_response>(
+                  std::runtime_error("connection refused"));
+            });
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.list_subjects(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    // A plain runtime_error is classified permanent and surfaces as a string
+    // http_call_error.
+    ASSERT_TRUE(std::holds_alternative<rc::http_call_error>(res.error()));
+    EXPECT_TRUE(
+      std::holds_alternative<ss::sstring>(
+        std::get<rc::http_call_error>(res.error())));
+}
+
+TEST(rest_client, list_subjects_http_error_attaches_error_code) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(
+              bh::status::not_found,
+              R"({"error_code": 40401, "message": "not found"})"));
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.list_subjects(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    ASSERT_TRUE(std::holds_alternative<rc::http_call_error>(res.error()));
+    const auto& call = std::get<rc::http_call_error>(res.error());
+    ASSERT_TRUE(std::holds_alternative<rc::http_status_error>(call));
+    const auto& status = std::get<rc::http_status_error>(call);
+    EXPECT_EQ(status.status, bh::status::not_found);
+    ASSERT_TRUE(status.error_code.has_value());
+    EXPECT_EQ(*status.error_code, 40401);
+}
+
+TEST(rest_client, list_subjects_parse_error_surfaced) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(bh::status::ok, R"({"not": "an array"})"));
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.list_subjects(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::parse_error>(res.error()));
+}
+
+TEST(rest_client, list_subjects_after_shutdown_is_aborted) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _)).Times(0);
+      }),
+      endpoint};
+
+    client.shutdown().get();
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.list_subjects(rtc).get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::aborted_error>(res.error()));
+}

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
@@ -394,9 +394,11 @@ TEST(rest_client, get_schema_by_version_success) {
     client.shutdown().get();
 
     ASSERT_TRUE(res.has_value());
-    EXPECT_EQ(res->schema.sub(), subject);
-    EXPECT_EQ(res->version, pps::schema_version{3});
-    EXPECT_EQ(res->id, pps::schema_id{100001});
+    EXPECT_TRUE(res->unknown_fields.empty());
+    const auto& s = res->schema;
+    EXPECT_EQ(s.schema.sub(), subject);
+    EXPECT_EQ(s.version, pps::schema_version{3});
+    EXPECT_EQ(s.id, pps::schema_id{100001});
 }
 
 TEST(rest_client, get_schema_by_version_deleted_adds_query_param) {

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
@@ -312,3 +312,111 @@ TEST(rest_client, list_subject_versions_subject_not_found) {
     ASSERT_TRUE(std::holds_alternative<rc::subject_not_found>(res.error()));
     EXPECT_EQ(std::get<rc::subject_not_found>(res.error()).subject, subject);
 }
+
+TEST(rest_client, get_schema_by_version_success) {
+    constexpr std::string_view body
+      = R"({"subject":"User","version":3,"id":100001,"schemaType":"AVRO",)"
+        R"("schema":"{\"type\":\"record\",\"name\":\"User\"}"})";
+    rc::client client{
+      make_http_client([body](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce([body](
+                        bh::request_header<>&& r,
+                        std::optional<iobuf>,
+                        ss::lowres_clock::duration) {
+                EXPECT_EQ(r.target(), "/subjects/User/versions/3");
+                return ss::make_ready_future<http::downloaded_response>(
+                  http::downloaded_response{
+                    .status = bh::status::ok, .body = iobuf::from(body)});
+            });
+      }),
+      endpoint};
+
+    auto subject = pps::context_subject::unqualified("User");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client
+                 .get_schema_by_version(subject, pps::schema_version{3}, rtc)
+                 .get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->schema.sub(), subject);
+    EXPECT_EQ(res->version, pps::schema_version{3});
+    EXPECT_EQ(res->id, pps::schema_id{100001});
+}
+
+TEST(rest_client, get_schema_by_version_subject_not_found) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(
+              bh::status::not_found,
+              R"({"error_code": 40401, "message": "Subject not found."})"));
+      }),
+      endpoint};
+
+    auto subject = pps::context_subject::unqualified("User");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client
+                 .get_schema_by_version(subject, pps::schema_version{5}, rtc)
+                 .get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::subject_not_found>(res.error()));
+}
+
+TEST(rest_client, get_schema_by_version_version_not_found) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(
+              bh::status::not_found,
+              R"({"error_code": 40402, "message": "Version 7 not found."})"));
+      }),
+      endpoint};
+
+    auto subject = pps::context_subject::unqualified("User");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client
+                 .get_schema_by_version(subject, pps::schema_version{7}, rtc)
+                 .get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    ASSERT_TRUE(std::holds_alternative<rc::version_not_found>(res.error()));
+    const auto& vnf = std::get<rc::version_not_found>(res.error());
+    EXPECT_EQ(vnf.subject, subject);
+    EXPECT_EQ(vnf.version, pps::schema_version{7});
+}
+
+TEST(rest_client, get_schema_by_version_invalid_version_not_translated) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(
+              bh::status::unprocessable_entity,
+              R"({"error_code": 42202, "message": "Invalid version"})"));
+      }),
+      endpoint};
+
+    auto subject = pps::context_subject::unqualified("User");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client
+                 .get_schema_by_version(subject, pps::schema_version{1}, rtc)
+                 .get();
+    client.shutdown().get();
+
+    // 422 is not a not-found condition: it stays a plain http_status_error.
+    ASSERT_FALSE(res.has_value());
+    ASSERT_TRUE(std::holds_alternative<rc::http_call_error>(res.error()));
+    const auto& call = std::get<rc::http_call_error>(res.error());
+    ASSERT_TRUE(std::holds_alternative<rc::http_status_error>(call));
+    EXPECT_EQ(
+      std::get<rc::http_status_error>(call).status,
+      bh::status::unprocessable_entity);
+}

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
@@ -255,3 +255,60 @@ TEST(rest_client, list_subjects_after_shutdown_is_aborted) {
     ASSERT_FALSE(res.has_value());
     EXPECT_TRUE(std::holds_alternative<rc::aborted_error>(res.error()));
 }
+
+TEST(rest_client, list_subject_versions_success_and_encodes_subject) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce([](
+                        bh::request_header<>&& r,
+                        std::optional<iobuf>,
+                        ss::lowres_clock::duration) {
+                EXPECT_EQ(r.method(), bh::verb::get);
+                // ":.ctx:orders" must be percent-encoded exactly once.
+                EXPECT_EQ(r.target(), "/subjects/%3A.ctx%3Aorders/versions");
+                return ss::make_ready_future<http::downloaded_response>(
+                  http::downloaded_response{
+                    .status = bh::status::ok,
+                    .body = iobuf::from("[1, 2, 3]")});
+            });
+      }),
+      endpoint,
+      std::nullopt,
+      pps::qualified_subjects_enabled::yes};
+
+    pps::context_subject subject{pps::context{".ctx"}, pps::subject{"orders"}};
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.list_subject_versions(subject, rtc).get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_THAT(
+      *res,
+      ElementsAre(
+        pps::schema_version{1},
+        pps::schema_version{2},
+        pps::schema_version{3}));
+}
+
+TEST(rest_client, list_subject_versions_subject_not_found) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(
+              bh::status::not_found,
+              R"({"error_code": 40401, "message": "Subject 'orders' not found."})"));
+      }),
+      endpoint};
+
+    auto subject = pps::context_subject::unqualified("orders");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.list_subject_versions(subject, rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    ASSERT_TRUE(std::holds_alternative<rc::subject_not_found>(res.error()));
+    EXPECT_EQ(std::get<rc::subject_not_found>(res.error()).subject, subject);
+}

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
@@ -220,6 +220,8 @@ TEST(rest_client, list_subjects_http_error_attaches_error_code) {
     EXPECT_EQ(status.status, bh::status::not_found);
     ASSERT_TRUE(status.error_code.has_value());
     EXPECT_EQ(*status.error_code, 40401);
+    ASSERT_TRUE(status.message.has_value());
+    EXPECT_EQ(*status.message, "not found");
 }
 
 TEST(rest_client, list_subjects_parse_error_surfaced) {

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
@@ -109,6 +109,30 @@ TEST(rest_client, list_subjects_request_shape_and_success) {
         pps::context_subject(pps::context{".ctx"}, pps::subject{"s2"})));
 }
 
+TEST(rest_client, list_subjects_deleted_adds_query_param) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce([](
+                        bh::request_header<>&& r,
+                        std::optional<iobuf>,
+                        ss::lowres_clock::duration) {
+                EXPECT_EQ(r.target(), "/subjects?deleted=true");
+                return ss::make_ready_future<http::downloaded_response>(
+                  http::downloaded_response{
+                    .status = bh::status::ok, .body = iobuf::from("[]")});
+            });
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.list_subjects(rtc, pps::include_deleted::yes).get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+}
+
 TEST(rest_client, list_subjects_no_credentials_omits_auth_header) {
     rc::client client{
       make_http_client([](mock_client& m) {
@@ -294,6 +318,33 @@ TEST(rest_client, list_subject_versions_success_and_encodes_subject) {
         pps::schema_version{3}));
 }
 
+TEST(rest_client, list_subject_versions_deleted_adds_query_param) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce([](
+                        bh::request_header<>&& r,
+                        std::optional<iobuf>,
+                        ss::lowres_clock::duration) {
+                EXPECT_EQ(r.target(), "/subjects/orders/versions?deleted=true");
+                return ss::make_ready_future<http::downloaded_response>(
+                  http::downloaded_response{
+                    .status = bh::status::ok, .body = iobuf::from("[1]")});
+            });
+      }),
+      endpoint};
+
+    auto subject = pps::context_subject::unqualified("orders");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client
+                 .list_subject_versions(subject, rtc, pps::include_deleted::yes)
+                 .get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+}
+
 TEST(rest_client, list_subject_versions_subject_not_found) {
     rc::client client{
       make_http_client([](mock_client& m) {
@@ -346,6 +397,38 @@ TEST(rest_client, get_schema_by_version_success) {
     EXPECT_EQ(res->schema.sub(), subject);
     EXPECT_EQ(res->version, pps::schema_version{3});
     EXPECT_EQ(res->id, pps::schema_id{100001});
+}
+
+TEST(rest_client, get_schema_by_version_deleted_adds_query_param) {
+    constexpr std::string_view body
+      = R"({"subject":"User","version":3,"id":100001,"schemaType":"AVRO",)"
+        R"("schema":"{\"type\":\"record\",\"name\":\"User\"}"})";
+    rc::client client{
+      make_http_client([body](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce([body](
+                        bh::request_header<>&& r,
+                        std::optional<iobuf>,
+                        ss::lowres_clock::duration) {
+                EXPECT_EQ(r.target(), "/subjects/User/versions/3?deleted=true");
+                return ss::make_ready_future<http::downloaded_response>(
+                  http::downloaded_response{
+                    .status = bh::status::ok, .body = iobuf::from(body)});
+            });
+      }),
+      endpoint};
+
+    auto subject = pps::context_subject::unqualified("User");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res
+      = client
+          .get_schema_by_version(
+            subject, pps::schema_version{3}, rtc, pps::include_deleted::yes)
+          .get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
 }
 
 TEST(rest_client, get_schema_by_version_subject_not_found) {

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "bytes/iobuf.h"
+#include "pandaproxy/schema_registry/rest_client/parse.h"
+#include "pandaproxy/schema_registry/types.h"
+#include "ssx/sformat.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/temporary_buffer.hh>
+
+#include <algorithm>
+#include <cstddef>
+#include <string_view>
+#include <vector>
+
+namespace pandaproxy::schema_registry::rest_client {
+
+namespace {
+
+// Build an iobuf whose bytes are split into separate fragments of at most
+// `chunk_size` bytes, to exercise the streaming parser across fragment
+// boundaries (including values that span fragments).
+iobuf fragmented_iobuf(std::string_view s, size_t chunk_size) {
+    iobuf buf;
+    for (size_t i = 0; i < s.size(); i += chunk_size) {
+        auto piece = s.substr(i, chunk_size);
+        ss::temporary_buffer<char> frag{piece.size()};
+        std::ranges::copy(piece, frag.get_write());
+        buf.append(std::move(frag));
+    }
+    return buf;
+}
+
+} // namespace
+
+TEST_CORO(parse_subjects_test, empty_array) {
+    auto res = co_await parse_subjects(
+      iobuf::from("[]"), qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_TRUE_CORO(res.value().empty());
+}
+
+TEST_CORO(parse_subjects_test, mixed_subjects_enabled) {
+    // bare, qualified, colon-in-subject, leading-':'-without-'.', and explicit
+    // default context. Element order is preserved.
+    auto res = co_await parse_subjects(
+      iobuf::from(
+        R"(["bare", ":.ctx:sub", ":.ctx:a:b:c", ":no-dot", ":.:def"])"),
+      qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(res.has_value());
+    const auto& s = res.value();
+    ASSERT_EQ_CORO(s.size(), size_t{5});
+    ASSERT_EQ_CORO(s[0], context_subject(default_context, subject{"bare"}));
+    ASSERT_EQ_CORO(s[1], context_subject(context{".ctx"}, subject{"sub"}));
+    ASSERT_EQ_CORO(s[2], context_subject(context{".ctx"}, subject{"a:b:c"}));
+    ASSERT_EQ_CORO(s[3], context_subject(default_context, subject{":no-dot"}));
+    ASSERT_EQ_CORO(s[4], context_subject(default_context, subject{"def"}));
+}
+
+TEST_CORO(parse_subjects_test, qualified_disabled_is_literal) {
+    // With the policy disabled, a ":.ctx:sub" element is taken verbatim as a
+    // default-context subject rather than being split.
+    auto res = co_await parse_subjects(
+      iobuf::from(R"([":.ctx:sub", "bare"])"), qualified_subjects_enabled::no);
+    ASSERT_TRUE_CORO(res.has_value());
+    const auto& s = res.value();
+    ASSERT_EQ_CORO(s.size(), size_t{2});
+    ASSERT_EQ_CORO(
+      s[0], context_subject(default_context, subject{":.ctx:sub"}));
+    ASSERT_EQ_CORO(s[1], context_subject(default_context, subject{"bare"}));
+}
+
+TEST_CORO(parse_subjects_test, trailing_content_after_array_is_error) {
+    // The subjects body is exactly one array; content after the closing ']' is
+    // rejected, not ignored.
+    for (std::string_view body :
+         {R"(["a"] "more")", R"(["a"][])", R"(["a"]garbage)", R"(["a"],)"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_subjects(
+          iobuf::from(body), qualified_subjects_enabled::yes);
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(parse_subjects_test, trailing_whitespace_is_ok) {
+    // Whitespace after the array is fine; the parser skips it to reach EOF.
+    auto res = co_await parse_subjects(
+      iobuf::from("[\"a\"]  \n\t "), qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res.value().size(), size_t{1});
+    ASSERT_EQ_CORO(
+      res.value()[0], context_subject(default_context, subject{"a"}));
+}
+
+TEST_CORO(parse_subjects_test, not_an_array_is_error) {
+    for (std::string_view body :
+         {R"({})", R"("just-a-string")", "42", "null", "true"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_subjects(
+          iobuf::from(body), qualified_subjects_enabled::yes);
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(parse_subjects_test, non_string_element_is_error) {
+    for (std::string_view body :
+         {R"(["ok", 42])",
+          R"(["ok", null])",
+          R"(["ok", {}])",
+          R"(["ok", ["nested"]])"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_subjects(
+          iobuf::from(body), qualified_subjects_enabled::yes);
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(parse_subjects_test, malformed_or_truncated_is_error) {
+    for (std::string_view body :
+         {"", "[", R"(["a")", R"(["a",)", R"(["unterminated)", "not json"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_subjects(
+          iobuf::from(body), qualified_subjects_enabled::yes);
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(parse_subjects_test, fragmented_input) {
+    // One byte per fragment: forces subjects (and the array structure) to span
+    // fragment boundaries.
+    constexpr std::string_view body = R"(["bare", ":.ctx:sub", ":.ctx:a:b:c"])";
+    auto res = co_await parse_subjects(
+      fragmented_iobuf(body, 1), qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(res.has_value());
+    const auto& s = res.value();
+    ASSERT_EQ_CORO(s.size(), size_t{3});
+    ASSERT_EQ_CORO(s[0], context_subject(default_context, subject{"bare"}));
+    ASSERT_EQ_CORO(s[1], context_subject(context{".ctx"}, subject{"sub"}));
+    ASSERT_EQ_CORO(s[2], context_subject(context{".ctx"}, subject{"a:b:c"}));
+}
+
+TEST_CORO(parse_subjects_test, round_trip) {
+    // Build the wire form from a set of subjects, parse it back, and assert we
+    // recover the originals (a lightweight stand-in until fuzzing exists).
+    std::vector<context_subject> expected{
+      context_subject(default_context, subject{"bare"}),
+      context_subject(context{".ctx"}, subject{"sub"}),
+      context_subject(context{".env"}, subject{"topic-value"}),
+      context_subject(default_context, subject{"with.dots"}),
+    };
+
+    iobuf body;
+    body.append("[", 1);
+    for (size_t i = 0; i < expected.size(); ++i) {
+        auto elem = ssx::sformat(
+          R"({}"{}")", i == 0 ? "" : ",", expected[i].to_string());
+        body.append(elem.data(), elem.size());
+    }
+    body.append("]", 1);
+
+    auto res = co_await parse_subjects(
+      std::move(body), qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(res.has_value());
+    const auto& s = res.value();
+    ASSERT_EQ_CORO(s.size(), expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        SCOPED_TRACE(i);
+        ASSERT_EQ_CORO(s[i], expected[i]);
+    }
+}
+
+} // namespace pandaproxy::schema_registry::rest_client

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
@@ -299,7 +299,8 @@ TEST_CORO(parse_subject_version_test, minimal_avro_defaults) {
         R"("schema":"{\"type\":\"string\"}"})"),
       qualified_subjects_enabled::yes);
     ASSERT_TRUE_CORO(res.has_value());
-    const auto& s = res.value();
+    ASSERT_TRUE_CORO(res.value().unknown_fields.empty());
+    const auto& s = res.value().schema;
     ASSERT_EQ_CORO(
       s.schema.sub(), (context_subject{default_context, subject{"User"}}));
     ASSERT_EQ_CORO(s.version, schema_version{1});
@@ -317,7 +318,7 @@ TEST_CORO(parse_subject_version_test, schema_types) {
         R"("schema":"{\"type\":\"object\"}"})"),
       qualified_subjects_enabled::yes);
     ASSERT_TRUE_CORO(json.has_value());
-    ASSERT_EQ_CORO(json.value().schema.type(), schema_type::json);
+    ASSERT_EQ_CORO(json.value().schema.schema.type(), schema_type::json);
 
     // PROTOBUF: the .proto text (quotes and newlines) is preserved verbatim.
     auto proto = co_await parse_subject_version(
@@ -326,9 +327,9 @@ TEST_CORO(parse_subject_version_test, schema_types) {
         R"("schema":"syntax = \"proto3\";\nmessage M {}\n"})"),
       qualified_subjects_enabled::yes);
     ASSERT_TRUE_CORO(proto.has_value());
-    ASSERT_EQ_CORO(proto.value().schema.type(), schema_type::protobuf);
-    ASSERT_EQ_CORO(
-      schema_text(proto.value()), "syntax = \"proto3\";\nmessage M {}\n");
+    const auto& p = proto.value().schema;
+    ASSERT_EQ_CORO(p.schema.type(), schema_type::protobuf);
+    ASSERT_EQ_CORO(schema_text(p), "syntax = \"proto3\";\nmessage M {}\n");
 }
 
 TEST_CORO(parse_subject_version_test, full_object_maps_all_fields) {
@@ -340,7 +341,8 @@ TEST_CORO(parse_subject_version_test, full_object_maps_all_fields) {
         R"("schema":"{\"type\":\"record\"}","deleted":true})"),
       qualified_subjects_enabled::yes);
     ASSERT_TRUE_CORO(res.has_value());
-    const auto& s = res.value();
+    ASSERT_TRUE_CORO(res.value().unknown_fields.empty());
+    const auto& s = res.value().schema;
     ASSERT_EQ_CORO(
       s.schema.sub(), (context_subject{context{".ctx"}, subject{"MyRecord"}}));
     ASSERT_EQ_CORO(s.version, schema_version{2});
@@ -365,25 +367,26 @@ TEST_CORO(parse_subject_version_test, reference_subject_honors_policy) {
     auto on = co_await parse_subject_version(
       iobuf::from(body), qualified_subjects_enabled::yes);
     ASSERT_TRUE_CORO(on.has_value());
+    const auto& on_ref = on.value().schema.schema.def().refs()[0];
+    ASSERT_EQ_CORO(on_ref.sub.qualified, is_qualified::yes);
     ASSERT_EQ_CORO(
-      on.value().schema.def().refs()[0].sub.qualified, is_qualified::yes);
-    ASSERT_EQ_CORO(
-      on.value().schema.def().refs()[0].sub.sub,
-      (context_subject{context{".ctx"}, subject{"Sub"}}));
+      on_ref.sub.sub, (context_subject{context{".ctx"}, subject{"Sub"}}));
 
     auto off = co_await parse_subject_version(
       iobuf::from(body), qualified_subjects_enabled::no);
     ASSERT_TRUE_CORO(off.has_value());
+    const auto& off_ref = off.value().schema.schema.def().refs()[0];
+    ASSERT_EQ_CORO(off_ref.sub.qualified, is_qualified::no);
     ASSERT_EQ_CORO(
-      off.value().schema.def().refs()[0].sub.qualified, is_qualified::no);
-    ASSERT_EQ_CORO(
-      off.value().schema.def().refs()[0].sub.sub,
+      off_ref.sub.sub,
       (context_subject{default_context, subject{":.ctx:Sub"}}));
 }
 
-TEST_CORO(parse_subject_version_test, ignores_unmodeled_fields) {
-    // guid/ts/ruleSet/schemaTags/metadata (and a future field) are skipped,
-    // including nested objects/arrays.
+TEST_CORO(parse_subject_version_test, records_unmodeled_fields) {
+    // guid/ts/ruleSet/schemaTags/metadata (and a future field) are not mapped
+    // into the schema, but their top-level names are recorded so the caller can
+    // decide whether dropping them is acceptable. A nested object/array is
+    // skipped without descending into it.
     auto res = co_await parse_subject_version(
       iobuf::from(
         R"({"guid":"abc","ts":1715000000000,"subject":"User","version":1,)"
@@ -393,13 +396,23 @@ TEST_CORO(parse_subject_version_test, ignores_unmodeled_fields) {
         R"("schemaTags":[{"tags":["PII"]}],"futureField":[1,2,3]})"),
       qualified_subjects_enabled::yes);
     ASSERT_TRUE_CORO(res.has_value());
-    const auto& s = res.value();
+    const auto& s = res.value().schema;
     ASSERT_EQ_CORO(
       s.schema.sub(), (context_subject{default_context, subject{"User"}}));
     ASSERT_EQ_CORO(s.version, schema_version{1});
     ASSERT_EQ_CORO(s.id, schema_id{7});
-    // metadata is not captured in v1.
+    // metadata is not mapped into the schema in v1.
     ASSERT_FALSE_CORO(s.schema.def().meta().has_value());
+    // The unmodeled top-level keys are reported, in encounter order; nested
+    // keys (metadata.properties, ruleSet.domainRules, ...) are not.
+    const auto& unknown = res.value().unknown_fields;
+    ASSERT_EQ_CORO(unknown.size(), size_t{6});
+    ASSERT_EQ_CORO(unknown[0], "guid");
+    ASSERT_EQ_CORO(unknown[1], "ts");
+    ASSERT_EQ_CORO(unknown[2], "ruleSet");
+    ASSERT_EQ_CORO(unknown[3], "metadata");
+    ASSERT_EQ_CORO(unknown[4], "schemaTags");
+    ASSERT_EQ_CORO(unknown[5], "futureField");
 }
 
 TEST_CORO(parse_subject_version_test, absent_fields_use_sentinels_not_error) {
@@ -407,17 +420,18 @@ TEST_CORO(parse_subject_version_test, absent_fields_use_sentinels_not_error) {
     auto empty = co_await parse_subject_version(
       iobuf::from("{}"), qualified_subjects_enabled::yes);
     ASSERT_TRUE_CORO(empty.has_value());
-    ASSERT_EQ_CORO(empty.value().version, invalid_schema_version);
-    ASSERT_EQ_CORO(empty.value().id, invalid_schema_id);
-    ASSERT_EQ_CORO(empty.value().schema.sub(), invalid_subject);
-    ASSERT_EQ_CORO(empty.value().schema.type(), schema_type::avro);
-    ASSERT_EQ_CORO(empty.value().deleted, is_deleted::no);
+    const auto& e = empty.value().schema;
+    ASSERT_EQ_CORO(e.version, invalid_schema_version);
+    ASSERT_EQ_CORO(e.id, invalid_schema_id);
+    ASSERT_EQ_CORO(e.schema.sub(), invalid_subject);
+    ASSERT_EQ_CORO(e.schema.type(), schema_type::avro);
+    ASSERT_EQ_CORO(e.deleted, is_deleted::no);
 
     auto no_schema = co_await parse_subject_version(
       iobuf::from(R"({"subject":"r","version":1,"id":2})"),
       qualified_subjects_enabled::yes);
     ASSERT_TRUE_CORO(no_schema.has_value());
-    ASSERT_EQ_CORO(no_schema.value().version, schema_version{1});
+    ASSERT_EQ_CORO(no_schema.value().schema.version, schema_version{1});
 }
 
 TEST_CORO(parse_subject_version_test, id_zero_is_valid) {
@@ -427,7 +441,7 @@ TEST_CORO(parse_subject_version_test, id_zero_is_valid) {
       iobuf::from(R"({"subject":"r","version":1,"id":0,"schema":"x"})"),
       qualified_subjects_enabled::yes);
     ASSERT_TRUE_CORO(res.has_value());
-    ASSERT_EQ_CORO(res.value().id, schema_id{0});
+    ASSERT_EQ_CORO(res.value().schema.id, schema_id{0});
 }
 
 TEST_CORO(parse_subject_version_test, rejects_unrepresentable) {
@@ -460,7 +474,7 @@ TEST_CORO(parse_subject_version_test, fragmented_input) {
     auto res = co_await parse_subject_version(
       fragmented_iobuf(body, 1), qualified_subjects_enabled::yes);
     ASSERT_TRUE_CORO(res.has_value());
-    const auto& s = res.value();
+    const auto& s = res.value().schema;
     ASSERT_EQ_CORO(
       s.schema.sub(), (context_subject{context{".ctx"}, subject{"User"}}));
     ASSERT_EQ_CORO(s.version, schema_version{12});

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
@@ -468,4 +468,59 @@ TEST_CORO(parse_subject_version_test, fragmented_input) {
     ASSERT_EQ_CORO(s.schema.def().refs().size(), size_t{1});
 }
 
+TEST_CORO(parse_error_body_test, full) {
+    auto res = co_await parse_error_body(
+      iobuf::from(R"({"error_code": 40401, "message": "Subject not found"})"));
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res->error_code, 40401);
+    ASSERT_EQ_CORO(res->message, "Subject not found");
+}
+
+TEST_CORO(parse_error_body_test, ignores_unknown_fields) {
+    auto res = co_await parse_error_body(
+      iobuf::from(R"({"extra": {"a": [1, 2]}, "error_code": 50001})"));
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res->error_code, 50001);
+    // message is optional; absent -> empty.
+    ASSERT_EQ_CORO(res->message, "");
+}
+
+TEST_CORO(parse_error_body_test, missing_error_code_is_nullopt) {
+    auto res = co_await parse_error_body(
+      iobuf::from(R"({"message": "no code here"})"));
+    ASSERT_FALSE_CORO(res.has_value());
+}
+
+TEST_CORO(parse_error_body_test, non_integer_error_code_is_nullopt) {
+    auto res = co_await parse_error_body(
+      iobuf::from(R"({"error_code": "40401"})"));
+    ASSERT_FALSE_CORO(res.has_value());
+}
+
+TEST_CORO(parse_error_body_test, non_object_is_nullopt) {
+    auto res = co_await parse_error_body(iobuf::from(R"([40401])"));
+    ASSERT_FALSE_CORO(res.has_value());
+}
+
+TEST_CORO(parse_error_body_test, non_json_is_nullopt) {
+    // Auth proxies may return an HTML or empty body instead of JSON.
+    auto res = co_await parse_error_body(
+      iobuf::from("<html>403 Forbidden</html>"));
+    ASSERT_FALSE_CORO(res.has_value());
+    auto empty = co_await parse_error_body(iobuf::from(""));
+    ASSERT_FALSE_CORO(empty.has_value());
+}
+
+TEST_CORO(parse_error_body_test, trailing_content_is_nullopt) {
+    // A complete object followed by garbage is not a valid JSON document.
+    auto res = co_await parse_error_body(
+      iobuf::from(R"({"error_code": 40401}garbage)"));
+    ASSERT_FALSE_CORO(res.has_value());
+    // Trailing whitespace is fine.
+    auto ok = co_await parse_error_body(
+      iobuf::from("{\"error_code\": 40401}  \n"));
+    ASSERT_TRUE_CORO(ok.has_value());
+    ASSERT_EQ_CORO(ok->error_code, 40401);
+}
+
 } // namespace pandaproxy::schema_registry::rest_client

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
@@ -41,6 +41,11 @@ iobuf fragmented_iobuf(std::string_view s, size_t chunk_size) {
     return buf;
 }
 
+// Linearize the raw schema text out of a parsed stored_schema for comparison.
+ss::sstring schema_text(const stored_schema& s) {
+    return s.schema.def().raw()().linearize_to_string();
+}
+
 } // namespace
 
 TEST_CORO(parse_subjects_test, empty_array) {
@@ -285,6 +290,182 @@ TEST_CORO(parse_subject_versions_test, round_trip) {
         SCOPED_TRACE(i);
         ASSERT_EQ_CORO(s[i], expected[i]);
     }
+}
+
+TEST_CORO(parse_subject_version_test, minimal_avro_defaults) {
+    auto res = co_await parse_subject_version(
+      iobuf::from(
+        R"({"subject":"User","version":1,"id":100001,)"
+        R"("schema":"{\"type\":\"string\"}"})"),
+      qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(res.has_value());
+    const auto& s = res.value();
+    ASSERT_EQ_CORO(
+      s.schema.sub(), (context_subject{default_context, subject{"User"}}));
+    ASSERT_EQ_CORO(s.version, schema_version{1});
+    ASSERT_EQ_CORO(s.id, schema_id{100001});
+    ASSERT_EQ_CORO(s.schema.type(), schema_type::avro); // default
+    ASSERT_EQ_CORO(s.deleted, is_deleted::no);          // default
+    ASSERT_TRUE_CORO(s.schema.def().refs().empty());
+    ASSERT_EQ_CORO(schema_text(s), R"({"type":"string"})");
+}
+
+TEST_CORO(parse_subject_version_test, schema_types) {
+    auto json = co_await parse_subject_version(
+      iobuf::from(
+        R"({"subject":"r","version":1,"id":2,"schemaType":"JSON",)"
+        R"("schema":"{\"type\":\"object\"}"})"),
+      qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(json.has_value());
+    ASSERT_EQ_CORO(json.value().schema.type(), schema_type::json);
+
+    // PROTOBUF: the .proto text (quotes and newlines) is preserved verbatim.
+    auto proto = co_await parse_subject_version(
+      iobuf::from(
+        R"({"subject":"r","version":1,"id":2,"schemaType":"PROTOBUF",)"
+        R"("schema":"syntax = \"proto3\";\nmessage M {}\n"})"),
+      qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(proto.has_value());
+    ASSERT_EQ_CORO(proto.value().schema.type(), schema_type::protobuf);
+    ASSERT_EQ_CORO(
+      schema_text(proto.value()), "syntax = \"proto3\";\nmessage M {}\n");
+}
+
+TEST_CORO(parse_subject_version_test, full_object_maps_all_fields) {
+    auto res = co_await parse_subject_version(
+      iobuf::from(
+        R"({"subject":":.ctx:MyRecord","version":2,"id":12,)"
+        R"("schemaType":"AVRO","references":[)"
+        R"({"name":"com.acme.Referenced","subject":"childSubject","version":1}],)"
+        R"("schema":"{\"type\":\"record\"}","deleted":true})"),
+      qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(res.has_value());
+    const auto& s = res.value();
+    ASSERT_EQ_CORO(
+      s.schema.sub(), (context_subject{context{".ctx"}, subject{"MyRecord"}}));
+    ASSERT_EQ_CORO(s.version, schema_version{2});
+    ASSERT_EQ_CORO(s.id, schema_id{12});
+    ASSERT_EQ_CORO(s.schema.type(), schema_type::avro);
+    ASSERT_EQ_CORO(s.deleted, is_deleted::yes);
+    ASSERT_EQ_CORO(schema_text(s), R"({"type":"record"})");
+    const auto& refs = s.schema.def().refs();
+    ASSERT_EQ_CORO(refs.size(), size_t{1});
+    ASSERT_EQ_CORO(refs[0].name, "com.acme.Referenced");
+    ASSERT_EQ_CORO(
+      refs[0].sub.sub,
+      (context_subject{default_context, subject{"childSubject"}}));
+    ASSERT_EQ_CORO(refs[0].version, schema_version{1});
+}
+
+TEST_CORO(parse_subject_version_test, reference_subject_honors_policy) {
+    constexpr std::string_view body
+      = R"({"subject":"r","version":1,"id":2,"schema":"x",)"
+        R"("references":[{"name":"n","subject":":.ctx:Sub","version":1}]})";
+
+    auto on = co_await parse_subject_version(
+      iobuf::from(body), qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(on.has_value());
+    ASSERT_EQ_CORO(
+      on.value().schema.def().refs()[0].sub.qualified, is_qualified::yes);
+    ASSERT_EQ_CORO(
+      on.value().schema.def().refs()[0].sub.sub,
+      (context_subject{context{".ctx"}, subject{"Sub"}}));
+
+    auto off = co_await parse_subject_version(
+      iobuf::from(body), qualified_subjects_enabled::no);
+    ASSERT_TRUE_CORO(off.has_value());
+    ASSERT_EQ_CORO(
+      off.value().schema.def().refs()[0].sub.qualified, is_qualified::no);
+    ASSERT_EQ_CORO(
+      off.value().schema.def().refs()[0].sub.sub,
+      (context_subject{default_context, subject{":.ctx:Sub"}}));
+}
+
+TEST_CORO(parse_subject_version_test, ignores_unmodeled_fields) {
+    // guid/ts/ruleSet/schemaTags/metadata (and a future field) are skipped,
+    // including nested objects/arrays.
+    auto res = co_await parse_subject_version(
+      iobuf::from(
+        R"({"guid":"abc","ts":1715000000000,"subject":"User","version":1,)"
+        R"("id":7,"schema":"x","schemaType":"AVRO",)"
+        R"("ruleSet":{"domainRules":[{"name":"r","kind":"TRANSFORM"}]},)"
+        R"("metadata":{"properties":{"owner":"team-a"},"sensitive":["ssn"]},)"
+        R"("schemaTags":[{"tags":["PII"]}],"futureField":[1,2,3]})"),
+      qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(res.has_value());
+    const auto& s = res.value();
+    ASSERT_EQ_CORO(
+      s.schema.sub(), (context_subject{default_context, subject{"User"}}));
+    ASSERT_EQ_CORO(s.version, schema_version{1});
+    ASSERT_EQ_CORO(s.id, schema_id{7});
+    // metadata is not captured in v1.
+    ASSERT_FALSE_CORO(s.schema.def().meta().has_value());
+}
+
+TEST_CORO(parse_subject_version_test, absent_fields_use_sentinels_not_error) {
+    // Permissive: missing fields are NOT errors; they take defaults/sentinels.
+    auto empty = co_await parse_subject_version(
+      iobuf::from("{}"), qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(empty.has_value());
+    ASSERT_EQ_CORO(empty.value().version, invalid_schema_version);
+    ASSERT_EQ_CORO(empty.value().id, invalid_schema_id);
+    ASSERT_EQ_CORO(empty.value().schema.sub(), invalid_subject);
+    ASSERT_EQ_CORO(empty.value().schema.type(), schema_type::avro);
+    ASSERT_EQ_CORO(empty.value().deleted, is_deleted::no);
+
+    auto no_schema = co_await parse_subject_version(
+      iobuf::from(R"({"subject":"r","version":1,"id":2})"),
+      qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(no_schema.has_value());
+    ASSERT_EQ_CORO(no_schema.value().version, schema_version{1});
+}
+
+TEST_CORO(parse_subject_version_test, id_zero_is_valid) {
+    // Unlike version (always >= 1), id 0 is legal: upstream permits id 0 on
+    // import, so a server may return it.
+    auto res = co_await parse_subject_version(
+      iobuf::from(R"({"subject":"r","version":1,"id":0,"schema":"x"})"),
+      qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res.value().id, schema_id{0});
+}
+
+TEST_CORO(parse_subject_version_test, rejects_unrepresentable) {
+    for (std::string_view body :
+         {R"({"schemaType":"YAML","subject":"r","schema":"x"})", // unknown enum
+          R"({"version":"1","subject":"r"})",    // version wrong type
+          R"({"id":1.5,"subject":"r"})",         // id non-integer
+          R"({"deleted":"no","subject":"r"})",   // deleted wrong type
+          R"({"version":0,"subject":"r"})",      // version non-positive
+          R"({"id":-1,"subject":"r"})",          // id negative
+          R"({"id":2147483648,"subject":"r"})",  // > INT32_MAX
+          R"({"references":[{"version":"x"}]})", // bad reference element
+          R"({"references":5})",                 // references not an array
+          "[1,2,3]",                             // not an object
+          R"({"subject":"r")",                   // truncated
+          R"({"subject":"r"}garbage)",           // trailing content after }
+          "not json"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_subject_version(
+          iobuf::from(body), qualified_subjects_enabled::yes);
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(parse_subject_version_test, fragmented_input) {
+    constexpr std::string_view body
+      = R"({"subject":":.ctx:User","version":12,"id":34,"schemaType":"AVRO",)"
+        R"("schema":"{\"type\":\"record\",\"name\":\"User\"}",)"
+        R"("references":[{"name":"N","subject":"Sub","version":1}]})";
+    auto res = co_await parse_subject_version(
+      fragmented_iobuf(body, 1), qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(res.has_value());
+    const auto& s = res.value();
+    ASSERT_EQ_CORO(
+      s.schema.sub(), (context_subject{context{".ctx"}, subject{"User"}}));
+    ASSERT_EQ_CORO(s.version, schema_version{12});
+    ASSERT_EQ_CORO(s.id, schema_id{34});
+    ASSERT_EQ_CORO(s.schema.def().refs().size(), size_t{1});
 }
 
 } // namespace pandaproxy::schema_registry::rest_client

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
@@ -18,6 +18,8 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
+#include <limits>
 #include <string_view>
 #include <vector>
 
@@ -168,6 +170,114 @@ TEST_CORO(parse_subjects_test, round_trip) {
 
     auto res = co_await parse_subjects(
       std::move(body), qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(res.has_value());
+    const auto& s = res.value();
+    ASSERT_EQ_CORO(s.size(), expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        SCOPED_TRACE(i);
+        ASSERT_EQ_CORO(s[i], expected[i]);
+    }
+}
+
+TEST_CORO(parse_subject_versions_test, basic) {
+    auto res = co_await parse_subject_versions(iobuf::from("[1, 2, 3]"));
+    ASSERT_TRUE_CORO(res.has_value());
+    const auto& s = res.value();
+    ASSERT_EQ_CORO(s.size(), size_t{3});
+    ASSERT_EQ_CORO(s[0], schema_version{1});
+    ASSERT_EQ_CORO(s[1], schema_version{2});
+    ASSERT_EQ_CORO(s[2], schema_version{3});
+}
+
+TEST_CORO(parse_subject_versions_test, empty_array) {
+    auto res = co_await parse_subject_versions(iobuf::from("[]"));
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_TRUE_CORO(res.value().empty());
+}
+
+TEST_CORO(parse_subject_versions_test, gaps_and_single) {
+    // Version numbers need not be contiguous; deleted versions leave gaps.
+    auto res = co_await parse_subject_versions(iobuf::from("[1, 3]"));
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res.value().size(), size_t{2});
+    ASSERT_EQ_CORO(res.value()[0], schema_version{1});
+    ASSERT_EQ_CORO(res.value()[1], schema_version{3});
+
+    auto one = co_await parse_subject_versions(iobuf::from("[1]"));
+    ASSERT_TRUE_CORO(one.has_value());
+    ASSERT_EQ_CORO(one.value().size(), size_t{1});
+    ASSERT_EQ_CORO(one.value()[0], schema_version{1});
+}
+
+TEST_CORO(parse_subject_versions_test, rejects_invalid_elements) {
+    for (std::string_view body :
+         {R"([-2])",         // negative (deletedAsNegative not supported)
+          R"([1, -2, 3])",   // mixed signs
+          R"([0])",          // zero never occurs
+          R"([2147483648])", // > INT32_MAX
+          R"([1.5])",        // non-integer (double)
+          R"([1e2])",        // scientific notation -> double
+          R"(["1"])",        // string
+          R"([null])",
+          R"([{}])",
+          R"([[1]])"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_subject_versions(iobuf::from(body));
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(parse_subject_versions_test, trailing_content_is_error) {
+    for (std::string_view body : {R"([1] 2)", R"([1][])", R"([1]garbage)"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_subject_versions(iobuf::from(body));
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(parse_subject_versions_test, trailing_whitespace_is_ok) {
+    auto res = co_await parse_subject_versions(iobuf::from("[1]  \n\t "));
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res.value().size(), size_t{1});
+}
+
+TEST_CORO(parse_subject_versions_test, malformed_or_truncated_is_error) {
+    for (std::string_view body : {"", "[", "[1", "[1,", "not json", "{}"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_subject_versions(iobuf::from(body));
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(parse_subject_versions_test, fragmented_input) {
+    // One byte per fragment: multi-digit numbers span fragment boundaries.
+    constexpr std::string_view body = "[1, 22, 333]";
+    auto res = co_await parse_subject_versions(fragmented_iobuf(body, 1));
+    ASSERT_TRUE_CORO(res.has_value());
+    const auto& s = res.value();
+    ASSERT_EQ_CORO(s.size(), size_t{3});
+    ASSERT_EQ_CORO(s[0], schema_version{1});
+    ASSERT_EQ_CORO(s[1], schema_version{22});
+    ASSERT_EQ_CORO(s[2], schema_version{333});
+}
+
+TEST_CORO(parse_subject_versions_test, round_trip) {
+    std::vector<schema_version> expected{
+      schema_version{1},
+      schema_version{2},
+      schema_version{5},
+      schema_version{std::numeric_limits<int32_t>::max()},
+    };
+
+    iobuf body;
+    body.append("[", 1);
+    for (size_t i = 0; i < expected.size(); ++i) {
+        auto elem = ssx::sformat("{}{}", i == 0 ? "" : ",", expected[i]());
+        body.append(elem.data(), elem.size());
+    }
+    body.append("]", 1);
+
+    auto res = co_await parse_subject_versions(std::move(body));
     ASSERT_TRUE_CORO(res.has_value());
     const auto& s = res.value();
     ASSERT_EQ_CORO(s.size(), expected.size());

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
@@ -383,10 +383,12 @@ TEST_CORO(parse_subject_version_test, reference_subject_honors_policy) {
 }
 
 TEST_CORO(parse_subject_version_test, records_unmodeled_fields) {
-    // guid/ts/ruleSet/schemaTags/metadata (and a future field) are not mapped
-    // into the schema, but their top-level names are recorded so the caller can
-    // decide whether dropping them is acceptable. A nested object/array is
-    // skipped without descending into it.
+    // guid/ts/ruleSet/schemaTags (and a future field) are not mapped into the
+    // schema, but their top-level names are recorded so the caller can decide
+    // whether dropping them is acceptable. A nested object/array under such a
+    // field is skipped without descending into it. metadata is special: its
+    // modeled `properties` is captured, while an unmodeled sub-key
+    // (`sensitive`) is reported under a `metadata.` prefix.
     auto res = co_await parse_subject_version(
       iobuf::from(
         R"({"guid":"abc","ts":1715000000000,"subject":"User","version":1,)"
@@ -401,18 +403,92 @@ TEST_CORO(parse_subject_version_test, records_unmodeled_fields) {
       s.schema.sub(), (context_subject{default_context, subject{"User"}}));
     ASSERT_EQ_CORO(s.version, schema_version{1});
     ASSERT_EQ_CORO(s.id, schema_id{7});
-    // metadata is not mapped into the schema in v1.
-    ASSERT_FALSE_CORO(s.schema.def().meta().has_value());
-    // The unmodeled top-level keys are reported, in encounter order; nested
-    // keys (metadata.properties, ruleSet.domainRules, ...) are not.
+    // metadata.properties is captured into the schema.
+    ASSERT_TRUE_CORO(s.schema.def().meta().has_value());
+    ASSERT_TRUE_CORO(s.schema.def().meta()->properties.has_value());
+    const auto& props = *s.schema.def().meta()->properties;
+    ASSERT_EQ_CORO(props.size(), size_t{1});
+    ASSERT_EQ_CORO(props.at("owner"), "team-a");
+    // The unmodeled keys are reported, in encounter order; modeled nested keys
+    // (metadata.properties, ruleSet.domainRules, ...) are not. metadata's
+    // unmodeled `sensitive` sub-key is reported under a `metadata.` prefix.
     const auto& unknown = res.value().unknown_fields;
     ASSERT_EQ_CORO(unknown.size(), size_t{6});
     ASSERT_EQ_CORO(unknown[0], "guid");
     ASSERT_EQ_CORO(unknown[1], "ts");
     ASSERT_EQ_CORO(unknown[2], "ruleSet");
-    ASSERT_EQ_CORO(unknown[3], "metadata");
+    ASSERT_EQ_CORO(unknown[3], "metadata.sensitive");
     ASSERT_EQ_CORO(unknown[4], "schemaTags");
     ASSERT_EQ_CORO(unknown[5], "futureField");
+}
+
+TEST_CORO(parse_subject_version_test, metadata_properties_coercion) {
+    // metadata.properties is a string map; numbers and booleans are coerced to
+    // strings (matching the write path), and key order is normalized by the
+    // underlying btree_map.
+    auto res = co_await parse_subject_version(
+      iobuf::from(
+        R"({"subject":"r","version":1,"id":2,"schema":"x","metadata":)"
+        R"({"properties":{"owner":"team-a","count":3,"ratio":1.5,)"
+        R"("enabled":true,"hidden":false}}})"),
+      qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_TRUE_CORO(res.value().unknown_fields.empty());
+    const auto& meta = res.value().schema.schema.def().meta();
+    ASSERT_TRUE_CORO(meta.has_value());
+    ASSERT_TRUE_CORO(meta->properties.has_value());
+    const auto& props = *meta->properties;
+    ASSERT_EQ_CORO(props.size(), size_t{5});
+    ASSERT_EQ_CORO(props.at("owner"), "team-a");
+    ASSERT_EQ_CORO(props.at("count"), "3");
+    ASSERT_EQ_CORO(props.at("ratio"), "1.5");
+    ASSERT_EQ_CORO(props.at("enabled"), "true");
+    ASSERT_EQ_CORO(props.at("hidden"), "false");
+}
+
+TEST_CORO(parse_subject_version_test, metadata_present_without_properties) {
+    // metadata carrying only unmodeled sub-keys still yields a present (but
+    // empty) schema_metadata; each unmodeled sub-key is reported with a prefix.
+    auto res = co_await parse_subject_version(
+      iobuf::from(
+        R"({"subject":"r","version":1,"id":2,"schema":"x","metadata":)"
+        R"({"tags":{"f":["PII"]},"sensitive":["ssn"]}})"),
+      qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(res.has_value());
+    const auto& meta = res.value().schema.schema.def().meta();
+    ASSERT_TRUE_CORO(meta.has_value());
+    ASSERT_FALSE_CORO(meta->properties.has_value());
+    const auto& unknown = res.value().unknown_fields;
+    ASSERT_EQ_CORO(unknown.size(), size_t{2});
+    ASSERT_EQ_CORO(unknown[0], "metadata.tags");
+    ASSERT_EQ_CORO(unknown[1], "metadata.sensitive");
+}
+
+TEST_CORO(parse_subject_version_test, metadata_empty_and_null) {
+    // metadata: {} is present-but-empty; metadata: null is treated as absent.
+    auto empty_obj = co_await parse_subject_version(
+      iobuf::from(R"({"subject":"r","version":1,"id":2,"metadata":{}})"),
+      qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(empty_obj.has_value());
+    ASSERT_TRUE_CORO(empty_obj.value().unknown_fields.empty());
+    ASSERT_TRUE_CORO(empty_obj.value().schema.schema.def().meta().has_value());
+
+    auto null_meta = co_await parse_subject_version(
+      iobuf::from(R"({"subject":"r","version":1,"id":2,"metadata":null})"),
+      qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(null_meta.has_value());
+    ASSERT_TRUE_CORO(null_meta.value().unknown_fields.empty());
+    ASSERT_FALSE_CORO(null_meta.value().schema.schema.def().meta().has_value());
+
+    // metadata.properties: null leaves properties absent (metadata present).
+    auto null_props = co_await parse_subject_version(
+      iobuf::from(
+        R"({"subject":"r","version":1,"metadata":{"properties":null}})"),
+      qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(null_props.has_value());
+    const auto& meta = null_props.value().schema.schema.def().meta();
+    ASSERT_TRUE_CORO(meta.has_value());
+    ASSERT_FALSE_CORO(meta->properties.has_value());
 }
 
 TEST_CORO(parse_subject_version_test, absent_fields_use_sentinels_not_error) {
@@ -455,9 +531,13 @@ TEST_CORO(parse_subject_version_test, rejects_unrepresentable) {
           R"({"id":2147483648,"subject":"r"})",  // > INT32_MAX
           R"({"references":[{"version":"x"}]})", // bad reference element
           R"({"references":5})",                 // references not an array
-          "[1,2,3]",                             // not an object
-          R"({"subject":"r")",                   // truncated
-          R"({"subject":"r"}garbage)",           // trailing content after }
+          R"({"metadata":5,"subject":"r"})",     // metadata not an object
+          R"({"metadata":{"properties":5}})",    // properties not an object
+          R"({"metadata":{"properties":{"k":["x"]}}})", // value not a scalar
+          R"({"metadata":{"properties":{"k":null}}})",  // value null
+          "[1,2,3]",                                    // not an object
+          R"({"subject":"r")",                          // truncated
+          R"({"subject":"r"}garbage)", // trailing content after }
           "not json"}) {
         SCOPED_TRACE(body);
         auto res = co_await parse_subject_version(

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/retry_policy_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/retry_policy_test.cc
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "pandaproxy/schema_registry/rest_client/retry_policy.h"
+
+#include <gtest/gtest.h>
+
+namespace r = pandaproxy::schema_registry::rest_client;
+using enum boost::beast::http::status;
+
+namespace {
+template<typename Ex>
+r::request_error throw_and_catch(Ex ex) {
+    try {
+        throw ex;
+    } catch (...) {
+        return r::default_retry_policy{}.should_retry(std::current_exception());
+    }
+}
+} // namespace
+
+TEST(default_retry_policy, status_ok) {
+    r::default_retry_policy p;
+    auto result = p.should_retry(
+      http::downloaded_response{.status = ok, .body = iobuf::from("success")});
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result.value().body, iobuf::from("success"));
+}
+
+TEST(default_retry_policy, status_retriable) {
+    r::default_retry_policy p;
+    for (const auto status : std::to_array(
+           {internal_server_error,
+            bad_gateway,
+            service_unavailable,
+            gateway_timeout,
+            too_many_requests,
+            request_timeout})) {
+        auto result = p.should_retry(
+          http::downloaded_response{
+            .status = status, .body = iobuf::from("retry")});
+        ASSERT_FALSE(result.has_value());
+        ASSERT_EQ(result.error().kind, r::error_kind::retriable_http_status);
+    }
+}
+
+TEST(default_retry_policy, status_not_retriable) {
+    r::default_retry_policy p;
+    for (const auto status : std::to_array(
+           {bad_request, unauthorized, method_not_allowed, not_acceptable})) {
+        auto result = p.should_retry(
+          http::downloaded_response{
+            .status = status, .body = iobuf::from("retry")});
+        ASSERT_FALSE(result.has_value());
+        ASSERT_EQ(result.error().kind, r::error_kind::permanent_failure);
+    }
+}
+
+TEST(default_retry_policy, boost_system_errors) {
+    auto retriable = throw_and_catch(
+      boost::system::system_error{boost::beast::http::error::end_of_stream});
+    ASSERT_EQ(retriable.kind, r::error_kind::network_error);
+    auto permanent_failure = throw_and_catch(
+      boost::system::system_error{boost::beast::http::error::bad_alloc});
+    ASSERT_EQ(permanent_failure.kind, r::error_kind::permanent_failure);
+}
+
+TEST(default_retry_policy, system_errors) {
+    auto retriable = throw_and_catch(
+      std::system_error{ETIMEDOUT, std::generic_category()});
+    ASSERT_EQ(retriable.kind, r::error_kind::network_error);
+    auto permanent_failure = throw_and_catch(
+      std::system_error{ETIMEDOUT, ss::tls::error_category()});
+    ASSERT_EQ(permanent_failure.kind, r::error_kind::permanent_failure);
+}
+
+TEST(default_retry_policy, abort_exception) {
+    auto gate_failure = throw_and_catch(ss::gate_closed_exception{});
+    ASSERT_EQ(gate_failure.kind, r::error_kind::aborted);
+    auto abort_failure = throw_and_catch(ss::abort_requested_exception{});
+    ASSERT_EQ(abort_failure.kind, r::error_kind::aborted);
+}
+
+TEST(default_retry_policy, nested_exception) {
+    auto gate_failure = throw_and_catch(
+      ss::nested_exception{
+        std::make_exception_ptr(ss::gate_closed_exception{}),
+        std::make_exception_ptr(std::runtime_error{"out"})});
+    ASSERT_EQ(gate_failure.kind, r::error_kind::aborted);
+    auto abort_failure = throw_and_catch(
+      ss::nested_exception{
+        std::make_exception_ptr(std::invalid_argument{""}),
+        std::make_exception_ptr(ss::abort_requested_exception{})});
+    ASSERT_EQ(abort_failure.kind, r::error_kind::aborted);
+
+    auto result = throw_and_catch(
+      ss::nested_exception{
+        std::make_exception_ptr(std::invalid_argument{"i"}),
+        std::make_exception_ptr(std::invalid_argument{"o"})});
+    ASSERT_EQ(result.kind, r::error_kind::permanent_failure);
+    ASSERT_TRUE(std::holds_alternative<ss::sstring>(result.err));
+    ASSERT_EQ(
+      "seastar::nested_exception [outer: std::invalid_argument (o), "
+      "inner: std::invalid_argument (i)]",
+      std::get<ss::sstring>(result.err));
+}

--- a/src/v/pandaproxy/schema_registry/test/context_subject.cc
+++ b/src/v/pandaproxy/schema_registry/test/context_subject.cc
@@ -115,6 +115,54 @@ TEST_F(ContextSubjectTest, FlagOffUnqualifiedUsesDefaultContext) {
     EXPECT_EQ(ctx_sub.sub(), "plain-topic");
 }
 
+TEST_F(ContextSubjectTest, FromStringExplicitPolicyParsesPerArgument) {
+    const auto enabled = qualified_subjects_enabled::yes;
+    const auto disabled = qualified_subjects_enabled::no;
+
+    // Enabled: the qualified-subject grammar applies.
+    EXPECT_EQ(
+      context_subject::from_string("my-topic", enabled),
+      (context_subject{default_context, subject{"my-topic"}}));
+    EXPECT_EQ(
+      context_subject::from_string(":.my-ctx:my-topic", enabled),
+      (context_subject{context{".my-ctx"}, subject{"my-topic"}}));
+    // Only the first colon after ":." splits context from subject.
+    EXPECT_EQ(
+      context_subject::from_string(":.ctx:a:b:c", enabled),
+      (context_subject{context{".ctx"}, subject{"a:b:c"}}));
+    // A leading ':' not followed by '.' is not a context marker.
+    EXPECT_EQ(
+      context_subject::from_string(":no-dot", enabled),
+      (context_subject{default_context, subject{":no-dot"}}));
+
+    // Disabled: the entire string is a subject in the default context.
+    EXPECT_EQ(
+      context_subject::from_string(":.my-ctx:my-topic", disabled),
+      (context_subject{default_context, subject{":.my-ctx:my-topic"}}));
+    EXPECT_EQ(
+      context_subject::from_string("plain-topic", disabled),
+      (context_subject{default_context, subject{"plain-topic"}}));
+}
+
+TEST_F(ContextSubjectTest, FromStringExplicitPolicyIgnoresClusterConfig) {
+    // The two-arg overload honors the caller-supplied policy regardless of the
+    // cluster config flag: set the global flag opposite to each explicit policy
+    // and prove the argument wins.
+    config::shard_local_cfg()
+      .schema_registry_enable_qualified_subjects.set_value(false);
+    EXPECT_EQ(
+      context_subject::from_string(
+        ":.my-ctx:my-topic", qualified_subjects_enabled::yes),
+      (context_subject{context{".my-ctx"}, subject{"my-topic"}}));
+
+    config::shard_local_cfg()
+      .schema_registry_enable_qualified_subjects.set_value(true);
+    EXPECT_EQ(
+      context_subject::from_string(
+        ":.my-ctx:my-topic", qualified_subjects_enabled::no),
+      (context_subject{default_context, subject{":.my-ctx:my-topic"}}));
+}
+
 TEST_F(ContextSubjectTest, ValidateSubjectRejectsReservedNames) {
     // __GLOBAL as subject is always rejected, regardless of context or mode
     EXPECT_THROW(

--- a/src/v/pandaproxy/schema_registry/test/context_subject.cc
+++ b/src/v/pandaproxy/schema_registry/test/context_subject.cc
@@ -259,7 +259,13 @@ TEST_F(ContextSubjectTest, ValidateSubjectConfigModeFlag) {
       exception);
 }
 
-class ContextSubjectReferenceTest : public ::testing::Test {};
+class ContextSubjectReferenceTest : public ::testing::Test {
+protected:
+    void TearDown() override {
+        config::shard_local_cfg()
+          .schema_registry_enable_qualified_subjects.reset();
+    }
+};
 
 TEST_F(ContextSubjectReferenceTest, FromString) {
     // Unqualified subjects: qualified=false
@@ -318,6 +324,27 @@ TEST_F(ContextSubjectReferenceTest, ToStringRoundTrip) {
         auto got = context_subject_reference::from_string(input).to_string();
         EXPECT_EQ(got, input);
     }
+}
+
+TEST_F(
+  ContextSubjectReferenceTest, FromStringExplicitPolicyIgnoresClusterConfig) {
+    // The two-arg overload honors the caller-supplied policy regardless of the
+    // cluster config flag: set the global flag opposite to each explicit policy
+    // and prove the argument wins.
+    config::shard_local_cfg()
+      .schema_registry_enable_qualified_subjects.set_value(false);
+    auto qual = context_subject_reference::from_string(
+      ":.ctx:sub", qualified_subjects_enabled::yes);
+    EXPECT_EQ(qual.qualified, is_qualified::yes);
+    EXPECT_EQ(qual.sub, (context_subject{context{".ctx"}, subject{"sub"}}));
+
+    config::shard_local_cfg()
+      .schema_registry_enable_qualified_subjects.set_value(true);
+    auto unqual = context_subject_reference::from_string(
+      ":.ctx:sub", qualified_subjects_enabled::no);
+    EXPECT_EQ(unqual.qualified, is_qualified::no);
+    EXPECT_EQ(
+      unqual.sub, (context_subject{default_context, subject{":.ctx:sub"}}));
 }
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/types.cc
+++ b/src/v/pandaproxy/schema_registry/types.cc
@@ -67,10 +67,10 @@ fmt::iterator schema_metadata::format_to(fmt::iterator it) const {
 }
 
 namespace {
-std::pair<context_subject, is_qualified> parse_subject(std::string_view input) {
+std::pair<context_subject, is_qualified>
+parse_subject(std::string_view input, qualified_subjects_enabled enabled) {
     // If qualified subject parsing is disabled, treat everything as literal
-    if (!config::shard_local_cfg()
-           .schema_registry_enable_qualified_subjects()) {
+    if (!enabled) {
         return {
           context_subject{default_context, subject{input}}, is_qualified::no};
     }
@@ -99,15 +99,26 @@ std::pair<context_subject, is_qualified> parse_subject(std::string_view input) {
     // Default case: unqualified subject or invalid qualified syntax
     return {context_subject{default_context, subject{input}}, is_qualified::no};
 }
+
+qualified_subjects_enabled cluster_qualified_subjects_enabled() {
+    return qualified_subjects_enabled{
+      config::shard_local_cfg().schema_registry_enable_qualified_subjects()};
+}
 } // namespace
 
 context_subject context_subject::from_string(std::string_view input) {
-    return parse_subject(input).first;
+    return from_string(input, cluster_qualified_subjects_enabled());
+}
+
+context_subject context_subject::from_string(
+  std::string_view input, qualified_subjects_enabled enabled) {
+    return parse_subject(input, enabled).first;
 }
 
 context_subject_reference
 context_subject_reference::from_string(std::string_view input) {
-    auto [sub, qualified] = parse_subject(input);
+    auto [sub, qualified] = parse_subject(
+      input, cluster_qualified_subjects_enabled());
     return context_subject_reference{
       .sub = std::move(sub),
       .qualified = qualified,

--- a/src/v/pandaproxy/schema_registry/types.cc
+++ b/src/v/pandaproxy/schema_registry/types.cc
@@ -117,8 +117,12 @@ context_subject context_subject::from_string(
 
 context_subject_reference
 context_subject_reference::from_string(std::string_view input) {
-    auto [sub, qualified] = parse_subject(
-      input, cluster_qualified_subjects_enabled());
+    return from_string(input, cluster_qualified_subjects_enabled());
+}
+
+context_subject_reference context_subject_reference::from_string(
+  std::string_view input, qualified_subjects_enabled enabled) {
+    auto [sub, qualified] = parse_subject(input, enabled);
     return context_subject_reference{
       .sub = std::move(sub),
       .qualified = qualified,

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -41,6 +41,8 @@ using force = ss::bool_class<struct force_tag>;
 using normalize = ss::bool_class<struct normalize_tag>;
 using verbose = ss::bool_class<struct verbose_tag>;
 using is_qualified = ss::bool_class<struct is_qualified_tag>;
+using qualified_subjects_enabled
+  = ss::bool_class<struct qualified_subjects_enabled_tag>;
 using is_config_or_mode = ss::bool_class<struct is_config_or_mode_tag>;
 
 /// Identifies the write path for shadowing write policy. The
@@ -207,8 +209,17 @@ struct context_subject {
     }
 
     /// Parse from qualified subject ":.context:subject" or unqualified
-    /// "subject" (which uses the default context)
+    /// "subject" (which uses the default context). Whether the qualified form
+    /// is honored is read from this node's cluster config
+    /// (schema_registry_enable_qualified_subjects).
     static context_subject from_string(std::string_view input);
+
+    /// As above, but the caller supplies whether qualified parsing is enabled
+    /// instead of reading cluster config. Use from code that must not depend on
+    /// this node's cluster config, e.g. a client parsing the responses of a
+    /// remote schema registry.
+    static context_subject
+    from_string(std::string_view input, qualified_subjects_enabled enabled);
 
     /// Helper for testing to create a simple unqualified subject in the default
     /// context

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -286,8 +286,17 @@ void validate_context(const context& ctx);
 /// A reference subject that may be qualified or unqualified.
 /// Unqualified references are resolved relative to a parent schema's context.
 struct context_subject_reference {
-    /// Parse from a string while detecting qualification status
+    /// Parse from a string while detecting qualification status. Whether the
+    /// qualified form is honored is read from this node's cluster config
+    /// (schema_registry_enable_qualified_subjects).
     static context_subject_reference from_string(std::string_view input);
+
+    /// As above, but the caller supplies whether qualified parsing is enabled
+    /// instead of reading cluster config. Use from code that must not depend on
+    /// this node's cluster config, e.g. a client parsing the responses of a
+    /// remote schema registry.
+    static context_subject_reference
+    from_string(std::string_view input, qualified_subjects_enabled enabled);
 
     /// Helper for testing to create a simple unqualified reference
     static context_subject_reference unqualified(std::string_view input) {


### PR DESCRIPTION
  Introduces a reusable Schema Registry REST client framework under
  `pandaproxy::schema_registry::rest_client`. It is a standalone, dependency-injected
  HTTP client (an injected `http::abstract_client`) that works against both Redpanda's
  own Schema Registry and third-party Confluent-compatible registries, with HTTP Basic
  auth, a retry policy, streaming response parsers, and a typed domain-error model. This
  is the base framework only — no feature consumes it yet.

  Scope (v1):
  - Three read endpoints: `GET /subjects`, `GET /subjects/{subject}/versions`, and
    `GET /subjects/{subject}/versions/{version}`.
  - `http::request_builder::with_basic_auth` (RFC 7617) on the shared HTTP layer.

  Out of scope (follow-ups): pagination / filter query params, the `latest` version
  selector, write endpoints, and the cluster_link SR sync adapter that will consume this
  client.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
