### PR TITLE
Iceberg header translation

### DIFF
--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -275,6 +275,7 @@ redpanda_cc_library(
         "//src/v/iceberg:schema",
         "//src/v/iceberg:values",
         "//src/v/model",
+        "//src/v/strings:utf8",
         "@seastar",
     ],
 )

--- a/src/v/datalake/catalog_schema_manager.h
+++ b/src/v/datalake/catalog_schema_manager.h
@@ -111,7 +111,7 @@ public:
     // Ensure the table schema is compatible with the writer struct. If the
     // table does not exist it is created, or, if the table exists and its
     // current schema doesn't include all of the fields (e.g. we are going from
-    // the schemaless schema to a schema containing user fields), the table's
+    // a key-value schema to a schema containing user fields), the table's
     // schema is updated to be compatible with the writer_struct.
     ss::future<checked<std::nullopt_t, schema_manager::errc>>
     ensure_table_schema(

--- a/src/v/datalake/coordinator/coordinator.cc
+++ b/src/v/datalake/coordinator/coordinator.cc
@@ -279,7 +279,8 @@ struct coordinator::table_schema_provider {
     get_table_id(const model::topic&) const = 0;
 
     virtual ss::future<checked<iceberg::struct_type, coordinator::errc>>
-      get_record_type(record_schema_components) const = 0;
+    get_record_type(
+      const cluster::topic_metadata&, record_schema_components) const = 0;
 
     virtual ss::sstring
     get_partition_spec(const cluster::topic_metadata&) const = 0;
@@ -375,7 +376,7 @@ coordinator::do_ensure_table_exists(
 
     auto table_id = schema_provider.get_table_id(topic);
     auto record_type = co_await schema_provider.get_record_type(
-      std::move(comps));
+      topic_md->get(), std::move(comps));
     if (!record_type.has_value()) {
         vlog(
           datalake_log.warn,
@@ -418,7 +419,9 @@ struct coordinator::main_table_schema_provider
     }
 
     ss::future<checked<iceberg::struct_type, coordinator::errc>>
-    get_record_type(record_schema_components comps) const final {
+    get_record_type(
+      const cluster::topic_metadata& topic_md,
+      record_schema_components comps) const final {
         std::optional<shared_resolved_type_t> val_type;
         if (comps.val_identifier) {
             auto type_res = co_await parent.type_resolver_.resolve_identifier(
@@ -429,7 +432,12 @@ struct coordinator::main_table_schema_provider
             val_type = std::move(type_res.value());
         }
 
-        auto record_type = default_translator{}.build_type(std::move(val_type));
+        const auto& mode = topic_md.get_configuration().properties.iceberg_mode;
+        if (mode.is_disabled()) {
+            co_return errc::failed;
+        }
+        auto record_type = default_translator{mode.headers()}.build_type(
+          std::move(val_type));
         co_return std::move(record_type.type);
     }
 
@@ -492,8 +500,16 @@ struct coordinator::dlq_table_schema_provider
     }
 
     ss::future<checked<iceberg::struct_type, coordinator::errc>>
-    get_record_type(record_schema_components) const final {
-        co_return key_value_translator{}.build_type(std::nullopt).type;
+    get_record_type(
+      const cluster::topic_metadata& topic_md,
+      record_schema_components) const final {
+        const auto& mode = topic_md.get_configuration().properties.iceberg_mode;
+        if (mode.is_disabled()) {
+            co_return errc::failed;
+        }
+        co_return key_value_translator{mode.headers()}
+          .build_type(std::nullopt)
+          .type;
     }
 
     ss::sstring get_partition_spec(const cluster::topic_metadata&) const final {

--- a/src/v/datalake/coordinator/tests/coordinator_test.cc
+++ b/src/v/datalake/coordinator/tests/coordinator_test.cc
@@ -254,6 +254,7 @@ public:
       const model::topic& topic, model::revision_id rev) {
         auto topic_cfg = cluster::topic_configuration(
           model::kafka_namespace, topic, 1, 1);
+        topic_cfg.properties.iceberg_mode = model::iceberg_mode::key_value;
         for (auto& crd : crds) {
             auto tt_res = crd->topic_table
                             .apply(

--- a/src/v/datalake/coordinator/tests/iceberg_file_committer_test.cc
+++ b/src/v/datalake/coordinator/tests/iceberg_file_committer_test.cc
@@ -115,7 +115,7 @@ public:
         auto res = schema_mgr
                      .ensure_table_schema(
                        table_ident,
-                       datalake::rp_base_struct_type(),
+                       datalake::rp_base_struct_type({}),
                        datalake::hour_partition_spec(),
                        iceberg::field_name_comparison::verbatim)
                      .get();
@@ -701,7 +701,7 @@ TEST_F(FileCommitterTest, TestDontLoadMainTable) {
     auto create_res = schema_mgr
                         .ensure_table_schema(
                           datalake::table_id_provider::dlq_table_id(topic),
-                          datalake::rp_base_struct_type(),
+                          datalake::rp_base_struct_type({}),
                           datalake::hour_partition_spec(),
                           iceberg::field_name_comparison::verbatim)
                         .get();

--- a/src/v/datalake/coordinator/tests/iceberg_file_committer_test.cc
+++ b/src/v/datalake/coordinator/tests/iceberg_file_committer_test.cc
@@ -115,7 +115,7 @@ public:
         auto res = schema_mgr
                      .ensure_table_schema(
                        table_ident,
-                       datalake::schemaless_struct_type(),
+                       datalake::rp_base_struct_type(),
                        datalake::hour_partition_spec(),
                        iceberg::field_name_comparison::verbatim)
                      .get();
@@ -701,7 +701,7 @@ TEST_F(FileCommitterTest, TestDontLoadMainTable) {
     auto create_res = schema_mgr
                         .ensure_table_schema(
                           datalake::table_id_provider::dlq_table_id(topic),
-                          datalake::schemaless_struct_type(),
+                          datalake::rp_base_struct_type(),
                           datalake::hour_partition_spec(),
                           iceberg::field_name_comparison::verbatim)
                         .get();

--- a/src/v/datalake/coordinator/tests/iceberg_snapshot_remover_test.cc
+++ b/src/v/datalake/coordinator/tests/iceberg_snapshot_remover_test.cc
@@ -67,7 +67,7 @@ public:
     ss::future<> create_table(const iceberg::table_identifier& table_id) {
         auto res = co_await catalog.load_or_create_table(
           table_id,
-          datalake::rp_base_struct_type(),
+          datalake::rp_base_struct_type({}),
           datalake::hour_partition_spec());
         ASSERT_FALSE_CORO(res.has_error());
     }

--- a/src/v/datalake/coordinator/tests/iceberg_snapshot_remover_test.cc
+++ b/src/v/datalake/coordinator/tests/iceberg_snapshot_remover_test.cc
@@ -67,7 +67,7 @@ public:
     ss::future<> create_table(const iceberg::table_identifier& table_id) {
         auto res = co_await catalog.load_or_create_table(
           table_id,
-          datalake::schemaless_struct_type(),
+          datalake::rp_base_struct_type(),
           datalake::hour_partition_spec());
         ASSERT_FALSE_CORO(res.has_error());
     }

--- a/src/v/datalake/coordinator/tests/state_machine_test.cc
+++ b/src/v/datalake/coordinator/tests/state_machine_test.cc
@@ -167,6 +167,7 @@ struct coordinator_stm_fixture : stm_raft_fixture<stm> {
     ss::future<> register_in_topic_table() {
         auto topic_cfg = cluster::topic_configuration(
           tp_ns.ns, tp_ns.tp, /*partition_count=*/1, /*replication_factor=*/1);
+        topic_cfg.properties.iceberg_mode = model::iceberg_mode::key_value;
         auto tt_res = co_await topic_table.apply(
           cluster::create_topic_cmd{tp_ns, {topic_cfg, {}}},
           model::offset{rev()});

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -81,10 +81,10 @@ make_record_translator(const model::iceberg_mode& mode) {
       "Cannot make record translator when iceberg is disabled, logic bug.");
     switch (mode.value().mode) {
     case model::iceberg_mode::schema_mode::binary:
-        return std::make_unique<key_value_translator>();
+        return std::make_unique<key_value_translator>(mode.headers());
     case model::iceberg_mode::schema_mode::schema_id_prefix:
     case model::iceberg_mode::schema_mode::schema_latest:
-        return std::make_unique<structured_data_translator>();
+        return std::make_unique<structured_data_translator>(mode.headers());
     }
 }
 } // namespace

--- a/src/v/datalake/partitioning_writer.h
+++ b/src/v/datalake/partitioning_writer.h
@@ -27,8 +27,8 @@ namespace datalake {
 // are partitioned by an Iceberg partition key.
 //
 // Uses the default partition spec to partition. As such, this class expects
-// that schemas and values given as inputs are constructed with the default
-// ("schemaless") schema and fields at the front.
+// that schemas and values given as inputs are constructed with the base
+// redpanda system fields at the front.
 class partitioning_writer {
 public:
     explicit partitioning_writer(

--- a/src/v/datalake/record_translator.cc
+++ b/src/v/datalake/record_translator.cc
@@ -111,7 +111,7 @@ default_translator::translate_data(
 
 record_type
 key_value_translator::build_type(std::optional<shared_resolved_type_t>) {
-    auto ret_type = rp_base_struct_type();
+    auto ret_type = rp_base_struct_type(_headers_cfg);
     ret_type.fields.emplace_back(
       iceberg::nested_field::create(
         rp_base_next_field_id,
@@ -146,7 +146,7 @@ key_value_translator::translate_data(
     auto ret_data = iceberg::struct_value{};
 
     auto system_data = build_rp_struct(
-      pid, o, std::move(key), ts, ts_t, headers);
+      pid, o, std::move(key), ts, ts_t, headers, _headers_cfg);
     ret_data.fields.emplace_back(std::move(system_data));
     ret_data.fields.emplace_back(
       parsable_val ? std::make_optional<iceberg::value>(
@@ -157,7 +157,7 @@ key_value_translator::translate_data(
 
 record_type structured_data_translator::build_type(
   std::optional<shared_resolved_type_t> val_type) {
-    auto ret_type = rp_base_struct_type();
+    auto ret_type = rp_base_struct_type(_headers_cfg);
     std::optional<schema_identifier> val_id;
     if (val_type.has_value()) {
         val_id = val_type.value()->id;
@@ -236,7 +236,7 @@ structured_data_translator::translate_data(
     }
     auto ret_data = iceberg::struct_value{};
     auto system_data = build_rp_struct(
-      pid, o, std::move(key), ts, ts_t, headers);
+      pid, o, std::move(key), ts, ts_t, headers, _headers_cfg);
     // Fill in the internal value field.
     ret_data.fields.emplace_back(std::move(system_data));
 

--- a/src/v/datalake/record_translator.cc
+++ b/src/v/datalake/record_translator.cc
@@ -111,10 +111,10 @@ default_translator::translate_data(
 
 record_type
 key_value_translator::build_type(std::optional<shared_resolved_type_t>) {
-    auto ret_type = schemaless_struct_type();
+    auto ret_type = rp_base_struct_type();
     ret_type.fields.emplace_back(
       iceberg::nested_field::create(
-        schemaless_next_field_id,
+        rp_base_next_field_id,
         "value",
         iceberg::field_required::no,
         iceberg::binary_type{}));
@@ -157,7 +157,7 @@ key_value_translator::translate_data(
 
 record_type structured_data_translator::build_type(
   std::optional<shared_resolved_type_t> val_type) {
-    auto ret_type = schemaless_struct_type();
+    auto ret_type = rp_base_struct_type();
     std::optional<schema_identifier> val_id;
     if (val_type.has_value()) {
         val_id = val_type.value()->id;
@@ -195,7 +195,7 @@ record_type structured_data_translator::build_type(
                 // Use the next id of the system defaults.
                 system_fields.fields.emplace_back(
                   iceberg::nested_field::create(
-                    schemaless_next_field_id,
+                    rp_base_next_field_id,
                     "data",
                     field->required,
                     std::move(field->type)));

--- a/src/v/datalake/record_translator.h
+++ b/src/v/datalake/record_translator.h
@@ -15,6 +15,7 @@
 #include "datalake/schema_identifier.h"
 #include "iceberg/datatypes.h"
 #include "iceberg/values.h"
+#include "model/metadata.h"
 #include "model/record.h"
 #include "model/timestamp.h"
 
@@ -60,6 +61,9 @@ public:
 
 class key_value_translator : public record_translator {
 public:
+    explicit key_value_translator(
+      model::iceberg_mode::headers_config headers_cfg = {})
+      : _headers_cfg(headers_cfg) {}
     record_type
     build_type(std::optional<shared_resolved_type_t> val_type) override;
     ss::future<checked<iceberg::struct_value, errc>> translate_data(
@@ -72,10 +76,16 @@ public:
       model::timestamp_type ts_t,
       const chunked_vector<model::record_header>& headers) override;
     ~key_value_translator() override = default;
+
+private:
+    model::iceberg_mode::headers_config _headers_cfg;
 };
 
 class structured_data_translator : public record_translator {
 public:
+    explicit structured_data_translator(
+      model::iceberg_mode::headers_config headers_cfg = {})
+      : _headers_cfg(headers_cfg) {}
     record_type
     build_type(std::optional<shared_resolved_type_t> val_type) override;
     ss::future<checked<iceberg::struct_value, errc>> translate_data(
@@ -88,6 +98,9 @@ public:
       model::timestamp_type ts_t,
       const chunked_vector<model::record_header>& headers) override;
     ~structured_data_translator() override = default;
+
+private:
+    model::iceberg_mode::headers_config _headers_cfg;
 };
 
 // Switches between key-value and structured translator, depending on if there
@@ -96,6 +109,10 @@ public:
 // mode with a topic config! Instead, callers should explicitly choose.
 class default_translator : public record_translator {
 public:
+    explicit default_translator(
+      model::iceberg_mode::headers_config headers_cfg = {})
+      : kv_translator(headers_cfg)
+      , structured_translator(headers_cfg) {}
     record_type
     build_type(std::optional<shared_resolved_type_t> val_type) override;
     ss::future<checked<iceberg::struct_value, errc>> translate_data(

--- a/src/v/datalake/table_definition.cc
+++ b/src/v/datalake/table_definition.cc
@@ -9,29 +9,58 @@
  */
 #include "datalake/table_definition.h"
 
+#include "strings/utf8.h"
+
 namespace datalake {
 
-iceberg::struct_type rp_base_struct_type() { return rp_base_desc::build(); }
+iceberg::struct_type
+rp_base_struct_type(model::iceberg_mode::headers_config headers_cfg) {
+    auto st = rp_base_desc::build();
+    using hsm = model::iceberg_mode::header_schema_mode;
+    switch (headers_cfg.value_type) {
+    case hsm::binary:
+        break;
+    case hsm::string: {
+        auto& list = std::get<iceberg::list_type>(
+          type_field<rp_desc, "headers">(rp_struct_type(st)).type);
+        type_field<header_kv_desc, "value">(
+          std::get<iceberg::struct_type>(list.element_field->type))
+          .type = iceberg::string_type{};
+        break;
+    }
+    }
+    return st;
+}
 
 namespace {
 
-std::optional<iceberg::value>
-build_headers_value(const chunked_vector<model::record_header>& headers) {
+std::optional<iceberg::value> build_headers_value(
+  const chunked_vector<model::record_header>& headers,
+  model::iceberg_mode::headers_config cfg) {
     if (headers.empty()) {
         return std::nullopt;
     }
+    using hsm = model::iceberg_mode::header_schema_mode;
     auto hdr_list = std::make_unique<iceberg::list_value>();
     for (const auto& hdr : headers) {
-        auto kv = header_kv_desc::build_value(
-          val<"key">(
-            hdr.key_size() >= 0 ? std::make_optional<iceberg::value>(
-                                    iceberg::string_value(hdr.key().copy()))
-                                : std::nullopt),
-          val<"value">(
-            hdr.value_size() >= 0 ? std::make_optional<iceberg::value>(
-                                      iceberg::binary_value(hdr.value().copy()))
-                                  : std::nullopt));
-        hdr_list->elements.emplace_back(std::move(kv));
+        auto key_val = hdr.key_size() >= 0
+                         ? std::make_optional<iceberg::value>(
+                             iceberg::string_value{hdr.key().copy()})
+                         : std::nullopt;
+        std::optional<iceberg::value> hdr_val;
+        if (cfg.value_type == hsm::string) {
+            if (hdr.value_size() >= 0) {
+                hdr_val = iceberg::string_value{
+                  utf8_sanitize(hdr.value().copy())};
+            }
+        } else {
+            if (hdr.value_size() >= 0) {
+                hdr_val = iceberg::binary_value{hdr.value().copy()};
+            }
+        }
+        hdr_list->elements.emplace_back(
+          header_kv_desc::build_value(
+            val<"key">(std::move(key_val)), val<"value">(std::move(hdr_val))));
     }
     return hdr_list;
 }
@@ -44,16 +73,18 @@ std::unique_ptr<iceberg::struct_value> build_rp_struct(
   std::optional<iobuf> key,
   model::timestamp ts,
   model::timestamp_type ts_t,
-  const chunked_vector<model::record_header>& headers) {
+  const chunked_vector<model::record_header>& headers,
+  model::iceberg_mode::headers_config cfg) {
+    auto headers_val = build_headers_value(headers, cfg);
+    auto key_val = key ? std::make_optional<iceberg::value>(
+                           iceberg::binary_value{std::move(*key)})
+                       : std::nullopt;
     return rp_desc::build_value(
       val<"partition">(iceberg::int_value(pid)),
       val<"offset">(iceberg::long_value(o)),
       val<"timestamp">(iceberg::timestamptz_value(ts.value() * 1000)),
-      val<"headers">(build_headers_value(headers)),
-      val<"key">(
-        key ? std::make_optional<iceberg::value>(
-                iceberg::binary_value(std::move(*key)))
-            : std::nullopt),
+      val<"headers">(std::move(headers_val)),
+      val<"key">(std::move(key_val)),
       val<"timestamp_type">(iceberg::int_value{static_cast<int32_t>(ts_t)}));
 }
 

--- a/src/v/datalake/table_definition.cc
+++ b/src/v/datalake/table_definition.cc
@@ -11,17 +11,7 @@
 
 namespace datalake {
 
-iceberg::struct_type schemaless_struct_type() {
-    return schemaless_desc::build();
-}
-
-iceberg::schema default_schema() {
-    return iceberg::schema{
-      .schema_struct = schemaless_struct_type(),
-      .schema_id = iceberg::schema::default_id,
-      .identifier_field_ids = {},
-    };
-}
+iceberg::struct_type rp_base_struct_type() { return rp_base_desc::build(); }
 
 namespace {
 

--- a/src/v/datalake/table_definition.h
+++ b/src/v/datalake/table_definition.h
@@ -10,8 +10,8 @@
 #pragma once
 
 #include "datalake/schema_descriptor.h"
-#include "iceberg/schema.h"
 #include "model/fundamental.h"
+#include "model/metadata.h"
 #include "model/record.h"
 #include "model/timestamp.h"
 
@@ -22,7 +22,8 @@ namespace datalake {
 //   - total_fields() / index_of<> field-index lookups
 //   - rp_base_next_field_id
 
-/// Canonical header key/value descriptor.
+/// Canonical header key/value descriptor (binary value — used for
+/// value construction; type is overridden at runtime when building the schema).
 using header_kv_desc = struct_desc<
   field_desc<"key", iceberg::string_type>,
   field_desc<"value", iceberg::binary_type>>;
@@ -46,9 +47,10 @@ inline constexpr std::string_view rp_struct_name = "redpanda";
 /// Translators that add fields should start IDs from here.
 inline const int rp_base_next_field_id = rp_base_desc::total_fields();
 
-/// Build the runtime base row struct_type. All translators start from this
-/// base and append their own value columns.
-iceberg::struct_type rp_base_struct_type();
+/// Build the base row struct_type, applying headers_config overrides
+/// (e.g. promote header values from binary to string).
+iceberg::struct_type
+rp_base_struct_type(model::iceberg_mode::headers_config headers_cfg);
 
 /// Build the redpanda system struct_value. Single definition used
 /// by all translators.
@@ -58,7 +60,8 @@ std::unique_ptr<iceberg::struct_value> build_rp_struct(
   std::optional<iobuf> key,
   model::timestamp ts,
   model::timestamp_type ts_t,
-  const chunked_vector<model::record_header>& headers);
+  const chunked_vector<model::record_header>& headers,
+  model::iceberg_mode::headers_config);
 
 /// Get the redpanda struct_type from a base row struct_type.
 inline iceberg::struct_type& rp_struct_type(iceberg::struct_type& row) {

--- a/src/v/datalake/table_definition.h
+++ b/src/v/datalake/table_definition.h
@@ -17,19 +17,17 @@
 
 namespace datalake {
 
-// The schema is defined once here as a type. All field ordering,
-// naming, and type information is derived from this single source.
-// Adding, removing, or reordering fields here automatically updates:
-//   - schemaless_struct_type() (runtime struct_type)
-//   - build_rp_struct() (runtime struct_value)
-//   - All typed field accessors
+// A single canonical descriptor set used for:
+//   - build_value() compile-time name/arity checking
+//   - total_fields() / index_of<> field-index lookups
+//   - rp_base_next_field_id
 
-/// Header key/value struct inside the headers list.
+/// Canonical header key/value descriptor.
 using header_kv_desc = struct_desc<
   field_desc<"key", iceberg::string_type>,
   field_desc<"value", iceberg::binary_type>>;
 
-/// The redpanda system struct.
+/// Canonical redpanda system struct descriptor.
 using rp_desc = struct_desc<
   field_desc<"partition", iceberg::int_type>,
   field_desc<"offset", iceberg::long_type>,
@@ -38,20 +36,19 @@ using rp_desc = struct_desc<
   field_desc<"key", iceberg::binary_type>,
   field_desc<"timestamp_type", iceberg::int_type>>;
 
-/// The top-level schemaless table struct.
-using schemaless_desc = struct_desc<field_desc<"redpanda", rp_desc>>;
+/// Canonical top-level base row descriptor: the "redpanda" system fields.
+/// Translators extend this by appending value/schema columns.
+using rp_base_desc = struct_desc<field_desc<"redpanda", rp_desc>>;
 
 inline constexpr std::string_view rp_struct_name = "redpanda";
 
-/// Next available pre-assignment field ID after the schemaless struct.
+/// Next available pre-assignment field ID after the base row descriptor.
 /// Translators that add fields should start IDs from here.
-inline const int schemaless_next_field_id = schemaless_desc::total_fields();
+inline const int rp_base_next_field_id = rp_base_desc::total_fields();
 
-/// Build the runtime struct_type from the compile-time descriptor.
-iceberg::struct_type schemaless_struct_type();
-
-/// Build the default iceberg schema.
-iceberg::schema default_schema();
+/// Build the runtime base row struct_type. All translators start from this
+/// base and append their own value columns.
+iceberg::struct_type rp_base_struct_type();
 
 /// Build the redpanda system struct_value. Single definition used
 /// by all translators.
@@ -63,16 +60,16 @@ std::unique_ptr<iceberg::struct_value> build_rp_struct(
   model::timestamp_type ts_t,
   const chunked_vector<model::record_header>& headers);
 
-/// Get the redpanda struct_type from a schemaless struct_type.
-inline iceberg::struct_type& rp_struct_type(iceberg::struct_type& schemaless) {
+/// Get the redpanda struct_type from a base row struct_type.
+inline iceberg::struct_type& rp_struct_type(iceberg::struct_type& row) {
     return std::get<iceberg::struct_type>(
-      type_field<schemaless_desc, "redpanda">(schemaless).type);
+      type_field<rp_base_desc, "redpanda">(row).type);
 }
 
 /// Get the redpanda struct_value from a data row.
 inline iceberg::struct_value& rp_struct_value(iceberg::struct_value& row) {
     return *std::get<std::unique_ptr<iceberg::struct_value>>(
-      value_field<schemaless_desc, "redpanda">(row).value());
+      value_field<rp_base_desc, "redpanda">(row).value());
 }
 
 } // namespace datalake

--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -432,6 +432,26 @@ redpanda_cc_btest(
 )
 
 redpanda_cc_gtest(
+    name = "table_definition_test",
+    timeout = "short",
+    srcs = [
+        "table_definition_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:iobuf_parser",
+        "//src/v/container:chunked_vector",
+        "//src/v/datalake:table_definition",
+        "//src/v/iceberg:datatypes",
+        "//src/v/iceberg:values",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "credential_manager_test",
     timeout = "short",
     srcs = [

--- a/src/v/datalake/tests/partitioning_writer_test.cc
+++ b/src/v/datalake/tests/partitioning_writer_test.cc
@@ -32,7 +32,7 @@ val_with_timestamp(const field_type& type, model::timestamp timestamp_ms) {
     return std::move(*std::get<std::unique_ptr<struct_value>>(val));
 }
 iceberg::struct_type default_type_with_columns(size_t extra_columns) {
-    auto type = rp_base_struct_type();
+    auto type = rp_base_struct_type({});
     for (size_t i = 0; i < extra_columns; ++i) {
         type.fields.emplace_back(
           nested_field::create(

--- a/src/v/datalake/tests/partitioning_writer_test.cc
+++ b/src/v/datalake/tests/partitioning_writer_test.cc
@@ -32,7 +32,7 @@ val_with_timestamp(const field_type& type, model::timestamp timestamp_ms) {
     return std::move(*std::get<std::unique_ptr<struct_value>>(val));
 }
 iceberg::struct_type default_type_with_columns(size_t extra_columns) {
-    auto type = schemaless_struct_type();
+    auto type = rp_base_struct_type();
     for (size_t i = 0; i < extra_columns; ++i) {
         type.fields.emplace_back(
           nested_field::create(

--- a/src/v/datalake/tests/table_definition_test.cc
+++ b/src/v/datalake/tests/table_definition_test.cc
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "bytes/iobuf.h"
+#include "bytes/iobuf_parser.h"
+#include "container/chunked_vector.h"
+#include "datalake/table_definition.h"
+#include "iceberg/datatypes.h"
+#include "iceberg/values.h"
+#include "model/record.h"
+
+#include <gtest/gtest.h>
+
+namespace datalake {
+namespace {
+
+using hsm = model::iceberg_mode::header_schema_mode;
+using headers_config = model::iceberg_mode::headers_config;
+
+// Build a model::record_header from plain string key and value.
+model::record_header
+make_header(std::string_view key, std::optional<std::string_view> value) {
+    iobuf key_buf;
+    key_buf.append(key.data(), key.size());
+    iobuf val_buf;
+    if (value) {
+        val_buf.append(value->data(), value->size());
+    }
+    return model::record_header{
+      static_cast<int32_t>(key.size()),
+      std::move(key_buf),
+      value ? static_cast<int32_t>(value->size()) : -1,
+      std::move(val_buf)};
+}
+
+// Extract the headers list value from an rp struct (as returned by
+// build_rp_struct). "headers" is at index 3 in rp_desc.
+const iceberg::list_value& get_headers_list(const iceberg::struct_value& rp) {
+    const auto& hdr_opt = rp.fields[3];
+    EXPECT_TRUE(hdr_opt.has_value());
+    return *std::get<std::unique_ptr<iceberg::list_value>>(*hdr_opt);
+}
+
+// Extract the header kv struct from a list element.
+const iceberg::struct_value&
+get_kv_struct(const iceberg::list_value& list, size_t idx) {
+    return *std::get<std::unique_ptr<iceberg::struct_value>>(
+      *list.elements[idx]);
+}
+
+// ---- rp_base_struct_type ------------------------------------------------
+
+TEST(RpBaseStructType, BinaryConfigProducesBinaryHeaderValueType) {
+    auto st = rp_base_struct_type({});
+    auto& rp_type = rp_struct_type(st);
+    // headers field is index 3
+    auto& hdr_field = *rp_type.fields[3];
+    auto& list_type = std::get<iceberg::list_type>(hdr_field.type);
+    auto& kv_type = std::get<iceberg::struct_type>(
+      list_type.element_field->type);
+    // value field is index 1 in kv struct.
+    // field_type = variant<primitive_type, struct_type, ...>; check both
+    // levels.
+    const auto& val_field_type = kv_type.fields[1]->type;
+    ASSERT_TRUE(
+      std::holds_alternative<iceberg::primitive_type>(val_field_type));
+    EXPECT_TRUE(
+      std::holds_alternative<iceberg::binary_type>(
+        std::get<iceberg::primitive_type>(val_field_type)));
+}
+
+TEST(RpBaseStructType, StringConfigProducesStringHeaderValueType) {
+    auto st = rp_base_struct_type({.value_type = hsm::string});
+    auto& rp_type = rp_struct_type(st);
+    auto& hdr_field = *rp_type.fields[3];
+    auto& list_type = std::get<iceberg::list_type>(hdr_field.type);
+    auto& kv_type = std::get<iceberg::struct_type>(
+      list_type.element_field->type);
+    const auto& val_field_type = kv_type.fields[1]->type;
+    ASSERT_TRUE(
+      std::holds_alternative<iceberg::primitive_type>(val_field_type));
+    EXPECT_TRUE(
+      std::holds_alternative<iceberg::string_type>(
+        std::get<iceberg::primitive_type>(val_field_type)));
+}
+
+// ---- build_rp_struct / header values ---------------------------------------
+
+TEST(BuildRpStruct, BinaryConfigProducesBinaryHeaderValues) {
+    chunked_vector<model::record_header> headers;
+    headers.push_back(make_header("k", "v"));
+
+    auto row = build_rp_struct(
+      model::partition_id{0},
+      kafka::offset{0},
+      std::nullopt,
+      model::timestamp{0},
+      model::timestamp_type::create_time,
+      headers,
+      {});
+
+    const auto& list = get_headers_list(*row);
+    ASSERT_EQ(list.elements.size(), 1);
+    const auto& kv = get_kv_struct(list, 0);
+    // value field (index 1) should be binary.
+    // value = variant<primitive_value, ...>; check both levels.
+    ASSERT_TRUE(kv.fields[1].has_value());
+    ASSERT_TRUE(
+      std::holds_alternative<iceberg::primitive_value>(*kv.fields[1]));
+    EXPECT_TRUE(
+      std::holds_alternative<iceberg::binary_value>(
+        std::get<iceberg::primitive_value>(*kv.fields[1])));
+}
+
+TEST(BuildRpStruct, StringConfigProducesStringHeaderValues) {
+    chunked_vector<model::record_header> headers;
+    headers.push_back(make_header("k", "hello"));
+
+    auto row = build_rp_struct(
+      model::partition_id{0},
+      kafka::offset{0},
+      std::nullopt,
+      model::timestamp{0},
+      model::timestamp_type::create_time,
+      headers,
+      {.value_type = hsm::string});
+
+    const auto& list = get_headers_list(*row);
+    ASSERT_EQ(list.elements.size(), 1);
+    const auto& kv = get_kv_struct(list, 0);
+    ASSERT_TRUE(kv.fields[1].has_value());
+    ASSERT_TRUE(
+      std::holds_alternative<iceberg::primitive_value>(*kv.fields[1]));
+    EXPECT_TRUE(
+      std::holds_alternative<iceberg::string_value>(
+        std::get<iceberg::primitive_value>(*kv.fields[1])));
+}
+
+TEST(BuildRpStruct, NullHeaderValue) {
+    chunked_vector<model::record_header> headers;
+    headers.push_back(make_header("k", std::nullopt));
+
+    auto row = build_rp_struct(
+      model::partition_id{0},
+      kafka::offset{0},
+      std::nullopt,
+      model::timestamp{0},
+      model::timestamp_type::create_time,
+      headers,
+      {.value_type = hsm::string});
+
+    const auto& list = get_headers_list(*row);
+    ASSERT_EQ(list.elements.size(), 1);
+    const auto& kv = get_kv_struct(list, 0);
+    // null value_size => std::nullopt in the value field
+    EXPECT_FALSE(kv.fields[1].has_value());
+}
+
+// ---- UTF-8 sanitization plumbing -------------------------------------------
+// Correctness of utf8_sanitize itself is covered by
+// strings/tests:utf8_sanitize_test. These tests verify only that string header
+// translation is wired to it.
+
+// Helper: build a single string header value and return it as std::string.
+std::string build_string_header_value(std::string_view raw_bytes) {
+    chunked_vector<model::record_header> headers;
+    headers.push_back(make_header("k", raw_bytes));
+
+    auto row = build_rp_struct(
+      model::partition_id{0},
+      kafka::offset{0},
+      std::nullopt,
+      model::timestamp{0},
+      model::timestamp_type::create_time,
+      headers,
+      {.value_type = hsm::string});
+
+    const auto& list = get_headers_list(*row);
+    const auto& kv = get_kv_struct(list, 0);
+    const auto& sv = std::get<iceberg::string_value>(
+      std::get<iceberg::primitive_value>(*kv.fields[1]));
+    iobuf_parser p(sv.val.copy());
+    return p.read_string(p.bytes_left());
+}
+
+TEST(StringHeaderSanitization, ValidUtf8PassesThrough) {
+    EXPECT_EQ(build_string_header_value("hello \xC3\xA9"), "hello \xC3\xA9");
+}
+
+TEST(StringHeaderSanitization, InvalidBytesReplaced) {
+    // bare continuation byte → U+FFFD
+    EXPECT_EQ(build_string_header_value("\x80"), "\xEF\xBF\xBD");
+}
+
+} // namespace
+} // namespace datalake

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -724,7 +724,7 @@ class DatalakeE2ETests(RedpandaTest):
                 },
                 default_value_schema=avro.loads(schema_str),
             )
-            producer.produce(topic=topic, value=record)
+            producer.produce(topic=topic, value=record, headers=[("h", b"hello")])
             producer.flush()
             dl.wait_for_translation(topic, msg_count=1)
 
@@ -739,6 +739,14 @@ class DatalakeE2ETests(RedpandaTest):
                 assert got == c.pyiceberg, (
                     f"pyiceberg {c.name}: expected={c.pyiceberg!r} got={got!r}"
                 )
+
+            # Verify headers are present and stored as binary (default mode).
+            hdrs = pydict["redpanda"][0]["headers"]
+            assert len(hdrs) == 1, f"expected 1 header, got {hdrs!r}"
+            assert hdrs[0]["key"] == "h", f"unexpected header key: {hdrs[0]['key']!r}"
+            assert hdrs[0]["value"] == b"hello", (
+                f"unexpected header value: {hdrs[0]['value']!r}"
+            )
 
             # Engine readback — one SQL projection, each column is a bool
             # check. All should be True.
@@ -758,6 +766,25 @@ class DatalakeE2ETests(RedpandaTest):
                 assert got is True, (
                     f"engine {c.name} check failed ({sql_check(c)}): got={got!r}"
                 )
+
+            # Verify header key and binary value via SQL.
+            hdr_key_sql = _engine_sql(
+                default="element_at(redpanda.headers, 1).key = 'h'",
+                duckdb_py="redpanda.headers[1].key = 'h'",
+            )(query_engine)
+            hdr_val_sql = _engine_sql(
+                default="element_at(redpanda.headers, 1).value = X'68656c6c6f'",
+                duckdb_py="redpanda.headers[1].value = '\\x68\\x65\\x6c\\x6c\\x6f'::BLOB",
+            )(query_engine)
+            hdr_rows = engine.run_query_fetch_all(
+                f"SELECT ({hdr_key_sql}) AS hdr_key_ok,"
+                f" ({hdr_val_sql}) AS hdr_val_ok FROM {table}"
+            )
+            assert len(hdr_rows) == 1
+            assert hdr_rows[0][0] is True, f"header key check failed: {hdr_rows[0]}"
+            assert hdr_rows[0][1] is True, (
+                f"header binary value check failed: {hdr_rows[0]}"
+            )
 
     @cluster(num_nodes=3)
     @matrix(
@@ -779,6 +806,75 @@ class DatalakeE2ETests(RedpandaTest):
     )
     def test_avro_all_iceberg_types_duckdb(self, cloud_storage_type, catalog_type):
         self._run_avro_all_iceberg_types(QueryEngineType.DUCKDB_PY, catalog_type)
+
+    @cluster(num_nodes=3)
+    @matrix(
+        cloud_storage_type=supported_storage_types(),
+        query_engine=[QueryEngineType.SPARK],
+        catalog_type=[CatalogType.REST_JDBC],
+    )
+    def test_header_string_mode(self, cloud_storage_type, query_engine, catalog_type):
+        """Verify that headers:value_type=string stores header values as UTF-8
+        strings, sanitizing invalid byte sequences to U+FFFD."""
+        topic = "header_string_mode"
+        table = f"redpanda.{topic}"
+        with DatalakeServices(
+            self.test_ctx,
+            redpanda=self.redpanda,
+            include_query_engines=[query_engine],
+            catalog_type=catalog_type,
+        ) as dl:
+            dl.create_iceberg_enabled_topic(
+                topic, iceberg_mode="headers:value_type=string"
+            )
+            producer = Producer({"bootstrap.servers": self.redpanda.brokers()})
+            # One header with valid UTF-8, one with a leading invalid byte so
+            # we verify sanitization fires end-to-end.
+            producer.produce(
+                topic,
+                value=b"v",
+                headers=[("ascii", b"hello"), ("bad_utf8", b"\x80world")],
+            )
+            producer.flush()
+            dl.wait_for_translation(topic, msg_count=1)
+
+            # pyiceberg: verify values and types (comes back as str, not bytes).
+            tbl = dl.catalog_client().load_table(("redpanda", topic))
+            pydict = tbl.scan().to_arrow().to_pydict()
+            hdrs = pydict["redpanda"][0]["headers"]
+            assert len(hdrs) == 2, f"expected 2 headers, got {hdrs!r}"
+            by_key = {h["key"]: h["value"] for h in hdrs}
+            assert by_key["ascii"] == "hello", f"unexpected value: {by_key['ascii']!r}"
+            # Invalid leading byte sanitized to U+FFFD.
+            assert by_key["bad_utf8"] == "\ufffdworld", (
+                f"unexpected value: {by_key['bad_utf8']!r}"
+            )
+
+            # Verify table structure: header values should be string, not binary.
+            spark = dl.spark()
+            spark_expected_out = [
+                (
+                    "redpanda",
+                    "struct<partition:int,offset:bigint,timestamp:timestamp,headers:array<struct<key:string,value:string>>,key:binary,timestamp_type:int>",
+                    None,
+                ),
+                ("value", "binary", None),
+                ("", "", ""),
+                ("# Partitioning", "", ""),
+                ("Part 0", "hours(redpanda.timestamp)", ""),
+            ]
+            spark_describe_out = spark.run_query_fetch_all(f"describe {table}")
+            assert spark_describe_out == spark_expected_out, str(spark_describe_out)
+
+            # SQL engine: verify the header value column is queryable as a
+            # string literal.
+            engine = dl.query_engine(query_engine)
+            rows = engine.run_query_fetch_all(
+                f"SELECT (element_at(redpanda.headers, 1).value = 'hello') AS ok"
+                f" FROM {table}"
+            )
+            assert len(rows) == 1
+            assert rows[0][0] is True, f"SQL string header check failed: {rows[0]}"
 
     # Note: nothing unique about this test so run it with single catalog/query engine.
     @cluster(num_nodes=3)


### PR DESCRIPTION
Adds translation of headers into UTF-8 strings instead of bytes.

Three commits
1. Rename "schemaless" to "base" to correct a misnomer, because now even key-value mode's schema has two variations.
2. Implement header value translation to string. Uses the utf8 sanitization machinery.
3. Ducktape test

Saving release notes for the follow-up with key translation.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
