### PR TITLE
`misc`: some useful metric shard aggregation 

### DIFF
--- a/src/v/cloud_storage/remote_probe.cc
+++ b/src/v/cloud_storage/remote_probe.cc
@@ -162,7 +162,9 @@ remote_probe::remote_probe(
                   return _segment_download_latency.public_histogram_logform();
               },
               sm::description("Segment download latency histogram")),
-          });
+          },
+          {},
+          {sm::shard_label});
     }
 
     if (!public_disabled) {

--- a/src/v/cloud_storage_clients/client_probe.cc
+++ b/src/v/cloud_storage_clients/client_probe.cc
@@ -250,7 +250,9 @@ void client_probe::setup_internal_metrics(
           [this] { return _total_multipart_aborts; },
           sm::description("Number of multipart uploads aborted"),
           labels),
-      });
+      },
+      {},
+      {sm::shard_label});
 }
 
 void client_probe::setup_public_metrics(

--- a/src/v/cloud_topics/level_one/maintenance/worker_probe.cc
+++ b/src/v/cloud_topics/level_one/maintenance/worker_probe.cc
@@ -125,7 +125,9 @@ void compaction_worker_probe::setup_metrics() {
             "Total size in bytes of new L1 objects uploaded by leveling jobs "
             "whose commit did not succeed (uploaded but not "
             "committed) across all cloud topic partitions on this shard")),
-      });
+      },
+      {},
+      {sm::shard_label});
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/leader_router_probe.cc
+++ b/src/v/cloud_topics/level_one/metastore/leader_router_probe.cc
@@ -104,7 +104,9 @@ void leader_router_probe::setup_metrics() {
           "preregister_objects_duration_microseconds",
           [this] { return _preregister_objects.internal_histogram_logform(); },
           sm::description("Latency of local preregister_objects requests")),
-      });
+      },
+      {},
+      {sm::shard_label});
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_zero/common/level_zero_probe.cc
+++ b/src/v/cloud_topics/level_zero/common/level_zero_probe.cc
@@ -157,7 +157,9 @@ void pipeline_probe::setup_internal_metrics(bool disable, ss::sstring name) {
           [this] { return _request_probe.cloud_write_bytes; },
           sm::description("Number of bytes uploaded to the cloud storage."),
           labels),
-      });
+      },
+      {},
+      {sm::shard_label});
 }
 
 void pipeline_probe::setup_public_metrics(bool disable, ss::sstring name) {
@@ -265,7 +267,9 @@ void write_request_scheduler_probe::setup_internal_metrics(bool disable) {
          sm::description(
            "Bytes buffered in the next pipeline stage, used for "
            "group split/merge decisions."),
-         labels)});
+         labels)},
+      {},
+      {sm::shard_label});
 }
 read_merge_probe::read_merge_probe(bool disable) {
     setup_internal_metrics(disable);
@@ -310,7 +314,9 @@ void read_merge_probe::setup_internal_metrics(bool disable) {
             "Total bytes of proxy requests forwarded to the next pipeline "
             "stage."),
           labels),
-      });
+      },
+      {},
+      {sm::shard_label});
 }
 
 batcher_probe::batcher_probe(bool disable) { setup_internal_metrics(disable); }
@@ -358,7 +364,9 @@ void batcher_probe::setup_internal_metrics(bool disable) {
           [this] { return _upload_size_hist.seastar_histogram_logform(); },
           sm::description("Level zero object size histogram in bytes."),
           labels),
-      });
+      },
+      {},
+      {sm::shard_label});
 }
 
 } // namespace cloud_topics::l0

--- a/src/v/cloud_topics/reconciler/reconciler_probe.cc
+++ b/src/v/cloud_topics/reconciler/reconciler_probe.cc
@@ -77,7 +77,9 @@ void reconciler_probe::setup_metrics() {
           "object_size_bytes",
           [this] { return _object_size_bytes.seastar_histogram_logform(); },
           sm::description("Distribution of built L1 object sizes in bytes")),
-      });
+      },
+      {},
+      {sm::shard_label});
 }
 
 } // namespace cloud_topics::reconciler

--- a/src/v/kafka/server/kafka_probe.h
+++ b/src/v/kafka/server/kafka_probe.h
@@ -101,7 +101,9 @@ public:
                 "Batch size across all topics measured at the kafka layer."),
               {},
               [this] { return _batch_size.batch_size_histogram_logform(); }),
-          });
+          },
+          {},
+          {sm::shard_label});
 
         _metrics.add_group(
           "kafka_rpc",

--- a/src/v/net/server.cc
+++ b/src/v/net/server.cc
@@ -343,7 +343,9 @@ void server::setup_metrics() {
        sm::make_histogram(
          "dispatch_handler_latency",
          [this] { return _hist.internal_histogram_logform(); },
-         sm::description(ssx::sformat("{}: Latency ", cfg.name)))});
+         sm::description(ssx::sformat("{}: Latency ", cfg.name)))},
+      {},
+      {sm::shard_label});
 }
 
 void server::setup_public_metrics() {


### PR DESCRIPTION
Fixing a number of metrics that should be aggregated by shard when `aggregate_metrics=true` that weren't currently being aggregated:

## `vectorized_cloud_topics_reconciler_*` (10)
- `vectorized_cloud_topics_reconciler_objects_uploaded`
- `vectorized_cloud_topics_reconciler_bytes_reconciled`
- `vectorized_cloud_topics_reconciler_batches_reconciled`
- `vectorized_cloud_topics_reconciler_partitions_reconciled`
- `vectorized_cloud_topics_reconciler_metastore_retries`
- `vectorized_cloud_topics_reconciler_offset_corrections`
- `vectorized_cloud_topics_reconciler_l0_read_duration_microseconds`
- `vectorized_cloud_topics_reconciler_object_build_duration_microseconds`
- `vectorized_cloud_topics_reconciler_metastore_add_objects_duration_microseconds`
- `vectorized_cloud_topics_reconciler_object_size_bytes`

## `vectorized_cloud_topics_l1_leader_router_*` (18)
- `vectorized_cloud_topics_l1_leader_router_add_objects_duration_microseconds`
- `vectorized_cloud_topics_l1_leader_router_compact_objects_duration_microseconds`
- `vectorized_cloud_topics_l1_leader_router_replace_objects_duration_microseconds`
- `vectorized_cloud_topics_l1_leader_router_get_first_offset_ge_duration_microseconds`
- `vectorized_cloud_topics_l1_leader_router_get_first_timestamp_ge_duration_microseconds`
- `vectorized_cloud_topics_l1_leader_router_get_first_offset_for_bytes_duration_microseconds`
- `vectorized_cloud_topics_l1_leader_router_get_offsets_duration_microseconds`
- `vectorized_cloud_topics_l1_leader_router_get_size_duration_microseconds`
- `vectorized_cloud_topics_l1_leader_router_get_compaction_info_duration_microseconds`
- `vectorized_cloud_topics_l1_leader_router_get_term_for_offset_duration_microseconds`
- `vectorized_cloud_topics_l1_leader_router_get_end_offset_for_term_duration_microseconds`
- `vectorized_cloud_topics_l1_leader_router_set_start_offset_duration_microseconds`
- `vectorized_cloud_topics_l1_leader_router_remove_topics_duration_microseconds`
- `vectorized_cloud_topics_l1_leader_router_get_compaction_infos_duration_microseconds`
- `vectorized_cloud_topics_l1_leader_router_get_extent_metadata_duration_microseconds`
- `vectorized_cloud_topics_l1_leader_router_flush_domain_duration_microseconds`
- `vectorized_cloud_topics_l1_leader_router_restore_domain_duration_microseconds`
- `vectorized_cloud_topics_l1_leader_router_preregister_objects_duration_microseconds`

## `vectorized_cloud_topics_compaction_worker_*` (7)
- `vectorized_cloud_topics_compaction_worker_batches_processed_total`
- `vectorized_cloud_topics_compaction_worker_batches_removed_total`
- `vectorized_cloud_topics_compaction_worker_records_removed_total`
- `vectorized_cloud_topics_compaction_worker_tombstones_removed_total`
- `vectorized_cloud_topics_compaction_worker_compaction_duration_microseconds`
- `vectorized_cloud_topics_compaction_worker_leveling_duration_microseconds`
- `vectorized_cloud_topics_compaction_worker_leveling_extents_reclaimed_total`

## `vectorized_cloud_topics_pipeline_*` (20)
- `vectorized_cloud_topics_pipeline_requests_in`
- `vectorized_cloud_topics_pipeline_requests_completed`
- `vectorized_cloud_topics_pipeline_requests_error`
- `vectorized_cloud_topics_pipeline_requests_timeout`
- `vectorized_cloud_topics_pipeline_request_processing_time_ms`
- `vectorized_cloud_topics_pipeline_current_memory_usage`
- `vectorized_cloud_topics_pipeline_memory_pressure_waits`
- `vectorized_cloud_topics_pipeline_memory_pressure_blocked`
- `vectorized_cloud_topics_pipeline_request_limit_waits`
- `vectorized_cloud_topics_pipeline_bytes_in`
- `vectorized_cloud_topics_pipeline_bytes_out`
- `vectorized_cloud_topics_pipeline_request_size_bytes`
- `vectorized_cloud_topics_pipeline_req_num_cache_reads`
- `vectorized_cloud_topics_pipeline_req_num_cache_writes`
- `vectorized_cloud_topics_pipeline_req_num_cloud_reads`
- `vectorized_cloud_topics_pipeline_req_num_cloud_writes`
- `vectorized_cloud_topics_pipeline_req_cache_read_bytes`
- `vectorized_cloud_topics_pipeline_req_cache_write_bytes`
- `vectorized_cloud_topics_pipeline_req_cloud_read_bytes`
- `vectorized_cloud_topics_pipeline_req_cloud_write_bytes`

## `vectorized_cloud_topics_write_request_scheduler_*` (8)
- `vectorized_cloud_topics_write_request_scheduler_scheduler_requests`
- `vectorized_cloud_topics_write_request_scheduler_scheduler_bytes`
- `vectorized_cloud_topics_write_request_scheduler_tx_requests_xshard`
- `vectorized_cloud_topics_write_request_scheduler_tx_bytes_xshard`
- `vectorized_cloud_topics_write_request_scheduler_rx_requests_xshard`
- `vectorized_cloud_topics_write_request_scheduler_rx_bytes_xshard`
- `vectorized_cloud_topics_write_request_scheduler_active_groups`
- `vectorized_cloud_topics_write_request_scheduler_next_stage_bytes`

## `vectorized_cloud_topics_read_merge_*` (4)
- `vectorized_cloud_topics_read_merge_requests_in`
- `vectorized_cloud_topics_read_merge_bytes_in`
- `vectorized_cloud_topics_read_merge_requests_out`
- `vectorized_cloud_topics_read_merge_bytes_out`

## `vectorized_cloud_topics_batcher_*` (5)
- `vectorized_cloud_topics_batcher_objects_uploaded`
- `vectorized_cloud_topics_batcher_bytes_uploaded`
- `vectorized_cloud_topics_batcher_upload_errors`
- `vectorized_cloud_topics_batcher_epoch_errors`
- `vectorized_cloud_topics_batcher_level_zero_object_size_bytes`

## `vectorized_<server>_*` (3)  _(<server> = internal_rpc, kafka_rpc, etc.)_
- `vectorized_<server>_max_service_mem_bytes`
- `vectorized_<server>_consumed_mem_bytes`
- `vectorized_<server>_dispatch_handler_latency`

## `vectorized_cloud_storage_*` (30)  _(internal group only)_
- `vectorized_cloud_storage_topic_manifest_uploads`
- `vectorized_cloud_storage_partition_manifest_uploads`
- `vectorized_cloud_storage_topic_manifest_downloads`
- `vectorized_cloud_storage_partition_manifest_downloads`
- `vectorized_cloud_storage_cluster_metadata_manifest_uploads`
- `vectorized_cloud_storage_cluster_metadata_manifest_downloads`
- `vectorized_cloud_storage_manifest_upload_backoff`
- `vectorized_cloud_storage_manifest_download_backoff`
- `vectorized_cloud_storage_successful_uploads`
- `vectorized_cloud_storage_successful_downloads`
- `vectorized_cloud_storage_failed_uploads`
- `vectorized_cloud_storage_failed_downloads`
- `vectorized_cloud_storage_failed_manifest_uploads`
- `vectorized_cloud_storage_failed_manifest_downloads`
- `vectorized_cloud_storage_upload_backoff`
- `vectorized_cloud_storage_download_backoff`
- `vectorized_cloud_storage_bytes_sent`
- `vectorized_cloud_storage_bytes_received`
- `vectorized_cloud_storage_index_uploads`
- `vectorized_cloud_storage_index_downloads`
- `vectorized_cloud_storage_failed_index_uploads`
- `vectorized_cloud_storage_failed_index_downloads`
- `vectorized_cloud_storage_spillover_manifest_uploads`
- `vectorized_cloud_storage_spillover_manifest_downloads`
- `vectorized_cloud_storage_controller_snapshot_successful_uploads`
- `vectorized_cloud_storage_controller_snapshot_failed_uploads`
- `vectorized_cloud_storage_controller_snapshot_upload_backoff`
- `vectorized_cloud_storage_batch_delete_errors`
- `vectorized_cloud_storage_client_acquisition_latency`
- `vectorized_cloud_storage_segment_download_latency`

## `vectorized_cloud_client_*` (20)
- `vectorized_cloud_client_total_uploads`
- `vectorized_cloud_client_total_downloads`
- `vectorized_cloud_client_all_requests`
- `vectorized_cloud_client_active_uploads`
- `vectorized_cloud_client_active_downloads`
- `vectorized_cloud_client_active_requests`
- `vectorized_cloud_client_total_inbound_bytes`
- `vectorized_cloud_client_total_outbound_bytes`
- `vectorized_cloud_client_num_rpc_errors`
- `vectorized_cloud_client_num_transport_errors`
- `vectorized_cloud_client_num_slowdowns`
- `vectorized_cloud_client_num_nosuchkey`
- `vectorized_cloud_client_num_borrows`
- `vectorized_cloud_client_lease_duration`
- `vectorized_cloud_client_client_pool_utilization`
- `vectorized_cloud_client_lease_timeouts_total`
- `vectorized_cloud_client_multipart_creates`
- `vectorized_cloud_client_multipart_uploads`
- `vectorized_cloud_client_multipart_completes`
- `vectorized_cloud_client_multipart_aborts`

## `vectorized_kafka_*` (1)  _(only batch_size newly aggregated)_
- `vectorized_kafka_batch_size`

---
**Total: 126 metric definitions across 11 groups / 4 commits.**


## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
