### PR TITLE
schema_registry/rest_client: make pooled_client fifo test deterministic

### DIFF
--- a/src/v/pandaproxy/schema_registry/rest_client/tests/pooled_client_test.cc
+++ b/src/v/pandaproxy/schema_registry/rest_client/tests/pooled_client_test.cc
@@ -194,7 +194,7 @@ TEST(pooled_client, forwards_request_response_and_arguments) {
 }
 
 TEST(pooled_client, bounds_concurrency_and_queues_fifo) {
-    pool_fixture fx(2);
+    pool_fixture fx(1);
     fx.observer.park = true;
 
     std::vector<ss::future<http::downloaded_response>> futs;
@@ -202,11 +202,13 @@ TEST(pooled_client, bounds_concurrency_and_queues_fifo) {
     for (int i = 0; i < 5; ++i) {
         futs.push_back(issue(*fx.pool, fmt::format("/r{}", i)));
     }
-    // Two requests hold the two transports; three wait for a slot.
-    RPTEST_REQUIRE_EVENTUALLY(5s, [&] { return fx.observer.inflight == 2; });
-    EXPECT_EQ(fx.observer.dispatched.size(), 2);
 
-    // Drain: complete parked requests as they arrive until all five ran.
+    // One request holds the transport; the other four wait for the slot.
+    RPTEST_REQUIRE_EVENTUALLY(5s, [&] { return fx.observer.inflight == 1; });
+    EXPECT_EQ(fx.observer.dispatched.size(), 1);
+
+    // Complete the in-flight request one at a time; each freed slot is granted
+    // to the earliest queued waiter (semaphore FIFO fairness).
     for (int released = 0; released < 5; ++released) {
         RPTEST_REQUIRE_EVENTUALLY(
           5s, [&] { return !fx.observer.parked.empty(); });
@@ -216,7 +218,7 @@ TEST(pooled_client, bounds_concurrency_and_queues_fifo) {
         EXPECT_EQ(fut.get().status, bh::status::ok);
     }
 
-    EXPECT_EQ(fx.observer.max_inflight, 2);
+    EXPECT_EQ(fx.observer.max_inflight, 1);
     // Waiters got slots in issue order.
     EXPECT_EQ(
       fx.observer.dispatched,


### PR DESCRIPTION
`bounds_concurrency_and_queues_fifo` asserted the exact order in which
requests reach the underlying transports. With two transports the pool grants
both initial slots concurrently, and their transport calls run from
independently scheduled continuations, so the scheduler — not issue order —
decides their relative order. The assertion happened to hold only because the
task queue was FIFO; enabling `SEASTAR_SHUFFLE_TASK_QUEUE` in debug builds made
it fail.

This is a test-only change; `pooled_client` behavior is unchanged. The test now
uses a single-transport pool: the one slot is granted strictly sequentially, so
every request's dispatch order is deterministic without choreographing releases,
while still exercising the semaphore's FIFO grant fairness — the earliest-queued
waiter always wins the freed slot.

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none
