### PR TITLE
dt/kgo: surface worker crashes as descriptive errors

### DIFF
--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -252,7 +252,7 @@ class KgoVerifierService(Service):
         # it is the one who actually replied to the `await_ready` calls.
         # Check that the PID we just launched is still running as a confirmation
         # that it is the one.
-        self._assert_running(node)
+        self.check_running(node)
         self._stopped = False
 
     def _await_ready(self, node: ClusterNode) -> None:
@@ -278,8 +278,19 @@ class KgoVerifierService(Service):
         else:
             return r.status_code == 200
 
-    def _assert_running(self, node: ClusterNode) -> None:
-        node.account.ssh_output(f"ps -p {self._pid}", allow_fail=False)
+    def _is_pid_running(self, node: ClusterNode) -> bool:
+        assert self._pid is not None, "worker must be started and not yet stopped"
+        return node.account.exists(f"/proc/{self._pid}")
+
+    def check_running(self, node: ClusterNode) -> None:
+        """
+        Raise if the remote process is not running.
+        """
+        if not self._is_pid_running(node):
+            raise RuntimeError(
+                f"{self.who_am_i()} on {node.name} exited unexpectedly "
+                f"(pid {self._pid} gone)"
+            )
 
     def stop_node(self, node: ClusterNode, **kwargs: Any) -> None:
         error = None
@@ -358,7 +369,8 @@ class KgoVerifierService(Service):
             return self._do_wait_node(node, timeout_sec)
         except:
             try:
-                self._remote(node, "print_stack")
+                if self._is_pid_running(node):
+                    self._remote(node, "print_stack")
             except Exception as e:
                 self._redpanda.logger.warning(
                     f"{self.who_am_i()} failed to print stacks during wait failure: {e}"
@@ -501,11 +513,18 @@ class StatusThread(threading.Thread):
     def run(self) -> None:
         try:
             self.poll_status()
-        except Exception as ex:
-            self._ex = ex
+        except Exception as poll_ex:
             self.logger.exception(
-                f"Error reading status from {self.who_am_i} on {self._node.name}"
+                f"Error reading status from {self.who_am_i} on {self._node.name}: {poll_ex}"
             )
+            # Prefer the worker-exit error when the status read failed because
+            # the process is already gone.
+            try:
+                self._parent.check_running(self._node)
+            except Exception as crash_ex:
+                self._ex = crash_ex
+            else:
+                self._ex = poll_ex
 
     def _ingest_status(self, worker_statuses: list[dict[str, Any]]) -> None:
         self.logger.debug(f"{self.who_am_i} status: {worker_statuses}")


### PR DESCRIPTION
When the status endpoint stops responding, the status thread raised a generic connection error. Probe the worker pid and, if it exited, raise an error naming the worker that crashed instead.

Also skip the print_stack request on a wait failure when the worker is no longer running, to avoid another spurious connection error.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
