### PR TITLE
cloud_topics/stm: always reset seen epoch window on term change

### DIFF
--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
@@ -17,14 +17,19 @@ namespace cloud_topics {
 
 void ctp_stm_state::advance_max_seen_epoch(
   model::term_id term, cluster_epoch epoch) noexcept {
-    if (term >= _seen_window_term && epoch > _max_seen_epoch) {
-        if (term > _seen_window_term) {
-            // If this is a new term, reset the window.
-            _previous_seen_epoch = epoch;
-            _seen_window_term = term;
-        } else {
-            _previous_seen_epoch = _max_seen_epoch.value_or(epoch);
-        }
+    if (term > _seen_window_term) {
+        // A new term always resets the window. The old window may carry a
+        // stale _max_seen_epoch above the new epoch (a fenced bump whose
+        // batch never landed before the leadership change); it must not
+        // survive into the new term or it blocks the reset and lets the
+        // stale window admit epochs the log no longer allows.
+        _seen_window_term = term;
+        _previous_seen_epoch = epoch;
+        _max_seen_epoch = epoch;
+        return;
+    }
+    if (term == _seen_window_term && epoch > _max_seen_epoch) {
+        _previous_seen_epoch = _max_seen_epoch.value_or(epoch);
         _max_seen_epoch = epoch;
     }
 }

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
@@ -49,6 +49,10 @@ public:
 
     /// This is invoked in the write path before the batch with new
     /// epoch value is even replicated.
+    ///
+    /// A term newer than the seen-window term always resets the window to
+    /// [epoch, epoch]; within the same term only a larger epoch advances the
+    /// max (the previous max becomes the window min).
     void
     advance_max_seen_epoch(model::term_id term, cluster_epoch epoch) noexcept;
 

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
@@ -341,6 +341,32 @@ TEST(ctp_stm_state_test, below_max_fence_allowed_with_applied_evidence) {
     EXPECT_FALSE(state.epoch_in_window(term, 131_epoch));
 }
 
+TEST(ctp_stm_state_test, seen_window_resets_on_term_change_despite_stale_max) {
+    // A fenced bump whose batch never lands can leave a very large
+    // _max_seen_epoch behind. A bump in a newer term must reset the window
+    // even when the new epoch is below the stale max, otherwise the stale
+    // window blocks the reset and the new term keeps fencing against it.
+    ct::ctp_stm_state state;
+    model::term_id term1(1);
+    model::term_id term2(2);
+
+    state.advance_max_seen_epoch(term1, 100_epoch);
+    EXPECT_EQ(state.get_max_seen_epoch(term1), 100_epoch);
+
+    // Epochs 7 and 8 land and apply (e.g. replicated by another leader).
+    state.advance_epoch(7_epoch, model::offset{0});
+    state.advance_epoch(8_epoch, model::offset{1});
+
+    // In the new term the stale window is invisible...
+    EXPECT_EQ(state.get_max_seen_epoch(term2), std::nullopt);
+    // ...and a bump below the stale max resets it.
+    state.advance_max_seen_epoch(term2, 9_epoch);
+    EXPECT_EQ(state.get_max_seen_epoch(term2), 9_epoch);
+    EXPECT_TRUE(state.epoch_in_window(term2, 9_epoch));
+    // Pre-bump epochs are fenced off until the bump batch applies.
+    EXPECT_FALSE(state.epoch_in_window(term2, 8_epoch));
+}
+
 TEST(ctp_stm_state_test, l0_simulation) {
     struct uploaded_l0_file_batch {
         ct::cluster_epoch epoch;


### PR DESCRIPTION
The seen epoch window of the ctp_stm is volatile in-memory state: it is not
part of the snapshot and nothing resets it on leadership changes, so keying it
by term is the only thing that invalidates it. A fence-time epoch bump whose
batch dies with the old leadership (failed replicate) leaves its
`_max_seen_epoch` behind. The batch itself can never land once `fence_epoch`
runs in a newer term — `sync()` completes only after every prior-term entry
that will ever commit has been applied — but the stale in-memory max survives.

The first bump of a new term only reset the window when the new epoch exceeded
that stale max. A lower bump made `advance_max_seen_epoch` a no-op while
`fence_epoch` still granted the fence, so the in-flight epoch was invisible:
concurrent fences kept evaluating against the applied window, several such
invisible bumps could land out of order, and the `epoch_window_checker`
vassert fired in `do_apply` on every replica, including on log replay.

This PR makes the term change always reset the window to `[epoch, epoch]`.
This is safe: the reset runs under the full write lock so no fenced
replication is in flight, and the discarded window can only describe batches
that are already applied or dead. Within a term the max still only moves
forward.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

🤖 Generated with [Claude Code](https://claude.com/claude-code)