### PR TITLE
[CORE-16760] cluster_link: re-check batch_mirror_topic_status before replicating

### DIFF
--- a/src/v/cluster/cluster_link/frontend.cc
+++ b/src/v/cluster/cluster_link/frontend.cc
@@ -175,6 +175,24 @@ ss::future<errc> frontend::batch_update_mirror_topic_status(
     if (!cluster_linking_enabled()) {
         co_return errc::feature_disabled;
     }
+    // Defense in depth at the replicate boundary. failover_link_topics only
+    // produces this batched command once batch_mirror_topic_status is active
+    // cluster-wide, and the controller leader observes activation no later than
+    // any follower, so a node reaching this path (locally or via a forwarded
+    // RPC) with the feature inactive is version skew or a bug -- never a normal
+    // state. Refuse rather than replicate: the batched command's record type is
+    // unknown to pre-feature binaries and would poison a downgrade's
+    // controller-log replay.
+    if (!_features->is_active(features::feature::batch_mirror_topic_status)) {
+        vlog(
+          cluster::clusterlog.error,
+          "Refusing to replicate a batched mirror-topic-status update for link "
+          "{} while the batch_mirror_topic_status feature is inactive; the "
+          "feature gates the only producer of this command, so this indicates "
+          "version skew or a logic error",
+          id);
+        co_return errc::feature_disabled;
+    }
     cluster_link_cmd c{
       cluster::cluster_link_batch_update_mirror_topic_status_cmd(
         id, std::move(cmd))};

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -1218,8 +1218,24 @@ PERTURB_EXERCISED_FEATURES = frozenset(
 )
 PERTURB_ACKNOWLEDGED_FEATURES = frozenset(
     {
-        # Cluster-linking features, out of scope for this single-cluster test.
+        # Cluster-linking features: exercising either needs a second (source)
+        # cluster, which this single-cluster test does not have.
+        #
+        # shadow_link_sr_api_sync gates configuring Schema Registry API-mode
+        # sync on the target. Covered end to end -- gated while unfinalized,
+        # working after finalize -- by ShadowLinkUnfinalizedUpgradeTest.
         "shadow_link_sr_api_sync",
+        # batch_mirror_topic_status gates only the batched controller command
+        # for mirror-topic failover, reachable solely via a failover on an
+        # active shadow link. Downgrade-safe by inspection: while unfinalized
+        # the feature is inactive, so failover falls back to the legacy
+        # per-topic path, which writes only controller-log records (command
+        # types and status-enum values) the prior release already decodes. The
+        # one new-in-26.2 record -- the batched failover command -- is not
+        # written until the feature activates post-finalize (and a HEAD-side
+        # backstop in frontend::batch_update_mirror_topic_status refuses to
+        # replicate it while inactive), so the window persists nothing that
+        # could break a downgrade.
         "batch_mirror_topic_status",
         # Iceberg extended-mode topic-config gate; exercising it needs Iceberg
         # topic setup orthogonal to the finalization behavior under test.
@@ -1456,10 +1472,12 @@ class ManualFinalizationUpgradeTest(FeaturesTestBase):
         self._exercise_tiered_cloud_topics()
         self._exercise_shadow_link_role_sync()
         self._exercise_fetch_controller_snapshot_rpc()
-        # The other two v26.2-gated features are not exercised by this
-        # single-cluster perturbation: shadow_link_sr_api_sync and
-        # batch_mirror_topic_status are both cluster-linking features
-        # (batch_mirror_topic_status additionally needs a second cluster).
+        # The other two v26.2-gated features are cluster-linking features that
+        # need a second (source) cluster, so they are acknowledged rather than
+        # exercised here; see PERTURB_ACKNOWLEDGED_FEATURES for why each stays
+        # downgrade-safe (shadow_link_sr_api_sync is covered by
+        # ShadowLinkUnfinalizedUpgradeTest; batch_mirror_topic_status is safe by
+        # inspection).
 
     def _exercise_tiered_cloud_topics(self):
         """tiered_cloud_topics gate: creating a topic with the tiered_v2


### PR DESCRIPTION
Hardens the downgrade safety of the v26.2 `batch_mirror_topic_status`
feature and documents why it is not exercised by the single-cluster
finalization test.

`batch_mirror_topic_status` selects a batched controller command for
mirror-topic failover. That command is the only cluster_link controller
command a pre-26.2 binary cannot decode, and the command dispatch aborts
on an unknown type, so replaying it on an older binary would fail. During
an unfinalized upgrade the feature is held inactive cluster-wide, so the
batched command must never reach the controller log or a rollback to the
prior release would break.

The feature is already checked at the origin (failover chooses the
batched path vs. the legacy per-topic fallback), but the command's
frontend entry point -- also reached via the forwarded-RPC receiver on
the controller leader -- only checked `cluster_linking_enabled()`. This
adds the feature check at that replicate boundary too, so the batched
command can never be replicated while the feature is inactive. Because
the controller leader observes feature activation no later than any
follower, the check firing indicates version skew or a bug: it logs an
error and rejects rather than replicating.

No behavior change in normal operation -- post-finalize the feature is
active and the batched path proceeds as before; pre-finalize failover
already uses the per-topic path. The second commit only rewrites comments
in the finalization test's acknowledged-features registry, explaining why
`batch_mirror_topic_status` stays downgrade-safe without an explicit
exercise.

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
