### PR TITLE
[v26.1.x] bazel: update seastar to b6f66c6f

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -306,7 +306,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "aUXEPAnAZGFEEdKcfSrPZ68eSC2BPlYlgpryO516PTE=",
+        "bzlTransitiveDigest": "f0Ay+EFVQdHzDxzBGU+6Mlsx8OQiNSv7gvsCEOH6oZM=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -487,9 +487,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "baed9183f85246578bf0ecb05147732f844bc95be0245148fe62208850e316ad",
-              "strip_prefix": "seastar-4152d2fc93a01d6a7a3ff46be90813b22cb11162",
-              "url": "https://github.com/redpanda-data/seastar/archive/4152d2fc93a01d6a7a3ff46be90813b22cb11162.tar.gz"
+              "sha256": "f6b52d7a25e7434f42cddb5b186ddc223f2d5608df0bec97672d94853d8cec36",
+              "strip_prefix": "seastar-b6f66c6fb05a917e53202d9306ffe07a752f6de1",
+              "url": "https://github.com/redpanda-data/seastar/archive/b6f66c6fb05a917e53202d9306ffe07a752f6de1.tar.gz"
             }
           },
           "unordered_dense": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -174,9 +174,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "baed9183f85246578bf0ecb05147732f844bc95be0245148fe62208850e316ad",
-        strip_prefix = "seastar-4152d2fc93a01d6a7a3ff46be90813b22cb11162",
-        url = "https://github.com/redpanda-data/seastar/archive/4152d2fc93a01d6a7a3ff46be90813b22cb11162.tar.gz",
+        sha256 = "f6b52d7a25e7434f42cddb5b186ddc223f2d5608df0bec97672d94853d8cec36",
+        strip_prefix = "seastar-b6f66c6fb05a917e53202d9306ffe07a752f6de1",
+        url = "https://github.com/redpanda-data/seastar/archive/b6f66c6fb05a917e53202d9306ffe07a752f6de1.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Backport of PR #30692 to the `v26.1.x` branch.

Advances the Seastar pin to the tip of redpanda-data/seastar's `v26.1.x`
branch, which now carries the merged fix (redpanda-data/seastar#291) for a
concurrent `put()` on the socket in the OpenSSL TLS backend, along with its
reproducer test.

* Seastar: `4152d2fc` → `b6f66c6f` — a direct descendant of the current pin;
  the only delta is the OpenSSL TLS fix, its reproducer, and a CI-only tweak.
* `MODULE.bazel.lock` updated to match the new pin.

## Backports Required

- [x] none - this is a backport

## Release Notes

* none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
