### PR TITLE
rptest: fix max_connections swarm sizing for librdkafka >= 2.10.0

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
@@ -317,9 +317,12 @@ class OMBValidationTest(RedpandaCloudTest):
             (tier_limits.max_connections_count - omb_connections) * 1.1
         )
 
-        # we expect each swarm producer to create 1 connection per broker, plus 1 additional connection
-        # for metadata
-        conn_per_swarm_producer = self.num_brokers + 1
+        # We expect each swarm producer to hold one connection per broker. Older librdkafka also kept a
+        # separate persistent connection to the bootstrap broker (the historical "+ 1"), but librdkafka
+        # removed it in v2.10.0 (confluentinc/librdkafka#4557): brokers are now keyed by id rather than
+        # host:port, so the bootstrap entry is merged into the learned broker list. client-swarm bundles
+        # librdkafka >= 2.10.0, so a producer holds exactly num_brokers connections.
+        conn_per_swarm_producer = self.num_brokers
 
         producer_per_swarm_node: int = (
             swarm_target_connections // conn_per_swarm_producer // SWARM_WORKERS


### PR DESCRIPTION
`OMBValidationTest.test_max_connections` sizes the swarm of producers from an
assumption about how many connections each swarm producer holds. It assumed
`num_brokers + 1`, where the `+ 1` was a persistent connection to the bootstrap
broker.

librdkafka removed that separate bootstrap-broker connection in v2.10.0
(confluentinc/librdkafka#4557): brokers are now keyed by id rather than
host:port, so the bootstrap entry is merged into the learned broker list and a
producer ends up holding exactly one connection per broker. client-swarm now
bundles librdkafka >= 2.10.0, so the old `+ 1` over-estimated the per-producer
connection count and the swarm was provisioned with too few producers to ever
reach the advertised connection target, causing the test to fail with e.g.
`Failed to reach target connections, actual: ~18560, target: 24723`.

This drops the stale `+ 1` so `conn_per_swarm_producer == num_brokers`, which
re-sizes `producer_per_swarm_node` upward and lets the swarm actually reach the
target connection count.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none