### PR TITLE
model/tests: add decompression cost microbenchmark

### DIFF
--- a/src/v/model/tests/BUILD
+++ b/src/v/model/tests/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:test.bzl", "redpanda_cc_btest", "redpanda_cc_gtest", "redpanda_test_cc_library")
+load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_btest", "redpanda_cc_gtest", "redpanda_test_cc_library")
 
 redpanda_test_cc_library(
     name = "random",
@@ -252,5 +252,24 @@ redpanda_cc_gtest(
         "//src/v/model",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
+    ],
+)
+
+redpanda_cc_bench(
+    name = "decompression_rpbench",
+    timeout = "long",
+    srcs = [
+        "decompression_bench.cc",
+    ],
+    test_regex = ".*zstd_r1_n16",
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/container:chunked_vector",
+        "//src/v/model",
+        "//src/v/model:batch_compression",
+        "//src/v/random:generators",
+        "//src/v/storage:record_batch_builder",
+        "@seastar",
+        "@seastar//:benchmark",
     ],
 )

--- a/src/v/model/tests/decompression_bench.cc
+++ b/src/v/model/tests/decompression_bench.cc
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+// This microbenchmark is a bit odd. It doesn't benchmark our code, but rather
+// the compression codecs Kafka uses. Its main use is for fitting a model we
+// have for CPU util when decompressing batches.
+//
+// The benchmark sweeps two axes per codec:
+//   * target ratio        -> seed length (chunk_size / ratio); the achieved
+//                            ratio is measured, not assumed.
+//   * decompressed size   -> via records_per_batch (chunk size is fixed).
+// so for each ratio we get a size sweep, which separates the fixed per-batch
+// overhead from the marginal per-byte cost.
+//
+// Each benchmark emits one stable metadata line to stderr (the achieved ratio
+// and byte counts seastar's timing output does not know about):
+//   DECOMP_META,<case>,<codec>,<target_ratio>,<chunk_size>,<records_per_batch>,
+//       <n_batches>,<decompressed_bytes_per_iter>,<compressed_bytes_per_iter>,
+//       <measured_ratio>
+
+#include "bytes/iobuf.h"
+#include "container/chunked_vector.h"
+#include "model/batch_compression.h"
+#include "model/compression.h"
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "random/generators.h"
+#include "storage/record_batch_builder.h"
+
+#include <seastar/testing/perf_tests.hh>
+
+#include <algorithm>
+#include <cstddef>
+#include <optional>
+#include <string>
+
+namespace {
+
+// Bytes per record value (one "record-sized chunk").
+constexpr size_t chunk_size = 256;
+// Batches consumed per timed iteration. More batches -> more decompress calls
+// per measurement -> steadier timing, while batch size stays the swept knob.
+constexpr size_t n_batches = 32;
+
+struct decompressing_consumer {
+    // Tally input/output bytes so we can derive the compression ratio.
+    size_t total_compressed_bytes = 0;
+    size_t total_decompressed_bytes = 0;
+
+    ss::future<ss::stop_iteration> operator()(model::record_batch batch) {
+        total_compressed_bytes += batch.size_bytes();
+        if (batch.compressed()) {
+            batch = co_await model::decompress_batch(batch);
+        }
+        total_decompressed_bytes += batch.size_bytes();
+        co_return ss::stop_iteration::no;
+    }
+    ss::future<decompressing_consumer> end_of_stream() {
+        co_return std::move(*this);
+    }
+};
+
+struct case_data {
+    chunked_vector<model::record_batch> compressed;
+    size_t decompressed_bytes = 0;
+    size_t compressed_bytes = 0;
+    double measured_ratio = 0.0;
+    bool meta_logged = false;
+};
+
+ss::logger dlog("decompression_bench");
+
+} // namespace
+
+class decompression_bench_fixture {
+public:
+    ss::future<> configure(
+      model::compression codec, size_t target_ratio, size_t records_per_batch) {
+        if (_case) {
+            co_return;
+        }
+        auto& cd = _case.emplace();
+
+        // Each record value is a short random seed tiled up to chunk_size, so
+        // it compresses by ~target_ratio on its own.
+        size_t seed_len = std::max<size_t>(1, chunk_size / target_ratio);
+
+        for (size_t b = 0; b < n_batches; ++b) {
+            storage::record_batch_builder builder(
+              model::record_batch_type::raft_data, model::offset{0});
+            for (size_t r = 0; r < records_per_batch; ++r) {
+                auto seed = random_generators::gen_alphanum_string(seed_len);
+                iobuf value;
+                while (value.size_bytes() < chunk_size) {
+                    size_t take = std::min(
+                      seed_len, chunk_size - value.size_bytes());
+                    value.append(seed.data(), take);
+                }
+                builder.add_raw_kv(std::nullopt, std::move(value));
+            }
+            auto uncompressed = std::move(builder).build();
+            cd.decompressed_bytes += uncompressed.size_bytes();
+            auto compressed = co_await model::compress_batch(
+              codec, std::move(uncompressed));
+            cd.compressed_bytes += compressed.size_bytes();
+            cd.compressed.push_back(std::move(compressed));
+        }
+        cd.measured_ratio = static_cast<double>(cd.decompressed_bytes)
+                            / static_cast<double>(cd.compressed_bytes);
+    }
+
+    ss::future<size_t> run_bench(
+      std::string case_name,
+      std::string codec,
+      size_t target_ratio,
+      size_t records_per_batch) {
+        auto& cd = *_case;
+
+        // Emit the stable metadata row once per case.
+        if (!cd.meta_logged) {
+            cd.meta_logged = true;
+            vlog(
+              dlog.info,
+              "DECOMP_META,{},{},{},{},{},{},{},{},{:.6f}",
+              case_name,
+              codec,
+              target_ratio,
+              chunk_size,
+              records_per_batch,
+              n_batches,
+              cd.decompressed_bytes,
+              cd.compressed_bytes,
+              cd.measured_ratio);
+        }
+
+        chunked_vector<model::record_batch> batches;
+        batches.reserve(cd.compressed.size());
+        for (auto& b : cd.compressed) {
+            batches.push_back(b.share());
+        }
+        auto reader = model::make_chunked_memory_record_batch_reader(
+          std::move(batches));
+
+        perf_tests::start_measuring_time();
+        auto res = co_await reader.consume(
+          decompressing_consumer{}, model::no_timeout);
+        perf_tests::stop_measuring_time();
+
+        perf_tests::do_not_optimize(res.total_decompressed_bytes);
+        co_return res.total_decompressed_bytes;
+    }
+
+private:
+    std::optional<case_data> _case;
+};
+
+// One PERF_TEST per (codec, target_ratio, records_per_batch) grid point. The
+// case name encodes the params and is the join key for the DECOMP_META line.
+#define DECOMP_CASE(codec, ratio, rpb)                                         \
+    PERF_TEST_CN(decompression_bench_fixture, codec##_r##ratio##_n##rpb) {     \
+        co_await configure(model::compression::codec, ratio, rpb);             \
+        co_return co_await run_bench(                                          \
+          #codec "_r" #ratio "_n" #rpb, #codec, ratio, rpb);                   \
+    }
+
+// Two grids, both spanning ratio 1 (incompressible) .. 16 (highly redundant)
+// and batch size n * 256 B = 4 KiB .. 256 KiB.
+//   MINIMAL: just the min/max corner of each dimension -- a fast smoke check
+//            that the bench builds and runs (the default).
+//   FULL:    dense, equal coverage per codec for actually fitting the 4
+//            coefficients. Switch to it (DECOMP_UPDATE_COEFFICIENTS=1) only
+//            when refreshing the model.
+// clang-format off
+#define GRID_MINIMAL(codec, X)                                                 \
+    X(codec,  1,   16) X(codec,  1, 1024)                                      \
+    X(codec, 16,   16) X(codec, 16, 1024)
+
+#define GRID_FULL(codec, X)                                                     \
+    X(codec,  1,   16) X(codec,  1,   64) X(codec,  1,  256) X(codec,  1, 1024) \
+    X(codec,  4,   16) X(codec,  4,   64) X(codec,  4,  256) X(codec,  4, 1024) \
+    X(codec,  8,   16) X(codec,  8,   64) X(codec,  8,  256) X(codec,  8, 1024) \
+    X(codec, 16,   16) X(codec, 16,   64) X(codec, 16,  256) X(codec, 16, 1024)
+// clang-format on
+
+#define DECOMP_UPDATE_COEFFICIENTS 0
+#if DECOMP_UPDATE_COEFFICIENTS
+#define GRID_FOR(codec, X) GRID_FULL(codec, X)
+#else
+#define GRID_FOR(codec, X) GRID_MINIMAL(codec, X)
+#endif
+
+#define DECOMP_GRID(X)                                                         \
+    GRID_FOR(zstd, X) GRID_FOR(lz4, X) GRID_FOR(snappy, X) GRID_FOR(gzip, X)
+
+DECOMP_GRID(DECOMP_CASE)


### PR DESCRIPTION
Adds a microbenchmark for the Kafka compression codecs (zstd, lz4, snappy, gzip) when decompressing batches. This is used to fit the CPU-utilization model for decompression. It sweeps two axes per codec: target compression ratio and decompressed batch size.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
