### PR TITLE
[DO NOT MERGE] tests: worst-case straddle arm for SR sync deflake A/B

### DIFF
--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -103,6 +103,10 @@ CONTROLLER_LOCKED_TASKS = [
     "Roles Migrator Task",
 ]
 
+# Matches mirroring_task::task_name in
+# src/v/cluster_link/schema_registry_sync/mirroring_task.h
+SCHEMA_REGISTRY_SYNC_TASK_NAME = "Schema Registry Shadowing"
+
 ALL_STORAGE_MODES = [
     TopicSpec.STORAGE_MODE_LOCAL,
     TopicSpec.STORAGE_MODE_IMPL_TIERED_V1,
@@ -605,6 +609,16 @@ class ShadowLinkTestBase(PreallocNodesTest):
     the target cluster. Secondary service is used as the source cluster.
     """
 
+    # Pause Schema Registry API-mode sync and wait for the sync task to park
+    # before the target cluster is stopped, so shutdown never overlaps an
+    # in-flight sync (an overlap can stall shutdown long enough to time the
+    # test out). Set False (class- or instance-level) to opt out, e.g. for
+    # tests that deliberately exercise shutdown during a sync.
+    pause_sr_sync_before_shutdown: bool = True
+    # The drain must outlast a mid-flight sync's destination write retries
+    # (~70s worst case) on a loaded debug machine.
+    sr_sync_pause_timeout_sec: int = 120
+
     def __init__(
         self,
         test_context: TestContext,
@@ -770,6 +784,92 @@ class ShadowLinkTestBase(PreallocNodesTest):
         self.admin_v2 = AdminV2(self.target_cluster_service)
         self.service_client = self.admin_v2.shadow_link()
         self.internal_service_client = self.admin_v2.internal_shadow_link()
+        self._install_sr_sync_pause_hook()
+
+    def _install_sr_sync_pause_hook(self) -> None:
+        """Make the target service's stop() pause SR sync first. The @cluster
+        decorator stops the target cluster inside the test wrapper, before
+        tearDown runs, so a tearDown hook would fire only after the cluster is
+        already gone; wrapping stop() runs the pause right before any stop of
+        a live cluster, on both the passed and failed paths, while both
+        clusters are still up."""
+        target = self.target_cluster_service
+        original_stop = target.stop
+
+        def stop_with_sr_sync_pause(**kwargs: Any) -> None:
+            # Skip when nothing is running: ducktape's teardown stops services
+            # again after the decorator already stopped this one, and a pause
+            # attempt against a stopped cluster would only log a spurious
+            # warning. Any stop of a live cluster (including a mid-test one)
+            # pauses first.
+            if self.pause_sr_sync_before_shutdown and target.started_nodes():
+                try:
+                    self._pause_schema_registry_sync(self.sr_sync_pause_timeout_sec)
+                except Exception:
+                    # Best effort: a failed pause must not replace the test's
+                    # own result; shutdown just proceeds with the usual
+                    # overlap odds.
+                    self.logger.warn(
+                        "failed to pause Schema Registry sync before shutdown",
+                        exc_info=True,
+                    )
+            original_stop(**kwargs)
+
+        target.stop = stop_with_sr_sync_pause
+
+    def _pause_schema_registry_sync(self, timeout_sec: int) -> None:
+        """Pause Schema Registry API-mode sync on every link and wait until
+        the sync task is parked, so no sync is running when the clusters
+        shut down."""
+        for link in self.list_links():
+            sr = link.configurations.schema_registry_sync_options
+            if not sr.HasField("shadow_schema_registry_api"):
+                continue
+            link_name = link.name
+            if not sr.shadow_schema_registry_api.paused:
+                self.logger.info(
+                    f"Pausing Schema Registry sync on link {link_name} before shutdown"
+                )
+                sr.shadow_schema_registry_api.paused = True
+                self.update_link(
+                    shadow_link=link,
+                    update_mask=google.protobuf.field_mask_pb2.FieldMask(
+                        paths=[
+                            "configurations.schema_registry_sync_options"
+                            ".shadow_schema_registry_api.paused"
+                        ]
+                    ),
+                )
+
+            def sr_task_parked() -> bool:
+                status = self.get_link(link_name).status
+                for task in status.task_statuses:
+                    if task.name == SCHEMA_REGISTRY_SYNC_TASK_NAME:
+                        if task.state not in (
+                            shadow_link_pb2.TASK_STATE_PAUSED,
+                            shadow_link_pb2.TASK_STATE_NOT_RUNNING,
+                        ):
+                            return False
+                        # The task reports PAUSED before its in-flight run
+                        # has drained (task::pause flips the state, then
+                        # closes the runner gate), so PAUSED alone is not
+                        # proof the sync stopped. current_sync clears only
+                        # when the run actually exits; require that too.
+                        return not status.schema_registry_sync_status.HasField(
+                            "current_sync"
+                        )
+                # No task entry: nothing is running, so nothing to drain.
+                return True
+
+            wait_until(
+                sr_task_parked,
+                timeout_sec=timeout_sec,
+                backoff_sec=1,
+                err_msg=(
+                    f"Schema Registry sync task on link {link_name} "
+                    "did not pause before shutdown"
+                ),
+            )
 
     @property
     def source_cluster(self) -> Cluster:

--- a/tests/rptest/tests/sr_sync_stop_hang_repro_test.py
+++ b/tests/rptest/tests/sr_sync_stop_hang_repro_test.py
@@ -1,0 +1,75 @@
+# Scratch repro for the SR-sync shutdown hang (do not commit).
+#
+# Forces the race behind "Redpanda node docker-rp-X failed to stop in 30
+# seconds" in the SR sync suite: register a large flat subject set on the
+# source, create the link, wait until the destination import is underway, then
+# return. The @cluster decorator's post-test stop SIGTERMs the destination
+# brokers while the full-sync run is mid-import, so task::stop()'s runner-gate
+# close must drain an in-flight run whose awaits are not abort-responsive.
+#
+# Expected: hangs (>30s stop -> TimeoutError) at 1cbb0dbcee; the question under
+# test is whether PR #31101's stop-ordering fixes drain it cleanly.
+
+from typing import Any
+
+from ducktape.tests.test import TestContext
+from ducktape.utils.util import wait_until
+
+from rptest.services.cluster import cluster
+from rptest.services.multi_cluster_services import SecondaryClusterArgs
+from rptest.services.redpanda import SchemaRegistryConfig
+from rptest.tests.cluster_linking_schema_registry_sync_test import (
+    SchemaRegistrySyncMixin,
+)
+from rptest.tests.cluster_linking_test_base import ShadowLinkTestBase
+from rptest.tests.schema_registry_test import SchemaRegistryRedpandaClient
+
+
+class SchemaRegistrySyncStopHangReproTest(ShadowLinkTestBase, SchemaRegistrySyncMixin):
+    SUBJECTS = 600
+
+    def __init__(self, test_context: TestContext, *args: Any, **kwargs: Any):
+        source_sr_config = SchemaRegistryConfig()
+        source_sr_config.mode_mutability = True
+        super().__init__(
+            test_context,
+            secondary_cluster_args=SecondaryClusterArgs(
+                schema_registry_config=source_sr_config
+            ),
+            schema_registry_config=SchemaRegistryConfig(),
+            extra_rp_conf={"enable_leader_balancer": False},
+            *args,
+            **kwargs,
+        )
+
+    def _make_source_client(self) -> SchemaRegistryRedpandaClient:
+        return SchemaRegistryRedpandaClient(self.source_cluster_service)
+
+    @cluster(num_nodes=6)
+    def test_stop_mid_import(self):
+        src = self._make_source_client()
+        dest = SchemaRegistryRedpandaClient(self.target_cluster_service)
+
+        for i in range(self.SUBJECTS):
+            self._add_leaf(src, i)
+
+        self._create_sr_link()
+
+        def import_underway() -> bool:
+            resp = dest.get_subjects()
+            if resp.status_code != 200:
+                return False
+            n = len(resp.json())
+            self.logger.info(f"destination has imported {n} subjects")
+            # Import has begun but the bulk is still pending: returning now
+            # guarantees the post-test stop lands with many import fibers
+            # inside destination seq_writer operations.
+            return 5 <= n < 150
+
+        wait_until(
+            import_underway,
+            timeout_sec=120,
+            backoff_sec=0.2,
+            err_msg="import never reached the mid-flight window",
+        )
+        self.logger.info("returning with import in flight; teardown stops the cluster")

--- a/tools/type-checking/type-check-strictness.json
+++ b/tools/type-checking/type-check-strictness.json
@@ -203,6 +203,7 @@
         "rptest/tests/services_self_test.py",
         "rptest/tests/shadow_indexing_firewall_test.py",
         "rptest/tests/shadow_link_sr_preflight_test.py",
+        "rptest/tests/sr_sync_stop_hang_repro_test.py",
         "rptest/tests/storage_failure_injection_test.py",
         "rptest/tests/strict_data_init_test.py",
         "rptest/tests/tiered_storage_enable_test.py",


### PR DESCRIPTION
**DO NOT MERGE — CI experiment arm.**

Worst-case validation for the test-side SR sync deflake in #31132. This branch is #31132's commit plus a cherry-pick of the forced-straddle repro test from the #31123 A/B baseline: it seeds 600 subjects on the source, waits until the destination import is mid-flight, and returns, so the post-test stop lands while a deep sync is in progress. At the #31123 A/B baseline this test hung 30/30 in CI ("failed to stop in 30 seconds").

The question under test: does the pause-before-shutdown hook from #31132 drain even a deep mid-import sync within its 60s window, or does the deflake only cover the shallow-sync case? Expected result if the hook holds: the repro test passes.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
