### PR TITLE
archival: frame-aligned spillover

### DIFF
--- a/src/v/cloud_storage/BUILD
+++ b/src/v/cloud_storage/BUILD
@@ -304,6 +304,7 @@ redpanda_cc_library(
     visibility = [":__subpackages__"],
     deps = [
         ":types",
+        "//src/v/container:chunked_vector",
         "//src/v/model",
         "//src/v/utils:delta_for",
         "@boost//:iterator",

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -387,6 +387,11 @@ size_t partition_manifest::segments_metadata_bytes() const {
     return _segments.inflated_actual_size().second;
 }
 
+chunked_vector<cstore_frame_info>
+partition_manifest::sealed_segment_frames() const {
+    return _segments.sealed_frames();
+}
+
 size_t partition_manifest::estimate_serialized_size() const {
     constexpr auto bytes_per_segment = 10;
     return _segments.size() * bytes_per_segment;

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -273,6 +273,11 @@ public:
     // manifest, or 0 if the memory is not being tracked.
     size_t segments_metadata_bytes() const;
 
+    /// Sizes of the sealed (immutable) frames of the segment metadata
+    /// store, oldest first. The frame boundaries are segment aligned.
+    /// Spillover uses these to pick frame-aligned cut points.
+    chunked_vector<cstore_frame_info> sealed_segment_frames() const;
+
     // Return very rough estimate of the size of the serialized manifest
     size_t estimate_serialized_size() const;
 

--- a/src/v/cloud_storage/segment_meta_cstore.cc
+++ b/src/v/cloud_storage/segment_meta_cstore.cc
@@ -710,6 +710,52 @@ public:
 
     size_t hints_size() const { return _hints.size(); }
 
+    /// Return sizes of the sealed frames, oldest first. The last frame of
+    /// every column is the one appends go to, so it's excluded. All columns
+    /// share the same frame boundaries because they are appended to and
+    /// truncated in lockstep.
+    chunked_vector<cstore_frame_info> sealed_frames() const {
+        const auto num_frames = _base_offset._frames.size();
+        chunked_vector<cstore_frame_info> res;
+        if (num_frames <= 1) {
+            return res;
+        }
+        res.reserve(num_frames - 1);
+        for (const auto& f : _base_offset._frames) {
+            if (res.size() == num_frames - 1) {
+                break;
+            }
+            res.push_back({.elements = f.size(), .size_bytes = 0});
+        }
+        std::apply(
+          [&](auto&&... col) {
+              auto accumulate = [&](const auto& c) {
+                  vassert(
+                    c._frames.size() == num_frames,
+                    "Column frame count mismatch: {} vs {}",
+                    c._frames.size(),
+                    num_frames);
+                  size_t ix = 0;
+                  for (const auto& f : c._frames) {
+                      if (ix == res.size()) {
+                          break;
+                      }
+                      vassert(
+                        f.size() == res[ix].elements,
+                        "Frame {} boundary mismatch: {} vs {} elements",
+                        ix,
+                        f.size(),
+                        res[ix].elements);
+                      res[ix].size_bytes += f.mem_use();
+                      ++ix;
+                  }
+              };
+              (accumulate(col), ...);
+          },
+          columns());
+        return res;
+    }
+
     /// Return two values: inflated size (size without compression) followed
     /// by the actual size that takes compression into account.
     std::pair<size_t, size_t> inflated_actual_size() const {
@@ -1069,6 +1115,11 @@ public:
         return _col.hints_size();
     }
 
+    chunked_vector<cstore_frame_info> sealed_frames() const {
+        flush_write_buffer();
+        return _col.sealed_frames();
+    }
+
     bool empty() const { return _write_buffer.empty() && _col.empty(); }
 
     bool contains(model::offset o) {
@@ -1188,6 +1239,10 @@ bool segment_meta_cstore::empty() const { return _impl->empty(); }
 size_t segment_meta_cstore::size() const { return _impl->size(); }
 
 size_t segment_meta_cstore::hints_size() const { return _impl->hints_size(); }
+
+chunked_vector<cstore_frame_info> segment_meta_cstore::sealed_frames() const {
+    return _impl->sealed_frames();
+}
 
 segment_meta_cstore::const_iterator
 segment_meta_cstore::upper_bound(model::offset o) const {

--- a/src/v/cloud_storage/segment_meta_cstore.h
+++ b/src/v/cloud_storage/segment_meta_cstore.h
@@ -11,12 +11,14 @@
 #pragma once
 
 #include "cloud_storage/types.h"
+#include "container/chunked_vector.h"
 #include "utils/delta_for.h"
 
 #include <boost/iterator/iterator_categories.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 
 #include <memory>
+#include <vector>
 
 namespace cloud_storage {
 
@@ -27,6 +29,15 @@ inline constexpr size_t cstore_max_frame_size = 1024;
 // the outer frame is recorded to speed up random access. The distance in
 // elements between consecutive hints is FOR size * cstore_sampling_rate.
 inline constexpr size_t cstore_sampling_rate = 8;
+
+/// Size information about a single sealed (immutable) frame of the column
+/// store. Every column of the store has identical frame boundaries, so a
+/// frame is described by the number of segments it holds and the memory
+/// used by the matching frames of all columns combined.
+struct cstore_frame_info {
+    size_t elements{0};
+    size_t size_bytes{0};
+};
 
 /// Column-store iterator
 ///
@@ -156,6 +167,11 @@ public:
 
     /// Number of base-offset hints currently stored. Test-only inspection.
     size_t hints_size() const;
+
+    /// Sizes of the sealed frames of the store, oldest first. The last
+    /// (actively appended to) frame is excluded. Spillover uses these to
+    /// pick frame-aligned cut points.
+    chunked_vector<cstore_frame_info> sealed_frames() const;
 
     // Access individual columns
     const gauge_col_t& get_size_bytes_column() const;

--- a/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
@@ -957,3 +957,43 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_steady_state_churn_hints) {
     // freshly encoded equivalent
     BOOST_REQUIRE_LE(churned_actual, 4 * fresh_actual);
 }
+
+BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_sealed_frames) {
+    segment_meta_cstore store;
+    auto manifest = generate_metadata(2500);
+    for (const auto& sm : manifest) {
+        store.insert(sm);
+    }
+    store.flush_write_buffer();
+
+    // 2500 elements: two sealed frames of cstore_max_frame_size elements
+    // each, the remaining 452 live in the active frame
+    auto frames = store.sealed_frames();
+    BOOST_REQUIRE_EQUAL(frames.size(), 2);
+    for (const auto& f : frames) {
+        BOOST_REQUIRE_EQUAL(f.elements, cstore_max_frame_size);
+        BOOST_REQUIRE_GT(f.size_bytes, 0);
+    }
+
+    // the active frame is never reported
+    segment_meta_cstore small;
+    for (size_t i = 0; i < cstore_max_frame_size; ++i) {
+        small.insert(manifest[i]);
+    }
+    small.flush_write_buffer();
+    BOOST_REQUIRE_EQUAL(small.sealed_frames().size(), 0);
+
+    // adding one more element seals the first frame
+    small.insert(manifest[cstore_max_frame_size]);
+    small.flush_write_buffer();
+    auto small_frames = small.sealed_frames();
+    BOOST_REQUIRE_EQUAL(small_frames.size(), 1);
+    BOOST_REQUIRE_EQUAL(small_frames[0].elements, cstore_max_frame_size);
+
+    // prefix truncation shrinks the first sealed frame
+    store.prefix_truncate(manifest[100].base_offset);
+    auto truncated = store.sealed_frames();
+    BOOST_REQUIRE_EQUAL(truncated.size(), 2);
+    BOOST_REQUIRE_EQUAL(truncated[0].elements, cstore_max_frame_size - 100);
+    BOOST_REQUIRE_EQUAL(truncated[1].elements, cstore_max_frame_size);
+}

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -3118,10 +3118,18 @@ ss::future<> ntp_archiver::apply_spillover() {
     }
 
     if (manifest_size_limit.has_value()) {
+        const auto frames = manifest().sealed_segment_frames();
+        size_t sealed_bytes = 0;
+        for (const auto& f : frames) {
+            sealed_bytes += f.size_bytes;
+        }
         vlog(
           _rtclog.debug,
-          "Manifest size: {}, manifest size limit (x2): {}",
+          "Manifest size: {}, sealed frames: {} ({} bytes), manifest size "
+          "limit (x2): {}",
           manifest().segments_metadata_bytes(),
+          frames.size(),
+          sealed_bytes,
           manifest_size_limit.value() * 2);
     } else {
         vlog(
@@ -3132,8 +3140,16 @@ ss::future<> ntp_archiver::apply_spillover() {
     }
     auto stop_condition = [&] {
         if (manifest_size_limit.has_value()) {
-            return manifest().segments_metadata_bytes()
-                   < manifest_size_limit.value() * 2;
+            // Measure only the sealed frames of the manifest. This is the
+            // exact set of bytes the spillover can remove, so the trigger
+            // and the tail construction use the same units and the tail is
+            // guaranteed to make progress once the threshold is crossed.
+            const auto frames = manifest().sealed_segment_frames();
+            size_t sealed_bytes = 0;
+            for (const auto& f : frames) {
+                sealed_bytes += f.size_bytes;
+            }
+            return sealed_bytes < manifest_size_limit.value() * 2;
         }
         return manifest().size() < manifest_max_segments.value() * 2;
     };
@@ -3252,33 +3268,34 @@ cloud_storage::spillover_manifest make_spillover_tail(
   std::optional<size_t> max_segments) {
     cloud_storage::spillover_manifest tail(
       manifest.get_ntp(), manifest.get_revision_id());
-    auto tail_complete = [&] {
-        // Don't allow empty spillover manifests even if the limit
-        // is too low.
-        if (size_limit.has_value()) {
-            return tail.segments_metadata_bytes() >= size_limit.value()
-                   && tail.size() > 0;
+    size_t take_elements = 0;
+    if (size_limit.has_value()) {
+        // Consume whole sealed frames of the manifest's column store until
+        // the limit is reached. The size of the tail is measured on the
+        // frames being removed rather than on a re-encoded copy, so the
+        // limit is reachable by construction. The active frame never
+        // spills, which keeps the manifest non-empty and the cut on a
+        // segment boundary.
+        size_t taken_bytes = 0;
+        for (const auto& frame : manifest.sealed_segment_frames()) {
+            take_elements += frame.elements;
+            taken_bytes += frame.size_bytes;
+            if (taken_bytes >= size_limit.value()) {
+                break;
+            }
         }
-        return max_segments.has_value() && tail.size() >= max_segments.value()
-               && tail.size() > 0;
-    };
-    auto remaining = manifest.size();
+    } else if (max_segments.has_value() && manifest.size() > 0) {
+        // Count-based limit is a test-only config, keep the element-wise
+        // cut but never consume the whole manifest.
+        take_elements = std::min(max_segments.value(), manifest.size() - 1);
+    }
     for (const auto& meta : manifest) {
-        // The limits are not guaranteed to be reachable: the manifest
-        // measures its own metadata size differently from a freshly
-        // encoded copy of the same segments, so the tail may measure
-        // smaller than the manifest it was carved from. The last segment
-        // has to stay behind regardless.
-        if (remaining == 1) {
+        if (tail.size() == take_elements) {
             break;
         }
         tail.add(meta);
         // No performance impact since all writes here are sequential.
         tail.flush_write_buffer();
-        --remaining;
-        if (tail_complete()) {
-            break;
-        }
     }
     return tail;
 }

--- a/src/v/cluster/archival/ntp_archiver_service.h
+++ b/src/v/cluster/archival/ntp_archiver_service.h
@@ -842,15 +842,22 @@ private:
 };
 
 /// Build the section of the STM manifest that will be offloaded to the
-/// cloud as a spillover manifest. Segments are consumed from the front of
-/// the manifest until the tail reaches 'size_limit' bytes of metadata (or
-/// 'max_segments' elements if the size limit is not set).
+/// cloud as a spillover manifest.
 ///
-/// The tail never covers the entire manifest: at least one segment is
-/// always left behind, otherwise the resulting spillover command would be
-/// rejected by 'partition_manifest::safe_spillover_manifest' which
-/// requires the manifest to remain non-empty after the spillover range is
-/// removed.
+/// With 'size_limit' set (production mode) the cut is frame-aligned:
+/// whole sealed frames of the manifest's column store are consumed from
+/// the front until their combined size reaches the limit. The size is
+/// measured on the frames being removed, so the limit is reachable by
+/// construction, and the active frame never spills. A manifest that fits
+/// entirely in the active frame produces an empty tail.
+///
+/// With only 'max_segments' set (test-only config) the cut is
+/// element-wise, taking up to 'max_segments' segments.
+///
+/// In both modes the tail never covers the entire manifest, otherwise the
+/// resulting spillover command would be rejected by
+/// 'partition_manifest::safe_spillover_manifest' which requires the
+/// manifest to remain non-empty after the spillover range is removed.
 cloud_storage::spillover_manifest make_spillover_tail(
   const cloud_storage::partition_manifest& manifest,
   std::optional<size_t> size_limit,

--- a/src/v/cluster/archival/tests/ntp_archiver_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_test.cc
@@ -1725,8 +1725,19 @@ static void test_manifest_spillover_impl(
     const int64_t rec_per_segment = 1;
     cloud_storage::partition_manifest manifest(manifest_ntp, manifest_revision);
 
+    // Spillover is frame-aligned and only the sealed frames of the
+    // manifest can spill, so the generated manifest has to accumulate
+    // 'start_manifest_size' bytes in sealed frames.
+    auto sealed_bytes = [&manifest] {
+        size_t total = 0;
+        for (const auto& f : manifest.sealed_segment_frames()) {
+            total += f.size_bytes;
+        }
+        return total;
+    };
+
     int i = 0;
-    while (manifest.segments_metadata_bytes() < start_manifest_size) {
+    while (sealed_bytes() < start_manifest_size) {
         auto bo = model::offset(i * rec_per_segment);
         auto co = model::offset(i * rec_per_segment + rec_per_segment - 1);
         auto delta = model::offset_delta(0);

--- a/src/v/cluster/archival/tests/spillover_tail_test.cc
+++ b/src/v/cluster/archival/tests/spillover_tail_test.cc
@@ -63,16 +63,50 @@ SEASTAR_THREAD_TEST_CASE(test_spillover_tail_stops_at_segment_limit) {
       manifest.safe_spillover_manifest(tail.make_manifest_metadata()));
 }
 
-SEASTAR_THREAD_TEST_CASE(test_spillover_tail_never_consumes_whole_manifest) {
-    // The size limit is impossible to reach: without a guard the tail
-    // would swallow the entire manifest and the resulting spillover
-    // command would be rejected by safe_spillover_manifest on apply
-    // (there has to be a segment left after the spillover range).
-    auto manifest = make_manifest(20);
-    auto tail = make_spillover_tail(manifest, 100_MiB, std::nullopt);
-    BOOST_REQUIRE_EQUAL(tail.size(), 19);
+SEASTAR_THREAD_TEST_CASE(test_spillover_tail_takes_one_frame) {
+    // Size-based spillover is frame-aligned: even a tiny limit takes
+    // exactly one sealed frame.
+    auto manifest = make_manifest(2500);
+    auto tail = make_spillover_tail(manifest, 1, std::nullopt);
+    BOOST_REQUIRE_EQUAL(tail.size(), cloud_storage::cstore_max_frame_size);
+    BOOST_REQUIRE_EQUAL(
+      tail.get_start_offset().value(), manifest.get_start_offset().value());
     BOOST_REQUIRE(
       manifest.safe_spillover_manifest(tail.make_manifest_metadata()));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_spillover_tail_takes_multiple_frames) {
+    // A limit that the first sealed frame doesn't reach pulls in the next
+    // whole frame.
+    auto manifest = make_manifest(2500);
+    auto frames = manifest.sealed_segment_frames();
+    BOOST_REQUIRE_EQUAL(frames.size(), 2);
+    auto tail = make_spillover_tail(
+      manifest, frames[0].size_bytes + 1, std::nullopt);
+    BOOST_REQUIRE_EQUAL(tail.size(), 2 * cloud_storage::cstore_max_frame_size);
+    BOOST_REQUIRE(
+      manifest.safe_spillover_manifest(tail.make_manifest_metadata()));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_spillover_tail_never_takes_active_frame) {
+    // The size limit is impossible to reach. The tail consumes every
+    // sealed frame but the active frame always stays behind, so the
+    // resulting spillover command remains applicable
+    // (safe_spillover_manifest requires a segment to remain after the
+    // spillover range).
+    auto manifest = make_manifest(2500);
+    auto tail = make_spillover_tail(manifest, 100_MiB, std::nullopt);
+    BOOST_REQUIRE_EQUAL(tail.size(), 2 * cloud_storage::cstore_max_frame_size);
+    BOOST_REQUIRE(
+      manifest.safe_spillover_manifest(tail.make_manifest_metadata()));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_spillover_tail_sub_frame_manifest) {
+    // A manifest that fits entirely in the active frame has nothing to
+    // spill in size mode.
+    auto manifest = make_manifest(20);
+    auto tail = make_spillover_tail(manifest, 100_MiB, std::nullopt);
+    BOOST_REQUIRE_EQUAL(tail.size(), 0);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_spillover_tail_single_segment_manifest) {
@@ -80,4 +114,14 @@ SEASTAR_THREAD_TEST_CASE(test_spillover_tail_single_segment_manifest) {
     auto manifest = make_manifest(1);
     auto tail = make_spillover_tail(manifest, 100_MiB, std::nullopt);
     BOOST_REQUIRE_EQUAL(tail.size(), 0);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_spillover_tail_count_mode_keeps_last_segment) {
+    // The count-based limit (test-only config) keeps the legacy
+    // element-wise cut and never consumes the whole manifest.
+    auto manifest = make_manifest(20);
+    auto tail = make_spillover_tail(manifest, std::nullopt, 100);
+    BOOST_REQUIRE_EQUAL(tail.size(), 19);
+    BOOST_REQUIRE(
+      manifest.safe_spillover_manifest(tail.make_manifest_metadata()));
 }


### PR DESCRIPTION
Follow-up to #31081 (stacked on it — the first three commits belong to that PR; review the last two here).

#31081 fixed the immediate cause of the stuck-spillover incident, but the spillover sizing remained structurally fragile: the trigger compares the STM manifest's *in-memory* metadata size against 2x `cloud_storage_spillover_manifest_size`, while the tail stops when a *freshly re-encoded copy* of the segments reaches 1x the limit. Those are two different encodings of the same data. Any divergence between them (hint accumulation, per-frame overhead, row alignment after truncations) can make the limit unreachable, which is why #31081 had to bolt on a "never consume the last segment" guard.

This PR makes size-based spillover **frame-aligned**: the unit of spillover is a whole sealed frame of the manifest's column store (`cstore_max_frame_size` = 1024 segments per frame; frame boundaries are identical across all 13 columns since they are appended/truncated in lockstep — now asserted).

- **Trigger:** sum of the sealed frames' actual bytes >= 2x limit. The active (last) frame is excluded.
- **Tail:** whole sealed frames from the front until their combined size reaches the limit.
- Both sides measure **the exact bytes that will be removed** — no estimate, no re-encode prediction; the limit is reachable by construction.
- The active frame never spills, so the manifest can never be emptied: the applicability requirement of `safe_spillover_manifest` (a segment must remain after the spillover range) holds structurally, and the last-segment special case in `make_spillover_tail` is deleted rather than patched.
- The count-based limit (`cloud_storage_spillover_manifest_max_segments`, documented test-only) keeps the element-wise cut so existing tests and recipes keep working.

Commits:

1. `cloud_storage: expose sealed cstore frame sizes` — `segment_meta_cstore::sealed_frames()` reporting element count and combined memory of each immutable frame (asserting cross-column frame alignment), plus a `partition_manifest::sealed_segment_frames()` passthrough.
2. `archival: frame-aligned spillover` — rework `make_spillover_tail()` and the `apply_spillover` trigger as described; `test_manifest_spillover` now generates enough sealed-frame bytes.

Behavior changes to be aware of:

- Spillover manifest sizes are quantized to frame sums; the config value acts as a target rather than an exact bound. `metadata_size_hint` (used by the read path to reserve materialized-manifest cache space) still carries the tail's own measured size.
- Manifests with fewer than ~1024 segments (everything in the active frame) no longer spill. At the default 64 KiB limit spillover previously started around ~7k segments, so this only affects configurations with artificially small limits.

Verification: new unit tests written test-first and observed failing against the previous implementation (`test_segment_meta_cstore_sealed_frames`, five frame-aligned `spillover_tail_test` cases: one frame, multiple frames, unreachable limit never takes the active frame, sub-frame manifest yields an empty tail, count-mode legacy). `segment_meta_cstore_test`, `partition_manifest_test`, `ntp_archiver_test`, `spillover_tail_test`, `cloud_storage_e2e_test`, and `delete_records_e2e_test` all pass.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Improvements

* Tiered Storage metadata spillover now cuts spillover manifests along the physical frame boundaries of the in-memory metadata store, making the spillover size limit reliably reachable and spillover behavior more predictable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
