### PR TITLE
`schema_registry`: recovery optimizations

### DIFF
--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -752,12 +752,24 @@ ss::future<> service::fetch_internal_topic() {
     auto max_offset = co_await _transport->get_high_watermark();
     vlog(srlog.debug, "Schema registry: _schemas max_offset: {}", max_offset);
 
+    using namespace std::chrono_literals;
     const auto defer = defer_processing{
       config::shard_local_cfg().schema_registry_deferred_recovery()};
+    auto replay_start = ss::lowres_clock::now();
     co_await _transport->consume_range(
       model::offset{0}, max_offset, consume_to_store{_store, writer(), defer});
+    auto replay_done = ss::lowres_clock::now();
 
     co_await _store.process_marked_schemas();
+
+    vlog(
+      srlog.info,
+      "Schema registry recovery complete: replayed to offset {} in {}ms "
+      "(deferred={}), canonicalised marked schemas in {}ms",
+      max_offset,
+      (replay_done - replay_start) / 1ms,
+      defer == defer_processing::yes,
+      (ss::lowres_clock::now() - replay_done) / 1ms);
 }
 
 service::service(

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -13,6 +13,7 @@
 
 #include "base/vlog.h"
 #include "config/configuration.h"
+#include "container/chunked_hash_map.h"
 #include "container/chunked_vector.h"
 #include "hashing/jump_consistent_hash.h"
 #include "hashing/xx.h"
@@ -28,6 +29,7 @@
 #include "pandaproxy/schema_registry/util.h"
 
 #include <seastar/core/future.hh>
+#include <seastar/core/loop.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/coroutine/as_future.hh>
 
@@ -58,6 +60,92 @@ ss::shard_id shard_for(const context_schema_id& id) {
 ss::shard_id shard_for(const context& ctx) {
     auto hash = xxhash_64(ctx().data(), ctx().length());
     return jump_consistent_hash(hash, ss::this_smp_shard_count());
+}
+
+/// Memoizes reference lookups for the duration of one
+/// process_marked_schemas() pass.
+///
+/// A (subject, version)'s definition is immutable once written, so
+/// serving repeats from a local cache is safe. Marked schemas commonly
+/// share their reference closure (layered proto packages), and without
+/// the cache every compile re-resolves the whole closure with chained
+/// cross-shard lookups.
+class caching_schema_getter final : public schema_getter {
+    // Cached entries share the store-owned definition buffers rather than
+    // copying them, so the cache pins memory (relevant if a definition is
+    // replaced mid-pass) rather than duplicating it, and schemas can be
+    // megabytes - so bound the pinned bytes rather than the entry count,
+    // generously. Reference closures are heavily shared; reset rather
+    // than evict if an unusual corpus overflows the cache.
+    static constexpr size_t max_bytes = 32 * 1024 * 1024;
+
+public:
+    explicit caching_schema_getter(sharded_store& store)
+      : _store{store} {}
+
+    ss::future<stored_schema> get_subject_schema(
+      context_subject sub,
+      std::optional<schema_version> version,
+      include_deleted inc_del) override {
+        if (!version.has_value()) {
+            // "latest" is not a stable key; don't cache it.
+            co_return co_await _store.get_subject_schema(
+              std::move(sub), version, inc_del);
+        }
+        auto key = subject_version{sub, *version};
+        if (auto it = _cache.find(key); it != _cache.end()) {
+            if (inc_del == include_deleted::no && it->second.deleted) {
+                // A cached soft-deleted entry can't answer an
+                // inc_del::no lookup; let the store produce its
+                // canonical error.
+                co_return co_await _store.get_subject_schema(
+                  std::move(sub), version, inc_del);
+            }
+            co_return it->second.share();
+        }
+        auto schema = co_await _store.get_subject_schema(
+          std::move(sub), version, inc_del);
+        auto size = schema.schema.def().raw()().size_bytes();
+        if (_cached_bytes + size >= max_bytes) {
+            _cache.clear();
+            _cached_bytes = 0;
+        }
+        if (_cache.emplace(std::move(key), schema.share()).second) {
+            _cached_bytes += size;
+        }
+        co_return schema;
+    }
+
+    ss::future<schema_definition>
+    get_schema_definition(context_schema_id id) override {
+        return _store.get_schema_definition(id);
+    }
+
+    ss::future<std::optional<schema_definition>>
+    maybe_get_schema_definition(context_schema_id id) override {
+        return _store.maybe_get_schema_definition(id);
+    }
+
+private:
+    sharded_store& _store;
+    chunked_hash_map<subject_version, stored_schema> _cache;
+    size_t _cached_bytes{0};
+};
+
+ss::future<subject_schema>
+make_canonical_with(schema_getter& getter, subject_schema schema) {
+    switch (schema.type()) {
+    case schema_type::avro:
+        co_return co_await make_canonical_avro_schema(
+          getter, std::move(schema));
+    case schema_type::protobuf:
+        co_return co_await make_canonical_protobuf_schema(
+          getter, std::move(schema));
+    case schema_type::json:
+        co_return co_await make_canonical_json_schema(
+          getter, std::move(schema));
+    }
+    __builtin_unreachable();
 }
 
 compatibility_result check_compatible(
@@ -230,38 +318,46 @@ ss::future<bool> sharded_store::upsert(
 }
 
 ss::future<> sharded_store::process_marked_schemas() {
+    // Bound the number of in-flight canonicalisations per shard: enough to
+    // hide the latency of cross-shard reference lookups without holding
+    // many partially-built descriptor sets in memory at once.
+    constexpr size_t max_concurrency = 8;
     return _store.invoke_on_all([this](store& store) {
         return ss::do_with(
-          store.extract_marked_schemas(), [this, &store](auto& marked) {
-              return ss::do_for_each(marked, [this, &store](auto id) {
-                  auto schema = store.get_schema_definition(id);
-                  if (schema.has_failure()) {
-                      // schema not found, ignore
-                      return ss::now();
-                  }
-                  return make_canonical_schema(
-                           {context_subject{id.ctx, subject{}},
-                            std::move(schema).assume_value()},
-                           normalize::no,
-                           false)
-                    .then([id, &store](auto canonical) {
-                        // Update the stored form of this schema to its
-                        // canonical form
-                        auto [sub, schema] = std::move(canonical).destructure();
-                        store.upsert_schema(id, std::move(schema), false);
-                    })
-                    .handle_exception([id](const std::exception_ptr& ep) {
-                        // processing attempt failed on marked schema. This is
-                        // not an issue of forward references. Ignore error and
-                        // keep schema in the store as-is
-                        vlog(
-                          srlog.debug,
-                          "process_marked_schemas failed for ctx={} id={}: {}",
-                          id.ctx,
-                          id.id,
-                          ep);
-                    });
-              });
+          store.extract_marked_schemas(),
+          caching_schema_getter{*this},
+          [&store](auto& marked, auto& getter) {
+              return ss::max_concurrent_for_each(
+                marked, max_concurrency, [&store, &getter](auto id) {
+                    auto schema = store.get_schema_definition(id);
+                    if (schema.has_failure()) {
+                        // schema not found, ignore
+                        return ss::now();
+                    }
+                    return make_canonical_with(
+                             getter,
+                             {context_subject{id.ctx, subject{}},
+                              std::move(schema).assume_value()})
+                      .then([id, &store](auto canonical) {
+                          // Update the stored form of this schema to its
+                          // canonical form
+                          auto [sub, schema]
+                            = std::move(canonical).destructure();
+                          store.upsert_schema(id, std::move(schema), false);
+                      })
+                      .handle_exception([id](const std::exception_ptr& ep) {
+                          // processing attempt failed on marked schema. This
+                          // is not an issue of forward references. Ignore
+                          // error and keep schema in the store as-is
+                          vlog(
+                            srlog.debug,
+                            "process_marked_schemas failed for ctx={} id={}: "
+                            "{}",
+                            id.ctx,
+                            id.id,
+                            ep);
+                      });
+                });
           });
     });
 }

--- a/src/v/pandaproxy/schema_registry/test/BUILD
+++ b/src/v/pandaproxy/schema_registry/test/BUILD
@@ -631,6 +631,33 @@ redpanda_cc_bench(
     ],
 )
 
+redpanda_cc_bench(
+    name = "recovery_rpbench",
+    timeout = "moderate",
+    srcs = [
+        "recovery_bench.cc",
+    ],
+    # The cross-shard costs this benchmark exercises need more than one
+    # shard to exist.
+    cpu = 2,
+    # recovery_inline compiles every replayed record; keep test mode to
+    # the cheap marked variant.
+    test_regex = ".*marked_replay",
+    deps = [
+        ":utils",
+        "//src/v/bytes:iobuf",
+        "//src/v/container:chunked_vector",
+        "//src/v/model",
+        "//src/v/pandaproxy/schema_registry:seq_writer",
+        "//src/v/pandaproxy/schema_registry:store",
+        "//src/v/pandaproxy/schema_registry:types",
+        "//src/v/storage:record_batch_builder",
+        "@fmt",
+        "@seastar",
+        "@seastar//:benchmark",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "rpc_transport_test",
     timeout = "short",

--- a/src/v/pandaproxy/schema_registry/test/recovery_bench.cc
+++ b/src/v/pandaproxy/schema_registry/test/recovery_bench.cc
@@ -1,0 +1,314 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "bytes/iobuf.h"
+#include "container/chunked_vector.h"
+#include "model/record.h"
+#include "pandaproxy/schema_registry/seq_writer.h"
+#include "pandaproxy/schema_registry/sharded_store.h"
+#include "pandaproxy/schema_registry/storage.h"
+#include "pandaproxy/schema_registry/test/utils.h"
+#include "pandaproxy/schema_registry/types.h"
+#include "storage/record_batch_builder.h"
+
+#include <seastar/core/smp.hh>
+#include <seastar/testing/perf_tests.hh>
+
+#include <fmt/format.h>
+
+#include <cstdlib>
+#include <string>
+
+namespace pps = pandaproxy::schema_registry;
+
+namespace {
+
+/// Benchmarks Schema Registry startup recovery: replaying an encoded
+/// _schemas history through consume_to_store - everything
+/// service::ensure_started() does apart from fetching the records.
+///
+/// The corpus mirrors a production registry: every schema sits atop a
+/// deep shared import chain (so a compile pulls in the whole closure),
+/// and every record is rewritten `churn` times over (re-registration
+/// history that survives in a compacted topic).
+///
+/// The benchmark deliberately uses only APIs that predate deferred
+/// recovery, so it can be run at every commit of the recovery work to
+/// measure each change. The deferred pipeline is exercised through the
+/// reversed corpus: a record whose references are not yet resolvable is
+/// stored raw and marked for the later process_marked_schemas() pass,
+/// which is the same store pipeline that deferred recovery drives
+/// explicitly for every record.
+///
+/// - recovery_inline: in-reference-order corpus, replay plus pass. Every
+///   record canonicalises (compiles) during the replay; this is recovery
+///   with schema_registry_deferred_recovery=false.
+/// - marked_replay: reversed corpus, replay only. Records take the
+///   raw-and-mark path; an upper bound for the deferred time-to-serving
+///   replay (it additionally pays one failed reference resolution per
+///   record).
+/// - marked_canonicalisation: reversed corpus, pass only. The compile of
+///   the store's final state, i.e. deferred recovery's background stage.
+///
+/// The reported runtime is per replayed record; multiply by a registry's
+/// record count to size a recovery. marked_canonicalisation's absolute
+/// cost scales with *distinct* schemas rather than history, so at low
+/// churn it can read as more expensive per record than the replay. The
+/// corpus is scalable via environment variables to reproduce
+/// production-sized totals, e.g.:
+///   RECOVERY_BENCH_SUBJECTS=7500 RECOVERY_BENCH_CHURN=60 \
+///     bazel run --config=release \
+///     //src/v/pandaproxy/schema_registry/test:recovery_rpbench -- \
+///     -t '.*marked.*'
+/// (recovery_inline at that scale takes minutes per iteration.)
+constexpr size_t schema_bytes = 3072;
+constexpr size_t records_per_batch = 100;
+
+int env_or(const char* name, int fallback) {
+    if (const char* v = std::getenv(name); v != nullptr) {
+        return std::stoi(v);
+    }
+    return fallback;
+}
+
+const int chain_depth = env_or("RECOVERY_BENCH_CHAIN", 30);
+const int n_subjects = env_or("RECOVERY_BENCH_SUBJECTS", 100);
+const int churn = env_or("RECOVERY_BENCH_CHURN", 10);
+
+std::string pad_fields(std::string header, std::string_view tail) {
+    int field_idx = 1;
+    while (header.size() < schema_bytes) {
+        header += fmt::format(
+          "  // padding comment for field number {:08}\n"
+          "  string field_{:08} = {};\n",
+          field_idx,
+          field_idx,
+          field_idx);
+        ++field_idx;
+    }
+    header += tail;
+    return header;
+}
+
+std::string make_common_proto(int k) {
+    auto header = fmt::format(
+      "syntax = \"proto3\";\npackage bench.common{};\n", k);
+    std::string embed;
+    if (k > 0) {
+        header += fmt::format("import \"common_{}.proto\";\n", k - 1);
+        embed = fmt::format(
+          "  bench.common{}.Rec{} prev = 15000;\n}}\n", k - 1, k - 1);
+    } else {
+        embed = "}\n";
+    }
+    header += fmt::format("message Rec{} {{\n", k);
+    return pad_fields(std::move(header), embed);
+}
+
+std::string make_subject_proto(int i) {
+    const int tail = chain_depth - 1;
+    auto header = fmt::format(
+      "syntax = \"proto3\";\n"
+      "package bench.subject{};\n"
+      "import \"common_{}.proto\";\n"
+      "message Payload{} {{\n"
+      "  bench.common{}.Rec{} rec = 15000;\n",
+      i,
+      tail,
+      i,
+      tail,
+      tail);
+    return pad_fields(std::move(header), "}\n");
+}
+
+pps::schema_definition::references make_refs(const ss::sstring& target) {
+    pps::schema_definition::references refs;
+    refs.push_back(
+      pps::schema_reference{
+        .name = target,
+        .sub = pps::context_subject_reference::unqualified(target),
+        .version = pps::schema_version{1}});
+    return refs;
+}
+
+struct encoded_corpus {
+    chunked_vector<model::record_batch> batches;
+    size_t records{0};
+};
+
+/// With in_reference_order, references precede their referents (the
+/// import chain, then every subject's record repeated `churn` times), so
+/// every record can canonicalise as it is applied. Reversed, no record's
+/// references are resolvable at apply time, so every record is stored
+/// raw and marked, leaving all compilation to
+/// process_marked_schemas() - the deferred recovery pipeline.
+///
+/// Keys are unsequenced, as consume_to_store receives for
+/// third-party/imported records, so they are applied unconditionally.
+encoded_corpus encode_corpus(bool in_reference_order) {
+    encoded_corpus corpus;
+    const auto ver1 = pps::schema_version{1};
+
+    std::unique_ptr<storage::record_batch_builder> rb;
+    auto flush = [&corpus, &rb]() {
+        if (rb) {
+            corpus.batches.push_back(std::move(*rb).build());
+            rb.reset();
+        }
+    };
+    auto add = [&](
+                 pps::context_subject sub,
+                 pps::schema_id id,
+                 pps::schema_definition def) {
+        if (!rb) {
+            rb = std::make_unique<storage::record_batch_builder>(
+              model::record_batch_type::raft_data,
+              model::offset(corpus.records));
+        }
+        // Serialize the key before the value moves `sub` out; the two
+        // arguments of add_raw_kv are unsequenced.
+        auto key = to_json_iobuf(
+          pps::schema_key{
+            .seq{std::nullopt},
+            .node{std::nullopt},
+            .sub{sub},
+            .version{ver1}});
+        rb->add_raw_kv(
+          std::move(key),
+          to_json_iobuf(
+            pps::schema_value{
+              .schema{std::move(sub), std::move(def)},
+              .version{ver1},
+              .id{id}}));
+        if (++corpus.records % records_per_batch == 0) {
+            flush();
+        }
+    };
+    auto add_common = [&](int k) {
+        auto name = fmt::format("common_{}.proto", k);
+        pps::schema_definition::references refs;
+        if (k > 0) {
+            refs = make_refs(fmt::format("common_{}.proto", k - 1));
+        }
+        add(
+          pps::context_subject::unqualified(name),
+          pps::schema_id{k + 1},
+          pps::schema_definition{
+            iobuf::from(make_common_proto(k)),
+            pps::schema_type::protobuf,
+            std::move(refs),
+            std::nullopt});
+    };
+    auto add_subject =
+      [&](int i, const pps::schema_definition::references& refs) {
+          auto sub = pps::context_subject::unqualified(
+            fmt::format("bench/subject{}.proto", i));
+          auto def = pps::schema_definition{
+            iobuf::from(make_subject_proto(i)),
+            pps::schema_type::protobuf,
+            refs.copy(),
+            std::nullopt};
+          for (int c = 0; c < churn; ++c) {
+              add(sub, pps::schema_id{chain_depth + i + 1}, def.share());
+          }
+      };
+
+    auto tail_refs = make_refs(fmt::format("common_{}.proto", chain_depth - 1));
+    if (in_reference_order) {
+        for (int k = 0; k < chain_depth; ++k) {
+            add_common(k);
+        }
+        for (int i = 0; i < n_subjects; ++i) {
+            add_subject(i, tail_refs);
+        }
+    } else {
+        for (int i = 0; i < n_subjects; ++i) {
+            add_subject(i, tail_refs);
+        }
+        for (int k = chain_depth - 1; k >= 0; --k) {
+            add_common(k);
+        }
+    }
+    flush();
+    return corpus;
+}
+
+class recovery_bench {
+public:
+    /// Replay an encoded corpus through consume_to_store into a fresh
+    /// store, as service recovery does after fetching. Measures the
+    /// replay, and the process_marked_schemas() pass if requested;
+    /// returns the record count so results read as time per record.
+    ss::future<size_t>
+    replay(bool in_reference_order, bool measure_replay, bool canonicalise) {
+        auto& corpus = in_reference_order ? _in_order : _reversed;
+        if (corpus.batches.empty()) {
+            corpus = encode_corpus(in_reference_order);
+        }
+
+        pps::sharded_store store;
+        co_await store.start(
+          pps::is_mutable::yes, ss::default_smp_service_group());
+        noop_transport transport;
+        ss::sharded<pps::seq_writer> seq;
+        co_await seq.start(
+          model::node_id{0},
+          ss::default_smp_service_group(),
+          std::ref(transport),
+          std::reference_wrapper(store),
+          ss::sharded_parameter(
+            [] { return std::make_unique<sequence_state_checker_test>(); }));
+
+        auto consumer = pps::consume_to_store{store, seq.local()};
+        if (measure_replay) {
+            perf_tests::start_measuring_time();
+        }
+        for (const auto& batch : corpus.batches) {
+            co_await consumer(batch.copy());
+        }
+        if (!measure_replay) {
+            perf_tests::start_measuring_time();
+        }
+        if (canonicalise) {
+            co_await store.process_marked_schemas();
+        }
+        perf_tests::stop_measuring_time();
+
+        co_await seq.stop();
+        co_await store.stop();
+        co_return corpus.records;
+    }
+
+private:
+    encoded_corpus _in_order;
+    encoded_corpus _reversed;
+};
+
+} // namespace
+
+// Recovery where every record canonicalises (compiles) as it is
+// replayed: schema_registry_deferred_recovery=false.
+PERF_TEST_CN(recovery_bench, recovery_inline) {
+    co_return co_await replay(true, true, true);
+}
+
+// A replay in which every record takes the raw-and-mark path: an upper
+// bound for deferred recovery's time-to-serving replay stage.
+PERF_TEST_CN(recovery_bench, marked_replay) {
+    co_return co_await replay(false, true, false);
+}
+
+// The process_marked_schemas() pass over a fully-marked store: deferred
+// recovery's background canonicalisation stage. Its cost scales with
+// distinct schemas rather than replayed records.
+PERF_TEST_CN(recovery_bench, marked_canonicalisation) {
+    co_return co_await replay(false, false, true);
+}


### PR DESCRIPTION
A series of schema registry optimizations that greatly speed up recovery and time to serve requests. E2E benchmark test referenced in commits (not checked in) is here: https://gist.github.com/WillemKauf/e4dc2119f2efd3552446e1058e095905
* `schema_registry`: parallelize recovery with deferred canonicalisation
* `schema_registry`: cache reference lookups in `process_marked_schemas()` (E2E: 358s -> 142s)

From a checked in benchmark, where:
* `recovery_inline`: reflects the existing performance/path of `schema_registry` recover with inline canonicalization
* `marked_replay`: reflects the performance for the fetch bound process of replaying the `_schema` log without canonicalizing any schemas
*  `marked_canonicalisation`: reflects the performance of the backgrounded process of canonicalizing a full marked `schema_registry`.

```  
  ┌─────────────────┬─────────────────┬───────────────┬─────────────────────────┬─────────────────────────────────────────┐
  │     commit      │ recovery_inline │ marked_replay │ marked_canonicalisation │                  step                   │
  ├─────────────────┼─────────────────┼───────────────┼─────────────────────────┼─────────────────────────────────────────┤
  │ bench           │ 1.44ms          │ 31.7µs        │ 1.97ms                  │ baseline                                │
  │ (pre-changes)   │                 │               │                         │                                         │
  ├─────────────────┼─────────────────┼───────────────┼─────────────────────────┼─────────────────────────────────────────┤
  │ deferred        │ 1.45ms          │ 33.1µs        │ 218µs                   │ 9.0x — mark-set dedup: the pass stops   │
  │                 │                 │               │                         │ recompiling churn duplicates            │
  ├─────────────────┼─────────────────┼───────────────┼─────────────────────────┼─────────────────────────────────────────┤
  │ lookup cache    │ 1.45ms          │ 32.8µs        │ 147µs                   │ 1.5x — cross-shard ref lookups memoized │
  │                 │                 │               │                         │  (now visible at 2 shards)              │
  ├─────────────────┼─────────────────┼───────────────┼─────────────────────────┼─────────────────────────────────────────┤
  │ descriptor      │ 1.44ms          │ 32.5µs        │ 38.2µs                  │ 3.9x — closure compiled once per group  │
  │ sharing         │                 │               │                         │                                         │
  ┼─────────────────┼───────────────┼──────────────────────────────────────────────────────┴─────────────────────────────────────────┘
```

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Improvements

* Optimize the `schema_registry` recovery path by caching references when canonicalizing schemas