### PR TITLE
cluster/commands: assert on unknown command type in deserialize

### DIFF
--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -661,6 +661,9 @@ deserialize(model::record_batch b, commands_type_list<Commands...>) {
     std::optional<std::variant<internal::deserializer<Commands>...>> ret;
     (void)((ret = internal::make_deserializer<Commands>(cmd_type), ret) || ...);
 
+    vassert(
+      ret.has_value(), "expected command with value: cmd type {}", cmd_type);
+
     return std::visit(
       [k_parser = std::move(k_parser),
        v_parser = std::move(v_parser),


### PR DESCRIPTION
Makes the generic controller-command dispatch fail with a clear
assertion, rather than undefined behavior, when it encounters a record
whose command type it does not recognize.

`deserialize()` probes each accepted command type and dereferences the
resulting optional with `*ret`. If the record's command type matches
none of the accepted commands the optional is empty, so `*ret` is
undefined behavior. This is reachable when an STM replays a record type
it does not know -- for example a command written by a newer binary and
replayed on an older one after a downgrade. Asserting `ret.has_value()`
first turns that into a deterministic, diagnosable failure that names the
offending command type.

No behavior change in normal operation: every replayed record's command
type is in the accepted list, so the assertion never fires.

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
