### PR TITLE
tools/antithesis: align selector paths and instrument by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -291,3 +291,6 @@ perf.data*
 
  # rpk binary
 src/go/rpk/cmd/rpk/rpk
+
+# antithesis
+/.antithesis

--- a/tools/antithesis/ducktape_deps/ducktape_singleton_driver.sh
+++ b/tools/antithesis/ducktape_deps/ducktape_singleton_driver.sh
@@ -33,7 +33,7 @@ if [ "${DUCKTAPE_DISABLE_FAULTS:-0}" = "1" ] && [ -n "${ANTITHESIS_STOP_FAULTS:-
   "${ANTITHESIS_STOP_FAULTS}" 86400
 fi
 
-pushd /root/tests
+pushd /root/
 
 COMMON_ARGS=(
   --cluster=ducktape.cluster.json.JsonCluster

--- a/tools/antithesis/ducktape_deps/select_single_test.py
+++ b/tools/antithesis/ducktape_deps/select_single_test.py
@@ -27,7 +27,7 @@ def parse_collected_tests(lines):
         if not m:
             continue
         cls, func, args_str, fpath = m.groups()
-        fpath = fpath.replace("/root/tests/", "")
+        fpath = fpath.removeprefix("/root/")
         selector = f"{fpath}::{cls}.{func}"
 
         if args_str.strip() != "None":

--- a/tools/antithesis/ducktape_test_package.py
+++ b/tools/antithesis/ducktape_test_package.py
@@ -19,7 +19,8 @@
 # Antithesis testing.
 #
 # This script:
-#   1. Builds Redpanda via Bazel (optionally with --config=antithesis)
+#   1. Builds Redpanda via Bazel (with --config=antithesis unless
+#      --no-instrumented)
 #   2. Builds the base test-node Docker image
 #   3. Builds the node image (test-node + baked-in Redpanda binaries)
 #   4. Builds the runner image (FROM node image + test code, config,
@@ -35,7 +36,7 @@
 #       --ducktape-args rptest/tests/e2e_shadow_indexing_test.py
 #   ./tools/antithesis/ducktape_test_package.py \
 #       --ducktape-args rptest/tests/e2e_shadow_indexing_test.py \
-#       --nodes 3 --instrumented
+#       --nodes 3 --no-instrumented
 #
 
 import argparse
@@ -266,8 +267,9 @@ def main() -> None:
     )
     parser.add_argument(
         "--instrumented",
-        action="store_true",
-        help="Build with --config=antithesis for coverage",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Build with --config=antithesis for coverage (default: enabled)",
     )
     parser.add_argument(
         "--max-parallel",


### PR DESCRIPTION
Minor tweaks to the Antithesis ducktape packaging tooling:

- **Align test selector paths.** Run the singleton driver from `/root/`
  (instead of `/root/tests`) and strip only the `/root/` prefix when
  building selectors, so selectors carry the `tests/` prefix (e.g.
  `tests/rptest/...`). This matches the paths accepted by `./tools/dt`
  and the GitHub slash commands.
- **Instrument builds by default.** Flip `--instrumented` to opt-out:
  builds now use `--config=antithesis` for coverage unless
  `--no-instrumented` is passed. Instrumented runs are the common case.
- **Gitignore `/.antithesis`,** the local temporary directory the
  packaging script writes compose files to.

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none
