### PR TITLE
`rptest`: fail fast on crashed kgo-verifier worker with cause

### DIFF
--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -282,15 +282,52 @@ class KgoVerifierService(Service):
         assert self._pid is not None, "worker must be started and not yet stopped"
         return node.account.exists(f"/proc/{self._pid}")
 
-    def check_running(self, node: ClusterNode) -> None:
+    def check_running(self, node: ClusterNode, classify: bool = False) -> None:
         """
         Raise if the remote process is not running.
+
+        When ``classify`` is set, tail the worker log to describe *why* it
+        exited and append that to the error, so the failure is self-diagnosing.
+        Off by default to keep the hot path (spawn confirmation) a cheap pid
+        probe; callers on a failure path (e.g. the status thread) opt in.
         """
-        if not self._is_pid_running(node):
-            raise RuntimeError(
-                f"{self.who_am_i()} on {node.name} exited unexpectedly "
-                f"(pid {self._pid} gone)"
+        if self._is_pid_running(node):
+            return
+        msg = (
+            f"{self.who_am_i()} on {node.name} exited unexpectedly "
+            f"(pid {self._pid} gone)"
+        )
+        if classify:
+            cause = self._classify_exit(node)
+            if cause is not None:
+                msg = f"{msg}: {cause}"
+        raise RuntimeError(msg)
+
+    def _classify_exit(self, node: ClusterNode) -> str | None:
+        """Best-effort cause of a worker exit, from the tail of its log.
+
+        A Go ``panic`` => an unexpected internal client crash; a fatal/error
+        line logged just before exit => a fatal error surfaced through the Kafka
+        protocol (kgo-verifier's ``util.Die`` logs at error level then exits;
+        data-loss detection logs at fatal level). Returns None if the cause
+        can't be determined or the log can't be read.
+        """
+        try:
+            out = node.account.ssh_output(
+                f"tail -n 50 {self.log_path}", timeout_sec=30, allow_fail=True
             )
+        except Exception as e:
+            self.logger.warning(
+                f"{self.who_am_i()} could not read log to classify exit: {e}"
+            )
+            return None
+        tail = out.decode("utf-8", errors="replace") if isinstance(out, bytes) else out
+        self.logger.warning(f"{self.who_am_i()} exit log tail:\n{tail}")
+        if "panic:" in tail:
+            return "internal client crash (panic)"
+        if "level=fatal" in tail or "level=error" in tail:
+            return "fatal error propagated through the protocol"
+        return None
 
     def stop_node(self, node: ClusterNode, **kwargs: Any) -> None:
         error = None
@@ -518,9 +555,10 @@ class StatusThread(threading.Thread):
                 f"Error reading status from {self.who_am_i} on {self._node.name}: {poll_ex}"
             )
             # Prefer the worker-exit error when the status read failed because
-            # the process is already gone.
+            # the process is already gone; classify the exit cause for a
+            # self-diagnosing error.
             try:
-                self._parent.check_running(self._node)
+                self._parent.check_running(self._node, classify=True)
             except Exception as crash_ex:
                 self._ex = crash_ex
             else:

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -463,6 +463,20 @@ class ClusterLinkingProgressVerifier:
         self.target_consumer.stop()
         self.producer.stop()
 
+    def _raise_if_worker_crashed(self):
+        """Fail fast if any kgo-verifier worker's status thread has errored.
+
+        A worker whose process dies (e.g. a client-library crash such as the
+        franz-go produce-path panic) stops answering status polls and can never
+        recover. Its StatusThread records the failure -- naming the worker that
+        exited -- and raise_on_error() re-raises it here, so validate_progress
+        surfaces that descriptive error immediately instead of waiting out
+        progress_timeout and reporting an opaque "Workload stalled".
+        """
+        for svc in (self.producer, self.source_consumer, self.target_consumer):
+            if svc._status_thread is not None:
+                svc._status_thread.raise_on_error()
+
     def validate_progress(self, progress_timeout=60, backoff_delay=5):
         workload_last_progress = time.time()
         source_consumer_last_reads = 0
@@ -474,6 +488,11 @@ class ClusterLinkingProgressVerifier:
             producer_acked = self.producer.produce_status.acked
             source_reads = self.source_consumer.consumer_status.validator.total_reads
             target_reads = self.target_consumer.consumer_status.validator.total_reads
+
+            # A crashed kgo-verifier worker can never make progress, so fail
+            # fast with the descriptive error its status thread recorded rather
+            # than blaming a "Workload stalled" after progress_timeout elapses.
+            self._raise_if_worker_crashed()
 
             # track workload progress
             if (


### PR DESCRIPTION
`ClusterLinkingProgressVerifier.validate_progress` waited out the full `progress_timeout` and raised an opaque `"Workload stalled"` whenever a worker stopped advancing — including when a kgo-verifier process had **crashed outright** (e.g. a franz-go produce-path panic), which can never recover. That conflated a client-side worker crash with a genuine shadow-link replication stall, and forced a needless `progress_timeout` wait before failing.

This PR does two things (building on #30943, which makes a worker's `StatusThread` record a descriptive "…exited unexpectedly (pid gone)" error when the status endpoint stops responding):

**1. Fail fast (`cluster_linking_test_base.py`).** `validate_progress` now calls `raise_on_error()` on each worker's status thread every iteration, so a crashed worker surfaces its real error immediately instead of after the 120s no-progress budget. A plain `"Workload stalled"` then reliably means a genuine replication stall rather than a crashed client.

**2. Classify the exit cause (`kgo_verifier_services.py`).** `check_running` gains an opt-in `classify` mode that tails the worker log to describe *why* it exited, and the status thread opts in:

| Exit | Example log tail | Label |
| --- | --- | --- |
| Go panic (internal client bug, e.g. the franz-go produce-path panic) | `panic: runtime error: index out of range [-1]` | `internal client crash (panic)` |
| Produce failure from broker (`util.Die` → `os.Exit`) | `level=error msg="Produce failed: UNKNOWN_TOPIC_OR_PARTITION: ..."` | `fatal error propagated through the protocol` |
| Data-loss detection (`log.Fatalf`) | `level=fatal msg="Unexpected data loss detected: ..."` | `fatal error propagated through the protocol` |

Classification lives in the shared service layer, so **every** kgo-verifier consumer/producer benefits, not just cluster linking. It's kept off the spawn hot path (a cheap pid probe) and is best-effort — it falls back to the unclassified "exited unexpectedly" message if the log can't be read.

Net: a crashed worker now reports e.g. `KgoVerifierProducer.<topic> on <node> exited unexpectedly (pid gone): internal client crash (panic)`.

Motivating context: CORE-16624, where a franz-go producer crash and a real target-side consumer-group stall both surfaced as the same `"Workload stalled"` assertion; this keeps the two distinguishable.

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none