### PR TITLE
CORE-16747 Schema Migrations: reference-ordered schema reconciler

### DIFF
--- a/src/v/cluster_link/schema_registry_sync/BUILD
+++ b/src/v/cluster_link/schema_registry_sync/BUILD
@@ -22,14 +22,24 @@ redpanda_cc_library(
     name = "mirroring_task",
     srcs = [
         "mirroring_task.cc",
+        "reconciler.cc",
     ],
     hdrs = [
         "mirroring_task.h",
+        "reconciler.h",
     ],
     implementation_deps = [
+        "//src/v/base",
+        "//src/v/cluster_link:logger",
+        "//src/v/config",
         "//src/v/container:chunked_hash_map",
         "//src/v/container:chunked_vector",
+        "//src/v/model",
+        "//src/v/pandaproxy/schema_registry:exceptions",
         "//src/v/pandaproxy/schema_registry:types",
+        "//src/v/ssx:future_util",
+        "//src/v/ssx:sformat",
+        "@abseil-cpp//absl/container:flat_hash_set",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -38,6 +48,7 @@ redpanda_cc_library(
         "//src/v/cluster_link/model",
         "//src/v/model",
         "//src/v/schema:registry",
+        "//src/v/ssx:semaphore",
         "@seastar",
     ],
 )

--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
@@ -156,7 +156,7 @@ ss::future<task::state_transition> mirroring_task::full_source_sync(
     for (const auto& subject : subjects) {
         as.check();
         auto versions_res = co_await _reader->list_subject_versions(
-          subject, as);
+          subject, ppsr::include_deleted::no, as);
         if (!versions_res.has_value()) {
             if (
               versions_res.error().kind

--- a/src/v/cluster_link/schema_registry_sync/reconciler.cc
+++ b/src/v/cluster_link/schema_registry_sync/reconciler.cc
@@ -1,0 +1,410 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster_link/schema_registry_sync/reconciler.h"
+
+#include "base/units.h"
+#include "cluster_link/logger.h"
+#include "ssx/future-util.h"
+#include "ssx/semaphore.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/semaphore.hh>
+#include <seastar/coroutine/as_future.hh>
+#include <seastar/util/defer.hh>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <utility>
+
+using namespace std::chrono_literals;
+
+namespace cluster_link::schema_registry_sync {
+
+namespace {
+
+// Units reserved against the memory budget before a body is fetched, gating
+// fetch entry on memory before the body size is known. After the read the
+// reservation is topped up to the real body size.
+constexpr size_t reconcile_reserve_bytes = 100_KiB;
+
+// Resolves a source schema's references to the (subject, version) nodes they
+// point at, so referenced schemas are imported before the schemas that depend
+// on them. Unqualified references resolve against the referring schema's own
+// context.
+chunked_vector<ppsr::subject_version>
+resolve_refs(const ppsr::stored_schema& stored) {
+    const auto& parent_ctx = stored.schema.sub().ctx;
+    chunked_vector<ppsr::subject_version> out;
+    for (const auto& ref : stored.schema.def().refs()) {
+        out.push_back(
+          ppsr::subject_version{ref.sub.resolve(parent_ctx), ref.version});
+    }
+    return out;
+}
+
+// Byte-size proxy for a schema body: the canonical definition's length. This
+// is what the byte-semaphore budgets, and what tests control via the fake.
+size_t body_size(const ppsr::stored_schema& s) {
+    return s.schema.def().raw()().size_bytes();
+}
+
+void adjust_units(
+  ssx::semaphore& sem, ssx::semaphore_units& units, size_t new_size) {
+    auto reserved = units.count();
+    if (reserved < new_size) {
+        units.adopt(ss::consume_units(sem, new_size - reserved));
+    } else {
+        units.return_units(reserved - new_size);
+    }
+}
+
+} // namespace
+
+reconciler::reconciler(
+  source_reader* source,
+  schema::registry* destination,
+  std::function<bool(const ppsr::context_subject&)> in_scope,
+  limits lim)
+  : _source(source)
+  , _destination(destination)
+  , _in_scope(std::move(in_scope))
+  , _limits(lim)
+  , _mem(std::max<size_t>(1, lim.memory_bytes), "schema_registry_sync/memory") {
+    // Floor the budget so the clamp `min(body_size, memory_bytes)` and the
+    // semaphore agree; a degenerate 0 admits one over-budget body at a time.
+    _limits.memory_bytes = std::max<size_t>(1, _limits.memory_bytes);
+}
+
+reconciler::node_data& reconciler::data(const ppsr::subject_version& n) {
+    return _nodes.try_emplace(n).first->second;
+}
+
+ss::future<source_result<void>> reconciler::reconcile(
+  work_set work,
+  chunked_hash_set<ppsr::subject_version> seed_replicated,
+  reconcile_stats& stats,
+  ss::abort_source& as) {
+    _replicated = std::move(seed_replicated);
+    _nodes.clear();
+    _discover_q.clear();
+    _import_q.clear();
+    _stats = &stats;
+    _stats->versions_changed = 0;
+    _stats->errors = 0;
+    _outstanding = 0;
+    _done = false;
+    _fault.reset();
+    _exn = nullptr;
+
+    for (auto& key : work.upserts) {
+        auto& d = data(key);
+        if (d.state == node_state::unseen) {
+            d.state = node_state::discovering;
+            _discover_q.push_back(key);
+            ++_outstanding;
+        }
+    }
+
+    // Nothing to do: no fibers needed.
+    if (_outstanding == 0) {
+        _done = true;
+        co_return source_result<void>{};
+    }
+
+    auto n_workers = std::max<size_t>(1, _limits.parallelism);
+    ss::gate gate;
+    for (size_t i = 0; i < n_workers; ++i) {
+        ssx::spawn_with_gate(gate, [this, &as] { return worker(as); });
+    }
+    co_await gate.close();
+
+    // Every fetch releases its reserved-and-consumed units before its worker
+    // returns, so once the pool has drained the budget is whole again on every
+    // exit path. A mismatch means some path leaked units.
+    dassert(
+      _mem.available_units()
+        == static_cast<ssize_t>(std::max<size_t>(1, _limits.memory_bytes)),
+      "reconcile leaked memory units: {} available of {}",
+      _mem.available_units(),
+      std::max<size_t>(1, _limits.memory_bytes));
+
+    if (_exn) {
+        std::rethrow_exception(_exn);
+    }
+    if (_fault.has_value()) {
+        co_return std::unexpected(std::move(*_fault));
+    }
+    // An external abort with no source fault: surface as a clean cancellation
+    // so the caller does not record a spurious failure.
+    as.check();
+
+    // Defensive: a valid source's reference graph is acyclic, so both queues
+    // drain only once every node is done or errored. A malformed cyclic source
+    // leaves nodes stuck pending (their in-degree never reaches 0); fail them
+    // here for observability.
+    for (const auto& [key, d] : _nodes) {
+        if (
+          d.state == node_state::pending
+          || d.state == node_state::discovering) {
+            fail(key, false);
+        } else {
+            vassert(
+              d.state == node_state::done || d.state == node_state::errored,
+              "reconcile left node {} in non-terminal state {}",
+              key.sub,
+              static_cast<int>(d.state));
+        }
+    }
+
+    co_return source_result<void>{};
+}
+
+ss::future<> reconciler::worker(ss::abort_source& as) {
+    while (true) {
+        try {
+            co_await _cv.wait([this, &as] {
+                return has_work() || _done || as.abort_requested();
+            });
+            if (_done || as.abort_requested()) {
+                co_return;
+            }
+            // The cv may release several waiters for a single enqueue; only the
+            // one that finds work proceeds, the rest loop back to wait.
+            if (!has_work()) {
+                continue;
+            }
+
+            // Pop one node. It moves from queued to in-flight but stays counted
+            // in `_outstanding` until this iteration's `discover`/`do_import`
+            // (incl. wake/fail) returns, so a mid-flight worker can never
+            // trigger premature-done.
+            bool discovering = !_discover_q.empty();
+            ppsr::subject_version n = discovering ? _discover_q.back()
+                                                  : _import_q.back();
+            if (discovering) {
+                _discover_q.pop_back();
+            } else {
+                _import_q.pop_back();
+            }
+
+            auto res = discovering ? co_await discover(n, as)
+                                   : co_await do_import(n, as);
+            if (!res.has_value()) {
+                if (!_fault.has_value()) {
+                    _fault = std::move(res.error());
+                }
+                _done = true;
+                _cv.broadcast();
+                co_return;
+            }
+
+            // This node is no longer in-flight. `discover`/`wake` may have
+            // enqueued new nodes (each bumping `_outstanding` and signalling);
+            // the run is complete only when nothing is queued or in-flight.
+            if (--_outstanding == 0) {
+                _done = true;
+                _cv.broadcast();
+                co_return;
+            }
+        } catch (...) {
+            auto eptr = std::current_exception();
+            // Abort / teardown unblocks the waits; exit quietly and let the
+            // caller observe the abort. Any other exception faults the sync.
+            if (!ssx::is_shutdown_exception(eptr)) {
+                if (!_exn) {
+                    _exn = eptr;
+                }
+            }
+            _done = true;
+            _cv.broadcast();
+            co_return;
+        }
+    }
+}
+
+ss::future<source_result<void>>
+reconciler::discover(const ppsr::subject_version& n, ss::abort_source& as) {
+    // Best effort memory management: reserve some overestimate of the typical
+    // schema body size before the read, then top up to the real size after.
+    // This provides a backpressure point so that a large schema body does not
+    // let the reconciler run out of memory. Note that we can allocate more than
+    // the limit if the body a single schema or the schemas fetched in parallel
+    // exceed the limit.
+    auto units = co_await ss::get_units(
+      _mem, std::min(reconcile_reserve_bytes, _limits.memory_bytes), as);
+
+    auto fetched = co_await _source->read_subject_version(n.sub, n.version, as);
+    if (!fetched.has_value()) {
+        if (fetched.error().kind == source_error_kind::source_unavailable) {
+            co_return std::unexpected(std::move(fetched.error()));
+        }
+        fail(n);
+        co_return source_result<void>{};
+    }
+
+    adjust_units(_mem, units, body_size(fetched.value()));
+
+    auto refs = resolve_refs(fetched.value());
+    chunked_hash_set<ppsr::subject_version> missing;
+    for (auto& ref : refs) {
+        if (!_in_scope(ref.sub)) {
+            vlog(
+              cllog.warn,
+              "Schema reference {}/{} of {}/{} is out of scope; cannot "
+              "replicate referrer",
+              ref.sub,
+              ref.version,
+              n.sub,
+              n.version);
+            fail(n);
+            co_return source_result<void>{};
+        }
+        if (!_replicated.contains(ref)) {
+            missing.insert(ref);
+        }
+    }
+
+    if (missing.empty()) {
+        co_await import_body(n, std::move(fetched.value()));
+        co_return source_result<void>{};
+    }
+
+    // The body is released here (fetched goes out of scope): the node will be
+    // re-fetched once its references complete, leading to it being fetched
+    // twice in this case; and at most twice on average overall.
+    auto& d = data(n);
+    d.state = node_state::pending;
+    d.in_deg = static_cast<uint32_t>(missing.size());
+    for (auto& ref : missing) {
+        auto& rd = data(ref);
+        if (rd.state == node_state::errored) {
+            // A referent already failed; the referrer can never import.
+            fail(n);
+            co_return source_result<void>{};
+        }
+        rd.dependents.push_back(n);
+        vassert(
+          std::ranges::contains(
+            std::to_array(
+              {node_state::unseen,
+               node_state::discovering,
+               node_state::pending,
+               node_state::importing}),
+            rd.state),
+          "referent {} in unexpected state {}",
+          ref.sub,
+          static_cast<int>(rd.state));
+        if (rd.state == node_state::unseen) {
+            // Only an unseen referent needs to be queued.
+            rd.state = node_state::discovering;
+            _discover_q.push_back(ref);
+            ++_outstanding;
+            _cv.signal();
+        }
+    }
+    co_return source_result<void>{};
+}
+
+ss::future<source_result<void>>
+reconciler::do_import(const ppsr::subject_version& n, ss::abort_source& as) {
+    // Same reserve-then-consume model as discover. An import node has no unmet
+    // deps: it waits on nothing while holding these units, so the byte
+    // semaphore cannot hold-and-wait (deadlock-free).
+    auto units = co_await ss::get_units(
+      _mem, std::min(reconcile_reserve_bytes, _limits.memory_bytes), as);
+
+    auto fetched = co_await _source->read_subject_version(n.sub, n.version, as);
+    if (!fetched.has_value()) {
+        if (fetched.error().kind == source_error_kind::source_unavailable) {
+            co_return std::unexpected(std::move(fetched.error()));
+        }
+        fail(n);
+        co_return source_result<void>{};
+    }
+
+    adjust_units(_mem, units, body_size(fetched.value()));
+
+    co_await import_body(n, std::move(fetched.value()));
+    co_return source_result<void>{};
+}
+
+ss::future<bool> reconciler::import_body(
+  const ppsr::subject_version& n, ppsr::stored_schema schema) {
+    data(n).state = node_state::importing;
+    auto fut = co_await ss::coroutine::as_future(
+      _destination->import_schema(std::move(schema)));
+    if (fut.failed()) {
+        auto eptr = fut.get_exception();
+        if (ssx::is_shutdown_exception(eptr)) {
+            // Propagate the shutdown/abort to the worker pool so it can exit
+            // cleanly.
+            std::rethrow_exception(eptr);
+        }
+        try {
+            std::rethrow_exception(eptr);
+        } catch (const std::exception& e) {
+            vlog(
+              cllog.warn,
+              "Failed to import schema {}/{}: {}",
+              n.sub,
+              n.version,
+              e.what());
+        }
+        fail(n);
+        co_return false;
+    }
+    data(n).state = node_state::done;
+    ++_stats->versions_changed;
+    wake(n);
+    co_return true;
+}
+
+void reconciler::wake(const ppsr::subject_version& n) {
+    _replicated.insert(n);
+    auto dependents = std::move(data(n).dependents);
+    for (const auto& w : dependents) {
+        auto& wd = data(w);
+        if (wd.state != node_state::pending) {
+            continue;
+        }
+        wd.in_deg = std::max(wd.in_deg, 1u) - 1;
+        if (wd.in_deg == 0) {
+            wd.state = node_state::importing;
+            _import_q.push_back(w);
+            ++_outstanding;
+            _cv.signal();
+        }
+    }
+}
+
+void reconciler::fail(const ppsr::subject_version& n, bool recurse) {
+    auto& d = data(n);
+    if (d.state == node_state::errored) {
+        return;
+    }
+    d.state = node_state::errored;
+    ++_stats->errors;
+    vlog(cllog.warn, "Failed to replicate schema {}/{}", n.sub, n.version);
+    if (!recurse) {
+        return;
+    }
+    // failed the node's dependents transitively, since they can never satisfy
+    // their references
+    auto dependents = std::move(d.dependents);
+    for (const auto& w : dependents) {
+        fail(w);
+    }
+}
+
+} // namespace cluster_link::schema_registry_sync

--- a/src/v/cluster_link/schema_registry_sync/reconciler.h
+++ b/src/v/cluster_link/schema_registry_sync/reconciler.h
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster_link/schema_registry_sync/source_reader.h"
+#include "container/chunked_hash_map.h"
+#include "container/chunked_vector.h"
+#include "pandaproxy/schema_registry/types.h"
+#include "schema/registry.h"
+#include "ssx/semaphore.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/semaphore.hh>
+
+#include <cstdint>
+#include <functional>
+
+namespace cluster_link::schema_registry_sync {
+
+namespace ppsr = pandaproxy::schema_registry;
+
+/// Outcome counters folded into the task's per-sync summary.
+struct reconcile_stats {
+    /// Source versions imported into the destination this run.
+    uint64_t versions_changed{0};
+    /// Per-item failures (unresolvable references, import conflicts, unparsable
+    /// schemas). These do not abort the run; the reconciler counts them and
+    /// continues.
+    uint64_t errors{0};
+};
+
+/// The set of changes a reconcile applies. Create-only: every upsert is a
+/// (context, subject, version) node present on the source but absent from the
+/// destination's active set.
+struct work_set {
+    chunked_vector<ppsr::subject_version> upserts;
+};
+
+/// \brief Imports missing source schema versions into the destination in
+/// reference (topological) order.
+///
+/// The destination Schema Registry validates that a schema's references already
+/// exist before accepting an import, so a referrer can only be imported after
+/// every schema it references. The reconciler discovers each node's references,
+/// builds the dependency graph incrementally, and drains it referent-first.
+///
+/// A node whose references are all already satisfied is imported on its first
+/// fetch (1-fetch path). A node discovered before its dependencies releases its
+/// body and is re-fetched once they complete (2-fetch path); this keeps a body
+/// in memory only while it is being imported, so a byte-budgeted driver cannot
+/// deadlock on a held body.
+///
+/// Not re-entrant: a single reconcile runs at a time. Per-run state is reset at
+/// the start of each `reconcile` call.
+class reconciler {
+public:
+    /// Resource bounds for a reconcile run.
+    struct limits {
+        /// Byte budget for schema bodies held in memory concurrently. Each
+        /// fetch reserves a small fixed amount before reading, then tops up to
+        /// the real body size with a non-blocking consume() that may drive the
+        /// budget negative; the next fetch then blocks until in-flight bodies
+        /// drain. A single body larger than the whole budget is admitted alone
+        /// (its reservation is clamped to the budget) so it still makes
+        /// progress. Floored to 1, so a degenerate 0 admits one body at a time.
+        ///
+        /// This bound is backpressure, not a hard per-fetch ceiling: the
+        /// reservation gates fetch entry and the post-read consume() throttles
+        /// subsequent fetches once a large body lands. A hard per-fetch byte
+        /// cap would need Content-Length from the real client up front and is
+        /// deferred.
+        size_t memory_bytes;
+        /// Number of worker fibers draining the discover/import queues.
+        size_t parallelism;
+    };
+
+    reconciler(
+      source_reader* source,
+      schema::registry* destination,
+      std::function<bool(const ppsr::context_subject&)> in_scope,
+      limits lim);
+
+    /// Imports `work_set.upserts` referent-first.
+    ///
+    /// `seed_replicated` is the destination inventory's `all` set: nodes
+    /// already present on the destination (including soft-deleted ones) satisfy
+    /// a referrer's references without being re-imported.
+    ///
+    /// `stats` is reset to zero at entry, then incremented live as each node
+    /// completes: `versions_changed` on every successful import, `errors` on
+    /// every per-item failure, at the moment it happens. The caller can observe
+    /// partial progress mid-run (it is single-shard, so the increments are
+    /// synchronous and race-free), and reads per-run counts when reconcile
+    /// returns.
+    ///
+    /// If the source becomes unreachable the future resolves with a
+    /// `source_error` of kind `source_unavailable`; the caller surfaces this as
+    /// link-unavailable. Per-item failures are counted in
+    /// `reconcile_stats::errors`, not propagated.
+    ss::future<source_result<void>> reconcile(
+      work_set work,
+      chunked_hash_set<ppsr::subject_version> seed_replicated,
+      reconcile_stats& stats,
+      ss::abort_source& as);
+
+private:
+    /// Lifecycle of a node in the reconcile graph. Every enqueue is gated on
+    /// the node's state so a node is never fetched, imported, or counted twice.
+    enum class node_state : uint8_t {
+        // Not yet enqueued for discovery.
+        unseen,
+        // Queueud (or being fetched) for the first time to discover its
+        // references. Separate from unseen so that a referent is only queued
+        // once (even in the case of multiple referrers or cyclic references).
+        discovering,
+        // Waiting on dependencies to complete before it can be imported.
+        pending,
+        // Dependencies satisfied; being refertched and written to the
+        // destination.
+        importing,
+        // Successfully imported
+        done,
+        // Failed; cannot be imported
+        errored,
+    };
+
+    struct node_data {
+        node_state state{node_state::unseen};
+        uint32_t in_deg{0};
+        chunked_vector<ppsr::subject_version> dependents;
+    };
+
+    /// Reads a discover-queue node, resolves its references, and either imports
+    /// it now (deps satisfied) or registers it as pending behind its missing
+    /// referents. Returns a source_error only on `source_unavailable`.
+    ss::future<source_result<void>>
+    discover(const ppsr::subject_version& n, ss::abort_source& as);
+
+    /// Reads and imports an import-queue node whose dependencies have all
+    /// completed.
+    ss::future<source_result<void>>
+    do_import(const ppsr::subject_version& n, ss::abort_source& as);
+
+    /// Imports a fetched body, classifying conflicts as per-item failures.
+    /// Returns true on a successful import.
+    ss::future<bool>
+    import_body(const ppsr::subject_version& n, ppsr::stored_schema schema);
+
+    /// Marks a node replicated and releases dependents whose in-degree hits 0.
+    void wake(const ppsr::subject_version& n);
+
+    /// Marks a node (and transitively its dependents) failed.
+    void fail(const ppsr::subject_version& n, bool recurse = true);
+
+    node_data& data(const ppsr::subject_version& n);
+
+    /// True while either queue has a node ready to be picked up by a worker.
+    bool has_work() const { return !_discover_q.empty() || !_import_q.empty(); }
+
+    /// A single worker fiber: waits for work, runs one node's discover/import,
+    /// and drives global-termination detection. Loops until done or aborted.
+    /// A source fault is recorded in `_fault` and stops the pool.
+    ss::future<> worker(ss::abort_source& as);
+
+    source_reader* _source;
+    schema::registry* _destination;
+    std::function<bool(const ppsr::context_subject&)> _in_scope;
+    limits _limits;
+
+    chunked_hash_set<ppsr::subject_version> _replicated;
+    chunked_hash_map<ppsr::subject_version, node_data> _nodes;
+    chunked_vector<ppsr::subject_version> _discover_q;
+    chunked_vector<ppsr::subject_version> _import_q;
+    /// Caller-provided counters, incremented live as nodes complete. Valid only
+    /// for the duration of a `reconcile` call.
+    reconcile_stats* _stats{nullptr};
+
+    /// Queued-or-in-flight node count. A node counts from the moment it is
+    /// enqueued until the worker that popped it finishes its discover/import
+    /// (including the synchronous `wake`/`fail` that may re-enqueue
+    /// dependents). The run is complete when this reaches zero with both queues
+    /// empty.
+    size_t _outstanding{0};
+    /// Set once the run is complete or must stop (fault/abort); all workers
+    /// observe it through the condition variable and exit.
+    bool _done{false};
+    /// First `source_unavailable` error seen by any worker; stops the pool.
+    std::optional<source_error> _fault;
+    /// First non-shutdown exception (e.g. an unexpected import error) seen by
+    /// any worker; rethrown after the pool drains to fault the whole sync.
+    std::exception_ptr _exn;
+
+    ssx::semaphore _mem;
+    ss::condition_variable _cv;
+};
+
+} // namespace cluster_link::schema_registry_sync

--- a/src/v/cluster_link/schema_registry_sync/source_reader.h
+++ b/src/v/cluster_link/schema_registry_sync/source_reader.h
@@ -59,14 +59,18 @@ public:
     source_reader& operator=(source_reader&&) = delete;
     virtual ~source_reader() = default;
 
+    virtual ss::future<source_result<chunked_vector<ppsr::context>>>
+    list_contexts(ss::abort_source&) = 0;
+
     virtual ss::future<source_result<chunked_vector<ppsr::context_subject>>>
     list_subjects(ppsr::context, ss::abort_source&) = 0;
 
     virtual ss::future<source_result<chunked_vector<ppsr::schema_version>>>
-    list_subject_versions(ppsr::context_subject, ss::abort_source&) = 0;
+    list_subject_versions(
+      ppsr::context_subject, ppsr::include_deleted, ss::abort_source&) = 0;
 
-    /// Reads a specific subject version's schema. Not used yet (the apply path
-    /// is not implemented); kept here so the reader seam is stable.
+    /// Reads a specific subject version's schema. The reconcile engine's
+    /// schema-body fetch path: called for every node it discovers and imports.
     virtual ss::future<source_result<ppsr::stored_schema>> read_subject_version(
       ppsr::context_subject, ppsr::schema_version, ss::abort_source&) = 0;
 };

--- a/src/v/cluster_link/schema_registry_sync/tests/BUILD
+++ b/src/v/cluster_link/schema_registry_sync/tests/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:test.bzl", "redpanda_cc_gtest")
+load("//bazel:test.bzl", "redpanda_cc_gtest", "redpanda_test_cc_library")
 
 redpanda_cc_gtest(
     name = "mirroring_task_test",
@@ -18,6 +18,42 @@ redpanda_cc_gtest(
         "//src/v/container:chunked_hash_map",
         "//src/v/container:chunked_vector",
         "//src/v/model",
+        "//src/v/pandaproxy/schema_registry:types",
+        "//src/v/schema:registry",
+        "//src/v/schema/tests:fake_registry",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_test_cc_library(
+    name = "sr_sync_test_fixtures",
+    hdrs = ["sr_sync_test_fixtures.h"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//src/v/cluster_link/schema_registry_sync:mirroring_task",
+        "//src/v/cluster_link/schema_registry_sync:source_reader",
+        "//src/v/container:chunked_hash_map",
+        "//src/v/container:chunked_vector",
+        "//src/v/pandaproxy/schema_registry:types",
+        "//src/v/schema:registry",
+        "//src/v/schema/tests:fake_registry",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "reconciler_test",
+    timeout = "short",
+    srcs = ["reconciler_test.cc"],
+    cpu = 1,
+    deps = [
+        ":sr_sync_test_fixtures",
+        "//src/v/cluster_link/schema_registry_sync:mirroring_task",
+        "//src/v/cluster_link/schema_registry_sync:source_reader",
+        "//src/v/container:chunked_hash_map",
+        "//src/v/container:chunked_vector",
         "//src/v/pandaproxy/schema_registry:types",
         "//src/v/schema:registry",
         "//src/v/schema/tests:fake_registry",

--- a/src/v/cluster_link/schema_registry_sync/tests/mirroring_task_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/mirroring_task_test.cc
@@ -78,6 +78,18 @@ public:
     explicit fake_source_reader(fake_source_state* state)
       : _state(state) {}
 
+    ss::future<srs::source_result<chunked_vector<ppsr::context>>>
+    list_contexts(ss::abort_source&) override {
+        chunked_hash_set<ppsr::context> seen;
+        chunked_vector<ppsr::context> contexts;
+        for (const auto& s : _state->schemas) {
+            if (seen.insert(s.schema.sub().ctx).second) {
+                contexts.push_back(s.schema.sub().ctx);
+            }
+        }
+        co_return contexts;
+    }
+
     ss::future<srs::source_result<chunked_vector<ppsr::context_subject>>>
     list_subjects(ppsr::context ctx, ss::abort_source&) override {
         if (_state->list_subjects_error.has_value()) {
@@ -98,7 +110,9 @@ public:
 
     ss::future<srs::source_result<chunked_vector<ppsr::schema_version>>>
     list_subject_versions(
-      ppsr::context_subject sub, ss::abort_source&) override {
+      ppsr::context_subject sub,
+      ppsr::include_deleted,
+      ss::abort_source&) override {
         chunked_vector<ppsr::schema_version> versions;
         for (const auto& s : _state->schemas) {
             if (s.schema.sub() == sub) {

--- a/src/v/cluster_link/schema_registry_sync/tests/reconciler_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/reconciler_test.cc
@@ -1,0 +1,628 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster_link/schema_registry_sync/reconciler.h"
+#include "cluster_link/schema_registry_sync/source_reader.h"
+#include "cluster_link/schema_registry_sync/tests/sr_sync_test_fixtures.h"
+#include "container/chunked_hash_map.h"
+#include "pandaproxy/schema_registry/error.h"
+#include "pandaproxy/schema_registry/types.h"
+#include "schema/tests/fake_registry.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/when_all.hh>
+
+#include <limits>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace cluster_link::tests {
+
+namespace {
+constexpr static auto no_memory_limit = std::numeric_limits<ssize_t>::max();
+}
+
+TEST(reconciler, replicates_chain_in_reference_order) {
+    reconcile_harness h;
+    auto a = ppsr::context_subject::unqualified("a");
+    auto b = ppsr::context_subject::unqualified("b");
+    h.source.add(a, 1);
+    h.source.add_with_refs(b, 1, refs_to({ref_to(a, 1)}));
+
+    // Upserts in referrer-first order: the engine must reorder.
+    srs::work_set work;
+    work.upserts.push_back(key(b, 1));
+    work.upserts.push_back(key(a, 1));
+
+    auto stats = h.run(std::move(work)).get();
+    ASSERT_TRUE(stats.has_value());
+    EXPECT_EQ(stats->versions_changed, 2);
+    EXPECT_EQ(stats->errors, 0);
+
+    const auto& all = h.destination.get_all();
+    auto ia = index_of(all, "a");
+    auto ib = index_of(all, "b");
+    ASSERT_GE(ia, 0);
+    ASSERT_GE(ib, 0);
+    EXPECT_LT(ia, ib);
+}
+
+// Tolerance test: a schema that lists the same reference twice is handled and
+// the referrer still imports referent-first. Holds with or without the dedup.
+TEST(reconciler, duplicate_reference_still_imports) {
+    reconcile_harness h;
+    auto a = ppsr::context_subject::unqualified("a");
+    auto b = ppsr::context_subject::unqualified("b");
+    h.source.add(a, 1);
+    h.source.add_with_refs(b, 1, refs_to({ref_to(a, 1), ref_to(a, 1)}));
+
+    srs::work_set work;
+    work.upserts.push_back(key(b, 1));
+    work.upserts.push_back(key(a, 1));
+
+    auto stats = h.run(std::move(work)).get();
+    ASSERT_TRUE(stats.has_value());
+    EXPECT_EQ(stats->versions_changed, 2);
+    EXPECT_EQ(stats->errors, 0);
+    EXPECT_LT(
+      index_of(h.destination.get_all(), "a"),
+      index_of(h.destination.get_all(), "b"));
+}
+
+TEST(reconciler, diamond_fetches_referent_once) {
+    reconcile_harness h;
+    auto a = ppsr::context_subject::unqualified("a");
+    auto b = ppsr::context_subject::unqualified("b");
+    auto c = ppsr::context_subject::unqualified("c");
+    auto d = ppsr::context_subject::unqualified("d");
+    h.source.add(a, 1);
+    h.source.add_with_refs(b, 1, refs_to({ref_to(a, 1)}));
+    h.source.add_with_refs(c, 1, refs_to({ref_to(a, 1)}));
+    h.source.add_with_refs(d, 1, refs_to({ref_to(b, 1), ref_to(c, 1)}));
+
+    srs::work_set work;
+    work.upserts.push_back(key(d, 1));
+    work.upserts.push_back(key(c, 1));
+    work.upserts.push_back(key(b, 1));
+    work.upserts.push_back(key(a, 1));
+
+    auto stats = h.run(std::move(work)).get();
+    ASSERT_TRUE(stats.has_value());
+    EXPECT_EQ(stats->versions_changed, 4);
+    EXPECT_EQ(stats->errors, 0);
+    // The shared referent a is fetched exactly once despite two referrers.
+    EXPECT_EQ(h.source.reads(a, 1), 1);
+
+    const auto& all = h.destination.get_all();
+    EXPECT_LT(index_of(all, "a"), index_of(all, "b"));
+    EXPECT_LT(index_of(all, "a"), index_of(all, "c"));
+    EXPECT_LT(index_of(all, "b"), index_of(all, "d"));
+    EXPECT_LT(index_of(all, "c"), index_of(all, "d"));
+}
+
+TEST(reconciler, out_of_scope_reference_errors_referrer) {
+    reconcile_harness h;
+    auto a = ppsr::context_subject{ppsr::context{".other"}, ppsr::subject{"a"}};
+    auto b = ppsr::context_subject::unqualified("b");
+    h.source.add(a, 1);
+    h.source.add_with_refs(b, 1, refs_to({ref_to(a, 1)}));
+
+    srs::work_set work;
+    work.upserts.push_back(key(b, 1));
+
+    ss::abort_source as;
+    // Only the default context is in scope; the ".other" referent is not.
+    auto r = h.make([](const ppsr::context_subject& s) {
+        return s.ctx == ppsr::default_context;
+    });
+    srs::reconcile_stats stats;
+    auto res = r.reconcile(std::move(work), {}, stats, as).get();
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(stats.versions_changed, 0);
+    EXPECT_EQ(stats.errors, 1);
+    EXPECT_EQ(index_of(h.destination.get_all(), "b"), -1);
+}
+
+TEST(reconciler, dangling_reference_errors_referrer) {
+    reconcile_harness h;
+    auto a = ppsr::context_subject::unqualified("a");
+    auto b = ppsr::context_subject::unqualified("b");
+    // b references a:v9, which does not exist on the source.
+    h.source.add_with_refs(b, 1, refs_to({ref_to(a, 9)}));
+
+    srs::work_set work;
+    work.upserts.push_back(key(b, 1));
+
+    auto stats = h.run(std::move(work)).get();
+    ASSERT_TRUE(stats.has_value());
+    EXPECT_EQ(stats->versions_changed, 0);
+    // Both the dangling referent (fetch fails) and the referrer error.
+    EXPECT_GE(stats->errors, 1);
+    EXPECT_EQ(index_of(h.destination.get_all(), "b"), -1);
+}
+
+TEST(reconciler, single_fetch_when_refs_already_replicated) {
+    reconcile_harness h;
+    auto a = ppsr::context_subject::unqualified("a");
+    auto b = ppsr::context_subject::unqualified("b");
+    h.source.add(a, 1);
+    h.source.add_with_refs(b, 1, refs_to({ref_to(a, 1)}));
+
+    // a is already replicated on the destination, so b imports on first fetch.
+    chunked_hash_set<ppsr::subject_version> seed;
+    seed.insert(key(a, 1));
+
+    srs::work_set work;
+    work.upserts.push_back(key(b, 1));
+
+    auto stats = h.run(std::move(work), std::move(seed)).get();
+    ASSERT_TRUE(stats.has_value());
+    EXPECT_EQ(stats->versions_changed, 1);
+    EXPECT_EQ(stats->errors, 0);
+    EXPECT_EQ(h.source.reads(b, 1), 1);
+}
+
+TEST(reconciler, double_fetch_when_discovered_before_deps) {
+    reconcile_harness h;
+    auto a = ppsr::context_subject::unqualified("a");
+    auto b = ppsr::context_subject::unqualified("b");
+    h.source.add(a, 1);
+    h.source.add_with_refs(b, 1, refs_to({ref_to(a, 1)}));
+
+    // Nothing pre-replicated. The engine drains discovery LIFO, so pushing a
+    // then b discovers b first: it finds a missing, releases its body, and is
+    // re-fetched once a completes.
+    srs::work_set work;
+    work.upserts.push_back(key(a, 1));
+    work.upserts.push_back(key(b, 1));
+
+    auto stats = h.run(std::move(work)).get();
+    ASSERT_TRUE(stats.has_value());
+    EXPECT_EQ(stats->versions_changed, 2);
+    EXPECT_EQ(h.source.reads(b, 1), 2);
+    EXPECT_EQ(h.source.reads(a, 1), 1);
+}
+
+TEST(reconciler, idempotent_resync) {
+    reconcile_harness h;
+    auto a = ppsr::context_subject::unqualified("a");
+    auto b = ppsr::context_subject::unqualified("b");
+    h.source.add(a, 1);
+    h.source.add_with_refs(b, 1, refs_to({ref_to(a, 1)}));
+
+    // Both already on the destination. With an empty work_set there is nothing
+    // to import and nothing to fetch.
+    chunked_hash_set<ppsr::subject_version> seed;
+    seed.insert(key(a, 1));
+    seed.insert(key(b, 1));
+
+    auto stats = h.run(srs::work_set{}, std::move(seed)).get();
+    ASSERT_TRUE(stats.has_value());
+    EXPECT_EQ(stats->versions_changed, 0);
+    EXPECT_EQ(stats->errors, 0);
+    EXPECT_EQ(h.source.reads(a, 1), 0);
+    EXPECT_EQ(h.source.reads(b, 1), 0);
+}
+
+// Invariant guard: the `seed_replicated` set satisfies references; it does NOT
+// mark upsert targets as complete. A node that is active on the source but
+// soft-deleted on the destination appears in both `upserts` (S.active \
+// D.active) and the `all`-based seed (soft-deleted nodes are in `all`). The
+// engine must still fetch and import it (reactivation). An "optimization" that
+// skipped upserts already in `_replicated` would silently drop this
+// reactivation and report success despite source/destination divergence.
+TEST(reconciler, seed_replicated_upsert_is_still_imported) {
+    reconcile_harness h;
+    auto a = ppsr::context_subject::unqualified("a");
+    h.source.add(a, 1);
+
+    // a:v1 is in the work-set AND in the reference-satisfaction seed (as a
+    // destination soft-deleted node would be).
+    chunked_hash_set<ppsr::subject_version> seed;
+    seed.insert(key(a, 1));
+
+    srs::work_set work;
+    work.upserts.push_back(key(a, 1));
+
+    auto stats = h.run(std::move(work), std::move(seed)).get();
+    ASSERT_TRUE(stats.has_value());
+    EXPECT_EQ(stats->versions_changed, 1);
+    EXPECT_EQ(stats->errors, 0);
+    // Still fetched (not skipped because it was in the seed).
+    EXPECT_GE(h.source.reads(a, 1), 1);
+}
+
+TEST(reconciler, cyclic_source_does_not_hang) {
+    reconcile_harness h;
+    auto a = ppsr::context_subject::unqualified("a");
+    auto b = ppsr::context_subject::unqualified("b");
+    // a refs b, b refs a: a malformed (cyclic) source.
+    h.source.add_with_refs(a, 1, refs_to({ref_to(b, 1)}));
+    h.source.add_with_refs(b, 1, refs_to({ref_to(a, 1)}));
+
+    srs::work_set work;
+    work.upserts.push_back(key(a, 1));
+    work.upserts.push_back(key(b, 1));
+
+    auto stats = h.run(std::move(work)).get();
+    ASSERT_TRUE(stats.has_value());
+    EXPECT_EQ(stats->versions_changed, 0);
+    EXPECT_EQ(stats->errors, 2);
+    EXPECT_TRUE(h.destination.get_all().empty());
+}
+
+TEST(reconciler, import_conflict_counts_as_error) {
+    reconcile_harness h;
+    auto a = ppsr::context_subject::unqualified("a");
+    auto b = ppsr::context_subject::unqualified("b");
+    h.source.add(a, 1);
+    h.source.add(b, 1);
+
+    // Pre-seed the destination with b:v1 at an id that collides with no source
+    // schema, so importing the source's b:v1 throws
+    // subject_version_schema_id_already_exists (not an unrelated id clash).
+    {
+        auto conflicting = make_schema(b, 1, R"({"conflict":true})");
+        conflicting.id = ppsr::schema_id{99};
+        h.destination.import_schema(std::move(conflicting)).get();
+    }
+
+    srs::work_set work;
+    work.upserts.push_back(key(a, 1));
+    work.upserts.push_back(key(b, 1));
+
+    auto stats = h.run(std::move(work)).get();
+    ASSERT_TRUE(stats.has_value());
+    // a imports; b conflicts and is counted as an error, no fault.
+    EXPECT_EQ(stats->versions_changed, 1);
+    EXPECT_EQ(stats->errors, 1);
+    EXPECT_GE(index_of(h.destination.get_all(), "a"), 0);
+}
+
+// Any import failure other than shutdown is a per-item error. The destination
+// can reject a schema the source happily served -- version/impl skew can make a
+// body unparseable, or a reference can fail to resolve at import. The
+// reconciler must count it, fail the node, cascade to dependents that can no
+// longer resolve, and keep going: one bad schema must never abort replication
+// of the rest. The in-memory fake never parses or validates references, so the
+// rejection is injected per node.
+TEST(reconciler, import_errors_are_per_item_and_cascade) {
+    fake_source_state source;
+    schema::fake_registry inner;
+    failing_import_registry destination{&inner};
+
+    auto a = ppsr::context_subject::unqualified("a"); // import rejected
+    auto b = ppsr::context_subject::unqualified("b"); // refs a -> cascades
+    auto x = ppsr::context_subject::unqualified("x"); // import rejected
+    auto y = ppsr::context_subject::unqualified("y"); // refs x -> cascades
+    auto z = ppsr::context_subject::unqualified("z"); // independent -> imports
+
+    source.add(a, 1);
+    source.add_with_refs(b, 1, refs_to({ref_to(a, 1)}));
+    source.add(x, 1);
+    source.add_with_refs(y, 1, refs_to({ref_to(x, 1)}));
+    source.add(z, 1);
+
+    // The destination rejects a (unparseable body) and x (reference unresolved
+    // at import). Both are intrinsic to one schema, not systemic failures.
+    destination.fail_import(
+      key(a, 1), ppsr::error_code::schema_invalid, "unparseable body");
+    destination.fail_import(
+      key(x, 1),
+      ppsr::error_code::schema_missing_reference,
+      "reference not found");
+
+    srs::work_set work;
+    for (const auto& s : {a, b, x, y, z}) {
+        work.upserts.push_back(key(s, 1));
+    }
+
+    fake_source_reader reader{&source};
+    srs::reconciler::limits lim{
+      .memory_bytes = no_memory_limit, .parallelism = 1};
+    auto r = srs::reconciler{
+      &reader,
+      &destination,
+      [](const ppsr::context_subject&) { return true; },
+      lim};
+
+    ss::abort_source as;
+    srs::reconcile_stats stats;
+    auto res = r.reconcile(std::move(work), {}, stats, as).get();
+
+    // The run completes (no fault) despite two rejected schemas.
+    ASSERT_TRUE(res.has_value());
+    // a and x are rejected at import; b and y cascade-fail (their referent
+    // never landed). Only the independent z imports.
+    EXPECT_EQ(stats.errors, 4);
+    EXPECT_EQ(stats.versions_changed, 1);
+    EXPECT_GE(index_of(inner.get_all(), "z"), 0);
+    EXPECT_EQ(index_of(inner.get_all(), "a"), -1);
+    EXPECT_EQ(index_of(inner.get_all(), "b"), -1);
+    EXPECT_EQ(index_of(inner.get_all(), "x"), -1);
+    EXPECT_EQ(index_of(inner.get_all(), "y"), -1);
+}
+
+// Deadlock regression: a deep chain e<-d<-c<-b<-a, a byte budget of a single
+// body, and four workers. The byte-semaphore can never deadlock because a
+// worker holds units only around the one node it imports (which waits on
+// nothing) and releases them when it defers a node with missing refs. The call
+// must RETURN (not hang) and import all five referent-first.
+TEST(reconciler, tiny_memory_budget_deep_chain_completes) {
+    reconcile_harness h;
+    auto a = ppsr::context_subject::unqualified("a");
+    auto b = ppsr::context_subject::unqualified("b");
+    auto c = ppsr::context_subject::unqualified("c");
+    auto d = ppsr::context_subject::unqualified("d");
+    auto e = ppsr::context_subject::unqualified("e");
+    h.source.add(a, 1);
+    auto chain =
+      [&](const ppsr::context_subject& sub, const ppsr::context_subject& dep) {
+          h.source.add_with_refs(sub, 1, refs_to({ref_to(dep, 1)}));
+      };
+    chain(b, a);
+    chain(c, b);
+    chain(d, c);
+    chain(e, d);
+
+    // One body fits at a time (acquire clamps to the budget), so only the
+    // deadlock-freedom invariant lets four workers make progress.
+    h.lim = srs::reconciler::limits{.memory_bytes = 1, .parallelism = 4};
+
+    srs::work_set work;
+    work.upserts.push_back(key(e, 1));
+    work.upserts.push_back(key(d, 1));
+    work.upserts.push_back(key(c, 1));
+    work.upserts.push_back(key(b, 1));
+    work.upserts.push_back(key(a, 1));
+
+    auto stats = h.run(std::move(work)).get();
+    ASSERT_TRUE(stats.has_value());
+    EXPECT_EQ(stats->versions_changed, 5);
+    EXPECT_EQ(stats->errors, 0);
+
+    const auto& all = h.destination.get_all();
+    EXPECT_LT(index_of(all, "a"), index_of(all, "b"));
+    EXPECT_LT(index_of(all, "b"), index_of(all, "c"));
+    EXPECT_LT(index_of(all, "c"), index_of(all, "d"));
+    EXPECT_LT(index_of(all, "d"), index_of(all, "e"));
+}
+
+// Abort mid-sync: the source read completes (so `discover` acquires byte-budget
+// units), then the destination import blocks until the test aborts. `reconcile`
+// must return promptly, the gate must close (no hang), and the units held
+// across the blocked import must be released (no leak) after the call returns.
+// Blocking in import rather than in the read is deliberate: it is the only way
+// the abort interrupts a worker that is holding units, so the assertion
+// exercises the release-on-abort path instead of being trivially satisfied.
+TEST(reconciler, abort_mid_sync_drains_cleanly) {
+    fake_source_state source;
+    schema::fake_registry inner;
+    source.add(ppsr::context_subject::unqualified("a"), 1);
+
+    fake_source_reader reader{&source};
+    blocking_import_registry destination{&inner};
+
+    srs::reconciler::limits lim{
+      .memory_bytes = no_memory_limit, .parallelism = 4};
+    auto r = srs::reconciler{
+      &reader,
+      &destination,
+      [](const ppsr::context_subject&) { return true; },
+      lim};
+
+    srs::work_set work;
+    work.upserts.push_back(key(ppsr::context_subject::unqualified("a"), 1));
+
+    ss::abort_source as;
+    srs::reconcile_stats stats;
+    auto fut = r.reconcile(std::move(work), {}, stats, as);
+
+    // A worker has read the body and acquired byte-budget units; it is now
+    // parked inside the import. Abort the sync while those units are held.
+    destination.entered().get();
+    as.request_abort();
+    // The in-flight import must be released manually: schema::registry's
+    // import_schema takes no abort_source, so requesting the reconcile's abort
+    // does not cancel an import already running inside the destination. The
+    // worker stays parked until the wrapper's own promise resolves, so the test
+    // resolves it as an abort to drive the worker through the unwind path. (In
+    // production the reconciler's gate.close() likewise waits for in-flight
+    // imports to finish rather than cancelling them.)
+    destination.abort();
+
+    // Returns promptly via the abort path (not a hang); the abort propagates as
+    // an exception, surfaced by reconcile's `as.check()`.
+    EXPECT_THROW(fut.get(), ss::abort_requested_exception);
+    // Leak-freedom on the abort path is asserted by the dassert in reconcile().
+}
+
+// Live-progress contract: the reconciler increments the caller's stats as each
+// node completes, not only at the end. Two independent nodes, a single worker:
+// the worker imports the first, then parks inside the second's import. At that
+// point the live `versions_changed` must already reflect the completed first
+// node (== 1), proving progress is observable mid-sync.
+TEST(reconciler, reports_progress_live) {
+    fake_source_state source;
+    schema::fake_registry inner;
+    auto a = ppsr::context_subject::unqualified("a");
+    auto b = ppsr::context_subject::unqualified("b");
+    source.add(a, 1);
+    source.add(b, 1);
+
+    fake_source_reader reader{&source};
+    // Let the first import through; park inside the second.
+    blocking_import_registry destination{&inner, /*block_after=*/1};
+
+    // Single worker so imports are strictly serialised: one completes before
+    // the next begins.
+    srs::reconciler::limits lim{
+      .memory_bytes = no_memory_limit, .parallelism = 1};
+    auto r = srs::reconciler{
+      &reader,
+      &destination,
+      [](const ppsr::context_subject&) { return true; },
+      lim};
+
+    srs::work_set work;
+    work.upserts.push_back(key(a, 1));
+    work.upserts.push_back(key(b, 1));
+
+    ss::abort_source as;
+    srs::reconcile_stats stats;
+    auto fut = r.reconcile(std::move(work), {}, stats, as);
+
+    // The worker has imported the first node and is now parked inside the
+    // second. The live counter already reflects the completed first node.
+    destination.entered().get();
+    EXPECT_EQ(stats.versions_changed, 1);
+
+    // Let the parked import complete; both nodes import.
+    destination.unblock();
+    auto res = fut.get();
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(stats.versions_changed, 2);
+    EXPECT_EQ(stats.errors, 0);
+}
+
+// A read returning `source_unavailable` mid-run is a fault: it stops the worker
+// pool and surfaces as the unavailable result (not a per-item error). Here a
+// referent b:1 is reachable but its read is forced to fail with
+// source_unavailable; reconcile must resolve to that error rather than counting
+// it among `stats.errors`. (The integration suite covers the list-path fault;
+// this covers the read path at the reconciler level.)
+TEST(reconciler, read_source_unavailable_faults_run) {
+    reconcile_harness h;
+    auto a = ppsr::context_subject::unqualified("a");
+    auto b = ppsr::context_subject::unqualified("b");
+    h.source.add(a, 1);
+    h.source.add(b, 1);
+    h.source.fail_read(
+      b,
+      1,
+      srs::source_error{
+        .kind = srs::source_error_kind::source_unavailable,
+        .message = "source down mid-run"});
+
+    srs::work_set work;
+    work.upserts.push_back(key(a, 1));
+    work.upserts.push_back(key(b, 1));
+
+    ss::abort_source as;
+    auto r = h.make();
+    srs::reconcile_stats stats;
+    auto res = r.reconcile(std::move(work), {}, stats, as).get();
+    ASSERT_FALSE(res.has_value());
+    EXPECT_EQ(res.error().kind, srs::source_error_kind::source_unavailable);
+}
+
+// Concurrency stress: a moderately large reference DAG (a base layer of leaves,
+// two layers each referencing the layer below, plus diamonds where multiple
+// referrers share referents), run with parallelism=4 and a modest byte budget
+// so the reserve-then-consume admission path is exercised. The run must
+// complete (no hang) with every node imported, no per-item errors, the
+// byte-semaphore back at its full budget (no leak), and topological order held
+// for every reference edge. Determinism comes from --runs_per_test rather than
+// randomised interleavings: with four workers and a tight budget, worker
+// scheduling already varies run to run.
+TEST(reconciler, concurrent_stress) {
+    reconcile_harness h;
+
+    constexpr int leaves = 24;
+    constexpr int mids = 12;
+    constexpr int tops = 6;
+
+    auto sub = [](std::string_view prefix, int i) {
+        return ppsr::context_subject::unqualified(
+          fmt::format("{}-{}", prefix, i));
+    };
+
+    // Record every reference edge so the topological-order assertion can check
+    // each one against the destination's import order.
+    std::vector<std::pair<ppsr::context_subject, ppsr::context_subject>> edges;
+    auto link =
+      [&](const ppsr::context_subject& from, const ppsr::context_subject& to) {
+          edges.emplace_back(to, from);
+      };
+
+    // Base layer: leaves with no references.
+    for (int i = 0; i < leaves; ++i) {
+        h.source.add(sub("leaf", i), 1);
+    }
+
+    // Mid layer: each references two distinct leaves; adjacent mids share a
+    // leaf, forming diamonds.
+    for (int i = 0; i < mids; ++i) {
+        auto l1 = sub("leaf", (2 * i) % leaves);
+        auto l2 = sub("leaf", (2 * i + 1) % leaves);
+        h.source.add_with_refs(
+          sub("mid", i), 1, refs_to({ref_to(l1, 1), ref_to(l2, 1)}));
+        link(sub("mid", i), l1);
+        link(sub("mid", i), l2);
+    }
+
+    // Top layer: each references two mids (shared across tops -> more
+    // diamonds).
+    for (int i = 0; i < tops; ++i) {
+        auto m1 = sub("mid", (2 * i) % mids);
+        auto m2 = sub("mid", (2 * i + 1) % mids);
+        h.source.add_with_refs(
+          sub("top", i), 1, refs_to({ref_to(m1, 1), ref_to(m2, 1)}));
+        link(sub("top", i), m1);
+        link(sub("top", i), m2);
+    }
+
+    constexpr int total = leaves + mids + tops;
+
+    // Upserts in reverse-dependency order (tops first) so the engine has to
+    // reorder; four workers; a budget that holds only a few bodies at once.
+    srs::work_set work;
+    for (int i = 0; i < tops; ++i) {
+        work.upserts.push_back(key(sub("top", i), 1));
+    }
+    for (int i = 0; i < mids; ++i) {
+        work.upserts.push_back(key(sub("mid", i), 1));
+    }
+    for (int i = 0; i < leaves; ++i) {
+        work.upserts.push_back(key(sub("leaf", i), 1));
+    }
+
+    h.lim = srs::reconciler::limits{
+      .memory_bytes = no_memory_limit, .parallelism = 4};
+
+    ss::abort_source as;
+    auto r = h.make();
+    srs::reconcile_stats stats;
+    auto res = r.reconcile(std::move(work), {}, stats, as).get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(stats.versions_changed, total);
+    EXPECT_EQ(stats.errors, 0);
+
+    // Every node imported exactly once.
+    const auto& all = h.destination.get_all();
+    EXPECT_EQ(all.size(), static_cast<size_t>(total));
+
+    // Topological order holds: for every (referent, referrer) edge the referent
+    // was imported before the referrer.
+    for (const auto& [referent, referrer] : edges) {
+        auto i_ref = index_of(all, referent.sub());
+        auto i_rer = index_of(all, referrer.sub());
+        ASSERT_GE(i_ref, 0);
+        ASSERT_GE(i_rer, 0);
+        EXPECT_LT(i_ref, i_rer)
+          << fmt::format("{} must precede {}", referent.sub(), referrer.sub());
+    }
+}
+
+} // namespace cluster_link::tests

--- a/src/v/cluster_link/schema_registry_sync/tests/sr_sync_test_fixtures.h
+++ b/src/v/cluster_link/schema_registry_sync/tests/sr_sync_test_fixtures.h
@@ -1,0 +1,440 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster_link/schema_registry_sync/reconciler.h"
+#include "cluster_link/schema_registry_sync/source_reader.h"
+#include "container/chunked_hash_map.h"
+#include "container/chunked_vector.h"
+#include "pandaproxy/schema_registry/error.h"
+#include "pandaproxy/schema_registry/errors.h"
+#include "pandaproxy/schema_registry/types.h"
+#include "schema/registry.h"
+#include "schema/tests/fake_registry.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+// Test fakes and helpers shared by the reconciler unit tests
+// (reconciler_test.cc) and the mirroring-task integration tests
+// (mirroring_task_test.cc). Header-only: every free function is `inline` so the
+// two translation units that include this share one definition.
+namespace cluster_link::tests {
+
+namespace ppsr = pandaproxy::schema_registry;
+namespace srs = cluster_link::schema_registry_sync;
+
+inline ppsr::stored_schema make_schema(
+  const ppsr::context_subject& sub,
+  int32_t version,
+  std::string_view def,
+  ppsr::is_deleted deleted = ppsr::is_deleted::no) {
+    return ppsr::stored_schema{
+      .schema = ppsr::
+        subject_schema{sub, ppsr::schema_definition{ppsr::schema_definition::raw_string{def}, ppsr::schema_type::avro}},
+      .version = ppsr::schema_version{version},
+      .id = ppsr::schema_id{version},
+      .deleted = deleted};
+}
+
+// A reference to one (subject, version) node. References to default-context
+// subjects are emitted unqualified (the common case); others are qualified.
+inline ppsr::schema_reference
+ref_to(const ppsr::context_subject& sub, int32_t ver) {
+    return ppsr::schema_reference{
+      .name = ss::sstring{sub.sub()},
+      .sub = ppsr::
+        context_subject_reference{sub, sub.ctx == ppsr::default_context ? ppsr::is_qualified::no : ppsr::is_qualified::yes},
+      .version = ppsr::schema_version{ver}};
+}
+
+// Collects schema_references into a definition's references container, so a
+// caller can write `refs_to({ref_to(a, 1), ref_to(b, 1)})` inline.
+inline ppsr::schema_definition::references
+refs_to(std::initializer_list<ppsr::schema_reference> refs) {
+    ppsr::schema_definition::references out;
+    for (const auto& ref : refs) {
+        out.push_back(ref);
+    }
+    return out;
+}
+
+inline ppsr::stored_schema make_schema_with_refs(
+  const ppsr::context_subject& sub,
+  int32_t version,
+  std::string_view def,
+  ppsr::schema_definition::references refs,
+  ppsr::schema_id id) {
+    return ppsr::stored_schema{
+      .schema = ppsr::
+        subject_schema{sub, ppsr::schema_definition{ppsr::schema_definition::raw_string{def}, ppsr::schema_type::avro, std::move(refs), std::nullopt}},
+      .version = ppsr::schema_version{version},
+      .id = id,
+      .deleted = ppsr::is_deleted::no};
+}
+
+// Index of the first stored schema whose subject matches `subject`, or -1.
+inline int index_of(
+  const std::vector<ppsr::stored_schema>& all, std::string_view subject) {
+    for (size_t i = 0; i < all.size(); ++i) {
+        if (all[i].schema.sub().sub() == ppsr::subject{ss::sstring{subject}}) {
+            return static_cast<int>(i);
+        }
+    }
+    return -1;
+}
+
+inline ppsr::subject_version
+key(const ppsr::context_subject& sub, int32_t version) {
+    return ppsr::subject_version{sub, ppsr::schema_version{version}};
+}
+
+/// Test-owned source-of-truth that the injected source reader serves from.
+struct fake_source_state {
+    chunked_vector<ppsr::context> contexts{ppsr::default_context};
+    chunked_vector<ppsr::stored_schema> schemas;
+    std::optional<srs::source_error> list_subjects_error;
+    // Forces list_subject_versions to fail for specific subjects, letting a
+    // test inject a per-subject enumeration failure (e.g. operation_failed)
+    // without taking down the whole listing.
+    chunked_hash_map<ppsr::context_subject, srs::source_error>
+      list_versions_errors;
+    // read_subject_version call count, keyed by (subject, version).
+    chunked_hash_map<ppsr::subject_version, uint32_t> read_counts;
+    // Forces read_subject_version to fail for specific (subject, version)
+    // nodes, letting a test inject a mid-run source fault (e.g.
+    // source_unavailable).
+    chunked_hash_map<ppsr::subject_version, srs::source_error> read_errors;
+
+    void fail_read(
+      const ppsr::context_subject& sub,
+      int32_t version,
+      srs::source_error err) {
+        read_errors.emplace(
+          ppsr::subject_version{sub, ppsr::schema_version{version}},
+          std::move(err));
+    }
+
+    void add(
+      const ppsr::context_subject& sub,
+      int32_t version,
+      ppsr::is_deleted deleted = ppsr::is_deleted::no) {
+        auto s = make_schema(
+          sub, version, fmt::format("{{\"v\":{}}}", version), deleted);
+        s.id = next_id();
+        schemas.push_back(std::move(s));
+    }
+
+    void add_with_refs(
+      const ppsr::context_subject& sub,
+      int32_t version,
+      ppsr::schema_definition::references refs) {
+        schemas.push_back(make_schema_with_refs(
+          sub,
+          version,
+          fmt::format("{{\"v\":{}}}", version),
+          std::move(refs),
+          next_id()));
+    }
+
+    // A globally-unique schema id, matching SR's per-context id namespace where
+    // distinct subjects never share an id.
+    ppsr::schema_id next_id() {
+        return ppsr::schema_id{static_cast<int32_t>(schemas.size() + 1)};
+    }
+
+    uint32_t reads(const ppsr::context_subject& sub, int32_t version) const {
+        auto it = read_counts.find(
+          ppsr::subject_version{sub, ppsr::schema_version{version}});
+        return it == read_counts.end() ? 0 : it->second;
+    }
+};
+
+class fake_source_reader final : public srs::source_reader {
+public:
+    explicit fake_source_reader(fake_source_state* state)
+      : _state(state) {}
+
+    ss::future<srs::source_result<chunked_vector<ppsr::context>>>
+    list_contexts(ss::abort_source&) override {
+        co_return _state->contexts.copy();
+    }
+
+    ss::future<srs::source_result<chunked_vector<ppsr::context_subject>>>
+    list_subjects(ppsr::context ctx, ss::abort_source&) override {
+        if (_state->list_subjects_error.has_value()) {
+            co_return std::unexpected(*_state->list_subjects_error);
+        }
+        chunked_hash_set<ppsr::context_subject> seen;
+        chunked_vector<ppsr::context_subject> subjects;
+        for (const auto& s : _state->schemas) {
+            if (s.schema.sub().ctx != ctx) {
+                continue;
+            }
+            if (seen.insert(s.schema.sub()).second) {
+                subjects.push_back(s.schema.sub());
+            }
+        }
+        co_return subjects;
+    }
+
+    ss::future<srs::source_result<chunked_vector<ppsr::schema_version>>>
+    list_subject_versions(
+      ppsr::context_subject sub,
+      ppsr::include_deleted include_deleted,
+      ss::abort_source&) override {
+        if (
+          auto it = _state->list_versions_errors.find(sub);
+          it != _state->list_versions_errors.end()) {
+            co_return std::unexpected(it->second);
+        }
+        chunked_vector<ppsr::schema_version> versions;
+        for (const auto& s : _state->schemas) {
+            if (s.schema.sub() != sub) {
+                continue;
+            }
+            if (
+              include_deleted == ppsr::include_deleted::no
+              && s.deleted == ppsr::is_deleted::yes) {
+                continue;
+            }
+            versions.push_back(s.version);
+        }
+        co_return versions;
+    }
+
+    ss::future<srs::source_result<ppsr::stored_schema>> read_subject_version(
+      ppsr::context_subject sub,
+      ppsr::schema_version version,
+      ss::abort_source&) override {
+        ++_state->read_counts[ppsr::subject_version{sub, version}];
+        if (
+          auto it = _state->read_errors.find(
+            ppsr::subject_version{sub, version});
+          it != _state->read_errors.end()) {
+            co_return std::unexpected(it->second);
+        }
+        for (const auto& s : _state->schemas) {
+            if (s.schema.sub() == sub && s.version == version) {
+                co_return s.share();
+            }
+        }
+        co_return std::unexpected(
+          srs::source_error{
+            .kind = srs::source_error_kind::operation_failed,
+            .message = "not found in source"});
+    }
+
+private:
+    fake_source_state* _state;
+};
+
+class fake_source_reader_factory final : public srs::source_reader_factory {
+public:
+    explicit fake_source_reader_factory(fake_source_state* state)
+      : _state(state) {}
+
+    std::unique_ptr<srs::source_reader> create() override {
+        return std::make_unique<fake_source_reader>(_state);
+    }
+
+private:
+    fake_source_state* _state;
+};
+
+// Holds the pieces a standalone reconcile test needs: a source state + reader,
+// a destination registry, and an all-contexts in_scope predicate.
+struct reconcile_harness {
+    fake_source_state source;
+    fake_source_reader reader{&source};
+    schema::fake_registry destination;
+
+    // Generous memory and a single worker by default. parallelism = 1 is
+    // intentional: with one worker the discover/import order is deterministic,
+    // so per-node fetch-count assertions (e.g. "a is fetched exactly once") are
+    // stable. Production defaults to 4 (driven by cluster config); under N > 1
+    // the fetch order across independent nodes is nondeterministic, so tests
+    // that exercise concurrency override `lim` and avoid exact fetch-count
+    // assertions.
+    srs::reconciler::limits lim{.memory_bytes = 1u << 20, .parallelism = 1};
+
+    srs::reconciler make(
+      std::function<bool(const ppsr::context_subject&)> in_scope =
+        [](const ppsr::context_subject&) { return true; }) {
+        return srs::reconciler{&reader, &destination, std::move(in_scope), lim};
+    }
+
+    ss::future<srs::source_result<srs::reconcile_stats>>
+    run(srs::work_set work, chunked_hash_set<ppsr::subject_version> seed = {}) {
+        ss::abort_source as;
+        auto r = make();
+        srs::reconcile_stats stats;
+        auto res = co_await r.reconcile(
+          std::move(work), std::move(seed), stats, as);
+        if (!res.has_value()) {
+            co_return std::unexpected(std::move(res.error()));
+        }
+        co_return stats;
+    }
+};
+
+// Base for test registries that wrap a real inner registry and override only
+// the calls a given test cares about; every other call delegates unchanged.
+class delegating_registry : public schema::registry {
+public:
+    explicit delegating_registry(schema::registry* inner)
+      : _inner(inner) {}
+
+    ss::future<ppsr::context_schema_id>
+    import_schema(ppsr::stored_schema schema) override {
+        return _inner->import_schema(std::move(schema));
+    }
+    bool is_enabled() const override { return _inner->is_enabled(); }
+    ss::future<ppsr::schema_getter*> getter() const override {
+        return _inner->getter();
+    }
+    ss::future<ppsr::schema_getter*> synced_getter() const override {
+        return _inner->synced_getter();
+    }
+    ss::future<ss::lowres_clock::time_point>
+    sync(ss::lowres_clock::duration max_age) override {
+        return _inner->sync(max_age);
+    }
+    ss::future<ppsr::schema_definition>
+    get_schema_definition(ppsr::context_schema_id id) const override {
+        return _inner->get_schema_definition(id);
+    }
+    ss::future<ppsr::stored_schema> get_subject_schema(
+      ppsr::context_subject sub,
+      std::optional<ppsr::schema_version> version) const override {
+        return _inner->get_subject_schema(std::move(sub), version);
+    }
+    ss::future<chunked_vector<ppsr::subject_version_deleted>>
+    list_subject_versions(
+      std::function<bool(const ppsr::context_subject&)> filter,
+      ppsr::include_deleted inc) const override {
+        return _inner->list_subject_versions(std::move(filter), inc);
+    }
+    ss::future<ppsr::context_schema_id>
+    create_schema(ppsr::subject_schema s) override {
+        return _inner->create_schema(std::move(s));
+    }
+    ss::future<bool> soft_delete_schema(
+      ppsr::context_subject sub, ppsr::schema_version v) override {
+        return _inner->soft_delete_schema(std::move(sub), v);
+    }
+    ss::future<chunked_vector<ppsr::schema_version>> permanent_delete_schema(
+      ppsr::context_subject sub,
+      std::optional<ppsr::schema_version> v) override {
+        return _inner->permanent_delete_schema(std::move(sub), v);
+    }
+    ss::future<bool>
+    write_mode(ppsr::context_subject sub, ppsr::mode m) override {
+        return _inner->write_mode(std::move(sub), m);
+    }
+    ss::future<bool> delete_mode(ppsr::context_subject sub) override {
+        return _inner->delete_mode(std::move(sub));
+    }
+    ss::future<bool> write_config(
+      ppsr::context_subject sub, ppsr::compatibility_level c) override {
+        return _inner->write_config(std::move(sub), c);
+    }
+    ss::future<bool> delete_config(ppsr::context_subject sub) override {
+        return _inner->delete_config(std::move(sub));
+    }
+
+protected:
+    schema::registry* _inner;
+};
+
+// Wraps a destination registry, suspending `import_schema` on an abortable wait
+// so a test can abort the sync while a worker holds byte-budget units around an
+// in-flight import. Every other call delegates to the inner registry.
+class blocking_import_registry final : public delegating_registry {
+public:
+    /// `block_after` imports are forwarded to the inner registry; the next
+    /// import parks (signalling `entered`) until the test aborts. Default 0
+    /// blocks the very first import.
+    explicit blocking_import_registry(
+      schema::registry* inner, size_t block_after = 0)
+      : delegating_registry(inner)
+      , _block_after(block_after) {}
+
+    ss::future<ppsr::context_schema_id>
+    import_schema(ppsr::stored_schema schema) override {
+        if (_imports_seen++ < _block_after) {
+            co_return co_await _inner->import_schema(std::move(schema));
+        }
+        if (!_entered_set) {
+            _entered_set = true;
+            _entered.set_value();
+        }
+        // Park until the test releases (clean completion) or aborts (the wait
+        // resolves with abort_requested).
+        co_await _release.get_future();
+        co_return co_await _inner->import_schema(std::move(schema));
+    }
+
+    ss::future<> entered() { return _entered.get_future(); }
+    // Resolve the parked import as an abort, so the run unwinds through the
+    // reconciler's abort path.
+    void abort() {
+        _release.set_exception(
+          std::make_exception_ptr(ss::abort_requested_exception{}));
+    }
+    // Resolve the parked import cleanly so it forwards to the inner registry.
+    void unblock() { _release.set_value(); }
+
+private:
+    size_t _block_after;
+    size_t _imports_seen{0};
+    bool _entered_set{false};
+    ss::promise<> _entered;
+    ss::promise<> _release;
+};
+
+// Wraps a destination registry, throwing a configured schema-registry error for
+// specific (subject, version) imports and delegating everything else. Lets a
+// test inject a per-item import failure the in-memory fake would never produce
+// on its own -- a body the destination cannot parse, or a reference that does
+// not resolve at import time.
+class failing_import_registry final : public delegating_registry {
+public:
+    using delegating_registry::delegating_registry;
+
+    void fail_import(
+      const ppsr::subject_version& key,
+      ppsr::error_code code,
+      ss::sstring message) {
+        _failures.emplace(key, ppsr::error_info{code, std::move(message)});
+    }
+
+    ss::future<ppsr::context_schema_id>
+    import_schema(ppsr::stored_schema schema) override {
+        ppsr::subject_version key{schema.schema.sub(), schema.version};
+        if (auto it = _failures.find(key); it != _failures.end()) {
+            return ss::make_exception_future<ppsr::context_schema_id>(
+              ppsr::as_exception(it->second));
+        }
+        return _inner->import_schema(std::move(schema));
+    }
+
+private:
+    chunked_hash_map<ppsr::subject_version, ppsr::error_info> _failures;
+};
+
+} // namespace cluster_link::tests

--- a/src/v/cluster_link/schema_registry_sync/unavailable_source_reader.cc
+++ b/src/v/cluster_link/schema_registry_sync/unavailable_source_reader.cc
@@ -23,6 +23,11 @@ source_error unavailable() {
 }
 } // namespace
 
+ss::future<source_result<chunked_vector<ppsr::context>>>
+unavailable_source_reader::list_contexts(ss::abort_source&) {
+    co_return std::unexpected(unavailable());
+}
+
 ss::future<source_result<chunked_vector<ppsr::context_subject>>>
 unavailable_source_reader::list_subjects(ppsr::context, ss::abort_source&) {
     co_return std::unexpected(unavailable());
@@ -30,7 +35,7 @@ unavailable_source_reader::list_subjects(ppsr::context, ss::abort_source&) {
 
 ss::future<source_result<chunked_vector<ppsr::schema_version>>>
 unavailable_source_reader::list_subject_versions(
-  ppsr::context_subject, ss::abort_source&) {
+  ppsr::context_subject, ppsr::include_deleted, ss::abort_source&) {
     co_return std::unexpected(unavailable());
 }
 

--- a/src/v/cluster_link/schema_registry_sync/unavailable_source_reader.h
+++ b/src/v/cluster_link/schema_registry_sync/unavailable_source_reader.h
@@ -22,11 +22,15 @@ namespace cluster_link::schema_registry_sync {
 /// the Schema Registry shadowing task parks the link in `link_unavailable`.
 class unavailable_source_reader final : public source_reader {
 public:
+    ss::future<source_result<chunked_vector<ppsr::context>>>
+    list_contexts(ss::abort_source&) override;
+
     ss::future<source_result<chunked_vector<ppsr::context_subject>>>
     list_subjects(ppsr::context, ss::abort_source&) override;
 
     ss::future<source_result<chunked_vector<ppsr::schema_version>>>
-    list_subject_versions(ppsr::context_subject, ss::abort_source&) override;
+    list_subject_versions(
+      ppsr::context_subject, ppsr::include_deleted, ss::abort_source&) override;
 
     ss::future<source_result<ppsr::stored_schema>> read_subject_version(
       ppsr::context_subject, ppsr::schema_version, ss::abort_source&) override;

--- a/src/v/datalake/tests/record_schema_resolver_test.cc
+++ b/src/v/datalake/tests/record_schema_resolver_test.cc
@@ -608,7 +608,8 @@ public:
         return _registry.get_subject_schema(sub, version);
     }
 
-    ss::future<chunked_vector<pandaproxy::schema_registry::subject_version>>
+    ss::future<
+      chunked_vector<pandaproxy::schema_registry::subject_version_deleted>>
     list_subject_versions(
       std::function<bool(const pandaproxy::schema_registry::context_subject&)>
         filter,

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -440,22 +440,22 @@ ss::future<chunked_vector<context_subject>> sharded_store::get_subjects(
     co_return co_await _store.map_reduce0(map, subjects{}, reduce);
 }
 
-ss::future<chunked_vector<subject_version>>
+ss::future<chunked_vector<subject_version_deleted>>
 sharded_store::list_subject_versions(
   std::function<bool(const context_subject&)> filter, include_deleted inc_del) {
-    using result_t = chunked_vector<subject_version>;
+    using result_t = chunked_vector<subject_version_deleted>;
     auto map = [filter = std::move(filter), inc_del](store& s) {
         result_t out;
         for (const auto& sub : s.get_subjects(inc_del)) {
             if (!filter(sub)) {
                 continue;
             }
-            auto versions = s.get_versions(sub, inc_del);
+            auto versions = s.get_version_ids(sub, inc_del);
             if (versions.has_error()) {
                 continue;
             }
-            for (auto v : versions.assume_value()) {
-                out.emplace_back(sub, v);
+            for (const auto& v : versions.assume_value()) {
+                out.push_back({sub, v.version, v.deleted});
             }
         }
         return out;

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -111,8 +111,10 @@ public:
       std::optional<ss::sstring> subject_prefix = std::nullopt);
 
     ///\brief Return every (subject, version) whose subject matches `filter`,
-    /// in a single scatter-gather across shards.
-    ss::future<chunked_vector<subject_version>> list_subject_versions(
+    /// in a single scatter-gather across shards. Each result carries its
+    /// version's soft-delete state, so an include_deleted scan reports both the
+    /// live and deleted nodes in one pass.
+    ss::future<chunked_vector<subject_version_deleted>> list_subject_versions(
       std::function<bool(const context_subject&)> filter,
       include_deleted inc_del);
 

--- a/src/v/pandaproxy/schema_registry/test/internal_writes.cc
+++ b/src/v/pandaproxy/schema_registry/test/internal_writes.cc
@@ -223,6 +223,53 @@ TEST_F(internal_writes_fixture, deletes_bypass_readonly) {
       pps::exception);
 }
 
+TEST_F(internal_writes_fixture, import_validates_reference_order) {
+    // The destination validates a schema's references against the store on
+    // import, so a referrer can only be imported after its referent. This
+    // anchors the reference-ordering requirement the shadowing reconciler
+    // relies on (the fake registry does not validate references).
+    auto referent_sub = pps::context_subject::unqualified("internal-referent");
+    auto referrer_sub = pps::context_subject::unqualified("internal-referrer");
+
+    auto referent_def = pps::schema_definition(
+      R"({"type":"record","name":"Address","namespace":"com.example",)"
+      R"("fields":[{"name":"city","type":"string"}]})",
+      pps::schema_type::avro);
+
+    auto referrer_def = pps::schema_definition(
+      R"({"type":"record","name":"Person","namespace":"com.example",)"
+      R"("fields":[{"name":"addr","type":"com.example.Address"}]})",
+      pps::schema_type::avro,
+      {pps::schema_reference{
+        .name = "com.example.Address",
+        .sub = {referent_sub, pps::is_qualified::no},
+        .version = pps::schema_version{1}}},
+      {});
+
+    auto referrer = [&] {
+        return pps::stored_schema{
+          .schema = {referrer_sub, referrer_def.share()},
+          .version = pps::schema_version{1},
+          .id = pps::schema_id{2},
+          .deleted = pps::is_deleted::no};
+    };
+
+    // Referrer-first: the referent is absent, so validation fails.
+    ASSERT_EQ(
+      import_error_code(referrer()), pps::error_code::schema_missing_reference);
+
+    // Referent-first, then referrer: validation resolves the reference and the
+    // import succeeds.
+    import(
+      pps::stored_schema{
+        .schema = {referent_sub, referent_def.share()},
+        .version = pps::schema_version{1},
+        .id = pps::schema_id{1},
+        .deleted = pps::is_deleted::no});
+    auto ctx_id = import(referrer());
+    ASSERT_EQ(ctx_id.id, pps::schema_id{2});
+}
+
 TEST_F(internal_writes_fixture, imports_preserve_deleted_state) {
     auto subject = pps::context_subject::unqualified("internal-deleted-state");
     auto schema_def = pps::schema_definition(

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -991,12 +991,15 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
 namespace {
 
 bool contains_subject_version(
-  const chunked_vector<pps::subject_version>& got,
+  const chunked_vector<pps::subject_version_deleted>& got,
   const pps::context_subject& sub,
-  pps::schema_version version) {
-    return std::ranges::any_of(got, [&](const pps::subject_version& sv) {
-        return sv.sub == sub && sv.version == version;
-    });
+  pps::schema_version version,
+  pps::is_deleted deleted = pps::is_deleted::no) {
+    return std::ranges::any_of(
+      got, [&](const pps::subject_version_deleted& sv) {
+          return sv.sub == sub && sv.version == version
+                 && sv.deleted == deleted;
+      });
 }
 
 void upsert_version(
@@ -1068,15 +1071,18 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_list_subject_versions) {
     BOOST_REQUIRE(contains_subject_version(live, a, pps::schema_version{1}));
     BOOST_REQUIRE(contains_subject_version(live, b, pps::schema_version{1}));
 
-    // include_deleted brings back a's second version and subject d entirely.
+    // include_deleted brings back a's second version and subject d entirely,
+    // each flagged with its soft-delete state in a single scan.
     auto with_deleted
       = store.list_subject_versions(only_default, pps::include_deleted::yes)
           .get();
     BOOST_REQUIRE_EQUAL(with_deleted.size(), 4);
-    BOOST_REQUIRE(
-      contains_subject_version(with_deleted, a, pps::schema_version{2}));
-    BOOST_REQUIRE(
-      contains_subject_version(with_deleted, d, pps::schema_version{1}));
+    BOOST_REQUIRE(contains_subject_version(
+      with_deleted, a, pps::schema_version{1}, pps::is_deleted::no));
+    BOOST_REQUIRE(contains_subject_version(
+      with_deleted, a, pps::schema_version{2}, pps::is_deleted::yes));
+    BOOST_REQUIRE(contains_subject_version(
+      with_deleted, d, pps::schema_version{1}, pps::is_deleted::yes));
 
     // A different predicate selects only the other context.
     auto in_other = store

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -640,6 +640,14 @@ struct subject_version {
       , version{v} {}
     context_subject sub;
     schema_version version;
+
+    friend bool
+    operator==(const subject_version&, const subject_version&) = default;
+
+    template<typename H>
+    friend H AbslHashValue(H h, const subject_version& sv) {
+        return H::combine(std::move(h), sv.sub, sv.version);
+    }
 };
 
 // Very similar to topic_key_type, separate to avoid intermingling storage code

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -650,6 +650,17 @@ struct subject_version {
     }
 };
 
+/// A (subject, version) pair carrying that version's soft-delete state, so a
+/// single include_deleted scan can report both the live and deleted nodes.
+struct subject_version_deleted {
+    context_subject sub;
+    schema_version version;
+    is_deleted deleted{is_deleted::no};
+
+    friend bool operator==(
+      const subject_version_deleted&, const subject_version_deleted&) = default;
+};
+
 // Very similar to topic_key_type, separate to avoid intermingling storage code
 enum class seq_marker_key_type {
     invalid = 0,

--- a/src/v/schema/registry.cc
+++ b/src/v/schema/registry.cc
@@ -77,7 +77,8 @@ public:
         co_return co_await reader->get_subject_schema(
           sub, version, ppsr::include_deleted::no);
     }
-    ss::future<chunked_vector<ppsr::subject_version>> list_subject_versions(
+    ss::future<chunked_vector<ppsr::subject_version_deleted>>
+    list_subject_versions(
       std::function<bool(const ppsr::context_subject&)> filter,
       ppsr::include_deleted inc_del) const override {
         auto [reader, _] = co_await service();
@@ -210,7 +211,8 @@ public:
         throw std::logic_error(
           "invalid attempted usage of a disabled schema registry");
     }
-    ss::future<chunked_vector<ppsr::subject_version>> list_subject_versions(
+    ss::future<chunked_vector<ppsr::subject_version_deleted>>
+    list_subject_versions(
       std::function<bool(const ppsr::context_subject&)>,
       ppsr::include_deleted) const override {
         throw std::logic_error(

--- a/src/v/schema/registry.h
+++ b/src/v/schema/registry.h
@@ -71,10 +71,11 @@ public:
         pandaproxy::schema_registry::context_subject,
         std::optional<pandaproxy::schema_registry::schema_version>) const = 0;
 
-    /// Lists every (subject, version) whose subject matches `filter`. The
-    /// predicate must be pure and copyable (it runs on each registry shard).
+    /// Lists every (subject, version) whose subject matches `filter`, each
+    /// carrying its version's soft-delete state. The predicate must be pure and
+    /// copyable (it runs on each registry shard).
     virtual ss::future<
-      chunked_vector<pandaproxy::schema_registry::subject_version>>
+      chunked_vector<pandaproxy::schema_registry::subject_version_deleted>>
     list_subject_versions(
       std::function<bool(const pandaproxy::schema_registry::context_subject&)>
         filter,

--- a/src/v/schema/tests/fake_registry.cc
+++ b/src/v/schema/tests/fake_registry.cc
@@ -101,12 +101,12 @@ ss::future<ppsr::schema_getter*> schema::fake_registry::getter() const {
     maybe_throw_injected_failure();
     co_return &_store;
 }
-ss::future<chunked_vector<ppsr::subject_version>>
+ss::future<chunked_vector<ppsr::subject_version_deleted>>
 schema::fake_registry::list_subject_versions(
   std::function<bool(const ppsr::context_subject&)> filter,
   ppsr::include_deleted inc_del) const {
     maybe_throw_injected_failure();
-    chunked_vector<ppsr::subject_version> out;
+    chunked_vector<ppsr::subject_version_deleted> out;
     for (const auto& s : _store.schemas) {
         if (!filter(s.schema.sub())) {
             continue;
@@ -114,7 +114,7 @@ schema::fake_registry::list_subject_versions(
         if (!inc_del && s.deleted) {
             continue;
         }
-        out.emplace_back(s.schema.sub(), s.version);
+        out.push_back({s.schema.sub(), s.version, s.deleted});
     }
     co_return out;
 }

--- a/src/v/schema/tests/fake_registry.h
+++ b/src/v/schema/tests/fake_registry.h
@@ -64,7 +64,8 @@ public:
       std::optional<pandaproxy::schema_registry::schema_version> version)
       const override;
 
-    ss::future<chunked_vector<pandaproxy::schema_registry::subject_version>>
+    ss::future<
+      chunked_vector<pandaproxy::schema_registry::subject_version_deleted>>
     list_subject_versions(
       std::function<bool(const pandaproxy::schema_registry::context_subject&)>
         filter,


### PR DESCRIPTION
This implements the core part of replicating schemas in reference order from a source schema registry to the local schema registry as a reconciler. The reconciler spawns a number of worker fibres, that all take schemas from a queue for replication. This enables more parallelism to avoid the mirroring process from becoming latency bound when handling the replication of a large number of subject versions (with upper limits expected at the ~100k subject version scale).

Fixes https://redpandadata.atlassian.net/browse/CORE-16747

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
