### PR TITLE
`storage`: reduce log level for shutdown exception in `disk_usage()`

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -4255,8 +4255,10 @@ ss::future<usage_report> disk_log_impl::disk_usage(gc_config cfg) {
           usage{},
           [](usage acc, usage u) { return acc + u; });
 
-        vlog(
-          gclog.warn,
+        vlogl(
+          gclog,
+          ssx::is_shutdown_exception(e) ? ss::log_level::debug
+                                        : ss::log_level::warn,
           "Unable to collect disk usage for ntp {}: {}, reporting usage of {} "
           "with no reclaimable bytes",
           config().ntp(),


### PR DESCRIPTION
What it says on the tin 

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
