### PR TITLE
`rptest`: add `id_allocator` to expected topics in `storage_init_check`

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1314,6 +1314,10 @@ class RedpandaServiceConstants:
     # at bootstrap with rf=1 and reconfigured up to
     # internal_topic_replication_factor as nodes join.
     CLOUD_TOPICS_METASTORE_TOPIC = "ct_l1_domain"
+    # ID allocator topic (model::id_allocator_nt). Created lazily on the first
+    # init_producer_id request, so it may appear in the data directory even on
+    # an otherwise-idle cluster.
+    ID_ALLOCATOR_TOPIC = "id_allocator"
 
 
 class RedpandaServiceABC(ABC, RedpandaServiceConstants):
@@ -3498,7 +3502,10 @@ class RedpandaService(Service, RedpandaServiceABC):
                     "_redpanda.audit_log",
                     "_redpanda.transform_logs",
                 },
-                self.KAFKA_INTERNAL_NAMESPACE: {self.CLOUD_TOPICS_METASTORE_TOPIC},
+                self.KAFKA_INTERNAL_NAMESPACE: {
+                    self.CLOUD_TOPICS_METASTORE_TOPIC,
+                    self.ID_ALLOCATOR_TOPIC,
+                },
             }
             expected["l1_staging"] = set()  # make type deduction happy
 


### PR DESCRIPTION
This topic is auto created on the first `init_producer_id`, which could be issued by a client before the cluster has fully finished startup.

This is benign - add the topic to the expected set in `RedpandaService::start()`.

Observed as the RCA for a flake in https://ci-artifacts.dev.vectorized.cloud/production-devprod/redpanda/86529/019f19e7-f7a7-4a82-bcb9-83550c5e23d2/vbuild/ducktape/results/2026-06-30--001/report.html. 

Fixes: 
* https://redpandadata.atlassian.net/browse/CORE-16230

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
