### PR TITLE
rptest: tolerate transient errors in await_user_exists

### DIFF
--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -1410,7 +1410,14 @@ class Admin:
     ):
         def user_exists():
             for node in self.redpanda.started_nodes():
-                users = self.list_users(node=node)
+                try:
+                    users = self.list_users(node=node)
+                except RequestException as e:
+                    self.redpanda.logger.debug(
+                        f"await_user_exists: transient error listing users on "
+                        f"{node.account.hostname}, retrying: {e}"
+                    )
+                    return False
                 if username not in users:
                     return False
             return True


### PR DESCRIPTION
## What

Make the `create_user(await_exists=True)` readback poll tolerate transient
request failures so `wait_until` can retry instead of failing the test on a
single connection reset.

## Why

`redpanda.start()` calls `Admin.create_user(*superuser, await_exists=True)`,
which polls `await_user_exists()` → `user_exists()` → `list_users(node=node)`.
A single transient `ConnectionResetError(104)` on the admin port during early
cluster startup was fatal because:
1. `list_users` passes an explicit `node=`, so `_request` sets
   `retry_connection = False` — the node-fallback retry only runs for
   random-node (`node=None`) calls.
2. The admin session's `Retry` is built with `connect=0, read=0,
   status_forcelist=[503]`, so urllib3 does zero connection-level retries.
3. `wait_until` does not swallow the raised exception, so it propagates
   straight up and never gets to retry.
The result is a startup connection-reset flake (not a product bug).

## Fix

Catch `RequestException` in the `user_exists()` poll and return `False`, so
`wait_until` retries within its existing timeout. This mirrors the pattern
already used by `node_supports_feature` and `get_stable_configuration` in the
same file. `RequestException` is already imported, and the change is scoped to
the startup readback path only — it does not touch `_request`'s deliberate
no-connection-retry design.

## Backports Required

- [ x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none