### PR TITLE
[CORE-16760] tests: guard tiered_cloud_topics unfinalized-downgrade gates

### DIFF
--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -59,6 +59,10 @@ struct ctp_stm_accessor {
     ss::future<model::offset> compute_local_retention_offset(ctp_stm& stm) {
         return stm.compute_local_retention_offset();
     }
+
+    ss::future<> apply(ctp_stm& stm, const model::record_batch& b) {
+        return stm.do_apply(b);
+    }
 };
 } // namespace cloud_topics
 
@@ -353,6 +357,60 @@ TEST_F_CORO(ctp_stm_fixture, advance_reconciled_offset_with_local_threshold) {
     res = co_await leader_api.advance_reconciled_offset(
       kafka::offset{20}, model::no_timeout, as, kafka::offset{15});
     ASSERT_TRUE_CORO(res.has_value());
+}
+
+TEST_F_CORO(ctp_stm_fixture, unknown_command_key_is_rejected_on_apply) {
+    // do_apply must reject an unrecognized ctp_stm command key rather than
+    // silently skip it. This is the downgrade poison pill the
+    // tiered_cloud_topics feature gate exists to prevent:
+    // set_min_allowed_local_threshold (key 5) is the v26.2 addition to the
+    // command vocabulary, and a pre-v26.2 binary -- whose ctp_stm_key enum
+    // stops at reset_state (4) -- hits exactly this throw when it replays such
+    // a command from a cloud-topic partition log. That is why the notifier and
+    // reconciler gate emission of the floor command on the feature being active
+    // (level_zero_notifier::notifications_enabled, reconciliation_source), so
+    // the command is never written while the cluster can still be downgraded.
+    // If a new key is added to ctp_stm_key, this test is the reminder that it
+    // is downgrade-sensitive and must be gated the same way.
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+    auto& leader = node(*get_leader());
+    auto stm = get_stm<0>(leader);
+    ct::ctp_stm_accessor accessor;
+
+    // Positive control: the newest known key (set_min_allowed_local_threshold)
+    // applies cleanly and mutates state.
+    {
+        storage::record_batch_builder builder(
+          model::record_batch_type::ctp_stm_command, model::offset{0});
+        builder.add_raw_kv(
+          serde::to_iobuf(ct::set_min_allowed_local_threshold_cmd::key),
+          serde::to_iobuf(
+            ct::set_min_allowed_local_threshold_cmd(kafka::offset{7})));
+        co_await accessor.apply(*stm, std::move(builder).build());
+        ASSERT_EQ_CORO(
+          api(leader).get_min_allowed_local_threshold(), kafka::offset{7});
+    }
+
+    // An unrecognized key (one an older binary might not know, or a future one
+    // this binary does not) throws instead of being ignored.
+    {
+        constexpr uint8_t unknown_key = 200;
+        storage::record_batch_builder builder(
+          model::record_batch_type::ctp_stm_command, model::offset{1});
+        builder.add_raw_kv(
+          serde::to_iobuf(unknown_key), serde::to_iobuf(int64_t{0}));
+
+        ss::sstring caught;
+        try {
+            co_await accessor.apply(*stm, std::move(builder).build());
+        } catch (const std::exception& e) {
+            caught = e.what();
+        }
+        ASSERT_NE_CORO(caught.find("Unknown ctp_stm_key"), ss::sstring::npos)
+          << "expected an unknown ctp_stm command key to be rejected, got: "
+          << caught;
+    }
 }
 
 TEST_F_CORO(ctp_stm_fixture, test_truncate_all_epochs) {

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -1463,34 +1463,70 @@ class ManualFinalizationUpgradeTest(FeaturesTestBase):
     def _exercise_tiered_cloud_topics(self):
         """tiered_cloud_topics gate: creating a topic with the tiered_v2
         (cloud-architecture) storage mode is refused until the feature is
-        active. Drive that
-        validator path while unfinalized and confirm the feature is unavailable
-        and the create is rejected. The topic is never created, so exercising
-        the gate cannot leave state that would block a downgrade."""
+        active. Drive that validator path while unfinalized and confirm the
+        feature is unavailable and the create is rejected -- via both spellings
+        that resolve to tiered_v2:
+          1. the explicit read-only redpanda.storage.mode.impl=tiered_v2
+             selector, and
+          2. redpanda.storage.mode=tiered resolved through the
+             default_redpanda_storage_mode_tiered_impl=tiered_v2 cluster
+             default.
+        The cluster default is NOT itself feature-gated, so path 2 is the
+        hole check: an operator flipping it during the (weeks-long) window must
+        not let a tiered_v2 topic slip past the create gate via mode resolution
+        (the same shape of hole seen in iceberg_extended_mode_config). No topic
+        is ever created, so exercising the gate cannot leave state that would
+        block a downgrade.
+
+        Note: the alter-config gate (AlterConfigs/IncrementalAlterConfigs) is
+        deliberately not exercised here -- the only storage-mode transition
+        permitted into tiered_v2 is cloud -> tiered_v2, and creating the cloud
+        source topic requires cloud storage, which this single-cluster test does
+        not configure."""
         assert self._feature_state("tiered_cloud_topics") == "unavailable", (
             "tiered_cloud_topics should be unavailable while the upgrade is unfinalized"
         )
+
+        # Path 1: the explicit impl selector.
+        self._assert_tiered_v2_create_gated(
+            "perturb-tiered-cloud-impl",
+            TopicSpec.storage_mode_config(TopicSpec.STORAGE_MODE_IMPL_TIERED_V2),
+        )
+
+        # Path 2: alias resolution via the cluster default. Setting the default
+        # to tiered_v2 makes a plain redpanda.storage.mode=tiered create resolve
+        # to tiered_v2; the gate must still reject it. Restore the default in a
+        # finally so later perturbation steps (and cycles) are unaffected.
+        self.redpanda.set_cluster_config(
+            {"default_redpanda_storage_mode_tiered_impl": "tiered_v2"}
+        )
         try:
-            RpkTool(self.redpanda).create_topic(
-                "perturb-tiered-cloud",
-                partitions=1,
-                config=TopicSpec.storage_mode_config(
-                    TopicSpec.STORAGE_MODE_IMPL_TIERED_V2
-                ),
+            self._assert_tiered_v2_create_gated(
+                "perturb-tiered-cloud-alias",
+                {TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_TIERED},
             )
+        finally:
+            self.redpanda.set_cluster_config(
+                {"default_redpanda_storage_mode_tiered_impl": "tiered_v1"}
+            )
+
+    def _assert_tiered_v2_create_gated(self, topic, config):
+        """Attempt to create `topic` with a config that resolves to the tiered_v2
+        storage mode and assert it is rejected by the storage-mode gate -- not by
+        an unrelated rpk/controller error (timeout, UNAVAILABLE, controller not
+        ready) that would otherwise read as a false "gate worked". The HEAD
+        validator rejects with INVALID_CONFIG and this distinctive message; the
+        create only ever runs on the HEAD binary, so the string is stable."""
+        try:
+            RpkTool(self.redpanda).create_topic(topic, partitions=1, config=config)
         except RpkException as e:
-            # Confirm the create failed via the storage-mode gate, not an
-            # unrelated rpk/controller error (timeout, UNAVAILABLE, controller
-            # not ready) that would otherwise read as a false "gate worked". The
-            # HEAD validator rejects with INVALID_CONFIG and this distinctive
-            # message; the create only ever runs on the HEAD binary, so the
-            # string is stable.
             assert "Invalid storage mode" in str(e), (
-                f"tiered_cloud create failed, but not via the storage-mode gate: {e}"
+                f"tiered_v2 create ({topic}) failed, but not via the "
+                f"storage-mode gate: {e}"
             )
         else:
             raise AssertionError(
-                "creating a tiered_cloud topic should be gated while unfinalized"
+                f"creating a tiered_v2 topic ({topic}) should be gated while unfinalized"
             )
 
     def _validate_role_sync_config(self):


### PR DESCRIPTION
Two test additions that guard the downgrade-safety of the v26.2
`tiered_cloud_topics` feature during an *unfinalized* upgrade — the window
in which the binaries are upgraded but the active version is held back so a
downgrade stays possible. The feature's gates are what keep that window
safe, so these tests pin the two spots most likely to regress silently.

**`cloud_topics/stm`: unknown ctp_stm command key is rejected on apply.**
`ctp_stm::do_apply` must throw on an unrecognized command key rather than
skip it. This is the concrete downgrade poison pill: a pre-v26.2 binary,
whose `ctp_stm_key` vocabulary stops at `reset_state`, throws here when it
replays the v26.2-only `set_min_allowed_local_threshold` (key 5) — which is
exactly why the level-zero notifier and the reconciler gate emission of
that command on the feature being active. The test is the reminder that any
new `ctp_stm_key` is downgrade-sensitive and must be gated the same way;
key 5 is a positive control that a known key still applies.

**`tests/rptest`: tiered_v2 create gate via the impl-default alias.** The
unfinalized-upgrade perturbation already refused a `tiered_v2` create via
the explicit `redpanda.storage.mode.impl` selector. This also drives the
alias path — `redpanda.storage.mode=tiered` resolved through the
`default_redpanda_storage_mode_tiered_impl=tiered_v2` cluster default, a
property that is *not* itself feature-gated — confirming that mode
resolution cannot smuggle a `tiered_v2` topic past the create gate while
the feature is inactive. The alter-config gate is intentionally not tested
here: the only permitted transition into `tiered_v2` is `cloud ->
tiered_v2`, and creating the `cloud` source needs cloud storage, which this
single-cluster test does not configure (documented in the test).

Verified: the gtest passes, and the full real-upgrade
`ManualFinalizationUpgradeTest.test_downgrade_before_finalize`
(v26.1.9 -> HEAD) passes with both create paths gated across each rollback
cycle.

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
