### PR TITLE
rptest: add skip_in_cdt opt-out for CDT runs

### DIFF
--- a/tests/rptest/test_suite_quick.yml
+++ b/tests/rptest/test_suite_quick.yml
@@ -12,6 +12,7 @@ quick:
   - tests/
   - transactions/
   - cfr_tests/
+  - utils/skip_in_cdt_test.py
 
   excluded:
   - tests/rpk_tuner_test.py

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -28,6 +28,7 @@ from rptest.services.cluster import cluster
 from rptest.services.redpanda import LoggingConfig, SecurityConfig, TLSProvider
 from rptest.services.redpanda_installer import RedpandaInstaller, wait_for_num_versions
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.utils.mode_checks import skip_file_in_cdt
 
 
 class MTLSProvider(TLSProvider):
@@ -853,3 +854,9 @@ class AccessControlListAuthzTest(AccessControlListTestBase):
         assert resp["ErrorCode"] != KError.CLUSTER_AUTHORIZATION_FAILED.value, (
             f"Response: {resp}"
         )
+
+
+# No-cloud suite: opt out of CDT (dockerized CI already covers it).
+skip_file_in_cdt(
+    reason="ACL/authz suite: no cloud-infra signal in CDT; dockerized CI covers it"
+)

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -84,7 +84,7 @@ from rptest.tests.schema_registry_test import (
     schema2_def,
 )
 from rptest.util import expect_exception, wait_until, wait_until_result
-from rptest.utils.mode_checks import skip_fips_mode
+from rptest.utils.mode_checks import skip_fips_mode, skip_file_in_cdt
 from rptest.utils.rpk_config import read_redpanda_cfg
 from rptest.utils.schema_registry_utils import Mode, get_subjects, put_mode
 
@@ -4406,3 +4406,9 @@ class AuditLogUpgradeTest(AuditLogTestBase):
         )
 
         self._test_audit_on_all_nodes("post_upgrade_restart")
+
+
+# No-cloud suite: opt out of CDT (dockerized CI already covers it).
+skip_file_in_cdt(
+    reason="audit-logging suite: no cloud-infra signal in CDT; dockerized CI covers it"
+)

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -29,6 +29,7 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import expect_exception, wait_until_result
 from rptest.utils.node_operations import NodeDecommissionWaiter
 from rptest.utils.rpenv import sample_license, sample_license_v1
+from rptest.utils.mode_checks import skip_file_in_cdt
 
 FEATURE_ALPHA_NAME = "__test_alpha"
 FEATURE_BRAVO_NAME = "__test_bravo"
@@ -2024,3 +2025,9 @@ class FeatureManagerDecommissionRegressionTest(FeaturesTestBase):
                 "feature_manager likely failed to wake on member removal."
             ),
         )
+
+
+# No-cloud suite: opt out of CDT (dockerized CI already covers it).
+skip_file_in_cdt(
+    reason="feature-flag suite: no cloud-infra signal in CDT; dockerized CI covers it"
+)

--- a/tests/rptest/tests/enterprise_features_license_test.py
+++ b/tests/rptest/tests/enterprise_features_license_test.py
@@ -18,7 +18,7 @@ from rptest.services.redpanda import (
 )
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import expect_exception
-from rptest.utils.mode_checks import skip_fips_mode
+from rptest.utils.mode_checks import skip_fips_mode, skip_file_in_cdt
 
 
 class EnterpriseFeaturesTestBase(RedpandaTest):
@@ -345,3 +345,9 @@ class EnterpriseFeaturesTest(EnterpriseFeaturesTestBase):
         )
 
         self.check_feature(feature, enabled=False, license_valid=False)
+
+
+# No-cloud suite: opt out of CDT (dockerized CI already covers it).
+skip_file_in_cdt(
+    reason="enterprise-license enforcement suite: no cloud-infra signal in CDT; dockerized CI covers it"
+)

--- a/tests/rptest/tests/gbac_claim_test.py
+++ b/tests/rptest/tests/gbac_claim_test.py
@@ -26,6 +26,7 @@ from rptest.services.redpanda import (
     make_redpanda_service,
 )
 from rptest.services.stub_oidc_provider import StubOIDCProvider
+from rptest.utils.mode_checks import skip_file_in_cdt
 
 
 class StubOIDCTestBase(Test):
@@ -1184,3 +1185,9 @@ class GbacConfigEdgeCaseTest(StubOIDCTestBase):
 
         producer = self.make_producer(client_id)
         self.assert_produce_denied(producer, topic)
+
+
+# No-cloud suite: opt out of CDT (dockerized CI already covers it).
+skip_file_in_cdt(
+    reason="group-based access-control suite: no cloud-infra signal in CDT; dockerized CI covers it"
+)

--- a/tests/rptest/tests/leadership_transfer_test.py
+++ b/tests/rptest/tests/leadership_transfer_test.py
@@ -27,6 +27,7 @@ from rptest.services.cluster import cluster
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, ResourceSettings
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import wait_until_result
+from rptest.utils.mode_checks import skip_file_in_cdt
 
 
 class ReplicaMetadata(TypedDict):
@@ -1103,3 +1104,9 @@ class LeadershipPinningTest(RedpandaTest):
         assert t2r == expected, (
             f"Expected topic-to-rack leaders {expected}. Got {t2r} instead"
         )
+
+
+# No-cloud suite: opt out of CDT (dockerized CI already covers it).
+skip_file_in_cdt(
+    reason="leadership-transfer suite: no cloud-infra signal in CDT; dockerized CI covers it"
+)

--- a/tests/rptest/tests/maintenance_test.py
+++ b/tests/rptest/tests/maintenance_test.py
@@ -21,6 +21,7 @@ from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 from rptest.tests.maintenance import MaintenanceTestBase
+from rptest.utils.mode_checks import skip_file_in_cdt
 
 
 class MaintenanceTest(MaintenanceTestBase):
@@ -228,3 +229,9 @@ class MaintenanceCycleTest(MaintenanceTestBase):
             backoff_sec=2,
             err_msg="Leaders distributed very unevenly",
         )
+
+
+# No-cloud suite: opt out of CDT (dockerized CI already covers it).
+skip_file_in_cdt(
+    reason="maintenance-mode suite: no cloud-infra signal in CDT; dockerized CI covers it"
+)

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -40,7 +40,11 @@ from rptest.services.redpanda import (
 from rptest.tests.group_membership_test import GroupCoordinatorTransferUtils
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import search_logs_with_timeout
-from rptest.utils.mode_checks import in_fips_environment, skip_debug_mode
+from rptest.utils.mode_checks import (
+    in_fips_environment,
+    skip_debug_mode,
+    skip_file_in_cdt,
+)
 from rptest.utils.utf8 import CONTROL_CHARS_MAP
 
 
@@ -2447,3 +2451,9 @@ class PandaProxyCompressedBatchesTest(PandaProxyEndpoints):
         assert item["offset"] == produced_offset, (
             "Pandaproxy consumer fetch consumed the wrong offset"
         )
+
+
+# No-cloud suite: opt out of CDT (dockerized CI already covers it).
+skip_file_in_cdt(
+    reason="pandaproxy HTTP-API suite: no cloud-infra signal in CDT; dockerized CI covers it"
+)

--- a/tests/rptest/tests/rbac_test.py
+++ b/tests/rptest/tests/rbac_test.py
@@ -37,7 +37,7 @@ from rptest.tests.metrics_reporter_test import MetricsReporterServer
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import expect_exception, expect_http_error, wait_until_result
 from rptest.utils.log_utils import wait_until_nag_is_set
-from rptest.utils.mode_checks import skip_fips_mode
+from rptest.utils.mode_checks import skip_fips_mode, skip_file_in_cdt
 
 ALICE = SaslCredentials("alice", "itsMeH0nest012", "SCRAM-SHA-256")
 
@@ -1231,3 +1231,9 @@ class RolePersistenceTest(RBACTestBase):
             backoff_sec=1,
             retry_on_exc=True,
         )
+
+
+# No-cloud suite: opt out of CDT (dockerized CI already covers it).
+skip_file_in_cdt(
+    reason="RBAC suite: no cloud-infra signal in CDT; dockerized CI covers it"
+)

--- a/tests/rptest/tests/redpanda_oauth_test.py
+++ b/tests/rptest/tests/redpanda_oauth_test.py
@@ -53,7 +53,7 @@ from rptest.tests.sasl_reauth_test import (
 from rptest.tests.tls_metrics_test import FaketimeTLSProvider
 from rptest.util import expect_exception, wait_until_result
 from rptest.utils.log_utils import wait_until_nag_is_set
-from rptest.utils.mode_checks import skip_fips_mode
+from rptest.utils.mode_checks import skip_fips_mode, skip_file_in_cdt
 
 CLIENT_ID = "myapp"
 TOKEN_AUDIENCE = "account"
@@ -2331,3 +2331,9 @@ class OIDCLicenseTest(RedpandaOIDCTestBase):
             timeout_sec=self.LICENSE_CHECK_INTERVAL_SEC * 2,
             err_msg="License nag failed to appear",
         )
+
+
+# No-cloud suite: opt out of CDT (dockerized CI already covers it).
+skip_file_in_cdt(
+    reason="OAuth/OIDC auth suite: no cloud-infra signal in CDT; dockerized CI covers it"
+)

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -68,7 +68,11 @@ from rptest.util import (
     wait_until_result,
 )
 from rptest.utils.log_utils import wait_until_nag_is_set
-from rptest.utils.mode_checks import skip_debug_mode, skip_fips_mode
+from rptest.utils.mode_checks import (
+    skip_debug_mode,
+    skip_file_in_cdt,
+    skip_fips_mode,
+)
 
 Headers: TypeAlias = dict[str, str] | None
 
@@ -11947,3 +11951,13 @@ class SchemaRegistryTransportCompatTest(RedpandaTest):
 
         self._flip_transport(use_rpc=False)
         self._verify_phase(after_rpc2, "kafka2", "Kafka2Rec", n)
+
+
+# Opt the entire schema-registry HTTP-API suite out of CDT: it is exhaustive and
+# adds significant runtime on real cloud infra without adding any cloud-infra
+# coverage (the dockerized CI run already exercises it end to end). The test
+# methods live on the base classes above; skip_file_in_cdt marks each module
+# class's own methods, so the thin concrete subclasses inherit the mark.
+skip_file_in_cdt(
+    reason="exhaustive SR HTTP-API suite; no cloud-infra signal (dockerized CI covers it)"
+)

--- a/tests/rptest/tests/scram_test.py
+++ b/tests/rptest/tests/scram_test.py
@@ -56,7 +56,7 @@ from rptest.tests.sasl_reauth_test import (
 )
 from rptest.util import expect_exception, expect_http_error
 from rptest.utils.log_utils import wait_until_nag_is_set
-from rptest.utils.mode_checks import in_fips_environment
+from rptest.utils.mode_checks import in_fips_environment, skip_file_in_cdt
 from rptest.utils.utf8 import (
     generate_string_with_control_character,
 )
@@ -1668,3 +1668,9 @@ class SCRAMReauthTest(BaseScramTest):
         )
         assert REAUTH_METRIC in metrics.keys()
         assert metrics[REAUTH_METRIC] > 0, "Expected client reauth on some broker..."
+
+
+# No-cloud suite: opt out of CDT (dockerized CI already covers it).
+skip_file_in_cdt(
+    reason="SASL/SCRAM auth suite: no cloud-infra signal in CDT; dockerized CI covers it"
+)

--- a/tests/rptest/tests/security_report_test.py
+++ b/tests/rptest/tests/security_report_test.py
@@ -30,7 +30,7 @@ from rptest.tests.audit_log_test import (
     AuditLogTestBase,
     AuditLogTestSecurityConfig,
 )
-from rptest.utils.mode_checks import skip_fips_mode
+from rptest.utils.mode_checks import skip_fips_mode, skip_file_in_cdt
 
 
 def make_from_dict(class_name, values):
@@ -1088,3 +1088,9 @@ class AuditlogClientSecurityReportTest(AuditLogTestBase):
             },
             audit_log_expected=audit_log_expected,
         )
+
+
+# No-cloud suite: opt out of CDT (dockerized CI already covers it).
+skip_file_in_cdt(
+    reason="security-report suite: no cloud-infra signal in CDT; dockerized CI covers it"
+)

--- a/tests/rptest/utils/mode_checks.py
+++ b/tests/rptest/utils/mode_checks.py
@@ -1,9 +1,13 @@
+import inspect
 import os
-from typing import Any
+import sys
+import warnings
+from collections.abc import Callable
+from typing import Any, TypeVar, overload
 
 from ducktape.cluster.cluster_spec import ClusterSpec
 from ducktape.mark import ignore
-from ducktape.tests.test import TestContext
+from ducktape.tests.test import Test, TestContext
 
 from rptest.utils.type_utils import rcast
 from rptest.util import FIPSMode, get_fips_mode
@@ -166,3 +170,186 @@ def skip_fips_mode(*args: Any, **kwargs: Any):
         return ignore(*args, **kwargs)
     else:
         return args[0]
+
+
+def in_cdt() -> bool:
+    """
+    True when running against real cloud infrastructure (a CDT run).
+
+    CDT exports CLOUD_PROVIDER=aws|gcp|azure before invoking ducktape; local and
+    dockerized-CI runs leave it unset (treated as "docker"). Read the env var
+    directly here, mirroring is_debug_mode()'s BUILD_TYPE check, to avoid an
+    import cycle: rptest.services.redpanda already imports this module.
+    """
+    return os.environ.get("CLOUD_PROVIDER", "docker") != "docker"
+
+
+_T = TypeVar("_T")
+
+
+def _skip_method_in_cdt(method: object, reason: str | None) -> None:
+    if reason is not None:
+        setattr(method, "_skip_in_cdt_reason", reason)
+    if in_cdt():
+        # ignore() attaches IgnoreAll in place (ducktape marks mutate fun.__dict__),
+        # so the mark lands on `method` itself; no re-bind of the return is needed.
+        ignore(method)
+
+
+def _mark_own_cdt_tests(cls: type) -> None:
+    # Mark only DIRECTLY-DEFINED test methods (a method ducktape treats as a test
+    # carries `marks` from @cluster/@matrix/@parametrize). ignore() mutates the
+    # function's __dict__ in place, so the mark is visible on the class.
+    for member in list(vars(cls).values()):
+        if callable(member) and hasattr(member, "marks"):
+            ignore(member)
+
+
+def _inherited_cdt_test_methods(cls: type) -> list[str]:
+    # Test methods carrying ducktape marks that are inherited from a base and not
+    # overridden on cls (i.e. absent from cls's own __dict__).
+    own = vars(cls)
+    return sorted(
+        {
+            name
+            for base in cls.__mro__[1:]
+            for name, member in vars(base).items()
+            if callable(member) and hasattr(member, "marks") and name not in own
+        }
+    )
+
+
+def _cross_module_cdt_test_methods(cls: type) -> list[str]:
+    # Marked test methods inherited from a base defined in ANOTHER module. Since
+    # skip_file_in_cdt only marks methods defined in this module, these would not
+    # be covered by a module-scope opt-out here.
+    own = vars(cls)
+    return sorted(
+        {
+            name
+            for base in cls.__mro__[1:]
+            if getattr(base, "__module__", None) != cls.__module__
+            for name, member in vars(base).items()
+            if callable(member) and hasattr(member, "marks") and name not in own
+        }
+    )
+
+
+def _skip_class_in_cdt(cls: type, reason: str | None) -> None:
+    if reason is not None:
+        setattr(cls, "_skip_in_cdt_reason", reason)
+    # ducktape marks are function-scoped: marking an inherited (shared) base method
+    # would skip it for EVERY subclass, so class-scope can't safely cover inherited
+    # tests. Fail loudly rather than silently leave an inherited test running in CDT.
+    inherited = _inherited_cdt_test_methods(cls)
+    if inherited:
+        raise RuntimeError(
+            f"@skip_in_cdt on {cls.__name__}: test method(s) {inherited} are "
+            f"inherited; class-scope skip only covers directly-defined methods. "
+            f"Apply @skip_in_cdt to the method(s), or to the class that defines them."
+        )
+    if in_cdt():
+        _mark_own_cdt_tests(cls)
+
+
+@overload
+def skip_in_cdt(target: _T, /) -> _T: ...
+
+
+@overload
+def skip_in_cdt(*, reason: str | None = ...) -> Callable[[_T], _T]: ...
+
+
+def skip_in_cdt(*args: Any, reason: str | None = None) -> Any:
+    """
+    Opt a test method or test class out of CDT (real-cloud) runs.
+
+    No-op locally and in dockerized CI (CLOUD_PROVIDER unset/"docker"); there the
+    test runs exactly as today. In CDT it attaches ducktape's ignore mark, so the
+    test is collected and reported as IGNORE (visible, not silently dropped) and
+    no cluster is allocated for it.
+
+    Method scope::
+
+        @skip_in_cdt(reason="HTTP-API only; no cloud-infra signal")
+        @cluster(num_nodes=3)
+        def test_x(self): ...
+
+    Class scope marks the class's DIRECTLY-DEFINED test methods; it raises if the
+    class's tests are inherited from a base (apply to the method or the base
+    instead), since ducktape marks are function-scoped and can't be class-scoped
+    safely::
+
+        @skip_in_cdt(reason="pure HTTP surface")
+        class MyTest(RedpandaTest): ...
+
+    `reason` is optional source-level documentation; it is stored on the target
+    as `_skip_in_cdt_reason` and is NOT forwarded to ducktape's ignore (which
+    would misread it as a parametrization matcher and silently un-skip the test).
+    """
+
+    def decorate(target: _T) -> _T:
+        if inspect.isclass(target):
+            _skip_class_in_cdt(target, reason)
+        else:
+            _skip_method_in_cdt(target, reason)
+        return target
+
+    if args:
+        # bare usage: @skip_in_cdt
+        return decorate(args[0])
+    # called usage: @skip_in_cdt(reason=...)
+    return decorate
+
+
+def skip_file_in_cdt(
+    reason: str | None = None, *, namespace: dict[str, Any] | None = None
+):
+    """
+    Opt every test class DEFINED IN THE CALLING MODULE out of CDT runs.
+
+    Call at module scope, AFTER the class definitions (typically the last line of
+    the file); if called earlier the classes are not yet in the module globals
+    and nothing is marked. Attaches no ignore marks locally or in dockerized CI
+    (tests run as today); the misuse warning below fires regardless of
+    environment, so a misapplied opt-out is caught at authoring time.
+
+    Marks the test methods DEFINED IN this module's classes. Only classes whose
+    __module__ matches are touched (an imported base class is left alone), and only
+    their directly-defined methods are marked -- a same-module base's methods are
+    marked too, so its subclasses are covered via the shared function object.
+    Because that mark lives on the function object itself, a subclass of the same
+    base in ANOTHER module would also be skipped in CDT (safe as long as opted-out
+    bases share no test methods with non-opted-out suites). A class here that
+    inherits test methods from another module -- whether or not it also defines its
+    own -- leaves those inherited tests uncovered; unlike the class decorator this
+    warns rather than raising, since module-scope means "the tests defined in this
+    file". `namespace` defaults to the caller's module globals; pass an explicit
+    dict in unit tests.
+    """
+    if namespace is None:
+        namespace = sys._getframe(1).f_globals
+    module_name = namespace.get("__name__")
+    for value in list(namespace.values()):
+        if (
+            inspect.isclass(value)
+            and issubclass(value, Test)
+            and value.__module__ == module_name
+        ):
+            if reason is not None:
+                setattr(value, "_skip_in_cdt_reason", reason)
+            if in_cdt():
+                _mark_own_cdt_tests(value)
+            # Test methods inherited from another module aren't covered here
+            # (skip_file marks module-local methods; the class decorator would
+            # raise). Warn for both inherited-only and mixed classes, so a
+            # misapplied opt-out is visible rather than a silent CDT no-op.
+            cross = _cross_module_cdt_test_methods(value)
+            if cross:
+                warnings.warn(
+                    f"skip_file_in_cdt: {value.__name__} in {module_name} inherits "
+                    f"test method(s) {cross} from another module; they will NOT be "
+                    f"skipped in CDT -- opt them out in the defining module or with a "
+                    f"method-scope @skip_in_cdt.",
+                    stacklevel=2,
+                )

--- a/tests/rptest/utils/skip_in_cdt_test.py
+++ b/tests/rptest/utils/skip_in_cdt_test.py
@@ -1,0 +1,222 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import os
+import warnings
+from contextlib import contextmanager
+from typing import Any
+
+from ducktape.mark.resource import cluster
+from ducktape.tests.test import Test
+
+from rptest.services.cluster import cluster as rp_cluster
+from rptest.utils.mode_checks import skip_in_cdt, skip_file_in_cdt
+
+
+@contextmanager
+def _cloud_provider(value: str | None):
+    """Temporarily set/unset CLOUD_PROVIDER, restoring the prior value."""
+    prev = os.environ.get("CLOUD_PROVIDER")
+    if value is None:
+        os.environ.pop("CLOUD_PROVIDER", None)
+    else:
+        os.environ["CLOUD_PROVIDER"] = value
+    try:
+        yield
+    finally:
+        if prev is None:
+            os.environ.pop("CLOUD_PROVIDER", None)
+        else:
+            os.environ["CLOUD_PROVIDER"] = prev
+
+
+def _ignore_marks(target: object) -> list[Any]:
+    marks: list[Any] = getattr(target, "marks", [])
+    return [m for m in marks if m.name == "IGNORE"]
+
+
+class SkipInCdtTest(Test):
+    """
+    Unit test for the CDT opt-out decorators. Runs with num_nodes=0 (no
+    cluster); inspects the ducktape marks the decorators attach under each
+    CLOUD_PROVIDER value.
+    """
+
+    @cluster(num_nodes=0)
+    def test_method_scope(self):
+        # docker: decorator is a no-op, method runs as today
+        with _cloud_provider("docker"):
+
+            @skip_in_cdt(reason="r")
+            @cluster(num_nodes=1)
+            def m_docker() -> None:
+                pass
+
+            assert _ignore_marks(m_docker) == [], "method must not be ignored on docker"
+            assert getattr(m_docker, "_skip_in_cdt_reason") == "r"
+
+        # cloud: method ignored with an ignore-ALL mark (not a param matcher)
+        with _cloud_provider("aws"):
+
+            @skip_in_cdt(reason="r")
+            @cluster(num_nodes=1)
+            def m_aws() -> None:
+                pass
+
+            marks = _ignore_marks(m_aws)
+            assert len(marks) == 1, "method must be ignored on aws"
+            # regression guard: reason must NOT be forwarded to ducktape ignore
+            assert marks[0].injected_args is None, (
+                "must be ignore-all, not a param matcher"
+            )
+
+    @cluster(num_nodes=0)
+    def test_class_scope(self):
+        with _cloud_provider("aws"):
+
+            @skip_in_cdt(reason="cls")
+            class Dummy(Test):
+                @cluster(num_nodes=1)
+                def test_a(self):
+                    pass
+
+                @cluster(num_nodes=1)
+                def test_b(self):
+                    pass
+
+                def helper(self):
+                    pass
+
+            assert _ignore_marks(Dummy.test_a), "test_a must be ignored on aws"
+            assert _ignore_marks(Dummy.test_b), "test_b must be ignored on aws"
+            assert _ignore_marks(Dummy.helper) == [], "non-test method untouched"
+            assert getattr(Dummy, "_skip_in_cdt_reason") == "cls"
+
+        with _cloud_provider("docker"):
+
+            @skip_in_cdt(reason="cls")
+            class Dummy2(Test):
+                @cluster(num_nodes=1)
+                def test_a(self):
+                    pass
+
+            assert _ignore_marks(Dummy2.test_a) == [], "no ignore on docker"
+
+    @cluster(num_nodes=0)
+    def test_file_scope(self):
+        class Local(Test):
+            @cluster(num_nodes=1)
+            def test_x(self):
+                pass
+
+        class Imported(Test):
+            @cluster(num_nodes=1)
+            def test_y(self):
+                pass
+
+        # Simulate a module file containing Local and an imported base class.
+        Local.__module__ = "fake_module"
+        Imported.__module__ = "other_module"
+        ns: dict[str, Any] = {
+            "__name__": "fake_module",
+            "Local": Local,
+            "Imported": Imported,
+        }
+
+        with _cloud_provider("aws"):
+            skip_file_in_cdt(reason="file", namespace=ns)
+
+        assert _ignore_marks(Local.test_x), "class defined in module must be ignored"
+        assert _ignore_marks(Imported.test_y) == [], "imported class left untouched"
+
+    @cluster(num_nodes=0)
+    def test_class_scope_inherited_raises(self):
+        # A class whose test methods are inherited (not directly defined) cannot be
+        # safely class-scoped (ducktape marks are function-scoped); @skip_in_cdt must
+        # raise rather than silently leave the inherited test running in CDT.
+        class Base(Test):
+            @cluster(num_nodes=1)
+            def test_inherited(self):
+                pass
+
+        class Sub(Base):  # no own test methods
+            pass
+
+        raised = False
+        try:
+            skip_in_cdt(reason="x")(Sub)
+        except RuntimeError:
+            raised = True
+        assert raised, "@skip_in_cdt on a class with only inherited tests must raise"
+
+    @cluster(num_nodes=0)
+    def test_file_scope_covers_same_module_base(self):
+        # skip_file_in_cdt marks each module class's OWN tests; a same-module base's
+        # tests get marked, so a thin subclass inheriting them is covered (no raise).
+        class Base(Test):
+            @cluster(num_nodes=1)
+            def test_x(self):
+                pass
+
+        class Sub(Base):  # no own test methods
+            pass
+
+        Base.__module__ = "fake_module"
+        Sub.__module__ = "fake_module"
+        ns: dict[str, Any] = {"__name__": "fake_module", "Base": Base, "Sub": Sub}
+        with _cloud_provider("aws"):
+            skip_file_in_cdt(reason="f", namespace=ns)
+        assert _ignore_marks(Base.test_x), "base's own test must be marked"
+        assert _ignore_marks(Sub.test_x), "subclass inherits the marked base test"
+
+    @cluster(num_nodes=0)
+    def test_rptest_cluster_wrapper_marks(self):
+        # Production test files use rptest's @cluster wrapper, not ducktape's raw
+        # one; the mechanism only sees `marks` because the wrapper propagates them
+        # (services/cluster.py: `wrapped.marks = f.marks`). Pin that contract -- the
+        # IGNORE mark must still land on a method decorated with the real wrapper.
+        with _cloud_provider("aws"):
+
+            @skip_in_cdt(reason="r")
+            @rp_cluster(num_nodes=1)
+            def m() -> None:
+                pass
+
+            assert _ignore_marks(m), (
+                "IGNORE must land on an rptest @cluster-wrapped method"
+            )
+
+    @cluster(num_nodes=0)
+    def test_file_scope_warns_on_cross_module_inherited(self):
+        # A class with its OWN test plus a test inherited from ANOTHER module:
+        # skip_file marks the own one but cannot cover the inherited (cross-module)
+        # one, so it must warn rather than silently miss it.
+        class OtherBase(Test):
+            @cluster(num_nodes=1)
+            def test_inherited(self):
+                pass
+
+        class Mixed(OtherBase):
+            @cluster(num_nodes=1)
+            def test_own(self):
+                pass
+
+        OtherBase.__module__ = "other_module"
+        Mixed.__module__ = "this_module"
+        ns: dict[str, Any] = {"__name__": "this_module", "Mixed": Mixed}
+
+        with _cloud_provider("aws"):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                skip_file_in_cdt(reason="mixed", namespace=ns)
+
+        assert _ignore_marks(Mixed.test_own), "own test must be marked"
+        assert any("test_inherited" in str(w.message) for w in caught), (
+            "must warn about the cross-module inherited test"
+        )


### PR DESCRIPTION
CDT runs every ducktape test on real cloud infrastructure, and a whole-run timeout fails the entire run. Some tests (e.g. exhaustive broker HTTP-API tests) add runtime there without adding cloud-infra coverage.

skip_in_cdt opts out a test method or a whole class; skip_file_in_cdt opts out every test class in a module. All are gated on CLOUD_PROVIDER != "docker", so they no-op locally and in dockerized CI and the default behavior is unchanged. In CDT they attach ducktape's ignore mark, so opted-out tests report as IGNORE rather than vanishing from the run.

reason is documentation only; it is never passed to ducktape's ignore, which would otherwise treat it as a parametrization matcher and silently un-skip the test.

    Why these are CDT-skippable: each is a no-cloud, non-compute, non-scale suite — a pure API/CLI/protocol/control-plane
    surface whose behavior is identical on docker vs real EC2+S3. All already run on every PR in dockerized CI, so running
    them again in CDT adds runtime but no coverage. (Compute/IO suites like data_transforms and log_compaction, and all
    scale_tests/, are deliberately kept — CDT is where they exercise real hardware.)

  - schema_registry_test — Schema Registry HTTP API; protocol surface, no cloud/hardware dependence.
  - pandaproxy_test — Pandaproxy HTTP API; same — pure REST surface.
  - redpanda_oauth_test — OAuth/OIDC auth flows; environment-independent.
  - acls_test — ACL authorization enforcement; logic-only, identical off-cloud.
  - scram_test — SASL/SCRAM auth; protocol/logic path, no cloud.
  - rbac_test — role-based access control; config/logic, env-independent.
  - gbac_claim_test — group access via OIDC claims; auth logic, no cloud.
  - security_report_test — security-report surface across interfaces; API-level.
  - audit_log_test — audit-event emission correctness; behavior-level, no storage/hardware sensitivity.
  - enterprise_features_license_test — license enforcement; gates on a sample-license flag, no cloud infra.
  - cluster_features_test — feature-flag activation state machine; control-plane logic.
  - maintenance_test — maintenance-mode drain/leadership via admin API; coordination logic.
  - leadership_transfer_test — leadership transfer/rebalance correctness; raft coordination, no storage or heavy compute.

### Accounting

- [schema registry](https://buildkite.com/redpanda/redpanda/builds/86579#019f1c65-9c2f-41e6-a183-f2f4f20a9efd) ~40m
- [big list](https://buildkite.com/redpanda/redpanda/builds/86634#019f20a6-2b52-4f31-8109-8cb72643cb00) ~2h15m
  - https://github.com/redpanda-data/redpanda/pull/30975#issuecomment-4861635087

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
