### PR TITLE
[v25.3.x] `storage`: make `_schemas` deletion exempt

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2966,6 +2966,18 @@ configuration::configuration()
        .visibility = visibility::tunable},
       10,
       {.min = 1})
+  , log_eviction_exempt_topics(
+      *this,
+      "log_eviction_exempt_topics",
+      "A list of topics in the kafka namespace whose local log is exempt "
+      "from any form of data deletion: retention settings, local retention "
+      "for topics with Tiered Storage enabled, and disk space management "
+      "never remove their data from local disk, and partition moves always "
+      "deliver the full log to the new replica. Does not affect topic "
+      "deletion via the Kafka API (see kafka_nodelete_topics).",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
+      {model::schema_registry_internal_tp.topic()},
+      &validate_non_empty_string_vec)
   , initial_retention_local_target_bytes_default(
       *this,
       "initial_retention_local_target_bytes_default",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -542,6 +542,7 @@ struct configuration final : public config_store {
     bounded_property<double, numeric_bounds> disk_reservation_percent;
     bounded_property<uint16_t> space_management_max_log_concurrency;
     bounded_property<uint16_t> space_management_max_segment_concurrency;
+    property<std::vector<ss::sstring>> log_eviction_exempt_topics;
     property<std::optional<size_t>>
       initial_retention_local_target_bytes_default;
     property<std::optional<std::chrono::milliseconds>>

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -100,6 +100,14 @@ namespace storage {
  * driven / constrained by historical reads. Similarly for transactions and
  * idempotence. Controller topic should space can be managed by snapshots.
  *
+ * Topics listed in the log_eviction_exempt_topics cluster property are also
+ * exempt. It defaults to the schema registry topic (kafka/_schemas) for the
+ * same reason: the schema registry replays the full topic on startup, so
+ * trimming its local log to the cloud tier (via local retention or space
+ * management on a tiered topic) would make recovery dependent on cloud
+ * reads. Its size is bounded by compaction, so retaining it locally is
+ * cheap.
+ *
  * Note on unsafe_enable_consumer_offsets_delete_retention: This a special
  * configuration some select users can use to enable retention on CO topic
  * because the compaction logic is ineffective and they would like to use
@@ -115,8 +123,14 @@ bool deletion_exempt(const model::ntp& ntp) {
                                      == model::kafka_consumer_offsets_nt.ns()
                                    && ntp.tp.topic
                                         == model::kafka_consumer_offsets_nt.tp;
+    bool is_eviction_exempt_topic
+      = ntp.ns() == model::kafka_namespace
+        && std::ranges::contains(
+          config::shard_local_cfg().log_eviction_exempt_topics(),
+          ntp.tp.topic());
     return (!is_tx_manager_ntp && is_internal_namespace)
-           || (is_consumer_offsets_ntp && !config::shard_local_cfg().unsafe_enable_consumer_offsets_delete_retention());
+           || (is_consumer_offsets_ntp && !config::shard_local_cfg().unsafe_enable_consumer_offsets_delete_retention())
+           || is_eviction_exempt_topic;
 }
 
 // Meant for reading batches from a single `segment`. This does not consider any

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -764,6 +764,7 @@ redpanda_cc_gtest(
     ],
     deps = [
         "//src/v/model",
+        "//src/v/storage",
         "//src/v/storage/tests:disk_log_builder",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",

--- a/src/v/storage/tests/log_retention_test.cc
+++ b/src/v/storage/tests/log_retention_test.cc
@@ -8,6 +8,8 @@
 // by the Apache License, Version 2.0
 
 #include "model/fundamental.h"
+#include "model/namespace.h"
+#include "storage/log.h"
 #include "storage/tests/utils/disk_log_builder.h"
 
 #include <seastar/util/defer.hh>
@@ -405,6 +407,82 @@ TEST_F(gc_fixture, retention_by_time_with_remote_write) {
     builder | storage::garbage_collect(model::timestamp{1}, std::nullopt)
       | storage::stop();
     EXPECT_EQ(builder.get_log()->segment_count(), 0);
+}
+
+TEST_F(gc_fixture, log_eviction_exempt_topics) {
+    /*
+     * deletion_exempt() follows the log_eviction_exempt_topics cluster
+     * property, which defaults to the schema registry topic and only
+     * applies to the kafka namespace.
+     */
+    ASSERT_TRUE(storage::deletion_exempt(model::schema_registry_internal_ntp));
+    const model::ntp user_ntp(
+      model::kafka_namespace, model::topic("foo"), model::partition_id(0));
+    ASSERT_FALSE(storage::deletion_exempt(user_ntp));
+    ASSERT_FALSE(
+      storage::deletion_exempt(
+        model::ntp(
+          model::ns("other"),
+          model::schema_registry_internal_tp.topic,
+          model::partition_id(0))));
+
+    config::shard_local_cfg().log_eviction_exempt_topics.set_value(
+      std::vector<ss::sstring>{"foo"});
+    EXPECT_FALSE(storage::deletion_exempt(model::schema_registry_internal_ntp));
+    EXPECT_TRUE(storage::deletion_exempt(user_ntp));
+    config::shard_local_cfg().log_eviction_exempt_topics.reset();
+    EXPECT_TRUE(storage::deletion_exempt(model::schema_registry_internal_ntp));
+}
+
+TEST_F(gc_fixture, schema_registry_deletion_exempt) {
+    /*
+     * The schema registry replays its full topic on startup, so neither
+     * retention nor space management may remove local data, even when the
+     * topic is tiered with an aggressive local retention target.
+     */
+    ASSERT_TRUE(storage::deletion_exempt(model::schema_registry_internal_ntp));
+
+    config::shard_local_cfg().get("cloud_storage_enabled").set_value(true);
+    auto reset_cfg = ss::defer(
+      [] { config::shard_local_cfg().get("cloud_storage_enabled").reset(); });
+
+    storage::ntp_config config{
+      model::schema_registry_internal_ntp, builder.get_log_config().base_dir};
+
+    storage::ntp_config::default_overrides overrides;
+    overrides.shadow_indexing_mode = model::shadow_indexing_mode::full;
+    overrides.storage_mode = model::redpanda_storage_mode::tiered;
+    overrides.retention_local_target_bytes = tristate<size_t>{1};
+    // In production _schemas is compact-only, which alone prevents retention
+    // GC (but not space management). Deliberately use the delete policy here
+    // so the GC half of this test exercises the exemption rather than the
+    // cleanup policy: deletion_exempt must hold even if the policy is ever
+    // (mis)configured to allow deletion.
+    overrides.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::deletion;
+    config.set_overrides(overrides);
+
+    builder | storage::start(std::move(config)) | storage::add_segment(0)
+      | storage::add_random_batch(0, 100, storage::maybe_compress_batches::yes)
+      | storage::add_segment(100)
+      | storage::add_random_batch(100, 2, storage::maybe_compress_batches::yes);
+
+    ASSERT_TRUE(builder.get_disk_log_impl().config().is_locally_collectable());
+    builder.gc(model::timestamp::now(), std::make_optional<size_t>(1)).get();
+    EXPECT_EQ(builder.get_log()->segment_count(), 2);
+
+    auto reclaimable = builder.get_log()
+                         ->get_reclaimable_offsets(
+                           storage::gc_config(
+                             model::timestamp::now(),
+                             std::make_optional<size_t>(1)))
+                         .get();
+    EXPECT_TRUE(reclaimable.effective_local_retention.empty());
+    EXPECT_TRUE(reclaimable.low_space_non_hinted.empty());
+    EXPECT_TRUE(reclaimable.low_space_hinted.empty());
+    EXPECT_TRUE(reclaimable.active_segment.empty());
+
+    builder | storage::stop();
 }
 
 TEST_F(gc_fixture, non_collectible_disk_usage_test) {


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31130
