### PR TITLE
DNM: Try letting brokers go down gracefully

### DIFF
--- a/tests/rptest/scale_tests/cloud_topics_cold_read_scale_test.py
+++ b/tests/rptest/scale_tests/cloud_topics_cold_read_scale_test.py
@@ -353,8 +353,10 @@ class CloudTopicsColdReadScaleTest(PreallocNodesTest):
             #
             # HACK: when CORE-16648 is fixed, drop this force-stop and let the
             # graceful teardown run -- a clean shutdown then becomes a real check.
-            self.logger.info(
-                "Force-stopping brokers to avoid the reconciler-wedge shutdown "
-                "hang (CORE-16648)"
-            )
-            self.redpanda.stop(forced=True)
+            # self.logger.info(
+            #     "Force-stopping brokers to avoid the reconciler-wedge shutdown "
+            #     "hang (CORE-16648)"
+            # )
+            # self.redpanda.stop(forced=True)
+            self.logger.info("Let brokers tear down gracefully")
+            self.redpanda.stop()


### PR DESCRIPTION
multi-part upload improvements might have made this much less likely to occur

if this passes we can ditch https://github.com/redpanda-data/redpanda/pull/30859

original PR: https://github.com/redpanda-data/redpanda/pull/30818

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
