### PR TITLE
[v25.2.x] k/s/group_manager: fix inflated consumer group lag after log truncation

### DIFF
--- a/src/v/kafka/server/consumer_group_lag_metrics_frontend.cc
+++ b/src/v/kafka/server/consumer_group_lag_metrics_frontend.cc
@@ -116,6 +116,9 @@ consumer_group_lag_metrics_frontend::get_partition_offsets(
           for (const auto& [topic, data] : res.data) {
               acc.data[topic].insert(data.begin(), data.end());
           }
+          for (const auto& [topic, data] : res.log_start_offsets) {
+              acc.log_start_offsets[topic].insert(data.begin(), data.end());
+          }
           return acc;
       });
 }
@@ -141,6 +144,8 @@ consumer_group_lag_metrics_frontend::get_local_partition_offsets(
               if (part.has_value()) {
                   reply.data[ktp.tp()][ktp.partition()] = kafka::offset{
                     part->high_watermark()()};
+                  reply.log_start_offsets[ktp.tp()][ktp.partition()]
+                    = kafka::offset{part->start_offset()()};
               }
           });
           return reply;
@@ -150,6 +155,12 @@ consumer_group_lag_metrics_frontend::get_local_partition_offsets(
           for (const auto& [t, ps] : rep.data) {
               for (const auto [p, o] : ps) {
                   auto& acc_off = acc.data[t][p];
+                  acc_off = std::max(acc_off, o);
+              }
+          }
+          for (const auto& [t, ps] : rep.log_start_offsets) {
+              for (const auto [p, o] : ps) {
+                  auto& acc_off = acc.log_start_offsets[t][p];
                   acc_off = std::max(acc_off, o);
               }
           }

--- a/src/v/kafka/server/consumer_group_lag_metrics_rpc_types.h
+++ b/src/v/kafka/server/consumer_group_lag_metrics_rpc_types.h
@@ -36,16 +36,22 @@ struct partition_offsets_request
 struct partition_offsets_reply
   : serde::envelope<
       partition_offsets_reply,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
     using offsets = chunked_hash_map<
       model::topic,
       chunked_hash_map<model::partition_id, kafka::offset>>;
+    // High watermark per partition.
     offsets data;
+    // Kafka log start offset (first readable offset) per partition. Populated
+    // alongside `data` by the partition leader. Empty when the reply comes from
+    // an older node that predates this field, in which case lag is computed
+    // without clamping the committed offset.
+    offsets log_start_offsets;
 
-    auto serde_fields() { return std::tie(data); }
+    auto serde_fields() { return std::tie(data, log_start_offsets); }
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -2087,8 +2087,23 @@ ss::future<> group_manager::collect_consumer_lag_metrics() {
                 if (partition_it == topic_it->second.end()) {
                     continue;
                 }
+                // Clamp committed offset to log_start_offset when known:
+                // a stale commit below log_start_offset means no consumable
+                // backlog exists and should not inflate lag. The log start
+                // offset is reported by the partition leader alongside the
+                // high watermark; it is absent when the leader runs an older
+                // version, in which case we fall back to the raw committed
+                // offset.
+                auto effective_offset = offset;
+                if (auto lso_topic_it = part_offsets.log_start_offsets.find(tp);
+                    lso_topic_it != part_offsets.log_start_offsets.end()) {
+                    if (auto lso_it = lso_topic_it->second.find(partition);
+                        lso_it != lso_topic_it->second.end()) {
+                        effective_offset = std::max(offset, lso_it->second);
+                    }
+                }
                 lag part_lag{static_cast<lag>(
-                  std::max(partition_it->second() - offset(), 0L))};
+                  std::max(partition_it->second() - effective_offset(), 0L))};
                 lag_metrics.sum += part_lag;
                 lag_metrics.max = std::max(lag_metrics.max, part_lag);
             }

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -1189,6 +1189,194 @@ class ConsumerGroupTest(RedpandaTest):
         for consumer in consumers:
             consumer.close()
 
+    @cluster(num_nodes=3)
+    def test_group_lag_metrics_with_retention(self):
+        """
+        Verify that consumer group lag metrics are not inflated when the
+        committed offset falls below the partition's log start offset due to
+        retention.  After trim-prefix advances log_start_offset past the
+        committed offset the lag gauges should report zero, not
+        hwm - committed_offset.
+        """
+        lag_collection_interval = 5
+        topic = "test-lag-retention"
+        group = "test-lag-retention-group"
+        partition = 0
+        msg_count = 1000
+        consume_count = 500
+
+        self.redpanda.set_cluster_config(
+            {
+                "enable_consumer_group_metrics": ["consumer_lag"],
+                "consumer_group_lag_collection_interval_sec": lag_collection_interval,
+            }
+        )
+
+        rpk = RpkTool(self.redpanda)
+
+        rpk.create_topic(topic, partitions=1, replicas=3)
+
+        producer = Producer({"bootstrap.servers": self.redpanda.brokers()})
+        for i in range(msg_count):
+            producer.produce(topic, value=f"msg-{i}")
+        producer.flush()
+
+        consumer = Consumer(
+            {
+                "bootstrap.servers": self.redpanda.brokers(),
+                "group.id": group,
+                "auto.offset.reset": "earliest",
+                "enable.auto.commit": False,
+            }
+        )
+        consumer.subscribe([topic])
+        consumed = consumer.consume(num_messages=consume_count, timeout=30)
+        assert len(consumed) == consume_count, (
+            f"Expected {consume_count} messages, got {len(consumed)}"
+        )
+        consumer.commit(asynchronous=False)
+        consumer.close()
+
+        def get_group_lag(metric_name) -> float | None:
+            samples = self.redpanda.metrics_samples(
+                [metric_name],
+                self.redpanda.started_nodes(),
+                MetricsEndpoint.PUBLIC_METRICS,
+            )
+            if samples is None:
+                return None
+            group_samples = (
+                samples[metric_name].label_filter({"redpanda_group": group}).samples
+            )
+            if not group_samples:
+                return None
+            return max(s.value for s in group_samples)
+
+        # Before trim-prefix: committed=500, hwm=1000, lag should be ~500.
+        # This confirms metrics are being collected before we apply the fix
+        # scenario, so the post-trim assertion is meaningful.
+        wait_until(
+            lambda: get_group_lag("redpanda_kafka_consumer_group_lag_max") is not None
+            and get_group_lag("redpanda_kafka_consumer_group_lag_max") > 0,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Expected lag_max > 0 after commit but before trim-prefix",
+        )
+
+        # Advance log_start_offset past all produced messages so the committed
+        # offset becomes stale: lag = max(hwm - max(committed, lso), 0) = 0.
+        rpk.trim_prefix(topic, msg_count, partitions=[partition])
+
+        # Wait for the metric to reflect the trim — up to two extra intervals.
+        wait_until(
+            lambda: get_group_lag("redpanda_kafka_consumer_group_lag_max") == 0
+            and get_group_lag("redpanda_kafka_consumer_group_lag_sum") == 0,
+            timeout_sec=lag_collection_interval * 2 + 30,
+            backoff_sec=lag_collection_interval,
+            err_msg=(
+                f"Expected lag_max=0 and lag_sum=0 after trim-prefix past "
+                f"committed offset, got lag_max="
+                f"{get_group_lag('redpanda_kafka_consumer_group_lag_max')}, "
+                f"lag_sum="
+                f"{get_group_lag('redpanda_kafka_consumer_group_lag_sum')}"
+            ),
+        )
+
+    @cluster(num_nodes=3)
+    def test_group_lag_metrics_partial_retention(self):
+        """
+        Verify that when retention advances log_start_offset past the committed
+        offset but readable data still remains (log_start_offset < hwm), the lag
+        reflects the readable backlog (hwm - log_start_offset) rather than the
+        stale hwm - committed_offset or a fully-clamped zero.
+
+        This is the case that distinguishes the fix from a clamp-everything-to-
+        zero bug: trim-prefix lands between the committed offset and the hwm.
+        """
+        lag_collection_interval = 5
+        topic = "test-lag-partial-retention"
+        group = "test-lag-partial-retention-group"
+        partition = 0
+        msg_count = 1000
+        consume_count = 500
+        trim_offset = 700
+
+        self.redpanda.set_cluster_config(
+            {
+                "enable_consumer_group_metrics": ["consumer_lag"],
+                "consumer_group_lag_collection_interval_sec": lag_collection_interval,
+            }
+        )
+
+        rpk = RpkTool(self.redpanda)
+
+        rpk.create_topic(topic, partitions=1, replicas=3)
+
+        producer = Producer({"bootstrap.servers": self.redpanda.brokers()})
+        for i in range(msg_count):
+            producer.produce(topic, value=f"msg-{i}")
+        producer.flush()
+
+        consumer = Consumer(
+            {
+                "bootstrap.servers": self.redpanda.brokers(),
+                "group.id": group,
+                "auto.offset.reset": "earliest",
+                "enable.auto.commit": False,
+            }
+        )
+        consumer.subscribe([topic])
+        consumed = consumer.consume(num_messages=consume_count, timeout=30)
+        assert len(consumed) == consume_count, (
+            f"Expected {consume_count} messages, got {len(consumed)}"
+        )
+        consumer.commit(asynchronous=False)
+        consumer.close()
+
+        def get_group_lag(metric_name) -> float | None:
+            samples = self.redpanda.metrics_samples(
+                [metric_name],
+                self.redpanda.started_nodes(),
+                MetricsEndpoint.PUBLIC_METRICS,
+            )
+            if samples is None:
+                return None
+            group_samples = (
+                samples[metric_name].label_filter({"redpanda_group": group}).samples
+            )
+            if not group_samples:
+                return None
+            return max(s.value for s in group_samples)
+
+        # Trim-prefix to an offset between the committed offset (500) and the
+        # hwm (1000). The committed offset is now stale, but data in
+        # [trim_offset, hwm) is still consumable.
+        responses = rpk.trim_prefix(topic, trim_offset, partitions=[partition])
+        assert len(responses) == 1, f"Expected 1 trim response, got {responses}"
+        new_start_offset = responses[0].new_start_offset
+        assert new_start_offset == trim_offset, (
+            f"Expected new start offset {trim_offset}, got {new_start_offset}"
+        )
+
+        # lag = max(hwm - max(committed, log_start_offset), 0)
+        #     = max(1000 - max(500, 700), 0) = 300
+        expected_lag = msg_count - new_start_offset
+
+        wait_until(
+            lambda: get_group_lag("redpanda_kafka_consumer_group_lag_max")
+            == expected_lag
+            and get_group_lag("redpanda_kafka_consumer_group_lag_sum") == expected_lag,
+            timeout_sec=lag_collection_interval * 2 + 30,
+            backoff_sec=lag_collection_interval,
+            err_msg=(
+                f"Expected lag_max={expected_lag} and lag_sum={expected_lag} "
+                f"after partial trim-prefix, got lag_max="
+                f"{get_group_lag('redpanda_kafka_consumer_group_lag_max')}, "
+                f"lag_sum="
+                f"{get_group_lag('redpanda_kafka_consumer_group_lag_sum')}"
+            ),
+        )
+
 
 @dataclass
 class OffsetAndMetadata:


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30822 to v25.2.x.

Closes #30871.

## Approach

This is **not** a direct cherry-pick. The upstream fix is built on dev's lag-collection design, which does not exist on v25.2.x, so a verbatim backport does not fit:

- **dev / v25.3.x:** consumer-group lag is computed on the coordinator from the **cluster health report**. To get the Kafka log start offset there, dev extracts the offset math into cluster-layer free functions (`partition_kafka_offsets.{h,cc}`) and adds a `log_start_offset` field to `partition_status` (serde bump). Three commits, spanning the `cluster` and `kafka` layers.
- **v25.2.x:** lag is computed on the **partition leader** via `consumer_group_lag_metrics_frontend`, which already reads the high watermark straight off the `partition_proxy`.

Because the leader-side frontend path already has the partition in hand, the fix is implemented natively for this branch as a **single self-contained commit** in the Kafka layer: the log start offset is carried back through the same `partition_offsets_reply` (via `partition_proxy::start_offset()`) alongside the high watermark, and the committed offset is clamped `effective = max(committed, log_start_offset)` before computing lag.

This avoids backporting machinery that v25.2.x does not need:
- **No `partition_status` serde change** (dev's `4 → 7` / three-field bump is dropped).
- **No cluster-layer extraction** of the Kafka offset logic and **no `replicated_partition` churn** — `cluster/` and `kafka/data/` stay byte-identical to baseline.
- **No additional work required on dev.** Dev keeps its own (health-report-based) implementation; this is an independent, branch-native fix.

## Changes

| File | Change |
|------|--------|
| `consumer_group_lag_metrics_rpc_types.h` | `partition_offsets_reply` gains a `log_start_offsets` map (serde `version<0> → <1>`, `compat_version` unchanged — appended field). |
| `consumer_group_lag_metrics_frontend.cc` | Leader populates `log_start_offsets` from `partition_proxy::start_offset()`; merged through both reduces. |
| `group_manager.cc` | Clamp committed offset up to the reply's `log_start_offset` before computing lag. Empty (older leader) → previous behaviour. |
| `consumer_group_test.py` | Two ducktape tests (see below). |

### Backwards compatibility
`partition_offsets_reply` is an internal RPC type. The new field is appended with `compat_version` unchanged: a new coordinator reading an old leader's reply gets an empty `log_start_offsets` map (falls back to the unclamped lag), and an old coordinator ignores the trailing field — safe across a rolling upgrade.

## Tests
- `test_group_lag_metrics_with_retention`: commits at 500, trims past 1000 (lso == hwm); asserts `lag_max`/`lag_sum` drop to 0.
- `test_group_lag_metrics_partial_retention`: commits at 500, trims to 700 (committed < lso < hwm); asserts lag reflects the readable backlog `hwm - lso` (300), distinguishing the fix from a clamp-everything-to-zero bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)