### PR TITLE
ssx/actor: document blocked tell() ordering as unspecified

### DIFF
--- a/src/v/ssx/actor.h
+++ b/src/v/ssx/actor.h
@@ -134,7 +134,9 @@ public:
         co_await _gate.close();
     }
 
-    // Send a message. It waits until space is available.
+    // Send a message. It waits until space is available. If multiple senders
+    // are blocked waiting for space, the order in which their messages are
+    // enqueued is unspecified.
     ss::future<> tell(T msg)
     requires(OverflowPolicy == overflow_policy::block)
     {

--- a/src/v/ssx/tests/actor_test.cc
+++ b/src/v/ssx/tests/actor_test.cc
@@ -159,8 +159,11 @@ TEST(Actor, ConcurrentTellsWithFullMailbox) {
     tell_fut2.get();
     tell_fut3.get();
 
-    // All messages should be processed
-    EXPECT_THAT(actor.processed, ElementsAre(1, 2, 3, 4, 5));
+    // All messages should be processed. Senders blocked on a full mailbox
+    // race for freed space when woken, so their relative order is
+    // unspecified.
+    EXPECT_THAT(
+      actor.processed, ::testing::UnorderedElementsAre(1, 2, 3, 4, 5));
     actor.stop().get();
 }
 


### PR DESCRIPTION
Enabling Seastar task queue shuffling (`SEASTAR_SHUFFLE_TASK_QUEUE`,
defined in debug/sanitize CMake builds but currently missing from the
Bazel debug build) makes `Actor.ConcurrentTellsWithFullMailbox` fail
with messages processed as `{1, 2, 3, 5, 4}`.

The test asserted that `tell()` calls blocked on a full mailbox
complete in call order, but the implementation doesn't guarantee that:
woken senders race to re-check for space and the freed slot goes to
whichever continuation the scheduler resumes first. The assertion only
passed because the reactor's FIFO task queue happened to resume waiters
in wakeup order. The sibling test `NoMessageLossUnderContention`
already treats the order of concurrent sends as unspecified.

Fix the test to assert liveness (all messages delivered, none lost)
rather than order, and document on `tell()` that ordering among
concurrently blocked senders is unspecified — only sequenced sends
(each `tell()` awaited before the next) are FIFO. The commit messages
discuss the fairness implications and what a FIFO implementation would
take, should a future use case need it.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes

* none
