### PR TITLE
tests: pause shadow-link SR sync before cluster shutdown to avoid stop timeout

### DIFF
--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -103,6 +103,10 @@ CONTROLLER_LOCKED_TASKS = [
     "Roles Migrator Task",
 ]
 
+# Matches mirroring_task::task_name in
+# src/v/cluster_link/schema_registry_sync/mirroring_task.h
+SCHEMA_REGISTRY_SYNC_TASK_NAME = "Schema Registry Shadowing"
+
 ALL_STORAGE_MODES = [
     TopicSpec.STORAGE_MODE_LOCAL,
     TopicSpec.STORAGE_MODE_IMPL_TIERED_V1,
@@ -605,6 +609,16 @@ class ShadowLinkTestBase(PreallocNodesTest):
     the target cluster. Secondary service is used as the source cluster.
     """
 
+    # Pause Schema Registry API-mode sync and wait for the sync task to park
+    # before the target cluster is stopped, so shutdown never overlaps an
+    # in-flight sync (an overlap can stall shutdown long enough to time the
+    # test out). Set False (class- or instance-level) to opt out, e.g. for
+    # tests that deliberately exercise shutdown during a sync.
+    pause_sr_sync_before_shutdown: bool = True
+    # The drain must outlast a mid-flight sync's destination write retries
+    # (~70s worst case) on a loaded debug machine.
+    sr_sync_pause_timeout_sec: int = 120
+
     def __init__(
         self,
         test_context: TestContext,
@@ -770,6 +784,92 @@ class ShadowLinkTestBase(PreallocNodesTest):
         self.admin_v2 = AdminV2(self.target_cluster_service)
         self.service_client = self.admin_v2.shadow_link()
         self.internal_service_client = self.admin_v2.internal_shadow_link()
+        self._install_sr_sync_pause_hook()
+
+    def _install_sr_sync_pause_hook(self) -> None:
+        """Make the target service's stop() pause SR sync first. The @cluster
+        decorator stops the target cluster inside the test wrapper, before
+        tearDown runs, so a tearDown hook would fire only after the cluster is
+        already gone; wrapping stop() runs the pause right before any stop of
+        a live cluster, on both the passed and failed paths, while both
+        clusters are still up."""
+        target = self.target_cluster_service
+        original_stop = target.stop
+
+        def stop_with_sr_sync_pause(**kwargs: Any) -> None:
+            # Skip when nothing is running: ducktape's teardown stops services
+            # again after the decorator already stopped this one, and a pause
+            # attempt against a stopped cluster would only log a spurious
+            # warning. Any stop of a live cluster (including a mid-test one)
+            # pauses first.
+            if self.pause_sr_sync_before_shutdown and target.started_nodes():
+                try:
+                    self._pause_schema_registry_sync(self.sr_sync_pause_timeout_sec)
+                except Exception:
+                    # Best effort: a failed pause must not replace the test's
+                    # own result; shutdown just proceeds with the usual
+                    # overlap odds.
+                    self.logger.warn(
+                        "failed to pause Schema Registry sync before shutdown",
+                        exc_info=True,
+                    )
+            original_stop(**kwargs)
+
+        target.stop = stop_with_sr_sync_pause
+
+    def _pause_schema_registry_sync(self, timeout_sec: int) -> None:
+        """Pause Schema Registry API-mode sync on every link and wait until
+        the sync task is parked, so no sync is running when the clusters
+        shut down."""
+        for link in self.list_links():
+            sr = link.configurations.schema_registry_sync_options
+            if not sr.HasField("shadow_schema_registry_api"):
+                continue
+            link_name = link.name
+            if not sr.shadow_schema_registry_api.paused:
+                self.logger.info(
+                    f"Pausing Schema Registry sync on link {link_name} before shutdown"
+                )
+                sr.shadow_schema_registry_api.paused = True
+                self.update_link(
+                    shadow_link=link,
+                    update_mask=google.protobuf.field_mask_pb2.FieldMask(
+                        paths=[
+                            "configurations.schema_registry_sync_options"
+                            ".shadow_schema_registry_api.paused"
+                        ]
+                    ),
+                )
+
+            def sr_task_parked() -> bool:
+                status = self.get_link(link_name).status
+                for task in status.task_statuses:
+                    if task.name == SCHEMA_REGISTRY_SYNC_TASK_NAME:
+                        if task.state not in (
+                            shadow_link_pb2.TASK_STATE_PAUSED,
+                            shadow_link_pb2.TASK_STATE_NOT_RUNNING,
+                        ):
+                            return False
+                        # The task reports PAUSED before its in-flight run
+                        # has drained (task::pause flips the state, then
+                        # closes the runner gate), so PAUSED alone is not
+                        # proof the sync stopped. current_sync clears only
+                        # when the run actually exits; require that too.
+                        return not status.schema_registry_sync_status.HasField(
+                            "current_sync"
+                        )
+                # No task entry: nothing is running, so nothing to drain.
+                return True
+
+            wait_until(
+                sr_task_parked,
+                timeout_sec=timeout_sec,
+                backoff_sec=1,
+                err_msg=(
+                    f"Schema Registry sync task on link {link_name} "
+                    "did not pause before shutdown"
+                ),
+            )
 
     @property
     def source_cluster(self) -> Cluster:


### PR DESCRIPTION
A Schema Registry API-mode sync that is still in flight when a cluster shuts down can stall shutdown long enough that the test times out. This shows up as CI flakiness in the shadow-link Schema Registry sync suites, where a periodic sync can overlap the end-of-test stop.

This PR wraps the target service's `stop()` in `ShadowLinkTestBase` so that stopping a live cluster first pauses SR API-mode sync on every shadow link and waits for the sync task to park before any broker is signalled. The `@cluster` decorator stops the target cluster inside the test wrapper (before `tearDown`), on both pass and fail paths, so hooking `stop()` is the only placement that runs ahead of the stop that actually times out. Running the pause while both clusters are still up also means the in-flight sync can drain against a live source, and a paused task cannot be restarted on a surviving node if `_schemas/0` leadership moves while brokers shut down (a newly started task always runs a full sync immediately, so that would otherwise recreate the overlap).

The hook is best effort (a failed pause only logs a warning and never replaces the test's own result), skips silently when no nodes are running (ducktape's teardown stops the service again after the decorator already has), and is a no-op for tests without SR API-mode sync configured. Tests can opt out via the `pause_sr_sync_before_shutdown` class/instance attribute, e.g. a future regression test that deliberately exercises shutdown during a sync.

This is a temporary measure to reduce CI flakiness until a proper shutdown fix lands that makes an in-flight sync abort promptly.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
