### PR TITLE
cluster_link: unsupported schema-feature policy for SR shadow sync

### DIFF
--- a/src/v/cluster_link/schema_registry_sync/BUILD
+++ b/src/v/cluster_link/schema_registry_sync/BUILD
@@ -76,6 +76,7 @@ redpanda_cc_library(
         "//src/v/ssx:future_util",
         "//src/v/ssx:sformat",
         "@abseil-cpp//absl/container:flat_hash_set",
+        "@fmt",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/v/cluster_link/schema_registry_sync/http_source_reader.cc
+++ b/src/v/cluster_link/schema_registry_sync/http_source_reader.cc
@@ -266,7 +266,7 @@ http_source_reader::list_subject_versions(
     co_return std::move(res.value());
 }
 
-ss::future<source_result<ppsr::stored_schema>>
+ss::future<source_result<ppsr::source_schema_read>>
 http_source_reader::read_subject_version(
   ppsr::context_subject sub,
   ppsr::schema_version version,
@@ -285,9 +285,11 @@ http_source_reader::read_subject_version(
     if (!res.has_value()) {
         co_return std::unexpected(to_source_error(std::move(res.error())));
     }
-    // Unmodeled response fields (parsed_schema::unknown_fields) are ignored;
-    // honoring the unsupported-feature policy is future work.
-    co_return std::move(res.value().schema);
+    // Carry the read through unchanged: the schema plus any unsupported fields
+    // the source served but Redpanda cannot store. The reconciler applies the
+    // configured unsupported-feature policy to
+    // `source_schema_read::unsupported`.
+    co_return std::move(res.value());
 }
 
 ss::future<source_result<std::optional<ppsr::mode>>>

--- a/src/v/cluster_link/schema_registry_sync/http_source_reader.h
+++ b/src/v/cluster_link/schema_registry_sync/http_source_reader.h
@@ -77,7 +77,7 @@ public:
     list_subject_versions(
       ppsr::context_subject, ppsr::include_deleted, ss::abort_source&) override;
 
-    ss::future<source_result<ppsr::stored_schema>> read_subject_version(
+    ss::future<source_result<ppsr::source_schema_read>> read_subject_version(
       ppsr::context_subject, ppsr::schema_version, ss::abort_source&) override;
 
     ss::future<source_result<std::optional<ppsr::mode>>>

--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
@@ -215,9 +215,13 @@ model::task_status_report mirroring_task::get_status_report() const {
             status.current_sync->summary.subject_versions_changed
               += _reconcile_stats.versions_changed;
             status.current_sync->summary.errors += _reconcile_stats.errors;
+            status.current_sync->summary.unsupported_features_removed
+              += _reconcile_stats.unsupported_features_removed;
             status.totals_since_task_start.subject_versions_changed
               += _reconcile_stats.versions_changed;
             status.totals_since_task_start.errors += _reconcile_stats.errors;
+            status.totals_since_task_start.unsupported_features_removed
+              += _reconcile_stats.unsupported_features_removed;
         }
         report.detail = model::task_detail{
           .schema_registry_sync_status = std::move(status)};
@@ -499,6 +503,7 @@ ss::future<> mirroring_task::list_one_subject(
 ss::future<task::state_transition> mirroring_task::full_source_sync(
   ss::abort_source& as,
   const chunked_hash_set<ppsr::context>& contexts,
+  model::schema_registry_sync_config::unsupported_feature_policy feature_policy,
   const ss::noncopyable_function<bool(const ppsr::context_subject&)>&
     in_scope) {
     // Cluster-global, so safe to read mid-sync (unlike the per-link config a
@@ -624,7 +629,8 @@ ss::future<task::state_transition> mirroring_task::full_source_sync(
       _destination,
       [&in_scope](const ppsr::context_subject& cs) { return in_scope(cs); },
       _mapper,
-      limits};
+      limits,
+      feature_policy};
 
     // The reconciler increments _reconcile_stats live (reflected mid-sync by
     // get_status_report); the fold below moves them into persistent state.
@@ -655,9 +661,13 @@ ss::future<task::state_transition> mirroring_task::full_source_sync(
     _status.current_sync->summary.subject_versions_changed
       += stats.versions_changed;
     _status.current_sync->summary.errors += stats.errors;
+    _status.current_sync->summary.unsupported_features_removed
+      += stats.unsupported_features_removed;
     _status.totals_since_task_start.subject_versions_changed
       += stats.versions_changed;
     _status.totals_since_task_start.errors += stats.errors;
+    _status.totals_since_task_start.unsupported_features_removed
+      += stats.unsupported_features_removed;
 
     const auto purged = co_await purge_destination_only_versions(
       std::move(to_purge), as);
@@ -826,9 +836,13 @@ mirroring_task::run_impl(ss::abort_source& as) {
     // phase shares one mapping without re-reading _config (which a concurrent
     // update_config could swap mid-run).
     _mapper = context_mapper::make(_config);
+    // Snapshot the per-link policy while `api` is known non-null. A concurrent
+    // update_config can swap `_config` across the co_awaits below (and inside
+    // full_source_sync), so it must not re-read api_mode() after suspending.
+    const auto feature_policy = api->feature_policy;
 
     co_await refresh_destination_inventory(in_scope, as);
-    co_return co_await full_source_sync(as, contexts, in_scope);
+    co_return co_await full_source_sync(as, contexts, feature_policy, in_scope);
 }
 
 task::state_transition

--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.h
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.h
@@ -123,6 +123,8 @@ private:
     ss::future<state_transition> full_source_sync(
       ss::abort_source&,
       const chunked_hash_set<ppsr::context>& contexts,
+      model::schema_registry_sync_config::unsupported_feature_policy
+        feature_policy,
       const ss::noncopyable_function<bool(const ppsr::context_subject&)>&
         in_scope);
 

--- a/src/v/cluster_link/schema_registry_sync/reconciler.cc
+++ b/src/v/cluster_link/schema_registry_sync/reconciler.cc
@@ -22,6 +22,8 @@
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/util/defer.hh>
 
+#include <fmt/ranges.h>
+
 #include <algorithm>
 #include <array>
 #include <chrono>
@@ -110,12 +112,14 @@ reconciler::reconciler(
   schema::registry* destination,
   ss::noncopyable_function<bool(const ppsr::context_subject&)> in_scope,
   const context_mapper& mapper,
-  limits lim)
+  limits lim,
+  model::schema_registry_sync_config::unsupported_feature_policy feature_policy)
   : _source(source)
   , _destination(destination)
   , _in_scope(std::move(in_scope))
   , _mapper(&mapper)
   , _limits(lim)
+  , _feature_policy(feature_policy)
   , _mem(std::max<size_t>(1, lim.memory_bytes), "schema_registry_sync/memory") {
     // Floor the budget so the clamp `min(body_size, memory_bytes)` and the
     // semaphore agree; a degenerate 0 admits one over-budget body at a time.
@@ -138,6 +142,7 @@ ss::future<source_result<void>> reconciler::reconcile(
     _stats = &stats;
     _stats->versions_changed = 0;
     _stats->errors = 0;
+    _stats->unsupported_features_removed = 0;
     _outstanding = 0;
     _done = false;
     _fault.reset();
@@ -316,6 +321,12 @@ reconciler::discover(const ppsr::subject_version& n, ss::abort_source& as) {
         co_return source_result<void>{};
     }
 
+    // Reject under FAIL before queuing references, so a schema we are going to
+    // reject does not drag its dependency subtree into the destination.
+    if (fail_if_contains_unsupported(n, fetched.value().unsupported)) {
+        co_return source_result<void>{};
+    }
+
     // The body is released here (fetched goes out of scope): the node will be
     // re-fetched once its references complete, leading to it being fetched
     // twice in this case; and at most twice on average overall.
@@ -375,8 +386,58 @@ reconciler::do_import(const ppsr::subject_version& n, ss::abort_source& as) {
     co_return source_result<void>{};
 }
 
+bool reconciler::fail_if_contains_unsupported(
+  const ppsr::subject_version& n,
+  const chunked_vector<ppsr::unsupported_feature>& unsupported) {
+    if (
+      _feature_policy
+        != model::schema_registry_sync_config::unsupported_feature_policy::fail
+      || unsupported.empty()) {
+        return false;
+    }
+    // The FAIL policy refuses to import a schema the destination cannot store
+    // faithfully, but this is a per-item failure, not a whole-sync abort: count
+    // it, log the offending fields, and let the rest of the subjects replicate.
+    vlog(
+      cllog.warn,
+      "{}/{} carries {} unsupported schema feature(s) the destination cannot "
+      "store; failing it under the FAIL policy: {}",
+      n.sub,
+      n.version,
+      unsupported.size(),
+      fmt::join(unsupported, ", "));
+    fail(n);
+    return true;
+}
+
+void reconciler::count_if_contains_unsupported_removed(
+  const ppsr::subject_version& n,
+  const chunked_vector<ppsr::unsupported_feature>& unsupported) {
+    if (
+      _feature_policy
+        != model::schema_registry_sync_config::unsupported_feature_policy::
+          remove
+      || unsupported.empty()) {
+        return;
+    }
+    vlog(
+      cllog.info,
+      "Removed {} unsupported schema feature(s) from {}/{}: {}",
+      unsupported.size(),
+      n.sub,
+      n.version,
+      fmt::join(unsupported, ", "));
+    _stats->unsupported_features_removed += unsupported.size();
+}
+
 ss::future<bool> reconciler::import_body(
   const ppsr::subject_version& n, ppsr::source_schema_read read) {
+    // Authoritative policy gate, next to the REMOVE handling below: every
+    // import path funnels through here (discover also rejects early, before
+    // queuing refs).
+    if (fail_if_contains_unsupported(n, read.unsupported)) {
+        co_return false;
+    }
     data(n).state = node_state::importing;
     // The graph key `n` stays in the source namespace; only the schema written
     // to the destination is remapped.
@@ -414,6 +475,10 @@ ss::future<bool> reconciler::import_body(
     }
     data(n).state = node_state::done;
     ++_stats->versions_changed;
+    // Account for REMOVE-stripped features only after the projection actually
+    // lands on the destination, so a failed import does not report features as
+    // removed. Only read.schema was moved above; read.unsupported is intact.
+    count_if_contains_unsupported_removed(n, read.unsupported);
     wake(n);
     co_return true;
 }

--- a/src/v/cluster_link/schema_registry_sync/reconciler.cc
+++ b/src/v/cluster_link/schema_registry_sync/reconciler.cc
@@ -289,9 +289,9 @@ reconciler::discover(const ppsr::subject_version& n, ss::abort_source& as) {
         co_return source_result<void>{};
     }
 
-    adjust_units(_mem, units, body_size(fetched.value()));
+    adjust_units(_mem, units, body_size(fetched.value().schema));
 
-    auto refs = resolve_refs(fetched.value());
+    auto refs = resolve_refs(fetched.value().schema);
     chunked_hash_set<ppsr::subject_version> missing;
     for (auto& ref : refs) {
         if (!_in_scope(ref.sub)) {
@@ -369,18 +369,18 @@ reconciler::do_import(const ppsr::subject_version& n, ss::abort_source& as) {
         co_return source_result<void>{};
     }
 
-    adjust_units(_mem, units, body_size(fetched.value()));
+    adjust_units(_mem, units, body_size(fetched.value().schema));
 
     co_await import_body(n, std::move(fetched.value()));
     co_return source_result<void>{};
 }
 
 ss::future<bool> reconciler::import_body(
-  const ppsr::subject_version& n, ppsr::stored_schema schema) {
+  const ppsr::subject_version& n, ppsr::source_schema_read read) {
     data(n).state = node_state::importing;
     // The graph key `n` stays in the source namespace; only the schema written
     // to the destination is remapped.
-    auto remapped = remap_for_import(*_mapper, std::move(schema));
+    auto remapped = remap_for_import(*_mapper, std::move(read.schema));
     if (!remapped.has_value()) {
         vlog(
           cllog.warn,

--- a/src/v/cluster_link/schema_registry_sync/reconciler.h
+++ b/src/v/cluster_link/schema_registry_sync/reconciler.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cluster_link/model/types.h"
 #include "cluster_link/schema_registry_sync/scope.h"
 #include "cluster_link/schema_registry_sync/source_reader.h"
 #include "container/chunked_hash_map.h"
@@ -37,9 +38,13 @@ struct reconcile_stats {
     /// Source versions imported into the destination this run.
     uint64_t versions_changed{0};
     /// Per-item failures (unresolvable references, import conflicts, unparsable
-    /// schemas). These do not abort the run; the reconciler counts them and
-    /// continues.
+    /// schemas, and -- under the FAIL policy -- source schemas carrying
+    /// unsupported fields). These do not abort the run; the reconciler counts
+    /// them and continues so the rest of the subjects still replicate.
     uint64_t errors{0};
+    /// Unsupported fields removed from imported schemas this run under the
+    /// REMOVE policy.
+    uint64_t unsupported_features_removed{0};
 };
 
 /// The set of changes a reconcile applies: each upsert is a (context, subject,
@@ -97,7 +102,9 @@ public:
       schema::registry* destination,
       ss::noncopyable_function<bool(const ppsr::context_subject&)> in_scope,
       const context_mapper& mapper,
-      limits lim);
+      limits lim,
+      model::schema_registry_sync_config::unsupported_feature_policy
+        feature_policy);
 
     /// Imports `work_set.upserts` referent-first.
     ///
@@ -163,10 +170,32 @@ private:
     /// Imports a fetched read, classifying conflicts as per-item failures.
     /// Returns true on a successful import. Carries the whole
     /// source_schema_read (not just the schema) so the unsupported-feature
-    /// policy can act on `read.unsupported` at the single per-node import
-    /// point.
+    /// policy can act on `read.unsupported` at the authoritative per-node
+    /// import point (FAIL rejection and REMOVE accounting both happen here).
     ss::future<bool>
     import_body(const ppsr::subject_version& n, ppsr::source_schema_read read);
+
+    /// Under the FAIL policy, treats a schema carrying `unsupported` fields as
+    /// a per-item failure: logs the offending fields, marks the node (and its
+    /// dependents) failed via fail(n), and returns true so the caller skips the
+    /// import. The rest of the sync proceeds -- fail-fast is reserved for
+    /// global errors like source unavailability. Returns false (a no-op) under
+    /// REMOVE or when the list is empty.
+    ///
+    /// Called by `import_body` (authoritative gate) and by `discover` before
+    /// queuing a node's references.
+    bool fail_if_contains_unsupported(
+      const ppsr::subject_version& n,
+      const chunked_vector<ppsr::unsupported_feature>& unsupported);
+
+    /// Under the REMOVE policy, accounts for the `unsupported` fields the
+    /// parser already dropped from a schema: logs them and adds them to
+    /// `unsupported_features_removed`. A no-op under FAIL or when the list is
+    /// empty. Call only after the import succeeds, so a failed import does not
+    /// report features as removed.
+    void count_if_contains_unsupported_removed(
+      const ppsr::subject_version& n,
+      const chunked_vector<ppsr::unsupported_feature>& unsupported);
 
     /// Marks a node replicated and releases dependents whose in-degree hits 0.
     void wake(const ppsr::subject_version& n);
@@ -189,6 +218,8 @@ private:
     ss::noncopyable_function<bool(const ppsr::context_subject&)> _in_scope;
     const context_mapper* _mapper;
     limits _limits;
+    model::schema_registry_sync_config::unsupported_feature_policy
+      _feature_policy;
 
     chunked_hash_set<ppsr::subject_version> _replicated;
     chunked_hash_map<ppsr::subject_version, node_data> _nodes;

--- a/src/v/cluster_link/schema_registry_sync/reconciler.h
+++ b/src/v/cluster_link/schema_registry_sync/reconciler.h
@@ -160,10 +160,13 @@ private:
     ss::future<source_result<void>>
     do_import(const ppsr::subject_version& n, ss::abort_source& as);
 
-    /// Imports a fetched body, classifying conflicts as per-item failures.
-    /// Returns true on a successful import.
+    /// Imports a fetched read, classifying conflicts as per-item failures.
+    /// Returns true on a successful import. Carries the whole
+    /// source_schema_read (not just the schema) so the unsupported-feature
+    /// policy can act on `read.unsupported` at the single per-node import
+    /// point.
     ss::future<bool>
-    import_body(const ppsr::subject_version& n, ppsr::stored_schema schema);
+    import_body(const ppsr::subject_version& n, ppsr::source_schema_read read);
 
     /// Marks a node replicated and releases dependents whose in-degree hits 0.
     void wake(const ppsr::subject_version& n);

--- a/src/v/cluster_link/schema_registry_sync/source_reader.h
+++ b/src/v/cluster_link/schema_registry_sync/source_reader.h
@@ -75,7 +75,11 @@ public:
 
     /// Reads a specific subject version's schema. The reconcile engine's
     /// schema-body fetch path: called for every node it discovers and imports.
-    virtual ss::future<source_result<ppsr::stored_schema>> read_subject_version(
+    /// Returns the schema projected into Redpanda's supported model plus any
+    /// unsupported fields the source carried but Redpanda cannot store, for the
+    /// caller to apply its unsupported-feature policy.
+    virtual ss::future<source_result<ppsr::source_schema_read>>
+    read_subject_version(
       ppsr::context_subject, ppsr::schema_version, ss::abort_source&) = 0;
 
     /// Reads the source's own (non-inherited) mode override for a subject or

--- a/src/v/cluster_link/schema_registry_sync/tests/http_source_reader_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/http_source_reader_test.cc
@@ -170,9 +170,20 @@ TEST(http_source_reader, read_subject_version_returns_schema) {
                  .get();
     reader.stop().get();
 
-    ASSERT_TRUE(res.has_value());
-    EXPECT_EQ(res->id, pps::schema_id{100001});
-    EXPECT_EQ(res->version, pps::schema_version{3});
+    EXPECT_THAT(
+      res,
+      Optional(AllOf(
+        Field(
+          "schema",
+          &pps::source_schema_read::schema,
+          AllOf(
+            Field("id", &pps::stored_schema::id, pps::schema_id{100001}),
+            Field(
+              "version",
+              &pps::stored_schema::version,
+              pps::schema_version{3}))),
+        Field(
+          "unsupported", &pps::source_schema_read::unsupported, IsEmpty()))));
 }
 
 // Discovery and body fetch must request deleted entries so the reconcile can

--- a/src/v/cluster_link/schema_registry_sync/tests/mirroring_task_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/mirroring_task_test.cc
@@ -251,6 +251,63 @@ TEST_F(mirroring_task_test, full_sync_imports_and_reports) {
     EXPECT_LT(index_of(all, "a"), index_of(all, "b"));
 }
 
+TEST_F(mirroring_task_test, remove_policy_strips_and_counts_unsupported) {
+    auto a = ppsr::context_subject::unqualified("a");
+    _source_state.add(a, 1);
+    _source_state.set_unsupported(a, 1, {{.json_pointer = "/ruleSet"}});
+
+    auto metadata = get_default_metadata();
+    metadata.configuration.schema_registry_sync_cfg.api_mode()->feature_policy
+      = model::schema_registry_sync_config::unsupported_feature_policy::remove;
+
+    lead_schema_registry();
+    fixture()->upsert_link(std::move(metadata)).get();
+
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+    ASSERT_TRUE(status.has_value());
+    // The supported projection is imported and the removed feature is counted.
+    EXPECT_EQ(status->last_full_sync->subject_versions_changed, 1);
+    EXPECT_EQ(status->last_full_sync->unsupported_features_removed, 1);
+    EXPECT_EQ(status->totals_since_task_start.unsupported_features_removed, 1);
+    EXPECT_GE(index_of(_registry.get_all(), "a"), 0);
+}
+
+TEST_F(mirroring_task_test, fail_policy_counts_unsupported_and_syncs_rest) {
+    // Under FAIL an unsupported feature is a counted per-item error, not a
+    // whole-sync abort: the offending subject is skipped while the rest sync,
+    // and the task stays active. Fail-fast is reserved for global errors like
+    // source unavailability.
+    auto a = ppsr::context_subject::unqualified("a"); // unsupported -> skipped
+    auto b = ppsr::context_subject::unqualified("b"); // clean -> imported
+    _source_state.add(a, 1);
+    _source_state.add(b, 1);
+    _source_state.set_unsupported(a, 1, {{.json_pointer = "/ruleSet"}});
+
+    auto metadata = get_default_metadata();
+    metadata.configuration.schema_registry_sync_cfg.api_mode()->feature_policy
+      = model::schema_registry_sync_config::unsupported_feature_policy::fail;
+
+    lead_schema_registry();
+    fixture()->upsert_link(std::move(metadata)).get();
+
+    // The full sync completes (the task does not fault): the unsupported
+    // subject is counted as an error and skipped, and the clean subject is
+    // imported.
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+    ASSERT_TRUE(status.has_value());
+    EXPECT_EQ(status->last_full_sync->errors, 1);
+    EXPECT_EQ(status->last_full_sync->subject_versions_changed, 1);
+    EXPECT_EQ(status->last_full_sync->unsupported_features_removed, 0);
+    EXPECT_EQ(index_of(_registry.get_all(), "a"), -1);
+    EXPECT_GE(index_of(_registry.get_all(), "b"), 0);
+}
+
 TEST_F(mirroring_task_test, source_unavailable_then_recovers) {
     _source_state.add(ppsr::context_subject::unqualified("orders-value"), 1);
     _source_state.list_subjects_error = srs::source_error{

--- a/src/v/cluster_link/schema_registry_sync/tests/reconciler_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/reconciler_test.cc
@@ -57,6 +57,28 @@ TEST(reconciler, replicates_chain_in_reference_order) {
     EXPECT_LT(ia, ib);
 }
 
+// A read carrying unsupported-feature diagnostics still imports normally: the
+// source_reader interface carries `unsupported` through, but the reconciler
+// does not yet act on it (policy enforcement is a later commit).
+TEST(reconciler, imports_schema_with_unsupported_diagnostics) {
+    reconcile_harness h;
+    auto a = ppsr::context_subject::unqualified("a");
+    h.source.add(a, 1);
+    chunked_vector<ppsr::unsupported_feature> unsupported;
+    unsupported.push_back(
+      ppsr::unsupported_feature{.json_pointer = "/ruleSet"});
+    h.source.set_unsupported(a, 1, std::move(unsupported));
+
+    srs::work_set work;
+    work.upserts.push_back(key(a, 1));
+
+    auto stats = h.run(std::move(work)).get();
+    ASSERT_TRUE(stats.has_value());
+    EXPECT_EQ(stats->versions_changed, 1);
+    EXPECT_EQ(stats->errors, 0);
+    EXPECT_GE(index_of(h.destination.get_all(), "a"), 0);
+}
+
 // Tolerance test: a schema that lists the same reference twice is handled and
 // the referrer still imports referent-first. Holds with or without the dedup.
 TEST(reconciler, duplicate_reference_still_imports) {

--- a/src/v/cluster_link/schema_registry_sync/tests/reconciler_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/reconciler_test.cc
@@ -57,16 +57,16 @@ TEST(reconciler, replicates_chain_in_reference_order) {
     EXPECT_LT(ia, ib);
 }
 
-// A read carrying unsupported-feature diagnostics still imports normally: the
-// source_reader interface carries `unsupported` through, but the reconciler
-// does not yet act on it (policy enforcement is a later commit).
-TEST(reconciler, imports_schema_with_unsupported_diagnostics) {
+// Under the REMOVE policy a schema carrying unsupported features is imported
+// (only the supported projection is stored) and the removals are counted.
+TEST(reconciler, remove_policy_imports_and_counts_unsupported) {
     reconcile_harness h;
+    h.feature_policy
+      = model::schema_registry_sync_config::unsupported_feature_policy::remove;
     auto a = ppsr::context_subject::unqualified("a");
     h.source.add(a, 1);
-    chunked_vector<ppsr::unsupported_feature> unsupported;
-    unsupported.push_back(
-      ppsr::unsupported_feature{.json_pointer = "/ruleSet"});
+    chunked_vector<ppsr::unsupported_feature> unsupported{
+      {.json_pointer = "/ruleSet"}, {.json_pointer = "/metadata/tags"}};
     h.source.set_unsupported(a, 1, std::move(unsupported));
 
     srs::work_set work;
@@ -75,8 +75,108 @@ TEST(reconciler, imports_schema_with_unsupported_diagnostics) {
     auto stats = h.run(std::move(work)).get();
     ASSERT_TRUE(stats.has_value());
     EXPECT_EQ(stats->versions_changed, 1);
+    EXPECT_EQ(stats->unsupported_features_removed, 2);
     EXPECT_EQ(stats->errors, 0);
     EXPECT_GE(index_of(h.destination.get_all(), "a"), 0);
+}
+
+// Under REMOVE the removed-features counter must reflect only projections that
+// actually landed: a schema carrying unsupported features whose import is
+// rejected counts a single error and leaves unsupported_features_removed at 0.
+TEST(reconciler, remove_policy_does_not_count_on_import_failure) {
+    fake_source_state source;
+    schema::fake_registry inner;
+    failing_import_registry destination{&inner};
+
+    auto a = ppsr::context_subject::unqualified("a");
+    source.add(a, 1);
+    source.set_unsupported(a, 1, {{.json_pointer = "/ruleSet"}});
+    destination.fail_import(
+      key(a, 1), ppsr::error_code::schema_invalid, "unparseable body");
+
+    srs::work_set work;
+    work.upserts.push_back(key(a, 1));
+
+    fake_source_reader reader{&source};
+    srs::context_mapper mapper;
+    srs::reconciler::limits lim{
+      .memory_bytes = no_memory_limit, .parallelism = 1};
+    auto r = srs::reconciler{
+      &reader,
+      &destination,
+      [](const ppsr::context_subject&) { return true; },
+      mapper,
+      lim,
+      model::schema_registry_sync_config::unsupported_feature_policy::remove};
+
+    ss::abort_source as;
+    srs::reconcile_stats stats;
+    auto res = r.reconcile(std::move(work), {}, stats, as).get();
+
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(stats.errors, 1);
+    EXPECT_EQ(stats.versions_changed, 0);
+    EXPECT_EQ(stats.unsupported_features_removed, 0);
+    EXPECT_EQ(index_of(inner.get_all(), "a"), -1);
+}
+
+// Under the FAIL policy an unsupported feature is a per-item failure, not a
+// whole-sync abort: the offending node is counted as an error and skipped
+// (never imported), while the rest of the work still replicates.
+TEST(reconciler, fail_policy_counts_and_skips_unsupported) {
+    reconcile_harness h;
+    h.feature_policy
+      = model::schema_registry_sync_config::unsupported_feature_policy::fail;
+    auto a = ppsr::context_subject::unqualified("a"); // unsupported -> skipped
+    auto b = ppsr::context_subject::unqualified("b"); // clean -> imported
+    h.source.add(a, 1);
+    h.source.add(b, 1);
+    h.source.set_unsupported(a, 1, {{.json_pointer = "/ruleSet"}});
+
+    srs::work_set work;
+    work.upserts.push_back(key(a, 1));
+    work.upserts.push_back(key(b, 1));
+
+    // The run completes (no throw); the unsupported node is counted and
+    // skipped.
+    auto stats = h.run(std::move(work)).get();
+    ASSERT_TRUE(stats.has_value());
+    EXPECT_EQ(stats->errors, 1);
+    EXPECT_EQ(stats->versions_changed, 1);
+    EXPECT_EQ(stats->unsupported_features_removed, 0);
+    EXPECT_EQ(index_of(h.destination.get_all(), "a"), -1);
+    EXPECT_GE(index_of(h.destination.get_all(), "b"), 0);
+}
+
+// Under FAIL a rejected schema is skipped before its references are queued, so
+// a reference pulled in solely for the rejected schema is not dragged into the
+// destination. Here b references a and only b is selected for replication; b
+// turns out to carry unsupported features (discovered on fetch) and is
+// rejected, so a -- reachable only as b's reference -- is never imported.
+TEST(reconciler, fail_policy_skips_references_of_rejected_schema) {
+    reconcile_harness h;
+    h.feature_policy
+      = model::schema_registry_sync_config::unsupported_feature_policy::fail;
+    auto a = ppsr::context_subject::unqualified("a"); // ref of b, pulled for b
+    auto b = ppsr::context_subject::unqualified("b"); // unsupported -> rejected
+    h.source.add(a, 1);
+    h.source.add_with_refs(b, 1, refs_to({ref_to(a, 1)}));
+    h.source.set_unsupported(b, 1, {{.json_pointer = "/ruleSet"}});
+
+    // Select only b for replication; a would be discovered solely as b's ref.
+    srs::work_set work;
+    work.upserts.push_back(key(b, 1));
+
+    auto stats = h.run(std::move(work)).get();
+    ASSERT_TRUE(stats.has_value());
+    EXPECT_EQ(stats->errors, 1);
+    EXPECT_EQ(stats->versions_changed, 0);
+    EXPECT_EQ(stats->unsupported_features_removed, 0);
+    EXPECT_EQ(index_of(h.destination.get_all(), "b"), -1);
+    EXPECT_EQ(index_of(h.destination.get_all(), "a"), -1);
+    // a is never even fetched: rejecting b before queuing its references means
+    // a is never discovered/enqueued, not merely dropped before import.
+    EXPECT_EQ(h.source.reads(a, 1), 0);
 }
 
 // Tolerance test: a schema that lists the same reference twice is handled and
@@ -409,7 +509,8 @@ TEST(reconciler, import_errors_are_per_item_and_cascade) {
       &destination,
       [](const ppsr::context_subject&) { return true; },
       mapper,
-      lim};
+      lim,
+      model::schema_registry_sync_config::unsupported_feature_policy::fail};
 
     ss::abort_source as;
     srs::reconcile_stats stats;
@@ -496,7 +597,8 @@ TEST(reconciler, abort_mid_sync_drains_cleanly) {
       &destination,
       [](const ppsr::context_subject&) { return true; },
       mapper,
-      lim};
+      lim,
+      model::schema_registry_sync_config::unsupported_feature_policy::fail};
 
     srs::work_set work;
     work.upserts.push_back(key(ppsr::context_subject::unqualified("a"), 1));
@@ -551,7 +653,8 @@ TEST(reconciler, reports_progress_live) {
       &destination,
       [](const ppsr::context_subject&) { return true; },
       mapper,
-      lim};
+      lim,
+      model::schema_registry_sync_config::unsupported_feature_policy::fail};
 
     srs::work_set work;
     work.upserts.push_back(key(a, 1));
@@ -743,7 +846,8 @@ TEST(reconciler, remaps_context_at_import) {
       &destination,
       [](const ppsr::context_subject&) { return true; },
       mapper,
-      lim};
+      lim,
+      model::schema_registry_sync_config::unsupported_feature_policy::fail};
 
     srs::work_set work;
     work.upserts.push_back(key(base, 1));

--- a/src/v/cluster_link/schema_registry_sync/tests/sr_sync_test_fixtures.h
+++ b/src/v/cluster_link/schema_registry_sync/tests/sr_sync_test_fixtures.h
@@ -141,6 +141,21 @@ struct fake_source_state {
           std::move(err));
     }
 
+    // Unsupported features to attach to a specific (subject, version)'s read,
+    // letting a test drive the reconciler's unsupported-feature policy.
+    chunked_hash_map<
+      ppsr::subject_version,
+      chunked_vector<ppsr::unsupported_feature>>
+      unsupported_features;
+
+    void set_unsupported(
+      const ppsr::context_subject& sub,
+      int32_t version,
+      chunked_vector<ppsr::unsupported_feature> features) {
+        unsupported_features[ppsr::subject_version{
+          sub, ppsr::schema_version{version}}] = std::move(features);
+    }
+
     void add(
       const ppsr::context_subject& sub,
       int32_t version,
@@ -244,7 +259,8 @@ public:
         co_return versions;
     }
 
-    ss::future<srs::source_result<ppsr::stored_schema>> read_subject_version(
+    ss::future<srs::source_result<ppsr::source_schema_read>>
+    read_subject_version(
       ppsr::context_subject sub,
       ppsr::schema_version version,
       ss::abort_source&) override {
@@ -257,7 +273,15 @@ public:
         }
         for (const auto& s : _state->schemas) {
             if (s.schema.sub() == sub && s.version == version) {
-                co_return s.share();
+                chunked_vector<ppsr::unsupported_feature> unsupported;
+                if (
+                  auto it = _state->unsupported_features.find(
+                    ppsr::subject_version{sub, version});
+                  it != _state->unsupported_features.end()) {
+                    unsupported = it->second.copy();
+                }
+                co_return ppsr::source_schema_read{
+                  .schema = s.share(), .unsupported = std::move(unsupported)};
             }
         }
         co_return std::unexpected(

--- a/src/v/cluster_link/schema_registry_sync/tests/sr_sync_test_fixtures.h
+++ b/src/v/cluster_link/schema_registry_sync/tests/sr_sync_test_fixtures.h
@@ -350,6 +350,9 @@ struct reconcile_harness {
     // that exercise concurrency override `lim` and avoid exact fetch-count
     // assertions.
     srs::reconciler::limits lim{.memory_bytes = 1u << 20, .parallelism = 1};
+    model::schema_registry_sync_config::unsupported_feature_policy
+      feature_policy
+      = model::schema_registry_sync_config::unsupported_feature_policy::fail;
 
     // Identity mapping by default: source and destination contexts coincide, so
     // reconcile tests need no remapping.
@@ -359,7 +362,12 @@ struct reconcile_harness {
       ss::noncopyable_function<bool(const ppsr::context_subject&)> in_scope =
         [](const ppsr::context_subject&) { return true; }) {
         return srs::reconciler{
-          &reader, &destination, std::move(in_scope), mapper, lim};
+          &reader,
+          &destination,
+          std::move(in_scope),
+          mapper,
+          lim,
+          feature_policy};
     }
 
     ss::future<srs::source_result<srs::reconcile_stats>>

--- a/src/v/cluster_link/schema_registry_sync/unavailable_source_reader.cc
+++ b/src/v/cluster_link/schema_registry_sync/unavailable_source_reader.cc
@@ -39,7 +39,7 @@ unavailable_source_reader::list_subject_versions(
     co_return std::unexpected(unavailable());
 }
 
-ss::future<source_result<ppsr::stored_schema>>
+ss::future<source_result<ppsr::source_schema_read>>
 unavailable_source_reader::read_subject_version(
   ppsr::context_subject, ppsr::schema_version, ss::abort_source&) {
     co_return std::unexpected(unavailable());

--- a/src/v/cluster_link/schema_registry_sync/unavailable_source_reader.h
+++ b/src/v/cluster_link/schema_registry_sync/unavailable_source_reader.h
@@ -43,7 +43,7 @@ public:
     list_subject_versions(
       ppsr::context_subject, ppsr::include_deleted, ss::abort_source&) override;
 
-    ss::future<source_result<ppsr::stored_schema>> read_subject_version(
+    ss::future<source_result<ppsr::source_schema_read>> read_subject_version(
       ppsr::context_subject, ppsr::schema_version, ss::abort_source&) override;
 
     ss::future<source_result<std::optional<ppsr::mode>>>

--- a/src/v/pandaproxy/schema_registry/rest_client/client.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.cc
@@ -564,7 +564,7 @@ client::list_subject_versions(
     co_return std::move(parsed.value());
 }
 
-ss::future<std::expected<parsed_schema, domain_error>>
+ss::future<std::expected<source_schema_read, domain_error>>
 client::get_schema_by_version(
   const context_subject& subject,
   schema_version version,

--- a/src/v/pandaproxy/schema_registry/rest_client/client.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.cc
@@ -35,6 +35,14 @@ namespace {
 
 constexpr std::string_view accept_json = "application/json";
 
+// Confluent returns extended schema fields (guid, ts, deleted) on a schema
+// response only when this request header is present. The migration client opts
+// in so the tolerant parser sees the full response and the ignorable-field list
+// explicitly drops the server-assigned ones (guid, ts) rather than relying on
+// the server to omit them.
+constexpr std::string_view accept_unknown_properties_header
+  = "Confluent-Accept-Unknown-Properties";
+
 // Schema Registry error_codes for the not-found conditions.
 constexpr int32_t error_code_subject_not_found = 40401;
 constexpr int32_t error_code_version_not_found = 40402;
@@ -580,7 +588,8 @@ client::get_schema_by_version(
           .path(
             fmt::format(
               "/subjects/{}/versions/{}", encode_subject(subject), version()))
-          .header("accept", accept_json);
+          .header("accept", accept_json)
+          .header(accept_unknown_properties_header, "true");
     add_deleted_param(request, deleted);
     maybe_add_basic_auth(request);
 

--- a/src/v/pandaproxy/schema_registry/rest_client/client.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/client.h
@@ -191,11 +191,11 @@ public:
     /// be fetched. A missing subject yields subject_not_found; a missing
     /// version (of an existing subject) yields version_not_found.
     ///
-    /// The result wraps the schema together with the names of any response
-    /// fields the client did not model (parsed_schema::unknown_fields); a
+    /// The result wraps the schema together with any unsupported response
+    /// fields the client could not store (source_schema_read::unsupported); a
     /// caller that needs fidelity can inspect them and apply its own strictness
     /// policy.
-    ss::future<std::expected<parsed_schema, domain_error>>
+    ss::future<std::expected<source_schema_read, domain_error>>
     get_schema_by_version(
       const context_subject& subject,
       schema_version version,

--- a/src/v/pandaproxy/schema_registry/rest_client/config.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/config.h
@@ -105,9 +105,12 @@ registry_compatibility_level_from_wire(std::string_view sv) {
 /// flags, metadata, rule sets) that this client does not model; the names of
 /// any such top-level fields present are recorded in \ref unknown_fields, so a
 /// caller can tell config content was dropped without this client having to
-/// model it (mirroring parsed_schema::unknown_fields). Redpanda's own server
-/// emits only `compatibilityLevel`, so unknown_fields is empty against it; a
-/// third-party Confluent-compatible registry may populate it.
+/// model it. This serves the same intent as source_schema_read::unsupported on
+/// the schema-fetch path, but is a simpler representation: bare top-level field
+/// names only, not the structured JSON pointer + type that path records.
+/// Redpanda's own server emits only `compatibilityLevel`, so unknown_fields is
+/// empty against it; a third-party Confluent-compatible registry may populate
+/// it.
 struct config_info {
     registry_compatibility_level level;
     ss::sstring raw;

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.cc
@@ -15,9 +15,12 @@
 
 #include <seastar/core/coroutine.hh>
 
+#include <algorithm>
+#include <array>
 #include <cstdint>
 #include <limits>
 #include <optional>
+#include <string_view>
 #include <utility>
 
 namespace pandaproxy::schema_registry::rest_client {
@@ -41,6 +44,57 @@ std::optional<int32_t> checked_nonnegative_i32(int64_t v) {
         return std::nullopt;
     }
     return static_cast<int32_t>(v);
+}
+
+// Server-assigned response fields Redpanda does not model but which carry no
+// user content. If a source returns them, this list drops them rather than
+// surfacing them to the unsupported-feature policy, so a source that returns
+// them does not spuriously trip it.
+//
+// A constexpr array scanned with ranges::contains is a deliberate choice at
+// this size: it keeps the list trivially extensible (just add a literal) rather
+// than a switch/case, and for N=2 a linear scan beats a hash set (no static
+// init, stays constexpr). Promote to a flat_hash_set only if this list grows
+// large or gains a bulk-lookup site (cf. cluster_link's
+// disallowed_topic_properties, materialized into a set in its validator).
+constexpr auto ignorable_fields = std::to_array<std::string_view>(
+  {"guid", "ts"});
+
+bool is_ignorable_field(std::string_view key) {
+    return std::ranges::contains(ignorable_fields, key);
+}
+
+// The field's JSON type name, for unsupported-feature diagnostics; takes the
+// parser's current value token.
+const char* json_type_name(serde::json::token t) {
+    using token = serde::json::token;
+    switch (t) {
+    case token::start_object:
+        return "object";
+    case token::start_array:
+        return "array";
+    case token::value_string:
+        return "string";
+    case token::value_int:
+    case token::value_double:
+        return "number";
+    case token::value_true:
+    case token::value_false:
+        return "boolean";
+    case token::value_null:
+        return "null";
+    // Non-value tokens never reach here (this is called only on the parser's
+    // current value token). They are enumerated rather than folded into a
+    // default so the switch stays exhaustive: -Wswitch (via -Werror) then flags
+    // a newly-added token at compile time instead of silently returning
+    // "unknown".
+    case token::error:
+    case token::key:
+    case token::end_object:
+    case token::end_array:
+    case token::eof:
+        return "unknown";
+    }
 }
 
 } // namespace
@@ -517,21 +571,19 @@ parse_references(serde::json::parser& p, qualified_subjects_enabled qualified) {
       parse_error{.reason = "truncated or malformed references array"});
 }
 
-// The result of parsing a metadata object: the modeled portion plus the names
-// of any sub-keys we don't model.
+// The result of parsing a metadata object: the modeled portion plus any
+// unsupported sub-fields, each already reported as a `/metadata/<key>` pointer.
 struct parsed_metadata {
     schema_metadata metadata;
-    // Unmodeled keys found directly inside `metadata` (e.g. `tags`,
-    // `sensitive`), unqualified; the caller qualifies and propagates them.
-    chunked_vector<ss::sstring> unknown_fields;
+    chunked_vector<unsupported_feature> unsupported;
 };
 
 // Parse a metadata object of the form {"properties": {<str>: <str>}, ...}.
 // Entered with the current token at the object start; leaves the parser at the
 // end_object token. Only `properties` is modeled; its values are stored as
 // strings, with numbers and booleans coerced to strings to match the write
-// path. Any other key (e.g. `tags`, `sensitive`) is returned, unqualified, in
-// parsed_metadata::unknown_fields for the caller to record.
+// path. Any other non-null key (e.g. `tags`, `sensitive`) is reported in
+// parsed_metadata::unsupported as a `/metadata/<key>` pointer.
 ss::future<std::expected<parsed_metadata, parse_error>>
 parse_metadata(serde::json::parser& p) {
     using token = serde::json::token;
@@ -546,7 +598,14 @@ parse_metadata(serde::json::parser& p) {
               parse_error{.reason = "truncated JSON in schema metadata"});
         }
         if (key != "properties") {
-            result.unknown_fields.push_back(std::move(key));
+            // A null value means the sub-field is absent; anything else is an
+            // unsupported feature, surfaced as a `/metadata/<key>` pointer.
+            if (p.token() != token::value_null) {
+                result.unsupported.push_back(
+                  unsupported_feature{
+                    .json_pointer = ssx::sformat("/metadata/{}", key),
+                    .json_type = json_type_name(p.token())});
+            }
             co_await p.skip_value();
             continue;
         }
@@ -602,7 +661,7 @@ parse_metadata(serde::json::parser& p) {
 
 } // namespace
 
-ss::future<std::expected<parsed_schema, parse_error>>
+ss::future<std::expected<source_schema_read, parse_error>>
 parse_subject_version(iobuf body, qualified_subjects_enabled qualified) {
     using token = serde::json::token;
     // Firewall exceptions from the parser: malformed input is reported via the
@@ -623,7 +682,7 @@ parse_subject_version(iobuf body, qualified_subjects_enabled qualified) {
         schema_definition::references refs;
         is_deleted deleted{false};
         std::optional<schema_metadata> metadata;
-        chunked_vector<ss::sstring> unknown_fields;
+        chunked_vector<unsupported_feature> unsupported;
 
         while (co_await p.next()) {
             if (p.token() == token::end_object) {
@@ -637,8 +696,8 @@ parse_subject_version(iobuf body, qualified_subjects_enabled qualified) {
                 }
                 // Absent fields fall back to defaults/sentinels; completeness
                 // is a higher-layer concern. Unmodeled fields were recorded in
-                // unknown_fields above for the caller to act on.
-                co_return parsed_schema{
+                // `unsupported` above for the caller to act on.
+                co_return source_schema_read{
                   .schema = stored_schema{
                     .schema = subject_schema{
                       subject.value_or(invalid_subject),
@@ -651,7 +710,7 @@ parse_subject_version(iobuf body, qualified_subjects_enabled qualified) {
                     .version = version.value_or(invalid_schema_version),
                     .id = id.value_or(invalid_schema_id),
                     .deleted = deleted},
-                  .unknown_fields = std::move(unknown_fields)};
+                  .unsupported = std::move(unsupported)};
             }
             if (p.token() != token::key) {
                 co_return std::unexpected(
@@ -730,30 +789,35 @@ parse_subject_version(iobuf body, qualified_subjects_enabled qualified) {
                 refs = std::move(*r);
             } else if (key == "metadata") {
                 // Partially modeled: parse_metadata captures `properties` and
-                // returns any other sub-key (e.g. `tags`), which we qualify
-                // with a `metadata.` prefix into unknown_fields. A null
-                // metadata is treated as absent; any other non-object is
-                // unrepresentable.
+                // returns any other sub-key (e.g. `tags`) as a
+                // `/metadata/<key>` unsupported feature. A null metadata is
+                // treated as absent; any other non-object is unrepresentable.
                 if (p.token() == token::start_object) {
                     auto m = co_await parse_metadata(p);
                     if (!m) {
                         co_return std::unexpected(std::move(m.error()));
                     }
                     metadata = std::move(m->metadata);
-                    for (const auto& sub : m->unknown_fields) {
-                        unknown_fields.push_back(
-                          ssx::sformat("metadata.{}", sub));
+                    for (auto& f : m->unsupported) {
+                        unsupported.push_back(std::move(f));
                     }
                 } else if (p.token() != token::value_null) {
                     co_return std::unexpected(
                       parse_error{.reason = "metadata must be an object"});
                 }
             } else {
-                // Unknown / not-yet-modeled field (guid, ts, ruleSet,
-                // schemaTags, ...): skip its value, but record the top-level
-                // key so the caller can decide whether dropping it is
-                // acceptable.
-                unknown_fields.push_back(std::move(key));
+                // Unmodeled field. Server-assigned fields that carry no user
+                // content (`guid`, `ts`) are dropped silently; a null value
+                // means the field is absent; anything else is an unsupported
+                // feature, surfaced as a `/<key>` pointer for the migration
+                // policy to act on.
+                if (
+                  !is_ignorable_field(key) && p.token() != token::value_null) {
+                    unsupported.push_back(
+                      unsupported_feature{
+                        .json_pointer = ssx::sformat("/{}", key),
+                        .json_type = json_type_name(p.token())});
+                }
                 co_await p.skip_value();
             }
         }

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.cc
@@ -47,9 +47,11 @@ std::optional<int32_t> checked_nonnegative_i32(int64_t v) {
 }
 
 // Server-assigned response fields Redpanda does not model but which carry no
-// user content. If a source returns them, this list drops them rather than
-// surfacing them to the unsupported-feature policy, so a source that returns
-// them does not spuriously trip it.
+// user content. The client opts into them via the
+// `Confluent-Accept-Unknown-Properties` header (see client.cc), so they arrive
+// on schema responses; this list drops them rather than surfacing them to the
+// unsupported-feature policy, so a source that returns them does not spuriously
+// trip it.
 //
 // A constexpr array scanned with ranges::contains is a deliberate choice at
 // this size: it keeps the list trivially extensible (just add a literal) rather

--- a/src/v/pandaproxy/schema_registry/rest_client/parse.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/parse.h
@@ -130,49 +130,36 @@ ss::future<std::expected<chunked_vector<subject_version>, parse_error>>
 parse_schema_id_subject_versions(
   iobuf body, qualified_subjects_enabled qualified);
 
-/// The outcome of parsing a get-schema-by-version response: the schema, plus
-/// the names of any top-level response fields the parser did not model.
-///
-/// parse_subject_version is deliberately lenient — it never rejects a response
-/// merely for carrying fields it doesn't model; it skips them and records their
-/// names here. This lets a caller that needs fidelity (e.g. schema migration)
-/// apply its own policy — reject, warn, or ignore — while a caller that doesn't
-/// care simply disregards the list. Recorded names are top-level keys, with one
-/// exception: `metadata` is only partially modeled (just `metadata.properties`
-/// is captured), so an unmodeled key directly under it is reported with a
-/// `metadata.` prefix (e.g. `metadata.tags`). An unmodeled key nested inside
-/// any other modeled field (e.g. within a reference) is skipped without being
-/// reported. It is therefore a best-effort signal that content was dropped, not
-/// a proof of a lossless round-trip.
-struct parsed_schema {
-    stored_schema schema;
-    chunked_vector<ss::sstring> unknown_fields;
-};
-
 /// Parse the body of a `GET /subjects/{subject}/versions/{version}` response
-/// into a parsed_schema (the schema plus the names of any unmodeled top-level
-/// fields).
+/// into a source_schema_read: the schema projected into Redpanda's supported
+/// model, plus a sidecar list of unsupported fields it could not store.
 ///
-/// This is a faithful, lenient deserialization (the lowest layer): unknown or
-/// not-yet-modeled fields (`guid`, `ts`, `ruleSet`, `schemaTags`, ...) are
-/// skipped — their names are collected in parsed_schema::unknown_fields for the
-/// caller to act on. `metadata` is partially modeled: `metadata.properties` is
-/// captured into the schema's metadata (values are stringified, matching the
-/// write path), while any other key under `metadata` (e.g. `metadata.tags`) is
-/// reported in unknown_fields under a `metadata.` prefix. Absent fields take
-/// their default/sentinel (absent `schemaType` -> AVRO, `deleted` -> false,
-/// `references` -> empty, `metadata` -> absent, and absent
-/// `subject`/`version`/`id`/`schema` -> the invalid sentinels). It does NOT
-/// enforce completeness or reject for unmodeled fields — whether an incomplete
-/// or lossy response is acceptable (a strict mode) is a higher-layer concern.
-/// It rejects only inputs it cannot represent: a non-object body, malformed
-/// JSON, a present modeled field with a wrong-typed or out-of-range value, or
-/// an unknown `schemaType`.
+/// This is a faithful, lenient deserialization (the lowest layer): it never
+/// rejects a response merely for carrying fields it doesn't model. Server-
+/// assigned fields that carry no user content (`guid`, `ts`) are dropped
+/// silently. Any other unmodeled field is surfaced in
+/// source_schema_read::unsupported as a JSON pointer (e.g. `/ruleSet`), for a
+/// caller that needs fidelity (e.g. schema migration) to apply its policy —
+/// fail, remove, or ignore. `metadata` is partially modeled:
+/// `metadata.properties` is captured into the schema's metadata (values are
+/// stringified, matching the write path), while any other key under `metadata`
+/// (e.g. `metadata.tags`) is reported as `/metadata/<key>`. A field whose value
+/// is null is treated as absent (not reported). An unmodeled key nested inside
+/// another modeled field (e.g. within a reference) is skipped without being
+/// reported — so `unsupported` is a best-effort signal that content was
+/// dropped, not a proof of a lossless round-trip.
+///
+/// Absent fields take their default/sentinel (absent `schemaType` -> AVRO,
+/// `deleted` -> false, `references` -> empty, `metadata` -> absent, and absent
+/// `subject`/`version`/`id`/`schema` -> the invalid sentinels). It rejects only
+/// inputs it cannot represent: a non-object body, malformed JSON, a present
+/// modeled field with a wrong-typed or out-of-range value, or an unknown
+/// `schemaType`.
 ///
 /// \p qualified is the caller-supplied policy for interpreting
 /// context-qualified subject strings (the response `subject` and each
 /// reference's `subject`). The function does not throw.
-ss::future<std::expected<parsed_schema, parse_error>>
+ss::future<std::expected<source_schema_read, parse_error>>
 parse_subject_version(iobuf body, qualified_subjects_enabled qualified);
 
 /// The structured error body Schema Registry returns on failures:

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_integration_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_integration_test.cc
@@ -294,7 +294,7 @@ FIXTURE_TEST(sr_rest_client_integration, pandaproxy_test_fixture) {
           = sut.get_schema_by_version(multi, pps::schema_version{2}, rtc).get();
         BOOST_REQUIRE(res.has_value());
         // Redpanda's SR emits only fields we model, so nothing is dropped.
-        BOOST_REQUIRE(res->unknown_fields.empty());
+        BOOST_REQUIRE(res->unsupported.empty());
         const auto& s = res->schema;
         BOOST_REQUIRE_EQUAL(s.schema.sub(), multi);
         BOOST_REQUIRE_EQUAL(s.version, pps::schema_version{2});
@@ -310,8 +310,8 @@ FIXTURE_TEST(sr_rest_client_integration, pandaproxy_test_fixture) {
               .get();
         BOOST_REQUIRE(res.has_value());
         // metadata.properties is modeled, so it parses back in full and nothing
-        // is reported as unknown.
-        BOOST_REQUIRE(res->unknown_fields.empty());
+        // is reported as unsupported.
+        BOOST_REQUIRE(res->unsupported.empty());
         const auto& def = res->schema.schema.def();
         BOOST_REQUIRE(def.meta().has_value());
         BOOST_REQUIRE(def.meta()->properties.has_value());

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
@@ -1585,7 +1585,7 @@ TEST(rest_client, get_schema_by_version_success) {
     client.shutdown().get();
 
     ASSERT_TRUE(res.has_value());
-    EXPECT_TRUE(res->unknown_fields.empty());
+    EXPECT_TRUE(res->unsupported.empty());
     const auto& s = res->schema;
     EXPECT_EQ(s.schema.sub(), subject);
     EXPECT_EQ(s.version, pps::schema_version{3});

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/client_test.cc
@@ -1592,6 +1592,42 @@ TEST(rest_client, get_schema_by_version_success) {
     EXPECT_EQ(s.id, pps::schema_id{100001});
 }
 
+TEST(rest_client, get_schema_by_version_opts_into_and_ignores_extended_fields) {
+    // The client sends Confluent-Accept-Unknown-Properties so the extended
+    // fields (guid, ts, deleted) are returned; guid/ts are on the ignorable
+    // list and deleted is modeled, so only a real feature (ruleSet) surfaces.
+    constexpr std::string_view body
+      = R"({"subject":"User","version":1,"id":2,"schema":"x",)"
+        R"("guid":"abc","ts":1715000000000,"deleted":false,)"
+        R"("ruleSet":{"domainRules":[{"name":"r"}]}})";
+    rc::client client{
+      make_http_client([body](mock_client& m) {
+          EXPECT_CALL(m, request_and_collect_response(_, _, _))
+            .WillOnce([body](
+                        bh::request_header<>&& r,
+                        std::optional<iobuf>,
+                        ss::lowres_clock::duration) {
+                EXPECT_EQ(r.at("Confluent-Accept-Unknown-Properties"), "true");
+                return ss::make_ready_future<http::downloaded_response>(
+                  http::downloaded_response{
+                    .status = bh::status::ok, .body = iobuf::from(body)});
+            });
+      }),
+      endpoint};
+
+    auto subject = pps::context_subject::unqualified("User");
+    ss::abort_source as;
+    retry_chain_node rtc(as, 5s, 100ms);
+    auto res = client
+                 .get_schema_by_version(subject, pps::schema_version{1}, rtc)
+                 .get();
+    client.shutdown().get();
+
+    ASSERT_TRUE(res.has_value());
+    ASSERT_EQ(res->unsupported.size(), size_t{1});
+    EXPECT_EQ(res->unsupported[0].json_pointer, "/ruleSet");
+}
+
 TEST(rest_client, get_schema_by_version_deleted_adds_query_param) {
     constexpr std::string_view body
       = R"({"subject":"User","version":3,"id":100001,"schemaType":"AVRO",)"

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/parse_test.cc
@@ -940,7 +940,7 @@ TEST_CORO(parse_subject_version_test, minimal_avro_defaults) {
         R"("schema":"{\"type\":\"string\"}"})"),
       qualified_subjects_enabled::yes);
     ASSERT_TRUE_CORO(res.has_value());
-    ASSERT_TRUE_CORO(res.value().unknown_fields.empty());
+    ASSERT_TRUE_CORO(res.value().unsupported.empty());
     const auto& s = res.value().schema;
     ASSERT_EQ_CORO(
       s.schema.sub(), (context_subject{default_context, subject{"User"}}));
@@ -982,7 +982,7 @@ TEST_CORO(parse_subject_version_test, full_object_maps_all_fields) {
         R"("schema":"{\"type\":\"record\"}","deleted":true})"),
       qualified_subjects_enabled::yes);
     ASSERT_TRUE_CORO(res.has_value());
-    ASSERT_TRUE_CORO(res.value().unknown_fields.empty());
+    ASSERT_TRUE_CORO(res.value().unsupported.empty());
     const auto& s = res.value().schema;
     ASSERT_EQ_CORO(
       s.schema.sub(), (context_subject{context{".ctx"}, subject{"MyRecord"}}));
@@ -1023,13 +1023,14 @@ TEST_CORO(parse_subject_version_test, reference_subject_honors_policy) {
       (context_subject{default_context, subject{":.ctx:Sub"}}));
 }
 
-TEST_CORO(parse_subject_version_test, records_unmodeled_fields) {
-    // guid/ts/ruleSet/schemaTags (and a future field) are not mapped into the
-    // schema, but their top-level names are recorded so the caller can decide
-    // whether dropping them is acceptable. A nested object/array under such a
-    // field is skipped without descending into it. metadata is special: its
-    // modeled `properties` is captured, while an unmodeled sub-key
-    // (`sensitive`) is reported under a `metadata.` prefix.
+TEST_CORO(parse_subject_version_test, surfaces_unsupported_fields) {
+    // ruleSet/schemaTags (and a future field) are not mapped into the schema;
+    // they are surfaced in `unsupported` as JSON pointers so the caller can
+    // apply its policy. A nested object/array under such a field is skipped
+    // without descending into it. metadata is special: its modeled `properties`
+    // is captured, while an unmodeled sub-key (`sensitive`) is reported as
+    // `/metadata/sensitive`. The server-assigned `guid`/`ts` are ignorable and
+    // dropped silently (not surfaced).
     auto res = co_await parse_subject_version(
       iobuf::from(
         R"({"guid":"abc","ts":1715000000000,"subject":"User","version":1,)"
@@ -1050,17 +1051,31 @@ TEST_CORO(parse_subject_version_test, records_unmodeled_fields) {
     const auto& props = *s.schema.def().meta()->properties;
     ASSERT_EQ_CORO(props.size(), size_t{1});
     ASSERT_EQ_CORO(props.at("owner"), "team-a");
-    // The unmodeled keys are reported, in encounter order; modeled nested keys
-    // (metadata.properties, ruleSet.domainRules, ...) are not. metadata's
-    // unmodeled `sensitive` sub-key is reported under a `metadata.` prefix.
-    const auto& unknown = res.value().unknown_fields;
-    ASSERT_EQ_CORO(unknown.size(), size_t{6});
-    ASSERT_EQ_CORO(unknown[0], "guid");
-    ASSERT_EQ_CORO(unknown[1], "ts");
-    ASSERT_EQ_CORO(unknown[2], "ruleSet");
-    ASSERT_EQ_CORO(unknown[3], "metadata.sensitive");
-    ASSERT_EQ_CORO(unknown[4], "schemaTags");
-    ASSERT_EQ_CORO(unknown[5], "futureField");
+    // Unsupported fields are surfaced as JSON pointers, in encounter order.
+    // guid/ts are ignorable (dropped); modeled nested keys
+    // (metadata.properties, ruleSet.domainRules, ...) are not reported.
+    const auto& unsupported = res.value().unsupported;
+    ASSERT_EQ_CORO(unsupported.size(), size_t{4});
+    ASSERT_EQ_CORO(unsupported[0].json_pointer, "/ruleSet");
+    ASSERT_EQ_CORO(unsupported[0].json_type, "object");
+    ASSERT_EQ_CORO(unsupported[1].json_pointer, "/metadata/sensitive");
+    ASSERT_EQ_CORO(unsupported[1].json_type, "array");
+    ASSERT_EQ_CORO(unsupported[2].json_pointer, "/schemaTags");
+    ASSERT_EQ_CORO(unsupported[2].json_type, "array");
+    ASSERT_EQ_CORO(unsupported[3].json_pointer, "/futureField");
+    ASSERT_EQ_CORO(unsupported[3].json_type, "array");
+}
+
+TEST_CORO(parse_subject_version_test, ignorable_and_null_unmodeled_fields) {
+    // Server-assigned guid/ts are ignorable, and a null-valued unmodeled field
+    // is treated as absent; none are surfaced.
+    auto res = co_await parse_subject_version(
+      iobuf::from(
+        R"({"subject":"r","version":1,"id":2,"schema":"x",)"
+        R"("guid":"g","ts":1,"ruleSet":null})"),
+      qualified_subjects_enabled::yes);
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_TRUE_CORO(res.value().unsupported.empty());
 }
 
 TEST_CORO(parse_subject_version_test, metadata_properties_coercion) {
@@ -1074,7 +1089,7 @@ TEST_CORO(parse_subject_version_test, metadata_properties_coercion) {
         R"("enabled":true,"hidden":false}}})"),
       qualified_subjects_enabled::yes);
     ASSERT_TRUE_CORO(res.has_value());
-    ASSERT_TRUE_CORO(res.value().unknown_fields.empty());
+    ASSERT_TRUE_CORO(res.value().unsupported.empty());
     const auto& meta = res.value().schema.schema.def().meta();
     ASSERT_TRUE_CORO(meta.has_value());
     ASSERT_TRUE_CORO(meta->properties.has_value());
@@ -1099,10 +1114,12 @@ TEST_CORO(parse_subject_version_test, metadata_present_without_properties) {
     const auto& meta = res.value().schema.schema.def().meta();
     ASSERT_TRUE_CORO(meta.has_value());
     ASSERT_FALSE_CORO(meta->properties.has_value());
-    const auto& unknown = res.value().unknown_fields;
-    ASSERT_EQ_CORO(unknown.size(), size_t{2});
-    ASSERT_EQ_CORO(unknown[0], "metadata.tags");
-    ASSERT_EQ_CORO(unknown[1], "metadata.sensitive");
+    const auto& unsupported = res.value().unsupported;
+    ASSERT_EQ_CORO(unsupported.size(), size_t{2});
+    ASSERT_EQ_CORO(unsupported[0].json_pointer, "/metadata/tags");
+    ASSERT_EQ_CORO(unsupported[0].json_type, "object");
+    ASSERT_EQ_CORO(unsupported[1].json_pointer, "/metadata/sensitive");
+    ASSERT_EQ_CORO(unsupported[1].json_type, "array");
 }
 
 TEST_CORO(parse_subject_version_test, metadata_empty_and_null) {
@@ -1111,14 +1128,14 @@ TEST_CORO(parse_subject_version_test, metadata_empty_and_null) {
       iobuf::from(R"({"subject":"r","version":1,"id":2,"metadata":{}})"),
       qualified_subjects_enabled::yes);
     ASSERT_TRUE_CORO(empty_obj.has_value());
-    ASSERT_TRUE_CORO(empty_obj.value().unknown_fields.empty());
+    ASSERT_TRUE_CORO(empty_obj.value().unsupported.empty());
     ASSERT_TRUE_CORO(empty_obj.value().schema.schema.def().meta().has_value());
 
     auto null_meta = co_await parse_subject_version(
       iobuf::from(R"({"subject":"r","version":1,"id":2,"metadata":null})"),
       qualified_subjects_enabled::yes);
     ASSERT_TRUE_CORO(null_meta.has_value());
-    ASSERT_TRUE_CORO(null_meta.value().unknown_fields.empty());
+    ASSERT_TRUE_CORO(null_meta.value().unsupported.empty());
     ASSERT_FALSE_CORO(null_meta.value().schema.schema.def().meta().has_value());
 
     // metadata.properties: null leaves properties absent (metadata present).
@@ -1271,7 +1288,7 @@ TEST_CORO(parse_error_body_test, trailing_content_is_nullopt) {
 
 TEST_CORO(parse_subject_version_test, reference_unknown_keys_skipped) {
     // A reference may carry keys the client does not model; they are skipped
-    // (never rejected, never recorded in unknown_fields) and the modeled
+    // (never rejected, never surfaced in `unsupported`) and the modeled
     // name/subject/version are still recovered.
     auto res = co_await parse_subject_version(
       iobuf::from(
@@ -1279,7 +1296,7 @@ TEST_CORO(parse_subject_version_test, reference_unknown_keys_skipped) {
         R"([{"extra":{"nested":true},"name":"n","subject":"s","version":2}]})"),
       qualified_subjects_enabled::yes);
     ASSERT_TRUE_CORO(res.has_value());
-    ASSERT_TRUE_CORO(res->unknown_fields.empty());
+    ASSERT_TRUE_CORO(res->unsupported.empty());
     const auto& refs = res->schema.schema.def().refs();
     ASSERT_EQ_CORO(refs.size(), size_t{1});
     ASSERT_EQ_CORO(refs[0].name, "n");

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -749,6 +749,33 @@ struct stored_schema {
     context_schema_id context_id() const { return {schema.sub().ctx, id}; }
 };
 
+/// \brief A field in a source Schema Registry response that Redpanda does not
+/// model and therefore cannot store (e.g. a rule set or metadata tags).
+///
+/// Surfaced as a sidecar diagnostic alongside the parsed schema so a migration
+/// task can apply its configured unsupported-feature policy and log what was
+/// dropped. Identified by a JSON pointer into the response (e.g. "/ruleSet" or
+/// "/metadata/tags").
+struct unsupported_feature {
+    ss::sstring json_pointer;
+    ss::sstring json_type;
+
+    friend bool operator==(
+      const unsupported_feature&, const unsupported_feature&) = default;
+
+    fmt::iterator format_to(fmt::iterator out) const {
+        return fmt::format_to(out, "{} ({})", json_pointer, json_type);
+    }
+};
+
+/// \brief The outcome of reading one schema from a source Schema Registry: the
+/// schema projected into Redpanda's supported model, plus any unsupported
+/// fields that were seen but not stored.
+struct source_schema_read {
+    stored_schema schema;
+    chunked_vector<unsupported_feature> unsupported;
+};
+
 ///\brief A mapping of version and schema id for a subject.
 struct subject_version_entry {
     subject_version_entry(


### PR DESCRIPTION
Implements the `unsupported_schema_feature_policy` config (FAIL default /
REMOVE) for API-mode Schema Registry shadowing, so a migration from a
Confluent-compatible source handles schema features Redpanda cannot store (rule
sets, schema tags, `metadata.tags`). The tolerant SR client now returns a
structured `source_schema_read { schema, unsupported[] }` — each
`unsupported_feature` carrying a JSON pointer (`/ruleSet`, `/metadata/tags`) and
JSON type — which the source reader carries through to the reconciler, which
applies the configured policy at the single per-node import point. The client
opts into extended source fields via the `Confluent-Accept-Unknown-Properties`
header, and a small allow-list of server-assigned fields (`guid`, `ts`) is
dropped silently.

REMOVE imports only the supported projection, increments
`unsupported_features_removed` (surfaced in `rpk shadow status` and totals), and
logs the stripped fields to the broker log. FAIL (the default) treats an
unsupported schema as a per-item failure: it logs the offending fields, counts
an error, and skips that schema while the rest of the subjects still replicate;
the task stays active, and only global errors (source unavailable) fail-fast.

Note: FAIL deliberately deviates from the RFC, which describes it as aborting /
faulting the whole sync. Per-item handling collects all per-item errors rather
than stopping on the first offender and keeps replicating whatever the
destination can store — more useful for a migration. The offending
subject/version and which fields tripped the policy are written to the broker
log (logger `shadow_link`). Happy to revisit if reviewers prefer whole-sync
abort semantics.

Note: this covers the schema-fetch path only — the policy acts on per-schema
`metadata`/`ruleSet` (`source_schema_read::unsupported`). Config-borne
governance features (`compatibilityGroup`, default/override metadata & rule sets
on `GET /config`) are out of scope: config sync replicates only
`compatibilityLevel` and records the rest as dropped `unknown_fields`. No
proto/model/converter/rpk changes: the config contract, the counter, and `rpk
shadow status` rendering already exist.

Tests: reconciler and mirroring-task unit/integration tests cover REMOVE (strip
+ count; no count on a failed import) and FAIL (count + skip the offender, sync
the rest, task stays active), plus diagnostics parsing (surfaced fields, ignored
`guid`/`ts`, `Confluent-Accept-Unknown-Properties` opt-in).

Note: e2e tests will be postponed and implemented once: https://redpandadata.atlassian.net/browse/CORE-16776 is delivered. Besides unit tests PR has been tested manually.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
-->

* none
