### PR TITLE
tools/antithesis: use ubuntu base for single-binary workload image

### DIFF
--- a/tools/antithesis/single_binary_deps/workload.Dockerfile.j2
+++ b/tools/antithesis/single_binary_deps/workload.Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM debian:12-slim
+FROM public.ecr.aws/docker/library/ubuntu:jammy
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gdb strace ltrace binutils procps \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Swap the single-binary Antithesis package base image from `debian:12-slim`
to `public.ecr.aws/docker/library/ubuntu:jammy`.

This brings the single-binary workload in line with the base image already
used by our other test images (`tests/docker/Dockerfile`, the sysroot
toolchain) and picks up its better vulnerability management. Jammy is the
newest release we can adopt while keeping libc compatible across the
redpanda bundled sysroot, the base image, and the libvoidstar Antithesis
SDK, so a further upgrade is not possible for now.

Refs CORE-16764, CORE-16763.

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none