### PR TITLE
c/a/segment_collector: demote benign reupload skip log to debug

### DIFF
--- a/src/v/cluster/archival/segment_reupload.cc
+++ b/src/v/cluster/archival/segment_reupload.cc
@@ -263,9 +263,9 @@ void segment_collector::collect_segments() {
       is_reupload_mode(_mode)
       && _begin_inclusive > _manifest.get_last_offset()) {
         vlog(
-          archival_log.warn,
-          "Start offset {} is ahead of manifest last offset {} for ntp {}, not "
-          "a reupload",
+          archival_log.debug,
+          "Start offset {} is ahead of manifest last offset {} for ntp {}, "
+          "nothing to reupload",
           _begin_inclusive,
           _manifest.get_last_offset(),
           _manifest.get_ntp());


### PR DESCRIPTION
When the local log start is entirely above the manifest tail (after recovery, or once retention evicts everything below it), a compacted reupload advances its begin offset to the log start, past the manifest last offset. That is a normal "nothing to reupload" state, so warn was needlessly alarming. Demote to debug.

See dbc55b6e90fd, which already treated this line as logging-only.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
