### PR TITLE
ct/l1/metastore: add configurations for RPC retries

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/BUILD
@@ -176,8 +176,14 @@ redpanda_cc_library(
 
 redpanda_cc_library(
     name = "retry",
+    srcs = [
+        "retry.cc",
+    ],
     hdrs = [
         "retry.h",
+    ],
+    implementation_deps = [
+        "//src/v/config",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/v/cloud_topics/level_one/metastore/leader_router.cc
+++ b/src/v/cloud_topics/level_one/metastore/leader_router.cc
@@ -16,6 +16,7 @@
 #include "cluster/metadata_cache.h"
 #include "cluster/partition_leaders_table.h"
 #include "cluster/shard_table.h"
+#include "config/configuration.h"
 #include "hashing/murmur.h"
 #include "model/namespace.h"
 #include "resource_mgmt/cpu_scheduling.h"
@@ -250,13 +251,16 @@ requires requires(
 ss::future<typename req_t::resp_t>
 leader_router::remote_dispatch(req_t request, model::node_id leader_id) {
     using resp_t = req_t::resp_t;
+    auto rpc_timeout
+      = config::shard_local_cfg().cloud_topics_metastore_rpc_timeout_ms();
     auto res = co_await _connection_cache->local()
                  .with_node_client<proto_t>(
                    _self,
                    ss::this_shard_id(),
                    leader_id,
                    rpc_timeout,
-                   [request = std::move(request)](proto_t proto) mutable {
+                   [request = std::move(request),
+                    rpc_timeout](proto_t proto) mutable {
                        return (proto.*Func)(
                          std::move(request),
                          ::rpc::client_opts{

--- a/src/v/cloud_topics/level_one/metastore/leader_router.h
+++ b/src/v/cloud_topics/level_one/metastore/leader_router.h
@@ -134,8 +134,6 @@ private:
     using proto_t = cloud_topics::l1::rpc::impl::l1_rpc_client_protocol;
     using client = cloud_topics::l1::rpc::impl::l1_rpc_client_protocol;
 
-    static constexpr std::chrono::seconds rpc_timeout{5};
-
     // utilities for boiler plate RPC code.
 
     template<auto Func, typename req_t>

--- a/src/v/cloud_topics/level_one/metastore/retry.cc
+++ b/src/v/cloud_topics/level_one/metastore/retry.cc
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "cloud_topics/level_one/metastore/retry.h"
+
+#include "config/configuration.h"
+
+#include <seastar/core/lowres_clock.hh>
+
+namespace cloud_topics::l1 {
+
+retry_chain_node make_default_metastore_rtc(ss::abort_source& as) {
+    return {
+      as,
+      ss::lowres_clock::now()
+        + config::shard_local_cfg().cloud_topics_metastore_retry_timeout_ms(),
+      default_metastore_retry_backoff};
+}
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/retry.h
+++ b/src/v/cloud_topics/level_one/metastore/retry.h
@@ -24,15 +24,11 @@ namespace cloud_topics::l1 {
 
 using namespace std::chrono_literals;
 
-static constexpr auto default_metastore_retry_timeout = 5s;
 static constexpr auto default_metastore_retry_backoff = 100ms;
 
-inline retry_chain_node make_default_metastore_rtc(ss::abort_source& as) {
-    return {
-      as,
-      ss::lowres_clock::now() + default_metastore_retry_timeout,
-      default_metastore_retry_backoff};
-}
+/// Build a retry_chain_node whose overall deadline is driven by the
+/// cloud_topics_metastore_retry_timeout_ms cluster config property.
+retry_chain_node make_default_metastore_rtc(ss::abort_source& as);
 
 template<typename Func>
 concept metastore_operation = requires(Func f) {

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -5073,6 +5073,14 @@ configuration::configuration()
       "behind and writes are being throttled.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       5min)
+  , cloud_topics_metastore_rpc_timeout_ms(
+      *this,
+      "cloud_topics_metastore_rpc_timeout_ms",
+      "Timeout for a single L1 metastore RPC to the metastore partition "
+      "leader. Bounds one attempt; the overall operation may retry until "
+      "cloud_topics_metastore_retry_timeout_ms elapses.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      30s)
   , cloud_topics_metastore_block_cache_size(
       *this,
       "cloud_topics_metastore_block_cache_size",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -5081,6 +5081,14 @@ configuration::configuration()
       "cloud_topics_metastore_retry_timeout_ms elapses.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       30s)
+  , cloud_topics_metastore_retry_timeout_ms(
+      *this,
+      "cloud_topics_metastore_retry_timeout_ms",
+      "Overall deadline for retrying an L1 metastore operation on transport "
+      "errors. To allow more than one attempt, keep this larger than "
+      "cloud_topics_metastore_rpc_timeout_ms.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      90s)
   , cloud_topics_metastore_block_cache_size(
       *this,
       "cloud_topics_metastore_block_cache_size",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -853,6 +853,7 @@ public:
     property<std::chrono::milliseconds>
       cloud_topics_metastore_lsm_apply_timeout_ms;
     property<std::chrono::milliseconds> cloud_topics_metastore_rpc_timeout_ms;
+    property<std::chrono::milliseconds> cloud_topics_metastore_retry_timeout_ms;
     bounded_property<size_t> cloud_topics_metastore_block_cache_size;
     bounded_property<size_t> cloud_topics_metastore_write_buffer_size;
     bounded_property<uint32_t> cloud_topics_metastore_max_pre_open_fibers;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -852,6 +852,7 @@ public:
       cloud_topics_metastore_replication_timeout_ms;
     property<std::chrono::milliseconds>
       cloud_topics_metastore_lsm_apply_timeout_ms;
+    property<std::chrono::milliseconds> cloud_topics_metastore_rpc_timeout_ms;
     bounded_property<size_t> cloud_topics_metastore_block_cache_size;
     bounded_property<size_t> cloud_topics_metastore_write_buffer_size;
     bounded_property<uint32_t> cloud_topics_metastore_max_pre_open_fibers;


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
In a cluster with heavy load and a somewhat slow metastore, I would see a modest number of timeouts coming from metastore RPCs. The default RPC timeout of 5s could sometimes be hit, and this would only lead to more load on the metastore, because we would retry. Bumps the RPC timeout to 30s and the retry timeout to 90s so that at least a retry would wait 30s before retrying an RPC.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
