### PR TITLE
[v25.3.x] dl/coordinator: add default formatter for errc

### DIFF
--- a/src/v/datalake/coordinator/types.cc
+++ b/src/v/datalake/coordinator/types.cc
@@ -17,37 +17,27 @@ namespace datalake::coordinator {
 std::ostream& operator<<(std::ostream& o, const errc& errc) {
     switch (errc) {
     case errc::ok:
-        o << "errc::ok";
-        break;
+        return o << "errc::ok";
     case errc::coordinator_topic_not_exists:
-        o << "errc::coordinator_topic_not_exists";
-        break;
+        return o << "errc::coordinator_topic_not_exists";
     case errc::not_leader:
-        o << "errc::not_leader";
-        break;
+        return o << "errc::not_leader";
     case errc::timeout:
-        o << "errc::timeout";
-        break;
+        return o << "errc::timeout";
     case errc::fenced:
-        o << "errc::fenced";
-        break;
+        return o << "errc::fenced";
     case errc::stale:
-        o << "errc::stale";
-        break;
+        return o << "errc::stale";
     case errc::concurrent_requests:
-        o << "errc::concurrent_requests";
-        break;
+        return o << "errc::concurrent_requests";
     case errc::revision_mismatch:
-        o << "errc::revision_mismatch";
-        break;
+        return o << "errc::revision_mismatch";
     case errc::incompatible_schema:
-        o << "errc::incompatible_schema";
-        break;
+        return o << "errc::incompatible_schema";
     case errc::failed:
-        o << "errc::failed";
-        break;
+        return o << "errc::failed";
     }
-    return o;
+    return o << fmt::format("errc::unknown({})", static_cast<int16_t>(errc));
 }
 
 std::ostream& operator<<(std::ostream& o, const ensure_table_exists_reply& r) {


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31003

- Command: git cherry-pick -x a9b2926053
- Commits backported: 1
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-31003-v25.3.x-1783022853

## Conflict details

- a9b2926053 (src/v/datalake/coordinator/types.h, src/v/datalake/coordinator/types.cc): The source commit added an unknown-value fallback to a `format_to(errc, ...)` free function in `types.h`, but that `format_to`-based formatter only exists on dev — v25.3.x still formats `errc` via `operator<<(std::ostream&, const errc&)` declared in `types.h` and defined in `types.cc` (the `operator<<`→`format_to` migration is a separate, un-backported commit). Resolved by keeping the target branch's `operator<<` declaration in `types.h` and applying the commit's actual intent — gracefully formatting unknown/future numeric `errc` values — to the `operator<<` definition in `types.cc`. Mirrored dev's exhaustive-switch + post-switch fallback by converting the per-case `break`s to early returns and adding `return o << fmt::format("errc::unknown({})", static_cast<int16_t>(errc));` after the switch, preserving `-Wswitch` exhaustiveness checking.
