### PR TITLE
[v26.1.x] raft: refresh election timer on recovery-path append_entries (pre-vote livelock)

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2030,6 +2030,8 @@ consensus::do_append_entries(append_entries_request&& r) {
     // follower (§5.2)
     maybe_update_leader(r.source_node());
 
+    auto refresh_hbeat = ss::defer([this] { _hbeat = clock_type::now(); });
+
     // raft.pdf: Reply false if log doesn’t contain an entry at
     // prevLogIndex whose term matches prevLogTerm (§5.3)
     // broken into 3 sections
@@ -2285,11 +2287,6 @@ consensus::do_append_entries(append_entries_request&& r) {
     // success. copy entries for each subsystem
 
     try {
-        auto deferred = ss::defer([this] {
-            // we do not want to include our disk flush latency into
-            // the leader vote timeout
-            _hbeat = clock_type::now();
-        });
         validate_offset_translator_delta(request_metadata, lstats);
 
         // simulate disk error


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30817

- Command: git cherry-pick -x 81f445b69b eb137bfae2
- Commits backported: 1
- Conflicts resolved: 0
- Commits skipped (already on target): 1
- Backport branch: ai-backport-pr-30817-v26.1.x-1782246599

## Notes

The PR contains two commits: `81f445b69b` (the fix in `src/v/raft/consensus.cc`)
and `eb137bfae2`, which is a `Merge branch 'dev'` merge commit. The merge commit
introduces only unrelated `dev` changes (`cloud_storage_clients/multipart_upload.cc`,
`tests/rptest/scale_tests/many_partitions_test.py`) and contributes no PR-specific
content — the PR's entire diff (`src/v/raft/consensus.cc`) is captured by
`81f445b69b`. The merge commit was therefore excluded from the backport rather
than dragging in unrelated `dev` work.


Fixes: https://github.com/redpanda-data/redpanda/issues/30885,
