### PR TITLE
Schema Migrations: config/mode/delete syncing and context remapping

### DIFF
--- a/src/v/cluster_link/schema_registry_sync/http_source_reader.cc
+++ b/src/v/cluster_link/schema_registry_sync/http_source_reader.cc
@@ -78,6 +78,51 @@ source_error to_source_error(rc::domain_error err) {
     return source_error{.kind = kind, .message = fmt::format("{}", err)};
 }
 
+// Narrow the open-enum source mode to Redpanda's mode. READONLY_OVERRIDE is
+// preserved as read_only; FORWARD and unknown have no representation and yield
+// nullopt, which the caller counts as a per-item error.
+std::optional<ppsr::mode> narrow_mode(rc::registry_mode m) {
+    switch (m) {
+    case rc::registry_mode::read_write:
+        return ppsr::mode::read_write;
+    case rc::registry_mode::read_only:
+    case rc::registry_mode::read_only_override:
+        return ppsr::mode::read_only;
+    case rc::registry_mode::import:
+        return ppsr::mode::import;
+    case rc::registry_mode::forward:
+    case rc::registry_mode::unknown:
+        return std::nullopt;
+    }
+    return std::nullopt;
+}
+
+// Narrow the open-enum compatibility level to Redpanda's closed enum; only
+// unknown has no representation and yields nullopt.
+std::optional<ppsr::compatibility_level>
+narrow_compat(rc::registry_compatibility_level c) {
+    using enum rc::registry_compatibility_level;
+    switch (c) {
+    case none:
+        return ppsr::compatibility_level::none;
+    case backward:
+        return ppsr::compatibility_level::backward;
+    case backward_transitive:
+        return ppsr::compatibility_level::backward_transitive;
+    case forward:
+        return ppsr::compatibility_level::forward;
+    case forward_transitive:
+        return ppsr::compatibility_level::forward_transitive;
+    case full:
+        return ppsr::compatibility_level::full;
+    case full_transitive:
+        return ppsr::compatibility_level::full_transitive;
+    case unknown:
+        return std::nullopt;
+    }
+    return std::nullopt;
+}
+
 } // namespace
 
 std::optional<net::unresolved_address>
@@ -243,6 +288,78 @@ http_source_reader::read_subject_version(
     // Unmodeled response fields (parsed_schema::unknown_fields) are ignored;
     // honoring the unsupported-feature policy is future work.
     co_return std::move(res.value().schema);
+}
+
+ss::future<source_result<std::optional<ppsr::mode>>>
+http_source_reader::read_mode(ppsr::context_subject sub, ss::abort_source& as) {
+    auto units = co_await ss::get_units(_inflight, 1, as);
+    auto client = co_await ensure_client(as);
+    if (!client.has_value()) {
+        co_return std::unexpected(std::move(client.error()));
+    }
+    retry_chain_node rtc(as, request_timeout, request_backoff);
+    // Prefer GET /mode over GET /mode/. for the default context to be
+    // backwards-compatible with a source that does not implement contexts.
+    auto res = sub.is_default_context()
+                 ? co_await client.value()->get_mode(rtc)
+                 : co_await client.value()->get_subject_mode(
+                     sub, rtc, ppsr::default_to_global::no);
+    if (!res.has_value()) {
+        if (std::holds_alternative<rc::subject_mode_not_found>(res.error())) {
+            co_return std::optional<ppsr::mode>{std::nullopt};
+        }
+        co_return std::unexpected(to_source_error(std::move(res.error())));
+    }
+    auto narrowed = narrow_mode(res.value().mode);
+    if (!narrowed.has_value()) {
+        co_return std::unexpected(
+          source_error{
+            .kind = source_error_kind::operation_failed,
+            .message = fmt::format(
+              "source mode '{}' of {} is not supported by the destination",
+              res.value().raw,
+              sub)});
+    }
+    co_return narrowed;
+}
+
+ss::future<source_result<std::optional<ppsr::compatibility_level>>>
+http_source_reader::read_config(
+  ppsr::context_subject sub, ss::abort_source& as) {
+    auto units = co_await ss::get_units(_inflight, 1, as);
+    auto client = co_await ensure_client(as);
+    if (!client.has_value()) {
+        co_return std::unexpected(std::move(client.error()));
+    }
+    retry_chain_node rtc(as, request_timeout, request_backoff);
+    // Prefer GET /config over GET /config/. for the default context to be
+    // backwards-compatible with a source that does not implement contexts.
+    auto res = sub.is_default_context()
+                 ? co_await client.value()->get_config(rtc)
+                 : co_await client.value()->get_subject_config(
+                     sub, rtc, ppsr::default_to_global::no);
+    if (!res.has_value()) {
+        if (std::holds_alternative<rc::subject_config_not_found>(res.error())) {
+            co_return std::optional<ppsr::compatibility_level>{std::nullopt};
+        }
+        co_return std::unexpected(to_source_error(std::move(res.error())));
+    }
+    auto narrowed = narrow_compat(res.value().level);
+    if (!narrowed.has_value()) {
+        co_return std::unexpected(
+          source_error{
+            .kind = source_error_kind::operation_failed,
+            .message = fmt::format(
+              "source compatibility level '{}' of {} is not supported by the "
+              "destination",
+              res.value().raw,
+              sub)});
+    }
+    // Unsupported config fields (config_info::unknown_fields, e.g.
+    // defaultRuleSet or compatibilityGroup) are ignored; honoring
+    // unsupported_schema_feature_policy is future work, as it is for the
+    // schema-body path in read_subject_version.
+    co_return narrowed;
 }
 
 ss::future<> http_source_reader::stop() {

--- a/src/v/cluster_link/schema_registry_sync/http_source_reader.h
+++ b/src/v/cluster_link/schema_registry_sync/http_source_reader.h
@@ -80,6 +80,12 @@ public:
     ss::future<source_result<ppsr::stored_schema>> read_subject_version(
       ppsr::context_subject, ppsr::schema_version, ss::abort_source&) override;
 
+    ss::future<source_result<std::optional<ppsr::mode>>>
+    read_mode(ppsr::context_subject, ss::abort_source&) override;
+
+    ss::future<source_result<std::optional<ppsr::compatibility_level>>>
+    read_config(ppsr::context_subject, ss::abort_source&) override;
+
     ss::future<> stop() override;
 
 private:

--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
@@ -18,6 +18,8 @@
 #include "container/chunked_hash_map.h"
 #include "container/chunked_vector.h"
 #include "model/namespace.h"
+#include "pandaproxy/schema_registry/error.h"
+#include "pandaproxy/schema_registry/exceptions.h"
 #include "pandaproxy/schema_registry/types.h"
 #include "ssx/future-util.h"
 
@@ -48,6 +50,18 @@ full_sync_interval(const model::schema_registry_sync_config& cfg) {
     }
     return model::schema_registry_sync_config::shadow_schema_registry_api::
       default_full_sync_interval;
+}
+
+// A hard-delete blocked by a live reference; the only failure the purge loop
+// retries (after the referencing version is deleted first).
+bool is_reference_blocked(const std::exception_ptr& ep) {
+    try {
+        std::rethrow_exception(ep);
+    } catch (const ppsr::exception& e) {
+        return e.code() == ppsr::error_code::subject_version_has_references;
+    } catch (...) {
+    }
+    return false;
 }
 
 } // namespace
@@ -213,6 +227,80 @@ ss::future<> mirroring_task::refresh_destination_inventory(
       _destination_inventory.active.size());
 }
 
+ss::future<> mirroring_task::hard_delete_target(
+  const ppsr::context_subject& dest_sub,
+  ppsr::schema_version version,
+  bool was_active) {
+    if (was_active) {
+        co_await _destination->soft_delete_schema(dest_sub, version);
+    }
+    co_await _destination->permanent_delete_schema(dest_sub, version);
+}
+
+ss::future<> mirroring_task::purge_one(
+  purge_target target,
+  ss::abort_source& as,
+  uint64_t& purged,
+  chunked_vector<purge_target>& next_round) {
+    as.check();
+    auto fut = co_await ss::coroutine::as_future(hard_delete_target(
+      target.node.sub, target.node.version, target.was_active));
+    if (fut.failed()) {
+        auto ex = fut.get_exception();
+        if (ssx::is_shutdown_exception(ex)) {
+            std::rethrow_exception(ex);
+        }
+        if (is_reference_blocked(ex)) {
+            // Referenced by a version not yet purged this round; retry later.
+            vlog(
+              logger().debug,
+              "Deferring hard-delete of {}/{}: {}",
+              target.node.sub,
+              target.node.version,
+              ex);
+            next_round.push_back(std::move(target));
+            co_return;
+        }
+        record_error(
+          fmt::format(
+            "failed to hard-delete {}/{}: {}",
+            target.node.sub,
+            target.node.version,
+            ex));
+        co_return;
+    }
+    ++purged;
+    ++_status.current_sync->summary.subject_versions_changed;
+    ++_status.totals_since_task_start.subject_versions_changed;
+}
+
+ss::future<uint64_t> mirroring_task::purge_destination_only_versions(
+  chunked_vector<purge_target> targets, ss::abort_source& as) {
+    uint64_t purged = 0;
+    // Rounds retry reference-blocked deletes (see header); stop when a round
+    // makes no progress and count the stuck remainder as errors.
+    const auto parallelism = std::max<size_t>(
+      1, config::shard_local_cfg().schema_registry_sync_parallelism());
+    while (!targets.empty()) {
+        const auto before = purged;
+        chunked_vector<purge_target> next_round;
+        co_await ss::max_concurrent_for_each(
+          targets, parallelism, [&](purge_target& t) {
+              return purge_one(std::move(t), as, purged, next_round);
+          });
+        if (purged == before) {
+            for (const auto& t : next_round) {
+                record_error(
+                  fmt::format(
+                    "failed to hard-delete {}/{}", t.node.sub, t.node.version));
+            }
+            break;
+        }
+        targets = std::move(next_round);
+    }
+    co_return purged;
+}
+
 ss::future<> mirroring_task::sync_mode_and_config(
   const ppsr::context_subject& target,
   ss::abort_source& as,
@@ -327,22 +415,29 @@ ss::future<> mirroring_task::list_one_subject(
   ss::abort_source& as,
   chunked_hash_set<ppsr::subject_version>& source_active,
   chunked_hash_set<ppsr::subject_version>& source_deleted,
+  chunked_hash_set<ppsr::context_subject>& failed_subjects,
   std::optional<source_error>& unavailable) {
     // A peer fiber already hit source_unavailable; skip the remaining work.
     if (unavailable.has_value()) {
         co_return;
     }
+    // A nullopt from a reachable error (not source_unavailable, which sets
+    // `unavailable`) leaves this subject's versions undiscovered, so exclude it
+    // from the hard-delete: its destination versions must not be read as
+    // source-absent.
     // List all versions first: unlike the active-only listing, it succeeds
     // for a fully soft-deleted subject. The two listings partition versions
     // into active vs. soft-deleted.
     auto all = co_await list_versions_once(
       subject, ppsr::include_deleted::yes, as, unavailable);
     if (!all.has_value()) {
+        failed_subjects.insert(subject);
         co_return;
     }
     auto active = co_await list_versions_once(
       subject, ppsr::include_deleted::no, as, unavailable);
     if (!active.has_value()) {
+        failed_subjects.insert(subject);
         co_return;
     }
     chunked_hash_set<ppsr::schema_version> active_set;
@@ -377,6 +472,12 @@ ss::future<task::state_transition> mirroring_task::full_source_sync(
     chunked_hash_set<ppsr::subject_version> source_active;
     chunked_hash_set<ppsr::subject_version> source_deleted;
 
+    // Track failed context and subject listing calls to narrow the hard-delete
+    // purge to only what discovery saw whole and avoid hard-deleting subjects
+    // based on incomplete discovery.
+    chunked_hash_set<ppsr::context> failed_contexts;
+    chunked_hash_set<ppsr::context_subject> failed_subjects;
+
     // Contexts are few, so enumerate their subjects sequentially. in_scope also
     // scopes discovery, keeping source and destination sides consistent.
     chunked_vector<ppsr::context_subject> subjects;
@@ -388,8 +489,10 @@ ss::future<task::state_transition> mirroring_task::full_source_sync(
               == source_error_kind::source_unavailable) {
                 co_return make_unavailable(subjects_res.error().message);
             }
-            // Reachable but failed (rare delete race): count and skip.
+            // Reachable but failed (rare delete race): count and skip, and
+            // spare this context's destination subjects from the purge.
             record_error(subjects_res.error().message);
+            failed_contexts.insert(ctx);
             continue;
         }
         for (auto& subject : subjects_res.value()) {
@@ -409,7 +512,12 @@ ss::future<task::state_transition> mirroring_task::full_source_sync(
       std::max<size_t>(1, limits.parallelism),
       [&](const ppsr::context_subject& subject) {
           return list_one_subject(
-            subject, as, source_active, source_deleted, unavailable);
+            subject,
+            as,
+            source_active,
+            source_deleted,
+            failed_subjects,
+            unavailable);
       });
     if (unavailable.has_value()) {
         co_return make_unavailable(unavailable->message);
@@ -429,10 +537,10 @@ ss::future<task::state_transition> mirroring_task::full_source_sync(
     // soft-deleted, and one still active on the destination has its deleted
     // body re-imported to propagate the soft-delete (import overwrites the
     // version's deleted flag). Soft-delete propagation covers source-present
-    // versions in both directions; purging destination-only versions
-    // (hard-delete propagation) is deferred, as is detecting divergent
-    // same-key content (a matching key is assumed to mean matching content --
-    // the destination is a managed mirror).
+    // versions in both directions; a version present on the destination but
+    // absent from the source entirely is hard-deleted below. Detecting
+    // divergent same-key content is out of scope (a matching key is assumed to
+    // mean matching content -- the destination is a managed mirror).
     work_set work;
     for (const auto& node : source_active) {
         if (!_destination_inventory.active.contains(node)) {
@@ -446,6 +554,23 @@ ss::future<task::state_transition> mirroring_task::full_source_sync(
         if (!dest_deleted) {
             work.upserts.push_back(node);
         }
+    }
+
+    // Hard-delete set: destination versions the source no longer has at all.
+    chunked_vector<purge_target> to_purge;
+    for (const auto& node : _destination_inventory.all) {
+        if (source_active.contains(node) || source_deleted.contains(node)) {
+            continue;
+        }
+        if (
+          failed_contexts.contains(node.sub.ctx)
+          || failed_subjects.contains(node.sub)) {
+            continue;
+        }
+        to_purge.push_back(
+          purge_target{
+            .node = node,
+            .was_active = _destination_inventory.active.contains(node)});
     }
 
     // The reconciler sinks the predicate by value; forward the borrowed one.
@@ -488,6 +613,9 @@ ss::future<task::state_transition> mirroring_task::full_source_sync(
       += stats.versions_changed;
     _status.totals_since_task_start.errors += stats.errors;
 
+    const auto purged = co_await purge_destination_only_versions(
+      std::move(to_purge), as);
+
     // Replicate modes/configs after the import (the destination contexts and
     // subjects now exist)
     chunked_vector<ppsr::context_subject> mode_config_targets;
@@ -528,12 +656,13 @@ ss::future<task::state_transition> mirroring_task::full_source_sync(
     vlog(
       logger().info,
       "Schema Registry full sync: {} source subjects ({} versions), {} "
-      "destination subjects; imported {} versions, {} modes, {} configs, {} "
-      "errors",
+      "destination subjects; imported {} versions, hard-deleted {} versions, "
+      "{} modes, {} configs, {} errors",
       _status.inventory.selected_source_subjects,
       _status.inventory.selected_source_subject_versions,
       _status.inventory.destination_subjects,
       stats.versions_changed,
+      purged,
       _status.current_sync->summary.modes_changed,
       _status.current_sync->summary.compatibility_configs_changed,
       _status.current_sync->summary.errors);

--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
@@ -19,6 +19,7 @@
 #include "container/chunked_vector.h"
 #include "model/namespace.h"
 #include "pandaproxy/schema_registry/types.h"
+#include "ssx/future-util.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/loop.hh>
@@ -210,6 +211,78 @@ ss::future<> mirroring_task::refresh_destination_inventory(
       subjects.size());
     _status.inventory.destination_subject_versions = static_cast<uint64_t>(
       _destination_inventory.active.size());
+}
+
+ss::future<> mirroring_task::sync_mode_and_config(
+  const ppsr::context_subject& target,
+  ss::abort_source& as,
+  std::optional<source_error>& unavailable) {
+    // A peer fiber already hit source_unavailable; skip the remaining work.
+    if (unavailable.has_value()) {
+        co_return;
+    }
+    auto mode = co_await _reader->read_mode(target, as);
+    if (!mode.has_value()) {
+        if (mode.error().kind == source_error_kind::source_unavailable) {
+            if (!unavailable.has_value()) {
+                unavailable = std::move(mode.error());
+            }
+            co_return;
+        }
+        // Unmappable value or other reachable failure: count and continue.
+        record_error(mode.error().message);
+    } else {
+        // Present -> mirror the override; absent -> remove any destination
+        // override
+        auto write = co_await ss::coroutine::as_future(
+          mode.value().has_value()
+            ? _destination->write_mode(target, *mode.value())
+            : _destination->delete_mode(target));
+        if (write.failed()) {
+            auto ex = write.get_exception();
+            if (ssx::is_shutdown_exception(ex)) {
+                std::rethrow_exception(ex);
+            }
+            record_error(
+              fmt::format("failed to sync mode for {}: {}", target, ex));
+        } else if (write.get()) {
+            ++_status.current_sync->summary.modes_changed;
+            ++_status.totals_since_task_start.modes_changed;
+        }
+    }
+
+    if (unavailable.has_value()) {
+        co_return;
+    }
+    auto config = co_await _reader->read_config(target, as);
+    if (!config.has_value()) {
+        if (config.error().kind == source_error_kind::source_unavailable) {
+            if (!unavailable.has_value()) {
+                unavailable = std::move(config.error());
+            }
+            co_return;
+        }
+        record_error(config.error().message);
+        co_return;
+    }
+
+    auto write = co_await ss::coroutine::as_future(
+      config.value().has_value()
+        ? _destination->write_config(target, *config.value())
+        : _destination->delete_config(target));
+    if (write.failed()) {
+        auto ex = write.get_exception();
+        if (ssx::is_shutdown_exception(ex)) {
+            std::rethrow_exception(ex);
+        }
+        record_error(
+          fmt::format("failed to sync config for {}: {}", target, ex));
+        co_return;
+    }
+    if (write.get()) {
+        ++_status.current_sync->summary.compatibility_configs_changed;
+        ++_status.totals_since_task_start.compatibility_configs_changed;
+    }
 }
 
 void mirroring_task::record_error(std::string_view what) {
@@ -415,6 +488,39 @@ ss::future<task::state_transition> mirroring_task::full_source_sync(
       += stats.versions_changed;
     _status.totals_since_task_start.errors += stats.errors;
 
+    // Replicate modes/configs after the import (the destination contexts and
+    // subjects now exist)
+    chunked_vector<ppsr::context_subject> mode_config_targets;
+
+    // The registry-wide global mode/config (GET /mode/:.__GLOBAL:) is synced
+    // only when in scope.
+    const auto global = ppsr::context_subject{
+      ppsr::global_context, ppsr::subject{""}};
+    if (in_scope(global)) {
+        mode_config_targets.push_back(global);
+    }
+    for (const auto& ctx : contexts) {
+        // A context in scope only via a subject filter is not in scope as a
+        // whole, so its context-level mode/config must not be touched.
+        ppsr::context_subject ctx_target{ctx, ppsr::subject{""}};
+        if (in_scope(ctx_target)) {
+            mode_config_targets.push_back(std::move(ctx_target));
+        }
+    }
+    for (const auto& subject : subjects) {
+        mode_config_targets.push_back(subject);
+    }
+    std::optional<source_error> mc_unavailable;
+    co_await ss::max_concurrent_for_each(
+      mode_config_targets,
+      std::max<size_t>(1, limits.parallelism),
+      [&](const ppsr::context_subject& target) {
+          return sync_mode_and_config(target, as, mc_unavailable);
+      });
+    if (mc_unavailable.has_value()) {
+        co_return make_unavailable(mc_unavailable->message);
+    }
+
     // Re-scan now that imports have landed so the reported destination counts
     // reflect the post-sync state, not the pre-import baseline the diff used.
     co_await refresh_destination_inventory(in_scope, as);
@@ -422,12 +528,15 @@ ss::future<task::state_transition> mirroring_task::full_source_sync(
     vlog(
       logger().info,
       "Schema Registry full sync: {} source subjects ({} versions), {} "
-      "destination subjects; imported {} versions, {} errors",
+      "destination subjects; imported {} versions, {} modes, {} configs, {} "
+      "errors",
       _status.inventory.selected_source_subjects,
       _status.inventory.selected_source_subject_versions,
       _status.inventory.destination_subjects,
       stats.versions_changed,
-      stats.errors);
+      _status.current_sync->summary.modes_changed,
+      _status.current_sync->summary.compatibility_configs_changed,
+      _status.current_sync->summary.errors);
 
     _status.current_sync->summary.finish_time = ::model::timestamp::now();
     _status.last_full_sync = _status.current_sync->summary;

--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
@@ -69,17 +69,34 @@ bool is_reference_blocked(const std::exception_ptr& ep) {
 ss::future<inventory> scan_destination_inventory(
   schema::registry& destination,
   ss::noncopyable_function<bool(const ppsr::context_subject&)> in_scope,
+  const context_mapper& mapper,
   ss::abort_source& as) {
     as.check();
+    // A destination node is in scope iff its context reverse-maps to a source
+    // context `in_scope` accepts (identity mapper: reduces to `in_scope`).
+    // Captured by reference like the underlying filter; both outlive the scan.
+    auto dest_in_scope = [&in_scope,
+                          &mapper](const ppsr::context_subject& dest_cs) {
+        auto src_ctx = mapper.reverse(dest_cs.ctx);
+        return src_ctx.has_value()
+               && in_scope(ppsr::context_subject{*src_ctx, dest_cs.sub});
+    };
     // list_subject_versions reads the store as-is; sync first so the scan
     // isn't stale (e.g. on a freshly-elected _schemas/0 leader).
     co_await destination.sync();
     auto versions = co_await destination.list_subject_versions(
-      std::move(in_scope), ppsr::include_deleted::yes);
+      std::move(dest_in_scope), ppsr::include_deleted::yes);
     inventory inv;
     inv.all.reserve(versions.size());
     for (const auto& sv : versions) {
-        auto node = ppsr::subject_version{sv.sub, sv.version};
+        // Back to the source namespace, so the diff/seed/purge phases speak
+        // one.
+        auto src_ctx = mapper.reverse(sv.sub.ctx);
+        if (!src_ctx.has_value()) {
+            continue;
+        }
+        auto node = ppsr::subject_version{
+          ppsr::context_subject{*src_ctx, sv.sub.sub}, sv.version};
         if (sv.deleted == ppsr::is_deleted::no) {
             inv.active.insert(node);
         }
@@ -116,6 +133,7 @@ void mirroring_task::reset_sync_state() {
     _status = model::schema_registry_sync_status{};
     _destination_inventory = inventory{};
     _reconcile_stats = reconcile_stats{};
+    _mapper = context_mapper{};
     _last_full_sync.reset();
 }
 
@@ -215,6 +233,7 @@ ss::future<> mirroring_task::refresh_destination_inventory(
     _destination_inventory = co_await scan_destination_inventory(
       *_destination,
       [&in_scope](const ppsr::context_subject& cs) { return in_scope(cs); },
+      _mapper,
       as);
 
     chunked_hash_set<ppsr::context_subject> subjects;
@@ -243,8 +262,21 @@ ss::future<> mirroring_task::purge_one(
   uint64_t& purged,
   chunked_vector<purge_target>& next_round) {
     as.check();
-    auto fut = co_await ss::coroutine::as_future(hard_delete_target(
-      target.node.sub, target.node.version, target.was_active));
+    // `node` is source-namespace; forward-map to the destination for the
+    // delete.
+    auto dest_ctx = _mapper.forward(target.node.sub.ctx);
+    if (!dest_ctx.has_value()) {
+        record_error(
+          fmt::format(
+            "cannot hard-delete {}/{}: source context has no destination "
+            "mapping",
+            target.node.sub,
+            target.node.version));
+        co_return;
+    }
+    const auto dest_sub = ppsr::context_subject{*dest_ctx, target.node.sub.sub};
+    auto fut = co_await ss::coroutine::as_future(
+      hard_delete_target(dest_sub, target.node.version, target.was_active));
     if (fut.failed()) {
         auto ex = fut.get_exception();
         if (ssx::is_shutdown_exception(ex)) {
@@ -309,6 +341,18 @@ ss::future<> mirroring_task::sync_mode_and_config(
     if (unavailable.has_value()) {
         co_return;
     }
+    // Read the source in its own (source) namespace; write to the destination
+    // under the remapped context. Identity leaves dest_target == target.
+    auto dest_ctx = _mapper.forward(target.ctx);
+    if (!dest_ctx.has_value()) {
+        record_error(
+          fmt::format(
+            "cannot sync mode/config for {}: source context has no destination "
+            "mapping",
+            target));
+        co_return;
+    }
+    const auto dest_target = ppsr::context_subject{*dest_ctx, target.sub};
     auto mode = co_await _reader->read_mode(target, as);
     if (!mode.has_value()) {
         if (mode.error().kind == source_error_kind::source_unavailable) {
@@ -324,15 +368,15 @@ ss::future<> mirroring_task::sync_mode_and_config(
         // override
         auto write = co_await ss::coroutine::as_future(
           mode.value().has_value()
-            ? _destination->write_mode(target, *mode.value())
-            : _destination->delete_mode(target));
+            ? _destination->write_mode(dest_target, *mode.value())
+            : _destination->delete_mode(dest_target));
         if (write.failed()) {
             auto ex = write.get_exception();
             if (ssx::is_shutdown_exception(ex)) {
                 std::rethrow_exception(ex);
             }
             record_error(
-              fmt::format("failed to sync mode for {}: {}", target, ex));
+              fmt::format("failed to sync mode for {}: {}", dest_target, ex));
         } else if (write.get()) {
             ++_status.current_sync->summary.modes_changed;
             ++_status.totals_since_task_start.modes_changed;
@@ -356,15 +400,15 @@ ss::future<> mirroring_task::sync_mode_and_config(
 
     auto write = co_await ss::coroutine::as_future(
       config.value().has_value()
-        ? _destination->write_config(target, *config.value())
-        : _destination->delete_config(target));
+        ? _destination->write_config(dest_target, *config.value())
+        : _destination->delete_config(dest_target));
     if (write.failed()) {
         auto ex = write.get_exception();
         if (ssx::is_shutdown_exception(ex)) {
             std::rethrow_exception(ex);
         }
         record_error(
-          fmt::format("failed to sync config for {}: {}", target, ex));
+          fmt::format("failed to sync config for {}: {}", dest_target, ex));
         co_return;
     }
     if (write.get()) {
@@ -574,10 +618,12 @@ ss::future<task::state_transition> mirroring_task::full_source_sync(
     }
 
     // The reconciler sinks the predicate by value; forward the borrowed one.
+    // The mapper remaps contexts at the import boundary only.
     auto rec = reconciler{
       _reader.get(),
       _destination,
       [&in_scope](const ppsr::context_subject& cs) { return in_scope(cs); },
+      _mapper,
       limits};
 
     // The reconciler increments _reconcile_stats live (reflected mid-sync by
@@ -775,6 +821,11 @@ mirroring_task::run_impl(ss::abort_source& as) {
     // wrapper.
     auto in_scope = make_in_scope(
       std::move(filter_contexts), std::move(filter_subjects));
+
+    // Rebuild once per run from the validated config; held on the task so every
+    // phase shares one mapping without re-reading _config (which a concurrent
+    // update_config could swap mid-run).
+    _mapper = context_mapper::make(_config);
 
     co_await refresh_destination_inventory(in_scope, as);
     co_return co_await full_source_sync(as, contexts, in_scope);

--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.h
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.h
@@ -148,6 +148,14 @@ private:
       ss::abort_source& as,
       std::optional<source_error>& unavailable);
 
+    /// Replicates one target's (subject or context-only) source mode and
+    /// compatibility config onto the destination: writes the source's own
+    /// override when it has one, deletes the destination override otherwise.
+    ss::future<> sync_mode_and_config(
+      const ppsr::context_subject& target,
+      ss::abort_source& as,
+      std::optional<source_error>& unavailable);
+
     // Requires a sync in progress (`current_sync` engaged).
     void record_error(std::string_view what);
 

--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.h
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.h
@@ -124,16 +124,15 @@ private:
     /// two calls recover the per-version deleted state: include_deleted::no
     /// gives the active versions, and the rest of the include_deleted::yes
     /// listing are soft-deleted. A reachable-but-failed listing is a counted
-    /// per-item error; a source_unavailable is captured in `unavailable` to
-    /// back off the sync. A member, not a coroutine lambda: run under
-    /// max_concurrent_for_each, a lambda could be freed while suspended and
-    /// dangle its captures, whereas the member coroutine frame owns `this` and
-    /// the shared state.
+    /// per-item error and adds the subject to `failed_subjects` so its versions
+    /// (undiscovered, hence source-absent-looking) are spared the hard-delete;
+    /// a source_unavailable is captured in `unavailable` to back off the sync.
     ss::future<> list_one_subject(
       const ppsr::context_subject& subject,
       ss::abort_source& as,
       chunked_hash_set<ppsr::subject_version>& source_active,
       chunked_hash_set<ppsr::subject_version>& source_deleted,
+      chunked_hash_set<ppsr::context_subject>& failed_subjects,
       std::optional<source_error>& unavailable);
 
     /// One source version listing with shared error handling: returns the
@@ -147,6 +146,37 @@ private:
       ppsr::include_deleted include_deleted,
       ss::abort_source& as,
       std::optional<source_error>& unavailable);
+
+    /// A destination (subject, version) to hard-delete because the source no
+    /// longer has it.
+    struct purge_target {
+        ppsr::subject_version node;
+        bool was_active;
+    };
+
+    /// Hard-deletes the source-absent destination versions in `targets`. A
+    /// version still referenced by another not-yet-purged version cannot be
+    /// deleted, so reference-blocked deletes are retried across rounds until a
+    /// round makes no progress. Returns the number of versions purged (folded
+    /// into subject-version changes).
+    ss::future<uint64_t> purge_destination_only_versions(
+      chunked_vector<purge_target> targets, ss::abort_source& as);
+
+    /// Attempts one hard-delete of `target`. If it fails because the version is
+    /// still referenced by another version, it is re-queued into `next_round`.
+    /// On success, `purged` is incremented.
+    ss::future<> purge_one(
+      purge_target target,
+      ss::abort_source& as,
+      uint64_t& purged,
+      chunked_vector<purge_target>& next_round);
+
+    /// Soft-deletes `dest_sub`/`version` first if `was_active` (the store
+    /// refuses to tombstone an active version), then permanently deletes it.
+    ss::future<> hard_delete_target(
+      const ppsr::context_subject& dest_sub,
+      ppsr::schema_version version,
+      bool was_active);
 
     /// Replicates one target's (subject or context-only) source mode and
     /// compatibility config onto the destination: writes the source's own

--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.h
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.h
@@ -33,11 +33,18 @@ struct inventory {
 
 /// Scans the destination registry for every in-scope (subject, version) node.
 /// A single include_deleted scan reports each version's soft-delete state, so
-/// `active` is the non-deleted subset of `all` from one snapshot. `in_scope`
-/// must be pure; it runs on each registry shard.
+/// `active` is the non-deleted subset of `all` from one snapshot.
+///
+/// `in_scope` is a source-namespace predicate; the destination is scanned in
+/// the destination namespace, so the scan reverse-maps each destination context
+/// to its source context via `mapper` before applying `in_scope` and returns
+/// nodes in the source namespace, keeping the whole diff single-namespaced.
+/// Under the identity mapper this is a passthrough. `in_scope` must be pure; it
+/// runs on each registry shard.
 ss::future<inventory> scan_destination_inventory(
   schema::registry& destination,
   ss::noncopyable_function<bool(const ppsr::context_subject&)> in_scope,
+  const context_mapper& mapper,
   ss::abort_source& as);
 
 /// Shadows a source Schema Registry into the local (destination) Schema
@@ -194,6 +201,10 @@ private:
     [[nodiscard]] state_transition make_faulted(const ss::sstring& reason);
 
     model::schema_registry_sync_config _config;
+    // Source->destination context remapping for the current run, rebuilt from
+    // _config at the start of each full sync. Applied only at the destination
+    // boundary; identity when no remapping is configured.
+    context_mapper _mapper;
     schema::registry* _destination;
     source_reader_factory* _source_factory;
     std::unique_ptr<source_reader> _reader;

--- a/src/v/cluster_link/schema_registry_sync/reconciler.cc
+++ b/src/v/cluster_link/schema_registry_sync/reconciler.cc
@@ -59,6 +59,40 @@ size_t body_size(const ppsr::stored_schema& s) {
     return s.schema.def().raw()().size_bytes();
 }
 
+// Rewrites a schema's contexts source->destination for import: the subject's
+// context and each context-qualified reference's context. An unqualified
+// reference is left alone -- it resolves against the referrer's remapped parent
+// on the destination. Body, type, and metadata are unchanged. nullopt if a
+// context has no destination mapping.
+std::optional<ppsr::stored_schema>
+remap_for_import(const context_mapper& mapper, ppsr::stored_schema s) {
+    if (mapper.is_identity()) {
+        return s;
+    }
+    auto [sub, def] = std::move(s.schema).destructure();
+    auto mapped_ctx = mapper.forward(sub.ctx);
+    if (!mapped_ctx.has_value()) {
+        return std::nullopt;
+    }
+    sub.ctx = *mapped_ctx;
+    auto [raw, type, refs, meta] = std::move(def).destructure();
+    for (auto& ref : refs) {
+        if (ref.sub.qualified == ppsr::is_qualified::yes) {
+            auto mapped_ref_ctx = mapper.forward(ref.sub.sub.ctx);
+            if (!mapped_ref_ctx.has_value()) {
+                return std::nullopt;
+            }
+            ref.sub.sub.ctx = *mapped_ref_ctx;
+        }
+    }
+    return ppsr::stored_schema{
+      .schema = ppsr::
+        subject_schema{std::move(sub), ppsr::schema_definition{std::move(raw), type, std::move(refs), std::move(meta)}},
+      .version = s.version,
+      .id = s.id,
+      .deleted = s.deleted};
+}
+
 void adjust_units(
   ssx::semaphore& sem, ssx::semaphore_units& units, size_t new_size) {
     auto reserved = units.count();
@@ -75,10 +109,12 @@ reconciler::reconciler(
   source_reader* source,
   schema::registry* destination,
   ss::noncopyable_function<bool(const ppsr::context_subject&)> in_scope,
+  const context_mapper& mapper,
   limits lim)
   : _source(source)
   , _destination(destination)
   , _in_scope(std::move(in_scope))
+  , _mapper(&mapper)
   , _limits(lim)
   , _mem(std::max<size_t>(1, lim.memory_bytes), "schema_registry_sync/memory") {
     // Floor the budget so the clamp `min(body_size, memory_bytes)` and the
@@ -342,8 +378,20 @@ reconciler::do_import(const ppsr::subject_version& n, ss::abort_source& as) {
 ss::future<bool> reconciler::import_body(
   const ppsr::subject_version& n, ppsr::stored_schema schema) {
     data(n).state = node_state::importing;
+    // The graph key `n` stays in the source namespace; only the schema written
+    // to the destination is remapped.
+    auto remapped = remap_for_import(*_mapper, std::move(schema));
+    if (!remapped.has_value()) {
+        vlog(
+          cllog.warn,
+          "Cannot replicate {}/{}: a context has no destination mapping",
+          n.sub,
+          n.version);
+        fail(n);
+        co_return false;
+    }
     auto fut = co_await ss::coroutine::as_future(
-      _destination->import_schema(std::move(schema)));
+      _destination->import_schema(std::move(*remapped)));
     if (fut.failed()) {
         auto eptr = fut.get_exception();
         if (ssx::is_shutdown_exception(eptr)) {

--- a/src/v/cluster_link/schema_registry_sync/reconciler.h
+++ b/src/v/cluster_link/schema_registry_sync/reconciler.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cluster_link/schema_registry_sync/scope.h"
 #include "cluster_link/schema_registry_sync/source_reader.h"
 #include "container/chunked_hash_map.h"
 #include "container/chunked_vector.h"
@@ -87,10 +88,15 @@ public:
         size_t parallelism;
     };
 
+    /// \param mapper source->destination context remapping, applied only at the
+    ///        import boundary (the discovery graph, `in_scope`, and reference
+    ///        resolution all run in the source-context namespace). The mapper
+    ///        must outlive the reconciler.
     reconciler(
       source_reader* source,
       schema::registry* destination,
       ss::noncopyable_function<bool(const ppsr::context_subject&)> in_scope,
+      const context_mapper& mapper,
       limits lim);
 
     /// Imports `work_set.upserts` referent-first.
@@ -178,6 +184,7 @@ private:
     source_reader* _source;
     schema::registry* _destination;
     ss::noncopyable_function<bool(const ppsr::context_subject&)> _in_scope;
+    const context_mapper* _mapper;
     limits _limits;
 
     chunked_hash_set<ppsr::subject_version> _replicated;

--- a/src/v/cluster_link/schema_registry_sync/scope.cc
+++ b/src/v/cluster_link/schema_registry_sync/scope.cc
@@ -16,6 +16,8 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/util/variant_utils.hh>
 
+#include <variant>
+
 namespace cluster_link::schema_registry_sync {
 
 ss::noncopyable_function<bool(const ppsr::context_subject&)> make_in_scope(
@@ -30,10 +32,138 @@ ss::noncopyable_function<bool(const ppsr::context_subject&)> make_in_scope(
     };
 }
 
+context_mapper
+context_mapper::make(const model::schema_registry_sync_config& config) {
+    context_mapper m;
+    const auto* api = config.api_mode();
+    if (api == nullptr || !api->destination.has_value()) {
+        return m;
+    }
+    using exact_context_mapping
+      = model::schema_registry_sync_config::exact_context_mapping;
+    if (
+      const auto* exact = std::get_if<exact_context_mapping>(
+        &*api->destination)) {
+        // An exact mapping is not identity even when its table is empty: it
+        // then covers no source context and rejects every one.
+        m._identity = false;
+        for (const auto& [src, dest] : exact->mappings) {
+            m._fwd.emplace(ppsr::context{src}, ppsr::context{dest});
+            m._rev.emplace(ppsr::context{dest}, ppsr::context{src});
+        }
+    }
+    // The identity_context_mapping variant leaves the mapper as identity,
+    // matching the no-destination-configured case.
+    return m;
+}
+
+std::optional<ppsr::context>
+context_mapper::forward(const ppsr::context& src) const {
+    if (_identity) {
+        return src;
+    }
+    // The global is written to the destination global directly, never remapped.
+    if (src == ppsr::global_context) {
+        return src;
+    }
+    if (auto it = _fwd.find(src); it != _fwd.end()) {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
+std::optional<ppsr::context>
+context_mapper::reverse(const ppsr::context& dest) const {
+    if (_identity) {
+        // Identity: every destination context maps back to itself.
+        return dest;
+    }
+    if (auto it = _rev.find(dest); it != _rev.end()) {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
 std::optional<ss::sstring> check_preconditions(
   const model::schema_registry_sync_config& config,
   const chunked_hash_set<ppsr::context>& in_scope_contexts,
   bool qualified_subjects_enabled) {
+    const auto* api = config.api_mode();
+    if (api == nullptr) {
+        return std::nullopt;
+    }
+
+    using exact_context_mapping
+      = model::schema_registry_sync_config::exact_context_mapping;
+
+    // Enumerates every source context the run intends to replicate: those in
+    // scope this run, plus any the filter names eagerly (which the source may
+    // not hold yet). Stops at the first fault `fn` reports. The registry-wide
+    // global (.__GLOBAL) is skipped: the sync writes it to the destination
+    // global directly (a typed store write, never remapped and independent of
+    // qualified subjects), so the mapping-coverage and default-context rules
+    // below do not apply to it.
+    auto for_each_source_context =
+      [&](auto&& fn) -> std::optional<ss::sstring> {
+        auto visit = [&](const ppsr::context& ctx) {
+            return ctx == ppsr::global_context ? std::nullopt : fn(ctx);
+        };
+        for (const auto& ctx : in_scope_contexts) {
+            if (auto r = visit(ctx)) {
+                return r;
+            }
+        }
+        for (const auto& ctx : api->filter.contexts) {
+            if (auto r = visit(ppsr::context{ctx})) {
+                return r;
+            }
+        }
+        // Parse as qualified so a non-default context expressed in subject
+        // syntax is seen, rather than flattened to a default-context subject.
+        for (const auto& sub : api->filter.subjects) {
+            auto parsed = ppsr::context_subject::from_string(
+              sub, ppsr::qualified_subjects_enabled::yes);
+            if (auto r = visit(parsed.ctx)) {
+                return r;
+            }
+        }
+        return std::nullopt;
+    };
+
+    // Mapping-usability checks, independent of qualified_subjects: an exact
+    // mapping must send every in-scope source context to a distinct
+    // destination. A missing mapping would drop a context silently; a shared
+    // destination would make the reverse map (used to scope the destination
+    // scan) ambiguous.
+    if (
+      api->destination.has_value()
+      && std::holds_alternative<exact_context_mapping>(*api->destination)) {
+        const auto& mappings
+          = std::get<exact_context_mapping>(*api->destination).mappings;
+        chunked_hash_set<ppsr::context> destinations;
+        for (const auto& [src, dest] : mappings) {
+            if (!destinations.insert(ppsr::context{dest}).second) {
+                return ssx::sformat(
+                  "context mapping destination '{}' is used by more than one "
+                  "source context",
+                  dest);
+            }
+        }
+        if (
+          auto r = for_each_source_context(
+            [&](const ppsr::context& ctx) -> std::optional<ss::sstring> {
+                if (!mappings.contains(ctx())) {
+                    return ssx::sformat(
+                      "source context '{}' in scope has no destination "
+                      "mapping",
+                      ctx);
+                }
+                return std::nullopt;
+            })) {
+            return r;
+        }
+    }
+
     if (qualified_subjects_enabled) {
         return std::nullopt;
     }
@@ -50,47 +180,18 @@ std::optional<ss::sstring> check_preconditions(
           ctx);
     };
 
-    const auto* api = config.api_mode();
-    if (api == nullptr) {
-        return std::nullopt;
-    }
-
     // Identity mapping (also the default when no remapping is configured):
     // every context the run touches becomes a destination context -- discovered
     // from the source, or named by a context or subject filter the source may
-    // not yet hold.
+    // not yet hold -- so each must be default-context.
     auto reject_identity = [&]() -> std::optional<ss::sstring> {
-        for (const auto& ctx : in_scope_contexts) {
-            if (auto r = rejected(ctx)) {
-                return r;
-            }
-        }
-        // The filter may name a context the source does not hold yet; under
-        // identity mapping it would still be written verbatim, so fail fast.
-        for (const auto& ctx : api->filter.contexts) {
-            if (auto r = rejected(ppsr::context{ctx})) {
-                return r;
-            }
-        }
-        // Parse as qualified to catch a non-default context the operator
-        // expressed in subject syntax; under the off flag it would otherwise be
-        // silently flattened to a literal default-context subject.
-        for (const auto& sub : api->filter.subjects) {
-            auto parsed = ppsr::context_subject::from_string(
-              sub, ppsr::qualified_subjects_enabled::yes);
-            if (auto r = rejected(parsed.ctx)) {
-                return r;
-            }
-        }
-        return std::nullopt;
+        return for_each_source_context(rejected);
     };
     if (!api->destination.has_value()) {
         return reject_identity();
     }
     using identity_context_mapping
       = model::schema_registry_sync_config::identity_context_mapping;
-    using exact_context_mapping
-      = model::schema_registry_sync_config::exact_context_mapping;
     return ss::visit(
       *api->destination,
       [&](const identity_context_mapping&) { return reject_identity(); },

--- a/src/v/cluster_link/schema_registry_sync/scope.h
+++ b/src/v/cluster_link/schema_registry_sync/scope.h
@@ -37,10 +37,52 @@ ss::noncopyable_function<bool(const ppsr::context_subject&)> make_in_scope(
   chunked_hash_set<ppsr::context> contexts,
   chunked_hash_set<ppsr::context_subject> subjects);
 
-/// Returns a fault reason if the configuration would write a non-default
-/// context to the destination while `qualified_subjects_enabled` is off (the
-/// destination can then only represent the default context), else nullopt. The
-/// flag is injected to keep the check pure and testable.
+/// Maps context names between source and destination per the link's configured
+/// destination mapping (identity, or an exact source->destination table).
+///
+/// The reconcile pipeline runs in the source-context namespace; the mapper is
+/// applied only at the destination boundary -- forward() when writing (imports,
+/// mode/config, hard-deletes), reverse() when reading destination state back
+/// into the diff.
+class context_mapper {
+public:
+    /// Identity when no destination mapping is configured or it is the identity
+    /// variant.
+    static context_mapper make(const model::schema_registry_sync_config&);
+
+    /// Source -> destination context; nullopt when an exact mapping has no
+    /// entry (identity and the global context pass through, and the caller
+    /// errors).
+    std::optional<ppsr::context> forward(const ppsr::context&) const;
+
+    /// Destination context -> source context; nullopt for a destination no
+    /// source maps to. A remap target is thereby claimed in its entirety, so
+    /// any subject placed there independently of the link reads as
+    /// source-absent and is hard-deleted -- map only into contexts the mirror
+    /// owns.
+    std::optional<ppsr::context> reverse(const ppsr::context&) const;
+
+    /// True when forward and reverse are both the identity.
+    bool is_identity() const { return _identity; }
+
+private:
+    // The mode, set from the config variant -- not inferred from _fwd
+    // emptiness, because an exact mapping with an empty table is a distinct
+    // state from identity: it covers no source context and so rejects every
+    // one, whereas identity passes every one through.
+    bool _identity{true};
+    // Empty for identity. Otherwise source->dest and its inverse (well-defined
+    // because destinations must be distinct).
+    chunked_hash_map<ppsr::context, ppsr::context> _fwd;
+    chunked_hash_map<ppsr::context, ppsr::context> _rev;
+};
+
+/// Returns a fault reason if the configuration cannot be replicated, else
+/// nullopt. Two classes of check: mapping usability (always) -- under an exact
+/// mapping every in-scope source context must map to a distinct destination;
+/// and the qualified-subject rule (only when `qualified_subjects_enabled` is
+/// off) -- no non-default context may reach the destination. The flag is
+/// injected to keep the check pure and testable.
 std::optional<ss::sstring> check_preconditions(
   const model::schema_registry_sync_config& config,
   const chunked_hash_set<ppsr::context>& in_scope_contexts,

--- a/src/v/cluster_link/schema_registry_sync/source_reader.h
+++ b/src/v/cluster_link/schema_registry_sync/source_reader.h
@@ -22,6 +22,7 @@
 
 #include <cstdint>
 #include <expected>
+#include <optional>
 
 namespace cluster_link::schema_registry_sync {
 
@@ -76,6 +77,18 @@ public:
     /// schema-body fetch path: called for every node it discovers and imports.
     virtual ss::future<source_result<ppsr::stored_schema>> read_subject_version(
       ppsr::context_subject, ppsr::schema_version, ss::abort_source&) = 0;
+
+    /// Reads the source's own (non-inherited) mode override for a subject or
+    /// context: nullopt for no explicit override (subject_mode_not_found), a
+    /// value to mirror, or an operation_failed error for a mode Redpanda cannot
+    /// represent (e.g. FORWARD), which the caller counts rather than treating
+    /// as nullopt.
+    virtual ss::future<source_result<std::optional<ppsr::mode>>>
+    read_mode(ppsr::context_subject, ss::abort_source&) = 0;
+
+    /// As read_mode, for the compatibility-level override.
+    virtual ss::future<source_result<std::optional<ppsr::compatibility_level>>>
+    read_config(ppsr::context_subject, ss::abort_source&) = 0;
 
     /// Releases any resources the reader holds (e.g. an HTTP transport). Called
     /// once before the reader is destroyed; the default is a no-op for readers

--- a/src/v/cluster_link/schema_registry_sync/tests/http_source_reader_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/http_source_reader_test.cc
@@ -311,6 +311,151 @@ TEST(http_source_reader, not_found_maps_to_subject_not_found) {
     EXPECT_EQ(res.error().kind, srs::source_error_kind::subject_not_found);
 }
 
+// read_mode narrows the source's open-enum mode to Redpanda's three-valued
+// mode. READONLY_OVERRIDE has no direct destination value but is read-only, so
+// it is preserved as READONLY rather than dropped.
+TEST(http_source_reader, read_mode_narrows_supported_modes) {
+    struct tc {
+        std::string_view wire;
+        pps::mode expected;
+    };
+    for (auto [wire, expected] : {
+           tc{"READWRITE", pps::mode::read_write},
+           tc{"READONLY", pps::mode::read_only},
+           tc{"READONLY_OVERRIDE", pps::mode::read_only},
+           tc{"IMPORT", pps::mode::import},
+         }) {
+        auto reader = reader_over([wire](mock_client& m) {
+            EXPECT_CALL(m, request_and_collect_response(_, _, _))
+              .WillOnce(respond(
+                bh::status::ok, fmt::format(R"({{"mode":"{}"}})", wire)));
+        });
+        ss::abort_source as;
+        auto res
+          = reader.read_mode(pps::context_subject::unqualified("s1"), as).get();
+        reader.stop().get();
+        ASSERT_TRUE(res.has_value()) << "wire=" << wire;
+        ASSERT_TRUE(res->has_value()) << "wire=" << wire;
+        EXPECT_EQ(**res, expected) << "wire=" << wire;
+    }
+}
+
+// A source mode Redpanda cannot represent (FORWARD, or an unknown value a newer
+// server reports) is a per-item operation_failed the task counts as an error,
+// not a nullopt (which would be misread as "no override").
+TEST(http_source_reader, read_mode_unmappable_is_operation_failed) {
+    for (auto wire : {"FORWARD", "SOMETHING_NEW"}) {
+        auto reader = reader_over([wire](mock_client& m) {
+            EXPECT_CALL(m, request_and_collect_response(_, _, _))
+              .WillOnce(respond(
+                bh::status::ok, fmt::format(R"({{"mode":"{}"}})", wire)));
+        });
+        ss::abort_source as;
+        auto res
+          = reader.read_mode(pps::context_subject::unqualified("s1"), as).get();
+        reader.stop().get();
+        ASSERT_FALSE(res.has_value()) << "wire=" << wire;
+        EXPECT_EQ(res.error().kind, srs::source_error_kind::operation_failed)
+          << "wire=" << wire;
+    }
+}
+
+// A subject with no explicit mode override (HTTP 404 / error_code 40409) is not
+// an error: it reads back as nullopt so the sync knows there is nothing to
+// replicate at this level.
+TEST(http_source_reader, read_mode_absent_override_is_nullopt) {
+    auto reader = reader_over([](mock_client& m) {
+        EXPECT_CALL(m, request_and_collect_response(_, _, _))
+          .WillOnce(respond(bh::status::not_found, R"({"error_code": 40409})"));
+    });
+    ss::abort_source as;
+    auto res
+      = reader.read_mode(pps::context_subject::unqualified("s1"), as).get();
+    reader.stop().get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_FALSE(res->has_value());
+}
+
+// The registry-wide global context is read via GET /mode/:.__GLOBAL: (a
+// context-qualified subject), not the subject-less GET /mode.
+TEST(http_source_reader, read_mode_global_context_hits_global_endpoint) {
+    auto reader = reader_over([](mock_client& m) {
+        EXPECT_CALL(m, request_and_collect_response(_, _, _))
+          .WillOnce([](
+                      bh::request_header<>&& r,
+                      std::optional<iobuf>,
+                      ss::lowres_clock::duration) {
+              EXPECT_THAT(
+                std::string(r.target().data(), r.target().size()),
+                HasSubstr(".__GLOBAL"));
+              return ss::make_ready_future<http::downloaded_response>(
+                http::downloaded_response{
+                  .status = bh::status::ok,
+                  .body = iobuf::from(R"({"mode":"READONLY"})")});
+          });
+    });
+    ss::abort_source as;
+    auto res = reader
+                 .read_mode(
+                   pps::context_subject{pps::global_context, pps::subject{""}},
+                   as)
+                 .get();
+    reader.stop().get();
+
+    ASSERT_TRUE(res.has_value());
+    ASSERT_TRUE(res->has_value());
+    EXPECT_EQ(**res, pps::mode::read_only);
+}
+
+// read_config mirrors read_mode: the seven defined levels narrow one-to-one, an
+// absent override (40408) is nullopt, and an unknown level is operation_failed.
+TEST(http_source_reader, read_config_narrows_and_classifies) {
+    {
+        auto reader = reader_over([](mock_client& m) {
+            EXPECT_CALL(m, request_and_collect_response(_, _, _))
+              .WillOnce(respond(
+                bh::status::ok, R"({"compatibilityLevel":"FULL_TRANSITIVE"})"));
+        });
+        ss::abort_source as;
+        auto res = reader
+                     .read_config(pps::context_subject::unqualified("s1"), as)
+                     .get();
+        reader.stop().get();
+        ASSERT_TRUE(res.has_value());
+        ASSERT_TRUE(res->has_value());
+        EXPECT_EQ(**res, pps::compatibility_level::full_transitive);
+    }
+    {
+        auto reader = reader_over([](mock_client& m) {
+            EXPECT_CALL(m, request_and_collect_response(_, _, _))
+              .WillOnce(
+                respond(bh::status::not_found, R"({"error_code": 40408})"));
+        });
+        ss::abort_source as;
+        auto res = reader
+                     .read_config(pps::context_subject::unqualified("s1"), as)
+                     .get();
+        reader.stop().get();
+        ASSERT_TRUE(res.has_value());
+        EXPECT_FALSE(res->has_value());
+    }
+    {
+        auto reader = reader_over([](mock_client& m) {
+            EXPECT_CALL(m, request_and_collect_response(_, _, _))
+              .WillOnce(respond(
+                bh::status::ok, R"({"compatibilityLevel":"WEIRD_LEVEL"})"));
+        });
+        ss::abort_source as;
+        auto res = reader
+                     .read_config(pps::context_subject::unqualified("s1"), as)
+                     .get();
+        reader.stop().get();
+        ASSERT_FALSE(res.has_value());
+        EXPECT_EQ(res.error().kind, srs::source_error_kind::operation_failed);
+    }
+}
+
 // A null config (not in API mode) or an unparseable URL yields an unavailable
 // reader, so the link parks rather than faulting.
 TEST(http_source_reader, factory_parks_on_missing_or_unparseable_config) {

--- a/src/v/cluster_link/schema_registry_sync/tests/mirroring_task_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/mirroring_task_test.cc
@@ -502,6 +502,163 @@ TEST_F(
     EXPECT_EQ(all[0].deleted, ppsr::is_deleted::yes);
 }
 
+TEST_F(mirroring_task_test, replicates_modes_and_configs) {
+    auto orders = ppsr::context_subject::unqualified("orders-value");
+    _source_state.add(orders, 1);
+    // A subject-level mode and compatibility override on the source.
+    _source_state.modes.emplace(orders, ppsr::mode::read_only);
+    _source_state.configs.emplace(orders, ppsr::compatibility_level::full);
+
+    lead_schema_registry();
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+    ASSERT_TRUE(status.has_value());
+
+    // Exactly one mode and one config change: the subject override. The
+    // context-level and global targets have no source override, so their
+    // no-op deletes do not count.
+    EXPECT_EQ(status->last_full_sync->modes_changed, 1);
+    EXPECT_EQ(status->last_full_sync->compatibility_configs_changed, 1);
+    EXPECT_EQ(status->last_full_sync->errors, 0);
+
+    ASSERT_TRUE(_registry.modes().contains(orders));
+    EXPECT_EQ(_registry.modes().at(orders), ppsr::mode::read_only);
+    ASSERT_TRUE(_registry.configs().contains(orders));
+    EXPECT_EQ(_registry.configs().at(orders), ppsr::compatibility_level::full);
+
+    // A second full sync over unchanged source state applies nothing: the
+    // destination writes short-circuit, so the per-sync counters stay zero
+    // (the totals do not double-count).
+    fixture()->update_link(model::id_t{0}, get_default_metadata()).get();
+    auto second = wait_for_sync_status([&](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value()
+                             && s.last_full_sync->finish_time
+                                  != status->last_full_sync->finish_time;
+                  }).get();
+    ASSERT_TRUE(second.has_value());
+    EXPECT_EQ(second->last_full_sync->modes_changed, 0);
+    EXPECT_EQ(second->last_full_sync->compatibility_configs_changed, 0);
+    EXPECT_EQ(second->totals_since_task_start.modes_changed, 1);
+    EXPECT_EQ(second->totals_since_task_start.compatibility_configs_changed, 1);
+}
+
+TEST_F(mirroring_task_test, removes_destination_override_absent_at_source) {
+    auto orders = ppsr::context_subject::unqualified("orders-value");
+    // The destination carries mode/config overrides from a prior state; the
+    // source subject exists but has no explicit override. The sync must remove
+    // the stale destination overrides.
+    seed_destination("orders-value", 1);
+    _registry.write_mode(orders, ppsr::mode::read_only).get();
+    _registry.write_config(orders, ppsr::compatibility_level::full).get();
+    _source_state.add(orders, 1);
+
+    lead_schema_registry();
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+    ASSERT_TRUE(status.has_value());
+
+    EXPECT_EQ(status->last_full_sync->modes_changed, 1);
+    EXPECT_EQ(status->last_full_sync->compatibility_configs_changed, 1);
+    EXPECT_FALSE(_registry.modes().contains(orders));
+    EXPECT_FALSE(_registry.configs().contains(orders));
+}
+
+TEST_F(mirroring_task_test, unmappable_source_mode_counted_not_applied) {
+    auto orders = ppsr::context_subject::unqualified("orders-value");
+    _source_state.add(orders, 1);
+    // The source reports a mode Redpanda cannot represent (the http reader
+    // surfaces this as operation_failed); it must be counted as a per-item
+    // error and skipped, not applied to the destination.
+    _source_state.read_mode_errors.emplace(
+      orders,
+      srs::source_error{
+        .kind = srs::source_error_kind::operation_failed,
+        .message = "source mode 'FORWARD' is not supported"});
+
+    lead_schema_registry();
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+    ASSERT_TRUE(status.has_value());
+
+    // Exactly one error: the single unmappable mode. Every other target (the
+    // subject's config, the default-context mode/config) is a no-op.
+    EXPECT_EQ(status->last_full_sync->errors, 1);
+    EXPECT_EQ(status->last_full_sync->modes_changed, 0);
+    // The unmappable mode does not block the subject's config sync, which has
+    // no source override here and so applies nothing.
+    EXPECT_FALSE(_registry.modes().contains(orders));
+}
+
+TEST_F(mirroring_task_test, syncs_global_context_mode_and_config) {
+    // An unfiltered sync mirrors the registry-wide global (.__GLOBAL)
+    // mode/config, even though it is not a listable context and holds no
+    // subject.
+    auto global = ppsr::context_subject{
+      ppsr::global_context, ppsr::subject{""}};
+    _source_state.add(ppsr::context_subject::unqualified("orders-value"), 1);
+    _source_state.modes.emplace(global, ppsr::mode::read_only);
+    _source_state.configs.emplace(global, ppsr::compatibility_level::full);
+
+    lead_schema_registry();
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+    ASSERT_TRUE(status.has_value());
+
+    ASSERT_TRUE(_registry.modes().contains(global));
+    EXPECT_EQ(_registry.modes().at(global), ppsr::mode::read_only);
+    ASSERT_TRUE(_registry.configs().contains(global));
+    EXPECT_EQ(_registry.configs().at(global), ppsr::compatibility_level::full);
+    // Exactly the global mode + global config change (no subject/context
+    // override in this DAG).
+    EXPECT_EQ(status->last_full_sync->modes_changed, 1);
+    EXPECT_EQ(status->last_full_sync->compatibility_configs_changed, 1);
+}
+
+TEST_F(mirroring_task_test, skips_global_context_mode_when_filtered_out) {
+    // A link scoped to a specific context must leave the registry-wide global
+    // (.__GLOBAL) alone -- it is synced only by an unfiltered sync or a filter
+    // that names the global context.
+    auto global = ppsr::context_subject{
+      ppsr::global_context, ppsr::subject{""}};
+    auto orders = ppsr::context_subject::unqualified("orders-value");
+    _source_state.add(orders, 1);
+    _source_state.modes.emplace(global, ppsr::mode::read_only);
+
+    auto metadata = get_default_metadata();
+    metadata.configuration.schema_registry_sync_cfg.api_mode()
+      ->filter.contexts.push_back(std::string{ppsr::default_context()});
+
+    lead_schema_registry();
+    fixture()->upsert_link(std::move(metadata)).get();
+
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+    ASSERT_TRUE(status.has_value());
+
+    // The source global override is neither read nor written.
+    EXPECT_FALSE(_registry.modes().contains(global));
+    EXPECT_EQ(status->last_full_sync->modes_changed, 0);
+}
+
 TEST_F(mirroring_task_test, pauses_when_config_paused) {
     lead_schema_registry();
     fixture()->upsert_link(get_default_metadata()).get();

--- a/src/v/cluster_link/schema_registry_sync/tests/mirroring_task_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/mirroring_task_test.cc
@@ -66,7 +66,7 @@ public:
 
         co_await _clmtf->get_manager().invoke_on_all([this](manager& m) {
             return m.register_task_factory<srs::mirroring_task_factory>(
-              &_registry, &_source_factory);
+              dest(), &_source_factory);
         });
 
         fixture()->elect_leader(::model::controller_ntp, self(), std::nullopt);
@@ -156,6 +156,10 @@ public:
         co_return result;
     }
 
+    // The destination registry the task writes to. Overridable so a test can
+    // wrap `_registry` (e.g. to reject deletes); defaults to `_registry`.
+    virtual schema::registry* dest() { return &_registry; }
+
     fake_source_state _source_state;
     fake_source_reader_factory _source_factory{&_source_state};
     schema::fake_registry _registry;
@@ -178,14 +182,15 @@ TEST_F(mirroring_task_test, populates_source_and_destination_inventory) {
     ASSERT_TRUE(status.has_value());
     EXPECT_EQ(status->inventory.selected_source_subjects, 1);
     EXPECT_EQ(status->inventory.selected_source_subject_versions, 2);
-    // The destination counters are refreshed after the import, so they reflect
-    // the post-sync state: the seeded payments-value plus the two imported
-    // orders-value versions.
-    EXPECT_EQ(status->inventory.destination_subjects, 2);
-    EXPECT_EQ(status->inventory.destination_subject_versions, 3);
-    // The two source versions are absent from the destination, so the reconcile
-    // imports both.
-    EXPECT_EQ(status->totals_since_task_start.subject_versions_changed, 2);
+    // The destination counters are refreshed after the sync, so they reflect
+    // the post-sync state. The seeded payments-value is absent from the source,
+    // so hard-delete propagation purges it; only the two imported orders-value
+    // versions remain.
+    EXPECT_EQ(status->inventory.destination_subjects, 1);
+    EXPECT_EQ(status->inventory.destination_subject_versions, 2);
+    // Two orders-value versions imported plus the source-absent payments-value
+    // hard-deleted: three subject-version changes.
+    EXPECT_EQ(status->totals_since_task_start.subject_versions_changed, 3);
     EXPECT_EQ(status->last_full_sync->errors, 0);
 }
 
@@ -502,6 +507,195 @@ TEST_F(
     EXPECT_EQ(all[0].deleted, ppsr::is_deleted::yes);
 }
 
+TEST_F(mirroring_task_test, hard_deletes_source_absent_versions) {
+    auto orders = ppsr::context_subject::unqualified("orders-value");
+    auto payments = ppsr::context_subject::unqualified("payments-value");
+    // The destination has two active subjects; the source only has
+    // orders-value. The source-absent payments-value must be soft-deleted then
+    // hard-deleted, while orders-value is kept.
+    seed_destination("orders-value", 1);
+    seed_destination("payments-value", 1);
+    _source_state.add(orders, 1);
+
+    lead_schema_registry();
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+    ASSERT_TRUE(status.has_value());
+
+    // orders-value was already present (no import); the one change is the
+    // payments-value hard-delete.
+    EXPECT_EQ(status->last_full_sync->subject_versions_changed, 1);
+    EXPECT_EQ(status->last_full_sync->errors, 0);
+
+    const auto& all = _registry.get_all();
+    ASSERT_EQ(all.size(), 1);
+    EXPECT_EQ(all[0].schema.sub(), orders);
+}
+
+TEST_F(
+  mirroring_task_test,
+  out_of_scope_destination_subject_spared_from_hard_delete) {
+    auto orders = ppsr::context_subject::unqualified("orders-value");
+    // Both subjects sit in the default context on the destination, but the
+    // subject filter selects only orders-value, so payments-value is out of
+    // scope. It is absent from the scoped source view -- yet must not be read
+    // as a source hard-delete.
+    seed_destination("orders-value", 1);
+    seed_destination("payments-value", 1);
+    _source_state.add(orders, 1);
+
+    auto metadata = get_default_metadata();
+    metadata.configuration.schema_registry_sync_cfg.api_mode()
+      ->filter.subjects.push_back("orders-value");
+
+    lead_schema_registry();
+    fixture()->upsert_link(std::move(metadata)).get();
+
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+    ASSERT_TRUE(status.has_value());
+
+    // orders-value is already present (no import) and payments-value is out of
+    // scope (no purge), so the sync changes nothing.
+    EXPECT_EQ(status->last_full_sync->subject_versions_changed, 0);
+    EXPECT_EQ(status->last_full_sync->errors, 0);
+
+    // Both destination subjects survive: the in-scope one untouched, the
+    // out-of-scope one spared rather than purged.
+    const auto& all = _registry.get_all();
+    chunked_vector<ppsr::subject> subjects;
+    for (const auto& s : all) {
+        subjects.push_back(s.schema.sub().sub);
+    }
+    EXPECT_THAT(
+      subjects,
+      testing::UnorderedElementsAre(
+        ppsr::subject{"orders-value"}, ppsr::subject{"payments-value"}));
+}
+
+TEST_F(mirroring_task_test, hard_deletes_already_soft_deleted_version) {
+    auto orders = ppsr::context_subject::unqualified("orders-value");
+    // The destination holds orders-value:v1 already soft-deleted; the source no
+    // longer has it at all, so it is purged (directly, no re-soft-delete).
+    _registry
+      .import_schema(
+        make_schema(orders, 1, R"({"v":1})", ppsr::is_deleted::yes))
+      .get();
+
+    lead_schema_registry();
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+    ASSERT_TRUE(status.has_value());
+
+    EXPECT_EQ(status->last_full_sync->subject_versions_changed, 1);
+    EXPECT_TRUE(_registry.get_all().empty());
+}
+
+TEST_F(mirroring_task_test, unlisted_subject_spared_from_hard_delete) {
+    auto orders = ppsr::context_subject::unqualified("orders-value");
+    auto flaky = ppsr::context_subject::unqualified("payments-value");
+    // Both subjects were mirrored on the destination by a prior sync. The
+    // source still has both, but listing flaky's versions fails transiently
+    // (reachable, not unavailable), so it drops out of the discovered source
+    // set and would look source-absent to the purge phase.
+    seed_destination("orders-value", 1);
+    seed_destination("payments-value", 1);
+    _source_state.add(orders, 1);
+    _source_state.add(flaky, 1);
+    _source_state.list_versions_errors.emplace(
+      flaky,
+      srs::source_error{
+        .kind = srs::source_error_kind::operation_failed,
+        .message = "version listing failed"});
+
+    lead_schema_registry();
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+    ASSERT_TRUE(status.has_value());
+    EXPECT_EQ(status->last_full_sync->errors, 1);
+
+    // The unlistable subject is excluded from the purge, so it survives rather
+    // than being erased on a discovery gap; nothing is hard-deleted.
+    EXPECT_EQ(status->last_full_sync->subject_versions_changed, 0);
+    EXPECT_EQ(_registry.get_all().size(), 2u);
+}
+
+TEST_F(mirroring_task_test, deleted_subject_purged_despite_unlisted_peer) {
+    auto flaky = ppsr::context_subject::unqualified("payments-value");
+    auto gone = ppsr::context_subject::unqualified("orders-value");
+    // The destination mirrors two subjects. The source still has flaky (but its
+    // version listing fails transiently) and no longer has gone at all. The
+    // failed peer must not block purging gone: discovery saw the source lacks
+    // it, so it is a real deletion.
+    seed_destination("payments-value", 1);
+    seed_destination("orders-value", 1);
+    _source_state.add(flaky, 1);
+    _source_state.list_versions_errors.emplace(
+      flaky,
+      srs::source_error{
+        .kind = srs::source_error_kind::operation_failed,
+        .message = "version listing failed"});
+
+    lead_schema_registry();
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+    ASSERT_TRUE(status.has_value());
+    EXPECT_EQ(status->last_full_sync->errors, 1);
+
+    // gone is purged (one change); the unlistable flaky is spared and remains.
+    EXPECT_EQ(status->last_full_sync->subject_versions_changed, 1);
+    const auto& all = _registry.get_all();
+    ASSERT_EQ(all.size(), 1u);
+    EXPECT_EQ(all[0].schema.sub(), flaky);
+}
+
+TEST_F(mirroring_task_test, failed_context_listing_spares_its_subjects) {
+    auto kept = ppsr::context_subject::unqualified("orders-value");
+    // The in-scope context's subject listing fails reachably (not unavailable,
+    // which would park the link), so its whole subject set is undiscovered. A
+    // destination subject in that context must be spared the purge rather than
+    // treated as source-absent.
+    seed_destination("orders-value", 1);
+    _source_state.list_subjects_error = srs::source_error{
+      .kind = srs::source_error_kind::operation_failed,
+      .message = "subject listing failed"};
+
+    lead_schema_registry();
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+    ASSERT_TRUE(status.has_value());
+    EXPECT_EQ(status->last_full_sync->errors, 1);
+
+    // The whole context was spared, so its seeded subject survives and nothing
+    // is hard-deleted.
+    EXPECT_EQ(status->last_full_sync->subject_versions_changed, 0);
+    const auto& all = _registry.get_all();
+    ASSERT_EQ(all.size(), 1u);
+    EXPECT_EQ(all[0].schema.sub(), kept);
+}
+
 TEST_F(mirroring_task_test, replicates_modes_and_configs) {
     auto orders = ppsr::context_subject::unqualified("orders-value");
     _source_state.add(orders, 1);
@@ -728,6 +922,87 @@ TEST_F(mirroring_task_test, destination_inventory_spans_contexts_and_deleted) {
 
     EXPECT_THAT(inv.active, testing::UnorderedElementsAre(a_v1, c_v1));
     EXPECT_THAT(inv.all, testing::UnorderedElementsAre(a_v1, c_v1, a_v2));
+}
+
+// Fixture whose destination wraps `_registry` so a test can make permanent
+// deletes fail, exercising the hard-delete retry loop the plain fake cannot.
+class mirroring_task_delete_retry_test : public mirroring_task_test {
+protected:
+    schema::registry* dest() override { return &_deferring; }
+    deferred_delete_registry _deferring{&_registry};
+};
+
+TEST_F(
+  mirroring_task_delete_retry_test,
+  hard_delete_retries_reference_blocked_purge) {
+    auto referrer = ppsr::context_subject::unqualified("referrer-value");
+    auto referent = ppsr::context_subject::unqualified("referent-value");
+    // Both are on the destination but absent from the source, so both are
+    // purged. The referent cannot be deleted until the referrer is, so its
+    // first attempt is rejected; the sync must delete the referrer and retry
+    // the referent in a later round rather than count an error.
+    seed_destination("referrer-value", 1);
+    seed_destination("referent-value", 1);
+    _deferring.block_until_purged(referent, referrer);
+
+    lead_schema_registry();
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+    ASSERT_TRUE(status.has_value());
+    // Both drained within the one sync, no error counted for the retry.
+    EXPECT_EQ(status->last_full_sync->subject_versions_changed, 2);
+    EXPECT_EQ(status->last_full_sync->errors, 0);
+    EXPECT_TRUE(_registry.get_all().empty());
+}
+
+TEST_F(mirroring_task_delete_retry_test, hard_delete_gives_up_on_stuck_purge) {
+    auto orders = ppsr::context_subject::unqualified("orders-value");
+    // A purge that never succeeds (a reference cycle the source can't have, but
+    // defensively handled): once a whole round makes no progress the sync stops
+    // retrying and counts it as one error rather than looping forever.
+    seed_destination("orders-value", 1);
+    _deferring.reject_forever(orders);
+
+    lead_schema_registry();
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+    ASSERT_TRUE(status.has_value());
+    EXPECT_EQ(status->last_full_sync->subject_versions_changed, 0);
+    EXPECT_EQ(status->last_full_sync->errors, 1);
+}
+
+TEST_F(
+  mirroring_task_delete_retry_test,
+  hard_delete_counts_non_reference_error_without_retry) {
+    auto stuck = ppsr::context_subject::unqualified("stuck-value");
+    auto ok = ppsr::context_subject::unqualified("ok-value");
+    // A non-reference destination fault (writes disabled) must be counted once,
+    // immediately -- not deferred and retried like a reference-ordering block.
+    // `ok` purges normally, so a retry loop would re-attempt `stuck` in a later
+    // round; asserting a single attempt pins the no-retry behavior.
+    seed_destination("stuck-value", 1);
+    seed_destination("ok-value", 1);
+    _deferring.fail_with(stuck, ppsr::error_code::writes_disabled);
+
+    lead_schema_registry();
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+    ASSERT_TRUE(status.has_value());
+    EXPECT_EQ(status->last_full_sync->subject_versions_changed, 1);
+    EXPECT_EQ(status->last_full_sync->errors, 1);
+    EXPECT_EQ(_deferring.permanent_delete_attempts(stuck), 1);
 }
 
 } // namespace cluster_link::tests

--- a/src/v/cluster_link/schema_registry_sync/tests/mirroring_task_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/mirroring_task_test.cc
@@ -853,6 +853,142 @@ TEST_F(mirroring_task_test, skips_global_context_mode_when_filtered_out) {
     EXPECT_EQ(status->last_full_sync->modes_changed, 0);
 }
 
+TEST_F(mirroring_task_test, replicates_context_level_mode_and_config) {
+    // A context-level override -- a whole context's default mode/config, keyed
+    // by the empty subject -- mirrors like a subject override, through the
+    // per-context targets of the mode/config pass. It is distinct from a
+    // subject in the context and from the registry-wide global (.__GLOBAL).
+    // Identity mapping, so the override stays under its own (.prod) context.
+    auto prod_ctx = ppsr::context_subject{
+      ppsr::context{".prod"}, ppsr::subject{""}};
+    _source_state.contexts.push_back(ppsr::context{".prod"});
+    _source_state.add(
+      ppsr::context_subject{
+        ppsr::context{".prod"}, ppsr::subject{"orders-value"}},
+      1);
+    _source_state.modes.emplace(prod_ctx, ppsr::mode::read_only);
+    _source_state.configs.emplace(prod_ctx, ppsr::compatibility_level::full);
+
+    lead_schema_registry();
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+    ASSERT_TRUE(status.has_value());
+
+    // Exactly one context-level mode + config change: the subject, the default
+    // context, and the global target carry no override, so their no-op deletes
+    // do not count.
+    EXPECT_EQ(status->last_full_sync->modes_changed, 1);
+    EXPECT_EQ(status->last_full_sync->compatibility_configs_changed, 1);
+    EXPECT_EQ(status->last_full_sync->errors, 0);
+
+    ASSERT_TRUE(_registry.modes().contains(prod_ctx));
+    EXPECT_EQ(_registry.modes().at(prod_ctx), ppsr::mode::read_only);
+    ASSERT_TRUE(_registry.configs().contains(prod_ctx));
+    EXPECT_EQ(
+      _registry.configs().at(prod_ctx), ppsr::compatibility_level::full);
+}
+
+TEST_F(mirroring_task_test, remaps_source_context_to_destination) {
+    // Collapse the source .prod context onto the destination default context.
+    // Mapping to the default target keeps the test independent of the
+    // qualified-subjects cluster config (a non-default destination would need
+    // it enabled). Filter to .prod so the mapping fully covers the scope.
+    auto prod_orders = ppsr::context_subject{
+      ppsr::context{".prod"}, ppsr::subject{"orders-value"}};
+    _source_state.contexts.push_back(ppsr::context{".prod"});
+    _source_state.add(prod_orders, 1);
+    _source_state.modes.emplace(prod_orders, ppsr::mode::read_only);
+    _source_state.configs.emplace(prod_orders, ppsr::compatibility_level::full);
+
+    auto metadata = get_default_metadata();
+    auto* api = metadata.configuration.schema_registry_sync_cfg.api_mode();
+    api->filter.contexts.push_back(".prod");
+    model::schema_registry_sync_config::exact_context_mapping mapping;
+    mapping.mappings.emplace(".prod", std::string{ppsr::default_context()});
+    api->destination = std::move(mapping);
+
+    lead_schema_registry();
+    fixture()->upsert_link(std::move(metadata)).get();
+
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+    ASSERT_TRUE(status.has_value());
+    EXPECT_EQ(status->last_full_sync->subject_versions_changed, 1);
+    EXPECT_EQ(status->last_full_sync->errors, 0);
+
+    // The schema lands in the destination's default context (remapped from
+    // .prod), not in .prod.
+    const auto& all = _registry.get_all();
+    ASSERT_EQ(all.size(), 1);
+    auto dest_orders = ppsr::context_subject::unqualified("orders-value");
+    EXPECT_EQ(all[0].schema.sub(), dest_orders);
+
+    // Mode and compatibility are written under the remapped (default) context.
+    ASSERT_TRUE(_registry.modes().contains(dest_orders));
+    EXPECT_EQ(_registry.modes().at(dest_orders), ppsr::mode::read_only);
+    ASSERT_TRUE(_registry.configs().contains(dest_orders));
+    EXPECT_EQ(
+      _registry.configs().at(dest_orders), ppsr::compatibility_level::full);
+
+    // The destination scan reverse-maps the default context back to .prod, so
+    // the mirrored subject is recognised as in-scope rather than hard-deleted.
+    EXPECT_EQ(status->inventory.destination_subjects, 1);
+    EXPECT_EQ(status->inventory.destination_subject_versions, 1);
+}
+
+TEST_F(mirroring_task_test, remaps_context_level_mode_and_config) {
+    // A context-level override on a source context is written under the
+    // REMAPPED destination context, not the source one -- the context-level
+    // counterpart of remaps_source_context_to_destination. Remaps .prod onto a
+    // distinct .staging context; both are non-default, which the on-by-default
+    // schema_registry_enable_qualified_subjects permits.
+    auto prod_ctx = ppsr::context_subject{
+      ppsr::context{".prod"}, ppsr::subject{""}};
+    auto prod_orders = ppsr::context_subject{
+      ppsr::context{".prod"}, ppsr::subject{"orders-value"}};
+    _source_state.contexts.push_back(ppsr::context{".prod"});
+    _source_state.add(prod_orders, 1);
+    _source_state.modes.emplace(prod_ctx, ppsr::mode::read_only);
+    _source_state.configs.emplace(prod_ctx, ppsr::compatibility_level::full);
+
+    auto metadata = get_default_metadata();
+    auto* api = metadata.configuration.schema_registry_sync_cfg.api_mode();
+    api->filter.contexts.push_back(".prod");
+    model::schema_registry_sync_config::exact_context_mapping mapping;
+    mapping.mappings.emplace(".prod", ".staging");
+    api->destination = std::move(mapping);
+
+    lead_schema_registry();
+    fixture()->upsert_link(std::move(metadata)).get();
+
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+    ASSERT_TRUE(status.has_value());
+    EXPECT_EQ(status->last_full_sync->modes_changed, 1);
+    EXPECT_EQ(status->last_full_sync->compatibility_configs_changed, 1);
+    EXPECT_EQ(status->last_full_sync->errors, 0);
+
+    // The override lands on the remapped .staging context, keyed by the empty
+    // subject; nothing is written under the source .prod context.
+    auto dest_ctx = ppsr::context_subject{
+      ppsr::context{".staging"}, ppsr::subject{""}};
+    ASSERT_TRUE(_registry.modes().contains(dest_ctx));
+    EXPECT_EQ(_registry.modes().at(dest_ctx), ppsr::mode::read_only);
+    ASSERT_TRUE(_registry.configs().contains(dest_ctx));
+    EXPECT_EQ(
+      _registry.configs().at(dest_ctx), ppsr::compatibility_level::full);
+    EXPECT_FALSE(_registry.modes().contains(prod_ctx));
+    EXPECT_FALSE(_registry.configs().contains(prod_ctx));
+}
+
 TEST_F(mirroring_task_test, pauses_when_config_paused) {
     lead_schema_registry();
     fixture()->upsert_link(get_default_metadata()).get();
@@ -910,9 +1046,11 @@ TEST_F(mirroring_task_test, destination_inventory_spans_contexts_and_deleted) {
     _registry.import_schema(make_schema(c, 1, R"({"v":1})")).get();
 
     ss::abort_source as;
+    srs::context_mapper identity;
     auto inv = srs::scan_destination_inventory(
                  _registry,
                  [](const ppsr::context_subject&) { return true; },
+                 identity,
                  as)
                  .get();
 

--- a/src/v/cluster_link/schema_registry_sync/tests/reconciler_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/reconciler_test.cc
@@ -381,10 +381,12 @@ TEST(reconciler, import_errors_are_per_item_and_cascade) {
     fake_source_reader reader{&source};
     srs::reconciler::limits lim{
       .memory_bytes = no_memory_limit, .parallelism = 1};
+    srs::context_mapper mapper;
     auto r = srs::reconciler{
       &reader,
       &destination,
       [](const ppsr::context_subject&) { return true; },
+      mapper,
       lim};
 
     ss::abort_source as;
@@ -466,10 +468,12 @@ TEST(reconciler, abort_mid_sync_drains_cleanly) {
 
     srs::reconciler::limits lim{
       .memory_bytes = no_memory_limit, .parallelism = 4};
+    srs::context_mapper mapper;
     auto r = srs::reconciler{
       &reader,
       &destination,
       [](const ppsr::context_subject&) { return true; },
+      mapper,
       lim};
 
     srs::work_set work;
@@ -519,10 +523,12 @@ TEST(reconciler, reports_progress_live) {
     // the next begins.
     srs::reconciler::limits lim{
       .memory_bytes = no_memory_limit, .parallelism = 1};
+    srs::context_mapper mapper;
     auto r = srs::reconciler{
       &reader,
       &destination,
       [](const ppsr::context_subject&) { return true; },
+      mapper,
       lim};
 
     srs::work_set work;
@@ -674,6 +680,94 @@ TEST(reconciler, concurrent_stress) {
         EXPECT_LT(i_ref, i_rer)
           << fmt::format("{} must precede {}", referent.sub(), referrer.sub());
     }
+}
+
+TEST(reconciler, remaps_context_at_import) {
+    fake_source_state source;
+    source.contexts.push_back(ppsr::context{".prod"});
+    auto base = ppsr::context_subject{
+      ppsr::context{".prod"}, ppsr::subject{"base"}};
+    auto leaf = ppsr::context_subject{
+      ppsr::context{".prod"}, ppsr::subject{"leaf"}};
+    auto orders = ppsr::context_subject{
+      ppsr::context{".prod"}, ppsr::subject{"orders"}};
+    source.add(base, 1);
+    source.add(leaf, 1);
+    // orders references base with a context-qualified reference, and leaf with
+    // an unqualified one (which resolves against orders' own .prod context).
+    source.add_with_refs(
+      orders,
+      1,
+      refs_to(
+        {ref_to(base, 1),
+         ref_to(ppsr::context_subject::unqualified("leaf"), 1)}));
+
+    fake_source_reader reader{&source};
+    schema::fake_registry destination;
+
+    // Map source .prod onto destination .dest.
+    model::schema_registry_sync_config config;
+    model::schema_registry_sync_config::shadow_schema_registry_api api;
+    model::schema_registry_sync_config::exact_context_mapping mapping;
+    mapping.mappings.emplace(".prod", ".dest");
+    api.destination = std::move(mapping);
+    config.sync_mode = std::move(api);
+    auto mapper = srs::context_mapper::make(config);
+
+    srs::reconciler::limits lim{
+      .memory_bytes = no_memory_limit, .parallelism = 1};
+    auto r = srs::reconciler{
+      &reader,
+      &destination,
+      [](const ppsr::context_subject&) { return true; },
+      mapper,
+      lim};
+
+    srs::work_set work;
+    work.upserts.push_back(key(base, 1));
+    work.upserts.push_back(key(leaf, 1));
+    work.upserts.push_back(key(orders, 1));
+    ss::abort_source as;
+    srs::reconcile_stats stats;
+    auto res = r.reconcile(std::move(work), {}, stats, as).get();
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(stats.versions_changed, 3);
+
+    // Every schema lands in the destination .dest context (subject remapped)...
+    const auto& all = destination.get_all();
+    ASSERT_EQ(all.size(), 3u);
+    for (const auto& s : all) {
+        EXPECT_EQ(s.schema.sub().ctx, ppsr::context{".dest"});
+    }
+    const ppsr::stored_schema* orders_stored = nullptr;
+    for (const auto& s : all) {
+        if (s.schema.sub().sub == ppsr::subject{"orders"}) {
+            orders_stored = &s;
+        }
+    }
+    ASSERT_NE(orders_stored, nullptr);
+    const auto& refs = orders_stored->schema.def().refs();
+    ASSERT_EQ(refs.size(), 2u);
+    auto ref_named =
+      [&](std::string_view name) -> const ppsr::schema_reference* {
+        for (const auto& r : refs) {
+            if (r.name == name) {
+                return &r;
+            }
+        }
+        return nullptr;
+    };
+    // ...the qualified reference's own context is remapped to .dest...
+    const auto* base_ref = ref_named("base");
+    ASSERT_NE(base_ref, nullptr);
+    EXPECT_EQ(base_ref->sub.qualified, ppsr::is_qualified::yes);
+    EXPECT_EQ(base_ref->sub.sub.ctx, ppsr::context{".dest"});
+    // ...and the unqualified reference is left as-is (it resolves against the
+    // remapped parent on the destination, so it needs no rewrite).
+    const auto* leaf_ref = ref_named("leaf");
+    ASSERT_NE(leaf_ref, nullptr);
+    EXPECT_EQ(leaf_ref->sub.qualified, ppsr::is_qualified::no);
+    EXPECT_EQ(leaf_ref->sub.sub.ctx, ppsr::default_context);
 }
 
 } // namespace cluster_link::tests

--- a/src/v/cluster_link/schema_registry_sync/tests/scope_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/scope_test.cc
@@ -111,6 +111,171 @@ TEST(scope, in_scope_filter_union_semantics) {
     }
 }
 
+TEST(scope, context_mapper_identity_passes_through) {
+    // No destination configured: forward and reverse are the identity, so the
+    // whole sync stays in the source namespace unchanged.
+    auto mapper = srs::context_mapper::make(config_with());
+    EXPECT_TRUE(mapper.is_identity());
+    EXPECT_EQ(mapper.forward(ppsr::context{".prod"}), ppsr::context{".prod"});
+    EXPECT_EQ(mapper.forward(ppsr::default_context), ppsr::default_context);
+    EXPECT_EQ(mapper.reverse(ppsr::context{".prod"}), ppsr::context{".prod"});
+
+    // An explicit identity mapping is equivalent to no destination.
+    model::schema_registry_sync_config::shadow_schema_registry_api api;
+    api.destination
+      = model::schema_registry_sync_config::identity_context_mapping{};
+    auto explicit_identity = srs::context_mapper::make(
+      config_with(std::move(api)));
+    EXPECT_TRUE(explicit_identity.is_identity());
+    EXPECT_EQ(
+      explicit_identity.forward(ppsr::context{".x"}), ppsr::context{".x"});
+}
+
+TEST(scope, context_mapper_exact_maps_both_ways) {
+    model::schema_registry_sync_config::shadow_schema_registry_api api;
+    model::schema_registry_sync_config::exact_context_mapping mapping;
+    mapping.mappings.emplace(".prod", ".dest");
+    mapping.mappings.emplace(".stage", ".dest-stage");
+    api.destination = std::move(mapping);
+    auto mapper = srs::context_mapper::make(config_with(std::move(api)));
+
+    EXPECT_FALSE(mapper.is_identity());
+    // Forward rewrites a configured source context to its destination.
+    EXPECT_EQ(mapper.forward(ppsr::context{".prod"}), ppsr::context{".dest"});
+    EXPECT_EQ(
+      mapper.forward(ppsr::context{".stage"}), ppsr::context{".dest-stage"});
+    // Reverse recovers the source context from its destination.
+    EXPECT_EQ(mapper.reverse(ppsr::context{".dest"}), ppsr::context{".prod"});
+    EXPECT_EQ(
+      mapper.reverse(ppsr::context{".dest-stage"}), ppsr::context{".stage"});
+    // A destination context no source maps to is out of scope.
+    EXPECT_EQ(mapper.reverse(ppsr::context{".prod"}), std::nullopt);
+    EXPECT_EQ(mapper.reverse(ppsr::default_context), std::nullopt);
+    // An unmapped source context has no destination -> nullopt, so callers drop
+    // the unit rather than leak an un-remapped context (check_preconditions
+    // covers every in-scope context; this guards one appearing afterwards).
+    EXPECT_EQ(mapper.forward(ppsr::context{".other"}), std::nullopt);
+    // The registry-wide global is never remapped, so it passes through even
+    // under an exact mapping (its mode/config is written to the dest global).
+    EXPECT_EQ(mapper.forward(ppsr::global_context), ppsr::global_context);
+}
+
+TEST(scope, context_mapper_empty_exact_rejects_all_not_identity) {
+    // An exact mapping with an empty table covers no source context, so it is
+    // NOT identity: forward/reverse must reject every non-global context rather
+    // than pass it through. (This is distinct from an identity or
+    // no-destination config, which pass everything through -- see
+    // context_mapper_identity_passes_through.) check_preconditions rejects such
+    // a config before the mapper is built whenever any context is in scope, but
+    // the mapper must still encode reject-all so the two modes never alias.
+    model::schema_registry_sync_config::shadow_schema_registry_api api;
+    api.destination
+      = model::schema_registry_sync_config::exact_context_mapping{};
+    auto mapper = srs::context_mapper::make(config_with(std::move(api)));
+
+    EXPECT_FALSE(mapper.is_identity());
+    EXPECT_EQ(mapper.forward(ppsr::context{".prod"}), std::nullopt);
+    EXPECT_EQ(mapper.forward(ppsr::default_context), std::nullopt);
+    EXPECT_EQ(mapper.reverse(ppsr::context{".prod"}), std::nullopt);
+    EXPECT_EQ(mapper.reverse(ppsr::default_context), std::nullopt);
+    // The global is still written to the destination global directly, so it
+    // passes through even under an (empty) exact mapping.
+    EXPECT_EQ(mapper.forward(ppsr::global_context), ppsr::global_context);
+}
+
+TEST(scope, preconditions_exact_mapping_requires_full_coverage) {
+    model::schema_registry_sync_config::shadow_schema_registry_api api;
+    model::schema_registry_sync_config::exact_context_mapping mapping;
+    mapping.mappings.emplace(".prod", ".dest");
+    api.destination = std::move(mapping);
+    auto config = config_with(std::move(api));
+
+    // The default context is in scope but unmapped: a source context with no
+    // destination would be dropped silently, so it faults regardless of the
+    // qualified-subjects flag (a usability check, not the qualified rule).
+    chunked_hash_set<ppsr::context> uncovered;
+    uncovered.insert(ppsr::default_context);
+    uncovered.insert(ppsr::context{".prod"});
+    EXPECT_TRUE(srs::check_preconditions(config, uncovered, true).has_value());
+    EXPECT_TRUE(srs::check_preconditions(config, uncovered, false).has_value());
+
+    // With only the mapped context in scope, the mapping fully covers it (the
+    // non-default target still needs qualified subjects, so check with the flag
+    // on).
+    chunked_hash_set<ppsr::context> covered;
+    covered.insert(ppsr::context{".prod"});
+    EXPECT_FALSE(srs::check_preconditions(config, covered, true).has_value());
+}
+
+TEST(scope, preconditions_exact_mapping_requires_coverage_of_filter_contexts) {
+    // A schema is imported only if it is in scope, and a context-qualified
+    // reference to another context is imported only if that context is in scope
+    // too (else the referrer is failed at reconcile time). "In scope" is
+    // defined by the source filter, so a context the filter names -- as a
+    // referenced context would be -- but the exact mapping omits must fault at
+    // config validation, before forward() would silently pass the unmapped
+    // context through to the destination. Checked with qualified subjects ON so
+    // only the mapping-coverage rule can fault (the qualified rule
+    // short-circuits), and with an empty discovered-context set so the fault
+    // comes purely from the filter, not from list_contexts.
+    chunked_hash_set<ppsr::context> no_discovered;
+
+    // A context filter names an unmapped context.
+    {
+        model::schema_registry_sync_config::shadow_schema_registry_api api;
+        api.filter.contexts.push_back(".a");
+        api.filter.contexts.push_back(".b"); // in scope, no destination mapping
+        model::schema_registry_sync_config::exact_context_mapping mapping;
+        mapping.mappings.emplace(".a", ".x");
+        api.destination = std::move(mapping);
+        auto config = config_with(std::move(api));
+        EXPECT_TRUE(
+          srs::check_preconditions(config, no_discovered, true).has_value());
+    }
+    // A subject filter in qualified syntax names a subject in an unmapped
+    // context -- the individual-subject shape a reference takes.
+    {
+        model::schema_registry_sync_config::shadow_schema_registry_api api;
+        api.filter.subjects.push_back(":.b:orders"); // .b in scope, unmapped
+        model::schema_registry_sync_config::exact_context_mapping mapping;
+        mapping.mappings.emplace(".a", ".x");
+        api.destination = std::move(mapping);
+        auto config = config_with(std::move(api));
+        EXPECT_TRUE(
+          srs::check_preconditions(config, no_discovered, true).has_value());
+    }
+    // Mapping every filtered context clears the fault.
+    {
+        model::schema_registry_sync_config::shadow_schema_registry_api api;
+        api.filter.contexts.push_back(".a");
+        api.filter.contexts.push_back(".b");
+        model::schema_registry_sync_config::exact_context_mapping mapping;
+        mapping.mappings.emplace(".a", ".x");
+        mapping.mappings.emplace(".b", ".y");
+        api.destination = std::move(mapping);
+        auto config = config_with(std::move(api));
+        EXPECT_FALSE(
+          srs::check_preconditions(config, no_discovered, true).has_value());
+    }
+}
+
+TEST(scope, preconditions_exact_mapping_rejects_duplicate_destination) {
+    model::schema_registry_sync_config::shadow_schema_registry_api api;
+    model::schema_registry_sync_config::exact_context_mapping mapping;
+    mapping.mappings.emplace(".a", ".x");
+    mapping.mappings.emplace(".b", ".x"); // collision: two sources -> .x
+    api.destination = std::move(mapping);
+    auto config = config_with(std::move(api));
+
+    chunked_hash_set<ppsr::context> in_scope;
+    in_scope.insert(ppsr::context{".a"});
+    in_scope.insert(ppsr::context{".b"});
+    // A shared destination makes the reverse map ambiguous, so it is rejected
+    // regardless of the qualified-subjects flag.
+    EXPECT_TRUE(srs::check_preconditions(config, in_scope, true).has_value());
+    EXPECT_TRUE(srs::check_preconditions(config, in_scope, false).has_value());
+}
+
 TEST(scope, preconditions_remapping_target_requires_qualified) {
     model::schema_registry_sync_config::shadow_schema_registry_api api;
     model::schema_registry_sync_config::exact_context_mapping mapping;
@@ -160,6 +325,36 @@ TEST(scope, preconditions_nondefault_filter_requires_qualified) {
         auto config = config_with(std::move(api));
         EXPECT_TRUE(srs::check_preconditions(config, empty, false).has_value());
         EXPECT_FALSE(srs::check_preconditions(config, empty, true).has_value());
+    }
+}
+
+TEST(scope, preconditions_global_context_exempt) {
+    // The registry-wide global (.__GLOBAL) is written to the destination global
+    // directly -- never remapped and independent of qualified subjects -- so
+    // naming it in a filter must not fault, unlike a real non-default context.
+    const auto global = ss::sstring{ppsr::global_context()};
+    chunked_hash_set<ppsr::context> empty;
+
+    // Under an exact mapping that covers the real source context but not
+    // .__GLOBAL, the global is exempt from the mapping-coverage check.
+    {
+        model::schema_registry_sync_config::shadow_schema_registry_api api;
+        api.filter.contexts.push_back(".prod");
+        api.filter.contexts.push_back(global);
+        model::schema_registry_sync_config::exact_context_mapping mapping;
+        mapping.mappings.emplace(".prod", ".dest");
+        api.destination = std::move(mapping);
+        auto config = config_with(std::move(api));
+        EXPECT_FALSE(srs::check_preconditions(config, empty, true).has_value());
+    }
+    // With qualified subjects off, a non-default context filter faults, but
+    // .__GLOBAL alone does not.
+    {
+        model::schema_registry_sync_config::shadow_schema_registry_api api;
+        api.filter.contexts.push_back(global);
+        auto config = config_with(std::move(api));
+        EXPECT_FALSE(
+          srs::check_preconditions(config, empty, false).has_value());
     }
 }
 

--- a/src/v/cluster_link/schema_registry_sync/tests/sr_sync_test_fixtures.h
+++ b/src/v/cluster_link/schema_registry_sync/tests/sr_sync_test_fixtures.h
@@ -327,10 +327,15 @@ struct reconcile_harness {
     // assertions.
     srs::reconciler::limits lim{.memory_bytes = 1u << 20, .parallelism = 1};
 
+    // Identity mapping by default: source and destination contexts coincide, so
+    // reconcile tests need no remapping.
+    srs::context_mapper mapper;
+
     srs::reconciler make(
       ss::noncopyable_function<bool(const ppsr::context_subject&)> in_scope =
         [](const ppsr::context_subject&) { return true; }) {
-        return srs::reconciler{&reader, &destination, std::move(in_scope), lim};
+        return srs::reconciler{
+          &reader, &destination, std::move(in_scope), mapper, lim};
     }
 
     ss::future<srs::source_result<srs::reconcile_stats>>

--- a/src/v/cluster_link/schema_registry_sync/tests/sr_sync_test_fixtures.h
+++ b/src/v/cluster_link/schema_registry_sync/tests/sr_sync_test_fixtures.h
@@ -495,4 +495,71 @@ private:
     chunked_hash_map<ppsr::subject_version, ppsr::error_info> _failures;
 };
 
+// Wraps a destination registry, modeling the real Schema Registry's refusal to
+// permanently delete a version still referenced by a live one (the in-memory
+// fake never rejects a delete). Lets a test drive the hard-delete retry loop: a
+// referent stays blocked until its referrer is purged, so the sync must delete
+// the referrer first and retry the referent in a later round rather than count
+// an error; a permanently-blocked delete ends up counted once.
+class deferred_delete_registry final : public delegating_registry {
+public:
+    using delegating_registry::delegating_registry;
+
+    // Reject permanent deletes of `referent` until `referrer` has been
+    // permanently deleted -- models a live reference the purge must clear
+    // first.
+    void block_until_purged(
+      const ppsr::context_subject& referent,
+      const ppsr::context_subject& referrer) {
+        _blocked_on.insert_or_assign(referent, referrer);
+    }
+    // Reject every permanent delete of `subject` -- models a permanently-stuck
+    // delete (e.g. a reference cycle) that must end up counted as an error.
+    void reject_forever(const ppsr::context_subject& subject) {
+        _forever.insert(subject);
+    }
+    // Reject every permanent delete of `subject` with a non-reference error --
+    // models a real destination fault the purge must count immediately rather
+    // than retry as if it were reference ordering.
+    void fail_with(const ppsr::context_subject& subject, ppsr::error_code ec) {
+        _fail_with.insert_or_assign(subject, ec);
+    }
+    size_t
+    permanent_delete_attempts(const ppsr::context_subject& subject) const {
+        auto it = _attempts.find(subject);
+        return it == _attempts.end() ? 0 : it->second;
+    }
+
+    ss::future<chunked_vector<ppsr::schema_version>> permanent_delete_schema(
+      ppsr::context_subject sub,
+      std::optional<ppsr::schema_version> v) override {
+        ++_attempts[sub];
+        if (auto f = _fail_with.find(sub); f != _fail_with.end()) {
+            return ss::make_exception_future<
+              chunked_vector<ppsr::schema_version>>(ppsr::as_exception(
+              ppsr::error_info{f->second, "destination fault"}));
+        }
+        auto it = _blocked_on.find(sub);
+        const bool blocked
+          = _forever.contains(sub)
+            || (it != _blocked_on.end() && !_purged.contains(it->second));
+        if (blocked) {
+            return ss::make_exception_future<
+              chunked_vector<ppsr::schema_version>>(ppsr::as_exception(
+              ppsr::error_info{
+                ppsr::error_code::subject_version_has_references,
+                "referenced by a live schema"}));
+        }
+        _purged.insert(sub);
+        return _inner->permanent_delete_schema(std::move(sub), v);
+    }
+
+private:
+    chunked_hash_map<ppsr::context_subject, ppsr::context_subject> _blocked_on;
+    chunked_hash_set<ppsr::context_subject> _forever;
+    chunked_hash_map<ppsr::context_subject, ppsr::error_code> _fail_with;
+    chunked_hash_map<ppsr::context_subject, size_t> _attempts;
+    chunked_hash_set<ppsr::context_subject> _purged;
+};
+
 } // namespace cluster_link::tests

--- a/src/v/cluster_link/schema_registry_sync/tests/sr_sync_test_fixtures.h
+++ b/src/v/cluster_link/schema_registry_sync/tests/sr_sync_test_fixtures.h
@@ -120,6 +120,17 @@ struct fake_source_state {
     // nodes, letting a test inject a mid-run source fault (e.g.
     // source_unavailable).
     chunked_hash_map<ppsr::subject_version, srs::source_error> read_errors;
+    // Source own-override modes/configs, keyed by subject or context-only
+    // target. Absence means "no explicit override" (read_mode/read_config
+    // return nullopt). The default context, if present, models the global
+    // mode/config.
+    chunked_hash_map<ppsr::context_subject, ppsr::mode> modes;
+    chunked_hash_map<ppsr::context_subject, ppsr::compatibility_level> configs;
+    // Forces read_mode/read_config to fail for specific targets, letting a test
+    // model an unmappable source value (operation_failed) or a fault.
+    chunked_hash_map<ppsr::context_subject, srs::source_error> read_mode_errors;
+    chunked_hash_map<ppsr::context_subject, srs::source_error>
+      read_config_errors;
 
     void fail_read(
       const ppsr::context_subject& sub,
@@ -253,6 +264,32 @@ public:
           srs::source_error{
             .kind = srs::source_error_kind::operation_failed,
             .message = "not found in source"});
+    }
+
+    ss::future<srs::source_result<std::optional<ppsr::mode>>>
+    read_mode(ppsr::context_subject sub, ss::abort_source&) override {
+        if (
+          auto it = _state->read_mode_errors.find(sub);
+          it != _state->read_mode_errors.end()) {
+            co_return std::unexpected(it->second);
+        }
+        if (auto it = _state->modes.find(sub); it != _state->modes.end()) {
+            co_return std::optional<ppsr::mode>{it->second};
+        }
+        co_return std::optional<ppsr::mode>{std::nullopt};
+    }
+
+    ss::future<srs::source_result<std::optional<ppsr::compatibility_level>>>
+    read_config(ppsr::context_subject sub, ss::abort_source&) override {
+        if (
+          auto it = _state->read_config_errors.find(sub);
+          it != _state->read_config_errors.end()) {
+            co_return std::unexpected(it->second);
+        }
+        if (auto it = _state->configs.find(sub); it != _state->configs.end()) {
+            co_return std::optional<ppsr::compatibility_level>{it->second};
+        }
+        co_return std::optional<ppsr::compatibility_level>{std::nullopt};
     }
 
 private:

--- a/src/v/cluster_link/schema_registry_sync/unavailable_source_reader.cc
+++ b/src/v/cluster_link/schema_registry_sync/unavailable_source_reader.cc
@@ -45,6 +45,17 @@ unavailable_source_reader::read_subject_version(
     co_return std::unexpected(unavailable());
 }
 
+ss::future<source_result<std::optional<ppsr::mode>>>
+unavailable_source_reader::read_mode(ppsr::context_subject, ss::abort_source&) {
+    co_return std::unexpected(unavailable());
+}
+
+ss::future<source_result<std::optional<ppsr::compatibility_level>>>
+unavailable_source_reader::read_config(
+  ppsr::context_subject, ss::abort_source&) {
+    co_return std::unexpected(unavailable());
+}
+
 std::unique_ptr<source_reader> unavailable_source_reader_factory::create(
   const model::schema_registry_sync_config::shadow_schema_registry_api*) {
     return std::make_unique<unavailable_source_reader>();

--- a/src/v/cluster_link/schema_registry_sync/unavailable_source_reader.h
+++ b/src/v/cluster_link/schema_registry_sync/unavailable_source_reader.h
@@ -46,6 +46,12 @@ public:
     ss::future<source_result<ppsr::stored_schema>> read_subject_version(
       ppsr::context_subject, ppsr::schema_version, ss::abort_source&) override;
 
+    ss::future<source_result<std::optional<ppsr::mode>>>
+    read_mode(ppsr::context_subject, ss::abort_source&) override;
+
+    ss::future<source_result<std::optional<ppsr::compatibility_level>>>
+    read_config(ppsr::context_subject, ss::abort_source&) override;
+
 private:
     source_error unavailable() const;
 

--- a/src/v/schema/tests/fake_registry.h
+++ b/src/v/schema/tests/fake_registry.h
@@ -105,6 +105,21 @@ public:
 
     const std::vector<pandaproxy::schema_registry::stored_schema>& get_all();
 
+    /// Test accessors for the mode/config overrides written to the registry, so
+    /// a test can assert what mode/config replication applied.
+    const std::map<
+      pandaproxy::schema_registry::context_subject,
+      pandaproxy::schema_registry::mode>&
+    modes() const {
+        return _modes;
+    }
+    const std::map<
+      pandaproxy::schema_registry::context_subject,
+      pandaproxy::schema_registry::compatibility_level>&
+    configs() const {
+        return _configs;
+    }
+
     void set_inject_failures(const std::exception_ptr& injected) {
         _injected_failure = injected;
     }

--- a/tests/rptest/tests/cluster_linking_schema_registry_sync_test.py
+++ b/tests/rptest/tests/cluster_linking_schema_registry_sync_test.py
@@ -645,6 +645,42 @@ class SchemaRegistrySyncE2ETest(ShadowLinkTestBase):
         )
 
     @cluster(num_nodes=6)
+    def test_schema_registry_api_sync_hard_delete(self):
+        # A source hard-delete (which requires a soft-delete first on the
+        # destination) being propagated as a purge -- a path the reconciler unit
+        # fakes cannot cover.
+        src = SchemaRegistryRedpandaClient(self.source_cluster_service)
+        dest = SchemaRegistryRedpandaClient(self.target_cluster_service)
+
+        keep, gone = "keep-value", "gone-value"
+        schema = self._record("V", [{"name": "v", "type": "string"}])
+        self._register(src, keep, schema)
+        self._register(src, gone, schema)
+
+        self._create_sr_link()
+        self._wait_synced(src, dest, [(keep, 1), (gone, 1)])
+
+        # Hard-delete gone-value at the source (soft then permanent). The next
+        # full sync must purge it from the destination, soft-deleting the still
+        # active destination version before the permanent delete.
+        assert src.delete_subject(gone).status_code == 200
+        assert src.delete_subject(gone, permanent=True).status_code == 200
+
+        def gone_purged() -> bool:
+            active, deleted = self._version_state(dest, gone)
+            return not active and not deleted
+
+        wait_until(
+            gone_purged,
+            timeout_sec=90,
+            backoff_sec=1,
+            err_msg="source hard-delete was not propagated to the destination",
+        )
+
+        # The in-source subject is untouched by the purge.
+        assert self._schema_view(dest, keep, 1) is not None
+
+    @cluster(num_nodes=6)
     def test_schema_registry_api_sync_out_of_scope_reference(self):
         src = SchemaRegistryRedpandaClient(self.source_cluster_service)
         dest = SchemaRegistryRedpandaClient(self.target_cluster_service)

--- a/tests/rptest/tests/cluster_linking_schema_registry_sync_test.py
+++ b/tests/rptest/tests/cluster_linking_schema_registry_sync_test.py
@@ -192,6 +192,8 @@ class SchemaRegistrySyncE2ETest(ShadowLinkTestBase):
         source_url: str | None = None,
         full_sync_interval_sec: int = 2,
         source_filter_subjects: list[str] | None = None,
+        source_filter_contexts: list[str] | None = None,
+        exact_context_map: dict[str, str] | None = None,
     ) -> str:
         # Create a shadow link that syncs only the Schema Registry, in API mode,
         # pointing at the source cluster's SR endpoint (or an explicit URL, e.g.
@@ -215,6 +217,13 @@ class SchemaRegistrySyncE2ETest(ShadowLinkTestBase):
         )
         if source_filter_subjects is not None:
             api.source_filter.subjects.extend(source_filter_subjects)
+        if source_filter_contexts is not None:
+            api.source_filter.contexts.extend(source_filter_contexts)
+        if exact_context_map is not None:
+            for source, destination in exact_context_map.items():
+                api.destination.exact.mappings.add(
+                    source=source, destination=destination
+                )
         req.shadow_link.configurations.schema_registry_sync_options.shadow_schema_registry_api.CopyFrom(
             api
         )
@@ -312,10 +321,12 @@ class SchemaRegistrySyncE2ETest(ShadowLinkTestBase):
 
     # --- status-counter checks ---------------------------------------------
 
-    # Counters the create-only reconcile does not yet populate: the admin API /
-    # rpk map them through, but they stay zero until compatibility, mode, and
-    # unsupported-feature handling are implemented.
-    UNPOPULATED_COUNTERS = (
+    # Counters expected to stay zero in the override-free DAG tests: those DAGs
+    # register no mode or compatibility overrides, so mode/config replication is
+    # a no-op, and unsupported-feature handling is unimplemented. A test that
+    # sets overrides (test_schema_registry_api_sync_compatibility) asserts the
+    # compatibility counter advances.
+    EXPECTED_ZERO_COUNTERS = (
         "compatibility_configs_changed",
         "modes_changed",
         "unsupported_features_removed",
@@ -393,7 +404,7 @@ class SchemaRegistrySyncE2ETest(ShadowLinkTestBase):
         assert totals.HasField("start_time"), totals
         assert totals.start_time.seconds > 0, totals
         assert not totals.HasField("finish_time"), totals
-        for name in self.UNPOPULATED_COUNTERS:
+        for name in self.EXPECTED_ZERO_COUNTERS:
             assert getattr(totals, name) == 0, (
                 f"unexpected {name}={getattr(totals, name)}"
             )
@@ -435,7 +446,7 @@ class SchemaRegistrySyncE2ETest(ShadowLinkTestBase):
         assert inv["destination_subject_versions"] == expected_versions, status
         assert totals["subject_versions_changed"] == expected_versions, status
         assert totals["errors"] == 0, status
-        for name in self.UNPOPULATED_COUNTERS:
+        for name in self.EXPECTED_ZERO_COUNTERS:
             assert totals[name] == 0, status
 
     @cluster(num_nodes=6)
@@ -556,6 +567,82 @@ class SchemaRegistrySyncE2ETest(ShadowLinkTestBase):
         assert src.delete_subject_version(after, "2").status_code == 200
         assert src.delete_subject(whole).status_code == 200
         self._wait_delete_synced(src, dest, subjects)
+
+    @cluster(num_nodes=6)
+    def test_schema_registry_api_sync_compatibility(self):
+        # A subject-level compatibility override round-tripping through the
+        # destination's write API -- a path the reconciler unit fakes cannot
+        # cover -- then un-setting it so the destination reverts to the
+        # inherited default. Mode replication is covered e2e by
+        # test_schema_registry_api_sync_context_remap.
+        src = SchemaRegistryRedpandaClient(self.source_cluster_service)
+        dest = SchemaRegistryRedpandaClient(self.target_cluster_service)
+
+        keep = "keep-value"
+        schema = self._record("V", [{"name": "v", "type": "string"}])
+        self._register(src, keep, schema)
+        # A subject-level compatibility override on the source, to be mirrored.
+        assert (
+            src.set_config_subject(
+                keep, data=json.dumps({"compatibility": "FULL"})
+            ).status_code
+            == 200
+        )
+
+        self._create_sr_link()
+        self._wait_synced(src, dest, [(keep, 1)])
+
+        # The compatibility override replicates to the destination and moves the
+        # compatibility_configs_changed counter.
+        def config_synced() -> bool:
+            c = dest.get_config_subject(keep)
+            return c.status_code == 200 and c.json().get("compatibilityLevel") == "FULL"
+
+        wait_until(
+            config_synced,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="compatibility config did not replicate to the destination",
+        )
+        wait_until(
+            lambda: self._admin_sr_status().totals_since_task_start.compatibility_configs_changed
+            >= 1,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="compatibility_configs_changed counter did not advance",
+        )
+
+        # Un-setting the source override propagates as a delete, reverting the
+        # destination subject to the inherited (global) default rather than
+        # leaving the stale FULL override behind.
+        before = self._admin_sr_status().totals_since_task_start.compatibility_configs_changed
+        assert src.delete_config_subject(keep).status_code == 200
+
+        def config_delete_synced() -> bool:
+            # With no subject-level override remaining, a non-fallback GET on the
+            # destination reports it missing (40401); a fallback GET now yields
+            # the global default rather than the removed FULL override.
+            missing = dest.get_config_subject(keep).status_code == 404
+            fallback = dest.get_config_subject(keep, fallback=True)
+            reverted = (
+                fallback.status_code == 200
+                and fallback.json().get("compatibilityLevel") != "FULL"
+            )
+            return missing and reverted
+
+        wait_until(
+            config_delete_synced,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="config override deletion did not replicate to the destination",
+        )
+        wait_until(
+            lambda: self._admin_sr_status().totals_since_task_start.compatibility_configs_changed
+            > before,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="compatibility_configs_changed counter did not advance for the delete",
+        )
 
     @cluster(num_nodes=6)
     def test_schema_registry_api_sync_out_of_scope_reference(self):

--- a/tests/rptest/tests/cluster_linking_schema_registry_sync_test.py
+++ b/tests/rptest/tests/cluster_linking_schema_registry_sync_test.py
@@ -55,11 +55,13 @@ class SchemaRegistrySyncE2ETest(ShadowLinkTestBase):
     EXTRA_MIDS = 10
 
     def __init__(self, test_context: TestContext, *args: Any, **kwargs: Any):
+        source_sr_config = SchemaRegistryConfig()
+        source_sr_config.mode_mutability = True
         super().__init__(
             test_context,
             # Source (secondary) cluster runs a Schema Registry too.
             secondary_cluster_args=SecondaryClusterArgs(
-                schema_registry_config=SchemaRegistryConfig()
+                schema_registry_config=source_sr_config
             ),
             # Destination (primary) cluster Schema Registry.
             schema_registry_config=SchemaRegistryConfig(),
@@ -679,6 +681,163 @@ class SchemaRegistrySyncE2ETest(ShadowLinkTestBase):
 
         # The in-source subject is untouched by the purge.
         assert self._schema_view(dest, keep, 1) is not None
+
+    @cluster(num_nodes=6)
+    def test_schema_registry_api_sync_context_remap(self):
+        src = SchemaRegistryRedpandaClient(self.source_cluster_service)
+        dest = SchemaRegistryRedpandaClient(self.target_cluster_service)
+
+        def qualified(ctx: str, name: str) -> str:
+            return f":{ctx}:{name}"
+
+        def by_name(refs: list[dict]) -> list[dict]:
+            return sorted(refs, key=lambda r: r["name"])
+
+        base_src = qualified(".prod", "base-value")
+        leaf_src = qualified(".prod", "leaf-value")
+        orders_src = qualified(".prod", "orders-value")
+        base_dst = qualified(".dest", "base-value")
+        leaf_dst = qualified(".dest", "leaf-value")
+        orders_dst = qualified(".dest", "orders-value")
+
+        base_schema = self._record("Base", [{"name": "b", "type": "string"}])
+        leaf_schema = self._record("Leaf", [{"name": "l", "type": "string"}])
+        orders_schema = self._record(
+            "Orders",
+            [
+                {"name": "base", "type": f"{NS}.Base"},
+                {"name": "leaf", "type": f"{NS}.Leaf"},
+            ],
+        )
+
+        # Register referents first (the source SR validates references on
+        # registration). orders references base with a context-qualified
+        # reference (":.prod:base-value") and leaf with an unqualified one (the
+        # bare "leaf-value", which the source resolves against orders' own .prod
+        # context).
+        self._register(src, base_src, base_schema)
+        self._register(src, leaf_src, leaf_schema)
+        self._register(
+            src,
+            orders_src,
+            orders_schema,
+            references=[
+                self._ref(f"{NS}.Base", base_src),
+                self._ref(f"{NS}.Leaf", "leaf-value"),
+            ],
+        )
+
+        # Subject-level compatibility and mode overrides on the referrer, both to
+        # be mirrored under the remapped context. Set the mode last: READONLY
+        # blocks no further writes here, and the destination import bypasses it.
+        assert (
+            src.set_config_subject(
+                orders_src, data=json.dumps({"compatibility": "FULL"})
+            ).status_code
+            == 200
+        )
+        assert (
+            src.set_mode_subject(
+                orders_src, data=json.dumps({"mode": "READONLY"})
+            ).status_code
+            == 200
+        )
+
+        # The source's canonical stored forms; the destination is compared
+        # against these (not against the registered dicts) so the assertions do
+        # not depend on SR canonicalization. Capturing them also guards the test
+        # premise: the qualified reference is stored qualified and the
+        # unqualified one is NOT canonicalized into a qualified subject.
+        src_base = self._schema_view(src, base_src, 1)
+        src_leaf = self._schema_view(src, leaf_src, 1)
+        src_orders = self._schema_view(src, orders_src, 1)
+        assert src_base is not None and src_leaf is not None
+        assert src_orders is not None
+        assert by_name(src_orders["references"]) == by_name(
+            [
+                {"name": f"{NS}.Base", "subject": base_src, "version": 1},
+                {"name": f"{NS}.Leaf", "subject": "leaf-value", "version": 1},
+            ]
+        ), src_orders["references"]
+
+        # Replicate only .prod, remapping it onto the destination .dest context.
+        self._create_sr_link(
+            source_filter_contexts=[".prod"],
+            exact_context_map={".prod": ".dest"},
+        )
+
+        expected_orders_refs = by_name(
+            [
+                # The qualified reference's own context is remapped .prod -> .dest.
+                {"name": f"{NS}.Base", "subject": base_dst, "version": 1},
+                # The unqualified reference is untouched: on the destination it
+                # resolves against orders' remapped .dest parent.
+                {"name": f"{NS}.Leaf", "subject": "leaf-value", "version": 1},
+            ]
+        )
+
+        def remapped() -> bool:
+            b = self._schema_view(dest, base_dst, 1)
+            leaf = self._schema_view(dest, leaf_dst, 1)
+            o = self._schema_view(dest, orders_dst, 1)
+            if b is None or leaf is None or o is None:
+                return False
+            # Referents (no references of their own) replicate verbatim.
+            if b != src_base or leaf != src_leaf:
+                return False
+            # The referrer keeps its ID and body; only its reference contexts
+            # remap.
+            return (
+                o["id"] == src_orders["id"]
+                and o["schema"] == src_orders["schema"]
+                and by_name(o["references"]) == expected_orders_refs
+            )
+
+        wait_until(
+            remapped,
+            timeout_sec=90,
+            backoff_sec=1,
+            err_msg="schemas/references did not remap into the .dest context",
+        )
+
+        # Nothing is written under the original .prod context on the destination.
+        for sub in (base_src, leaf_src, orders_src):
+            assert self._schema_view(dest, sub, 1) is None, sub
+
+        # The compatibility and mode overrides replicate under the remapped
+        # context (read the explicit override, not the global fallback).
+        def overrides_remapped() -> bool:
+            c = dest.get_config_subject(orders_dst)
+            m = dest.get_mode_subject(orders_dst, fallback=False)
+            return (
+                c.status_code == 200
+                and c.json().get("compatibilityLevel") == "FULL"
+                and m.status_code == 200
+                and m.json().get("mode") == "READONLY"
+            )
+
+        wait_until(
+            overrides_remapped,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="compatibility/mode overrides did not remap into .dest",
+        )
+
+        # Both overrides are counted, and the remap completed error-free.
+        def counters_advanced() -> bool:
+            totals = self._admin_sr_status().totals_since_task_start
+            return (
+                totals.compatibility_configs_changed >= 1
+                and totals.modes_changed >= 1
+                and totals.errors == 0
+            )
+
+        wait_until(
+            counters_advanced,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="mode/compatibility counters did not advance under remap",
+        )
 
     @cluster(num_nodes=6)
     def test_schema_registry_api_sync_out_of_scope_reference(self):


### PR DESCRIPTION
- Integrate mode and config reading into the source reader
- Replicate subject/context/global-context-level modes and configs
- Propagate Schema Registry hard-deletes by purging destination versions the source no longer has, with safeguards against transient source listing failures erasing valid mirror data.
- Wire context remapping through the sync so a source context replicates into a differently-named destination context, with identity mapping as a passthrough.
- Adds unit and end-to-end test coverage for all of the above

Fixes https://redpandadata.atlassian.net/browse/CORE-16746
Fixes https://redpandadata.atlassian.net/browse/CORE-16605

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
