### PR TITLE
[CORE-15812] ct/scale: raise fetch concurrency for cloud_topics MPT variants

### DIFF
--- a/src/v/cloud_storage_clients/multipart_upload.cc
+++ b/src/v/cloud_storage_clients/multipart_upload.cc
@@ -12,12 +12,52 @@
 
 #include "base/vassert.h"
 #include "base/vlog.h"
+#include "cloud_storage_clients/s3_error.h"
+#include "net/connection.h"
 #include "ssx/future-util.h"
 
+#include <seastar/core/timed_out_error.hh>
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/exception.hh>
 
 namespace cloud_storage_clients {
+
+namespace {
+
+// Classify a failed multipart sub-request for logging. A retryable failure is
+// not a true failure: the upload is re-driven by the caller's retry/backoff, so
+// log it at warn and reserve error for genuine failures. Retryable means either
+// an S3 throttle / transient server error (slow_down / internal_error /
+// request_timeout, as s3_client::send_request maps to error_outcome::retry) or
+// a transient transport error (reconnect or timeout, mirroring
+// handle_client_transport_error). (ABS throttles still log at error; parity is
+// a follow-up.)
+ss::log_level multipart_failure_log_level(const std::exception_ptr& ex) {
+    if (ssx::is_shutdown_exception(ex)) {
+        return ss::log_level::warn;
+    }
+    try {
+        std::rethrow_exception(ex);
+    } catch (const rest_error_response& e) {
+        switch (e.code()) {
+        case s3_error_code::slow_down:
+        case s3_error_code::internal_error:
+        case s3_error_code::request_timeout:
+            return ss::log_level::warn;
+        default:
+            return ss::log_level::error;
+        }
+    } catch (const std::system_error& e) {
+        return net::is_reconnect_error(e) ? ss::log_level::warn
+                                          : ss::log_level::error;
+    } catch (const ss::timed_out_error&) {
+        return ss::log_level::warn;
+    } catch (...) {
+        return ss::log_level::error;
+    }
+}
+
+} // namespace
 
 /// Data sink implementation that delegates to multipart_upload::put()
 ///
@@ -136,8 +176,7 @@ ss::future<> multipart_upload::complete() {
             auto ex = fut.get_exception();
             vlogl(
               _logger,
-              ssx::is_shutdown_exception(ex) ? ss::log_level::warn
-                                             : ss::log_level::error,
+              multipart_failure_log_level(ex),
               "Multipart upload final part failed, aborting: {}",
               ex);
             co_await abort_on_error();
@@ -155,8 +194,7 @@ ss::future<> multipart_upload::complete() {
         auto ex = fut.get_exception();
         vlogl(
           _logger,
-          ssx::is_shutdown_exception(ex) ? ss::log_level::warn
-                                         : ss::log_level::error,
+          multipart_failure_log_level(ex),
           "Multipart upload completion failed, aborting: {}",
           ex);
         co_await abort_on_error();

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -1020,6 +1020,16 @@ class ManyPartitionsTest(PreallocNodesTest):
             }
         )
 
+        # CORE-15812: a cloud-topic partition read is latency-bound on a
+        # per-object metastore lookup + footer read + object-store GET. At the
+        # default fetch_max_read_concurrency=1 a fetch reads its partitions
+        # serially, so at this scale (thousands of small partitions) the
+        # per-read round-trips cannot keep up and the consumer-group consumer
+        # times out. A little concurrency pipelines the per-partition reads and
+        # hides the latency.
+        if cloud_topics_enabled:
+            self.redpanda.add_extra_rp_conf({"fetch_max_read_concurrency": 4})
+
         self.redpanda.start()
 
         self.logger.info("Entering topic creation")


### PR DESCRIPTION
The cloud_topics ManyPartitionsTest variants (regular and tiered_storage) time out at the default fetch_max_read_concurrency=1. Set it to 4 for the cloud_topics path.

A cloud-topic partition read is latency-bound: per L1 object it does a metastore lookup, a footer read, and -- on a cache miss -- an object-store GET to populate the local cache. That GET dominates (~70-90% of read wall-clock) and is a round-trip cost, not bandwidth: aggregate throughput with concurrency is ~170 MB/s, far below object-store bandwidth.

fetch_max_read_concurrency caps how many partition reads in a fetch run concurrently. At the default of 1 a broker reads its hundreds of partitions serially, so the per-read round-trips serialize; across tens of thousands of small objects that is tens of minutes of pure latency and the consumer never keeps up. The regular (local-log) topic in the same test drains fine because a local read is not a latency-bound network op. Running the reads concurrently pipelines the GETs and hides the latency.

Not the cause:
- Cache size: cranking the cloud cache (2.4->50 GiB) and the L1 reader cache (128->10k) did not help; the reads are round-trip-bound, not cache-size-bound, and a high-concurrency run drains with default caches.
- The L1 reader cache cannot warm here: each small partition is read to completion in one pass, so a finished reader has nothing to reuse.
- The max_bytes early-return was suspected, but reverting it still failed. This is a scale limitation of the default serial read, not a regression.

Follow-up: the many-small-partition read pattern is inherently inefficient (each GET amortizes over little data, readers are uncacheable). Another idea for optimization: coalescing reads across partitions co-resident in one L1 object, or prefetching object downloads off the fetch critical path.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
