### PR TITLE
kafka: add fetch_busy_latency_us metric

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -617,6 +617,8 @@ public:
         size_t total_size;
         // The time it took for the first `fetch_ntps` to complete
         std::chrono::microseconds first_run_latency_result;
+        bool waited{false};
+        std::optional<op_context::latency_point> last_data_read_time;
     };
 
     ss::future<worker_result> run() {
@@ -781,6 +783,7 @@ private:
 
     ss::future<worker_result> do_run() {
         bool first_run{true};
+        bool waited{false};
         std::chrono::microseconds first_run_latency_result{0};
         // A map of indexes in `requests` to their corresponding index in
         // `_ctx.requests`.
@@ -813,7 +816,16 @@ private:
                 start_time = op_context::latency_clock::now();
             }
 
+            std::optional<op_context::latency_point> read_start
+              = op_context::latency_clock::now();
+
             auto q_results = co_await query_requests(std::move(requests));
+            // read_start anchors the busy interval; drop it unless this
+            // post-wait read returned data. Not carried past the wait below,
+            // so the reported interval can never span a wait.
+            if (first_run || q_results.total_size == 0) {
+                read_start.reset();
+            }
             if (first_run) {
                 results = std::move(q_results.results);
                 total_size = q_results.total_size;
@@ -845,6 +857,8 @@ private:
                   .read_results = std::move(results),
                   .total_size = total_size,
                   .first_run_latency_result = first_run_latency_result,
+                  .waited = waited,
+                  .last_data_read_time = read_start,
                 };
             }
 
@@ -867,9 +881,12 @@ private:
                   .read_results = std::move(results),
                   .total_size = total_size,
                   .first_run_latency_result = first_run_latency_result,
+                  .waited = waited,
+                  .last_data_read_time = read_start,
                 };
             }
 
+            waited = true;
             co_await _completed_waiter_count.wait();
 
             if (_as.abort_requested()) {
@@ -877,6 +894,8 @@ private:
                   .read_results = std::move(results),
                   .total_size = total_size,
                   .first_run_latency_result = first_run_latency_result,
+                  .waited = waited,
+                  .last_data_read_time = std::nullopt,
                 };
             }
 
@@ -902,7 +921,9 @@ public:
     ss::future<> execute_plan(op_context& octx, fetch_plan plan) final {
         auto fetch_read_strategy
           = config::shard_local_cfg().fetch_read_strategy();
-        if (is_fetch_strategy_with_debounce(fetch_read_strategy)) {
+        _fetch_used_debounce = is_fetch_strategy_with_debounce(
+          fetch_read_strategy);
+        if (_fetch_used_debounce) {
             co_await ss::sleep(
               std::min(
                 config::shard_local_cfg().fetch_reads_debounce_timeout(),
@@ -941,6 +962,17 @@ public:
         if (_thrown_exception) {
             std::rethrow_exception(_thrown_exception);
         }
+    }
+
+    bool fetch_waited() const { return _wait_state == wait_state::waited; }
+
+    bool bytes_were_read() const { return _bytes_were_read; }
+
+    bool fetch_used_debounce() const { return _fetch_used_debounce; }
+
+    const std::optional<op_context::latency_point>&
+    last_data_read_time() const {
+        return _last_data_read_time;
     }
 
 private:
@@ -1117,6 +1149,24 @@ private:
         octx.rctx.probe().record_fetch_latency(
           results.first_run_latency_result);
 
+        if (results.waited) {
+            if (_wait_state != wait_state::completed_without_waiting) {
+                _wait_state = wait_state::waited;
+            }
+        } else if (
+          _wait_state == wait_state::not_waited && results.total_size > 0
+          && octx.should_stop_fetch()) {
+            _wait_state = wait_state::completed_without_waiting;
+        }
+        if (results.last_data_read_time) {
+            _last_data_read_time = _last_data_read_time
+                                     ? std::max(
+                                         *_last_data_read_time,
+                                         *results.last_data_read_time)
+                                     : *results.last_data_read_time;
+        }
+        _bytes_were_read |= results.total_size > 0;
+
         _last_result_size[fetch.shard] = results.total_size;
         _completed_shard_fetches.push_back(std::move(fetch));
         _has_progress.signal();
@@ -1153,6 +1203,11 @@ private:
     ss::condition_variable _has_progress;
     std::vector<shard_fetch> _completed_shard_fetches;
     std::vector<size_t> _last_result_size;
+    enum class wait_state { not_waited, waited, completed_without_waiting };
+    wait_state _wait_state{wait_state::not_waited};
+    std::optional<op_context::latency_point> _last_data_read_time;
+    bool _bytes_were_read{false};
+    bool _fetch_used_debounce{false};
     // If any child task throws an exception this holds on to the exception
     // until all child tasks have been stopped and its safe to rethrow the
     // exception.
@@ -1446,12 +1501,46 @@ ss::future<> do_fetch(op_context& octx) {
 
     nonpolling_fetch_plan_executor executor;
     co_await executor.execute_plan(octx, std::move(fetch_plan));
+    octx.fetch_waited = executor.fetch_waited();
+    octx.last_data_read_time = executor.last_data_read_time();
+    octx.fetch_used_debounce = executor.fetch_used_debounce();
+    if (!executor.bytes_were_read()) {
+        octx.last_data_read_time.reset();
+    }
 }
 } // namespace
 
 namespace testing {
 ss::future<> do_fetch(op_context& octx) { return ::kafka::do_fetch(octx); }
 } // namespace testing
+
+namespace {
+
+void record_fetch_busy_latency(
+  bool fetch_used_debounce,
+  handler_probe::hist_t::measurement* handler_latency,
+  bool fetch_waited,
+  bool fetch_bytes_were_read,
+  std::optional<op_context::latency_point> last_data_read_time,
+  kafka_probe& probe) {
+    if (fetch_used_debounce || !fetch_bytes_were_read) {
+        return;
+    }
+    auto handler_end = op_context::latency_clock::now();
+    if (fetch_waited) {
+        if (last_data_read_time) {
+            auto busy_latency
+              = std::chrono::duration_cast<std::chrono::microseconds>(
+                handler_end - *last_data_read_time);
+            probe.record_fetch_busy_latency(busy_latency);
+        }
+    } else if (handler_latency) {
+        probe.record_fetch_busy_latency(
+          handler_latency->compute_total_latency());
+    }
+}
+
+} // namespace
 
 template<>
 ss::future<response_ptr>
@@ -1472,6 +1561,13 @@ fetch_handler::handle(request_context rctx, ss::smp_service_group ssg) {
           }
           octx.response.data.error_code = error_code::none;
           return do_fetch(octx).then([&octx] {
+              auto fetch_waited = octx.fetch_waited;
+              auto fetch_bytes_were_read = octx.response_size > 0;
+              auto last_data_read_time = octx.last_data_read_time;
+              auto* handler_latency = octx.rctx.handler_latency_measurement();
+              auto& probe = octx.rctx.server().local().kafka_probe();
+              auto fetch_used_debounce = octx.fetch_used_debounce;
+
               auto resp_units_deleter = octx.response_memory_units_deleter();
 
               // NOTE: Audit call doesn't happen until _after_ the fetch
@@ -1481,6 +1577,22 @@ fetch_handler::handle(request_context rctx, ss::smp_service_group ssg) {
                   return std::move(octx).send_error_response(
                     error_code::broker_not_available);
               }
+
+              octx.rctx.add_response_resource_deleter(
+                ss::make_deleter([fetch_used_debounce,
+                                  handler_latency,
+                                  fetch_waited,
+                                  fetch_bytes_were_read,
+                                  last_data_read_time,
+                                  &probe] {
+                    record_fetch_busy_latency(
+                      fetch_used_debounce,
+                      handler_latency,
+                      fetch_waited,
+                      fetch_bytes_were_read,
+                      last_data_read_time,
+                      probe);
+                }));
 
               octx.rctx.add_response_resource_deleter(
                 std::move(resp_units_deleter));

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -25,6 +25,7 @@
 #include <seastar/core/smp.hh>
 
 #include <memory>
+#include <optional>
 
 namespace kafka {
 
@@ -188,6 +189,10 @@ struct op_context {
      * @brief Returns the total number of units held by the response.
      */
     size_t total_response_memory_units() const;
+
+    bool fetch_waited{false};
+    std::optional<latency_point> last_data_read_time;
+    bool fetch_used_debounce{false};
 
     request_context rctx;
     ss::smp_service_group ssg;

--- a/src/v/kafka/server/kafka_probe.h
+++ b/src/v/kafka/server/kafka_probe.h
@@ -55,6 +55,17 @@ public:
               latency_labels,
               [this] { return _fetch_latency.internal_histogram_logform(); }),
             sm::make_histogram(
+              "fetch_busy_latency_us",
+              sm::description(
+                "Fetch busy latency: for immediate fetches, full handler "
+                "latency; for waited fetches, time from the start of the last "
+                "post-wakeup read that returned data until the response is "
+                "sent."),
+              latency_labels,
+              [this] {
+                  return _fetch_busy_latency.internal_histogram_logform();
+              }),
+            sm::make_histogram(
               "produce_latency_us",
               sm::description("Produce Latency"),
               latency_labels,
@@ -167,6 +178,10 @@ public:
         _fetch_latency.record(micros.count());
     }
 
+    void record_fetch_busy_latency(std::chrono::microseconds micros) {
+        _fetch_busy_latency.record(micros.count());
+    }
+
     void add_fetch_response_dropped_bytes(uint64_t bytes) {
         _fetch_response_dropped_bytes += bytes;
     }
@@ -189,6 +204,7 @@ private:
 
     hist_t _produce_latency;
     hist_t _fetch_latency;
+    hist_t _fetch_busy_latency;
     // non partition or topic related as that is too expensive for histograms
     batch_size_hist _batch_size;
 

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -433,6 +433,10 @@ public:
           std::move(res));
     }
 
+    handler_probe::hist_t::measurement* handler_latency_measurement() const {
+        return _request_resources->handler_latency.get();
+    }
+
 private:
     template<typename T>
     security::auth_result do_authorized(


### PR DESCRIPTION
There is two main existing latency metrics:

 - First is the legacy "fetch latency" metric: This one was always just
   measuring a single poll. This was a pointless as it's a very niche
   implementation detail but also it scaled with empty fetches so didn't
   actually scale with fetch truely getting slower
 - Handler metrics: These ones measure true handler latency. This is
   a meaningful metric. However given how kafka fetch works it can be
   confusing if one is not really aware of how fetch works. This often
   leads to "fetch latency gone up" when clients run into
   fetch.max.wait.

This patch tries to introduce a new metric that tries to solve both
issues:
 - Don't report crazy high or low values
 - Report on latency of meaningful work

Effectively we want to measure only "busy" fetch work that lead to
actual data being returned.

We separate two cases:

- for immediate fetches (no waiting): full handler latency, measured
  after the response is sent so it matches the per-handler latency;
- for waited fetches: time from the start of the last post-wakeup read
  that returned data until the response is sent. This is a compromise
  for this important sub case.

Idle wait time is intentionally excluded. If a fetch waited but no
bytes were read after any wakeup, the sample is skipped because there
is no 'busy' interval to measure.

The timestamp for waited fetches is captured before query_requests()
starts on non-first iterations, so the read itself (disk, cloud, etc.)
is included in the metric. The per-shard state is aggregated on the
coordinator shard and recorded in a continuation after send_response()
returns.

Note that for a case with min.fetch.bytes > 1 and us eventually timing
out we drop the sample. Making this work would require more complicated
timestamp tracking and it isn't in the spirit of the metric anyway.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

