### PR TITLE
storage: simplify head append in segment_appender::do_append

### DIFF
--- a/src/v/storage/segment_appender.cc
+++ b/src/v/storage/segment_appender.cc
@@ -215,16 +215,17 @@ ss::future<> segment_appender::do_append(const char* buf, size_t n) {
             }
         }
 
-        size_t written = 0;
         if (likely(_head)) {
-            const size_t sz = _head->append(buf + written, n - written);
-            written += sz;
-            _bytes_flush_pending += sz;
+            const size_t written = _head->append(buf, n);
+            _bytes_flush_pending += written;
             if (_head->is_full()) {
                 dispatch_background_head_write();
             }
+            buf += written;
+            n -= written;
         }
-        if (written == n) {
+
+        if (n == 0) {
             co_return;
         }
 
@@ -237,9 +238,6 @@ ss::future<> segment_appender::do_append(const char* buf, size_t n) {
         auto chunk = co_await internal::chunks().get();
         vassert(!_head, "cannot overwrite existing chunk");
         _head = std::move(chunk);
-
-        buf += written;
-        n -= written;
     }
 }
 


### PR DESCRIPTION
`written` is always zero at the append call site in
`segment_appender::do_append`, so the `buf + written` / `n - written`
offset arithmetic was a no-op. Append the full buffer directly and reuse
`written` for the returned byte count, dropping the redundant temporary.

No behavior change.

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none