### PR TITLE
cloud_topics: make reconciler's local-read floor an exclusive bound

### DIFF
--- a/src/v/cloud_topics/reconciler/reconciliation_source.cc
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.cc
@@ -103,6 +103,12 @@ public:
         // The floor may only cover placeholder-backed data that this commit
         // makes readable from L1: clamp the reader's observation to the
         // committed LRO (the metadata pass may have scanned ahead of it).
+        // Both the observation and the LRO are inclusive offsets while the
+        // floor is the exclusive lower bound for local reads (reads below it
+        // go to L1), so convert with next_offset: the last placeholder-backed
+        // offset itself must be readable from L1 once its L0 object is
+        // garbage-collected. A scan that saw no placeholders resolves the
+        // observation with offset::min(), which must not advance the floor.
         // The feature gate is checked at the propagation point as well as
         // at observation time: the set_min_allowed_local_threshold stm
         // command cannot be applied by pre-v26.2 replicas, so it must never
@@ -110,10 +116,11 @@ public:
         std::optional<kafka::offset> min_allowed_local_threshold;
         if (
           auto hwm = harvest_placeholder_observation();
-          hwm.has_value()
+          hwm.has_value() && *hwm >= kafka::offset{0}
           && _partition->feature_table().local().is_active(
             features::feature::tiered_cloud_topics)) {
-            min_allowed_local_threshold = std::min(offset, *hwm);
+            min_allowed_local_threshold = std::min(
+              kafka::next_offset(offset), kafka::next_offset(*hwm));
         }
         ctp_stm_api api(_partition->raft()->stm_manager()->get<ctp_stm>());
         auto res = co_await api.advance_reconciled_offset(


### PR DESCRIPTION
The reconciler and the L1 compaction sink both advance a partition's `min_allowed_local_threshold` (the local-read floor: fetches below it are served from L1, fetches at or above it from the local log), but they disagreed on its semantics. The compaction sink publishes an exclusive bound — one past the highest cleaned offset — matching the read-path routing check `start_offset < local_floor`. The reconciler published the inclusive `last_offset` of the highest placeholder observed by the reconciliation scan, clamped by the inclusive LRO.

As a result, the last placeholder-backed offset of a partition (the floor itself) could never route to L1 and was always served by materializing the local placeholder from its L0 object. Once L0 GC deleted that object (legitimately — the data was fully reconciled into L1), any consumer whose fetch boundary landed exactly on the floor stalled permanently: the fetch path fails with `download_not_found`, retries restart at the same offset, and the state survives node restarts and cache wipes. Observed in CI as an `EndToEndCloudTopicsStorageModeToggleTest.test_toggle_storage_mode` timeout (buildkite build 87255), where a consumer stalled at the floor offset after ~6300 failed downloads of a single GC'd L0 object.

The fix converts both the placeholder observation and the LRO clamp with `kafka::next_offset`, making the reconciler's floor consistently exclusive and aligned with the compaction sink. The conversion also requires guarding the empty observation: a scan that saw no placeholders reports `offset::min()`, which `next_offset` clamps to 0 and which previously was dropped by the monotonic guard; without the explicit check it would replicate a useless floor-0 command on partitions with an unset floor.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none