### PR TITLE
ct/l1/meta: Fix double future::get_exception

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/partition_validator.cc
+++ b/src/v/cloud_topics/level_one/metastore/partition_validator.cc
@@ -552,11 +552,7 @@ partition_validator::validate_objects(
             auto ec = ssx::is_shutdown_exception(ex) ? errc::shutting_down
                                                      : errc::io_error;
             co_return std::unexpected(error(
-              ec,
-              fmt::format(
-                "object_exists failed for {}: {}",
-                oid,
-                exists_fut.get_exception())));
+              ec, fmt::format("object_exists failed for {}: {}", oid, ex)));
         }
         auto dl_res = exists_fut.get();
         switch (dl_res) {


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

what it says on the tin

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Bug Fixes

* fix a latent double get_exception call on a failed future in cloud topics metastore

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
