### PR TITLE
dt/tests: de-flake ConsumerGroupTest.test_group_lag_metrics

### DIFF
--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -923,7 +923,11 @@ class ConsumerGroupTest(RedpandaTest):
         )
         topic_count = 1
         partition_count = 20
-        consumer_count = 4
+        # One consumer per partition: each consumer then owns exactly one
+        # partition, so its consume() queue holds only that partition and any
+        # non-empty poll covers it -- avoiding the cross-partition delivery-order
+        # starvation that made this test flaky (CORE-13976). See the consume loop.
+        consumer_count = partition_count
         group = "test-lag-metrics-group"
         # Use a small batch size to ensure that fetches are distributed across all partitions
         batch_size = 1

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -10,6 +10,7 @@
 
 import asyncio
 from contextlib import closing
+import json
 import random
 import threading
 import time
@@ -949,6 +950,12 @@ class ConsumerGroupTest(RedpandaTest):
             ]
         )
 
+        # Per-consumer librdkafka statistics, refreshed via stats_cb. Cheap to
+        # collect; only dumped on failure (see not_ready_diagnostic) to show the
+        # per-broker connection state and per-partition fetch state when a
+        # consumer stalls reading from a broker. See CORE-13976.
+        consumer_stats: dict[int, dict] = {}
+
         def create_consumer(instance_id: int) -> Consumer:
             return Consumer(
                 {
@@ -960,6 +967,10 @@ class ConsumerGroupTest(RedpandaTest):
                     "enable.auto.offset.store": True,
                     "enable.auto.commit": False,
                     "max.partition.fetch.bytes": batch_size,
+                    "statistics.interval.ms": 2000,
+                    "stats_cb": lambda s, i=instance_id: consumer_stats.__setitem__(
+                        i, json.loads(s)
+                    ),
                     "log_level": 7,
                     "debug": "cgrp",
                 },
@@ -1069,11 +1080,51 @@ class ConsumerGroupTest(RedpandaTest):
                     consumed_from[i].add((msg.topic(), msg.partition()))
             return all_consumers_ready()
 
+        def not_ready_diagnostic() -> str:
+            """On timeout, dump each stalled consumer's assigned-but-unconsumed
+            partitions together with the librdkafka broker/partition state, so a
+            failure is self-diagnosing (which broker's fetch path stalled, and
+            whether it looks like a dead connection vs a stuck fetch)."""
+            lines = ["Timed out waiting for all partitions to be consumed"]
+            for i in range(len(consumers)):
+                missing = assigned[i] - consumed_from[i]
+                if assigned[i] and not missing:
+                    continue
+                stats = consumer_stats.get(i, {})
+                brokers = {
+                    b.get("nodeid"): {
+                        "state": b.get("state"),
+                        "rxidle_us": b.get("rxidle"),
+                    }
+                    for b in stats.get("brokers", {}).values()
+                    if b.get("nodeid", -1) >= 0
+                }
+                lines.append(
+                    f"consumer {i}: missing {sorted(missing)} of assigned "
+                    f"{sorted(assigned[i])}; brokers={brokers}"
+                )
+                for topic in stats.get("topics", {}).values():
+                    tname = topic.get("topic")
+                    for pid, p in topic.get("partitions", {}).items():
+                        try:
+                            key = (tname, int(pid))
+                        except ValueError:
+                            continue
+                        if key not in missing:
+                            continue
+                        lines.append(
+                            f"  {tname}/{pid}: leader={p.get('leader')} "
+                            f"fetch_state={p.get('fetch_state')} "
+                            f"next_offset={p.get('next_offset')} "
+                            f"rxbytes={p.get('rxbytes')} lag={p.get('consumer_lag')}"
+                        )
+            return "\n".join(lines)
+
         wait_until(
             consume_and_check_ready,
             30,
             1,
-            err_msg="Timed out waiting for all partitions to be consumed",
+            err_msg=not_ready_diagnostic,
         )
 
         self.logger.info("Waiting for lag_metrics")


### PR DESCRIPTION
`ConsumerGroupTest.test_group_lag_metrics` has been a long-standing flake
(CORE-13976), intermittently failing with "Not all partitions were consumed"
and (after an earlier retry-loop change) "Timed out waiting for all partitions
to be consumed".

## Root cause & fix

The test waits for every assigned partition to surface at least one record
before committing and checking lag metrics. With multiple partitions per
consumer, librdkafka prefetches all of a consumer's partitions into a single
client-side queue, and `consume()` only returns records already queued — so
records for a partition that lands at the back of that queue can sit behind
others and never surface within the deadline, timing the test out. Broker logs
from a failing run confirmed the brokers had already served every partition to
the log tail; the stall was purely a client-side under-drain, not a Redpanda
issue.

There's a tension in fixing this by tuning counts: raising `consume()`'s
`num_messages` to drain the whole backlog guarantees coverage, but it also
consumes ~everything, driving committed offsets to the high-watermark and
collapsing the group lag this test exists to measure (`lag_sum`/`lag_max` → 0).
Draining less preserves lag but reintroduces the starvation.

This sidesteps the tension instead of tuning counts: give each consumer exactly
one partition (`consumer_count = partition_count`). A consumer's queue then
holds only its single partition, so any non-empty poll covers it — there is no
cross-partition ordering left to starve — while the small per-poll consume still
leaves most records unconsumed, so lag stays measurable.

Verified locally (`DUCKTAPE_REPEAT=5`): 5/5 pass, with `lag_sum` ≈ 31k and
`lag_max` ≈ 1865 — i.e. the lag assertions are still validating real, non-zero
values.

## Added diagnostics (hedge against future flakiness)

As a hedge in case a different stall shows up later, the consumers now collect
librdkafka statistics, and on the readiness-wait timeout the test dumps, per
stalled consumer, its missing partitions plus the per-broker connection state
(`state`/`rxidle`) and per-partition fetch state
(`leader`/`fetch_state`/`next_offset`/`rxbytes`/`lag`). This is emitted only on
failure (zero cost on passing runs) and makes any future recurrence
self-diagnosing without having to pull and cross-reference the per-broker logs.

## Keeping the partition-tracking readiness logic

The `assigned`/`consumed_from` coverage loop is kept (rather than reverting to a
fixed-count consume): each poll re-reads `consumer.assignment()` and checks
coverage against the *current* assignment, so the test continues to handle
consumer-group rebalances cleanly — if partitions move between consumers mid-run,
readiness is always evaluated against the up-to-date assignment.

## Backports Required

- [x] none - not a bug fix (test-only change)

## Release Notes

* none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
