### PR TITLE
schema_registry: load _schemas once across shards on startup

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3994,6 +3994,15 @@ configuration::configuration()
       "replayed record is compiled sequentially during the replay.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       true)
+  , schema_registry_replay_on_startup(
+      *this,
+      "schema_registry_replay_on_startup",
+      "Replay the internal `_schemas` topic into the store at Schema Registry "
+      "start-up instead of lazily on the first request. Makes recovery time "
+      "predictable and keeps the first request from blocking behind a full "
+      "replay.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      false)
   , schema_registry_avro_use_named_references(
       *this, "schema_registry_avro_use_named_references")
   , schema_registry_enable_qualified_subjects(

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -685,6 +685,7 @@ struct configuration final : public config_store {
     enterprise<property<bool>> schema_registry_enable_authorization;
     property<bool> schema_registry_always_normalize;
     property<bool> schema_registry_deferred_recovery;
+    property<bool> schema_registry_replay_on_startup;
     deprecated_property schema_registry_avro_use_named_references;
     property<bool> schema_registry_enable_qualified_subjects;
     bounded_property<size_t> schema_registry_sync_memory_bytes;

--- a/src/v/pandaproxy/schema_registry/BUILD
+++ b/src/v/pandaproxy/schema_registry/BUILD
@@ -477,6 +477,7 @@ redpanda_cc_library(
         "//src/v/security:request_auth",
         "//src/v/security/audit",
         "//src/v/security/audit:types",
+        "//src/v/ssx:future_util",
         "//src/v/ssx:semaphore",
         "//src/v/ssx:sformat",
         "//src/v/strings:string_switch",

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -587,6 +587,24 @@ server::routes_t get_schema_registry_routes(ss::gate& gate, one_shot& es) {
     return routes;
 }
 
+ss::future<> service::ensure_topic_loaded() {
+    // `service` is a peering_sharded_service, so each shard has its own
+    // `_ensure_started` one_shot. If the first requests after start-up land on
+    // several shards at once, each shard's one_shot would independently run
+    // do_start() and launch its own full `_schemas` replay on the reader
+    // shard. Redundant replays each pay the full recovery cost, so N racing
+    // shards make recovery up to N times slower.
+    //
+    // Funnel all shards through a single one_shot on the reader shard, so the
+    // topic is loaded exactly once. The per-shard `_ensure_started` one_shot
+    // still caches completion, so once started this costs nothing on later
+    // requests; only the first request on each shard pays the cross-shard hop.
+    return container().invoke_on(
+      seq_writer::reader_shard, _ctx.smp_sg, [](service& s) {
+          return s._load_once();
+      });
+}
+
 ss::future<> service::do_start() {
     if (_is_started) {
         co_return;
@@ -795,7 +813,8 @@ service::service(
   , _topic_metadata_cache(std::move(topic_metadata_cache))
   , _controller(controller)
   , _audit_mgr(audit_mgr)
-  , _ensure_started{[this]() { return do_start(); }}
+  , _ensure_started{[this]() { return ensure_topic_loaded(); }}
+  , _load_once{[this]() { return do_start(); }}
   , _auth{
       config::always_true(),
       config::shard_local_cfg().superusers.bind(),

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -36,6 +36,7 @@
 #include "security/audit/audit_log_manager.h"
 #include "security/authorizer.h"
 #include "security/request_auth.h"
+#include "ssx/future-util.h"
 #include "ssx/semaphore.h"
 #include "utils/tristate.h"
 
@@ -823,10 +824,30 @@ service::service(
 ss::future<> service::start() {
     static std::vector<model::broker_endpoint> not_advertised{};
     _server.routes(get_schema_registry_routes(_gate, _ensure_started));
-    co_return co_await _server.start(
+    co_await _server.start(
       _config.schema_registry_api(),
       _config.schema_registry_api_tls(),
       not_advertised);
+
+    if (
+      ss::this_shard_id() == seq_writer::reader_shard
+      && config::shard_local_cfg().schema_registry_replay_on_startup()) {
+        // Proactively hydrate the store rather than wait for the first request.
+        // Fire-and-forget under the gate: a large topic can take a while to
+        // replay and must not block broker start-up. This goes through the
+        // single-flight ensure_started(), so a request that races it still
+        // triggers exactly one replay.
+        ssx::spawn_with_gate(_gate, [this] {
+            return ensure_started().handle_exception(
+              [](const std::exception_ptr& e) {
+                  vlog(
+                    srlog.warn,
+                    "eager _schemas replay failed at start-up; will retry on "
+                    "the first request: {}",
+                    e);
+              });
+        });
+    }
 }
 
 ss::future<> service::stop() {

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -606,9 +606,12 @@ ss::future<> service::ensure_topic_loaded() {
 }
 
 ss::future<> service::do_start() {
-    if (_is_started) {
-        co_return;
-    }
+    // Invoked only on the reader shard, via _load_once, so it runs exactly
+    // once and can drive the reader-shard-only fetch directly.
+    vassert(
+      ss::this_shard_id() == seq_writer::reader_shard,
+      "do_start must run on the reader shard, not {}",
+      ss::this_shard_id());
     auto guard = _gate.hold();
     try {
         co_await create_internal_topic();
@@ -623,60 +626,51 @@ ss::future<> service::do_start() {
           std::current_exception());
         throw;
     }
-    co_await container().invoke_on_all(
-      _ctx.smp_sg, [](this auto, service& s) -> ss::future<> {
-          s._is_started = true;
-          if (ss::this_shard_id() != seq_writer::reader_shard) {
-              co_return;
-          }
+    using namespace std::chrono_literals;
 
-          using namespace std::chrono_literals;
-
-          // create_internal_topic returns once the controller commits
-          // the topic, but the metadata cache and partition leadership
-          // are established asynchronously. Retry transient errors in
-          // that window with exponential backoff (100ms..5s, ~26s total).
-          constexpr int max_attempts = 10;
-          constexpr auto max_backoff = 5000ms;
-          auto backoff = 100ms;
-          for (int attempts = 0;; ++attempts) {
-              auto fut = co_await ss::coroutine::as_future(
-                s.fetch_internal_topic());
-              if (!fut.failed()) {
-                  co_return;
-              }
-              auto eptr = fut.get_exception();
-              if (attempts >= max_attempts) {
-                  std::rethrow_exception(eptr);
-              }
-              try {
-                  std::rethrow_exception(eptr);
-              } catch (const kafka::exception_base& e) {
-                  if (!kafka::is_retriable(e.error)) {
-                      throw;
-                  }
-              } catch (const exception& e) {
-                  // kafka_client_transport wraps "topic missing" as
-                  // unknown_server_error via schema_registry::exception.
-                  // treat this as retriable and rethrow anything else.
-                  if (e.code() != kafka::error_code::unknown_server_error) {
-                      throw;
-                  }
-              }
-              vlog(
-                srlog.info,
-                "Retriable error encountered while initializing the schemas "
-                "topic: {}. Retrying in {}ms",
-                eptr,
-                backoff.count());
-              try {
-                  co_await ss::sleep_abortable(backoff, s._as);
-              } catch (const ss::sleep_aborted&) {
-                  std::rethrow_exception(eptr);
-              }
-              backoff = std::min(backoff * 2, max_backoff);
-          }
-      });
+    // create_internal_topic returns once the controller commits the topic,
+    // but the metadata cache and partition leadership are established
+    // asynchronously. Retry transient errors in that window with exponential
+    // backoff (100ms..5s, ~26s total).
+    constexpr int max_attempts = 10;
+    constexpr auto max_backoff = 5000ms;
+    auto backoff = 100ms;
+    for (int attempts = 0;; ++attempts) {
+        auto fut = co_await ss::coroutine::as_future(fetch_internal_topic());
+        if (!fut.failed()) {
+            co_return;
+        }
+        auto eptr = fut.get_exception();
+        if (attempts >= max_attempts) {
+            std::rethrow_exception(eptr);
+        }
+        try {
+            std::rethrow_exception(eptr);
+        } catch (const kafka::exception_base& e) {
+            if (!kafka::is_retriable(e.error)) {
+                throw;
+            }
+        } catch (const exception& e) {
+            // kafka_client_transport wraps "topic missing" as
+            // unknown_server_error via schema_registry::exception.
+            // treat this as retriable and rethrow anything else.
+            if (e.code() != kafka::error_code::unknown_server_error) {
+                throw;
+            }
+        }
+        vlog(
+          srlog.info,
+          "Retriable error encountered while initializing the schemas "
+          "topic: {}. Retrying in {}ms",
+          eptr,
+          backoff.count());
+        try {
+            co_await ss::sleep_abortable(backoff, _as);
+        } catch (const ss::sleep_aborted&) {
+            std::rethrow_exception(eptr);
+        }
+        backoff = std::min(backoff * 2, max_backoff);
+    }
 }
 
 ss::future<> service::ensure_internal_topic() {

--- a/src/v/pandaproxy/schema_registry/service.h
+++ b/src/v/pandaproxy/schema_registry/service.h
@@ -69,6 +69,7 @@ public:
     std::unique_ptr<cluster::controller>& controller() { return _controller; }
 
 private:
+    // Only ever invoked on the reader shard, via _load_once.
     ss::future<> do_start();
     /// Route every shard's start-up through a single one_shot on the reader
     /// shard, so the `_schemas` topic is replayed exactly once regardless of
@@ -101,7 +102,6 @@ private:
     // once, no matter how many shards enter start-up concurrently.
     one_shot _load_once;
     request_authenticator _auth;
-    bool _is_started{false};
 };
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/service.h
+++ b/src/v/pandaproxy/schema_registry/service.h
@@ -70,6 +70,11 @@ public:
 
 private:
     ss::future<> do_start();
+    /// Route every shard's start-up through a single one_shot on the reader
+    /// shard, so the `_schemas` topic is replayed exactly once regardless of
+    /// how many shards receive their first request concurrently. See the
+    /// definition for why the per-shard one_shots would otherwise race.
+    ss::future<> ensure_topic_loaded();
     ss::future<> create_internal_topic();
     ss::future<> fetch_internal_topic();
     configuration _config;
@@ -88,7 +93,13 @@ private:
     ss::sharded<security::audit::audit_log_manager>& _audit_mgr;
     ss::abort_source _as;
 
+    // Per-shard: caches that start-up has completed on this shard, giving a
+    // cheap fast path for subsequent requests. Its action delegates to
+    // `_load_once` on the reader shard.
     one_shot _ensure_started;
+    // Reader shard only: the single authority that runs `do_start()` exactly
+    // once, no matter how many shards enter start-up concurrently.
+    one_shot _load_once;
     request_authenticator _auth;
     bool _is_started{false};
 };

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -12134,3 +12134,108 @@ class SchemaRegistryStartupRecoveryTest(RedpandaTest):
         )
         assert r.status_code == requests.codes.ok, r.text
         assert len(r.json()) >= self.N_SUBJECTS
+
+    @cluster(num_nodes=3, log_allow_list=_SR_STARTUP_RECOVERY_LOG_ALLOW_LIST)
+    def test_replay_on_startup_without_request(self):
+        """
+        With schema_registry_replay_on_startup enabled, the store must hydrate
+        proactively at startup without any client request driving it.
+
+        admin restart_service re-runs service::start() (via api::restart ->
+        start -> service::start), which is where the eager trigger lives, and
+        does not restart the broker process, so the log persists and we can
+        watch for the replay without touching the SR API.
+        """
+        node = self.redpanda.nodes[0]
+        host = node.account.hostname
+
+        # Populate _schemas so a restart has a topic to replay.
+        self._register_schemas(host)
+        wait_until(
+            lambda: self._all_subjects_served(host),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="subjects not visible after registration",
+        )
+
+        self.redpanda.set_cluster_config({"schema_registry_replay_on_startup": True})
+
+        init_before = self.redpanda.count_log_node(node, self.INIT_MARKER)
+
+        admin = Admin(self.redpanda)
+        result = admin.restart_service(rp_service="schema-registry", node=node)
+        assert result.status_code == requests.codes.ok, (
+            f"restart_service failed: {result.status_code} {result.text}"
+        )
+
+        # Deliberately issue NO SR request. The eager startup trigger must drive
+        # the replay on its own. count_log_node greps the broker log over ssh,
+        # so polling here does not hit the SR API and cannot trigger the lazy
+        # path.
+        wait_until(
+            lambda: self.redpanda.count_log_node(node, self.INIT_MARKER) > init_before,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="eager startup replay did not run without any request",
+        )
+
+        replays = self.redpanda.count_log_node(node, self.INIT_MARKER) - init_before
+        assert replays == 1, (
+            f"expected exactly one eager replay, saw {replays} "
+            f"('{self.INIT_MARKER}' delta)."
+        )
+
+        # The store hydrated without a request; a request now succeeds
+        # immediately rather than blocking on a cold replay.
+        assert self._all_subjects_served(host)
+
+    @cluster(num_nodes=3, log_allow_list=_SR_STARTUP_RECOVERY_LOG_ALLOW_LIST)
+    def test_no_replay_on_startup_by_default(self):
+        """
+        With schema_registry_replay_on_startup unset (the default), recovery
+        stays lazy: a restart does not replay _schemas until a request (or an
+        internal access) arrives. The complement of
+        test_replay_on_startup_without_request, and a guard that the config
+        actually gates the eager path.
+        """
+        node = self.redpanda.nodes[0]
+        host = node.account.hostname
+
+        self._register_schemas(host)
+        wait_until(
+            lambda: self._all_subjects_served(host),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="subjects not visible after registration",
+        )
+
+        # Deliberately leave schema_registry_replay_on_startup at its default
+        # (off). do_start() logs INIT_MARKER once per run, so a flat count after
+        # a restart with no request means recovery did not run.
+        init_before = self.redpanda.count_log_node(node, self.INIT_MARKER)
+
+        admin = Admin(self.redpanda)
+        result = admin.restart_service(rp_service="schema-registry", node=node)
+        assert result.status_code == requests.codes.ok, (
+            f"restart_service failed: {result.status_code} {result.text}"
+        )
+
+        # No SR request is issued. Give recovery ample time to (not) happen;
+        # a real replay of this topic completes in well under a second.
+        time.sleep(15)
+        assert self.redpanda.count_log_node(node, self.INIT_MARKER) == init_before, (
+            "recovery ran at startup without the config set and without a "
+            "request; it should be lazy by default"
+        )
+
+        # The first request now lazily triggers exactly one replay and serves.
+        wait_until(
+            lambda: self._all_subjects_served(host),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="lazy recovery did not serve after the first request",
+        )
+        replays = self.redpanda.count_log_node(node, self.INIT_MARKER) - init_before
+        assert replays == 1, (
+            f"expected exactly one lazy replay after the first request, saw {replays}."
+        )

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -13,6 +13,7 @@ import json
 import random
 import re
 import socket
+import threading
 import time
 import urllib.parse
 import uuid
@@ -11942,3 +11943,194 @@ class SchemaRegistryTransportCompatTest(RedpandaTest):
 
         self._flip_transport(use_rpc=False)
         self._verify_phase(after_rpc2, "kafka2", "Kafka2Rec", n)
+
+
+# The SR briefly returns HTTP 500 (std::exception) to requests that arrive
+# while restart_service is tearing down and rebuilding it. This test sends load
+# during the restart window on purpose, so those transient errors are expected
+# and unrelated to the startup race under test.
+_SR_STARTUP_RECOVERY_LOG_ALLOW_LIST = DEFAULT_LOG_ALLOW_LIST + [
+    r"schemaregistry - reply.h.*HTTP 500 Internal Server Error",
+]
+
+
+class SchemaRegistryStartupRecoveryTest(RedpandaTest):
+    """
+    Schema Registry recovery of the `_schemas` topic on startup must run
+    exactly one replay per broker, even when many first requests land on
+    different shards at once.
+
+    Regression test for the multi-shard `do_start()` startup race.
+    `service` is a per-shard peering_sharded_service, so each shard owns its
+    own `_ensure_started` one_shot, and `do_start()` only stamps `_is_started`
+    (its re-entry guard) from inside its `invoke_on_all`, after
+    `create_internal_topic()`. That leaves a window in which first requests
+    arriving on several shards concurrently each run `do_start()` and launch
+    their own independent, redundant full replay on the reader shard, slowing
+    recovery by up to a factor of the shard count.
+
+    `do_start()` logs "Schema registry successfully initialized" exactly once
+    per invocation (before its fetch-retry loop, only on success), so the
+    increase in that marker across a single SR restart is precisely the number
+    of replays that ran. The fix funnels every shard through a single reader-
+    shard one_shot, so the count is deterministically 1.
+
+    Reproducing the race on unfixed code is timing-dependent (the window is a
+    single cold `create_internal_topic()` call), so we restart repeatedly under
+    heavy concurrent load to raise the odds; the assertion is exact on the
+    fixed code regardless. Multiple shards are required, so this runs the
+    brokers with >1 CPU (num_cpus=1 has a single shard and cannot race).
+    """
+
+    INIT_MARKER = "Schema registry successfully initialized"
+    # A second consumer re-applying already-loaded offsets: the fingerprint of
+    # a concurrent redundant replay. Absent when a single replay runs.
+    RACE_MARKER = "advance_offset ignoring"
+
+    N_SUBJECTS = 200
+    RESTARTS = 5
+    HAMMER_THREADS = 32
+
+    def __init__(self, test_context: TestContext):
+        super().__init__(
+            test_context=test_context,
+            num_brokers=3,
+            extra_rp_conf={
+                "auto_create_topics_enabled": False,
+                "schema_registry_use_rpc": False,
+            },
+            # Multiple shards per broker are required to exercise the
+            # cross-shard startup race; num_cpus=1 has a single shard and the
+            # race cannot occur. More shards increase reproduction odds.
+            resource_settings=ResourceSettings(num_cpus=2),
+            log_config=log_config,  # schemaregistry: trace
+            pandaproxy_config=PandaproxyConfig(),
+            schema_registry_config=SchemaRegistryConfig(),
+        )
+        self.sr_client = SchemaRegistryRedpandaClient(redpanda=self.redpanda)
+
+    @staticmethod
+    def _schema(i: int) -> str:
+        return json.dumps(
+            {
+                "schema": json.dumps(
+                    {
+                        "type": "record",
+                        "name": f"rec{i}",
+                        "fields": [{"name": "f", "type": "string"}],
+                    }
+                )
+            }
+        )
+
+    def _register_schemas(self, hostname: str) -> None:
+        for i in range(self.N_SUBJECTS):
+            r = self.sr_client.request(
+                "POST",
+                f"subjects/test-{i}-value/versions",
+                headers=HTTP_POST_HEADERS,
+                data=self._schema(i),
+                hostname=hostname,
+            )
+            assert r.status_code == requests.codes.ok, (
+                f"register subject {i} failed: {r.status_code} {r.text}"
+            )
+
+    def _all_subjects_served(self, hostname: str) -> bool:
+        r = self.sr_client.request(
+            "GET", "subjects", headers=HTTP_GET_HEADERS, hostname=hostname
+        )
+        return r.status_code == requests.codes.ok and len(r.json()) >= self.N_SUBJECTS
+
+    @cluster(num_nodes=3, log_allow_list=_SR_STARTUP_RECOVERY_LOG_ALLOW_LIST)
+    def test_single_replay_per_startup(self):
+        node = self.redpanda.nodes[0]
+        host = node.account.hostname
+        base = f"http://{host}:8081"
+
+        # Populate _schemas so recovery has real work and the subject list is
+        # non-trivial to serve.
+        self._register_schemas(host)
+        wait_until(
+            lambda: self._all_subjects_served(host),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="subjects not visible after registration",
+        )
+
+        for iteration in range(self.RESTARTS):
+            init_before = self.redpanda.count_log_node(node, self.INIT_MARKER)
+            race_before = self.redpanda.count_log_node(node, self.RACE_MARKER)
+
+            # Pile concurrent read load on the target broker so that, right
+            # after the restart resets SR, first requests fan out across its
+            # shards and (on unfixed code) trigger the race. Raw requests bypass
+            # the SR client's retry/sleep so the load stays tight; responses are
+            # irrelevant, we only care about driving startup.
+            stop = threading.Event()
+
+            def hammer():
+                while not stop.is_set():
+                    for path in (
+                        "subjects",
+                        f"schemas/ids/{random.randint(1, self.N_SUBJECTS)}",
+                    ):
+                        try:
+                            requests.get(
+                                f"{base}/{path}",
+                                headers=HTTP_GET_HEADERS,
+                                timeout=2,
+                            )
+                        except Exception:
+                            pass
+
+            threads = [
+                threading.Thread(target=hammer, daemon=True)
+                for _ in range(self.HAMMER_THREADS)
+            ]
+            for t in threads:
+                t.start()
+
+            try:
+                admin = Admin(self.redpanda)
+                result = admin.restart_service(rp_service="schema-registry", node=node)
+                assert result.status_code == requests.codes.ok, (
+                    f"restart_service failed: {result.status_code} {result.text}"
+                )
+
+                # Recovery: the store rehydrates and subjects are served again.
+                wait_until(
+                    lambda: self._all_subjects_served(host),
+                    timeout_sec=60,
+                    backoff_sec=1,
+                    err_msg=f"SR did not recover after restart {iteration}",
+                )
+            finally:
+                stop.set()
+                for t in threads:
+                    t.join(timeout=10)
+
+            init_after = self.redpanda.count_log_node(node, self.INIT_MARKER)
+            race_after = self.redpanda.count_log_node(node, self.RACE_MARKER)
+
+            replays = init_after - init_before
+            assert replays == 1, (
+                f"iteration {iteration}: expected exactly one _schemas replay "
+                f"per SR restart, saw {replays} "
+                f"('{self.INIT_MARKER}' {init_before}->{init_after}). "
+                f">1 means the multi-shard do_start() startup race launched "
+                f"redundant concurrent replays."
+            )
+            assert race_after == race_before, (
+                f"iteration {iteration}: saw {race_after - race_before} "
+                f"'{self.RACE_MARKER}' lines during recovery -- a second "
+                f"consumer re-applied already-loaded offsets, i.e. a concurrent "
+                f"redundant replay ran."
+            )
+
+        # Everything is still served correctly after the restart cycles.
+        r = self.sr_client.request(
+            "GET", "subjects", headers=HTTP_GET_HEADERS, hostname=host
+        )
+        assert r.status_code == requests.codes.ok, r.text
+        assert len(r.json()) >= self.N_SUBJECTS


### PR DESCRIPTION
Schema Registry recovery of the internal `_schemas` topic on startup could
run multiple redundant full replays concurrently on the reader shard, making
cold start of a large registry take much longer than necessary (recovery
time scaled with the number of racing shards).

`service` is a per-shard `peering_sharded_service`, so each shard owns its
own `_ensure_started` one_shot, and `do_start()` only stamps `_is_started`
(its re-entry guard) from inside its `invoke_on_all`, after
`create_internal_topic()`. Previously, when first requests landed on several
shards within that window, each shard ran its own `do_start()` and launched
an independent replay.

This PR instead funnels every shard through a single one_shot on the reader
shard so the topic is loaded exactly once; the per-shard one_shot still
caches completion, so only the first request on each shard pays a
cross-shard hop and steady state is unchanged.

Recovery is also lazy (nothing loads the topic until the first request), so
the first request after a restart can block for the whole replay. This PR
adds a cluster config, `schema_registry_replay_on_startup` (default off),
that proactively drives the single-flight load at startup, fire-and-forget
under the gate, so the store hydrates ahead of traffic without blocking
broker start-up.

Covered by ducktape tests: a single replay per restart under concurrent
multi-shard load, and the eager/lazy behavior of the new config.

## Backports Required

- [x] v26.2.x
- [x] v26.1.x

## Release Notes

### Improvements

* Schema Registry now replays the internal `_schemas` topic exactly once
  when recovering on startup, instead of running redundant concurrent
  replays; cold start of a large registry is significantly faster.
* Added a `schema_registry_replay_on_startup` cluster property (default off)
  that hydrates the Schema Registry store at broker start-up rather than
  lazily on the first request.
