### PR TITLE
ct/housekeeper: skip retention for compact-only topics

### DIFF
--- a/src/v/cloud_topics/housekeeper/housekeeper.cc
+++ b/src/v/cloud_topics/housekeeper/housekeeper.cc
@@ -49,28 +49,31 @@ ss::future<> housekeeper::stop() {
 }
 
 ss::future<> housekeeper::do_housekeeping() {
-    kafka::offset new_start_offset = kafka::offset::min();
-    if (auto retention_bytes = _config->retention_bytes(_tidp)) {
-        new_start_offset = co_await do_bytes_retention(*retention_bytes);
-    }
-    if (auto retention_duration = _config->retention_duration(_tidp)) {
-        auto offset = co_await do_time_retention(*retention_duration);
-        new_start_offset = std::max(new_start_offset, offset);
-    }
-    auto max_allowed_start_offset = _l0_metastore->get_max_allowed_start_offset(
-      _tidp);
-    if (max_allowed_start_offset < new_start_offset) {
-        vlog(
-          cd_log.trace,
-          "{} - Pinning requested new start offset {} by max allowed start "
-          "offset {}",
-          _tidp,
-          new_start_offset,
-          max_allowed_start_offset);
-        new_start_offset = max_allowed_start_offset;
-    }
-    if (new_start_offset != kafka::offset::min()) {
-        co_await _l0_metastore->set_start_offset(_tidp, new_start_offset, &_as);
+    if (_config->deletion_enabled(_tidp)) {
+        kafka::offset new_start_offset = kafka::offset::min();
+        if (auto retention_bytes = _config->retention_bytes(_tidp)) {
+            new_start_offset = co_await do_bytes_retention(*retention_bytes);
+        }
+        if (auto retention_duration = _config->retention_duration(_tidp)) {
+            auto offset = co_await do_time_retention(*retention_duration);
+            new_start_offset = std::max(new_start_offset, offset);
+        }
+        auto max_allowed_start_offset
+          = _l0_metastore->get_max_allowed_start_offset(_tidp);
+        if (max_allowed_start_offset < new_start_offset) {
+            vlog(
+              cd_log.trace,
+              "{} - Pinning requested new start offset {} by max allowed start "
+              "offset {}",
+              _tidp,
+              new_start_offset,
+              max_allowed_start_offset);
+            new_start_offset = max_allowed_start_offset;
+        }
+        if (new_start_offset != kafka::offset::min()) {
+            co_await _l0_metastore->set_start_offset(
+              _tidp, new_start_offset, &_as);
+        }
     }
     // Sync the start offset back to the L1 metastore.
     // DeleteRecords may advance the L0 start offset past the L1 start offset.

--- a/src/v/cloud_topics/housekeeper/housekeeper.h
+++ b/src/v/cloud_topics/housekeeper/housekeeper.h
@@ -88,6 +88,9 @@ public:
     public:
         virtual ~retention_configuration() = default;
 
+        // Whether the cleanup policy enables deletion.
+        virtual bool deletion_enabled(const model::topic_id_partition&) = 0;
+
         // The amount of bytes to retain in the partition.
         virtual std::optional<size_t>
         retention_bytes(const model::topic_id_partition&) = 0;

--- a/src/v/cloud_topics/housekeeper/manager.cc
+++ b/src/v/cloud_topics/housekeeper/manager.cc
@@ -157,6 +157,12 @@ public:
         state)
       : _state(state) {}
 
+    bool deletion_enabled(const model::topic_id_partition& tidp) override {
+        auto& state = _state->at(tidp);
+        return model::is_deletion_enabled(
+          state.partition->get_ntp_config().cleanup_policy());
+    }
+
     std::optional<size_t>
     retention_bytes(const model::topic_id_partition& tidp) override {
         auto& state = _state->at(tidp);

--- a/src/v/cloud_topics/housekeeper/tests/housekeeper_test.cc
+++ b/src/v/cloud_topics/housekeeper/tests/housekeeper_test.cc
@@ -144,6 +144,7 @@ private:
 struct simple_retention_config {
     std::optional<size_t> bytes;
     std::optional<std::chrono::milliseconds> duration;
+    bool deletion_enabled = true;
 };
 
 class retention_config_impl
@@ -151,6 +152,10 @@ class retention_config_impl
 public:
     explicit retention_config_impl(const simple_retention_config& cfg)
       : _cfg(cfg) {}
+
+    bool deletion_enabled(const model::topic_id_partition&) override {
+        return _cfg.deletion_enabled;
+    }
 
     std::optional<size_t>
     retention_bytes(const model::topic_id_partition&) override {
@@ -535,6 +540,31 @@ TEST_F(HousekeeperTest, MixedRetentionBothDeleteAll) {
 
     housekeeper.do_housekeeping().get();
     EXPECT_EQ(start_offset(), kafka::offset{250});
+}
+
+TEST_F(HousekeeperTest, RetentionSkippedWhenDeletionDisabled) {
+    // A compact-only topic disables deletion: even aggressive retention must
+    // not advance the start offset.
+    simple_retention_config cfg;
+    cfg.bytes = 50_KiB;
+    cfg.duration = 5min;
+    cfg.deletion_enabled = false;
+    auto housekeeper = make_housekeeper(cfg);
+    EXPECT_EQ(start_offset(), kafka::offset{0});
+
+    add_object({
+      .records = 100,
+      .size = 2_MiB,
+      .max_timestamp = model::timestamp_clock::now() - 2h,
+    });
+    add_object({
+      .records = 150,
+      .size = 2_MiB,
+      .max_timestamp = model::timestamp_clock::now() - 1h,
+    });
+
+    housekeeper.do_housekeeping().get();
+    EXPECT_EQ(start_offset(), kafka::offset{0});
 }
 
 TEST_F(HousekeeperTest, MultipleObjectsTimeRetention) {

--- a/tests/rptest/tests/cloud_topics/retention_test.py
+++ b/tests/rptest/tests/cloud_topics/retention_test.py
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import time
+
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
 from ducktape.mark import matrix
 from ducktape.tests.test import TestContext
@@ -314,4 +316,80 @@ class CloudTopicsRetentionTest(EndToEndCloudTopicsBase):
         # Waits until the the partition size reaches a reported size of 0
         ct_utils.wait_until_l1_partition_size(
             self.admin, self.topic_name, 0, lambda size: size == 0
+        )
+
+    def _assert_start_offset_stays_zero(
+        self,
+        topic: str,
+        partition: int,
+        duration_sec: int,
+        backoff_sec: int,
+    ):
+        """
+        Poll start_offset for `duration_sec`, asserting it never advances past
+        0. The window spans several housekeeping intervals (5s each), so any
+        retention enforcement would have fired and advanced the offset by the
+        time this returns.
+        """
+        deadline = time.monotonic() + duration_sec
+        while time.monotonic() < deadline:
+            part = self._get_partition_info(topic, partition)
+            self.logger.info(
+                f"start_offset for {topic}:{partition} = {part.start_offset} "
+                f"(hwm={part.high_watermark})"
+            )
+            assert part.start_offset == 0, (
+                f"Retention must not advance start_offset for a compact-only "
+                f"topic, but it advanced to {part.start_offset}"
+            )
+            time.sleep(backoff_sec)
+
+    @cluster(num_nodes=4)
+    @matrix(
+        cloud_storage_type=get_cloud_storage_type(),
+        storage_mode=[
+            TopicSpec.STORAGE_MODE_CLOUD,
+            TopicSpec.STORAGE_MODE_IMPL_TIERED_V2,
+        ],
+    )
+    def test_compact_only_topic_ignores_retention(
+        self, cloud_storage_type: CloudStorageType, storage_mode: str
+    ):
+        """
+        A compact-only topic (cleanup.policy=compact) must never have its start
+        offset advanced by retention, even with retention.bytes and retention.ms
+        set aggressively low. Retention (log deletion) only applies when the
+        cleanup policy enables deletion; compaction alone rewrites data but must
+        keep the log start offset pinned at 0.
+        """
+        num_messages = 3000
+        total_bytes = num_messages * 1024  # ~3MB, far above retention.bytes
+
+        rpk = RpkTool(self.redpanda)
+        rpk.create_topic(
+            topic=self.topic_name,
+            partitions=1,
+            replicas=3,
+            config={
+                **TopicSpec.storage_mode_config(storage_mode),
+                "cleanup.policy": TopicSpec.CLEANUP_COMPACT,
+                # Aggressively low retention that WOULD advance the start offset
+                # if it were (incorrectly) applied to a compact-only topic.
+                "retention.bytes": "1024",
+                "retention.ms": "10",
+            },
+        )
+
+        self._produce(topic=self.topic_name, bytes_to_produce=total_bytes)
+        self.wait_until_reconciled(topic=self.topic_name, partition=0)
+
+        # Confirm data actually landed in L1, so retention would have something
+        # to act on.
+        ct_utils.wait_until_l1_partition_size(
+            self.admin, self.topic_name, 0, lambda size: size > 0
+        )
+
+        # Across several housekeeping intervals, the start offset must stay 0.
+        self._assert_start_offset_stays_zero(
+            topic=self.topic_name, partition=0, duration_sec=40, backoff_sec=5
         )


### PR DESCRIPTION
The housekeeping loop computed retention and advanced the start offset without consulting the cleanup policy. For compact-only topics this deleted readable data that compaction is meant to preserve.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Bug Fix

* Fixes a bug where Cloud Topics with the `compact` cleanup policy would have log retention policies applied to them.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
