### PR TITLE
[CORE-16834] cluster_link: propagate context deletions in SR sync

### DIFF
--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
@@ -30,6 +30,7 @@
 
 #include <fmt/ranges.h>
 
+#include <ranges>
 #include <utility>
 
 namespace cluster_link::schema_registry_sync {
@@ -61,6 +62,19 @@ bool is_reference_blocked(const std::exception_ptr& ep) {
         std::rethrow_exception(ep);
     } catch (const ppsr::exception& e) {
         return e.code() == ppsr::error_code::subject_version_has_references;
+    } catch (...) {
+    }
+    return false;
+}
+
+// A context delete blocked because the context still has subjects (e.g. a
+// reference-blocked version survived the purge); retried on the next full sync
+// rather than counted as a hard error.
+bool is_context_not_empty(const std::exception_ptr& ep) {
+    try {
+        std::rethrow_exception(ep);
+    } catch (const ppsr::exception& e) {
+        return e.code() == ppsr::error_code::context_not_empty;
     } catch (...) {
     }
     return false;
@@ -337,6 +351,59 @@ ss::future<uint64_t> mirroring_task::purge_destination_only_versions(
         targets = std::move(next_round);
     }
     co_return purged;
+}
+
+ss::future<> mirroring_task::delete_source_absent_contexts(
+  const chunked_hash_set<ppsr::context>& contexts,
+  const ss::noncopyable_function<bool(const ppsr::context_subject&)>& in_scope,
+  ss::abort_source& as) {
+    // Enumerated in the destination namespace. A destination context is a
+    // deletion target when it is owned by this link (reverse-maps to a source
+    // context), managed as a whole (in scope as a context, not merely via a
+    // subject filter), is not the default context (which always exists), and is
+    // no longer present at the source. Its subjects were already purged above.
+    // `dest_contexts` is a named local, so the lazy view is safe to iterate
+    // across the deletes below (which touch the store, not these operands).
+    const auto dest_contexts = co_await _destination->list_contexts();
+    auto to_delete
+      = dest_contexts | std::views::filter([&](const ppsr::context& dest_ctx) {
+            if (dest_ctx == ppsr::default_context) {
+                return false;
+            }
+            auto src_ctx = _mapper.reverse(dest_ctx);
+            return src_ctx.has_value()
+                   && in_scope(
+                     ppsr::context_subject{*src_ctx, ppsr::subject{""}})
+                   && !contexts.contains(*src_ctx);
+        });
+
+    for (const auto& dest_ctx : to_delete) {
+        as.check();
+        auto fut = co_await ss::coroutine::as_future(
+          _destination->delete_context(dest_ctx));
+        if (fut.failed()) {
+            auto ex = fut.get_exception();
+            if (ssx::is_shutdown_exception(ex)) {
+                std::rethrow_exception(ex);
+            }
+            if (is_context_not_empty(ex)) {
+                // The purge could not empty it this run (e.g. a
+                // reference-blocked version); retry on the next full sync.
+                vlog(
+                  logger().debug,
+                  "Deferring delete of source-absent context {}: {}",
+                  dest_ctx,
+                  ex);
+                continue;
+            }
+            record_error(
+              fmt::format(
+                "failed to delete source-absent context {}: {}", dest_ctx, ex));
+            continue;
+        }
+        vlog(
+          logger().info, "Deleted context {} absent from the source", dest_ctx);
+    }
 }
 
 bool mirroring_task::fail_if_contains_unsupported(
@@ -770,6 +837,11 @@ ss::future<task::state_transition> mirroring_task::full_source_sync(
     if (mc_unavailable.has_value()) {
         co_return make_unavailable(mc_unavailable->message);
     }
+
+    // Tombstone any destination context whose source context is gone (its
+    // subjects were purged above). Runs after mode/config so a
+    // source-unavailable run backs off before touching contexts.
+    co_await delete_source_absent_contexts(contexts, in_scope, as);
 
     // Re-scan now that imports have landed so the reported destination counts
     // reflect the post-sync state, not the pre-import baseline the diff used.

--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.h
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.h
@@ -187,6 +187,19 @@ private:
       ppsr::schema_version version,
       bool was_active);
 
+    /// Tombstones every destination context this link owns and holds in scope
+    /// as a whole that no longer exists at the source (`contexts`). The
+    /// context's subjects must already have been purged; a not-yet-empty
+    /// context (e.g. a reference-blocked version survived the purge) is left
+    /// for the next full sync. Matches Confluent's DELETE /contexts: only the
+    /// context marker is removed, leaving any context-level mode/config
+    /// overrides untouched.
+    ss::future<> delete_source_absent_contexts(
+      const chunked_hash_set<ppsr::context>& contexts,
+      const ss::noncopyable_function<bool(const ppsr::context_subject&)>&
+        in_scope,
+      ss::abort_source& as);
+
     /// Replicates one target's (subject or context-only) source mode and
     /// compatibility config onto the destination: writes the source's own
     /// override when it has one, deletes the destination override otherwise.

--- a/src/v/cluster_link/schema_registry_sync/tests/mirroring_task_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/mirroring_task_test.cc
@@ -1267,6 +1267,53 @@ TEST_F(mirroring_task_test, destination_inventory_spans_contexts_and_deleted) {
     EXPECT_THAT(inv.all, testing::UnorderedElementsAre(a_v1, c_v1, a_v2));
 }
 
+TEST_F(mirroring_task_test, deletes_source_absent_context) {
+    // The destination holds a subject under .prod, materializing that context;
+    // the source has no .prod context at all. The whole context is a deletion:
+    // its subject is purged, then the now-empty context is tombstoned so it no
+    // longer lists. A default-context subject present at the source is synced
+    // and left alone, showing the phase deletes only the source-absent context.
+    auto prod_orders = ppsr::context_subject{
+      ppsr::context{".prod"}, ppsr::subject{"orders-value"}};
+    _registry.import_schema(make_schema(prod_orders, 1, R"({"v":1})")).get();
+    auto keep = ppsr::context_subject::unqualified("keep-value");
+    _source_state.add(keep, 1);
+
+    lead_schema_registry();
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+    // Present, error-free, and exactly two subject-version changes: keep-value
+    // imported (+1) and the source-absent .prod subject purged (+1).
+    ASSERT_THAT(
+      status,
+      testing::Optional(
+        testing::Field(
+          &model::schema_registry_sync_status::last_full_sync,
+          testing::Optional(
+            testing::AllOf(
+              testing::Field(&model::schema_registry_sync_summary::errors, 0),
+              testing::Field(
+                &model::schema_registry_sync_summary::subject_versions_changed,
+                2))))));
+
+    // The .prod subject was purged; only keep-value remains.
+    EXPECT_THAT(
+      _registry.get_all(),
+      testing::ElementsAre(
+        testing::Field(
+          &ppsr::stored_schema::schema,
+          testing::Property(&ppsr::subject_schema::sub, keep))));
+
+    // .prod is tombstoned: only the default context is still materialized.
+    EXPECT_THAT(
+      _registry.list_contexts().get(),
+      testing::ElementsAre(ppsr::default_context));
+}
+
 // Fixture whose destination wraps `_registry` so a test can make permanent
 // deletes fail, exercising the hard-delete retry loop the plain fake cannot.
 class mirroring_task_delete_retry_test : public mirroring_task_test {
@@ -1346,6 +1393,42 @@ TEST_F(
     EXPECT_EQ(status->last_full_sync->subject_versions_changed, 1);
     EXPECT_EQ(status->last_full_sync->errors, 1);
     EXPECT_EQ(_deferring.permanent_delete_attempts(stuck), 1);
+}
+
+TEST_F(mirroring_task_delete_retry_test, defers_delete_of_non_empty_context) {
+    // The .prod context is source-absent, but its only subject's purge is
+    // permanently blocked, so the context never empties. delete_context is
+    // skipped (context_not_empty) rather than counted as an extra error or
+    // faulted, leaving the context listed for a later full sync to retry.
+    auto prod_orders = ppsr::context_subject{
+      ppsr::context{".prod"}, ppsr::subject{"orders-value"}};
+    _registry.import_schema(make_schema(prod_orders, 1, R"({"v":1})")).get();
+    _deferring.reject_forever(prod_orders);
+
+    lead_schema_registry();
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    auto status = wait_for_sync_status([](const auto& s) {
+                      return s.last_full_sync.has_value()
+                             && !s.current_sync.has_value();
+                  }).get();
+    // The single error is the stuck purge; the skipped context delete adds
+    // none.
+    ASSERT_THAT(
+      status,
+      testing::Optional(
+        testing::Field(
+          &model::schema_registry_sync_status::last_full_sync,
+          testing::Optional(
+            testing::Field(&model::schema_registry_sync_summary::errors, 1)))));
+
+    // .prod is not deleted: it stays listed alongside the default context, so a
+    // later full sync retries it. A still-listed non-empty context also implies
+    // its blocked subject survived.
+    EXPECT_THAT(
+      _registry.list_contexts().get(),
+      testing::UnorderedElementsAre(
+        ppsr::default_context, ppsr::context{".prod"}));
 }
 
 } // namespace cluster_link::tests

--- a/src/v/cluster_link/schema_registry_sync/tests/sr_sync_test_fixtures.h
+++ b/src/v/cluster_link/schema_registry_sync/tests/sr_sync_test_fixtures.h
@@ -467,6 +467,9 @@ public:
     get_subjects(ppsr::include_deleted inc) const override {
         return _inner->get_subjects(inc);
     }
+    ss::future<chunked_vector<ppsr::context>> list_contexts() const override {
+        return _inner->list_contexts();
+    }
     ss::future<ppsr::context_schema_id>
     create_schema(ppsr::subject_schema s) override {
         return _inner->create_schema(std::move(s));
@@ -493,6 +496,9 @@ public:
     }
     ss::future<bool> delete_config(ppsr::context_subject sub) override {
         return _inner->delete_config(std::move(sub));
+    }
+    ss::future<> delete_context(ppsr::context ctx) override {
+        return _inner->delete_context(std::move(ctx));
     }
 
 protected:

--- a/src/v/datalake/tests/record_schema_resolver_test.cc
+++ b/src/v/datalake/tests/record_schema_resolver_test.cc
@@ -631,6 +631,11 @@ public:
         return _registry.get_subjects(inc_del);
     }
 
+    ss::future<chunked_vector<pandaproxy::schema_registry::context>>
+    list_contexts() const override {
+        return _registry.list_contexts();
+    }
+
     ss::future<pandaproxy::schema_registry::context_schema_id> create_schema(
       pandaproxy::schema_registry::subject_schema unparsed) override {
         return _registry.create_schema(std::move(unparsed));
@@ -675,6 +680,11 @@ public:
     ss::future<bool>
     delete_config(pandaproxy::schema_registry::context_subject sub) override {
         return _registry.delete_config(std::move(sub));
+    }
+
+    ss::future<>
+    delete_context(pandaproxy::schema_registry::context ctx) override {
+        return _registry.delete_context(std::move(ctx));
     }
 
     const std::vector<pandaproxy::schema_registry::stored_schema>& get_all() {

--- a/src/v/pandaproxy/schema_registry/errors.h
+++ b/src/v/pandaproxy/schema_registry/errors.h
@@ -261,6 +261,12 @@ inline error_info context_not_empty(const context& ctx) {
       fmt::format("The specified context '{}' is not empty.", ctx())};
 }
 
+inline error_info cannot_delete_default_context() {
+    return error_info{
+      error_code::subject_version_operation_not_permitted,
+      "Cannot delete the default context"};
+}
+
 inline error_info context_invalid(std::string_view ctx) {
     return error_info{
       error_code::context_invalid,

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -1528,13 +1528,6 @@ delete_context(server::request_t rq, server::reply_t rp) {
 
     auto ctx = context{parse_normalized_context(*rq.req)};
 
-    if (ctx == default_context) {
-        throw as_exception(
-          error_info{
-            error_code::subject_version_operation_not_permitted,
-            "Cannot delete the default context"});
-    }
-
     co_await rq.service().writer().delete_context(ctx);
 
     rp.rep->set_status(ss::http::reply::status_type::no_content);

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -672,13 +672,14 @@ seq_writer::do_delete_context(context ctx, model::offset write_at) {
     }
 }
 
-ss::future<> seq_writer::delete_context(context ctx) {
+ss::future<> seq_writer::delete_context(context ctx, write_source src) {
     auto ctx_copy = ctx;
     co_await sequenced_write(
       [ctx{std::move(ctx)}](model::offset write_at, seq_writer& seq) {
           return seq.do_delete_context(ctx, write_at);
       },
-      std::move(ctx_copy));
+      std::move(ctx_copy),
+      src);
 }
 
 /// Impermanent delete: update a version with is_deleted=true

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -673,6 +673,11 @@ seq_writer::do_delete_context(context ctx, model::offset write_at) {
 }
 
 ss::future<> seq_writer::delete_context(context ctx, write_source src) {
+    // Enforced here, on the path every caller shares (REST handler and the
+    // internal shadow-link sync alike), rather than only at the HTTP edge.
+    if (ctx == default_context) {
+        throw as_exception(cannot_delete_default_context());
+    }
     auto ctx_copy = ctx;
     co_await sequenced_write(
       [ctx{std::move(ctx)}](model::offset write_at, seq_writer& seq) {

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -100,7 +100,8 @@ public:
     ss::future<bool> delete_mode(
       context_subject ctx_sub, write_source src = write_source::client);
 
-    ss::future<> delete_context(context ctx);
+    ss::future<>
+    delete_context(context ctx, write_source src = write_source::client);
 
     ss::future<bool> delete_subject_version(
       context_subject sub,

--- a/src/v/schema/registry.cc
+++ b/src/v/schema/registry.cc
@@ -99,6 +99,10 @@ public:
         auto [reader, _] = co_await service();
         co_return co_await reader->get_subjects(inc_del, std::nullopt);
     }
+    ss::future<chunked_vector<ppsr::context>> list_contexts() const override {
+        auto [reader, _] = co_await service();
+        co_return co_await reader->get_materialized_contexts();
+    }
 
     ss::future<ppsr::context_schema_id>
     create_schema(ppsr::subject_schema schema) override {
@@ -185,6 +189,13 @@ public:
         co_return result;
     }
 
+    ss::future<> delete_context(ppsr::context ctx) override {
+        auto [_, writer] = co_await service();
+        co_await writer->delete_context(
+          std::move(ctx), ppsr::write_source::schema_registry_sync);
+        _last_sync_time = ss::lowres_clock::now();
+    }
+
 private:
     ss::future<std::pair<ppsr::sharded_store*, ppsr::seq_writer*>>
     service() const {
@@ -244,6 +255,10 @@ public:
         throw std::logic_error(
           "invalid attempted usage of a disabled schema registry");
     }
+    ss::future<chunked_vector<ppsr::context>> list_contexts() const override {
+        throw std::logic_error(
+          "invalid attempted usage of a disabled schema registry");
+    }
     ss::future<ppsr::context_schema_id>
     create_schema(ppsr::subject_schema) override {
         throw std::logic_error(
@@ -278,6 +293,10 @@ public:
           "invalid attempted usage of a disabled schema registry");
     }
     ss::future<bool> delete_config(ppsr::context_subject) override {
+        throw std::logic_error(
+          "invalid attempted usage of a disabled schema registry");
+    }
+    ss::future<> delete_context(ppsr::context) override {
         throw std::logic_error(
           "invalid attempted usage of a disabled schema registry");
     }

--- a/src/v/schema/registry.h
+++ b/src/v/schema/registry.h
@@ -103,6 +103,12 @@ public:
       chunked_vector<pandaproxy::schema_registry::context_subject>>
       get_subjects(pandaproxy::schema_registry::include_deleted) const = 0;
 
+    /// Lists every materialized context (always includes the default context).
+    /// Mirrors the source's context enumeration so shadow-link sync can detect
+    /// a context that has been deleted at the source.
+    virtual ss::future<chunked_vector<pandaproxy::schema_registry::context>>
+    list_contexts() const = 0;
+
     virtual ss::future<pandaproxy::schema_registry::context_schema_id>
       create_schema(pandaproxy::schema_registry::subject_schema) = 0;
 
@@ -148,6 +154,14 @@ public:
 
     virtual ss::future<bool>
       delete_config(pandaproxy::schema_registry::context_subject) = 0;
+
+    /// Deletes (tombstones) a materialized context, removing only the context
+    /// marker and leaving any context-level mode/config overrides untouched, as
+    /// Confluent's DELETE /contexts does. Throws if the context is not
+    /// materialized or still has subjects (counting soft-deleted ones).
+    /// Redpanda additionally forbids deleting the default context.
+    virtual ss::future<>
+      delete_context(pandaproxy::schema_registry::context) = 0;
 
     ///@}
 };

--- a/src/v/schema/tests/fake_registry.cc
+++ b/src/v/schema/tests/fake_registry.cc
@@ -139,9 +139,23 @@ schema::fake_registry::get_subjects(ppsr::include_deleted inc_del) const {
       | std::ranges::to<chunked_vector<ppsr::context_subject>>();
 }
 
+ss::future<chunked_vector<ppsr::context>>
+schema::fake_registry::list_contexts() const {
+    maybe_throw_injected_failure();
+    // `_contexts` holds only non-default contexts (default is always present
+    // and never gets a CONTEXT record), so seed with the default and copy the
+    // rest.
+    auto out = chunked_vector{ppsr::default_context};
+    std::ranges::copy(_contexts, std::back_inserter(out));
+    co_return out;
+}
+
 ss::future<ppsr::context_schema_id>
 schema::fake_registry::create_schema(ppsr::subject_schema unparsed) {
     maybe_throw_injected_failure();
+    if (unparsed.sub().ctx != ppsr::default_context) {
+        _contexts.insert(unparsed.sub().ctx);
+    }
     // This is wrong, but simple for our testing.
     for (const auto& s : _store.schemas) {
         if (
@@ -172,6 +186,9 @@ schema::fake_registry::create_schema(ppsr::subject_schema unparsed) {
 ss::future<ppsr::context_schema_id>
 schema::fake_registry::import_schema(ppsr::stored_schema imported) {
     maybe_throw_injected_failure();
+    if (imported.schema.sub().ctx != ppsr::default_context) {
+        _contexts.insert(imported.schema.sub().ctx);
+    }
 
     for (const auto& s : _store.schemas) {
         if (
@@ -280,6 +297,29 @@ ss::future<bool>
 schema::fake_registry::delete_config(ppsr::context_subject sub) {
     maybe_throw_injected_failure();
     co_return _configs.erase(sub) > 0;
+}
+
+ss::future<> schema::fake_registry::delete_context(ppsr::context ctx) {
+    maybe_throw_injected_failure();
+    if (ctx == ppsr::default_context) {
+        throw as_exception(ppsr::cannot_delete_default_context());
+    }
+    // Mirror the real store: an unmaterialized context is not found.
+    if (!_contexts.contains(ctx)) {
+        throw as_exception(
+          ppsr::error_info{
+            ppsr::error_code::subject_not_found,
+            fmt::format("Context '{}' not found", ctx())});
+    }
+    // Mirror the real store: a context can only be tombstoned once empty,
+    // counting soft-deleted subjects (include_deleted::yes).
+    const bool not_empty = std::ranges::any_of(
+      _store.schemas, [&](const auto& s) { return s.schema.sub().ctx == ctx; });
+    if (not_empty) {
+        throw as_exception(ppsr::context_not_empty(ctx));
+    }
+    _contexts.erase(ctx);
+    co_return;
 }
 
 const std::vector<ppsr::stored_schema>& schema::fake_registry::get_all() {

--- a/src/v/schema/tests/fake_registry.h
+++ b/src/v/schema/tests/fake_registry.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 
+#include "container/chunked_hash_map.h"
 #include "pandaproxy/schema_registry/schema_getter.h"
 #include "schema/registry.h"
 
@@ -81,6 +82,9 @@ public:
     get_subjects(
       pandaproxy::schema_registry::include_deleted inc_del) const override;
 
+    ss::future<chunked_vector<pandaproxy::schema_registry::context>>
+    list_contexts() const override;
+
     ss::future<pandaproxy::schema_registry::context_schema_id> create_schema(
       pandaproxy::schema_registry::subject_schema unparsed) override;
 
@@ -111,6 +115,9 @@ public:
     ss::future<bool>
     delete_config(pandaproxy::schema_registry::context_subject sub) override;
 
+    ss::future<>
+    delete_context(pandaproxy::schema_registry::context ctx) override;
+
     const std::vector<pandaproxy::schema_registry::stored_schema>& get_all();
 
     /// Test accessors for the mode/config overrides written to the registry, so
@@ -137,6 +144,10 @@ private:
 
     std::exception_ptr _injected_failure;
     mutable fake_store _store;
+    // Non-default contexts materialized by an import/create, mirroring the real
+    // store's lazy CONTEXT record: a context stays listed after its subjects
+    // are purged until delete_context tombstones it.
+    chunked_hash_set<pandaproxy::schema_registry::context> _contexts;
     std::map<
       pandaproxy::schema_registry::context_subject,
       pandaproxy::schema_registry::mode>

--- a/tests/docker/ducktape-deps/confluent-schema-registry
+++ b/tests/docker/ducktape-deps/confluent-schema-registry
@@ -4,14 +4,14 @@ set -e
 source "$(dirname "${BASH_SOURCE[0]}")/download-utils" # import download-utils
 
 # Confluent Platform Community Edition includes Schema Registry, used as a
-# cross-vendor source in the shadow-link SR migration ducktape tests. Pin to a
-# version compatible with the Apache Kafka version used by the multi-cluster
-# shadow-link tests (kafka 3.7/3.8 -> CP 7.7.x).
-CP_VERSION=7.7.1
+# cross-vendor source in the shadow-link SR migration ducktape tests. Schema
+# Registry is a plain Kafka client and stays backward-compatible with the
+# Apache Kafka version used by the multi-cluster shadow-link tests (kafka 3.8).
+CP_VERSION=8.0.1
 CP_FILE=confluent-community-${CP_VERSION}.tar.gz
 
 # Confluent's archive is the canonical source for the tarball.
-CP_URL=https://packages.confluent.io/archive/7.7/${CP_FILE}
+CP_URL=https://packages.confluent.io/archive/8.0/${CP_FILE}
 
 mkdir -p /opt/confluent
 chmod a+rw /opt/confluent

--- a/tests/rptest/tests/cluster_linking_schema_registry_sync_test.py
+++ b/tests/rptest/tests/cluster_linking_schema_registry_sync_test.py
@@ -708,6 +708,56 @@ class SchemaRegistrySyncMixin:
         # The in-source subject is untouched by the purge.
         assert self._schema_view(dest, keep, 1) is not None
 
+    def _test_schema_registry_api_sync_context_delete(self):
+        # A whole source context is deleted (Confluent-style: empty it, then
+        # DELETE /contexts). The destination must converge: the context's
+        # subjects purged and the context itself tombstoned so it no longer
+        # lists, while a default-context subject is left untouched.
+        src = self._make_source_client()
+        dest = SchemaRegistryRedpandaClient(self.target_cluster_service)
+
+        prod_orders = ":.prod:orders-value"
+        keep = "keep-value"  # default context
+
+        self._register(
+            src, prod_orders, self._record("Orders", [{"name": "v", "type": "string"}])
+        )
+        self._register(
+            src, keep, self._record("Keep", [{"name": "v", "type": "string"}])
+        )
+
+        self._create_sr_link()
+
+        # Both subjects replicate and the .prod context materializes on the
+        # destination.
+        self._wait_synced(src, dest, [(prod_orders, 1), (keep, 1)])
+        wait_until(
+            lambda: ".prod" in set(dest.get_contexts().json()),
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="the .prod context did not materialize on the destination",
+        )
+
+        # Delete the whole .prod context at the source: hard-delete its only
+        # subject to empty it (soft then permanent, as the source requires), then
+        # DELETE /contexts/.prod.
+        assert src.delete_subject(prod_orders).status_code == 200
+        assert src.delete_subject(prod_orders, permanent=True).status_code == 200
+        assert src.delete_context(".prod").status_code in (200, 204)
+
+        # The next full sync purges the .prod subject and tombstones the context,
+        # so the destination's context listing drops back to the default context.
+        wait_until(
+            lambda: ".prod" not in set(dest.get_contexts().json()),
+            timeout_sec=90,
+            backoff_sec=1,
+            err_msg="source context deletion did not propagate to the destination",
+        )
+
+        # The default-context subject is untouched; the .prod subject is gone.
+        assert self._schema_view(dest, keep, 1) is not None
+        assert self._schema_view(dest, prod_orders, 1) is None
+
     def _test_schema_registry_api_sync_context_remap(self):
         src = self._make_source_client()
         dest = SchemaRegistryRedpandaClient(self.target_cluster_service)
@@ -1311,6 +1361,10 @@ class SchemaRegistrySyncE2ETest(ShadowLinkTestBase, SchemaRegistrySyncMixin):
         self._test_schema_registry_api_sync_context_remap()
 
     @cluster(num_nodes=6)
+    def test_schema_registry_api_sync_context_delete(self):
+        self._test_schema_registry_api_sync_context_delete()
+
+    @cluster(num_nodes=6)
     def test_schema_registry_api_sync_out_of_scope_reference(self):
         self._test_schema_registry_api_sync_out_of_scope_reference()
 
@@ -1430,6 +1484,10 @@ class ConfluentSchemaRegistrySyncE2ETest(ShadowLinkTestBase, SchemaRegistrySyncM
     @cluster(num_nodes=5)
     def test_schema_registry_api_sync_context_remap(self):
         self._test_schema_registry_api_sync_context_remap()
+
+    @cluster(num_nodes=5)
+    def test_schema_registry_api_sync_context_delete(self):
+        self._test_schema_registry_api_sync_context_delete()
 
     @cluster(num_nodes=5)
     def test_schema_registry_api_sync_unsupported_schema_remove(self):


### PR DESCRIPTION
Extends shadow-link Schema Registry sync to propagate context deletions: a
full sync now tombstones destination contexts whose source context no longer
exists (after purging their subjects), matching Confluent's DELETE /contexts
behavior.

Also folds in two supporting changes: the default-context delete guard moves
into seq_writer so the internal sync path enforces it (not just the REST
handler), and the ducktape Confluent image bumps to 8.0.1 (first release with
DELETE /contexts) so the cross-vendor e2e can drive it.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
