### PR TITLE
dl/coordinator: fix drain test flake under task shuffling

### DIFF
--- a/src/v/datalake/coordinator/tests/coordinator_test.cc
+++ b/src/v/datalake/coordinator/tests/coordinator_test.cc
@@ -861,7 +861,10 @@ TEST_F(CoordinatorChunkedLoopTest, TestDrainsBacklogWithoutSleeping) {
     // we can stage the full backlog before a pass begins.
     opt_ref leader_opt;
     ASSERT_NO_FATAL_FAILURE(wait_for_leader(leader_opt).get());
+    // Step down and notify -- this causes the background loop to stop sleeping
+    // in the now-defunct term and wait for further notification.
     leader_opt->get().stm.raft()->step_down("test").get();
+    leader_opt->get().crd.notify_leadership(std::nullopt);
     ASSERT_NO_FATAL_FAILURE(wait_for_leader(leader_opt).get());
     auto& leader = leader_opt->get();
 


### PR DESCRIPTION
Deflake `TestDrainsBacklogWithoutSleeping` by notifying the coordinator of the leader step-down. Test-only: production forwards raft leadership changes to the coordinator via `coordinator_manager`, which aborts the commit-interval sleep on step-down; the test drove raft leadership directly and skipped that, so a re-elected node's loop could stay asleep in the defunct term and miss the `notify_leadership(self)` trigger. Surfaced by Seastar task-queue shuffling (`SEASTAR_SHUFFLE_TASK_QUEUE`), which we'll enable separately.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
