### PR TITLE
[CORE-16827] `lsm/io`: coalesce chunk fetch failures as a value, not an exception

### DIFF
--- a/src/v/lsm/io/chunked_remote_file_reader.cc
+++ b/src/v/lsm/io/chunked_remote_file_reader.cc
@@ -170,26 +170,43 @@ chunked_remote_file_reader::ensure_chunk_cached(
         }
         if (auto it = _in_flight.find(chunk.start); it != _in_flight.end()) {
             auto found_fut = it->second.get_future();
-            // A download is already in flight. Wait for it, then re-open in
-            // the next iteration.
-            if (!co_await std::move(found_fut)) {
+            // A download is already in flight. Wait for its outcome, then
+            // re-open in the next iteration.
+            switch (co_await std::move(found_fut)) {
+            case chunk_fetch_outcome::present:
+                break; // fall through and re-open from cache
+            case chunk_fetch_outcome::absent:
                 co_return std::nullopt;
+            case chunk_fetch_outcome::failed:
+                // The leader's fetch failed and rethrew the underlying error to
+                // its own caller. Surface an equivalent failure here rather
+                // than routing an exception through the shared future, which
+                // could be dropped as an ignored exceptional future if a waiter
+                // is torn down during shutdown.
+                throw io_error_exception(
+                  "in-flight fetch of chunk {} of {} failed",
+                  chunk.start,
+                  _key);
             }
         } else {
             // There isn't an in-flight download; kick one off and publish a
             // shared future.
-            ss::shared_promise<bool> sp;
+            ss::shared_promise<chunk_fetch_outcome> sp;
             _in_flight.emplace(chunk.start, sp.get_shared_future());
             auto fetched = co_await ss::coroutine::as_future(
               download_chunk(chunk, parent));
             _in_flight.erase(chunk.start);
             if (fetched.failed()) {
+                // Publish the failure to waiters and rethrow to
+                // this caller.
                 auto eptr = fetched.get_exception();
-                sp.set_exception(eptr);
+                sp.set_value(chunk_fetch_outcome::failed);
                 std::rethrow_exception(eptr);
             }
             bool found = fetched.get();
-            sp.set_value(found);
+            sp.set_value(
+              found ? chunk_fetch_outcome::present
+                    : chunk_fetch_outcome::absent);
             if (!found) {
                 co_return std::nullopt;
             }

--- a/src/v/lsm/io/chunked_remote_file_reader.h
+++ b/src/v/lsm/io/chunked_remote_file_reader.h
@@ -141,10 +141,22 @@ private:
     ss::abort_source& _as;
     cloud_io::group_id _gid;
 
+    /// Outcome of an in-flight chunk fetch, published to coalesced waiters.
+    /// Failure is encoded as a value.
+    enum class chunk_fetch_outcome : uint8_t {
+        /// The object exists and the chunk was hydrated into the cache.
+        present,
+        /// The object does not exist (404).
+        absent,
+        /// The fetch failed transiently.
+        failed,
+    };
+
     // In-flight chunk fetches keyed by chunk start. An entry exists only while
-    // a download is in progress; the value is true if the object exists, false
-    // on 404. Coalesces concurrent fetches of the same chunk.
-    chunked_hash_map<uint64_t, ss::shared_future<bool>> _in_flight;
+    // a download is in progress. Coalesces concurrent fetches of the same
+    // chunk.
+    chunked_hash_map<uint64_t, ss::shared_future<chunk_fetch_outcome>>
+      _in_flight;
     ss::gate _gate;
 };
 


### PR DESCRIPTION
The chunked SST reader dedups concurrent fetches of the same chunk behind a `shared_promise`, previously carrying a bool and resolved with `set_exception` on a failed download. A waiter torn down during shutdown could leave its peer future orphaned, producing a spurious "Exceptional future ignored".

Encode the fetch outcome as a value (`present`/`absent`/`failed`) so the coalescing promise is only ever resolved with `set_value()`. The leader still rethrows the real error to its own caller, and waiters surface a failure of their own.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
