### PR TITLE
[DNM] baseline: SR sync shutdown-ordering fixes only (control for #31123)

### DIFF
--- a/src/v/cluster_link/link.cc
+++ b/src/v/cluster_link/link.cc
@@ -136,6 +136,14 @@ ss::future<> link::start() {
 }
 
 ss::future<> link::stop() noexcept {
+    // Idempotent AND join-safe: the removal handler and manager shutdown both
+    // stop links and can race during teardown. A late caller waits for the
+    // first stop to complete rather than returning early -- the removal
+    // handler destroys the link right after its stop() resolves, so an early
+    // return would free the link out from under the still-running first stop.
+    if (std::exchange(_stop_requested, true)) {
+        co_return co_await _stopped.get_shared_future();
+    }
     vlog(
       cllog.info,
       "Stopping cluster link {} ({})",
@@ -187,6 +195,9 @@ ss::future<> link::stop() noexcept {
     _probe.reset(nullptr);
 
     vlog(cllog.info, "Stopped link {} ({})", _config->name, _config->uuid);
+    // Release any callers joined on a concurrent stop; they may free the link
+    // as soon as this resolves.
+    _stopped.set_value();
 }
 
 ss::future<cl_result<void>> link::register_task(task_factory* tf) {

--- a/src/v/cluster_link/link.h
+++ b/src/v/cluster_link/link.h
@@ -22,6 +22,8 @@
 #include "ssx/mutex.h"
 #include "utils/notification_list.h"
 
+#include <seastar/core/shared_future.hh>
+
 namespace cluster_link {
 
 class link_probe;
@@ -153,5 +155,12 @@ private:
     std::unique_ptr<link_probe> _probe;
     ss::gate _gate;
     ss::abort_source _as;
+    // stop() is called by both the link-removal handler and manager shutdown,
+    // which can race. The first call does the work; later calls must wait for
+    // it to COMPLETE (not return early): the removal handler frees the link
+    // right after stop() resolves, so an early return would let it destroy
+    // the link while the first stop is still suspended inside it.
+    bool _stop_requested{false};
+    ss::shared_promise<> _stopped;
 };
 } // namespace cluster_link

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -150,15 +150,45 @@ ss::future<> manager::stop() {
     vlog(cllog.info, "Stopping cluster link manager");
 
     co_await on_controller_stepdown();
+    vlog(cllog.debug, "manager stop: controller stepdown complete");
 
-    co_await _queue.shutdown();
     _link_task_reconciler_timer.cancel();
     _as.request_abort();
     _link_created_cv.broken();
-    co_await _g.close();
-    for (auto& [_, link] : _links) {
+
+    // Stop the links (which aborts their tasks) BEFORE draining the work
+    // queue and the gate: a queued link-change handler or an in-flight
+    // reconcile tick can be blocked on task machinery that only unblocks once
+    // the tasks' run fibers are aborted. Draining first sequences that abort
+    // behind the very drain that waits on it, deadlocking shutdown until the
+    // node-stop timeout kills the process.
+    //
+    // The queue is still live here and its one executing item may mutate
+    // _links, so stop by id snapshot and re-lookup; a link created after the
+    // snapshot is caught by the sweep below.
+    chunked_vector<id_t> ids;
+    ids.reserve(_links.size());
+    for (const auto& [id, _] : _links) {
+        ids.push_back(id);
+    }
+    for (const auto& id : ids) {
+        if (auto it = _links.find(id); it != _links.end()) {
+            co_await it->second->stop();
+        }
+    }
+    vlog(cllog.debug, "manager stop: links stopped");
+
+    co_await _queue.shutdown();
+    vlog(cllog.debug, "manager stop: work queue drained");
+
+    // The queue is drained and the reconcile timer canceled, so _links is
+    // stable now; sweep up any link a mid-flight handler created after the
+    // snapshot (stop() is idempotent, so re-stopping the rest is a no-op).
+    for (const auto& [_, link] : _links) {
         co_await link->stop();
     }
+
+    co_await _g.close();
 
     vlog(cllog.info, "Cluster link manager stopped");
 }
@@ -880,6 +910,11 @@ ss::future<> manager::link_task_reconciler() {
     auto units = std::move(fut).get();
 
     for (const auto& [_, link] : _links) {
+        // Shutdown aborts before stopping links; registering a task on a
+        // link that is about to stop would leak a never-stopped runner.
+        if (_as.abort_requested()) {
+            co_return;
+        }
         vlog(
           cllog.trace,
           "Reconciling tasks for cluster link {} ({})",

--- a/src/v/cluster_link/schema_registry_sync/BUILD
+++ b/src/v/cluster_link/schema_registry_sync/BUILD
@@ -89,6 +89,7 @@ redpanda_cc_library(
         "//src/v/metrics",
         "//src/v/model",
         "//src/v/schema:registry",
+        "//src/v/ssx:mutex",
         "//src/v/ssx:semaphore",
         "@seastar",
     ],

--- a/src/v/cluster_link/schema_registry_sync/http_source_reader.cc
+++ b/src/v/cluster_link/schema_registry_sync/http_source_reader.cc
@@ -177,10 +177,25 @@ http_source_reader::http_source_reader(std::unique_ptr<rc::client> client)
 
 ss::future<source_result<rc::client*>>
 http_source_reader::ensure_client(ss::abort_source& as) {
+    // Checked before the fast path: stop() nulls _client, and a call arriving
+    // after stop (fibers may still be unwinding when the reader is stopped)
+    // must fail rather than rebuild a client nothing would ever stop.
+    if (_stopped) {
+        co_return std::unexpected(
+          source_error{
+            .kind = source_error_kind::source_unavailable,
+            .message = "source reader is stopped"});
+    }
     if (_client) {
         co_return _client.get();
     }
     auto build = co_await ss::get_units(_build, 1, as);
+    if (_stopped) {
+        co_return std::unexpected(
+          source_error{
+            .kind = source_error_kind::source_unavailable,
+            .message = "source reader is stopped"});
+    }
     if (_client) {
         co_return _client.get();
     }
@@ -389,7 +404,12 @@ ss::future<> http_source_reader::stop() {
     // Idempotent: the reader can be stopped more than once (e.g. an in-flight
     // reconciler stopping the task before link teardown stops it again). The
     // rest_client's gate must be closed exactly once, so release the client
-    // after shutting it down and skip it on a repeat call.
+    // after shutting it down and skip it on a repeat call. The sticky
+    // _stopped flag rejects post-stop rebuilds, and waiting out the build
+    // mutex means a build that raced this stop is shut down here rather than
+    // leaked.
+    _stopped = true;
+    auto build = co_await ss::get_units(_build, 1);
     if (auto client = std::move(_client); client) {
         co_await client->shutdown();
     }

--- a/src/v/cluster_link/schema_registry_sync/http_source_reader.h
+++ b/src/v/cluster_link/schema_registry_sync/http_source_reader.h
@@ -99,6 +99,10 @@ private:
     // Connection inputs for the lazy build; nullopt once a client is injected.
     std::optional<http_source_connection> _conn;
     std::unique_ptr<rc::client> _client;
+    // Set by stop(): the reader is stopped while the reconcile engine's
+    // fibers may still be unwinding, and a late call must fail rather than
+    // lazily rebuild the client (which nothing would ever stop).
+    bool _stopped{false};
     // Serializes the lazy client build only. Requests run concurrently: the
     // reconcile engine drives this reader from several fibers, and the
     // rest_client's pooled transport bounds them to one in-flight request per

--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.cc
@@ -154,31 +154,58 @@ ss::future<cl_result<void>> mirroring_task::start() {
 }
 
 ss::future<cl_result<void>> mirroring_task::stop() noexcept {
-    auto res = co_await task::stop();
-    _probe.clear();
-    // task::stop() closed the runner's gate, so no run_impl is in flight and it
-    // is safe to reset the state directly (unlike update_config, which races a
-    // running fiber and defers via _config_changed). Reset so a later leader
-    // starts fresh: this instance may regain _schemas/0 leadership (A->B->A)
-    // and would otherwise report a prior tenure's stale counters/inventory and
-    // skip its first full sync on a still-recent _last_full_sync.
-    reset_sync_state();
-    // The run loop has stopped, so no fiber is using the reader; release its
-    // HTTP transport. as_future guards the noexcept contract.
-    if (_reader) {
-        auto stopped = co_await ss::coroutine::as_future(_reader->stop());
-        if (stopped.failed()) {
-            auto ex = stopped.get_exception();
-            vlog(
-              logger().warn,
-              "Error stopping Schema Registry source reader: {}",
-              ex);
+    // Stop the reader BEFORE joining the run fiber: run_impl can be parked on
+    // reader-internal waits that only the reader's own shutdown aborts (the
+    // rate limiter's token queue and Retry-After pause -- up to 60s -- and the
+    // connection pool's slot queue are deaf to the runner's abort source).
+    // Joining first would sequence that abort behind the join that needs it.
+    // The reader is built to be stopped under fire: in-flight and queued
+    // requests fail promptly with abort-classified errors and run_impl
+    // unwinds. as_future guards the noexcept contract.
+    //
+    // Under _reader_lifecycle: run_impl is still live here (reader-first), so a
+    // concurrent reset_reader() could otherwise free the reader while this
+    // stop() is suspended mid-shutdown. The lock is dropped before the join
+    // below, so it cannot deadlock against a reset_reader() the join waits on.
+    {
+        auto reader_units = co_await _reader_lifecycle.get_units();
+        if (_reader) {
+            auto stopped = co_await ss::coroutine::as_future(_reader->stop());
+            if (stopped.failed()) {
+                auto ex = stopped.get_exception();
+                vlog(
+                  logger().warn,
+                  "Error stopping Schema Registry source reader: {}",
+                  ex);
+            }
         }
     }
+    auto res = co_await task::stop();
+    _probe.clear();
+    // task::stop() closed the runner's gate, so no run_impl is in flight and
+    // it is safe to reset the state directly (unlike update_config, which
+    // races a running fiber and defers via _config_changed). Reset so a later
+    // leader starts fresh: this instance may regain _schemas/0 leadership
+    // (A->B->A) and would otherwise report a prior tenure's stale
+    // counters/inventory and skip its first full sync on a still-recent
+    // _last_full_sync.
+    reset_sync_state();
+    // Replace the stopped reader with a fresh one for that possible A->B->A
+    // re-acquisition. The reader's stop() is permanent by design (it refuses
+    // to rebuild its client so an unwinding fiber cannot resurrect it during
+    // teardown), and run_impl only rebuilds the reader on a config change, so
+    // a restarted task would otherwise keep using the dead reader and never
+    // sync. No lock needed: the run fibers have been joined, so reset_reader()
+    // cannot run and none is mid-request on the old reader.
+    _reader = _source_factory->create(_config.api_mode());
     co_return res;
 }
 
 ss::future<> mirroring_task::reset_reader() {
+    // Serialize with stop() (see _reader_lifecycle): both stop and then free
+    // the reader by reassignment, and either can be suspended in the reader's
+    // shutdown when the other reaches the free.
+    auto reader_units = co_await _reader_lifecycle.get_units();
     if (_reader) {
         auto stopped = co_await ss::coroutine::as_future(_reader->stop());
         if (stopped.failed()) {

--- a/src/v/cluster_link/schema_registry_sync/mirroring_task.h
+++ b/src/v/cluster_link/schema_registry_sync/mirroring_task.h
@@ -17,6 +17,7 @@
 #include "cluster_link/task.h"
 #include "container/chunked_hash_map.h"
 #include "schema/registry.h"
+#include "ssx/mutex.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/util/noncopyable_function.hh>
@@ -237,6 +238,14 @@ private:
     schema::registry* _destination;
     source_reader_factory* _source_factory;
     std::unique_ptr<source_reader> _reader;
+    // Serializes stopping and replacing _reader. stop() (reader-first, while
+    // run_impl is still live) and reset_reader() (run by run_impl on a config
+    // change) both stop the reader and then free it via reassignment; without
+    // serialization one can free the reader while the other's stop() is
+    // suspended mid-shutdown, a use-after-free. Held only around the
+    // stop+reassign, never across the run-fiber join, so it cannot deadlock
+    // with task::stop().
+    ssx::mutex _reader_lifecycle{"cluster_link/sr_source/reader_lifecycle"};
     inventory _destination_inventory;
     model::schema_registry_sync_status _status;
     // Live counters for the in-flight reconcile; reflected by get_status_report

--- a/src/v/cluster_link/schema_registry_sync/tests/http_source_reader_test.cc
+++ b/src/v/cluster_link/schema_registry_sync/tests/http_source_reader_test.cc
@@ -113,6 +113,62 @@ TEST(http_source_reader, list_contexts_enumerates_all_contexts) {
         pps::default_context, pps::context{".dev"}, pps::context{".prod"}));
 }
 
+// Stopping the reader while a request is in flight aborts the request rather
+// than waiting for it out: mirroring_task::stop() stops the reader before
+// joining the run fibers, relying on exactly this to unwedge fibers parked in
+// reader-internal waits (rate-limiter token/pause queues, pool slots).
+TEST(http_source_reader, stop_aborts_in_flight_requests) {
+    std::deque<ss::promise<http::downloaded_response>> parked;
+    auto reader = reader_over([&](mock_client& m) {
+        ON_CALL(m, request_and_collect_response(_, _, _))
+          .WillByDefault([&](
+                           bh::request_header<>&&,
+                           std::optional<iobuf>,
+                           ss::lowres_clock::duration) {
+              parked.emplace_back();
+              return parked.back().get_future();
+          });
+        // Like the real transport, shutdown fails the requests it is
+        // servicing.
+        ON_CALL(m, shutdown_and_stop()).WillByDefault([&] {
+            for (auto& request : parked) {
+                request.set_exception(
+                  std::make_exception_ptr(ss::abort_requested_exception{}));
+            }
+            parked.clear();
+            return ss::make_ready_future<>();
+        });
+    });
+    ss::abort_source as;
+    auto req = reader.list_contexts(as);
+    RPTEST_REQUIRE_EVENTUALLY(5s, [&] { return !parked.empty(); });
+
+    reader.stop().get();
+    auto res = req.get();
+    ASSERT_FALSE(res.has_value());
+    EXPECT_EQ(res.error().kind, srs::source_error_kind::source_unavailable);
+}
+
+// A reader call after stop() must fail fast instead of lazily rebuilding the
+// client: the reconcile engine's fibers can still be unwinding when the
+// reader is stopped, and a rebuilt client would never be shut down.
+TEST(http_source_reader, calls_after_stop_fail_without_rebuild) {
+    srs::http_source_connection conn{
+      .address = net::unresolved_address("example.invalid", 8081),
+      .endpoint = "http://example.invalid:8081",
+    };
+    srs::http_source_reader reader{std::move(conn)};
+    reader.stop().get();
+
+    ss::abort_source as;
+    auto res = reader.list_contexts(as).get();
+    ASSERT_FALSE(res.has_value());
+    EXPECT_EQ(res.error().kind, srs::source_error_kind::source_unavailable);
+    EXPECT_THAT(res.error().message, HasSubstr("stopped"));
+    // stop() stays idempotent.
+    reader.stop().get();
+}
+
 // stop() is idempotent: the task teardown can stop the reader more than once
 // (an in-flight reconciler stopping the task before link teardown stops it
 // again). A second stop() must not double-close the rest_client's gate, which

--- a/tests/rptest/tests/sr_sync_stop_hang_repro_test.py
+++ b/tests/rptest/tests/sr_sync_stop_hang_repro_test.py
@@ -1,0 +1,75 @@
+# Scratch repro for the SR-sync shutdown hang (do not commit).
+#
+# Forces the race behind "Redpanda node docker-rp-X failed to stop in 30
+# seconds" in the SR sync suite: register a large flat subject set on the
+# source, create the link, wait until the destination import is underway, then
+# return. The @cluster decorator's post-test stop SIGTERMs the destination
+# brokers while the full-sync run is mid-import, so task::stop()'s runner-gate
+# close must drain an in-flight run whose awaits are not abort-responsive.
+#
+# Expected: hangs (>30s stop -> TimeoutError) at 1cbb0dbcee; the question under
+# test is whether PR #31101's stop-ordering fixes drain it cleanly.
+
+from typing import Any
+
+from ducktape.tests.test import TestContext
+from ducktape.utils.util import wait_until
+
+from rptest.services.cluster import cluster
+from rptest.services.multi_cluster_services import SecondaryClusterArgs
+from rptest.services.redpanda import SchemaRegistryConfig
+from rptest.tests.cluster_linking_schema_registry_sync_test import (
+    SchemaRegistrySyncMixin,
+)
+from rptest.tests.cluster_linking_test_base import ShadowLinkTestBase
+from rptest.tests.schema_registry_test import SchemaRegistryRedpandaClient
+
+
+class SchemaRegistrySyncStopHangReproTest(ShadowLinkTestBase, SchemaRegistrySyncMixin):
+    SUBJECTS = 600
+
+    def __init__(self, test_context: TestContext, *args: Any, **kwargs: Any):
+        source_sr_config = SchemaRegistryConfig()
+        source_sr_config.mode_mutability = True
+        super().__init__(
+            test_context,
+            secondary_cluster_args=SecondaryClusterArgs(
+                schema_registry_config=source_sr_config
+            ),
+            schema_registry_config=SchemaRegistryConfig(),
+            extra_rp_conf={"enable_leader_balancer": False},
+            *args,
+            **kwargs,
+        )
+
+    def _make_source_client(self) -> SchemaRegistryRedpandaClient:
+        return SchemaRegistryRedpandaClient(self.source_cluster_service)
+
+    @cluster(num_nodes=6)
+    def test_stop_mid_import(self):
+        src = self._make_source_client()
+        dest = SchemaRegistryRedpandaClient(self.target_cluster_service)
+
+        for i in range(self.SUBJECTS):
+            self._add_leaf(src, i)
+
+        self._create_sr_link()
+
+        def import_underway() -> bool:
+            resp = dest.get_subjects()
+            if resp.status_code != 200:
+                return False
+            n = len(resp.json())
+            self.logger.info(f"destination has imported {n} subjects")
+            # Import has begun but the bulk is still pending: returning now
+            # guarantees the post-test stop lands with many import fibers
+            # inside destination seq_writer operations.
+            return 5 <= n < 150
+
+        wait_until(
+            import_underway,
+            timeout_sec=120,
+            backoff_sec=0.2,
+            err_msg="import never reached the mid-flight window",
+        )
+        self.logger.info("returning with import in flight; teardown stops the cluster")


### PR DESCRIPTION
**Do not merge — CI control run.**

Baseline for comparing against #31123: the two shutdown-ordering fixes cherry-picked from #31101, plus the stop-hang repro ducktape test, **without** the abort_source threading. Running the same targeted `/ci-repeat` exercises on both branches quantifies how much of the SR-sync stop-timeout hang the ordering fixes resolve on their own versus with the destination write path made abort-aware.

Local baseline for reference: the forced mid-import repro hangs 3/4 on this stack (4/4 at the base commit, 4/4 clean with the abort threading).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
