### PR TITLE
RFC ts-ct-migration: archival flag + structural routing [PR 4]

### DIFF
--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -18,6 +18,7 @@
 #include "cluster/controller_api.h"
 #include "cluster/health_monitor_frontend.h"
 #include "kafka/client/transport.h"
+#include "kafka/data/partition_proxy.h"
 #include "kafka/data/replicated_partition.h"
 #include "kafka/protocol/fetch.h"
 #include "kafka/protocol/find_coordinator.h"
@@ -196,6 +197,166 @@ TEST_F(ManualFixture, TestSizeEstimationWithCloud) {
         EXPECT_NEAR(
           total_estimated_sz, left_estimated_sz + right_estimated_sz, 4000);
     }
+}
+
+// A partition mid tiered->cloud migration is served transparently as tiered
+// storage. The migration is entered by the operator flipping the topic's
+// storage mode to cloud (topic_mode == cloud), but the durable partition_mode
+// is still tiered until cutover, and the serving accessors key on partition_mode
+// -- so cloud_topic_enabled()/is_remote_fetch_enabled() still report the tiered
+// values and nothing about the read path changes. This exercises the full
+// replicated_partition API surface plus make_partition_proxy routing and
+// asserts byte-for-byte parity with the same partition before the flip:
+// offsets, size estimates, and timequery are unchanged, prefix truncation still
+// works, and the partition still routes to the replicated_partition path.
+// Regression for the timequery corner -- it must consult the tiered/imported
+// prefix, not the local-log start, throughout.
+TEST_F(ManualFixture, MigratingPartitionServedAsTieredStorage) {
+    test_local_cfg.get("cloud_storage_disable_upload_loop_for_tests")
+      .set_value(true);
+    test_local_cfg.get("cloud_storage_spillover_manifest_max_segments")
+      .set_value(std::make_optional<size_t>(5));
+    test_local_cfg.get("cloud_storage_spillover_manifest_size")
+      .set_value(std::optional<size_t>{});
+    const model::topic topic_name("migrating-rp");
+    model::ntp ntp(model::kafka_namespace, topic_name, 0);
+
+    cluster::topic_properties props;
+    props.shadow_indexing = model::shadow_indexing_mode::full;
+    props.cleanup_policy_bitflags = model::cleanup_policy_bitflags::deletion;
+    add_topic({model::kafka_namespace, topic_name}, 1, props).get();
+    wait_for_leader(ntp).get();
+
+    auto partition = app.partition_manager.local().get(ntp);
+    auto& archiver = partition->archiver().value().get();
+    archiver.initialize_probe();
+    tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
+    auto total_records = gen.num_segments(40)
+                           .batches_per_segment(5)
+                           .additional_local_segments(10)
+                           .produce()
+                           .get();
+    ASSERT_GE(total_records, 200);
+    ASSERT_TRUE(archiver.sync_for_tests().get());
+    archiver.apply_spillover().get();
+
+    // Keep some segments local and the prefix only in tiered storage, so the
+    // API spans both regions (cloud prefix + local suffix) and the parity check
+    // is meaningful.
+    auto log = partition->log();
+    auto& manifest = partition->archival_meta_stm()->manifest();
+    log->set_cloud_gc_offset(model::next_offset(manifest.get_last_offset()));
+    // Wait for GC to trim the local prefix so it lives only in tiered storage
+    // (the local log start advances above 0). Reads of the prefix must then
+    // come from the cloud, which is what makes the migrating-parity check below
+    // meaningful (and is the condition the timequery bug needed to manifest).
+    RPTEST_REQUIRE_EVENTUALLY(
+      20s, [&] { return log->offsets().start_offset > model::offset(0); });
+
+    struct snapshot {
+        model::offset start;
+        model::offset hwm;
+        model::offset local_start;
+        model::offset lso;
+        kafka::leader_epoch epoch;
+        model::offset offset_lag;
+        size_t total_sz;
+        size_t cloud_sz;
+        std::optional<model::offset> tq_earliest;
+    };
+    auto capture = [](kafka::replicated_partition& rp) {
+        auto lso = rp.last_stable_offset();
+        EXPECT_FALSE(lso.has_error());
+        auto last = kafka::prev_offset(model::offset_cast(lso.value()));
+        auto local_start = model::offset_cast(rp.local_start_offset());
+        // timequery for the epoch resolves to the earliest available offset; it
+        // must consult the tiered/imported prefix, not just the local log.
+        storage::timequery_config tq_cfg{
+          rp.start_offset(),
+          model::timestamp(0),
+          rp.high_watermark(),
+          {model::record_batch_type::raft_data},
+          std::nullopt};
+        auto tq = rp.timequery(tq_cfg).get();
+        return snapshot{
+          .start = rp.start_offset(),
+          .hwm = rp.high_watermark(),
+          .local_start = rp.local_start_offset(),
+          .lso = lso.value(),
+          .epoch = rp.leader_epoch(),
+          .offset_lag = rp.offset_lag(),
+          .total_sz = rp.estimate_size_between(kafka::offset(0), last),
+          .cloud_sz = rp.estimate_size_between(
+            kafka::offset(0), kafka::prev_offset(local_start)),
+          .tq_earliest = tq.has_value()
+                           ? std::optional<model::offset>(tq->offset)
+                           : std::nullopt,
+        };
+    };
+
+    kafka::replicated_partition rp_tiered(partition);
+    auto tiered = capture(rp_tiered);
+    // The prefix really is cloud-only (local log starts above 0), so timequery
+    // for the epoch must reach into tiered storage to answer 0.
+    ASSERT_GT(tiered.local_start, model::offset(0));
+    ASSERT_EQ(
+      tiered.tq_earliest, std::optional<model::offset>(model::offset(0)));
+
+    // Enter the migrating state: the operator flips the topic's storage mode to
+    // cloud (topic_mode), while the durable partition_mode is still tiered until
+    // cutover. Serving accessors key on partition_mode, so
+    // cloud_topic_enabled() stays false and the partition keeps being served as
+    // tiered storage.
+    ASSERT_TRUE(log->config().has_overrides());
+    auto overrides = log->config().get_overrides();
+    overrides.storage_mode = model::redpanda_storage_mode::cloud;
+    log->set_overrides(overrides);
+    log->set_partition_mode(model::redpanda_storage_mode::tiered);
+    ASSERT_EQ(log->config().topic_mode(), model::redpanda_storage_mode::cloud);
+    ASSERT_EQ(
+      log->config().partition_mode(), model::redpanda_storage_mode::tiered);
+    ASSERT_FALSE(log->config().cloud_topic_enabled());
+
+    kafka::replicated_partition rp_mig(partition);
+    auto migrating = capture(rp_mig);
+
+    // Transparent migration: every read/size API returns exactly what it did as
+    // plain tiered storage.
+    EXPECT_EQ(tiered.start, migrating.start);
+    EXPECT_EQ(tiered.hwm, migrating.hwm);
+    EXPECT_EQ(tiered.local_start, migrating.local_start);
+    EXPECT_EQ(tiered.lso, migrating.lso);
+    EXPECT_EQ(tiered.epoch, migrating.epoch);
+    EXPECT_EQ(tiered.offset_lag, migrating.offset_lag);
+    // Entering the migrating state writes nothing to the log (it only adjusts
+    // the ntp_config overrides), so every size estimate is exactly unchanged.
+    EXPECT_EQ(tiered.total_sz, migrating.total_sz);
+    EXPECT_EQ(tiered.cloud_sz, migrating.cloud_sz);
+    // Regression: timequery still resolves to offset 0 via the imported extents
+    // (not the local-log start) while migrating.
+    EXPECT_EQ(tiered.tq_earliest, migrating.tq_earliest);
+    EXPECT_EQ(
+      migrating.tq_earliest, std::optional<model::offset>(model::offset(0)));
+
+    // make_partition_proxy routes the migrating partition to the tiered-storage
+    // (replicated_partition) path via the standard cloud_topic_enabled()==false
+    // branch -- partition_mode is still tiered, so no manifest-specific routing
+    // gate is needed. It must behave identically to a directly-constructed
+    // replicated_partition, not the (empty) cloud-topic path.
+    kafka::partition_proxy proxy = kafka::make_partition_proxy(partition);
+    EXPECT_EQ(proxy.start_offset(), rp_mig.start_offset());
+    EXPECT_EQ(proxy.high_watermark(), rp_mig.high_watermark());
+    EXPECT_GT(proxy.high_watermark(), model::offset(0));
+
+    // DeleteRecords / prefix truncation works while migrating and advances the
+    // start offset (eviction STM + archival manifest head-prune path).
+    auto trunc = model::offset(total_records / 2);
+    auto tec
+      = rp_mig.prefix_truncate(trunc, ss::lowres_clock::now() + 30s).get();
+    ASSERT_EQ(tec, kafka::error_code::none);
+    RPTEST_REQUIRE_EVENTUALLY(
+      10s, [&] { return rp_mig.start_offset() >= trunc; });
 }
 
 class EndToEndFixture

--- a/src/v/cloud_topics/level_zero/stm/BUILD
+++ b/src/v/cloud_topics/level_zero/stm/BUILD
@@ -182,6 +182,7 @@ redpanda_cc_library(
     implementation_deps = [
         ":ctp_stm",
         "//src/v/cloud_topics:logger",
+        "//src/v/config",
     ],
     visibility = ["//visibility:public"],
     deps = ["//src/v/cluster:state_machine_registry"],

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -427,6 +427,16 @@ ctp_stm::take_local_snapshot(ssx::semaphore_units) {
 }
 
 ss::future<> ctp_stm::apply_raft_snapshot(const iobuf& buf) {
+    // An empty snapshot is applied during recovery fast-forward: the raft
+    // snapshot created when bootstrapping a pre-existing partition carries no
+    // per-STM data, so state_machine_manager hands each STM an empty buffer to
+    // advance over. There is no ctp_stm state to restore then -- e.g. a
+    // partition recovered mid tiered->cloud migration has no L1 state (its data
+    // is still in tiered storage). Keep the default (empty) state and advance,
+    // mirroring log_eviction_stm's empty-snapshot handling.
+    if (buf.empty()) {
+        co_return;
+    }
     auto snap = serde::from_iobuf<ctp_stm_snapshot>(buf.copy());
     _state = std::move(snap.state);
     _epoch_checker = snap.checker;

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
@@ -123,6 +123,18 @@ ctp_stm_api::advance_reconciled_offset(
   model::timeout_clock::time_point deadline,
   ss::abort_source& as,
   std::optional<kafka::offset> min_allowed_local_threshold) {
+    auto lrlo = _stm->_raft->log()->to_log_offset(kafka::offset_cast(lro));
+    return advance_reconciled_offset(
+      lro, lrlo, deadline, as, min_allowed_local_threshold);
+}
+
+ss::future<std::expected<std::monostate, ctp_stm_api_errc>>
+ctp_stm_api::advance_reconciled_offset(
+  kafka::offset lro,
+  model::offset lrlo,
+  model::timeout_clock::time_point deadline,
+  ss::abort_source& as,
+  std::optional<kafka::offset> min_allowed_local_threshold) {
     // The floor is monotonic: drop targets the state already covers.
     if (
       min_allowed_local_threshold.has_value()
@@ -138,7 +150,6 @@ ctp_stm_api::advance_reconciled_offset(
       model::record_batch_type::ctp_stm_command, model::offset(0));
 
     if (advances_lro) {
-        auto lrlo = _stm->_raft->log()->to_log_offset(kafka::offset_cast(lro));
         vlog(
           _log.debug,
           "Replicating ctp_stm_cmd::advance_reconciled_offset{{lro:{} "

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.h
@@ -85,6 +85,20 @@ public:
       ss::abort_source& as,
       std::optional<kafka::offset> min_allowed_local_threshold = std::nullopt);
 
+    /// As above, but with the reconciled log offset supplied explicitly rather
+    /// than derived from the raft offset translator. Used to seed the
+    /// reconciliation baseline of a TS-migrated partition directly to the
+    /// migration boundary (kafka offset + the raft offset of the last uploaded
+    /// TS segment) so the already-uploaded TS region of the local raft log can
+    /// be trimmed without waiting for the first CT reconciliation cycle.
+    ss::future<std::expected<std::monostate, ctp_stm_api_errc>>
+    advance_reconciled_offset(
+      kafka::offset last_reconciled_offset,
+      model::offset last_reconciled_log_offset,
+      model::timeout_clock::time_point deadline,
+      ss::abort_source& as,
+      std::optional<kafka::offset> min_allowed_local_threshold = std::nullopt);
+
     ss::future<std::expected<std::monostate, ctp_stm_api_errc>>
     set_start_offset(
       kafka::offset new_start_offset,

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_factory.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_factory.cc
@@ -12,13 +12,25 @@
 
 #include "cloud_topics/level_zero/stm/ctp_stm.h"
 #include "cloud_topics/logger.h"
+#include "config/configuration.h"
 
 namespace cloud_topics::l0 {
 
 bool ctp_stm_factory::is_applicable_for(
   const storage::ntp_config& ntp_cfg) const {
-    return ntp_cfg.cloud_topic_enabled()
-           && !ntp_cfg.is_read_replica_mode_enabled();
+    if (ntp_cfg.is_read_replica_mode_enabled()) {
+        return false;
+    }
+    if (ntp_cfg.cloud_topic_enabled()) {
+        return true;
+    }
+    // Pre-install an (idle) ctp_stm on tiered-storage partitions when cloud
+    // topics are available, so a tiered->cloud/tiered_cloud migration needs no
+    // runtime STM install -- the STM is already present and inert
+    // (get_max_collectible_offset() returns max() until CT data is applied)
+    // until the partition becomes a cloud topic.
+    return config::shard_local_cfg().cloud_storage_enabled()
+           && ntp_cfg.is_archival_enabled();
 }
 
 void ctp_stm_factory::create(

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
@@ -179,7 +179,16 @@ model::offset ctp_stm_state::get_max_collectible_offset() const noexcept {
     if (_last_reconciled_log_offset.has_value()) {
         return _last_reconciled_log_offset.value();
     }
-    // Truncation is impossible without LRO
+    // An STM that has applied no CT data must not constrain truncation: it may
+    // be an inert passenger on a partition that is not (yet) a cloud topic
+    // (e.g. a tiered partition pre-installed with ctp_stm so a migration needs
+    // no runtime STM install). Without this a passenger would pin the local log
+    // at offset::min() forever.
+    if (!_max_applied_epoch.has_value()) {
+        return model::offset::max();
+    }
+    // CT data has been applied but not yet reconciled to L1: protect it.
+    // Truncation is impossible without an LRO.
     return model::offset::min();
 }
 

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
@@ -30,7 +30,9 @@ TEST(ctp_stm_state_test, initial_state) {
     EXPECT_FALSE(state.get_max_seen_epoch(model::term_id(1)).has_value());
     EXPECT_FALSE(state.get_last_reconciled_offset().has_value());
     EXPECT_FALSE(state.get_last_reconciled_log_offset().has_value());
-    EXPECT_EQ(state.get_max_collectible_offset(), model::offset::min());
+    // An STM with no applied CT data is an inert passenger and must not
+    // constrain truncation.
+    EXPECT_EQ(state.get_max_collectible_offset(), model::offset::max());
 }
 
 TEST(ctp_stm_state_test, advance_max_seen_epoch) {
@@ -107,8 +109,15 @@ TEST(ctp_stm_state_test, advance_last_reconciled_offset) {
 TEST(ctp_stm_state_test, get_max_collectible_offset) {
     ct::ctp_stm_state state;
 
+    // No CT data applied yet: inert passenger, do not constrain truncation.
+    EXPECT_EQ(state.get_max_collectible_offset(), model::offset::max());
+
+    // CT data applied (a placeholder advanced the epoch) but not yet reconciled
+    // to L1: protect it by pinning collection at min().
+    state.advance_epoch(ct::cluster_epoch(1), model::offset(10));
     EXPECT_EQ(state.get_max_collectible_offset(), model::offset::min());
 
+    // Once reconciled, collect up to the reconciled log offset.
     model::offset log_offset(500);
     state.advance_last_reconciled_offset(kafka::offset(300), log_offset);
     EXPECT_EQ(state.get_max_collectible_offset(), log_offset);

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -48,6 +48,10 @@ struct ctp_stm_accessor {
           snapshot.header, std::move(snapshot.data));
     }
 
+    auto apply_raft_snapshot(ctp_stm& stm, const iobuf& buf) {
+        return stm.apply_raft_snapshot(buf);
+    }
+
     bool epoch_cv_has_waiters(ctp_stm& stm) {
         return stm._epoch_updated_cv.has_waiters();
     }
@@ -562,6 +566,37 @@ TEST_F_CORO(ctp_stm_fixture, test_snapshot) {
         auto fence = co_await api(leader).fence_epoch(ct::cluster_epoch{1});
         ASSERT_FALSE_CORO(fence.has_value());
     }
+}
+
+// The recovery fast-forward hands each STM an empty raft snapshot to advance
+// over: a bootstrapped pre-existing partition carries no per-STM data, and a
+// partition recovered mid tiered->cloud migration has no L1 ctp_stm state (its
+// data is still in tiered storage). apply_raft_snapshot must treat an empty
+// buffer as a no-op -- not try to deserialize it (which threw before the guard)
+// and not clobber existing state with a default.
+TEST_F_CORO(ctp_stm_fixture, apply_empty_raft_snapshot_is_noop) {
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+    auto& leader = node(*get_leader());
+
+    // Establish some applied state so we can prove the empty snapshot doesn't
+    // reset it.
+    auto b1 = make_record_batch(ct::cluster_epoch{2}, model::offset{0}, 0);
+    auto res = co_await replicate_record_batch(leader, std::move(b1));
+    ASSERT_TRUE_CORO(res.has_value());
+    auto max_epoch_before = api(leader).get_max_epoch();
+    ASSERT_TRUE_CORO(max_epoch_before.has_value());
+    ASSERT_EQ_CORO(max_epoch_before.value(), ct::cluster_epoch{2});
+
+    auto stm = get_stm<0>(leader);
+    ct::ctp_stm_accessor a;
+    // Must not throw on an empty buffer.
+    co_await a.apply_raft_snapshot(*stm, iobuf{});
+
+    // State preserved, not reset to default.
+    auto max_epoch_after = api(leader).get_max_epoch();
+    ASSERT_TRUE_CORO(max_epoch_after.has_value());
+    ASSERT_EQ_CORO(max_epoch_after.value(), max_epoch_before.value());
 }
 
 TEST_F_CORO(ctp_stm_fixture, test_fence_epoch_concurrent_new_epoch) {

--- a/src/v/cluster/archival/archival_metadata_stm.cc
+++ b/src/v/cluster/archival/archival_metadata_stm.cc
@@ -1729,10 +1729,14 @@ archival_metadata_stm_factory::archival_metadata_stm_factory(
 
 bool archival_metadata_stm_factory::is_applicable_for(
   const storage::ntp_config& ntp_cfg) const {
+    // The archival STM is created on cloud-topic partitions too (no
+    // cloud_topic_enabled() == false guard). For a partition migrated from
+    // tiered storage it is reconstructed from its snapshot and its manifest
+    // stays available to gate local-log truncation. For a partition that was
+    // always a cloud topic the manifest is empty, so it is an inert passenger.
     return _cloud_storage_enabled && _cloud_storage_api.local_is_initialized()
            && ntp_cfg.ntp().tp.topic != model::kafka_consumer_offsets_topic
-           && ntp_cfg.ntp().ns == model::kafka_namespace
-           && ntp_cfg.cloud_topic_enabled() == false;
+           && ntp_cfg.ntp().ns == model::kafka_namespace;
 }
 
 void archival_metadata_stm_factory::create(

--- a/src/v/cluster/archival/archival_metadata_stm.cc
+++ b/src/v/cluster/archival/archival_metadata_stm.cc
@@ -1373,6 +1373,18 @@ model::offset archival_metadata_stm::max_removable_local_log_offset() {
         collect_all = false;
     }
 
+    // The manifest, not the storage mode, governs local-log truncation. While
+    // the partition still holds archived data (a non-empty live manifest or a
+    // spillover archive) it is still served from tiered storage and may hold
+    // local data not yet uploaded, so its local log must not be trimmed past
+    // cloud_recoverable_offset(). is_archival_enabled() can report false while
+    // archived data is still present -- e.g. a partition mid tiered->cloud
+    // migration whose effective storage mode is cloud -- which would otherwise
+    // collect_all and stop constraining truncation, evicting the not-yet-
+    // uploaded data. Gate collect_all on holds_archived_data() so it takes
+    // effect only once the manifest is cleared.
+    collect_all = collect_all && !holds_archived_data();
+
     if (collect_all || is_read_replica || (uploads_paused && gaps_allowed)) {
         // The archival is disabled but the state machine still exists so we
         // shouldn't stop eviction from happening.
@@ -1672,6 +1684,11 @@ ss::future<> archival_metadata_stm::stop() {
 const cloud_storage::partition_manifest&
 archival_metadata_stm::manifest() const {
     return *_manifest;
+}
+
+bool archival_metadata_stm::holds_archived_data() const {
+    return _manifest->size() > 0
+           || _manifest->get_archive_start_offset() != model::offset{};
 }
 
 model::offset archival_metadata_stm::get_start_offset() const {

--- a/src/v/cluster/archival/archival_metadata_stm.h
+++ b/src/v/cluster/archival/archival_metadata_stm.h
@@ -216,6 +216,11 @@ public:
     /// added with `add_segments`.
     const cloud_storage::partition_manifest& manifest() const;
 
+    /// True if the partition holds tiered-storage data: the manifest has
+    /// segments, or a non-empty spillover archive. Used to detect that a
+    /// partition is (still) tiered storage independent of the topic config.
+    bool holds_archived_data() const;
+
     ss::future<> stop() override;
 
     static ss::future<> make_snapshot(
@@ -252,6 +257,7 @@ public:
     model::offset get_last_offset() const;
     model::offset get_archive_start_offset() const;
     model::offset get_archive_clean_offset() const;
+
     kafka::offset get_start_kafka_offset() const;
 
     // Return list of all segments that has to be

--- a/src/v/cluster/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/cluster/archival/tests/archival_metadata_stm_test.cc
@@ -256,6 +256,42 @@ FIXTURE_TEST(
       archival_stm->manifest().begin()->committed_offset, model::offset(99));
 }
 
+// With archival disabled (the flipped, mid-migration storage mode) but a
+// non-empty manifest, max_removable_local_log_offset keeps constraining
+// local-log truncation rather than collecting all -- protecting tiered-storage
+// data that has not yet been uploaded.
+FIXTURE_TEST(test_migration_local_trim_clamp, archival_metadata_stm_fixture) {
+    wait_for_confirmed_leader();
+
+    // The fixture's partition has archival disabled. With an empty manifest,
+    // nothing constrains local-log truncation.
+    BOOST_REQUIRE_EQUAL(
+      archival_stm->max_removable_local_log_offset(), model::offset::max());
+
+    // Add a segment so the manifest is non-empty.
+    std::vector<cloud_storage::segment_meta> m;
+    m.push_back(
+      segment_meta{
+        .base_offset = model::offset(0),
+        .committed_offset = model::offset(99),
+        .archiver_term = model::term_id(1),
+        .segment_term = model::term_id(1)});
+    archival_stm
+      ->add_segments(
+        m,
+        std::nullopt,
+        model::producer_id{},
+        ss::lowres_clock::now() + 10s,
+        never_abort,
+        cluster::segment_validated::yes)
+      .get();
+    BOOST_REQUIRE_EQUAL(archival_stm->manifest().size(), 1);
+
+    // Now truncation is constrained (no longer offset::max()).
+    BOOST_REQUIRE_NE(
+      archival_stm->max_removable_local_log_offset(), model::offset::max());
+}
+
 FIXTURE_TEST(test_archival_stm_segment_replace, archival_metadata_stm_fixture) {
     wait_for_confirmed_leader();
     std::vector<cloud_storage::segment_meta> m1;

--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -384,9 +384,15 @@ log_eviction_stm_factory::log_eviction_stm_factory(storage::kvstore& kvstore)
 
 bool log_eviction_stm_factory::is_applicable_for(
   const storage::ntp_config& cfg) const {
-    if (cfg.cloud_topic_enabled()) {
-        return false;
-    }
+    // (No cloud_topic_enabled() == false guard.) Install the eviction STM on
+    // cloud-topic partitions too. STM membership is fixed at construction and a
+    // tiered->cloud migration does not reconstruct the partition, so a
+    // partition migrating from tiered storage -- still served from its local
+    // log + archival manifest -- must already carry the eviction STM to keep
+    // supporting prefix truncation (DeleteRecords) and retention while
+    // migrating. On a native cloud topic it is an inert passenger: retention
+    // and DeleteRecords go through the L1 path, so no local eviction requests
+    // are generated.
     return !storage::deletion_exempt(cfg.ntp());
 }
 

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -913,6 +913,10 @@ ss::future<> partition::update_configuration(topic_properties new_properties) {
     // Pass the configuration update to the raft layer
     _raft->notify_config_update();
 
+    // A storage.mode change lands in topic_mode() (above); keep the durable
+    // partition_mode in step so serving predicates see the new mode.
+    co_await maybe_sync_partition_mode();
+
     // If this partition's cloud storage mode changed, rebuild the archiver.
     // This must happen after the raft+storage update, because it reads raft's
     // ntp_config to decide whether to construct an archiver.
@@ -1776,6 +1780,34 @@ void partition::update_partition_mode() {
     }
     _raft->log()->set_partition_mode(
       _partition_properties_stm->partition_mode());
+}
+
+ss::future<> partition::maybe_sync_partition_mode() {
+    if (!_partition_properties_stm || !is_leader()) {
+        co_return;
+    }
+    if (!_feature_table.local().is_active(
+          features::feature::topic_mode_migration)) {
+        co_return;
+    }
+    // At this point in the stack a partition's mode is simply its topic's
+    // configured mode -- there is no migration yet -- so mirror topic_mode()
+    // through whenever they differ. (A legacy shadow_indexing topic has
+    // topic_mode() == unset; partition_mode starts unset too, so this is a
+    // no-op and it stays unset.)
+    const auto target = get_ntp_config().topic_mode();
+    if (_partition_properties_stm->partition_mode() == target) {
+        co_return;
+    }
+    auto res = co_await _partition_properties_stm->set_partition_mode(target);
+    if (res.has_error()) {
+        vlog(
+          clusterlog.debug,
+          "{}: failed to sync partition_mode to {}: {}",
+          _raft->ntp(),
+          target,
+          res.error().message());
+    }
 }
 
 ss::future<result<model::offset>> partition::set_writes_disabled(

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -473,6 +473,17 @@ ss::future<> partition::start(
     _partition_properties_stm
       = _raft->stm_manager()->get<cluster::partition_properties_stm>();
 
+    // Feed the partition's durable storage mode into the log's ntp_config and
+    // keep it up to date as the STM applies changes. Reading replicated STM
+    // state is always safe; writes (which require the partition_mode feature)
+    // are gated separately. Until partition_mode is set, partition_mode() is
+    // `unset` and ntp_config falls back to the topic-config-derived mode.
+    if (_partition_properties_stm) {
+        _partition_properties_stm->set_partition_mode_change_callback(
+          [this] { update_partition_mode(); });
+        update_partition_mode();
+    }
+
     // Start the probe after the partition is fully initialised
     _probe.setup_metrics(ntp);
 
@@ -1758,6 +1769,14 @@ partition::force_abort_replica_set_update(model::revision_id rev) {
     return _raft->abort_configuration_change(rev);
 }
 consensus_ptr partition::raft() const { return _raft; }
+
+void partition::update_partition_mode() {
+    if (!_partition_properties_stm) {
+        return;
+    }
+    _raft->log()->set_partition_mode(
+      _partition_properties_stm->partition_mode());
+}
 
 ss::future<result<model::offset>> partition::set_writes_disabled(
   partition_properties_stm::writes_disabled disable,

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -164,6 +164,16 @@ public:
 
     bool is_elected_leader() const;
     bool is_leader() const;
+
+    // Keep the durable partition_mode in step with the topic-configured
+    // storage mode: whenever they differ -- a storage.mode change, or the
+    // first time a leader records it -- write topic_mode() through to
+    // partition_properties. Gated behind the partition_mode feature and
+    // leader-only. Legacy shadow_indexing topics (topic_mode() == unset) are
+    // left unset. Invoked on leadership, on migration-feature activation, and
+    // on topic-config changes (update_configuration).
+    ss::future<> maybe_sync_partition_mode();
+
     bool has_followers() const;
     void block_new_leadership() const;
     void unblock_new_leadership() const;

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -425,6 +425,11 @@ private:
     // dirty so that it gets reuploaded
     ss::future<> restart_archiver(bool should_notify_topic_config);
 
+    // Push the partition's durable storage mode (partition_properties_stm) into
+    // the log's ntp_config, so ntp_config::partition_mode() reflects it. Called
+    // at start and whenever the STM signals a change.
+    void update_partition_mode();
+
     consensus_ptr _raft; // never null
     ss::shared_ptr<cluster::log_eviction_stm> _log_eviction_stm;
     ss::shared_ptr<cluster::rm_stm> _rm_stm;

--- a/src/v/cluster/partition_kafka_offsets.cc
+++ b/src/v/cluster/partition_kafka_offsets.cc
@@ -38,7 +38,19 @@ model::offset kafka_high_watermark(const partition& p) {
             return model::offset(0);
         }
     }
-    return p.log()->from_log_offset(p.high_watermark());
+    auto hwm = p.log()->from_log_offset(p.high_watermark());
+    // A partition served from tiered storage whose local log does not cover its
+    // cloud data reports the cloud high watermark. This is the case for a
+    // partition mid tiered->cloud migration whose local log was wiped by
+    // cluster recovery: its data lives in the cloud manifest, so without this
+    // the (empty) local log would report high watermark 0 and hide the
+    // recovered prefix from ListOffsets and consumers. For a healthy partition
+    // the cloud watermark never exceeds the local one (uploads lag production),
+    // so this is a no-op.
+    if (p.cloud_data_available()) {
+        hwm = std::max(hwm, p.next_cloud_offset());
+    }
+    return hwm;
 }
 
 model::offset kafka_start_offset_with_override(

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -30,6 +30,7 @@
 #include "raft/consensus_utils.h"
 #include "raft/fundamental.h"
 #include "ssx/async-clear.h"
+#include "ssx/future-util.h"
 
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -73,6 +74,12 @@ partition_manager::partition_manager(
                 if (a) {
                     a.value().get().notify_leadership(leader_id);
                 }
+                // Sync the partition's durable storage mode to its topic
+                // config on becoming leader (no-op when not leader or already
+                // in sync). The shared_ptr keeps the partition alive across
+                // the async write.
+                ssx::spawn_with_gate(
+                  _gate, [p] { return p->maybe_sync_partition_mode(); });
             }
         });
     _shutdown_watchdog.set_callback(

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -107,7 +107,32 @@ partition_manager::get_topic_partition_table(
 
 ss::future<> partition_manager::start() {
     maybe_arm_shutdown_watchdog();
+    // Sync partition_mode once the migration feature activates. The
+    // leadership-notification sync (maybe_sync_partition_mode) is gated on the
+    // feature being active, so a partition that became leader while the
+    // feature was inactive is left with partition_mode == unset. Re-run the
+    // sync on every current leader when the feature turns active; partitions
+    // that gain leadership after activation are covered by the leadership
+    // notification.
+    ssx::spawn_with_gate(
+      _gate, [this] { return sync_partition_mode_on_migration_feature(); });
     co_return;
+}
+
+ss::future<> partition_manager::sync_partition_mode_on_migration_feature() {
+    try {
+        co_await _feature_table.local().await_feature(
+          features::feature::topic_mode_migration, _as);
+    } catch (...) {
+        // Aborted on shutdown before the feature activated.
+        co_return;
+    }
+    for (auto& [_, p] : _ntp_table) {
+        if (p->is_leader()) {
+            ssx::spawn_with_gate(
+              _gate, [p] { return p->maybe_sync_partition_mode(); });
+        }
+    }
 }
 
 ss::future<consensus_ptr> partition_manager::manage(

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -277,6 +277,11 @@ private:
     void check_partitions_shutdown_state();
 
     void maybe_arm_shutdown_watchdog();
+
+    // Awaits the topic_mode_migration feature and then re-runs
+    // maybe_sync_partition_mode on every current leader, covering partitions
+    // that became leader while the feature was inactive.
+    ss::future<> sync_partition_mode_on_migration_feature();
     storage::api& _storage;
     /// used to wait for concurrent recoveries
     ss::sharded<raft::group_manager>& _raft_manager;

--- a/src/v/cluster/partition_properties_stm.cc
+++ b/src/v/cluster/partition_properties_stm.cc
@@ -40,7 +40,8 @@ partition_properties_stm::partition_properties_stm(
   , _state_snapshots({state_snapshot{
       .writes_disabled = writes_disabled::no,
       .update_offset = model::offset{},
-      .writes_revision_id{}}}) {}
+      .writes_revision_id{},
+      .partition_mode = model::redpanda_storage_mode::unset}}) {}
 
 ss::future<iobuf>
 partition_properties_stm::take_raft_snapshot(model::offset o) {
@@ -88,7 +89,8 @@ partition_properties_stm::take_raft_snapshot(model::offset o) {
     co_return serde::to_iobuf(
       raft_snapshot{
         .writes_disabled = it->writes_disabled,
-        .writes_revision_id = it->writes_revision_id});
+        .writes_revision_id = it->writes_revision_id,
+        .partition_mode = it->partition_mode});
 }
 
 ss::future<raft::local_snapshot_applied>
@@ -157,43 +159,66 @@ void partition_properties_stm::apply_record(
     auto key = r.release_key();
     auto value = r.release_value();
     auto ot = serde::from_iobuf<operation_type>(std::move(key));
-    if (ot != operation_type::update_writes_disabled) [[unlikely]] {
-        vlog(
-          _log.warn,
-          "ignored unknown operation type with value: {}",
-          static_cast<int>(ot));
-        return;
-    }
-    auto update = serde::from_iobuf<update_writes_disabled_cmd>(
-      std::move(value));
-    vlog(
-      _log.trace,
-      "Applying update {} at offset: {}",
-      update,
+    const auto update_offset = model::offset(
       r.offset_delta() + batch_begin_offset);
     const auto current_state = _state_snapshots.back();
-    bool is_legacy_command = update.writes_revision_id == model::revision_id{};
-    bool is_newer_revision = update.writes_revision_id
-                             > current_state.writes_revision_id;
-    if (!is_newer_revision && !is_legacy_command) {
+    switch (ot) {
+    case operation_type::update_writes_disabled: {
+        auto update = serde::from_iobuf<update_writes_disabled_cmd>(
+          std::move(value));
         vlog(
-          _log.error,
-          "Ignoring out-of-order update: {}, current state: {}",
+          _log.trace,
+          "Applying update {} at offset: {}",
           update,
-          _state_snapshots.back());
+          update_offset);
+        bool is_legacy_command = update.writes_revision_id
+                                 == model::revision_id{};
+        bool is_newer_revision = update.writes_revision_id
+                                 > current_state.writes_revision_id;
+        if (!is_newer_revision && !is_legacy_command) {
+            vlog(
+              _log.error,
+              "Ignoring out-of-order update: {}, current state: {}",
+              update,
+              current_state);
+            return;
+        }
+        bool differs = update.writes_disabled != current_state.writes_disabled
+                       || update.writes_revision_id
+                            != current_state.writes_revision_id;
+        if (differs) {
+            // copy-modify preserves the other properties (e.g. partition_mode)
+            auto next = current_state;
+            next.writes_disabled = update.writes_disabled;
+            next.writes_revision_id = update.writes_revision_id;
+            next.update_offset = update_offset;
+            _state_snapshots.push_back(next);
+        }
         return;
     }
-    bool differs = update.writes_disabled != current_state.writes_disabled
-                   || update.writes_revision_id
-                        != current_state.writes_revision_id;
-    if (differs) {
-        _state_snapshots.push_back(
-          state_snapshot{
-            .writes_disabled = update.writes_disabled,
-            .update_offset = model::offset(
-              r.offset_delta() + batch_begin_offset),
-            .writes_revision_id = update.writes_revision_id});
+    case operation_type::update_partition_mode: {
+        auto update = serde::from_iobuf<update_partition_mode_cmd>(
+          std::move(value));
+        vlog(
+          _log.trace,
+          "Applying partition_mode update {} at offset: {}",
+          update,
+          update_offset);
+        // idempotent by value, ordered by log offset (no revision needed).
+        if (update.partition_mode != current_state.partition_mode) {
+            auto next = current_state;
+            next.partition_mode = update.partition_mode;
+            next.update_offset = update_offset;
+            _state_snapshots.push_back(next);
+            notify_partition_mode_change();
+        }
+        return;
     }
+    }
+    vlog(
+      _log.warn,
+      "ignored unknown operation type with value: {}",
+      static_cast<int>(ot));
 }
 
 ss::future<>
@@ -211,7 +236,9 @@ partition_properties_stm::apply_raft_snapshot(const iobuf& buffer) {
       state_snapshot{
         .writes_disabled = snapshot.writes_disabled,
         .update_offset = model::prev_offset(_raft->start_offset()),
-        .writes_revision_id = snapshot.writes_revision_id});
+        .writes_revision_id = snapshot.writes_revision_id,
+        .partition_mode = snapshot.partition_mode});
+    notify_partition_mode_change();
     co_return;
 }
 
@@ -301,6 +328,93 @@ model::record_batch partition_properties_stm::make_update_partitions_batch(
     return std::move(builder).build();
 }
 
+model::record_batch partition_properties_stm::make_update_partition_mode_batch(
+  update_partition_mode_cmd cmd) {
+    storage::record_batch_builder builder(
+      model::record_batch_type::partition_properties_update, model::offset{});
+    builder.add_raw_kv(
+      serde::to_iobuf(operation_type::update_partition_mode),
+      serde::to_iobuf(std::move(cmd)));
+    return std::move(builder).build();
+}
+
+ss::future<result<model::offset>>
+partition_properties_stm::replicate_partition_mode_update(
+  model::timeout_clock::duration timeout, update_partition_mode_cmd cmd) {
+    auto holder = _gate.hold();
+    auto units = co_await _writes_mutex.get_units();
+    if (!co_await sync(timeout)) {
+        co_return errc::not_leader;
+    }
+
+    vassert(
+      !_state_snapshots.empty(),
+      "The invariant of state snapshot containing at least one element is "
+      "broken");
+    auto current_state = _state_snapshots.back();
+    if (cmd.partition_mode == current_state.partition_mode) [[unlikely]] {
+        // no-op
+        co_return current_state.update_offset;
+    }
+
+    auto b = make_update_partition_mode_batch(cmd);
+    vlog(_log.debug, "replicating update partition mode command: {}", cmd);
+    raft::replicate_options r_opts(
+      raft::consistency_level::quorum_ack,
+      _insync_term,
+      std::chrono::milliseconds(timeout / 1ms));
+    r_opts.set_force_flush();
+    auto r = co_await _raft->replicate(std::move(b), r_opts);
+
+    if (r.has_error()) {
+        vlog(
+          _log.warn,
+          "error replicating update partition mode command: {} - {}",
+          cmd,
+          r.error().message());
+        co_await _raft->step_down("partition_properties_stm/replication_error");
+        co_return r.error();
+    }
+
+    auto message_offset = r.value().last_offset;
+    if (!co_await wait_no_throw(
+          message_offset, model::timeout_clock::time_point::max())) {
+        co_await _raft->step_down("partition_properties_stm/replication_error");
+        co_return errc::shutting_down;
+    }
+    co_return message_offset;
+}
+
+ss::future<result<model::offset>> partition_properties_stm::set_partition_mode(
+  model::redpanda_storage_mode mode) {
+    vlog(_log.info, "setting partition mode to {}", mode);
+    return replicate_partition_mode_update(
+      _sync_timeout(), update_partition_mode_cmd{.partition_mode = mode});
+}
+
+model::redpanda_storage_mode partition_properties_stm::partition_mode() const {
+    vassert(
+      !_state_snapshots.empty(),
+      "The invariant of state snapshot containing at least one element is "
+      "broken");
+    return _state_snapshots.back().partition_mode;
+}
+
+void partition_properties_stm::notify_partition_mode_change() {
+    if (_partition_mode_change_cb) {
+        _partition_mode_change_cb();
+    }
+}
+
+ss::future<result<model::redpanda_storage_mode>>
+partition_properties_stm::sync_partition_mode() {
+    auto holder = _gate.hold();
+    if (!co_await sync(_sync_timeout())) {
+        co_return errc::not_leader;
+    }
+    co_return partition_mode();
+}
+
 ss::future<result<model::offset>>
 partition_properties_stm::disable_writes(model::revision_id revision_id) {
     vlog(_log.info, "disabling partition writes");
@@ -355,9 +469,18 @@ fmt::iterator
 partition_properties_stm::raft_snapshot::format_to(fmt::iterator it) const {
     return fmt::format_to(
       it,
-      "{{writes_disabled: {}, writes_revision_id: {}}}",
+      "{{writes_disabled: {}, writes_revision_id: {}, partition_mode: {}}}",
       writes_disabled,
-      writes_revision_id);
+      writes_revision_id,
+      model::redpanda_storage_mode_to_string(partition_mode));
+}
+
+fmt::iterator partition_properties_stm::update_partition_mode_cmd::format_to(
+  fmt::iterator it) const {
+    return fmt::format_to(
+      it,
+      "{{partition_mode: {}}}",
+      model::redpanda_storage_mode_to_string(partition_mode));
 }
 
 fmt::iterator partition_properties_stm::update_writes_disabled_cmd::format_to(
@@ -373,10 +496,12 @@ fmt::iterator
 partition_properties_stm::state_snapshot::format_to(fmt::iterator it) const {
     return fmt::format_to(
       it,
-      "{{update_offset: {}, writes_disabled: {}, writes_revision_id: {}}}",
+      "{{update_offset: {}, writes_disabled: {}, writes_revision_id: {}, "
+      "partition_mode: {}}}",
       update_offset,
       writes_disabled,
-      writes_revision_id);
+      writes_revision_id,
+      model::redpanda_storage_mode_to_string(partition_mode));
 }
 
 fmt::iterator

--- a/src/v/cluster/partition_properties_stm.h
+++ b/src/v/cluster/partition_properties_stm.h
@@ -15,8 +15,11 @@
 #include "cluster/state_machine_registry.h"
 #include "container/chunked_vector.h"
 #include "model/fundamental.h"
+#include "model/metadata.h"
 #include "raft/persisted_stm.h"
 #include "serde/envelope.h"
+
+#include <seastar/util/noncopyable_function.hh>
 
 namespace cluster {
 
@@ -50,6 +53,26 @@ public:
     // Returns a current value of the writes disabled property.
     writes_disabled are_writes_disabled() const;
 
+    // Updates the persistent, partition-local storage mode; returns the offset
+    // of the update message. This is the partition's own durable record of its
+    // storage mode, decoupled from the topic config (see partition_mode()).
+    ss::future<result<model::offset>>
+      set_partition_mode(model::redpanda_storage_mode);
+    // Waits for the state to be up to date and returns the partition mode; only
+    // intended to be called on the current leader.
+    ss::future<result<model::redpanda_storage_mode>> sync_partition_mode();
+    // Returns the current partition mode. `unset` means "not yet bootstrapped";
+    // callers (ntp_config) fall back to the topic-config-derived mode.
+    model::redpanda_storage_mode partition_mode() const;
+
+    // Registers a callback invoked on this shard whenever partition_mode may
+    // have changed (on apply and on raft-snapshot restore), so the owner can
+    // re-read partition_mode() and propagate it (e.g. into ntp_config).
+    void
+    set_partition_mode_change_callback(ss::noncopyable_function<void()> cb) {
+        _partition_mode_change_cb = std::move(cb);
+    }
+
     raft::stm_initial_recovery_policy
     get_initial_recovery_policy() const final {
         return raft::stm_initial_recovery_policy::skip_to_end;
@@ -80,19 +103,43 @@ private:
           const update_writes_disabled_cmd&) = default;
     };
 
+    struct update_partition_mode_cmd
+      : serde::envelope<
+          update_partition_mode_cmd,
+          serde::version<0>,
+          serde::compat_version<0>> {
+        model::redpanda_storage_mode partition_mode
+          = model::redpanda_storage_mode::unset;
+
+        auto serde_fields() { return std::tie(partition_mode); }
+        fmt::iterator format_to(fmt::iterator it) const;
+        friend bool operator==(
+          const update_partition_mode_cmd&,
+          const update_partition_mode_cmd&) = default;
+    };
+
     struct state_snapshot
       : serde::envelope<
           state_snapshot,
-          serde::version<1>,
+          serde::version<2>,
           serde::compat_version<0>> {
         // todo: in a major release we can change it to use a local_snapshot +
         // update_offset
         writes_disabled writes_disabled;
         model::offset update_offset;
         model::revision_id writes_revision_id;
+        // serde v2; absent in older snapshots -> defaults to `unset`, which the
+        // partition_mode() accessor / ntp_config treats as "fall back to the
+        // topic-config-derived mode" (bootstrap fallback).
+        model::redpanda_storage_mode partition_mode
+          = model::redpanda_storage_mode::unset;
 
         auto serde_fields() {
-            return std::tie(writes_disabled, update_offset, writes_revision_id);
+            return std::tie(
+              writes_disabled,
+              update_offset,
+              writes_revision_id,
+              partition_mode);
         }
         fmt::iterator format_to(fmt::iterator it) const;
         friend bool
@@ -101,12 +148,15 @@ private:
 
     struct raft_snapshot
       : serde::
-          envelope<raft_snapshot, serde::version<1>, serde::compat_version<0>> {
+          envelope<raft_snapshot, serde::version<2>, serde::compat_version<0>> {
         writes_disabled writes_disabled = writes_disabled::no;
         model::revision_id writes_revision_id;
+        model::redpanda_storage_mode partition_mode
+          = model::redpanda_storage_mode::unset;
 
         auto serde_fields() {
-            return std::tie(writes_disabled, writes_revision_id);
+            return std::tie(
+              writes_disabled, writes_revision_id, partition_mode);
         }
         fmt::iterator format_to(fmt::iterator it) const;
 
@@ -134,6 +184,7 @@ private:
 
     enum class operation_type {
         update_writes_disabled = 0,
+        update_partition_mode = 1,
     };
 
     ss::future<> do_apply(const model::record_batch&) final;
@@ -142,10 +193,15 @@ private:
 
     static model::record_batch
       make_update_partitions_batch(update_writes_disabled_cmd);
+    static model::record_batch
+      make_update_partition_mode_batch(update_partition_mode_cmd);
 
     ss::future<result<model::offset>> replicate_properties_update(
       model::timeout_clock::duration timeout,
       update_writes_disabled_cmd command);
+    ss::future<result<model::offset>> replicate_partition_mode_update(
+      model::timeout_clock::duration timeout,
+      update_partition_mode_cmd command);
 
     config::binding<std::chrono::milliseconds> _sync_timeout;
 
@@ -158,6 +214,9 @@ private:
 
     // For linearizing access to writes_disabled state on the leader
     ssx::mutex _writes_mutex{"c/partition_properties_stm::writes_mutex"};
+
+    void notify_partition_mode_change();
+    ss::noncopyable_function<void()> _partition_mode_change_cb;
 };
 
 class partition_properties_stm_factory : public state_machine_factory {

--- a/src/v/cluster/tests/partition_properties_stm_test.cc
+++ b/src/v/cluster/tests/partition_properties_stm_test.cc
@@ -16,6 +16,7 @@
 #include "config/mock_property.h"
 #include "container/chunked_circular_buffer.h"
 #include "model/fundamental.h"
+#include "model/metadata.h"
 #include "model/record.h"
 #include "model/tests/random_batch.h"
 #include "raft/replicate.h"
@@ -113,6 +114,32 @@ struct partition_properties_stm_fixture : raft::raft_fixture {
         auto r = co_await get_writes_disabled_on_leader();
         ASSERT_TRUE_CORO(r.has_value());
         ASSERT_EQ_CORO(r.value(), disabled);
+    }
+
+    ss::future<> set_partition_mode(
+      model::redpanda_storage_mode mode, bool expect_success = true) {
+        auto res = co_await retry_with_leader(
+          raft::default_timeout(),
+          2s,
+          [mode](raft::raft_node_instance& leader_node) {
+              return get_stm(leader_node)->set_partition_mode(mode);
+          });
+        ASSERT_EQ_CORO(res.has_value(), expect_success);
+    }
+
+    ss::future<> assert_partition_mode(model::redpanda_storage_mode mode) {
+        auto r = co_await get_leader_stm()->sync_partition_mode();
+        ASSERT_TRUE_CORO(r.has_value());
+        ASSERT_EQ_CORO(r.value(), mode);
+    }
+
+    ss::future<>
+    check_partition_mode_consistent(model::redpanda_storage_mode mode) {
+        RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this, mode] {
+            return std::ranges::all_of(
+              node_stms | std::views::values,
+              [mode](auto stm) { return stm->partition_mode() == mode; });
+        });
     }
 
     ss::future<result<model::offset>> replicate_random_batches() {
@@ -415,6 +442,135 @@ TEST_F_CORO(
     ASSERT_EQ_CORO(writes_disabled, should_be_disabled);
     co_await wait_for_committed_offset(last_applied, 10s);
     co_await check_state_consistent(should_be_disabled);
+}
+
+TEST_F_CORO(partition_properties_stm_fixture, test_partition_mode_basic) {
+    co_await initialize_state_machines();
+    co_await wait_for_leader(10s);
+    // A fresh partition has never had partition_mode written: it reads `unset`
+    // (the "not bootstrapped -> fall back to topic_mode" sentinel).
+    co_await assert_partition_mode(model::redpanda_storage_mode::unset);
+
+    co_await set_partition_mode(model::redpanda_storage_mode::tiered);
+    co_await assert_partition_mode(model::redpanda_storage_mode::tiered);
+    // idempotent
+    co_await set_partition_mode(model::redpanda_storage_mode::tiered);
+    co_await assert_partition_mode(model::redpanda_storage_mode::tiered);
+    // the migration cutover transition: tiered -> cloud
+    co_await set_partition_mode(model::redpanda_storage_mode::cloud);
+    co_await assert_partition_mode(model::redpanda_storage_mode::cloud);
+    co_await check_partition_mode_consistent(
+      model::redpanda_storage_mode::cloud);
+}
+
+// writes_disabled and partition_mode share one state_snapshot; updating one
+// must preserve the other (the apply copy-modify).
+TEST_F_CORO(
+  partition_properties_stm_fixture, test_partition_mode_independent_of_writes) {
+    co_await initialize_state_machines();
+
+    co_await disable_writes(model::revision_id{1});
+    co_await set_partition_mode(model::redpanda_storage_mode::tiered);
+    co_await assert_writes(stm_t::writes_disabled::yes);
+    co_await assert_partition_mode(model::redpanda_storage_mode::tiered);
+
+    // a partition_mode update leaves writes_disabled untouched
+    co_await set_partition_mode(model::redpanda_storage_mode::cloud);
+    co_await assert_writes(stm_t::writes_disabled::yes);
+    co_await assert_partition_mode(model::redpanda_storage_mode::cloud);
+
+    // and a writes_disabled update leaves partition_mode untouched
+    co_await enable_writes(model::revision_id{2});
+    co_await assert_writes(stm_t::writes_disabled::no);
+    co_await assert_partition_mode(model::redpanda_storage_mode::cloud);
+}
+
+TEST_F_CORO(partition_properties_stm_fixture, test_partition_mode_snapshot) {
+    co_await initialize_state_machines();
+
+    auto before_set = co_await replicate_random_batches();
+    co_await set_partition_mode(model::redpanda_storage_mode::tiered);
+    [[maybe_unused]] auto _ignored = co_await replicate_random_batches();
+
+    auto leader_id = get_leader();
+    EXPECT_TRUE(leader_id.has_value());
+    auto& leader_node = node(leader_id.value());
+
+    // snapshot taken before the set command -> unset
+    auto o = co_await leader_node.random_batch_base_offset(before_set.value());
+    auto snap_before = partition_properties_stm_accessor::snap_from_iobuf(
+      co_await get_leader_stm()->take_raft_snapshot(o));
+    ASSERT_EQ_CORO(
+      snap_before.partition_mode, model::redpanda_storage_mode::unset);
+
+    // snapshot at the set command offset -> tiered (and writes_disabled intact)
+    auto snap_at = partition_properties_stm_accessor::snap_from_iobuf(
+      co_await get_leader_stm()->take_raft_snapshot(
+        model::next_offset(before_set.value())));
+    ASSERT_EQ_CORO(
+      snap_at.partition_mode, model::redpanda_storage_mode::tiered);
+    ASSERT_EQ_CORO(snap_at.writes_disabled, stm_t::writes_disabled::no);
+}
+
+TEST_F_CORO(partition_properties_stm_fixture, test_partition_mode_recovery) {
+    co_await initialize_state_machines();
+    co_await set_partition_mode(model::redpanda_storage_mode::tiered);
+    [[maybe_unused]] auto _ignored = co_await replicate_random_batches();
+    co_await set_partition_mode(model::redpanda_storage_mode::cloud);
+    co_await assert_partition_mode(model::redpanda_storage_mode::cloud);
+    auto last_applied = get_leader_stm()->last_applied_offset();
+
+    // restart preserving data: recover from local (kvstore) snapshot + replay
+    co_await restart_nodes();
+    co_await wait_for_leader(10s);
+    co_await assert_partition_mode(model::redpanda_storage_mode::cloud);
+    co_await wait_for_committed_offset(last_applied, 10s);
+    co_await check_partition_mode_consistent(
+      model::redpanda_storage_mode::cloud);
+
+    // take a raft snapshot on every node, then restart with one node's data
+    // dropped: that node recovers partition_mode from the raft snapshot.
+    for (auto& [_, node] : nodes()) {
+        auto base_offset = co_await node->random_batch_base_offset(
+          node->raft()->committed_offset(), model::offset(1));
+        auto snapshot_offset = model::prev_offset(base_offset);
+        auto result = co_await node->raft()->stm_manager()->take_snapshot(
+          snapshot_offset);
+        co_await node->raft()->write_snapshot(
+          raft::write_snapshot_cfg(snapshot_offset, std::move(result.data)));
+    }
+    co_await restart_nodes({model::node_id(1)});
+    co_await wait_for_leader(10s);
+    co_await assert_partition_mode(model::redpanda_storage_mode::cloud);
+    co_await wait_for_committed_offset(last_applied, 10s);
+    co_await check_partition_mode_consistent(
+      model::redpanda_storage_mode::cloud);
+}
+
+// The change callback (used by partition to push partition_mode into
+// ntp_config) must fire when partition_mode changes, on each replica that
+// applies the change.
+TEST_F_CORO(
+  partition_properties_stm_fixture, test_partition_mode_change_callback) {
+    co_await initialize_state_machines();
+    co_await wait_for_leader(10s);
+
+    auto fired = ss::make_lw_shared<int>(0);
+    for (auto& [_, stm] : node_stms) {
+        stm->set_partition_mode_change_callback([fired] { ++(*fired); });
+    }
+
+    co_await set_partition_mode(model::redpanda_storage_mode::tiered);
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [fired] { return *fired >= 1; });
+    co_await check_partition_mode_consistent(
+      model::redpanda_storage_mode::tiered);
+
+    // an idempotent (no-op) update does not change state, so it does not fire
+    auto before = *fired;
+    co_await set_partition_mode(model::redpanda_storage_mode::tiered);
+    co_await check_partition_mode_consistent(
+      model::redpanda_storage_mode::tiered);
+    ASSERT_EQ_CORO(*fired, before);
 }
 
 } // namespace cluster

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -111,6 +111,8 @@ std::string_view to_string_view(feature f) {
         return "remote_labels";
     case feature::partition_properties_stm:
         return "partition_properties_stm";
+    case feature::topic_mode_migration:
+        return "topic_mode_migration";
     case feature::shadow_indexing_split_topic_property_update:
         return "shadow_indexing_split_topic_property_update";
     case feature::datalake_iceberg:

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -66,6 +66,7 @@ enum class feature : std::uint64_t {
     membership_change_controller_cmds = 1ULL << 22U,
     controller_snapshots = 1ULL << 23U,
     cloud_storage_manifest_format_v2 = 1ULL << 24U,
+    topic_mode_migration = 1ULL << 25U,
     force_partition_reconfiguration = 1ULL << 26U,
     delete_records = 1ULL << 29U,
     raft_coordinated_recovery = 1ULL << 31U,
@@ -431,6 +432,12 @@ inline constexpr std::array feature_schema{
     release_version::v24_3_1,
     "partition_properties_stm",
     feature::partition_properties_stm,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    release_version::v26_3_1,
+    "topic_mode_migration",
+    feature::topic_mode_migration,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{

--- a/src/v/raft/tests/failure_injectable_log.cc
+++ b/src/v/raft/tests/failure_injectable_log.cc
@@ -210,6 +210,12 @@ void failure_injectable_log::set_overrides(
     return _underlying_log->set_overrides(overrides);
 }
 
+void failure_injectable_log::set_partition_mode(
+  model::redpanda_storage_mode mode) {
+    mutable_config().set_partition_mode(mode);
+    return _underlying_log->set_partition_mode(mode);
+}
+
 bool failure_injectable_log::notify_compaction_update() {
     return _underlying_log->notify_compaction_update();
 }

--- a/src/v/raft/tests/failure_injectable_log.h
+++ b/src/v/raft/tests/failure_injectable_log.h
@@ -116,6 +116,8 @@ public:
 
     void set_overrides(storage::ntp_config::default_overrides) final;
 
+    void set_partition_mode(model::redpanda_storage_mode) final;
+
     bool notify_compaction_update() final;
 
     int64_t compaction_backlog() final;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -3799,6 +3799,10 @@ void disk_log_impl::set_overrides(ntp_config::default_overrides o) {
     mutable_config().set_overrides(o);
 }
 
+void disk_log_impl::set_partition_mode(model::redpanda_storage_mode m) {
+    mutable_config().set_partition_mode(m);
+}
+
 /**
  * We express compaction backlog as the size of data that has to be read to
  * perform full compaction.

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -168,6 +168,7 @@ public:
     size_t size_bytes() const override { return _probe->partition_size(); }
     uint64_t size_bytes_after_offset(model::offset o) const override;
     void set_overrides(ntp_config::default_overrides) final;
+    void set_partition_mode(model::redpanda_storage_mode) final;
     bool notify_compaction_update() final;
 
     int64_t compaction_backlog() final;

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -223,6 +223,12 @@ public:
     /// topic/partition-level overrides
     virtual void set_overrides(ntp_config::default_overrides) = 0;
 
+    /// Mutates the partition_mode stored in the log's ntp_config: the
+    /// partition's own durable storage mode, fed from partition_properties.
+    /// Abstract rather than defaulted, like set_overrides: a wrapping log that
+    /// silently dropped this would report a stale storage mode from config().
+    virtual void set_partition_mode(model::redpanda_storage_mode) = 0;
+
     /// Notifies the log about a possible change to the log compaction config.
     /// Returns true if the log compaction changed.
     virtual bool notify_compaction_update() = 0;

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -247,38 +247,58 @@ public:
                                      : topic_recovery_enabled::no;
     }
 
+    // The storage mode the topic config requests (the "desired" mode). `unset`
+    // for a legacy topic that uses shadow_indexing_mode instead of
+    // storage_mode.
+    model::redpanda_storage_mode topic_mode() const {
+        return _overrides ? _overrides->storage_mode
+                          : model::redpanda_storage_mode::unset;
+    }
+
+    // The partition's own durable storage mode (the "actual" mode), recorded in
+    // partition_properties and pushed in via set_partition_mode(). Falls back
+    // to topic_mode() when unset (not yet bootstrapped). Serving/behavior
+    // accessors key on partition_mode rather than topic_mode.
+    // On a storage mode switch that needs migration, partition_mode is
+    // advanced to match topic_mode only once the migration completes.
+    model::redpanda_storage_mode partition_mode() const {
+        return _partition_mode != model::redpanda_storage_mode::unset
+                 ? _partition_mode
+                 : topic_mode();
+    }
+
+    void set_partition_mode(model::redpanda_storage_mode m) {
+        _partition_mode = m;
+    }
+
     bool is_archival_enabled() const {
-        if (_overrides == nullptr) {
-            return false;
-        }
+        const auto mode = partition_mode();
         // Explicit tiered
-        if (_overrides->storage_mode == model::redpanda_storage_mode::tiered) {
+        if (mode == model::redpanda_storage_mode::tiered) {
             return true;
         }
         // Explicit local or cloud
-        if (_overrides->storage_mode != model::redpanda_storage_mode::unset) {
+        if (mode != model::redpanda_storage_mode::unset) {
             return false;
         }
         // Unset, fall back to legacy shadow_indexing
-        return _overrides->shadow_indexing_mode
+        return _overrides && _overrides->shadow_indexing_mode
                && model::is_archival_enabled(
                  _overrides->shadow_indexing_mode.value());
     }
 
     bool is_remote_fetch_enabled() const {
-        if (_overrides == nullptr) {
-            return false;
-        }
+        const auto mode = partition_mode();
         // Explicit tiered
-        if (_overrides->storage_mode == model::redpanda_storage_mode::tiered) {
+        if (mode == model::redpanda_storage_mode::tiered) {
             return true;
         }
         // Explicit local or cloud
-        if (_overrides->storage_mode != model::redpanda_storage_mode::unset) {
+        if (mode != model::redpanda_storage_mode::unset) {
             return false;
         }
         // Unset, fall back to legacy shadow_indexing
-        return _overrides->shadow_indexing_mode
+        return _overrides && _overrides->shadow_indexing_mode
                && model::is_fetch_enabled(
                  _overrides->shadow_indexing_mode.value());
     }
@@ -302,23 +322,22 @@ public:
      * both reads and writes to S3, and is not a read replica.
      */
     bool is_tiered_storage() const {
-        if (_overrides == nullptr) {
+        if (is_read_replica_mode_enabled()) {
             return false;
         }
-        if (_overrides->read_replica.value_or(false)) {
-            return false;
-        }
+        const auto mode = partition_mode();
         // Explicit tiered
-        if (_overrides->storage_mode == model::redpanda_storage_mode::tiered) {
+        if (mode == model::redpanda_storage_mode::tiered) {
             return true;
         }
         // Explicit local or cloud
-        if (_overrides->storage_mode != model::redpanda_storage_mode::unset) {
+        if (mode != model::redpanda_storage_mode::unset) {
             return false;
         }
         // Unset, fall back to legacy shadow_indexing
-        return _overrides->shadow_indexing_mode
-               == model::shadow_indexing_mode::full;
+        return _overrides
+               && _overrides->shadow_indexing_mode
+                    == model::shadow_indexing_mode::full;
     }
 
     bool remote_delete() const {
@@ -439,17 +458,13 @@ public:
     }
 
     bool cloud_topic_enabled() const {
-        return _overrides
-               && (_overrides->storage_mode
-                     == model::redpanda_storage_mode::cloud
-                   || _overrides->storage_mode
-                        == model::redpanda_storage_mode::tiered_cloud);
+        const auto mode = partition_mode();
+        return mode == model::redpanda_storage_mode::cloud
+               || mode == model::redpanda_storage_mode::tiered_cloud;
     }
 
     bool is_tiered_cloud() const {
-        return _overrides
-               && _overrides->storage_mode
-                    == model::redpanda_storage_mode::tiered_cloud;
+        return partition_mode() == model::redpanda_storage_mode::tiered_cloud;
     }
 
     std::optional<double> min_cleanable_dirty_ratio() const {
@@ -510,6 +525,12 @@ private:
     /// This revision is used to construct cloud storage paths. It differs from
     /// _topic_revision in case of recovered topics or read replicas.
     model::initial_revision_id _remote_rev{0};
+
+    /// The partition's own durable storage mode, fed from partition_properties
+    /// (see partition_mode()). `unset` until bootstrapped, when the mode
+    /// accessors fall back to the topic-config-derived topic_mode().
+    model::redpanda_storage_mode _partition_mode
+      = model::redpanda_storage_mode::unset;
 
 public:
     // in storage/types.cc

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -1235,6 +1235,11 @@ PERTURB_ACKNOWLEDGED_FEATURES = frozenset(
         # Iceberg extended-mode topic-config gate; exercising it needs Iceberg
         # topic setup orthogonal to the finalization behavior under test.
         "iceberg_extended_mode_config",
+        # Downgrade-safe by inspection: most of the functionality this gates is
+        # not present yet, so nothing writes the new partition_mode command while
+        # an upgrade is unfinalized. A follow-up PR exercises the gate for real
+        # once the migration trigger lands.
+        "topic_mode_migration",
     }
 )
 
@@ -1397,12 +1402,13 @@ class ManualFinalizationUpgradeTest(UnfinalizedUpgradeMixin, FeaturesTestBase):
         self._exercise_tiered_cloud_topics()
         self._exercise_shadow_link_role_sync()
         self._exercise_fetch_controller_snapshot_rpc()
-        # The other two v26.2-gated features are cluster-linking features that
-        # need a second (source) cluster, so they are acknowledged rather than
-        # exercised here; see PERTURB_ACKNOWLEDGED_FEATURES for why each stays
-        # downgrade-safe (shadow_link_sr_api_sync is covered by
+        # The remaining gated features are acknowledged rather than exercised
+        # here; see PERTURB_ACKNOWLEDGED_FEATURES for why each stays
+        # downgrade-safe. Two are v26.2 cluster-linking features needing a second
+        # (source) cluster (shadow_link_sr_api_sync is covered by
         # ShadowLinkUnfinalizedUpgradeTest; batch_mirror_topic_status is safe by
-        # inspection).
+        # inspection); topic_mode_migration is v26.3-gated and gates nothing
+        # user-visible until the migration trigger lands.
 
     def _exercise_tiered_cloud_topics(self):
         """tiered_cloud_topics gate: creating a topic with the tiered_v2


### PR DESCRIPTION
No longer needed.