### PR TITLE
[CORE-16830] `rptest`: extend `start_timeout` in `timely_shutdown_test`

### DIFF
--- a/tests/rptest/tests/timely_shutdown_test.py
+++ b/tests/rptest/tests/timely_shutdown_test.py
@@ -112,7 +112,11 @@ class ShutdownTest(EndToEndTest):
                 self.redpanda.logger.info(
                     f"Restarting leader node {leader.account.hostname}"
                 )
-                self.redpanda.restart_nodes(leader)
+                # The background failure injector repeatedly isolates a random
+                # non-leader node, which can strip the 3-node controller of
+                # quorum while the restarted node is trying to rejoin. Give the
+                # restarting node some extra timeout slack.
+                self.redpanda.restart_nodes(leader, start_timeout=90)
                 pending_attempts -= 1
         finally:
             # Stop the finjector


### PR DESCRIPTION
In this test, the background failure injector repeatedly isolates a random non-leader node, which can strip the 3-node controller of quorum while the restarted node is trying to rejoin.

Give the restarting node some extra timeout slack to avoid test flakes.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
