### PR TITLE
cluster/health: use kafka high watermark in partition_status

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -1064,8 +1064,7 @@ partition_status build_partition_status(const partition& p) {
 
     if (p.ntp().ns == model::kafka_namespace && p.started()) {
         // HWM cannot be reliably retrieved until raft has started
-        status.high_watermark = model::offset_cast(
-          p.log()->from_log_offset(p.high_watermark()));
+        status.high_watermark = model::offset_cast(kafka_high_watermark(p));
         status.log_start_offset = model::offset_cast(kafka_start_offset(p));
     }
 

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -23,7 +23,7 @@ from confluent_kafka import (
     TopicPartition,
 )
 from confluent_kafka.admin import AdminClient
-from ducktape.mark import ignore, parametrize
+from ducktape.mark import ignore, matrix, parametrize
 from ducktape.utils.util import wait_until
 from kafka import KafkaConsumer
 from kafka.admin import KafkaAdminClient
@@ -41,9 +41,15 @@ from rptest.services.redpanda import (
     RESTART_LOG_ALLOW_LIST,
     LoggingConfig,
     MetricsEndpoint,
+    get_cloud_storage_type,
 )
 from rptest.services.rpk_producer import RpkProducer
 from rptest.services.verifiable_consumer import VerifiableConsumer
+from rptest.tests.read_replica_e2e_test import (
+    READ_REPLICA_LOG_ALLOW_LIST,
+    ReadReplicaE2EBase,
+    get_hwm_per_partition,
+)
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import wait_until_result
 from rptest.utils.mode_checks import skip_debug_mode
@@ -1920,4 +1926,171 @@ class ConsumerGroupOffsetResetTest(RedpandaTest):
         tp = self.list_consumer_group_offsets(topic.name).topic_partitions[0]
         assert tp.offset == INVALID_OFFSET, (
             f"Expected offset '{INVALID_OFFSET}' but got '{tp.offset}', instead"
+        )
+
+
+class ReadReplicaConsumerLagTest(ReadReplicaE2EBase):
+    """
+    Regression test: consumer-group lag metrics must reflect the real,
+    cloud-aware high watermark for read-replica topics.
+
+    Bug: build_partition_status() reports a partition's high watermark as
+    from_log_offset(p.high_watermark()). For a read replica the local raft
+    log holds only the synced manifest (no data batches), so that value
+    translates to ~0 in the Kafka offset space — instead of the real cloud
+    high watermark (next_cloud_offset). The health-report HWM consumed by
+    group_manager's lag metric is therefore 0, and the reported lag collapses
+    to 0 regardless of the committed offset.
+
+    The Kafka-visible HWM (rpk / list_offsets) is NOT affected, because it
+    goes through replicated_partition::high_watermark() -> kafka_high_watermark(),
+    which has a read-replica branch returning next_cloud_offset().
+
+    This test pins the committed offset to 0 so the reported lag reduces to
+    exactly the health-report HWM:
+
+        lag = max(hwm_report - max(committed=0, log_start_offset~0), 0)
+            = hwm_report
+
+    With the fix (build_partition_status using kafka_high_watermark()),
+    hwm_report == kafka_hwm and the asserted lag == kafka_hwm. On the unfixed
+    code hwm_report == 0, so this assertion FAILS — which is the proof that
+    the bug is real.
+
+    Lives alongside the single-cluster test_group_lag_metrics_* tests above,
+    but in its own class because it needs the read-replica (tiered storage +
+    second cluster) setup from ReadReplicaE2EBase.
+    """
+
+    LAG_COLLECTION_INTERVAL = 5
+    GROUP = "rr-consumer-lag-group"
+
+    # 3 nodes: source broker (1) + producer (1) + read-replica broker (1).
+    # The consumer is an in-process confluent_kafka client, not a ducktape
+    # service, so it needs no node of its own.
+    @cluster(num_nodes=3, log_allow_list=READ_REPLICA_LOG_ALLOW_LIST)
+    @matrix(cloud_storage_type=get_cloud_storage_type(docker_use_arbitrary=True))
+    def test_group_lag_metrics_read_replica(self, cloud_storage_type):
+        num_messages = 1000
+        partition = 0
+
+        # Source: tiered-storage topic with data; then a synced read replica.
+        # Single partition keeps the offset arithmetic unambiguous.
+        self._setup_read_replica(
+            num_messages=num_messages,
+            partition_count=1,
+            num_source_brokers=1,
+            num_rrr_brokers=1,
+            replication_factor=1,
+        )
+
+        rr = self.second_cluster
+        assert rr is not None
+
+        # The consumer group lives on the read-replica cluster, so the lag
+        # metric is collected there — enable it there.
+        rr.set_cluster_config(
+            {
+                "enable_consumer_group_metrics": ["consumer_lag"],
+                "consumer_group_lag_collection_interval_sec": self.LAG_COLLECTION_INTERVAL,
+            }
+        )
+
+        # Kafka-visible HWM on the read replica (via list_offsets). This is the
+        # CORRECT, cloud-aware HWM and proves the data is really readable.
+        id_to_hwm = wait_until_result(
+            lambda: get_hwm_per_partition(rr, self.topic_name, 1),
+            timeout_sec=60,
+            backoff_sec=2,
+        )
+        kafka_hwm = id_to_hwm[partition]
+        # Guard against a false pass: the final assertion is lag == kafka_hwm,
+        # and the bug makes the reported lag 0. If kafka_hwm were also 0 (data
+        # not yet synced to the replica) that assertion would trivially hold
+        # (0 == 0) even on buggy code. Requiring kafka_hwm > 0 ensures the
+        # comparison actually distinguishes the bug (0) from the fix
+        # (kafka_hwm). We don't assert an exact count: the producer overshoots
+        # num_messages and only uploaded/synced offsets reach the replica.
+        assert kafka_hwm > 0, (
+            f"expected a non-zero Kafka HWM on the read replica, got {kafka_hwm}"
+        )
+
+        # Create the group on the read replica and force its committed offset
+        # to 0. With committed == 0 the reported lag reduces to exactly the
+        # health-report HWM, so the metric value below directly reveals it.
+        consumer = Consumer(
+            {
+                "bootstrap.servers": rr.brokers(),
+                "group.id": self.GROUP,
+                "auto.offset.reset": "earliest",
+                "enable.auto.commit": False,
+            }
+        )
+        try:
+            consumer.subscribe([self.topic_name])
+            # Poll once to join the group and get the partition assigned.
+            consumer.poll(timeout=30)
+            consumer.commit(
+                offsets=[TopicPartition(self.topic_name, partition, 0)],
+                asynchronous=False,
+            )
+            committed = consumer.committed(
+                [TopicPartition(self.topic_name, partition)]
+            )[0].offset
+        finally:
+            consumer.close()
+
+        assert committed == 0, f"expected committed offset 0, got {committed}"
+        self.logger.info(
+            f"read replica: Kafka HWM={kafka_hwm}, committed={committed}, "
+            f"expected (Kafka-visible) lag={kafka_hwm}"
+        )
+
+        def get_group_lag(metric_name: str) -> float | None:
+            samples = rr.metrics_samples(
+                [metric_name],
+                rr.started_nodes(),
+                MetricsEndpoint.PUBLIC_METRICS,
+            )
+            if metric_name not in samples:
+                return None
+            group_samples = (
+                samples[metric_name]
+                .label_filter({"redpanda_group": self.GROUP})
+                .samples
+            )
+            if not group_samples:
+                return None
+            return max(s.value for s in group_samples)
+
+        # Wait until the metric is being collected for this group at all
+        # (gives at least one collection cycle after the commit).
+        wait_until(
+            lambda: get_group_lag("redpanda_kafka_consumer_group_lag_max") is not None,
+            timeout_sec=self.LAG_COLLECTION_INTERVAL * 2 + 30,
+            backoff_sec=self.LAG_COLLECTION_INTERVAL,
+            err_msg="consumer_group_lag_max metric never appeared for the group",
+        )
+
+        # With committed == 0 the reported lag equals the health-report HWM.
+        # It must equal the real, Kafka-visible HWM. On the unfixed code the
+        # health-report HWM for a read replica is 0 (the local manifest-log
+        # position), so this fails with lag_max == 0 — the proof of the bug.
+        def lag_matches_cloud_hwm() -> bool:
+            lag_max = get_group_lag("redpanda_kafka_consumer_group_lag_max")
+            lag_sum = get_group_lag("redpanda_kafka_consumer_group_lag_sum")
+            self.logger.info(
+                f"observed lag_max={lag_max}, lag_sum={lag_sum}, expected={kafka_hwm}"
+            )
+            return lag_max == kafka_hwm and lag_sum == kafka_hwm
+
+        wait_until(
+            lag_matches_cloud_hwm,
+            timeout_sec=self.LAG_COLLECTION_INTERVAL * 2 + 30,
+            backoff_sec=self.LAG_COLLECTION_INTERVAL,
+            err_msg=(
+                f"consumer-group lag did not reflect the cloud HWM "
+                f"({kafka_hwm}) for the read replica. A reported lag of 0 "
+                f"means the health-report HWM is 0 (read-replica HWM bug)."
+            ),
         )

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -172,7 +172,13 @@ def cross_region_rrr_test(func, /):
     return func
 
 
-class TestReadReplicaService(EndToEndTest):
+class ReadReplicaE2EBase(EndToEndTest):
+    """Read-replica setup helpers shared across read-replica test classes.
+
+    Holds no @cluster test methods, so ducktape does not collect it; concrete
+    subclasses (TestReadReplicaService and others) add their own tests while
+    reusing _setup_read_replica()/start_second_cluster()/etc."""
+
     log_segment_size = 1048576  # 5MB
     topic_name = "panda-topic"
 
@@ -185,7 +191,7 @@ class TestReadReplicaService(EndToEndTest):
             cloud_storage_spillover_manifest_size=None,
             cloud_topics_long_term_flush_interval=1000,
         )
-        super(TestReadReplicaService, self).__init__(
+        super().__init__(
             test_context=test_context,
             si_settings=SISettings(
                 test_context,
@@ -380,6 +386,8 @@ class TestReadReplicaService(EndToEndTest):
         else:
             return None
 
+
+class TestReadReplicaService(ReadReplicaE2EBase):
     @cluster(num_nodes=7, log_allow_list=READ_REPLICA_LOG_ALLOW_LIST)
     @matrix(
         partition_count=[1],


### PR DESCRIPTION
build_partition_status() reported a partition's high watermark as from_log_offset(p.high_watermark()), the raw local-log position. For a read replica the local raft log holds only the synced manifest (no data batches), so this translates to ~0 in the Kafka offset space instead of the real cloud high watermark (next_cloud_offset).

The consumer-group lag metric reads this health-report HWM, so redpanda_kafka_consumer_group_lag_{max,sum} collapsed to 0 for read-replica topics regardless of the committed offset, hiding real backlog. The Kafka-visible HWM (rpk / list_offsets) was unaffected because it already goes through kafka_high_watermark().

Use cluster::kafka_high_watermark(p) so high_watermark is cloud-aware and consistent with the log_start_offset set alongside it. For non-read-replica partitions the value is unchanged.

Covered by a ducktape test
(ReadReplicaConsumerLagTest.test_group_lag_metrics_read_replica in consumer_group_test.py): it pins the committed offset to 0 so the reported lag reduces to the health-report HWM, then asserts that lag equals the cloud-visible HWM. The read-replica setup helpers were extracted from TestReadReplicaService into a ReadReplicaE2EBase base class so the new test can reuse them without inheriting the e2e suite.

Follow-up to CORE-16393.

Bug has been reproduced using following steps:
- use image version without fix, fix the issue and re-iterate with the new docker image
```
#0 Build local version of redpanda:
bazel run //bazel/packaging:image_load

# ============================================================
# Manual repro: read-replica consumer-group lag metric bug.
# build_partition_status reports the raw local-log HWM (~0 on a read
# replica, whose local log holds only the synced manifest) instead of
# the cloud HWM. The lag metric reads that, so it collapses to 0.
#
# Needs docker + local rpk. Do NOT `set -e` — run line by line.
# ============================================================

NET=rr-repro; BUCKET=panda-bucket; AKEY=minio; SKEY=minio123
TOPIC=repro-lag; GROUP=rr-group; IMG=redpandadata/redpanda-dev:latest
# Kafka API + admin API endpoints for each cluster (admin is needed for
# `cluster config set`; -X brokers alone only points the Kafka client).
SRC="rpk -X brokers=localhost:19092 -X admin.hosts=localhost:19644"  # source
RR="rpk  -X brokers=localhost:29092 -X admin.hosts=localhost:29644"  # read replica

# 1. Network + MinIO (S3) + bucket
docker network create $NET
docker run -d --name minio --network $NET -p 9000:9000 \
  -e MINIO_ROOT_USER=$AKEY -e MINIO_ROOT_PASSWORD=$SKEY \
  quay.io/minio/minio server /data
sleep 5
docker run --rm --network $NET --entrypoint sh quay.io/minio/mc -c \
  "mc alias set m http://minio:9000 $AKEY $SKEY && mc mb m/$BUCKET"

# Shared tiered-storage flags (short upload intervals => fast RR visibility)
CS="--set redpanda.cloud_storage_enabled=true \
    --set redpanda.cloud_storage_access_key=$AKEY \
    --set redpanda.cloud_storage_secret_key=$SKEY \
    --set redpanda.cloud_storage_region=local \
    --set redpanda.cloud_storage_bucket=$BUCKET \
    --set redpanda.cloud_storage_api_endpoint=minio \
    --set redpanda.cloud_storage_api_endpoint_port=9000 \
    --set redpanda.cloud_storage_disable_tls=true \
    --set redpanda.cloud_storage_segment_max_upload_interval_sec=10 \
    --set redpanda.cloud_storage_manifest_max_upload_interval_sec=10"

# 2. Source cluster (writes to cloud); admin API on host port 19644
docker run -d --name src --network $NET -p 19092:19092 -p 19644:9644 $IMG \
  redpanda start --mode dev-container --smp 1 --memory 1G \
  --kafka-addr external://0.0.0.0:19092 \
  --advertise-kafka-addr external://localhost:19092 $CS

# 3. Read-replica cluster (separate cluster, same bucket); admin API on 29644
docker run -d --name rr --network $NET -p 29092:19092 -p 29644:9644 $IMG \
  redpanda start --mode dev-container --smp 1 --memory 1G \
  --kafka-addr external://0.0.0.0:19092 \
  --advertise-kafka-addr external://localhost:29092 $CS
sleep 8

# 4. Source: tiered-storage topic + 1000 messages
$SRC topic create $TOPIC -p 1 -r 1 \
  -c redpanda.remote.write=true -c redpanda.remote.read=true
seq 1 1000 | $SRC topic produce $TOPIC --format '%v\n' >/dev/null

# 5. Read replica: create RR topic + enable the lag metric here
#    (the consumer group lives on this cluster, so collection is here)
$RR topic create $TOPIC -c redpanda.remote.readreplica=$BUCKET
$RR cluster config set enable_consumer_group_metrics '[consumer_lag]'
$RR cluster config set consumer_group_lag_collection_interval_sec 5

# 6. Wait until the data is readable on the RR (HWM reaches 1000).
#    If this hangs >40s, segments haven't uploaded yet — keep waiting.
echo "waiting for read replica HWM=1000 ..."
until $RR topic describe $TOPIC -p 2>/dev/null | grep -qE '\b1000\b'; do sleep 3; done
$RR topic describe $TOPIC -p          # HIGH-WATERMARK = 1000 (cloud-aware, correct)

# 7. Consume 1 record with a group on the RR (commits offset 1)
$RR topic consume $TOPIC --group $GROUP --num 1 >/dev/null

# 8. The contrast — both numbers are for the same group on the same cluster:
$RR group describe $GROUP
# CURRENT-OFFSET=1, LOG-END-OFFSET=1000, LAG=999  <- CORRECT (list_offsets path)
# (If CURRENT-OFFSET is still 0, re-run step 7, then continue.)

sleep 12                               # let one 5s collection interval pass
curl -s http://localhost:29644/public_metrics | grep consumer_group_lag
# redpanda_kafka_consumer_group_lag_max{...redpanda_group="rr-group"} 0.000000  <- WRONG, should be 999
# redpanda_kafka_consumer_group_lag_sum{...redpanda_group="rr-group"} 0.000000  <- WRONG, should be 999

# 9. Cleanup
docker rm -f src rr minio && docker network rm $NET
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes

### Bug Fixes
* Fix consumer group lag metrics reporting 0 for read-replica topics.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.


Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->