### PR TITLE
[CORE-16852] `ct`: ignore ready future in `~l0_source()`

### DIFF
--- a/src/v/cloud_topics/reconciler/reconciliation_source.cc
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.cc
@@ -63,6 +63,13 @@ public:
       , _fe(ss::make_lw_shared<frontend>(partition, dp_api))
       , _partition(std::move(partition)) {}
 
+    l0_source(const l0_source&) = delete;
+    l0_source& operator=(const l0_source&) = delete;
+    l0_source(l0_source&&) = delete;
+    l0_source& operator=(l0_source&&) = delete;
+
+    ~l0_source() override { discard_placeholder_observation(); }
+
     bool has_pending_data() override {
         auto lro = last_reconciled_offset();
         auto lso = _fe->last_stable_offset();


### PR DESCRIPTION
Fixes exceptional future ignored warnings stemming from race conditions between detached partitions and waiters on a reconciliation source's HWM.

```
DEBUG 2026-07-14 06:10:11,804 [shard 1:main] reconciler - reconciler.cc:200 - Detaching partition {kafka/tp-workload-tc-compact/7}
WARN  2026-07-14 06:10:11,804 [shard 1:main] seastar - Exceptional future ignored: seastar::broken_promise (broken promise), backtrace:
[Backtrace #0]
seastar::guarded_backtrace(void**, int) at ./external/+non_module_dependencies+seastar/src/util/backtrace.cc:96
 (inlined by) void seastar::backtrace<seastar::current_backtrace_tasklocal()::$_0>(seastar::current_backtrace_tasklocal()::$_0&&, bool) at ./external/+non_module_dependencies+seastar/include/seastar/util/backtrace.hh:97
 (inlined by) seastar::current_backtrace_tasklocal() at ./external/+non_module_dependencies+seastar/src/util/backtrace.cc:105
seastar::current_tasktrace() at ./external/+non_module_dependencies+seastar/src/util/backtrace.cc:142
seastar::internal::report_failed_future(std::exception_ptr const&) at ./external/+non_module_dependencies+seastar/src/core/future.cc:223
seastar::internal::report_failed_future(seastar::future_state_base::any&&) at ./external/+non_module_dependencies+seastar/src/core/future.cc:231
seastar::future_state_base::any::check_failure() at ./external/+non_module_dependencies+seastar/include/seastar/core/future.hh:602
 (inlined by) seastar::future_state<detail::base_named_type<long, kafka::kafka_offset_type, std::__1::integral_constant<bool, true>>>::clear() at ./external/+non_module_dependencies+seastar/include/seastar/core/future.hh:651
 (inlined by) seastar::future_state<detail::base_named_type<long, kafka::kafka_offset_type, std::__1::integral_constant<bool, true>>>::~future_state() at ./external/+non_module_dependencies+seastar/include/seastar/core/future.hh:656
 (inlined by) seastar::future<detail::base_named_type<long, kafka::kafka_offset_type, std::__1::integral_constant<bool, true>>>::~future() at ./external/+non_module_dependencies+seastar/include/seastar/core/future.hh:1385
 (inlined by) std::__1::__optional_destruct_base<seastar::future<detail::base_named_type<long, kafka::kafka_offset_type, std::__1::integral_constant<bool, true>>>, false>::~__optional_destruct_base[abi:nqe220100]() at ./external/toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/optional:387
 (inlined by) cloud_topics::reconciler::(anonymous namespace)::l0_source::~l0_source() at ./src/v/cloud_topics/reconciler/reconciliation_source.cc:55
 (inlined by) seastar::shared_ptr_count_for<cloud_topics::reconciler::(anonymous namespace)::l0_source>::~shared_ptr_count_for() at ./external/+non_module_dependencies+seastar/include/seastar/core/shared_ptr.hh:477
 (inlined by) seastar::shared_ptr_count_for<cloud_topics::reconciler::(anonymous namespace)::l0_source>::~shared_ptr_count_for() at ./external/+non_module_dependencies+seastar/include/seastar/core/shared_ptr.hh:477
seastar::shared_ptr<cloud_topics::reconciler::source>::~shared_ptr() at ./external/+non_module_dependencies+seastar/include/seastar/core/shared_ptr.hh:554
 (inlined by) seastar::shared_ptr<cloud_topics::reconciler::source>::operator=(seastar::shared_ptr<cloud_topics::reconciler::source>&&) at ./external/+non_module_dependencies+seastar/include/seastar/core/shared_ptr.hh:567
std::__1::pair<model::ntp, seastar::shared_ptr<cloud_topics::reconciler::source>>::operator=[abi:nqe220100](std::__1::pair<model::ntp, seastar::shared_ptr<cloud_topics::reconciler::source>>&&) at ./external/toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__utility/pair.h:239
```

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
