### PR TITLE
gha: set reaction-token for slash-commands

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: peter-evans/slash-command-dispatch@v5
         with:
           token: ${{ env.ACTIONS_BOT_TOKEN }}
+          reaction-token: ${{ env.ACTIONS_BOT_TOKEN }}
           permission: read
           issue-type: both
           commands: |


### PR DESCRIPTION
The slash-command dispatcher is supposed to react with :eyes: every time it parses a comment on a pull request but this has been broken for a while because it uses the default `github.token` instead of the `ACTIONS_BOT_TOKEN` and the default token's permissions don't allow reactions on comments.

So, explicitly set `reaction-token` to the same token we use for dispatch.

Jira: [DEVPROD-4481]


## Backports Required

- [X] none - not a (product) bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

[DEVPROD-4481]: https://redpandadata.atlassian.net/browse/DEVPROD-4481?