### PR TITLE
rpk: fix describe-storage size output for tiered_cloud_topic

### DIFF
--- a/src/go/rpk/pkg/cli/topic/describe_storage.go
+++ b/src/go/rpk/pkg/cli/topic/describe_storage.go
@@ -169,21 +169,36 @@ func newDescribeStorageCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 
 			sections.Add(secSize, func() {
 				mode := report[0].CloudStatus.CloudStorageMode
-				isCloudTopic := mode == "cloud_topic" || mode == "cloud_topic_read_replica"
+				isCloudTopic := mode == "cloud_topic" || mode == "cloud_topic_read_replica" || mode == "tiered_cloud_topic"
 				if isCloudTopic {
-					tw := out.NewTable("PARTITION", "LOCAL-BYTES", "L0-BYTES", "L1-BYTES", "TOTAL-BYTES", "L1-EXTENTS")
+					// Only a tiered_cloud_topic has a local log worth
+					// reporting segments for; cloud_topic and read replicas
+					// do not.
+					isTiered := mode == "tiered_cloud_topic"
+					headers := []string{"PARTITION", "LOCAL-BYTES"}
+					if isTiered {
+						headers = append(headers, "LOCAL-SEGMENTS")
+					}
+					headers = append(headers, "L0-BYTES", "L1-BYTES", "TOTAL-BYTES", "L1-EXTENTS")
+					tw := out.NewTable(headers...)
 					defer tw.Flush()
 					for _, r := range report {
 						l1 := r.CloudStatus.CloudLogBytes
 						l0 := r.CloudStatus.TotalLogBytes - l1
-						tw.Print(
+						row := []any{
 							r.Partition,
 							humanReadable(r.CloudStatus.LocalLogBytes, human, humanSize),
+						}
+						if isTiered {
+							row = append(row, r.CloudStatus.LocalLogSegmentCount)
+						}
+						row = append(row,
 							humanReadable(l0, human, humanSize),
 							humanReadable(l1, human, humanSize),
 							humanReadable(r.CloudStatus.TotalLogBytes, human, humanSize),
 							r.CloudStatus.CloudLogSegmentCount,
 						)
+						tw.Print(row...)
 					}
 				} else {
 					tw := out.NewTable("PARTITION", "CLOUD-BYTES", "LOCAL-BYTES", "TOTAL-BYTES", "CLOUD-SEGMENTS", "LOCAL-SEGMENTS")
@@ -293,8 +308,9 @@ partition (excluding cloud and local overlap), and the number of segments in
 the cloud and on local disk. The cloud segment count does not include segments
 queued for deletion.
 
-For cloud topics, the size section shows the L0 (level zero) and L1 (level
-one) byte breakdown, the total bytes, and the number of L1 extents.
+For cloud topics, the size section shows the local log size, the L0 (level
+zero) and L1 (level one) byte breakdown, the total bytes, and the number of L1
+extents. For tiered_cloud_topic, the local segment count is also shown.
 
 SYNC
 

--- a/src/v/kafka/data/cloud_topic_partition.cc
+++ b/src/v/kafka/data/cloud_topic_partition.cc
@@ -26,6 +26,7 @@
 #include "model/timeout_clock.h"
 #include "raft/errc.h"
 #include "raft/replicate.h"
+#include "storage/log.h"
 #include "storage/types.h"
 
 #include <seastar/core/future.hh>
@@ -321,10 +322,14 @@ cloud_topic_partition::get_cloud_storage_status() const {
     auto l0_size = _fe->get_l0_size_estimate();
     auto l1_size = (co_await _fe->l1_size())
                      .value_or(cloud_topics::l1::metastore::size_response{});
-    status.mode = _partition->get_ntp_config().is_tiered_cloud()
-                    ? cluster::cloud_storage_mode::tiered_cloud_topic
-                    : cluster::cloud_storage_mode::cloud_topic;
+    const auto is_tiered = _partition->get_ntp_config().is_tiered_cloud();
+    status.mode = is_tiered ? cluster::cloud_storage_mode::tiered_cloud_topic
+                            : cluster::cloud_storage_mode::cloud_topic;
     status.local_log_size_bytes = local_size;
+    // Only a tiered_cloud_topic keeps a local log worth reporting segments for.
+    if (is_tiered) {
+        status.local_log_segment_count = _partition->log()->segment_count();
+    }
     // Report the L1 size via "cloud" size bytes and the sum of L0 and L1 sizes
     // via "total" log size bytes. Users can derive the L0 size through total -
     // cloud.

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -944,6 +944,20 @@ class RpkTool:
                 pass
         return res
 
+    def describe_storage(self, topic: str, timeout: int | None = None) -> str:
+        """Run `rpk topic describe-storage <topic>` and return the raw output.
+
+        The command talks to both the Kafka API (topic metadata) and the admin
+        API (cloud storage status), so the admin endpoints are passed too.
+        """
+        cmd = [
+            "describe-storage",
+            topic,
+            "--api-urls",
+            self._redpanda.admin_endpoints(),
+        ]
+        return self._run_topic(cmd, timeout=timeout)
+
     def alter_topic_config(self, topic: str, set_key: str, set_value: Any) -> None:
         cmd = ["alter-config", topic, "--set", f"{set_key}={set_value}", "--no-confirm"]
         out = self._run_topic(cmd)

--- a/tests/rptest/tests/cloud_topics/describe_storage_test.py
+++ b/tests/rptest/tests/cloud_topics/describe_storage_test.py
@@ -1,0 +1,132 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+"""
+Coverage for `rpk topic describe-storage` on cloud-topic partitions.
+
+The command renders the cloud storage status: for a cloud topic the size
+section must use the L0/L1 layout, not the CLOUD-BYTES/CLOUD-SEGMENTS columns
+used for segment-based tiered storage. A local segment count is shown only for
+a tiered_cloud_topic, which keeps a real local log.
+"""
+
+from ducktape.mark import matrix
+from ducktape.tests.test import TestContext
+from ducktape.utils.util import wait_until
+
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
+from rptest.tests.cloud_topics.e2e_test import EndToEndCloudTopicsBase
+
+
+def _sections(output: str) -> dict[str, list[str]]:
+    """Split describe-storage output into {SECTION_NAME: [content lines]}.
+
+    Each section is a header word, then a line of '=', then content lines up to
+    the next blank line.
+    """
+    sections: dict[str, list[str]] = {}
+    lines = output.splitlines()
+    current: str | None = None
+    i = 0
+    while i < len(lines):
+        stripped = lines[i].strip()
+        if stripped and i + 1 < len(lines) and set(lines[i + 1].strip()) == {"="}:
+            current = stripped
+            sections[current] = []
+            i += 2
+            continue
+        if current is not None and stripped:
+            sections[current].append(lines[i])
+        i += 1
+    return sections
+
+
+def _size_row(output: str) -> tuple[list[str], dict[str, str]]:
+    """Return (column headers, partition-0 row as {column: value}) for SIZE."""
+    lines = _sections(output).get("SIZE", [])
+    assert len(lines) >= 2, f"no SIZE table in describe-storage output:\n{output}"
+    header = lines[0].split()
+    row = lines[1].split()
+    return header, dict(zip(header, row))
+
+
+class CloudTopicDescribeStorageTest(EndToEndCloudTopicsBase):
+    topics = (
+        TopicSpec(
+            name=EndToEndCloudTopicsBase.s3_topic_name,
+            partition_count=1,
+            replication_factor=3,
+        ),
+    )
+
+    def __init__(self, test_context: TestContext):
+        super().__init__(test_context=test_context)
+        self.msg_size = 16 * 1024
+        # ~32 MiB: enough to land committed data in L1 after reconciliation.
+        self.msg_count = 2000
+
+    @cluster(num_nodes=4)
+    @matrix(
+        storage_mode=[
+            TopicSpec.STORAGE_MODE_CLOUD,
+            TopicSpec.STORAGE_MODE_IMPL_TIERED_V2,
+        ],
+    )
+    def test_describe_storage_by_mode(self, storage_mode: str):
+        # The topic is created in `storage_mode` by the base setUp.
+        assert self.redpanda is not None
+        topic = self.s3_topic_name
+        is_tiered = storage_mode == TopicSpec.STORAGE_MODE_IMPL_TIERED_V2
+        expected_mode = "tiered_cloud_topic" if is_tiered else "cloud_topic"
+
+        KgoVerifierProducer.oneshot(
+            self.test_context,
+            self.redpanda,
+            topic,
+            msg_size=self.msg_size,
+            msg_count=self.msg_count,
+            timeout_sec=180,
+        )
+        self.wait_until_reconciled(topic=topic, partition=0, timeout_sec=120)
+
+        # Poll the CLI until it reports L1 bytes, which can lag reconciliation.
+        def l1_reported() -> bool:
+            output = self.rpk.describe_storage(topic)
+            self.logger.info(f"describe-storage ({storage_mode}):\n{output}")
+            header, row = _size_row(output)
+            return "L1-BYTES" in header and int(row["L1-BYTES"]) > 0
+
+        wait_until(
+            l1_reported,
+            timeout_sec=60,
+            backoff_sec=3,
+            retry_on_exc=True,
+            err_msg=f"describe-storage never reported L1 bytes for {expected_mode}",
+        )
+
+        output = self.rpk.describe_storage(topic)
+        header, row = _size_row(output)
+
+        # SIZE uses the cloud-topic L0/L1 columns, not the CLOUD-BYTES/
+        # CLOUD-SEGMENTS columns used for segment-based tiered storage.
+        for col in ("LOCAL-BYTES", "L0-BYTES", "L1-BYTES", "TOTAL-BYTES", "L1-EXTENTS"):
+            assert col in header, f"missing {col} in {header}:\n{output}"
+        for col in ("CLOUD-BYTES", "CLOUD-SEGMENTS"):
+            assert col not in header, (
+                f"cloud-topic size table unexpectedly has {col} in {header}:\n{output}"
+            )
+
+        # A local segment count is shown only for tiered_cloud_topic.
+        if is_tiered:
+            assert "LOCAL-SEGMENTS" in header, output
+            assert int(row["LOCAL-SEGMENTS"]) > 0, output
+        else:
+            assert "LOCAL-SEGMENTS" not in header, output


### PR DESCRIPTION
NOTE: this doesn't address that cloud_topics as a whole doesn't print correct offsets in describe-storage

describe-storage prints a SIZE section per topic, but it only recognized cloud_topic and cloud_topic_read_replica as cloud-topic modes. A tiered_cloud_topic therefore rendered with the layout used for segment-based tiered storage: L1 bytes were mislabeled as CLOUD-BYTES, the L0 breakdown was hidden, and LOCAL-SEGMENTS was printed as zero.

Treat tiered_cloud_topic as a cloud topic so the SIZE section reports the L0/L1/extents breakdown. Unlike a plain cloud topic or a read replica, a tiered_cloud_topic also keeps a real local log, so report its local segment count in the cloud storage status and add a LOCAL-SEGMENTS column for it; the other cloud-topic modes have no local log worth reporting, so the count and column are omitted for them.

Add a ducktape test that drives `rpk topic describe-storage` for both a cloud_topic and a tiered_cloud_topic and asserts the SIZE section uses the L0/L1 columns rather than the segment-based tiered-storage layout, and that a LOCAL-SEGMENTS column appears only for the tiered_cloud_topic.

Before, a tiered_cloud_topic:

```
  SIZE
  ====
  PARTITION  CLOUD-BYTES  LOCAL-BYTES  TOTAL-BYTES  CLOUD-SEGMENTS  LOCAL-SEGMENTS
  0          878554407    878511539    878554407    11              0
```

After:

```
  SIZE
  ====
  PARTITION  LOCAL-BYTES  LOCAL-SEGMENTS  L0-BYTES  L1-BYTES   TOTAL-BYTES  L1-EXTENTS
  0          878511539    7               0         878554407  878554407    11
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
