### PR TITLE
cluster_link: groundwork for shadow link role sync

### DIFF
--- a/src/v/cluster_link/BUILD
+++ b/src/v/cluster_link/BUILD
@@ -48,7 +48,11 @@ redpanda_cc_library(
     visibility = ["//src/v/cluster_link:__subpackages__"],
     deps = [
         "//src/v/cluster_link/model",
+        "//src/v/kafka/client:cluster",
         "//src/v/kafka/client:configuration",
+        "//src/v/kafka/protocol",
+        "//src/v/ssx:sformat",
+        "@seastar",
     ],
 )
 
@@ -134,6 +138,7 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         ":logger",
+        ":utils",
         "//src/v/cluster_link/model",
         "//src/v/kafka/server:topic_config_utils",
         "//src/v/model",
@@ -193,6 +198,7 @@ redpanda_cc_library(
     visibility = ["//src/v/cluster_link:__subpackages__"],
     deps = [
         ":impl",
+        ":utils",
         "//src/v/cluster:fwd",
         "//src/v/cluster_link/model",
         "//src/v/kafka/client:cluster",

--- a/src/v/cluster_link/model/BUILD
+++ b/src/v/cluster_link/model/BUILD
@@ -28,6 +28,7 @@ redpanda_cc_library(
         "//src/v/serde:map",
         "//src/v/serde:named_type",
         "//src/v/serde:optional",
+        "//src/v/serde:set",
         "//src/v/serde:variant",
         "//src/v/serde:vector",
         "//src/v/utils:absl_sstring_hash",

--- a/src/v/cluster_link/model/filter_utils.cc
+++ b/src/v/cluster_link/model/filter_utils.cc
@@ -13,9 +13,8 @@
 
 namespace cluster_link::model {
 namespace {
-template<typename T>
 bool select_using_filter(
-  const T& resource,
+  std::string_view resource,
   const chunked_vector<resource_name_filter_pattern>& patterns) {
     bool matched = false;
     for (const auto& pattern : patterns) {
@@ -28,7 +27,7 @@ bool select_using_filter(
             break;
         case filter_pattern_type::prefix:
             if (!pattern.pattern.empty()) {
-                filter_selected = resource().starts_with(pattern.pattern);
+                filter_selected = resource.starts_with(pattern.pattern);
             }
             break;
         }
@@ -51,13 +50,19 @@ bool select_using_filter(
 bool select_topic(
   ::model::topic_view topic,
   const chunked_vector<resource_name_filter_pattern>& patterns) {
-    return select_using_filter(topic, patterns);
+    return select_using_filter(topic(), patterns);
 }
 
 bool select_group(
   const kafka::group_id& group_id,
   const chunked_vector<resource_name_filter_pattern>& patterns) {
-    return select_using_filter(group_id, patterns);
+    return select_using_filter(group_id(), patterns);
+}
+
+bool select_role(
+  std::string_view role_name,
+  const chunked_vector<resource_name_filter_pattern>& patterns) {
+    return select_using_filter(role_name, patterns);
 }
 
 } // namespace cluster_link::model

--- a/src/v/cluster_link/model/filter_utils.h
+++ b/src/v/cluster_link/model/filter_utils.h
@@ -34,4 +34,8 @@ bool select_group(
   const kafka::group_id& group_id,
   const chunked_vector<resource_name_filter_pattern>& patterns);
 
+bool select_role(
+  std::string_view role_name,
+  const chunked_vector<resource_name_filter_pattern>& patterns);
+
 } // namespace cluster_link::model

--- a/src/v/cluster_link/model/tests/test_model.cc
+++ b/src/v/cluster_link/model/tests/test_model.cc
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
+#include "cluster_link/model/filter_utils.h"
 #include "cluster_link/model/types.h"
 #include "serde/rw/rw.h"
 
@@ -195,5 +196,23 @@ TEST(test_model, role_sync_config_serde_round_trip) {
     EXPECT_EQ(decoded.role_sync_cfg.is_enabled, enabled_t::no);
     EXPECT_EQ(
       decoded.role_sync_cfg.get_task_interval(), std::chrono::seconds{45});
+}
+TEST(test_model, select_role_include_exclude_prefix) {
+    using namespace cluster_link::model;
+    chunked_vector<resource_name_filter_pattern> patterns;
+    patterns.push_back(
+      resource_name_filter_pattern{
+        .pattern_type = filter_pattern_type::prefix,
+        .filter = filter_type::include,
+        .pattern = "analytics-"});
+    patterns.push_back(
+      resource_name_filter_pattern{
+        .pattern_type = filter_pattern_type::literal,
+        .filter = filter_type::exclude,
+        .pattern = "analytics-secret"});
+
+    EXPECT_TRUE(select_role("analytics-reader", patterns));
+    EXPECT_FALSE(select_role("analytics-secret", patterns)); // excluded
+    EXPECT_FALSE(select_role("ops-admin", patterns));        // no include match
 }
 } // namespace cluster_link::model::tests

--- a/src/v/cluster_link/model/tests/test_model.cc
+++ b/src/v/cluster_link/model/tests/test_model.cc
@@ -176,4 +176,24 @@ TEST(test_model, schema_registry_sync_config_legacy_skips_v1_api_mode) {
 
     EXPECT_FALSE(legacy.sync_schema_registry_topic_mode.has_value());
 }
+
+TEST(test_model, role_sync_config_serde_round_trip) {
+    link_configuration cfg;
+    cfg.role_sync_cfg.is_enabled = enabled_t::no;
+    cfg.role_sync_cfg.task_interval = std::chrono::seconds{45};
+    cfg.role_sync_cfg.role_name_filters.push_back(
+      resource_name_filter_pattern{
+        .pattern_type = filter_pattern_type::prefix,
+        .filter = filter_type::include,
+        .pattern = "analytics-"});
+
+    auto buf = serde::to_iobuf(cfg.copy());
+    auto decoded = serde::from_iobuf<link_configuration>(std::move(buf));
+
+    EXPECT_EQ(decoded, cfg);
+    ASSERT_EQ(decoded.role_sync_cfg.role_name_filters.size(), 1);
+    EXPECT_EQ(decoded.role_sync_cfg.is_enabled, enabled_t::no);
+    EXPECT_EQ(
+      decoded.role_sync_cfg.get_task_interval(), std::chrono::seconds{45});
+}
 } // namespace cluster_link::model::tests

--- a/src/v/cluster_link/model/types.cc
+++ b/src/v/cluster_link/model/types.cc
@@ -286,12 +286,20 @@ void schema_registry_sync_config::serde_read(
     }
 }
 
+role_sync_config role_sync_config::copy() const {
+    role_sync_config copy;
+    copy.is_enabled = is_enabled;
+    copy.task_interval = task_interval;
+    copy.role_name_filters = role_name_filters.copy();
+    return copy;
+}
 link_configuration link_configuration::copy() const {
     link_configuration copy;
     copy.topic_metadata_mirroring_cfg = topic_metadata_mirroring_cfg.copy();
     copy.consumer_groups_mirroring_cfg = consumer_groups_mirroring_cfg.copy();
     copy.security_settings_sync_cfg = security_settings_sync_cfg.copy();
     copy.schema_registry_sync_cfg = schema_registry_sync_cfg.copy();
+    copy.role_sync_cfg = role_sync_cfg.copy();
     return copy;
 }
 
@@ -908,17 +916,30 @@ auto fmt::formatter<cluster_link::model::security_settings_sync_config>::format(
       cfg.acl_filters);
 }
 
+auto fmt::formatter<cluster_link::model::role_sync_config>::format(
+  const cluster_link::model::role_sync_config& cfg, format_context& ctx) const
+  -> decltype(ctx.out()) {
+    return fmt::format_to(
+      ctx.out(),
+      "{{enabled: {}, task_interval: {}, role_name_filters: {}}}",
+      cfg.is_enabled,
+      cfg.task_interval,
+      cfg.role_name_filters);
+}
+
 auto fmt::formatter<cluster_link::model::link_configuration>::format(
   const cluster_link::model::link_configuration& cfg, format_context& ctx) const
   -> decltype(ctx.out()) {
     return fmt::format_to(
       ctx.out(),
       "{{topic_metadata_mirroring_cfg: {}, consumer_groups_mirroring_cfg: {}, "
-      "security_settings_sync_cfg: {}, schema_registry_sync_cfg: {}}}",
+      "security_settings_sync_cfg: {}, schema_registry_sync_cfg: {}, "
+      "role_sync_cfg: {}}}",
       cfg.topic_metadata_mirroring_cfg,
       cfg.consumer_groups_mirroring_cfg,
       cfg.security_settings_sync_cfg,
-      cfg.schema_registry_sync_cfg);
+      cfg.schema_registry_sync_cfg,
+      cfg.role_sync_cfg);
 }
 
 auto fmt::

--- a/src/v/cluster_link/model/types.h
+++ b/src/v/cluster_link/model/types.h
@@ -27,6 +27,7 @@
 #include "serde/rw/map.h"
 #include "serde/rw/named_type.h"
 #include "serde/rw/optional.h"
+#include "serde/rw/set.h"
 #include "serde/rw/variant.h"
 #include "serde/rw/vector.h"
 #include "utils/absl_sstring_hash.h"
@@ -958,13 +959,44 @@ struct security_settings_sync_config
 };
 
 /**
+ * Configuration for syncing RBAC roles
+ */
+struct role_sync_config
+  : serde::
+      envelope<role_sync_config, serde::version<0>, serde::compat_version<0>> {
+    /// Flag to indicate if the task is enabled or not
+    enabled_t is_enabled{enabled_t::yes};
+    /// Interval for the role sync task
+    std::optional<ss::lowres_clock::duration> task_interval;
+    /// Default interval
+    static constexpr auto task_interval_default = std::chrono::seconds{30};
+
+    ss::lowres_clock::duration get_task_interval() const {
+        return task_interval.value_or(task_interval_default);
+    }
+
+    /// Filters selecting which roles to shadow, by role name. Defaults to
+    /// empty: no roles are synced until at least one include filter is added.
+    chunked_vector<resource_name_filter_pattern> role_name_filters;
+
+    friend bool
+    operator==(const role_sync_config&, const role_sync_config&) = default;
+
+    auto serde_fields() {
+        return std::tie(is_enabled, task_interval, role_name_filters);
+    }
+
+    role_sync_config copy() const;
+};
+
+/**
  * Configuration of a cluster link. Configuration changes are driven by the
  * API and are a result of user actions.
  */
 struct link_configuration
   : serde::envelope<
       link_configuration,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
     /// Configuration for the auto mirror topic creation task
     topic_metadata_mirroring_config topic_metadata_mirroring_cfg;
@@ -974,6 +1006,8 @@ struct link_configuration
     security_settings_sync_config security_settings_sync_cfg;
     /// Configuration for syncing schema registry
     schema_registry_sync_config schema_registry_sync_cfg;
+    /// Configuration for syncing RBAC roles
+    role_sync_config role_sync_cfg;
 
     friend bool
     operator==(const link_configuration&, const link_configuration&) = default;
@@ -983,7 +1017,8 @@ struct link_configuration
           topic_metadata_mirroring_cfg,
           consumer_groups_mirroring_cfg,
           security_settings_sync_cfg,
-          schema_registry_sync_cfg);
+          schema_registry_sync_cfg,
+          role_sync_cfg);
     }
 
     link_configuration copy() const;
@@ -1855,6 +1890,14 @@ struct fmt::formatter<cluster_link::model::security_settings_sync_config>
     auto format(
       const cluster_link::model::security_settings_sync_config& m,
       format_context& ctx) const -> decltype(ctx.out());
+};
+
+template<>
+struct fmt::formatter<cluster_link::model::role_sync_config>
+  : fmt::formatter<string_view> {
+    auto format(
+      const cluster_link::model::role_sync_config& m, format_context& ctx) const
+      -> decltype(ctx.out());
 };
 
 template<>

--- a/src/v/cluster_link/security_migrator.cc
+++ b/src/v/cluster_link/security_migrator.cc
@@ -13,6 +13,7 @@
 
 #include "cluster_link/link.h"
 #include "cluster_link/model/types.h"
+#include "cluster_link/utils.h"
 #include "kafka/protocol/types.h"
 #include "kafka/server/handlers/details/security.h"
 #include "security/acl.h"
@@ -25,13 +26,6 @@ using namespace std::chrono_literals;
 namespace cluster_link {
 
 namespace {
-bool has_required_permissions(
-  kafka::cluster_authorized_operations permissions_to_check,
-  kafka::cluster_authorized_operations required_permissions) {
-    return (permissions_to_check & required_permissions)
-           == required_permissions;
-}
-
 security::acl_operation model_to_security(model::acl_operation op) {
     switch (op) {
     case model::acl_operation::any:
@@ -314,49 +308,17 @@ security_migrator::run_impl(ss::abort_source& as) {
           .reason = std::move(msg)};
     }
 
-    kafka::api_version describe_acls_version;
-    try {
-        auto supported_api_versions = co_await cluster.supported_api_versions(
-          kafka::describe_acls_api::key, as);
-        if (!supported_api_versions.has_value()) {
-            auto msg = ssx::sformat(
-              "Failed to get supported API version for DescribeACLs");
-            vlog(logger().warn, "{}", msg);
-            co_return state_transition{
-              .desired_state = model::task_state::link_unavailable,
-              .reason = std::move(msg)};
-        }
-
-        if (
-          supported_api_versions.value().min
-          > kafka::describe_acls_api::max_valid) {
-            auto msg = ssx::sformat(
-              "Unsupported API version for DescribeACLs: {}",
-              supported_api_versions.value().min);
-            vlog(logger().warn, "{}", msg);
-            co_return state_transition{
-              .desired_state = model::task_state::link_unavailable,
-              .reason = std::move(msg)};
-        }
-
-        describe_acls_version = std::min(
-          supported_api_versions.value().max,
-          kafka::describe_acls_api::max_valid);
-        vlog(
-          logger().debug,
-          "Using describe_acls version: {}",
-          describe_acls_version);
-    } catch (const ss::abort_requested_exception&) {
-        // Rethrow abort requested to allow caller to handle it
-        throw;
-    } catch (const std::exception& e) {
-        auto msg = ssx::sformat(
-          "Failed to get supported API version for DescribeACLs: {}", e.what());
-        vlog(logger().warn, "{}", msg);
+    auto version_res = co_await negotiate_api_version<kafka::describe_acls_api>(
+      cluster, as);
+    if (!version_res.has_value()) {
+        vlog(logger().warn, "{}", version_res.error());
         co_return state_transition{
           .desired_state = model::task_state::link_unavailable,
-          .reason = std::move(msg)};
+          .reason = std::move(version_res).error()};
     }
+    auto describe_acls_version = version_res.value();
+    vlog(
+      logger().debug, "Using describe_acls version: {}", describe_acls_version);
 
     as.check();
     auto acls_f = co_await ss::coroutine::as_future(

--- a/src/v/cluster_link/security_migrator.h
+++ b/src/v/cluster_link/security_migrator.h
@@ -13,6 +13,7 @@
 
 #include "cluster_link/model/types.h"
 #include "cluster_link/task.h"
+#include "cluster_link/utils.h"
 #include "kafka/protocol/describe_acls.h"
 #include "kafka/protocol/types.h"
 
@@ -27,8 +28,7 @@ namespace cluster_link {
 class security_migrator : public controller_locked_task {
 public:
     static constexpr auto task_name = "Security Migrator Task";
-    static constexpr kafka::cluster_authorized_operations required_permissions
-      = kafka::cluster_authorized_operations{0x100}; // DESCRIBE
+    static constexpr auto required_permissions = cluster_describe_permission;
 
     security_migrator(link* link, const model::metadata& config);
     security_migrator(const security_migrator&) = delete;

--- a/src/v/cluster_link/source_topic_syncer.cc
+++ b/src/v/cluster_link/source_topic_syncer.cc
@@ -14,6 +14,7 @@
 #include "cluster_link/link.h"
 #include "cluster_link/model/filter_utils.h"
 #include "cluster_link/model/types.h"
+#include "cluster_link/utils.h"
 #include "model/namespace.h"
 
 namespace cluster_link {
@@ -32,13 +33,6 @@ const absl::flat_hash_map<ss::sstring, ss::sstring>
 
 const chunked_vector<ss::sstring> topic_prefix_denylist{
   ss::sstring("__redpanda"), ss::sstring("_redpanda")};
-
-bool has_required_permissions(
-  kafka::topic_authorized_operations permissions_to_check,
-  kafka::topic_authorized_operations required_permissions) {
-    return (permissions_to_check & required_permissions)
-           == required_permissions;
-}
 
 template<typename K, typename V>
 chunked_hash_map<K, V> copy_hash_map(const chunked_hash_map<K, V>& source) {
@@ -255,50 +249,20 @@ source_topic_syncer::run_impl(ss::abort_source& as) {
 
     // Grab the version of DescribeConfigs that's supported on the source
     // cluster and ensure we support it
-    kafka::api_version describe_configs_version;
-    try {
-        auto supported_api_versions = co_await cluster.supported_api_versions(
-          kafka::describe_configs_api::key, as);
-        if (!supported_api_versions.has_value()) {
-            auto msg = ssx::sformat(
-              "Failed to get supported API version for describe_configs");
-            vlog(logger().warn, "{}", msg);
-            co_return state_transition{
-              .desired_state = model::task_state::link_unavailable,
-              .reason = std::move(msg)};
-        }
-        // Make sure the minimum version supported on the cluster is not higher
-        // than the maximum version supported by the shadow cluster
-        if (
-          supported_api_versions.value().min
-          > kafka::describe_configs_api::max_valid) {
-            auto msg = ssx::sformat(
-              "Unsupported DescribeConfigs API version: {}",
-              supported_api_versions.value());
-            vlog(logger().warn, "{}", msg);
-            co_return state_transition{
-              .desired_state = model::task_state::link_unavailable,
-              .reason = std::move(msg)};
-        }
-        describe_configs_version = std::min(
-          supported_api_versions.value().max,
-          kafka::describe_configs_api::max_valid);
-        vlog(
-          logger().debug,
-          "Using describe_configs version: {}",
-          describe_configs_version);
-    } catch (const ss::abort_requested_exception&) {
-        // Rethrow abort requested to allow caller to handle it
-        throw;
-    } catch (const std::exception& e) {
-        auto msg = ssx::sformat(
-          "Failed to get supported API version for describe_configs: {}",
-          e.what());
-        vlog(logger().warn, "{}", msg);
+    auto version_res
+      = co_await negotiate_api_version<kafka::describe_configs_api>(
+        cluster, as);
+    if (!version_res.has_value()) {
+        vlog(logger().warn, "{}", version_res.error());
         co_return state_transition{
           .desired_state = model::task_state::link_unavailable,
-          .reason = std::move(msg)};
+          .reason = std::move(version_res).error()};
     }
+    auto describe_configs_version = version_res.value();
+    vlog(
+      logger().debug,
+      "Using describe_configs version: {}",
+      describe_configs_version);
 
     // If we are going to shadow the schema registry topic, we need to ensure
     // that it's either empty or it does not exist.  Check for its HWM.  This is

--- a/src/v/cluster_link/utils.h
+++ b/src/v/cluster_link/utils.h
@@ -12,10 +12,77 @@
 #pragma once
 
 #include "cluster_link/model/types.h"
+#include "kafka/client/cluster.h"
 #include "kafka/client/configuration.h"
+#include "kafka/protocol/types.h"
+#include "ssx/sformat.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+
+#include <algorithm>
+#include <concepts>
+#include <expected>
 
 namespace cluster_link {
 kafka::client::connection_configuration
 metadata_to_kafka_config(const model::metadata&);
+
+/// Returns true if `have` includes every bit set in `required`.
+template<typename T>
+bool has_required_permissions(T have, T required) {
+    return (have & required) == required;
+}
+
+/// Cluster-level DESCRIBE permission (0x100), required on the source cluster to
+/// read security objects (ACLs, roles) for replication.
+inline constexpr auto cluster_describe_permission
+  = kafka::cluster_authorized_operations{0x100};
+
+/// A Kafka API whose highest supported wire version can be negotiated: a
+/// KafkaApi (providing `key`) that also exposes the `max_valid` version this
+/// build supports.
+template<typename T>
+concept NegotiableKafkaApi = kafka::KafkaApi<T> && requires {
+    { T::max_valid } -> std::convertible_to<const kafka::api_version&>;
+};
+
+/// Negotiates the wire version to use for the Kafka API `ApiT` against the
+/// source `cluster`: the highest version both the source and this build
+/// support. Error messages use `ApiT::name` (the wire protocol API name). On
+/// success returns the negotiated version; on failure returns an error string
+/// suitable for a task state_transition reason. Rethrows
+/// ss::abort_requested_exception so callers can propagate aborts.
+template<NegotiableKafkaApi ApiT>
+ss::future<std::expected<kafka::api_version, ss::sstring>>
+negotiate_api_version(kafka::client::cluster& cluster, ss::abort_source& as) {
+    try {
+        auto supported_api_versions = co_await cluster.supported_api_versions(
+          ApiT::key, as);
+        if (!supported_api_versions.has_value()) {
+            co_return std::unexpected(
+              ssx::sformat(
+                "Failed to get supported API version for {}", ApiT::name));
+        }
+        if (supported_api_versions->min > ApiT::max_valid) {
+            co_return std::unexpected(
+              ssx::sformat(
+                "Unsupported API version for {}: {}",
+                ApiT::name,
+                supported_api_versions->min));
+        }
+        co_return std::min(supported_api_versions->max, ApiT::max_valid);
+    } catch (const ss::abort_requested_exception&) {
+        // Rethrow abort requested to allow caller to handle it
+        throw;
+    } catch (const std::exception& e) {
+        co_return std::unexpected(
+          ssx::sformat(
+            "Failed to get supported API version for {}: {}",
+            ApiT::name,
+            e.what()));
+    }
+}
 
 } // namespace cluster_link

--- a/src/v/kafka/client/BUILD
+++ b/src/v/kafka/client/BUILD
@@ -47,6 +47,7 @@ redpanda_cc_library(
         "//src/v/kafka/protocol:describe_groups",
         "//src/v/kafka/protocol:describe_log_dirs",
         "//src/v/kafka/protocol:describe_producers",
+        "//src/v/kafka/protocol:describe_redpanda_roles",
         "//src/v/kafka/protocol:describe_transactions",
         "//src/v/kafka/protocol:describe_user_scram_credentials",
         "//src/v/kafka/protocol:end_txn",

--- a/src/v/kafka/client/api_types.h
+++ b/src/v/kafka/client/api_types.h
@@ -30,6 +30,7 @@
 #include "kafka/protocol/describe_groups.h"
 #include "kafka/protocol/describe_log_dirs.h"
 #include "kafka/protocol/describe_producers.h"
+#include "kafka/protocol/describe_redpanda_roles.h"
 #include "kafka/protocol/describe_transactions.h"
 #include "kafka/protocol/describe_user_scram_credentials.h"
 #include "kafka/protocol/end_txn.h"
@@ -70,7 +71,10 @@ auto response_variant(type_list<Ts...>) {
 }
 } // namespace internal
 
-using request_t = decltype(internal::request_variant(request_types{}));
-using response_t = decltype(internal::response_variant(request_types{}));
+// request_t and response_t cover both standard Kafka APIs and the
+// Redpanda-specific reserved-range APIs so that dispatch_to_any works
+// for all KafkaApi types including those with keys >= 15000.
+using request_t = decltype(internal::request_variant(all_request_types{}));
+using response_t = decltype(internal::response_variant(all_request_types{}));
 
 } // namespace kafka::client

--- a/src/v/kafka/protocol/flex_versions.cc
+++ b/src/v/kafka/protocol/flex_versions.cc
@@ -36,8 +36,7 @@ fill_flex(api_key_table<api_version>& versions, type_list<Ts...>) {
 
 consteval auto get_flexible_request_min_versions_list() {
     api_key_table<api_version> versions{invalid_api};
-    fill_flex(versions, request_types{});
-    fill_flex(versions, redpanda_request_types{});
+    fill_flex(versions, all_request_types{});
     return versions;
 }
 

--- a/src/v/kafka/protocol/messages.h
+++ b/src/v/kafka/protocol/messages.h
@@ -118,6 +118,11 @@ using request_types = make_request_types<
 // stay sized to the standard range; both lists feed api_key_indexed_array.
 using redpanda_request_types = make_request_types<describe_redpanda_roles_api>;
 
+// Union of the standard and reserved request types, for consumers that fill a
+// region-routed api_key_indexed_array or build a flat list over every API.
+using all_request_types
+  = type_list_cat_t<request_types, redpanda_request_types>;
+
 namespace detail {
 template<typename... Ts>
 consteval api_key::type max_key(type_list<Ts...>) {

--- a/src/v/kafka/protocol/type_list.h
+++ b/src/v/kafka/protocol/type_list.h
@@ -17,4 +17,16 @@ namespace kafka {
 template<typename... Ts>
 struct type_list {};
 
+/// Concatenate two type_lists into a single type_list.
+template<typename A, typename B>
+struct type_list_cat;
+
+template<typename... Ts, typename... Us>
+struct type_list_cat<type_list<Ts...>, type_list<Us...>> {
+    using type = type_list<Ts..., Us...>;
+};
+
+template<typename A, typename B>
+using type_list_cat_t = typename type_list_cat<A, B>::type;
+
 } // namespace kafka

--- a/src/v/kafka/server/BUILD
+++ b/src/v/kafka/server/BUILD
@@ -104,6 +104,18 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "roles",
+    hdrs = [
+        "handlers/details/roles.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/kafka/protocol/schemata:describe_redpanda_roles_response",
+        "//src/v/security",
+    ],
+)
+
+redpanda_cc_library(
     name = "server",
     srcs = [
         "client_quota_translator.cc",
@@ -272,6 +284,7 @@ redpanda_cc_library(
         ":datalake_usage_api",
         ":logger",
         ":qdc_monitor_config",
+        ":roles",
         ":security",
         ":topic_config_utils",
         "//proto/redpanda/core/admin/v2:kafka_connections_redpanda_proto",

--- a/src/v/kafka/server/handlers/api_versions.cc
+++ b/src/v/kafka/server/handlers/api_versions.cc
@@ -35,8 +35,7 @@ serialize_apis(type_list<RequestTypes...>) {
 
 static chunked_vector<api_versions_response_key>
 get_supported_apis(bool is_idempotence_enabled, bool are_transactions_enabled) {
-    auto all_api = serialize_apis(handler_request_types{});
-    all_api.append_range(serialize_apis(redpanda_handler_request_types{}));
+    auto all_api = serialize_apis(all_handler_request_types{});
 
     chunked_vector<api_versions_response_key> filtered;
     std::copy_if(

--- a/src/v/kafka/server/handlers/describe_redpanda_roles.cc
+++ b/src/v/kafka/server/handlers/describe_redpanda_roles.cc
@@ -12,6 +12,7 @@
 
 #include "container/chunked_hash_map.h"
 #include "kafka/protocol/errors.h"
+#include "kafka/server/handlers/details/roles.h"
 #include "kafka/server/request_context.h"
 #include "kafka/server/response.h"
 #include "security/acl.h"
@@ -23,21 +24,6 @@
 #include <ranges>
 
 namespace kafka {
-
-namespace {
-
-redpanda_role to_wire(const security::role_with_members& rwm) {
-    redpanda_role out;
-    out.name = rwm.name();
-    for (const auto& m : rwm.role.members()) {
-        out.members.push_back(
-          redpanda_role_member{
-            .member_type = static_cast<int8_t>(m.type()), .name = m.name()});
-    }
-    return out;
-}
-
-} // namespace
 
 template<>
 ss::future<response_ptr> describe_redpanda_roles_handler::handle(
@@ -82,7 +68,7 @@ ss::future<response_ptr> describe_redpanda_roles_handler::handle(
     };
 
     resp.data.roles = roles.roles_with_members(matches)
-                      | std::views::transform(to_wire)
+                      | std::views::transform(details::to_wire_redpanda_role)
                       | std::ranges::to<chunked_vector<redpanda_role>>();
 
     co_return co_await ctx.respond(std::move(resp));

--- a/src/v/kafka/server/handlers/details/roles.h
+++ b/src/v/kafka/server/handlers/details/roles.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "kafka/protocol/schemata/describe_redpanda_roles_response.h"
+#include "security/role.h"
+#include "security/types.h"
+
+#include <fmt/format.h>
+
+#include <stdexcept>
+
+namespace kafka::details {
+
+// Wire contract (DescribeRedpandaRoles role member): 0 = user, 1 = group.
+inline security::role_member_type to_role_member_type(int8_t type) {
+    switch (type) {
+    case 0:
+        return security::role_member_type::user;
+    case 1:
+        return security::role_member_type::group;
+    default:
+        throw std::runtime_error(
+          fmt::format("Invalid role member type: {}", static_cast<int>(type)));
+    }
+}
+
+inline int8_t to_wire_role_member_type(security::role_member_type type) {
+    return static_cast<int8_t>(type);
+}
+
+inline security::role_with_members
+to_role_with_members(const redpanda_role& role) {
+    security::role::container_type members;
+    for (const auto& m : role.members) {
+        members.insert(
+          security::role_member{to_role_member_type(m.member_type), m.name});
+    }
+    return security::role_with_members{
+      .name = security::role_name{role.name},
+      .role = security::role{std::move(members)}};
+}
+
+inline redpanda_role
+to_wire_redpanda_role(const security::role_with_members& rwm) {
+    redpanda_role out;
+    out.name = rwm.name();
+    for (const auto& m : rwm.role.members()) {
+        out.members.push_back(
+          redpanda_role_member{
+            .member_type = to_wire_role_member_type(m.type()),
+            .name = m.name()});
+    }
+    return out;
+}
+
+} // namespace kafka::details

--- a/src/v/kafka/server/handlers/handler_interface.cc
+++ b/src/v/kafka/server/handlers/handler_interface.cc
@@ -130,17 +130,15 @@ struct handler_holder {
       H::handle};
 };
 
-template<typename... Std, typename... Rsv>
-constexpr auto make_lut(type_list<Std...>, type_list<Rsv...>) {
+template<typename... H>
+constexpr auto make_lut(type_list<H...>) {
     api_key_table<handler> lut{};
-    ((lut[Std::api::key] = &handler_holder<Std>::instance), ...);
-    ((lut[Rsv::api::key] = &handler_holder<Rsv>::instance), ...);
+    ((lut[H::api::key] = &handler_holder<H>::instance), ...);
     return lut;
 }
 
 static const auto& handlers() {
-    static constexpr auto lut = make_lut(
-      handler_request_types{}, redpanda_handler_request_types{});
+    static constexpr auto lut = make_lut(all_handler_request_types{});
     return lut;
 }
 

--- a/src/v/kafka/server/handlers/handlers.h
+++ b/src/v/kafka/server/handlers/handlers.h
@@ -122,6 +122,11 @@ using handler_request_types = make_handler_request_types<
 using redpanda_handler_request_types
   = make_handler_request_types<describe_redpanda_roles_handler>;
 
+// Union of the standard and reserved handler types, for consumers that fill a
+// region-routed dispatch LUT or build a flat list over every handler.
+using all_handler_request_types
+  = type_list_cat_t<handler_request_types, redpanda_handler_request_types>;
+
 template<typename... RequestTypes>
 static constexpr size_t max_api_key(type_list<RequestTypes...>) {
     /// Black magic here is an overload of std::max() that takes an

--- a/src/v/redpanda/admin/services/shadow_link/converter.cc
+++ b/src/v/redpanda/admin/services/shadow_link/converter.cc
@@ -40,6 +40,7 @@ using proto::admin::create_shadow_link_request;
 using proto::admin::http_basic_auth_options;
 using proto::admin::name_filter;
 using proto::admin::plain_config;
+using proto::admin::role_sync_options;
 using proto::admin::schema_registry_auth_options;
 using proto::admin::schema_registry_context_destination;
 using proto::admin::schema_registry_context_map;
@@ -600,6 +601,23 @@ create_security_settings_sync_config(
     return config;
 }
 
+cluster_link::model::role_sync_config
+create_role_sync_config(const role_sync_options& options) {
+    cluster_link::model::role_sync_config config;
+
+    if (options.get_interval() > absl::ZeroDuration()) {
+        config.task_interval = absl::ToChronoNanoseconds(
+          options.get_interval());
+    }
+
+    config.role_name_filters = to_filter_patterns(
+      options.get_role_name_filters());
+
+    config.is_enabled = cluster_link::model::enabled_t{!options.get_paused()};
+
+    return config;
+}
+
 cluster_link::model::link_configuration
 create_link_configuration(const shadow_link& sl) {
     cluster_link::model::link_configuration config;
@@ -616,6 +634,9 @@ create_link_configuration(const shadow_link& sl) {
 
     config.schema_registry_sync_cfg = create_schema_registry_sync_config(
       sl.get_configurations().get_schema_registry_sync_options());
+
+    config.role_sync_cfg = create_role_sync_config(
+      sl.get_configurations().get_role_sync_options());
 
     return config;
 }
@@ -1187,6 +1208,21 @@ security_settings_sync_options create_security_settings_sync_options(
     return options;
 }
 
+role_sync_options
+create_role_sync_options(const cluster_link::model::role_sync_config& config) {
+    role_sync_options options;
+
+    options.set_interval(
+      absl::FromChrono(
+        config.task_interval.value_or(ss::lowres_clock::duration::zero())));
+    options.set_effective_interval(
+      absl::FromChrono(config.get_task_interval()));
+    options.set_role_name_filters(to_name_filters(config.role_name_filters));
+    options.set_paused(!bool(config.is_enabled));
+
+    return options;
+}
+
 void starting_offset_to_proto(
   std::optional<model::timestamp> ts, topic_metadata_sync_options& options) {
     if (!ts.has_value()) {
@@ -1402,6 +1438,8 @@ create_shadow_link_configuration(const cluster_link::model::metadata& md) {
     configurations.set_schema_registry_sync_options(
       create_schema_registry_sync_options(
         md.configuration.schema_registry_sync_cfg));
+    configurations.set_role_sync_options(
+      create_role_sync_options(md.configuration.role_sync_cfg));
 
     return configurations;
 }

--- a/src/v/redpanda/admin/services/shadow_link/tests/converter_test.cc
+++ b/src/v/redpanda/admin/services/shadow_link/tests/converter_test.cc
@@ -2170,3 +2170,87 @@ TEST(converter_test, timestamp_to_string) {
         EXPECT_EQ(absl::FromUnixMillis(1759193250080), ts);
     }
 }
+
+TEST(converter_test, metadata_to_shadow_link_roles) {
+    auto md = ss::make_lw_shared<cluster_link::model::metadata>();
+    md->configuration.role_sync_cfg.task_interval = 45s;
+    md->configuration.role_sync_cfg.role_name_filters.push_back(
+      cluster_link::model::resource_name_filter_pattern{
+        .pattern_type = cluster_link::model::filter_pattern_type::prefix,
+        .filter = cluster_link::model::filter_type::include,
+        .pattern = "analytics-"});
+
+    auto sl = admin::metadata_to_shadow_link(std::move(md), {});
+
+    const auto& role_sync = sl.get_configurations().get_role_sync_options();
+    EXPECT_EQ(role_sync.get_interval(), absl::Seconds(45));
+    EXPECT_EQ(role_sync.get_paused(), false);
+    ASSERT_EQ(role_sync.get_role_name_filters().size(), 1);
+
+    const auto& filter = role_sync.get_role_name_filters()[0];
+    EXPECT_EQ(filter.get_pattern_type(), proto::admin::pattern_type::prefix);
+    EXPECT_EQ(filter.get_filter_type(), proto::admin::filter_type::include);
+    EXPECT_EQ(filter.get_name(), "analytics-");
+}
+
+TEST(converter_test, shadow_link_to_metadata_roles) {
+    proto::admin::create_shadow_link_request req;
+    auto& shadow_link = req.get_shadow_link();
+    shadow_link.set_name("test-link");
+
+    auto& configs = shadow_link.get_configurations();
+    configs.get_client_options().set_bootstrap_servers({"localhost:9092"});
+
+    auto& role_sync = configs.get_role_sync_options();
+    role_sync.set_interval(absl::Seconds(45));
+    role_sync.set_paused(true);
+
+    auto& filter = role_sync.get_role_name_filters().emplace_back();
+    filter.set_pattern_type(proto::admin::pattern_type::prefix);
+    filter.set_filter_type(proto::admin::filter_type::include);
+    filter.set_name("analytics-");
+
+    auto md = admin::convert_create_to_metadata(std::move(req));
+
+    const auto& role_sync_cfg = md.configuration.role_sync_cfg;
+    EXPECT_EQ(role_sync_cfg.get_task_interval(), 45s);
+    EXPECT_FALSE(role_sync_cfg.is_enabled);
+    ASSERT_EQ(role_sync_cfg.role_name_filters.size(), 1);
+
+    const auto& filter_pattern = role_sync_cfg.role_name_filters[0];
+    EXPECT_EQ(
+      filter_pattern.pattern_type,
+      cluster_link::model::filter_pattern_type::prefix);
+    EXPECT_EQ(filter_pattern.filter, cluster_link::model::filter_type::include);
+    EXPECT_EQ(filter_pattern.pattern, "analytics-");
+}
+
+TEST(converter_test, update_shadow_link_role_sync) {
+    cluster_link::model::metadata current_md;
+    current_md.name = cluster_link::model::name_t{"test-link"};
+    current_md.uuid = cluster_link::model::uuid_t{uuid_t::create()};
+    current_md.connection.bootstrap_servers = {
+      net::unresolved_address("localhost", 9092)};
+    admin::set_client_id(current_md);
+
+    proto::admin::update_shadow_link_request req;
+    req.get_shadow_link()
+      .get_configurations()
+      .get_role_sync_options()
+      .set_interval(absl::Seconds(90));
+    req.get_update_mask().paths.push_back(
+      serde::pb::field_mask::path{
+        "configurations", "role_sync_options", "interval"});
+
+    auto update_cmd = admin::create_update_cluster_link_config_cmd(
+      std::move(req),
+      ss::make_lw_shared<cluster_link::model::metadata>({
+        .name = current_md.name,
+        .uuid = current_md.uuid,
+        .connection = current_md.connection,
+        .configuration = current_md.configuration.copy(),
+      }));
+
+    EXPECT_EQ(update_cmd.connection, current_md.connection);
+    EXPECT_EQ(update_cmd.link_config.role_sync_cfg.get_task_interval(), 90s);
+}


### PR DESCRIPTION
Groundwork for shadow link role sync, split out from a larger branch to keep
review tractable. This PR lands the reusable refactors, the Kafka
client/protocol support for reserved-range APIs, and the role-sync
configuration surface. It introduces no active role syncing and no runtime
behavior change — the roles migrator that consumes all of this follows in a
stacked PR.

Refactors:
- Extract shared API-version and permission helpers in cluster_link into
  `utils.h`, de-duplicating `security_migrator` and `source_topic_syncer`.
- Extract `redpanda_role` wire conversion out of the DescribeRedpandaRoles
  handler into `kafka/server/handlers/details/roles.h` so it can be reused.

Kafka reserved-range API cleanup:
- Add a `type_list_cat_t` helper and combined `all_request_types` /
  `all_handler_request_types` aliases (the union of the existing standard and
  reserved-range lists), and route the call sites that walked both lists
  separately through the single alias. Pure refactor, no behavior change.
- Point the kafka client's `request_t` / `response_t` variants at that
  combined list so the client can dispatch reserved-range APIs (key >= 15000)
  such as DescribeRedpandaRoles.

Role-sync configuration (inert until the migrator lands):
- Add `role_sync_config` to the link configuration model.
- Convert role-sync options in the admin `shadow_link` converter.
- Generalize filter matching so it applies to role names, not just topics.

Covered by unit tests for the link-config parsing and the `shadow_link`
converter.

Part of [CORE-16456](https://redpandadata.atlassian.net/browse/CORE-16456).

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none


[CORE-16456]: https://redpandadata.atlassian.net/browse/CORE-16456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ