### PR TITLE
cluster_link/sr: abort destination schema registry writes on task stop

### DIFF
--- a/src/v/cluster_link/link.cc
+++ b/src/v/cluster_link/link.cc
@@ -136,6 +136,14 @@ ss::future<> link::start() {
 }
 
 ss::future<> link::stop() noexcept {
+    // Idempotent AND join-safe: the removal handler and manager shutdown both
+    // stop links and can race during teardown. A late caller waits for the
+    // first stop to complete rather than returning early -- the removal
+    // handler destroys the link right after its stop() resolves, so an early
+    // return would free the link out from under the still-running first stop.
+    if (std::exchange(_stop_requested, true)) {
+        co_return co_await _stopped.get_shared_future();
+    }
     vlog(
       cllog.info,
       "Stopping cluster link {} ({})",
@@ -187,6 +195,9 @@ ss::future<> link::stop() noexcept {
     _probe.reset(nullptr);
 
     vlog(cllog.info, "Stopped link {} ({})", _config->name, _config->uuid);
+    // Release any callers joined on a concurrent stop; they may free the link
+    // as soon as this resolves.
+    _stopped.set_value();
 }
 
 ss::future<cl_result<void>> link::register_task(task_factory* tf) {

--- a/src/v/cluster_link/link.h
+++ b/src/v/cluster_link/link.h
@@ -22,6 +22,8 @@
 #include "ssx/mutex.h"
 #include "utils/notification_list.h"
 
+#include <seastar/core/shared_future.hh>
+
 namespace cluster_link {
 
 class link_probe;
@@ -153,5 +155,12 @@ private:
     std::unique_ptr<link_probe> _probe;
     ss::gate _gate;
     ss::abort_source _as;
+    // stop() is called by both the link-removal handler and manager shutdown,
+    // which can race. The first call does the work; later calls must wait for
+    // it to COMPLETE (not return early): the removal handler frees the link
+    // right after stop() resolves, so an early return would let it destroy
+    // the link while the first stop is still suspended inside it.
+    bool _stop_requested{false};
+    ss::shared_promise<> _stopped;
 };
 } // namespace cluster_link

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -150,15 +150,45 @@ ss::future<> manager::stop() {
     vlog(cllog.info, "Stopping cluster link manager");
 
     co_await on_controller_stepdown();
+    vlog(cllog.debug, "manager stop: controller stepdown complete");
 
-    co_await _queue.shutdown();
     _link_task_reconciler_timer.cancel();
     _as.request_abort();
     _link_created_cv.broken();
-    co_await _g.close();
-    for (auto& [_, link] : _links) {
+
+    // Stop the links (which aborts their tasks) BEFORE draining the work
+    // queue and the gate: a queued link-change handler or an in-flight
+    // reconcile tick can be blocked on task machinery that only unblocks once
+    // the tasks' run fibers are aborted. Draining first sequences that abort
+    // behind the very drain that waits on it, deadlocking shutdown until the
+    // node-stop timeout kills the process.
+    //
+    // The queue is still live here and its one executing item may mutate
+    // _links, so stop by id snapshot and re-lookup; a link created after the
+    // snapshot is caught by the sweep below.
+    chunked_vector<id_t> ids;
+    ids.reserve(_links.size());
+    for (const auto& [id, _] : _links) {
+        ids.push_back(id);
+    }
+    for (const auto& id : ids) {
+        if (auto it = _links.find(id); it != _links.end()) {
+            co_await it->second->stop();
+        }
+    }
+    vlog(cllog.debug, "manager stop: links stopped");
+
+    co_await _queue.shutdown();
+    vlog(cllog.debug, "manager stop: work queue drained");
+
+    // The queue is drained and the reconcile timer canceled, so _links is
+    // stable now; sweep up any link a mid-flight handler created after the
+    // snapshot (stop() is idempotent, so re-stopping the rest is a no-op).
+    for (const auto& [_, link] : _links) {
         co_await link->stop();
     }
+
+    co_await _g.close();
 
     vlog(cllog.info, "Cluster link manager stopped");
 }
@@ -880,6 +910,11 @@ ss::future<> manager::link_task_reconciler() {
     auto units = std::move(fut).get();
 
     for (const auto& [_, link] : _links) {
+        // Shutdown aborts before stopping links; registering a task on a
+        // link that is about to stop would leak a never-stopped runner.
+        if (_as.abort_requested()) {
+            co_return;
+        }
         vlog(
           cllog.trace,
           "Reconciling tasks for cluster link {} ({})",

--- a/src/v/cluster_link/schema_registry_sync/BUILD
+++ b/src/v/cluster_link/schema_registry_sync/BUILD
@@ -89,6 +89,7 @@ redpanda_cc_library(
         "//src/v/metrics",
         "//src/v/model",
         "//src/v/schema:registry",
+        "//src/v/ssx:mutex",
         "//src/v/ssx:semaphore",
         "@seastar",
     ],

--- a/src/v/cluster_link/schema_registry_sync/BUILD
+++ b/src/v/cluster_link/schema_registry_sync/BUILD
@@ -89,6 +89,7 @@ redpanda_cc_library(
         "//src/v/metrics",
         "//src/v/model",
         "//src/v/schema:registry",
+        "//src/v/ssx:abort_source",
         "//src/v/ssx:mutex",
         "//src/v/ssx:semaphore",
         "@seastar",

--- a/src/v/cluster_link/schema_registry_sync/http_source_reader.cc
+++ b/src/v/cluster_link/schema_registry_sync/http_source_reader.cc
@@ -177,10 +177,25 @@ http_source_reader::http_source_reader(std::unique_ptr<rc::client> client)
 
 ss::future<source_result<rc::client*>>
 http_source_reader::ensure_client(ss::abort_source& as) {
+    // Checked before the fast path: stop() nulls _client, and a call arriving
+    // after stop (fibers may still be unwinding when the reader is stopped)
+    // must fail rather than rebuild a client nothing would ever stop.
+    if (_stopped) {
+        co_return std::unexpected(
+          source_error{
+            .kind = source_error_kind::source_unavailable,
+            .message = "source reader is stopped"});
+    }
     if (_client) {
         co_return _client.get();
     }
     auto build = co_await ss::get_units(_build, 1, as);
+    if (_stopped) {
+        co_return std::unexpected(
+          source_error{
+            .kind = source_error_kind::source_unavailable,
+            .message = "source reader is stopped"});
+    }
     if (_client) {
         co_return _client.get();
     }
@@ -389,7 +404,12 @@ ss::future<> http_source_reader::stop() {
     // Idempotent: the reader can be stopped more than once (e.g. an in-flight
     // reconciler stopping the task before link teardown stops it again). The
     // rest_client's gate must be closed exactly once, so release the client
-    // after shutting it down and skip it on a repeat call.
+    // after shutting it down and skip it on a repeat call. The sticky
+    // _stopped flag rejects post-stop rebuilds, and waiting out the build
+    // mutex means a build that raced this stop is shut down here rather than
+    // leaked.
+    _stopped = true;
+    auto build = co_await ss::get_units(_build, 1);
     if (auto client = std::move(_client); client) {
         co_await client->shutdown();
     }

--- a/src/v/cluster_link/schema_registry_sync/http_source_reader.h
+++ b/src/v/cluster_link/schema_registry_sync/http_source_reader.h
@@ -99,6 +99,10 @@ private:
     // Connection inputs for the lazy build; nullopt once a client is injected.
     std::optional<http_source_connection> _conn;
     std::unique_ptr<rc::client> _client;
+    // Set by stop(): the reader is stopped while the reconcile engine's
+    // fibers may still be unwinding, and a late call must fail rather than
+    // lazily rebuild the client (which nothing would ever stop).
+    bool _stopped{false};
     // Serializes the lazy client build only. Requests run concurrently: the
     // reconcile engine drives this reader from several fibers, and the
     // rest_client's pooled transport bounds them to one in-flight request per

--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
@@ -154,31 +154,58 @@ ss::future<cl_result<void>> mirroring_task::start() {
 }
 
 ss::future<cl_result<void>> mirroring_task::stop() noexcept {
-    auto res = co_await task::stop();
-    _probe.clear();
-    // task::stop() closed the runner's gate, so no run_impl is in flight and it
-    // is safe to reset the state directly (unlike update_config, which races a
-    // running fiber and defers via _config_changed). Reset so a later leader
-    // starts fresh: this instance may regain _schemas/0 leadership (A->B->A)
-    // and would otherwise report a prior tenure's stale counters/inventory and
-    // skip its first full sync on a still-recent _last_full_sync.
-    reset_sync_state();
-    // The run loop has stopped, so no fiber is using the reader; release its
-    // HTTP transport. as_future guards the noexcept contract.
-    if (_reader) {
-        auto stopped = co_await ss::coroutine::as_future(_reader->stop());
-        if (stopped.failed()) {
-            auto ex = stopped.get_exception();
-            vlog(
-              logger().warn,
-              "Error stopping Schema Registry source reader: {}",
-              ex);
+    // Stop the reader BEFORE joining the run fiber: run_impl can be parked on
+    // reader-internal waits that only the reader's own shutdown aborts (the
+    // rate limiter's token queue and Retry-After pause -- up to 60s -- and the
+    // connection pool's slot queue are deaf to the runner's abort source).
+    // Joining first would sequence that abort behind the join that needs it.
+    // The reader is built to be stopped under fire: in-flight and queued
+    // requests fail promptly with abort-classified errors and run_impl
+    // unwinds. as_future guards the noexcept contract.
+    //
+    // Under _reader_lifecycle: run_impl is still live here (reader-first), so a
+    // concurrent reset_reader() could otherwise free the reader while this
+    // stop() is suspended mid-shutdown. The lock is dropped before the join
+    // below, so it cannot deadlock against a reset_reader() the join waits on.
+    {
+        auto reader_units = co_await _reader_lifecycle.get_units();
+        if (_reader) {
+            auto stopped = co_await ss::coroutine::as_future(_reader->stop());
+            if (stopped.failed()) {
+                auto ex = stopped.get_exception();
+                vlog(
+                  logger().warn,
+                  "Error stopping Schema Registry source reader: {}",
+                  ex);
+            }
         }
     }
+    auto res = co_await task::stop();
+    _probe.clear();
+    // task::stop() closed the runner's gate, so no run_impl is in flight and
+    // it is safe to reset the state directly (unlike update_config, which
+    // races a running fiber and defers via _config_changed). Reset so a later
+    // leader starts fresh: this instance may regain _schemas/0 leadership
+    // (A->B->A) and would otherwise report a prior tenure's stale
+    // counters/inventory and skip its first full sync on a still-recent
+    // _last_full_sync.
+    reset_sync_state();
+    // Replace the stopped reader with a fresh one for that possible A->B->A
+    // re-acquisition. The reader's stop() is permanent by design (it refuses
+    // to rebuild its client so an unwinding fiber cannot resurrect it during
+    // teardown), and run_impl only rebuilds the reader on a config change, so
+    // a restarted task would otherwise keep using the dead reader and never
+    // sync. No lock needed: the run fibers have been joined, so reset_reader()
+    // cannot run and none is mid-request on the old reader.
+    _reader = _source_factory->create(_config.api_mode());
     co_return res;
 }
 
 ss::future<> mirroring_task::reset_reader() {
+    // Serialize with stop() (see _reader_lifecycle): both stop and then free
+    // the reader by reassignment, and either can be suspended in the reader's
+    // shutdown when the other reaches the free.
+    auto reader_units = co_await _reader_lifecycle.get_units();
     if (_reader) {
         auto stopped = co_await ss::coroutine::as_future(_reader->stop());
         if (stopped.failed()) {

--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
@@ -72,7 +72,8 @@ ss::future<inventory> scan_destination_inventory(
   schema::registry& destination,
   ss::noncopyable_function<bool(const ppsr::context_subject&)> in_scope,
   const context_mapper& mapper,
-  ss::abort_source& as) {
+  ss::abort_source& as,
+  ssx::sharded_abort_source* dest_as) {
     as.check();
     // A destination node is in scope iff its context reverse-maps to a source
     // context `in_scope` accepts (identity mapper: reduces to `in_scope`).
@@ -85,7 +86,7 @@ ss::future<inventory> scan_destination_inventory(
     };
     // list_subject_versions reads the store as-is; sync first so the scan
     // isn't stale (e.g. on a freshly-elected _schemas/0 leader).
-    co_await destination.sync();
+    co_await destination.sync({}, dest_as);
     auto versions = co_await destination.list_subject_versions(
       std::move(dest_in_scope), ppsr::include_deleted::yes);
     inventory inv;
@@ -287,7 +288,8 @@ ss::future<> mirroring_task::refresh_destination_inventory(
       *_destination,
       [&in_scope](const ppsr::context_subject& cs) { return in_scope(cs); },
       _mapper,
-      as);
+      as,
+      &_run_sas);
 
     chunked_hash_set<ppsr::context_subject> subjects;
     for (const auto& key : _destination_inventory.active) {
@@ -304,9 +306,10 @@ ss::future<> mirroring_task::hard_delete_target(
   ppsr::schema_version version,
   bool was_active) {
     if (was_active) {
-        co_await _destination->soft_delete_schema(dest_sub, version);
+        co_await _destination->soft_delete_schema(dest_sub, version, &_run_sas);
     }
-    co_await _destination->permanent_delete_schema(dest_sub, version);
+    co_await _destination->permanent_delete_schema(
+      dest_sub, version, &_run_sas);
 }
 
 ss::future<> mirroring_task::purge_one(
@@ -440,6 +443,7 @@ ss::future<> mirroring_task::sync_mode_and_config(
     if (unavailable.has_value()) {
         co_return;
     }
+    as.check();
     // Read the source in its own (source) namespace; write to the destination
     // under the remapped context. Identity leaves dest_target == target.
     auto dest_ctx = _mapper.forward(target.ctx);
@@ -467,8 +471,8 @@ ss::future<> mirroring_task::sync_mode_and_config(
         // override
         auto write = co_await ss::coroutine::as_future(
           mode.value().has_value()
-            ? _destination->write_mode(dest_target, *mode.value())
-            : _destination->delete_mode(dest_target));
+            ? _destination->write_mode(dest_target, *mode.value(), &_run_sas)
+            : _destination->delete_mode(dest_target, &_run_sas));
         if (write.failed()) {
             auto ex = write.get_exception();
             if (ssx::is_shutdown_exception(ex)) {
@@ -485,6 +489,7 @@ ss::future<> mirroring_task::sync_mode_and_config(
     if (unavailable.has_value()) {
         co_return;
     }
+    as.check();
     auto config = co_await _reader->read_config(target, as);
     if (!config.has_value()) {
         if (config.error().kind == source_error_kind::source_unavailable) {
@@ -506,8 +511,8 @@ ss::future<> mirroring_task::sync_mode_and_config(
 
     auto write = co_await ss::coroutine::as_future(
       cfg.compatibility.has_value()
-        ? _destination->write_config(dest_target, *cfg.compatibility)
-        : _destination->delete_config(dest_target));
+        ? _destination->write_config(dest_target, *cfg.compatibility, &_run_sas)
+        : _destination->delete_config(dest_target, &_run_sas));
     if (write.failed()) {
         auto ex = write.get_exception();
         if (ssx::is_shutdown_exception(ex)) {
@@ -639,6 +644,7 @@ ss::future<task::state_transition> mirroring_task::full_source_sync(
     // scopes discovery, keeping source and destination sides consistent.
     chunked_vector<ppsr::context_subject> subjects;
     for (const auto& ctx : contexts) {
+        as.check();
         auto subjects_res = co_await _reader->list_subjects(ctx, as);
         if (!subjects_res.has_value()) {
             if (
@@ -739,6 +745,7 @@ ss::future<task::state_transition> mirroring_task::full_source_sync(
     auto rec = reconciler{
       _reader.get(),
       _destination,
+      &_run_sas,
       [&in_scope](const ppsr::context_subject& cs) { return in_scope(cs); },
       _mapper,
       limits,
@@ -846,6 +853,21 @@ ss::future<task::state_transition> mirroring_task::full_source_sync(
 
 ss::future<task::state_transition>
 mirroring_task::run_impl(ss::abort_source& as) {
+    // Bracket the run with the sharded fan-out of the runner's abort: every
+    // destination write below hands &_run_sas down to seq_writer, whose
+    // waits resolve it per-shard. Stop on every exit path so the sharded
+    // instances never outlive the run.
+    co_await _run_sas.start(as);
+    auto res = co_await ss::coroutine::as_future(do_run_impl(as));
+    co_await _run_sas.stop();
+    if (res.failed()) {
+        std::rethrow_exception(res.get_exception());
+    }
+    co_return std::move(res).get();
+}
+
+ss::future<mirroring_task::state_transition>
+mirroring_task::do_run_impl(ss::abort_source& as) {
     // Stamp the cumulative summary's start time once per leadership acquisition
     // (the proto documents totals_since_task_start.start_time as the task
     // start). stop() clears the status on losing leadership, so the next leader

--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.h
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.h
@@ -17,6 +17,7 @@
 #include "cluster_link/task.h"
 #include "container/chunked_hash_map.h"
 #include "schema/registry.h"
+#include "ssx/mutex.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/util/noncopyable_function.hh>
@@ -237,6 +238,14 @@ private:
     schema::registry* _destination;
     source_reader_factory* _source_factory;
     std::unique_ptr<source_reader> _reader;
+    // Serializes stopping and replacing _reader. stop() (reader-first, while
+    // run_impl is still live) and reset_reader() (run by run_impl on a config
+    // change) both stop the reader and then free it via reassignment; without
+    // serialization one can free the reader while the other's stop() is
+    // suspended mid-shutdown, a use-after-free. Held only around the
+    // stop+reassign, never across the run-fiber join, so it cannot deadlock
+    // with task::stop().
+    ssx::mutex _reader_lifecycle{"cluster_link/sr_source/reader_lifecycle"};
     inventory _destination_inventory;
     model::schema_registry_sync_status _status;
     // Live counters for the in-flight reconcile; reflected by get_status_report

--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.h
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.h
@@ -17,6 +17,7 @@
 #include "cluster_link/task.h"
 #include "container/chunked_hash_map.h"
 #include "schema/registry.h"
+#include "ssx/abort_source.h"
 #include "ssx/mutex.h"
 
 #include <seastar/core/abort_source.hh>
@@ -47,7 +48,8 @@ ss::future<inventory> scan_destination_inventory(
   schema::registry& destination,
   ss::noncopyable_function<bool(const ppsr::context_subject&)> in_scope,
   const context_mapper& mapper,
-  ss::abort_source& as);
+  ss::abort_source& as,
+  ssx::sharded_abort_source* dest_as = nullptr);
 
 /// Shadows a source Schema Registry into the local (destination) Schema
 /// Registry. Runs on the shard leading `_schemas/0`, a cluster-wide singleton.
@@ -85,6 +87,9 @@ public:
 
 protected:
     ss::future<state_transition> run_impl(ss::abort_source&) override;
+
+    /// The body of run_impl, wrapped so _run_sas brackets every exit path.
+    ss::future<state_transition> do_run_impl(ss::abort_source&);
 
     bool should_start_impl(ss::shard_id, ::model::node_id) const final;
 
@@ -252,6 +257,11 @@ private:
     // for mid-sync progress, then folded into _status at end of run.
     reconcile_stats _reconcile_stats;
     probe _probe;
+    // Per-run fan-out of the runner's abort to every shard: destination
+    // seq_writer waits run on shard zero while the runner's abort_source
+    // lives on the shard leading _schemas/0, and ss::abort_source is not
+    // cross-shard safe. Started/stopped by run_impl around each run.
+    ssx::sharded_abort_source _run_sas;
     std::optional<ss::lowres_clock::time_point> _last_full_sync;
     // Set by update_config, consumed by run_impl to force a full scan. A flag
     // (rather than mutating _status/_last_full_sync in update_config) avoids

--- a/src/v/cluster_link/schema_registry_sync/reconciler.cc
+++ b/src/v/cluster_link/schema_registry_sync/reconciler.cc
@@ -110,12 +110,14 @@ void adjust_units(
 reconciler::reconciler(
   source_reader* source,
   schema::registry* destination,
+  ssx::sharded_abort_source* dest_as,
   ss::noncopyable_function<bool(const ppsr::context_subject&)> in_scope,
   const context_mapper& mapper,
   limits lim,
   model::schema_registry_sync_config::unsupported_feature_policy feature_policy)
   : _source(source)
   , _destination(destination)
+  , _dest_as(dest_as)
   , _in_scope(std::move(in_scope))
   , _mapper(&mapper)
   , _limits(lim)
@@ -464,7 +466,7 @@ ss::future<bool> reconciler::import_body(
         co_return false;
     }
     auto fut = co_await ss::coroutine::as_future(
-      _destination->import_schema(std::move(*remapped)));
+      _destination->import_schema(std::move(*remapped), _dest_as));
     if (fut.failed()) {
         auto eptr = fut.get_exception();
         if (ssx::is_shutdown_exception(eptr)) {

--- a/src/v/cluster_link/schema_registry_sync/reconciler.h
+++ b/src/v/cluster_link/schema_registry_sync/reconciler.h
@@ -108,6 +108,7 @@ public:
     reconciler(
       source_reader* source,
       schema::registry* destination,
+      ssx::sharded_abort_source* dest_as,
       ss::noncopyable_function<bool(const ppsr::context_subject&)> in_scope,
       const context_mapper& mapper,
       limits lim,
@@ -223,6 +224,8 @@ private:
 
     source_reader* _source;
     schema::registry* _destination;
+    // Run-scoped destination abort handle, forwarded to import_schema.
+    ssx::sharded_abort_source* _dest_as;
     ss::noncopyable_function<bool(const ppsr::context_subject&)> _in_scope;
     const context_mapper* _mapper;
     limits _limits;

--- a/src/v/cluster_link/schema_registry_sync/tests/BUILD
+++ b/src/v/cluster_link/schema_registry_sync/tests/BUILD
@@ -42,6 +42,7 @@ redpanda_test_cc_library(
         "//src/v/pandaproxy/schema_registry:types",
         "//src/v/schema:registry",
         "//src/v/schema/tests:fake_registry",
+        "//src/v/ssx:abort_source",
         "@seastar",
     ],
 )

--- a/src/v/cluster_link/schema_registry_sync/tests/http_source_reader_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/http_source_reader_test.cc
@@ -113,6 +113,62 @@ TEST(http_source_reader, list_contexts_enumerates_all_contexts) {
         pps::default_context, pps::context{".dev"}, pps::context{".prod"}));
 }
 
+// Stopping the reader while a request is in flight aborts the request rather
+// than waiting for it out: mirroring_task::stop() stops the reader before
+// joining the run fibers, relying on exactly this to unwedge fibers parked in
+// reader-internal waits (rate-limiter token/pause queues, pool slots).
+TEST(http_source_reader, stop_aborts_in_flight_requests) {
+    std::deque<ss::promise<http::downloaded_response>> parked;
+    auto reader = reader_over([&](mock_client& m) {
+        ON_CALL(m, request_and_collect_response(_, _, _))
+          .WillByDefault([&](
+                           bh::request_header<>&&,
+                           std::optional<iobuf>,
+                           ss::lowres_clock::duration) {
+              parked.emplace_back();
+              return parked.back().get_future();
+          });
+        // Like the real transport, shutdown fails the requests it is
+        // servicing.
+        ON_CALL(m, shutdown_and_stop()).WillByDefault([&] {
+            for (auto& request : parked) {
+                request.set_exception(
+                  std::make_exception_ptr(ss::abort_requested_exception{}));
+            }
+            parked.clear();
+            return ss::make_ready_future<>();
+        });
+    });
+    ss::abort_source as;
+    auto req = reader.list_contexts(as);
+    RPTEST_REQUIRE_EVENTUALLY(5s, [&] { return !parked.empty(); });
+
+    reader.stop().get();
+    auto res = req.get();
+    ASSERT_FALSE(res.has_value());
+    EXPECT_EQ(res.error().kind, srs::source_error_kind::source_unavailable);
+}
+
+// A reader call after stop() must fail fast instead of lazily rebuilding the
+// client: the reconcile engine's fibers can still be unwinding when the
+// reader is stopped, and a rebuilt client would never be shut down.
+TEST(http_source_reader, calls_after_stop_fail_without_rebuild) {
+    srs::http_source_connection conn{
+      .address = net::unresolved_address("example.invalid", 8081),
+      .endpoint = "http://example.invalid:8081",
+    };
+    srs::http_source_reader reader{std::move(conn)};
+    reader.stop().get();
+
+    ss::abort_source as;
+    auto res = reader.list_contexts(as).get();
+    ASSERT_FALSE(res.has_value());
+    EXPECT_EQ(res.error().kind, srs::source_error_kind::source_unavailable);
+    EXPECT_THAT(res.error().message, HasSubstr("stopped"));
+    // stop() stays idempotent.
+    reader.stop().get();
+}
+
 // stop() is idempotent: the task teardown can stop the reader more than once
 // (an in-flight reconciler stopping the task before link teardown stops it
 // again). A second stop() must not double-close the rest_client's gate, which

--- a/src/v/cluster_link/schema_registry_sync/tests/mirroring_task_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/mirroring_task_test.cc
@@ -117,10 +117,12 @@ public:
     // Seeds the destination registry with one (subject, version).
     void seed_destination(std::string_view subject, int32_t version) {
         _registry
-          .import_schema(make_schema(
-            ppsr::context_subject::unqualified(subject),
-            version,
-            fmt::format("{{\"v\":{}}}", version)))
+          .import_schema(
+            make_schema(
+              ppsr::context_subject::unqualified(subject),
+              version,
+              fmt::format("{{\"v\":{}}}", version)),
+            nullptr)
           .get();
     }
 
@@ -811,7 +813,7 @@ TEST_F(mirroring_task_test, hard_deletes_already_soft_deleted_version) {
     // longer has it at all, so it is purged (directly, no re-soft-delete).
     _registry
       .import_schema(
-        make_schema(orders, 1, R"({"v":1})", ppsr::is_deleted::yes))
+        make_schema(orders, 1, R"({"v":1})", ppsr::is_deleted::yes), nullptr)
       .get();
 
     lead_schema_registry();
@@ -973,8 +975,9 @@ TEST_F(mirroring_task_test, removes_destination_override_absent_at_source) {
     // source subject exists but has no explicit override. The sync must remove
     // the stale destination overrides.
     seed_destination("orders-value", 1);
-    _registry.write_mode(orders, ppsr::mode::read_only).get();
-    _registry.write_config(orders, ppsr::compatibility_level::full).get();
+    _registry.write_mode(orders, ppsr::mode::read_only, nullptr).get();
+    _registry.write_config(orders, ppsr::compatibility_level::full, nullptr)
+      .get();
     _source_state.add(orders, 1);
 
     lead_schema_registry();
@@ -1414,6 +1417,59 @@ TEST_F(mirroring_task_test, metric_values_are_fetched_live_on_scrape) {
     probe.clear();
 }
 
+// Fixture whose destination parks imports until the abort handle passed by
+// the task fires: stop() can only drain the runner if the task threads its
+// run abort_source into destination operations.
+class mirroring_task_abort_gated_import_test : public mirroring_task_test {
+public:
+    // If the task never passes its abort handle (the red state of the test
+    // below), the parked import would wedge the base teardown's task stop;
+    // unwedge it first.
+    ss::future<> TearDownAsync() override {
+        _gated.release();
+        co_await mirroring_task_test::TearDownAsync();
+    }
+
+protected:
+    schema::registry* dest() override { return &_gated; }
+
+    // The first import forwards (the run publishes a status snapshot), the
+    // second parks -- same proven shape as mirroring_task_blocking_import_test.
+    abort_gated_import_registry _gated{&_registry, /*block_after=*/1};
+};
+
+TEST_F(
+  mirroring_task_abort_gated_import_test,
+  stop_aborts_parked_destination_write) {
+    // A destination write parked at broker teardown resolves only through
+    // the task's abort_source. Losing leadership stops the task; the runner
+    // gate must drain -- observed via the metric series stop() drops after
+    // the drain -- without the test releasing the park. Red while the task
+    // does not thread its run abort into destination operations.
+    _source_state.add(ppsr::context_subject::unqualified("a"), 1);
+    _source_state.add(ppsr::context_subject::unqualified("b"), 1);
+
+    lead_schema_registry();
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    _gated.entered().get();
+    auto status
+      = wait_for_sync_status([](const auto& s) {
+            return s.current_sync.has_value()
+                   && s.totals_since_task_start.subject_versions_changed == 1;
+        }).get();
+    EXPECT_TRUE(status.has_value());
+
+    unlead_schema_registry();
+    ASSERT_TRUE(wait_for_task_state(model::task_state::stopped).get());
+
+    ::tests::cooperative_spin_wait_with_timeout(wait_interval, [] {
+        return !sr_sync_metric(
+                  "subject_versions_changed", ss::metrics::default_handle())
+                  .has_value();
+    }).get();
+}
+
 // Fixture whose destination parks an import mid-reconcile, so a test can
 // observe the task while _reconcile_stats holds counts not yet folded into
 // _status.
@@ -1531,11 +1587,12 @@ TEST_F(mirroring_task_test, destination_inventory_spans_contexts_and_deleted) {
     // Default-context "a": v1 active, v2 soft-deleted. Context ".b" subject
     // "c": v1 active. The scan must span both contexts and separate active from
     // soft-deleted.
-    _registry.import_schema(make_schema(a, 1, R"({"v":1})")).get();
+    _registry.import_schema(make_schema(a, 1, R"({"v":1})"), nullptr).get();
     _registry
-      .import_schema(make_schema(a, 2, R"({"v":2})", ppsr::is_deleted::yes))
+      .import_schema(
+        make_schema(a, 2, R"({"v":2})", ppsr::is_deleted::yes), nullptr)
       .get();
-    _registry.import_schema(make_schema(c, 1, R"({"v":1})")).get();
+    _registry.import_schema(make_schema(c, 1, R"({"v":1})"), nullptr).get();
 
     ss::abort_source as;
     srs::context_mapper identity;

--- a/src/v/cluster_link/schema_registry_sync/tests/reconciler_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/reconciler_test.cc
@@ -106,6 +106,7 @@ TEST(reconciler, remove_policy_does_not_count_on_import_failure) {
     auto r = srs::reconciler{
       &reader,
       &destination,
+      /*dest_as=*/nullptr,
       [](const ppsr::context_subject&) { return true; },
       mapper,
       lim,
@@ -378,7 +379,7 @@ TEST(reconciler, propagates_soft_delete_over_active_destination) {
     auto a = ppsr::context_subject::unqualified("a");
     // Destination already holds a:v1 active; the source has soft-deleted it but
     // does not echo the flag, so only the listing-derived set conveys it.
-    h.destination.import_schema(make_schema(a, 1, R"({"v":1})")).get();
+    h.destination.import_schema(make_schema(a, 1, R"({"v":1})"), nullptr).get();
     h.source.reports_deleted_flag = false;
     h.source.add(a, 1, ppsr::is_deleted::yes);
 
@@ -516,7 +517,7 @@ TEST(reconciler, import_conflict_counts_as_error) {
     {
         auto conflicting = make_schema(b, 1, R"({"conflict":true})");
         conflicting.id = ppsr::schema_id{99};
-        h.destination.import_schema(std::move(conflicting)).get();
+        h.destination.import_schema(std::move(conflicting), nullptr).get();
     }
 
     srs::work_set work;
@@ -576,6 +577,7 @@ TEST(reconciler, import_errors_are_per_item_and_cascade) {
     auto r = srs::reconciler{
       &reader,
       &destination,
+      /*dest_as=*/nullptr,
       [](const ppsr::context_subject&) { return true; },
       mapper,
       lim,
@@ -664,6 +666,7 @@ TEST(reconciler, abort_mid_sync_drains_cleanly) {
     auto r = srs::reconciler{
       &reader,
       &destination,
+      /*dest_as=*/nullptr,
       [](const ppsr::context_subject&) { return true; },
       mapper,
       lim,
@@ -720,6 +723,7 @@ TEST(reconciler, reports_progress_live) {
     auto r = srs::reconciler{
       &reader,
       &destination,
+      /*dest_as=*/nullptr,
       [](const ppsr::context_subject&) { return true; },
       mapper,
       lim,
@@ -913,6 +917,7 @@ TEST(reconciler, remaps_context_at_import) {
     auto r = srs::reconciler{
       &reader,
       &destination,
+      /*dest_as=*/nullptr,
       [](const ppsr::context_subject&) { return true; },
       mapper,
       lim,

--- a/src/v/cluster_link/schema_registry_sync/tests/sr_sync_test_fixtures.h
+++ b/src/v/cluster_link/schema_registry_sync/tests/sr_sync_test_fixtures.h
@@ -20,10 +20,12 @@
 #include "pandaproxy/schema_registry/types.h"
 #include "schema/registry.h"
 #include "schema/tests/fake_registry.h"
+#include "ssx/abort_source.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/sleep.hh>
 #include <seastar/util/noncopyable_function.hh>
 
 #include <memory>
@@ -399,6 +401,7 @@ struct reconcile_harness {
         return srs::reconciler{
           &reader,
           &destination,
+          /*dest_as=*/nullptr,
           std::move(in_scope),
           mapper,
           lim,
@@ -426,9 +429,9 @@ public:
     explicit delegating_registry(schema::registry* inner)
       : _inner(inner) {}
 
-    ss::future<ppsr::context_schema_id>
-    import_schema(ppsr::stored_schema schema) override {
-        return _inner->import_schema(std::move(schema));
+    ss::future<ppsr::context_schema_id> import_schema(
+      ppsr::stored_schema schema, ssx::sharded_abort_source* as) override {
+        return _inner->import_schema(std::move(schema), as);
     }
     bool is_enabled() const override { return _inner->is_enabled(); }
     ss::future<> ensure_internal_topic() override {
@@ -440,9 +443,10 @@ public:
     ss::future<ppsr::schema_getter*> synced_getter() const override {
         return _inner->synced_getter();
     }
-    ss::future<ss::lowres_clock::time_point>
-    sync(ss::lowres_clock::duration max_age) override {
-        return _inner->sync(max_age);
+    ss::future<ss::lowres_clock::time_point> sync(
+      ss::lowres_clock::duration max_age,
+      ssx::sharded_abort_source* as) override {
+        return _inner->sync(max_age, as);
     }
     ss::future<ppsr::schema_definition>
     get_schema_definition(ppsr::context_schema_id id) const override {
@@ -472,27 +476,36 @@ public:
         return _inner->create_schema(std::move(s));
     }
     ss::future<bool> soft_delete_schema(
-      ppsr::context_subject sub, ppsr::schema_version v) override {
-        return _inner->soft_delete_schema(std::move(sub), v);
+      ppsr::context_subject sub,
+      ppsr::schema_version v,
+      ssx::sharded_abort_source* as) override {
+        return _inner->soft_delete_schema(std::move(sub), v, as);
     }
     ss::future<chunked_vector<ppsr::schema_version>> permanent_delete_schema(
       ppsr::context_subject sub,
-      std::optional<ppsr::schema_version> v) override {
-        return _inner->permanent_delete_schema(std::move(sub), v);
+      std::optional<ppsr::schema_version> v,
+      ssx::sharded_abort_source* as) override {
+        return _inner->permanent_delete_schema(std::move(sub), v, as);
     }
-    ss::future<bool>
-    write_mode(ppsr::context_subject sub, ppsr::mode m) override {
-        return _inner->write_mode(std::move(sub), m);
+    ss::future<bool> write_mode(
+      ppsr::context_subject sub,
+      ppsr::mode m,
+      ssx::sharded_abort_source* as) override {
+        return _inner->write_mode(std::move(sub), m, as);
     }
-    ss::future<bool> delete_mode(ppsr::context_subject sub) override {
-        return _inner->delete_mode(std::move(sub));
+    ss::future<bool> delete_mode(
+      ppsr::context_subject sub, ssx::sharded_abort_source* as) override {
+        return _inner->delete_mode(std::move(sub), as);
     }
     ss::future<bool> write_config(
-      ppsr::context_subject sub, ppsr::compatibility_level c) override {
-        return _inner->write_config(std::move(sub), c);
+      ppsr::context_subject sub,
+      ppsr::compatibility_level c,
+      ssx::sharded_abort_source* as) override {
+        return _inner->write_config(std::move(sub), c, as);
     }
-    ss::future<bool> delete_config(ppsr::context_subject sub) override {
-        return _inner->delete_config(std::move(sub));
+    ss::future<bool> delete_config(
+      ppsr::context_subject sub, ssx::sharded_abort_source* as) override {
+        return _inner->delete_config(std::move(sub), as);
     }
 
 protected:
@@ -512,10 +525,10 @@ public:
       : delegating_registry(inner)
       , _block_after(block_after) {}
 
-    ss::future<ppsr::context_schema_id>
-    import_schema(ppsr::stored_schema schema) override {
+    ss::future<ppsr::context_schema_id> import_schema(
+      ppsr::stored_schema schema, ssx::sharded_abort_source* as) override {
         if (_imports_seen++ < _block_after) {
-            co_return co_await _inner->import_schema(std::move(schema));
+            co_return co_await _inner->import_schema(std::move(schema), as);
         }
         if (!_entered_set) {
             _entered_set = true;
@@ -524,7 +537,7 @@ public:
         // Park until the test releases (clean completion) or aborts (the wait
         // resolves with abort_requested).
         co_await _release.get_future();
-        co_return co_await _inner->import_schema(std::move(schema));
+        co_return co_await _inner->import_schema(std::move(schema), as);
     }
 
     ss::future<> entered() { return _entered.get_future(); }
@@ -545,6 +558,64 @@ private:
     ss::promise<> _release;
 };
 
+// Wraps a destination registry, parking `import_schema` until the abort
+// handle the caller passed fires. Models a destination write stuck in broker
+// teardown: the wait resolves only through the threaded abort_source, so a
+// task that does not pass its run abort into destination operations wedges
+// here until the test's release() escape hatch.
+class abort_gated_import_registry final : public delegating_registry {
+public:
+    /// `block_after` imports are forwarded to the inner registry; the next
+    /// one parks until the caller-passed abort fires (or release()).
+    explicit abort_gated_import_registry(
+      schema::registry* inner, size_t block_after = 0)
+      : delegating_registry(inner)
+      , _block_after(block_after) {}
+
+    ss::future<ppsr::context_schema_id> import_schema(
+      ppsr::stored_schema schema, ssx::sharded_abort_source* as) override {
+        if (_imports_seen++ < _block_after) {
+            co_return co_await _inner->import_schema(std::move(schema), as);
+        }
+        if (!_entered_set) {
+            _entered_set = true;
+            _entered.set_value();
+        }
+        if (as != nullptr) {
+            try {
+                co_await ss::sleep_abortable(
+                  std::chrono::hours{1}, as->local());
+            } catch (const ss::sleep_aborted&) {
+                // Surface the abort itself, shutdown-classified, the way an
+                // abort-aware production destination would.
+                as->local().check();
+            }
+        } else {
+            // No abort handle threaded through: only the escape hatch ends
+            // the park (today's un-abortable hang, bounded for teardown).
+            co_await _release.get_future();
+        }
+        co_return co_await _inner->import_schema(std::move(schema), as);
+    }
+
+    ss::future<> entered() { return _entered.get_future(); }
+
+    void release() {
+        if (!_released) {
+            _released = true;
+            _release.set_value();
+        }
+    }
+
+private:
+    size_t _block_after;
+    size_t _imports_seen{0};
+    bool _entered_set{false};
+    bool _released{false};
+    ss::promise<> _entered;
+    ss::promise<> _release;
+};
+
 // Wraps a destination registry, throwing a configured schema-registry error for
 // specific (subject, version) imports and delegating everything else. Lets a
 // test inject a per-item import failure the in-memory fake would never produce
@@ -561,14 +632,14 @@ public:
         _failures.emplace(key, ppsr::error_info{code, std::move(message)});
     }
 
-    ss::future<ppsr::context_schema_id>
-    import_schema(ppsr::stored_schema schema) override {
+    ss::future<ppsr::context_schema_id> import_schema(
+      ppsr::stored_schema schema, ssx::sharded_abort_source* as) override {
         ppsr::subject_version key{schema.schema.sub(), schema.version};
         if (auto it = _failures.find(key); it != _failures.end()) {
             return ss::make_exception_future<ppsr::context_schema_id>(
               ppsr::as_exception(it->second));
         }
-        return _inner->import_schema(std::move(schema));
+        return _inner->import_schema(std::move(schema), as);
     }
 
 private:
@@ -590,12 +661,14 @@ public:
     }
 
     ss::future<bool> write_config(
-      ppsr::context_subject sub, ppsr::compatibility_level c) override {
+      ppsr::context_subject sub,
+      ppsr::compatibility_level c,
+      ssx::sharded_abort_source* as) override {
         if (auto it = _failures.find(sub); it != _failures.end()) {
             return ss::make_exception_future<bool>(
               ppsr::as_exception(it->second));
         }
-        return _inner->write_config(std::move(sub), c);
+        return _inner->write_config(std::move(sub), c, as);
     }
 
 private:
@@ -639,7 +712,8 @@ public:
 
     ss::future<chunked_vector<ppsr::schema_version>> permanent_delete_schema(
       ppsr::context_subject sub,
-      std::optional<ppsr::schema_version> v) override {
+      std::optional<ppsr::schema_version> v,
+      ssx::sharded_abort_source* as) override {
         ++_attempts[sub];
         if (auto f = _fail_with.find(sub); f != _fail_with.end()) {
             return ss::make_exception_future<
@@ -658,7 +732,7 @@ public:
                 "referenced by a live schema"}));
         }
         _purged.insert(sub);
-        return _inner->permanent_delete_schema(std::move(sub), v);
+        return _inner->permanent_delete_schema(std::move(sub), v, as);
     }
 
 private:

--- a/src/v/cluster_link/tests/link_test.cc
+++ b/src/v/cluster_link/tests/link_test.cc
@@ -689,7 +689,8 @@ ss::future<> seed_subject(
           subject_schema{ppsr::context_subject{std::move(ctx), ppsr::subject{std::move(sub)}}, ppsr::schema_definition{ppsr::schema_definition::raw_string{R"({"type":"string"})"}, ppsr::schema_type::avro}},
         .version = ppsr::schema_version{1},
         .id = ppsr::schema_id{1},
-        .deleted = deleted});
+        .deleted = deleted},
+      nullptr);
 }
 } // namespace
 

--- a/src/v/datalake/tests/record_schema_resolver_test.cc
+++ b/src/v/datalake/tests/record_schema_resolver_test.cc
@@ -594,7 +594,7 @@ public:
         co_return &_store;
     }
     ss::future<ss::lowres_clock::time_point>
-    sync(ss::lowres_clock::duration) override {
+    sync(ss::lowres_clock::duration, ssx::sharded_abort_source*) override {
         co_return ss::lowres_clock::now();
     }
     ss::future<pandaproxy::schema_registry::schema_definition>
@@ -637,44 +637,50 @@ public:
     }
 
     ss::future<pandaproxy::schema_registry::context_schema_id> import_schema(
-      pandaproxy::schema_registry::stored_schema imported) override {
-        return _registry.import_schema(std::move(imported));
+      pandaproxy::schema_registry::stored_schema imported,
+      ssx::sharded_abort_source* as) override {
+        return _registry.import_schema(std::move(imported), as);
     }
 
     ss::future<bool> soft_delete_schema(
       pandaproxy::schema_registry::context_subject sub,
-      pandaproxy::schema_registry::schema_version version) override {
-        return _registry.soft_delete_schema(std::move(sub), version);
+      pandaproxy::schema_registry::schema_version version,
+      ssx::sharded_abort_source* as) override {
+        return _registry.soft_delete_schema(std::move(sub), version, as);
     }
 
     ss::future<chunked_vector<pandaproxy::schema_registry::schema_version>>
     permanent_delete_schema(
       pandaproxy::schema_registry::context_subject sub,
-      std::optional<pandaproxy::schema_registry::schema_version> version)
-      override {
-        return _registry.permanent_delete_schema(std::move(sub), version);
+      std::optional<pandaproxy::schema_registry::schema_version> version,
+      ssx::sharded_abort_source* as) override {
+        return _registry.permanent_delete_schema(std::move(sub), version, as);
     }
 
     ss::future<bool> write_mode(
       pandaproxy::schema_registry::context_subject sub,
-      pandaproxy::schema_registry::mode mode) override {
-        return _registry.write_mode(std::move(sub), mode);
+      pandaproxy::schema_registry::mode mode,
+      ssx::sharded_abort_source* as) override {
+        return _registry.write_mode(std::move(sub), mode, as);
     }
 
-    ss::future<bool>
-    delete_mode(pandaproxy::schema_registry::context_subject sub) override {
-        return _registry.delete_mode(std::move(sub));
+    ss::future<bool> delete_mode(
+      pandaproxy::schema_registry::context_subject sub,
+      ssx::sharded_abort_source* as) override {
+        return _registry.delete_mode(std::move(sub), as);
     }
 
     ss::future<bool> write_config(
       pandaproxy::schema_registry::context_subject sub,
-      pandaproxy::schema_registry::compatibility_level compat) override {
-        return _registry.write_config(std::move(sub), compat);
+      pandaproxy::schema_registry::compatibility_level compat,
+      ssx::sharded_abort_source* as) override {
+        return _registry.write_config(std::move(sub), compat, as);
     }
 
-    ss::future<bool>
-    delete_config(pandaproxy::schema_registry::context_subject sub) override {
-        return _registry.delete_config(std::move(sub));
+    ss::future<bool> delete_config(
+      pandaproxy::schema_registry::context_subject sub,
+      ssx::sharded_abort_source* as) override {
+        return _registry.delete_config(std::move(sub), as);
     }
 
     const std::vector<pandaproxy::schema_registry::stored_schema>& get_all() {

--- a/src/v/kafka/client/BUILD
+++ b/src/v/kafka/client/BUILD
@@ -371,6 +371,7 @@ redpanda_cc_library(
         "//src/v/net",
         "//src/v/random:generators",
         "//src/v/security",
+        "//src/v/ssx:abort_source",
         "//src/v/ssx:future_util",
         "//src/v/ssx:mutex",
         "//src/v/ssx:semaphore",

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -380,18 +380,20 @@ void throw_on_error(const T& r) {
 
 } // namespace
 
-ss::future<list_offsets_response>
-client::list_offsets(list_offsets_request req) {
-    co_return co_await gated_retry_with_mitigation([this, &req]() {
-        return do_list_offsets(req);
-    }).then([](auto res) {
-        throw_on_error<list_offsets_response>(res);
-        return res;
-    });
+ss::future<list_offsets_response> client::list_offsets(
+  list_offsets_request req,
+  std::optional<std::reference_wrapper<ss::abort_source>> ext_as) {
+    co_return co_await gated_retry_with_mitigation_ext(
+      [this, &req]() { return do_list_offsets(req); }, ext_as)
+      .then([](auto res) {
+          throw_on_error<list_offsets_response>(res);
+          return res;
+      });
 }
 
-ss::future<list_offsets_response>
-client::list_offsets(model::topic_partition tp) {
+ss::future<list_offsets_response> client::list_offsets(
+  model::topic_partition tp,
+  std::optional<std::reference_wrapper<ss::abort_source>> ext_as) {
     kafka::list_offsets_request req;
     req.data.topics.emplace_back(
       kafka::list_offset_topic{
@@ -400,7 +402,7 @@ client::list_offsets(model::topic_partition tp) {
           .partition_index = tp.partition,
           .max_num_offsets = 1,
         }}});
-    return list_offsets(std::move(req));
+    return list_offsets(std::move(req), ext_as);
 }
 
 ss::future<list_offsets_response>
@@ -497,7 +499,8 @@ ss::future<fetch_response> client::fetch_partition(
   model::topic_partition tp,
   model::offset offset,
   std::chrono::milliseconds timeout,
-  std::optional<int32_t> max_bytes) {
+  std::optional<int32_t> max_bytes,
+  std::optional<std::reference_wrapper<ss::abort_source>> ext_as) {
     const auto min_bytes = _consumer_config.fetch_min_bytes;
     const int32_t max_bytes_value = max_bytes.value_or(
       _consumer_config.fetch_max_bytes);
@@ -510,24 +513,26 @@ ss::future<fetch_response> client::fetch_partition(
     return ss::do_with(
       std::move(build_request),
       std::move(tp),
-      [this](auto& build_request, model::topic_partition& tp) {
-          return gated_retry_with_mitigation([this, &tp, &build_request]() {
-                     auto leader_id = _cluster->get_topics().leader(tp);
-                     if (!leader_id) {
-                         return ss::make_exception_future<fetch_response>(
-                           partition_error(
-                             tp, error_code::unknown_topic_or_partition));
-                     }
-                     return _cluster
-                       ->dispatch_to(
-                         *leader_id,
-                         build_request(tp),
-                         api_version_for(fetch_api::key))
-                       .then([leader_id, &tp](fetch_response res) {
-                           return maybe_throw_exception(
-                             *leader_id, tp, std::move(res));
-                       });
-                 })
+      [this, ext_as](auto& build_request, model::topic_partition& tp) {
+          return gated_retry_with_mitigation_ext(
+                   [this, &tp, &build_request]() {
+                       auto leader_id = _cluster->get_topics().leader(tp);
+                       if (!leader_id) {
+                           return ss::make_exception_future<fetch_response>(
+                             partition_error(
+                               tp, error_code::unknown_topic_or_partition));
+                       }
+                       return _cluster
+                         ->dispatch_to(
+                           *leader_id,
+                           build_request(tp),
+                           api_version_for(fetch_api::key))
+                         .then([leader_id, &tp](fetch_response res) {
+                             return maybe_throw_exception(
+                               *leader_id, tp, std::move(res));
+                         });
+                   },
+                   ext_as)
             .handle_exception([&tp](std::exception_ptr ex) {
                 return make_fetch_response(tp, ex);
             });

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -27,6 +27,7 @@
 #include "kafka/protocol/fetch.h"
 #include "kafka/protocol/list_offset.h"
 #include "kafka/protocol/metadata.h"
+#include "ssx/abort_source.h"
 #include "ssx/semaphore.h"
 #include "utils/prefix_logger.h"
 #include "utils/unresolved_address.h"
@@ -89,6 +90,31 @@ public:
           _as);
     }
 
+    /// \brief Like gated_retry_with_mitigation, but also aborts when the
+    /// caller-supplied abort source fires: retries and backoff sleeps respond
+    /// to whichever of the client's internal abort source or `ext_as` fires
+    /// first. An in-flight wire request still runs to its own timeout.
+    template<typename Func>
+    std::invoke_result_t<Func> gated_retry_with_mitigation_ext(
+      Func func,
+      std::optional<std::reference_wrapper<ss::abort_source>> ext_as) {
+        if (!ext_as.has_value()) {
+            return gated_retry_with_mitigation(std::move(func));
+        }
+        return ss::do_with(
+          ssx::composite_abort_source(_as, ext_as->get()),
+          [this,
+           func{std::move(func)}](ssx::composite_abort_source& cas) mutable {
+              return gated_retry_with_mitigation_impl(
+                _gate,
+                _retries_config.max_retries,
+                _retries_config.retry_base_backoff,
+                std::move(func),
+                [this](std::exception_ptr ex) { return mitigate_error(ex); },
+                cas.as());
+          });
+    }
+
     /// \brief Dispatch a request to any broker.
     template<typename Func>
     requires requires {
@@ -118,15 +144,23 @@ public:
     ss::future<produce_response>
     produce_records(model::topic topic, chunked_vector<record_essence> batch);
 
-    ss::future<list_offsets_response> list_offsets(list_offsets_request req);
+    ss::future<list_offsets_response> list_offsets(
+      list_offsets_request req,
+      std::optional<std::reference_wrapper<ss::abort_source>> ext_as
+      = std::nullopt);
 
-    ss::future<list_offsets_response> list_offsets(model::topic_partition tp);
+    ss::future<list_offsets_response> list_offsets(
+      model::topic_partition tp,
+      std::optional<std::reference_wrapper<ss::abort_source>> ext_as
+      = std::nullopt);
 
     ss::future<fetch_response> fetch_partition(
       model::topic_partition tp,
       model::offset offset,
       std::chrono::milliseconds timeout,
-      std::optional<int32_t> max_bytes = std::nullopt);
+      std::optional<int32_t> max_bytes = std::nullopt,
+      std::optional<std::reference_wrapper<ss::abort_source>> ext_as
+      = std::nullopt);
 
     ss::future<member_id>
     create_consumer(const group_id& g_id, member_id name = kafka::no_member);

--- a/src/v/kafka/client/client_fetch_batch_reader.cc
+++ b/src/v/kafka/client/client_fetch_batch_reader.cc
@@ -26,12 +26,14 @@ public:
       kafka::client::client& client,
       model::topic_partition tp,
       model::offset first,
-      model::offset last)
+      model::offset last,
+      std::optional<std::reference_wrapper<ss::abort_source>> ext_as)
       : _client{client}
       , _tp{std::move(tp)}
       , _next_offset{first}
       , _last_offset{last}
-      , _batch_reader{} {}
+      , _batch_reader{}
+      , _ext_as{ext_as} {}
 
     // Implements model::record_batch_reader::impl
     bool is_end_of_stream() const final { return _next_offset >= _last_offset; }
@@ -48,7 +50,9 @@ public:
               _tp,
               _next_offset,
               std::chrono::duration_cast<std::chrono::milliseconds>(
-                t - model::timeout_clock::now()));
+                t - model::timeout_clock::now()),
+              std::nullopt,
+              _ext_as);
             vlog(
               _client.logger().debug,
               "fetch_batch_reader: fetch result: {}",
@@ -93,15 +97,17 @@ private:
     model::offset _next_offset;
     model::offset _last_offset;
     std::optional<kafka::batch_reader> _batch_reader;
+    std::optional<std::reference_wrapper<ss::abort_source>> _ext_as;
 };
 
 model::record_batch_reader make_client_fetch_batch_reader(
   kafka::client::client& client,
   model::topic_partition tp,
   model::offset first,
-  model::offset last) {
+  model::offset last,
+  std::optional<std::reference_wrapper<ss::abort_source>> ext_as) {
     return model::make_record_batch_reader<client_fetcher>(
-      client, std::move(tp), first, last);
+      client, std::move(tp), first, last, ext_as);
 }
 
 } // namespace kafka::client

--- a/src/v/kafka/client/client_fetch_batch_reader.h
+++ b/src/v/kafka/client/client_fetch_batch_reader.h
@@ -15,6 +15,11 @@
 #include "model/fundamental.h"
 #include "model/record_batch_reader.h"
 
+#include <seastar/core/abort_source.hh>
+
+#include <functional>
+#include <optional>
+
 namespace kafka::client {
 
 ///\brief Adapt a kafka::client to fetch from a tp as a
@@ -23,6 +28,8 @@ model::record_batch_reader make_client_fetch_batch_reader(
   kafka::client::client& client,
   model::topic_partition tp,
   model::offset first,
-  model::offset last);
+  model::offset last,
+  std::optional<std::reference_wrapper<ss::abort_source>> ext_as
+  = std::nullopt);
 
 } // namespace kafka::client

--- a/src/v/pandaproxy/schema_registry/BUILD
+++ b/src/v/pandaproxy/schema_registry/BUILD
@@ -315,6 +315,7 @@ redpanda_cc_library(
         "//src/v/pandaproxy:json",
         "//src/v/pandaproxy:parsing",
         "//src/v/random:time_jitter",
+        "//src/v/ssx:abort_source",
         "//src/v/ssx:semaphore",
         "//src/v/ssx:sformat",
         "//src/v/strings:string_switch",

--- a/src/v/pandaproxy/schema_registry/kafka_client_transport.cc
+++ b/src/v/pandaproxy/schema_registry/kafka_client_transport.cc
@@ -131,10 +131,20 @@ kafka_client_transport::produce(model::record_batch batch) {
     co_return produce_result{.base_offset = res.base_offset};
 }
 
-ss::future<model::offset> kafka_client_transport::get_high_watermark() {
+ss::future<model::offset> kafka_client_transport::get_high_watermark(
+  std::optional<std::reference_wrapper<ss::abort_source>> as) {
+    if (as.has_value()) {
+        as->get().check();
+    }
     auto offsets_f = co_await ss::coroutine::as_future(
-      _client->list_offsets(model::schema_registry_internal_tp));
+      _client->list_offsets(model::schema_registry_internal_tp, as));
     if (offsets_f.failed()) {
+        // A fired abort supersedes whatever the client surfaced: fetch/produce
+        // paths can launder abort exceptions into generic kafka errors, and a
+        // shutdown must be classifiable as one by the caller.
+        if (as.has_value()) {
+            as->get().check();
+        }
         rethrow_partition_error(offsets_f.get_exception());
     }
     auto offsets = std::move(offsets_f).get();
@@ -152,22 +162,37 @@ ss::future<> kafka_client_transport::consume_range(
   model::offset start,
   model::offset end,
   ss::noncopyable_function<ss::future<ss::stop_iteration>(model::record_batch)>
-    consumer) {
+    consumer,
+  std::optional<std::reference_wrapper<ss::abort_source>> as) {
+    if (as.has_value()) {
+        as->get().check();
+    }
     struct batch_consumer {
         ss::noncopyable_function<ss::future<ss::stop_iteration>(
           model::record_batch)>
           fn;
+        std::optional<std::reference_wrapper<ss::abort_source>> as;
         ss::future<ss::stop_iteration> operator()(model::record_batch batch) {
+            // Abort between batches: the catch-up read can span many slices
+            // and must not outlive a shutdown by more than one of them.
+            if (as.has_value()) {
+                as->get().check();
+            }
             return fn(std::move(batch));
         }
         void end_of_stream() {}
     };
     auto rdr = kafka::client::make_client_fetch_batch_reader(
-      *_client, model::schema_registry_internal_tp, start, end);
+      *_client, model::schema_registry_internal_tp, start, end, as);
     auto fut = co_await ss::coroutine::as_future(
       std::move(rdr).consume(
-        batch_consumer{std::move(consumer)}, model::no_timeout));
+        batch_consumer{std::move(consumer), as}, model::no_timeout));
     if (fut.failed()) {
+        // See get_high_watermark: a fired abort must surface as itself, not
+        // as the laundered kafka error the fetch path may report.
+        if (as.has_value()) {
+            as->get().check();
+        }
         rethrow_partition_error(fut.get_exception());
     }
 }

--- a/src/v/pandaproxy/schema_registry/kafka_client_transport.h
+++ b/src/v/pandaproxy/schema_registry/kafka_client_transport.h
@@ -19,7 +19,9 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/sharded.hh>
 
+#include <functional>
 #include <memory>
+#include <optional>
 
 namespace kafka::data::rpc {
 class topic_creator;
@@ -40,12 +42,14 @@ public:
     ss::future<> stop() final;
 
     ss::future<produce_result> produce(model::record_batch batch) override;
-    ss::future<model::offset> get_high_watermark() override;
+    ss::future<model::offset> get_high_watermark(
+      std::optional<std::reference_wrapper<ss::abort_source>> as) override;
     ss::future<> consume_range(
       model::offset start,
       model::offset end,
       ss::noncopyable_function<
-        ss::future<ss::stop_iteration>(model::record_batch)> consumer) override;
+        ss::future<ss::stop_iteration>(model::record_batch)> consumer,
+      std::optional<std::reference_wrapper<ss::abort_source>> as) override;
 
     ss::future<> configure();
     ss::future<cluster::errc> create_topic(

--- a/src/v/pandaproxy/schema_registry/rpc_transport.cc
+++ b/src/v/pandaproxy/schema_registry/rpc_transport.cc
@@ -71,7 +71,8 @@ ss::future<produce_result> rpc_transport::produce(model::record_batch batch) {
     co_return produce_result{.base_offset = *res.base_offset};
 }
 
-ss::future<model::offset> rpc_transport::get_high_watermark() {
+ss::future<model::offset> rpc_transport::get_high_watermark(
+  std::optional<std::reference_wrapper<ss::abort_source>>) {
     auto result = co_await _client.get_single_partition_offsets(
       model::schema_registry_internal_tp);
     if (result.has_error()) {
@@ -85,7 +86,8 @@ ss::future<> rpc_transport::consume_range(
   model::offset start,
   model::offset end,
   ss::noncopyable_function<ss::future<ss::stop_iteration>(model::record_batch)>
-    consumer) {
+    consumer,
+  std::optional<std::reference_wrapper<ss::abort_source>>) {
     // The RPC consume API may not return all records in a single call,
     // so loop until we've consumed up to the desired end offset.
 

--- a/src/v/pandaproxy/schema_registry/rpc_transport.h
+++ b/src/v/pandaproxy/schema_registry/rpc_transport.h
@@ -32,12 +32,14 @@ public:
     ss::future<> stop() final { return ss::now(); }
 
     ss::future<produce_result> produce(model::record_batch batch) override;
-    ss::future<model::offset> get_high_watermark() override;
+    ss::future<model::offset> get_high_watermark(
+      std::optional<std::reference_wrapper<ss::abort_source>> as) override;
     ss::future<> consume_range(
       model::offset start,
       model::offset end,
       ss::noncopyable_function<
-        ss::future<ss::stop_iteration>(model::record_batch)> consumer) override;
+        ss::future<ss::stop_iteration>(model::record_batch)> consumer,
+      std::optional<std::reference_wrapper<ss::abort_source>> as) override;
     ss::future<cluster::errc> create_topic(
       model::topic_namespace_view,
       int32_t partition_count,

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -107,9 +107,16 @@ struct batch_builder : public storage::record_batch_builder {
 /// Call this before reading from the store, if servicing
 /// a REST API endpoint that requires global knowledge of latest
 /// data (i.e. any listings)
-ss::future<> seq_writer::read_sync() {
-    auto max_offset = co_await _transport->get_high_watermark();
-    co_await wait_for(max_offset - model::offset{1});
+ss::future<> seq_writer::read_sync(ssx::sharded_abort_source* as) {
+    // Resolved on the calling shard: seq_writer is peering-sharded and each
+    // shard owns its own transport/client, so the local abort instance is
+    // the right one both for facade-shard calls and the shard-zero
+    // sequenced_write path.
+    auto ext = as != nullptr
+                 ? std::optional{std::ref(as->local())}
+                 : std::optional<std::reference_wrapper<ss::abort_source>>{};
+    auto max_offset = co_await _transport->get_high_watermark(ext);
+    co_await wait_for(max_offset - model::offset{1}, as);
     co_await _store.process_marked_schemas();
 }
 
@@ -127,29 +134,40 @@ ss::future<> seq_writer::check_mutable(
     co_return;
 }
 
-ss::future<> seq_writer::wait_for(model::offset offset) {
+ss::future<>
+seq_writer::wait_for(model::offset offset, ssx::sharded_abort_source* as) {
     return container().invoke_on(
-      reader_shard, _smp_opts, [offset](seq_writer& seq) {
-          if (auto waiters = seq._wait_for_sem.waiters(); waiters != 0) {
-              vlog(srlog.trace, "wait_for waiting for {} waiters", waiters);
-          }
-          return ss::with_semaphore(seq._wait_for_sem, 1, [&seq, offset]() {
-              if (offset > seq._loaded_offset) {
-                  vlog(
-                    srlog.debug,
-                    "wait_for dirty!  Reading {}..{}",
-                    seq._loaded_offset,
-                    offset);
-                  return seq._transport->consume_range(
-                    seq._loaded_offset + model::offset{1},
-                    offset + model::offset{1},
-                    consume_to_store{seq._store, seq});
-              } else {
-                  vlog(srlog.trace, "wait_for clean (offset  {})", offset);
-                  return ss::make_ready_future<>();
-              }
-          });
+      reader_shard, _smp_opts, [offset, as](seq_writer& seq) {
+          return seq.wait_for_inner(offset, as);
       });
+}
+
+ss::future<> seq_writer::wait_for_inner(
+  model::offset offset, ssx::sharded_abort_source* as) {
+    if (auto waiters = _wait_for_sem.waiters(); waiters != 0) {
+        vlog(srlog.trace, "wait_for waiting for {} waiters", waiters);
+    }
+    auto units = as != nullptr
+                   ? co_await ss::get_units(_wait_for_sem, 1, as->local())
+                   : co_await ss::get_units(_wait_for_sem, 1);
+    if (offset > _loaded_offset) {
+        vlog(
+          srlog.debug,
+          "wait_for dirty!  Reading {}..{}",
+          _loaded_offset,
+          offset);
+        auto ext
+          = as != nullptr
+              ? std::optional{std::ref(as->local())}
+              : std::optional<std::reference_wrapper<ss::abort_source>>{};
+        co_await _transport->consume_range(
+          _loaded_offset + model::offset{1},
+          offset + model::offset{1},
+          consume_to_store{_store, *this},
+          ext);
+    } else {
+        vlog(srlog.trace, "wait_for clean (offset  {})", offset);
+    }
 }
 
 /// Helper for write methods that need to check + retry if their
@@ -397,14 +415,16 @@ seq_writer::do_write_subject_version_imported(
 }
 
 ss::future<sharded_store::insert_result>
-seq_writer::write_subject_version_imported(stored_schema schema) {
+seq_writer::write_subject_version_imported(
+  stored_schema schema, ssx::sharded_abort_source* as) {
     co_return co_await sequenced_write(
       [&schema](model::offset write_at, seq_writer& seq) {
           return seq.do_write_subject_version_imported(
             schema.share(), write_at);
       },
       schema.schema.sub().ctx,
-      write_source::schema_registry_sync);
+      write_source::schema_registry_sync,
+      as);
 }
 
 ss::future<std::optional<bool>> seq_writer::do_write_config(
@@ -455,7 +475,10 @@ ss::future<std::optional<bool>> seq_writer::do_write_config(
 }
 
 ss::future<bool> seq_writer::write_config(
-  context_subject ctx_sub, compatibility_level compat, write_source src) {
+  context_subject ctx_sub,
+  compatibility_level compat,
+  write_source src,
+  ssx::sharded_abort_source* as) {
     auto ctx = ctx_sub.ctx;
     return sequenced_write(
       [ctx_sub{std::move(ctx_sub)}, compat, src](
@@ -463,7 +486,8 @@ ss::future<bool> seq_writer::write_config(
           return seq.do_write_config(ctx_sub, compat, write_at, src);
       },
       std::move(ctx),
-      src);
+      src,
+      as);
 }
 
 ss::future<std::optional<bool>>
@@ -499,15 +523,16 @@ seq_writer::do_delete_config(context_subject ctx_sub, write_source src) {
     }
 }
 
-ss::future<bool>
-seq_writer::delete_config(context_subject ctx_sub, write_source src) {
+ss::future<bool> seq_writer::delete_config(
+  context_subject ctx_sub, write_source src, ssx::sharded_abort_source* as) {
     auto ctx = ctx_sub.ctx;
     return sequenced_write(
       [ctx_sub{std::move(ctx_sub)}, src](model::offset, seq_writer& seq) {
           return seq.do_delete_config(ctx_sub, src);
       },
       std::move(ctx),
-      src);
+      src,
+      as);
 }
 
 ss::future<std::optional<bool>> seq_writer::do_write_mode(
@@ -591,7 +616,11 @@ ss::future<std::optional<bool>> seq_writer::do_write_mode(
 }
 
 ss::future<bool> seq_writer::write_mode(
-  context_subject ctx_sub, mode mode, force f, write_source src) {
+  context_subject ctx_sub,
+  mode mode,
+  force f,
+  write_source src,
+  ssx::sharded_abort_source* as) {
     auto ctx = ctx_sub.ctx;
     return sequenced_write(
       [ctx_sub{std::move(ctx_sub)}, mode, f, src](
@@ -599,7 +628,8 @@ ss::future<bool> seq_writer::write_mode(
           return seq.do_write_mode(ctx_sub, mode, f, write_at, src);
       },
       std::move(ctx),
-      src);
+      src,
+      as);
 }
 
 ss::future<std::optional<bool>> seq_writer::do_delete_mode(
@@ -631,8 +661,8 @@ ss::future<std::optional<bool>> seq_writer::do_delete_mode(
     }
 }
 
-ss::future<bool>
-seq_writer::delete_mode(context_subject ctx_sub, write_source src) {
+ss::future<bool> seq_writer::delete_mode(
+  context_subject ctx_sub, write_source src, ssx::sharded_abort_source* as) {
     auto ctx = ctx_sub.ctx;
     return sequenced_write(
       [ctx_sub{std::move(ctx_sub)},
@@ -640,7 +670,8 @@ seq_writer::delete_mode(context_subject ctx_sub, write_source src) {
           return seq.do_delete_mode(ctx_sub, write_at, src);
       },
       std::move(ctx),
-      src);
+      src,
+      as);
 }
 
 ss::future<std::optional<bool>>
@@ -725,7 +756,10 @@ ss::future<std::optional<bool>> seq_writer::do_delete_subject_version(
 }
 
 ss::future<bool> seq_writer::delete_subject_version(
-  context_subject sub, schema_version version, write_source src) {
+  context_subject sub,
+  schema_version version,
+  write_source src,
+  ssx::sharded_abort_source* as) {
     auto ctx = sub.ctx;
     return sequenced_write(
       [sub{std::move(sub)}, version, src](
@@ -733,7 +767,8 @@ ss::future<bool> seq_writer::delete_subject_version(
           return seq.do_delete_subject_version(sub, version, write_at, src);
       },
       std::move(ctx),
-      src);
+      src,
+      as);
 }
 
 ss::future<std::optional<chunked_vector<schema_version>>>
@@ -805,14 +840,16 @@ seq_writer::delete_subject_impermanent(context_subject sub, write_source src) {
 ss::future<chunked_vector<schema_version>> seq_writer::delete_subject_permanent(
   context_subject sub,
   std::optional<schema_version> version,
-  write_source src) {
+  write_source src,
+  ssx::sharded_abort_source* as) {
     auto ctx = sub.ctx;
     return sequenced_write(
       [sub{std::move(sub)}, version, src](model::offset, seq_writer& seq) {
           return seq.delete_subject_permanent_inner(sub, version, src);
       },
       std::move(ctx),
-      src);
+      src,
+      as);
 }
 
 ss::future<std::optional<chunked_vector<schema_version>>>

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -18,6 +18,7 @@
 #include "pandaproxy/schema_registry/transport.h"
 #include "pandaproxy/schema_registry/types.h"
 #include "random/simple_time_jitter.h"
+#include "ssx/abort_source.h"
 #include "ssx/semaphore.h"
 #include "utils/retry.h"
 
@@ -61,7 +62,7 @@ public:
       , _node_id(node_id)
       , _state_checker(std::move(state_checker)) {}
 
-    ss::future<> read_sync();
+    ss::future<> read_sync(ssx::sharded_abort_source* as = nullptr);
 
     // Throws 42205 if the subject cannot be modified
     ss::future<> check_mutable(
@@ -78,16 +79,19 @@ public:
     /// Internal sync path for importing a subject version with caller-supplied
     /// schema ID, version, and deleted state. Bypasses client write guards
     /// such as read-only mode and mode_mutability.
-    ss::future<sharded_store::insert_result>
-    write_subject_version_imported(stored_schema schema);
+    ss::future<sharded_store::insert_result> write_subject_version_imported(
+      stored_schema schema, ssx::sharded_abort_source* as = nullptr);
 
     ss::future<bool> write_config(
       context_subject ctx_sub,
       compatibility_level compat,
-      write_source src = write_source::client);
+      write_source src = write_source::client,
+      ssx::sharded_abort_source* as = nullptr);
 
     ss::future<bool> delete_config(
-      context_subject ctx_sub, write_source src = write_source::client);
+      context_subject ctx_sub,
+      write_source src = write_source::client,
+      ssx::sharded_abort_source* as = nullptr);
 
     /// \param f bypasses only the import-mode emptiness check, never
     /// mode_mutability.
@@ -95,17 +99,21 @@ public:
       context_subject ctx_sub,
       mode m,
       force f,
-      write_source src = write_source::client);
+      write_source src = write_source::client,
+      ssx::sharded_abort_source* as = nullptr);
 
     ss::future<bool> delete_mode(
-      context_subject ctx_sub, write_source src = write_source::client);
+      context_subject ctx_sub,
+      write_source src = write_source::client,
+      ssx::sharded_abort_source* as = nullptr);
 
     ss::future<> delete_context(context ctx);
 
     ss::future<bool> delete_subject_version(
       context_subject sub,
       schema_version version,
-      write_source src = write_source::client);
+      write_source src = write_source::client,
+      ssx::sharded_abort_source* as = nullptr);
 
     ss::future<chunked_vector<schema_version>> delete_subject_impermanent(
       context_subject sub, write_source src = write_source::client);
@@ -113,7 +121,8 @@ public:
     ss::future<chunked_vector<schema_version>> delete_subject_permanent(
       context_subject sub,
       std::optional<schema_version> version,
-      write_source src = write_source::client);
+      write_source src = write_source::client,
+      ssx::sharded_abort_source* as = nullptr);
 
 private:
     ss::smp_submit_to_options _smp_opts;
@@ -175,39 +184,59 @@ private:
     /// Helper for write paths that use sequence+retry logic to synchronize
     /// multiple writing nodes.
     template<typename F>
-    auto
-    sequenced_write(F f, context ctx, write_source src = write_source::client) {
+    auto sequenced_write(
+      F f,
+      context ctx,
+      write_source src = write_source::client,
+      ssx::sharded_abort_source* as = nullptr) {
         if (_state_checker->writes_disabled(src, ctx)) [[unlikely]] {
             throw as_exception(writes_disabled());
         }
         auto base_backoff = _jitter.next_duration();
-        auto remote = [base_backoff, f](seq_writer& seq) {
-            if (auto waiters = seq._write_sem.waiters(); waiters != 0) {
-                vlog(
-                  srlog.trace,
-                  "sequenced_write waiting for {} waiters",
-                  waiters);
-            }
-            return ss::with_semaphore(
-              seq._write_sem, 1, [&seq, f, base_backoff]() {
-                  if (
-                    auto waiters = seq._wait_for_sem.waiters(); waiters != 0) {
-                      vlog(
-                        srlog.debug,
-                        "sequenced_write acquired write_sem with {} "
-                        "wait_for_sem waiters",
-                        waiters);
-                  }
-                  return retry_with_backoff(
-                    max_retries,
-                    [f, &seq]() { return seq.sequenced_write_inner(f); },
-                    base_backoff);
-              });
+        auto remote = [base_backoff, f, as](seq_writer& seq) {
+            return seq.sequenced_write_remote(f, base_backoff, as);
         };
 
         return container()
           .invoke_on(reader_shard, _smp_opts, remote)
           .then([](auto res) { return std::move(res).value(); });
+    }
+
+    /// The shard-zero body of sequenced_write: serialize on _write_sem, then
+    /// run the read-then-write attempt loop. A member coroutine (not a lambda
+    /// coroutine) so the frame owns its state across suspensions. `as` is the
+    /// caller's abort handle, resolved to this shard's instance here (after
+    /// the hop): it aborts the semaphore wait and the retry loop's pre-checks
+    /// and backoff sleeps.
+    template<
+      typename F,
+      typename invoke_result_t = typename std::
+        invoke_result_t<F, model::offset, seq_writer&>::value_type::value_type>
+    ss::future<
+      outcome::outcome<invoke_result_t, std::error_code, std::exception_ptr>>
+    sequenced_write_remote(
+      F f,
+      ss::lowres_clock::duration base_backoff,
+      ssx::sharded_abort_source* as) {
+        if (auto waiters = _write_sem.waiters(); waiters != 0) {
+            vlog(
+              srlog.trace, "sequenced_write waiting for {} waiters", waiters);
+        }
+        auto units = as != nullptr
+                       ? co_await ss::get_units(_write_sem, 1, as->local())
+                       : co_await ss::get_units(_write_sem, 1);
+        if (auto waiters = _wait_for_sem.waiters(); waiters != 0) {
+            vlog(
+              srlog.debug,
+              "sequenced_write acquired write_sem with {} "
+              "wait_for_sem waiters",
+              waiters);
+        }
+        co_return co_await retry_with_backoff(
+          max_retries,
+          [&f, this, as]() { return sequenced_write_inner(f, as); },
+          base_backoff,
+          as != nullptr ? std::optional{std::ref(as->local())} : std::nullopt);
     }
 
     /// The part of sequenced_write that runs on shard zero
@@ -224,10 +253,10 @@ private:
         invoke_result_t<F, model::offset, seq_writer&>::value_type::value_type>
     ss::future<
       outcome::outcome<invoke_result_t, std::error_code, std::exception_ptr>>
-    sequenced_write_inner(F f) {
+    sequenced_write_inner(F f, ssx::sharded_abort_source* as = nullptr) {
         // If we run concurrently with them, redundant replays to the store
         // will be safely dropped based on offset.
-        co_await read_sync();
+        co_await read_sync(as);
 
         auto next_offset = _loaded_offset + model::offset{1};
         std::optional<invoke_result_t> r;
@@ -249,7 +278,10 @@ private:
       std::optional<model::offset> write_at, model::record_batch batch);
 
     /// Block until this offset is available, fetching if necessary
-    ss::future<> wait_for(model::offset offset);
+    ss::future<>
+    wait_for(model::offset offset, ssx::sharded_abort_source* as = nullptr);
+    ss::future<>
+    wait_for_inner(model::offset offset, ssx::sharded_abort_source* as);
 
     std::unique_ptr<sequence_state_checker> _state_checker;
 

--- a/src/v/pandaproxy/schema_registry/test/BUILD
+++ b/src/v/pandaproxy/schema_registry/test/BUILD
@@ -221,6 +221,7 @@ redpanda_test_cc_library(
         "//src/v/pandaproxy/schema_registry:seq_writer",
         "//src/v/pandaproxy/schema_registry:transport",
         "//src/v/pandaproxy/schema_registry:types",
+        "@seastar",
     ],
 )
 
@@ -239,6 +240,28 @@ redpanda_cc_btest(
         "//src/v/pandaproxy/schema_registry:seq_writer",
         "//src/v/pandaproxy/schema_registry:store",
         "//src/v/pandaproxy/schema_registry:types",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "seq_writer_abort",
+    timeout = "short",
+    srcs = [
+        "seq_writer_abort.cc",
+    ],
+    cpu = 1,
+    deps = [
+        ":utils",
+        "//src/v/model",
+        "//src/v/pandaproxy/schema_registry:seq_writer",
+        "//src/v/pandaproxy/schema_registry:store",
+        "//src/v/pandaproxy/schema_registry:types",
+        "//src/v/ssx:abort_source",
+        "//src/v/ssx:future_util",
         "//src/v/test_utils:seastar_boost",
         "@boost//:test",
         "@seastar",

--- a/src/v/pandaproxy/schema_registry/test/rpc_transport_test.cc
+++ b/src/v/pandaproxy/schema_registry/test/rpc_transport_test.cc
@@ -23,6 +23,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <optional>
 #include <vector>
 
 namespace pps = pandaproxy::schema_registry;
@@ -105,7 +106,9 @@ public:
 
     pps::rpc_transport& transport() { return *_transport; }
 
-    model::offset hwm() { return transport().get_high_watermark().get(); }
+    model::offset hwm() {
+        return transport().get_high_watermark(std::nullopt).get();
+    }
 
     void set_errors(int n) {
         _kd->local_partition_manager()->set_errors(n);
@@ -201,7 +204,8 @@ TEST_P(SchemaRegistryRpcTransportTest, ConsumeRangeProducedBatches) {
             max_consumed = std::max(max_consumed, b.base_offset());
             records_consumed.push_back(std::move(b));
             co_return ss::stop_iteration::no;
-        })
+        },
+        std::nullopt)
       .get();
 
     EXPECT_EQ(records_consumed.size(), records_produced.size());
@@ -225,7 +229,8 @@ TEST_P(SchemaRegistryRpcTransportTest, ConsumeRangeRetriesOnTransientError) {
           this auto, model::record_batch) -> ss::future<ss::stop_iteration> {
             ++consumed_count;
             co_return ss::stop_iteration::no;
-        })
+        },
+        std::nullopt)
       .get();
     EXPECT_EQ(consumed_count, 1);
 }
@@ -242,7 +247,8 @@ TEST_P(SchemaRegistryRpcTransportTest, ConsumeRangeEmpty) {
           this auto, model::record_batch) -> ss::future<ss::stop_iteration> {
             ++consumed_count;
             co_return ss::stop_iteration::no;
-        })
+        },
+        std::nullopt)
       .get();
     EXPECT_EQ(consumed_count, 0);
 }
@@ -259,7 +265,8 @@ TEST_P(SchemaRegistryRpcTransportTest, ConsumeRangePastHwmThrows) {
           hwm() + model::offset(10),
           [](model::record_batch) -> ss::future<ss::stop_iteration> {
               co_return ss::stop_iteration::no;
-          })
+          },
+          std::nullopt)
         .get(),
       kafka::exception);
 }

--- a/src/v/pandaproxy/schema_registry/test/seq_writer_abort.cc
+++ b/src/v/pandaproxy/schema_registry/test/seq_writer_abort.cc
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "pandaproxy/schema_registry/seq_writer.h"
+#include "pandaproxy/schema_registry/sharded_store.h"
+#include "pandaproxy/schema_registry/test/utils.h"
+#include "pandaproxy/schema_registry/types.h"
+#include "ssx/abort_source.h"
+#include "ssx/future-util.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/defer.hh>
+
+#include <chrono>
+
+namespace pps = pandaproxy::schema_registry;
+using namespace std::chrono_literals;
+
+namespace {
+
+/// Transport whose read path parks, mimicking a broker whose kafka layer was
+/// torn down mid-shutdown while a seq_writer operation is in flight.
+///
+/// The contract under test: seq_writer must hand its caller's abort_source
+/// down to the transport, and a fired abort must resolve the parked wait
+/// exceptionally. Without a handle the wait parks until the test's escape
+/// hatch (release()), which models today's un-abortable hang.
+class blocking_transport final : public noop_transport {
+public:
+    ss::future<model::offset> get_high_watermark(
+      std::optional<std::reference_wrapper<ss::abort_source>> as) override {
+        if (!_entered_set) {
+            _entered_set = true;
+            _entered.set_value();
+        }
+        if (as.has_value()) {
+            try {
+                co_await ss::sleep_abortable(1h, as->get());
+            } catch (const ss::sleep_aborted&) {
+                // Surface the abort itself (shutdown-classified), as the
+                // production transport does via as.check().
+                as->get().check();
+            }
+            co_return model::offset{0};
+        }
+        // No abort handle: park until the teardown escape hatch.
+        co_await _release.get_future();
+        co_return model::offset{0};
+    }
+
+    ss::future<> entered() { return _entered.get_future(); }
+
+    void release() {
+        if (!_released) {
+            _released = true;
+            _release.set_value();
+        }
+    }
+
+private:
+    bool _entered_set{false};
+    bool _released{false};
+    ss::promise<> _entered;
+    ss::promise<> _release;
+};
+
+} // namespace
+
+/// A seq_writer write parked in its transport read must resolve promptly and
+/// shutdown-classified when the caller's abort_source fires. Guards the
+/// cluster_link SR-sync shutdown path: task::stop() cannot drain its runner
+/// while a destination write sits in an un-abortable transport wait.
+SEASTAR_THREAD_TEST_CASE(seq_writer_write_aborts_parked_transport_wait) {
+    pps::sharded_store s;
+    s.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&s]() { s.stop().get(); });
+
+    blocking_transport transport;
+
+    ss::sharded<pps::seq_writer> seq;
+    seq
+      .start(
+        model::node_id{0},
+        ss::default_smp_service_group(),
+        std::ref(transport),
+        std::reference_wrapper(s),
+        ss::sharded_parameter(
+          [] { return std::make_unique<sequence_state_checker_test>(); }))
+      .get();
+    auto stop_seq = ss::defer([&seq]() { seq.stop().get(); });
+    // Runs before stop_seq: unwedge a still-parked write (the red state of
+    // this test) so teardown does not hang.
+    auto release_transport = ss::defer([&transport]() { transport.release(); });
+
+    ss::abort_source parent;
+    ssx::sharded_abort_source sas;
+    sas.start(parent).get();
+    auto stop_sas = ss::defer([&sas]() { sas.stop().get(); });
+
+    auto fut = seq.local().write_config(
+      pps::context_subject::unqualified("abort-test"),
+      pps::compatibility_level::backward,
+      pps::write_source::schema_registry_sync,
+      &sas);
+
+    // The write is parked inside the transport's read (read_sync).
+    transport.entered().get();
+
+    parent.request_abort();
+
+    // Bounded on the assertion side only (no abandonment: the future is
+    // polled, never dropped): the write must resolve exceptionally and
+    // shutdown-classified well within the bound once the abort fires.
+    for (int i = 0; i < 100 && !fut.available(); ++i) {
+        ss::sleep(100ms).get();
+    }
+    BOOST_REQUIRE_MESSAGE(
+      fut.available(),
+      "write did not resolve within 10s of the abort; the abort_source is "
+      "not reaching the parked transport wait");
+    BOOST_REQUIRE(fut.failed());
+    auto ex = fut.get_exception();
+    BOOST_REQUIRE_MESSAGE(
+      ssx::is_shutdown_exception(ex),
+      "abort must surface as a shutdown-classified exception");
+}

--- a/src/v/pandaproxy/schema_registry/test/utils.h
+++ b/src/v/pandaproxy/schema_registry/test/utils.h
@@ -11,6 +11,10 @@
 #include "pandaproxy/schema_registry/seq_writer.h"
 #include "pandaproxy/schema_registry/transport.h"
 
+#include <seastar/core/abort_source.hh>
+
+#include <functional>
+#include <optional>
 #include <stdexcept>
 
 class sequence_state_checker_test
@@ -47,7 +51,8 @@ public:
     produce(model::record_batch) override {
         throw std::runtime_error("noop_transport::produce not implemented");
     }
-    ss::future<model::offset> get_high_watermark() override {
+    ss::future<model::offset> get_high_watermark(
+      std::optional<std::reference_wrapper<ss::abort_source>>) override {
         throw std::runtime_error(
           "noop_transport::get_high_watermark not implemented");
     }
@@ -55,7 +60,8 @@ public:
       model::offset,
       model::offset,
       ss::noncopyable_function<
-        ss::future<ss::stop_iteration>(model::record_batch)>) override {
+        ss::future<ss::stop_iteration>(model::record_batch)>,
+      std::optional<std::reference_wrapper<ss::abort_source>>) override {
         throw std::runtime_error(
           "noop_transport::consume_range not implemented");
     }
@@ -81,7 +87,8 @@ public:
           pandaproxy::schema_registry::produce_result{.base_offset = base});
     }
 
-    ss::future<model::offset> get_high_watermark() override {
+    ss::future<model::offset> get_high_watermark(
+      std::optional<std::reference_wrapper<ss::abort_source>>) override {
         return ss::make_ready_future<model::offset>(model::offset{0});
     }
 

--- a/src/v/pandaproxy/schema_registry/transport.h
+++ b/src/v/pandaproxy/schema_registry/transport.h
@@ -16,10 +16,14 @@
 #include "model/fundamental.h"
 #include "model/record.h"
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/util/noncopyable_function.hh>
+
+#include <functional>
+#include <optional>
 
 namespace pandaproxy::schema_registry {
 
@@ -47,7 +51,9 @@ public:
     virtual ss::future<produce_result> produce(model::record_batch batch) = 0;
 
     /// Get the high watermark (next offset) for the _schemas topic.
-    virtual ss::future<model::offset> get_high_watermark() = 0;
+    virtual ss::future<model::offset> get_high_watermark(
+      std::optional<std::reference_wrapper<ss::abort_source>> as = std::nullopt)
+      = 0;
 
     /// Consume batches from [start, end) on the _schemas topic.
     /// Calls consumer(batch) for each batch. Handles pagination internally.
@@ -56,7 +62,9 @@ public:
       model::offset start,
       model::offset end,
       ss::noncopyable_function<
-        ss::future<ss::stop_iteration>(model::record_batch)> consumer) = 0;
+        ss::future<ss::stop_iteration>(model::record_batch)> consumer,
+      std::optional<std::reference_wrapper<ss::abort_source>> as = std::nullopt)
+      = 0;
 
     /// Create the internal schema registry topic.
     virtual ss::future<cluster::errc> create_topic(

--- a/src/v/schema/BUILD
+++ b/src/v/schema/BUILD
@@ -36,6 +36,7 @@ redpanda_cc_library(
         "//src/v/pandaproxy/schema_registry:server",
         "//src/v/pandaproxy/schema_registry:store",
         "//src/v/pandaproxy/schema_registry:types",
+        "//src/v/ssx:abort_source",
         "@seastar",
     ],
 )

--- a/src/v/schema/registry.cc
+++ b/src/v/schema/registry.cc
@@ -54,15 +54,16 @@ public:
         co_return reader;
     }
 
-    ss::future<ss::lowres_clock::time_point>
-    sync(ss::lowres_clock::duration max_age) override {
+    ss::future<ss::lowres_clock::time_point> sync(
+      ss::lowres_clock::duration max_age,
+      ssx::sharded_abort_source* as) override {
         auto now = ss::lowres_clock::now();
 
         if (
           now - _last_sync_time > max_age
           || max_age == ss::lowres_clock::duration{}) {
             auto [reader, writer] = co_await service();
-            co_await writer->read_sync();
+            co_await writer->read_sync(as);
             _last_sync_time = now;
         }
 
@@ -112,11 +113,11 @@ public:
         co_return ppsr::context_schema_id{std::move(ctx), result.id};
     }
 
-    ss::future<ppsr::context_schema_id>
-    import_schema(ppsr::stored_schema schema) override {
+    ss::future<ppsr::context_schema_id> import_schema(
+      ppsr::stored_schema schema, ssx::sharded_abort_source* as) override {
         auto ctx = schema.schema.sub().ctx;
         auto [reader, writer] = co_await service();
-        co_await writer->read_sync();
+        co_await writer->read_sync(as);
         auto parsed = co_await reader->make_canonical_schema(
           std::move(schema.schema),
           ppsr::normalize::no,
@@ -124,63 +125,79 @@ public:
         co_await reader->validate_schema(parsed.share());
         schema.schema = std::move(parsed);
         auto result = co_await writer->write_subject_version_imported(
-          std::move(schema));
+          std::move(schema), as);
         _last_sync_time = ss::lowres_clock::now();
         co_return ppsr::context_schema_id{std::move(ctx), result.id};
     }
 
     ss::future<bool> soft_delete_schema(
-      ppsr::context_subject sub, ppsr::schema_version version) override {
+      ppsr::context_subject sub,
+      ppsr::schema_version version,
+      ssx::sharded_abort_source* as) override {
         auto [_, writer] = co_await service();
         auto result = co_await writer->delete_subject_version(
-          std::move(sub), version, ppsr::write_source::schema_registry_sync);
+          std::move(sub),
+          version,
+          ppsr::write_source::schema_registry_sync,
+          as);
         _last_sync_time = ss::lowres_clock::now();
         co_return result;
     }
 
     ss::future<chunked_vector<ppsr::schema_version>> permanent_delete_schema(
       ppsr::context_subject sub,
-      std::optional<ppsr::schema_version> version) override {
+      std::optional<ppsr::schema_version> version,
+      ssx::sharded_abort_source* as) override {
         auto [_, writer] = co_await service();
         auto result = co_await writer->delete_subject_permanent(
-          std::move(sub), version, ppsr::write_source::schema_registry_sync);
+          std::move(sub),
+          version,
+          ppsr::write_source::schema_registry_sync,
+          as);
         _last_sync_time = ss::lowres_clock::now();
         co_return result;
     }
 
-    ss::future<bool>
-    write_mode(ppsr::context_subject sub, ppsr::mode m) override {
+    ss::future<bool> write_mode(
+      ppsr::context_subject sub,
+      ppsr::mode m,
+      ssx::sharded_abort_source* as) override {
         auto [_, writer] = co_await service();
         auto result = co_await writer->write_mode(
           std::move(sub),
           m,
           ppsr::force::yes,
-          ppsr::write_source::schema_registry_sync);
+          ppsr::write_source::schema_registry_sync,
+          as);
         _last_sync_time = ss::lowres_clock::now();
         co_return result;
     }
 
-    ss::future<bool> delete_mode(ppsr::context_subject sub) override {
+    ss::future<bool> delete_mode(
+      ppsr::context_subject sub, ssx::sharded_abort_source* as) override {
         auto [_, writer] = co_await service();
         auto result = co_await writer->delete_mode(
-          std::move(sub), ppsr::write_source::schema_registry_sync);
+          std::move(sub), ppsr::write_source::schema_registry_sync, as);
         _last_sync_time = ss::lowres_clock::now();
         co_return result;
     }
 
     ss::future<bool> write_config(
-      ppsr::context_subject sub, ppsr::compatibility_level compat) override {
+      ppsr::context_subject sub,
+      ppsr::compatibility_level compat,
+      ssx::sharded_abort_source* as) override {
         auto [_, writer] = co_await service();
         auto result = co_await writer->write_config(
-          std::move(sub), compat, ppsr::write_source::schema_registry_sync);
+          std::move(sub), compat, ppsr::write_source::schema_registry_sync, as);
         _last_sync_time = ss::lowres_clock::now();
         co_return result;
     }
 
-    ss::future<bool> delete_config(ppsr::context_subject sub) override {
+    ss::future<bool> delete_config(
+      ppsr::context_subject sub, ssx::sharded_abort_source* as) override {
         auto [_, writer] = co_await service();
         auto result = co_await writer->delete_config(
-          std::move(sub), ppsr::write_source::schema_registry_sync);
+          std::move(sub), ppsr::write_source::schema_registry_sync, as);
         _last_sync_time = ss::lowres_clock::now();
         co_return result;
     }
@@ -212,7 +229,7 @@ public:
           "invalid attempted usage of a disabled schema registry");
     }
     ss::future<ss::lowres_clock::time_point>
-    sync(ss::lowres_clock::duration) override {
+    sync(ss::lowres_clock::duration, ssx::sharded_abort_source*) override {
         throw std::logic_error(
           "invalid attempted usage of a disabled schema registry");
     }
@@ -250,34 +267,43 @@ public:
           "invalid attempted usage of a disabled schema registry");
     }
     ss::future<ppsr::context_schema_id>
-    import_schema(ppsr::stored_schema) override {
+    import_schema(ppsr::stored_schema, ssx::sharded_abort_source*) override {
         throw std::logic_error(
           "invalid attempted usage of a disabled schema registry");
     }
-    ss::future<bool>
-    soft_delete_schema(ppsr::context_subject, ppsr::schema_version) override {
+    ss::future<bool> soft_delete_schema(
+      ppsr::context_subject,
+      ppsr::schema_version,
+      ssx::sharded_abort_source*) override {
         throw std::logic_error(
           "invalid attempted usage of a disabled schema registry");
     }
     ss::future<chunked_vector<ppsr::schema_version>> permanent_delete_schema(
-      ppsr::context_subject, std::optional<ppsr::schema_version>) override {
+      ppsr::context_subject,
+      std::optional<ppsr::schema_version>,
+      ssx::sharded_abort_source*) override {
         throw std::logic_error(
           "invalid attempted usage of a disabled schema registry");
     }
-    ss::future<bool> write_mode(ppsr::context_subject, ppsr::mode) override {
-        throw std::logic_error(
-          "invalid attempted usage of a disabled schema registry");
-    }
-    ss::future<bool> delete_mode(ppsr::context_subject) override {
+    ss::future<bool> write_mode(
+      ppsr::context_subject, ppsr::mode, ssx::sharded_abort_source*) override {
         throw std::logic_error(
           "invalid attempted usage of a disabled schema registry");
     }
     ss::future<bool>
-    write_config(ppsr::context_subject, ppsr::compatibility_level) override {
+    delete_mode(ppsr::context_subject, ssx::sharded_abort_source*) override {
         throw std::logic_error(
           "invalid attempted usage of a disabled schema registry");
     }
-    ss::future<bool> delete_config(ppsr::context_subject) override {
+    ss::future<bool> write_config(
+      ppsr::context_subject,
+      ppsr::compatibility_level,
+      ssx::sharded_abort_source*) override {
+        throw std::logic_error(
+          "invalid attempted usage of a disabled schema registry");
+    }
+    ss::future<bool>
+    delete_config(ppsr::context_subject, ssx::sharded_abort_source*) override {
         throw std::logic_error(
           "invalid attempted usage of a disabled schema registry");
     }

--- a/src/v/schema/registry.h
+++ b/src/v/schema/registry.h
@@ -14,6 +14,7 @@
 #include "pandaproxy/schema_registry/fwd.h"
 #include "pandaproxy/schema_registry/schema_getter.h"
 #include "pandaproxy/schema_registry/types.h"
+#include "ssx/abort_source.h"
 
 #include <seastar/util/noncopyable_function.hh>
 
@@ -64,8 +65,9 @@ public:
     ///                a new sync. If zero (default), always forces a sync.
     /// \return time point of the last sync (either current time if sync was
     ///         performed, or the previous sync time if no sync was needed).
-    virtual ss::future<ss::lowres_clock::time_point>
-    sync(ss::lowres_clock::duration max_age = {}) = 0;
+    virtual ss::future<ss::lowres_clock::time_point> sync(
+      ss::lowres_clock::duration max_age = {},
+      ssx::sharded_abort_source* as = nullptr) = 0;
 
     ss::future<std::optional<pandaproxy::schema_registry::valid_schema>>
     get_valid_schema(
@@ -123,31 +125,39 @@ public:
     /// Import a schema with source id/version. Identical imports are no-ops;
     /// conflicts throw.
     virtual ss::future<pandaproxy::schema_registry::context_schema_id>
-      import_schema(pandaproxy::schema_registry::stored_schema) = 0;
+    import_schema(
+      pandaproxy::schema_registry::stored_schema,
+      ssx::sharded_abort_source* as = nullptr) = 0;
 
     virtual ss::future<bool> soft_delete_schema(
       pandaproxy::schema_registry::context_subject,
-      pandaproxy::schema_registry::schema_version) = 0;
+      pandaproxy::schema_registry::schema_version,
+      ssx::sharded_abort_source* as = nullptr) = 0;
 
     virtual ss::future<
       chunked_vector<pandaproxy::schema_registry::schema_version>>
-      permanent_delete_schema(
-        pandaproxy::schema_registry::context_subject,
-        std::optional<pandaproxy::schema_registry::schema_version>) = 0;
+    permanent_delete_schema(
+      pandaproxy::schema_registry::context_subject,
+      std::optional<pandaproxy::schema_registry::schema_version>,
+      ssx::sharded_abort_source* as = nullptr) = 0;
 
     virtual ss::future<bool> write_mode(
       pandaproxy::schema_registry::context_subject,
-      pandaproxy::schema_registry::mode) = 0;
+      pandaproxy::schema_registry::mode,
+      ssx::sharded_abort_source* as = nullptr) = 0;
 
-    virtual ss::future<bool>
-      delete_mode(pandaproxy::schema_registry::context_subject) = 0;
+    virtual ss::future<bool> delete_mode(
+      pandaproxy::schema_registry::context_subject,
+      ssx::sharded_abort_source* as = nullptr) = 0;
 
     virtual ss::future<bool> write_config(
       pandaproxy::schema_registry::context_subject,
-      pandaproxy::schema_registry::compatibility_level) = 0;
+      pandaproxy::schema_registry::compatibility_level,
+      ssx::sharded_abort_source* as = nullptr) = 0;
 
-    virtual ss::future<bool>
-      delete_config(pandaproxy::schema_registry::context_subject) = 0;
+    virtual ss::future<bool> delete_config(
+      pandaproxy::schema_registry::context_subject,
+      ssx::sharded_abort_source* as = nullptr) = 0;
 
     ///@}
 };

--- a/src/v/schema/tests/fake_registry.cc
+++ b/src/v/schema/tests/fake_registry.cc
@@ -169,8 +169,8 @@ schema::fake_registry::create_schema(ppsr::subject_schema unparsed) {
     co_return _store.schemas.back().context_id();
 }
 
-ss::future<ppsr::context_schema_id>
-schema::fake_registry::import_schema(ppsr::stored_schema imported) {
+ss::future<ppsr::context_schema_id> schema::fake_registry::import_schema(
+  ppsr::stored_schema imported, ssx::sharded_abort_source*) {
     maybe_throw_injected_failure();
 
     for (const auto& s : _store.schemas) {
@@ -208,7 +208,9 @@ schema::fake_registry::import_schema(ppsr::stored_schema imported) {
 }
 
 ss::future<bool> schema::fake_registry::soft_delete_schema(
-  ppsr::context_subject sub, ppsr::schema_version version) {
+  ppsr::context_subject sub,
+  ppsr::schema_version version,
+  ssx::sharded_abort_source*) {
     maybe_throw_injected_failure();
     for (auto& s : _store.schemas) {
         if (s.schema.sub() == sub && s.version == version) {
@@ -221,7 +223,9 @@ ss::future<bool> schema::fake_registry::soft_delete_schema(
 
 ss::future<chunked_vector<ppsr::schema_version>>
 schema::fake_registry::permanent_delete_schema(
-  ppsr::context_subject sub, std::optional<ppsr::schema_version> version) {
+  ppsr::context_subject sub,
+  std::optional<ppsr::schema_version> version,
+  ssx::sharded_abort_source*) {
     maybe_throw_injected_failure();
     chunked_vector<ppsr::schema_version> deleted;
     std::erase_if(_store.schemas, [&](const ppsr::stored_schema& schema) {
@@ -241,8 +245,8 @@ schema::fake_registry::permanent_delete_schema(
     co_return deleted;
 }
 
-ss::future<bool>
-schema::fake_registry::write_mode(ppsr::context_subject sub, ppsr::mode mode) {
+ss::future<bool> schema::fake_registry::write_mode(
+  ppsr::context_subject sub, ppsr::mode mode, ssx::sharded_abort_source*) {
     maybe_throw_injected_failure();
     auto it = _modes.find(sub);
     if (it == _modes.end()) {
@@ -256,13 +260,16 @@ schema::fake_registry::write_mode(ppsr::context_subject sub, ppsr::mode mode) {
     co_return true;
 }
 
-ss::future<bool> schema::fake_registry::delete_mode(ppsr::context_subject sub) {
+ss::future<bool> schema::fake_registry::delete_mode(
+  ppsr::context_subject sub, ssx::sharded_abort_source*) {
     maybe_throw_injected_failure();
     co_return _modes.erase(sub) > 0;
 }
 
 ss::future<bool> schema::fake_registry::write_config(
-  ppsr::context_subject sub, ppsr::compatibility_level compat) {
+  ppsr::context_subject sub,
+  ppsr::compatibility_level compat,
+  ssx::sharded_abort_source*) {
     maybe_throw_injected_failure();
     auto it = _configs.find(sub);
     if (it == _configs.end()) {
@@ -276,8 +283,8 @@ ss::future<bool> schema::fake_registry::write_config(
     co_return true;
 }
 
-ss::future<bool>
-schema::fake_registry::delete_config(ppsr::context_subject sub) {
+ss::future<bool> schema::fake_registry::delete_config(
+  ppsr::context_subject sub, ssx::sharded_abort_source*) {
     maybe_throw_injected_failure();
     co_return _configs.erase(sub) > 0;
 }

--- a/src/v/schema/tests/fake_registry.h
+++ b/src/v/schema/tests/fake_registry.h
@@ -52,7 +52,7 @@ public:
     }
 
     ss::future<ss::lowres_clock::time_point>
-    sync(ss::lowres_clock::duration) override {
+    sync(ss::lowres_clock::duration, ssx::sharded_abort_source*) override {
         return ss::make_ready_future<ss::lowres_clock::time_point>(
           ss::lowres_clock::now());
     }
@@ -84,32 +84,38 @@ public:
     ss::future<pandaproxy::schema_registry::context_schema_id> create_schema(
       pandaproxy::schema_registry::subject_schema unparsed) override;
 
-    ss::future<pandaproxy::schema_registry::context_schema_id>
-    import_schema(pandaproxy::schema_registry::stored_schema imported) override;
+    ss::future<pandaproxy::schema_registry::context_schema_id> import_schema(
+      pandaproxy::schema_registry::stored_schema imported,
+      ssx::sharded_abort_source* as) override;
 
     ss::future<bool> soft_delete_schema(
       pandaproxy::schema_registry::context_subject sub,
-      pandaproxy::schema_registry::schema_version version) override;
+      pandaproxy::schema_registry::schema_version version,
+      ssx::sharded_abort_source* as) override;
 
     ss::future<chunked_vector<pandaproxy::schema_registry::schema_version>>
     permanent_delete_schema(
       pandaproxy::schema_registry::context_subject sub,
-      std::optional<pandaproxy::schema_registry::schema_version> version)
-      override;
+      std::optional<pandaproxy::schema_registry::schema_version> version,
+      ssx::sharded_abort_source* as) override;
 
     ss::future<bool> write_mode(
       pandaproxy::schema_registry::context_subject sub,
-      pandaproxy::schema_registry::mode mode) override;
+      pandaproxy::schema_registry::mode mode,
+      ssx::sharded_abort_source* as) override;
 
-    ss::future<bool>
-    delete_mode(pandaproxy::schema_registry::context_subject sub) override;
+    ss::future<bool> delete_mode(
+      pandaproxy::schema_registry::context_subject sub,
+      ssx::sharded_abort_source* as) override;
 
     ss::future<bool> write_config(
       pandaproxy::schema_registry::context_subject sub,
-      pandaproxy::schema_registry::compatibility_level compat) override;
+      pandaproxy::schema_registry::compatibility_level compat,
+      ssx::sharded_abort_source* as) override;
 
-    ss::future<bool>
-    delete_config(pandaproxy::schema_registry::context_subject sub) override;
+    ss::future<bool> delete_config(
+      pandaproxy::schema_registry::context_subject sub,
+      ssx::sharded_abort_source* as) override;
 
     const std::vector<pandaproxy::schema_registry::stored_schema>& get_all();
 

--- a/src/v/utils/retry.h
+++ b/src/v/utils/retry.h
@@ -67,8 +67,10 @@ ss::futurize_t<std::invoke_result_t<Func>> retry_with_backoff(
                      if (as.has_value()) {
                          try {
                              as->get().check();
-                         } catch (const std::exception& e) {
-                             promise.set_exception(e);
+                         } catch (...) {
+                             // Preserve the concrete abort exception type so
+                             // callers can classify it as a shutdown.
+                             promise.set_exception(std::current_exception());
                              return ss::make_ready_future<stop_iteration>(
                                stop_iteration::yes);
                          }
@@ -102,7 +104,7 @@ ss::futurize_t<std::invoke_result_t<Func>> retry_with_backoff(
                              auto sleep_dur = base_backoff * next;
                              auto f = (as.has_value())
                                         ? ss::sleep_abortable(sleep_dur, *as)
-                                        : ss::sleep(sleep_dur * next);
+                                        : ss::sleep(sleep_dur);
                              return f.then([] { return stop_iteration::no; })
                                .handle_exception(
                                  [&promise](std::exception_ptr e) {

--- a/tests/rptest/tests/sr_sync_stop_hang_repro_test.py
+++ b/tests/rptest/tests/sr_sync_stop_hang_repro_test.py
@@ -1,0 +1,75 @@
+# Scratch repro for the SR-sync shutdown hang (do not commit).
+#
+# Forces the race behind "Redpanda node docker-rp-X failed to stop in 30
+# seconds" in the SR sync suite: register a large flat subject set on the
+# source, create the link, wait until the destination import is underway, then
+# return. The @cluster decorator's post-test stop SIGTERMs the destination
+# brokers while the full-sync run is mid-import, so task::stop()'s runner-gate
+# close must drain an in-flight run whose awaits are not abort-responsive.
+#
+# Expected: hangs (>30s stop -> TimeoutError) at 1cbb0dbcee; the question under
+# test is whether PR #31101's stop-ordering fixes drain it cleanly.
+
+from typing import Any
+
+from ducktape.tests.test import TestContext
+from ducktape.utils.util import wait_until
+
+from rptest.services.cluster import cluster
+from rptest.services.multi_cluster_services import SecondaryClusterArgs
+from rptest.services.redpanda import SchemaRegistryConfig
+from rptest.tests.cluster_linking_schema_registry_sync_test import (
+    SchemaRegistrySyncMixin,
+)
+from rptest.tests.cluster_linking_test_base import ShadowLinkTestBase
+from rptest.tests.schema_registry_test import SchemaRegistryRedpandaClient
+
+
+class SchemaRegistrySyncStopHangReproTest(ShadowLinkTestBase, SchemaRegistrySyncMixin):
+    SUBJECTS = 600
+
+    def __init__(self, test_context: TestContext, *args: Any, **kwargs: Any):
+        source_sr_config = SchemaRegistryConfig()
+        source_sr_config.mode_mutability = True
+        super().__init__(
+            test_context,
+            secondary_cluster_args=SecondaryClusterArgs(
+                schema_registry_config=source_sr_config
+            ),
+            schema_registry_config=SchemaRegistryConfig(),
+            extra_rp_conf={"enable_leader_balancer": False},
+            *args,
+            **kwargs,
+        )
+
+    def _make_source_client(self) -> SchemaRegistryRedpandaClient:
+        return SchemaRegistryRedpandaClient(self.source_cluster_service)
+
+    @cluster(num_nodes=6)
+    def test_stop_mid_import(self):
+        src = self._make_source_client()
+        dest = SchemaRegistryRedpandaClient(self.target_cluster_service)
+
+        for i in range(self.SUBJECTS):
+            self._add_leaf(src, i)
+
+        self._create_sr_link()
+
+        def import_underway() -> bool:
+            resp = dest.get_subjects()
+            if resp.status_code != 200:
+                return False
+            n = len(resp.json())
+            self.logger.info(f"destination has imported {n} subjects")
+            # Import has begun but the bulk is still pending: returning now
+            # guarantees the post-test stop lands with many import fibers
+            # inside destination seq_writer operations.
+            return 5 <= n < 150
+
+        wait_until(
+            import_underway,
+            timeout_sec=120,
+            backoff_sec=0.2,
+            err_msg="import never reached the mid-flight window",
+        )
+        self.logger.info("returning with import in flight; teardown stops the cluster")


### PR DESCRIPTION
Draft for CI signal — the working diff is currently one WIP commit and will be split into a reviewable commit series before marking ready.

A broker stopping while a shadow-link Schema Registry sync is in flight can hang past ducktape's 30s stop timeout (the `SchemaRegistrySyncE2ETest` stop-timeout flake): `task::stop()` waits unbounded on the in-flight run, whose destination writes through `ppsr::seq_writer` never observe the task's abort_source, while application shutdown has already torn down the kafka path they retry against.

This threads a per-run abort handle from the mirroring task down through the destination write path so a stop request cuts through every wait:

- `utils/retry`: preserve the concrete abort exception type (was sliced to `std::exception`, defeating shutdown classification) and fix the accidentally-quadratic non-abort backoff sleep.
- `kafka/client`: `list_offsets`/`fetch_partition` accept an optional external abort source, composed with the client-internal one; threaded through the fetch batch reader.
- `pandaproxy/sr`: the `transport` read ops accept an abort source; `kafka_client_transport` forwards it and re-checks around calls (fetch can launder aborts into generic kafka errors); `seq_writer` takes an `ssx::sharded_abort_source*` on the sync-path write methods — abortable `_write_sem`/`_wait_for_sem` waits, abort-aware retry loop, threaded into `read_sync`'s catch-up consume.
- `schema::registry`: destination-write virtuals accept the handle (defaulted; HTTP handler paths unchanged).
- `cluster_link`: the mirroring task brackets each run with a per-run `ssx::sharded_abort_source` (the runner's abort lives on the `_schemas/0` leader shard; seq_writer blocks on shard zero), passes it at every destination call, and adds the missing per-item abort checks in the mode/config sweep and context enumeration.

Includes two shutdown-ordering fixes cherry-picked from #31101 (this branch is intended to land after it; a rebase will drop the duplicates).

Red/green coverage: a `seq_writer` unit test parks a write in a blocking transport and asserts the abort resolves it shutdown-classified; a mirroring-task test parks a destination import and asserts `stop()` drains the runner unaided; a ducktape test SIGTERMs the destination cluster mid-import (deterministically red before the fix: 4/4 stop-timeouts at the base commit, 3/4 with the ordering fixes alone, 4/4 clean here). The original e2e flake shape passes 24/24 under CPU load on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
