### PR TITLE
[v25.2.x] datalake: fix namespace-gone race in table name smoke test

### DIFF
--- a/tests/rptest/tests/datalake/datalake_table_name_test.py
+++ b/tests/rptest/tests/datalake/datalake_table_name_test.py
@@ -39,6 +39,33 @@ class DatalakeTableNameTest(RedpandaTest):
         # redpanda will be started by DatalakeServices
         pass
 
+    @staticmethod
+    def _wait_for_table_gone(spark, table_name: str):
+        def table_gone() -> bool:
+            try:
+                return table_name not in [
+                    row[1]
+                    for row in spark.run_query_fetch_all("SHOW TABLES IN redpanda")
+                ]
+            except pyhive.exc.OperationalError as e:
+                # Purging the last table deletes all files under the
+                # namespace prefix in S3, so the namespace disappears.
+                # An absent namespace means the table is gone too.
+                # JDBC-backed catalogs report NoSuchNamespaceException.
+                # HadoopCatalog instead gets FileNotFoundException from
+                # S3AFileSystem and wraps it as RuntimeIOException
+                # ("Failed to list tables under: <ns>").
+                msg = str(e)
+                if "NoSuchNamespaceException" in msg or "Failed to list tables" in msg:
+                    return True
+                raise
+
+        wait_until(
+            table_gone,
+            timeout_sec=30,
+            err_msg=f"Table {table_name} was not deleted",
+        )
+
     # For iceberg, should it be an icecube test?
     def _iceberg_dot_replacement_smoke(self, dl, topic, replacement):
         rpk = RpkTool(self.redpanda)
@@ -78,12 +105,8 @@ class DatalakeTableNameTest(RedpandaTest):
             timeout_sec=30,
             err_msg=f"Topic {topic} was not deleted",
         )
-        wait_until(
-            lambda: expected_table
-            not in spark.run_query_fetch_all("SHOW TABLES IN redpanda"),
-            timeout_sec=30,
-            err_msg=f"Table {expected_table} was not deleted",
-        )
+
+        self._wait_for_table_gone(spark, expected_table)
 
     @cluster(num_nodes=3)
     @matrix(
@@ -161,25 +184,7 @@ class DatalakeTableNameTest(RedpandaTest):
                 err_msg=f"Topic {topic} was not deleted",
             )
 
-            def dlq_table_gone() -> bool:
-                try:
-                    return expected_dlq_table not in [
-                        row[1]
-                        for row in spark.run_query_fetch_all("SHOW TABLES IN redpanda")
-                    ]
-                except pyhive.exc.OperationalError as e:
-                    if "NoSuchNamespaceException" in str(e):
-                        # Purging the last table deletes all files under the
-                        # namespace prefix in S3, so the namespace disappears.
-                        # An absent namespace means the table is gone too.
-                        return True
-                    raise
-
-            wait_until(
-                dlq_table_gone,
-                timeout_sec=30,
-                err_msg=f"DLQ table {expected_dlq_table} was not deleted",
-            )
+            self._wait_for_table_gone(spark, expected_dlq_table)
 
 
 class DatalakeTableNameInvalidReplacementTest(RedpandaTest):


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31030

- Command: git cherry-pick -x cb44e29070
- Commits backported: 1
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-31030-v25.2.x-1783450604

## Conflict details

- cb44e29070 (tests/rptest/tests/datalake/datalake_table_name_test.py): the commit replaces the inline `dlq_table_gone` helper with a call to the newly-extracted shared `_wait_for_table_gone` method. The target branch had an older inline `dlq_table_gone` that only handled `NoSuchNamespaceException` (missing the `"Failed to list tables"` case). Resolved by accepting the incoming side (`self._wait_for_table_gone(spark, expected_dlq_table)`); the shared helper added by this commit already covers both exception cases, so the consolidation is a strict superset of the target's prior behavior.
