### PR TITLE
[CORE-16770] rptest: use FIPS-valid password in rpk shadow-link e2e

### DIFF
--- a/tests/rptest/tests/rpk_shadow_link_test.py
+++ b/tests/rptest/tests/rpk_shadow_link_test.py
@@ -165,7 +165,7 @@ class RpkShadowLinkTest(ShadowLinkTestBase):
         return the ACL fields expected to appear on the shadow cluster."""
         user = "shadow-user"
         acl_topic = "acl-topic"
-        self.source_cluster_rpk.sasl_create_user(user, "shadow-pass")
+        self.source_cluster_rpk.sasl_create_user(user, "shadow-pass-1234")
         self.source_cluster_rpk.acl_create(
             RPKACLInput(
                 allow_principal=[user],


### PR DESCRIPTION
`_seed_source_acl` created a SASL user with an 11-char password. Under
FIPS, the admin API requires SCRAM passwords of at least 14 chars, so
the test failed during setup in the FIPS nightly CDT run. Bump the
fixture password to 16 chars.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

