### PR TITLE
Core 16393 fix redpanda kafka consumer group lag max fix health monitor.cc

### DIFF
--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -127,6 +127,10 @@ public:
         return _hm_frontend;
     }
 
+    ss::sharded<health_monitor_backend>& get_health_monitor_backend() {
+        return _hm_backend;
+    }
+
     ss::sharded<feature_manager>& get_feature_manager() {
         return _feature_manager;
     }

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -950,29 +950,34 @@ health_monitor_backend::get_current_node_health() {
 
 namespace {
 
-partition_status build_partition_status(const partition& p) {
+partition_status build_partition_status(
+  const ss::lw_shared_ptr<partition>& p,
+  const std::optional<kafka_start_offset_provider>& kafka_start_offset) {
     partition_status status;
-    status.id = p.ntp().tp.partition;
-    status.term = p.term();
-    status.leader_id = p.get_leader_id();
-    status.revision_id = p.get_revision_id();
-    status.size_bytes = p.size_bytes() + p.non_log_disk_size_bytes();
-    status.reclaimable_size_bytes = p.reclaimable_size_bytes();
-    auto ctp_stm = p.raft()->stm_manager()->get<cloud_topics::ctp_stm>();
+    status.id = p->ntp().tp.partition;
+    status.term = p->term();
+    status.leader_id = p->get_leader_id();
+    status.revision_id = p->get_revision_id();
+    status.size_bytes = p->size_bytes() + p->non_log_disk_size_bytes();
+    status.reclaimable_size_bytes = p->reclaimable_size_bytes();
+    auto ctp_stm = p->raft()->stm_manager()->get<cloud_topics::ctp_stm>();
     if (ctp_stm) {
         status.cloud_topic_max_gc_eligible_epoch
           = ctp_stm->estimate_inactive_epoch();
     }
     status.shard = ss::this_shard_id();
 
-    if (p.ntp().ns == model::kafka_namespace && p.started()) {
+    if (p->ntp().ns == model::kafka_namespace && p->started()) {
         // HWM cannot be reliably retrieved until raft has started
         status.high_watermark = model::offset_cast(
-          p.log()->from_log_offset(p.high_watermark()));
+          p->log()->from_log_offset(p->high_watermark()));
+        if (kafka_start_offset) {
+            status.log_start_offset = (*kafka_start_offset)(p);
+        }
     }
 
-    if (p.raft()->is_elected_leader()) {
-        const auto fms = p.raft()->get_follower_metrics();
+    if (p->raft()->is_elected_leader()) {
+        const auto fms = p->raft()->get_follower_metrics();
 
         status.followers_stats.emplace();
         status.under_replicated_replicas = 0;
@@ -1007,12 +1012,11 @@ struct shard_report {
       topics;
 };
 
-shard_report collect_shard_local_reports(partition_manager& pm) {
-    auto partitions = pm.partitions() | std::views::values;
-
+shard_report collect_shard_local_reports(
+  partition_manager& pm,
+  const std::optional<kafka_start_offset_provider>& kafka_start_offset) {
     shard_report report;
-
-    for (const auto& p : partitions) {
+    for (const auto& p : pm.partitions() | std::views::values) {
         const auto& ntp = p->ntp();
         auto it = report.topics.find(model::topic_namespace_view{ntp});
         if (it == report.topics.end()) {
@@ -1022,7 +1026,7 @@ shard_report collect_shard_local_reports(partition_manager& pm) {
                      chunked_vector<partition_status>{})
                    .first;
         }
-        it->second.push_back(build_partition_status(*p));
+        it->second.push_back(build_partition_status(p, kafka_start_offset));
     }
     return report;
 }
@@ -1043,7 +1047,10 @@ reports_acc_t reduce_reports_map(reports_acc_t acc, shard_report shard_report) {
 ss::future<chunked_vector<topic_status>>
 health_monitor_backend::collect_topic_status() {
     auto reports_map = co_await _partition_manager.map_reduce0(
-      [](partition_manager& pm) { return collect_shard_local_reports(pm); },
+      [&kafka_start_offset = _kafka_start_offset_provider](
+        partition_manager& pm) {
+          return collect_shard_local_reports(pm, kafka_start_offset);
+      },
       reports_acc_t{},
       &reduce_reports_map);
 

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -94,6 +94,10 @@ public:
     cluster::notification_id_type register_node_callback(health_node_cb_t cb);
     void unregister_node_callback(cluster::notification_id_type id);
 
+    void set_kafka_start_offset_provider(kafka_start_offset_provider p) {
+        _kafka_start_offset_provider = std::move(p);
+    }
+
     ss::future<result<std::optional<cluster::drain_status>>>
       get_node_drain_status(model::node_id, model::timeout_clock::time_point);
 
@@ -262,6 +266,8 @@ private:
     cluster::notification_id_type _next_callback_id{0};
 
     ssx::mutex _report_collection_mutex{"health_report_collection"};
+
+    std::optional<kafka_start_offset_provider> _kafka_start_offset_provider;
 
     friend struct health_report_accessor;
 };

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -219,7 +219,8 @@ fmt::iterator partition_status::format_to(fmt::iterator it) const {
       it,
       "{{id: {}, term: {}, leader_id: {}, revision_id: {}, size_bytes: {}, "
       "reclaimable_size_bytes: {}, under_replicated: {}, shard: {}, "
-      "followers_stats: {}, kafka_highwatermark: {}, ct_max_gc_epoch: {}}}",
+      "followers_stats: {}, kafka_highwatermark: {}, ct_max_gc_epoch: {}, "
+      "log_start_offset: {}}}",
       id,
       term,
       leader_id,
@@ -230,7 +231,8 @@ fmt::iterator partition_status::format_to(fmt::iterator it) const {
       shard,
       followers_stats,
       high_watermark,
-      cloud_topic_max_gc_eligible_epoch);
+      cloud_topic_max_gc_eligible_epoch,
+      log_start_offset);
 }
 
 topic_status& topic_status::operator=(const topic_status& rhs) {

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -31,9 +31,21 @@
 #include "utils/named_type.h"
 
 #include <seastar/core/chunked_fifo.hh>
+#include <seastar/util/noncopyable_function.hh>
+#include <seastar/core/shared_ptr.hh>
 #include <seastar/util/bool_class.hh>
 
 namespace cluster {
+
+class partition;
+
+/// Callback injected from the Kafka layer into health_monitor_backend to
+/// compute a partition replica's Kafka-space log start offset (first readable
+/// offset, accounting for cloud storage and start-offset overrides). cluster
+/// cannot depend on kafka/data, so the computation is supplied as a callback
+/// backed by kafka::replicated_partition.
+using kafka_start_offset_provider = ss::noncopyable_function<
+  kafka::offset(ss::lw_shared_ptr<partition>)>;
 
 inline constexpr ss::shard_id health_monitor_backend_shard = 0;
 /**
@@ -107,7 +119,7 @@ struct followers_stats
 };
 struct partition_status
   : serde::
-      envelope<partition_status, serde::version<6>, serde::compat_version<0>> {
+      envelope<partition_status, serde::version<7>, serde::compat_version<0>> {
     static constexpr size_t invalid_size_bytes = size_t(-1);
     static constexpr uint32_t invalid_shard_id = uint32_t(-1);
 
@@ -155,6 +167,13 @@ struct partition_status
      */
     std::optional<int64_t> cloud_topic_max_gc_eligible_epoch;
 
+    /**
+     * Kafka log start offset (first readable offset) for this partition
+     * replica. Only populated for Kafka namespace partitions. std::nullopt
+     * when reported by nodes running an older version.
+     */
+    std::optional<kafka::offset> log_start_offset;
+
     auto serde_fields() {
         return std::tie(
           id,
@@ -167,7 +186,8 @@ struct partition_status
           shard,
           followers_stats,
           high_watermark,
-          cloud_topic_max_gc_eligible_epoch);
+          cloud_topic_max_gc_eligible_epoch,
+          log_start_offset);
     }
 
     fmt::iterator format_to(fmt::iterator it) const;

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -397,12 +397,63 @@ SEASTAR_THREAD_TEST_CASE(partition_status_serialiaztion_test) {
       .leader_id = model::node_id(123),
       .revision_id = model::revision_id(1024),
       .size_bytes = 4096,
+      .high_watermark = kafka::offset(500),
+      .log_start_offset = kafka::offset(100),
     };
     auto original = status;
 
     auto result = serialize_roundtrip_rpc(std::move(status));
 
     BOOST_CHECK(result == original);
+}
+
+// Verify that partition_status v6 data (without log_start_offset) is safely
+// decoded by the current v7 reader, leaving log_start_offset as nullopt.
+SEASTAR_THREAD_TEST_CASE(partition_status_v7_log_start_offset_compat_test) {
+    struct partition_status_v6
+      : serde::envelope<
+          partition_status_v6,
+          serde::version<6>,
+          serde::compat_version<0>> {
+        model::partition_id id;
+        model::term_id term;
+        std::optional<model::node_id> leader_id;
+        model::revision_id revision_id;
+        size_t size_bytes{0};
+        std::optional<uint8_t> under_replicated_replicas;
+        std::optional<size_t> reclaimable_size_bytes;
+        uint32_t shard{0};
+        std::optional<cluster::followers_stats> followers_stats;
+        kafka::offset high_watermark{42};
+        std::optional<int64_t> cloud_topic_max_gc_eligible_epoch;
+
+        auto serde_fields() {
+            return std::tie(
+              id,
+              term,
+              leader_id,
+              revision_id,
+              size_bytes,
+              under_replicated_replicas,
+              reclaimable_size_bytes,
+              shard,
+              followers_stats,
+              high_watermark,
+              cloud_topic_max_gc_eligible_epoch);
+        }
+    };
+
+    partition_status_v6 old{};
+    old.id = model::partition_id(1);
+    old.term = model::term_id(2);
+    old.high_watermark = kafka::offset(100);
+
+    auto buf = serde::to_iobuf(std::move(old));
+    auto result = serde::from_iobuf<cluster::partition_status>(buf.copy());
+
+    BOOST_CHECK_EQUAL(result.id, model::partition_id(1));
+    BOOST_CHECK_EQUAL(result.high_watermark, kafka::offset(100));
+    BOOST_CHECK(!result.log_start_offset.has_value());
 }
 
 struct partition_status_v0 {

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -2355,11 +2355,16 @@ ss::future<> group_manager::collect_consumer_lag_metrics() {
         co_return;
     }
 
-    static constexpr auto find_partition_hwm =
+    struct lag_bounds {
+        std::optional<kafka::offset> high_watermark;
+        std::optional<kafka::offset> log_start_offset;
+    };
+
+    static constexpr auto find_lag_bounds =
       [](
         const cluster::cluster_health_report& response,
-        const model::topic_partition& tp) -> std::optional<kafka::offset> {
-        std::optional<kafka::offset> max_hwm;
+        const model::topic_partition& tp) -> lag_bounds {
+        lag_bounds max_bounds;
         for (const auto& report : response.node_reports) {
             const model::topic_namespace_view tn{
               model::kafka_namespace, tp.topic};
@@ -2371,23 +2376,35 @@ ss::future<> group_manager::collect_consumer_lag_metrics() {
             if (partition_it == topic_it->second.end()) {
                 continue;
             }
-            auto hwm = partition_it->second.high_watermark;
-            if (!max_hwm || hwm > *max_hwm) {
-                max_hwm = hwm;
+            const auto& ps = partition_it->second;
+            if (
+              !max_bounds.high_watermark
+              || ps.high_watermark > *max_bounds.high_watermark) {
+                max_bounds.high_watermark = ps.high_watermark;
+                max_bounds.log_start_offset = ps.log_start_offset;
             }
         }
-        return max_hwm;
+        return max_bounds;
     };
 
     const auto set_metrics = [&report_r](const group_manager& gm) {
         for (const auto& group : gm._groups | std::views::values) {
             consumer_lag_metrics lag_metrics{};
             for (const auto& [tp, group_topic_offsets] : group->offsets()) {
-                if (auto hwm = find_partition_hwm(report_r.value(), tp); hwm) {
+                auto [hwm, lso] = find_lag_bounds(report_r.value(), tp);
+                if (hwm) {
                     auto committed_offset = offset_cast(
                       group_topic_offsets->metadata.offset);
+                    // Clamp committed_offset up to log_start_offset when
+                    // known: a stale commit below log_start_offset means no
+                    // consumable backlog exists and should not inflate lag.
+                    // log_start_offset is nullopt for reports from older nodes
+                    // — fall back to the pre-fix behaviour in that case.
+                    auto effective_committed = lso ? std::max(
+                                                       committed_offset, *lso)
+                                                   : committed_offset;
                     lag part_lag{static_cast<lag>(
-                      std::max(*hwm - committed_offset, offset{0}))};
+                      std::max(*hwm - effective_committed, offset{0}))};
                     lag_metrics.sum += part_lag;
                     lag_metrics.max = std::max(lag_metrics.max, part_lag);
                 }

--- a/src/v/redpanda/BUILD
+++ b/src/v/redpanda/BUILD
@@ -88,6 +88,7 @@ redpanda_cc_library(
         "//src/v/finjector",
         "//src/v/kafka/client",
         "//src/v/kafka/client:configuration",
+        "//src/v/kafka/data:partition_proxy",
         "//src/v/kafka/data/rpc",
         "//src/v/kafka/server",
         "//src/v/kafka/server:app",

--- a/src/v/redpanda/application_start.cc
+++ b/src/v/redpanda/application_start.cc
@@ -20,6 +20,7 @@
 #include "cluster/cloud_metadata/offsets_upload_router.h"
 #include "cluster/cluster_discovery.h"
 #include "cluster/controller.h"
+#include "cluster/health_monitor_backend.h"
 #include "cluster/feature_manager.h"
 #include "cluster/id_allocator_stm.h"
 #include "cluster/log_eviction_stm.h"
@@ -36,6 +37,7 @@
 #include "datalake/coordinator/state_machine.h"
 #include "datalake/translation/state_machine.h"
 #include "debug_bundle/debug_bundle_service.h"
+#include "kafka/data/replicated_partition.h"
 #include "kafka/server/group_manager.h"
 #include "kafka/server/group_tx_tracker_stm.h"
 #include "kafka/server/quota_manager.h"
@@ -164,6 +166,18 @@ void application::start_runtime_services(
         _data_migrations_group_proxy,
         cloud_topics_app ? cloud_topics_app->get_state() : nullptr)
       .get();
+
+    // The Kafka start offset is computed by replicated_partition (kafka
+    // layer), which depends on cluster; health_monitor_backend lives in
+    // cluster and can't depend back on it. Inject the computation here,
+    // above both layers, to avoid the dependency cycle.
+    controller->get_health_monitor_backend()
+      .local()
+      .set_kafka_start_offset_provider(
+        [](ss::lw_shared_ptr<cluster::partition> p) -> kafka::offset {
+            kafka::replicated_partition rp{std::move(p)};
+            return model::offset_cast(rp.start_offset());
+        });
 
     if (archiver_manager.local_is_initialized()) {
         archiver_manager.invoke_on_all(&archival::archiver_manager::start)

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -1196,6 +1196,194 @@ class ConsumerGroupTest(RedpandaTest):
         for consumer in consumers:
             consumer.close()
 
+    @cluster(num_nodes=3)
+    def test_group_lag_metrics_with_retention(self):
+        """
+        Verify that consumer group lag metrics are not inflated when the
+        committed offset falls below the partition's log start offset due to
+        retention.  After trim-prefix advances log_start_offset past the
+        committed offset the lag gauges should report zero, not
+        hwm - committed_offset.
+        """
+        lag_collection_interval = 5
+        topic = "test-lag-retention"
+        group = "test-lag-retention-group"
+        partition = 0
+        msg_count = 1000
+        consume_count = 500
+
+        self.redpanda.set_cluster_config(
+            {
+                "enable_consumer_group_metrics": ["consumer_lag"],
+                "consumer_group_lag_collection_interval_sec": lag_collection_interval,
+            }
+        )
+
+        rpk = RpkTool(self.redpanda)
+
+        rpk.create_topic(topic, partitions=1, replicas=3)
+
+        producer = Producer({"bootstrap.servers": self.redpanda.brokers()})
+        for i in range(msg_count):
+            producer.produce(topic, value=f"msg-{i}")
+        producer.flush()
+
+        consumer = Consumer(
+            {
+                "bootstrap.servers": self.redpanda.brokers(),
+                "group.id": group,
+                "auto.offset.reset": "earliest",
+                "enable.auto.commit": False,
+            }
+        )
+        consumer.subscribe([topic])
+        consumed = consumer.consume(num_messages=consume_count, timeout=30)
+        assert len(consumed) == consume_count, (
+            f"Expected {consume_count} messages, got {len(consumed)}"
+        )
+        consumer.commit(asynchronous=False)
+        consumer.close()
+
+        def get_group_lag(metric_name) -> float | None:
+            samples = self.redpanda.metrics_samples(
+                [metric_name],
+                self.redpanda.started_nodes(),
+                MetricsEndpoint.PUBLIC_METRICS,
+            )
+            if samples is None:
+                return None
+            group_samples = (
+                samples[metric_name].label_filter({"redpanda_group": group}).samples
+            )
+            if not group_samples:
+                return None
+            return max(s.value for s in group_samples)
+
+        # Before trim-prefix: committed=500, hwm=1000, lag should be ~500.
+        # This confirms metrics are being collected before we apply the fix
+        # scenario, so the post-trim assertion is meaningful.
+        wait_until(
+            lambda: get_group_lag("redpanda_kafka_consumer_group_lag_max") is not None
+            and get_group_lag("redpanda_kafka_consumer_group_lag_max") > 0,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Expected lag_max > 0 after commit but before trim-prefix",
+        )
+
+        # Advance log_start_offset past all produced messages so the committed
+        # offset becomes stale: lag = max(hwm - max(committed, lso), 0) = 0.
+        rpk.trim_prefix(topic, msg_count, partitions=[partition])
+
+        # Wait for the metric to reflect the trim — up to two extra intervals.
+        wait_until(
+            lambda: get_group_lag("redpanda_kafka_consumer_group_lag_max") == 0
+            and get_group_lag("redpanda_kafka_consumer_group_lag_sum") == 0,
+            timeout_sec=lag_collection_interval * 2 + 30,
+            backoff_sec=lag_collection_interval,
+            err_msg=(
+                f"Expected lag_max=0 and lag_sum=0 after trim-prefix past "
+                f"committed offset, got lag_max="
+                f"{get_group_lag('redpanda_kafka_consumer_group_lag_max')}, "
+                f"lag_sum="
+                f"{get_group_lag('redpanda_kafka_consumer_group_lag_sum')}"
+            ),
+        )
+
+    @cluster(num_nodes=3)
+    def test_group_lag_metrics_partial_retention(self):
+        """
+        Verify that when retention advances log_start_offset past the committed
+        offset but readable data still remains (log_start_offset < hwm), the lag
+        reflects the readable backlog (hwm - log_start_offset) rather than the
+        stale hwm - committed_offset or a fully-clamped zero.
+
+        This is the case that distinguishes the fix from a clamp-everything-to-
+        zero bug: trim-prefix lands between the committed offset and the hwm.
+        """
+        lag_collection_interval = 5
+        topic = "test-lag-partial-retention"
+        group = "test-lag-partial-retention-group"
+        partition = 0
+        msg_count = 1000
+        consume_count = 500
+        trim_offset = 700
+
+        self.redpanda.set_cluster_config(
+            {
+                "enable_consumer_group_metrics": ["consumer_lag"],
+                "consumer_group_lag_collection_interval_sec": lag_collection_interval,
+            }
+        )
+
+        rpk = RpkTool(self.redpanda)
+
+        rpk.create_topic(topic, partitions=1, replicas=3)
+
+        producer = Producer({"bootstrap.servers": self.redpanda.brokers()})
+        for i in range(msg_count):
+            producer.produce(topic, value=f"msg-{i}")
+        producer.flush()
+
+        consumer = Consumer(
+            {
+                "bootstrap.servers": self.redpanda.brokers(),
+                "group.id": group,
+                "auto.offset.reset": "earliest",
+                "enable.auto.commit": False,
+            }
+        )
+        consumer.subscribe([topic])
+        consumed = consumer.consume(num_messages=consume_count, timeout=30)
+        assert len(consumed) == consume_count, (
+            f"Expected {consume_count} messages, got {len(consumed)}"
+        )
+        consumer.commit(asynchronous=False)
+        consumer.close()
+
+        def get_group_lag(metric_name) -> float | None:
+            samples = self.redpanda.metrics_samples(
+                [metric_name],
+                self.redpanda.started_nodes(),
+                MetricsEndpoint.PUBLIC_METRICS,
+            )
+            if samples is None:
+                return None
+            group_samples = (
+                samples[metric_name].label_filter({"redpanda_group": group}).samples
+            )
+            if not group_samples:
+                return None
+            return max(s.value for s in group_samples)
+
+        # Trim-prefix to an offset between the committed offset (500) and the
+        # hwm (1000). The committed offset is now stale, but data in
+        # [trim_offset, hwm) is still consumable.
+        responses = rpk.trim_prefix(topic, trim_offset, partitions=[partition])
+        assert len(responses) == 1, f"Expected 1 trim response, got {responses}"
+        new_start_offset = responses[0].new_start_offset
+        assert new_start_offset == trim_offset, (
+            f"Expected new start offset {trim_offset}, got {new_start_offset}"
+        )
+
+        # lag = max(hwm - max(committed, log_start_offset), 0)
+        #     = max(1000 - max(500, 700), 0) = 300
+        expected_lag = msg_count - new_start_offset
+
+        wait_until(
+            lambda: get_group_lag("redpanda_kafka_consumer_group_lag_max")
+            == expected_lag
+            and get_group_lag("redpanda_kafka_consumer_group_lag_sum") == expected_lag,
+            timeout_sec=lag_collection_interval * 2 + 30,
+            backoff_sec=lag_collection_interval,
+            err_msg=(
+                f"Expected lag_max={expected_lag} and lag_sum={expected_lag} "
+                f"after partial trim-prefix, got lag_max="
+                f"{get_group_lag('redpanda_kafka_consumer_group_lag_max')}, "
+                f"lag_sum="
+                f"{get_group_lag('redpanda_kafka_consumer_group_lag_sum')}"
+            ),
+        )
+
 
 class TestConsumer:
     def __init__(


### PR DESCRIPTION
## Fix consumer group lag inflated by log truncation

### Problem

`redpanda_kafka_consumer_group_lag_{max,sum}` overstates backlog after trim-prefix or aggressive retention. When a group's committed offset falls below the partition's log start offset, lag is reported as `hwm - committed_offset` instead of `0` — counting records that no longer exist.

### Fix

Carry `log_start_offset` alongside `high_watermark` in `cluster_health_report`, and clamp `effective_committed = max(committed, log_start_offset)` before computing lag. When `log_start_offset` is absent (older node), fall back to the previous behaviour.

Covered by two ducktape tests:
- `test_group_lag_metrics_with_retention` — trim past the committed offset (`lso == hwm`): lag drops to 0.
- `test_group_lag_metrics_partial_retention` — trim between committed and hwm: lag reflects the readable backlog `hwm - lso`.

### Why the Kafka offset is injected via a callback

`log_start_offset` is a **Kafka-space** offset computed by `kafka::replicated_partition`, but `health_monitor_backend` (which builds the report) can't call it directly — it would create a build cycle.

`cluster::partition` and `health_monitor_backend` share the target `//src/v/cluster:cluster`, and `replicated_partition` (kafka layer) already depends on it:

```
   //src/v/cluster:cluster ──────────────► //src/v/kafka/data:partition_proxy
            ▲   (edge we'd need)                  │   (replicated_partition)
            └──────────────  already exists  ◄────┘
                          ⟲  CYCLE
```

Breaking the cycle would require splitting `cluster::partition` out of the mega-target (it pulls in most of the cluster STM layer) or lifting `health_monitor_backend` above it (used by `controller`, `leader_balancer`, `feature_manager`, ...) — both large refactors.

**Solution — dependency inversion:** `cluster` declares a `kafka_start_offset_provider` callback type; `application` (above both layers) registers an implementation backed by `replicated_partition`:

```
  application  ──set_kafka_start_offset_provider([](p){ return replicated_partition{p}.start_offset(); })
      │
      ├─► cluster:      declares the callback type + health_monitor_backend calls it
      └─► kafka/data:   provides replicated_partition (the actual computation)
```

All edges stay one-directional (`kafka → cluster`, `application → both`). `log_start_offset` is left `nullopt` until the provider is registered (and for non-kafka partitions); `high_watermark` is still translated inline, so it is unaffected.

### Commits
- `cluster/health: add log_start_offset to partition_status` — serde v6→7 field + the provider seam.
- `kafka/group_manager: fix consumer group lag inflated by log truncation` — the lag clamp + tests.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
