### PR TITLE
CORE-16645 Schema Migrations: integrate reconciler for schema replication

### DIFF
--- a/src/v/cluster_link/schema_registry_sync/BUILD
+++ b/src/v/cluster_link/schema_registry_sync/BUILD
@@ -23,10 +23,12 @@ redpanda_cc_library(
     srcs = [
         "mirroring_task.cc",
         "reconciler.cc",
+        "scope.cc",
     ],
     hdrs = [
         "mirroring_task.h",
         "reconciler.h",
+        "scope.h",
     ],
     implementation_deps = [
         "//src/v/base",

--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
@@ -12,12 +12,16 @@
 #include "cluster_link/schema_registry_sync/mirroring_task.h"
 
 #include "cluster_link/link.h"
+#include "cluster_link/schema_registry_sync/reconciler.h"
+#include "cluster_link/schema_registry_sync/scope.h"
+#include "config/configuration.h"
 #include "container/chunked_hash_map.h"
 #include "container/chunked_vector.h"
 #include "model/namespace.h"
 #include "pandaproxy/schema_registry/types.h"
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/loop.hh>
 #include <seastar/util/defer.hh>
 
 #include <utility>
@@ -116,38 +120,121 @@ bool mirroring_task::should_long_sync() const {
 
 model::task_status_report mirroring_task::get_status_report() const {
     auto report = task::get_status_report();
-    // The sync runs only on the shard leading _schemas/0; other shards keep the
-    // task stopped with default (empty) status. Emitting that empty status
-    // would let a non-leader's report win the cross-shard/node admin
-    // aggregation over the leader's real status, so only a running task
-    // surfaces it.
+    // Only the shard leading _schemas/0 runs the sync; a stopped shard's empty
+    // status must not win the admin aggregation over the leader's, so suppress
+    // it.
     if (get_state() != model::task_state::stopped) {
+        auto status = _status;
+        // Reflect the in-flight reconcile's live counters for mid-sync
+        // progress. Guarded on current_sync so it cannot double-count after the
+        // fold (which zeroes _reconcile_stats and bakes them into _status).
+        if (status.current_sync.has_value()) {
+            status.current_sync->summary.subject_versions_changed
+              += _reconcile_stats.versions_changed;
+            status.current_sync->summary.errors += _reconcile_stats.errors;
+            status.totals_since_task_start.subject_versions_changed
+              += _reconcile_stats.versions_changed;
+            status.totals_since_task_start.errors += _reconcile_stats.errors;
+        }
         report.detail = model::task_detail{
-          .schema_registry_sync_status = _status};
+          .schema_registry_sync_status = std::move(status)};
     }
     return report;
 }
 
-ss::future<> mirroring_task::refresh_destination_inventory() {
-    // Single scatter-gather over the local registry. Destination/internal
-    // faults bubble out and become `faulted`.
-    auto subject_versions = co_await _destination->list_subject_versions(
-      [](const ppsr::context_subject& cs) {
-          return cs.ctx == ppsr::default_context;
-      },
-      ppsr::include_deleted::no);
+ss::future<> mirroring_task::refresh_destination_inventory(
+  const ss::noncopyable_function<bool(const ppsr::context_subject&)>& in_scope,
+  ss::abort_source& as) {
+    // Destination/internal faults bubble out and become `faulted`. The scan
+    // sinks the predicate by value; forward the borrowed one.
+    _destination_inventory = co_await scan_destination_inventory(
+      *_destination,
+      [&in_scope](const ppsr::context_subject& cs) { return in_scope(cs); },
+      as);
+
     chunked_hash_set<ppsr::context_subject> subjects;
-    for (const auto& sv : subject_versions) {
-        subjects.insert(sv.sub);
+    for (const auto& key : _destination_inventory.active) {
+        subjects.insert(key.sub);
     }
     _status.inventory.destination_subjects = static_cast<uint64_t>(
       subjects.size());
     _status.inventory.destination_subject_versions = static_cast<uint64_t>(
-      subject_versions.size());
+      _destination_inventory.active.size());
+}
+
+ss::future<std::optional<chunked_vector<ppsr::schema_version>>>
+mirroring_task::list_versions_once(
+  const ppsr::context_subject& subject,
+  ppsr::include_deleted include_deleted,
+  ss::abort_source& as,
+  std::optional<source_error>& unavailable,
+  model::schema_registry_sync_summary& summary) {
+    as.check();
+    auto res = co_await _reader->list_subject_versions(
+      subject, include_deleted, as);
+    if (res.has_value()) {
+        co_return std::move(res.value());
+    }
+    if (res.error().kind == source_error_kind::source_unavailable) {
+        if (!unavailable.has_value()) {
+            unavailable = std::move(res.error());
+        }
+        co_return std::nullopt;
+    }
+    // Reachable but failed (rare delete race): count and skip. Counters are
+    // touched only between co_awaits, so sharing them across the concurrent
+    // fibers is safe on one reactor.
+    ++summary.errors;
+    ++_status.totals_since_task_start.errors;
+    _status.last_error_message = res.error().message;
+    _status.current_sync->summary = summary;
+    vlog(logger().warn, "Schema Registry sync error: {}", res.error().message);
+    co_return std::nullopt;
+}
+
+ss::future<> mirroring_task::list_one_subject(
+  const ppsr::context_subject& subject,
+  ss::abort_source& as,
+  chunked_hash_set<ppsr::subject_version>& source_active,
+  chunked_hash_set<ppsr::subject_version>& source_deleted,
+  std::optional<source_error>& unavailable,
+  model::schema_registry_sync_summary& summary) {
+    // A peer fiber already hit source_unavailable; skip the remaining work.
+    if (unavailable.has_value()) {
+        co_return;
+    }
+    // Two listings recover the per-version deleted state the bare source
+    // listing omits: `active` are the non-deleted versions; the remainder of
+    // `all` are soft-deleted. Short-circuit on the first failure so a failing
+    // subject counts at most one error.
+    auto active = co_await list_versions_once(
+      subject, ppsr::include_deleted::no, as, unavailable, summary);
+    if (!active.has_value()) {
+        co_return;
+    }
+    auto all = co_await list_versions_once(
+      subject, ppsr::include_deleted::yes, as, unavailable, summary);
+    if (!all.has_value()) {
+        co_return;
+    }
+    chunked_hash_set<ppsr::schema_version> active_set;
+    for (auto version : *active) {
+        active_set.insert(version);
+        source_active.insert(ppsr::subject_version{subject, version});
+    }
+    for (auto version : *all) {
+        if (!active_set.contains(version)) {
+            source_deleted.insert(ppsr::subject_version{subject, version});
+        }
+    }
 }
 
 ss::future<task::state_transition> mirroring_task::full_source_sync(
-  ss::abort_source& as, model::schema_registry_sync_summary& summary) {
+  ss::abort_source& as,
+  model::schema_registry_sync_summary& summary,
+  const chunked_hash_set<ppsr::context>& contexts,
+  const ss::noncopyable_function<bool(const ppsr::context_subject&)>&
+    in_scope) {
     auto record_error = [this, &summary](std::string_view what) {
         ++summary.errors;
         ++_status.totals_since_task_start.errors;
@@ -156,53 +243,150 @@ ss::future<task::state_transition> mirroring_task::full_source_sync(
         vlog(logger().warn, "Schema Registry sync error: {}", what);
     };
 
-    auto subjects_res = co_await _reader->list_subjects(
-      ppsr::default_context, as);
-    if (!subjects_res.has_value()) {
-        if (
-          subjects_res.error().kind == source_error_kind::source_unavailable) {
-            co_return make_unavailable(subjects_res.error().message);
+    // Cluster-global, so safe to read mid-sync (unlike the per-link config a
+    // concurrent update_config can swap). The one parallelism bound governs
+    // both the version-listing fan-out and the reconcile's import concurrency.
+    auto limits = reconciler::limits{
+      .memory_bytes
+      = config::shard_local_cfg().schema_registry_sync_memory_bytes(),
+      .parallelism
+      = config::shard_local_cfg().schema_registry_sync_parallelism()};
+
+    // Discover the source nodes; the reconciler fetches the bodies. Active and
+    // soft-deleted are tracked apart so the work-set diff can treat them
+    // differently (see below).
+    chunked_hash_set<ppsr::subject_version> source_active;
+    chunked_hash_set<ppsr::subject_version> source_deleted;
+
+    // Contexts are few, so enumerate their subjects sequentially. in_scope also
+    // scopes discovery, keeping source and destination sides consistent.
+    chunked_vector<ppsr::context_subject> subjects;
+    for (const auto& ctx : contexts) {
+        auto subjects_res = co_await _reader->list_subjects(ctx, as);
+        if (!subjects_res.has_value()) {
+            if (
+              subjects_res.error().kind
+              == source_error_kind::source_unavailable) {
+                co_return make_unavailable(subjects_res.error().message);
+            }
+            // Reachable but failed (rare delete race): count and skip.
+            record_error(subjects_res.error().message);
+            continue;
         }
-        // Could not enumerate the source: count the error and retry next cycle
-        // without recording a (misleading) completed full sync. The source is
-        // reachable, so this is not link_unavailable.
-        record_error(subjects_res.error().message);
+        for (auto& subject : subjects_res.value()) {
+            if (in_scope(subject)) {
+                subjects.push_back(std::move(subject));
+            }
+        }
+    }
+    _status.inventory.selected_source_subjects = subjects.size();
+
+    // Bounded concurrency over independent round-trips. list_one_subject is a
+    // member, not a coroutine lambda (see its declaration), so the forwarding
+    // lambda only returns its future.
+    std::optional<source_error> unavailable;
+    co_await ss::max_concurrent_for_each(
+      subjects,
+      std::max<size_t>(1, limits.parallelism),
+      [&](const ppsr::context_subject& subject) {
+          return list_one_subject(
+            subject, as, source_active, source_deleted, unavailable, summary);
+      });
+    if (unavailable.has_value()) {
+        co_return make_unavailable(unavailable->message);
+    }
+
+    // Every discovered source version is selected for sync, soft-deleted ones
+    // included (they are imported below), so count both -- mirroring
+    // selected_source_subjects, a discovery count rather than a change count.
+    _status.inventory.selected_source_subject_versions = static_cast<uint64_t>(
+      source_active.size() + source_deleted.size());
+
+    // State-aware. An active source version missing from the destination's
+    // active set is imported (creating it, or reactivating one that is
+    // soft-deleted on the destination -- the seed does not suppress work
+    // items). A soft-deleted source version is imported unless it is already
+    // soft-deleted on the destination: an absent version is imported
+    // soft-deleted, and one still active on the destination has its deleted
+    // body re-imported to propagate the soft-delete (import overwrites the
+    // version's deleted flag). Soft-delete propagation covers source-present
+    // versions in both directions; purging destination-only versions
+    // (hard-delete propagation) is deferred, as is detecting divergent
+    // same-key content (a matching key is assumed to mean matching content --
+    // the destination is a managed mirror).
+    work_set work;
+    for (const auto& node : source_active) {
+        if (!_destination_inventory.active.contains(node)) {
+            work.upserts.push_back(node);
+        }
+    }
+    for (const auto& node : source_deleted) {
+        const bool dest_deleted = _destination_inventory.all.contains(node)
+                                  && !_destination_inventory.active.contains(
+                                    node);
+        if (!dest_deleted) {
+            work.upserts.push_back(node);
+        }
+    }
+
+    // The reconciler sinks the predicate by value; forward the borrowed one.
+    auto rec = reconciler{
+      _reader.get(),
+      _destination,
+      [&in_scope](const ppsr::context_subject& cs) { return in_scope(cs); },
+      limits};
+
+    // The reconciler increments _reconcile_stats live (reflected mid-sync by
+    // get_status_report); the fold below moves them into persistent state.
+    _reconcile_stats = reconcile_stats{};
+    // Seed with the full (active + soft-deleted) set: soft-deleted nodes still
+    // satisfy references. reconcile sinks it by value and
+    // _destination_inventory is rebuilt next run, so move `all` in rather than
+    // copy it.
+    auto result = co_await rec.reconcile(
+      std::move(work),
+      std::move(_destination_inventory.all),
+      _reconcile_stats,
+      as);
+    if (!result.has_value()) {
+        if (result.error().kind == source_error_kind::source_unavailable) {
+            co_return make_unavailable(result.error().message);
+        }
+        // reconcile only surfaces source_unavailable today; treat any other
+        // error defensively as a counted per-item failure.
+        record_error(result.error().message);
         co_return make_active();
     }
 
-    const auto& subjects = subjects_res.value();
-    uint64_t version_count = 0;
-    for (const auto& subject : subjects) {
-        as.check();
-        auto versions_res = co_await _reader->list_subject_versions(
-          subject, ppsr::include_deleted::no, as);
-        if (!versions_res.has_value()) {
-            if (
-              versions_res.error().kind
-              == source_error_kind::source_unavailable) {
-                co_return make_unavailable(versions_res.error().message);
-            }
-            record_error(versions_res.error().message);
-            continue;
-        }
-        version_count += static_cast<uint64_t>(versions_res.value().size());
-    }
-    _status.inventory.selected_source_subjects = static_cast<uint64_t>(
-      subjects.size());
-    _status.inventory.selected_source_subject_versions = version_count;
+    const auto stats = _reconcile_stats;
+    // Fold once into persistent state, then clear so the report-time reflection
+    // cannot double-count.
+    _reconcile_stats = reconcile_stats{};
+    summary.subject_versions_changed += stats.versions_changed;
+    summary.errors += stats.errors;
+    _status.totals_since_task_start.subject_versions_changed
+      += stats.versions_changed;
+    _status.totals_since_task_start.errors += stats.errors;
+    _status.current_sync->summary = summary;
 
-    // The reconcile/apply step (import missing versions, update, delete, apply
-    // config/mode) is not implemented yet.
+    // Re-scan now that imports have landed so the reported destination counts
+    // reflect the post-sync state, not the pre-import baseline the diff used.
+    co_await refresh_destination_inventory(in_scope, as);
+
     vlog(
       logger().info,
       "Schema Registry full sync: {} source subjects ({} versions), {} "
-      "destination subjects; reconcile/apply not yet implemented",
+      "destination subjects; imported {} versions, {} errors",
       _status.inventory.selected_source_subjects,
       _status.inventory.selected_source_subject_versions,
-      _status.inventory.destination_subjects);
+      _status.inventory.destination_subjects,
+      stats.versions_changed,
+      stats.errors);
 
     summary.finish_time = ::model::timestamp::now();
     _status.last_full_sync = summary;
+    // Completed (best-effort, per-item failures counted), so advance the timer
+    // and retry on the normal interval.
     _last_full_sync = ss::lowres_clock::now();
     co_return make_active();
 }
@@ -233,12 +417,78 @@ mirroring_task::run_impl(ss::abort_source& as) {
         co_return make_active();
     }
 
-    co_await refresh_destination_inventory();
+    // Contexts to replicate = source contexts intersected with the filter.
+    auto contexts_res = co_await _reader->list_contexts(as);
+    if (!contexts_res.has_value()) {
+        if (
+          contexts_res.error().kind == source_error_kind::source_unavailable) {
+            co_return make_unavailable(contexts_res.error().message);
+        }
+        ++summary.errors;
+        ++_status.totals_since_task_start.errors;
+        _status.last_error_message = contexts_res.error().message;
+        _status.current_sync->summary = summary;
+        vlog(
+          logger().warn,
+          "Schema Registry sync error: {}",
+          contexts_res.error().message);
+        co_return make_active();
+    }
+    // Filter has union semantics: filter.contexts selects whole contexts,
+    // filter.subjects adds individual qualified subjects (each carrying its own
+    // context), and an empty filter replicates everything.
+    const auto qualified = ppsr::qualified_subjects_enabled{
+      config::shard_local_cfg().schema_registry_enable_qualified_subjects()};
+    chunked_hash_set<ppsr::context> filter_contexts;
+    chunked_hash_set<ppsr::context_subject> filter_subjects;
+    const auto* api = _config.api_mode();
+    if (api == nullptr) {
+        vlog(
+          logger().debug,
+          "Schema Registry sync disabled mid-run; skipping remainder of sync");
+        co_return make_active();
+    }
+    for (const auto& ctx : api->filter.contexts) {
+        filter_contexts.insert(ppsr::context{ctx});
+    }
+    for (const auto& sub : api->filter.subjects) {
+        filter_subjects.insert(
+          ppsr::context_subject::from_string(sub, qualified));
+    }
+    const bool unfiltered = filter_contexts.empty() && filter_subjects.empty();
+    // A filtered subject's context must be scanned even when the context filter
+    // omits it, else that subject is never discovered.
+    chunked_hash_set<ppsr::context> subject_contexts;
+    for (const auto& cs : filter_subjects) {
+        subject_contexts.insert(cs.ctx);
+    }
+    chunked_hash_set<ppsr::context> contexts;
+    for (auto& ctx : contexts_res.value()) {
+        if (
+          unfiltered || filter_contexts.contains(ctx)
+          || subject_contexts.contains(ctx)) {
+            contexts.insert(std::move(ctx));
+        }
+    }
 
-    // full_source_sync advances _last_full_sync only when a scan completes, so
-    // a failed enumeration retries on the next tick rather than waiting a full
-    // interval.
-    co_return co_await full_source_sync(as, summary);
+    if (
+      auto reason = check_preconditions(
+        _config,
+        contexts,
+        config::shard_local_cfg().schema_registry_enable_qualified_subjects());
+      reason.has_value()) {
+        co_return make_faulted(*reason);
+    }
+
+    // in_scope is move-only (its filter sets are not copyable) but two by-value
+    // sinks consume it per run (the destination scan and the reconciler), so
+    // build it once and lend it by reference; each sink forwards a thin
+    // wrapper.
+    auto in_scope = make_in_scope(
+      std::move(filter_contexts), std::move(filter_subjects));
+
+    co_await refresh_destination_inventory(in_scope, as);
+    co_return co_await full_source_sync(as, summary, contexts, in_scope);
 }
 
 task::state_transition
@@ -246,6 +496,9 @@ mirroring_task::make_unavailable(const ss::sstring& reason) {
     vlog(
       logger().warn, "Schema Registry shadowing task unavailable: {}", reason);
     _status.last_error_message = reason;
+    // No special backoff: an unavailable run leaves _last_full_sync unadvanced,
+    // so the next tail tick re-attempts the full sync and the link recovers on
+    // the normal cadence once the source comes back.
     return state_transition{
       .desired_state = model::task_state::link_unavailable, .reason = reason};
 }
@@ -254,6 +507,13 @@ task::state_transition mirroring_task::make_active() {
     return state_transition{
       .desired_state = model::task_state::active,
       .reason = "Schema Registry shadowing task finished a sync"};
+}
+
+task::state_transition mirroring_task::make_faulted(const ss::sstring& reason) {
+    vlog(logger().warn, "Schema Registry shadowing task faulted: {}", reason);
+    _status.last_error_message = reason;
+    return state_transition{
+      .desired_state = model::task_state::faulted, .reason = reason};
 }
 
 std::string_view mirroring_task_factory::created_task_name() const noexcept {

--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
@@ -46,6 +46,25 @@ full_sync_interval(const model::schema_registry_sync_config& cfg) {
 
 } // namespace
 
+ss::future<inventory> scan_destination_inventory(
+  schema::registry& destination,
+  ss::noncopyable_function<bool(const ppsr::context_subject&)> in_scope,
+  ss::abort_source& as) {
+    as.check();
+    auto versions = co_await destination.list_subject_versions(
+      std::move(in_scope), ppsr::include_deleted::yes);
+    inventory inv;
+    inv.all.reserve(versions.size());
+    for (const auto& sv : versions) {
+        auto node = ppsr::subject_version{sv.sub, sv.version};
+        if (sv.deleted == ppsr::is_deleted::no) {
+            inv.active.insert(node);
+        }
+        inv.all.insert(std::move(node));
+    }
+    co_return inv;
+}
+
 mirroring_task::mirroring_task(
   link* link,
   const model::metadata& link_metadata,

--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
@@ -162,13 +162,19 @@ ss::future<> mirroring_task::refresh_destination_inventory(
       _destination_inventory.active.size());
 }
 
+void mirroring_task::record_error(std::string_view what) {
+    ++_status.current_sync->summary.errors;
+    ++_status.totals_since_task_start.errors;
+    _status.last_error_message = ss::sstring{what};
+    vlog(logger().warn, "Schema Registry sync error: {}", what);
+}
+
 ss::future<std::optional<chunked_vector<ppsr::schema_version>>>
 mirroring_task::list_versions_once(
   const ppsr::context_subject& subject,
   ppsr::include_deleted include_deleted,
   ss::abort_source& as,
-  std::optional<source_error>& unavailable,
-  model::schema_registry_sync_summary& summary) {
+  std::optional<source_error>& unavailable) {
     as.check();
     auto res = co_await _reader->list_subject_versions(
       subject, include_deleted, as);
@@ -184,11 +190,7 @@ mirroring_task::list_versions_once(
     // Reachable but failed (rare delete race): count and skip. Counters are
     // touched only between co_awaits, so sharing them across the concurrent
     // fibers is safe on one reactor.
-    ++summary.errors;
-    ++_status.totals_since_task_start.errors;
-    _status.last_error_message = res.error().message;
-    _status.current_sync->summary = summary;
-    vlog(logger().warn, "Schema Registry sync error: {}", res.error().message);
+    record_error(res.error().message);
     co_return std::nullopt;
 }
 
@@ -197,8 +199,7 @@ ss::future<> mirroring_task::list_one_subject(
   ss::abort_source& as,
   chunked_hash_set<ppsr::subject_version>& source_active,
   chunked_hash_set<ppsr::subject_version>& source_deleted,
-  std::optional<source_error>& unavailable,
-  model::schema_registry_sync_summary& summary) {
+  std::optional<source_error>& unavailable) {
     // A peer fiber already hit source_unavailable; skip the remaining work.
     if (unavailable.has_value()) {
         co_return;
@@ -208,12 +209,12 @@ ss::future<> mirroring_task::list_one_subject(
     // `all` are soft-deleted. Short-circuit on the first failure so a failing
     // subject counts at most one error.
     auto active = co_await list_versions_once(
-      subject, ppsr::include_deleted::no, as, unavailable, summary);
+      subject, ppsr::include_deleted::no, as, unavailable);
     if (!active.has_value()) {
         co_return;
     }
     auto all = co_await list_versions_once(
-      subject, ppsr::include_deleted::yes, as, unavailable, summary);
+      subject, ppsr::include_deleted::yes, as, unavailable);
     if (!all.has_value()) {
         co_return;
     }
@@ -231,18 +232,9 @@ ss::future<> mirroring_task::list_one_subject(
 
 ss::future<task::state_transition> mirroring_task::full_source_sync(
   ss::abort_source& as,
-  model::schema_registry_sync_summary& summary,
   const chunked_hash_set<ppsr::context>& contexts,
   const ss::noncopyable_function<bool(const ppsr::context_subject&)>&
     in_scope) {
-    auto record_error = [this, &summary](std::string_view what) {
-        ++summary.errors;
-        ++_status.totals_since_task_start.errors;
-        _status.last_error_message = ss::sstring{what};
-        _status.current_sync->summary = summary;
-        vlog(logger().warn, "Schema Registry sync error: {}", what);
-    };
-
     // Cluster-global, so safe to read mid-sync (unlike the per-link config a
     // concurrent update_config can swap). The one parallelism bound governs
     // both the version-listing fan-out and the reconcile's import concurrency.
@@ -290,7 +282,7 @@ ss::future<task::state_transition> mirroring_task::full_source_sync(
       std::max<size_t>(1, limits.parallelism),
       [&](const ppsr::context_subject& subject) {
           return list_one_subject(
-            subject, as, source_active, source_deleted, unavailable, summary);
+            subject, as, source_active, source_deleted, unavailable);
       });
     if (unavailable.has_value()) {
         co_return make_unavailable(unavailable->message);
@@ -362,12 +354,12 @@ ss::future<task::state_transition> mirroring_task::full_source_sync(
     // Fold once into persistent state, then clear so the report-time reflection
     // cannot double-count.
     _reconcile_stats = reconcile_stats{};
-    summary.subject_versions_changed += stats.versions_changed;
-    summary.errors += stats.errors;
+    _status.current_sync->summary.subject_versions_changed
+      += stats.versions_changed;
+    _status.current_sync->summary.errors += stats.errors;
     _status.totals_since_task_start.subject_versions_changed
       += stats.versions_changed;
     _status.totals_since_task_start.errors += stats.errors;
-    _status.current_sync->summary = summary;
 
     // Re-scan now that imports have landed so the reported destination counts
     // reflect the post-sync state, not the pre-import baseline the diff used.
@@ -383,8 +375,8 @@ ss::future<task::state_transition> mirroring_task::full_source_sync(
       stats.versions_changed,
       stats.errors);
 
-    summary.finish_time = ::model::timestamp::now();
-    _status.last_full_sync = summary;
+    _status.current_sync->summary.finish_time = ::model::timestamp::now();
+    _status.last_full_sync = _status.current_sync->summary;
     // Completed (best-effort, per-item failures counted), so advance the timer
     // and retry on the normal interval.
     _last_full_sync = ss::lowres_clock::now();
@@ -398,12 +390,10 @@ mirroring_task::run_impl(ss::abort_source& as) {
     const bool long_sync = std::exchange(_config_changed, false)
                            || should_long_sync();
 
-    model::schema_registry_sync_summary summary;
-    summary.start_time = ::model::timestamp::now();
     _status.current_sync = model::schema_registry_current_sync{
       .sync_type = long_sync ? model::schema_registry_sync_type::full
                              : model::schema_registry_sync_type::tail,
-      .summary = summary};
+      .summary = {.start_time = ::model::timestamp::now()}};
     // current_sync reflects an in-progress sync only; clear it on every exit
     // (success, unavailable, or a fault that throws out of run_impl) so a stale
     // partial summary is never reported between runs.
@@ -424,14 +414,7 @@ mirroring_task::run_impl(ss::abort_source& as) {
           contexts_res.error().kind == source_error_kind::source_unavailable) {
             co_return make_unavailable(contexts_res.error().message);
         }
-        ++summary.errors;
-        ++_status.totals_since_task_start.errors;
-        _status.last_error_message = contexts_res.error().message;
-        _status.current_sync->summary = summary;
-        vlog(
-          logger().warn,
-          "Schema Registry sync error: {}",
-          contexts_res.error().message);
+        record_error(contexts_res.error().message);
         co_return make_active();
     }
     // Filter has union semantics: filter.contexts selects whole contexts,
@@ -488,7 +471,7 @@ mirroring_task::run_impl(ss::abort_source& as) {
       std::move(filter_contexts), std::move(filter_subjects));
 
     co_await refresh_destination_inventory(in_scope, as);
-    co_return co_await full_source_sync(as, summary, contexts, in_scope);
+    co_return co_await full_source_sync(as, contexts, in_scope);
 }
 
 task::state_transition

--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.h
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.h
@@ -95,12 +95,11 @@ private:
 
     /// Full source scan and create-only reconcile: discovers the active source
     /// nodes (across `contexts`), imports those missing from the destination's
-    /// active set in reference order, and folds the result into `summary` and
-    /// the task status. Returns the resulting task state (active, or
-    /// link_unavailable if the source becomes unreachable).
+    /// active set in reference order, and folds the result into the in-progress
+    /// sync summary and the task status. Returns the resulting task state
+    /// (active, or link_unavailable if the source becomes unreachable).
     ss::future<state_transition> full_source_sync(
       ss::abort_source&,
-      model::schema_registry_sync_summary&,
       const chunked_hash_set<ppsr::context>& contexts,
       const ss::noncopyable_function<bool(const ppsr::context_subject&)>&
         in_scope);
@@ -120,8 +119,7 @@ private:
       ss::abort_source& as,
       chunked_hash_set<ppsr::subject_version>& source_active,
       chunked_hash_set<ppsr::subject_version>& source_deleted,
-      std::optional<source_error>& unavailable,
-      model::schema_registry_sync_summary& summary);
+      std::optional<source_error>& unavailable);
 
     /// One source version listing with shared error handling: returns the
     /// versions on success, or nullopt after capturing a source_unavailable in
@@ -133,8 +131,10 @@ private:
       const ppsr::context_subject& subject,
       ppsr::include_deleted include_deleted,
       ss::abort_source& as,
-      std::optional<source_error>& unavailable,
-      model::schema_registry_sync_summary& summary);
+      std::optional<source_error>& unavailable);
+
+    // Requires a sync in progress (`current_sync` engaged).
+    void record_error(std::string_view what);
 
     [[nodiscard]] state_transition make_unavailable(const ss::sstring& reason);
     [[nodiscard]] state_transition make_active();

--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.h
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cluster_link/schema_registry_sync/reconciler.h"
 #include "cluster_link/schema_registry_sync/source_reader.h"
 #include "cluster_link/task.h"
 #include "container/chunked_hash_map.h"
@@ -41,8 +42,9 @@ ss::future<inventory> scan_destination_inventory(
 
 /// Shadows a source Schema Registry into the local (destination) Schema
 /// Registry. Runs on the shard leading `_schemas/0`, a cluster-wide singleton.
-/// Each run reconciles the source onto the destination; it currently reports
-/// source and destination inventory and does not yet import.
+/// Each run reconciles the source onto the destination, importing the source
+/// schema versions missing from the destination in reference (topological)
+/// order.
 ///
 /// Source failures travel as `source_error` values: an unavailable source
 /// parks the link, a per-item failure is counted and skipped. Destination and
@@ -83,24 +85,70 @@ private:
     /// `_config_changed`, consumed in `run_impl`.
     bool should_long_sync() const;
 
-    /// Refreshes destination inventory counters from the local registry in a
-    /// single scatter-gather. Throws on internal/destination faults.
-    ss::future<> refresh_destination_inventory();
+    /// Rescans the destination inventory across all in-scope contexts, retains
+    /// it on the task, and refreshes the destination counters. Throws on
+    /// internal/destination faults.
+    ss::future<> refresh_destination_inventory(
+      const ss::noncopyable_function<bool(const ppsr::context_subject&)>&
+        in_scope,
+      ss::abort_source&);
 
-    /// Full source scan: refreshes source inventory counters. Returns the
-    /// resulting task state (active, or link_unavailable if the source is
-    /// down).
-    ss::future<state_transition>
-    full_source_sync(ss::abort_source&, model::schema_registry_sync_summary&);
+    /// Full source scan and create-only reconcile: discovers the active source
+    /// nodes (across `contexts`), imports those missing from the destination's
+    /// active set in reference order, and folds the result into `summary` and
+    /// the task status. Returns the resulting task state (active, or
+    /// link_unavailable if the source becomes unreachable).
+    ss::future<state_transition> full_source_sync(
+      ss::abort_source&,
+      model::schema_registry_sync_summary&,
+      const chunked_hash_set<ppsr::context>& contexts,
+      const ss::noncopyable_function<bool(const ppsr::context_subject&)>&
+        in_scope);
+
+    /// Lists one subject's versions, classifying each into `source_active` or
+    /// `source_deleted`. The source listing returns bare version numbers, so
+    /// two calls recover the per-version deleted state: include_deleted::no
+    /// gives the active versions, and the rest of the include_deleted::yes
+    /// listing are soft-deleted. A reachable-but-failed listing is a counted
+    /// per-item error; a source_unavailable is captured in `unavailable` to
+    /// back off the sync. A member, not a coroutine lambda: run under
+    /// max_concurrent_for_each, a lambda could be freed while suspended and
+    /// dangle its captures, whereas the member coroutine frame owns `this` and
+    /// the shared state.
+    ss::future<> list_one_subject(
+      const ppsr::context_subject& subject,
+      ss::abort_source& as,
+      chunked_hash_set<ppsr::subject_version>& source_active,
+      chunked_hash_set<ppsr::subject_version>& source_deleted,
+      std::optional<source_error>& unavailable,
+      model::schema_registry_sync_summary& summary);
+
+    /// One source version listing with shared error handling: returns the
+    /// versions on success, or nullopt after capturing a source_unavailable in
+    /// `unavailable` or counting a reachable-but-failed listing as a per-item
+    /// error. Lets list_one_subject short-circuit so a failing subject counts
+    /// at most one error across its two listings.
+    ss::future<std::optional<chunked_vector<ppsr::schema_version>>>
+    list_versions_once(
+      const ppsr::context_subject& subject,
+      ppsr::include_deleted include_deleted,
+      ss::abort_source& as,
+      std::optional<source_error>& unavailable,
+      model::schema_registry_sync_summary& summary);
 
     [[nodiscard]] state_transition make_unavailable(const ss::sstring& reason);
     [[nodiscard]] state_transition make_active();
+    [[nodiscard]] state_transition make_faulted(const ss::sstring& reason);
 
     model::schema_registry_sync_config _config;
     schema::registry* _destination;
     source_reader_factory* _source_factory;
     std::unique_ptr<source_reader> _reader;
+    inventory _destination_inventory;
     model::schema_registry_sync_status _status;
+    // Live counters for the in-flight reconcile; reflected by get_status_report
+    // for mid-sync progress, then folded into _status at end of run.
+    reconcile_stats _reconcile_stats;
     std::optional<ss::lowres_clock::time_point> _last_full_sync;
     // Set by update_config, consumed by run_impl to force a full scan. A flag
     // (rather than mutating _status/_last_full_sync in update_config) avoids

--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.h
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.h
@@ -13,9 +13,31 @@
 
 #include "cluster_link/schema_registry_sync/source_reader.h"
 #include "cluster_link/task.h"
+#include "container/chunked_hash_map.h"
 #include "schema/registry.h"
 
+#include <seastar/core/abort_source.hh>
+#include <seastar/util/noncopyable_function.hh>
+
 namespace cluster_link::schema_registry_sync {
+
+/// A snapshot of the destination Schema Registry's in-scope (subject, version)
+/// nodes, retained for diffing against the source during reconciliation.
+struct inventory {
+    /// Non-deleted (subject, version) nodes.
+    chunked_hash_set<ppsr::subject_version> active;
+    /// Non-deleted and soft-deleted nodes; a superset of `active`.
+    chunked_hash_set<ppsr::subject_version> all;
+};
+
+/// Scans the destination registry for every in-scope (subject, version) node.
+/// A single include_deleted scan reports each version's soft-delete state, so
+/// `active` is the non-deleted subset of `all` from one snapshot. `in_scope`
+/// must be pure; it runs on each registry shard.
+ss::future<inventory> scan_destination_inventory(
+  schema::registry& destination,
+  ss::noncopyable_function<bool(const ppsr::context_subject&)> in_scope,
+  ss::abort_source& as);
 
 /// Shadows a source Schema Registry into the local (destination) Schema
 /// Registry. Runs on the shard leading `_schemas/0`, a cluster-wide singleton.

--- a/src/v/cluster_link/schema_registry_sync/reconciler.cc
+++ b/src/v/cluster_link/schema_registry_sync/reconciler.cc
@@ -74,7 +74,7 @@ void adjust_units(
 reconciler::reconciler(
   source_reader* source,
   schema::registry* destination,
-  std::function<bool(const ppsr::context_subject&)> in_scope,
+  ss::noncopyable_function<bool(const ppsr::context_subject&)> in_scope,
   limits lim)
   : _source(source)
   , _destination(destination)

--- a/src/v/cluster_link/schema_registry_sync/reconciler.h
+++ b/src/v/cluster_link/schema_registry_sync/reconciler.h
@@ -41,9 +41,10 @@ struct reconcile_stats {
     uint64_t errors{0};
 };
 
-/// The set of changes a reconcile applies. Create-only: every upsert is a
-/// (context, subject, version) node present on the source but absent from the
-/// destination's active set.
+/// The set of changes a reconcile applies: each upsert is a (context, subject,
+/// version) node imported from the source with its source deleted state. The
+/// caller selects which nodes to upsert (create, reactivate, or propagate a
+/// soft-delete); the reconciler imports them in reference order.
 struct work_set {
     chunked_vector<ppsr::subject_version> upserts;
 };

--- a/src/v/cluster_link/schema_registry_sync/reconciler.h
+++ b/src/v/cluster_link/schema_registry_sync/reconciler.h
@@ -23,9 +23,9 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/semaphore.hh>
+#include <seastar/util/noncopyable_function.hh>
 
 #include <cstdint>
-#include <functional>
 
 namespace cluster_link::schema_registry_sync {
 
@@ -89,7 +89,7 @@ public:
     reconciler(
       source_reader* source,
       schema::registry* destination,
-      std::function<bool(const ppsr::context_subject&)> in_scope,
+      ss::noncopyable_function<bool(const ppsr::context_subject&)> in_scope,
       limits lim);
 
     /// Imports `work_set.upserts` referent-first.
@@ -176,7 +176,7 @@ private:
 
     source_reader* _source;
     schema::registry* _destination;
-    std::function<bool(const ppsr::context_subject&)> _in_scope;
+    ss::noncopyable_function<bool(const ppsr::context_subject&)> _in_scope;
     limits _limits;
 
     chunked_hash_set<ppsr::subject_version> _replicated;

--- a/src/v/cluster_link/schema_registry_sync/scope.cc
+++ b/src/v/cluster_link/schema_registry_sync/scope.cc
@@ -11,6 +11,11 @@
 
 #include "cluster_link/schema_registry_sync/scope.h"
 
+#include "ssx/sformat.h"
+
+#include <seastar/core/sstring.hh>
+#include <seastar/util/variant_utils.hh>
+
 namespace cluster_link::schema_registry_sync {
 
 ss::noncopyable_function<bool(const ppsr::context_subject&)> make_in_scope(
@@ -23,6 +28,82 @@ ss::noncopyable_function<bool(const ppsr::context_subject&)> make_in_scope(
         return unfiltered || contexts.contains(sub.ctx)
                || subjects.contains(sub);
     };
+}
+
+std::optional<ss::sstring> check_preconditions(
+  const model::schema_registry_sync_config& config,
+  const chunked_hash_set<ppsr::context>& in_scope_contexts,
+  bool qualified_subjects_enabled) {
+    if (qualified_subjects_enabled) {
+        return std::nullopt;
+    }
+
+    // With qualified subjects off the destination can only hold the default
+    // context, so reject any non-default context that would be written there.
+    auto rejected = [](const ppsr::context& ctx) -> std::optional<ss::sstring> {
+        if (ctx == ppsr::default_context) {
+            return std::nullopt;
+        }
+        return ssx::sformat(
+          "non-default context '{}' requires "
+          "schema_registry_enable_qualified_subjects to be enabled",
+          ctx);
+    };
+
+    const auto* api = config.api_mode();
+    if (api == nullptr) {
+        return std::nullopt;
+    }
+
+    // Identity mapping (also the default when no remapping is configured):
+    // every context the run touches becomes a destination context -- discovered
+    // from the source, or named by a context or subject filter the source may
+    // not yet hold.
+    auto reject_identity = [&]() -> std::optional<ss::sstring> {
+        for (const auto& ctx : in_scope_contexts) {
+            if (auto r = rejected(ctx)) {
+                return r;
+            }
+        }
+        // The filter may name a context the source does not hold yet; under
+        // identity mapping it would still be written verbatim, so fail fast.
+        for (const auto& ctx : api->filter.contexts) {
+            if (auto r = rejected(ppsr::context{ctx})) {
+                return r;
+            }
+        }
+        // Parse as qualified to catch a non-default context the operator
+        // expressed in subject syntax; under the off flag it would otherwise be
+        // silently flattened to a literal default-context subject.
+        for (const auto& sub : api->filter.subjects) {
+            auto parsed = ppsr::context_subject::from_string(
+              sub, ppsr::qualified_subjects_enabled::yes);
+            if (auto r = rejected(parsed.ctx)) {
+                return r;
+            }
+        }
+        return std::nullopt;
+    };
+    if (!api->destination.has_value()) {
+        return reject_identity();
+    }
+    using identity_context_mapping
+      = model::schema_registry_sync_config::identity_context_mapping;
+    using exact_context_mapping
+      = model::schema_registry_sync_config::exact_context_mapping;
+    return ss::visit(
+      *api->destination,
+      [&](const identity_context_mapping&) { return reject_identity(); },
+      [&](const exact_context_mapping& m) -> std::optional<ss::sstring> {
+          // Remapping writes to the mapping targets; source contexts are
+          // remapped away, so only the targets matter.
+          for (const auto& [_, dest] : m.mappings) {
+              if (auto r = rejected(ppsr::context{dest})) {
+                  return r;
+              }
+          }
+          return std::nullopt;
+      });
 }
 
 } // namespace cluster_link::schema_registry_sync

--- a/src/v/cluster_link/schema_registry_sync/scope.cc
+++ b/src/v/cluster_link/schema_registry_sync/scope.cc
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster_link/schema_registry_sync/scope.h"
+
+namespace cluster_link::schema_registry_sync {
+
+ss::noncopyable_function<bool(const ppsr::context_subject&)> make_in_scope(
+  chunked_hash_set<ppsr::context> contexts,
+  chunked_hash_set<ppsr::context_subject> subjects) {
+    const bool unfiltered = contexts.empty() && subjects.empty();
+    return [unfiltered,
+            contexts = std::move(contexts),
+            subjects = std::move(subjects)](const ppsr::context_subject& sub) {
+        return unfiltered || contexts.contains(sub.ctx)
+               || subjects.contains(sub);
+    };
+}
+
+} // namespace cluster_link::schema_registry_sync

--- a/src/v/cluster_link/schema_registry_sync/scope.h
+++ b/src/v/cluster_link/schema_registry_sync/scope.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "container/chunked_hash_map.h"
+#include "pandaproxy/schema_registry/types.h"
+
+#include <seastar/util/noncopyable_function.hh>
+
+namespace cluster_link::schema_registry_sync {
+
+namespace ppsr = pandaproxy::schema_registry;
+
+/// Builds a pure predicate reporting whether a context-qualified subject
+/// belongs to the link's scope, following the configured source filter's union
+/// semantics:
+///   * neither `contexts` nor `subjects` configured: no filter, every node is
+///     in scope;
+///   * otherwise a node is in scope if its context is one of `contexts`, OR it
+///     is one of the individually listed `subjects`.
+/// A subject filter therefore widens scope -- it adds individual subjects from
+/// contexts the context filter does not select -- rather than narrowing it.
+ss::noncopyable_function<bool(const ppsr::context_subject&)> make_in_scope(
+  chunked_hash_set<ppsr::context> contexts,
+  chunked_hash_set<ppsr::context_subject> subjects);
+
+} // namespace cluster_link::schema_registry_sync

--- a/src/v/cluster_link/schema_registry_sync/scope.h
+++ b/src/v/cluster_link/schema_registry_sync/scope.h
@@ -11,10 +11,14 @@
 
 #pragma once
 
+#include "cluster_link/model/types.h"
 #include "container/chunked_hash_map.h"
 #include "pandaproxy/schema_registry/types.h"
 
+#include <seastar/core/sstring.hh>
 #include <seastar/util/noncopyable_function.hh>
+
+#include <optional>
 
 namespace cluster_link::schema_registry_sync {
 
@@ -32,5 +36,14 @@ namespace ppsr = pandaproxy::schema_registry;
 ss::noncopyable_function<bool(const ppsr::context_subject&)> make_in_scope(
   chunked_hash_set<ppsr::context> contexts,
   chunked_hash_set<ppsr::context_subject> subjects);
+
+/// Returns a fault reason if the configuration would write a non-default
+/// context to the destination while `qualified_subjects_enabled` is off (the
+/// destination can then only represent the default context), else nullopt. The
+/// flag is injected to keep the check pure and testable.
+std::optional<ss::sstring> check_preconditions(
+  const model::schema_registry_sync_config& config,
+  const chunked_hash_set<ppsr::context>& in_scope_contexts,
+  bool qualified_subjects_enabled);
 
 } // namespace cluster_link::schema_registry_sync

--- a/src/v/cluster_link/schema_registry_sync/tests/BUILD
+++ b/src/v/cluster_link/schema_registry_sync/tests/BUILD
@@ -69,7 +69,9 @@ redpanda_cc_gtest(
     srcs = ["scope_test.cc"],
     cpu = 1,
     deps = [
+        "//src/v/cluster_link/model",
         "//src/v/cluster_link/schema_registry_sync:mirroring_task",
+        "//src/v/container:chunked_hash_map",
         "//src/v/pandaproxy/schema_registry:types",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",

--- a/src/v/cluster_link/schema_registry_sync/tests/BUILD
+++ b/src/v/cluster_link/schema_registry_sync/tests/BUILD
@@ -8,6 +8,7 @@ redpanda_cc_gtest(
     ],
     cpu = 1,
     deps = [
+        ":sr_sync_test_fixtures",
         "//src/v/cluster:cluster_link_table",
         "//src/v/cluster:fwd",
         "//src/v/cluster_link:impl",

--- a/src/v/cluster_link/schema_registry_sync/tests/BUILD
+++ b/src/v/cluster_link/schema_registry_sync/tests/BUILD
@@ -62,3 +62,17 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "scope_test",
+    timeout = "short",
+    srcs = ["scope_test.cc"],
+    cpu = 1,
+    deps = [
+        "//src/v/cluster_link/schema_registry_sync:mirroring_task",
+        "//src/v/pandaproxy/schema_registry:types",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/cluster_link/schema_registry_sync/tests/mirroring_task_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/mirroring_task_test.cc
@@ -23,6 +23,8 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/sleep.hh>
 
+#include <gmock/gmock.h>
+
 using namespace std::chrono_literals;
 
 namespace cluster_link::tests {
@@ -187,9 +189,61 @@ TEST_F(mirroring_task_test, populates_source_and_destination_inventory) {
     EXPECT_EQ(status->last_full_sync->errors, 0);
 }
 
-TEST_F(mirroring_task_test, source_unavailable_is_unavailable) {
-    // A context must exist for discovery to reach list_subjects, where the
-    // source reports itself unavailable.
+TEST_F(mirroring_task_test, full_sync_imports_and_reports) {
+    auto a = ppsr::context_subject::unqualified("a");
+    auto b = ppsr::context_subject::unqualified("b");
+    auto c = ppsr::context_subject::unqualified("c");
+    // a:v1 (no refs), b:v1 refs a:v1 (a small ref graph), c:v1 (no refs). The
+    // engine must import a before b regardless of listing order.
+    _source_state.add(a, 1);
+    _source_state.add_with_refs(b, 1, refs_to({ref_to(a, 1)}));
+    _source_state.add(c, 1);
+
+    lead_schema_registry();
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && s.last_full_sync->subject_versions_changed == 3
+                             && !s.current_sync.has_value();
+                  }).get();
+
+    ASSERT_TRUE(status.has_value());
+    EXPECT_EQ(status->last_full_sync->subject_versions_changed, 3);
+    EXPECT_EQ(status->last_full_sync->errors, 0);
+    EXPECT_EQ(status->totals_since_task_start.subject_versions_changed, 3);
+
+    // Create-only replication imports schema versions but never touches
+    // compatibility configs, subject modes, or unsupported-feature handling,
+    // so those deferred counters stay zero.
+    EXPECT_EQ(status->last_full_sync->compatibility_configs_changed, 0);
+    EXPECT_EQ(status->last_full_sync->modes_changed, 0);
+    EXPECT_EQ(status->last_full_sync->unsupported_features_removed, 0);
+
+    // Three source subjects (a, b, c) with one version each; the destination
+    // was empty before the sync and, after the post-import refresh, mirrors all
+    // three.
+    EXPECT_EQ(status->inventory.selected_source_subjects, 3);
+    EXPECT_EQ(status->inventory.selected_source_subject_versions, 3);
+    EXPECT_EQ(status->inventory.destination_subjects, 3);
+    EXPECT_EQ(status->inventory.destination_subject_versions, 3);
+
+    // The sync has finished: current_sync is cleared, and last_full_sync
+    // carries both a start and a finish timestamp (start <= finish).
+    EXPECT_FALSE(status->current_sync.has_value());
+    ASSERT_TRUE(status->last_full_sync->start_time.has_value());
+    ASSERT_TRUE(status->last_full_sync->finish_time.has_value());
+    EXPECT_LE(
+      status->last_full_sync->start_time->value(),
+      status->last_full_sync->finish_time->value());
+
+    // All three source versions landed on the destination, referent-first.
+    const auto& all = _registry.get_all();
+    EXPECT_EQ(all.size(), 3);
+    EXPECT_LT(index_of(all, "a"), index_of(all, "b"));
+}
+
+TEST_F(mirroring_task_test, source_unavailable_then_recovers) {
     _source_state.add(ppsr::context_subject::unqualified("orders-value"), 1);
     _source_state.list_subjects_error = srs::source_error{
       .kind = srs::source_error_kind::source_unavailable,
@@ -198,7 +252,18 @@ TEST_F(mirroring_task_test, source_unavailable_is_unavailable) {
     lead_schema_registry();
     fixture()->upsert_link(get_default_metadata()).get();
 
+    // An unreachable source parks the task as link_unavailable.
     ASSERT_TRUE(wait_for_task_state(model::task_state::link_unavailable).get());
+
+    // Once the source recovers, the next tick re-attempts the still-due full
+    // sync (the unavailable run left the timer unadvanced) and reaches active.
+    _source_state.list_subjects_error.reset();
+    ASSERT_TRUE(wait_for_task_state(model::task_state::active).get());
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && s.inventory.selected_source_subjects == 1;
+                  }).get();
+    ASSERT_TRUE(status.has_value());
 }
 
 TEST_F(mirroring_task_test, config_update_forces_full_resync) {
@@ -229,6 +294,211 @@ TEST_F(mirroring_task_test, config_update_forces_full_resync) {
     ASSERT_TRUE(second.has_value());
 }
 
+TEST_F(mirroring_task_test, source_list_failure_completes_and_advances) {
+    auto ok = ppsr::context_subject::unqualified("orders-value");
+    auto failing = ppsr::context_subject::unqualified("payments-value");
+    _source_state.add(ok, 1);
+    _source_state.add(failing, 1);
+    // Listing payments-value's versions fails (reachable, not unavailable).
+    // This is a rare source-side delete race: it is counted as a per-item error
+    // and skipped, but the full sync still completes and advances the timer.
+    _source_state.list_versions_errors.emplace(
+      failing,
+      srs::source_error{
+        .kind = srs::source_error_kind::operation_failed,
+        .message = "version listing failed"});
+
+    lead_schema_registry();
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    // The full sync completes best-effort: the error is counted, orders-value's
+    // single version is listed and imported, and last_full_sync is recorded
+    // (the timer advanced -- the failure does not force a fast retry).
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+    ASSERT_TRUE(status.has_value());
+    EXPECT_GE(status->totals_since_task_start.errors, 1);
+    EXPECT_EQ(status->last_full_sync->errors, 1);
+    EXPECT_EQ(status->inventory.selected_source_subject_versions, 1);
+    EXPECT_EQ(status->last_full_sync->subject_versions_changed, 1);
+
+    // The reachable subject was still imported; the failing one was skipped.
+    const auto& all = _registry.get_all();
+    ASSERT_EQ(all.size(), 1);
+    EXPECT_EQ(all[0].schema.sub().sub(), ppsr::subject{"orders-value"});
+}
+
+TEST_F(
+  mirroring_task_test, source_context_listing_failure_counts_and_recovers) {
+    _source_state.add(ppsr::context_subject::unqualified("orders-value"), 1);
+    // A reachable failure (not source_unavailable, which would park the link)
+    // must still be counted while the task stays active.
+    _source_state.list_contexts_error = srs::source_error{
+      .kind = srs::source_error_kind::operation_failed,
+      .message = "context listing failed"};
+
+    lead_schema_registry();
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    auto failed = wait_for_sync_status([](const auto& s) {
+                      return s.totals_since_task_start.errors >= 1;
+                  }).get();
+    ASSERT_TRUE(failed.has_value());
+    EXPECT_FALSE(failed->last_full_sync.has_value());
+    EXPECT_EQ(failed->last_error_message, "context listing failed");
+
+    _source_state.list_contexts_error.reset();
+    auto ok = wait_for_sync_status([](const auto& s) {
+                  return s.last_full_sync.has_value()
+                         && s.inventory.selected_source_subjects == 1;
+              }).get();
+    ASSERT_TRUE(ok.has_value());
+    EXPECT_EQ(ok->last_full_sync->subject_versions_changed, 1);
+}
+
+TEST_F(mirroring_task_test, source_filter_scopes_discovery_and_import) {
+    // The source has two default-context subjects; the configured subject
+    // filter selects only orders-value. The excluded payments-value must be
+    // neither listed (selected_source_*) nor imported (destination).
+    auto orders = ppsr::context_subject::unqualified("orders-value");
+    auto payments = ppsr::context_subject::unqualified("payments-value");
+    _source_state.add(orders, 1);
+    _source_state.add(payments, 1);
+
+    auto metadata = get_default_metadata();
+    metadata.configuration.schema_registry_sync_cfg.api_mode()
+      ->filter.subjects.push_back("orders-value");
+
+    lead_schema_registry();
+    fixture()->upsert_link(std::move(metadata)).get();
+
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+
+    ASSERT_TRUE(status.has_value());
+    // Only the in-scope subject is selected and imported.
+    EXPECT_EQ(status->inventory.selected_source_subjects, 1);
+    EXPECT_EQ(status->inventory.selected_source_subject_versions, 1);
+    EXPECT_EQ(status->last_full_sync->subject_versions_changed, 1);
+    EXPECT_EQ(status->last_full_sync->errors, 0);
+
+    const auto& all = _registry.get_all();
+    ASSERT_EQ(all.size(), 1);
+    EXPECT_EQ(all[0].schema.sub().sub(), ppsr::subject{"orders-value"});
+}
+
+TEST_F(mirroring_task_test, source_filter_excludes_unlisted_context) {
+    // The source has a default-context subject and a non-default-context
+    // subject. Filtering to the default context must exclude the non-default
+    // one from discovery -- and, because it is excluded, the run never needs
+    // qualified subjects for it.
+    auto orders = ppsr::context_subject::unqualified("orders-value");
+    auto other = ppsr::context_subject{
+      ppsr::context{".other"}, ppsr::subject{"x"}};
+    _source_state.contexts.push_back(ppsr::context{".other"});
+    _source_state.add(orders, 1);
+    _source_state.add(other, 1);
+
+    auto metadata = get_default_metadata();
+    metadata.configuration.schema_registry_sync_cfg.api_mode()
+      ->filter.contexts.push_back(std::string{ppsr::default_context()});
+
+    lead_schema_registry();
+    fixture()->upsert_link(std::move(metadata)).get();
+
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+
+    ASSERT_TRUE(status.has_value());
+    EXPECT_EQ(status->inventory.selected_source_subjects, 1);
+    EXPECT_EQ(status->inventory.selected_source_subject_versions, 1);
+    EXPECT_EQ(status->last_full_sync->subject_versions_changed, 1);
+    EXPECT_EQ(status->last_full_sync->errors, 0);
+
+    const auto& all = _registry.get_all();
+    ASSERT_EQ(all.size(), 1);
+    EXPECT_EQ(all[0].schema.sub().ctx, ppsr::default_context);
+}
+
+TEST_F(mirroring_task_test, syncs_soft_deleted_source_versions) {
+    auto orders = ppsr::context_subject::unqualified("orders-value");
+    auto payments = ppsr::context_subject::unqualified("payments-value");
+    // orders-value: v1 active, v2 soft-deleted. payments-value: only a
+    // soft-deleted v1 (no active version at all, so it is reached only because
+    // discovery enumerates deleted versions).
+    _source_state.add(orders, 1);
+    _source_state.add(orders, 2, ppsr::is_deleted::yes);
+    _source_state.add(payments, 1, ppsr::is_deleted::yes);
+
+    lead_schema_registry();
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+    ASSERT_TRUE(status.has_value());
+
+    // The selected-versions count spans active and soft-deleted discoveries
+    // (orders v1 + v2, payments v1), not just the active subset.
+    EXPECT_EQ(status->inventory.selected_source_subject_versions, 3);
+
+    // All three versions are synced, each preserving its source deleted state.
+    const auto& all = _registry.get_all();
+    EXPECT_EQ(all.size(), 3);
+    auto find_ver = [&](
+                      const ppsr::context_subject& sub,
+                      int32_t v) -> const ppsr::stored_schema* {
+        for (const auto& s : all) {
+            if (s.schema.sub() == sub && s.version == ppsr::schema_version{v}) {
+                return &s;
+            }
+        }
+        return nullptr;
+    };
+    const auto* o1 = find_ver(orders, 1);
+    const auto* o2 = find_ver(orders, 2);
+    const auto* p1 = find_ver(payments, 1);
+    ASSERT_NE(o1, nullptr);
+    ASSERT_NE(o2, nullptr);
+    ASSERT_NE(p1, nullptr);
+    EXPECT_EQ(o1->deleted, ppsr::is_deleted::no);
+    EXPECT_EQ(o2->deleted, ppsr::is_deleted::yes);
+    EXPECT_EQ(p1->deleted, ppsr::is_deleted::yes);
+}
+
+TEST_F(
+  mirroring_task_test, propagates_source_soft_delete_to_active_destination) {
+    auto orders = ppsr::context_subject::unqualified("orders-value");
+    // The destination holds orders-value:v1 active (a prior sync imported it);
+    // the source has since soft-deleted it. The run must propagate the delete
+    // by re-importing the deleted body over the live destination version.
+    seed_destination("orders-value", 1);
+    _source_state.add(orders, 1, ppsr::is_deleted::yes);
+
+    lead_schema_registry();
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    auto status
+      = wait_for_sync_status([](const auto& s) {
+            return s.last_full_sync.has_value() && !s.current_sync.has_value()
+                   && s.totals_since_task_start.subject_versions_changed >= 1;
+        }).get();
+    ASSERT_TRUE(status.has_value());
+
+    const auto& all = _registry.get_all();
+    ASSERT_EQ(all.size(), 1);
+    EXPECT_EQ(all[0].schema.sub(), orders);
+    EXPECT_EQ(all[0].version, ppsr::schema_version{1});
+    EXPECT_EQ(all[0].deleted, ppsr::is_deleted::yes);
+}
+
 TEST_F(mirroring_task_test, follows_partition_leadership) {
     auto subject = ppsr::context_subject::unqualified("orders-value");
     _source_state.add(subject, 1);
@@ -252,6 +522,33 @@ TEST_F(mirroring_task_test, follows_partition_leadership) {
     const auto* task = find_sr_status(report);
     ASSERT_NE(task, nullptr);
     EXPECT_FALSE(task->detail.has_value());
+}
+
+TEST_F(mirroring_task_test, destination_inventory_spans_contexts_and_deleted) {
+    auto a = ppsr::context_subject::unqualified("a");
+    auto c = ppsr::context_subject{ppsr::context{".b"}, ppsr::subject{"c"}};
+    // Default-context "a": v1 active, v2 soft-deleted. Context ".b" subject
+    // "c": v1 active. The scan must span both contexts and separate active from
+    // soft-deleted.
+    _registry.import_schema(make_schema(a, 1, R"({"v":1})")).get();
+    _registry
+      .import_schema(make_schema(a, 2, R"({"v":2})", ppsr::is_deleted::yes))
+      .get();
+    _registry.import_schema(make_schema(c, 1, R"({"v":1})")).get();
+
+    ss::abort_source as;
+    auto inv = srs::scan_destination_inventory(
+                 _registry,
+                 [](const ppsr::context_subject&) { return true; },
+                 as)
+                 .get();
+
+    auto a_v1 = ppsr::subject_version{a, ppsr::schema_version{1}};
+    auto a_v2 = ppsr::subject_version{a, ppsr::schema_version{2}};
+    auto c_v1 = ppsr::subject_version{c, ppsr::schema_version{1}};
+
+    EXPECT_THAT(inv.active, testing::UnorderedElementsAre(a_v1, c_v1));
+    EXPECT_THAT(inv.all, testing::UnorderedElementsAre(a_v1, c_v1, a_v2));
 }
 
 } // namespace cluster_link::tests

--- a/src/v/cluster_link/schema_registry_sync/tests/mirroring_task_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/mirroring_task_test.cc
@@ -11,6 +11,7 @@
 
 #include "cluster_link/schema_registry_sync/mirroring_task.h"
 #include "cluster_link/schema_registry_sync/source_reader.h"
+#include "cluster_link/schema_registry_sync/tests/sr_sync_test_fixtures.h"
 #include "cluster_link/tests/deps.h"
 #include "container/chunked_vector.h"
 #include "model/namespace.h"
@@ -20,29 +21,17 @@
 #include "test_utils/test.h"
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/sleep.hh>
 
 using namespace std::chrono_literals;
 
 namespace cluster_link::tests {
-
-namespace ppsr = pandaproxy::schema_registry;
-namespace srs = cluster_link::schema_registry_sync;
 
 namespace {
 
 static const model::name_t link_name{"test_sr_link"};
 constexpr auto tail_interval = 1s;
 constexpr auto wait_interval = 5s;
-
-ppsr::stored_schema make_schema(
-  const ppsr::context_subject& sub, int32_t version, std::string_view def) {
-    return ppsr::stored_schema{
-      .schema = ppsr::
-        subject_schema{sub, ppsr::schema_definition{ppsr::schema_definition::raw_string{def}, ppsr::schema_type::avro}},
-      .version = ppsr::schema_version{version},
-      .id = ppsr::schema_id{version},
-      .deleted = ppsr::is_deleted::no};
-}
 
 model::metadata get_default_metadata() {
     model::metadata metadata{
@@ -61,98 +50,6 @@ model::metadata get_default_metadata() {
     metadata.configuration.schema_registry_sync_cfg.sync_mode = std::move(api);
     return metadata;
 }
-
-/// Test-owned source-of-truth that the injected source reader serves from.
-struct fake_source_state {
-    chunked_vector<ppsr::stored_schema> schemas;
-    std::optional<srs::source_error> list_subjects_error;
-
-    void add(const ppsr::context_subject& sub, int32_t version) {
-        schemas.push_back(
-          make_schema(sub, version, fmt::format("{{\"v\":{}}}", version)));
-    }
-};
-
-class fake_source_reader final : public srs::source_reader {
-public:
-    explicit fake_source_reader(fake_source_state* state)
-      : _state(state) {}
-
-    ss::future<srs::source_result<chunked_vector<ppsr::context>>>
-    list_contexts(ss::abort_source&) override {
-        chunked_hash_set<ppsr::context> seen;
-        chunked_vector<ppsr::context> contexts;
-        for (const auto& s : _state->schemas) {
-            if (seen.insert(s.schema.sub().ctx).second) {
-                contexts.push_back(s.schema.sub().ctx);
-            }
-        }
-        co_return contexts;
-    }
-
-    ss::future<srs::source_result<chunked_vector<ppsr::context_subject>>>
-    list_subjects(ppsr::context ctx, ss::abort_source&) override {
-        if (_state->list_subjects_error.has_value()) {
-            co_return std::unexpected(*_state->list_subjects_error);
-        }
-        chunked_hash_set<ppsr::context_subject> seen;
-        chunked_vector<ppsr::context_subject> subjects;
-        for (const auto& s : _state->schemas) {
-            if (s.schema.sub().ctx != ctx) {
-                continue;
-            }
-            if (seen.insert(s.schema.sub()).second) {
-                subjects.push_back(s.schema.sub());
-            }
-        }
-        co_return subjects;
-    }
-
-    ss::future<srs::source_result<chunked_vector<ppsr::schema_version>>>
-    list_subject_versions(
-      ppsr::context_subject sub,
-      ppsr::include_deleted,
-      ss::abort_source&) override {
-        chunked_vector<ppsr::schema_version> versions;
-        for (const auto& s : _state->schemas) {
-            if (s.schema.sub() == sub) {
-                versions.push_back(s.version);
-            }
-        }
-        co_return versions;
-    }
-
-    ss::future<srs::source_result<ppsr::stored_schema>> read_subject_version(
-      ppsr::context_subject sub,
-      ppsr::schema_version version,
-      ss::abort_source&) override {
-        for (const auto& s : _state->schemas) {
-            if (s.schema.sub() == sub && s.version == version) {
-                co_return s.share();
-            }
-        }
-        co_return std::unexpected(
-          srs::source_error{
-            .kind = srs::source_error_kind::operation_failed,
-            .message = "not found in source"});
-    }
-
-private:
-    fake_source_state* _state;
-};
-
-class fake_source_reader_factory final : public srs::source_reader_factory {
-public:
-    explicit fake_source_reader_factory(fake_source_state* state)
-      : _state(state) {}
-
-    std::unique_ptr<srs::source_reader> create() override {
-        return std::make_unique<fake_source_reader>(_state);
-    }
-
-private:
-    fake_source_state* _state;
-};
 
 } // namespace
 

--- a/src/v/cluster_link/schema_registry_sync/tests/mirroring_task_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/mirroring_task_test.cc
@@ -279,14 +279,21 @@ TEST_F(mirroring_task_test, populates_source_and_destination_inventory) {
     ASSERT_TRUE(status.has_value());
     EXPECT_EQ(status->inventory.selected_source_subjects, 1);
     EXPECT_EQ(status->inventory.selected_source_subject_versions, 2);
-    EXPECT_EQ(status->inventory.destination_subjects, 1);
-    EXPECT_EQ(status->inventory.destination_subject_versions, 1);
-    // Nothing is imported yet, so the destination is unchanged.
-    EXPECT_EQ(status->totals_since_task_start.subject_versions_changed, 0);
+    // The destination counters are refreshed after the import, so they reflect
+    // the post-sync state: the seeded payments-value plus the two imported
+    // orders-value versions.
+    EXPECT_EQ(status->inventory.destination_subjects, 2);
+    EXPECT_EQ(status->inventory.destination_subject_versions, 3);
+    // The two source versions are absent from the destination, so the reconcile
+    // imports both.
+    EXPECT_EQ(status->totals_since_task_start.subject_versions_changed, 2);
     EXPECT_EQ(status->last_full_sync->errors, 0);
 }
 
 TEST_F(mirroring_task_test, source_unavailable_is_unavailable) {
+    // A context must exist for discovery to reach list_subjects, where the
+    // source reports itself unavailable.
+    _source_state.add(ppsr::context_subject::unqualified("orders-value"), 1);
     _source_state.list_subjects_error = srs::source_error{
       .kind = srs::source_error_kind::source_unavailable,
       .message = "source down"};

--- a/src/v/cluster_link/schema_registry_sync/tests/reconciler_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/reconciler_test.cc
@@ -242,6 +242,57 @@ TEST(reconciler, seed_replicated_upsert_is_still_imported) {
     EXPECT_GE(h.source.reads(a, 1), 1);
 }
 
+// A soft-deleted source version imports preserving its deleted state: the
+// reconciler fetches the body (which carries the flag) and import_schema stores
+// it soft-deleted. Underpins the task syncing soft-deleted source versions
+// preserving their deleted state.
+TEST(reconciler, imports_soft_deleted_as_deleted) {
+    reconcile_harness h;
+    auto a = ppsr::context_subject::unqualified("a");
+    h.source.add(a, 1, ppsr::is_deleted::yes);
+
+    srs::work_set work;
+    work.upserts.push_back(key(a, 1));
+
+    auto stats = h.run(std::move(work)).get();
+    ASSERT_TRUE(stats.has_value());
+    EXPECT_EQ(stats->versions_changed, 1);
+    EXPECT_EQ(stats->errors, 0);
+
+    const auto& all = h.destination.get_all();
+    auto ia = index_of(all, "a");
+    ASSERT_GE(ia, 0);
+    EXPECT_EQ(all[ia].deleted, ppsr::is_deleted::yes);
+}
+
+// Soft-delete propagation onto an active destination version: re-importing the
+// source body (which now carries deleted=yes) transitions an existing active
+// version to soft-deleted. The node is in the seed (a destination version is in
+// `all`), so this also guards that a seeded upsert is still imported. Underpins
+// the task propagating a source soft-delete onto a live destination version.
+TEST(reconciler, propagates_soft_delete_over_active_destination) {
+    reconcile_harness h;
+    auto a = ppsr::context_subject::unqualified("a");
+    // Destination already holds a:v1 active; the source has soft-deleted it.
+    h.destination.import_schema(make_schema(a, 1, R"({"v":1})")).get();
+    h.source.add(a, 1, ppsr::is_deleted::yes);
+
+    chunked_hash_set<ppsr::subject_version> seed;
+    seed.insert(key(a, 1));
+    srs::work_set work;
+    work.upserts.push_back(key(a, 1));
+
+    auto stats = h.run(std::move(work), std::move(seed)).get();
+    ASSERT_TRUE(stats.has_value());
+    EXPECT_EQ(stats->versions_changed, 1);
+    EXPECT_EQ(stats->errors, 0);
+
+    const auto& all = h.destination.get_all();
+    auto ia = index_of(all, "a");
+    ASSERT_GE(ia, 0);
+    EXPECT_EQ(all[ia].deleted, ppsr::is_deleted::yes);
+}
+
 TEST(reconciler, cyclic_source_does_not_hang) {
     reconcile_harness h;
     auto a = ppsr::context_subject::unqualified("a");

--- a/src/v/cluster_link/schema_registry_sync/tests/scope_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/scope_test.cc
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster_link/schema_registry_sync/scope.h"
+#include "pandaproxy/schema_registry/types.h"
+#include "test_utils/test.h"
+
+namespace cluster_link::tests {
+
+namespace ppsr = pandaproxy::schema_registry;
+namespace srs = cluster_link::schema_registry_sync;
+
+TEST(scope, in_scope_predicate_matches_configured_contexts) {
+    chunked_hash_set<ppsr::context> contexts{
+      ppsr::default_context, ppsr::context{".b"}};
+    // Empty subject set: no per-subject restriction within the in-scope
+    // contexts.
+    auto in_scope = srs::make_in_scope(std::move(contexts), {});
+
+    EXPECT_TRUE(in_scope(ppsr::context_subject::unqualified("orders")));
+    EXPECT_TRUE(
+      in_scope(ppsr::context_subject{ppsr::context{".b"}, ppsr::subject{"x"}}));
+    EXPECT_FALSE(
+      in_scope(ppsr::context_subject{ppsr::context{".c"}, ppsr::subject{"x"}}));
+}
+
+TEST(scope, in_scope_filter_union_semantics) {
+    // The source filter's context and subject selectors union: contexts select
+    // whole contexts, subjects add individual context-qualified subjects, and
+    // an empty filter replicates everything. Every scenario checks the same
+    // four subjects in the same order, so the cases read as a truth table:
+    //   * default_a:     subject "a" in the default context
+    //   * other_x:       subject "x" in the .other context
+    //   * example:       subject "example" in the .onemore context
+    //   * onemore_other: subject "other" in the .onemore context (the rest of
+    //                    .onemore that an individual `example` selector leaves
+    //                    out)
+    const auto other = ppsr::context{".other"};
+    const auto onemore = ppsr::context{".onemore"};
+    const auto default_a = ppsr::context_subject::unqualified("a");
+    const auto other_x = ppsr::context_subject{other, ppsr::subject{"x"}};
+    const auto example = ppsr::context_subject{
+      onemore, ppsr::subject{"example"}};
+    const auto onemore_other = ppsr::context_subject{
+      onemore, ppsr::subject{"other"}};
+
+    auto ctxs = [](std::initializer_list<ppsr::context> cs) {
+        chunked_hash_set<ppsr::context> out;
+        for (const auto& c : cs) {
+            out.insert(c);
+        }
+        return out;
+    };
+    auto subs = [](std::initializer_list<ppsr::context_subject> ss) {
+        chunked_hash_set<ppsr::context_subject> out;
+        for (const auto& s : ss) {
+            out.insert(s);
+        }
+        return out;
+    };
+
+    // No filter: every subject is in scope.
+    {
+        auto in_scope = srs::make_in_scope(ctxs({}), subs({}));
+        EXPECT_TRUE(in_scope(default_a));
+        EXPECT_TRUE(in_scope(other_x));
+        EXPECT_TRUE(in_scope(example));
+        EXPECT_TRUE(in_scope(onemore_other));
+    }
+    // Context selector only: the whole .other context, nothing else.
+    {
+        auto in_scope = srs::make_in_scope(ctxs({other}), subs({}));
+        EXPECT_FALSE(in_scope(default_a));
+        EXPECT_TRUE(in_scope(other_x));
+        EXPECT_FALSE(in_scope(example));
+        EXPECT_FALSE(in_scope(onemore_other));
+    }
+    // Context UNION subject: all of .other, plus the single .onemore:example;
+    // the rest of .onemore stays out.
+    {
+        auto in_scope = srs::make_in_scope(ctxs({other}), subs({example}));
+        EXPECT_FALSE(in_scope(default_a));
+        EXPECT_TRUE(in_scope(other_x));
+        EXPECT_TRUE(in_scope(example));
+        EXPECT_FALSE(in_scope(onemore_other));
+    }
+    // Subject selector only: just the single .onemore:example subject.
+    {
+        auto in_scope = srs::make_in_scope(ctxs({}), subs({example}));
+        EXPECT_FALSE(in_scope(default_a));
+        EXPECT_FALSE(in_scope(other_x));
+        EXPECT_TRUE(in_scope(example));
+        EXPECT_FALSE(in_scope(onemore_other));
+    }
+}
+
+} // namespace cluster_link::tests

--- a/src/v/cluster_link/schema_registry_sync/tests/scope_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/scope_test.cc
@@ -18,6 +18,15 @@ namespace cluster_link::tests {
 namespace ppsr = pandaproxy::schema_registry;
 namespace srs = cluster_link::schema_registry_sync;
 
+namespace {
+model::schema_registry_sync_config config_with(
+  model::schema_registry_sync_config::shadow_schema_registry_api api = {}) {
+    model::schema_registry_sync_config config;
+    config.sync_mode = std::move(api);
+    return config;
+}
+} // namespace
+
 TEST(scope, in_scope_predicate_matches_configured_contexts) {
     chunked_hash_set<ppsr::context> contexts{
       ppsr::default_context, ppsr::context{".b"}};
@@ -100,6 +109,105 @@ TEST(scope, in_scope_filter_union_semantics) {
         EXPECT_TRUE(in_scope(example));
         EXPECT_FALSE(in_scope(onemore_other));
     }
+}
+
+TEST(scope, preconditions_remapping_target_requires_qualified) {
+    model::schema_registry_sync_config::shadow_schema_registry_api api;
+    model::schema_registry_sync_config::exact_context_mapping mapping;
+    mapping.mappings.emplace(".", ".prod"); // default -> non-default target
+    api.destination = std::move(mapping);
+    auto config = config_with(std::move(api));
+
+    chunked_hash_set<ppsr::context> in_scope;
+    in_scope.insert(ppsr::default_context);
+    // Flag off rejects the non-default target; flag on allows any context.
+    EXPECT_TRUE(srs::check_preconditions(config, in_scope, false).has_value());
+    EXPECT_FALSE(srs::check_preconditions(config, in_scope, true).has_value());
+}
+
+TEST(scope, preconditions_remapping_to_default_allowed) {
+    model::schema_registry_sync_config::shadow_schema_registry_api api;
+    model::schema_registry_sync_config::exact_context_mapping mapping;
+    mapping.mappings.emplace(".src", "."); // non-default source -> default
+    api.destination = std::move(mapping);
+    auto config = config_with(std::move(api));
+
+    // The non-default source context (in_scope) is irrelevant under remapping:
+    // only the default target is written.
+    chunked_hash_set<ppsr::context> in_scope;
+    in_scope.insert(ppsr::context{".src"});
+    EXPECT_FALSE(srs::check_preconditions(config, in_scope, false).has_value());
+}
+
+TEST(scope, preconditions_nondefault_filter_requires_qualified) {
+    chunked_hash_set<ppsr::context> empty;
+
+    // A non-default context filter faults eagerly, before the source is known
+    // to hold the context.
+    {
+        model::schema_registry_sync_config::shadow_schema_registry_api api;
+        api.filter.contexts.push_back(".prod");
+        auto config = config_with(std::move(api));
+        EXPECT_TRUE(srs::check_preconditions(config, empty, false).has_value());
+        EXPECT_FALSE(srs::check_preconditions(config, empty, true).has_value());
+    }
+    // A subject filter in qualified syntax names a non-default context; it is
+    // parsed as qualified so the off flag cannot flatten it to a default
+    // subject and hide the fault.
+    {
+        model::schema_registry_sync_config::shadow_schema_registry_api api;
+        api.filter.subjects.push_back(":.prod:orders");
+        auto config = config_with(std::move(api));
+        EXPECT_TRUE(srs::check_preconditions(config, empty, false).has_value());
+        EXPECT_FALSE(srs::check_preconditions(config, empty, true).has_value());
+    }
+}
+
+TEST(scope, preconditions_explicit_identity_matches_no_destination) {
+    // An explicit identity mapping is the default (no-destination) case, so a
+    // non-default filter context must fault identically -- the two config
+    // spellings cannot diverge.
+    model::schema_registry_sync_config::shadow_schema_registry_api api;
+    api.filter.contexts.push_back(".prod");
+    api.destination
+      = model::schema_registry_sync_config::identity_context_mapping{};
+    auto config = config_with(std::move(api));
+
+    chunked_hash_set<ppsr::context> empty;
+    EXPECT_TRUE(srs::check_preconditions(config, empty, false).has_value());
+    EXPECT_FALSE(srs::check_preconditions(config, empty, true).has_value());
+}
+
+TEST(scope, preconditions_remapping_ignores_source_filter) {
+    // Mapping a non-default source context onto the default destination is
+    // allowed even with the flag off: the source-filter name is remapped away,
+    // so only the (default) target is written.
+    model::schema_registry_sync_config::shadow_schema_registry_api api;
+    api.filter.contexts.push_back(".prod");
+    model::schema_registry_sync_config::exact_context_mapping mapping;
+    mapping.mappings.emplace(".prod", "."); // non-default source -> default
+    api.destination = std::move(mapping);
+    auto config = config_with(std::move(api));
+
+    chunked_hash_set<ppsr::context> in_scope;
+    in_scope.insert(ppsr::context{".prod"});
+    EXPECT_FALSE(srs::check_preconditions(config, in_scope, false).has_value());
+}
+
+TEST(scope, preconditions_require_qualified_subjects_for_nondefault) {
+    auto config = config_with();
+
+    chunked_hash_set<ppsr::context> nondefault;
+    nondefault.insert(ppsr::context{".b"});
+    EXPECT_TRUE(
+      srs::check_preconditions(config, nondefault, false).has_value());
+    EXPECT_FALSE(
+      srs::check_preconditions(config, nondefault, true).has_value());
+
+    chunked_hash_set<ppsr::context> default_only;
+    default_only.insert(ppsr::default_context);
+    EXPECT_FALSE(
+      srs::check_preconditions(config, default_only, false).has_value());
 }
 
 } // namespace cluster_link::tests

--- a/src/v/cluster_link/schema_registry_sync/tests/sr_sync_test_fixtures.h
+++ b/src/v/cluster_link/schema_registry_sync/tests/sr_sync_test_fixtures.h
@@ -107,6 +107,7 @@ key(const ppsr::context_subject& sub, int32_t version) {
 struct fake_source_state {
     chunked_vector<ppsr::context> contexts{ppsr::default_context};
     chunked_vector<ppsr::stored_schema> schemas;
+    std::optional<srs::source_error> list_contexts_error;
     std::optional<srs::source_error> list_subjects_error;
     // Forces list_subject_versions to fail for specific subjects, letting a
     // test inject a per-subject enumeration failure (e.g. operation_failed)
@@ -171,6 +172,9 @@ public:
 
     ss::future<srs::source_result<chunked_vector<ppsr::context>>>
     list_contexts(ss::abort_source&) override {
+        if (_state->list_contexts_error.has_value()) {
+            co_return std::unexpected(*_state->list_contexts_error);
+        }
         co_return _state->contexts.copy();
     }
 

--- a/src/v/cluster_link/schema_registry_sync/tests/sr_sync_test_fixtures.h
+++ b/src/v/cluster_link/schema_registry_sync/tests/sr_sync_test_fixtures.h
@@ -24,8 +24,8 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
+#include <seastar/util/noncopyable_function.hh>
 
-#include <functional>
 #include <memory>
 #include <vector>
 
@@ -273,7 +273,7 @@ struct reconcile_harness {
     srs::reconciler::limits lim{.memory_bytes = 1u << 20, .parallelism = 1};
 
     srs::reconciler make(
-      std::function<bool(const ppsr::context_subject&)> in_scope =
+      ss::noncopyable_function<bool(const ppsr::context_subject&)> in_scope =
         [](const ppsr::context_subject&) { return true; }) {
         return srs::reconciler{&reader, &destination, std::move(in_scope), lim};
     }
@@ -325,7 +325,7 @@ public:
     }
     ss::future<chunked_vector<ppsr::subject_version_deleted>>
     list_subject_versions(
-      std::function<bool(const ppsr::context_subject&)> filter,
+      ss::noncopyable_function<bool(const ppsr::context_subject&)> filter,
       ppsr::include_deleted inc) const override {
         return _inner->list_subject_versions(std::move(filter), inc);
     }

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3953,6 +3953,22 @@ configuration::configuration()
       "context.",
       {.needs_restart = needs_restart::yes, .visibility = visibility::user},
       true)
+  , schema_registry_sync_memory_bytes(
+      *this,
+      "schema_registry_sync_memory_bytes",
+      "Maximum bytes of schema bodies held in memory at once while a schema "
+      "registry cluster link reconciles from the source.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      16_MiB,
+      {.min = 1_MiB})
+  , schema_registry_sync_parallelism(
+      *this,
+      "schema_registry_sync_parallelism",
+      "Maximum number of schemas imported concurrently while a schema registry "
+      "cluster link reconciles from the source.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      4,
+      {.min = 1, .max = 1024})
   , pp_sr_smp_max_non_local_requests(
       *this,
       "pp_sr_smp_max_non_local_requests",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -682,6 +682,8 @@ struct configuration final : public config_store {
     property<bool> schema_registry_always_normalize;
     deprecated_property schema_registry_avro_use_named_references;
     property<bool> schema_registry_enable_qualified_subjects;
+    bounded_property<size_t> schema_registry_sync_memory_bytes;
+    bounded_property<size_t> schema_registry_sync_parallelism;
     property<std::optional<uint32_t>> pp_sr_smp_max_non_local_requests;
     bounded_property<size_t> max_in_flight_schema_registry_requests_per_shard;
     bounded_property<size_t> max_in_flight_pandaproxy_requests_per_shard;

--- a/src/v/datalake/tests/record_schema_resolver_test.cc
+++ b/src/v/datalake/tests/record_schema_resolver_test.cc
@@ -611,8 +611,8 @@ public:
     ss::future<
       chunked_vector<pandaproxy::schema_registry::subject_version_deleted>>
     list_subject_versions(
-      std::function<bool(const pandaproxy::schema_registry::context_subject&)>
-        filter,
+      ss::noncopyable_function<
+        bool(const pandaproxy::schema_registry::context_subject&)> filter,
       pandaproxy::schema_registry::include_deleted inc_del) const override {
         return _registry.list_subject_versions(std::move(filter), inc_del);
     }

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -442,9 +442,12 @@ ss::future<chunked_vector<context_subject>> sharded_store::get_subjects(
 
 ss::future<chunked_vector<subject_version_deleted>>
 sharded_store::list_subject_versions(
-  std::function<bool(const context_subject&)> filter, include_deleted inc_del) {
+  ss::noncopyable_function<bool(const context_subject&)> filter,
+  include_deleted inc_del) {
     using result_t = chunked_vector<subject_version_deleted>;
-    auto map = [filter = std::move(filter), inc_del](store& s) {
+    // Captured by reference because it is move-only; the coroutine frame keeps
+    // `filter` alive for the scan.
+    auto map = [&filter, inc_del](store& s) {
         result_t out;
         for (const auto& sub : s.get_subjects(inc_del)) {
             if (!filter(sub)) {

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -16,8 +16,7 @@
 #include "pandaproxy/schema_registry/types.h"
 
 #include <seastar/core/sharded.hh>
-
-#include <functional>
+#include <seastar/util/noncopyable_function.hh>
 
 namespace pandaproxy::schema_registry {
 
@@ -115,7 +114,7 @@ public:
     /// version's soft-delete state, so an include_deleted scan reports both the
     /// live and deleted nodes in one pass.
     ss::future<chunked_vector<subject_version_deleted>> list_subject_versions(
-      std::function<bool(const context_subject&)> filter,
+      ss::noncopyable_function<bool(const context_subject&)> filter,
       include_deleted inc_del);
 
     ///\brief Return whether there are any subjects.

--- a/src/v/schema/registry.cc
+++ b/src/v/schema/registry.cc
@@ -79,7 +79,7 @@ public:
     }
     ss::future<chunked_vector<ppsr::subject_version_deleted>>
     list_subject_versions(
-      std::function<bool(const ppsr::context_subject&)> filter,
+      ss::noncopyable_function<bool(const ppsr::context_subject&)> filter,
       ppsr::include_deleted inc_del) const override {
         auto [reader, _] = co_await service();
         co_return co_await reader->list_subject_versions(
@@ -213,7 +213,7 @@ public:
     }
     ss::future<chunked_vector<ppsr::subject_version_deleted>>
     list_subject_versions(
-      std::function<bool(const ppsr::context_subject&)>,
+      ss::noncopyable_function<bool(const ppsr::context_subject&)>,
       ppsr::include_deleted) const override {
         throw std::logic_error(
           "invalid attempted usage of a disabled schema registry");

--- a/src/v/schema/registry.h
+++ b/src/v/schema/registry.h
@@ -15,7 +15,7 @@
 #include "pandaproxy/schema_registry/schema_getter.h"
 #include "pandaproxy/schema_registry/types.h"
 
-#include <functional>
+#include <seastar/util/noncopyable_function.hh>
 
 namespace schema {
 /**
@@ -72,13 +72,13 @@ public:
         std::optional<pandaproxy::schema_registry::schema_version>) const = 0;
 
     /// Lists every (subject, version) whose subject matches `filter`, each
-    /// carrying its version's soft-delete state. The predicate must be pure and
-    /// copyable (it runs on each registry shard).
+    /// carrying its version's soft-delete state. The predicate must be pure; it
+    /// is invoked on each registry shard.
     virtual ss::future<
       chunked_vector<pandaproxy::schema_registry::subject_version_deleted>>
     list_subject_versions(
-      std::function<bool(const pandaproxy::schema_registry::context_subject&)>
-        filter,
+      ss::noncopyable_function<
+        bool(const pandaproxy::schema_registry::context_subject&)> filter,
       pandaproxy::schema_registry::include_deleted) const = 0;
 
     virtual ss::future<pandaproxy::schema_registry::context_schema_id>

--- a/src/v/schema/tests/fake_registry.cc
+++ b/src/v/schema/tests/fake_registry.cc
@@ -103,7 +103,7 @@ ss::future<ppsr::schema_getter*> schema::fake_registry::getter() const {
 }
 ss::future<chunked_vector<ppsr::subject_version_deleted>>
 schema::fake_registry::list_subject_versions(
-  std::function<bool(const ppsr::context_subject&)> filter,
+  ss::noncopyable_function<bool(const ppsr::context_subject&)> filter,
   ppsr::include_deleted inc_del) const {
     maybe_throw_injected_failure();
     chunked_vector<ppsr::subject_version_deleted> out;

--- a/src/v/schema/tests/fake_registry.h
+++ b/src/v/schema/tests/fake_registry.h
@@ -14,8 +14,8 @@
 #include "schema/registry.h"
 
 #include <seastar/core/future.hh>
+#include <seastar/util/noncopyable_function.hh>
 
-#include <functional>
 #include <map>
 
 namespace schema {
@@ -67,8 +67,8 @@ public:
     ss::future<
       chunked_vector<pandaproxy::schema_registry::subject_version_deleted>>
     list_subject_versions(
-      std::function<bool(const pandaproxy::schema_registry::context_subject&)>
-        filter,
+      ss::noncopyable_function<
+        bool(const pandaproxy::schema_registry::context_subject&)> filter,
       pandaproxy::schema_registry::include_deleted inc_del) const override;
 
     ss::future<pandaproxy::schema_registry::context_schema_id> create_schema(


### PR DESCRIPTION
This PR wires in the schema reconciler into the schema mirroring task to actually sync schemas (both non-deleted and soft-deleted) into the destination schema registry. It starts respecting the scope filtering config.

A check is added against the value of `schema_registry_enable_qualified_subjects` to require that context support is enabled if context-related functionality is being used.

See the commit messages for details.

Fixes https://redpandadata.atlassian.net/browse/CORE-16645

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
