### PR TITLE
rptest: fail fast on datalake translation overshoot

### DIFF
--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -383,6 +383,13 @@ class DatalakeServices:
             self.redpanda.logger.debug(
                 f"Current counts for {table_name}: {counts}, want {op=} {msg_count}"
             )
+            if op is operator.eq:
+                overshot = {name: c for name, c in counts.items() if c > msg_count}
+                if overshot:
+                    raise RuntimeError(
+                        f"Table {table_name} count exceeded expected {msg_count}: "
+                        f"{overshot}."
+                    )
             return all([op(c, msg_count) for _, c in counts.items()])
 
         wait_until_with_progress_check(


### PR DESCRIPTION
`wait_for_translation` with `op=eq` waits for translation to catch up, so the
table count should never exceed `msg_count`. Today an overshoot never converges
back to equality and the test burns the full timeout, then reports a misleading
"Timed out waiting for events to appear in datalake".

This makes the `op=eq` path raise as soon as any query engine reports a count
greater than `msg_count`, surfacing the real problem (duplicate rows) fast and
with a clear message. `op=gt` (a lower bound) is unaffected.

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none