### PR TITLE
tests/rptest: expose L0 GC unreadability after a storage-mode flip

### DIFF
--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -282,6 +282,7 @@ redpanda_cc_library(
         "//src/v/cloud_io:admission_control_types",
         "//src/v/model",
         "//src/v/utils:to_string",
+        "@seastar",
     ],
 )
 

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -45,6 +45,12 @@ level_zero_log_reader_impl::level_zero_log_reader_impl(
       _config.max_bytes, _ct_api->materialize_max_bytes());
 }
 
+level_zero_log_reader_impl::~level_zero_log_reader_impl() {
+    if (_config.max_placeholder_offset) {
+        _config.max_placeholder_offset->set_value(_max_placeholder_offset);
+    }
+}
+
 ss::future<model::record_batch_reader::storage_t>
 level_zero_log_reader_impl::do_load_slice(
   model::timeout_clock::time_point deadline) {
@@ -293,6 +299,7 @@ level_zero_log_reader_impl::fetch_metadata(
     // Convert L0 meta batches to extent_meta structures.
     struct metadata_consumer {
         chunked_circular_buffer<local_log_batch> ret;
+        kafka::offset* max_placeholder_offset;
 
         ss::future<ss::stop_iteration> operator()(model::record_batch batch) {
             auto header = batch.header();
@@ -309,6 +316,8 @@ level_zero_log_reader_impl::fetch_metadata(
               .base_offset = model::offset_cast(batch.base_offset()),
               .last_offset = model::offset_cast(batch.last_offset()),
             };
+            *max_placeholder_offset = std::max(
+              *max_placeholder_offset, e.last_offset);
             auto placeholder = parse_placeholder_batch(std::move(batch));
             e.id = placeholder.id;
             e.first_byte_offset = placeholder.offset;
@@ -322,7 +331,9 @@ level_zero_log_reader_impl::fetch_metadata(
         }
     };
 
-    co_return co_await std::move(reader).consume(metadata_consumer{}, deadline);
+    co_return co_await std::move(reader).consume(
+      metadata_consumer{.max_placeholder_offset = &_max_placeholder_offset},
+      deadline);
 }
 
 ss::future<std::expected<chunked_circular_buffer<model::record_batch>, errc>>

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
@@ -76,6 +76,10 @@ public:
       ss::lw_shared_ptr<cluster::partition> underlying,
       data_plane_api* ct_api);
 
+    // Resolves the config's max_placeholder_offset out-channel (if any) with
+    // the largest placeholder offset observed by the metadata pass.
+    ~level_zero_log_reader_impl() override;
+
     bool is_end_of_stream() const final;
 
     ss::future<model::record_batch_reader::storage_t>
@@ -155,6 +159,10 @@ private:
     bool _end_of_stream{false};
 
     cloud_topic_log_reader_config _config;
+    // Largest last-offset among the placeholder batches observed by
+    // fetch_metadata (a const method, hence mutable): feeds the
+    // max_placeholder_offset out-channel on destruction.
+    mutable kafka::offset _max_placeholder_offset{kafka::offset::min()};
     kafka::offset _next_offset;
     ss::lw_shared_ptr<cluster::partition> _ctp;
     data_plane_api* _ct_api;

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
@@ -121,24 +121,45 @@ ss::future<std::expected<std::monostate, ctp_stm_api_errc>>
 ctp_stm_api::advance_reconciled_offset(
   kafka::offset lro,
   model::timeout_clock::time_point deadline,
-  ss::abort_source& as) {
-    if (lro <= get_last_reconciled_offset()) {
+  ss::abort_source& as,
+  std::optional<kafka::offset> min_allowed_local_threshold) {
+    // The floor is monotonic: drop targets the state already covers.
+    if (
+      min_allowed_local_threshold.has_value()
+      && *min_allowed_local_threshold <= get_min_allowed_local_threshold()) {
+        min_allowed_local_threshold.reset();
+    }
+    const bool advances_lro = lro > get_last_reconciled_offset();
+    if (!advances_lro && !min_allowed_local_threshold.has_value()) {
         co_return std::monostate{};
     }
 
-    auto lrlo = _stm->_raft->log()->to_log_offset(kafka::offset_cast(lro));
-
-    vlog(
-      _log.debug,
-      "Replicating ctp_stm_cmd::advance_reconciled_offset{{lro:{} lrlo:{}}}",
-      lro,
-      lrlo);
-
     storage::record_batch_builder builder(
       model::record_batch_type::ctp_stm_command, model::offset(0));
-    builder.add_raw_kv(
-      serde::to_iobuf(advance_reconciled_offset_cmd::key),
-      serde::to_iobuf(advance_reconciled_offset_cmd(lro, lrlo)));
+
+    if (advances_lro) {
+        auto lrlo = _stm->_raft->log()->to_log_offset(kafka::offset_cast(lro));
+        vlog(
+          _log.debug,
+          "Replicating ctp_stm_cmd::advance_reconciled_offset{{lro:{} "
+          "lrlo:{}}}",
+          lro,
+          lrlo);
+        builder.add_raw_kv(
+          serde::to_iobuf(advance_reconciled_offset_cmd::key),
+          serde::to_iobuf(advance_reconciled_offset_cmd(lro, lrlo)));
+    }
+    if (min_allowed_local_threshold.has_value()) {
+        vlog(
+          _log.debug,
+          "Replicating ctp_stm_cmd::set_min_allowed_local_threshold{{{}}} "
+          "alongside the LRO advance",
+          *min_allowed_local_threshold);
+        builder.add_raw_kv(
+          serde::to_iobuf(set_min_allowed_local_threshold_cmd::key),
+          serde::to_iobuf(
+            set_min_allowed_local_threshold_cmd(*min_allowed_local_threshold)));
+    }
 
     auto batch = std::move(builder).build();
     auto apply_result = co_await replicated_apply(

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.h
@@ -70,11 +70,20 @@ public:
     /// Get threshold offset for local readers
     kafka::offset get_min_allowed_local_threshold() const;
 
+    /// Replicate an advance_reconciled_offset_cmd, optionally combined with
+    /// a set_min_allowed_local_threshold_cmd in the same record batch so
+    /// both advance atomically. The min_allowed_local_threshold is used by
+    /// the reconciler to move the local-read floor over placeholder-backed
+    /// ranges it has reconciled into L1: once the floor passes them, reads
+    /// are served from L1 and the placeholders' L0 objects may be safely
+    /// garbage-collected. Values that do not advance the current floor are
+    /// ignored.
     ss::future<std::expected<std::monostate, ctp_stm_api_errc>>
     advance_reconciled_offset(
       kafka::offset last_reconciled_offset,
       model::timeout_clock::time_point deadline,
-      ss::abort_source& as);
+      ss::abort_source& as,
+      std::optional<kafka::offset> min_allowed_local_threshold = std::nullopt);
 
     ss::future<std::expected<std::monostate, ctp_stm_api_errc>>
     set_start_offset(

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -312,6 +312,49 @@ TEST_F_CORO(ctp_stm_fixture, test_last_reconciled_offset) {
     ASSERT_FALSE_CORO(gc_epoch_after->has_value());
 }
 
+TEST_F_CORO(ctp_stm_fixture, advance_reconciled_offset_with_local_threshold) {
+    // The reconciler can piggyback a min_allowed_local_threshold advance on
+    // the LRO advance; both commands travel in one record batch and apply
+    // atomically.
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+    ss::abort_source as;
+
+    auto leader_api = api(node(*get_leader()));
+    ASSERT_EQ_CORO(
+      leader_api.get_min_allowed_local_threshold(), kafka::offset::min());
+
+    // LRO + floor advance in one shot.
+    auto res = co_await leader_api.advance_reconciled_offset(
+      kafka::offset{10}, model::no_timeout, as, kafka::offset{5});
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(leader_api.get_last_reconciled_offset(), kafka::offset{10});
+    ASSERT_EQ_CORO(
+      leader_api.get_min_allowed_local_threshold(), kafka::offset{5});
+
+    // A floor target the state already covers is dropped; the LRO still
+    // advances.
+    res = co_await leader_api.advance_reconciled_offset(
+      kafka::offset{20}, model::no_timeout, as, kafka::offset{5});
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(leader_api.get_last_reconciled_offset(), kafka::offset{20});
+    ASSERT_EQ_CORO(
+      leader_api.get_min_allowed_local_threshold(), kafka::offset{5});
+
+    // A floor advance without an LRO advance still replicates.
+    res = co_await leader_api.advance_reconciled_offset(
+      kafka::offset{20}, model::no_timeout, as, kafka::offset{15});
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(leader_api.get_last_reconciled_offset(), kafka::offset{20});
+    ASSERT_EQ_CORO(
+      leader_api.get_min_allowed_local_threshold(), kafka::offset{15});
+
+    // Neither advances: no-op.
+    res = co_await leader_api.advance_reconciled_offset(
+      kafka::offset{20}, model::no_timeout, as, kafka::offset{15});
+    ASSERT_TRUE_CORO(res.has_value());
+}
+
 TEST_F_CORO(ctp_stm_fixture, test_truncate_all_epochs) {
     // This test gradually adds epochs and removes them by advancing the
     // reconciled offset. It checks that the epochs are removed correctly and

--- a/src/v/cloud_topics/log_reader_config.h
+++ b/src/v/cloud_topics/log_reader_config.h
@@ -17,6 +17,9 @@
 #include "model/record_batch_types.h"
 #include "model/timestamp.h"
 
+#include <seastar/core/future.hh>
+#include <seastar/core/shared_ptr.hh>
+
 #include <optional>
 #include <ostream>
 
@@ -108,6 +111,15 @@ struct cloud_topic_log_reader_config {
 
     // cloud_io admission lane for this reader's cloud storage requests.
     cloud_io::group_id group{cloud_io::group_id::default_group};
+
+    // Out-channel for placeholder tracking: when set, the L0 reader resolves
+    // the promise on destruction with the largest last-offset of the
+    // placeholder batches it observed while scanning the local log, or
+    // kafka::offset::min() if it observed none. The observation may extend
+    // past the range actually delivered to the consumer (the metadata pass
+    // reads ahead of materialization), so consumers must clamp it to the
+    // range they act on.
+    ss::lw_shared_ptr<ss::promise<kafka::offset>> max_placeholder_offset{};
 
     fmt::iterator format_to(fmt::iterator it) const;
 };

--- a/src/v/cloud_topics/reconciler/BUILD
+++ b/src/v/cloud_topics/reconciler/BUILD
@@ -72,6 +72,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics/level_zero/stm:ctp_stm_api",
         "//src/v/cluster:fwd",
         "//src/v/config",
+        "//src/v/features",
         "//src/v/kafka/utils:txn_reader",
         "//src/v/metrics",
         "//src/v/utils:retry_chain_node",

--- a/src/v/cloud_topics/reconciler/reconciliation_source.cc
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.cc
@@ -19,6 +19,7 @@
 #include "cloud_topics/logger.h"
 #include "cluster/partition.h"
 #include "config/configuration.h"
+#include "features/feature_table.h"
 #include "kafka/utils/txn_reader.h"
 #include "model/fundamental.h"
 #include "model/record_batch_reader.h"
@@ -92,9 +93,24 @@ public:
 
     ss::future<std::expected<void, errc>> set_last_reconciled_offset(
       kafka::offset offset, ss::abort_source& as) override {
+        // The floor may only cover placeholder-backed data that this commit
+        // makes readable from L1: clamp the reader's observation to the
+        // committed LRO (the metadata pass may have scanned ahead of it).
+        // The feature gate is checked at the propagation point as well as
+        // at observation time: the set_min_allowed_local_threshold stm
+        // command cannot be applied by pre-v26.2 replicas, so it must never
+        // be replicated before the cluster is fully upgraded.
+        std::optional<kafka::offset> min_allowed_local_threshold;
+        if (
+          auto hwm = harvest_placeholder_observation();
+          hwm.has_value()
+          && _partition->feature_table().local().is_active(
+            features::feature::tiered_cloud_topics)) {
+            min_allowed_local_threshold = std::min(offset, *hwm);
+        }
         ctp_stm_api api(_partition->raft()->stm_manager()->get<ctp_stm>());
         auto res = co_await api.advance_reconciled_offset(
-          offset, model::no_timeout, as);
+          offset, model::no_timeout, as, min_allowed_local_threshold);
         if (!res.has_value()) {
             switch (res.error()) {
             case ctp_stm_api_errc::timeout:
@@ -149,6 +165,21 @@ public:
         if (cfg.max_offset < cfg.start_offset) {
             co_return model::make_empty_record_batch_reader();
         }
+        discard_placeholder_observation();
+        if (
+          _partition->feature_table().local().is_active(
+            features::feature::tiered_cloud_topics)) {
+            // Ask the reader to report the placeholder-backed high watermark
+            // of the range it scans; the commit path advances the local-read
+            // floor (min_allowed_local_threshold) over it, so that data
+            // reconciled from placeholders is read from L1 rather than from
+            // local placeholders whose L0 objects may be garbage-collected.
+            // Gated on the feature flag because the floor command cannot be
+            // applied by pre-v26.2 replicas.
+            auto p = ss::make_lw_shared<ss::promise<kafka::offset>>();
+            _max_placeholder_offset = p->get_future();
+            cfg.max_placeholder_offset = std::move(p);
+        }
         auto reader = co_await _fe->make_reader(cfg);
 
         // It's important the `aborted_transaction_tracker_impl` takes a shared
@@ -165,8 +196,43 @@ public:
     }
 
 private:
+    // Collect the placeholder high watermark reported by the most recent
+    // reader. The reader resolves the promise on destruction, which in the
+    // reconciler's flow happens strictly before the LRO commit; an
+    // unresolved observation is simply skipped (the next reconciliation
+    // covers the same prefix again).
+    std::optional<kafka::offset> harvest_placeholder_observation() {
+        if (
+          !_max_placeholder_offset.has_value()
+          || !_max_placeholder_offset->available()) {
+            return std::nullopt;
+        }
+        auto fut = std::move(*_max_placeholder_offset);
+        _max_placeholder_offset.reset();
+        if (fut.failed()) {
+            fut.ignore_ready_future();
+            return std::nullopt;
+        }
+        auto hwm = fut.get();
+        if (hwm == kafka::offset::min()) {
+            // The scanned range contained no placeholders.
+            return std::nullopt;
+        }
+        return hwm;
+    }
+
+    void discard_placeholder_observation() {
+        if (_max_placeholder_offset.has_value()) {
+            if (_max_placeholder_offset->available()) {
+                _max_placeholder_offset->ignore_ready_future();
+            }
+            _max_placeholder_offset.reset();
+        }
+    }
+
     ss::lw_shared_ptr<frontend> _fe;
     ss::lw_shared_ptr<cluster::partition> _partition;
+    std::optional<ss::future<kafka::offset>> _max_placeholder_offset;
 };
 
 } // namespace

--- a/tests/rptest/tests/cloud_topics/e2e_test.py
+++ b/tests/rptest/tests/cloud_topics/e2e_test.py
@@ -25,6 +25,8 @@ from rptest.services.kgo_verifier_services import (
     KgoVerifierSeqConsumer,
 )
 from rptest.services.redpanda import (
+    LoggingConfig,
+    RESTART_LOG_ALLOW_LIST,
     SISettings,
     make_redpanda_service,
     MetricsEndpoint,
@@ -471,11 +473,43 @@ class EndToEndCloudTopicsTest(EndToEndCloudTopicsBase):
         )
 
 
+L0_DATA_PREFIX = "level_zero/data/"
+
+# When the read path tries to materialize a placeholder whose L0 object was
+# garbage-collected there is no L1 fallback; the reader fails the fetch.
+MODE_TOGGLE_LOG_ALLOW_LIST = RESTART_LOG_ALLOW_LIST + [
+    "Failed to materialize batches from the cloud storage",
+    # Downstream fallout of the failed materialization in the fetch path.
+    "cloud_topics.*runtime_error",
+    "kafka.*Failed to materialize",
+]
+
+
 class EndToEndCloudTopicsStorageModeToggleTest(EndToEndCloudTopicsBase):
     """Exercise toggling a topic between 'cloud' and 'tiered' storage modes
     (the latter resolves to tiered_v2 via the cluster default) while a
-    rate-limited producer is running, then validate the resulting log with a
-    sequential consumer."""
+    rate-limited producer is running, then validate that the whole log stays
+    readable once the L0 objects behind the already-reconciled region are
+    garbage-collected.
+
+    The final read exercises the mode-flip / L0-GC interaction: after a
+    cloud -> tiered_v2 flip the tiered read branch serves everything at or
+    above the local log's start offset from the local log, ignoring the
+    last-reconciled offset. The local log still holds placeholders for the
+    already-reconciled region, and L0 GC is allowed to delete the objects
+    those placeholders reference (their epoch is inactive and they are past
+    the minimum age). Reading that region then has to materialize
+    placeholders against deleted objects, which fails with no L1 fallback,
+    even though L1 holds a complete copy of the data. The flip also freezes
+    local prefix-truncation (tiered_v2 honors full topic retention, which is
+    effectively infinite here), so the log never self-heals by trimming the
+    placeholder region.
+
+    With the default 12h cloud_topics_short_term_gc_minimum_object_age the
+    window is practically unreachable; the test shrinks it (plus the epoch
+    rotation and housekeeping intervals that gate GC eligibility) to make
+    the sequence take seconds.
+    """
 
     topics = (
         TopicSpec(
@@ -486,19 +520,58 @@ class EndToEndCloudTopicsStorageModeToggleTest(EndToEndCloudTopicsBase):
     )
 
     def __init__(self, test_context, extra_rp_conf=None, env=None):
+        extra_rp_conf = dict(extra_rp_conf or {})
+        extra_rp_conf.update(
+            {
+                # L0 objects become GC-eligible after 30s instead of 12h.
+                "cloud_topics_short_term_gc_minimum_object_age": 30_000,
+                "cloud_topics_short_term_gc_interval": 5_000,
+                "cloud_topics_short_term_gc_backoff_interval": 5_000,
+                # GC eligibility requires the partition's inactive-epoch
+                # estimate to advance past the epoch the data was written
+                # under. That takes housekeeper epoch bumps, and each bump
+                # needs the controller to have minted a fresh cluster epoch
+                # (default mint interval: 10min) and the local cache to have
+                # picked it up. Do not shrink max_same_epoch_duration below
+                # the mint interval: epoch fetches fail outright while the
+                # cached epoch is older than it.
+                "cloud_storage_housekeeping_interval_ms": 5_000,
+                "cloud_topics_epoch_service_epoch_increment_interval": 5_000,
+                "cloud_topics_epoch_service_local_epoch_cache_duration": 5_000,
+                # Reads must materialize from object storage rather than be
+                # served by the write-through batch cache, which would mask
+                # the deleted objects.
+                "disable_batch_cache": True,
+                # Many small L0 objects.
+                "cloud_topics_produce_batching_size_threshold": 65536,
+            }
+        )
         super(EndToEndCloudTopicsStorageModeToggleTest, self).__init__(
             test_context, extra_rp_conf, env
         )
         self.msg_size = 16 * 1024
         # Size the workload so the producer is still sending when the
         # toggle window ends: at ~10 MB/s with 16 KiB messages this is
-        # ~400s of traffic, vs. a 5-minute toggle window.
-        self.msg_count = 250_000
+        # ~33s of traffic, vs. a 30-second toggle window.
+        self.msg_count = 20_000
         self.rate_limit_bps = 10 * 1024 * 1024  # 10 MB/s
-        self.toggle_duration_sec = 5 * 60
+        self.toggle_duration_sec = 30
         self.toggle_interval_sec = 5
+        # The GC gates (epoch eligibility, safety monitor, age) all log at
+        # debug; without this the reason GC skips an object is invisible.
+        assert self.redpanda
+        self.redpanda._log_config = LoggingConfig("info", {"cloud_topics": "debug"})
 
-    @cluster(num_nodes=5)
+    def _l0_object_count(self) -> int:
+        assert self.redpanda
+        return sum(
+            1
+            for _ in self.redpanda.cloud_storage_client.list_objects(
+                self.s3_bucket_name, prefix=L0_DATA_PREFIX
+            )
+        )
+
+    @cluster(num_nodes=4, log_allow_list=MODE_TOGGLE_LOG_ALLOW_LIST)
     def test_toggle_storage_mode(self):
         assert self.redpanda is not None
         assert self.topic is not None
@@ -514,14 +587,6 @@ class EndToEndCloudTopicsStorageModeToggleTest(EndToEndCloudTopicsBase):
             msg_count=self.msg_count,
             rate_limit_bps=self.rate_limit_bps,
             tolerate_failed_produce=True,
-        )
-        consumer = KgoVerifierSeqConsumer(
-            self.test_context,
-            self.redpanda,
-            self.topic,
-            self.msg_size,
-            loop=False,
-            producer=producer,
         )
         # The toggle flips through the 'tiered' alias; point it at the
         # cloud-architecture variant (the default is tiered_v1, under which
@@ -550,26 +615,91 @@ class EndToEndCloudTopicsStorageModeToggleTest(EndToEndCloudTopicsBase):
                     f"(acked={producer.produce_status.acked})"
                 )
 
-            # Let the producer run to completion so the consumer has a
-            # natural stopping point.
+            # Let the producer run to completion so the read-back has a
+            # known record count.
             producer.wait(timeout_sec=10 * 60)
+            acked = producer.produce_status.acked
             self.logger.info(
-                f"producer finished with acked={producer.produce_status.acked}, "
+                f"producer finished with acked={acked}, "
                 f"bad_offsets={producer.produce_status.bad_offsets}"
             )
-
-            # Passing the producer to the consumer makes wait() block
-            # until the consumer has read every produced offset and
-            # validates reads internally.
-            consumer.start(clean=False)
-            consumer.wait(timeout_sec=10 * 60)
-
-            self.wait_until_all_reconciled()
         finally:
             producer.stop()
-            consumer.stop()
             producer.free()
-            consumer.free()
+
+        # End the toggling in tiered_v2 mode: the local log keeps the
+        # placeholders for whatever was reconciled while in cloud mode.
+        self.rpk.alter_topic_config(
+            self.topic, TopicSpec.PROPERTY_STORAGE_MODE, TopicSpec.STORAGE_MODE_TIERED
+        )
+        self.wait_until_all_reconciled()
+
+        l0_before = self._l0_object_count()
+        self.logger.info(f"L0 objects after reconciliation: {l0_before}")
+        assert l0_before > 0, "expected reconciled data to have L0 objects"
+
+        # Trickle produce keeps the reconciler advancing the last-reconciled
+        # offset past the housekeeper's epoch-bump command batches; the
+        # inactive-epoch estimate (and with it GC eligibility) only moves
+        # when the LRO does. The trickled records take the tiered (raft)
+        # write path and land above the placeholder region under test.
+        trickled = 0
+
+        topic = self.topic
+
+        def l0_gone() -> bool:
+            nonlocal trickled
+            count = self._l0_object_count()
+            self.logger.info(f"L0 objects remaining: {count}")
+            if count > 0:
+                self.kafka_tools.produce(topic, 50, self.msg_size, acks=-1)
+                trickled += 50
+            return count == 0
+
+        wait_until(
+            l0_gone,
+            timeout_sec=240,
+            backoff_sec=10,
+            err_msg="L0 GC did not delete the reconciled objects",
+        )
+
+        # The reconciler downloaded the L0 objects to build L1, leaving them
+        # in the cloud-storage disk cache, which the fetch path consults
+        # before object storage and which survives the objects' deletion.
+        # Wipe it (and any in-memory state) so the read has to go to object
+        # storage, as it would once the cache entries are evicted.
+        for node in self.redpanda.nodes:
+            self.redpanda.stop_node(node)
+        for node in self.redpanda.nodes:
+            node.account.ssh(f"rm -rf {self.redpanda.cache_dir}")
+        for node in self.redpanda.nodes:
+            self.redpanda.start_node(node)
+        redpanda = self.redpanda
+        wait_until(
+            lambda: redpanda.healthy(),
+            timeout_sec=60,
+            backoff_sec=2,
+            err_msg="cluster did not become healthy after cache wipe",
+        )
+
+        # Read the whole log back: every acked record (plus the trickled
+        # ones) must be consumable; the reconciled region is expected to be
+        # served from L1 once its L0 objects are gone.
+        expected = acked + trickled
+        out = self.rpk.consume(
+            self.topic,
+            offset="start",
+            n=expected,
+            format="%o\n",
+            quiet=True,
+            timeout=120,
+        )
+        consumed = len(out.splitlines())
+        assert consumed == expected, (
+            f"consumed {consumed}/{expected} records after storage-mode "
+            f"toggling and L0 GC; the reconciled region is expected to be "
+            f"readable from L1"
+        )
 
 
 class EndToEndCloudTopicsTxTest(EndToEndCloudTopicsBase):


### PR DESCRIPTION
Reworks the storage-mode toggle ducktape test so it reproduces a data
unreadability bug in the mode-flip / L0-GC interaction (report:
https://gist.github.com/nvartolomei/fdb274b629a2184ec63709eb740d8c5d).

After a `cloud` → `tiered_v2` storage-mode flip, the tiered read branch
serves everything at or above the local log's start offset from the local
log, ignoring the last-reconciled offset. The local log still holds
placeholders for the already-reconciled region, and L0 GC is allowed to
delete the objects those placeholders reference once their epoch goes
inactive and the minimum object age passes. Reading that region then has
to materialize placeholders against deleted objects, which fails with
`download_not_found` and no L1 fallback — even though L1 holds a complete
copy of the data. The flip also freezes local prefix-truncation
(tiered_v2 honors full topic retention), so the log never self-heals by
trimming the placeholder region.

The test shrinks `cloud_topics_short_term_gc_minimum_object_age` (12h →
30s) and the epoch/housekeeping intervals that gate GC eligibility,
disables the batch cache, ends the toggling in `tiered_v2`,
trickle-produces until the reconciled L0 objects are collected, wipes the
cloud-storage disk cache with a rolling restart, and reads the whole log
back. The read wedges on the placeholder region (~94k
`Failed to materialize sorted run: download_not_found` warnings in a
local run) instead of returning every acked record.

**This PR is a reproducer: the altered test is expected to FAIL until the
bug is fixed.** It is opened as a draft to anchor the discussion of the
fix (make the tiered read branch respect the last-reconciled offset, fall
back to L1 on materialization failure, or resume prefix-truncation of the
reconciled region after a flip).

Depends on #30966 (the storage-mode impl rework), whose commits are
included underneath.

## Backports Required

- [x] none - issue does not exist in previous branches
- [ ] none - this is a backport
- [ ] none - not a bug fix
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
