### PR TITLE
`ct/l1`: add streaming reads

### DIFF
--- a/src/v/cloud_topics/level_one/common/BUILD
+++ b/src/v/cloud_topics/level_one/common/BUILD
@@ -120,7 +120,6 @@ redpanda_cc_library(
         ":object_id",
         ":object_utils",
         ":single_flight",
-        "//src/v/base",
         "//src/v/cloud_io:cache",
         "//src/v/cloud_io:io_result",
         "//src/v/cloud_io:remote",

--- a/src/v/cloud_topics/level_one/common/abstract_io.cc
+++ b/src/v/cloud_topics/level_one/common/abstract_io.cc
@@ -19,8 +19,11 @@ ss::future<ss::input_stream<char>> io::read_file(staging_file* file) {
 }
 
 ss::future<std::expected<iobuf, io::errc>> io::read_object_as_iobuf(
-  object_extent extent, ss::abort_source* as, cloud_io::group_id gid) {
-    auto result = co_await this->read_object(extent, as, gid);
+  object_extent extent,
+  ss::abort_source* as,
+  cloud_io::group_id gid,
+  bool skip_cache) {
+    auto result = co_await this->read_object(extent, as, gid, skip_cache);
     if (!result) {
         co_return std::unexpected(result.error());
     }

--- a/src/v/cloud_topics/level_one/common/abstract_io.h
+++ b/src/v/cloud_topics/level_one/common/abstract_io.h
@@ -84,14 +84,24 @@ public:
     // Read part of an object from object storage, returning an input stream
     // representing the object data.
     //
-    // Behind the scenes, there may or may not be caching going on.
-    virtual ss::future<std::expected<ss::input_stream<char>, errc>>
-    read_object(object_extent, ss::abort_source*, cloud_io::group_id g) = 0;
+    // Behind the scenes, there may or may not be caching going on. When
+    // `skip_cache` is set the cache is still consulted first, but a miss is
+    // streamed directly from object storage without being written to the cache.
+    // This is intended for bulk, one-shot reads (e.g. leveling and compaction)
+    // that would otherwise pollute the cache with data that won't be re-read.
+    virtual ss::future<std::expected<ss::input_stream<char>, errc>> read_object(
+      object_extent,
+      ss::abort_source*,
+      cloud_io::group_id g,
+      bool skip_cache = false) = 0;
 
     // The same as `read_object` except that instead of returning an input
     // stream, the data is fully buffered into an `iobuf`.
     virtual ss::future<std::expected<iobuf, errc>> read_object_as_iobuf(
-      object_extent, ss::abort_source*, cloud_io::group_id g);
+      object_extent,
+      ss::abort_source*,
+      cloud_io::group_id g,
+      bool skip_cache = false);
 
     // Delete the specified objects from object storage.
     virtual ss::future<std::expected<void, errc>>

--- a/src/v/cloud_topics/level_one/common/fake_io.cc
+++ b/src/v/cloud_topics/level_one/common/fake_io.cc
@@ -114,7 +114,10 @@ ss::future<std::expected<ss::input_stream<char>, io::errc>>
 fake_io::read_object(
   object_extent extent,
   ss::abort_source*,
-  [[maybe_unused]] cloud_io::group_id gid) {
+  [[maybe_unused]] cloud_io::group_id gid,
+  // fake_io keeps everything in memory and never caches, so it is always
+  // effectively a streaming read regardless of this flag.
+  [[maybe_unused]] bool skip_cache) {
     co_return get_object(extent.id)
       .transform(
         [&extent](

--- a/src/v/cloud_topics/level_one/common/fake_io.h
+++ b/src/v/cloud_topics/level_one/common/fake_io.h
@@ -27,7 +27,10 @@ public:
     put_object(object_id, staging_file*, ss::abort_source*) override;
 
     ss::future<std::expected<ss::input_stream<char>, errc>> read_object(
-      object_extent, ss::abort_source*, cloud_io::group_id g) override;
+      object_extent,
+      ss::abort_source*,
+      cloud_io::group_id g,
+      bool skip_cache) override;
 
     ss::future<std::expected<void, errc>>
     delete_objects(chunked_vector<object_id>, ss::abort_source*) override;

--- a/src/v/cloud_topics/level_one/common/file_io.cc
+++ b/src/v/cloud_topics/level_one/common/file_io.cc
@@ -10,7 +10,6 @@
 
 #include "cloud_topics/level_one/common/file_io.h"
 
-#include "base/vassert.h"
 #include "cloud_io/io_result.h"
 #include "cloud_io/remote.h"
 #include "cloud_storage_clients/client.h"
@@ -20,11 +19,16 @@
 #include "cloud_topics/logger.h"
 #include "config/configuration.h"
 
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/file.hh>
 #include <seastar/core/fstream.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/coroutine/as_future.hh>
 
 #include <memory>
 #include <optional>
+#include <utility>
 
 using namespace std::chrono_literals;
 
@@ -87,6 +91,142 @@ struct one_time_stream_provider : public stream_provider {
         return ss::now();
     }
     std::optional<ss::input_stream<char>> _st;
+};
+
+// A streaming download source for L1 objects that chunks downloads per
+// `chunk_size`. This may result in many GET requests per object download.
+//
+// The object's byte range is read one bounded chunk at a time. `get()` fully
+// buffers the next chunk via `download_stream` (a separate ranged GET), which
+// returns the lease to the pool as soon as the chunk's body has been read off
+// the connection. The buffered chunk is then served from memory, lease-free,
+// while subsequent `get()`s drain it; only once it is exhausted is the next
+// chunk fetched. Peak in-memory bytes and the connection-hold duration per read
+// are both bounded by `chunk_size`.
+class streaming_download_source final : public ss::data_source_impl {
+public:
+    // chunk_size bounds both the peak in-memory bytes held per read and the
+    // span of object bytes downloaded under a single held lease. _next_pos and
+    // _last_pos are initialized to inclusive byte ranges.
+    streaming_download_source(
+      cloud_io::remote* remote,
+      cloud_storage_clients::bucket_name bucket,
+      cloud_storage_clients::object_key key,
+      cloud_storage_clients::http_byte_range range,
+      ss::abort_source& as,
+      cloud_io::group_id gid,
+      size_t chunk_size)
+      : _remote(remote)
+      , _bucket(std::move(bucket))
+      , _key(std::move(key))
+      , _next_pos(range.first)
+      , _last_pos(range.second)
+      , _as(as)
+      , _gid(gid)
+      , _chunk_size(chunk_size) {}
+
+    streaming_download_source(const streaming_download_source&) = delete;
+    streaming_download_source&
+    operator=(const streaming_download_source&) = delete;
+    streaming_download_source(streaming_download_source&&) = delete;
+    streaming_download_source& operator=(streaming_download_source&&) = delete;
+    ~streaming_download_source() override = default;
+
+    ss::future<ss::temporary_buffer<char>> get() override {
+        while (true) {
+            _as.check();
+            if (!_current.empty()) {
+                auto buf = std::move(_current.front());
+                _current.pop_front();
+                co_return buf;
+            }
+            if (_next_pos > _last_pos) {
+                // An empty buffer signals end-of-stream.
+                co_return ss::temporary_buffer<char>();
+            }
+            co_await download_next_chunk();
+        }
+    }
+
+    ss::future<> close() override { return ss::now(); }
+
+private:
+    // Fetches the next chunk of the object's byte range into `_current`. The
+    // lease is released when `download_stream` returns, before the buffered
+    // chunk is served.
+    ss::future<> download_next_chunk() {
+        static constexpr auto timeout = 10s;
+        static constexpr auto backoff = 100ms;
+        const auto chunk_first = _next_pos;
+        const auto chunk_last = std::min(
+          chunk_first + _chunk_size - 1, _last_pos);
+        _next_pos = chunk_last + 1;
+        retry_chain_node root(_as, ss::lowres_clock::now() + timeout, backoff);
+
+        cloud_io::try_consume_stream consumer =
+          [this](uint64_t /*content_length*/, ss::input_stream<char> stream) {
+              return drain_chunk(std::move(stream));
+          };
+
+        auto result_fut = co_await ss::coroutine::as_future(
+          _remote->download_stream(
+            cloud_io::transfer_details{
+              .bucket = _bucket,
+              .key = _key,
+              .parent_rtc = root,
+            },
+            consumer,
+            "l1_stream_download",
+            /*acquire_hydration_units=*/true,
+            cloud_storage_clients::http_byte_range{chunk_first, chunk_last},
+            {},
+            _gid));
+        if (result_fut.failed()) {
+            std::rethrow_exception(result_fut.get_exception());
+        }
+        auto result = result_fut.get();
+        if (result != cloud_io::download_result::success) {
+            throw std::runtime_error(
+              fmt::format("L1 streaming download failed: {}", result));
+        }
+    }
+
+    // Reads a chunk's whole body into `_current`. Cleared up-front so that a
+    // retried download re-buffers from scratch rather than appending to a
+    // partially-read result.
+    ss::future<uint64_t> drain_chunk(ss::input_stream<char> stream) {
+        _current.clear();
+        uint64_t total = 0;
+        std::exception_ptr ex;
+        try {
+            while (true) {
+                _as.check();
+                auto buf = co_await stream.read();
+                if (buf.empty()) {
+                    break;
+                }
+                total += buf.size();
+                _current.push_back(std::move(buf));
+            }
+        } catch (...) {
+            ex = std::current_exception();
+        }
+        co_await stream.close();
+        if (ex) {
+            std::rethrow_exception(ex);
+        }
+        co_return total;
+    }
+
+    cloud_io::remote* _remote;
+    cloud_storage_clients::bucket_name _bucket;
+    cloud_storage_clients::object_key _key;
+    size_t _next_pos;
+    size_t _last_pos;
+    ss::abort_source& _as;
+    cloud_io::group_id _gid;
+    size_t _chunk_size;
+    ss::chunked_fifo<ss::temporary_buffer<char>> _current;
 };
 
 } // namespace
@@ -242,7 +382,10 @@ ss::future<std::expected<void, io::errc>> file_io::do_download_to_cache(
 
 ss::future<std::expected<ss::input_stream<char>, io::errc>>
 file_io::read_object(
-  object_extent extent, ss::abort_source* as, cloud_io::group_id gid) {
+  object_extent extent,
+  ss::abort_source* as,
+  cloud_io::group_id gid,
+  bool skip_cache) {
     if (_gate.is_closed()) {
         co_return std::unexpected(io::errc::file_io_error);
     }
@@ -278,6 +421,22 @@ file_io::read_object(
 
         if (_probe) {
             _probe->register_cache_miss();
+        }
+
+        if (skip_cache) {
+            // Not in the cache: stream directly from object storage in bounded
+            // chunks without populating the cache.
+            co_return ss::input_stream<char>(ss::data_source(
+              std::make_unique<streaming_download_source>(
+                _remote,
+                _bucket,
+                object_path_factory::level_one_path(extent.id),
+                cloud_storage_clients::http_byte_range{
+                  extent.position, extent.position + extent.size - 1},
+                *as,
+                gid,
+                config::shard_local_cfg()
+                  .cloud_topics_l1_streaming_read_chunk_size())));
         }
 
         // single_flight dedups concurrent downloads for this extent.

--- a/src/v/cloud_topics/level_one/common/file_io.h
+++ b/src/v/cloud_topics/level_one/common/file_io.h
@@ -55,7 +55,10 @@ public:
     put_object(object_id, staging_file*, ss::abort_source*) override;
 
     ss::future<std::expected<ss::input_stream<char>, errc>> read_object(
-      object_extent, ss::abort_source*, cloud_io::group_id g) override;
+      object_extent,
+      ss::abort_source*,
+      cloud_io::group_id g,
+      bool skip_cache) override;
 
     ss::future<std::expected<void, errc>>
     delete_objects(chunked_vector<object_id>, ss::abort_source*) override;

--- a/src/v/cloud_topics/level_one/common/tests/BUILD
+++ b/src/v/cloud_topics/level_one/common/tests/BUILD
@@ -45,3 +45,35 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "file_io_stream_test",
+    timeout = "short",
+    srcs = [
+        "file_io_stream_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:iobuf_parser",
+        "//src/v/cloud_io:basic_cache_service_api",
+        "//src/v/cloud_io:cache",
+        "//src/v/cloud_io:remote",
+        "//src/v/cloud_io:remote_api",
+        "//src/v/cloud_io/tests:s3_imposter",
+        "//src/v/cloud_io/tests:scoped_remote",
+        "//src/v/cloud_storage_clients",
+        "//src/v/cloud_topics/level_one/common:file_io",
+        "//src/v/cloud_topics/level_one/common:object_id",
+        "//src/v/cloud_topics/level_one/common:object_utils",
+        "//src/v/config",
+        "//src/v/storage:disk",
+        "//src/v/test_utils:gtest",
+        "//src/v/test_utils:scoped_config",
+        "//src/v/test_utils:tmp_dir",
+        "//src/v/utils:retry_chain_node",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_one/common/tests/file_io_stream_test.cc
+++ b/src/v/cloud_topics/level_one/common/tests/file_io_stream_test.cc
@@ -1,0 +1,344 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "base/units.h"
+#include "bytes/iobuf.h"
+#include "bytes/iobuf_parser.h"
+#include "cloud_io/basic_cache_service_api.h"
+#include "cloud_io/cache_service.h"
+#include "cloud_io/remote.h"
+#include "cloud_io/tests/s3_imposter.h"
+#include "cloud_io/tests/scoped_remote.h"
+#include "cloud_topics/level_one/common/file_io.h"
+#include "cloud_topics/level_one/common/object_id.h"
+#include "cloud_topics/level_one/common/object_utils.h"
+#include "config/property.h"
+#include "storage/disk.h"
+#include "test_utils/scoped_config.h"
+#include "test_utils/test.h"
+#include "test_utils/tmp_dir.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/sharded.hh>
+
+#include <gtest/gtest.h>
+
+using namespace cloud_topics;
+using namespace std::chrono_literals;
+
+namespace {
+
+ss::abort_source never_abort;
+
+ss::future<ss::sstring> drain(ss::input_stream<char> stream) {
+    iobuf buf;
+    while (true) {
+        auto chunk = co_await stream.read();
+        if (chunk.empty()) {
+            break;
+        }
+        buf.append(std::move(chunk));
+    }
+    co_await stream.close();
+    iobuf_parser p(std::move(buf));
+    co_return p.read_string(p.bytes_left());
+}
+
+} // namespace
+
+// Exercises file_io's skip_cache (streaming) read path against a real remote
+// and cache backed by the S3 imposter. The streaming path bridges
+// download_stream (push) into a pull input_stream without ever populating the
+// local cache.
+class l1_file_io_stream_test
+  : public s3_imposter_fixture
+  , public seastar_test {
+public:
+    void SetUp() override {
+        set_expectations_and_listen({});
+        _scoped = cloud_io::scoped_remote::create(1, get_configuration());
+
+        _cache_dir = _tmp.get_path() / "cache";
+        cloud_io::cache::initialize(_cache_dir).get();
+        _cache
+          .start(
+            _cache_dir,
+            30_GiB,
+            config::mock_binding<double>(0.0),
+            config::mock_binding<uint64_t>(1_MiB + 500_KiB),
+            config::mock_binding<std::optional<double>>(std::nullopt),
+            config::mock_binding<uint32_t>(100000),
+            config::mock_binding<uint16_t>(3))
+          .get();
+        _cache.invoke_on_all([](cloud_io::cache& c) { return c.start(); })
+          .get();
+        _cache
+          .invoke_on(
+            ss::shard_id{0},
+            [](cloud_io::cache& c) {
+                c.notify_disk_status(
+                  100_GiB, 50_GiB, storage::disk_space_alert::ok);
+            })
+          .get();
+
+        _io = std::make_unique<l1::file_io>(
+          _tmp.get_path() / "staging",
+          &_scoped->remote.local(),
+          bucket_name,
+          &_cache.local());
+    }
+
+    void TearDown() override {
+        _io.reset();
+        _cache.stop().get();
+        _scoped->request_stop();
+        _scoped.reset();
+    }
+
+    void upload(l1::object_id oid, std::string_view body) {
+        retry_chain_node rtc(never_abort, 5s, 100ms);
+        auto res
+          = _scoped->remote.local()
+              .upload_object(
+                {.transfer_details
+                 = {.bucket = bucket_name, .key = l1::object_path_factory::level_one_path(oid), .parent_rtc = rtc},
+                 .display_str = "test-upload",
+                 .payload = iobuf::from(body)})
+              .get();
+        ASSERT_EQ(res, cloud_io::upload_result::success);
+    }
+
+    // The cache key file_io derives for a given extent.
+    std::filesystem::path cache_key(const l1::object_extent& e) {
+        return fmt::format(
+          "l1_{}_position_{}_size_{}.partial", e.id, e.position, e.size);
+    }
+
+    cloud_io::cache_element_status is_cached(const l1::object_extent& e) {
+        return _cache.local().is_cached(cache_key(e)).get();
+    }
+
+    temporary_dir _tmp{"l1_file_io_stream_test"};
+    std::filesystem::path _cache_dir;
+    std::unique_ptr<cloud_io::scoped_remote> _scoped;
+    ss::sharded<cloud_io::cache> _cache;
+    std::unique_ptr<l1::file_io> _io;
+};
+
+TEST_F(l1_file_io_stream_test, streaming_read_returns_full_object) {
+    auto oid = l1::create_object_id();
+    const ss::sstring body = "hello level one streaming read";
+    upload(oid, body);
+
+    l1::object_extent extent{.id = oid, .position = 0, .size = body.size()};
+    auto stream_res = _io
+                        ->read_object(
+                          extent,
+                          &never_abort,
+                          cloud_io::group_id::default_group,
+                          /*skip_cache=*/true)
+                        .get();
+    ASSERT_TRUE(stream_res.has_value());
+    auto contents = drain(std::move(stream_res).value()).get();
+
+    EXPECT_EQ(contents, body);
+    // The streaming path must not populate the cache.
+    EXPECT_EQ(is_cached(extent), cloud_io::cache_element_status::not_available);
+}
+
+TEST_F(l1_file_io_stream_test, cached_read_populates_cache) {
+    auto oid = l1::create_object_id();
+    const ss::sstring body = "this read goes through the cache";
+    upload(oid, body);
+
+    l1::object_extent extent{.id = oid, .position = 0, .size = body.size()};
+    auto stream_res = _io
+                        ->read_object(
+                          extent,
+                          &never_abort,
+                          cloud_io::group_id::default_group,
+                          /*skip_cache=*/false)
+                        .get();
+    ASSERT_TRUE(stream_res.has_value());
+    auto contents = drain(std::move(stream_res).value()).get();
+
+    EXPECT_EQ(contents, body);
+    // The cached path, in contrast, leaves the extent in the cache.
+    EXPECT_EQ(is_cached(extent), cloud_io::cache_element_status::available);
+}
+
+TEST_F(l1_file_io_stream_test, skip_cache_read_served_from_cache_when_present) {
+    auto oid = l1::create_object_id();
+    const ss::sstring body = "skip_cache still reads an already-cached object";
+    upload(oid, body);
+
+    l1::object_extent extent{.id = oid, .position = 0, .size = body.size()};
+
+    // Populate the cache via a normal (non-skip) read.
+    {
+        auto res = _io
+                     ->read_object(
+                       extent,
+                       &never_abort,
+                       cloud_io::group_id::default_group,
+                       /*skip_cache=*/false)
+                     .get();
+        ASSERT_TRUE(res.has_value());
+        EXPECT_EQ(drain(std::move(res).value()).get(), body);
+    }
+    ASSERT_EQ(is_cached(extent), cloud_io::cache_element_status::available);
+
+    auto count_gets = [this] {
+        return get_requests([](const http_test_utils::request_info& r) {
+                   return r.method == "GET";
+               })
+          .size();
+    };
+    const auto gets_before = count_gets();
+
+    // skip_cache only suppresses cache *insertion*, not lookup: an extent
+    // already on disk is served from the cache, so this read issues no
+    // additional GET to object storage and leaves the cache populated.
+    auto res = _io
+                 ->read_object(
+                   extent,
+                   &never_abort,
+                   cloud_io::group_id::default_group,
+                   /*skip_cache=*/true)
+                 .get();
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(drain(std::move(res).value()).get(), body);
+
+    EXPECT_EQ(count_gets(), gets_before);
+    EXPECT_EQ(is_cached(extent), cloud_io::cache_element_status::available);
+}
+
+TEST_F(l1_file_io_stream_test, streaming_read_partial_extent) {
+    auto oid = l1::create_object_id();
+    const ss::sstring body = "0123456789abcdef";
+    upload(oid, body);
+
+    // Read a sub-range of the object; the bridge passes the byte range through
+    // to download_stream.
+    l1::object_extent extent{.id = oid, .position = 4, .size = 6};
+    auto stream_res = _io
+                        ->read_object(
+                          extent,
+                          &never_abort,
+                          cloud_io::group_id::default_group,
+                          /*skip_cache=*/true)
+                        .get();
+    ASSERT_TRUE(stream_res.has_value());
+    auto contents = drain(std::move(stream_res).value()).get();
+
+    EXPECT_EQ(contents, "456789");
+    EXPECT_EQ(is_cached(extent), cloud_io::cache_element_status::not_available);
+}
+
+TEST_F(l1_file_io_stream_test, streaming_read_early_close_does_not_hang) {
+    auto oid = l1::create_object_id();
+    // Spans several get() reads so a buffered chunk remains after the first
+    // read; close() must drop it and return without hanging.
+    const ss::sstring body(4_MiB, 'x');
+    upload(oid, body);
+
+    l1::object_extent extent{.id = oid, .position = 0, .size = body.size()};
+    auto stream_res = _io
+                        ->read_object(
+                          extent,
+                          &never_abort,
+                          cloud_io::group_id::default_group,
+                          /*skip_cache=*/true)
+                        .get();
+    ASSERT_TRUE(stream_res.has_value());
+    auto stream = std::move(stream_res).value();
+
+    // Read once, then close with bytes still buffered. close() must drop the
+    // buffered remainder and return rather than hang.
+    auto chunk = stream.read().get();
+    EXPECT_FALSE(chunk.empty());
+    stream.close().get();
+}
+
+TEST_F(l1_file_io_stream_test, streaming_read_abort_surfaces_as_error) {
+    auto oid = l1::create_object_id();
+    // Spans several get() reads so buffered bytes remain when we abort.
+    const ss::sstring body(4_MiB, 'x');
+    upload(oid, body);
+
+    ss::abort_source as;
+    l1::object_extent extent{.id = oid, .position = 0, .size = body.size()};
+    auto stream_res = _io
+                        ->read_object(
+                          extent,
+                          &as,
+                          cloud_io::group_id::default_group,
+                          /*skip_cache=*/true)
+                        .get();
+    ASSERT_TRUE(stream_res.has_value());
+    auto stream = std::move(stream_res).value();
+
+    // Consume one chunk, then abort. The remainder of the read must fail with
+    // an exception rather than terminating as a (truncated) clean end-of-stream
+    // -- otherwise a cancelled maintenance read could be committed as if it had
+    // read the whole extent.
+    auto first = stream.read().get();
+    EXPECT_FALSE(first.empty());
+    as.request_abort();
+
+    EXPECT_THROW(
+      {
+          while (!stream.read().get().empty()) {
+          }
+      },
+      ss::abort_requested_exception);
+    stream.close().get();
+}
+
+TEST_F(l1_file_io_stream_test, streaming_read_chunks_large_object) {
+    // Pin the chunk size so the test is independent of the configured
+    // default: a read larger than one chunk must be served as several ranged
+    // GETs (each releasing the lease) and reassembled in order.
+    static constexpr size_t chunk_size = 1_MiB;
+    scoped_config cfg;
+    cfg.get("cloud_topics_l1_streaming_read_chunk_size").set_value(chunk_size);
+    const size_t total = 2 * chunk_size + 512_KiB; // spans 3 chunks
+
+    auto oid = l1::create_object_id();
+    // Position-dependent (ASCII, so the UTF8 drain() accepts it) content so a
+    // misordered or truncated chunk is caught by the comparison below: the
+    // chunk size is not a multiple of 26, so an out-of-order chunk breaks the
+    // pattern at the seam.
+    ss::sstring body(total, '\0');
+    for (size_t i = 0; i < total; ++i) {
+        body[i] = static_cast<char>('a' + (i % 26));
+    }
+    upload(oid, body);
+
+    l1::object_extent extent{.id = oid, .position = 0, .size = total};
+    auto stream_res = _io
+                        ->read_object(
+                          extent,
+                          &never_abort,
+                          cloud_io::group_id::default_group,
+                          /*skip_cache=*/true)
+                        .get();
+    ASSERT_TRUE(stream_res.has_value());
+    auto contents = drain(std::move(stream_res).value()).get();
+
+    EXPECT_EQ(contents.size(), body.size());
+    EXPECT_EQ(contents, body);
+    EXPECT_EQ(is_cached(extent), cloud_io::cache_element_status::not_available);
+
+    // ceil(total / chunk_size) ranged GETs, one per chunk.
+    auto gets = get_requests(
+      [](const http_test_utils::request_info& r) { return r.method == "GET"; });
+    EXPECT_EQ(gets.size(), 3);
+}

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -162,8 +162,12 @@ level_one_log_reader_impl::read_some(
               read_batches(*_current_stream->reader));
             if (read_fut.failed()) {
                 auto ex = read_fut.get_exception();
-                vlog(
-                  _log.error,
+                auto log_level = ssx::is_shutdown_exception(ex)
+                                   ? ss::log_level::debug
+                                   : ss::log_level::error;
+                vlogl(
+                  _log,
+                  log_level,
                   "Exception reading from open stream (object {}): {}",
                   _current_stream->oid,
                   ex);
@@ -330,8 +334,11 @@ ss::future<l1::footer> level_one_log_reader_impl::read_footer(
       extent, abort_source, _config.group, _config.skip_cache));
     if (read_fut.failed()) {
         auto ex = read_fut.get_exception();
-        vlog(
-          _log.error,
+        auto log_level = ssx::is_shutdown_exception(ex) ? ss::log_level::debug
+                                                        : ss::log_level::error;
+        vlogl(
+          _log,
+          log_level,
           "Exception opening stream for footer from object {} (pos {} object "
           "size {}): {}",
           oid,

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -92,12 +92,23 @@ level_one_log_reader_impl::open_reader_at(
       .position = extent_position,
       .size = extent_size,
     };
+    // Choose the abort source for the read. Prefer the caller's, which always
+    // outlives the read. A skip_cache read streams in the background and
+    // outlives this call, so it can't fall back to the local abort source
+    // (it would dangle) and uses none; a cached read completes before we
+    // return, so the local fallback is safe there.
     ss::abort_source default_abort_source;
-    auto* abort_source = _config.abort_source
-                           ? &_config.abort_source.value().get()
-                           : &default_abort_source;
-    auto stream_fut = co_await ss::coroutine::as_future(
-      _io->read_object(extent, abort_source, _config.group));
+    ss::abort_source* abort_source = nullptr;
+    if (_config.abort_source) {
+        abort_source = &_config.abort_source.value().get();
+    } else {
+        vassert(
+          !_config.skip_cache,
+          "skip_cache reads require a caller-provided abort source");
+        abort_source = &default_abort_source;
+    }
+    auto stream_fut = co_await ss::coroutine::as_future(_io->read_object(
+      extent, abort_source, _config.group, _config.skip_cache));
     if (stream_fut.failed()) {
         auto ex = stream_fut.get_exception();
         vlog(
@@ -315,8 +326,8 @@ ss::future<l1::footer> level_one_log_reader_impl::read_footer(
     auto* abort_source = _config.abort_source
                            ? &_config.abort_source.value().get()
                            : &default_abort_source;
-    auto read_fut = co_await ss::coroutine::as_future(
-      _io->read_object_as_iobuf(extent, abort_source, _config.group));
+    auto read_fut = co_await ss::coroutine::as_future(_io->read_object_as_iobuf(
+      extent, abort_source, _config.group, _config.skip_cache));
     if (read_fut.failed()) {
         auto ex = read_fut.get_exception();
         vlog(

--- a/src/v/cloud_topics/level_one/maintenance/compaction/compaction_source.cc
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/compaction_source.cc
@@ -216,6 +216,7 @@ ss::future<ss::stop_iteration> compaction_source::map_building_iteration() {
           max_offset,
           std::nullopt,
           _as);
+        config.skip_cache = true;
         auto rdr = model::record_batch_reader(
           std::make_unique<level_one_log_reader_impl>(
             config, _ntp, _tp, _metastore, _io, _l1_reader_probe));
@@ -289,6 +290,7 @@ ss::future<ss::stop_iteration> compaction_source::deduplication_iteration(
           last_offset,
           std::nullopt,
           _as);
+        config.skip_cache = true;
         auto rdr = model::record_batch_reader(
           std::make_unique<level_one_log_reader_impl>(
             config, _ntp, _tp, _metastore, _io, _l1_reader_probe));

--- a/src/v/cloud_topics/level_one/maintenance/leveling/leveling_source.cc
+++ b/src/v/cloud_topics/level_one/maintenance/leveling/leveling_source.cc
@@ -82,6 +82,7 @@ ss::future<ss::stop_iteration> leveling_source::deduplication_iteration(
       last_offset,
       std::nullopt,
       _as);
+    config.skip_cache = true;
     auto rdr = model::record_batch_reader(
       std::make_unique<level_one_log_reader_impl>(
         config, _ntp, _tp, _metastore, _io));

--- a/src/v/cloud_topics/level_one/metastore/tests/garbage_collector_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/garbage_collector_test.cc
@@ -205,8 +205,11 @@ public:
     }
 
     ss::future<std::expected<ss::input_stream<char>, errc>> read_object(
-      object_extent ext, ss::abort_source* as, cloud_io::group_id g) override {
-        return underlying_->read_object(ext, as, g);
+      object_extent ext,
+      ss::abort_source* as,
+      cloud_io::group_id g,
+      bool skip_cache) override {
+        return underlying_->read_object(ext, as, g, skip_cache);
     }
 
     ss::future<std::expected<void, errc>>

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4955,6 +4955,19 @@ configuration::configuration()
        .visibility = visibility::tunable},
       128_MiB,
       {.min = 16_MiB, .max = 100_GiB})
+  , cloud_topics_l1_streaming_read_chunk_size(
+      *this,
+      "cloud_topics_l1_streaming_read_chunk_size",
+      "Maximum number of object-storage bytes that a cache-bypassing L1 "
+      "streaming read (used by leveling and compaction) buffers in memory at "
+      "once before serving them to the reader. Bounds both peak per-read "
+      "memory and how much of an object is downloaded under a single held "
+      "cloud storage client connection.",
+      {.needs_restart = needs_restart::no,
+       .example = "16777216",
+       .visibility = visibility::tunable},
+      32_MiB,
+      {.min = 1_MiB, .max = 128_MiB})
   , cloud_topics_long_term_garbage_collection_interval(
       *this,
       "cloud_topics_long_term_garbage_collection_interval",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -828,6 +828,7 @@ public:
     property<bool> cloud_topics_compaction_disabled;
     property<bool> cloud_topics_leveling_disabled;
     bounded_property<uint64_t> cloud_topics_compaction_key_map_memory;
+    bounded_property<size_t> cloud_topics_l1_streaming_read_chunk_size;
     property<std::chrono::milliseconds>
       cloud_topics_long_term_garbage_collection_interval;
     property<std::chrono::milliseconds> cloud_topics_long_term_flush_interval;


### PR DESCRIPTION
Caching data read for maintenance jobs (compaction, leveling) makes little sense:
1. it can thrash the cache which holds data that is actually important for consumers and indicative of current fetch patterns
2. data read during maintenance jobs is ostensibly never going to be read again, since these operations replace objects in the `metastore` which will be the objects ultimately fetched in the future. 

Add cache-bypassing streaming reads to the `l1::io` layer and allow l1 readers to utilize this approach instead through use of the existing `skip_cache` boolean. This flag is applied to leveling and compaction readers.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
