### PR TITLE
`security`: make `acls_node::pattern` const

### DIFF
--- a/src/v/security/acl_store.h
+++ b/src/v/security/acl_store.h
@@ -97,7 +97,7 @@ private:
      * they must not move when other patterns are added or removed.
      */
     struct acls_node {
-        resource_pattern pattern;
+        const resource_pattern pattern;
         acl_entry_set entries;
     };
 


### PR DESCRIPTION
## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
