### PR TITLE
rpk: fix doubled "are" in rpk group help text

### DIFF
--- a/src/go/rpk/pkg/cli/group/group.go
+++ b/src/go/rpk/pkg/cli/group/group.go
@@ -41,7 +41,7 @@ member to the group, then each of the three members will consume two
 partitions. This allows you to horizontally scale consuming of topics.
 
 The unit of scaling is a single partition. If you add more consumers to a group
-than there are are total partitions to consume, then some consumers will be
+than there are total partitions to consume, then some consumers will be
 idle. More commonly, you have many more partitions than consumer group members
 and each member consumes a chunk of available partitions. One scenario where
 you may want more members than partitions is if you want active standby's to


### PR DESCRIPTION
## Summary

Fix a doubled word in the `rpk group` long help text: "if you add more consumers to a group than there are **are** total partitions to consume" → "...than there are total partitions...".

## Why

This help string (`group.go`) is the source for the auto-generated `rpk group` reference page in the docs. Fixing it here corrects both `rpk group -h` and the generated docs, rather than patching the generated `.adoc` (which gets overwritten on regeneration).

Reported via a docs typo fix (redpanda-data/docs#1746).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes


* none
