### PR TITLE
[CORE-16027] `ct/l0`: fix divide-by-zero in write scheduler

### DIFF
--- a/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
@@ -224,6 +224,12 @@ schedule_result<Clock> scheduler_context<Clock>::try_schedule_upload(
 
     // First check round-robin: is it this shard's turn within the group?
     auto grp_size = get_group_size(gid);
+    if (grp_size == 0) {
+        // A concurrent split/merge on another shard moved every shard out of
+        // `gid` between reading the group id above and counting its members,
+        // leaving the group momentarily empty from our view.
+        return {schedule_action::skip, std::nullopt, gid};
+    }
     auto current_ix = group.ix.load();
     auto shard_index_in_group = get_shard_index_in_group(shard, gid);
 


### PR DESCRIPTION
`scheduler_context::try_schedule_upload()` reads this shard's group id, then computes the group size in a separate scan of the shared `shard_to_group` array. The scheduler runs concurrently on every shard against a single shared context, so a merge on another shard can move every shard (including this one) out of the group between the two reads. `get_group_size()` then returns 0, and the round-robin check `current_ix % grp_size` divides by zero, raising SIGFPE.

Guard against this crash by checking for `grp_size == 0` before proceeding.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Bug Fixes

* Fixes a bug in which a stale read in the l0 write scheduler could result in a division by zero (raising SIGFPE).