### PR TITLE
rpk: add --regex flag to 'rpk topic alter-config'

### DIFF
--- a/src/go/rpk/pkg/cli/topic/config.go
+++ b/src/go/rpk/pkg/cli/topic/config.go
@@ -19,6 +19,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"go.uber.org/zap"
@@ -51,6 +52,7 @@ func newAlterConfigCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 
 		dry       bool
 		noConfirm bool
+		re        bool
 	)
 
 	cmd := &cobra.Command{
@@ -68,6 +70,11 @@ Incremental altering supports four operations:
   3) Appending a new value to a list-of-values key
   4) Subtracting (removing) an existing value from a list-of-values key
 
+The --regex flag (-r) opts into parsing the input topics as regular expressions
+and altering any non-internal topic that matches any of the expressions. The
+topic list command accepts the same input regex format, which lets you preview
+which topics will be altered.
+
 The --dry option will validate whether the requested configuration change is
 valid, but does not apply it.
 Use the flag '--no-confirm' to avoid the confirmation prompt.`,
@@ -84,6 +91,12 @@ Use the flag '--no-confirm' to avoid the confirmation prompt.`,
 			cl, err := kafka.NewFranzClient(fs, p)
 			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
 			defer cl.Close()
+
+			if re {
+				adm := kadm.NewClient(cl)
+				topics, err = regexTopics(adm, topics)
+				out.MaybeDie(err, "unable to filter topics by regex: %v", err)
+			}
 
 			if len(topics) == 0 {
 				out.Exit("No topics specified.")
@@ -210,6 +223,7 @@ Use the flag '--no-confirm' to avoid the confirmation prompt.`,
 
 	cmd.Flags().BoolVar(&dry, "dry", false, "Dry run: validate the alter request, but do not apply")
 	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Disable confirmation prompt")
+	cmd.Flags().BoolVarP(&re, "regex", "r", false, "Parse topics as regex; alter any topic that matches any input topic expression")
 
 	p.InstallFormatFlag(cmd)
 	return cmd

--- a/src/go/rpk/pkg/cli/topic/config_test.go
+++ b/src/go/rpk/pkg/cli/topic/config_test.go
@@ -10,12 +10,17 @@
 package topic
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
 )
 
 func TestPrintAlterConfigResults(t *testing.T) {
@@ -32,4 +37,56 @@ func TestPrintAlterConfigResults(t *testing.T) {
 		{"foo", "OK"},
 		{"bar", "Invalid", "topic"},
 	}, out.TableRows(b.String()))
+}
+
+func TestAlterConfigRegex(t *testing.T) {
+	cluster, err := kfake.NewCluster(kfake.NumBrokers(1))
+	require.NoError(t, err)
+	t.Cleanup(cluster.Close)
+
+	fs := afero.NewMemMapFs()
+	configPath := "/tmp/rpk.yaml"
+	require.NoError(t, afero.WriteFile(fs, configPath, []byte(testConfig(cluster.ListenAddrs())), 0o644))
+
+	params := &config.Params{
+		ConfigFlag: configPath,
+		Formatter:  config.OutFormatter{Kind: "text"},
+	}
+
+	// Seed two topics that match "foo.*" and one that does not.
+	kgoClient, err := kgo.NewClient(kgo.SeedBrokers(cluster.ListenAddrs()...))
+	require.NoError(t, err)
+	t.Cleanup(kgoClient.Close)
+	adm := kadm.NewClient(kgoClient)
+	_, err = adm.CreateTopics(context.Background(), 1, 1, nil, "foo", "foo2", "bar")
+	require.NoError(t, err)
+
+	// Apply a config to every topic matching the regex, without naming each.
+	cmd := newAlterConfigCommand(fs, params)
+	cmd.SetArgs([]string{"alter-config", "-r", "foo.*", "--set", "retention.ms=3600000"})
+	output := captureOutput(func() {
+		err := cmd.Execute()
+		require.NoError(t, err)
+	})
+
+	// Matched topics are reported; the non-matching topic is left untouched.
+	require.Contains(t, output, "foo")
+	require.Contains(t, output, "foo2")
+	require.NotContains(t, output, "bar")
+
+	// The config is applied only to the topics that matched the regex.
+	rcs, err := adm.DescribeTopicConfigs(context.Background(), "foo", "foo2", "bar")
+	require.NoError(t, err)
+	got := make(map[string]string)
+	for _, rc := range rcs {
+		require.NoError(t, rc.Err)
+		for _, c := range rc.Configs {
+			if c.Key == "retention.ms" && c.Value != nil {
+				got[rc.Name] = *c.Value
+			}
+		}
+	}
+	require.Equal(t, "3600000", got["foo"])
+	require.Equal(t, "3600000", got["foo2"])
+	require.NotEqual(t, "3600000", got["bar"])
 }


### PR DESCRIPTION
`rpk topic alter-config` required naming every topic explicitly, so applying the
same config across many topics meant a shell loop (`rpk topic list -r ... | xargs
...`) or listing every name up to the shell length limit. `rpk topic list` and
`rpk topic delete` already support a `--regex`/`-r` flag — this brings the same to
`alter-config`:

```
rpk topic alter-config -r "foo.*" --set retention.ms=3600000
TOPIC  STATUS
foo    OK
foo2   OK
```

When `-r` is set, the input topics are parsed as regular expressions and expanded
against the cluster's topic list via the existing `regexTopics` helper before the
incremental-alter request is issued. Help text mirrors the `delete`/`list` wording.

A kfake integration test creates topics that do and do not match an expression and
asserts the config is applied only to the matches.

Fixes #14605

## Backports Required

- [x] none - not a bug fix

## Release Notes

### Improvements

* `rpk topic alter-config` now supports a `--regex`/`-r` flag to alter the config
  of all topics matching one or more regular expressions.
