### PR TITLE
cloud_storage/tests: drop unused dep from segment_meta_cstore_test

### DIFF
--- a/src/v/cloud_storage/tests/BUILD
+++ b/src/v/cloud_storage/tests/BUILD
@@ -73,7 +73,6 @@ redpanda_cc_btest(
         "segment_meta_cstore_test.cc",
     ],
     deps = [
-        ":common",
         "//src/v/base",
         "//src/v/cloud_storage:segment_meta_cstore",
         "//src/v/cloud_storage:types",


### PR DESCRIPTION
The `segment_meta_cstore_test` target depends on `:common`, but the test
includes no headers from it. Through `//src/v/redpanda/tests:fixture` that
dependency pulls the full application into the test's build graph (~10k
compile actions, including datalake/iceberg). With the dependency removed
the test builds with just the cstore library and its direct deps.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none