### PR TITLE
ts-ct-migration: partition_mode substrate [PR 0]

### DIFF
--- a/src/v/cluster/BUILD
+++ b/src/v/cluster/BUILD
@@ -2500,6 +2500,7 @@ redpanda_cc_library(
         "//src/v/ssx:minimum_interval_timer",
         "//src/v/ssx:mutex",
         "//src/v/ssx:rate_limited_function",
+        "//src/v/ssx:reconciler",
         "//src/v/ssx:semaphore",
         "//src/v/ssx:sformat",
         "//src/v/ssx:single_sharded",

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -31,6 +31,7 @@
 #include "raft/fwd.h"
 #include "raft/state_machine_manager.h"
 #include "ssx/future-util.h"
+#include "ssx/sformat.h"
 #include "ssx/when_all.h"
 #include "storage/ntp_config.h"
 
@@ -53,6 +54,12 @@ partition::partition(
   ss::sharded<cloud_topics::state_accessors>* ct_state)
   : _raft(std::move(r))
   , _cloud_topics_state(ct_state)
+  , _partition_storage_mode_apply(
+      _partition_storage_mode_gate,
+      clusterlog,
+      ssx::sformat("{} partition_storage_mode apply", _raft->ntp()),
+      [this] { return apply_partition_storage_mode(); },
+      _as)
   , _probe(std::make_unique<replicated_partition_probe>(*this))
   , _feature_table(feature_table)
   , _archival_conf(std::move(archival_conf))
@@ -522,6 +529,31 @@ ss::future<> partition::start(
         co_await _cloud_storage_partition->start();
     }
 
+    // Feed the partition's durable storage mode into the log's ntp_config and
+    // keep it up to date as the STM applies changes. Reading replicated STM
+    // state is always safe; writes (which require the partition_storage_mode
+    // feature) are gated separately. Until partition_storage_mode is set,
+    // partition_storage_mode() is `unset` and ntp_config falls back to the
+    // topic-config-derived mode.
+    //
+    // Registered here, rather than as soon as the stm is available, because the
+    // callback's apply can build an archiver, and an archiver holds the
+    // manifest view constructed above.
+    if (_partition_properties_stm) {
+        // Notify rather than reconcile inline: this fires on the raft apply /
+        // snapshot-restore fiber, which must not block on stopping the archiver
+        // -- that stop waits on archiver fibers which themselves wait for
+        // archival_metadata_stm to apply, and apply cannot proceed while the
+        // callback is blocked.
+        _partition_properties_stm->set_partition_storage_mode_change_callback(
+          [this] { _partition_storage_mode_apply.notify(); });
+        // Synchronously for the initial load: the archiver decision below reads
+        // ntp_config, so the mode has to be in place before it runs rather than
+        // deferred to a fiber that may not have run yet.
+        _raft->log()->set_partition_storage_mode(
+          _partition_properties_stm->partition_storage_mode());
+    }
+
     {
         auto archiver_reset_guard = co_await ssx::with_timeout_abortable(
           ss::get_units(_archiver_reset_mutex, 1),
@@ -548,6 +580,12 @@ ss::future<> partition::stop() {
     auto partition_ntp = ntp();
     vlog(clusterlog.debug, "Stopping partition: {}", partition_ntp);
     _as.request_abort();
+
+    // Before the archiver teardown below, so nothing is mid-rebuild while we
+    // stop it. Closed after _as is aborted, so an in-flight loop stops retrying
+    // and gives up on the reset mutex rather than restarting the archiver we
+    // are stopping.
+    co_await _partition_storage_mode_gate.close();
 
     unregister_flush_hook(_archiver_flush_subscription);
 
@@ -1758,6 +1796,34 @@ partition::force_abort_replica_set_update(model::revision_id rev) {
     return _raft->abort_configuration_change(rev);
 }
 consensus_ptr partition::raft() const { return _raft; }
+
+ss::future<> partition::apply_partition_storage_mode() {
+    const auto& ntp_cfg = _raft->log()->config();
+    const auto durable = _partition_properties_stm->partition_storage_mode();
+    const auto current = ntp_cfg.partition_storage_mode();
+    const auto effective = ntp_cfg.resolve_partition_storage_mode(durable);
+
+    if (current != effective) {
+        vlog(
+          clusterlog.info,
+          "{}: partition_storage_mode {} -> {}",
+          _raft->ntp(),
+          current,
+          effective);
+    } else {
+        vlog(
+          clusterlog.debug,
+          "{}: recording partition_storage_mode {}, effective mode unchanged",
+          _raft->ntp(),
+          durable);
+    }
+
+    _raft->log()->set_partition_storage_mode(durable);
+
+    if (should_construct_archiver() != static_cast<bool>(_archiver)) {
+        co_await restart_archiver(true);
+    }
+}
 
 ss::future<result<model::offset>> partition::set_writes_disabled(
   partition_properties_stm::writes_disabled disable,

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -32,14 +32,17 @@
 #include "raft/state_machine_manager.h"
 #include "ssx/future-util.h"
 #include "ssx/sformat.h"
+#include "ssx/sleep_abortable.h"
 #include "ssx/when_all.h"
 #include "storage/ntp_config.h"
 
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
 #include <seastar/util/defer.hh>
 
 #include <chrono>
 #include <optional>
+#include <system_error>
 
 namespace cluster {
 
@@ -59,6 +62,12 @@ partition::partition(
       clusterlog,
       ssx::sformat("{} partition_storage_mode apply", _raft->ntp()),
       [this] { return apply_partition_storage_mode(); },
+      _as)
+  , _partition_storage_mode_sync(
+      _partition_storage_mode_gate,
+      clusterlog,
+      ssx::sformat("{} partition_storage_mode sync", _raft->ntp()),
+      [this] { return sync_partition_storage_mode(); },
       _as)
   , _probe(std::make_unique<replicated_partition_probe>(*this))
   , _feature_table(feature_table)
@@ -940,27 +949,43 @@ ss::future<> partition::update_configuration(topic_properties new_properties) {
     // Pass the configuration update to the raft layer
     _raft->notify_config_update();
 
-    // If this partition's cloud storage mode changed, rebuild the archiver.
-    // This must happen after the raft+storage update, because it reads raft's
-    // ntp_config to decide whether to construct an archiver.
-    if (cloud_storage_changed) {
-        co_await restart_archiver(true);
-    } else {
-        vlog(
-          clusterlog.trace,
-          "update_configuration[{}]: no cloud storage change, archiver "
-          "exists={}",
-          _raft->ntp(),
-          bool(_archiver));
-
-        if (_archiver) {
+    // If topic_storage_mode() == partition_storage_mode() and there was a
+    // change to archiver configuration, restart the archiver here. If
+    // topic_storage_mode() != partition_storage_mode(), we know:
+    // 1. partition_properties_stm::partition_storage_mode is set, and since
+    //    sync_partition_storage_mode is its only writer, the sync is enabled
+    // 2. the sync loop poked below will propagate a raft update to
+    //    bring it into sync and restart the archiver if necessary, marking the
+    //    topic manifest dirty as it does
+    if (
+      get_ntp_config().topic_storage_mode()
+      == get_ntp_config().partition_storage_mode()) {
+        if (cloud_storage_changed) {
+            co_await restart_archiver(true);
+        } else if (_archiver) {
             // Assume that a partition config may also mean a topic
             // configuration change.  This could be optimized by hooking
             // in separate updates from the controller when our topic
             // configuration changes.
             _archiver->notify_topic_config();
         }
+    } else {
+        vlog(
+          clusterlog.trace,
+          "update_configuration[{}]: leaving the archiver to the "
+          "partition_storage_mode update, topic_storage_mode={} "
+          "partition_storage_mode={}",
+          _raft->ntp(),
+          get_ntp_config().topic_storage_mode(),
+          get_ntp_config().partition_storage_mode());
     }
+
+    // A storage.mode change lands in topic_storage_mode() (above); keep the
+    // durable partition_storage_mode in step so serving predicates see the new
+    // mode. In the background: the sync takes a raft commit, and this path runs
+    // inside controller_backend's per-NTP reconciliation, which must not block
+    // on it.
+    _partition_storage_mode_sync.notify();
 }
 
 ss::future<> partition::restart_archiver(bool should_notify_topic_config) {
@@ -1823,6 +1848,50 @@ ss::future<> partition::apply_partition_storage_mode() {
     if (should_construct_archiver() != static_cast<bool>(_archiver)) {
         co_await restart_archiver(true);
     }
+}
+
+bool partition::partition_storage_mode_sync_enabled() const {
+    // Read replicas are excluded because nothing on one keys on
+    // partition_storage_mode: every predicate that would consult it
+    // short-circuits on being a read replica first, including the archiver's
+    // construction gate. Recording a mode would be a quorum write per partition
+    // to produce durable state that governs nothing, and that a later reader
+    // could mistake for a real mode.
+    return _partition_properties_stm
+           && _feature_table.local().is_active(
+             features::feature::topic_storage_mode_migration)
+           && !get_ntp_config().is_read_replica_mode_enabled();
+}
+
+ss::future<> partition::sync_partition_storage_mode() {
+    if (!partition_storage_mode_sync_enabled() || !is_leader()) {
+        co_return;
+    }
+    // All allowed storage mode transitions are simply passed through: mirror
+    // topic_storage_mode() into partition_storage_mode whenever they differ. (A
+    // legacy shadow_indexing topic has topic_storage_mode() == unset;
+    // partition_storage_mode starts unset too, so this is a no-op and it stays
+    // unset.)
+    //
+    // Recomputed on every attempt: the topic config may change while retrying,
+    // including while a previous attempt was replicating.
+    const auto target = get_ntp_config().topic_storage_mode();
+    if (_partition_properties_stm->partition_storage_mode() == target) {
+        co_return;
+    }
+    // The archiver is rebuilt after the ntp_config flip by
+    // apply_partition_storage_mode, on the apply path -- nothing to order here.
+    auto res = co_await _partition_properties_stm->set_partition_storage_mode(
+      target);
+    if (res.has_error()) {
+        // Retried with backoff for as long as this replica is still leader: a
+        // replication error steps the leader down, and then the next attempt
+        // finds itself ineligible and the successor's notification takes over.
+        co_await ss::coroutine::return_exception(
+          std::system_error{res.error()});
+    }
+    // A target that moves while replicating comes from update_configuration,
+    // which notifies as well, so there is no need to ask for another pass here.
 }
 
 ss::future<result<model::offset>> partition::set_writes_disabled(

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -23,11 +23,13 @@
 #include "model/record_batch_reader.h"
 #include "model/timeout_clock.h"
 #include "raft/replicate.h"
+#include "ssx/reconciler.h"
 #include "storage/ntp_config.h"
 #include "storage/translating_reader.h"
 #include "storage/types.h"
 #include "utils/notification_list.h"
 
+#include <seastar/core/gate.hh>
 #include <seastar/core/shared_ptr.hh>
 
 namespace cloud_topics {
@@ -425,6 +427,10 @@ private:
     // dirty so that it gets reuploaded
     ss::future<> restart_archiver(bool should_notify_topic_config);
 
+    // Move ntp_config to the STM's partition_storage_mode and restart the
+    // archiver if needed. Driven by _partition_storage_mode_apply.
+    ss::future<> apply_partition_storage_mode();
+
     consensus_ptr _raft; // never null
     ss::shared_ptr<cluster::log_eviction_stm> _log_eviction_stm;
     ss::shared_ptr<cluster::rm_stm> _rm_stm;
@@ -432,6 +438,10 @@ private:
     ss::shared_ptr<partition_properties_stm> _partition_properties_stm;
     ss::sharded<cloud_topics::state_accessors>* _cloud_topics_state;
     ss::abort_source _as;
+    // Holds the apply loop triggered by the stm's partition_storage_mode
+    // callback; closed in stop() before the archiver is torn down.
+    ss::gate _partition_storage_mode_gate;
+    ssx::reconciler _partition_storage_mode_apply;
     partition_probe _probe;
     ss::sharded<features::feature_table>& _feature_table;
     ss::lw_shared_ptr<const archival::configuration> _archival_conf;

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -166,6 +166,16 @@ public:
 
     bool is_elected_leader() const;
     bool is_leader() const;
+
+    // The loop keeping durable partition_storage_mode in step with
+    // topic_storage_mode() (see sync_partition_storage_mode). Poke it on
+    // becoming leader, on migration-feature activation and on topic-config
+    // changes; notify_and_wait() to bound how many quorum writes a sweep has in
+    // flight at once.
+    ssx::reconciler& partition_storage_mode_sync() {
+        return _partition_storage_mode_sync;
+    }
+
     bool has_followers() const;
     void block_new_leadership() const;
     void unblock_new_leadership() const;
@@ -427,9 +437,23 @@ private:
     // dirty so that it gets reuploaded
     ss::future<> restart_archiver(bool should_notify_topic_config);
 
+    // Precondition for sync_partition_storage_mode: the stm exists, the feature
+    // is active, and this is not a read replica (nothing on one keys on
+    // partition_storage_mode).
+    bool partition_storage_mode_sync_enabled() const;
+
     // Move ntp_config to the STM's partition_storage_mode and restart the
     // archiver if needed. Driven by _partition_storage_mode_apply.
     ss::future<> apply_partition_storage_mode();
+
+    // Write topic_storage_mode() through to partition_properties if this
+    // leader's durable partition_storage_mode differs from it, so that the
+    // serving predicates see the new mode. Gated behind the
+    // partition_storage_mode feature and leader-only; legacy shadow_indexing
+    // topics (topic_storage_mode() == unset) are left unset. Driven by
+    // _partition_storage_mode_sync; returning is success, a throw is retried
+    // with backoff.
+    ss::future<> sync_partition_storage_mode();
 
     consensus_ptr _raft; // never null
     ss::shared_ptr<cluster::log_eviction_stm> _log_eviction_stm;
@@ -438,10 +462,14 @@ private:
     ss::shared_ptr<partition_properties_stm> _partition_properties_stm;
     ss::sharded<cloud_topics::state_accessors>* _cloud_topics_state;
     ss::abort_source _as;
-    // Holds the apply loop triggered by the stm's partition_storage_mode
-    // callback; closed in stop() before the archiver is torn down.
+    // Holds both partition_storage_mode loops -- the apply loop triggered by
+    // the stm's partition_storage_mode callback and the sync loop triggered by
+    // leadership, the migration-feature sweep and update_configuration. Closed
+    // in stop() before the archiver is torn down. Neither loop waits on the
+    // other, so one gate for both is enough.
     ss::gate _partition_storage_mode_gate;
     ssx::reconciler _partition_storage_mode_apply;
+    ssx::reconciler _partition_storage_mode_sync;
     partition_probe _probe;
     ss::sharded<features::feature_table>& _feature_table;
     ss::lw_shared_ptr<const archival::configuration> _archival_conf;

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -30,6 +30,7 @@
 #include "raft/consensus_utils.h"
 #include "raft/fundamental.h"
 #include "ssx/async-clear.h"
+#include "ssx/future-util.h"
 
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -73,6 +74,12 @@ partition_manager::partition_manager(
                 if (a) {
                     a.value().get().notify_leadership(leader_id);
                 }
+                // Sync the partition's durable storage mode to its topic
+                // config on becoming leader (no-op when not leader or already
+                // in sync). Detached: the sync runs under the partition's own
+                // gate, and only one loop runs per partition however many
+                // callers poke it.
+                p->partition_storage_mode_sync().notify();
             }
         });
     _shutdown_watchdog.set_callback(

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -25,6 +25,7 @@
 #include "cluster/partition_recovery_manager.h"
 #include "cluster/topic_configuration.h"
 #include "cluster/types.h"
+#include "container/chunked_vector.h"
 #include "model/metadata.h"
 #include "raft/consensus.h"
 #include "raft/consensus_utils.h"
@@ -32,6 +33,7 @@
 #include "ssx/async-clear.h"
 #include "ssx/future-util.h"
 
+#include <seastar/core/loop.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/shared_ptr.hh>
 
@@ -107,7 +109,57 @@ partition_manager::get_topic_partition_table(
 
 ss::future<> partition_manager::start() {
     maybe_arm_shutdown_watchdog();
+    // Sync partition_storage_mode once the migration feature activates. The
+    // leadership-notification sync (sync_partition_storage_mode) is gated on
+    // the feature being active, so a partition that became leader while the
+    // feature was inactive is left with partition_storage_mode == unset. Re-run
+    // the sync on every current leader when the feature turns active;
+    // partitions that gain leadership after activation are covered by the
+    // leadership notification.
+    ssx::spawn_with_gate(_gate, [this] {
+        return sync_partition_storage_mode_on_migration_feature();
+    });
     co_return;
+}
+
+ss::future<>
+partition_manager::sync_partition_storage_mode_on_migration_feature() {
+    try {
+        co_await _feature_table.local().await_feature(
+          features::feature::topic_storage_mode_migration, _as);
+    } catch (...) {
+        // Aborted on shutdown before the feature activated.
+        co_return;
+    }
+    // Snapshot the current leaders: _ntp_table can mutate across the yields
+    // below, and sync_partition_storage_mode re-checks leadership anyway.
+    chunked_vector<ss::lw_shared_ptr<partition>> leaders;
+    for (const auto& [_, p] : _ntp_table) {
+        if (p->is_leader()) {
+            leaders.push_back(p);
+        }
+    }
+    // Bound the concurrency, per shard (this sweep runs on every shard): at
+    // activation every leader needs a real sync (a quorum write), on every
+    // node in the cluster at the same time.
+    //
+    // Both halves of the shutdown handling are needed. The wait is on _as as
+    // well as on the sync because the loop being waited for belongs to the
+    // partition and outlives this sweep, while stop_partitions() closes the
+    // gate this fiber holds before it stops any partition -- a wait only the
+    // partition could end would deadlock shutdown. The check is because
+    // max_concurrent_for_each runs the whole range regardless, so without it
+    // every remaining leader would still be notified on the way out.
+    co_await ss::max_concurrent_for_each(leaders, 16, [this](const auto& p) {
+        if (_as.abort_requested()) {
+            return ss::now();
+        }
+        return ssx::ignore_shutdown_exceptions(
+          ssx::with_timeout_abortable(
+            p->partition_storage_mode_sync().notify_and_wait(),
+            ss::lowres_clock::time_point::max(),
+            _as));
+    });
 }
 
 ss::future<consensus_ptr> partition_manager::manage(

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -277,6 +277,12 @@ private:
     void check_partitions_shutdown_state();
 
     void maybe_arm_shutdown_watchdog();
+
+    // Awaits the topic_storage_mode_migration feature and then re-runs
+    // the partition_storage_mode sync on every current leader (with bounded
+    // concurrency), covering partitions that became leader while the feature
+    // was inactive.
+    ss::future<> sync_partition_storage_mode_on_migration_feature();
     storage::api& _storage;
     /// used to wait for concurrent recoveries
     ss::sharded<raft::group_manager>& _raft_manager;

--- a/src/v/cluster/partition_properties_stm.cc
+++ b/src/v/cluster/partition_properties_stm.cc
@@ -40,7 +40,8 @@ partition_properties_stm::partition_properties_stm(
   , _state_snapshots({state_snapshot{
       .writes_disabled = writes_disabled::no,
       .update_offset = model::offset{},
-      .writes_revision_id{}}}) {}
+      .writes_revision_id{},
+      .partition_storage_mode = model::redpanda_storage_mode::unset}}) {}
 
 ss::future<iobuf>
 partition_properties_stm::take_raft_snapshot(model::offset o) {
@@ -88,7 +89,8 @@ partition_properties_stm::take_raft_snapshot(model::offset o) {
     co_return serde::to_iobuf(
       raft_snapshot{
         .writes_disabled = it->writes_disabled,
-        .writes_revision_id = it->writes_revision_id});
+        .writes_revision_id = it->writes_revision_id,
+        .partition_storage_mode = it->partition_storage_mode});
 }
 
 ss::future<raft::local_snapshot_applied>
@@ -157,43 +159,69 @@ void partition_properties_stm::apply_record(
     auto key = r.release_key();
     auto value = r.release_value();
     auto ot = serde::from_iobuf<operation_type>(std::move(key));
-    if (ot != operation_type::update_writes_disabled) [[unlikely]] {
-        vlog(
-          _log.warn,
-          "ignored unknown operation type with value: {}",
-          static_cast<int>(ot));
-        return;
-    }
-    auto update = serde::from_iobuf<update_writes_disabled_cmd>(
-      std::move(value));
-    vlog(
-      _log.trace,
-      "Applying update {} at offset: {}",
-      update,
+    const auto update_offset = model::offset(
       r.offset_delta() + batch_begin_offset);
     const auto current_state = _state_snapshots.back();
-    bool is_legacy_command = update.writes_revision_id == model::revision_id{};
-    bool is_newer_revision = update.writes_revision_id
-                             > current_state.writes_revision_id;
-    if (!is_newer_revision && !is_legacy_command) {
+    switch (ot) {
+    case operation_type::update_writes_disabled: {
+        auto update = serde::from_iobuf<update_writes_disabled_cmd>(
+          std::move(value));
         vlog(
-          _log.error,
-          "Ignoring out-of-order update: {}, current state: {}",
+          _log.trace,
+          "Applying update {} at offset: {}",
           update,
-          _state_snapshots.back());
+          update_offset);
+        bool is_legacy_command = update.writes_revision_id
+                                 == model::revision_id{};
+        bool is_newer_revision = update.writes_revision_id
+                                 > current_state.writes_revision_id;
+        if (!is_newer_revision && !is_legacy_command) {
+            vlog(
+              _log.error,
+              "Ignoring out-of-order update: {}, current state: {}",
+              update,
+              current_state);
+            return;
+        }
+        bool differs = update.writes_disabled != current_state.writes_disabled
+                       || update.writes_revision_id
+                            != current_state.writes_revision_id;
+        if (differs) {
+            // copy-modify preserves the other properties (e.g.
+            // partition_storage_mode)
+            auto next = current_state;
+            next.writes_disabled = update.writes_disabled;
+            next.writes_revision_id = update.writes_revision_id;
+            next.update_offset = update_offset;
+            _state_snapshots.push_back(next);
+        }
         return;
     }
-    bool differs = update.writes_disabled != current_state.writes_disabled
-                   || update.writes_revision_id
-                        != current_state.writes_revision_id;
-    if (differs) {
-        _state_snapshots.push_back(
-          state_snapshot{
-            .writes_disabled = update.writes_disabled,
-            .update_offset = model::offset(
-              r.offset_delta() + batch_begin_offset),
-            .writes_revision_id = update.writes_revision_id});
+    case operation_type::update_partition_storage_mode: {
+        auto update = serde::from_iobuf<update_partition_storage_mode_cmd>(
+          std::move(value));
+        vlog(
+          _log.trace,
+          "Applying partition_storage_mode update {} at offset: {}",
+          update,
+          update_offset);
+        // idempotent by value, ordered by log offset (no revision needed).
+        if (
+          update.partition_storage_mode
+          != current_state.partition_storage_mode) {
+            auto next = current_state;
+            next.partition_storage_mode = update.partition_storage_mode;
+            next.update_offset = update_offset;
+            _state_snapshots.push_back(next);
+            notify_partition_storage_mode_change();
+        }
+        return;
     }
+    }
+    vlog(
+      _log.warn,
+      "ignored unknown operation type with value: {}",
+      static_cast<int>(ot));
 }
 
 ss::future<>
@@ -211,7 +239,9 @@ partition_properties_stm::apply_raft_snapshot(const iobuf& buffer) {
       state_snapshot{
         .writes_disabled = snapshot.writes_disabled,
         .update_offset = model::prev_offset(_raft->start_offset()),
-        .writes_revision_id = snapshot.writes_revision_id});
+        .writes_revision_id = snapshot.writes_revision_id,
+        .partition_storage_mode = snapshot.partition_storage_mode});
+    notify_partition_storage_mode_change();
     co_return;
 }
 
@@ -301,6 +331,99 @@ model::record_batch partition_properties_stm::make_update_partitions_batch(
     return std::move(builder).build();
 }
 
+model::record_batch
+partition_properties_stm::make_update_partition_storage_mode_batch(
+  update_partition_storage_mode_cmd cmd) {
+    storage::record_batch_builder builder(
+      model::record_batch_type::partition_properties_update, model::offset{});
+    builder.add_raw_kv(
+      serde::to_iobuf(operation_type::update_partition_storage_mode),
+      serde::to_iobuf(std::move(cmd)));
+    return std::move(builder).build();
+}
+
+ss::future<result<model::offset>>
+partition_properties_stm::replicate_partition_storage_mode_update(
+  model::timeout_clock::duration timeout,
+  update_partition_storage_mode_cmd cmd) {
+    auto holder = _gate.hold();
+    auto units = co_await _writes_mutex.get_units();
+    if (!co_await sync(timeout)) {
+        co_return errc::not_leader;
+    }
+
+    vassert(
+      !_state_snapshots.empty(),
+      "The invariant of state snapshot containing at least one element is "
+      "broken");
+    auto current_state = _state_snapshots.back();
+    if (cmd.partition_storage_mode == current_state.partition_storage_mode)
+      [[unlikely]] {
+        // no-op
+        co_return current_state.update_offset;
+    }
+
+    auto b = make_update_partition_storage_mode_batch(cmd);
+    vlog(_log.debug, "replicating update partition mode command: {}", cmd);
+    raft::replicate_options r_opts(
+      raft::consistency_level::quorum_ack,
+      _insync_term,
+      std::chrono::milliseconds(timeout / 1ms));
+    r_opts.set_force_flush();
+    auto r = co_await _raft->replicate(std::move(b), r_opts);
+
+    if (r.has_error()) {
+        vlog(
+          _log.warn,
+          "error replicating update partition mode command: {} - {}",
+          cmd,
+          r.error().message());
+        co_await _raft->step_down("partition_properties_stm/replication_error");
+        co_return r.error();
+    }
+
+    auto message_offset = r.value().last_offset;
+    if (!co_await wait_no_throw(
+          message_offset, model::timeout_clock::time_point::max())) {
+        co_await _raft->step_down("partition_properties_stm/replication_error");
+        co_return errc::shutting_down;
+    }
+    co_return message_offset;
+}
+
+ss::future<result<model::offset>>
+partition_properties_stm::set_partition_storage_mode(
+  model::redpanda_storage_mode mode) {
+    vlog(_log.info, "setting partition mode to {}", mode);
+    return replicate_partition_storage_mode_update(
+      _sync_timeout(),
+      update_partition_storage_mode_cmd{.partition_storage_mode = mode});
+}
+
+model::redpanda_storage_mode
+partition_properties_stm::partition_storage_mode() const {
+    vassert(
+      !_state_snapshots.empty(),
+      "The invariant of state snapshot containing at least one element is "
+      "broken");
+    return _state_snapshots.back().partition_storage_mode;
+}
+
+void partition_properties_stm::notify_partition_storage_mode_change() {
+    if (_partition_storage_mode_change_cb) {
+        _partition_storage_mode_change_cb();
+    }
+}
+
+ss::future<result<model::redpanda_storage_mode>>
+partition_properties_stm::sync_partition_storage_mode() {
+    auto holder = _gate.hold();
+    if (!co_await sync(_sync_timeout())) {
+        co_return errc::not_leader;
+    }
+    co_return partition_storage_mode();
+}
+
 ss::future<result<model::offset>>
 partition_properties_stm::disable_writes(model::revision_id revision_id) {
     vlog(_log.info, "disabling partition writes");
@@ -355,9 +478,20 @@ fmt::iterator
 partition_properties_stm::raft_snapshot::format_to(fmt::iterator it) const {
     return fmt::format_to(
       it,
-      "{{writes_disabled: {}, writes_revision_id: {}}}",
+      "{{writes_disabled: {}, writes_revision_id: {}, partition_storage_mode: "
+      "{}}}",
       writes_disabled,
-      writes_revision_id);
+      writes_revision_id,
+      model::redpanda_storage_mode_to_string(partition_storage_mode));
+}
+
+fmt::iterator
+partition_properties_stm::update_partition_storage_mode_cmd::format_to(
+  fmt::iterator it) const {
+    return fmt::format_to(
+      it,
+      "{{partition_storage_mode: {}}}",
+      model::redpanda_storage_mode_to_string(partition_storage_mode));
 }
 
 fmt::iterator partition_properties_stm::update_writes_disabled_cmd::format_to(
@@ -373,10 +507,12 @@ fmt::iterator
 partition_properties_stm::state_snapshot::format_to(fmt::iterator it) const {
     return fmt::format_to(
       it,
-      "{{update_offset: {}, writes_disabled: {}, writes_revision_id: {}}}",
+      "{{update_offset: {}, writes_disabled: {}, writes_revision_id: {}, "
+      "partition_storage_mode: {}}}",
       update_offset,
       writes_disabled,
-      writes_revision_id);
+      writes_revision_id,
+      model::redpanda_storage_mode_to_string(partition_storage_mode));
 }
 
 fmt::iterator

--- a/src/v/cluster/partition_properties_stm.h
+++ b/src/v/cluster/partition_properties_stm.h
@@ -15,8 +15,11 @@
 #include "cluster/state_machine_registry.h"
 #include "container/chunked_vector.h"
 #include "model/fundamental.h"
+#include "model/metadata.h"
 #include "raft/persisted_stm.h"
 #include "serde/envelope.h"
+
+#include <seastar/util/noncopyable_function.hh>
 
 namespace cluster {
 
@@ -50,6 +53,29 @@ public:
     // Returns a current value of the writes disabled property.
     writes_disabled are_writes_disabled() const;
 
+    // Updates the persistent, partition-local storage mode; returns the offset
+    // of the update message. This is the partition's own durable record of its
+    // storage mode, decoupled from the topic config (see
+    // partition_storage_mode()).
+    ss::future<result<model::offset>>
+      set_partition_storage_mode(model::redpanda_storage_mode);
+    // Waits for the state to be up to date and returns the partition mode; only
+    // intended to be called on the current leader.
+    ss::future<result<model::redpanda_storage_mode>>
+    sync_partition_storage_mode();
+    // Returns the current partition mode. `unset` means "not yet bootstrapped";
+    // callers (ntp_config) fall back to the topic-config-derived mode.
+    model::redpanda_storage_mode partition_storage_mode() const;
+
+    // Registers a callback invoked on this shard whenever
+    // partition_storage_mode may have changed (on apply and on raft-snapshot
+    // restore), so the owner can re-read partition_storage_mode() and propagate
+    // it (e.g. into ntp_config).
+    void set_partition_storage_mode_change_callback(
+      ss::noncopyable_function<void()> cb) {
+        _partition_storage_mode_change_cb = std::move(cb);
+    }
+
     raft::stm_initial_recovery_policy
     get_initial_recovery_policy() const final {
         return raft::stm_initial_recovery_policy::skip_to_end;
@@ -80,19 +106,42 @@ private:
           const update_writes_disabled_cmd&) = default;
     };
 
+    struct update_partition_storage_mode_cmd
+      : serde::envelope<
+          update_partition_storage_mode_cmd,
+          serde::version<0>,
+          serde::compat_version<0>> {
+        model::redpanda_storage_mode partition_storage_mode
+          = model::redpanda_storage_mode::unset;
+
+        auto serde_fields() { return std::tie(partition_storage_mode); }
+        fmt::iterator format_to(fmt::iterator it) const;
+        friend bool operator==(
+          const update_partition_storage_mode_cmd&,
+          const update_partition_storage_mode_cmd&) = default;
+    };
+
     struct state_snapshot
       : serde::envelope<
           state_snapshot,
-          serde::version<1>,
+          serde::version<2>,
           serde::compat_version<0>> {
         // todo: in a major release we can change it to use a local_snapshot +
         // update_offset
         writes_disabled writes_disabled;
         model::offset update_offset;
         model::revision_id writes_revision_id;
+        // If == unset, ntp_config will fall back partition_storage_mode() to
+        // topic_storage_mode() (currently configured topic mode)
+        model::redpanda_storage_mode partition_storage_mode
+          = model::redpanda_storage_mode::unset;
 
         auto serde_fields() {
-            return std::tie(writes_disabled, update_offset, writes_revision_id);
+            return std::tie(
+              writes_disabled,
+              update_offset,
+              writes_revision_id,
+              partition_storage_mode);
         }
         fmt::iterator format_to(fmt::iterator it) const;
         friend bool
@@ -101,12 +150,15 @@ private:
 
     struct raft_snapshot
       : serde::
-          envelope<raft_snapshot, serde::version<1>, serde::compat_version<0>> {
+          envelope<raft_snapshot, serde::version<2>, serde::compat_version<0>> {
         writes_disabled writes_disabled = writes_disabled::no;
         model::revision_id writes_revision_id;
+        model::redpanda_storage_mode partition_storage_mode
+          = model::redpanda_storage_mode::unset;
 
         auto serde_fields() {
-            return std::tie(writes_disabled, writes_revision_id);
+            return std::tie(
+              writes_disabled, writes_revision_id, partition_storage_mode);
         }
         fmt::iterator format_to(fmt::iterator it) const;
 
@@ -134,6 +186,7 @@ private:
 
     enum class operation_type {
         update_writes_disabled = 0,
+        update_partition_storage_mode = 1,
     };
 
     ss::future<> do_apply(const model::record_batch&) final;
@@ -142,10 +195,15 @@ private:
 
     static model::record_batch
       make_update_partitions_batch(update_writes_disabled_cmd);
+    static model::record_batch make_update_partition_storage_mode_batch(
+      update_partition_storage_mode_cmd);
 
     ss::future<result<model::offset>> replicate_properties_update(
       model::timeout_clock::duration timeout,
       update_writes_disabled_cmd command);
+    ss::future<result<model::offset>> replicate_partition_storage_mode_update(
+      model::timeout_clock::duration timeout,
+      update_partition_storage_mode_cmd command);
 
     config::binding<std::chrono::milliseconds> _sync_timeout;
 
@@ -156,8 +214,12 @@ private:
     // cleaned when the local snapshot is taken.
     chunked_vector<state_snapshot> _state_snapshots;
 
-    // For linearizing access to writes_disabled state on the leader
+    // For linearizing access to writes_disabled and partition_storage_mode
+    // state on the leader
     ssx::mutex _writes_mutex{"c/partition_properties_stm::writes_mutex"};
+
+    void notify_partition_storage_mode_change();
+    ss::noncopyable_function<void()> _partition_storage_mode_change_cb;
 };
 
 class partition_properties_stm_factory : public state_machine_factory {

--- a/src/v/cluster/tests/partition_properties_stm_test.cc
+++ b/src/v/cluster/tests/partition_properties_stm_test.cc
@@ -16,6 +16,7 @@
 #include "config/mock_property.h"
 #include "container/chunked_circular_buffer.h"
 #include "model/fundamental.h"
+#include "model/metadata.h"
 #include "model/record.h"
 #include "model/tests/random_batch.h"
 #include "raft/replicate.h"
@@ -113,6 +114,34 @@ struct partition_properties_stm_fixture : raft::raft_fixture {
         auto r = co_await get_writes_disabled_on_leader();
         ASSERT_TRUE_CORO(r.has_value());
         ASSERT_EQ_CORO(r.value(), disabled);
+    }
+
+    ss::future<> set_partition_storage_mode(
+      model::redpanda_storage_mode mode, bool expect_success = true) {
+        auto res = co_await retry_with_leader(
+          raft::default_timeout(),
+          2s,
+          [mode](raft::raft_node_instance& leader_node) {
+              return get_stm(leader_node)->set_partition_storage_mode(mode);
+          });
+        ASSERT_EQ_CORO(res.has_value(), expect_success);
+    }
+
+    ss::future<>
+    assert_partition_storage_mode(model::redpanda_storage_mode mode) {
+        auto r = co_await get_leader_stm()->sync_partition_storage_mode();
+        ASSERT_TRUE_CORO(r.has_value());
+        ASSERT_EQ_CORO(r.value(), mode);
+    }
+
+    ss::future<>
+    check_partition_storage_mode_consistent(model::redpanda_storage_mode mode) {
+        RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this, mode] {
+            return std::ranges::all_of(
+              node_stms | std::views::values, [mode](auto stm) {
+                  return stm->partition_storage_mode() == mode;
+              });
+        });
     }
 
     ss::future<result<model::offset>> replicate_random_batches() {
@@ -415,6 +444,146 @@ TEST_F_CORO(
     ASSERT_EQ_CORO(writes_disabled, should_be_disabled);
     co_await wait_for_committed_offset(last_applied, 10s);
     co_await check_state_consistent(should_be_disabled);
+}
+
+TEST_F_CORO(
+  partition_properties_stm_fixture, test_partition_storage_mode_basic) {
+    co_await initialize_state_machines();
+    co_await wait_for_leader(10s);
+    // A fresh partition has never had partition_storage_mode written: it reads
+    // `unset` (the "not bootstrapped -> fall back to topic_storage_mode"
+    // sentinel).
+    co_await assert_partition_storage_mode(model::redpanda_storage_mode::unset);
+
+    co_await set_partition_storage_mode(model::redpanda_storage_mode::tiered);
+    co_await assert_partition_storage_mode(
+      model::redpanda_storage_mode::tiered);
+    // idempotent
+    co_await set_partition_storage_mode(model::redpanda_storage_mode::tiered);
+    co_await assert_partition_storage_mode(
+      model::redpanda_storage_mode::tiered);
+    // the migration cutover transition: tiered -> cloud
+    co_await set_partition_storage_mode(model::redpanda_storage_mode::cloud);
+    co_await assert_partition_storage_mode(model::redpanda_storage_mode::cloud);
+    co_await check_partition_storage_mode_consistent(
+      model::redpanda_storage_mode::cloud);
+}
+
+// writes_disabled and partition_storage_mode share one state_snapshot; updating
+// one must preserve the other (the apply copy-modify).
+TEST_F_CORO(
+  partition_properties_stm_fixture,
+  test_partition_storage_mode_independent_of_writes) {
+    co_await initialize_state_machines();
+
+    co_await disable_writes(model::revision_id{1});
+    co_await set_partition_storage_mode(model::redpanda_storage_mode::tiered);
+    co_await assert_writes(stm_t::writes_disabled::yes);
+    co_await assert_partition_storage_mode(
+      model::redpanda_storage_mode::tiered);
+
+    // a partition_storage_mode update leaves writes_disabled untouched
+    co_await set_partition_storage_mode(model::redpanda_storage_mode::cloud);
+    co_await assert_writes(stm_t::writes_disabled::yes);
+    co_await assert_partition_storage_mode(model::redpanda_storage_mode::cloud);
+
+    // and a writes_disabled update leaves partition_storage_mode untouched
+    co_await enable_writes(model::revision_id{2});
+    co_await assert_writes(stm_t::writes_disabled::no);
+    co_await assert_partition_storage_mode(model::redpanda_storage_mode::cloud);
+}
+
+TEST_F_CORO(
+  partition_properties_stm_fixture, test_partition_storage_mode_snapshot) {
+    co_await initialize_state_machines();
+
+    auto before_set = co_await replicate_random_batches();
+    co_await set_partition_storage_mode(model::redpanda_storage_mode::tiered);
+    [[maybe_unused]] auto _ignored = co_await replicate_random_batches();
+
+    auto leader_id = get_leader();
+    EXPECT_TRUE(leader_id.has_value());
+    auto& leader_node = node(leader_id.value());
+
+    // snapshot taken before the set command -> unset
+    auto o = co_await leader_node.random_batch_base_offset(before_set.value());
+    auto snap_before = partition_properties_stm_accessor::snap_from_iobuf(
+      co_await get_leader_stm()->take_raft_snapshot(o));
+    ASSERT_EQ_CORO(
+      snap_before.partition_storage_mode, model::redpanda_storage_mode::unset);
+
+    // snapshot at the set command offset -> tiered (and writes_disabled intact)
+    auto snap_at = partition_properties_stm_accessor::snap_from_iobuf(
+      co_await get_leader_stm()->take_raft_snapshot(
+        model::next_offset(before_set.value())));
+    ASSERT_EQ_CORO(
+      snap_at.partition_storage_mode, model::redpanda_storage_mode::tiered);
+    ASSERT_EQ_CORO(snap_at.writes_disabled, stm_t::writes_disabled::no);
+}
+
+TEST_F_CORO(
+  partition_properties_stm_fixture, test_partition_storage_mode_recovery) {
+    co_await initialize_state_machines();
+    co_await set_partition_storage_mode(model::redpanda_storage_mode::tiered);
+    [[maybe_unused]] auto _ignored = co_await replicate_random_batches();
+    co_await set_partition_storage_mode(model::redpanda_storage_mode::cloud);
+    co_await assert_partition_storage_mode(model::redpanda_storage_mode::cloud);
+    auto last_applied = get_leader_stm()->last_applied_offset();
+
+    // restart preserving data: recover from local (kvstore) snapshot + replay
+    co_await restart_nodes();
+    co_await wait_for_leader(10s);
+    co_await assert_partition_storage_mode(model::redpanda_storage_mode::cloud);
+    co_await wait_for_committed_offset(last_applied, 10s);
+    co_await check_partition_storage_mode_consistent(
+      model::redpanda_storage_mode::cloud);
+
+    // take a raft snapshot on every node, then restart with one node's data
+    // dropped: that node recovers partition_storage_mode from the raft
+    // snapshot.
+    for (auto& [_, node] : nodes()) {
+        auto base_offset = co_await node->random_batch_base_offset(
+          node->raft()->committed_offset(), model::offset(1));
+        auto snapshot_offset = model::prev_offset(base_offset);
+        auto result = co_await node->raft()->stm_manager()->take_snapshot(
+          snapshot_offset);
+        co_await node->raft()->write_snapshot(
+          raft::write_snapshot_cfg(snapshot_offset, std::move(result.data)));
+    }
+    co_await restart_nodes({model::node_id(1)});
+    co_await wait_for_leader(10s);
+    co_await assert_partition_storage_mode(model::redpanda_storage_mode::cloud);
+    co_await wait_for_committed_offset(last_applied, 10s);
+    co_await check_partition_storage_mode_consistent(
+      model::redpanda_storage_mode::cloud);
+}
+
+// The change callback (used by partition to push partition_storage_mode into
+// ntp_config) must fire when partition_storage_mode changes, on each replica
+// that applies the change.
+TEST_F_CORO(
+  partition_properties_stm_fixture,
+  test_partition_storage_mode_change_callback) {
+    co_await initialize_state_machines();
+    co_await wait_for_leader(10s);
+
+    auto fired = ss::make_lw_shared<int>(0);
+    for (auto& [_, stm] : node_stms) {
+        stm->set_partition_storage_mode_change_callback(
+          [fired] { ++(*fired); });
+    }
+
+    co_await set_partition_storage_mode(model::redpanda_storage_mode::tiered);
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [fired] { return *fired >= 1; });
+    co_await check_partition_storage_mode_consistent(
+      model::redpanda_storage_mode::tiered);
+
+    // an idempotent (no-op) update does not change state, so it does not fire
+    auto before = *fired;
+    co_await set_partition_storage_mode(model::redpanda_storage_mode::tiered);
+    co_await check_partition_storage_mode_consistent(
+      model::redpanda_storage_mode::tiered);
+    ASSERT_EQ_CORO(*fired, before);
 }
 
 } // namespace cluster

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -111,6 +111,8 @@ std::string_view to_string_view(feature f) {
         return "remote_labels";
     case feature::partition_properties_stm:
         return "partition_properties_stm";
+    case feature::topic_storage_mode_migration:
+        return "topic_storage_mode_migration";
     case feature::shadow_indexing_split_topic_property_update:
         return "shadow_indexing_split_topic_property_update";
     case feature::datalake_iceberg:

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -66,6 +66,7 @@ enum class feature : std::uint64_t {
     membership_change_controller_cmds = 1ULL << 22U,
     controller_snapshots = 1ULL << 23U,
     cloud_storage_manifest_format_v2 = 1ULL << 24U,
+    topic_storage_mode_migration = 1ULL << 25U,
     force_partition_reconfiguration = 1ULL << 26U,
     delete_records = 1ULL << 29U,
     raft_coordinated_recovery = 1ULL << 31U,
@@ -431,6 +432,12 @@ inline constexpr std::array feature_schema{
     release_version::v24_3_1,
     "partition_properties_stm",
     feature::partition_properties_stm,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    release_version::v26_3_1,
+    "topic_storage_mode_migration",
+    feature::topic_storage_mode_migration,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{

--- a/src/v/raft/tests/failure_injectable_log.cc
+++ b/src/v/raft/tests/failure_injectable_log.cc
@@ -212,6 +212,12 @@ void failure_injectable_log::set_overrides(
     return _underlying_log->set_overrides(overrides);
 }
 
+void failure_injectable_log::set_partition_storage_mode(
+  model::redpanda_storage_mode mode) {
+    mutable_config().set_partition_storage_mode(mode);
+    return _underlying_log->set_partition_storage_mode(mode);
+}
+
 bool failure_injectable_log::notify_compaction_update() {
     return _underlying_log->notify_compaction_update();
 }

--- a/src/v/raft/tests/failure_injectable_log.h
+++ b/src/v/raft/tests/failure_injectable_log.h
@@ -118,6 +118,8 @@ public:
 
     void set_overrides(storage::ntp_config::default_overrides) final;
 
+    void set_partition_storage_mode(model::redpanda_storage_mode) final;
+
     bool notify_compaction_update() final;
 
     int64_t compaction_backlog() final;

--- a/src/v/ssx/BUILD
+++ b/src/v/ssx/BUILD
@@ -188,6 +188,20 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "reconciler",
+    hdrs = [
+        "reconciler.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":future_util",
+        ":sleep_abortable",
+        "//src/v/base",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "sleep_abortable",
     hdrs = [
         "sleep_abortable.h",

--- a/src/v/ssx/reconciler.h
+++ b/src/v/ssx/reconciler.h
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "base/vlog.h"
+#include "ssx/future-util.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future-util.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/shared_future.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/coroutine/as_future.hh>
+#include <seastar/util/defer.hh>
+#include <seastar/util/log.hh>
+#include <seastar/util/noncopyable_function.hh>
+
+#include <algorithm>
+#include <chrono>
+#include <list>
+#include <optional>
+#include <utility>
+
+namespace ssx {
+
+using namespace std::chrono_literals;
+
+/// Function to run on notify().  Returning is success.  Exceptions are retried
+/// with a backoff.  A shutdown exception ends the loop and propagates to
+/// waiters.
+using reconcile_fn = ss::noncopyable_function<ss::future<>()>;
+
+struct backoff_policy {
+    std::chrono::milliseconds base{100ms};
+    std::chrono::milliseconds max{5s};
+};
+
+/// Ensures that the reconcile_fn runs at least once after each call to
+/// notify().
+///
+/// notify() records that desired state may have moved and starts the loop if it
+/// is not already running. A notification that arrives mid-attempt is not lost:
+/// it causes another attempt rather than a second concurrent loop.
+///
+/// A closed gate, abort source, or a shutdown exception from the reconcile_fn
+/// results in giving up on all pending notifies and notifying waiters of
+/// failure.
+///
+/// User is responsible for triggering the passed abort source and closing the
+/// passed gate before anything the step touches is torn down.
+class reconciler {
+public:
+    reconciler(
+      ss::gate& gate,
+      ss::logger& log,
+      ss::sstring name,
+      reconcile_fn step,
+      ss::abort_source& as,
+      backoff_policy backoff = {})
+      : _gate(gate)
+      , _log(log)
+      , _name(std::move(name))
+      , _step(std::move(step))
+      , _backoff(backoff)
+      , _as(as) {}
+
+    reconciler(const reconciler&) = delete;
+    reconciler& operator=(const reconciler&) = delete;
+    reconciler(reconciler&&) = delete;
+    reconciler& operator=(reconciler&&) = delete;
+    ~reconciler() = default;
+
+    /// Notify to trigger a reconciliation.  Never blocks and never throws.
+    void notify() {
+        _dirty = true;
+        if (_running) {
+            return;
+        }
+        if (check_give_up()) {
+            return;
+        }
+        // Set before spawning rather than inside run(), so the single-loop
+        // guarantee does not rest on the coroutine body starting eagerly.
+        _running = true;
+        // Holds the gate for the duration of the loop
+        ssx::spawn_with_gate(_gate, [this] { return run(); });
+    }
+
+    /// notify(), and resolve once an attempt that began after this call has
+    /// succeeded.
+    ///
+    /// Fails with the reason the loop gave up (abort, closed gate).
+    /// A caller which does not care should detach with
+    /// ssx::ignore_shutdown_exceptions.
+    ss::future<> notify_and_wait() {
+        if (!_pending) {
+            _pending.emplace();
+        }
+        auto f = _pending->get_shared_future();
+        notify();
+        return f;
+    }
+
+    bool idle() const { return !_running; }
+
+private:
+    using waiters = std::list<ss::shared_promise<>>;
+
+    bool check_give_up(waiters* covering = nullptr) {
+        if (_gate.is_closed()) {
+            give_up(
+              covering, std::make_exception_ptr(ss::gate_closed_exception{}));
+            return true;
+        }
+        if (aborted()) {
+            give_up(
+              covering,
+              std::make_exception_ptr(ss::abort_requested_exception{}));
+            return true;
+        }
+        return false;
+    }
+
+    void give_up(waiters* covering, const std::exception_ptr& e) {
+        waiters to_fail;
+        if (covering != nullptr) {
+            to_fail.splice(to_fail.end(), *covering);
+        }
+        if (_pending) {
+            to_fail.push_back(std::move(*_pending));
+            _pending.reset();
+        }
+        for (auto& w : to_fail) {
+            w.set_exception(e);
+        }
+    }
+
+    bool aborted() const { return _as.abort_requested(); }
+
+    bool stopping() const { return _gate.is_closed() || aborted(); }
+
+    ss::future<> sleep(std::chrono::milliseconds delay) {
+        return ss::sleep_abortable(delay, _as);
+    }
+
+    ss::future<> run() {
+        auto mark_idle = ss::defer([this]() noexcept { _running = false; });
+
+        auto delay = _backoff.base;
+        // waiters covered by the current attempt
+        waiters covering;
+        while (_dirty && !stopping()) {
+            _dirty = false;
+            if (_pending) {
+                covering.push_back(std::move(*_pending));
+                _pending.reset();
+            }
+            auto f = co_await ss::coroutine::as_future(
+              ss::futurize_invoke(_step));
+            if (!f.failed()) {
+                for (auto& w : covering) {
+                    w.set_value();
+                }
+                covering.clear();
+                delay = _backoff.base;
+                continue;
+            }
+            auto e = f.get_exception();
+            if (ssx::is_shutdown_exception(e)) {
+                give_up(&covering, e);
+                co_return;
+            }
+            vlog(
+              _log.warn,
+              "{}: reconciliation attempt failed: {}; retrying in {}ms",
+              _name,
+              e,
+              delay / 1ms);
+            _dirty = true;
+            auto slept = co_await ss::coroutine::as_future(sleep(delay));
+            if (slept.failed()) {
+                give_up(&covering, slept.get_exception());
+                co_return;
+            }
+            delay = std::min(delay * 2, _backoff.max);
+        }
+        check_give_up(&covering);
+    }
+
+    ss::gate& _gate;
+    ss::logger& _log;
+    ss::sstring _name;
+    reconcile_fn _step;
+    backoff_policy _backoff;
+    ss::abort_source& _as;
+    // Waiters whose notification no attempt has begun to answer yet.
+    std::optional<ss::shared_promise<>> _pending;
+    bool _dirty{false};
+    bool _running{false};
+};
+
+} // namespace ssx

--- a/src/v/ssx/tests/BUILD
+++ b/src/v/ssx/tests/BUILD
@@ -349,6 +349,24 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "reconciler_test",
+    timeout = "short",
+    srcs = [
+        "reconciler_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/base",
+        "//src/v/ssx:future_util",
+        "//src/v/ssx:reconciler",
+        "//src/v/test_utils:async",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "single_fiber_executor_test",
     timeout = "short",
     srcs = [

--- a/src/v/ssx/tests/reconciler_test.cc
+++ b/src/v/ssx/tests/reconciler_test.cc
@@ -1,0 +1,354 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "base/seastarx.h"
+#include "ssx/reconciler.h"
+#include "test_utils/async.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/semaphore.hh>
+#include <seastar/coroutine/as_future.hh>
+#include <seastar/util/later.hh>
+#include <seastar/util/log.hh>
+
+#include <chrono>
+#include <exception>
+#include <stdexcept>
+
+namespace ssx {
+
+using namespace std::chrono_literals;
+
+namespace {
+
+ss::logger test_log("reconciler_test");
+
+/// We want to be able to be more selective than ssx::is_shutdown_exception so
+/// we can distinguish broken_promise from abort_requested.
+template<typename Ex>
+bool failed_with(const ss::future<>& f) {
+    try {
+        std::rethrow_exception(const_cast<ss::future<>&>(f).get_exception());
+    } catch (const Ex&) {
+        return true;
+    } catch (...) {
+    }
+    return false;
+}
+
+/// Runs a step under a gate closed on scope exit, so a test that leaves the
+/// loop mid-retry does not have to unwind it by hand.
+class harness {
+public:
+    explicit harness(reconcile_fn step, backoff_policy backoff = {})
+      : _r(_gate, test_log, "test", std::move(step), _as, backoff) {}
+
+    reconciler& r() { return _r; }
+    ss::abort_source& as() { return _as; }
+
+    ss::future<> stop() {
+        _as.request_abort();
+        return _gate.close();
+    }
+
+    ss::future<> close_gate() { return _gate.close(); }
+
+private:
+    ss::gate _gate;
+    ss::abort_source _as;
+    reconciler _r;
+};
+
+} // namespace
+
+TEST_CORO(Reconciler, does_not_run_until_notified) {
+    int runs = 0;
+    harness h([&runs] {
+        ++runs;
+        return ss::now();
+    });
+    co_await ss::yield();
+    ASSERT_EQ_CORO(runs, 0);
+    ASSERT_TRUE_CORO(h.r().idle());
+    co_await h.stop();
+}
+
+TEST_CORO(Reconciler, notify_and_wait_resolves_after_a_run) {
+    int runs = 0;
+    harness h([&runs] {
+        ++runs;
+        return ss::now();
+    });
+    co_await h.r().notify_and_wait();
+    ASSERT_EQ_CORO(runs, 1);
+    co_await h.stop();
+}
+
+// Notifications arriving while a run is in progress collapse into exactly one
+// further run: not zero (the change would be lost) and not one per notify.
+TEST_CORO(Reconciler, notifies_during_a_run_collapse_into_one) {
+    int runs = 0;
+    ss::promise<> hold;
+    harness h([&runs, &hold] {
+        ++runs;
+        return runs == 1 ? hold.get_future() : ss::now();
+    });
+
+    h.r().notify();
+    co_await ss::yield();
+    ASSERT_EQ_CORO(runs, 1);
+
+    h.r().notify();
+    h.r().notify();
+    h.r().notify();
+    ASSERT_EQ_CORO(runs, 1);
+
+    hold.set_value();
+    co_await tests::cooperative_spin_wait_with_timeout(
+      5s, [&h] { return h.r().idle(); });
+    ASSERT_EQ_CORO(runs, 2);
+    co_await h.stop();
+}
+
+// A run already in flight may have read the state the notification is about, so
+// it cannot be what satisfies the waiter.
+TEST_CORO(Reconciler, a_run_in_flight_does_not_satisfy_a_later_waiter) {
+    int runs = 0;
+    ss::promise<> hold;
+    harness h([&runs, &hold] {
+        ++runs;
+        return runs == 1 ? hold.get_future() : ss::now();
+    });
+
+    h.r().notify();
+    co_await ss::yield();
+    ASSERT_EQ_CORO(runs, 1);
+
+    auto waiter = h.r().notify_and_wait();
+    ASSERT_FALSE_CORO(waiter.available());
+
+    hold.set_value();
+    co_await std::move(waiter);
+    ASSERT_EQ_CORO(runs, 2);
+    co_await h.stop();
+}
+
+// A waiter queued while a run is in flight is folded into the retry of that
+// run, so it is answered by the next attempt rather than waiting for one of its
+// own -- and, above all, is not dropped.
+TEST_CORO(Reconciler, a_waiter_queued_during_a_retry_is_still_answered) {
+    int runs = 0;
+    ss::promise<> hold;
+    harness h(
+      [&runs, &hold] {
+          ++runs;
+          return runs == 1 ? hold.get_future() : ss::now();
+      },
+      backoff_policy{.base = 1ms, .max = 1ms});
+
+    auto first = h.r().notify_and_wait();
+    co_await ss::yield();
+    ASSERT_EQ_CORO(runs, 1);
+
+    // Queued while the first run is still in flight, so the attempt that
+    // answers it is the retry, which begins after the notification.
+    auto second = h.r().notify_and_wait();
+
+    hold.set_exception(std::runtime_error("first attempt fails"));
+    co_await std::move(first);
+    co_await std::move(second);
+    ASSERT_EQ_CORO(runs, 2);
+    co_await h.stop();
+}
+
+// Two waiters answered by consecutive attempts of one loop. Each attempt
+// answers its own batch and no more: the first waiter is answered as its
+// attempt ends, while the second attempt is already in flight and its waiter
+// still pending.
+TEST_CORO(Reconciler, consecutive_attempts_answer_their_own_waiters) {
+    // The step reports each attempt as it begins and then blocks, so the test
+    // can look at the reconciler with an attempt in flight.
+    ss::semaphore begun{0};
+    ss::semaphore finish{0};
+    int attempts = 0;
+    harness h([&begun, &finish, &attempts] {
+        ++attempts;
+        begun.signal(1);
+        return finish.wait(1);
+    });
+
+    auto first = h.r().notify_and_wait();
+    co_await begun.wait(1);
+    ASSERT_FALSE_CORO(first.available());
+
+    // Queued while the first attempt is in flight, so it belongs to the next
+    // one rather than to the attempt about to finish.
+    auto second = h.r().notify_and_wait();
+
+    finish.signal(1);
+    co_await begun.wait(1);
+
+    // The second attempt is now blocked, and the state of the two waiters says
+    // which attempt answered which.
+    ASSERT_TRUE_CORO(first.available());
+    ASSERT_FALSE_CORO(second.available());
+    co_await std::move(first);
+
+    finish.signal(1);
+    co_await std::move(second);
+    ASSERT_EQ_CORO(attempts, 2);
+    co_await h.stop();
+}
+
+TEST_CORO(Reconciler, failures_are_retried_until_success) {
+    int runs = 0;
+    harness h(
+      [&runs] {
+          ++runs;
+          if (runs <= 3) {
+              return ss::make_exception_future<>(std::runtime_error("not yet"));
+          }
+          return ss::now();
+      },
+      backoff_policy{.base = 1ms, .max = 4ms});
+
+    co_await h.r().notify_and_wait();
+    ASSERT_EQ_CORO(runs, 4);
+    co_await h.stop();
+}
+
+// A step that throws before its first suspension point fails the attempt, it
+// does not escape the loop.
+TEST_CORO(Reconciler, a_synchronous_throw_is_a_failed_attempt) {
+    int runs = 0;
+    harness h(
+      [&runs] {
+          ++runs;
+          if (runs == 1) {
+              throw std::runtime_error("thrown before suspending");
+          }
+          return ss::now();
+      },
+      backoff_policy{.base = 1ms, .max = 1ms});
+
+    co_await h.r().notify_and_wait();
+    ASSERT_EQ_CORO(runs, 2);
+    co_await h.stop();
+}
+
+TEST_CORO(Reconciler, a_shutdown_exception_from_the_step_stops_the_loop) {
+    int runs = 0;
+    harness h([&runs] {
+        ++runs;
+        return ss::make_exception_future<>(ss::abort_requested_exception{});
+    });
+
+    auto res = co_await ss::coroutine::as_future(h.r().notify_and_wait());
+    ASSERT_TRUE_CORO(res.failed());
+    ASSERT_TRUE_CORO(failed_with<ss::abort_requested_exception>(res));
+    // The loop gives up before answering the waiter, so it is already gone by
+    // the time this resumes: stopped rather than retried.
+    ASSERT_TRUE_CORO(h.r().idle());
+    ASSERT_EQ_CORO(runs, 1);
+    co_await h.stop();
+}
+
+// An abort has to interrupt the backoff, not merely be noticed once it expires,
+// so the backoff here is far longer than the test is willing to wait for.
+TEST_CORO(Reconciler, an_abort_fails_the_waiter_rather_than_hanging_it) {
+    ss::semaphore attempted{0};
+    harness h(
+      [&attempted] {
+          attempted.signal(1);
+          return ss::make_exception_future<>(
+            std::runtime_error("never succeeds"));
+      },
+      backoff_policy{.base = 10s, .max = 10s});
+
+    auto waiter = h.r().notify_and_wait();
+    // The attempt has run and failed, so the loop is in its backoff.
+    co_await attempted.wait(1);
+
+    const auto start = std::chrono::steady_clock::now();
+    h.as().request_abort();
+    auto res = co_await ss::coroutine::as_future(std::move(waiter));
+    const auto waited = std::chrono::steady_clock::now() - start;
+
+    ASSERT_TRUE_CORO(res.failed());
+    ASSERT_TRUE_CORO(failed_with<ss::abort_requested_exception>(res));
+    ASSERT_LT_CORO(waited, 2s);
+    co_await h.stop();
+}
+
+// Closing the gate has to end a retrying loop, or the close waits on a holder
+// that never leaves -- and the waiter it was carrying has to be told. Unlike an
+// abort, a close cannot interrupt the backoff, so the loop only notices when
+// the sleep expires and the close pays for it: hence the short backoff here.
+TEST_CORO(Reconciler, closing_the_gate_ends_a_retrying_loop) {
+    ss::semaphore attempted{0};
+    harness h(
+      [&attempted] {
+          attempted.signal(1);
+          return ss::make_exception_future<>(
+            std::runtime_error("never succeeds"));
+      },
+      backoff_policy{.base = 20ms, .max = 20ms});
+
+    auto waiter = h.r().notify_and_wait();
+    // The attempt has run and failed, so the loop is retrying.
+    co_await attempted.wait(1);
+
+    co_await h.close_gate();
+    auto res = co_await ss::coroutine::as_future(std::move(waiter));
+    ASSERT_TRUE_CORO(res.failed());
+    ASSERT_TRUE_CORO(failed_with<ss::gate_closed_exception>(res));
+}
+
+TEST_CORO(Reconciler, an_already_aborted_source_fails_the_waiter) {
+    ss::gate gate;
+    ss::abort_source as;
+    as.request_abort();
+
+    int runs = 0;
+    reconciler r(
+      gate,
+      test_log,
+      "test",
+      [&runs] {
+          ++runs;
+          return ss::now();
+      },
+      as);
+
+    auto res = co_await ss::coroutine::as_future(r.notify_and_wait());
+    ASSERT_TRUE_CORO(res.failed());
+    ASSERT_TRUE_CORO(failed_with<ss::abort_requested_exception>(res));
+    ASSERT_EQ_CORO(runs, 0);
+    co_await gate.close();
+}
+
+TEST_CORO(Reconciler, notifying_a_closed_reconciler_fails_the_waiter) {
+    int runs = 0;
+    harness h([&runs] {
+        ++runs;
+        return ss::now();
+    });
+    co_await h.close_gate();
+
+    h.r().notify();
+    auto res = co_await ss::coroutine::as_future(h.r().notify_and_wait());
+    ASSERT_TRUE_CORO(res.failed());
+    ASSERT_TRUE_CORO(failed_with<ss::gate_closed_exception>(res));
+    ASSERT_EQ_CORO(runs, 0);
+}
+
+} // namespace ssx

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -3801,6 +3801,10 @@ void disk_log_impl::set_overrides(ntp_config::default_overrides o) {
     mutable_config().set_overrides(o);
 }
 
+void disk_log_impl::set_partition_storage_mode(model::redpanda_storage_mode m) {
+    mutable_config().set_partition_storage_mode(m);
+}
+
 /**
  * We express compaction backlog as the size of data that has to be read to
  * perform full compaction.

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -171,6 +171,7 @@ public:
     size_t size_bytes() const override { return _probe->partition_size(); }
     uint64_t size_bytes_after_offset(model::offset o) const override;
     void set_overrides(ntp_config::default_overrides) final;
+    void set_partition_storage_mode(model::redpanda_storage_mode) final;
     bool notify_compaction_update() final;
 
     int64_t compaction_backlog() final;

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -226,6 +226,12 @@ public:
     /// topic/partition-level overrides
     virtual void set_overrides(ntp_config::default_overrides) = 0;
 
+    /// Mutates the partition_storage_mode stored in the log's ntp_config: the
+    /// partition's own durable storage mode, fed from partition_properties.
+    /// Abstract rather than defaulted, like set_overrides: a wrapping log that
+    /// silently dropped this would report a stale storage mode from config().
+    virtual void set_partition_storage_mode(model::redpanda_storage_mode) = 0;
+
     /// Notifies the log about a possible change to the log compaction config.
     /// Returns true if the log compaction changed.
     virtual bool notify_compaction_update() = 0;

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -21,6 +21,7 @@
 #include <seastar/core/sstring.hh>
 
 #include <optional>
+#include <stdexcept>
 
 namespace storage {
 using with_cache = ss::bool_class<struct log_cache_tag>;
@@ -247,40 +248,84 @@ public:
                                      : topic_recovery_enabled::no;
     }
 
+    // The storage mode the topic config requests (the "desired" mode). `unset`
+    // for a legacy topic that uses shadow_indexing_mode instead of
+    // storage_mode.
+    model::redpanda_storage_mode topic_storage_mode() const {
+        return _overrides ? _overrides->storage_mode
+                          : model::redpanda_storage_mode::unset;
+    }
+
+    // The partition's own durable storage mode (the "actual" mode), recorded in
+    // partition_properties and pushed in via set_partition_storage_mode().
+    // Falls back to topic_storage_mode() when unset (not yet bootstrapped).
+    // Serving/behavior accessors key on partition_storage_mode rather than
+    // topic_storage_mode. On a storage mode switch that needs migration,
+    // partition_storage_mode is advanced to match topic_storage_mode only once
+    // the migration completes.
+    model::redpanda_storage_mode partition_storage_mode() const {
+        return resolve_partition_storage_mode(_partition_storage_mode);
+    }
+
+    // Resolve a durable partition_storage_mode value the way
+    // partition_storage_mode() does, for asking what a mode would mean before
+    // it is applied.
+    model::redpanda_storage_mode
+    resolve_partition_storage_mode(model::redpanda_storage_mode m) const {
+        return m != model::redpanda_storage_mode::unset ? m
+                                                        : topic_storage_mode();
+    }
+
+    void set_partition_storage_mode(model::redpanda_storage_mode m) {
+        _partition_storage_mode = m;
+    }
+
+    // True while the partition is mid tiered->cloud migration: the topic config
+    // requests a cloud storage mode (topic_storage_mode) but the partition's
+    // durable partition_storage_mode is still tiered.  The partition is served
+    // as tiered until partition_storage_mode is advanced to match.
+    bool is_migrating() const {
+        const auto tm = topic_storage_mode();
+        return (tm == model::redpanda_storage_mode::cloud
+                || tm == model::redpanda_storage_mode::tiered_cloud)
+               && partition_storage_mode()
+                    == model::redpanda_storage_mode::tiered;
+    }
+
     bool is_archival_enabled() const {
-        if (_overrides == nullptr) {
-            return false;
-        }
-        // Explicit tiered
-        if (_overrides->storage_mode == model::redpanda_storage_mode::tiered) {
+        using enum model::redpanda_storage_mode;
+        switch (partition_storage_mode()) {
+        case tiered:
             return true;
-        }
-        // Explicit local or cloud
-        if (_overrides->storage_mode != model::redpanda_storage_mode::unset) {
+        case local:
+        case cloud:
+        case tiered_cloud:
             return false;
+        case unset:
+            // Legacy shadow_indexing topic: no storage mode was ever recorded,
+            // so the shadow_indexing flags are the answer.
+            return _overrides && _overrides->shadow_indexing_mode
+                   && model::is_archival_enabled(
+                     _overrides->shadow_indexing_mode.value());
         }
-        // Unset, fall back to legacy shadow_indexing
-        return _overrides->shadow_indexing_mode
-               && model::is_archival_enabled(
-                 _overrides->shadow_indexing_mode.value());
+        throw std::invalid_argument("unknown redpanda_storage_mode");
     }
 
     bool is_remote_fetch_enabled() const {
-        if (_overrides == nullptr) {
-            return false;
-        }
-        // Explicit tiered
-        if (_overrides->storage_mode == model::redpanda_storage_mode::tiered) {
+        using enum model::redpanda_storage_mode;
+        switch (partition_storage_mode()) {
+        case tiered:
             return true;
-        }
-        // Explicit local or cloud
-        if (_overrides->storage_mode != model::redpanda_storage_mode::unset) {
+        case local:
+        case cloud:
+        case tiered_cloud:
             return false;
+        case unset:
+            return _overrides && _overrides->shadow_indexing_mode
+                   && model::is_fetch_enabled(
+                     _overrides->shadow_indexing_mode.value());
         }
-        // Unset, fall back to legacy shadow_indexing
-        return _overrides->shadow_indexing_mode
-               && model::is_fetch_enabled(
-                 _overrides->shadow_indexing_mode.value());
+        throw std::invalid_argument("unknown redpanda_storage_mode");
     }
 
     bool is_read_replica_mode_enabled() const {
@@ -302,23 +347,23 @@ public:
      * both reads and writes to S3, and is not a read replica.
      */
     bool is_tiered_storage() const {
-        if (_overrides == nullptr) {
+        if (is_read_replica_mode_enabled()) {
             return false;
         }
-        if (_overrides->read_replica.value_or(false)) {
-            return false;
-        }
-        // Explicit tiered
-        if (_overrides->storage_mode == model::redpanda_storage_mode::tiered) {
+        using enum model::redpanda_storage_mode;
+        switch (partition_storage_mode()) {
+        case tiered:
             return true;
-        }
-        // Explicit local or cloud
-        if (_overrides->storage_mode != model::redpanda_storage_mode::unset) {
+        case local:
+        case cloud:
+        case tiered_cloud:
             return false;
+        case unset:
+            return _overrides
+                   && _overrides->shadow_indexing_mode
+                        == model::shadow_indexing_mode::full;
         }
-        // Unset, fall back to legacy shadow_indexing
-        return _overrides->shadow_indexing_mode
-               == model::shadow_indexing_mode::full;
+        throw std::invalid_argument("unknown redpanda_storage_mode");
     }
 
     bool remote_delete() const {
@@ -439,17 +484,14 @@ public:
     }
 
     bool cloud_topic_enabled() const {
-        return _overrides
-               && (_overrides->storage_mode
-                     == model::redpanda_storage_mode::cloud
-                   || _overrides->storage_mode
-                        == model::redpanda_storage_mode::tiered_cloud);
+        const auto mode = partition_storage_mode();
+        return mode == model::redpanda_storage_mode::cloud
+               || mode == model::redpanda_storage_mode::tiered_cloud;
     }
 
     bool is_tiered_cloud() const {
-        return _overrides
-               && _overrides->storage_mode
-                    == model::redpanda_storage_mode::tiered_cloud;
+        return partition_storage_mode()
+               == model::redpanda_storage_mode::tiered_cloud;
     }
 
     std::optional<double> min_cleanable_dirty_ratio() const {
@@ -510,6 +552,13 @@ private:
     /// This revision is used to construct cloud storage paths. It differs from
     /// _topic_revision in case of recovered topics or read replicas.
     model::initial_revision_id _remote_rev{0};
+
+    /// The partition's own durable storage mode, fed from partition_properties
+    /// (see partition_storage_mode()). `unset` until bootstrapped, when the
+    /// mode accessors fall back to the topic-config-derived
+    /// topic_storage_mode().
+    model::redpanda_storage_mode _partition_storage_mode
+      = model::redpanda_storage_mode::unset;
 
 public:
     // in storage/types.cc

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -780,6 +780,20 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "ntp_config_test",
+    timeout = "short",
+    srcs = [
+        "ntp_config_test.cc",
+    ],
+    deps = [
+        "//src/v/model",
+        "//src/v/storage",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "log_retention_test",
     timeout = "short",
     srcs = [

--- a/src/v/storage/tests/ntp_config_test.cc
+++ b/src/v/storage/tests/ntp_config_test.cc
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "model/metadata.h"
+#include "storage/ntp_config.h"
+
+#include <gtest/gtest.h>
+
+// The serving predicates key on partition_storage_mode (the partition's own
+// durable mode), not on topic_storage_mode (what the topic config asks for).
+// Every call site of these predicates is untouched by that split, so pinning
+// the table here is what establishes that a partition mid tiered->cloud
+// migration keeps being served as tiered storage until cutover.
+namespace storage {
+namespace {
+
+using mode = model::redpanda_storage_mode;
+
+ntp_config make_cfg(std::optional<mode> topic_storage_mode) {
+    auto overrides = std::make_unique<ntp_config::default_overrides>();
+    if (topic_storage_mode.has_value()) {
+        overrides->storage_mode = *topic_storage_mode;
+    }
+    return ntp_config{
+      model::ntp{
+        model::kafka_namespace, model::topic{"t"}, model::partition_id{0}},
+      "/tmp/test",
+      std::move(overrides)};
+}
+
+TEST(
+  ntp_config_storage_mode,
+  partition_storage_mode_falls_back_to_topic_storage_mode) {
+    // Until the partition_properties STM records a mode, partition_storage_mode
+    // is `unset` and the accessors read through to the topic config.
+    auto cfg = make_cfg(mode::tiered);
+    EXPECT_EQ(cfg.topic_storage_mode(), mode::tiered);
+    EXPECT_EQ(cfg.partition_storage_mode(), mode::tiered);
+    EXPECT_TRUE(cfg.is_archival_enabled());
+    EXPECT_TRUE(cfg.is_remote_fetch_enabled());
+    EXPECT_FALSE(cfg.cloud_topic_enabled());
+    EXPECT_FALSE(cfg.is_migrating());
+}
+
+TEST(ntp_config_storage_mode, native_cloud_topic) {
+    auto cfg = make_cfg(mode::cloud);
+    cfg.set_partition_storage_mode(mode::cloud);
+    EXPECT_TRUE(cfg.cloud_topic_enabled());
+    EXPECT_FALSE(cfg.is_tiered_cloud());
+    EXPECT_FALSE(cfg.is_archival_enabled());
+    EXPECT_FALSE(cfg.is_remote_fetch_enabled());
+    // Already the requested mode, so there is nothing to migrate.
+    EXPECT_FALSE(cfg.is_migrating());
+}
+
+TEST(ntp_config_storage_mode, migrating_is_served_as_tiered_storage) {
+    // The migration trigger: the topic config asks for cloud while the
+    // partition's durable mode is still tiered. The partition must keep every
+    // tiered-storage behavior -- archival uploads and remote fetch -- and must
+    // NOT be routed to the cloud-topic path.
+    for (auto destination : {mode::cloud, mode::tiered_cloud}) {
+        auto cfg = make_cfg(destination);
+        cfg.set_partition_storage_mode(mode::tiered);
+        EXPECT_EQ(cfg.topic_storage_mode(), destination);
+        EXPECT_EQ(cfg.partition_storage_mode(), mode::tiered);
+        EXPECT_TRUE(cfg.is_migrating());
+        EXPECT_FALSE(cfg.cloud_topic_enabled());
+        EXPECT_TRUE(cfg.is_archival_enabled());
+        EXPECT_TRUE(cfg.is_remote_fetch_enabled());
+    }
+}
+
+TEST(ntp_config_storage_mode, cutover_flips_routing) {
+    // Cutover advances partition_storage_mode to match topic_storage_mode. That
+    // single write is the routing flip: the partition stops being
+    // archival/remote-fetch and becomes a cloud topic, and is no longer
+    // migrating.
+    auto cfg = make_cfg(mode::tiered_cloud);
+    cfg.set_partition_storage_mode(mode::tiered);
+    ASSERT_TRUE(cfg.is_migrating());
+
+    cfg.set_partition_storage_mode(mode::tiered_cloud);
+    EXPECT_FALSE(cfg.is_migrating());
+    EXPECT_TRUE(cfg.cloud_topic_enabled());
+    EXPECT_TRUE(cfg.is_tiered_cloud());
+    EXPECT_FALSE(cfg.is_archival_enabled());
+    EXPECT_FALSE(cfg.is_remote_fetch_enabled());
+}
+
+TEST(ntp_config_storage_mode, unset_falls_back_to_shadow_indexing) {
+    // Legacy topics carry no storage_mode; both modes read `unset` and the
+    // accessors fall back to shadow_indexing_mode. The split must not disturb
+    // this path.
+    auto cfg = make_cfg(std::nullopt);
+    ASSERT_EQ(cfg.topic_storage_mode(), mode::unset);
+    ASSERT_EQ(cfg.partition_storage_mode(), mode::unset);
+    EXPECT_FALSE(cfg.is_migrating());
+    EXPECT_FALSE(cfg.cloud_topic_enabled());
+
+    auto overrides = ntp_config::default_overrides{};
+    overrides.shadow_indexing_mode = model::shadow_indexing_mode::full;
+    cfg.set_overrides(overrides);
+    EXPECT_TRUE(cfg.is_archival_enabled());
+    EXPECT_TRUE(cfg.is_remote_fetch_enabled());
+
+    overrides.shadow_indexing_mode = model::shadow_indexing_mode::disabled;
+    cfg.set_overrides(overrides);
+    EXPECT_FALSE(cfg.is_archival_enabled());
+    EXPECT_FALSE(cfg.is_remote_fetch_enabled());
+}
+
+TEST(
+  ntp_config_storage_mode,
+  resolve_partition_storage_mode_reads_through_unset_only) {
+    auto cfg = make_cfg(mode::tiered);
+
+    // `unset` is the "not yet bootstrapped" sentinel, and the only value that
+    // reads through to the topic config. That read-through is what makes a
+    // partition which has never recorded a mode behave as its topic asks.
+    EXPECT_EQ(cfg.resolve_partition_storage_mode(mode::unset), mode::tiered);
+
+    // Every other value is the partition's own answer and shadows
+    // topic_storage_mode -- what lets a migrating partition stay tiered while
+    // its topic asks for cloud.
+    for (auto m :
+         {mode::local, mode::tiered, mode::cloud, mode::tiered_cloud}) {
+        EXPECT_EQ(cfg.resolve_partition_storage_mode(m), m)
+          << "durable mode " << static_cast<int>(m);
+    }
+
+    // partition_storage_mode() is defined as resolve_partition_storage_mode of
+    // the durable value; callers reason about transitions with the latter, so
+    // they must not diverge.
+    for (auto m :
+         {mode::unset,
+          mode::local,
+          mode::tiered,
+          mode::cloud,
+          mode::tiered_cloud}) {
+        cfg.set_partition_storage_mode(m);
+        EXPECT_EQ(
+          cfg.partition_storage_mode(), cfg.resolve_partition_storage_mode(m))
+          << "durable mode " << static_cast<int>(m);
+    }
+}
+
+TEST(ntp_config_storage_mode, is_archival_enabled_table) {
+    auto cfg = make_cfg(mode::local);
+
+    // Only explicit tiered archives. cloud/tiered_cloud are served by the
+    // cloud-topic path instead, and local does not archive at all.
+    cfg.set_partition_storage_mode(mode::tiered);
+    EXPECT_TRUE(cfg.is_archival_enabled());
+    cfg.set_partition_storage_mode(mode::local);
+    EXPECT_FALSE(cfg.is_archival_enabled());
+    cfg.set_partition_storage_mode(mode::cloud);
+    EXPECT_FALSE(cfg.is_archival_enabled());
+    cfg.set_partition_storage_mode(mode::tiered_cloud);
+    EXPECT_FALSE(cfg.is_archival_enabled());
+}
+
+TEST(ntp_config_storage_mode, is_archival_enabled_legacy_fallback) {
+    // Both modes unset: the legacy shadow_indexing flag is the answer. Driving
+    // this through the real accessor means the durable mode has to be unset
+    // *and* read through to an unset topic mode, which is the only way a
+    // deployed partition reaches the fallback.
+    auto cfg = make_cfg(std::nullopt);
+    cfg.set_partition_storage_mode(mode::unset);
+    EXPECT_FALSE(cfg.is_archival_enabled());
+
+    auto overrides = ntp_config::default_overrides{};
+    overrides.shadow_indexing_mode = model::shadow_indexing_mode::full;
+    cfg.set_overrides(overrides);
+    EXPECT_TRUE(cfg.is_archival_enabled());
+
+    // ...and the fallback must not leak into the explicit modes.
+    cfg.set_partition_storage_mode(mode::local);
+    EXPECT_FALSE(cfg.is_archival_enabled());
+    cfg.set_partition_storage_mode(mode::cloud);
+    EXPECT_FALSE(cfg.is_archival_enabled());
+    cfg.set_partition_storage_mode(mode::tiered);
+    EXPECT_TRUE(cfg.is_archival_enabled());
+}
+
+TEST(ntp_config_storage_mode, cloud_topic_enabled_table) {
+    // The cloud-topic answer is a property of the resolved mode alone -- no
+    // legacy shadow_indexing fallback.
+    auto cfg = make_cfg(mode::local);
+    cfg.set_partition_storage_mode(mode::cloud);
+    EXPECT_TRUE(cfg.cloud_topic_enabled());
+    cfg.set_partition_storage_mode(mode::tiered_cloud);
+    EXPECT_TRUE(cfg.cloud_topic_enabled());
+    cfg.set_partition_storage_mode(mode::local);
+    EXPECT_FALSE(cfg.cloud_topic_enabled());
+    cfg.set_partition_storage_mode(mode::tiered);
+    EXPECT_FALSE(cfg.cloud_topic_enabled());
+}
+
+} // namespace
+} // namespace storage

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -1235,6 +1235,11 @@ PERTURB_ACKNOWLEDGED_FEATURES = frozenset(
         # Iceberg extended-mode topic-config gate; exercising it needs Iceberg
         # topic setup orthogonal to the finalization behavior under test.
         "iceberg_extended_mode_config",
+        # Downgrade-safe by inspection: most of the functionality this gates is
+        # not present yet, so nothing writes the new partition_storage_mode command while
+        # an upgrade is unfinalized. A follow-up PR exercises the gate for real
+        # once the migration trigger lands.
+        "topic_storage_mode_migration",
     }
 )
 
@@ -1417,12 +1422,13 @@ class ManualFinalizationUpgradeTest(UnfinalizedUpgradeMixin, FeaturesTestBase):
         self._exercise_tiered_cloud_topics()
         self._exercise_shadow_link_role_sync()
         self._exercise_fetch_controller_snapshot_rpc()
-        # The other two v26.2-gated features are cluster-linking features that
-        # need a second (source) cluster, so they are acknowledged rather than
-        # exercised here; see PERTURB_ACKNOWLEDGED_FEATURES for why each stays
-        # downgrade-safe (shadow_link_sr_api_sync is covered by
+        # The remaining gated features are acknowledged rather than exercised
+        # here; see PERTURB_ACKNOWLEDGED_FEATURES for why each stays
+        # downgrade-safe. Two are v26.2 cluster-linking features needing a second
+        # (source) cluster (shadow_link_sr_api_sync is covered by
         # ShadowLinkUnfinalizedUpgradeTest; batch_mirror_topic_status is safe by
-        # inspection).
+        # inspection); topic_storage_mode_migration is v26.3-gated and gates nothing
+        # user-visible until the migration trigger lands.
 
     def _exercise_tiered_cloud_topics(self):
         """tiered_cloud_topics gate: creating a topic with the tiered_v2


### PR DESCRIPTION
## Release Notes

### Features

* Adds topic_mode_migration feature.  Enabled automatically, it allows the below
  partition_properties_stm::partition_mode behavior and will eventually enable cloud/tsv2
  migrations.
* A partition's storage mode is now governed by partition_properties_stm::partition_mode.
  It's maintained on leadership change, update_configuration, and on activation of the
  topic_mode_migration feature.

## Summary

Introduces **`partition_mode`**: a partition's own durable storage mode, recorded
in `partition_properties` and decoupled from the topic config, so a migration can
be modelled as `partition_mode` still differing from the topic-config-derived
`topic_mode` until cutover.

This is meant as a foundation for later work to migrate from tiered to cloud/tsv2,
but tsv2<->cloud transitions are also affected.

Commits:

- **`cluster`: carry `partition_mode` in `partition_properties_stm`** — a durable
  per-partition storage mode alongside `writes_disabled`, with a change callback on
  apply and on raft-snapshot restore. Older snapshots decode it as `unset`.
- **`features`: add the `topic_mode_migration` feature** — the flag gating the
  migration capability across the stack. `always`, so it auto-activates at
  `v26_3_1`; whether a migration may be *triggered* is separately gated by config
  in a later PR.
- **`storage`: split `ntp_config` storage mode into `topic_mode` + `partition_mode`**
  — the serving predicates key on the partition's own mode, which falls back to the
  topic's while `unset`, and `is_migrating()` derives the phase from the two. The
  legacy `shadow_indexing` fallback is preserved.
- **`ssx`: add a single-fiber reconciler** — both loops below want the same thing: a
  notify guarantees a run beginning after it, at most one run happens at a time
  however many notifiers there are, failures retry with backoff without the
  notifier waiting, and anyone who does wait is told when it gives up.
- **`cluster/partition`: feed `partition_mode` from `partition_properties` into
  `ntp_config`** — the STM's mode is pushed into the log's config at start and on
  every change. The change callback only notifies a reconciler, since it runs on the
  raft apply fiber and stopping the archiver there deadlocks; the reconciler
  publishes the mode and rebuilds the archiver when that changes whether it should
  exist.
- **`cluster/partition`: sync `partition_mode` with the topic storage mode** — a
  leader writes `topic_mode()` through on gaining leadership and on topic-config
  changes, on a second reconciler. While the two modes agree, `update_configuration`
  acts on archiver-visible config changes itself; while they differ, the change
  rides the replicated mode update instead, which is also what makes it correct off
  the leader.
- **`cluster/partition`: sync `partition_mode` on migration-feature activation** —
  the leadership sync is feature-gated, so on activation sweep the current leaders
  and re-run the idempotent sync, with bounded concurrency because every leader in
  the cluster needs a quorum write at once.

## Note: `partition_mode` initialization

On topic creation, `partition_properties::partition_mode` is initialized by
`sync_partition_mode` when the partition first becomes leader.

## Testing

- `ntp_config_test` (new): pins the predicate table the split produces —
  `partition_mode` unset falling back to `topic_mode`, a native cloud topic, the
  migrating state for both `cloud` and `tiered_cloud` destinations, the cutover
  flip, and the legacy `shadow_indexing` path. The predicates' call sites are
  unchanged by the split, and the only place in `src/v` reading the raw override is
  `topic_table`'s config propagation, so pinning the table is what establishes the
  serving behaviour.
- `reconciler_test` (new): the properties that are easy to break and hard to
  notice. A notify during a run causes exactly one further run; a waiter is never
  answered by a run that began before it, and is answered as its own run ends
  rather than when the loop goes idle; a waiter queued behind a retrying one is
  still answered; a step that throws before its first suspension is a failed
  attempt rather than an exception escaping the loop; and each way of giving up
  (abort, closed gate, shutdown exception from the step) fails the waiter with
  that reason rather than dropping it. The abort case asserts that the abort
  *interrupts* the backoff rather than being noticed once it expires.
- `partition_properties_stm_test`: `partition_mode` default-unset; set /
  idempotent / change with cross-node consistency; independence from
  `writes_disabled` on the shared snapshot; raft-snapshot round-trip at the right
  offsets; recovery (local kvstore snapshot + replay, and raft-snapshot recovery
  after dropping a node's data); and the change callback firing on a real change
  but not on an idempotent no-op.
- The feature-activation sweep is not covered by a unit test: it is a one-shot
  spawned from `partition_manager::start()`, so an in-process fixture reaches it
  only before any partition exists. It is covered by the ducktape suite in PR 8,
  which drives real feature activation.
- `sync_partition_mode` itself is uncovered at the unit level: it needs a
  partition-level fixture (leader + stm + feature table) that does not exist. Its
  retry and single-flight behaviour is the reconciler's, which is tested; the sync
  happy paths ride the PR 8 ducktape suite.
- Full end-to-end coverage rides with the later migration PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[Design Doc](https://docs.google.com/document/d/1HmzBsabpu28Oh8d2PW_HoEQA4rB3Jo1jcj1D3Rsh5mo/edit?usp=sharing)

**PR 0** · [PR 1c](https://github.com/redpanda-data/redpanda/pull/31290) · [PR 1d](https://github.com/redpanda-data/redpanda/pull/31291) · [PR 2](https://github.com/redpanda-data/redpanda/pull/30887) · [PR 3](https://github.com/redpanda-data/redpanda/pull/30891) · [PR 5](https://github.com/redpanda-data/redpanda/pull/30893) · [PR 6](https://github.com/redpanda-data/redpanda/pull/30894) · [PR 7](https://github.com/redpanda-data/redpanda/pull/30895) · [PR 8](https://github.com/redpanda-data/redpanda/pull/30896)



