### PR TITLE
dt: fail fast when Confluent SR binary is missing

### DIFF
--- a/tests/rptest/services/confluent_schema_registry.py
+++ b/tests/rptest/services/confluent_schema_registry.py
@@ -81,6 +81,13 @@ class ConfluentSchemaRegistryService(Service):
         return node.account.java_pids("SchemaRegistryMain")
 
     def start_node(self, node, **kwargs):
+        if not node.account.exists(SR_BIN):
+            raise RuntimeError(
+                f"Confluent SR binary not found at {SR_BIN} on "
+                f"{node.account.hostname}. The Confluent Platform install "
+                f"({CP_DIR}) is missing or incomplete on this node's image"
+            )
+
         props = self._properties()
         self.logger.info(f"Starting Confluent SR on {node.account.hostname}\n{props}")
         with tempfile.NamedTemporaryFile(mode="w") as f:


### PR DESCRIPTION
When the Confluent Platform install (/opt/confluent) is absent, e.g.
on nodes whose image never provisioned it, schema-registry-start exits
immediately and start_node only surfaced a mute 90s "did not become
reachable" timeout.

Check for the binary up front and raise a clear error naming the
missing install, so the failure is diagnosable at a glance instead of
after the full wait.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

