### PR TITLE
dl/coordinator: bound pending-file memory under commit backlogs

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4602,6 +4602,16 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       10000,
       {.min = 1})
+  , datalake_coordinator_max_pending_files(
+      *this,
+      "datalake_coordinator_max_pending_files",
+      "Maximum number of pending data files a coordinator accumulates across "
+      "all of its topics before it sheds load, rejecting new files and offset "
+      "requests until it commits enough of the backlog. Bounds the "
+      "coordinator's pending-file memory.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      100000,
+      {.min = 1})
   , iceberg_disable_automatic_snapshot_expiry(
       *this,
       "iceberg_disable_automatic_snapshot_expiry",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4592,6 +4592,16 @@ configuration::configuration()
       "but may be useful if the Iceberg catalog does not support tags.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)
+  , datalake_coordinator_max_files_per_commit(
+      *this,
+      "datalake_coordinator_max_files_per_commit",
+      "Target maximum number of pending data files committed to an Iceberg "
+      "table in a single commit. A larger backlog is committed across multiple "
+      "passes to bound the memory used per commit. May be exceeded slightly to "
+      "avoid splitting files sharing a commit offset.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      10000,
+      {.min = 1})
   , iceberg_disable_automatic_snapshot_expiry(
       *this,
       "iceberg_disable_automatic_snapshot_expiry",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -769,6 +769,7 @@ struct configuration final : public config_store {
       iceberg_schema_case_insensitive;
     bounded_property<std::chrono::milliseconds> iceberg_target_lag_ms;
     property<bool> iceberg_disable_snapshot_tagging;
+    bounded_property<size_t> datalake_coordinator_max_files_per_commit;
     property<bool> iceberg_disable_automatic_snapshot_expiry;
     property<std::optional<ss::sstring>> iceberg_topic_name_dot_replacement;
     property<ss::sstring> iceberg_dlq_table_suffix;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -770,6 +770,7 @@ struct configuration final : public config_store {
     bounded_property<std::chrono::milliseconds> iceberg_target_lag_ms;
     property<bool> iceberg_disable_snapshot_tagging;
     bounded_property<size_t> datalake_coordinator_max_files_per_commit;
+    bounded_property<size_t> datalake_coordinator_max_pending_files;
     property<bool> iceberg_disable_automatic_snapshot_expiry;
     property<std::optional<ss::sstring>> iceberg_topic_name_dot_replacement;
     property<ss::sstring> iceberg_dlq_table_suffix;

--- a/src/v/datalake/coordinator/BUILD
+++ b/src/v/datalake/coordinator/BUILD
@@ -30,9 +30,11 @@ redpanda_cc_library(
     name = "coordinator",
     srcs = [
         "coordinator.cc",
+        "coordinator_probe.cc",
     ],
     hdrs = [
         "coordinator.h",
+        "coordinator_probe.h",
     ],
     implementation_deps = [
         ":catalog_config",
@@ -62,6 +64,7 @@ redpanda_cc_library(
         "//src/v/config",
         "//src/v/container:chunked_hash_map",
         "//src/v/container:chunked_vector",
+        "//src/v/metrics",
         "//src/v/model",
         "@abseil-cpp//absl/hash",
         "@seastar",

--- a/src/v/datalake/coordinator/BUILD
+++ b/src/v/datalake/coordinator/BUILD
@@ -304,6 +304,7 @@ redpanda_cc_library(
         ":translated_offset_range",
         "//src/v/base",
         "//src/v/container:chunked_hash_map",
+        "//src/v/container:chunked_vector",
         "//src/v/iceberg:manifest_entry",
         "//src/v/model",
         "//src/v/serde",

--- a/src/v/datalake/coordinator/coordinator.cc
+++ b/src/v/datalake/coordinator/coordinator.cc
@@ -167,6 +167,7 @@ coordinator::run_until_term_change(model::term_id term) {
     auto reset_term_as = ss::defer([this] { term_as_.reset(); });
     vlog(datalake_log.debug, "Running coordinator loop in term {}", term);
     while (raft.is_leader() && term == raft.term()) {
+        bool has_more_to_commit = false;
         // Make a copy of the topics to reconcile, in case the map changes
         // during this call.
         // TODO: probably worth building a more robust scheduler.
@@ -215,7 +216,9 @@ coordinator::run_until_term_change(model::term_id term) {
             }
             // TODO: apply table retention periodically too.
 
-            auto updates = std::move(commit_res.value());
+            auto commit = std::move(commit_res.value());
+            has_more_to_commit |= commit.has_more;
+            auto& updates = commit.updates;
             if (!updates.empty()) {
                 storage::record_batch_builder builder(
                   model::record_batch_type::datalake_coordinator,
@@ -245,6 +248,11 @@ coordinator::run_until_term_change(model::term_id term) {
                     break;
                 }
             }
+        }
+        if (has_more_to_commit) {
+            // A commit left more pending files; start the next pass immediately
+            // instead of idling for a full commit interval.
+            continue;
         }
         auto sleep_res = co_await ss::coroutine::as_future(
           ssx::sleep_abortable(commit_interval_(), as_, term_as));

--- a/src/v/datalake/coordinator/coordinator.cc
+++ b/src/v/datalake/coordinator/coordinator.cc
@@ -537,6 +537,31 @@ coordinator::sync_ensure_dlq_table_exists(
     co_return notify_waiters_and_erase(key, in_flight_dlq_, res_fut.get());
 }
 
+bool coordinator::has_too_many_pending_files() {
+    auto now = ss::lowres_clock::now();
+    if (
+      backpressured_as_of_.has_value()
+      && now - *backpressured_as_of_ < commit_interval_()) {
+        return true;
+    }
+    const auto threshold = max_pending_files_();
+    size_t pending = 0;
+    for (const auto& [_, tp_state] : stm_->state().topic_to_state) {
+        for (const auto& [pid, p_state] : tp_state.pid_to_pending_files) {
+            for (const auto& entry : p_state.pending_entries) {
+                pending += entry.data.files.size()
+                           + entry.data.dlq_files.size();
+                if (pending >= threshold) {
+                    backpressured_as_of_ = now;
+                    return true;
+                }
+            }
+        }
+    }
+    backpressured_as_of_ = std::nullopt;
+    return false;
+}
+
 ss::future<checked<std::nullopt_t, coordinator::errc>>
 coordinator::sync_add_files(
   model::topic_partition tp,
@@ -549,6 +574,13 @@ coordinator::sync_add_files(
     auto gate = maybe_gate();
     if (gate.has_error()) {
         co_return gate.error();
+    }
+    if (has_too_many_pending_files()) {
+        vlog(
+          datalake_log.debug,
+          "Rejecting request to add files for {}: too many pending files",
+          tp);
+        co_return errc::failed;
     }
     vlog(
       datalake_log.debug,
@@ -641,9 +673,20 @@ coordinator::sync_get_last_added_offsets(
     if (sync_res.has_error()) {
         co_return convert_stm_errc(sync_res.error());
     }
+    const bool backpressure = has_too_many_pending_files();
+    if (backpressure) {
+        vlog(
+          datalake_log.debug,
+          "Signaling backpressure for offsets request for {}: too many pending "
+          "files",
+          tp);
+        // Fall through to actually return offsets, even if we're under load.
+        // Returning a valid response despite backpressure allows translators
+        // to report lag.
+    }
     auto topic_it = stm_->state().topic_to_state.find(tp.topic);
     if (topic_it == stm_->state().topic_to_state.end()) {
-        co_return last_offsets{std::nullopt, std::nullopt};
+        co_return last_offsets{std::nullopt, std::nullopt, backpressure};
     }
     const auto& topic = topic_it->second;
     if (requested_topic_rev < topic.revision) {
@@ -658,7 +701,7 @@ coordinator::sync_get_last_added_offsets(
         if (topic.lifecycle_state == topic_state::lifecycle_state_t::purged) {
             // Coordinator is ready to accept files for the new topic revision,
             // but there is no stm record yet. Reply with "no offset".
-            co_return last_offsets{std::nullopt, std::nullopt};
+            co_return last_offsets{std::nullopt, std::nullopt, backpressure};
         }
 
         vlog(
@@ -681,16 +724,17 @@ coordinator::sync_get_last_added_offsets(
 
     auto partition_it = topic.pid_to_pending_files.find(tp.partition);
     if (partition_it == topic.pid_to_pending_files.end()) {
-        co_return last_offsets{std::nullopt, std::nullopt};
+        co_return last_offsets{std::nullopt, std::nullopt, backpressure};
     }
     const auto& prt_state = partition_it->second;
     if (prt_state.pending_entries.empty()) {
         co_return last_offsets{
-          prt_state.last_committed, prt_state.last_committed};
+          prt_state.last_committed, prt_state.last_committed, backpressure};
     }
     co_return last_offsets{
       prt_state.pending_entries.back().data.last_offset,
-      prt_state.last_committed};
+      prt_state.last_committed,
+      backpressure};
 }
 
 void coordinator::notify_leadership(std::optional<model::node_id> leader_id) {

--- a/src/v/datalake/coordinator/coordinator.cc
+++ b/src/v/datalake/coordinator/coordinator.cc
@@ -580,6 +580,7 @@ coordinator::sync_add_files(
           datalake_log.debug,
           "Rejecting request to add files for {}: too many pending files",
           tp);
+        probe_.increment_add_files_backpressure();
         co_return errc::failed;
     }
     vlog(
@@ -683,6 +684,7 @@ coordinator::sync_get_last_added_offsets(
         // Fall through to actually return offsets, even if we're under load.
         // Returning a valid response despite backpressure allows translators
         // to report lag.
+        probe_.increment_fetch_offsets_backpressure();
     }
     auto topic_it = stm_->state().topic_to_state.find(tp.topic);
     if (topic_it == stm_->state().topic_to_state.end()) {

--- a/src/v/datalake/coordinator/coordinator.h
+++ b/src/v/datalake/coordinator/coordinator.h
@@ -22,6 +22,10 @@
 #include "datalake/fwd.h"
 #include "model/fundamental.h"
 
+#include <seastar/core/lowres_clock.hh>
+
+#include <optional>
+
 namespace datalake::coordinator {
 
 // Public interface that provides access to the coordinator STM. Conceptually,
@@ -52,7 +56,8 @@ public:
       snapshot_remover& snapshot_remover,
       config::binding<std::chrono::milliseconds> commit_interval,
       config::binding<ss::sstring> default_partition_spec,
-      config::binding<bool> disable_snapshot_expiry)
+      config::binding<bool> disable_snapshot_expiry,
+      config::binding<size_t> max_pending_files)
       : stm_(std::move(stm))
       , topic_table_(topics)
       , type_resolver_(type_resolver)
@@ -62,7 +67,8 @@ public:
       , snapshot_remover_(snapshot_remover)
       , commit_interval_(std::move(commit_interval))
       , default_partition_spec_(std::move(default_partition_spec))
-      , disable_snapshot_expiry_(std::move(disable_snapshot_expiry)) {}
+      , disable_snapshot_expiry_(std::move(disable_snapshot_expiry))
+      , max_pending_files_(std::move(max_pending_files)) {}
 
     void start();
     ss::future<> stop_and_wait();
@@ -83,6 +89,9 @@ public:
     struct last_offsets {
         std::optional<kafka::offset> last_added_offset;
         std::optional<kafka::offset> last_committed_offset;
+        // Set when the coordinator has too many pending files: the offsets are
+        // still valid, but the translator should hold off on new translation.
+        bool backpressure{false};
     };
     ss::future<checked<last_offsets, errc>> sync_get_last_added_offsets(
       model::topic_partition tp, model::revision_id topic_rev);
@@ -166,6 +175,11 @@ private:
     // capabilities" out.
     bool using_glue_catalog() const;
 
+    // Returns whether the coordinator state has too many pending files, which
+    // is used as a signal to reject adding new files and instruct translators
+    // to not create new files.
+    bool has_too_many_pending_files();
+
     ss::shared_ptr<coordinator_stm> stm_;
     cluster::topic_table& topic_table_;
     type_resolver& type_resolver_;
@@ -176,6 +190,9 @@ private:
     config::binding<std::chrono::milliseconds> commit_interval_;
     config::binding<ss::sstring> default_partition_spec_;
     config::binding<bool> disable_snapshot_expiry_;
+    // Threshold of total pending files across this coordinator's topics above
+    // which it rejects new files.
+    config::binding<size_t> max_pending_files_;
 
     ss::gate gate_;
     ss::abort_source as_;
@@ -187,6 +204,10 @@ private:
 
     ensure_table_map_t in_flight_main_;
     ensure_table_map_t in_flight_dlq_;
+
+    // Timestamp at which the total number of files was computed to be above
+    // `max_pending_files_`, if ever.
+    std::optional<ss::lowres_clock::time_point> backpressured_as_of_;
 };
 inline fmt::iterator format_to(coordinator::errc e, fmt::iterator out) {
     switch (e) {

--- a/src/v/datalake/coordinator/coordinator.h
+++ b/src/v/datalake/coordinator/coordinator.h
@@ -15,6 +15,7 @@
 #include "config/property.h"
 #include "container/chunked_hash_map.h"
 #include "container/chunked_vector.h"
+#include "datalake/coordinator/coordinator_probe.h"
 #include "datalake/coordinator/file_committer.h"
 #include "datalake/coordinator/partition_state_override.h"
 #include "datalake/coordinator/snapshot_remover.h"
@@ -68,7 +69,8 @@ public:
       , commit_interval_(std::move(commit_interval))
       , default_partition_spec_(std::move(default_partition_spec))
       , disable_snapshot_expiry_(std::move(disable_snapshot_expiry))
-      , max_pending_files_(std::move(max_pending_files)) {}
+      , max_pending_files_(std::move(max_pending_files))
+      , probe_(stm_->raft()->ntp()) {}
 
     void start();
     ss::future<> stop_and_wait();
@@ -208,6 +210,8 @@ private:
     // Timestamp at which the total number of files was computed to be above
     // `max_pending_files_`, if ever.
     std::optional<ss::lowres_clock::time_point> backpressured_as_of_;
+
+    coordinator_probe probe_;
 };
 inline fmt::iterator format_to(coordinator::errc e, fmt::iterator out) {
     switch (e) {

--- a/src/v/datalake/coordinator/coordinator_manager.cc
+++ b/src/v/datalake/coordinator/coordinator_manager.cc
@@ -150,7 +150,8 @@ void coordinator_manager::start_managing(cluster::partition& p) {
       config::shard_local_cfg().iceberg_catalog_commit_interval_ms.bind(),
       config::shard_local_cfg().iceberg_default_partition_spec.bind(),
       config::shard_local_cfg()
-        .iceberg_disable_automatic_snapshot_expiry.bind());
+        .iceberg_disable_automatic_snapshot_expiry.bind(),
+      config::shard_local_cfg().datalake_coordinator_max_pending_files.bind());
     if (p.is_leader()) {
         crd->notify_leadership(self_);
     }

--- a/src/v/datalake/coordinator/coordinator_manager.cc
+++ b/src/v/datalake/coordinator/coordinator_manager.cc
@@ -63,7 +63,9 @@ ss::future<> coordinator_manager::start() {
       storage_,
       *catalog_,
       manifest_io_,
-      config::shard_local_cfg().iceberg_disable_snapshot_tagging.bind());
+      config::shard_local_cfg().iceberg_disable_snapshot_tagging.bind(),
+      config::shard_local_cfg()
+        .datalake_coordinator_max_files_per_commit.bind());
     snapshot_remover_ = std::make_unique<iceberg_snapshot_remover>(
       *catalog_, manifest_io_);
 

--- a/src/v/datalake/coordinator/coordinator_probe.cc
+++ b/src/v/datalake/coordinator/coordinator_probe.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "datalake/coordinator/coordinator_probe.h"
+
+#include "config/configuration.h"
+#include "metrics/metrics.h"
+#include "metrics/prometheus_sanitize.h"
+
+namespace datalake::coordinator {
+
+namespace {
+const auto namespace_label = metrics::make_namespaced_label("namespace");
+const auto topic_label = metrics::make_namespaced_label("topic");
+const auto partition_label = metrics::make_namespaced_label("partition");
+}; // namespace
+
+coordinator_probe::coordinator_probe(model::ntp ntp)
+  : _ntp(std::move(ntp)) {
+    if (!config::shard_local_cfg().disable_public_metrics()) {
+        _public_metrics.emplace();
+        register_backpressure_metrics();
+    }
+}
+
+void coordinator_probe::register_backpressure_metrics() {
+    namespace sm = ss::metrics;
+    std::vector<sm::label_instance> labels{
+      namespace_label(_ntp.ns()),
+      topic_label(_ntp.tp.topic()),
+      partition_label(_ntp.tp.partition()),
+    };
+    _public_metrics->add_group(
+      prometheus_sanitize::metrics_name("iceberg:coordinator"),
+      {
+        sm::make_counter(
+          "add_files_backpressure_rejections",
+          _add_files_backpressure,
+          sm::description(
+            "Number of add-files requests rejected because the coordinator had "
+            "too many pending files"),
+          labels)
+          .aggregate({
+            sm::shard_label,
+            partition_label,
+          }),
+        sm::make_counter(
+          "fetch_offsets_backpressure_signals",
+          _fetch_offsets_backpressure,
+          sm::description(
+            "Number of fetch-offsets requests that signaled backpressure "
+            "because the coordinator had too many pending files"),
+          labels)
+          .aggregate({
+            sm::shard_label,
+            partition_label,
+          }),
+      });
+}
+
+} // namespace datalake::coordinator

--- a/src/v/datalake/coordinator/coordinator_probe.h
+++ b/src/v/datalake/coordinator/coordinator_probe.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "metrics/metrics.h"
+#include "model/fundamental.h"
+
+namespace datalake::coordinator {
+
+class coordinator_probe final {
+public:
+    explicit coordinator_probe(model::ntp ntp);
+
+    // An add-files request was rejected because the coordinator had too many
+    // pending files.
+    void increment_add_files_backpressure() { ++_add_files_backpressure; }
+
+    // A fetch-offsets request signaled backpressure to the translator because
+    // the coordinator had too many pending files.
+    void increment_fetch_offsets_backpressure() {
+        ++_fetch_offsets_backpressure;
+    }
+
+private:
+    void register_backpressure_metrics();
+
+    model::ntp _ntp;
+    std::optional<metrics::public_metric_groups> _public_metrics;
+
+    size_t _add_files_backpressure = 0;
+    size_t _fetch_offsets_backpressure = 0;
+};
+
+} // namespace datalake::coordinator

--- a/src/v/datalake/coordinator/file_committer.h
+++ b/src/v/datalake/coordinator/file_committer.h
@@ -24,8 +24,18 @@ public:
         failed,
         shutting_down,
     };
-    virtual ss::future<
-      checked<chunked_vector<mark_files_committed_update>, errc>>
+
+    struct commit_result {
+        // Updates to replicate to the STM marking the committed files.
+        chunked_vector<mark_files_committed_update> updates;
+
+        // Whether the file committer left pending files uncommitted (e.g.
+        // there were too many to commit at once). Callers should commit again
+        // to continue making progress.
+        bool has_more{false};
+    };
+
+    virtual ss::future<checked<commit_result, errc>>
     commit_topic_files_to_catalog(model::topic, const topics_state&) const = 0;
 
     using purge_data = ss::bool_class<struct purge_data_tag>;

--- a/src/v/datalake/coordinator/frontend.cc
+++ b/src/v/datalake/coordinator/frontend.cc
@@ -102,7 +102,7 @@ ss::future<fetch_latest_translated_offset_reply> fetch_latest_offset(
     }
     auto& val = ret.value();
     co_return fetch_latest_translated_offset_reply{
-      val.last_added_offset, val.last_committed_offset};
+      val.last_added_offset, val.last_committed_offset, val.backpressure};
 }
 } // namespace
 

--- a/src/v/datalake/coordinator/iceberg_file_committer.cc
+++ b/src/v/datalake/coordinator/iceberg_file_committer.cc
@@ -439,8 +439,7 @@ get_cluster_uuid(storage::api& storage) {
 
 } // namespace
 
-ss::future<
-  checked<chunked_vector<mark_files_committed_update>, file_committer::errc>>
+ss::future<checked<file_committer::commit_result, file_committer::errc>>
 iceberg_file_committer::commit_topic_files_to_catalog(
   model::topic topic, const topics_state& state) const {
     vlog(datalake_log.debug, "Beginning commit for topic {}", topic);
@@ -455,12 +454,17 @@ iceberg_file_committer::commit_topic_files_to_catalog(
       tp_it == state.topic_to_state.end()
       || !tp_it->second.has_pending_entries()) {
         vlog(datalake_log.debug, "Topic {} has no pending entries", topic);
-        co_return chunked_vector<mark_files_committed_update>{};
+        co_return commit_result{};
     }
     // Make a copy up here so we don't have to worry about the state changing
     // underneath us. The STM should be robust enough to detect and reject
-    // concurrent changes that result in invalid state updates.
-    auto tp_state = tp_it->second.copy();
+    // concurrent changes that result in invalid state updates. The copy is
+    // bounded so that a large backlog is committed in chunks across multiple
+    // passes rather than materialized all at once. If the copy was bounded,
+    // report it so the caller can drain the remainder promptly.
+    bool topic_has_more = false;
+    auto tp_state = tp_it->second.copy_bounded(
+      max_files_per_commit_(), topic_has_more);
     auto topic_revision = tp_state.revision;
 
     // Main table (may not exist if all records so far were invalid and the
@@ -567,7 +571,7 @@ iceberg_file_committer::commit_topic_files_to_catalog(
           "No new data to mark committed for topic {} revision {}",
           topic,
           topic_revision);
-        co_return chunked_vector<mark_files_committed_update>{};
+        co_return commit_result{.has_more = topic_has_more};
     }
     chunked_vector<mark_files_committed_update> updates;
     updates.reserve(pending_commits.size());
@@ -642,7 +646,8 @@ iceberg_file_committer::commit_topic_files_to_catalog(
       main_table_files,
       dlq_table_files);
 
-    co_return updates;
+    co_return commit_result{
+      .updates = std::move(updates), .has_more = topic_has_more};
 }
 
 ss::future<checked<std::nullopt_t, file_committer::errc>>

--- a/src/v/datalake/coordinator/iceberg_file_committer.h
+++ b/src/v/datalake/coordinator/iceberg_file_committer.h
@@ -31,11 +31,13 @@ public:
       storage::api& storage,
       iceberg::catalog& catalog,
       iceberg::manifest_io& io,
-      config::binding<bool> disable_snapshot_tags)
+      config::binding<bool> disable_snapshot_tags,
+      config::binding<size_t> max_files_per_commit)
       : storage_(storage)
       , catalog_(catalog)
       , io_(io)
-      , disable_snapshot_tags_(std::move(disable_snapshot_tags)) {}
+      , disable_snapshot_tags_(std::move(disable_snapshot_tags))
+      , max_files_per_commit_(std::move(max_files_per_commit)) {}
     ~iceberg_file_committer() override = default;
 
     // Commits the given files to the table, creating the table if necessary.
@@ -54,8 +56,7 @@ public:
     // result in the calls doing IO to build Iceberg metadata and at least one
     // of the calls failing to commit to the table. Ensuring a single caller
     // avoids this potential waste of IO.
-    ss::future<checked<chunked_vector<mark_files_committed_update>, errc>>
-    commit_topic_files_to_catalog(
+    ss::future<checked<commit_result, errc>> commit_topic_files_to_catalog(
       model::topic, const topics_state&) const final;
 
     ss::future<checked<std::nullopt_t, errc>>
@@ -67,6 +68,7 @@ private:
     iceberg::catalog& catalog_;
     iceberg::manifest_io& io_;
     config::binding<bool> disable_snapshot_tags_;
+    config::binding<size_t> max_files_per_commit_;
 };
 
 } // namespace datalake::coordinator

--- a/src/v/datalake/coordinator/state.cc
+++ b/src/v/datalake/coordinator/state.cc
@@ -9,6 +9,11 @@
  */
 #include "datalake/coordinator/state.h"
 
+#include "container/chunked_vector.h"
+
+#include <optional>
+#include <queue>
+
 namespace datalake::coordinator {
 
 pending_entry pending_entry::copy() const {
@@ -34,6 +39,90 @@ topic_state topic_state::copy() const {
     result.lifecycle_state = lifecycle_state;
     result.total_kafka_bytes_processed = total_kafka_bytes_processed;
     result.last_committed_snapshot_id = last_committed_snapshot_id;
+    return result;
+}
+
+topic_state
+topic_state::copy_bounded(size_t max_files, bool& was_bounded) const {
+    was_bounded = false;
+    // Fast path: if every pending file already fits within the limit, there is
+    // nothing to bound, so skip building the merge below and copy as-is.
+    bool is_within_bound = [this, max_files] {
+        size_t total_files = 0;
+        for (const auto& [_, p_state] : pid_to_pending_files) {
+            for (const auto& e : p_state.pending_entries) {
+                total_files += e.data.files.size() + e.data.dlq_files.size();
+                if (total_files > max_files) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }();
+    if (is_within_bound) {
+        return copy();
+    }
+    topic_state result;
+    result.revision = revision;
+    result.lifecycle_state = lifecycle_state;
+    result.total_kafka_bytes_processed = total_kafka_bytes_processed;
+    result.last_committed_snapshot_id = last_committed_snapshot_id;
+
+    // Go through the partitions' state, ordering by offset added to the
+    // coordinator. Collect files in coordinator offset order so there's an
+    // exact offset-defined cutline that can be committed to the catalog that
+    // is represented by the returned topic state.
+    struct cursor {
+        model::partition_id pid;
+        const partition_state* p;
+        std::deque<pending_entry>::const_iterator iter;
+        std::deque<pending_entry>::const_iterator end;
+        model::offset offset() const { return iter->added_pending_at; }
+    };
+    auto offset_greater = [](const cursor& a, const cursor& b) {
+        return a.offset() > b.offset();
+    };
+    std::
+      priority_queue<cursor, chunked_vector<cursor>, decltype(offset_greater)>
+        fronts(offset_greater);
+    for (const auto& [id, p_state] : pid_to_pending_files) {
+        if (!p_state.pending_entries.empty()) {
+            fronts.push(
+              cursor{
+                .pid = id,
+                .p = &p_state,
+                .iter = p_state.pending_entries.begin(),
+                .end = p_state.pending_entries.end()});
+        }
+    }
+    std::optional<model::offset> accepted_up_to;
+    size_t files = 0;
+    while (!fronts.empty()) {
+        auto cur = fronts.top();
+        const auto& cur_entry = *cur.iter;
+        const size_t entry_files = cur_entry.data.files.size()
+                                   + cur_entry.data.dlq_files.size();
+        if (
+          accepted_up_to.has_value()
+          // Make sure we add all files added at `accepted_up_to` (ensuring if
+          // there were multiple added in the same offset we get them all),
+          // even if that means going above the file limit.
+          && cur_entry.added_pending_at != *accepted_up_to
+          && files + entry_files > max_files) {
+            break;
+        }
+        fronts.pop();
+        files += entry_files;
+        accepted_up_to = cur_entry.added_pending_at;
+        auto& p_result = result.pid_to_pending_files[cur.pid];
+        p_result.last_committed = cur.p->last_committed;
+        p_result.pending_entries.push_back(cur_entry.copy());
+        if (++cur.iter != cur.end) {
+            fronts.push(std::move(cur));
+        }
+    }
+    // If we stopped with cursors still queued, the limit left entries out.
+    was_bounded = !fronts.empty();
     return result;
 }
 

--- a/src/v/datalake/coordinator/state.h
+++ b/src/v/datalake/coordinator/state.h
@@ -137,6 +137,18 @@ struct topic_state
     std::optional<iceberg::snapshot_id> last_committed_snapshot_id;
     topic_state copy() const;
 
+    // Like copy() but limits the pending entries to only include up to the
+    // given number of files. The entries in the returned state are consistent
+    // with respect to a coordinator offset upper bound: if an entry at offset
+    // O is included, every entry (in any partition) at offset <= O is as well.
+    // This is required for Iceberg commit dedup, which uses the coordinator
+    // offset as a cursor.
+    //
+    // `was_bounded` is set to true if the limit left some pending entries out
+    // of the copy, so the caller knows a subsequent copy is needed to drain the
+    // remainder.
+    topic_state copy_bounded(size_t max_files, bool& was_bounded) const;
+
     // TODO: add table-wide metadata like Kafka schema id, Iceberg table uuid,
     // etc.
 };

--- a/src/v/datalake/coordinator/tests/coordinator_test.cc
+++ b/src/v/datalake/coordinator/tests/coordinator_test.cc
@@ -36,10 +36,9 @@ namespace {
 // No-op committer that doesn't commit anything.
 class noop_file_committer : public file_committer {
 public:
-    ss::future<checked<chunked_vector<mark_files_committed_update>, errc>>
-    commit_topic_files_to_catalog(
+    ss::future<checked<commit_result, errc>> commit_topic_files_to_catalog(
       model::topic, const topics_state&) const override {
-        co_return chunked_vector<mark_files_committed_update>{};
+        co_return commit_result{};
     }
 
     ss::future<checked<std::nullopt_t, errc>>
@@ -48,6 +47,54 @@ public:
     }
 
     ~noop_file_committer() override = default;
+};
+
+// Commits only the earliest pending entry of each partition per call, leaving
+// later entries pending. Mimics a committer bounded by a small chunk size, so
+// the coordinator must make multiple passes to fully drain a backlog.
+class chunked_file_committer : public file_committer {
+public:
+    ss::future<checked<commit_result, errc>> commit_topic_files_to_catalog(
+      model::topic t, const topics_state& state) const override {
+        chunked_vector<mark_files_committed_update> ret;
+        auto it = state.topic_to_state.find(t);
+        if (it == state.topic_to_state.end()) {
+            co_return commit_result{};
+        }
+        const auto& tstate = it->second;
+        bool has_more = false;
+        for (const auto& [pid, pstate] : tstate.pid_to_pending_files) {
+            if (pstate.pending_entries.empty()) {
+                continue;
+            }
+            // We commit only the front entry, so any later entries are left
+            // behind -- report that there is more to commit.
+            if (pstate.pending_entries.size() > 1) {
+                has_more = true;
+            }
+            const auto& front = pstate.pending_entries.front();
+            auto build_res = mark_files_committed_update::build(
+              state,
+              model::topic_partition{t, pid},
+              tstate.revision,
+              front.data.last_offset,
+              front.data.kafka_bytes_processed);
+            EXPECT_FALSE(build_res.has_error());
+            if (build_res.has_error()) {
+                co_return errc::failed;
+            }
+            ret.emplace_back(std::move(build_res.value()));
+        }
+        co_return commit_result{
+          .updates = std::move(ret), .has_more = has_more};
+    }
+
+    ss::future<checked<std::nullopt_t, errc>>
+    drop_table(const iceberg::table_identifier&, purge_data) const final {
+        co_return std::nullopt;
+    }
+
+    ~chunked_file_committer() override = default;
 };
 
 const model::topic topic_base{"test_topic"};
@@ -191,6 +238,9 @@ ss::future<> file_adder_loop(
 struct crd_test_param {
     bool with_chaos{false};
     bool noop_commits{true};
+    // Use a committer that commits only one entry per partition per call, so a
+    // backlog must be drained over multiple coordinator passes.
+    bool chunked_commits{false};
     std::chrono::milliseconds file_commit_interval{10ms};
 };
 
@@ -221,19 +271,19 @@ public:
               raft,
               config::mock_binding<std::chrono::seconds>(1s));
             node->start(std::move(builder)).get();
-            if (args.noop_commits) {
-                crds.at(id()) = std::make_unique<coordinator_node>(
-                  std::move(stm),
-                  std::make_unique<noop_file_committer>(),
-                  std::make_unique<noop_snapshot_remover>(),
-                  args.file_commit_interval);
+            std::unique_ptr<file_committer> committer;
+            if (args.chunked_commits) {
+                committer = std::make_unique<chunked_file_committer>();
+            } else if (args.noop_commits) {
+                committer = std::make_unique<noop_file_committer>();
             } else {
-                crds.at(id()) = std::make_unique<coordinator_node>(
-                  std::move(stm),
-                  std::make_unique<simple_file_committer>(),
-                  std::make_unique<noop_snapshot_remover>(),
-                  args.file_commit_interval);
+                committer = std::make_unique<simple_file_committer>();
             }
+            crds.at(id()) = std::make_unique<coordinator_node>(
+              std::move(stm),
+              std::move(committer),
+              std::make_unique<noop_snapshot_remover>(),
+              args.file_commit_interval);
         }
         for (auto& crd : crds) {
             crd->crd.start();
@@ -744,4 +794,57 @@ TEST_F(CoordinatorSleepingLoopTest, TestQuickShutdownOnLeadershipChange) {
     leader.crd.notify_leadership(std::nullopt);
     RPTEST_REQUIRE_EVENTUALLY(
       100ms, [&] { return !leader.crd.leader_loop_running(); });
+}
+
+class CoordinatorChunkedLoopTest : public CoordinatorTest {
+public:
+    crd_test_param param() const override {
+        return {
+          .with_chaos = false,
+          .noop_commits = false,
+          .chunked_commits = true,
+          // Long interval: if the loop slept between chunks, draining a backlog
+          // would take many seconds. The drain signal should let a single
+          // wake-up drain it promptly.
+          .file_commit_interval = 10s,
+        };
+    }
+};
+
+TEST_F(CoordinatorChunkedLoopTest, TestDrainsBacklogWithoutSleeping) {
+    // Stop the loop kicked off in SetUp and re-elect, so the loop is idle and
+    // we can stage the full backlog before a pass begins.
+    opt_ref leader_opt;
+    ASSERT_NO_FATAL_FAILURE(wait_for_leader(leader_opt).get());
+    leader_opt->get().stm.raft()->step_down("test").get();
+    ASSERT_NO_FATAL_FAILURE(wait_for_leader(leader_opt).get());
+    auto& leader = leader_opt->get();
+
+    const auto tp00 = tp(0, 0);
+    const model::revision_id rev0{1};
+    register_in_topic_tables(tp00.topic, rev0);
+    leader.ensure_table(tp00.topic, rev0);
+
+    // Stage a backlog of five entries while the loop is idle. The chunked
+    // committer commits only one entry per pass, so fully draining requires
+    // multiple passes.
+    auto add_res
+      = leader.crd
+          .sync_add_files(
+            tp00,
+            rev0,
+            make_pending_files(
+              {{0, 99}, {100, 199}, {200, 299}, {300, 399}, {400, 499}}))
+          .get();
+    ASSERT_FALSE(add_res.has_error()) << add_res.error();
+    wait_for_apply().get();
+
+    // Trigger a coordinator loop: despite the higher file commit interval, the
+    // backlog should be drained quickly.
+    leader.crd.notify_leadership(leader.stm.raft()->self().id());
+    RPTEST_REQUIRE_EVENTUALLY(5s, [&] {
+        auto tp_state = leader.stm.state().partition_state(tp00);
+        return tp_state.has_value()
+               && tp_state->get().last_committed == kafka::offset{499};
+    });
 }

--- a/src/v/datalake/coordinator/tests/coordinator_test.cc
+++ b/src/v/datalake/coordinator/tests/coordinator_test.cc
@@ -126,7 +126,8 @@ struct coordinator_node {
           *snapshot_remover,
           commit_interval_ms.bind(),
           default_partition_spec.bind(),
-          disable_snapshot_expiry.bind()) {}
+          disable_snapshot_expiry.bind(),
+          max_pending_files.bind()) {}
 
     ss::future<checked<std::nullopt_t, coordinator::errc>>
     remove_tombstone(const model::topic&, model::revision_id) {
@@ -146,6 +147,7 @@ struct coordinator_node {
     config::mock_property<ss::sstring> default_partition_spec{
       "(hour(redpanda.timestamp))"};
     config::mock_property<bool> disable_snapshot_expiry{false};
+    config::mock_property<size_t> max_pending_files{100000};
     cluster::data_migrations::migrated_resources mr;
     cluster::topic_table topic_table;
     datalake::binary_type_resolver type_resolver;
@@ -469,6 +471,48 @@ TEST_F(CoordinatorTest, TestAddFilesHappyPath) {
               c->stm.state(), tp00, std::nullopt, total_expected_00));
         }
     }
+}
+
+TEST_F(CoordinatorTest, TestBackpressure) {
+    opt_ref leader_opt;
+    ASSERT_NO_FATAL_FAILURE(wait_for_leader(leader_opt).get());
+    auto& leader = leader_opt->get();
+    // Shed load once two pending files accumulate.
+    leader.max_pending_files.update(2);
+    const auto tp00 = tp(0, 0);
+    const model::revision_id rev0{1};
+    register_in_topic_tables(tp00.topic, rev0);
+    leader.ensure_table(tp00.topic, rev0);
+
+    // First two single-file adds are under the threshold and accepted (the
+    // check sees the count from before the add).
+    for (const auto& v : {pairs_t{{0, 100}}, pairs_t{{101, 200}}}) {
+        auto add_res = leader.crd
+                         .sync_add_files(
+                           tp00,
+                           rev0,
+                           make_pending_files(v, /*with_file=*/true))
+                         .get();
+        ASSERT_FALSE(add_res.has_error()) << add_res.error();
+        wait_for_apply().get();
+    }
+
+    // Two pending files now meet the threshold, so further requests are shed.
+    auto add_res = leader.crd
+                     .sync_add_files(
+                       tp00,
+                       rev0,
+                       make_pending_files({{201, 300}}, /*with_file=*/true))
+                     .get();
+    ASSERT_TRUE(add_res.has_error());
+    ASSERT_EQ(add_res.error(), coordinator::errc::failed);
+
+    // Fetching offsets is not rejected: the offsets are still useful for lag
+    // reporting, so the request succeeds with the backpressure flag set to tell
+    // the translator to hold off on new translation.
+    auto last_res = leader.crd.sync_get_last_added_offsets(tp00, rev0).get();
+    ASSERT_FALSE(last_res.has_error()) << last_res.error();
+    ASSERT_TRUE(last_res.value().backpressure);
 }
 
 TEST_F(CoordinatorTest, TestLastAddedHappyPath) {

--- a/src/v/datalake/coordinator/tests/iceberg_file_committer_test.cc
+++ b/src/v/datalake/coordinator/tests/iceberg_file_committer_test.cc
@@ -96,7 +96,12 @@ public:
               return &feature_table.local();
           }())
       , manifest_io(remote(), bucket_name)
-      , committer(storage, catalog, manifest_io, config::mock_binding(false)) {
+      , committer(
+          storage,
+          catalog,
+          manifest_io,
+          config::mock_binding(false),
+          config::mock_binding<size_t>(10000)) {
         feature_table
           .invoke_on_all(
             [](features::feature_table& f) { f.testing_activate_all(); })
@@ -170,7 +175,7 @@ TEST_F(FileCommitterTest, TestCommit) {
     });
     auto res = committer.commit_topic_files_to_catalog(topic, state).get();
     ASSERT_FALSE(res.has_error());
-    auto updates = std::move(res.value());
+    auto updates = std::move(res.value().updates);
     ASSERT_EQ(updates.size(), 3);
     ASSERT_EQ(
       updates[0].tp, model::topic_partition(topic, model::partition_id{0}));
@@ -196,13 +201,13 @@ TEST_F(FileCommitterTest, TestMissingTable) {
     // is not there yet.
     auto res = committer.commit_topic_files_to_catalog(topic, state).get();
     ASSERT_FALSE(res.has_error());
-    ASSERT_EQ(res.value().size(), 0);
+    ASSERT_EQ(res.value().updates.size(), 0);
 
     create_table();
 
     res = committer.commit_topic_files_to_catalog(topic, state).get();
     ASSERT_FALSE(res.has_error());
-    ASSERT_TRUE(res.value().empty());
+    ASSERT_TRUE(res.value().updates.empty());
     load_res = catalog.load_table(table_ident).get();
     // The table should be created.
     ASSERT_FALSE(load_res.has_error());
@@ -214,7 +219,7 @@ TEST_F(FileCommitterTest, TestMissingTable) {
       {{{0, 100}}}, /*added_at=*/model::offset{1000}, /*with_files=*/true);
     res = committer.commit_topic_files_to_catalog(topic, state).get();
     ASSERT_FALSE(res.has_error());
-    ASSERT_EQ(1, res.value().size());
+    ASSERT_EQ(1, res.value().updates.size());
 
     load_res = catalog.load_table(table_ident).get();
     ASSERT_FALSE(load_res.has_error());
@@ -252,7 +257,7 @@ TEST_F(FileCommitterTest, TestMissingTopic) {
     topics_state state;
     auto res = committer.commit_topic_files_to_catalog(topic, state).get();
     ASSERT_FALSE(res.has_error());
-    ASSERT_TRUE(res.value().empty());
+    ASSERT_TRUE(res.value().updates.empty());
 
     // If our state didn't have the topic, we won't bother creating a table.
     auto load_res = catalog.load_table(table_ident).get();
@@ -388,7 +393,7 @@ TEST_F(FileCommitterTest, TestDeduplicateAllFiles) {
     ASSERT_TRUE(load_res.value().snapshots.has_value());
     ASSERT_EQ(1, load_res.value().snapshots.value().size());
 
-    auto updates = std::move(res.value());
+    auto updates = std::move(res.value().updates);
     ASSERT_EQ(updates.size(), 1);
     ASSERT_EQ(
       updates[0].tp, model::topic_partition(topic, model::partition_id{0}));
@@ -407,7 +412,7 @@ TEST_F(FileCommitterTest, TestDeduplicateAllFiles) {
     // This should result in a metadata update to be replicated, as presumably
     // the earlier one was not successfully replicated (e.g. because of a
     // leadership change).
-    updates = std::move(res.value());
+    updates = std::move(res.value().updates);
     ASSERT_EQ(updates.size(), 1);
     ASSERT_EQ(
       updates[0].tp, model::topic_partition(topic, model::partition_id{0}));
@@ -430,7 +435,7 @@ TEST_F(FileCommitterTest, TestDeduplicateSomeFiles) {
     ASSERT_TRUE(load_res.value().snapshots.has_value());
     ASSERT_EQ(1, load_res.value().snapshots.value().size());
 
-    auto updates = std::move(res.value());
+    auto updates = std::move(res.value().updates);
     ASSERT_EQ(updates.size(), 1);
     ASSERT_EQ(
       updates[0].tp, model::topic_partition(topic, model::partition_id{0}));
@@ -452,7 +457,7 @@ TEST_F(FileCommitterTest, TestDeduplicateSomeFiles) {
 
     // This should result in a metadata update to be replicated, as there are
     // new files committed.
-    updates = std::move(res.value());
+    updates = std::move(res.value().updates);
     ASSERT_EQ(updates.size(), 1);
     ASSERT_EQ(
       updates[0].tp, model::topic_partition(topic, model::partition_id{0}));
@@ -474,7 +479,7 @@ TEST_F(FileCommitterTest, TestDeduplicateFromAncestor) {
 
     auto res = committer.commit_topic_files_to_catalog(topic, state).get();
     ASSERT_FALSE(res.has_error());
-    auto updates = std::move(res.value());
+    auto updates = std::move(res.value().updates);
     ASSERT_EQ(updates.size(), 1);
     ASSERT_EQ(
       updates[0].tp, model::topic_partition(topic, model::partition_id{0}));
@@ -523,7 +528,7 @@ TEST_F(FileCommitterTest, TestDeduplicateFromAncestor) {
     res = committer.commit_topic_files_to_catalog(topic, state).get();
     ASSERT_FALSE(res.has_error());
 
-    updates = std::move(res.value());
+    updates = std::move(res.value().updates);
     ASSERT_EQ(updates.size(), 1);
     ASSERT_EQ(
       updates[0].tp, model::topic_partition(topic, model::partition_id{0}));
@@ -565,7 +570,11 @@ TEST_F(FileCommitterTest, TestDontDeduplicateFromOtherCluster) {
     auto new_storage = dummy_storage(feature_table);
     new_storage.set_cluster_uuid(new_cluster);
     iceberg_file_committer new_cluster_committer(
-      new_storage, catalog, manifest_io, config::mock_binding(false));
+      new_storage,
+      catalog,
+      manifest_io,
+      config::mock_binding(false),
+      config::mock_binding<size_t>(10000));
     res = new_cluster_committer
             .commit_topic_files_to_catalog(topic, new_cluster_state)
             .get();
@@ -725,4 +734,73 @@ TEST_F(FileCommitterTest, TestDontLoadMainTable) {
     };
     auto main_reqs = get_requests(is_main_request);
     ASSERT_EQ(0, main_reqs.size());
+}
+
+TEST_F(FileCommitterTest, TestChunkedCommitsAcrossPartitions) {
+    create_table();
+
+    constexpr int num_partitions = 3;
+    constexpr int adds_per_partition = 6;
+    constexpr size_t chunk_files = 2;
+    constexpr size_t total_files = num_partitions * adds_per_partition;
+
+    // Each (partition, round) is a separate control-topic batch with one file.
+    // Partition p uses a disjoint offset range so every file path is unique.
+    // Control offsets (added_pending_at) are assigned round-robin, so entries
+    // interleave across partitions (numbers below are control offsets):
+    //
+    //   p0:  0  3  6  9 12 15
+    //   p1:  1  4  7 10 13 16
+    //   p2:  2  5  8 11 14 17
+    //
+    // The chunking must ensure that when committing files from coordinator
+    // offset O, all files added at or before O are also committed.
+    topics_state state;
+    auto& tstate = state.topic_to_state[topic];
+    int64_t control_offset = 0;
+    for (int round = 0; round < adds_per_partition; ++round) {
+        for (int p = 0; p < num_partitions; ++p) {
+            const int64_t begin = (p * 100000) + (round * 100);
+            auto ranges = make_pending_files(
+              {{begin, begin + 99}}, /*with_file=*/true);
+            tstate.pid_to_pending_files[model::partition_id{p}]
+              .pending_entries.emplace_back(
+                pending_entry{
+                  .data = std::move(ranges[0]),
+                  .added_pending_at = model::offset{control_offset++}});
+        }
+    }
+
+    iceberg_file_committer chunked_committer(
+      storage,
+      catalog,
+      manifest_io,
+      config::mock_binding(false),
+      config::mock_binding<size_t>(chunk_files));
+
+    // Drain the backlog in chunks.
+    size_t passes = 0;
+    while (tstate.has_pending_entries()) {
+        ASSERT_LE(passes, total_files) << "drain did not converge";
+        ++passes;
+        auto res
+          = chunked_committer.commit_topic_files_to_catalog(topic, state).get();
+        ASSERT_FALSE(res.has_error());
+        auto updates = std::move(res.value().updates);
+        ASSERT_FALSE(updates.empty()) << "a pass committed nothing";
+        for (auto& update : updates) {
+            ASSERT_FALSE(update.apply(state).has_error());
+        }
+    }
+
+    // Chunking must actually have happened (not a single big commit).
+    ASSERT_GT(passes, 1u);
+
+    // The current snapshot should reference every file exactly once.
+    chunked_vector<ss::sstring> uris;
+    ASSERT_NO_FATAL_FAILURE(get_current_data_files(&uris));
+    ASSERT_EQ(uris.size(), total_files);
+    chunked_hash_set<ss::sstring> unique_uris;
+    unique_uris.insert(uris.begin(), uris.end());
+    ASSERT_EQ(unique_uris.size(), total_files);
 }

--- a/src/v/datalake/coordinator/tests/state_machine_test.cc
+++ b/src/v/datalake/coordinator/tests/state_machine_test.cc
@@ -46,6 +46,10 @@ struct coordinator_stm_fixture : stm_raft_fixture<stm> {
         return config::mock_binding<bool>(false);
     }
 
+    config::binding<size_t> max_pending_files() const {
+        return config::mock_binding<size_t>(100000);
+    }
+
     stm_shptrs_t create_stms(
       state_machine_manager_builder& builder,
       raft_node_instance& node) override {
@@ -70,7 +74,8 @@ struct coordinator_stm_fixture : stm_raft_fixture<stm> {
                 snapshot_remover,
                 commit_interval(),
                 default_partition_spec(),
-                disable_snapshot_expiry());
+                disable_snapshot_expiry(),
+                max_pending_files());
             coordinators[node.get_vnode()]->start();
             return ss::now();
         });

--- a/src/v/datalake/coordinator/tests/state_test_utils.h
+++ b/src/v/datalake/coordinator/tests/state_test_utils.h
@@ -27,8 +27,7 @@ namespace datalake::coordinator {
 // pending files as committed. Doesn't affect any external state.
 class simple_file_committer : public file_committer {
 public:
-    ss::future<checked<chunked_vector<mark_files_committed_update>, errc>>
-    commit_topic_files_to_catalog(
+    ss::future<checked<commit_result, errc>> commit_topic_files_to_catalog(
       model::topic t, const topics_state& state) const override {
         chunked_vector<mark_files_committed_update> ret;
         auto t_iter = std::ranges::find(
@@ -36,7 +35,7 @@ public:
           t,
           &std::pair<model::topic, topic_state>::first);
         if (t_iter == state.topic_to_state.end()) {
-            co_return ret;
+            co_return commit_result{};
         }
         // Mark the last file in each partition as committed.
         auto& t_state = t_iter->second;
@@ -54,7 +53,8 @@ public:
             EXPECT_FALSE(build_res.has_error());
             ret.emplace_back(std::move(build_res.value()));
         }
-        co_return ret;
+        // Commits everything in one pass, so never leaves a backlog.
+        co_return commit_result{.updates = std::move(ret)};
     }
 
     ss::future<checked<std::nullopt_t, errc>>

--- a/src/v/datalake/coordinator/tests/state_update_test.cc
+++ b/src/v/datalake/coordinator/tests/state_update_test.cc
@@ -456,3 +456,101 @@ TEST(StateUpdateTest, TestPartialReset) {
     // pid 2: created with last_committed.
     ASSERT_NO_FATAL_FAILURE(check_partition(state, tp2, 99, {}));
 }
+
+namespace {
+size_t total_pending_entries(const topic_state& ts) {
+    size_t n = 0;
+    for (const auto& [_, p_state] : ts.pid_to_pending_files) {
+        n += p_state.pending_entries.size();
+    }
+    return n;
+}
+
+// Appends a single one-file pending entry for partition `p` at control-topic
+// offset `added_at`.
+void add_entry(
+  topic_state& ts,
+  model::partition_id p,
+  int64_t begin,
+  int64_t end,
+  model::offset added_at) {
+    auto ranges = make_pending_files({{begin, end}}, /*with_file=*/true);
+    ts.pid_to_pending_files[p].pending_entries.emplace_back(
+      pending_entry{
+        .data = std::move(ranges[0]), .added_pending_at = added_at});
+}
+} // namespace
+
+// Each entry is added by a separate control-topic batch, so each carries a
+// distinct added_pending_at; with one file per entry, the file budget maps to
+// a number of entries.
+TEST(CopyBoundedTest, TruncatesByControlOffsetWatermark) {
+    topic_state ts;
+    ts.revision = rev;
+    for (int i = 0; i < 5; ++i) {
+        add_entry(ts, pid, i * 10, i * 10 + 9, model::offset{1000 + i});
+    }
+
+    // Fewer than available: truncated to a downward-closed prefix, metadata
+    // preserved, and reported as bounded.
+    bool bounded = false;
+    auto chunk = ts.copy_bounded(3, bounded);
+    EXPECT_EQ(total_pending_entries(chunk), 3);
+    EXPECT_TRUE(bounded);
+    EXPECT_EQ(chunk.revision, rev);
+
+    // Exactly the limit, and more than available (equivalent to copy()): not
+    // bounded, nothing left out.
+    EXPECT_EQ(total_pending_entries(ts.copy_bounded(5, bounded)), 5);
+    EXPECT_FALSE(bounded);
+    EXPECT_EQ(total_pending_entries(ts.copy_bounded(100, bounded)), 5);
+    EXPECT_FALSE(bounded);
+}
+
+// Regression test: a subset commit must be downward-closed by added_pending_at
+// across partitions. Otherwise the Iceberg dedup watermark (the max committed
+// added_pending_at) would later cause the excluded earlier entries to be
+// silently skipped and dropped from the table.
+TEST(CopyBoundedTest, IsDownwardClosedAcrossPartitions) {
+    const model::partition_id pid0{0};
+    const model::partition_id pid1{1};
+    topic_state ts;
+    // Control offsets interleave across partitions: pid0@10, pid1@11, pid0@12,
+    // pid1@13.
+    add_entry(ts, pid0, 0, 9, model::offset{10});
+    add_entry(ts, pid1, 0, 9, model::offset{11});
+    add_entry(ts, pid0, 10, 19, model::offset{12});
+    add_entry(ts, pid1, 10, 19, model::offset{13});
+
+    // Budget of 2 files: the watermark lands at offset 11, so each partition
+    // keeps exactly its first (earliest) entry. A per-partition prefix that
+    // ignored offset ordering would instead keep both of one partition's
+    // entries (including offset 12) while dropping the other's offset-11 entry.
+    bool bounded = false;
+    auto chunk = ts.copy_bounded(2, bounded);
+    EXPECT_TRUE(bounded);
+    ASSERT_EQ(total_pending_entries(chunk), 2);
+    ASSERT_TRUE(chunk.pid_to_pending_files.contains(pid0));
+    ASSERT_TRUE(chunk.pid_to_pending_files.contains(pid1));
+    const auto& p0 = chunk.pid_to_pending_files.at(pid0).pending_entries;
+    const auto& p1 = chunk.pid_to_pending_files.at(pid1).pending_entries;
+    ASSERT_EQ(p0.size(), 1);
+    ASSERT_EQ(p1.size(), 1);
+    EXPECT_EQ(p0.front().added_pending_at, model::offset{10});
+    EXPECT_EQ(p1.front().added_pending_at, model::offset{11});
+}
+
+// A single control-offset batch is committed all-or-nothing: splitting it would
+// leave same-offset entries below the watermark, which the dedup would drop.
+TEST(CopyBoundedTest, IncludesWholeBatchEvenWhenOverLimit) {
+    topic_state ts;
+    // Five entries sharing one added_pending_at (one add_files_update batch).
+    for (int i = 0; i < 5; ++i) {
+        add_entry(ts, pid, i * 10, i * 10 + 9, model::offset{1000});
+    }
+    bool bounded = false;
+    EXPECT_EQ(total_pending_entries(ts.copy_bounded(1, bounded)), 5);
+    // The whole same-offset batch is included, so nothing is left over and the
+    // copy is not reported as bounded.
+    EXPECT_FALSE(bounded);
+}

--- a/src/v/datalake/coordinator/types.h
+++ b/src/v/datalake/coordinator/types.h
@@ -238,7 +238,7 @@ struct add_translated_data_files_request
 struct fetch_latest_translated_offset_reply
   : serde::envelope<
       fetch_latest_translated_offset_reply,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
     fetch_latest_translated_offset_reply() = default;
     explicit fetch_latest_translated_offset_reply(errc err)
@@ -249,6 +249,14 @@ struct fetch_latest_translated_offset_reply
       : last_added_offset(last_added)
       , last_iceberg_committed_offset(last_committed)
       , errc(errc::ok) {}
+    explicit fetch_latest_translated_offset_reply(
+      std::optional<kafka::offset> last_added,
+      std::optional<kafka::offset> last_committed,
+      bool backpressure)
+      : last_added_offset(last_added)
+      , last_iceberg_committed_offset(last_committed)
+      , errc(errc::ok)
+      , backpressure(backpressure) {}
 
     // The offset of the latest data file added to the coordinator.
     std::optional<kafka::offset> last_added_offset;
@@ -258,13 +266,23 @@ struct fetch_latest_translated_offset_reply
     // If not ok, the request processing has a problem.
     errc errc;
 
+    // The coordinator has too many pending files. The offsets above are still
+    // valid (and worth reporting as lag), but the translator should hold off on
+    // translating new data until the coordinator drains its backlog.
+    bool backpressure{false};
+
     fmt::iterator format_to(fmt::iterator it) const {
         return fmt::format_to(
-          it, "{{errc: {}, offset: {}}}", errc, last_added_offset);
+          it,
+          "{{errc: {}, offset: {}, backpressure: {}}}",
+          errc,
+          last_added_offset,
+          backpressure);
     }
 
     auto serde_fields() {
-        return std::tie(last_added_offset, errc, last_iceberg_committed_offset);
+        return std::tie(
+          last_added_offset, errc, last_iceberg_committed_offset, backpressure);
     }
 };
 

--- a/src/v/datalake/translation/deps.cc
+++ b/src/v/datalake/translation/deps.cc
@@ -600,6 +600,10 @@ public:
         _probe->update_commit_offset_lag(new_lag);
     }
 
+    void report_backpressure_backoff() final {
+        _probe->increment_backpressure_backoff();
+    }
+
 private:
     scheduling::clock::duration compute_target_lag() const {
         // todo: In addition to integrating with config subsystem, an additional

--- a/src/v/datalake/translation/deps.h
+++ b/src/v/datalake/translation/deps.h
@@ -301,6 +301,10 @@ public:
     // Report and update the lag of data that has yet to be committed.
     virtual void report_commit_lag(int64_t new_lag) = 0;
 
+    // Note that translation backed off because the coordinator signaled
+    // backpressure (too many pending files).
+    virtual void report_backpressure_backoff() = 0;
+
     static std::unique_ptr<translation_context>
     make_default_translation_context(
       local_path,

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -219,6 +219,26 @@ partition_translator::fetch_translation_offsets(retry_chain_node& rcn) {
         current_translation_lto = checkpointed_lto;
     }
 
+    translation_offsets offsets;
+    offsets.coordinator_lto = checkpointed_lto;
+
+    if (result.backpressure) {
+        // The coordinator is shedding load for this topic. We've reported lag
+        // and reconciled the translated offset above, but don't proceed with
+        // translation.
+        _translation_ctx->report_backpressure_backoff();
+        static constexpr auto log_freq = 30s;
+        thread_local static ss::logger::rate_limit rate(log_freq);
+        vloglr(
+          datalake_log,
+          ss::log_level::info,
+          rate,
+          "[{}] Coordinator applying backpressure (too many pending files); "
+          "backing off translation",
+          _data_source->ntp());
+        co_return offsets;
+    }
+
     static constexpr auto data_wait_duration = 3s;
     // Wait until some data is ready to be translated.
     auto maybe_begin_offset = co_await _data_source->wait_for_data_to_translate(
@@ -226,8 +246,6 @@ partition_translator::fetch_translation_offsets(retry_chain_node& rcn) {
       ss::lowres_clock::now() + data_wait_duration,
       _as);
 
-    translation_offsets offsets;
-    offsets.coordinator_lto = checkpointed_lto;
     if (!maybe_begin_offset) {
         vlog(
           _logger.trace,

--- a/src/v/datalake/translation/tests/partition_translator_tests.cc
+++ b/src/v/datalake/translation/tests/partition_translator_tests.cc
@@ -70,6 +70,18 @@ public:
         return _error_on_add_translated_files;
     }
 
+    void set_coordinator_backpressure(bool b) { _coordinator_backpressure = b; }
+
+    bool coordinator_backpressure() const { return _coordinator_backpressure; }
+
+    void note_backpressure_rejection() { _backpressure_rejections++; }
+
+    ss::future<> wait_for_backpressure_rejections(
+      size_t n, std::chrono::seconds timeout = 10s) {
+        RPTEST_REQUIRE_EVENTUALLY_CORO(
+          timeout, [n, this] { return _backpressure_rejections >= n; });
+    }
+
     // translation error propagation
     void set_error_on_translation(bool error) { _error_on_translation = error; }
 
@@ -129,6 +141,8 @@ private:
     kafka::offset _max_translatable_offset{};
 
     bool _error_on_add_translated_files{false};
+    bool _coordinator_backpressure{false};
+    size_t _backpressure_rejections{0};
     bool _error_on_translation{false};
     bool _error_on_flush{false};
     size_t _num_translation_attempts{0};
@@ -247,6 +261,10 @@ public:
         if (it != _last_added_offsets.end()) {
             reply.last_added_offset = it->second;
         }
+        if (_test_ctx.coordinator_backpressure()) {
+            _test_ctx.note_backpressure_rejection();
+            reply.backpressure = true;
+        }
         co_return reply;
     }
 
@@ -339,6 +357,8 @@ public:
     void report_translation_lag(int64_t) final {}
 
     void report_commit_lag(int64_t) final {}
+
+    void report_backpressure_backoff() final {}
 
 private:
     size_t _translated_bytes{0};
@@ -469,6 +489,22 @@ TEST_F_CORO(partition_translator_fixture, test_coordinator_retries) {
     // Ensure translation does not make any progress
     ASSERT_LT_CORO(test_ctx.max_translated_offset(), kafka::offset{0});
     test_ctx.set_error_on_add_translated_files(false);
+    co_await test_ctx.wait_for_translation_attempts(10);
+    ASSERT_GT_CORO(test_ctx.max_translated_offset(), kafka::offset{0});
+}
+
+TEST_F_CORO(partition_translator_fixture, test_coordinator_backpressure) {
+    auto& test_ctx = make_test_context();
+    test_ctx.set_coordinator_backpressure(true);
+    co_await add_translator(test_ctx);
+
+    // Wait until the translator has actually been rejected a few times, so we
+    // know it polled and backed off rather than simply not having started yet.
+    co_await test_ctx.wait_for_backpressure_rejections(3);
+    ASSERT_LT_CORO(test_ctx.max_translated_offset(), kafka::offset{0});
+
+    // Once the coordinator stops shedding load, translation resumes.
+    test_ctx.set_coordinator_backpressure(false);
     co_await test_ctx.wait_for_translation_attempts(10);
     ASSERT_GT_CORO(test_ctx.max_translated_offset(), kafka::offset{0});
 }

--- a/src/v/datalake/translation/translation_probe.cc
+++ b/src/v/datalake/translation/translation_probe.cc
@@ -33,7 +33,32 @@ translation_probe::translation_probe(model::ntp ntp)
         register_invalid_record_metric();
         register_throughput_metrics();
         register_lag_metrics();
+        register_backpressure_metric();
     }
+}
+
+void translation_probe::register_backpressure_metric() {
+    namespace sm = ss::metrics;
+    std::vector<sm::label_instance> labels{
+      namespace_label(_ntp.ns()),
+      topic_label(_ntp.tp.topic()),
+      partition_label(_ntp.tp.partition()),
+    };
+    _public_metrics->add_group(
+      group_name,
+      {
+        sm::make_counter(
+          "backpressure_backoffs",
+          _backpressure_backoffs,
+          sm::description(
+            "Number of times translation backed off because the coordinator "
+            "signaled backpressure (too many pending files)"),
+          labels)
+          .aggregate({
+            sm::shard_label,
+            partition_label,
+          }),
+      });
 }
 
 void translation_probe::register_lag_metrics() {

--- a/src/v/datalake/translation/translation_probe.h
+++ b/src/v/datalake/translation/translation_probe.h
@@ -74,11 +74,16 @@ public:
         _commit_offset_lag = new_lag;
     }
 
+    // Translation backed off because the coordinator signaled backpressure
+    // (too many pending files).
+    void increment_backpressure_backoff() { _backpressure_backoffs += 1; }
+
 private:
     void register_created_files_metrics();
     void register_invalid_record_metric();
     void register_throughput_metrics();
     void register_lag_metrics();
+    void register_backpressure_metric();
 
 private:
     model::ntp _ntp;
@@ -97,6 +102,8 @@ private:
     size_t _num_failed_kafka_schema_resolution = 0;
     size_t _num_failed_data_translation = 0;
     size_t _num_failed_iceberg_schema_resolution = 0;
+
+    size_t _backpressure_backoffs = 0;
 
     // NOTE: the accounting for bytes here is not strictly accurate and should
     // only be used to get a rough sense for translation throughput.

--- a/tests/rptest/tests/datalake/coordinator_backpressure_test.py
+++ b/tests/rptest/tests/datalake/coordinator_backpressure_test.py
@@ -1,0 +1,206 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Licensed as a Redpanda Enterprise file under the Redpanda Community
+# License (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+import time
+
+from ducktape.mark import matrix
+from ducktape.utils.util import wait_until
+
+from rptest.clients.admin import v2 as admin_v2
+from rptest.services.catalog_service import CatalogType
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import MetricsEndpoint, SISettings
+from rptest.tests.datalake.datalake_services import DatalakeServices
+from rptest.tests.datalake.datalake_verifier import DatalakeVerifier
+from rptest.tests.datalake.query_engine_base import QueryEngineType
+from rptest.tests.datalake.utils import supported_storage_types
+from rptest.tests.redpanda_test import RedpandaTest
+
+ADD_FILES_BACKPRESSURE_METRIC = (
+    "redpanda_iceberg_coordinator_add_files_backpressure_rejections_total"
+)
+FETCH_OFFSETS_BACKPRESSURE_METRIC = (
+    "redpanda_iceberg_coordinator_fetch_offsets_backpressure_signals_total"
+)
+# Translator-side counter of how often translation backed off in response to
+# coordinator backpressure.
+TRANSLATION_BACKOFF_METRIC = "redpanda_iceberg_translation_backpressure_backoffs_total"
+# Total parquet files created by translation.
+FILES_CREATED_METRIC = "redpanda_iceberg_translation_files_created_total"
+
+# Coordinator sheds load once this many pending files accumulate.
+MAX_PENDING_FILES = 10
+
+
+class CoordinatorBackpressureTest(RedpandaTest):
+    """
+    End-to-end check that datalake coordinator backpressure behaves sensibly:
+    when a backlog of pending files builds up faster than it can commit, the
+    coordinator sheds load, translators back off in response, and the backlog
+    still commits to the catalog correctly.
+    """
+
+    def __init__(self, test_ctx, *args, **kwargs):
+        super(CoordinatorBackpressureTest, self).__init__(
+            test_ctx,
+            num_brokers=1,
+            si_settings=SISettings(test_context=test_ctx),
+            extra_rp_conf={
+                "iceberg_enabled": "true",
+                # Translate eagerly, but commit rarely and only a file at a
+                # time, so a backlog of pending files accumulates between commits
+                # far faster than it drains and trips backpressure.
+                "iceberg_target_lag_ms": 1000,
+                "iceberg_catalog_commit_interval_ms": 10000,
+                "datalake_coordinator_max_files_per_commit": 1,
+                # Shed load once a small backlog of pending files accumulates.
+                "datalake_coordinator_max_pending_files": MAX_PENDING_FILES,
+            },
+            *args,
+            **kwargs,
+        )
+        self.test_ctx = test_ctx
+        self.topic_name = "test"
+
+    def setUp(self):
+        # redpanda will be started by DatalakeServices
+        pass
+
+    def metric_sum(self, metric: str) -> float:
+        """
+        Returns the total value of a coordinator backpressure counter across all
+        nodes and partitions.
+        """
+        samples = self.redpanda.metrics_sample(
+            metric, self.redpanda.nodes, MetricsEndpoint.PUBLIC_METRICS
+        )
+        if not samples:
+            return 0
+        return sum(s.value for s in samples.samples)
+
+    def pending_file_count(self) -> int:
+        """
+        Returns the number of pending data files (including DLQ files) the
+        coordinator is tracking for the topic, read from the coordinator state
+        admin endpoint. This mirrors what the coordinator counts when deciding
+        to shed load.
+        """
+        admin = admin_v2.Admin(self.redpanda)
+        request = admin_v2.datalake_pb.GetCoordinatorStateRequest(
+            topics_filter=[self.topic_name]
+        )
+        response = admin.datalake().get_coordinator_state(request)
+        total = 0
+        for t_state in response.state.topic_states.values():
+            for p_state in t_state.partition_states.values():
+                for entry in p_state.pending_entries:
+                    total += len(entry.data.data_files) + len(entry.data.dlq_files)
+        return total
+
+    @cluster(num_nodes=4)
+    @matrix(cloud_storage_type=supported_storage_types())
+    def test_backpressure_on_pending_backlog(self, cloud_storage_type):
+        """
+        A burst across many partitions drives the pending-file backlog to the
+        cap; the coordinator sheds load and translators back off in response.
+        Once the pressure is relieved, the whole backlog commits to the table
+        exactly once and the backlog drains.
+        """
+        partition_count = 30
+        with DatalakeServices(
+            self.test_ctx,
+            redpanda=self.redpanda,
+            include_query_engines=[QueryEngineType.SPARK],
+            catalog_type=CatalogType.REST_JDBC,
+        ) as dl:
+            dl.create_iceberg_enabled_topic(self.topic_name, partitions=partition_count)
+            spark = dl.spark()
+
+            # A burst across many partitions floods translation faster than the
+            # coordinator commits, so a backlog of pending files builds up.
+            dl.produce_to_topic(self.topic_name, msg_size=1024, msg_count=30000)
+
+            # The coordinator sheds load once the backlog crosses the cap.
+            wait_until(
+                lambda: self.metric_sum(FETCH_OFFSETS_BACKPRESSURE_METRIC) > 0,
+                timeout_sec=30,
+                backoff_sec=1,
+                err_msg="coordinator never applied backpressure",
+            )
+
+            # Translators respect the signal by backing off rather than spinning.
+            wait_until(
+                lambda: self.metric_sum(TRANSLATION_BACKOFF_METRIC) > 0,
+                timeout_sec=30,
+                backoff_sec=1,
+                err_msg="no translator backed off in response to backpressure",
+            )
+
+            # The backlog is visible at (or above) the cap via the coordinator
+            # state endpoint.
+            wait_until(
+                lambda: self.pending_file_count() >= MAX_PENDING_FILES,
+                timeout_sec=15,
+                backoff_sec=1,
+                err_msg="pending file backlog never reached the backpressure threshold",
+            )
+
+            # Backpressure throttles the pipeline but must not stall commits:
+            # the coordinator should keep landing files in the Iceberg table.
+            # Feed the pipeline a bit so there is new data to commit if needed.
+            committed_before = spark.count_parquet_files("redpanda", self.topic_name)
+            dl.produce_to_topic(self.topic_name, msg_size=1024, msg_count=100)
+            wait_until(
+                lambda: spark.count_parquet_files("redpanda", self.topic_name)
+                > committed_before,
+                timeout_sec=60,
+                backoff_sec=2,
+                err_msg="coordinator stopped committing to iceberg under backpressure",
+            )
+
+            # Under sustained backpressure the pipeline should settle: with
+            # translators blocked, neither the pending-file backlog nor the
+            # number of parquet files translated keeps growing. Both should
+            # hold steady over a window shorter than the commit interval.
+            def quiesced():
+                before = (
+                    self.pending_file_count(),
+                    self.metric_sum(FILES_CREATED_METRIC),
+                )
+                time.sleep(5)
+                after = (
+                    self.pending_file_count(),
+                    self.metric_sum(FILES_CREATED_METRIC),
+                )
+                return before == after
+
+            wait_until(
+                quiesced,
+                timeout_sec=60,
+                backoff_sec=1,
+                err_msg="pending/translated file counts never stabilized under backpressure",
+            )
+
+            # Relieve the pressure so the backlog drains promptly.
+            self.redpanda.set_cluster_config(
+                {
+                    "iceberg_catalog_commit_interval_ms": 1000,
+                    "datalake_coordinator_max_files_per_commit": 10000,
+                    "datalake_coordinator_max_pending_files": 1000000,
+                }
+            )
+            wait_until(
+                lambda: self.pending_file_count() == 0,
+                timeout_sec=30,
+                backoff_sec=1,
+                err_msg="pending file backlog never drained",
+            )
+
+            # The whole backlog commits to the table exactly once (no gaps or
+            # duplicates).
+            DatalakeVerifier.oneshot(self.redpanda, self.topic_name, spark)

--- a/tools/type-checking/type-check-strictness.json
+++ b/tools/type-checking/type-check-strictness.json
@@ -109,6 +109,7 @@
         "rptest/tests/datalake/batching_test.py",
         "rptest/tests/datalake/blocked_catalog_test.py",
         "rptest/tests/datalake/cluster_restore_test.py",
+        "rptest/tests/datalake/coordinator_backpressure_test.py",
         "rptest/tests/datalake/coordinator_retention_test.py",
         "rptest/tests/datalake/databricks_test.py",
         "rptest/tests/datalake/datalake_dlq_test.py",


### PR DESCRIPTION
When an Iceberg topic accumulates a large backlog of uncommitted data files, e.g. the catalog has been rejecting the coordinator's commits for a while, the coordinator can build up an unbounded set of pending files in its replicated state. Reconciling that backlog forces it to materialize the whole set at once (the per-commit state copy plus the accumulated Iceberg file list), which can OOM the broker.

This series bounds that memory along two independent axes:

1. Per-commit: commit the backlog in fixed-size chunks instead of all at once.
2. Aggregate: cap how large the pending set is allowed to grow in the first place.

High level changes:

- add topic_state::copy_bounded(): a copy() variant that returns at most N pending files, keeping a batch's files together so a chunk is committed atomically.
- commit pending files in bounded chunks: drain the backlog over multiple passes via copy_bounded().
- back off translation under coordinator backpressure: translators treat a new too_many_pending_files error as a deschedule-and-back-off signal rather than a retryable error.
- shed load when a coordinator has too many pending files: reject add-files/fetch-offset once the aggregate pending count crosses the threshold, until the backlog drains.

The approach taken here is relatively simple, opting to go with tunable count-based backpressure, rather than more rigorous memory-based backpressure. This is mostly because the implementation was easier, though the mechanisms for backpressure should be reusable if we decide to change this in the future.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes

### Improvements

* The Iceberg Topics Coordinator will now commit to the Iceberg catalog in chunks, avoiding an OOM when the catalog has rejected Redpanda commits for prolonged periods of time.
* Iceberg Topics will stop creating new parquet files if there is a large backlog of files not yet committed to the Iceberg catalog. This helps avoid an OOM when the catalog has rejected Redpanda commits for prolonged periods of time.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
