### PR TITLE
[CORE-16854] `bazel`: point `seastar` at `cde680a9`

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -355,7 +355,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "0jixidnjQWeriRAkguQNUdk9ZcLmay0y7T1ydxy6rmo=",
+        "bzlTransitiveDigest": "Bffna9oLJ/oM7EhVfdyNe1CFGXtT9gf1Uixha+LdI+Q=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedInputs": [
           "REPO_MAPPING:,bazel_tools bazel_tools",
@@ -528,9 +528,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "839be691002102028946214504f0d17e9f01237a0ff6dc5faf219fb1ca59e1eb",
-              "strip_prefix": "seastar-7960dd3c4a9ad6d2f40f533cc2d9aefa179d84cb",
-              "url": "https://github.com/redpanda-data/seastar/archive/7960dd3c4a9ad6d2f40f533cc2d9aefa179d84cb.tar.gz"
+              "sha256": "120bb1711ea5c56124b83556fec3dc85d8edd9b3c0990419b7c8900659a46e5f",
+              "strip_prefix": "seastar-cde680a9c6c3ff290a46f93a7ccea570ee8ccd87",
+              "url": "https://github.com/redpanda-data/seastar/archive/cde680a9c6c3ff290a46f93a7ccea570ee8ccd87.tar.gz"
             }
           },
           "unordered_dense": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -164,9 +164,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "839be691002102028946214504f0d17e9f01237a0ff6dc5faf219fb1ca59e1eb",
-        strip_prefix = "seastar-7960dd3c4a9ad6d2f40f533cc2d9aefa179d84cb",
-        url = "https://github.com/redpanda-data/seastar/archive/7960dd3c4a9ad6d2f40f533cc2d9aefa179d84cb.tar.gz",
+        sha256 = "120bb1711ea5c56124b83556fec3dc85d8edd9b3c0990419b7c8900659a46e5f",
+        strip_prefix = "seastar-cde680a9c6c3ff290a46f93a7ccea570ee8ccd87",
+        url = "https://github.com/redpanda-data/seastar/archive/cde680a9c6c3ff290a46f93a7ccea570ee8ccd87.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Pulls in the seastar fix for `cpu_profiler` crashes when a sample lands during a context switch, along with `chunked_hash_map` from-range utilities.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
