### PR TITLE
schema_registry/rest: add http rate limiting

### DIFF
--- a/src/v/cluster_link/link.cc
+++ b/src/v/cluster_link/link.cc
@@ -136,6 +136,14 @@ ss::future<> link::start() {
 }
 
 ss::future<> link::stop() noexcept {
+    // Idempotent AND join-safe: the removal handler and manager shutdown both
+    // stop links and can race during teardown. A late caller waits for the
+    // first stop to complete rather than returning early -- the removal
+    // handler destroys the link right after its stop() resolves, so an early
+    // return would free the link out from under the still-running first stop.
+    if (std::exchange(_stop_requested, true)) {
+        co_return co_await _stopped.get_shared_future();
+    }
     vlog(
       cllog.info,
       "Stopping cluster link {} ({})",
@@ -187,6 +195,9 @@ ss::future<> link::stop() noexcept {
     _probe.reset(nullptr);
 
     vlog(cllog.info, "Stopped link {} ({})", _config->name, _config->uuid);
+    // Release any callers joined on a concurrent stop; they may free the link
+    // as soon as this resolves.
+    _stopped.set_value();
 }
 
 ss::future<cl_result<void>> link::register_task(task_factory* tf) {

--- a/src/v/cluster_link/link.h
+++ b/src/v/cluster_link/link.h
@@ -22,6 +22,8 @@
 #include "ssx/mutex.h"
 #include "utils/notification_list.h"
 
+#include <seastar/core/shared_future.hh>
+
 namespace cluster_link {
 
 class link_probe;
@@ -153,5 +155,12 @@ private:
     std::unique_ptr<link_probe> _probe;
     ss::gate _gate;
     ss::abort_source _as;
+    // stop() is called by both the link-removal handler and manager shutdown,
+    // which can race. The first call does the work; later calls must wait for
+    // it to COMPLETE (not return early): the removal handler frees the link
+    // right after stop() resolves, so an early return would let it destroy
+    // the link while the first stop is still suspended inside it.
+    bool _stop_requested{false};
+    ss::shared_promise<> _stopped;
 };
 } // namespace cluster_link

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -150,15 +150,45 @@ ss::future<> manager::stop() {
     vlog(cllog.info, "Stopping cluster link manager");
 
     co_await on_controller_stepdown();
+    vlog(cllog.debug, "manager stop: controller stepdown complete");
 
-    co_await _queue.shutdown();
     _link_task_reconciler_timer.cancel();
     _as.request_abort();
     _link_created_cv.broken();
-    co_await _g.close();
-    for (auto& [_, link] : _links) {
+
+    // Stop the links (which aborts their tasks) BEFORE draining the work
+    // queue and the gate: a queued link-change handler or an in-flight
+    // reconcile tick can be blocked on task machinery that only unblocks once
+    // the tasks' run fibers are aborted. Draining first sequences that abort
+    // behind the very drain that waits on it, deadlocking shutdown until the
+    // node-stop timeout kills the process.
+    //
+    // The queue is still live here and its one executing item may mutate
+    // _links, so stop by id snapshot and re-lookup; a link created after the
+    // snapshot is caught by the sweep below.
+    chunked_vector<id_t> ids;
+    ids.reserve(_links.size());
+    for (const auto& [id, _] : _links) {
+        ids.push_back(id);
+    }
+    for (const auto& id : ids) {
+        if (auto it = _links.find(id); it != _links.end()) {
+            co_await it->second->stop();
+        }
+    }
+    vlog(cllog.debug, "manager stop: links stopped");
+
+    co_await _queue.shutdown();
+    vlog(cllog.debug, "manager stop: work queue drained");
+
+    // The queue is drained and the reconcile timer canceled, so _links is
+    // stable now; sweep up any link a mid-flight handler created after the
+    // snapshot (stop() is idempotent, so re-stopping the rest is a no-op).
+    for (const auto& [_, link] : _links) {
         co_await link->stop();
     }
+
+    co_await _g.close();
 
     vlog(cllog.info, "Cluster link manager stopped");
 }
@@ -880,6 +910,11 @@ ss::future<> manager::link_task_reconciler() {
     auto units = std::move(fut).get();
 
     for (const auto& [_, link] : _links) {
+        // Shutdown aborts before stopping links; registering a task on a
+        // link that is about to stop would leak a never-stopped runner.
+        if (_as.abort_requested()) {
+            co_return;
+        }
         vlog(
           cllog.trace,
           "Reconciling tasks for cluster link {} ({})",

--- a/src/v/cluster_link/schema_registry_sync/BUILD
+++ b/src/v/cluster_link/schema_registry_sync/BUILD
@@ -35,6 +35,7 @@ redpanda_cc_library(
         "//src/v/net",
         "//src/v/pandaproxy/schema_registry/rest_client:error",
         "//src/v/pandaproxy/schema_registry/rest_client:pooled_client",
+        "//src/v/pandaproxy/schema_registry/rest_client:rate_limited_client",
         "//src/v/utils:retry_chain_node",
         "@ada",
     ],

--- a/src/v/cluster_link/schema_registry_sync/BUILD
+++ b/src/v/cluster_link/schema_registry_sync/BUILD
@@ -90,6 +90,7 @@ redpanda_cc_library(
         "//src/v/metrics",
         "//src/v/model",
         "//src/v/schema:registry",
+        "//src/v/ssx:mutex",
         "//src/v/ssx:semaphore",
         "@seastar",
     ],

--- a/src/v/cluster_link/schema_registry_sync/http_source_reader.cc
+++ b/src/v/cluster_link/schema_registry_sync/http_source_reader.cc
@@ -178,10 +178,25 @@ http_source_reader::http_source_reader(std::unique_ptr<rc::client> client)
 
 ss::future<source_result<rc::client*>>
 http_source_reader::ensure_client(ss::abort_source& as) {
+    // Checked before the fast path: stop() nulls _client, and a call arriving
+    // after stop (fibers may still be unwinding when the reader is stopped)
+    // must fail rather than rebuild a client nothing would ever stop.
+    if (_stopped) {
+        co_return std::unexpected(
+          source_error{
+            .kind = source_error_kind::source_unavailable,
+            .message = "source reader is stopped"});
+    }
     if (_client) {
         co_return _client.get();
     }
     auto build = co_await ss::get_units(_build, 1, as);
+    if (_stopped) {
+        co_return std::unexpected(
+          source_error{
+            .kind = source_error_kind::source_unavailable,
+            .message = "source reader is stopped"});
+    }
     if (_client) {
         co_return _client.get();
     }
@@ -395,7 +410,12 @@ ss::future<> http_source_reader::stop() {
     // Idempotent: the reader can be stopped more than once (e.g. an in-flight
     // reconciler stopping the task before link teardown stops it again). The
     // rest_client's gate must be closed exactly once, so release the client
-    // after shutting it down and skip it on a repeat call.
+    // after shutting it down and skip it on a repeat call. The sticky
+    // _stopped flag rejects post-stop rebuilds, and waiting out the build
+    // mutex means a build that raced this stop is shut down here rather than
+    // leaked.
+    _stopped = true;
+    auto build = co_await ss::get_units(_build, 1);
     if (auto client = std::move(_client); client) {
         co_await client->shutdown();
     }

--- a/src/v/cluster_link/schema_registry_sync/http_source_reader.cc
+++ b/src/v/cluster_link/schema_registry_sync/http_source_reader.cc
@@ -21,6 +21,7 @@
 #include "net/transport.h"
 #include "pandaproxy/schema_registry/rest_client/error.h"
 #include "pandaproxy/schema_registry/rest_client/pooled_client.h"
+#include "pandaproxy/schema_registry/rest_client/rate_limited_client.h"
 #include "utils/retry_chain_node.h"
 
 #include <seastar/core/coroutine.hh>
@@ -214,8 +215,13 @@ http_source_reader::ensure_client(ss::abort_source& as) {
         for (size_t i = 0; i < pool_size; ++i) {
             transports.push_back(std::make_unique<http::client>(cfg));
         }
+        // Limiter over pool: a request pays for dispatch (rate cap and any
+        // server-imposed Retry-After pause) before competing for a
+        // connection.
         _client = std::make_unique<rc::client>(
-          std::make_unique<rc::pooled_client>(std::move(transports)),
+          std::make_unique<rc::rate_limited_client>(
+            std::make_unique<rc::pooled_client>(std::move(transports)),
+            _conn->max_requests_per_sec),
           _conn->endpoint,
           _conn->auth,
           ppsr::qualified_subjects_enabled::yes);
@@ -411,7 +417,9 @@ std::unique_ptr<source_reader> http_source_reader_factory::create(
       .address = std::move(*address),
       .endpoint = api_cfg->source_url,
       .tls_enabled = bool(api_cfg->tls_enabled),
-      .provide_sni = bool(api_cfg->tls_provide_sni)};
+      .provide_sni = bool(api_cfg->tls_provide_sni),
+      .max_requests_per_sec = static_cast<size_t>(
+        api_cfg->get_max_source_requests_per_second())};
 
     if (api_cfg->ca.has_value()) {
         conn.truststore = to_certificate(api_cfg->ca.value());

--- a/src/v/cluster_link/schema_registry_sync/http_source_reader.h
+++ b/src/v/cluster_link/schema_registry_sync/http_source_reader.h
@@ -107,6 +107,10 @@ private:
     // Connection inputs for the lazy build; nullopt once a client is injected.
     std::optional<http_source_connection> _conn;
     std::unique_ptr<rc::client> _client;
+    // Set by stop(): the reader is stopped while the reconcile engine's
+    // fibers may still be unwinding, and a late call must fail rather than
+    // lazily rebuild the client (which nothing would ever stop).
+    bool _stopped{false};
     // Serializes the lazy client build only. Requests run concurrently: the
     // reconcile engine drives this reader from several fibers, and the
     // rest_client's pooled transport bounds them to one in-flight request per

--- a/src/v/cluster_link/schema_registry_sync/http_source_reader.h
+++ b/src/v/cluster_link/schema_registry_sync/http_source_reader.h
@@ -40,6 +40,14 @@ struct http_source_connection {
     std::optional<net::key_store> client_key;
     bool provide_sni{true};
     std::optional<rc::basic_auth_credentials> auth;
+    /// Cap on requests/sec to the source, resolved from the link's
+    /// max_source_requests_per_second (always > 0: conversion rejects
+    /// negatives and maps zero/unset to the default). Like the other
+    /// connection settings, a link-config change applies when the task next
+    /// (re)starts.
+    size_t max_requests_per_sec{
+      model::schema_registry_sync_config::shadow_schema_registry_api::
+        default_max_source_requests_per_second};
 };
 
 /// Resolves a source Schema Registry URL to the host:port the transport should

--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
@@ -154,31 +154,58 @@ ss::future<cl_result<void>> mirroring_task::start() {
 }
 
 ss::future<cl_result<void>> mirroring_task::stop() noexcept {
-    auto res = co_await task::stop();
-    _probe.clear();
-    // task::stop() closed the runner's gate, so no run_impl is in flight and it
-    // is safe to reset the state directly (unlike update_config, which races a
-    // running fiber and defers via _config_changed). Reset so a later leader
-    // starts fresh: this instance may regain _schemas/0 leadership (A->B->A)
-    // and would otherwise report a prior tenure's stale counters/inventory and
-    // skip its first full sync on a still-recent _last_full_sync.
-    reset_sync_state();
-    // The run loop has stopped, so no fiber is using the reader; release its
-    // HTTP transport. as_future guards the noexcept contract.
-    if (_reader) {
-        auto stopped = co_await ss::coroutine::as_future(_reader->stop());
-        if (stopped.failed()) {
-            auto ex = stopped.get_exception();
-            vlog(
-              logger().warn,
-              "Error stopping Schema Registry source reader: {}",
-              ex);
+    // Stop the reader BEFORE joining the run fiber: run_impl can be parked on
+    // reader-internal waits that only the reader's own shutdown aborts (the
+    // rate limiter's token queue and Retry-After pause -- up to 60s -- and the
+    // connection pool's slot queue are deaf to the runner's abort source).
+    // Joining first would sequence that abort behind the join that needs it.
+    // The reader is built to be stopped under fire: in-flight and queued
+    // requests fail promptly with abort-classified errors and run_impl
+    // unwinds. as_future guards the noexcept contract.
+    //
+    // Under _reader_lifecycle: run_impl is still live here (reader-first), so a
+    // concurrent reset_reader() could otherwise free the reader while this
+    // stop() is suspended mid-shutdown. The lock is dropped before the join
+    // below, so it cannot deadlock against a reset_reader() the join waits on.
+    {
+        auto reader_units = co_await _reader_lifecycle.get_units();
+        if (_reader) {
+            auto stopped = co_await ss::coroutine::as_future(_reader->stop());
+            if (stopped.failed()) {
+                auto ex = stopped.get_exception();
+                vlog(
+                  logger().warn,
+                  "Error stopping Schema Registry source reader: {}",
+                  ex);
+            }
         }
     }
+    auto res = co_await task::stop();
+    _probe.clear();
+    // task::stop() closed the runner's gate, so no run_impl is in flight and
+    // it is safe to reset the state directly (unlike update_config, which
+    // races a running fiber and defers via _config_changed). Reset so a later
+    // leader starts fresh: this instance may regain _schemas/0 leadership
+    // (A->B->A) and would otherwise report a prior tenure's stale
+    // counters/inventory and skip its first full sync on a still-recent
+    // _last_full_sync.
+    reset_sync_state();
+    // Replace the stopped reader with a fresh one for that possible A->B->A
+    // re-acquisition. The reader's stop() is permanent by design (it refuses
+    // to rebuild its client so an unwinding fiber cannot resurrect it during
+    // teardown), and run_impl only rebuilds the reader on a config change, so
+    // a restarted task would otherwise keep using the dead reader and never
+    // sync. No lock needed: the run fibers have been joined, so reset_reader()
+    // cannot run and none is mid-request on the old reader.
+    _reader = _source_factory->create(_config.api_mode());
     co_return res;
 }
 
 ss::future<> mirroring_task::reset_reader() {
+    // Serialize with stop() (see _reader_lifecycle): both stop and then free
+    // the reader by reassignment, and either can be suspended in the reader's
+    // shutdown when the other reaches the free.
+    auto reader_units = co_await _reader_lifecycle.get_units();
     if (_reader) {
         auto stopped = co_await ss::coroutine::as_future(_reader->stop());
         if (stopped.failed()) {

--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.h
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.h
@@ -17,6 +17,7 @@
 #include "cluster_link/task.h"
 #include "container/chunked_hash_map.h"
 #include "schema/registry.h"
+#include "ssx/mutex.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/util/noncopyable_function.hh>
@@ -237,6 +238,14 @@ private:
     schema::registry* _destination;
     source_reader_factory* _source_factory;
     std::unique_ptr<source_reader> _reader;
+    // Serializes stopping and replacing _reader. stop() (reader-first, while
+    // run_impl is still live) and reset_reader() (run by run_impl on a config
+    // change) both stop the reader and then free it via reassignment; without
+    // serialization one can free the reader while the other's stop() is
+    // suspended mid-shutdown, a use-after-free. Held only around the
+    // stop+reassign, never across the run-fiber join, so it cannot deadlock
+    // with task::stop().
+    ssx::mutex _reader_lifecycle{"cluster_link/sr_source/reader_lifecycle"};
     inventory _destination_inventory;
     model::schema_registry_sync_status _status;
     // Live counters for the in-flight reconcile; reflected by get_status_report

--- a/src/v/cluster_link/schema_registry_sync/tests/http_source_reader_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/http_source_reader_test.cc
@@ -113,6 +113,62 @@ TEST(http_source_reader, list_contexts_enumerates_all_contexts) {
         pps::default_context, pps::context{".dev"}, pps::context{".prod"}));
 }
 
+// Stopping the reader while a request is in flight aborts the request rather
+// than waiting for it out: mirroring_task::stop() stops the reader before
+// joining the run fibers, relying on exactly this to unwedge fibers parked in
+// reader-internal waits (rate-limiter token/pause queues, pool slots).
+TEST(http_source_reader, stop_aborts_in_flight_requests) {
+    std::deque<ss::promise<http::downloaded_response>> parked;
+    auto reader = reader_over([&](mock_client& m) {
+        ON_CALL(m, request_and_collect_response(_, _, _))
+          .WillByDefault([&](
+                           bh::request_header<>&&,
+                           std::optional<iobuf>,
+                           ss::lowres_clock::duration) {
+              parked.emplace_back();
+              return parked.back().get_future();
+          });
+        // Like the real transport, shutdown fails the requests it is
+        // servicing.
+        ON_CALL(m, shutdown_and_stop()).WillByDefault([&] {
+            for (auto& request : parked) {
+                request.set_exception(
+                  std::make_exception_ptr(ss::abort_requested_exception{}));
+            }
+            parked.clear();
+            return ss::make_ready_future<>();
+        });
+    });
+    ss::abort_source as;
+    auto req = reader.list_contexts(as);
+    RPTEST_REQUIRE_EVENTUALLY(5s, [&] { return !parked.empty(); });
+
+    reader.stop().get();
+    auto res = req.get();
+    ASSERT_FALSE(res.has_value());
+    EXPECT_EQ(res.error().kind, srs::source_error_kind::source_unavailable);
+}
+
+// A reader call after stop() must fail fast instead of lazily rebuilding the
+// client: the reconcile engine's fibers can still be unwinding when the
+// reader is stopped, and a rebuilt client would never be shut down.
+TEST(http_source_reader, calls_after_stop_fail_without_rebuild) {
+    srs::http_source_connection conn{
+      .address = net::unresolved_address("example.invalid", 8081),
+      .endpoint = "http://example.invalid:8081",
+    };
+    srs::http_source_reader reader{std::move(conn)};
+    reader.stop().get();
+
+    ss::abort_source as;
+    auto res = reader.list_contexts(as).get();
+    ASSERT_FALSE(res.has_value());
+    EXPECT_EQ(res.error().kind, srs::source_error_kind::source_unavailable);
+    EXPECT_THAT(res.error().message, HasSubstr("stopped"));
+    // stop() stays idempotent.
+    reader.stop().get();
+}
+
 // stop() is idempotent: the task teardown can stop the reader more than once
 // (an in-flight reconciler stopping the task before link teardown stops it
 // again). A second stop() must not double-close the rest_client's gate, which

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -786,9 +786,12 @@ ss::future<http::downloaded_response> client::request_and_collect_response(
     }
 
     auto status_code = co_await status(response);
+    boost::beast::http::fields headers = response->get_headers();
     auto body = co_await drain(response);
     co_return downloaded_response{
-      .status = status_code, .body = std::move(body)};
+      .status = status_code,
+      .body = std::move(body),
+      .headers = std::move(headers)};
 }
 
 ss::output_stream<char> client::request_stream::as_output_stream() {

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -73,6 +73,8 @@ std::string_view content_type_string(content_type type);
 struct downloaded_response {
     boost::beast::http::status status;
     iobuf body;
+    // Response header fields, verbatim from the wire (e.g. Retry-After).
+    boost::beast::http::fields headers;
 };
 
 // Interface to allow testing the http client with mocks

--- a/src/v/http/tests/http_client_test.cc
+++ b/src/v/http/tests/http_client_test.cc
@@ -236,6 +236,30 @@ SEASTAR_THREAD_TEST_CASE(test_http_POST_roundtrip) {
       });
 }
 
+SEASTAR_THREAD_TEST_CASE(test_collect_response_carries_headers) {
+    auto config = transport_configuration();
+    auto [server, client] = started_client_and_server(config);
+
+    http::client::request_header header;
+    header.method(boost::beast::http::verb::get);
+    header.target("/get");
+    header_set_host(header, config.server_addr);
+
+    auto resp = client->request_and_collect_response(std::move(header)).get();
+    server->stop().get();
+
+    BOOST_REQUIRE_EQUAL(resp.status, boost::beast::http::status::ok);
+    BOOST_REQUIRE(!resp.body.empty());
+    // The collected headers mirror the wire: the server's content-length
+    // matches the body actually received.
+    auto content_length = resp.headers.find(
+      boost::beast::http::field::content_length);
+    BOOST_REQUIRE(content_length != resp.headers.end());
+    BOOST_REQUIRE_EQUAL(
+      std::string(content_length->value()),
+      std::to_string(resp.body.size_bytes()));
+}
+
 /// Test http streaming requests e2e in ss::async
 template<class Func>
 void test_http_streaming_request(

--- a/src/v/pandaproxy/schema_registry/rest_client/BUILD
+++ b/src/v/pandaproxy/schema_registry/rest_client/BUILD
@@ -93,6 +93,31 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "rate_limited_client",
+    srcs = [
+        "rate_limited_client.cc",
+    ],
+    hdrs = [
+        "rate_limited_client.h",
+    ],
+    implementation_deps = [
+        ":logger",
+    ],
+    visibility = [
+        "//src/v/cluster_link:__subpackages__",
+        "//src/v/pandaproxy:__subpackages__",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/http",
+        "//src/v/utils:token_bucket",
+        "@boost//:beast",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "pooled_client",
     srcs = [
         "pooled_client.cc",

--- a/src/v/pandaproxy/schema_registry/rest_client/rate_limited_client.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/rate_limited_client.cc
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "pandaproxy/schema_registry/rest_client/rate_limited_client.h"
+
+#include "base/external_fmt.h"
+#include "base/vlog.h"
+#include "pandaproxy/schema_registry/rest_client/logger.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/coroutine/as_future.hh>
+
+#include <boost/beast/http/field.hpp>
+#include <boost/beast/http/status.hpp>
+
+#include <charconv>
+#include <utility>
+
+namespace pandaproxy::schema_registry::rest_client {
+
+namespace {
+
+// Bucket units charged per request. token_bucket grants tokens in ~50ms
+// ticks with integer math (rate * 45ms / 1000ms per tick), so a bucket run
+// directly in requests/sec starves forever below ~23/s: each tick rounds to
+// zero tokens and the accrual window resets. Scaling by 1000 keeps every
+// configured rate >= 1/s accruing fractional requests per tick.
+constexpr size_t tokens_per_request = 1000;
+
+// Stands in for "no cap" while waiters may be parked on the bucket: the
+// bucket cannot be destroyed under them, so a disable re-rates it high enough
+// to be no practical constraint and the request path stops consulting it.
+constexpr size_t effectively_unlimited_rps = 1'000'000'000;
+
+// The bucket rate for a requests/sec cap; capacity follows the rate, i.e. up
+// to one second of burst.
+constexpr size_t bucket_rate(size_t requests_per_sec) {
+    return requests_per_sec * tokens_per_request;
+}
+
+// Parse the delta-seconds form of Retry-After, clamped to max_retry_after.
+// The clamp happens before the duration is constructed: chrono::seconds has a
+// signed rep, so an unclamped value above int64 max would wrap negative and
+// silently disable the pause instead of bounding it. The HTTP-date form (and
+// any other unparseable value) yields nullopt and is ignored.
+std::optional<std::chrono::seconds>
+parse_retry_after(const boost::beast::http::fields& headers) {
+    auto it = headers.find(boost::beast::http::field::retry_after);
+    if (it == headers.end()) {
+        return std::nullopt;
+    }
+    auto value = it->value();
+    uint64_t seconds{};
+    auto [ptr, ec] = std::from_chars(
+      value.data(), value.data() + value.size(), seconds);
+    if (ec != std::errc{} || ptr != value.data() + value.size()) {
+        return std::nullopt;
+    }
+    constexpr auto max_seconds = static_cast<uint64_t>(
+      rate_limited_client::max_retry_after.count());
+    return std::chrono::seconds{
+      static_cast<std::chrono::seconds::rep>(std::min(seconds, max_seconds))};
+}
+
+} // namespace
+
+rate_limited_client::rate_limited_client(
+  std::unique_ptr<http::abstract_client> inner,
+  std::optional<size_t> requests_per_sec)
+  : _inner(std::move(inner)) {
+    update_rate(requests_per_sec);
+}
+
+void rate_limited_client::update_rate(std::optional<size_t> requests_per_sec) {
+    if (requests_per_sec == _rate) {
+        return;
+    }
+    if (requests_per_sec.has_value()) {
+        if (_bucket.has_value()) {
+            _bucket->update_rate(bucket_rate(*requests_per_sec));
+        } else {
+            _bucket.emplace(
+              bucket_rate(*requests_per_sec),
+              "schema_registry/rest_client/rate");
+        }
+    } else if (_bucket.has_value()) {
+        _bucket->update_rate(bucket_rate(effectively_unlimited_rps));
+    }
+    _rate = requests_per_sec;
+}
+
+ss::lowres_clock::duration rate_limited_client::pause_remaining() const {
+    auto now = ss::lowres_clock::now();
+    return _paused_until > now ? _paused_until - now
+                               : ss::lowres_clock::duration::zero();
+}
+
+void rate_limited_client::observe_throttle_signal(
+  const http::downloaded_response& response) {
+    using enum boost::beast::http::status;
+    if (
+      response.status != too_many_requests
+      && response.status != service_unavailable) {
+        return;
+    }
+    auto retry_after = parse_retry_after(response.headers);
+    if (!retry_after.has_value()) {
+        return;
+    }
+    auto deadline = ss::lowres_clock::now() + *retry_after;
+    if (deadline > _paused_until) {
+        _paused_until = deadline;
+        vlog(
+          srclog.info,
+          "source signaled {} with Retry-After; pausing requests for {}s",
+          response.status,
+          retry_after->count());
+    }
+}
+
+ss::future<> rate_limited_client::wait_out_pause() {
+    // Loop: a concurrent throttled response may extend the pause while this
+    // fiber sleeps.
+    while (true) {
+        auto now = ss::lowres_clock::now();
+        if (now >= _paused_until) {
+            co_return;
+        }
+        co_await ss::sleep_abortable<ss::lowres_clock>(
+          _paused_until - now, _as);
+    }
+}
+
+ss::future<http::downloaded_response>
+rate_limited_client::request_and_collect_response(
+  boost::beast::http::request_header<>&& request,
+  std::optional<iobuf> payload,
+  ss::lowres_clock::duration timeout) {
+    // Move the request into this frame before any suspension so it does not
+    // depend on the caller's object while paused or waiting for a token.
+    auto owned_request = std::move(request);
+    auto holder = _gate.hold();
+    // Wait out a server-imposed pause first, then pay for a token, so a
+    // backlog released from a pause is still paced by the bucket.
+    co_await wait_out_pause();
+    if (_rate.has_value()) {
+        // value(): a configured rate implies an engaged bucket (update_rate
+        // maintains this); throw rather than dereference if that invariant is
+        // ever broken.
+        co_await _bucket.value().throttle(tokens_per_request, _as);
+        // A throttled response may have armed the pause while this fiber
+        // waited for its token; dispatching now would leak through the pause,
+        // so sleep it out too. The token stays spent: the request still
+        // dispatches exactly once.
+        co_await wait_out_pause();
+    }
+    auto response = co_await ss::coroutine::as_future(
+      _inner->request_and_collect_response(
+        std::move(owned_request), std::move(payload), timeout));
+    if (response.failed()) {
+        co_return co_await std::move(response);
+    }
+    auto value = std::move(response).get();
+    observe_throttle_signal(value);
+    co_return std::move(value);
+}
+
+ss::future<> rate_limited_client::shutdown_and_stop() {
+    auto drained = _gate.close();
+    // Wakes pause sleepers (sleep_aborted) and token waiters
+    // (semaphore_aborted); the bucket itself needs no shutdown since every
+    // wait goes through _as.
+    _as.request_abort();
+    co_await _inner->shutdown_and_stop();
+    co_await std::move(drained);
+}
+
+} // namespace pandaproxy::schema_registry::rest_client

--- a/src/v/pandaproxy/schema_registry/rest_client/rate_limited_client.h
+++ b/src/v/pandaproxy/schema_registry/rest_client/rate_limited_client.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "base/seastarx.h"
+#include "bytes/iobuf.h"
+#include "http/client.h"
+#include "utils/token_bucket.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/lowres_clock.hh>
+
+#include <memory>
+#include <optional>
+
+namespace pandaproxy::schema_registry::rest_client {
+
+/// An http::abstract_client that bounds the rate of requests sent through it
+/// and honors server throttle signals. Compose it over a pooled_client so a
+/// request acquires a token before it competes for a connection.
+///
+/// Two independent mechanisms:
+/// - When a rate is configured, a token bucket caps dispatched requests per
+///   second. Every attempt costs one token, so a caller's retries are charged
+///   like first attempts. update_rate() retunes, enables, or disables the cap
+///   live.
+/// - A 429 (or 503) response carrying a Retry-After header pauses dispatch of
+///   ALL requests until the indicated deadline, clamped to max_retry_after,
+///   whether or not a rate is configured: the server signaled client-wide
+///   overload, so every fiber backs off, not just the one that saw the
+///   response. Only the delta-seconds form is recognized; the HTTP-date form
+///   is ignored.
+///
+/// shutdown_and_stop() must be called exactly once before destruction. It
+/// rejects new requests, wakes fibers waiting on the pause or on a token,
+/// stops the wrapped transport, and drains.
+class rate_limited_client final : public http::abstract_client {
+public:
+    /// Upper bound on an accepted Retry-After, so a broken or hostile server
+    /// cannot park the client indefinitely.
+    static constexpr std::chrono::seconds max_retry_after{60};
+
+    /// \param inner the transport to dispatch on (typically a pooled_client)
+    /// \param requests_per_sec proactive rate cap; nullopt disables it
+    rate_limited_client(
+      std::unique_ptr<http::abstract_client> inner,
+      std::optional<size_t> requests_per_sec);
+
+    ss::future<http::downloaded_response> request_and_collect_response(
+      boost::beast::http::request_header<>&& request,
+      std::optional<iobuf> payload = std::nullopt,
+      ss::lowres_clock::duration timeout = http::default_connect_timeout) final;
+
+    ss::future<> shutdown_and_stop() final;
+
+    /// Retune the request-rate cap; nullopt disables proactive limiting.
+    /// Fibers already waiting for a token are re-paced at the new rate (a
+    /// disable releases them promptly).
+    void update_rate(std::optional<size_t> requests_per_sec);
+
+    /// Time left in a server-imposed Retry-After pause; zero when dispatch is
+    /// not paused.
+    ss::lowres_clock::duration pause_remaining() const;
+
+private:
+    // Extend the dispatch pause when the response carries a throttle signal.
+    void observe_throttle_signal(const http::downloaded_response& response);
+
+    // Resolves once dispatch is not paused, sleeping out extensions armed
+    // while waiting.
+    ss::future<> wait_out_pause();
+
+    std::unique_ptr<http::abstract_client> _inner;
+    // The configured cap. The bucket is engaged lazily on first enable and
+    // never destroyed (waiters may be parked on it); when the cap is disabled
+    // the request path skips the bucket and _bucket is re-rated so parked
+    // waiters drain promptly.
+    std::optional<size_t> _rate;
+    std::optional<token_bucket<>> _bucket;
+    ss::lowres_clock::time_point _paused_until{};
+    // Wakes pause sleepers and token waiters on shutdown.
+    ss::abort_source _as;
+    ss::gate _gate;
+};
+
+} // namespace pandaproxy::schema_registry::rest_client

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/BUILD
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/BUILD
@@ -73,6 +73,24 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "rate_limited_client_test",
+    timeout = "short",
+    srcs = [
+        "rate_limited_client_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/http",
+        "//src/v/pandaproxy/schema_registry/rest_client:rate_limited_client",
+        "//src/v/test_utils:async",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "pooled_client_test",
     timeout = "short",
     srcs = [

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/rate_limited_client_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/rate_limited_client_test.cc
@@ -1,0 +1,323 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "bytes/iobuf.h"
+#include "http/client.h"
+#include "pandaproxy/schema_registry/rest_client/rate_limited_client.h"
+#include "test_utils/async.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/util/later.hh>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <deque>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace rc = pandaproxy::schema_registry::rest_client;
+namespace bh = boost::beast::http;
+using namespace std::chrono_literals;
+
+namespace {
+
+// Records dispatch times and answers every request with a canned response.
+class fake_transport final : public http::abstract_client {
+public:
+    ss::future<http::downloaded_response> request_and_collect_response(
+      bh::request_header<>&& request,
+      std::optional<iobuf>,
+      ss::lowres_clock::duration) final {
+        dispatch_times.push_back(ss::lowres_clock::now());
+        targets.emplace_back(request.target().begin(), request.target().end());
+        if (park) {
+            parked.emplace_back();
+            return parked.back().get_future();
+        }
+        auto response = http::downloaded_response{
+          .status = _status, .body = iobuf{}, .headers = _headers};
+        // One-shot: after replying with the canned throttle signal once,
+        // subsequent requests succeed, mirroring a server whose window
+        // reopened.
+        if (_one_shot) {
+            _status = bh::status::ok;
+            _headers = bh::fields{};
+            _one_shot = false;
+        }
+        return ss::make_ready_future<http::downloaded_response>(
+          std::move(response));
+    }
+
+    ss::future<> shutdown_and_stop() final {
+        stopped = true;
+        return ss::make_ready_future<>();
+    }
+
+    void respond_once_with(
+      bh::status status, std::optional<std::string> retry_after) {
+        _status = status;
+        _headers = bh::fields{};
+        if (retry_after.has_value()) {
+            _headers.set(bh::field::retry_after, *retry_after);
+        }
+        _one_shot = true;
+    }
+
+    // Completes the oldest parked request with the given response.
+    void
+    release_one(bh::status status, std::optional<std::string> retry_after) {
+        ASSERT_FALSE(parked.empty());
+        bh::fields headers;
+        if (retry_after.has_value()) {
+            headers.set(bh::field::retry_after, *retry_after);
+        }
+        auto request = std::move(parked.front());
+        parked.pop_front();
+        request.set_value(
+          http::downloaded_response{
+            .status = status, .body = iobuf{}, .headers = std::move(headers)});
+    }
+
+    std::vector<ss::lowres_clock::time_point> dispatch_times;
+    std::vector<std::string> targets;
+    bool stopped{false};
+    // When true, requests park until release_one().
+    bool park{false};
+    std::deque<ss::promise<http::downloaded_response>> parked;
+
+private:
+    bh::status _status{bh::status::ok};
+    bh::fields _headers;
+    bool _one_shot{false};
+};
+
+struct limiter_fixture {
+    explicit limiter_fixture(std::optional<size_t> rate) {
+        auto owned = std::make_unique<fake_transport>();
+        transport = owned.get();
+        limiter = std::make_unique<rc::rate_limited_client>(
+          std::move(owned), rate);
+    }
+
+    ss::future<http::downloaded_response> issue(std::string_view target) {
+        bh::request_header<> header;
+        header.method(bh::verb::get);
+        header.target(target);
+        co_return co_await limiter->request_and_collect_response(
+          std::move(header));
+    }
+
+    fake_transport* transport;
+    std::unique_ptr<rc::rate_limited_client> limiter;
+};
+
+} // namespace
+
+TEST(rate_limited_client, unlimited_mode_passes_through_immediately) {
+    limiter_fixture fx(std::nullopt);
+    auto start = ss::lowres_clock::now();
+    for (int i = 0; i < 20; ++i) {
+        auto res = fx.issue("/r").get();
+        EXPECT_EQ(res.status, bh::status::ok);
+    }
+    EXPECT_EQ(fx.transport->dispatch_times.size(), 20);
+    // No pacing: a generous bound that a single throttled request would blow.
+    EXPECT_LT(ss::lowres_clock::now() - start, 5s);
+    EXPECT_EQ(fx.limiter->pause_remaining(), 0ms);
+    fx.limiter->shutdown_and_stop().get();
+    EXPECT_TRUE(fx.transport->stopped);
+}
+
+TEST(rate_limited_client, paces_requests_at_configured_rate) {
+    // rate 5/s with burst capacity 5: the sixth request must wait for a
+    // refresh (~200ms of accrual at this rate).
+    limiter_fixture fx(5);
+    auto start = ss::lowres_clock::now();
+    for (int i = 0; i < 6; ++i) {
+        fx.issue("/r").get();
+    }
+    auto elapsed = ss::lowres_clock::now() - start;
+    EXPECT_EQ(fx.transport->dispatch_times.size(), 6);
+    EXPECT_GE(elapsed, 100ms) << "sixth request was not paced";
+    fx.limiter->shutdown_and_stop().get();
+}
+
+TEST(rate_limited_client, retry_after_pauses_subsequent_dispatch) {
+    limiter_fixture fx(std::nullopt);
+    fx.transport->respond_once_with(bh::status::too_many_requests, "1");
+
+    // The throttled response is returned to the caller (retrying is the
+    // caller's job), and the pause is now armed.
+    auto throttled = fx.issue("/a").get();
+    EXPECT_EQ(throttled.status, bh::status::too_many_requests);
+    EXPECT_GT(fx.limiter->pause_remaining(), 500ms);
+
+    auto start = ss::lowres_clock::now();
+    auto res = fx.issue("/b").get();
+    EXPECT_EQ(res.status, bh::status::ok);
+    EXPECT_GE(ss::lowres_clock::now() - start, 900ms)
+      << "dispatch was not paused for Retry-After";
+    fx.limiter->shutdown_and_stop().get();
+}
+
+TEST(rate_limited_client, retry_after_is_clamped) {
+    // A day, and a value above chrono::seconds' signed rep (uint64_t max):
+    // both clamp to max_retry_after rather than overflowing or being dropped.
+    for (auto huge : {"86400", "18446744073709551615"}) {
+        limiter_fixture fx(std::nullopt);
+        fx.transport->respond_once_with(bh::status::too_many_requests, huge);
+        fx.issue("/a").get();
+        EXPECT_GT(fx.limiter->pause_remaining(), 30s) << "value=" << huge;
+        EXPECT_LE(
+          fx.limiter->pause_remaining(),
+          rc::rate_limited_client::max_retry_after)
+          << "value=" << huge;
+        fx.limiter->shutdown_and_stop().get();
+    }
+}
+
+TEST(rate_limited_client, service_unavailable_with_retry_after_pauses) {
+    limiter_fixture fx(std::nullopt);
+    fx.transport->respond_once_with(bh::status::service_unavailable, "30");
+    fx.issue("/a").get();
+    EXPECT_GT(fx.limiter->pause_remaining(), 20s);
+    fx.limiter->shutdown_and_stop().get();
+}
+
+TEST(rate_limited_client, throttle_signal_without_or_bad_header_is_ignored) {
+    {
+        // 429 with no Retry-After: reactive backoff is the caller's retry
+        // policy; no client-wide pause.
+        limiter_fixture fx(std::nullopt);
+        fx.transport->respond_once_with(
+          bh::status::too_many_requests, std::nullopt);
+        fx.issue("/a").get();
+        EXPECT_EQ(fx.limiter->pause_remaining(), 0ms);
+        fx.limiter->shutdown_and_stop().get();
+    }
+    {
+        // HTTP-date form is not parsed in v1.
+        limiter_fixture fx(std::nullopt);
+        fx.transport->respond_once_with(
+          bh::status::too_many_requests, "Fri, 31 Dec 2027 23:59:59 GMT");
+        fx.issue("/a").get();
+        EXPECT_EQ(fx.limiter->pause_remaining(), 0ms);
+        fx.limiter->shutdown_and_stop().get();
+    }
+    {
+        // A value from_chars cannot represent at all (> uint64_t max) is
+        // ignored rather than undefined.
+        limiter_fixture fx(std::nullopt);
+        fx.transport->respond_once_with(
+          bh::status::too_many_requests, "99999999999999999999");
+        fx.issue("/a").get();
+        EXPECT_EQ(fx.limiter->pause_remaining(), 0ms);
+        fx.limiter->shutdown_and_stop().get();
+    }
+    {
+        // A plain error status must not pause dispatch.
+        limiter_fixture fx(std::nullopt);
+        fx.transport->respond_once_with(bh::status::internal_server_error, "5");
+        fx.issue("/a").get();
+        EXPECT_EQ(fx.limiter->pause_remaining(), 0ms);
+        fx.limiter->shutdown_and_stop().get();
+    }
+}
+
+TEST(rate_limited_client, update_rate_disable_releases_waiters) {
+    // rate 1/s, capacity 1: the second request parks on the bucket.
+    limiter_fixture fx(1);
+    fx.issue("/a").get();
+    auto waiting = fx.issue("/b");
+    ss::yield().get();
+    EXPECT_EQ(fx.transport->dispatch_times.size(), 1);
+
+    fx.limiter->update_rate(std::nullopt);
+    // Released promptly: well before the ~1s a token would have taken.
+    auto start = ss::lowres_clock::now();
+    waiting.get();
+    EXPECT_LT(ss::lowres_clock::now() - start, 500ms);
+    EXPECT_EQ(fx.transport->dispatch_times.size(), 2);
+
+    // Disabled mode dispatches immediately.
+    fx.issue("/c").get();
+    EXPECT_EQ(fx.transport->dispatch_times.size(), 3);
+    fx.limiter->shutdown_and_stop().get();
+}
+
+TEST(rate_limited_client, update_rate_enables_limiting_live) {
+    limiter_fixture fx(std::nullopt);
+    fx.issue("/a").get();
+    fx.limiter->update_rate(5);
+    auto start = ss::lowres_clock::now();
+    // Burst capacity 5, so the sixth paced request waits.
+    for (int i = 0; i < 6; ++i) {
+        fx.issue("/r").get();
+    }
+    EXPECT_GE(ss::lowres_clock::now() - start, 100ms);
+    fx.limiter->shutdown_and_stop().get();
+}
+
+TEST(rate_limited_client, pause_armed_while_waiting_for_token_is_honored) {
+    // rate 1/s: the first request drains the burst capacity, so the second
+    // parks in the token wait for ~1s.
+    limiter_fixture fx(1);
+    fx.transport->park = true;
+    auto first = fx.issue("/a");
+    RPTEST_REQUIRE_EVENTUALLY(
+      5s, [&] { return fx.transport->parked.size() == 1; });
+    auto second = fx.issue("/b");
+    ss::yield().get();
+    EXPECT_EQ(fx.transport->dispatch_times.size(), 1);
+
+    // Answer the first request with a throttle signal while the second is
+    // still waiting for its token: the pause armed here must gate the second
+    // request's dispatch even though it already passed the pause check.
+    auto armed_at = ss::lowres_clock::now();
+    fx.transport->release_one(bh::status::too_many_requests, "3");
+    EXPECT_EQ(first.get().status, bh::status::too_many_requests);
+    EXPECT_GT(fx.limiter->pause_remaining(), 1s);
+
+    // The second request gets its token after ~1s but must sleep out the
+    // pause (~3s) before dispatching.
+    RPTEST_REQUIRE_EVENTUALLY(
+      10s, [&] { return fx.transport->parked.size() == 1; });
+    EXPECT_GE(ss::lowres_clock::now() - armed_at, 2s)
+      << "dispatch leaked through a pause armed during the token wait";
+    fx.transport->release_one(bh::status::ok, std::nullopt);
+    EXPECT_EQ(second.get().status, bh::status::ok);
+    fx.limiter->shutdown_and_stop().get();
+}
+
+TEST(rate_limited_client, shutdown_wakes_paused_and_waiting_requests) {
+    limiter_fixture fx(1);
+    fx.transport->respond_once_with(bh::status::too_many_requests, "60");
+    fx.issue("/a").get();
+    EXPECT_GT(fx.limiter->pause_remaining(), 30s);
+
+    // Parked sleeping out the pause.
+    auto paused = fx.issue("/b");
+    ss::yield().get();
+    EXPECT_EQ(fx.transport->dispatch_times.size(), 1);
+
+    fx.limiter->shutdown_and_stop().get();
+    EXPECT_THROW(paused.get(), ss::sleep_aborted);
+    EXPECT_TRUE(fx.transport->stopped);
+    EXPECT_THROW(fx.issue("/c").get(), ss::gate_closed_exception);
+}

--- a/src/v/pandaproxy/schema_registry/rest_client/tests/retry_policy_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/retry_policy_test.cc
@@ -12,6 +12,7 @@
 #include "pandaproxy/schema_registry/rest_client/retry_policy.h"
 
 #include <seastar/core/future.hh>
+#include <seastar/core/sleep.hh>
 
 #include <gtest/gtest.h>
 
@@ -101,6 +102,12 @@ TEST(default_retry_policy, abort_exception) {
     ASSERT_EQ(gate_failure.kind, r::error_kind::aborted);
     auto abort_failure = throw_and_catch(ss::abort_requested_exception{});
     ASSERT_EQ(abort_failure.kind, r::error_kind::aborted);
+    // The rate-limiting transport sleeps out server-imposed pauses; an
+    // aborted sleep is a shutdown, not a request failure. sleep_aborted
+    // derives from abort_requested_exception, so the abort classification
+    // covers it; this pins that inheritance-dependent behavior.
+    auto sleep_failure = throw_and_catch(ss::sleep_aborted{});
+    ASSERT_EQ(sleep_failure.kind, r::error_kind::aborted);
 }
 
 TEST(default_retry_policy, nested_exception) {

--- a/tests/rptest/tests/cluster_linking_schema_registry_sync_test.py
+++ b/tests/rptest/tests/cluster_linking_schema_registry_sync_test.py
@@ -1053,7 +1053,14 @@ class SchemaRegistrySyncMixin:
             self._register(src, subject, self._large_schema(i, body))
             pairs.append((subject, 1))
 
-        self._create_sr_link()
+        # Effectively unthrottled: at the default 30 req/s the periodic full
+        # syncs saturate the 2s interval on slow CI hardware, so teardown
+        # always lands mid-sync and can hang node shutdown on an unabortable
+        # destination write racing raft shutdown (issue #31108). A fast sync
+        # restores the idle-at-teardown profile this test always ran with;
+        # drop the override once #31108 is fixed. Rate-limiting behavior
+        # itself is covered by test_schema_registry_api_sync_teardown_mid_sync.
+        self._create_sr_link(max_source_requests_per_second=1000)
         self._wait_synced(src, dest, pairs)
 
     def _test_schema_registry_api_sync_teardown_mid_sync(self):

--- a/tests/rptest/tests/cluster_linking_schema_registry_sync_test.py
+++ b/tests/rptest/tests/cluster_linking_schema_registry_sync_test.py
@@ -222,6 +222,7 @@ class SchemaRegistrySyncMixin:
         exact_context_map: dict[str, str] | None = None,
         feature_policy: shadow_link_pb2.UnsupportedSchemaFeaturePolicy.ValueType
         | None = None,
+        max_source_requests_per_second: int | None = None,
     ) -> str:
         # Create a shadow link that syncs only the Schema Registry, in API mode,
         # pointing at the source cluster's SR endpoint (or an explicit URL, e.g.
@@ -243,6 +244,8 @@ class SchemaRegistrySyncMixin:
                 seconds=full_sync_interval_sec
             ),
         )
+        if max_source_requests_per_second is not None:
+            api.max_source_requests_per_second = max_source_requests_per_second
         if feature_policy is not None:
             api.unsupported_schema_feature_policy = feature_policy
         if source_filter_subjects is not None:
@@ -1053,6 +1056,31 @@ class SchemaRegistrySyncMixin:
         self._create_sr_link()
         self._wait_synced(src, dest, pairs)
 
+    def _test_schema_registry_api_sync_teardown_mid_sync(self):
+        src = self._make_source_client()
+        dest = SchemaRegistryRedpandaClient(self.target_cluster_service)
+
+        # Enough subjects that a full sync at 2 requests/s takes far longer
+        # than the 2s full-sync interval, so the task is effectively always
+        # mid-sync from here on.
+        pairs: list[Pair] = []
+        for i in range(16):
+            subject = f"subj-{i}-value"
+            self._register(src, subject, self._leaf_schema(i))
+            pairs.append((subject, 1))
+
+        # The per-link cap doubles as coverage that the admin field reaches
+        # the reader's rate limiter: at the default rate this sync finishes in
+        # a couple of seconds, so _wait_synced only passes this slowly because
+        # the field applied.
+        self._create_sr_link(max_source_requests_per_second=2)
+        self._wait_synced(src, dest, pairs)
+        # The regression under test fires at teardown: stopping a node while
+        # the throttled sync is mid-flight used to deadlock cluster_link
+        # shutdown (the manager drained its work queue and gate before
+        # aborting the tasks they were blocked on) until the 30s node-stop
+        # timeout killed the node. Success here is simply a clean teardown.
+
     def _test_schema_registry_api_sync_survives_leadership_change(self):
         src = self._make_source_client()
         dest = SchemaRegistryRedpandaClient(self.target_cluster_service)
@@ -1429,6 +1457,12 @@ class SchemaRegistrySyncE2ETest(ShadowLinkTestBase, SchemaRegistrySyncMixin):
     @cluster(num_nodes=6)
     def test_schema_registry_api_sync_survives_leadership_change(self):
         self._test_schema_registry_api_sync_survives_leadership_change()
+
+    # Redpanda-source only: the teardown behavior under test is
+    # vendor-agnostic, so one leaf suffices.
+    @cluster(num_nodes=6)
+    def test_schema_registry_api_sync_teardown_mid_sync(self):
+        self._test_schema_registry_api_sync_teardown_mid_sync()
 
 
 class ConfluentSchemaRegistrySyncE2ETest(ShadowLinkTestBase, SchemaRegistrySyncMixin):


### PR DESCRIPTION
Adds rate limiting to the schema registry rest client used by shadow link SR sync, composing over the connection pooling added in #31090 (rest_client -> rate limiter -> connection pool).

- Requests to the source registry are capped by a token bucket: one token per attempt (retries pay too), acquired before competing for a pooled connection. The cap comes from the link's existing `max_source_requests_per_second` setting, previously accepted and persisted but unenforced: unset or zero means the documented 30 request/s default, negatives are rejected at conversion, and describe reports the resolved value via `effective_max_source_requests_per_second`. Like the reader's other connection settings, a change applies when the task next (re)starts.
- A 429 (or 503) response carrying `Retry-After` (delta-seconds form) pauses all dispatch until the indicated deadline, clamped to 60s, whether or not a cap is configured: the server signaled client-wide overload, so every fiber backs off. The caller's retry backoff applies on top.
- `http::downloaded_response` now carries the response header fields, which makes the Retry-After handling possible.

Because throttled syncs are in flight most of the time, this series also fixes the two shutdown-liveness orderings that CI surfaced (both pre-existing; the wider in-flight window made them reliable):

- First commit: `manager::stop()` drained its work queue and gate before stopping links, sequencing the task abort behind the very drains that waited on it; stopping a node mid-sync hung until the 30s node-stop timeout. Links are now stopped first, and `link::stop()` is join-safe under the removal-handler/shutdown race (late callers wait on a shared future for the in-flight stop to complete rather than returning early, so the removal handler cannot free a link mid-stop). A ducktape test (`test_schema_registry_api_sync_teardown_mid_sync`) pins teardown-mid-sync and exercises the per-link cap end to end.
- `mirroring_task::stop()` joined the run fiber before stopping the reader, but the reader's shutdown is what aborts the limiter/pool waits (including the 60s Retry-After pause). The reader is now stopped first; its stop is sticky (a late call from a still-unwinding fiber fails instead of lazily rebuilding a client nothing would stop) and serializes with the in-flight lazy build.

One deeper, narrower liveness gap remains and is tracked in #31108 rather than grown into this PR: a destination `_schemas` write (seq_writer -> raft produce, no abort/deadline) racing raft shutdown can still wedge a node stop. It predates this series; the memory-backpressure ducktape test pins its link rate high to keep the idle-at-teardown profile it always ran with until #31108 is fixed (see the in-test comment).

Note for reviewers: the limiter runs the bucket at 1000 units per request because `utils/token_bucket.h` starves permanently below ~23 units/sec (each ~50ms tick grants `rate * 45ms / 1000ms` tokens with integer math and resets the accrual window, so low rates round to zero forever). Existing users run at byte rates and cannot hit this; fixing the primitive itself is left to a follow-up.

Verified with unit tests plus ducktape, including release mode (where the teardown races reproduce): the SR sync e2e suite passes; the previously-failing memory-backpressure teardown and the new teardown-mid-sync regression test pass repeatedly in both fastbuild and release; the regression test deadlocks without the first commit's reordering; and a sync throttled to 2 rps via the per-link field runs visibly paced, showing the setting is enforced end to end.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

(The shutdown-ordering fix is the first commit in the series, separable if a backport of just that fix is ever wanted; without rate limiting its window is very narrow.)

## Release Notes

### Features

* Schema Registry sync shadow links now enforce the link's `max_source_requests_per_second` setting (default 30 requests/sec) when reading from the source registry, and honor a throttling source's `Retry-After` response header.
