### PR TITLE
[v26.1.x] dl/coordinator: add default formatter for errc

### DIFF
--- a/src/v/datalake/coordinator/types.cc
+++ b/src/v/datalake/coordinator/types.cc
@@ -46,6 +46,9 @@ std::ostream& operator<<(std::ostream& o, const errc& errc) {
     case errc::failed:
         o << "errc::failed";
         break;
+    default:
+        fmt::print(o, "errc::unknown({})", static_cast<int16_t>(errc));
+        break;
     }
     return o;
 }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31003

- Command: git cherry-pick -x a9b2926053
- Commits backported: 1
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-31003-v26.1.x-1783022851

## Conflict details

- a9b2926053 (src/v/datalake/coordinator/types.h): The source PR modifies a
  `format_to(errc, ...)` helper, but v26.1.x has not adopted the `format_to`
  migration and still formats `errc` via `std::ostream& operator<<`. Kept the
  target branch's `operator<<` declaration in types.h and adapted the PR's
  intent — printing a fallback string for unknown/future numeric errc values
  received over the wire — by adding a `default:` case to the `operator<<`
  definition in src/v/datalake/coordinator/types.cc.
