### PR TITLE
`ct/l1`: set `_max_slice_bytes` in `level_one_reader`

### DIFF
--- a/src/v/cloud_topics/level_one/frontend_reader/BUILD
+++ b/src/v/cloud_topics/level_one/frontend_reader/BUILD
@@ -48,6 +48,7 @@ redpanda_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//src/v/base",
         "//src/v/bytes:iostream",
         "//src/v/cloud_topics:log_reader_config",
         "//src/v/cloud_topics:logger",

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -41,7 +41,8 @@ level_one_log_reader_impl::level_one_log_reader_impl(
   model::topic_id_partition tidp,
   l1::metastore* metastore,
   l1::io* io_interface,
-  level_one_reader_probe* probe)
+  level_one_reader_probe* probe,
+  size_t max_slice_bytes)
   : _config(cfg)
   , _ntp(std::move(ntp))
   , _tidp(tidp)
@@ -49,7 +50,8 @@ level_one_log_reader_impl::level_one_log_reader_impl(
   , _metastore(metastore)
   , _io(io_interface)
   , _probe(probe)
-  , _log(cd_log, fmt::format("[{}/{}/{}]", fmt::ptr(this), _ntp, _tidp)) {
+  , _log(cd_log, fmt::format("[{}/{}/{}]", fmt::ptr(this), _ntp, _tidp))
+  , _max_slice_bytes(max_slice_bytes) {
     vlog(_log.debug, "New reader created {}", _config);
 }
 
@@ -389,6 +391,10 @@ level_one_log_reader_impl::read_batches(l1::object_reader& reader) {
         }
         if (is_over_limit_with_bytes(hdr->size_bytes)) {
             set_end_of_stream();
+            break;
+        }
+
+        if (bytes_read > 0 && bytes_read + hdr->size_bytes > _max_slice_bytes) {
             break;
         }
 

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
@@ -9,6 +9,7 @@
  */
 #pragma once
 
+#include "base/units.h"
 #include "cloud_topics/level_one/common/abstract_io.h"
 #include "cloud_topics/level_one/common/object.h"
 #include "cloud_topics/level_one/common/object_id.h"
@@ -75,13 +76,16 @@ struct open_stream {
  */
 class level_one_log_reader_impl : public model::record_batch_reader::impl {
 public:
+    static constexpr size_t default_max_slice_bytes = 32_MiB;
+
     level_one_log_reader_impl(
       const cloud_topic_log_reader_config& cfg,
       model::ntp ntp,
       model::topic_id_partition tidp,
       l1::metastore* metastore,
       l1::io* io_interface,
-      level_one_reader_probe* probe = nullptr);
+      level_one_reader_probe* probe = nullptr,
+      size_t max_slice_bytes = default_max_slice_bytes);
 
     bool is_end_of_stream() const final;
 
@@ -201,6 +205,7 @@ private:
     level_one_reader_probe* _probe;
     prefix_logger _log;
     size_t _bytes_consumed{0};
+    size_t _max_slice_bytes;
     bool _was_cached{false};
 
     // Open stream for the current object. Non-null while the reader is

--- a/src/v/cloud_topics/level_one/frontend_reader/tests/BUILD
+++ b/src/v/cloud_topics/level_one/frontend_reader/tests/BUILD
@@ -52,6 +52,7 @@ redpanda_cc_gtest(
     ],
     deps = [
         ":l1_reader_fixture",
+        "//src/v/base",
         "//src/v/bytes:iostream",
         "//src/v/cloud_topics:log_reader_config",
         "//src/v/cloud_topics:logger",

--- a/src/v/cloud_topics/level_one/frontend_reader/tests/reader_test.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/tests/reader_test.cc
@@ -8,6 +8,7 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 
+#include "base/units.h"
 #include "bytes/iostream.h"
 #include "cloud_topics/level_one/common/fake_io.h"
 #include "cloud_topics/level_one/common/object.h"
@@ -23,7 +24,10 @@
 
 #include <gtest/gtest.h>
 
+#include <iostream>
+#include <limits>
 #include <optional>
+#include <tuple>
 
 using namespace cloud_topics;
 using namespace std::chrono_literals;
@@ -657,4 +661,78 @@ TEST_F(l1_reader_test, lookahead_multiple_objects) {
     auto reader_no_prefetch = make_reader(ntp, tidp);
     auto result_no_prefetch = read_all(std::move(reader_no_prefetch));
     EXPECT_EQ(result_no_prefetch, expected);
+}
+
+// Demonstrates that the per-slice cap bounds the reader's peak in-memory
+// footprint. Without the cap, read_batches returned an entire offset range in a
+// single slice, so reading a large extent (with no max_bytes limit, as
+// compaction/leveling do) can materialize the whole thing at once. With the
+// cap, the same range is delivered across multiple bounded slices.
+TEST_F(l1_reader_test, slice_cap_bounds_peak_reader_memory) {
+    auto [ntp, tidp] = make_ntidp("big_extent_topic");
+
+    // Build a ~64 MiB single-partition extent from uncompressed batches so the
+    // stored size is predictable (not shrunk by compression).
+    static constexpr size_t batch_bytes = 1_MiB;
+    static constexpr int num_batches = 64;
+    model::test::record_batch_spec spec{
+      .offset = model::offset{0},
+      .allow_compression = false,
+      .count = num_batches,
+      .records = 1,
+      .record_sizes = std::vector<size_t>{batch_bytes},
+    };
+    {
+        std::vector<tidp_batches_t> tidp_batches;
+        tidp_batches.emplace_back(
+          tidp, model::test::make_random_batches(spec).get());
+        make_l1_objects(std::move(tidp_batches)).get();
+    }
+
+    // Drive do_load_slice directly so we can observe the bytes held in a single
+    // slice (i.e. the reader's peak in-memory footprint for the read).
+    auto measure = [&](size_t slice_cap) {
+        auto impl = std::make_unique<level_one_log_reader_impl>(
+          make_test_config(),
+          ntp,
+          tidp,
+          &_metastore,
+          &_io,
+          /*probe=*/nullptr,
+          slice_cap);
+        size_t total = 0;
+        size_t peak_slice = 0;
+        size_t slices = 0;
+        while (!impl->is_end_of_stream()) {
+            auto storage = impl->do_load_slice(model::no_timeout).get();
+            const auto& data = std::get<model::record_batch_reader::data_t>(
+              storage);
+            size_t slice_bytes = 0;
+            for (const auto& b : data) {
+                slice_bytes += b.size_bytes();
+            }
+            if (!data.empty()) {
+                ++slices;
+            }
+            total += slice_bytes;
+            peak_slice = std::max(peak_slice, slice_bytes);
+        }
+        impl->finally().get();
+        return std::tuple{total, peak_slice, slices};
+    };
+
+    // Unbounded: no per-slice cap -> the whole extent is one slice, so the
+    // reader holds the entire ~64 MiB at once.
+    auto [unbounded_total, unbounded_peak, unbounded_slices] = measure(
+      std::numeric_limits<size_t>::max());
+
+    // Now: the production cap -> the extent is chunked into bounded slices.
+    constexpr auto cap = level_one_log_reader_impl::default_max_slice_bytes;
+    auto [bounded_total, bounded_peak, bounded_slices] = measure(cap);
+
+    EXPECT_EQ(unbounded_total, bounded_total); // identical data read both ways
+    EXPECT_EQ(unbounded_slices, 1u);           // one giant slice
+    EXPECT_GE(unbounded_peak, 60_MiB);         // ~64 MiB held at once
+    EXPECT_GT(bounded_slices, 1u);             // chunked
+    EXPECT_LE(bounded_peak, cap);              // bounded to the cap
 }


### PR DESCRIPTION
Compaction and leveling readers consume an extent's full offset range with no `max_bytes` limit, so `read_batches()` tends to materialize every batch in the range into a single slice. In practice, this could mean holding an entire extent in memory at once (potentially up to 128MiB).

Cap each slice at `default_max_slice_bytes` (32MiB) so a large range is delivered across bounded slices instead. Unlike the `max_bytes` limit, hitting this cap ends only the current slice: the stream stays open and `consume()` resumes from there, so the reader's peak footprint is the cap rather than the extent size.

Consumer fetches are already bounded by `max_bytes`, which are well under this default value, and are therefore likely unaffected by this change.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
