### PR TITLE
ct/l1: record fully-scanned empty ranges as cleaned

### DIFF
--- a/src/v/cloud_topics/level_one/maintenance/compaction/compaction_source.cc
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/compaction_source.cc
@@ -226,20 +226,30 @@ ss::future<ss::stop_iteration> compaction_source::map_building_iteration() {
         map_is_full = res.map_is_full;
         auto max_indexed_offset = res.max_indexed_offset;
 
-        if (max_indexed_offset.has_value()) {
-            bool range_has_tombstones = res.range_has_tombstones;
-            auto base_offset = start_offset;
-            auto last_offset = map_is_full ? model::offset_cast(
-                                               max_indexed_offset.value())
-                                           : max_offset;
+        if (!map_is_full) {
+            // The scan completed without the map filling up, implying it
+            // read through the whole range. Regardless of whether we actually
+            // indexed anything (we may not have, e.g. if the log was prefix
+            // truncated, or if there's a gap caused by aborted transactions),
+            // we should treat this range as clean upon completion.
+            _new_cleaned_ranges.push_back(
+              {.base_offset = start_offset,
+               .last_offset = max_offset,
+               .has_tombstones = res.range_has_tombstones});
+        } else if (max_indexed_offset.has_value()) {
+            // The map filled mid-range: only the prefix up to the last
+            // indexed record is covered.
+            auto last_offset = model::offset_cast(max_indexed_offset.value());
             dassert(
-              base_offset <= last_offset,
+              start_offset <= last_offset,
               "Cleaned range must be properly bounded.");
             _new_cleaned_ranges.push_back(
-              {.base_offset = base_offset,
+              {.base_offset = start_offset,
                .last_offset = last_offset,
-               .has_tombstones = range_has_tombstones});
+               .has_tombstones = res.range_has_tombstones});
         }
+        // Otherwise the map filled before indexing anything in this range
+        // (it was already at capacity on entry); nothing to clean.
 
         if (map_is_full) {
             co_return ss::stop_iteration::yes;

--- a/src/v/cloud_topics/level_one/maintenance/compaction/tests/reducer_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/tests/reducer_test.cc
@@ -415,6 +415,113 @@ TEST_F(ReducerTestFixture, LinearKeyValueReducerSetStartOffset) {
     ASSERT_TRUE(compaction_info->offsets_response.dirty_ranges.empty());
 }
 
+// Retention can move the start offset under a running compaction job, and
+// the job still commits: it removes records, but its cleaned ranges are all
+// rejected against the start offset it snapshotted before the truncation,
+// so nothing is marked clean. Verify the emptied range is left dirty with
+// the epoch advanced, and that a fresh pass then converges the log.
+TEST_F(ReducerTestFixture, RetentionRaceEmptiesRangeWithoutCleaning) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+
+    // Three extents, two keys, newest copies at the head:
+    //   [0,1]: a b
+    //   [2,3]: a b
+    //   [4,5]: a b
+    auto add_extent = [&](kafka::offset base, const ss::sstring& sfx) {
+        std::vector<tests::kv_t> kvs;
+        kvs.emplace_back("a", "a" + sfx);
+        kvs.emplace_back("b", "b" + sfx);
+        chunked_circular_buffer<model::record_batch> batches;
+        batches.push_back(
+          tests::batch_from_kvs(
+            kvs,
+            model::offset{base()},
+            model::timestamp::now(),
+            model::compression::none));
+        std::vector<tidp_batches_t> tidp_batches;
+        tidp_batches.emplace_back(tidp, std::move(batches));
+        return make_l1_objects(std::move(tidp_batches));
+    };
+    add_extent(kafka::offset{0}, "0").get();
+    add_extent(kafka::offset{2}, "2").get();
+    add_extent(kafka::offset{4}, "4").get();
+
+    auto info_spec = l1::metastore::compaction_info_spec{
+      .tidp = tidp,
+      .tombstone_removal_upper_bound_ts = model::timestamp::max()};
+
+    // The job snapshots its inputs: start offset 0, the whole log dirty.
+    auto before_truncate = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(before_truncate.has_value());
+    ASSERT_EQ(before_truncate->start_offset, kafka::offset{0});
+    ASSERT_TRUE(before_truncate->offsets_response.dirty_ranges.covers(
+      kafka::offset{0}, kafka::offset{5}));
+    const auto initial_epoch = before_truncate->compaction_epoch;
+
+    // Retention fires mid-job: truncate to 2, deleting extent [0,1].
+    auto sso_res = _metastore.set_start_offset(tidp, kafka::offset{2}).get();
+    ASSERT_TRUE(sso_res.has_value());
+
+    // The job finishes with its pre-truncation snapshot. Dedup rewrites
+    // [2,3] empty -- both records are superseded by the copies at [4,5] --
+    // and the max compactible offset stops it before it reaches [4,5]
+    // itself.
+    do_compact(
+      tidp,
+      ntp,
+      std::move(before_truncate->offsets_response),
+      before_truncate->compaction_epoch,
+      /*pre-truncation start_offset=*/kafka::offset{0},
+      &_metastore,
+      &_io,
+      0ms,
+      /*max_compactible_offset=*/kafka::offset{3})
+      .get();
+
+    // The job's commit went through: the epoch advanced and [2,3]'s records
+    // are gone. Nothing was recorded clean, since the compaction did't read
+    // [0,1] and believed the start offset to be 0.
+    auto after_compact = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(after_compact.has_value());
+    EXPECT_EQ(
+      after_compact->compaction_epoch,
+      l1::metastore::compaction_epoch{initial_epoch() + 1});
+    EXPECT_EQ(after_compact->start_offset, kafka::offset{2});
+    ASSERT_FLOAT_EQ(after_compact->dirty_ratio, 1.0);
+    ASSERT_TRUE(after_compact->offsets_response.dirty_ranges.covers(
+      kafka::offset{2}, kafka::offset{5}));
+    {
+        auto batches = read_all(make_reader(ntp, tidp, kafka::offset{2}));
+        ASSERT_EQ(batches.size(), 1);
+        EXPECT_EQ(batches.front().base_offset(), model::offset{4});
+        EXPECT_EQ(batches.front().record_count(), 2);
+    }
+
+    // A fresh pass converges: [2,3] is deemed clean since it is empty, [4,5]
+    // gets cleaned.
+    auto fresh = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(fresh.has_value());
+    do_compact(
+      tidp,
+      ntp,
+      std::move(fresh->offsets_response),
+      fresh->compaction_epoch,
+      fresh->start_offset,
+      &_metastore,
+      &_io)
+      .get();
+
+    auto final_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(final_info.has_value());
+    EXPECT_FLOAT_EQ(final_info->dirty_ratio, 0.0);
+    EXPECT_TRUE(final_info->offsets_response.dirty_ranges.empty());
+
+    latest_kv_map_t latest_kv;
+    latest_kv.insert_or_assign("a", "a4");
+    latest_kv.insert_or_assign("b", "b4");
+    verify_compacted_log(ntp, tidp, latest_kv, /*records=*/2, /*batches=*/1);
+}
+
 TEST_F(ReducerTestFixture, TombstoneReducer) {
     ss::abort_source as;
     auto [ntp, tidp] = make_ntidp("test_topic");


### PR DESCRIPTION
I noticed a totally idle test cluster spinning cycles on compaction with no end in sight. From the debug logs it kept building a 0-key compaction map and finalizing with no new cleaned ranges:

```
Built compaction map with 0 keys (max allowed 3186737)
Finalized job with compaction metadata update: {new_cleaned_ranges:[], ...}
```

Compaction only records a cleaned range where it indexed at least one key. A dirty range with no records is therefore never marked clean, and the scheduler re-dispatches a no-op compaction every interval.

Such a range comes out of a race between retention and compaction. Three extents, two keys, newest copies at the head. Nothing has been compacted yet, so cleaned is empty and all of [0,5] is dirty:

```
  [0,1]: a b    to be truncated
  [2,3]: a b    becomes a gap
  [4,5]: a b    latest copies
```

1. A compaction job starts. It snapshots start_offset=0 and the dirty [0,5], and can compact up to offset 3 (translation pins the rest).
2. Retention truncates the log to offset 2, deleting [0,1]. This does not bump the compaction epoch, so the running job cannot notice. Dirty is now [2,5].
3. The job's dedup pass rewrites [2,3] as an empty extent: both records are superseded by the head.
4. At commit, cleaned ranges must be covered contiguously from the job's remembered start offset, 0. Nothing covers 0 anymore, so the job registers no cleaned ranges. The commit still passes the epoch check: the empty [2,3] goes in, cleaned stays empty, and all of [2,5] is still dirty.
5. [2,3] is now empty and dirty.
6. A later pass scans the dirty [2,5]. It indexes keys in [4,5] and marks that clean, but [2,3] has nothing left to index, so nothing is recorded for it. The log settles at cleaned=[4,5], dirty=[2,3], and stays there forever: every pass scans [2,3], finds nothing, and moves on with it still dirty.

Aborted transactions leave the same kind of empty range, since the reconciler strips them at ingest.

An empty, fully-scanned range has nothing to compact and is inherently clean, so record it as such. That converges the log no matter how the range formed.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Bug Fixes

* Fixes a bug in cloud topics compaction that could cause repeated no-op compactions if the topic uses retention or transactions.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
