### PR TITLE
cloud_storage: remove unused manifest memory tracker

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -115,19 +115,13 @@ segment_meta partition_manifest::lw_segment_meta::convert(
 partition_manifest::partition_manifest()
   : _ntp()
   , _rev()
-  , _mem_tracker(ss::make_shared<util::mem_tracker>(""))
   , _segments()
   , _last_offset(0) {}
 
 partition_manifest::partition_manifest(
-  model::ntp ntp,
-  model::initial_revision_id rev,
-  ss::shared_ptr<util::mem_tracker> partition_mem_tracker)
+  model::ntp ntp, model::initial_revision_id rev)
   : _ntp(std::move(ntp))
   , _rev(rev)
-  , _mem_tracker(
-      partition_mem_tracker ? partition_mem_tracker->create_child("manifest")
-                            : ss::make_shared<util::mem_tracker>(""))
   , _segments()
   , _last_offset(0) {}
 
@@ -629,7 +623,7 @@ bool partition_manifest::advance_start_kafka_offset(
 }
 
 void partition_manifest::unsafe_reset() {
-    *this = partition_manifest{_ntp, _rev, _mem_tracker};
+    *this = partition_manifest{_ntp, _rev};
 }
 
 bool partition_manifest::advance_highest_producer_id(model::producer_id pid) {
@@ -1052,7 +1046,6 @@ partition_manifest partition_manifest::clone() const {
     partition_manifest tmp(
       _ntp,
       _rev,
-      _mem_tracker,
       _start_offset,
       _last_offset,
       _last_uploaded_compacted_offset,
@@ -1280,9 +1273,6 @@ struct partition_manifest_handler
   : public rapidjson::
       BaseReaderHandler<rapidjson::UTF8<>, partition_manifest_handler> {
     using key_string = ss::basic_sstring<char, uint32_t, 31>;
-
-    explicit partition_manifest_handler(ss::shared_ptr<util::mem_tracker> mt)
-      : _manifest_mem_tracker(std::move(mt)) {}
 
     bool StartObject() {
         switch (_state) {
@@ -1799,8 +1789,6 @@ struct partition_manifest_handler
     std::optional<segment_name_format> _meta_sname_format;
     std::optional<size_t> _metadata_size_hint;
 
-    ss::shared_ptr<util::mem_tracker> _manifest_mem_tracker;
-
     void check_that_required_meta_fields_are_present() {
         if (!_size_bytes) {
             throw std::runtime_error(fmt_with_ctx(
@@ -1874,7 +1862,7 @@ void partition_manifest::update_with_json(iobuf buf) {
     std::istream stream(&ibuf);
     json::IStreamWrapper wrapper(stream);
     rapidjson::Reader reader;
-    partition_manifest_handler handler(_mem_tracker);
+    partition_manifest_handler handler;
 
     if (reader.Parse(wrapper, handler)) {
         partition_manifest::do_update(std::move(handler));

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -21,7 +21,6 @@
 #include "model/record.h"
 #include "model/timestamp.h"
 #include "serde/rw/envelope.h"
-#include "utils/tracking_allocator.h"
 
 #include <seastar/core/iostream.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -123,18 +122,13 @@ public:
     /// Create empty manifest that supposed to be updated later
     partition_manifest();
 
-    /// Create manifest for specific ntp with memory tracked on a child tracker
-    /// of `partition_mem_tracker`.
-    explicit partition_manifest(
-      model::ntp ntp,
-      model::initial_revision_id rev,
-      ss::shared_ptr<util::mem_tracker> partition_mem_tracker = nullptr);
+    /// Create manifest for specific ntp.
+    explicit partition_manifest(model::ntp ntp, model::initial_revision_id rev);
 
     template<class segment_t>
     partition_manifest(
       model::ntp ntp,
       model::initial_revision_id rev,
-      ss::shared_ptr<util::mem_tracker> manifest_mem_tracker,
       model::offset so,
       model::offset lo,
       model::offset lco,
@@ -154,7 +148,6 @@ public:
       model::offset last_applied_offset)
       : _ntp(std::move(ntp))
       , _rev(rev)
-      , _mem_tracker(std::move(manifest_mem_tracker))
       , _segments()
       , _last_offset(lo)
       , _start_offset(so)
@@ -496,8 +489,6 @@ public:
     /// after the call.
     void delete_replaced_segments();
 
-    ss::shared_ptr<util::mem_tracker> mem_tracker() { return _mem_tracker; }
-
     /// Transition manifest into such state which makes any uploads or reuploads
     /// impossible.
     void disable_permanently();
@@ -536,7 +527,6 @@ public:
     }
 
     auto serde_fields() {
-        // this list excludes _mem_tracker, which is not serialized
         return std::tie(
           _ntp,
           _rev,
@@ -559,7 +549,6 @@ public:
           _applied_offset);
     }
     auto serde_fields() const {
-        // this list excludes _mem_tracker, which is not serialized
         return std::tie(
           _ntp,
           _rev,
@@ -582,7 +571,7 @@ public:
           _applied_offset);
     }
 
-    /// Compare two manifests for equality. Don't compare the mem_tracker.
+    /// Compare two manifests for equality.
     bool operator==(const partition_manifest& other) const {
         return serde_fields() == other.serde_fields();
     }
@@ -656,10 +645,6 @@ private:
 
     model::ntp _ntp;
     model::initial_revision_id _rev;
-
-    // Tracker of memory for this manifest.
-    // Currently only tracks memory allocated for `_segments`.
-    ss::shared_ptr<util::mem_tracker> _mem_tracker;
 
     segment_map _segments;
     /// Collection of replaced but not yet removed segments

--- a/src/v/cloud_storage/segment_state.h
+++ b/src/v/cloud_storage/segment_state.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cloud_storage/partition_manifest.h"
+#include "container/intrusive_list_helpers.h"
 #include "model/fundamental.h"
 #include "seastar/core/weak_ptr.hh"
 #include "ssx/semaphore.h"

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -459,14 +459,6 @@ SEASTAR_THREAD_TEST_CASE(test_segment_contains) {
       == std::next(m.begin(), m.size() - 1));
 }
 
-// Test for the partition manifest tracked memory.
-SEASTAR_THREAD_TEST_CASE(test_manifest_mem_tracking) {
-    partition_manifest empty_manifest;
-    empty_manifest
-      .update(manifest_format::json, make_manifest_stream(empty_manifest_json))
-      .get();
-}
-
 SEASTAR_THREAD_TEST_CASE(test_manifest_type) {
     partition_manifest m;
     BOOST_REQUIRE(m.get_manifest_type() == manifest_type::partition);
@@ -2044,8 +2036,7 @@ SEASTAR_THREAD_TEST_CASE(test_reset_manifest) {
       path, "60000000/meta/test-ns/test-topic/42_1/manifest.bin");
     BOOST_REQUIRE_EQUAL(m.size(), 5);
 
-    partition_manifest expected{
-      m.get_ntp(), m.get_revision_id(), m.mem_tracker()};
+    partition_manifest expected{m.get_ntp(), m.get_revision_id()};
 
     m.unsafe_reset();
     BOOST_REQUIRE(m == expected);

--- a/src/v/cluster/archival/archival_metadata_stm.cc
+++ b/src/v/cluster/archival/archival_metadata_stm.cc
@@ -691,10 +691,9 @@ archival_metadata_stm::archival_metadata_stm(
   std::optional<model::topic_namespace> remote_topic_namespace_override)
   : raft::persisted_stm<>(archival_stm_snapshot, logger, raft)
   , _logger(logger, ssx::sformat("ntp: {}", raft->ntp()))
-  , _mem_tracker(ss::make_shared<util::mem_tracker>(raft->ntp().path()))
   , _manifest(
       ss::make_shared<cloud_storage::partition_manifest>(
-        raft->ntp(), raft->log_config().get_remote_revision(), _mem_tracker))
+        raft->ntp(), raft->log_config().get_remote_revision()))
   , _cloud_storage_api(remote)
   , _feature_table(ft)
   , _remote_path_provider(
@@ -1250,7 +1249,6 @@ archival_metadata_stm::apply_local_snapshot(
     *_manifest = cloud_storage::partition_manifest(
       _raft->ntp(),
       _raft->log_config().get_remote_revision(),
-      _manifest->mem_tracker(),
       snap.start_offset,
       snap.last_offset,
       snap.last_uploaded_compacted_offset,

--- a/src/v/cluster/archival/archival_metadata_stm.h
+++ b/src/v/cluster/archival/archival_metadata_stm.h
@@ -382,7 +382,6 @@ private:
 
     ssx::mutex _lock{"archival_metadata_stm"};
 
-    ss::shared_ptr<util::mem_tracker> _mem_tracker;
     ss::shared_ptr<cloud_storage::partition_manifest> _manifest;
 
     // The offset of the last mark_clean_cmd applied: if the manifest is


### PR DESCRIPTION
Removes the `_mem_tracker` plumbed through `partition_manifest`, the JSON
parse handler, and `archival_metadata_stm`.

The tracker was wired to the segment map's `tracking_allocator` to back a
segment-memory metric. The cstore migration (`segment_meta_cstore`)
dropped that wiring, so the tracker has tracked nothing since: it is never
fed allocations and its `consumption()` is never read.

Segment metadata size is available via the
`cloud_storage_segments_metadata_bytes` metric.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none