### PR TITLE
`cluster`: persist formation timestamp in controller

### DIFF
--- a/src/v/cluster/bootstrap_backend.cc
+++ b/src/v/cluster/bootstrap_backend.cc
@@ -225,6 +225,9 @@ bootstrap_backend::apply(bootstrap_cluster_cmd cmd, model::offset offset) {
     }
 
     co_await apply_cluster_uuid(cmd.value.uuid);
+    if (cmd.value.formation_timestamp) {
+        co_await apply_formation_timestamp(*cmd.value.formation_timestamp);
+    }
 
     co_return errc::success;
 }
@@ -242,8 +245,16 @@ ss::future<> bootstrap_backend::apply_cluster_uuid(model::cluster_uuid uuid) {
     vlog(clusterlog.debug, "Cluster UUID initialized {}", uuid);
 }
 
+ss::future<> bootstrap_backend::apply_formation_timestamp(model::timestamp ts) {
+    co_await _storage.invoke_on_all(
+      [ts](storage::api& storage) { storage.set_formation_timestamp(ts); });
+    _formation_timestamp_applied = ts;
+    vlog(clusterlog.debug, "Cluster formation timestamp initialized {}", ts);
+}
+
 ss::future<> bootstrap_backend::fill_snapshot(controller_snapshot& snap) const {
     snap.bootstrap.cluster_uuid = _cluster_uuid_applied;
+    snap.bootstrap.formation_timestamp = _formation_timestamp_applied;
     co_return;
 }
 
@@ -253,7 +264,12 @@ ss::future<> bootstrap_backend::apply_snapshot(
     // must dispatch updates to other parts of the controller stm
     // (members_manager, feature_table, credential_store). But if we are
     // applying a controller snapshot, these updates will be handled by the
-    // sub-stms themselves. Here we only need to initialize the cluster uuid.
+    // sub-stms themselves. Here we only need to initialize the cluster uuid
+    // and the formation timestamp.
+
+    if (snap.bootstrap.formation_timestamp) {
+        co_await apply_formation_timestamp(*snap.bootstrap.formation_timestamp);
+    }
 
     auto snap_cluster_uuid = snap.bootstrap.cluster_uuid;
     vlog(

--- a/src/v/cluster/bootstrap_backend.h
+++ b/src/v/cluster/bootstrap_backend.h
@@ -57,9 +57,16 @@ public:
     ss::future<> fill_snapshot(controller_snapshot&) const;
     ss::future<> apply_snapshot(model::offset, const controller_snapshot&);
 
+    /// Wall-clock time at which the cluster first formed, if known. Absent for
+    /// clusters bootstrapped before this was recorded (serde version < 4).
+    std::optional<model::timestamp> formation_timestamp() const {
+        return _formation_timestamp_applied;
+    }
+
 private:
     ss::future<std::error_code> apply(bootstrap_cluster_cmd, model::offset);
     ss::future<> apply_cluster_uuid(model::cluster_uuid);
+    ss::future<> apply_formation_timestamp(model::timestamp);
 
     ss::sharded<security::credential_store>& _credentials;
     ss::sharded<storage::api>& _storage;
@@ -68,6 +75,7 @@ private:
     ss::sharded<feature_backend>& _feature_backend;
     ss::sharded<cluster_recovery_table>& _cluster_recovery_table;
     std::optional<model::cluster_uuid> _cluster_uuid_applied;
+    std::optional<model::timestamp> _formation_timestamp_applied;
 };
 
 } // namespace cluster

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -1170,6 +1170,7 @@ ss::future<> controller::cluster_creation_hook(
         cmd_data.founding_version
           = features::feature_table::get_latest_logical_version();
         cmd_data.initial_nodes = discovery.founding_brokers();
+        cmd_data.formation_timestamp = model::timestamp::now();
         co_return co_await create_cluster(std::move(cmd_data), as);
     }
 

--- a/src/v/cluster/controller_snapshot.h
+++ b/src/v/cluster/controller_snapshot.h
@@ -34,12 +34,17 @@ namespace controller_snapshot_parts {
 
 struct bootstrap_t
   : public serde::
-      envelope<bootstrap_t, serde::version<0>, serde::compat_version<0>> {
+      envelope<bootstrap_t, serde::version<1>, serde::compat_version<0>> {
     std::optional<model::cluster_uuid> cluster_uuid;
+
+    // Wall-clock time at which the cluster first formed. Absent for clusters
+    // bootstrapped before this field existed, or whose bootstrap record
+    // pre-dates it. See bootstrap_cluster_cmd_data::formation_timestamp.
+    std::optional<model::timestamp> formation_timestamp;
 
     friend bool operator==(const bootstrap_t&, const bootstrap_t&) = default;
 
-    auto serde_fields() { return std::tie(cluster_uuid); }
+    auto serde_fields() { return std::tie(cluster_uuid, formation_timestamp); }
 };
 
 struct features_t

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1746,7 +1746,7 @@ struct cluster_recovery_init_state
 struct bootstrap_cluster_cmd_data
   : serde::envelope<
       bootstrap_cluster_cmd_data,
-      serde::version<3>,
+      serde::version<4>,
       serde::compat_version<0>> {
     friend bool operator==(
       const bootstrap_cluster_cmd_data&,
@@ -1759,7 +1759,8 @@ struct bootstrap_cluster_cmd_data
           node_ids_by_uuid,
           founding_version,
           initial_nodes,
-          recovery_state);
+          recovery_state,
+          formation_timestamp);
     }
 
     model::cluster_uuid uuid;
@@ -1774,6 +1775,10 @@ struct bootstrap_cluster_cmd_data
 
     // If set, begins a cluster recovery using this state as the basis.
     std::optional<cluster_recovery_init_state> recovery_state;
+
+    // Wall-clock time at which the founding node generated this bootstrap
+    // record, i.e. when the cluster first formed.
+    std::optional<model::timestamp> formation_timestamp;
 };
 
 struct cluster_recovery_init_cmd_data

--- a/src/v/redpanda/admin/api-doc/cluster.json
+++ b/src/v/redpanda/admin/api-doc/cluster.json
@@ -68,6 +68,21 @@
             ]
         },
         {
+            "path": "/v1/cluster/formation_timestamp",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get the wall-clock time at which this cluster first formed",
+                    "type": "get_cluster_formation_timestamp",
+                    "nickname": "get_cluster_formation_timestamp",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
+        },
+        {
             "path": "/v1/cluster/metrics_uuid",
             "operations": [
                 {
@@ -346,6 +361,15 @@
             "properties": {
                 "cluster_uuid": {
                     "type": "string"
+                }
+            }
+        },
+        "cluster_formation_timestamp": {
+            "id": "cluster_formation_timestamp",
+            "properties": {
+                "formation_timestamp": {
+                    "type": "long",
+                    "description": "Timestamp at which the cluster first formed."
                 }
             }
         },

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -4195,6 +4195,20 @@ void admin_server::register_cluster_routes() {
           return ss::json::json_return_type(ss::json::json_void());
       });
 
+    register_route_sync<publik>(
+      ss::httpd::cluster_json::get_cluster_formation_timestamp,
+      [this](ss::httpd::const_req) -> ss::json::json_return_type {
+          vlog(adminlog.debug, "Requested cluster formation timestamp");
+          const std::optional<model::timestamp>& formation_ts
+            = _controller->get_storage().local().get_formation_timestamp();
+          if (formation_ts) {
+              ss::httpd::cluster_json::cluster_formation_timestamp ret;
+              ret.formation_timestamp = formation_ts->value();
+              return ss::json::json_return_type(ret);
+          }
+          return ss::json::json_return_type(ss::json::json_void());
+      });
+
     register_route<publik>(
       ss::httpd::cluster_json::get_metrics_uuid,
       [this](std::unique_ptr<ss::http::request> req) {

--- a/src/v/storage/api.h
+++ b/src/v/storage/api.h
@@ -14,6 +14,7 @@
 #include "base/seastarx.h"
 #include "features/feature_table.h"
 #include "model/fundamental.h"
+#include "model/timestamp.h"
 #include "storage/chunk_cache.h"
 #include "storage/disk.h"
 #include "storage/kvstore.h"
@@ -103,6 +104,13 @@ public:
         return _cluster_uuid;
     }
 
+    void set_formation_timestamp(model::timestamp ts) {
+        _formation_timestamp = ts;
+    }
+    const std::optional<model::timestamp>& get_formation_timestamp() const {
+        return _formation_timestamp;
+    }
+
     ss::future<bool> wait_for_cluster_uuid();
 
     kvstore& kvs() { return *_kvstore; }
@@ -145,6 +153,8 @@ private:
 
     std::optional<model::cluster_uuid> _cluster_uuid;
     ss::condition_variable _has_cluster_uuid_cond;
+
+    std::optional<model::timestamp> _formation_timestamp;
 };
 
 } // namespace storage

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -1664,6 +1664,20 @@ class Admin:
             return r.json()["cluster_uuid"]
         return None
 
+    def get_cluster_formation_timestamp(self, node: MaybeNode = None) -> int | None:
+        """Return the cluster formation timestamp (milliseconds since the Unix
+        epoch) reported by GET /v1/cluster/formation_timestamp, or None if the
+        timestamp was not recorded at formation."""
+        try:
+            r = self._request("GET", "cluster/formation_timestamp", node=node)
+        except HTTPError as ex:
+            if ex.response.status_code == 404:
+                return None
+            raise
+        if len(r.text) > 0:
+            return r.json().get("formation_timestamp")
+        return None
+
     def get_metrics_uuid(self, node: MaybeNode = None) -> str | None:
         """
         Returns the concents of the `/v1/cluster/metrics_uuid` endpoint.

--- a/tests/rptest/tests/controller_snapshot_test.py
+++ b/tests/rptest/tests/controller_snapshot_test.py
@@ -246,12 +246,24 @@ class ControllerSnapshotTest(RedpandaTest):
         cluster_uuid = admin.get_cluster_uuid(node=seed_nodes[0])
         assert cluster_uuid is not None
 
+        # The formation timestamp is recorded in the bootstrap command and
+        # persisted in the controller snapshot, so it must be present, stable
+        # across restarts, and identical on every node (including late joiners
+        # that receive it via the controller join snapshot).
+        formation_ts = admin.get_cluster_formation_timestamp(node=seed_nodes[0])
+        assert formation_ts is not None and formation_ts > 0, (
+            f"unexpected formation timestamp {formation_ts}"
+        )
+
         node_ids_per_idx = {}
 
         def check_and_save_node_ids(started):
             for n in started:
                 uuid = admin.get_cluster_uuid(node=n)
                 assert cluster_uuid == uuid, f"unexpected cluster uuid {uuid}"
+
+                ts = admin.get_cluster_formation_timestamp(node=n)
+                assert formation_ts == ts, f"unexpected formation timestamp {ts}"
 
                 brokers = admin.get_brokers(node=n)
                 assert len(brokers) == len(started)


### PR DESCRIPTION
* Persist the cluster formation timestamp in the controller log & snapshot, using the existing `bootstrap_cluster_cmd_data` command.
* add `cluster_formation_timestamp` admin endpoint

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes


* none
