### PR TITLE
[CORE-16755] Add additional schema registry REST client API endpoints

### DIFF
--- a/src/v/pandaproxy/schema_registry/rest_client/BUILD
+++ b/src/v/pandaproxy/schema_registry/rest_client/BUILD
@@ -8,6 +8,7 @@ redpanda_cc_library(
         "parse.cc",
     ],
     hdrs = [
+        "mode.h",
         "parse.h",
     ],
     implementation_deps = [
@@ -19,6 +20,7 @@ redpanda_cc_library(
         "//src/v/bytes:iobuf",
         "//src/v/container:chunked_vector",
         "//src/v/pandaproxy/schema_registry:types",
+        "//src/v/strings:string_switch",
         "@seastar",
     ],
 )

--- a/src/v/pandaproxy/schema_registry/rest_client/BUILD
+++ b/src/v/pandaproxy/schema_registry/rest_client/BUILD
@@ -8,6 +8,7 @@ redpanda_cc_library(
         "parse.cc",
     ],
     hdrs = [
+        "config.h",
         "mode.h",
         "parse.h",
     ],

--- a/src/v/pandaproxy/schema_registry/rest_client/client.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.cc
@@ -38,6 +38,7 @@ constexpr std::string_view accept_json = "application/json";
 // Schema Registry error_codes for the not-found conditions.
 constexpr int32_t error_code_subject_not_found = 40401;
 constexpr int32_t error_code_version_not_found = 40402;
+constexpr int32_t error_code_schema_id_not_found = 40403;
 constexpr int32_t error_code_subject_config_not_found = 40408;
 constexpr int32_t error_code_subject_mode_not_found = 40409;
 
@@ -151,6 +152,29 @@ domain_error translate_subject_config_not_found(
       status->error_code == error_code_subject_config_not_found
       || status->error_code == error_code_subject_not_found) {
         return domain_error{subject_config_not_found{subject}};
+    }
+    return err;
+}
+
+// Translate a terminal 404 from GET /schemas/ids/{id}/versions into the typed
+// schema_id_not_found: error_code 40403 (the schema-not-found code) means the
+// id does not resolve in the searched context. Unlike the subject/config
+// endpoints this uses only 40403 — a bare 404 (unknown path), other statuses,
+// and non-http errors all pass through unchanged.
+domain_error translate_schema_id_not_found(domain_error err, schema_id id) {
+    auto* call = std::get_if<http_call_error>(&err);
+    if (call == nullptr) {
+        return err;
+    }
+    auto* status = std::get_if<http_status_error>(call);
+    if (status == nullptr) {
+        return err;
+    }
+    if (status->status != boost::beast::http::status::not_found) {
+        return err;
+    }
+    if (status->error_code == error_code_schema_id_not_found) {
+        return domain_error{schema_id_not_found{id}};
     }
     return err;
 }
@@ -547,6 +571,41 @@ client::get_schema_by_version(
           translate_not_found(std::move(response.error()), subject, version));
     }
     auto parsed = co_await parse_subject_version(
+      std::move(response.value()), _qualified);
+    if (!parsed.has_value()) {
+        co_return std::unexpected(domain_error{std::move(parsed.error())});
+    }
+    co_return std::move(parsed.value());
+}
+
+ss::future<std::expected<chunked_vector<subject_version>, domain_error>>
+client::get_schema_id_subject_versions(
+  schema_id id, retry_chain_node& rtc, std::optional<context_subject> subject) {
+    auto gate = maybe_gate();
+    if (!gate.has_value()) {
+        co_return std::unexpected(std::move(gate.error()));
+    }
+    // TODO: deleted/offset/limit are unimplemented. Redpanda's server ignores
+    // them on this endpoint (it always returns the live pairs unpaginated), and
+    // the report notes pagination here is unstable because the result is
+    // unordered.
+    auto request = http::request_builder{}
+                     .method(boost::beast::http::verb::get)
+                     .path(fmt::format("/schemas/ids/{}/versions", id()))
+                     .header("accept", accept_json);
+    if (subject.has_value()) {
+        // Selects the context to resolve the id in. query_param_kv
+        // percent-encodes the value (":" -> "%3A").
+        request.query_param_kv("subject", subject->to_string());
+    }
+    maybe_add_basic_auth(request);
+
+    auto response = co_await perform_request(rtc, std::move(request));
+    if (!response.has_value()) {
+        co_return std::unexpected(
+          translate_schema_id_not_found(std::move(response.error()), id));
+    }
+    auto parsed = co_await parse_schema_id_subject_versions(
       std::move(response.value()), _qualified);
     if (!parsed.has_value()) {
         co_return std::unexpected(domain_error{std::move(parsed.error())});

--- a/src/v/pandaproxy/schema_registry/rest_client/client.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.cc
@@ -272,6 +272,53 @@ client::list_subjects(retry_chain_node& rtc, include_deleted deleted) {
     co_return std::move(parsed.value());
 }
 
+ss::future<std::expected<chunked_vector<context>, domain_error>>
+client::list_contexts(
+  retry_chain_node& rtc, std::optional<ss::sstring> context_prefix) {
+    auto gate = maybe_gate();
+    if (!gate.has_value()) {
+        co_return std::unexpected(std::move(gate.error()));
+    }
+    // TODO: offset/limit pagination is unimplemented (Redpanda SR ignores it
+    // and returns every materialized context in one unpaginated call).
+    auto request = http::request_builder{}
+                     .method(boost::beast::http::verb::get)
+                     .path("/contexts")
+                     .header("accept", accept_json);
+    if (context_prefix.has_value()) {
+        // A source-filtering hint for servers that honor it; the result is also
+        // filtered client-side below, so it is correct against a server that
+        // ignores it (Redpanda's own server does).
+        request.query_param_kv("contextPrefix", *context_prefix);
+    }
+    maybe_add_basic_auth(request);
+
+    auto response = co_await perform_request(rtc, std::move(request));
+    if (!response.has_value()) {
+        co_return std::unexpected(std::move(response.error()));
+    }
+    auto parsed = co_await parse_contexts(std::move(response.value()));
+    if (!parsed.has_value()) {
+        co_return std::unexpected(domain_error{std::move(parsed.error())});
+    }
+    if (context_prefix.has_value()) {
+        // Filter by the returned dot-prefixed name form (e.g. ".prod" matches
+        // ".prod" and ".prod-eu"), matching the server's contextPrefix
+        // semantics, so the result is correct even if the server did not
+        // filter.
+        chunked_vector<context> filtered;
+        for (auto& ctx : parsed.value()) {
+            if (
+              std::string_view{ctx()}.starts_with(
+                std::string_view{*context_prefix})) {
+                filtered.push_back(std::move(ctx));
+            }
+        }
+        co_return std::move(filtered);
+    }
+    co_return std::move(parsed.value());
+}
+
 ss::future<std::expected<chunked_vector<schema_version>, domain_error>>
 client::list_subject_versions(
   const context_subject& subject,

--- a/src/v/pandaproxy/schema_registry/rest_client/client.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.cc
@@ -38,6 +38,7 @@ constexpr std::string_view accept_json = "application/json";
 // Schema Registry error_codes for the not-found conditions.
 constexpr int32_t error_code_subject_not_found = 40401;
 constexpr int32_t error_code_version_not_found = 40402;
+constexpr int32_t error_code_subject_config_not_found = 40408;
 constexpr int32_t error_code_subject_mode_not_found = 40409;
 
 // Percent-encode a subject for use as a single path segment. The qualified wire
@@ -122,6 +123,34 @@ domain_error translate_subject_mode_not_found(
       status->error_code == error_code_subject_mode_not_found
       || status->error_code == error_code_subject_not_found) {
         return domain_error{subject_mode_not_found{subject}};
+    }
+    return err;
+}
+
+// Translate a terminal 404 from GET /config/{subject} into the typed
+// subject_config_not_found: error_code 40408 is the documented "no
+// subject-level compatibility" signal, and some server versions use 40401 for
+// the same case, so both map. Anything else (other statuses, a bare 404 for an
+// unknown path, non-http errors like retries_exhausted) passes through
+// unchanged. Only reachable with default_to_global::no; with yes the effective
+// config always resolves.
+domain_error translate_subject_config_not_found(
+  domain_error err, const context_subject& subject) {
+    auto* call = std::get_if<http_call_error>(&err);
+    if (call == nullptr) {
+        return err;
+    }
+    auto* status = std::get_if<http_status_error>(call);
+    if (status == nullptr) {
+        return err;
+    }
+    if (status->status != boost::beast::http::status::not_found) {
+        return err;
+    }
+    if (
+      status->error_code == error_code_subject_config_not_found
+      || status->error_code == error_code_subject_not_found) {
+        return domain_error{subject_config_not_found{subject}};
     }
     return err;
 }
@@ -426,6 +455,33 @@ client::get_config(retry_chain_node& rtc) {
     auto response = co_await perform_request(rtc, std::move(request));
     if (!response.has_value()) {
         co_return std::unexpected(std::move(response.error()));
+    }
+    auto parsed = co_await parse_config(std::move(response.value()));
+    if (!parsed.has_value()) {
+        co_return std::unexpected(domain_error{std::move(parsed.error())});
+    }
+    co_return std::move(parsed.value());
+}
+
+ss::future<std::expected<config_info, domain_error>> client::get_subject_config(
+  const context_subject& subject,
+  retry_chain_node& rtc,
+  default_to_global fallback) {
+    auto gate = maybe_gate();
+    if (!gate.has_value()) {
+        co_return std::unexpected(std::move(gate.error()));
+    }
+    auto request = http::request_builder{}
+                     .method(boost::beast::http::verb::get)
+                     .path(fmt::format("/config/{}", encode_subject(subject)))
+                     .header("accept", accept_json);
+    add_default_to_global_param(request, fallback);
+    maybe_add_basic_auth(request);
+
+    auto response = co_await perform_request(rtc, std::move(request));
+    if (!response.has_value()) {
+        co_return std::unexpected(translate_subject_config_not_found(
+          std::move(response.error()), subject));
     }
     auto parsed = co_await parse_config(std::move(response.value()));
     if (!parsed.has_value()) {

--- a/src/v/pandaproxy/schema_registry/rest_client/client.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.cc
@@ -38,6 +38,7 @@ constexpr std::string_view accept_json = "application/json";
 // Schema Registry error_codes for the not-found conditions.
 constexpr int32_t error_code_subject_not_found = 40401;
 constexpr int32_t error_code_version_not_found = 40402;
+constexpr int32_t error_code_subject_mode_not_found = 40409;
 
 // Percent-encode a subject for use as a single path segment. The qualified wire
 // form ":.ctx:sub" contains ':' which must be encoded ("%3A"); uri_encode also
@@ -55,6 +56,16 @@ void add_deleted_param(
   http::request_builder& request, include_deleted deleted) {
     if (deleted) {
         request.query_param_kv("deleted", "true");
+    }
+}
+
+// Append ?defaultToGlobal=true to request the effective (hierarchy-resolved)
+// mode instead of the subject's own override. Omitted otherwise, so the default
+// request asks for the subject's own mode (which yields 40409 when unset).
+void add_default_to_global_param(
+  http::request_builder& request, default_to_global fallback) {
+    if (fallback) {
+        request.query_param_kv("defaultToGlobal", "true");
     }
 }
 
@@ -84,6 +95,33 @@ domain_error translate_not_found(
       version.has_value()
       && status->error_code == error_code_version_not_found) {
         return domain_error{version_not_found{subject, *version}};
+    }
+    return err;
+}
+
+// Translate a terminal 404 from GET /mode/{subject} into the typed
+// subject_mode_not_found: error_code 40409 is the documented "no subject-level
+// mode" signal, and some server versions use 40401 for the same case, so both
+// map. Anything else (other statuses, a bare 404 for an unknown path, non-http
+// errors like retries_exhausted) passes through unchanged. Only reachable with
+// default_to_global::no; with yes the effective mode always resolves.
+domain_error translate_subject_mode_not_found(
+  domain_error err, const context_subject& subject) {
+    auto* call = std::get_if<http_call_error>(&err);
+    if (call == nullptr) {
+        return err;
+    }
+    auto* status = std::get_if<http_status_error>(call);
+    if (status == nullptr) {
+        return err;
+    }
+    if (status->status != boost::beast::http::status::not_found) {
+        return err;
+    }
+    if (
+      status->error_code == error_code_subject_mode_not_found
+      || status->error_code == error_code_subject_not_found) {
+        return domain_error{subject_mode_not_found{subject}};
     }
     return err;
 }
@@ -336,6 +374,33 @@ client::get_mode(retry_chain_node& rtc) {
     auto response = co_await perform_request(rtc, std::move(request));
     if (!response.has_value()) {
         co_return std::unexpected(std::move(response.error()));
+    }
+    auto parsed = co_await parse_mode(std::move(response.value()));
+    if (!parsed.has_value()) {
+        co_return std::unexpected(domain_error{std::move(parsed.error())});
+    }
+    co_return std::move(parsed.value());
+}
+
+ss::future<std::expected<mode_info, domain_error>> client::get_subject_mode(
+  const context_subject& subject,
+  retry_chain_node& rtc,
+  default_to_global fallback) {
+    auto gate = maybe_gate();
+    if (!gate.has_value()) {
+        co_return std::unexpected(std::move(gate.error()));
+    }
+    auto request = http::request_builder{}
+                     .method(boost::beast::http::verb::get)
+                     .path(fmt::format("/mode/{}", encode_subject(subject)))
+                     .header("accept", accept_json);
+    add_default_to_global_param(request, fallback);
+    maybe_add_basic_auth(request);
+
+    auto response = co_await perform_request(rtc, std::move(request));
+    if (!response.has_value()) {
+        co_return std::unexpected(translate_subject_mode_not_found(
+          std::move(response.error()), subject));
     }
     auto parsed = co_await parse_mode(std::move(response.value()));
     if (!parsed.has_value()) {

--- a/src/v/pandaproxy/schema_registry/rest_client/client.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.cc
@@ -319,6 +319,31 @@ client::list_contexts(
     co_return std::move(parsed.value());
 }
 
+ss::future<std::expected<mode_info, domain_error>>
+client::get_mode(retry_chain_node& rtc) {
+    auto gate = maybe_gate();
+    if (!gate.has_value()) {
+        co_return std::unexpected(std::move(gate.error()));
+    }
+    // defaultToGlobal is omitted: on the subject-less GET /mode it has no
+    // observable effect (the global mode is returned either way).
+    auto request = http::request_builder{}
+                     .method(boost::beast::http::verb::get)
+                     .path("/mode")
+                     .header("accept", accept_json);
+    maybe_add_basic_auth(request);
+
+    auto response = co_await perform_request(rtc, std::move(request));
+    if (!response.has_value()) {
+        co_return std::unexpected(std::move(response.error()));
+    }
+    auto parsed = co_await parse_mode(std::move(response.value()));
+    if (!parsed.has_value()) {
+        co_return std::unexpected(domain_error{std::move(parsed.error())});
+    }
+    co_return std::move(parsed.value());
+}
+
 ss::future<std::expected<chunked_vector<schema_version>, domain_error>>
 client::list_subject_versions(
   const context_subject& subject,

--- a/src/v/pandaproxy/schema_registry/rest_client/client.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.cc
@@ -409,6 +409,31 @@ ss::future<std::expected<mode_info, domain_error>> client::get_subject_mode(
     co_return std::move(parsed.value());
 }
 
+ss::future<std::expected<config_info, domain_error>>
+client::get_config(retry_chain_node& rtc) {
+    auto gate = maybe_gate();
+    if (!gate.has_value()) {
+        co_return std::unexpected(std::move(gate.error()));
+    }
+    // defaultToGlobal is omitted: on the subject-less GET /config it has no
+    // observable effect (the global config is returned either way).
+    auto request = http::request_builder{}
+                     .method(boost::beast::http::verb::get)
+                     .path("/config")
+                     .header("accept", accept_json);
+    maybe_add_basic_auth(request);
+
+    auto response = co_await perform_request(rtc, std::move(request));
+    if (!response.has_value()) {
+        co_return std::unexpected(std::move(response.error()));
+    }
+    auto parsed = co_await parse_config(std::move(response.value()));
+    if (!parsed.has_value()) {
+        co_return std::unexpected(domain_error{std::move(parsed.error())});
+    }
+    co_return std::move(parsed.value());
+}
+
 ss::future<std::expected<chunked_vector<schema_version>, domain_error>>
 client::list_subject_versions(
   const context_subject& subject,

--- a/src/v/pandaproxy/schema_registry/rest_client/client.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.h
@@ -14,6 +14,7 @@
 #include "bytes/iobuf.h"
 #include "container/chunked_vector.h"
 #include "http/client.h"
+#include "pandaproxy/schema_registry/rest_client/config.h"
 #include "pandaproxy/schema_registry/rest_client/credentials.h"
 #include "pandaproxy/schema_registry/rest_client/error.h"
 #include "pandaproxy/schema_registry/rest_client/mode.h"
@@ -126,6 +127,23 @@ public:
       const context_subject& subject,
       retry_chain_node& rtc,
       default_to_global fallback = default_to_global::no);
+
+    /// GET /config — read the registry-wide (global / default) configuration.
+    /// Like get_mode this always resolves to a value: a registry with no global
+    /// config set reports the built-in default compatibility level (BACKWARD),
+    /// so there is no operation-specific not-found (only a transient 500 /
+    /// error_code 50001 storage failure, handled by the retry policy).
+    ///
+    /// Only the compatibility level is modeled (see config.h): it is an open
+    /// enum, so a value a newer server reports is surfaced as
+    /// registry_compatibility_level::unknown with the verbatim string in
+    /// config_info::raw. Any other top-level config fields present (validation
+    /// flags, metadata, rule sets — which Redpanda's own server does not emit)
+    /// are named in config_info::unknown_fields rather than modeled. The
+    /// `defaultToGlobal` query parameter is omitted: on the subject-less global
+    /// endpoint it has no observable effect.
+    ss::future<std::expected<config_info, domain_error>>
+    get_config(retry_chain_node& rtc);
 
     /// GET /subjects/{subject}/versions — list the version numbers registered
     /// under \p subject. With \p deleted set to yes, soft-deleted versions are

--- a/src/v/pandaproxy/schema_registry/rest_client/client.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.h
@@ -192,6 +192,43 @@ public:
       retry_chain_node& rtc,
       include_deleted deleted = include_deleted::no);
 
+    /// GET /schemas/ids/{id}/versions — list every (subject, version) pair
+    /// backed by the schema with numeric \p id. One schema's content can be
+    /// registered under many subjects; this enumerates all of them within one
+    /// context. An id that does not resolve yields schema_id_not_found (HTTP
+    /// 404 / error_code 40403 — the schema-not-found code, not the 40401/40402
+    /// used elsewhere).
+    ///
+    /// Schema ids are namespaced PER CONTEXT, so \p subject selects the context
+    /// to resolve \p id in; it is sent verbatim as the `subject` query
+    /// parameter. It only LOCATES the schema — it never filters the output: the
+    /// result always lists every subject in the resolved context that shares
+    /// the content, regardless of \p subject. The four forms:
+    ///   - std::nullopt (default): resolve \p id in the DEFAULT context.
+    ///   - a bare context, e.g. context_subject{context{".ctx"}, subject{""}}
+    ///     (wire ":.ctx:"): resolve \p id in ".ctx" whichever subject holds it.
+    ///     The recommended way to target a named context.
+    ///   - a context-qualified subject, e.g. {context{".ctx"}, subject{"s"}}
+    ///     (wire ":.ctx:s"): resolves \p id in ".ctx" ONLY IF "s" carries it,
+    ///     else schema_id_not_found even when \p id exists in ".ctx" under
+    ///     other subjects. Rarely useful.
+    ///   - a plain subject, e.g. context_subject::unqualified("s"): tries the
+    ///     default context, then falls back to searching other contexts for a
+    ///     subject of that name holding \p id. Surprising; avoid.
+    /// Prefer std::nullopt or the bare-context form.
+    ///
+    /// Returned subjects are context-qualified for a non-default context. The
+    /// pairs are UNORDERED (the endpoint does not guarantee an order); sort
+    /// client-side if you need determinism. Soft-deleted pairs are excluded:
+    /// the `deleted`, `offset`, and `limit` query parameters are unimplemented
+    /// because Redpanda's server ignores them here (it always returns the live
+    /// pairs in a single unpaginated response).
+    ss::future<std::expected<chunked_vector<subject_version>, domain_error>>
+    get_schema_id_subject_versions(
+      schema_id id,
+      retry_chain_node& rtc,
+      std::optional<context_subject> subject = std::nullopt);
+
     /// Stops the transport and drains in-flight requests. Must be called before
     /// destroying the client.
     ss::future<> shutdown();

--- a/src/v/pandaproxy/schema_registry/rest_client/client.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.h
@@ -16,6 +16,7 @@
 #include "http/client.h"
 #include "pandaproxy/schema_registry/rest_client/credentials.h"
 #include "pandaproxy/schema_registry/rest_client/error.h"
+#include "pandaproxy/schema_registry/rest_client/mode.h"
 #include "pandaproxy/schema_registry/rest_client/parse.h"
 #include "pandaproxy/schema_registry/rest_client/retry_policy.h"
 #include "pandaproxy/schema_registry/types.h"
@@ -89,6 +90,21 @@ public:
     list_contexts(
       retry_chain_node& rtc,
       std::optional<ss::sstring> context_prefix = std::nullopt);
+
+    /// GET /mode — read the registry-wide (global / default-context) operating
+    /// mode. This endpoint always resolves to a value: a registry that never
+    /// had a global mode set reports READWRITE. There is no operation-specific
+    /// not-found condition (only a transient 500 / error_code 50001 storage
+    /// failure, handled by the retry policy).
+    ///
+    /// The mode is an open enum (see mode.h): the values the Schema Registry
+    /// REST API defines are mapped to registry_mode, and any value a newer
+    /// server reports is surfaced as registry_mode::unknown with the verbatim
+    /// wire string preserved in mode_info::raw, rather than rejected. The
+    /// `defaultToGlobal` query parameter is omitted: on the subject-less global
+    /// endpoint it has no observable effect.
+    ss::future<std::expected<mode_info, domain_error>>
+    get_mode(retry_chain_node& rtc);
 
     /// GET /subjects/{subject}/versions — list the version numbers registered
     /// under \p subject. With \p deleted set to yes, soft-deleted versions are

--- a/src/v/pandaproxy/schema_registry/rest_client/client.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.h
@@ -106,6 +106,27 @@ public:
     ss::future<std::expected<mode_info, domain_error>>
     get_mode(retry_chain_node& rtc);
 
+    /// GET /mode/{subject} — read the mode of a single subject (or a context,
+    /// when \p subject names one). \p fallback selects which of two questions
+    /// is asked:
+    ///   - no (default): the subject's OWN explicitly-set mode. A subject with
+    ///     no override yields subject_mode_not_found (HTTP 404 / error_code
+    ///     40409; a 40401 from some server versions is treated the same). Use
+    ///     this to read back an override or detect its absence.
+    ///   - yes: the EFFECTIVE mode, resolving subject -> context -> global ->
+    ///     built-in default. This always resolves, so subject_mode_not_found
+    ///     cannot occur. Use this for the mode that actually governs the
+    ///     subject.
+    ///
+    /// The result is the same open enum as get_mode (see mode.h). Targeting: a
+    /// plain/qualified subject reads that subject; a context string (":.ctx:")
+    /// reads that context's mode; the explicit default context (":.:") behaves
+    /// like the global get_mode.
+    ss::future<std::expected<mode_info, domain_error>> get_subject_mode(
+      const context_subject& subject,
+      retry_chain_node& rtc,
+      default_to_global fallback = default_to_global::no);
+
     /// GET /subjects/{subject}/versions — list the version numbers registered
     /// under \p subject. With \p deleted set to yes, soft-deleted versions are
     /// included. A missing subject yields subject_not_found.

--- a/src/v/pandaproxy/schema_registry/rest_client/client.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.h
@@ -71,6 +71,25 @@ public:
     list_subjects(
       retry_chain_node& rtc, include_deleted deleted = include_deleted::no);
 
+    /// GET /contexts — list the contexts that currently exist in the registry.
+    /// The default context is always present, returned as the one-character
+    /// context ".". Each element is the bare, dot-prefixed context name (e.g.
+    /// ".dev"); to reuse one as a context-qualified subject prefix elsewhere,
+    /// wrap it in colons (".dev" -> ":.dev:"). There is no operation-specific
+    /// not-found: an empty registry still lists ["."].
+    ///
+    /// When \p context_prefix is set, only contexts whose (dot-prefixed) name
+    /// begins with it are returned — e.g. ".prod" matches ".prod" and
+    /// ".prod-eu", and "." matches every context. The prefix is both sent as
+    /// the `contextPrefix` query parameter (so a server that supports it
+    /// filters at the source) AND applied client-side, so the result is
+    /// correctly filtered even against a server that ignores the parameter
+    /// (Redpanda's own server does). nullopt (the default) applies no filter.
+    ss::future<std::expected<chunked_vector<context>, domain_error>>
+    list_contexts(
+      retry_chain_node& rtc,
+      std::optional<ss::sstring> context_prefix = std::nullopt);
+
     /// GET /subjects/{subject}/versions — list the version numbers registered
     /// under \p subject. With \p deleted set to yes, soft-deleted versions are
     /// included. A missing subject yields subject_not_found.

--- a/src/v/pandaproxy/schema_registry/rest_client/client.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.h
@@ -145,6 +145,28 @@ public:
     ss::future<std::expected<config_info, domain_error>>
     get_config(retry_chain_node& rtc);
 
+    /// GET /config/{subject} — read the configuration of a single subject (or a
+    /// context, when \p subject names one). \p fallback selects which of two
+    /// questions is asked:
+    ///   - no (default): the subject's OWN config. A subject with no
+    ///     override yields subject_config_not_found (HTTP 404 / error_code
+    ///     40408; a 40401 from some server versions is treated the same). Use
+    ///     this to read back an override or detect its absence.
+    ///   - yes: the EFFECTIVE config, resolving subject -> context -> global ->
+    ///     built-in default. This always resolves, so subject_config_not_found
+    ///     cannot occur. Use this for the config that actually governs the
+    ///     subject.
+    ///
+    /// The result is the same config_info as get_config (see config.h).
+    /// Targeting: a plain/qualified subject reads that subject; a context
+    /// string
+    /// (":.ctx:") reads that context's config; the explicit default context
+    /// (":.:") behaves like the global get_config.
+    ss::future<std::expected<config_info, domain_error>> get_subject_config(
+      const context_subject& subject,
+      retry_chain_node& rtc,
+      default_to_global fallback = default_to_global::no);
+
     /// GET /subjects/{subject}/versions — list the version numbers registered
     /// under \p subject. With \p deleted set to yes, soft-deleted versions are
     /// included. A missing subject yields subject_not_found.

--- a/src/v/pandaproxy/schema_registry/rest_client/config.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/config.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "base/format_to.h"
+#include "base/seastarx.h"
+#include "container/chunked_vector.h"
+#include "strings/string_switch.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <string_view>
+
+namespace pandaproxy::schema_registry::rest_client {
+
+/// The registry-wide (global / default) compatibility level reported by
+/// `GET /config`, modeled as an open enum. The Schema Registry REST API defines
+/// the values below; because a newer (or third-party Confluent-compatible)
+/// server may report another, an unrecognized wire value maps to
+/// registry_compatibility_level::unknown rather than being rejected, and the
+/// verbatim string is preserved alongside it in \ref config_info::raw. This is
+/// the open-enum counterpart of Redpanda's closed
+/// schema_registry::compatibility_level.
+enum class registry_compatibility_level {
+    /// NONE — no compatibility checking.
+    none,
+    /// BACKWARD — the built-in default a registry reports when no global
+    /// compatibility is set (operators may configure a different server
+    /// default).
+    backward,
+    /// BACKWARD_TRANSITIVE.
+    backward_transitive,
+    /// FORWARD.
+    forward,
+    /// FORWARD_TRANSITIVE.
+    forward_transitive,
+    /// FULL.
+    full,
+    /// FULL_TRANSITIVE.
+    full_transitive,
+    /// A value this client does not recognize (e.g. one a newer server
+    /// introduced). The original string is retained in \ref config_info::raw.
+    unknown,
+};
+
+constexpr std::string_view to_string_view(registry_compatibility_level c) {
+    switch (c) {
+    case registry_compatibility_level::none:
+        return "NONE";
+    case registry_compatibility_level::backward:
+        return "BACKWARD";
+    case registry_compatibility_level::backward_transitive:
+        return "BACKWARD_TRANSITIVE";
+    case registry_compatibility_level::forward:
+        return "FORWARD";
+    case registry_compatibility_level::forward_transitive:
+        return "FORWARD_TRANSITIVE";
+    case registry_compatibility_level::full:
+        return "FULL";
+    case registry_compatibility_level::full_transitive:
+        return "FULL_TRANSITIVE";
+    case registry_compatibility_level::unknown:
+        return "{unknown}";
+    }
+    return "{invalid}";
+}
+
+inline fmt::iterator
+format_to(registry_compatibility_level c, fmt::iterator out) {
+    return fmt::format_to(out, "{}", to_string_view(c));
+}
+
+/// Map a Schema Registry `compatibilityLevel` wire string to a
+/// registry_compatibility_level. An unrecognized (including empty) string
+/// yields registry_compatibility_level::unknown — the open-enum contract — so
+/// the caller keeps the original value in \ref config_info::raw rather than
+/// losing it.
+constexpr registry_compatibility_level
+registry_compatibility_level_from_wire(std::string_view sv) {
+    using enum registry_compatibility_level;
+    return string_switch<registry_compatibility_level>(sv)
+      .match(to_string_view(none), none)
+      .match(to_string_view(backward), backward)
+      .match(to_string_view(backward_transitive), backward_transitive)
+      .match(to_string_view(forward), forward)
+      .match(to_string_view(forward_transitive), forward_transitive)
+      .match(to_string_view(full), full)
+      .match(to_string_view(full_transitive), full_transitive)
+      .default_match(unknown);
+}
+
+/// The result of `GET /config`: the registry's global configuration.
+///
+/// Only `compatibilityLevel` is modeled — as an open enum in \ref level, with
+/// the verbatim wire string kept in \ref raw so a value mapped to unknown is
+/// not lost. The endpoint may carry many other optional fields (validation
+/// flags, metadata, rule sets) that this client does not model; the names of
+/// any such top-level fields present are recorded in \ref unknown_fields, so a
+/// caller can tell config content was dropped without this client having to
+/// model it (mirroring parsed_schema::unknown_fields). Redpanda's own server
+/// emits only `compatibilityLevel`, so unknown_fields is empty against it; a
+/// third-party Confluent-compatible registry may populate it.
+struct config_info {
+    registry_compatibility_level level;
+    ss::sstring raw;
+    chunked_vector<ss::sstring> unknown_fields;
+};
+
+} // namespace pandaproxy::schema_registry::rest_client

--- a/src/v/pandaproxy/schema_registry/rest_client/error.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/error.h
@@ -145,6 +145,19 @@ struct subject_mode_not_found {
     }
 };
 
+// The subject (or context) has no explicitly-configured compatibility config
+// (HTTP 404 / error_code 40408; some server versions instead use 40401, which
+// this client treats the same). Only produced by get_subject_config with
+// default_to_global::no; with yes the effective config always resolves, so
+// this never occurs.
+struct subject_config_not_found {
+    context_subject subject;
+
+    fmt::iterator format_to(fmt::iterator it) const {
+        return fmt::format_to(it, "subject config not configured: {}", subject);
+    }
+};
+
 // Represents the sum of all error types which can be encountered during
 // rest-client operations. The JSON-decode arm reuses parse_error from parse.h.
 using domain_error = std::variant<
@@ -155,6 +168,7 @@ using domain_error = std::variant<
   subject_not_found,
   version_not_found,
   subject_mode_not_found,
+  subject_config_not_found,
   aborted_error>;
 
 } // namespace pandaproxy::schema_registry::rest_client
@@ -208,6 +222,9 @@ struct fmt::formatter<pandaproxy::schema_registry::rest_client::domain_error>
               return fmt::format_to(ctx.out(), "{}", value);
           },
           [&](const rc::subject_mode_not_found& value) {
+              return fmt::format_to(ctx.out(), "{}", value);
+          },
+          [&](const rc::subject_config_not_found& value) {
               return fmt::format_to(ctx.out(), "{}", value);
           },
           [&](const rc::aborted_error& value) {

--- a/src/v/pandaproxy/schema_registry/rest_client/error.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/error.h
@@ -158,6 +158,19 @@ struct subject_config_not_found {
     }
 };
 
+// The numeric schema id does not resolve in the searched context
+// (HTTP 404 / error_code 40403 — the schema-not-found code, distinct from the
+// 40401/40402 the subject/version endpoints use). Often this just means the
+// wrong context was targeted via get_schema_id_subject_versions' subject
+// parameter.
+struct schema_id_not_found {
+    schema_id id;
+
+    fmt::iterator format_to(fmt::iterator it) const {
+        return fmt::format_to(it, "schema id not found: {}", id());
+    }
+};
+
 // Represents the sum of all error types which can be encountered during
 // rest-client operations. The JSON-decode arm reuses parse_error from parse.h.
 using domain_error = std::variant<
@@ -169,6 +182,7 @@ using domain_error = std::variant<
   version_not_found,
   subject_mode_not_found,
   subject_config_not_found,
+  schema_id_not_found,
   aborted_error>;
 
 } // namespace pandaproxy::schema_registry::rest_client
@@ -225,6 +239,9 @@ struct fmt::formatter<pandaproxy::schema_registry::rest_client::domain_error>
               return fmt::format_to(ctx.out(), "{}", value);
           },
           [&](const rc::subject_config_not_found& value) {
+              return fmt::format_to(ctx.out(), "{}", value);
+          },
+          [&](const rc::schema_id_not_found& value) {
               return fmt::format_to(ctx.out(), "{}", value);
           },
           [&](const rc::aborted_error& value) {

--- a/src/v/pandaproxy/schema_registry/rest_client/error.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/error.h
@@ -132,6 +132,19 @@ struct version_not_found {
     }
 };
 
+// The subject (or context) has no explicitly-configured mode
+// (HTTP 404 / error_code 40409; some server versions instead use 40401, which
+// this client treats the same). Only produced by get_subject_mode with
+// default_to_global::no; with yes the effective mode always resolves, so this
+// never occurs.
+struct subject_mode_not_found {
+    context_subject subject;
+
+    fmt::iterator format_to(fmt::iterator it) const {
+        return fmt::format_to(it, "subject mode not configured: {}", subject);
+    }
+};
+
 // Represents the sum of all error types which can be encountered during
 // rest-client operations. The JSON-decode arm reuses parse_error from parse.h.
 using domain_error = std::variant<
@@ -141,6 +154,7 @@ using domain_error = std::variant<
   retries_exhausted,
   subject_not_found,
   version_not_found,
+  subject_mode_not_found,
   aborted_error>;
 
 } // namespace pandaproxy::schema_registry::rest_client
@@ -191,6 +205,9 @@ struct fmt::formatter<pandaproxy::schema_registry::rest_client::domain_error>
               return fmt::format_to(ctx.out(), "{}", value);
           },
           [&](const rc::version_not_found& value) {
+              return fmt::format_to(ctx.out(), "{}", value);
+          },
+          [&](const rc::subject_mode_not_found& value) {
               return fmt::format_to(ctx.out(), "{}", value);
           },
           [&](const rc::aborted_error& value) {

--- a/src/v/pandaproxy/schema_registry/rest_client/mode.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/mode.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "base/format_to.h"
+#include "base/seastarx.h"
+#include "strings/string_switch.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <string_view>
+
+namespace pandaproxy::schema_registry::rest_client {
+
+/// The registry-wide (global / default-context) operating mode reported by
+/// `GET /mode`, modeled as an open enum. The Schema Registry REST API defines
+/// the values below; because a newer (or third-party Confluent-compatible)
+/// server may report another, an unrecognized wire value maps to
+/// \ref registry_mode::unknown rather than being rejected, and the verbatim
+/// string is preserved alongside it in \ref mode_info::raw. Note this is a
+/// superset of Redpanda's own three-valued \ref schema_registry::mode:
+/// READONLY_OVERRIDE and FORWARD are values a client must recognize on the wire
+/// even though this node's server never emits them.
+enum class registry_mode {
+    /// READWRITE — normal operation; reads and writes (registration) allowed.
+    /// The built-in default a registry reports when no global mode was set.
+    read_write,
+    /// READONLY — writes rejected, reads allowed.
+    read_only,
+    /// READONLY_OVERRIDE — a read-only variant. Deprecated in favor of READONLY
+    /// on the global context, but still recognized on the wire.
+    read_only_override,
+    /// IMPORT — bulk-import mode (schemas registered with explicit IDs and
+    /// versions).
+    import,
+    /// FORWARD — forwarding mode; only ever valid at the global level.
+    forward,
+    /// A value this client does not recognize (e.g. one a newer server
+    /// introduced). The original string is retained in \ref mode_info::raw.
+    unknown,
+};
+
+constexpr std::string_view to_string_view(registry_mode m) {
+    switch (m) {
+    case registry_mode::read_write:
+        return "READWRITE";
+    case registry_mode::read_only:
+        return "READONLY";
+    case registry_mode::read_only_override:
+        return "READONLY_OVERRIDE";
+    case registry_mode::import:
+        return "IMPORT";
+    case registry_mode::forward:
+        return "FORWARD";
+    case registry_mode::unknown:
+        return "{unknown}";
+    }
+    return "{invalid}";
+}
+
+inline fmt::iterator format_to(registry_mode m, fmt::iterator out) {
+    return fmt::format_to(out, "{}", to_string_view(m));
+}
+
+/// Map a Schema Registry `mode` wire string to a \ref registry_mode. An
+/// unrecognized (including empty) string yields registry_mode::unknown — the
+/// open-enum contract — so the caller keeps the original value in
+/// \ref mode_info::raw rather than losing it. READONLY_OVERRIDE is deprecated
+/// but still mapped.
+constexpr registry_mode registry_mode_from_wire(std::string_view sv) {
+    return string_switch<registry_mode>(sv)
+      .match(
+        to_string_view(registry_mode::read_write), registry_mode::read_write)
+      .match(to_string_view(registry_mode::read_only), registry_mode::read_only)
+      .match(
+        to_string_view(registry_mode::read_only_override),
+        registry_mode::read_only_override)
+      .match(to_string_view(registry_mode::import), registry_mode::import)
+      .match(to_string_view(registry_mode::forward), registry_mode::forward)
+      .default_match(registry_mode::unknown);
+}
+
+/// The result of `GET /mode`: the registry's global operating mode. The
+/// verbatim wire string is retained in \ref raw so a value mapped to
+/// registry_mode::unknown (e.g. a mode a newer server introduced) is not lost;
+/// \ref raw carries the same string for recognized values too.
+struct mode_info {
+    registry_mode mode;
+    ss::sstring raw;
+};
+
+} // namespace pandaproxy::schema_registry::rest_client

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.cc
@@ -143,6 +143,73 @@ parse_contexts(iobuf body) {
     }
 }
 
+ss::future<std::expected<mode_info, parse_error>> parse_mode(iobuf body) {
+    using token = serde::json::token;
+    // Firewall exceptions from the parser: malformed input is reported via the
+    // returned std::expected, not thrown.
+    try {
+        serde::json::parser p(std::move(body));
+
+        if (!co_await p.next() || p.token() != token::start_object) {
+            co_return std::unexpected(
+              parse_error{.reason = "expected a JSON object"});
+        }
+
+        std::optional<mode_info> result;
+        while (co_await p.next()) {
+            if (p.token() == token::end_object) {
+                // The body is exactly one JSON object: reject any trailing
+                // content rather than ignoring it.
+                co_await p.next();
+                if (p.token() != token::eof) {
+                    co_return std::unexpected(
+                      parse_error{
+                        .reason = "trailing content after mode object"});
+                }
+                if (!result.has_value()) {
+                    // `mode` is the one field a successful response must carry.
+                    co_return std::unexpected(
+                      parse_error{.reason = "missing mode field"});
+                }
+                co_return std::move(*result);
+            }
+            if (p.token() != token::key) {
+                co_return std::unexpected(
+                  parse_error{.reason = "expected an object key"});
+            }
+            auto key = p.value_string().linearize_to_string();
+            if (!co_await p.next()) {
+                co_return std::unexpected(
+                  parse_error{.reason = "truncated JSON after key"});
+            }
+            if (key == "mode") {
+                if (p.token() != token::value_string) {
+                    co_return std::unexpected(
+                      parse_error{.reason = "mode must be a string"});
+                }
+                // Shape is strict but the value is open: map the recognized
+                // wire strings and keep the verbatim value, so an unrecognized
+                // (open-enum) mode is preserved rather than rejected.
+                auto raw = p.value_string().linearize_to_string();
+                result = mode_info{
+                  .mode = registry_mode_from_wire(raw), .raw = std::move(raw)};
+            } else {
+                // Ignore any other field: the server omits null/empty fields
+                // and a client must not assume any field beyond `mode`.
+                co_await p.skip_value();
+            }
+        }
+
+        // next() returned false before the closing '}'.
+        co_return std::unexpected(
+          parse_error{.reason = "truncated or malformed JSON"});
+    } catch (const std::exception& e) {
+        co_return std::unexpected(
+          parse_error{
+            .reason = ssx::sformat("failed to parse mode: {}", e.what())});
+    }
+}
+
 ss::future<std::expected<chunked_vector<schema_version>, parse_error>>
 parse_subject_versions(iobuf body) {
     using token = serde::json::token;

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.cc
@@ -385,6 +385,13 @@ parse_schema_id_subject_versions(
             std::optional<context_subject> sub;
             std::optional<schema_version> version;
             while (co_await p.next() && p.token() != token::end_object) {
+                // Shape is strict: reject a non-key token explicitly rather
+                // than letting value_string() throw and rely on the catch
+                // below.
+                if (p.token() != token::key) {
+                    co_return std::unexpected(
+                      parse_error{.reason = "expected an object key"});
+                }
                 auto key = p.value_string().linearize_to_string();
                 if (!co_await p.next()) {
                     co_return std::unexpected(
@@ -429,7 +436,7 @@ parse_schema_id_subject_versions(
         co_return std::unexpected(
           parse_error{
             .reason = ssx::sformat(
-              "failed to parse subject-versions: {}", e.what())});
+              "failed to parse schema-id subject-versions: {}", e.what())});
     }
 }
 
@@ -455,6 +462,12 @@ parse_references(serde::json::parser& p, qualified_subjects_enabled qualified) {
         std::optional<context_subject_reference> sub;
         std::optional<schema_version> version;
         while (co_await p.next() && p.token() != token::end_object) {
+            // Shape is strict: reject a non-key token explicitly rather than
+            // letting value_string() throw and rely on the catch in the caller.
+            if (p.token() != token::key) {
+                co_return std::unexpected(
+                  parse_error{.reason = "expected an object key"});
+            }
             auto key = p.value_string().linearize_to_string();
             if (!co_await p.next()) {
                 co_return std::unexpected(

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.cc
@@ -210,6 +210,81 @@ ss::future<std::expected<mode_info, parse_error>> parse_mode(iobuf body) {
     }
 }
 
+ss::future<std::expected<config_info, parse_error>> parse_config(iobuf body) {
+    using token = serde::json::token;
+    // Firewall exceptions from the parser: malformed input is reported via the
+    // returned std::expected, not thrown.
+    try {
+        serde::json::parser p(std::move(body));
+
+        if (!co_await p.next() || p.token() != token::start_object) {
+            co_return std::unexpected(
+              parse_error{.reason = "expected a JSON object"});
+        }
+
+        std::optional<registry_compatibility_level> level;
+        ss::sstring raw;
+        chunked_vector<ss::sstring> unknown_fields;
+        while (co_await p.next()) {
+            if (p.token() == token::end_object) {
+                // The body is exactly one JSON object: reject any trailing
+                // content rather than ignoring it.
+                co_await p.next();
+                if (p.token() != token::eof) {
+                    co_return std::unexpected(
+                      parse_error{
+                        .reason = "trailing content after config object"});
+                }
+                if (!level.has_value()) {
+                    // compatibilityLevel is the one field a config response is
+                    // documented to always carry.
+                    co_return std::unexpected(
+                      parse_error{
+                        .reason = "missing compatibilityLevel field"});
+                }
+                co_return config_info{
+                  .level = *level,
+                  .raw = std::move(raw),
+                  .unknown_fields = std::move(unknown_fields)};
+            }
+            if (p.token() != token::key) {
+                co_return std::unexpected(
+                  parse_error{.reason = "expected an object key"});
+            }
+            auto key = p.value_string().linearize_to_string();
+            if (!co_await p.next()) {
+                co_return std::unexpected(
+                  parse_error{.reason = "truncated JSON after key"});
+            }
+            if (key == "compatibilityLevel") {
+                if (p.token() != token::value_string) {
+                    co_return std::unexpected(
+                      parse_error{
+                        .reason = "compatibilityLevel must be a string"});
+                }
+                // Shape is strict but the value is open: map the recognized
+                // wire strings and keep the verbatim value, so an unrecognized
+                // (open-enum) level is preserved rather than rejected.
+                raw = p.value_string().linearize_to_string();
+                level = registry_compatibility_level_from_wire(raw);
+            } else {
+                // Any other top-level field is unmodeled: record its name so a
+                // caller can tell config was dropped, then skip its value.
+                unknown_fields.push_back(std::move(key));
+                co_await p.skip_value();
+            }
+        }
+
+        // next() returned false before the closing '}'.
+        co_return std::unexpected(
+          parse_error{.reason = "truncated or malformed JSON"});
+    } catch (const std::exception& e) {
+        co_return std::unexpected(
+          parse_error{
+            .reason = ssx::sformat("failed to parse config: {}", e.what())});
+    }
+}
+
 ss::future<std::expected<chunked_vector<schema_version>, parse_error>>
 parse_subject_versions(iobuf body) {
     using token = serde::json::token;

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.cc
@@ -347,6 +347,92 @@ parse_subject_versions(iobuf body) {
     }
 }
 
+ss::future<std::expected<chunked_vector<subject_version>, parse_error>>
+parse_schema_id_subject_versions(
+  iobuf body, qualified_subjects_enabled qualified) {
+    using token = serde::json::token;
+    // Firewall exceptions from the parser: malformed input is reported via the
+    // returned std::expected, not thrown.
+    try {
+        serde::json::parser p(std::move(body));
+
+        if (!co_await p.next() || p.token() != token::start_array) {
+            co_return std::unexpected(
+              parse_error{
+                .reason = "expected a JSON array of subject-version objects"});
+        }
+
+        chunked_vector<subject_version> result;
+        while (co_await p.next()) {
+            if (p.token() == token::end_array) {
+                // The body is exactly a JSON array: reject any trailing content
+                // rather than ignoring it.
+                co_await p.next();
+                if (p.token() != token::eof) {
+                    co_return std::unexpected(
+                      parse_error{
+                        .reason
+                        = "trailing content after subject-versions array"});
+                }
+                co_return std::move(result);
+            }
+            if (p.token() != token::start_object) {
+                co_return std::unexpected(
+                  parse_error{.reason = "expected a subject-version object"});
+            }
+            // Each element is a {subject, version} object. Unknown keys are
+            // tolerated and skipped, but both modeled fields must be present.
+            std::optional<context_subject> sub;
+            std::optional<schema_version> version;
+            while (co_await p.next() && p.token() != token::end_object) {
+                auto key = p.value_string().linearize_to_string();
+                if (!co_await p.next()) {
+                    co_return std::unexpected(
+                      parse_error{
+                        .reason = "truncated JSON in subject-version object"});
+                }
+                if (key == "subject") {
+                    if (p.token() != token::value_string) {
+                        co_return std::unexpected(
+                          parse_error{.reason = "subject must be a string"});
+                    }
+                    sub = context_subject::from_string(
+                      p.value_string().linearize_to_string(), qualified);
+                } else if (key == "version") {
+                    if (p.token() != token::value_int) {
+                        co_return std::unexpected(
+                          parse_error{.reason = "version must be an integer"});
+                    }
+                    auto v = checked_positive_i32(p.value_int());
+                    if (!v) {
+                        co_return std::unexpected(
+                          parse_error{.reason = "version number out of range"});
+                    }
+                    version = schema_version{*v};
+                } else {
+                    co_await p.skip_value();
+                }
+            }
+            if (!sub.has_value() || !version.has_value()) {
+                co_return std::unexpected(
+                  parse_error{
+                    .reason
+                    = "subject-version object missing subject or version"});
+            }
+            result.emplace_back(std::move(*sub), *version);
+        }
+
+        // next() returned false before the closing ']' was seen.
+        co_return std::unexpected(
+          parse_error{.reason = "truncated or malformed JSON"});
+    } catch (const std::exception& e) {
+        co_return std::unexpected(
+          parse_error{
+            .reason = ssx::sformat(
+              "failed to parse subject-versions: {}", e.what())});
+    }
+}
+
 namespace {
 
 // Parse a JSON array of {name, subject, version} reference objects. Entered

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.cc
@@ -93,6 +93,56 @@ parse_subjects(iobuf body, qualified_subjects_enabled qualified) {
     }
 }
 
+ss::future<std::expected<chunked_vector<context>, parse_error>>
+parse_contexts(iobuf body) {
+    using token = serde::json::token;
+    // Firewall exceptions from the parser: malformed input is reported via the
+    // returned std::expected, not thrown.
+    try {
+        serde::json::parser p(std::move(body));
+
+        if (!co_await p.next() || p.token() != token::start_array) {
+            co_return std::unexpected(
+              parse_error{.reason = "expected a JSON array of contexts"});
+        }
+
+        chunked_vector<context> contexts;
+        while (co_await p.next()) {
+            switch (p.token()) {
+            case token::end_array:
+                // The body is exactly a JSON array of strings: reject any
+                // trailing content rather than ignoring it.
+                co_await p.next();
+                if (p.token() != token::eof) {
+                    co_return std::unexpected(
+                      parse_error{
+                        .reason = "trailing content after contexts array"});
+                }
+                co_return std::move(contexts);
+            case token::value_string:
+                // Each element is a bare, dot-prefixed context name (".",
+                // ".dev") and is wrapped verbatim. Unlike a subject, a context
+                // has no ":.ctx:" qualified form to decode here.
+                contexts.push_back(
+                  context{p.value_string().linearize_to_string()});
+                break;
+            default:
+                co_return std::unexpected(
+                  parse_error{
+                    .reason = "expected a string element in contexts array"});
+            }
+        }
+
+        // next() returned false before the closing ']' was seen.
+        co_return std::unexpected(
+          parse_error{.reason = "truncated or malformed JSON"});
+    } catch (const std::exception& e) {
+        co_return std::unexpected(
+          parse_error{
+            .reason = ssx::sformat("failed to parse contexts: {}", e.what())});
+    }
+}
+
 ss::future<std::expected<chunked_vector<schema_version>, parse_error>>
 parse_subject_versions(iobuf body) {
     using token = serde::json::token;

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.h
@@ -13,6 +13,7 @@
 #include "base/seastarx.h"
 #include "bytes/iobuf.h"
 #include "container/chunked_vector.h"
+#include "pandaproxy/schema_registry/rest_client/config.h"
 #include "pandaproxy/schema_registry/rest_client/mode.h"
 #include "pandaproxy/schema_registry/types.h"
 
@@ -79,6 +80,21 @@ parse_contexts(iobuf body);
 /// beyond `mode`. The function does not throw: malformed input is reported via
 /// the returned std::expected.
 ss::future<std::expected<mode_info, parse_error>> parse_mode(iobuf body);
+
+/// Parse the body of a `GET /config` response into a config_info.
+///
+/// The body is a JSON object. Only `compatibilityLevel` (a string) is modeled,
+/// as an open enum (see config.h) with the verbatim wire string kept in
+/// config_info::raw. Every other top-level field is unmodeled: its name is
+/// recorded in config_info::unknown_fields and its value skipped, so a caller
+/// can tell config content was dropped without this client modeling the rich
+/// object. As with parse_mode the shape is strict — a non-object body, a
+/// missing or non-string `compatibilityLevel`, or trailing content after the
+/// object yields a parse_error — while the compatibilityLevel value is open: an
+/// unrecognized string maps to registry_compatibility_level::unknown rather
+/// than being rejected. The function does not throw: malformed input is
+/// reported via the returned std::expected.
+ss::future<std::expected<config_info, parse_error>> parse_config(iobuf body);
 
 /// Parse the body of a `GET /subjects/{subject}/versions` response into a list
 /// of versions.

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.h
@@ -112,6 +112,24 @@ ss::future<std::expected<config_info, parse_error>> parse_config(iobuf body);
 ss::future<std::expected<chunked_vector<schema_version>, parse_error>>
 parse_subject_versions(iobuf body);
 
+/// Parse the body of a `GET /schemas/ids/{id}/versions` response into a list of
+/// (subject, version) pairs.
+///
+/// The body must be a JSON array of objects, each with a `subject` string and a
+/// `version` integer in [1, INT32_MAX] (e.g. `[{"subject":"s","version":1}]`).
+/// Each subject is decoded with context_subject::from_string under \p qualified
+/// (a non-default context comes back context-qualified, e.g. ":.ctx:s"), just
+/// like parse_subjects. Unknown keys within an object are tolerated and
+/// skipped, but both `subject` and `version` must be present; a non-array, a
+/// non-object element, a wrong-typed or out-of-range field, a missing field, or
+/// trailing content after the array yields a parse_error. The result order
+/// follows the wire order, which the Schema Registry does not guarantee for
+/// this endpoint. The function does not throw: malformed input is reported via
+/// the returned std::expected.
+ss::future<std::expected<chunked_vector<subject_version>, parse_error>>
+parse_schema_id_subject_versions(
+  iobuf body, qualified_subjects_enabled qualified);
+
 /// The outcome of parsing a get-schema-by-version response: the schema, plus
 /// the names of any top-level response fields the parser did not model.
 ///

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.h
@@ -13,6 +13,7 @@
 #include "base/seastarx.h"
 #include "bytes/iobuf.h"
 #include "container/chunked_vector.h"
+#include "pandaproxy/schema_registry/rest_client/mode.h"
 #include "pandaproxy/schema_registry/types.h"
 
 #include <seastar/core/future.hh>
@@ -64,6 +65,20 @@ parse_subjects(iobuf body, qualified_subjects_enabled qualified);
 /// malformed input is reported via the returned std::expected.
 ss::future<std::expected<chunked_vector<context>, parse_error>>
 parse_contexts(iobuf body);
+
+/// Parse the body of a `GET /mode` response into a mode_info.
+///
+/// The body is a JSON object with a single modeled field, `mode`, a string
+/// (e.g. `{"mode": "READWRITE"}`). Parsing splits shape from value: the shape
+/// is strict — a non-object body, a missing `mode`, a non-string `mode`, or any
+/// trailing content after the object yields a parse_error — whereas the `mode`
+/// value is an open enum, so an unrecognized (or empty) string is not rejected
+/// but mapped to registry_mode::unknown with the original preserved in
+/// mode_info::raw (see mode.h). Any other top-level field is ignored: the
+/// server omits null/empty fields, and a client must not assume any field
+/// beyond `mode`. The function does not throw: malformed input is reported via
+/// the returned std::expected.
+ss::future<std::expected<mode_info, parse_error>> parse_mode(iobuf body);
 
 /// Parse the body of a `GET /subjects/{subject}/versions` response into a list
 /// of versions.

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.h
@@ -48,6 +48,23 @@ struct parse_error {
 ss::future<std::expected<chunked_vector<context_subject>, parse_error>>
 parse_subjects(iobuf body, qualified_subjects_enabled qualified);
 
+/// Parse the body of a `GET /contexts` response into a list of contexts.
+///
+/// The response is a JSON array of context-name strings (see the Schema
+/// Registry REST API). Each element is a bare, dot-prefixed context name: the
+/// default context is exactly ".", and a named context is "." + name (e.g.
+/// ".dev"). These are NOT the ":.name:" colon-qualified forms used by
+/// context-qualified subjects, so — unlike parse_subjects — there is no
+/// qualified/unqualified policy: each string is wrapped verbatim into a
+/// `context`.
+///
+/// The body must be exactly a JSON array of strings: a non-array, a non-string
+/// element, or any trailing content after the array yields a parse_error (same
+/// strict, fixed shape as parse_subjects). The function does not throw:
+/// malformed input is reported via the returned std::expected.
+ss::future<std::expected<chunked_vector<context>, parse_error>>
+parse_contexts(iobuf body);
+
 /// Parse the body of a `GET /subjects/{subject}/versions` response into a list
 /// of versions.
 ///

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/BUILD
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/BUILD
@@ -29,6 +29,26 @@ redpanda_cc_gtest(
         "//src/v/pandaproxy/schema_registry/rest_client:retry_policy",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "error_test",
+    timeout = "short",
+    srcs = [
+        "error_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/http:request_builder",
+        "//src/v/pandaproxy/schema_registry:types",
+        "//src/v/pandaproxy/schema_registry/rest_client:error",
+        "//src/v/pandaproxy/schema_registry/rest_client:parse",
+        "//src/v/test_utils:gtest",
+        "@fmt",
+        "@googletest//:gtest",
+        "@seastar",
     ],
 )
 

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_integration_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_integration_test.cc
@@ -358,6 +358,62 @@ FIXTURE_TEST(sr_rest_client_integration, pandaproxy_test_fixture) {
           std::holds_alternative<rc::version_not_found>(res.error()));
     }
 
+    // Kept before the delete section, while multi/v1 and solo/v1 are both live.
+    auto sv_contains = [](
+                         const auto& range,
+                         const pps::context_subject& s,
+                         pps::schema_version v) {
+        return std::ranges::any_of(range, [&](const pps::subject_version& sv) {
+            return sv.sub == s && sv.version == v;
+        });
+    };
+
+    info(
+      "get_schema_id_subject_versions enumerates every subject sharing an id");
+    {
+        // "multi" v1 and "solo" v1 registered identical content (schema_v1), so
+        // they share one schema id in the default context; the lookup returns
+        // both pairs.
+        auto v1
+          = sut.get_schema_by_version(multi, pps::schema_version{1}, rtc).get();
+        BOOST_REQUIRE(v1.has_value());
+
+        auto res = sut.get_schema_id_subject_versions(v1->schema.id, rtc).get();
+        BOOST_REQUIRE(res.has_value());
+        // Order is not guaranteed; check membership.
+        BOOST_REQUIRE(sv_contains(res.value(), multi, pps::schema_version{1}));
+        BOOST_REQUIRE(sv_contains(res.value(), solo, pps::schema_version{1}));
+    }
+
+    info(
+      "get_schema_id_subject_versions yields schema_id_not_found for a missing "
+      "id (real 40403)");
+    {
+        auto res
+          = sut.get_schema_id_subject_versions(pps::schema_id{123456}, rtc)
+              .get();
+        BOOST_REQUIRE(!res.has_value());
+        BOOST_REQUIRE(
+          std::holds_alternative<rc::schema_id_not_found>(res.error()));
+    }
+
+    info("get_schema_id_subject_versions resolves an id in a named context");
+    {
+        // ctx-sub lives in .myctx; passing it as the subject parameter resolves
+        // the id within that context (%3A path/query encoding end-to-end).
+        auto cs = sut
+                    .get_schema_by_version(ctx_sub, pps::schema_version{1}, rtc)
+                    .get();
+        BOOST_REQUIRE(cs.has_value());
+
+        auto res
+          = sut.get_schema_id_subject_versions(cs->schema.id, rtc, ctx_sub)
+              .get();
+        BOOST_REQUIRE(res.has_value());
+        BOOST_REQUIRE(
+          sv_contains(res.value(), ctx_sub, pps::schema_version{1}));
+    }
+
     info("deleted=true surfaces soft-deleted versions and subjects");
     {
         // Soft-delete version 1 of "multi" (v2 remains, so the subject stays

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_integration_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_integration_test.cc
@@ -84,6 +84,19 @@ void soft_delete(http::client& client, std::string_view subject_path) {
     BOOST_REQUIRE_EQUAL(res.headers.result(), bh::status::ok);
 }
 
+// Set the registry-wide (global) mode via PUT /mode on the seed client.
+// mode_mutability defaults to true, so this is accepted.
+void put_global_mode(http::client& client, std::string_view mode_value) {
+    auto res = http_request(
+      client,
+      "/mode",
+      iobuf::from(fmt::format(R"({{"mode": "{}"}})", mode_value)),
+      bh::verb::put,
+      serialization_format::schema_registry_v1_json,
+      serialization_format::schema_registry_v1_json);
+    BOOST_REQUIRE_EQUAL(res.headers.result(), bh::status::ok);
+}
+
 } // namespace
 
 // Drives the rest_client against the in-tree Schema Registry server: seeds
@@ -156,6 +169,16 @@ FIXTURE_TEST(sr_rest_client_integration, pandaproxy_test_fixture) {
         };
         BOOST_REQUIRE(contains(pps::context{".myctx"}));
         BOOST_REQUIRE(!contains(pps::default_context));
+    }
+
+    info("get_mode returns the default READWRITE global mode");
+    {
+        // No global mode has been set, so the registry reports its built-in
+        // default. The real server emits {"mode":"READWRITE"}.
+        auto res = sut.get_mode(rtc).get();
+        BOOST_REQUIRE(res.has_value());
+        BOOST_REQUIRE(res->mode == rc::registry_mode::read_write);
+        BOOST_REQUIRE_EQUAL(res->raw, "READWRITE");
     }
 
     info("list_subject_versions returns [1, 2]");
@@ -300,6 +323,24 @@ FIXTURE_TEST(sr_rest_client_integration, pandaproxy_test_fixture) {
             BOOST_REQUIRE(all.has_value());
             BOOST_REQUIRE(contains(all.value(), solo));
         }
+    }
+
+    // Kept last: switching the global mode to READONLY would reject the schema
+    // registrations and soft-deletes the earlier sections rely on.
+    info("get_mode reflects a mode change made via PUT /mode");
+    {
+        put_global_mode(seed, "READONLY");
+        auto ro = sut.get_mode(rtc).get();
+        BOOST_REQUIRE(ro.has_value());
+        BOOST_REQUIRE(ro->mode == rc::registry_mode::read_only);
+        BOOST_REQUIRE_EQUAL(ro->raw, "READONLY");
+
+        // Reading tracks a change in the other direction too (and restores the
+        // registry so it isn't left read-only).
+        put_global_mode(seed, "READWRITE");
+        auto rw = sut.get_mode(rtc).get();
+        BOOST_REQUIRE(rw.has_value());
+        BOOST_REQUIRE(rw->mode == rc::registry_mode::read_write);
     }
 
     sut.shutdown().get();

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_integration_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_integration_test.cc
@@ -113,6 +113,20 @@ void put_subject_mode(
     BOOST_REQUIRE_EQUAL(res.headers.result(), bh::status::ok);
 }
 
+// Set the registry-wide (global) compatibility via PUT /config on the seed
+// client. Note the request field is "compatibility", whereas GET /config
+// returns it as "compatibilityLevel".
+void put_global_config(http::client& client, std::string_view compat) {
+    auto res = http_request(
+      client,
+      "/config",
+      iobuf::from(fmt::format(R"({{"compatibility": "{}"}})", compat)),
+      bh::verb::put,
+      serialization_format::schema_registry_v1_json,
+      serialization_format::schema_registry_v1_json);
+    BOOST_REQUIRE_EQUAL(res.headers.result(), bh::status::ok);
+}
+
 } // namespace
 
 // Drives the rest_client against the in-tree Schema Registry server: seeds
@@ -195,6 +209,18 @@ FIXTURE_TEST(sr_rest_client_integration, pandaproxy_test_fixture) {
         BOOST_REQUIRE(res.has_value());
         BOOST_REQUIRE(res->mode == rc::registry_mode::read_write);
         BOOST_REQUIRE_EQUAL(res->raw, "READWRITE");
+    }
+
+    info("get_config returns the default BACKWARD compatibility level");
+    {
+        // No global config has been set, so the registry reports its built-in
+        // default. The real server emits {"compatibilityLevel":"BACKWARD"} and
+        // nothing else, so unknown_fields is empty.
+        auto res = sut.get_config(rtc).get();
+        BOOST_REQUIRE(res.has_value());
+        BOOST_REQUIRE(res->level == rc::registry_compatibility_level::backward);
+        BOOST_REQUIRE_EQUAL(res->raw, "BACKWARD");
+        BOOST_REQUIRE(res->unknown_fields.empty());
     }
 
     info(
@@ -378,6 +404,16 @@ FIXTURE_TEST(sr_rest_client_integration, pandaproxy_test_fixture) {
           = sut.get_subject_mode(multi, rtc, pps::default_to_global::yes).get();
         BOOST_REQUIRE(effective.has_value());
         BOOST_REQUIRE(effective->mode == rc::registry_mode::read_only);
+    }
+
+    info("get_config reflects a compatibility change made via PUT /config");
+    {
+        // PUT uses the "compatibility" field; GET returns "compatibilityLevel".
+        put_global_config(seed, "FULL");
+        auto res = sut.get_config(rtc).get();
+        BOOST_REQUIRE(res.has_value());
+        BOOST_REQUIRE(res->level == rc::registry_compatibility_level::full);
+        BOOST_REQUIRE_EQUAL(res->raw, "FULL");
     }
 
     // Kept last: switching the global mode to READONLY would reject the schema

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_integration_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_integration_test.cc
@@ -127,6 +127,22 @@ void put_global_config(http::client& client, std::string_view compat) {
     BOOST_REQUIRE_EQUAL(res.headers.result(), bh::status::ok);
 }
 
+// Set a subject's (or context's) compatibility via PUT /config/{subject} on the
+// seed client. As with PUT /config the request field is "compatibility".
+void put_subject_config(
+  http::client& client,
+  std::string_view subject_path,
+  std::string_view compat) {
+    auto res = http_request(
+      client,
+      fmt::format("/config/{}", subject_path),
+      iobuf::from(fmt::format(R"({{"compatibility": "{}"}})", compat)),
+      bh::verb::put,
+      serialization_format::schema_registry_v1_json,
+      serialization_format::schema_registry_v1_json);
+    BOOST_REQUIRE_EQUAL(res.headers.result(), bh::status::ok);
+}
+
 } // namespace
 
 // Drives the rest_client against the in-tree Schema Registry server: seeds
@@ -221,6 +237,27 @@ FIXTURE_TEST(sr_rest_client_integration, pandaproxy_test_fixture) {
         BOOST_REQUIRE(res->level == rc::registry_compatibility_level::backward);
         BOOST_REQUIRE_EQUAL(res->raw, "BACKWARD");
         BOOST_REQUIRE(res->unknown_fields.empty());
+    }
+
+    info(
+      "get_subject_config: an un-overridden subject is not configured, but "
+      "defaultToGlobal resolves the effective config");
+    {
+        // "multi" was seeded without a subject-level config, so its own config
+        // is the real 40408 (mapped to subject_config_not_found).
+        auto own = sut.get_subject_config(multi, rtc).get();
+        BOOST_REQUIRE(!own.has_value());
+        BOOST_REQUIRE(
+          std::holds_alternative<rc::subject_config_not_found>(own.error()));
+
+        // With defaultToGlobal the effective config resolves down to the global
+        // default (BACKWARD) rather than 40408.
+        auto effective
+          = sut.get_subject_config(multi, rtc, pps::default_to_global::yes)
+              .get();
+        BOOST_REQUIRE(effective.has_value());
+        BOOST_REQUIRE(
+          effective->level == rc::registry_compatibility_level::backward);
     }
 
     info(
@@ -384,6 +421,30 @@ FIXTURE_TEST(sr_rest_client_integration, pandaproxy_test_fixture) {
             BOOST_REQUIRE(all.has_value());
             BOOST_REQUIRE(contains(all.value(), solo));
         }
+    }
+
+    // Kept after the delete section but before the subject mode is set to
+    // READONLY below: a subject in read-only mode rejects config writes too.
+    info(
+      "get_subject_config reflects a subject config set via "
+      "PUT /config/<subject>");
+    {
+        // A subject-level override, distinct from the global compatibility.
+        put_subject_config(seed, "multi", "NONE");
+
+        // Without defaultToGlobal we read the subject's own override back.
+        auto own = sut.get_subject_config(multi, rtc).get();
+        BOOST_REQUIRE(own.has_value());
+        BOOST_REQUIRE(own->level == rc::registry_compatibility_level::none);
+        BOOST_REQUIRE_EQUAL(own->raw, "NONE");
+
+        // The effective config agrees: a subject override wins over the global.
+        auto effective
+          = sut.get_subject_config(multi, rtc, pps::default_to_global::yes)
+              .get();
+        BOOST_REQUIRE(effective.has_value());
+        BOOST_REQUIRE(
+          effective->level == rc::registry_compatibility_level::none);
     }
 
     // Kept after the delete section: setting "multi" READONLY would block the

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_integration_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_integration_test.cc
@@ -87,8 +87,9 @@ void soft_delete(http::client& client, std::string_view subject_path) {
 } // namespace
 
 // Drives the rest_client against the in-tree Schema Registry server: seeds
-// schemas over the real REST API, then exercises all three read calls plus the
-// real not-found (40401/40402) responses through a real http::client. This is
+// schemas over the real REST API, then exercises its read calls (list_subjects,
+// list_contexts, list_subject_versions, get_schema_by_version) plus the real
+// not-found (40401/40402) responses through a real http::client. This is
 // the fidelity counterpart to the mock-based client_test — it proves the wire
 // shape, qualified-subject %3A path encoding, and error-code classification
 // against actual server responses. (References are covered by the parser unit
@@ -125,6 +126,36 @@ FIXTURE_TEST(sr_rest_client_integration, pandaproxy_test_fixture) {
         BOOST_REQUIRE(contains(multi));
         BOOST_REQUIRE(contains(solo));
         BOOST_REQUIRE(contains(ctx_sub));
+    }
+
+    info("list_contexts returns the default and the seeded named context");
+    {
+        auto res = sut.list_contexts(rtc).get();
+        BOOST_REQUIRE(res.has_value());
+        const auto& ctxs = res.value();
+        auto contains = [&ctxs](const pps::context& c) {
+            return std::ranges::find(ctxs, c) != ctxs.end();
+        };
+        // The default context is always present; registering :.myctx:ctx-sub
+        // above materialized ".myctx".
+        BOOST_REQUIRE(contains(pps::default_context));
+        BOOST_REQUIRE(contains(pps::context{".myctx"}));
+    }
+
+    info(
+      "list_contexts filters by prefix client-side (the server ignores the "
+      "contextPrefix param)");
+    {
+        // Redpanda returns every context; the client filters, so only ".myctx"
+        // — not the default "." — comes back for the ".myctx" prefix.
+        auto res = sut.list_contexts(rtc, ss::sstring{".myctx"}).get();
+        BOOST_REQUIRE(res.has_value());
+        const auto& ctxs = res.value();
+        auto contains = [&ctxs](const pps::context& c) {
+            return std::ranges::find(ctxs, c) != ctxs.end();
+        };
+        BOOST_REQUIRE(contains(pps::context{".myctx"}));
+        BOOST_REQUIRE(!contains(pps::default_context));
     }
 
     info("list_subject_versions returns [1, 2]");

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_integration_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_integration_test.cc
@@ -97,6 +97,22 @@ void put_global_mode(http::client& client, std::string_view mode_value) {
     BOOST_REQUIRE_EQUAL(res.headers.result(), bh::status::ok);
 }
 
+// Set a subject's (or context's) mode via PUT /mode/{subject} on the seed
+// client. subject_path is the raw wire form.
+void put_subject_mode(
+  http::client& client,
+  std::string_view subject_path,
+  std::string_view mode_value) {
+    auto res = http_request(
+      client,
+      fmt::format("/mode/{}", subject_path),
+      iobuf::from(fmt::format(R"({{"mode": "{}"}})", mode_value)),
+      bh::verb::put,
+      serialization_format::schema_registry_v1_json,
+      serialization_format::schema_registry_v1_json);
+    BOOST_REQUIRE_EQUAL(res.headers.result(), bh::status::ok);
+}
+
 } // namespace
 
 // Drives the rest_client against the in-tree Schema Registry server: seeds
@@ -179,6 +195,25 @@ FIXTURE_TEST(sr_rest_client_integration, pandaproxy_test_fixture) {
         BOOST_REQUIRE(res.has_value());
         BOOST_REQUIRE(res->mode == rc::registry_mode::read_write);
         BOOST_REQUIRE_EQUAL(res->raw, "READWRITE");
+    }
+
+    info(
+      "get_subject_mode: an un-overridden subject is not configured, but "
+      "defaultToGlobal resolves the effective mode");
+    {
+        // "multi" was seeded without a subject-level mode, so its own mode is
+        // the real 40409 (mapped to subject_mode_not_found).
+        auto own = sut.get_subject_mode(multi, rtc).get();
+        BOOST_REQUIRE(!own.has_value());
+        BOOST_REQUIRE(
+          std::holds_alternative<rc::subject_mode_not_found>(own.error()));
+
+        // With defaultToGlobal the effective mode resolves down to the global
+        // default (READWRITE) rather than 40409.
+        auto effective
+          = sut.get_subject_mode(multi, rtc, pps::default_to_global::yes).get();
+        BOOST_REQUIRE(effective.has_value());
+        BOOST_REQUIRE(effective->mode == rc::registry_mode::read_write);
     }
 
     info("list_subject_versions returns [1, 2]");
@@ -323,6 +358,26 @@ FIXTURE_TEST(sr_rest_client_integration, pandaproxy_test_fixture) {
             BOOST_REQUIRE(all.has_value());
             BOOST_REQUIRE(contains(all.value(), solo));
         }
+    }
+
+    // Kept after the delete section: setting "multi" READONLY would block the
+    // soft-deletes above.
+    info(
+      "get_subject_mode reflects a subject mode set via PUT /mode/<subject>");
+    {
+        put_subject_mode(seed, "multi", "READONLY");
+
+        // Without defaultToGlobal we read the subject's own override back.
+        auto own = sut.get_subject_mode(multi, rtc).get();
+        BOOST_REQUIRE(own.has_value());
+        BOOST_REQUIRE(own->mode == rc::registry_mode::read_only);
+        BOOST_REQUIRE_EQUAL(own->raw, "READONLY");
+
+        // The effective mode agrees: a subject override wins over the global.
+        auto effective
+          = sut.get_subject_mode(multi, rtc, pps::default_to_global::yes).get();
+        BOOST_REQUIRE(effective.has_value());
+        BOOST_REQUIRE(effective->mode == rc::registry_mode::read_only);
     }
 
     // Kept last: switching the global mode to READONLY would reject the schema

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
@@ -465,6 +465,173 @@ TEST(rest_client, list_contexts_prefix_dot_matches_all) {
     EXPECT_THAT(*res, ElementsAre(pps::default_context, pps::context{".dev"}));
 }
 
+TEST(rest_client, get_mode_request_shape_and_success) {
+    auto check_and_respond = [](
+                               bh::request_header<>&& r,
+                               std::optional<iobuf>,
+                               ss::lowres_clock::duration) {
+        EXPECT_EQ(r.method(), bh::verb::get);
+        // No defaultToGlobal query param on the subject-less endpoint.
+        EXPECT_EQ(r.target(), "/mode");
+        EXPECT_EQ(r.at(bh::field::accept), "application/json");
+        // base64("user:pass") == "dXNlcjpwYXNz"
+        EXPECT_EQ(r.at(bh::field::authorization), "Basic dXNlcjpwYXNz");
+        return ss::make_ready_future<http::downloaded_response>(
+          http::downloaded_response{
+            .status = bh::status::ok,
+            .body = iobuf::from(R"({"mode": "READWRITE"})")});
+    };
+    rc::client client{
+      make_http_client([&](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(check_and_respond);
+      }),
+      endpoint,
+      rc::basic_auth_credentials{.username = "user", .password = "pass"}};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.get_mode(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->mode, rc::registry_mode::read_write);
+    EXPECT_EQ(res->raw, "READWRITE");
+}
+
+TEST(rest_client, get_mode_open_enum_tolerates_unknown_values) {
+    // A value Redpanda's own enum lacks (FORWARD) and a hypothetical future
+    // value both parse: known -> enumerator, unknown -> `unknown` + raw. This
+    // is the open-enum contract the client must honor against other registries.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(bh::status::ok, R"({"mode": "FORWARD"})"))
+            .WillOnce(respond(bh::status::ok, R"({"mode": "GALAXY_BRAIN"})"));
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+
+    auto fwd = client.get_mode(rtc).get();
+    ASSERT_TRUE(fwd.has_value());
+    EXPECT_EQ(fwd->mode, rc::registry_mode::forward);
+    EXPECT_EQ(fwd->raw, "FORWARD");
+
+    auto unknown = client.get_mode(rtc).get();
+    ASSERT_TRUE(unknown.has_value());
+    EXPECT_EQ(unknown->mode, rc::registry_mode::unknown);
+    EXPECT_EQ(unknown->raw, "GALAXY_BRAIN");
+
+    client.shutdown().get();
+}
+
+TEST(rest_client, get_mode_no_credentials_omits_auth_header) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce([](
+                        bh::request_header<>&& r,
+                        std::optional<iobuf>,
+                        ss::lowres_clock::duration) {
+                EXPECT_EQ(r.count(bh::field::authorization), 0);
+                return ss::make_ready_future<http::downloaded_response>(
+                  http::downloaded_response{
+                    .status = bh::status::ok,
+                    .body = iobuf::from(R"({"mode": "READONLY"})")});
+            });
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.get_mode(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->mode, rc::registry_mode::read_only);
+}
+
+TEST(rest_client, get_mode_storage_error_is_retried) {
+    // The report's one operation-specific failure, 500 / error_code 50001
+    // (backend storage), is transient: the client retries it and succeeds once
+    // the store recovers.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(
+              bh::status::internal_server_error,
+              R"({"error_code": 50001, "message": "Failed to get mode"})"))
+            .WillOnce(respond(bh::status::ok, R"({"mode": "READWRITE"})"));
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 30s, 10ms);
+    auto res = client.get_mode(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->mode, rc::registry_mode::read_write);
+}
+
+TEST(rest_client, get_mode_parse_error_surfaced) {
+    // A well-formed but wrong-shaped 200 body (an array, not the mode object)
+    // surfaces as a parse_error.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(bh::status::ok, R"(["not", "an", "object"])"));
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.get_mode(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::parse_error>(res.error()));
+}
+
+TEST(rest_client, get_mode_after_shutdown_is_aborted) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _)).Times(0);
+      }),
+      endpoint};
+
+    client.shutdown().get();
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.get_mode(rtc).get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::aborted_error>(res.error()));
+}
+
+TEST(rest_client, get_mode_retries_exhausted_surfaces_error) {
+    // A persistently failing transient status exhausts the retry budget;
+    // get_mode propagates the terminal error from perform_request rather than
+    // attempting to parse a body.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillRepeatedly(respond(bh::status::service_unavailable, "busy"));
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 100ms, 10ms);
+    auto res = client.get_mode(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::retries_exhausted>(res.error()));
+}
+
 TEST(rest_client, list_subject_versions_success_and_encodes_subject) {
     rc::client client{
       make_http_client([](mock_client& m) {

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
@@ -1558,3 +1558,259 @@ TEST(rest_client, get_schema_by_version_invalid_version_not_translated) {
       std::get<rc::http_status_error>(call).status,
       bh::status::unprocessable_entity);
 }
+
+TEST(rest_client, get_schema_id_subject_versions_request_shape_and_success) {
+    auto check_and_respond = [](
+                               bh::request_header<>&& r,
+                               std::optional<iobuf>,
+                               ss::lowres_clock::duration) {
+        EXPECT_EQ(r.method(), bh::verb::get);
+        // No subject query param -> the default context.
+        EXPECT_EQ(r.target(), "/schemas/ids/100001/versions");
+        EXPECT_EQ(r.at(bh::field::accept), "application/json");
+        // base64("user:pass") == "dXNlcjpwYXNz"
+        EXPECT_EQ(r.at(bh::field::authorization), "Basic dXNlcjpwYXNz");
+        return ss::make_ready_future<
+          http::downloaded_response>(http::downloaded_response{
+          .status = bh::status::ok,
+          .body = iobuf::from(
+            R"([{"subject": "orders", "version": 1}, {"subject": "orders-copy", "version": 3}])")});
+    };
+    rc::client client{
+      make_http_client([&](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(check_and_respond);
+      }),
+      endpoint,
+      rc::basic_auth_credentials{.username = "user", .password = "pass"}};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client
+                 .get_schema_id_subject_versions(pps::schema_id{100001}, rtc)
+                 .get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_THAT(
+      *res,
+      ElementsAre(
+        pps::subject_version(
+          pps::context_subject::unqualified("orders"), pps::schema_version{1}),
+        pps::subject_version(
+          pps::context_subject::unqualified("orders-copy"),
+          pps::schema_version{3})));
+}
+
+TEST(
+  rest_client, get_schema_id_subject_versions_subject_param_selects_context) {
+    // A context_subject is sent verbatim as the `subject` query param,
+    // percent-encoded (":" -> "%3A").
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce([](
+                        bh::request_header<>&& r,
+                        std::optional<iobuf>,
+                        ss::lowres_clock::duration) {
+                EXPECT_EQ(
+                  r.target(),
+                  "/schemas/ids/7/versions?subject=%3A.ctx%3Aorders");
+                return ss::make_ready_future<http::downloaded_response>(
+                  http::downloaded_response{
+                    .status = bh::status::ok,
+                    .body = iobuf::from(
+                      R"([{"subject": ":.ctx:orders", "version": 1}])")});
+            });
+      }),
+      endpoint,
+      std::nullopt,
+      pps::qualified_subjects_enabled::yes};
+
+    pps::context_subject subject{pps::context{".ctx"}, pps::subject{"orders"}};
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res
+      = client.get_schema_id_subject_versions(pps::schema_id{7}, rtc, subject)
+          .get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_THAT(
+      *res,
+      ElementsAre(
+        pps::subject_version(
+          pps::context_subject(pps::context{".ctx"}, pps::subject{"orders"}),
+          pps::schema_version{1})));
+}
+
+TEST(rest_client, get_schema_id_subject_versions_empty_array) {
+    // The id exists but no live pair matches: a valid empty result, not a 404.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(bh::status::ok, "[]"));
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res
+      = client.get_schema_id_subject_versions(pps::schema_id{1}, rtc).get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_THAT(*res, IsEmpty());
+}
+
+TEST(rest_client, get_schema_id_subject_versions_not_found) {
+    // 404 / 40403 (schema-not-found) becomes the typed schema_id_not_found.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(
+              bh::status::not_found,
+              R"({"error_code": 40403, "message": "Schema 999 not found"})"));
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res
+      = client.get_schema_id_subject_versions(pps::schema_id{999}, rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    ASSERT_TRUE(std::holds_alternative<rc::schema_id_not_found>(res.error()));
+    EXPECT_EQ(
+      std::get<rc::schema_id_not_found>(res.error()).id, pps::schema_id{999});
+}
+
+TEST(rest_client, get_schema_id_subject_versions_bare_404_passes_through) {
+    // A bare 404 (e.g. the singular /version path) is not 40403, so it stays a
+    // generic http error rather than schema_id_not_found.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(
+              bh::status::not_found,
+              R"({"error_code": 404, "message": "not found"})"));
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res
+      = client.get_schema_id_subject_versions(pps::schema_id{1}, rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::http_call_error>(res.error()));
+}
+
+TEST(rest_client, get_schema_id_subject_versions_bad_request_passes_through) {
+    // A 400 (e.g. a non-integer id/offset on the server) is not a 404, so it
+    // stays a generic http error rather than schema_id_not_found.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(
+              bh::status::bad_request,
+              R"({"error_code": 400, "message": "bad"})"));
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res
+      = client.get_schema_id_subject_versions(pps::schema_id{1}, rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::http_call_error>(res.error()));
+}
+
+TEST(
+  rest_client,
+  get_schema_id_subject_versions_transport_exception_passes_through) {
+    // A connection-level failure is a string http_call_error (no status), so
+    // translation cannot classify it and passes it through unchanged.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce([](
+                        bh::request_header<>&&,
+                        std::optional<iobuf>,
+                        ss::lowres_clock::duration) {
+                return ss::make_exception_future<http::downloaded_response>(
+                  std::runtime_error("connection refused"));
+            });
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res
+      = client.get_schema_id_subject_versions(pps::schema_id{1}, rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    ASSERT_TRUE(std::holds_alternative<rc::http_call_error>(res.error()));
+    EXPECT_TRUE(
+      std::holds_alternative<ss::sstring>(
+        std::get<rc::http_call_error>(res.error())));
+}
+
+TEST(rest_client, get_schema_id_subject_versions_retries_exhausted) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillRepeatedly(respond(bh::status::service_unavailable, "busy"));
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 100ms, 10ms);
+    auto res
+      = client.get_schema_id_subject_versions(pps::schema_id{1}, rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::retries_exhausted>(res.error()));
+}
+
+TEST(rest_client, get_schema_id_subject_versions_parse_error_surfaced) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(bh::status::ok, R"({"not": "an array"})"));
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res
+      = client.get_schema_id_subject_versions(pps::schema_id{1}, rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::parse_error>(res.error()));
+}
+
+TEST(rest_client, get_schema_id_subject_versions_after_shutdown_is_aborted) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _)).Times(0);
+      }),
+      endpoint};
+
+    client.shutdown().get();
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res
+      = client.get_schema_id_subject_versions(pps::schema_id{1}, rtc).get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::aborted_error>(res.error()));
+}

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
@@ -1070,6 +1070,269 @@ TEST(rest_client, get_config_after_shutdown_is_aborted) {
     EXPECT_TRUE(std::holds_alternative<rc::aborted_error>(res.error()));
 }
 
+TEST(rest_client, get_subject_config_request_shape_and_success) {
+    auto check_and_respond = [](
+                               bh::request_header<>&& r,
+                               std::optional<iobuf>,
+                               ss::lowres_clock::duration) {
+        EXPECT_EQ(r.method(), bh::verb::get);
+        // No defaultToGlobal by default: this asks for the subject's own
+        // config.
+        EXPECT_EQ(r.target(), "/config/orders");
+        EXPECT_EQ(r.at(bh::field::accept), "application/json");
+        // base64("user:pass") == "dXNlcjpwYXNz"
+        EXPECT_EQ(r.at(bh::field::authorization), "Basic dXNlcjpwYXNz");
+        return ss::make_ready_future<http::downloaded_response>(
+          http::downloaded_response{
+            .status = bh::status::ok,
+            .body = iobuf::from(R"({"compatibilityLevel": "NONE"})")});
+    };
+    rc::client client{
+      make_http_client([&](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(check_and_respond);
+      }),
+      endpoint,
+      rc::basic_auth_credentials{.username = "user", .password = "pass"}};
+
+    auto subject = pps::context_subject::unqualified("orders");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.get_subject_config(subject, rtc).get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->level, rc::registry_compatibility_level::none);
+    EXPECT_EQ(res->raw, "NONE");
+    EXPECT_TRUE(res->unknown_fields.empty());
+}
+
+TEST(rest_client, get_subject_config_encodes_qualified_subject) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce([](
+                        bh::request_header<>&& r,
+                        std::optional<iobuf>,
+                        ss::lowres_clock::duration) {
+                // ":.ctx:orders" percent-encoded exactly once.
+                EXPECT_EQ(r.target(), "/config/%3A.ctx%3Aorders");
+                return ss::make_ready_future<http::downloaded_response>(
+                  http::downloaded_response{
+                    .status = bh::status::ok,
+                    .body = iobuf::from(R"({"compatibilityLevel": "FULL"})")});
+            });
+      }),
+      endpoint,
+      std::nullopt,
+      pps::qualified_subjects_enabled::yes};
+
+    pps::context_subject subject{pps::context{".ctx"}, pps::subject{"orders"}};
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.get_subject_config(subject, rtc).get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->level, rc::registry_compatibility_level::full);
+}
+
+TEST(rest_client, get_subject_config_default_to_global_adds_query_param) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce([](
+                        bh::request_header<>&& r,
+                        std::optional<iobuf>,
+                        ss::lowres_clock::duration) {
+                EXPECT_EQ(r.target(), "/config/orders?defaultToGlobal=true");
+                return ss::make_ready_future<http::downloaded_response>(
+                  http::downloaded_response{
+                    .status = bh::status::ok,
+                    .body = iobuf::from(
+                      R"({"compatibilityLevel": "BACKWARD"})")});
+            });
+      }),
+      endpoint};
+
+    auto subject = pps::context_subject::unqualified("orders");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client
+                 .get_subject_config(subject, rtc, pps::default_to_global::yes)
+                 .get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->level, rc::registry_compatibility_level::backward);
+}
+
+TEST(rest_client, get_subject_config_no_subject_level_config) {
+    // The operation-specific outcome: 404 / 40408 becomes
+    // subject_config_not_found rather than a generic http error.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(
+              bh::status::not_found,
+              R"({"error_code": 40408, "message": "Subject 'orders' does not have subject-level compatibility configured"})"));
+      }),
+      endpoint};
+
+    auto subject = pps::context_subject::unqualified("orders");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.get_subject_config(subject, rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    ASSERT_TRUE(
+      std::holds_alternative<rc::subject_config_not_found>(res.error()));
+    EXPECT_EQ(
+      std::get<rc::subject_config_not_found>(res.error()).subject, subject);
+}
+
+TEST(rest_client, get_subject_config_40401_also_maps_to_not_configured) {
+    // Some server versions use 40401 for the missing-subject-config case; the
+    // client treats it the same as 40408 (the report's defensive guidance).
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(
+              bh::status::not_found,
+              R"({"error_code": 40401, "message": "Subject 'orders' not found"})"));
+      }),
+      endpoint};
+
+    auto subject = pps::context_subject::unqualified("orders");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.get_subject_config(subject, rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(
+      std::holds_alternative<rc::subject_config_not_found>(res.error()));
+}
+
+TEST(rest_client, get_subject_config_other_errors_pass_through_untranslated) {
+    // Only 404/40408 (and 40401) map to subject_config_not_found. A 404 for an
+    // unknown path (bare error_code 404) and a non-404 status both stay generic
+    // http errors, so a bad URL is not mistaken for a missing subject config.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(
+              bh::status::not_found,
+              R"({"error_code": 404, "message": "not found"})"))
+            .WillOnce(respond(
+              bh::status::unprocessable_entity,
+              R"({"error_code": 42200, "message": "bad"})"));
+      }),
+      endpoint};
+
+    auto subject = pps::context_subject::unqualified("orders");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+
+    auto bad_path = client.get_subject_config(subject, rtc).get();
+    ASSERT_FALSE(bad_path.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::http_call_error>(bad_path.error()));
+
+    auto unprocessable = client.get_subject_config(subject, rtc).get();
+    ASSERT_FALSE(unprocessable.has_value());
+    EXPECT_TRUE(
+      std::holds_alternative<rc::http_call_error>(unprocessable.error()));
+
+    client.shutdown().get();
+}
+
+TEST(rest_client, get_subject_config_retries_exhausted_surfaces_error) {
+    // A non-http terminal error (retries_exhausted) is not an
+    // http_status_error, so translation leaves it untouched and it surfaces
+    // as-is.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillRepeatedly(respond(bh::status::service_unavailable, "busy"));
+      }),
+      endpoint};
+
+    auto subject = pps::context_subject::unqualified("orders");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 100ms, 10ms);
+    auto res = client.get_subject_config(subject, rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::retries_exhausted>(res.error()));
+}
+
+TEST(rest_client, get_subject_config_transport_exception_passes_through) {
+    // A connection-level failure is a string http_call_error (no status), so
+    // translation cannot classify it and passes it through unchanged.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce([](
+                        bh::request_header<>&&,
+                        std::optional<iobuf>,
+                        ss::lowres_clock::duration) {
+                return ss::make_exception_future<http::downloaded_response>(
+                  std::runtime_error("connection refused"));
+            });
+      }),
+      endpoint};
+
+    auto subject = pps::context_subject::unqualified("orders");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.get_subject_config(subject, rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    ASSERT_TRUE(std::holds_alternative<rc::http_call_error>(res.error()));
+    EXPECT_TRUE(
+      std::holds_alternative<ss::sstring>(
+        std::get<rc::http_call_error>(res.error())));
+}
+
+TEST(rest_client, get_subject_config_parse_error_surfaced) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(bh::status::ok, R"(["not", "an", "object"])"));
+      }),
+      endpoint};
+
+    auto subject = pps::context_subject::unqualified("orders");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.get_subject_config(subject, rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::parse_error>(res.error()));
+}
+
+TEST(rest_client, get_subject_config_after_shutdown_is_aborted) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _)).Times(0);
+      }),
+      endpoint};
+
+    client.shutdown().get();
+
+    auto subject = pps::context_subject::unqualified("orders");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.get_subject_config(subject, rtc).get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::aborted_error>(res.error()));
+}
+
 TEST(rest_client, list_subject_versions_success_and_encodes_subject) {
     rc::client client{
       make_http_client([](mock_client& m) {

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
@@ -282,6 +282,189 @@ TEST(rest_client, list_subjects_after_shutdown_is_aborted) {
     EXPECT_TRUE(std::holds_alternative<rc::aborted_error>(res.error()));
 }
 
+TEST(rest_client, list_contexts_request_shape_and_success) {
+    auto check_and_respond = [](
+                               bh::request_header<>&& r,
+                               std::optional<iobuf>,
+                               ss::lowres_clock::duration) {
+        EXPECT_EQ(r.method(), bh::verb::get);
+        EXPECT_EQ(r.target(), "/contexts");
+        EXPECT_EQ(r.at(bh::field::accept), "application/json");
+        // base64("user:pass") == "dXNlcjpwYXNz"
+        EXPECT_EQ(r.at(bh::field::authorization), "Basic dXNlcjpwYXNz");
+        return ss::make_ready_future<http::downloaded_response>(
+          http::downloaded_response{
+            .status = bh::status::ok, .body = iobuf::from(R"([".", ".dev"])")});
+    };
+    rc::client client{
+      make_http_client([&](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(check_and_respond);
+      }),
+      endpoint,
+      rc::basic_auth_credentials{.username = "user", .password = "pass"}};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.list_contexts(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_THAT(*res, ElementsAre(pps::default_context, pps::context{".dev"}));
+}
+
+TEST(rest_client, list_contexts_no_credentials_omits_auth_header) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce([](
+                        bh::request_header<>&& r,
+                        std::optional<iobuf>,
+                        ss::lowres_clock::duration) {
+                EXPECT_EQ(r.count(bh::field::authorization), 0);
+                return ss::make_ready_future<http::downloaded_response>(
+                  http::downloaded_response{
+                    .status = bh::status::ok, .body = iobuf::from(R"(["."])")});
+            });
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.list_contexts(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_THAT(*res, ElementsAre(pps::default_context));
+}
+
+TEST(rest_client, list_contexts_retries_then_succeeds) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(bh::status::service_unavailable, "busy"))
+            .WillOnce(respond(bh::status::ok, R"(["."])"));
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 30s, 10ms);
+    auto res = client.list_contexts(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_THAT(*res, SizeIs(1));
+}
+
+TEST(rest_client, list_contexts_parse_error_surfaced) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(bh::status::ok, R"({"not": "an array"})"));
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.list_contexts(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::parse_error>(res.error()));
+}
+
+TEST(rest_client, list_contexts_after_shutdown_is_aborted) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _)).Times(0);
+      }),
+      endpoint};
+
+    client.shutdown().get();
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.list_contexts(rtc).get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::aborted_error>(res.error()));
+}
+
+TEST(rest_client, list_contexts_prefix_sends_param_and_filters_client_side) {
+    // The client sends ?contextPrefix= AND filters client-side, so a server
+    // that ignores the param (like Redpanda, which returns everything here)
+    // still yields correctly-filtered results.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce([](
+                        bh::request_header<>&& r,
+                        std::optional<iobuf>,
+                        ss::lowres_clock::duration) {
+                EXPECT_EQ(r.target(), "/contexts?contextPrefix=.prod");
+                return ss::make_ready_future<http::downloaded_response>(
+                  http::downloaded_response{
+                    .status = bh::status::ok,
+                    .body = iobuf::from(
+                      R"([".", ".prod", ".prod-eu", ".staging"])")});
+            });
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.list_contexts(rtc, ss::sstring{".prod"}).get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_THAT(
+      *res, ElementsAre(pps::context{".prod"}, pps::context{".prod-eu"}));
+}
+
+TEST(rest_client, list_contexts_prefix_matching_nothing_is_empty) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(bh::status::ok, R"([".", ".dev"])"));
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.list_contexts(rtc, ss::sstring{".zzz"}).get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_THAT(*res, IsEmpty());
+}
+
+TEST(rest_client, list_contexts_prefix_dot_matches_all) {
+    // "." is a prefix of every returned context, so nothing is filtered out.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce([](
+                        bh::request_header<>&& r,
+                        std::optional<iobuf>,
+                        ss::lowres_clock::duration) {
+                EXPECT_EQ(r.target(), "/contexts?contextPrefix=.");
+                return ss::make_ready_future<http::downloaded_response>(
+                  http::downloaded_response{
+                    .status = bh::status::ok,
+                    .body = iobuf::from(R"([".", ".dev"])")});
+            });
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.list_contexts(rtc, ss::sstring{"."}).get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_THAT(*res, ElementsAre(pps::default_context, pps::context{".dev"}));
+}
+
 TEST(rest_client, list_subject_versions_success_and_encodes_subject) {
     rc::client client{
       make_http_client([](mock_client& m) {

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
@@ -282,6 +282,52 @@ TEST(rest_client, list_subjects_after_shutdown_is_aborted) {
     EXPECT_TRUE(std::holds_alternative<rc::aborted_error>(res.error()));
 }
 
+TEST(rest_client, request_aborted_by_transport_is_aborted) {
+    // A transport failure that is an abort/shutdown (here abort_requested) is
+    // classified aborted by the retry policy and short-circuits the retry loop
+    // as an aborted_error rather than being retried to exhaustion.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce([](
+                        bh::request_header<>&&,
+                        std::optional<iobuf>,
+                        ss::lowres_clock::duration) {
+                return ss::make_exception_future<http::downloaded_response>(
+                  ss::abort_requested_exception{});
+            });
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.list_subjects(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::aborted_error>(res.error()));
+}
+
+TEST(rest_client, request_with_pre_aborted_source_is_aborted) {
+    // If the retry chain's abort source is already tripped, the first
+    // rtc.retry() raises a shutdown exception before any request is issued; the
+    // call resolves as aborted, and the transport is never invoked.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _)).Times(0);
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    as.request_abort();
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.list_subjects(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::aborted_error>(res.error()));
+}
+
 TEST(rest_client, list_contexts_request_shape_and_success) {
     auto check_and_respond = [](
                                bh::request_header<>&& r,
@@ -371,6 +417,26 @@ TEST(rest_client, list_contexts_parse_error_surfaced) {
 
     ASSERT_FALSE(res.has_value());
     EXPECT_TRUE(std::holds_alternative<rc::parse_error>(res.error()));
+}
+
+TEST(rest_client, list_contexts_http_error_surfaced) {
+    // A permanent HTTP error from perform_request passes through unchanged:
+    // contexts has no operation-specific not-found translation.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(
+              respond(bh::status::bad_request, R"({"error_code": 40001})"));
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.list_contexts(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::http_call_error>(res.error()));
 }
 
 TEST(rest_client, list_contexts_after_shutdown_is_aborted) {
@@ -1417,6 +1483,42 @@ TEST(rest_client, list_subject_versions_subject_not_found) {
     EXPECT_EQ(std::get<rc::subject_not_found>(res.error()).subject, subject);
 }
 
+TEST(rest_client, list_subject_versions_parse_error_surfaced) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(bh::status::ok, R"({"not": "an array"})"));
+      }),
+      endpoint};
+
+    auto subject = pps::context_subject::unqualified("orders");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.list_subject_versions(subject, rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::parse_error>(res.error()));
+}
+
+TEST(rest_client, list_subject_versions_after_shutdown_is_aborted) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _)).Times(0);
+      }),
+      endpoint};
+
+    client.shutdown().get();
+
+    auto subject = pps::context_subject::unqualified("orders");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.list_subject_versions(subject, rtc).get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::aborted_error>(res.error()));
+}
+
 TEST(rest_client, get_schema_by_version_success) {
     constexpr std::string_view body
       = R"({"subject":"User","version":3,"id":100001,"schemaType":"AVRO",)"
@@ -1557,6 +1659,46 @@ TEST(rest_client, get_schema_by_version_invalid_version_not_translated) {
     EXPECT_EQ(
       std::get<rc::http_status_error>(call).status,
       bh::status::unprocessable_entity);
+}
+
+TEST(rest_client, get_schema_by_version_parse_error_surfaced) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(bh::status::ok, R"([1, 2, 3])"));
+      }),
+      endpoint};
+
+    auto subject = pps::context_subject::unqualified("User");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client
+                 .get_schema_by_version(subject, pps::schema_version{1}, rtc)
+                 .get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::parse_error>(res.error()));
+}
+
+TEST(rest_client, get_schema_by_version_after_shutdown_is_aborted) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _)).Times(0);
+      }),
+      endpoint};
+
+    client.shutdown().get();
+
+    auto subject = pps::context_subject::unqualified("User");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client
+                 .get_schema_by_version(subject, pps::schema_version{1}, rtc)
+                 .get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::aborted_error>(res.error()));
 }
 
 TEST(rest_client, get_schema_id_subject_versions_request_shape_and_success) {

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
@@ -632,6 +632,266 @@ TEST(rest_client, get_mode_retries_exhausted_surfaces_error) {
     EXPECT_TRUE(std::holds_alternative<rc::retries_exhausted>(res.error()));
 }
 
+TEST(rest_client, get_subject_mode_request_shape_and_success) {
+    auto check_and_respond = [](
+                               bh::request_header<>&& r,
+                               std::optional<iobuf>,
+                               ss::lowres_clock::duration) {
+        EXPECT_EQ(r.method(), bh::verb::get);
+        // No defaultToGlobal by default: this asks for the subject's own mode.
+        EXPECT_EQ(r.target(), "/mode/orders");
+        EXPECT_EQ(r.at(bh::field::accept), "application/json");
+        // base64("user:pass") == "dXNlcjpwYXNz"
+        EXPECT_EQ(r.at(bh::field::authorization), "Basic dXNlcjpwYXNz");
+        return ss::make_ready_future<http::downloaded_response>(
+          http::downloaded_response{
+            .status = bh::status::ok,
+            .body = iobuf::from(R"({"mode": "READONLY"})")});
+    };
+    rc::client client{
+      make_http_client([&](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(check_and_respond);
+      }),
+      endpoint,
+      rc::basic_auth_credentials{.username = "user", .password = "pass"}};
+
+    auto subject = pps::context_subject::unqualified("orders");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.get_subject_mode(subject, rtc).get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->mode, rc::registry_mode::read_only);
+    EXPECT_EQ(res->raw, "READONLY");
+}
+
+TEST(rest_client, get_subject_mode_encodes_qualified_subject) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce([](
+                        bh::request_header<>&& r,
+                        std::optional<iobuf>,
+                        ss::lowres_clock::duration) {
+                // ":.ctx:orders" percent-encoded exactly once.
+                EXPECT_EQ(r.target(), "/mode/%3A.ctx%3Aorders");
+                return ss::make_ready_future<http::downloaded_response>(
+                  http::downloaded_response{
+                    .status = bh::status::ok,
+                    .body = iobuf::from(R"({"mode": "IMPORT"})")});
+            });
+      }),
+      endpoint,
+      std::nullopt,
+      pps::qualified_subjects_enabled::yes};
+
+    pps::context_subject subject{pps::context{".ctx"}, pps::subject{"orders"}};
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.get_subject_mode(subject, rtc).get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->mode, rc::registry_mode::import);
+}
+
+TEST(rest_client, get_subject_mode_default_to_global_adds_query_param) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce([](
+                        bh::request_header<>&& r,
+                        std::optional<iobuf>,
+                        ss::lowres_clock::duration) {
+                EXPECT_EQ(r.target(), "/mode/orders?defaultToGlobal=true");
+                return ss::make_ready_future<http::downloaded_response>(
+                  http::downloaded_response{
+                    .status = bh::status::ok,
+                    .body = iobuf::from(R"({"mode": "READWRITE"})")});
+            });
+      }),
+      endpoint};
+
+    auto subject = pps::context_subject::unqualified("orders");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client
+                 .get_subject_mode(subject, rtc, pps::default_to_global::yes)
+                 .get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->mode, rc::registry_mode::read_write);
+}
+
+TEST(rest_client, get_subject_mode_no_subject_level_mode) {
+    // The operation-specific outcome: 404 / 40409 becomes
+    // subject_mode_not_found rather than a generic http error.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(
+              bh::status::not_found,
+              R"({"error_code": 40409, "message": "Subject 'orders' does not have subject-level mode configured"})"));
+      }),
+      endpoint};
+
+    auto subject = pps::context_subject::unqualified("orders");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.get_subject_mode(subject, rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    ASSERT_TRUE(
+      std::holds_alternative<rc::subject_mode_not_found>(res.error()));
+    EXPECT_EQ(
+      std::get<rc::subject_mode_not_found>(res.error()).subject, subject);
+}
+
+TEST(rest_client, get_subject_mode_40401_also_maps_to_not_configured) {
+    // Some server versions use 40401 for the missing-subject-mode case; the
+    // client treats it the same as 40409 (the report's defensive guidance).
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(
+              bh::status::not_found,
+              R"({"error_code": 40401, "message": "Subject 'orders' not found"})"));
+      }),
+      endpoint};
+
+    auto subject = pps::context_subject::unqualified("orders");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.get_subject_mode(subject, rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(
+      std::holds_alternative<rc::subject_mode_not_found>(res.error()));
+}
+
+TEST(rest_client, get_subject_mode_other_errors_pass_through_untranslated) {
+    // Only 404/40409 (and 40401) map to subject_mode_not_found. A 404 for an
+    // unknown path (bare error_code 404) and a non-404 status both stay generic
+    // http errors, so a bad URL is not mistaken for a missing subject mode.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(
+              bh::status::not_found,
+              R"({"error_code": 404, "message": "not found"})"))
+            .WillOnce(respond(
+              bh::status::unprocessable_entity,
+              R"({"error_code": 42200, "message": "bad"})"));
+      }),
+      endpoint};
+
+    auto subject = pps::context_subject::unqualified("orders");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+
+    auto bad_path = client.get_subject_mode(subject, rtc).get();
+    ASSERT_FALSE(bad_path.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::http_call_error>(bad_path.error()));
+
+    auto unprocessable = client.get_subject_mode(subject, rtc).get();
+    ASSERT_FALSE(unprocessable.has_value());
+    EXPECT_TRUE(
+      std::holds_alternative<rc::http_call_error>(unprocessable.error()));
+
+    client.shutdown().get();
+}
+
+TEST(rest_client, get_subject_mode_retries_exhausted_surfaces_error) {
+    // A non-http terminal error (retries_exhausted) is not an
+    // http_status_error, so translation leaves it untouched and it surfaces
+    // as-is.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillRepeatedly(respond(bh::status::service_unavailable, "busy"));
+      }),
+      endpoint};
+
+    auto subject = pps::context_subject::unqualified("orders");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 100ms, 10ms);
+    auto res = client.get_subject_mode(subject, rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::retries_exhausted>(res.error()));
+}
+
+TEST(rest_client, get_subject_mode_transport_exception_passes_through) {
+    // A connection-level failure is a string http_call_error (no status), so
+    // translation cannot classify it and passes it through unchanged.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce([](
+                        bh::request_header<>&&,
+                        std::optional<iobuf>,
+                        ss::lowres_clock::duration) {
+                return ss::make_exception_future<http::downloaded_response>(
+                  std::runtime_error("connection refused"));
+            });
+      }),
+      endpoint};
+
+    auto subject = pps::context_subject::unqualified("orders");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.get_subject_mode(subject, rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    ASSERT_TRUE(std::holds_alternative<rc::http_call_error>(res.error()));
+    EXPECT_TRUE(
+      std::holds_alternative<ss::sstring>(
+        std::get<rc::http_call_error>(res.error())));
+}
+
+TEST(rest_client, get_subject_mode_parse_error_surfaced) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(bh::status::ok, R"(["not", "an", "object"])"));
+      }),
+      endpoint};
+
+    auto subject = pps::context_subject::unqualified("orders");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.get_subject_mode(subject, rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::parse_error>(res.error()));
+}
+
+TEST(rest_client, get_subject_mode_after_shutdown_is_aborted) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _)).Times(0);
+      }),
+      endpoint};
+
+    client.shutdown().get();
+
+    auto subject = pps::context_subject::unqualified("orders");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.get_subject_mode(subject, rtc).get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::aborted_error>(res.error()));
+}
+
 TEST(rest_client, list_subject_versions_success_and_encodes_subject) {
     rc::client client{
       make_http_client([](mock_client& m) {

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
@@ -892,6 +892,184 @@ TEST(rest_client, get_subject_mode_after_shutdown_is_aborted) {
     EXPECT_TRUE(std::holds_alternative<rc::aborted_error>(res.error()));
 }
 
+TEST(rest_client, get_config_request_shape_and_success) {
+    auto check_and_respond = [](
+                               bh::request_header<>&& r,
+                               std::optional<iobuf>,
+                               ss::lowres_clock::duration) {
+        EXPECT_EQ(r.method(), bh::verb::get);
+        EXPECT_EQ(r.target(), "/config");
+        EXPECT_EQ(r.at(bh::field::accept), "application/json");
+        // base64("user:pass") == "dXNlcjpwYXNz"
+        EXPECT_EQ(r.at(bh::field::authorization), "Basic dXNlcjpwYXNz");
+        return ss::make_ready_future<http::downloaded_response>(
+          http::downloaded_response{
+            .status = bh::status::ok,
+            .body = iobuf::from(R"({"compatibilityLevel": "BACKWARD"})")});
+    };
+    rc::client client{
+      make_http_client([&](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(check_and_respond);
+      }),
+      endpoint,
+      rc::basic_auth_credentials{.username = "user", .password = "pass"}};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.get_config(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->level, rc::registry_compatibility_level::backward);
+    EXPECT_EQ(res->raw, "BACKWARD");
+    EXPECT_TRUE(res->unknown_fields.empty());
+}
+
+TEST(rest_client, get_config_open_enum_tolerates_unknown_value) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(
+              respond(bh::status::ok, R"({"compatibilityLevel": "SIDEWAYS"})"));
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.get_config(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->level, rc::registry_compatibility_level::unknown);
+    EXPECT_EQ(res->raw, "SIDEWAYS");
+}
+
+TEST(rest_client, get_config_records_unmodeled_fields) {
+    // A Confluent registry may return a rich object; the client models only
+    // compatibilityLevel and names the rest in unknown_fields.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(
+              bh::status::ok,
+              R"({"compatibilityLevel": "FULL", "normalize": true, "validateFields": false})"));
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.get_config(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->level, rc::registry_compatibility_level::full);
+    EXPECT_THAT(
+      res->unknown_fields, ElementsAre("normalize", "validateFields"));
+}
+
+TEST(rest_client, get_config_no_credentials_omits_auth_header) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce([](
+                        bh::request_header<>&& r,
+                        std::optional<iobuf>,
+                        ss::lowres_clock::duration) {
+                EXPECT_EQ(r.count(bh::field::authorization), 0);
+                return ss::make_ready_future<http::downloaded_response>(
+                  http::downloaded_response{
+                    .status = bh::status::ok,
+                    .body = iobuf::from(R"({"compatibilityLevel": "NONE"})")});
+            });
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.get_config(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->level, rc::registry_compatibility_level::none);
+}
+
+TEST(rest_client, get_config_storage_error_is_retried) {
+    // The report's one operation-specific failure, 500 / error_code 50001
+    // (backend storage), is transient: the client retries and recovers.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(
+              bh::status::internal_server_error,
+              R"({"error_code": 50001, "message": "Failed to get compatibility level"})"))
+            .WillOnce(
+              respond(bh::status::ok, R"({"compatibilityLevel": "BACKWARD"})"));
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 30s, 10ms);
+    auto res = client.get_config(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->level, rc::registry_compatibility_level::backward);
+}
+
+TEST(rest_client, get_config_retries_exhausted_surfaces_error) {
+    // A persistently failing transient status exhausts the retry budget;
+    // get_config propagates the terminal error rather than parsing a body.
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillRepeatedly(respond(bh::status::service_unavailable, "busy"));
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 100ms, 10ms);
+    auto res = client.get_config(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::retries_exhausted>(res.error()));
+}
+
+TEST(rest_client, get_config_parse_error_surfaced) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce(respond(bh::status::ok, R"(["not", "an", "object"])"));
+      }),
+      endpoint};
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.get_config(rtc).get();
+    client.shutdown().get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::parse_error>(res.error()));
+}
+
+TEST(rest_client, get_config_after_shutdown_is_aborted) {
+    rc::client client{
+      make_http_client([](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _)).Times(0);
+      }),
+      endpoint};
+
+    client.shutdown().get();
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client.get_config(rtc).get();
+
+    ASSERT_FALSE(res.has_value());
+    EXPECT_TRUE(std::holds_alternative<rc::aborted_error>(res.error()));
+}
+
 TEST(rest_client, list_subject_versions_success_and_encodes_subject) {
     rc::client client{
       make_http_client([](mock_client& m) {

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/error_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/error_test.cc
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "http/request_builder.h"
+#include "pandaproxy/schema_registry/rest_client/error.h"
+#include "pandaproxy/schema_registry/rest_client/parse.h"
+#include "pandaproxy/schema_registry/types.h"
+
+#include <fmt/format.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <vector>
+
+// These tests pin the display/log form of the error types. Nothing else formats
+// a domain_error, so without them the error_kind mapping and every variant's
+// format_to path go unexercised even though the values are asserted elsewhere.
+
+namespace pandaproxy::schema_registry::rest_client {
+
+using ::testing::HasSubstr;
+
+namespace {
+ss::sstring fmt_error(domain_error err) { return fmt::format("{}", err); }
+} // namespace
+
+TEST(error_kind_test, to_string_view_covers_every_kind) {
+    using enum error_kind;
+    EXPECT_EQ(to_string_view(permanent_failure), "permanent_failure");
+    EXPECT_EQ(to_string_view(aborted), "aborted");
+    EXPECT_EQ(to_string_view(retriable_http_status), "retriable_http_status");
+    EXPECT_EQ(to_string_view(network_error), "network_error");
+    EXPECT_EQ(to_string_view(timeout), "timeout");
+    // The fmt formatter (via format_to) mirrors to_string_view.
+    EXPECT_EQ(fmt::format("{}", network_error), "network_error");
+}
+
+TEST(error_kind_test, is_retriable_classification) {
+    using enum error_kind;
+    EXPECT_TRUE(is_retriable(retriable_http_status));
+    EXPECT_TRUE(is_retriable(network_error));
+    EXPECT_TRUE(is_retriable(timeout));
+    EXPECT_FALSE(is_retriable(permanent_failure));
+    EXPECT_FALSE(is_retriable(aborted));
+}
+
+TEST(http_status_error_test, format_includes_error_code_and_body) {
+    // Both optional fields present: exercises the error_code and body arms of
+    // http_status_error::format_to.
+    http_status_error with_all{
+      .status = boost::beast::http::status::not_found,
+      .body = "the body",
+      .error_code = 40401,
+      .message = "not found"};
+    auto s = fmt::format("{}", with_all);
+    EXPECT_THAT(s, HasSubstr("error_code=40401"));
+    EXPECT_THAT(s, HasSubstr("the body"));
+
+    // Neither optional field: no error_code suffix, no body suffix.
+    http_status_error bare{
+      .status = boost::beast::http::status::service_unavailable, .body = ""};
+    auto bare_s = fmt::format("{}", bare);
+    EXPECT_THAT(bare_s, ::testing::Not(HasSubstr("error_code=")));
+}
+
+TEST(domain_error_test, format_url_build_error) {
+    EXPECT_THAT(
+      fmt_error(domain_error{http::url_build_error{"bad url"}}),
+      HasSubstr("url_build_error: bad url"));
+}
+
+TEST(domain_error_test, format_parse_error) {
+    EXPECT_THAT(
+      fmt_error(domain_error{parse_error{.reason = "expected array"}}),
+      HasSubstr("parse_error: expected array"));
+}
+
+TEST(domain_error_test, format_http_call_error_status_and_string) {
+    // The http_status_error arm of http_call_error.
+    EXPECT_THAT(
+      fmt_error(
+        domain_error{http_call_error{http_status_error{
+          .status = boost::beast::http::status::bad_gateway,
+          .body = "upstream"}}}),
+      HasSubstr("http_call_error"));
+    // The bare-string arm (a transport exception rendered to text).
+    EXPECT_THAT(
+      fmt_error(domain_error{http_call_error{ss::sstring{"connection reset"}}}),
+      HasSubstr("connection reset"));
+}
+
+TEST(domain_error_test, format_retries_exhausted_lists_every_reason) {
+    using enum error_kind;
+    // All reason kinds in one list drives the error_kind formatter (via
+    // fmt::join) across every enumerator, and last_error drives that arm.
+    retries_exhausted ex{
+      .reasons
+      = {permanent_failure, aborted, retriable_http_status, network_error, timeout},
+      .last_error = http_call_error{ss::sstring{"last one"}}};
+    auto s = fmt_error(domain_error{ex});
+    EXPECT_THAT(s, HasSubstr("retries_exhausted"));
+    EXPECT_THAT(s, HasSubstr("network_error"));
+    EXPECT_THAT(s, HasSubstr("timeout"));
+    EXPECT_THAT(s, HasSubstr("last_error"));
+
+    // The no-last_error arm: reasons still render, no last_error suffix.
+    retries_exhausted none{
+      .reasons = {network_error}, .last_error = std::nullopt};
+    EXPECT_THAT(
+      fmt_error(domain_error{none}), ::testing::Not(HasSubstr("last_error")));
+}
+
+TEST(domain_error_test, format_typed_not_found_variants) {
+    auto subject = context_subject::unqualified("orders");
+    EXPECT_THAT(
+      fmt_error(domain_error{subject_not_found{subject}}),
+      HasSubstr("subject not found"));
+    EXPECT_THAT(
+      fmt_error(domain_error{version_not_found{subject, schema_version{7}}}),
+      HasSubstr("version not found"));
+    EXPECT_THAT(
+      fmt_error(domain_error{subject_mode_not_found{subject}}),
+      HasSubstr("subject mode not configured"));
+    EXPECT_THAT(
+      fmt_error(domain_error{subject_config_not_found{subject}}),
+      HasSubstr("subject config not configured"));
+    EXPECT_THAT(
+      fmt_error(domain_error{schema_id_not_found{schema_id{42}}}),
+      HasSubstr("schema id not found"));
+}
+
+TEST(domain_error_test, format_aborted_error) {
+    EXPECT_THAT(
+      fmt_error(domain_error{aborted_error{"shutting down"}}),
+      HasSubstr("aborted_error: shutting down"));
+}
+
+} // namespace pandaproxy::schema_registry::rest_client

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
@@ -284,6 +284,164 @@ TEST_CORO(parse_contexts_test, malformed_or_truncated_is_error) {
     }
 }
 
+TEST_CORO(parse_mode_test, readwrite) {
+    auto res = co_await parse_mode(iobuf::from(R"({"mode": "READWRITE"})"));
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res->mode, registry_mode::read_write);
+    ASSERT_EQ_CORO(res->raw, "READWRITE");
+}
+
+TEST_CORO(parse_mode_test, all_known_values_map_to_enumerators) {
+    // Every value the Schema Registry REST API defines maps to its enumerator,
+    // including READONLY_OVERRIDE (deprecated) and FORWARD — values Redpanda's
+    // own server never emits but a Confluent-compatible one can. raw always
+    // carries the verbatim wire string.
+    const std::pair<std::string_view, registry_mode> cases[] = {
+      {"READWRITE", registry_mode::read_write},
+      {"READONLY", registry_mode::read_only},
+      {"READONLY_OVERRIDE", registry_mode::read_only_override},
+      {"IMPORT", registry_mode::import},
+      {"FORWARD", registry_mode::forward},
+    };
+    for (const auto& [wire, expected] : cases) {
+        SCOPED_TRACE(wire);
+        auto res = co_await parse_mode(
+          iobuf::from(ssx::sformat(R"({{"mode": "{}"}})", wire)));
+        ASSERT_TRUE_CORO(res.has_value());
+        ASSERT_EQ_CORO(res->mode, expected);
+        ASSERT_EQ_CORO(res->raw, ss::sstring{wire});
+    }
+}
+
+TEST_CORO(parse_mode_test, unknown_value_is_open_enum) {
+    // An unrecognized mode is tolerated, not rejected: it maps to `unknown`
+    // with the verbatim wire string preserved so nothing is lost.
+    auto res = co_await parse_mode(iobuf::from(R"({"mode": "GALAXY_BRAIN"})"));
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res->mode, registry_mode::unknown);
+    ASSERT_EQ_CORO(res->raw, "GALAXY_BRAIN");
+}
+
+TEST_CORO(parse_mode_test, empty_value_is_unknown_not_error) {
+    // Shape is strict, value is open: a present-but-empty string is not a shape
+    // violation; the value simply maps to `unknown` (raw="").
+    auto res = co_await parse_mode(iobuf::from(R"({"mode": ""})"));
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res->mode, registry_mode::unknown);
+    ASSERT_EQ_CORO(res->raw, "");
+}
+
+TEST_CORO(parse_mode_test, ignores_unknown_fields) {
+    // Only `mode` is modeled; any other top-level field is skipped, whether it
+    // precedes or follows `mode` and whatever its (possibly nested) value.
+    for (std::string_view body :
+         {R"({"mode": "READONLY", "extra": 123})",
+          R"({"extra": {"a": [1, 2]}, "mode": "READONLY"})"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_mode(iobuf::from(body));
+        ASSERT_TRUE_CORO(res.has_value());
+        ASSERT_EQ_CORO(res->mode, registry_mode::read_only);
+        ASSERT_EQ_CORO(res->raw, "READONLY");
+    }
+}
+
+TEST_CORO(parse_mode_test, missing_mode_is_error) {
+    // `mode` is the one field a successful response must carry.
+    for (std::string_view body : {R"({})", R"({"other": 1})"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_mode(iobuf::from(body));
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(parse_mode_test, non_object_is_error) {
+    for (std::string_view body :
+         {R"(["READWRITE"])", R"("READWRITE")", "42", "null", "true"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_mode(iobuf::from(body));
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(parse_mode_test, non_string_mode_is_error) {
+    for (std::string_view body :
+         {R"({"mode": 5})",
+          R"({"mode": null})",
+          R"({"mode": ["READWRITE"]})",
+          R"({"mode": {}})",
+          R"({"mode": true})"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_mode(iobuf::from(body));
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(parse_mode_test, trailing_content_after_object_is_error) {
+    // The mode body is exactly one object; content after the closing '}' is
+    // rejected, not ignored.
+    for (std::string_view body :
+         {R"({"mode": "READWRITE"} "more")",
+          R"({"mode": "READWRITE"}{})",
+          R"({"mode": "READWRITE"}garbage)",
+          R"({"mode": "READWRITE"},)"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_mode(iobuf::from(body));
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(parse_mode_test, trailing_whitespace_is_ok) {
+    auto res = co_await parse_mode(
+      iobuf::from("{\"mode\": \"READWRITE\"}  \n\t "));
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res->mode, registry_mode::read_write);
+}
+
+TEST_CORO(parse_mode_test, fragmented_input) {
+    // One byte per fragment forces the object structure and the mode value to
+    // span parser fragment boundaries.
+    auto res = co_await parse_mode(
+      fragmented_iobuf(R"({"mode": "READONLY_OVERRIDE"})", 1));
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res->mode, registry_mode::read_only_override);
+    ASSERT_EQ_CORO(res->raw, "READONLY_OVERRIDE");
+}
+
+TEST_CORO(parse_mode_test, malformed_or_truncated_is_error) {
+    // Missing close brace, missing value, unterminated string, an unclosed
+    // object after a complete pair, a dangling key at EOF, and non-JSON — every
+    // route ends in an error, never a partial result.
+    for (std::string_view body :
+         {"",
+          "{",
+          R"({"mode")",
+          R"({"mode":)",
+          R"({"mode": "READWRITE)",
+          R"({"mode": "READWRITE")",
+          R"({"x": 1, "mode")",
+          "not json"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_mode(iobuf::from(body));
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST(registry_mode_test, to_string_view_and_format) {
+    // The display/log form of every mode, including the open-enum `unknown`
+    // sentinel. The known arms are also hit via registry_mode_from_wire, but
+    // this pins the full contract and the format_to path.
+    EXPECT_EQ(to_string_view(registry_mode::read_write), "READWRITE");
+    EXPECT_EQ(to_string_view(registry_mode::read_only), "READONLY");
+    EXPECT_EQ(
+      to_string_view(registry_mode::read_only_override), "READONLY_OVERRIDE");
+    EXPECT_EQ(to_string_view(registry_mode::import), "IMPORT");
+    EXPECT_EQ(to_string_view(registry_mode::forward), "FORWARD");
+    EXPECT_EQ(to_string_view(registry_mode::unknown), "{unknown}");
+    // The fmt formatter (via format_to) mirrors to_string_view.
+    EXPECT_EQ(fmt::format("{}", registry_mode::forward), "FORWARD");
+    EXPECT_EQ(fmt::format("{}", registry_mode::unknown), "{unknown}");
+}
+
 TEST_CORO(parse_subject_versions_test, basic) {
     auto res = co_await parse_subject_versions(iobuf::from("[1, 2, 3]"));
     ASSERT_TRUE_CORO(res.has_value());

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
@@ -442,6 +442,185 @@ TEST(registry_mode_test, to_string_view_and_format) {
     EXPECT_EQ(fmt::format("{}", registry_mode::unknown), "{unknown}");
 }
 
+TEST_CORO(parse_config_test, compatibility_level_only) {
+    // Redpanda's server emits just compatibilityLevel; nothing is recorded as
+    // an unknown field.
+    auto res = co_await parse_config(
+      iobuf::from(R"({"compatibilityLevel": "BACKWARD"})"));
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res->level, registry_compatibility_level::backward);
+    ASSERT_EQ_CORO(res->raw, "BACKWARD");
+    ASSERT_TRUE_CORO(res->unknown_fields.empty());
+}
+
+TEST_CORO(parse_config_test, all_known_levels_map_to_enumerators) {
+    const std::pair<std::string_view, registry_compatibility_level> cases[] = {
+      {"NONE", registry_compatibility_level::none},
+      {"BACKWARD", registry_compatibility_level::backward},
+      {"BACKWARD_TRANSITIVE",
+       registry_compatibility_level::backward_transitive},
+      {"FORWARD", registry_compatibility_level::forward},
+      {"FORWARD_TRANSITIVE", registry_compatibility_level::forward_transitive},
+      {"FULL", registry_compatibility_level::full},
+      {"FULL_TRANSITIVE", registry_compatibility_level::full_transitive},
+    };
+    for (const auto& [wire, expected] : cases) {
+        SCOPED_TRACE(wire);
+        auto res = co_await parse_config(
+          iobuf::from(ssx::sformat(R"({{"compatibilityLevel": "{}"}})", wire)));
+        ASSERT_TRUE_CORO(res.has_value());
+        ASSERT_EQ_CORO(res->level, expected);
+        ASSERT_EQ_CORO(res->raw, ss::sstring{wire});
+    }
+}
+
+TEST_CORO(parse_config_test, unknown_level_is_open_enum) {
+    // An unrecognized level is tolerated, not rejected: it maps to `unknown`
+    // with the verbatim wire string preserved.
+    auto res = co_await parse_config(
+      iobuf::from(R"({"compatibilityLevel": "SIDEWAYS"})"));
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res->level, registry_compatibility_level::unknown);
+    ASSERT_EQ_CORO(res->raw, "SIDEWAYS");
+}
+
+TEST_CORO(parse_config_test, empty_level_is_unknown_not_error) {
+    // Shape is strict, value is open: a present-but-empty string maps to
+    // `unknown` (raw="") rather than failing.
+    auto res = co_await parse_config(
+      iobuf::from(R"({"compatibilityLevel": ""})"));
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res->level, registry_compatibility_level::unknown);
+    ASSERT_EQ_CORO(res->raw, "");
+}
+
+TEST_CORO(parse_config_test, records_unmodeled_fields) {
+    // A Confluent registry may return a rich object. Only compatibilityLevel is
+    // modeled; every other top-level field's name is recorded (in encounter
+    // order) and its value skipped, whatever its shape (scalar, object, null).
+    auto res = co_await parse_config(
+      iobuf::from(
+        R"({"compatibilityLevel": "FULL", "normalize": true, )"
+        R"("validateFields": false, )"
+        R"("defaultMetadata": {"properties": {"o": "a"}}, )"
+        R"("defaultRuleSet": null})"));
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res->level, registry_compatibility_level::full);
+    ASSERT_EQ_CORO(res->unknown_fields.size(), size_t{4});
+    ASSERT_EQ_CORO(res->unknown_fields[0], "normalize");
+    ASSERT_EQ_CORO(res->unknown_fields[1], "validateFields");
+    ASSERT_EQ_CORO(res->unknown_fields[2], "defaultMetadata");
+    ASSERT_EQ_CORO(res->unknown_fields[3], "defaultRuleSet");
+}
+
+TEST_CORO(parse_config_test, compatibility_level_need_not_come_first) {
+    auto res = co_await parse_config(
+      iobuf::from(R"({"normalize": true, "compatibilityLevel": "FORWARD"})"));
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res->level, registry_compatibility_level::forward);
+    ASSERT_EQ_CORO(res->unknown_fields.size(), size_t{1});
+    ASSERT_EQ_CORO(res->unknown_fields[0], "normalize");
+}
+
+TEST_CORO(parse_config_test, missing_compatibility_level_is_error) {
+    // compatibilityLevel is the one field a config response must carry.
+    for (std::string_view body : {R"({})", R"({"normalize": true})"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_config(iobuf::from(body));
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(parse_config_test, non_object_is_error) {
+    for (std::string_view body :
+         {R"(["BACKWARD"])", R"("BACKWARD")", "42", "null", "true"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_config(iobuf::from(body));
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(parse_config_test, non_string_compatibility_level_is_error) {
+    for (std::string_view body :
+         {R"({"compatibilityLevel": 5})",
+          R"({"compatibilityLevel": null})",
+          R"({"compatibilityLevel": ["BACKWARD"]})",
+          R"({"compatibilityLevel": {}})",
+          R"({"compatibilityLevel": true})"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_config(iobuf::from(body));
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(parse_config_test, trailing_content_after_object_is_error) {
+    for (std::string_view body :
+         {R"({"compatibilityLevel": "NONE"} "more")",
+          R"({"compatibilityLevel": "NONE"}{})",
+          R"({"compatibilityLevel": "NONE"}garbage)",
+          R"({"compatibilityLevel": "NONE"},)"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_config(iobuf::from(body));
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(parse_config_test, trailing_whitespace_is_ok) {
+    auto res = co_await parse_config(
+      iobuf::from("{\"compatibilityLevel\": \"FULL\"}  \n\t "));
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res->level, registry_compatibility_level::full);
+}
+
+TEST_CORO(parse_config_test, fragmented_input) {
+    // One byte per fragment forces the object structure, the level value, and
+    // an unmodeled field to span parser fragment boundaries.
+    auto res = co_await parse_config(fragmented_iobuf(
+      R"({"compatibilityLevel": "BACKWARD_TRANSITIVE", "normalize": true})",
+      1));
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(
+      res->level, registry_compatibility_level::backward_transitive);
+    ASSERT_EQ_CORO(res->raw, "BACKWARD_TRANSITIVE");
+    ASSERT_EQ_CORO(res->unknown_fields.size(), size_t{1});
+    ASSERT_EQ_CORO(res->unknown_fields[0], "normalize");
+}
+
+TEST_CORO(parse_config_test, malformed_or_truncated_is_error) {
+    for (std::string_view body :
+         {"",
+          "{",
+          R"({"compatibilityLevel")",
+          R"({"compatibilityLevel":)",
+          R"({"compatibilityLevel": "BACKWARD)",
+          R"({"compatibilityLevel": "BACKWARD")",
+          R"({"normalize": true, "compatibilityLevel")",
+          "not json"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_config(iobuf::from(body));
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST(registry_compatibility_level_test, to_string_view_and_format) {
+    // The display/log form of every level, including the open-enum `unknown`
+    // sentinel. Known arms are also hit via
+    // registry_compatibility_level_from_wire, but this pins the full contract
+    // and the format_to path.
+    using cl = registry_compatibility_level;
+    EXPECT_EQ(to_string_view(cl::none), "NONE");
+    EXPECT_EQ(to_string_view(cl::backward), "BACKWARD");
+    EXPECT_EQ(to_string_view(cl::backward_transitive), "BACKWARD_TRANSITIVE");
+    EXPECT_EQ(to_string_view(cl::forward), "FORWARD");
+    EXPECT_EQ(to_string_view(cl::forward_transitive), "FORWARD_TRANSITIVE");
+    EXPECT_EQ(to_string_view(cl::full), "FULL");
+    EXPECT_EQ(to_string_view(cl::full_transitive), "FULL_TRANSITIVE");
+    EXPECT_EQ(to_string_view(cl::unknown), "{unknown}");
+    // The fmt formatter (via format_to) mirrors to_string_view.
+    EXPECT_EQ(fmt::format("{}", cl::full_transitive), "FULL_TRANSITIVE");
+    EXPECT_EQ(fmt::format("{}", cl::unknown), "{unknown}");
+}
+
 TEST_CORO(parse_subject_versions_test, basic) {
     auto res = co_await parse_subject_versions(iobuf::from("[1, 2, 3]"));
     ASSERT_TRUE_CORO(res.has_value());

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
@@ -184,6 +184,106 @@ TEST_CORO(parse_subjects_test, round_trip) {
     }
 }
 
+TEST_CORO(parse_contexts_test, basic) {
+    // The default context (".") sorts first, followed by named, dot-prefixed
+    // contexts. Each string is wrapped verbatim; order is preserved.
+    auto res = co_await parse_contexts(
+      iobuf::from(R"([".", ".dev", ".prod-eu"])"));
+    ASSERT_TRUE_CORO(res.has_value());
+    const auto& c = res.value();
+    ASSERT_EQ_CORO(c.size(), size_t{3});
+    ASSERT_EQ_CORO(c[0], default_context);
+    ASSERT_EQ_CORO(c[1], context{".dev"});
+    ASSERT_EQ_CORO(c[2], context{".prod-eu"});
+}
+
+TEST_CORO(parse_contexts_test, default_only) {
+    // A brand-new/empty registry still reports the default context.
+    auto res = co_await parse_contexts(iobuf::from(R"(["."])"));
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res.value().size(), size_t{1});
+    ASSERT_EQ_CORO(res.value()[0], default_context);
+}
+
+TEST_CORO(parse_contexts_test, empty_array) {
+    // A contextPrefix that matches nothing yields []; the parser accepts it
+    // even though a live registry always has at least the default context.
+    auto res = co_await parse_contexts(iobuf::from("[]"));
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_TRUE_CORO(res.value().empty());
+}
+
+TEST_CORO(parse_contexts_test, colon_form_taken_verbatim) {
+    // Contexts are never colon-qualified in this response; a ":.ctx:"-looking
+    // element is not split, it is wrapped verbatim as a context.
+    auto res = co_await parse_contexts(iobuf::from(R"([":.ctx:"])"));
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res.value().size(), size_t{1});
+    ASSERT_EQ_CORO(res.value()[0], context{":.ctx:"});
+}
+
+TEST_CORO(parse_contexts_test, fragmented_input) {
+    // One byte per fragment: forces context names and the array structure to
+    // span fragment boundaries.
+    constexpr std::string_view body = R"([".", ".dev", ".prod-eu"])";
+    auto res = co_await parse_contexts(fragmented_iobuf(body, 1));
+    ASSERT_TRUE_CORO(res.has_value());
+    const auto& c = res.value();
+    ASSERT_EQ_CORO(c.size(), size_t{3});
+    ASSERT_EQ_CORO(c[0], default_context);
+    ASSERT_EQ_CORO(c[1], context{".dev"});
+    ASSERT_EQ_CORO(c[2], context{".prod-eu"});
+}
+
+TEST_CORO(parse_contexts_test, not_an_array_is_error) {
+    for (std::string_view body :
+         {R"({})", R"("just-a-string")", "42", "null", "true"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_contexts(iobuf::from(body));
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(parse_contexts_test, non_string_element_is_error) {
+    for (std::string_view body :
+         {R"([".", 42])",
+          R"([".", null])",
+          R"([".", {}])",
+          R"([".", ["x"]])"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_contexts(iobuf::from(body));
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(parse_contexts_test, trailing_content_after_array_is_error) {
+    // The contexts body is exactly one array; content after the closing ']' is
+    // rejected, not ignored.
+    for (std::string_view body :
+         {R"(["."] "more")", R"(["."][])", R"(["."]garbage)", R"(["."],)"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_contexts(iobuf::from(body));
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(parse_contexts_test, trailing_whitespace_is_ok) {
+    auto res = co_await parse_contexts(iobuf::from("[\".\"]  \n\t "));
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res.value().size(), size_t{1});
+    ASSERT_EQ_CORO(res.value()[0], default_context);
+}
+
+TEST_CORO(parse_contexts_test, malformed_or_truncated_is_error) {
+    // Missing close bracket, dangling comma, unterminated string, non-JSON.
+    for (std::string_view body :
+         {"", "[", "[\".\"", "[\".\",", "[\".unterminated", "not json"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_contexts(iobuf::from(body));
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
 TEST_CORO(parse_subject_versions_test, basic) {
     auto res = co_await parse_subject_versions(iobuf::from("[1, 2, 3]"));
     ASSERT_TRUE_CORO(res.has_value());

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
@@ -621,6 +621,176 @@ TEST(registry_compatibility_level_test, to_string_view_and_format) {
     EXPECT_EQ(fmt::format("{}", cl::unknown), "{unknown}");
 }
 
+TEST_CORO(parse_schema_id_subject_versions_test, basic) {
+    auto res = co_await parse_schema_id_subject_versions(
+      iobuf::from(
+        R"([{"subject": "s1", "version": 1}, {"subject": "s2", "version": 3}])"),
+      qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(res.has_value());
+    const auto& v = res.value();
+    ASSERT_EQ_CORO(v.size(), size_t{2});
+    ASSERT_EQ_CORO(v[0].sub, context_subject(default_context, subject{"s1"}));
+    ASSERT_EQ_CORO(v[0].version, schema_version{1});
+    ASSERT_EQ_CORO(v[1].sub, context_subject(default_context, subject{"s2"}));
+    ASSERT_EQ_CORO(v[1].version, schema_version{3});
+}
+
+TEST_CORO(parse_schema_id_subject_versions_test, qualified_subject) {
+    // A non-default context comes back context-qualified and is split under the
+    // qualified policy, exactly like parse_subjects.
+    auto res = co_await parse_schema_id_subject_versions(
+      iobuf::from(R"([{"subject": ":.ctx:orders", "version": 2}])"),
+      qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res.value().size(), size_t{1});
+    ASSERT_EQ_CORO(
+      res.value()[0].sub, context_subject(context{".ctx"}, subject{"orders"}));
+    ASSERT_EQ_CORO(res.value()[0].version, schema_version{2});
+}
+
+TEST_CORO(
+  parse_schema_id_subject_versions_test, qualified_disabled_is_literal) {
+    auto res = co_await parse_schema_id_subject_versions(
+      iobuf::from(R"([{"subject": ":.ctx:orders", "version": 2}])"),
+      qualified_subjects_enabled::no);
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(
+      res.value()[0].sub,
+      context_subject(default_context, subject{":.ctx:orders"}));
+}
+
+TEST_CORO(parse_schema_id_subject_versions_test, empty_array) {
+    // A valid outcome: the id exists but no pair matches the filters.
+    auto res = co_await parse_schema_id_subject_versions(
+      iobuf::from("[]"), qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_TRUE_CORO(res.value().empty());
+}
+
+TEST_CORO(parse_schema_id_subject_versions_test, unknown_keys_are_skipped) {
+    // Extra keys (in any order) are tolerated; subject/version still parse.
+    auto res = co_await parse_schema_id_subject_versions(
+      iobuf::from(
+        R"([{"guid": "g", "version": 5, "subject": "s", "ruleSet": {"x": [1]}}])"),
+      qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res.value().size(), size_t{1});
+    ASSERT_EQ_CORO(
+      res.value()[0].sub, context_subject(default_context, subject{"s"}));
+    ASSERT_EQ_CORO(res.value()[0].version, schema_version{5});
+}
+
+TEST_CORO(parse_schema_id_subject_versions_test, missing_field_is_error) {
+    // Both subject and version must be present.
+    for (std::string_view body :
+         {R"([{"subject": "s"}])", R"([{"version": 1}])", R"([{}])"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_schema_id_subject_versions(
+          iobuf::from(body), qualified_subjects_enabled::yes);
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(parse_schema_id_subject_versions_test, not_an_array_is_error) {
+    for (std::string_view body :
+         {R"({"subject": "s", "version": 1})", R"("s")", "42", "null"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_schema_id_subject_versions(
+          iobuf::from(body), qualified_subjects_enabled::yes);
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(parse_schema_id_subject_versions_test, non_object_element_is_error) {
+    for (std::string_view body :
+         {R"(["s"])", R"([1])", R"([{"subject": "s", "version": 1}, 2])"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_schema_id_subject_versions(
+          iobuf::from(body), qualified_subjects_enabled::yes);
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(parse_schema_id_subject_versions_test, wrong_typed_field_is_error) {
+    for (std::string_view body :
+         {R"([{"subject": 5, "version": 1}])",
+          R"([{"subject": "s", "version": "1"}])",
+          R"([{"subject": "s", "version": 1.5}])"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_schema_id_subject_versions(
+          iobuf::from(body), qualified_subjects_enabled::yes);
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(
+  parse_schema_id_subject_versions_test, out_of_range_version_is_error) {
+    // version must be >= 1.
+    for (std::string_view body :
+         {R"([{"subject": "s", "version": 0}])",
+          R"([{"subject": "s", "version": -1}])"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_schema_id_subject_versions(
+          iobuf::from(body), qualified_subjects_enabled::yes);
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(parse_schema_id_subject_versions_test, trailing_content_is_error) {
+    for (std::string_view body :
+         {R"([{"subject": "s", "version": 1}] "x")",
+          R"([{"subject": "s", "version": 1}]{})",
+          R"([{"subject": "s", "version": 1}],)"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_schema_id_subject_versions(
+          iobuf::from(body), qualified_subjects_enabled::yes);
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
+TEST_CORO(parse_schema_id_subject_versions_test, trailing_whitespace_is_ok) {
+    auto res = co_await parse_schema_id_subject_versions(
+      iobuf::from("[{\"subject\": \"s\", \"version\": 1}]  \n\t "),
+      qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res.value().size(), size_t{1});
+}
+
+TEST_CORO(parse_schema_id_subject_versions_test, fragmented_input) {
+    // One byte per fragment forces the objects, their keys, and the array
+    // structure to span parser fragment boundaries.
+    auto res = co_await parse_schema_id_subject_versions(
+      fragmented_iobuf(
+        R"([{"subject": ":.ctx:orders", "version": 2}, {"subject": "s", "version": 1}])",
+        1),
+      qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(res.has_value());
+    const auto& v = res.value();
+    ASSERT_EQ_CORO(v.size(), size_t{2});
+    ASSERT_EQ_CORO(
+      v[0].sub, context_subject(context{".ctx"}, subject{"orders"}));
+    ASSERT_EQ_CORO(v[0].version, schema_version{2});
+    ASSERT_EQ_CORO(v[1].sub, context_subject(default_context, subject{"s"}));
+    ASSERT_EQ_CORO(v[1].version, schema_version{1});
+}
+
+TEST_CORO(
+  parse_schema_id_subject_versions_test, malformed_or_truncated_is_error) {
+    for (std::string_view body :
+         {"",
+          "[",
+          R"([{)",
+          R"([{"subject")",
+          R"([{"subject": "s", "version": 1)",
+          R"([{"subject": "s", "version": 1})",
+          "not json"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_schema_id_subject_versions(
+          iobuf::from(body), qualified_subjects_enabled::yes);
+        ASSERT_FALSE_CORO(res.has_value());
+    }
+}
+
 TEST_CORO(parse_subject_versions_test, basic) {
     auto res = co_await parse_subject_versions(iobuf::from("[1, 2, 3]"));
     ASSERT_TRUE_CORO(res.has_value());

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
@@ -726,6 +726,25 @@ TEST_CORO(parse_schema_id_subject_versions_test, non_object_element_is_error) {
     }
 }
 
+TEST_CORO(
+  parse_schema_id_subject_versions_test, non_key_token_in_object_is_error) {
+    // An object member that opens with a non-key token (a bare value) is
+    // rejected by an explicit shape check rather than by letting value_string()
+    // throw and relying on the exception firewall.
+    auto res = co_await parse_schema_id_subject_versions(
+      iobuf::from(R"([{true}])"), qualified_subjects_enabled::yes);
+    ASSERT_FALSE_CORO(res.has_value());
+}
+
+TEST_CORO(
+  parse_schema_id_subject_versions_test, unknown_key_missing_value_is_error) {
+    // An unmodeled key with no value faults the skip path; the exception
+    // firewall reports it as a parse_error rather than letting it escape.
+    auto res = co_await parse_schema_id_subject_versions(
+      iobuf::from(R"([{"x"}])"), qualified_subjects_enabled::yes);
+    ASSERT_FALSE_CORO(res.has_value());
+}
+
 TEST_CORO(parse_schema_id_subject_versions_test, wrong_typed_field_is_error) {
     for (std::string_view body :
          {R"([{"subject": 5, "version": 1}])",
@@ -1164,7 +1183,10 @@ TEST_CORO(parse_subject_version_test, rejects_unrepresentable) {
           R"({"references":[{"name":42}]})",    // reference name wrong type
           R"({"references":[{"subject":42}]})", // reference subject wrong type
           R"({"references":[{"version":0}]})", // reference version out of range
-          R"({"references":[{)", // truncated reference: parser throws, caught
+          R"({"references":[{true}]})",        // reference: non-key token
+          R"({"references":[{)", // reference: missing key (truncated)
+          R"({"metadata":{)",    // truncated metadata (parser throws, firewall
+                                 // catch)
           "[1,2,3]",             // not an object
           R"({"subject":"r")",   // truncated
           R"({"subject":"r"}garbage)", // trailing content after }

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
@@ -426,6 +426,14 @@ TEST_CORO(parse_mode_test, malformed_or_truncated_is_error) {
     }
 }
 
+TEST_CORO(parse_mode_test, unknown_field_missing_value_is_error) {
+    // An unmodeled field whose value is absent (a truncated object) faults the
+    // skip-unknown path; the exception firewall reports it as a parse_error
+    // rather than letting the parser exception escape.
+    auto res = co_await parse_mode(iobuf::from(R"({"other"})"));
+    ASSERT_FALSE_CORO(res.has_value());
+}
+
 TEST(registry_mode_test, to_string_view_and_format) {
     // The display/log form of every mode, including the open-enum `unknown`
     // sentinel. The known arms are also hit via registry_mode_from_wire, but
@@ -600,6 +608,13 @@ TEST_CORO(parse_config_test, malformed_or_truncated_is_error) {
         auto res = co_await parse_config(iobuf::from(body));
         ASSERT_FALSE_CORO(res.has_value());
     }
+}
+
+TEST_CORO(parse_config_test, unknown_field_missing_value_is_error) {
+    // As parse_mode: an unmodeled field with no value trips the skip path; the
+    // firewall turns the parser exception into a parse_error.
+    auto res = co_await parse_config(iobuf::from(R"({"other"})"));
+    ASSERT_FALSE_CORO(res.has_value());
 }
 
 TEST(registry_compatibility_level_test, to_string_view_and_format) {
@@ -1142,8 +1157,16 @@ TEST_CORO(parse_subject_version_test, rejects_unrepresentable) {
           R"({"metadata":{"properties":5}})",    // properties not an object
           R"({"metadata":{"properties":{"k":["x"]}}})", // value not a scalar
           R"({"metadata":{"properties":{"k":null}}})",  // value null
-          "[1,2,3]",                                    // not an object
-          R"({"subject":"r")",                          // truncated
+          R"({"subject":42})",                          // subject wrong type
+          R"({"schema":42,"subject":"r"})",             // schema wrong type
+          R"({"schemaType":42,"subject":"r"})",         // schemaType wrong type
+          R"({"references":[42]})",             // reference not an object
+          R"({"references":[{"name":42}]})",    // reference name wrong type
+          R"({"references":[{"subject":42}]})", // reference subject wrong type
+          R"({"references":[{"version":0}]})", // reference version out of range
+          R"({"references":[{)", // truncated reference: parser throws, caught
+          "[1,2,3]",             // not an object
+          R"({"subject":"r")",   // truncated
           R"({"subject":"r"}garbage)", // trailing content after }
           "not json"}) {
         SCOPED_TRACE(body);
@@ -1222,6 +1245,59 @@ TEST_CORO(parse_error_body_test, trailing_content_is_nullopt) {
       iobuf::from("{\"error_code\": 40401}  \n"));
     ASSERT_TRUE_CORO(ok.has_value());
     ASSERT_EQ_CORO(ok->error_code, 40401);
+}
+
+TEST_CORO(parse_subject_version_test, reference_unknown_keys_skipped) {
+    // A reference may carry keys the client does not model; they are skipped
+    // (never rejected, never recorded in unknown_fields) and the modeled
+    // name/subject/version are still recovered.
+    auto res = co_await parse_subject_version(
+      iobuf::from(
+        R"({"subject":"r","version":1,"references":)"
+        R"([{"extra":{"nested":true},"name":"n","subject":"s","version":2}]})"),
+      qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_TRUE_CORO(res->unknown_fields.empty());
+    const auto& refs = res->schema.schema.def().refs();
+    ASSERT_EQ_CORO(refs.size(), size_t{1});
+    ASSERT_EQ_CORO(refs[0].name, "n");
+    ASSERT_EQ_CORO(refs[0].version, schema_version{2});
+}
+
+TEST_CORO(parse_error_body_test, non_key_token_is_nullopt) {
+    // After '{', a token that is not an object key means a malformed body:
+    // tolerantly nullopt, not an error.
+    auto res = co_await parse_error_body(iobuf::from(R"({true})"));
+    ASSERT_FALSE_CORO(res.has_value());
+}
+
+TEST_CORO(parse_error_body_test, error_code_out_of_int32_range_is_nullopt) {
+    // error_code must fit int32; a value outside the range is not a usable
+    // code, so it is dropped and the body (carrying no other code) yields
+    // nullopt.
+    auto res = co_await parse_error_body(
+      iobuf::from(R"({"error_code": 9999999999})"));
+    ASSERT_FALSE_CORO(res.has_value());
+}
+
+TEST_CORO(parse_error_body_test, non_string_message_ignored) {
+    // A present-but-wrong-typed message is skipped like any unmodeled field;
+    // the error_code is still recovered and message stays empty.
+    auto res = co_await parse_error_body(
+      iobuf::from(R"({"error_code": 40401, "message": 42})"));
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res->error_code, 40401);
+    ASSERT_EQ_CORO(res->message, "");
+}
+
+TEST_CORO(parse_error_body_test, missing_value_is_nullopt) {
+    // A key with no value makes the parser throw while skipping; the tolerant
+    // firewall turns that into nullopt rather than propagating.
+    for (std::string_view body : {R"({"error_code"})", R"({"unknown"})"}) {
+        SCOPED_TRACE(body);
+        auto res = co_await parse_error_body(iobuf::from(body));
+        ASSERT_FALSE_CORO(res.has_value());
+    }
 }
 
 } // namespace pandaproxy::schema_registry::rest_client

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/retry_policy_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/retry_policy_test.cc
@@ -11,6 +11,8 @@
 
 #include "pandaproxy/schema_registry/rest_client/retry_policy.h"
 
+#include <seastar/core/future.hh>
+
 #include <gtest/gtest.h>
 
 namespace r = pandaproxy::schema_registry::rest_client;
@@ -68,9 +70,21 @@ TEST(default_retry_policy, boost_system_errors) {
     auto retriable = throw_and_catch(
       boost::system::system_error{boost::beast::http::error::end_of_stream});
     ASSERT_EQ(retriable.kind, r::error_kind::network_error);
+    // A partial_message (peer closed mid-response) is the other treated-as-
+    // retriable beast error, distinct from end_of_stream.
+    auto retriable_partial = throw_and_catch(
+      boost::system::system_error{boost::beast::http::error::partial_message});
+    ASSERT_EQ(retriable_partial.kind, r::error_kind::network_error);
     auto permanent_failure = throw_and_catch(
       boost::system::system_error{boost::beast::http::error::bad_alloc});
     ASSERT_EQ(permanent_failure.kind, r::error_kind::permanent_failure);
+}
+
+TEST(default_retry_policy, timed_out_error_is_retriable) {
+    // A seastar timeout (e.g. the per-request deadline elapsing) is retriable
+    // as a timeout, distinct from the network_error/permanent classes above.
+    auto result = throw_and_catch(ss::timed_out_error{});
+    ASSERT_EQ(result.kind, r::error_kind::timeout);
 }
 
 TEST(default_retry_policy, system_errors) {


### PR DESCRIPTION
https://redpandadata.atlassian.net/browse/CORE-16755

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
