### PR TITLE
kafka/server: cap obligatory read to one batch when over-committed

### DIFF
--- a/src/v/kafka/server/fetch_memory_units.cc
+++ b/src/v/kafka/server/fetch_memory_units.cc
@@ -67,7 +67,7 @@ fetch_memory_units_manager::units::~units() noexcept {
       "foreign units need to be released via the fetch_memory_units_manager");
 }
 
-fetch_memory_units fetch_memory_units_manager::allocate_memory_units(
+memory_units_allocation fetch_memory_units_manager::allocate_memory_units(
   const model::ktp& ktp,
   size_t max_bytes,
   size_t max_batch_size,
@@ -131,7 +131,12 @@ fetch_memory_units fetch_memory_units_manager::allocate_memory_units(
         units_to_alloc = std::min(available_units, max_units);
     }
 
-    return {allocate_units(units_to_alloc), _local_instance_fn};
+    const bool exceeded_available_units = units_to_alloc > available_units;
+
+    return {
+      .units
+      = fetch_memory_units{allocate_units(units_to_alloc), _local_instance_fn},
+      .exceeded_available_units = exceeded_available_units};
 }
 
 fetch_memory_units fetch_memory_units_manager::zero_units() {

--- a/src/v/kafka/server/fetch_memory_units.h
+++ b/src/v/kafka/server/fetch_memory_units.h
@@ -24,6 +24,7 @@ namespace kafka {
 using namespace std::chrono_literals;
 
 class fetch_memory_units;
+struct memory_units_allocation;
 
 /***
  * This service handles allocating/releasing semaphore units for the fetch path.
@@ -66,8 +67,12 @@ public:
      * \param require_min_units If true then at least \ref min_units will be
      * allocated regardless of the units available in \ref memory_sem and \ref
      * memory_fetch_sem.
+     *
+     * The returned \ref memory_units_allocation also reports whether the memory
+     * semaphores were allowed to go negative in order to satisfy \ref
+     * require_max_batch_size.
      */
-    fetch_memory_units allocate_memory_units(
+    memory_units_allocation allocate_memory_units(
       const model::ktp& ktp,
       size_t max_bytes,
       size_t max_batch_size,
@@ -166,6 +171,18 @@ private:
 
     fetch_memory_units_manager::units _units;
     fetch_memory_units_manager::local_instance_fn _local_instance_fn;
+};
+
+/***
+ * Result of \ref fetch_memory_units_manager::allocate_memory_units.
+ */
+struct [[nodiscard]] memory_units_allocation {
+    /// The allocated memory units.
+    fetch_memory_units units;
+    /// True if more units were reserved than the memory semaphores had
+    /// available (allowing them to go negative) in order to satisfy \ref
+    /// require_max_batch_size.
+    bool exceeded_available_units;
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -225,12 +225,13 @@ static ss::future<read_result> do_read_from_ntp(
     // control available memory
     auto memory_units = units_mgr.zero_units();
     if (!ntp_config.cfg.skip_read) {
-        memory_units = units_mgr.allocate_memory_units(
+        auto allocation = units_mgr.allocate_memory_units(
           ntp_config.ktp(),
           ntp_config.cfg.max_bytes,
           ntp_config.cfg.max_batch_size,
           ntp_config.cfg.avg_batch_size,
           obligatory_batch_read);
+        memory_units = std::move(allocation.units);
         if (!memory_units.has_units()) {
             ntp_config.cfg.skip_read = true;
         } else if (ntp_config.cfg.max_bytes > memory_units.num_units()) {

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -237,6 +237,12 @@ static ss::future<read_result> do_read_from_ntp(
         } else if (ntp_config.cfg.max_bytes > memory_units.num_units()) {
             ntp_config.cfg.max_bytes = memory_units.num_units();
         }
+
+        // If this is an obligatory read and we've had to over-extend the memory
+        // semaphore then ensure that no more than a single batch is read.
+        if (obligatory_batch_read && allocation.exceeded_available_units) {
+            ntp_config.cfg.max_bytes = 1;
+        }
     }
 
     /*

--- a/src/v/kafka/server/tests/fetch_memory_units_test.cc
+++ b/src/v/kafka/server/tests/fetch_memory_units_test.cc
@@ -136,7 +136,7 @@ TEST_F_CORO(fetch_memory_units_test_fixture, test_cross_shard_free) {
     };
 
     auto remote_units = co_await get_remote_units(max_release_size);
-    EXPECT_EQ(remote_units.value().num_units(), max_release_size);
+    EXPECT_EQ(remote_units.value().units.num_units(), max_release_size);
     EXPECT_EQ(local_fetch_semaphore().available_units(), max_release_size);
     EXPECT_EQ(local_kafka_semaphore().available_units(), max_release_size);
     EXPECT_EQ(co_await other_fetch_sem_avail(), 0);
@@ -149,7 +149,7 @@ TEST_F_CORO(fetch_memory_units_test_fixture, test_cross_shard_free) {
     EXPECT_EQ(co_await other_kafka_sem_avail(), max_release_size);
 
     remote_units = co_await get_remote_units(max_release_size - 1);
-    EXPECT_EQ(remote_units.value().num_units(), max_release_size - 1);
+    EXPECT_EQ(remote_units.value().units.num_units(), max_release_size - 1);
     EXPECT_NE(co_await other_fetch_sem_avail(), max_release_size);
     EXPECT_NE(co_await other_kafka_sem_avail(), max_release_size);
 
@@ -172,13 +172,13 @@ TEST_F_CORO(fetch_memory_units_test_fixture, test_max_units) {
     co_await set_max_message_size(10);
 
     auto units = mgr.allocate_memory_units(model::ktp{}, 1, 100, 1, false);
-    EXPECT_EQ(units.num_units(), 10);
+    EXPECT_EQ(units.units.num_units(), 10);
     units = mgr.allocate_memory_units(model::ktp{}, 1, 100, 1, true);
-    EXPECT_EQ(units.num_units(), 10);
+    EXPECT_EQ(units.units.num_units(), 10);
 
     // `max_bytes` should still be reserved if there are enough units.
     units = mgr.allocate_memory_units(model::ktp{}, 100, 1, 1, false);
-    EXPECT_EQ(units.num_units(), 100);
+    EXPECT_EQ(units.units.num_units(), 100);
 }
 
 TEST_F_CORO(fetch_memory_units_test_fixture, test_adjust_units) {
@@ -187,7 +187,8 @@ TEST_F_CORO(fetch_memory_units_test_fixture, test_adjust_units) {
     co_await set_kafka_units(10);
     co_await set_fetch_units(10);
 
-    auto units = mgr.allocate_memory_units(model::ktp{}, 10, 10, 10, false);
+    auto units
+      = mgr.allocate_memory_units(model::ktp{}, 10, 10, 10, false).units;
     EXPECT_EQ(units.num_units(), 10);
     units.adjust_units(5);
     EXPECT_EQ(units.num_units(), 5);
@@ -204,14 +205,21 @@ TEST_F_CORO(fetch_memory_units_test_fixture, test_allocate_memory_units) {
     co_await set_fetch_units(50_MiB);
 
     const auto test_case =
-      [&mgr](size_t max_bytes, bool obligatory_batch_read) -> size_t {
+      [&](size_t max_bytes, bool obligatory_batch_read) -> size_t {
+        const size_t available = std::min(
+          local_kafka_semaphore().available_units(),
+          local_fetch_semaphore().available_units());
         auto mu = mgr.allocate_memory_units(
           model::ktp{},
           max_bytes,
           batch_size,
           batch_size,
           obligatory_batch_read);
-        return mu.num_units();
+        // The semaphores are only allowed to go negative when an obligatory
+        // read forces us to reserve more units than were available.
+        EXPECT_EQ(
+          mu.exceeded_available_units, mu.units.num_units() > available);
+        return mu.units.num_units();
     };
 
     // below are test prerequisites, tests are done based on these assumptions


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
When `allocate_memory_units` reports it let the memory semaphores go
negative to satisfy an obligatory batch read, cap max_bytes to a single
batch so the read does not pull in additional data on top of the memory
we already over-committed.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes
### Bug Fixes
* Avoid reading more than 1 batch on obligatory reads if memory is already over-committed. 
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
