### PR TITLE
[CORE-16860] kafka/client: resume consumer group fetch from committed offset

### DIFF
--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -34,6 +34,8 @@
 #include <seastar/core/when_all.hh>
 #include <seastar/coroutine/exception.hh>
 
+#include <absl/container/flat_hash_map.h>
+
 #include <algorithm>
 #include <chrono>
 #include <exception>
@@ -545,6 +547,83 @@ consumer::dispatch_fetch(broker_reqs_t::value_type br) {
     co_return res;
 }
 
+ss::future<> consumer::seed_positions_from_committed() {
+    // Collect the assigned partitions that have no fetch position yet --
+    // freshly (re)assigned ones. A partition that already carries an in-RAM
+    // position (e.g. a same-instance rebalance) is left untouched: that
+    // position is at least as recent as the committed offset, so re-seeding
+    // would re-read.
+    chunked_vector<offset_fetch_request_topic> req;
+    absl::flat_hash_map<model::topic_partition, shared_broker_t>
+      broker_by_partition;
+    // Each topic is a unique key in _assignment, so one request entry per
+    // iteration collects all of that topic's initializing partitions.
+    for (const auto& [t, ps] : _assignment) {
+        offset_fetch_request_topic topic_req{.name = t};
+        for (const auto& p : ps) {
+            model::topic_partition tp{t, p};
+            auto leader = _topic_cache.leader(tp);
+            if (!leader) {
+                throw partition_error(
+                  tp, error_code::unknown_topic_or_partition);
+            }
+            auto broker = _brokers.find(*leader);
+            if (_fetch_sessions[broker].has_offset(tp)) {
+                continue;
+            }
+            broker_by_partition.emplace(tp, std::move(broker));
+            topic_req.partition_indexes.push_back(p);
+        }
+        if (!topic_req.partition_indexes.empty()) {
+            req.push_back(std::move(topic_req));
+        }
+    }
+    if (broker_by_partition.empty()) {
+        // Every assigned partition already has a position
+        co_return;
+    }
+
+    auto res = co_await offset_fetch(std::move(req));
+    for (const auto& t : res.data.topics) {
+        for (const auto& part : t.partitions) {
+            model::topic_partition tp{t.name, part.partition_index};
+            // A per-partition error must not be swallowed: skipping it would
+            // leave the partition uninitialized, so the fetch below would start
+            // it at earliest and silently re-read the whole log instead of
+            // resuming. Throw so the retry mitigates (update_metadata for a
+            // transient unknown_topic_or_partition, surfaces the rest).
+            if (part.error_code != error_code::none) {
+                throw partition_error(tp, part.error_code);
+            }
+            auto it = broker_by_partition.find(tp);
+            if (it == broker_by_partition.end()) {
+                continue;
+            }
+            // A committed offset of -1 means the group has none: seed earliest
+            // (log start, the only reset policy pandaproxy allows). Seeding a
+            // concrete value also marks the partition initialized, so committed
+            // is not re-fetched on every poll. Otherwise the fetch position is
+            // committed+1: our commit stores the last consumed offset
+            // (commit-all stores position-1; an explicit REST commit stores the
+            // client's value, so posting X resumes at X+1). If committed+1 is
+            // below the log start after retention, the fetch returns
+            // offset_out_of_range and the reseed to log_start recovers it.
+            const auto pos = part.committed_offset < model::offset{0}
+                               ? model::offset{0}
+                               : part.committed_offset + model::offset{1};
+            vlog(
+              _logger->debug,
+              "Consumer: {}: seeding {} from committed offset {} -> position "
+              "{}",
+              *this,
+              tp,
+              part.committed_offset,
+              pos);
+            _fetch_sessions[it->second].reseed(tp, pos);
+        }
+    }
+}
+
 consumer::broker_reqs_t consumer::build_fetch_requests(
   std::chrono::milliseconds timeout, std::optional<int32_t> max_bytes) {
     broker_reqs_t broker_reqs;
@@ -653,6 +732,12 @@ ss::future<std::pair<fetch_response, bool>> consumer::fetch_round(
 ss::future<fetch_response> consumer::fetch(
   std::chrono::milliseconds timeout, std::optional<int32_t> max_bytes) {
     refresh_inactivity_timer();
+
+    // Before fetching, seed any freshly (re)assigned partition from the group's
+    // committed offset so a fresh consumer instance resumes where the group
+    // left off, mirroring the Java consumer's updateFetchPositions at the start
+    // of poll(). Cheap when nothing is initializing (no OffsetFetch is issued).
+    co_await seed_positions_from_committed();
 
     // An out-of-range partition is reseeded to the log start and stripped from
     // the response (the pandaproxy serializer rejects any partition error), so

--- a/src/v/kafka/client/consumer.h
+++ b/src/v/kafka/client/consumer.h
@@ -107,6 +107,18 @@ private:
 
     ss::future<fetch_response> dispatch_fetch(broker_reqs_t::value_type br);
 
+    /// \brief Seed the fetch position of every assigned partition that has no
+    /// position yet from the group's committed offset, mirroring the Java
+    /// consumer's updateFetchPositions -> refreshCommittedOffsetsIfNeeded.
+    ///
+    /// Runs at the start of each fetch() but issues an OffsetFetch only when a
+    /// partition is still initializing (freshly (re)assigned). Partitions that
+    /// already carry an in-RAM position -- e.g. a same-instance rebalance --
+    /// keep it. A partition with no committed offset is seeded to earliest,
+    /// which also marks it initialized so committed is not re-fetched on every
+    /// poll.
+    ss::future<> seed_positions_from_committed();
+
     /// \brief Build one fetch_request per broker leading a partition in the
     /// current assignment, seeded with each broker's fetch_session id/epoch
     /// and each partition's tracked fetch offset.

--- a/src/v/kafka/client/fetch_session.cc
+++ b/src/v/kafka/client/fetch_session.cc
@@ -26,6 +26,14 @@ model::offset fetch_session::offset(model::topic_partition_view tpv) const {
     return part_it->second;
 }
 
+bool fetch_session::has_offset(model::topic_partition_view tpv) const {
+    auto topic_it = _offsets.find(tpv.topic);
+    if (topic_it == _offsets.end()) {
+        return false;
+    }
+    return topic_it->second.contains(tpv.partition);
+}
+
 void fetch_session::reseed(
   model::topic_partition_view tpv, model::offset new_offset) {
     _offsets[model::topic{tpv.topic}][tpv.partition] = new_offset;

--- a/src/v/kafka/client/fetch_session.h
+++ b/src/v/kafka/client/fetch_session.h
@@ -40,6 +40,14 @@ public:
     kafka::fetch_session_epoch epoch() const { return _epoch; }
     model::offset offset(model::topic_partition_view tpv) const;
 
+    /// \brief Whether a fetch position is tracked for a partition.
+    ///
+    /// Distinguishes a genuinely-tracked offset of 0 from an absent one, which
+    /// offset() cannot (it returns 0 for both). Used to decide which assigned
+    /// partitions are still initializing and need seeding from the committed
+    /// offset.
+    bool has_offset(model::topic_partition_view tpv) const;
+
     /// \brief Directly set the tracked fetch offset for a partition, e.g. to
     /// recover from offset_out_of_range by seeking to the log_start_offset
     /// the broker reported (pandaproxy only allows

--- a/src/v/kafka/client/test/fetch_session.cc
+++ b/src/v/kafka/client/test/fetch_session.cc
@@ -206,6 +206,32 @@ SEASTAR_THREAD_TEST_CASE(test_fetch_session_reseed) {
     BOOST_REQUIRE_EQUAL(s.offset(ctx.tp), model::offset{48});
 }
 
+// CORE-16860: has_offset() distinguishes a genuinely-tracked offset of 0 from
+// an absent one (offset() returns 0 for both), so consumer::fetch() can tell
+// which assigned partitions are still initializing and must be seeded from the
+// committed offset.
+SEASTAR_THREAD_TEST_CASE(test_fetch_session_has_offset) {
+    context ctx;
+    kc::fetch_session s;
+
+    const model::topic_partition other_tp{ctx.tp.topic, model::partition_id{3}};
+
+    // Nothing tracked yet.
+    BOOST_REQUIRE(!s.has_offset(ctx.tp));
+    BOOST_REQUIRE(!s.has_offset(other_tp));
+
+    // A reseed to 0 is a tracked position, not an absence.
+    s.reseed(ctx.tp, model::offset{0});
+    BOOST_REQUIRE(s.has_offset(ctx.tp));
+    BOOST_REQUIRE_EQUAL(s.offset(ctx.tp), model::offset{0});
+    // A sibling partition is still absent.
+    BOOST_REQUIRE(!s.has_offset(other_tp));
+
+    // Delivered records also make a partition tracked.
+    ctx.apply_fetch_response(s, 8);
+    BOOST_REQUIRE(s.has_offset(ctx.tp));
+}
+
 // CORE-16844: apply()/discard() do not reseed offset_out_of_range
 // partitions themselves -- that's the caller's job via reseed(), done once
 // while scanning every broker's response to decide whether to retry (see

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -2563,6 +2563,186 @@ class PandaProxyConsumerGroupTest(PandaProxyEndpoints):
             f"got {recovered[0]['offset']}"
         )
 
+    @cluster(num_nodes=3)
+    def test_consumer_group_resumes_from_committed_offset(self):
+        """
+        CORE-16860: a fresh consumer instance in a group that has a committed
+        offset must resume from it, not restart at earliest. A committed offset
+        is the last consumed offset, so the resumed position is committed+1
+        (posting X resumes at X+1). A group with no committed offset still
+        starts at earliest. This behaves very similarly to the Confluent REST
+        API.
+        """
+        num_records = 20
+        commit_offset = 9
+
+        # One produce call per record so each lands on its own offset, making
+        # the resume position unambiguous (see the OOR tests for why).
+        self.logger.info(f"Producing {num_records} records to topic: {self.topic}")
+        for i in range(num_records):
+            produce_result_raw = self._produce_topic(
+                self.topic,
+                json.dumps({"records": [{"value": {"i": i}, "partition": 0}]}),
+                headers=HTTP_PRODUCE_JSON_V2_TOPIC_HEADERS,
+            )
+            assert produce_result_raw.status_code == requests.codes.ok
+
+        group_id = f"pandaproxy-group-{uuid.uuid4()}"
+        self.logger.info(
+            f"Instance A joins group {group_id} and commits offset {commit_offset}"
+        )
+        cc_res = self._create_consumer(group_id)
+        assert cc_res.status_code == requests.codes.ok
+        a = Consumer(cc_res.json(), self.logger)
+        assert a.subscribe([self.topic]).status_code == requests.codes.no_content
+
+        sco_req = dict(
+            partitions=[dict(topic=self.topic, partition=0, offset=commit_offset)]
+        )
+        assert (
+            a.set_offsets(data=json.dumps(sco_req)).status_code
+            == requests.codes.no_content
+        )
+        # Remove A: its in-RAM position is gone, only the committed offset in
+        # the group survives.
+        assert a.remove().status_code == requests.codes.no_content
+
+        self.logger.info(
+            "Fresh instance B in the same group must resume from "
+            f"the committed offset ({commit_offset}+1)"
+        )
+        cc_res = self._create_consumer(group_id)
+        assert cc_res.status_code == requests.codes.ok
+        b = Consumer(cc_res.json(), self.logger)
+        assert b.subscribe([self.topic]).status_code == requests.codes.no_content
+
+        resumed: list = []
+
+        def resumed_records():
+            cf_res = b.fetch(headers=HTTP_CONSUMER_FETCH_JSON_V2_HEADERS)
+            assert cf_res.status_code == requests.codes.ok, (
+                f"Expected 200, got {cf_res.status_code}: {cf_res.text}"
+            )
+            resumed.extend(cf_res.json())
+            return len(resumed) > 0
+
+        wait_until(
+            resumed_records,
+            timeout_sec=30,
+            backoff_sec=0,
+            err_msg="fresh instance never resumed from the committed offset",
+        )
+        assert resumed[0]["offset"] == commit_offset + 1, (
+            f"expected resume from committed+1 ({commit_offset + 1}), "
+            f"got {resumed[0]['offset']}"
+        )
+
+        self.logger.info(
+            "Control: a new group with no committed offset must start at earliest (0)"
+        )
+        control_group = f"pandaproxy-group-{uuid.uuid4()}"
+        cc_res = self._create_consumer(control_group)
+        assert cc_res.status_code == requests.codes.ok
+        c = Consumer(cc_res.json(), self.logger)
+        assert c.subscribe([self.topic]).status_code == requests.codes.no_content
+
+        fresh: list = []
+
+        def fresh_records():
+            cf_res = c.fetch(headers=HTTP_CONSUMER_FETCH_JSON_V2_HEADERS)
+            assert cf_res.status_code == requests.codes.ok, (
+                f"Expected 200, got {cf_res.status_code}: {cf_res.text}"
+            )
+            fresh.extend(cf_res.json())
+            return len(fresh) > 0
+
+        wait_until(
+            fresh_records,
+            timeout_sec=30,
+            backoff_sec=0,
+            err_msg="fresh group never fetched from earliest",
+        )
+        assert fresh[0]["offset"] == 0, (
+            f"expected a group with no committed offset to start at 0, "
+            f"got {fresh[0]['offset']}"
+        )
+
+    @cluster(num_nodes=3)
+    def test_consumer_group_resume_recovers_below_trimmed_log_start(self):
+        """
+        CORE-16860 + CORE-16844: a consumer commits an offset, then retention
+        trims the log start past it. A fresh instance in the same group resumes
+        from the committed offset, its fetch hits offset_out_of_range, and it
+        recovers to the new log start -- rather than staying stuck or silently
+        re-reading from 0.
+        """
+        num_records = 20
+        commit_offset = 5
+        trim_offset = 10
+
+        self.logger.info(f"Producing {num_records} records to topic: {self.topic}")
+        for i in range(num_records):
+            r = self._produce_topic(
+                self.topic,
+                json.dumps({"records": [{"value": {"i": i}, "partition": 0}]}),
+                headers=HTTP_PRODUCE_JSON_V2_TOPIC_HEADERS,
+            )
+            assert r.status_code == requests.codes.ok
+
+        group_id = f"pandaproxy-group-{uuid.uuid4()}"
+        self.logger.info(f"Instance A commits offset {commit_offset} in {group_id}")
+        cc_res = self._create_consumer(group_id)
+        assert cc_res.status_code == requests.codes.ok
+        a = Consumer(cc_res.json(), self.logger)
+        assert a.subscribe([self.topic]).status_code == requests.codes.no_content
+        sco_req = dict(
+            partitions=[dict(topic=self.topic, partition=0, offset=commit_offset)]
+        )
+        assert (
+            a.set_offsets(data=json.dumps(sco_req)).status_code
+            == requests.codes.no_content
+        )
+        assert a.remove().status_code == requests.codes.no_content
+
+        self.logger.info(
+            f"Trimming {self.topic}/0 prefix to {trim_offset} (past committed "
+            f"{commit_offset})"
+        )
+        rpk = RpkTool(self.redpanda)
+        trim_result = rpk.trim_prefix(self.topic, offset=trim_offset, partitions=[0])
+        assert len(trim_result) == 1
+        assert trim_result[0].new_start_offset == trim_offset, trim_result[0]
+
+        self.logger.info(
+            "Fresh instance B resumes from committed+1 (below the new log start), "
+            f"hits offset_out_of_range, and recovers to the log start ({trim_offset})"
+        )
+        cc_res = self._create_consumer(group_id)
+        assert cc_res.status_code == requests.codes.ok
+        b = Consumer(cc_res.json(), self.logger)
+        assert b.subscribe([self.topic]).status_code == requests.codes.no_content
+
+        recovered: list = []
+
+        def recovered_records():
+            cf_res = b.fetch(headers=HTTP_CONSUMER_FETCH_JSON_V2_HEADERS)
+            assert cf_res.status_code == requests.codes.ok, (
+                f"Expected 200, got {cf_res.status_code}: {cf_res.text}"
+            )
+            recovered.extend(cf_res.json())
+            return len(recovered) > 0
+
+        wait_until(
+            recovered_records,
+            timeout_sec=30,
+            backoff_sec=0,
+            err_msg="consumer never recovered after its committed offset was trimmed",
+        )
+        assert recovered[0]["offset"] == trim_offset, (
+            f"expected recovery to the new log start ({trim_offset}), "
+            f"got {recovered[0]['offset']}"
+        )
+
 
 class PandaProxyCompressedBatchesTest(PandaProxyEndpoints):
     topics = [


### PR DESCRIPTION
Follow-up to the `offset_out_of_range` fix (#31064, now merged into `dev`): a
fresh HTTP Proxy consumer instance now resumes from the group's committed offset
instead of always restarting at the earliest available offset.

### What this adds
- **`kafka/client: resume consumer group fetch from committed offset`** — at the
  start of `fetch()`, seed every freshly (re)assigned partition's fetch position
  from the group's committed offset (`committed+1`; our commit stores the last
  consumed offset). Only initializing partitions are seeded; no OffsetFetch is
  issued once positioned. A per-partition OffsetFetch error surfaces (throws)
  instead of a silent restart at earliest.
- **`tests/pandaproxy: cover resume-from-committed end-to-end`** — two ducktape
  cases: (1) instance A commits, is removed, a fresh instance B resumes from
  committed+1 (with a control group that has no committed offset starting at
  earliest); (2) a consumer commits, retention trims the log start past the
  committed offset, and a fresh instance resumes from committed, hits
  `offset_out_of_range`, and recovers to the new log start.

This behaves very similarly to the Confluent REST API: committing offset X
resumes the group at X+1.

### Performance
`seed_positions_from_committed()` runs at the start of every `fetch()`, but its
cost in the fetch path is negligible: once every assigned partition has a
position it issues no OffsetFetch and only does an in-memory scan of the
assignment, so in steady state it adds no I/O — the OffsetFetch RPC fires only on
the first poll after a (re)assignment while a partition is still initializing.
Relative to the fetch round-trip and record-batch serialization that dominate a
poll, the per-poll seed check is in the noise.

### Why we don't resolve the log start upfront (keeping it simple)
When a partition has no committed offset we seed it to `0` and let the existing
`offset_out_of_range` recovery jump to the real log start, rather than issuing a
`ListOffsets(EARLIEST)` to resolve it beforehand. This is deliberate — the fetch
response already carries `log_start_offset` on `offset_out_of_range`, so the
recovery reseeds to the true start with **no extra RPC** (a dedicated
`ListOffsets` also targets partition leaders, not the coordinator, so it would
add a whole new dispatch path). The recovery has to exist regardless: the log can
be trimmed between any `ListOffsets` and the following fetch, so
`offset_out_of_range` is always reachable — `ListOffsets` could only sometimes
save one round-trip, never remove the recovery. And that round-trip is a one-time
cost on the first poll after a fresh assignment on a trimmed log, not the hot
path. Full upfront earliest resolution can be a follow-up optimization if it ever
proves worthwhile; it is intentionally left out here to keep this change small
and safe.

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes

### Improvements
* HTTP Proxy: a consumer group now resumes from its committed offset on a fresh
  consumer instance instead of re-reading from the earliest available offset.
