### PR TITLE
[v26.1.x] [CORE-15812] ct/scale: raise fetch concurrency for cloud_topics MPT variants

### DIFF
--- a/src/v/cloud_storage_clients/multipart_upload.cc
+++ b/src/v/cloud_storage_clients/multipart_upload.cc
@@ -12,11 +12,51 @@
 
 #include "base/vassert.h"
 #include "base/vlog.h"
+#include "cloud_storage_clients/s3_error.h"
+#include "net/connection.h"
 #include "ssx/future-util.h"
 
+#include <seastar/core/timed_out_error.hh>
 #include <seastar/coroutine/as_future.hh>
 
 namespace cloud_storage_clients {
+
+namespace {
+
+// Classify a failed multipart sub-request for logging. A retryable failure is
+// not a true failure: the upload is re-driven by the caller's retry/backoff, so
+// log it at warn and reserve error for genuine failures. Retryable means either
+// an S3 throttle / transient server error (slow_down / internal_error /
+// request_timeout, as s3_client::send_request maps to error_outcome::retry) or
+// a transient transport error (reconnect or timeout, mirroring
+// handle_client_transport_error). (ABS throttles still log at error; parity is
+// a follow-up.)
+ss::log_level multipart_failure_log_level(const std::exception_ptr& ex) {
+    if (ssx::is_shutdown_exception(ex)) {
+        return ss::log_level::warn;
+    }
+    try {
+        std::rethrow_exception(ex);
+    } catch (const rest_error_response& e) {
+        switch (e.code()) {
+        case s3_error_code::slow_down:
+        case s3_error_code::internal_error:
+        case s3_error_code::request_timeout:
+            return ss::log_level::warn;
+        default:
+            return ss::log_level::error;
+        }
+    } catch (const std::system_error& e) {
+        return net::is_reconnect_error(e) ? ss::log_level::warn
+                                          : ss::log_level::error;
+    } catch (const ss::timed_out_error&) {
+        return ss::log_level::warn;
+    } catch (...) {
+        return ss::log_level::error;
+    }
+}
+
+} // namespace
 
 /// Data sink implementation that delegates to multipart_upload::put()
 ///
@@ -150,8 +190,7 @@ ss::future<> multipart_upload::complete() {
             auto ex = fut.get_exception();
             vlogl(
               _logger,
-              ssx::is_shutdown_exception(ex) ? ss::log_level::warn
-                                             : ss::log_level::error,
+              multipart_failure_log_level(ex),
               "Multipart upload final part failed, aborting: {}",
               ex);
             co_await abort_on_error();
@@ -169,8 +208,7 @@ ss::future<> multipart_upload::complete() {
         auto ex = fut.get_exception();
         vlogl(
           _logger,
-          ssx::is_shutdown_exception(ex) ? ss::log_level::warn
-                                         : ss::log_level::error,
+          multipart_failure_log_level(ex),
           "Multipart upload completion failed, aborting: {}",
           ex);
         co_await abort_on_error();

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -1023,6 +1023,14 @@ class ManyPartitionsTest(PreallocNodesTest):
 
         if cloud_topics_enabled:
             self.redpanda.add_extra_rp_conf({CLOUD_TOPICS_CONFIG_STR: True})
+            # CORE-15812: a cloud-topic partition read is latency-bound on a
+            # per-object metastore lookup + footer read + object-store GET. At
+            # the default fetch_max_read_concurrency=1 a fetch reads its
+            # partitions serially, so at this scale (thousands of small
+            # partitions) the per-read round-trips cannot keep up and the
+            # consumer-group consumer times out. A little concurrency pipelines
+            # the per-partition reads and hides the latency.
+            self.redpanda.add_extra_rp_conf({"fetch_max_read_concurrency": 4})
 
         self.redpanda.start()
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30861

- Command: git cherry-pick -x d4a3eaa9e5 5392acc9c0
- Commits backported: 2
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-30861-v26.1.x-1782176639

## Conflict details

- d4a3eaa9e5 (tests/rptest/scale_tests/many_partitions_test.py): the commit adds a `fetch_max_read_concurrency: 4` config under the `if cloud_topics_enabled:` guard, but the target branch already has a `CLOUD_TOPICS_CONFIG_STR: True` setting in that same guarded block (not present on dev). Merged both into a single `if cloud_topics_enabled:` block, keeping the target's existing setting and adding the new concurrency config.
