### PR TITLE
[CORE-16624] `kgo-verifier`: keep consumer-group client alive across transient errors

### DIFF
--- a/tests/go/kgo-verifier/pkg/worker/verifier/group_read_worker.go
+++ b/tests/go/kgo-verifier/pkg/worker/verifier/group_read_worker.go
@@ -194,16 +194,12 @@ func (grw *GroupReadWorker) Wait(ctx context.Context) error {
 						"fiber %v: restarting consumer group reader for error %v",
 						fiberId, err)
 
-					// Since we are consuming with a consumer group it is legal
-					// to read older offsets on next try.
-					//
-					// Note for maintainers: Consider implementing checkpointing
-					// on consumer group commits and reverting monotonicity test
-					// state up to last commit. This will further validate
-					// linearizability of offset commits.
-					grw.Status.Validator.ResetMonotonicityTestState()
-
-					// Loop around and retry
+					// Loop around and retry. Transient group/coordinator errors
+					// no longer reach here (the poll loop keeps the client alive
+					// and lets franz-go recover); this only fires on genuine
+					// unrecoverable errors. Monotonicity state is reset on
+					// (re)assignment via the OnPartitionsAssigned callback, so no
+					// reset is needed here.
 				} else {
 					log.Infof("fiber %v: consumer group reader finished", fiberId)
 					break
@@ -228,6 +224,14 @@ func (grw *GroupReadWorker) consumerGroupReadInner(
 	opts = append(opts, []kgo.Opt{
 		kgo.ConsumeTopics(grw.config.workerCfg.Topic),
 		kgo.ConsumerGroup(groupName),
+		// A consumer group legally re-reads from the last commit when partitions
+		// are (re)assigned after a rebalance, which can move offsets/leader
+		// epochs backwards. Reset the monotonicity baseline on assignment so
+		// those re-reads don't trip the out-of-order check -- without tearing
+		// down the client (see the poll loop below).
+		kgo.OnPartitionsAssigned(func(_ context.Context, _ *kgo.Client, _ map[string][]int32) {
+			grw.Status.Validator.ResetMonotonicityTestState()
+		}),
 	}...)
 	if grw.config.rateLimitBytes > 0 {
 		// reduce batch size for smoother rate limiting
@@ -260,7 +264,6 @@ func (grw *GroupReadWorker) consumerGroupReadInner(
 			return ctx.Err()
 		}
 
-		var r_err error
 		fetches.EachError(func(t string, p int32, err error) {
 			log.Warnf(
 				"fiber %v: Consumer group fetch %s/%d e=%v...",
@@ -273,14 +276,16 @@ func (grw *GroupReadWorker) consumerGroupReadInner(
 				} else {
 					log.Fatalf("Unexpected data loss detected: %v", lossErr)
 				}
-			} else {
-				r_err = err
 			}
+			// Other fetch errors (coordinator moves, rebalances, connection
+			// drops) are transient: franz-go manages the group membership and
+			// recovers on continued polling, keeping this member's id stable.
+			// We deliberately do NOT tear down and recreate the client here --
+			// doing so rejoins as a brand-new member, and under coordinator
+			// churn that piles up phantom members and wedges the group in a
+			// never-completing rebalance. Log and keep polling; a genuine lack
+			// of progress is caught by the caller's progress timeout.
 		})
-
-		if r_err != nil {
-			return r_err
-		}
 
 		fetches.EachRecord(func(r *kgo.Record) {
 			log.Debugf(


### PR DESCRIPTION
When kgo-verifier sees an error propagated from the kafka client, it
creates a new client and joins as a new member with a new id.  In tests
with failure injection or other behavior which causes movement of the
__consumer_offsets leader, this creates a problem as the consumer group
won't be able to sync without waiting out the entire rebalance timeout,
which is likely longer than the period between leader changes induced
by the test.

Normally, franz-go retries this sort of error internally.  However, it
will eventually give up after a time period or number of retries and
propagate the error to the caller.  Once that happens to one of the
kgo-verifier fibers, it'll rejoin as a new id forcing a rebalance and
preventing progress across all fibers.  This is relatively rare, so it
doesn't cause a high rate of CI failure, but it seems to reliably stall
progress when it does happen.

To avoid this behavior, this patch modifies group_read_worker.go to
retain the client instance and thus ID for non-data-loss errors.
We do still need to reset the monotonicity validator, so the patch
moves that reset into the kgo.OnPartitionsAssigned callback

Addresses the target consumer-group stall in CORE-16624.

## How was it tested?

Validated with a two-phase recovery reproduction (a separate, not-for-merge
harness): coordinator-leadership churn + forced rebalances drive the readers
into the recreate loop, then leadership churn is relaxed to a rate slower
than the rebalance timeout but well within what a healthy client needs to
recover.

- Without this patch: the target consumer group froze mid-consume and the
  workload stalled out the progress timeout -> FAIL.
- With this patch: the `NOT_COORDINATOR` path still fires (the changed code
  is exercised), but the client stays alive (0 restarts), recovers, and the
  workload completes -> PASS.

## Backports Required

- [x] none - papercut/not impactful enough to backport

## Release Notes

* none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
