### PR TITLE
[CORE-16744] Fix flaky NodeCrash in test_downgrade_rejected_after_finalize

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -530,6 +530,14 @@ class ResourceSettings:
     def num_cpus(self) -> int | None:
         return self._num_cpus
 
+    @property
+    def core_dump_limit(self) -> str | None:
+        return self._core_dump_limit
+
+    @core_dump_limit.setter
+    def core_dump_limit(self, value: str | None) -> None:
+        self._core_dump_limit = value
+
     def to_cli(self, *, dedicated_node: bool) -> Tuple[str, str]:
         """
 
@@ -3753,6 +3761,28 @@ class RedpandaService(Service, RedpandaServiceABC):
         finally:
             self.signal_redpanda(node, signal=signal.SIGCONT)
             self.add_to_started_nodes(node)
+
+    @contextmanager
+    def core_dumps_disabled(self):
+        """Context manager that disables core dumps for redpanda processes
+        started within the block, restoring the prior limit on exit.
+
+        Intended for tests that deliberately abort a node -- e.g. a startup that
+        is expected to fail -- where the SIGILL from vassert's __builtin_trap()
+        would otherwise trigger a core dump. Flushing a multi-GB core on a loaded
+        host can take longer than the start/termination timeout and flake the
+        test; the abort reason is already captured in the log and the
+        crash_tracker crash file, so the kernel core adds no diagnostic value.
+
+        The limit is a shared resource setting, so this affects every node
+        started while the block is active -- fine for the sequential single-node
+        starts these tests perform."""
+        prev = self._resource_settings.core_dump_limit
+        self._resource_settings.core_dump_limit = "0"
+        try:
+            yield
+        finally:
+            self._resource_settings.core_dump_limit = prev
 
     def sockets_clear(self, node: RemoteClusterNode):
         """

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -1812,10 +1812,15 @@ class ManualFinalizationUpgradeTest(FeaturesTestBase):
         + [
             # The old binary aborts via vassert when it detects the cluster
             # advanced past the version it supports. Allow the rejection message
-            # plus the generic crash artifacts the intentional abort emits.
+            # plus the generic crash artifacts the intentional abort emits. Both
+            # crash-file variants are allowed: vassert records the crash, then
+            # the SIGILL handler from __builtin_trap() finds the writer already
+            # consumed and skips -- a benign double-tap on a single shard, not a
+            # real second crash.
             "Incompatible downgrade detected",
             "assert - Backtrace:",
             "Recorded crash reason to crash file",
+            "Skipping recording crash reason to crash file",
         ],
     )
     def test_downgrade_rejected_after_finalize(self):
@@ -1844,7 +1849,24 @@ class ManualFinalizationUpgradeTest(FeaturesTestBase):
         victim = self.redpanda.nodes[-1]
         self.redpanda.stop_node(victim)
         self.installer.install([victim], old_release)
-        self.redpanda.start_node(victim, expect_fail=True)
+
+        # The abort runs through vassert -> __builtin_trap() -> SIGILL, whose
+        # default disposition writes a core dump. Flushing a full core of a
+        # multi-GB process can take longer than the expect_fail termination
+        # timeout on a loaded CI host, leaving the process alive past the
+        # deadline and flaking the test (CORE-16744). Two mitigations, because
+        # whether a core dump can be suppressed depends on the CI host's
+        # core_pattern (file vs pipe): disable core dumps for this start (a
+        # deliberately aborted node needs no core -- the reason is already in the
+        # log and the crash file), and double the termination timeout as an
+        # environment-independent backstop. The HEAD rejoin below runs outside
+        # the block and still dumps core if it crashes unexpectedly.
+        with self.redpanda.core_dumps_disabled():
+            self.redpanda.start_node(
+                victim,
+                expect_fail=True,
+                timeout=2 * self.redpanda.node_ready_timeout_s,
+            )
         assert self.redpanda.search_log_node(
             victim, "Incompatible downgrade detected"
         ), "old binary should refuse to start after finalization"


### PR DESCRIPTION
Fixes: CORE-16744

## Problem

`ManualFinalizationUpgradeTest.test_downgrade_rejected_after_finalize` (added in #30814) flakes intermittently on `dev` with a misleading `NodeCrash`:

```
<NodeCrash docker-rp-18: Skipping recording crash reason to crash file on shard 0 (the writer has already been consumed by another crash)>
...
ducktape.errors.TimeoutError: Redpanda processes did not terminate on docker-rp-18 during startup as expected in 40 sec
```

It's genuinely flaky, not config-gated — the ticket records 1 FAIL / 13 PASS on the same commit in the same CI window. That's why it passed on the original PR but started surfacing on `dev`: it runs continuously across many parallel shards on loaded hosts, so a low-probability timing flake shows up every couple of days.

The test deliberately rolls a node back to an old release after finalization and expects it to abort on the `Incompatible downgrade detected` guard. That part works as intended — the flake is in how the aborted process is observed:

1. **Slow termination (the real trigger).** The abort runs `vassert` → `__builtin_trap()` → SIGILL, whose default disposition writes a **core dump**. `start_node(expect_fail=True)` only waits `node_ready_timeout_s` (40s) for the PID to disappear. On a loaded CI host, flushing a multi-GB core takes longer than that — the failing run shows the process still in `CoreDumping: 1` ~42s after the trap — so the wait times out and the test fails.

2. **Masking (why the surfaced error is confusing).** `raise_on_crash` runs *only after a failure* and greps logs for `crash reason to crash file`. A vassert deterministically emits **two** such lines on shard 0: `Recorded crash reason to crash file (vassert)` (allow-listed), then — because the trap's signal handler finds the crash writer already consumed — `Skipping recording crash reason to crash file` (**not** allow-listed). So once the timeout fails the test, the post-failure crash scan surfaces the benign "Skipping…" line as a `NodeCrash`, hiding the real `TimeoutError`. (This is a single-shard double-record by design — both lines are `shard 0` — not the multi-shard race originally hypothesized in the ticket.)

## Fix

Test hardening only; no product change.

- **`RedpandaService.core_dumps_disabled()` (new, pre-req commit).** A public context manager that disables core dumps for nodes started within the block (toggling `ResourceSettings.core_dump_limit` through a new property/setter, restored on exit). A deliberately-aborted node needs no core: the reason is already in the log and the crash_tracker `.crash` file, and CI decodes backtraces from stdout, so nothing diagnostic is lost.
- **Wrap the expected-abort start** in `core_dumps_disabled()` so it exits promptly where the host uses a file-based `core_pattern`.
- **Double the `expect_fail` timeout (→ 80s)** as an environment-independent backstop, since whether a core dump can be suppressed depends on the host `core_pattern` (file vs pipe). The two mitigations are complementary: one removes the core write, the other tolerates it.
- **Allow-list `Skipping recording crash reason to crash file`** so any future failure of this test reports its real cause instead of the masking `NodeCrash`.

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
