### PR TITLE
[CORE-16760] Add additional unfinalized upgrade test for role/SR sync feature flags

### DIFF
--- a/src/v/cluster_link/model/tests/test_model.cc
+++ b/src/v/cluster_link/model/tests/test_model.cc
@@ -37,6 +37,31 @@ struct schema_registry_sync_config_v0
 
     auto serde_fields() { return std::tie(sync_schema_registry_topic_mode); }
 };
+
+// The shape of link_configuration before role sync (v26.2) appended
+// role_sync_cfg: the four fields that preceded it, at the original envelope
+// version. Models a node on the prior release decoding a link configuration
+// written by an upgraded node. Reuses the current nested config types (as
+// schema_registry_sync_config_v0 does) -- only the absence of the trailing
+// role_sync_cfg field is modeled here.
+struct link_configuration_v0
+  : serde::envelope<
+      link_configuration_v0,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    topic_metadata_mirroring_config topic_metadata_mirroring_cfg;
+    consumer_groups_mirroring_config consumer_groups_mirroring_cfg;
+    security_settings_sync_config security_settings_sync_cfg;
+    schema_registry_sync_config schema_registry_sync_cfg;
+
+    auto serde_fields() {
+        return std::tie(
+          topic_metadata_mirroring_cfg,
+          consumer_groups_mirroring_cfg,
+          security_settings_sync_cfg,
+          schema_registry_sync_cfg);
+    }
+};
 } // namespace
 
 TEST(test_model, test_no_leak_private_data) {
@@ -219,6 +244,58 @@ TEST(test_model, role_sync_config_serde_round_trip) {
     EXPECT_EQ(
       decoded.role_sync_cfg.get_task_interval(), std::chrono::seconds{45});
 }
+
+// Downgrade safety for the unfinalized-upgrade feature. Role sync (v26.2)
+// appends role_sync_cfg to link_configuration as a trailing field, bumping the
+// envelope to version<1> while leaving compat_version at 0. Because shadow
+// links exist since v25.3, a link created or edited on the upgraded binary
+// while the upgrade is still unfinalized persists a v1 link_configuration in
+// the controller log; if that upgrade is rolled back, a node on the prior
+// release must still decode the record -- recovering every field it knows and
+// skipping the trailing role_sync_cfg. If this breaks (compat_version bumped,
+// or a field inserted ahead of role_sync_cfg) an unfinalized downgrade could no
+// longer replay the controller log.
+TEST(test_model, link_configuration_legacy_reads_v1_role_sync) {
+    link_configuration cfg;
+    // A field that predates role_sync_cfg: the legacy reader must recover it.
+    cfg.topic_metadata_mirroring_cfg.is_enabled = enabled_t::no;
+    cfg.topic_metadata_mirroring_cfg.task_interval = std::chrono::seconds{45};
+    // The trailing v1-only field, populated so the test proves it is skipped
+    // rather than corrupting the decode of the fields ahead of it.
+    cfg.role_sync_cfg.is_enabled = enabled_t::no;
+    cfg.role_sync_cfg.role_name_filters.push_back(
+      resource_name_filter_pattern{
+        .pattern_type = filter_pattern_type::prefix,
+        .filter = filter_type::include,
+        .pattern = "analytics-"});
+
+    auto legacy = serde_to<link_configuration_v0>(cfg);
+
+    EXPECT_EQ(legacy.topic_metadata_mirroring_cfg.is_enabled, enabled_t::no);
+    EXPECT_EQ(
+      legacy.topic_metadata_mirroring_cfg.get_task_interval(),
+      std::chrono::seconds{45});
+}
+
+// The complementary upgrade-read direction: a link_configuration written by the
+// prior release (no role_sync_cfg field) is decoded by the current binary,
+// which must default role_sync_cfg rather than fail. An upgraded node reads
+// pre-upgrade link records this way on every restart.
+TEST(test_model, link_configuration_reads_v0_defaults_role_sync) {
+    link_configuration_v0 legacy;
+    legacy.topic_metadata_mirroring_cfg.is_enabled = enabled_t::no;
+
+    auto cfg = serde_to<link_configuration>(legacy);
+
+    EXPECT_EQ(cfg.topic_metadata_mirroring_cfg.is_enabled, enabled_t::no);
+    // role_sync_cfg falls back to its defaults: no filters, so the migrator is
+    // a no-op until one is configured.
+    EXPECT_TRUE(cfg.role_sync_cfg.role_name_filters.empty());
+    EXPECT_EQ(
+      cfg.role_sync_cfg.get_task_interval(),
+      role_sync_config::task_interval_default);
+}
+
 TEST(test_model, select_role_include_exclude_prefix) {
     using namespace cluster_link::model;
     chunked_vector<resource_name_filter_pattern> patterns;

--- a/src/v/redpanda/admin/services/shadow_link/shadow_link.cc
+++ b/src/v/redpanda/admin/services/shadow_link/shadow_link.cc
@@ -32,7 +32,7 @@ void check_sr_api_sync_supported(
     if (!feature_table.is_active(features::feature::shadow_link_sr_api_sync)) {
         throw serde::pb::rpc::failed_precondition_exception(
           "Schema Registry API sync mode cannot be configured until the "
-          "cluster is fully upgraded");
+          "upgrade is finalized");
     }
 }
 
@@ -44,8 +44,7 @@ void check_role_sync_supported(
     }
     if (!feature_table.is_active(features::feature::shadow_link_role_sync)) {
         throw serde::pb::rpc::failed_precondition_exception(
-          "Role sync cannot be configured until the cluster is fully "
-          "upgraded");
+          "Role sync cannot be configured until the upgrade is finalized");
     }
 }
 } // namespace

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -1678,7 +1678,7 @@ class ManualFinalizationUpgradeTest(UnfinalizedUpgradeMixin, FeaturesTestBase):
         # latest; the flag rides along in the controller log untouched.
         self.logger.info(f"Upgrading to intermediate release {mid}")
         mid_logical = self._upgrade_all_to(mid)
-        self._wait_for_cluster_version(mid_logical)
+        self._wait_for_version_everywhere(mid_logical, timeout_sec=60)
         held_version = mid_logical
 
         # The v26.1 hop was NOT gated, so the active version -- which doubles as

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -1174,12 +1174,6 @@ class ManualFinalizationTest(FeaturesTestBase):
         ]
 
 
-# The `features_auto_finalization` knob was backported to v26.1.9, so the real
-# upgrade below must start from a released patch that already has it. The knob
-# lets a cluster opt out of auto-finalization *before* upgrading to a HEAD build
-# that ships the gating logic and the admin v2 RPCs.
-MANUAL_FINALIZE_MIN_OLD_RELEASE = (26, 1, 9)
-
 # The same knob was also backported to v25.3.15, the oldest release from which a
 # multi-hop upgrade (v25.3 -> v26.1 -> HEAD) can carry the opt-out through every
 # hop with the flag set only once.
@@ -1279,10 +1273,10 @@ class ManualFinalizationUpgradeTest(UnfinalizedUpgradeMixin, FeaturesTestBase):
         old_release = self.installer.highest_from_prior_feature_version(
             RedpandaInstaller.HEAD
         )
-        assert old_release >= MANUAL_FINALIZE_MIN_OLD_RELEASE, (
+        assert old_release >= self.MIN_OLD_RELEASE, (
             f"prior feature version {old_release} predates the "
             f"features_auto_finalization backport "
-            f"{MANUAL_FINALIZE_MIN_OLD_RELEASE}; cannot opt out before upgrade"
+            f"{self.MIN_OLD_RELEASE}; cannot opt out before upgrade"
         )
         self.old_release = old_release
         self.logger.info(f"Starting cluster on old release {old_release}")
@@ -1658,9 +1652,8 @@ class ManualFinalizationUpgradeTest(UnfinalizedUpgradeMixin, FeaturesTestBase):
             f"backport {MANUAL_FINALIZE_MIN_OLDEST_RELEASE}"
         )
         mid, _ = self.installer.latest_for_line((26, 1))
-        assert mid >= MANUAL_FINALIZE_MIN_OLD_RELEASE, (
-            f"latest v26.1 patch {mid} predates the backport "
-            f"{MANUAL_FINALIZE_MIN_OLD_RELEASE}"
+        assert mid >= self.MIN_OLD_RELEASE, (
+            f"latest v26.1 patch {mid} predates the backport {self.MIN_OLD_RELEASE}"
         )
 
         # Hop 0: boot the oldest release and opt out of auto-finalization once.

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -30,6 +30,7 @@ from rptest.services.cluster import cluster
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 from rptest.services.redpanda_installer import RedpandaInstaller, wait_for_num_versions
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.tests.unfinalized_upgrade_mixin import UnfinalizedUpgradeMixin
 from rptest.util import expect_exception, wait_until_result
 from rptest.utils.node_operations import NodeDecommissionWaiter
 from rptest.utils.rpenv import sample_license, sample_license_v1
@@ -1228,7 +1229,7 @@ PERTURB_ACKNOWLEDGED_FEATURES = frozenset(
 )
 
 
-class ManualFinalizationUpgradeTest(FeaturesTestBase):
+class ManualFinalizationUpgradeTest(UnfinalizedUpgradeMixin, FeaturesTestBase):
     """
     Real-upgrade counterpart to ManualFinalizationTest.
 
@@ -1292,76 +1293,6 @@ class ManualFinalizationUpgradeTest(FeaturesTestBase):
         self.logger.info(
             f"Old release {old_release} reports logical version {self.old_logical}"
         )
-
-    def _restart_at_new(self, nodes):
-        """Upgrade `nodes` to the HEAD build and restart them in place."""
-        self.installer.install(nodes, RedpandaInstaller.HEAD)
-        self.redpanda.restart_nodes(nodes)
-        self._wait_for_cluster_settled()
-
-        self.new_logical = self._node_latest_logical_version(nodes[0])
-        self.logger.info(f"HEAD build reports logical version {self.new_logical}")
-        assert self.new_logical > self.old_logical, (
-            f"expected HEAD logical version {self.new_logical} to exceed the old "
-            f"version {self.old_logical}; the upgrade did not raise the version"
-        )
-
-    def _node_latest_logical_version(self, node):
-        """Read a (possibly just-restarted) node's latest logical version,
-        tolerating the brief window before it is serving the admin API."""
-
-        def query():
-            return self.admin.get_features(node=node).get("node_latest_version")
-
-        return wait_until_result(
-            query,
-            timeout_sec=30,
-            backoff_sec=1,
-            err_msg="node did not report node_latest_version after upgrade",
-        )
-
-    def _upgrade_all_to(self, version):
-        """Install `version` on every node, restart in place, and return the
-        binary's latest logical version."""
-        self.installer.install(self.redpanda.nodes, version)
-        self.redpanda.restart_nodes(self.redpanda.nodes)
-        self._wait_for_cluster_settled()
-        return self._node_latest_logical_version(self.redpanda.nodes[0])
-
-    def _wait_for_cluster_version(self, target, timeout_sec=60):
-        """Wait until every node reports cluster_version == target."""
-
-        def check():
-            return all(
-                self.admin.get_features(node=n)["cluster_version"] == target
-                for n in self.redpanda.nodes
-            )
-
-        wait_until(check, timeout_sec=timeout_sec, backoff_sec=1)
-
-    def _wait_for_cluster_settled(self, timeout_sec=90):
-        """Wait for the cluster to settle after a restart: every broker has
-        rejoined and no under-replicated partitions remain. `start_node` only
-        waits for per-node readiness (the v1 ready probe), not cluster
-        convergence -- so without this a "did not advance" assertion could pass
-        merely because the controller has not yet observed the upgrade."""
-        self.redpanda.wait_for_membership(first_start=False)
-        wait_until(
-            self.redpanda.healthy,
-            timeout_sec=timeout_sec,
-            backoff_sec=2,
-            err_msg="cluster did not become healthy after restart",
-        )
-
-    def _downgrade_all_to(self, release):
-        """Roll every node back to `release` (an older binary) without
-        finalizing, then wait for the cluster to come back healthy. This is the
-        rollback the unfinalized-upgrade feature is meant to preserve: because
-        the active version was never advanced, the older binary can still run on
-        the existing on-disk data."""
-        self.installer.install(self.redpanda.nodes, release)
-        self.redpanda.restart_nodes(self.redpanda.nodes)
-        self._wait_for_cluster_settled()
 
     def _perturb(self, phase):
         """Perturb the cluster while it sits in `phase` (e.g.
@@ -1625,45 +1556,6 @@ class ManualFinalizationUpgradeTest(FeaturesTestBase):
             "perturbation coverage: add an exercise in the matching _perturb_* "
             "step, or acknowledge them in PERTURB_ACKNOWLEDGED_FEATURES"
         )
-
-    def _disable_auto_finalization(self):
-        self.redpanda.set_cluster_config({"features_auto_finalization": False})
-
-    def _call_with_leader_retry(self, call, timeout_sec=30):
-        """Retry a controller-leader-routed admin v2 call through the transient
-        UNAVAILABLE window after restarts/leadership changes. See the identical
-        helper in ManualFinalizationTest for the rationale."""
-        deadline = time.time() + timeout_sec
-        while True:
-            try:
-                return call()
-            except ConnectError as e:
-                if e.code != ConnectErrorCode.UNAVAILABLE or time.time() >= deadline:
-                    raise
-                time.sleep(1)
-
-    def _finalize(self):
-        return self._call_with_leader_retry(
-            lambda: self.admin_v2.features().finalize_upgrade(
-                features_pb2.FinalizeUpgradeRequest()
-            )
-        )
-
-    def _get_upgrade_status(self):
-        return self._call_with_leader_retry(
-            lambda: self.admin_v2.features().get_upgrade_status(
-                features_pb2.GetUpgradeStatusRequest()
-            )
-        )
-
-    def _wait_for_status_state(self, state, timeout_sec=30):
-        """Wait until GetUpgradeStatus reports `state`; return that status."""
-        wait_until(
-            lambda: self._get_upgrade_status().state == state,
-            timeout_sec=timeout_sec,
-            backoff_sec=1,
-        )
-        return self._get_upgrade_status()
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_auto_finalization_disabled_blocks_advance(self):

--- a/tests/rptest/tests/cluster_linking_unfinalized_upgrade_test.py
+++ b/tests/rptest/tests/cluster_linking_unfinalized_upgrade_test.py
@@ -1,0 +1,420 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import json
+
+import google.protobuf.duration_pb2 as duration_pb2
+import google.protobuf.field_mask_pb2 as field_mask_pb2
+from connectrpc.errors import ConnectError, ConnectErrorCode
+from ducktape.utils.util import wait_until
+
+from rptest.clients.admin.proto.redpanda.core.admin.v2 import (
+    features_pb2,
+    security_pb2,
+    shadow_link_pb2,
+)
+from rptest.clients.admin.v2 import Admin as AdminV2
+from rptest.clients.rpk import RpkTool
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from rptest.services.multi_cluster_services import SecondaryClusterArgs
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, SchemaRegistryConfig
+from rptest.services.redpanda_installer import RedpandaInstaller
+from rptest.tests.cluster_linking_test_base import ShadowLinkTestBase
+from rptest.tests.rbac_test_v2 import AdminV2RoleWrapper
+from rptest.tests.schema_registry_test import SchemaRegistryRedpandaClient
+from rptest.tests.unfinalized_upgrade_mixin import UnfinalizedUpgradeMixin
+
+# The old release the target starts on must carry the backported
+# `features_auto_finalization` knob so the opt-out can be set before upgrading
+# to a HEAD build that ships the gating logic. Backported to v26.1.9. Kept in
+# sync with ManualFinalizationUpgradeTest's MANUAL_FINALIZE_MIN_OLD_RELEASE.
+MIN_OLD_RELEASE = (26, 1, 9)
+
+LINK_NAME = "unfinalized-link"
+
+# Gate messages from shadow_link.cc (check_role_sync_supported /
+# check_sr_api_sync_supported). Matched as substrings so exact wording drift in
+# the tail of the sentence does not break the test.
+ROLE_SYNC_GATE = "Role sync cannot be configured"
+SR_API_GATE = "Schema Registry API sync mode cannot be configured"
+
+# A source topic mirrored to the target to prove the link's data plane keeps
+# working across the upgrade/downgrade transitions (feature-agnostic signal).
+MIRROR_TOPIC = "mirror-check"
+MIRROR_RECORDS_PRE = 10
+MIRROR_RECORDS_POST = 10
+
+# Roles seeded on the source. Only the "synced-" prefixed one is in the role
+# sync filter; the excluded one must never appear on the target.
+SYNCED_ROLE = "synced-app"
+EXCLUDED_ROLE = "excluded-app"
+
+# A single Schema Registry subject registered on the source, expected to appear
+# on the target once SR API-mode sync is configured post-finalize.
+SR_SUBJECT = "synced-value"
+
+
+class ShadowLinkUnfinalizedUpgradeTest(ShadowLinkTestBase, UnfinalizedUpgradeMixin):
+    """
+    Full-lifecycle cluster-linking test across an *unfinalized* upgrade.
+
+    The target cluster (the one that owns the shadow link, runs the sync tasks,
+    and persists the `link_configuration`) is `self.redpanda`. It boots on the
+    prior release, opts out of auto-finalization, and is rolled forward to HEAD
+    while the active (downgrade-floor) version is held back -- the state a real
+    deployment may sit in for weeks. The source cluster is a fixed HEAD cluster
+    (features active) providing topics, roles, and schemas to mirror.
+
+    The lifecycle exercised end to end:
+      1. While unfinalized, the link's data plane works (topic mirroring) but the
+         v26.2 sync features are gated: configuring role sync or Schema Registry
+         API-mode sync is refused with FAILED_PRECONDITION.
+      2. The link's `link_configuration` -- written to the controller log by the
+         HEAD binary -- survives a rollback to the prior release: the cluster
+         comes back healthy and mirroring resumes, proving the record is
+         forward/backward wire-compatible (the integration counterpart to the
+         serde unit test link_configuration_legacy_reads_v1_role_sync).
+      3. After the upgrade is finally finalized, the gates open and both features
+         actually sync real data: roles matching the filter appear on the target,
+         and the source's schema appears in the target's Schema Registry.
+    """
+
+    def __init__(self, test_context, *args, **kwargs):
+        # Schema Registry on both clusters so SR API-mode sync can be exercised:
+        # the source registers schemas, the target imports them over the link.
+        super().__init__(
+            test_context,
+            num_brokers=3,
+            secondary_cluster_args=SecondaryClusterArgs(
+                schema_registry_config=SchemaRegistryConfig()
+            ),
+            schema_registry_config=SchemaRegistryConfig(),
+            *args,
+            **kwargs,
+        )
+
+    def setUp(self):
+        # Install the old release on the target BEFORE the base setUp starts it.
+        # MultiClusterServices asserts the primary has no started nodes and then
+        # starts it, so pre-installing here makes the target boot the old binary;
+        # the source (secondary) boots HEAD.
+        self.installer = self.redpanda._installer
+        self.old_release = self.installer.highest_from_prior_feature_version(
+            RedpandaInstaller.HEAD
+        )
+        assert self.old_release >= MIN_OLD_RELEASE, (
+            f"prior feature version {self.old_release} predates the "
+            f"features_auto_finalization backport {MIN_OLD_RELEASE}; cannot opt "
+            "out before upgrade"
+        )
+        self.logger.info(f"Target starts on old release {self.old_release}")
+        self.installer.install(self.redpanda.nodes, self.old_release)
+
+        super().setUp()
+
+        self.admin = Admin(self.redpanda)
+        self.old_logical = self.admin.get_features()["cluster_version"]
+        self.logger.info(
+            f"Old release {self.old_release} reports logical version {self.old_logical}"
+        )
+
+        # Role clients: source is where roles are authored, target is where the
+        # migrator should reproduce the filtered subset.
+        self._src_roles = AdminV2RoleWrapper(AdminV2(self.source_cluster_service))
+        self._dst_roles = AdminV2RoleWrapper(AdminV2(self.target_cluster_service))
+
+        # Schema Registry clients (port 8081) for the SR API-mode sync check.
+        self._src_sr = SchemaRegistryRedpandaClient(self.source_cluster_service)
+        self._dst_sr = SchemaRegistryRedpandaClient(self.target_cluster_service)
+
+    # ---- small helpers -----------------------------------------------------
+
+    def _role_members(self, wrapper, role):
+        """Return the set of member names (users and groups) of `role`, or an
+        empty set if the role does not exist yet (tolerates a not-yet-synced
+        role on the target)."""
+        try:
+            members = wrapper.get_role(role).members
+        except ConnectError as e:
+            assert e.code == ConnectErrorCode.NOT_FOUND, (
+                f"unexpected error reading role {role}: {e}"
+            )
+            return set()
+        names = set()
+        for m in members:
+            which = m.WhichOneof("member")
+            if which == "user":
+                names.add(m.user.name)
+            elif which == "group":
+                names.add(m.group.name)
+        return names
+
+    def _target_topic_hwm(self, topic):
+        """Sum of per-partition high watermarks for `topic` on the target, or
+        None if the (mirror) topic is not present yet. describe_topic is a lazy
+        generator, so the iteration itself must be guarded."""
+        rpk = RpkTool(self.target_cluster_service)
+        try:
+            partitions = list(rpk.describe_topic(topic, tolerant=True))
+        except Exception:
+            return None
+        if not partitions:
+            return None
+        return sum(p.high_watermark for p in partitions if p.high_watermark is not None)
+
+    def _produce_source(self, topic, count):
+        rpk = RpkTool(self.source_cluster_service)
+        for i in range(count):
+            rpk.produce(topic, key=f"k{i}", msg=f"v{i}", partition=0)
+
+    def _wait_mirrored(self, topic, min_hwm, label):
+        wait_until(
+            lambda: (self._target_topic_hwm(topic) or 0) >= min_hwm,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg=lambda: (
+                f"topic {topic} did not mirror to target ({label}): "
+                f"hwm={self._target_topic_hwm(topic)} < {min_hwm}"
+            ),
+        )
+
+    def _register_source_schema(self):
+        # Body shape matches SchemaRegistrySyncMixin._register: the schema dict
+        # is JSON-encoded into the "schema" field (AVRO is the SR default).
+        schema = {
+            "type": "record",
+            "name": "SyncedRecord",
+            "fields": [{"name": "f", "type": "string"}],
+        }
+        body = json.dumps({"schema": json.dumps(schema)})
+        resp = self._src_sr.post_subjects_subject_versions(
+            subject=SR_SUBJECT, data=body
+        )
+        assert resp.status_code == 200, (
+            f"registering {SR_SUBJECT} on source SR failed: "
+            f"{resp.status_code} {resp.text}"
+        )
+
+    def _target_subjects(self):
+        # get_subjects returns the raw HTTP response, not a parsed list.
+        resp = self._dst_sr.get_subjects()
+        if resp.status_code != 200:
+            return []
+        return resp.json()
+
+    def _create_link_mirroring_topic(self, topic):
+        """Create the shadow link mirroring only `topic`.
+
+        Deliberately NOT mirror_all_topics: a "*" filter also mirrors the
+        internal _schemas topic, which would carry the source's schemas to the
+        target's Schema Registry via ordinary (v25.3) topic mirroring --
+        independently of the v26.2 SR API-mode sync feature -- and make
+        _verify_sr_api_sync_works vacuous. Restricting the filter to the data
+        topic leaves SR API-mode sync as the only path for a schema to reach
+        the target SR."""
+        req = self.create_default_link_request(
+            LINK_NAME,
+            mirror_all_topics=False,
+            mirror_all_groups=False,
+            mirror_all_acls=False,
+        )
+        req.shadow_link.configurations.topic_metadata_sync_options.auto_create_shadow_topic_filters.append(
+            shadow_link_pb2.NameFilter(
+                pattern_type=shadow_link_pb2.PATTERN_TYPE_LITERAL,
+                filter_type=shadow_link_pb2.FILTER_TYPE_INCLUDE,
+                name=topic,
+            )
+        )
+        return self.create_link_with_request(req=req)
+
+    def _update_link_role_sync(self):
+        """Fetch the link, add a role-sync config selecting the SYNCED_ROLE
+        prefix, and apply it via the role_sync_options field mask."""
+        link = self.get_link(LINK_NAME)
+        link.configurations.role_sync_options.CopyFrom(
+            shadow_link_pb2.RoleSyncOptions(
+                interval=duration_pb2.Duration(seconds=1),
+                paused=False,
+                role_name_filters=[
+                    shadow_link_pb2.NameFilter(
+                        pattern_type=shadow_link_pb2.PATTERN_TYPE_PREFIX,
+                        filter_type=shadow_link_pb2.FILTER_TYPE_INCLUDE,
+                        name="synced-",
+                    )
+                ],
+            )
+        )
+        return self.update_link(
+            shadow_link=link,
+            update_mask=field_mask_pb2.FieldMask(
+                paths=["configurations.role_sync_options"]
+            ),
+        )
+
+    def _update_link_sr_api(self):
+        """Fetch the link, add Schema Registry API-mode sync pointed at the
+        source SR, and apply it via the schema_registry_sync_options mask."""
+        link = self.get_link(LINK_NAME)
+        api = shadow_link_pb2.SchemaRegistrySyncOptions.ShadowSchemaRegistryApi(
+            source_url=self._src_sr.base_uri(),
+            tail_interval=duration_pb2.Duration(seconds=2),
+            full_sync_interval=duration_pb2.Duration(seconds=2),
+        )
+        link.configurations.schema_registry_sync_options.shadow_schema_registry_api.CopyFrom(
+            api
+        )
+        return self.update_link(
+            shadow_link=link,
+            update_mask=field_mask_pb2.FieldMask(
+                paths=["configurations.schema_registry_sync_options"]
+            ),
+        )
+
+    # ---- lifecycle phases --------------------------------------------------
+
+    def _assert_v26_2_sync_gated(self):
+        """While unfinalized, both v26.2 sync surfaces must be refused on the
+        target with FAILED_PRECONDITION and the feature-specific message -- this
+        is what keeps a downgrade safe (no role/SR-API state can be written)."""
+        try:
+            self._update_link_role_sync()
+        except ConnectError as e:
+            assert e.code == ConnectErrorCode.FAILED_PRECONDITION, (
+                f"role sync should be gated by a precondition, got {e}"
+            )
+            assert ROLE_SYNC_GATE in str(e), (
+                f"role sync rejected, but not via the feature gate: {e}"
+            )
+        else:
+            raise AssertionError("role sync should be gated while unfinalized")
+
+        try:
+            self._update_link_sr_api()
+        except ConnectError as e:
+            assert e.code == ConnectErrorCode.FAILED_PRECONDITION, (
+                f"SR API-mode sync should be gated by a precondition, got {e}"
+            )
+            assert SR_API_GATE in str(e), (
+                f"SR API-mode sync rejected, but not via the feature gate: {e}"
+            )
+        else:
+            raise AssertionError("SR API-mode sync should be gated while unfinalized")
+
+    def _verify_role_sync_works(self):
+        """Post-finalize: configuring role sync is accepted and the migrator
+        actually reproduces the filtered roles on the target."""
+        self._update_link_role_sync()
+
+        def synced():
+            return self._role_members(self._dst_roles, SYNCED_ROLE) == {
+                "alice",
+                "eng",
+            }
+
+        wait_until(
+            synced,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="filtered role did not sync to the target after finalize",
+        )
+        assert EXCLUDED_ROLE not in self._dst_roles.list_role_names(), (
+            "a role outside the sync filter was mirrored to the target"
+        )
+
+    def _verify_sr_api_sync_works(self):
+        """Post-finalize: configuring SR API-mode sync is accepted and the
+        source's subject appears in the target's Schema Registry.
+
+        The link mirrors only the data topic (not _schemas), so SR API-mode is
+        the only path by which a schema can reach the target SR. Assert the
+        subject is absent before configuring it, so its later appearance is
+        attributable to the feature rather than to topic mirroring or pre-existing
+        state -- the same rigor the role-sync check gets from the migrator being
+        the sole path for roles."""
+        assert SR_SUBJECT not in self._target_subjects(), (
+            f"{SR_SUBJECT} is on the target SR before SR API-mode sync was "
+            "configured; it reached the target by some other path (e.g. _schemas "
+            "topic mirroring), which would make this verification vacuous"
+        )
+        self._update_link_sr_api()
+
+        wait_until(
+            lambda: SR_SUBJECT in self._target_subjects(),
+            timeout_sec=90,
+            backoff_sec=1,
+            err_msg="schema did not sync to the target Schema Registry after finalize",
+        )
+
+    @cluster(num_nodes=6, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_full_lifecycle(self):
+        # Seed the source data plane that the link mirrors/syncs from.
+        self._src_roles.create_role(
+            role=SYNCED_ROLE,
+            members=[
+                security_pb2.RoleMember(user=security_pb2.RoleUser(name="alice")),
+                security_pb2.RoleMember(group=security_pb2.RoleGroup(name="eng")),
+            ],
+        )
+        self._src_roles.create_role(
+            role=EXCLUDED_ROLE,
+            members=[security_pb2.RoleMember(user=security_pb2.RoleUser(name="bob"))],
+        )
+        self._register_source_schema()
+        RpkTool(self.source_cluster_service).create_topic(MIRROR_TOPIC, partitions=1)
+
+        # Opt out of auto-finalization on the old binary, before upgrading.
+        self._disable_auto_finalization()
+
+        # Roll the target forward to HEAD. Auto-finalization is off, so the
+        # active version is held at the old version: READY_TO_FINALIZE.
+        self._restart_at_new(self.redpanda.nodes)
+        status = self._wait_for_status_state(
+            features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE
+        )
+        assert self.admin.get_features()["cluster_version"] == self.old_logical
+        assert not status.auto_finalization_enabled
+
+        # The shadow_linking feature is v25.3, so the link machinery is fully
+        # live even though the upgrade is unfinalized: create a topic-mirroring
+        # link (mirroring only MIRROR_TOPIC -- see _create_link_mirroring_topic
+        # for why _schemas must be excluded). This create writes a v1
+        # link_configuration to the controller log.
+        self._create_link_mirroring_topic(MIRROR_TOPIC)
+        self._produce_source(MIRROR_TOPIC, MIRROR_RECORDS_PRE)
+        self._wait_mirrored(MIRROR_TOPIC, MIRROR_RECORDS_PRE, "unfinalized")
+
+        # ...but the v26.2 sync features are gated off.
+        self._assert_v26_2_sync_gated()
+
+        # Roll the target back to the old release WITHOUT finalizing. The v1
+        # link_configuration written by HEAD must replay on the old binary: the
+        # cluster returns healthy, the active version is unchanged, and mirroring
+        # resumes -- proving the persisted record survived the version boundary.
+        self._downgrade_all_to(self.old_release)
+        assert self.admin.get_features()["cluster_version"] == self.old_logical
+        self._produce_source(MIRROR_TOPIC, MIRROR_RECORDS_POST)
+        self._wait_mirrored(
+            MIRROR_TOPIC, MIRROR_RECORDS_PRE + MIRROR_RECORDS_POST, "downgraded"
+        )
+
+        # Roll forward again and this time finalize: the active version advances
+        # past the gate's require_version and the v26.2 features activate.
+        self._restart_at_new(self.redpanda.nodes)
+        self._wait_for_status_state(features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE)
+        self._finalize()
+        self._wait_for_version_everywhere(self.new_logical)
+        finalized = self._wait_for_status_state(
+            features_pb2.FINALIZATION_STATE_FINALIZED
+        )
+        assert finalized.active_version == self.new_logical
+
+        # Both gates are open now: the features must actually sync real data.
+        self._verify_role_sync_works()
+        self._verify_sr_api_sync_works()

--- a/tests/rptest/tests/cluster_linking_unfinalized_upgrade_test.py
+++ b/tests/rptest/tests/cluster_linking_unfinalized_upgrade_test.py
@@ -31,12 +31,6 @@ from rptest.tests.rbac_test_v2 import AdminV2RoleWrapper
 from rptest.tests.schema_registry_test import SchemaRegistryRedpandaClient
 from rptest.tests.unfinalized_upgrade_mixin import UnfinalizedUpgradeMixin
 
-# The old release the target starts on must carry the backported
-# `features_auto_finalization` knob so the opt-out can be set before upgrading
-# to a HEAD build that ships the gating logic. Backported to v26.1.9. Kept in
-# sync with ManualFinalizationUpgradeTest's MANUAL_FINALIZE_MIN_OLD_RELEASE.
-MIN_OLD_RELEASE = (26, 1, 9)
-
 LINK_NAME = "unfinalized-link"
 
 # Gate messages from shadow_link.cc (check_role_sync_supported /
@@ -109,10 +103,10 @@ class ShadowLinkUnfinalizedUpgradeTest(ShadowLinkTestBase, UnfinalizedUpgradeMix
         self.old_release = self.installer.highest_from_prior_feature_version(
             RedpandaInstaller.HEAD
         )
-        assert self.old_release >= MIN_OLD_RELEASE, (
+        assert self.old_release >= self.MIN_OLD_RELEASE, (
             f"prior feature version {self.old_release} predates the "
-            f"features_auto_finalization backport {MIN_OLD_RELEASE}; cannot opt "
-            "out before upgrade"
+            f"features_auto_finalization backport {self.MIN_OLD_RELEASE}; cannot "
+            "opt out before upgrade"
         )
         self.logger.info(f"Target starts on old release {self.old_release}")
         self.installer.install(self.redpanda.nodes, self.old_release)

--- a/tests/rptest/tests/cluster_linking_unfinalized_upgrade_test.py
+++ b/tests/rptest/tests/cluster_linking_unfinalized_upgrade_test.py
@@ -277,35 +277,55 @@ class ShadowLinkUnfinalizedUpgradeTest(ShadowLinkTestBase, UnfinalizedUpgradeMix
             ),
         )
 
+    def _update_link_sr_topic(self):
+        """Fetch the link and enable topic-mode Schema Registry sync (shadow the
+        source _schemas topic byte-for-byte). Unlike API-mode, topic-mode
+        predates v26.2 and is not behind the shadow_link_sr_api_sync gate, so it
+        is accepted even while the upgrade is unfinalized."""
+        link = self.get_link(LINK_NAME)
+        link.configurations.schema_registry_sync_options.shadow_schema_registry_topic.CopyFrom(
+            shadow_link_pb2.SchemaRegistrySyncOptions.ShadowSchemaRegistryTopic()
+        )
+        return self.update_link(
+            shadow_link=link,
+            update_mask=field_mask_pb2.FieldMask(
+                paths=["configurations.schema_registry_sync_options"]
+            ),
+        )
+
+    def _assert_sr_sync_mode(self, expected, label):
+        """Read the link back through the controller and assert its persisted
+        Schema Registry sync mode is `expected` (a oneof field name, e.g.
+        "shadow_schema_registry_topic")."""
+        opts = self.get_link(LINK_NAME).configurations.schema_registry_sync_options
+        got = opts.WhichOneof("schema_registry_shadowing_mode")
+        assert got == expected, f"expected SR sync mode {expected} ({label}), got {got}"
+
     # ---- lifecycle phases --------------------------------------------------
+
+    def _assert_gated(self, action, gate_msg, what):
+        """Assert `action` -- an update engaging a v26.2-gated sync surface -- is
+        refused with FAILED_PRECONDITION carrying the feature-specific gate
+        message. This is what keeps a downgrade safe: no gated state reaches the
+        controller log while the upgrade is unfinalized."""
+        try:
+            action()
+        except ConnectError as e:
+            assert e.code == ConnectErrorCode.FAILED_PRECONDITION, (
+                f"{what} should be gated by a precondition, got {e}"
+            )
+            assert gate_msg in str(e), (
+                f"{what} rejected, but not via the feature gate: {e}"
+            )
+        else:
+            raise AssertionError(f"{what} should be gated while unfinalized")
 
     def _assert_v26_2_sync_gated(self):
         """While unfinalized, both v26.2 sync surfaces must be refused on the
         target with FAILED_PRECONDITION and the feature-specific message -- this
         is what keeps a downgrade safe (no role/SR-API state can be written)."""
-        try:
-            self._update_link_role_sync()
-        except ConnectError as e:
-            assert e.code == ConnectErrorCode.FAILED_PRECONDITION, (
-                f"role sync should be gated by a precondition, got {e}"
-            )
-            assert ROLE_SYNC_GATE in str(e), (
-                f"role sync rejected, but not via the feature gate: {e}"
-            )
-        else:
-            raise AssertionError("role sync should be gated while unfinalized")
-
-        try:
-            self._update_link_sr_api()
-        except ConnectError as e:
-            assert e.code == ConnectErrorCode.FAILED_PRECONDITION, (
-                f"SR API-mode sync should be gated by a precondition, got {e}"
-            )
-            assert SR_API_GATE in str(e), (
-                f"SR API-mode sync rejected, but not via the feature gate: {e}"
-            )
-        else:
-            raise AssertionError("SR API-mode sync should be gated while unfinalized")
+        self._assert_gated(self._update_link_role_sync, ROLE_SYNC_GATE, "role sync")
+        self._assert_gated(self._update_link_sr_api, SR_API_GATE, "SR API-mode sync")
 
     def _verify_role_sync_works(self):
         """Post-finalize: configuring role sync is accepted and the migrator
@@ -418,3 +438,73 @@ class ShadowLinkUnfinalizedUpgradeTest(ShadowLinkTestBase, UnfinalizedUpgradeMix
         # Both gates are open now: the features must actually sync real data.
         self._verify_role_sync_works()
         self._verify_sr_api_sync_works()
+
+    @cluster(num_nodes=6, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_topic_mode_sr_sync_survives_downgrade(self):
+        """Topic-mode Schema Registry sync -- shadowing the source _schemas topic
+        byte-for-byte -- is the pre-v26.2 mechanism and is NOT behind the
+        shadow_link_sr_api_sync gate. An operator can therefore enable it during
+        the (potentially weeks-long) unfinalized window, so the *populated*
+        schema_registry_sync_config it persists must survive a rollback to the
+        prior release.
+
+        test_full_lifecycle only ever persists an empty schema_registry_sync_cfg
+        across the downgrade (its link mirrors a data topic, and API-mode is
+        gated). This drives a populated one through a real downgrade/replay --
+        the integration counterpart to the serde unit test
+        schema_registry_sync_config_legacy_reads_v1_topic_mode, where a v0
+        (prior-release) reader must recover field 0 (topic mode) from the v1
+        record the upgraded binary wrote.
+
+        Lifecycle:
+          1. Unfinalized on HEAD: API-mode is refused (gated) while topic-mode is
+             accepted (ungated) -- the gate distinguishes the two modes. The
+             accepted config is read back through the controller.
+          2. Roll back to the prior release without finalizing: the cluster
+             returns healthy (the populated v1 record replayed on the old binary)
+             and the link's data plane keeps mirroring.
+          3. Roll forward again: the topic-mode config is still intact, proving it
+             made the v1 -> v0 -> v1 round trip uncorrupted.
+
+        Note: topic-mode has no source-side preflight (sr_preflight_checker only
+        probes API-mode), and no source schema is registered here, so enabling it
+        persists the config without actually shadowing _schemas. Functional
+        _schemas shadowing is covered by the dedicated SR sync suites; this test
+        is about the persisted config surviving the version boundary.
+        """
+        RpkTool(self.source_cluster_service).create_topic(MIRROR_TOPIC, partitions=1)
+
+        # Opt out of auto-finalization on the old binary, then roll the target
+        # forward to HEAD with the active (downgrade-floor) version held back.
+        self._disable_auto_finalization()
+        self._restart_at_new(self.redpanda.nodes)
+        self._wait_for_status_state(features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE)
+        assert self.admin.get_features()["cluster_version"] == self.old_logical
+
+        # shadow_linking is v25.3, so the link machinery is live while
+        # unfinalized: create a topic-mirroring link and confirm the data plane.
+        self._create_link_mirroring_topic(MIRROR_TOPIC)
+        self._produce_source(MIRROR_TOPIC, MIRROR_RECORDS_PRE)
+        self._wait_mirrored(MIRROR_TOPIC, MIRROR_RECORDS_PRE, "unfinalized")
+
+        # The gate distinguishes the SR sync modes: API-mode is refused...
+        self._assert_gated(self._update_link_sr_api, SR_API_GATE, "SR API-mode sync")
+        # ...but topic-mode (pre-v26.2, ungated) is accepted and persisted as a
+        # populated schema_registry_sync_config in the controller log.
+        self._update_link_sr_topic()
+        self._assert_sr_sync_mode("shadow_schema_registry_topic", "unfinalized")
+
+        # Roll back to the prior release WITHOUT finalizing. The populated v1
+        # link_configuration must replay on the old binary: healthy cluster,
+        # unchanged active version, and the data plane still mirroring.
+        self._downgrade_all_to(self.old_release)
+        assert self.admin.get_features()["cluster_version"] == self.old_logical
+        self._produce_source(MIRROR_TOPIC, MIRROR_RECORDS_POST)
+        self._wait_mirrored(
+            MIRROR_TOPIC, MIRROR_RECORDS_PRE + MIRROR_RECORDS_POST, "downgraded"
+        )
+
+        # Roll forward again: the topic-mode config survived the round trip.
+        self._restart_at_new(self.redpanda.nodes)
+        self._wait_for_status_state(features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE)
+        self._assert_sr_sync_mode("shadow_schema_registry_topic", "re-upgraded")

--- a/tests/rptest/tests/cluster_linking_unfinalized_upgrade_test.py
+++ b/tests/rptest/tests/cluster_linking_unfinalized_upgrade_test.py
@@ -212,13 +212,14 @@ class ShadowLinkUnfinalizedUpgradeTest(ShadowLinkTestBase, UnfinalizedUpgradeMix
     def _create_link_mirroring_topic(self, topic):
         """Create the shadow link mirroring only `topic`.
 
-        Deliberately NOT mirror_all_topics: a "*" filter also mirrors the
-        internal _schemas topic, which would carry the source's schemas to the
-        target's Schema Registry via ordinary (v25.3) topic mirroring --
-        independently of the v26.2 SR API-mode sync feature -- and make
-        _verify_sr_api_sync_works vacuous. Restricting the filter to the data
-        topic leaves SR API-mode sync as the only path for a schema to reach
-        the target SR."""
+        The internal _schemas topic is not mirrored by an ordinary topic
+        filter: the source topic syncer special-cases it (select_topic gates
+        _schemas on is_topic_mode()), so it is shadowed only when topic-mode
+        Schema Registry sync is configured -- never via the topic filter, "*"
+        included. That is what keeps _verify_sr_api_sync_works non-vacuous:
+        with topic-mode off, API-mode sync is the only path for a source
+        schema to reach the target SR. The single literal filter just keeps
+        this test's mirrored set to the one data topic it asserts on."""
         req = self.create_default_link_request(
             LINK_NAME,
             mirror_all_topics=False,
@@ -352,8 +353,9 @@ class ShadowLinkUnfinalizedUpgradeTest(ShadowLinkTestBase, UnfinalizedUpgradeMix
         """Post-finalize: configuring SR API-mode sync is accepted and the
         source's subject appears in the target's Schema Registry.
 
-        The link mirrors only the data topic (not _schemas), so SR API-mode is
-        the only path by which a schema can reach the target SR. Assert the
+        _schemas is never topic-mirrored here (it is shadowed only under
+        topic-mode sync, not by the topic filter), so SR API-mode is the only
+        path by which a schema can reach the target SR. Assert the
         subject is absent before configuring it, so its later appearance is
         attributable to the feature rather than to topic mirroring or pre-existing
         state -- the same rigor the role-sync check gets from the migrator being

--- a/tests/rptest/tests/unfinalized_upgrade_mixin.py
+++ b/tests/rptest/tests/unfinalized_upgrade_mixin.py
@@ -73,17 +73,6 @@ class UnfinalizedUpgradeMixin:
         self._wait_for_cluster_settled()
         return self._node_latest_logical_version(self.redpanda.nodes[0])
 
-    def _wait_for_cluster_version(self, target, timeout_sec=60):
-        """Wait until every node reports cluster_version == target."""
-
-        def check():
-            return all(
-                self.admin.get_features(node=n)["cluster_version"] == target
-                for n in self.redpanda.nodes
-            )
-
-        wait_until(check, timeout_sec=timeout_sec, backoff_sec=1)
-
     def _wait_for_cluster_settled(self, timeout_sec=90):
         """Wait for the cluster to settle after a restart: every broker has
         rejoined and no under-replicated partitions remain. `start_node` only

--- a/tests/rptest/tests/unfinalized_upgrade_mixin.py
+++ b/tests/rptest/tests/unfinalized_upgrade_mixin.py
@@ -1,0 +1,162 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import time
+
+from connectrpc.errors import ConnectError, ConnectErrorCode
+from ducktape.utils.util import wait_until
+
+from rptest.clients.admin.proto.redpanda.core.admin.v2 import features_pb2
+from rptest.services.redpanda_installer import RedpandaInstaller
+from rptest.util import wait_until_result
+
+
+class UnfinalizedUpgradeMixin:
+    """Reusable driver for the manual-finalization (unfinalized upgrade) flow:
+    roll a cluster's binaries forward with `features_auto_finalization=false`
+    so the active (downgrade-floor) version is held back, observe/finalize via
+    the admin v2 RPCs, and roll back before finalizing.
+
+    These primitives were factored out of ManualFinalizationUpgradeTest so a
+    second test can drive the same flow against a different cluster topology
+    (e.g. the target cluster of a shadow link, with a fixed source alongside).
+
+    The concrete test must provide, before any of these are called:
+      - ``self.redpanda``   -- the RedpandaService being upgraded/downgraded,
+      - ``self.installer``  -- its RedpandaInstaller (usually
+                               ``self.redpanda._installer``),
+      - ``self.admin``      -- a v1 Admin against that cluster,
+      - ``self.admin_v2``   -- an admin v2 client against that cluster,
+      - ``self.old_logical``-- the logical version of the pre-upgrade binary
+                               (set by the test's own "start at old" step).
+    ``_restart_at_new`` sets ``self.new_logical``.
+    """
+
+    def _restart_at_new(self, nodes):
+        """Upgrade `nodes` to the HEAD build and restart them in place."""
+        self.installer.install(nodes, RedpandaInstaller.HEAD)
+        self.redpanda.restart_nodes(nodes)
+        self._wait_for_cluster_settled()
+
+        self.new_logical = self._node_latest_logical_version(nodes[0])
+        self.logger.info(f"HEAD build reports logical version {self.new_logical}")
+        assert self.new_logical > self.old_logical, (
+            f"expected HEAD logical version {self.new_logical} to exceed the old "
+            f"version {self.old_logical}; the upgrade did not raise the version"
+        )
+
+    def _node_latest_logical_version(self, node):
+        """Read a (possibly just-restarted) node's latest logical version,
+        tolerating the brief window before it is serving the admin API."""
+
+        def query():
+            return self.admin.get_features(node=node).get("node_latest_version")
+
+        return wait_until_result(
+            query,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="node did not report node_latest_version after upgrade",
+        )
+
+    def _upgrade_all_to(self, version):
+        """Install `version` on every node, restart in place, and return the
+        binary's latest logical version."""
+        self.installer.install(self.redpanda.nodes, version)
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        self._wait_for_cluster_settled()
+        return self._node_latest_logical_version(self.redpanda.nodes[0])
+
+    def _wait_for_cluster_version(self, target, timeout_sec=60):
+        """Wait until every node reports cluster_version == target."""
+
+        def check():
+            return all(
+                self.admin.get_features(node=n)["cluster_version"] == target
+                for n in self.redpanda.nodes
+            )
+
+        wait_until(check, timeout_sec=timeout_sec, backoff_sec=1)
+
+    def _wait_for_cluster_settled(self, timeout_sec=90):
+        """Wait for the cluster to settle after a restart: every broker has
+        rejoined and no under-replicated partitions remain. `start_node` only
+        waits for per-node readiness (the v1 ready probe), not cluster
+        convergence -- so without this a "did not advance" assertion could pass
+        merely because the controller has not yet observed the upgrade."""
+        self.redpanda.wait_for_membership(first_start=False)
+        wait_until(
+            self.redpanda.healthy,
+            timeout_sec=timeout_sec,
+            backoff_sec=2,
+            err_msg="cluster did not become healthy after restart",
+        )
+
+    def _downgrade_all_to(self, release):
+        """Roll every node back to `release` (an older binary) without
+        finalizing, then wait for the cluster to come back healthy. This is the
+        rollback the unfinalized-upgrade feature is meant to preserve: because
+        the active version was never advanced, the older binary can still run on
+        the existing on-disk data."""
+        self.installer.install(self.redpanda.nodes, release)
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        self._wait_for_cluster_settled()
+
+    def _wait_for_version_everywhere(self, target_version, timeout_sec=20):
+        """Wait until every node reports cluster_version == target_version.
+        Version propagation lags feature-flag writes because it rides periodic
+        health messages, so this tolerates a short delay."""
+
+        def check():
+            return all(
+                self.admin.get_features(node=node)["cluster_version"] == target_version
+                for node in self.redpanda.nodes
+            )
+
+        wait_until(check, timeout_sec=timeout_sec, backoff_sec=1)
+
+    def _disable_auto_finalization(self):
+        self.redpanda.set_cluster_config({"features_auto_finalization": False})
+
+    def _call_with_leader_retry(self, call, timeout_sec=30):
+        """Retry a controller-leader-routed admin v2 call through the transient
+        UNAVAILABLE window after restarts/leadership changes. The v2 connect
+        client does not retry leadership itself; only UNAVAILABLE is retried,
+        other errors (e.g. FAILED_PRECONDITION) propagate immediately."""
+        deadline = time.time() + timeout_sec
+        while True:
+            try:
+                return call()
+            except ConnectError as e:
+                if e.code != ConnectErrorCode.UNAVAILABLE or time.time() >= deadline:
+                    raise
+                time.sleep(1)
+
+    def _finalize(self):
+        return self._call_with_leader_retry(
+            lambda: self.admin_v2.features().finalize_upgrade(
+                features_pb2.FinalizeUpgradeRequest()
+            )
+        )
+
+    def _get_upgrade_status(self):
+        return self._call_with_leader_retry(
+            lambda: self.admin_v2.features().get_upgrade_status(
+                features_pb2.GetUpgradeStatusRequest()
+            )
+        )
+
+    def _wait_for_status_state(self, state, timeout_sec=30):
+        """Wait until GetUpgradeStatus reports `state`; return that status."""
+        wait_until(
+            lambda: self._get_upgrade_status().state == state,
+            timeout_sec=timeout_sec,
+            backoff_sec=1,
+        )
+        return self._get_upgrade_status()

--- a/tests/rptest/tests/unfinalized_upgrade_mixin.py
+++ b/tests/rptest/tests/unfinalized_upgrade_mixin.py
@@ -38,6 +38,12 @@ class UnfinalizedUpgradeMixin:
     ``_restart_at_new`` sets ``self.new_logical``.
     """
 
+    # The pre-upgrade binary must be a released patch that already carries the
+    # backported `features_auto_finalization` knob, so auto-finalization can be
+    # disabled *before* upgrading to a HEAD build that ships the gating logic.
+    # Backported to v26.1.9.
+    MIN_OLD_RELEASE = (26, 1, 9)
+
     def _restart_at_new(self, nodes):
         """Upgrade `nodes` to the HEAD build and restart them in place."""
         self.installer.install(nodes, RedpandaInstaller.HEAD)

--- a/tools/type-checking/type-check-strictness.json
+++ b/tools/type-checking/type-check-strictness.json
@@ -442,6 +442,7 @@
         "rptest/tests/tls_metrics_test.py",
         "rptest/tests/topic_creation_test.py",
         "rptest/tests/topic_delete_test.py",
+        "rptest/tests/unfinalized_upgrade_mixin.py",
         "rptest/tests/upgrade_test.py",
         "rptest/tests/usage_test.py",
         "rptest/tests/workload_upgrade_runner_test.py",

--- a/tools/type-checking/type-check-strictness.json
+++ b/tools/type-checking/type-check-strictness.json
@@ -88,6 +88,7 @@
         "rptest/tests/cluster_linking_e2e_test.py",
         "rptest/tests/cluster_linking_schema_registry_sync_test.py",
         "rptest/tests/cluster_linking_topic_syncing_test.py",
+        "rptest/tests/cluster_linking_unfinalized_upgrade_test.py",
         "rptest/tests/cluster_recovery_test.py",
         "rptest/tests/compacted_term_rolled_recovery_test.py",
         "rptest/tests/compaction_recovery_test.py",


### PR DESCRIPTION
Add additional unfinalized upgrade test for role sync feature flag

* @nguyen-andrew first and third commits are role sync
* @nguyen-andrew @pgellert second commit is a test refactor to share code with shadow linking tests
* @pgellert fifth commit is schema registry


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
