### PR TITLE
[v26.1.x] `config/rpc`: add `enable_development_metrics`

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -586,6 +586,14 @@ configuration::configuration()
       "endpoint.",
       base_property::metadata{},
       false)
+  , enable_development_metrics(
+      *this,
+      "enable_development_metrics",
+      "Enable registering development-oriented metrics on the internal "
+      "`/metrics` endpoint, such as the per-method internal RPC latency "
+      "histograms.",
+      {.needs_restart = needs_restart::no},
+      false)
   , aggregate_metrics(
       *this,
       "aggregate_metrics",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -183,6 +183,7 @@ struct configuration final : public config_store {
     property<std::optional<ss::sstring>> cluster_id;
     property<bool> disable_metrics;
     property<bool> disable_public_metrics;
+    property<bool> enable_development_metrics;
     property<bool> aggregate_metrics;
     property<std::vector<ss::sstring>> enable_consumer_group_metrics;
     property<std::chrono::seconds> consumer_group_lag_collection_interval;

--- a/src/v/rpc/rpc_compiler.py
+++ b/src/v/rpc/rpc_compiler.py
@@ -56,6 +56,7 @@ RPC_TEMPLATE = """
 #include <array>
 #include <functional>
 #include <chrono>
+#include <optional>
 #include <tuple>
 #include <cstdint>
 
@@ -79,24 +80,13 @@ public:
     virtual ~{{service_name}}_service() noexcept = default;
 
     void setup_metrics() final {
-        namespace sm = ss::metrics;
-        auto service_label = sm::label("service");
-        auto method_label = sm::label("method");
-      {%- for method in methods %}
-        {
-            std::vector<ss::metrics::label_instance> labels{
-              service_label("{{service_name}}"),
-              method_label("{{method.name}}")};
-            _metrics.add_group(
-              prometheus_sanitize::metrics_name("internal_rpc"),
-              {sm::make_histogram(
-                "latency",
-                [this] { return _methods[{{loop.index-1}}].probes.latency_hist().internal_histogram_logform(); },
-                sm::description("Internal RPC service latency"),
-                labels),
-                }, {}, {sm::shard_label, method_label});
-        }
-      {%- endfor %}
+        // Watch `enable_development_metrics` so the per-method internal RPC
+        // latency metrics can be registered/deregistered at runtime without a
+        // restart.
+        _development_metrics_binding.emplace(
+          config::shard_local_cfg().enable_development_metrics.bind());
+        _development_metrics_binding->watch([this] { update_metrics(); });
+        update_metrics();
     }
 
     ss::scheduling_group& get_scheduling_group() override {
@@ -141,6 +131,35 @@ private:
     }
     {%- endfor %}
 
+    void update_metrics() {
+        _metrics.clear();
+        for (auto& m : _methods) {
+            m.probes.reset_latency_hist();
+        }
+        if (!config::shard_local_cfg().enable_development_metrics()) {
+            return;
+        }
+        namespace sm = ss::metrics;
+        auto service_label = sm::label("service");
+        auto method_label = sm::label("method");
+      {%- for method in methods %}
+        {
+            _methods[{{loop.index-1}}].probes.enable_latency_hist();
+            std::vector<ss::metrics::label_instance> labels{
+              service_label("{{service_name}}"),
+              method_label("{{method.name}}")};
+            _metrics.add_group(
+              prometheus_sanitize::metrics_name("internal_rpc"),
+              {sm::make_histogram(
+                "latency",
+                [this] { return _methods[{{loop.index-1}}].probes.latency_hist()->internal_histogram_logform(); },
+                sm::description("Internal RPC service latency"),
+                labels),
+                }, {}, {sm::shard_label, method_label});
+        }
+      {%- endfor %}
+    }
+
     ss::scheduling_group _sc;
     ss::smp_service_group _ssg;
     std::array<::rpc::method, {{methods|length}}> _methods{%raw %}{{{% endraw %}
@@ -151,6 +170,7 @@ private:
       {%- endfor %}
     {% raw %}}}{% endraw %};
     metrics::internal_metric_groups _metrics;
+    std::optional<config::binding<bool>> _development_metrics_binding;
 };
 
 class {{service_name}}_client_protocol {% if final_protocol %}final{% endif %} {

--- a/src/v/rpc/rpc_server.cc
+++ b/src/v/rpc/rpc_server.cc
@@ -281,8 +281,9 @@ ss::future<> rpc_server::dispatch_method_once(
                     }
                     return send_reply(ctx, std::move(reply_buf))
                       .finally([m, l = std::move(l)]() mutable {
-                          m->probes.latency_hist().record(
-                            l->compute_total_latency().count());
+                          if (auto* h = m->probes.latency_hist()) {
+                              h->record(l->compute_total_latency().count());
+                          }
                       });
                 });
           })

--- a/src/v/rpc/types.h
+++ b/src/v/rpc/types.h
@@ -37,6 +37,7 @@
 #include <cstdint>
 #include <iosfwd>
 #include <limits>
+#include <memory>
 #include <type_traits>
 #include <vector>
 
@@ -418,12 +419,21 @@ class method_probes {
 public:
     using hist_t = log_hist_internal;
 
-    hist_t& latency_hist() { return _latency_hist; }
-    const hist_t& latency_hist() const { return _latency_hist; }
+    hist_t* latency_hist() { return _latency_hist.get(); }
+    const hist_t* latency_hist() const { return _latency_hist.get(); }
+
+    /// Lazily allocate the latency histogram. Called from the generated
+    /// `setup_metrics` only when the metric is actually being registered.
+    void enable_latency_hist() {
+        if (!_latency_hist) {
+            _latency_hist = std::make_unique<hist_t>();
+        }
+    }
+
+    void reset_latency_hist() { _latency_hist.reset(); }
 
 private:
-    // roughly 208 bytes
-    hist_t _latency_hist;
+    std::unique_ptr<hist_t> _latency_hist{nullptr};
 };
 
 /// \brief most method implementations will be codegenerated

--- a/tests/rptest/tests/development_metrics_test.py
+++ b/tests/rptest/tests/development_metrics_test.py
@@ -1,0 +1,136 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import threading
+import time
+
+from ducktape.tests.test import TestContext
+from ducktape.utils.util import wait_until
+
+from rptest.clients.types import TopicSpec
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import MetricsEndpoint
+from rptest.services.rpk_producer import RpkProducer
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class DevelopmentMetricsToggleTest(RedpandaTest):
+    """
+    Toggles `enable_development_metrics` on and off repeatedly.
+    """
+
+    INTERNAL_RPC_LATENCY = "vectorized_internal_rpc_latency"
+
+    topics = (TopicSpec(partition_count=20, replication_factor=3),)
+
+    def __init__(self, test_context: TestContext):
+        super().__init__(test_context=test_context, num_brokers=3)
+
+    def _rpc_latency_series(self) -> int:
+        """Total internal_rpc_latency series across all nodes."""
+        total = 0
+        for node in self.redpanda.nodes:
+            for family in self.redpanda.metrics(
+                node,
+                metrics_endpoint=MetricsEndpoint.METRICS,
+                name=self.INTERNAL_RPC_LATENCY,
+            ):
+                total += len(family.samples)
+        return total
+
+    @cluster(num_nodes=4)
+    def test_toggle_under_load(self):
+        # This test intentionally writes a config record per toggle, which
+        # bloats the controller log well past the default guard. That growth is
+        # expected here, so raise the limit.
+        self.redpanda.set_expected_controller_records(50_000)
+
+        admin = Admin(self.redpanda)
+
+        # Sustained produce traffic to drive raft replication RPCs while we
+        # toggle. msg_count is large enough to outlast the toggling window.
+        producer = RpkProducer(
+            self.test_context,
+            self.redpanda,
+            self.topic,
+            msg_size=1024,
+            msg_count=10_000_000,
+            acks=-1,
+        )
+        producer.start()
+
+        stop = threading.Event()
+        toggle_errors: list[Exception] = []
+        toggle_count = [0]
+
+        def toggler():
+            value = True
+            while not stop.is_set():
+                try:
+                    admin.patch_cluster_config(
+                        upsert={"enable_development_metrics": value}
+                    )
+                except Exception as e:
+                    toggle_errors.append(e)
+                    return
+                value = not value
+                toggle_count[0] += 1
+                # Small backoff so we don't drown the controller in config
+                # writes, while still flipping fast enough to interleave with
+                # in-flight RPC recording.
+                time.sleep(0.05)
+
+        toggle_time = 30
+        t = threading.Thread(target=toggler, daemon=True)
+        t.start()
+        try:
+            # Concurrently scrape metrics so a read races register/deregister.
+            deadline = time.time() + toggle_time
+            while time.time() < deadline:
+                # Don't assert on the value (it's racing the toggler); just
+                # ensure scraping never errors / crashes a node.
+                self._rpc_latency_series()
+                time.sleep(0.5)
+        finally:
+            stop.set()
+            t.join(timeout=30)
+
+        assert not toggle_errors, f"toggler failed: {toggle_errors}"
+        assert toggle_count[0] > 10, f"expected many toggles, got {toggle_count[0]}"
+        self.logger.info(f"completed {toggle_count[0]} config toggles")
+
+        producer.stop()
+
+        # The cluster must have survived the toggling intact.
+        assert self.redpanda.all_up()
+        wait_until(
+            self.redpanda.healthy,
+            timeout_sec=60,
+            backoff_sec=2,
+            err_msg="cluster not healthy after toggling",
+        )
+
+        # Deterministic final state checks. Enabled => series are registered.
+        self.redpanda.set_cluster_config({"enable_development_metrics": True})
+        wait_until(
+            lambda: self._rpc_latency_series() > 0,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="internal_rpc_latency absent after enabling",
+        )
+
+        # Disabled => series are deregistered.
+        self.redpanda.set_cluster_config({"enable_development_metrics": False})
+        wait_until(
+            lambda: self._rpc_latency_series() == 0,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="internal_rpc_latency still present after disabling",
+        )


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30913
