### PR TITLE
security: cache derived SCRAM stored key 

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4178,6 +4178,16 @@ configuration::configuration()
       },
       std::vector<ss::sstring>{"BASIC"},
       validate_http_authn_mechanisms)
+  , scram_credential_cache_enabled(
+      *this,
+      "scram_credential_cache_enabled",
+      "Whether to cache SCRAM password validation results for authentication "
+      "paths that receive a plaintext password on every request (HTTP Basic "
+      "authentication and SASL/PLAIN). When enabled, repeat authentications "
+      "skip the salted password derivation, which costs thousands of HMAC "
+      "operations per validation.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      false)
   , enable_mpx_extensions(
       *this,
       "enable_mpx_extensions",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -712,6 +712,7 @@ struct configuration final : public config_store {
 
     // HTTP Authentication
     enterprise<property<std::vector<ss::sstring>>> http_authentication;
+    property<bool> scram_credential_cache_enabled;
 
     // MPX
     property<bool> enable_mpx_extensions;

--- a/src/v/crypto/crypto.cc
+++ b/src/v/crypto/crypto.cc
@@ -16,6 +16,7 @@
 #include "crypto/types.h"
 #include "internal.h"
 
+#include <openssl/crypto.h>
 #include <openssl/evp.h>
 #include <openssl/provider.h>
 
@@ -156,4 +157,11 @@ void clear_evp_cache() {
 
 bool fips_enabled() { return 1 == OSSL_PROVIDER_available(nullptr, "fips"); }
 } // namespace internal
+
+void secure_erase(bytes_span<> buf) noexcept {
+    if (buf.empty()) {
+        return;
+    }
+    OPENSSL_cleanse(buf.data(), buf.size());
+}
 } // namespace crypto

--- a/src/v/crypto/crypto.h
+++ b/src/v/crypto/crypto.h
@@ -377,6 +377,16 @@ bytes generate_random(
   size_t len, use_private_rng private_rng = use_private_rng::no);
 
 /**
+ * Securely erases the contents of the buffer
+ *
+ * Zeroes the buffer in a way the optimizer cannot elide; use it to scrub
+ * key material from memory that is about to be released or reused.
+ *
+ * @param buf The buffer to erase
+ */
+void secure_erase(bytes_span<> buf) noexcept;
+
+/**
  * Secure RNG structure that can be used with stdlib RNG utilities
  *
  * @tparam UsePrivate Whether or not to use the private RNG

--- a/src/v/crypto/tests/BUILD
+++ b/src/v/crypto/tests/BUILD
@@ -59,6 +59,19 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "secure_erase_test",
+    timeout = "short",
+    srcs = [
+        "secure_erase_tests.cc",
+    ],
+    deps = [
+        "//src/v/crypto",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "signature_test",
     timeout = "short",
     srcs = [

--- a/src/v/crypto/tests/secure_erase_tests.cc
+++ b/src/v/crypto/tests/secure_erase_tests.cc
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "crypto/crypto.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+
+TEST(crypto_secure_erase, zeroes_buffer) {
+    constexpr size_t buf_size = 64;
+    constexpr uint8_t fill_byte = 0xab;
+    std::array<uint8_t, buf_size> buf{};
+    buf.fill(fill_byte);
+    crypto::secure_erase(buf);
+    for (auto b : buf) {
+        EXPECT_EQ(b, 0);
+    }
+}
+
+TEST(crypto_secure_erase, empty_buffer_is_noop) {
+    crypto::secure_erase(bytes_span<>{});
+}

--- a/src/v/security/BUILD
+++ b/src/v/security/BUILD
@@ -111,6 +111,7 @@ redpanda_cc_library(
         "role.cc",
         "scram_algorithm.cc",
         "scram_authenticator.cc",
+        "scram_credential_cache.cc",
     ],
     hdrs = [
         "acl.h",
@@ -142,6 +143,7 @@ redpanda_cc_library(
         "scram_algorithm.h",
         "scram_authenticator.h",
         "scram_credential.h",
+        "scram_credential_cache.h",
         "types.h",
     ],
     implementation_deps = [
@@ -186,6 +188,7 @@ redpanda_cc_library(
         "//src/v/strings:utf8",
         "//src/v/utils:absl_sstring_hash",
         "//src/v/utils:base64",
+        "//src/v/utils:chunked_kv_cache",
         "//src/v/utils:log_hist",
         "//src/v/utils:named_type",
         "//src/v/utils:to_string",

--- a/src/v/security/scram_algorithm.h
+++ b/src/v/security/scram_algorithm.h
@@ -339,6 +339,18 @@ public:
     }
 
     /**
+     * Computes the stored key for a plaintext password, as persisted in a
+     * scram_credential. This is the expensive part of non-SCRAM password
+     * validation: the salted password derivation runs `iterations` HMAC
+     * rounds.
+     */
+    static bytes derive_stored_key(
+      const ss::sstring& password, bytes_view salt, int iterations) {
+        auto salted_password = salt_password(password, salt, iterations);
+        return stored_key(client_key(salted_password));
+    }
+
+    /**
      * For doing non-SCRAM authentication, such as HTTP basic auth over TLS,
      * using stored SCRAM credentials.
      */
@@ -347,10 +359,8 @@ public:
       bytes_view reference_stored_key,
       bytes_view salt,
       int iterations) {
-        auto salted_password = salt_password(password, salt, iterations);
-        auto clientkey = client_key(salted_password);
-        auto storedkey = stored_key(clientkey);
-        return storedkey == reference_stored_key;
+        return derive_stored_key(password, salt, iterations)
+               == reference_stored_key;
     }
 
 private:

--- a/src/v/security/scram_authenticator.cc
+++ b/src/v/security/scram_authenticator.cc
@@ -206,12 +206,13 @@ std::optional<std::string_view> validate_scram_credential(
 
 std::optional<std::string_view> validate_scram_credential(
   const scram_credential& cred, const credential_password& password) {
-    if (config::shard_local_cfg().scram_credential_cache_enabled()) {
-        static thread_local scram_credential_cache cache{
-          scram_credential_cache::default_capacity};
-        return detail::validate_scram_credential(cred, password, &cache);
-    }
-    return detail::validate_scram_credential(cred, password, nullptr);
+    // Constructed on first use, which forces the shard's configuration
+    // thread_local into existence first and therefore destroys the holder
+    // (and its config binding) before the configuration at thread exit.
+    static thread_local scram_credential_cache_holder holder{
+      config::shard_local_cfg().scram_credential_cache_enabled.bind(),
+      scram_credential_cache::default_capacity};
+    return detail::validate_scram_credential(cred, password, holder.get());
 }
 
 } // namespace security

--- a/src/v/security/scram_authenticator.cc
+++ b/src/v/security/scram_authenticator.cc
@@ -11,10 +11,12 @@
 #include "security/scram_authenticator.h"
 
 #include "base/vlog.h"
+#include "config/configuration.h"
 #include "random/secure_generators.h"
 #include "security/credential_store.h"
 #include "security/errc.h"
 #include "security/logger.h"
+#include "security/scram_credential_cache.h"
 
 namespace security {
 
@@ -148,22 +150,68 @@ scram_authenticator<T>::authenticate(bytes auth_bytes) {
 template class scram_authenticator<scram_sha256>;
 template class scram_authenticator<scram_sha512>;
 
+namespace {
+
+// Matches a password against a stored credential by rederiving its stored
+// key. When a cache is given, the derivation is memoized; a null cache
+// derives every time (the plain, un-memoized path).
+template<typename scram>
+bool match_password(
+  scram_credential_cache* cache,
+  const scram_credential& cred,
+  const credential_password& password) {
+    constexpr auto mech = scram_mechanism_traits<scram>::algorithm;
+    if (cache != nullptr) {
+        auto cached = cache->get(
+          mech, password, cred.salt(), cred.iterations());
+        if (cached.has_value()) {
+            return *cached == cred.stored_key();
+        }
+    }
+    auto stored_key = scram::derive_stored_key(
+      password(), cred.salt(), cred.iterations());
+    auto valid = stored_key == cred.stored_key();
+    if (cache != nullptr) {
+        cache->put(
+          mech,
+          password,
+          cred.salt(),
+          cred.iterations(),
+          std::move(stored_key));
+    }
+    return valid;
+}
+} // namespace
+
+namespace detail {
+
 std::optional<std::string_view> validate_scram_credential(
-  const scram_credential& cred, const credential_password& password) {
+  const scram_credential& cred,
+  const credential_password& password,
+  scram_credential_cache* cache) {
     std::optional<std::string_view> sasl_mechanism;
     if (
-      cred.stored_key().size() == security::scram_sha256::key_size
-      && security::scram_sha256::validate_password(
-        password, cred.stored_key(), cred.salt(), cred.iterations())) {
-        sasl_mechanism = security::scram_sha256_authenticator::name;
+      cred.stored_key().size() == scram_sha256::key_size
+      && match_password<scram_sha256>(cache, cred, password)) {
+        sasl_mechanism = scram_sha256_authenticator::name;
     } else if (
-      cred.stored_key().size() == security::scram_sha512::key_size
-      && security::scram_sha512::validate_password(
-        password, cred.stored_key(), cred.salt(), cred.iterations())) {
-        sasl_mechanism = security::scram_sha512_authenticator::name;
+      cred.stored_key().size() == scram_sha512::key_size
+      && match_password<scram_sha512>(cache, cred, password)) {
+        sasl_mechanism = scram_sha512_authenticator::name;
     }
 
     return sasl_mechanism;
+}
+} // namespace detail
+
+std::optional<std::string_view> validate_scram_credential(
+  const scram_credential& cred, const credential_password& password) {
+    if (config::shard_local_cfg().scram_credential_cache_enabled()) {
+        static thread_local scram_credential_cache cache{
+          scram_credential_cache::default_capacity};
+        return detail::validate_scram_credential(cred, password, &cache);
+    }
+    return detail::validate_scram_credential(cred, password, nullptr);
 }
 
 } // namespace security

--- a/src/v/security/scram_authenticator.cc
+++ b/src/v/security/scram_authenticator.cc
@@ -164,8 +164,8 @@ bool match_password(
     if (cache != nullptr) {
         auto cached = cache->get(
           mech, password, cred.salt(), cred.iterations());
-        if (cached.has_value()) {
-            return *cached == cred.stored_key();
+        if (cached != nullptr) {
+            return cached->data == cred.stored_key();
         }
     }
     auto stored_key = scram::derive_stored_key(

--- a/src/v/security/scram_authenticator.h
+++ b/src/v/security/scram_authenticator.h
@@ -79,11 +79,13 @@ private:
 template<>
 struct scram_mechanism_traits<scram_sha256> {
     static constexpr const char* name = "SCRAM-SHA-256";
+    static constexpr scram_algorithm_t algorithm = scram_algorithm_t::sha256;
 };
 
 template<>
 struct scram_mechanism_traits<scram_sha512> {
     static constexpr const char* name = "SCRAM-SHA-512";
+    static constexpr scram_algorithm_t algorithm = scram_algorithm_t::sha512;
 };
 
 struct scram_sha256_authenticator {
@@ -98,7 +100,23 @@ struct scram_sha512_authenticator {
       = scram_mechanism_traits<scram_sha512>::name;
 };
 
+class scram_credential_cache;
+
+/// Validates a plaintext password against a stored SCRAM credential, for
+/// non-SCRAM authentication such as HTTP Basic auth and SASL/PLAIN. Returns
+/// the credential's SASL mechanism name on success.
+///
+/// Consults the shard's scram_credential_cache to skip the expensive salted
+/// password derivation for recently validated (password, credential) pairs,
+/// unless disabled via the scram_credential_cache_enabled config.
 std::optional<std::string_view> validate_scram_credential(
   const scram_credential& cred, const credential_password& password);
 
+namespace detail {
+/// As above, against a caller-provided cache.
+std::optional<std::string_view> validate_scram_credential(
+  const scram_credential& cred,
+  const credential_password& password,
+  scram_credential_cache* cache);
+} // namespace detail
 } // namespace security

--- a/src/v/security/scram_authenticator.h
+++ b/src/v/security/scram_authenticator.h
@@ -114,6 +114,11 @@ std::optional<std::string_view> validate_scram_credential(
 
 namespace detail {
 /// As above, against a caller-provided cache.
+///
+/// Neither the cache pointer nor any view it returns may be held across a
+/// scheduling point: a config watch may flush (destroy) the cache between
+/// suspensions. Validation is currently synchronous end to end, which is
+/// what makes them safe.
 std::optional<std::string_view> validate_scram_credential(
   const scram_credential& cred,
   const credential_password& password,

--- a/src/v/security/scram_credential_cache.cc
+++ b/src/v/security/scram_credential_cache.cc
@@ -10,9 +10,11 @@
  */
 #include "security/scram_credential_cache.h"
 
+#include "base/vlog.h"
 #include "bytes/random.h"
 #include "crypto/crypto.h"
 #include "hashing/secure.h"
+#include "security/logger.h"
 
 #include <seastar/core/shared_ptr.hh>
 
@@ -98,6 +100,35 @@ scram_credential_cache::stats_t scram_credential_cache::stats() const {
       .hits = s.hit_count,
       .misses = s.access_count - s.hit_count,
       .size = s.index_size};
+}
+
+scram_credential_cache_holder::scram_credential_cache_holder(
+  config::binding<bool> enabled, size_t capacity)
+  : _enabled(std::move(enabled))
+  , _capacity(capacity) {
+    _enabled.watch([this] {
+        if (!_enabled() && _cache) {
+            vlog(seclog.info, "SCRAM credential cache disabled, flushing");
+            _cache.reset();
+        }
+    });
+}
+
+scram_credential_cache* scram_credential_cache_holder::get() {
+    if (!_enabled()) {
+        return nullptr;
+    }
+    if (!_cache) {
+        // Constructed here rather than in the watch so that a throwing
+        // construction surfaces on the authentication path (which simply
+        // retries next call) instead of failing a config update.
+        _cache.emplace(_capacity);
+        vlog(
+          seclog.debug,
+          "SCRAM credential cache constructed, capacity {}",
+          _capacity);
+    }
+    return &*_cache;
 }
 
 } // namespace security

--- a/src/v/security/scram_credential_cache.cc
+++ b/src/v/security/scram_credential_cache.cc
@@ -11,6 +11,7 @@
 #include "security/scram_credential_cache.h"
 
 #include "bytes/random.h"
+#include "crypto/crypto.h"
 #include "hashing/secure.h"
 
 #include <seastar/core/shared_ptr.hh>
@@ -24,6 +25,10 @@ namespace {
 // The S3-FIFO probationary queue is conventionally ~10% of the cache.
 constexpr size_t small_queue_ratio = 10;
 } // namespace
+
+scram_credential_cache::zeroizing_bytes::~zeroizing_bytes() {
+    crypto::secure_erase({data.data(), data.size()});
+}
 
 scram_credential_cache::scram_credential_cache(size_t capacity)
   : _digest_key(random_generators::get_crypto_bytes(digest_size))
@@ -46,7 +51,7 @@ scram_credential_cache::key_t scram_credential_cache::make_key(
     // cannot be matched against password guesses. HMAC rather than
     // sha256(secret ‖ inputs) because direct hashing has a length-extension
     // weakness; HMAC is the standard way to key a hash with a secret.
-    hmac_sha256 mac(_digest_key);
+    hmac_sha256 mac(_digest_key.data);
     // The packing must keep field boundaries unambiguous: password and
     // salt are both variable-length fields, so the password length is
     // written first; without it, (password "ab", salt "c") and (password
@@ -63,16 +68,17 @@ scram_credential_cache::key_t scram_credential_cache::make_key(
     return {.digest = mac.reset()};
 }
 
-std::optional<bytes> scram_credential_cache::get(
+ss::shared_ptr<const scram_credential_cache::zeroizing_bytes>
+scram_credential_cache::get(
   scram_algorithm_t mech,
   const credential_password& password,
   bytes_view salt,
   int iterations) {
     auto val = _cache.get_value(make_key(mech, password, salt, iterations));
     if (!val) {
-        return std::nullopt;
+        return nullptr;
     }
-    return **val;
+    return std::move(*val);
 }
 
 void scram_credential_cache::put(
@@ -83,7 +89,7 @@ void scram_credential_cache::put(
   bytes stored_key) {
     _cache.try_insert(
       make_key(mech, password, salt, iterations),
-      ss::make_shared<bytes>(std::move(stored_key)));
+      ss::make_shared<zeroizing_bytes>(std::move(stored_key)));
 }
 
 scram_credential_cache::stats_t scram_credential_cache::stats() const {

--- a/src/v/security/scram_credential_cache.cc
+++ b/src/v/security/scram_credential_cache.cc
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "security/scram_credential_cache.h"
+
+#include "bytes/random.h"
+#include "hashing/secure.h"
+
+#include <seastar/core/shared_ptr.hh>
+
+#include <algorithm>
+#include <bit>
+
+namespace security {
+
+namespace {
+// The S3-FIFO probationary queue is conventionally ~10% of the cache.
+constexpr size_t small_queue_ratio = 10;
+} // namespace
+
+scram_credential_cache::scram_credential_cache(size_t capacity)
+  : _digest_key(random_generators::get_crypto_bytes(digest_size))
+  , _cache([capacity]() -> decltype(_cache)::config {
+      auto small_size = std::max<size_t>(1, capacity / small_queue_ratio);
+      // s3_fifo::cache requires cache_size > small_size; derive cache_size
+      // from small_size so the invariant holds even for tiny capacities.
+      return {
+        .cache_size = std::max(capacity, small_size + 1),
+        .small_size = small_size};
+  }()) {}
+
+scram_credential_cache::key_t scram_credential_cache::make_key(
+  scram_algorithm_t mech,
+  const credential_password& password,
+  bytes_view salt,
+  int iterations) const {
+    // The digest is keyed with a random per-instance secret so that cached
+    // keys are not plain password hashes: without the secret, a digest
+    // cannot be matched against password guesses. HMAC rather than
+    // sha256(secret ‖ inputs) because direct hashing has a length-extension
+    // weakness; HMAC is the standard way to key a hash with a secret.
+    hmac_sha256 mac(_digest_key);
+    // The packing must keep field boundaries unambiguous: password and
+    // salt are both variable-length fields, so the password length is
+    // written first; without it, (password "ab", salt "c") and (password
+    // "a", salt "bc") would pack to the same bytes and collide.
+    mac.update(std::array<char, 1>{static_cast<char>(mech)});
+    mac.update(
+      std::bit_cast<std::array<char, sizeof(uint32_t)>>(
+        static_cast<uint32_t>(iterations)));
+    mac.update(
+      std::bit_cast<std::array<char, sizeof(uint32_t)>>(
+        static_cast<uint32_t>(password().size())));
+    mac.update(std::string_view{password()});
+    mac.update(salt);
+    return {.digest = mac.reset()};
+}
+
+std::optional<bytes> scram_credential_cache::get(
+  scram_algorithm_t mech,
+  const credential_password& password,
+  bytes_view salt,
+  int iterations) {
+    auto val = _cache.get_value(make_key(mech, password, salt, iterations));
+    if (!val) {
+        return std::nullopt;
+    }
+    return **val;
+}
+
+void scram_credential_cache::put(
+  scram_algorithm_t mech,
+  const credential_password& password,
+  bytes_view salt,
+  int iterations,
+  bytes stored_key) {
+    _cache.try_insert(
+      make_key(mech, password, salt, iterations),
+      ss::make_shared<bytes>(std::move(stored_key)));
+}
+
+scram_credential_cache::stats_t scram_credential_cache::stats() const {
+    auto s = _cache.stat();
+    return {
+      .hits = s.hit_count,
+      .misses = s.access_count - s.hit_count,
+      .size = s.index_size};
+}
+
+} // namespace security

--- a/src/v/security/scram_credential_cache.h
+++ b/src/v/security/scram_credential_cache.h
@@ -12,6 +12,7 @@
 
 #include "base/seastarx.h"
 #include "bytes/bytes.h"
+#include "config/property.h"
 #include "security/scram_credential.h"
 #include "security/types.h"
 #include "utils/chunked_kv_cache.h"
@@ -110,6 +111,26 @@ private:
 
     zeroizing_bytes _digest_key;
     utils::chunked_kv_cache<key_t, zeroizing_bytes> _cache;
+};
+
+/// \brief Ties a shard's scram_credential_cache to its enable config.
+///
+/// get() returns the cache while enabled (constructing it on first use) and
+/// nullptr while disabled. Disabling flushes eagerly: the config watch
+/// destroys the cache, securely erasing every memoized derivation, without
+/// waiting for the next authentication on the shard. Re-enabling builds a
+/// fresh cache with a fresh digest key.
+class scram_credential_cache_holder {
+public:
+    scram_credential_cache_holder(
+      config::binding<bool> enabled, size_t capacity);
+
+    scram_credential_cache* get();
+
+private:
+    config::binding<bool> _enabled;
+    size_t _capacity;
+    std::optional<scram_credential_cache> _cache;
 };
 
 } // namespace security

--- a/src/v/security/scram_credential_cache.h
+++ b/src/v/security/scram_credential_cache.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "bytes/bytes.h"
+#include "security/scram_credential.h"
+#include "security/types.h"
+#include "utils/chunked_kv_cache.h"
+
+#include <array>
+#include <cstddef>
+#include <optional>
+
+namespace security {
+
+/// \brief Per-shard memoization of SCRAM password derivations.
+///
+/// Validating a plaintext password against a stored SCRAM credential
+/// rederives the credential's stored key (RFC 5802 `Hi`, at least 4096 HMAC
+/// rounds). HTTP Basic auth and SASL/PLAIN pay that cost on every
+/// authentication, which is expensive enough to saturate a core at a few
+/// thousand authentications per second. This cache memoizes the derivation:
+/// (algorithm, password, salt, iterations) -> stored key.
+///
+/// Entries are keyed by an HMAC (with a random per-instance key) of the
+/// inputs so plaintext passwords are not retained. The value is the stored
+/// key derived from the presented password: for a correct password this is
+/// the credential's stored key, already persisted in the credential store;
+/// an incorrect password is cached too (so repeated bad credentials stay
+/// cheap), and its derived value reveals nothing about the stored credential.
+/// Either way a memory disclosure yields no credential secret beyond what the
+/// store already holds. The memoized mapping is purely functional, so entries
+/// never go stale: updating a credential generates a fresh salt, which
+/// changes the cache key.
+class scram_credential_cache {
+public:
+    static constexpr size_t default_capacity = 1024;
+
+    struct stats_t {
+        size_t hits;
+        size_t misses;
+        size_t size;
+    };
+
+    explicit scram_credential_cache(size_t capacity);
+
+    /// Returns the memoized stored key for the derivation inputs, if any.
+    std::optional<bytes> get(
+      scram_algorithm_t mech,
+      const credential_password& password,
+      bytes_view salt,
+      int iterations);
+
+    /// Memoizes the stored key derived from the given inputs.
+    void put(
+      scram_algorithm_t mech,
+      const credential_password& password,
+      bytes_view salt,
+      int iterations,
+      bytes stored_key);
+
+    stats_t stats() const;
+
+private:
+    static constexpr size_t digest_size = 32;
+
+    struct key_t {
+        std::array<char, digest_size> digest;
+
+        bool operator==(const key_t&) const = default;
+
+        template<typename H>
+        friend H AbslHashValue(H h, const key_t& k) {
+            return H::combine(std::move(h), k.digest);
+        }
+    };
+
+    key_t make_key(
+      scram_algorithm_t mech,
+      const credential_password& password,
+      bytes_view salt,
+      int iterations) const;
+
+    bytes _digest_key;
+    utils::chunked_kv_cache<key_t, bytes> _cache;
+};
+
+} // namespace security

--- a/src/v/security/scram_credential_cache.h
+++ b/src/v/security/scram_credential_cache.h
@@ -10,10 +10,13 @@
  */
 #pragma once
 
+#include "base/seastarx.h"
 #include "bytes/bytes.h"
 #include "security/scram_credential.h"
 #include "security/types.h"
 #include "utils/chunked_kv_cache.h"
+
+#include <seastar/core/shared_ptr.hh>
 
 #include <array>
 #include <cstddef>
@@ -40,6 +43,7 @@ namespace security {
 /// store already holds. The memoized mapping is purely functional, so entries
 /// never go stale: updating a credential generates a fresh salt, which
 /// changes the cache key.
+///
 class scram_credential_cache {
 public:
     static constexpr size_t default_capacity = 1024;
@@ -50,10 +54,25 @@ public:
         size_t size;
     };
 
+    /// Secret bytes, securely erased on destruction: eviction, flush, and
+    /// shutdown all scrub the cache's secrets through this one destructor.
+    struct zeroizing_bytes {
+        explicit zeroizing_bytes(bytes b) noexcept
+          : data(std::move(b)) {}
+        zeroizing_bytes(const zeroizing_bytes&) = delete;
+        zeroizing_bytes& operator=(const zeroizing_bytes&) = delete;
+        zeroizing_bytes(zeroizing_bytes&&) = delete;
+        zeroizing_bytes& operator=(zeroizing_bytes&&) = delete;
+        ~zeroizing_bytes();
+
+        bytes data;
+    };
+
     explicit scram_credential_cache(size_t capacity);
 
-    /// Returns the memoized stored key for the derivation inputs, if any.
-    std::optional<bytes> get(
+    /// Returns the memoized stored key for the derivation inputs, or null on
+    /// a miss.
+    ss::shared_ptr<const zeroizing_bytes> get(
       scram_algorithm_t mech,
       const credential_password& password,
       bytes_view salt,
@@ -89,8 +108,8 @@ private:
       bytes_view salt,
       int iterations) const;
 
-    bytes _digest_key;
-    utils::chunked_kv_cache<key_t, bytes> _cache;
+    zeroizing_bytes _digest_key;
+    utils::chunked_kv_cache<key_t, zeroizing_bytes> _cache;
 };
 
 } // namespace security

--- a/src/v/security/tests/BUILD
+++ b/src/v/security/tests/BUILD
@@ -273,6 +273,7 @@ redpanda_cc_bench(
         "scram_credential_bench.cc",
     ],
     deps = [
+        "//src/v/config",
         "//src/v/security",
         "//src/v/ssx:sformat",
         "@seastar",

--- a/src/v/security/tests/BUILD
+++ b/src/v/security/tests/BUILD
@@ -34,6 +34,22 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_btest(
+    name = "scram_credential_cache_test",
+    timeout = "short",
+    srcs = [
+        "scram_credential_cache_test.cc",
+    ],
+    deps = [
+        "//src/v/bytes",
+        "//src/v/security",
+        "//src/v/test_utils:random_bytes",
+        "@boost//:test",
+        "@fmt",
+        "@seastar//:testing",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "plain_authenticator_test",
     timeout = "short",

--- a/src/v/security/tests/BUILD
+++ b/src/v/security/tests/BUILD
@@ -42,6 +42,7 @@ redpanda_cc_btest(
     ],
     deps = [
         "//src/v/bytes",
+        "//src/v/config",
         "//src/v/security",
         "//src/v/test_utils:random_bytes",
         "@boost//:test",

--- a/src/v/security/tests/BUILD
+++ b/src/v/security/tests/BUILD
@@ -252,6 +252,19 @@ redpanda_cc_bench(
 )
 
 redpanda_cc_bench(
+    name = "scram_credential_bench_rpbench",
+    srcs = [
+        "scram_credential_bench.cc",
+    ],
+    deps = [
+        "//src/v/security",
+        "//src/v/ssx:sformat",
+        "@seastar",
+        "@seastar//:benchmark",
+    ],
+)
+
+redpanda_cc_bench(
     name = "oidc_authenticator_bench_rpbench",
     srcs = [
         "oidc_authenticator_bench.cc",

--- a/src/v/security/tests/scram_algorithm_test.cc
+++ b/src/v/security/tests/scram_algorithm_test.cc
@@ -353,4 +353,26 @@ BOOST_AUTO_TEST_CASE(make_credentials_sets_timestamp) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(derive_stored_key_matches_credential) {
+    const ss::sstring password = "letmein-derive";
+
+    auto creds256 = scram_sha256::make_credentials(
+      password, scram_sha256::min_iterations);
+    BOOST_REQUIRE(
+      scram_sha256::derive_stored_key(
+        password, creds256.salt(), creds256.iterations())
+      == creds256.stored_key());
+    BOOST_REQUIRE(
+      scram_sha256::derive_stored_key(
+        "wrong-password", creds256.salt(), creds256.iterations())
+      != creds256.stored_key());
+
+    auto creds512 = scram_sha512::make_credentials(
+      password, scram_sha512::min_iterations);
+    BOOST_REQUIRE(
+      scram_sha512::derive_stored_key(
+        password, creds512.salt(), creds512.iterations())
+      == creds512.stored_key());
+}
+
 } // namespace security

--- a/src/v/security/tests/scram_credential_bench.cc
+++ b/src/v/security/tests/scram_credential_bench.cc
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
+#include "config/configuration.h"
 #include "security/scram_algorithm.h"
 #include "security/scram_authenticator.h"
 #include "security/types.h"
@@ -24,10 +25,12 @@
 // costs the same as a correct one: the mismatch is only detected after the
 // full derivation.
 //
-// The correct/wrong cases reuse one credential per case, so they benefit
-// from any per-credential memoization of the derivation; the
-// unique-password case uses a fresh password each call and always pays the
-// full derivation.
+// The plain cases run with the credential cache at its default (disabled)
+// and pay the full derivation on every call. The _cached group enables
+// scram_credential_cache_enabled: its correct/wrong cases reuse one
+// credential per case, so repeat calls are served from the cache, while
+// its unique-password case never repeats and always pays the full
+// derivation.
 
 namespace {
 
@@ -76,6 +79,60 @@ PERF_TEST(validate_scram_credential, sha512_correct_password) {
 // Never-repeating passwords: every call pays the full salted-password
 // derivation, with no opportunity for memoization.
 PERF_TEST(validate_scram_credential, sha256_unique_passwords) {
+    static size_t counter = 0;
+    security::credential_password unique{
+      ssx::sformat("benchpassword-{}", counter++)};
+    auto mechanism = security::validate_scram_credential(
+      sha256_credential(), unique);
+    perf_tests::do_not_optimize(mechanism);
+}
+
+namespace {
+
+// Enables the credential cache for the _cached group. The fixture is
+// constructed before each run and destroyed after it, so the config
+// toggles outside the measured region.
+struct validate_scram_credential_cached {
+    validate_scram_credential_cached() {
+        config::shard_local_cfg().scram_credential_cache_enabled.set_value(
+          true);
+    }
+    validate_scram_credential_cached(const validate_scram_credential_cached&)
+      = delete;
+    validate_scram_credential_cached&
+    operator=(const validate_scram_credential_cached&) = delete;
+    validate_scram_credential_cached(validate_scram_credential_cached&&)
+      = delete;
+    validate_scram_credential_cached&
+    operator=(validate_scram_credential_cached&&) = delete;
+    ~validate_scram_credential_cached() {
+        config::shard_local_cfg().scram_credential_cache_enabled.reset();
+    }
+};
+
+} // namespace
+
+PERF_TEST_F(validate_scram_credential_cached, sha256_correct_password) {
+    auto mechanism = security::validate_scram_credential(
+      sha256_credential(), password());
+    perf_tests::do_not_optimize(mechanism);
+}
+
+PERF_TEST_F(validate_scram_credential_cached, sha256_wrong_password) {
+    auto mechanism = security::validate_scram_credential(
+      sha256_credential(), wrong_password());
+    perf_tests::do_not_optimize(mechanism);
+}
+
+PERF_TEST_F(validate_scram_credential_cached, sha512_correct_password) {
+    auto mechanism = security::validate_scram_credential(
+      sha512_credential(), password());
+    perf_tests::do_not_optimize(mechanism);
+}
+
+// No hit is possible, so every call pays the full derivation plus the
+// cache lookup and insertion overhead.
+PERF_TEST_F(validate_scram_credential_cached, sha256_unique_passwords) {
     static size_t counter = 0;
     security::credential_password unique{
       ssx::sformat("benchpassword-{}", counter++)};

--- a/src/v/security/tests/scram_credential_bench.cc
+++ b/src/v/security/tests/scram_credential_bench.cc
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "security/scram_algorithm.h"
+#include "security/scram_authenticator.h"
+#include "security/types.h"
+#include "ssx/sformat.h"
+
+#include <seastar/testing/perf_tests.hh>
+
+// Measures security::validate_scram_credential, the password check that
+// request_authenticator::do_authenticate runs on every HTTP Basic auth
+// request (pandaproxy, schema registry, admin API). The PBKDF2-style
+// salted-password derivation (scram_algorithm::hi, min_iterations = 4096
+// HMAC rounds) is what pegged pandaproxy CPU in INC-2882. A wrong password
+// costs the same as a correct one: the mismatch is only detected after the
+// full derivation.
+//
+// The correct/wrong cases reuse one credential per case, so they benefit
+// from any per-credential memoization of the derivation; the
+// unique-password case uses a fresh password each call and always pays the
+// full derivation.
+
+namespace {
+
+const security::credential_password& password() {
+    static const security::credential_password p{"benchpassword"};
+    return p;
+}
+
+const security::credential_password& wrong_password() {
+    static const security::credential_password p{"wrongpassword"};
+    return p;
+}
+
+const security::scram_credential& sha256_credential() {
+    static const auto cred = security::scram_sha256::make_credentials(
+      password()(), security::scram_sha256::min_iterations);
+    return cred;
+}
+
+const security::scram_credential& sha512_credential() {
+    static const auto cred = security::scram_sha512::make_credentials(
+      password()(), security::scram_sha512::min_iterations);
+    return cred;
+}
+
+} // namespace
+
+PERF_TEST(validate_scram_credential, sha256_correct_password) {
+    auto mechanism = security::validate_scram_credential(
+      sha256_credential(), password());
+    perf_tests::do_not_optimize(mechanism);
+}
+
+PERF_TEST(validate_scram_credential, sha256_wrong_password) {
+    auto mechanism = security::validate_scram_credential(
+      sha256_credential(), wrong_password());
+    perf_tests::do_not_optimize(mechanism);
+}
+
+PERF_TEST(validate_scram_credential, sha512_correct_password) {
+    auto mechanism = security::validate_scram_credential(
+      sha512_credential(), password());
+    perf_tests::do_not_optimize(mechanism);
+}
+
+// Never-repeating passwords: every call pays the full salted-password
+// derivation, with no opportunity for memoization.
+PERF_TEST(validate_scram_credential, sha256_unique_passwords) {
+    static size_t counter = 0;
+    security::credential_password unique{
+      ssx::sformat("benchpassword-{}", counter++)};
+    auto mechanism = security::validate_scram_credential(
+      sha256_credential(), unique);
+    perf_tests::do_not_optimize(mechanism);
+}

--- a/src/v/security/tests/scram_credential_cache_test.cc
+++ b/src/v/security/tests/scram_credential_cache_test.cc
@@ -39,16 +39,16 @@ BOOST_AUTO_TEST_CASE(cache_miss_then_hit) {
     auto stored_key = tests::random_bytes(32);
 
     BOOST_REQUIRE(
-      !cache.get(scram_algorithm_t::sha256, password(), salt, iterations)
-         .has_value());
+      cache.get(scram_algorithm_t::sha256, password(), salt, iterations)
+      == nullptr);
 
     cache.put(
       scram_algorithm_t::sha256, password(), salt, iterations, stored_key);
 
     auto hit = cache.get(
       scram_algorithm_t::sha256, password(), salt, iterations);
-    BOOST_REQUIRE(hit.has_value());
-    BOOST_REQUIRE(*hit == stored_key);
+    BOOST_REQUIRE(hit != nullptr);
+    BOOST_REQUIRE(hit->data == stored_key);
 
     auto stats = cache.stats();
     BOOST_REQUIRE_EQUAL(stats.hits, 1);
@@ -66,28 +66,28 @@ BOOST_AUTO_TEST_CASE(cache_key_includes_all_inputs) {
     // Same inputs: hit.
     BOOST_REQUIRE(
       cache.get(scram_algorithm_t::sha256, password(), salt, iterations)
-        .has_value());
+      != nullptr);
     // Different password: miss.
-    BOOST_REQUIRE(!cache
-                     .get(
-                       scram_algorithm_t::sha256,
-                       credential_password{"other-password"},
-                       salt,
-                       iterations)
-                     .has_value());
+    BOOST_REQUIRE(
+      cache.get(
+        scram_algorithm_t::sha256,
+        credential_password{"other-password"},
+        salt,
+        iterations)
+      == nullptr);
     // Different salt (i.e. the credential was updated): miss.
     auto other_salt = tests::random_bytes(16);
     BOOST_REQUIRE(
-      !cache.get(scram_algorithm_t::sha256, password(), other_salt, iterations)
-         .has_value());
+      cache.get(scram_algorithm_t::sha256, password(), other_salt, iterations)
+      == nullptr);
     // Different iteration count: miss.
     BOOST_REQUIRE(
-      !cache.get(scram_algorithm_t::sha256, password(), salt, iterations * 2)
-         .has_value());
+      cache.get(scram_algorithm_t::sha256, password(), salt, iterations * 2)
+      == nullptr);
     // Different mechanism: miss.
     BOOST_REQUIRE(
-      !cache.get(scram_algorithm_t::sha512, password(), salt, iterations)
-         .has_value());
+      cache.get(scram_algorithm_t::sha512, password(), salt, iterations)
+      == nullptr);
 }
 
 BOOST_AUTO_TEST_CASE(cache_is_bounded) {
@@ -105,13 +105,13 @@ BOOST_AUTO_TEST_CASE(cache_is_bounded) {
     }
 
     // A one-hit-wonder inserted early must have been evicted.
-    BOOST_REQUIRE(!cache
-                     .get(
-                       scram_algorithm_t::sha256,
-                       credential_password{"password-0"},
-                       salt,
-                       iterations)
-                     .has_value());
+    BOOST_REQUIRE(
+      cache.get(
+        scram_algorithm_t::sha256,
+        credential_password{"password-0"},
+        salt,
+        iterations)
+      == nullptr);
     // The index may retain evicted (ghost) entries, but remains bounded well
     // below the number of insertions.
     BOOST_REQUIRE_LT(cache.stats().size, capacity * 5);
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(cache_tiny_capacity_does_not_crash) {
           scram_algorithm_t::sha256, password(), salt, iterations, stored_key);
         BOOST_REQUIRE(
           cache.get(scram_algorithm_t::sha256, password(), salt, iterations)
-            .has_value());
+          != nullptr);
     }
 }
 

--- a/src/v/security/tests/scram_credential_cache_test.cc
+++ b/src/v/security/tests/scram_credential_cache_test.cc
@@ -11,6 +11,8 @@
 #define BOOST_TEST_MODULE security
 
 #include "bytes/bytes.h"
+#include "config/configuration.h"
+#include "config/mock_property.h"
 #include "security/scram_algorithm.h"
 #include "security/scram_authenticator.h"
 #include "security/scram_credential_cache.h"
@@ -191,6 +193,63 @@ BOOST_AUTO_TEST_CASE(cached_validate_scram_credential_password_change) {
     BOOST_REQUIRE(
       !detail::validate_scram_credential(new_cred, password(), &cache)
          .has_value());
+}
+
+BOOST_AUTO_TEST_CASE(holder_disabled_returns_no_cache) {
+    config::mock_property<bool> enabled(false);
+    scram_credential_cache_holder holder(enabled.bind(), 16);
+    BOOST_REQUIRE(holder.get() == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(holder_flushes_on_disable) {
+    config::mock_property<bool> enabled(true);
+    scram_credential_cache_holder holder(enabled.bind(), 16);
+    auto salt = tests::random_bytes(16);
+    auto stored_key = tests::random_bytes(32);
+
+    auto* cache = holder.get();
+    BOOST_REQUIRE(cache != nullptr);
+    cache->put(
+      scram_algorithm_t::sha256, password(), salt, iterations, stored_key);
+    BOOST_REQUIRE(
+      cache->get(scram_algorithm_t::sha256, password(), salt, iterations)
+      != nullptr);
+
+    // Disabling flushes: the cache is destroyed eagerly, without waiting for
+    // the next authentication.
+    enabled.update(false);
+    BOOST_REQUIRE(holder.get() == nullptr);
+
+    // Re-enabling builds a fresh cache: the old entry is gone.
+    enabled.update(true);
+    auto* fresh = holder.get();
+    BOOST_REQUIRE(fresh != nullptr);
+    BOOST_REQUIRE(
+      fresh->get(scram_algorithm_t::sha256, password(), salt, iterations)
+      == nullptr);
+    BOOST_REQUIRE_EQUAL(fresh->stats().size, 0);
+}
+
+BOOST_AUTO_TEST_CASE(public_validate_survives_config_toggling) {
+    auto& enabled = config::shard_local_cfg().scram_credential_cache_enabled;
+    auto cred = scram_sha256::make_credentials(
+      password()(), scram_sha256::min_iterations);
+
+    enabled.set_value(true);
+    BOOST_REQUIRE(validate_scram_credential(cred, password()).has_value());
+    BOOST_REQUIRE(validate_scram_credential(cred, password()).has_value());
+
+    // Disable mid-stream: validation falls back to plain derivation.
+    enabled.set_value(false);
+    BOOST_REQUIRE(validate_scram_credential(cred, password()).has_value());
+
+    // Re-enable: caching resumes with a fresh cache.
+    enabled.set_value(true);
+    BOOST_REQUIRE(validate_scram_credential(cred, password()).has_value());
+    const credential_password wrong{"wrong-password"};
+    BOOST_REQUIRE(!validate_scram_credential(cred, wrong).has_value());
+
+    enabled.reset();
 }
 
 } // namespace security

--- a/src/v/security/tests/scram_credential_cache_test.cc
+++ b/src/v/security/tests/scram_credential_cache_test.cc
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#define BOOST_TEST_MODULE security
+
+#include "bytes/bytes.h"
+#include "security/scram_credential_cache.h"
+#include "security/types.h"
+#include "test_utils/random_bytes.h"
+
+#include <boost/test/unit_test.hpp>
+#include <fmt/format.h>
+
+namespace security {
+
+namespace {
+
+const credential_password& password() {
+    static const credential_password p{"cache-test-password"};
+    return p;
+}
+
+constexpr int iterations = 4096;
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(cache_miss_then_hit) {
+    scram_credential_cache cache(16);
+    auto salt = tests::random_bytes(16);
+    auto stored_key = tests::random_bytes(32);
+
+    BOOST_REQUIRE(
+      !cache.get(scram_algorithm_t::sha256, password(), salt, iterations)
+         .has_value());
+
+    cache.put(
+      scram_algorithm_t::sha256, password(), salt, iterations, stored_key);
+
+    auto hit = cache.get(
+      scram_algorithm_t::sha256, password(), salt, iterations);
+    BOOST_REQUIRE(hit.has_value());
+    BOOST_REQUIRE(*hit == stored_key);
+
+    auto stats = cache.stats();
+    BOOST_REQUIRE_EQUAL(stats.hits, 1);
+    BOOST_REQUIRE_EQUAL(stats.misses, 1);
+}
+
+BOOST_AUTO_TEST_CASE(cache_key_includes_all_inputs) {
+    scram_credential_cache cache(16);
+    auto salt = tests::random_bytes(16);
+    auto stored_key = tests::random_bytes(32);
+
+    cache.put(
+      scram_algorithm_t::sha256, password(), salt, iterations, stored_key);
+
+    // Same inputs: hit.
+    BOOST_REQUIRE(
+      cache.get(scram_algorithm_t::sha256, password(), salt, iterations)
+        .has_value());
+    // Different password: miss.
+    BOOST_REQUIRE(!cache
+                     .get(
+                       scram_algorithm_t::sha256,
+                       credential_password{"other-password"},
+                       salt,
+                       iterations)
+                     .has_value());
+    // Different salt (i.e. the credential was updated): miss.
+    auto other_salt = tests::random_bytes(16);
+    BOOST_REQUIRE(
+      !cache.get(scram_algorithm_t::sha256, password(), other_salt, iterations)
+         .has_value());
+    // Different iteration count: miss.
+    BOOST_REQUIRE(
+      !cache.get(scram_algorithm_t::sha256, password(), salt, iterations * 2)
+         .has_value());
+    // Different mechanism: miss.
+    BOOST_REQUIRE(
+      !cache.get(scram_algorithm_t::sha512, password(), salt, iterations)
+         .has_value());
+}
+
+BOOST_AUTO_TEST_CASE(cache_is_bounded) {
+    constexpr size_t capacity = 16;
+    scram_credential_cache cache(capacity);
+    auto salt = tests::random_bytes(16);
+
+    for (size_t i = 0; i < capacity * 10; ++i) {
+        cache.put(
+          scram_algorithm_t::sha256,
+          credential_password{fmt::format("password-{}", i)},
+          salt,
+          iterations,
+          tests::random_bytes(32));
+    }
+
+    // A one-hit-wonder inserted early must have been evicted.
+    BOOST_REQUIRE(!cache
+                     .get(
+                       scram_algorithm_t::sha256,
+                       credential_password{"password-0"},
+                       salt,
+                       iterations)
+                     .has_value());
+    // The index may retain evicted (ghost) entries, but remains bounded well
+    // below the number of insertions.
+    BOOST_REQUIRE_LT(cache.stats().size, capacity * 5);
+}
+
+BOOST_AUTO_TEST_CASE(cache_tiny_capacity_does_not_crash) {
+    // The S3-FIFO backing asserts cache_size > small_size; capacities below
+    // that minimum must be floored rather than trip the assertion.
+    for (size_t capacity : {size_t{0}, size_t{1}, size_t{2}}) {
+        scram_credential_cache cache(capacity);
+        auto salt = tests::random_bytes(16);
+        auto stored_key = tests::random_bytes(32);
+        cache.put(
+          scram_algorithm_t::sha256, password(), salt, iterations, stored_key);
+        BOOST_REQUIRE(
+          cache.get(scram_algorithm_t::sha256, password(), salt, iterations)
+            .has_value());
+    }
+}
+
+} // namespace security

--- a/src/v/security/tests/scram_credential_cache_test.cc
+++ b/src/v/security/tests/scram_credential_cache_test.cc
@@ -11,6 +11,8 @@
 #define BOOST_TEST_MODULE security
 
 #include "bytes/bytes.h"
+#include "security/scram_algorithm.h"
+#include "security/scram_authenticator.h"
 #include "security/scram_credential_cache.h"
 #include "security/types.h"
 #include "test_utils/random_bytes.h"
@@ -128,6 +130,67 @@ BOOST_AUTO_TEST_CASE(cache_tiny_capacity_does_not_crash) {
           cache.get(scram_algorithm_t::sha256, password(), salt, iterations)
             .has_value());
     }
+}
+
+BOOST_AUTO_TEST_CASE(cached_validate_scram_credential) {
+    scram_credential_cache cache(16);
+    auto cred = scram_sha256::make_credentials(
+      password()(), scram_sha256::min_iterations);
+
+    auto mech = detail::validate_scram_credential(cred, password(), &cache);
+    BOOST_REQUIRE(mech.has_value());
+    BOOST_REQUIRE_EQUAL(*mech, scram_sha256_authenticator::name);
+    BOOST_REQUIRE_EQUAL(cache.stats().hits, 0);
+
+    // Repeat validation is served from the cache with the same result.
+    mech = detail::validate_scram_credential(cred, password(), &cache);
+    BOOST_REQUIRE(mech.has_value());
+    BOOST_REQUIRE_EQUAL(*mech, scram_sha256_authenticator::name);
+    BOOST_REQUIRE_EQUAL(cache.stats().hits, 1);
+
+    // A wrong password fails, and keeps failing once its derivation is
+    // cached.
+    const credential_password wrong{"wrong-password"};
+    BOOST_REQUIRE(
+      !detail::validate_scram_credential(cred, wrong, &cache).has_value());
+    BOOST_REQUIRE(
+      !detail::validate_scram_credential(cred, wrong, &cache).has_value());
+}
+
+BOOST_AUTO_TEST_CASE(cached_validate_scram_credential_sha512) {
+    scram_credential_cache cache(16);
+    auto cred = scram_sha512::make_credentials(
+      password()(), scram_sha512::min_iterations);
+
+    for (int i = 0; i < 2; ++i) {
+        auto mech = detail::validate_scram_credential(cred, password(), &cache);
+        BOOST_REQUIRE(mech.has_value());
+        BOOST_REQUIRE_EQUAL(*mech, scram_sha512_authenticator::name);
+    }
+    BOOST_REQUIRE_EQUAL(cache.stats().hits, 1);
+}
+
+BOOST_AUTO_TEST_CASE(cached_validate_scram_credential_password_change) {
+    scram_credential_cache cache(16);
+    auto cred = scram_sha256::make_credentials(
+      password()(), scram_sha256::min_iterations);
+
+    // Warm the cache with the old credential.
+    BOOST_REQUIRE(detail::validate_scram_credential(cred, password(), &cache));
+    BOOST_REQUIRE(detail::validate_scram_credential(cred, password(), &cache));
+
+    // The user's password is changed: the new credential gets a fresh salt.
+    const credential_password new_password{"brand-new-password"};
+    auto new_cred = scram_sha256::make_credentials(
+      new_password(), scram_sha256::min_iterations);
+
+    // The stale cache entries do not interfere in either direction.
+    BOOST_REQUIRE(
+      detail::validate_scram_credential(new_cred, new_password, &cache)
+        .has_value());
+    BOOST_REQUIRE(
+      !detail::validate_scram_credential(new_cred, password(), &cache)
+         .has_value());
 }
 
 } // namespace security


### PR DESCRIPTION
HTTP Basic auth (PandaProxy, Schema Registry, Admin API) and Kafka SASL/PLAIN
rederive the credential's stored SCRAM key on every request: a PBKDF2-style
loop of >=4096 HMAC rounds, run on-reactor before the body is parsed. Under
high-rate authenticated traffic this dominates CPU. A cluster serving a few
hundred HTTP-produce req/s per shard through PandaProxy saturated its reactor
core almost entirely in this path (~45% of on-CPU time in
`validate_scram_credential`), starving heartbeats.

This memoizes the derivation with a bounded per-shard cache, keyed by an HMAC
of (algorithm, password, salt, iterations) and holding only the derived stored
key (already in the credential store). It is purely functional, so a password
change re-salts and re-keys and entries never go stale.

The cache is gated by the `scram_credential_cache_enabled` cluster config and
**ships disabled by default** — strictly opt-in, out-of-the-box behavior is
unchanged. Entries are erased (`OPENSSL_cleanse`) on eviction, flush, and
shutdown, and disabling the config flushes every shard's cache eagerly.

Fixes [CORE-16829]

### Security considerations (for review)

- Only the derived stored key is cached — the value already persisted in the
  credential store; no plaintext or salted password is retained.
- The cache key is an HMAC of (algorithm, password, salt, iterations) under a
  random per-boot key, so a memory dump exposes no offline-crackable material
  and keys can't be correlated across shards or reboots.
- Every hit re-compares the cached stored key against the credential's live
  stored key, so a rotated credential (re-salted, hence re-keyed) or a
  cache-key collision fails closed. A false accept would require colliding both
  the HMAC key and the SCRAM stored key at once — two independent SHA
  collisions, one under a secret key — negligible and no weaker than SCRAM's
  existing assumptions.
- Hits (~0.6 µs) and misses (~0.4 ms) are timing-distinguishable, but both
  correct and wrong passwords are cached, so a hit only reveals that an exact
  (user, password) was tried recently — not whether it is correct. Correctness
  still comes from the 200/401 response, and distinct guesses (a dictionary
  attack) always miss. Caching failed validations also keeps bad-credential
  floods cheap.
- Entries and the per-instance HMAC key scrub themselves through one
  destructor, and lookups return non-owning views so hits never leave an
  uncleansed heap copy.

### Microbench (`--config=release`, single core)

Repeat = same credential per call (steady-state auth); unique = fresh password
per call (cache-miss path).

| Validation case                        | Disabled (default) | Enabled | Speedup   |
| -------------------------------------- | ------------------ | ------- | --------- |
| SHA-256, correct password (repeat)     | 391 µs             | 558 ns  | ~700x     |
| SHA-256, wrong password (repeat)       | 392 µs             | 568 ns  | ~690x     |
| SHA-512, correct password (repeat)     | 1.04 ms            | 554 ns  | ~1,880x   |
| SHA-256, unique password (cache miss)  | 390 µs             | 396 µs  | unchanged |

### End-to-end (single core, unbatched ~2 KiB HTTP produce)

| Scenario                              | Disabled (default)     | Enabled                  |
| ------------------------------------- | ---------------------- | ------------------------ |
| Basic-auth produce                    | 288 req/s, 3.43 ms/req | 635 req/s, 1.56 ms/req   |
| No-auth baseline (same path, no auth) | 589 req/s, 1.68 ms/req | 660 req/s, 1.50 ms/req   |
| Basic-auth, 50% empty-body requests   | 336 req/s, 2.96 ms/req | 1,354 req/s, 0.74 ms/req |

The cache is disabled by default, so out-of-the-box throughput is the Disabled
column. Enabling it (`scram_credential_cache_enabled=true`) raises Basic-auth
throughput to match the no-auth baseline; toggling it back off returns to the
Disabled numbers, so the config gates the behavior cleanly in both directions.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none


[CORE-16829]: https://redpandadata.atlassian.net/browse/CORE-16829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
