### PR TITLE
[v25.2.x] dl/coordinator: add default formatter for errc

### DIFF
--- a/src/v/datalake/coordinator/types.cc
+++ b/src/v/datalake/coordinator/types.cc
@@ -46,6 +46,9 @@ std::ostream& operator<<(std::ostream& o, const errc& errc) {
     case errc::failed:
         o << "errc::failed";
         break;
+    default:
+        fmt::print(o, "errc::unknown({})", static_cast<int16_t>(errc));
+        break;
     }
     return o;
 }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31003

- Command: git cherry-pick -x a9b2926053
- Commits backported: 1
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-31003-v25.2.x-1783022846

## Conflict details

- a9b2926053 (src/v/datalake/coordinator/types.h): dev migrated `errc` formatting to an inline `format_to` in the header, but v25.2.x still declares `operator<<` in the header and implements it in `types.cc`. Kept the target branch's `operator<<` declaration in the header and applied the commit's intent — an `errc::unknown(N)` fallback for out-of-range wire-deserialized values — as a `default:` case in the `operator<<` switch in `src/v/datalake/coordinator/types.cc`.
