### PR TITLE
bazel/seastar: enable task queue shuffling in debug builds

### DIFF
--- a/bazel/thirdparty/seastar.BUILD
+++ b/bazel/thirdparty/seastar.BUILD
@@ -2,7 +2,7 @@
 # This build is a translation of Seastar's official cmake-based build.
 #
 
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "int_flag")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "int_flag", "string_flag")
 load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
@@ -61,9 +61,16 @@ bool_flag(
     build_setting_default = False,
 )
 
-bool_flag(
+# Defines SEASTAR_SHUFFLE_TASK_QUEUE; "auto" enables it when the
+# @seastar//:debug flag is true.
+string_flag(
     name = "shuffle_task_queue",
-    build_setting_default = False,
+    build_setting_default = "auto",
+    values = [
+        "auto",
+        "true",
+        "false",
+    ],
 )
 
 int_flag(
@@ -152,6 +159,14 @@ config_setting(
     name = "with_shuffle_task_queue",
     flag_values = {
         ":shuffle_task_queue": "true",
+    },
+)
+
+config_setting(
+    name = "with_shuffle_task_queue_auto",
+    flag_values = {
+        ":debug": "true",
+        ":shuffle_task_queue": "auto",
     },
 )
 
@@ -652,6 +667,7 @@ cc_library(
         "//conditions:default": [],
     }) + select({
         ":with_shuffle_task_queue": ["SEASTAR_SHUFFLE_TASK_QUEUE"],
+        ":with_shuffle_task_queue_auto": ["SEASTAR_SHUFFLE_TASK_QUEUE"],
         "//conditions:default": [],
     }) + select({
         ":use_stack_guards": ["SEASTAR_THREAD_STACK_GUARDS"],


### PR DESCRIPTION
Shuffling was on in our debug CMake builds: Seastar defines
SEASTAR_SHUFFLE_TASK_QUEUE for its Debug, Sanitize and Fuzz
configurations, where swapping pending tasks surfaces latent ordering
assumptions. The move to Bazel dropped it.

@seastar//:shuffle_task_queue becomes tri-state: "auto" (the default)
follows @seastar//:debug, while "true"/"false" force it either way, e.g.
to shuffle in a release build.

.bazelrc sets @seastar//:debug for every build except --config=release,
so fastbuild gets shuffling too. That is deliberate: developers hit bad
ordering assumptions during ordinary local iteration rather than only
under --config=debug in CI.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none