### PR TITLE
`transform`: prevent de-reference of `nullptr` at startup

### DIFF
--- a/src/v/transform/api.cc
+++ b/src/v/transform/api.cc
@@ -788,7 +788,13 @@ service::get_factory(model::transform_metadata meta) {
 ss::future<model::cluster_transform_report>
 service::compute_node_local_report() {
     co_return co_await container().map_reduce0(
-      [](service& s) { return s._manager->compute_report(); },
+      [](service& s) {
+          // The internal RPC server starts serving generate_report before the
+          // transform subsystem finishes booting. A peer shard may not have run
+          // service::start() yet, so its _manager may still be null.
+          return s._manager ? s._manager->compute_report()
+                            : model::cluster_transform_report{};
+      },
       model::cluster_transform_report{},
       [](
         model::cluster_transform_report agg,


### PR DESCRIPTION
The internal RPC server starts serving `generate_report()` requests before the transform subsystem finishes booting. A peer shard may not have run `service::start()` yet, so its `_manager` may still be null at the time `compute_node_local_report()` is ran.

Add a check here on `_manager` and return a default constructed `cluster_transform_report{}` if we end up racing with `service::start()`.

Relevant slack thread: https://redpandadata.slack.com/archives/C0BBNG6PRRR/p1782292840712719?thread_ts=1782290667.576499&cid=C0BBNG6PRRR

Backtrace:

```
[Backtrace #0]
crash_tracker::recorder::record_crash_sighandler(crash_tracker::recorder::recorded_signo) at ./external/+non_module_dependencies+seastar/src/util/backtrace.cc:102
crash_tracker::(anonymous namespace)::install_oneshot_signal_handler<11, (void (*)())(&crash_tracker::(anonymous namespace)::sigsegv_action)>()::{lambda(int, siginfo_t*, void*)#1}::__invoke(int, siginfo_t*, void*) at ././src/v/crash_tracker/signals.cc:94
wasmtime::runtime::vm::sys::unix::signals::trap_handler at wasmtime.242a22f69a64418c-cgu.0:?
addr2line: '/opt/redpanda/lib/libc.so.6': No such file
/opt/redpanda/lib/libc.so.6 0x4251f 
absl::lts_20250814::container_internal::btree<absl::lts_20250814::container_internal::map_params<detail::base_named_type<long, model::transform_id_tag, std::__1::integral_constant<bool, true> >, model::transform_report, std::__1::less<detail::base_named_type<long, model::transform_id_tag, std::__1::integral_constant<bool, true> > >, std::__1::allocator<std::__1::pair<detail::base_named_type<long, model::transform_id_tag, std::__1::integral_constant<bool, true> > const, model::transform_report> >, 256, false> >::btree(absl::lts_20250814::container_internal::key_compare_adapter<std::__1::less<detail::base_named_type<long, model::transform_id_tag, std::__1::integral_constant<bool, true> > >, detail::base_named_type<long, model::transform_id_tag, std::__1::integral_constant<bool, true> > >::checked_compare const&, std::__1::allocator<std::__1::pair<detail::base_named_type<long, model::transform_id_tag, std::__1::integral_constant<bool, true> > const, model::transform_report> > const&) at ./external/abseil-cpp+/absl/container/internal/btree.h:1420
 (inlined by) absl::lts_20250814::container_internal::btree_container<absl::lts_20250814::container_internal::btree<absl::lts_20250814::container_internal::map_params<detail::base_named_type<long, model::transform_id_tag, std::__1::integral_constant<bool, true> >, model::transform_report, std::__1::less<detail::base_named_type<long, model::transform_id_tag, std::__1::integral_constant<bool, true> > >, std::__1::allocator<std::__1::pair<detail::base_named_type<long, model::transform_id_tag, std::__1::integral_constant<bool, true> > const, model::transform_report> >, 256, false> > >::btree_container() at ./external/abseil-cpp+/absl/container/internal/btree_container.h:76
 (inlined by) absl::lts_20250814::container_internal::btree_set_container<absl::lts_20250814::container_internal::btree<absl::lts_20250814::container_internal::map_params<detail::base_named_type<long, model::transform_id_tag, std::__1::integral_constant<bool, true> >, model::transform_report, std::__1::less<detail::base_named_type<long, model::transform_id_tag, std::__1::integral_constant<bool, true> > >, std::__1::allocator<std::__1::pair<detail::base_named_type<long, model::transform_id_tag, std::__1::integral_constant<bool, true> > const, model::transform_report> >, 256, false> > >::btree_set_container() at ./external/abseil-cpp+/absl/container/internal/btree_container.h:306
 (inlined by) absl::lts_20250814::container_internal::btree_map_container<absl::lts_20250814::container_internal::btree<absl::lts_20250814::container_internal::map_params<detail::base_named_type<long, model::transform_id_tag, std::__1::integral_constant<bool, true> >, model::transform_report, std::__1::less<detail::base_named_type<long, model::transform_id_tag, std::__1::integral_constant<bool, true> > >, std::__1::allocator<std::__1::pair<detail::base_named_type<long, model::transform_id_tag, std::__1::integral_constant<bool, true> > const, model::transform_report> >, 256, false> > >::btree_map_container() at ./external/abseil-cpp+/absl/container/internal/btree_container.h:491
 (inlined by) absl::lts_20250814::btree_map<detail::base_named_type<long, model::transform_id_tag, std::__1::integral_constant<bool, true> >, model::transform_report, std::__1::less<detail::base_named_type<long, model::transform_id_tag, std::__1::integral_constant<bool, true> > >, std::__1::allocator<std::__1::pair<detail::base_named_type<long, model::transform_id_tag, std::__1::integral_constant<bool, true> > const, model::transform_report> > >::btree_map() at ./external/abseil-cpp+/absl/container/btree_map.h:138
 (inlined by) model::cluster_transform_report::cluster_transform_report() at ./bazel-out/k8-opt/bin/src/v/model/_virtual_includes/model/model/transform.h:368
 (inlined by) transform::manager<seastar::lowres_clock>::compute_report() const at ././src/v/transform/transform_manager.cc:475
transform::service::compute_node_local_report()::$_0::operator()(transform::service&) const at ././src/v/transform/api.cc:827
 (inlined by) decltype (((std::declval<transform::service::compute_node_local_report()::$_0 const&>)())((std::declval<transform::service&>)())) std::__1::__invoke[abi:ne200100]<transform::service::compute_node_local_report()::$_0 const&, transform::service&>(transform::service::compute_node_local_report()::$_0 const&, transform::service&) at ./external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__type_traits/invoke.h:179
 (inlined by) std::__1::invoke_result<transform::service::compute_node_local_report()::$_0 const&, transform::service&>::type std::__1::invoke[abi:ne200100]<transform::service::compute_node_local_report()::$_0 const&, transform::service&>(transform::service::compute_node_local_report()::$_0 const&, transform::service&) at ./external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__functional/invoke.h:29
 (inlined by) seastar::sharded<transform::service>::map_reduce0<transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1>(transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1)::{lambda(unsigned int)#1}::operator()(unsigned int) const::{lambda()#1}::operator()() const at ./external/+non_module_dependencies+seastar/include/seastar/core/sharded.hh:456
 (inlined by) seastar::future<model::cluster_transform_report> seastar::futurize<model::cluster_transform_report>::invoke<seastar::sharded<transform::service>::map_reduce0<transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1>(transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1)::{lambda(unsigned int)#1}::operator()(unsigned int) const::{lambda()#1}>(seastar::sharded<transform::service>::map_reduce0<transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1>(transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1)::{lambda(unsigned int)#1}::operator()(unsigned int) const::{lambda()#1}&&) at ./external/+non_module_dependencies+seastar/include/seastar/core/future.hh:1961
 (inlined by) seastar::futurize<std::__1::invoke_result<seastar::sharded<transform::service>::map_reduce0<transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1>(transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1)::{lambda(unsigned int)#1}::operator()(unsigned int) const::{lambda()#1}>::type>::type seastar::smp::submit_to<seastar::sharded<transform::service>::map_reduce0<transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1>(transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1)::{lambda(unsigned int)#1}::operator()(unsigned int) const::{lambda()#1}>(unsigned int, seastar::smp_submit_to_options, seastar::sharded<transform::service>::map_reduce0<transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1>(transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1)::{lambda(unsigned int)#1}::operator()(unsigned int) const::{lambda()#1}&&) at ./external/+non_module_dependencies+seastar/include/seastar/core/smp.hh:365
 (inlined by) seastar::futurize<std::__1::invoke_result<seastar::sharded<transform::service>::map_reduce0<transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1>(transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1)::{lambda(unsigned int)#1}::operator()(unsigned int) const::{lambda()#1}>::type>::type seastar::smp::submit_to<seastar::sharded<transform::service>::map_reduce0<transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1>(transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1)::{lambda(unsigned int)#1}::operator()(unsigned int) const::{lambda()#1}>(unsigned int, seastar::sharded<transform::service>::map_reduce0<transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1>(transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1)::{lambda(unsigned int)#1}::operator()(unsigned int) const::{lambda()#1}&&) at ./external/+non_module_dependencies+seastar/include/seastar/core/smp.hh:399
 (inlined by) seastar::sharded<transform::service>::map_reduce0<transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1>(transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1)::{lambda(unsigned int)#1}::operator()(unsigned int) const at ./external/+non_module_dependencies+seastar/include/seastar/core/sharded.hh:454
 (inlined by) seastar::future<model::cluster_transform_report> seastar::futurize<seastar::future<model::cluster_transform_report> >::invoke<seastar::sharded<transform::service>::map_reduce0<transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1>(transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1)::{lambda(unsigned int)#1}&, unsigned int>(seastar::sharded<transform::service>::map_reduce0<transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1>(transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1)::{lambda(unsigned int)#1}&, unsigned int&&) at ./external/+non_module_dependencies+seastar/include/seastar/core/future.hh:1959
 (inlined by) auto seastar::futurize_invoke<seastar::sharded<transform::service>::map_reduce0<transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1>(transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1)::{lambda(unsigned int)#1}&, unsigned int>(seastar::sharded<transform::service>::map_reduce0<transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1>(transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1)::{lambda(unsigned int)#1}&, unsigned int&&) at ./external/+non_module_dependencies+seastar/include/seastar/core/future.hh:1990
 (inlined by) _ZN7seastar10map_reduceINSt3__16ranges9iota_viewIjjE10__iteratorEZNS_7shardedIN9transform7serviceEE11map_reduce0IZNS8_25compute_node_local_reportEvE3$_0N5model24cluster_transform_reportEZNS8_25compute_node_local_reportEvE3$_1EENS_6futureIT0_EET_SG_T1_EUljE_SD_SE_QrQSI_SG_SJ_T2__XdeppfL0p_XnefL0p_fL0p_RNS1_14convertible_toIbEEXclfL0p0_defL0p_EQsr9is_futureIDTclfL0p0_defL0p_EEEE5valueXclfL0p2_clsr3stdE4movefL0p1_EcldtclfL0p0_defL0p_E3getEERNSM_ISJ_EEEEENSF_ISJ_EESI_SI_OSG_SJ_SL_ at ./external/+non_module_dependencies+seastar/include/seastar/core/map_reduce.hh:193
 (inlined by) seastar::future<model::cluster_transform_report> seastar::sharded<transform::service>::map_reduce0<transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1>(transform::service::compute_node_local_report()::$_0, model::cluster_transform_report, transform::service::compute_node_local_report()::$_1) at ./external/+non_module_dependencies+seastar/include/seastar/core/sharded.hh:459
 (inlined by) transform::service::compute_node_local_report() at ././src/v/transform/api.cc:826
transform::wrapped_service_reporter::compute_report() at ././src/v/transform/api.cc:474
transform::rpc::local_service::compute_node_local_report() at ././src/v/transform/rpc/service.cc:271
 (inlined by) transform::rpc::network_service::generate_report(transform::rpc::generate_report_request, rpc::streaming_context&) at ././src/v/transform/rpc/service.cc:457
std::__1::coroutine_handle<seastar::internal::coroutine_traits_base<transform::rpc::generate_report_reply>::promise_type>::resume[abi:ne200100]() const at ./external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__coroutine/coroutine_handle.h:144
 (inlined by) seastar::internal::coroutine_traits_base<transform::rpc::generate_report_reply>::promise_type::run_and_dispose() at ./external/+non_module_dependencies+seastar/include/seastar/core/coroutine.hh:80
seastar::reactor::task_queue::run_tasks() at ././external/+non_module_dependencies+seastar/src/core/reactor.cc:2721
seastar::reactor::task_queue_group::run_tasks() at ././external/+non_module_dependencies+seastar/src/core/reactor.cc:3222
 (inlined by) seastar::reactor::task_queue_group::run_some_tasks() at ././external/+non_module_dependencies+seastar/src/core/reactor.cc:3206
 (inlined by) seastar::reactor::do_run() at ././external/+non_module_dependencies+seastar/src/core/reactor.cc:3394
std::__1::__function::__func<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_0, std::__1::allocator<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_0>, void ()>::operator()() at ././external/+non_module_dependencies+seastar/src/core/reactor.cc:4685
seastar::posix_thread::start_routine(void*) at ./external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__functional/function.h:436
/opt/redpanda/lib/libc.so.6 0x94ac2 
/opt/redpanda/lib/libc.so.6 0x12684f 
```

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [X] v25.3.x
- [ ] v25.2.x

## Release Notes


### Bug Fixes

* Fixes a bug in which a `generate_report()` request to the `transform` system could result in a `nullptr` dereference at startup 