### PR TITLE
syschecks/rpk: enforce minimum memory requirement as fatal

### DIFF
--- a/src/go/rpk/pkg/tuners/redpanda_checkers.go
+++ b/src/go/rpk/pkg/tuners/redpanda_checkers.go
@@ -118,7 +118,7 @@ func NewMemoryChecker(fs afero.Fs) Checker {
 	return NewIntChecker(
 		FreeMemChecker,
 		"Free memory per CPU [MB]",
-		Warning,
+		Fatal,
 		func(current int) bool {
 			return current >= 2048
 		},

--- a/src/v/syschecks/syschecks.cc
+++ b/src/v/syschecks/syschecks.cc
@@ -82,7 +82,7 @@ void memory(bool ignore) {
         return;
     }
     auto line = fmt::format(
-      "Memory: '{}' below recommended: '{}'", shard_mem, kMinMemory);
+      "Memory: '{}' below minimum: '{}'", shard_mem, kMinMemory);
     checklog.error(line.c_str());
     if (!ignore) {
         throw std::runtime_error(line);


### PR DESCRIPTION
Fixes #30172

When Redpanda is started with insufficient memory, the system check throws a runtime error but incorrectly logs the threshold as "recommended" rather than "minimum". Furthermore, the `rpk` hardware checker flagged this constraint as a Warning instead of a Fatal error.

This patch resolves the issue by updating the C++ syscheck log output to explicitly state "below minimum:" and elevates the Go-based `rpk` FreeMemChecker severity to Fatal, strictly enforcing the hard memory requirement.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## UX Changes

* `rpk redpanda check` now reports insufficient memory per CPU as a `Fatal` error rather than a `Warning`.

## Release Notes

### Improvements

* Corrected the C++ startup memory validation log message to state "minimum" instead of "recommended".
* `rpk` hardware checker now strictly enforces the minimum memory requirement as a fatal error.