### PR TITLE
[v26.1.x] datalake: Fix deleted namespace race for REST_HADOOP catalog

### DIFF
--- a/tests/rptest/tests/datalake/datalake_table_name_test.py
+++ b/tests/rptest/tests/datalake/datalake_table_name_test.py
@@ -168,10 +168,18 @@ class DatalakeTableNameTest(RedpandaTest):
                         for row in spark.run_query_fetch_all("SHOW TABLES IN redpanda")
                     ]
                 except pyhive.exc.OperationalError as e:
-                    if "NoSuchNamespaceException" in str(e):
-                        # Purging the last table deletes all files under the
-                        # namespace prefix in S3, so the namespace disappears.
-                        # An absent namespace means the table is gone too.
+                    # Purging the last table deletes all files under the
+                    # namespace prefix in S3, so the namespace disappears.
+                    # An absent namespace means the table is gone too.
+                    # JDBC-backed catalogs report NoSuchNamespaceException.
+                    # HadoopCatalog instead gets FileNotFoundException from
+                    # S3AFileSystem and wraps it as RuntimeIOException
+                    # ("Failed to list tables under: <ns>").
+                    msg = str(e)
+                    if (
+                        "NoSuchNamespaceException" in msg
+                        or "Failed to list tables" in msg
+                    ):
                         return True
                     raise
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30928
