### PR TITLE
kafka: quiet and stop auditing broker-internal authz probes

### DIFF
--- a/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
+++ b/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
@@ -216,9 +216,14 @@ ss::future<response_ptr> offset_for_leader_epoch_handler::handle(
     std::vector<offset_for_leader_topic_result> unauthorized;
 
     // authorize
+    //
+    // cluster_action here is a fast path for brokers/superusers; a regular
+    // consumer is expected to fail it and fall through to the per-topic
+    // describe checks below. quiet the authz log for the expected failure.
     if (!ctx.authorized(
           security::acl_operation::cluster_action,
-          security::default_cluster_name)) {
+          security::default_cluster_name,
+          authz_quiet{true})) {
         auto it = std::stable_partition(
           request.data.topics.begin(),
           request.data.topics.end(),

--- a/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
+++ b/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
@@ -219,11 +219,14 @@ ss::future<response_ptr> offset_for_leader_epoch_handler::handle(
     //
     // cluster_action here is a fast path for brokers/superusers; a regular
     // consumer is expected to fail it and fall through to the per-topic
-    // describe checks below. quiet the authz log for the expected failure.
+    // describe checks below. quiet the authz log and skip auditing for
+    // this broker-internal probe on both allow and deny. the user-meaningful
+    // access decisions happen at the per-topic describe checks below.
     if (!ctx.authorized(
           security::acl_operation::cluster_action,
           security::default_cluster_name,
-          authz_quiet{true})) {
+          authz_quiet{true},
+          audit_authz_check::no)) {
         auto it = std::stable_partition(
           request.data.topics.begin(),
           request.data.topics.end(),

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -1905,11 +1905,20 @@ ss::future<response_ptr> init_producer_id_handler::handle(
               });
         }
 
+        // probe whether the client has write on any topic, as a fall back
+        // to the idempotent_write cluster ACL check below. quiet the authz
+        // log and skip auditing for this broker-internal probe on both
+        // allow and deny. the client asked for an idempotent producer ID,
+        // not to write to any specific topic, so neither outcome is a
+        // user-initiated access decision.
         bool permitted = false;
         auto topics = ctx.metadata_cache().all_topics();
         for (auto& tp_ns : topics) {
             permitted = ctx.authorized(
-              security::acl_operation::write, tp_ns.tp, authz_quiet{true});
+              security::acl_operation::write,
+              tp_ns.tp,
+              authz_quiet{true},
+              audit_authz_check::no);
             if (permitted) {
                 break;
             }


### PR DESCRIPTION
Fixes #21552

OffsetForLeaderEpoch's cluster_action probe is a fast path for brokers and superusers; a regular consumer is expected to fail it and fall through to the per-topic describe check. Today the failed probe emits an info-level log line and an audit event attributed to the client, both of which mislead operators and SIEM tooling about what actually happened. The same broker-internal-probe pattern exists in the metadata visibility filter and the init_producer_id any-topic write fall back.

This branch lands two commits:

1. `kafka: quiet cluster_action probe in OffsetForLeaderEpoch` — adds `authz_quiet{true}` to the probe, matching the existing pattern at the equivalent broker-internal probes in `metadata.cc` and `server.cc`.

2. `kafka: skip audit events for broker-internal authz probes` — pairs `authz_quiet{true}` with `audit_authz_check::no` at all three broker-internal probe sites (metadata visibility filter, init_producer_id any-topic write fall back, and the OffsetForLeaderEpoch cluster_action fast path). Without this, a single API call from a least-privilege client can fan out into O(topics) denied-access audit events, distorting the audit record and triggering recon-detection rules on benign traffic.

Gate-style call sites that return `topic_authorization_failed` to the client (e.g. the per-topic describe in `offset_for_leader_epoch.cc`) keep their existing audit behaviour.

Internal: CORE-5730, CORE-16762.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [x] v25.3.x

(Backport scope left for maintainer decision. Both fixes are low-risk single-argument additions; the audit-fidelity fix is the more impactful of the two for customers running with audit logging enabled.)

## UX Changes

None.

## Release Notes

### Bug Fixes

* OffsetForLeaderEpoch no longer logs a spurious authz failure for non-superuser consumers.
* Broker-internal authorisation probes (metadata visibility filtering, init_producer_id write fall back, OffsetForLeaderEpoch cluster_action fast path) no longer emit denied-access audit events attributed to the client. Previously, a request from a least-privilege client could generate O(topics) denied-access audit events that misrepresented broker-side checks as client-initiated access attempts.