### PR TITLE
[CORE-10453] `rptest`: remove flakey `wait_all_segments()` condition

### DIFF
--- a/tests/rptest/tests/controller_erase_test.py
+++ b/tests/rptest/tests/controller_erase_test.py
@@ -74,25 +74,6 @@ class ControllerEraseTest(RedpandaTest):
             controller_elected, timeout_sec=15, backoff_sec=1
         )
 
-        def wait_all_segments():
-            storage = self.redpanda.node_storage(victim_node)
-            segments = (
-                storage.ns["redpanda"]
-                .topics["controller"]
-                .partitions["0_0"]
-                .segments.keys()
-            )
-            # We expect that segments count for controller should be transfers_leadership_count + 1.
-            # Because each transfer creates one segment + initial leadership after restart creates first segment
-            return len(segments) == transfers_leadership_count + 1
-
-        wait_until(
-            wait_all_segments,
-            timeout_sec=40,
-            backoff_sec=1,
-            err_msg=f"Victim node({victim_node}) does not contain expected segments count({transfers_leadership_count + 1}) for controller log",
-        )
-
         bystander_node_dirty_offset = admin.get_controller_status(bystander_node)[
             "dirty_offset"
         ]


### PR DESCRIPTION
In this test, when running with argument `partial=False`, we use the default value for `controller_snapshot_max_age_sec=60`. In slow runs of this test which exceed 60s, this means that we may potentially snapshot and prefix truncate the controller log. Removing segments this way can cause the condition in `wait_all_segments()` to fail.

However, this is a bad condition to wait on, since the number of segments really doesn't matter. The other wait condition here (in which we wait on the last applied offset for the controller log to tick up to what is expected) is a stronger/more correct wait condition.

Remove `wait_all_segments()` from the test to deflake it.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
