### PR TITLE
`config`: drop default `cloud_topics_max_concurrent_leveling_jobs_per_shard=1`

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4895,7 +4895,7 @@ configuration::configuration()
       "Maximum number of leveling jobs that may run concurrently on a single "
       "shard. Live-adjustable.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      5,
+      1,
       {.min = size_t{1}, .max = size_t{64}})
   , cloud_topics_leveling_min_extent_size_ratio(
       *this,


### PR DESCRIPTION
Leveling seems really happy to hog the client pool resources (since the default number of clients per shard=20, from
`cloud_storage_max_connections`) when allowing 5 concurrent jobs per shard.

Drop this value to 1 to be more conservative with leveling for its first release in v26.2.1.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
