### PR TITLE
cloud_storage/archival: fix spillover stuck on cstore hint-map bloat

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -1131,7 +1131,8 @@ segment_meta partition_manifest::make_manifest_metadata() const {
     };
 }
 
-bool partition_manifest::safe_spillover_manifest(const segment_meta& meta) {
+bool partition_manifest::safe_spillover_manifest(
+  const segment_meta& meta) const {
     // New spillover manifest should connect with previous spillover manifests
     // and *this manifest. The manifest is not truncated yet so meta.base_offset
     // should be equal to start offset and the meta.committed_offset + 1 should

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -381,7 +381,7 @@ public:
 
     /// Return 'true' if the spillover manifest can be added to
     /// the manifest without creating a gap
-    bool safe_spillover_manifest(const segment_meta& meta);
+    bool safe_spillover_manifest(const segment_meta& meta) const;
 
     /// \brief Set start offset without removing any data from the
     /// manifest.

--- a/src/v/cloud_storage/segment_meta_cstore.cc
+++ b/src/v/cloud_storage/segment_meta_cstore.cc
@@ -269,8 +269,6 @@ public:
 
     /// Add element to the store. The operation is transactional.
     void append(const segment_meta& meta) {
-        auto ix = _base_offset.size();
-
         try {
             details::tuple_map(
               [&](auto& col, auto accessor) {
@@ -285,8 +283,15 @@ public:
             vunreachable("column_store bad_alloc during 'append' operation");
         }
 
+        // Sample by position within the current frame rather than by the
+        // total store size. When the store is churned by interleaved
+        // appends and prefix truncations (retention steady state) its size
+        // can settle on a multiple of the sampling interval, in which case
+        // a size-based condition would insert a hint on every append and
+        // the hint map would grow to one entry per element.
+        auto frame_ix = _base_offset.last_frame_size() - 1;
         if (
-          ix
+          frame_ix
             % static_cast<uint32_t>(
               ::details::FOR_buffer_depth * cstore_sampling_rate)
           == 0) {

--- a/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
@@ -881,10 +881,10 @@ BOOST_AUTO_TEST_CASE(slow_path_drops_hints_from_cloned_frame) {
 // Reproduces a hint-index leak: a store whose size sits at a multiple of
 // the hint sampling interval (FOR_buffer_depth * cstore_sampling_rate = 128)
 // while being churned by interleaved appends and prefix truncations. The
-// sampling condition keys off the total store size, so at such sizes every
-// append inserts a hint (~one per element instead of one per 128). The
-// accumulated hints inflate inflated_actual_size() several-fold, which in
-// turn makes the archiver's spillover size heuristics diverge from the
+// sampling condition used to key off the total store size, so at such sizes
+// every append inserted a hint (~one per element instead of one per 128).
+// The accumulated hints inflated inflated_actual_size() several-fold, which
+// in turn made the archiver's spillover size heuristics diverge from the
 // size of a freshly encoded manifest with identical content.
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_steady_state_churn_hints) {
     namespace rg = random_generators;
@@ -951,10 +951,9 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_steady_state_churn_hints) {
                   << " hints; fresh: " << fresh_actual << " bytes, "
                   << fresh.hints_size() << " hints");
 
-    // Captures the current (buggy) behavior: the hint map grows towards
-    // one entry per element instead of the designed one per 128, and the
-    // reported size diverges from the freshly encoded equivalent by an
-    // order of magnitude.
-    BOOST_REQUIRE_GE(store.hints_size(), steady_size / 2);
-    BOOST_REQUIRE_GE(churned_actual, 8 * fresh_actual);
+    // design density is one hint per 128 elements
+    BOOST_REQUIRE_LE(store.hints_size(), 2 * steady_size / 128 + 4);
+    // accounting of the churned store must stay comparable to the
+    // freshly encoded equivalent
+    BOOST_REQUIRE_LE(churned_actual, 4 * fresh_actual);
 }

--- a/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
@@ -877,3 +877,84 @@ BOOST_AUTO_TEST_CASE(slow_path_drops_hints_from_cloned_frame) {
     BOOST_REQUIRE_EQUAL(hints_before, expected_hints);
     BOOST_REQUIRE_EQUAL(hints_after, expected_hints);
 }
+
+// Reproduces a hint-index leak: a store whose size sits at a multiple of
+// the hint sampling interval (FOR_buffer_depth * cstore_sampling_rate = 128)
+// while being churned by interleaved appends and prefix truncations. The
+// sampling condition keys off the total store size, so at such sizes every
+// append inserts a hint (~one per element instead of one per 128). The
+// accumulated hints inflate inflated_actual_size() several-fold, which in
+// turn makes the archiver's spillover size heuristics diverge from the
+// size of a freshly encoded manifest with identical content.
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_steady_state_churn_hints) {
+    namespace rg = random_generators;
+    segment_meta_cstore store;
+
+    int64_t next_base = 5000000;
+    int64_t ts = 1780000000000;
+    int64_t delta = 400000;
+    std::deque<int64_t> live_bases;
+
+    auto make_next = [&]() {
+        auto base = next_base;
+        auto committed = base + 75 + rg::get_int(0, 20);
+        segment_meta m{
+          .is_compacted = false,
+          .size_bytes = static_cast<size_t>(16000 + rg::get_int(0, 4000)),
+          .base_offset = model::offset(base),
+          .committed_offset = model::offset(committed),
+          .base_timestamp = model::timestamp(ts),
+          .max_timestamp = model::timestamp(ts + 300000 + rg::get_int(0, 9000)),
+          .delta_offset = model::offset_delta(delta),
+          .ntp_revision = model::initial_revision_id(1),
+          .archiver_term = model::term_id(115),
+          .segment_term = model::term_id(115),
+          .delta_offset_end = model::offset_delta(
+            delta + 10 + rg::get_int(0, 4)),
+          .sname_format = segment_name_format::v3,
+          .metadata_size_hint = 0,
+        };
+        next_base = committed + 1;
+        ts = m.max_timestamp.value() + 100;
+        delta = m.delta_offset_end();
+        live_bases.push_back(base);
+        return m;
+    };
+
+    // Must be a multiple of 128 and larger than one frame (1024) so hints
+    // in the trailing frames survive head truncation.
+    constexpr size_t steady_size = 1920;
+    for (size_t i = 0; i < steady_size; ++i) {
+        store.insert(make_next());
+    }
+    store.flush_write_buffer();
+
+    for (size_t round = 0; round < 3000; ++round) {
+        store.insert(make_next());
+        // production reads between mutations flush single-entry batches
+        (void)store.size();
+        live_bases.pop_front();
+        store.prefix_truncate(model::offset(live_bases.front()));
+    }
+
+    // rebuild a store with identical content, the way the spillover
+    // path re-encodes the manifest tail
+    segment_meta_cstore fresh;
+    for (auto it = store.begin(); it != store.end(); ++it) {
+        fresh.insert(*it);
+        fresh.flush_write_buffer();
+    }
+    auto [churned_inflated, churned_actual] = store.inflated_actual_size();
+    auto [fresh_inflated, fresh_actual] = fresh.inflated_actual_size();
+    BOOST_TEST_MESSAGE(
+      "churned: " << churned_actual << " bytes, " << store.hints_size()
+                  << " hints; fresh: " << fresh_actual << " bytes, "
+                  << fresh.hints_size() << " hints");
+
+    // Captures the current (buggy) behavior: the hint map grows towards
+    // one entry per element instead of the designed one per 128, and the
+    // reported size diverges from the freshly encoded equivalent by an
+    // order of magnitude.
+    BOOST_REQUIRE_GE(store.hints_size(), steady_size / 2);
+    BOOST_REQUIRE_GE(churned_actual, 8 * fresh_actual);
+}

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -3137,36 +3137,18 @@ ss::future<> ntp_archiver::apply_spillover() {
         }
         return manifest().size() < manifest_max_segments.value() * 2;
     };
-    auto spillover_complete = [&](
-                                const cloud_storage::spillover_manifest& tail) {
-        // Don't allow empty spillover manifests even if the limit
-        // is too low.
-        if (manifest_size_limit.has_value()) {
-            return tail.segments_metadata_bytes() >= manifest_size_limit.value()
-                   && tail.size() > 0;
-        }
-        return tail.size() >= manifest_max_segments.value() && tail.size() > 0;
-    };
     while (!stop_condition()) {
-        auto tail = [&]() {
-            cloud_storage::spillover_manifest tail(_ntp, _rev);
-            for (const auto& meta : manifest()) {
-                vlog(
-                  _rtclog.trace,
-                  "Adding segment {} to the spillover manifest that starts at "
-                  "{}",
-                  meta,
-                  tail.get_start_offset().value_or(model::offset{}));
-                tail.add(meta);
-                // No performance impact since all writes here are
-                // sequential.
-                tail.flush_write_buffer();
-                if (spillover_complete(tail)) {
-                    break;
-                }
-            }
-            return tail;
-        }();
+        auto tail = make_spillover_tail(
+          manifest(), manifest_size_limit, manifest_max_segments);
+        if (tail.empty()) {
+            vlog(
+              _rtclog.warn,
+              "Can't apply spillover, the manifest with {} segments and {} "
+              "bytes can't be split",
+              manifest().size(),
+              manifest().segments_metadata_bytes());
+            co_return;
+        }
         vlog(
           _rtclog.info,
           "Preparing spillover: manifest has {} segments and {} bytes, "
@@ -3190,6 +3172,17 @@ ss::future<> ntp_archiver::apply_spillover() {
           first,
           last,
           spillover_meta);
+
+        // Replicating a spillover command that the STM will reject on
+        // apply would fail housekeeping and leak the uploaded manifest,
+        // so validate it upfront the same way the STM does.
+        if (!manifest().safe_spillover_manifest(spillover_meta)) {
+            vlog(
+              _rtclog.error,
+              "Aborting spillover, the command won't be applicable: {}",
+              spillover_meta);
+            co_return;
+        }
 
         retry_chain_node upload_rtc(
           manifest_upload_timeout, manifest_upload_backoff, &_rtcnode);
@@ -3251,6 +3244,43 @@ ss::future<> ntp_archiver::apply_spillover() {
         // Reset fence for the next iteration
         fence = emit_rw_fence();
     }
+}
+
+cloud_storage::spillover_manifest make_spillover_tail(
+  const cloud_storage::partition_manifest& manifest,
+  std::optional<size_t> size_limit,
+  std::optional<size_t> max_segments) {
+    cloud_storage::spillover_manifest tail(
+      manifest.get_ntp(), manifest.get_revision_id());
+    auto tail_complete = [&] {
+        // Don't allow empty spillover manifests even if the limit
+        // is too low.
+        if (size_limit.has_value()) {
+            return tail.segments_metadata_bytes() >= size_limit.value()
+                   && tail.size() > 0;
+        }
+        return max_segments.has_value() && tail.size() >= max_segments.value()
+               && tail.size() > 0;
+    };
+    auto remaining = manifest.size();
+    for (const auto& meta : manifest) {
+        // The limits are not guaranteed to be reachable: the manifest
+        // measures its own metadata size differently from a freshly
+        // encoded copy of the same segments, so the tail may measure
+        // smaller than the manifest it was carved from. The last segment
+        // has to stay behind regardless.
+        if (remaining == 1) {
+            break;
+        }
+        tail.add(meta);
+        // No performance impact since all writes here are sequential.
+        tail.flush_write_buffer();
+        --remaining;
+        if (tail_complete()) {
+            break;
+        }
+    }
+    return tail;
 }
 
 flush_result ntp_archiver::flush() {

--- a/src/v/cluster/archival/ntp_archiver_service.h
+++ b/src/v/cluster/archival/ntp_archiver_service.h
@@ -16,6 +16,7 @@
 #include "cloud_storage/remote.h"
 #include "cloud_storage/remote_path_provider.h"
 #include "cloud_storage/remote_segment_index.h"
+#include "cloud_storage/spillover_manifest.h"
 #include "cloud_storage/types.h"
 #include "cluster/archival/archival_policy.h"
 #include "cluster/archival/probe.h"
@@ -839,5 +840,20 @@ private:
 
     friend class archiver_fixture;
 };
+
+/// Build the section of the STM manifest that will be offloaded to the
+/// cloud as a spillover manifest. Segments are consumed from the front of
+/// the manifest until the tail reaches 'size_limit' bytes of metadata (or
+/// 'max_segments' elements if the size limit is not set).
+///
+/// The tail never covers the entire manifest: at least one segment is
+/// always left behind, otherwise the resulting spillover command would be
+/// rejected by 'partition_manifest::safe_spillover_manifest' which
+/// requires the manifest to remain non-empty after the spillover range is
+/// removed.
+cloud_storage::spillover_manifest make_spillover_tail(
+  const cloud_storage::partition_manifest& manifest,
+  std::optional<size_t> size_limit,
+  std::optional<size_t> max_segments);
 
 } // namespace archival

--- a/src/v/cluster/archival/tests/BUILD
+++ b/src/v/cluster/archival/tests/BUILD
@@ -207,6 +207,23 @@ redpanda_cc_btest(
 )
 
 redpanda_cc_btest(
+    name = "spillover_tail_test",
+    timeout = "short",
+    srcs = [
+        "spillover_tail_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/cloud_storage",
+        "//src/v/cluster",
+        "//src/v/model",
+        "//src/v/test_utils:seastar_boost",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
     name = "retention_strategy_test",
     timeout = "short",
     srcs = [

--- a/src/v/cluster/archival/tests/spillover_tail_test.cc
+++ b/src/v/cluster/archival/tests/spillover_tail_test.cc
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/partition_manifest.h"
+#include "cloud_storage/spillover_manifest.h"
+#include "cluster/archival/ntp_archiver_service.h"
+#include "model/fundamental.h"
+#include "model/timestamp.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+using namespace archival;
+
+namespace {
+
+cloud_storage::partition_manifest make_manifest(size_t num_segments) {
+    cloud_storage::partition_manifest manifest(
+      model::ntp(
+        model::kafka_namespace, model::topic("panda"), model::partition_id(0)),
+      model::initial_revision_id(1));
+    int64_t base = 0;
+    int64_t ts = 1780000000000;
+    for (size_t i = 0; i < num_segments; ++i) {
+        auto committed = base + 80;
+        manifest.add(
+          cloud_storage::segment_meta{
+            .is_compacted = false,
+            .size_bytes = 18000,
+            .base_offset = model::offset(base),
+            .committed_offset = model::offset(committed),
+            .base_timestamp = model::timestamp(ts),
+            .max_timestamp = model::timestamp(ts + 300000),
+            .delta_offset = model::offset_delta(0),
+            .ntp_revision = model::initial_revision_id(1),
+            .archiver_term = model::term_id(1),
+            .segment_term = model::term_id(1),
+            .delta_offset_end = model::offset_delta(0),
+            .sname_format = cloud_storage::segment_name_format::v3,
+            .metadata_size_hint = 0,
+          });
+        base = committed + 1;
+        ts += 300000;
+    }
+    return manifest;
+}
+
+} // namespace
+
+SEASTAR_THREAD_TEST_CASE(test_spillover_tail_stops_at_segment_limit) {
+    auto manifest = make_manifest(20);
+    auto tail = make_spillover_tail(manifest, std::nullopt, 5);
+    BOOST_REQUIRE_EQUAL(tail.size(), 5);
+    BOOST_REQUIRE_EQUAL(
+      tail.get_start_offset().value(), manifest.get_start_offset().value());
+    BOOST_REQUIRE(
+      manifest.safe_spillover_manifest(tail.make_manifest_metadata()));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_spillover_tail_never_consumes_whole_manifest) {
+    // The size limit is impossible to reach: without a guard the tail
+    // would swallow the entire manifest and the resulting spillover
+    // command would be rejected by safe_spillover_manifest on apply
+    // (there has to be a segment left after the spillover range).
+    auto manifest = make_manifest(20);
+    auto tail = make_spillover_tail(manifest, 100_MiB, std::nullopt);
+    BOOST_REQUIRE_EQUAL(tail.size(), 19);
+    BOOST_REQUIRE(
+      manifest.safe_spillover_manifest(tail.make_manifest_metadata()));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_spillover_tail_single_segment_manifest) {
+    // Nothing can be spilled from a single-segment manifest
+    auto manifest = make_manifest(1);
+    auto tail = make_spillover_tail(manifest, 100_MiB, std::nullopt);
+    BOOST_REQUIRE_EQUAL(tail.size(), 0);
+}

--- a/src/v/utils/delta_for.h
+++ b/src/v/utils/delta_for.h
@@ -1261,6 +1261,14 @@ public:
         return _frames.back().get_current_stream_pos();
     }
 
+    /// Number of elements in the last (currently appended to) frame
+    size_t last_frame_size() const {
+        if (_frames.empty()) {
+            return 0;
+        }
+        return _frames.back().size();
+    }
+
     struct column_tx_t {
         using frame_tx_t = typename frame_t::frame_tx_t;
         using frame_list_t = std::list<frame_t>;


### PR DESCRIPTION
## The problem

On a long-lived partition with time-based retention and small, frequent segments, the archiver can get permanently stuck retrying spillover. Every housekeeping round logs:

```
WARN  cloud_storage - partition_manifest.cc - Can't apply spillover manifest because the end of the manifest is not aligned, ...
ERROR cluster - archival_metadata_stm.cc - Can't apply spillover_cmd: ...
WARN  archival - Error occurred during housekeeping: Spillover command applied with invalid manifest: ...
```

and each attempt uploads a uniquely-named spillover manifest to the bucket that is never referenced afterwards (an orphaned object per round, ~288/day), plus a `spillover_cmd` in the raft log that is rejected on apply. Observed in production running for months.

## Root cause

`column_store::append` samples an index hint when `current_size % 128 == 0`. This gives the intended one-hint-per-128-elements only for a store that grows. A partition in retention steady state keeps a roughly constant segment count, and when that count settles on a multiple of 128 (e.g. 7 days retention ÷ ~5.25 min/segment = 1920 = 15×128 segments), **every** append inserts a ~300 byte hint. The hints are only garbage-collected when the head frame passes them, so the map accumulates towards one entry per live segment and inflates `segments_metadata_bytes()` by an order of magnitude (measured: 614 KiB vs 37 KiB for identical content).

The inflated size crosses the spillover trigger (`cloud_storage_spillover_manifest_size × 2`), but the spillover tail is a freshly encoded manifest that measures only ~37 KiB for the same segments and never reaches the ×1 completion limit. The tail therefore consumes the *entire* STM manifest, and `safe_spillover_manifest` correctly rejects the command on apply because no segment remains after the spillover range — after the manifest was already uploaded and the command replicated. Nothing changes the inputs, so the next round repeats the identical doomed operation.

## The commits

1. **`cloud_storage: regression test for hint sampling under churn`** — test-only commit that reproduces the issue. It models the production workload (steady 1920 = 15×128 segments, one append + one prefix truncation per round) and captures the current buggy behavior: 1848 hints instead of ~15, 614 KiB reported for content that freshly encodes to 37 KiB. The commit asserts the buggy values so it stays green for bisecting; the next commit flips the expectations.

2. **`cloud_storage: sample cstore hints by position in frame`** — the fix: sample by the element's position within the current frame instead of the total store size. Append-only stores behave exactly as before (frames hold 1024 = 8×128 elements); churned stores now keep the designed 1/128 hint density (measured after the fix: 15 hints, 39 KiB vs 37 KiB fresh). Flips the regression test assertions to the designed bounds.

3. **`archival: don't let spillover consume the whole STM manifest`** — defense in depth for any remaining accounting divergence:
   - tail construction extracted into `make_spillover_tail()`, which always leaves the last segment behind, so the command stays applicable and the loop converges even when the size limit is unreachable;
   - the spillover command is validated with `safe_spillover_manifest` (now `const`) **before** the manifest upload and replication, so a doomed spillover can no longer leak bucket objects or dead raft commands.

On already-affected clusters the first housekeeping round after upgrade spills all-but-one segment into a single spillover manifest and the STM manifest rebuilds compact, which stops the log spam and the object leak immediately.

## Verification

- every commit builds and its tests pass, including the test-only first commit (validated against unfixed code)
- new tests: `test_segment_meta_cstore_steady_state_churn_hints`, `spillover_tail_test` (segment-limit, unreachable-size-limit, and single-segment cases)
- `segment_meta_cstore_test`, `delta_for_test`, `partition_manifest_test`, `ntp_archiver_test`, and `cloud_storage_e2e_test` (spillover cases) all pass

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x

## Release Notes

### Bug fixes

* Fixed a rare condition where Tiered Storage metadata spillover could get permanently stuck on partitions with small, frequent segments, repeatedly logging "Can't apply spillover_cmd" and leaving orphaned spillover manifest objects in the bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
