### PR TITLE
[v26.1.x] `schema_registry`: parallelize recovery with deferred canonicalisation

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3849,6 +3849,14 @@ configuration::configuration()
        .visibility = visibility::user,
        .aliases = {"schema_registry_normalize_on_startup"}},
       false)
+  , schema_registry_deferred_recovery(
+      *this,
+      "schema_registry_deferred_recovery",
+      "Defer schema compilation during Schema Registry startup, then compile "
+      "the loaded schemas in parallel across cores. If disabled, every "
+      "replayed record is compiled sequentially during the replay.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      true)
   , schema_registry_avro_use_named_references(
       *this, "schema_registry_avro_use_named_references")
   , schema_registry_enable_qualified_subjects(

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -671,6 +671,7 @@ struct configuration final : public config_store {
 
     enterprise<property<bool>> schema_registry_enable_authorization;
     property<bool> schema_registry_always_normalize;
+    property<bool> schema_registry_deferred_recovery;
     deprecated_property schema_registry_avro_use_named_references;
     property<bool> schema_registry_enable_qualified_subjects;
     property<std::optional<uint32_t>> pp_sr_smp_max_non_local_requests;

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -856,16 +856,15 @@ ss::future<> service::fetch_internal_topic() {
     auto max_offset = offset_res.data.topics[0].partitions[0].offset;
     vlog(srlog.debug, "Schema registry: _schemas max_offset: {}", max_offset);
 
+    const auto defer = defer_processing{
+      config::shard_local_cfg().schema_registry_deferred_recovery()};
     co_await kafka::client::make_client_fetch_batch_reader(
       _client.local(),
       model::schema_registry_internal_tp,
       model::offset{0},
       max_offset)
-      .consume(consume_to_store{_store, writer()}, model::no_timeout);
+      .consume(consume_to_store{_store, writer(), defer}, model::no_timeout);
 
-    // If a schema failed to be compiled, it will be marked. We attempt to
-    // reprocess them once now that the whole topic has been read, in case
-    // they have a reference to a schema declared later in the topic.
     co_await _store.process_marked_schemas();
 }
 

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -206,21 +206,27 @@ ss::future<bool> sharded_store::upsert(
   subject_schema schema,
   schema_id id,
   schema_version version,
-  is_deleted deleted) {
-    auto canonical_fut = co_await ss::coroutine::as_future(
-      make_canonical_schema(schema.share(), normalize::no, false));
-    bool processing_failed = canonical_fut.failed();
-    if (processing_failed) {
-        canonical_fut.ignore_ready_future();
-    } else {
-        schema = canonical_fut.get();
+  is_deleted deleted,
+  defer_processing defer) {
+    // A deferred schema is stored raw and marked; otherwise canonicalise
+    // inline and mark only on failure. Marked schemas are canonicalised by
+    // process_marked_schemas() once the whole topic has been loaded into
+    // the store.
+    bool mark_schema = defer == defer_processing::yes;
+    if (defer == defer_processing::no) {
+        auto canonical_fut = co_await ss::coroutine::as_future(
+          make_canonical_schema(schema.share(), normalize::no, false));
+        mark_schema = canonical_fut.failed();
+        if (mark_schema) {
+            canonical_fut.ignore_ready_future();
+        } else {
+            schema = canonical_fut.get();
+        }
     }
 
     auto [sub, def] = std::move(schema).destructure();
-    // mark schemas that failed to be processed here. They will be given
-    // one more chance once we have loaded all the topic to the store.
     co_await upsert_schema(
-      context_schema_id{sub.ctx, id}, std::move(def), processing_failed);
+      context_schema_id{sub.ctx, id}, std::move(def), mark_schema);
     co_return co_await upsert_subject(
       marker, std::move(sub), version, id, deleted);
 }

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -53,14 +53,25 @@ public:
     };
     ss::future<insert_result> project_ids(stored_schema schema);
 
+    ///\brief Upsert a schema and its subject version.
+    ///
+    /// With defer_processing::no the schema is canonicalised inline (on the
+    /// calling shard); a schema that fails to canonicalise is stored raw and
+    /// marked for reprocessing. With defer_processing::yes canonicalisation
+    /// is skipped entirely and the schema is stored raw and marked; used by
+    /// the initial topic replay so that process_marked_schemas() can
+    /// canonicalise the store's final state in parallel across shards
+    /// instead of compiling every replayed record on the reader shard.
     ss::future<bool> upsert(
       seq_marker marker,
       subject_schema schema,
       schema_id id,
       schema_version version,
-      is_deleted deleted);
+      is_deleted deleted,
+      defer_processing defer = defer_processing::no);
 
-    // This function will try to compile all marked schemas.
+    // This function will try to compile all marked schemas, each on the
+    // shard that owns it, concurrently across shards.
     // It should be called every time new schemas are loaded from
     // the topic into the store.
     ss::future<> process_marked_schemas();

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -1707,9 +1707,13 @@ model::record_batch as_record_batch(Key key, Value val) {
 }
 
 struct consume_to_store {
-    explicit consume_to_store(sharded_store& s, seq_writer& seq)
+    explicit consume_to_store(
+      sharded_store& s,
+      seq_writer& seq,
+      defer_processing defer = defer_processing::no)
       : _store{s}
-      , _sequencer(seq) {}
+      , _sequencer(seq)
+      , _defer(defer) {}
 
     ss::future<ss::stop_iteration> operator()(model::record_batch b) {
         if (!b.header().attrs.is_control()) {
@@ -1871,7 +1875,8 @@ struct consume_to_store {
                   std::move(val->schema),
                   val->id,
                   val->version,
-                  val->deleted);
+                  val->deleted,
+                  _defer);
             }
         } catch (const exception& e) {
             vlog(srlog.debug, "Error replaying: {}: {}", key, e.what());
@@ -2078,6 +2083,7 @@ struct consume_to_store {
     void end_of_stream() {}
     sharded_store& _store;
     seq_writer& _sequencer;
+    defer_processing _defer{defer_processing::no};
 };
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -16,6 +16,7 @@
 #include "absl/container/btree_set.h"
 #include "absl/container/node_hash_map.h"
 #include "config/configuration.h"
+#include "container/chunked_hash_map.h"
 #include "container/chunked_vector.h"
 #include "metrics/metrics.h"
 #include "metrics/prometheus_sanitize.h"
@@ -838,7 +839,9 @@ public:
     bool upsert_schema(
       context_schema_id id, schema_definition def, bool mark_schema) {
         if (mark_schema) {
-            _marked_schemas.push_back(id);
+            _marked_schemas.insert(id);
+        } else {
+            _marked_schemas.erase(id);
         }
         auto [it, inserted] = _schemas.insert_or_assign(
           std::move(id), schema_entry(std::move(def)));
@@ -861,8 +864,8 @@ public:
         }
     }
 
-    // This function returns and unmarkes all marked schemas.
-    chunked_vector<context_schema_id> extract_marked_schemas() {
+    // This function returns and unmarks all marked schemas.
+    chunked_hash_set<context_schema_id> extract_marked_schemas() {
         return std::exchange(_marked_schemas, {});
     }
 
@@ -1316,7 +1319,7 @@ private:
 
     schema_map _schemas;
     subject_map _subjects;
-    chunked_vector<context_schema_id> _marked_schemas;
+    chunked_hash_set<context_schema_id> _marked_schemas;
     context_store_map _context_stores;
 
     is_mutable _mutable;

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -986,6 +986,106 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
                      .get());
 }
 
+// Deferred processing: upsert with defer_processing::yes stores the raw
+// definition and marks the schema; process_marked_schemas() canonicalises
+// every marked schema afterwards. Deferral makes topic order irrelevant: a
+// schema upserted before the schema it references still converges to the
+// same state as inline canonicalisation in dependency order.
+SEASTAR_THREAD_TEST_CASE(test_sharded_store_deferred_processing) {
+    const pps::schema_version ver1{1};
+    const auto marker = pps::seq_marker{
+      std::nullopt, std::nullopt, ver1, pps::seq_marker_key_type::schema};
+    const auto simple_schema = pps::subject_schema{
+      pps::context_subject::unqualified("simple.proto"), simple.share()};
+    const auto imported_schema = pps::subject_schema{
+      pps::context_subject::unqualified("imported.proto"), imported.share()};
+
+    // Reference pass: inline canonicalisation, in dependency order. Capture
+    // the canonical definitions, then stop the store (two live stores would
+    // double-register metrics).
+    std::vector<iobuf> expected_defs;
+    {
+        pps::sharded_store inline_store;
+        inline_store
+          .start(pps::is_mutable::yes, ss::default_smp_service_group())
+          .get();
+        auto stop_inline = ss::defer(
+          [&inline_store]() { inline_store.stop().get(); });
+        inline_store
+          .upsert(
+            marker,
+            simple_schema.share(),
+            pps::schema_id{1},
+            ver1,
+            pps::is_deleted::no)
+          .get();
+        inline_store
+          .upsert(
+            marker,
+            imported_schema.share(),
+            pps::schema_id{2},
+            ver1,
+            pps::is_deleted::no)
+          .get();
+        for (auto id : {pps::schema_id{1}, pps::schema_id{2}}) {
+            expected_defs.push_back(
+              inline_store.get_schema_definition({pps::default_context, id})
+                .get()
+                .raw()()
+                .copy());
+        }
+    }
+
+    // Deferred store: forward-reference order, canonicalisation deferred.
+    pps::sharded_store deferred_store;
+    deferred_store.start(pps::is_mutable::yes, ss::default_smp_service_group())
+      .get();
+    auto stop_deferred = ss::defer(
+      [&deferred_store]() { deferred_store.stop().get(); });
+    deferred_store
+      .upsert(
+        marker,
+        imported_schema.share(),
+        pps::schema_id{2},
+        ver1,
+        pps::is_deleted::no,
+        pps::defer_processing::yes)
+      .get();
+
+    // No canonicalisation was attempted: the raw definition is stored as-is.
+    auto raw_def = deferred_store
+                     .get_schema_definition(
+                       {pps::default_context, pps::schema_id{2}})
+                     .get();
+    BOOST_REQUIRE_EQUAL(raw_def.raw()(), imported.raw()());
+
+    deferred_store
+      .upsert(
+        marker,
+        simple_schema.share(),
+        pps::schema_id{1},
+        ver1,
+        pps::is_deleted::no,
+        pps::defer_processing::yes)
+      .get();
+
+    deferred_store.process_marked_schemas().get();
+
+    // Both stores converge to the same canonical definitions.
+    for (auto id : {pps::schema_id{1}, pps::schema_id{2}}) {
+        auto got = deferred_store
+                     .get_schema_definition({pps::default_context, id})
+                     .get();
+        BOOST_REQUIRE_EQUAL(got.raw()(), expected_defs[id() - 1]);
+    }
+
+    // Reference tracking is unaffected by deferral.
+    auto referenced_by
+      = deferred_store.referenced_by(simple_schema.sub(), ver1).get();
+    BOOST_REQUIRE_EQUAL(referenced_by.size(), 1);
+    BOOST_REQUIRE_EQUAL(referenced_by[0].id, pps::schema_id{2});
+}
+
 SEASTAR_THREAD_TEST_CASE(test_sharded_store_find_unordered) {
     pps::sharded_store store;
     store.start(pps::is_mutable::no, ss::default_smp_service_group()).get();

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -38,6 +38,9 @@ using is_deleted = ss::bool_class<struct is_deleted_tag>;
 using default_to_global = ss::bool_class<struct default_to_global_tag>;
 using force = ss::bool_class<struct force_tag>;
 using normalize = ss::bool_class<struct normalize_tag>;
+/// Defer canonicalisation of an upserted schema: mark it for a later
+/// process_marked_schemas() pass instead of canonicalising inline.
+using defer_processing = ss::bool_class<struct defer_processing_tag>;
 using verbose = ss::bool_class<struct verbose_tag>;
 using is_qualified = ss::bool_class<struct is_qualified_tag>;
 using is_config_or_mode = ss::bool_class<struct is_config_or_mode_tag>;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31131

- Command: git cherry-pick -x c556a7c9bc
- Commits backported: 1
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-31131-v26.1.x-1784302453

## Conflict details

- c556a7c9bc (src/v/pandaproxy/schema_registry/service.cc): the target branch consumes the `_schemas` topic during recovery via `kafka::client::make_client_fetch_batch_reader(...).consume(...)`, whereas dev uses `_transport->consume_range(...)`. Kept the target's reader mechanism and applied the commit's intent by constructing the `defer_processing` flag from `schema_registry_deferred_recovery` and passing it into `consume_to_store{_store, writer(), defer}`.
- c556a7c9bc (src/v/pandaproxy/schema_registry/test/sharded_store.cc): the incoming hunk also carried a `namespace {}` helper block (`contains_subject_version`, `upsert_version`) and `test_sharded_store_list_subject_versions`, which originate from a different commit not present on the target branch. Added only this PR's `test_sharded_store_deferred_processing` test and dropped the unrelated pre-existing context.
