### PR TITLE
[v25.3.x] `transform`: prevent de-reference of `nullptr` at startup

### DIFF
--- a/src/v/transform/api.cc
+++ b/src/v/transform/api.cc
@@ -824,7 +824,13 @@ service::get_factory(model::transform_metadata meta) {
 ss::future<model::cluster_transform_report>
 service::compute_node_local_report() {
     co_return co_await container().map_reduce0(
-      [](service& s) { return s._manager->compute_report(); },
+      [](service& s) {
+          // The internal RPC server starts serving generate_report before the
+          // transform subsystem finishes booting. A peer shard may not have run
+          // service::start() yet, so its _manager may still be null.
+          return s._manager ? s._manager->compute_report()
+                            : model::cluster_transform_report{};
+      },
       model::cluster_transform_report{},
       [](
         model::cluster_transform_report agg,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30907
