### PR TITLE
raft: process replication_monitor waiters directly

### DIFF
--- a/src/v/raft/replication_monitor.cc
+++ b/src/v/raft/replication_monitor.cc
@@ -13,38 +13,13 @@
 
 #include "raft/consensus.h"
 #include "raft/errc.h"
-#include "ssx/future-util.h"
 
 #include <ranges>
 
 namespace raft {
 
 replication_monitor::replication_monitor(consensus* r)
-  : _raft(r) {
-    ssx::repeat_until_gate_closed(_gate, [this] {
-        return do_notify_replicated().handle_exception(
-          [this](const std::exception_ptr& e) {
-              if (!ssx::is_shutdown_exception(e)) {
-                  vlog(
-                    _raft->_ctxlog.error,
-                    "Exception running replication monitor, ignoring: {}",
-                    e);
-              }
-          });
-    });
-
-    ssx::repeat_until_gate_closed(_gate, [this] {
-        return do_notify_committed().handle_exception(
-          [this](const std::exception_ptr& e) {
-              if (!ssx::is_shutdown_exception(e)) {
-                  vlog(
-                    _raft->_ctxlog.error,
-                    "Exception running replication monitor, ignoring: {}",
-                    e);
-              }
-          });
-    });
-}
+  : _raft(r) {}
 
 fmt::iterator replication_monitor::format_to(fmt::iterator it) const {
     static constexpr long max_waiters_to_print = 3;
@@ -68,13 +43,11 @@ fmt::iterator replication_monitor::format_to(fmt::iterator it) const {
 }
 
 ss::future<> replication_monitor::stop() {
-    auto f = _gate.close();
     for (auto& [_, waiter] : _waiters) {
         waiter->done.set_value(errc::shutting_down);
     }
-    _committed_event_cv.broken();
-    _replicated_event_cv.broken();
-    return f;
+    _waiters.clear();
+    return _gate.close();
 }
 
 ss::future<errc> replication_monitor::do_wait_until(
@@ -161,28 +134,30 @@ bool replication_monitor::is_append_replicated(
            && _raft->_majority_replicated_index >= append_info.last_offset;
 }
 
-ss::future<> replication_monitor::do_notify_replicated() {
-    if (_pending_majority_replication_waiters > 0) {
-        auto majority_replicated_offset = _raft->_majority_replicated_index;
-        auto it = _waiters.begin();
-        while (it != _waiters.end()
-               && it->first <= majority_replicated_offset) {
-            auto& entry = it->second;
-            auto& append_info = entry->append_info;
-            if (
-              entry->type == wait_type::majority_replication
-              && is_append_replicated(append_info)) {
-                entry->done.set_value(errc::success);
-                it = _waiters.erase(it);
-            } else {
-                ++it;
-            }
+void replication_monitor::notify_replicated() {
+    if (_gate.is_closed() || _pending_majority_replication_waiters == 0) {
+        return;
+    }
+    auto majority_replicated_offset = _raft->_majority_replicated_index;
+    auto it = _waiters.begin();
+    while (it != _waiters.end() && it->first <= majority_replicated_offset) {
+        auto& entry = it->second;
+        auto& append_info = entry->append_info;
+        if (
+          entry->type == wait_type::majority_replication
+          && is_append_replicated(append_info)) {
+            entry->done.set_value(errc::success);
+            it = _waiters.erase(it);
+        } else {
+            ++it;
         }
     }
-    co_await _replicated_event_cv.wait();
 }
 
-ss::future<> replication_monitor::do_notify_committed() {
+void replication_monitor::notify_committed() {
+    if (_gate.is_closed() || _waiters.empty()) {
+        return;
+    }
     auto committed_offset = _raft->committed_offset();
     auto committed_offset_term = _raft->get_term(committed_offset);
     auto it = _waiters.begin();
@@ -207,21 +182,6 @@ ss::future<> replication_monitor::do_notify_committed() {
             ++it;
         }
     }
-    co_await _committed_event_cv.wait();
-}
-
-void replication_monitor::notify_replicated() {
-    if (_gate.is_closed()) {
-        return;
-    }
-    _replicated_event_cv.signal();
-}
-
-void replication_monitor::notify_committed() {
-    if (_gate.is_closed()) {
-        return;
-    }
-    _committed_event_cv.signal();
 }
 
 replication_monitor::waiter::waiter(

--- a/src/v/raft/replication_monitor.h
+++ b/src/v/raft/replication_monitor.h
@@ -17,7 +17,6 @@
 #include "model/fundamental.h"
 #include "storage/types.h"
 
-#include <seastar/core/condition-variable.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
 
@@ -37,9 +36,9 @@ class consensus;
  *   2. offset majority replicated (without flush)
  *
  * Internally this class maintains a list of waiters for these events.
- * The main work loop that notifies these waiters runs out side of
- * consensus op lock. The waiters are also notified of the truncation
- * event if the desired offset is truncated in case of a leadership change.
+ * Waiters are notified directly from the consensus event hooks.
+ * The waiters are also notified of the truncation event if the
+ * desired offset is truncated in case of a leadership change.
  */
 class replication_monitor {
 public:
@@ -99,9 +98,6 @@ private:
         }
     };
 
-    ss::future<> do_notify_replicated();
-    ss::future<> do_notify_committed();
-
     ss::future<errc> do_wait_until(storage::append_result, wait_type);
 
     bool is_append_replicated(const storage::append_result&) const;
@@ -116,8 +112,6 @@ private:
     waiters_type _waiters;
     ss::gate _gate;
 
-    ss::condition_variable _replicated_event_cv;
-    ss::condition_variable _committed_event_cv;
     // Tracks the number of waiters of type majority_replication in
     // the waiters map. This is an optimization to avoid looping
     // through all waiters in the map if there are no waiters


### PR DESCRIPTION
The replication_monitor ran two background loops (do_notify_replicated,
do_notify_committed) parked on condition variables. Each notify_*() call
signaled the CV, waking the loop (1 task), which processed the _waiters
map and parked again. Further it used a fairly inefficient
repeat_until_gate_closed which induces many unneeded extra tasks.

Remove the loops, CVs, and do_notify_* methods. Move the waiter-
processing logic into notify_replicated() and notify_committed() directly.

Per-iter delta vs baseline (tasks / instructions / allocs):
  produce 1_KiB:   40.42 -> 32.42   58633 -> 56269   100.36 -> 92.34
  raft quorum_16B: 129.34 -> 105.30  169108 -> 161034  289.85 -> 265.79

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
