### PR TITLE
`ct/l1`: downgrade more log levels on shutdown exception

### DIFF
--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -111,8 +111,14 @@ level_one_log_reader_impl::open_reader_at(
       extent, abort_source, _config.group, _config.skip_cache));
     if (stream_fut.failed()) {
         auto ex = stream_fut.get_exception();
-        vlog(
-          _log.error, "Exception opening stream for L1 object {}: {}", oid, ex);
+        auto log_level = ssx::is_shutdown_exception(ex) ? ss::log_level::debug
+                                                        : ss::log_level::error;
+        vlogl(
+          _log,
+          log_level,
+          "Exception opening stream for L1 object {}: {}",
+          oid,
+          ex);
         std::rethrow_exception(ex);
     }
     auto stream_result = stream_fut.get();
@@ -498,7 +504,14 @@ level_one_log_reader_impl::materialize_batches_from_object_offset(
       read_batches(*_current_stream->reader));
     if (read_fut.failed()) {
         auto ex = read_fut.get_exception();
-        vlog(_log.error, "Exception reading L1 object {}: {}", object.oid, ex);
+        auto log_level = ssx::is_shutdown_exception(ex) ? ss::log_level::debug
+                                                        : ss::log_level::error;
+        vlogl(
+          _log,
+          log_level,
+          "Exception reading L1 object {}: {}",
+          object.oid,
+          ex);
         co_await close_current_stream();
         co_await ss::coroutine::return_exception_ptr(std::move(ex));
     }


### PR DESCRIPTION
`ERROR` log lines due to thrown exceptions introduced by streaming reads: https://github.com/redpanda-data/redpanda/pull/30924

These are benign and should be logged as such.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes


* none
