### PR TITLE
ct/l1/metastore: harden STM lifetime for consensus and sync()

### DIFF
--- a/src/v/cloud_topics/level_one/domain/BUILD
+++ b/src/v/cloud_topics/level_one/domain/BUILD
@@ -143,6 +143,7 @@ redpanda_cc_library(
         "//src/v/container:chunked_hash_map",
         "//src/v/container:chunked_vector",
         "//src/v/model",
+        "//src/v/raft",
         "//src/v/ssx:checkpoint_mutex",
         "@abseil-cpp//absl/container:btree",
         "@seastar",

--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -240,6 +240,7 @@ db_domain_manager::entity_locks::acquire_objects(
 db_domain_manager::db_domain_manager(
   model::term_id expected_term,
   ss::shared_ptr<stm> stm,
+  ss::lw_shared_ptr<raft::consensus> raft,
   cloud_io::cache* cache,
   cloud_io::remote* remote,
   cloud_storage_clients::bucket_name bucket,
@@ -253,6 +254,7 @@ db_domain_manager::db_domain_manager(
   , object_io_(object_io)
   , sg_(sg)
   , stm_(std::move(stm))
+  , raft_(std::move(raft))
   , gc_interval_(
       config::shard_local_cfg()
         .cloud_topics_long_term_garbage_collection_interval)
@@ -1743,7 +1745,7 @@ db_domain_manager::write_rows_no_lock(chunked_vector<write_batch_row> rows) {
     }
     if (needs_step_down) {
         auto step_down_fut = co_await ss::coroutine::as_future(
-          stm_->raft()->step_down_in_term(
+          raft_->step_down_in_term(
             expected_term_, "Failed to write to database"));
         if (step_down_fut.failed()) {
             // Only throws at shutdown.
@@ -1760,7 +1762,7 @@ ss::future<std::expected<void, rpc::errc>> db_domain_manager::maybe_open_db() {
     if (db_ && !db_->needs_reopen()) {
         co_return std::expected<void, rpc::errc>{};
     }
-    auto cur_term = stm_->raft()->term();
+    auto cur_term = raft_->term();
     if (cur_term != expected_term_) {
         vlog(
           cd_log.debug,
@@ -1790,7 +1792,7 @@ ss::future<std::expected<void, rpc::errc>> db_domain_manager::maybe_open_db() {
     vlog(
       cd_log.debug, "Opening database with expected term {}", expected_term_);
     auto db_res = co_await replicated_database::open(
-      expected_term_, stm_.get(), cache_, remote_, bucket_, as_, sg_);
+      expected_term_, stm_.get(), raft_, cache_, remote_, bucket_, as_, sg_);
     if (!db_res.has_value()) {
         co_return std::unexpected(
           log_and_convert(db_res.error(), "Failed to open database: "));
@@ -1805,7 +1807,7 @@ ss::future<> db_domain_manager::gc_loop() {
         co_return;
     }
 
-    auto ntp = stm_->raft()->log()->config().ntp();
+    auto ntp = raft_->log()->config().ntp();
     db_garbage_collector gc(object_io_, probe_);
     while (!as_.abort_requested()) {
         // NOTE: even though the garbage collector will remove objects and
@@ -1974,7 +1976,7 @@ db_domain_manager::restore_domain(rpc::restore_domain_request req) {
       "Re-opening database with expected term {}",
       expected_term_);
     auto db_res = co_await replicated_database::open(
-      expected_term_, stm_.get(), cache_, remote_, bucket_, as_, sg_);
+      expected_term_, stm_.get(), raft_, cache_, remote_, bucket_, as_, sg_);
     if (!db_res.has_value()) {
         co_return rpc::restore_domain_reply{
           .ec = log_and_convert(db_res.error(), "Failed to reopen database: "),

--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.h
@@ -19,6 +19,7 @@
 #include "cloud_topics/level_one/metastore/lsm/stm.h"
 #include "model/fundamental.h"
 #include "model/timestamp.h"
+#include "raft/consensus.h"
 #include "ssx/checkpoint_mutex.h"
 
 #include <seastar/core/abort_source.hh>
@@ -37,6 +38,7 @@ public:
     explicit db_domain_manager(
       model::term_id expected_term,
       ss::shared_ptr<stm> stm,
+      ss::lw_shared_ptr<raft::consensus> raft,
       cloud_io::cache* cache,
       cloud_io::remote* remote,
       cloud_storage_clients::bucket_name bucket,
@@ -244,6 +246,11 @@ private:
     ss::scheduling_group sg_;
 
     ss::shared_ptr<stm> stm_;
+
+    // Consensus for the partition backing the STM. Held to keep it alive for
+    // the lifetime of this manager and to observe leadership/term without
+    // reaching through the STM, which does not own the consensus.
+    ss::lw_shared_ptr<raft::consensus> raft_;
 
     // Hold in write mode when changing the db instance.
     // Hold in read mode for other access to the db that doesn't reopen the db.

--- a/src/v/cloud_topics/level_one/domain/domain_supervisor.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_supervisor.cc
@@ -331,6 +331,7 @@ private:
             domain_mgr = ss::make_shared<db_domain_manager>(
               *expected_term,
               stm_manager->get<stm>(),
+              (*partition)->raft(),
               _cache,
               _remote,
               _bucket,

--- a/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
+++ b/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
@@ -55,11 +55,13 @@ ss::future<> random_sleep_ms(int max_ms) {
 struct domain_manager_node {
     domain_manager_node(
       ss::shared_ptr<stm> s,
+      ss::lw_shared_ptr<raft::consensus> raft,
       cloud_io::remote* remote,
       const cloud_storage_clients::bucket_name& bucket,
       cloud_io::cache* cache,
       const ss::sstring& staging_path)
       : stm_ptr(std::move(s))
+      , raft(std::move(raft))
       , remote(remote)
       , bucket(bucket)
       , cache(cache)
@@ -74,8 +76,9 @@ struct domain_manager_node {
     // retained in the list too, to validate that their usage fails.
     db_domain_manager* open_manager(bool start_gc) {
         auto mgr = std::make_unique<db_domain_manager>(
-          stm_ptr->raft()->confirmed_term(),
+          raft->confirmed_term(),
           stm_ptr,
+          raft,
           cache,
           remote,
           bucket,
@@ -118,6 +121,7 @@ struct domain_manager_node {
     }
 
     ss::shared_ptr<stm> stm_ptr;
+    ss::lw_shared_ptr<raft::consensus> raft;
     cloud_io::remote* remote;
     const cloud_storage_clients::bucket_name& bucket;
     cloud_io::cache* cache;
@@ -366,6 +370,7 @@ public:
             auto staging_path = fmt::format("db_domain_manager_test_{}", id());
             dm_nodes.at(id()) = std::make_unique<domain_manager_node>(
               std::move(s),
+              node->raft(),
               &sr->remote.local(),
               bucket_name,
               &test_cache.local(),
@@ -386,6 +391,10 @@ public:
                 } catch (...) {
                     // Ignore errors during teardown.
                 }
+                // Drop the node (and its consensus reference) before tearing
+                // down the raft fixture, so the fixture destroys the consensus
+                // and closes its log while storage services are still up.
+                node.reset();
             }
         }
         raft::raft_fixture::TearDownAsync().get();
@@ -402,7 +411,7 @@ public:
             return std::nullopt;
         }
         auto& node = *dm_nodes.at(leader_id.value()());
-        if (!node.stm_ptr->raft()->is_leader()) {
+        if (!node.raft->is_leader()) {
             return std::nullopt;
         }
         return node;
@@ -707,7 +716,7 @@ TEST_P(DbDomainManagerTestWithParams, TestConcurrentUpdates) {
     for (int i = 0; i < 10; ++i) {
         opt_ref leader_opt;
         ASSERT_NO_FATAL_FAILURE(wait_for_leader(leader_opt).get());
-        auto raft = leader_opt->get().stm_ptr->raft();
+        auto raft = leader_opt->get().raft;
         auto start_term = raft->confirmed_term();
 
         // Allow for some progress in the current term.
@@ -718,7 +727,7 @@ TEST_P(DbDomainManagerTestWithParams, TestConcurrentUpdates) {
         }
 
         // Step down and create a domain manager for the new leader.
-        leader_opt->get().stm_ptr->raft()->step_down("test stepdown").get();
+        leader_opt->get().raft->step_down("test stepdown").get();
         ASSERT_NO_FATAL_FAILURE(wait_for_leader(leader_opt).get());
         auto& leader_node = leader_opt->get();
         leader_node.open_manager(/*start_gc=*/true);
@@ -758,10 +767,10 @@ TEST_P(DbDomainManagerTestWithParams, TestUpdatesWithDroppedAppends) {
     for (int i = 0; i < 3; ++i) {
         opt_ref leader_opt;
         ASSERT_NO_FATAL_FAILURE(wait_for_leader(leader_opt).get());
-        auto raft = leader_opt->get().stm_ptr->raft();
+        auto raft = leader_opt->get().raft;
         auto start_term = raft->confirmed_term();
         auto starting_next = expected_add_next;
-        auto leader_id = leader_opt->get().stm_ptr->raft()->self();
+        auto leader_id = leader_opt->get().raft->self();
         auto& leader = node(leader_id.id());
 
         // Wait for there to make progress before mucking with appends.

--- a/src/v/cloud_topics/level_one/metastore/lsm/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/lsm/BUILD
@@ -244,6 +244,7 @@ redpanda_cc_library(
         "//src/v/lsm/io:persistence",
         "//src/v/lsm/proto:manifest_redpanda_proto",
         "//src/v/model",
+        "//src/v/raft",
         "//src/v/ssx:future_util",
         "//src/v/utils:detailed_error",
         "@seastar",

--- a/src/v/cloud_topics/level_one/metastore/lsm/replicated_db.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/replicated_db.cc
@@ -56,6 +56,7 @@ ss::future<std::expected<
 replicated_database::open(
   model::term_id expected_term,
   stm* s,
+  ss::lw_shared_ptr<raft::consensus> raft,
   cloud_io::cache* cache,
   cloud_io::remote* remote,
   const cloud_storage_clients::bucket_name& bucket,
@@ -201,8 +202,8 @@ replicated_database::open(
             }
         }
     }
-    auto ret = std::unique_ptr<replicated_database>(
-      new replicated_database(term, domain_uuid, s, std::move(db), as, sg));
+    auto ret = std::unique_ptr<replicated_database>(new replicated_database(
+      term, domain_uuid, s, std::move(raft), std::move(db), as, sg));
     ret->start();
     co_return std::move(ret);
 }
@@ -228,7 +229,7 @@ replicated_database::close() {
 }
 
 bool replicated_database::needs_reopen() const {
-    return !stm_->raft()->is_leader() || term_ != stm_->raft()->confirmed_term()
+    return !raft_->is_leader() || term_ != raft_->confirmed_term()
            || get_domain_uuid() != expected_domain_uuid_;
 }
 

--- a/src/v/cloud_topics/level_one/metastore/lsm/replicated_db.h
+++ b/src/v/cloud_topics/level_one/metastore/lsm/replicated_db.h
@@ -19,6 +19,7 @@
 #include "lsm/lsm.h"
 #include "lsm/proto/manifest.proto.h"
 #include "model/fundamental.h"
+#include "raft/consensus.h"
 #include "utils/detailed_error.h"
 
 #include <seastar/core/scheduling.hh>
@@ -63,6 +64,7 @@ public:
     open(
       model::term_id expected_term,
       stm* s,
+      ss::lw_shared_ptr<raft::consensus> raft,
       cloud_io::cache* cache,
       cloud_io::remote* remote,
       const cloud_storage_clients::bucket_name& bucket,
@@ -102,12 +104,14 @@ private:
       model::term_id term,
       domain_uuid domain_uuid,
       stm* s,
+      ss::lw_shared_ptr<raft::consensus> raft,
       lsm::database db,
       ss::abort_source& as,
       ss::scheduling_group sg)
       : term_(term)
       , expected_domain_uuid_(domain_uuid)
       , stm_(s)
+      , raft_(std::move(raft))
       , db_(std::move(db))
       , as_(as)
       , sg_(sg) {}
@@ -133,6 +137,11 @@ private:
 
     // STM for replication and state access.
     stm* stm_;
+
+    // Consensus for this partition. Held to keep it alive for the lifetime of
+    // this database and to observe leadership/term without reaching through the
+    // STM, which does not own the consensus.
+    ss::lw_shared_ptr<raft::consensus> raft_;
 
     // The underlying LSM database.
     lsm::database db_;

--- a/src/v/cloud_topics/level_one/metastore/lsm/stm.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/stm.cc
@@ -61,6 +61,11 @@ stm::stm(
 ss::future<std::expected<model::term_id, stm::errc>> stm::sync(
   model::timeout_clock::duration timeout,
   std::optional<std::reference_wrapper<ss::abort_source>> as) {
+    auto gh = _gate.try_hold();
+    if (!gh) {
+        co_return std::unexpected(errc::shutting_down);
+    }
+
     auto sync_res = co_await ss::coroutine::as_future(
       metastore_stm_base::sync(timeout, as));
     if (sync_res.failed()) {

--- a/src/v/cloud_topics/level_one/metastore/lsm/stm.h
+++ b/src/v/cloud_topics/level_one/metastore/lsm/stm.h
@@ -34,7 +34,6 @@ public:
 
     explicit stm(
       ss::logger&, raft::consensus*, config::binding<std::chrono::seconds>);
-    raft::consensus* raft() { return _raft; }
 
     // Syncs the STM such that we're guaranteed that it has applied all records
     // from the previous terms. Calling does _not_ ensure that all records from

--- a/src/v/cloud_topics/level_one/metastore/lsm/tests/replicated_db_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/tests/replicated_db_test.cc
@@ -65,10 +65,12 @@ ss::future<chunked_vector<write_batch_row>> get_rows(lsm::database& db) {
 struct replicated_db_node {
     replicated_db_node(
       ss::shared_ptr<stm> s,
+      ss::lw_shared_ptr<raft::consensus> raft,
       cloud_io::remote* remote,
       const cloud_storage_clients::bucket_name& bucket,
       cloud_io::cache* cache)
       : stm_ptr(std::move(s))
+      , raft(std::move(raft))
       , remote(remote)
       , bucket(bucket)
       , cache(cache) {}
@@ -76,8 +78,9 @@ struct replicated_db_node {
     ss::future<std::expected<replicated_database*, replicated_database::error>>
     open_db() {
         auto ret = co_await replicated_database::open(
-          stm_ptr->raft()->confirmed_term(),
+          raft->confirmed_term(),
           stm_ptr.get(),
+          raft,
           cache,
           remote,
           bucket,
@@ -98,12 +101,13 @@ struct replicated_db_node {
                 vlog(
                   rdb_test_log.warn,
                   "Failed to close DB for node {}",
-                  stm_ptr->raft()->self());
+                  raft->self());
             }
         }
     }
 
     ss::shared_ptr<stm> stm_ptr;
+    ss::lw_shared_ptr<raft::consensus> raft;
     cloud_io::remote* remote;
     const cloud_storage_clients::bucket_name& bucket;
     cloud_io::cache* cache;
@@ -176,6 +180,7 @@ public:
 
             db_nodes.at(id()) = std::make_unique<replicated_db_node>(
               std::move(s),
+              node->raft(),
               &sr->remote.local(),
               bucket_name,
               &test_cache.local());
@@ -193,6 +198,10 @@ public:
         for (auto& node : db_nodes) {
             if (node) {
                 node->close().get();
+                // Drop the node (and its consensus reference) before tearing
+                // down the raft fixture, so the fixture destroys the consensus
+                // and closes its log while storage services are still up.
+                node.reset();
             }
         }
         raft::raft_fixture::TearDownAsync().get();
@@ -209,7 +218,7 @@ public:
             return std::nullopt;
         }
         auto& node = *db_nodes.at(leader_id.value()());
-        if (!node.stm_ptr->raft()->is_leader()) {
+        if (!node.raft->is_leader()) {
             return std::nullopt;
         }
         return node;
@@ -326,7 +335,7 @@ TEST_F(ReplicatedDatabaseTest, TestBasicWrites) {
       ElementsAre(MatchesKV("key1", "value1")));
 
     // Elect a new leader.
-    initial_leader->stm_ptr->raft()->step_down("test").get();
+    initial_leader->raft->step_down("test").get();
     opt_ref leader_opt;
     ASSERT_NO_FATAL_FAILURE(wait_for_leader(leader_opt).get());
     auto& new_leader = leader_opt->get();
@@ -417,7 +426,7 @@ TEST_F(ReplicatedDatabaseTest, TestBasicFlush) {
     }
 
     // Opening the database on a new leader should yield all the rows.
-    initial_leader->stm_ptr->raft()->step_down("test").get();
+    initial_leader->raft->step_down("test").get();
     opt_ref leader_opt;
     ASSERT_NO_FATAL_FAILURE(wait_for_leader(leader_opt).get());
     auto& new_leader = leader_opt->get();
@@ -512,7 +521,7 @@ TEST_F(ReplicatedDatabaseTest, TestFlushFailure) {
       ElementsAre(MatchesKV("key1", "value1")));
 
     // Step down as leader of the given term.
-    initial_leader->stm_ptr->raft()->step_down("test").get();
+    initial_leader->raft->step_down("test").get();
     opt_ref leader_opt;
     ASSERT_NO_FATAL_FAILURE(wait_for_leader(leader_opt).get());
 
@@ -680,7 +689,7 @@ TEST_F(ReplicatedDatabaseTest, TestReplayTombstones) {
 
     // Transfer leadership. The new leader will replay the tombstone from the
     // volatile buffer.
-    initial_leader->stm_ptr->raft()->step_down("test").get();
+    initial_leader->raft->step_down("test").get();
     opt_ref leader_opt;
     ASSERT_NO_FATAL_FAILURE(wait_for_leader(leader_opt).get());
     auto& new_leader = leader_opt->get();


### PR DESCRIPTION
Removes the `stm::raft()` accessor from the L1 LSM metastore STM and hardens
two externally-called STM entry points against lifetime issues.

The STM does not own the raft consensus, so handing out the raw pointer via
`raft()` let callers dereference it with no lifetime guarantee. This resolves a
use-after-free where `db_domain_manager::gc_loop` accessed the consensus's log
via `stm_->raft()->log()` after the consensus had been freed. Callers that need
the consensus now hold a `consensus_ptr` themselves (`db_domain_manager`,
`replicated_database`, and the test fixtures). Holding the consensus keeps its
log alive, so the fixtures release it before tearing down the raft fixture,
letting the log close while storage services are still up.

Separately, `stm::sync()` now holds the STM gate for its duration, as the base
`persisted_stm` contract requires of externally-called async methods; without
it, resuming after the awaited base `sync()` could touch a destroyed STM.

## Backports Required

- [x] v26.1.x

## Release Notes

### Bug Fixes

* Fixed a potential broker crash (use-after-free) in the cloud topics metastore when accessing Raft state during leadership changes.