### PR TITLE
[CORE-16648] cloud_topics: abort in-flight multipart uploads on shutdown

### DIFF
--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -1349,7 +1349,8 @@ remote::initiate_multipart_upload(
   const cloud_storage_clients::bucket_name& bucket,
   const cloud_storage_clients::object_key& key,
   size_t part_size,
-  ss::lowres_clock::duration timeout) {
+  ss::lowres_clock::duration timeout,
+  ss::abort_source* as) {
     auto guard = _gate.hold();
 
     const auto bucket_parts = cloud_storage_clients::parse_bucket_name(bucket);
@@ -1390,7 +1391,7 @@ remote::initiate_multipart_upload(
 
     // Create the multipart_upload with the wrapped state
     auto upload = ss::make_shared<cloud_storage_clients::multipart_upload>(
-      std::move(wrapped_state), part_size, log);
+      std::move(wrapped_state), part_size, log, as);
 
     co_return upload;
 }

--- a/src/v/cloud_io/remote.h
+++ b/src/v/cloud_io/remote.h
@@ -175,6 +175,8 @@ public:
     /// \param key Object key
     /// \param part_size Size of each part (must be >= 5 MiB for S3/GCS)
     /// \param timeout Operation timeout
+    /// \param as If set, makes the upload's ops abortable so a stalled op
+    ///   cannot block the caller's shutdown (see multipart_upload's ctor).
     /// \return multipart_upload handle or error
     ss::future<result<
       cloud_storage_clients::multipart_upload_ref,
@@ -183,7 +185,8 @@ public:
       const cloud_storage_clients::bucket_name& bucket,
       const cloud_storage_clients::object_key& key,
       size_t part_size,
-      ss::lowres_clock::duration timeout);
+      ss::lowres_clock::duration timeout,
+      ss::abort_source* as = nullptr);
 
     // If you need to spawn a background task that relies on
     // this object staying alive, spawn it with this gate.

--- a/src/v/cloud_storage_clients/multipart_upload.cc
+++ b/src/v/cloud_storage_clients/multipart_upload.cc
@@ -16,6 +16,7 @@
 #include "net/connection.h"
 #include "ssx/future-util.h"
 
+#include <seastar/core/shared_future.hh>
 #include <seastar/core/timed_out_error.hh>
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/exception.hh>
@@ -92,10 +93,27 @@ private:
 multipart_upload::multipart_upload(
   ss::shared_ptr<multipart_upload_state> state,
   size_t part_size,
-  ss::logger& logger)
+  ss::logger& logger,
+  ss::abort_source* as)
   : _state(std::move(state))
   , _part_size(part_size)
-  , _logger(logger) {}
+  , _logger(logger)
+  , _abort_source(as) {}
+
+ss::future<> multipart_upload::with_op_abort(ss::future<> op) {
+    if (_abort_source == nullptr) {
+        return op;
+    }
+    // The op holds _state by raw pointer and keeps running after abort ends
+    // the caller's wait, so _state must outlive the wait or the running op
+    // would use-after-free. Observe op via a shared_future: the returned
+    // handle is the caller's abortable wait; a detached continuation holds
+    // _state on the other.
+    auto shared = ss::make_lw_shared<ss::shared_future<>>(std::move(op));
+    ssx::background = shared->get_future().then_wrapped(
+      [shared, state = _state](ss::future<> f) { f.ignore_ready_future(); });
+    return ssx::with_abort(shared->get_future(), *_abort_source);
+}
 
 multipart_upload::~multipart_upload() {
     vassert(
@@ -132,7 +150,7 @@ ss::future<> multipart_upload::put(iobuf data) {
               _logger.debug,
               "Initializing multipart upload for first part (size: {})",
               _part_size);
-            co_await _state->initialize_multipart();
+            co_await with_op_abort(_state->initialize_multipart());
             _multipart_initialized = true;
         }
 
@@ -141,7 +159,8 @@ ss::future<> multipart_upload::put(iobuf data) {
           "Uploading part {} (size: {})",
           _part_number,
           part_data.size_bytes());
-        co_await _state->upload_part(_part_number++, std::move(part_data));
+        co_await with_op_abort(
+          _state->upload_part(_part_number++, std::move(part_data)));
     }
 }
 
@@ -159,7 +178,8 @@ ss::future<> multipart_upload::complete() {
           _logger.debug,
           "Small file optimization: using single put_object (size: {})",
           _buffer.size_bytes());
-        co_await _state->upload_as_single_object(std::move(_buffer));
+        co_await with_op_abort(
+          _state->upload_as_single_object(std::move(_buffer)));
         co_return;
     }
 
@@ -170,8 +190,8 @@ ss::future<> multipart_upload::complete() {
           "Uploading final part {} (size: {})",
           _part_number,
           _buffer.size_bytes());
-        auto fut = co_await ss::coroutine::as_future(
-          _state->upload_part(_part_number++, std::move(_buffer)));
+        auto fut = co_await ss::coroutine::as_future(with_op_abort(
+          _state->upload_part(_part_number++, std::move(_buffer))));
         if (fut.failed()) {
             auto ex = fut.get_exception();
             vlogl(
@@ -189,7 +209,7 @@ ss::future<> multipart_upload::complete() {
       "Completing multipart upload ({} parts)",
       _part_number - 1);
     auto fut = co_await ss::coroutine::as_future(
-      _state->complete_multipart_upload());
+      with_op_abort(_state->complete_multipart_upload()));
     if (fut.failed()) {
         auto ex = fut.get_exception();
         vlogl(
@@ -217,7 +237,7 @@ ss::future<> multipart_upload::abort() {
 
     vlog(_logger.debug, "Aborting multipart upload");
     try {
-        co_await _state->abort_multipart_upload();
+        co_await with_op_abort(_state->abort_multipart_upload());
     } catch (...) {
         // Log but don't propagate abort failures - we're already aborting
         vlog(
@@ -229,7 +249,7 @@ ss::future<> multipart_upload::abort() {
 
 ss::future<> multipart_upload::abort_on_error() {
     auto fut = co_await ss::coroutine::as_future(
-      _state->abort_multipart_upload());
+      with_op_abort(_state->abort_multipart_upload()));
     if (fut.failed()) {
         vlog(
           _logger.warn,

--- a/src/v/cloud_storage_clients/multipart_upload.h
+++ b/src/v/cloud_storage_clients/multipart_upload.h
@@ -15,6 +15,7 @@
 #include "bytes/iobuf.h"
 #include "cloud_storage_clients/types.h"
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -117,10 +118,15 @@ public:
     /// \param state Backend-specific state implementation
     /// \param part_size Size of each part in bytes
     /// \param logger Logger to use for diagnostics
+    /// \param as If set, makes each backend operation
+    ///   (initialize/upload_part/complete/abort) abortable, so a stalled op
+    ///   cannot block the caller's shutdown.
+    ///   Null by default, so callers that don't pass one are unchanged.
     explicit multipart_upload(
       ss::shared_ptr<multipart_upload_state> state,
       size_t part_size,
-      ss::logger& logger);
+      ss::logger& logger,
+      ss::abort_source* as = nullptr);
 
     ~multipart_upload() override;
 
@@ -178,6 +184,9 @@ private:
     /// Best-effort abort after a failure during complete()
     ss::future<> abort_on_error();
 
+    /// Make a backend op abortable via the abort source (no-op if unset).
+    ss::future<> with_op_abort(ss::future<> op);
+
     ss::shared_ptr<multipart_upload_state> _state;
     size_t _part_size;
     ss::logger& _logger;
@@ -185,6 +194,7 @@ private:
     size_t _part_number{1};
     bool _multipart_initialized{false};
     bool _finalized{false};
+    ss::abort_source* _abort_source{nullptr};
 };
 
 } // namespace cloud_storage_clients

--- a/src/v/cloud_storage_clients/tests/multipart_upload_test.cc
+++ b/src/v/cloud_storage_clients/tests/multipart_upload_test.cc
@@ -15,8 +15,10 @@
 #include "cloud_storage_clients/tests/client_pool_builder.h"
 #include "test_utils/random_bytes.h"
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
 #include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/later.hh>
 
 #include <boost/test/unit_test.hpp>
 
@@ -25,6 +27,61 @@ using namespace cloud_storage_clients::tests;
 
 static ss::logger test_log("multipart_upload_test");
 static constexpr size_t test_part_size = 5_MiB;
+
+namespace {
+// A backend state where one chosen op never resolves, to exercise the abort
+// source (given to the multipart_upload ctor); the rest complete promptly so
+// the upload can still be finalized. Records its own destruction so a test can
+// assert the keep-alive holds the state alive while an abandoned op is still in
+// flight (otherwise that op would use-after-free).
+class hanging_multipart_state final : public multipart_upload_state {
+public:
+    enum class hang_on { initialize, upload_part, complete, abort };
+
+    hanging_multipart_state(
+      hang_on which,
+      ss::lw_shared_ptr<ss::promise<>> hang,
+      ss::lw_shared_ptr<bool> destroyed)
+      : _hang_on(which)
+      , _hang(std::move(hang))
+      , _destroyed(std::move(destroyed)) {}
+
+    ~hanging_multipart_state() override { *_destroyed = true; }
+
+    ss::future<> initialize_multipart() override {
+        return gate(hang_on::initialize);
+    }
+    ss::future<> upload_part(size_t, iobuf) override {
+        return gate(hang_on::upload_part);
+    }
+    ss::future<> complete_multipart_upload() override {
+        return gate(hang_on::complete);
+    }
+    ss::future<> abort_multipart_upload() override {
+        return gate(hang_on::abort);
+    }
+    ss::future<> upload_as_single_object(iobuf) override {
+        return gate(hang_on::complete);
+    }
+    bool is_multipart_initialized() const override { return true; }
+    ss::sstring upload_id() const override { return "hanging"; }
+
+private:
+    // A coroutine that suspends on an external promise, mirroring a real
+    // backend op whose suspended frame holds only a raw `this` to the state --
+    // so the deadline's keep-alive is the only thing keeping the state alive
+    // once the op is abandoned.
+    ss::future<> gate(hang_on op) {
+        if (op == _hang_on) {
+            co_await _hang->get_future();
+        }
+    }
+
+    hang_on _hang_on;
+    ss::lw_shared_ptr<ss::promise<>> _hang;
+    ss::lw_shared_ptr<bool> _destroyed;
+};
+} // namespace
 
 SEASTAR_THREAD_TEST_CASE(test_multipart_upload_basic) {
     s3_imposter_fixture imposter;
@@ -398,4 +455,95 @@ SEASTAR_THREAD_TEST_CASE(test_multipart_upload_put_after_complete_is_noop) {
     upload->abort().get();
 
     BOOST_CHECK_EQUAL(imposter.get_requests().size(), requests_after_complete);
+}
+
+// When an abort source is set, a stalled backend op (here an upload_part that
+// never resolves) must stop the caller's wait when the abort source fires;
+// that is what unblocks reconciler shutdown, since the stuck send cannot be
+// woken. The abandoned op keeps running, so its backend state must stay alive
+// (no use-after-free) until it resolves, and the upload must still finalize
+// and destruct cleanly.
+SEASTAR_THREAD_TEST_CASE(test_multipart_upload_aborts) {
+    ss::abort_source as;
+    auto hang = ss::make_lw_shared<ss::promise<>>();
+    auto destroyed = ss::make_lw_shared<bool>(false);
+    auto state = ss::make_shared<hanging_multipart_state>(
+      hanging_multipart_state::hang_on::upload_part, hang, destroyed);
+    auto upload = ss::make_shared<multipart_upload>(
+      state, test_part_size, test_log, &as);
+
+    // 6 MiB triggers a part upload, which hangs; the abort must end the wait.
+    auto put_fut = upload->put(::tests::random_iobuf(6_MiB));
+    as.request_abort();
+    BOOST_CHECK_THROW(put_fut.get(), ss::abort_requested_exception);
+
+    // The upload still finalizes cleanly via abort() (its backend abort does
+    // not hang), so the destructor's finalized invariant holds.
+    upload->abort().get();
+
+    // Drop every external reference. The abandoned upload_part is still
+    // suspended; only the keep-alive references the state now, so it must not
+    // have been destroyed, or the still-running op would use-after-free.
+    state = {};
+    upload = {};
+    BOOST_CHECK(!*destroyed);
+
+    // Releasing the stuck op (the production analogue is the force-closed
+    // connection erroring it) drops the keep-alive and frees the state.
+    hang->set_value();
+    ss::yield().get();
+}
+
+// abort() makes its own backend abort request, which is routed through the
+// abort source too, so a stuck AbortMultipartUpload cannot block shutdown.
+// With the source fired, abort() returns rather than waiting on it, and stays
+// best-effort (no throw), leaving the upload finalized.
+SEASTAR_THREAD_TEST_CASE(test_multipart_upload_abort_op_is_bounded) {
+    ss::abort_source as;
+    auto hang = ss::make_lw_shared<ss::promise<>>();
+    auto destroyed = ss::make_lw_shared<bool>(false);
+    auto state = ss::make_shared<hanging_multipart_state>(
+      hanging_multipart_state::hang_on::abort, hang, destroyed);
+    auto upload = ss::make_shared<multipart_upload>(
+      state, test_part_size, test_log, &as);
+
+    // Initialize the upload; only the backend abort hangs.
+    upload->put(::tests::random_iobuf(6_MiB)).get();
+
+    as.request_abort();
+    upload->abort().get();
+    BOOST_CHECK(upload->is_finalized());
+
+    hang->set_value();
+    ss::yield().get();
+}
+
+// abort() makes its own backend abort and finalizes, but does not unstick an
+// in-flight put: a part upload hung from an earlier put stays hung after
+// abort() returns. Firing the abort source is what ends that wait.
+SEASTAR_THREAD_TEST_CASE(
+  test_multipart_upload_abort_leaves_put_to_abort_source) {
+    ss::abort_source as;
+    auto hang = ss::make_lw_shared<ss::promise<>>();
+    auto destroyed = ss::make_lw_shared<bool>(false);
+    auto state = ss::make_shared<hanging_multipart_state>(
+      hanging_multipart_state::hang_on::upload_part, hang, destroyed);
+    auto upload = ss::make_shared<multipart_upload>(
+      state, test_part_size, test_log, &as);
+
+    // A part upload hangs; the put is left in flight.
+    auto put_fut = upload->put(::tests::random_iobuf(6_MiB));
+
+    // abort()'s own backend abort does not hang, so abort() finalizes and
+    // returns without touching the hung put.
+    upload->abort().get();
+    BOOST_CHECK(upload->is_finalized());
+    BOOST_CHECK(!put_fut.available());
+
+    // The abort source is what ends the hung put's wait.
+    as.request_abort();
+    BOOST_CHECK_THROW(put_fut.get(), ss::abort_requested_exception);
+
+    hang->set_value();
+    ss::yield().get();
 }

--- a/src/v/cloud_topics/level_one/common/file_io.cc
+++ b/src/v/cloud_topics/level_one/common/file_io.cc
@@ -286,7 +286,7 @@ file_io::create_multipart_upload(
     static constexpr auto timeout = 10s;
     auto key = object_path_factory::level_one_path(oid);
     auto result_fut = co_await ss::coroutine::as_future(
-      _remote->initiate_multipart_upload(_bucket, key, part_size, timeout));
+      _remote->initiate_multipart_upload(_bucket, key, part_size, timeout, as));
     if (result_fut.failed()) {
         auto ex = result_fut.get_exception();
         vlog(cd_log.warn, "Error initiating multipart upload: {}", ex);

--- a/src/v/ssx/future-util.h
+++ b/src/v/ssx/future-util.h
@@ -486,6 +486,64 @@ seastar::future<T...> with_timeout_abortable(
     return result;
 }
 
+/// \brief Wait for a future, or until an abort source fires, whichever first.
+///
+/// Like \ref with_timeout_abortable but with no deadline: resolves with \p f,
+/// or fails with the abort source's exception (abort_requested_exception by
+/// default) when \p as fires. Aborting does not cancel the wrapped future -- it
+/// keeps running and its result is ignored once we stop waiting.
+///
+/// \param f future to wait for
+/// \param as abort source
+template<typename... T>
+seastar::future<T...>
+with_abort(seastar::future<T...> f, seastar::abort_source& as) {
+    if (f.available()) {
+        return f;
+    }
+
+    struct state {
+        seastar::promise<T...> done;
+        seastar::abort_source::subscription sub;
+        bool settled{false};
+
+        explicit state(seastar::abort_source& as) {
+            try {
+                as.check();
+            } catch (...) {
+                settled = true;
+                done.set_to_current_exception();
+                return;
+            }
+            auto maybe_sub = as.subscribe(
+              [this,
+               &as](const std::optional<std::exception_ptr>& ex) noexcept {
+                  settled = true;
+                  done.set_exception(ex.value_or(as.get_default_exception()));
+              });
+            vassert(
+              maybe_sub,
+              "abort_source was just checked, subscribe cannot fail here");
+            sub = std::move(*maybe_sub);
+        }
+    };
+
+    auto st = std::make_unique<state>(as);
+    auto result = st->done.get_future();
+
+    background = f.then_wrapped([st = std::move(st)](auto&& f) {
+        // Unsubscribe first so a late abort cannot set `done` after we forward.
+        st->sub = seastar::abort_source::subscription{};
+        if (st->settled) {
+            f.ignore_ready_future();
+        } else {
+            f.forward_to(std::move(st->done));
+        }
+    });
+
+    return result;
+}
+
 // Create a ready future with template deduction.
 //
 // In most cases you should not need specify a template parameter using this

--- a/src/v/ssx/tests/future_util.cc
+++ b/src/v/ssx/tests/future_util.cc
@@ -146,3 +146,49 @@ SEASTAR_THREAD_TEST_CASE(with_timeout_abortable_custom_ex_test) {
         seastar::manual_clock::advance(40ms);
     }
 }
+
+SEASTAR_THREAD_TEST_CASE(with_abort_test) {
+    // future already ready -> value, abort never consulted
+    {
+        seastar::abort_source as;
+        auto res = ssx::with_abort(seastar::make_ready_future<int>(7), as);
+        BOOST_CHECK_EQUAL(res.get(), 7);
+    }
+
+    // future completes before any abort -> value
+    {
+        auto f = seastar::sleep<seastar::manual_clock>(50ms).then(
+          [] { return seastar::make_ready_future<int>(123); });
+        seastar::abort_source as;
+        auto res = ssx::with_abort(std::move(f), as);
+
+        seastar::manual_clock::advance(50ms);
+        BOOST_CHECK_EQUAL(res.get(), 123);
+    }
+
+    // abort before the future completes -> abort_requested_exception
+    {
+        auto f = seastar::sleep<seastar::manual_clock>(150ms).then(
+          [] { return seastar::make_ready_future<int>(123); });
+        seastar::abort_source as;
+        auto res = ssx::with_abort(std::move(f), as);
+
+        as.request_abort();
+        BOOST_CHECK_THROW(res.get(), seastar::abort_requested_exception);
+        // f has to resolve or LSAN thinks there are leaks
+        seastar::manual_clock::advance(150ms);
+    }
+
+    // already aborted at call time -> abort_requested_exception
+    {
+        seastar::abort_source as;
+        as.request_abort();
+        auto f = seastar::sleep<seastar::manual_clock>(50ms).then(
+          [] { return seastar::make_ready_future<int>(123); });
+        auto res = ssx::with_abort(std::move(f), as);
+
+        BOOST_CHECK_THROW(res.get(), seastar::abort_requested_exception);
+        // f has to resolve or LSAN thinks there are leaks
+        seastar::manual_clock::advance(50ms);
+    }
+}


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

A multipart-upload part send stuck on a saturated connection has nothing to
  cancel it, so it blocks the cloud_topics reconciler's `stop()` and the broker
  can't shut down gracefully. This threads the reconciler's abort source through
  the multipart upload so shutdown stops waiting on a stuck op, with a new
  deadline-free `ssx::with_abort` helper.

  The test in [#30818](https://github.com/redpanda-data/redpanda/pull/30818)
  SIGKILLs its cluster to work around this hang; with this fix it shouldn't
  have to.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Bug Fixes

* Fix a bug where in-flight operations in the cloud topics reconciler could get stuck during shutdown.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
