### PR TITLE
`security`: store ACLs in a non-contiguous chunked set

### DIFF
--- a/src/v/security/BUILD
+++ b/src/v/security/BUILD
@@ -156,6 +156,7 @@ redpanda_cc_library(
         "//src/v/bytes",
         "//src/v/bytes:random",
         "//src/v/config",
+        "//src/v/container:chunked_hash_map",
         "//src/v/container:chunked_vector",
         "//src/v/container:radix_tree",
         "//src/v/crypto",

--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -173,7 +173,7 @@ acl_store::find(resource_type resource, const ss::sstring& name) const {
 
     opt_entry_set wildcards;
     if (const auto it = _acls.find(wildcard_pattern); it != _acls.end()) {
-        wildcards = {it->first, it->second};
+        wildcards = {(*it)->pattern, (*it)->entries};
     }
 
     const resource_pattern_probe literal_pattern(
@@ -181,7 +181,7 @@ acl_store::find(resource_type resource, const ss::sstring& name) const {
 
     opt_entry_set literals;
     if (const auto it = _acls.find(literal_pattern); it != _acls.end()) {
-        literals = {it->first, it->second};
+        literals = {(*it)->pattern, (*it)->entries};
     }
 
     /*
@@ -222,7 +222,8 @@ chunked_vector<chunked_vector<acl_binding>> acl_store::remove_bindings(
       resources;
 
     // collect binding filters that match resources
-    for (auto& [pattern, entries] : _acls) {
+    for (const auto& node : _acls) {
+        const auto& pattern = node->pattern;
         for (size_t i = 0U; i < filters.size(); i++) {
             const auto& filter = filters[i];
             if (filter.pattern().matches(pattern)) {
@@ -268,7 +269,7 @@ chunked_vector<chunked_vector<acl_binding>> acl_store::remove_bindings(
 
         // remove matching entries and track the deleted binding along with the
         // index of the filter that matched the entry.
-        it->second.erase_if(
+        (*it)->entries.erase_if(
           [&filters, &resource, &deleted, &maybe_roles, dry_run](
             const acl_entry& entry) {
               for (const auto& filter : filters) {
@@ -286,7 +287,7 @@ chunked_vector<chunked_vector<acl_binding>> acl_store::remove_bindings(
               return false;
           });
         for (const auto& principal : maybe_roles) {
-            it->second.remove_if_role(principal);
+            (*it)->entries.remove_if_role(principal);
         }
         // ensure that elements won't outlive the corresponding bindings
         // in enclosing scope.
@@ -297,7 +298,7 @@ chunked_vector<chunked_vector<acl_binding>> acl_store::remove_bindings(
         // references `_acls` elements, so its entry must be dropped in lockstep
         // with the `_acls` key (see the `_acls` invariant). `resource` is a key
         // in `resources`, not in `_acls`, so it stays valid past the erase.
-        if (!dry_run && it->second.empty()) {
+        if (!dry_run && (*it)->entries.empty()) {
             if (resource.pattern() == pattern_type::prefixed) {
                 if (
                   auto idx = _prefix_index.find(resource.resource());
@@ -330,9 +331,9 @@ chunked_vector<chunked_vector<acl_binding>> acl_store::remove_bindings(
 chunked_vector<acl_binding>
 acl_store::acls(const acl_binding_filter& filter) const {
     chunked_vector<acl_binding> result;
-    for (const auto& acl : _acls) {
-        for (const auto& entry : acl.second) {
-            acl_binding binding(acl.first, entry);
+    for (const auto& node : _acls) {
+        for (const auto& entry : node->entries) {
+            acl_binding binding(node->pattern, entry);
             if (filter.matches(binding)) {
                 result.push_back(binding);
             }
@@ -343,9 +344,9 @@ acl_store::acls(const acl_binding_filter& filter) const {
 
 ss::future<chunked_vector<acl_binding>> acl_store::all_bindings() const {
     chunked_vector<acl_binding> result;
-    for (const auto& acl : _acls) {
-        for (const auto& entry : acl.second) {
-            result.push_back(acl_binding{acl.first, entry});
+    for (const auto& node : _acls) {
+        for (const auto& entry : node->entries) {
+            result.push_back(acl_binding{node->pattern, entry});
             co_await ss::coroutine::maybe_yield();
         }
     }
@@ -360,7 +361,8 @@ acl_store::reset_bindings(const chunked_vector<acl_binding>& bindings) {
     return ss::do_for_each(
              bindings, [this](const auto& binding) { insert_binding(binding); })
       .then([this] {
-          return ss::do_for_each(_acls, [](auto& kv) { kv.second.rehash(); });
+          return ss::do_for_each(
+            _acls, [](const auto& node) { node->entries.rehash(); });
       });
 }
 

--- a/src/v/security/acl_store.h
+++ b/src/v/security/acl_store.h
@@ -10,14 +10,15 @@
  */
 #pragma once
 #include "absl/container/flat_hash_map.h"
-#include "absl/container/node_hash_map.h"
 #include "absl/hash/hash.h"
+#include "container/chunked_hash_map.h"
 #include "container/chunked_vector.h"
 #include "container/radix_tree.h"
 #include "security/acl.h"
 #include "security/acl_entry_set.h"
 
 #include <functional>
+#include <memory>
 #include <string_view>
 #include <tuple>
 
@@ -25,9 +26,11 @@ namespace security {
 
 /*
  * A lightweight, non-owning reference to one (pattern, entry set) pair held by
- * an acl_store. `_acls` is a node-based map, so these references stay valid
- * across inserts and erasures of *other* patterns; they are invalidated only
- * when this pattern itself is erased (see acl_store::find()).
+ * an acl_store. The pair lives in a heap-allocated node owned by `_acls` via a
+ * unique_ptr, so these references stay valid across inserts and erasures of
+ * *other* patterns (the map may relocate the unique_ptr, but never the node it
+ * points at); they are invalidated only when this pattern itself is erased (see
+ * acl_store::find()).
  */
 struct acl_entry_set_match {
     std::reference_wrapper<const resource_pattern> resource;
@@ -62,11 +65,12 @@ public:
     chunked_vector<acl_binding> acls(const acl_binding_filter&) const;
 
     /**
-     * WARNING: The returned acl_matches holds references into `_acls`. Because
-     * `_acls` is node-based these survive inserts and removals of *other*
-     * patterns, but reset_bindings() (or erasing a referenced pattern) frees
-     * the referents. Do not use an acl_matches across a yield point or any
-     * acl_store mutation: doing so may result in UNDEFINED BEHAVIOR.
+     * WARNING: The returned acl_matches holds references into `_acls`. The
+     * entry sets live in heap-owned nodes, so these survive inserts and
+     * removals of *other* patterns, but reset_bindings() (or erasing a
+     * referenced pattern) frees the referents. Do not use an acl_matches across
+     * a yield point or any acl_store mutation: doing so may result in UNDEFINED
+     * BEHAVIOR.
      */
     acl_matches find(resource_type, const ss::sstring&) const;
 
@@ -87,19 +91,36 @@ private:
     };
 
     /*
-     * Normalize a resource_pattern or resource_pattern_probe to a common key:
-     * the name is viewed as bytes so a probe and the resource_pattern it stands
-     * in for produce an identical key. Sharing this between the hash and the
-     * equality keeps the two consistent and enables allocation-free
-     * heterogeneous lookups.
+     * The (pattern, entry set) pair, heap-allocated and owned by `_acls` so its
+     * address is stable for as long as the pattern lives. The prefix index and
+     * acl_matches reference these fields directly (see acl_entry_set_match), so
+     * they must not move when other patterns are added or removed.
+     */
+    struct acls_node {
+        resource_pattern pattern;
+        acl_entry_set entries;
+    };
+
+    /*
+     * Normalize a resource_pattern, a resource_pattern_probe, or a stored
+     * acls_node to a common key: the name is viewed as bytes so a probe and the
+     * resource_pattern it stands in for produce an identical key. Sharing this
+     * between the hash and the equality keeps the two consistent and enables
+     * allocation-free heterogeneous lookups.
      */
     static std::tuple<resource_type, std::string_view, pattern_type>
     pattern_key(const auto& p) {
         return {p.resource(), p.name(), p.pattern()};
     }
+    static std::tuple<resource_type, std::string_view, pattern_type>
+    pattern_key(const std::unique_ptr<acls_node>& n) {
+        return pattern_key(n->pattern);
+    }
 
     struct resource_pattern_hash {
         using is_transparent = void;
+        // absl::HashOf already mixes well; tell unordered_dense not to re-mix.
+        using is_avalanching = void;
         size_t operator()(const auto& p) const {
             return absl::HashOf(pattern_key(p));
         }
@@ -112,25 +133,26 @@ private:
     };
 
     /*
-     * A node-based map so references to elements survive inserts and erasures
-     * of other patterns. This lets the prefix index hold direct references to
-     * the (pattern, entry set) pairs here (see acl_entry_set_match) without
-     * being invalidated when unrelated ACLs are added or removed.
+     * A chunked_hash_set with heap-owned acls_nodes so references to elements
+     * survive inserts and erasures of other patterns. This lets the prefix
+     * index hold direct references to the (pattern, entry set) pairs here (see
+     * acl_entry_set_match) without being invalidated when unrelated ACLs are
+     * added or removed.
      */
-    using container_type = absl::node_hash_map<
-      resource_pattern,
-      acl_entry_set,
+    using container_type = chunked_hash_set<
+      std::unique_ptr<acls_node>,
       resource_pattern_hash,
       resource_pattern_eq>;
 
     /*
-     * INVARIANT: `_prefix_index` holds references into the elements of `_acls`.
-     * Node stability keeps them valid across inserts and across erasing *other*
-     * patterns, but erasing a prefixed pattern that the index references leaves
-     * a dangling reference -> use-after-free in find(). So any erasure of an
-     * `_acls` key MUST drop the corresponding `_prefix_index` entry in the same
-     * step. remove_bindings() (the only key-erasing path) does exactly this
-     * when it prunes an emptied pattern; reset_bindings() clears both.
+     * INVARIANT: `_prefix_index` holds references into the `acls_node`s that
+     * `_acls` owns. The unique_ptr indirection keeps them valid across inserts
+     * and across erasing *other* patterns, but erasing a prefixed pattern that
+     * the index references frees its node -> use-after-free in find(). So any
+     * erasure of an `_acls` key MUST drop the corresponding `_prefix_index`
+     * entry in the same step. remove_bindings() (the only element-erasing path)
+     * does exactly this when it prunes an emptied pattern; reset_bindings()
+     * clears both.
      */
     container_type _acls;
 
@@ -142,10 +164,11 @@ private:
      * and the stored match references each entry set directly, so no further
      * `_acls` lookup is needed.
      *
-     * The references are stable because `_acls` is node-based, so the index is
-     * maintained incrementally: add inserts a reference to the new pattern,
-     * remove drops it when (and only when) it prunes the emptied pattern from
-     * `_acls`, and reset rebuilds alongside `_acls`.
+     * The references are stable because each entry set lives in a heap-owned
+     * acls_node, so the index is maintained incrementally: add inserts a
+     * reference to the new pattern, remove drops it when (and only when) it
+     * prunes the emptied pattern from `_acls`, and reset rebuilds alongside
+     * `_acls`. There are few resource types, so this map stays tiny.
      */
     absl::flat_hash_map<resource_type, radix_tree<acl_entry_set_match>>
       _prefix_index;
@@ -155,13 +178,19 @@ private:
     /// set it was added to so callers may rehash(); does not rehash itself.
     acl_entry_set& insert_binding(const acl_binding& binding) {
         const auto& pattern = binding.pattern();
-        auto [it, inserted] = _acls.try_emplace(pattern);
-        it->second.insert(binding.entry());
-        if (inserted && pattern.pattern() == pattern_type::prefixed) {
-            _prefix_index[pattern.resource()].insert(
-              it->first.name(), acl_entry_set_match{it->first, it->second});
+        if (auto it = _acls.find(pattern); it != _acls.end()) {
+            (*it)->entries.insert(binding.entry());
+            return (*it)->entries;
         }
-        return it->second;
+        auto [it, _] = _acls.insert(std::make_unique<acls_node>(pattern));
+        auto& node = **it;
+        node.entries.insert(binding.entry());
+        if (pattern.pattern() == pattern_type::prefixed) {
+            _prefix_index[pattern.resource()].insert(
+              node.pattern.name(),
+              acl_entry_set_match{node.pattern, node.entries});
+        }
+        return node.entries;
     }
 };
 


### PR DESCRIPTION
`acl_store::_acls` was an `absl::node_hash_map`, chosen for reference stability. Unfortunately this means allocations are contiguous, which can lead to oversized allocations and OOMs.

Rewrite it using `chunked_hash_set`; because reference stability across insertions/erasures is still required, we use a second layer of indirection via `std::unique_ptr<>` to `acl_node`s.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Improvements

* Prevent oversized allocations/OOMs when using a large number of ACLs in `redpanda`
