### PR TITLE
sr/dt: default mode_mutability to true, matching the broker

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1277,7 +1277,7 @@ class SchemaRegistryConfig(TlsConfig):
     SR_TLS_CLIENT_KEY_FILE = "/etc/redpanda/sr_client.key"
     SR_TLS_CLIENT_CRT_FILE = "/etc/redpanda/sr_client.crt"
 
-    mode_mutability = False
+    mode_mutability = True
 
     def __init__(self) -> None:
         super(SchemaRegistryConfig, self).__init__()

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -3000,7 +3000,6 @@ class AuditLogTestSchemaRegistryBase(AuditLogTestBase):
     def __init__(self, test_context, **kwargs):
         sr_config = SchemaRegistryConfig()
         sr_config.authn_method = "http_basic"
-        sr_config.mode_mutability = True
         extra_rp_conf = {"schema_registry_use_rpc": False}
         if "extra_rp_conf" in kwargs:
             extra_rp_conf.update(kwargs.pop("extra_rp_conf"))

--- a/tests/rptest/tests/rpk_registry_test.py
+++ b/tests/rptest/tests/rpk_registry_test.py
@@ -71,7 +71,6 @@ class RpkRegistryTest(RedpandaTest):
 
         self.schema_registry_config = SchemaRegistryConfig()
         self.schema_registry_config.require_client_auth = True
-        self.schema_registry_config.mode_mutability = True
 
     # Override Redpanda start to create the certs and enable auth.
     def setUp(self):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -5208,14 +5208,11 @@ class SchemaRegistryContextTestBase(SchemaRegistryEndpoints):
     """
 
     def __init__(self, context: TestContext, **kwargs: Any):
-        schema_registry_config = SchemaRegistryConfig()
-        schema_registry_config.mode_mutability = True
         extra_rp_conf = {}
         if "extra_rp_conf" in kwargs:
             extra_rp_conf.update(kwargs.pop("extra_rp_conf"))
         super().__init__(
             context,
-            schema_registry_config=schema_registry_config,
             extra_rp_conf=extra_rp_conf,
             **kwargs,
         )
@@ -7379,7 +7376,6 @@ class SchemaRegistryBasicAuthTestBase(SchemaRegistryEndpoints):
 
         schema_registry_config = SchemaRegistryConfig()
         schema_registry_config.authn_method = "http_basic"
-        schema_registry_config.mode_mutability = True
 
         extra_rp_conf = {}
         if "extra_rp_conf" in kwargs:
@@ -10472,7 +10468,6 @@ class SchemaRegistryAclAuthzTestBase(SchemaRegistryEndpoints):
 
         schema_registry_config = SchemaRegistryConfig()
         schema_registry_config.authn_method = "http_basic"
-        schema_registry_config.mode_mutability = True
 
         merged_rp_conf = {"schema_registry_use_rpc": False}
         if extra_rp_conf:


### PR DESCRIPTION
The broker-side default, defined in
src/v/pandaproxy/schema_registry/configuration.cc, flipped to true in https://github.com/redpanda-data/redpanda/commit/0744a21d411187f63f8f7c7b0e06b0d3bb101cbd but the ducktape SchemaRegistryConfig stayed false. Align the harness with the product default and drop the now-redundant per-test true overrides, except in the ModeMutable test classes, which pin the flag they exercise (mirroring the explicit false in ModeNotMutableTest).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
