### PR TITLE
[v26.1.x] dl/coordinator: fix drain test flake under task shuffling

### DIFF
--- a/src/v/datalake/coordinator/tests/coordinator_test.cc
+++ b/src/v/datalake/coordinator/tests/coordinator_test.cc
@@ -845,7 +845,10 @@ TEST_F(CoordinatorChunkedLoopTest, TestDrainsBacklogWithoutSleeping) {
     // we can stage the full backlog before a pass begins.
     opt_ref leader_opt;
     ASSERT_NO_FATAL_FAILURE(wait_for_leader(leader_opt).get());
+    // Step down and notify -- this causes the background loop to stop sleeping
+    // in the now-defunct term and wait for further notification.
     leader_opt->get().stm.raft()->step_down("test").get();
+    leader_opt->get().crd.notify_leadership(std::nullopt);
     ASSERT_NO_FATAL_FAILURE(wait_for_leader(leader_opt).get());
     auto& leader = leader_opt->get();
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31151
