### PR TITLE
rpk: Add new Schema Registry option to Shadow Link command space

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -3,7 +3,7 @@ managed:
   enabled: false
 inputs:
   # You can get the full commit sha from https://buf.build/redpandadata/core/docs
-  - module: buf.build/redpandadata/core:36db7bac51c24fa2814cb010af7e2575
+  - module: buf.build/redpandadata/core:5b0ab84ea0824fb18952cbc337e8dac7
     paths:
       - redpanda/core/admin/v2/shadow_link.proto
       - redpanda/core/common/v1/acl.proto

--- a/src/go/rpk/gen/protocomments/admin/v2/comments.pb.go
+++ b/src/go/rpk/gen/protocomments/admin/v2/comments.pb.go
@@ -66,13 +66,19 @@ var Comments = map[string]string{
 	"redpanda.core.admin.v2.GetShadowTopicRequest.name":             "The name of the shadow topic to get",
 	"redpanda.core.admin.v2.GetShadowTopicRequest.shadow_link_name": "The name of the shadow link the topic is contained in",
 	"redpanda.core.admin.v2.GetShadowTopicResponse":                 "Response of to getting a shadow topic",
-	"redpanda.core.admin.v2.ListShadowLinksRequest":                 "Request to list all shadow links",
-	"redpanda.core.admin.v2.ListShadowLinksResponse":                "All shadow links on the cluster",
-	"redpanda.core.admin.v2.ListShadowLinksResponse.shadow_links":   "The shadow links",
-	"redpanda.core.admin.v2.ListShadowTopicsRequest":                "Request to list all shadow topics in a shadow link",
-	"redpanda.core.admin.v2.ListShadowTopicsResponse":               "Response to listing all shadow topics in a shadow link",
-	"redpanda.core.admin.v2.NameFilter":                             "A filter based on the name of a resource",
-	"redpanda.core.admin.v2.NameFilter.filter_type":                 "Include or exclude",
+	"redpanda.core.admin.v2.HTTPBasicAuthOptions":                   "HTTP Basic auth credentials.",
+	"redpanda.core.admin.v2.HTTPBasicAuthOptions.password":          "HTTP Basic auth password. For Confluent Cloud, this is the API secret.",
+	"redpanda.core.admin.v2.HTTPBasicAuthOptions.password_set":      "Indicates that the password has been set.",
+	"redpanda.core.admin.v2.HTTPBasicAuthOptions.password_set_at": `Timestamp of when the password was last set - only valid if password_set
+ is true.`,
+	"redpanda.core.admin.v2.HTTPBasicAuthOptions.username":        "HTTP Basic auth username. For Confluent Cloud, this is the API key.",
+	"redpanda.core.admin.v2.ListShadowLinksRequest":               "Request to list all shadow links",
+	"redpanda.core.admin.v2.ListShadowLinksResponse":              "All shadow links on the cluster",
+	"redpanda.core.admin.v2.ListShadowLinksResponse.shadow_links": "The shadow links",
+	"redpanda.core.admin.v2.ListShadowTopicsRequest":              "Request to list all shadow topics in a shadow link",
+	"redpanda.core.admin.v2.ListShadowTopicsResponse":             "Response to listing all shadow topics in a shadow link",
+	"redpanda.core.admin.v2.NameFilter":                           "A filter based on the name of a resource",
+	"redpanda.core.admin.v2.NameFilter.filter_type":               "Include or exclude",
 	"redpanda.core.admin.v2.NameFilter.name": `The resource name, or "*"
  Note if "*", must be the _only_ character
  and ` + "`" + `pattern_type` + "`" + ` must be ` + "`" + `PATTERN_TYPE_LITERAL` + "`" + ``,
@@ -86,20 +92,86 @@ var Comments = map[string]string{
 	"redpanda.core.admin.v2.PlainConfig.password_set": "Indicates that the password has been set",
 	"redpanda.core.admin.v2.PlainConfig.password_set_at": `Timestamp of when the password was last set - only valid if password_set
  is true`,
-	"redpanda.core.admin.v2.PlainConfig.username":            "PLAIN username",
-	"redpanda.core.admin.v2.SCRAM_MECHANISM_SCRAM_SHA_256":   "SCRAM-SHA-256",
-	"redpanda.core.admin.v2.SCRAM_MECHANISM_SCRAM_SHA_512":   "SCRAM-SHA-512",
-	"redpanda.core.admin.v2.SHADOW_LINK_STATE_ACTIVE":        "Shadow link is active",
-	"redpanda.core.admin.v2.SHADOW_LINK_STATE_PAUSED":        "Shadow link was paused",
-	"redpanda.core.admin.v2.SHADOW_LINK_STATE_UNSPECIFIED":   "Unspecified",
-	"redpanda.core.admin.v2.SHADOW_TOPIC_STATE_ACTIVE":       "Shadow topic is active",
-	"redpanda.core.admin.v2.SHADOW_TOPIC_STATE_FAILED_OVER":  "Shadow topic has failed over successfully",
-	"redpanda.core.admin.v2.SHADOW_TOPIC_STATE_FAILING_OVER": "Shadow topic is in the process of failing over",
-	"redpanda.core.admin.v2.SHADOW_TOPIC_STATE_FAULTED":      "Shadow topic has faulted",
-	"redpanda.core.admin.v2.SHADOW_TOPIC_STATE_PAUSED":       "Shadow topic has been paused",
-	"redpanda.core.admin.v2.SHADOW_TOPIC_STATE_PROMOTED":     "Shadow topic is promoted successfully",
-	"redpanda.core.admin.v2.SHADOW_TOPIC_STATE_PROMOTING":    "Shadow topic is in the process of being promoted",
-	"redpanda.core.admin.v2.SchemaRegistrySyncOptions":       "Options for how the Schema Registry is synced.",
+	"redpanda.core.admin.v2.PlainConfig.username":                      "PLAIN username",
+	"redpanda.core.admin.v2.SCHEMA_REGISTRY_SYNC_TYPE_FULL":            "A full source scan is running.",
+	"redpanda.core.admin.v2.SCHEMA_REGISTRY_SYNC_TYPE_TAIL":            "An incremental tail sync is running.",
+	"redpanda.core.admin.v2.SCHEMA_REGISTRY_SYNC_TYPE_UNSPECIFIED":     "The Schema Registry sync type is not specified.",
+	"redpanda.core.admin.v2.SCRAM_MECHANISM_SCRAM_SHA_256":             "SCRAM-SHA-256",
+	"redpanda.core.admin.v2.SCRAM_MECHANISM_SCRAM_SHA_512":             "SCRAM-SHA-512",
+	"redpanda.core.admin.v2.SHADOW_LINK_STATE_ACTIVE":                  "Shadow link is active",
+	"redpanda.core.admin.v2.SHADOW_LINK_STATE_PAUSED":                  "Shadow link was paused",
+	"redpanda.core.admin.v2.SHADOW_LINK_STATE_UNSPECIFIED":             "Unspecified",
+	"redpanda.core.admin.v2.SHADOW_TOPIC_STATE_ACTIVE":                 "Shadow topic is active",
+	"redpanda.core.admin.v2.SHADOW_TOPIC_STATE_FAILED_OVER":            "Shadow topic has failed over successfully",
+	"redpanda.core.admin.v2.SHADOW_TOPIC_STATE_FAILING_OVER":           "Shadow topic is in the process of failing over",
+	"redpanda.core.admin.v2.SHADOW_TOPIC_STATE_FAULTED":                "Shadow topic has faulted",
+	"redpanda.core.admin.v2.SHADOW_TOPIC_STATE_PAUSED":                 "Shadow topic has been paused",
+	"redpanda.core.admin.v2.SHADOW_TOPIC_STATE_PROMOTED":               "Shadow topic is promoted successfully",
+	"redpanda.core.admin.v2.SHADOW_TOPIC_STATE_PROMOTING":              "Shadow topic is in the process of being promoted",
+	"redpanda.core.admin.v2.SchemaRegistryAuthOptions":                 "Authentication settings for source Schema Registry HTTP requests.",
+	"redpanda.core.admin.v2.SchemaRegistryAuthOptions.basic":           "Authenticate source Schema Registry requests with HTTP Basic auth.",
+	"redpanda.core.admin.v2.SchemaRegistryContextDestination":          "Destination context mapping for source Schema Registry data.",
+	"redpanda.core.admin.v2.SchemaRegistryContextDestination.exact":    "Map selected source contexts to explicit destination contexts.",
+	"redpanda.core.admin.v2.SchemaRegistryContextDestination.identity": "Preserve source context names in the destination Schema Registry.",
+	"redpanda.core.admin.v2.SchemaRegistryContextMap":                  "One source-to-destination context mapping.",
+	"redpanda.core.admin.v2.SchemaRegistryContextMap.destination":      "Destination context name.",
+	"redpanda.core.admin.v2.SchemaRegistryContextMap.source":           "Source context name.",
+	"redpanda.core.admin.v2.SchemaRegistryCurrentSync":                 "A Schema Registry sync that is currently running.",
+	"redpanda.core.admin.v2.SchemaRegistryCurrentSync.summary":         "Counters for the sync currently running.",
+	"redpanda.core.admin.v2.SchemaRegistryCurrentSync.sync_type":       "Type of Schema Registry sync currently running.",
+	"redpanda.core.admin.v2.SchemaRegistryExactContextMappings":        "Explicit source-to-destination context mappings.",
+	"redpanda.core.admin.v2.SchemaRegistryExactContextMappings.mappings": `Explicit source-to-destination context mappings. Every source context in
+ the effective source scope must have exactly one mapping.`,
+	"redpanda.core.admin.v2.SchemaRegistryIdentityContextMapping": "Preserve source context names in the destination Schema Registry.",
+	"redpanda.core.admin.v2.SchemaRegistryInventory":              "Last observed Schema Registry inventory.",
+	"redpanda.core.admin.v2.SchemaRegistryInventory.destination_subject_versions": `Number of destination subject versions corresponding to the selected
+ source subjects after applying destination context mapping.`,
+	"redpanda.core.admin.v2.SchemaRegistryInventory.destination_subjects": `Number of destination subjects corresponding to the selected source
+ subjects after applying destination context mapping.`,
+	"redpanda.core.admin.v2.SchemaRegistryInventory.selected_source_subject_versions": `Number of source subject versions selected for replication after
+ applying source scope context and subject filters.`,
+	"redpanda.core.admin.v2.SchemaRegistryInventory.selected_source_subjects": `Number of source subjects selected for replication after applying source
+ scope context and subject filters.`,
+	"redpanda.core.admin.v2.SchemaRegistrySourceFilter": `Filter for specific Schema Registry contexts and subjects to select for
+ replication. If unset or empty, the whole source Schema Registry is
+ replicated.`,
+	"redpanda.core.admin.v2.SchemaRegistrySourceFilter.contexts": `Source contexts to replicate in full, for example ".", ".prod", or
+ ".staging". If both ` + "`" + `contexts` + "`" + ` and ` + "`" + `subjects` + "`" + ` are set, the effective
+ source scope is the union of both selections.`,
+	"redpanda.core.admin.v2.SchemaRegistrySourceFilter.subjects": `Exact source subjects to replicate, using Schema Registry qualified
+ subject syntax. For example, "orders-value" selects the subject in the
+ default context, and ":.prod:orders-value" selects the subject in context
+ ".prod". If both ` + "`" + `contexts` + "`" + ` and ` + "`" + `subjects` + "`" + ` are set, the union of both
+ selections is replicated. If a subject is also included by ` + "`" + `contexts` + "`" + `, it
+ is counted and replicated once.`,
+	"redpanda.core.admin.v2.SchemaRegistrySyncOptions": "Options for how the Schema Registry is synced.",
+	"redpanda.core.admin.v2.SchemaRegistrySyncOptions.ShadowSchemaRegistryApi": `Replicates selected Schema Registry subjects, configs, modes, and schema
+ IDs over the Schema Registry HTTP API.`,
+	"redpanda.core.admin.v2.SchemaRegistrySyncOptions.ShadowSchemaRegistryApi.auth_options": `Authentication settings for requests to the source Schema Registry.
+ If unset, requests are sent without authentication.`,
+	"redpanda.core.admin.v2.SchemaRegistrySyncOptions.ShadowSchemaRegistryApi.destination": `Mapping from source contexts implied by ` + "`" + `source_filter` + "`" + ` to
+ destination contexts. Each source context included in the replication
+ must map to a distinct destination context to avoid
+ collisions. If unset, source context names are preserved.`,
+	"redpanda.core.admin.v2.SchemaRegistrySyncOptions.ShadowSchemaRegistryApi.effective_full_sync_interval":             "The effective interval between full scans.",
+	"redpanda.core.admin.v2.SchemaRegistrySyncOptions.ShadowSchemaRegistryApi.effective_max_source_requests_per_second": "The effective maximum request rate, in requests per second.",
+	"redpanda.core.admin.v2.SchemaRegistrySyncOptions.ShadowSchemaRegistryApi.effective_tail_interval":                  "The effective interval between incremental polls.",
+	"redpanda.core.admin.v2.SchemaRegistrySyncOptions.ShadowSchemaRegistryApi.full_sync_interval": `Interval between full scans of the selected source subjects. If unset
+ or zero, the cluster default of 5m is used.`,
+	"redpanda.core.admin.v2.SchemaRegistrySyncOptions.ShadowSchemaRegistryApi.max_source_requests_per_second": `Maximum request rate, in requests per second, for calls to the source
+ Schema Registry. If unset or zero, a default rate limit of 30
+ requests/s is used.`,
+	"redpanda.core.admin.v2.SchemaRegistrySyncOptions.ShadowSchemaRegistryApi.source_filter": `Filter for specific Schema Registry contexts and subjects to select
+ for replication. If unset or empty, the whole source Schema Registry
+ is replicated.`,
+	"redpanda.core.admin.v2.SchemaRegistrySyncOptions.ShadowSchemaRegistryApi.source_url": "The source Schema Registry URL to use.",
+	"redpanda.core.admin.v2.SchemaRegistrySyncOptions.ShadowSchemaRegistryApi.tail_interval": `Interval between incremental polls for new source subjects and
+ subject versions. If unset or zero, the cluster default of 10s is
+ used.`,
+	"redpanda.core.admin.v2.SchemaRegistrySyncOptions.ShadowSchemaRegistryApi.tls_settings": "TLS settings for requests to the source Schema Registry.",
+	"redpanda.core.admin.v2.SchemaRegistrySyncOptions.ShadowSchemaRegistryApi.unsupported_schema_feature_policy": `Policy for handling source schema features unsupported by the
+ destination, such as rulesets or metadata tags. If unset, FAIL is
+ used.`,
 	"redpanda.core.admin.v2.SchemaRegistrySyncOptions.ShadowSchemaRegistryTopic": `Shadow the entire source cluster's Schema Registry byte-for-byte.
  If set, the Shadow Link will attempt to add the ` + "`" + `_schemas` + "`" + `
  topic to the list of Shadow Topics as long as:
@@ -113,6 +185,31 @@ var Comments = map[string]string{
  ` + "`" + `_schemas` + "`" + ` topic will be replicated byte-for-byte.  To stop shadowing the
  ` + "`" + `_schemas` + "`" + ` topic, unset this field, then either fail-over the topic or
  delete it.`,
+	"redpanda.core.admin.v2.SchemaRegistrySyncStatus": "Status of Schema Registry syncing.",
+	"redpanda.core.admin.v2.SchemaRegistrySyncStatus.current_sync": `Sync currently running. This is unset when no Schema Registry sync is
+ running.`,
+	"redpanda.core.admin.v2.SchemaRegistrySyncStatus.inventory": `Last observed source and destination Schema Registry inventory. These
+ counts are updated as sync work observes source and destination state.`,
+	"redpanda.core.admin.v2.SchemaRegistrySyncStatus.last_error_message": `Short sanitized summary of the most recent Schema Registry sync
+ error. Detailed errors are written to broker logs.`,
+	"redpanda.core.admin.v2.SchemaRegistrySyncStatus.last_full_sync": `Counters from the most recently completed full sync. This is unset until
+ a full sync completes on the current task instance.`,
+	"redpanda.core.admin.v2.SchemaRegistrySyncStatus.totals_since_task_start": `Cumulative counters since the Schema Registry task started. These
+ counters reset after task restart or leadership transfer.`,
+	"redpanda.core.admin.v2.SchemaRegistrySyncSummary": "Summary counters for one Schema Registry sync or for a cumulative interval.",
+	"redpanda.core.admin.v2.SchemaRegistrySyncSummary.compatibility_configs_changed": `Number of selected compatibility configuration changes applied to the
+ destination.`,
+	"redpanda.core.admin.v2.SchemaRegistrySyncSummary.errors": "Number of errors observed during the sync or cumulative interval.",
+	"redpanda.core.admin.v2.SchemaRegistrySyncSummary.finish_time": `Time when the sync finished. This is unset for a sync that is still
+ running and for cumulative counters.`,
+	"redpanda.core.admin.v2.SchemaRegistrySyncSummary.modes_changed": "Number of selected mode changes applied to the destination.",
+	"redpanda.core.admin.v2.SchemaRegistrySyncSummary.start_time": `Time when the sync started. For cumulative counters, this is the time
+ when the Schema Registry task started.`,
+	"redpanda.core.admin.v2.SchemaRegistrySyncSummary.subject_versions_changed": `Number of selected subject versions created, updated, or deleted on the
+ destination.`,
+	"redpanda.core.admin.v2.SchemaRegistrySyncSummary.unsupported_features_removed": `Number of unsupported fields removed from schemas or schema configs when
+ UNSUPPORTED_SCHEMA_FEATURE_POLICY_REMOVE is used.`,
+	"redpanda.core.admin.v2.SchemaRegistrySyncType":   "Type of Schema Registry sync currently running.",
 	"redpanda.core.admin.v2.ScramConfig":              "SCRAM settings",
 	"redpanda.core.admin.v2.ScramConfig.password":     "Password",
 	"redpanda.core.admin.v2.ScramConfig.password_set": "Indicates that the password has been set",
@@ -173,6 +270,7 @@ var Comments = map[string]string{
 	"redpanda.core.admin.v2.ShadowLinkConfigurations.topic_metadata_sync_options":  "Topic metadata sync options",
 	"redpanda.core.admin.v2.ShadowLinkState":                                       "State of the shadow link",
 	"redpanda.core.admin.v2.ShadowLinkStatus":                                      "Status of the shadow link",
+	"redpanda.core.admin.v2.ShadowLinkStatus.schema_registry_sync_status":          "Status of Schema Registry syncing.",
 	"redpanda.core.admin.v2.ShadowLinkStatus.shadow_topics":                        "Status of shadow topics",
 	"redpanda.core.admin.v2.ShadowLinkStatus.synced_shadow_topic_properties":       "List of topic properties that are being synced",
 	"redpanda.core.admin.v2.ShadowLinkStatus.task_statuses":                        "Statuses of the running tasks",
@@ -260,6 +358,10 @@ var Comments = map[string]string{
 	"redpanda.core.admin.v2.TopicPartitionInformation.source_high_watermark":         "Source partition's HWM",
 	"redpanda.core.admin.v2.TopicPartitionInformation.source_last_stable_offset":     "Source partition's LSO",
 	"redpanda.core.admin.v2.TopicPartitionInformation.source_last_updated_timestamp": "Timestamp of the last time the source partition information was updated",
+	"redpanda.core.admin.v2.UNSUPPORTED_SCHEMA_FEATURE_POLICY_FAIL":                  "Fail the sync when an unsupported schema feature is encountered.",
+	"redpanda.core.admin.v2.UNSUPPORTED_SCHEMA_FEATURE_POLICY_REMOVE":                "Remove unsupported schema features before writing to the destination.",
+	"redpanda.core.admin.v2.UNSUPPORTED_SCHEMA_FEATURE_POLICY_UNSPECIFIED":           "Use the default unsupported schema feature handling behavior.",
+	"redpanda.core.admin.v2.UnsupportedSchemaFeaturePolicy":                          "Policy for handling source schema features unsupported by the destination.",
 	"redpanda.core.admin.v2.UpdateShadowLinkRequest":                                 "Updates a shadow link",
 	"redpanda.core.admin.v2.UpdateShadowLinkRequest.shadow_link":                     "The shadow link to update",
 	"redpanda.core.admin.v2.UpdateShadowLinkRequest.update_mask": `The list of fields to update

--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -7,7 +7,7 @@ require (
 	buf.build/gen/go/redpandadata/cloud/connectrpc/go v1.19.1-20260409133226-cd0bdc42a0f9.2
 	buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.11-20260409133226-cd0bdc42a0f9.1
 	buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.11-20260323171043-6e06f84ad823.1
-	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260409143030-36db7bac51c2.1
+	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260608080241-5b0ab84ea082.1
 	buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20260409091301-5e03d1b04513.2
 	buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.11-20260409091301-5e03d1b04513.1
 	buf.build/gen/go/redpandadata/gatekeeper/connectrpc/go v1.19.1-20251022210437-a5dd600d04b6.2

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -14,8 +14,8 @@ buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.11-20260323171043-
 buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.11-20260323171043-6e06f84ad823.1/go.mod h1:3w7EzexwlL6PIFGbbeKZ0yHfUlAmI0aBVzF/QoFb8Cg=
 buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20260409143030-36db7bac51c2.2 h1:SEwSVRuX4g6P79wde2y0EuBD46EMb/vuOKOXIiCNWCM=
 buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20260409143030-36db7bac51c2.2/go.mod h1:9yQAJXFjjbVbBGlABqSz1eNtIPLhrbf5FU795I1u5Sg=
-buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260409143030-36db7bac51c2.1 h1:QBkqRLTqXkOxSTvKsf8ww7rRtucQUW/2wljnxpnQ3yU=
-buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260409143030-36db7bac51c2.1/go.mod h1:5sjUVquVwNxt3Q/EhE/UW0BBJ5sgPiaVTw8//wxRULI=
+buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260608080241-5b0ab84ea082.1 h1:lLdtkh1oXeNO0XDgsarqJ9iR2/RfypaQxz33/D3Z2d0=
+buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260608080241-5b0ab84ea082.1/go.mod h1:5sjUVquVwNxt3Q/EhE/UW0BBJ5sgPiaVTw8//wxRULI=
 buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20260409091301-5e03d1b04513.2 h1:8t4xNuFJqh2mW4RPa6sVjL+Bm6ONZq7Gj3PsCPMNUFM=
 buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20260409091301-5e03d1b04513.2/go.mod h1:EN4XJHrOIY8SoHVk9NuZf9I4DtlmhSq6ixlNhbCR+L4=
 buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.11-20260409091301-5e03d1b04513.1 h1:vbHgxorgH6giQxyTPtd+rHkke0E8w5VU1bQC5WjV6qY=

--- a/src/go/rpk/pkg/cli/shadow/BUILD
+++ b/src/go/rpk/pkg/cli/shadow/BUILD
@@ -54,6 +54,7 @@ go_test(
         "config_test.go",
         "create_test.go",
         "mapper_test.go",
+        "status_test.go",
         "types_test.go",
         "update_test.go",
     ],
@@ -71,5 +72,6 @@ go_test(
         "@in_gopkg_yaml_v2//:yaml_v2",
         "@org_golang_google_protobuf//reflect/protoreflect",
         "@org_golang_google_protobuf//types/known/durationpb",
+        "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )

--- a/src/go/rpk/pkg/cli/shadow/create.go
+++ b/src/go/rpk/pkg/cli/shadow/create.go
@@ -173,7 +173,7 @@ func printShadowLinkCfgOverview(slCfg *ShadowLinkConfig) {
 			tw.Print("Source Redpanda ID:", slCfg.CloudOptions.SourceRedpandaID)
 		}
 	}
-	if len(slCfg.ClientOptions.BootstrapServers) > 0 {
+	if slCfg.ClientOptions != nil && len(slCfg.ClientOptions.BootstrapServers) > 0 {
 		tw.Print("Bootstrap Servers:", "")
 		for _, srv := range slCfg.ClientOptions.BootstrapServers {
 			tw.Print("", fmt.Sprintf("- %s", srv))

--- a/src/go/rpk/pkg/cli/shadow/create.go
+++ b/src/go/rpk/pkg/cli/shadow/create.go
@@ -188,15 +188,20 @@ func validateParsedShadowLinkConfig(slCfg *ShadowLinkConfig) error {
 	if slCfg.Name == "" {
 		return errors.New("the Shadow Link name is required")
 	}
+	// ClientOptions may be nil when the config omits the client_options block,
+	// which is valid for cloud (bootstrap servers are optional there).
+	clientOpts := slCfg.ClientOptions
 	// Cloud configuration does not require bootstrap servers.
-	if slCfg.CloudOptions == nil && len(slCfg.ClientOptions.BootstrapServers) == 0 {
+	if slCfg.CloudOptions == nil && (clientOpts == nil || len(clientOpts.BootstrapServers) == 0) {
 		return errors.New("at least one bootstrap server is required")
 	}
-	if tls := slCfg.ClientOptions.TLSSettings; tls != nil && tls.TLSFileSettings != nil && tls.TLSPEMSettings != nil {
-		return errors.New("only one of TLS file settings or PEM settings can be provided")
-	}
-	if auth := slCfg.ClientOptions.AuthenticationConfiguration; auth != nil && auth.ScramConfiguration != nil && auth.PlainConfiguration != nil {
-		return errors.New("only one of scram_configuration or plain_configuration can be provided")
+	if clientOpts != nil {
+		if tls := clientOpts.TLSSettings; tls != nil && tls.TLSFileSettings != nil && tls.TLSPEMSettings != nil {
+			return errors.New("only one of TLS file settings or PEM settings can be provided")
+		}
+		if auth := clientOpts.AuthenticationConfiguration; auth != nil && auth.ScramConfiguration != nil && auth.PlainConfiguration != nil {
+			return errors.New("only one of scram_configuration or plain_configuration can be provided")
+		}
 	}
 	if ts := slCfg.TopicMetadataSyncOptions; ts != nil {
 		var count int
@@ -213,6 +218,19 @@ func validateParsedShadowLinkConfig(slCfg *ShadowLinkConfig) error {
 			return errors.New("only one of start_at_latest, start_at_earliest, or start_at_timestamp can be provided")
 		}
 	}
+	if sr := slCfg.SchemaRegistrySyncOptions; sr != nil {
+		if sr.ShadowSchemaRegistryTopic != nil && sr.ShadowSchemaRegistryAPI != nil {
+			return errors.New("only one of shadow_schema_registry_topic or shadow_schema_registry_api can be provided")
+		}
+		if api := sr.ShadowSchemaRegistryAPI; api != nil {
+			if tls := api.TLSSettings; tls != nil && tls.TLSFileSettings != nil && tls.TLSPEMSettings != nil {
+				return errors.New("only one of schema registry API TLS file settings or PEM settings can be provided")
+			}
+			if dest := api.Destination; dest != nil && dest.Identity != nil && dest.Exact != nil {
+				return errors.New("only one of schema registry destination identity or exact can be provided")
+			}
+		}
+	}
 
 	slc := slCfg.CloudOptions
 	if slc == nil {
@@ -225,18 +243,33 @@ func validateParsedShadowLinkConfig(slCfg *ShadowLinkConfig) error {
 	if slc.ShadowRedpandaID == slc.SourceRedpandaID {
 		return errors.New("shadow_redpanda_id and source_redpanda_id cannot be the same")
 	}
-	co := slCfg.ClientOptions
-	if co == nil {
-		return nil
-	}
-	if co.TLSSettings != nil && co.TLSSettings.TLSFileSettings != nil {
+	// Cloud requires inline PEM content; the cloud agent cannot read local file
+	// paths, so file-based TLS settings are rejected for both the client and the
+	// schema registry API.
+	if clientOpts != nil && clientOpts.TLSSettings != nil && clientOpts.TLSSettings.TLSFileSettings != nil {
 		return errors.New("TLS file settings are not supported when using cloud options; use tls_pem_settings instead")
 	}
-	if pw := authPassword(co); pw != "" && !strings.HasPrefix(pw, secretsPrefix) {
-		return errors.New("cloud shadow links don't support plain passwords, you must use secrets from the secrets store. See 'rpk security secret --help' for more details")
+	if sr := slCfg.SchemaRegistrySyncOptions; sr != nil && sr.ShadowSchemaRegistryAPI != nil {
+		if tls := sr.ShadowSchemaRegistryAPI.TLSSettings; tls != nil && tls.TLSFileSettings != nil {
+			return errors.New("schema registry API TLS file settings are not supported when using cloud options; use tls_pem_settings instead")
+		}
 	}
-	if key := tlsKey(slCfg.ClientOptions); key != "" && !strings.HasPrefix(key, secretsPrefix) {
-		return errors.New("cloud shadow links don't support plain TLS keys, you must use secrets from the secrets store. See 'rpk security secret --help' for more details")
+	// Cloud secret-bearing fields must reference the secrets store rather than
+	// carry plain values. These accessors nil-guard internally, so they are
+	// safe even when client_options or schema_registry_sync_options is unset.
+	secretRefs := []struct {
+		value string
+		kind  string
+	}{
+		{authPassword(clientOpts), "passwords"},
+		{tlsKey(clientOpts), "TLS keys"},
+		{srAPIAuthPassword(slCfg.SchemaRegistrySyncOptions), "passwords"},
+		{srAPITLSKey(slCfg.SchemaRegistrySyncOptions), "TLS keys"},
+	}
+	for _, ref := range secretRefs {
+		if ref.value != "" && !strings.HasPrefix(ref.value, secretsPrefix) {
+			return fmt.Errorf("cloud shadow links don't support plain %s, you must use secrets from the secrets store. See 'rpk security secret --help' for more details", ref.kind)
+		}
 	}
 	return nil
 }
@@ -267,6 +300,30 @@ func tlsKey(co *ShadowLinkClientOptions) string {
 	return ""
 }
 
+// srAPIAuthPassword extracts the schema registry API basic-auth password from
+// the schema registry sync options, if set.
+func srAPIAuthPassword(opts *SchemaRegistrySyncOptions) string {
+	if opts == nil || opts.ShadowSchemaRegistryAPI == nil {
+		return ""
+	}
+	if auth := opts.ShadowSchemaRegistryAPI.AuthOptions; auth != nil && auth.Basic != nil {
+		return auth.Basic.Password
+	}
+	return ""
+}
+
+// srAPITLSKey extracts the schema registry API TLS PEM key from the schema
+// registry sync options, if set.
+func srAPITLSKey(opts *SchemaRegistrySyncOptions) string {
+	if opts == nil || opts.ShadowSchemaRegistryAPI == nil {
+		return ""
+	}
+	if tls := opts.ShadowSchemaRegistryAPI.TLSSettings; tls != nil && tls.TLSPEMSettings != nil {
+		return tls.TLSPEMSettings.Key
+	}
+	return ""
+}
+
 // tryShadowLinkErrReason attempts to extract a more specific error reason from
 // the Shadow Link response, defaulting to a generic error message if the call
 // fails or there is no additional information.
@@ -282,9 +339,25 @@ func tryShadowLinkErrReason(ctx context.Context, cl controlplanev1connect.Shadow
 }
 
 func validateCloudSecrets(ctx context.Context, prof *config.RpkProfile, slCfg *ShadowLinkConfig) error {
-	// We should only try to validate if pass or key are present in the config.
-	pass, key := authPassword(slCfg.ClientOptions), tlsKey(slCfg.ClientOptions)
-	if pass == "" && key == "" {
+	// We should only try to validate the secrets that are present in the
+	// config.
+	refs := []struct {
+		value string
+		desc  string
+	}{
+		{authPassword(slCfg.ClientOptions), "authentication password"},
+		{tlsKey(slCfg.ClientOptions), "TLS key"},
+		{srAPIAuthPassword(slCfg.SchemaRegistrySyncOptions), "schema registry authentication password"},
+		{srAPITLSKey(slCfg.SchemaRegistrySyncOptions), "schema registry TLS key"},
+	}
+	var present bool
+	for _, r := range refs {
+		if r.value != "" {
+			present = true
+			break
+		}
+	}
+	if !present {
 		return nil
 	}
 	// We can't validate the presence of secrets if the Shadow Link is not for
@@ -312,14 +385,12 @@ func validateCloudSecrets(ctx context.Context, prof *config.RpkProfile, slCfg *S
 		secretRefs[fmt.Sprintf("%s%s}", secretsPrefix, secret.Id)] = struct{}{}
 	}
 
-	if pass != "" {
-		if _, ok := secretRefs[pass]; !ok {
-			return fmt.Errorf("unable to find authentication password secret %q in the shadow cluster secrets store (REDPANDA_CLUSTER scope)", pass)
+	for _, r := range refs {
+		if r.value == "" {
+			continue
 		}
-	}
-	if key != "" {
-		if _, ok := secretRefs[key]; !ok {
-			return fmt.Errorf("unable to find TLS key secret %q in the shadow cluster secrets store (REDPANDA_CLUSTER scope)", key)
+		if _, ok := secretRefs[r.value]; !ok {
+			return fmt.Errorf("unable to find %s secret %q in the shadow cluster secrets store (REDPANDA_CLUSTER scope)", r.desc, r.value)
 		}
 	}
 	return nil

--- a/src/go/rpk/pkg/cli/shadow/create_test.go
+++ b/src/go/rpk/pkg/cli/shadow/create_test.go
@@ -49,6 +49,14 @@ func TestValidateParsedShadowLinkConfig(t *testing.T) {
 			expectedErr: "at least one bootstrap server is required",
 		},
 		{
+			name: "self-hosted config - omitted client options",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				// No ClientOptions block at all; must not panic.
+			},
+			expectedErr: "at least one bootstrap server is required",
+		},
+		{
 			name: "both TLS file and PEM settings",
 			config: &ShadowLinkConfig{
 				Name: "test-link",
@@ -217,6 +225,85 @@ func TestValidateParsedShadowLinkConfig(t *testing.T) {
 				},
 			},
 		},
+		// Schema registry validation tests
+		{
+			name: "both schema registry shadowing modes set",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+				},
+				SchemaRegistrySyncOptions: &SchemaRegistrySyncOptions{
+					ShadowSchemaRegistryTopic: &ShadowSchemaRegistryTopic{},
+					ShadowSchemaRegistryAPI: &ShadowSchemaRegistryAPI{
+						SourceURL: "https://source-sr:8081",
+					},
+				},
+			},
+			expectedErr: "only one of shadow_schema_registry_topic or shadow_schema_registry_api can be provided",
+		},
+		{
+			name: "schema registry API - both TLS file and PEM settings",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+				},
+				SchemaRegistrySyncOptions: &SchemaRegistrySyncOptions{
+					ShadowSchemaRegistryAPI: &ShadowSchemaRegistryAPI{
+						SourceURL: "https://source-sr:8081",
+						TLSSettings: &TLSSettings{
+							TLSFileSettings: &TLSFileSettings{CAPath: "/path/to/ca"},
+							TLSPEMSettings:  &TLSPEMSettings{CA: "pem-content"},
+						},
+					},
+				},
+			},
+			expectedErr: "only one of schema registry API TLS file settings or PEM settings can be provided",
+		},
+		{
+			name: "schema registry API - both destination mappings set",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+				},
+				SchemaRegistrySyncOptions: &SchemaRegistrySyncOptions{
+					ShadowSchemaRegistryAPI: &ShadowSchemaRegistryAPI{
+						SourceURL: "https://source-sr:8081",
+						Destination: &SchemaRegistryContextDestination{
+							Identity: &SchemaRegistryIdentityContextMapping{},
+							Exact: &SchemaRegistryExactContextMappings{
+								Mappings: []*SchemaRegistryContextMap{
+									{Source: ".", Destination: ".shadow"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErr: "only one of schema registry destination identity or exact can be provided",
+		},
+		{
+			name: "valid config - schema registry API mode",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+				},
+				SchemaRegistrySyncOptions: &SchemaRegistrySyncOptions{
+					ShadowSchemaRegistryAPI: &ShadowSchemaRegistryAPI{
+						SourceURL: "https://source-sr:8081",
+						AuthOptions: &SchemaRegistryAuthOptions{
+							Basic: &HTTPBasicAuthOptions{Username: "u", Password: "p"},
+						},
+						Destination: &SchemaRegistryContextDestination{
+							Identity: &SchemaRegistryIdentityContextMapping{},
+						},
+					},
+				},
+			},
+		},
 		// Cloud-specific validation tests
 		{
 			name: "cloud config - missing shadow_redpanda_id",
@@ -300,6 +387,128 @@ func TestValidateParsedShadowLinkConfig(t *testing.T) {
 				},
 			},
 			expectedErr: "cloud shadow links don't support plain TLS keys",
+		},
+		{
+			name: "cloud config - schema registry API plain password not allowed",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				CloudOptions: &CloudShadowLinkOptions{
+					ShadowRedpandaID: "shadow-cluster",
+				},
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+				},
+				SchemaRegistrySyncOptions: &SchemaRegistrySyncOptions{
+					ShadowSchemaRegistryAPI: &ShadowSchemaRegistryAPI{
+						SourceURL: "https://source-sr:8081",
+						AuthOptions: &SchemaRegistryAuthOptions{
+							Basic: &HTTPBasicAuthOptions{
+								Username: "user",
+								Password: "plain-password-not-allowed",
+							},
+						},
+					},
+				},
+			},
+			expectedErr: "cloud shadow links don't support plain passwords",
+		},
+		{
+			name: "cloud config - schema registry API plain tls key not allowed",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				CloudOptions: &CloudShadowLinkOptions{
+					ShadowRedpandaID: "shadow-cluster",
+				},
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+				},
+				SchemaRegistrySyncOptions: &SchemaRegistrySyncOptions{
+					ShadowSchemaRegistryAPI: &ShadowSchemaRegistryAPI{
+						SourceURL: "https://source-sr:8081",
+						TLSSettings: &TLSSettings{
+							Enabled: true,
+							TLSPEMSettings: &TLSPEMSettings{
+								Key: "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+							},
+						},
+					},
+				},
+			},
+			expectedErr: "cloud shadow links don't support plain TLS keys",
+		},
+		{
+			name: "cloud config - schema registry API TLS file settings not allowed",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				CloudOptions: &CloudShadowLinkOptions{
+					ShadowRedpandaID: "shadow-cluster",
+				},
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+				},
+				SchemaRegistrySyncOptions: &SchemaRegistrySyncOptions{
+					ShadowSchemaRegistryAPI: &ShadowSchemaRegistryAPI{
+						SourceURL: "https://source-sr:8081",
+						TLSSettings: &TLSSettings{
+							Enabled:         true,
+							TLSFileSettings: &TLSFileSettings{CAPath: "/path/to/ca.crt"},
+						},
+					},
+				},
+			},
+			expectedErr: "schema registry API TLS file settings are not supported when using cloud options",
+		},
+		{
+			name: "cloud config - schema registry API plain password with omitted client options",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				CloudOptions: &CloudShadowLinkOptions{
+					ShadowRedpandaID: "shadow-cluster",
+				},
+				// No ClientOptions block; the SR-API secret check must still run.
+				SchemaRegistrySyncOptions: &SchemaRegistrySyncOptions{
+					ShadowSchemaRegistryAPI: &ShadowSchemaRegistryAPI{
+						SourceURL: "https://source-sr:8081",
+						AuthOptions: &SchemaRegistryAuthOptions{
+							Basic: &HTTPBasicAuthOptions{
+								Username: "user",
+								Password: "plain-password-not-allowed",
+							},
+						},
+					},
+				},
+			},
+			expectedErr: "cloud shadow links don't support plain passwords",
+		},
+		{
+			name: "valid cloud config - schema registry API with secrets",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				CloudOptions: &CloudShadowLinkOptions{
+					ShadowRedpandaID: "shadow-cluster",
+				},
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+				},
+				SchemaRegistrySyncOptions: &SchemaRegistrySyncOptions{
+					ShadowSchemaRegistryAPI: &ShadowSchemaRegistryAPI{
+						SourceURL: "https://source-sr:8081",
+						AuthOptions: &SchemaRegistryAuthOptions{
+							Basic: &HTTPBasicAuthOptions{
+								Username: "user",
+								Password: "${secrets.SR_PASSWORD}",
+							},
+						},
+						TLSSettings: &TLSSettings{
+							Enabled: true,
+							TLSPEMSettings: &TLSPEMSettings{
+								CA:  "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+								Key: "${secrets.SR_TLS_KEY}",
+							},
+						},
+					},
+				},
+			},
 		},
 		{
 			name: "valid cloud config - with secrets store password",

--- a/src/go/rpk/pkg/cli/shadow/describe.go
+++ b/src/go/rpk/pkg/cli/shadow/describe.go
@@ -102,7 +102,22 @@ type describeSecuritySyncOptions struct {
 }
 
 type describeSchemaRegistrySyncOptions struct {
-	ShadowingMode string `json:"shadowing_mode" yaml:"shadowing_mode"`
+	ShadowingMode           string                           `json:"shadowing_mode" yaml:"shadowing_mode"`
+	ShadowSchemaRegistryAPI *describeShadowSchemaRegistryAPI `json:"shadow_schema_registry_api,omitempty" yaml:"shadow_schema_registry_api,omitempty"`
+}
+
+// describeShadowSchemaRegistryAPI uses effective interval/rate values and auth
+// metadata (not the password).
+type describeShadowSchemaRegistryAPI struct {
+	SourceURL                      string                            `json:"source_url" yaml:"source_url"`
+	AuthOptions                    *describeAuthenticationConfig     `json:"auth_options,omitempty" yaml:"auth_options,omitempty"`
+	TLSSettings                    *TLSSettings                      `json:"tls_settings,omitempty" yaml:"tls_settings,omitempty"`
+	TailInterval                   string                            `json:"tail_interval" yaml:"tail_interval"`
+	FullSyncInterval               string                            `json:"full_sync_interval" yaml:"full_sync_interval"`
+	MaxSourceRequestsPerSecond     int32                             `json:"max_source_requests_per_second" yaml:"max_source_requests_per_second"`
+	SourceFilter                   *SchemaRegistrySourceFilter       `json:"source_filter,omitempty" yaml:"source_filter,omitempty"`
+	Destination                    *SchemaRegistryContextDestination `json:"destination,omitempty" yaml:"destination,omitempty"`
+	UnsupportedSchemaFeaturePolicy string                            `json:"unsupported_schema_feature_policy" yaml:"unsupported_schema_feature_policy"`
 }
 
 func newDescribeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
@@ -275,6 +290,7 @@ func printCloudShadowLinkDescription(f config.OutFormatter, link *controlplanev1
 			secTopicSync:      opts.topic,
 			secConsumerOffset: opts.co,
 			secSecurity:       opts.sec,
+			secSchemaRegistry: opts.sr,
 		})...,
 	)
 
@@ -350,29 +366,7 @@ func printClient(opts *adminv2.ShadowLinkClientOptions) {
 	}
 
 	// TLS section
-	if tls := opts.GetTlsSettings(); tls != nil {
-		tw.Print("TLS:", "")
-		tw.Print("----", "")
-		// TLS settings can be either file-based or PEM-based.
-		if fileSettings := tls.GetTlsFileSettings(); fileSettings != nil {
-			// CA is required, key and cert are optional.
-			tw.Print("CA", fileSettings.GetCaPath())
-			if keyPath := fileSettings.GetKeyPath(); keyPath != "" {
-				tw.Print("KEY", keyPath)
-			}
-			if certPath := fileSettings.GetCertPath(); certPath != "" {
-				tw.Print("CERT", certPath)
-			}
-		} else if pemSettings := tls.GetTlsPemSettings(); pemSettings != nil {
-			tw.Print("CA", pemSettings.GetCa())
-			if key := pemSettings.GetKeyFingerprint(); key != "" {
-				tw.Print("KEY FINGERPRINT", key)
-			}
-			if cert := pemSettings.GetCert(); cert != "" {
-				tw.Print("CERT", cert)
-			}
-		}
-	}
+	printTLSSettings(tw, opts.GetTlsSettings())
 
 	// SASL section
 	if auth := opts.GetAuthenticationConfiguration(); auth != nil {
@@ -560,6 +554,84 @@ func printSchemaRegistrySync(opts *adminv2.SchemaRegistrySyncOptions) {
 		return
 	}
 	tw.Print("SHADOWING MODE", strings.ReplaceAll(opts.WhichSchemaRegistryShadowingMode().String(), "_", " "))
+
+	api := opts.GetShadowSchemaRegistryApi()
+	if api == nil {
+		return
+	}
+	tw.Print("SOURCE URL", api.GetSourceUrl())
+	tw.Print("TAIL INTERVAL", api.GetEffectiveTailInterval().AsDuration().String())
+	tw.Print("FULL SYNC INTERVAL", api.GetEffectiveFullSyncInterval().AsDuration().String())
+	tw.Print("MAX SOURCE REQUESTS PER SECOND", api.GetEffectiveMaxSourceRequestsPerSecond())
+	tw.Print("UNSUPPORTED SCHEMA FEATURE POLICY", formatUnsupportedSchemaFeaturePolicy(api.GetUnsupportedSchemaFeaturePolicy()))
+
+	printTLSSettings(tw, api.GetTlsSettings())
+
+	if basic := api.GetAuthOptions().GetBasic(); basic != nil {
+		tw.Print("", "")
+		tw.Print("BASIC AUTH:", "")
+		tw.Print("-----------", "")
+		tw.Print("USERNAME", basic.GetUsername())
+		if basic.GetPasswordSet() {
+			tw.Print("PASSWORD SET AT", basic.GetPasswordSetAt().AsTime().Format(time.RFC3339))
+		}
+	}
+
+	if sf := api.GetSourceFilter(); sf != nil {
+		if contexts := sf.GetContexts(); len(contexts) > 0 {
+			tw.Print("SOURCE CONTEXTS:", "")
+			for _, c := range contexts {
+				tw.Print("", fmt.Sprintf("- %s", c))
+			}
+		}
+		if subjects := sf.GetSubjects(); len(subjects) > 0 {
+			tw.Print("SOURCE SUBJECTS:", "")
+			for _, s := range subjects {
+				tw.Print("", fmt.Sprintf("- %s", s))
+			}
+		}
+	}
+
+	if dest := api.GetDestination(); dest != nil {
+		switch {
+		case dest.GetIdentity() != nil:
+			tw.Print("DESTINATION", "identity")
+		case dest.GetExact() != nil:
+			tw.Print("DESTINATION", "exact")
+			for _, m := range dest.GetExact().GetMappings() {
+				tw.Print("", fmt.Sprintf("- %s -> %s", m.GetSource(), m.GetDestination()))
+			}
+		}
+	}
+}
+
+// printTLSSettings renders the shared core TLS settings (file- or PEM-based)
+// used by both the client options and the schema registry API.
+func printTLSSettings(tw *out.TabWriter, tls *corecommonv1.TLSSettings) {
+	if tls == nil {
+		return
+	}
+	tw.Print("TLS:", "")
+	tw.Print("----", "")
+	// TLS settings can be either file-based or PEM-based.
+	if fileSettings := tls.GetTlsFileSettings(); fileSettings != nil {
+		// CA is required, key and cert are optional.
+		tw.Print("CA", fileSettings.GetCaPath())
+		if keyPath := fileSettings.GetKeyPath(); keyPath != "" {
+			tw.Print("KEY", keyPath)
+		}
+		if certPath := fileSettings.GetCertPath(); certPath != "" {
+			tw.Print("CERT", certPath)
+		}
+	} else if pemSettings := tls.GetTlsPemSettings(); pemSettings != nil {
+		tw.Print("CA", pemSettings.GetCa())
+		if key := pemSettings.GetKeyFingerprint(); key != "" {
+			tw.Print("KEY FINGERPRINT", key)
+		}
+		if cert := pemSettings.GetCert(); cert != "" {
+			tw.Print("CERT", cert)
+		}
+	}
 }
 
 func formatScramMechanism(m adminv2.ScramMechanism) string {
@@ -609,6 +681,10 @@ func formatACLOperation(o corecommonv1.ACLOperation) string {
 
 func formatACLPermissionType(p corecommonv1.ACLPermissionType) string {
 	return strings.ToUpper(strings.TrimPrefix(p.String(), "ACL_PERMISSION_TYPE_"))
+}
+
+func formatUnsupportedSchemaFeaturePolicy(p adminv2.UnsupportedSchemaFeaturePolicy) string {
+	return strings.TrimPrefix(p.String(), "UNSUPPORTED_SCHEMA_FEATURE_POLICY_")
 }
 
 // fromAdminV2ShadowLinkDescription converts adminv2.ShadowLink to shadowLinkDescription.
@@ -788,6 +864,35 @@ func buildDescribeSchemaRegistryOptions(opts *adminv2.SchemaRegistrySyncOptions)
 		return nil
 	}
 	return &describeSchemaRegistrySyncOptions{
-		ShadowingMode: strings.ReplaceAll(opts.WhichSchemaRegistryShadowingMode().String(), "_", " "),
+		ShadowingMode:           strings.ReplaceAll(opts.WhichSchemaRegistryShadowingMode().String(), "_", " "),
+		ShadowSchemaRegistryAPI: buildDescribeShadowSchemaRegistryAPI(opts.GetShadowSchemaRegistryApi()),
 	}
+}
+
+func buildDescribeShadowSchemaRegistryAPI(api *adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryApi) *describeShadowSchemaRegistryAPI {
+	if api == nil {
+		return nil
+	}
+	d := &describeShadowSchemaRegistryAPI{
+		SourceURL:                      api.GetSourceUrl(),
+		TLSSettings:                    adminTLSToCfg(api.GetTlsSettings()),
+		TailInterval:                   api.GetEffectiveTailInterval().AsDuration().String(),
+		FullSyncInterval:               api.GetEffectiveFullSyncInterval().AsDuration().String(),
+		MaxSourceRequestsPerSecond:     api.GetEffectiveMaxSourceRequestsPerSecond(),
+		SourceFilter:                   adminSchemaRegistrySourceFilterToCfg(api.GetSourceFilter()),
+		Destination:                    adminSchemaRegistryDestinationToCfg(api.GetDestination()),
+		UnsupportedSchemaFeaturePolicy: formatUnsupportedSchemaFeaturePolicy(api.GetUnsupportedSchemaFeaturePolicy()),
+	}
+	if basic := api.GetAuthOptions().GetBasic(); basic != nil {
+		var passwordSetAt string
+		if basic.GetPasswordSet() && basic.GetPasswordSetAt() != nil {
+			passwordSetAt = basic.GetPasswordSetAt().AsTime().Format(time.RFC3339)
+		}
+		d.AuthOptions = &describeAuthenticationConfig{
+			Username:      basic.GetUsername(),
+			PasswordSet:   basic.GetPasswordSet(),
+			PasswordSetAt: passwordSetAt,
+		}
+	}
+	return d
 }

--- a/src/go/rpk/pkg/cli/shadow/mapper.go
+++ b/src/go/rpk/pkg/cli/shadow/mapper.go
@@ -779,11 +779,116 @@ func adminSchemaRegistrySyncToCfg(opts *adminv2.SchemaRegistrySyncOptions) *Sche
 	cfg := &SchemaRegistrySyncOptions{}
 
 	// Handle schema_registry_shadowing_mode oneof
-	if _, ok := opts.GetSchemaRegistryShadowingMode().(*adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryTopic_); ok {
+	switch mode := opts.GetSchemaRegistryShadowingMode().(type) {
+	case *adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryTopic_:
 		cfg.ShadowSchemaRegistryTopic = &ShadowSchemaRegistryTopic{}
+	case *adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryApi_:
+		cfg.ShadowSchemaRegistryAPI = adminShadowSchemaRegistryAPIToCfg(mode.ShadowSchemaRegistryApi)
 	}
 
 	return cfg
+}
+
+func adminShadowSchemaRegistryAPIToCfg(api *adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryApi) *ShadowSchemaRegistryAPI {
+	if api == nil {
+		return nil
+	}
+
+	cfg := &ShadowSchemaRegistryAPI{
+		SourceURL:                      api.GetSourceUrl(),
+		MaxSourceRequestsPerSecond:     api.GetMaxSourceRequestsPerSecond(),
+		AuthOptions:                    adminSchemaRegistryAuthToCfg(api.GetAuthOptions()),
+		SourceFilter:                   adminSchemaRegistrySourceFilterToCfg(api.GetSourceFilter()),
+		Destination:                    adminSchemaRegistryDestinationToCfg(api.GetDestination()),
+		UnsupportedSchemaFeaturePolicy: adminUnsupportedSchemaFeaturePolicyToCfg(api.GetUnsupportedSchemaFeaturePolicy()),
+	}
+
+	if api.GetTlsSettings() != nil {
+		cfg.TLSSettings = adminTLSToCfg(api.GetTlsSettings())
+	}
+
+	if api.GetTailInterval() != nil {
+		cfg.TailInterval = api.GetTailInterval().AsDuration()
+	}
+
+	if api.GetFullSyncInterval() != nil {
+		cfg.FullSyncInterval = api.GetFullSyncInterval().AsDuration()
+	}
+
+	return cfg
+}
+
+func adminSchemaRegistryAuthToCfg(auth *adminv2.SchemaRegistryAuthOptions) *SchemaRegistryAuthOptions {
+	if auth == nil {
+		return nil
+	}
+
+	if basic := auth.GetBasic(); basic != nil {
+		return &SchemaRegistryAuthOptions{
+			Basic: &HTTPBasicAuthOptions{
+				Username: basic.GetUsername(),
+				Password: basic.GetPassword(),
+				// password_set and password_set_at are output-only
+			},
+		}
+	}
+
+	return nil
+}
+
+func adminSchemaRegistrySourceFilterToCfg(filter *adminv2.SchemaRegistrySourceFilter) *SchemaRegistrySourceFilter {
+	if filter == nil {
+		return nil
+	}
+
+	return &SchemaRegistrySourceFilter{
+		Contexts: filter.GetContexts(),
+		Subjects: filter.GetSubjects(),
+	}
+}
+
+func adminSchemaRegistryDestinationToCfg(dest *adminv2.SchemaRegistryContextDestination) *SchemaRegistryContextDestination {
+	if dest == nil {
+		return nil
+	}
+
+	cfg := &SchemaRegistryContextDestination{}
+
+	// Handle mapping oneof
+	switch mapping := dest.GetMapping().(type) {
+	case *adminv2.SchemaRegistryContextDestination_Identity:
+		cfg.Identity = &SchemaRegistryIdentityContextMapping{}
+	case *adminv2.SchemaRegistryContextDestination_Exact:
+		exact := &SchemaRegistryExactContextMappings{}
+		for _, m := range mapping.Exact.GetMappings() {
+			exact.Mappings = append(exact.Mappings, adminSchemaRegistryContextMapToCfg(m))
+		}
+		cfg.Exact = exact
+	}
+
+	return cfg
+}
+
+func adminSchemaRegistryContextMapToCfg(m *adminv2.SchemaRegistryContextMap) *SchemaRegistryContextMap {
+	if m == nil {
+		return nil
+	}
+
+	return &SchemaRegistryContextMap{
+		Source:      m.GetSource(),
+		Destination: m.GetDestination(),
+	}
+}
+
+func adminUnsupportedSchemaFeaturePolicyToCfg(p adminv2.UnsupportedSchemaFeaturePolicy) UnsupportedSchemaFeaturePolicy {
+	switch p {
+	case adminv2.UnsupportedSchemaFeaturePolicy_UNSUPPORTED_SCHEMA_FEATURE_POLICY_FAIL:
+		return UnsupportedSchemaFeaturePolicyFail
+	case adminv2.UnsupportedSchemaFeaturePolicy_UNSUPPORTED_SCHEMA_FEATURE_POLICY_REMOVE:
+		return UnsupportedSchemaFeaturePolicyRemove
+	default:
+		return ""
+	}
 }
 
 func adminMapFilterToCfg(filter *adminv2.NameFilter) *NameFilter {

--- a/src/go/rpk/pkg/cli/shadow/mapper.go
+++ b/src/go/rpk/pkg/cli/shadow/mapper.go
@@ -300,16 +300,125 @@ func mapSchemaRegistrySyncOptions(opts *SchemaRegistrySyncOptions) *adminv2.Sche
 
 	pbOpts := &adminv2.SchemaRegistrySyncOptions{}
 
-	// Handle schema_registry_shadowing_mode oneof
-	// If the struct has the ShadowSchemaRegistryTopic field populated,
-	// we set the oneof
+	// Handle schema_registry_shadowing_mode oneof. Only one can be set
 	if opts.ShadowSchemaRegistryTopic != nil {
 		pbOpts.SchemaRegistryShadowingMode = &adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryTopic_{
 			ShadowSchemaRegistryTopic: &adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryTopic{},
 		}
+	} else if opts.ShadowSchemaRegistryAPI != nil {
+		pbOpts.SchemaRegistryShadowingMode = &adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryApi_{
+			ShadowSchemaRegistryApi: mapShadowSchemaRegistryAPI(opts.ShadowSchemaRegistryAPI),
+		}
 	}
 
 	return pbOpts
+}
+
+func mapShadowSchemaRegistryAPI(api *ShadowSchemaRegistryAPI) *adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryApi {
+	if api == nil {
+		return nil
+	}
+
+	pbAPI := &adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryApi{
+		SourceUrl:                      api.SourceURL,
+		MaxSourceRequestsPerSecond:     api.MaxSourceRequestsPerSecond,
+		AuthOptions:                    mapSchemaRegistryAuthOptions(api.AuthOptions),
+		SourceFilter:                   mapSchemaRegistrySourceFilter(api.SourceFilter),
+		Destination:                    mapSchemaRegistryContextDestination(api.Destination),
+		UnsupportedSchemaFeaturePolicy: mapUnsupportedSchemaFeaturePolicy(api.UnsupportedSchemaFeaturePolicy),
+		// effective_* fields are output-only
+	}
+
+	if api.TLSSettings != nil {
+		pbAPI.TlsSettings = mapTLSSettings(api.TLSSettings)
+	}
+
+	if api.TailInterval > 0 {
+		pbAPI.TailInterval = durationpb.New(api.TailInterval)
+	}
+
+	if api.FullSyncInterval > 0 {
+		pbAPI.FullSyncInterval = durationpb.New(api.FullSyncInterval)
+	}
+
+	return pbAPI
+}
+
+func mapSchemaRegistryAuthOptions(auth *SchemaRegistryAuthOptions) *adminv2.SchemaRegistryAuthOptions {
+	if auth == nil {
+		return nil
+	}
+
+	pbAuth := &adminv2.SchemaRegistryAuthOptions{}
+	if auth.Basic != nil {
+		pbAuth.AuthOptions = &adminv2.SchemaRegistryAuthOptions_Basic{
+			Basic: &adminv2.HTTPBasicAuthOptions{
+				Username: auth.Basic.Username,
+				Password: auth.Basic.Password,
+				// password_set and password_set_at are output-only
+			},
+		}
+	}
+
+	return pbAuth
+}
+
+func mapSchemaRegistrySourceFilter(filter *SchemaRegistrySourceFilter) *adminv2.SchemaRegistrySourceFilter {
+	if filter == nil {
+		return nil
+	}
+
+	return &adminv2.SchemaRegistrySourceFilter{
+		Contexts: filter.Contexts,
+		Subjects: filter.Subjects,
+	}
+}
+
+func mapSchemaRegistryContextDestination(dest *SchemaRegistryContextDestination) *adminv2.SchemaRegistryContextDestination {
+	if dest == nil {
+		return nil
+	}
+
+	pbDest := &adminv2.SchemaRegistryContextDestination{}
+
+	// Handle mapping oneof. only one can be set
+	if dest.Identity != nil {
+		pbDest.Mapping = &adminv2.SchemaRegistryContextDestination_Identity{
+			Identity: &adminv2.SchemaRegistryIdentityContextMapping{},
+		}
+	} else if dest.Exact != nil {
+		exact := &adminv2.SchemaRegistryExactContextMappings{}
+		for _, m := range dest.Exact.Mappings {
+			exact.Mappings = append(exact.Mappings, mapSchemaRegistryContextMap(m))
+		}
+		pbDest.Mapping = &adminv2.SchemaRegistryContextDestination_Exact{
+			Exact: exact,
+		}
+	}
+
+	return pbDest
+}
+
+func mapSchemaRegistryContextMap(m *SchemaRegistryContextMap) *adminv2.SchemaRegistryContextMap {
+	if m == nil {
+		return nil
+	}
+
+	return &adminv2.SchemaRegistryContextMap{
+		Source:      m.Source,
+		Destination: m.Destination,
+	}
+}
+
+func mapUnsupportedSchemaFeaturePolicy(p UnsupportedSchemaFeaturePolicy) adminv2.UnsupportedSchemaFeaturePolicy {
+	switch p {
+	case UnsupportedSchemaFeaturePolicyFail:
+		return adminv2.UnsupportedSchemaFeaturePolicy_UNSUPPORTED_SCHEMA_FEATURE_POLICY_FAIL
+	case UnsupportedSchemaFeaturePolicyRemove:
+		return adminv2.UnsupportedSchemaFeaturePolicy_UNSUPPORTED_SCHEMA_FEATURE_POLICY_REMOVE
+	default:
+		return adminv2.UnsupportedSchemaFeaturePolicy_UNSUPPORTED_SCHEMA_FEATURE_POLICY_UNSPECIFIED
+	}
 }
 
 func mapNameFilter(filter *NameFilter) *adminv2.NameFilter {

--- a/src/go/rpk/pkg/cli/shadow/mapper_test.go
+++ b/src/go/rpk/pkg/cli/shadow/mapper_test.go
@@ -1182,6 +1182,143 @@ func TestAdminSecuritySyncToCfg(t *testing.T) {
 	}
 }
 
+func TestAdminSchemaRegistrySyncToCfg(t *testing.T) {
+	tests := []struct {
+		name string
+		opts *adminv2.SchemaRegistrySyncOptions
+		want *SchemaRegistrySyncOptions
+	}{
+		{
+			name: "nil options returns nil",
+			opts: nil,
+			want: nil,
+		},
+		{
+			name: "no shadowing mode set",
+			opts: &adminv2.SchemaRegistrySyncOptions{},
+			want: &SchemaRegistrySyncOptions{},
+		},
+		{
+			name: "topic mode",
+			opts: &adminv2.SchemaRegistrySyncOptions{
+				SchemaRegistryShadowingMode: &adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryTopic_{
+					ShadowSchemaRegistryTopic: &adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryTopic{},
+				},
+			},
+			want: &SchemaRegistrySyncOptions{
+				ShadowSchemaRegistryTopic: &ShadowSchemaRegistryTopic{},
+			},
+		},
+		{
+			name: "API mode full with exact destination",
+			opts: &adminv2.SchemaRegistrySyncOptions{
+				SchemaRegistryShadowingMode: &adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryApi_{
+					ShadowSchemaRegistryApi: &adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryApi{
+						SourceUrl: "https://source-sr.example.com:8081",
+						AuthOptions: &adminv2.SchemaRegistryAuthOptions{
+							AuthOptions: &adminv2.SchemaRegistryAuthOptions_Basic{
+								Basic: &adminv2.HTTPBasicAuthOptions{
+									Username: "sr-user",
+									Password: "sr-pass",
+								},
+							},
+						},
+						TlsSettings: &corecommonv1.TLSSettings{
+							Enabled: true,
+							TlsSettings: &corecommonv1.TLSSettings_TlsFileSettings{
+								TlsFileSettings: &corecommonv1.TLSFileSettings{
+									CaPath: "/path/to/ca.crt",
+								},
+							},
+						},
+						TailInterval:               durationpb.New(10 * time.Second),
+						FullSyncInterval:           durationpb.New(5 * time.Minute),
+						MaxSourceRequestsPerSecond: 30,
+						SourceFilter: &adminv2.SchemaRegistrySourceFilter{
+							Contexts: []string{".", ".prod"},
+							Subjects: []string{"orders-value"},
+						},
+						Destination: &adminv2.SchemaRegistryContextDestination{
+							Mapping: &adminv2.SchemaRegistryContextDestination_Exact{
+								Exact: &adminv2.SchemaRegistryExactContextMappings{
+									Mappings: []*adminv2.SchemaRegistryContextMap{
+										{Source: ".", Destination: ".shadow"},
+									},
+								},
+							},
+						},
+						UnsupportedSchemaFeaturePolicy: adminv2.UnsupportedSchemaFeaturePolicy_UNSUPPORTED_SCHEMA_FEATURE_POLICY_REMOVE,
+					},
+				},
+			},
+			want: &SchemaRegistrySyncOptions{
+				ShadowSchemaRegistryAPI: &ShadowSchemaRegistryAPI{
+					SourceURL: "https://source-sr.example.com:8081",
+					AuthOptions: &SchemaRegistryAuthOptions{
+						Basic: &HTTPBasicAuthOptions{
+							Username: "sr-user",
+							Password: "sr-pass",
+						},
+					},
+					TLSSettings: &TLSSettings{
+						Enabled: true,
+						TLSFileSettings: &TLSFileSettings{
+							CAPath: "/path/to/ca.crt",
+						},
+					},
+					TailInterval:               10 * time.Second,
+					FullSyncInterval:           5 * time.Minute,
+					MaxSourceRequestsPerSecond: 30,
+					SourceFilter: &SchemaRegistrySourceFilter{
+						Contexts: []string{".", ".prod"},
+						Subjects: []string{"orders-value"},
+					},
+					Destination: &SchemaRegistryContextDestination{
+						Exact: &SchemaRegistryExactContextMappings{
+							Mappings: []*SchemaRegistryContextMap{
+								{Source: ".", Destination: ".shadow"},
+							},
+						},
+					},
+					UnsupportedSchemaFeaturePolicy: UnsupportedSchemaFeaturePolicyRemove,
+				},
+			},
+		},
+		{
+			name: "API mode with identity destination",
+			opts: &adminv2.SchemaRegistrySyncOptions{
+				SchemaRegistryShadowingMode: &adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryApi_{
+					ShadowSchemaRegistryApi: &adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryApi{
+						SourceUrl: "https://source-sr.example.com:8081",
+						Destination: &adminv2.SchemaRegistryContextDestination{
+							Mapping: &adminv2.SchemaRegistryContextDestination_Identity{
+								Identity: &adminv2.SchemaRegistryIdentityContextMapping{},
+							},
+						},
+						UnsupportedSchemaFeaturePolicy: adminv2.UnsupportedSchemaFeaturePolicy_UNSUPPORTED_SCHEMA_FEATURE_POLICY_FAIL,
+					},
+				},
+			},
+			want: &SchemaRegistrySyncOptions{
+				ShadowSchemaRegistryAPI: &ShadowSchemaRegistryAPI{
+					SourceURL: "https://source-sr.example.com:8081",
+					Destination: &SchemaRegistryContextDestination{
+						Identity: &SchemaRegistryIdentityContextMapping{},
+					},
+					UnsupportedSchemaFeaturePolicy: UnsupportedSchemaFeaturePolicyFail,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := adminSchemaRegistrySyncToCfg(tt.opts)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestAdminMapFilterToCfg(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -1767,4 +1904,68 @@ func TestAdminACLOperationToCfg_UnknownValue(t *testing.T) {
 func TestAdminPermissionTypeToCfg_UnknownValue(t *testing.T) {
 	result := adminPermissionTypeToCfg(corecommonv1.ACLPermissionType_ACL_PERMISSION_TYPE_UNSPECIFIED)
 	require.Equal(t, ACLPermissionType(""), result, "unspecified permission type should return empty string")
+}
+
+func TestAdminUnsupportedSchemaFeaturePolicyToCfg_UnknownValue(t *testing.T) {
+	result := adminUnsupportedSchemaFeaturePolicyToCfg(adminv2.UnsupportedSchemaFeaturePolicy_UNSUPPORTED_SCHEMA_FEATURE_POLICY_UNSPECIFIED)
+	require.Equal(t, UnsupportedSchemaFeaturePolicy(""), result, "unspecified policy should return empty string")
+}
+
+// TestSchemaRegistryAPIRoundTrip verifies that a config using the schema
+// registry API shadowing mode survives a config -> proto -> config round-trip.
+// The API mode is a separate oneof branch from the topic mode covered by
+// TestRoundTrip, so it cannot coexist with that test's config.
+func TestSchemaRegistryAPIRoundTrip(t *testing.T) {
+	originalConfig := &ShadowLinkConfig{
+		Name: "sr-api-shadow-link",
+		ClientOptions: &ShadowLinkClientOptions{
+			BootstrapServers: []string{"broker1:9092", "broker2:9092"},
+		},
+		SchemaRegistrySyncOptions: &SchemaRegistrySyncOptions{
+			ShadowSchemaRegistryAPI: &ShadowSchemaRegistryAPI{
+				SourceURL: "https://source-sr.example.com:8081",
+				AuthOptions: &SchemaRegistryAuthOptions{
+					Basic: &HTTPBasicAuthOptions{
+						Username: "sr-user",
+						Password: "sr-pass",
+					},
+				},
+				TLSSettings: &TLSSettings{
+					Enabled: true,
+					TLSFileSettings: &TLSFileSettings{
+						CAPath:   "/etc/ssl/certs/ca.crt",
+						KeyPath:  "/etc/ssl/private/client.key",
+						CertPath: "/etc/ssl/certs/client.crt",
+					},
+				},
+				TailInterval:               15 * time.Second,
+				FullSyncInterval:           10 * time.Minute,
+				MaxSourceRequestsPerSecond: 50,
+				SourceFilter: &SchemaRegistrySourceFilter{
+					Contexts: []string{".", ".prod", ".staging"},
+					Subjects: []string{"orders-value", ":.prod:payments-value"},
+				},
+				Destination: &SchemaRegistryContextDestination{
+					Exact: &SchemaRegistryExactContextMappings{
+						Mappings: []*SchemaRegistryContextMap{
+							{Source: ".", Destination: ".shadow"},
+							{Source: ".prod", Destination: ".prod-shadow"},
+						},
+					},
+				},
+				UnsupportedSchemaFeaturePolicy: UnsupportedSchemaFeaturePolicyRemove,
+			},
+		},
+	}
+
+	// Step 1: Convert config to proto (config -> proto)
+	adminShadowLink := shadowLinkConfigToProto(originalConfig)
+	require.NotNil(t, adminShadowLink, "shadow link should not be nil")
+
+	// Step 2: Convert proto back to config (proto -> config)
+	roundTripConfig := shadowLinkToConfig(adminShadowLink)
+	require.NotNil(t, roundTripConfig, "round-trip config should not be nil")
+
+	// Step 3: Verify the round-trip config matches the original
+	require.Equal(t, originalConfig, roundTripConfig, "round-trip config should exactly match original config")
 }

--- a/src/go/rpk/pkg/cli/shadow/mapper_test.go
+++ b/src/go/rpk/pkg/cli/shadow/mapper_test.go
@@ -471,6 +471,158 @@ func TestMapSecuritySyncOptions(t *testing.T) {
 	}
 }
 
+func TestMapSchemaRegistrySyncOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		opts *SchemaRegistrySyncOptions
+		want *adminv2.SchemaRegistrySyncOptions
+	}{
+		{
+			name: "nil options returns nil",
+			opts: nil,
+			want: nil,
+		},
+		{
+			name: "no shadowing mode set",
+			opts: &SchemaRegistrySyncOptions{},
+			want: &adminv2.SchemaRegistrySyncOptions{},
+		},
+		{
+			name: "topic mode",
+			opts: &SchemaRegistrySyncOptions{
+				ShadowSchemaRegistryTopic: &ShadowSchemaRegistryTopic{},
+			},
+			want: &adminv2.SchemaRegistrySyncOptions{
+				SchemaRegistryShadowingMode: &adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryTopic_{
+					ShadowSchemaRegistryTopic: &adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryTopic{},
+				},
+			},
+		},
+		{
+			name: "API mode minimal",
+			opts: &SchemaRegistrySyncOptions{
+				ShadowSchemaRegistryAPI: &ShadowSchemaRegistryAPI{
+					SourceURL: "https://source-sr.example.com:8081",
+				},
+			},
+			want: &adminv2.SchemaRegistrySyncOptions{
+				SchemaRegistryShadowingMode: &adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryApi_{
+					ShadowSchemaRegistryApi: &adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryApi{
+						SourceUrl: "https://source-sr.example.com:8081",
+					},
+				},
+			},
+		},
+		{
+			name: "API mode full with exact destination",
+			opts: &SchemaRegistrySyncOptions{
+				ShadowSchemaRegistryAPI: &ShadowSchemaRegistryAPI{
+					SourceURL: "https://source-sr.example.com:8081",
+					AuthOptions: &SchemaRegistryAuthOptions{
+						Basic: &HTTPBasicAuthOptions{
+							Username: "sr-user",
+							Password: "sr-pass",
+						},
+					},
+					TLSSettings: &TLSSettings{
+						Enabled: true,
+						TLSFileSettings: &TLSFileSettings{
+							CAPath: "/path/to/ca.crt",
+						},
+					},
+					TailInterval:               10 * time.Second,
+					FullSyncInterval:           5 * time.Minute,
+					MaxSourceRequestsPerSecond: 30,
+					SourceFilter: &SchemaRegistrySourceFilter{
+						Contexts: []string{".", ".prod"},
+						Subjects: []string{"orders-value"},
+					},
+					Destination: &SchemaRegistryContextDestination{
+						Exact: &SchemaRegistryExactContextMappings{
+							Mappings: []*SchemaRegistryContextMap{
+								{Source: ".", Destination: ".shadow"},
+							},
+						},
+					},
+					UnsupportedSchemaFeaturePolicy: UnsupportedSchemaFeaturePolicyRemove,
+				},
+			},
+			want: &adminv2.SchemaRegistrySyncOptions{
+				SchemaRegistryShadowingMode: &adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryApi_{
+					ShadowSchemaRegistryApi: &adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryApi{
+						SourceUrl: "https://source-sr.example.com:8081",
+						AuthOptions: &adminv2.SchemaRegistryAuthOptions{
+							AuthOptions: &adminv2.SchemaRegistryAuthOptions_Basic{
+								Basic: &adminv2.HTTPBasicAuthOptions{
+									Username: "sr-user",
+									Password: "sr-pass",
+								},
+							},
+						},
+						TlsSettings: &corecommonv1.TLSSettings{
+							Enabled: true,
+							TlsSettings: &corecommonv1.TLSSettings_TlsFileSettings{
+								TlsFileSettings: &corecommonv1.TLSFileSettings{
+									CaPath: "/path/to/ca.crt",
+								},
+							},
+						},
+						TailInterval:               durationpb.New(10 * time.Second),
+						FullSyncInterval:           durationpb.New(5 * time.Minute),
+						MaxSourceRequestsPerSecond: 30,
+						SourceFilter: &adminv2.SchemaRegistrySourceFilter{
+							Contexts: []string{".", ".prod"},
+							Subjects: []string{"orders-value"},
+						},
+						Destination: &adminv2.SchemaRegistryContextDestination{
+							Mapping: &adminv2.SchemaRegistryContextDestination_Exact{
+								Exact: &adminv2.SchemaRegistryExactContextMappings{
+									Mappings: []*adminv2.SchemaRegistryContextMap{
+										{Source: ".", Destination: ".shadow"},
+									},
+								},
+							},
+						},
+						UnsupportedSchemaFeaturePolicy: adminv2.UnsupportedSchemaFeaturePolicy_UNSUPPORTED_SCHEMA_FEATURE_POLICY_REMOVE,
+					},
+				},
+			},
+		},
+		{
+			name: "API mode with identity destination",
+			opts: &SchemaRegistrySyncOptions{
+				ShadowSchemaRegistryAPI: &ShadowSchemaRegistryAPI{
+					SourceURL: "https://source-sr.example.com:8081",
+					Destination: &SchemaRegistryContextDestination{
+						Identity: &SchemaRegistryIdentityContextMapping{},
+					},
+					UnsupportedSchemaFeaturePolicy: UnsupportedSchemaFeaturePolicyFail,
+				},
+			},
+			want: &adminv2.SchemaRegistrySyncOptions{
+				SchemaRegistryShadowingMode: &adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryApi_{
+					ShadowSchemaRegistryApi: &adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryApi{
+						SourceUrl: "https://source-sr.example.com:8081",
+						Destination: &adminv2.SchemaRegistryContextDestination{
+							Mapping: &adminv2.SchemaRegistryContextDestination_Identity{
+								Identity: &adminv2.SchemaRegistryIdentityContextMapping{},
+							},
+						},
+						UnsupportedSchemaFeaturePolicy: adminv2.UnsupportedSchemaFeaturePolicy_UNSUPPORTED_SCHEMA_FEATURE_POLICY_FAIL,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapSchemaRegistrySyncOptions(tt.opts)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestMapNameFilter(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/src/go/rpk/pkg/cli/shadow/status.go
+++ b/src/go/rpk/pkg/cli/shadow/status.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
 	dataplanev1 "buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go/redpanda/api/dataplane/v1"
@@ -30,6 +31,7 @@ type slStatusOptions struct {
 	overview bool
 	task     bool
 	topic    bool
+	sr       bool
 }
 
 // Helper types for unified printing across AdminAPI and Dataplane API.
@@ -63,10 +65,41 @@ type partitionInfo struct {
 }
 
 type shadowLinkStatus struct {
-	Overview                    linkOverview  `json:"overview" yaml:"overview"`
-	Tasks                       []taskStatus  `json:"tasks" yaml:"tasks"`
-	Topics                      []topicStatus `json:"topics" yaml:"topics"`
-	SyncedShadowTopicProperties []string      `json:"synced_shadow_topic_properties" yaml:"synced_shadow_topic_properties"`
+	Overview                    linkOverview              `json:"overview" yaml:"overview"`
+	Tasks                       []taskStatus              `json:"tasks" yaml:"tasks"`
+	Topics                      []topicStatus             `json:"topics" yaml:"topics"`
+	SyncedShadowTopicProperties []string                  `json:"synced_shadow_topic_properties" yaml:"synced_shadow_topic_properties"`
+	SchemaRegistry              *schemaRegistrySyncStatus `json:"schema_registry,omitempty" yaml:"schema_registry,omitempty"`
+}
+
+type schemaRegistrySyncStatus struct {
+	Inventory            *schemaRegistryInventory   `json:"inventory,omitempty" yaml:"inventory,omitempty"`
+	CurrentSync          *schemaRegistryCurrentSync `json:"current_sync,omitempty" yaml:"current_sync,omitempty"`
+	LastFullSync         *schemaRegistrySyncSummary `json:"last_full_sync,omitempty" yaml:"last_full_sync,omitempty"`
+	TotalsSinceTaskStart *schemaRegistrySyncSummary `json:"totals_since_task_start,omitempty" yaml:"totals_since_task_start,omitempty"`
+	LastErrorMessage     string                     `json:"last_error_message,omitempty" yaml:"last_error_message,omitempty"`
+}
+
+type schemaRegistryInventory struct {
+	SelectedSourceSubjects        int64 `json:"selected_source_subjects" yaml:"selected_source_subjects"`
+	SelectedSourceSubjectVersions int64 `json:"selected_source_subject_versions" yaml:"selected_source_subject_versions"`
+	DestinationSubjects           int64 `json:"destination_subjects" yaml:"destination_subjects"`
+	DestinationSubjectVersions    int64 `json:"destination_subject_versions" yaml:"destination_subject_versions"`
+}
+
+type schemaRegistryCurrentSync struct {
+	SyncType string                     `json:"sync_type" yaml:"sync_type"`
+	Summary  *schemaRegistrySyncSummary `json:"summary,omitempty" yaml:"summary,omitempty"`
+}
+
+type schemaRegistrySyncSummary struct {
+	StartTime                   string `json:"start_time,omitempty" yaml:"start_time,omitempty"`
+	FinishTime                  string `json:"finish_time,omitempty" yaml:"finish_time,omitempty"`
+	SubjectVersionsChanged      int64  `json:"subject_versions_changed" yaml:"subject_versions_changed"`
+	CompatibilityConfigsChanged int64  `json:"compatibility_configs_changed" yaml:"compatibility_configs_changed"`
+	ModesChanged                int64  `json:"modes_changed" yaml:"modes_changed"`
+	UnsupportedFeaturesRemoved  int64  `json:"unsupported_features_removed" yaml:"unsupported_features_removed"`
+	Errors                      int64  `json:"errors" yaml:"errors"`
 }
 
 func newStatusCommand(fs afero.Fs, p *config.Params) *cobra.Command {
@@ -140,25 +173,27 @@ Display specific sections:
 	cmd.Flags().BoolVarP(&opts.overview, "print-overview", "o", false, "Print the overview section")
 	cmd.Flags().BoolVarP(&opts.task, "print-task", "k", false, "Print the task status section")
 	cmd.Flags().BoolVarP(&opts.topic, "print-topic", "t", false, "Print the detailed topic status section")
+	cmd.Flags().BoolVarP(&opts.sr, "print-registry", "y", false, "Print the schema registry sync status section")
 	cmd.Flags().BoolVarP(&opts.all, "print-all", "a", false, "Print all sections")
 
 	p.InstallFormatFlag(cmd)
 	return cmd
 }
 
-// If no flags are set, default to overview and client sections.
+// If no flags are set, default to all sections.
 func (o *slStatusOptions) defaultOrAll() {
 	// We currently default to all sections until we have more fields to show.
-	if o.all || (!o.overview && !o.task && !o.topic) {
-		o.overview, o.task, o.topic = true, true, true
+	if o.all || (!o.overview && !o.task && !o.topic && !o.sr) {
+		o.overview, o.task, o.topic, o.sr = true, true, true, true
 	}
 }
 
 func printShadowLinkStatus(status shadowLinkStatus, opts slStatusOptions) {
 	const (
-		secOverview = "Overview"
-		secTasks    = "Tasks"
-		secTopics   = "Topics"
+		secOverview       = "Overview"
+		secTasks          = "Tasks"
+		secTopics         = "Topics"
+		secSchemaRegistry = "Schema Registry"
 	)
 
 	sections := out.NewSections(
@@ -166,6 +201,9 @@ func printShadowLinkStatus(status shadowLinkStatus, opts slStatusOptions) {
 			secOverview: opts.overview,
 			secTasks:    opts.task,
 			secTopics:   opts.topic,
+			// Only shown when present: topic-mode links and the cloud
+			// (dataplane) path do not carry schema registry sync status.
+			secSchemaRegistry: opts.sr && status.SchemaRegistry != nil,
 		})...,
 	)
 
@@ -179,6 +217,10 @@ func printShadowLinkStatus(status shadowLinkStatus, opts slStatusOptions) {
 
 	sections.Add(secTopics, func() {
 		printStatusTopics(status.Topics, status.SyncedShadowTopicProperties)
+	})
+
+	sections.Add(secSchemaRegistry, func() {
+		printStatusSchemaRegistry(status.SchemaRegistry)
 	})
 }
 
@@ -232,6 +274,66 @@ func printStatusPartitionTable(partitions []partitionInfo) {
 	}
 }
 
+func printStatusSchemaRegistry(sr *schemaRegistrySyncStatus) {
+	if sr == nil {
+		fmt.Println("No schema registry sync status.")
+		return
+	}
+	tw := out.NewTabWriter()
+	defer tw.Flush()
+
+	if inv := sr.Inventory; inv != nil {
+		tw.Print("SELECTED SOURCE SUBJECTS", inv.SelectedSourceSubjects)
+		tw.Print("SELECTED SOURCE SUBJECT VERSIONS", inv.SelectedSourceSubjectVersions)
+		tw.Print("DESTINATION SUBJECTS", inv.DestinationSubjects)
+		tw.Print("DESTINATION SUBJECT VERSIONS", inv.DestinationSubjectVersions)
+	}
+	if cs := sr.CurrentSync; cs != nil {
+		tw.Print("", "")
+		tw.Print("CURRENT SYNC:", "")
+		tw.Print("-------------", "")
+		// TYPE is only meaningful while a sync is running.
+		if cs.Summary != nil && cs.Summary.StartTime != "" {
+			tw.Print("TYPE", cs.SyncType)
+		}
+		printStatusSyncSummary(tw, cs.Summary)
+	}
+	if s := sr.LastFullSync; s != nil {
+		tw.Print("", "")
+		tw.Print("LAST FULL SYNC:", "")
+		tw.Print("---------------", "")
+		printStatusSyncSummary(tw, s)
+	}
+	if s := sr.TotalsSinceTaskStart; s != nil {
+		tw.Print("", "")
+		tw.Print("TOTALS SINCE TASK START:", "")
+		tw.Print("------------------------", "")
+		printStatusSyncSummary(tw, s)
+	}
+	if sr.LastErrorMessage != "" {
+		tw.Print("", "")
+		tw.Print("LAST ERROR", sr.LastErrorMessage)
+	}
+}
+
+func printStatusSyncSummary(tw *out.TabWriter, s *schemaRegistrySyncSummary) {
+	// A missing start time means the sync has not run yet; the counters would
+	// all be zero, so show a clear message instead.
+	if s == nil || s.StartTime == "" {
+		tw.Print("Sync has not started.")
+		return
+	}
+	tw.Print("START TIME", s.StartTime)
+	if s.FinishTime != "" {
+		tw.Print("FINISH TIME", s.FinishTime)
+	}
+	tw.Print("SUBJECT VERSIONS CHANGED", s.SubjectVersionsChanged)
+	tw.Print("COMPATIBILITY CONFIGS CHANGED", s.CompatibilityConfigsChanged)
+	tw.Print("MODES CHANGED", s.ModesChanged)
+	tw.Print("UNSUPPORTED FEATURES REMOVED", s.UnsupportedFeaturesRemoved)
+	tw.Print("ERRORS", s.Errors)
+}
+
 // fromAdminV2ShadowLink converts an adminv2.ShadowLink to the unified shadowLinkStatus.
 func fromAdminV2ShadowLink(link *adminv2.ShadowLink) shadowLinkStatus {
 	status := link.GetStatus()
@@ -247,6 +349,7 @@ func fromAdminV2ShadowLink(link *adminv2.ShadowLink) shadowLinkStatus {
 			State: state,
 		},
 		SyncedShadowTopicProperties: status.GetSyncedShadowTopicProperties(),
+		SchemaRegistry:              schemaRegistrySyncStatusToView(status.GetSchemaRegistrySyncStatus()),
 	}
 
 	// Convert tasks
@@ -288,6 +391,57 @@ func fromAdminV2ShadowLink(link *adminv2.ShadowLink) shadowLinkStatus {
 	}
 
 	return result
+}
+
+// schemaRegistrySyncStatusToView converts the admin proto schema registry sync
+// status to the unified view. The dataplane (cloud) API does not expose this
+// status, so it is only populated on the self-hosted path.
+func schemaRegistrySyncStatusToView(s *adminv2.SchemaRegistrySyncStatus) *schemaRegistrySyncStatus {
+	if s == nil {
+		return nil
+	}
+	view := &schemaRegistrySyncStatus{
+		LastFullSync:         schemaRegistrySyncSummaryToView(s.GetLastFullSync()),
+		TotalsSinceTaskStart: schemaRegistrySyncSummaryToView(s.GetTotalsSinceTaskStart()),
+		LastErrorMessage:     s.GetLastErrorMessage(),
+	}
+	if inv := s.GetInventory(); inv != nil {
+		view.Inventory = &schemaRegistryInventory{
+			SelectedSourceSubjects:        inv.GetSelectedSourceSubjects(),
+			SelectedSourceSubjectVersions: inv.GetSelectedSourceSubjectVersions(),
+			DestinationSubjects:           inv.GetDestinationSubjects(),
+			DestinationSubjectVersions:    inv.GetDestinationSubjectVersions(),
+		}
+	}
+	if cs := s.GetCurrentSync(); cs != nil {
+		view.CurrentSync = &schemaRegistryCurrentSync{
+			SyncType: strings.TrimPrefix(cs.GetSyncType().String(), "SCHEMA_REGISTRY_SYNC_TYPE_"),
+			Summary:  schemaRegistrySyncSummaryToView(cs.GetSummary()),
+		}
+	}
+	return view
+}
+
+func schemaRegistrySyncSummaryToView(s *adminv2.SchemaRegistrySyncSummary) *schemaRegistrySyncSummary {
+	if s == nil {
+		return nil
+	}
+	view := &schemaRegistrySyncSummary{
+		SubjectVersionsChanged:      s.GetSubjectVersionsChanged(),
+		CompatibilityConfigsChanged: s.GetCompatibilityConfigsChanged(),
+		ModesChanged:                s.GetModesChanged(),
+		UnsupportedFeaturesRemoved:  s.GetUnsupportedFeaturesRemoved(),
+		Errors:                      s.GetErrors(),
+	}
+	// The API sends a zero (epoch) timestamp rather than omitting the field
+	// when a sync has not run yet, so treat zero as unset.
+	if t := s.GetStartTime(); t != nil && (t.GetSeconds() != 0 || t.GetNanos() != 0) {
+		view.StartTime = t.AsTime().Format(time.RFC3339)
+	}
+	if t := s.GetFinishTime(); t != nil && (t.GetSeconds() != 0 || t.GetNanos() != 0) {
+		view.FinishTime = t.AsTime().Format(time.RFC3339)
+	}
+	return view
 }
 
 // fromDataplaneShadowLink converts dataplane API responses to the unified shadowLinkStatus.

--- a/src/go/rpk/pkg/cli/shadow/status_test.go
+++ b/src/go/rpk/pkg/cli/shadow/status_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package shadow
+
+import (
+	"testing"
+	"time"
+
+	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestFromAdminV2ShadowLinkSchemaRegistry(t *testing.T) {
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		link *adminv2.ShadowLink
+		want *schemaRegistrySyncStatus
+	}{
+		{
+			name: "no status",
+			link: &adminv2.ShadowLink{Name: "no-status"},
+			want: nil,
+		},
+		{
+			name: "status without schema registry sync",
+			link: &adminv2.ShadowLink{
+				Name:   "topic-mode",
+				Status: &adminv2.ShadowLinkStatus{},
+			},
+			want: nil,
+		},
+		{
+			name: "full schema registry sync status",
+			link: &adminv2.ShadowLink{
+				Name: "sr-link",
+				Uid:  "uid-123",
+				Status: &adminv2.ShadowLinkStatus{
+					SchemaRegistrySyncStatus: &adminv2.SchemaRegistrySyncStatus{
+						Inventory: &adminv2.SchemaRegistryInventory{
+							SelectedSourceSubjects:        10,
+							SelectedSourceSubjectVersions: 25,
+							DestinationSubjects:           8,
+							DestinationSubjectVersions:    20,
+						},
+						CurrentSync: &adminv2.SchemaRegistryCurrentSync{
+							SyncType: adminv2.SchemaRegistrySyncType_SCHEMA_REGISTRY_SYNC_TYPE_FULL,
+							Summary: &adminv2.SchemaRegistrySyncSummary{
+								StartTime:              timestamppb.New(start),
+								SubjectVersionsChanged: 5,
+								Errors:                 1,
+							},
+						},
+						LastFullSync: &adminv2.SchemaRegistrySyncSummary{
+							StartTime:                   timestamppb.New(start),
+							FinishTime:                  timestamppb.New(start.Add(time.Minute)),
+							SubjectVersionsChanged:      25,
+							CompatibilityConfigsChanged: 3,
+							ModesChanged:                1,
+							UnsupportedFeaturesRemoved:  2,
+						},
+						TotalsSinceTaskStart: &adminv2.SchemaRegistrySyncSummary{
+							SubjectVersionsChanged: 100,
+						},
+						LastErrorMessage: "transient source error",
+					},
+				},
+			},
+			want: &schemaRegistrySyncStatus{
+				Inventory: &schemaRegistryInventory{
+					SelectedSourceSubjects:        10,
+					SelectedSourceSubjectVersions: 25,
+					DestinationSubjects:           8,
+					DestinationSubjectVersions:    20,
+				},
+				CurrentSync: &schemaRegistryCurrentSync{
+					SyncType: "FULL",
+					Summary: &schemaRegistrySyncSummary{
+						StartTime:              "2024-01-01T00:00:00Z",
+						SubjectVersionsChanged: 5,
+						Errors:                 1,
+					},
+				},
+				LastFullSync: &schemaRegistrySyncSummary{
+					StartTime:                   "2024-01-01T00:00:00Z",
+					FinishTime:                  "2024-01-01T00:01:00Z",
+					SubjectVersionsChanged:      25,
+					CompatibilityConfigsChanged: 3,
+					ModesChanged:                1,
+					UnsupportedFeaturesRemoved:  2,
+				},
+				TotalsSinceTaskStart: &schemaRegistrySyncSummary{
+					SubjectVersionsChanged: 100,
+				},
+				LastErrorMessage: "transient source error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fromAdminV2ShadowLink(tt.link)
+			require.Equal(t, tt.want, got.SchemaRegistry)
+		})
+	}
+}

--- a/src/go/rpk/pkg/cli/shadow/types.go
+++ b/src/go/rpk/pkg/cli/shadow/types.go
@@ -205,6 +205,8 @@ type SecuritySettingsSyncOptions struct {
 }
 
 type SchemaRegistrySyncOptions struct {
+	// One of the following shadowing modes must be selected:
+	//
 	// Shadow the entire source cluster's Schema Registry byte-for-byte.
 	// If set, the Shadow Link will attempt to add the `_schemas`
 	// topic to the list of Shadow Topics as long as:
@@ -219,9 +221,111 @@ type SchemaRegistrySyncOptions struct {
 	// `_schemas` topic, unset this field, then either fail-over the topic or
 	// delete it.
 	ShadowSchemaRegistryTopic *ShadowSchemaRegistryTopic `json:"shadow_schema_registry_topic,omitempty" yaml:"shadow_schema_registry_topic,omitempty"`
+	// Shadow the source cluster's Schema Registry through its HTTP API,
+	// replicating the selected contexts and subjects to the shadow cluster.
+	ShadowSchemaRegistryAPI *ShadowSchemaRegistryAPI `json:"shadow_schema_registry_api,omitempty" yaml:"shadow_schema_registry_api,omitempty"`
 }
 
 type ShadowSchemaRegistryTopic struct{}
+
+type ShadowSchemaRegistryAPI struct {
+	// The source Schema Registry URL to use
+	SourceURL string `json:"source_url,omitempty" yaml:"source_url,omitempty"`
+	// Authentication settings for requests to the source Schema Registry.
+	// If unset, requests are sent without authentication
+	AuthOptions *SchemaRegistryAuthOptions `json:"auth_options,omitempty" yaml:"auth_options,omitempty"`
+	// TLS settings for requests to the source Schema Registry
+	TLSSettings *TLSSettings `json:"tls_settings,omitempty" yaml:"tls_settings,omitempty"`
+	// Interval between incremental polls for new source subjects and subject
+	// versions
+	// If 0 is provided, defaults to 10 seconds
+	TailInterval time.Duration `json:"tail_interval,omitempty" yaml:"tail_interval,omitempty"`
+	// Interval between full scans of the selected source subjects
+	// If 0 is provided, defaults to 5 minutes
+	FullSyncInterval time.Duration `json:"full_sync_interval,omitempty" yaml:"full_sync_interval,omitempty"`
+	// Maximum request rate, in requests per second, for calls to the source
+	// Schema Registry
+	// If 0 is provided, defaults to 30 requests/s
+	MaxSourceRequestsPerSecond int32 `json:"max_source_requests_per_second,omitempty" yaml:"max_source_requests_per_second,omitempty"`
+	// Filter for specific Schema Registry contexts and subjects to select
+	// for replication. If unset or empty, the whole source Schema Registry
+	// is replicated
+	SourceFilter *SchemaRegistrySourceFilter `json:"source_filter,omitempty" yaml:"source_filter,omitempty"`
+	// Mapping from source contexts implied by `source_filter` to destination
+	// contexts. Each source context included in the replication must map to
+	// a distinct destination context to avoid collisions. If unset, source
+	// context names are preserved
+	Destination *SchemaRegistryContextDestination `json:"destination,omitempty" yaml:"destination,omitempty"`
+	// Policy for handling source schema features unsupported by the
+	// destination, such as rulesets or metadata tags. If unset, FAIL is used
+	UnsupportedSchemaFeaturePolicy UnsupportedSchemaFeaturePolicy `json:"unsupported_schema_feature_policy,omitempty" yaml:"unsupported_schema_feature_policy,omitempty"`
+}
+
+// SchemaRegistryAuthOptions is the union for source Schema Registry
+// authentication options.
+type SchemaRegistryAuthOptions struct {
+	// Authenticate source Schema Registry requests with HTTP Basic auth
+	Basic *HTTPBasicAuthOptions `json:"basic,omitempty" yaml:"basic,omitempty"`
+}
+
+// HTTPBasicAuthOptions are HTTP Basic auth credentials.
+type HTTPBasicAuthOptions struct {
+	// HTTP Basic auth username. For Confluent Cloud, this is the API key
+	Username string `json:"username,omitempty" yaml:"username,omitempty"`
+	// HTTP Basic auth password. For Confluent Cloud, this is the API secret
+	Password string `json:"password,omitempty" yaml:"password,omitempty"`
+}
+
+type SchemaRegistrySourceFilter struct {
+	// Source contexts to replicate in full, for example ".", ".prod", or
+	// ".staging". If both `contexts` and `subjects` are set, the effective
+	// source scope is the union of both selections
+	Contexts []string `json:"contexts,omitempty" yaml:"contexts,omitempty"`
+	// Exact source subjects to replicate, using Schema Registry qualified
+	// subject syntax. For example, "orders-value" selects the subject in the
+	// default context, and ":.prod:orders-value" selects the subject in
+	// context ".prod"
+	Subjects []string `json:"subjects,omitempty" yaml:"subjects,omitempty"`
+}
+
+// SchemaRegistryContextDestination is the union for mapping source contexts
+// to destination contexts.
+type SchemaRegistryContextDestination struct {
+	// One of the following must be provided:
+	//
+	// Source context names are preserved on the destination
+	Identity *SchemaRegistryIdentityContextMapping `json:"identity,omitempty" yaml:"identity,omitempty"`
+	// Explicit source-to-destination context mappings
+	Exact *SchemaRegistryExactContextMappings `json:"exact,omitempty" yaml:"exact,omitempty"`
+}
+
+type SchemaRegistryIdentityContextMapping struct{}
+
+type SchemaRegistryExactContextMappings struct {
+	// Explicit source-to-destination context mappings. Every source context
+	// in the effective source scope must have exactly one mapping
+	Mappings []*SchemaRegistryContextMap `json:"mappings,omitempty" yaml:"mappings,omitempty"`
+}
+
+type SchemaRegistryContextMap struct {
+	// Source context name
+	Source string `json:"source,omitempty" yaml:"source,omitempty"`
+	// Destination context name
+	Destination string `json:"destination,omitempty" yaml:"destination,omitempty"`
+}
+
+// UnsupportedSchemaFeaturePolicy are valid policies for handling source
+// schema features unsupported by the destination.
+type UnsupportedSchemaFeaturePolicy string
+
+const (
+	// UnsupportedSchemaFeaturePolicyFail fails the sync when an unsupported
+	// schema feature is encountered.
+	UnsupportedSchemaFeaturePolicyFail UnsupportedSchemaFeaturePolicy = "FAIL"
+	// UnsupportedSchemaFeaturePolicyRemove removes unsupported fields from
+	// schemas or schema configs.
+	UnsupportedSchemaFeaturePolicyRemove UnsupportedSchemaFeaturePolicy = "REMOVE"
+)
 
 type NameFilter struct {
 	// Literal or prefix

--- a/src/go/rpk/pkg/cli/shadow/types_test.go
+++ b/src/go/rpk/pkg/cli/shadow/types_test.go
@@ -190,6 +190,79 @@ client_options:
 				},
 			},
 		},
+		{
+			name: "schema registry API mode",
+			yamlData: `
+name: "sr-api-test"
+client_options:
+  bootstrap_servers:
+    - "broker1:9092"
+schema_registry_sync_options:
+  shadow_schema_registry_api:
+    source_url: "https://source-sr.example.com:8081"
+    auth_options:
+      basic:
+        username: "sr-user"
+        password: "sr-pass"
+    tls_settings:
+      enabled: true
+      tls_file_settings:
+        ca_path: "/path/to/ca.crt"
+    tail_interval: "10s"
+    full_sync_interval: "5m"
+    max_source_requests_per_second: 30
+    source_filter:
+      contexts:
+        - "."
+        - ".prod"
+      subjects:
+        - "orders-value"
+    destination:
+      exact:
+        mappings:
+          - source: "."
+            destination: ".shadow"
+    unsupported_schema_feature_policy: "REMOVE"
+`,
+			want: ShadowLinkConfig{
+				Name: "sr-api-test",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+				},
+				SchemaRegistrySyncOptions: &SchemaRegistrySyncOptions{
+					ShadowSchemaRegistryAPI: &ShadowSchemaRegistryAPI{
+						SourceURL: "https://source-sr.example.com:8081",
+						AuthOptions: &SchemaRegistryAuthOptions{
+							Basic: &HTTPBasicAuthOptions{
+								Username: "sr-user",
+								Password: "sr-pass",
+							},
+						},
+						TLSSettings: &TLSSettings{
+							Enabled: true,
+							TLSFileSettings: &TLSFileSettings{
+								CAPath: "/path/to/ca.crt",
+							},
+						},
+						TailInterval:               10 * time.Second,
+						FullSyncInterval:           5 * time.Minute,
+						MaxSourceRequestsPerSecond: 30,
+						SourceFilter: &SchemaRegistrySourceFilter{
+							Contexts: []string{".", ".prod"},
+							Subjects: []string{"orders-value"},
+						},
+						Destination: &SchemaRegistryContextDestination{
+							Exact: &SchemaRegistryExactContextMappings{
+								Mappings: []*SchemaRegistryContextMap{
+									{Source: ".", Destination: ".shadow"},
+								},
+							},
+						},
+						UnsupportedSchemaFeaturePolicy: UnsupportedSchemaFeaturePolicyRemove,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -367,6 +440,65 @@ func TestShadowLinkConfigUnmarshalJSON(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "schema registry API mode",
+			jsonData: `{
+				"name": "sr-api-test",
+				"client_options": {
+					"bootstrap_servers": ["broker1:9092"]
+				},
+				"schema_registry_sync_options": {
+					"shadow_schema_registry_api": {
+						"source_url": "https://source-sr.example.com:8081",
+						"auth_options": {
+							"basic": {
+								"username": "sr-user",
+								"password": "sr-pass"
+							}
+						},
+						"tail_interval": 10000000000,
+						"full_sync_interval": 300000000000,
+						"max_source_requests_per_second": 30,
+						"source_filter": {
+							"contexts": ["."],
+							"subjects": ["orders-value"]
+						},
+						"destination": {
+							"identity": {}
+						},
+						"unsupported_schema_feature_policy": "FAIL"
+					}
+				}
+			}`,
+			want: ShadowLinkConfig{
+				Name: "sr-api-test",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+				},
+				SchemaRegistrySyncOptions: &SchemaRegistrySyncOptions{
+					ShadowSchemaRegistryAPI: &ShadowSchemaRegistryAPI{
+						SourceURL: "https://source-sr.example.com:8081",
+						AuthOptions: &SchemaRegistryAuthOptions{
+							Basic: &HTTPBasicAuthOptions{
+								Username: "sr-user",
+								Password: "sr-pass",
+							},
+						},
+						TailInterval:               10 * time.Second,
+						FullSyncInterval:           5 * time.Minute,
+						MaxSourceRequestsPerSecond: 30,
+						SourceFilter: &SchemaRegistrySourceFilter{
+							Contexts: []string{"."},
+							Subjects: []string{"orders-value"},
+						},
+						Destination: &SchemaRegistryContextDestination{
+							Identity: &SchemaRegistryIdentityContextMapping{},
+						},
+						UnsupportedSchemaFeaturePolicy: UnsupportedSchemaFeaturePolicyFail,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -388,10 +520,12 @@ func TestShadowLinkConfigDrift(t *testing.T) {
 		// durationpb.Duration which has an underlying struct with exported
 		// fields.
 		regexp.MustCompile(`^.*\.interval$`),
+		regexp.MustCompile(`^.*\.(tail_interval|full_sync_interval)$`),
 		// Enums in protobuf but string in our config.
 		regexp.MustCompile(`_filters\..*_type$`),
 		regexp.MustCompile(`^.*\.scram_configuration.scram_mechanism$`),
 		regexp.MustCompile(`^security_sync_options\.acl_filters\.access_filter\.operation$`),
+		regexp.MustCompile(`^.*\.unsupported_schema_feature_policy$`),
 		// one of: start_at_timestamp is a oneof field in protobuf but is a
 		// duration. In proto, it is parsed as a struct containing a timestamp
 		// field, but in the resulting JSON it is represented as a timestamp,

--- a/src/go/rpk/pkg/cli/shadow/update.go
+++ b/src/go/rpk/pkg/cli/shadow/update.go
@@ -173,15 +173,27 @@ Update a Shadow Link configuration:
 	return cmd
 }
 
-// if the password is set, replace it with a redacted value so user can provide
-// a change easily instead of writing the full password field.
+// if a password is set, replace it with a redacted value so user can provide
+// a change easily instead of writing the full password field. The server only
+// reports whether a password is set, never its value.
 func addRedactedPasswordString(cfg *ShadowLinkConfig, link *adminv2.ShadowLink) {
-	isPassSet := link.GetConfigurations().GetClientOptions().GetAuthenticationConfiguration().GetScramConfiguration().GetPasswordSet()
-	if !isPassSet {
-		return
+	const redacted = "<redacted>"
+
+	cfgs := link.GetConfigurations()
+	if cfgs.GetClientOptions().GetAuthenticationConfiguration().GetScramConfiguration().GetPasswordSet() {
+		if co := cfg.ClientOptions; co != nil {
+			if auth := co.AuthenticationConfiguration; auth != nil && auth.ScramConfiguration != nil {
+				auth.ScramConfiguration.Password = redacted
+			}
+		}
 	}
-	if auth := cfg.ClientOptions.AuthenticationConfiguration; auth != nil && auth.ScramConfiguration != nil {
-		auth.ScramConfiguration.Password = "<redacted>"
+
+	if cfgs.GetSchemaRegistrySyncOptions().GetShadowSchemaRegistryApi().GetAuthOptions().GetBasic().GetPasswordSet() {
+		if sr := cfg.SchemaRegistrySyncOptions; sr != nil && sr.ShadowSchemaRegistryAPI != nil {
+			if auth := sr.ShadowSchemaRegistryAPI.AuthOptions; auth != nil && auth.Basic != nil {
+				auth.Basic.Password = redacted
+			}
+		}
 	}
 }
 

--- a/src/go/rpk/pkg/cli/shadow/update_test.go
+++ b/src/go/rpk/pkg/cli/shadow/update_test.go
@@ -266,6 +266,45 @@ func TestDiffConfigs(t *testing.T) {
 				"configurations.client_options.authentication_configuration",
 			},
 		},
+		{
+			name: "schema registry API scalar field change - source_url",
+			original: &ShadowLinkConfig{
+				SchemaRegistrySyncOptions: &SchemaRegistrySyncOptions{
+					ShadowSchemaRegistryAPI: &ShadowSchemaRegistryAPI{
+						SourceURL: "https://old-sr:8081",
+					},
+				},
+			},
+			updated: &ShadowLinkConfig{
+				SchemaRegistrySyncOptions: &SchemaRegistrySyncOptions{
+					ShadowSchemaRegistryAPI: &ShadowSchemaRegistryAPI{
+						SourceURL: "https://new-sr:8081",
+					},
+				},
+			},
+			want: []string{
+				"configurations.schema_registry_sync_options.shadow_schema_registry_api.source_url",
+			},
+		},
+		{
+			name: "schema registry shadowing mode switch - topic to api",
+			original: &ShadowLinkConfig{
+				SchemaRegistrySyncOptions: &SchemaRegistrySyncOptions{
+					ShadowSchemaRegistryTopic: &ShadowSchemaRegistryTopic{},
+				},
+			},
+			updated: &ShadowLinkConfig{
+				SchemaRegistrySyncOptions: &SchemaRegistrySyncOptions{
+					ShadowSchemaRegistryAPI: &ShadowSchemaRegistryAPI{
+						SourceURL: "https://source-sr:8081",
+					},
+				},
+			},
+			want: []string{
+				"configurations.schema_registry_sync_options.shadow_schema_registry_topic",
+				"configurations.schema_registry_sync_options.shadow_schema_registry_api",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR adds support for the new Schema Registry option in shadow link: `shadow_schema_registry_api`

**The template**

The new option is defined in Core's proto: https://github.com/redpanda-data/redpanda/blob/dev/proto/redpanda/core/admin/v2/shadow_link.proto#L418 but here is how it will look like in our config file (a 1:1)

```yaml
schema_registry_sync_options:
  shadow_schema_registry_api:
    # The source Schema Registry URL to use.
    source_url: ""
    # Authentication settings for requests to the source Schema Registry.
    # If unset, requests are sent without authentication.
    auth_options:
      # Authenticate source Schema Registry requests with HTTP Basic auth.
      basic:
        # HTTP Basic auth username. For Confluent Cloud, this is the API key.
        username: ""
        # HTTP Basic auth password. For Confluent Cloud, this is the API secret.
        password: ""
    # TLS settings for requests to the source Schema Registry.
    tls_settings:
      # Whether or not TLS is enabled
      enabled: false
      # Certificates and keys are provided as files
      tls_file_settings:
        # Path to the CA
        ca_path: ""
        # Key and Cert are optional but if one is provided, then both must be
        # Path to the key
        key_path: ""
        # Path to the cert
        cert_path: ""
      # Certificates and keys are provided in PEM format
      tls_pem_settings:
        # The CA
        ca: ""
        # Key and Cert are optional but if one is provided, then both must be
        # The key
        key: ""
        # The cert
        cert: ""
      # If true, the SNI hostname will not be provided when TLS is used
      do_not_set_sni_hostname: false
    # Interval between incremental polls for new source subjects and
    # subject versions. If unset or zero, the cluster default of 10s is
    # used.
    tail_interval: 30s # duration (e.g., 30s, 1m, 1h)
    # Interval between full scans of the selected source subjects. If unset
    # or zero, the cluster default of 5m is used.
    full_sync_interval: 30s # duration (e.g., 30s, 1m, 1h)
    # Maximum request rate, in requests per second, for calls to the source
    # Schema Registry. If unset or zero, a default rate limit of 30
    # requests/s is used.
    max_source_requests_per_second: 0
    # Filter for specific Schema Registry contexts and subjects to select
    # for replication. If unset or empty, the whole source Schema Registry
    # is replicated.
    source_filter:
      # Source contexts to replicate in full, for example ".", ".prod", or
      # ".staging". If both `contexts` and `subjects` are set, the effective
      # source scope is the union of both selections.
      contexts: []
      # Exact source subjects to replicate, using Schema Registry qualified
      # subject syntax. For example, "orders-value" selects the subject in the
      # default context, and ":.prod:orders-value" selects the subject in context
      # ".prod". If both `contexts` and `subjects` are set, the union of both
      # selections is replicated. If a subject is also included by `contexts`, it
      # is counted and replicated once.
      subjects: []
    # Mapping from source contexts implied by `source_filter` to
    # destination contexts. Each source context included in the replication
    # must map to a distinct destination context to avoid
    # collisions. If unset, source context names are preserved.
    destination:
      # Preserve source context names in the destination Schema Registry.
      identity:                                                                             # Map selected source contexts to explicit destination contexts.
      exact:
        # Explicit source-to-destination context mappings. Every source context in
        # the effective source scope must have exactly one mapping.
        mappings:
          # Source context name.
          source: ""
          # Destination context name.
          destination: ""
    # Policy for handling source schema features unsupported by the
    # destination, such as rulesets or metadata tags. If unset, FAIL is
    # used.                                                                               
    unsupported_schema_feature_policy: FAIL # Fail the sync when an unsupported schema feature is encountered.
```

This PR also handle the whole command life cycle: `create`, `describe` and `status`

**Describe**
```
$ rpk shadow describe shadow-link-with-new-opts -y
SCHEMA REGISTRY SYNC
====================
SHADOWING MODE                     shadow schema registry api
SOURCE URL                         https://schema-registry-5dc240c4.d8qpb2a0pa8fqqs9ttl0.fmc.prd.cloud.redpanda.com:30081
TAIL INTERVAL                      35s
FULL SYNC INTERVAL                 35s
MAX SOURCE REQUESTS PER SECOND     30
UNSUPPORTED SCHEMA FEATURE POLICY  FAIL

BASIC AUTH:
-----------
USERNAME                           foo
PASSWORD SET AT                    2026-06-19T22:30:04Z
DESTINATION                        identity
```

**Status**
```
$ rpk shadow status shadow-link-with-new-opts -y
SCHEMA REGISTRY
===============
SELECTED SOURCE SUBJECTS          0
SELECTED SOURCE SUBJECT VERSIONS  0
DESTINATION SUBJECTS              0
DESTINATION SUBJECT VERSIONS      0

CURRENT SYNC:
-------------
Sync has not started.

LAST FULL SYNC:
---------------
Sync has not started.

TOTALS SINCE TASK START:
------------------------
Sync has not started.
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes


### Features

* rpk shadow: support new Schema Registry Sync option `shadow_schema_registry_api` in Shadow Links.
