### PR TITLE
strings/utf8: unify string_view validator on table scanner

### DIFF
--- a/src/v/strings/utf8.cc
+++ b/src/v/strings/utf8.cc
@@ -207,6 +207,16 @@ iobuf replace_invalid_utf8(const iobuf& input) {
 
 } // namespace
 
+bool is_valid_utf8(std::string_view s) {
+    utf8_scan_state state;
+    for (const auto& c : s) {
+        if (!accept_utf8_byte(state, static_cast<uint8_t>(c))) {
+            return false;
+        }
+    }
+    return state.pending == 0;
+}
+
 bool is_valid_utf8(const iobuf& buf) {
     utf8_scan_state state;
     for (const auto& frag : buf) {

--- a/src/v/strings/utf8.h
+++ b/src/v/strings/utf8.h
@@ -141,20 +141,15 @@ inline size_t validate_and_truncate(std::string_view s) {
     return valid_length;
 }
 
-inline bool is_valid_utf8(std::string_view s) {
-    auto begin = s.cbegin();
-    auto end = s.cend();
+/// Returns true iff \p s is valid UTF-8. Rejects surrogates, overlong
+/// encodings, and truncated sequences.
+bool is_valid_utf8(std::string_view s);
 
-    while (begin != end) {
-        const boost::locale::utf::code_point c
-          = boost::locale::utf::utf_traits<char>::decode(begin, end);
-        if (!boost::locale::utf::is_valid_codepoint(c)) {
-            return false;
-        }
-        // continue
-    }
-    return true;
-}
+/// Fragment-aware UTF-8 validation with no allocation.
+///
+/// Returns true iff \p buf is valid UTF-8. Rejects surrogates, overlong
+/// encodings, and truncated sequences.
+bool is_valid_utf8(const iobuf& buf);
 
 template<typename Thrower>
 requires ExceptionThrower<Thrower>
@@ -189,12 +184,6 @@ std::string_view utf8_truncate_min(std::string_view s, size_t max_bytes);
 /// byte length.
 std::optional<std::string>
 utf8_truncate_max(std::string_view s, size_t max_bytes);
-
-/// Fragment-aware UTF-8 validation with no allocation.
-///
-/// Returns false if \p buf contains any byte sequence that is not valid
-/// UTF-8, including surrogates, overlong encodings, and truncated sequences.
-bool is_valid_utf8(const iobuf& buf);
 
 /// Replace invalid UTF-8 byte sequences with U+FFFD (EF BF BD).
 ///


### PR DESCRIPTION
Drop the boost::locale decode loop for is_valid_utf8(string_view) and reuse the table-driven state machine already backing the iobuf overload. Same semantics (rejects surrogates, overlongs, and truncated sequences), but >2x faster / roughly half the instructions.

Extensively fuzzed differentially against the boost::locale oracle locally to confirm the two agree on every input.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
