### PR TITLE
partition_properties_stm: allow adjacent revison-less operations

### DIFF
--- a/src/v/cluster/partition_properties_stm.cc
+++ b/src/v/cluster/partition_properties_stm.cc
@@ -248,17 +248,6 @@ partition_properties_stm::replicate_properties_update(
           current_state);
         co_return errc::invalid_data_migration_state;
     }
-    if (
-      cmd.writes_revision_id == current_state.writes_revision_id
-      && cmd.writes_disabled != current_state.writes_disabled) [[unlikely]] {
-        vlog(
-          _log.error,
-          "Conflicting writes_disabled state for the same revision: {}, "
-          "current state: {}",
-          cmd,
-          current_state);
-        co_return errc::invalid_data_migration_state;
-    }
 
     // replicate the command
     auto b = make_update_partitions_batch(cmd);

--- a/src/v/cluster/tests/partition_properties_stm_test.cc
+++ b/src/v/cluster/tests/partition_properties_stm_test.cc
@@ -66,7 +66,6 @@ struct partition_properties_stm_fixture : raft::raft_fixture {
     ss::future<> check_res(result<model::offset> res, bool expect_success) {
         ASSERT_TRUE_CORO(expect_success == res.has_value());
         if (!expect_success) {
-            // we don;t
             ASSERT_EQ_CORO(res.error(), errc::invalid_data_migration_state);
         }
     }
@@ -152,8 +151,8 @@ struct partition_properties_stm_fixture : raft::raft_fixture {
             auto o = co_await replicate_random_batches();
             vlog(tstlog.info, "last batches offset offset: {}", o);
 
-            // 10% chance to create a legacy record
-            if (random_generators::get_int(10) == 0) {
+            // 1/6 chance to create a legacy record
+            if (random_generators::get_int(6) == 0) {
                 revision_id = model::revision_id{};
             }
 
@@ -265,6 +264,12 @@ TEST_F_CORO(partition_properties_stm_fixture, test_basic_operations) {
     co_await disable_writes(model::revision_id{});
     co_await assert_writes(stm_t::writes_disabled::yes);
     // idempotent with empty revision id
+    co_await disable_writes(model::revision_id{});
+    co_await assert_writes(stm_t::writes_disabled::yes);
+    // a legacy command flips the state even when the current revision is also
+    // empty, i.e. adjacent legacy commands are not treated as out-of-order
+    co_await enable_writes(model::revision_id{});
+    co_await assert_writes(stm_t::writes_disabled::no);
     co_await disable_writes(model::revision_id{});
     co_await assert_writes(stm_t::writes_disabled::yes);
     // after reset, even revision id 1 works


### PR DESCRIPTION
These should not happen in the wild, as revision id comes from raft, but
since test check this case it should behave appropriately.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
