### PR TITLE
storage: mark snapshot writer/reader closed regardless of close outcome

### DIFF
--- a/src/v/storage/snapshot.cc
+++ b/src/v/storage/snapshot.cc
@@ -253,12 +253,9 @@ ss::future<iobuf> snapshot_reader::read_metadata() {
 ss::future<size_t> snapshot_reader::get_snapshot_size() { return _file.size(); }
 
 ss::future<> snapshot_reader::close() {
-    return _input
-      .close() // finishes read-ahead work
-      .then([this] {
-          _closed = true;
-          return _file.close();
-      });
+    return _input.close()
+      .finally([this] { return _file.close(); })
+      .finally([this] { _closed = true; });
 }
 
 snapshot_writer::~snapshot_writer() noexcept {
@@ -325,10 +322,7 @@ ss::future<> snapshot_writer::write_metadata(iobuf buf) {
 }
 
 ss::future<> snapshot_writer::close() {
-    return _output.flush().then([this] {
-        _closed = true;
-        return _output.close();
-    });
+    return _output.close().finally([this] { _closed = true; });
 }
 
 ss::future<std::optional<size_t>>

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -390,6 +390,7 @@ redpanda_cc_gtest(
         "//src/v/test_utils:gtest",
         "//src/v/test_utils:random_bytes",
         "@googletest//:gtest",
+        "@seastar",
         "@seastar//:testing",
     ],
 )

--- a/src/v/storage/tests/snapshot_test.cc
+++ b/src/v/storage/tests/snapshot_test.cc
@@ -13,9 +13,47 @@
 #include "test_utils/gtest_exception.h"
 #include "test_utils/random_bytes.h"
 
+#include <seastar/core/iostream.hh>
+#include <seastar/core/temporary_buffer.hh>
+
 #include <gtest/gtest.h>
 
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <string>
+
 using namespace redpanda::test_utils;
+
+namespace {
+
+constexpr const char* injected_sink_error = "injected snapshot sink failure";
+
+// Fails writes/flush (emulating e.g. ENOSPC) but records a successful close.
+class failing_data_sink final : public ss::data_sink_impl {
+public:
+    explicit failing_data_sink(bool& closed) noexcept
+      : _closed(closed) {}
+
+    ss::future<> put(std::span<ss::temporary_buffer<char>>) final {
+        return ss::make_exception_future<>(
+          std::runtime_error(injected_sink_error));
+    }
+    ss::future<> flush() final {
+        return ss::make_exception_future<>(
+          std::runtime_error(injected_sink_error));
+    }
+    ss::future<> close() final {
+        _closed = true;
+        return ss::make_ready_future<>();
+    }
+    size_t buffer_size() const noexcept final { return 4096; }
+
+private:
+    bool& _closed;
+};
+
+} // namespace
 
 TEST(SnapshotTest, MissingSnapshotIsNotError) {
     storage::simple_snapshot_manager mgr(
@@ -173,4 +211,34 @@ TEST(SnapshotTest, RemovePartialSnapshots) {
 
     ASSERT_FALSE(ss::file_exists(p1.string()).get());
     ASSERT_FALSE(ss::file_exists(p2.string()).get());
+}
+
+// Regression test for the ~snapshot_writer vassert(_closed) that used to mask
+// real I/O errors: a snapshot_writer whose underlying stream fails on
+// flush/close must (a) propagate the genuine error to the caller and (b) still
+// satisfy the destructor invariant, so going out of scope after a failed
+// close() does not abort the process. Previously close() set _closed only after
+// a successful flush(), so a flush failure left _closed==false and the
+// destructor aborted, masking the real error (e.g. ENOSPC).
+TEST(SnapshotTest, WriterCloseFailurePropagatesAndMarksClosed) {
+    bool sink_closed = false;
+    {
+        storage::snapshot_writer writer(
+          ss::output_stream<char>(
+            ss::data_sink(std::make_unique<failing_data_sink>(sink_closed))));
+
+        // Buffered; the write only reaches the failing sink at close().
+        writer.write_metadata(iobuf()).get();
+
+        ASSERT_THROWS_WITH_PREDICATE(
+          writer.close().get(),
+          std::runtime_error,
+          [](const std::runtime_error& e) {
+              return std::string(e.what()).find(injected_sink_error)
+                     != std::string::npos;
+          });
+
+        EXPECT_TRUE(sink_closed);
+    }
+    EXPECT_TRUE(sink_closed);
 }


### PR DESCRIPTION
`snapshot_writer::close()` and `snapshot_reader::close()` set `_closed` only
*after* the underlying flush / input-close succeeded. On an I/O failure —
classically ENOSPC, which for a buffered stream only surfaces when `close()`
flushes the last buffered bytes — `_closed` stayed false. The object is then
destroyed during coroutine unwinding and the destructor's `vassert(_closed)`
aborts the process, masking the real error and leaking the fd. Observed as a
`storage/snapshot.cc:265` abort out of
`raft::state_machine_manager::write_initial_recovery_snapshot`, with no log line
naming the actual (disk-full) cause.

Set `_closed` from a `finally()` so the invariant holds once `close()`
completes regardless of I/O outcome: the genuine error still propagates to the
caller, the fd is always released, and a `close()` that was started but never
awaited is still caught.

More context: https://redpandadata.slack.com/archives/C01ND4SVB6Z/p1784548640689519

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes

### Bug Fixes

* Fixed a crash where a snapshot write failing on a full disk (ENOSPC) aborted
  the node with a misleading "snapshot writer has to be closed" assertion
  instead of surfacing the I/O error.
