### PR TITLE
rptest: drive unfinalized-upgrade tests through rpk cluster upgrade

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -366,6 +366,16 @@ class AclList:
         )
 
 
+class RpkUpgradeFinalizationState:
+    """State strings reported by `rpk cluster upgrade status`: the admin v2
+    FinalizationState enum names, lowercased with underscores as spaces (see
+    src/go/rpk/pkg/cli/cluster/upgrade/status.go)."""
+
+    FINALIZED = "finalized"
+    READY_TO_FINALIZE = "ready to finalize"
+    UPGRADE_IN_PROGRESS = "upgrade in progress"
+
+
 class RpkTool:
     """
     Wrapper around rpk.
@@ -1696,6 +1706,44 @@ class RpkTool:
 
         output = self._execute(cmd)
         return list(filter(None, map(parse, output.splitlines())))
+
+    def cluster_upgrade_status(self) -> dict[str, Any]:
+        """
+        Run `rpk cluster upgrade status` and return the parsed JSON response:
+        state (an RpkUpgradeFinalizationState string), active_version,
+        version_after_finalization, auto_finalization_enabled, and members
+        (per-broker node_id, release_version, logical_version, version_known,
+        alive).
+        """
+        cmd = [
+            self._rpk_binary(),
+            "-X",
+            "admin.hosts=" + self._admin_host(),
+            "cluster",
+            "upgrade",
+            "status",
+            "--format",
+            "json",
+        ]
+        return json.loads(self._execute(cmd))
+
+    def cluster_upgrade_finalize(self, no_confirm: bool = True) -> str:
+        """
+        Run `rpk cluster upgrade finalize` and return its output. The command
+        validates upfront (via the upgrade status) and only sends the finalize
+        request when the cluster is ready to finalize.
+        """
+        cmd = [
+            self._rpk_binary(),
+            "-X",
+            "admin.hosts=" + self._admin_host(),
+            "cluster",
+            "upgrade",
+            "finalize",
+        ]
+        if no_confirm:
+            cmd.append("--no-confirm")
+        return self._execute(cmd)
 
     def cluster_connections_list(
         self, limit: int, filter_raw: str | None = None, order_by: str | None = None

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -23,7 +23,7 @@ from rptest.clients.admin.proto.redpanda.core.admin.v2 import (
 )
 from rptest.clients.admin.v2 import Admin as AdminV2
 from rptest.clients.kafka_cli_tools import KafkaCliTools
-from rptest.clients.rpk import RpkException, RpkTool
+from rptest.clients.rpk import RpkException, RpkTool, RpkUpgradeFinalizationState
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
@@ -1252,12 +1252,17 @@ class ManualFinalizationUpgradeTest(UnfinalizedUpgradeMixin, FeaturesTestBase):
 
     It mirrors three ManualFinalizationTest scenarios end to end:
       - auto-finalization disabled blocks the post-upgrade advance,
-      - an explicit FinalizeUpgrade drives the advance, and
-      - GetUpgradeStatus reports the finalization lifecycle.
+      - an explicit finalize drives the advance, and
+      - the upgrade status reports the finalization lifecycle.
+
+    Where ManualFinalizationTest calls the admin v2 RPCs directly (pinning the
+    server-side API contract), this test drives the workflow through
+    `rpk cluster upgrade` status/finalize -- the operator surface built on
+    those RPCs -- so the rpk subcommands get end-to-end coverage.
 
     The old release has neither the gating logic nor the v2 RPCs, so the opt-out
     is set on the old binary (which also exercises the backported knob) and the
-    status/finalize RPCs are only invoked once every node is on HEAD.
+    status/finalize commands are only invoked once every node is on HEAD.
     """
 
     # DescribeRedpandaRoles occupies the reserved Redpanda Kafka API key range
@@ -1764,20 +1769,20 @@ class ManualFinalizationUpgradeTest(UnfinalizedUpgradeMixin, FeaturesTestBase):
         # even run. The active version is held at the old (downgrade floor)
         # version, with the uniform higher version available to finalize.
         status = self._wait_for_status_state(
-            features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE
+            RpkUpgradeFinalizationState.READY_TO_FINALIZE
         )
         assert self.admin.get_features()["cluster_version"] == self.old_logical
-        assert status.active_version == self.old_logical
-        assert status.version_after_finalization == self.new_logical
-        assert not status.auto_finalization_enabled
+        assert status["active_version"] == self.old_logical
+        assert status["version_after_finalization"] == self.new_logical
+        assert not status["auto_finalization_enabled"]
 
         # Dwell and re-check: the version must stay held across subsequent
         # gating-loop ticks, not advance late.
         time.sleep(MANUAL_FINALIZE_HOLD_DWELL_SEC)
         assert self.admin.get_features()["cluster_version"] == self.old_logical
         assert (
-            self._get_upgrade_status().state
-            == features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE
+            self._get_upgrade_status()["state"]
+            == RpkUpgradeFinalizationState.READY_TO_FINALIZE
         )
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
@@ -1793,7 +1798,7 @@ class ManualFinalizationUpgradeTest(UnfinalizedUpgradeMixin, FeaturesTestBase):
         The old release has no v2 RPCs, so (unlike the synthetic test) the
         FINALIZED-at-rest state cannot be observed before the upgrade; the
         lifecycle is observed from READY_TO_FINALIZE (post-upgrade) through
-        FINALIZED, checked against both the v2 status and the v1 features API.
+        FINALIZED, checked against both the rpk status and the v1 features API.
         """
         self._start_at_old()
         self._disable_auto_finalization()
@@ -1803,26 +1808,28 @@ class ManualFinalizationUpgradeTest(UnfinalizedUpgradeMixin, FeaturesTestBase):
         self._restart_at_new(self.redpanda.nodes)
 
         status = self._wait_for_status_state(
-            features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE
+            RpkUpgradeFinalizationState.READY_TO_FINALIZE
         )
-        assert status.active_version == self.old_logical
-        assert status.version_after_finalization == self.new_logical
-        # The v1 features API agrees with the v2 status: the advance is deferred,
-        # so cluster_version is still held at the old (downgrade-floor) version.
+        assert status["active_version"] == self.old_logical
+        assert status["version_after_finalization"] == self.new_logical
+        # The v1 features API agrees with the rpk status: the advance is
+        # deferred, so cluster_version is still held at the old
+        # (downgrade-floor) version.
         assert self.admin.get_features()["cluster_version"] == self.old_logical
-        assert len(status.members) == len(self.redpanda.nodes)
-        assert all(m.version_known and m.alive for m in status.members)
-        assert all(m.logical_version == self.new_logical for m in status.members)
+        members = status["members"]
+        assert len(members) == len(self.redpanda.nodes)
+        assert all(m["version_known"] and m["alive"] for m in members)
+        assert all(m["logical_version"] == self.new_logical for m in members)
         # release_version is plumbed through from the per-node health report.
-        assert all(m.release_version for m in status.members)
+        assert all(m["release_version"] for m in members)
 
         # Finalize: the active version catches up; no downgrade after this.
         self._finalize()
         self._wait_for_version_everywhere(self.new_logical)
 
-        status = self._wait_for_status_state(features_pb2.FINALIZATION_STATE_FINALIZED)
-        assert status.active_version == self.new_logical
-        assert status.version_after_finalization == self.new_logical
+        status = self._wait_for_status_state(RpkUpgradeFinalizationState.FINALIZED)
+        assert status["active_version"] == self.new_logical
+        assert status["version_after_finalization"] == self.new_logical
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_config_passes_through_multi_hop_upgrade(self):
@@ -1905,15 +1912,15 @@ class ManualFinalizationUpgradeTest(UnfinalizedUpgradeMixin, FeaturesTestBase):
                 # so downgrade back across this hop IS preserved until it is
                 # finalized.
                 status = self._wait_for_status_state(
-                    features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE
+                    RpkUpgradeFinalizationState.READY_TO_FINALIZE
                 )
                 assert self.admin.get_features()["cluster_version"] == held_version
-                assert status.active_version == held_version
-                assert status.version_after_finalization == hop_logical
+                assert status["active_version"] == held_version
+                assert status["version_after_finalization"] == hop_logical
                 # The decisive passthrough check: this binary sees
                 # auto-finalization as disabled even though the flag was set
                 # only once, on the oldest release.
-                assert not status.auto_finalization_enabled
+                assert not status["auto_finalization_enabled"]
 
                 if final_hop:
                     # Dwell and re-check: the version must stay held across
@@ -1926,10 +1933,10 @@ class ManualFinalizationUpgradeTest(UnfinalizedUpgradeMixin, FeaturesTestBase):
                 self._finalize()
                 self._wait_for_version_everywhere(hop_logical)
                 finalized = self._wait_for_status_state(
-                    features_pb2.FINALIZATION_STATE_FINALIZED
+                    RpkUpgradeFinalizationState.FINALIZED
                 )
-                assert finalized.active_version == hop_logical
-                assert finalized.version_after_finalization == hop_logical
+                assert finalized["active_version"] == hop_logical
+                assert finalized["version_after_finalization"] == hop_logical
             held_version = hop_logical
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
@@ -1960,10 +1967,10 @@ class ManualFinalizationUpgradeTest(UnfinalizedUpgradeMixin, FeaturesTestBase):
             # what keeps the downgrade available.
             self._restart_at_new(self.redpanda.nodes)
             status = self._wait_for_status_state(
-                features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE
+                RpkUpgradeFinalizationState.READY_TO_FINALIZE
             )
             assert self.admin.get_features()["cluster_version"] == old_logical
-            assert not status.auto_finalization_enabled
+            assert not status["auto_finalization_enabled"]
 
             self._perturb(f"cycle{cycle}-upgraded-unfinalized")
 
@@ -1983,14 +1990,12 @@ class ManualFinalizationUpgradeTest(UnfinalizedUpgradeMixin, FeaturesTestBase):
         # finalizing. The active version advances to the head version.
         self.logger.info("final attempt: upgrade -> finalize")
         self._restart_at_new(self.redpanda.nodes)
-        self._wait_for_status_state(features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE)
+        self._wait_for_status_state(RpkUpgradeFinalizationState.READY_TO_FINALIZE)
         self._finalize()
         self._wait_for_version_everywhere(self.new_logical)
-        finalized = self._wait_for_status_state(
-            features_pb2.FINALIZATION_STATE_FINALIZED
-        )
-        assert finalized.active_version == self.new_logical
-        assert finalized.version_after_finalization == self.new_logical
+        finalized = self._wait_for_status_state(RpkUpgradeFinalizationState.FINALIZED)
+        assert finalized["active_version"] == self.new_logical
+        assert finalized["version_after_finalization"] == self.new_logical
 
         # With the upgrade finalized, the v26.2 feature gates have opened:
         # confirm the features actually work.
@@ -2028,10 +2033,10 @@ class ManualFinalizationUpgradeTest(UnfinalizedUpgradeMixin, FeaturesTestBase):
         # Upgrade and this time finalize, advancing the active version past what
         # the old binary supports.
         self._restart_at_new(self.redpanda.nodes)
-        self._wait_for_status_state(features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE)
+        self._wait_for_status_state(RpkUpgradeFinalizationState.READY_TO_FINALIZE)
         self._finalize()
         self._wait_for_version_everywhere(self.new_logical)
-        self._wait_for_status_state(features_pb2.FINALIZATION_STATE_FINALIZED)
+        self._wait_for_status_state(RpkUpgradeFinalizationState.FINALIZED)
 
         # Attempt to roll a single node back to the old release. The old binary
         # reads the persisted feature table, sees the cluster advanced past the

--- a/tests/rptest/tests/cluster_linking_unfinalized_upgrade_test.py
+++ b/tests/rptest/tests/cluster_linking_unfinalized_upgrade_test.py
@@ -15,12 +15,11 @@ from connectrpc.errors import ConnectError, ConnectErrorCode
 from ducktape.utils.util import wait_until
 
 from rptest.clients.admin.proto.redpanda.core.admin.v2 import (
-    features_pb2,
     security_pb2,
     shadow_link_pb2,
 )
 from rptest.clients.admin.v2 import Admin as AdminV2
-from rptest.clients.rpk import RpkTool
+from rptest.clients.rpk import RpkTool, RpkUpgradeFinalizationState
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.multi_cluster_services import SecondaryClusterArgs
@@ -421,10 +420,10 @@ class ShadowLinkUnfinalizedUpgradeTest(ShadowLinkTestBase, UnfinalizedUpgradeMix
         # active version is held at the old version: READY_TO_FINALIZE.
         self._restart_at_new(self.redpanda.nodes)
         status = self._wait_for_status_state(
-            features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE
+            RpkUpgradeFinalizationState.READY_TO_FINALIZE
         )
         assert self.admin.get_features()["cluster_version"] == self.old_logical
-        assert not status.auto_finalization_enabled
+        assert not status["auto_finalization_enabled"]
 
         # The shadow_linking feature is v25.3, so the link machinery is fully
         # live even though the upgrade is unfinalized: create a topic-mirroring
@@ -453,13 +452,11 @@ class ShadowLinkUnfinalizedUpgradeTest(ShadowLinkTestBase, UnfinalizedUpgradeMix
         # Roll forward again and this time finalize: the active version advances
         # past the gate's require_version and the v26.2 features activate.
         self._restart_at_new(self.redpanda.nodes)
-        self._wait_for_status_state(features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE)
+        self._wait_for_status_state(RpkUpgradeFinalizationState.READY_TO_FINALIZE)
         self._finalize()
         self._wait_for_version_everywhere(self.new_logical)
-        finalized = self._wait_for_status_state(
-            features_pb2.FINALIZATION_STATE_FINALIZED
-        )
-        assert finalized.active_version == self.new_logical
+        finalized = self._wait_for_status_state(RpkUpgradeFinalizationState.FINALIZED)
+        assert finalized["active_version"] == self.new_logical
 
         # Both gates are open now: the features must actually sync real data.
         self._verify_role_sync_works()
@@ -505,7 +502,7 @@ class ShadowLinkUnfinalizedUpgradeTest(ShadowLinkTestBase, UnfinalizedUpgradeMix
         # forward to HEAD with the active (downgrade-floor) version held back.
         self._disable_auto_finalization()
         self._restart_at_new(self.redpanda.nodes)
-        self._wait_for_status_state(features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE)
+        self._wait_for_status_state(RpkUpgradeFinalizationState.READY_TO_FINALIZE)
         assert self.admin.get_features()["cluster_version"] == self.old_logical
 
         # shadow_linking is v25.3, so the link machinery is live while
@@ -540,5 +537,5 @@ class ShadowLinkUnfinalizedUpgradeTest(ShadowLinkTestBase, UnfinalizedUpgradeMix
 
         # Roll forward again: the topic-mode config survived the round trip.
         self._restart_at_new(self.redpanda.nodes)
-        self._wait_for_status_state(features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE)
+        self._wait_for_status_state(RpkUpgradeFinalizationState.READY_TO_FINALIZE)
         self._assert_sr_sync_mode("shadow_schema_registry_topic", "re-upgraded")

--- a/tests/rptest/tests/unfinalized_upgrade_mixin.py
+++ b/tests/rptest/tests/unfinalized_upgrade_mixin.py
@@ -12,7 +12,7 @@ import time
 from connectrpc.errors import ConnectError, ConnectErrorCode
 from ducktape.utils.util import wait_until
 
-from rptest.clients.admin.proto.redpanda.core.admin.v2 import features_pb2
+from rptest.clients.rpk import RpkException, RpkTool
 from rptest.services.redpanda_installer import RedpandaInstaller
 from rptest.util import wait_until_result
 
@@ -21,7 +21,8 @@ class UnfinalizedUpgradeMixin:
     """Reusable driver for the manual-finalization (unfinalized upgrade) flow:
     roll a cluster's binaries forward with `features_auto_finalization=false`
     so the active (downgrade-floor) version is held back, observe/finalize via
-    the admin v2 RPCs, and roll back before finalizing.
+    `rpk cluster upgrade` status/finalize (the operator surface over the admin
+    v2 FeaturesService RPCs), and roll back before finalizing.
 
     These primitives were factored out of ManualFinalizationUpgradeTest so a
     second test can drive the same flow against a different cluster topology
@@ -32,10 +33,15 @@ class UnfinalizedUpgradeMixin:
       - ``self.installer``  -- its RedpandaInstaller (usually
                                ``self.redpanda._installer``),
       - ``self.admin``      -- a v1 Admin against that cluster,
-      - ``self.admin_v2``   -- an admin v2 client against that cluster,
       - ``self.old_logical``-- the logical version of the pre-upgrade binary
                                (set by the test's own "start at old" step).
     ``_restart_at_new`` sets ``self.new_logical``.
+
+    rpk runs from the test runner's HEAD install (see RpkTool._rpk_binary), not
+    from the cluster nodes, so the `cluster upgrade` subcommands are available
+    regardless of which release the brokers currently run. They are still only
+    invoked once every broker is on HEAD, because the old releases lack the
+    server-side admin v2 FeaturesService.
     """
 
     # The pre-upgrade binary must be a released patch that already carries the
@@ -120,10 +126,13 @@ class UnfinalizedUpgradeMixin:
         self.redpanda.set_cluster_config({"features_auto_finalization": False})
 
     def _call_with_leader_retry(self, call, timeout_sec=30):
-        """Retry a controller-leader-routed admin v2 call through the transient
-        UNAVAILABLE window after restarts/leadership changes. The v2 connect
-        client does not retry leadership itself; only UNAVAILABLE is retried,
-        other errors (e.g. FAILED_PRECONDITION) propagate immediately."""
+        """Retry a controller-leader-routed admin call through the transient
+        UNAVAILABLE window after restarts/leadership changes. Handles both
+        transports the tests use: direct admin v2 connect calls (typed error
+        code) and rpk invocations, where the connect code appears in rpk's
+        stderr (e.g. "unable to retrieve upgrade status: unavailable: ...").
+        Only UNAVAILABLE is retried; other errors (e.g. FAILED_PRECONDITION)
+        propagate immediately."""
         deadline = time.time() + timeout_sec
         while True:
             try:
@@ -131,27 +140,32 @@ class UnfinalizedUpgradeMixin:
             except ConnectError as e:
                 if e.code != ConnectErrorCode.UNAVAILABLE or time.time() >= deadline:
                     raise
-                time.sleep(1)
+            except RpkException as e:
+                if "unavailable" not in e.stderr.lower() or time.time() >= deadline:
+                    raise
+            time.sleep(1)
 
     def _finalize(self):
-        return self._call_with_leader_retry(
-            lambda: self.admin_v2.features().finalize_upgrade(
-                features_pb2.FinalizeUpgradeRequest()
-            )
-        )
+        """Finalize the upgrade via `rpk cluster upgrade finalize`."""
+        rpk = RpkTool(self.redpanda)
+        return self._call_with_leader_retry(rpk.cluster_upgrade_finalize)
 
     def _get_upgrade_status(self):
-        return self._call_with_leader_retry(
-            lambda: self.admin_v2.features().get_upgrade_status(
-                features_pb2.GetUpgradeStatusRequest()
-            )
-        )
+        """Return the parsed `rpk cluster upgrade status` JSON response."""
+        rpk = RpkTool(self.redpanda)
+        return self._call_with_leader_retry(rpk.cluster_upgrade_status)
 
     def _wait_for_status_state(self, state, timeout_sec=30):
-        """Wait until GetUpgradeStatus reports `state`; return that status."""
-        wait_until(
-            lambda: self._get_upgrade_status().state == state,
+        """Wait until the upgrade status reports `state` (an
+        RpkUpgradeFinalizationState string); return the status that
+        reported it."""
+
+        def check():
+            status = self._get_upgrade_status()
+            return status["state"] == state, status
+
+        return wait_until_result(
+            check,
             timeout_sec=timeout_sec,
             backoff_sec=1,
         )
-        return self._get_upgrade_status()


### PR DESCRIPTION
## Cover letter

Follow-up to #30930, which added `rpk cluster upgrade finalize` and
`rpk cluster upgrade status` and was verified manually against a live
cluster. This gives those subcommands automated end-to-end coverage by
swapping them into the existing unfinalized-upgrade integration tests
instead of adding net-new tests.

The real-upgrade operator-workflow tests — `ManualFinalizationUpgradeTest`
(5 tests) and `ShadowLinkUnfinalizedUpgradeTest` (2 tests), which share
`UnfinalizedUpgradeMixin` — previously observed and finalized the upgrade
by invoking the admin v2 `FeaturesService` RPCs directly through the
python connect client. The mixin now drives that workflow through
`rpk cluster upgrade status --format json` and
`rpk cluster upgrade finalize --no-confirm`, i.e. exactly the way an
operator would. Every existing assertion is preserved (states, active /
post-finalization versions, auto-finalization flag, per-broker members
incl. release version, liveness, and version-known), now checked against
rpk's JSON output; the v1 features API cross-checks are unchanged.

What this covers end to end, per run:

- `status` reporting `ready to finalize` and `finalized` (including the
  full per-broker member table) against a real binary upgrade, a
  multi-hop upgrade, repeated upgrade/downgrade rollback cycles, and a
  shadow-link topology;
- `finalize --no-confirm` validating upfront, sending the
  `FinalizeUpgrade` RPC, and the active version advancing — the manual
  scenarios 1–2 from #30930.

Notes on scope:

- `RpkTool` gains `cluster_upgrade_status()` / `cluster_upgrade_finalize()`
  plus an `RpkUpgradeFinalizationState` constants class mirroring the
  state strings rpk derives from the proto enum. rpk runs from the test
  runner's HEAD install, so the subcommands exist regardless of which
  release the brokers are on; as before, they are only invoked once every
  broker runs HEAD (old releases lack the server-side v2 service).
- The synthetic `ManualFinalizationTest` and the audit-log tests keep
  calling the RPCs directly on purpose: they pin the *server-side* API
  contract (FAILED_PRECONDITION when auto-finalization is enabled,
  idempotent no-op re-finalize, accept-then-decline on mixed versions or
  a dead node, audit records). `rpk cluster upgrade finalize`
  deliberately front-runs those paths with client-side validation, so
  swapping rpk in there would silently delete the only automated coverage
  of the server-side gates.
- The mixin's UNAVAILABLE leader-retry is preserved and now handles both
  transports: rpk invocations (the connect code appears in rpk's stderr)
  and direct connect calls, since one perturb helper still routes a
  connect call through it. Only UNAVAILABLE is retried.

## Backports Required

- [x] none - not a bug fix

## Release Notes

- none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
