### PR TITLE
rptest: enable idempotent produce in datalake tests

### DIFF
--- a/tests/rptest/tests/datalake/biglake_test.py
+++ b/tests/rptest/tests/datalake/biglake_test.py
@@ -167,7 +167,12 @@ class BiglakeTest(RedpandaTest):
             dl.produce_to_topic(self.topic_name, 1024, count)
 
             self.logger.info(f"Producing {count} valid messages to {self.topic_name}")
-            producer = Producer({"bootstrap.servers": self.redpanda.brokers()})
+            producer = Producer(
+                {
+                    "bootstrap.servers": self.redpanda.brokers(),
+                    "enable.idempotence": True,
+                }
+            )
             for i in range(count):
                 producer.produce(
                     self.topic_name,

--- a/tests/rptest/tests/datalake/custom_partitioning_test.py
+++ b/tests/rptest/tests/datalake/custom_partitioning_test.py
@@ -158,6 +158,7 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
                 "bootstrap.servers": self.redpanda.brokers(),
                 "key.serializer": StringSerializer("utf_8"),
                 "value.serializer": value_serializer,
+                "enable.idempotence": True,
             }
         )
 

--- a/tests/rptest/tests/datalake/databricks_test.py
+++ b/tests/rptest/tests/datalake/databricks_test.py
@@ -242,6 +242,7 @@ class DatabricksTest(RedpandaTest):
                     {
                         "bootstrap.servers": self.redpanda.brokers(),
                         "schema.registry.url": self.redpanda.schema_reg().split(",")[0],
+                        "enable.idempotence": True,
                     },
                     default_value_schema=raw_schema,
                 )

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -508,6 +508,7 @@ class DatalakeE2ETests(RedpandaTest):
                     {
                         "bootstrap.servers": self.redpanda.brokers(),
                         "schema.registry.url": self.redpanda.schema_reg().split(",")[0],
+                        "enable.idempotence": True,
                     },
                     default_value_schema=raw_schema,
                 )
@@ -721,6 +722,7 @@ class DatalakeE2ETests(RedpandaTest):
                 {
                     "bootstrap.servers": self.redpanda.brokers(),
                     "schema.registry.url": self.redpanda.schema_reg().split(",")[0],
+                    "enable.idempotence": True,
                 },
                 default_value_schema=avro.loads(schema_str),
             )
@@ -827,7 +829,12 @@ class DatalakeE2ETests(RedpandaTest):
             dl.create_iceberg_enabled_topic(
                 topic, iceberg_mode="headers:value_type=string"
             )
-            producer = Producer({"bootstrap.servers": self.redpanda.brokers()})
+            producer = Producer(
+                {
+                    "bootstrap.servers": self.redpanda.brokers(),
+                    "enable.idempotence": True,
+                }
+            )
             # One header with valid UTF-8, one with a leading invalid byte so
             # we verify sanitization fires end-to-end.
             producer.produce(
@@ -922,6 +929,7 @@ class DatalakeE2ETests(RedpandaTest):
                 {
                     "bootstrap.servers": self.redpanda.brokers(),
                     "schema.registry.url": sr_url,
+                    "enable.idempotence": True,
                 },
                 default_key_schema=avro.loads(key_schema_str),
                 default_value_schema=avro.loads(val_schema_str),
@@ -995,7 +1003,12 @@ class DatalakeE2ETests(RedpandaTest):
                 topic,
                 iceberg_mode="key:mode=string;value:mode=string",
             )
-            producer = Producer({"bootstrap.servers": self.redpanda.brokers()})
+            producer = Producer(
+                {
+                    "bootstrap.servers": self.redpanda.brokers(),
+                    "enable.idempotence": True,
+                }
+            )
             # Record with valid UTF-8 key and value.
             producer.produce(topic, key=b"hello-key", value=b"hello-val")
             # Record with invalid UTF-8 in key and value (bare continuation
@@ -1087,7 +1100,12 @@ class DatalakeE2ETests(RedpandaTest):
                 )
 
                 self.logger.info(f"Producing records for topic {test_case_topic_name}")
-                producer = Producer({"bootstrap.servers": self.redpanda.brokers()})
+                producer = Producer(
+                    {
+                        "bootstrap.servers": self.redpanda.brokers(),
+                        "enable.idempotence": True,
+                    }
+                )
                 for i in range(count):
                     t = time.time()
                     producer.produce(
@@ -1184,7 +1202,12 @@ class DatalakeE2ETests(RedpandaTest):
             )
 
             self.logger.info(f"Producing records for topic {self.topic_name}")
-            producer = Producer({"bootstrap.servers": self.redpanda.brokers()})
+            producer = Producer(
+                {
+                    "bootstrap.servers": self.redpanda.brokers(),
+                    "enable.idempotence": True,
+                }
+            )
             for _ in range(count):
                 t = time.time()
                 record = record_generator(t)
@@ -1267,7 +1290,12 @@ class DatalakeE2ETests(RedpandaTest):
                 )
 
                 self.logger.info(f"Producing records for topic {test_case_topic_name}")
-                producer = Producer({"bootstrap.servers": self.redpanda.brokers()})
+                producer = Producer(
+                    {
+                        "bootstrap.servers": self.redpanda.brokers(),
+                        "enable.idempotence": True,
+                    }
+                )
                 for i in range(count):
                     t = time.time()
                     producer.produce(
@@ -1392,7 +1420,12 @@ message_type {
         count = 100
 
         def produce_protos():
-            producer = Producer({"bootstrap.servers": self.redpanda.brokers()})
+            producer = Producer(
+                {
+                    "bootstrap.servers": self.redpanda.brokers(),
+                    "enable.idempotence": True,
+                }
+            )
             for i in range(count):
                 record = json.dumps(
                     {
@@ -1720,6 +1753,7 @@ message_type {
                 {
                     "bootstrap.servers": self.redpanda.brokers(),
                     "schema.registry.url": self.redpanda.schema_reg().split(",")[0],
+                    "enable.idempotence": True,
                 },
                 default_value_schema=schema,
             )
@@ -1864,7 +1898,12 @@ class DatalakeMultiBrokerE2ETest(RedpandaTest):
         Person = factory.GetPrototype(person_desc)
 
         def produce_protos():
-            producer = Producer({"bootstrap.servers": self.redpanda.brokers()})
+            producer = Producer(
+                {
+                    "bootstrap.servers": self.redpanda.brokers(),
+                    "enable.idempotence": True,
+                }
+            )
             for i in range(count):
                 record = json.dumps(
                     {

--- a/tests/rptest/tests/datalake/iceberg_toggling_test.py
+++ b/tests/rptest/tests/datalake/iceberg_toggling_test.py
@@ -75,6 +75,7 @@ class IcebergTogglingTest(RedpandaTest):
                 "bootstrap.servers": self.redpanda.brokers(),
                 "key.serializer": StringSerializer("utf_8"),
                 "value.serializer": value_serializer,
+                "enable.idempotence": True,
             }
         )
 

--- a/tests/rptest/tests/datalake/schema_evolution_test.py
+++ b/tests/rptest/tests/datalake/schema_evolution_test.py
@@ -168,6 +168,7 @@ class GenericSchema:
             {
                 "bootstrap.servers": dl.redpanda.brokers(),
                 "schema.registry.url": dl.redpanda.schema_reg().split(",")[0],
+                "enable.idempotence": True,
             },
             default_value_schema=avro.loads(json.dumps(self._rep)),
         )

--- a/tests/rptest/tests/datalake/schema_evolution_test_v25_2_compat.py
+++ b/tests/rptest/tests/datalake/schema_evolution_test_v25_2_compat.py
@@ -182,6 +182,7 @@ class GenericSchema:
             {
                 "bootstrap.servers": dl.redpanda.brokers(),
                 "schema.registry.url": dl.redpanda.schema_reg().split(",")[0],
+                "enable.idempotence": True,
             },
             default_value_schema=avro.loads(json.dumps(self._rep)),
         )

--- a/tests/rptest/tests/datalake/schema_registry_context_test.py
+++ b/tests/rptest/tests/datalake/schema_registry_context_test.py
@@ -94,6 +94,7 @@ class DatalakeSchemaRegistryContextTest(RedpandaTest):
             {
                 "bootstrap.servers": self.redpanda.brokers(),
                 "value.serializer": avro_serializer,
+                "enable.idempotence": True,
             }
         )
         for record in records:

--- a/tests/rptest/tests/datalake/schema_scale_test.py
+++ b/tests/rptest/tests/datalake/schema_scale_test.py
@@ -89,6 +89,7 @@ class SchemaScaleTester:
             {
                 "bootstrap.servers": self.redpanda.brokers(),
                 "schema.registry.url": self.redpanda.schema_reg().split(",")[0],
+                "enable.idempotence": True,
             },
             default_value_schema=avro.loads(json.dumps(self.schema.to_json())),
         )


### PR DESCRIPTION
Datalake ducktape tests that assert an exact translated row count can flake. The confluent-kafka-python producers they build default to `enable.idempotence=false`, so a produce retry (e.g. during a partition move or leader change) appends duplicate records to the Kafka log. Translation faithfully copies the duplicates to Iceberg, pushing the table's row count above the produced count, and `wait_for_translation` — which defaults to an exact `op=eq` check — times out with "Timed out waiting for events ... to appear in datalake".

This enables idempotent produce on those producers so retries no longer duplicate records. Tests that are already immune are left unchanged: `KgoVerifierProducer` (franz-go, idempotent by default), `wait_for_translation_until_offset` (offset-based, duplicates don't inflate it), `DatalakeVerifier` (compares Iceberg against the Kafka log offset-by-offset), and `op=gt` lower-bound waits.

Motivation and full root-cause analysis: https://redpandadata.atlassian.net/browse/CORE-14743

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none