### PR TITLE
cloud_topics: short-circuit single_flight::run on aborted source

### DIFF
--- a/src/v/cloud_topics/level_one/common/single_flight.h
+++ b/src/v/cloud_topics/level_one/common/single_flight.h
@@ -75,6 +75,11 @@ public:
     /// - On any work failure (leader's own, inherited by mergers, or
     ///   merger-side abort), returns unexpected(errc).
     ///
+    /// If `as` is already aborted on entry, run returns
+    /// unexpected(cloud_op_timeout) immediately. It neither
+    /// coordinates nor runs work, so a cancelled caller never becomes a
+    /// leader that healthy mergers would then inherit a failure from.
+    ///
     /// run never throws and reports every failure through run_result's
     /// error branch. If work's returned future fails, we propagate
     /// errc::file_io_error to this caller and any waiting mergers, and
@@ -129,6 +134,10 @@ ss::future<single_flight::run_result> single_flight::run(
   ss::abort_source& as,
   WorkFn work,
   ss::logger* logger) noexcept {
+    if (as.abort_requested()) {
+        co_return std::unexpected(io::errc::cloud_op_timeout);
+    }
+
     auto j = join_or_lead(cache_key, as);
 
     if (j.kind == join_kind::merger) {

--- a/src/v/cloud_topics/level_one/common/tests/single_flight_test.cc
+++ b/src/v/cloud_topics/level_one/common/tests/single_flight_test.cc
@@ -61,6 +61,25 @@ TEST_CORO(SingleFlightTest, ColdRunBecomesLeader) {
     ASSERT_EQ_CORO(map.in_flight(), 0u);
 }
 
+// An already-aborted caller short-circuits to cloud_op_timeout without
+// running work or inserting an entry (so it never becomes a leader).
+TEST_CORO(SingleFlightTest, AbortedBeforeRunShortCircuits) {
+    single_flight map;
+    ss::abort_source as;
+    as.request_abort();
+
+    bool work_ran = false;
+    auto r = co_await map.run("/a", as, [&] {
+        work_ran = true;
+        return ready(ok());
+    });
+
+    ASSERT_FALSE_CORO(work_ran);
+    ASSERT_FALSE_CORO(r.has_value());
+    ASSERT_EQ_CORO(r.error(), io::errc::cloud_op_timeout);
+    ASSERT_EQ_CORO(map.in_flight(), 0u);
+}
+
 TEST_CORO(SingleFlightTest, ConcurrentRunsLeaderPublishesSuccess) {
     single_flight map;
     ss::promise<single_flight::outcome> leader_p;


### PR DESCRIPTION
run() now returns cloud_op_timeout immediately when the caller's abort_source is already aborted on entry, before it can become a leader. This stops a cancelled caller from leading a flight that healthy mergers then inherit the failure from, and skips the wasted reservation and GET.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
