### PR TITLE
`model`: fix `iobuf` over-reservation for null key/value records

### DIFF
--- a/src/v/model/record_utils.cc
+++ b/src/v/model/record_utils.cc
@@ -225,7 +225,9 @@ void append_record_to_buffer(iobuf& a, const model::record& r) {
     append_vint_to_iobuf(a, r.timestamp_delta());
     append_vint_to_iobuf(a, r.offset_delta());
 
-    a.reserve_memory(r.key_size() + r.value_size());
+    auto key_bytes = std::max(r.key_size(), 0);
+    auto val_bytes = std::max(r.value_size(), 0);
+    a.reserve_memory(key_bytes + val_bytes);
     append_vint_to_iobuf(a, r.key_size());
     if (r.key_size() > 0) {
         for (auto& f : r.key()) {


### PR DESCRIPTION
`append_record_to_buffer()` reserved `key_size() + value_size()` bytes before writing a record. For a record whose key and value are both absent those sizes are `-1` each, so the sum `-2` underflows the size_t argument of `iobuf::reserve_memory()` to ~2^64. `reserve_memory()` then allocates 128 KiB fragments for every record (which is eventually trimmed back down to size).

This is especially problematic for cloud topics, since we call:

```
| `encode_placeholder_batch()`
 \-> `builder::add_raw_kv(std::nullopt, std::nullopt)` (for `N` records)
  \-> `builder::add_raw_kw()`
   \-> `model::append_record_to_buffer()`
```

This seems to mean potentially many (tens? hundreds?) of megabytes allocated and freed on the L0 write path for no reason.

Fix the bug by clamping reserved bytes to 0.

From a test, not checked in:

https://gist.github.com/WillemKauf/1090815d4e566165a0fe1e548ed877f2

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Improvements

* Fixes a bug where unnecessary memory allocations/deallocations were being made on the L0 write path in cloud topics
