### PR TITLE
tests: Bump aio_limit_test timeout

### DIFF
--- a/tests/rptest/tests/aio_limit_test.py
+++ b/tests/rptest/tests/aio_limit_test.py
@@ -46,4 +46,4 @@ class AioLimitTest(RedpandaTest):
         )
         producer.start()
         # RP shouldn't crash and still be able to handle the low rate
-        producer.wait(timeout_sec=180)
+        producer.wait(timeout_sec=300)


### PR DESCRIPTION
Locally this finishes a lot faster but it seems it's very susceptible to the environment.

From failed runs I can't see why it wouldn't finish with more time.

Bump the timeout.

Fixes CORE-15282

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes


* none
