### PR TITLE
[CORE-15451] cluster_link/replication: retry deferred prefix truncation on commit

### DIFF
--- a/src/v/cluster_link/replication/partition_replicator.cc
+++ b/src/v/cluster_link/replication/partition_replicator.cc
@@ -121,6 +121,9 @@ ss::future<bool> partition_replicator::handle_replication_result(
         // source to sink
         // We only intend to backoff on consecutive failures.
         _backoff_policy.reset();
+        // The shadow high watermark just advanced, so a prefix truncation that
+        // was deferred waiting for the shadow to catch up can now proceed.
+        co_await maybe_synchronize_start_offset();
         co_return true;
     } catch (...) {
         auto eptr = std::current_exception();

--- a/src/v/cluster_link/replication/tests/partition_replicator_tests.cc
+++ b/src/v/cluster_link/replication/tests/partition_replicator_tests.cc
@@ -408,4 +408,22 @@ TEST_F_CORO(PartitionReplicatorFixture, TestNoStartOffsetOvershootOnResume) {
       5s, [&] { return _sink->start_offset() == kafka::offset(50); });
 }
 
+// A shadow partition that catches up to a prefix-trimmed source in a single
+// batch must still sync its start offset. When the batch is fetched the shadow
+// HWM is still behind the trim point, so the truncation is deferred; and once
+// the batch is replicated no further source data arrives to drive another
+// fetch. The truncation must therefore be retried when the batch commits.
+TEST_F_CORO(PartitionReplicatorFixture, TestTrimSyncAfterSingleCatchUpFetch) {
+    // Source is prefix-trimmed to 5 but still has a moving tail (lso > 5), so
+    // truncation stays deferred until the shadow catches up to the trim point.
+    _source->set_reported_start_offset(kafka::offset(5));
+
+    // A single batch [0, 9] catches the shadow up past the trim point. After it
+    // commits the source is idle, so the commit itself must retry the sync.
+    co_await push_data();
+
+    RPTEST_REQUIRE_EVENTUALLY_CORO(
+      5s, [&] { return _sink->start_offset() == kafka::offset(5); });
+}
+
 } // namespace cluster_link::replication


### PR DESCRIPTION
When a source partition is prefix-trimmed, the shadow partition has to truncate to the same start offset. maybe_synchronize_start_offset() defers that while the shadow hasn't replicated up to the source start offset yet and (before this commit) relied on the next fetch_next() to retry.

It's possible that after deferring the prefix-trim, we replicate up to the source HWM so there isn't a next fetch_next(), and so our start offset never proceeds.

This commit retries the synchronization when a batch commits, which is exactly when the shadow high watermark advances past the offset the truncation was waiting on, so it no longer depends on new source data arriving.

This attempts to fix
ShadowLinkingReplicationTests.test_auto_prefix_trimming which is quite flaky.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Bug Fixes

* Fixes an issue where cluster linking would not replicate the partition start offset.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
