### PR TITLE
[CORE-16405] cl/test: uncap target consumer reads for compacted syncs

### DIFF
--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -232,6 +232,13 @@ class ClusterLinkingProgressVerifier:
         self.consumer_properties: dict[str, Any] = (
             consumer_properties if consumer_properties else {}
         )
+        # When using compaction, the completion criteria examines per-partition
+        # offsets, which may be at odds with having a max_msgs set.
+        assert not (self.use_compaction and "max_msgs" in self.consumer_properties), (
+            "max_msgs is incompatible with use_compaction: completion requires "
+            "per-partition offset parity, which a bounded read may never reach. "
+            "Let the consumer tail (continuous) instead."
+        )
         self.timeout_sec = timeout_sec
         self.validate_number_of_messages_on_target = (
             validate_number_of_messages_on_target
@@ -275,12 +282,14 @@ class ClusterLinkingProgressVerifier:
         )
         self.source_consumer.start(clean=False)
 
+        # NOTE: when using compaction, the completion criteria examines
+        # per-partition offsets, which is at odds with having a max_msgs.
         self.target_consumer = KgoVerifierConsumerGroupConsumer(
             context=self.test_context,
             redpanda=self.target_cluster.service,
             topic=self.topic,
             msg_size=self.msg_size,
-            max_msgs=self.msg_count,
+            max_msgs=None if self.use_compaction else self.msg_count,
             readers=readers,
             use_transactions=self.use_transactions,
             group_name=f"target-cg-{self._instance_id}",


### PR DESCRIPTION
The target consumer carried a fixed read-count cap (max_msgs=msg_count) while the source consumer did not. Under compaction, workload completion is gated on per-partition offset parity (max_offsets_match), which a bounded read cannot reach: rebalance re-reads spend the budget, and a partition whose leadership churns has its tail produced and replicated late, so the consumer stops below max_offsets_produced and the workload never finishes reading to the HWM despite replication finishing.

This commit drops the cap on the compacted path so the target consumer tails to parity like the source consumer; the non-compacted path keeps its count-based cap unchanged.

To avoid this in the future, we also now reject max_msgs with use_compaction up front so the incompatibility fails fast instead of stalling for the progress timeout.

This attempts to fix ShadowLinkingRandomOpsTest.test_node_operations, which is quite flaky.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
