### PR TITLE
`ct/l1`: commit compaction and leveling output incrementally

### DIFF
--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -1455,6 +1455,9 @@ db_domain_manager::do_get_leveling_info(
             }
             builder.process_extent(
               base, extent.val.last_offset, extent.val.len);
+            if (builder.is_full()) {
+                break;
+            }
         }
     }
     co_return rpc::get_leveling_info_reply{

--- a/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
+++ b/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
@@ -1157,6 +1157,382 @@ TEST_F(DbDomainManagerTest, TestGarbageCollectionDeletionDelay) {
       30s, [&] { return all_objects_missing(object_ids); });
 }
 
+namespace {
+// A "partial" compaction commit: a batch of the job's output objects with
+// an empty compaction update. This is the existing compact_objects shape
+// the sink's no-metadata fallback has always used: the epoch is validated
+// and bumped, the extents are replaced span-exact, and no compaction state
+// is recorded. Bumping the epoch on every batch is what fences stale
+// rewriters (straggler compactions, leveling jobs with old read snapshots)
+// out of the job's data for the remainder of the run.
+l1_rpc::compact_objects_request make_partial_compact(
+  const model::topic_id_partition& tp,
+  chunked_vector<new_object> objects,
+  partition_state::compaction_epoch_t expected_epoch) {
+    l1_rpc::compact_objects_request req;
+    req.metastore_partition = model::partition_id(0);
+    req.new_objects = std::move(objects);
+    compaction_state_update csu;
+    csu.cleaned_at = model::timestamp::missing();
+    csu.expected_compaction_epoch = expected_epoch;
+    req.compaction_updates.emplace(tp, std::move(csu));
+    return req;
+}
+} // namespace
+
+// Models a long-running compaction job under the incremental-commit
+// pattern: the job lands each batch of output objects via a partial
+// compaction commit as it is produced (validated span-exact and bumping
+// the compaction epoch every time), then finishes with a metadata-only
+// compact_objects() carrying no objects — just the cleaned ranges,
+// recorded against the epoch its own partials advanced. The job may run
+// arbitrarily longer than the preregistration TTL: by the time the GC
+// could expire anything, the objects are already committed. Together with
+// TestReplaceObjectsAfterPreregistrationExpiry (where a single-shot commit
+// of a job outliving the TTL is rejected), this shows the incremental
+// pattern is what makes long jobs commit safely.
+TEST_F(DbDomainManagerTest, TestPartialCompactsSurvivePreregistrationExpiry) {
+    cfg.get("cloud_topics_long_term_garbage_collection_interval")
+      .set_value(100ms);
+    cfg.get("cloud_topics_preregistered_object_ttl").set_value(1ms);
+
+    auto tp = make_tp();
+    // Seed [0, 30) as three extents.
+    add_preregistered_objects(tp, kafka::offset(0), 3, 10, model::term_id(1));
+
+    auto partial_commit =
+      [&](kafka::offset base, uint32_t count, int expected_epoch) {
+          auto prereg = initial_manager
+                          ->preregister_objects({
+                            .metastore_partition = model::partition_id(0),
+                            .count = count,
+                          })
+                          .get();
+          ASSERT_EQ(prereg.ec, l1_rpc::errc::ok);
+          auto reply = initial_manager
+                         ->compact_objects(make_partial_compact(
+                           tp,
+                           make_new_objects_with_ids(
+                             tp, base, 10, prereg.object_ids),
+                           partition_state::compaction_epoch_t{expected_epoch}))
+                         .get();
+          ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+      };
+
+    // Incremental phase: partial-commit [0, 20) as the job produces its
+    // first two output objects, bumping the epoch to 1.
+    ASSERT_NO_FATAL_FAILURE(partial_commit(kafka::offset(0), 2, 0));
+
+    // The job outlives the preregistration TTL while the GC cycles; the
+    // committed objects are no longer preregistrations, so there is
+    // nothing for the GC to expire from under the job.
+    ASSERT_EQ(initial_manager->flush_domain({}).get().ec, l1_rpc::errc::ok);
+    initial_manager->start();
+    ss::sleep(1s).get();
+
+    // Tail of the job: the last output object lands the same way.
+    ASSERT_NO_FATAL_FAILURE(partial_commit(kafka::offset(20), 1, 1));
+
+    // Final commit: metadata only. Atomically records the job's cleaned
+    // ranges against the epoch its partials advanced.
+    {
+        l1_rpc::compact_objects_request req;
+        req.metastore_partition = model::partition_id(0);
+        compaction_state_update csu;
+        csu.new_cleaned_ranges.push_back({
+          .base_offset = kafka::offset(0),
+          .last_offset = kafka::offset(29),
+          .has_tombstones = false,
+        });
+        csu.cleaned_at = model::timestamp::now();
+        csu.expected_compaction_epoch = partition_state::compaction_epoch_t{2};
+        req.compaction_updates.emplace(tp, std::move(csu));
+        auto reply = initial_manager->compact_objects(std::move(req)).get();
+        ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+    }
+
+    // The log is [0, 30) across the job's three output extents, the epoch
+    // advanced once per partial plus once for the metadata commit, and the
+    // log is fully clean.
+    validate_metadata(
+      tp, kafka::offset(0), kafka::offset(30), exact_next::yes, 3);
+    {
+        l1_rpc::get_compaction_info_request req;
+        req.tp = tp;
+        req.tombstone_removal_upper_bound_ts = model::timestamp::max();
+        auto reply = initial_manager->get_compaction_info(std::move(req)).get();
+        ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+        EXPECT_EQ(
+          reply.compaction_epoch, partition_state::compaction_epoch_t{3});
+        EXPECT_TRUE(reply.dirty_ranges.empty());
+    }
+}
+
+// A truncation advancing the start offset between a job's partial commits
+// and its final commit deletes the extent rows of output objects that
+// fall wholly below the new start offset. The metadata-only final commit
+// references no extents, so it is unaffected and must succeed.
+TEST_F(DbDomainManagerTest, TestMetadataOnlyCompactAfterTruncation) {
+    auto tp = make_tp();
+    // Seed [0, 30) as three extents.
+    add_preregistered_objects(tp, kafka::offset(0), 3, 10, model::term_id(1));
+
+    auto partial_commit =
+      [&](kafka::offset base, uint32_t count, int expected_epoch) {
+          auto prereg = initial_manager
+                          ->preregister_objects({
+                            .metastore_partition = model::partition_id(0),
+                            .count = count,
+                          })
+                          .get();
+          ASSERT_EQ(prereg.ec, l1_rpc::errc::ok);
+          auto reply = initial_manager
+                         ->compact_objects(make_partial_compact(
+                           tp,
+                           make_new_objects_with_ids(
+                             tp, base, 10, prereg.object_ids),
+                           partition_state::compaction_epoch_t{expected_epoch}))
+                         .get();
+          ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+      };
+
+    ASSERT_NO_FATAL_FAILURE(partial_commit(kafka::offset(0), 2, 0));
+
+    // Retention truncates to offset 15 mid-job: the first output object's
+    // extent [0, 9] is deleted; [10, 19] straddles the start offset and
+    // survives.
+    {
+        l1_rpc::set_start_offset_request req;
+        req.tp = tp;
+        req.start_offset = kafka::offset(15);
+        auto reply = initial_manager->set_start_offset(std::move(req)).get();
+        ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+    }
+
+    ASSERT_NO_FATAL_FAILURE(partial_commit(kafka::offset(20), 1, 1));
+
+    {
+        l1_rpc::compact_objects_request req;
+        req.metastore_partition = model::partition_id(0);
+        compaction_state_update csu;
+        csu.new_cleaned_ranges.push_back({
+          .base_offset = kafka::offset(0),
+          .last_offset = kafka::offset(29),
+          .has_tombstones = false,
+        });
+        csu.cleaned_at = model::timestamp::now();
+        csu.expected_compaction_epoch = partition_state::compaction_epoch_t{2};
+        req.compaction_updates.emplace(tp, std::move(csu));
+        auto reply = initial_manager->compact_objects(std::move(req)).get();
+        ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+    }
+
+    // The surviving log has start offset 15, next offset 30, and extents
+    // [10, 19] and [20, 29]; the epoch advanced once per partial plus once
+    // for the metadata commit, and the live region is fully clean.
+    {
+        auto offsets_reply = initial_manager->get_offsets({.tp = tp}).get();
+        ASSERT_EQ(offsets_reply.ec, l1_rpc::errc::ok);
+        EXPECT_EQ(offsets_reply.start_offset, kafka::offset(15));
+        EXPECT_EQ(offsets_reply.next_offset, kafka::offset(30));
+    }
+    {
+        l1_rpc::get_compaction_info_request req;
+        req.tp = tp;
+        req.tombstone_removal_upper_bound_ts = model::timestamp::max();
+        auto reply = initial_manager->get_compaction_info(std::move(req)).get();
+        ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+        EXPECT_EQ(
+          reply.compaction_epoch, partition_state::compaction_epoch_t{3});
+        EXPECT_TRUE(reply.dirty_ranges.empty());
+    }
+}
+
+// The metadata-only commit is still fenced by the compaction epoch: a job
+// whose epoch is stale (another compaction committed since it began) must
+// be rejected.
+TEST_F(DbDomainManagerTest, TestMetadataOnlyCompactRejectsStaleEpoch) {
+    auto tp = make_tp();
+    add_preregistered_objects(tp, kafka::offset(0), 1, 10, model::term_id(1));
+
+    l1_rpc::compact_objects_request req;
+    req.metastore_partition = model::partition_id(0);
+    compaction_state_update csu;
+    csu.new_cleaned_ranges.push_back({
+      .base_offset = kafka::offset(0),
+      .last_offset = kafka::offset(9),
+      .has_tombstones = false,
+    });
+    csu.cleaned_at = model::timestamp::now();
+    csu.expected_compaction_epoch = partition_state::compaction_epoch_t{1};
+    req.compaction_updates.emplace(tp, std::move(csu));
+    auto reply = initial_manager->compact_objects(std::move(req)).get();
+    EXPECT_EQ(reply.ec, l1_rpc::errc::concurrent_requests);
+}
+
+// A metadata-only commit may only mark offsets the log has seen as
+// cleaned.
+TEST_F(DbDomainManagerTest, TestMetadataOnlyCompactRejectsRangeBeyondNext) {
+    auto tp = make_tp();
+    add_preregistered_objects(tp, kafka::offset(0), 3, 10, model::term_id(1));
+
+    l1_rpc::compact_objects_request req;
+    req.metastore_partition = model::partition_id(0);
+    compaction_state_update csu;
+    csu.new_cleaned_ranges.push_back({
+      .base_offset = kafka::offset(0),
+      .last_offset = kafka::offset(49),
+      .has_tombstones = false,
+    });
+    csu.cleaned_at = model::timestamp::now();
+    csu.expected_compaction_epoch = partition_state::compaction_epoch_t{0};
+    req.compaction_updates.emplace(tp, std::move(csu));
+    auto reply = initial_manager->compact_objects(std::move(req)).get();
+    EXPECT_EQ(reply.ec, l1_rpc::errc::concurrent_requests);
+}
+
+// The job commits each batch of output objects via a partial compaction commit
+// (bumping the epoch every time), then finishes with a metadata-only
+// compact_objects recording the cleaned ranges against the epoch its partials
+// advanced.
+TEST_F(DbDomainManagerTest, TestPartialCompactsThenMetadataOnlyCompact) {
+    auto tp = make_tp();
+    // Seed [0, 30) as three extents.
+    add_preregistered_objects(tp, kafka::offset(0), 3, 10, model::term_id(1));
+
+    // Three partial commits, one per output object; each bumps the epoch.
+    for (int i = 0; i < 3; ++i) {
+        auto prereg = initial_manager
+                        ->preregister_objects({
+                          .metastore_partition = model::partition_id(0),
+                          .count = 1,
+                        })
+                        .get();
+        ASSERT_EQ(prereg.ec, l1_rpc::errc::ok);
+        auto reply = initial_manager
+                       ->compact_objects(make_partial_compact(
+                         tp,
+                         make_new_objects_with_ids(
+                           tp, kafka::offset(i * 10), 10, prereg.object_ids),
+                         partition_state::compaction_epoch_t{i}))
+                       .get();
+        ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+    }
+
+    // Final commit: metadata only, against the epoch the partials advanced.
+    {
+        l1_rpc::compact_objects_request req;
+        req.metastore_partition = model::partition_id(0);
+        compaction_state_update csu;
+        csu.new_cleaned_ranges.push_back({
+          .base_offset = kafka::offset(0),
+          .last_offset = kafka::offset(29),
+          .has_tombstones = false,
+        });
+        csu.cleaned_at = model::timestamp::now();
+        csu.expected_compaction_epoch = partition_state::compaction_epoch_t{3};
+        req.compaction_updates.emplace(tp, std::move(csu));
+        auto reply = initial_manager->compact_objects(std::move(req)).get();
+        ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+    }
+
+    validate_metadata(
+      tp, kafka::offset(0), kafka::offset(30), exact_next::yes, 3);
+    {
+        l1_rpc::get_compaction_info_request req;
+        req.tp = tp;
+        req.tombstone_removal_upper_bound_ts = model::timestamp::max();
+        auto reply = initial_manager->get_compaction_info(std::move(req)).get();
+        ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+        EXPECT_EQ(
+          reply.compaction_epoch, partition_state::compaction_epoch_t{4});
+        EXPECT_TRUE(reply.dirty_ranges.empty());
+    }
+}
+
+// A partial commit fences straggler compaction jobs: once one job's
+// partial bumps the epoch, another job still pinned at the old epoch is
+// rejected on its very first partial rather than wasting a full run.
+TEST_F(DbDomainManagerTest, TestPartialCompactFencesStragglerCompaction) {
+    auto tp = make_tp();
+    add_preregistered_objects(tp, kafka::offset(0), 2, 10, model::term_id(1));
+
+    auto partial = [&](kafka::offset base, int expected_epoch) {
+        auto prereg = initial_manager
+                        ->preregister_objects({
+                          .metastore_partition = model::partition_id(0),
+                          .count = 1,
+                        })
+                        .get();
+        EXPECT_EQ(prereg.ec, l1_rpc::errc::ok);
+        return initial_manager
+          ->compact_objects(make_partial_compact(
+            tp,
+            make_new_objects_with_ids(tp, base, 10, prereg.object_ids),
+            partition_state::compaction_epoch_t{expected_epoch}))
+          .get();
+    };
+
+    // Job A's first partial bumps the epoch to 1.
+    ASSERT_EQ(partial(kafka::offset(0), 0).ec, l1_rpc::errc::ok);
+    // Straggler job B, still pinned at epoch 0, is fenced immediately —
+    // even on a range job A never touched.
+    EXPECT_EQ(
+      partial(kafka::offset(10), 0).ec, l1_rpc::errc::concurrent_requests);
+    // Job A continues at the epoch its own partial advanced.
+    EXPECT_EQ(partial(kafka::offset(10), 1).ec, l1_rpc::errc::ok);
+}
+
+// A partial commit fences leveling jobs with stale read snapshots: a
+// leveling replace_objects carries the epoch it read at, so once a
+// compaction partial bumps the epoch, the stale repackaging can no longer
+// land on top of the job's deduplicated output (or anywhere else in the
+// partition).
+TEST_F(DbDomainManagerTest, TestPartialCompactFencesStaleLeveling) {
+    auto tp = make_tp();
+    add_preregistered_objects(tp, kafka::offset(0), 2, 10, model::term_id(1));
+
+    // A leveling job "reads" at epoch 0 here (its replace below carries
+    // expected epoch 0). Compaction's partial then bumps the epoch.
+    {
+        auto prereg = initial_manager
+                        ->preregister_objects({
+                          .metastore_partition = model::partition_id(0),
+                          .count = 1,
+                        })
+                        .get();
+        ASSERT_EQ(prereg.ec, l1_rpc::errc::ok);
+        auto reply = initial_manager
+                       ->compact_objects(make_partial_compact(
+                         tp,
+                         make_new_objects_with_ids(
+                           tp, kafka::offset(0), 10, prereg.object_ids),
+                         partition_state::compaction_epoch_t{0}))
+                       .get();
+        ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+    }
+
+    // The stale leveling commit — same boundaries as what it read, so
+    // span-exact alone would let it through — is rejected by the epoch.
+    {
+        auto prereg = initial_manager
+                        ->preregister_objects({
+                          .metastore_partition = model::partition_id(0),
+                          .count = 1,
+                        })
+                        .get();
+        ASSERT_EQ(prereg.ec, l1_rpc::errc::ok);
+        l1_rpc::replace_objects_request req{
+          .metastore_partition = model::partition_id(0),
+          .new_objects = make_new_objects_with_ids(
+            tp, kafka::offset(10), 10, prereg.object_ids),
+          .expected_epochs = {{tp, partition_state::compaction_epoch_t{0}}},
+        };
+        auto reply = initial_manager->replace_objects(std::move(req)).get();
+        EXPECT_EQ(reply.ec, l1_rpc::errc::concurrent_requests);
+    }
+}
+
 TEST_F(DbDomainManagerTest, TestGetSizeBasic) {
     auto tp = make_tp();
     // Add 3 objects, each with an extent of size 512 bytes.

--- a/src/v/cloud_topics/level_one/maintenance/compaction/compaction_sink.cc
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/compaction_sink.cc
@@ -20,6 +20,8 @@
 #include "model/timestamp.h"
 #include "utils/prefix_logger.h"
 
+#include <stdexcept>
+
 namespace cloud_topics::l1 {
 
 namespace {
@@ -92,6 +94,7 @@ compaction_sink::compaction_sink(
   metastore* metastore,
   ss::abort_source& as,
   config::binding<size_t> max_object_size,
+  config::binding<size_t> commit_interval_bytes,
   size_t upload_part_size,
   compaction_worker_probe& probe,
   prefix_logger& ctxlog,
@@ -103,12 +106,13 @@ compaction_sink::compaction_sink(
       metastore,
       as,
       std::move(max_object_size),
+      std::move(commit_interval_bytes),
       upload_part_size,
       ctxlog,
       std::move(opts))
   , _dirty_range_intervals(dirty_range_intervals)
   , _removable_tombstone_ranges(removable_tombstone_ranges)
-  , _expected_compaction_epoch(expected_compaction_epoch)
+  , _current_epoch(expected_compaction_epoch)
   , _start_offset(start_offset)
   , _probe(probe)
   , _notifier(notifier) {}
@@ -125,8 +129,6 @@ compaction_sink::initialize(compaction::sliding_window_reducer::source& src) {
         co_return false;
     }
 
-    co_await init_metadata_builder();
-
     auto& new_cleaned_ranges = ct_src._new_cleaned_ranges;
     new_cleaned_ranges.shrink_to_fit();
     _new_cleaned_ranges = std::move(new_cleaned_ranges);
@@ -140,136 +142,179 @@ compaction_sink::initialize(compaction::sliding_window_reducer::source& src) {
     co_return true;
 }
 
-ss::future<ss::stop_iteration>
-compaction_sink::operator()(model::record_batch b) {
-    auto next_offset = model::offset_cast(b.base_offset());
-    auto prev_offset = kafka::prev_offset(next_offset);
-
-    if (
-      _inflight_object
-      && _inflight_object->builder->file_size() >= _max_object_size()) {
-        co_await flush(prev_offset);
-    }
-
-    if (!_inflight_object) {
-        co_await initialize_builder(next_offset);
-    }
-
-    co_await _inflight_object->builder->add_batch(std::move(b));
-
-    co_return ss::stop_iteration::no;
-}
-
 ss::future<std::expected<void, metastore::errc>>
-compaction_sink::do_compact_objects(metastore::compaction_map_t compact_map) {
+compaction_sink::do_compact_objects(
+  const metastore::object_metadata_builder& builder,
+  metastore::compaction_map_t compact_map) {
     co_return co_await l1::retry_metastore_op_with_default_rtc(
-      [this, &compact_map]() {
-          return _metastore->compact_objects(*_metadata_builder, compact_map);
+      [this, &builder, &compact_map]() {
+          return _metastore->compact_objects(builder, compact_map);
       },
       _as);
 }
 
-ss::future<> compaction_sink::compact_objects_without_update() {
-    auto compaction_update = metastore::compaction_update{
-      .new_cleaned_ranges = {},
-      .removed_tombstones_ranges = {},
-      .cleaned_at = model::timestamp::missing(),
-      .expected_compaction_epoch = _expected_compaction_epoch};
-
-    metastore::compaction_map_t compact_map;
-    compact_map.emplace(_tp, std::move(compaction_update));
-    auto replace_res = co_await do_compact_objects(std::move(compact_map));
-    if (replace_res.has_value()) {
-        _probe.add_compaction_objects_committed(_output_objects);
-        _probe.add_compaction_bytes_committed(_output_bytes);
-        vlog(
-          _ctxlog.info, "Finalized job without a compaction metadata update");
-    } else {
-        _probe.add_compaction_objects_rejected(_output_objects);
-        _probe.add_compaction_bytes_rejected(_output_bytes);
-        vlog(_ctxlog.warn, "Could not finalize job: {}.", replace_res.error());
-    }
-}
-
-ss::future<> compaction_sink::compact_objects_with_update(
+metastore::compaction_update compaction_sink::make_compaction_update(
   chunked_vector<metastore::compaction_update::cleaned_range>
     new_cleaned_ranges,
-  offset_interval_set removed_tombstone_ranges) {
-    auto compaction_update = metastore::compaction_update{
+  offset_interval_set removed_tombstone_ranges,
+  metastore::compaction_epoch expected_epoch) {
+    auto cleaned_at = new_cleaned_ranges.empty()
+                          && removed_tombstone_ranges.empty()
+                        ? model::timestamp::missing()
+                        : model::timestamp::now();
+    return metastore::compaction_update{
       .new_cleaned_ranges = std::move(new_cleaned_ranges),
       .removed_tombstones_ranges = std::move(removed_tombstone_ranges),
-      .cleaned_at = model::timestamp::now(),
-      .expected_compaction_epoch = _expected_compaction_epoch};
+      .cleaned_at = cleaned_at,
+      .expected_compaction_epoch = expected_epoch};
+}
 
-    auto compaction_update_str = fmt::format("{}", compaction_update);
+metastore::compaction_map_t compaction_sink::make_compaction_map(
+  metastore::compaction_update update) const {
     metastore::compaction_map_t compact_map;
-    compact_map.emplace(_tp, std::move(compaction_update));
-    auto commit_res = co_await do_compact_objects(std::move(compact_map));
+    compact_map.emplace(_tp, std::move(update));
+    return compact_map;
+}
 
-    if (commit_res.has_value()) {
-        _probe.add_compaction_objects_committed(_output_objects);
-        _probe.add_compaction_bytes_committed(_output_bytes);
-        vlog(
-          _ctxlog.info,
-          "Finalized job with compaction metadata update: {}",
-          compaction_update_str);
-    } else {
+ss::future<bool>
+compaction_sink::advance_local_threshold_floor(kafka::offset new_floor) {
+    // _notifier is null only in tests, where the notification is a no-op.
+    if (_notifier == nullptr) {
+        co_return true;
+    }
+    vlog(
+      _ctxlog.debug,
+      "Compaction advancing min_allowed_local_threshold to {}",
+      new_floor);
+    auto res = co_await _notifier->set_min_allowed_local_threshold(
+      _tp, new_floor);
+    if (!res.has_value()) {
         vlog(
           _ctxlog.warn,
-          "Could not finalize job with compaction metadata update {}: {}. "
-          "Retrying object update without metadata.",
-          compaction_update_str,
-          commit_res.error());
-        co_return co_await compact_objects_without_update();
+          "Failed to advance min_allowed_local_threshold to {} ({})",
+          new_floor,
+          res.error());
+        co_return false;
     }
+    co_return true;
+}
+
+ss::future<> compaction_sink::commit_objects(
+  std::unique_ptr<metastore::object_metadata_builder> builder) {
+    // Data is about to be durably replaced. Advance the partition's
+    // min_allowed_local_threshold floor before the first partial commit so
+    // that local reads cannot serve records this job removes, mirroring the
+    // pre-commit floor advance of the single-request path. The floor is
+    // advanced once, to the top of the job's candidate cleaned ranges (the
+    // final cleaned ranges are a subset).
+    if (!_floor_advanced) {
+        if (
+          auto new_floor = get_max_cleaned_offset(_new_cleaned_ranges);
+          new_floor.has_value()) {
+            if (!co_await advance_local_threshold_floor(*new_floor)) {
+                throw std::runtime_error(
+                  fmt::format(
+                    "[{}] aborting compaction: could not advance "
+                    "min_allowed_local_threshold",
+                    _tp));
+            }
+        }
+        _floor_advanced = true;
+    }
+
+    // Partial compaction commit: the finished object(s) with an empty
+    // compaction update, which validates and bumps the compaction epoch.
+    auto commit_res = co_await do_compact_objects(
+      *builder,
+      make_compaction_map(make_compaction_update({}, {}, _current_epoch)));
+    if (!commit_res.has_value()) {
+        _probe.add_compaction_objects_rejected(_pending_objects);
+        _probe.add_compaction_bytes_rejected(_pending_bytes);
+        auto err = commit_res.error();
+        throw std::runtime_error(
+          fmt::format(
+            "[{}] aborting compaction: partial commit at epoch {} failed: "
+            "{}",
+            _tp,
+            _current_epoch,
+            err));
+    }
+    _probe.add_compaction_objects_committed(_pending_objects);
+    _probe.add_compaction_bytes_committed(_pending_bytes);
+    _committed_objects += _pending_objects;
+    ++_partial_commits;
+    _current_epoch = metastore::compaction_epoch{_current_epoch() + 1};
+    vlog(
+      _ctxlog.debug,
+      "Partial compaction commit of {} object(s) landed; compaction epoch "
+      "advanced to {}",
+      _pending_objects,
+      _current_epoch);
 }
 
 ss::future<> compaction_sink::finalize(bool success) {
-    auto should_commit = co_await finalize_inflight(success);
-    if (!should_commit) {
+    co_await finalize_inflight(success);
+
+    if (!success) {
+        vlog(
+          _ctxlog.warn,
+          "Skipping compaction metadata commit; {}",
+          _partial_commits == 0
+            ? fmt::format("no partial commits had landed")
+            : fmt::format(
+                "{} object(s) already committed in {} partial commit(s)",
+                _committed_objects,
+                _partial_commits));
+        co_return;
+    }
+    auto removed_tombstone_ranges = get_removed_tombstone_ranges(
+      _removable_tombstone_ranges, _processed_extents);
+    auto new_cleaned_ranges = get_new_cleaned_ranges(
+      _new_cleaned_ranges, _processed_extents, _start_offset);
+    if (new_cleaned_ranges.empty() && removed_tombstone_ranges.empty()) {
+        vlog(
+          _ctxlog.info,
+          "Finalized job without a compaction metadata update; {} extent(s) "
+          "compacted into {} object(s) in {} partial commit(s)",
+          _processed_extent_count,
+          _committed_objects,
+          _partial_commits);
         co_return;
     }
 
-    if (_any_object_failed) {
-        co_await compact_objects_without_update();
+    // The min_allowed_local_threshold floor was already advanced before the
+    // first partial commit. Record the job's compaction metadata against
+    // the epoch its own partial commits advanced.
+    auto compaction_update = make_compaction_update(
+      std::move(new_cleaned_ranges),
+      std::move(removed_tombstone_ranges),
+      _current_epoch);
+    auto compaction_update_str = fmt::format("{}", compaction_update);
+    auto compact_map = make_compaction_map(std::move(compaction_update));
+    auto commit_res = co_await l1::retry_metastore_op_with_default_rtc(
+      [this, &compact_map]() {
+          return _metastore->commit_compaction_metadata(compact_map);
+      },
+      _as);
+    if (commit_res.has_value()) {
+        vlog(
+          _ctxlog.info,
+          "Finalized job with compaction metadata update: {} ({} extent(s) "
+          "compacted into {} object(s) in {} partial commit(s))",
+          compaction_update_str,
+          _processed_extent_count,
+          _committed_objects,
+          _partial_commits);
     } else {
-        auto removed_tombstone_ranges = get_removed_tombstone_ranges(
-          _removable_tombstone_ranges, _processed_extents);
-        auto new_cleaned_ranges = get_new_cleaned_ranges(
-          _new_cleaned_ranges, _processed_extents, _start_offset);
-
-        // Advance the partition's min_allowed_local_threshold floor before
-        // committing the compaction. Compaction removes tombstones within the
-        // cleaned ranges, so local reads below the new floor could otherwise
-        // serve records that L1 has just deleted. If the floor cannot be
-        // advanced we skip the commit and retry the whole job later. _notifier
-        // is null only in tests, where the notification is a no-op.
-        if (
-          auto new_floor = get_max_cleaned_offset(new_cleaned_ranges);
-          new_floor.has_value() && _notifier != nullptr) {
-            vlog(
-              _ctxlog.debug,
-              "[{}] compaction advancing min_allowed_local_threshold to {}",
-              _tp,
-              *new_floor);
-            auto res = co_await _notifier->set_min_allowed_local_threshold(
-              _tp, *new_floor);
-            if (!res.has_value()) {
-                _probe.add_compaction_objects_rejected(_output_objects);
-                _probe.add_compaction_bytes_rejected(_output_bytes);
-                vlog(
-                  _ctxlog.warn,
-                  "[{}] skipping compaction commit: failed to advance "
-                  "min_allowed_local_threshold to {} ({})",
-                  _tp,
-                  *new_floor,
-                  res.error());
-                co_return;
-            }
-        }
-
-        co_await compact_objects_with_update(
-          std::move(new_cleaned_ranges), std::move(removed_tombstone_ranges));
+        vlog(
+          _ctxlog.warn,
+          "Could not commit compaction metadata update {}: {}; {} extent(s) "
+          "compacted into {} object(s) in {} partial commit(s)",
+          compaction_update_str,
+          commit_res.error(),
+          _processed_extent_count,
+          _committed_objects,
+          _partial_commits);
     }
 }
 

--- a/src/v/cloud_topics/level_one/maintenance/compaction/compaction_sink.h
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/compaction_sink.h
@@ -35,6 +35,7 @@ public:
       l1::metastore*,
       ss::abort_source&,
       config::binding<size_t>,
+      config::binding<size_t>,
       size_t,
       compaction_worker_probe&,
       prefix_logger&,
@@ -44,26 +45,41 @@ public:
     ss::future<bool>
     initialize(compaction::sliding_window_reducer::source&) final;
 
-    ss::future<ss::stop_iteration> operator()(model::record_batch) final;
-
     ss::future<> finalize(bool success) final;
+
+protected:
+    // Commits the builder's finished objects as a partial compaction
+    // commit: a compact_objects() carrying the objects and an empty
+    // compaction update, which validates and bumps the compaction epoch.
+    // Bumping the epoch on every batch keeps the job's progress durable and
+    // fences stale rewriters (straggler compaction jobs, leveling jobs with
+    // old read snapshots) for the remainder of the run. Throws on failure,
+    // aborting the run.
+    ss::future<>
+      commit_objects(std::unique_ptr<metastore::object_metadata_builder>) final;
 
 private:
     // Makes a `compact_objects()` request to the `metastore`, using the
     // provided (potentially empty) `compaction_map_t` as the metastore
     // compaction update.
-    ss::future<std::expected<void, metastore::errc>>
-      do_compact_objects(metastore::compaction_map_t);
+    ss::future<std::expected<void, metastore::errc>> do_compact_objects(
+      const metastore::object_metadata_builder&, metastore::compaction_map_t);
 
-    // Finalizes the compaction via `metastore->compact_objects()` without a
-    // compaction metadata update.
-    ss::future<> compact_objects_without_update();
+    // Advances the partition's min_allowed_local_threshold floor via the
+    // notifier. Returns false if the floor could not be advanced, in which
+    // case no compaction data or metadata may be committed.
+    ss::future<bool> advance_local_threshold_floor(kafka::offset new_floor);
 
-    // Finalizes the compaction via `metastore->compact_objects()` with a
-    // compaction metadata update.
-    ss::future<> compact_objects_with_update(
+    // Builds a compaction update carrying the given ranges at the given
+    // expected epoch.
+    static metastore::compaction_update make_compaction_update(
       chunked_vector<metastore::compaction_update::cleaned_range>,
-      offset_interval_set);
+      offset_interval_set,
+      metastore::compaction_epoch);
+
+    // Wraps the given update into a single-partition compaction map.
+    metastore::compaction_map_t
+      make_compaction_map(metastore::compaction_update) const;
 
 private:
     // Offset ranges for the contained `topic_id_partition` obtained from the
@@ -72,8 +88,21 @@ private:
     const interval_vec& _dirty_range_intervals;
     const offset_interval_set& _removable_tombstone_ranges;
 
-    // The expected compaction epoch for the log.
-    const metastore::compaction_epoch _expected_compaction_epoch;
+    // The compaction epoch the job's own partial commits have advanced the
+    // partition to. Each successful partial commit bumps this by one; the
+    // final metadata-only commit validates against (and bumps) it.
+    metastore::compaction_epoch _current_epoch;
+
+    // Number of partial commits this job has landed, and the output
+    // objects they committed. Reported against the processed extent count
+    // at finalize to show the job's extent-count reduction.
+    uint64_t _partial_commits{0};
+    uint64_t _committed_objects{0};
+
+    // Whether the min_allowed_local_threshold floor was advanced for this
+    // job (advanced once, before the first partial commit removes any
+    // data).
+    bool _floor_advanced{false};
 
     // The start offset of the log.
     kafka::offset _start_offset;

--- a/src/v/cloud_topics/level_one/maintenance/compaction/tests/reducer_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/tests/reducer_test.cc
@@ -100,7 +100,9 @@ ss::future<> do_compact(
   l1::metastore* metastore,
   l1::io* io,
   std::chrono::milliseconds min_compaction_lag_ms = 0ms,
-  kafka::offset max_compactible_offset = kafka::offset::max()) {
+  kafka::offset max_compactible_offset = kafka::offset::max(),
+  size_t max_object_size = 128_MiB,
+  size_t commit_interval_bytes = 512_MiB) {
     ss::abort_source as;
     auto state = l1::compaction_job_state::running;
     auto map = compaction::simple_key_offset_map();
@@ -131,7 +133,8 @@ ss::future<> do_compact(
       io,
       metastore,
       as,
-      config::mock_binding<size_t>(128_MiB),
+      config::mock_binding<size_t>(max_object_size),
+      config::mock_binding<size_t>(commit_interval_bytes),
       16_MiB,
       probe,
       logger);
@@ -152,7 +155,9 @@ ss::future<> do_compact_with_throwing_sink(
   l1::throwing_compaction_sink::predicate_t should_roll,
   l1::throwing_compaction_sink::predicate_t should_throw,
   std::chrono::milliseconds min_compaction_lag_ms = 0ms,
-  kafka::offset max_compactible_offset = kafka::offset::max()) {
+  kafka::offset max_compactible_offset = kafka::offset::max(),
+  size_t max_object_size = 128_MiB,
+  size_t commit_interval_bytes = 512_MiB) {
     ss::abort_source as;
     auto state = l1::compaction_job_state::running;
     auto map = compaction::simple_key_offset_map();
@@ -174,8 +179,9 @@ ss::future<> do_compact_with_throwing_sink(
       probe,
       nullptr,
       logger);
-    // Use a very large max_object_size to disable size-based rolls; the
-    // throwing_compaction_sink's should_roll predicate controls rolling.
+    // By default max_object_size is very large to disable size-based rolls,
+    // leaving rolling to the throwing_compaction_sink's should_roll
+    // predicate.
     auto inner_sink = std::make_unique<l1::compaction_sink>(
       tidp,
       dirty_range_intervals,
@@ -185,7 +191,8 @@ ss::future<> do_compact_with_throwing_sink(
       io,
       metastore,
       as,
-      config::mock_binding<size_t>(128_MiB),
+      config::mock_binding<size_t>(max_object_size),
+      config::mock_binding<size_t>(commit_interval_bytes),
       16_MiB,
       probe,
       logger);
@@ -1028,6 +1035,859 @@ TEST_F(ReducerTestFixture, MaxCompactibleOffsetReducer) {
     ASSERT_GT(compaction_info->dirty_ratio, 0.0);
     ASSERT_TRUE(compaction_info->offsets_response.dirty_ranges.covers(
       max_compactible_offset, last_offset));
+}
+
+// The sink commits accumulated output objects as partial compaction commits
+// at source extent boundaries, each bumping the compaction epoch, then
+// records the job's compaction metadata in a final metadata-only commit that
+// bumps it once more. A tiny max object size makes every source extent's
+// output exceed the threshold, so the job issues one partial commit per
+// source extent.
+TEST_F(ReducerTestFixture, IncrementalCommitsAdvanceEpochPerPartialCommit) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+    constexpr int num_extents = 3;
+    constexpr int batches_per_extent = 10;
+    constexpr int records_per_batch = 5;
+    constexpr int total_records = num_extents * batches_per_extent
+                                  * records_per_batch;
+
+    // Split one contiguous batch stream across several source extents; all
+    // keys are distinct so nothing is deduplicated away and every extent
+    // produces enough output to reach the commit interval.
+    latest_kv_map_t latest_kv_map;
+    auto batches = generate_batches(
+      num_extents * batches_per_extent,
+      /*cardinality=*/total_records,
+      records_per_batch,
+      /*starting_value=*/0,
+      /*produce_tombstones=*/false,
+      &latest_kv_map);
+    for (int i = 0; i < num_extents; ++i) {
+        chunked_circular_buffer<model::record_batch> extent_batches;
+        for (int j = 0; j < batches_per_extent; ++j) {
+            extent_batches.push_back(std::move(batches.front()));
+            batches.pop_front();
+        }
+        std::vector<tidp_batches_t> tidp_batches;
+        tidp_batches.emplace_back(tidp, std::move(extent_batches));
+        make_l1_objects(std::move(tidp_batches)).get();
+    }
+
+    auto info_spec = l1::metastore::compaction_info_spec{
+      .tidp = tidp,
+      .tombstone_removal_upper_bound_ts = model::timestamp::max()};
+    auto compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    auto initial_epoch = compaction_info->compaction_epoch;
+
+    do_compact(
+      tidp,
+      ntp,
+      std::move(compaction_info->offsets_response),
+      compaction_info->compaction_epoch,
+      compaction_info->start_offset,
+      &_metastore,
+      &_io,
+      0ms,
+      kafka::offset::max(),
+      /*max_object_size=*/512,
+      /*commit_interval_bytes=*/512)
+      .get();
+
+    // One partial commit per source extent, plus the final metadata-only
+    // commit.
+    compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    EXPECT_EQ(
+      compaction_info->compaction_epoch(), initial_epoch() + num_extents + 1);
+    EXPECT_TRUE(compaction_info->offsets_response.dirty_ranges.empty());
+
+    // Nothing was lost: every distinct key survives.
+    verify_compacted_log(
+      ntp,
+      tidp,
+      latest_kv_map,
+      total_records,
+      num_extents * batches_per_extent);
+}
+
+// Commit cadence is governed by the commit interval, not the object size:
+// with an interval larger than the job's entire output, no boundary commit
+// fires even though every boundary has multiple finished objects pending,
+// and the whole job commits as one batch at finalize (plus the final
+// metadata-only commit).
+TEST_F(ReducerTestFixture, CommitIntervalGovernsCommitCadence) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+    constexpr int num_extents = 3;
+    constexpr int batches_per_extent = 8;
+    constexpr int records_per_batch = 5;
+    constexpr int total_records = num_extents * batches_per_extent
+                                  * records_per_batch;
+
+    latest_kv_map_t latest_kv_map;
+    auto batches = generate_batches(
+      num_extents * batches_per_extent,
+      /*cardinality=*/total_records,
+      records_per_batch,
+      /*starting_value=*/0,
+      /*produce_tombstones=*/false,
+      &latest_kv_map);
+    for (int i = 0; i < num_extents; ++i) {
+        chunked_circular_buffer<model::record_batch> extent_batches;
+        for (int j = 0; j < batches_per_extent; ++j) {
+            extent_batches.push_back(std::move(batches.front()));
+            batches.pop_front();
+        }
+        std::vector<tidp_batches_t> tidp_batches;
+        tidp_batches.emplace_back(tidp, std::move(extent_batches));
+        make_l1_objects(std::move(tidp_batches)).get();
+    }
+
+    auto info_spec = l1::metastore::compaction_info_spec{
+      .tidp = tidp,
+      .tombstone_removal_upper_bound_ts = model::timestamp::max()};
+    auto compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    auto initial_epoch = compaction_info->compaction_epoch;
+
+    // Objects roll at 512 bytes, so every boundary has finished objects
+    // pending — but the commit interval is far larger than the job's whole
+    // output, so no boundary commit fires. The job's output lands in one
+    // commit from the finalize path, followed by the metadata-only commit:
+    // exactly two epoch bumps.
+    do_compact(
+      tidp,
+      ntp,
+      std::move(compaction_info->offsets_response),
+      initial_epoch,
+      compaction_info->start_offset,
+      &_metastore,
+      &_io,
+      0ms,
+      kafka::offset::max(),
+      /*max_object_size=*/512,
+      /*commit_interval_bytes=*/1_MiB)
+      .get();
+
+    compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    EXPECT_EQ(compaction_info->compaction_epoch(), initial_epoch() + 2);
+    EXPECT_TRUE(compaction_info->offsets_response.dirty_ranges.empty());
+
+    verify_compacted_log(
+      ntp,
+      tidp,
+      latest_kv_map,
+      total_records,
+      num_extents * batches_per_extent);
+}
+
+// After a partial commit cuts at an extent boundary, the next extent's
+// leading batches may be deduplicated away entirely (all their records
+// superseded later in the log), so the first batch reaching the sink sits
+// past the extent base. The next object must still be anchored at the
+// extent base — a mid-extent leading edge would fail the metastore's
+// span-exact validation and reject every subsequent partial commit.
+TEST_F(ReducerTestFixture, PostCommitObjectAnchorsAtExtentBase) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+    constexpr int records_per_batch = 5;
+    constexpr int batches_per_extent = 4;
+    constexpr int records_per_extent = records_per_batch * batches_per_extent;
+
+    // Three extents. Extent 2's first batch reuses keys that extent 3's
+    // first batch overwrites, so it is fully deduplicated away; every
+    // other batch has unique keys and survives.
+    latest_kv_map_t latest_kv_map;
+    auto make_extent_batches = [&](
+                                 int extent_idx, bool reused_first_batch_keys) {
+        chunked_circular_buffer<model::record_batch> batches;
+        for (int b = 0; b < batches_per_extent; ++b) {
+            auto base_offset = model::offset(
+              extent_idx * records_per_extent + b * records_per_batch);
+            // The reused key range lives at [1000, 1005); unique keys
+            // equal their record offsets.
+            auto kvs = reused_first_batch_keys && b == 0
+                         ? tests::kv_t::sequence(
+                             /*start=*/extent_idx * records_per_extent,
+                             records_per_batch,
+                             /*val_start=*/extent_idx * records_per_extent,
+                             /*cardinality=*/records_per_batch,
+                             /*produce_tombstones=*/false,
+                             /*base=*/1000)
+                         : tests::kv_t::sequence(
+                             /*start=*/base_offset(),
+                             records_per_batch,
+                             /*val_start=*/base_offset(),
+                             /*cardinality=*/10000);
+            for (const auto& kv : kvs) {
+                latest_kv_map.insert_or_assign(kv.key, kv.val);
+            }
+            batches.push_back(
+              tests::batch_from_kvs(
+                kvs,
+                base_offset,
+                model::timestamp::now(),
+                model::compression::none));
+        }
+        std::vector<tidp_batches_t> tidp_batches;
+        tidp_batches.emplace_back(tidp, std::move(batches));
+        make_l1_objects(std::move(tidp_batches)).get();
+    };
+    make_extent_batches(0, false);
+    make_extent_batches(1, true);
+    make_extent_batches(2, true);
+
+    auto info_spec = l1::metastore::compaction_info_spec{
+      .tidp = tidp,
+      .tombstone_removal_upper_bound_ts = model::timestamp::max()};
+    auto compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    auto initial_epoch = compaction_info->compaction_epoch;
+
+    // Per-boundary commits: extent 1's commit leaves the anchor, extent 2's
+    // first batch is dropped by the filter, and extent 2's commit must
+    // still span exactly from the extent base.
+    do_compact(
+      tidp,
+      ntp,
+      std::move(compaction_info->offsets_response),
+      initial_epoch,
+      compaction_info->start_offset,
+      &_metastore,
+      &_io,
+      0ms,
+      kafka::offset::max(),
+      /*max_object_size=*/512,
+      /*commit_interval_bytes=*/512)
+      .get();
+
+    // Two partial commits (extent 2's output alone stays under the commit
+    // interval, so extents 2 and 3 land together at extent 3's boundary —
+    // still spanning from extent 2's base) plus the metadata-only commit,
+    // and a fully clean log.
+    compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    EXPECT_EQ(compaction_info->compaction_epoch(), initial_epoch() + 3);
+    EXPECT_TRUE(compaction_info->offsets_response.dirty_ranges.empty());
+
+    // Extent 2's first batch is gone; everything else survives.
+    verify_compacted_log(
+      ntp,
+      tidp,
+      latest_kv_map,
+      /*expected_records=*/3 * records_per_extent - records_per_batch,
+      /*expected_batches=*/3 * batches_per_extent - 1);
+}
+
+// A boundary commit cuts coverage; the next object is anchored at the
+// boundary's successor when the next extent is prepared. If that extent is
+// fully deduplicated away (all its keys rewritten in a later extent) and a
+// live extent follows contiguously, the object must stay open across the
+// dead extent and swallow its span: the live extent's batches land in an
+// object based at the dead extent's base, so the next commit replaces both
+// extents exactly.
+TEST_F(ReducerTestFixture, DeadInteriorExtentIsSwallowedAfterCut) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+    constexpr int records_per_batch = 5;
+    constexpr int batches_per_extent = 4;
+    constexpr int records_per_extent = records_per_batch * batches_per_extent;
+    constexpr int num_extents = 3;
+
+    // Extent 0 [0,19]: unique keys, survives and triggers the boundary
+    // commit. Extent 1 [20,39]: keys 1000..1019 with old values. Extent 2
+    // [40,59]: the same keys with new values, so every record of extent 1
+    // is superseded while extent 2 survives in full.
+    latest_kv_map_t latest_kv_map;
+    for (int extent_idx = 0; extent_idx < num_extents; ++extent_idx) {
+        const bool reused_keys = extent_idx >= 1;
+        chunked_circular_buffer<model::record_batch> batches;
+        for (int b = 0; b < batches_per_extent; ++b) {
+            auto base_offset = model::offset(
+              extent_idx * records_per_extent + b * records_per_batch);
+            auto kvs = reused_keys ? tests::kv_t::sequence(
+                                       /*start=*/b * records_per_batch,
+                                       records_per_batch,
+                                       /*val_start=*/base_offset(),
+                                       /*cardinality=*/records_per_extent,
+                                       /*produce_tombstones=*/false,
+                                       /*base=*/1000)
+                                   : tests::kv_t::sequence(
+                                       /*start=*/base_offset(),
+                                       records_per_batch,
+                                       /*val_start=*/base_offset(),
+                                       /*cardinality=*/10000);
+            for (const auto& kv : kvs) {
+                latest_kv_map.insert_or_assign(kv.key, kv.val);
+            }
+            batches.push_back(
+              tests::batch_from_kvs(
+                kvs,
+                base_offset,
+                model::timestamp::now(),
+                model::compression::none));
+        }
+        std::vector<tidp_batches_t> tidp_batches;
+        tidp_batches.emplace_back(tidp, std::move(batches));
+        make_l1_objects(std::move(tidp_batches)).get();
+    }
+
+    auto info_spec = l1::metastore::compaction_info_spec{
+      .tidp = tidp,
+      .tombstone_removal_upper_bound_ts = model::timestamp::max()};
+    auto compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    auto initial_epoch = compaction_info->compaction_epoch;
+
+    do_compact(
+      tidp,
+      ntp,
+      std::move(compaction_info->offsets_response),
+      initial_epoch,
+      compaction_info->start_offset,
+      &_metastore,
+      &_io,
+      0ms,
+      kafka::offset::max(),
+      /*max_object_size=*/512,
+      /*commit_interval_bytes=*/512)
+      .get();
+
+    // Two data commits — extent 0's boundary cut, then the object spanning
+    // dead extent 1 plus live extent 2 — and the metadata-only commit. A
+    // mis-anchored object would fail span-exact validation and abort the
+    // run instead.
+    compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    EXPECT_EQ(compaction_info->compaction_epoch(), initial_epoch() + 3);
+    EXPECT_TRUE(compaction_info->offsets_response.dirty_ranges.empty());
+
+    // Extent 1's superseded records are gone; extents 0 and 2 survive.
+    verify_compacted_log(
+      ntp,
+      tidp,
+      latest_kv_map,
+      /*expected_records=*/2 * records_per_extent,
+      /*expected_batches=*/2 * batches_per_extent);
+}
+
+// A boundary commit cuts coverage — but the very next extent is skipped by
+// min_compaction_lag_ms (fresh timestamps), so the source jumps with
+// nothing processed since the cut. No object may claim anything between
+// the cut and the jump: the next object must re-anchor at the live
+// extent's base, and the skipped extent must stay dirty with no claims
+// over it.
+TEST_F(ReducerTestFixture, JumpAfterCutReanchorsAtLiveExtent) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+    constexpr int records_per_batch = 5;
+    constexpr int batches_per_extent = 4;
+    constexpr int records_per_extent = records_per_batch * batches_per_extent;
+    constexpr int num_extents = 3;
+    constexpr auto lag = std::chrono::hours(1);
+
+    // Extents 0 [0,19] and 2 [40,59] are older than the compaction lag;
+    // extent 1 [20,39] is fresh, so the deduplication pass jumps over it.
+    // All keys are unique so every streamed record survives.
+    const auto old_ts = model::timestamp(
+      model::timestamp::now()() - 2 * std::chrono::milliseconds(lag).count());
+    latest_kv_map_t latest_kv_map;
+    for (int extent_idx = 0; extent_idx < num_extents; ++extent_idx) {
+        const auto ts = extent_idx == 1 ? model::timestamp::now() : old_ts;
+        chunked_circular_buffer<model::record_batch> batches;
+        for (int b = 0; b < batches_per_extent; ++b) {
+            auto base_offset = model::offset(
+              extent_idx * records_per_extent + b * records_per_batch);
+            auto kvs = tests::kv_t::sequence(
+              /*start=*/base_offset(),
+              records_per_batch,
+              /*val_start=*/base_offset(),
+              /*cardinality=*/10000);
+            for (const auto& kv : kvs) {
+                latest_kv_map.insert_or_assign(kv.key, kv.val);
+            }
+            batches.push_back(
+              tests::batch_from_kvs(
+                kvs, base_offset, ts, model::compression::none));
+        }
+        std::vector<tidp_batches_t> tidp_batches;
+        tidp_batches.emplace_back(tidp, std::move(batches));
+        make_l1_objects(std::move(tidp_batches)).get();
+    }
+
+    auto info_spec = l1::metastore::compaction_info_spec{
+      .tidp = tidp,
+      .tombstone_removal_upper_bound_ts = model::timestamp::max()};
+    auto compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    auto initial_epoch = compaction_info->compaction_epoch;
+
+    do_compact(
+      tidp,
+      ntp,
+      std::move(compaction_info->offsets_response),
+      initial_epoch,
+      compaction_info->start_offset,
+      &_metastore,
+      &_io,
+      /*min_compaction_lag_ms=*/lag,
+      kafka::offset::max(),
+      /*max_object_size=*/512,
+      /*commit_interval_bytes=*/512)
+      .get();
+
+    // Two data commits — extent 0's boundary cut and extent 2's rewrite —
+    // plus the metadata-only commit; nothing contiguous follows either
+    // cut, so no object is started until the re-anchor at extent 2.
+    compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    EXPECT_EQ(compaction_info->compaction_epoch(), initial_epoch() + 3);
+
+    // Only the range below the skipped extent may be claimed clean; the
+    // skipped extent and everything above it stay dirty.
+    EXPECT_FALSE(compaction_info->offsets_response.dirty_ranges.covers(
+      kafka::offset{0}, kafka::offset{records_per_extent - 1}));
+    EXPECT_TRUE(compaction_info->offsets_response.dirty_ranges.covers(
+      kafka::offset{records_per_extent},
+      kafka::offset{3 * records_per_extent - 1}));
+
+    // Nothing was lost, including the skipped (lag-protected) extent.
+    verify_compacted_log(
+      ntp,
+      tidp,
+      latest_kv_map,
+      /*expected_records=*/num_extents * records_per_extent,
+      /*expected_batches=*/num_extents * batches_per_extent);
+
+    // Once the lag expires, a second pass compacts the skipped extent and
+    // the claims converge over the whole log.
+    do_compact(
+      tidp,
+      ntp,
+      std::move(compaction_info->offsets_response),
+      compaction_info->compaction_epoch,
+      compaction_info->start_offset,
+      &_metastore,
+      &_io,
+      /*min_compaction_lag_ms=*/0ms,
+      kafka::offset::max(),
+      /*max_object_size=*/512,
+      /*commit_interval_bytes=*/512)
+      .get();
+
+    compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    EXPECT_TRUE(compaction_info->offsets_response.dirty_ranges.empty());
+    verify_compacted_log(
+      ntp,
+      tidp,
+      latest_kv_map,
+      /*expected_records=*/num_extents * records_per_extent,
+      /*expected_batches=*/num_extents * batches_per_extent);
+}
+
+// The non-contiguous variant of the dead-tail case below: a boundary
+// commit cuts coverage at extent 0 and extent 1 is fully deduplicated
+// away (all its keys rewritten in extent 3), and then the source jumps
+// over extent 2 — skipped by min_compaction_lag_ms, its timestamps being
+// newer than the extents around it — so prepare_iteration() re-anchors at
+// extent 3 and nothing would replace extent 1, even though the final
+// metadata claims its range clean. The sink must claim the dead span with
+// an (empty) object before the jump.
+TEST_F(ReducerTestFixture, DeadTailExtentIsReplacedBeforeJump) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+    constexpr int records_per_batch = 5;
+    constexpr int batches_per_extent = 4;
+    constexpr int records_per_extent = records_per_batch * batches_per_extent;
+    constexpr int num_extents = 4;
+    constexpr auto lag = std::chrono::hours(1);
+
+    // Extents 0, 1, 3 are older than the compaction lag; extent 2 is
+    // fresh, so the deduplication pass skips over it. Extent 1's keys are
+    // all rewritten in extent 3, making every one of its records
+    // superseded.
+    const auto old_ts = model::timestamp(
+      model::timestamp::now()() - 2 * std::chrono::milliseconds(lag).count());
+    latest_kv_map_t latest_kv_map;
+    for (int extent_idx = 0; extent_idx < num_extents; ++extent_idx) {
+        const bool reused_keys = extent_idx == 1 || extent_idx == 3;
+        const auto ts = extent_idx == 2 ? model::timestamp::now() : old_ts;
+        chunked_circular_buffer<model::record_batch> batches;
+        for (int b = 0; b < batches_per_extent; ++b) {
+            auto base_offset = model::offset(
+              extent_idx * records_per_extent + b * records_per_batch);
+            auto kvs = reused_keys ? tests::kv_t::sequence(
+                                       /*start=*/b * records_per_batch,
+                                       records_per_batch,
+                                       /*val_start=*/base_offset(),
+                                       /*cardinality=*/records_per_extent,
+                                       /*produce_tombstones=*/false,
+                                       /*base=*/1000)
+                                   : tests::kv_t::sequence(
+                                       /*start=*/base_offset(),
+                                       records_per_batch,
+                                       /*val_start=*/base_offset(),
+                                       /*cardinality=*/10000);
+            for (const auto& kv : kvs) {
+                latest_kv_map.insert_or_assign(kv.key, kv.val);
+            }
+            batches.push_back(
+              tests::batch_from_kvs(
+                kvs, base_offset, ts, model::compression::none));
+        }
+        std::vector<tidp_batches_t> tidp_batches;
+        tidp_batches.emplace_back(tidp, std::move(batches));
+        make_l1_objects(std::move(tidp_batches)).get();
+    }
+
+    auto info_spec = l1::metastore::compaction_info_spec{
+      .tidp = tidp,
+      .tombstone_removal_upper_bound_ts = model::timestamp::max()};
+    auto compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+
+    do_compact(
+      tidp,
+      ntp,
+      std::move(compaction_info->offsets_response),
+      compaction_info->compaction_epoch,
+      compaction_info->start_offset,
+      &_metastore,
+      &_io,
+      /*min_compaction_lag_ms=*/lag,
+      kafka::offset::max(),
+      /*max_object_size=*/512,
+      /*commit_interval_bytes=*/512)
+      .get();
+
+    // Extent 1's superseded records must actually be gone — not merely
+    // claimed clean while the old extent still serves them. Extent 2 is
+    // untouched (too fresh to compact).
+    verify_compacted_log(
+      ntp,
+      tidp,
+      latest_kv_map,
+      /*expected_records=*/(num_extents - 1) * records_per_extent,
+      /*expected_batches=*/(num_extents - 1) * batches_per_extent);
+
+    // The skipped extent held back every claim at or above it: only the
+    // range below it was marked clean, and everything from the skipped
+    // extent up stays dirty — including extent 3, which was rewritten but
+    // may not be claimed across the gap.
+    compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    EXPECT_FALSE(compaction_info->offsets_response.dirty_ranges.covers(
+      kafka::offset{0}, kafka::offset{2 * records_per_extent - 1}));
+    EXPECT_TRUE(compaction_info->offsets_response.dirty_ranges.covers(
+      kafka::offset{2 * records_per_extent},
+      kafka::offset{4 * records_per_extent - 1}));
+
+    // Once the lag expires, a second pass compacts the skipped extent and
+    // the claims converge: the whole log is clean and the data unchanged.
+    do_compact(
+      tidp,
+      ntp,
+      std::move(compaction_info->offsets_response),
+      compaction_info->compaction_epoch,
+      compaction_info->start_offset,
+      &_metastore,
+      &_io,
+      /*min_compaction_lag_ms=*/0ms,
+      kafka::offset::max(),
+      /*max_object_size=*/512,
+      /*commit_interval_bytes=*/512)
+      .get();
+
+    compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    EXPECT_TRUE(compaction_info->offsets_response.dirty_ranges.empty());
+    verify_compacted_log(
+      ntp,
+      tidp,
+      latest_kv_map,
+      /*expected_records=*/(num_extents - 1) * records_per_extent,
+      /*expected_batches=*/(num_extents - 1) * batches_per_extent);
+}
+
+// A boundary commit cuts coverage at an extent boundary and leaves the
+// anchor for the next object. If every extent after that boundary is fully
+// deduplicated away — here, a trailing extent of expired tombstones — the
+// anchor is never consumed and nothing replaces those extents. Yet
+// finish_iteration() recorded them as processed, so the final metadata
+// claims their range clean and their tombstones removed while the old
+// extent still physically serves them, and the range is never compacted
+// again. The sink must claim the dead span with an (empty) object before
+// coverage ends.
+TEST_F(ReducerTestFixture, DeadTailExtentIsReplacedAtJobEnd) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+    constexpr int records_per_batch = 5;
+    constexpr int batches_per_extent = 4;
+    constexpr int records_per_extent = records_per_batch * batches_per_extent;
+    constexpr int num_extents = 4;
+
+    // Extents 0-2: unique live keys. Extent 3 [60,79]: only tombstones.
+    latest_kv_map_t latest_kv_map;
+    for (int extent_idx = 0; extent_idx < num_extents; ++extent_idx) {
+        const bool tombstones = extent_idx == num_extents - 1;
+        chunked_circular_buffer<model::record_batch> batches;
+        for (int b = 0; b < batches_per_extent; ++b) {
+            auto base_offset = model::offset(
+              extent_idx * records_per_extent + b * records_per_batch);
+            auto kvs = tests::kv_t::sequence(
+              /*start=*/base_offset(),
+              records_per_batch,
+              /*val_start=*/base_offset(),
+              /*cardinality=*/10000,
+              tombstones);
+            for (const auto& kv : kvs) {
+                latest_kv_map.insert_or_assign(kv.key, kv.val);
+            }
+            batches.push_back(
+              tests::batch_from_kvs(
+                kvs,
+                base_offset,
+                model::timestamp::now(),
+                model::compression::none));
+        }
+        std::vector<tidp_batches_t> tidp_batches;
+        tidp_batches.emplace_back(tidp, std::move(batches));
+        make_l1_objects(std::move(tidp_batches)).get();
+    }
+
+    auto info_spec = l1::metastore::compaction_info_spec{
+      .tidp = tidp,
+      .tombstone_removal_upper_bound_ts = model::timestamp::max()};
+    auto compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+
+    // Record extent 3's range as cleaned-with-tombstones so that, with
+    // tombstone_removal_upper_bound_ts=max, the job sees its tombstones as
+    // removable and drops every one of its records.
+    chunked_vector<l1::metastore::compaction_update::cleaned_range> cleaned;
+    cleaned.push_back(
+      l1::metastore::compaction_update::cleaned_range{
+        .base_offset = kafka::offset{3 * records_per_extent},
+        .last_offset = kafka::offset{4 * records_per_extent - 1},
+        .has_tombstones = true});
+    l1::metastore::compaction_map_t seed;
+    seed.emplace(
+      tidp,
+      l1::metastore::compaction_update{
+        .new_cleaned_ranges = std::move(cleaned),
+        .cleaned_at = model::timestamp::now(),
+        .expected_compaction_epoch = compaction_info->compaction_epoch});
+    ASSERT_TRUE(_metastore.commit_compaction_metadata(seed).get());
+
+    compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    ASSERT_TRUE(
+      compaction_info->offsets_response.removable_tombstone_ranges.covers(
+        kafka::offset{3 * records_per_extent},
+        kafka::offset{4 * records_per_extent - 1}));
+
+    // Every live extent's output crosses the commit interval at its
+    // boundary, so extent 2's boundary commit leaves the anchor at extent
+    // 3's base; extent 3 then contributes nothing and the job ends.
+    do_compact(
+      tidp,
+      ntp,
+      std::move(compaction_info->offsets_response),
+      compaction_info->compaction_epoch,
+      compaction_info->start_offset,
+      &_metastore,
+      &_io,
+      0ms,
+      kafka::offset::max(),
+      /*max_object_size=*/512,
+      /*commit_interval_bytes=*/512)
+      .get();
+
+    // The log is fully clean: nothing dirty, no removable tombstones left
+    // (the dead range's cleaned-with-tombstones entry was erased), and the
+    // empty object's extent is a first-class replacement in the state.
+    compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    EXPECT_TRUE(compaction_info->offsets_response.dirty_ranges.empty());
+    EXPECT_TRUE(
+      compaction_info->offsets_response.removable_tombstone_ranges.empty());
+
+    // Extent 3's expired tombstones must actually be gone — not merely
+    // claimed removed while the old extent still serves them.
+    verify_compacted_log(
+      ntp,
+      tidp,
+      latest_kv_map,
+      /*expected_records=*/(num_extents - 1) * records_per_extent,
+      /*expected_batches=*/(num_extents - 1) * batches_per_extent);
+}
+
+// A partial commit rejected by the metastore (stale compaction epoch, e.g.
+// a competing job committed after this job read its snapshot) aborts the
+// run: no extents are replaced and no compaction metadata is recorded, so
+// the log stays fully dirty for the retry.
+TEST_F(ReducerTestFixture, StaleEpochAbortsWithoutMetadata) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+    constexpr int num_extents = 3;
+    constexpr int batches_per_extent = 10;
+    constexpr int records_per_batch = 5;
+    constexpr int total_records = num_extents * batches_per_extent
+                                  * records_per_batch;
+
+    latest_kv_map_t latest_kv_map;
+    auto batches = generate_batches(
+      num_extents * batches_per_extent,
+      /*cardinality=*/total_records,
+      records_per_batch,
+      /*starting_value=*/0,
+      /*produce_tombstones=*/false,
+      &latest_kv_map);
+    for (int i = 0; i < num_extents; ++i) {
+        chunked_circular_buffer<model::record_batch> extent_batches;
+        for (int j = 0; j < batches_per_extent; ++j) {
+            extent_batches.push_back(std::move(batches.front()));
+            batches.pop_front();
+        }
+        std::vector<tidp_batches_t> tidp_batches;
+        tidp_batches.emplace_back(tidp, std::move(extent_batches));
+        make_l1_objects(std::move(tidp_batches)).get();
+    }
+
+    auto info_spec = l1::metastore::compaction_info_spec{
+      .tidp = tidp,
+      .tombstone_removal_upper_bound_ts = model::timestamp::max()};
+    auto compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    auto initial_epoch = compaction_info->compaction_epoch;
+
+    // A competing job bumps the epoch after this job read its snapshot.
+    l1::metastore::compaction_map_t bump;
+    bump.emplace(
+      tidp,
+      l1::metastore::compaction_update{
+        .expected_compaction_epoch = initial_epoch});
+    auto bump_res = _metastore.commit_compaction_metadata(bump).get();
+    ASSERT_TRUE(bump_res.has_value());
+
+    // The first partial commit is rejected as stale and aborts the run.
+    EXPECT_THROW(
+      do_compact(
+        tidp,
+        ntp,
+        std::move(compaction_info->offsets_response),
+        initial_epoch,
+        compaction_info->start_offset,
+        &_metastore,
+        &_io,
+        0ms,
+        kafka::offset::max(),
+        /*max_object_size=*/512,
+        /*commit_interval_bytes=*/512)
+        .get(),
+      std::runtime_error);
+
+    // Only the competing bump moved the epoch; the rejected commit replaced
+    // nothing and recorded no metadata, so the log is still fully dirty.
+    compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    EXPECT_EQ(compaction_info->compaction_epoch(), initial_epoch() + 1);
+    EXPECT_TRUE(compaction_info->offsets_response.dirty_ranges.covers(
+      kafka::offset{0}, kafka::offset{total_records - 1}));
+
+    // Nothing was lost: every record is still readable.
+    verify_compacted_log(
+      ntp,
+      tidp,
+      latest_kv_map,
+      total_records,
+      num_extents * batches_per_extent);
+}
+
+// A job that fails after a partial commit has landed keeps the committed
+// prefix durable but must not record compaction metadata: the extents the
+// partial commit replaced stay replaced, while every cleaned range stays
+// dirty so the retry recompacts them.
+TEST_F(ReducerTestFixture, AbortAfterPartialCommitSkipsMetadata) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+    constexpr int num_extents = 3;
+    constexpr int batches_per_extent = 10;
+    constexpr int records_per_batch = 5;
+    constexpr int total_records = num_extents * batches_per_extent
+                                  * records_per_batch;
+
+    latest_kv_map_t latest_kv_map;
+    auto batches = generate_batches(
+      num_extents * batches_per_extent,
+      /*cardinality=*/total_records,
+      records_per_batch,
+      /*starting_value=*/0,
+      /*produce_tombstones=*/false,
+      &latest_kv_map);
+    for (int i = 0; i < num_extents; ++i) {
+        chunked_circular_buffer<model::record_batch> extent_batches;
+        for (int j = 0; j < batches_per_extent; ++j) {
+            extent_batches.push_back(std::move(batches.front()));
+            batches.pop_front();
+        }
+        std::vector<tidp_batches_t> tidp_batches;
+        tidp_batches.emplace_back(tidp, std::move(extent_batches));
+        make_l1_objects(std::move(tidp_batches)).get();
+    }
+
+    auto info_spec = l1::metastore::compaction_info_spec{
+      .tidp = tidp,
+      .tombstone_removal_upper_bound_ts = model::timestamp::max()};
+    auto compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    auto initial_epoch = compaction_info->compaction_epoch;
+
+    // Throw partway through the second extent: the first extent's boundary
+    // commit has landed by then, and the job dies before finishing.
+    int batch_count = 0;
+    EXPECT_THROW(
+      do_compact_with_throwing_sink(
+        tidp,
+        ntp,
+        std::move(compaction_info->offsets_response),
+        initial_epoch,
+        compaction_info->start_offset,
+        &_metastore,
+        &_io,
+        /*should_roll=*/[] { return false; },
+        /*should_throw=*/
+        [&batch_count] { return ++batch_count == batches_per_extent + 5; },
+        0ms,
+        kafka::offset::max(),
+        /*max_object_size=*/512,
+        /*commit_interval_bytes=*/512)
+        .get(),
+      std::runtime_error);
+
+    // Exactly one partial commit landed (one epoch bump), and no compaction
+    // metadata was recorded, so the whole log is still dirty for the retry.
+    compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    EXPECT_EQ(compaction_info->compaction_epoch(), initial_epoch() + 1);
+    EXPECT_TRUE(compaction_info->offsets_response.dirty_ranges.covers(
+      kafka::offset{0}, kafka::offset{total_records - 1}));
+
+    // The committed prefix was durably replaced: the first extent's range is
+    // now backed by more, smaller extents.
+    auto extents = _metastore
+                     .get_extent_metadata_forwards(
+                       tidp,
+                       kafka::offset{0},
+                       kafka::offset::max(),
+                       std::numeric_limits<size_t>::max(),
+                       l1::metastore::include_object_metadata::no)
+                     .get();
+    ASSERT_TRUE(extents.has_value());
+    EXPECT_GT(extents->extents.size(), static_cast<size_t>(num_extents));
+
+    // Nothing was lost: every record is still readable.
+    verify_compacted_log(
+      ntp,
+      tidp,
+      latest_kv_map,
+      total_records,
+      num_extents * batches_per_extent);
 }
 
 // Tests the exceptional path in compaction_sink::finalize() where the inflight

--- a/src/v/cloud_topics/level_one/maintenance/l1_object_sink.cc
+++ b/src/v/cloud_topics/level_one/maintenance/l1_object_sink.cc
@@ -20,6 +20,7 @@
 #include "ssx/future-util.h"
 
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
 
 namespace cloud_topics::l1 {
 
@@ -29,6 +30,7 @@ l1_object_sink::l1_object_sink(
   metastore* metastore,
   ss::abort_source& as,
   config::binding<size_t> max_object_size,
+  config::binding<size_t> commit_interval_bytes,
   size_t upload_part_size,
   prefix_logger& ctxlog,
   object_builder::options opts)
@@ -37,6 +39,7 @@ l1_object_sink::l1_object_sink(
   , _metastore(metastore)
   , _as(as)
   , _max_object_size(std::move(max_object_size))
+  , _commit_interval_bytes(std::move(commit_interval_bytes))
   , _ctxlog(ctxlog)
   , _upload_part_size(upload_part_size)
   , _opts(opts) {}
@@ -57,6 +60,9 @@ ss::future<> l1_object_sink::init_metadata_builder() {
 
 ss::future<>
 l1_object_sink::initialize_builder(kafka::offset object_base_offset) {
+    if (!_metadata_builder) {
+        co_await init_metadata_builder();
+    }
     auto oid_res = co_await _metadata_builder->create_object_for(_tp);
     if (!oid_res.has_value()) {
         auto msg = fmt::format("Failed to create object: {}", oid_res.error());
@@ -73,7 +79,7 @@ l1_object_sink::initialize_builder(kafka::offset object_base_offset) {
         auto msg = fmt::format(
           "Failed to create multipart upload for object {}: {}",
           oid,
-          static_cast<int>(upload_res.error()));
+          upload_res.error());
         vlog(_ctxlog.warn, "{}", msg);
         throw std::runtime_error(msg);
     }
@@ -95,7 +101,6 @@ ss::future<> l1_object_sink::discard_object(
     (co_await ss::coroutine::as_future(upload->abort())).ignore_ready_future();
     (co_await ss::coroutine::as_future(builder->close())).ignore_ready_future();
     std::ignore = _metadata_builder->remove_pending_object(oid);
-    _any_object_failed = true;
 }
 
 ss::future<> l1_object_sink::flush(kafka::offset object_last_offset) {
@@ -119,8 +124,13 @@ ss::future<> l1_object_sink::flush(kafka::offset object_last_offset) {
                                         : ss::log_level::warn,
           "Exception creating object_info: {}.",
           e);
-        co_return co_await discard_object(
-          std::move(upload), std::move(builder), oid);
+        co_await discard_object(std::move(upload), std::move(builder), oid);
+        // A discarded object would leave a hole in the offset span of the
+        // next commit, which the metastore would reject; abort the run.
+        co_await ss::coroutine::return_exception_ptr(std::move(e));
+        // Unreachable: return_exception_ptr() completes the coroutine. The
+        // explicit co_return terminates the branch for static analysis.
+        co_return;
     }
 
     // close() completes the multipart upload via the stream's data sink.
@@ -137,8 +147,7 @@ ss::future<> l1_object_sink::flush(kafka::offset object_last_offset) {
             co_await upload->abort();
         }
         std::ignore = _metadata_builder->remove_pending_object(oid);
-        _any_object_failed = true;
-        co_return;
+        co_await ss::coroutine::return_exception_ptr(std::move(e));
     }
 
     // Upload succeeded — register the object with the metadata builder.
@@ -172,31 +181,49 @@ ss::future<> l1_object_sink::flush(kafka::offset object_last_offset) {
 
     auto add_res = _metadata_builder->add(oid, std::move(ntp_md));
     if (!add_res.has_value()) {
-        vlog(
-          _ctxlog.warn,
+        auto msg = fmt::format(
           "Failed to add object {} to metadata builder: {}",
           oid,
           add_res.error());
+        vlog(_ctxlog.warn, "{}", msg);
         std::ignore = _metadata_builder->remove_pending_object(oid);
-        _any_object_failed = true;
-        co_return;
+        co_await ss::coroutine::return_exception(std::runtime_error(msg));
     }
 
     auto finish_res = _metadata_builder->finish(
       oid, object_info.footer_offset, object_info.size_bytes);
     if (!finish_res.has_value()) {
-        vlog(
-          _ctxlog.warn,
+        auto msg = fmt::format(
           "Failed to finish object {} in metadata builder: {}",
           oid,
           finish_res.error());
+        vlog(_ctxlog.warn, "{}", msg);
         std::ignore = _metadata_builder->remove_pending_object(oid);
-        _any_object_failed = true;
-        co_return;
+        co_await ss::coroutine::return_exception(std::runtime_error(msg));
     }
 
-    ++_output_objects;
-    _output_bytes += object_info.size_bytes;
+    ++_pending_objects;
+    _pending_bytes += object_info.size_bytes;
+}
+
+ss::future<ss::stop_iteration>
+l1_object_sink::operator()(model::record_batch b) {
+    auto next_offset = model::offset_cast(b.base_offset());
+    auto prev_offset = kafka::prev_offset(next_offset);
+
+    if (
+      _inflight_object
+      && _inflight_object->builder->file_size() >= _max_object_size()) {
+        co_await flush(prev_offset);
+    }
+
+    if (!_inflight_object) {
+        co_await initialize_builder(next_offset);
+    }
+
+    co_await _inflight_object->builder->add_batch(std::move(b));
+
+    co_return ss::stop_iteration::no;
 }
 
 ss::future<> l1_object_sink::prepare_iteration(kafka::offset next_extent_base) {
@@ -205,13 +232,18 @@ ss::future<> l1_object_sink::prepare_iteration(kafka::offset next_extent_base) {
         auto prev_extent_last_offset
           = _processed_extents.make_reverse_stream().next().last_offset;
         if (next_extent_base == kafka::next_offset(prev_extent_last_offset)) {
-            co_return;
+            if (_inflight_object) {
+                co_return;
+            }
+            // Intentional fallthrough.
+        } else {
+            // Passed extents are non-contiguous. Force a roll of the
+            // currently built L1 object with the previous extent's last
+            // offset, and start a new L1 object with the new extent's base
+            // offset.
+            co_await flush(prev_extent_last_offset);
+            // Intentional fallthrough.
         }
-        // Passed extents are non-contiguous. Force a roll of the
-        // currently built L1 object with previous extent's last offset, and
-        // start a new L1 object with the new extent's base offset.
-        co_await flush(prev_extent_last_offset);
-        // Intentional fallthrough.
     }
     co_await initialize_builder(next_extent_base);
 }
@@ -219,12 +251,33 @@ ss::future<> l1_object_sink::prepare_iteration(kafka::offset next_extent_base) {
 ss::future<> l1_object_sink::finish_iteration(
   kafka::offset prev_extent_base, kafka::offset prev_extent_last) {
     _processed_extents.insert(prev_extent_base, prev_extent_last);
-    co_return;
+    ++_processed_extent_count;
+    // Accumulate output until at least one commit interval's worth is
+    // pending, then cut the inflight object at this extent boundary and
+    // commit everything finished so far.
+    auto uncommitted_bytes
+      = _pending_bytes
+        + (_inflight_object ? _inflight_object->builder->file_size() : 0);
+    if (uncommitted_bytes < _commit_interval_bytes()) {
+        co_return;
+    }
+    co_await flush(prev_extent_last);
+    co_await commit_finished_objects();
 }
 
-ss::future<bool> l1_object_sink::finalize_inflight(bool success) {
+ss::future<> l1_object_sink::commit_finished_objects() {
+    if (!_metadata_builder || _metadata_builder->is_empty()) {
+        // Everything finished has already been committed.
+        co_return;
+    }
+    co_await commit_objects(std::exchange(_metadata_builder, nullptr));
+    _pending_objects = 0;
+    _pending_bytes = 0;
+}
+
+ss::future<> l1_object_sink::finalize_inflight(bool success) {
     if (!_metadata_builder) {
-        co_return false;
+        co_return;
     }
 
     if (_inflight_object) {
@@ -259,14 +312,11 @@ ss::future<bool> l1_object_sink::finalize_inflight(bool success) {
         }
     }
 
-    if (_metadata_builder->is_empty()) {
-        vlog(
-          _ctxlog.debug,
-          "Finalized job without any built or uploaded objects.");
-        co_return false;
+    // The flush above cut the last object at the last processed extent
+    // boundary; commit whatever finished output has not been committed yet.
+    if (success) {
+        co_await commit_finished_objects();
     }
-
-    co_return true;
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/maintenance/l1_object_sink.h
+++ b/src/v/cloud_topics/level_one/maintenance/l1_object_sink.h
@@ -22,6 +22,8 @@
 #include "model/timestamp.h"
 #include "utils/prefix_logger.h"
 
+#include <stdexcept>
+
 namespace cloud_topics::l1 {
 
 class l1_object_sink : public compaction::sliding_window_reducer::sink {
@@ -32,18 +34,32 @@ public:
       l1::metastore*,
       ss::abort_source&,
       config::binding<size_t>,
+      config::binding<size_t>,
       size_t,
       prefix_logger&,
       object_builder::options = {});
 
+    // Writes a batch into the inflight L1 object, rolling it first if it
+    // has reached max_object_size and lazily starting a new object at the
+    // batch's offset when there is none (right after a mid-extent roll).
+    ss::future<ss::stop_iteration> operator()(model::record_batch) final;
+
     // Called by the `source` before batches in a new extent range are provided
     // to the `sink`. This is an asynchronous function because the active L1
     // object may need to be rolled, in case that the next extent range provided
-    // is non-contiguous.
+    // is non-contiguous. Anchors the new object at the extent base: the
+    // extent's first batches may have been deduplicated away, but the
+    // object must still claim the extent's full offset span for its commit
+    // to replace extents exactly.
     ss::future<> prepare_iteration(kafka::offset) final;
 
     // Called by the `source` after batches in an extent range are provided
-    // to the `sink`.
+    // to the `sink`. Commits the job's finished output objects incrementally
+    // as it goes: commits may only happen at source extent boundaries — the
+    // replaced intervals must align exactly with the extents being replaced —
+    // so once at least a full object's worth of output has accumulated, the
+    // inflight object is cut at the extent boundary this iteration finished
+    // and everything finished so far is committed via `commit_objects()`.
     ss::future<> finish_iteration(kafka::offset, kafka::offset) final;
 
 protected:
@@ -64,10 +80,26 @@ protected:
       std::unique_ptr<object_builder>,
       object_id);
 
-    // Handles the common finalize preamble: flushes or discards inflight
-    // objects, checks if the builder is empty. Returns true if derived class
-    // should proceed with commit logic, false if there is nothing to commit.
-    ss::future<bool> finalize_inflight(bool success);
+    // Commits the passed metadata builder's finished-but-uncommitted
+    // objects (counted by _pending_objects/_pending_bytes) to the
+    // metastore. Called at source extent boundaries once at least one
+    // commit interval's worth of output has accumulated, and again for the
+    // tail during finalize_inflight(). Takes ownership of the builder:
+    // committed objects must not be resent, so the next
+    // initialize_builder() starts a fresh one.
+    virtual ss::future<>
+      commit_objects(std::unique_ptr<metastore::object_metadata_builder>) = 0;
+
+    // Commits finished output that has not been acknowledged yet via
+    // `commit_objects()`, handing it ownership of the consumed metadata
+    // builder. No-op if nothing new has finished.
+    ss::future<> commit_finished_objects();
+
+    // Handles the common finalize preamble: flushes the inflight object (cut
+    // at the last processed extent boundary) on the success path or discards
+    // it on the exceptional path, then commits whatever finished output has
+    // not been committed yet.
+    ss::future<> finalize_inflight(bool success);
 
 protected:
     model::topic_id_partition _tp;
@@ -76,22 +108,22 @@ protected:
     ss::abort_source& _as;
     // The target maximum L1 object size that will be built.
     config::binding<size_t> _max_object_size;
+    // Bytes of finished output to accumulate before committing: at each
+    // source extent boundary, once at least this much output is pending,
+    // the inflight object is cut and everything finished so far is
+    // committed.
+    config::binding<size_t> _commit_interval_bytes;
     prefix_logger& _ctxlog;
     // The part size used for multipart uploads.
     size_t _upload_part_size;
     const object_builder::options _opts;
 
-    // The metadata builder for the current compaction job, created during
-    // `initialize()` from the metastore and used to track new objects.
-    std::unique_ptr<metastore::object_metadata_builder> _metadata_builder;
-
-    // Tracks whether any upload failed during this job.
-    bool _any_object_failed{false};
-
-    // Number of output L1 objects successfully registered with the metadata
-    // builder, and their total size in bytes.
-    size_t _output_objects{0};
-    size_t _output_bytes{0};
+    // Finished output objects registered with the metadata builder but not
+    // yet committed, and their total size in bytes. Reset by
+    // commit_finished_objects(); the metadata builder holds the objects
+    // themselves.
+    uint64_t _pending_objects{0};
+    uint64_t _pending_bytes{0};
 
     // The L1 object currently being built via multipart upload.
     struct inflight_object_t {
@@ -106,6 +138,16 @@ protected:
     // The interval set that is populated by extents which have been read by the
     // `source` and written by the `sink`.
     offset_interval_set _processed_extents;
+
+    // Number of finish_iteration() calls: source extents for compaction,
+    // leveling ranges for leveling (which tracks its own extent count from
+    // range metadata instead).
+    uint64_t _processed_extent_count{0};
+
+private:
+    // The metadata builder for the current compaction job, created during
+    // `initialize()` from the metastore and used to track new objects.
+    std::unique_ptr<metastore::object_metadata_builder> _metadata_builder;
 };
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/maintenance/leveling/BUILD
+++ b/src/v/cloud_topics/level_one/maintenance/leveling/BUILD
@@ -36,6 +36,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics/level_one/frontend_reader:reader",
         "//src/v/cloud_topics/level_one/maintenance:meta",
         "//src/v/cloud_topics/level_one/metastore",
+        "//src/v/cloud_topics/level_one/metastore:extent_metadata_reader",
         "//src/v/cloud_topics/level_one/metastore:leveling_range_builder",
         "//src/v/compaction:reducer",
         "//src/v/container:chunked_vector",

--- a/src/v/cloud_topics/level_one/maintenance/leveling/leveling_sink.cc
+++ b/src/v/cloud_topics/level_one/maintenance/leveling/leveling_sink.cc
@@ -25,6 +25,7 @@ leveling_sink::leveling_sink(
   metastore* metastore,
   ss::abort_source& as,
   config::binding<size_t> max_object_size,
+  config::binding<size_t> commit_interval_bytes,
   size_t upload_part_size,
   compaction_worker_probe& probe,
   prefix_logger& ctxlog,
@@ -35,6 +36,7 @@ leveling_sink::leveling_sink(
       metastore,
       as,
       std::move(max_object_size),
+      std::move(commit_interval_bytes),
       upload_part_size,
       ctxlog,
       std::move(opts))
@@ -55,8 +57,6 @@ leveling_sink::initialize(compaction::sliding_window_reducer::source& src) {
       size_t{0},
       [](size_t acc, const auto& range) { return acc + range.extent_count; });
 
-    co_await init_metadata_builder();
-
     vlog(
       _ctxlog.debug,
       "Initialized leveling job with {} leveling ranges",
@@ -65,60 +65,70 @@ leveling_sink::initialize(compaction::sliding_window_reducer::source& src) {
     co_return true;
 }
 
-ss::future<ss::stop_iteration>
-leveling_sink::operator()(model::record_batch b) {
-    auto next_offset = model::offset_cast(b.base_offset());
-    auto prev_offset = kafka::prev_offset(next_offset);
-
-    if (
-      _inflight_object
-      && _inflight_object->builder->file_size() >= _max_object_size()) {
-        co_await flush(prev_offset);
-    }
-
-    if (!_inflight_object) {
-        co_await initialize_builder(next_offset);
-    }
-
-    co_await _inflight_object->builder->add_batch(std::move(b));
-
-    co_return ss::stop_iteration::no;
-}
-
-ss::future<> leveling_sink::finalize(bool success) {
-    auto should_commit = co_await finalize_inflight(success);
-    if (!should_commit) {
-        co_return;
-    }
-
+ss::future<> leveling_sink::commit_objects(
+  std::unique_ptr<metastore::object_metadata_builder> builder) {
     metastore::replace_epoch_map_t epoch_map;
     epoch_map.emplace(_tp, _expected_compaction_epoch);
     auto replace_res = co_await l1::retry_metastore_op_with_default_rtc(
-      [this, &epoch_map]() {
-          return _metastore->replace_objects(*_metadata_builder, epoch_map);
+      [this, &builder, &epoch_map]() {
+          return _metastore->replace_objects(*builder, epoch_map);
       },
       _as);
-    if (replace_res.has_value()) {
-        auto reclaimed = _input_extents > _output_objects
-                           ? _input_extents - _output_objects
-                           : size_t{0};
-        _probe.add_leveling_extents_reclaimed(reclaimed);
-        _probe.add_leveling_objects_committed(_output_objects);
-        _probe.add_leveling_bytes_committed(_output_bytes);
-        vlog(
-          _ctxlog.info,
-          "Finalized leveling with {} extents reclaimed ({}->{})",
-          reclaimed,
-          _input_extents,
-          _output_objects);
-    } else {
-        _probe.add_leveling_objects_rejected(_output_objects);
-        _probe.add_leveling_bytes_rejected(_output_bytes);
+    if (!replace_res.has_value()) {
+        _probe.add_leveling_objects_rejected(_pending_objects);
+        _probe.add_leveling_bytes_rejected(_pending_bytes);
+        auto err = replace_res.error();
+        throw std::runtime_error(
+          fmt::format(
+            "[{}] aborting leveling: object replacement at epoch {} failed: "
+            "{}",
+            _tp,
+            _expected_compaction_epoch,
+            err));
+    }
+    _probe.add_leveling_objects_committed(_pending_objects);
+    _probe.add_leveling_bytes_committed(_pending_bytes);
+    _committed_objects += _pending_objects;
+    ++_partial_commits;
+    vlog(
+      _ctxlog.debug,
+      "Partial leveling commit of {} object(s) landed at epoch {}",
+      _pending_objects,
+      _expected_compaction_epoch);
+}
+
+ss::future<> leveling_sink::finalize(bool success) {
+    co_await finalize_inflight(success);
+
+    if (!success) {
         vlog(
           _ctxlog.warn,
-          "Could not commit object replacement during leveling: {}.",
-          replace_res.error());
+          "Skipping leveling finalization; {}",
+          _committed_objects == 0
+            ? fmt::format("no objects had been committed")
+            : fmt::format(
+                "{} object(s) already committed", _committed_objects));
+        co_return;
     }
+
+    if (_committed_objects == 0) {
+        vlog(
+          _ctxlog.debug, "Finalized leveling without any committed objects.");
+        co_return;
+    }
+
+    auto reclaimed = _input_extents > _committed_objects
+                       ? _input_extents - _committed_objects
+                       : size_t{0};
+    _probe.add_leveling_extents_reclaimed(reclaimed);
+    vlog(
+      _ctxlog.info,
+      "Finalized leveling with {} extents reclaimed ({}->{}) in {} partial "
+      "commit(s)",
+      reclaimed,
+      _input_extents,
+      _committed_objects,
+      _partial_commits);
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/maintenance/leveling/leveling_sink.h
+++ b/src/v/cloud_topics/level_one/maintenance/leveling/leveling_sink.h
@@ -28,6 +28,7 @@ public:
       l1::metastore*,
       ss::abort_source&,
       config::binding<size_t> max_object_size,
+      config::binding<size_t> commit_interval_bytes,
       size_t upload_part_size,
       compaction_worker_probe&,
       prefix_logger&,
@@ -36,9 +37,17 @@ public:
     ss::future<bool>
     initialize(compaction::sliding_window_reducer::source&) final;
 
-    ss::future<ss::stop_iteration> operator()(model::record_batch) final;
-
     ss::future<> finalize(bool success) final;
+
+protected:
+    // Commits the builder's finished objects via replace_objects() at the
+    // job's pinned compaction epoch. Unlike compaction's partial commits,
+    // this does not bump the epoch: leveling must never fence a concurrent
+    // compaction job, while compaction's epoch bumps fence this job's
+    // remaining commits. Throws on failure, aborting the run; extents
+    // replaced by earlier commits remain durable.
+    ss::future<>
+      commit_objects(std::unique_ptr<metastore::object_metadata_builder>) final;
 
 private:
     // The expected compaction epoch for the log.
@@ -46,10 +55,16 @@ private:
 
     compaction_worker_probe& _probe;
 
-    // Total undersized input extents across this job's leveling ranges, summed
-    // in `initialize()`. Compared against the base class's `_output_objects`
-    // on commit to report the net extent-count reduction.
+    // Total undersized input extents across this job's leveling ranges,
+    // summed in `initialize()`. Compared against _committed_objects at
+    // finalize to report the net extent-count reduction.
     size_t _input_extents{0};
+
+    // Output objects committed over the job's lifetime, across all commits.
+    uint64_t _committed_objects{0};
+
+    // Number of partial commits this job has landed.
+    uint64_t _partial_commits{0};
 };
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/maintenance/leveling/leveling_source.cc
+++ b/src/v/cloud_topics/level_one/maintenance/leveling/leveling_source.cc
@@ -12,6 +12,7 @@
 
 #include "cloud_io/admission_control_types.h"
 #include "cloud_topics/level_one/frontend_reader/level_one_reader.h"
+#include "cloud_topics/level_one/metastore/extent_metadata_reader.h"
 #include "cloud_topics/log_reader_config.h"
 #include "model/record_batch_reader.h"
 #include "model/timeout_clock.h"
@@ -72,31 +73,50 @@ ss::future<ss::stop_iteration> leveling_source::deduplication_iteration(
         co_return ss::stop_iteration::yes;
     }
 
-    const auto& range = *_range_it;
-
-    kafka::offset start_offset{range.base_offset};
-    kafka::offset last_offset{range.last_offset};
-    cloud_topic_log_reader_config config(
-      cloud_io::group_id::default_group,
-      start_offset,
-      last_offset,
-      std::nullopt,
+    auto reader = extent_metadata_reader(
+      _metastore,
+      _tp,
+      kafka::offset{_range_it->base_offset},
+      kafka::offset{_range_it->last_offset},
+      extent_metadata_reader::iteration_direction::forwards,
       _as);
-    config.skip_cache = true;
-    auto rdr = model::record_batch_reader(
-      std::make_unique<level_one_log_reader_impl>(
-        config, _ntp, _tp, _metastore, _io));
+    auto gen = reader.generator();
+    while (auto extent_res_opt = co_await gen()) {
+        auto& extent_res = extent_res_opt->get();
+        if (!extent_res.has_value()) {
+            vlog(
+              _ctxlog.warn,
+              "Error fetching extent metadata during leveling iteration: {}",
+              extent_res.error());
+            co_return ss::stop_iteration::yes;
+        }
 
-    co_await sink.prepare_iteration(start_offset);
-    co_await std::move(rdr).consume(
-      passthrough_consumer{sink}, model::no_timeout);
-    co_await sink.finish_iteration(start_offset, last_offset);
+        auto extent = std::move(extent_res).value();
 
-    vlog(
-      _ctxlog.debug,
-      "L1 leveling rewriting offset range ({}~{})",
-      start_offset,
-      last_offset);
+        kafka::offset start_offset{extent.base_offset};
+        kafka::offset last_offset{extent.last_offset};
+        cloud_topic_log_reader_config config(
+          cloud_io::group_id::default_group,
+          start_offset,
+          last_offset,
+          std::nullopt,
+          _as);
+        config.skip_cache = true;
+        auto rdr = model::record_batch_reader(
+          std::make_unique<level_one_log_reader_impl>(
+            config, _ntp, _tp, _metastore, _io));
+
+        co_await sink.prepare_iteration(start_offset);
+        co_await std::move(rdr).consume(
+          passthrough_consumer{sink}, model::no_timeout);
+        co_await sink.finish_iteration(start_offset, last_offset);
+
+        vlog(
+          _ctxlog.debug,
+          "L1 leveling rewriting offset range ({}~{})",
+          start_offset,
+          last_offset);
+    }
 
     ++_range_it;
     co_return ss::stop_iteration::no;

--- a/src/v/cloud_topics/level_one/maintenance/leveling/leveling_source.h
+++ b/src/v/cloud_topics/level_one/maintenance/leveling/leveling_source.h
@@ -59,7 +59,9 @@ private:
     // undersized/fragmented L1 objects).
     chunked_vector<levelable_range> _leveling_ranges;
 
-    // Iterator over _leveling_ranges for the current range being processed.
+    // Cursor into `_leveling_ranges`. deduplication_iteration() processes the
+    // range it points at — iterating that range's extents one at a time — then
+    // advances it, one range per call, until the ranges are exhausted.
     chunked_vector<levelable_range>::iterator _range_it;
 
     metastore* _metastore;

--- a/src/v/cloud_topics/level_one/maintenance/leveling/tests/leveling_reducer_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/leveling/tests/leveling_reducer_test.cc
@@ -61,7 +61,8 @@ ss::future<> do_level(
   l1::metastore::compaction_epoch epoch,
   l1::metastore* metastore,
   l1::io* io,
-  size_t max_object_size = 128_MiB) {
+  size_t max_object_size = 128_MiB,
+  size_t commit_interval_bytes = 512_MiB) {
     ss::abort_source as;
     auto state = l1::compaction_job_state::running;
     l1::compaction_worker_probe probe;
@@ -82,6 +83,7 @@ ss::future<> do_level(
       metastore,
       as,
       config::mock_binding<size_t>(max_object_size),
+      config::mock_binding<size_t>(commit_interval_bytes),
       test_upload_part_size,
       probe,
       test_ctxlog);
@@ -269,6 +271,120 @@ TEST_F(LevelingReducerTest, PreservesBatchData) {
     }
 }
 
+// Leveling commits its output incrementally, one replace_objects() per
+// range boundary once at least a full object's worth of output has
+// accumulated. Unlike compaction's partial commits, leveling commits must
+// not bump the compaction epoch: leveling must never fence a concurrent
+// compaction job.
+TEST_F(LevelingReducerTest, IncrementalCommitsPreserveEpoch) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+    const int records_per_batch = 10;
+    const int batches_per_extent = 5;
+    const int num_extents = 4;
+    const int records_per_extent = batches_per_extent * records_per_batch;
+
+    for (int i = 0; i < num_extents; ++i) {
+        upload_batches(
+          tidp,
+          model::offset{i * records_per_extent},
+          batches_per_extent,
+          records_per_batch);
+    }
+
+    auto orig_reader = make_reader(ntp, tidp);
+    auto orig_batches = read_all(std::move(orig_reader));
+    ASSERT_GT(orig_batches.size(), 0);
+
+    auto leveling_info = get_all_leveling_info(tidp, 100_KiB);
+    ASSERT_FALSE(leveling_info.ranges.empty());
+    auto initial_epoch = leveling_info.epoch;
+
+    // Split the run into two ranges so the job crosses two range
+    // boundaries; a tiny max_object_size makes each boundary's accumulated
+    // output exceed the commit threshold, forcing one commit per range.
+    chunked_vector<l1::levelable_range> ranges;
+    ranges.push_back(
+      l1::levelable_range{
+        .base_offset = kafka::offset{0},
+        .last_offset = kafka::offset{2 * records_per_extent - 1},
+        .extent_count = 2});
+    ranges.push_back(
+      l1::levelable_range{
+        .base_offset = kafka::offset{2 * records_per_extent},
+        .last_offset = kafka::offset{4 * records_per_extent - 1},
+        .extent_count = 2});
+
+    do_level(
+      ntp,
+      tidp,
+      std::move(ranges),
+      initial_epoch,
+      &_metastore,
+      &_io,
+      /*max_object_size=*/512,
+      /*commit_interval_bytes=*/512)
+      .get();
+
+    // Leveling commits never bump the compaction epoch.
+    auto after_info = get_all_leveling_info(tidp, 100_KiB);
+    EXPECT_EQ(after_info.epoch, initial_epoch);
+
+    // Every record survives the rewrite byte-for-byte.
+    auto new_reader = make_reader(ntp, tidp);
+    auto new_batches = read_all(std::move(new_reader));
+    ASSERT_EQ(orig_batches.size(), new_batches.size());
+    for (size_t i = 0; i < orig_batches.size(); ++i) {
+        EXPECT_EQ(orig_batches[i].header(), new_batches[i].header())
+          << "Batch header mismatch at index " << i;
+        EXPECT_EQ(orig_batches[i].data(), new_batches[i].data())
+          << "Batch data mismatch at index " << i;
+    }
+}
+
+// A leveling commit rejected by the metastore (stale compaction epoch, e.g.
+// a compaction job committed since this job read its snapshot) aborts the
+// run without replacing any extents.
+TEST_F(LevelingReducerTest, StaleEpochAbortsJob) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+    const int records_per_batch = 10;
+    const int batches_per_extent = 5;
+    const int num_extents = 4;
+    const int records_per_extent = batches_per_extent * records_per_batch;
+
+    for (int i = 0; i < num_extents; ++i) {
+        upload_batches(
+          tidp,
+          model::offset{i * records_per_extent},
+          batches_per_extent,
+          records_per_batch);
+    }
+    auto extents_before = count_extents(tidp);
+
+    auto leveling_info = get_all_leveling_info(tidp, 100_KiB);
+    ASSERT_FALSE(leveling_info.ranges.empty());
+    auto initial_epoch = leveling_info.epoch;
+    auto stale_epoch = l1::metastore::compaction_epoch{initial_epoch() + 1};
+
+    // A tiny commit interval forces the commit through the range-boundary
+    // path, whose failure aborts the run.
+    EXPECT_THROW(
+      do_level(
+        ntp,
+        tidp,
+        std::move(leveling_info.ranges),
+        stale_epoch,
+        &_metastore,
+        &_io,
+        /*max_object_size=*/512,
+        /*commit_interval_bytes=*/512)
+        .get(),
+      std::runtime_error);
+
+    // Nothing was replaced and the epoch is untouched.
+    EXPECT_EQ(count_extents(tidp), extents_before);
+    EXPECT_EQ(get_all_leveling_info(tidp, 100_KiB).epoch, initial_epoch);
+}
+
 // If hard_stop is requested, the source stops iteration immediately and the
 // sink does not commit any replacement.
 TEST_F(LevelingReducerTest, HardStopPreempts) {
@@ -314,6 +430,7 @@ TEST_F(LevelingReducerTest, HardStopPreempts) {
       &_metastore,
       as,
       config::mock_binding<size_t>(128_MiB),
+      config::mock_binding<size_t>(512_MiB),
       test_upload_part_size,
       probe,
       test_ctxlog);
@@ -371,6 +488,7 @@ TEST_F(LevelingReducerTest, EmptyLevelingRangesIsNoOp) {
       &_metastore,
       as,
       config::mock_binding<size_t>(128_MiB),
+      config::mock_binding<size_t>(512_MiB),
       test_upload_part_size,
       probe,
       test_ctxlog);

--- a/src/v/cloud_topics/level_one/maintenance/worker.cc
+++ b/src/v/cloud_topics/level_one/maintenance/worker.cc
@@ -398,6 +398,8 @@ ss::future<> compaction_worker::compact_log(compaction_job* job) {
       _metastore,
       _as,
       config::shard_local_cfg().cloud_topics_compaction_max_object_size.bind(),
+      config::shard_local_cfg()
+        .cloud_topics_compaction_commit_interval_bytes.bind(),
       _upload_part_size,
       _probe,
       ctxlog,
@@ -494,6 +496,8 @@ ss::future<> compaction_worker::do_level_range(leveling_job* job) {
       _as,
       config::shard_local_cfg()
         .cloud_topics_reconciliation_max_object_size.bind(),
+      config::shard_local_cfg()
+        .cloud_topics_leveling_commit_interval_bytes.bind(),
       _upload_part_size,
       _probe,
       ctxlog,

--- a/src/v/cloud_topics/level_one/metastore/leveling_range_builder.h
+++ b/src/v/cloud_topics/level_one/metastore/leveling_range_builder.h
@@ -84,7 +84,15 @@ public:
     explicit leveling_range_builder(size_t min_acceptable_extent_bytes)
       : _min_acceptable_extent_bytes(min_acceptable_extent_bytes)
       , _max_acceptable_range_bytes(
-          config::shard_local_cfg().cloud_topics_leveling_max_range_bytes()) {}
+          config::shard_local_cfg().cloud_topics_leveling_max_range_bytes())
+      , _max_ranges(
+          config::shard_local_cfg()
+            .cloud_topics_leveling_max_ranges_per_partition()) {}
+
+    // Whether the cap on ranges per partition has been reached. Callers should
+    // stop feeding extents once this is true; the scan reply is bounded and
+    // the remaining ranges are picked up by a later scan.
+    bool is_full() const { return _ranges.size() >= _max_ranges; }
 
     // Processes a single extent.
     void process_extent(kafka::offset base, kafka::offset last, size_t len) {
@@ -134,7 +142,9 @@ private:
         const bool undersized_tail = tail == is_tail_range::yes
                                      && _range->bytes
                                           < _min_acceptable_extent_bytes;
-        if (_range->extent_count > 1 && !undersized_tail) {
+        if (
+          _range->extent_count > 1 && !undersized_tail
+          && _ranges.size() < _max_ranges) {
             _ranges.push_back(
               levelable_range{
                 .base_offset = _range->base,
@@ -148,6 +158,7 @@ private:
 
     size_t _min_acceptable_extent_bytes;
     size_t _max_acceptable_range_bytes;
+    size_t _max_ranges;
     std::optional<in_progress_range> _range;
     chunked_vector<levelable_range> _ranges;
 };

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
@@ -922,6 +922,68 @@ compact_objects_db_update::build_rows(
     chunked_hash_map<model::topic_id_partition, metadata_row_value>
       updated_metadata;
 
+    if (new_objects.empty()) {
+        // Metadata-only commit.
+        chunked_hash_map<model::topic_id_partition, compaction_state>
+          merged_compaction_states;
+        for (const auto& [t, p_updates] : compaction_updates) {
+            for (const auto& [p, comp_update] : p_updates) {
+                model::topic_id_partition tidp{t, p};
+                auto meta = co_await get_metadata_for_update(
+                  state, updated_metadata, tidp, "compaction");
+                if (!meta.has_value()) {
+                    co_return std::unexpected(std::move(meta.error()));
+                }
+                // Cleaned ranges must refer to offsets the log has seen.
+                for (const auto& r : comp_update.new_cleaned_ranges) {
+                    if (r.last_offset >= meta.value()->next_offset) {
+                        co_return std::unexpected(db_update_error(
+                          invalid_update,
+                          fmt::format(
+                            "Cleaned range [{}, {}] for {} extends past the "
+                            "next offset {}",
+                            r.base_offset,
+                            r.last_offset,
+                            tidp,
+                            meta.value()->next_offset)));
+                    }
+                }
+                compaction_state merged;
+                auto merge_res = co_await merge_compaction_state(
+                  tidp, comp_update, state, *meta.value(), merged);
+                if (!merge_res.has_value()) {
+                    co_return std::unexpected(std::move(merge_res.error()));
+                }
+                // An update with no cleaned ranges and no tombstone
+                // removals validates and bumps the epoch but leaves the
+                // compaction state definitionally unchanged; skip
+                // rewriting the row. The epoch bump still lands via the
+                // metadata row.
+                if (
+                  !comp_update.new_cleaned_ranges.empty()
+                  || !comp_update.removed_tombstones_ranges.empty()) {
+                    merged_compaction_states[tidp] = std::move(merged);
+                }
+            }
+        }
+        for (const auto& [tidp, comp_state] : merged_compaction_states) {
+            out.emplace_back(
+              write_batch_row{
+                .key = compaction_row_key::encode(tidp),
+                .value = serde::to_iobuf(
+                  compaction_row_value{.state = comp_state}),
+              });
+        }
+        for (auto& [tidp, meta] : updated_metadata) {
+            out.emplace_back(
+              write_batch_row{
+                .key = metadata_row_key::encode(tidp),
+                .value = serde::to_iobuf(meta),
+              });
+        }
+        co_return std::expected<void, db_update_error>{};
+    }
+
     auto replacements_res = co_await validate_replacement(
       state, new_objects, updated_metadata);
     if (!replacements_res.has_value()) {
@@ -941,14 +1003,21 @@ compact_objects_db_update::build_rows(
             if (!meta.has_value()) {
                 co_return std::unexpected(std::move(meta.error()));
             }
+            compaction_state merged;
             auto merge_res = co_await merge_compaction_state(
-              tidp,
-              comp_update,
-              state,
-              *meta.value(),
-              merged_compaction_states[tidp]);
+              tidp, comp_update, state, *meta.value(), merged);
             if (!merge_res.has_value()) {
                 co_return std::unexpected(std::move(merge_res.error()));
+            }
+            // An update with no cleaned ranges and no tombstone removals —
+            // the shape a job uses to commit a batch of output objects
+            // mid-run — validates and bumps the epoch but leaves the
+            // compaction state definitionally unchanged; skip rewriting
+            // the row. The epoch bump still lands via the metadata row.
+            if (
+              !comp_update.new_cleaned_ranges.empty()
+              || !comp_update.removed_tombstones_ranges.empty()) {
+                merged_compaction_states[tidp] = std::move(merged);
             }
 
             // If there are new cleaned ranges, check that the extents replace
@@ -1001,6 +1070,17 @@ compact_objects_db_update::discover_replaced_object_ids(
 
 std::expected<void, db_update_error>
 compact_objects_db_update::validate_inputs() const {
+    if (new_objects.empty()) {
+        // Metadata-only commit (see build_rows). All request-level checks
+        // relate new objects to the compaction updates, so there is nothing
+        // further to validate here beyond the request not being a no-op.
+        if (compaction_updates.empty()) {
+            return std::unexpected(db_update_error(
+              invalid_input,
+              "Metadata-only compaction request carries no updates"));
+        }
+        return std::expected<void, db_update_error>{};
+    }
     auto layout_res = validate_new_objects_extent_layout(new_objects);
     if (!layout_res.has_value()) {
         return std::unexpected(layout_res.error());

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -368,6 +368,15 @@ public:
     virtual ss::future<std::expected<void, errc>> compact_objects(
       const object_metadata_builder&, const compaction_map_t&) = 0;
 
+    // Commits compaction metadata without any object replacements: the
+    // cleaned ranges, tombstone-removal ranges, and one epoch bump. Used by
+    // jobs that installed their output objects incrementally via partial
+    // compact_objects() commits (objects with an empty compaction update,
+    // each of which bumped the epoch), so the expected epoch here is the one
+    // the job's own partial commits advanced.
+    virtual ss::future<std::expected<void, errc>>
+    commit_compaction_metadata(const compaction_map_t&) = 0;
+
     // All the information required to query a `compaction_info_response` from
     // the metastore. Parameters are used for call to `get_compaction_info()`.
     struct compaction_info_spec {

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -719,6 +719,45 @@ replicated_metastore::get_end_offset_for_term(
 }
 
 ss::future<std::expected<void, metastore::errc>>
+replicated_metastore::commit_compaction_metadata(
+  const metastore::compaction_map_t& compaction_updates) {
+    chunked_hash_map<
+      model::partition_id,
+      chunked_hash_map<model::topic_id_partition, compaction_state_update>>
+      compaction_updates_by_partition;
+    for (auto& [tp, update] : compaction_updates) {
+        auto metastore_partition = fe_.metastore_partition(tp);
+        if (!metastore_partition) {
+            vlog(cd_log.warn, "Unable to get metastore partition for {}", tp);
+            co_return std::unexpected(errc::transport_error);
+        }
+        compaction_updates_by_partition[*metastore_partition].emplace(
+          tp, meta_to_rpc_compact_update(update));
+    }
+    for (auto& [partition_id, updates] : compaction_updates_by_partition) {
+        rpc::compact_objects_request req;
+        req.metastore_partition = partition_id;
+        req.compaction_updates = std::move(updates);
+        auto reply_fut = co_await ss::coroutine::as_future(
+          fe_.compact_objects(std::move(req)));
+        if (reply_fut.failed()) {
+            auto ex = reply_fut.get_exception();
+            vlog(cd_log.warn, "Error while sending request: {}", ex);
+            co_return std::unexpected(metastore::errc::transport_error);
+        }
+        auto reply = reply_fut.get();
+        if (reply.ec != rpc::errc::ok) {
+            vlog(
+              cd_log.debug,
+              "Error code received for request {}",
+              int(reply.ec));
+            co_return std::unexpected(rpc_to_meta_errc(reply.ec));
+        }
+    }
+    co_return std::expected<void, errc>{};
+}
+
+ss::future<std::expected<void, metastore::errc>>
 replicated_metastore::compact_objects(
   const metastore::object_metadata_builder& builder,
   const metastore::compaction_map_t& compaction_updates) {

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
@@ -74,6 +74,8 @@ public:
       const object_metadata_builder&, const compaction_map_t&) override;
     ss::future<std::expected<void, errc>> compact_objects(
       const chunked_vector<object_metadata>&, const compaction_map_t&);
+    ss::future<std::expected<void, errc>>
+    commit_compaction_metadata(const compaction_map_t&) override;
 
     ss::future<std::expected<compaction_offsets_response, errc>>
     get_compaction_offsets(const model::topic_id_partition&, model::timestamp);

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -829,6 +829,9 @@ simple_metastore::get_leveling_info(
         }
         const auto base = std::max(ext.base_offset, prt.start_offset);
         builder.process_extent(base, ext.last_offset, ext.len);
+        if (builder.is_full()) {
+            break;
+        }
     }
     resp.ranges = std::move(builder).finalize();
     return resp;

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -529,6 +529,13 @@ simple_metastore::get_term_for_offset(
 }
 
 ss::future<std::expected<void, metastore::errc>>
+simple_metastore::commit_compaction_metadata(
+  const compaction_map_t& compaction_metas) {
+    co_return co_await compact_objects(
+      chunked_vector<object_metadata>{}, compaction_metas);
+}
+
+ss::future<std::expected<void, metastore::errc>>
 simple_metastore::compact_objects(
   const chunked_vector<object_metadata>& objects,
   const compaction_map_t& compaction_metas) {

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -102,6 +102,8 @@ public:
       const object_metadata_builder&, const compaction_map_t&) override;
     ss::future<std::expected<void, errc>> compact_objects(
       const chunked_vector<object_metadata>&, const compaction_map_t&);
+    ss::future<std::expected<void, errc>>
+    commit_compaction_metadata(const compaction_map_t&) override;
 
     void preregister_objects(const chunked_vector<object_id>&);
 

--- a/src/v/cloud_topics/level_one/metastore/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update.cc
@@ -628,6 +628,49 @@ replace_objects_update::build(
 
 std::expected<std::monostate, stm_update_error>
 compact_objects_update::can_apply(const state& state) {
+    if (new_objects.empty()) {
+        // Metadata-only commit.
+        if (compaction_updates.empty()) {
+            return std::unexpected(stm_update_error(
+              "Metadata-only compaction request carries no updates"));
+        }
+        for (const auto& [t, t_req] : compaction_updates) {
+            for (const auto& [p, compaction_update] : t_req) {
+                model::topic_id_partition tidp{t, p};
+                auto p_ref = state.partition_state(tidp);
+                if (!p_ref.has_value()) {
+                    return std::unexpected(stm_update_error(
+                      fmt::format("Partition {} not tracked by state", tidp)));
+                }
+                const auto& p_state = p_ref->get();
+                if (
+                  compaction_update.expected_compaction_epoch
+                  != p_state.compaction_epoch) {
+                    return std::unexpected(stm_update_error(
+                      fmt::format(
+                        "Expected compaction epoch {} does not match the "
+                        "current compaction epoch {} for {}",
+                        compaction_update.expected_compaction_epoch,
+                        p_state.compaction_epoch,
+                        tidp)));
+                }
+                // Cleaned ranges must refer to offsets the log has seen.
+                for (const auto& r : compaction_update.new_cleaned_ranges) {
+                    if (r.last_offset >= p_state.next_offset) {
+                        return std::unexpected(stm_update_error(
+                          fmt::format(
+                            "Cleaned range [{}, {}] for {} extends past "
+                            "the next offset {}",
+                            r.base_offset,
+                            r.last_offset,
+                            tidp,
+                            p_state.next_offset)));
+                    }
+                }
+            }
+        }
+        return std::monostate{};
+    }
     auto layout_res = validate_new_objects_layout(state, new_objects);
     if (!layout_res.has_value()) {
         return std::unexpected(layout_res.error());
@@ -784,6 +827,17 @@ compact_objects_update::apply(state& state) {
             model::topic_id_partition tidp{t, p};
             auto& p_state = state.topic_to_state[tidp.topic_id]
                               .pid_to_state[tidp.partition];
+            // An update with no cleaned ranges and no tombstone removals —
+            // the shape a job uses to commit a batch of output objects
+            // mid-run — bumps the epoch but leaves the compaction state
+            // untouched, mirroring the LSM path which skips rewriting the
+            // compaction row.
+            if (
+              compaction_update.new_cleaned_ranges.empty()
+              && compaction_update.removed_tombstones_ranges.empty()) {
+                ++p_state.compaction_epoch;
+                continue;
+            }
             if (!p_state.compaction_state.has_value()) {
                 p_state.compaction_state.emplace();
             }

--- a/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
@@ -1341,8 +1341,8 @@ TEST_P(StateUpdateParamTest, TestCompactWithEpochOnlyUpdate) {
 
     // A compact_objects request whose compaction_update has only the
     // expected_compaction_epoch set — no cleaned ranges, no tombstone
-    // removals — is valid. Extents are replaced, the epoch is bumped, and
-    // an empty compaction_state is visible.
+    // removals — is valid. Extents are replaced and the epoch is bumped,
+    // but the compaction state is left untouched (absent here).
     auto replace = compact_objects_builder()
                      .add(new_obj_builder(oid2, 100, 1100)
                             .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
@@ -1359,7 +1359,7 @@ TEST_P(StateUpdateParamTest, TestCompactWithEpochOnlyUpdate) {
       = s.partition_state(model::topic_id_partition::from(tidp_a))->get();
     EXPECT_THAT(prt_a.extents, ElementsAre(MatchesRange(oid2, 0_o, 10_o)));
     EXPECT_EQ(prt_a.compaction_epoch, partition_state::compaction_epoch_t{1});
-    EXPECT_TRUE(prt_a.compaction_state.has_value());
+    EXPECT_FALSE(prt_a.compaction_state.has_value());
 }
 
 TEST_P(StateUpdateParamTest, TestRejectsNotPreregistered) {

--- a/src/v/cloud_topics/read_replica/snapshot_metastore.cc
+++ b/src/v/cloud_topics/read_replica/snapshot_metastore.cc
@@ -230,6 +230,11 @@ snapshot_metastore::compact_objects(
     co_return std::unexpected(errc::invalid_request);
 }
 
+ss::future<std::expected<void, l1::metastore::errc>>
+snapshot_metastore::commit_compaction_metadata(const compaction_map_t&) {
+    co_return std::unexpected(errc::invalid_request);
+}
+
 ss::future<
   std::expected<l1::metastore::compaction_info_response, l1::metastore::errc>>
 snapshot_metastore::get_compaction_info(const compaction_info_spec&) {

--- a/src/v/cloud_topics/read_replica/snapshot_metastore.h
+++ b/src/v/cloud_topics/read_replica/snapshot_metastore.h
@@ -72,6 +72,8 @@ public:
 
     ss::future<std::expected<void, errc>> compact_objects(
       const object_metadata_builder&, const compaction_map_t&) override;
+    ss::future<std::expected<void, errc>>
+    commit_compaction_metadata(const compaction_map_t&) override;
 
     ss::future<std::expected<compaction_info_response, errc>>
     get_compaction_info(const compaction_info_spec&) override;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -5035,6 +5035,28 @@ configuration::configuration()
       "in time and blast radius. Lower values mean more, smaller jobs.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1_GiB)
+  , cloud_topics_compaction_commit_interval_bytes(
+      *this,
+      "cloud_topics_compaction_commit_interval_bytes",
+      "Bytes of finished output an L1 compaction job accumulates before "
+      "committing it to the metastore. Commits happen at the next source "
+      "extent boundary once at least this much output is pending. Lower "
+      "values bound the work lost to a failed job and the time committed "
+      "objects spend pre-registered, at the cost of more metastore commits "
+      "and one potentially undersized trailing object per commit.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      512_MiB)
+  , cloud_topics_leveling_commit_interval_bytes(
+      *this,
+      "cloud_topics_leveling_commit_interval_bytes",
+      "Bytes of finished output an L1 leveling job accumulates before "
+      "committing it to the metastore. Commits happen at the next source "
+      "extent boundary once at least this much output is pending. Lower "
+      "values bound the work lost to a failed job and the time committed "
+      "objects spend pre-registered, at the cost of more metastore commits "
+      "and one potentially undersized trailing object per commit.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      512_MiB)
   , cloud_topics_compaction_disabled(
       *this,
       "cloud_topics_compaction_disabled",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -5035,6 +5035,15 @@ configuration::configuration()
       "in time and blast radius. Lower values mean more, smaller jobs.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1_GiB)
+  , cloud_topics_leveling_max_ranges_per_partition(
+      *this,
+      "cloud_topics_leveling_max_ranges_per_partition",
+      "Maximum number of levelable ranges returned per partition by a single "
+      "leveling scan. Bounds the scan reply's size as well as the rate at "
+      "which leveling work is produced along with "
+      "`cloud_topics_leveling_interval_ms`.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      5)
   , cloud_topics_compaction_commit_interval_bytes(
       *this,
       "cloud_topics_compaction_commit_interval_bytes",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -835,6 +835,7 @@ public:
     bounded_property<double, numeric_bounds>
       cloud_topics_leveling_min_extent_size_ratio;
     property<size_t> cloud_topics_leveling_max_range_bytes;
+    property<size_t> cloud_topics_leveling_max_ranges_per_partition;
     property<size_t> cloud_topics_compaction_commit_interval_bytes;
     property<size_t> cloud_topics_leveling_commit_interval_bytes;
     property<bool> cloud_topics_compaction_disabled;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -835,6 +835,8 @@ public:
     bounded_property<double, numeric_bounds>
       cloud_topics_leveling_min_extent_size_ratio;
     property<size_t> cloud_topics_leveling_max_range_bytes;
+    property<size_t> cloud_topics_compaction_commit_interval_bytes;
+    property<size_t> cloud_topics_leveling_commit_interval_bytes;
     property<bool> cloud_topics_compaction_disabled;
     property<bool> cloud_topics_leveling_disabled;
     bounded_property<uint64_t> cloud_topics_compaction_key_map_memory;

--- a/tests/rptest/tests/cloud_topics/compaction_stress_test.py
+++ b/tests/rptest/tests/cloud_topics/compaction_stress_test.py
@@ -382,3 +382,108 @@ class CompactionStressWritePressureTest(CompactionStressBase):
             )
         finally:
             producer.stop()
+
+
+class CompactionPreregistrationTTLTest(CompactionStressBase):
+    """
+    Regression test: a compaction job whose duration exceeds
+    `cloud_topics_preregistered_object_ttl` must still be able to commit.
+
+    A compaction job preregisters its output L1 objects as it creates them,
+    and the metastore GC expires preregistrations older than the TTL. If the
+    job outlives the TTL, its preregistrations are expired mid-flight and
+    every commit is rejected with invalid_request ("object ... not
+    pre-registered"). The job then re-runs for the same duration and fails
+    the same way, forever, so any partition whose compaction takes longer
+    than the TTL livelocks and starves compaction of other partitions.
+
+    We shrink the TTL below the job duration (and speed up the GC that
+    enforces it) and require compaction to make committed progress anyway.
+    """
+
+    TOPIC_NAME = "prereg_ttl_stress"
+    MSG_SIZE = 512
+    # Well below any realistic job duration for this data volume; the GC
+    # enforcing it runs every second.
+    PREREG_TTL_MS = 15_000
+
+    if is_debug_mode():
+        key_set_cardinality = 10_000
+        msg_count = 50_000
+    else:
+        key_set_cardinality = 100_000
+        msg_count = 1_000_000
+
+    def __init__(self, test_context: TestContext):
+        super().__init__(
+            test_context,
+            extra_rp_conf={
+                "cloud_topics_preregistered_object_ttl": self.PREREG_TTL_MS,
+                "cloud_topics_long_term_garbage_collection_interval": 1_000,
+                # Small output objects, source extents, and commit interval
+                # so incremental commits fire frequently: an output object is
+                # preregistered when its builder is created and must be
+                # committed within the TTL, and commits can only happen at
+                # source extent boundaries once a commit interval's worth of
+                # output is pending.
+                "cloud_topics_compaction_max_object_size": 1024 * 1024,
+                "cloud_topics_reconciliation_max_object_size": 8 * 1024 * 1024,
+                "cloud_topics_compaction_commit_interval_bytes": 1024 * 1024,
+                "cloud_topics_leveling_commit_interval_bytes": 1024 * 1024,
+            },
+        )
+
+    def setUp(self):
+        assert self.redpanda
+        self.redpanda.start()
+        self.rpk.create_topic(
+            topic=self.TOPIC_NAME,
+            partitions=1,
+            replicas=3,
+            config={
+                **TopicSpec.storage_mode_config(TopicSpec.STORAGE_MODE_CLOUD),
+                "cleanup.policy": TopicSpec.CLEANUP_COMPACT,
+                "min.cleanable.dirty.ratio": "0.0",
+            },
+        )
+
+    def get_compaction_objects_committed(self) -> float:
+        return self._metric_sum(
+            "vectorized_cloud_topics_compaction_worker_"
+            "compaction_objects_committed_total"
+        )
+
+    @cluster(num_nodes=4)
+    def test_commit_survives_prereg_ttl(self):
+        self.wait_for_managed_logs()
+
+        producer = self.produce_and_wait(
+            topic=self.TOPIC_NAME,
+            msg_size=self.MSG_SIZE,
+            msg_count=self.msg_count,
+            key_set_cardinality=self.key_set_cardinality,
+        )
+
+        # Compaction of this data volume takes far longer than the TTL. If
+        # in-flight preregistrations are not protected from GC expiry, every
+        # commit is rejected and this counter never moves.
+        wait_until(
+            lambda: self.get_compaction_objects_committed() > 0,
+            timeout_sec=600,
+            backoff_sec=10,
+            err_msg=lambda: (
+                "Compaction never committed any objects "
+                f"(committed={self.get_compaction_objects_committed()}, "
+                f"rounds={self.get_log_compactions()}, "
+                f"records_removed={self.get_records_removed()}). "
+                "Check for 'Could not commit' WARNs / 'not pre-registered' "
+                "rejections: compaction jobs outliving "
+                "cloud_topics_preregistered_object_ttl cannot commit."
+            ),
+        )
+
+        self.wait_for_compaction_quiesce()
+        self.consume_and_verify(
+            topic=self.TOPIC_NAME,
+            producer=producer,
+        )


### PR DESCRIPTION

Long compaction jobs previously deferred their entire commit to a single `compact_objects()` at the end of the job. Any object uploaded early had to survive until then: on busy partitions jobs can run for hours while the preregistered-object TTL (default 1h) expires the pending rows, so the final commit was rejected and the job (and every retry) lost all its work. Leveling committed the same way, losing its whole rewrite when fenced by a concurrent compaction.

`l1_object_sink` now commits batches of finished output objects mid-run. Commits may only happen where the replaced intervals align exactly with existing extents, so the sink accumulates output until at least a commit interval's worth is pending and then cuts the inflight object at the source extent boundary in `finish_iteration()`, committing everything finished so far through a new `commit_objects()` hook.

Commit cadence is governed by a new tunable, `cloud_topics_maintenance_commit_interval_bytes` (default 512MiB). Cutting the inflight object at a boundary produces one potentially undersized trailing object per partial commit.

`compaction_sink` implements the hook as a `compact_objects()` carrying the objects and an empty compaction update. The job finishes with a metadata-only commit that records the cleaned ranges and tombstone removals against the epoch its own partial commits advanced. The `min_allowed_local_threshold` floor is advanced only once, before the first partial commit removes any data.

`leveling_sink` implements the hook as `replace_objects()` at the job's pinned epoch.


## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
