### PR TITLE
[CORE-16434] cluster_link: Fix prefix truncation liveness issue

### DIFF
--- a/src/v/cluster_link/replication/partition_replicator.cc
+++ b/src/v/cluster_link/replication/partition_replicator.cc
@@ -16,12 +16,18 @@
 
 #include <seastar/coroutine/switch_to.hh>
 
+#include <chrono>
+#include <exception>
+
 using namespace std::chrono_literals;
 
 namespace cluster_link::replication {
 
 static constexpr std::chrono::seconds base_backoff{1};
 static constexpr std::chrono::seconds max_backoff{10};
+
+static constexpr std::chrono::milliseconds base_sync_backoff{2500};
+static constexpr std::chrono::milliseconds max_sync_backoff{15000};
 
 partition_replicator::partition_replicator(
   const model::ntp& ntp,
@@ -42,6 +48,9 @@ partition_replicator::partition_replicator(
   , _backoff_policy(
       make_exponential_backoff_policy<ss::lowres_clock>(
         base_backoff, max_backoff))
+  , _sync_backoff_policy(
+      make_exponential_backoff_policy<ss::lowres_clock>(
+        base_sync_backoff, max_sync_backoff))
   , _probe{}
   , _link_data_probe{std::move(ldp)} {
     if (cfg.has_value()) {
@@ -76,6 +85,19 @@ ss::future<> partition_replicator::start() {
                                  ? ss::log_level::trace
                                  : ss::log_level::warn;
               vlogl(_log, log_level, "Error in fetch_and_replicate: {}", e);
+          });
+    });
+    ssx::repeat_until_gate_closed_or_aborted(_gate, _as, [this] {
+        return maybe_synchronize_start_offset_bg().handle_exception(
+          [this](const std::exception_ptr& e) {
+              auto log_level = ssx::is_shutdown_exception(e)
+                                 ? ss::log_level::trace
+                                 : ss::log_level::warn;
+              vlogl(
+                _log,
+                log_level,
+                "Error in maybe_synchronize_start_offset_bg: {}",
+                e);
           });
     });
 }
@@ -260,7 +282,6 @@ ss::future<> partition_replicator::fetch_and_replicate() {
         while (!_gate.is_closed() && !as.abort_requested()) {
             auto inflight_units = co_await ss::get_units(_max_requests, 1, as);
             auto data = co_await _source->fetch_next(as);
-            co_await maybe_synchronize_start_offset();
             if (data.batches.empty()) {
                 continue;
             }
@@ -319,19 +340,49 @@ ss::future<> partition_replicator::fetch_and_replicate() {
     }
 }
 
-ss::future<> partition_replicator::maybe_synchronize_start_offset() {
+ss::future<> partition_replicator::maybe_synchronize_start_offset_bg() {
+    while (!_gate.is_closed() && !_as.abort_requested()) {
+        auto sleep_for = _sync_backoff_policy.current_backoff_duration();
+        vlog(
+          _log.trace,
+          "(sync-start-offset) backing off for {}ms",
+          sleep_for / std::chrono::milliseconds{1});
+        try {
+            co_await ss::sleep_abortable(sleep_for, _as);
+            auto inflight = co_await ss::get_units(_max_requests, 1, _as);
+            auto truncated = co_await maybe_synchronize_start_offset();
+            // Reset the backoff when we made progress so a follow-up
+            // truncation is applied promptly; otherwise keep backing off.
+            if (truncated) {
+                _sync_backoff_policy.reset();
+            } else {
+                _sync_backoff_policy.next_backoff();
+            }
+        } catch (...) {
+            auto eptr = std::current_exception();
+            if (ssx::is_shutdown_exception(eptr)) {
+                vlog(_log.trace, "Shutdown exception in sync-start loop");
+                break;
+            }
+            vlog(_log.warn, "Error in sync-start loop: {}", eptr);
+            _sync_backoff_policy.next_backoff();
+        }
+    }
+}
+
+ss::future<bool> partition_replicator::maybe_synchronize_start_offset() {
     auto shadow_partition_hwm = _sink->high_watermark();
     auto shadow_partition_start_offset = _sink->start_offset();
     auto source_offsets = _source->get_offsets();
 
     if (!_sink->can_prefix_truncate()) {
         vlog(_log.trace, "Partition does not support prefix truncation");
-        co_return;
+        co_return false;
     }
 
     if (!source_offsets.has_value()) {
         vlog(_log.debug, "Source partition not reporting offsets");
-        co_return;
+        co_return false;
     }
 
     auto source_start_offset = source_offsets->source_start_offset;
@@ -344,7 +395,7 @@ ss::future<> partition_replicator::maybe_synchronize_start_offset() {
           "shadow: {}",
           source_start_offset,
           shadow_partition_start_offset);
-        co_return;
+        co_return false;
     }
 
     // The source partition may perform a prefix truncation that lands in the
@@ -367,7 +418,7 @@ ss::future<> partition_replicator::maybe_synchronize_start_offset() {
           source_start_offset,
           source_lso,
           shadow_partition_hwm);
-        co_return;
+        co_return false;
     }
 
     auto truncate_offset = std::max(_truncation_floor, source_start_offset);
@@ -378,6 +429,7 @@ ss::future<> partition_replicator::maybe_synchronize_start_offset() {
       truncate_offset);
 
     co_await prefix_truncate(truncate_offset);
+    co_return true;
 }
 
 ss::future<> partition_replicator::prefix_truncate(kafka::offset o) {

--- a/src/v/cluster_link/replication/partition_replicator.h
+++ b/src/v/cluster_link/replication/partition_replicator.h
@@ -74,7 +74,7 @@ public:
 
     partition_offsets_report get_partition_offsets_report() const;
 
-    ss::future<> maybe_synchronize_start_offset();
+    ss::future<bool> maybe_synchronize_start_offset();
 
     void set_data_probe(link_data_probe_ptr);
     void unset_data_probe();
@@ -85,6 +85,8 @@ public:
     bool shutdown_initiated() noexcept;
 
 private:
+    ss::future<> maybe_synchronize_start_offset_bg();
+
     struct replicate_ctx {
         ::model::offset begin;
         ::model::offset end;
@@ -128,6 +130,7 @@ private:
     ssx::semaphore _max_requests{
       max_in_flight_requests, "partition_replicator"};
     backoff_policy _backoff_policy;
+    backoff_policy _sync_backoff_policy;
     std::optional<replication_probe> _probe;
     link_data_probe_ptr _link_data_probe;
 };

--- a/src/v/cluster_link/replication/tests/partition_replicator_tests.cc
+++ b/src/v/cluster_link/replication/tests/partition_replicator_tests.cc
@@ -408,4 +408,34 @@ TEST_F_CORO(PartitionReplicatorFixture, TestNoStartOffsetOvershootOnResume) {
       5s, [&] { return _sink->start_offset() == kafka::offset(50); });
 }
 
+// Regression test for the prefix-truncation liveness fix. The shadow start
+// offset must be synchronized to a source prefix trim even when the replicator
+// is not actively fetching new data. Previously the synchronization ran only
+// immediately after a fetch returned, so a parked fetch (no new source data,
+// e.g. after a source-side disturbance) left a pending truncation unapplied
+// indefinitely, and the shadow start offset never caught up to the source. The
+// background synchronization loop decouples the trim from the fetch cycle.
+TEST_F_CORO(PartitionReplicatorFixture, TestSyncStartOffsetWhileFetchParked) {
+    // Replicate [0, 99]. The shadow partition catches up to the source and the
+    // fetch loop then parks because no further data is produced to the source.
+    for (int i = 0; i < 10; ++i) {
+        co_await push_data();
+    }
+    RPTEST_REQUIRE_EVENTUALLY_CORO(
+      5s, [&] { return _sink->last_replicated_offset() == kafka::offset(99); });
+
+    // No prefix trim has happened yet.
+    ASSERT_EQ_CORO(_sink->start_offset(), kafka::offset(0));
+
+    // The source is prefix-trimmed to offset 50. The shadow is already caught
+    // up (hwm 100 >= 50), so the truncation is immediately applicable -- but no
+    // new data will ever be fetched to drive it.
+    _source->set_reported_start_offset(kafka::offset(50));
+
+    // The background synchronization loop must apply the trim without any
+    // further fetch activity.
+    RPTEST_REQUIRE_EVENTUALLY_CORO(
+      20s, [&] { return _sink->start_offset() == kafka::offset(50); });
+}
+
 } // namespace cluster_link::replication


### PR DESCRIPTION
Previously, the fetch_and_replicate was performing start offset sync first followed by the fetch. The fetch could potentially block for a long period of time. While this is the case the prefix truncation is also blocked. This means that the prefix truncation on a target could be blocked if no new data is produced into the source.

This commit separates both prefix trncation and fetching into two independent async loops. The prefix truncation is running periodically and not tied to the fetching.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none