### PR TITLE
[CORE-16253] dl/translation/tests: de-flake test_happy_path timing

### DIFF
--- a/src/v/datalake/translation/tests/fair_scheduling_policy_tests.cc
+++ b/src/v/datalake/translation/tests/fair_scheduling_policy_tests.cc
@@ -133,11 +133,22 @@ TEST_F_CORO(simple_fair_scheduling_policy_fixture, test_happy_path) {
            .translation_throughput_bytes_per_sec = 1_MiB,
            .num_concurrent_writers = 1}));
     }
-    // 120 * 10ms = 12s
-    static constexpr size_t expected_translations = 120;
+    // With no contention every translator should be scheduled repeatedly and
+    // accrue running time. Running time per translation is dominated by the
+    // mock's sleeps, not the 10ms quota: the running window spans
+    // translate + maybe_checkpoint + notify_done, and notify_done alone sleeps
+    // 100ms every cycle.
+    //   - large-lag (1min): never checkpoints during the test
+    //     -> ~110ms/translation
+    //   - small-lag (10ms): checkpoints every cycle (+100ms)
+    //     -> ~210ms/translation
+    // A large-lag translator reaches >12s running time at ~110 translations
+    // (~14s wall); a small-lag translator reaches >100 translations at ~23s
+    // wall. Both are well under the 45s deadline.
+    static constexpr size_t expected_translations = 100;
     static constexpr auto expected_runtime
       = std::chrono::duration_cast<clock::duration>(12s);
-    RPTEST_REQUIRE_EVENTUALLY_CORO(30s, [this]() {
+    RPTEST_REQUIRE_EVENTUALLY_CORO(45s, [this]() {
         const auto& translators = _scheduler->all_translators();
         return std::all_of(
           translators.begin(), translators.end(), [](const auto& it) {


### PR DESCRIPTION
The slowest small-lag translator needs ~28s to reach 120 scheduled translations (each cycle is dominated by two 100ms mock sleeps, not the 10ms quota), leaving little margin under the 30s deadline. Cut the required count to 100 and raise the deadline to 45s.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
