### PR TITLE
cluster_link: shadow link roles migrator

### DIFF
--- a/src/v/cluster_link/BUILD
+++ b/src/v/cluster_link/BUILD
@@ -268,6 +268,22 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "role_reconcile",
+    srcs = [
+        "role_reconcile.cc",
+    ],
+    hdrs = [
+        "role_reconcile.h",
+    ],
+    visibility = ["//src/v/cluster_link:__subpackages__"],
+    deps = [
+        "//src/v/container:chunked_hash_map",
+        "//src/v/container:chunked_vector",
+        "//src/v/security",
+    ],
+)
+
+redpanda_cc_library(
     name = "rpc_service",
     srcs = [
         "rpc_service.cc",

--- a/src/v/cluster_link/BUILD
+++ b/src/v/cluster_link/BUILD
@@ -83,6 +83,7 @@ redpanda_cc_library(
         "//src/v/cluster:plugin_backend",
         "//src/v/cluster:types",
         "//src/v/cluster_link/utils:topic_properties_utils",
+        "//src/v/features",
     ],
     visibility = ["//src/v/cluster_link:__subpackages__"],
     deps = [
@@ -109,6 +110,7 @@ redpanda_cc_library(
         "//src/v/kafka/data/rpc",
         "//src/v/metrics",
         "//src/v/model",
+        "//src/v/security",
         "//src/v/ssx:future_util",
         "//src/v/ssx:mutex",
         "//src/v/ssx:work_queue",

--- a/src/v/cluster_link/BUILD
+++ b/src/v/cluster_link/BUILD
@@ -210,6 +210,35 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "roles_migrator",
+    srcs = [
+        "roles_migrator.cc",
+    ],
+    hdrs = [
+        "roles_migrator.h",
+    ],
+    implementation_deps = [
+        ":impl",
+        ":role_reconcile",
+        "//src/v/kafka/server:security",
+        "//src/v/security",
+    ],
+    visibility = ["//src/v/cluster_link:__subpackages__"],
+    deps = [
+        ":logger",
+        ":role_reconcile",
+        ":utils",
+        "//src/v/cluster:fwd",
+        "//src/v/cluster_link/model",
+        "//src/v/kafka/client:cluster",
+        "//src/v/kafka/protocol",
+        "//src/v/kafka/protocol:describe_redpanda_roles",
+        "//src/v/kafka/server:roles",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "cluster_link",
     srcs = [
         "service.cc",
@@ -221,6 +250,7 @@ redpanda_cc_library(
         ":group_mirroring_task",
         ":impl",
         ":logger",
+        ":roles_migrator",
         ":security_migrator",
         ":source_topic_syncer",
         "//src/v/cluster:fwd",

--- a/src/v/cluster_link/deps.cc
+++ b/src/v/cluster_link/deps.cc
@@ -14,24 +14,71 @@
 #include "cluster/members_table.h"
 #include "cluster/security_frontend.h"
 #include "cluster_link/utils.h"
+#include "features/feature_table.h"
 #include "kafka/data/rpc/client.h"
 #include "kafka/data/rpc/serde.h"
+#include "security/role_store.h"
 
 namespace cluster_link {
 
 namespace {
 class security_impl : public security_service {
 public:
-    explicit security_impl(ss::sharded<cluster::security_frontend>* security_fe)
-      : _security_fe(security_fe) {}
+    security_impl(
+      ss::sharded<cluster::security_frontend>* security_fe,
+      ss::sharded<security::role_store>* role_store,
+      ss::sharded<features::feature_table>* features)
+      : _security_fe(security_fe)
+      , _role_store(role_store)
+      , _features(features) {}
+
     ss::future<chunked_vector<cluster::errc>> create_acls(
       chunked_vector<security::acl_binding> bindings,
       ::model::timeout_clock::duration timeout) final {
         return _security_fe->local().create_acls(std::move(bindings), timeout);
     }
 
+    ss::future<std::error_code> create_role(
+      security::role_name name,
+      security::role role,
+      ::model::timeout_clock::duration timeout) final {
+        return _security_fe->local().create_role(
+          std::move(name),
+          std::move(role),
+          ::model::timeout_clock::now() + timeout);
+    }
+
+    ss::future<std::error_code> update_role(
+      security::role_name name,
+      security::role role,
+      ::model::timeout_clock::duration timeout) final {
+        return _security_fe->local().update_role(
+          std::move(name),
+          std::move(role),
+          ::model::timeout_clock::now() + timeout);
+    }
+
+    ss::future<std::error_code> delete_role(
+      security::role_name name,
+      ::model::timeout_clock::duration timeout) final {
+        return _security_fe->local().delete_role(
+          std::move(name), ::model::timeout_clock::now() + timeout);
+    }
+
+    bool rbac_active() const final {
+        return _features->local().is_active(
+          features::feature::role_based_access_control);
+    }
+
+    chunked_vector<security::role_with_members> read_shadow_roles(
+      const std::function<bool(const security::role_name&)>& pred) const final {
+        return _role_store->local().roles_with_members(pred);
+    }
+
 private:
     ss::sharded<cluster::security_frontend>* _security_fe;
+    ss::sharded<security::role_store>* _role_store;
+    ss::sharded<features::feature_table>* _features;
 };
 
 class kafka_rpc_client_impl : public kafka_rpc_client_service {
@@ -66,8 +113,10 @@ private:
 } // namespace
 
 std::unique_ptr<security_service> security_service::make_default(
-  ss::sharded<cluster::security_frontend>* security_fe) {
-    return std::make_unique<security_impl>(security_fe);
+  ss::sharded<cluster::security_frontend>* security_fe,
+  ss::sharded<security::role_store>* role_store,
+  ss::sharded<features::feature_table>* features) {
+    return std::make_unique<security_impl>(security_fe, role_store, features);
 }
 
 std::unique_ptr<kafka::client::cluster>

--- a/src/v/cluster_link/deps.h
+++ b/src/v/cluster_link/deps.h
@@ -20,8 +20,16 @@
 #include "kafka/data/rpc/fwd.h"
 #include "kafka/data/rpc/serde.h"
 #include "model/fundamental.h"
+#include "security/fwd.h"
+#include "security/role.h"
+#include "security/types.h"
 
 #include <expected>
+#include <functional>
+
+namespace features {
+class feature_table;
+} // namespace features
 
 namespace cluster_link {
 
@@ -189,12 +197,38 @@ public:
     security_service& operator=(security_service&&) = delete;
     virtual ~security_service() = default;
 
-    static std::unique_ptr<security_service>
-    make_default(ss::sharded<cluster::security_frontend>*);
+    static std::unique_ptr<security_service> make_default(
+      ss::sharded<cluster::security_frontend>*,
+      ss::sharded<security::role_store>*,
+      ss::sharded<features::feature_table>*);
 
     virtual ss::future<chunked_vector<cluster::errc>> create_acls(
       chunked_vector<security::acl_binding>,
       ::model::timeout_clock::duration) = 0;
+
+    /// Create a role on the shadow cluster. errc::role_exists if it already
+    /// exists; errc::feature_disabled if RBAC is not active.
+    virtual ss::future<std::error_code> create_role(
+      security::role_name,
+      security::role,
+      ::model::timeout_clock::duration) = 0;
+    /// Overwrite a role's membership on the shadow cluster.
+    /// errc::role_does_not_exist if it is gone; errc::feature_disabled if RBAC
+    /// is not active.
+    virtual ss::future<std::error_code> update_role(
+      security::role_name,
+      security::role,
+      ::model::timeout_clock::duration) = 0;
+    /// Delete a role on the shadow cluster. errc::role_does_not_exist if
+    /// already gone; errc::feature_disabled if RBAC is not active.
+    virtual ss::future<std::error_code>
+      delete_role(security::role_name, ::model::timeout_clock::duration) = 0;
+    /// Whether the role_based_access_control feature is active locally.
+    virtual bool rbac_active() const = 0;
+    /// Enumerate shadow-cluster roles (with members) matching the predicate,
+    /// from the local controller role_store.
+    virtual chunked_vector<security::role_with_members> read_shadow_roles(
+      const std::function<bool(const security::role_name&)>&) const = 0;
 };
 
 class kafka_rpc_client_service {

--- a/src/v/cluster_link/role_reconcile.cc
+++ b/src/v/cluster_link/role_reconcile.cc
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster_link/role_reconcile.h"
+
+#include "container/chunked_hash_map.h"
+
+namespace cluster_link {
+
+role_changes reconcile_roles(
+  chunked_vector<security::role_with_members> source_selected,
+  chunked_vector<security::role_with_members> shadow_selected) {
+    auto to_map = [](chunked_vector<security::role_with_members> roles) {
+        chunked_hash_map<security::role_name, security::role> m;
+        m.reserve(roles.size());
+        for (auto& r : roles) {
+            m.emplace(std::move(r.name), std::move(r.role));
+        }
+        return m;
+    };
+    auto source = to_map(std::move(source_selected));
+    auto shadow = to_map(std::move(shadow_selected));
+
+    role_changes changes;
+    for (auto& [src_name, src_role] : source) {
+        auto it = shadow.find(src_name);
+        if (it == shadow.end()) {
+            changes.to_create.push_back(
+              {.name = src_name, .role = std::move(src_role)});
+        } else if (src_role.members() != it->second.members()) {
+            changes.to_update.push_back(
+              {.name = src_name, .role = std::move(src_role)});
+        }
+    }
+
+    for (const auto& [shadow_name, _] : shadow) {
+        if (!source.contains(shadow_name)) {
+            changes.to_delete.push_back(shadow_name);
+        }
+    }
+
+    return changes;
+}
+
+} // namespace cluster_link

--- a/src/v/cluster_link/role_reconcile.h
+++ b/src/v/cluster_link/role_reconcile.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "container/chunked_vector.h"
+#include "security/role.h"
+#include "security/types.h"
+
+namespace cluster_link {
+
+/// The set of role mutations needed to make the shadow cluster's in-scope
+/// roles match the source's in-scope roles. Inputs to reconcile_roles are
+/// already filtered to the configured selection, so this struct carries no
+/// policy.
+struct role_changes {
+    chunked_vector<security::role_with_members> to_create;
+    chunked_vector<security::role_with_members> to_update;
+    chunked_vector<security::role_name> to_delete;
+};
+
+/// Compute the full-mirror diff between two already-filtered role sets:
+///   to_create   = source \ shadow (by name)
+///   to_update   = names in both whose membership differs
+///   to_delete   = shadow \ source (by name)
+role_changes reconcile_roles(
+  chunked_vector<security::role_with_members> source_selected,
+  chunked_vector<security::role_with_members> shadow_selected);
+
+} // namespace cluster_link

--- a/src/v/cluster_link/roles_migrator.cc
+++ b/src/v/cluster_link/roles_migrator.cc
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/dev/licenses/rcl.md
+ *
+ */
+
+#include "cluster_link/roles_migrator.h"
+
+#include "cluster_link/link.h"
+#include "cluster_link/model/filter_utils.h"
+#include "cluster_link/role_reconcile.h"
+#include "cluster_link/utils.h"
+#include "kafka/protocol/types.h"
+#include "kafka/server/handlers/details/roles.h"
+
+#include <seastar/coroutine/as_future.hh>
+
+using namespace std::chrono_literals;
+
+namespace cluster_link {
+
+namespace {
+constexpr auto role_apply_timeout = 5s;
+constexpr auto role_apply_concurrency = 5;
+} // namespace
+
+roles_migrator::roles_migrator(link* link, const model::metadata& config)
+  : controller_locked_task(
+      link,
+      config.configuration.role_sync_cfg.get_task_interval(),
+      roles_migrator::task_name)
+  , _config(config.configuration.role_sync_cfg.copy()) {}
+
+void roles_migrator::update_config(const model::metadata& config) {
+    _config = config.configuration.role_sync_cfg.copy();
+    set_run_interval(config.configuration.role_sync_cfg.get_task_interval());
+}
+
+model::enabled_t roles_migrator::is_enabled() const {
+    return _config.is_enabled;
+}
+
+ss::future<task::state_transition>
+roles_migrator::run_impl(ss::abort_source& as) {
+    vlog(logger().trace, "Running roles migrator task");
+
+    if (_config.role_name_filters.empty()) {
+        vlog(logger().debug, "No role filters configured, skipping task");
+        co_return state_transition{
+          .desired_state = model::task_state::active,
+          .reason = "No role filters configured, skipping task"};
+    }
+
+    if (!get_link()->get_security_service().rbac_active()) {
+        co_return state_transition{
+          .desired_state = model::task_state::link_unavailable,
+          .reason = "RBAC disabled on the shadow cluster (cannot sync roles)"};
+    }
+
+    auto& cluster = get_link()->get_cluster_connection();
+
+    try {
+        co_await cluster.request_metadata_update(std::nullopt);
+    } catch (const std::exception& e) {
+        auto msg = ssx::sformat("Failed to update metadata: {}", e.what());
+        vlog(logger().warn, "{}", msg);
+        co_return state_transition{
+          .desired_state = model::task_state::link_unavailable,
+          .reason = std::move(msg)};
+    }
+
+    as.check();
+
+    if (!has_required_permissions(
+          cluster.get_cluster_authorized_operations(),
+          roles_migrator::required_permissions)) {
+        auto msg = ssx::sformat(
+          "Shadow link client has insufficient permissions on the source "
+          "cluster to replicate roles. Requires {:08x}, has {:08x}",
+          roles_migrator::required_permissions,
+          cluster.get_cluster_authorized_operations());
+        vlog(logger().warn, "{}", msg);
+        co_return state_transition{
+          .desired_state = model::task_state::link_unavailable,
+          .reason = std::move(msg)};
+    }
+
+    auto version_res
+      = co_await negotiate_api_version<kafka::describe_redpanda_roles_api>(
+        cluster, as);
+    if (!version_res.has_value()) {
+        vlog(logger().warn, "{}", version_res.error());
+        co_return state_transition{
+          .desired_state = model::task_state::link_unavailable,
+          .reason = std::move(version_res).error()};
+    }
+    auto version = version_res.value();
+
+    as.check();
+
+    // Fetch ALL roles in a single request (null filter). Single request => no
+    // partial fetch => deletes are only ever computed from a complete success.
+    kafka::describe_redpanda_roles_request req;
+    auto resp_f = co_await ss::coroutine::as_future(
+      cluster.dispatch_to_any(std::move(req), version));
+    if (resp_f.failed()) {
+        auto ex = resp_f.get_exception();
+        auto level = ssx::is_shutdown_exception(ex) ? ss::log_level::trace
+                                                    : ss::log_level::warn;
+        auto msg = ssx::sformat("Failed to fetch roles: {}", ex);
+        vlogl(logger(), level, "{}", msg);
+        co_return state_transition{
+          .desired_state = model::task_state::link_unavailable,
+          .reason = std::move(msg)};
+    }
+    auto resp = std::move(resp_f).get();
+    if (resp.data.error_code != kafka::error_code::none) {
+        auto msg = ssx::sformat(
+          "DescribeRedpandaRoles returned error: {}{}",
+          resp.data.error_code,
+          resp.data.error_message.has_value()
+            ? " (" + resp.data.error_message.value() + ")"
+            : "");
+        vlog(logger().warn, "{}", msg);
+        co_return state_transition{
+          .desired_state = model::task_state::link_unavailable,
+          .reason = std::move(msg)};
+    }
+
+    const auto predicate = [this](const security::role_name& name) {
+        return model::select_role(name(), _config.role_name_filters);
+    };
+
+    chunked_vector<security::role_with_members> source_selected;
+    try {
+        for (const auto& role : resp.data.roles) {
+            auto rwm = kafka::details::to_role_with_members(role);
+            if (predicate(rwm.name)) {
+                source_selected.push_back(std::move(rwm));
+            }
+        }
+    } catch (const std::exception& e) {
+        auto msg = ssx::sformat(
+          "Error parsing roles from source cluster: {}", e.what());
+        vlog(logger().warn, "{}", msg);
+        co_return state_transition{
+          .desired_state = model::task_state::faulted,
+          .reason = std::move(msg)};
+    }
+
+    auto shadow_selected = get_link()->get_security_service().read_shadow_roles(
+      predicate);
+
+    auto changes = reconcile_roles(
+      std::move(source_selected), std::move(shadow_selected));
+
+    as.check();
+
+    size_t failures = 0;
+    size_t created = 0;
+    size_t updated = 0;
+    size_t deleted = 0;
+    bool rbac_disabled = false;
+    auto& security = get_link()->get_security_service();
+
+    co_await ss::max_concurrent_for_each(
+      changes.to_create,
+      role_apply_concurrency,
+      [&](this auto, security::role_with_members& r) -> ss::future<> {
+          if (rbac_disabled) {
+              co_return;
+          }
+          auto ec = co_await security.create_role(
+            r.name, std::move(r.role), role_apply_timeout);
+          if (ec == cluster::errc::feature_disabled) {
+              rbac_disabled = true;
+          } else if (ec == cluster::errc::role_exists) {
+              // role_exists is a benign race: the role appeared since the
+              // reconcile snapshot, and the next cycle reconciles it.
+              vlog(
+                logger().trace,
+                "Skipping create of already-existing role {}",
+                r.name);
+          } else if (ec) {
+              vlog(logger().warn, "Failed to create role {}: {}", r.name, ec);
+              ++failures;
+          } else {
+              ++created;
+          }
+      });
+    as.check();
+
+    co_await ss::max_concurrent_for_each(
+      changes.to_update,
+      role_apply_concurrency,
+      [&](this auto, security::role_with_members& r) -> ss::future<> {
+          if (rbac_disabled) {
+              co_return;
+          }
+          auto ec = co_await security.update_role(
+            r.name, std::move(r.role), role_apply_timeout);
+          if (ec == cluster::errc::feature_disabled) {
+              rbac_disabled = true;
+          } else if (ec == cluster::errc::role_does_not_exist) {
+              // role_does_not_exist is a benign race: the role was deleted
+              // since the reconcile snapshot, and the next cycle reconciles it.
+              vlog(
+                logger().trace, "Skipping update of vanished role {}", r.name);
+          } else if (ec) {
+              vlog(logger().warn, "Failed to update role {}: {}", r.name, ec);
+              ++failures;
+          } else {
+              ++updated;
+          }
+      });
+    as.check();
+
+    co_await ss::max_concurrent_for_each(
+      changes.to_delete,
+      role_apply_concurrency,
+      [&](this auto, security::role_name& name) -> ss::future<> {
+          if (rbac_disabled) {
+              co_return;
+          }
+          auto ec = co_await security.delete_role(name, role_apply_timeout);
+          if (ec == cluster::errc::feature_disabled) {
+              rbac_disabled = true;
+          } else if (ec && ec != cluster::errc::role_does_not_exist) {
+              // role_does_not_exist is a benign race: the role was already
+              // gone since the reconcile snapshot, which is the desired state.
+              ++failures;
+              vlog(logger().warn, "Failed to delete role {}: {}", name, ec);
+          } else {
+              ++deleted;
+          }
+      });
+
+    auto summary = ssx::sformat(
+      "{} created, {} updated, {} deleted, {} failures",
+      created,
+      updated,
+      deleted,
+      failures);
+
+    if (rbac_disabled) {
+        co_return state_transition{
+          .desired_state = model::task_state::link_unavailable,
+          .reason = ssx::sformat(
+            "RBAC disabled on the shadow cluster ({} before RBAC was "
+            "disabled)",
+            summary)};
+    }
+
+    co_return state_transition{
+      .desired_state = failures > 0 ? model::task_state::faulted
+                                    : model::task_state::active,
+      .reason = ssx::sformat("Synced roles: {}", summary)};
+}
+
+std::string_view roles_migrator_factory::created_task_name() const noexcept {
+    return roles_migrator::task_name;
+}
+
+std::unique_ptr<task> roles_migrator_factory::create_task(link* link) {
+    return std::make_unique<roles_migrator>(link, *(link->get_config()));
+}
+
+} // namespace cluster_link

--- a/src/v/cluster_link/roles_migrator.h
+++ b/src/v/cluster_link/roles_migrator.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/dev/licenses/rcl.md
+ *
+ */
+
+#pragma once
+
+#include "cluster_link/model/types.h"
+#include "cluster_link/task.h"
+#include "cluster_link/utils.h"
+#include "kafka/protocol/describe_redpanda_roles.h"
+#include "kafka/protocol/types.h"
+
+namespace cluster_link {
+
+/// Periodically full-mirrors RBAC roles from the source cluster onto the
+/// shadow cluster, within the configured role-name filter scope.
+class roles_migrator : public controller_locked_task {
+public:
+    static constexpr auto task_name = "Roles Migrator Task";
+    static constexpr auto required_permissions = cluster_describe_permission;
+
+    roles_migrator(link* link, const model::metadata& config);
+    roles_migrator(const roles_migrator&) = delete;
+    roles_migrator(roles_migrator&&) = delete;
+    roles_migrator& operator=(const roles_migrator&) = delete;
+    roles_migrator& operator=(roles_migrator&&) = delete;
+    ~roles_migrator() override = default;
+
+    void update_config(const model::metadata& config) override;
+
+    model::enabled_t is_enabled() const final;
+
+protected:
+    ss::future<state_transition> run_impl(ss::abort_source&) override;
+
+private:
+    model::role_sync_config _config;
+};
+
+class roles_migrator_factory : public task_factory {
+public:
+    std::string_view created_task_name() const noexcept final;
+    std::unique_ptr<task> create_task(link* link) final;
+};
+
+} // namespace cluster_link

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -1279,7 +1279,10 @@ ss::future<> service::maybe_start_manager() {
         _shard_table, _partition_manager, _smp_group),
       topic_metadata_cache::make_default(_metadata_cache),
       topic_creator::make_default(_controller),
-      security_service::make_default(_security_fe),
+      security_service::make_default(
+        _security_fe,
+        &_controller->get_role_store(),
+        &_controller->get_feature_table()),
       std::make_unique<link_registry_adapter>(&_plf->local(), this),
       std::make_unique<default_link_factory>(
         _partition_manager,

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -29,6 +29,7 @@
 #include "cluster_link/replication/deps.h"
 #include "cluster_link/replication/mux_remote_consumer.h"
 #include "cluster_link/replication/types.h"
+#include "cluster_link/roles_migrator.h"
 #include "cluster_link/schema_registry_sync/mirroring_task.h"
 #include "cluster_link/schema_registry_sync/unavailable_source_reader.h"
 #include "cluster_link/security_migrator.h"
@@ -1301,6 +1302,7 @@ ss::future<> service::maybe_start_manager() {
     co_await _manager->register_task_factory<source_topic_syncer_factory>();
     co_await _manager->register_task_factory<group_mirroring_task_factory>();
     co_await _manager->register_task_factory<security_migrator_factory>();
+    co_await _manager->register_task_factory<roles_migrator_factory>();
 
     // The destination Schema Registry and source reader factory are owned by
     // the service so they outlive the tasks. The source reader is unavailable

--- a/src/v/cluster_link/tests/BUILD
+++ b/src/v/cluster_link/tests/BUILD
@@ -178,6 +178,20 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "role_reconcile_test",
+    timeout = "short",
+    srcs = [
+        "role_reconcile_test.cc",
+    ],
+    deps = [
+        "//src/v/cluster_link:role_reconcile",
+        "//src/v/security",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "partition_replicator_fixture_test",
     timeout = "short",
     srcs = [

--- a/src/v/cluster_link/tests/BUILD
+++ b/src/v/cluster_link/tests/BUILD
@@ -178,6 +178,24 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "roles_migrator_test",
+    timeout = "short",
+    srcs = [
+        "roles_migrator_test.cc",
+    ],
+    deps = [
+        ":test_deps",
+        "//src/v/cluster_link:roles_migrator",
+        "//src/v/kafka/protocol:describe_redpanda_roles",
+        "//src/v/kafka/server:roles",
+        "//src/v/security",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "role_reconcile_test",
     timeout = "short",
     srcs = [

--- a/src/v/cluster_link/tests/deps.h
+++ b/src/v/cluster_link/tests/deps.h
@@ -23,6 +23,8 @@
 #include "kafka/data/rpc/deps.h"
 #include "kafka/data/rpc/test/deps.h"
 #include "security/acl_entry_set.h"
+#include "security/role.h"
+#include "security/role_store.h"
 
 #include <seastar/util/defer.hh>
 
@@ -593,17 +595,79 @@ public:
             entries.rehash();
             results.emplace_back(cluster::errc::success);
         }
-
         co_return results;
     }
 
+    ss::future<std::error_code> create_role(
+      security::role_name name,
+      security::role role,
+      ::model::timeout_clock::duration) final {
+        if (!_rbac_active) {
+            co_return cluster::errc::feature_disabled;
+        }
+        if (_roles.contains(name)) {
+            co_return cluster::errc::role_exists;
+        }
+        _roles.emplace(std::move(name), std::move(role));
+        co_return cluster::errc::success;
+    }
+
+    ss::future<std::error_code> update_role(
+      security::role_name name,
+      security::role role,
+      ::model::timeout_clock::duration) final {
+        if (!_rbac_active) {
+            co_return cluster::errc::feature_disabled;
+        }
+        auto it = _roles.find(name);
+        if (it == _roles.end()) {
+            co_return cluster::errc::role_does_not_exist;
+        }
+        it->second = std::move(role);
+        co_return cluster::errc::success;
+    }
+
+    ss::future<std::error_code> delete_role(
+      security::role_name name, ::model::timeout_clock::duration) final {
+        if (!_rbac_active) {
+            co_return cluster::errc::feature_disabled;
+        }
+        if (_roles.erase(name) == 0) {
+            co_return cluster::errc::role_does_not_exist;
+        }
+        co_return cluster::errc::success;
+    }
+
+    bool rbac_active() const final { return _rbac_active; }
+
+    chunked_vector<security::role_with_members> read_shadow_roles(
+      const std::function<bool(const security::role_name&)>& pred) const final {
+        chunked_vector<security::role_with_members> out;
+        for (const auto& [name, role] : _roles) {
+            if (pred(name)) {
+                out.push_back(
+                  security::role_with_members{
+                    .name = name, .role = security::role{role.members()}});
+            }
+        }
+        return out;
+    }
+
+    // Test seams.
+    void set_rbac_active(bool active) { _rbac_active = active; }
+    void seed_role(security::role_name name, security::role role) {
+        _roles.insert_or_assign(std::move(name), std::move(role));
+    }
+    const auto& roles() const { return _roles; }
     const auto& acls() { return _acls; }
 
 private:
-    using container_type
+    using acl_container_type
       = chunked_hash_map<security::resource_pattern, security::acl_entry_set>;
 
-    container_type _acls;
+    acl_container_type _acls;
+    chunked_hash_map<security::role_name, security::role> _roles;
+    bool _rbac_active{true};
 };
 
 class fake_members_table_provider : public members_table_provider {

--- a/src/v/cluster_link/tests/role_reconcile_test.cc
+++ b/src/v/cluster_link/tests/role_reconcile_test.cc
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster_link/role_reconcile.h"
+#include "security/role.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace cluster_link {
+namespace {
+
+security::role_member user(std::string_view n) {
+    return security::role_member{
+      security::role_member_type::user, ss::sstring{n}};
+}
+
+security::role_with_members rwm(
+  std::string_view name, std::initializer_list<security::role_member> members) {
+    return security::role_with_members{
+      .name = security::role_name{ss::sstring{name}},
+      .role = security::role{security::role::container_type{members}}};
+}
+
+} // namespace
+
+TEST(role_reconcile, create_only) {
+    chunked_vector<security::role_with_members> src{rwm("a", {user("u1")})};
+    chunked_vector<security::role_with_members> dst{};
+    auto changes = reconcile_roles(std::move(src), std::move(dst));
+    EXPECT_THAT(
+      changes.to_create,
+      testing::ElementsAre(
+        testing::Field(
+          &security::role_with_members::name, security::role_name{"a"})));
+    EXPECT_THAT(changes.to_update, testing::IsEmpty());
+    EXPECT_THAT(changes.to_delete, testing::IsEmpty());
+}
+
+TEST(role_reconcile, membership_update) {
+    chunked_vector<security::role_with_members> src{
+      rwm("a", {user("u1"), user("u2")})};
+    chunked_vector<security::role_with_members> dst{rwm("a", {user("u1")})};
+    auto changes = reconcile_roles(std::move(src), std::move(dst));
+    EXPECT_THAT(changes.to_create, testing::IsEmpty());
+    ASSERT_THAT(
+      changes.to_update,
+      testing::ElementsAre(
+        testing::Field(
+          &security::role_with_members::name, security::role_name{"a"})));
+    EXPECT_THAT(
+      changes.to_update[0].role.members(),
+      testing::UnorderedElementsAre(user("u1"), user("u2")));
+    EXPECT_THAT(changes.to_delete, testing::IsEmpty());
+}
+
+TEST(role_reconcile, deletion_propagation) {
+    chunked_vector<security::role_with_members> src{};
+    chunked_vector<security::role_with_members> dst{rwm("a", {user("u1")})};
+    auto changes = reconcile_roles(std::move(src), std::move(dst));
+    EXPECT_THAT(changes.to_create, testing::IsEmpty());
+    EXPECT_THAT(changes.to_update, testing::IsEmpty());
+    EXPECT_THAT(
+      changes.to_delete, testing::ElementsAre(security::role_name{"a"}));
+}
+
+TEST(role_reconcile, no_op_when_equal) {
+    chunked_vector<security::role_with_members> src{rwm("a", {user("u1")})};
+    chunked_vector<security::role_with_members> dst{rwm("a", {user("u1")})};
+    auto changes = reconcile_roles(std::move(src), std::move(dst));
+    EXPECT_THAT(changes.to_create, testing::IsEmpty());
+    EXPECT_THAT(changes.to_update, testing::IsEmpty());
+    EXPECT_THAT(changes.to_delete, testing::IsEmpty());
+}
+
+TEST(role_reconcile, mixed_outcomes) {
+    chunked_vector<security::role_with_members> src{
+      rwm("a", {user("u1"), user("u2")}), rwm("c", {user("u3")})};
+    chunked_vector<security::role_with_members> dst{
+      rwm("a", {user("u1")}), rwm("b", {user("u4")})};
+    auto changes = reconcile_roles(std::move(src), std::move(dst));
+
+    EXPECT_THAT(
+      changes.to_create,
+      testing::ElementsAre(
+        testing::Field(
+          &security::role_with_members::name, security::role_name{"c"})));
+
+    ASSERT_THAT(
+      changes.to_update,
+      testing::ElementsAre(
+        testing::Field(
+          &security::role_with_members::name, security::role_name{"a"})));
+    EXPECT_THAT(
+      changes.to_update[0].role.members(),
+      testing::UnorderedElementsAre(user("u1"), user("u2")));
+
+    EXPECT_THAT(
+      changes.to_delete, testing::ElementsAre(security::role_name{"b"}));
+}
+
+} // namespace cluster_link

--- a/src/v/cluster_link/tests/roles_migrator_test.cc
+++ b/src/v/cluster_link/tests/roles_migrator_test.cc
@@ -1,0 +1,357 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster_link/roles_migrator.h"
+#include "cluster_link/tests/deps.h"
+#include "kafka/protocol/describe_redpanda_roles.h"
+#include "kafka/server/handlers/details/roles.h"
+#include "test_utils/async.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/sleep.hh>
+
+using namespace std::chrono_literals;
+
+namespace cluster_link::tests {
+namespace {
+static const auto link_name = model::name_t("test_link");
+
+model::metadata get_default_metadata() {
+    model::role_sync_config role_cfg;
+    role_cfg.task_interval = 1s;
+    role_cfg.role_name_filters.emplace_back(
+      model::resource_name_filter_pattern{
+        .pattern_type = model::filter_pattern_type::prefix,
+        .filter = model::filter_type::include,
+        .pattern = "synced-"});
+
+    model::metadata md{
+      .name = link_name,
+      .uuid = model::uuid_t(::uuid_t::create()),
+      .connection = model::
+        connection_config{.bootstrap_servers = {net::unresolved_address("localhost", 9092)}},
+      .state = model::link_state{}};
+    md.configuration.role_sync_cfg = std::move(role_cfg);
+    return md;
+}
+
+security::role_member user(std::string_view n) {
+    return security::role_member{
+      security::role_member_type::user, ss::sstring{n}};
+}
+
+// Builds a role with user-type members, mirroring how the migrator maps a
+// wire role to security::role_with_members.
+security::role_with_members rwm(
+  std::string_view name, std::initializer_list<security::role_member> members) {
+    return security::role_with_members{
+      .name = security::role_name{ss::sstring{name}},
+      .role = security::role{security::role::container_type{members}}};
+}
+
+} // namespace
+
+class roles_migrator_test : public seastar_test {
+public:
+    static constexpr auto task_reconciler_interval = 1s;
+
+    ss::future<> SetUpAsync() override {
+        _clmtf = std::make_unique<cluster_link_manager_test_fixture>(self());
+        co_await _clmtf->wire_up_and_start(
+          std::make_unique<test_link_factory>(task_reconciler_interval));
+
+        _clmtf->get_cluster_mock().set_cluster_authorized_operations(
+          kafka::cluster_authorized_operations(0x100));
+
+        // Advertise describe_redpanda_roles_api at version 0 on all brokers
+        // so that the migrator's version negotiation succeeds.
+        for (auto nid : _clmtf->get_cluster_mock().get_broker_ids()) {
+            _clmtf->get_cluster_mock().set_supported_versions(
+              nid,
+              kafka::describe_redpanda_roles_api::key,
+              kafka::client::api_version_range{
+                .min = kafka::api_version(0), .max = kafka::api_version(0)});
+        }
+
+        _clmtf->get_cluster_mock().register_handler(
+          kafka::describe_redpanda_roles_api::key,
+          [this](
+            ::model::node_id, kafka::client::request_t, kafka::api_version) {
+              kafka::describe_redpanda_roles_response resp;
+              resp.data.error_code = _fetch_error;
+              resp.data.roles = _source_roles
+                                | std::views::transform(
+                                  kafka::details::to_wire_redpanda_role)
+                                | std::ranges::to<decltype(resp.data.roles)>();
+              return ss::make_ready_future<kafka::client::response_t>(
+                kafka::client::response_t{std::move(resp)});
+          });
+
+        co_await _clmtf->get_manager().invoke_on_all([](manager& m) {
+            return m.register_task_factory<roles_migrator_factory>();
+        });
+
+        fixture().elect_leader(::model::controller_ntp, self(), std::nullopt);
+    }
+
+    ss::future<> TearDownAsync() override {
+        co_await _clmtf->reset();
+        _clmtf.reset();
+    }
+
+    ::model::node_id self() { return ::model::node_id(0); }
+    cluster_link_manager_test_fixture& fixture() { return *_clmtf; }
+
+    // Waits (up to 5s) for the roles migrator task to report the given state.
+    // Returns false on timeout.
+    ss::future<bool> wait_for_roles_task_state(model::task_state want) {
+        return fixture().wait_for_report_to_match(
+          5s, 200ms, [want](const model::cluster_link_task_status_report& r) {
+              auto link_it = r.link_reports.find(link_name);
+              if (link_it == r.link_reports.end()) {
+                  return false;
+              }
+              auto task_it = link_it->second.task_status_reports.find(
+                roles_migrator::task_name);
+              if (task_it == link_it->second.task_status_reports.end()) {
+                  return false;
+              }
+              return task_it->second.task_state == want;
+          });
+    }
+
+    // Sets the roles (and optional top-level error) the mocked source cluster
+    // returns from DescribeRedpandaRoles.
+    void set_source_roles(
+      std::vector<security::role_with_members> roles,
+      kafka::error_code ec = kafka::error_code::none) {
+        _source_roles = std::move(roles);
+        _fetch_error = ec;
+    }
+
+private:
+    std::unique_ptr<cluster_link_manager_test_fixture> _clmtf;
+    std::vector<security::role_with_members> _source_roles;
+    kafka::error_code _fetch_error{kafka::error_code::none};
+};
+
+TEST_F_CORO(roles_migrator_test, fetch_and_apply) {
+    set_source_roles(
+      {rwm("synced-role", {user("u1")}),
+       rwm("excluded-role", {user("u2")})}); // out of scope
+
+    co_await fixture().upsert_link(get_default_metadata());
+
+    // The in-scope role is mirrored.
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this] {
+        return fixture().security_service().roles().contains(
+          security::role_name{"synced-role"});
+    });
+    // Out-of-scope role must NOT be mirrored.
+    EXPECT_FALSE(
+      fixture().security_service().roles().contains(
+        security::role_name{"excluded-role"}));
+}
+
+TEST_F_CORO(roles_migrator_test, membership_update_propagation) {
+    set_source_roles({rwm("synced-role", {user("u1")})});
+
+    co_await fixture().upsert_link(get_default_metadata());
+
+    // Initial create with a single member.
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this] {
+        const auto& roles = fixture().security_service().roles();
+        auto it = roles.find(security::role_name{"synced-role"});
+        return it != roles.end() && it->second.members().size() == 1;
+    });
+
+    // The source role gains a member; the change must propagate as a full
+    // member-set replace through update_role.
+    set_source_roles({rwm("synced-role", {user("u1"), user("u2")})});
+
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this] {
+        const auto& roles = fixture().security_service().roles();
+        auto it = roles.find(security::role_name{"synced-role"});
+        return it != roles.end()
+               && it->second.members().contains(
+                 security::role_member{security::role_member_type::user, "u1"})
+               && it->second.members().contains(
+                 security::role_member{security::role_member_type::user, "u2"});
+    });
+}
+
+TEST_F_CORO(roles_migrator_test, deletion_propagation) {
+    // Destination has an in-scope role the source does not; it must be pruned.
+    fixture().security_service().seed_role(
+      security::role_name{"synced-stale"}, security::role{});
+    set_source_roles({});
+
+    co_await fixture().upsert_link(get_default_metadata());
+
+    RPTEST_REQUIRE_EVENTUALLY_CORO(
+      5s, [this] { return fixture().security_service().roles().empty(); });
+}
+
+TEST_F_CORO(roles_migrator_test, fail_safe_on_fetch_error) {
+    // Seed an in-scope dest role, then make the source return a top-level
+    // error.
+    fixture().security_service().seed_role(
+      security::role_name{"synced-keep"}, security::role{});
+    set_source_roles({}, kafka::error_code::broker_not_available);
+
+    co_await fixture().upsert_link(get_default_metadata());
+
+    // The task must actually reach link_unavailable (not merely time out)...
+    auto reached = co_await wait_for_roles_task_state(
+      model::task_state::link_unavailable);
+    EXPECT_TRUE(reached);
+    // ...and the role survives a failed fetch.
+    EXPECT_TRUE(
+      fixture().security_service().roles().contains(
+        security::role_name{"synced-keep"}));
+}
+
+TEST_F_CORO(roles_migrator_test, no_filters_syncs_nothing) {
+    // Role sync is enabled but no filters are configured: nothing is synced and
+    // the shadow cluster is left untouched. (paused is reserved for user
+    // action, so the task simply stays idle.)
+    fixture().security_service().seed_role(
+      security::role_name{"role-a"}, security::role{});
+    set_source_roles({rwm("role-b", {user("u1")})});
+
+    auto md = get_default_metadata();
+    md.configuration.role_sync_cfg.role_name_filters.clear();
+    co_await fixture().upsert_link(std::move(md));
+
+    // Let the periodic task fire several times; assert it makes no changes.
+    co_await ss::sleep(3 * task_reconciler_interval);
+
+    EXPECT_TRUE( // seeded role untouched (not pruned)
+      fixture().security_service().roles().contains(
+        security::role_name{"role-a"}));
+    EXPECT_FALSE( // and nothing was created
+      fixture().security_service().roles().contains(
+        security::role_name{"role-b"}));
+}
+
+TEST_F_CORO(roles_migrator_test, link_unavailable_when_rbac_inactive) {
+    // RBAC inactive on the shadow cluster is a preflight gate: the migrator
+    // parks in link_unavailable and mirrors nothing, even with an in-scope
+    // source role waiting to sync.
+    fixture().security_service().set_rbac_active(false);
+    set_source_roles({rwm("synced-role", {user("u1")})});
+
+    co_await fixture().upsert_link(get_default_metadata());
+
+    auto reached = co_await wait_for_roles_task_state(
+      model::task_state::link_unavailable);
+    EXPECT_TRUE(reached);
+    EXPECT_TRUE(fixture().security_service().roles().empty());
+
+    // Enabling RBAC clears the gate; the next reconcile cycle mirrors the role.
+    fixture().security_service().set_rbac_active(true);
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this] {
+        return fixture().security_service().roles().contains(
+          security::role_name{"synced-role"});
+    });
+}
+
+TEST_F_CORO(roles_migrator_test, link_unavailable_when_missing_permission) {
+    // Without cluster DESCRIBE permission on the source the migrator cannot
+    // safely enumerate roles, so it parks in link_unavailable before fetching
+    // and mirrors nothing, even with an in-scope source role waiting to sync.
+    fixture().get_cluster_mock().set_cluster_authorized_operations(
+      kafka::cluster_authorized_operations(0));
+    set_source_roles({rwm("synced-role", {user("u1")})});
+
+    co_await fixture().upsert_link(get_default_metadata());
+
+    auto reached = co_await wait_for_roles_task_state(
+      model::task_state::link_unavailable);
+    EXPECT_TRUE(reached);
+    EXPECT_TRUE(fixture().security_service().roles().empty());
+}
+
+TEST_F_CORO(roles_migrator_test, filter_change_rescopes_sync) {
+    // A filter change at runtime re-scopes what the sync manages on the next
+    // reconcile cycle. A role that enters scope is mirrored; a role that leaves
+    // scope is orphaned -- it survives on the shadow cluster even once the
+    // source drops it, whereas a still-in-scope role is pruned. Filtering is
+    // symmetric across source and shadow, so the deselected role is absent from
+    // both reconcile snapshots and is never considered for deletion. (Were the
+    // filter applied to the source only, the orphan would appear in the shadow
+    // snapshot but not the source one and get pruned.)
+    set_source_roles(
+      {rwm("synced-role", {user("u1")}),
+       rwm(
+         "rescoped-role",
+         {user("u2")})}); // out of scope under the initial filter
+
+    co_await fixture().upsert_link(get_default_metadata());
+
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this] {
+        return fixture().security_service().roles().contains(
+          security::role_name{"synced-role"});
+    });
+
+    // Shift the filter from the "synced-" prefix to the "rescoped-" prefix:
+    // synced-role leaves scope (becoming an orphan) and rescoped-role enters.
+    auto md = co_await fixture().find_link_by_name(link_name)->copy();
+    md.configuration.role_sync_cfg.role_name_filters.clear();
+    md.configuration.role_sync_cfg.role_name_filters.emplace_back(
+      model::resource_name_filter_pattern{
+        .pattern_type = model::filter_pattern_type::prefix,
+        .filter = model::filter_type::include,
+        .pattern = "rescoped-"});
+    auto link_id = fixture().find_link_id_by_name(link_name);
+    ASSERT_TRUE_CORO(link_id.has_value());
+    co_await fixture().update_link(*link_id, std::move(md));
+
+    // rescoped-role can only be mirrored under the new filter, so its
+    // appearance is a positive signal that the filter change has taken effect.
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this] {
+        return fixture().security_service().roles().contains(
+          security::role_name{"rescoped-role"});
+    });
+
+    // With the new filter live, clear the source. The in-scope role
+    // (rescoped-role) is pruned; the out-of-scope orphan (synced-role) is left
+    // untouched.
+    set_source_roles({});
+
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this] {
+        return !fixture().security_service().roles().contains(
+          security::role_name{"rescoped-role"});
+    });
+    EXPECT_TRUE(
+      fixture().security_service().roles().contains(
+        security::role_name{"synced-role"}));
+}
+
+TEST_F_CORO(roles_migrator_test, link_unavailable_when_api_unsupported) {
+    // The source doesn't advertise DescribeRedpandaRoles at all (e.g. a vanilla
+    // Kafka cluster, or a Redpanda predating the custom API), so version
+    // negotiation finds no supported version -> link_unavailable.
+    for (auto nid : fixture().get_cluster_mock().get_broker_ids()) {
+        fixture().get_cluster_mock().remove_supported_version(
+          nid, kafka::describe_redpanda_roles_api::key);
+    }
+    set_source_roles({rwm("synced-role", {user("u1")})});
+
+    co_await fixture().upsert_link(get_default_metadata());
+
+    auto reached = co_await wait_for_roles_task_state(
+      model::task_state::link_unavailable);
+    EXPECT_TRUE(reached);
+    EXPECT_TRUE(fixture().security_service().roles().empty());
+}
+
+} // namespace cluster_link::tests

--- a/src/v/kafka/client/test/cluster_mock.h
+++ b/src/v/kafka/client/test/cluster_mock.h
@@ -120,6 +120,14 @@ public:
         _broker_api_versions[id].insert_or_assign(key, range);
     }
 
+    void remove_supported_version(model::node_id id, api_key key) {
+        if (
+          auto it = _broker_api_versions.find(id);
+          it != _broker_api_versions.end()) {
+            it->second.erase(key);
+        }
+    }
+
     void add_topic(
       model::topic topic_name,
       size_t partition_count,

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -409,7 +409,20 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
     def test_task_states_change(self):
         topic = TopicSpec(name="test-topic", partition_count=3, replication_factor=3)
         self.source_default_client().create_topic(topic)
-        self.create_link("test-link")
+        req = self.create_default_link_request("test-link")
+        req.shadow_link.configurations.role_sync_options.CopyFrom(
+            shadow_link_pb2.RoleSyncOptions(
+                interval=google.protobuf.duration_pb2.Duration(seconds=1),
+                role_name_filters=[
+                    shadow_link_pb2.NameFilter(
+                        pattern_type=shadow_link_pb2.PATTERN_TYPE_PREFIX,
+                        filter_type=shadow_link_pb2.FILTER_TYPE_INCLUDE,
+                        name="e2e-roles-",
+                    )
+                ],
+            )
+        )
+        self.create_link_with_request(req)
 
         wait_until(
             lambda: self._topics_are_present_in_target_cluster([topic]),

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -99,6 +99,7 @@ DISALLOWED_SYNCED_TOPIC_PROPERTIES = [
 CONTROLLER_LOCKED_TASKS = [
     "Source Topic Sync",
     "Security Migrator Task",
+    "Roles Migrator Task",
 ]
 
 ALL_STORAGE_MODES = [

--- a/tests/rptest/tests/shadow_link_role_sync_test.py
+++ b/tests/rptest/tests/shadow_link_role_sync_test.py
@@ -22,8 +22,13 @@ from rptest.clients.admin.proto.redpanda.core.admin.v2 import (
     shadow_link_pb2,
 )
 from rptest.clients.admin.v2 import Admin as AdminV2
+from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
-from rptest.services.multi_cluster_services import SecondaryClusterArgs
+from rptest.services.multi_cluster_services import (
+    SecondaryClusterArgs,
+    SecondaryClusterSpec,
+    ServiceType,
+)
 from rptest.tests.cluster_linking_test_base import ShadowLinkTestBase
 from rptest.tests.rbac_test_v2 import AdminV2RoleWrapper
 from rptest.util import expect_timeout
@@ -283,3 +288,70 @@ class ShadowLinkRoleSyncTest(RoleSyncTestBase):
         assert self._dst_role_members("unmanaged-role") == {"local-admin"}, (
             "out-of-scope destination role's membership was altered by the migrator"
         )
+
+
+class ShadowLinkRoleSyncKafkaSourceTest(RoleSyncTestBase):
+    """Role sync degrades gracefully when the source is an Apache Kafka cluster
+    that does not implement DescribeRedpandaRoles (Kafka API key 15000)."""
+
+    def __init__(self, test_context: TestContext):
+        super().__init__(
+            test_context=test_context,
+            num_brokers=3,
+            secondary_cluster_args=SecondaryClusterArgs(),
+        )
+
+    def get_source_cluster_spec(self) -> SecondaryClusterSpec:
+        return SecondaryClusterSpec(
+            ServiceType.KAFKA,
+            kafka_version="3.8.0",
+            kafka_quorum="COMBINED_KRAFT",
+        )
+
+    @cluster(num_nodes=6)
+    def test_roles_park_but_link_still_syncs_topics(self):
+        # No RBAC roles exist on an Apache Kafka source; the roles task cannot
+        # negotiate the custom DescribeRedpandaRoles API (Kafka API key 15000)
+        # and parks. The rest of the link rides standard Kafka APIs, so it must
+        # keep working: one task parking is isolated from its siblings.
+        topic = TopicSpec(name="mirror-topic", partition_count=3, replication_factor=3)
+        self.source_default_client().create_topic(topic)
+
+        self._create_link_with_role_sync()
+
+        def parked() -> bool:
+            task = self._roles_task()
+            return (
+                task is not None
+                and task.state == shadow_link_pb2.TASK_STATE_LINK_UNAVAILABLE
+            )
+
+        wait_until(
+            parked,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="roles task did not park LINK_UNAVAILABLE against a Kafka source",
+        )
+        task = self._roles_task()
+        assert task is not None and task.reason, (
+            "expected a non-empty reason explaining the unsupported API"
+        )
+        assert task.state != shadow_link_pb2.TASK_STATE_FAULTED, (
+            "roles task must park (LINK_UNAVAILABLE), not fault, on an unsupported source"
+        )
+        # Nothing was mirrored.
+        assert not [
+            n for n in self._dst.list_role_names() if n.startswith("synced-")
+        ], "no roles should be mirrored from a Kafka source"
+
+        # The parked roles task does not impair the data plane: a topic created
+        # on the Kafka source still syncs to the target over standard Kafka APIs.
+        wait_until(
+            lambda: self.topic_partitions_exists_in_target(topic),
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="topic did not sync to target while the roles task was parked",
+        )
+
+        # Topic sync completing did not un-park or fault the roles task.
+        assert parked(), "roles task should remain parked after topic sync"

--- a/tests/rptest/tests/shadow_link_role_sync_test.py
+++ b/tests/rptest/tests/shadow_link_role_sync_test.py
@@ -1,0 +1,235 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from typing import Callable
+
+from connectrpc.errors import ConnectError, ConnectErrorCode
+
+import google.protobuf.duration_pb2 as duration_pb2
+import google.protobuf.field_mask_pb2 as field_mask_pb2
+
+from ducktape.tests.test import TestContext
+from ducktape.utils.util import wait_until
+
+from rptest.clients.admin.proto.redpanda.core.admin.v2 import (
+    security_pb2,
+    shadow_link_pb2,
+)
+from rptest.clients.admin.v2 import Admin as AdminV2
+from rptest.services.cluster import cluster
+from rptest.services.multi_cluster_services import SecondaryClusterArgs
+from rptest.tests.cluster_linking_test_base import ShadowLinkTestBase
+from rptest.tests.rbac_test_v2 import AdminV2RoleWrapper
+from rptest.util import expect_timeout
+
+
+# Matches roles_migrator::task_name in src/v/cluster_link/roles_migrator.h.
+ROLES_MIGRATOR_TASK_NAME = "Roles Migrator Task"
+
+
+def _user(name: str) -> security_pb2.RoleMember:
+    """Construct a user-type RoleMember."""
+    return security_pb2.RoleMember(user=security_pb2.RoleUser(name=name))
+
+
+def _group(name: str) -> security_pb2.RoleMember:
+    """Construct a group-type RoleMember."""
+    return security_pb2.RoleMember(group=security_pb2.RoleGroup(name=name))
+
+
+class RoleSyncTestBase(ShadowLinkTestBase):
+    """Shared helpers for shadow-link role-sync tests. Holds no test methods so
+    concrete subclasses with different topologies can reuse it without
+    re-running each other's tests."""
+
+    LINK = "role-sync-link"
+
+    def setUp(self):
+        super().setUp()
+        self._dst = AdminV2RoleWrapper(AdminV2(self.target_cluster_service))
+
+    def _create_link_with_role_sync(
+        self,
+        filters: list[shadow_link_pb2.NameFilter] | None = None,
+        mutate_req: Callable[[shadow_link_pb2.CreateShadowLinkRequest], None]
+        | None = None,
+    ) -> None:
+        req = self.create_default_link_request(self.LINK)
+        if filters is None:
+            filters = [
+                shadow_link_pb2.NameFilter(
+                    pattern_type=shadow_link_pb2.PATTERN_TYPE_PREFIX,
+                    filter_type=shadow_link_pb2.FILTER_TYPE_INCLUDE,
+                    name="synced-",
+                )
+            ]
+        opts = shadow_link_pb2.RoleSyncOptions(
+            interval=duration_pb2.Duration(seconds=1),
+            paused=False,
+            role_name_filters=filters,
+        )
+        req.shadow_link.configurations.role_sync_options.CopyFrom(opts)
+        if mutate_req is not None:
+            mutate_req(req)
+        self.create_link_with_request(req)
+
+    def _dst_role_members(self, role: str) -> set[str]:
+        try:
+            members = self._dst.get_role(role).members
+        except ConnectError as e:
+            assert e.code == ConnectErrorCode.NOT_FOUND, (
+                f"unexpected error fetching role {role!r}: {e}"
+            )
+            return set()
+        result: set[str] = set()
+        for m in members:
+            match m.WhichOneof("member"):
+                case "user":
+                    result.add(m.user.name)
+                case "group":
+                    result.add(m.group.name)
+                case other:
+                    raise AssertionError(
+                        f"unexpected role member type {other!r} in role {role!r}"
+                    )
+        return result
+
+    def _set_role_sync_paused(self, paused: bool) -> None:
+        link = self.get_link(self.LINK)
+        link.configurations.role_sync_options.paused = paused
+        self.update_link(
+            shadow_link=link,
+            update_mask=field_mask_pb2.FieldMask(
+                paths=["configurations.role_sync_options.paused"]
+            ),
+        )
+
+    def _roles_task(self):
+        for task in self.get_link(self.LINK).status.task_statuses:
+            if task.name == ROLES_MIGRATOR_TASK_NAME:
+                return task
+        return None
+
+    def _roles_task_state(self):
+        task = self._roles_task()
+        return task.state if task is not None else None
+
+
+class ShadowLinkRoleSyncTest(RoleSyncTestBase):
+    """End-to-end test for the shadow link roles migrator (plaintext source)."""
+
+    def __init__(self, test_context: TestContext):
+        super().__init__(
+            test_context=test_context,
+            num_brokers=3,
+            secondary_cluster_args=SecondaryClusterArgs(),
+        )
+
+    def setUp(self):
+        super().setUp()
+        self._src = AdminV2RoleWrapper(AdminV2(self.source_cluster_service))
+
+    @cluster(num_nodes=6)
+    def test_role_sync_full_mirror(self):
+        """
+        Verify full mirror lifecycle: initial sync of users and groups,
+        membership update, out-of-scope exclusion, deletion, and the
+        pause/resume cycle (including a member removal made while paused).
+        """
+        # Roles on the source. "synced-keep" is in scope (prefix "synced-") and
+        # carries both a user and a group member; it survives to drive the
+        # pause/resume sequence below. "synced-doomed" is in scope and exercises
+        # deletion. "excluded-role" is out of scope.
+        self._src.create_role(
+            role="synced-keep", members=[_user("u1"), _group("synced-group")]
+        )
+        self._src.create_role(role="synced-doomed", members=[_user("u4")])
+        self._src.create_role(role="excluded-role", members=[_user("u2")])
+
+        self._create_link_with_role_sync()
+
+        # Initial mirror: both in-scope roles, with their full membership
+        # (users and groups), appear on the destination.
+        def initial_mirror_complete() -> bool:
+            return self._dst_role_members("synced-keep") == {
+                "u1",
+                "synced-group",
+            } and self._dst_role_members("synced-doomed") == {"u4"}
+
+        wait_until(
+            initial_mirror_complete,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="initial role state did not mirror to destination",
+        )
+
+        # Out-of-scope role must never appear. The positive checks above prove a
+        # full sync cycle completed, so excluded-role's absence here means
+        # "excluded by the filter" rather than merely "not synced yet".
+        assert "excluded-role" not in self._dst.list_role_names(), (
+            "excluded-role (out-of-scope) should not be mirrored to destination"
+        )
+
+        # Membership addition propagates.
+        self._src.add_role_members(role="synced-keep", members=[_user("u3")])
+        wait_until(
+            lambda: (
+                self._dst_role_members("synced-keep") == {"u1", "u3", "synced-group"}
+            ),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="membership addition did not propagate",
+        )
+
+        # Role deletion propagates.
+        self._src.delete_role("synced-doomed", delete_acls=False)
+        wait_until(
+            lambda: "synced-doomed" not in self._dst.list_role_names(),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="role deletion did not propagate",
+        )
+
+        # Pausing role sync parks the roles migrator task in the paused state.
+        self._set_role_sync_paused(True)
+        wait_until(
+            lambda: self._roles_task_state() == shadow_link_pb2.TASK_STATE_PAUSED,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="roles migrator did not pause after role sync was paused",
+        )
+
+        # A removal made while paused must not propagate. The migrator is
+        # confirmed parked above; poll for the removal across several sync
+        # intervals and require that it never lands. A timeout here is the
+        # success case: the forbidden state was never observed.
+        self._src.remove_role_members(
+            role="synced-keep", members=[_group("synced-group")]
+        )
+        with expect_timeout():
+            wait_until(
+                lambda: "synced-group" not in self._dst_role_members("synced-keep"),
+                timeout_sec=5,
+                backoff_sec=1,
+            )
+
+        # Resuming the link should allow the removal to propagate.
+        self._set_role_sync_paused(False)
+        wait_until(
+            lambda: self._roles_task_state() == shadow_link_pb2.TASK_STATE_ACTIVE,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="roles migrator did not resume after role sync was unpaused",
+        )
+        wait_until(
+            lambda: "synced-group" not in self._dst_role_members("synced-keep"),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="member removal made while paused did not propagate on resume",
+        )

--- a/tests/rptest/tests/shadow_link_role_sync_test.py
+++ b/tests/rptest/tests/shadow_link_role_sync_test.py
@@ -233,3 +233,53 @@ class ShadowLinkRoleSyncTest(RoleSyncTestBase):
             backoff_sec=1,
             err_msg="member removal made while paused did not propagate on resume",
         )
+
+    @cluster(num_nodes=6)
+    def test_reconcile_authority_is_scoped(self):
+        """The reconcile is full-replace authoritative, but only over in-scope
+        roles. For an in-scope role the destination is driven back to the
+        source: a member added directly on the destination is stripped and a
+        role deleted on the destination is recreated. A destination role
+        outside the filter scope, with no source counterpart, is left
+        untouched."""
+        self._src.create_role(
+            role="synced-role", members=[_user("u1"), _group("synced-group")]
+        )
+        # "unmanaged-" is outside the default "synced-" include filter, so the
+        # migrator never selects it on either side.
+        self._dst.create_role(role="unmanaged-role", members=[_user("local-admin")])
+        self._create_link_with_role_sync()
+        wait_until(
+            lambda: self._dst_role_members("synced-role") == {"u1", "synced-group"},
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="initial role state did not mirror to destination",
+        )
+
+        # A member added directly on the destination is stripped on reconcile.
+        self._dst.add_role_members(role="synced-role", members=[_user("drift-member")])
+        wait_until(
+            lambda: self._dst_role_members("synced-role") == {"u1", "synced-group"},
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="foreign member added on destination was not reverted",
+        )
+
+        # A role deleted on the destination is recreated from the source.
+        self._dst.delete_role("synced-role", delete_acls=False)
+        wait_until(
+            lambda: self._dst_role_members("synced-role") == {"u1", "synced-group"},
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="role deleted on destination was not recreated",
+        )
+
+        # The reverts above are observed reconcile cycles that ran while
+        # "unmanaged-role" existed, so its survival here is "left alone by the
+        # filter" rather than "not yet reconciled".
+        assert "unmanaged-role" in self._dst.list_role_names(), (
+            "out-of-scope destination role was deleted by the migrator"
+        )
+        assert self._dst_role_members("unmanaged-role") == {"local-admin"}, (
+            "out-of-scope destination role's membership was altered by the migrator"
+        )

--- a/tests/rptest/tests/shadow_link_role_sync_test.py
+++ b/tests/rptest/tests/shadow_link_role_sync_test.py
@@ -500,3 +500,51 @@ class ShadowLinkRoleSyncAuthTest(RoleSyncTestBase):
         assert topic not in set(bob_rpk.list_topics()), (
             "non-member BOB must not be authorized by the synced role"
         )
+
+    @cluster(num_nodes=6)
+    def test_permission_grant_activates_sync(self):
+        limited_user = "limited-link-user"
+        limited_pw = "limited-link-password"
+        su_rpk = self._source_superuser_rpk()
+
+        # An in-scope role exists on the source, waiting to sync.
+        self._src.create_role(role="synced-role", members=[_user("u1")])
+
+        # A non-superuser link principal that lacks cluster DESCRIBE on the source.
+        su_rpk.sasl_create_user(limited_user, limited_pw)
+
+        self._create_link_with_role_sync(
+            mutate_req=lambda req: self._add_link_scram_creds(
+                req, limited_user, limited_pw
+            )
+        )
+
+        # Without DESCRIBE the migrator cannot enumerate roles -> LINK_UNAVAILABLE.
+        wait_until(
+            lambda: (
+                self._roles_task_state() == shadow_link_pb2.TASK_STATE_LINK_UNAVAILABLE
+            ),
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="roles task did not park LINK_UNAVAILABLE without permission",
+        )
+        assert "synced-role" not in self._dst.list_role_names(), (
+            "nothing should sync while the link principal lacks permission"
+        )
+        task = self._roles_task()
+        assert task is not None and task.reason, "expected a non-empty reason"
+
+        # Grant cluster DESCRIBE on the source; the task recovers and mirrors.
+        su_rpk.acl_create_allow_cluster(username=limited_user, op="describe")
+        wait_until(
+            lambda: self._roles_task_state() == shadow_link_pb2.TASK_STATE_ACTIVE,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="roles task did not become ACTIVE after the permission grant",
+        )
+        wait_until(
+            lambda: self._dst_role_members("synced-role") == {"u1"},
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="role did not mirror after the permission grant",
+        )

--- a/tests/rptest/tests/shadow_link_role_sync_test.py
+++ b/tests/rptest/tests/shadow_link_role_sync_test.py
@@ -22,13 +22,17 @@ from rptest.clients.admin.proto.redpanda.core.admin.v2 import (
     shadow_link_pb2,
 )
 from rptest.clients.admin.v2 import Admin as AdminV2
+from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
+from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.multi_cluster_services import (
     SecondaryClusterArgs,
     SecondaryClusterSpec,
     ServiceType,
 )
+from rptest.services.redpanda import SaslCredentials, SecurityConfig
+from rptest.tests.admin_api_auth_test import create_user_and_wait  # type: ignore[reportUnknownVariableType]
 from rptest.tests.cluster_linking_test_base import ShadowLinkTestBase
 from rptest.tests.rbac_test_v2 import AdminV2RoleWrapper
 from rptest.util import expect_timeout
@@ -36,6 +40,9 @@ from rptest.util import expect_timeout
 
 # Matches roles_migrator::task_name in src/v/cluster_link/roles_migrator.h.
 ROLES_MIGRATOR_TASK_NAME = "Roles Migrator Task"
+
+ALICE = SaslCredentials("alice", "itsMeH0nest012", "SCRAM-SHA-256")
+BOB = SaslCredentials("bob", "itsMeH0nest012", "SCRAM-SHA-256")
 
 
 def _user(name: str) -> security_pb2.RoleMember:
@@ -355,3 +362,141 @@ class ShadowLinkRoleSyncKafkaSourceTest(RoleSyncTestBase):
 
         # Topic sync completing did not un-park or fault the roles task.
         assert parked(), "roles task should remain parked after topic sync"
+
+
+class ShadowLinkRoleSyncAuthTest(RoleSyncTestBase):
+    """Role sync with SASL/SCRAM on both clusters: functional authorization and
+    the source-permission boundary."""
+
+    SUPERUSER_LINK = "cluster-link-user"
+    SUPERUSER_LINK_PW = "cluster-link-password"
+
+    def __init__(self, test_context: TestContext):
+        security = SecurityConfig()
+        security.enable_sasl = True
+        super().__init__(
+            test_context=test_context,
+            num_brokers=3,
+            security=security,
+            secondary_cluster_args=SecondaryClusterArgs(security=security),
+        )
+
+    def _source_superuser_rpk(self) -> RpkTool:
+        su = self.redpanda.SUPERUSER_CREDENTIALS
+        return RpkTool(
+            self.source_cluster_service,
+            username=su.username,
+            password=su.password,
+            sasl_mechanism=su.mechanism,
+        )
+
+    def _add_link_scram_creds(
+        self,
+        req: shadow_link_pb2.CreateShadowLinkRequest,
+        username: str,
+        password: str,
+    ) -> None:
+        req.shadow_link.configurations.client_options.authentication_configuration.scram_configuration.CopyFrom(
+            shadow_link_pb2.ScramConfig(
+                username=username,
+                password=password,
+                scram_mechanism=shadow_link_pb2.SCRAM_MECHANISM_SCRAM_SHA_256,
+            )
+        )
+
+    def setUp(self):
+        super().setUp()
+        su = self.redpanda.SUPERUSER_CREDENTIALS
+        # Under SASL, the base's unauthenticated target clients fail. Rebind the
+        # shadow-link service client and the destination role wrapper to a
+        # superuser-authenticated AdminV2 (see Global Constraints).
+        self.admin_v2 = AdminV2(
+            self.target_cluster_service, auth=(su.username, su.password)
+        )
+        self.service_client = self.admin_v2.shadow_link()
+        self._dst = AdminV2RoleWrapper(self.admin_v2)
+        # _src talks Admin v2 to the source as the source superuser.
+        self._src = AdminV2RoleWrapper(
+            AdminV2(self.source_cluster_service, auth=(su.username, su.password))
+        )
+        # A privileged link principal on the source (added to superusers so it
+        # can enumerate roles and ACLs).
+        self._source_superuser_rpk().sasl_create_user(
+            self.SUPERUSER_LINK, self.SUPERUSER_LINK_PW
+        )
+        self.source_cluster_service.set_cluster_config(
+            {"superusers": [su.username, self.SUPERUSER_LINK]}
+        )
+
+    def _target_visible_topics(self, creds: SaslCredentials) -> set[str]:
+        rpk = RpkTool(
+            self.target_cluster_service,
+            username=creds.username,
+            password=creds.password,
+            sasl_mechanism=creds.algorithm,
+        )
+        try:
+            return set(rpk.list_topics())
+        except Exception:
+            return set()
+
+    @cluster(num_nodes=6)
+    def test_functional_authz_end_to_end(self):
+        topic = "authz-topic"
+        su_rpk = self._source_superuser_rpk()
+
+        # Pre-provision the member identities on the DESTINATION (credentials do
+        # not sync; they model operator-provisioned DR identities).
+        target_su = self.redpanda.SUPERUSER_CREDENTIALS
+        target_admin = Admin(
+            self.target_cluster_service,
+            auth=(target_su.username, target_su.password),
+        )
+        create_user_and_wait(self.target_cluster_service, target_admin, ALICE)
+        create_user_and_wait(self.target_cluster_service, target_admin, BOB)
+
+        # SOURCE: topic, in-scope role with ALICE as a member, and an ACL bound
+        # to the role principal granting DESCRIBE on the topic.
+        su_rpk.create_topic(topic)
+        self._src.create_role(role="synced-role", members=[_user(ALICE.username)])
+        su_rpk.sasl_allow_principal(
+            "RedpandaRole:synced-role", ["describe"], "topic", topic
+        )
+
+        # Link with role sync + ACL sync (security_sync is on by default in
+        # create_default_link_request) + SCRAM client creds.
+        self._create_link_with_role_sync(
+            mutate_req=lambda req: self._add_link_scram_creds(
+                req, self.SUPERUSER_LINK, self.SUPERUSER_LINK_PW
+            )
+        )
+
+        # Role membership mirrors to the destination.
+        wait_until(
+            lambda: self._dst_role_members("synced-role") == {ALICE.username},
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="role membership did not mirror to destination",
+        )
+
+        # The synced role + role-bound ACL authorize the member, not a non-member.
+        # ALICE (member) gains topic visibility once role + ACL have both synced.
+        wait_until(
+            lambda: topic in self._target_visible_topics(ALICE),
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="member ALICE was not authorized via the synced role + ACL",
+        )
+        # BOB (non-member) is authenticated but must NOT see the ACL-protected
+        # topic. Probe directly (not via the exception-swallowing helper) so a
+        # transient rpk failure surfaces as an error rather than a vacuous
+        # "denied" pass.
+        bob_rpk = RpkTool(
+            self.target_cluster_service,
+            username=BOB.username,
+            password=BOB.password,
+            sasl_mechanism=BOB.algorithm,
+        )
+        assert topic not in set(bob_rpk.list_topics()), (
+            "non-member BOB must not be authorized by the synced role"
+        )


### PR DESCRIPTION
Implements shadow link role sync, the follow-on to the groundwork merged in
#30932. That PR landed the role-sync configuration surface inert; this PR adds
the migrator that consumes it, so configuring role sync on a link now actually
syncs roles.

The roles migrator is a periodic, controller-leader-singleton task that
full-mirrors RBAC roles from the source cluster onto the shadow-link
destination, within the configured role-name filter scope. New roles, member
changes, and source-side deletions all propagate; in-scope destination roles
missing from the source are pruned, matching shadow-DR semantics. Source and
apply errors are surfaced through the task state.

Covered by `reconcile_roles` unit tests, C++ fixture tests for the migrator
task, and a ducktape e2e suite (full mirror, in-scope authority, functional
authz over synced roles and ACLs, parking against an Apache Kafka source, and
permission-grant recovery).

Fixes [CORE-16456](https://redpandadata.atlassian.net/browse/CORE-16456).

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Features

* Shadow links can now mirror RBAC roles from the source cluster to the
  destination. Configure role sync on the link with a sync interval and
  role-name filters to select which roles are kept in sync.


[CORE-16456]: https://redpandadata.atlassian.net/browse/CORE-16456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ