### PR TITLE
datalake: Support nesting value fields

### DIFF
--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -497,7 +497,7 @@ redpanda_cc_library(
     ],
     visibility = [":__subpackages__"],
     deps = [
-        ":schema_identifier",
+        ":record_translator",
         "//src/v/base",
     ],
 )

--- a/src/v/datalake/coordinator/coordinator.cc
+++ b/src/v/datalake/coordinator/coordinator.cc
@@ -497,7 +497,6 @@ coordinator::sync_ensure_table_exists(
                                .properties.schema_registry_context.value_or(
                                  pandaproxy::schema_registry::default_context)
                            : pandaproxy::schema_registry::default_context;
-
     auto res_fut = co_await ss::coroutine::as_future(do_ensure_table_exists(
       topic,
       topic_revision,

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -283,7 +283,7 @@ ss::future<ss::stop_iteration> record_multiplexer::do_multiplex(
             auto record_type = _record_translator.build_type(
               std::move(key_type), std::move(val_type));
             auto ensure_res = co_await _table_creator.ensure_table(
-              _ntp.tp.topic, _topic_revision, record_type.comps);
+              _ntp.tp.topic, _topic_revision, record_type);
             if (ensure_res.has_error()) {
                 auto e = ensure_res.error();
                 switch (e) {

--- a/src/v/datalake/record_translator.cc
+++ b/src/v/datalake/record_translator.cc
@@ -125,28 +125,40 @@ record_type record_translator::build_type(
           = iceberg::string_type{};
     }
 
+    using value_layout = model::iceberg_mode::value_layout;
+
     std::optional<schema_identifier> val_id;
     if (val_type.has_value()) {
         val_id = val_type.value()->id;
         auto struct_type = std::get<iceberg::struct_type>(
           iceberg::make_copy(val_type.value()->type));
         relax_field_requirements(struct_type);
-        for (auto& field : struct_type.fields) {
-            if (field->name == rp_struct_name) {
-                // To avoid collisions, move user fields named "redpanda" into
-                // the nested "redpanda" system field.
-                auto& system_fields = rp_struct_type(ret_type);
-                // Use the next id of the system defaults.
-                system_fields.fields.emplace_back(
-                  iceberg::nested_field::create(
-                    rp_base_next_field_id,
-                    "data",
-                    field->required,
-                    std::move(field->type)));
-                continue;
+        switch (_val_cfg.layout) {
+        case value_layout::nested:
+            ret_type.fields.emplace_back(
+              iceberg::nested_field::create(
+                rp_base_next_field_id,
+                "value",
+                iceberg::field_required::no,
+                std::move(struct_type)));
+            break;
+        case value_layout::flat:
+            for (auto& field : struct_type.fields) {
+                if (field->name == rp_struct_name) {
+                    // To avoid collisions, move user fields named "redpanda"
+                    // into the nested "redpanda" system field.
+                    auto& system_fields = rp_struct_type(ret_type);
+                    system_fields.fields.emplace_back(
+                      iceberg::nested_field::create(
+                        rp_base_next_field_id,
+                        "data",
+                        field->required,
+                        std::move(field->type)));
+                    continue;
+                }
+                ret_type.fields.emplace_back(std::move(field));
             }
-            // Add the extra user-defined fields.
-            ret_type.fields.emplace_back(std::move(field));
+            break;
         }
     } else {
         iceberg::field_type val_field_type
@@ -254,20 +266,30 @@ record_translator::translate_data(
             co_return errc::translation_error;
         }
 
-        auto redpanda_field_idx = get_redpanda_idx(
-          std::get<iceberg::struct_type>(resolved.type));
-        // Unwrap the struct fields.
-        auto& val_struct = std::get<std::unique_ptr<iceberg::struct_value>>(
-          translated_val.value().value());
-        for (size_t i = 0; i < val_struct->fields.size(); ++i) {
-            auto& field = val_struct->fields[i];
-            if (redpanda_field_idx == i) {
-                // To avoid collisions, move user fields named "redpanda" into
-                // the nested "redpanda" system field.
-                rp_struct_value(ret_data).fields.emplace_back(std::move(field));
-                continue;
+        auto val_struct = std::move(
+          std::get<std::unique_ptr<iceberg::struct_value>>(
+            translated_val.value().value()));
+
+        using value_layout = model::iceberg_mode::value_layout;
+        switch (_val_cfg.layout) {
+        case value_layout::nested:
+            ret_data.fields.emplace_back(
+              std::make_optional<iceberg::value>(std::move(val_struct)));
+            break;
+        case value_layout::flat: {
+            auto redpanda_field_idx = get_redpanda_idx(
+              std::get<iceberg::struct_type>(resolved.type));
+            for (size_t i = 0; i < val_struct->fields.size(); ++i) {
+                auto& field = val_struct->fields[i];
+                if (redpanda_field_idx == i) {
+                    rp_struct_value(ret_data).fields.emplace_back(
+                      std::move(field));
+                    continue;
+                }
+                ret_data.fields.emplace_back(std::move(field));
             }
-            ret_data.fields.emplace_back(std::move(field));
+            break;
+        }
         }
     } else {
         if (parsable_val.has_value()) {

--- a/src/v/datalake/table_creator.h
+++ b/src/v/datalake/table_creator.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "base/format_to.h"
-#include "datalake/schema_identifier.h"
+#include "datalake/record_translator.h"
 
 namespace datalake {
 
@@ -38,7 +38,7 @@ public:
     virtual ss::future<checked<std::nullopt_t, errc>> ensure_table(
       const model::topic&,
       model::revision_id topic_revision,
-      record_schema_components) const = 0;
+      const record_type&) const = 0;
 
     virtual ss::future<checked<std::nullopt_t, errc>> ensure_dlq_table(
       const model::topic&, model::revision_id topic_revision) const = 0;

--- a/src/v/datalake/tests/gtest_record_multiplexer_test.cc
+++ b/src/v/datalake/tests/gtest_record_multiplexer_test.cc
@@ -38,7 +38,7 @@ using namespace datalake;
 namespace {
 simple_schema_manager simple_schema_mgr(iceberg::uri("s3://bucket/test"));
 binary_type_resolver bin_resolver;
-direct_table_creator t_creator{bin_resolver, simple_schema_mgr};
+direct_table_creator t_creator{simple_schema_mgr};
 const model::ntp
   ntp(model::ns{"rp"}, model::topic{"t"}, model::partition_id{0});
 const model::revision_id rev{123};
@@ -256,7 +256,7 @@ public:
     RecordMultiplexerParquetTest()
       : schema_mgr(catalog, &features)
       , type_resolver(registry)
-      , t_creator(type_resolver, schema_mgr) {
+      , t_creator(schema_mgr) {
         features.testing_activate_all();
     }
 

--- a/src/v/datalake/tests/record_multiplexer_bench.cc
+++ b/src/v/datalake/tests/record_multiplexer_bench.cc
@@ -399,7 +399,7 @@ public:
       , _schema_mgr(catalog, &_features)
       , _type_resolver(registry, _schema_cache, _resolved_type_cache)
       , _record_gen(&registry)
-      , _table_creator(_type_resolver, _schema_mgr) {
+      , _table_creator(_schema_mgr) {
         _features.testing_activate_all();
     }
 

--- a/src/v/datalake/tests/record_multiplexer_test.cc
+++ b/src/v/datalake/tests/record_multiplexer_test.cc
@@ -122,11 +122,11 @@ public:
     RecordMultiplexerTestBase()
       : schema_mgr(catalog, &features)
       , type_resolver(registry)
-      , t_creator(type_resolver, schema_mgr) {
+      , t_creator(schema_mgr) {
         features.testing_activate_all();
     }
 
-    record_multiplexer make_mux() {
+    record_multiplexer make_mux(record_translator& t = translator) {
         return record_multiplexer(
           ntp,
           topic_rev,
@@ -134,7 +134,7 @@ public:
           schema_mgr,
           type_resolver,
           bin_key_resolver,
-          translator,
+          t,
           t_creator,
           model::iceberg_invalid_record_action::dlq_table,
           iceberg::field_name_comparison::verbatim,
@@ -595,7 +595,7 @@ TEST_F(RecordMultiplexerTest, TestMultiplexingFromMiddleOfBatch) {
 TEST_F(RecordMultiplexerTest, TestRecordTimestamp) {
     // Make sure we respect client vs broker timestamps.
     binary_type_resolver kv_resolver; // This test doesn't need schemas
-    direct_table_creator table_creator(kv_resolver, schema_mgr);
+    direct_table_creator table_creator(schema_mgr);
     record_translator kv_translator;
     auto mux = record_multiplexer(
       ntp,
@@ -647,4 +647,46 @@ TEST_F(RecordMultiplexerTest, TestRecordTimestamp) {
           &partitioning_writer::partitioned_file::partition_key_path,
           remote_path("redpanda.timestamp_hour=2025-09-14-21"))));
     EXPECT_EQ(files.dlq_files.size(), 0);
+}
+
+TEST_F(RecordMultiplexerTest, NestedLayoutSchema) {
+    using vl = model::iceberg_mode::value_layout;
+    using sm = model::iceberg_mode::schema_mode;
+    record_translator nested_translator{
+      {}, {.mode = sm::schema_id_prefix, .layout = vl::nested}, {}};
+
+    tests::record_generator gen(&registry);
+    auto reg_res
+      = gen.register_avro_schema("avro_v1", avro_schema_v1_str).get();
+    ASSERT_FALSE(reg_res.has_error()) << reg_res.error();
+
+    storage::record_batch_builder batch_builder(
+      model::record_batch_type::raft_data, model::offset{0});
+    auto add_res
+      = gen.add_random_avro_record(batch_builder, "avro_v1", std::nullopt)
+          .get();
+    ASSERT_FALSE(add_res.has_error());
+
+    auto reader = model::make_memory_record_batch_reader(
+      {std::move(batch_builder).build()});
+    auto mux = make_mux(nested_translator);
+    mux.multiplex(std::move(reader), kafka::offset{0}, model::no_timeout, as)
+      .get();
+    record_multiplexer::finished_files files;
+    ASSERT_FALSE(std::move(mux).finish(files).get().has_error());
+
+    auto schema = get_current_schema();
+    ASSERT_TRUE(schema.has_value());
+
+    // Nested layout: top-level fields are only "redpanda" and "value".
+    const auto& top = schema->schema_struct.fields;
+    ASSERT_EQ(top.size(), 2);
+    EXPECT_EQ(top[0]->name, "redpanda");
+    EXPECT_EQ(top[1]->name, "value");
+
+    // "value" should be a struct containing the two avro fields.
+    const auto& value_struct = std::get<iceberg::struct_type>(top[1]->type);
+    ASSERT_EQ(value_struct.fields.size(), 2);
+    EXPECT_EQ(value_struct.fields[0]->name, "mynum");
+    EXPECT_EQ(value_struct.fields[1]->name, "mylong");
 }

--- a/src/v/datalake/tests/test_utils.cc
+++ b/src/v/datalake/tests/test_utils.cc
@@ -42,45 +42,16 @@ iceberg::unresolved_partition_spec day_partition_spec() {
     };
 }
 
-direct_table_creator::direct_table_creator(
-  type_resolver& tr, schema_manager& sm)
-  : type_resolver_(tr)
-  , schema_mgr_(sm) {}
+direct_table_creator::direct_table_creator(schema_manager& sm)
+  : schema_mgr_(sm) {}
 
 ss::future<checked<std::nullopt_t, table_creator::errc>>
 direct_table_creator::ensure_table(
-  const model::topic& topic,
-  model::revision_id,
-  record_schema_components comps) const {
+  const model::topic& topic, model::revision_id, const record_type& rt) const {
     auto table_id = table_id_provider::table_id(topic);
-
-    std::optional<shared_resolved_type_t> key_type;
-    if (comps.key_identifier) {
-        auto type_res = co_await type_resolver_.resolve_identifier(
-          comps.key_identifier.value(),
-          pandaproxy::schema_registry::default_context);
-        if (type_res.has_error()) {
-            co_return errc::failed;
-        }
-        key_type = std::move(type_res.value());
-    }
-
-    std::optional<shared_resolved_type_t> val_type;
-    if (comps.val_identifier) {
-        auto type_res = co_await type_resolver_.resolve_identifier(
-          comps.val_identifier.value(),
-          pandaproxy::schema_registry::default_context);
-        if (type_res.has_error()) {
-            co_return errc::failed;
-        }
-        val_type = std::move(type_res.value());
-    }
-
-    auto record_type = record_translator{}.build_type(
-      std::move(key_type), std::move(val_type));
     auto ensure_res = co_await schema_mgr_.ensure_table_schema(
       table_id,
-      record_type.type,
+      rt.type,
       hour_partition_spec(),
       iceberg::field_name_comparison::verbatim);
     if (ensure_res.has_error()) {

--- a/src/v/datalake/tests/test_utils.h
+++ b/src/v/datalake/tests/test_utils.h
@@ -10,7 +10,6 @@
 #pragma once
 
 #include "datalake/catalog_schema_manager.h"
-#include "datalake/record_schema_resolver.h"
 #include "datalake/table_creator.h"
 
 namespace datalake {
@@ -24,18 +23,17 @@ iceberg::unresolved_partition_spec day_partition_spec();
 // Creates or alters the table by interfacing directly with a catalog.
 class direct_table_creator : public table_creator {
 public:
-    direct_table_creator(type_resolver&, schema_manager&);
+    explicit direct_table_creator(schema_manager&);
 
     ss::future<checked<std::nullopt_t, errc>> ensure_table(
       const model::topic&,
       model::revision_id topic_revision,
-      record_schema_components) const final;
+      const record_type&) const final;
 
     ss::future<checked<std::nullopt_t, errc>> ensure_dlq_table(
       const model::topic&, model::revision_id topic_revision) const final;
 
 private:
-    type_resolver& type_resolver_;
     schema_manager& schema_mgr_;
 };
 

--- a/src/v/datalake/tests/translation_task_test.cc
+++ b/src/v/datalake/tests/translation_task_test.cc
@@ -59,8 +59,7 @@ public:
           std::make_unique<simple_schema_manager>(
             iceberg::uri_converter(sr->remote.local().provider())
               .to_uri(bucket_name, "test")))
-      , t_creator(
-          std::make_unique<direct_table_creator>(*schema_resolver, *schema_mgr))
+      , t_creator(std::make_unique<direct_table_creator>(*schema_mgr))
       , location_provider(sr->remote.local().provider(), bucket_name)
       , probe(ntp) {
         set_expectations_and_listen({});

--- a/src/v/datalake/translation/deps.cc
+++ b/src/v/datalake/translation/deps.cc
@@ -212,12 +212,12 @@ public:
     ss::future<checked<std::nullopt_t, errc>> ensure_table(
       const model::topic& topic,
       model::revision_id topic_revision,
-      record_schema_components comps) const final {
+      const record_type& rt) const final {
         auto ensure_res = co_await coordinator_fe_.ensure_table_exists(
           coordinator::ensure_table_exists_request{
             topic,
             topic_revision,
-            comps,
+            rt.comps,
           });
         switch (ensure_res.errc) {
         case coordinator::errc::ok:

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -683,6 +683,12 @@ public:
     /// Whether header values are stored as binary or decoded as UTF-8 strings.
     enum class header_schema_mode : uint8_t { binary, string };
 
+    /// How translated value fields are placed in the Iceberg row.
+    enum class value_layout : uint8_t {
+        flat,   ///< User fields placed at top level of the row (default).
+        nested, ///< User fields wrapped inside a "value" struct.
+    };
+
     /// Schema decoding config for the key section.
     struct key_config {
         schema_mode mode{schema_mode::binary};
@@ -698,7 +704,14 @@ public:
         ss::sstring subject; ///< Empty = <topic>-value (topic name strategy).
         ss::sstring
           protobuf_name; ///< Empty = first proto message definition in schema.
+        value_layout layout{value_layout::flat};
         bool operator==(const value_config&) const = default;
+
+        /// Returns true if this config can be fully represented by the legacy
+        /// wire discriminants (0–3).
+        bool is_legacy_compatible() const noexcept {
+            return layout == value_layout::flat;
+        }
     };
 
     /// Config for the headers section.
@@ -749,7 +762,8 @@ public:
         }
         const auto& e = std::get<enabled_impl>(_impl);
         return e.key.mode != schema_mode::binary
-               || e.headers.value_type != header_schema_mode::binary;
+               || e.headers.value_type != header_schema_mode::binary
+               || !e.value.is_legacy_compatible();
     }
 
     /// \pre !is_disabled()

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -675,6 +675,16 @@ constexpr std::string_view to_sv(iceberg_mode::header_schema_mode t) {
     __builtin_unreachable();
 }
 
+constexpr std::string_view to_sv(iceberg_mode::value_layout l) {
+    switch (l) {
+    case iceberg_mode::value_layout::flat:
+        return "flat";
+    case iceberg_mode::value_layout::nested:
+        return "nested";
+    }
+    return "unknown";
+}
+
 // Parse "opt1=val1,opt2=val2" into a map, enforcing no duplicate keys and no
 // empty keys or values. An empty string returns an empty map (all defaults).
 std::optional<absl::flat_hash_map<std::string, std::string>>
@@ -776,6 +786,29 @@ parse_extended_iceberg_mode(std::string_view str) {
                 cfg.subject = ss::sstring(v);
             } else if (k == "protobuf_name") {
                 cfg.protobuf_name = ss::sstring(v);
+            } else if (k == "layout") {
+                // layout is value-only; key_config has no layout field.
+                if constexpr (requires { cfg.layout; }) {
+                    using vl = iceberg_mode::value_layout;
+                    auto l = string_switch<std::optional<vl>>(v)
+                               .match("flat", vl::flat)
+                               .match("nested", vl::nested)
+                               .default_match(std::nullopt);
+                    if (!l) {
+                        return std::unexpected(
+                          fmt::format(
+                            "unknown layout '{}' in section '{}'",
+                            v,
+                            sec_name));
+                    }
+                    cfg.layout = *l;
+                } else {
+                    return std::unexpected(
+                      fmt::format(
+                        "layout is only valid in the value section, "
+                        "not '{}'",
+                        sec_name));
+                }
             } else {
                 return std::unexpected(
                   fmt::format(
@@ -790,6 +823,19 @@ parse_extended_iceberg_mode(std::string_view str) {
                 "subject and protobuf_name require mode=schema_latest in "
                 "section '{}'",
                 sec_name));
+        }
+        if constexpr (requires { cfg.layout; }) {
+            using sm = iceberg_mode::schema_mode;
+            if (
+              cfg.layout == iceberg_mode::value_layout::nested
+              && cfg.mode != sm::schema_id_prefix
+              && cfg.mode != sm::schema_latest) {
+                return std::unexpected(
+                  fmt::format(
+                    "layout=nested requires a schema mode "
+                    "(schema_id_prefix or schema_latest) in section '{}'",
+                    sec_name));
+            }
         }
         return {};
     };
@@ -841,7 +887,8 @@ void write_nested(iobuf& out, const iceberg_mode& m) {
     // with the old wire discriminants so that old nodes can read them.
     if (
       e.key == iceberg_mode::key_config{}
-      && e.headers == iceberg_mode::headers_config{}) {
+      && e.headers == iceberg_mode::headers_config{}
+      && e.value.is_legacy_compatible()) {
         switch (e.value.mode) {
         case iceberg_mode::schema_mode::binary:
             write(out, wire_key_value);
@@ -910,9 +957,11 @@ fmt::iterator iceberg_mode::format_to(fmt::iterator it) const {
     }
     const auto& e = std::get<enabled_impl>(_impl);
 
-    // If key and headers are at their defaults the config is expressible as a
-    // legacy string; prefer that for maximal compatibility.
-    if (e.key == key_config{} && e.headers == headers_config{}) {
+    // If key, headers, and value are legacy-compatible the config is
+    // expressible as a legacy string; prefer that for maximal compatibility.
+    if (
+      e.key == key_config{} && e.headers == headers_config{}
+      && e.value.is_legacy_compatible()) {
         switch (e.value.mode) {
         case schema_mode::binary:
             return fmt::format_to(it, "key_value");
@@ -950,12 +999,12 @@ fmt::iterator iceberg_mode::format_to(fmt::iterator it) const {
         any = true;
     };
 
-    auto emit_schema_section = [&](std::string_view name, const auto& cfg) {
+    auto emit_key_section = [&](const key_config& cfg) {
         if (cfg.mode == schema_mode::binary) {
-            return; // all defaults, omit
+            return;
         }
         sep();
-        it = fmt::format_to(it, "{}:mode={}", name, to_sv(cfg.mode));
+        it = fmt::format_to(it, "key:mode={}", to_sv(cfg.mode));
         if (!cfg.subject.empty()) {
             it = fmt::format_to(it, ",subject={}", cfg.subject);
         }
@@ -964,14 +1013,45 @@ fmt::iterator iceberg_mode::format_to(fmt::iterator it) const {
         }
     };
 
-    emit_schema_section("key", e.key);
-    emit_schema_section("value", e.value);
-
-    if (e.headers.value_type != header_schema_mode::binary) {
+    auto emit_value_section = [&](const value_config& cfg) {
+        if (cfg.mode == schema_mode::binary && cfg.is_legacy_compatible()) {
+            return;
+        }
         sep();
-        it = fmt::format_to(
-          it, "headers:value_type={}", to_sv(e.headers.value_type));
-    }
+        it = fmt::format_to(it, "value:");
+        bool first = true;
+        auto opt = [&](std::string_view k, std::string_view v) {
+            if (!first) {
+                it = fmt::format_to(it, ",");
+            }
+            it = fmt::format_to(it, "{}={}", k, v);
+            first = false;
+        };
+        if (cfg.mode != schema_mode::binary) {
+            opt("mode", to_sv(cfg.mode));
+        }
+        if (!cfg.subject.empty()) {
+            opt("subject", cfg.subject);
+        }
+        if (!cfg.protobuf_name.empty()) {
+            opt("protobuf_name", cfg.protobuf_name);
+        }
+        if (cfg.layout != value_layout::flat) {
+            opt("layout", to_sv(cfg.layout));
+        }
+    };
+
+    auto emit_headers_section = [&](const headers_config& cfg) {
+        if (cfg.value_type == header_schema_mode::binary) {
+            return;
+        }
+        sep();
+        it = fmt::format_to(it, "headers:value_type={}", to_sv(cfg.value_type));
+    };
+
+    emit_key_section(e.key);
+    emit_value_section(e.value);
+    emit_headers_section(e.headers);
 
     return it;
 }

--- a/src/v/model/tests/iceberg_mode_test.cc
+++ b/src/v/model/tests/iceberg_mode_test.cc
@@ -608,3 +608,91 @@ TEST(IcebergModeParseErrorMsg, SubjectWithStringMode) {
       "subject and protobuf_name require mode=schema_latest in section "
       "'value'");
 }
+
+// --- value layout ---
+
+using vl = model::iceberg_mode::value_layout;
+
+TEST(IcebergModeLayout, ParseNestedWithSchemaIdPrefix) {
+    auto m = parse("value:mode=schema_id_prefix,layout=nested");
+    ASSERT_TRUE(m.has_value());
+    EXPECT_EQ(m->value().mode, sm::schema_id_prefix);
+    EXPECT_EQ(m->value().layout, vl::nested);
+}
+
+TEST(IcebergModeLayout, ParseNestedWithSchemaLatest) {
+    auto m = parse("value:mode=schema_latest,layout=nested");
+    ASSERT_TRUE(m.has_value());
+    EXPECT_EQ(m->value().mode, sm::schema_latest);
+    EXPECT_EQ(m->value().layout, vl::nested);
+}
+
+TEST(IcebergModeLayout, ParseFlatExplicit) {
+    // explicit flat is a no-op; serializes as the legacy key_value string
+    auto m = parse("value:layout=flat");
+    ASSERT_TRUE(m.has_value());
+    EXPECT_EQ(m->value().layout, vl::flat);
+    EXPECT_EQ(to_string(*m), "key_value");
+}
+
+TEST(IcebergModeLayout, ParseNestedWithBinaryRejected) {
+    auto e = parse_err("value:layout=nested");
+    EXPECT_EQ(
+      e,
+      "layout=nested requires a schema mode (schema_id_prefix or "
+      "schema_latest) in section 'value'");
+}
+
+TEST(IcebergModeLayout, ParseNestedWithStringRejected) {
+    auto e = parse_err("value:mode=string,layout=nested");
+    EXPECT_EQ(
+      e,
+      "layout=nested requires a schema mode (schema_id_prefix or "
+      "schema_latest) in section 'value'");
+}
+
+TEST(IcebergModeLayout, ParseLayoutInKeySection) {
+    auto e = parse_err("key:layout=nested");
+    EXPECT_EQ(e, "layout is only valid in the value section, not 'key'");
+}
+
+TEST(IcebergModeLayout, ParseUnknownLayout) {
+    auto e = parse_err("value:layout=sideways");
+    EXPECT_EQ(e, "unknown layout 'sideways' in section 'value'");
+}
+
+TEST(IcebergModeLayout, FormatNested) {
+    enabled e{};
+    e.value.mode = sm::schema_id_prefix;
+    e.value.layout = vl::nested;
+    model::iceberg_mode m{std::move(e)};
+    EXPECT_EQ(to_string(m), "value:mode=schema_id_prefix,layout=nested");
+}
+
+TEST(IcebergModeLayout, StringRoundtripNested) {
+    enabled e{};
+    e.value.mode = sm::schema_id_prefix;
+    e.value.layout = vl::nested;
+    check_stable(model::iceberg_mode{std::move(e)});
+}
+
+TEST(IcebergModeLayout, WireRoundtripNested) {
+    enabled e{};
+    e.value.mode = sm::schema_id_prefix;
+    e.value.layout = vl::nested;
+    model::iceberg_mode m{std::move(e)};
+    EXPECT_EQ(wire_roundtrip(m), m);
+}
+
+TEST(IcebergModeLayout, NestedNeedsExtendedClusterFeature) {
+    enabled e{};
+    e.value.mode = sm::schema_id_prefix;
+    e.value.layout = vl::nested;
+    model::iceberg_mode m{std::move(e)};
+    EXPECT_TRUE(m.needs_extended_cluster_feature());
+}
+
+TEST(IcebergModeLayout, FlatDoesNotNeedExtendedClusterFeature) {
+    EXPECT_FALSE(
+      model::iceberg_mode::key_value.needs_extended_cluster_feature());
+}

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -1803,6 +1803,100 @@ message_type {
                 f_name = f_tuple[0]
                 validate_data_file_path(f_name)
 
+    @cluster(num_nodes=3)
+    @matrix(
+        cloud_storage_type=supported_storage_types(),
+        catalog_type=[CatalogType.REST_JDBC],
+    )
+    def test_iceberg_value_layout(self, cloud_storage_type, catalog_type):
+        """Verify layout=flat and layout=nested produce the expected Iceberg
+        schema shapes and that values are queryable via Spark SQL.
+
+        Flat layout (default): user schema fields are promoted to the top
+        level of the row alongside the 'redpanda' system struct.
+
+        Nested layout: all user fields are wrapped inside a top-level
+        'value' struct, keeping the user schema separate from system fields.
+        """
+        layout_schema_str = json.dumps(
+            {
+                "type": "record",
+                "name": "LayoutTest",
+                "fields": [
+                    {"name": "mynum", "type": "int"},
+                    {"name": "mylong", "type": "long"},
+                ],
+            }
+        )
+        flat_topic = "flat_layout"
+        nested_topic = "nested_layout"
+        record = {"mynum": 42, "mylong": 99}
+
+        with DatalakeServices(
+            self.test_ctx,
+            redpanda=self.redpanda,
+            include_query_engines=[QueryEngineType.SPARK],
+            catalog_type=catalog_type,
+        ) as dl:
+            dl.create_iceberg_enabled_topic(
+                flat_topic,
+                iceberg_mode="value:mode=schema_id_prefix",
+            )
+            dl.create_iceberg_enabled_topic(
+                nested_topic,
+                iceberg_mode="value:mode=schema_id_prefix,layout=nested",
+            )
+
+            schema = avro.loads(layout_schema_str)
+            producer = AvroProducer(
+                {
+                    "bootstrap.servers": self.redpanda.brokers(),
+                    "schema.registry.url": self.redpanda.schema_reg().split(",")[0],
+                },
+                default_value_schema=schema,
+            )
+            producer.produce(topic=flat_topic, value=record)
+            producer.produce(topic=nested_topic, value=record)
+            producer.flush()
+
+            dl.wait_for_translation(flat_topic, msg_count=1)
+            dl.wait_for_translation(nested_topic, msg_count=1)
+
+            # Flat: mynum and mylong are top-level fields; no 'value' wrapper.
+            flat_tbl = dl.catalog_client().load_table(("redpanda", flat_topic))
+            flat_names = [f.name for f in flat_tbl.schema().fields]
+            assert "mynum" in flat_names, flat_names
+            assert "mylong" in flat_names, flat_names
+            assert "value" not in flat_names, flat_names
+
+            # Nested: a top-level 'value' struct holds the user fields.
+            nested_tbl = dl.catalog_client().load_table(("redpanda", nested_topic))
+            nested_top = [f.name for f in nested_tbl.schema().fields]
+            assert "value" in nested_top, nested_top
+            assert "mynum" not in nested_top, nested_top
+            assert "mylong" not in nested_top, nested_top
+            value_field = next(
+                f for f in nested_tbl.schema().fields if f.name == "value"
+            )
+            nested_value_names = [f.name for f in value_field.field_type.fields]
+            assert "mynum" in nested_value_names, nested_value_names
+            assert "mylong" in nested_value_names, nested_value_names
+
+            # SQL: flat fields accessible at top level.
+            spark = dl.spark()
+            flat_rows = spark.run_query_fetch_all(
+                f"SELECT mynum, mylong FROM redpanda.{flat_topic}"
+            )
+            assert len(flat_rows) == 1, flat_rows
+            assert flat_rows[0] == (42, 99), flat_rows[0]
+
+            # SQL: nested fields accessible via the 'value' struct.
+            nested_rows = spark.run_query_fetch_all(
+                f"SELECT value.mynum, value.mylong FROM redpanda.{nested_topic}"
+            )
+            assert len(nested_rows) == 1, nested_rows
+            assert nested_rows[0] == (42, 99), nested_rows[0]
+
 
 class DatalakeMultiBrokerE2ETest(RedpandaTest):
     def __init__(self, test_ctx, *args, **kwargs):


### PR DESCRIPTION
This series of changes adds support for a `layout` key in the `value` section of the expanded iceberg mode config, with possible values `nested` and `flat` (the default and current behavior). When `layout=nested`, value fields will be located inside a top-level `value` struct instead of at the top level (`flat`).

There are three commits:
1. Config support and plumbing. No functional change from the config.
2. Implementation of the nesting.
3. A ducktape test for the nested vs. flat behavior. Should apply regardless of changes to commit 2.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Features

* Adds a new `layout` key to the Iceberg mode config string, in the value section. `layout` supports two values: `nested` and `flat`. When `layout=nested`, translated value fields will be located nested in a `value` key at the top level of the row schema. When `layout=flat`, translated value fields will be located at the top-level, except collisions with names in the `redpanda` metadata struct will be relocated inside `redpanda.data`. `layout=flat` is the default and matches with the previous behavior.
