### PR TITLE
cloud_topics/stm: fix stale epoch admission after failed epoch bump replicate

### DIFF
--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
@@ -79,7 +79,35 @@ bool ctp_stm_state::epoch_in_window(
       _max_applied_epoch.value_or(cluster_epoch::min()));
     auto begin = _previous_seen_epoch.value_or(
       _previous_applied_epoch.value_or(end));
-    return epoch >= begin && epoch <= end;
+    if (epoch < begin || epoch > end) {
+        return false;
+    }
+    if (epoch == end) {
+        return true;
+    }
+    // A below-max epoch is only admissible if some epoch batch is known to
+    // precede the max-seen epoch's first batch in the log. The seen window
+    // alone can't prove this: a fence-time bump whose batch never lands (a
+    // failed replicate) leaves a lower bound with no counterpart in the log.
+    // If nothing precedes the max epoch's first batch, the log epoch window
+    // collapses to [max, max] when that batch applies, and a below-max batch
+    // landing after it violates the log invariant enforced by
+    // epoch_window_checker and may reference L0 objects the GC already
+    // considers inactive.
+    //
+    // Applied state gives positional evidence, since apply follows log order:
+    // - _max_applied_epoch < end: an applied batch sits at a lower log
+    //   position than any batch at the max-seen epoch (applied or not).
+    // - _max_applied_epoch == end: the max epoch applied; a batch preceded it
+    //   iff the applied window did not collapse to [end, end].
+    if (!_max_applied_epoch.has_value()) {
+        return false;
+    }
+    if (*_max_applied_epoch < end) {
+        return true;
+    }
+    return *_max_applied_epoch == end
+           && _previous_applied_epoch.value_or(end) < end;
 }
 
 bool ctp_stm_state::epoch_above_window(

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
@@ -295,6 +295,52 @@ TEST(ctp_stm_state_test, sliding_window_issue) {
     EXPECT_EQ(estimate_inactive_epoch(), 9_epoch);
 }
 
+TEST(ctp_stm_state_test, below_max_fence_requires_applied_evidence) {
+    // A fenced epoch bump whose batch never lands leaves a phantom lower
+    // bound in the seen window. Admitting a below-max epoch is only sound if
+    // some epoch batch is known to precede the max-seen epoch's first batch
+    // in the log; otherwise the log's epoch window collapses to [max, max]
+    // when the max applies and the below-max batch violates it.
+    ct::ctp_stm_state state;
+    model::term_id term(1);
+
+    // Two fence-time bumps, no batch lands for either.
+    state.advance_max_seen_epoch(term, 132_epoch);
+    state.advance_max_seen_epoch(term, 141_epoch);
+
+    // At-max admission is always sound.
+    EXPECT_TRUE(state.epoch_in_window(term, 141_epoch));
+    // Below-max admission has no applied evidence: reject.
+    EXPECT_FALSE(state.epoch_in_window(term, 132_epoch));
+
+    // The max epoch lands as the first batch in the log: the log window is
+    // [141, 141], so 132 must still be rejected.
+    state.advance_epoch(141_epoch, model::offset{0});
+    EXPECT_FALSE(state.epoch_in_window(term, 132_epoch));
+    EXPECT_TRUE(state.epoch_in_window(term, 141_epoch));
+}
+
+TEST(ctp_stm_state_test, below_max_fence_allowed_with_applied_evidence) {
+    // The legitimate in-flight case: the previous epoch's batch landed and
+    // applied before the bump, so a straggler at that epoch stays admissible
+    // both before and after the max epoch's batch applies.
+    ct::ctp_stm_state state;
+    model::term_id term(1);
+
+    state.advance_max_seen_epoch(term, 132_epoch);
+    state.advance_epoch(132_epoch, model::offset{0});
+
+    state.advance_max_seen_epoch(term, 141_epoch);
+    // An applied 132 batch precedes any (future) 141 batch in the log.
+    EXPECT_TRUE(state.epoch_in_window(term, 132_epoch));
+
+    state.advance_epoch(141_epoch, model::offset{1});
+    // The log window is [132, 141]: 132 remains admissible.
+    EXPECT_TRUE(state.epoch_in_window(term, 132_epoch));
+    EXPECT_TRUE(state.epoch_in_window(term, 141_epoch));
+    EXPECT_FALSE(state.epoch_in_window(term, 131_epoch));
+}
+
 TEST(ctp_stm_state_test, l0_simulation) {
     struct uploaded_l0_file_batch {
         ct::cluster_epoch epoch;
@@ -410,10 +456,20 @@ TEST(ctp_stm_state_test, l0_simulation) {
             possible_operations.emplace_back([&universe, &oplog, term] {
                 auto batch = universe.uploaded_batches.front();
                 universe.uploaded_batches.pop_front();
-                if (!universe.stm.epoch_in_window(term, batch.epoch)) {
+                // Mirror the fence_epoch branches: bump the window for an
+                // above-window epoch, replicate an in-window epoch, reject
+                // everything else. A below-max epoch is rejected while no
+                // applied batch proves that something precedes the max
+                // epoch's first batch in the log (the producer would retry
+                // with a fresh epoch).
+                if (universe.stm.epoch_above_window(term, batch.epoch)) {
                     universe.stm.advance_max_seen_epoch(term, batch.epoch);
                     ASSERT_TRUE(
                       universe.stm.epoch_in_window(term, batch.epoch));
+                } else if (!universe.stm.epoch_in_window(term, batch.epoch)) {
+                    oplog.push_back(
+                      fmt::format("rejected batch with epoch {}", batch.epoch));
+                    return;
                 }
                 placeholder_batch placeholder{
                   .epoch = batch.epoch, .offset = universe.hwm++};

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -1121,6 +1121,59 @@ TEST_F_CORO(
     }
 }
 
+TEST_F_CORO(ctp_stm_fixture, test_below_max_fence_rejected_without_batches) {
+    // Companion to test_failed_epoch_bump_replicate_poisons_seen_window
+    // covering the concurrent variant: the max-seen epoch's batch is not in
+    // the log yet (here it is never replicated at all - the same state the
+    // fence observes while that batch is still mid-replication). With no
+    // epoch batch applied there is no evidence that anything precedes the
+    // max epoch's first batch, so a below-max fence must be rejected.
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+
+    auto& leader = node(*get_leader());
+    auto leader_api = api(leader);
+
+    // Two fence-time bumps, neither replicates a batch.
+    {
+        auto fence = co_await leader_api.fence_epoch(ct::cluster_epoch{132});
+        ASSERT_TRUE_CORO(fence.has_value());
+    }
+    {
+        auto fence = co_await leader_api.fence_epoch(ct::cluster_epoch{141});
+        ASSERT_TRUE_CORO(fence.has_value());
+    }
+
+    auto stale_fence = co_await leader_api.fence_epoch(ct::cluster_epoch{132});
+    ASSERT_FALSE_CORO(stale_fence.has_value())
+      << "below-max epoch admitted while no epoch batch has been applied";
+}
+
+TEST_F_CORO(ctp_stm_fixture, test_below_max_fence_allowed_after_epoch_landed) {
+    // The window's intended semantics survive the fix: when the previous
+    // epoch's batch actually landed before the bump, a straggler at that
+    // epoch is admitted and its batch is legal in the log (the checker
+    // window is [132, 141]).
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+
+    auto& leader = node(*get_leader());
+    auto leader_api = api(leader);
+
+    bool ok = co_await replicate_with_epoch(
+      leader, ct::cluster_epoch{132}, model::offset{0}, 0);
+    ASSERT_TRUE_CORO(ok);
+    ok = co_await replicate_with_epoch(
+      leader, ct::cluster_epoch{141}, model::offset{1}, 1);
+    ASSERT_TRUE_CORO(ok);
+
+    // The straggler at the previous epoch is fenced and replicated without
+    // tripping the epoch_window_checker.
+    ok = co_await replicate_with_epoch(
+      leader, ct::cluster_epoch{132}, model::offset{2}, 2);
+    ASSERT_TRUE_CORO(ok);
+}
+
 // Test for the combined advance_epoch + sync_to_next_placeholder functionality.
 // This is the primary use case: enabling GC progress on idle partitions by
 // recording the current epoch and advancing LRLO past the advance_epoch batch.

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -1060,6 +1060,67 @@ TEST_F_CORO(
       << "change, allowing an epoch that is below the applied window [7, 8].";
 }
 
+TEST_F_CORO(
+  ctp_stm_fixture, test_failed_epoch_bump_replicate_poisons_seen_window) {
+    // Bug reproduction (Antithesis ct_stress crash): a fence-time epoch bump
+    // whose batch never lands in the log leaves a phantom lower bound in the
+    // seen window, admitting a stale epoch that the log-content invariant
+    // forbids.
+    //
+    // Scenario, all within one term on one leader:
+    // 1. A writer fences epoch 132 (first fence in the term, seen window
+    //    becomes [132, 132]) but its replicate fails - nothing lands in the
+    //    log and the fence guard is dropped.
+    // 2. A writer fences epoch 141 (seen window [132, 141]) and replicates.
+    //    The log's first epoch-bearing batch carries 141, so the
+    //    epoch_window_checker window collapses to [141, 141] and the applied
+    //    state treats epochs <= 140 as inactive (their L0 objects become
+    //    eligible for GC).
+    // 3. A writer fences epoch 132 again. This must be rejected: admitting it
+    //    lands an epoch-132 placeholder after the 141 batch, and every
+    //    replica that applies the batch dies in
+    //    epoch_window_checker::check_epoch with "epoch 132 at N is outside of
+    //    sliding window [141, 141]".
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+
+    auto& leader = node(*get_leader());
+    auto leader_api = api(leader);
+
+    // Step 1: fence epoch 132 and drop the guard without replicating,
+    // simulating a fenced write whose replicate failed (e.g. leadership
+    // churn between the fence and the raft append).
+    {
+        auto fence = co_await leader_api.fence_epoch(ct::cluster_epoch{132});
+        ASSERT_TRUE_CORO(fence.has_value());
+        // Guard dropped here; the seen window keeps [132, 132].
+    }
+
+    // Step 2: fence epoch 141 and replicate a placeholder under the fence.
+    // This is the first epoch-bearing batch in the log.
+    bool ok = co_await replicate_with_epoch(
+      leader, ct::cluster_epoch{141}, model::offset{0}, 0);
+    ASSERT_TRUE_CORO(ok);
+
+    // Step 3: epoch 132 is now below the log window and must be rejected.
+    auto stale_fence = co_await leader_api.fence_epoch(ct::cluster_epoch{132});
+    EXPECT_FALSE(stale_fence.has_value())
+      << "fence_epoch admitted epoch 132 although the log's first epoch "
+         "entry is 141: the seen-window lower bound came from a bump whose "
+         "batch never landed in the log";
+
+    if (stale_fence.has_value()) {
+        // Under the bug, replicating with the granted fence reproduces the
+        // crash: apply trips the epoch_window_checker vassert on every
+        // replica.
+        auto guard = std::move(stale_fence.value());
+        auto batch = make_record_batch(
+          ct::cluster_epoch{132}, model::offset{1}, 1);
+        auto res = co_await replicate_record_batch(leader, std::move(batch));
+        ASSERT_TRUE_CORO(res.has_value());
+    }
+}
+
 // Test for the combined advance_epoch + sync_to_next_placeholder functionality.
 // This is the primary use case: enabling GC progress on idle partitions by
 // recording the current epoch and advancing LRLO past the advance_epoch batch.


### PR DESCRIPTION
The Antithesis ct_stress workload crashed two replicas with:

```
Assert failure: (src/v/cloud_topics/level_zero/stm/ctp_stm.cc:634)
'_min_epoch <= epoch && epoch <= _max_epoch'
[{kafka/ctc/1}] epoch 132 at 83 is outside of sliding window [141, 141]
```

The ctp_stm fence maintains an in-memory "seen" epoch window whose lower
bound is set at fence time, before the epoch bump's batch is replicated.
When that replicate fails (leadership churn, timeouts), the lower bound has
no counterpart in the log. If the next epoch's batch is then the first
epoch-bearing batch to land, the log's epoch window collapses to
`[max, max]`, while the fence still admits writes at the phantom lower
bound. Such a write lands above the max epoch's batch and:

* violates the log invariant enforced by `epoch_window_checker`, crashing
  every replica that applies the batch (the log itself is poisoned, so the
  crash is deterministic on replay), and
* may reference L0 objects that the GC already considers inactive, i.e. a
  potential data-loss hazard independent of the assert.

The fix makes `epoch_in_window` admit a below-max epoch only when applied
state proves that some epoch batch precedes the max-seen epoch's first
batch in the log (apply follows log order, so applied state is positional
evidence). At-max fences and the epoch bump path are unchanged; the
legitimate one-epoch-behind, in-flight writer case keeps working. In the
narrow race where the previous epoch's batch is committed but not yet
applied, the fence rejects transiently and the producer's existing retry
path handles it - the deliberate safe direction.

The first commit is a reproducer written before the fix; it replays the
scenario on a single leader within a single term and died with the exact
assert above. The second commit is the fix plus regression tests covering
both guard branches at the state level and end-to-end.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Bug Fixes

* Fixed a cloud-topics epoch fencing race where an epoch bump whose
  replication failed could later admit a stale-epoch write, poisoning the
  partition log and crashing all replicas of the partition.
