### PR TITLE
tests: scale coverage for shadow-link role sync

### DIFF
--- a/src/v/cluster/security_manager.cc
+++ b/src/v/cluster/security_manager.cc
@@ -211,11 +211,10 @@ security_manager::fill_snapshot(controller_snapshot& controller_snap) const {
 
     snapshot.acls = co_await _authorizer.local().all_bindings();
 
-    auto roles = _roles.local().range([](const auto&) { return true; });
+    auto roles = co_await _roles.local().all_roles_with_members();
     snapshot.roles.reserve(roles.size());
-    for (const auto& role : roles) {
-        security::role_name name{role};
-        snapshot.roles.emplace_back(name, *_roles.local().get(name));
+    for (auto& rwm : roles) {
+        snapshot.roles.emplace_back(std::move(rwm.name), std::move(rwm.role));
     }
 
     co_return;

--- a/src/v/security/BUILD
+++ b/src/v/security/BUILD
@@ -178,6 +178,7 @@ redpanda_cc_library(
         "//src/v/serde:named_type",
         "//src/v/serde:optional",
         "//src/v/serde:variant",
+        "//src/v/ssx:async_algorithm",
         "//src/v/ssx:future_util",
         "//src/v/ssx:sformat",
         "//src/v/ssx:thread_worker",

--- a/src/v/security/role.cc
+++ b/src/v/security/role.cc
@@ -12,6 +12,9 @@
 
 #include "container/chunked_hash_map.h"
 #include "security/role_store.h"
+#include "ssx/async_algorithm.h"
+
+#include <seastar/core/future.hh>
 
 #include <algorithm>
 #include <ranges>
@@ -119,6 +122,41 @@ chunked_vector<role_with_members> role_store::roles_with_members(
             .role = role{std::move(members)}});
     }
     return result;
+}
+
+ss::future<chunked_vector<role_with_members>>
+role_store::all_roles_with_members() const {
+    // IMPORTANT: intended solely for security_manager::fill_snapshot.
+
+    // One counter spans all three phases so yield accounting is continuous.
+    ssx::async_counter counter;
+
+    chunked_hash_map<role_name_view, role::container_type> by_role;
+    by_role.reserve(_roles.size());
+    co_await ssx::async_for_each_counter(
+      counter, _roles, [&by_role](const role_name& rn) {
+          by_role.try_emplace(role_name_view{rn});
+      });
+
+    for (const auto& [member, role_names] : _members_store) {
+        co_await ssx::async_for_each_counter(
+          counter, role_names, [&by_role, &member](const role_name_view& rn) {
+              if (auto it = by_role.find(rn); it != by_role.end()) {
+                  it->second.insert(member);
+              }
+          });
+    }
+
+    chunked_vector<role_with_members> result;
+    result.reserve(by_role.size());
+    co_await ssx::async_for_each_counter(counter, by_role, [&result](auto& e) {
+        auto& [name_view, members] = e;
+        result.push_back(
+          role_with_members{
+            .name = role_name{ss::sstring{name_view()}},
+            .role = role{std::move(members)}});
+    });
+    co_return result;
 }
 
 } // namespace security

--- a/src/v/security/role_store.h
+++ b/src/v/security/role_store.h
@@ -18,6 +18,7 @@
 #include "security/role.h"
 #include "security/types.h"
 
+#include <seastar/core/future.hh>
 #include <seastar/util/noncopyable_function.hh>
 
 #include <boost/range/iterator_range.hpp>
@@ -144,6 +145,19 @@ public:
     // an empty member set).
     chunked_vector<role_with_members>
     roles_with_members(const std::function<bool(const role_name&)>& pred) const;
+
+    // IMPORTANT: intended solely for security_manager::fill_snapshot. This
+    // suspends mid-iteration, which is safe ONLY while the caller holds
+    // mux_state_machine's _apply_mtx: that mutex serializes against command
+    // application, so _roles/_members_store can't mutate across a yield. A
+    // caller without that lock risks iterating a container that changes
+    // underfoot.
+    //
+    // Like roles_with_members, but enumerates every role with its members in a
+    // single pass and yields periodically, so snapshotting a very large role
+    // store doesn't stall the reactor.
+    ss::future<chunked_vector<role_with_members>>
+    all_roles_with_members() const;
 
     static constexpr auto name_prefix_filter =
       [](const role_accessor& e, std::string_view filter) {

--- a/tests/rptest/tests/rpk_shadow_link_test.py
+++ b/tests/rptest/tests/rpk_shadow_link_test.py
@@ -48,6 +48,7 @@ class RpkShadowLinkTest(ShadowLinkTestBase):
         expected_acl = self._seed_source_acl()
         source_offsets = self._seed_source_consumer_group(topic)
         subject = self._seed_source_schema()
+        expected_role = self._seed_source_role()
 
         assert not self.topic_exists_in_target(topic.name), (
             f"{topic.name} unexpectedly present on the shadow cluster before linking"
@@ -87,6 +88,13 @@ class RpkShadowLinkTest(ShadowLinkTestBase):
             backoff_sec=2,
             retry_on_exc=True,
             err_msg="schema registry subject was not synced to the shadow cluster",
+        )
+        wait_until(
+            lambda: self._role_synced(rpk, expected_role),
+            timeout_sec=90,
+            backoff_sec=2,
+            retry_on_exc=True,
+            err_msg="role was not synced to the shadow cluster",
         )
 
     def _full_link_config(self) -> dict[str, Any]:
@@ -131,6 +139,16 @@ class RpkShadowLinkTest(ShadowLinkTestBase):
             },
             "schema_registry_sync_options": {
                 "shadow_schema_registry_topic": {},
+            },
+            "role_sync_options": {
+                "interval": "1s",
+                "role_name_filters": [
+                    {
+                        "pattern_type": "PREFIX",
+                        "filter_type": "INCLUDE",
+                        "name": "synced-",
+                    }
+                ],
             },
         }
 
@@ -191,6 +209,16 @@ class RpkShadowLinkTest(ShadowLinkTestBase):
         self.source_cluster_rpk.create_schema_from_str(subject, schema)
         return subject
 
+    def _seed_source_role(self) -> dict[str, str]:
+        """Create a role with a member on the source cluster, and return the
+        role name and member principal expected to appear on the shadow
+        cluster. The name matches the link's PREFIX 'synced-' role filter."""
+        role = "synced-test-role"
+        member = "role-member"
+        self.source_cluster_rpk.create_role(role)
+        self.source_cluster_rpk.assign_role(role, [member])
+        return {"role": role, "member": member}
+
     def _assert_link_listed(self, rpk: RpkTool) -> None:
         links = rpk.shadow_list()
         self.logger.debug(f"rpk shadow list: {links}")
@@ -223,6 +251,17 @@ class RpkShadowLinkTest(ShadowLinkTestBase):
         self.logger.debug(f"target subjects: {subjects}")
         names = [s["subject"] if isinstance(s, dict) else s for s in subjects]
         return subject in names
+
+    def _role_synced(self, rpk: RpkTool, expected: dict[str, str]) -> bool:
+        roles = rpk.list_roles().get("roles", [])
+        self.logger.debug(f"target roles: {roles}")
+        if expected["role"] not in roles:
+            return False
+        members = [
+            m["name"] for m in rpk.describe_role(expected["role"]).get("members", [])
+        ]
+        self.logger.debug(f"target role {expected['role']} members: {members}")
+        return expected["member"] in members
 
     def _wait_link_active(self, rpk: RpkTool) -> None:
         def link_active() -> bool:

--- a/tests/rptest/tests/shadow_link_role_sync_test.py
+++ b/tests/rptest/tests/shadow_link_role_sync_test.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import time
 from typing import Callable
 
 from connectrpc.errors import ConnectError, ConnectErrorCode
@@ -14,6 +15,7 @@ from connectrpc.errors import ConnectError, ConnectErrorCode
 import google.protobuf.duration_pb2 as duration_pb2
 import google.protobuf.field_mask_pb2 as field_mask_pb2
 
+from ducktape.mark import parametrize
 from ducktape.tests.test import TestContext
 from ducktape.utils.util import wait_until
 
@@ -547,4 +549,154 @@ class ShadowLinkRoleSyncAuthTest(RoleSyncTestBase):
             timeout_sec=60,
             backoff_sec=1,
             err_msg="role did not mirror after the permission grant",
+        )
+
+
+class ShadowLinkRoleSyncScaleTest(RoleSyncTestBase):
+    """Scale characterization for the roles migrator. Each parametrized point
+    runs the full create -> update -> delete lifecycle (exercising all three
+    migrator apply loops at volume) while pushing one cost axis: role count,
+    total membership, or a single role's member set.
+    """
+
+    PREFIX = "synced-"
+
+    def __init__(self, test_context: TestContext):
+        super().__init__(
+            test_context=test_context,
+            num_brokers=3,
+            secondary_cluster_args=SecondaryClusterArgs(),
+        )
+
+    def setUp(self):
+        super().setUp()
+        self._src = AdminV2RoleWrapper(AdminV2(self.source_cluster_service))
+
+    def _retry_transient(
+        self, fn: Callable[..., object], *args: object, **kwargs: object
+    ) -> None:
+        """Run a source mutation, retrying the transient controller-backpressure
+        errors -- raft not_leader/timeout, surfaced as a ConnectError 'internal'
+        -- that thousands of rapid role mutations can provoke. Other error codes
+        and the final failure propagate."""
+        last: ConnectError | None = None
+        for attempt in range(6):
+            try:
+                fn(*args, **kwargs)
+                return
+            except ConnectError as e:
+                if e.code != ConnectErrorCode.INTERNAL:
+                    raise
+                last = e
+                self.logger.debug(f"retrying transient source mutation: {e}")
+                time.sleep(0.5 * (attempt + 1))
+        assert last is not None
+        raise last
+
+    def _seed_source_roles(self, num_roles: int, members_per_role: int) -> set[str]:
+        """Create num_roles in-scope roles on the source, each with
+        members_per_role distinct user members; return the role names. Members
+        are free-form principal names that need no backing user accounts -- the
+        migrator mirrors them as data."""
+        names: set[str] = set()
+        for i in range(num_roles):
+            name = f"{self.PREFIX}role-{i}"
+            members = [_user(f"u-{i}-{m}") for m in range(members_per_role)]
+            self._retry_transient(self._src.create_role, role=name, members=members)
+            names.add(name)
+        return names
+
+    def _synced_role_names(self) -> set[str]:
+        return {n for n in self._dst.list_role_names() if n.startswith(self.PREFIX)}
+
+    @cluster(num_nodes=6)
+    @parametrize(num_roles=5000, members_per_role=1)
+    @parametrize(num_roles=50, members_per_role=100)
+    @parametrize(num_roles=5, members_per_role=1000)
+    def test_role_sync_at_scale(self, num_roles: int, members_per_role: int) -> None:
+        # create + update + delete each write ~1 controller record per role, on
+        # both the source (seed/modify/delete) and the target (mirror), so each
+        # controller log grows by ~3*num_roles over the lifecycle. Raise the
+        # guard above its 1000 default to admit that while still catching runaway
+        # writes.
+        max_controller_records = 1000 + num_roles * 3
+        self.redpanda.set_expected_controller_records(max_controller_records)
+        self.source_cluster_service.set_expected_controller_records(
+            max_controller_records
+        )
+
+        first = f"{self.PREFIX}role-0"
+        last = f"{self.PREFIX}role-{num_roles - 1}"
+        mirror_timeout_sec = 240
+
+        # CREATE: seed the source, then mirror it to the destination.
+        seed_start = time.time()
+        expected = self._seed_source_roles(num_roles, members_per_role)
+        self.logger.info(
+            f"seeded {num_roles} source roles x {members_per_role} members "
+            f"in {time.time() - seed_start:.1f}s"
+        )
+        create_start = time.time()
+        self._create_link_with_role_sync()
+        wait_until(
+            lambda: self._synced_role_names() >= expected,
+            timeout_sec=mirror_timeout_sec,
+            backoff_sec=2,
+            err_msg=f"{num_roles} roles did not fully mirror within "
+            f"{mirror_timeout_sec}s",
+        )
+        self.logger.info(
+            f"role sync created {num_roles} roles in {time.time() - create_start:.1f}s"
+        )
+        # Membership integrity at the range ends (a full per-role check would add
+        # num_roles RPCs); the first and last seeded roles bound the range.
+        for i in sorted({0, num_roles - 1}):
+            name = f"{self.PREFIX}role-{i}"
+            want = {f"u-{i}-{m}" for m in range(members_per_role)}
+            assert self._dst_role_members(name) == want, (
+                f"membership mismatch for {name} after create"
+            )
+
+        # UPDATE: change every role's membership -- drop one member from each --
+        # so all num_roles roles flow through the update apply loop.
+        update_start = time.time()
+        for i in range(num_roles):
+            self._retry_transient(
+                self._src.remove_role_members,
+                role=f"{self.PREFIX}role-{i}",
+                members=[_user(f"u-{i}-0")],
+            )
+        wait_until(
+            lambda: (
+                "u-0-0" not in self._dst_role_members(first)
+                and f"u-{num_roles - 1}-0" not in self._dst_role_members(last)
+            ),
+            timeout_sec=mirror_timeout_sec,
+            backoff_sec=2,
+            err_msg=f"membership update did not mirror for {num_roles} roles",
+        )
+        self.logger.info(
+            f"role sync updated {num_roles} roles in {time.time() - update_start:.1f}s"
+        )
+
+        # DELETE: drop every source role and confirm the destination is pruned.
+        delete_start = time.time()
+        for name in expected:
+            self._retry_transient(self._src.delete_role, name, delete_acls=False)
+        wait_until(
+            lambda: len(self._synced_role_names()) == 0,
+            timeout_sec=mirror_timeout_sec,
+            backoff_sec=2,
+            err_msg=f"{num_roles} roles were not pruned from the destination",
+        )
+        self.logger.info(
+            f"role sync deleted {num_roles} roles in {time.time() - delete_start:.1f}s"
+        )
+
+        # The full lifecycle ran fault-free -> the task settles ACTIVE.
+        wait_until(
+            lambda: self._roles_task_state() == shadow_link_pb2.TASK_STATE_ACTIVE,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="roles task did not settle ACTIVE after the lifecycle",
         )


### PR DESCRIPTION
Part of ENG-898 (shadowing roles). Adds scale coverage for the role-sync
migrator (CORE-16456), exercising sync against a large role set well beyond
current fleet usage (which tops out around ~200 roles per cluster).

- `tests:` `ShadowLinkRoleSyncScaleTest` drives the migrator through a
  full create/update/delete lifecycle at 5000 total members across three
  cost axes -- many roles (5000x1), wide membership (50x100), and a large
  per-role member set (5x1000) -- asserting the destination mirrors the
  source at each phase and the task settles `ACTIVE`.

Drive-by fix surfaced by the scale test:  `security_manager::fill_snapshot`
previously had a per-role `get()` loop that rescanned the member store 
on every call (quadratic) and could stall the controller reactor under large
role counts. Added `role_store::all_roles_with_members()` to allow it to
snapshot the roles in a single pass over the member store and yields
periodically. This is preventative hardening rather than a reported bug - 
the stall only bites well above today's fleet usage.

Fixes [CORE-16768](https://redpandadata.atlassian.net/browse/CORE-16768)

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none


[CORE-16768]: https://redpandadata.atlassian.net/browse/CORE-16768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ