### PR TITLE
[v26.1.x] [CORE-16286] [CORE-15930] [CORE-14631] [CORE-14630] [CORE-13673] [CORE-14807] [CORE-13712] [CORE-13347] `cluster`: remove `shard` aggregation for `leader_id` and `under_replicated_replicas`

### DIFF
--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -82,9 +82,7 @@ void replicated_partition_probe::setup_internal_metrics(const model::ntp& ntp) {
              return _partition.raft()->get_under_replicated().value_or(0);
          },
          sm::description("Number of under replicated replicas"),
-         labels)},
-      {},
-      {sm::shard_label});
+         labels)});
 
     _metrics.add_group(
       cluster_metrics_name,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30556
