### PR TITLE
cloud_topics/stm: move seen epoch window boundaries only under the write lock

### DIFF
--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -472,16 +472,19 @@ ctp_stm::fence_epoch(cluster_epoch e, model::timeout_clock::duration timeout) {
     while (true) {
         if (_state.epoch_in_window(term, e)) {
             // Case 1.1. Same epoch, need to acquire read-lock.
-            // Case 1.2. This epoch is out of order. We can accept it if it lies
-            //           in [previous-epoch, max-seen-epoch) range. We also need
-            //           to acquire a read fence as in 1.1.
+            // Case 1.2. This epoch is a window boundary or the window is
+            //           frozen. We also need to acquire a read fence as in
+            //           1.1.
             auto unit = co_await ss::get_units(_lock, 1, _as);
             if (_state.epoch_in_window(term, e)) {
                 co_return cluster_epoch_fence{
                   .unit = std::move(unit), .term = term};
             }
-        } else if (_state.epoch_above_window(term, e)) {
-            // Case 2. New epoch, need to acquire write-lock.
+        } else if (_state.epoch_moves_window(term, e)) {
+            // Case 2. The epoch is admitted by moving a seen-window boundary
+            // (bumping the max or raising the min), need to acquire
+            // write-lock so no fenced replication is in flight while the
+            // window moves.
             auto epoch_update_lock = _epoch_update_lock.try_get_units();
             if (!epoch_update_lock) {
                 // Someone else is updating the epoch - wait for the update and
@@ -497,10 +500,10 @@ ctp_stm::fence_epoch(cluster_epoch e, model::timeout_clock::duration timeout) {
             std::optional<cluster_epoch_fence> epoch_fence_opt;
             if (
               _state.epoch_in_window(term, e)
-              || _state.epoch_above_window(term, e)) {
-                vlog(_log.debug, "Bumping max seen epoch to {}", e);
-                _state.advance_max_seen_epoch(term, e);
-                // Demote to reader lock after max_seen_epoch is updated.
+              || _state.epoch_moves_window(term, e)) {
+                vlog(_log.debug, "Moving seen epoch window to admit {}", e);
+                _state.move_seen_window(term, e);
+                // Demote to reader lock after the window is updated.
                 unit.return_units(unit.count() - 1);
                 epoch_fence_opt.emplace(std::move(unit), term);
             }

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
@@ -17,14 +17,19 @@ namespace cloud_topics {
 
 void ctp_stm_state::advance_max_seen_epoch(
   model::term_id term, cluster_epoch epoch) noexcept {
-    if (term >= _seen_window_term && epoch > _max_seen_epoch) {
-        if (term > _seen_window_term) {
-            // If this is a new term, reset the window.
-            _previous_seen_epoch = epoch;
-            _seen_window_term = term;
-        } else {
-            _previous_seen_epoch = _max_seen_epoch.value_or(epoch);
-        }
+    if (term > _seen_window_term) {
+        // A new term always resets the window. The old window may carry a
+        // stale _max_seen_epoch above the new epoch (a fenced bump whose
+        // batch never landed before the leadership change); it must not
+        // survive into the new term or it blocks the reset and lets the
+        // stale window admit epochs the log no longer allows.
+        _seen_window_term = term;
+        _previous_seen_epoch = epoch;
+        _max_seen_epoch = epoch;
+        return;
+    }
+    if (term == _seen_window_term && epoch > _max_seen_epoch) {
+        _previous_seen_epoch = _max_seen_epoch.value_or(epoch);
         _max_seen_epoch = epoch;
     }
 }

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
@@ -10,6 +10,7 @@
 
 #include "cloud_topics/level_zero/stm/ctp_stm_state.h"
 
+#include "base/vassert.h"
 #include "model/fundamental.h"
 #include "utils/to_string.h"
 
@@ -68,6 +69,25 @@ void ctp_stm_state::applied_epochs::on_lro_advanced(
     }
 }
 
+ctp_stm_state::resolved_window
+ctp_stm_state::resolve_window(model::term_id term) const noexcept {
+    if (!_seen.has_value() || term > _seen->term) {
+        // The seen window is invisible to queries at newer terms: any epoch
+        // it admitted is either already applied or died with the old
+        // leadership (fence_epoch syncs before querying).
+        return {
+          .state = window_state::applied_only,
+          .window = _applied.window(),
+        };
+    }
+    if (_applied.max == _seen->window.max) {
+        // The batch carrying the seen max has been applied: the log's epoch
+        // window is frozen at the applied window until the next bump.
+        return {.state = window_state::frozen, .window = _applied.window()};
+    }
+    return {.state = window_state::pending, .window = _seen->window};
+}
+
 std::optional<kafka::offset>
 ctp_stm_state::get_last_reconciled_offset() const noexcept {
     return _last_reconciled_offset;
@@ -103,52 +123,67 @@ ctp_stm_state::get_previous_seen_epoch(model::term_id term) const noexcept {
 
 bool ctp_stm_state::epoch_in_window(
   model::term_id term, cluster_epoch epoch) const noexcept {
-    if (!_seen.has_value() || term > _seen->term) {
-        // The seen window is invisible to queries at newer terms: the
-        // applied window is the only evidence.
-        auto applied = _applied.window();
-        return applied.has_value() && applied->contains(epoch);
+    auto resolved = resolve_window(term);
+    switch (resolved.state) {
+    case window_state::applied_only:
+    case window_state::frozen:
+        // Everything in the log's own window is admissible: no in-flight
+        // epoch can ratchet the window above an admitted epoch (frozen: the
+        // pending max has already applied; applied_only: there is no
+        // pending max).
+        return resolved.window.has_value() && resolved.window->contains(epoch);
+    case window_state::pending:
+        // Only the window boundaries can be replicated concurrently in any
+        // log order: the max is the largest epoch that can reach the log in
+        // this term and can never end up below the log's epoch window; the
+        // min also requires a non-empty applied state, otherwise the
+        // max-seen batch may land into an empty log first and collapse the
+        // log window to [max, max] above it (see
+        // epoch_window_checker::check_epoch). Interior epochs have to move
+        // the window min first (see epoch_moves_window).
+        return epoch == resolved.window->max
+               || (epoch == resolved.window->min && _applied.max.has_value());
     }
-    const auto& seen = _seen->window;
-    if (!seen.contains(epoch)) {
-        return false;
-    }
-    if (epoch == seen.max) {
-        return true;
-    }
-    // A below-max epoch is only admissible if some epoch batch is known to
-    // precede the max-seen epoch's first batch in the log. The seen window
-    // alone can't prove this: a fence-time bump whose batch never lands (a
-    // failed replicate) leaves a lower bound with no counterpart in the log.
-    // If nothing precedes the max epoch's first batch, the log epoch window
-    // collapses to [max, max] when that batch applies, and a below-max batch
-    // landing after it violates the log invariant enforced by
-    // epoch_window_checker and may reference L0 objects the GC already
-    // considers inactive.
-    //
-    // Applied state gives positional evidence, since apply follows log order:
-    // - applied max < seen max: an applied batch sits at a lower log
-    //   position than any batch at the max-seen epoch (applied or not).
-    // - applied max == seen max: the max epoch applied; a batch preceded it
-    //   iff the applied window did not collapse to [max, max].
-    if (!_applied.max.has_value()) {
-        return false;
-    }
-    if (*_applied.max < seen.max) {
-        return true;
-    }
-    return *_applied.max == seen.max
-           && _applied.previous.value_or(seen.max) < seen.max;
+    vunreachable("invalid window_state");
 }
 
 bool ctp_stm_state::epoch_above_window(
   model::term_id term, cluster_epoch epoch) const noexcept {
-    if (!_seen.has_value() || term > _seen->term) {
-        // The seen window is invisible to queries at newer terms.
-        auto applied = _applied.window();
-        return !applied.has_value() || epoch > applied->max;
+    auto resolved = resolve_window(term);
+    // An empty window (nothing applied, nothing seen) is below any epoch.
+    return !resolved.window.has_value() || epoch > resolved.window->max;
+}
+
+bool ctp_stm_state::epoch_moves_window(
+  model::term_id term, cluster_epoch epoch) const noexcept {
+    if (epoch_above_window(term, epoch)) {
+        // Admitted by bumping the window max.
+        return true;
     }
-    return epoch > _seen->window.max;
+    if (!_seen.has_value() || term != _seen->term) {
+        return false;
+    }
+    const auto& seen = _seen->window;
+    // An interior epoch is admitted by becoming the new window min. This is
+    // only sound while the max-seen batch hasn't applied (a frozen window is
+    // admissible via epoch_in_window and must not move) and while nothing
+    // above the epoch, other than the pending max-seen epoch, has reached
+    // the non-empty log.
+    return seen.interior(epoch) && _applied.max.has_value()
+           && *_applied.max < seen.max && epoch >= *_applied.max;
+}
+
+void ctp_stm_state::move_seen_window(
+  model::term_id term, cluster_epoch epoch) noexcept {
+    if (epoch_above_window(term, epoch)) {
+        advance_max_seen_epoch(term, epoch);
+    } else if (epoch_moves_window(term, epoch)) {
+        // The interior epoch becomes the new window min: admissions below it
+        // are fenced off, so its batch can't be overtaken in the log by two
+        // distinct higher epochs (which would ratchet the log's epoch window
+        // above it).
+        _seen->window.min = epoch;
+    }
 }
 
 std::optional<cluster_epoch>

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
@@ -17,20 +17,54 @@ namespace cloud_topics {
 
 void ctp_stm_state::advance_max_seen_epoch(
   model::term_id term, cluster_epoch epoch) noexcept {
-    if (term > _seen_window_term) {
+    if (!_seen.has_value() || term > _seen->term) {
         // A new term always resets the window. The old window may carry a
-        // stale _max_seen_epoch above the new epoch (a fenced bump whose
-        // batch never landed before the leadership change); it must not
-        // survive into the new term or it blocks the reset and lets the
-        // stale window admit epochs the log no longer allows.
-        _seen_window_term = term;
-        _previous_seen_epoch = epoch;
-        _max_seen_epoch = epoch;
+        // stale max above the new epoch (a fenced bump whose batch never
+        // landed before the leadership change); it must not survive into
+        // the new term or it blocks the reset and leaves the new term's
+        // in-flight epochs invisible to concurrent fences.
+        _seen = seen_epochs{
+          .term = term,
+          .window = {.min = epoch, .max = epoch},
+        };
         return;
     }
-    if (term == _seen_window_term && epoch > _max_seen_epoch) {
-        _previous_seen_epoch = _max_seen_epoch.value_or(epoch);
-        _max_seen_epoch = epoch;
+    if (term == _seen->term && epoch > _seen->window.max) {
+        // The previous max becomes the window min.
+        _seen->window = {.min = _seen->window.max, .max = epoch};
+    }
+}
+
+std::optional<epoch_window>
+ctp_stm_state::applied_epochs::window() const noexcept {
+    if (!max.has_value()) {
+        return std::nullopt;
+    }
+    return epoch_window{.min = previous.value_or(*max), .max = *max};
+}
+
+void ctp_stm_state::applied_epochs::advance(
+  cluster_epoch epoch, model::offset offset) noexcept {
+    if (epoch <= max.value_or(cluster_epoch::min())) {
+        return;
+    }
+    if (!min_lower_bound.has_value()) {
+        // First epoch applied to the STM
+        min_lower_bound = epoch;
+    }
+    // Move the sliding window: the old max becomes the window min.
+    previous = max.value_or(epoch);
+    max = epoch;
+    window_offset = offset;
+}
+
+void ctp_stm_state::applied_epochs::on_lro_advanced(
+  model::offset lro_log_offset) noexcept {
+    if (window_offset.value_or(model::offset{}) <= lro_log_offset) {
+        // The LRO advanced past the offset at which the window transitioned
+        // to the current max, so everything below the previous epoch is
+        // inactive.
+        min_lower_bound = previous;
     }
 }
 
@@ -46,48 +80,40 @@ ctp_stm_state::get_last_reconciled_log_offset() const noexcept {
 
 std::optional<cluster_epoch>
 ctp_stm_state::estimate_min_epoch() const noexcept {
-    return _min_epoch_lower_bound;
+    return _applied.min_lower_bound;
 }
 
 std::optional<model::offset>
 ctp_stm_state::current_epoch_window_offset() const noexcept {
-    return _current_epoch_window_offset;
+    return _applied.window_offset;
 }
 
 std::optional<cluster_epoch>
 ctp_stm_state::get_previous_applied_epoch() const noexcept {
-    return _previous_applied_epoch;
+    return _applied.previous;
 }
 
 std::optional<cluster_epoch>
 ctp_stm_state::get_previous_seen_epoch(model::term_id term) const noexcept {
-    if (term > _seen_window_term) {
+    if (!_seen.has_value() || term > _seen->term) {
         return std::nullopt;
     }
-    return _previous_seen_epoch;
+    return _seen->window.min;
 }
 
 bool ctp_stm_state::epoch_in_window(
   model::term_id term, cluster_epoch epoch) const noexcept {
-    // If the term is newer then treat the window as unset.
-    if (term > _seen_window_term) {
-        auto end = _max_applied_epoch.value_or(cluster_epoch::min());
-        auto begin = _previous_applied_epoch.value_or(end);
-        return epoch >= begin && epoch <= end;
+    if (!_seen.has_value() || term > _seen->term) {
+        // The seen window is invisible to queries at newer terms: the
+        // applied window is the only evidence.
+        auto applied = _applied.window();
+        return applied.has_value() && applied->contains(epoch);
     }
-    // NOTE: the window should move forward with _max_seen_epoch.
-    // If _max_seen_epoch is greater than _max_applied_epoch then
-    // the window should be [_previous_seen_epoch, _max_seen_epoch].
-    // The window reflects in-flight requests. Write fence is required
-    // to move it forward.
-    auto end = _max_seen_epoch.value_or(
-      _max_applied_epoch.value_or(cluster_epoch::min()));
-    auto begin = _previous_seen_epoch.value_or(
-      _previous_applied_epoch.value_or(end));
-    if (epoch < begin || epoch > end) {
+    const auto& seen = _seen->window;
+    if (!seen.contains(epoch)) {
         return false;
     }
-    if (epoch == end) {
+    if (epoch == seen.max) {
         return true;
     }
     // A below-max epoch is only admissible if some epoch batch is known to
@@ -101,30 +127,28 @@ bool ctp_stm_state::epoch_in_window(
     // considers inactive.
     //
     // Applied state gives positional evidence, since apply follows log order:
-    // - _max_applied_epoch < end: an applied batch sits at a lower log
+    // - applied max < seen max: an applied batch sits at a lower log
     //   position than any batch at the max-seen epoch (applied or not).
-    // - _max_applied_epoch == end: the max epoch applied; a batch preceded it
-    //   iff the applied window did not collapse to [end, end].
-    if (!_max_applied_epoch.has_value()) {
+    // - applied max == seen max: the max epoch applied; a batch preceded it
+    //   iff the applied window did not collapse to [max, max].
+    if (!_applied.max.has_value()) {
         return false;
     }
-    if (*_max_applied_epoch < end) {
+    if (*_applied.max < seen.max) {
         return true;
     }
-    return *_max_applied_epoch == end
-           && _previous_applied_epoch.value_or(end) < end;
+    return *_applied.max == seen.max
+           && _applied.previous.value_or(seen.max) < seen.max;
 }
 
 bool ctp_stm_state::epoch_above_window(
   model::term_id term, cluster_epoch epoch) const noexcept {
-    // If the term changed, treat it as unset.
-    if (term > _seen_window_term) {
-        auto end = _max_applied_epoch.value_or(cluster_epoch::min());
-        return epoch > end;
+    if (!_seen.has_value() || term > _seen->term) {
+        // The seen window is invisible to queries at newer terms.
+        auto applied = _applied.window();
+        return !applied.has_value() || epoch > applied->max;
     }
-    auto end = _max_seen_epoch.value_or(
-      _max_applied_epoch.value_or(cluster_epoch::min()));
-    return epoch > end;
+    return epoch > _seen->window.max;
 }
 
 std::optional<cluster_epoch>
@@ -133,32 +157,13 @@ ctp_stm_state::estimate_inactive_epoch() const noexcept {
 }
 
 void ctp_stm_state::advance_epoch(cluster_epoch epoch, model::offset offset) {
-    // Register new epoch
-    if (epoch > _max_applied_epoch.value_or(cluster_epoch::min())) {
-        // A new max epoch requires the sliding window of epoch values in flight
-        // to be moved.
-        if (!_min_epoch_lower_bound.has_value()) {
-            // First epoch applied to the STM
-            _min_epoch_lower_bound = epoch;
-        }
-        // Move the sliding window
-        _previous_applied_epoch = _max_applied_epoch.value_or(epoch);
-        _max_applied_epoch = epoch;
-        _current_epoch_window_offset = offset;
-    }
+    _applied.advance(epoch, offset);
 }
 
 void ctp_stm_state::advance_last_reconciled_offset(
   kafka::offset new_last_reconciled_offset,
   model::offset new_last_reconciled_log_offset) noexcept {
-    if (
-      _current_epoch_window_offset.value_or(model::offset{})
-      <= new_last_reconciled_log_offset) {
-        // We advanced LRO past the offset at which we saw the current
-        // epoch window value so we can use previous epoch as
-        // the new min_applied_epoch
-        _min_epoch_lower_bound = _previous_applied_epoch;
-    }
+    _applied.on_lro_advanced(new_last_reconciled_log_offset);
     _last_reconciled_offset = std::max(
       _last_reconciled_offset.value_or(kafka::offset{}),
       new_last_reconciled_offset);
@@ -169,15 +174,15 @@ void ctp_stm_state::advance_last_reconciled_offset(
 
 std::optional<cluster_epoch>
 ctp_stm_state::get_max_applied_epoch() const noexcept {
-    return _max_applied_epoch;
+    return _applied.max;
 }
 
 std::optional<cluster_epoch>
 ctp_stm_state::get_max_seen_epoch(model::term_id term) const noexcept {
-    if (term > _seen_window_term) {
+    if (!_seen.has_value() || term > _seen->term) {
         return std::nullopt;
     }
-    return _max_seen_epoch;
+    return _seen->window.max;
 }
 
 model::offset ctp_stm_state::get_max_collectible_offset() const noexcept {
@@ -227,17 +232,23 @@ kafka::offset ctp_stm_state::get_min_allowed_local_threshold() const noexcept {
 }
 
 fmt::iterator ctp_stm_state::format_to(fmt::iterator it) const {
+    std::optional<cluster_epoch> seen_min;
+    std::optional<cluster_epoch> seen_max;
+    if (_seen.has_value()) {
+        seen_min = _seen->window.min;
+        seen_max = _seen->window.max;
+    }
     return fmt::format_to(
       it,
       "{{seen_window=[{}, {}], applied_window=[{}, {}], "
       "epoch_window_offset={}, min_epoch_lower_bound={}, lro={}, lrlo={}, "
       "start_offset={}}}",
-      _previous_seen_epoch,
-      _max_seen_epoch,
-      _previous_applied_epoch,
-      _max_applied_epoch,
-      _current_epoch_window_offset,
-      _min_epoch_lower_bound,
+      seen_min,
+      seen_max,
+      _applied.previous,
+      _applied.max,
+      _applied.window_offset,
+      _applied.min_lower_bound,
       _last_reconciled_offset,
       _last_reconciled_log_offset,
       _start_offset);

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
@@ -122,6 +122,16 @@ public:
     /// Return true if the epoch is above the current window
     bool
     epoch_above_window(model::term_id term, cluster_epoch epoch) const noexcept;
+    /// Return true if the epoch can be admitted by moving a seen-window
+    /// boundary: bumping the max above the window or raising the min to an
+    /// interior epoch. The caller has to hold the write lock across
+    /// move_seen_window so no fenced replication is in flight while the
+    /// window moves.
+    bool
+    epoch_moves_window(model::term_id term, cluster_epoch epoch) const noexcept;
+    /// Move a seen-window boundary to admit the epoch. No-op for epochs
+    /// that don't satisfy epoch_moves_window.
+    void move_seen_window(model::term_id term, cluster_epoch epoch) noexcept;
 
     /// Estimate inactive epoch
     std::optional<cluster_epoch> estimate_inactive_epoch() const noexcept;
@@ -245,6 +255,34 @@ private:
         /// the window transitioned to the current max.
         void on_lro_advanced(model::offset lro_log_offset) noexcept;
     };
+
+    /// How the seen and the applied windows combine into the effective
+    /// admission window for a query at a given term.
+    enum class window_state {
+        /// No seen window is visible at the term (never built, or built in
+        /// an older term): the applied window is the only evidence.
+        applied_only,
+        /// The batch carrying the seen max hasn't been applied yet: the
+        /// effective window is the seen window and only its boundaries are
+        /// safe to replicate concurrently.
+        pending,
+        /// The batch carrying the seen max has been applied: the log's
+        /// epoch window is frozen at the applied window until the next
+        /// bump.
+        frozen,
+    };
+
+    struct resolved_window {
+        window_state state;
+        /// The effective admission window; nullopt only in the applied_only
+        /// state when nothing has been applied yet.
+        std::optional<epoch_window> window;
+    };
+
+    /// Combine the seen and the applied windows for a query at the given
+    /// term. This is the only place where the seen-window term visibility
+    /// rule and the seen/applied fallbacks live.
+    resolved_window resolve_window(model::term_id term) const noexcept;
 
     /// In-flight (seen) epoch window.
     ///

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
@@ -49,6 +49,10 @@ public:
 
     /// This is invoked in the write path before the batch with new
     /// epoch value is even replicated.
+    ///
+    /// A term newer than the seen-window term always resets the window to
+    /// [epoch, epoch]; within the same term only a larger epoch advances the
+    /// max (the previous max becomes the window min).
     void
     advance_max_seen_epoch(model::term_id term, cluster_epoch epoch) noexcept;
 

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
@@ -18,6 +18,21 @@
 
 namespace cloud_topics {
 
+/// A closed interval of cluster epochs, [min, max].
+struct epoch_window {
+    cluster_epoch min;
+    cluster_epoch max;
+
+    /// True if the epoch lies within the window boundaries (inclusive).
+    bool contains(cluster_epoch epoch) const noexcept {
+        return epoch >= min && epoch <= max;
+    }
+    /// True if the epoch lies strictly between the window boundaries.
+    bool interior(cluster_epoch epoch) const noexcept {
+        return epoch > min && epoch < max;
+    }
+};
+
 /// In-memory state of the cloud-topics state machine (ctp_stm).
 ///
 class ctp_stm_state
@@ -147,14 +162,16 @@ public:
     /// when the floor is unset.
     kafka::offset get_min_allowed_local_threshold() const noexcept;
 
+    // The wire format predates the applied_epochs grouping: the fields are
+    // serialized individually at their historical positions.
     auto serde_fields() {
         return std::tie(
-          _max_applied_epoch,
+          _applied.max,
           _last_reconciled_offset,
           _last_reconciled_log_offset,
-          _current_epoch_window_offset,
-          _min_epoch_lower_bound,
-          _previous_applied_epoch,
+          _applied.window_offset,
+          _applied.min_lower_bound,
+          _applied.previous,
           _start_offset,
           _size_estimator,
           _min_allowed_local_threshold);
@@ -176,46 +193,68 @@ public:
     fmt::iterator format_to(fmt::iterator) const;
 
 private:
-    /// The term at which the *_seen_epochs are for, due to the sliding window
-    /// having the ability to diverge, we only track it within a single term,
-    /// then reset the window to avoid nasty edge cases when leadership changes.
-    model::term_id _seen_window_term;
-    /// The max epoch after the current in flight requests are applied.
+    /// The seen window: the range of epochs admitted for replication within
+    /// a single term. The max is the largest epoch expected to reach the log
+    /// in the term (its batch may still be replicating); epochs below the
+    /// min are fenced off. Due to the sliding window having the ability to
+    /// diverge from the log, the window is only meaningful within the term
+    /// it was built in and is invisible to queries at newer terms (see
+    /// resolve_window).
     ///
-    /// This is required because of the pipelining of requests in the STM.
-    /// If present, we don't allow any replicated requests to have an epoch
-    /// that is lower than this value.
-    std::optional<cluster_epoch> _max_seen_epoch;
+    /// Invariant: window.min <= window.max. Every move preserves it: a
+    /// term reset collapses the window to one epoch, a bump makes the old
+    /// max the new min, an interior admission raises the min below the max.
+    struct seen_epochs {
+        model::term_id term;
+        epoch_window window;
+    };
 
-    /// The previous epoch after the current in flight requests are applied.
-    /// Requests with epochs below this value are fenced and not allowed to be
-    /// applied to the STM.
+    /// The applied side of the epoch tracking: the epoch window of the log
+    /// (the last two distinct epochs applied to the STM) together with the
+    /// offset bookkeeping that ties the window to the log position and to
+    /// the LRO-driven GC lower bound.
+    struct applied_epochs {
+        /// The maximum epoch of applied batches to the STM.
+        ///
+        /// We enforce no epochs applied or replicated are less than this
+        /// value.
+        std::optional<cluster_epoch> max;
+
+        /// The epoch that preceded max in the log.
+        /// Invariant: previous <= max; engaged whenever max is engaged.
+        std::optional<cluster_epoch> previous;
+
+        /// The offset at which the window transitioned to the current max.
+        std::optional<model::offset> window_offset;
+
+        /// The epoch which is less or equal to the current epoch window
+        /// referenced by the first record batch after the last reconciled
+        /// offset. This epoch is not guaranteed to be "active" (from the
+        /// point of view of the partition) but it's guaranteed that all
+        /// epochs before this epoch are "inactive".
+        std::optional<cluster_epoch> min_lower_bound;
+
+        /// The applied window [previous, max]; nullopt when nothing has
+        /// been applied yet.
+        std::optional<epoch_window> window() const noexcept;
+
+        /// Idempotently advance the window (see advance_epoch).
+        void advance(cluster_epoch epoch, model::offset offset) noexcept;
+
+        /// Advance min_lower_bound once the LRO passes the offset at which
+        /// the window transitioned to the current max.
+        void on_lro_advanced(model::offset lro_log_offset) noexcept;
+    };
+
+    /// In-flight (seen) epoch window.
     ///
     /// Not persisted with the snapshot because it reflects the state of
     /// in-flight requests.
-    std::optional<cluster_epoch> _previous_seen_epoch;
+    std::optional<seen_epochs> _seen;
 
-    /// The maximum epoch of applied batches to the STM.
-    ///
-    /// We enforce no epochs applied or replicated are less than this value.
-    std::optional<cluster_epoch> _max_applied_epoch;
-
-    /// The previous max epoch applied to the STM state.
-    /// Invariant:
-    /// - _previous_epoch < _max_applied_epoch
-    /// - _previous_epoch <= _previous_seen_epoch
-    std::optional<cluster_epoch> _previous_applied_epoch;
-
-    /// The offset at which the current applied epoch window was transitioned
-    /// to.
-    std::optional<model::offset> _current_epoch_window_offset;
-
-    /// The epoch which is less or equal to the current epoch window referenced
-    /// by the first record batch after the last reconciled offset.
-    /// This epoch is not guaranteed to be "active" (from the point of
-    /// view of the partition) but it's guaranteed that all epochs before
-    /// this epoch are "inactive".
-    std::optional<cluster_epoch> _min_epoch_lower_bound;
+    /// Applied epoch window and its offset bookkeeping. The members are
+    /// persisted with the snapshot individually (see serde_fields).
+    applied_epochs _applied;
 
     /// The last offset that was uploaded to L1. This value may lag behind
     /// the value stored in the L1 metastore, but should never be ahead of

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
@@ -367,6 +367,32 @@ TEST(ctp_stm_state_test, seen_window_resets_on_term_change_despite_stale_max) {
     EXPECT_FALSE(state.epoch_in_window(term2, 8_epoch));
 }
 
+TEST(ctp_stm_state_test, stale_epoch_rejected_after_seen_applied_divergence) {
+    // A fence-time bump whose batch never lands (failed replicate) diverges
+    // the seen window from the log content. Interior epochs that land
+    // afterwards ratchet the log's epoch window upwards ([10, 12], then
+    // [12, 13]); an epoch below it must not be admitted: replicated, it
+    // would land above the batches that moved the log window past it and
+    // trip the epoch_window_checker vassert in do_apply on every replica
+    // (and break the GC epoch lower bound).
+    ct::ctp_stm_state state;
+    model::term_id term(1);
+
+    state.advance_max_seen_epoch(term, 10_epoch);
+    state.advance_epoch(10_epoch, model::offset{0});
+    // Bump to 14; the bump batch is discarded.
+    state.advance_max_seen_epoch(term, 14_epoch);
+    // Interior epochs 12 and 13 land.
+    state.advance_epoch(12_epoch, model::offset{1});
+    state.advance_epoch(13_epoch, model::offset{2});
+
+    // The log window is [12, 13]: epochs below it are not admissible.
+    EXPECT_FALSE(state.epoch_in_window(term, 11_epoch));
+    EXPECT_FALSE(state.epoch_in_window(term, 12_epoch));
+    // The pending max-seen epoch remains admissible.
+    EXPECT_TRUE(state.epoch_in_window(term, 14_epoch));
+}
+
 TEST(ctp_stm_state_test, l0_simulation) {
     struct uploaded_l0_file_batch {
         ct::cluster_epoch epoch;

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
@@ -238,10 +238,13 @@ TEST(ctp_stm_state_test, sliding_window_issue) {
     EXPECT_TRUE(state.epoch_in_window(term, 5_epoch));
     // Our previous epoch is good still
     EXPECT_TRUE(state.epoch_in_window(term, 2_epoch));
-    // And so is something in between (unlikely in real life, but just to show)
-    EXPECT_TRUE(state.epoch_in_window(term, 3_epoch));
+    // Something in between is not a window boundary: it can only be admitted
+    // by moving the window min (write lock in fence_epoch).
+    EXPECT_FALSE(state.epoch_in_window(term, 3_epoch));
+    EXPECT_TRUE(state.epoch_moves_window(term, 3_epoch));
     // Something below is still bad
     EXPECT_FALSE(state.epoch_in_window(term, 1_epoch));
+    EXPECT_FALSE(state.epoch_moves_window(term, 1_epoch));
 
     // Still not safe to GC, we accept stuff at epoch 0
     EXPECT_EQ(estimate_inactive_epoch(), 1_epoch);
@@ -260,7 +263,9 @@ TEST(ctp_stm_state_test, sliding_window_issue) {
     state.advance_max_seen_epoch(term, 10_epoch);
     EXPECT_TRUE(state.epoch_in_window(term, 10_epoch));
     EXPECT_TRUE(state.epoch_in_window(term, 5_epoch));
-    EXPECT_TRUE(state.epoch_in_window(term, 8_epoch));
+    // Interior epochs need a window move.
+    EXPECT_FALSE(state.epoch_in_window(term, 8_epoch));
+    EXPECT_TRUE(state.epoch_moves_window(term, 8_epoch));
     EXPECT_FALSE(state.epoch_in_window(term, 0_epoch));
     EXPECT_FALSE(state.epoch_in_window(term, 4_epoch));
 
@@ -278,7 +283,8 @@ TEST(ctp_stm_state_test, sliding_window_issue) {
     state.advance_max_seen_epoch(term, 15_epoch);
     EXPECT_TRUE(state.epoch_in_window(term, 10_epoch));
     EXPECT_TRUE(state.epoch_in_window(term, 15_epoch));
-    EXPECT_TRUE(state.epoch_in_window(term, 12_epoch));
+    EXPECT_FALSE(state.epoch_in_window(term, 12_epoch));
+    EXPECT_TRUE(state.epoch_moves_window(term, 12_epoch));
     EXPECT_FALSE(state.epoch_in_window(term, 9_epoch));
 
     EXPECT_EQ(estimate_inactive_epoch(), 4_epoch);
@@ -393,6 +399,91 @@ TEST(ctp_stm_state_test, stale_epoch_rejected_after_seen_applied_divergence) {
     EXPECT_TRUE(state.epoch_in_window(term, 14_epoch));
 }
 
+TEST(ctp_stm_state_test, interior_epoch_moves_window_min) {
+    ct::ctp_stm_state state;
+    model::term_id term(1);
+
+    // Epoch 10 lands and applies, then a bump to 14 whose batch is still in
+    // flight.
+    state.advance_max_seen_epoch(term, 10_epoch);
+    state.advance_epoch(10_epoch, model::offset{0});
+    state.advance_max_seen_epoch(term, 14_epoch);
+
+    // Window boundaries are admissible under a read fence.
+    EXPECT_TRUE(state.epoch_in_window(term, 10_epoch));
+    EXPECT_TRUE(state.epoch_in_window(term, 14_epoch));
+    // Interior epochs are not: they require a window move.
+    EXPECT_FALSE(state.epoch_in_window(term, 12_epoch));
+    EXPECT_TRUE(state.epoch_moves_window(term, 12_epoch));
+
+    state.move_seen_window(term, 12_epoch);
+    // 12 became the window min...
+    EXPECT_TRUE(state.epoch_in_window(term, 12_epoch));
+    // ...and fenced off everything below it.
+    EXPECT_FALSE(state.epoch_in_window(term, 10_epoch));
+    EXPECT_FALSE(state.epoch_in_window(term, 11_epoch));
+    EXPECT_FALSE(state.epoch_moves_window(term, 11_epoch));
+}
+
+TEST(ctp_stm_state_test, stale_epoch_rejected_after_interior_window_moves) {
+    // Regression: a bump whose batch never lands, followed by interior
+    // epochs that land one after another, ratchets the log's epoch window
+    // upwards ([10, 12], then [12, 13]). An epoch below the last interior
+    // admission must be rejected: replicated, it would land above the
+    // batches that moved the log window past it, tripping the
+    // epoch_window_checker vassert in do_apply on every replica and breaking
+    // the GC epoch lower bound.
+    ct::ctp_stm_state state;
+    model::term_id term(1);
+
+    state.advance_max_seen_epoch(term, 10_epoch);
+    state.advance_epoch(10_epoch, model::offset{0});
+    // Bump to 14; the bump batch is discarded (replicate failed).
+    state.advance_max_seen_epoch(term, 14_epoch);
+
+    // Interior epochs 12 and 13 are admitted by moving the window min and
+    // their batches land: the log window becomes [12, 13].
+    ASSERT_TRUE(state.epoch_moves_window(term, 12_epoch));
+    state.move_seen_window(term, 12_epoch);
+    state.advance_epoch(12_epoch, model::offset{1});
+    ASSERT_TRUE(state.epoch_moves_window(term, 13_epoch));
+    state.move_seen_window(term, 13_epoch);
+    state.advance_epoch(13_epoch, model::offset{2});
+
+    // Epoch 11 is below the log window: neither admissible nor able to move
+    // the window.
+    EXPECT_FALSE(state.epoch_in_window(term, 11_epoch));
+    EXPECT_FALSE(state.epoch_moves_window(term, 11_epoch));
+    // Epoch 12 is below the log window max as well: only the window
+    // boundaries remain admissible.
+    EXPECT_FALSE(state.epoch_in_window(term, 12_epoch));
+    EXPECT_TRUE(state.epoch_in_window(term, 13_epoch));
+    EXPECT_TRUE(state.epoch_in_window(term, 14_epoch));
+}
+
+TEST(ctp_stm_state_test, frozen_window_admits_applied_range) {
+    // Once the max-seen epoch's batch has applied, nothing can move the
+    // log's epoch window until the next bump, so everything within the
+    // applied window is admissible without moving the seen window.
+    ct::ctp_stm_state state;
+    model::term_id term(1);
+
+    state.advance_max_seen_epoch(term, 10_epoch);
+    state.advance_epoch(10_epoch, model::offset{0});
+    state.advance_max_seen_epoch(term, 14_epoch);
+    state.advance_epoch(14_epoch, model::offset{1});
+
+    // The log window is frozen at [10, 14].
+    for (int64_t e = 10; e <= 14; ++e) {
+        EXPECT_TRUE(state.epoch_in_window(term, ct::cluster_epoch{e})) << e;
+        // No window move is needed (or allowed).
+        EXPECT_FALSE(state.epoch_moves_window(term, ct::cluster_epoch{e})) << e;
+    }
+    EXPECT_FALSE(state.epoch_in_window(term, 9_epoch));
+    EXPECT_FALSE(state.epoch_moves_window(term, 9_epoch));
+    EXPECT_TRUE(state.epoch_moves_window(term, 15_epoch));
+}
+
 TEST(ctp_stm_state_test, l0_simulation) {
     struct uploaded_l0_file_batch {
         ct::cluster_epoch epoch;
@@ -409,6 +500,12 @@ TEST(ctp_stm_state_test, l0_simulation) {
         // be applied to the log. The epochs may not be in order because they
         // may come from different shards/brokers.
         ss::chunked_fifo<uploaded_l0_file_batch> uploaded_batches;
+        // Batches that are fenced (admitted for replication) but have not
+        // reached the log yet. The real system replicates them concurrently,
+        // so they may land in any order; a seen-window move waits for all of
+        // them to land first (the fence write lock drains in-flight
+        // replications).
+        std::vector<ct::cluster_epoch> fenced_batches;
         // Placeholders that are replicated, but not yet applied to the
         // to the STM.
         ss::chunked_fifo<placeholder_batch> unapplied_placeholders;
@@ -416,6 +513,11 @@ TEST(ctp_stm_state_test, l0_simulation) {
         ss::chunked_fifo<placeholder_batch> log_placeholders;
         // hwm for the partition
         kafka::offset hwm = 0_offset;
+        // Mirrors epoch_window_checker: the sliding epoch window of the log
+        // content that every appended batch has to satisfy (or every replica
+        // dies applying it).
+        ct::cluster_epoch checker_min = ct::cluster_epoch::min();
+        ct::cluster_epoch checker_max = ct::cluster_epoch::min();
 
         testing::AssertionResult validate() {
             // The main thing we want to validate is that there are no batches
@@ -434,20 +536,23 @@ TEST(ctp_stm_state_test, l0_simulation) {
             // What do we say we can GC?
             auto inactive_epoch = stm.estimate_inactive_epoch();
             if (min_active_epoch == non_reconciled_batches.end()) {
-                // There is nothing in the log unreconcilded, we should not yet
-                // have an inactive epoch above what is yet to be replicated.
-                if (!uploaded_batches.empty()) {
-                    auto it = std::ranges::min_element(
-                      uploaded_batches, std::less<>(), [](const auto& batch) {
-                          return batch.epoch;
-                      });
-                    if (inactive_epoch > it->epoch) {
-                        return testing::AssertionFailure() << fmt::format(
-                                 "expected inactive epoch ({}) to not be above "
-                                 "active epochs {}",
-                                 inactive_epoch.value(),
-                                 it->epoch);
-                    }
+                // There is nothing in the log unreconciled, we should not yet
+                // have an inactive epoch above what is yet to be replicated
+                // (uploaded or fenced and in flight).
+                std::optional<ct::cluster_epoch> min_pending;
+                for (const auto& batch : uploaded_batches) {
+                    min_pending = std::min(
+                      min_pending.value_or(batch.epoch), batch.epoch);
+                }
+                for (auto epoch : fenced_batches) {
+                    min_pending = std::min(min_pending.value_or(epoch), epoch);
+                }
+                if (min_pending.has_value() && inactive_epoch > *min_pending) {
+                    return testing::AssertionFailure() << fmt::format(
+                             "expected inactive epoch ({}) to not be above "
+                             "active epochs {}",
+                             inactive_epoch.value(),
+                             *min_pending);
                 }
             } else if (inactive_epoch >= min_active_epoch->epoch) {
                 return testing::AssertionFailure() << fmt::format(
@@ -503,28 +608,69 @@ TEST(ctp_stm_state_test, l0_simulation) {
           << fmt::format("operations:\n{}", fmt::join(oplog, "\n"));
         // Possible operations we can perform in the universe.
         std::vector<std::function<void()>> possible_operations;
-        // If there are batches to upload, let's do it.
+        // If there are batches to upload, fence the next one. Mirror the
+        // fence_epoch branches: epochs admissible under the current window
+        // take a read fence; epochs that require moving a window boundary
+        // (bumping the max or raising the min) take the write lock, which
+        // drains in-flight replications first - so such an admission is only
+        // possible while nothing is in flight; everything else is rejected
+        // (the producer would retry with a fresh epoch).
         if (!universe.uploaded_batches.empty()) {
-            possible_operations.emplace_back([&universe, &oplog, term] {
-                auto batch = universe.uploaded_batches.front();
-                universe.uploaded_batches.pop_front();
-                // Mirror the fence_epoch branches: bump the window for an
-                // above-window epoch, replicate an in-window epoch, reject
-                // everything else. A below-max epoch is rejected while no
-                // applied batch proves that something precedes the max
-                // epoch's first batch in the log (the producer would retry
-                // with a fresh epoch).
-                if (universe.stm.epoch_above_window(term, batch.epoch)) {
-                    universe.stm.advance_max_seen_epoch(term, batch.epoch);
-                    ASSERT_TRUE(
-                      universe.stm.epoch_in_window(term, batch.epoch));
-                } else if (!universe.stm.epoch_in_window(term, batch.epoch)) {
+            auto epoch = universe.uploaded_batches.front().epoch;
+            bool in_window = universe.stm.epoch_in_window(term, epoch);
+            bool moves = universe.stm.epoch_moves_window(term, epoch);
+            if (in_window || (moves && universe.fenced_batches.empty())) {
+                possible_operations.emplace_back(
+                  [&universe, &oplog, term, epoch, in_window] {
+                      universe.uploaded_batches.pop_front();
+                      if (!in_window) {
+                          universe.stm.move_seen_window(term, epoch);
+                          ASSERT_TRUE(
+                            universe.stm.epoch_in_window(term, epoch));
+                      }
+                      universe.fenced_batches.push_back(epoch);
+                      oplog.push_back(
+                        fmt::format("fenced batch with epoch {}", epoch));
+                  });
+            } else if (!moves) {
+                possible_operations.emplace_back([&universe, &oplog, epoch] {
+                    universe.uploaded_batches.pop_front();
                     oplog.push_back(
-                      fmt::format("rejected batch with epoch {}", batch.epoch));
-                    return;
-                }
+                      fmt::format("rejected batch with epoch {}", epoch));
+                });
+            }
+            // Otherwise the admission is waiting for the write lock: the
+            // replicate operations below drain the in-flight batches first.
+        }
+        // Replicate a fenced batch. In-flight batches can reach the log in
+        // any order, so pick a random one.
+        if (!universe.fenced_batches.empty()) {
+            possible_operations.emplace_back([&universe, &oplog] {
+                auto idx = random_generators::get_int<size_t>(
+                  universe.fenced_batches.size() - 1);
+                auto epoch = universe.fenced_batches[idx];
+                universe.fenced_batches.erase(
+                  universe.fenced_batches.begin()
+                  + static_cast<std::ptrdiff_t>(idx));
                 placeholder_batch placeholder{
-                  .epoch = batch.epoch, .offset = universe.hwm++};
+                  .epoch = epoch, .offset = universe.hwm++};
+                // Mirror epoch_window_checker::check_epoch: every batch
+                // reaching the log must be within the log's sliding epoch
+                // window.
+                if (epoch > universe.checker_max) {
+                    universe.checker_min = universe.checker_max
+                                               == ct::cluster_epoch::min()
+                                             ? epoch
+                                             : universe.checker_max;
+                    universe.checker_max = epoch;
+                }
+                ASSERT_GE(epoch, universe.checker_min) << fmt::format(
+                  "epoch {} landed below the log window [{}, {}], "
+                  "operations:\n{}",
+                  epoch,
+                  universe.checker_min,
+                  universe.checker_max,
+                  fmt::join(oplog, "\n"));
                 universe.unapplied_placeholders.push_back(placeholder);
                 universe.log_placeholders.push_back(placeholder);
                 oplog.push_back(

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
@@ -341,6 +341,32 @@ TEST(ctp_stm_state_test, below_max_fence_allowed_with_applied_evidence) {
     EXPECT_FALSE(state.epoch_in_window(term, 131_epoch));
 }
 
+TEST(ctp_stm_state_test, seen_window_resets_on_term_change_despite_stale_max) {
+    // A fenced bump whose batch never lands can leave a very large
+    // _max_seen_epoch behind. A bump in a newer term must reset the window
+    // even when the new epoch is below the stale max, otherwise the stale
+    // window blocks the reset and the new term keeps fencing against it.
+    ct::ctp_stm_state state;
+    model::term_id term1(1);
+    model::term_id term2(2);
+
+    state.advance_max_seen_epoch(term1, 100_epoch);
+    EXPECT_EQ(state.get_max_seen_epoch(term1), 100_epoch);
+
+    // Epochs 7 and 8 land and apply (e.g. replicated by another leader).
+    state.advance_epoch(7_epoch, model::offset{0});
+    state.advance_epoch(8_epoch, model::offset{1});
+
+    // In the new term the stale window is invisible...
+    EXPECT_EQ(state.get_max_seen_epoch(term2), std::nullopt);
+    // ...and a bump below the stale max resets it.
+    state.advance_max_seen_epoch(term2, 9_epoch);
+    EXPECT_EQ(state.get_max_seen_epoch(term2), 9_epoch);
+    EXPECT_TRUE(state.epoch_in_window(term2, 9_epoch));
+    // Pre-bump epochs are fenced off until the bump batch applies.
+    EXPECT_FALSE(state.epoch_in_window(term2, 8_epoch));
+}
+
 TEST(ctp_stm_state_test, l0_simulation) {
     struct uploaded_l0_file_batch {
         ct::cluster_epoch epoch;

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -1174,6 +1174,81 @@ TEST_F_CORO(ctp_stm_fixture, test_below_max_fence_allowed_after_epoch_landed) {
     ASSERT_TRUE_CORO(ok);
 }
 
+TEST_F_CORO(ctp_stm_fixture, test_interior_epoch_fence_after_failed_bump) {
+    // Regression: a fenced epoch bump whose batch never lands, followed by
+    // interior (out-of-order) epochs that do land, must not admit an epoch
+    // below the batches already in the log.
+    //
+    // Scenario, all within one term:
+    // 1. Fence + replicate epoch 10 (seen window [10, 10]).
+    // 2. Fence epoch 14, drop the guard without replicating (seen window
+    //    [10, 14], nothing at epoch 14 in the log).
+    // 3. Fence + replicate epoch 12: fence_epoch raises the window min to 12
+    //    under the write lock. The log window becomes [10, 12].
+    // 4. Fence + replicate epoch 13: the window min moves to 13, the log
+    //    window ratchets to [12, 13].
+    // 5. Fence epoch 11: must be rejected. The old admission check
+    //    (_max_applied_epoch < max_seen) granted the fence and the
+    //    replicated batch tripped the epoch_window_checker vassert in
+    //    do_apply on every replica ("epoch 11 at N is outside of sliding
+    //    window [12, 13]").
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+
+    auto& leader = node(*get_leader());
+    auto leader_api = api(leader);
+
+    bool ok = co_await replicate_with_epoch(
+      leader, ct::cluster_epoch{10}, model::offset{0}, 0);
+    ASSERT_TRUE_CORO(ok);
+
+    {
+        auto fence = co_await leader_api.fence_epoch(ct::cluster_epoch{14});
+        ASSERT_TRUE_CORO(fence.has_value());
+        // Guard dropped without replicating: the bump batch never lands.
+    }
+
+    // Interior epochs are admitted one by one, each moving the window min.
+    ok = co_await replicate_with_epoch(
+      leader, ct::cluster_epoch{12}, model::offset{1}, 1);
+    ASSERT_TRUE_CORO(ok);
+
+    // 11 is already below the window min.
+    {
+        auto stale = co_await leader_api.fence_epoch(ct::cluster_epoch{11});
+        EXPECT_FALSE(stale.has_value())
+          << "fence_epoch admitted epoch 11 although the window min moved "
+             "past it";
+    }
+
+    ok = co_await replicate_with_epoch(
+      leader, ct::cluster_epoch{13}, model::offset{2}, 2);
+    ASSERT_TRUE_CORO(ok);
+
+    auto stale_fence = co_await leader_api.fence_epoch(ct::cluster_epoch{11});
+    EXPECT_FALSE(stale_fence.has_value())
+      << "fence_epoch admitted epoch 11 although the log window is [12, 13]";
+    if (stale_fence.has_value()) {
+        // Under the bug, replicating with the granted fence reproduces the
+        // crash: apply trips the epoch_window_checker vassert on every
+        // replica.
+        auto guard = std::move(stale_fence.value());
+        auto batch = make_record_batch(
+          ct::cluster_epoch{11}, model::offset{3}, 3);
+        auto res = co_await replicate_record_batch(leader, std::move(batch));
+        ASSERT_TRUE_CORO(res.has_value());
+    }
+
+    // The window boundaries stay usable: a straggler at the window min and
+    // a batch at the pending max are both admissible.
+    ok = co_await replicate_with_epoch(
+      leader, ct::cluster_epoch{13}, model::offset{3}, 3);
+    ASSERT_TRUE_CORO(ok);
+    ok = co_await replicate_with_epoch(
+      leader, ct::cluster_epoch{14}, model::offset{4}, 4);
+    ASSERT_TRUE_CORO(ok);
+}
+
 // Test for the combined advance_epoch + sync_to_next_placeholder functionality.
 // This is the primary use case: enabling GC progress on idle partitions by
 // recording the current epoch and advancing LRLO past the advance_epoch batch.


### PR DESCRIPTION
The ctp_stm epoch fence admitted any epoch within the seen window `[previous_seen, max_seen]` under a shared (read) fence. This is unsound: batches admitted under one window can reach the log in any order, and every batch that lands above the current log maximum ratchets the log's epoch window forward (this is the invariant `epoch_window_checker` enforces in `do_apply`, and the applied window feeds the L0 GC epoch lower bound). A fenced bump whose batch never lands, followed by two interior epochs that do land, moves the log window above a third interior epoch that the fence still admits:

1. fence 10, replicate, apply — seen `[10, 10]`, log `[10, 10]`
2. fence 14, replicate fails — seen `[10, 14]`, log `[10, 10]`
3. fence 12, replicate, apply — seen `[10, 14]`, log `[10, 12]`
4. fence 13, replicate, apply — seen `[10, 14]`, log `[12, 13]`
5. fence 11: admitted by the old check (`max_applied < max_seen`), lands above the epoch-13 batch and trips the `epoch_window_checker` vassert on every replica that applies it — including on replay after restart. Without the assert the GC lower bound would treat the epoch-11 L0 objects as inactive while a placeholder still references them.

This PR reworks the admission rules so a shared fence only admits epochs that cannot violate the log window regardless of landing order: the window boundaries themselves and, once the max-seen batch has applied (which freezes the log window until the next bump), anything within the applied window. Every other admissible epoch must first move a seen-window boundary — bump the max (as before) or raise the min to the admitted epoch — and both moves now require the write lock, i.e. they wait for all in-flight fenced replications to land.

The PR also fixes a latent bug in `advance_max_seen_epoch`: the first bump of a new term didn't reset the seen window when the new epoch was below a stale `_max_seen_epoch` left behind by a failed bump in a previous term, so the bump was never recorded in the window and concurrent fences couldn't see it.

The l0 simulation test now models fenced batches landing in random order and asserts the `epoch_window_checker` invariant on every landed batch. New state- and raft-level regression tests cover the interior-epoch scenario above.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
