### PR TITLE
[CORE-16776] cluster_link: test SR-sync against a Confluent source

### DIFF
--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
@@ -602,6 +602,11 @@ ss::future<task::state_transition> mirroring_task::full_source_sync(
                                     node);
         if (!dest_deleted) {
             work.upserts.push_back(node);
+            // Authoritative deleted-state from the listing partition: the
+            // reconciler imports these soft-deleted regardless of the
+            // per-version source body, which a standard source (e.g. Confluent)
+            // does not populate with a `deleted` flag by default.
+            work.soft_deleted.insert(node);
         }
     }
 

--- a/src/v/cluster_link/schema_registry_sync/reconciler.cc
+++ b/src/v/cluster_link/schema_registry_sync/reconciler.cc
@@ -136,6 +136,7 @@ ss::future<source_result<void>> reconciler::reconcile(
   reconcile_stats& stats,
   ss::abort_source& as) {
     _replicated = std::move(seed_replicated);
+    _soft_deleted = std::move(work.soft_deleted);
     _nodes.clear();
     _discover_q.clear();
     _import_q.clear();
@@ -438,6 +439,12 @@ ss::future<bool> reconciler::import_body(
     if (fail_if_contains_unsupported(n, read.unsupported)) {
         co_return false;
     }
+    // Deleted-state is authoritative from the caller's active-vs-deleted
+    // listing partition, not the per-version source body: a standard source
+    // (e.g. Confluent) omits the `deleted` flag from that body by default, so
+    // the fetched flag cannot be trusted to propagate a soft-delete.
+    read.schema.deleted = _soft_deleted.contains(n) ? ppsr::is_deleted::yes
+                                                    : ppsr::is_deleted::no;
     data(n).state = node_state::importing;
     // The graph key `n` stays in the source namespace; only the schema written
     // to the destination is remapped.

--- a/src/v/cluster_link/schema_registry_sync/reconciler.h
+++ b/src/v/cluster_link/schema_registry_sync/reconciler.h
@@ -51,8 +51,16 @@ struct reconcile_stats {
 /// version) node imported from the source with its source deleted state. The
 /// caller selects which nodes to upsert (create, reactivate, or propagate a
 /// soft-delete); the reconciler imports them in reference order.
+///
+/// `soft_deleted` names the upserts that are soft-deleted on the source, so the
+/// reconciler imports them soft-deleted regardless of the per-version source
+/// response, which cannot be relied on for deleted-state: a standard source
+/// (e.g. Confluent) omits the `deleted` flag from the per-version body by
+/// default. The caller instead derives this from its own active-vs-deleted
+/// listing partition, which is authoritative across SR vendors.
 struct work_set {
     chunked_vector<ppsr::subject_version> upserts;
+    chunked_hash_set<ppsr::subject_version> soft_deleted;
 };
 
 /// \brief Imports missing source schema versions into the destination in
@@ -222,6 +230,9 @@ private:
       _feature_policy;
 
     chunked_hash_set<ppsr::subject_version> _replicated;
+    /// Upserts the caller classified as soft-deleted on the source; imported
+    /// soft-deleted, overriding the per-version source body's deleted flag.
+    chunked_hash_set<ppsr::subject_version> _soft_deleted;
     chunked_hash_map<ppsr::subject_version, node_data> _nodes;
     chunked_vector<ppsr::subject_version> _discover_q;
     chunked_vector<ppsr::subject_version> _import_q;

--- a/src/v/cluster_link/schema_registry_sync/tests/reconciler_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/reconciler_test.cc
@@ -365,8 +365,8 @@ TEST(reconciler, seed_replicated_upsert_is_still_imported) {
 }
 
 // A soft-deleted source version imports preserving its deleted state: the
-// reconciler fetches the body (which carries the flag) and import_schema stores
-// it soft-deleted. Underpins the task syncing soft-deleted source versions
+// caller declares it in work_set.soft_deleted and import_schema stores it
+// soft-deleted. Underpins the task syncing soft-deleted source versions
 // preserving their deleted state.
 TEST(reconciler, imports_soft_deleted_as_deleted) {
     reconcile_harness h;
@@ -375,6 +375,7 @@ TEST(reconciler, imports_soft_deleted_as_deleted) {
 
     srs::work_set work;
     work.upserts.push_back(key(a, 1));
+    work.soft_deleted.insert(key(a, 1));
 
     auto stats = h.run(std::move(work)).get();
     ASSERT_TRUE(stats.has_value());
@@ -388,10 +389,11 @@ TEST(reconciler, imports_soft_deleted_as_deleted) {
 }
 
 // Soft-delete propagation onto an active destination version: re-importing the
-// source body (which now carries deleted=yes) transitions an existing active
-// version to soft-deleted. The node is in the seed (a destination version is in
-// `all`), so this also guards that a seeded upsert is still imported. Underpins
-// the task propagating a source soft-delete onto a live destination version.
+// version with the caller's declared deleted-state transitions an existing
+// active version to soft-deleted. The node is in the seed (a destination
+// version is in `all`), so this also guards that a seeded upsert is still
+// imported. Underpins the task propagating a source soft-delete onto a live
+// destination version.
 TEST(reconciler, propagates_soft_delete_over_active_destination) {
     reconcile_harness h;
     auto a = ppsr::context_subject::unqualified("a");
@@ -403,8 +405,37 @@ TEST(reconciler, propagates_soft_delete_over_active_destination) {
     seed.insert(key(a, 1));
     srs::work_set work;
     work.upserts.push_back(key(a, 1));
+    work.soft_deleted.insert(key(a, 1));
 
     auto stats = h.run(std::move(work), std::move(seed)).get();
+    ASSERT_TRUE(stats.has_value());
+    EXPECT_EQ(stats->versions_changed, 1);
+    EXPECT_EQ(stats->errors, 0);
+
+    const auto& all = h.destination.get_all();
+    auto ia = index_of(all, "a");
+    ASSERT_GE(ia, 0);
+    EXPECT_EQ(all[ia].deleted, ppsr::is_deleted::yes);
+}
+
+// The caller's declared soft-delete wins over the per-version source body: a
+// standard (e.g. Confluent) source omits the `deleted` flag from that body by
+// default, so read_subject_version reports the version active, yet declaring it
+// in work_set.soft_deleted still lands it soft-deleted on the destination.
+// Guards the cross-vendor soft-delete propagation the HTTP source reader
+// relies on.
+TEST(reconciler, caller_soft_delete_wins_over_active_source_body) {
+    reconcile_harness h;
+    auto a = ppsr::context_subject::unqualified("a");
+    // Source body reports the version ACTIVE, like a standard SR that does not
+    // echo a deleted flag.
+    h.source.add(a, 1, ppsr::is_deleted::no);
+
+    srs::work_set work;
+    work.upserts.push_back(key(a, 1));
+    work.soft_deleted.insert(key(a, 1));
+
+    auto stats = h.run(std::move(work)).get();
     ASSERT_TRUE(stats.has_value());
     EXPECT_EQ(stats->versions_changed, 1);
     EXPECT_EQ(stats->errors, 0);

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -100,6 +100,14 @@ RUN --mount=type=cache,id=dl-cache,target=/dl-cache /kafka-tools && \
 
 #################################
 
+FROM base AS confluent-schema-registry
+
+COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/confluent-schema-registry /
+RUN --mount=type=cache,id=dl-cache,target=/dl-cache /confluent-schema-registry && \
+    rm /confluent-schema-registry
+
+#################################
+
 FROM java-base AS base-with-tools
 
 COPY --chmod=0755 tests/docker/ducktape-deps/tool-pkgs /
@@ -444,6 +452,7 @@ COPY --from=java-verifiers /opt/redpanda-tests/java /opt/redpanda-tests/java
 COPY --from=java-verifiers /opt/verifiers /opt/verifiers
 COPY --from=java-verifiers /opt/kafka-serde /opt/kafka-serde
 COPY --from=kafka-tools /opt /opt
+COPY --from=confluent-schema-registry /opt/confluent /opt/confluent
 COPY --from=kcat /usr/local/bin/kcat /usr/local/bin/
 COPY --from=sarama-examples /opt/sarama /opt/sarama
 COPY --from=golang-test-clients /opt/redpanda-tests/go /opt/redpanda-tests/go

--- a/tests/docker/ducktape-deps/confluent-schema-registry
+++ b/tests/docker/ducktape-deps/confluent-schema-registry
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+source "$(dirname "${BASH_SOURCE[0]}")/download-utils" # import download-utils
+
+# Confluent Platform Community Edition includes Schema Registry, used as a
+# cross-vendor source in the shadow-link SR migration ducktape tests. Pin to a
+# version compatible with the Apache Kafka version used by the multi-cluster
+# shadow-link tests (kafka 3.7/3.8 -> CP 7.7.x).
+CP_VERSION=7.7.1
+CP_FILE=confluent-community-${CP_VERSION}.tar.gz
+
+# Confluent's archive is the canonical source for the tarball.
+CP_URL=https://packages.confluent.io/archive/7.7/${CP_FILE}
+
+mkdir -p /opt/confluent
+chmod a+rw /opt/confluent
+DL_STRIP=1 download_extract "${CP_URL}" /opt/confluent

--- a/tests/rptest/services/confluent_schema_registry.py
+++ b/tests/rptest/services/confluent_schema_registry.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import os
+import tempfile
+
+import requests
+from ducktape.services.service import Service
+from ducktape.utils.util import wait_until
+
+CP_DIR = "/opt/confluent"
+SR_BIN = os.path.join(CP_DIR, "bin", "schema-registry-start")
+SR_LOG = "/var/log/schema-registry.log"
+SR_PROPS = "/tmp/schema-registry.properties"
+SR_DEFAULT_PORT = 8081
+
+
+class ConfluentSchemaRegistryService(Service):
+    """
+    Single-node Confluent Schema Registry, used for migration / cross-vendor
+    compatibility tests. The registry stores schemas in the `_schemas` topic
+    of whichever Kafka-compatible cluster is passed as `bootstrap_provider`.
+
+    `bootstrap_provider` is anything that exposes a `bootstrap_servers()`
+    method returning a comma-separated host:port list — e.g. a
+    `KafkaServiceAdapter` wrapping `kafkatest.services.kafka.KafkaService`,
+    or a `RedpandaService`.
+    """
+
+    logs = {
+        "schema_registry_log": {
+            "path": SR_LOG,
+            "collect_default": True,
+        },
+    }
+
+    def __init__(self, context, bootstrap_provider, port: int = SR_DEFAULT_PORT):
+        super().__init__(context, num_nodes=1)
+        self._bootstrap_provider = bootstrap_provider
+        self.port = port
+
+    def _bootstrap_servers(self) -> str:
+        bs = self._bootstrap_provider.bootstrap_servers()
+        # Confluent SR expects PLAINTEXT://host:port form for plaintext.
+        return ",".join(
+            f"PLAINTEXT://{ep}" if "://" not in ep else ep for ep in bs.split(",")
+        )
+
+    def _properties(self) -> str:
+        return (
+            f"listeners=http://0.0.0.0:{self.port}\n"
+            f"kafkastore.bootstrap.servers={self._bootstrap_servers()}\n"
+            "kafkastore.topic=_schemas\n"
+            "schema.compatibility.level=none\n"
+            # This is a test-only registry; RF=1 keeps `_schemas` writable on a
+            # small source cluster regardless of its broker count.
+            "kafkastore.topic.replication.factor=1\n"
+        )
+
+    def url(self, node=None) -> str:
+        node = node or self.nodes[0]
+        return f"http://{node.account.hostname}:{self.port}"
+
+    def alive(self, node) -> bool:
+        try:
+            r = requests.get(f"{self.url(node)}/subjects", timeout=2)
+            return r.status_code == 200
+        except Exception:
+            return False
+
+    def pids(self, node):
+        # The registry's JVM main class is
+        # io.confluent.kafka.schemaregistry.rest.SchemaRegistryMain; match on
+        # the (unambiguous) simple class name so stop_node actually finds it.
+        return node.account.java_pids("SchemaRegistryMain")
+
+    def start_node(self, node, **kwargs):
+        props = self._properties()
+        self.logger.info(f"Starting Confluent SR on {node.account.hostname}\n{props}")
+        with tempfile.NamedTemporaryFile(mode="w") as f:
+            f.write(props)
+            f.flush()
+            node.account.copy_to(f.name, SR_PROPS)
+
+        cmd = f"nohup {SR_BIN} {SR_PROPS} > {SR_LOG} 2>&1 &"
+        node.account.ssh(cmd, allow_fail=False)
+
+        wait_until(
+            lambda: self.alive(node),
+            timeout_sec=90,
+            backoff_sec=2,
+            err_msg=f"Confluent SR did not become reachable at {self.url(node)}",
+        )
+        self.logger.info(f"Confluent SR is up at {self.url(node)}")
+
+    def stop_node(self, node, **kwargs):
+        for pid in self.pids(node):
+            node.account.signal(pid, 15, allow_fail=True)
+        wait_until(
+            lambda: len(self.pids(node)) == 0,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Confluent SR did not stop",
+        )
+
+    def clean_node(self, node, **kwargs):
+        node.account.ssh(f"rm -f {SR_PROPS} {SR_LOG}", allow_fail=True)

--- a/tests/rptest/services/multi_cluster_services.py
+++ b/tests/rptest/services/multi_cluster_services.py
@@ -165,12 +165,14 @@ class RedpandaCluster(Cluster):
 
 class SecondaryClusterArgs:
     """
-    Container used to hold args and kwargs for the secondary cluster.
+    Container used to hold args and kwargs for the secondary (source) cluster.
 
-    Will be passed to the secondary cluster's create method
+    `num_brokers` sizes the source cluster; the remaining args/kwargs are
+    passed to the source cluster's create method.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, num_brokers: int = 3, *args, **kwargs):
+        self.num_brokers = num_brokers
         self.args = args
         self.kwargs = kwargs
 
@@ -184,7 +186,6 @@ class MultiClusterServices:
         secondary_spec: SecondaryClusterSpec = SecondaryClusterSpec(
             ServiceType.REDPANDA
         ),
-        num_brokers=3,
         secondary_args: SecondaryClusterArgs = SecondaryClusterArgs(),
     ):
         self.test_ctx = test_ctx
@@ -194,7 +195,7 @@ class MultiClusterServices:
             self._clusters.append(
                 RedpandaCluster.create(
                     self.test_ctx,
-                    num_brokers,
+                    secondary_args.num_brokers,
                     *secondary_args.args,
                     **secondary_args.kwargs,
                 )
@@ -203,7 +204,7 @@ class MultiClusterServices:
             self._clusters.append(
                 KafkaCluster.create(
                     self.test_ctx,
-                    num_brokers,
+                    secondary_args.num_brokers,
                     secondary_spec.kafka_version
                     if secondary_spec.kafka_version
                     else KAFKA_VERSION,

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -157,7 +157,6 @@ class MultiClusterRedpandaTest(MultiClusterTestBase):
             self.logger,
             self.redpanda,
             secondary_spec=SecondaryClusterSpec(ServiceType.REDPANDA),
-            num_brokers=3,
         ) as services:
             assert services.secondary.is_redpanda, (
                 f"Expected Redpanda service, got {services.secondary}"
@@ -188,7 +187,6 @@ class MultiClusterKafkaTest(MultiClusterTestBase):
             secondary_spec=SecondaryClusterSpec(
                 ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
             ),
-            num_brokers=3,
         ) as services:
             assert services.secondary.is_kafka, (
                 f"Expected Kafka service, got {services.secondary}"

--- a/tests/rptest/tests/cluster_linking_schema_registry_sync_test.py
+++ b/tests/rptest/tests/cluster_linking_schema_registry_sync_test.py
@@ -27,7 +27,12 @@ from rptest.clients.admin.proto.redpanda.core.admin.v2 import shadow_link_pb2
 from rptest.clients.rpk import RpkTool
 from rptest.services.admin import Admin
 from rptest.services.cluster import TestContext, cluster
-from rptest.services.multi_cluster_services import SecondaryClusterArgs
+from rptest.services.confluent_schema_registry import ConfluentSchemaRegistryService
+from rptest.services.multi_cluster_services import (
+    SecondaryClusterArgs,
+    SecondaryClusterSpec,
+    ServiceType,
+)
 from rptest.services.redpanda import SchemaRegistryConfig
 from rptest.tests.cluster_linking_test_base import ShadowLinkTestBase
 from rptest.tests.schema_registry_test import SchemaRegistryRedpandaClient
@@ -39,9 +44,22 @@ LINK_NAME = "sr-sync"
 Pair = tuple[str, int]
 
 
-class SchemaRegistrySyncE2ETest(ShadowLinkTestBase):
-    """Source cluster SR -> destination cluster SR over the shadow-link HTTP
-    source reader, at scale and with concurrent / post-sync additions."""
+class SchemaRegistrySyncMixin:
+    """Shared shadow-link Schema Registry "API mode" sync suite: source cluster
+    SR -> destination cluster SR over the HTTP source reader, at scale and with
+    concurrent / post-sync additions.
+
+    Not a Test: mixed into a ShadowLinkTestBase leaf per source vendor (see
+    SchemaRegistrySyncE2ETest / ConfluentSchemaRegistrySyncE2ETest below). Each
+    leaf supplies the source registry via _make_source_client and declares its
+    own node budget; ducktape collects the leaves, never this class."""
+
+    # Members supplied by ShadowLinkTestBase once mixed into a leaf.
+    logger: Any
+    target_cluster_service: Any
+    create_default_link_request: Any
+    create_link_with_request: Any
+    get_link: Any
 
     # A layered diamond DAG (top -> mid -> leaf), like the reconciler
     # concurrent_stress unit test but larger: adjacent referrers share referents,
@@ -55,20 +73,17 @@ class SchemaRegistrySyncE2ETest(ShadowLinkTestBase):
     EXTRA_LEAVES = 10
     EXTRA_MIDS = 10
 
-    def __init__(self, test_context: TestContext, *args: Any, **kwargs: Any):
-        source_sr_config = SchemaRegistryConfig()
-        source_sr_config.mode_mutability = True
-        super().__init__(
-            test_context,
-            # Source (secondary) cluster runs a Schema Registry too.
-            secondary_cluster_args=SecondaryClusterArgs(
-                schema_registry_config=source_sr_config
-            ),
-            # Destination (primary) cluster Schema Registry.
-            schema_registry_config=SchemaRegistryConfig(),
-            *args,
-            **kwargs,
-        )
+    # --- source Schema Registry hook ---------------------------------------
+    # Each leaf points this at its vendor's Schema Registry; the destination
+    # side stays Redpanda throughout.
+
+    def _make_source_client(self) -> SchemaRegistryRedpandaClient:
+        raise NotImplementedError
+
+    def _source_sr_url(self) -> str:
+        # Derive from the seeding client so the link source_url and the client
+        # can never point at different registries.
+        return self._make_source_client().base_uri()
 
     # --- schema builders ---------------------------------------------------
 
@@ -204,7 +219,7 @@ class SchemaRegistrySyncE2ETest(ShadowLinkTestBase):
         # subsequent full syncs land quickly. An optional exact-subject filter
         # scopes replication. Returns the source URL used.
         if source_url is None:
-            source_url = self.source_cluster_service.schema_reg(limit=1)
+            source_url = self._source_sr_url()
         req = self.create_default_link_request(
             link_name=LINK_NAME,
             mirror_all_topics=False,
@@ -452,9 +467,8 @@ class SchemaRegistrySyncE2ETest(ShadowLinkTestBase):
         for name in self.EXPECTED_ZERO_COUNTERS:
             assert totals[name] == 0, status
 
-    @cluster(num_nodes=6)
-    def test_schema_registry_api_sync_e2e(self):
-        src = SchemaRegistryRedpandaClient(self.source_cluster_service)
+    def _test_schema_registry_api_sync_e2e(self):
+        src = self._make_source_client()
         dest = SchemaRegistryRedpandaClient(self.target_cluster_service)
 
         # The destination `_schemas` topic is NOT warmed up here on purpose:
@@ -529,9 +543,8 @@ class SchemaRegistrySyncE2ETest(ShadowLinkTestBase):
         #    rendering of it.
         self._verify_counters(all_pairs)
 
-    @cluster(num_nodes=6)
-    def test_schema_registry_api_sync_soft_delete(self):
-        src = SchemaRegistryRedpandaClient(self.source_cluster_service)
+    def _test_schema_registry_api_sync_soft_delete(self):
+        src = self._make_source_client()
         dest = SchemaRegistryRedpandaClient(self.target_cluster_service)
 
         # seeded-value: mixed active/deleted before the first sync.
@@ -571,14 +584,13 @@ class SchemaRegistrySyncE2ETest(ShadowLinkTestBase):
         assert src.delete_subject(whole).status_code == 200
         self._wait_delete_synced(src, dest, subjects)
 
-    @cluster(num_nodes=6)
-    def test_schema_registry_api_sync_compatibility(self):
+    def _test_schema_registry_api_sync_compatibility(self):
         # A subject-level compatibility override round-tripping through the
         # destination's write API -- a path the reconciler unit fakes cannot
         # cover -- then un-setting it so the destination reverts to the
         # inherited default. Mode replication is covered e2e by
         # test_schema_registry_api_sync_context_remap.
-        src = SchemaRegistryRedpandaClient(self.source_cluster_service)
+        src = self._make_source_client()
         dest = SchemaRegistryRedpandaClient(self.target_cluster_service)
 
         keep = "keep-value"
@@ -647,12 +659,11 @@ class SchemaRegistrySyncE2ETest(ShadowLinkTestBase):
             err_msg="compatibility_configs_changed counter did not advance for the delete",
         )
 
-    @cluster(num_nodes=6)
-    def test_schema_registry_api_sync_hard_delete(self):
+    def _test_schema_registry_api_sync_hard_delete(self):
         # A source hard-delete (which requires a soft-delete first on the
         # destination) being propagated as a purge -- a path the reconciler unit
         # fakes cannot cover.
-        src = SchemaRegistryRedpandaClient(self.source_cluster_service)
+        src = self._make_source_client()
         dest = SchemaRegistryRedpandaClient(self.target_cluster_service)
 
         keep, gone = "keep-value", "gone-value"
@@ -683,9 +694,8 @@ class SchemaRegistrySyncE2ETest(ShadowLinkTestBase):
         # The in-source subject is untouched by the purge.
         assert self._schema_view(dest, keep, 1) is not None
 
-    @cluster(num_nodes=6)
-    def test_schema_registry_api_sync_context_remap(self):
-        src = SchemaRegistryRedpandaClient(self.source_cluster_service)
+    def _test_schema_registry_api_sync_context_remap(self):
+        src = self._make_source_client()
         dest = SchemaRegistryRedpandaClient(self.target_cluster_service)
 
         def qualified(ctx: str, name: str) -> str:
@@ -840,9 +850,8 @@ class SchemaRegistrySyncE2ETest(ShadowLinkTestBase):
             err_msg="mode/compatibility counters did not advance under remap",
         )
 
-    @cluster(num_nodes=6)
-    def test_schema_registry_api_sync_out_of_scope_reference(self):
-        src = SchemaRegistryRedpandaClient(self.source_cluster_service)
+    def _test_schema_registry_api_sync_out_of_scope_reference(self):
+        src = self._make_source_client()
         dest = SchemaRegistryRedpandaClient(self.target_cluster_service)
 
         # leaf-0 is a referent; mid-0 references it; ok-value is independent.
@@ -882,9 +891,8 @@ class SchemaRegistrySyncE2ETest(ShadowLinkTestBase):
         assert "ok-value" in dest_subjects, dest_subjects
         assert "mid-0-value" not in dest_subjects, dest_subjects
 
-    @cluster(num_nodes=6)
-    def test_schema_registry_api_sync_recovers_after_source_unavailable(self):
-        src = SchemaRegistryRedpandaClient(self.source_cluster_service)
+    def _test_schema_registry_api_sync_recovers_after_source_unavailable(self):
+        src = self._make_source_client()
         dest = SchemaRegistryRedpandaClient(self.target_cluster_service)
 
         self._register(
@@ -936,9 +944,8 @@ class SchemaRegistrySyncE2ETest(ShadowLinkTestBase):
             err_msg="link did not recover after the source became reachable again",
         )
 
-    @cluster(num_nodes=6)
-    def test_schema_registry_api_sync_memory_backpressure(self):
-        src = SchemaRegistryRedpandaClient(self.source_cluster_service)
+    def _test_schema_registry_api_sync_memory_backpressure(self):
+        src = self._make_source_client()
         dest = SchemaRegistryRedpandaClient(self.target_cluster_service)
 
         # Shrink the reconcile memory budget to its 1 MiB floor and raise
@@ -966,9 +973,8 @@ class SchemaRegistrySyncE2ETest(ShadowLinkTestBase):
         self._create_sr_link()
         self._wait_synced(src, dest, pairs)
 
-    @cluster(num_nodes=6)
-    def test_schema_registry_api_sync_survives_leadership_change(self):
-        src = SchemaRegistryRedpandaClient(self.source_cluster_service)
+    def _test_schema_registry_api_sync_survives_leadership_change(self):
+        src = self._make_source_client()
         dest = SchemaRegistryRedpandaClient(self.target_cluster_service)
         admin = Admin(self.target_cluster_service)
 
@@ -1115,3 +1121,169 @@ class SchemaRegistrySyncE2ETest(ShadowLinkTestBase):
             backoff_sec=1,
             err_msg="reused instance did not reset state on regaining leadership",
         )
+
+
+class SchemaRegistrySyncE2ETest(ShadowLinkTestBase, SchemaRegistrySyncMixin):
+    """Redpanda source: a secondary Redpanda cluster provides the source Schema
+    Registry (co-located on its brokers).
+
+    Node budget: 3 (destination Redpanda) + 3 (source Redpanda) = 6."""
+
+    def __init__(self, test_context: TestContext, *args: Any, **kwargs: Any):
+        source_sr_config = SchemaRegistryConfig()
+        source_sr_config.mode_mutability = True
+        super().__init__(
+            test_context,
+            # Source (secondary) cluster runs a Schema Registry too.
+            secondary_cluster_args=SecondaryClusterArgs(
+                schema_registry_config=source_sr_config
+            ),
+            # Destination (primary) cluster Schema Registry.
+            schema_registry_config=SchemaRegistryConfig(),
+            *args,
+            **kwargs,
+        )
+
+    def _make_source_client(self) -> SchemaRegistryRedpandaClient:
+        return SchemaRegistryRedpandaClient(self.source_cluster_service)
+
+    @cluster(num_nodes=6)
+    def test_schema_registry_api_sync_e2e(self):
+        self._test_schema_registry_api_sync_e2e()
+
+    @cluster(num_nodes=6)
+    def test_schema_registry_api_sync_soft_delete(self):
+        self._test_schema_registry_api_sync_soft_delete()
+
+    @cluster(num_nodes=6)
+    def test_schema_registry_api_sync_compatibility(self):
+        self._test_schema_registry_api_sync_compatibility()
+
+    @cluster(num_nodes=6)
+    def test_schema_registry_api_sync_hard_delete(self):
+        self._test_schema_registry_api_sync_hard_delete()
+
+    @cluster(num_nodes=6)
+    def test_schema_registry_api_sync_context_remap(self):
+        self._test_schema_registry_api_sync_context_remap()
+
+    @cluster(num_nodes=6)
+    def test_schema_registry_api_sync_out_of_scope_reference(self):
+        self._test_schema_registry_api_sync_out_of_scope_reference()
+
+    @cluster(num_nodes=6)
+    def test_schema_registry_api_sync_recovers_after_source_unavailable(self):
+        self._test_schema_registry_api_sync_recovers_after_source_unavailable()
+
+    @cluster(num_nodes=6)
+    def test_schema_registry_api_sync_memory_backpressure(self):
+        self._test_schema_registry_api_sync_memory_backpressure()
+
+    @cluster(num_nodes=6)
+    def test_schema_registry_api_sync_survives_leadership_change(self):
+        self._test_schema_registry_api_sync_survives_leadership_change()
+
+
+class ConfluentSchemaRegistrySyncE2ETest(ShadowLinkTestBase, SchemaRegistrySyncMixin):
+    """Confluent Platform Schema Registry (backed by an Apache Kafka source
+    cluster) as the shadow-link source; the destination stays Redpanda.
+    See CORE-16776 / CORE-16357.
+
+    Node budget: 3 (destination Redpanda) + 1 (Apache Kafka source) + 1
+    (Confluent SR) = 5. The Confluent SR is a separate service that needs its
+    own node (a Redpanda source's SR is co-located on its brokers), so the Kafka
+    source is held to a single broker -- see the SecondaryClusterArgs below.
+
+    Runs the full suite. Against a Confluent source, global compat/mode
+    replication has a known cross-vendor gap -- see EXPECTED_ZERO_COUNTERS."""
+
+    # Full-sync compat/mode replication reads the registry-wide global config
+    # via Redpanda's ":.__GLOBAL:" pseudo-subject. A Confluent source 404s it
+    # (it exposes the global config at GET /config, with no subject), so the
+    # sync reads "no override" and deletes the destination's global config,
+    # landing compatibility_configs_changed at 1 instead of 0. Known cross-vendor
+    # gap in global compat replication, orthogonal to what this suite exercises,
+    # so drop that one counter from the zero-check here. (modes_changed stays 0
+    # on the pinned Confluent version.)
+    EXPECTED_ZERO_COUNTERS = ("modes_changed", "unsupported_features_removed")
+
+    def __init__(self, test_context: TestContext, *args: Any, **kwargs: Any):
+        super().__init__(
+            test_context,
+            # Destination (primary) cluster Schema Registry; the source SR is
+            # the separate Confluent service started in setUp.
+            schema_registry_config=SchemaRegistryConfig(),
+            # Single-broker Kafka source: the Confluent SR takes a node of its
+            # own, so a one-broker source keeps the topology at 5 nodes (3 dest
+            # + 1 kafka + 1 SR). A one-broker source is fine here -- the SR's
+            # _schemas topic is RF=1.
+            secondary_cluster_args=SecondaryClusterArgs(num_brokers=1),
+            *args,
+            **kwargs,
+        )
+        self._confluent_sr: ConfluentSchemaRegistryService | None = None
+
+    def get_source_cluster_spec(self) -> SecondaryClusterSpec:
+        # Source cluster is Apache Kafka (KRaft); the Confluent SR is attached to
+        # it in setUp. Mirrors the Kafka-source topology used by
+        # cluster_linking_e2e_test.
+        return SecondaryClusterSpec(
+            ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
+        )
+
+    def setUp(self):
+        # Starts the Apache Kafka source + Redpanda destination clusters.
+        super().setUp()
+        # Attach a Confluent Schema Registry to the Kafka source and start it.
+        self._confluent_sr = ConfluentSchemaRegistryService(
+            self.test_context, bootstrap_provider=self.source_cluster_service
+        )
+        self._confluent_sr.start()
+
+    def _confluent(self) -> ConfluentSchemaRegistryService:
+        assert self._confluent_sr is not None, "Confluent SR not started"
+        return self._confluent_sr
+
+    def _make_source_client(self) -> SchemaRegistryRedpandaClient:
+        sr = self._confluent()
+        # The base client hardcodes port 8081 and only needs
+        # .nodes[*].account.hostname + .logger, so the ducktape service
+        # duck-types cleanly; the Confluent SR must use the default port.
+        assert sr.port == 8081, "Confluent SR must listen on 8081 for the SR client"
+        return SchemaRegistryRedpandaClient(sr)  # type: ignore[arg-type]
+
+    @cluster(num_nodes=5)
+    def test_schema_registry_api_sync_e2e(self):
+        self._test_schema_registry_api_sync_e2e()
+
+    @cluster(num_nodes=5)
+    def test_schema_registry_api_sync_soft_delete(self):
+        self._test_schema_registry_api_sync_soft_delete()
+
+    @cluster(num_nodes=5)
+    def test_schema_registry_api_sync_out_of_scope_reference(self):
+        self._test_schema_registry_api_sync_out_of_scope_reference()
+
+    @cluster(num_nodes=5)
+    def test_schema_registry_api_sync_recovers_after_source_unavailable(self):
+        self._test_schema_registry_api_sync_recovers_after_source_unavailable()
+
+    @cluster(num_nodes=5)
+    def test_schema_registry_api_sync_memory_backpressure(self):
+        self._test_schema_registry_api_sync_memory_backpressure()
+
+    @cluster(num_nodes=5)
+    def test_schema_registry_api_sync_survives_leadership_change(self):
+        self._test_schema_registry_api_sync_survives_leadership_change()
+
+    @cluster(num_nodes=5)
+    def test_schema_registry_api_sync_compatibility(self):
+        self._test_schema_registry_api_sync_compatibility()
+
+    @cluster(num_nodes=5)
+    def test_schema_registry_api_sync_hard_delete(self):
+        self._test_schema_registry_api_sync_hard_delete()
+
+    @cluster(num_nodes=5)
+    def test_schema_registry_api_sync_context_remap(self):
+        self._test_schema_registry_api_sync_context_remap()

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -667,7 +667,9 @@ class ShadowLinkTestBase(PreallocNodesTest):
                 )
                 sec_kwargs["extra_rp_conf"] = sec_extra
             secondary_cluster_args = SecondaryClusterArgs(
-                *secondary_cluster_args.args, **sec_kwargs
+                secondary_cluster_args.num_brokers,
+                *secondary_cluster_args.args,
+                **sec_kwargs,
             )
 
         kwargs.setdefault(
@@ -741,7 +743,6 @@ class ShadowLinkTestBase(PreallocNodesTest):
             self.logger,
             self.redpanda,
             secondary_spec=self.source_cluster_spec,
-            num_brokers=3,
             secondary_args=self.secondary_cluster_args,
         )
         self.services.setUp()

--- a/tools/type-checking/type-check-strictness.json
+++ b/tools/type-checking/type-check-strictness.json
@@ -51,6 +51,7 @@
         "rptest/services/compatibility/franzgo_examples.py",
         "rptest/services/compatibility/kafka_streams_examples.py",
         "rptest/services/compatibility/sarama_examples.py",
+        "rptest/services/confluent_schema_registry.py",
         "rptest/services/datalake/catalog/databricks_unity.py",
         "rptest/services/datalake/query_engine/databricks_sql.py",
         "rptest/services/datalake/query_engine/duckdb_py.py",


### PR DESCRIPTION
Adds end-to-end ducktape coverage for the shadow-link Schema Registry
"API mode" sync against a Confluent Platform source registry (backed by
an Apache Kafka cluster), alongside the existing Redpanda-to-Redpanda
coverage, and fixes the one product gap it surfaced. The suite is
restructured into a shared mixin with a thin leaf per source vendor, so
the same tests run against either source through a _make_source_client
hook.

Standing up the Confluent source revealed that soft-delete propagation
did not converge cross-vendor: the reconciler took an imported version's
deleted-state from the per-version source response body, which a
standard source (e.g. Confluent) omits by default, so a soft-deleted
version imported active and the full-sync diff re-imported it every
cycle, forever. The fix derives the deleted-state from the caller's
authoritative active-vs-deleted listing partition instead.

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
