### PR TITLE
[CORE-16606]: relaxation of blocked writes for Schema Registry API based replication

### DIFF
--- a/src/v/cluster/cluster_link/frontend.cc
+++ b/src/v/cluster/cluster_link/frontend.cc
@@ -399,13 +399,25 @@ bool api_mode_shadows_context(
 }
 
 bool link_disables_schema_registry_writes(
-  const ::cluster_link::model::metadata& md, ppsr::write_source source) {
+  const ::cluster_link::model::metadata& md,
+  ppsr::write_source source,
+  std::string_view context) {
     switch (source) {
     case ppsr::write_source::client:
-        return link_shadows_schema_registry_topic(md)
-               || md.configuration.schema_registry_sync_cfg.api_mode()
-                    != nullptr;
+        // Topic-mode shadowing owns the whole _schemas topic, so it blocks
+        // every context.
+        if (link_shadows_schema_registry_topic(md)) {
+            return true;
+        }
+        // API-mode shadowing only blocks the contexts it mirrors, identified
+        // by source_filter/destination.
+        if (auto* api = md.configuration.schema_registry_sync_cfg.api_mode()) {
+            return api_mode_shadows_context(*api, context);
+        }
+        return false;
     case ppsr::write_source::schema_registry_sync:
+        // The sync importer writes to the local _schemas topic, which is only
+        // blocked under topic-mode shadowing.
         return link_shadows_schema_registry_topic(md);
     }
     __builtin_unreachable();
@@ -414,28 +426,39 @@ bool link_disables_schema_registry_writes(
 } // namespace
 
 bool frontend::schema_registry_shadowing_active() const {
-    return schema_registry_writes_disabled(ppsr::write_source::client);
+    if (!cluster_link_active()) {
+        return false;
+    }
+    auto link_ids = get_all_link_ids();
+    return std::ranges::any_of(link_ids, [this](id_t link_id) -> bool {
+        const auto md = find_link_by_id(link_id);
+        return md && link_shadows_schema_registry(*md);
+    });
 }
 
 bool frontend::schema_registry_writes_disabled(
-  ppsr::write_source source) const {
+  ppsr::write_source source, std::string_view context) const {
     if (!cluster_link_active()) {
         return false;
     }
 
     auto link_ids = get_all_link_ids();
-    return std::ranges::any_of(link_ids, [this, source](id_t link_id) -> bool {
-        const auto md = find_link_by_id(link_id);
-        if (!md) {
-            return false;
-        }
-        return link_disables_schema_registry_writes(*md, source);
-    });
+    return std::ranges::any_of(
+      link_ids, [this, source, context](id_t link_id) -> bool {
+          const auto md = find_link_by_id(link_id);
+          if (!md) {
+              return false;
+          }
+          return link_disables_schema_registry_writes(*md, source, context);
+      });
 }
 
 bool frontend::schema_registry_internal_topic_creation_blocked() const {
+    // Topic-creation blocking is context-independent: only topic-mode
+    // shadowing owns the local _schemas topic. The context argument is unused
+    // by the sync write source.
     return schema_registry_writes_disabled(
-      ppsr::write_source::schema_registry_sync);
+      ppsr::write_source::schema_registry_sync, ppsr::default_context());
 }
 
 ss::future<errc> frontend::do_mutation(

--- a/src/v/cluster/cluster_link/frontend.cc
+++ b/src/v/cluster/cluster_link/frontend.cc
@@ -342,29 +342,28 @@ bool link_shadows_schema_registry(const ::cluster_link::model::metadata& md) {
 bool filter_selects_source_context(
   const ::cluster_link::model::schema_registry_sync_config::source_filter&
     filter,
-  std::string_view source_context) {
+  const ppsr::context& source_context) {
+    // An empty filter selects every source context.
+    if (filter.contexts.empty() && filter.subjects.empty()) {
+        return true;
+    }
     if (
-      std::ranges::find(filter.contexts, source_context)
+      std::ranges::find(filter.contexts, source_context())
       != filter.contexts.end()) {
         return true;
     }
     return std::ranges::any_of(
-      filter.subjects, [source_context](const auto& subject) {
+      filter.subjects, [&source_context](const auto& subject) {
           const auto parsed = ppsr::context_subject::from_string(
             subject, ppsr::qualified_subjects_enabled::yes);
-          return std::string_view{parsed.ctx()} == source_context;
+          return parsed.ctx == source_context;
       });
 }
 
 bool api_mode_shadows_context(
   const ::cluster_link::model::schema_registry_sync_config::
     shadow_schema_registry_api& api,
-  std::string_view dest_context) {
-    // No filters
-    if (api.filter.contexts.empty() && api.filter.subjects.empty()) {
-        return true;
-    }
-
+  const ppsr::context& dest_context) {
     // Identity mapping: the destination context name equals the source name.
     if (!api.destination) {
         return filter_selects_source_context(api.filter, dest_context);
@@ -372,14 +371,14 @@ bool api_mode_shadows_context(
 
     return ss::visit(
       *api.destination,
-      [&api, dest_context](
+      [&api, &dest_context](
         const ::cluster_link::model::schema_registry_sync_config::
           identity_context_mapping&) {
           // Identity mapping: the destination context name equals the source
           // name.
           return filter_selects_source_context(api.filter, dest_context);
       },
-      [&api, dest_context](
+      [&api, &dest_context](
         const ::cluster_link::model::schema_registry_sync_config::
           exact_context_mapping& destination) {
           // Exact mapping: a destination context is owned only when some
@@ -389,8 +388,9 @@ bool api_mode_shadows_context(
           // destination name alone would over-block.
           for (const auto& [src_ctx, dst_ctx] : destination.mappings) {
               if (
-                dst_ctx == dest_context
-                && filter_selects_source_context(api.filter, src_ctx)) {
+                dest_context == dst_ctx
+                && filter_selects_source_context(
+                  api.filter, ppsr::context{src_ctx})) {
                   return true;
               }
           }
@@ -398,29 +398,19 @@ bool api_mode_shadows_context(
       });
 }
 
-bool link_disables_schema_registry_writes(
-  const ::cluster_link::model::metadata& md,
-  ppsr::write_source source,
-  std::string_view context) {
-    switch (source) {
-    case ppsr::write_source::client:
-        // Topic-mode shadowing owns the whole _schemas topic, so it blocks
-        // every context.
-        if (link_shadows_schema_registry_topic(md)) {
-            return true;
-        }
-        // API-mode shadowing only blocks the contexts it mirrors, identified
-        // by source_filter/destination.
-        if (auto* api = md.configuration.schema_registry_sync_cfg.api_mode()) {
-            return api_mode_shadows_context(*api, context);
-        }
-        return false;
-    case ppsr::write_source::schema_registry_sync:
-        // The sync importer writes to the local _schemas topic, which is only
-        // blocked under topic-mode shadowing.
-        return link_shadows_schema_registry_topic(md);
+bool link_disables_client_writes(
+  const ::cluster_link::model::metadata& md, const ppsr::context& context) {
+    // Topic-mode shadowing owns the whole _schemas topic, so it blocks every
+    // context.
+    if (link_shadows_schema_registry_topic(md)) {
+        return true;
     }
-    __builtin_unreachable();
+    // API-mode shadowing only blocks the contexts it mirrors, identified by
+    // source_filter/destination.
+    if (auto* api = md.configuration.schema_registry_sync_cfg.api_mode()) {
+        return api_mode_shadows_context(*api, context);
+    }
+    return false;
 }
 
 } // namespace
@@ -436,29 +426,31 @@ bool frontend::schema_registry_shadowing_active() const {
     });
 }
 
-bool frontend::schema_registry_writes_disabled(
-  ppsr::write_source source, std::string_view context) const {
+bool frontend::schema_registry_client_writes_disabled(
+  std::string_view context) const {
+    if (!cluster_link_active()) {
+        return false;
+    }
+
+    ppsr::context local_context{ss::sstring{context}};
+    auto link_ids = get_all_link_ids();
+    return std::ranges::any_of(
+      link_ids, [this, &local_context](id_t link_id) -> bool {
+          const auto md = find_link_by_id(link_id);
+          return md && link_disables_client_writes(*md, local_context);
+      });
+}
+
+bool frontend::schema_registry_local_topic_writes_disabled() const {
     if (!cluster_link_active()) {
         return false;
     }
 
     auto link_ids = get_all_link_ids();
-    return std::ranges::any_of(
-      link_ids, [this, source, context](id_t link_id) -> bool {
-          const auto md = find_link_by_id(link_id);
-          if (!md) {
-              return false;
-          }
-          return link_disables_schema_registry_writes(*md, source, context);
-      });
-}
-
-bool frontend::schema_registry_internal_topic_creation_blocked() const {
-    // Topic-creation blocking is context-independent: only topic-mode
-    // shadowing owns the local _schemas topic. The context argument is unused
-    // by the sync write source.
-    return schema_registry_writes_disabled(
-      ppsr::write_source::schema_registry_sync, ppsr::default_context());
+    return std::ranges::any_of(link_ids, [this](id_t link_id) -> bool {
+        const auto md = find_link_by_id(link_id);
+        return md && link_shadows_schema_registry_topic(*md);
+    });
 }
 
 ss::future<errc> frontend::do_mutation(

--- a/src/v/cluster/cluster_link/frontend.cc
+++ b/src/v/cluster/cluster_link/frontend.cc
@@ -27,6 +27,7 @@
 #include "ssx/when_all.h"
 
 #include <algorithm>
+#include <variant>
 
 namespace cluster::cluster_link {
 
@@ -331,6 +332,70 @@ bool link_shadows_schema_registry_topic(
     }
     // Topic mode owns _schemas even before the mirror topic appears.
     return md.configuration.schema_registry_sync_cfg.is_topic_mode();
+}
+
+bool link_shadows_schema_registry(const ::cluster_link::model::metadata& md) {
+    return link_shadows_schema_registry_topic(md)
+           || md.configuration.schema_registry_sync_cfg.api_mode() != nullptr;
+}
+
+bool filter_selects_source_context(
+  const ::cluster_link::model::schema_registry_sync_config::source_filter&
+    filter,
+  std::string_view source_context) {
+    if (
+      std::ranges::find(filter.contexts, source_context)
+      != filter.contexts.end()) {
+        return true;
+    }
+    return std::ranges::any_of(
+      filter.subjects, [source_context](const auto& subject) {
+          const auto parsed = ppsr::context_subject::from_string(
+            subject, ppsr::qualified_subjects_enabled::yes);
+          return std::string_view{parsed.ctx()} == source_context;
+      });
+}
+
+bool api_mode_shadows_context(
+  const ::cluster_link::model::schema_registry_sync_config::
+    shadow_schema_registry_api& api,
+  std::string_view dest_context) {
+    // No filters
+    if (api.filter.contexts.empty() && api.filter.subjects.empty()) {
+        return true;
+    }
+
+    // Identity mapping: the destination context name equals the source name.
+    if (!api.destination) {
+        return filter_selects_source_context(api.filter, dest_context);
+    }
+
+    return ss::visit(
+      *api.destination,
+      [&api, dest_context](
+        const ::cluster_link::model::schema_registry_sync_config::
+          identity_context_mapping&) {
+          // Identity mapping: the destination context name equals the source
+          // name.
+          return filter_selects_source_context(api.filter, dest_context);
+      },
+      [&api, dest_context](
+        const ::cluster_link::model::schema_registry_sync_config::
+          exact_context_mapping& destination) {
+          // Exact mapping: a destination context is owned only when some
+          // filter-selected source maps to it. Both conditions matter -- a
+          // mapping whose source is not selected by the filter is inert
+          // (nothing is mirrored into its destination), so matching the
+          // destination name alone would over-block.
+          for (const auto& [src_ctx, dst_ctx] : destination.mappings) {
+              if (
+                dst_ctx == dest_context
+                && filter_selects_source_context(api.filter, src_ctx)) {
+                  return true;
+              }
+          }
+          return false;
+      });
 }
 
 bool link_disables_schema_registry_writes(

--- a/src/v/cluster/cluster_link/frontend.h
+++ b/src/v/cluster/cluster_link/frontend.h
@@ -27,6 +27,8 @@
 
 #include <seastar/core/sharded.hh>
 
+#include <string_view>
+
 namespace cluster::cluster_link {
 class frontend : public ss::peering_sharded_service<frontend> {
     using cluster_link_cmd = std::variant<
@@ -147,9 +149,14 @@ public:
     /// True if any Schema Registry shadowing mode is active.
     bool schema_registry_shadowing_active() const;
 
-    /// True if Schema Registry writes from this source must be rejected.
+    /// True if a Schema Registry write from this source to the given context
+    /// must be rejected. With API-mode shadowing, only contexts owned by the
+    /// mirroring (per source_filter/destination) are blocked; topic-mode
+    /// shadowing blocks every context. The context is identified by name (the
+    /// underlying value of pandaproxy::schema_registry::context).
     bool schema_registry_writes_disabled(
-      pandaproxy::schema_registry::write_source) const;
+      pandaproxy::schema_registry::write_source,
+      std::string_view context) const;
 
     /// True if this node must not create a local _schemas topic because
     /// topic-mode shadowing owns it.

--- a/src/v/cluster/cluster_link/frontend.h
+++ b/src/v/cluster/cluster_link/frontend.h
@@ -21,7 +21,6 @@
 #include "features/feature_table.h"
 #include "features/fwd.h"
 #include "model/timeout_clock.h"
-#include "pandaproxy/schema_registry/fwd.h"
 #include "rpc/connection_cache.h"
 #include "rpc/fwd.h"
 
@@ -149,18 +148,18 @@ public:
     /// True if any Schema Registry shadowing mode is active.
     bool schema_registry_shadowing_active() const;
 
-    /// True if a Schema Registry write from this source to the given context
-    /// must be rejected. With API-mode shadowing, only contexts owned by the
-    /// mirroring (per source_filter/destination) are blocked; topic-mode
-    /// shadowing blocks every context. The context is identified by name (the
-    /// underlying value of pandaproxy::schema_registry::context).
-    bool schema_registry_writes_disabled(
-      pandaproxy::schema_registry::write_source,
-      std::string_view context) const;
+    /// True if a client Schema Registry write to the given context must be
+    /// rejected. With API-mode shadowing, only contexts owned by the mirroring
+    /// (per source_filter/destination) are blocked; topic-mode shadowing
+    /// blocks every context. The context is identified by name (the underlying
+    /// value of pandaproxy::schema_registry::context).
+    bool schema_registry_client_writes_disabled(std::string_view context) const;
 
-    /// True if this node must not create a local _schemas topic because
-    /// topic-mode shadowing owns it.
-    bool schema_registry_internal_topic_creation_blocked() const;
+    /// True if a write to the local _schemas topic must be rejected. Covers
+    /// both the internal sync importer and _schemas topic creation; it is
+    /// context-independent because only topic-mode shadowing owns the local
+    /// topic.
+    bool schema_registry_local_topic_writes_disabled() const;
 
 private:
     ss::future<errc>

--- a/src/v/cluster/cluster_link/tests/BUILD
+++ b/src/v/cluster/cluster_link/tests/BUILD
@@ -42,6 +42,38 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "shadow_link_write_blocking",
+    timeout = "short",
+    srcs = [
+        "shadow_link_write_blocking.cc",
+    ],
+    cpu = 1,
+    deps = [
+        ":test_lib",
+        "//src/v/base",
+        "//src/v/cluster",
+        "//src/v/cluster:client_quota_backend",
+        "//src/v/cluster:cluster_link_table",
+        "//src/v/cluster:cluster_link_types",
+        "//src/v/cluster:cluster_recovery_table",
+        "//src/v/cluster:commands",
+        "//src/v/cluster:controller_log_limiter",
+        "//src/v/cluster:data_migration_table",
+        "//src/v/cluster:feature_backend",
+        "//src/v/cluster:notification",
+        "//src/v/cluster:plugin_backend",
+        "//src/v/cluster_link/model",
+        "//src/v/model",
+        "//src/v/raft",
+        "//src/v/test_utils:gtest",
+        "//src/v/utils:unresolved_address",
+        "//src/v/utils:uuid",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "frontend_validation_test",
     timeout = "short",
     srcs = [

--- a/src/v/cluster/cluster_link/tests/shadow_link_write_blocking.cc
+++ b/src/v/cluster/cluster_link/tests/shadow_link_write_blocking.cc
@@ -1,0 +1,382 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "base/vassert.h"
+#include "cluster/cluster_link/frontend.h"
+#include "cluster/cluster_link/table.h"
+#include "cluster/cluster_link/tests/utils.h"
+#include "cluster_link/model/types.h"
+#include "model/fundamental.h"
+#include "model/namespace.h"
+#include "test_utils/test.h"
+#include "utils/unresolved_address.h"
+#include "utils/uuid.h"
+
+#include <gtest/gtest.h>
+
+namespace cluster::cluster_link {
+
+namespace clm = ::cluster_link::model;
+
+// Exercises the write-protection decision at the level of
+// cluster_link::frontend, driven directly off a sharded<table> populated with
+// link metadata. The decision logic (frontend -> api_mode_shadows_context ->
+// filter_selects_source_context) runs against real metadata without booting a
+// node: the frontend is constructed with only the table dependency, since the
+// write-blocking queries touch nothing else.
+class shadow_link_write_blocking_test : public seastar_test {
+public:
+    ss::future<> SetUpAsync() override {
+        co_await _table.start();
+        _frontend = std::make_unique<frontend>(
+          model::node_id{1},
+          /*leaders=*/nullptr,
+          &_table.local(),
+          /*controller=*/nullptr,
+          /*connections=*/nullptr,
+          /*features=*/nullptr,
+          /*as=*/nullptr);
+    }
+
+    ss::future<> TearDownAsync() override {
+        _frontend.reset();
+        co_await _table.stop();
+    }
+
+    static clm::metadata
+    make_base_metadata(clm::name_t name = clm::name_t{"sr-shadow"}) {
+        return clm::metadata{
+          .name = std::move(name),
+          .uuid = clm::uuid_t{::uuid_t::create()},
+          .connection = clm::connection_config{
+            .bootstrap_servers = {net::unresolved_address{"localhost", 9092}}}};
+    }
+
+    // Builds base metadata carrying a _schemas mirror topic in the given
+    // status, to exercise the mirror-topic branch of topic-mode shadowing
+    // (where the failover status decides whether the local topic is writable).
+    static clm::metadata
+    make_schemas_mirror_link(clm::mirror_topic_status status) {
+        auto md = make_base_metadata();
+        testing::set_link_mirror_topics(
+          md,
+          model::schema_registry_internal_tp.topic,
+          status,
+          model::schema_registry_internal_tp.topic);
+        return md;
+    }
+
+    // Applies an upsert command straight to the table, bypassing the
+    // controller/raft path. Re-upserting an existing link name overwrites it.
+    ss::future<> install_link(clm::metadata md) {
+        auto err = co_await _table.local().apply_update(
+          testing::create_upsert_command(
+            model::offset{++_latest_id}, std::move(md)));
+        vassert(!err, "Failed to install link: {}", err.message());
+    }
+
+    // Installs a Schema Registry shadow link with the given sync mode.
+    ss::future<> install_shadow_link(auto sync_mode) {
+        auto md = make_base_metadata();
+        md.configuration.schema_registry_sync_cfg.sync_mode = std::move(
+          sync_mode);
+        co_await install_link(std::move(md));
+    }
+
+    frontend& fe() { return *_frontend; }
+
+    bool client_write_blocked(std::string_view ctx) {
+        return _frontend->schema_registry_client_writes_disabled(ctx);
+    }
+
+    bool sync_write_blocked() {
+        return _frontend->schema_registry_local_topic_writes_disabled();
+    }
+
+    ss::sharded<table> _table;
+    std::unique_ptr<frontend> _frontend;
+    int64_t _latest_id{0};
+};
+
+// Identity mapping: a destination context is owned when the filter selects the
+// same source context, whether named directly or implied by a selected subject.
+TEST_F_CORO(
+  shadow_link_write_blocking_test, api_shadow_blocks_only_owned_context) {
+    // Baseline: with no shadow link, nothing is blocked.
+    EXPECT_FALSE(fe().schema_registry_shadowing_active());
+    EXPECT_FALSE(client_write_blocked(".prod"));
+
+    clm::schema_registry_sync_config::shadow_schema_registry_api api;
+    api.source_url = "http://schema-registry.example.com:8081";
+    api.filter.contexts = {".prod"};
+    // Subjects also select their context: a qualified subject (".audit"), a
+    // context-only qualified subject (":.payments" -> ".payments"), and an
+    // unqualified subject (the default context ".").
+    api.filter.subjects = {":.audit:events", ":.payments", "orders-value"};
+    api.destination
+      = clm::schema_registry_sync_config::identity_context_mapping{};
+    co_await install_shadow_link(std::move(api));
+
+    EXPECT_TRUE(fe().schema_registry_shadowing_active());
+
+    // Owned via the filter, directly or through a selected subject's context.
+    EXPECT_TRUE(client_write_blocked(".prod"));
+    EXPECT_TRUE(client_write_blocked(".audit"));
+    EXPECT_TRUE(client_write_blocked(".payments"));
+    EXPECT_TRUE(client_write_blocked("."));
+    // Not selected by anything in the filter.
+    EXPECT_FALSE(client_write_blocked(".staging"));
+
+    // Sync (import) writes are never blocked under API-mode shadowing, even for
+    // an owned context: that is how the mirroring populates the destination.
+    EXPECT_FALSE(sync_write_blocked());
+}
+
+// Exact mapping: a destination context is owned when a selected source context
+// maps to it. Blocking follows the destination name, not the source name.
+TEST_F_CORO(
+  shadow_link_write_blocking_test, api_shadow_blocks_remapped_destination) {
+    clm::schema_registry_sync_config::exact_context_mapping exact;
+    exact.mappings.emplace(".prod", ".prod-mirror");
+
+    clm::schema_registry_sync_config::shadow_schema_registry_api api;
+    api.source_url = "http://schema-registry.example.com:8081";
+    api.filter.contexts = {".prod"};
+    api.destination = std::move(exact);
+    co_await install_shadow_link(std::move(api));
+
+    // The mapped destination ".prod-mirror" is owned.
+    EXPECT_TRUE(client_write_blocked(".prod-mirror"));
+    // The source-named ".prod" is not a local destination, so it is writable.
+    EXPECT_FALSE(client_write_blocked(".prod"));
+    EXPECT_FALSE(client_write_blocked(".staging"));
+}
+
+// Exact mapping: a mapping whose source context is not selected by the filter
+// is inert -- nothing is mirrored into its destination, so that destination
+// stays writable. Ownership requires both the destination name to match and the
+// source to be selected by the filter.
+TEST_F_CORO(
+  shadow_link_write_blocking_test, api_shadow_ignores_unfiltered_mapping) {
+    clm::schema_registry_sync_config::exact_context_mapping exact;
+    exact.mappings.emplace(".prod", ".prod-mirror");
+    // ".staging" maps to ".staging-mirror" but is not selected by the filter.
+    exact.mappings.emplace(".staging", ".staging-mirror");
+
+    clm::schema_registry_sync_config::shadow_schema_registry_api api;
+    api.source_url = "http://schema-registry.example.com:8081";
+    api.filter.contexts = {".prod"};
+    api.destination = std::move(exact);
+    co_await install_shadow_link(std::move(api));
+
+    // The filter-selected source ".prod" makes its destination owned.
+    EXPECT_TRUE(client_write_blocked(".prod-mirror"));
+    // ".staging-mirror" is also a mapping destination, but its source
+    // ".staging" is not in the filter, so the mapping is inert and the
+    // destination stays writable.
+    EXPECT_FALSE(client_write_blocked(".staging-mirror"));
+}
+
+// Topic-mode shadowing owns the entire local _schemas topic, so it blocks every
+// context regardless of any source filter, and also blocks the sync importer
+// and internal topic creation.
+TEST_F_CORO(
+  shadow_link_write_blocking_test, topic_shadow_blocks_every_context) {
+    co_await install_shadow_link(
+      clm::schema_registry_sync_config::shadow_entire_schema_registry{});
+
+    EXPECT_TRUE(fe().schema_registry_shadowing_active());
+
+    // Every context is blocked for client writes, owned or not.
+    EXPECT_TRUE(client_write_blocked(".prod"));
+    EXPECT_TRUE(client_write_blocked(".staging"));
+    EXPECT_TRUE(client_write_blocked("."));
+
+    // Unlike API mode, the sync importer and internal _schemas topic creation
+    // are blocked too, because topic-mode owns the topic itself.
+    EXPECT_TRUE(sync_write_blocked());
+    EXPECT_TRUE(fe().schema_registry_local_topic_writes_disabled());
+}
+
+// An empty source filter mirrors the whole source registry, so API-mode
+// shadowing owns (and blocks client writes to) every context.
+TEST_F_CORO(
+  shadow_link_write_blocking_test, api_shadow_empty_filter_blocks_all) {
+    clm::schema_registry_sync_config::shadow_schema_registry_api api;
+    api.source_url = "http://schema-registry.example.com:8081";
+    // No contexts and no subjects -> the whole source registry is mirrored.
+    api.destination
+      = clm::schema_registry_sync_config::identity_context_mapping{};
+    co_await install_shadow_link(std::move(api));
+
+    EXPECT_TRUE(client_write_blocked("."));
+    EXPECT_TRUE(client_write_blocked(".prod"));
+    EXPECT_TRUE(client_write_blocked(".staging"));
+
+    // Still API mode, so the sync importer and internal _schemas topic creation
+    // are not blocked, even though every context is owned for client writes.
+    EXPECT_FALSE(sync_write_blocked());
+    EXPECT_FALSE(fe().schema_registry_local_topic_writes_disabled());
+}
+
+// No destination set falls back to identity mapping: a destination context is
+// owned exactly when the filter selects the same source context. Exercises the
+// `!destination` branch, which is distinct from an explicit identity mapping.
+TEST_F_CORO(
+  shadow_link_write_blocking_test, api_shadow_unset_destination_is_identity) {
+    clm::schema_registry_sync_config::shadow_schema_registry_api api;
+    api.source_url = "http://schema-registry.example.com:8081";
+    api.filter.contexts = {".prod"};
+    // destination left unset (std::nullopt).
+    co_await install_shadow_link(std::move(api));
+
+    EXPECT_TRUE(client_write_blocked(".prod"));
+    EXPECT_FALSE(client_write_blocked(".staging"));
+}
+
+// An empty filter selects every source context, but an exact mapping is
+// exhaustive: only the destinations it names are mirrored, so ownership is
+// limited to those destinations even when the filter selects all sources.
+TEST_F_CORO(
+  shadow_link_write_blocking_test,
+  api_shadow_empty_filter_blocks_only_mapped_destinations) {
+    clm::schema_registry_sync_config::exact_context_mapping exact;
+    exact.mappings.emplace(".prod", ".prod-mirror");
+
+    clm::schema_registry_sync_config::shadow_schema_registry_api api;
+    api.source_url = "http://schema-registry.example.com:8081";
+    // Empty filter (no contexts, no subjects).
+    api.destination = std::move(exact);
+    co_await install_shadow_link(std::move(api));
+
+    // Only the mapped destination is owned; the unmapped source name and
+    // unrelated contexts stay writable.
+    EXPECT_TRUE(client_write_blocked(".prod-mirror"));
+    EXPECT_FALSE(client_write_blocked(".prod"));
+    EXPECT_FALSE(client_write_blocked(".anything"));
+}
+
+// Exact mapping combined with a subject filter: a subject selects its source
+// context, and ownership then follows that source context's mapped destination.
+TEST_F_CORO(
+  shadow_link_write_blocking_test,
+  api_shadow_exact_mapping_with_subject_filter) {
+    clm::schema_registry_sync_config::exact_context_mapping exact;
+    exact.mappings.emplace(".payments", ".payments-mirror");
+
+    clm::schema_registry_sync_config::shadow_schema_registry_api api;
+    api.source_url = "http://schema-registry.example.com:8081";
+    // A context-only qualified subject (":.payments") selects the ".payments"
+    // source context.
+    api.filter.subjects = {":.payments"};
+    api.destination = std::move(exact);
+    co_await install_shadow_link(std::move(api));
+
+    // ".payments" is selected via the subject and maps to ".payments-mirror".
+    EXPECT_TRUE(client_write_blocked(".payments-mirror"));
+    // The source-named context and unrelated contexts stay writable.
+    EXPECT_FALSE(client_write_blocked(".payments"));
+    EXPECT_FALSE(client_write_blocked(".staging"));
+}
+
+// Two source contexts map to the same destination; the destination is owned as
+// long as at least one of those sources is selected by the filter.
+TEST_F_CORO(
+  shadow_link_write_blocking_test,
+  api_shadow_shared_destination_owned_if_any_source_selected) {
+    clm::schema_registry_sync_config::exact_context_mapping exact;
+    exact.mappings.emplace(".prod", ".shared");
+    exact.mappings.emplace(".staging", ".shared");
+
+    clm::schema_registry_sync_config::shadow_schema_registry_api api;
+    api.source_url = "http://schema-registry.example.com:8081";
+    // Only ".prod" is selected; ".staging" is not.
+    api.filter.contexts = {".prod"};
+    api.destination = std::move(exact);
+    co_await install_shadow_link(std::move(api));
+
+    // ".shared" is owned because the selected ".prod" maps to it, even though
+    // the other source (".staging") is not selected.
+    EXPECT_TRUE(client_write_blocked(".shared"));
+}
+
+// Topic-mode shadowing via a real _schemas mirror topic: while the mirror has
+// not yet failed over, it owns the local topic, so every client write and the
+// sync importer are blocked. Exercises the mirror-topic branch of
+// link_shadows_schema_registry_topic and the non-mutable arm of
+// is_topic_mutable across every pre-failover status.
+TEST_F_CORO(
+  shadow_link_write_blocking_test, topic_mirror_blocks_writes_before_failover) {
+    for (auto status : {
+           clm::mirror_topic_status::active,
+           clm::mirror_topic_status::failed,
+           clm::mirror_topic_status::paused,
+           clm::mirror_topic_status::failing_over,
+           clm::mirror_topic_status::promoting,
+         }) {
+        co_await install_link(make_schemas_mirror_link(status));
+        auto s = static_cast<int>(status);
+        EXPECT_TRUE(fe().schema_registry_shadowing_active()) << "status=" << s;
+        // Topic-mode owns the whole _schemas topic: every context is blocked.
+        EXPECT_TRUE(client_write_blocked(".prod")) << "status=" << s;
+        EXPECT_TRUE(client_write_blocked(".")) << "status=" << s;
+        // The sync importer and internal topic creation are blocked too.
+        EXPECT_TRUE(sync_write_blocked()) << "status=" << s;
+    }
+}
+
+// Relaxation after failover: once the _schemas mirror has failed over or been
+// promoted, the local topic is mutable again, so shadowing is no longer active
+// and neither client nor sync writes are blocked. Exercises the mutable arm of
+// is_topic_mutable.
+TEST_F_CORO(
+  shadow_link_write_blocking_test, topic_mirror_relaxes_writes_after_failover) {
+    for (auto status : {
+           clm::mirror_topic_status::failed_over,
+           clm::mirror_topic_status::promoted,
+         }) {
+        co_await install_link(make_schemas_mirror_link(status));
+        auto s = static_cast<int>(status);
+        // The link still exists (cluster linking is active), so this exercises
+        // the decision logic rather than the no-link early-out.
+        EXPECT_FALSE(fe().schema_registry_shadowing_active()) << "status=" << s;
+        EXPECT_FALSE(client_write_blocked(".prod")) << "status=" << s;
+        EXPECT_FALSE(sync_write_blocked()) << "status=" << s;
+    }
+}
+
+// Aggregation across links: write blocking is the OR over every link, so two
+// API-mode links owning different contexts each block their own, while a
+// context owned by neither stays writable.
+TEST_F_CORO(
+  shadow_link_write_blocking_test, multiple_links_each_block_their_context) {
+    auto make_api_link = [](clm::name_t name, ss::sstring owned_context) {
+        auto md = make_base_metadata(std::move(name));
+        clm::schema_registry_sync_config::shadow_schema_registry_api api;
+        api.source_url = "http://schema-registry.example.com:8081";
+        api.filter.contexts = {std::move(owned_context)};
+        api.destination
+          = clm::schema_registry_sync_config::identity_context_mapping{};
+        md.configuration.schema_registry_sync_cfg.sync_mode = std::move(api);
+        return md;
+    };
+
+    co_await install_link(make_api_link(clm::name_t{"link-a"}, ".prod"));
+    co_await install_link(make_api_link(clm::name_t{"link-b"}, ".staging"));
+
+    // Each link blocks its own owned context; the any_of across links covers
+    // both.
+    EXPECT_TRUE(client_write_blocked(".prod"));
+    EXPECT_TRUE(client_write_blocked(".staging"));
+    // A context owned by neither link stays writable.
+    EXPECT_FALSE(client_write_blocked(".audit"));
+}
+
+} // namespace cluster::cluster_link

--- a/src/v/pandaproxy/schema_registry/api.cc
+++ b/src/v/pandaproxy/schema_registry/api.cc
@@ -154,10 +154,11 @@ public:
       std::unique_ptr<cluster::controller>& c)
       : _controller(c) {}
 
-    writes_disabled_t writes_disabled(write_source source) const final {
+    writes_disabled_t
+    writes_disabled(write_source source, const context& ctx) const final {
         auto& frontend = _controller->get_cluster_link_frontend().local();
         return writes_disabled_t{
-          frontend.schema_registry_writes_disabled(source)};
+          frontend.schema_registry_writes_disabled(source, ctx())};
     }
 
 private:

--- a/src/v/pandaproxy/schema_registry/api.cc
+++ b/src/v/pandaproxy/schema_registry/api.cc
@@ -157,8 +157,15 @@ public:
     writes_disabled_t
     writes_disabled(write_source source, const context& ctx) const final {
         auto& frontend = _controller->get_cluster_link_frontend().local();
-        return writes_disabled_t{
-          frontend.schema_registry_writes_disabled(source, ctx())};
+        switch (source) {
+        case write_source::client:
+            return writes_disabled_t{
+              frontend.schema_registry_client_writes_disabled(ctx())};
+        case write_source::schema_registry_sync:
+            return writes_disabled_t{
+              frontend.schema_registry_local_topic_writes_disabled()};
+        }
+        __builtin_unreachable();
     }
 
 private:

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -285,7 +285,8 @@ seq_writer::write_subject_version(stored_schema schema) {
     co_return co_await sequenced_write(
       [&schema](model::offset write_at, seq_writer& seq) {
           return seq.do_write_subject_version(schema.share(), write_at);
-      });
+      },
+      schema.schema.sub().ctx);
 }
 
 ss::future<std::optional<sharded_store::insert_result>>
@@ -402,6 +403,7 @@ seq_writer::write_subject_version_imported(stored_schema schema) {
           return seq.do_write_subject_version_imported(
             schema.share(), write_at);
       },
+      schema.schema.sub().ctx,
       write_source::schema_registry_sync);
 }
 
@@ -454,11 +456,13 @@ ss::future<std::optional<bool>> seq_writer::do_write_config(
 
 ss::future<bool> seq_writer::write_config(
   context_subject ctx_sub, compatibility_level compat, write_source src) {
+    auto ctx = ctx_sub.ctx;
     return sequenced_write(
       [ctx_sub{std::move(ctx_sub)}, compat, src](
         model::offset write_at, seq_writer& seq) {
           return seq.do_write_config(ctx_sub, compat, write_at, src);
       },
+      std::move(ctx),
       src);
 }
 
@@ -497,10 +501,12 @@ seq_writer::do_delete_config(context_subject ctx_sub, write_source src) {
 
 ss::future<bool>
 seq_writer::delete_config(context_subject ctx_sub, write_source src) {
+    auto ctx = ctx_sub.ctx;
     return sequenced_write(
       [ctx_sub{std::move(ctx_sub)}, src](model::offset, seq_writer& seq) {
           return seq.do_delete_config(ctx_sub, src);
       },
+      std::move(ctx),
       src);
 }
 
@@ -586,11 +592,13 @@ ss::future<std::optional<bool>> seq_writer::do_write_mode(
 
 ss::future<bool> seq_writer::write_mode(
   context_subject ctx_sub, mode mode, force f, write_source src) {
+    auto ctx = ctx_sub.ctx;
     return sequenced_write(
       [ctx_sub{std::move(ctx_sub)}, mode, f, src](
         model::offset write_at, seq_writer& seq) {
           return seq.do_write_mode(ctx_sub, mode, f, write_at, src);
       },
+      std::move(ctx),
       src);
 }
 
@@ -625,11 +633,13 @@ ss::future<std::optional<bool>> seq_writer::do_delete_mode(
 
 ss::future<bool>
 seq_writer::delete_mode(context_subject ctx_sub, write_source src) {
+    auto ctx = ctx_sub.ctx;
     return sequenced_write(
       [ctx_sub{std::move(ctx_sub)},
        src](model::offset write_at, seq_writer& seq) {
           return seq.do_delete_mode(ctx_sub, write_at, src);
       },
+      std::move(ctx),
       src);
 }
 
@@ -663,10 +673,12 @@ seq_writer::do_delete_context(context ctx, model::offset write_at) {
 }
 
 ss::future<> seq_writer::delete_context(context ctx) {
+    auto ctx_copy = ctx;
     co_await sequenced_write(
       [ctx{std::move(ctx)}](model::offset write_at, seq_writer& seq) {
           return seq.do_delete_context(ctx, write_at);
-      });
+      },
+      std::move(ctx_copy));
 }
 
 /// Impermanent delete: update a version with is_deleted=true
@@ -714,11 +726,13 @@ ss::future<std::optional<bool>> seq_writer::do_delete_subject_version(
 
 ss::future<bool> seq_writer::delete_subject_version(
   context_subject sub, schema_version version, write_source src) {
+    auto ctx = sub.ctx;
     return sequenced_write(
       [sub{std::move(sub)}, version, src](
         model::offset write_at, seq_writer& seq) {
           return seq.do_delete_subject_version(sub, version, write_at, src);
       },
+      std::move(ctx),
       src);
 }
 
@@ -775,10 +789,12 @@ seq_writer::do_delete_subject_impermanent(
 ss::future<chunked_vector<schema_version>>
 seq_writer::delete_subject_impermanent(context_subject sub, write_source src) {
     vlog(srlog.debug, "delete_subject_impermanent sub={}", sub);
+    auto ctx = sub.ctx;
     return sequenced_write(
       [sub{std::move(sub)}, src](model::offset write_at, seq_writer& seq) {
           return seq.do_delete_subject_impermanent(sub, write_at, src);
       },
+      std::move(ctx),
       src);
 }
 
@@ -790,10 +806,12 @@ ss::future<chunked_vector<schema_version>> seq_writer::delete_subject_permanent(
   context_subject sub,
   std::optional<schema_version> version,
   write_source src) {
+    auto ctx = sub.ctx;
     return sequenced_write(
       [sub{std::move(sub)}, version, src](model::offset, seq_writer& seq) {
           return seq.delete_subject_permanent_inner(sub, version, src);
       },
+      std::move(ctx),
       src);
 }
 

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -33,7 +33,11 @@ public:
     sequence_state_checker& operator=(sequence_state_checker&&) = delete;
 
     using writes_disabled_t = ss::bool_class<struct writes_disabled_tag>;
-    virtual writes_disabled_t writes_disabled(write_source) const = 0;
+    /// True if a write from the given source to the given context must be
+    /// rejected. The context lets shadow linking block only the contexts owned
+    /// by an active mirroring, rather than the whole Schema Registry.
+    virtual writes_disabled_t
+    writes_disabled(write_source, const context&) const = 0;
 };
 
 using namespace std::chrono_literals;
@@ -171,8 +175,9 @@ private:
     /// Helper for write paths that use sequence+retry logic to synchronize
     /// multiple writing nodes.
     template<typename F>
-    auto sequenced_write(F f, write_source src = write_source::client) {
-        if (_state_checker->writes_disabled(src)) [[unlikely]] {
+    auto
+    sequenced_write(F f, context ctx, write_source src = write_source::client) {
+        if (_state_checker->writes_disabled(src, ctx)) [[unlikely]] {
             throw as_exception(writes_disabled());
         }
         auto base_backoff = _jitter.next_duration();

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -676,7 +676,7 @@ ss::future<> service::create_internal_topic() {
     if (
       _controller->get_cluster_link_frontend()
         .local()
-        .schema_registry_internal_topic_creation_blocked()) {
+        .schema_registry_local_topic_writes_disabled()) {
         throw std::runtime_error(
           "Shadow Linking actively mirroring schema "
           "registry topic.  Topic will not be created");

--- a/src/v/pandaproxy/schema_registry/test/utils.h
+++ b/src/v/pandaproxy/schema_registry/test/utils.h
@@ -23,7 +23,8 @@ public:
       , _sync_writes_disabled(sync_writes_disabled) {}
 
     writes_disabled_t writes_disabled(
-      pandaproxy::schema_registry::write_source source) const final {
+      pandaproxy::schema_registry::write_source source,
+      const pandaproxy::schema_registry::context&) const final {
         switch (source) {
         case pandaproxy::schema_registry::write_source::client:
             return _client_writes_disabled;

--- a/tests/rptest/tests/cluster_linking_schema_registry_write_blocking_test.py
+++ b/tests/rptest/tests/cluster_linking_schema_registry_write_blocking_test.py
@@ -1,0 +1,187 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.cluster import cluster
+from rptest.tests.cluster_linking_topic_syncing_test import (
+    ClusterLinkingSchemaRegistryBase,
+)
+from rptest.tests.schema_registry_test import SchemaRegistryRedpandaClient
+
+from ducktape.utils.util import wait_until
+
+import google.protobuf.field_mask_pb2
+import json
+
+
+class ClusterLinkingSchemaRegistryWriteBlocking(ClusterLinkingSchemaRegistryBase):
+    """
+    Verify granular Schema Registry client-write blocking under API-mode
+    shadowing: only the contexts selected by source_filter are write-protected
+    on the target, while writes to out-of-scope contexts still succeed.
+    """
+
+    def post_schema_to_context(
+        self,
+        sr_client: SchemaRegistryRedpandaClient,
+        context: str,
+        subject: str,
+        schema: str,
+    ):
+        """Post a schema to a context-scoped subject, returning the raw
+        response so the caller can assert on the status code."""
+        result_raw = sr_client.post_subjects_subject_versions(
+            subject=subject,
+            data=json.dumps({"schema": schema, "schemaType": "PROTOBUF"}),
+            base_path=f"contexts/{context}",
+        )
+        self.logger.debug(
+            f"post_schema_to_context {context}/{subject} result: {result_raw}"
+        )
+        return result_raw
+
+    def wait_for_context_write_blocked(
+        self,
+        sr_client: SchemaRegistryRedpandaClient,
+        context: str,
+        schema: str,
+    ):
+        """Poll client writes to `context` until one is blocked (HTTP 412).
+
+        Write protection activates asynchronously: update_link returns once the
+        controller accepts the update, but the Schema Registry serving node
+        applies the new link metadata on its own schedule. Each attempt uses a
+        fresh subject because registering a subject+schema that already exists
+        short-circuits in the handler and returns 200 without ever consulting
+        the write-protection check -- so reusing one subject could register
+        before the block activates and then never observe it."""
+        attempt = 0
+
+        def blocked() -> bool:
+            nonlocal attempt
+            attempt += 1
+            return (
+                self.post_schema_to_context(
+                    sr_client, context, f"probe-{attempt}-value", schema
+                ).status_code
+                == 412
+            )
+
+        wait_until(
+            blocked,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"client write to context '{context}' never became blocked (412)",
+        )
+
+    @cluster(num_nodes=6)
+    def test_schema_registry_api_granular_write_blocking(self):
+        """
+        With API-mode Schema Registry shadowing, only the contexts selected by
+        source_filter are write-protected on the target. Writes to contexts
+        outside the filter must still succeed.
+
+        The sync task does not need to be running for this test: the write
+        protection policy is a pure function of the link configuration, decided
+        locally on each write attempt.
+        """
+        # Touch the target schema registry to materialize the local _schemas
+        # topic (creation is not blocked in API mode) and confirm it is empty.
+        target_sr_client = self.target_sr_client()
+        assert len(self.get_subjects(target_sr_client)) == 0, (
+            "Expected no subjects on the target before shadowing"
+        )
+
+        # Create a shadow link that shadows only the ".prod" context via the
+        # Schema Registry API, mapping contexts identically onto the target.
+        created_link = self.create_link("test-link")
+        api = created_link.configurations.schema_registry_sync_options.shadow_schema_registry_api
+        api.source_url = "http://schema-registry.example.com:8081"
+        api.source_filter.contexts.append(".prod")
+        api.destination.identity.SetInParent()
+        update_mask = google.protobuf.field_mask_pb2.FieldMask(
+            paths=["configurations.schema_registry_sync_options"]
+        )
+        updated_link = self.update_link(created_link, update_mask)
+        assert list(
+            updated_link.configurations.schema_registry_sync_options.shadow_schema_registry_api.source_filter.contexts
+        ) == [".prod"], "source_filter not applied after update"
+
+        # A client write to the in-scope ".prod" context is blocked (HTTP 412)
+        # once write protection has propagated to the serving node.
+        self.wait_for_context_write_blocked(
+            target_sr_client, ".prod", self.simple_proto_def
+        )
+
+        # A client write to the out-of-scope ".staging" context succeeds (200).
+        allowed = self.post_schema_to_context(
+            target_sr_client, ".staging", "orders-value", self.simple_a_proto_def
+        )
+        assert allowed.status_code == 200, (
+            f"Expected 200 for out-of-scope context '.staging'. "
+            f"Got {allowed.status_code}: {allowed.text}"
+        )
+
+    @cluster(num_nodes=6)
+    def test_schema_registry_api_exact_context_mapping_write_blocking(self):
+        """
+        With API-mode Schema Registry shadowing using an exact
+        source->destination context mapping, write protection follows the
+        *destination* context name: the mapped destination is blocked, while the
+        source-named context (which is not a local destination) and out-of-scope
+        contexts remain writable.
+        """
+        # Touch the target schema registry to materialize the local _schemas
+        # topic (creation is not blocked in API mode) and confirm it is empty.
+        target_sr_client = self.target_sr_client()
+        assert len(self.get_subjects(target_sr_client)) == 0, (
+            "Expected no subjects on the target before shadowing"
+        )
+
+        # Shadow only the ".prod" source context, remapping it onto
+        # ".prod-mirror" on the target.
+        created_link = self.create_link("test-link")
+        api = created_link.configurations.schema_registry_sync_options.shadow_schema_registry_api
+        api.source_url = "http://schema-registry.example.com:8081"
+        api.source_filter.contexts.append(".prod")
+        api.destination.exact.mappings.add(source=".prod", destination=".prod-mirror")
+        update_mask = google.protobuf.field_mask_pb2.FieldMask(
+            paths=["configurations.schema_registry_sync_options"]
+        )
+        updated_link = self.update_link(created_link, update_mask)
+        updated_api = updated_link.configurations.schema_registry_sync_options.shadow_schema_registry_api
+        assert list(updated_api.source_filter.contexts) == [".prod"], (
+            "source_filter not applied after update"
+        )
+        assert [
+            (m.source, m.destination) for m in updated_api.destination.exact.mappings
+        ] == [(".prod", ".prod-mirror")], "exact mapping not applied after update"
+
+        # A client write to the mapped destination ".prod-mirror" is owned and so
+        # is blocked (HTTP 412) once write protection has propagated.
+        self.wait_for_context_write_blocked(
+            target_sr_client, ".prod-mirror", self.simple_proto_def
+        )
+
+        # The source-named ".prod" is not a local destination, so it is writable.
+        allowed_source = self.post_schema_to_context(
+            target_sr_client, ".prod", "orders-value", self.simple_a_proto_def
+        )
+        assert allowed_source.status_code == 200, (
+            f"Expected 200 for source-named context '.prod'. "
+            f"Got {allowed_source.status_code}: {allowed_source.text}"
+        )
+
+        # An out-of-scope context succeeds (200).
+        allowed_out = self.post_schema_to_context(
+            target_sr_client, ".staging", "orders-value", self.simple_b_proto_def
+        )
+        assert allowed_out.status_code == 200, (
+            f"Expected 200 for out-of-scope context '.staging'. "
+            f"Got {allowed_out.status_code}: {allowed_out.text}"
+        )

--- a/tests/rptest/tests/cluster_linking_topic_syncing_test.py
+++ b/tests/rptest/tests/cluster_linking_topic_syncing_test.py
@@ -769,10 +769,8 @@ class ClusterLinkingTopicSyncingWithMtls(ClusterLinkingTopicSyncingTestBase):
         )
 
 
-class ClusterLinkingSchemaRegistry(ShadowLinkTestBase):
-    """
-    These tests verify the behavior of syncing schema registry
-    """
+class ClusterLinkingSchemaRegistryBase(ShadowLinkTestBase):
+    """Shared setup and helpers for Schema Registry shadow-linking tests."""
 
     simple_proto_def = """
 syntax = "proto3";
@@ -853,6 +851,12 @@ message CType {
         result = result_raw.json()
         assert isinstance(result, list), f"Expected list but got {result}"
         return result
+
+
+class ClusterLinkingSchemaRegistry(ClusterLinkingSchemaRegistryBase):
+    """
+    These tests verify the behavior of syncing schema registry
+    """
 
     @cluster(num_nodes=6)
     def test_schema_registry_basic(self):


### PR DESCRIPTION
Relax Schema Registry write blocking under API-mode shadowing so that a
client write is rejected only when it targets a context actually owned by
the mirroring, instead of blocking the whole Schema Registry whenever any
API-mode shadow link is active.

A new `shadow_schema_registry_api::blocks_context` decides ownership from
the link's `source_filter` and `destination` config (empty filter → the
whole source registry is mirrored, so every context is owned; otherwise a
destination context is owned when a filter-selected source context maps to
it, under identity or exact mapping). The write path now threads the
destination context through `writes_disabled` / `sequenced_write`, and the
frontend client branch consults `blocks_context`. Topic-mode shadowing is
unchanged — it owns the entire `_schemas` topic and still blocks every
context — as is the `schema_registry_sync` write source.

Commits:
- cluster_link: add `blocks_context` to the API-mode SR shadowing config (+ unit test)
- schema_registry: block client writes only to owned contexts (context plumbing + frontend policy)
- cluster_link: ducktape test asserting in-scope context writes are rejected (412) while out-of-scope writes succeed (200)

## Backports Required
- [x] none - not a bug fix

## Release Notes
* none