### PR TITLE
[CORE-16425] consumer_group_test: exclude shard label from hwm grouping

### DIFF
--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -1037,7 +1037,18 @@ class ConsumerGroupTest(RedpandaTest):
             hwm_by_tp = {}
             for s in metrics["redpanda_kafka_max_offset"].samples:
                 if s.labels["redpanda_topic"] in topics:
-                    key = tuple((k, v) for k, v in s.labels.items() if k != "node")
+                    # Group by partition identity only. Exclude "node" and
+                    # "shard": redpanda_kafka_max_offset is emitted per replica
+                    # and carries a per-shard "shard" label, and each broker
+                    # assigns a partition to a shard independently, so a single
+                    # partition's replicas otherwise spread across distinct
+                    # (node, shard) pairs and inflate the count past
+                    # partition_count.
+                    key = tuple(
+                        (k, v)
+                        for k, v in s.labels.items()
+                        if k not in ("node", "shard")
+                    )
                     hwm_by_tp.setdefault(key, []).append(s.value)
             return [max(hwm) for hwm in hwm_by_tp.values()]
 


### PR DESCRIPTION
test_group_lag_metrics groups redpanda_kafka_max_offset samples by
their full label set minus "node", expecting one group per partition.
This relied on the metric being aggregated across shards.

The metric is now emitted with a per-shard "shard" label (shard
aggregation was [dropped](https://github.com/redpanda-data/redpanda/commit/0c950c45ff98cdddcae2c1efbdb6496e916338e6) to avoid an oversized allocation in the metrics
aggregation path). Each broker maps a partition to a shard
independently, so a partition's replicas land on differing shards and
no longer collapse into a single group. hwm_len then overshoots
partition_count by a run-dependent amount (observed anywhere in
20..60), and hwm_sum double-counts the same high watermark, making the
test flaky.

Exclude "shard" alongside "node" so the grouping key reduces to the
partition identity (namespace, topic, partition). All replicas of a
partition collapse into one group again, restoring deterministic
hwm_len == partition_count and a correct hwm_sum, independent of shard
placement.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
