### PR TITLE
metrics: expose cluster identity via cluster_info gauge

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -55,6 +55,7 @@
 #include "version/version.h"
 #include "wasm/cache.h"
 
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/memory.hh>
 #include <seastar/core/metrics.hh>
 #include <seastar/core/prometheus.hh>
@@ -637,6 +638,32 @@ void application::setup_internal_metrics() {
          [] { return static_cast<unsigned int>(config::node().fips_mode()); },
          sm::description(
            "Identifies whether or not Redpanda is running in FIPS mode."))});
+}
+
+ss::future<> application::register_cluster_identity_metrics() {
+    namespace sm = ss::metrics;
+
+    if (!metrics::any_enabled()) {
+        co_return;
+    }
+
+    // The cluster UUID is not known when setup_metrics() runs: it is loaded
+    // from the kvstore (restart) or replicated via the bootstrap command
+    // (brand new cluster) only after storage starts. Wait for it and register
+    // the identity metrics late; the waiter is broken at shutdown.
+    if (!co_await storage.local().wait_for_cluster_uuid()) {
+        co_return;
+    }
+
+    _cluster_identity_metrics.add_group(
+      "cluster",
+      {sm::make_gauge(
+         "info",
+         [] { return 1; },
+         sm::description("Redpanda cluster identity information"),
+         {sm::label("cluster_uuid")(
+           ssx::sformat("{}", *storage.local().get_cluster_uuid()))})
+         .aggregate({sm::shard_label})});
 }
 
 void application::validate_arguments(const po::variables_map& cfg) {

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -66,6 +66,7 @@
 #include "wasm/fwd.h"
 
 #include <seastar/core/app-template.hh>
+#include <seastar/core/gate.hh>
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/sharded.hh>
 
@@ -335,6 +336,7 @@ private:
     void setup_metrics();
     void setup_public_metrics();
     void setup_internal_metrics();
+    ss::future<> register_cluster_identity_metrics();
     std::unique_ptr<ss::app_template> _app;
 
     // Early in startup, we load config from disk or from the response to
@@ -381,6 +383,12 @@ private:
 
     metrics::internal_metric_groups _metrics;
     ss::sharded<metrics::public_metrics_group_service> _public_metrics;
+    // Cluster identity metrics register in a background fiber once the
+    // cluster UUID becomes available (immediately on restart, after
+    // bootstrap on a brand new cluster). The gate is closed via _deferred
+    // at shutdown.
+    ss::gate _cluster_identity_gate;
+    metrics::all_metrics_groups _cluster_identity_metrics;
     std::unique_ptr<kafka::rm_group_proxy_impl> _rm_group_proxy;
     ss::sharded<cluster::data_migrations::group_proxy>
       _data_migrations_group_proxy;

--- a/src/v/redpanda/application_bootstrap.cc
+++ b/src/v/redpanda/application_bootstrap.cc
@@ -37,6 +37,7 @@
 #include "resource_mgmt/scheduling_groups_probe.h"
 #include "rpc/rpc_utils.h"
 #include "security/audit/audit_log_manager.h"
+#include "ssx/future-util.h"
 #include "ssx/thread_worker.h"
 #include "storage/api.h"
 #include "storage/chunk_cache.h"
@@ -728,4 +729,9 @@ void application::post_start_tasks() {
     // misconfigurations are also treated as unclean shutdowns
     // thus avoiding crashloops.
     schedule_crash_tracker_file_cleanup();
+
+    ssx::spawn_with_gate(_cluster_identity_gate, [this] {
+        return register_cluster_identity_metrics();
+    });
+    _deferred.emplace_back([this] { _cluster_identity_gate.close().get(); });
 }

--- a/src/v/storage/api.h
+++ b/src/v/storage/api.h
@@ -97,7 +97,10 @@ public:
 
     void set_cluster_uuid(const model::cluster_uuid& cluster_uuid) {
         _cluster_uuid = cluster_uuid;
-        _has_cluster_uuid_cond.signal();
+        // broadcast, not signal: multiple independent fibers may be blocked
+        // in wait_for_cluster_uuid() on the same shard (cloud metadata
+        // uploader, datalake committer, identity metrics registration).
+        _has_cluster_uuid_cond.broadcast();
     }
     const std::optional<model::cluster_uuid>& get_cluster_uuid() const {
         return _cluster_uuid;

--- a/tests/rptest/tests/metrics_test.py
+++ b/tests/rptest/tests/metrics_test.py
@@ -14,8 +14,11 @@ from ducktape.tests.test import Test
 
 from rptest.clients.default import DefaultClient
 from rptest.clients.types import TopicSpec
+from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import MetricsEndpoint, make_redpanda_service
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.util import wait_until_result
 
 BOOTSTRAP_CONFIG = {
     "disable_metrics": False,
@@ -47,7 +50,13 @@ class MetricsTest(Test):
         # We ignore those because:
         #  - seastar metrics so not affected by aggregate_metrics anyway
         #  - compaction io_queue class metrics can pop up after a delay so might make this flaky
-        return list(metric for metric in metrics if "io_queue" not in metric)
+        #  - cluster_info registers in the background once the cluster UUID is
+        #    known, so it can appear between scrapes
+        return list(
+            metric
+            for metric in metrics
+            if "io_queue" not in metric and "cluster_info" not in metric
+        )
 
     @cluster(num_nodes=3)
     @matrix(aggregate_metrics=[True, False])
@@ -202,3 +211,59 @@ class DisableMetricsTest(Test):
         internal endpoint is unaffected and still exposes Redpanda metrics.
         """
         self._verify_endpoint_disabled(MetricsEndpoint.PUBLIC_METRICS)
+
+
+class ClusterIdentityMetricsTest(RedpandaTest):
+    def __init__(self, test_ctx, *args, **kwargs):
+        super().__init__(test_ctx, num_brokers=3, *args, **kwargs)
+
+    def _cluster_uuid_label(self, node, endpoint) -> str | None:
+        """The cluster_uuid label of the cluster_info metric on `endpoint`,
+        or None if the metric has not been registered yet."""
+        prefix = (
+            "redpanda" if endpoint == MetricsEndpoint.PUBLIC_METRICS else "vectorized"
+        )
+        families = [
+            f
+            for f in self.redpanda.metrics(
+                node, endpoint, name=f"{prefix}_cluster_info"
+            )
+            if f.samples
+        ]
+        if not families:
+            return None
+        assert len(families) == 1, f"expected a single family, got {families}"
+        samples = families[0].samples
+        assert len(samples) == 1, (
+            f"expected a single cluster_info series, got {samples}"
+        )
+        assert samples[0].value == 1
+        return samples[0].labels["cluster_uuid"]
+
+    @cluster(num_nodes=3)
+    def test_cluster_info_metric(self):
+        """
+        Every broker must expose the cluster_info identity metric on both
+        metrics endpoints, carrying the bootstrap cluster UUID as reported
+        by the admin API's GET /v1/cluster/uuid.
+
+        The metric registers in the background once the cluster UUID is
+        known, so tolerate a brief delay after startup.
+        """
+        expected_uuid = Admin(self.redpanda).get_cluster_uuid(self.redpanda.nodes[0])
+        assert expected_uuid, "admin API returned no cluster UUID"
+
+        for node in self.redpanda.nodes:
+            for endpoint in [MetricsEndpoint.METRICS, MetricsEndpoint.PUBLIC_METRICS]:
+                uuid = wait_until_result(
+                    lambda: self._cluster_uuid_label(node, endpoint),
+                    timeout_sec=30,
+                    backoff_sec=1,
+                    retry_on_exc=True,
+                    err_msg=f"cluster_info metric did not appear on "
+                    f"{endpoint.value} of {node.name}",
+                )
+                assert uuid == expected_uuid, (
+                    f"cluster_info on {endpoint.value} of {node.name} reports "
+                    f"cluster_uuid={uuid}, expected {expected_uuid}"
+                )


### PR DESCRIPTION
## Motivation

Nothing in a Prometheus scrape uniquely identifies which cluster a broker belongs to. Users who want to distinguish clusters in dashboards, recording rules, or federated setups must inject `external_labels` in every scrape config, which is error-prone and often skipped. The bootstrap cluster UUID (immutable, created once at cluster formation, not user-editable — unlike the `cluster_id` config) is the trustworthy identity, so expose it directly.

## What this does

Adds a constant info-style gauge to **both** metrics endpoints, following the `kube_state_metrics` `*_info` convention (join via `group_left` in PromQL):

```
redpanda_cluster_info{cluster_uuid="<bootstrap uuid>"} 1     # /public_metrics
vectorized_cluster_info{cluster_uuid="<bootstrap uuid>"} 1   # /metrics
```

An info metric was chosen over stamping the UUID onto every series: per-series labels would change the identity of every time series on upgrade (breaking dashboards and recording rules), bloat scrape payloads, and fight with external labels that observability pipelines already add.

## Design notes

- The cluster UUID is not yet known when `setup_metrics()` runs (it is loaded from the kvstore / replicated via the bootstrap command only after storage starts), so registration happens in a background fiber that waits on `storage::api::wait_for_cluster_uuid()`: immediate on restart, right after bootstrap on a brand-new cluster. Until then the metric is simply absent — a node that has not joined a cluster has no cluster identity.
- Follows the `metrics/instance_metrics.cc` precedent: `metrics::all_metrics_groups` for dual-endpoint registration (honors both disable flags), `ssx::spawn_with_gate` for the fiber, gate closed via `_deferred` at shutdown (`application::shutdown()` breaks the UUID waiters as its first step, so the fiber always unblocks).

## Bug fix (first commit, independently backportable)

`storage::api::set_cluster_uuid()` used `condition_variable::signal()`, which wakes exactly **one** waiter. Multiple independent fibers can be blocked in `wait_for_cluster_uuid()` on the same shard — the cloud metadata uploader (`cluster/cloud_metadata/uploader.cc`) and the datalake iceberg committer (`datalake/coordinator/iceberg_file_committer.cc`) — so on a freshly bootstrapped cluster the losing fiber slept forever (e.g. cluster metadata uploads silently never starting for the life of the process). This is a latent pre-existing race that the new waiter here would have made more likely; fixed with `broadcast()`.

## Testing

- New ducktape test `ClusterIdentityMetricsTest.test_cluster_info_metric`: 3-broker cluster, asserts the metric appears on both endpoints of every broker and the label matches the admin API's `GET /v1/cluster/uuid`.
- `MetricsTest.test_aggregate_metrics` now excludes `cluster_info` from its line counts, since the async registration could otherwise change the count between scrapes.
- Developed on a machine without Bazel: relying on CI for build, clang-format, and the rptest type checker. Python formatted/linted with the repo-pinned ruff 0.12.10.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x (first commit only — the `signal()`→`broadcast()` fix)
- [x] v25.3.x (first commit only — the `signal()`→`broadcast()` fix)
- [ ] v25.2.x

## Release Notes

### Improvements

* The bootstrap cluster UUID is now exposed on both metrics endpoints as a constant `cluster_info` gauge with a `cluster_uuid` label, so Prometheus scrapes can uniquely identify the cluster without external labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7sDG1E1hom3tZ2nd3FH2e
