### PR TITLE
[CORE-16759] schema_registry/rest: add http connection pooling

### DIFF
--- a/src/v/cluster_link/schema_registry_sync/BUILD
+++ b/src/v/cluster_link/schema_registry_sync/BUILD
@@ -34,6 +34,7 @@ redpanda_cc_library(
         "//src/v/http",
         "//src/v/net",
         "//src/v/pandaproxy/schema_registry/rest_client:error",
+        "//src/v/pandaproxy/schema_registry/rest_client:pooled_client",
         "//src/v/utils:retry_chain_node",
         "@ada",
     ],

--- a/src/v/cluster_link/schema_registry_sync/http_source_reader.cc
+++ b/src/v/cluster_link/schema_registry_sync/http_source_reader.cc
@@ -20,6 +20,7 @@
 #include "net/tls_certificate_probe.h"
 #include "net/transport.h"
 #include "pandaproxy/schema_registry/rest_client/error.h"
+#include "pandaproxy/schema_registry/rest_client/pooled_client.h"
 #include "utils/retry_chain_node.h"
 
 #include <seastar/core/coroutine.hh>
@@ -42,6 +43,12 @@ namespace {
 // retries_exhausted, which the reader maps to source_unavailable.
 constexpr auto request_timeout = 30s;
 constexpr auto request_backoff = 100ms;
+
+// Upper bound on pooled connections to the source registry. The pool is sized
+// to schema_registry_sync_parallelism (the reconciler's fan-out), capped here
+// so a large parallelism setting does not hold as many sockets open against
+// the source.
+constexpr size_t max_source_connections = 8;
 
 // Map a rest_client failure onto a source_error. A source that is unreachable
 // or rejecting every request is source_unavailable and parks the link; a 404 is
@@ -169,7 +176,11 @@ http_source_reader::http_source_reader(std::unique_ptr<rc::client> client)
   : _client(std::move(client)) {}
 
 ss::future<source_result<rc::client*>>
-http_source_reader::ensure_client(ss::abort_source&) {
+http_source_reader::ensure_client(ss::abort_source& as) {
+    if (_client) {
+        co_return _client.get();
+    }
+    auto build = co_await ss::get_units(_build, 1, as);
     if (_client) {
         co_return _client.get();
     }
@@ -193,8 +204,18 @@ http_source_reader::ensure_client(ss::abort_source&) {
                 cfg.tls_sni_hostname = _conn->address.host();
             }
         }
+        // Enough connections for the reconciler's fan-out; each http::client
+        // connects lazily on first use, so idle pool slots cost no sockets.
+        auto pool_size = std::min(
+          config::shard_local_cfg().schema_registry_sync_parallelism(),
+          max_source_connections);
+        std::vector<std::unique_ptr<http::abstract_client>> transports;
+        transports.reserve(pool_size);
+        for (size_t i = 0; i < pool_size; ++i) {
+            transports.push_back(std::make_unique<http::client>(cfg));
+        }
         _client = std::make_unique<rc::client>(
-          std::make_unique<http::client>(cfg),
+          std::make_unique<rc::pooled_client>(std::move(transports)),
           _conn->endpoint,
           _conn->auth,
           ppsr::qualified_subjects_enabled::yes);
@@ -211,7 +232,6 @@ http_source_reader::ensure_client(ss::abort_source&) {
 
 ss::future<source_result<chunked_vector<ppsr::context>>>
 http_source_reader::list_contexts(ss::abort_source& as) {
-    auto units = co_await ss::get_units(_inflight, 1, as);
     auto client = co_await ensure_client(as);
     if (!client.has_value()) {
         co_return std::unexpected(std::move(client.error()));
@@ -228,7 +248,6 @@ http_source_reader::list_contexts(ss::abort_source& as) {
 
 ss::future<source_result<chunked_vector<ppsr::context_subject>>>
 http_source_reader::list_subjects(ppsr::context ctx, ss::abort_source& as) {
-    auto units = co_await ss::get_units(_inflight, 1, as);
     auto client = co_await ensure_client(as);
     if (!client.has_value()) {
         co_return std::unexpected(std::move(client.error()));
@@ -252,7 +271,6 @@ http_source_reader::list_subject_versions(
   ppsr::context_subject sub,
   ppsr::include_deleted include_deleted,
   ss::abort_source& as) {
-    auto units = co_await ss::get_units(_inflight, 1, as);
     auto client = co_await ensure_client(as);
     if (!client.has_value()) {
         co_return std::unexpected(std::move(client.error()));
@@ -271,7 +289,6 @@ http_source_reader::read_subject_version(
   ppsr::context_subject sub,
   ppsr::schema_version version,
   ss::abort_source& as) {
-    auto units = co_await ss::get_units(_inflight, 1, as);
     auto client = co_await ensure_client(as);
     if (!client.has_value()) {
         co_return std::unexpected(std::move(client.error()));
@@ -295,7 +312,6 @@ http_source_reader::read_subject_version(
 
 ss::future<source_result<std::optional<ppsr::mode>>>
 http_source_reader::read_mode(ppsr::context_subject sub, ss::abort_source& as) {
-    auto units = co_await ss::get_units(_inflight, 1, as);
     auto client = co_await ensure_client(as);
     if (!client.has_value()) {
         co_return std::unexpected(std::move(client.error()));
@@ -329,7 +345,6 @@ http_source_reader::read_mode(ppsr::context_subject sub, ss::abort_source& as) {
 ss::future<source_result<std::optional<ppsr::compatibility_level>>>
 http_source_reader::read_config(
   ppsr::context_subject sub, ss::abort_source& as) {
-    auto units = co_await ss::get_units(_inflight, 1, as);
     auto client = co_await ensure_client(as);
     if (!client.has_value()) {
         co_return std::unexpected(std::move(client.error()));

--- a/src/v/cluster_link/schema_registry_sync/http_source_reader.h
+++ b/src/v/cluster_link/schema_registry_sync/http_source_reader.h
@@ -56,12 +56,13 @@ std::optional<net::unresolved_address> parse_source_address(std::string_view);
 /// Enumerates every source context (via GET /contexts); basic auth and TLS
 /// are honored from the link config. The reconcile engine drives discovery
 /// (list contexts/subjects/versions) and schema-body fetches through this
-/// reader.
+/// reader, concurrently over a small pool of connections sized from
+/// schema_registry_sync_parallelism.
 class http_source_reader final : public source_reader {
 public:
-    /// Production: the HTTP transport (and its TLS credentials) is built lazily
-    /// from `conn` on the first request, since credential building is async but
-    /// the factory that creates the reader is not.
+    /// Production: the HTTP transports (and their TLS credentials) are built
+    /// lazily from `conn` on the first request, since credential building is
+    /// async but the factory that creates the reader is not.
     explicit http_source_reader(http_source_connection conn);
     /// Test seam: takes a ready rest_client, bypassing the lazy transport
     /// build.
@@ -90,19 +91,19 @@ public:
 
 private:
     /// Returns the rest_client, building it (and its TLS credentials) on first
-    /// call. Always invoked while holding `_inflight`, so at most one build
-    /// runs; a build failure surfaces as source_unavailable so the link parks
-    /// and retries. Returns a borrowed pointer owned by `_client`.
+    /// call. The build is serialized on `_build` so at most one runs; a build
+    /// failure surfaces as source_unavailable so the link parks and retries.
+    /// Returns a borrowed pointer owned by `_client`.
     ss::future<source_result<rc::client*>> ensure_client(ss::abort_source&);
 
     // Connection inputs for the lazy build; nullopt once a client is injected.
     std::optional<http_source_connection> _conn;
     std::unique_ptr<rc::client> _client;
-    // The reconcile engine drives this reader from several fibers, but the
-    // underlying http::client owns a single connection and cannot service
-    // concurrent requests (overlapping I/O double-completes the socket's
-    // pollable_fd), so _inflight serializes every request onto one slot.
-    ssx::semaphore _inflight{1, "cluster_link/sr_source/inflight"};
+    // Serializes the lazy client build only. Requests run concurrently: the
+    // reconcile engine drives this reader from several fibers, and the
+    // rest_client's pooled transport bounds them to one in-flight request per
+    // pooled connection.
+    ssx::semaphore _build{1, "cluster_link/sr_source/build"};
 };
 
 class http_source_reader_factory final : public source_reader_factory {

--- a/src/v/cluster_link/schema_registry_sync/tests/BUILD
+++ b/src/v/cluster_link/schema_registry_sync/tests/BUILD
@@ -78,6 +78,7 @@ redpanda_cc_gtest(
         "//src/v/http",
         "//src/v/pandaproxy/schema_registry:types",
         "//src/v/pandaproxy/schema_registry/rest_client:client",
+        "//src/v/test_utils:async",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
         "@seastar",

--- a/src/v/cluster_link/schema_registry_sync/tests/http_source_reader_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/http_source_reader_test.cc
@@ -15,12 +15,15 @@
 #include "http/client.h"
 #include "pandaproxy/schema_registry/rest_client/client.h"
 #include "pandaproxy/schema_registry/types.h"
+#include "test_utils/async.h"
 
 #include <seastar/core/abort_source.hh>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <deque>
 #include <memory>
 #include <optional>
 
@@ -134,6 +137,43 @@ TEST(http_source_reader, stop_is_idempotent) {
     reader.stop().get();
 
     EXPECT_EQ(shutdowns, 1);
+}
+
+// The reader does not serialize requests: the reconcile engine's fibers drive
+// it concurrently, and in-flight requests are bounded by the pooled transport
+// underneath (here a single injected mock, so two requests overlapping on it
+// proves the reader itself imposes no serialization).
+TEST(http_source_reader, requests_run_concurrently) {
+    int inflight = 0;
+    int max_inflight = 0;
+    std::deque<ss::promise<http::downloaded_response>> parked;
+    auto reader = reader_over([&](mock_client& m) {
+        EXPECT_CALL(m, request_and_collect_response(_, _, _))
+          .WillRepeatedly([&](
+                            bh::request_header<>&&,
+                            std::optional<iobuf>,
+                            ss::lowres_clock::duration) {
+              ++inflight;
+              max_inflight = std::max(max_inflight, inflight);
+              parked.emplace_back();
+              return parked.back().get_future().finally(
+                [&inflight] { --inflight; });
+          });
+    });
+    ss::abort_source as;
+    auto first = reader.list_contexts(as);
+    auto second = reader.list_contexts(as);
+    RPTEST_REQUIRE_EVENTUALLY(5s, [&] { return parked.size() == 2; });
+    EXPECT_EQ(max_inflight, 2);
+
+    for (auto& request : parked) {
+        request.set_value(
+          http::downloaded_response{
+            .status = bh::status::ok, .body = iobuf::from(R"(["."])")});
+    }
+    ASSERT_TRUE(first.get().has_value());
+    ASSERT_TRUE(second.get().has_value());
+    reader.stop().get();
 }
 
 // The rest_client scopes GET /subjects to the requested context (a mock that

--- a/src/v/pandaproxy/schema_registry/rest_client/BUILD
+++ b/src/v/pandaproxy/schema_registry/rest_client/BUILD
@@ -93,6 +93,28 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "pooled_client",
+    srcs = [
+        "pooled_client.cc",
+    ],
+    hdrs = [
+        "pooled_client.h",
+    ],
+    visibility = [
+        "//src/v/cluster_link:__subpackages__",
+        "//src/v/pandaproxy:__subpackages__",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/http",
+        "//src/v/ssx:semaphore",
+        "@boost//:beast",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "client",
     srcs = [
         "client.cc",

--- a/src/v/pandaproxy/schema_registry/rest_client/pooled_client.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/pooled_client.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "pandaproxy/schema_registry/rest_client/pooled_client.h"
+
+#include "base/vassert.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/coroutine/as_future.hh>
+
+#include <utility>
+
+namespace pandaproxy::schema_registry::rest_client {
+
+pooled_client::pooled_client(
+  std::vector<std::unique_ptr<http::abstract_client>> transports)
+  : _transports(std::move(transports))
+  , _slots(_transports.size(), "schema_registry/rest_client/pool") {
+    vassert(
+      !_transports.empty(), "a pooled_client requires at least one transport");
+    _idle.reserve(_transports.size());
+    for (const auto& transport : _transports) {
+        _idle.push_back(transport.get());
+    }
+}
+
+ss::future<http::downloaded_response>
+pooled_client::request_and_collect_response(
+  boost::beast::http::request_header<>&& request,
+  std::optional<iobuf> payload,
+  ss::lowres_clock::duration timeout) {
+    // Move the request into this frame before any suspension so it does not
+    // depend on the caller's object while queued for a transport.
+    auto owned_request = std::move(request);
+    auto holder = _gate.hold();
+    auto slot = co_await ss::get_units(_slots, 1, _as);
+    vassert(!_idle.empty(), "slot acquired with no idle transport");
+    auto* transport = _idle.back();
+    _idle.pop_back();
+    auto response = co_await ss::coroutine::as_future(
+      transport->request_and_collect_response(
+        std::move(owned_request), std::move(payload), timeout));
+    // Returned on failure too: the transport reconnects lazily on next use.
+    _idle.push_back(transport);
+    co_return co_await std::move(response);
+}
+
+ss::future<> pooled_client::shutdown_and_stop() {
+    auto drained = _gate.close();
+    _as.request_abort();
+    // Stopping a transport promptly fails a request it is servicing, so
+    // in-flight requests unwind and the gate can drain.
+    co_await ss::parallel_for_each(
+      _transports, [](const std::unique_ptr<http::abstract_client>& transport) {
+          return transport->shutdown_and_stop();
+      });
+    co_await std::move(drained);
+}
+
+} // namespace pandaproxy::schema_registry::rest_client

--- a/src/v/pandaproxy/schema_registry/rest_client/pooled_client.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/pooled_client.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "base/seastarx.h"
+#include "bytes/iobuf.h"
+#include "http/client.h"
+#include "ssx/semaphore.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/lowres_clock.hh>
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+namespace pandaproxy::schema_registry::rest_client {
+
+/// An http::abstract_client that multiplexes requests over a fixed set of
+/// underlying transports, so up to pool-size requests run concurrently. Exists
+/// because one http::client owns a single connection that cannot service
+/// concurrent requests: each request gets exclusive use of one transport for
+/// its full duration, and callers beyond the pool size queue (FIFO) for the
+/// next free transport.
+///
+/// A transport is returned to the pool after failure as well as success: a
+/// transport whose request failed self-heals on next use (http::client
+/// reconnects a stale or dead socket lazily).
+///
+/// shutdown_and_stop() must be called exactly once before destruction. It
+/// rejects new requests, ejects queued waiters, stops every transport (which
+/// promptly fails requests that are mid-flight), and drains.
+class pooled_client final : public http::abstract_client {
+public:
+    /// \param transports the single-connection transports to pool; must be
+    ///        non-empty. Owned by the pool for its lifetime.
+    explicit pooled_client(
+      std::vector<std::unique_ptr<http::abstract_client>> transports);
+
+    ss::future<http::downloaded_response> request_and_collect_response(
+      boost::beast::http::request_header<>&& request,
+      std::optional<iobuf> payload = std::nullopt,
+      ss::lowres_clock::duration timeout = http::default_connect_timeout) final;
+
+    ss::future<> shutdown_and_stop() final;
+
+private:
+    std::vector<std::unique_ptr<http::abstract_client>> _transports;
+    // Transports not currently leased to a request. Borrows from _transports:
+    // a request pops one after acquiring a slot and pushes it back when the
+    // transport call completes. Capacity is reserved up front so the push
+    // back cannot throw.
+    std::vector<http::abstract_client*> _idle;
+    ssx::semaphore _slots;
+    // Ejects slot waiters on shutdown.
+    ss::abort_source _as;
+    ss::gate _gate;
+};
+
+} // namespace pandaproxy::schema_registry::rest_client

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/BUILD
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/BUILD
@@ -72,6 +72,25 @@ redpanda_cc_gtest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "pooled_client_test",
+    timeout = "short",
+    srcs = [
+        "pooled_client_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/http",
+        "//src/v/pandaproxy/schema_registry/rest_client:pooled_client",
+        "//src/v/test_utils:async",
+        "//src/v/test_utils:gtest",
+        "@fmt",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
 redpanda_cc_btest(
     name = "client_integration_test",
     timeout = "short",

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/pooled_client_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/pooled_client_test.cc
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "bytes/iobuf.h"
+#include "http/client.h"
+#include "pandaproxy/schema_registry/rest_client/pooled_client.h"
+#include "test_utils/async.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/util/later.hh>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <deque>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <vector>
+
+namespace rc = pandaproxy::schema_registry::rest_client;
+namespace bh = boost::beast::http;
+using namespace std::chrono_literals;
+
+namespace {
+
+class fake_transport;
+
+// Shared across a test's fake transports to observe pool-wide behavior.
+struct pool_observer {
+    // When true, requests park until release_one() or transport shutdown.
+    bool park{false};
+    int inflight{0};
+    int max_inflight{0};
+    // Request targets in dispatch order.
+    std::vector<ss::sstring> dispatched;
+    struct parked_request {
+        ss::promise<http::downloaded_response> promise;
+        fake_transport* transport;
+    };
+    std::deque<parked_request> parked;
+
+    // Completes the oldest parked request successfully.
+    void release_one() {
+        ASSERT_FALSE(parked.empty());
+        auto req = std::move(parked.front());
+        parked.pop_front();
+        req.promise.set_value(
+          http::downloaded_response{.status = bh::status::ok, .body = iobuf{}});
+    }
+};
+
+// A single-connection transport double. Requests either complete immediately
+// (with the configured response or an injected failure) or park on the
+// observer until released; shutdown fails this transport's parked requests,
+// mirroring how stopping a real http::client fails the request it is
+// servicing.
+class fake_transport final : public http::abstract_client {
+public:
+    explicit fake_transport(pool_observer& observer)
+      : _observer(observer) {}
+
+    ss::future<http::downloaded_response> request_and_collect_response(
+      bh::request_header<>&& request,
+      std::optional<iobuf> payload,
+      ss::lowres_clock::duration timeout) final {
+        // The pool must lease a transport to one request at a time.
+        EXPECT_EQ(_inflight, 0) << "transport leased to two requests at once";
+        EXPECT_FALSE(_stopped) << "request dispatched to a stopped transport";
+        ++_inflight;
+        ++_observer.inflight;
+        _observer.max_inflight = std::max(
+          _observer.max_inflight, _observer.inflight);
+        _observer.dispatched.emplace_back(
+          request.target().begin(), request.target().end());
+        _last_payload_size = payload.has_value() ? payload->size_bytes() : 0;
+        _last_timeout = timeout;
+
+        auto response = ss::make_ready_future<http::downloaded_response>(
+          http::downloaded_response{
+            .status = _status, .body = iobuf::from(_body)});
+        if (_fail_next) {
+            _fail_next = false;
+            response = ss::make_exception_future<http::downloaded_response>(
+              std::runtime_error("injected transport failure"));
+        } else if (_observer.park) {
+            _observer.parked.push_back(
+              {.promise = ss::promise<http::downloaded_response>{},
+               .transport = this});
+            response = _observer.parked.back().promise.get_future();
+        }
+        return response.finally([this] {
+            --_inflight;
+            --_observer.inflight;
+        });
+    }
+
+    ss::future<> shutdown_and_stop() final {
+        _stopped = true;
+        // Like a real transport, fail the request this transport is servicing.
+        for (auto& parked : _observer.parked) {
+            if (parked.transport == this) {
+                parked.promise.set_exception(
+                  std::make_exception_ptr(
+                    std::runtime_error("transport stopped")));
+            }
+        }
+        std::erase_if(_observer.parked, [this](const auto& parked) {
+            return parked.transport == this;
+        });
+        return ss::make_ready_future<>();
+    }
+
+    void set_response(bh::status status, ss::sstring body) {
+        _status = status;
+        _body = std::move(body);
+    }
+    void fail_next() { _fail_next = true; }
+    bool stopped() const { return _stopped; }
+    size_t last_payload_size() const { return _last_payload_size; }
+    ss::lowres_clock::duration last_timeout() const { return _last_timeout; }
+
+private:
+    pool_observer& _observer;
+    int _inflight{0};
+    bool _stopped{false};
+    bool _fail_next{false};
+    bh::status _status{bh::status::ok};
+    ss::sstring _body;
+    size_t _last_payload_size{0};
+    ss::lowres_clock::duration _last_timeout{};
+};
+
+// A pool of n fake transports plus non-owning handles to each fake.
+struct pool_fixture {
+    explicit pool_fixture(size_t n) {
+        std::vector<std::unique_ptr<http::abstract_client>> owned;
+        owned.reserve(n);
+        for (size_t i = 0; i < n; ++i) {
+            auto transport = std::make_unique<fake_transport>(observer);
+            transports.push_back(transport.get());
+            owned.push_back(std::move(transport));
+        }
+        pool = std::make_unique<rc::pooled_client>(std::move(owned));
+    }
+
+    pool_observer observer;
+    std::vector<fake_transport*> transports;
+    std::unique_ptr<rc::pooled_client> pool;
+};
+
+// A coroutine so the header outlives the request: the pool may suspend the
+// request while it waits for a free transport.
+ss::future<http::downloaded_response>
+issue(rc::pooled_client& pool, std::string_view target) {
+    bh::request_header<> header;
+    header.method(bh::verb::get);
+    header.target(target);
+    co_return co_await pool.request_and_collect_response(std::move(header));
+}
+
+} // namespace
+
+TEST(pooled_client, forwards_request_response_and_arguments) {
+    pool_fixture fx(1);
+    fx.transports[0]->set_response(bh::status::created, "hello response");
+
+    bh::request_header<> header;
+    header.method(bh::verb::get);
+    header.target("/subjects");
+    auto res = fx.pool
+                 ->request_and_collect_response(
+                   std::move(header), iobuf::from("payload!"), 123ms)
+                 .get();
+
+    EXPECT_EQ(res.status, bh::status::created);
+    EXPECT_EQ(res.body, iobuf::from("hello response"));
+    EXPECT_EQ(fx.observer.dispatched, (std::vector<ss::sstring>{"/subjects"}));
+    EXPECT_EQ(fx.transports[0]->last_payload_size(), 8);
+    EXPECT_EQ(fx.transports[0]->last_timeout(), 123ms);
+    fx.pool->shutdown_and_stop().get();
+}
+
+TEST(pooled_client, bounds_concurrency_and_queues_fifo) {
+    pool_fixture fx(2);
+    fx.observer.park = true;
+
+    std::vector<ss::future<http::downloaded_response>> futs;
+    futs.reserve(5);
+    for (int i = 0; i < 5; ++i) {
+        futs.push_back(issue(*fx.pool, fmt::format("/r{}", i)));
+    }
+    // Two requests hold the two transports; three wait for a slot.
+    RPTEST_REQUIRE_EVENTUALLY(5s, [&] { return fx.observer.inflight == 2; });
+    EXPECT_EQ(fx.observer.dispatched.size(), 2);
+
+    // Drain: complete parked requests as they arrive until all five ran.
+    for (int released = 0; released < 5; ++released) {
+        RPTEST_REQUIRE_EVENTUALLY(
+          5s, [&] { return !fx.observer.parked.empty(); });
+        fx.observer.release_one();
+    }
+    for (auto& fut : futs) {
+        EXPECT_EQ(fut.get().status, bh::status::ok);
+    }
+
+    EXPECT_EQ(fx.observer.max_inflight, 2);
+    // Waiters got slots in issue order.
+    EXPECT_EQ(
+      fx.observer.dispatched,
+      (std::vector<ss::sstring>{"/r0", "/r1", "/r2", "/r3", "/r4"}));
+    fx.pool->shutdown_and_stop().get();
+}
+
+TEST(pooled_client, transport_returned_after_failure) {
+    pool_fixture fx(1);
+    fx.transports[0]->fail_next();
+
+    auto failed = issue(*fx.pool, "/fail");
+    EXPECT_THROW(failed.get(), std::runtime_error);
+
+    // The transport and its slot were recycled after the failure.
+    auto res = issue(*fx.pool, "/ok").get();
+    EXPECT_EQ(res.status, bh::status::ok);
+    EXPECT_EQ(
+      fx.observer.dispatched, (std::vector<ss::sstring>{"/fail", "/ok"}));
+    fx.pool->shutdown_and_stop().get();
+}
+
+TEST(pooled_client, shutdown_fails_inflight_ejects_waiters_rejects_new) {
+    pool_fixture fx(2);
+    fx.observer.park = true;
+
+    auto in_flight_a = issue(*fx.pool, "/a");
+    auto in_flight_b = issue(*fx.pool, "/b");
+    RPTEST_REQUIRE_EVENTUALLY(
+      5s, [&] { return fx.observer.parked.size() == 2; });
+    auto waiter = issue(*fx.pool, "/c");
+    // Let the third request reach the slot queue (its coroutine may start
+    // asynchronously) so shutdown ejects a waiter, not an unstarted request.
+    for (int i = 0; i < 3; ++i) {
+        ss::yield().get();
+    }
+    EXPECT_EQ(fx.observer.dispatched.size(), 2);
+
+    fx.pool->shutdown_and_stop().get();
+
+    // In-flight requests fail when their transport stops; the queued waiter
+    // is ejected with an abort.
+    EXPECT_THROW(in_flight_a.get(), std::runtime_error);
+    EXPECT_THROW(in_flight_b.get(), std::runtime_error);
+    EXPECT_THROW(waiter.get(), ss::abort_requested_exception);
+    EXPECT_TRUE(fx.transports[0]->stopped());
+    EXPECT_TRUE(fx.transports[1]->stopped());
+    // New requests are rejected once shut down.
+    EXPECT_THROW(issue(*fx.pool, "/d").get(), ss::gate_closed_exception);
+}


### PR DESCRIPTION
Adds schema registry rest client http connection pooling.

Next: adding rate limiting.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
