### PR TITLE
`model`: add `for_each_record<Fields...>()` 

### DIFF
--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -16,6 +16,7 @@
 #include "cloud_topics/level_zero/stm/placeholder.h"
 #include "cloud_topics/level_zero/stm/types.h"
 #include "cloud_topics/types.h"
+#include "model/record_fields.h"
 #include "model/timeout_clock.h"
 #include "raft/consensus.h"
 #include "raft/persisted_stm.h"
@@ -38,8 +39,8 @@ cluster_epoch extract_epoch(model::record_batch&& batch) {
       "Expected batch type to be ctp_placeholder, got {}",
       batch.header().type);
     iobuf value;
-    batch.for_each_record([&value](model::record&& r) {
-        value = std::move(r).release_value();
+    batch.for_each_record<model::record_field::value>([&value](auto r) {
+        value = std::move(r.value);
         return ss::stop_iteration::yes;
     });
 
@@ -377,8 +378,8 @@ void ctp_stm::apply_placeholder(const model::record_batch& batch) {
     vassert(
       batch.record_count() > 0, "Record batch must have at least one record");
     iobuf value;
-    batch.for_each_record([&value](model::record&& r) {
-        value = std::move(r).release_value();
+    batch.for_each_record<model::record_field::value>([&value](auto r) {
+        value = std::move(r.value);
         return ss::stop_iteration::yes;
     });
     auto placeholder = serde::from_iobuf<ctp_placeholder>(std::move(value));

--- a/src/v/model/BUILD
+++ b/src/v/model/BUILD
@@ -39,6 +39,7 @@ redpanda_cc_library(
         "record.h",
         "record_batch_reader.h",
         "record_batch_types.h",
+        "record_fields.h",
         "record_utils.h",
         "timeout_clock.h",
         "timestamp.h",

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -39,6 +39,7 @@
 #include <cstdint>
 #include <limits>
 #include <numeric>
+#include <stdexcept>
 #include <variant>
 #include <vector>
 
@@ -357,6 +358,12 @@ private:
     iobuf _value;
     chunked_vector<record_header> _headers{};
 };
+
+/// Compile-time record-field selector for `record_batch::for_each_record<>()`.
+/// The enumerators, the `parsed_record<>` return type and the parsing logic all
+/// live in `model/record_fields.h`; only the opaque enum is forward-declared
+/// here so `record_batch` can declare its `for_each_record<>` members.
+enum class record_field : uint8_t;
 
 class record_batch_attributes final {
 public:
@@ -927,6 +934,12 @@ public:
     /**
      * Iterate over records with lazy record materialization.
      *
+     * This function materializes every `model::record` within the batch,
+     * which includes making allocations and copies for each record's key,
+     * value, headers, etc. If you are writing a loop over a record batch which
+     * only requires a subset of the fields present in `model::record`, strongly
+     * consider using `for_each_record<Fields...>()` for optimization purposes.
+     *
      * Use `model::for_each_record(..)` for futurized version.
      */
     template<typename Func>
@@ -944,6 +957,24 @@ public:
             }
         }
     }
+
+    /**
+     * Iterate over records materializing only the requested `Fields`.
+     *
+     * `f` is invoked with a `parsed_record<Fields...>&&` that exposes exactly
+     * the requested fields as members. Unrequested variable-length fields
+     * (key/value/headers) are skipped in the buffer rather than copied out.
+     *
+     * As with `for_each_record`, `f` may return `ss::stop_iteration` to halt.
+     */
+    template<record_field First, record_field... Rest, typename Func>
+    void for_each_record(Func f) const;
+
+    /**
+     * Futurized `for_each_record<Fields...>`.
+     */
+    template<record_field First, record_field... Rest, typename Func>
+    ss::future<> for_each_record_async(Func f) const;
 
     /**
      * Iterate over record metadata.

--- a/src/v/model/record_fields.h
+++ b/src/v/model/record_fields.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "bytes/bytes.h"
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
 #include "container/chunked_vector.h"
@@ -41,10 +42,19 @@ enum class record_field : uint8_t {
     timestamp_delta,
     /// `int32_t` delta from the batch base offset.
     offset_delta,
+    /// `int32_t`, the key's raw length varint: -1 for a null key, 0 for an
+    /// empty one. Matches `record::key_size()`.
+    key_size,
     /// `iobuf`, empty when the record has a null/empty key.
     key,
+    /// `bytes`, the key materialized into contiguous memory instead of an
+    /// `iobuf`. Mutually exclusive with `key`.
+    key_bytes,
     /// `bool`, true when the record has a null value.
     is_tombstone,
+    /// `int32_t`, the value's raw length varint: -1 for a null value (a
+    /// tombstone), 0 for an empty one. Matches `record::value_size()`.
+    value_size,
     /// `iobuf`, empty when the record has a null/empty value.
     value,
     /// `chunked_vector<record_header>`.
@@ -77,13 +87,28 @@ struct record_field_holder<record_field::offset_delta> {
 };
 
 template<>
+struct record_field_holder<record_field::key_size> {
+    int32_t key_size{-1};
+};
+
+template<>
 struct record_field_holder<record_field::key> {
     iobuf key;
 };
 
 template<>
+struct record_field_holder<record_field::key_bytes> {
+    bytes key_bytes;
+};
+
+template<>
 struct record_field_holder<record_field::is_tombstone> {
     bool is_tombstone{false};
+};
+
+template<>
+struct record_field_holder<record_field::value_size> {
+    int32_t value_size{-1};
 };
 
 template<>
@@ -103,9 +128,12 @@ inline constexpr std::array record_field_layout_order{
   record_field::headers,
   record_field::key,
   record_field::value,
+  record_field::key_bytes,
   record_field::timestamp_delta,
   record_field::size_bytes,
   record_field::offset_delta,
+  record_field::key_size,
+  record_field::value_size,
   record_field::attributes,
   record_field::is_tombstone,
 };
@@ -139,6 +167,18 @@ using layout_sorted_pack_t
   = decltype(make_layout_pack<layout_sorted_fields<Fields...>()>(
     std::make_index_sequence<sizeof...(Fields)>{}));
 
+/// Materialize `len` bytes from the parser as an `iobuf`, zero-copy sharing
+/// when the parser supports it (`iobuf_parser`) and copying otherwise
+/// (`iobuf_const_parser`).
+template<typename Parser>
+iobuf consume_buf(Parser& p, size_t len) {
+    if constexpr (requires { p.share(len); }) {
+        return p.share(len);
+    } else {
+        return p.copy(len);
+    }
+}
+
 } // namespace detail
 
 /// \brief The subset of a record materialized by `parse_record_fields<>()`.
@@ -167,19 +207,26 @@ struct parsed_record : detail::layout_sorted_pack_t<Fields...> {
 /// are materialized) and the record's declared size is validated against the
 /// bytes its fields actually occupy, so a malformed record throws instead of
 /// being silently skipped over.
-template<bool FullyParse, record_field... Fields>
-parsed_record<Fields...> parse_record_fields(iobuf_const_parser& p) {
+template<bool FullyParse, record_field... Fields, typename Parser>
+parsed_record<Fields...> parse_record_fields(Parser& p) {
     constexpr auto wants = [](record_field f) {
         return ((Fields == f) || ...);
     };
+    static_assert(
+      !(wants(record_field::key) && wants(record_field::key_bytes)),
+      "key and key_bytes are two representations of the same field; request "
+      "only one");
 
     // A field must be decoded (though not necessarily materialized) when it is
     // requested, when any later field is requested, or when `FullyParse`
     // requires walking the whole record.
     constexpr bool reach_headers = wants(record_field::headers) || FullyParse;
     constexpr bool reach_value = reach_headers || wants(record_field::value)
+                                 || wants(record_field::value_size)
                                  || wants(record_field::is_tombstone);
-    constexpr bool reach_key = reach_value || wants(record_field::key);
+    constexpr bool reach_key = reach_value || wants(record_field::key)
+                               || wants(record_field::key_bytes)
+                               || wants(record_field::key_size);
     constexpr bool reach_offset = reach_key
                                   || wants(record_field::offset_delta);
     constexpr bool reach_ts = reach_offset
@@ -220,7 +267,15 @@ parsed_record<Fields...> parse_record_fields(iobuf_const_parser& p) {
         skip_tail();
         return out;
     }
-    auto attr = p.consume_type<record_attributes::type>();
+    /*
+     * require that record attributes be unaffected by endianness. all of the
+     * other record fields are properly handled by virtue of their types being
+     * either blobs or variable length integers.
+     */
+    static_assert(
+      sizeof(record_attributes::type) == 1,
+      "model attributes expected to be one byte");
+    auto attr = p.template consume_type<record_attributes::type>();
     if constexpr (wants(record_field::attributes)) {
         out.attributes = record_attributes(attr);
     }
@@ -255,9 +310,16 @@ parsed_record<Fields...> parse_record_fields(iobuf_const_parser& p) {
             key_length,
             record_size));
     }
+    if constexpr (wants(record_field::key_size)) {
+        out.key_size = static_cast<int32_t>(key_length);
+    }
     if constexpr (wants(record_field::key)) {
         if (key_length > 0) {
-            out.key = p.copy(static_cast<size_t>(key_length));
+            out.key = detail::consume_buf(p, static_cast<size_t>(key_length));
+        }
+    } else if constexpr (wants(record_field::key_bytes)) {
+        if (key_length > 0) {
+            out.key_bytes = p.read_bytes(static_cast<size_t>(key_length));
         }
     } else if constexpr (reach_value) {
         // Key not requested, but a later field is: advance past it. When key is
@@ -275,6 +337,9 @@ parsed_record<Fields...> parse_record_fields(iobuf_const_parser& p) {
     if constexpr (wants(record_field::is_tombstone)) {
         out.is_tombstone = value_length < 0;
     }
+    if constexpr (wants(record_field::value_size)) {
+        out.value_size = static_cast<int32_t>(value_length);
+    }
     if (value_length > record_size) [[unlikely]] {
         throw std::out_of_range(
           fmt::format(
@@ -284,7 +349,8 @@ parsed_record<Fields...> parse_record_fields(iobuf_const_parser& p) {
     }
     if constexpr (wants(record_field::value)) {
         if (value_length > 0) {
-            out.value = p.copy(static_cast<size_t>(value_length));
+            out.value = detail::consume_buf(
+              p, static_cast<size_t>(value_length));
         }
     } else if constexpr (reach_headers) {
         if (value_length > 0) {
@@ -312,7 +378,7 @@ parsed_record<Fields...> parse_record_fields(iobuf_const_parser& p) {
         [[maybe_unused]] iobuf hkey;
         if (hk_len > 0) {
             if constexpr (wants(record_field::headers)) {
-                hkey = p.copy(static_cast<size_t>(hk_len));
+                hkey = detail::consume_buf(p, static_cast<size_t>(hk_len));
             } else {
                 p.skip(static_cast<size_t>(hk_len));
             }
@@ -321,7 +387,7 @@ parsed_record<Fields...> parse_record_fields(iobuf_const_parser& p) {
         [[maybe_unused]] iobuf hval;
         if (hv_len > 0) {
             if constexpr (wants(record_field::headers)) {
-                hval = p.copy(static_cast<size_t>(hv_len));
+                hval = detail::consume_buf(p, static_cast<size_t>(hv_len));
             } else {
                 p.skip(static_cast<size_t>(hv_len));
             }
@@ -350,8 +416,8 @@ parsed_record<Fields...> parse_record_fields(iobuf_const_parser& p) {
 /// The common, non-validating parse: unrequested trailing fields are skipped
 /// wholesale rather than decoded. Overload resolution cannot confuse the two:
 /// a leading `bool` never binds to `record_field` and vice versa.
-template<record_field... Fields>
-parsed_record<Fields...> parse_record_fields(iobuf_const_parser& p) {
+template<record_field... Fields, typename Parser>
+parsed_record<Fields...> parse_record_fields(Parser& p) {
     return parse_record_fields<false, Fields...>(p);
 }
 

--- a/src/v/model/record_fields.h
+++ b/src/v/model/record_fields.h
@@ -1,0 +1,396 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "bytes/iobuf_parser.h"
+#include "container/chunked_vector.h"
+#include "model/record.h"
+
+#include <seastar/core/future.hh>
+
+#include <array>
+#include <cstdint>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+
+namespace model {
+
+/// \brief Compile-time selectable record fields for `for_each_record<>()`.
+///
+/// Pass a subset of these to `record_batch::for_each_record<Fields...>()` (or
+/// directly to `parse_record_fields<Fields...>()`) to control which parts of a
+/// record are materialized while iterating.
+enum class record_field : uint8_t {
+    /// `int32_t`, the record's encoded size: everything after the size varint
+    /// itself. Matches `record::size_bytes()`.
+    size_bytes,
+    /// `model::record_attributes`.
+    attributes,
+    /// `int64_t` delta from the batch first timestamp.
+    timestamp_delta,
+    /// `int32_t` delta from the batch base offset.
+    offset_delta,
+    /// `iobuf`, empty when the record has a null/empty key.
+    key,
+    /// `bool`, true when the record has a null value.
+    is_tombstone,
+    /// `iobuf`, empty when the record has a null/empty value.
+    value,
+    /// `chunked_vector<record_header>`.
+    headers,
+};
+
+namespace detail {
+
+template<record_field F>
+struct record_field_holder;
+
+template<>
+struct record_field_holder<record_field::size_bytes> {
+    int32_t size_bytes{0};
+};
+
+template<>
+struct record_field_holder<record_field::attributes> {
+    record_attributes attributes{};
+};
+
+template<>
+struct record_field_holder<record_field::timestamp_delta> {
+    int64_t timestamp_delta{0};
+};
+
+template<>
+struct record_field_holder<record_field::offset_delta> {
+    int32_t offset_delta{0};
+};
+
+template<>
+struct record_field_holder<record_field::key> {
+    iobuf key;
+};
+
+template<>
+struct record_field_holder<record_field::is_tombstone> {
+    bool is_tombstone{false};
+};
+
+template<>
+struct record_field_holder<record_field::value> {
+    iobuf value;
+};
+
+template<>
+struct record_field_holder<record_field::headers> {
+    chunked_vector<record_header> headers;
+};
+
+/// Canonical base ordering for `parsed_record`, descending by member
+/// size/alignment so that any requested subset packs with minimal padding,
+/// regardless of the order the fields were requested in.
+inline constexpr std::array record_field_layout_order{
+  record_field::headers,
+  record_field::key,
+  record_field::value,
+  record_field::timestamp_delta,
+  record_field::size_bytes,
+  record_field::offset_delta,
+  record_field::attributes,
+  record_field::is_tombstone,
+};
+
+template<record_field... Fields>
+consteval auto layout_sorted_fields() {
+    std::array<record_field, sizeof...(Fields)> out{};
+    size_t i = 0;
+    for (auto f : record_field_layout_order) {
+        if (((Fields == f) || ...)) {
+            out[i++] = f;
+        }
+    }
+    if (i != out.size()) {
+        // Compile-time failure: a duplicate field was requested, or a
+        // `record_field` is missing from `record_field_layout_order`.
+        throw std::logic_error("invalid record_field pack");
+    }
+    return out;
+}
+
+template<record_field... Fields>
+struct field_holder_pack : record_field_holder<Fields>... {};
+
+template<auto SortedFields, size_t... Is>
+auto make_layout_pack(std::index_sequence<Is...>)
+  -> field_holder_pack<SortedFields[Is]...>;
+
+template<record_field... Fields>
+using layout_sorted_pack_t
+  = decltype(make_layout_pack<layout_sorted_fields<Fields...>()>(
+    std::make_index_sequence<sizeof...(Fields)>{}));
+
+} // namespace detail
+
+/// \brief The subset of a record materialized by `parse_record_fields<>()`.
+template<record_field... Fields>
+struct parsed_record : detail::layout_sorted_pack_t<Fields...> {
+    static_assert(
+      sizeof...(Fields) > 0, "for_each_record<> requires at least one field");
+
+    /// True iff `F` was requested; usable in `if constexpr` by callers.
+    template<record_field F>
+    static constexpr bool has = ((Fields == F) || ...);
+};
+
+/// \brief Parse a single record from `p`, materializing only `Fields`.
+///
+/// A record is a strictly ordered sequence of variable-length fields:
+///
+///   size | attributes | ts_delta | offset_delta | key | value | headers
+///
+/// Because the fields are variable length there is no way to seek to one:
+/// reaching a field requires decoding everything before it.
+///
+/// Consumes exactly one record from `p`.
+///
+/// With `FullyParse` set, every field is decoded (though still only `Fields`
+/// are materialized) and the record's declared size is validated against the
+/// bytes its fields actually occupy, so a malformed record throws instead of
+/// being silently skipped over.
+template<bool FullyParse, record_field... Fields>
+parsed_record<Fields...> parse_record_fields(iobuf_const_parser& p) {
+    constexpr auto wants = [](record_field f) {
+        return ((Fields == f) || ...);
+    };
+
+    // A field must be decoded (though not necessarily materialized) when it is
+    // requested, when any later field is requested, or when `FullyParse`
+    // requires walking the whole record.
+    constexpr bool reach_headers = wants(record_field::headers) || FullyParse;
+    constexpr bool reach_value = reach_headers || wants(record_field::value)
+                                 || wants(record_field::is_tombstone);
+    constexpr bool reach_key = reach_value || wants(record_field::key);
+    constexpr bool reach_offset = reach_key
+                                  || wants(record_field::offset_delta);
+    constexpr bool reach_ts = reach_offset
+                              || wants(record_field::timestamp_delta);
+    constexpr bool reach_attr = reach_ts || wants(record_field::attributes);
+
+    parsed_record<Fields...> out;
+
+    // `record_size` covers everything after the size varint itself, so it lets
+    // us skip whatever remains of the record from any point.
+    auto [record_size, rv] = p.read_varlong();
+    if (static_cast<size_t>(record_size) > p.bytes_left()) [[unlikely]] {
+        throw std::out_of_range(
+          fmt::format(
+            "Expected record size {} but only {} bytes left",
+            record_size,
+            p.bytes_left()));
+    }
+    if constexpr (wants(record_field::size_bytes)) {
+        out.size_bytes = static_cast<int32_t>(record_size);
+    }
+    const size_t body_start = p.bytes_consumed();
+    auto body_bytes_consumed = [&] { return p.bytes_consumed() - body_start; };
+    [[maybe_unused]] auto skip_tail = [&] {
+        const size_t consumed = body_bytes_consumed();
+        if (consumed > static_cast<size_t>(record_size)) [[unlikely]] {
+            throw std::out_of_range(
+              fmt::format(
+                "Record fields consumed {} bytes, overrunning the declared "
+                "record size {}",
+                consumed,
+                record_size));
+        }
+        p.skip(static_cast<size_t>(record_size) - consumed);
+    };
+
+    if constexpr (!reach_attr) {
+        skip_tail();
+        return out;
+    }
+    auto attr = p.consume_type<record_attributes::type>();
+    if constexpr (wants(record_field::attributes)) {
+        out.attributes = record_attributes(attr);
+    }
+
+    if constexpr (!reach_ts) {
+        skip_tail();
+        return out;
+    }
+    auto [timestamp_delta, tv] = p.read_varlong();
+    if constexpr (wants(record_field::timestamp_delta)) {
+        out.timestamp_delta = static_cast<int64_t>(timestamp_delta);
+    }
+
+    if constexpr (!reach_offset) {
+        skip_tail();
+        return out;
+    }
+    auto [offset_delta, ov] = p.read_varlong();
+    if constexpr (wants(record_field::offset_delta)) {
+        out.offset_delta = static_cast<int32_t>(offset_delta);
+    }
+
+    if constexpr (!reach_key) {
+        skip_tail();
+        return out;
+    }
+    auto [key_length, kv] = p.read_varlong();
+    if (key_length > record_size) [[unlikely]] {
+        throw std::out_of_range(
+          fmt::format(
+            "Expected key length {} but record has only {} bytes in total",
+            key_length,
+            record_size));
+    }
+    if constexpr (wants(record_field::key)) {
+        if (key_length > 0) {
+            out.key = p.copy(static_cast<size_t>(key_length));
+        }
+    } else if constexpr (reach_value) {
+        // Key not requested, but a later field is: advance past it. When key is
+        // the last requested field the `skip_tail` below covers these bytes.
+        if (key_length > 0) {
+            p.skip(static_cast<size_t>(key_length));
+        }
+    }
+
+    if constexpr (!reach_value) {
+        skip_tail();
+        return out;
+    }
+    auto [value_length, vv] = p.read_varlong();
+    if constexpr (wants(record_field::is_tombstone)) {
+        out.is_tombstone = value_length < 0;
+    }
+    if (value_length > record_size) [[unlikely]] {
+        throw std::out_of_range(
+          fmt::format(
+            "Expected value length {} but record has only {} bytes in total",
+            value_length,
+            record_size));
+    }
+    if constexpr (wants(record_field::value)) {
+        if (value_length > 0) {
+            out.value = p.copy(static_cast<size_t>(value_length));
+        }
+    } else if constexpr (reach_headers) {
+        if (value_length > 0) {
+            p.skip(static_cast<size_t>(value_length));
+        }
+    }
+
+    if constexpr (!reach_headers) {
+        skip_tail();
+        return out;
+    }
+    auto [header_count, hcv] = p.read_varlong();
+    if (static_cast<size_t>(header_count) > p.bytes_left()) [[unlikely]] {
+        throw std::out_of_range(
+          fmt::format(
+            "Expected {} headers, but only {} bytes left",
+            header_count,
+            p.bytes_left()));
+    }
+    if constexpr (wants(record_field::headers)) {
+        out.headers.reserve(header_count);
+    }
+    for (int64_t i = 0; i < header_count; ++i) {
+        auto [hk_len, hkv] = p.read_varlong();
+        [[maybe_unused]] iobuf hkey;
+        if (hk_len > 0) {
+            if constexpr (wants(record_field::headers)) {
+                hkey = p.copy(static_cast<size_t>(hk_len));
+            } else {
+                p.skip(static_cast<size_t>(hk_len));
+            }
+        }
+        auto [hv_len, hvv] = p.read_varlong();
+        [[maybe_unused]] iobuf hval;
+        if (hv_len > 0) {
+            if constexpr (wants(record_field::headers)) {
+                hval = p.copy(static_cast<size_t>(hv_len));
+            } else {
+                p.skip(static_cast<size_t>(hv_len));
+            }
+        }
+        if constexpr (wants(record_field::headers)) {
+            out.headers.emplace_back(
+              static_cast<int32_t>(hk_len),
+              std::move(hkey),
+              static_cast<int32_t>(hv_len),
+              std::move(hval));
+        }
+    }
+    // The whole record was decoded, so its declared size must match the bytes
+    // its fields occupy exactly.
+    const size_t consumed = body_bytes_consumed();
+    if (consumed != static_cast<size_t>(record_size)) [[unlikely]] {
+        throw std::out_of_range(
+          fmt::format(
+            "Record size mismatch: expected {} but parsed {} bytes",
+            record_size,
+            consumed));
+    }
+    return out;
+}
+
+/// The common, non-validating parse: unrequested trailing fields are skipped
+/// wholesale rather than decoded. Overload resolution cannot confuse the two:
+/// a leading `bool` never binds to `record_field` and vice versa.
+template<record_field... Fields>
+parsed_record<Fields...> parse_record_fields(iobuf_const_parser& p) {
+    return parse_record_fields<false, Fields...>(p);
+}
+
+template<record_field First, record_field... Rest, typename Func>
+void record_batch::for_each_record(Func f) const {
+    using parsed = parsed_record<First, Rest...>;
+    iobuf_const_parser parser(_records);
+    for (int32_t i = 0; i < _header.record_count; ++i) {
+        auto pr = parse_record_fields<First, Rest...>(parser);
+        if constexpr (std::is_void_v<std::invoke_result_t<Func, parsed&&>>) {
+            f(std::move(pr));
+        } else {
+            ss::stop_iteration s = f(std::move(pr));
+            if (s == ss::stop_iteration::yes) {
+                return;
+            }
+        }
+    }
+}
+
+template<record_field First, record_field... Rest, typename Func>
+ss::future<> record_batch::for_each_record_async(Func f) const {
+    using parsed = parsed_record<First, Rest...>;
+    iobuf_const_parser parser(_records);
+    for (int32_t i = 0; i < _header.record_count; ++i) {
+        auto pr = parse_record_fields<First, Rest...>(parser);
+        if constexpr (
+          std::is_same_v<
+            ss::futurize_t<std::invoke_result_t<Func, parsed&&>>,
+            ss::future<ss::stop_iteration>>) {
+            ss::stop_iteration s = co_await ss::futurize_invoke(
+              f, std::move(pr));
+            if (s == ss::stop_iteration::yes) {
+                co_return;
+            }
+        } else {
+            co_await ss::futurize_invoke(f, std::move(pr));
+        }
+    }
+}
+
+} // namespace model

--- a/src/v/model/record_utils.cc
+++ b/src/v/model/record_utils.cc
@@ -11,6 +11,7 @@
 
 #include "hashing/crc32c.h"
 #include "model/record.h"
+#include "model/record_fields.h"
 #include "utils/vint.h"
 
 #include <type_traits>
@@ -289,81 +290,28 @@ model::record_key_metadata parse_record_key_from_buffer(iobuf_const_parser& p) {
     return {static_cast<int32_t>(offset_delta), is_tombstone, std::move(key)};
 }
 
+namespace {
+
+template<bool FullyParse>
+model::record_metadata do_parse_record_metadata(iobuf_const_parser& p) {
+    auto pr = parse_record_fields<
+      FullyParse,
+      model::record_field::size_bytes,
+      model::record_field::attributes,
+      model::record_field::timestamp_delta,
+      model::record_field::offset_delta>(p);
+    return {pr.size_bytes, pr.attributes, pr.timestamp_delta, pr.offset_delta};
+}
+
+} // namespace
+
 model::record_metadata parse_record_metadata_from_buffer(
   iobuf_const_parser& p, bool fully_parse_record) {
-    auto [record_size, attr] = parse_record_meta_from_buffer(p);
-    auto [timestamp_delta, tv] = p.read_varlong();
-    auto [offset_delta, ov] = p.read_varlong();
-
-    if (!fully_parse_record) {
-        auto total_bytes_read = 1 + tv + ov;
-        if (record_size <= total_bytes_read) [[unlikely]] {
-            throw std::out_of_range(
-              fmt::format(
-                "Expected record size {} to be greater than bytes read {}",
-                record_size,
-                total_bytes_read));
-        }
-        p.skip(record_size - total_bytes_read);
-    } else {
-        auto start = p.bytes_consumed() - (tv + ov);
-        auto [key_length, kv] = p.read_varlong();
-        if (key_length > record_size) [[unlikely]] {
-            throw std::out_of_range(
-              fmt::format(
-                "Expected key length {} but record has only {} bytes in total",
-                key_length,
-                record_size));
-        }
-        if (key_length > 0) {
-            p.skip(key_length);
-        }
-        auto [value_length, vv] = p.read_varlong();
-        if (value_length > record_size) [[unlikely]] {
-            throw std::out_of_range(
-              fmt::format(
-                "Expected value length {} but record has only {} bytes in "
-                "total",
-                value_length,
-                record_size));
-        }
-        if (value_length > 0) {
-            p.skip(value_length);
-        }
-        auto [header_count, hcv] = p.read_varlong();
-        if (static_cast<size_t>(header_count) > p.bytes_left()) [[unlikely]] {
-            throw std::out_of_range(
-              fmt::format(
-                "Expected {} headers, but only {} bytes left",
-                header_count,
-                p.bytes_left()));
-        }
-        for (int64_t i = 0; i < header_count; ++i) {
-            auto [hk_len, hkv] = p.read_varlong();
-            if (hk_len > 0) {
-                p.skip(hk_len);
-            }
-            auto [hv_len, hvv] = p.read_varlong();
-            if (hv_len > 0) {
-                p.skip(hv_len);
-            }
-        }
-        // record_size includes the 1-byte attr already consumed above.
-        auto bytes_parsed = p.bytes_consumed() - start + 1;
-        if (bytes_parsed != static_cast<size_t>(record_size)) [[unlikely]] {
-            throw std::out_of_range(
-              fmt::format(
-                "Record size mismatch: expected {} but parsed {} bytes",
-                record_size,
-                bytes_parsed));
-        }
-    }
-    return {
-      static_cast<int32_t>(record_size),
-      model::record_attributes(attr),
-      static_cast<int64_t>(timestamp_delta),
-      static_cast<int32_t>(offset_delta),
-    };
+    // With `fully_parse_record` the entire record structure (key, value and
+    // every header) is walked and validated without being materialized;
+    // otherwise those fields are skipped over wholesale.
+    return fully_parse_record ? do_parse_record_metadata<true>(p)
+                              : do_parse_record_metadata<false>(p);
 }
 
 } // namespace model

--- a/src/v/model/record_utils.cc
+++ b/src/v/model/record_utils.cc
@@ -91,123 +91,42 @@ uint32_t crc_record_batch(const record_batch& b) {
     return crc_record_batch(b.header(), b.data());
 }
 
-template<typename Parser, typename ParserData>
-static chunked_vector<model::record_header>
-parse_record_headers(Parser& parser, ParserData parser_data) {
-    chunked_vector<model::record_header> headers;
-    auto [header_count, _] = parser.read_varlong();
-    /**
-     * If records buffer is corrupted, it may result in reading very large
-     * number, check if it is the case and throw an exception.
-     */
-    if (static_cast<size_t>(header_count) > parser.bytes_left()) [[unlikely]] {
-        throw std::out_of_range(
-          fmt::format(
-            "Expected {} headers, but only {} bytes left",
-            header_count,
-            parser.bytes_left()));
-    }
-    headers.reserve(header_count);
-    for (int i = 0; i < header_count; ++i) {
-        auto [key_length, kv] = parser.read_varlong();
-        iobuf key;
-        if (key_length > 0) {
-            key = parser_data(parser, key_length);
-        }
-        auto [value_length, vv] = parser.read_varlong();
-        iobuf value;
-        if (value_length > 0) {
-            value = parser_data(parser, value_length);
-        }
-        headers.emplace_back(
-          model::record_header(
-            key_length, std::move(key), value_length, std::move(value)));
-    }
-    return headers;
+namespace {
+
+// Materializes the record's key/value/headers zero-copy (via `share`) when
+// given an `iobuf_parser`, and by copying when given an `iobuf_const_parser`.
+template<typename Parser>
+model::record do_parse_one_record(Parser& parser) {
+    auto pr = parse_record_fields<
+      model::record_field::size_bytes,
+      model::record_field::attributes,
+      model::record_field::timestamp_delta,
+      model::record_field::offset_delta,
+      model::record_field::key_size,
+      model::record_field::key,
+      model::record_field::value_size,
+      model::record_field::value,
+      model::record_field::headers>(parser);
+    return {
+      pr.size_bytes,
+      pr.attributes,
+      pr.timestamp_delta,
+      pr.offset_delta,
+      pr.key_size,
+      std::move(pr.key),
+      pr.value_size,
+      std::move(pr.value),
+      std::move(pr.headers)};
 }
 
-template<typename Parser, typename ParserData>
-static model::record do_parse_one_record_from_buffer(
-  Parser& parser,
-  int32_t record_size,
-  model::record_attributes::type attr,
-  ParserData parser_data) {
-    auto [timestamp_delta, tv] = parser.read_varlong();
-    auto [offset_delta, ov] = parser.read_varlong();
-    auto [key_length, kv] = parser.read_varlong();
-    iobuf key;
-    if (key_length > 0) {
-        if (key_length > record_size) [[unlikely]] {
-            throw std::out_of_range(
-              fmt::format(
-                "Expected key length {} but record has only {} bytes in total",
-                key_length,
-                record_size));
-        }
-        key = parser_data(parser, key_length);
-    }
-    auto [value_length, vv] = parser.read_varlong();
-    iobuf value;
-    if (value_length > 0) {
-        if (value_length > record_size) [[unlikely]] {
-            throw std::out_of_range(
-              fmt::format(
-                "Expected value length {} but record has only {} bytes in "
-                "total",
-                value_length,
-                record_size));
-        }
-        value = parser_data(parser, value_length);
-    }
-    auto headers = parse_record_headers(parser, parser_data);
-    return model::record(
-      record_size,
-      model::record_attributes(attr),
-      static_cast<int64_t>(timestamp_delta),
-      static_cast<int32_t>(offset_delta),
-      key_length,
-      std::move(key),
-      value_length,
-      std::move(value),
-      std::move(headers));
-}
-
-static std::pair<int64_t, model::record_attributes::type>
-parse_record_meta_from_buffer(iobuf_parser_base& parser) {
-    /*
-     * require that record attributes be unaffected by endianness. all of the
-     * other record fields are properly handled by virtue of their types being
-     * either blobs or variable length integers.
-     */
-    static_assert(
-      sizeof(model::record_attributes::type) == 1,
-      "model attributes expected to be one byte");
-    auto [record_size, rv] = parser.read_varlong();
-    if (static_cast<size_t>(record_size) > parser.bytes_left()) [[unlikely]] {
-        throw std::out_of_range(
-          fmt::format(
-            "Expected record size {} but only {} bytes left",
-            record_size,
-            parser.bytes_left()));
-    }
-    auto attr = parser.consume_type<model::record_attributes::type>();
-    return std::make_pair(record_size, attr);
-}
+} // namespace
 
 model::record parse_one_record_from_buffer(iobuf_parser& parser) {
-    auto [record_size, attr] = parse_record_meta_from_buffer(parser);
-    return do_parse_one_record_from_buffer(
-      parser, record_size, attr, [](iobuf_parser& parser, int64_t len) {
-          return parser.share(len);
-      });
+    return do_parse_one_record(parser);
 }
 
 model::record parse_one_record_copy_from_buffer(iobuf_const_parser& parser) {
-    auto [record_size, attr] = parse_record_meta_from_buffer(parser);
-    return do_parse_one_record_from_buffer(
-      parser, record_size, attr, [](iobuf_const_parser& parser, int64_t len) {
-          return parser.copy(len);
-      });
+    return do_parse_one_record(parser);
 }
 
 static inline void append_vint_to_iobuf(iobuf& b, int64_t v) {
@@ -262,32 +181,14 @@ void append_record_to_buffer(iobuf& a, const model::record& r) {
 }
 
 model::record_key_metadata parse_record_key_from_buffer(iobuf_const_parser& p) {
-    [[maybe_unused]] auto [record_size, attr] = parse_record_meta_from_buffer(
-      p);
-    [[maybe_unused]] auto [timestamp_delta, tv] = p.read_varlong();
-    auto [offset_delta, ov] = p.read_varlong();
-    auto [key_length, kv] = p.read_varlong();
-    bytes key;
-    if (key_length > 0) {
-        key = p.read_bytes(static_cast<size_t>(key_length));
-    }
-    auto [value_length, vv] = p.read_varlong();
-    const bool is_tombstone = value_length < 0;
-    // record_size covers attributes(1) + the four varints + key + value +
-    // headers; we've consumed up to and including value_length, so the rest is
-    // the value bytes plus the (skipped) headers.
-    const int64_t header_and_key_bytes = 1 + tv + ov + kv
-                                         + std::max<int64_t>(key_length, 0)
-                                         + vv;
-    if (record_size < header_and_key_bytes) [[unlikely]] {
-        throw std::out_of_range(
-          fmt::format(
-            "Record size {} smaller than parsed header+key bytes {}",
-            record_size,
-            header_and_key_bytes));
-    }
-    p.skip(static_cast<size_t>(record_size - header_and_key_bytes));
-    return {static_cast<int32_t>(offset_delta), is_tombstone, std::move(key)};
+    auto pr = parse_record_fields<
+      model::record_field::offset_delta,
+      model::record_field::key_bytes,
+      model::record_field::is_tombstone>(p);
+    return {
+      .offset_delta = pr.offset_delta,
+      .is_tombstone = pr.is_tombstone,
+      .key = std::move(pr.key_bytes)};
 }
 
 namespace {

--- a/src/v/model/tests/BUILD
+++ b/src/v/model/tests/BUILD
@@ -170,6 +170,7 @@ redpanda_cc_gtest(
         "//src/v/model",
         "//src/v/model:batch_compression",
         "//src/v/test_utils:gtest",
+        "//src/v/utils:vint",
         "@googletest//:gtest",
     ],
 )

--- a/src/v/model/tests/BUILD
+++ b/src/v/model/tests/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:test.bzl", "redpanda_cc_btest", "redpanda_cc_gtest", "redpanda_test_cc_library")
+load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_btest", "redpanda_cc_gtest", "redpanda_test_cc_library")
 
 redpanda_test_cc_library(
     name = "random",
@@ -172,6 +172,20 @@ redpanda_cc_gtest(
         "//src/v/test_utils:gtest",
         "//src/v/utils:vint",
         "@googletest//:gtest",
+    ],
+)
+
+redpanda_cc_bench(
+    name = "record_fields_rpbench",
+    srcs = [
+        "record_fields_bench.cc",
+    ],
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/model",
+        "//src/v/random:generators",
+        "@seastar",
+        "@seastar//:benchmark",
     ],
 )
 

--- a/src/v/model/tests/record_batch_test.cc
+++ b/src/v/model/tests/record_batch_test.cc
@@ -833,6 +833,102 @@ TEST_F(RecordBatchTest, ParseRecordFieldsFullParseDetectsSlack) {
     }
 }
 
+// key_bytes materializes the same key as `key`, just as contiguous `bytes`; a
+// null key yields empty bytes.
+TEST_F(RecordBatchTest, ParseRecordFieldsKeyBytes) {
+    std::vector<model::record> recs;
+    recs.push_back(make_record(0, iobuf::from("k0"), iobuf::from("v0")));
+    recs.push_back(make_record(1, std::nullopt, iobuf::from("v1")));
+    auto batch = batch_from_records(std::move(recs));
+
+    auto parser = iobuf_const_parser(batch.data());
+    auto pr0 = model::parse_record_fields<model::record_field::key_bytes>(
+      parser);
+    EXPECT_EQ(pr0.key_bytes, iobuf_to_bytes(iobuf::from("k0")));
+    auto pr1 = model::parse_record_fields<model::record_field::key_bytes>(
+      parser);
+    EXPECT_TRUE(pr1.key_bytes.empty());
+    EXPECT_EQ(parser.bytes_left(), 0u);
+}
+
+// key_size/value_size expose the raw length varints, preserving the
+// distinction between a null field (-1) and an empty one (0) that the iobuf
+// representations erase.
+TEST_F(RecordBatchTest, ParseRecordFieldsSizesPreserveNull) {
+    std::vector<model::record> recs;
+    recs.push_back(make_record(0, iobuf::from("key"), iobuf::from("value")));
+    recs.push_back(make_record(1, std::nullopt, iobuf{})); // null key
+    recs.push_back(make_record(2, iobuf{}, std::nullopt)); // tombstone
+    auto batch = batch_from_records(std::move(recs));
+
+    struct sizes {
+        int32_t key_size;
+        int32_t value_size;
+    };
+    std::vector<sizes> parsed;
+    batch.for_each_record<
+      model::record_field::key_size,
+      model::record_field::value_size>(
+      [&parsed](auto pr) { parsed.push_back({pr.key_size, pr.value_size}); });
+
+    ASSERT_EQ(parsed.size(), 3u);
+    EXPECT_EQ(parsed[0].key_size, 3);
+    EXPECT_EQ(parsed[0].value_size, 5);
+    EXPECT_EQ(parsed[1].key_size, -1);
+    EXPECT_EQ(parsed[1].value_size, 0);
+    EXPECT_EQ(parsed[2].key_size, 0);
+    EXPECT_EQ(parsed[2].value_size, -1);
+}
+
+// parse_one_record_copy_from_buffer must reproduce the original record
+// exactly — including null (not just empty) keys, values and header values —
+// so serialization round-trips.
+TEST_F(RecordBatchTest, ParseOneRecordRoundTrip) {
+    std::vector<model::record> originals;
+    originals.push_back(
+      make_record(0, iobuf::from("key"), iobuf::from("value")));
+    originals.push_back(make_record(1, std::nullopt, iobuf::from("v")));
+    originals.push_back(make_record(2, iobuf::from("k"), std::nullopt));
+    originals.push_back(make_record(3, iobuf{}, iobuf{}));
+    {
+        chunked_vector<model::record_header> h;
+        h.emplace_back(2, iobuf::from("hk"), -1, iobuf{}); // null header value
+        h.emplace_back(-1, iobuf{}, 2, iobuf::from("hv")); // null header key
+        originals.push_back(
+          make_record(4, iobuf::from("k4"), iobuf::from("v4"), std::move(h)));
+    }
+
+    iobuf buf;
+    for (const auto& r : originals) {
+        model::append_record_to_buffer(buf, r);
+    }
+
+    auto parser = iobuf_const_parser(buf);
+    for (const auto& r : originals) {
+        auto parsed = model::parse_one_record_copy_from_buffer(parser);
+        EXPECT_EQ(parsed, r);
+    }
+    EXPECT_EQ(parser.bytes_left(), 0u);
+}
+
+// The zero-copy (share) variant must parse identically to the copy variant.
+TEST_F(RecordBatchTest, ParseOneRecordShareMatchesCopy) {
+    auto original = make_record(
+      0, iobuf::from("share-key"), iobuf::from("share-value"));
+    iobuf buf;
+    model::append_record_to_buffer(buf, original);
+
+    auto copy_parser = iobuf_const_parser(buf);
+    auto copied = model::parse_one_record_copy_from_buffer(copy_parser);
+
+    auto share_parser = iobuf_parser(std::move(buf));
+    auto shared = model::parse_one_record_from_buffer(share_parser);
+
+    EXPECT_EQ(shared, copied);
+    EXPECT_EQ(shared, original);
+    EXPECT_EQ(share_parser.bytes_left(), 0u);
+}
+
 // for_each_record_async<Fields...> honours ss::stop_iteration.
 TEST_F(RecordBatchTest, ForEachRecordFieldsAsyncStops) {
     std::vector<model::record> recs;

--- a/src/v/model/tests/record_batch_test.cc
+++ b/src/v/model/tests/record_batch_test.cc
@@ -13,12 +13,15 @@
 #include "model/batch_compression.h"
 #include "model/record.h"
 #include "model/record_batch_types.h"
+#include "model/record_fields.h"
 #include "model/record_utils.h"
 #include "model/tests/random_batch.h"
 #include "model/timestamp.h"
+#include "utils/vint.h"
 
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <optional>
 #include <string_view>
 #include <vector>
@@ -440,6 +443,410 @@ TEST_F(RecordBatchTest, ForEachRecordKeyAsyncStops) {
           model::record_key_metadata kv) -> ss::future<ss::stop_iteration> {
             seen.push_back(kv.offset_delta);
             co_return kv.offset_delta == 2 ? ss::stop_iteration::yes
+                                           : ss::stop_iteration::no;
+        })
+      .get();
+
+    EXPECT_EQ(seen, (std::vector<int32_t>{0, 1, 2}));
+}
+
+namespace {
+
+// Membership probes: true iff the field is an accessible member of `PR`. Used
+// to assert, at compile time, that a parsed_record exposes exactly the
+// requested fields and nothing else.
+template<typename PR>
+concept has_offset_delta = requires(PR pr) { pr.offset_delta; };
+template<typename PR>
+concept has_timestamp_delta = requires(PR pr) { pr.timestamp_delta; };
+template<typename PR>
+concept has_attributes = requires(PR pr) { pr.attributes; };
+template<typename PR>
+concept has_is_tombstone = requires(PR pr) { pr.is_tombstone; };
+template<typename PR>
+concept has_key = requires(PR pr) { pr.key; };
+template<typename PR>
+concept has_value = requires(PR pr) { pr.value; };
+template<typename PR>
+concept has_headers = requires(PR pr) { pr.headers; };
+
+} // namespace
+
+// The returned type exposes exactly the requested fields; every unrequested
+// field is absent (not merely uninitialized), so touching it would fail to
+// compile. These static_asserts *are* the compile-time-safety guarantee.
+TEST_F(RecordBatchTest, ParsedRecordExposesOnlyRequestedFields) {
+    using kv_t = model::
+      parsed_record<model::record_field::key, model::record_field::value>;
+    static_assert(has_key<kv_t>);
+    static_assert(has_value<kv_t>);
+    static_assert(!has_offset_delta<kv_t>);
+    static_assert(!has_timestamp_delta<kv_t>);
+    static_assert(!has_attributes<kv_t>);
+    static_assert(!has_is_tombstone<kv_t>);
+    static_assert(!has_headers<kv_t>);
+
+    using key_only_t = model::parsed_record<
+      model::record_field::offset_delta,
+      model::record_field::is_tombstone,
+      model::record_field::key>;
+    static_assert(has_offset_delta<key_only_t>);
+    static_assert(has_is_tombstone<key_only_t>);
+    static_assert(has_key<key_only_t>);
+    static_assert(!has_value<key_only_t>);
+    static_assert(!has_timestamp_delta<key_only_t>);
+    static_assert(!has_attributes<key_only_t>);
+    static_assert(!has_headers<key_only_t>);
+
+    // The `has<F>` compile-time membership helper mirrors the probes above.
+    static_assert(kv_t::has<model::record_field::key>);
+    static_assert(!kv_t::has<model::record_field::headers>);
+}
+
+// for_each_record<Fields...> yields the same values as a full parse for every
+// selectable field, across normal records, a tombstone, a null-key record, and
+// a record with headers.
+TEST_F(RecordBatchTest, ForEachRecordFieldsMatchesFullParse) {
+    std::vector<model::record> recs;
+    recs.push_back(make_record(0, iobuf::from("k0"), iobuf::from("v0")));
+    recs.push_back(
+      make_record(1, iobuf::from("k1"), std::nullopt)); // tombstone
+    recs.push_back(make_record(2, std::nullopt, iobuf::from("v2"))); // null key
+    {
+        chunked_vector<model::record_header> h;
+        h.emplace_back(1, iobuf::from("a"), 1, iobuf::from("b"));
+        recs.push_back(
+          make_record(3, iobuf::from("k3"), iobuf::from("v3"), std::move(h)));
+    }
+    auto batch = batch_from_records(std::move(recs));
+
+    struct row {
+        int32_t offset_delta;
+        int64_t timestamp_delta;
+        bool is_tombstone;
+        bytes key;
+        bytes value;
+        size_t header_count;
+        bool operator==(const row&) const = default;
+    };
+
+    std::vector<row> full;
+    batch.for_each_record([&full](model::record r) {
+        full.push_back(
+          {r.offset_delta(),
+           r.timestamp_delta(),
+           r.is_tombstone(),
+           iobuf_to_bytes(r.key()),
+           iobuf_to_bytes(r.value()),
+           r.headers().size()});
+    });
+
+    std::vector<row> selected;
+    batch.for_each_record<
+      model::record_field::offset_delta,
+      model::record_field::timestamp_delta,
+      model::record_field::is_tombstone,
+      model::record_field::key,
+      model::record_field::value,
+      model::record_field::headers>([&selected](auto pr) {
+        selected.push_back(
+          {pr.offset_delta,
+           pr.timestamp_delta,
+           pr.is_tombstone,
+           iobuf_to_bytes(pr.key),
+           iobuf_to_bytes(pr.value),
+           pr.headers.size()});
+    });
+
+    ASSERT_EQ(full.size(), 4u);
+    EXPECT_EQ(selected, full);
+}
+
+// Requesting a strict subset materializes only those fields; the loop still
+// walks every record correctly because unrequested fields are skipped in the
+// buffer by exactly the right number of bytes.
+TEST_F(RecordBatchTest, ForEachRecordFieldsValueOnly) {
+    std::vector<model::record> recs;
+    recs.push_back(make_record(0, iobuf::from("k0"), iobuf::from("v0")));
+    recs.push_back(make_record(1, iobuf::from("k1"), iobuf::from("v1")));
+    recs.push_back(make_record(2, iobuf::from("k2"), std::nullopt));
+    auto batch = batch_from_records(std::move(recs));
+
+    std::vector<bytes> values;
+    batch.for_each_record<model::record_field::value>(
+      [&values](auto pr) { values.push_back(iobuf_to_bytes(pr.value)); });
+
+    EXPECT_EQ(
+      values,
+      (std::vector<bytes>{
+        iobuf_to_bytes(iobuf::from("v0")),
+        iobuf_to_bytes(iobuf::from("v1")),
+        bytes{}}));
+}
+
+// parsed_record's bases are laid out in a canonical order regardless of the
+// order the fields were requested in, so reversed packs have identical sizes
+// (a naive request-ordered layout would pad them differently).
+TEST_F(RecordBatchTest, ParsedRecordLayoutIsOrderIndependent) {
+    using fwd_t = model::parsed_record<
+      model::record_field::is_tombstone,
+      model::record_field::attributes,
+      model::record_field::offset_delta,
+      model::record_field::timestamp_delta>;
+    using rev_t = model::parsed_record<
+      model::record_field::timestamp_delta,
+      model::record_field::offset_delta,
+      model::record_field::attributes,
+      model::record_field::is_tombstone>;
+    static_assert(sizeof(fwd_t) == sizeof(rev_t));
+
+    using kv_fwd_t = model::parsed_record<
+      model::record_field::is_tombstone,
+      model::record_field::key,
+      model::record_field::value,
+      model::record_field::headers>;
+    using kv_rev_t = model::parsed_record<
+      model::record_field::headers,
+      model::record_field::value,
+      model::record_field::key,
+      model::record_field::is_tombstone>;
+    static_assert(sizeof(kv_fwd_t) == sizeof(kv_rev_t));
+}
+
+// Every field parsed via parse_record_fields matches the fully materialized
+// record, across randomized batches (random keys/values/headers/timestamps),
+// and each record consumes exactly its bytes so the loop stays aligned.
+TEST_F(RecordBatchTest, ParseRecordFieldsRandomizedMatchesFullParse) {
+    for (int iter = 0; iter < 20; ++iter) {
+        auto b = model::test::make_random_batch(
+          model::offset(0),
+          /*num_records=*/1 + iter,
+          /*allow_compression=*/false);
+
+        std::vector<model::record> full;
+        b.for_each_record(
+          [&full](model::record r) { full.push_back(std::move(r)); });
+
+        auto parser = iobuf_const_parser(b.data());
+        for (const auto& r : full) {
+            auto pr = model::parse_record_fields<
+              model::record_field::size_bytes,
+              model::record_field::attributes,
+              model::record_field::timestamp_delta,
+              model::record_field::offset_delta,
+              model::record_field::key,
+              model::record_field::is_tombstone,
+              model::record_field::value,
+              model::record_field::headers>(parser);
+            EXPECT_EQ(pr.size_bytes, r.size_bytes());
+            EXPECT_EQ(pr.attributes, r.attributes());
+            EXPECT_EQ(pr.timestamp_delta, r.timestamp_delta());
+            EXPECT_EQ(pr.offset_delta, r.offset_delta());
+            EXPECT_EQ(pr.key, r.key());
+            EXPECT_EQ(pr.is_tombstone, r.is_tombstone());
+            EXPECT_EQ(pr.value, r.value());
+            ASSERT_EQ(pr.headers.size(), r.headers().size());
+            for (size_t i = 0; i < pr.headers.size(); ++i) {
+                EXPECT_EQ(pr.headers[i], r.headers()[i]);
+            }
+        }
+        EXPECT_EQ(parser.bytes_left(), 0u);
+    }
+}
+
+// Requesting each field on its own must both return the right value and skip
+// the rest of the record by exactly the right number of bytes (checked by the
+// next record parsing correctly and by bytes_left() == 0 at the end).
+TEST_F(RecordBatchTest, ParseRecordFieldsEachFieldIndividually) {
+    std::vector<model::record> recs;
+    {
+        chunked_vector<model::record_header> h;
+        h.emplace_back(2, iobuf::from("hk"), 3, iobuf::from("hdr"));
+        recs.push_back(make_record(
+          0, iobuf::from("key-0"), iobuf::from("value-0"), std::move(h)));
+    }
+    recs.push_back(make_record(1, iobuf::from("key-1"), std::nullopt));
+    recs.push_back(make_record(2, std::nullopt, iobuf::from("value-2")));
+    auto batch = batch_from_records(std::move(recs));
+
+    std::vector<model::record> full;
+    batch.for_each_record(
+      [&full](model::record r) { full.push_back(std::move(r)); });
+    ASSERT_EQ(full.size(), 3u);
+
+    auto parse_each = [&batch, &full]<model::record_field F>(auto&& check_one) {
+        auto parser = iobuf_const_parser(batch.data());
+        for (const auto& r : full) {
+            check_one(model::parse_record_fields<F>(parser), r);
+        }
+        EXPECT_EQ(parser.bytes_left(), 0u);
+    };
+
+    parse_each.operator()<model::record_field::size_bytes>(
+      [](auto pr, const auto& r) { EXPECT_EQ(pr.size_bytes, r.size_bytes()); });
+    parse_each.operator()<model::record_field::attributes>(
+      [](auto pr, const auto& r) { EXPECT_EQ(pr.attributes, r.attributes()); });
+    parse_each.operator()<model::record_field::timestamp_delta>(
+      [](auto pr, const auto& r) {
+          EXPECT_EQ(pr.timestamp_delta, r.timestamp_delta());
+      });
+    parse_each.operator()<model::record_field::offset_delta>(
+      [](auto pr, const auto& r) {
+          EXPECT_EQ(pr.offset_delta, r.offset_delta());
+      });
+    parse_each.operator()<model::record_field::key>(
+      [](auto pr, const auto& r) { EXPECT_EQ(pr.key, r.key()); });
+    parse_each.operator()<model::record_field::is_tombstone>(
+      [](auto pr, const auto& r) {
+          EXPECT_EQ(pr.is_tombstone, r.is_tombstone());
+      });
+    parse_each.operator()<model::record_field::value>(
+      [](auto pr, const auto& r) { EXPECT_EQ(pr.value, r.value()); });
+    parse_each.operator()<model::record_field::headers>(
+      [](auto pr, const auto& r) {
+          ASSERT_EQ(pr.headers.size(), r.headers().size());
+          for (size_t i = 0; i < pr.headers.size(); ++i) {
+              EXPECT_EQ(pr.headers[i], r.headers()[i]);
+          }
+      });
+}
+
+namespace {
+
+void append_vint(iobuf& b, int64_t v) {
+    auto vb = vint::to_bytes(v);
+    b.append(vb.data(), vb.size());
+}
+
+// Assemble one raw record: attributes byte, zero timestamp/offset deltas, the
+// given key/value (nullopt encodes as length -1) and no headers, prefixed with
+// its size varint. `declared_size_delta` shifts the size prefix away from the
+// true body size to simulate corruption.
+iobuf make_raw_record(
+  std::optional<std::string_view> key,
+  std::optional<std::string_view> value,
+  int64_t declared_size_delta = 0,
+  std::optional<int64_t> key_length_override = std::nullopt) {
+    iobuf body;
+    const uint8_t attr = 0;
+    body.append(&attr, 1);
+    append_vint(body, 0); // timestamp delta
+    append_vint(body, 0); // offset delta
+    append_vint(
+      body,
+      key_length_override.value_or(
+        key ? static_cast<int64_t>(key->size()) : -1));
+    if (key) {
+        body.append(key->data(), key->size());
+    }
+    append_vint(body, value ? static_cast<int64_t>(value->size()) : -1);
+    if (value) {
+        body.append(value->data(), value->size());
+    }
+    append_vint(body, 0); // header count
+    iobuf rec;
+    append_vint(
+      rec, static_cast<int64_t>(body.size_bytes()) + declared_size_delta);
+    rec.append(std::move(body));
+    return rec;
+}
+
+} // namespace
+
+// A record size prefix that exceeds the bytes actually present must throw.
+TEST_F(RecordBatchTest, ParseRecordFieldsTruncatedBuffer) {
+    auto rec = make_raw_record("key", "value", /*declared_size_delta=*/100);
+    auto parser = iobuf_const_parser(rec);
+    EXPECT_THROW(
+      model::parse_record_fields<model::record_field::value>(parser),
+      std::out_of_range);
+}
+
+// A key length larger than the record itself must throw rather than read into
+// the next record's bytes.
+TEST_F(RecordBatchTest, ParseRecordFieldsOversizedKeyLength) {
+    auto rec = make_raw_record(
+      "key", "value", /*declared_size_delta=*/0, /*key_length_override=*/1000);
+    // Enough trailing bytes that the parser could physically read them if the
+    // length check were missing.
+    rec.append(iobuf::from(std::string(1000, 'x')));
+    auto parser = iobuf_const_parser(rec);
+    EXPECT_THROW(
+      model::parse_record_fields<model::record_field::key>(parser),
+      std::out_of_range);
+}
+
+// A record whose fields overrun its declared size must throw when the parser
+// skips the tail, instead of silently misaligning on the next record.
+TEST_F(RecordBatchTest, ParseRecordFieldsFieldsOverrunDeclaredSize) {
+    // Shrink the declared size below what the decoded fields occupy, while
+    // leaving enough bytes in the buffer to pass the initial size check. The
+    // key alone (17 bytes plus the preceding varints) overruns the shrunken
+    // size, so skipping the tail after it must throw.
+    auto rec = make_raw_record(
+      "a-long-enough-key", "value", /*declared_size_delta=*/-10);
+    auto parser = iobuf_const_parser(rec);
+    EXPECT_THROW(
+      model::parse_record_fields<model::record_field::key>(parser),
+      std::out_of_range);
+}
+
+// An absurd header count (corrupted varint) must throw before attempting to
+// reserve/parse that many headers.
+TEST_F(RecordBatchTest, ParseRecordFieldsCorruptHeaderCount) {
+    iobuf body;
+    const uint8_t attr = 0;
+    body.append(&attr, 1);
+    append_vint(body, 0);                                   // timestamp delta
+    append_vint(body, 0);                                   // offset delta
+    append_vint(body, -1);                                  // null key
+    append_vint(body, -1);                                  // null value
+    append_vint(body, std::numeric_limits<int32_t>::max()); // header count
+    iobuf rec;
+    append_vint(rec, static_cast<int64_t>(body.size_bytes()));
+    rec.append(std::move(body));
+    auto parser = iobuf_const_parser(rec);
+    EXPECT_THROW(
+      model::parse_record_fields<model::record_field::headers>(parser),
+      std::out_of_range);
+}
+
+// Slack bytes hidden inside the declared record size are undetectable when
+// skipping (they are simply skipped over), but a full parse walks every field
+// and must flag the mismatch.
+TEST_F(RecordBatchTest, ParseRecordFieldsFullParseDetectsSlack) {
+    auto rec = make_raw_record("key", "value", /*declared_size_delta=*/2);
+    rec.append(iobuf::from("xx")); // the slack the size prefix accounts for
+    {
+        auto parser = iobuf_const_parser(rec);
+        auto pr = model::parse_record_fields<model::record_field::offset_delta>(
+          parser);
+        EXPECT_EQ(pr.offset_delta, 0);
+        EXPECT_EQ(parser.bytes_left(), 0u);
+    }
+    {
+        auto parser = iobuf_const_parser(rec);
+        EXPECT_THROW(
+          (model::parse_record_fields<true, model::record_field::offset_delta>(
+            parser)),
+          std::out_of_range);
+    }
+}
+
+// for_each_record_async<Fields...> honours ss::stop_iteration.
+TEST_F(RecordBatchTest, ForEachRecordFieldsAsyncStops) {
+    std::vector<model::record> recs;
+    for (int32_t i = 0; i < 5; ++i) {
+        recs.push_back(make_record(i, iobuf::from("k"), iobuf::from("v")));
+    }
+    auto batch = batch_from_records(std::move(recs));
+
+    std::vector<int32_t> seen;
+    batch
+      .for_each_record_async<model::record_field::offset_delta>(
+        [&seen](this auto, auto pr) -> ss::future<ss::stop_iteration> {
+            seen.push_back(pr.offset_delta);
+            co_return pr.offset_delta == 2 ? ss::stop_iteration::yes
                                            : ss::stop_iteration::no;
         })
       .get();

--- a/src/v/model/tests/record_fields_bench.cc
+++ b/src/v/model/tests/record_fields_bench.cc
@@ -1,0 +1,166 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "bytes/iobuf.h"
+#include "model/record.h"
+#include "model/record_batch_types.h"
+#include "model/record_fields.h"
+#include "model/record_utils.h"
+#include "model/timestamp.h"
+#include "random/generators.h"
+
+#include <seastar/testing/perf_tests.hh>
+
+#include <cstdint>
+
+namespace {
+
+constexpr int32_t records_per_batch = 100;
+constexpr size_t key_size = 16;
+
+model::record_batch make_batch(size_t value_size) {
+    iobuf body;
+    for (int32_t i = 0; i < records_per_batch; ++i) {
+        auto r = model::record(
+          model::record_attributes(0),
+          /*timestamp_delta=*/i,
+          /*offset_delta=*/i,
+          iobuf::from(random_generators::gen_alphanum_string(key_size)),
+          iobuf::from(random_generators::gen_alphanum_string(value_size)),
+          {});
+        model::append_record_to_buffer(body, r);
+    }
+    model::record_batch_header hdr{};
+    hdr.type = model::record_batch_type::raft_data;
+    hdr.base_offset = model::offset(0);
+    hdr.record_count = records_per_batch;
+    hdr.last_offset_delta = records_per_batch - 1;
+    hdr.first_timestamp = model::timestamp(0);
+    hdr.max_timestamp = model::timestamp(records_per_batch - 1);
+    hdr.reset_size_checksum_metadata(body);
+    return {hdr, std::move(body), model::record_batch::tag_ctor_ng{}};
+}
+
+size_t run_full(const model::record_batch& b) {
+    size_t cnt = 0;
+    b.for_each_record([&cnt](model::record r) {
+        perf_tests::do_not_optimize(r);
+        ++cnt;
+    });
+    return cnt;
+}
+
+// The field set used when building a compaction index.
+size_t run_key_fields(const model::record_batch& b) {
+    size_t cnt = 0;
+    b.for_each_record<
+      model::record_field::offset_delta,
+      model::record_field::key,
+      model::record_field::is_tombstone>([&cnt](auto pr) {
+        perf_tests::do_not_optimize(pr);
+        ++cnt;
+    });
+    return cnt;
+}
+
+// The field set used by a batch timequery.
+size_t run_timequery_fields(const model::record_batch& b) {
+    size_t cnt = 0;
+    b.for_each_record<
+      model::record_field::timestamp_delta,
+      model::record_field::offset_delta>([&cnt](auto pr) {
+        perf_tests::do_not_optimize(pr);
+        ++cnt;
+    });
+    return cnt;
+}
+
+size_t run_metadata(const model::record_batch& b, bool fully_parse) {
+    size_t cnt = 0;
+    b.for_each_record_metadata(
+      [&cnt](model::record_metadata md) {
+          perf_tests::do_not_optimize(md);
+          ++cnt;
+          return ss::stop_iteration::no;
+      },
+      fully_parse);
+    return cnt;
+}
+
+size_t run_record_key(const model::record_batch& b) {
+    size_t cnt = 0;
+    b.for_each_record_key([&cnt](const model::record_key_metadata& k) {
+        perf_tests::do_not_optimize(k);
+        ++cnt;
+    });
+    return cnt;
+}
+
+class record_fields_bench {
+protected:
+    model::record_batch _batch_64b = make_batch(64);
+    model::record_batch _batch_1kib = make_batch(1024);
+    model::record_batch _batch_16kib = make_batch(16UL * 1024);
+};
+
+} // namespace
+
+PERF_TEST_F(record_fields_bench, full_64b) { return run_full(_batch_64b); }
+PERF_TEST_F(record_fields_bench, full_1kib) { return run_full(_batch_1kib); }
+PERF_TEST_F(record_fields_bench, full_16kib) { return run_full(_batch_16kib); }
+
+PERF_TEST_F(record_fields_bench, key_fields_64b) {
+    return run_key_fields(_batch_64b);
+}
+PERF_TEST_F(record_fields_bench, key_fields_1kib) {
+    return run_key_fields(_batch_1kib);
+}
+PERF_TEST_F(record_fields_bench, key_fields_16kib) {
+    return run_key_fields(_batch_16kib);
+}
+
+PERF_TEST_F(record_fields_bench, timequery_fields_64b) {
+    return run_timequery_fields(_batch_64b);
+}
+PERF_TEST_F(record_fields_bench, timequery_fields_1kib) {
+    return run_timequery_fields(_batch_1kib);
+}
+PERF_TEST_F(record_fields_bench, timequery_fields_16kib) {
+    return run_timequery_fields(_batch_16kib);
+}
+
+PERF_TEST_F(record_fields_bench, metadata_64b) {
+    return run_metadata(_batch_64b, false);
+}
+PERF_TEST_F(record_fields_bench, metadata_1kib) {
+    return run_metadata(_batch_1kib, false);
+}
+PERF_TEST_F(record_fields_bench, metadata_16kib) {
+    return run_metadata(_batch_16kib, false);
+}
+
+PERF_TEST_F(record_fields_bench, metadata_full_parse_64b) {
+    return run_metadata(_batch_64b, true);
+}
+PERF_TEST_F(record_fields_bench, metadata_full_parse_1kib) {
+    return run_metadata(_batch_1kib, true);
+}
+PERF_TEST_F(record_fields_bench, metadata_full_parse_16kib) {
+    return run_metadata(_batch_16kib, true);
+}
+
+PERF_TEST_F(record_fields_bench, record_key_64b) {
+    return run_record_key(_batch_64b);
+}
+PERF_TEST_F(record_fields_bench, record_key_1kib) {
+    return run_record_key(_batch_1kib);
+}
+PERF_TEST_F(record_fields_bench, record_key_16kib) {
+    return run_record_key(_batch_16kib);
+}

--- a/src/v/raft/configuration_bootstrap_state.cc
+++ b/src/v/raft/configuration_bootstrap_state.cc
@@ -12,6 +12,7 @@
 #include "base/likely.h"
 #include "bytes/iobuf_parser.h"
 #include "model/record.h"
+#include "model/record_fields.h"
 #include "raft/consensus_utils.h"
 
 namespace raft {
@@ -33,11 +34,12 @@ void configuration_bootstrap_state::process_configuration(
     auto last_offset = b.last_offset();
 
     process_offsets(b.base_offset(), last_offset);
-    b.for_each_record([this, o = b.base_offset()](model::record rec) {
-        iobuf_parser parser(rec.release_value());
-        _configurations.emplace_back(
-          o, details::deserialize_configuration(parser));
-    });
+    b.for_each_record<model::record_field::value>(
+      [this, o = b.base_offset()](auto rec) {
+          iobuf_parser parser(std::move(rec.value));
+          _configurations.emplace_back(
+            o, details::deserialize_configuration(parser));
+      });
 }
 void configuration_bootstrap_state::process_data_offsets(
   model::record_batch b) {

--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -17,6 +17,7 @@
 #include "model/fundamental.h"
 #include "model/offset_interval.h"
 #include "model/record.h"
+#include "model/record_fields.h"
 #include "storage/logger.h"
 #include "storage/offset_translator_state.h"
 #include "storage/parser_errc.h"
@@ -573,14 +574,15 @@ ss::future<timequery_result> batch_timequery(
         batch = co_await model::decompress_batch(batch);
     }
     const auto& header = batch.header();
-    co_await batch.for_each_record_async(
-      [&result_o, &result_t, &header, query_interval, t](
-        const model::record& r) {
-          auto record_o = model::offset{r.offset_delta()} + header.base_offset;
+    co_await batch.for_each_record_async<
+      model::record_field::offset_delta,
+      model::record_field::timestamp_delta>(
+      [&result_o, &result_t, &header, query_interval, t](auto r) {
+          auto record_o = model::offset{r.offset_delta} + header.base_offset;
           auto record_t = header.attrs.timestamp_type()
                               == model::timestamp_type::create_time
                             ? model::timestamp(
-                                header.first_timestamp() + r.timestamp_delta())
+                                header.first_timestamp() + r.timestamp_delta)
                             : header.max_timestamp;
           if (record_t >= t && query_interval.contains(record_o)) {
               result_o = record_o;

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -14,6 +14,7 @@
 #include "compaction/utils.h"
 #include "config/configuration.h"
 #include "model/batch_compression.h"
+#include "model/record_fields.h"
 #include "ssx/future-util.h"
 #include "storage/batch_cache.h"
 #include "storage/compacted_index_writer.h"
@@ -486,14 +487,15 @@ void segment::cache_truncate(model::offset offset) {
 ss::future<> segment::do_compaction_index_batch(const model::record_batch& b) {
     vassert(!b.compressed(), "wrong method. Call compact_index_batch. {}", b);
     auto& w = compaction_index();
-    return model::for_each_record(
-      b,
+    return b.for_each_record_async<
+      model::record_field::offset_delta,
+      model::record_field::key>(
       [o = b.base_offset(),
        batch_type = b.header().type,
        is_control_batch = b.header().attrs.is_control(),
-       &w](const model::record& r) {
+       &w](auto r) {
           return w.index(
-            batch_type, is_control_batch, r.key(), o, r.offset_delta());
+            batch_type, is_control_batch, r.key, o, r.offset_delta);
       });
 }
 ss::future<> segment::compaction_index_batch(const model::record_batch& b) {


### PR DESCRIPTION
`record_batch::for_each_record()` is a bit of a performance footgun, since it fully materializes a `model::record` object for every record within a batch, when often, not all of the record's fields are necessary/used for a given loop over a batch.

Add a new templatized overload `for_each_record<Fields...>()`, which allows the user to specify exactly which fields of a `model::record` should be materialized. Example use is:

```cpp
    b.for_each_record<
      model::record_field::offset_delta,
      model::record_field::key,
      model::record_field::is_tombstone>([](auto pr) {
        // access pr.offset_delta, pr.key, pr.is_tombstone
    });
```

Using template magic, the return type `parsed_record<>` (deduced in the above example with `auto`) will only contain the specified fields, making the following erroneous code impossible to write (as it simply won't compile):

```cpp
    b.for_each_record<
      model::record_field::offset_delta,
      model::record_field::key,
      model::record_field::is_tombstone>([&](auto pr) {
        // `model::record_field::value` was not requested in `Fields...`,
        // so trying to access it will cause a compilation error.
        return func(std::move(pr.value));
    });
```

From ad-hoc benchmarks (not checked in) targeting each call-site swap:

* `log_reader::batch_timequery()`:
```
┌────────────┬──────────┬─────────┬─────────┬────────────┐
│ value size │   full   │ fields  │ speedup │ allocs/rec │
├────────────┼──────────┼─────────┼─────────┼────────────┤
│ 64 B       │ 69.1 ns  │ 18.1 ns │ 3.8×    │ 4 → 0      │
├────────────┼──────────┼─────────┼─────────┼────────────┤
│ 1 KiB      │ 74.1 ns  │ 19.0 ns │ 3.9×    │ 4 → 0      │
├────────────┼──────────┼─────────┼─────────┼────────────┤
│ 16 KiB     │ 235.9 ns │ 19.0 ns │ 12.4×   │ 4 → 0      │
└────────────┴──────────┴─────────┴─────────┴────────────┘
```

* `segment::do_compaction_index_batch()`:
```
┌────────────┬──────────┬─────────┬─────────┬────────────┐
│ value size │   full   │ fields  │ speedup │ allocs/rec │
├────────────┼──────────┼─────────┼─────────┼────────────┤
│ 64 B       │ 69.0 ns  │ 38.3 ns │ 1.8×    │ 4 → 2      │
├────────────┼──────────┼─────────┼─────────┼────────────┤
│ 1 KiB      │ 74.0 ns  │ 38.0 ns │ 1.95×   │ 4 → 2      │
├────────────┼──────────┼─────────┼─────────┼────────────┤
│ 16 KiB     │ 235.7 ns │ 38.7 ns │ 6.1×    │ 4 → 2      │
└────────────┴──────────┴─────────┴─────────┴────────────┘
```

* `ctp_stm.cc`/`configuration_bootstrap_state.cc` (both these locations
access the same fields, so individual benchmarks should reflect the same
improvement):

```
┌────────────┬──────────┬──────────┬─────────┬────────────┐
│ value size │   full   │  fields  │ speedup │ allocs/rec │
├────────────┼──────────┼──────────┼─────────┼────────────┤
│ 64 B       │ 68.6 ns  │ 45.4 ns  │ 1.5×    │ 4 → 2      │
├────────────┼──────────┼──────────┼─────────┼────────────┤
│ 1 KiB      │ 74.1 ns  │ 51.5 ns  │ 1.4×    │ 4 → 2      │
├────────────┼──────────┼──────────┼─────────┼────────────┤
│ 16 KiB     │ 235.6 ns │ 212.4 ns │ 1.1×    │ 4 → 2      │
└────────────┴──────────┴──────────┴─────────┴────────────┘
```

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
