### PR TITLE
model/iceberg_mode: always serialize all sections in DSL format

### DIFF
--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -1407,9 +1407,13 @@ FIXTURE_TEST(test_iceberg_property, alter_config_test_fixture) {
                  "value:mode=schema_latest,subject=foo",
                  "value_schema_latest:subject=foo"},
                new_fmt_case{
-                 "key:mode=schema_id_prefix", "key:mode=schema_id_prefix"},
+                 "key:mode=schema_id_prefix",
+                 "key:mode=schema_id_prefix;value:mode=binary,layout=flat;"
+                 "headers:value_type=binary"},
                new_fmt_case{
-                 "headers:value_type=string", "headers:value_type=string"},
+                 "headers:value_type=string",
+                 "key:mode=binary;value:mode=binary,layout=flat;"
+                 "headers:value_type=string"},
              }) {
             absl::flat_hash_map<ss::sstring, ss::sstring> properties;
             properties.emplace("redpanda.iceberg.mode", input);

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -990,7 +990,8 @@ fmt::iterator iceberg_mode::format_to(fmt::iterator it) const {
         }
     }
 
-    // Section-based format. Only emit sections that differ from defaults.
+    // Section-based format. Always emit all sections and options so that
+    // defaults are frozen at set-time (prevents schema drift on upgrade).
     bool any = false;
     auto sep = [&]() {
         if (any) {
@@ -1000,9 +1001,6 @@ fmt::iterator iceberg_mode::format_to(fmt::iterator it) const {
     };
 
     auto emit_key_section = [&](const key_config& cfg) {
-        if (cfg.mode == schema_mode::binary) {
-            return;
-        }
         sep();
         it = fmt::format_to(it, "key:mode={}", to_sv(cfg.mode));
         if (!cfg.subject.empty()) {
@@ -1014,37 +1012,18 @@ fmt::iterator iceberg_mode::format_to(fmt::iterator it) const {
     };
 
     auto emit_value_section = [&](const value_config& cfg) {
-        if (cfg.mode == schema_mode::binary && cfg.is_legacy_compatible()) {
-            return;
-        }
         sep();
-        it = fmt::format_to(it, "value:");
-        bool first = true;
-        auto opt = [&](std::string_view k, std::string_view v) {
-            if (!first) {
-                it = fmt::format_to(it, ",");
-            }
-            it = fmt::format_to(it, "{}={}", k, v);
-            first = false;
-        };
-        if (cfg.mode != schema_mode::binary) {
-            opt("mode", to_sv(cfg.mode));
-        }
+        it = fmt::format_to(it, "value:mode={}", to_sv(cfg.mode));
         if (!cfg.subject.empty()) {
-            opt("subject", cfg.subject);
+            it = fmt::format_to(it, ",subject={}", cfg.subject);
         }
         if (!cfg.protobuf_name.empty()) {
-            opt("protobuf_name", cfg.protobuf_name);
+            it = fmt::format_to(it, ",protobuf_name={}", cfg.protobuf_name);
         }
-        if (cfg.layout != value_layout::flat) {
-            opt("layout", to_sv(cfg.layout));
-        }
+        it = fmt::format_to(it, ",layout={}", to_sv(cfg.layout));
     };
 
     auto emit_headers_section = [&](const headers_config& cfg) {
-        if (cfg.value_type == header_schema_mode::binary) {
-            return;
-        }
         sep();
         it = fmt::format_to(it, "headers:value_type={}", to_sv(cfg.value_type));
     };

--- a/src/v/model/tests/iceberg_mode_test.cc
+++ b/src/v/model/tests/iceberg_mode_test.cc
@@ -288,14 +288,20 @@ TEST(IcebergModeFormat, NewKeySchema) {
     enabled e{};
     e.key.mode = sm::schema_id_prefix;
     model::iceberg_mode m{std::move(e)};
-    EXPECT_EQ(to_string(m), "key:mode=schema_id_prefix");
+    EXPECT_EQ(
+      to_string(m),
+      "key:mode=schema_id_prefix;value:mode=binary,layout=flat;"
+      "headers:value_type=binary");
 }
 
 TEST(IcebergModeFormat, NewHeadersString) {
     enabled e{};
     e.headers.value_type = hsm::string;
     model::iceberg_mode m{std::move(e)};
-    EXPECT_EQ(to_string(m), "headers:value_type=string");
+    EXPECT_EQ(
+      to_string(m),
+      "key:mode=binary;value:mode=binary,layout=flat;"
+      "headers:value_type=string");
 }
 
 // New-format string that is equivalent to an old-format string serializes
@@ -540,14 +546,20 @@ TEST(IcebergModeFormat, KeyModeString) {
     enabled e{};
     e.key.mode = sm::string;
     model::iceberg_mode m{std::move(e)};
-    EXPECT_EQ(to_string(m), "key:mode=string");
+    EXPECT_EQ(
+      to_string(m),
+      "key:mode=string;value:mode=binary,layout=flat;"
+      "headers:value_type=binary");
 }
 
 TEST(IcebergModeFormat, ValueModeString) {
     enabled e{};
     e.value.mode = sm::string;
     model::iceberg_mode m{std::move(e)};
-    EXPECT_EQ(to_string(m), "value:mode=string");
+    EXPECT_EQ(
+      to_string(m),
+      "key:mode=binary;value:mode=string,layout=flat;"
+      "headers:value_type=binary");
 }
 
 TEST(IcebergModeFormat, KeyAndValueModeString) {
@@ -555,7 +567,10 @@ TEST(IcebergModeFormat, KeyAndValueModeString) {
     e.key.mode = sm::string;
     e.value.mode = sm::string;
     model::iceberg_mode m{std::move(e)};
-    EXPECT_EQ(to_string(m), "key:mode=string;value:mode=string");
+    EXPECT_EQ(
+      to_string(m),
+      "key:mode=string;value:mode=string,layout=flat;"
+      "headers:value_type=binary");
 }
 
 TEST(IcebergModeStringRoundtrip, KeyModeString) {
@@ -666,7 +681,10 @@ TEST(IcebergModeLayout, FormatNested) {
     e.value.mode = sm::schema_id_prefix;
     e.value.layout = vl::nested;
     model::iceberg_mode m{std::move(e)};
-    EXPECT_EQ(to_string(m), "value:mode=schema_id_prefix,layout=nested");
+    EXPECT_EQ(
+      to_string(m),
+      "key:mode=binary;value:mode=schema_id_prefix,layout=nested;"
+      "headers:value_type=binary");
 }
 
 TEST(IcebergModeLayout, StringRoundtripNested) {


### PR DESCRIPTION
When using the section-based DSL format (as opposed to legacy strings like "key_value"), always emit all three sections (key, value, headers) with all their options, even when they match defaults. This freezes the config at set-time so that future changes to defaults won't silently alter the Iceberg table schema for existing topics.

Of course, this freeze doesn't apply to legacy strings, so we must still take care not to change defaults in a way that breaks legacy string users. Ideally, a future version will deprecate the legacy strings and rewrite them to the new DSL.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
