### PR TITLE
[v26.1.x] `ct`: bump log level for `invalid_update`

### DIFF
--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -74,7 +74,7 @@ rpc::errc log_and_convert(const db_update_error& e, std::string_view prefix) {
         break;
     case invalid_update:
         ret = rpc::errc::concurrent_requests;
-        lvl = ss::log_level::debug;
+        lvl = ss::log_level::warn;
         break;
     }
     vlogl(cd_log, lvl, "{}{}", prefix, e);


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31113
