### PR TITLE
`rptest`: fix TopicSpec storage-mode constant in toggle reconciliation test

### DIFF
--- a/tests/rptest/tests/cloud_topics/e2e_test.py
+++ b/tests/rptest/tests/cloud_topics/e2e_test.py
@@ -1320,7 +1320,7 @@ class EndToEndCloudTopicsReconciliationToggleTest(EndToEndCloudTopicsBase):
     @matrix(
         storage_mode=[
             TopicSpec.STORAGE_MODE_CLOUD,
-            TopicSpec.STORAGE_MODE_TIERED_CLOUD,
+            TopicSpec.STORAGE_MODE_IMPL_TIERED_V2,
         ],
     )
     def test_toggle_reconciliation(self, storage_mode: str):


### PR DESCRIPTION
Merge race fix

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
