### PR TITLE
[CORE-16773] `lsan`: don't report on `leak:seastar::alien::message_queue`

### DIFF
--- a/lsan_suppressions.txt
+++ b/lsan_suppressions.txt
@@ -6,3 +6,8 @@ leak:fips/self_test.c
 # This suppression should be revisited/removed once both OpenSSL
 # versions have been updated.
 leak:crypto/mem.c
+
+# alien::message_queue::_pending is a boost::lockfree::queue<work_item*>,
+# where tagged pointers are used to mask addresses. LSan interprets memory
+# (which are pointed to by these tagged pointers) as leaked.
+leak:seastar::alien::message_queue


### PR DESCRIPTION
Introduced by https://github.com/redpanda-data/redpanda/pull/30829 (commit 341302f91c7cfdd5c56abb8c38a80cc3ba48909c) and observed in `v26.1.x` backport branch https://buildkite.com/redpanda/redpanda/builds/86538 - I haven't seen it reproduce on `dev`, but better safe than sorry.


```
==12==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 64 byte(s) in 1 object(s) allocated from:
    #0 0xaaaab535018c in posix_memalign /src/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:139:3
    #1 0xffffa01335ac in boost::alignment::aligned_alloc(unsigned long, unsigned long) external/rules_boost++non_module_dependencies+boost/libs/align/include/boost/align/detail/aligned_alloc_posix.hpp:26:9
    #2 0xffffa01335ac in boost::alignment::aligned_allocator<boost::lockfree::queue<seastar::alien::message_queue::work_item*>::node, 64ul>::allocate(unsigned long, void const*) external/rules_boost++non_module_dependencies+boost/libs/align/include/boost/align/aligned_allocator.hpp:70:19
    #3 0xffffa01335ac in boost::lockfree::detail::freelist_stack<boost::lockfree::queue<seastar::alien::message_queue::work_item*>::node, boost::alignment::aligned_allocator<boost::lockfree::queue<seastar::alien::message_queue::work_item*>::node, 64ul>>::freelist_stack<boost::alignment::aligned_allocator<boost::lockfree::queue<seastar::alien::message_queue::work_item*>::node, 64ul>>(boost::alignment::aligned_allocator<boost::lockfree::queue<seastar::alien::message_queue::work_item*>::node, 64ul> const&, unsigned long) external/rules_boost++non_module_dependencies+boost/libs/lockfree/include/boost/lockfree/detail/freelist.hpp:62:31
    #4 0xffffa01300ec in boost::lockfree::queue<seastar::alien::message_queue::work_item*>::queue(unsigned long) external/rules_boost++non_module_dependencies+boost/libs/lockfree/include/boost/lockfree/queue.hpp:234:9
    #5 0xffffa01300ec in seastar::alien::message_queue::lf_queue::lf_queue(seastar::reactor*) external/+non_module_dependencies+seastar/include/seastar/core/alien.hh:57:40
    #6 0xffffa01300ec in seastar::alien::message_queue::message_queue(seastar::reactor*) external/+non_module_dependencies+seastar/src/core/alien.cc:46:5
    #7 0xffffa0131c14 in seastar::alien::instance::create_qs(std::__1::vector<seastar::reactor*, std::__1::allocator<seastar::reactor*>> const&) external/+non_module_dependencies+seastar/src/core/alien.cc:138:26
    #8 0xffffa05582ac in seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&) external/+non_module_dependencies+seastar/src/core/reactor.cc:4765:18
    #9 0xffffa01670bc in seastar::app_template::run_deprecated(int, char**, std::__1::function<void ()>&&) external/+non_module_dependencies+seastar/src/core/app-template.cc:242:15
    #10 0xffffa01662a8 in seastar::app_template::run(int, char**, std::__1::function<seastar::future<int> ()>&&) external/+non_module_dependencies+seastar/src/core/app-template.cc:160:12
    #11 0xffffa18cb0e8 in seastar::testing::test_runner::start_thread(int, char**)::$_0::operator()() external/+non_module_dependencies+seastar/src/testing/test_runner.cc:77:26
    #12 0xffffa18cb0e8 in decltype(std::declval<seastar::testing::test_runner::start_thread(int, char**)::$_0&>()()) std::__1::__invoke[abi:se200100]<seastar::testing::test_runner::start_thread(int, char**)::$_0&>(seastar::testing::test_runner::start_thread(int, char**)::$_0&) external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__type_traits/invoke.h:179:25
    #13 0xffffa18cb0e8 in void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:se200100]<seastar::testing::test_runner::start_thread(int, char**)::$_0&>(seastar::testing::test_runner::start_thread(int, char**)::$_0&) external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__type_traits/invoke.h:251:5
    #14 0xffffa18cb0e8 in void std::__1::__invoke_r[abi:se200100]<void, seastar::testing::test_runner::start_thread(int, char**)::$_0&>(seastar::testing::test_runner::start_thread(int, char**)::$_0&) external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__type_traits/invoke.h:273:10
    #15 0xffffa18cb0e8 in std::__1::__function::__alloc_func<seastar::testing::test_runner::start_thread(int, char**)::$_0, std::__1::allocator<seastar::testing::test_runner::start_thread(int, char**)::$_0>, void ()>::operator()[abi:se200100]() external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__functional/function.h:167:12
    #16 0xffffa18cb0e8 in std::__1::__function::__func<seastar::testing::test_runner::start_thread(int, char**)::$_0, std::__1::allocator<seastar::testing::test_runner::start_thread(int, char**)::$_0>, void ()>::operator()() external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__functional/function.h:319:10
    #17 0xffffa042bad4 in std::__1::function<void ()>::operator()() const external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__functional/function.h:995:10
    #18 0xffffa042bad4 in seastar::posix_thread::start_routine(void*) external/+non_module_dependencies+seastar/src/core/posix.cc:90:5
    #19 0xaaaab534d034 in asan_thread_start(void*) /src/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:239:28
    #20 0xffff95eebb48  (/lib/aarch64-linux-gnu/libc.so.6+0xebb48) (BuildId: d5ef86dde36cbd3289566cf5098226035d76f2e1)

Indirect leak of 8128 byte(s) in 127 object(s) allocated from:
    #0 0xaaaab535018c in posix_memalign /src/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:139:3
    #1 0xffffa01335ac in boost::alignment::aligned_alloc(unsigned long, unsigned long) external/rules_boost++non_module_dependencies+boost/libs/align/include/boost/align/detail/aligned_alloc_posix.hpp:26:9
    #2 0xffffa01335ac in boost::alignment::aligned_allocator<boost::lockfree::queue<seastar::alien::message_queue::work_item*>::node, 64ul>::allocate(unsigned long, void const*) external/rules_boost++non_module_dependencies+boost/libs/align/include/boost/align/aligned_allocator.hpp:70:19
    #3 0xffffa01335ac in boost::lockfree::detail::freelist_stack<boost::lockfree::queue<seastar::alien::message_queue::work_item*>::node, boost::alignment::aligned_allocator<boost::lockfree::queue<seastar::alien::message_queue::work_item*>::node, 64ul>>::freelist_stack<boost::alignment::aligned_allocator<boost::lockfree::queue<seastar::alien::message_queue::work_item*>::node, 64ul>>(boost::alignment::aligned_allocator<boost::lockfree::queue<seastar::alien::message_queue::work_item*>::node, 64ul> const&, unsigned long) external/rules_boost++non_module_dependencies+boost/libs/lockfree/include/boost/lockfree/detail/freelist.hpp:62:31
    #4 0xffffa01300ec in boost::lockfree::queue<seastar::alien::message_queue::work_item*>::queue(unsigned long) external/rules_boost++non_module_dependencies+boost/libs/lockfree/include/boost/lockfree/queue.hpp:234:9
    #5 0xffffa01300ec in seastar::alien::message_queue::lf_queue::lf_queue(seastar::reactor*) external/+non_module_dependencies+seastar/include/seastar/core/alien.hh:57:40
    #6 0xffffa01300ec in seastar::alien::message_queue::message_queue(seastar::reactor*) external/+non_module_dependencies+seastar/src/core/alien.cc:46:5
    #7 0xffffa0131c14 in seastar::alien::instance::create_qs(std::__1::vector<seastar::reactor*, std::__1::allocator<seastar::reactor*>> const&) external/+non_module_dependencies+seastar/src/core/alien.cc:138:26
    #8 0xffffa05582ac in seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&) external/+non_module_dependencies+seastar/src/core/reactor.cc:4765:18
    #9 0xffffa01670bc in seastar::app_template::run_deprecated(int, char**, std::__1::function<void ()>&&) external/+non_module_dependencies+seastar/src/core/app-template.cc:242:15
    #10 0xffffa01662a8 in seastar::app_template::run(int, char**, std::__1::function<seastar::future<int> ()>&&) external/+non_module_dependencies+seastar/src/core/app-template.cc:160:12
    #11 0xffffa18cb0e8 in seastar::testing::test_runner::start_thread(int, char**)::$_0::operator()() external/+non_module_dependencies+seastar/src/testing/test_runner.cc:77:26
    #12 0xffffa18cb0e8 in decltype(std::declval<seastar::testing::test_runner::start_thread(int, char**)::$_0&>()()) std::__1::__invoke[abi:se200100]<seastar::testing::test_runner::start_thread(int, char**)::$_0&>(seastar::testing::test_runner::start_thread(int, char**)::$_0&) external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__type_traits/invoke.h:179:25
    #13 0xffffa18cb0e8 in void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:se200100]<seastar::testing::test_runner::start_thread(int, char**)::$_0&>(seastar::testing::test_runner::start_thread(int, char**)::$_0&) external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__type_traits/invoke.h:251:5
    #14 0xffffa18cb0e8 in void std::__1::__invoke_r[abi:se200100]<void, seastar::testing::test_runner::start_thread(int, char**)::$_0&>(seastar::testing::test_runner::start_thread(int, char**)::$_0&) external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__type_traits/invoke.h:273:10
    #15 0xffffa18cb0e8 in std::__1::__function::__alloc_func<seastar::testing::test_runner::start_thread(int, char**)::$_0, std::__1::allocator<seastar::testing::test_runner::start_thread(int, char**)::$_0>, void ()>::operator()[abi:se200100]() external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__functional/function.h:167:12
    #16 0xffffa18cb0e8 in std::__1::__function::__func<seastar::testing::test_runner::start_thread(int, char**)::$_0, std::__1::allocator<seastar::testing::test_runner::start_thread(int, char**)::$_0>, void ()>::operator()() external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__functional/function.h:319:10
    #17 0xffffa042bad4 in std::__1::function<void ()>::operator()() const external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__functional/function.h:995:10
    #18 0xffffa042bad4 in seastar::posix_thread::start_routine(void*) external/+non_module_dependencies+seastar/src/core/posix.cc:90:5
    #19 0xaaaab534d034 in asan_thread_start(void*) /src/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:239:28
    #20 0xffff95eebb48  (/lib/aarch64-linux-gnu/libc.so.6+0xebb48) (BuildId: d5ef86dde36cbd3289566cf5098226035d76f2e1)

SUMMARY: AddressSanitizer: 8192 byte(s) leaked in 128 allocation(s).
INFO: to ignore leaks on libFuzzer side use -detect_leaks=0.
```

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes


* none
