### PR TITLE
`ct/l1`: don't schedule leveling when compacting CTP

### DIFF
--- a/src/v/cloud_topics/level_one/maintenance/log_info_collector.cc
+++ b/src/v/cloud_topics/level_one/maintenance/log_info_collector.cc
@@ -345,6 +345,9 @@ log_info_collector::build_leveling_specs(log_list_t& logs_list) const {
 
     chunked_vector<metastore::leveling_info_spec> specs;
     for (auto& log : logs_list) {
+        if (log.compaction.inflight_shard.has_value()) {
+            continue;
+        }
         specs.emplace_back(
           metastore::leveling_info_spec{log.tidp, min_acceptable});
     }
@@ -390,6 +393,9 @@ void log_info_collector::populate_logs_with_leveling_info(
             continue;
         }
         auto& log = *log_it;
+        if (log->compaction.inflight_shard.has_value()) {
+            continue;
+        }
         if (!leveling_info.has_value()) {
             // Minimize logging on benign `missing_ntp` errors in case
             // the `metastore` does not yet have any reconciled data for the log

--- a/src/v/cloud_topics/level_one/maintenance/tests/log_info_collector_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/tests/log_info_collector_test.cc
@@ -260,6 +260,37 @@ TEST_F(LogInfoCollectorTestFixture, TestLevelingSkipsOverlappingRange) {
     ASSERT_EQ(log_ptr->leveling.inflight_ranges.size(), 1u);
 }
 
+// Leveling and compaction of the same CTP shouldn't be scheduled concurrently:
+// while a CTP has an inflight compaction, leveling collection should not queue
+// jobs for it. Once the compaction completes (clearing `inflight_shard`),
+// collection queues its ranges again.
+TEST_F(LogInfoCollectorTestFixture, TestLevelingSkipsCompactingLog) {
+    auto [ntp, tidp] = make_ntidp("leveling_topic");
+    auto log_ptr = ss::make_lw_shared<l1::log_compaction_meta>(tidp, ntp);
+    seed_undersized_objects(tidp, 2);
+
+    l1::log_set_t logs_set;
+    logs_set.insert(log_ptr);
+    l1::log_list_t logs_list;
+    logs_list.push_back(*log_ptr);
+
+    l1::log_info_collector collector(
+      &_metastore,
+      std::make_unique<fake_cfg_provider>(),
+      std::make_unique<fake_offset_provider>());
+    l1::leveling_extent_reclamation_policy policy{
+      config::mock_binding<size_t>(size_t{1024} * 1024)};
+    l1::leveling_queue queue(policy.get_comparator());
+
+    log_ptr->compaction.inflight_shard = ss::this_shard_id();
+    collector.collect_leveling_info(logs_set, logs_list, queue).get();
+    ASSERT_TRUE(queue.empty());
+
+    log_ptr->compaction.inflight_shard.reset();
+    collector.collect_leveling_info(logs_set, logs_list, queue).get();
+    ASSERT_GT(queue.size(), 0u);
+}
+
 // A range whose completion timestamp is not strictly before the collection's
 // snapshot must be retained: the collector cannot yet assume the metastore
 // reflects the commit, so the overlapping range must not be re-queued.

--- a/src/v/cloud_topics/level_one/maintenance/tests/worker_manager_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/tests/worker_manager_test.cc
@@ -269,6 +269,129 @@ TEST_F(WorkerManagerTestFixture, AcquireLevelingWorkSkipsStaleEntries) {
     ASSERT_TRUE(lq.empty());
 }
 
+// Leveling should not run concurrently with compaction of the same CTP:
+// `try_acquire_leveling_work` must drop a job whose CTP has an inflight
+// compaction (without marking its range inflight) and return the next live
+// job behind it.
+TEST_F(WorkerManagerTestFixture, AcquireLevelingWorkSkipsCompactingCTP) {
+    auto cmp_func =
+      [](const l1::compaction_job_ptr& a, const l1::compaction_job_ptr& b) {
+          return a->meta->ntp < b->meta->ntp;
+      };
+
+    l1::compaction_scheduler_probe probe;
+    l1::compaction_queue pq(std::move(cmp_func));
+    l1::leveling_extent_reclamation_policy lq_policy{
+      config::mock_binding<size_t>(size_t{1024} * 1024)};
+    l1::leveling_queue lq(lq_policy.get_comparator());
+    l1::log_list_t list;
+    l1::worker_manager manager(
+      pq, lq, nullptr, nullptr, nullptr, probe, nullptr);
+    auto stop_manager = ss::defer([&manager] { manager.stop().get(); });
+
+    auto make_meta = [](std::string_view topic) {
+        auto ntp = model::ntp(
+          model::ns("kafka"),
+          model::topic(ss::sstring{topic}),
+          model::partition_id(0));
+        auto tidp = model::topic_id_partition(
+          model::topic_id(uuid_t::create()), ntp.tp.partition);
+        return ss::make_lw_shared<l1::log_compaction_meta>(tidp, ntp);
+    };
+    // Higher extent_count => higher expected reclaim => sorts first.
+    auto make_job =
+      [](const l1::log_compaction_meta_ptr& meta, size_t extent_count) {
+          return ss::make_lw_shared<l1::leveling_job>(
+            meta,
+            l1::levelable_range{
+              .base_offset = kafka::offset{0},
+              .last_offset = kafka::offset{99},
+              .size_bytes = 1,
+              .extent_count = extent_count},
+            l1::metastore::compaction_epoch{0});
+      };
+
+    // A managed CTP with an inflight compaction at the head of the queue.
+    auto compacting = make_meta("compacting");
+    list.push_back(*compacting);
+    compacting->compaction.inflight_shard = ss::this_shard_id();
+    lq.push(make_job(compacting, 100));
+
+    // A live CTP with no inflight compaction sitting behind it.
+    auto live = make_meta("live");
+    list.push_back(*live);
+    lq.push(make_job(live, 10));
+
+    auto work_opt = manager.try_acquire_leveling_work(ss::this_shard_id());
+    ASSERT_TRUE(work_opt.has_value());
+    ASSERT_EQ(work_opt.value()->meta->ntp, live->ntp);
+    ASSERT_TRUE(lq.empty());
+    // The dropped job's range was never marked inflight, so the collector is
+    // free to re-queue it once the compaction completes.
+    ASSERT_TRUE(compacting->leveling.inflight_ranges.empty());
+}
+
+// Dequeuing a compaction job must preempt leveling of the same CTP: its queued
+// leveling jobs are dropped and its inflight leveling jobs are hard-stopped.
+TEST_F(WorkerManagerTestFixture, AcquireCompactionWorkPreemptsLeveling) {
+    auto cmp_func =
+      [](const l1::compaction_job_ptr& a, const l1::compaction_job_ptr& b) {
+          return a->meta->ntp < b->meta->ntp;
+      };
+
+    l1::compaction_scheduler_probe probe;
+    l1::compaction_queue pq(std::move(cmp_func));
+    l1::leveling_extent_reclamation_policy lq_policy{
+      config::mock_binding<size_t>(size_t{1024} * 1024)};
+    l1::leveling_queue lq(lq_policy.get_comparator());
+    l1::log_list_t list;
+    l1::worker_manager manager(
+      pq, lq, nullptr, nullptr, nullptr, probe, nullptr);
+    start_workers(manager).get();
+    auto stop_manager = ss::defer([&manager] { manager.stop().get(); });
+
+    const auto shard = ss::this_shard_id();
+    const auto ntp = model::ntp(
+      model::ns("kafka"), model::topic("tapioca"), model::partition_id(0));
+    const auto tidp = model::topic_id_partition(
+      model::topic_id(uuid_t::create()), ntp.tp.partition);
+    const auto base = kafka::offset{0};
+    auto meta = ss::make_lw_shared<l1::log_compaction_meta>(tidp, ntp);
+    list.push_back(*meta);
+
+    pq.push(
+      ss::make_lw_shared<l1::compaction_job>(
+        meta, l1::compaction_info_and_timestamp{}));
+
+    // A queued leveling job for the CTP, plus an inflight one on this shard.
+    lq.push(
+      ss::make_lw_shared<l1::leveling_job>(
+        meta,
+        l1::levelable_range{
+          .base_offset = kafka::offset{100},
+          .last_offset = kafka::offset{199},
+          .size_bytes = 1,
+          .extent_count = 2},
+        l1::metastore::compaction_epoch{0}));
+    meta->leveling.inflight_shards[shard] = 1;
+    add_inflight_leveling_job(manager, shard, tidp, base).get();
+
+    auto work_opt = manager.try_acquire_compaction_work(shard);
+    ASSERT_TRUE(work_opt.has_value());
+    ASSERT_TRUE(work_opt.value()->meta->compaction.inflight_shard.has_value());
+
+    // The CTP's queued leveling job was dropped on compaction dequeue.
+    ASSERT_TRUE(lq.empty());
+
+    // The preemption is dispatched asynchronously onto the manager's gate;
+    // drain the task queue so it runs, then confirm the inflight leveling job
+    // was hard-stopped.
+    tests::drain_task_queue().get();
+    ASSERT_EQ(
+      inflight_leveling_state(manager, shard, tidp, base).get(),
+      l1::compaction_job_state::hard_stop);
+}
+
 // `complete_leveling_work` decrements the CTP's inflight-shard count and stamps
 // the just-completed range with a commit timestamp, replacing the `nullopt`
 // recorded at acquire so the collector applies a post-commit cooldown before

--- a/src/v/cloud_topics/level_one/maintenance/worker.cc
+++ b/src/v/cloud_topics/level_one/maintenance/worker.cc
@@ -43,6 +43,13 @@ ss::future<bool> is_linked(const log_compaction_meta* meta) {
     });
 }
 
+ss::future<bool> may_level(const log_compaction_meta* meta) {
+    return ss::smp::submit_to(worker_manager::worker_manager_shard, [meta] {
+        return meta->link.is_linked()
+               && !meta->compaction.inflight_shard.has_value();
+    });
+}
+
 } // namespace
 
 compaction_worker::compaction_worker(
@@ -446,7 +453,7 @@ ss::future<> compaction_worker::do_level_range(leveling_job* job) {
         }
     });
 
-    if (!co_await is_linked(job->meta.get())) {
+    if (!co_await may_level(job->meta.get())) {
         co_return;
     }
 

--- a/src/v/cloud_topics/level_one/maintenance/worker_manager.cc
+++ b/src/v/cloud_topics/level_one/maintenance/worker_manager.cc
@@ -89,6 +89,14 @@ worker_manager::try_acquire_compaction_work(ss::shard_id shard) {
     // Marking the CTP inflight (and skipping inflight CTPs during sampling)
     // is how a CTP is kept out of the queue while being compacted.
     job->meta->compaction.inflight_shard = shard;
+
+    // Ideally, leveling should not run concurrently with compaction of the same
+    // CTP. Stop any inflight leveling jobs and clear the queue of any others
+    // queued for the same CTP.
+    _leveling_queue.clear(job->meta->tidp);
+    _probe.set_leveling_queue_length(_leveling_queue.size());
+    request_stop_leveling(job->meta);
+
     return ss::make_foreign(job);
 }
 
@@ -123,6 +131,11 @@ worker_manager::try_acquire_leveling_work(ss::shard_id shard) {
 
         if (!job || !job->meta || !job->meta->link.is_linked()) {
             // The CTP was unmanaged after this job was queued; drop it.
+            continue;
+        }
+
+        if (job->meta->compaction.inflight_shard.has_value()) {
+            // The CTP has an inflight compaction on-going; drop it.
             continue;
         }
 


### PR DESCRIPTION
Try to avoid wasting resources by scheduling leveling and compaction concurrently for the same partition. While the `compaction_epoch` prevents any correctness issues here already, it is a waste of resources and somewhat noisy to continually fail leveling due to a compaction of the log making the leveling work invalid.


## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
