### PR TITLE
bazel: update seastar to 7960dd3c

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -355,7 +355,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "QK0XCW+BTz2nsWYrtviVuUGVhvcjmy31lieoIfTWB2w=",
+        "bzlTransitiveDigest": "0jixidnjQWeriRAkguQNUdk9ZcLmay0y7T1ydxy6rmo=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedInputs": [
           "REPO_MAPPING:,bazel_tools bazel_tools",
@@ -528,9 +528,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "7f395262aa42d3ffec092a112971c36e5ce7513c8729be6a1a0c606cc5d4fc12",
-              "strip_prefix": "seastar-4027b6ed4ad267594fcfaaada877b1c30fc05e0c",
-              "url": "https://github.com/redpanda-data/seastar/archive/4027b6ed4ad267594fcfaaada877b1c30fc05e0c.tar.gz"
+              "sha256": "839be691002102028946214504f0d17e9f01237a0ff6dc5faf219fb1ca59e1eb",
+              "strip_prefix": "seastar-7960dd3c4a9ad6d2f40f533cc2d9aefa179d84cb",
+              "url": "https://github.com/redpanda-data/seastar/archive/7960dd3c4a9ad6d2f40f533cc2d9aefa179d84cb.tar.gz"
             }
           },
           "unordered_dense": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -164,9 +164,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "7f395262aa42d3ffec092a112971c36e5ce7513c8729be6a1a0c606cc5d4fc12",
-        strip_prefix = "seastar-4027b6ed4ad267594fcfaaada877b1c30fc05e0c",
-        url = "https://github.com/redpanda-data/seastar/archive/4027b6ed4ad267594fcfaaada877b1c30fc05e0c.tar.gz",
+        sha256 = "839be691002102028946214504f0d17e9f01237a0ff6dc5faf219fb1ca59e1eb",
+        strip_prefix = "seastar-7960dd3c4a9ad6d2f40f533cc2d9aefa179d84cb",
+        url = "https://github.com/redpanda-data/seastar/archive/7960dd3c4a9ad6d2f40f533cc2d9aefa179d84cb.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Update the vendored Seastar to the latest commit on the `v26.2.x` branch of the redpanda-data/seastar fork.

- Previous SHA: `4027b6ed4ad2`
- New SHA: `7960dd3c4a9a`

Changes:
- reactor: Auto enable overprovisioned in k8s on 6.12-7.0

Full comparison: https://github.com/redpanda-data/seastar/compare/4027b6ed4ad267594fcfaaada877b1c30fc05e0c...7960dd3c4a9ad6d2f40f533cc2d9aefa179d84cb

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none