### PR TITLE
delta_for: Hoist end() out of the loop check

### DIFF
--- a/src/v/utils/delta_for.h
+++ b/src/v/utils/delta_for.h
@@ -1006,12 +1006,13 @@ private:
     template<class PredT>
     const_iterator pred_search(value_t value) const {
         PredT pred;
-        for (auto it = begin(); it != end(); ++it) {
+        auto end_it = end();
+        for (auto it = begin(); it != end_it; ++it) {
             if (pred(*it, value)) {
                 return it;
             }
         }
-        return end();
+        return end_it;
     }
 
     std::array<value_t, buffer_depth> _head{};
@@ -1509,12 +1510,13 @@ public:
     /// Find first value that matches the predicate
     const_iterator pred_search(
       value_t value, std::regular_invocable<value_t, value_t> auto pred) const {
-        for (auto it = this->begin(); it != this->end(); ++it) {
+        auto end_it = this->end();
+        for (auto it = this->begin(); it != end_it; ++it) {
             if (pred(*it, value)) {
                 return it;
             }
         }
-        return this->end();
+        return end_it;
     }
 };
 
@@ -1556,14 +1558,15 @@ public:
             }
             index += it->size();
         }
+        auto end_it = this->end();
         if (it != this->_frames.end()) {
             auto start = const_iterator(it, this->_frames.end(), 0, index);
-            for (; start != this->end(); ++start) {
+            for (; start != end_it; ++start) {
                 if (pred(*start, value)) {
                     return start;
                 }
             }
         }
-        return this->end();
+        return end_it;
     }
 };

--- a/src/v/utils/tests/delta_for_bench.cc
+++ b/src/v/utils/tests/delta_for_bench.cc
@@ -132,11 +132,16 @@ void append_tx_test(StoreT& store, int test_scale) {
 }
 
 template<class StoreT>
-void find_test(StoreT& store) {
+size_t find_test(StoreT& store) {
+    constexpr size_t batch = 10;
+    auto target = *store.last_value();
     perf_tests::start_measuring_time();
-    auto it = store.find(*store.last_value());
-    perf_tests::do_not_optimize(it);
+    for (size_t i = 0; i < batch; i++) {
+        auto it = store.find(target);
+        perf_tests::do_not_optimize(it);
+    }
     perf_tests::stop_measuring_time();
+    return batch;
 }
 
 template<class StoreT>
@@ -173,9 +178,11 @@ PERF_TEST(deltafor_bench, xor_column_append_tx2) {
     append_tx_test(column, 4097);
 }
 
-PERF_TEST(deltafor_bench, xor_frame_find_4K) { find_test(xor_frame_4K); }
+PERF_TEST(deltafor_bench, xor_frame_find_4K) { return find_test(xor_frame_4K); }
 
-PERF_TEST(deltafor_bench, xor_column_find_4K) { find_test(xor_column_4K); }
+PERF_TEST(deltafor_bench, xor_column_find_4K) {
+    return find_test(xor_column_4K);
+}
 
 PERF_TEST(deltafor_bench, xor_frame_at_4K) { at_test(xor_frame_4K); }
 
@@ -209,9 +216,13 @@ PERF_TEST(deltafor_bench, delta_column_append_tx2) {
     append_tx_test(column, 4097);
 }
 
-PERF_TEST(deltafor_bench, delta_frame_find_4K) { find_test(delta_frame_4K); }
+PERF_TEST(deltafor_bench, delta_frame_find_4K) {
+    return find_test(delta_frame_4K);
+}
 
-PERF_TEST(deltafor_bench, delta_column_find_4K) { find_test(delta_column_4K); }
+PERF_TEST(deltafor_bench, delta_column_find_4K) {
+    return find_test(delta_column_4K);
+}
 
 PERF_TEST(deltafor_bench, delta_column_find_4M) { at_test(delta_column_4M); }
 


### PR DESCRIPTION
Avoid rebuilding the default end iterator on every scanned element.

end() didn't get optimized out and it's not entirely free in this
iterator's case. Hoise it out manually.

Possibly this addresses some noise we are seeing.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes


* none
