### PR TITLE
raft/tests: group node data under a single per-test directory

### DIFF
--- a/src/v/raft/tests/raft_fixture_base.cc
+++ b/src/v/raft/tests/raft_fixture_base.cc
@@ -365,28 +365,6 @@ in_memory_test_protocol::distribute_compaction_mtro(
 raft_node_instance::raft_node_instance(
   model::node_id id,
   model::revision_id revision,
-  raft_node_map& node_map,
-  ss::sharded<features::feature_table>& feature_table,
-  leader_update_clb_t leader_update_clb,
-  bool enable_longest_log_detection,
-  config::binding<std::chrono::milliseconds> election_timeout,
-  config::binding<std::chrono::milliseconds> heartbeat_interval,
-  bool with_offset_translation)
-  : raft_node_instance(
-      id,
-      revision,
-      test_env::random_dir_path("test_raft_{}_", 12),
-      node_map,
-      feature_table,
-      std::move(leader_update_clb),
-      enable_longest_log_detection,
-      std::move(election_timeout),
-      std::move(heartbeat_interval),
-      with_offset_translation) {}
-
-raft_node_instance::raft_node_instance(
-  model::node_id id,
-  model::revision_id revision,
   ss::sstring base_directory,
   raft_node_map& node_map,
   ss::sharded<features::feature_table>& feature_table,
@@ -602,6 +580,10 @@ void raft_node_instance::reset_dispatch_handlers() {
     _protocol->reset_dispatch_handlers();
 }
 
+raft_fixture_base::raft_fixture_base()
+  : _logger("raft-fixture")
+  , _test_dir(test_env::random_dir_path("test_raft_", 12)) {}
+
 seastar::future<> raft_fixture_base::stop() {
     co_await ss::smp::invoke_on_all(
       []() { config::shard_local_cfg().for_each([](auto& p) { p.reset(); }); });
@@ -630,24 +612,8 @@ seastar::future<> raft_fixture_base::start() {
 
 raft_node_instance&
 raft_fixture_base::add_node(model::node_id id, model::revision_id rev) {
-    auto instance = std::make_unique<raft_node_instance>(
-      id,
-      rev,
-      *this,
-      _features,
-      [id, this](leadership_status lst) {
-          _leaders_view[id] = lst;
-          if (_leader_clb) {
-              _leader_clb.value()(id, lst);
-          }
-      },
-      _enable_longest_log_detection,
-      _election_timeout.bind(),
-      _heartbeat_interval.bind(),
-      _with_offset_translation);
-
-    auto [it, success] = _nodes.emplace(id, std::move(instance));
-    return *it->second;
+    return add_node(
+      id, rev, fmt::format("{}/node_{}", _test_dir.string(), id()));
 }
 
 raft_node_instance& raft_fixture_base::add_node(

--- a/src/v/raft/tests/raft_fixture_base.h
+++ b/src/v/raft/tests/raft_fixture_base.h
@@ -206,17 +206,6 @@ public:
       config::binding<std::chrono::milliseconds> heartbeat_interval,
       bool with_offset_translation = false);
 
-    raft_node_instance(
-      model::node_id id,
-      model::revision_id revision,
-      raft_node_map& node_map,
-      ss::sharded<features::feature_table>& feature_table,
-      leader_update_clb_t leader_update_clb,
-      bool enable_longest_log_detection,
-      config::binding<std::chrono::milliseconds> election_timeout,
-      config::binding<std::chrono::milliseconds> heartbeat_interval,
-      bool with_offset_translation = false);
-
     raft_node_instance(const raft_node_instance&) = delete;
     raft_node_instance(raft_node_instance&&) noexcept = delete;
     raft_node_instance& operator=(raft_node_instance&&) = delete;
@@ -348,8 +337,7 @@ class raft_fixture_base : public raft_node_map {
 public:
     using leader_update_clb_t
       = ss::noncopyable_function<void(model::node_id, leadership_status)>;
-    raft_fixture_base()
-      : _logger("raft-fixture") {}
+    raft_fixture_base();
     using raft_nodes_t = absl::
       flat_hash_map<model::node_id, std::unique_ptr<raft_node_instance>>;
     static constexpr raft::group_id group_id = raft::group_id(123);
@@ -639,6 +627,7 @@ private:
     config::mock_property<std::chrono::milliseconds> _election_timeout{500ms};
     config::mock_property<std::chrono::milliseconds> _heartbeat_interval{50ms};
     bool _with_offset_translation = false;
+    std::filesystem::path _test_dir;
 };
 
 std::ostream& operator<<(std::ostream& o, msg_type type);


### PR DESCRIPTION
Place all raft fixture node data under one top-level temporary directory with per-node subdirectories, rather than a separate random directory per node. This groups per-test artifacts and drops the unformatted "test_raft_{}_" prefix that leaked into segment log lines.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
