### PR TITLE
ct/l1/metastore: adjustments to pre-opening and add configurations

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/lsm/replicated_db.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/replicated_db.cc
@@ -144,6 +144,8 @@ replicated_database::open(
           .max_pre_open_fibers
           = config::shard_local_cfg()
               .cloud_topics_metastore_max_pre_open_fibers(),
+          .block_cache_size
+          = config::shard_local_cfg().cloud_topics_metastore_block_cache_size(),
           .file_deletion_delay = absl::FromChrono(
             config::shard_local_cfg()
               .cloud_topics_long_term_file_deletion_delay()),

--- a/src/v/cloud_topics/level_one/metastore/lsm/replicated_db.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/replicated_db.cc
@@ -139,6 +139,8 @@ replicated_database::open(
         lsm::options{
           .database_epoch = epoch(),
           .compaction_scheduling_group = sg,
+          .write_buffer_size = config::shard_local_cfg()
+                                 .cloud_topics_metastore_write_buffer_size(),
           .max_pre_open_fibers
           = config::shard_local_cfg()
               .cloud_topics_metastore_max_pre_open_fibers(),

--- a/src/v/cloud_topics/level_one/metastore/lsm/replicated_db.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/replicated_db.cc
@@ -139,6 +139,9 @@ replicated_database::open(
         lsm::options{
           .database_epoch = epoch(),
           .compaction_scheduling_group = sg,
+          .max_pre_open_fibers
+          = config::shard_local_cfg()
+              .cloud_topics_metastore_max_pre_open_fibers(),
           .file_deletion_delay = absl::FromChrono(
             config::shard_local_cfg()
               .cloud_topics_long_term_file_deletion_delay()),

--- a/src/v/cloud_topics/read_replica/snapshot_manager.cc
+++ b/src/v/cloud_topics/read_replica/snapshot_manager.cc
@@ -148,7 +148,10 @@ ss::future<> database_refresher::open_or_refresh() {
       lsm::options{
         .database_epoch = lsm::internal::database_epoch::max(),
         .readonly = true,
-        // TODO: tuning.
+        .max_pre_open_fibers = config::shard_local_cfg()
+                                 .cloud_topics_metastore_max_pre_open_fibers(),
+        .block_cache_size
+        = config::shard_local_cfg().cloud_topics_metastore_block_cache_size(),
       },
       std::move(io));
     vlog(logger_.debug, "Opened with seqno {}", db.max_applied_seqno());

--- a/src/v/cloud_topics/read_replica/tests/snapshot_manager_test.cc
+++ b/src/v/cloud_topics/read_replica/tests/snapshot_manager_test.cc
@@ -18,6 +18,7 @@
 #include "config/configuration.h"
 #include "lsm/lsm.h"
 #include "storage/disk.h"
+#include "test_utils/scoped_config.h"
 #include "test_utils/tmp_dir.h"
 
 #include <gtest/gtest.h>
@@ -33,6 +34,32 @@ const auto test_tidp = model::topic_id_partition{
   model::topic_id{uuid_t::create()}, model::partition_id{0}};
 using o = kafka::offset;
 
+void start_cache(
+  ss::sharded<cloud_io::cache>& cache, const std::filesystem::path& dir) {
+    cloud_io::cache::initialize(dir).get();
+    cache
+      .start(
+        dir,
+        30_GiB,
+        config::mock_binding<double>(0.0),
+        config::mock_binding<uint64_t>(100_MiB),
+        config::mock_binding<std::optional<double>>(std::nullopt),
+        config::mock_binding<uint32_t>(100000),
+        config::mock_binding<uint16_t>(3))
+      .get();
+    cache.invoke_on_all([](cloud_io::cache& c) { return c.start(); }).get();
+    cache
+      .invoke_on(
+        ss::shard_id{0},
+        [](cloud_io::cache& c) {
+            c.notify_disk_status(
+              100ULL * 1024 * 1024 * 1024,
+              50ULL * 1024 * 1024 * 1024,
+              storage::disk_space_alert::ok);
+        })
+      .get();
+}
+
 } // namespace
 class SnapshotManagerTest
   : public ::testing::Test
@@ -41,39 +68,23 @@ public:
     void SetUp() override {
         db_s3_imposter_fixture::start().get();
         sr_ = cloud_io::scoped_remote::create(10, conf);
-        config::shard_local_cfg()
-          .cloud_storage_readreplica_manifest_sync_timeout_ms.set_value(500ms);
+        cfg_.get("cloud_storage_readreplica_manifest_sync_timeout_ms")
+          .set_value(500ms);
         staging_dir_ = std::make_unique<temporary_dir>("snapshot_manager_test");
 
-        auto cache_dir = staging_dir_->get_path() / "cache";
-        cloud_io::cache::initialize(cache_dir).get();
-        writer_cache_
-          .start(
-            cache_dir,
-            30_GiB,
-            config::mock_binding<double>(0.0),
-            config::mock_binding<uint64_t>(100_MiB),
-            config::mock_binding<std::optional<double>>(std::nullopt),
-            config::mock_binding<uint32_t>(100000),
-            config::mock_binding<uint16_t>(3))
-          .get();
-        writer_cache_
-          .invoke_on_all([](cloud_io::cache& c) { return c.start(); })
-          .get();
-        writer_cache_
-          .invoke_on(
-            ss::shard_id{0},
-            [](cloud_io::cache& c) {
-                c.notify_disk_status(
-                  100ULL * 1024 * 1024 * 1024,
-                  50ULL * 1024 * 1024 * 1024,
-                  storage::disk_space_alert::ok);
-            })
-          .get();
+        // The writer and reader run separate caches in one process, so disable
+        // metrics to avoid double-registering the shared cache metric names.
+        cfg_.get("disable_metrics").set_value(true);
+        cfg_.get("disable_public_metrics").set_value(true);
+
+        // The writer and reader use separate caches so that the reader
+        // hydrates from S3 rather than reading the writer's cached objects.
+        start_cache(writer_cache_, staging_dir_->get_path() / "writer_cache");
+        start_cache(reader_cache_, staging_dir_->get_path() / "reader_cache");
 
         reader_staging_dir_ = staging_dir_->get_path() / "reader";
         snapshot_mgr_ = std::make_unique<read_replica::snapshot_manager>(
-          reader_staging_dir_, &sr_->remote.local(), nullptr);
+          reader_staging_dir_, &sr_->remote.local(), &reader_cache_.local());
     }
 
     void TearDown() override {
@@ -85,6 +96,7 @@ public:
             snapshot_mgr_->stop().get();
             snapshot_mgr_.reset();
         }
+        reader_cache_.stop().get();
         writer_cache_.stop().get();
         sr_.reset();
         db_s3_imposter_fixture::stop().get();
@@ -138,8 +150,10 @@ public:
     }
 
 protected:
+    scoped_config cfg_;
     std::unique_ptr<temporary_dir> staging_dir_;
     ss::sharded<cloud_io::cache> writer_cache_;
+    ss::sharded<cloud_io::cache> reader_cache_;
     std::filesystem::path reader_staging_dir_;
     std::unique_ptr<cloud_io::scoped_remote> sr_;
     std::unique_ptr<read_replica::snapshot_manager> snapshot_mgr_;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -5012,6 +5012,16 @@ configuration::configuration()
       "behind and writes are being throttled.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       5min)
+  , cloud_topics_metastore_max_pre_open_fibers(
+      *this,
+      "cloud_topics_metastore_max_pre_open_fibers",
+      "If non-zero, the number of fibers used to pre-open every SST file in "
+      "the L1 metastore LSM database at open time (broker restart or "
+      "partition leadership transfer), populating caches before the first "
+      "read. Set to 0 to open SSTs lazily.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      10,
+      {.min = 0, .max = 1024})
   , cloud_topics_parallel_fetch_enabled(
       *this,
       "cloud_topics_parallel_fetch_enabled",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -5012,6 +5012,15 @@ configuration::configuration()
       "behind and writes are being throttled.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       5min)
+  , cloud_topics_metastore_block_cache_size(
+      *this,
+      "cloud_topics_metastore_block_cache_size",
+      "Size in bytes of the per-database uncompressed-block cache used by the "
+      "L1 metastore LSM database. Only takes effect when an LSM database is "
+      "opened (broker restart or metastore partition leadership transfer).",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      10_MiB,
+      {.min = 1_MiB, .max = 64_GiB})
   , cloud_topics_metastore_write_buffer_size(
       *this,
       "cloud_topics_metastore_write_buffer_size",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -5012,6 +5012,16 @@ configuration::configuration()
       "behind and writes are being throttled.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       5min)
+  , cloud_topics_metastore_write_buffer_size(
+      *this,
+      "cloud_topics_metastore_write_buffer_size",
+      "Size in bytes of the memtable for the L1 metastore LSM database. Also "
+      "parameterizes per-level target SST file sizes (each level is sized "
+      "proportionally to this value). Only takes effect when an LSM database "
+      "is opened (broker restart or metastore partition leadership transfer).",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      16_MiB,
+      {.min = 1_MiB, .max = 1_GiB})
   , cloud_topics_metastore_max_pre_open_fibers(
       *this,
       "cloud_topics_metastore_max_pre_open_fibers",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -847,6 +847,7 @@ public:
       cloud_topics_metastore_replication_timeout_ms;
     property<std::chrono::milliseconds>
       cloud_topics_metastore_lsm_apply_timeout_ms;
+    bounded_property<size_t> cloud_topics_metastore_write_buffer_size;
     bounded_property<uint32_t> cloud_topics_metastore_max_pre_open_fibers;
 
     property<bool> cloud_topics_parallel_fetch_enabled;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -847,6 +847,7 @@ public:
       cloud_topics_metastore_replication_timeout_ms;
     property<std::chrono::milliseconds>
       cloud_topics_metastore_lsm_apply_timeout_ms;
+    bounded_property<size_t> cloud_topics_metastore_block_cache_size;
     bounded_property<size_t> cloud_topics_metastore_write_buffer_size;
     bounded_property<uint32_t> cloud_topics_metastore_max_pre_open_fibers;
 

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -847,6 +847,7 @@ public:
       cloud_topics_metastore_replication_timeout_ms;
     property<std::chrono::milliseconds>
       cloud_topics_metastore_lsm_apply_timeout_ms;
+    bounded_property<uint32_t> cloud_topics_metastore_max_pre_open_fibers;
 
     property<bool> cloud_topics_parallel_fetch_enabled;
 

--- a/src/v/lsm/db/impl.cc
+++ b/src/v/lsm/db/impl.cc
@@ -68,11 +68,13 @@ ss::future<std::unique_ptr<impl>> impl::open(
     }
     // If we're readonly, we don't need to start any compaction loop.
     if (db->_opts->readonly) {
+        db->maybe_start_prewarm();
         vlog(log.trace, "open_end readonly=true");
         co_return db;
     }
     co_await db->_gc_actor.start();
     db->maybe_schedule_compaction();
+    db->maybe_start_prewarm();
     vlog(log.trace, "open_end readonly=false");
     co_return db;
 }
@@ -298,25 +300,50 @@ lsm::data_stats impl::get_data_stats() const {
 ss::future<> impl::recover() {
     vlog(log.trace, "recover_start");
     co_await _versions->recover();
-    // If requested, then pre-open all the files we know about.
-    if (auto max_fibers = _opts->max_pre_open_fibers) {
-        chunked_vector<ss::lw_shared_ptr<file_meta_data>> all_files;
-        for (auto level : _opts->levels) {
-            auto files = _versions->current()->get_overlapping_inputs(
-              level.number, std::nullopt, std::nullopt);
-            for (auto& file : files) {
-                all_files.push_back(std::move(file));
-            }
-        }
-        vlog(log.trace, "recover_pre_open_start files={}", all_files.size());
-        co_await ss::max_concurrent_for_each(
-          all_files, max_fibers, [this](ss::lw_shared_ptr<file_meta_data> f) {
-              return _table_cache->create_iterator(f->handle, f->file_size)
-                .discard_result();
-          });
-        vlog(log.trace, "recover_pre_open_end files={}", all_files.size());
-    }
     vlog(log.trace, "recover_end");
+}
+
+void impl::maybe_start_prewarm() {
+    if (_opts->max_pre_open_fibers == 0) {
+        return;
+    }
+    auto h = _gate.hold();
+    ssx::background = prewarm().then_wrapped([h](ss::future<> f) {
+        if (f.failed()) {
+            auto ex = f.get_exception();
+            vlog(log.warn, "prewarm aborted: {}", ex);
+        }
+    });
+}
+
+ss::future<> impl::prewarm() {
+    auto max_fibers = _opts->max_pre_open_fibers;
+    auto version = _versions->current();
+    chunked_vector<ss::lw_shared_ptr<file_meta_data>> all_files;
+    for (auto level : _opts->levels) {
+        auto files = version->get_overlapping_inputs(
+          level.number, std::nullopt, std::nullopt);
+        for (auto& file : files) {
+            all_files.push_back(std::move(file));
+        }
+    }
+    vlog(log.trace, "prewarm_start files={}", all_files.size());
+    co_await ss::max_concurrent_for_each(
+      all_files, max_fibers, [this](ss::lw_shared_ptr<file_meta_data> f) {
+          if (_as.abort_requested()) {
+              return ss::now();
+          }
+          return _table_cache->create_iterator(f->handle, f->file_size)
+            .discard_result()
+            .handle_exception([f](const std::exception_ptr& e) {
+                vlog(
+                  log.debug,
+                  "prewarm failed to open file {}: {}",
+                  f->handle.id(),
+                  e);
+            });
+      });
+    vlog(log.trace, "prewarm_end files={}", all_files.size());
 }
 
 void impl::maybe_schedule_compaction() {

--- a/src/v/lsm/db/impl.h
+++ b/src/v/lsm/db/impl.h
@@ -110,6 +110,12 @@ private:
 
     ss::future<> recover();
 
+    // If pre-opening is enabled (max_pre_open_fibers > 0), launches a
+    // best-effort background fiber that warms the table cache by opening
+    // every SST in the current version.
+    void maybe_start_prewarm();
+    ss::future<> prewarm();
+
     ss::future<> make_room_for_write();
 
     void maybe_schedule_compaction();

--- a/src/v/lsm/db/tests/impl_test.cc
+++ b/src/v/lsm/db/tests/impl_test.cc
@@ -531,13 +531,17 @@ TEST_F(ImplTest, PreOpenFiles) {
     _options->max_pre_open_fibers = 0;
     restart();
 
+    // Warming, if any, runs in the background; drain to give it a chance.
+    tests::drain_task_queue().get();
     EXPECT_EQ(opened_files().size(), 0);
     EXPECT_TRUE(matches_shadow());
 
-    // Restart with max_pre_open_fibers > 0 (enabled)
+    // Restart with max_pre_open_fibers > 0 (enabled). Warming is a background
+    // fiber, so wait for the reactor to drain.
     _options->max_pre_open_fibers = 4;
     restart();
 
+    tests::drain_task_queue().get();
     EXPECT_EQ(opened_files().size(), files.size());
     for (const auto& file : files) {
         EXPECT_TRUE(opened_files().contains(file))


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This PR makes a few tweaks to the opening of the metastore:
- First, it makes the LSM open call a background operation rather than a synchronous operation. For the metastore, the LSM is opened upon becoming partition leader, and it waits for the open to complete before serving requests. Even with cold SSTs it's worth allowing the open to proceed, at least to avoid a window of metastore unavailability.
- Actually make the metastore use the preopening feature. In a scaled cluster, I've seen this significantly help avoid high metastore latencies on cold starts (empirically, low minutes -> low tens of seconds).
- Adds configurables for the memtable size and block cache size. The defaults are left as is, but they're useful to have as tunables at least for testing.
- Related configs are also plumbed into the read replica databases

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
