### PR TITLE
[UX-1350] rpk shadow: add role sync configuration support

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -3,7 +3,7 @@ managed:
   enabled: false
 inputs:
   # You can get the full commit sha from https://buf.build/redpandadata/core/docs
-  - module: buf.build/redpandadata/core:5b0ab84ea0824fb18952cbc337e8dac7
+  - module: buf.build/redpandadata/core:288047c1b16f4a4c95053d66e16815f7
     paths:
       - redpanda/core/admin/v2/shadow_link.proto
       - redpanda/core/common/v1/acl.proto

--- a/src/go/rpk/gen/protocomments/admin/v2/comments.pb.go
+++ b/src/go/rpk/gen/protocomments/admin/v2/comments.pb.go
@@ -39,8 +39,10 @@ var Comments = map[string]string{
 	"redpanda.core.admin.v2.ConsumerOffsetSyncOptions.paused": `Allows user to pause the consumer offset sync task.  If paused, then
  the task will enter the 'paused' state and not sync consumer offsets from
  the source cluster`,
-	"redpanda.core.admin.v2.CreateShadowLinkRequest":              "Create a new shadow link",
-	"redpanda.core.admin.v2.CreateShadowLinkRequest.shadow_link":  "The shadow link to create",
+	"redpanda.core.admin.v2.CreateShadowLinkRequest":             "Create a new shadow link",
+	"redpanda.core.admin.v2.CreateShadowLinkRequest.shadow_link": "The shadow link to create",
+	"redpanda.core.admin.v2.CreateShadowLinkRequest.validate_only": `If true, validate connection parameters without creating the link.
+ Returns an empty response on success or an error if validation fails.`,
 	"redpanda.core.admin.v2.CreateShadowLinkResponse":             "Response to creating a shadow link",
 	"redpanda.core.admin.v2.CreateShadowLinkResponse.shadow_link": "The shadow link that was created",
 	"redpanda.core.admin.v2.DeleteShadowLinkRequest":              "Request to delete a shadow link",
@@ -92,7 +94,15 @@ var Comments = map[string]string{
 	"redpanda.core.admin.v2.PlainConfig.password_set": "Indicates that the password has been set",
 	"redpanda.core.admin.v2.PlainConfig.password_set_at": `Timestamp of when the password was last set - only valid if password_set
  is true`,
-	"redpanda.core.admin.v2.PlainConfig.username":                      "PLAIN username",
+	"redpanda.core.admin.v2.PlainConfig.username":               "PLAIN username",
+	"redpanda.core.admin.v2.RoleSyncOptions":                    "Options for syncing RBAC roles",
+	"redpanda.core.admin.v2.RoleSyncOptions.effective_interval": "The effective interval for the task",
+	"redpanda.core.admin.v2.RoleSyncOptions.interval": `Sync interval
+ If 0 provided, defaults to 30 seconds`,
+	"redpanda.core.admin.v2.RoleSyncOptions.paused": `Allows user to pause the role sync task.  If paused, then the task will
+ enter the 'paused' state and will not sync roles from the source cluster`,
+	"redpanda.core.admin.v2.RoleSyncOptions.role_name_filters": `Filters selecting which roles to shadow by name.  Defaults to empty: no
+ roles are synced until at least one include filter is added`,
 	"redpanda.core.admin.v2.SCHEMA_REGISTRY_SYNC_TYPE_FULL":            "A full source scan is running.",
 	"redpanda.core.admin.v2.SCHEMA_REGISTRY_SYNC_TYPE_TAIL":            "An incremental tail sync is running.",
 	"redpanda.core.admin.v2.SCHEMA_REGISTRY_SYNC_TYPE_UNSPECIFIED":     "The Schema Registry sync type is not specified.",
@@ -265,6 +275,7 @@ var Comments = map[string]string{
 	"redpanda.core.admin.v2.ShadowLinkConfigurations":                              "ShadowLink options",
 	"redpanda.core.admin.v2.ShadowLinkConfigurations.client_options":               "Configuration for the internal kafka client",
 	"redpanda.core.admin.v2.ShadowLinkConfigurations.consumer_offset_sync_options": "Consumer offset sync options",
+	"redpanda.core.admin.v2.ShadowLinkConfigurations.role_sync_options":            "Role sync options",
 	"redpanda.core.admin.v2.ShadowLinkConfigurations.schema_registry_sync_options": "Schema Registry sync options",
 	"redpanda.core.admin.v2.ShadowLinkConfigurations.security_sync_options":        "Security settings sync options",
 	"redpanda.core.admin.v2.ShadowLinkConfigurations.topic_metadata_sync_options":  "Topic metadata sync options",

--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -7,7 +7,7 @@ require (
 	buf.build/gen/go/redpandadata/cloud/connectrpc/go v1.19.1-20260409133226-cd0bdc42a0f9.2
 	buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.11-20260409133226-cd0bdc42a0f9.1
 	buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.11-20260323171043-6e06f84ad823.1
-	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260608080241-5b0ab84ea082.1
+	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260623153049-288047c1b16f.1
 	buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20260409091301-5e03d1b04513.2
 	buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.11-20260409091301-5e03d1b04513.1
 	buf.build/gen/go/redpandadata/gatekeeper/connectrpc/go v1.19.1-20251022210437-a5dd600d04b6.2

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -14,8 +14,8 @@ buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.11-20260323171043-
 buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.11-20260323171043-6e06f84ad823.1/go.mod h1:3w7EzexwlL6PIFGbbeKZ0yHfUlAmI0aBVzF/QoFb8Cg=
 buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.2-20260608080241-5b0ab84ea082.1 h1:REoEEpW3VLzOMm1fWkVWCbu7pnHO+OyZdsKL7MT6Chc=
 buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.2-20260608080241-5b0ab84ea082.1/go.mod h1:+xnk83uu51cCNf3Hogv22YnoMkiTXeRMYjsuDMVElKk=
-buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260608080241-5b0ab84ea082.1 h1:lLdtkh1oXeNO0XDgsarqJ9iR2/RfypaQxz33/D3Z2d0=
-buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260608080241-5b0ab84ea082.1/go.mod h1:5sjUVquVwNxt3Q/EhE/UW0BBJ5sgPiaVTw8//wxRULI=
+buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260623153049-288047c1b16f.1 h1:TmJYP+PsyrF7jsKfL/PXJmllkbJaoibeeoEQugy0xmg=
+buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260623153049-288047c1b16f.1/go.mod h1:5sjUVquVwNxt3Q/EhE/UW0BBJ5sgPiaVTw8//wxRULI=
 buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20260409091301-5e03d1b04513.2 h1:8t4xNuFJqh2mW4RPa6sVjL+Bm6ONZq7Gj3PsCPMNUFM=
 buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20260409091301-5e03d1b04513.2/go.mod h1:EN4XJHrOIY8SoHVk9NuZf9I4DtlmhSq6ixlNhbCR+L4=
 buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.11-20260409091301-5e03d1b04513.1 h1:vbHgxorgH6giQxyTPtd+rHkke0E8w5VU1bQC5WjV6qY=

--- a/src/go/rpk/pkg/cli/shadow/config.go
+++ b/src/go/rpk/pkg/cli/shadow/config.go
@@ -199,12 +199,26 @@ func generateSampleConfig(cloud bool) *ShadowLinkConfig {
 		SchemaRegistrySyncOptions: &SchemaRegistrySyncOptions{
 			ShadowSchemaRegistryTopic: &ShadowSchemaRegistryTopic{},
 		},
+		RoleSyncOptions: &RoleSyncOptions{
+			Interval: 30 * time.Second,
+			Paused:   false,
+			RoleNameFilters: []*NameFilter{
+				{
+					PatternType: PatternTypeLiteral,
+					FilterType:  FilterTypeInclude,
+					Name:        "*",
+				},
+			},
+		},
 	}
 	if cloud {
 		slCfg.CloudOptions = &CloudShadowLinkOptions{
 			SourceRedpandaID: "m7xtv2qq5njbhwruk88f",
 			ShadowRedpandaID: "p9skc1dd3fmzgvquj66h",
 		}
+
+		// Role sync is not yet supported for Redpanda Cloud shadow links.
+		slCfg.RoleSyncOptions = nil
 
 		slCfg.ClientOptions.BootstrapServers = nil
 		// This is confusing on Cloud, user is already providing the Redpanda ID.
@@ -352,6 +366,10 @@ func toScreamingSnakeCase(s string) string {
 func writeFieldTemplate(sb *strings.Builder, field protoreflect.FieldDescriptor, indent int, cloud bool) {
 	// Skip tls_file_settings for Cloud (only tls_pem_settings is valid)
 	if cloud && string(field.Name()) == "tls_file_settings" {
+		return
+	}
+	// Role sync is not yet supported for Redpanda Cloud shadow links.
+	if cloud && string(field.Name()) == "role_sync_options" {
 		return
 	}
 

--- a/src/go/rpk/pkg/cli/shadow/create.go
+++ b/src/go/rpk/pkg/cli/shadow/create.go
@@ -237,6 +237,11 @@ func validateParsedShadowLinkConfig(slCfg *ShadowLinkConfig) error {
 		return nil
 	}
 	// Cloud only validations.
+	// Role sync is not yet available in the cloud control-plane API, so reject
+	// it up front rather than silently dropping it.
+	if slCfg.RoleSyncOptions != nil {
+		return errors.New("role sync options are not yet supported for Redpanda Cloud shadow links")
+	}
 	if slc.ShadowRedpandaID == "" {
 		return errors.New("shadow_redpanda_id is required in cloud options")
 	}

--- a/src/go/rpk/pkg/cli/shadow/create_test.go
+++ b/src/go/rpk/pkg/cli/shadow/create_test.go
@@ -304,6 +304,21 @@ func TestValidateParsedShadowLinkConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "valid config - self-hosted with role sync",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+				},
+				RoleSyncOptions: &RoleSyncOptions{
+					Interval: 30 * time.Second,
+					RoleNameFilters: []*NameFilter{
+						{PatternType: PatternTypePrefix, FilterType: FilterTypeInclude, Name: "team-"},
+					},
+				},
+			},
+		},
 		// Cloud-specific validation tests
 		{
 			name: "cloud config - missing shadow_redpanda_id",
@@ -329,6 +344,24 @@ func TestValidateParsedShadowLinkConfig(t *testing.T) {
 				},
 			},
 			expectedErr: "shadow_redpanda_id and source_redpanda_id cannot be the same",
+		},
+		{
+			name: "cloud config - role sync not allowed",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				CloudOptions: &CloudShadowLinkOptions{
+					ShadowRedpandaID: "shadow-cluster",
+				},
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+				},
+				RoleSyncOptions: &RoleSyncOptions{
+					RoleNameFilters: []*NameFilter{
+						{PatternType: PatternTypeLiteral, FilterType: FilterTypeInclude, Name: "*"},
+					},
+				},
+			},
+			expectedErr: "role sync options are not yet supported for Redpanda Cloud shadow links",
 		},
 		{
 			name: "cloud config - TLS file settings not allowed",

--- a/src/go/rpk/pkg/cli/shadow/describe.go
+++ b/src/go/rpk/pkg/cli/shadow/describe.go
@@ -35,6 +35,7 @@ const (
 	secConsumerOffset = "Consumer Offset Sync"
 	secSecurity       = "Security Sync"
 	secSchemaRegistry = "Schema Registry Sync"
+	secRole           = "Role Sync"
 )
 
 // shadowLinkDescription is the unified output for both cloud and self-hosted.
@@ -54,6 +55,7 @@ type shadowLinkDescription struct {
 	ConsumerOffsetSyncOptions *describeConsumerOffsetSyncOptions `json:"consumer_offset_sync_options,omitempty" yaml:"consumer_offset_sync_options,omitempty"`
 	SecuritySyncOptions       *describeSecuritySyncOptions       `json:"security_sync_options,omitempty" yaml:"security_sync_options,omitempty"`
 	SchemaRegistrySyncOptions *describeSchemaRegistrySyncOptions `json:"schema_registry_sync_options,omitempty" yaml:"schema_registry_sync_options,omitempty"`
+	RoleSyncOptions           *describeRoleSyncOptions           `json:"role_sync_options,omitempty" yaml:"role_sync_options,omitempty"`
 }
 
 // describeClientOptions uses effective values and auth metadata (not password).
@@ -99,6 +101,12 @@ type describeSecuritySyncOptions struct {
 	Interval   string       `json:"interval" yaml:"interval"`
 	Paused     bool         `json:"paused" yaml:"paused"`
 	ACLFilters []*ACLFilter `json:"acl_filters,omitempty" yaml:"acl_filters,omitempty"`
+}
+
+type describeRoleSyncOptions struct {
+	Interval        string        `json:"interval" yaml:"interval"`
+	Paused          bool          `json:"paused" yaml:"paused"`
+	RoleNameFilters []*NameFilter `json:"role_name_filters,omitempty" yaml:"role_name_filters,omitempty"`
 }
 
 type describeSchemaRegistrySyncOptions struct {
@@ -205,6 +213,7 @@ Display output as JSON:
 	cmd.Flags().BoolVarP(&opts.co, "print-consumer", "r", false, "Print the detailed consumer offset configuration section")
 	cmd.Flags().BoolVarP(&opts.sec, "print-security", "s", false, "Print the detailed security configuration section")
 	cmd.Flags().BoolVarP(&opts.sr, "print-registry", "y", false, "Print the detailed schema registry configuration section")
+	cmd.Flags().BoolVar(&opts.role, "print-role", false, "Print the detailed role sync configuration section")
 	cmd.Flags().BoolVarP(&opts.all, "print-all", "a", false, "Print all sections")
 	p.InstallFormatFlag(cmd)
 	return cmd
@@ -218,16 +227,17 @@ type slDescribeOptions struct {
 	co       bool // consumer offset
 	sec      bool // security
 	sr       bool // schema registry
+	role     bool
 }
 
 // If no flags are set, default to overview and client sections.
 func (o *slDescribeOptions) defaultOrAll() {
-	if !o.all && !o.overview && !o.client && !o.topic && !o.co && !o.sec && !o.sr {
+	if !o.all && !o.overview && !o.client && !o.topic && !o.co && !o.sec && !o.sr && !o.role {
 		o.overview, o.client = true, true
 	}
 
 	if o.all {
-		o.overview, o.client, o.topic, o.co, o.sec, o.sr = true, true, true, true, true, true
+		o.overview, o.client, o.topic, o.co, o.sec, o.sr, o.role = true, true, true, true, true, true, true
 	}
 }
 
@@ -246,6 +256,7 @@ func printShadowLinkDescription(f config.OutFormatter, link *adminv2.ShadowLink,
 			secConsumerOffset: opts.co,
 			secSecurity:       opts.sec,
 			secSchemaRegistry: opts.sr,
+			secRole:           opts.role,
 		})...,
 	)
 
@@ -273,6 +284,10 @@ func printShadowLinkDescription(f config.OutFormatter, link *adminv2.ShadowLink,
 
 	sections.Add(secSchemaRegistry, func() {
 		printSchemaRegistrySync(cfg.GetSchemaRegistrySyncOptions())
+	})
+
+	sections.Add(secRole, func() {
+		printRoleSync(cfg.GetRoleSyncOptions())
 	})
 }
 
@@ -515,6 +530,25 @@ func printConsumerOffsetSync(opts *adminv2.ConsumerOffsetSyncOptions) {
 	}
 }
 
+func printRoleSync(opts *adminv2.RoleSyncOptions) {
+	tw := out.NewTabWriter()
+	defer tw.Flush()
+	if opts == nil {
+		tw.Print("No role sync configuration")
+		return
+	}
+
+	tw.Print("PAUSED", opts.GetPaused())
+	tw.Print("INTERVAL", opts.GetEffectiveInterval().AsDuration().String())
+
+	if len(opts.GetRoleNameFilters()) > 0 {
+		tw.Print("ROLE NAME FILTERS:", "")
+		for _, filter := range opts.GetRoleNameFilters() {
+			tw.Print("", fmt.Sprintf("- %s %s %q", formatFilterType(filter.GetFilterType()), formatPatternType(filter.GetPatternType()), filter.GetName()))
+		}
+	}
+}
+
 func printSecuritySync(opts *adminv2.SecuritySettingsSyncOptions) {
 	tw := out.NewTabWriter()
 	defer tw.Flush()
@@ -703,6 +737,7 @@ func fromAdminV2ShadowLinkDescription(link *adminv2.ShadowLink) shadowLinkDescri
 		ConsumerOffsetSyncOptions: buildDescribeConsumerOffsetOptions(cfg.GetConsumerOffsetSyncOptions()),
 		SecuritySyncOptions:       buildDescribeSecurityOptions(cfg.GetSecuritySyncOptions()),
 		SchemaRegistrySyncOptions: buildDescribeSchemaRegistryOptions(cfg.GetSchemaRegistrySyncOptions()),
+		RoleSyncOptions:           buildDescribeRoleOptions(cfg.GetRoleSyncOptions()),
 	}
 }
 
@@ -841,6 +876,21 @@ func buildDescribeConsumerOffsetOptions(opts *adminv2.ConsumerOffsetSyncOptions)
 		Interval:     opts.GetEffectiveInterval().AsDuration().String(),
 		Paused:       opts.GetPaused(),
 		GroupFilters: filters,
+	}
+}
+
+func buildDescribeRoleOptions(opts *adminv2.RoleSyncOptions) *describeRoleSyncOptions {
+	if opts == nil {
+		return nil
+	}
+	var filters []*NameFilter
+	for _, f := range opts.GetRoleNameFilters() {
+		filters = append(filters, adminMapFilterToCfg(f))
+	}
+	return &describeRoleSyncOptions{
+		Interval:        opts.GetEffectiveInterval().AsDuration().String(),
+		Paused:          opts.GetPaused(),
+		RoleNameFilters: filters,
 	}
 }
 

--- a/src/go/rpk/pkg/cli/shadow/mapper.go
+++ b/src/go/rpk/pkg/cli/shadow/mapper.go
@@ -33,6 +33,7 @@ func shadowLinkConfigToProto(slCfg *ShadowLinkConfig) *adminv2.ShadowLink {
 		ConsumerOffsetSyncOptions: mapConsumerOffsetSyncOptions(slCfg.ConsumerOffsetSyncOptions),
 		SecuritySyncOptions:       mapSecuritySyncOptions(slCfg.SecuritySyncOptions),
 		SchemaRegistrySyncOptions: mapSchemaRegistrySyncOptions(slCfg.SchemaRegistrySyncOptions),
+		RoleSyncOptions:           mapRoleSyncOptions(slCfg.RoleSyncOptions),
 	}
 	return shadowLink
 }
@@ -288,6 +289,26 @@ func mapSecuritySyncOptions(opts *SecuritySettingsSyncOptions) *adminv2.Security
 
 	for _, filter := range opts.ACLFilters {
 		pbOpts.AclFilters = append(pbOpts.AclFilters, mapACLFilter(filter))
+	}
+
+	return pbOpts
+}
+
+func mapRoleSyncOptions(opts *RoleSyncOptions) *adminv2.RoleSyncOptions {
+	if opts == nil {
+		return nil
+	}
+
+	pbOpts := &adminv2.RoleSyncOptions{
+		Paused: opts.Paused,
+	}
+
+	if opts.Interval > 0 {
+		pbOpts.Interval = durationpb.New(opts.Interval)
+	}
+
+	for _, filter := range opts.RoleNameFilters {
+		pbOpts.RoleNameFilters = append(pbOpts.RoleNameFilters, mapNameFilter(filter))
 	}
 
 	return pbOpts
@@ -587,6 +608,7 @@ func shadowLinkToConfig(sl *adminv2.ShadowLink) *ShadowLinkConfig {
 		cfg.ConsumerOffsetSyncOptions = adminConsumerOffsetSyncToCfg(sl.GetConfigurations().GetConsumerOffsetSyncOptions())
 		cfg.SecuritySyncOptions = adminSecuritySyncToCfg(sl.GetConfigurations().GetSecuritySyncOptions())
 		cfg.SchemaRegistrySyncOptions = adminSchemaRegistrySyncToCfg(sl.GetConfigurations().GetSchemaRegistrySyncOptions())
+		cfg.RoleSyncOptions = adminRoleSyncToCfg(sl.GetConfigurations().GetRoleSyncOptions())
 	}
 
 	return cfg
@@ -766,6 +788,26 @@ func adminSecuritySyncToCfg(opts *adminv2.SecuritySettingsSyncOptions) *Security
 
 	for _, filter := range opts.GetAclFilters() {
 		cfg.ACLFilters = append(cfg.ACLFilters, adminACLFilterToCfg(filter))
+	}
+
+	return cfg
+}
+
+func adminRoleSyncToCfg(opts *adminv2.RoleSyncOptions) *RoleSyncOptions {
+	if opts == nil {
+		return nil
+	}
+
+	cfg := &RoleSyncOptions{
+		Paused: opts.GetPaused(),
+	}
+
+	if opts.GetInterval() != nil {
+		cfg.Interval = opts.GetInterval().AsDuration()
+	}
+
+	for _, filter := range opts.GetRoleNameFilters() {
+		cfg.RoleNameFilters = append(cfg.RoleNameFilters, adminMapFilterToCfg(filter))
 	}
 
 	return cfg

--- a/src/go/rpk/pkg/cli/shadow/mapper_test.go
+++ b/src/go/rpk/pkg/cli/shadow/mapper_test.go
@@ -399,6 +399,54 @@ func TestMapConsumerOffsetSyncOptions(t *testing.T) {
 	}
 }
 
+func TestMapRoleSyncOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		opts *RoleSyncOptions
+		want *adminv2.RoleSyncOptions
+	}{
+		{
+			name: "nil options returns nil",
+			opts: nil,
+			want: nil,
+		},
+		{
+			name: "paused with zero interval",
+			opts: &RoleSyncOptions{
+				Paused:   true,
+				Interval: 0,
+			},
+			want: &adminv2.RoleSyncOptions{
+				Paused: true,
+			},
+		},
+		{
+			name: "not paused with filters",
+			opts: &RoleSyncOptions{
+				Paused:   false,
+				Interval: 45 * time.Second,
+				RoleNameFilters: []*NameFilter{
+					{PatternType: PatternTypePrefix, FilterType: FilterTypeInclude, Name: "team-"},
+				},
+			},
+			want: &adminv2.RoleSyncOptions{
+				Paused:   false,
+				Interval: durationpb.New(45 * time.Second),
+				RoleNameFilters: []*adminv2.NameFilter{
+					{PatternType: adminv2.PatternType_PATTERN_TYPE_PREFIX, FilterType: adminv2.FilterType_FILTER_TYPE_INCLUDE, Name: "team-"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapRoleSyncOptions(tt.opts)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestMapSecuritySyncOptions(t *testing.T) {
 	tests := []struct {
 		name string
@@ -1109,6 +1157,55 @@ func TestAdminConsumerOffsetSyncToCfg(t *testing.T) {
 	}
 }
 
+func TestAdminRoleSyncToCfg(t *testing.T) {
+	tests := []struct {
+		name string
+		opts *adminv2.RoleSyncOptions
+		want *RoleSyncOptions
+	}{
+		{
+			name: "nil options returns nil",
+			opts: nil,
+			want: nil,
+		},
+		{
+			name: "paused with nil interval",
+			opts: &adminv2.RoleSyncOptions{
+				Paused:   true,
+				Interval: nil,
+			},
+			want: &RoleSyncOptions{
+				Paused:   true,
+				Interval: 0,
+			},
+		},
+		{
+			name: "not paused with filters",
+			opts: &adminv2.RoleSyncOptions{
+				Paused:   false,
+				Interval: durationpb.New(45 * time.Second),
+				RoleNameFilters: []*adminv2.NameFilter{
+					{PatternType: adminv2.PatternType_PATTERN_TYPE_PREFIX, FilterType: adminv2.FilterType_FILTER_TYPE_INCLUDE, Name: "team-"},
+				},
+			},
+			want: &RoleSyncOptions{
+				Paused:   false,
+				Interval: 45 * time.Second,
+				RoleNameFilters: []*NameFilter{
+					{PatternType: PatternTypePrefix, FilterType: FilterTypeInclude, Name: "team-"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := adminRoleSyncToCfg(tt.opts)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestAdminSecuritySyncToCfg(t *testing.T) {
 	tests := []struct {
 		name string
@@ -1545,6 +1642,22 @@ func TestRoundTrip(t *testing.T) {
 						PermissionType: ACLPermissionTypeAllow,
 						Host:           "*",
 					},
+				},
+			},
+		},
+		RoleSyncOptions: &RoleSyncOptions{
+			Paused:   true,
+			Interval: 75 * time.Second,
+			RoleNameFilters: []*NameFilter{
+				{
+					PatternType: PatternTypePrefix,
+					FilterType:  FilterTypeInclude,
+					Name:        "team-",
+				},
+				{
+					PatternType: PatternTypeLiteral,
+					FilterType:  FilterTypeExclude,
+					Name:        "admin",
 				},
 			},
 		},

--- a/src/go/rpk/pkg/cli/shadow/types.go
+++ b/src/go/rpk/pkg/cli/shadow/types.go
@@ -28,6 +28,8 @@ type ShadowLinkConfig struct {
 	SecuritySyncOptions *SecuritySettingsSyncOptions `json:"security_sync_options,omitempty" yaml:"security_sync_options,omitempty"`
 	// Schema Registry sync options
 	SchemaRegistrySyncOptions *SchemaRegistrySyncOptions `json:"schema_registry_sync_options,omitempty" yaml:"schema_registry_sync_options,omitempty"`
+	// Role sync options
+	RoleSyncOptions *RoleSyncOptions `json:"role_sync_options,omitempty" yaml:"role_sync_options,omitempty"`
 }
 
 type CloudShadowLinkOptions struct {
@@ -202,6 +204,18 @@ type SecuritySettingsSyncOptions struct {
 	Paused bool `json:"paused,omitempty" yaml:"paused,omitempty"`
 	// ACL filters
 	ACLFilters []*ACLFilter `json:"acl_filters,omitempty" yaml:"acl_filters,omitempty"`
+}
+
+type RoleSyncOptions struct {
+	// Sync interval
+	// If 0 provided, defaults to 30 seconds
+	Interval time.Duration `json:"interval,omitempty" yaml:"interval,omitempty"`
+	// Allows user to pause the role sync task. If paused, then the task will
+	// enter the 'paused' state and will not sync roles from the source cluster
+	Paused bool `json:"paused,omitempty" yaml:"paused,omitempty"`
+	// Filters selecting which roles to shadow by name. Defaults to empty: no
+	// roles are synced until at least one include filter is added
+	RoleNameFilters []*NameFilter `json:"role_name_filters,omitempty" yaml:"role_name_filters,omitempty"`
 }
 
 type SchemaRegistrySyncOptions struct {

--- a/src/go/rpk/pkg/cli/shadow/types_test.go
+++ b/src/go/rpk/pkg/cli/shadow/types_test.go
@@ -70,6 +70,13 @@ consumer_offset_sync_options:
 security_sync_options:
   interval: "30s"
   paused: false
+role_sync_options:
+  interval: "30s"
+  paused: false
+  role_name_filters:
+    - pattern_type: "PREFIX"
+      filter_type: "INCLUDE"
+      name: "team-"
 `,
 			want: ShadowLinkConfig{
 				Name: "test-shadow-link",
@@ -120,6 +127,17 @@ security_sync_options:
 				SecuritySyncOptions: &SecuritySettingsSyncOptions{
 					Interval: 30 * time.Second,
 					Paused:   false,
+				},
+				RoleSyncOptions: &RoleSyncOptions{
+					Interval: 30 * time.Second,
+					Paused:   false,
+					RoleNameFilters: []*NameFilter{
+						{
+							PatternType: "PREFIX",
+							FilterType:  "INCLUDE",
+							Name:        "team-",
+						},
+					},
 				},
 			},
 		},
@@ -328,6 +346,15 @@ func TestShadowLinkConfigUnmarshalJSON(t *testing.T) {
 				"security_sync_options": {
 					"interval": 30000000000,
 					"paused": false
+				},
+				"role_sync_options": {
+					"interval": 30000000000,
+					"paused": false,
+					"role_name_filters": [{
+						"pattern_type": "PREFIX",
+						"filter_type": "INCLUDE",
+						"name": "team-"
+					}]
 				}
 			}`,
 			want: ShadowLinkConfig{
@@ -379,6 +406,17 @@ func TestShadowLinkConfigUnmarshalJSON(t *testing.T) {
 				SecuritySyncOptions: &SecuritySettingsSyncOptions{
 					Interval: 30 * time.Second,
 					Paused:   false,
+				},
+				RoleSyncOptions: &RoleSyncOptions{
+					Interval: 30 * time.Second,
+					Paused:   false,
+					RoleNameFilters: []*NameFilter{
+						{
+							PatternType: "PREFIX",
+							FilterType:  "INCLUDE",
+							Name:        "team-",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
The admin v2 ShadowLink proto now carries a role_sync_options message (Introduced in https://github.com/redpanda-data/redpanda/pull/30838). Add the user-facing config type, the proto mappings in both directions, a describe section, and a sample config block.

The cloud control-plane proto does not expose role sync yet, so it is wired only on the self-hosted admin path and rejected with a clear error for Redpanda Cloud links.

**Sample config:**
```yaml
name: sample-shadow-link
...
role_sync_options:
  interval: 30s
  role_name_filters:
    - pattern_type: LITERAL
      filter_type: INCLUDE
      name: '*'
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Features

* rpk now supports `role_sync_options` when creating a Shadow Link.
