### PR TITLE
ts-ct-migration: STM coexistence [PR 2]

### DIFF
--- a/src/v/cloud_topics/level_zero/stm/BUILD
+++ b/src/v/cloud_topics/level_zero/stm/BUILD
@@ -182,6 +182,8 @@ redpanda_cc_library(
     implementation_deps = [
         ":ctp_stm",
         "//src/v/cloud_topics:logger",
+        "//src/v/config",
+        "//src/v/model",
     ],
     visibility = ["//visibility:public"],
     deps = ["//src/v/cluster:state_machine_registry"],

--- a/src/v/cloud_topics/level_zero/stm/BUILD
+++ b/src/v/cloud_topics/level_zero/stm/BUILD
@@ -182,6 +182,7 @@ redpanda_cc_library(
     implementation_deps = [
         ":ctp_stm",
         "//src/v/cloud_topics:logger",
+        "//src/v/config",
     ],
     visibility = ["//visibility:public"],
     deps = ["//src/v/cluster:state_machine_registry"],

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -462,6 +462,11 @@ ctp_stm::take_local_snapshot(ssx::semaphore_units) {
 }
 
 ss::future<> ctp_stm::apply_raft_snapshot(const iobuf& buf) {
+    // Snapshots taken prior to ctp_stm existing on the partition will be empty.
+    // Treat as a noop, implicitly setting the stm to the default state.
+    if (buf.empty()) {
+        co_return;
+    }
     auto snap = serde::from_iobuf<ctp_stm_snapshot>(buf.copy());
     _state = std::move(snap.state);
     _epoch_checker = snap.checker;
@@ -567,6 +572,15 @@ ctp_stm::fence_epoch(cluster_epoch e, model::timeout_clock::duration timeout) {
 }
 
 model::offset ctp_stm::max_removable_local_log_offset() {
+    // ctp_stm is unconditionally present on tiered and local partitions in
+    // order to allow for migration to cloud/tsv2, but it owns trimming only
+    // on cloud-topic partitions: until this partition's log says the topic
+    // is a cloud topic, don't pin truncation. The storage mode is monotone
+    // (never cloud -> non-cloud) and the flip propagates through this log,
+    // so any applied cloud-topic data is preceded by the flip.
+    if (!_raft->log()->config().cloud_topic_enabled()) {
+        return model::offset::max();
+    }
     // If there is an active reader, it holds back prefix truncation.
     if (!_active_readers.empty()) {
         return _active_readers.front().lrlo;

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -427,6 +427,16 @@ ctp_stm::take_local_snapshot(ssx::semaphore_units) {
 }
 
 ss::future<> ctp_stm::apply_raft_snapshot(const iobuf& buf) {
+    // An empty snapshot is applied during recovery fast-forward: the raft
+    // snapshot created when bootstrapping a pre-existing partition carries no
+    // per-STM data, so state_machine_manager hands each STM an empty buffer to
+    // advance over. There is no ctp_stm state to restore then -- e.g. a
+    // partition recovered mid tiered->cloud migration has no L1 state (its data
+    // is still in tiered storage). Keep the default (empty) state and advance,
+    // mirroring log_eviction_stm's empty-snapshot handling.
+    if (buf.empty()) {
+        co_return;
+    }
     auto snap = serde::from_iobuf<ctp_stm_snapshot>(buf.copy());
     _state = std::move(snap.state);
     _epoch_checker = snap.checker;

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -76,13 +76,23 @@ ctp_stm::ctp_stm(ss::logger& logger, raft::consensus* raft)
   : raft::persisted_stm<>(name, logger, raft)
   , _lock(ss::semaphore::max_counter()) {}
 
-ss::future<> ctp_stm::start() {
-    ssx::spawn_with_gate(_gate, [this] { return prefix_truncate_bg(); });
-    return raft::persisted_stm<>::start();
+ss::future<> ctp_stm::stop_bg_fiber() { return _bg_worker.stop(); }
+
+ss::future<> ctp_stm::sync_bg_fiber_to_mode() {
+    // The prefix-truncation fiber drives local-log trimming for cloud topics
+    // only; on any other mode the local log is managed by the storage layer
+    // and log_eviction_stm, and the pre-installed ctp_stm stays inert.
+    const bool should_run = _raft->log()->config().cloud_topic_enabled()
+                            && !_gate.is_closed();
+    if (should_run) {
+        co_await _bg_worker.start();
+    } else {
+        co_await _bg_worker.stop();
+    }
 }
 
 ss::future<> ctp_stm::stop() {
-    _lro_advanced.broken();
+    co_await stop_bg_fiber();
     _as.request_abort();
     _epoch_update_lock.broken();
     _epoch_updated_cv.broken();
@@ -108,34 +118,55 @@ ss::future<> ctp_stm::stop() {
     co_await _lock.wait(ss::semaphore::max_counter());
 }
 
-ss::future<> ctp_stm::prefix_truncate_bg() {
+ss::future<> ctp_bg_worker::start() {
+    auto units = co_await _lock.get_units();
+    if (_fiber.has_value()) {
+        co_return;
+    }
+    _fiber = prefix_truncate_bg();
+}
+
+ss::future<> ctp_bg_worker::stop() {
+    auto units = co_await _lock.get_units();
+    if (!_fiber.has_value()) {
+        co_return;
+    }
+    _as.request_abort();
+    _lro_advanced.signal();
+    co_await std::exchange(_fiber, std::nullopt).value();
+    // A fresh abort source so the fiber can be started again.
+    _as = ss::abort_source{};
+}
+
+ss::future<> ctp_bg_worker::prefix_truncate_bg() {
     static constexpr auto retry_backoff_time = 5s;
     static constexpr auto min_truncate_period = 60s;
-    while (!_gate.is_closed()) {
+    auto gh = _stm._gate.hold();
+    while (!_as.abort_requested() && !_stm._gate.is_closed()) {
         // Compute the truncation target once per iteration. storage.mode=cloud
         // trims aggressively (the local log only holds placeholders);
         // storage.mode=tiered_cloud honors local retention plus the compaction
         // floor and so keeps more data locally.
-        const bool is_tiered = _raft->log()->config().is_tiered_cloud();
+        const bool is_tiered = _stm._raft->log()->config().is_tiered_cloud();
         model::offset target;
         if (is_tiered) {
-            target = co_await compute_local_retention_offset();
+            target = co_await _stm.compute_local_retention_offset();
         } else {
             // storage.mode=cloud keeps only placeholders locally; the
             // reconciled data lives in the cloud, so trim as aggressively as
             // the max collectible offset and any active readers allow.
-            target = max_removable_local_log_offset();
+            target = _stm.max_removable_local_log_offset();
         }
         vlog(
-          _log.trace,
+          _stm._log.trace,
           "Waiting for prefix-truncate target to advance past {}, current "
           "snapshot index: {}",
           target,
-          _raft->last_snapshot_index());
+          _stm._raft->last_snapshot_index());
         try {
             if (
-              _raft->last_snapshot_index() >= target && _active_readers.empty()
-              && !is_tiered) {
+              _stm._raft->last_snapshot_index() >= target
+              && _stm._active_readers.empty() && !is_tiered) {
                 // Only wait without a timeout if there are no active readers
                 // that could be holding us back. tiered_cloud always polls
                 // because its space-management offset is set without signalling
@@ -152,23 +183,23 @@ ss::future<> ctp_stm::prefix_truncate_bg() {
                 co_return;
             }
             vlog(
-              _log.error,
+              _stm._log.error,
               "error waiting for prefix-truncate target to advance in ctp stm "
               "background loop: {}",
               std::current_exception());
         }
-        auto snapshot_index = _raft->last_snapshot_index();
+        auto snapshot_index = _stm._raft->last_snapshot_index();
         vlog(
-          _log.trace,
+          _stm._log.trace,
           "Attempting to snapshot ctp at {}, last snapshot at {}",
           target,
-          _raft->last_snapshot_index());
+          _stm._raft->last_snapshot_index());
         try {
-            co_await _raft->snapshot_and_truncate_log(target);
+            co_await _stm._raft->snapshot_and_truncate_log(target);
         } catch (...) {
             auto ex = std::current_exception();
             vlogl(
-              _log,
+              _stm._log,
               ssx::is_shutdown_exception(ex) ? ss::log_level::debug
                                              : ss::log_level::error,
               "Error occurred when attempting to write snapshot: {}",
@@ -178,9 +209,13 @@ ss::future<> ctp_stm::prefix_truncate_bg() {
         // If we successfully truncated our log, then wait a bit before
         // truncating it again so if LRO is making lots of rapid but small
         // progress we aren't snapshotting too much.
-        if (_raft->last_snapshot_index() > snapshot_index) {
-            co_await ss::sleep_abortable<ss::lowres_clock>(
-              min_truncate_period, _as);
+        if (_stm._raft->last_snapshot_index() > snapshot_index) {
+            try {
+                co_await ss::sleep_abortable<ss::lowres_clock>(
+                  min_truncate_period, _as);
+            } catch (const ss::sleep_aborted&) {
+                co_return;
+            }
         }
     }
 }
@@ -342,7 +377,7 @@ void ctp_stm::apply_advance_reconciled_offset(model::record record) {
     auto lrlo = cmd.last_reconciled_log_offset;
     vlog(_log.debug, "New LRO value is {}, log offset {}", lro, lrlo);
     _state.advance_last_reconciled_offset(lro, lrlo);
-    _lro_advanced.signal();
+    _bg_worker.notify_lro_advanced();
 }
 
 void ctp_stm::apply_set_start_offset(model::record record) {
@@ -370,7 +405,7 @@ void ctp_stm::apply_set_min_allowed_local_threshold(model::record record) {
       record.release_value());
     vlog(_log.debug, "Applying set_min_allowed_local_threshold: {}", cmd.value);
     _state.set_min_allowed_local_threshold(cmd.value);
-    _lro_advanced.signal();
+    _bg_worker.notify_lro_advanced();
 }
 
 void ctp_stm::apply_placeholder(const model::record_batch& batch) {

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -49,6 +49,38 @@ struct epoch_window_checker
     model::offset _latest_offset;
 };
 
+class ctp_stm;
+
+/// Manages ctp_stm's background fiber.
+class ctp_bg_worker {
+public:
+    explicit ctp_bg_worker(ctp_stm& stm)
+      : _stm(stm) {}
+
+    /// Spawn the fiber; a no-op when it is already running.
+    ss::future<> start();
+
+    /// Stop the fiber and wait for it to exit; a no-op when not running.
+    ss::future<> stop();
+
+    bool is_running() const { return _fiber.has_value(); }
+
+    void notify_lro_advanced() { _lro_advanced.signal(); }
+
+private:
+    ss::future<> prefix_truncate_bg();
+
+    ctp_stm& _stm;
+    ss::abort_source _as;
+    // Should be signaled every time the prefix-truncate target may have
+    // advanced.
+    ss::condition_variable _lro_advanced;
+    // Present while the fiber runs; resolves when it has exited.
+    std::optional<ss::future<>> _fiber;
+    // Serializes start()/stop() transitions.
+    ssx::mutex _lock{"ctp_bg_worker"};
+};
+
 /// The STM that tracks current cluster epoch and LRO.
 /// The goal is to guarantee that the cluster epoch is monotonic and
 /// to provide the smallest cluster epoch available through the
@@ -58,6 +90,7 @@ struct epoch_window_checker
 /// metadata batch to its in-memory state.
 class ctp_stm final : public raft::persisted_stm<> {
     friend class ctp_stm_api;
+    friend class ctp_bg_worker;
     friend struct ctp_stm_accessor; // for tests
 
     static constexpr auto sync_timeout = std::chrono::seconds(10);
@@ -65,8 +98,19 @@ class ctp_stm final : public raft::persisted_stm<> {
 public:
     static constexpr const char* name = "ctp_stm";
 
-    ss::future<> start() override;
     ss::future<> stop() override;
+
+    /// Start or stop the background prefix-truncation fiber to match the
+    /// partition's current storage mode.  Must not be run before
+    /// _raft->log()->config() has been populated with partition_mode from
+    /// partition_properties_stm. Called by partition::start() and
+    /// partition::apply_partition_storage_mode().
+    ss::future<> sync_bg_fiber_to_mode();
+
+    /// Stop the background work fiber. Called from stop() because
+    /// partition_manager::do_shutdown() tears down stms prior to calling
+    /// partition::stop().
+    ss::future<> stop_bg_fiber();
 
     ctp_stm(ss::logger&, raft::consensus*);
 
@@ -149,9 +193,6 @@ private:
     /// retention.bytes.
     storage::gc_config build_gc_config() const;
 
-    // The prefix truncation background loop
-    ss::future<> prefix_truncate_bg();
-
     /// Target log offset for the background prefix-truncate loop. Computed
     /// uniformly for all TSv2 partitions, compacted or not. The target
     /// combines:
@@ -189,9 +230,10 @@ private:
     // is purely idempotent in terms of operations applied.
     epoch_window_checker _epoch_checker;
 
-    // An abort source to stop the prefix truncation loop on stop.
-    ss::condition_variable _lro_advanced;
+    // Aborts in-flight sync and epoch-fence lock waiters on stop.
     ss::abort_source _as;
+
+    ctp_bg_worker _bg_worker{*this};
 
     // The last point that we truncated to, so we can skip writing a raft
     // snapshot if needed. This is volatile state (which is fine).

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
@@ -123,6 +123,18 @@ ctp_stm_api::advance_reconciled_offset(
   model::timeout_clock::time_point deadline,
   ss::abort_source& as,
   std::optional<kafka::offset> min_allowed_local_threshold) {
+    auto lrlo = _stm->_raft->log()->to_log_offset(kafka::offset_cast(lro));
+    return advance_reconciled_offset(
+      lro, lrlo, deadline, as, min_allowed_local_threshold);
+}
+
+ss::future<std::expected<std::monostate, ctp_stm_api_errc>>
+ctp_stm_api::advance_reconciled_offset(
+  kafka::offset lro,
+  model::offset lrlo,
+  model::timeout_clock::time_point deadline,
+  ss::abort_source& as,
+  std::optional<kafka::offset> min_allowed_local_threshold) {
     // The floor is monotonic: drop targets the state already covers.
     if (
       min_allowed_local_threshold.has_value()
@@ -138,7 +150,6 @@ ctp_stm_api::advance_reconciled_offset(
       model::record_batch_type::ctp_stm_command, model::offset(0));
 
     if (advances_lro) {
-        auto lrlo = _stm->_raft->log()->to_log_offset(kafka::offset_cast(lro));
         vlog(
           _log.debug,
           "Replicating ctp_stm_cmd::advance_reconciled_offset{{lro:{} "

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.h
@@ -85,6 +85,20 @@ public:
       ss::abort_source& as,
       std::optional<kafka::offset> min_allowed_local_threshold = std::nullopt);
 
+    /// As above, but with the reconciled log offset supplied explicitly rather
+    /// than derived from the raft offset translator. Used to seed the
+    /// reconciliation baseline of a TS-migrated partition directly to the
+    /// migration boundary (kafka offset + the raft offset of the last uploaded
+    /// TS segment) so the already-uploaded TS region of the local raft log can
+    /// be trimmed without waiting for the first CT reconciliation cycle.
+    ss::future<std::expected<std::monostate, ctp_stm_api_errc>>
+    advance_reconciled_offset(
+      kafka::offset last_reconciled_offset,
+      model::offset last_reconciled_log_offset,
+      model::timeout_clock::time_point deadline,
+      ss::abort_source& as,
+      std::optional<kafka::offset> min_allowed_local_threshold = std::nullopt);
+
     ss::future<std::expected<std::monostate, ctp_stm_api_errc>>
     set_start_offset(
       kafka::offset new_start_offset,

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_factory.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_factory.cc
@@ -12,13 +12,23 @@
 
 #include "cloud_topics/level_zero/stm/ctp_stm.h"
 #include "cloud_topics/logger.h"
+#include "config/configuration.h"
+#include "model/namespace.h"
 
 namespace cloud_topics::l0 {
 
 bool ctp_stm_factory::is_applicable_for(
   const storage::ntp_config& ntp_cfg) const {
-    return ntp_cfg.cloud_topic_enabled()
-           && !ntp_cfg.is_read_replica_mode_enabled();
+    if (ntp_cfg.is_read_replica_mode_enabled()) {
+        return false;
+    }
+    if (ntp_cfg.cloud_topic_enabled()) {
+        return true;
+    }
+    // Pre-install an (idle) ctp_stm on user-topic partitions when cloud
+    // topics are available to support migration to cloud/tsv2.
+    return config::shard_local_cfg().cloud_storage_enabled()
+           && model::is_user_topic(ntp_cfg.ntp());
 }
 
 void ctp_stm_factory::create(

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_factory.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_factory.cc
@@ -12,13 +12,25 @@
 
 #include "cloud_topics/level_zero/stm/ctp_stm.h"
 #include "cloud_topics/logger.h"
+#include "config/configuration.h"
 
 namespace cloud_topics::l0 {
 
 bool ctp_stm_factory::is_applicable_for(
   const storage::ntp_config& ntp_cfg) const {
-    return ntp_cfg.cloud_topic_enabled()
-           && !ntp_cfg.is_read_replica_mode_enabled();
+    if (ntp_cfg.is_read_replica_mode_enabled()) {
+        return false;
+    }
+    if (ntp_cfg.cloud_topic_enabled()) {
+        return true;
+    }
+    // Pre-install an (idle) ctp_stm on tiered-storage partitions when cloud
+    // topics are available, so a tiered->cloud/tiered_cloud migration needs no
+    // runtime STM install -- the STM is already present and inert
+    // (get_max_collectible_offset() returns max() until CT data is applied)
+    // until the partition becomes a cloud topic.
+    return config::shard_local_cfg().cloud_storage_enabled()
+           && ntp_cfg.is_archival_enabled();
 }
 
 void ctp_stm_factory::create(

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
@@ -179,7 +179,16 @@ model::offset ctp_stm_state::get_max_collectible_offset() const noexcept {
     if (_last_reconciled_log_offset.has_value()) {
         return _last_reconciled_log_offset.value();
     }
-    // Truncation is impossible without LRO
+    // An STM that has applied no CT data must not constrain truncation: it may
+    // be an inert passenger on a partition that is not (yet) a cloud topic
+    // (e.g. a tiered partition pre-installed with ctp_stm so a migration needs
+    // no runtime STM install). Without this a passenger would pin the local log
+    // at offset::min() forever.
+    if (!_max_applied_epoch.has_value()) {
+        return model::offset::max();
+    }
+    // CT data has been applied but not yet reconciled to L1: protect it.
+    // Truncation is impossible without an LRO.
     return model::offset::min();
 }
 

--- a/src/v/cloud_topics/level_zero/stm/tests/BUILD
+++ b/src/v/cloud_topics/level_zero/stm/tests/BUILD
@@ -55,7 +55,9 @@ redpanda_cc_gtest(
         "//src/v/model",
         "//src/v/raft/tests:raft_fixture",
         "//src/v/ssx:when_all",
+        "//src/v/storage",
         "//src/v/test_utils:gtest",
+        "//src/v/test_utils:scoped_config",
         "@googletest//:gtest",
     ],
 )

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
@@ -30,7 +30,9 @@ TEST(ctp_stm_state_test, initial_state) {
     EXPECT_FALSE(state.get_max_seen_epoch(model::term_id(1)).has_value());
     EXPECT_FALSE(state.get_last_reconciled_offset().has_value());
     EXPECT_FALSE(state.get_last_reconciled_log_offset().has_value());
-    EXPECT_EQ(state.get_max_collectible_offset(), model::offset::min());
+    // An STM with no applied CT data is an inert passenger and must not
+    // constrain truncation.
+    EXPECT_EQ(state.get_max_collectible_offset(), model::offset::max());
 }
 
 TEST(ctp_stm_state_test, advance_max_seen_epoch) {
@@ -107,8 +109,15 @@ TEST(ctp_stm_state_test, advance_last_reconciled_offset) {
 TEST(ctp_stm_state_test, get_max_collectible_offset) {
     ct::ctp_stm_state state;
 
+    // No CT data applied yet: inert passenger, do not constrain truncation.
+    EXPECT_EQ(state.get_max_collectible_offset(), model::offset::max());
+
+    // CT data applied (a placeholder advanced the epoch) but not yet reconciled
+    // to L1: protect it by pinning collection at min().
+    state.advance_epoch(ct::cluster_epoch(1), model::offset(10));
     EXPECT_EQ(state.get_max_collectible_offset(), model::offset::min());
 
+    // Once reconciled, collect up to the reconciled log offset.
     model::offset log_offset(500);
     state.advance_last_reconciled_offset(kafka::offset(300), log_offset);
     EXPECT_EQ(state.get_max_collectible_offset(), log_offset);

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -48,6 +48,10 @@ struct ctp_stm_accessor {
           snapshot.header, std::move(snapshot.data));
     }
 
+    auto apply_raft_snapshot(ctp_stm& stm, const iobuf& buf) {
+        return stm.apply_raft_snapshot(buf);
+    }
+
     bool epoch_cv_has_waiters(ctp_stm& stm) {
         return stm._epoch_updated_cv.has_waiters();
     }
@@ -562,6 +566,37 @@ TEST_F_CORO(ctp_stm_fixture, test_snapshot) {
         auto fence = co_await api(leader).fence_epoch(ct::cluster_epoch{1});
         ASSERT_FALSE_CORO(fence.has_value());
     }
+}
+
+// The recovery fast-forward hands each STM an empty raft snapshot to advance
+// over: a bootstrapped pre-existing partition carries no per-STM data, and a
+// partition recovered mid tiered->cloud migration has no L1 ctp_stm state (its
+// data is still in tiered storage). apply_raft_snapshot must treat an empty
+// buffer as a no-op -- not try to deserialize it (which threw before the guard)
+// and not clobber existing state with a default.
+TEST_F_CORO(ctp_stm_fixture, apply_empty_raft_snapshot_is_noop) {
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+    auto& leader = node(*get_leader());
+
+    // Establish some applied state so we can prove the empty snapshot doesn't
+    // reset it.
+    auto b1 = make_record_batch(ct::cluster_epoch{2}, model::offset{0}, 0);
+    auto res = co_await replicate_record_batch(leader, std::move(b1));
+    ASSERT_TRUE_CORO(res.has_value());
+    auto max_epoch_before = api(leader).get_max_epoch();
+    ASSERT_TRUE_CORO(max_epoch_before.has_value());
+    ASSERT_EQ_CORO(max_epoch_before.value(), ct::cluster_epoch{2});
+
+    auto stm = get_stm<0>(leader);
+    ct::ctp_stm_accessor a;
+    // Must not throw on an empty buffer.
+    co_await a.apply_raft_snapshot(*stm, iobuf{});
+
+    // State preserved, not reset to default.
+    auto max_epoch_after = api(leader).get_max_epoch();
+    ASSERT_TRUE_CORO(max_epoch_after.has_value());
+    ASSERT_EQ_CORO(max_epoch_after.value(), max_epoch_before.value());
 }
 
 TEST_F_CORO(ctp_stm_fixture, test_fence_epoch_concurrent_new_epoch) {

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -59,6 +59,10 @@ struct ctp_stm_accessor {
     ss::future<model::offset> compute_local_retention_offset(ctp_stm& stm) {
         return stm.compute_local_retention_offset();
     }
+
+    bool bg_fiber_running(const ctp_stm& stm) {
+        return stm._bg_worker.is_running();
+    }
 };
 } // namespace cloud_topics
 
@@ -66,7 +70,29 @@ class ctp_stm_fixture : public raft::stm_raft_fixture<ct::ctp_stm> {
 public:
     ss::future<> start() {
         enable_offset_translation();
+        // ctp_stm's prefix-truncate bg fiber only runs on cloud partitions;
+        // see ctp_stm::sync_bg_fiber_to_mode().
+        set_ntp_config_overrides(
+          storage::ntp_config::default_overrides{
+            .storage_mode = model::redpanda_storage_mode::cloud});
         co_await initialize_state_machines();
+        co_await sync_bg_fibers();
+    }
+
+    /// Start without the cloud storage mode: the pre-migration passenger
+    /// (ctp_stm pre-installed on a tiered/local partition).
+    ss::future<> start_as_passenger() {
+        enable_offset_translation();
+        co_await initialize_state_machines();
+        co_await sync_bg_fibers();
+    }
+
+    /// partition::start() starts the bg fiber after feeding
+    /// partition storage mode into _raft->log()->config()
+    ss::future<> sync_bg_fibers() {
+        for (auto& [id, node] : nodes()) {
+            co_await get_stm<0>(*node)->sync_bg_fiber_to_mode();
+        }
     }
 
     stm_shptrs_t create_stms(
@@ -1739,4 +1765,26 @@ TEST_F_CORO(
       kafka::offset_cast(kafka::offset{50}));
     ASSERT_EQ_CORO(
       co_await accessor.compute_local_retention_offset(*stm), expected);
+}
+
+TEST_F_CORO(ctp_stm_fixture, bg_fiber_follows_storage_mode) {
+    co_await start_as_passenger();
+    co_await wait_for_leader(raft::default_timeout());
+    auto& leader = node(*get_leader());
+    auto stm = get_stm<0>(leader);
+    ct::ctp_stm_accessor accessor;
+
+    /// The fiber doesn't start on its own
+    EXPECT_FALSE(accessor.bg_fiber_running(*stm));
+    co_await stm->sync_bg_fiber_to_mode();
+
+    /// The fiber doesn't run on a non-cloud partition
+    EXPECT_FALSE(accessor.bg_fiber_running(*stm));
+
+    /// Cutover advances the partition's storage mode to cloud; the next sync
+    /// starts the fiber.
+    leader.raft()->log()->set_partition_storage_mode(
+      model::redpanda_storage_mode::cloud);
+    co_await stm->sync_bg_fiber_to_mode();
+    EXPECT_TRUE(accessor.bg_fiber_running(*stm));
 }

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -11,15 +11,19 @@
 #include "cloud_topics/level_zero/stm/ctp_stm.h"
 #include "cloud_topics/level_zero/stm/ctp_stm_api.h"
 #include "cloud_topics/level_zero/stm/ctp_stm_commands.h"
+#include "cloud_topics/level_zero/stm/ctp_stm_factory.h"
 #include "cloud_topics/level_zero/stm/placeholder.h"
 #include "cloud_topics/logger.h"
 #include "cloud_topics/types.h"
 #include "model/fundamental.h"
+#include "model/metadata.h"
 #include "model/timeout_clock.h"
 #include "model/timestamp.h"
 #include "raft/tests/raft_fixture.h"
 #include "ssx/when_all.h"
+#include "storage/ntp_config.h"
 #include "test_utils/async.h"
+#include "test_utils/scoped_config.h"
 
 #include <optional>
 
@@ -48,6 +52,10 @@ struct ctp_stm_accessor {
           snapshot.header, std::move(snapshot.data));
     }
 
+    auto apply_raft_snapshot(ctp_stm& stm, const iobuf& buf) {
+        return stm.apply_raft_snapshot(buf);
+    }
+
     bool epoch_cv_has_waiters(ctp_stm& stm) {
         return stm._epoch_updated_cv.has_waiters();
     }
@@ -70,8 +78,8 @@ class ctp_stm_fixture : public raft::stm_raft_fixture<ct::ctp_stm> {
 public:
     ss::future<> start() {
         enable_offset_translation();
-        // ctp_stm's prefix-truncate bg fiber only runs on cloud partitions;
-        // see ctp_stm::sync_bg_fiber_to_mode().
+        // ctp_stm max_removable_local_log_offset() behavior depends on
+        // ntp_config overrides
         set_ntp_config_overrides(
           storage::ntp_config::default_overrides{
             .storage_mode = model::redpanda_storage_mode::cloud});
@@ -588,6 +596,18 @@ TEST_F_CORO(ctp_stm_fixture, test_snapshot) {
         auto fence = co_await api(leader).fence_epoch(ct::cluster_epoch{1});
         ASSERT_FALSE_CORO(fence.has_value());
     }
+}
+
+// Tolerate an empty snapshot as a noop after ctp_stm installation.
+TEST_F_CORO(ctp_stm_fixture, apply_empty_raft_snapshot_is_noop) {
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+    auto& leader = node(*get_leader());
+
+    auto stm = get_stm<0>(leader);
+    ct::ctp_stm_accessor a;
+    // Must not throw on an empty buffer.
+    co_await a.apply_raft_snapshot(*stm, iobuf{});
 }
 
 TEST_F_CORO(ctp_stm_fixture, test_fence_epoch_concurrent_new_epoch) {
@@ -1765,6 +1785,68 @@ TEST_F_CORO(
       kafka::offset_cast(kafka::offset{50}));
     ASSERT_EQ_CORO(
       co_await accessor.compute_local_retention_offset(*stm), expected);
+}
+
+// A ctp_stm pre-installed on a non-cloud partition doesn't own trimming and
+// must not pin truncation.
+TEST_F_CORO(ctp_stm_fixture, passenger_does_not_pin_truncation) {
+    co_await start_as_passenger();
+    co_await wait_for_leader(raft::default_timeout());
+    auto stm = get_stm<0>(node(*get_leader()));
+    ct::ctp_stm_accessor accessor;
+    ASSERT_EQ_CORO(
+      accessor.max_removable_local_log_offset(*stm), model::offset::max());
+}
+
+// On a cloud-topic partition, nothing may be trimmed before reconciliation
+// records progress — even while the state is still empty.
+TEST_F_CORO(ctp_stm_fixture, cloud_partition_pins_truncation_when_empty) {
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+    auto stm = get_stm<0>(node(*get_leader()));
+    ct::ctp_stm_accessor accessor;
+    ASSERT_EQ_CORO(
+      accessor.max_removable_local_log_offset(*stm), model::offset::min());
+}
+
+namespace {
+storage::ntp_config make_factory_cfg(
+  model::ntp ntp,
+  model::redpanda_storage_mode mode,
+  bool read_replica = false) {
+    storage::ntp_config::default_overrides o;
+    o.storage_mode = mode;
+    if (read_replica) {
+        o.read_replica = true;
+    }
+    return {
+      std::move(ntp),
+      "",
+      std::make_unique<storage::ntp_config::default_overrides>(o)};
+}
+} // namespace
+
+TEST(ctp_stm_factory_test, is_applicable_for) {
+    using mode = model::redpanda_storage_mode;
+    ct::l0::ctp_stm_factory factory;
+    auto user_ntp = model::ntp(
+      model::kafka_namespace, model::topic("t"), model::partition_id(0));
+
+    scoped_config cfg;
+    cfg.get("cloud_storage_enabled").set_value(true);
+    for (auto m : {mode::unset, mode::local, mode::tiered, mode::cloud}) {
+        EXPECT_TRUE(factory.is_applicable_for(make_factory_cfg(user_ntp, m)));
+    }
+    EXPECT_FALSE(factory.is_applicable_for(
+      make_factory_cfg(user_ntp, mode::cloud, /*read_replica=*/true)));
+    EXPECT_FALSE(factory.is_applicable_for(
+      make_factory_cfg(model::controller_ntp, mode::local)));
+
+    cfg.get("cloud_storage_enabled").set_value(false);
+    EXPECT_FALSE(
+      factory.is_applicable_for(make_factory_cfg(user_ntp, mode::local)));
+    EXPECT_TRUE(
+      factory.is_applicable_for(make_factory_cfg(user_ntp, mode::cloud)));
 }
 
 TEST_F_CORO(ctp_stm_fixture, bg_fiber_follows_storage_mode) {

--- a/src/v/cluster/BUILD
+++ b/src/v/cluster/BUILD
@@ -1468,6 +1468,7 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/model",
         "//src/v/raft",
+        "//src/v/ssx:mutex",
         "//src/v/storage",
         "@seastar",
     ],

--- a/src/v/cluster/BUILD
+++ b/src/v/cluster/BUILD
@@ -2500,6 +2500,7 @@ redpanda_cc_library(
         "//src/v/ssx:minimum_interval_timer",
         "//src/v/ssx:mutex",
         "//src/v/ssx:rate_limited_function",
+        "//src/v/ssx:reconciler",
         "//src/v/ssx:semaphore",
         "//src/v/ssx:sformat",
         "//src/v/ssx:single_sharded",

--- a/src/v/cluster/archival/archival_metadata_stm.cc
+++ b/src/v/cluster/archival/archival_metadata_stm.cc
@@ -1729,10 +1729,14 @@ archival_metadata_stm_factory::archival_metadata_stm_factory(
 
 bool archival_metadata_stm_factory::is_applicable_for(
   const storage::ntp_config& ntp_cfg) const {
+    // The archival STM is created on cloud-topic partitions too (no
+    // cloud_topic_enabled() == false guard). For a partition migrated from
+    // tiered storage it is reconstructed from its snapshot and its manifest
+    // stays available to gate local-log truncation. For a partition that was
+    // always a cloud topic the manifest is empty, so it is an inert passenger.
     return _cloud_storage_enabled && _cloud_storage_api.local_is_initialized()
            && ntp_cfg.ntp().tp.topic != model::kafka_consumer_offsets_topic
-           && ntp_cfg.ntp().ns == model::kafka_namespace
-           && ntp_cfg.cloud_topic_enabled() == false;
+           && ntp_cfg.ntp().ns == model::kafka_namespace;
 }
 
 void archival_metadata_stm_factory::create(

--- a/src/v/cluster/archival/archival_metadata_stm.cc
+++ b/src/v/cluster/archival/archival_metadata_stm.cc
@@ -1729,10 +1729,13 @@ archival_metadata_stm_factory::archival_metadata_stm_factory(
 
 bool archival_metadata_stm_factory::is_applicable_for(
   const storage::ntp_config& ntp_cfg) const {
+    // Retain archival_metadata_stm if _cloud_storage_enabled for user topics
+    // unless the topic was created originally as cloud or tsv2.
+    // Topics migrated from local/tsv1 to cloud/tsv2 keep the stm.
     return _cloud_storage_enabled && _cloud_storage_api.local_is_initialized()
            && ntp_cfg.ntp().tp.topic != model::kafka_consumer_offsets_topic
            && ntp_cfg.ntp().ns == model::kafka_namespace
-           && ntp_cfg.cloud_topic_enabled() == false;
+           && (ntp_cfg.cloud_topic_enabled() == false || ntp_cfg.migrated_to_cloud());
 }
 
 void archival_metadata_stm_factory::create(

--- a/src/v/cluster/archival/archival_metadata_stm.cc
+++ b/src/v/cluster/archival/archival_metadata_stm.cc
@@ -1373,6 +1373,18 @@ model::offset archival_metadata_stm::max_removable_local_log_offset() {
         collect_all = false;
     }
 
+    // The manifest, not the storage mode, governs local-log truncation. While
+    // the partition still holds archived data (a non-empty live manifest or a
+    // spillover archive) it is still served from tiered storage and may hold
+    // local data not yet uploaded, so its local log must not be trimmed past
+    // cloud_recoverable_offset(). is_archival_enabled() can report false while
+    // archived data is still present -- e.g. a partition mid tiered->cloud
+    // migration whose effective storage mode is cloud -- which would otherwise
+    // collect_all and stop constraining truncation, evicting the not-yet-
+    // uploaded data. Gate collect_all on holds_archived_data() so it takes
+    // effect only once the manifest is cleared.
+    collect_all = collect_all && !holds_archived_data();
+
     if (collect_all || is_read_replica || (uploads_paused && gaps_allowed)) {
         // The archival is disabled but the state machine still exists so we
         // shouldn't stop eviction from happening.
@@ -1672,6 +1684,11 @@ ss::future<> archival_metadata_stm::stop() {
 const cloud_storage::partition_manifest&
 archival_metadata_stm::manifest() const {
     return *_manifest;
+}
+
+bool archival_metadata_stm::holds_archived_data() const {
+    return _manifest->size() > 0
+           || _manifest->get_archive_start_offset() != model::offset{};
 }
 
 model::offset archival_metadata_stm::get_start_offset() const {

--- a/src/v/cluster/archival/archival_metadata_stm.h
+++ b/src/v/cluster/archival/archival_metadata_stm.h
@@ -216,6 +216,11 @@ public:
     /// added with `add_segments`.
     const cloud_storage::partition_manifest& manifest() const;
 
+    /// True if the partition holds tiered-storage data: the manifest has
+    /// segments, or a non-empty spillover archive. Used to detect that a
+    /// partition is (still) tiered storage independent of the topic config.
+    bool holds_archived_data() const;
+
     ss::future<> stop() override;
 
     static ss::future<> make_snapshot(
@@ -252,6 +257,7 @@ public:
     model::offset get_last_offset() const;
     model::offset get_archive_start_offset() const;
     model::offset get_archive_clean_offset() const;
+
     kafka::offset get_start_kafka_offset() const;
 
     // Return list of all segments that has to be

--- a/src/v/cluster/archival/tests/BUILD
+++ b/src/v/cluster/archival/tests/BUILD
@@ -66,6 +66,7 @@ redpanda_cc_btest(
         "//src/v/cloud_storage_clients",
         "//src/v/cluster",
         "//src/v/cluster:errc",
+        "//src/v/cluster:log_eviction_stm",
         "//src/v/cluster:state_machine_registry",
         "//src/v/cluster:topic_table",
         "//src/v/config",

--- a/src/v/cluster/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/cluster/archival/tests/archival_metadata_stm_test.cc
@@ -256,6 +256,42 @@ FIXTURE_TEST(
       archival_stm->manifest().begin()->committed_offset, model::offset(99));
 }
 
+// With archival disabled (the flipped, mid-migration storage mode) but a
+// non-empty manifest, max_removable_local_log_offset keeps constraining
+// local-log truncation rather than collecting all -- protecting tiered-storage
+// data that has not yet been uploaded.
+FIXTURE_TEST(test_migration_local_trim_clamp, archival_metadata_stm_fixture) {
+    wait_for_confirmed_leader();
+
+    // The fixture's partition has archival disabled. With an empty manifest,
+    // nothing constrains local-log truncation.
+    BOOST_REQUIRE_EQUAL(
+      archival_stm->max_removable_local_log_offset(), model::offset::max());
+
+    // Add a segment so the manifest is non-empty.
+    std::vector<cloud_storage::segment_meta> m;
+    m.push_back(
+      segment_meta{
+        .base_offset = model::offset(0),
+        .committed_offset = model::offset(99),
+        .archiver_term = model::term_id(1),
+        .segment_term = model::term_id(1)});
+    archival_stm
+      ->add_segments(
+        m,
+        std::nullopt,
+        model::producer_id{},
+        ss::lowres_clock::now() + 10s,
+        never_abort,
+        cluster::segment_validated::yes)
+      .get();
+    BOOST_REQUIRE_EQUAL(archival_stm->manifest().size(), 1);
+
+    // Now truncation is constrained (no longer offset::max()).
+    BOOST_REQUIRE_NE(
+      archival_stm->max_removable_local_log_offset(), model::offset::max());
+}
+
 FIXTURE_TEST(test_archival_stm_segment_replace, archival_metadata_stm_fixture) {
     wait_for_confirmed_leader();
     std::vector<cloud_storage::segment_meta> m1;

--- a/src/v/cluster/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/cluster/archival/tests/archival_metadata_stm_test.cc
@@ -12,6 +12,7 @@
 #include "cloud_storage/types.h"
 #include "cloud_storage_clients/upstream_registry.h"
 #include "cluster/archival/archival_metadata_stm.h"
+#include "cluster/log_eviction_stm.h"
 #include "http/tests/http_imposter.h"
 #include "model/record.h"
 #include "model/timestamp.h"
@@ -1108,4 +1109,69 @@ FIXTURE_TEST(
       archival_stm->manifest().get_archive_clean_offset());
     BOOST_REQUIRE_EQUAL(
       archival_stm->manifest().full_log_start_kafka_offset(), kafka::offset(0));
+}
+
+namespace {
+storage::ntp_config make_predicate_cfg(
+  model::ntp ntp,
+  model::redpanda_storage_mode mode,
+  model::redpanda_storage_mode migrated) {
+    storage::ntp_config::default_overrides o;
+    o.storage_mode = mode;
+    o.migrated_from = migrated;
+    return {
+      std::move(ntp),
+      "",
+      std::make_unique<storage::ntp_config::default_overrides>(o)};
+}
+} // namespace
+
+// Test is_applicable_for dependencies on mode and migrated_from:
+// - local and tsv1 topics have archival_metadata_stm and log_eviction_stm
+// - migrated topics retain archival_metadata_stm and log_eviction_stm
+// - natively created cloud topics never carry them
+FIXTURE_TEST(
+  test_migrated_membership_predicates, archival_metadata_stm_fixture) {
+    using mode = model::redpanda_storage_mode;
+    cluster::archival_metadata_stm_factory archival_factory(
+      true, cloud_api, _feature_table);
+    cluster::log_eviction_stm_factory eviction_factory(_storage.local().kvs());
+
+    auto user_ntp = model::ntp(
+      model::kafka_namespace, model::topic("t"), model::partition_id(0));
+
+    struct row {
+        mode storage_mode;
+        mode migrated_from;
+        bool expected;
+    };
+    for (const auto& r : {
+           row{mode::tiered, mode::unset, true},
+           row{mode::local, mode::unset, true},
+           row{mode::cloud, mode::unset, false},
+           row{mode::tiered_cloud, mode::unset, false},
+           row{mode::cloud, mode::tiered, true},
+           row{mode::cloud, mode::local, true},
+           row{mode::tiered_cloud, mode::tiered, true},
+         }) {
+        auto cfg = make_predicate_cfg(
+          user_ntp, r.storage_mode, r.migrated_from);
+        BOOST_CHECK_EQUAL(archival_factory.is_applicable_for(cfg), r.expected);
+        BOOST_CHECK_EQUAL(eviction_factory.is_applicable_for(cfg), r.expected);
+    }
+
+    // Identity exclusions hold regardless of migration state.
+    auto offsets_ntp = model::ntp(
+      model::kafka_namespace,
+      model::kafka_consumer_offsets_topic,
+      model::partition_id(0));
+    auto offsets_cfg = make_predicate_cfg(
+      offsets_ntp, mode::cloud, mode::tiered);
+    BOOST_CHECK(!archival_factory.is_applicable_for(offsets_cfg));
+    BOOST_CHECK(!eviction_factory.is_applicable_for(offsets_cfg));
+
+    auto internal_cfg = make_predicate_cfg(
+      model::controller_ntp, mode::cloud, mode::tiered);
+    BOOST_CHECK(!archival_factory.is_applicable_for(internal_cfg));
+    BOOST_CHECK(!eviction_factory.is_applicable_for(internal_cfg));
 }

--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -18,6 +18,8 @@
 #include "serde/envelope.h"
 #include "ssx/future-util.h"
 
+#include <seastar/core/when_all.hh>
+
 namespace cluster {
 
 struct snapshot_data
@@ -35,29 +37,59 @@ struct snapshot_data
 
 log_eviction_stm::log_eviction_stm(
   raft::consensus* raft, ss::logger& logger, storage::kvstore& kvstore)
-  : base_t("log_eviction_stm.snapshot", logger, raft, kvstore) {}
+  : base_t("log_eviction_stm.snapshot", logger, raft, kvstore)
+  , _bg_worker(*this) {}
 
-ss::future<> log_eviction_stm::start() {
-    ssx::spawn_with_gate(_gate, [this] { return monitor_log_eviction(); });
-    ssx::spawn_with_gate(
-      _gate, [this] { return handle_log_eviction_events(); });
-    return base_t::start();
-}
+ss::future<> log_eviction_stm::stop_bg_fiber() { return _bg_worker.stop(); }
 
 ss::future<> log_eviction_stm::stop() {
-    _as.request_abort();
-    _has_pending_truncation.broken();
+    co_await stop_bg_fiber();
     co_await base_t::stop();
 }
 
-ss::future<> log_eviction_stm::handle_log_eviction_events() {
+ss::future<> log_eviction_stm::sync_bg_fiber_to_mode() {
+    // Storage-driven eviction only applies to partitions that are not cloud
+    // topics; on a cloud topic (in particular a migrated one, which retains
+    // this stm) local-log trimming is driven by the ctp_stm instead.
+    const bool should_run = !_raft->log()->config().cloud_topic_enabled()
+                            && !_gate.is_closed();
+    if (should_run) {
+        co_await _bg_worker.start();
+    } else {
+        co_await _bg_worker.stop();
+    }
+}
+
+ss::future<> log_eviction_bg_worker::start() {
+    auto units = co_await _lock.get_units();
+    if (_fibers.has_value()) {
+        co_return;
+    }
+    _fibers = ss::when_all_succeed(
+                monitor_log_eviction(), handle_log_eviction_events())
+                .discard_result();
+}
+
+ss::future<> log_eviction_bg_worker::stop() {
+    auto units = co_await _lock.get_units();
+    if (!_fibers.has_value()) {
+        co_return;
+    }
+    _as.request_abort();
+    _has_pending_truncation.signal();
+    co_await std::exchange(_fibers, std::nullopt).value();
+    // A fresh abort source so the fibers can be started again.
+    _as = ss::abort_source{};
+}
+
+ss::future<> log_eviction_bg_worker::handle_log_eviction_events() {
     static constexpr auto retry_backoff_time = 5s;
     /// This method is executed as a background fiber and it attempts to write
     /// snapshots as close to effective_start_offset as possible.
-    auto gh = _gate.hold();
+    auto gh = _stm.gate().hold();
 
     bool previous_iter_truncated_everything = true;
-    while (!_as.abort_requested() && !_gate.is_closed()) {
+    while (!_as.abort_requested() && !_stm.gate().is_closed()) {
         /// This background fiber can be woken-up via apply() when special
         /// batches are processed or by the storage layer when local
         /// eviction is triggered.
@@ -84,10 +116,10 @@ ss::future<> log_eviction_stm::handle_log_eviction_events() {
         }
 
         auto evict_until = std::max(
-          _delete_records_eviction_offset, _storage_eviction_offset);
+          _stm._delete_records_eviction_offset, _stm._storage_eviction_offset);
         try {
             previous_iter_truncated_everything
-              = co_await _raft->snapshot_and_truncate_log(evict_until);
+              = co_await _stm._raft->snapshot_and_truncate_log(evict_until);
         } catch (const ss::abort_requested_exception& ex) {
             // ignore abort requested exception, shutting down
             std::ignore = ex;
@@ -98,27 +130,28 @@ ss::future<> log_eviction_stm::handle_log_eviction_events() {
             std::ignore = ex;
         } catch (const std::exception& e) {
             vlog(
-              _log.error,
+              _stm._log.error,
               "Error occurred when attempting to write snapshot: {}",
               e);
         }
     }
 }
 
-ss::future<model::offset> log_eviction_stm::storage_eviction_event() {
-    return _raft->monitor_log_eviction(_as);
+ss::future<model::offset>
+log_eviction_stm::storage_eviction_event(ss::abort_source& as) {
+    return _raft->monitor_log_eviction(as);
 }
 
-ss::future<> log_eviction_stm::monitor_log_eviction() {
+ss::future<> log_eviction_bg_worker::monitor_log_eviction() {
     /// This method is executed as a background fiber and is listening for
     /// eviction events from the storage layer. These events will trigger a
     /// write snapshot, and the log will be prefix truncated.
-    auto gh = _gate.hold();
+    auto gh = _stm.gate().hold();
     while (!_as.abort_requested()) {
         try {
-            auto eviction_offset = co_await storage_eviction_event();
-            if (eviction_offset > _storage_eviction_offset) {
-                _storage_eviction_offset = eviction_offset;
+            auto eviction_offset = co_await _stm.storage_eviction_event(_as);
+            if (eviction_offset > _stm._storage_eviction_offset) {
+                _stm._storage_eviction_offset = eviction_offset;
                 _has_pending_truncation.signal();
             }
         } catch (const ss::abort_requested_exception&) {
@@ -126,7 +159,7 @@ ss::future<> log_eviction_stm::monitor_log_eviction() {
         } catch (const ss::gate_closed_exception&) {
             // ignore gate closed exception, shutting down
         } catch (const std::exception& e) {
-            vlog(_log.info, "Error handling log eviction - {}", e);
+            vlog(_stm._log.info, "Error handling log eviction - {}", e);
         }
     }
 }
@@ -337,7 +370,7 @@ ss::future<> log_eviction_stm::do_apply(const model::record_batch& batch) {
 
         /// Set the delete records offset.
         _delete_records_eviction_offset = truncate_offset;
-        _has_pending_truncation.signal();
+        _bg_worker.notify_pending_truncation();
     }
 }
 

--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -384,9 +384,15 @@ log_eviction_stm_factory::log_eviction_stm_factory(storage::kvstore& kvstore)
 
 bool log_eviction_stm_factory::is_applicable_for(
   const storage::ntp_config& cfg) const {
-    if (cfg.cloud_topic_enabled()) {
-        return false;
-    }
+    // (No cloud_topic_enabled() == false guard.) Install the eviction STM on
+    // cloud-topic partitions too. STM membership is fixed at construction and a
+    // tiered->cloud migration does not reconstruct the partition, so a
+    // partition migrating from tiered storage -- still served from its local
+    // log + archival manifest -- must already carry the eviction STM to keep
+    // supporting prefix truncation (DeleteRecords) and retention while
+    // migrating. On a native cloud topic it is an inert passenger: retention
+    // and DeleteRecords go through the L1 path, so no local eviction requests
+    // are generated.
     return !storage::deletion_exempt(cfg.ntp());
 }
 

--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -417,7 +417,8 @@ log_eviction_stm_factory::log_eviction_stm_factory(storage::kvstore& kvstore)
 
 bool log_eviction_stm_factory::is_applicable_for(
   const storage::ntp_config& cfg) const {
-    if (cfg.cloud_topic_enabled()) {
+    // No log_eviction_stm on cloud/tsv2, unless migrated from local/tsv1
+    if (cfg.cloud_topic_enabled() && !cfg.migrated_to_cloud()) {
         return false;
     }
     return !storage::deletion_exempt(cfg.ntp());

--- a/src/v/cluster/log_eviction_stm.h
+++ b/src/v/cluster/log_eviction_stm.h
@@ -16,6 +16,7 @@
 #include "model/fundamental.h"
 #include "raft/fwd.h"
 #include "raft/persisted_stm.h"
+#include "ssx/mutex.h"
 #include "storage/kvstore.h"
 
 #include <seastar/core/abort_source.hh>
@@ -46,9 +47,45 @@ namespace testing {
 class log_eviction_stm_accessor;
 } // namespace testing
 
+class log_eviction_stm;
+
+/// Manages log_eviction_stm's background fibers: handle_log_eviction_events()
+/// and monitor_log_eviction().
+class log_eviction_bg_worker {
+public:
+    explicit log_eviction_bg_worker(log_eviction_stm& stm)
+      : _stm(stm) {}
+
+    /// Spawn the fibers; a no-op when they are already running.
+    ss::future<> start();
+
+    /// Stop the fibers and wait for them to exit; a no-op when not running.
+    ss::future<> stop();
+
+    bool is_running() const { return _fibers.has_value(); }
+
+    void notify_pending_truncation() { _has_pending_truncation.signal(); }
+
+private:
+    friend class testing::log_eviction_stm_accessor;
+
+    ss::future<> monitor_log_eviction();
+    ss::future<> handle_log_eviction_events();
+
+    log_eviction_stm& _stm;
+    ss::abort_source _as;
+    // Should be signaled every time a pending truncation may have appeared.
+    ss::condition_variable _has_pending_truncation;
+    // Present while the fibers run, resolves when both have exited.
+    std::optional<ss::future<>> _fibers;
+    // Serializes start()/stop() transitions.
+    ssx::mutex _lock{"log_eviction_bg_worker"};
+};
+
 class log_eviction_stm
   : public raft::persisted_stm<raft::kvstore_backed_stm_snapshot> {
     friend class testing::log_eviction_stm_accessor;
+    friend class log_eviction_bg_worker;
 
 public:
     static constexpr std::string_view name = "log_eviction_stm";
@@ -56,7 +93,17 @@ public:
     using offset_result = result<model::offset, std::error_code>;
     log_eviction_stm(raft::consensus*, ss::logger&, storage::kvstore&);
 
-    ss::future<> start() override;
+    /// Start or stop the background eviction fibers to match the partition's
+    /// current storage mode.  Must not be run before _raft->log()->config()
+    /// has been populated with partition_mode from partition_properties_stm.
+    /// Called by partition::start() and
+    /// partition::apply_partition_storage_mode().
+    ss::future<> sync_bg_fiber_to_mode();
+
+    /// Stop the background work fibers. Called from stop() because
+    /// partition_manager::do_shutdown() tears down stms prior to calling
+    /// partition::stop().
+    ss::future<> stop_bg_fiber();
 
     ss::future<> stop() override;
 
@@ -128,15 +175,13 @@ protected:
     ss::future<raft::stm_snapshot>
     take_local_snapshot(ssx::semaphore_units apply_units) override;
 
-    virtual ss::future<model::offset> storage_eviction_event();
+    virtual ss::future<model::offset> storage_eviction_event(ss::abort_source&);
 
 private:
     using base_t = raft::persisted_stm<raft::kvstore_backed_stm_snapshot>;
     void increment_start_offset(model::offset);
     bool should_process_evict(model::offset);
 
-    ss::future<> monitor_log_eviction();
-    ss::future<> handle_log_eviction_events();
     ss::future<> do_apply(const model::record_batch&) final;
     ss::future<> apply_raft_snapshot(const iobuf&) final;
 
@@ -146,8 +191,6 @@ private:
       std::optional<std::reference_wrapper<ss::abort_source>> as);
 
 private:
-    ss::abort_source _as;
-
     // Offset we are able to truncate based on local retention policy, as
     // signaled by the storage layer. This value is not maintained via the
     // persisted_stm and may be different across replicas.
@@ -158,11 +201,10 @@ private:
     // replica.
     model::offset _delete_records_eviction_offset;
 
-    // Should be signaled every time either of the above offsets are updated.
-    ss::condition_variable _has_pending_truncation;
-
     // Kafka offset of the last `prefix_truncate_record` applied to this stm.
     kafka::offset _cached_kafka_start_offset_override;
+
+    log_eviction_bg_worker _bg_worker;
 
     ss::gate& gate() { return _gate; }
 };
@@ -179,16 +221,8 @@ public:
 
     static void reset_gate(log_eviction_stm& stm) { stm.gate() = ss::gate{}; }
 
-    static void request_abort(log_eviction_stm& stm) {
-        stm._as.request_abort();
-    }
-
-    static void reset_abort_source(log_eviction_stm& stm) {
-        stm._as = ss::abort_source{};
-    }
-
-    static void break_has_pending_truncation(log_eviction_stm& stm) {
-        stm._has_pending_truncation.broken();
+    static bool bg_fiber_running(const log_eviction_stm& stm) {
+        return stm._bg_worker.is_running();
     }
 };
 

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -31,6 +31,7 @@
 #include "raft/fwd.h"
 #include "raft/state_machine_manager.h"
 #include "ssx/future-util.h"
+#include "ssx/sformat.h"
 #include "ssx/when_all.h"
 #include "storage/ntp_config.h"
 
@@ -53,6 +54,12 @@ partition::partition(
   ss::sharded<cloud_topics::state_accessors>* ct_state)
   : _raft(std::move(r))
   , _cloud_topics_state(ct_state)
+  , _partition_storage_mode_apply(
+      _partition_storage_mode_gate,
+      clusterlog,
+      ssx::sformat("{} partition_storage_mode apply", _raft->ntp()),
+      [this] { return apply_partition_storage_mode(); },
+      _as)
   , _probe(std::make_unique<replicated_partition_probe>(*this))
   , _feature_table(feature_table)
   , _archival_conf(std::move(archival_conf))
@@ -522,6 +529,31 @@ ss::future<> partition::start(
         co_await _cloud_storage_partition->start();
     }
 
+    // Feed the partition's durable storage mode into the log's ntp_config and
+    // keep it up to date as the STM applies changes. Reading replicated STM
+    // state is always safe; writes (which require the partition_storage_mode
+    // feature) are gated separately. Until partition_storage_mode is set,
+    // partition_storage_mode() is `unset` and ntp_config falls back to the
+    // topic-config-derived mode.
+    //
+    // Registered here, rather than as soon as the stm is available, because the
+    // callback's apply can build an archiver, and an archiver holds the
+    // manifest view constructed above.
+    if (_partition_properties_stm) {
+        // Notify rather than reconcile inline: this fires on the raft apply /
+        // snapshot-restore fiber, which must not block on stopping the archiver
+        // -- that stop waits on archiver fibers which themselves wait for
+        // archival_metadata_stm to apply, and apply cannot proceed while the
+        // callback is blocked.
+        _partition_properties_stm->set_partition_storage_mode_change_callback(
+          [this] { _partition_storage_mode_apply.notify(); });
+        // Synchronously for the initial load: the archiver decision below reads
+        // ntp_config, so the mode has to be in place before it runs rather than
+        // deferred to a fiber that may not have run yet.
+        _raft->log()->set_partition_storage_mode(
+          _partition_properties_stm->partition_storage_mode());
+    }
+
     {
         auto archiver_reset_guard = co_await ssx::with_timeout_abortable(
           ss::get_units(_archiver_reset_mutex, 1),
@@ -548,6 +580,12 @@ ss::future<> partition::stop() {
     auto partition_ntp = ntp();
     vlog(clusterlog.debug, "Stopping partition: {}", partition_ntp);
     _as.request_abort();
+
+    // Before the archiver teardown below, so nothing is mid-rebuild while we
+    // stop it. Closed after _as is aborted, so an in-flight loop stops retrying
+    // and gives up on the reset mutex rather than restarting the archiver we
+    // are stopping.
+    co_await _partition_storage_mode_gate.close();
 
     unregister_flush_hook(_archiver_flush_subscription);
 
@@ -1758,6 +1796,34 @@ partition::force_abort_replica_set_update(model::revision_id rev) {
     return _raft->abort_configuration_change(rev);
 }
 consensus_ptr partition::raft() const { return _raft; }
+
+ss::future<> partition::apply_partition_storage_mode() {
+    const auto& ntp_cfg = _raft->log()->config();
+    const auto durable = _partition_properties_stm->partition_storage_mode();
+    const auto current = ntp_cfg.partition_storage_mode();
+    const auto effective = ntp_cfg.resolve_partition_storage_mode(durable);
+
+    if (current != effective) {
+        vlog(
+          clusterlog.info,
+          "{}: partition_storage_mode {} -> {}",
+          _raft->ntp(),
+          current,
+          effective);
+    } else {
+        vlog(
+          clusterlog.debug,
+          "{}: recording partition_storage_mode {}, effective mode unchanged",
+          _raft->ntp(),
+          durable);
+    }
+
+    _raft->log()->set_partition_storage_mode(durable);
+
+    if (should_construct_archiver() != static_cast<bool>(_archiver)) {
+        co_await restart_archiver(true);
+    }
+}
 
 ss::future<result<model::offset>> partition::set_writes_disabled(
   partition_properties_stm::writes_disabled disable,

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -32,14 +32,17 @@
 #include "raft/state_machine_manager.h"
 #include "ssx/future-util.h"
 #include "ssx/sformat.h"
+#include "ssx/sleep_abortable.h"
 #include "ssx/when_all.h"
 #include "storage/ntp_config.h"
 
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
 #include <seastar/util/defer.hh>
 
 #include <chrono>
 #include <optional>
+#include <system_error>
 
 namespace cluster {
 
@@ -59,6 +62,12 @@ partition::partition(
       clusterlog,
       ssx::sformat("{} partition_storage_mode apply", _raft->ntp()),
       [this] { return apply_partition_storage_mode(); },
+      _as)
+  , _partition_storage_mode_sync(
+      _partition_storage_mode_gate,
+      clusterlog,
+      ssx::sformat("{} partition_storage_mode sync", _raft->ntp()),
+      [this] { return sync_partition_storage_mode(); },
       _as)
   , _probe(std::make_unique<replicated_partition_probe>(*this))
   , _feature_table(feature_table)
@@ -940,27 +949,43 @@ ss::future<> partition::update_configuration(topic_properties new_properties) {
     // Pass the configuration update to the raft layer
     _raft->notify_config_update();
 
-    // If this partition's cloud storage mode changed, rebuild the archiver.
-    // This must happen after the raft+storage update, because it reads raft's
-    // ntp_config to decide whether to construct an archiver.
-    if (cloud_storage_changed) {
-        co_await restart_archiver(true);
-    } else {
-        vlog(
-          clusterlog.trace,
-          "update_configuration[{}]: no cloud storage change, archiver "
-          "exists={}",
-          _raft->ntp(),
-          bool(_archiver));
-
-        if (_archiver) {
+    // If topic_storage_mode() == partition_storage_mode() and there was a
+    // change to archiver configuration, restart the archiver here. If
+    // topic_storage_mode() != partition_storage_mode(), we know:
+    // 1. partition_properties_stm::partition_storage_mode is set, and since
+    //    sync_partition_storage_mode is its only writer, the sync is enabled
+    // 2. the sync loop poked below will propagate a raft update to
+    //    bring it into sync and restart the archiver if necessary, marking the
+    //    topic manifest dirty as it does
+    if (
+      get_ntp_config().topic_storage_mode()
+      == get_ntp_config().partition_storage_mode()) {
+        if (cloud_storage_changed) {
+            co_await restart_archiver(true);
+        } else if (_archiver) {
             // Assume that a partition config may also mean a topic
             // configuration change.  This could be optimized by hooking
             // in separate updates from the controller when our topic
             // configuration changes.
             _archiver->notify_topic_config();
         }
+    } else {
+        vlog(
+          clusterlog.trace,
+          "update_configuration[{}]: leaving the archiver to the "
+          "partition_storage_mode update, topic_storage_mode={} "
+          "partition_storage_mode={}",
+          _raft->ntp(),
+          get_ntp_config().topic_storage_mode(),
+          get_ntp_config().partition_storage_mode());
     }
+
+    // A storage.mode change lands in topic_storage_mode() (above); keep the
+    // durable partition_storage_mode in step so serving predicates see the new
+    // mode. In the background: the sync takes a raft commit, and this path runs
+    // inside controller_backend's per-NTP reconciliation, which must not block
+    // on it.
+    _partition_storage_mode_sync.notify();
 }
 
 ss::future<> partition::restart_archiver(bool should_notify_topic_config) {
@@ -1823,6 +1848,50 @@ ss::future<> partition::apply_partition_storage_mode() {
     if (should_construct_archiver() != static_cast<bool>(_archiver)) {
         co_await restart_archiver(true);
     }
+}
+
+bool partition::partition_storage_mode_sync_enabled() const {
+    // Read replicas are excluded because nothing on one keys on
+    // partition_storage_mode: every predicate that would consult it
+    // short-circuits on being a read replica first, including the archiver's
+    // construction gate. Recording a mode would be a quorum write per partition
+    // to produce durable state that governs nothing, and that a later reader
+    // could mistake for a real mode.
+    return _partition_properties_stm
+           && _feature_table.local().is_active(
+             features::feature::topic_storage_mode_migration)
+           && !get_ntp_config().is_read_replica_mode_enabled();
+}
+
+ss::future<> partition::sync_partition_storage_mode() {
+    if (!partition_storage_mode_sync_enabled() || !is_leader()) {
+        co_return;
+    }
+    // All allowed storage mode transitions are simply passed through: mirror
+    // topic_storage_mode() into partition_storage_mode whenever they differ. (A
+    // legacy shadow_indexing topic has topic_storage_mode() == unset;
+    // partition_storage_mode starts unset too, so this is a no-op and it stays
+    // unset.)
+    //
+    // Recomputed on every attempt: the topic config may change while retrying,
+    // including while a previous attempt was replicating.
+    const auto target = get_ntp_config().topic_storage_mode();
+    if (_partition_properties_stm->partition_storage_mode() == target) {
+        co_return;
+    }
+    // The archiver is rebuilt after the ntp_config flip by
+    // apply_partition_storage_mode, on the apply path -- nothing to order here.
+    auto res = co_await _partition_properties_stm->set_partition_storage_mode(
+      target);
+    if (res.has_error()) {
+        // Retried with backoff for as long as this replica is still leader: a
+        // replication error steps the leader down, and then the next attempt
+        // finds itself ineligible and the successor's notification takes over.
+        co_await ss::coroutine::return_exception(
+          std::system_error{res.error()});
+    }
+    // A target that moves while replicating comes from update_configuration,
+    // which notifies as well, so there is no need to ask for another pass here.
 }
 
 ss::future<result<model::offset>> partition::set_writes_disabled(

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -565,6 +565,9 @@ ss::future<> partition::start(
     }
 
     // Run stm background fibers if needed.
+    if (_log_eviction_stm) {
+        co_await _log_eviction_stm->sync_bg_fiber_to_mode();
+    }
     if (auto ctp = _raft->stm_manager()->get<cloud_topics::ctp_stm>(); ctp) {
         co_await ctp->sync_bg_fiber_to_mode();
     }
@@ -1855,6 +1858,9 @@ ss::future<> partition::apply_partition_storage_mode() {
         co_await restart_archiver(true);
     }
 
+    if (_log_eviction_stm) {
+        co_await _log_eviction_stm->sync_bg_fiber_to_mode();
+    }
     if (auto ctp = _raft->stm_manager()->get<cloud_topics::ctp_stm>(); ctp) {
         co_await ctp->sync_bg_fiber_to_mode();
     }

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -13,6 +13,7 @@
 #include "cloud_storage/partition_manifest_downloader.h"
 #include "cloud_storage/read_path_probes.h"
 #include "cloud_storage/remote_partition.h"
+#include "cloud_topics/level_zero/stm/ctp_stm.h"
 #include "cluster/archival/archival_metadata_stm.h"
 #include "cluster/archival/ntp_archiver_service.h"
 #include "cluster/archival/upload_housekeeping_service.h"
@@ -561,6 +562,11 @@ ss::future<> partition::start(
         // deferred to a fiber that may not have run yet.
         _raft->log()->set_partition_storage_mode(
           _partition_properties_stm->partition_storage_mode());
+    }
+
+    // Run stm background fibers if needed.
+    if (auto ctp = _raft->stm_manager()->get<cloud_topics::ctp_stm>(); ctp) {
+        co_await ctp->sync_bg_fiber_to_mode();
     }
 
     {
@@ -1847,6 +1853,10 @@ ss::future<> partition::apply_partition_storage_mode() {
 
     if (should_construct_archiver() != static_cast<bool>(_archiver)) {
         co_await restart_archiver(true);
+    }
+
+    if (auto ctp = _raft->stm_manager()->get<cloud_topics::ctp_stm>(); ctp) {
+        co_await ctp->sync_bg_fiber_to_mode();
     }
 }
 

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -23,11 +23,13 @@
 #include "model/record_batch_reader.h"
 #include "model/timeout_clock.h"
 #include "raft/replicate.h"
+#include "ssx/reconciler.h"
 #include "storage/ntp_config.h"
 #include "storage/translating_reader.h"
 #include "storage/types.h"
 #include "utils/notification_list.h"
 
+#include <seastar/core/gate.hh>
 #include <seastar/core/shared_ptr.hh>
 
 namespace cloud_topics {
@@ -425,6 +427,10 @@ private:
     // dirty so that it gets reuploaded
     ss::future<> restart_archiver(bool should_notify_topic_config);
 
+    // Move ntp_config to the STM's partition_storage_mode and restart the
+    // archiver if needed. Driven by _partition_storage_mode_apply.
+    ss::future<> apply_partition_storage_mode();
+
     consensus_ptr _raft; // never null
     ss::shared_ptr<cluster::log_eviction_stm> _log_eviction_stm;
     ss::shared_ptr<cluster::rm_stm> _rm_stm;
@@ -432,6 +438,10 @@ private:
     ss::shared_ptr<partition_properties_stm> _partition_properties_stm;
     ss::sharded<cloud_topics::state_accessors>* _cloud_topics_state;
     ss::abort_source _as;
+    // Holds the apply loop triggered by the stm's partition_storage_mode
+    // callback; closed in stop() before the archiver is torn down.
+    ss::gate _partition_storage_mode_gate;
+    ssx::reconciler _partition_storage_mode_apply;
     partition_probe _probe;
     ss::sharded<features::feature_table>& _feature_table;
     ss::lw_shared_ptr<const archival::configuration> _archival_conf;

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -166,6 +166,16 @@ public:
 
     bool is_elected_leader() const;
     bool is_leader() const;
+
+    // The loop keeping durable partition_storage_mode in step with
+    // topic_storage_mode() (see sync_partition_storage_mode). Poke it on
+    // becoming leader, on migration-feature activation and on topic-config
+    // changes; notify_and_wait() to bound how many quorum writes a sweep has in
+    // flight at once.
+    ssx::reconciler& partition_storage_mode_sync() {
+        return _partition_storage_mode_sync;
+    }
+
     bool has_followers() const;
     void block_new_leadership() const;
     void unblock_new_leadership() const;
@@ -427,9 +437,23 @@ private:
     // dirty so that it gets reuploaded
     ss::future<> restart_archiver(bool should_notify_topic_config);
 
+    // Precondition for sync_partition_storage_mode: the stm exists, the feature
+    // is active, and this is not a read replica (nothing on one keys on
+    // partition_storage_mode).
+    bool partition_storage_mode_sync_enabled() const;
+
     // Move ntp_config to the STM's partition_storage_mode and restart the
     // archiver if needed. Driven by _partition_storage_mode_apply.
     ss::future<> apply_partition_storage_mode();
+
+    // Write topic_storage_mode() through to partition_properties if this
+    // leader's durable partition_storage_mode differs from it, so that the
+    // serving predicates see the new mode. Gated behind the
+    // partition_storage_mode feature and leader-only; legacy shadow_indexing
+    // topics (topic_storage_mode() == unset) are left unset. Driven by
+    // _partition_storage_mode_sync; returning is success, a throw is retried
+    // with backoff.
+    ss::future<> sync_partition_storage_mode();
 
     consensus_ptr _raft; // never null
     ss::shared_ptr<cluster::log_eviction_stm> _log_eviction_stm;
@@ -438,10 +462,14 @@ private:
     ss::shared_ptr<partition_properties_stm> _partition_properties_stm;
     ss::sharded<cloud_topics::state_accessors>* _cloud_topics_state;
     ss::abort_source _as;
-    // Holds the apply loop triggered by the stm's partition_storage_mode
-    // callback; closed in stop() before the archiver is torn down.
+    // Holds both partition_storage_mode loops -- the apply loop triggered by
+    // the stm's partition_storage_mode callback and the sync loop triggered by
+    // leadership, the migration-feature sweep and update_configuration. Closed
+    // in stop() before the archiver is torn down. Neither loop waits on the
+    // other, so one gate for both is enough.
     ss::gate _partition_storage_mode_gate;
     ssx::reconciler _partition_storage_mode_apply;
+    ssx::reconciler _partition_storage_mode_sync;
     partition_probe _probe;
     ss::sharded<features::feature_table>& _feature_table;
     ss::lw_shared_ptr<const archival::configuration> _archival_conf;

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -30,6 +30,7 @@
 #include "raft/consensus_utils.h"
 #include "raft/fundamental.h"
 #include "ssx/async-clear.h"
+#include "ssx/future-util.h"
 
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -73,6 +74,12 @@ partition_manager::partition_manager(
                 if (a) {
                     a.value().get().notify_leadership(leader_id);
                 }
+                // Sync the partition's durable storage mode to its topic
+                // config on becoming leader (no-op when not leader or already
+                // in sync). Detached: the sync runs under the partition's own
+                // gate, and only one loop runs per partition however many
+                // callers poke it.
+                p->partition_storage_mode_sync().notify();
             }
         });
     _shutdown_watchdog.set_callback(

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -25,6 +25,7 @@
 #include "cluster/partition_recovery_manager.h"
 #include "cluster/topic_configuration.h"
 #include "cluster/types.h"
+#include "container/chunked_vector.h"
 #include "model/metadata.h"
 #include "raft/consensus.h"
 #include "raft/consensus_utils.h"
@@ -32,6 +33,7 @@
 #include "ssx/async-clear.h"
 #include "ssx/future-util.h"
 
+#include <seastar/core/loop.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/shared_ptr.hh>
 
@@ -107,7 +109,57 @@ partition_manager::get_topic_partition_table(
 
 ss::future<> partition_manager::start() {
     maybe_arm_shutdown_watchdog();
+    // Sync partition_storage_mode once the migration feature activates. The
+    // leadership-notification sync (sync_partition_storage_mode) is gated on
+    // the feature being active, so a partition that became leader while the
+    // feature was inactive is left with partition_storage_mode == unset. Re-run
+    // the sync on every current leader when the feature turns active;
+    // partitions that gain leadership after activation are covered by the
+    // leadership notification.
+    ssx::spawn_with_gate(_gate, [this] {
+        return sync_partition_storage_mode_on_migration_feature();
+    });
     co_return;
+}
+
+ss::future<>
+partition_manager::sync_partition_storage_mode_on_migration_feature() {
+    try {
+        co_await _feature_table.local().await_feature(
+          features::feature::topic_storage_mode_migration, _as);
+    } catch (...) {
+        // Aborted on shutdown before the feature activated.
+        co_return;
+    }
+    // Snapshot the current leaders: _ntp_table can mutate across the yields
+    // below, and sync_partition_storage_mode re-checks leadership anyway.
+    chunked_vector<ss::lw_shared_ptr<partition>> leaders;
+    for (const auto& [_, p] : _ntp_table) {
+        if (p->is_leader()) {
+            leaders.push_back(p);
+        }
+    }
+    // Bound the concurrency, per shard (this sweep runs on every shard): at
+    // activation every leader needs a real sync (a quorum write), on every
+    // node in the cluster at the same time.
+    //
+    // Both halves of the shutdown handling are needed. The wait is on _as as
+    // well as on the sync because the loop being waited for belongs to the
+    // partition and outlives this sweep, while stop_partitions() closes the
+    // gate this fiber holds before it stops any partition -- a wait only the
+    // partition could end would deadlock shutdown. The check is because
+    // max_concurrent_for_each runs the whole range regardless, so without it
+    // every remaining leader would still be notified on the way out.
+    co_await ss::max_concurrent_for_each(leaders, 16, [this](const auto& p) {
+        if (_as.abort_requested()) {
+            return ss::now();
+        }
+        return ssx::ignore_shutdown_exceptions(
+          ssx::with_timeout_abortable(
+            p->partition_storage_mode_sync().notify_and_wait(),
+            ss::lowres_clock::time_point::max(),
+            _as));
+    });
 }
 
 ss::future<consensus_ptr> partition_manager::manage(

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -277,6 +277,12 @@ private:
     void check_partitions_shutdown_state();
 
     void maybe_arm_shutdown_watchdog();
+
+    // Awaits the topic_storage_mode_migration feature and then re-runs
+    // the partition_storage_mode sync on every current leader (with bounded
+    // concurrency), covering partitions that became leader while the feature
+    // was inactive.
+    ss::future<> sync_partition_storage_mode_on_migration_feature();
     storage::api& _storage;
     /// used to wait for concurrent recoveries
     ss::sharded<raft::group_manager>& _raft_manager;

--- a/src/v/cluster/partition_properties_stm.cc
+++ b/src/v/cluster/partition_properties_stm.cc
@@ -40,7 +40,8 @@ partition_properties_stm::partition_properties_stm(
   , _state_snapshots({state_snapshot{
       .writes_disabled = writes_disabled::no,
       .update_offset = model::offset{},
-      .writes_revision_id{}}}) {}
+      .writes_revision_id{},
+      .partition_storage_mode = model::redpanda_storage_mode::unset}}) {}
 
 ss::future<iobuf>
 partition_properties_stm::take_raft_snapshot(model::offset o) {
@@ -88,7 +89,8 @@ partition_properties_stm::take_raft_snapshot(model::offset o) {
     co_return serde::to_iobuf(
       raft_snapshot{
         .writes_disabled = it->writes_disabled,
-        .writes_revision_id = it->writes_revision_id});
+        .writes_revision_id = it->writes_revision_id,
+        .partition_storage_mode = it->partition_storage_mode});
 }
 
 ss::future<raft::local_snapshot_applied>
@@ -157,43 +159,69 @@ void partition_properties_stm::apply_record(
     auto key = r.release_key();
     auto value = r.release_value();
     auto ot = serde::from_iobuf<operation_type>(std::move(key));
-    if (ot != operation_type::update_writes_disabled) [[unlikely]] {
-        vlog(
-          _log.warn,
-          "ignored unknown operation type with value: {}",
-          static_cast<int>(ot));
-        return;
-    }
-    auto update = serde::from_iobuf<update_writes_disabled_cmd>(
-      std::move(value));
-    vlog(
-      _log.trace,
-      "Applying update {} at offset: {}",
-      update,
+    const auto update_offset = model::offset(
       r.offset_delta() + batch_begin_offset);
     const auto current_state = _state_snapshots.back();
-    bool is_legacy_command = update.writes_revision_id == model::revision_id{};
-    bool is_newer_revision = update.writes_revision_id
-                             > current_state.writes_revision_id;
-    if (!is_newer_revision && !is_legacy_command) {
+    switch (ot) {
+    case operation_type::update_writes_disabled: {
+        auto update = serde::from_iobuf<update_writes_disabled_cmd>(
+          std::move(value));
         vlog(
-          _log.error,
-          "Ignoring out-of-order update: {}, current state: {}",
+          _log.trace,
+          "Applying update {} at offset: {}",
           update,
-          _state_snapshots.back());
+          update_offset);
+        bool is_legacy_command = update.writes_revision_id
+                                 == model::revision_id{};
+        bool is_newer_revision = update.writes_revision_id
+                                 > current_state.writes_revision_id;
+        if (!is_newer_revision && !is_legacy_command) {
+            vlog(
+              _log.error,
+              "Ignoring out-of-order update: {}, current state: {}",
+              update,
+              current_state);
+            return;
+        }
+        bool differs = update.writes_disabled != current_state.writes_disabled
+                       || update.writes_revision_id
+                            != current_state.writes_revision_id;
+        if (differs) {
+            // copy-modify preserves the other properties (e.g.
+            // partition_storage_mode)
+            auto next = current_state;
+            next.writes_disabled = update.writes_disabled;
+            next.writes_revision_id = update.writes_revision_id;
+            next.update_offset = update_offset;
+            _state_snapshots.push_back(next);
+        }
         return;
     }
-    bool differs = update.writes_disabled != current_state.writes_disabled
-                   || update.writes_revision_id
-                        != current_state.writes_revision_id;
-    if (differs) {
-        _state_snapshots.push_back(
-          state_snapshot{
-            .writes_disabled = update.writes_disabled,
-            .update_offset = model::offset(
-              r.offset_delta() + batch_begin_offset),
-            .writes_revision_id = update.writes_revision_id});
+    case operation_type::update_partition_storage_mode: {
+        auto update = serde::from_iobuf<update_partition_storage_mode_cmd>(
+          std::move(value));
+        vlog(
+          _log.trace,
+          "Applying partition_storage_mode update {} at offset: {}",
+          update,
+          update_offset);
+        // idempotent by value, ordered by log offset (no revision needed).
+        if (
+          update.partition_storage_mode
+          != current_state.partition_storage_mode) {
+            auto next = current_state;
+            next.partition_storage_mode = update.partition_storage_mode;
+            next.update_offset = update_offset;
+            _state_snapshots.push_back(next);
+            notify_partition_storage_mode_change();
+        }
+        return;
     }
+    }
+    vlog(
+      _log.warn,
+      "ignored unknown operation type with value: {}",
+      static_cast<int>(ot));
 }
 
 ss::future<>
@@ -211,7 +239,9 @@ partition_properties_stm::apply_raft_snapshot(const iobuf& buffer) {
       state_snapshot{
         .writes_disabled = snapshot.writes_disabled,
         .update_offset = model::prev_offset(_raft->start_offset()),
-        .writes_revision_id = snapshot.writes_revision_id});
+        .writes_revision_id = snapshot.writes_revision_id,
+        .partition_storage_mode = snapshot.partition_storage_mode});
+    notify_partition_storage_mode_change();
     co_return;
 }
 
@@ -301,6 +331,99 @@ model::record_batch partition_properties_stm::make_update_partitions_batch(
     return std::move(builder).build();
 }
 
+model::record_batch
+partition_properties_stm::make_update_partition_storage_mode_batch(
+  update_partition_storage_mode_cmd cmd) {
+    storage::record_batch_builder builder(
+      model::record_batch_type::partition_properties_update, model::offset{});
+    builder.add_raw_kv(
+      serde::to_iobuf(operation_type::update_partition_storage_mode),
+      serde::to_iobuf(std::move(cmd)));
+    return std::move(builder).build();
+}
+
+ss::future<result<model::offset>>
+partition_properties_stm::replicate_partition_storage_mode_update(
+  model::timeout_clock::duration timeout,
+  update_partition_storage_mode_cmd cmd) {
+    auto holder = _gate.hold();
+    auto units = co_await _writes_mutex.get_units();
+    if (!co_await sync(timeout)) {
+        co_return errc::not_leader;
+    }
+
+    vassert(
+      !_state_snapshots.empty(),
+      "The invariant of state snapshot containing at least one element is "
+      "broken");
+    auto current_state = _state_snapshots.back();
+    if (cmd.partition_storage_mode == current_state.partition_storage_mode)
+      [[unlikely]] {
+        // no-op
+        co_return current_state.update_offset;
+    }
+
+    auto b = make_update_partition_storage_mode_batch(cmd);
+    vlog(_log.debug, "replicating update partition mode command: {}", cmd);
+    raft::replicate_options r_opts(
+      raft::consistency_level::quorum_ack,
+      _insync_term,
+      std::chrono::milliseconds(timeout / 1ms));
+    r_opts.set_force_flush();
+    auto r = co_await _raft->replicate(std::move(b), r_opts);
+
+    if (r.has_error()) {
+        vlog(
+          _log.warn,
+          "error replicating update partition mode command: {} - {}",
+          cmd,
+          r.error().message());
+        co_await _raft->step_down("partition_properties_stm/replication_error");
+        co_return r.error();
+    }
+
+    auto message_offset = r.value().last_offset;
+    if (!co_await wait_no_throw(
+          message_offset, model::timeout_clock::time_point::max())) {
+        co_await _raft->step_down("partition_properties_stm/replication_error");
+        co_return errc::shutting_down;
+    }
+    co_return message_offset;
+}
+
+ss::future<result<model::offset>>
+partition_properties_stm::set_partition_storage_mode(
+  model::redpanda_storage_mode mode) {
+    vlog(_log.info, "setting partition mode to {}", mode);
+    return replicate_partition_storage_mode_update(
+      _sync_timeout(),
+      update_partition_storage_mode_cmd{.partition_storage_mode = mode});
+}
+
+model::redpanda_storage_mode
+partition_properties_stm::partition_storage_mode() const {
+    vassert(
+      !_state_snapshots.empty(),
+      "The invariant of state snapshot containing at least one element is "
+      "broken");
+    return _state_snapshots.back().partition_storage_mode;
+}
+
+void partition_properties_stm::notify_partition_storage_mode_change() {
+    if (_partition_storage_mode_change_cb) {
+        _partition_storage_mode_change_cb();
+    }
+}
+
+ss::future<result<model::redpanda_storage_mode>>
+partition_properties_stm::sync_partition_storage_mode() {
+    auto holder = _gate.hold();
+    if (!co_await sync(_sync_timeout())) {
+        co_return errc::not_leader;
+    }
+    co_return partition_storage_mode();
+}
+
 ss::future<result<model::offset>>
 partition_properties_stm::disable_writes(model::revision_id revision_id) {
     vlog(_log.info, "disabling partition writes");
@@ -355,9 +478,20 @@ fmt::iterator
 partition_properties_stm::raft_snapshot::format_to(fmt::iterator it) const {
     return fmt::format_to(
       it,
-      "{{writes_disabled: {}, writes_revision_id: {}}}",
+      "{{writes_disabled: {}, writes_revision_id: {}, partition_storage_mode: "
+      "{}}}",
       writes_disabled,
-      writes_revision_id);
+      writes_revision_id,
+      model::redpanda_storage_mode_to_string(partition_storage_mode));
+}
+
+fmt::iterator
+partition_properties_stm::update_partition_storage_mode_cmd::format_to(
+  fmt::iterator it) const {
+    return fmt::format_to(
+      it,
+      "{{partition_storage_mode: {}}}",
+      model::redpanda_storage_mode_to_string(partition_storage_mode));
 }
 
 fmt::iterator partition_properties_stm::update_writes_disabled_cmd::format_to(
@@ -373,10 +507,12 @@ fmt::iterator
 partition_properties_stm::state_snapshot::format_to(fmt::iterator it) const {
     return fmt::format_to(
       it,
-      "{{update_offset: {}, writes_disabled: {}, writes_revision_id: {}}}",
+      "{{update_offset: {}, writes_disabled: {}, writes_revision_id: {}, "
+      "partition_storage_mode: {}}}",
       update_offset,
       writes_disabled,
-      writes_revision_id);
+      writes_revision_id,
+      model::redpanda_storage_mode_to_string(partition_storage_mode));
 }
 
 fmt::iterator

--- a/src/v/cluster/partition_properties_stm.h
+++ b/src/v/cluster/partition_properties_stm.h
@@ -15,8 +15,11 @@
 #include "cluster/state_machine_registry.h"
 #include "container/chunked_vector.h"
 #include "model/fundamental.h"
+#include "model/metadata.h"
 #include "raft/persisted_stm.h"
 #include "serde/envelope.h"
+
+#include <seastar/util/noncopyable_function.hh>
 
 namespace cluster {
 
@@ -50,6 +53,29 @@ public:
     // Returns a current value of the writes disabled property.
     writes_disabled are_writes_disabled() const;
 
+    // Updates the persistent, partition-local storage mode; returns the offset
+    // of the update message. This is the partition's own durable record of its
+    // storage mode, decoupled from the topic config (see
+    // partition_storage_mode()).
+    ss::future<result<model::offset>>
+      set_partition_storage_mode(model::redpanda_storage_mode);
+    // Waits for the state to be up to date and returns the partition mode; only
+    // intended to be called on the current leader.
+    ss::future<result<model::redpanda_storage_mode>>
+    sync_partition_storage_mode();
+    // Returns the current partition mode. `unset` means "not yet bootstrapped";
+    // callers (ntp_config) fall back to the topic-config-derived mode.
+    model::redpanda_storage_mode partition_storage_mode() const;
+
+    // Registers a callback invoked on this shard whenever
+    // partition_storage_mode may have changed (on apply and on raft-snapshot
+    // restore), so the owner can re-read partition_storage_mode() and propagate
+    // it (e.g. into ntp_config).
+    void set_partition_storage_mode_change_callback(
+      ss::noncopyable_function<void()> cb) {
+        _partition_storage_mode_change_cb = std::move(cb);
+    }
+
     raft::stm_initial_recovery_policy
     get_initial_recovery_policy() const final {
         return raft::stm_initial_recovery_policy::skip_to_end;
@@ -80,19 +106,42 @@ private:
           const update_writes_disabled_cmd&) = default;
     };
 
+    struct update_partition_storage_mode_cmd
+      : serde::envelope<
+          update_partition_storage_mode_cmd,
+          serde::version<0>,
+          serde::compat_version<0>> {
+        model::redpanda_storage_mode partition_storage_mode
+          = model::redpanda_storage_mode::unset;
+
+        auto serde_fields() { return std::tie(partition_storage_mode); }
+        fmt::iterator format_to(fmt::iterator it) const;
+        friend bool operator==(
+          const update_partition_storage_mode_cmd&,
+          const update_partition_storage_mode_cmd&) = default;
+    };
+
     struct state_snapshot
       : serde::envelope<
           state_snapshot,
-          serde::version<1>,
+          serde::version<2>,
           serde::compat_version<0>> {
         // todo: in a major release we can change it to use a local_snapshot +
         // update_offset
         writes_disabled writes_disabled;
         model::offset update_offset;
         model::revision_id writes_revision_id;
+        // If == unset, ntp_config will fall back partition_storage_mode() to
+        // topic_storage_mode() (currently configured topic mode)
+        model::redpanda_storage_mode partition_storage_mode
+          = model::redpanda_storage_mode::unset;
 
         auto serde_fields() {
-            return std::tie(writes_disabled, update_offset, writes_revision_id);
+            return std::tie(
+              writes_disabled,
+              update_offset,
+              writes_revision_id,
+              partition_storage_mode);
         }
         fmt::iterator format_to(fmt::iterator it) const;
         friend bool
@@ -101,12 +150,15 @@ private:
 
     struct raft_snapshot
       : serde::
-          envelope<raft_snapshot, serde::version<1>, serde::compat_version<0>> {
+          envelope<raft_snapshot, serde::version<2>, serde::compat_version<0>> {
         writes_disabled writes_disabled = writes_disabled::no;
         model::revision_id writes_revision_id;
+        model::redpanda_storage_mode partition_storage_mode
+          = model::redpanda_storage_mode::unset;
 
         auto serde_fields() {
-            return std::tie(writes_disabled, writes_revision_id);
+            return std::tie(
+              writes_disabled, writes_revision_id, partition_storage_mode);
         }
         fmt::iterator format_to(fmt::iterator it) const;
 
@@ -134,6 +186,7 @@ private:
 
     enum class operation_type {
         update_writes_disabled = 0,
+        update_partition_storage_mode = 1,
     };
 
     ss::future<> do_apply(const model::record_batch&) final;
@@ -142,10 +195,15 @@ private:
 
     static model::record_batch
       make_update_partitions_batch(update_writes_disabled_cmd);
+    static model::record_batch make_update_partition_storage_mode_batch(
+      update_partition_storage_mode_cmd);
 
     ss::future<result<model::offset>> replicate_properties_update(
       model::timeout_clock::duration timeout,
       update_writes_disabled_cmd command);
+    ss::future<result<model::offset>> replicate_partition_storage_mode_update(
+      model::timeout_clock::duration timeout,
+      update_partition_storage_mode_cmd command);
 
     config::binding<std::chrono::milliseconds> _sync_timeout;
 
@@ -156,8 +214,12 @@ private:
     // cleaned when the local snapshot is taken.
     chunked_vector<state_snapshot> _state_snapshots;
 
-    // For linearizing access to writes_disabled state on the leader
+    // For linearizing access to writes_disabled and partition_storage_mode
+    // state on the leader
     ssx::mutex _writes_mutex{"c/partition_properties_stm::writes_mutex"};
+
+    void notify_partition_storage_mode_change();
+    ss::noncopyable_function<void()> _partition_storage_mode_change_cb;
 };
 
 class partition_properties_stm_factory : public state_machine_factory {

--- a/src/v/cluster/tests/BUILD
+++ b/src/v/cluster/tests/BUILD
@@ -1246,6 +1246,8 @@ redpanda_cc_gtest(
     cpu = 1,
     deps = [
         "//src/v/cluster:topic_configuration",
+        "//src/v/model",
+        "//src/v/storage",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
     ],

--- a/src/v/cluster/tests/log_eviction_stm_test.cc
+++ b/src/v/cluster/tests/log_eviction_stm_test.cc
@@ -19,11 +19,6 @@ public:
       raft::consensus* c, ss::logger& logger, storage::kvstore& kvs)
       : cluster::log_eviction_stm(c, logger, kvs) {}
 
-    ss::future<> stop() override {
-        p->set_exception(ss::abort_requested_exception());
-        return cluster::log_eviction_stm::stop();
-    }
-
     /**
      * The two following methods can be used to drive the eviction stms
      * storage eviction event processing loop. It works by overriding a method
@@ -35,11 +30,24 @@ public:
      * that the event loop will call storage_eviction_event() for the next
      * future.
      */
-    ss::future<model::offset> storage_eviction_event() override {
+    ss::future<model::offset>
+    storage_eviction_event(ss::abort_source& as) override {
         logger.info("eviction_stm waiting on storage event");
         vassert(!p.has_value(), "Cannot have value");
+        if (as.abort_requested()) {
+            return ss::make_exception_future<model::offset>(
+              ss::abort_requested_exception());
+        }
         p = ss::promise<model::offset>();
-        return p->get_future();
+        /// Use passed abort source so worker's stop() wakes a parked fiber
+        /// without test involvement.
+        auto sub = as.subscribe([this]() noexcept {
+            if (p.has_value()) {
+                p->set_exception(ss::abort_requested_exception());
+                p.reset();
+            }
+        });
+        return p->get_future().finally([sub = std::move(sub)] {});
     }
 
     void drive_eviction_loop(model::offset o) {
@@ -71,6 +79,11 @@ TEST_F(eviction_stm_fixture, test_eviction_stm_deadlock) {
           node->raft().get(), logger(), node->get_kvstore());
 
         node->start(std::move(stm_mgr_builder)).get();
+        node->raft()
+          ->stm_manager()
+          ->get<test_log_eviction_stm>()
+          ->sync_bg_fiber_to_mode()
+          .get();
     }
     std::vector<storage::offset_stats> offsets;
     for (auto i = 0; i < 5; ++i) {
@@ -124,4 +137,33 @@ TEST_F(eviction_stm_fixture, test_eviction_stm_deadlock) {
 
     next_start_offset = highest_term1_offset + model::offset(1);
     ASSERT_EQ(next_start_offset, eviction_stm->effective_start_offset());
+}
+
+TEST_F(eviction_stm_fixture, test_bg_worker_stops_on_cloud_transition) {
+    add_node(model::node_id(0), model::revision_id(0));
+    for (auto& [id, node] : nodes()) {
+        raft::state_machine_manager_builder stm_mgr_builder;
+        node->initialise(all_vnodes()).get();
+        stm_mgr_builder.create_stm<cluster::log_eviction_stm>(
+          node->raft().get(), logger(), node->get_kvstore());
+        node->start(std::move(stm_mgr_builder)).get();
+    }
+    auto& n = node(model::node_id(0));
+    auto stm = n.raft()->stm_manager()->get<cluster::log_eviction_stm>();
+    using accessor = cluster::testing::log_eviction_stm_accessor;
+
+    /// The fibers do not start with the stm; the partition starts them once
+    /// the durable storage mode has been fed into ntp_config.
+    ASSERT_FALSE(accessor::bg_fiber_running(*stm));
+
+    /// A partition that is not a cloud topic runs the eviction fibers.
+    stm->sync_bg_fiber_to_mode().get();
+    ASSERT_TRUE(accessor::bg_fiber_running(*stm));
+
+    /// Flipping the partition's storage mode to cloud stops the fibers on the
+    /// next sync, as the partition-mode-change path will do.
+    n.raft()->log()->set_partition_storage_mode(
+      model::redpanda_storage_mode::cloud);
+    stm->sync_bg_fiber_to_mode().get();
+    ASSERT_FALSE(accessor::bg_fiber_running(*stm));
 }

--- a/src/v/cluster/tests/partition_properties_stm_test.cc
+++ b/src/v/cluster/tests/partition_properties_stm_test.cc
@@ -16,6 +16,7 @@
 #include "config/mock_property.h"
 #include "container/chunked_circular_buffer.h"
 #include "model/fundamental.h"
+#include "model/metadata.h"
 #include "model/record.h"
 #include "model/tests/random_batch.h"
 #include "raft/replicate.h"
@@ -113,6 +114,34 @@ struct partition_properties_stm_fixture : raft::raft_fixture {
         auto r = co_await get_writes_disabled_on_leader();
         ASSERT_TRUE_CORO(r.has_value());
         ASSERT_EQ_CORO(r.value(), disabled);
+    }
+
+    ss::future<> set_partition_storage_mode(
+      model::redpanda_storage_mode mode, bool expect_success = true) {
+        auto res = co_await retry_with_leader(
+          raft::default_timeout(),
+          2s,
+          [mode](raft::raft_node_instance& leader_node) {
+              return get_stm(leader_node)->set_partition_storage_mode(mode);
+          });
+        ASSERT_EQ_CORO(res.has_value(), expect_success);
+    }
+
+    ss::future<>
+    assert_partition_storage_mode(model::redpanda_storage_mode mode) {
+        auto r = co_await get_leader_stm()->sync_partition_storage_mode();
+        ASSERT_TRUE_CORO(r.has_value());
+        ASSERT_EQ_CORO(r.value(), mode);
+    }
+
+    ss::future<>
+    check_partition_storage_mode_consistent(model::redpanda_storage_mode mode) {
+        RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this, mode] {
+            return std::ranges::all_of(
+              node_stms | std::views::values, [mode](auto stm) {
+                  return stm->partition_storage_mode() == mode;
+              });
+        });
     }
 
     ss::future<result<model::offset>> replicate_random_batches() {
@@ -415,6 +444,146 @@ TEST_F_CORO(
     ASSERT_EQ_CORO(writes_disabled, should_be_disabled);
     co_await wait_for_committed_offset(last_applied, 10s);
     co_await check_state_consistent(should_be_disabled);
+}
+
+TEST_F_CORO(
+  partition_properties_stm_fixture, test_partition_storage_mode_basic) {
+    co_await initialize_state_machines();
+    co_await wait_for_leader(10s);
+    // A fresh partition has never had partition_storage_mode written: it reads
+    // `unset` (the "not bootstrapped -> fall back to topic_storage_mode"
+    // sentinel).
+    co_await assert_partition_storage_mode(model::redpanda_storage_mode::unset);
+
+    co_await set_partition_storage_mode(model::redpanda_storage_mode::tiered);
+    co_await assert_partition_storage_mode(
+      model::redpanda_storage_mode::tiered);
+    // idempotent
+    co_await set_partition_storage_mode(model::redpanda_storage_mode::tiered);
+    co_await assert_partition_storage_mode(
+      model::redpanda_storage_mode::tiered);
+    // the migration cutover transition: tiered -> cloud
+    co_await set_partition_storage_mode(model::redpanda_storage_mode::cloud);
+    co_await assert_partition_storage_mode(model::redpanda_storage_mode::cloud);
+    co_await check_partition_storage_mode_consistent(
+      model::redpanda_storage_mode::cloud);
+}
+
+// writes_disabled and partition_storage_mode share one state_snapshot; updating
+// one must preserve the other (the apply copy-modify).
+TEST_F_CORO(
+  partition_properties_stm_fixture,
+  test_partition_storage_mode_independent_of_writes) {
+    co_await initialize_state_machines();
+
+    co_await disable_writes(model::revision_id{1});
+    co_await set_partition_storage_mode(model::redpanda_storage_mode::tiered);
+    co_await assert_writes(stm_t::writes_disabled::yes);
+    co_await assert_partition_storage_mode(
+      model::redpanda_storage_mode::tiered);
+
+    // a partition_storage_mode update leaves writes_disabled untouched
+    co_await set_partition_storage_mode(model::redpanda_storage_mode::cloud);
+    co_await assert_writes(stm_t::writes_disabled::yes);
+    co_await assert_partition_storage_mode(model::redpanda_storage_mode::cloud);
+
+    // and a writes_disabled update leaves partition_storage_mode untouched
+    co_await enable_writes(model::revision_id{2});
+    co_await assert_writes(stm_t::writes_disabled::no);
+    co_await assert_partition_storage_mode(model::redpanda_storage_mode::cloud);
+}
+
+TEST_F_CORO(
+  partition_properties_stm_fixture, test_partition_storage_mode_snapshot) {
+    co_await initialize_state_machines();
+
+    auto before_set = co_await replicate_random_batches();
+    co_await set_partition_storage_mode(model::redpanda_storage_mode::tiered);
+    [[maybe_unused]] auto _ignored = co_await replicate_random_batches();
+
+    auto leader_id = get_leader();
+    EXPECT_TRUE(leader_id.has_value());
+    auto& leader_node = node(leader_id.value());
+
+    // snapshot taken before the set command -> unset
+    auto o = co_await leader_node.random_batch_base_offset(before_set.value());
+    auto snap_before = partition_properties_stm_accessor::snap_from_iobuf(
+      co_await get_leader_stm()->take_raft_snapshot(o));
+    ASSERT_EQ_CORO(
+      snap_before.partition_storage_mode, model::redpanda_storage_mode::unset);
+
+    // snapshot at the set command offset -> tiered (and writes_disabled intact)
+    auto snap_at = partition_properties_stm_accessor::snap_from_iobuf(
+      co_await get_leader_stm()->take_raft_snapshot(
+        model::next_offset(before_set.value())));
+    ASSERT_EQ_CORO(
+      snap_at.partition_storage_mode, model::redpanda_storage_mode::tiered);
+    ASSERT_EQ_CORO(snap_at.writes_disabled, stm_t::writes_disabled::no);
+}
+
+TEST_F_CORO(
+  partition_properties_stm_fixture, test_partition_storage_mode_recovery) {
+    co_await initialize_state_machines();
+    co_await set_partition_storage_mode(model::redpanda_storage_mode::tiered);
+    [[maybe_unused]] auto _ignored = co_await replicate_random_batches();
+    co_await set_partition_storage_mode(model::redpanda_storage_mode::cloud);
+    co_await assert_partition_storage_mode(model::redpanda_storage_mode::cloud);
+    auto last_applied = get_leader_stm()->last_applied_offset();
+
+    // restart preserving data: recover from local (kvstore) snapshot + replay
+    co_await restart_nodes();
+    co_await wait_for_leader(10s);
+    co_await assert_partition_storage_mode(model::redpanda_storage_mode::cloud);
+    co_await wait_for_committed_offset(last_applied, 10s);
+    co_await check_partition_storage_mode_consistent(
+      model::redpanda_storage_mode::cloud);
+
+    // take a raft snapshot on every node, then restart with one node's data
+    // dropped: that node recovers partition_storage_mode from the raft
+    // snapshot.
+    for (auto& [_, node] : nodes()) {
+        auto base_offset = co_await node->random_batch_base_offset(
+          node->raft()->committed_offset(), model::offset(1));
+        auto snapshot_offset = model::prev_offset(base_offset);
+        auto result = co_await node->raft()->stm_manager()->take_snapshot(
+          snapshot_offset);
+        co_await node->raft()->write_snapshot(
+          raft::write_snapshot_cfg(snapshot_offset, std::move(result.data)));
+    }
+    co_await restart_nodes({model::node_id(1)});
+    co_await wait_for_leader(10s);
+    co_await assert_partition_storage_mode(model::redpanda_storage_mode::cloud);
+    co_await wait_for_committed_offset(last_applied, 10s);
+    co_await check_partition_storage_mode_consistent(
+      model::redpanda_storage_mode::cloud);
+}
+
+// The change callback (used by partition to push partition_storage_mode into
+// ntp_config) must fire when partition_storage_mode changes, on each replica
+// that applies the change.
+TEST_F_CORO(
+  partition_properties_stm_fixture,
+  test_partition_storage_mode_change_callback) {
+    co_await initialize_state_machines();
+    co_await wait_for_leader(10s);
+
+    auto fired = ss::make_lw_shared<int>(0);
+    for (auto& [_, stm] : node_stms) {
+        stm->set_partition_storage_mode_change_callback(
+          [fired] { ++(*fired); });
+    }
+
+    co_await set_partition_storage_mode(model::redpanda_storage_mode::tiered);
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [fired] { return *fired >= 1; });
+    co_await check_partition_storage_mode_consistent(
+      model::redpanda_storage_mode::tiered);
+
+    // an idempotent (no-op) update does not change state, so it does not fire
+    auto before = *fired;
+    co_await set_partition_storage_mode(model::redpanda_storage_mode::tiered);
+    co_await check_partition_storage_mode_consistent(
+      model::redpanda_storage_mode::tiered);
+    ASSERT_EQ_CORO(*fired, before);
 }
 
 } // namespace cluster

--- a/src/v/cluster/tests/topic_properties_test.cc
+++ b/src/v/cluster/tests/topic_properties_test.cc
@@ -8,8 +8,13 @@
 // by the Apache License, Version 2.0
 
 #include "cluster/topic_properties.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
+#include "storage/ntp_config.h"
 
 #include <gtest/gtest.h>
+
+#include <memory>
 
 namespace cluster {
 
@@ -25,6 +30,49 @@ TEST(TopicProperties, ostream) {
     stream << properties;
     auto result = stream.str();
     ASSERT_FALSE(result.contains("{}")) << result;
+}
+
+namespace {
+storage::ntp_config make_ntp_config(
+  model::redpanda_storage_mode mode, model::redpanda_storage_mode migrated) {
+    storage::ntp_config::default_overrides o;
+    o.storage_mode = mode;
+    o.migrated_from = migrated;
+    return {
+      model::ntp(
+        model::kafka_namespace, model::topic("t"), model::partition_id(0)),
+      "",
+      std::make_unique<storage::ntp_config::default_overrides>(o)};
+}
+} // namespace
+
+// Tests cloud_topic_enabled/migrated_to_cloud behavior
+// w.r.t. storage.mode and migrated_from
+TEST(TopicProperties, ntp_config_migrated_to_cloud_matrix) {
+    using mode = model::redpanda_storage_mode;
+
+    storage::ntp_config bare(
+      model::ntp(
+        model::kafka_namespace, model::topic("t"), model::partition_id(0)),
+      "");
+    EXPECT_FALSE(bare.cloud_topic_enabled());
+    EXPECT_FALSE(bare.migrated_to_cloud());
+
+    for (auto m : {mode::local, mode::tiered, mode::unset}) {
+        auto cfg = make_ntp_config(m, mode::unset);
+        EXPECT_FALSE(cfg.cloud_topic_enabled());
+        EXPECT_FALSE(cfg.migrated_to_cloud());
+    }
+    for (auto m : {mode::cloud, mode::tiered_cloud}) {
+        auto native = make_ntp_config(m, mode::unset);
+        EXPECT_TRUE(native.cloud_topic_enabled());
+        EXPECT_FALSE(native.migrated_to_cloud());
+        for (auto src : {mode::tiered, mode::local}) {
+            auto migrated = make_ntp_config(m, src);
+            EXPECT_TRUE(migrated.cloud_topic_enabled());
+            EXPECT_TRUE(migrated.migrated_to_cloud());
+        }
+    }
 }
 
 } // namespace cluster

--- a/src/v/cluster/tests/topic_table_test.cc
+++ b/src/v/cluster/tests/topic_table_test.cc
@@ -544,6 +544,47 @@ FIXTURE_TEST(test_tracking_broker_and_command_revisions, topic_table_fixture) {
       model::revision_id{19});
 }
 
+FIXTURE_TEST(test_migrated_from_update_applies, topic_table_fixture) {
+    auto& topics = table.local();
+    using mode = model::redpanda_storage_mode;
+
+    auto create = make_create_topic_cmd("test_migrated_from", 1, 1);
+    create.value.cfg.properties.storage_mode = mode::tiered;
+    auto tp_ns = create.value.cfg.tp_ns;
+    auto ec = topics.apply(create, model::offset{10}).get();
+    BOOST_REQUIRE_EQUAL(ec, cluster::errc::success);
+
+    // The migration trigger sends storage_mode and migrated_from in a single
+    // update (see kafka record_migrated_from_on_migration).
+    cluster::incremental_topic_updates update;
+    update.storage_mode.op = cluster::incremental_update_operation::set;
+    update.storage_mode.value.emplace(mode::cloud);
+    update.migrated_from.op = cluster::incremental_update_operation::set;
+    update.migrated_from.value = mode::tiered;
+    ec = topics
+           .apply(
+             cluster::update_topic_properties_cmd{tp_ns, update},
+             model::offset{11})
+           .get();
+    BOOST_REQUIRE_EQUAL(ec, cluster::errc::success);
+    auto cfg = topics.get_topic_cfg(tp_ns);
+    BOOST_REQUIRE(cfg.has_value());
+    BOOST_REQUIRE(cfg->properties.storage_mode == mode::cloud);
+    BOOST_REQUIRE(cfg->properties.migrated_from == mode::tiered);
+
+    // remove clears migrated_from back to unset, like any other property.
+    cluster::incremental_topic_updates rm;
+    rm.migrated_from.op = cluster::incremental_update_operation::remove;
+    ec = topics
+           .apply(
+             cluster::update_topic_properties_cmd{tp_ns, rm}, model::offset{12})
+           .get();
+    BOOST_REQUIRE_EQUAL(ec, cluster::errc::success);
+    cfg = topics.get_topic_cfg(tp_ns);
+    BOOST_REQUIRE(cfg.has_value());
+    BOOST_REQUIRE(cfg->properties.migrated_from == mode::unset);
+}
+
 FIXTURE_TEST(test_topic_with_schema_id_validation_ops, topic_table_fixture) {
     auto& topics = table.local();
 

--- a/src/v/cluster/topic_configuration.cc
+++ b/src/v/cluster/topic_configuration.cc
@@ -64,6 +64,7 @@ storage::ntp_config topic_configuration::make_ntp_config(
             .max_compaction_lag_ms = properties.max_compaction_lag_ms,
             .remote_allow_gaps = properties.remote_topic_allow_gaps,
             .storage_mode = properties.storage_mode,
+            .migrated_from = properties.migrated_from,
           });
     }
     return {

--- a/src/v/cluster/topic_properties.cc
+++ b/src/v/cluster/topic_properties.cc
@@ -54,7 +54,8 @@ fmt::iterator topic_properties::format_to(fmt::iterator it) const {
       "max_compaction_lag_ms: {}, "
       "message_timestamp_before_max_ms: {}, "
       "message_timestamp_after_max_ms: {}, "
-      "redpanda_storage_mode: {}}}",
+      "redpanda_storage_mode: {}, "
+      "migrated_from: {}}}",
       compression,
       cleanup_policy_bitflags,
       compaction_strategy,
@@ -102,7 +103,8 @@ fmt::iterator topic_properties::format_to(fmt::iterator it) const {
       max_compaction_lag_ms,
       message_timestamp_before_max_ms,
       message_timestamp_after_max_ms,
-      storage_mode);
+      storage_mode,
+      migrated_from);
 }
 
 bool topic_properties::is_local_topic() const {
@@ -168,6 +170,7 @@ bool topic_properties::has_overrides() const {
         || message_timestamp_before_max_ms.has_value()
         || message_timestamp_after_max_ms.has_value()
         || storage_mode != storage::ntp_config::default_storage_mode
+        || migrated_from != model::redpanda_storage_mode::unset
         || schema_registry_context.has_value();
 
     return overrides;
@@ -266,6 +269,7 @@ topic_properties::get_ntp_cfg_overrides() const {
     ret.max_compaction_lag_ms = max_compaction_lag_ms;
     ret.remote_allow_gaps = remote_topic_allow_gaps;
     ret.storage_mode = storage_mode;
+    ret.migrated_from = migrated_from;
     return ret;
 }
 

--- a/src/v/cluster/topic_properties.h
+++ b/src/v/cluster/topic_properties.h
@@ -35,7 +35,7 @@ namespace cluster {
  */
 struct topic_properties
   : serde::
-      envelope<topic_properties, serde::version<14>, serde::compat_version<0>> {
+      envelope<topic_properties, serde::version<15>, serde::compat_version<0>> {
     topic_properties() noexcept = default;
     topic_properties(
       std::optional<model::compression> compression,
@@ -247,6 +247,11 @@ struct topic_properties
     model::redpanda_storage_mode storage_mode{
       storage::ntp_config::default_storage_mode};
 
+    // Storage mode this topic was migrated from. Set as part of
+    // storage.mode alter config from local/tsv1 -> cloud/tsv2
+    model::redpanda_storage_mode migrated_from{
+      model::redpanda_storage_mode::unset};
+
     bool is_local_topic() const;
 
     bool is_cloud_topic() const {
@@ -329,7 +334,8 @@ struct topic_properties
           message_timestamp_before_max_ms,
           message_timestamp_after_max_ms,
           storage_mode,
-          schema_registry_context);
+          schema_registry_context,
+          migrated_from);
     }
 
     friend bool

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -1045,10 +1045,9 @@ void incremental_update(
     }
 }
 
-void incremental_update(
+void incremental_update_no_remove(
   model::redpanda_storage_mode& property,
-  property_update<std::optional<model::redpanda_storage_mode>> override,
-  model::redpanda_storage_mode /*default_value*/) {
+  property_update<std::optional<model::redpanda_storage_mode>> override) {
     // Validation of storage mode transitions is done at the kafka layer.
     // This function only applies the update.
     switch (override.op) {
@@ -1228,9 +1227,11 @@ topic_properties topic_table::update_topic_properties(
       updated_properties.message_timestamp_after_max_ms,
       overrides.message_timestamp_after_max_ms);
     incremental_update(updated_properties.remote_label, overrides.remote_label);
+    incremental_update_no_remove(
+      updated_properties.storage_mode, overrides.storage_mode);
     incremental_update(
-      updated_properties.storage_mode,
-      overrides.storage_mode,
+      updated_properties.migrated_from,
+      overrides.migrated_from,
       storage::ntp_config::default_storage_mode);
     incremental_update(
       updated_properties.schema_registry_context,

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -664,7 +664,7 @@ struct property_update<tristate<T>>
 struct incremental_topic_updates
   : serde::envelope<
       incremental_topic_updates,
-      serde::version<11>,
+      serde::version<12>,
       serde::compat_version<0>> {
     static constexpr int8_t version_with_data_policy = -1;
     static constexpr int8_t version_with_shadow_indexing = -3;
@@ -756,6 +756,12 @@ struct incremental_topic_updates
       message_timestamp_after_max_ms;
     property_update<std::optional<model::redpanda_storage_mode>> storage_mode;
 
+    // Set alongside a storage_mode update that migrates the topic to
+    // cloud/tiered_cloud: the pre-migration mode. See
+    // topic_properties::migrated_from.
+    property_update<model::redpanda_storage_mode> migrated_from{
+      model::redpanda_storage_mode::unset, incremental_update_operation::none};
+
     property_update<std::optional<pandaproxy::schema_registry::context>>
       schema_registry_context;
 
@@ -822,7 +828,8 @@ struct incremental_topic_updates
           message_timestamp_after_max_ms,
           remote_label,
           storage_mode,
-          schema_registry_context);
+          schema_registry_context,
+          migrated_from);
     }
 
     fmt::iterator format_to(fmt::iterator it) const;

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -111,6 +111,8 @@ std::string_view to_string_view(feature f) {
         return "remote_labels";
     case feature::partition_properties_stm:
         return "partition_properties_stm";
+    case feature::topic_storage_mode_migration:
+        return "topic_storage_mode_migration";
     case feature::shadow_indexing_split_topic_property_update:
         return "shadow_indexing_split_topic_property_update";
     case feature::datalake_iceberg:

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -66,6 +66,7 @@ enum class feature : std::uint64_t {
     membership_change_controller_cmds = 1ULL << 22U,
     controller_snapshots = 1ULL << 23U,
     cloud_storage_manifest_format_v2 = 1ULL << 24U,
+    topic_storage_mode_migration = 1ULL << 25U,
     force_partition_reconfiguration = 1ULL << 26U,
     delete_records = 1ULL << 29U,
     raft_coordinated_recovery = 1ULL << 31U,
@@ -431,6 +432,12 @@ inline constexpr std::array feature_schema{
     release_version::v24_3_1,
     "partition_properties_stm",
     feature::partition_properties_stm,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    release_version::v26_3_1,
+    "topic_storage_mode_migration",
+    feature::topic_storage_mode_migration,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -99,7 +99,7 @@ create_topic_properties_update(
     std::apply(apply_op(op_t::none), update.custom_properties.serde_fields());
 
     static_assert(
-      std::tuple_size_v<decltype(update.properties.serde_fields())> == 45,
+      std::tuple_size_v<decltype(update.properties.serde_fields())> == 46,
       "If you add a property, decide on its default alter config "
       "policy, and handle the update in the loop below");
     static_assert(
@@ -143,6 +143,9 @@ create_topic_properties_update(
     update.properties.delete_retention_ms.op = op_t::none;
 
     update.properties.storage_mode.op = op_t::none;
+    // Internal: set alongside a storage.mode migration, never reset by a full
+    // AlterConfigs.
+    update.properties.migrated_from.op = op_t::none;
     update.properties.schema_registry_context.op = op_t::none;
 
     // Now that the defaults are set, continue to set properties from the

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -1372,15 +1372,15 @@ FIXTURE_TEST(
     app.partition_manager
       .invoke_on(
         *stopped_shard,
-        [stopped_ntp](cluster::partition_manager& mgr) {
+        [stopped_ntp](
+          this auto, cluster::partition_manager& mgr) -> ss::future<> {
             auto partition = mgr.get(stopped_ntp);
             auto stm = partition->raft()
                          ->stm_manager()
-                         ->get<cluster::log_eviction_stm>();
+                         ->template get<cluster::log_eviction_stm>();
             using accessor = cluster::testing::log_eviction_stm_accessor;
-            accessor::request_abort(*stm);
-            accessor::break_has_pending_truncation(*stm);
-            return accessor::close_gate(*stm);
+            co_await stm->stop_bg_fiber();
+            co_await accessor::close_gate(*stm);
         })
       .get();
 
@@ -1442,7 +1442,6 @@ FIXTURE_TEST(
                          ->get<cluster::log_eviction_stm>();
             using accessor = cluster::testing::log_eviction_stm_accessor;
             accessor::reset_gate(*stm);
-            accessor::reset_abort_source(*stm);
         })
       .get();
 }

--- a/src/v/raft/tests/failure_injectable_log.cc
+++ b/src/v/raft/tests/failure_injectable_log.cc
@@ -212,6 +212,12 @@ void failure_injectable_log::set_overrides(
     return _underlying_log->set_overrides(overrides);
 }
 
+void failure_injectable_log::set_partition_storage_mode(
+  model::redpanda_storage_mode mode) {
+    mutable_config().set_partition_storage_mode(mode);
+    return _underlying_log->set_partition_storage_mode(mode);
+}
+
 bool failure_injectable_log::notify_compaction_update() {
     return _underlying_log->notify_compaction_update();
 }

--- a/src/v/raft/tests/failure_injectable_log.h
+++ b/src/v/raft/tests/failure_injectable_log.h
@@ -118,6 +118,8 @@ public:
 
     void set_overrides(storage::ntp_config::default_overrides) final;
 
+    void set_partition_storage_mode(model::redpanda_storage_mode) final;
+
     bool notify_compaction_update() final;
 
     int64_t compaction_backlog() final;

--- a/src/v/raft/tests/raft_fixture_base.cc
+++ b/src/v/raft/tests/raft_fixture_base.cc
@@ -435,7 +435,13 @@ raft_node_instance::initialise(std::vector<raft::vnode> initial_nodes) {
       [this] { return storage::log_config(_base_directory, 8_MiB); },
       std::ref(_features));
     co_await _storage.invoke_on_all([](storage::api& a) { return a.start(); });
-    storage::ntp_config ntp_cfg(ntp(), _base_directory);
+    storage::ntp_config ntp_cfg(
+      ntp(),
+      _base_directory,
+      _ntp_config_overrides
+        ? std::make_unique<storage::ntp_config::default_overrides>(
+            *_ntp_config_overrides)
+        : nullptr);
 
     _underlying_log = co_await _storage.local().log_mgr().manage(
       std::move(ntp_cfg),
@@ -634,6 +640,10 @@ raft_node_instance& raft_fixture_base::add_node(
       _election_timeout.bind(),
       _heartbeat_interval.bind(),
       _with_offset_translation);
+
+    if (_ntp_config_overrides) {
+        instance->set_ntp_config_overrides(*_ntp_config_overrides);
+    }
 
     auto [it, success] = _nodes.emplace(id, std::move(instance));
     return *it->second;

--- a/src/v/raft/tests/raft_fixture_base.h
+++ b/src/v/raft/tests/raft_fixture_base.h
@@ -31,6 +31,7 @@
 #include "ssx/sformat.h"
 #include "storage/api.h"
 #include "storage/log.h"
+#include "storage/ntp_config.h"
 #include "test_utils/random_bytes.h"
 #include "utils/prefix_logger.h"
 
@@ -214,6 +215,10 @@ public:
 
     ss::sstring base_directory() const { return _base_directory; }
 
+    void set_ntp_config_overrides(storage::ntp_config::default_overrides o) {
+        _ntp_config_overrides = std::move(o);
+    }
+
     ss::sstring work_directory() const {
         return ssx::sformat(
           "{}/{}_{}", base_directory(), ntp().path(), _revision);
@@ -326,6 +331,7 @@ private:
     config::binding<std::chrono::milliseconds> _election_timeout;
     config::binding<std::chrono::milliseconds> _heartbeat_interval;
     bool _with_offset_translation;
+    std::optional<storage::ntp_config::default_overrides> _ntp_config_overrides;
     ss::sharded<fixture_group_manager> _group_manager;
     fixture_shard_manager _shard_manager{};
     service_t _service;
@@ -591,6 +597,10 @@ public:
 
     void enable_offset_translation() { _with_offset_translation = true; }
 
+    void set_ntp_config_overrides(storage::ntp_config::default_overrides o) {
+        _ntp_config_overrides = std::move(o);
+    }
+
     std::chrono::milliseconds get_election_timeout() const {
         return _election_timeout();
     }
@@ -627,6 +637,7 @@ private:
     config::mock_property<std::chrono::milliseconds> _election_timeout{500ms};
     config::mock_property<std::chrono::milliseconds> _heartbeat_interval{50ms};
     bool _with_offset_translation = false;
+    std::optional<storage::ntp_config::default_overrides> _ntp_config_overrides;
     std::filesystem::path _test_dir;
 };
 

--- a/src/v/ssx/BUILD
+++ b/src/v/ssx/BUILD
@@ -188,6 +188,20 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "reconciler",
+    hdrs = [
+        "reconciler.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":future_util",
+        ":sleep_abortable",
+        "//src/v/base",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "sleep_abortable",
     hdrs = [
         "sleep_abortable.h",

--- a/src/v/ssx/reconciler.h
+++ b/src/v/ssx/reconciler.h
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "base/vlog.h"
+#include "ssx/future-util.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future-util.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/shared_future.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/coroutine/as_future.hh>
+#include <seastar/util/defer.hh>
+#include <seastar/util/log.hh>
+#include <seastar/util/noncopyable_function.hh>
+
+#include <algorithm>
+#include <chrono>
+#include <list>
+#include <optional>
+#include <utility>
+
+namespace ssx {
+
+using namespace std::chrono_literals;
+
+/// Function to run on notify().  Returning is success.  Exceptions are retried
+/// with a backoff.  A shutdown exception ends the loop and propagates to
+/// waiters.
+using reconcile_fn = ss::noncopyable_function<ss::future<>()>;
+
+struct backoff_policy {
+    std::chrono::milliseconds base{100ms};
+    std::chrono::milliseconds max{5s};
+};
+
+/// Ensures that the reconcile_fn runs at least once after each call to
+/// notify().
+///
+/// notify() records that desired state may have moved and starts the loop if it
+/// is not already running. A notification that arrives mid-attempt is not lost:
+/// it causes another attempt rather than a second concurrent loop.
+///
+/// A closed gate, abort source, or a shutdown exception from the reconcile_fn
+/// results in giving up on all pending notifies and notifying waiters of
+/// failure.
+///
+/// User is responsible for triggering the passed abort source and closing the
+/// passed gate before anything the step touches is torn down.
+class reconciler {
+public:
+    reconciler(
+      ss::gate& gate,
+      ss::logger& log,
+      ss::sstring name,
+      reconcile_fn step,
+      ss::abort_source& as,
+      backoff_policy backoff = {})
+      : _gate(gate)
+      , _log(log)
+      , _name(std::move(name))
+      , _step(std::move(step))
+      , _backoff(backoff)
+      , _as(as) {}
+
+    reconciler(const reconciler&) = delete;
+    reconciler& operator=(const reconciler&) = delete;
+    reconciler(reconciler&&) = delete;
+    reconciler& operator=(reconciler&&) = delete;
+    ~reconciler() = default;
+
+    /// Notify to trigger a reconciliation.  Never blocks and never throws.
+    void notify() {
+        _dirty = true;
+        if (_running) {
+            return;
+        }
+        if (check_give_up()) {
+            return;
+        }
+        // Set before spawning rather than inside run(), so the single-loop
+        // guarantee does not rest on the coroutine body starting eagerly.
+        _running = true;
+        // Holds the gate for the duration of the loop
+        ssx::spawn_with_gate(_gate, [this] { return run(); });
+    }
+
+    /// notify(), and resolve once an attempt that began after this call has
+    /// succeeded.
+    ///
+    /// Fails with the reason the loop gave up (abort, closed gate).
+    /// A caller which does not care should detach with
+    /// ssx::ignore_shutdown_exceptions.
+    ss::future<> notify_and_wait() {
+        if (!_pending) {
+            _pending.emplace();
+        }
+        auto f = _pending->get_shared_future();
+        notify();
+        return f;
+    }
+
+    bool idle() const { return !_running; }
+
+private:
+    using waiters = std::list<ss::shared_promise<>>;
+
+    bool check_give_up(waiters* covering = nullptr) {
+        if (_gate.is_closed()) {
+            give_up(
+              covering, std::make_exception_ptr(ss::gate_closed_exception{}));
+            return true;
+        }
+        if (aborted()) {
+            give_up(
+              covering,
+              std::make_exception_ptr(ss::abort_requested_exception{}));
+            return true;
+        }
+        return false;
+    }
+
+    void give_up(waiters* covering, const std::exception_ptr& e) {
+        waiters to_fail;
+        if (covering != nullptr) {
+            to_fail.splice(to_fail.end(), *covering);
+        }
+        if (_pending) {
+            to_fail.push_back(std::move(*_pending));
+            _pending.reset();
+        }
+        for (auto& w : to_fail) {
+            w.set_exception(e);
+        }
+    }
+
+    bool aborted() const { return _as.abort_requested(); }
+
+    bool stopping() const { return _gate.is_closed() || aborted(); }
+
+    ss::future<> sleep(std::chrono::milliseconds delay) {
+        return ss::sleep_abortable(delay, _as);
+    }
+
+    ss::future<> run() {
+        auto mark_idle = ss::defer([this]() noexcept { _running = false; });
+
+        auto delay = _backoff.base;
+        // waiters covered by the current attempt
+        waiters covering;
+        while (_dirty && !stopping()) {
+            _dirty = false;
+            if (_pending) {
+                covering.push_back(std::move(*_pending));
+                _pending.reset();
+            }
+            auto f = co_await ss::coroutine::as_future(
+              ss::futurize_invoke(_step));
+            if (!f.failed()) {
+                for (auto& w : covering) {
+                    w.set_value();
+                }
+                covering.clear();
+                delay = _backoff.base;
+                continue;
+            }
+            auto e = f.get_exception();
+            if (ssx::is_shutdown_exception(e)) {
+                give_up(&covering, e);
+                co_return;
+            }
+            vlog(
+              _log.warn,
+              "{}: reconciliation attempt failed: {}; retrying in {}ms",
+              _name,
+              e,
+              delay / 1ms);
+            _dirty = true;
+            auto slept = co_await ss::coroutine::as_future(sleep(delay));
+            if (slept.failed()) {
+                give_up(&covering, slept.get_exception());
+                co_return;
+            }
+            delay = std::min(delay * 2, _backoff.max);
+        }
+        check_give_up(&covering);
+    }
+
+    ss::gate& _gate;
+    ss::logger& _log;
+    ss::sstring _name;
+    reconcile_fn _step;
+    backoff_policy _backoff;
+    ss::abort_source& _as;
+    // Waiters whose notification no attempt has begun to answer yet.
+    std::optional<ss::shared_promise<>> _pending;
+    bool _dirty{false};
+    bool _running{false};
+};
+
+} // namespace ssx

--- a/src/v/ssx/tests/BUILD
+++ b/src/v/ssx/tests/BUILD
@@ -349,6 +349,24 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "reconciler_test",
+    timeout = "short",
+    srcs = [
+        "reconciler_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/base",
+        "//src/v/ssx:future_util",
+        "//src/v/ssx:reconciler",
+        "//src/v/test_utils:async",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "single_fiber_executor_test",
     timeout = "short",
     srcs = [

--- a/src/v/ssx/tests/reconciler_test.cc
+++ b/src/v/ssx/tests/reconciler_test.cc
@@ -1,0 +1,354 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "base/seastarx.h"
+#include "ssx/reconciler.h"
+#include "test_utils/async.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/semaphore.hh>
+#include <seastar/coroutine/as_future.hh>
+#include <seastar/util/later.hh>
+#include <seastar/util/log.hh>
+
+#include <chrono>
+#include <exception>
+#include <stdexcept>
+
+namespace ssx {
+
+using namespace std::chrono_literals;
+
+namespace {
+
+ss::logger test_log("reconciler_test");
+
+/// We want to be able to be more selective than ssx::is_shutdown_exception so
+/// we can distinguish broken_promise from abort_requested.
+template<typename Ex>
+bool failed_with(const ss::future<>& f) {
+    try {
+        std::rethrow_exception(const_cast<ss::future<>&>(f).get_exception());
+    } catch (const Ex&) {
+        return true;
+    } catch (...) {
+    }
+    return false;
+}
+
+/// Runs a step under a gate closed on scope exit, so a test that leaves the
+/// loop mid-retry does not have to unwind it by hand.
+class harness {
+public:
+    explicit harness(reconcile_fn step, backoff_policy backoff = {})
+      : _r(_gate, test_log, "test", std::move(step), _as, backoff) {}
+
+    reconciler& r() { return _r; }
+    ss::abort_source& as() { return _as; }
+
+    ss::future<> stop() {
+        _as.request_abort();
+        return _gate.close();
+    }
+
+    ss::future<> close_gate() { return _gate.close(); }
+
+private:
+    ss::gate _gate;
+    ss::abort_source _as;
+    reconciler _r;
+};
+
+} // namespace
+
+TEST_CORO(Reconciler, does_not_run_until_notified) {
+    int runs = 0;
+    harness h([&runs] {
+        ++runs;
+        return ss::now();
+    });
+    co_await ss::yield();
+    ASSERT_EQ_CORO(runs, 0);
+    ASSERT_TRUE_CORO(h.r().idle());
+    co_await h.stop();
+}
+
+TEST_CORO(Reconciler, notify_and_wait_resolves_after_a_run) {
+    int runs = 0;
+    harness h([&runs] {
+        ++runs;
+        return ss::now();
+    });
+    co_await h.r().notify_and_wait();
+    ASSERT_EQ_CORO(runs, 1);
+    co_await h.stop();
+}
+
+// Notifications arriving while a run is in progress collapse into exactly one
+// further run: not zero (the change would be lost) and not one per notify.
+TEST_CORO(Reconciler, notifies_during_a_run_collapse_into_one) {
+    int runs = 0;
+    ss::promise<> hold;
+    harness h([&runs, &hold] {
+        ++runs;
+        return runs == 1 ? hold.get_future() : ss::now();
+    });
+
+    h.r().notify();
+    co_await ss::yield();
+    ASSERT_EQ_CORO(runs, 1);
+
+    h.r().notify();
+    h.r().notify();
+    h.r().notify();
+    ASSERT_EQ_CORO(runs, 1);
+
+    hold.set_value();
+    co_await tests::cooperative_spin_wait_with_timeout(
+      5s, [&h] { return h.r().idle(); });
+    ASSERT_EQ_CORO(runs, 2);
+    co_await h.stop();
+}
+
+// A run already in flight may have read the state the notification is about, so
+// it cannot be what satisfies the waiter.
+TEST_CORO(Reconciler, a_run_in_flight_does_not_satisfy_a_later_waiter) {
+    int runs = 0;
+    ss::promise<> hold;
+    harness h([&runs, &hold] {
+        ++runs;
+        return runs == 1 ? hold.get_future() : ss::now();
+    });
+
+    h.r().notify();
+    co_await ss::yield();
+    ASSERT_EQ_CORO(runs, 1);
+
+    auto waiter = h.r().notify_and_wait();
+    ASSERT_FALSE_CORO(waiter.available());
+
+    hold.set_value();
+    co_await std::move(waiter);
+    ASSERT_EQ_CORO(runs, 2);
+    co_await h.stop();
+}
+
+// A waiter queued while a run is in flight is folded into the retry of that
+// run, so it is answered by the next attempt rather than waiting for one of its
+// own -- and, above all, is not dropped.
+TEST_CORO(Reconciler, a_waiter_queued_during_a_retry_is_still_answered) {
+    int runs = 0;
+    ss::promise<> hold;
+    harness h(
+      [&runs, &hold] {
+          ++runs;
+          return runs == 1 ? hold.get_future() : ss::now();
+      },
+      backoff_policy{.base = 1ms, .max = 1ms});
+
+    auto first = h.r().notify_and_wait();
+    co_await ss::yield();
+    ASSERT_EQ_CORO(runs, 1);
+
+    // Queued while the first run is still in flight, so the attempt that
+    // answers it is the retry, which begins after the notification.
+    auto second = h.r().notify_and_wait();
+
+    hold.set_exception(std::runtime_error("first attempt fails"));
+    co_await std::move(first);
+    co_await std::move(second);
+    ASSERT_EQ_CORO(runs, 2);
+    co_await h.stop();
+}
+
+// Two waiters answered by consecutive attempts of one loop. Each attempt
+// answers its own batch and no more: the first waiter is answered as its
+// attempt ends, while the second attempt is already in flight and its waiter
+// still pending.
+TEST_CORO(Reconciler, consecutive_attempts_answer_their_own_waiters) {
+    // The step reports each attempt as it begins and then blocks, so the test
+    // can look at the reconciler with an attempt in flight.
+    ss::semaphore begun{0};
+    ss::semaphore finish{0};
+    int attempts = 0;
+    harness h([&begun, &finish, &attempts] {
+        ++attempts;
+        begun.signal(1);
+        return finish.wait(1);
+    });
+
+    auto first = h.r().notify_and_wait();
+    co_await begun.wait(1);
+    ASSERT_FALSE_CORO(first.available());
+
+    // Queued while the first attempt is in flight, so it belongs to the next
+    // one rather than to the attempt about to finish.
+    auto second = h.r().notify_and_wait();
+
+    finish.signal(1);
+    co_await begun.wait(1);
+
+    // The second attempt is now blocked, and the state of the two waiters says
+    // which attempt answered which.
+    ASSERT_TRUE_CORO(first.available());
+    ASSERT_FALSE_CORO(second.available());
+    co_await std::move(first);
+
+    finish.signal(1);
+    co_await std::move(second);
+    ASSERT_EQ_CORO(attempts, 2);
+    co_await h.stop();
+}
+
+TEST_CORO(Reconciler, failures_are_retried_until_success) {
+    int runs = 0;
+    harness h(
+      [&runs] {
+          ++runs;
+          if (runs <= 3) {
+              return ss::make_exception_future<>(std::runtime_error("not yet"));
+          }
+          return ss::now();
+      },
+      backoff_policy{.base = 1ms, .max = 4ms});
+
+    co_await h.r().notify_and_wait();
+    ASSERT_EQ_CORO(runs, 4);
+    co_await h.stop();
+}
+
+// A step that throws before its first suspension point fails the attempt, it
+// does not escape the loop.
+TEST_CORO(Reconciler, a_synchronous_throw_is_a_failed_attempt) {
+    int runs = 0;
+    harness h(
+      [&runs] {
+          ++runs;
+          if (runs == 1) {
+              throw std::runtime_error("thrown before suspending");
+          }
+          return ss::now();
+      },
+      backoff_policy{.base = 1ms, .max = 1ms});
+
+    co_await h.r().notify_and_wait();
+    ASSERT_EQ_CORO(runs, 2);
+    co_await h.stop();
+}
+
+TEST_CORO(Reconciler, a_shutdown_exception_from_the_step_stops_the_loop) {
+    int runs = 0;
+    harness h([&runs] {
+        ++runs;
+        return ss::make_exception_future<>(ss::abort_requested_exception{});
+    });
+
+    auto res = co_await ss::coroutine::as_future(h.r().notify_and_wait());
+    ASSERT_TRUE_CORO(res.failed());
+    ASSERT_TRUE_CORO(failed_with<ss::abort_requested_exception>(res));
+    // The loop gives up before answering the waiter, so it is already gone by
+    // the time this resumes: stopped rather than retried.
+    ASSERT_TRUE_CORO(h.r().idle());
+    ASSERT_EQ_CORO(runs, 1);
+    co_await h.stop();
+}
+
+// An abort has to interrupt the backoff, not merely be noticed once it expires,
+// so the backoff here is far longer than the test is willing to wait for.
+TEST_CORO(Reconciler, an_abort_fails_the_waiter_rather_than_hanging_it) {
+    ss::semaphore attempted{0};
+    harness h(
+      [&attempted] {
+          attempted.signal(1);
+          return ss::make_exception_future<>(
+            std::runtime_error("never succeeds"));
+      },
+      backoff_policy{.base = 10s, .max = 10s});
+
+    auto waiter = h.r().notify_and_wait();
+    // The attempt has run and failed, so the loop is in its backoff.
+    co_await attempted.wait(1);
+
+    const auto start = std::chrono::steady_clock::now();
+    h.as().request_abort();
+    auto res = co_await ss::coroutine::as_future(std::move(waiter));
+    const auto waited = std::chrono::steady_clock::now() - start;
+
+    ASSERT_TRUE_CORO(res.failed());
+    ASSERT_TRUE_CORO(failed_with<ss::abort_requested_exception>(res));
+    ASSERT_LT_CORO(waited, 2s);
+    co_await h.stop();
+}
+
+// Closing the gate has to end a retrying loop, or the close waits on a holder
+// that never leaves -- and the waiter it was carrying has to be told. Unlike an
+// abort, a close cannot interrupt the backoff, so the loop only notices when
+// the sleep expires and the close pays for it: hence the short backoff here.
+TEST_CORO(Reconciler, closing_the_gate_ends_a_retrying_loop) {
+    ss::semaphore attempted{0};
+    harness h(
+      [&attempted] {
+          attempted.signal(1);
+          return ss::make_exception_future<>(
+            std::runtime_error("never succeeds"));
+      },
+      backoff_policy{.base = 20ms, .max = 20ms});
+
+    auto waiter = h.r().notify_and_wait();
+    // The attempt has run and failed, so the loop is retrying.
+    co_await attempted.wait(1);
+
+    co_await h.close_gate();
+    auto res = co_await ss::coroutine::as_future(std::move(waiter));
+    ASSERT_TRUE_CORO(res.failed());
+    ASSERT_TRUE_CORO(failed_with<ss::gate_closed_exception>(res));
+}
+
+TEST_CORO(Reconciler, an_already_aborted_source_fails_the_waiter) {
+    ss::gate gate;
+    ss::abort_source as;
+    as.request_abort();
+
+    int runs = 0;
+    reconciler r(
+      gate,
+      test_log,
+      "test",
+      [&runs] {
+          ++runs;
+          return ss::now();
+      },
+      as);
+
+    auto res = co_await ss::coroutine::as_future(r.notify_and_wait());
+    ASSERT_TRUE_CORO(res.failed());
+    ASSERT_TRUE_CORO(failed_with<ss::abort_requested_exception>(res));
+    ASSERT_EQ_CORO(runs, 0);
+    co_await gate.close();
+}
+
+TEST_CORO(Reconciler, notifying_a_closed_reconciler_fails_the_waiter) {
+    int runs = 0;
+    harness h([&runs] {
+        ++runs;
+        return ss::now();
+    });
+    co_await h.close_gate();
+
+    h.r().notify();
+    auto res = co_await ss::coroutine::as_future(h.r().notify_and_wait());
+    ASSERT_TRUE_CORO(res.failed());
+    ASSERT_TRUE_CORO(failed_with<ss::gate_closed_exception>(res));
+    ASSERT_EQ_CORO(runs, 0);
+}
+
+} // namespace ssx

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -3801,6 +3801,10 @@ void disk_log_impl::set_overrides(ntp_config::default_overrides o) {
     mutable_config().set_overrides(o);
 }
 
+void disk_log_impl::set_partition_storage_mode(model::redpanda_storage_mode m) {
+    mutable_config().set_partition_storage_mode(m);
+}
+
 /**
  * We express compaction backlog as the size of data that has to be read to
  * perform full compaction.

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -171,6 +171,7 @@ public:
     size_t size_bytes() const override { return _probe->partition_size(); }
     uint64_t size_bytes_after_offset(model::offset o) const override;
     void set_overrides(ntp_config::default_overrides) final;
+    void set_partition_storage_mode(model::redpanda_storage_mode) final;
     bool notify_compaction_update() final;
 
     int64_t compaction_backlog() final;

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -226,6 +226,12 @@ public:
     /// topic/partition-level overrides
     virtual void set_overrides(ntp_config::default_overrides) = 0;
 
+    /// Mutates the partition_storage_mode stored in the log's ntp_config: the
+    /// partition's own durable storage mode, fed from partition_properties.
+    /// Abstract rather than defaulted, like set_overrides: a wrapping log that
+    /// silently dropped this would report a stale storage mode from config().
+    virtual void set_partition_storage_mode(model::redpanda_storage_mode) = 0;
+
     /// Notifies the log about a possible change to the log compaction config.
     /// Returns true if the log compaction changed.
     virtual bool notify_compaction_update() = 0;

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -21,6 +21,7 @@
 #include <seastar/core/sstring.hh>
 
 #include <optional>
+#include <stdexcept>
 
 namespace storage {
 using with_cache = ss::bool_class<struct log_cache_tag>;
@@ -247,40 +248,84 @@ public:
                                      : topic_recovery_enabled::no;
     }
 
+    // The storage mode the topic config requests (the "desired" mode). `unset`
+    // for a legacy topic that uses shadow_indexing_mode instead of
+    // storage_mode.
+    model::redpanda_storage_mode topic_storage_mode() const {
+        return _overrides ? _overrides->storage_mode
+                          : model::redpanda_storage_mode::unset;
+    }
+
+    // The partition's own durable storage mode (the "actual" mode), recorded in
+    // partition_properties and pushed in via set_partition_storage_mode().
+    // Falls back to topic_storage_mode() when unset (not yet bootstrapped).
+    // Serving/behavior accessors key on partition_storage_mode rather than
+    // topic_storage_mode. On a storage mode switch that needs migration,
+    // partition_storage_mode is advanced to match topic_storage_mode only once
+    // the migration completes.
+    model::redpanda_storage_mode partition_storage_mode() const {
+        return resolve_partition_storage_mode(_partition_storage_mode);
+    }
+
+    // Resolve a durable partition_storage_mode value the way
+    // partition_storage_mode() does, for asking what a mode would mean before
+    // it is applied.
+    model::redpanda_storage_mode
+    resolve_partition_storage_mode(model::redpanda_storage_mode m) const {
+        return m != model::redpanda_storage_mode::unset ? m
+                                                        : topic_storage_mode();
+    }
+
+    void set_partition_storage_mode(model::redpanda_storage_mode m) {
+        _partition_storage_mode = m;
+    }
+
+    // True while the partition is mid tiered->cloud migration: the topic config
+    // requests a cloud storage mode (topic_storage_mode) but the partition's
+    // durable partition_storage_mode is still tiered.  The partition is served
+    // as tiered until partition_storage_mode is advanced to match.
+    bool is_migrating() const {
+        const auto tm = topic_storage_mode();
+        return (tm == model::redpanda_storage_mode::cloud
+                || tm == model::redpanda_storage_mode::tiered_cloud)
+               && partition_storage_mode()
+                    == model::redpanda_storage_mode::tiered;
+    }
+
     bool is_archival_enabled() const {
-        if (_overrides == nullptr) {
-            return false;
-        }
-        // Explicit tiered
-        if (_overrides->storage_mode == model::redpanda_storage_mode::tiered) {
+        using enum model::redpanda_storage_mode;
+        switch (partition_storage_mode()) {
+        case tiered:
             return true;
-        }
-        // Explicit local or cloud
-        if (_overrides->storage_mode != model::redpanda_storage_mode::unset) {
+        case local:
+        case cloud:
+        case tiered_cloud:
             return false;
+        case unset:
+            // Legacy shadow_indexing topic: no storage mode was ever recorded,
+            // so the shadow_indexing flags are the answer.
+            return _overrides && _overrides->shadow_indexing_mode
+                   && model::is_archival_enabled(
+                     _overrides->shadow_indexing_mode.value());
         }
-        // Unset, fall back to legacy shadow_indexing
-        return _overrides->shadow_indexing_mode
-               && model::is_archival_enabled(
-                 _overrides->shadow_indexing_mode.value());
+        throw std::invalid_argument("unknown redpanda_storage_mode");
     }
 
     bool is_remote_fetch_enabled() const {
-        if (_overrides == nullptr) {
-            return false;
-        }
-        // Explicit tiered
-        if (_overrides->storage_mode == model::redpanda_storage_mode::tiered) {
+        using enum model::redpanda_storage_mode;
+        switch (partition_storage_mode()) {
+        case tiered:
             return true;
-        }
-        // Explicit local or cloud
-        if (_overrides->storage_mode != model::redpanda_storage_mode::unset) {
+        case local:
+        case cloud:
+        case tiered_cloud:
             return false;
+        case unset:
+            return _overrides && _overrides->shadow_indexing_mode
+                   && model::is_fetch_enabled(
+                     _overrides->shadow_indexing_mode.value());
         }
-        // Unset, fall back to legacy shadow_indexing
-        return _overrides->shadow_indexing_mode
-               && model::is_fetch_enabled(
-                 _overrides->shadow_indexing_mode.value());
+        throw std::invalid_argument("unknown redpanda_storage_mode");
     }
 
     bool is_read_replica_mode_enabled() const {
@@ -302,23 +347,23 @@ public:
      * both reads and writes to S3, and is not a read replica.
      */
     bool is_tiered_storage() const {
-        if (_overrides == nullptr) {
+        if (is_read_replica_mode_enabled()) {
             return false;
         }
-        if (_overrides->read_replica.value_or(false)) {
-            return false;
-        }
-        // Explicit tiered
-        if (_overrides->storage_mode == model::redpanda_storage_mode::tiered) {
+        using enum model::redpanda_storage_mode;
+        switch (partition_storage_mode()) {
+        case tiered:
             return true;
-        }
-        // Explicit local or cloud
-        if (_overrides->storage_mode != model::redpanda_storage_mode::unset) {
+        case local:
+        case cloud:
+        case tiered_cloud:
             return false;
+        case unset:
+            return _overrides
+                   && _overrides->shadow_indexing_mode
+                        == model::shadow_indexing_mode::full;
         }
-        // Unset, fall back to legacy shadow_indexing
-        return _overrides->shadow_indexing_mode
-               == model::shadow_indexing_mode::full;
+        throw std::invalid_argument("unknown redpanda_storage_mode");
     }
 
     bool remote_delete() const {
@@ -439,17 +484,14 @@ public:
     }
 
     bool cloud_topic_enabled() const {
-        return _overrides
-               && (_overrides->storage_mode
-                     == model::redpanda_storage_mode::cloud
-                   || _overrides->storage_mode
-                        == model::redpanda_storage_mode::tiered_cloud);
+        const auto mode = partition_storage_mode();
+        return mode == model::redpanda_storage_mode::cloud
+               || mode == model::redpanda_storage_mode::tiered_cloud;
     }
 
     bool is_tiered_cloud() const {
-        return _overrides
-               && _overrides->storage_mode
-                    == model::redpanda_storage_mode::tiered_cloud;
+        return partition_storage_mode()
+               == model::redpanda_storage_mode::tiered_cloud;
     }
 
     std::optional<double> min_cleanable_dirty_ratio() const {
@@ -510,6 +552,13 @@ private:
     /// This revision is used to construct cloud storage paths. It differs from
     /// _topic_revision in case of recovered topics or read replicas.
     model::initial_revision_id _remote_rev{0};
+
+    /// The partition's own durable storage mode, fed from partition_properties
+    /// (see partition_storage_mode()). `unset` until bootstrapped, when the
+    /// mode accessors fall back to the topic-config-derived
+    /// topic_storage_mode().
+    model::redpanda_storage_mode _partition_storage_mode
+      = model::redpanda_storage_mode::unset;
 
 public:
     // in storage/types.cc

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -97,6 +97,11 @@ public:
         // Storage mode for the topic (local, tiered, or cloud)
         model::redpanda_storage_mode storage_mode{default_storage_mode};
 
+        // Storage mode this topic was migrated from, see
+        // topic_properties::migrated_from
+        model::redpanda_storage_mode migrated_from{
+          model::redpanda_storage_mode::unset};
+
         fmt::iterator format_to(fmt::iterator it) const;
     };
 
@@ -492,6 +497,12 @@ public:
     bool is_tiered_cloud() const {
         return partition_storage_mode()
                == model::redpanda_storage_mode::tiered_cloud;
+    }
+
+    bool migrated_to_cloud() const {
+        return _overrides
+               && _overrides->migrated_from
+                    != model::redpanda_storage_mode::unset;
     }
 
     std::optional<double> min_cleanable_dirty_ratio() const {

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -780,6 +780,20 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "ntp_config_test",
+    timeout = "short",
+    srcs = [
+        "ntp_config_test.cc",
+    ],
+    deps = [
+        "//src/v/model",
+        "//src/v/storage",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "log_retention_test",
     timeout = "short",
     srcs = [

--- a/src/v/storage/tests/ntp_config_test.cc
+++ b/src/v/storage/tests/ntp_config_test.cc
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "model/metadata.h"
+#include "storage/ntp_config.h"
+
+#include <gtest/gtest.h>
+
+// The serving predicates key on partition_storage_mode (the partition's own
+// durable mode), not on topic_storage_mode (what the topic config asks for).
+// Every call site of these predicates is untouched by that split, so pinning
+// the table here is what establishes that a partition mid tiered->cloud
+// migration keeps being served as tiered storage until cutover.
+namespace storage {
+namespace {
+
+using mode = model::redpanda_storage_mode;
+
+ntp_config make_cfg(std::optional<mode> topic_storage_mode) {
+    auto overrides = std::make_unique<ntp_config::default_overrides>();
+    if (topic_storage_mode.has_value()) {
+        overrides->storage_mode = *topic_storage_mode;
+    }
+    return ntp_config{
+      model::ntp{
+        model::kafka_namespace, model::topic{"t"}, model::partition_id{0}},
+      "/tmp/test",
+      std::move(overrides)};
+}
+
+TEST(
+  ntp_config_storage_mode,
+  partition_storage_mode_falls_back_to_topic_storage_mode) {
+    // Until the partition_properties STM records a mode, partition_storage_mode
+    // is `unset` and the accessors read through to the topic config.
+    auto cfg = make_cfg(mode::tiered);
+    EXPECT_EQ(cfg.topic_storage_mode(), mode::tiered);
+    EXPECT_EQ(cfg.partition_storage_mode(), mode::tiered);
+    EXPECT_TRUE(cfg.is_archival_enabled());
+    EXPECT_TRUE(cfg.is_remote_fetch_enabled());
+    EXPECT_FALSE(cfg.cloud_topic_enabled());
+    EXPECT_FALSE(cfg.is_migrating());
+}
+
+TEST(ntp_config_storage_mode, native_cloud_topic) {
+    auto cfg = make_cfg(mode::cloud);
+    cfg.set_partition_storage_mode(mode::cloud);
+    EXPECT_TRUE(cfg.cloud_topic_enabled());
+    EXPECT_FALSE(cfg.is_tiered_cloud());
+    EXPECT_FALSE(cfg.is_archival_enabled());
+    EXPECT_FALSE(cfg.is_remote_fetch_enabled());
+    // Already the requested mode, so there is nothing to migrate.
+    EXPECT_FALSE(cfg.is_migrating());
+}
+
+TEST(ntp_config_storage_mode, migrating_is_served_as_tiered_storage) {
+    // The migration trigger: the topic config asks for cloud while the
+    // partition's durable mode is still tiered. The partition must keep every
+    // tiered-storage behavior -- archival uploads and remote fetch -- and must
+    // NOT be routed to the cloud-topic path.
+    for (auto destination : {mode::cloud, mode::tiered_cloud}) {
+        auto cfg = make_cfg(destination);
+        cfg.set_partition_storage_mode(mode::tiered);
+        EXPECT_EQ(cfg.topic_storage_mode(), destination);
+        EXPECT_EQ(cfg.partition_storage_mode(), mode::tiered);
+        EXPECT_TRUE(cfg.is_migrating());
+        EXPECT_FALSE(cfg.cloud_topic_enabled());
+        EXPECT_TRUE(cfg.is_archival_enabled());
+        EXPECT_TRUE(cfg.is_remote_fetch_enabled());
+    }
+}
+
+TEST(ntp_config_storage_mode, cutover_flips_routing) {
+    // Cutover advances partition_storage_mode to match topic_storage_mode. That
+    // single write is the routing flip: the partition stops being
+    // archival/remote-fetch and becomes a cloud topic, and is no longer
+    // migrating.
+    auto cfg = make_cfg(mode::tiered_cloud);
+    cfg.set_partition_storage_mode(mode::tiered);
+    ASSERT_TRUE(cfg.is_migrating());
+
+    cfg.set_partition_storage_mode(mode::tiered_cloud);
+    EXPECT_FALSE(cfg.is_migrating());
+    EXPECT_TRUE(cfg.cloud_topic_enabled());
+    EXPECT_TRUE(cfg.is_tiered_cloud());
+    EXPECT_FALSE(cfg.is_archival_enabled());
+    EXPECT_FALSE(cfg.is_remote_fetch_enabled());
+}
+
+TEST(ntp_config_storage_mode, unset_falls_back_to_shadow_indexing) {
+    // Legacy topics carry no storage_mode; both modes read `unset` and the
+    // accessors fall back to shadow_indexing_mode. The split must not disturb
+    // this path.
+    auto cfg = make_cfg(std::nullopt);
+    ASSERT_EQ(cfg.topic_storage_mode(), mode::unset);
+    ASSERT_EQ(cfg.partition_storage_mode(), mode::unset);
+    EXPECT_FALSE(cfg.is_migrating());
+    EXPECT_FALSE(cfg.cloud_topic_enabled());
+
+    auto overrides = ntp_config::default_overrides{};
+    overrides.shadow_indexing_mode = model::shadow_indexing_mode::full;
+    cfg.set_overrides(overrides);
+    EXPECT_TRUE(cfg.is_archival_enabled());
+    EXPECT_TRUE(cfg.is_remote_fetch_enabled());
+
+    overrides.shadow_indexing_mode = model::shadow_indexing_mode::disabled;
+    cfg.set_overrides(overrides);
+    EXPECT_FALSE(cfg.is_archival_enabled());
+    EXPECT_FALSE(cfg.is_remote_fetch_enabled());
+}
+
+TEST(
+  ntp_config_storage_mode,
+  resolve_partition_storage_mode_reads_through_unset_only) {
+    auto cfg = make_cfg(mode::tiered);
+
+    // `unset` is the "not yet bootstrapped" sentinel, and the only value that
+    // reads through to the topic config. That read-through is what makes a
+    // partition which has never recorded a mode behave as its topic asks.
+    EXPECT_EQ(cfg.resolve_partition_storage_mode(mode::unset), mode::tiered);
+
+    // Every other value is the partition's own answer and shadows
+    // topic_storage_mode -- what lets a migrating partition stay tiered while
+    // its topic asks for cloud.
+    for (auto m :
+         {mode::local, mode::tiered, mode::cloud, mode::tiered_cloud}) {
+        EXPECT_EQ(cfg.resolve_partition_storage_mode(m), m)
+          << "durable mode " << static_cast<int>(m);
+    }
+
+    // partition_storage_mode() is defined as resolve_partition_storage_mode of
+    // the durable value; callers reason about transitions with the latter, so
+    // they must not diverge.
+    for (auto m :
+         {mode::unset,
+          mode::local,
+          mode::tiered,
+          mode::cloud,
+          mode::tiered_cloud}) {
+        cfg.set_partition_storage_mode(m);
+        EXPECT_EQ(
+          cfg.partition_storage_mode(), cfg.resolve_partition_storage_mode(m))
+          << "durable mode " << static_cast<int>(m);
+    }
+}
+
+TEST(ntp_config_storage_mode, is_archival_enabled_table) {
+    auto cfg = make_cfg(mode::local);
+
+    // Only explicit tiered archives. cloud/tiered_cloud are served by the
+    // cloud-topic path instead, and local does not archive at all.
+    cfg.set_partition_storage_mode(mode::tiered);
+    EXPECT_TRUE(cfg.is_archival_enabled());
+    cfg.set_partition_storage_mode(mode::local);
+    EXPECT_FALSE(cfg.is_archival_enabled());
+    cfg.set_partition_storage_mode(mode::cloud);
+    EXPECT_FALSE(cfg.is_archival_enabled());
+    cfg.set_partition_storage_mode(mode::tiered_cloud);
+    EXPECT_FALSE(cfg.is_archival_enabled());
+}
+
+TEST(ntp_config_storage_mode, is_archival_enabled_legacy_fallback) {
+    // Both modes unset: the legacy shadow_indexing flag is the answer. Driving
+    // this through the real accessor means the durable mode has to be unset
+    // *and* read through to an unset topic mode, which is the only way a
+    // deployed partition reaches the fallback.
+    auto cfg = make_cfg(std::nullopt);
+    cfg.set_partition_storage_mode(mode::unset);
+    EXPECT_FALSE(cfg.is_archival_enabled());
+
+    auto overrides = ntp_config::default_overrides{};
+    overrides.shadow_indexing_mode = model::shadow_indexing_mode::full;
+    cfg.set_overrides(overrides);
+    EXPECT_TRUE(cfg.is_archival_enabled());
+
+    // ...and the fallback must not leak into the explicit modes.
+    cfg.set_partition_storage_mode(mode::local);
+    EXPECT_FALSE(cfg.is_archival_enabled());
+    cfg.set_partition_storage_mode(mode::cloud);
+    EXPECT_FALSE(cfg.is_archival_enabled());
+    cfg.set_partition_storage_mode(mode::tiered);
+    EXPECT_TRUE(cfg.is_archival_enabled());
+}
+
+TEST(ntp_config_storage_mode, cloud_topic_enabled_table) {
+    // The cloud-topic answer is a property of the resolved mode alone -- no
+    // legacy shadow_indexing fallback.
+    auto cfg = make_cfg(mode::local);
+    cfg.set_partition_storage_mode(mode::cloud);
+    EXPECT_TRUE(cfg.cloud_topic_enabled());
+    cfg.set_partition_storage_mode(mode::tiered_cloud);
+    EXPECT_TRUE(cfg.cloud_topic_enabled());
+    cfg.set_partition_storage_mode(mode::local);
+    EXPECT_FALSE(cfg.cloud_topic_enabled());
+    cfg.set_partition_storage_mode(mode::tiered);
+    EXPECT_FALSE(cfg.cloud_topic_enabled());
+}
+
+} // namespace
+} // namespace storage

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -152,7 +152,8 @@ fmt::iterator ntp_config::default_overrides::format_to(fmt::iterator it) const {
       "initial_retention_local_target_ms: {}, write_caching: {}, flush_ms: {}, "
       "flush_bytes: {}, iceberg_mode: {}, remote_allow_gaps: {}, "
       "delete_retention_ms: {}, min_cleanable_dirty_ratio: {}, "
-      "min_compaction_lag_ms: {}, max_compaction_lag_ms: {}, storage_mode: {} "
+      "min_compaction_lag_ms: {}, max_compaction_lag_ms: {}, storage_mode: {}, "
+      "migrated_from: {} "
       "}}",
       compaction_strategy,
       cleanup_policy_bitflags,
@@ -175,7 +176,8 @@ fmt::iterator ntp_config::default_overrides::format_to(fmt::iterator it) const {
       min_cleanable_dirty_ratio,
       min_compaction_lag_ms,
       max_compaction_lag_ms,
-      storage_mode);
+      storage_mode,
+      migrated_from);
 }
 
 fmt::iterator ntp_config::format_to(fmt::iterator it) const {

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -1235,6 +1235,11 @@ PERTURB_ACKNOWLEDGED_FEATURES = frozenset(
         # Iceberg extended-mode topic-config gate; exercising it needs Iceberg
         # topic setup orthogonal to the finalization behavior under test.
         "iceberg_extended_mode_config",
+        # Downgrade-safe by inspection: most of the functionality this gates is
+        # not present yet, so nothing writes the new partition_storage_mode command while
+        # an upgrade is unfinalized. A follow-up PR exercises the gate for real
+        # once the migration trigger lands.
+        "topic_storage_mode_migration",
     }
 )
 
@@ -1417,12 +1422,13 @@ class ManualFinalizationUpgradeTest(UnfinalizedUpgradeMixin, FeaturesTestBase):
         self._exercise_tiered_cloud_topics()
         self._exercise_shadow_link_role_sync()
         self._exercise_fetch_controller_snapshot_rpc()
-        # The other two v26.2-gated features are cluster-linking features that
-        # need a second (source) cluster, so they are acknowledged rather than
-        # exercised here; see PERTURB_ACKNOWLEDGED_FEATURES for why each stays
-        # downgrade-safe (shadow_link_sr_api_sync is covered by
+        # The remaining gated features are acknowledged rather than exercised
+        # here; see PERTURB_ACKNOWLEDGED_FEATURES for why each stays
+        # downgrade-safe. Two are v26.2 cluster-linking features needing a second
+        # (source) cluster (shadow_link_sr_api_sync is covered by
         # ShadowLinkUnfinalizedUpgradeTest; batch_mirror_topic_status is safe by
-        # inspection).
+        # inspection); topic_storage_mode_migration is v26.3-gated and gates nothing
+        # user-visible until the migration trigger lands.
 
     def _exercise_tiered_cloud_topics(self):
         """tiered_cloud_topics gate: creating a topic with the tiered_v2


### PR DESCRIPTION
## Release Notes

* none

## BLUF

- Include `ctp_stm` on all user partitions to allow for upgrade, as with
  `archival_metadata_stm` on local partitions.
- Add a `topic_config::migrated_from` field representing the mode from which a
  cloud/tsv2 partition was migrated.
- Check `topic_config::migrated_from` in
  `archival_metadata_stm_factory::is_applicable_for()` and
  `log_eviction_stm_factory::is_applicable_for()` to keep them around
  after migration.
- Sync the background fibers of `ctp_stm` and `log_eviction_stm` to
  `partition_storage_mode`, so whichever of the two is inert on a given
  partition runs no fibers.

This means that:
- `ctp_stm` will be present but inert on local and tsv1 partitions.
- `archival_metadata_stm` and `log_eviction_stm` will be present but inert on
  partitions migrated from local/tsv1.
- `archival_metadata_stm` and `log_eviction_stm` will still *not be present* on
  natively created tsv2/cloud partitions.

## Motivation

In order to convert a partition from local/tsv1 to cloud/tsv2, we need
to continue to operate as a tsv1/local partition until we're ready to
switch over.  For tsv1, this means continuing to operate as we populate
metastore with the tsv1 segment metadata from the archival manifest.

However, as soon as we set the `topic_properties` `storage.mode` override
to tsv2/cloud, `archival_metadata_stm_factory::is_applicable_for()` and
`log_eviction_stm_factory::is_applicable_for()` are going to return false.
Any broker restarted during that period would drop those stms and cease
to operate correctly.

This PR addresses the above by introducing a `topic_properties::migrated_from`
field which we can set during an alter-config on `storage.mode` representing
the prior storage mode of the partition.
`archival_metadata_stm_factory::is_applicable_for()` and
`log_eviction_stm_factory::is_applicable_for()` can then use that field to
continue returning true for migrated partitions.

Additionally, we need `ctp_stm` to exist.  To address that, we'll make it
unconditionally present on all user topics, as with `archival_metadata_stm` on
local partitions.

`ctp_stm` and `log_eviction_stm` had background fibers tied to their
start()/stop() lifecycles.  That no longer works, so this PR:
- moves the fiber lifecycle handling into a helper class
- moves the fiber startup from stm start() to partition::start(), where
  `partition_properties_stm::partition_storage_mode` is available and
  `_raft->log()->config()` has been populated
- rechecks fiber status in `partition::apply_partition_storage_mode()`

## What's in this PR

Based on [PR 0](https://github.com/redpanda-data/redpanda/pull/30977); the
first seven commits are PR 0's. PR 2's own commits:

- **`raft/tests`: allow specifying ntp_config overrides in raft_fixture**
- **`cloud_topics`: run ctp_stm's prefix-truncate fiber only for cloud modes**
- **`cloud_topics/stm`: enable `ctp_stm` on local and tsv1 topics**
- **`cloud_topics/stm`: explicit-log-offset `advance_reconciled_offset`
  overload**
  - Preparation for a later PR allowing us to pre-set `reconciled_offset` prior
    to cutover.
- **`cluster/storage`: add `migrated_from` topic property**
  - Also carried in `incremental_topic_updates` so the `storage.mode` alter
    can set it in the same update.
- **`cluster`: run log_eviction_stm's fibers only for non-cloud modes**
- **`cluster`: retain archival and log_eviction stms on migration**

## Testing

- `ctp_stm_test`:
  - test ensuring an inert `ctp_stm` doesn't pin truncation
  - test for tolerating an empty snapshot
  - test for `is_applicable_for` behavior
  - test that the prefix-truncate fiber doesn't start on a non-cloud
    partition and starts on the transition to cloud
- `log_eviction_stm_test`:
  - test that the fibers run on a non-cloud partition and stop on the
    transition to cloud
- `topic_properties_test`:
  - `cloud_topic_enabled()` / `migrated_to_cloud()` behavior tests
- `topic_table_test`:
  - `incremental_topic_updates` `migrated_from` application
- `archival_metadata_stm_test`:
  - test for `is_applicable_for` behavior w.r.t. `storage_mode × migrated_from`, plus identity exclusions

## Alternatives

[20260625_supervisor_stm.md](https://github.com/Lazin/redpanda/blob/exp/hierarchical-stms/docs/rfcs/20260625_supervisor_stm.md):
Introduces a mechanism which allows for dynamically creating and removing stms.
This proposal would suffice for add `ctp_stm`, but wouldn't solve the problem
of keeping `archival_metadata_stm` and `log_eviction_stm` around until
migration cuts over to cloud/tsv2. It could likely be extended to permit
"promoting" an existing static stm to dynamic status for that purpose.

[20260729_dynamic_stm_membership.md](https://github.com/sjust-redpanda/redpanda/blob/sjust/ts-ct-migration-pr2-dynamic/docs/rfcs/20260729_dynamic_stm_membership.md):
This proposal addresses the `archival_metadata_stm` and `log_eviction_stm`
problem by determining the STM set from the `initial_recovery_snapshot` or
`managed_snapshot` after partition creation and introducing two new control
batches to add or remove STMs.  This one is relatively disruptive as it
needs to add a bit of state to `initial_recovery_snapshot`.  The behavior
during STM removal is also fairly subtle.

On the whole, my proposal is to skip adding a dynamic STM mechanism for now.
Both proposals are fairly involved, and aren't really essential to implementing
migration.  The proposal in this PR has the downside of adding `ctp_stm` to
local and tsv1 partitions, but this is how we handle most STMs for optional
features already.  `archival_metadata_stm` and `log_eviction_stm` stick around
after migration, but aren't imposed on newly created tsv2 or cloud partitions.
Long term, once tsv1 is phased out, we can drop `archival_metadata_stm` more
simply than with a full dynamic stm solution.

It would also be fairly easy to update migration to take advantage of dynamic
stm addition/removal later on if we choose to implement it.

[Design Doc](https://docs.google.com/document/d/1HmzBsabpu28Oh8d2PW_HoEQA4rB3Jo1jcj1D3Rsh5mo/edit?usp=sharing)

[PR 0](https://github.com/redpanda-data/redpanda/pull/30977) · [PR 1a](https://github.com/redpanda-data/redpanda/pull/31288) · [PR 1b](https://github.com/redpanda-data/redpanda/pull/31289) · [PR 1c](https://github.com/redpanda-data/redpanda/pull/31290) · [PR 1d](https://github.com/redpanda-data/redpanda/pull/31291) · **PR 2** · [PR 3](https://github.com/redpanda-data/redpanda/pull/30891) · [PR 4](https://github.com/redpanda-data/redpanda/pull/30892) · [PR 5](https://github.com/redpanda-data/redpanda/pull/30893) · [PR 6](https://github.com/redpanda-data/redpanda/pull/30894) · [PR 7](https://github.com/redpanda-data/redpanda/pull/30895) · [PR 8](https://github.com/redpanda-data/redpanda/pull/30896)
