### PR TITLE
`config`: bump `min_cleanable_dirty_ratio` to 0.5

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1070,9 +1070,9 @@ configuration::configuration()
       "The topic property `min.cleanable.dirty.ratio` overrides the value of "
       "`min_cleanable_dirty_ratio` at the topic level.",
       {.needs_restart = needs_restart::no,
-       .example = "0.2",
+       .example = "0.5",
        .visibility = visibility::user},
-      0.2,
+      0.5,
       {.min = 0.0, .max = 1.0})
   , min_compaction_lag_ms(
       *this,

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -278,7 +278,7 @@ class DescribeTopicsTest(RedpandaTest):
             ),
             "min.cleanable.dirty.ratio": ConfigProperty(
                 config_type="DOUBLE",
-                value="0.2",
+                value="0.5",
                 doc_string='The minimum ratio between the number of bytes in "dirty" segments and '
                 "the total number of bytes in closed segments that must be reached "
                 "before a partition's log is eligible for compaction in a compact topic. "


### PR DESCRIPTION
The original default value of 0.2 was chosen to be more conservative w/r/t changing the behavior of compaction scheduling in `redpanda`. However, we have seen that in practice, adopting a higher default is preferable in many cases, and now with cloud topics compaction adoption, a solid default is even more important.

Bump the default to 0.5.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
