### PR TITLE
[v25.2.x] [CORE-16282] json: make the schema walk keyword-aware

### DIFF
--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -49,8 +49,10 @@
 #include <jsoncons_ext/jsonschema/jsonschema.hpp>
 #include <rapidjson/error/en.h>
 
+#include <array>
 #include <exception>
 #include <filesystem>
+#include <optional>
 #include <ranges>
 #include <string_view>
 
@@ -2215,6 +2217,105 @@ constexpr const char* id_keyword(json_schema_dialect jsd) {
     return "$id";
 }
 
+// Where a subschema can appear relative to a keyword. Used to walk a schema
+// without mistaking a property name for a keyword: e.g. under "properties" the
+// keys are arbitrary names and only the values are subschemas, so the keyword
+// position of an enclosing schema (such as "id"/"$id") must not be looked up
+// against those names.
+enum class subschema_position : uint8_t {
+    // not a subschema-bearing keyword, do not descend
+    none,
+    // value is a subschema, or an array of subschemas (e.g. "not", "allOf",
+    // "items"); descend by shape
+    schema,
+    // value is a map of name -> subschema (e.g. "properties", "$defs"); descend
+    // into the values, never the map itself
+    map,
+};
+
+// A subschema-bearing keyword and the dialects it applies to. The
+// json_schema_dialect enum is ordered chronologically (draft4 < draft6 < ... <
+// draft202012), so the keyword applies from `since` up to (and including)
+// `until`.
+struct keyword_spec {
+    std::string_view name;
+    subschema_position position;
+    json_schema_dialect since;
+    // last dialect the keyword applies to; nullopt means "from `since` onward
+    // forever" (including future dialects). Set only for keywords that a later
+    // draft removed, so they are not walked in dialects that ignore them.
+    std::optional<json_schema_dialect> until = std::nullopt;
+
+    constexpr bool applies_to(json_schema_dialect dialect) const {
+        return dialect >= since && (!until || dialect <= *until);
+    }
+};
+
+// Classify a keyword by where subschemas appear under it, for the given
+// dialect. The table is organised as a spec changelog: one row per keyword,
+// grouped by the draft that introduced it. A key that is not a keyword in
+// `dialect` (e.g.
+// "$defs" under draft-04) returns `none`, so it is treated as an ordinary name
+// rather than a schema position.
+//
+// NOTE: when adding a new json_schema_dialect, review this table for keywords
+// that dialect introduces.
+constexpr subschema_position
+classify_keyword(json_schema_dialect dialect, std::string_view key) {
+    using enum subschema_position;
+    using enum json_schema_dialect;
+    constexpr auto specs = std::to_array<keyword_spec>({
+      // draft-04 core vocabulary
+      {.name = "properties", .position = map, .since = draft4},
+      {.name = "patternProperties", .position = map, .since = draft4},
+      {.name = "additionalProperties", .position = schema, .since = draft4},
+      {.name = "items", .position = schema, .since = draft4},
+      // "additionalItems" was removed in 2020-12 and "dependencies" split into
+      // "dependentSchemas"/"dependentRequired" in 2019-09; bound them so they
+      // are not walked in later dialects that treat the name as opaque data.
+      {.name = "additionalItems",
+       .position = schema,
+       .since = draft4,
+       .until = draft201909},
+      {.name = "dependencies",
+       .position = map,
+       .since = draft4,
+       .until = draft7},
+      {.name = "allOf", .position = schema, .since = draft4},
+      {.name = "anyOf", .position = schema, .since = draft4},
+      {.name = "oneOf", .position = schema, .since = draft4},
+      {.name = "not", .position = schema, .since = draft4},
+      // ("definitions" is intentionally left unbounded: 2020-12 schemas
+      // commonly still use it as a definitions container.)
+      {.name = "definitions", .position = map, .since = draft4},
+      // draft-06
+      {.name = "propertyNames", .position = schema, .since = draft6},
+      {.name = "contains", .position = schema, .since = draft6},
+      // draft-07
+      {.name = "if", .position = schema, .since = draft7},
+      {.name = "then", .position = schema, .since = draft7},
+      {.name = "else", .position = schema, .since = draft7},
+      // 2019-09
+      {.name = "$defs", .position = map, .since = draft201909},
+      {.name = "dependentSchemas", .position = map, .since = draft201909},
+      {.name = "unevaluatedProperties",
+       .position = schema,
+       .since = draft201909},
+      {.name = "unevaluatedItems", .position = schema, .since = draft201909},
+      {.name = "contentSchema", .position = schema, .since = draft201909},
+      // 2020-12
+      {.name = "prefixItems", .position = schema, .since = draft202012},
+    });
+
+    auto spec = std::ranges::find_if(specs, [&](const keyword_spec& s) {
+        return s.name == key && s.applies_to(dialect);
+    });
+    if (spec != specs.end()) {
+        return spec->position;
+    }
+    return none;
+}
+
 void collect_bundled_schemas_and_fix_refs(
   id_to_schema_pointer& bundled_schemas,
   jsoncons::uri base_uri,
@@ -2294,24 +2395,58 @@ void collect_bundled_schemas_and_fix_refs(
                             .string();
     }
 
-    // lambda to recursively scan the object for more bundled schemas and $refs
-    auto collect_and_fix = [&](const auto& key, auto& value) {
-        collect_bundled_schemas_and_fix_refs(
-          bundled_schemas, base_uri, this_obj_ptr / key, value, dialect);
-    };
+    // lambda to recursively scan a nested subschema for more bundled schemas
+    // and $refs
+    auto recurse_schema =
+      [&](jsoncons::jsonpointer::json_pointer ptr, jsoncons::ojson& value) {
+          collect_bundled_schemas_and_fix_refs(
+            bundled_schemas, base_uri, std::move(ptr), value, dialect);
+      };
+    // recurse into every object element of an array position (e.g. "allOf")
+    auto recurse_array_schemas =
+      [&](const jsoncons::jsonpointer::json_pointer& base,
+          jsoncons::ojson& arr) {
+          for (auto i = 0u; i < arr.size(); ++i) {
+              if (arr[i].is_object()) {
+                  recurse_schema(base / i, arr[i]);
+              }
+          }
+      };
+    // recurse into every object value of a map position (e.g. "properties");
+    // the keys are arbitrary names, only the values are subschemas
+    auto recurse_map_schemas =
+      [&](const jsoncons::jsonpointer::json_pointer& base,
+          jsoncons::ojson& obj) {
+          for (auto& m : obj.object_range()) {
+              if (m.value().is_object()) {
+                  recurse_schema(base / m.key(), m.value());
+              }
+          }
+      };
 
-    // recursively scan the object for more bundled schemas and $refs
+    // recursively scan the object for more bundled schemas and $refs. Only
+    // descend into genuine subschema positions: under keywords like
+    // "properties" the keys are arbitrary property names, so they must not be
+    // treated as schemas (otherwise a property named "id"/"$id"/"$ref" would be
+    // misread as the corresponding keyword).
     for (auto& e : this_obj.object_range()) {
         const auto& key = e.key();
         auto& value = e.value();
-        if (value.is_object()) {
-            collect_and_fix(key, value);
-        } else if (value.is_array()) {
-            for (auto i = 0u; i < value.size(); ++i) {
-                if (value[i].is_object()) {
-                    collect_and_fix(i, value[i]);
-                }
+        switch (classify_keyword(dialect, key)) {
+        case subschema_position::none:
+            break;
+        case subschema_position::map:
+            if (value.is_object()) {
+                recurse_map_schemas(this_obj_ptr / key, value);
             }
+            break;
+        case subschema_position::schema:
+            if (value.is_object()) {
+                recurse_schema(this_obj_ptr / key, value);
+            } else if (value.is_array()) {
+                recurse_array_schemas(this_obj_ptr / key, value);
+            }
+            break;
         }
     }
 }

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -159,9 +159,11 @@ static const auto error_test_cases = std::to_array({
 {
   "$comment": "the root schema is valid but the bundled schema is not",
   "$defs": {
-      "$comment": "dialect is unkown",
+    "bundled": {
+      "$comment": "dialect is unknown",
       "$id": "https://example.com/mismatch_id",
       "$schema": "http://json-schema.org/draft-3000/schema#"
+    }
   }
 }
 )",
@@ -170,19 +172,62 @@ static const auto error_test_cases = std::to_array({
       "bundled schema without a known dialect: "
       "'http://json-schema.org/draft-3000/schema#'"}},
   error_test_case{
+    // The bundled schema declares draft-04, where "exclusiveMinimum" must be a
+    // boolean; the numeric value is valid under the root's 2020-12 metaschema
+    // (so the root is valid and "$defs" is walked) but invalid once the walk
+    // re-validates the bundled schema against its own dialect.
     R"(
 {
   "$comment": "the root schema is valid but the bundled schema is not",
   "$defs": {
+    "bundled": {
       "$comment": "schema is invalid",
-      "$id": "https://example.com/mismatch_id",
-      "type": "potato"
+      "id": "https://example.com/mismatch_id",
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "exclusiveMinimum": 5
+    }
   }
 }
 )",
     pps::error_info{
       pps::error_code::schema_invalid,
-      R"(bundled schema is invalid. Invalid json schema: '{"$comment":"schema is invalid","$id":"https://example.com/mismatch_id","type":"potato"}'. Error: '/type: Must be valid against at least one schema, but found no matching schemas')"}},
+      R"(bundled schema is invalid. Invalid json schema: '{"$comment":"schema is invalid","$schema":"http://json-schema.org/draft-04/schema#","exclusiveMinimum":5,"id":"https://example.com/mismatch_id"}'. Error: '/exclusiveMinimum: Expected boolean, found uint64')"}},
+  // the walk must descend into array positions: a bundled schema under "allOf"
+  // with an unknown dialect is reached and rejected
+  error_test_case{
+    R"(
+{
+  "allOf": [
+    {
+      "$id": "https://example.com/bundled",
+      "$schema": "http://json-schema.org/draft-3000/schema#"
+    }
+  ]
+}
+)",
+    pps::error_info{
+      pps::error_code::schema_invalid,
+      "bundled schema without a known dialect: "
+      "'http://json-schema.org/draft-3000/schema#'"}},
+  // the walk must descend into the tuple-array form of "items" (the
+  // single-or-array fallthrough): the array value forces the dialect to
+  // 2019-09, where "items" may be a tuple, and the bundled element is reached
+  error_test_case{
+    R"(
+{
+  "type": "array",
+  "items": [
+    {
+      "$id": "https://example.com/bundled",
+      "$schema": "http://json-schema.org/draft-3000/schema#"
+    }
+  ]
+}
+)",
+    pps::error_info{
+      pps::error_code::schema_invalid,
+      "bundled schema without a known dialect: "
+      "'http://json-schema.org/draft-3000/schema#'"}},
 });
 SEASTAR_THREAD_TEST_CASE(test_make_invalid_json_schema) {
     for (const auto& data : error_test_cases) {
@@ -277,6 +322,111 @@ static constexpr auto valid_test_cases = std::to_array<std::string_view>({
     "id":{
       "type":"string"
     }
+  }
+})json",
+  // Keyword-named properties and out-of-dialect keywords must be treated as
+  // ordinary names, not schema keywords (CORE-16282). Each registers cleanly;
+  // before the fix these were misread as the "id"/"$id"/"$ref" keyword.
+  //
+  // the exact reported schema: a property named "id" under draft-04
+  R"json(
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": ["string", "null"],
+      "description": "The ID of the element"
+    }
+  }
+})json",
+  // draft-06 (and later) use "$id" as the identifier, so a property named "id"
+  // is an ordinary name here -- only draft-04 has the "id" collision
+  R"json(
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  }
+})json",
+  // a property named "id" nested under "definitions"/"patternProperties" is
+  // also just a property name
+  R"json(
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "elem": {
+      "type": "object",
+      "properties": { "id": { "type": "string" } }
+    }
+  },
+  "patternProperties": {
+    "^x-": { "properties": { "id": { "type": "integer" } } }
+  }
+})json",
+  // other reserved keyword names used as property names must not be treated as
+  // keywords either (their values are subschemas)
+  R"json(
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "$ref": { "type": "string" },
+    "$schema": { "type": "string" }
+  }
+})json",
+  // from draft-06 the identifier keyword is "$id" (not "id"), so a property
+  // named "$id" is the >=draft6 analogue of the reported bug and must likewise
+  // be treated as a property name, not the schema identifier
+  R"json(
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "type": "object",
+  "properties": {
+    "$id": { "type": "string" }
+  }
+})json",
+  // keyword classification is dialect-aware: "$defs" was only introduced in
+  // draft 2019-09, so under draft-04 it is an ordinary member and must not be
+  // walked as a map of subschemas. If it were, the walk would treat the inner
+  // object as a bundled schema (it has the draft-04 "id" keyword) and reject it
+  // for the invalid "type", but draft-04 ignores the unknown "$defs", so the
+  // schema is valid.
+  R"json(
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$defs": {
+    "notAKeywordInDraft4": {
+      "id": "https://example.com/x",
+      "type": "potato"
+    }
+  }
+})json",
+  // dialect gating again, for an array position: "prefixItems" only exists from
+  // 2020-12, so under draft-07 it is an ordinary member and is not walked --
+  // the bundled element with an unknown dialect is never reached, so the schema
+  // is valid (were it walked, the unknown dialect would be rejected)
+  R"json(
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "prefixItems": [
+    {
+      "$id": "https://example.com/bundled",
+      "$schema": "http://json-schema.org/draft-3000/schema#"
+    }
+  ]
+})json",
+  // dialect gating for a removed keyword: "additionalItems" was dropped in
+  // 2020-12, so it is an ordinary member there and is not walked -- the bundled
+  // value with an unknown dialect is never reached, so the schema is valid
+  // (under an earlier draft, where it is a keyword, it would be rejected)
+  R"json(
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalItems": {
+    "$id": "https://example.com/bundled",
+    "$schema": "http://json-schema.org/draft-3000/schema#"
   }
 })json",
 });


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30865

- Command: git cherry-pick -x 4ea8f6e472
- Commits backported: 1
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-30865-v25.2.x-1782387400

## Conflict details

- 4ea8f6e472 (src/v/pandaproxy/schema_registry/json.cc): the source commit was
  written on top of a prior dev-only refactor that converted the bundled-schema
  walk from recursion to an explicit work-stack (`process_work_item` /
  `collect_work_item` / `work_stack`). That refactor does not exist on
  v25.2.x, where `collect_bundled_schemas_and_fix_refs` is still recursive.
  Resolved by applying only this commit's intent — the keyword-aware walk — to
  the recursive version: added the dialect-independent `subschema_position`,
  `keyword_spec`, and `classify_keyword` definitions verbatim, and rewrote the
  scan loop to switch on `classify_keyword(dialect, key)` so only genuine
  subschema positions are descended into. The iterative-only `push_schema` /
  `push_array_schemas` / `push_map_schemas` helpers (which push onto
  `work_stack`) were re-expressed as `recurse_schema` / `recurse_array_schemas`
  / `recurse_map_schemas` that recurse directly, and `item.*` references were
  mapped back to the recursive function's `this_obj` / `this_obj_ptr` /
  `base_uri` / `dialect` locals. The `collect_work_item` struct and
  `process_work_item` scaffolding were intentionally not introduced. The test
  additions in test/test_json_schema.cc auto-merged cleanly.
