### PR TITLE
config: add O_DIRECT hint to config read failures

### DIFF
--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -26,7 +26,11 @@
 #include "rpc/connection_cache.h"
 #include "utils/file_io.h"
 
+#include <fmt/format.h>
+
 #include <algorithm>
+#include <stdexcept>
+#include <system_error>
 
 namespace cluster {
 
@@ -434,15 +438,39 @@ config_manager::preload(const YAML::Node& legacy_config) {
  */
 ss::future<bool> config_manager::load_bootstrap() {
     YAML::Node config;
+    ss::sstring config_str;
+
     try {
-        auto config_str = co_await read_fully_to_string(bootstrap_path());
-        config = YAML::Load(config_str);
+        config_str = co_await read_fully_to_string(bootstrap_path());
     } catch (const std::filesystem::filesystem_error& e) {
-        // This is normal on upgrade from pre-config_manager version or
-        // on newly added node.  Also permitted later if user
-        // chooses to e.g. blow away config cache during disaster recovery.
-        vlog(clusterlog.info, "Can't load config bootstrap file: {}", e);
-        co_return false;
+        if (e.code() == std::errc::no_such_file_or_directory) {
+            // This is normal on upgrade from pre-config_manager version or
+            // on newly added node.  Also permitted later if user
+            // chooses to e.g. blow away config cache during disaster recovery.
+            vlog(clusterlog.info, "Can't load config bootstrap file: {}", e);
+            co_return false;
+        }
+        throw std::runtime_error(format_file_io_error(
+          fmt::format(
+            "Failed to read config bootstrap file {}",
+            bootstrap_path().string()),
+          std::current_exception()));
+    } catch (...) {
+        throw std::runtime_error(format_file_io_error(
+          fmt::format(
+            "Failed to read config bootstrap file {}",
+            bootstrap_path().string()),
+          std::current_exception()));
+    }
+
+    try {
+        config = YAML::Load(config_str);
+    } catch (...) {
+        throw std::runtime_error(
+          fmt::format(
+            "Failed to parse config bootstrap file {}: {}",
+            bootstrap_path(),
+            std::current_exception()));
     }
 
     // This node has never seen a cluster configuration message.

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -668,7 +668,15 @@ YAML::Node application::hydrate_node_config(const po::variables_map& cfg) {
     // Retain the original bytes loaded so that we can hexdump them later
     // if YAML Parse fails.
     // Related: https://github.com/redpanda-data/redpanda/issues/3798
-    auto yaml_raw_bytes = read_fully_tmpbuf(cfg_path).get();
+    ss::temporary_buffer<char> yaml_raw_bytes;
+    try {
+        yaml_raw_bytes = read_fully_tmpbuf(cfg_path).get();
+    } catch (...) {
+        throw std::runtime_error(format_file_io_error(
+          fmt::format("Failed to read config file {}", cfg_path.string()),
+          std::current_exception()));
+    }
+
     auto yaml_raw_str = ss::to_sstring(yaml_raw_bytes.clone());
     YAML::Node config;
     try {

--- a/src/v/utils/BUILD
+++ b/src/v/utils/BUILD
@@ -240,6 +240,7 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/bytes:iobuf",
         "//src/v/bytes:iostream",
+        "@fmt",
         "@seastar",
     ],
 )

--- a/src/v/utils/file_io.cc
+++ b/src/v/utils/file_io.cc
@@ -19,6 +19,10 @@
 #include <seastar/core/fstream.hh>
 #include <seastar/core/temporary_buffer.hh>
 
+#include <fmt/format.h>
+
+#include <system_error>
+
 ss::future<ss::temporary_buffer<char>>
 read_fully_tmpbuf(const std::filesystem::path& name) {
     return ss::with_file(
@@ -60,6 +64,45 @@ read_fully_to_string(const std::filesystem::path& name) {
     return read_fully_tmpbuf(name).then([](ss::temporary_buffer<char> buf) {
         return ss::to_sstring(std::move(buf));
     });
+}
+
+// The read helpers above open files with O_DIRECT (via Seastar's
+// open_file_dma). Filesystems without direct-I/O support reject this with
+// EINVAL, which surfaces as an opaque "Invalid argument". A notable case is an
+// overlayfs whose lower layer is squashfs, which rejects the O_DIRECT open
+// with EINVAL. Some environments bind-mount the bootstrap config from such a
+// filesystem, so startup failed with no indication of the cause. Append a hint
+// pointing at O_DIRECT in that case.
+//
+// This matters mainly for config files, which users often bind-mount onto
+// arbitrary filesystems. Data directories are not a concern here: they are
+// validated separately by syschecks::disk, which does a round-trip O_DIRECT
+// check.
+//
+// See:
+//   https://github.com/scylladb/seastar/issues/3518
+//   https://github.com/redpanda-data/redpanda/issues/14473
+std::string
+format_file_io_error(std::string_view context, std::exception_ptr eptr) {
+    std::string what = "unknown error";
+    bool is_einval = false;
+    try {
+        if (eptr) {
+            std::rethrow_exception(eptr);
+        }
+    } catch (const std::system_error& e) {
+        what = e.what();
+        is_einval = e.code() == std::errc::invalid_argument;
+    } catch (const std::exception& e) {
+        what = e.what();
+    } catch (...) {
+        what = "unknown exception";
+    }
+    return fmt::format(
+      "{}: {}{}",
+      context,
+      what,
+      is_einval ? " (EINVAL). Does this filesystem support O_DIRECT?" : "");
 }
 
 ss::future<> write_fully(const std::filesystem::path& p, iobuf buf) {

--- a/src/v/utils/file_io.h
+++ b/src/v/utils/file_io.h
@@ -17,7 +17,10 @@
 #include <seastar/core/seastar.hh>
 #include <seastar/core/temporary_buffer.hh>
 
+#include <exception>
 #include <filesystem>
+#include <string>
+#include <string_view>
 
 /// \brief Read an entire file into a ss::temporary_buffer
 ///
@@ -39,3 +42,10 @@ ss::future<> write_fully(const std::filesystem::path&, iobuf buf);
 // returned if the file does not exist. Any other errors are propagated via
 // thrown exception.
 ss::future<> maybe_remove_file(std::string_view name);
+
+/// \brief Format a file I/O error message for logging or throwing.
+///
+/// Appends an O_DIRECT hint when the error is EINVAL; see the definition for
+/// why (some filesystems reject direct I/O).
+std::string
+format_file_io_error(std::string_view context, std::exception_ptr eptr);


### PR DESCRIPTION
Config files are read with O_DIRECT (via Seastar's `open_file_dma`). On a
filesystem that doesn't support direct I/O the read fails with EINVAL, which
previously surfaced as an opaque `Failure during startup: system_error (error
system:22, Invalid argument)` with no indication of the cause. This happens in
some environments that bind-mount the bootstrap config from an overlayfs whose
lower layer is squashfs.

This wraps the node- and bootstrap-config reads to report the file path and, on
EINVAL, a hint that the filesystem may not support O_DIRECT. The hint is scoped
to config files (often bind-mounted onto arbitrary filesystems); data
directories are validated separately by `syschecks::disk`, which does a
round-trip O_DIRECT check.

It also stops `config_manager::load_bootstrap` from swallowing non-ENOENT
errors: previously any `filesystem_error` (including the O_DIRECT EINVAL) was
treated as "bootstrap file absent", so the node started silently without
applying the bootstrap config. Now only a genuinely missing file (ENOENT) is
ignored; any other error fails startup.

See:
- https://github.com/scylladb/seastar/issues/3518
- https://github.com/redpanda-data/redpanda/issues/14473

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Improvements

* Startup failures caused by reading config files on filesystems without
  O_DIRECT support (e.g. an overlayfs over squashfs, common when the config is
  bind-mounted) now report the file path and an O_DIRECT hint instead of an
  opaque "Invalid argument".

  **Behavior change:** if the bootstrap config file (`.bootstrap.yaml`) is
  present but unreadable, the node now fails to start instead of silently
  starting as though no bootstrap config existed. A missing bootstrap file is
  still ignored, as before.
