### PR TITLE
`ct`: bump log level for `invalid_update`

### DIFF
--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -72,7 +72,7 @@ rpc::errc log_and_convert(const db_update_error& e, std::string_view prefix) {
         break;
     case invalid_update:
         ret = rpc::errc::concurrent_requests;
-        lvl = ss::log_level::debug;
+        lvl = ss::log_level::warn;
         break;
     }
     vlogl(cd_log, lvl, "{}{}", prefix, e);


### PR DESCRIPTION
These can sometimes be non-transient and would help to debug/unblock repeated failures to commit certain updates.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
