### PR TITLE
ct/l0: poison producer queue successors on pre-raft failure

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -687,6 +687,20 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
     } else {
         co_await ticket.redeem();
     }
+    // A lower-sequence request from this producer failed before reaching
+    // rm_stm. Fail retriably so the client retries the whole run in order
+    // rather than this request leapfrogging the dropped lower sequence into
+    // rm_stm as an unknown producer. The ticket destructor cascades the poison
+    // to our successor.
+    if (ticket.poisoned()) {
+        vlog(
+          cd_log.debug,
+          "Producer {} request poisoned by an earlier failed request for ntp "
+          "{}; failing in order",
+          batch_id.pid,
+          ntp);
+        co_return default_errc;
+    }
     // Now that our producer order is resolved, we can fence epochs
     // we must resolve producer order first to prevent races where a
     // request waits on a previous request in the producer queue, but

--- a/src/v/cloud_topics/level_zero/common/producer_queue.cc
+++ b/src/v/cloud_topics/level_zero/common/producer_queue.cc
@@ -30,6 +30,8 @@ public:
     virtual ~impl() = default;
     virtual ss::future<> redeem() = 0;
     virtual void release() = 0;
+    virtual void abandon() = 0;
+    virtual bool poisoned() const = 0;
 };
 
 namespace {
@@ -53,6 +55,11 @@ public:
         _units = {};
         _as.request_abort();
     }
+
+    // Non-idempotent producers carry no per-producer ordering, so there is
+    // nothing to poison.
+    void abandon() override { release(); }
+    bool poisoned() const override { return false; }
 
     ss::semaphore& _s;
     ss::semaphore_units<> _units;
@@ -79,9 +86,28 @@ public:
         }
     }
 
-    ~ticket_impl() override { release(); }
+    // Fail-safe: a ticket dropped without an explicit release() never reached
+    // raft, so poison the successor to preserve per-producer ordering.
+    ~ticket_impl() override { abandon(); }
 
     ss::future<> redeem() override { return _p.get_future(); }
+
+    bool poisoned() const override { return _poisoned; }
+
+    void abandon() override {
+        if (!_map) {
+            // already released or abandoned
+            return;
+        }
+        // Tag the immediate successor before unlinking. The tag survives the
+        // relink in release(): whenever the successor's redeem resolves (now,
+        // if we are the head, or later via our predecessor), it observes the
+        // poison.
+        if (_next != nullptr) {
+            _next->_poisoned = true;
+        }
+        release();
+    }
 
     void release() override {
         // Use the null map to signify a released ticket.
@@ -119,6 +145,7 @@ public:
 private:
     ticket_impl* _prev;
     ticket_impl* _next = nullptr;
+    bool _poisoned = false;
 
     model::producer_id _pid;
     ss::lw_shared_ptr<producer_state_map> _map;
@@ -190,6 +217,8 @@ ss::future<> producer_ticket::redeem(ss::abort_source& as) {
 }
 
 void producer_ticket::release() { _impl->release(); }
+void producer_ticket::abandon() { _impl->abandon(); }
+bool producer_ticket::poisoned() const { return _impl->poisoned(); }
 
 // producer_queue wrapper implementation
 producer_queue::producer_queue()

--- a/src/v/cloud_topics/level_zero/common/producer_queue.h
+++ b/src/v/cloud_topics/level_zero/common/producer_queue.h
@@ -94,6 +94,20 @@ public:
     // immediately.
     void release();
 
+    // Release the ticket but mark the next waiter as poisoned.
+    //
+    // Signals that this request never reached raft (e.g. it failed during L0
+    // upload or epoch fencing). The next waiter, and transitively the rest of
+    // this producer's queued requests, must not be admitted ahead of this
+    // request's (lower) sequence, so they observe `poisoned()` and fail in
+    // order instead. A ticket dropped without an explicit `release()` abandons
+    // by default.
+    void abandon();
+
+    // Whether a predecessor abandoned ahead of this ticket. Meaningful once
+    // `redeem()` has resolved.
+    bool poisoned() const;
+
 private:
     explicit producer_ticket(std::unique_ptr<impl> impl);
     friend class producer_queue;

--- a/src/v/cloud_topics/level_zero/common/tests/producer_queue_test.cc
+++ b/src/v/cloud_topics/level_zero/common/tests/producer_queue_test.cc
@@ -156,6 +156,81 @@ TEST_CORO(producer_queue_test, auto_release_on_destruction) {
     ticket3.release();
 }
 
+TEST_CORO(producer_queue_test, release_does_not_poison_successor) {
+    producer_queue queue;
+    model::producer_id pid{1};
+
+    auto ticket1 = queue.reserve(pid);
+    auto ticket2 = queue.reserve(pid);
+
+    co_await ticket1.redeem();
+    // A normal release means ticket1's request reached raft; ticket2 must not
+    // be poisoned.
+    ticket1.release();
+
+    co_await ticket2.redeem();
+    ASSERT_FALSE_CORO(ticket2.poisoned());
+    ticket2.release();
+}
+
+TEST_CORO(producer_queue_test, abandon_poisons_next_waiter) {
+    producer_queue queue;
+    model::producer_id pid{1};
+
+    auto ticket1 = queue.reserve(pid);
+    auto ticket2 = queue.reserve(pid);
+
+    co_await ticket1.redeem();
+    // ticket1's request failed before reaching raft (e.g. epoch fence
+    // rejected). The next waiter must observe the poison so it fails in order
+    // rather than leapfrogging ticket1's lower sequence into rm_stm.
+    ticket1.abandon();
+
+    co_await ticket2.redeem();
+    ASSERT_TRUE_CORO(ticket2.poisoned());
+    ticket2.release();
+}
+
+TEST_CORO(producer_queue_test, poison_cascades_down_the_queue) {
+    producer_queue queue;
+    model::producer_id pid{1};
+
+    auto ticket1 = queue.reserve(pid);
+    auto ticket2 = queue.reserve(pid);
+    auto ticket3 = queue.reserve(pid);
+
+    co_await ticket1.redeem();
+    ticket1.abandon();
+
+    co_await ticket2.redeem();
+    ASSERT_TRUE_CORO(ticket2.poisoned());
+    // A poisoned request abandons in turn, propagating the poison.
+    ticket2.abandon();
+
+    co_await ticket3.redeem();
+    ASSERT_TRUE_CORO(ticket3.poisoned());
+    ticket3.release();
+}
+
+TEST_CORO(producer_queue_test, dropped_ticket_poisons_successor) {
+    producer_queue queue;
+    model::producer_id pid{1};
+
+    auto ticket1 = queue.reserve(pid);
+    auto ticket2 = queue.reserve(pid);
+
+    co_await ticket1.redeem();
+    {
+        // ticket1 is dropped without an explicit release(): it never reached
+        // raft, so the successor must be poisoned (fail-safe).
+        auto dropped = std::move(ticket1);
+    }
+
+    co_await ticket2.redeem();
+    ASSERT_TRUE_CORO(ticket2.poisoned());
+    ticket2.release();
+}
+
 TEST_CORO(producer_queue_test, continuation_cleanup) {
     producer_queue queue;
     model::producer_id pid{1};


### PR DESCRIPTION
Was seeing some OOOS errors and they were failing my benchrunner workloads.

When an L0 produce fails after passing producer-queue ordering but before reaching rm_stm (epoch fence rejection, upload failure, etc.), the ticket previously just released its slot. A higher-sequence request from the same producer could then reach rm_stm first, where it is treated as an unknown producer at a non-zero sequence and accepted via the eviction-recovery path. The dropped lower-sequence retry is then permanently rejected as out-of-order, silently losing and reordering an idempotent producer's data.

Make a ticket that did not reach raft abandon() instead of release(), poisoning its successor so the producer's run is retried in order. The poison cascades down the queue. release() now signals success only; a ticket dropped without it abandons by default.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Bug Fixes

* Avoids an offset_out_of_sequence error when using Cloud Topics.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
