### PR TITLE
kafka: chunk describe ACLs response to avoid oversized-allocation crash

### DIFF
--- a/src/v/kafka/server/handlers/describe_acls.cc
+++ b/src/v/kafka/server/handlers/describe_acls.cc
@@ -11,6 +11,7 @@
 #include "kafka/server/handlers/describe_acls.h"
 
 #include "cluster/security_frontend.h"
+#include "container/chunked_hash_map.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/server/handlers/details/security.h"
 #include "kafka/server/request_context.h"
@@ -30,7 +31,7 @@ static void fill_response(
     /*
      * collapse common acls by pattern
      */
-    absl::flat_hash_map<
+    chunked_hash_map<
       security::resource_pattern,
       chunked_vector<security::acl_entry>>
       entries;

--- a/tests/rptest/tests/describe_acls_scale_test.py
+++ b/tests/rptest/tests/describe_acls_scale_test.py
@@ -1,0 +1,74 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+import math
+import time
+
+from ducktape.mark import parametrize
+from ducktape.tests.test import TestContext
+
+from rptest.clients.rpk import RpkTool, RPKACLInput
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class DescribeAclsScaleTest(RedpandaTest):
+    """DescribeAcls groups matching bindings by resource pattern, so a
+    non-chunked container makes one allocation that grows with the pattern
+    count and overflows at scale (CORE-16758). The harness fails the test if a
+    broker logs an `oversized allocation` above 200KiB while building the
+    response.
+    """
+
+    PRINCIPAL = "User:scale-test"
+    BATCH_SIZE = 1000
+
+    def __init__(self, test_context: TestContext) -> None:
+        super().__init__(test_context=test_context, num_brokers=1)
+        self._rpk = RpkTool(self.redpanda)
+
+    def _create_topic_acls(self, num_acls: int) -> None:
+        """Create num_acls allow-read ACLs, one per distinct topic, to seed
+        that many resource patterns. The topics need not exist. Batched into
+        single rpk invocations of BATCH_SIZE."""
+        created = 0
+        while created < num_acls:
+            end = min(created + self.BATCH_SIZE, num_acls)
+            topics = [f"scale-topic-{i}" for i in range(created, end)]
+            self._rpk.acl_create(
+                RPKACLInput(
+                    allow_principal=[self.PRINCIPAL],
+                    operation=["read"],
+                    topic=topics,
+                )
+            )
+            created = end
+
+    @cluster(num_nodes=1)
+    @parametrize(num_acls=10000)
+    def test_describe_acls_at_scale(self, num_acls: int) -> None:
+        # Each CreateACLs batch replicates as a single create_acls_cmd
+        # controller record (not one per binding), so raise the guard by the
+        # batch count.
+        num_batches = math.ceil(num_acls / self.BATCH_SIZE)
+        self.redpanda.set_expected_controller_records(1000 + num_batches)
+
+        seed_start = time.time()
+        self._create_topic_acls(num_acls)
+        self.logger.info(f"created {num_acls} ACLs in {time.time() - seed_start:.1f}s")
+
+        # DescribeAcls builds the grouping container with num_acls patterns.
+        list_start = time.time()
+        out = self._rpk.acl_list()
+        self.logger.info(f"described ACLs in {time.time() - list_start:.1f}s")
+
+        # Sanity check that the describe returned the seeded ACLs.
+        found = out.count(self.PRINCIPAL)
+        assert found >= num_acls, (
+            f"expected at least {num_acls} ACL rows in describe response, found {found}"
+        )


### PR DESCRIPTION
`DescribeAcls` collapses matching bindings into the response keyed by resource
pattern, using a `flat_hash_map`. Its single contiguous backing array grows
with the distinct-pattern count (topics + schema subjects); on a large cluster
(~10k topics, 26.1.10) it reaches the MB range. Such a large contiguous
allocation can fail under heap fragmentation even with free memory, which
aborted the broker in the reported incident; at smaller scale it surfaces as an
oversized-allocation warning.

Swap the grouping map to `chunked_hash_map` so storage is allocated in bounded
chunks. The added ducktape scale test seeds 10k distinct-resource ACLs and
issues a `DescribeAcls`; the harness fails on the old code
(`oversized allocation: 331776 bytes`) and passes with the fix.

Fixes [CORE-16758](https://redpandadata.atlassian.net/browse/CORE-16758)

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes

### Bug Fixes

* Fixed a broker crash that could occur when describing ACLs on clusters with a
  large number of ACLs.


[CORE-16758]: https://redpandadata.atlassian.net/browse/CORE-16758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ