### PR TITLE
ssx,raft: rework repeat_until_gate_closed as a coroutine

### DIFF
--- a/src/v/raft/replication_monitor.cc
+++ b/src/v/raft/replication_monitor.cc
@@ -21,29 +21,19 @@ namespace raft {
 
 replication_monitor::replication_monitor(consensus* r)
   : _raft(r) {
-    ssx::repeat_until_gate_closed(_gate, [this] {
-        return do_notify_replicated().handle_exception(
-          [this](const std::exception_ptr& e) {
-              if (!ssx::is_shutdown_exception(e)) {
-                  vlog(
-                    _raft->_ctxlog.error,
-                    "Exception running replication monitor, ignoring: {}",
-                    e);
-              }
-          });
-    });
+    auto exception_handler = [this](const std::exception_ptr& e) {
+        if (!ssx::is_shutdown_exception(e)) {
+            vlog(
+              _raft->_ctxlog.error,
+              "Exception running replication monitor, ignoring: {}",
+              e);
+        }
+    };
+    ssx::repeat_until_gate_closed(
+      _gate, [this] { return do_notify_replicated(); }, exception_handler);
 
-    ssx::repeat_until_gate_closed(_gate, [this] {
-        return do_notify_committed().handle_exception(
-          [this](const std::exception_ptr& e) {
-              if (!ssx::is_shutdown_exception(e)) {
-                  vlog(
-                    _raft->_ctxlog.error,
-                    "Exception running replication monitor, ignoring: {}",
-                    e);
-              }
-          });
-    });
+    ssx::repeat_until_gate_closed(
+      _gate, [this] { return do_notify_committed(); }, exception_handler);
 }
 
 fmt::iterator replication_monitor::format_to(fmt::iterator it) const {
@@ -211,14 +201,14 @@ ss::future<> replication_monitor::do_notify_committed() {
 }
 
 void replication_monitor::notify_replicated() {
-    if (_gate.is_closed()) {
+    if (_gate.is_closed() || _pending_majority_replication_waiters == 0) {
         return;
     }
     _replicated_event_cv.signal();
 }
 
 void replication_monitor::notify_committed() {
-    if (_gate.is_closed()) {
+    if (_gate.is_closed() || _waiters.empty()) {
         return;
     }
     _committed_event_cv.signal();

--- a/src/v/ssx/future-util.h
+++ b/src/v/ssx/future-util.h
@@ -17,6 +17,7 @@
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/condition-variable.hh>
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
@@ -352,17 +353,35 @@ inline void spawn_with_gate(seastar::gate& g, Func&& func) noexcept {
 template<class Func>
 inline void
 repeat_until_gate_closed(seastar::gate& gate, Func&& func) noexcept {
-    spawn_with_gate(gate, [&gate, func = std::forward<Func>(func)]() mutable {
-        return ss::do_until(
-          [&gate] { return gate.is_closed(); },
-          [func = std::forward<Func>(func)]() mutable {
-              return ss::futurize_invoke(func).handle_exception(
-                [](const std::exception_ptr&) {
-                    // A generic catch all to avoid exceptional futures.
-                    // The input func may include it's own exception handling.
-                });
-          });
-    });
+    repeat_until_gate_closed(
+      gate, std::forward<Func>(func), [](const std::exception_ptr&) {});
+}
+
+/// \brief Repeats the passed func in a detached fiber until the gate is closed,
+/// invoking exception_handler on any exception.
+///
+/// \param gate Gate object to use.
+/// \param func function to invoke.
+/// \param exception_handler called with any exception thrown by func.
+template<class Func, class ExceptionHandler>
+inline void repeat_until_gate_closed(
+  seastar::gate& gate,
+  Func&& func,
+  ExceptionHandler&& exception_handler) noexcept {
+    spawn_with_gate(
+      gate,
+      [&gate,
+       func = std::forward<Func>(func),
+       exception_handler = std::forward<ExceptionHandler>(exception_handler)](
+        this auto) -> seastar::future<> {
+          while (!gate.is_closed()) {
+              try {
+                  co_await seastar::futurize_invoke(func);
+              } catch (...) {
+                  exception_handler(std::current_exception());
+              }
+          }
+      });
 }
 
 /// \brief Repeats the passed func in a detached fiber until the gate is closed
@@ -374,17 +393,37 @@ repeat_until_gate_closed(seastar::gate& gate, Func&& func) noexcept {
 template<class Func>
 inline void repeat_until_gate_closed_or_aborted(
   ss::gate& gate, ss::abort_source& as, Func&& func) noexcept {
+    repeat_until_gate_closed_or_aborted(
+      gate, as, std::forward<Func>(func), [](const std::exception_ptr&) {});
+}
+
+/// \brief Repeats the passed func in a detached fiber until the gate is closed
+/// or abort is triggered, invoking exception_handler on any exception.
+///
+/// \param gate Gate object to use.
+/// \param as Abort source to use.
+/// \param func function to invoke.
+/// \param exception_handler called with any exception thrown by func.
+template<class Func, class ExceptionHandler>
+inline void repeat_until_gate_closed_or_aborted(
+  ss::gate& gate,
+  ss::abort_source& as,
+  Func&& func,
+  ExceptionHandler&& exception_handler) noexcept {
     spawn_with_gate(
-      gate, [&gate, &as, func = std::forward<Func>(func)]() mutable {
-          return ss::do_until(
-            [&gate, &as] { return as.abort_requested() || gate.is_closed(); },
-            [func = std::forward<Func>(func)]() mutable {
-                return ss::futurize_invoke(func).handle_exception(
-                  [](const std::exception_ptr&) {
-                      // A generic catch all to avoid exceptional futures.
-                      // The input func may include it's own exception handling.
-                  });
-            });
+      gate,
+      [&gate,
+       &as,
+       func = std::forward<Func>(func),
+       exception_handler = std::forward<ExceptionHandler>(exception_handler)](
+        this auto) -> seastar::future<> {
+          while (!as.abort_requested() && !gate.is_closed()) {
+              try {
+                  co_await seastar::futurize_invoke(func);
+              } catch (...) {
+                  exception_handler(std::current_exception());
+              }
+          }
       });
 }
 


### PR DESCRIPTION
Replace do_until + .handle_exception (which scheduled 2 extra forwarding
continuation tasks per iteration on the success path) with a single
while-loop coroutine using try/catch. spawn_with_gate is retained for
gate management.

Add an overload that accepts an exception_handler callback so callers
that need error logging (e.g. replication_monitor) can do so inside the
catch block without a separate .handle_exception continuation.

replication_monitor switches to the exception_handler overload, dropping
its inner .handle_exception(log) continuation.

Further the replication_monitor background loops (do_notify_replicated,
do_notify_committed) are woken on every majority_replicated and
commit_index update via CV signals. When there are no registered
waiters, the loops wake, find nothing to process, and go back to
sleep, wasting a task per signal.

Per-iter delta (tasks / instructions / allocs):
  produce 1_KiB:   40.43 -> 34.42   58967 -> 57165   100.37 -> 94.33
  raft quorum_16B: 129.30 -> 105.30  169407 -> 161085  289.79 -> 265.79

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes


* none
