### PR TITLE
[v26.1.x] schema_registry: load _schemas once across shards on startup

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3869,6 +3869,15 @@ configuration::configuration()
       "replayed record is compiled sequentially during the replay.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       true)
+  , schema_registry_replay_on_startup(
+      *this,
+      "schema_registry_replay_on_startup",
+      "Replay the internal `_schemas` topic into the store at Schema Registry "
+      "start-up instead of lazily on the first request. Makes recovery time "
+      "predictable and keeps the first request from blocking behind a full "
+      "replay.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      false)
   , schema_registry_avro_use_named_references(
       *this, "schema_registry_avro_use_named_references")
   , schema_registry_enable_qualified_subjects(

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -673,6 +673,7 @@ struct configuration final : public config_store {
     enterprise<property<bool>> schema_registry_enable_authorization;
     property<bool> schema_registry_always_normalize;
     property<bool> schema_registry_deferred_recovery;
+    property<bool> schema_registry_replay_on_startup;
     deprecated_property schema_registry_avro_use_named_references;
     property<bool> schema_registry_enable_qualified_subjects;
     property<std::optional<uint32_t>> pp_sr_smp_max_non_local_requests;

--- a/src/v/pandaproxy/schema_registry/BUILD
+++ b/src/v/pandaproxy/schema_registry/BUILD
@@ -231,6 +231,7 @@ redpanda_cc_library(
         "//src/v/security:request_auth",
         "//src/v/security/audit",
         "//src/v/security/audit:types",
+        "//src/v/ssx:future_util",
         "//src/v/ssx:semaphore",
         "//src/v/ssx:sformat",
         "//src/v/strings:string_switch",

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -609,6 +609,24 @@ server::routes_t get_schema_registry_routes(ss::gate& gate, one_shot& es) {
     return routes;
 }
 
+ss::future<> service::ensure_topic_loaded() {
+    // `service` is a peering_sharded_service, so each shard has its own
+    // `_ensure_started` one_shot. If the first requests after start-up land on
+    // several shards at once, each shard's one_shot would independently run
+    // do_start() and launch its own full `_schemas` replay on the reader
+    // shard. Redundant replays each pay the full recovery cost, so N racing
+    // shards make recovery up to N times slower.
+    //
+    // Funnel all shards through a single one_shot on the reader shard, so the
+    // topic is loaded exactly once. The per-shard `_ensure_started` one_shot
+    // still caches completion, so once started this costs nothing on later
+    // requests; only the first request on each shard pays the cross-shard hop.
+    return container().invoke_on(
+      seq_writer::reader_shard, _ctx.smp_sg, [](service& s) {
+          return s._load_once();
+      });
+}
+
 ss::future<> service::do_start() {
     if (_is_started) {
         co_return;
@@ -977,7 +995,8 @@ service::service(
   , _topic_creator(std::move(topic_creator))
   , _controller(controller)
   , _audit_mgr(audit_mgr)
-  , _ensure_started{[this]() { return do_start(); }}
+  , _ensure_started{[this]() { return ensure_topic_loaded(); }}
+  , _load_once{[this]() { return do_start(); }}
   , _auth{
       config::always_true(),
       config::shard_local_cfg().superusers.bind(),

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -42,6 +42,7 @@
 #include "security/credential_store.h"
 #include "security/ephemeral_credential_store.h"
 #include "security/request_auth.h"
+#include "ssx/future-util.h"
 #include "ssx/semaphore.h"
 #include "utils/tristate.h"
 
@@ -1010,10 +1011,30 @@ ss::future<> service::start() {
     co_await configure();
     static std::vector<model::broker_endpoint> not_advertised{};
     _server.routes(get_schema_registry_routes(_gate, _ensure_started));
-    co_return co_await _server.start(
+    co_await _server.start(
       _config.schema_registry_api(),
       _config.schema_registry_api_tls(),
       not_advertised);
+
+    if (
+      ss::this_shard_id() == seq_writer::reader_shard
+      && config::shard_local_cfg().schema_registry_replay_on_startup()) {
+        // Proactively hydrate the store rather than wait for the first request.
+        // Fire-and-forget under the gate: a large topic can take a while to
+        // replay and must not block broker start-up. This goes through the
+        // single-flight ensure_started(), so a request that races it still
+        // triggers exactly one replay.
+        ssx::spawn_with_gate(_gate, [this] {
+            return ensure_started().handle_exception(
+              [](const std::exception_ptr& e) {
+                  vlog(
+                    srlog.warn,
+                    "eager _schemas replay failed at start-up; will retry on "
+                    "the first request: {}",
+                    e);
+              });
+        });
+    }
 }
 
 ss::future<> service::stop() {

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -628,9 +628,12 @@ ss::future<> service::ensure_topic_loaded() {
 }
 
 ss::future<> service::do_start() {
-    if (_is_started) {
-        co_return;
-    }
+    // Invoked only on the reader shard, via _load_once, so it runs exactly
+    // once and can drive the reader-shard-only fetch directly.
+    vassert(
+      ss::this_shard_id() == seq_writer::reader_shard,
+      "do_start must run on the reader shard, not {}",
+      ss::this_shard_id());
     auto guard = _gate.hold();
     try {
         co_await create_internal_topic();
@@ -645,12 +648,7 @@ ss::future<> service::do_start() {
           std::current_exception());
         throw;
     }
-    co_await container().invoke_on_all(_ctx.smp_sg, [](service& s) {
-        s._is_started = true;
-        return ss::this_shard_id() == seq_writer::reader_shard
-                 ? s.fetch_internal_topic()
-                 : ss::now();
-    });
+    co_await fetch_internal_topic();
 }
 
 ss::future<> create_acls(cluster::security_frontend& security_fe) {

--- a/src/v/pandaproxy/schema_registry/service.h
+++ b/src/v/pandaproxy/schema_registry/service.h
@@ -76,6 +76,7 @@ public:
     }
 
 private:
+    // Only ever invoked on the reader shard, via _load_once.
     ss::future<> do_start();
     ss::future<> configure();
     ss::future<> inform(model::node_id);
@@ -116,7 +117,6 @@ private:
     one_shot _load_once;
     request_authenticator _auth;
     bool _has_ephemeral_credentials{false};
-    bool _is_started{false};
 };
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/service.h
+++ b/src/v/pandaproxy/schema_registry/service.h
@@ -80,6 +80,11 @@ private:
     ss::future<> configure();
     ss::future<> inform(model::node_id);
     ss::future<> do_inform(model::node_id);
+    /// Route every shard's start-up through a single one_shot on the reader
+    /// shard, so the `_schemas` topic is replayed exactly once regardless of
+    /// how many shards receive their first request concurrently. See the
+    /// definition for why the per-shard one_shots would otherwise race.
+    ss::future<> ensure_topic_loaded();
     ss::future<> create_internal_topic();
     ss::future<> fetch_internal_topic();
     ss::future<> validate_topic_creation_authorization();
@@ -102,7 +107,13 @@ private:
     std::unique_ptr<cluster::controller>& _controller;
     ss::sharded<security::audit::audit_log_manager>& _audit_mgr;
 
+    // Per-shard: caches that start-up has completed on this shard, giving a
+    // cheap fast path for subsequent requests. Its action delegates to
+    // `_load_once` on the reader shard.
     one_shot _ensure_started;
+    // Reader shard only: the single authority that runs `do_start()` exactly
+    // once, no matter how many shards enter start-up concurrently.
+    one_shot _load_once;
     request_authenticator _auth;
     bool _has_ephemeral_credentials{false};
     bool _is_started{false};

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -11421,3 +11421,108 @@ class SchemaRegistryStartupRecoveryTest(RedpandaTest):
         )
         assert r.status_code == requests.codes.ok, r.text
         assert len(r.json()) >= self.N_SUBJECTS
+
+    @cluster(num_nodes=3, log_allow_list=_SR_STARTUP_RECOVERY_LOG_ALLOW_LIST)
+    def test_replay_on_startup_without_request(self):
+        """
+        With schema_registry_replay_on_startup enabled, the store must hydrate
+        proactively at startup without any client request driving it.
+
+        admin restart_service re-runs service::start() (via api::restart ->
+        start -> service::start), which is where the eager trigger lives, and
+        does not restart the broker process, so the log persists and we can
+        watch for the replay without touching the SR API.
+        """
+        node = self.redpanda.nodes[0]
+        host = node.account.hostname
+
+        # Populate _schemas so a restart has a topic to replay.
+        self._register_schemas(host)
+        wait_until(
+            lambda: self._all_subjects_served(host),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="subjects not visible after registration",
+        )
+
+        self.redpanda.set_cluster_config({"schema_registry_replay_on_startup": True})
+
+        init_before = self.redpanda.count_log_node(node, self.INIT_MARKER)
+
+        admin = Admin(self.redpanda)
+        result = admin.restart_service(rp_service="schema-registry", node=node)
+        assert result.status_code == requests.codes.ok, (
+            f"restart_service failed: {result.status_code} {result.text}"
+        )
+
+        # Deliberately issue NO SR request. The eager startup trigger must drive
+        # the replay on its own. count_log_node greps the broker log over ssh,
+        # so polling here does not hit the SR API and cannot trigger the lazy
+        # path.
+        wait_until(
+            lambda: self.redpanda.count_log_node(node, self.INIT_MARKER) > init_before,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="eager startup replay did not run without any request",
+        )
+
+        replays = self.redpanda.count_log_node(node, self.INIT_MARKER) - init_before
+        assert replays == 1, (
+            f"expected exactly one eager replay, saw {replays} "
+            f"('{self.INIT_MARKER}' delta)."
+        )
+
+        # The store hydrated without a request; a request now succeeds
+        # immediately rather than blocking on a cold replay.
+        assert self._all_subjects_served(host)
+
+    @cluster(num_nodes=3, log_allow_list=_SR_STARTUP_RECOVERY_LOG_ALLOW_LIST)
+    def test_no_replay_on_startup_by_default(self):
+        """
+        With schema_registry_replay_on_startup unset (the default), recovery
+        stays lazy: a restart does not replay _schemas until a request (or an
+        internal access) arrives. The complement of
+        test_replay_on_startup_without_request, and a guard that the config
+        actually gates the eager path.
+        """
+        node = self.redpanda.nodes[0]
+        host = node.account.hostname
+
+        self._register_schemas(host)
+        wait_until(
+            lambda: self._all_subjects_served(host),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="subjects not visible after registration",
+        )
+
+        # Deliberately leave schema_registry_replay_on_startup at its default
+        # (off). do_start() logs INIT_MARKER once per run, so a flat count after
+        # a restart with no request means recovery did not run.
+        init_before = self.redpanda.count_log_node(node, self.INIT_MARKER)
+
+        admin = Admin(self.redpanda)
+        result = admin.restart_service(rp_service="schema-registry", node=node)
+        assert result.status_code == requests.codes.ok, (
+            f"restart_service failed: {result.status_code} {result.text}"
+        )
+
+        # No SR request is issued. Give recovery ample time to (not) happen;
+        # a real replay of this topic completes in well under a second.
+        time.sleep(15)
+        assert self.redpanda.count_log_node(node, self.INIT_MARKER) == init_before, (
+            "recovery ran at startup without the config set and without a "
+            "request; it should be lazy by default"
+        )
+
+        # The first request now lazily triggers exactly one replay and serves.
+        wait_until(
+            lambda: self._all_subjects_served(host),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="lazy recovery did not serve after the first request",
+        )
+        replays = self.redpanda.count_log_node(node, self.INIT_MARKER) - init_before
+        assert replays == 1, (
+            f"expected exactly one lazy replay after the first request, saw {replays}."
+        )

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -13,6 +13,7 @@ import json
 import random
 import re
 import socket
+import threading
 import time
 import urllib.parse
 import uuid
@@ -11229,3 +11230,194 @@ class SchemaRegistryContextAuthzTest(SchemaRegistryAclAuthzTestBase):
             403,
             f"GET schemas/ids/{sid}/schema should be 403, got {result.status_code}",
         )
+
+
+# The SR briefly returns HTTP 500 (std::exception) to requests that arrive
+# while restart_service is tearing down and rebuilding it. This test sends load
+# during the restart window on purpose, so those transient errors are expected
+# and unrelated to the startup race under test.
+_SR_STARTUP_RECOVERY_LOG_ALLOW_LIST = DEFAULT_LOG_ALLOW_LIST + [
+    r"schemaregistry - reply.h.*HTTP 500 Internal Server Error",
+]
+
+
+class SchemaRegistryStartupRecoveryTest(RedpandaTest):
+    """
+    Schema Registry recovery of the `_schemas` topic on startup must run
+    exactly one replay per broker, even when many first requests land on
+    different shards at once.
+
+    Regression test for the multi-shard `do_start()` startup race.
+    `service` is a per-shard peering_sharded_service, so each shard owns its
+    own `_ensure_started` one_shot, and `do_start()` only stamps `_is_started`
+    (its re-entry guard) from inside its `invoke_on_all`, after
+    `create_internal_topic()`. That leaves a window in which first requests
+    arriving on several shards concurrently each run `do_start()` and launch
+    their own independent, redundant full replay on the reader shard, slowing
+    recovery by up to a factor of the shard count.
+
+    `do_start()` logs "Schema registry successfully initialized" exactly once
+    per invocation (before its fetch-retry loop, only on success), so the
+    increase in that marker across a single SR restart is precisely the number
+    of replays that ran. The fix funnels every shard through a single reader-
+    shard one_shot, so the count is deterministically 1.
+
+    Reproducing the race on unfixed code is timing-dependent (the window is a
+    single cold `create_internal_topic()` call), so we restart repeatedly under
+    heavy concurrent load to raise the odds; the assertion is exact on the
+    fixed code regardless. Multiple shards are required, so this runs the
+    brokers with >1 CPU (num_cpus=1 has a single shard and cannot race).
+    """
+
+    INIT_MARKER = "Schema registry successfully initialized"
+    # A second consumer re-applying already-loaded offsets: the fingerprint of
+    # a concurrent redundant replay. Absent when a single replay runs.
+    RACE_MARKER = "advance_offset ignoring"
+
+    N_SUBJECTS = 200
+    RESTARTS = 5
+    HAMMER_THREADS = 32
+
+    def __init__(self, test_context: TestContext):
+        super().__init__(
+            test_context=test_context,
+            num_brokers=3,
+            extra_rp_conf={
+                "auto_create_topics_enabled": False,
+                "schema_registry_use_rpc": False,
+            },
+            # Multiple shards per broker are required to exercise the
+            # cross-shard startup race; num_cpus=1 has a single shard and the
+            # race cannot occur. More shards increase reproduction odds.
+            resource_settings=ResourceSettings(num_cpus=2),
+            log_config=log_config,  # schemaregistry: trace
+            pandaproxy_config=PandaproxyConfig(),
+            schema_registry_config=SchemaRegistryConfig(),
+        )
+        self.sr_client = SchemaRegistryRedpandaClient(redpanda=self.redpanda)
+
+    @staticmethod
+    def _schema(i: int) -> str:
+        return json.dumps(
+            {
+                "schema": json.dumps(
+                    {
+                        "type": "record",
+                        "name": f"rec{i}",
+                        "fields": [{"name": "f", "type": "string"}],
+                    }
+                )
+            }
+        )
+
+    def _register_schemas(self, hostname: str) -> None:
+        for i in range(self.N_SUBJECTS):
+            r = self.sr_client.request(
+                "POST",
+                f"subjects/test-{i}-value/versions",
+                headers=HTTP_POST_HEADERS,
+                data=self._schema(i),
+                hostname=hostname,
+            )
+            assert r.status_code == requests.codes.ok, (
+                f"register subject {i} failed: {r.status_code} {r.text}"
+            )
+
+    def _all_subjects_served(self, hostname: str) -> bool:
+        r = self.sr_client.request(
+            "GET", "subjects", headers=HTTP_GET_HEADERS, hostname=hostname
+        )
+        return r.status_code == requests.codes.ok and len(r.json()) >= self.N_SUBJECTS
+
+    @cluster(num_nodes=3, log_allow_list=_SR_STARTUP_RECOVERY_LOG_ALLOW_LIST)
+    def test_single_replay_per_startup(self):
+        node = self.redpanda.nodes[0]
+        host = node.account.hostname
+        base = f"http://{host}:8081"
+
+        # Populate _schemas so recovery has real work and the subject list is
+        # non-trivial to serve.
+        self._register_schemas(host)
+        wait_until(
+            lambda: self._all_subjects_served(host),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="subjects not visible after registration",
+        )
+
+        for iteration in range(self.RESTARTS):
+            init_before = self.redpanda.count_log_node(node, self.INIT_MARKER)
+            race_before = self.redpanda.count_log_node(node, self.RACE_MARKER)
+
+            # Pile concurrent read load on the target broker so that, right
+            # after the restart resets SR, first requests fan out across its
+            # shards and (on unfixed code) trigger the race. Raw requests bypass
+            # the SR client's retry/sleep so the load stays tight; responses are
+            # irrelevant, we only care about driving startup.
+            stop = threading.Event()
+
+            def hammer():
+                while not stop.is_set():
+                    for path in (
+                        "subjects",
+                        f"schemas/ids/{random.randint(1, self.N_SUBJECTS)}",
+                    ):
+                        try:
+                            requests.get(
+                                f"{base}/{path}",
+                                headers=HTTP_GET_HEADERS,
+                                timeout=2,
+                            )
+                        except Exception:
+                            pass
+
+            threads = [
+                threading.Thread(target=hammer, daemon=True)
+                for _ in range(self.HAMMER_THREADS)
+            ]
+            for t in threads:
+                t.start()
+
+            try:
+                admin = Admin(self.redpanda)
+                result = admin.restart_service(rp_service="schema-registry", node=node)
+                assert result.status_code == requests.codes.ok, (
+                    f"restart_service failed: {result.status_code} {result.text}"
+                )
+
+                # Recovery: the store rehydrates and subjects are served again.
+                wait_until(
+                    lambda: self._all_subjects_served(host),
+                    timeout_sec=60,
+                    backoff_sec=1,
+                    err_msg=f"SR did not recover after restart {iteration}",
+                )
+            finally:
+                stop.set()
+                for t in threads:
+                    t.join(timeout=10)
+
+            init_after = self.redpanda.count_log_node(node, self.INIT_MARKER)
+            race_after = self.redpanda.count_log_node(node, self.RACE_MARKER)
+
+            replays = init_after - init_before
+            assert replays == 1, (
+                f"iteration {iteration}: expected exactly one _schemas replay "
+                f"per SR restart, saw {replays} "
+                f"('{self.INIT_MARKER}' {init_before}->{init_after}). "
+                f">1 means the multi-shard do_start() startup race launched "
+                f"redundant concurrent replays."
+            )
+            assert race_after == race_before, (
+                f"iteration {iteration}: saw {race_after - race_before} "
+                f"'{self.RACE_MARKER}' lines during recovery -- a second "
+                f"consumer re-applied already-loaded offsets, i.e. a concurrent "
+                f"redundant replay ran."
+            )
+
+        # Everything is still served correctly after the restart cycles.
+        r = self.sr_client.request(
+            "GET", "subjects", headers=HTTP_GET_HEADERS, hostname=host
+        )
+        assert r.status_code == requests.codes.ok, r.text
+        assert len(r.json()) >= self.N_SUBJECTS


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31137

- Command: git cherry-pick -x 89a0736450 44ed325e38 e9aae739ad
- Commits backported: 3
- Conflicts resolved: 3
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-31137-v26.1.x-1784349711

## Conflict details

- 89a0736450 (src/v/pandaproxy/schema_registry/service.h): the new `ensure_topic_loaded()` declaration collided with target-only private methods (`configure`, `inform`, `do_inform`); kept both — target's methods plus the new declaration and its doc comment.
- 89a0736450 (tests/rptest/tests/schema_registry_test.py): the append at EOF conflicted because the target branch diverges heavily in this file (different `ContextAuthz` base classes, and it lacks the source-only transport-variant/stress/compat test classes). Took target's content and added only what this commit introduces: `import threading` and the new `SchemaRegistryStartupRecoveryTest` class; the unrelated source-only classes were not introduced.
- 44ed325e38 (src/v/pandaproxy/schema_registry/service.h): commit removes the now-redundant `_is_started` guard; target additionally has `_has_ephemeral_credentials` (absent on source). Kept `_has_ephemeral_credentials`, dropped `_is_started`.
- 44ed325e38 (src/v/pandaproxy/schema_registry/service.cc): the source-branch `do_start()` tail carried a retry/backoff loop that does not exist on the target branch (it came from an unrelated source-only PR). Applied the commit's intent — single-flight do_start runs inline on the reader shard — by replacing the target's `invoke_on_all`/`_is_started` block with a direct `co_await fetch_internal_topic();`, preserving target behavior (no retry loop introduced).
- e9aae739ad (src/v/config/configuration.h, src/v/config/configuration.cc): adjacent property `schema_registry_deferred_recovery` exists on source but not on target. Added only this commit's new property `schema_registry_replay_on_startup` (declaration and initializer in matching order); did not introduce the unrelated `schema_registry_deferred_recovery`.
