### PR TITLE
[v26.1.x] `schema_registry`: recovery optimizations

### DIFF
--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -21,7 +21,7 @@
 #include "pandaproxy/schema_registry/compatibility.h"
 #include "pandaproxy/schema_registry/error.h"
 #include "pandaproxy/schema_registry/errors.h"
-#include "pandaproxy/schema_registry/sharded_store.h"
+#include "pandaproxy/schema_registry/schema_getter.h"
 #include "pandaproxy/schema_registry/types.h"
 #include "re2/re2.h"
 #include "utils/to_string.h"
@@ -283,10 +283,11 @@ std::string_view as_string_view(const json::Value& v) {
     return {v.GetString(), v.GetStringLength()};
 }
 
-ss::future<> check_references(sharded_store& store, subject_schema schema) {
+ss::future<> check_references(schema_getter& store, subject_schema schema) {
     for (const auto& ref : schema.def().refs()) {
         auto resolved_sub = ref.sub.resolve(schema.sub().ctx);
-        co_await store.get_id(resolved_sub, ref.version)
+        co_await store
+          .get_subject_schema(resolved_sub, ref.version, include_deleted::yes)
           .discard_result()
           .handle_exception_type([&](const exception& e) {
               if (failed_subject_schema_lookup(e.code())) {
@@ -2592,7 +2593,7 @@ make_json_schema_definition(schema_getter&, subject_schema schema) {
 }
 
 ss::future<subject_schema> make_canonical_json_schema(
-  sharded_store& store, subject_schema unparsed_schema, normalize norm) {
+  schema_getter& store, subject_schema unparsed_schema, normalize norm) {
     auto [sub, unparsed] = std::move(unparsed_schema).destructure();
     auto [def, type, refs, meta] = std::move(unparsed).destructure();
 

--- a/src/v/pandaproxy/schema_registry/json.h
+++ b/src/v/pandaproxy/schema_registry/json.h
@@ -21,7 +21,7 @@ ss::future<json_schema_definition>
 make_json_schema_definition(schema_getter& store, subject_schema schema);
 
 ss::future<subject_schema> make_canonical_json_schema(
-  sharded_store& store, subject_schema def, normalize norm = normalize::no);
+  schema_getter& store, subject_schema def, normalize norm = normalize::no);
 
 compatibility_result check_compatible(
   const json_schema_definition& reader,

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -20,7 +20,7 @@
 #include "pandaproxy/logger.h"
 #include "pandaproxy/schema_registry/compatibility.h"
 #include "pandaproxy/schema_registry/errors.h"
-#include "pandaproxy/schema_registry/sharded_store.h"
+#include "pandaproxy/schema_registry/schema_getter.h"
 #include "pandaproxy/schema_registry/types.h"
 #include "ssx/sformat.h"
 #include "utils/base64.h"
@@ -656,7 +656,7 @@ ss::future<protobuf_schema_definition> make_protobuf_schema_definition(
 }
 
 ss::future<schema_definition> validate_protobuf_schema(
-  sharded_store& store,
+  schema_getter& store,
   subject_schema schema,
   normalize norm,
   output_format format) {
@@ -667,7 +667,7 @@ ss::future<schema_definition> validate_protobuf_schema(
 }
 
 ss::future<subject_schema> make_canonical_protobuf_schema(
-  sharded_store& store,
+  schema_getter& store,
   subject_schema schema,
   normalize norm,
   output_format format) {
@@ -679,7 +679,7 @@ ss::future<subject_schema> make_canonical_protobuf_schema(
 }
 
 ss::future<schema_definition> format_protobuf_schema_definition(
-  sharded_store& store, schema_definition schema, output_format format) {
+  schema_getter& store, schema_definition schema, output_format format) {
     switch (format) {
     case output_format::ignore_extensions:
         throw as_exception(format_not_supported(format));

--- a/src/v/pandaproxy/schema_registry/protobuf.h
+++ b/src/v/pandaproxy/schema_registry/protobuf.h
@@ -24,19 +24,19 @@ ss::future<protobuf_schema_definition> make_protobuf_schema_definition(
   schema_getter& store, subject_schema schema, normalize norm = normalize::no);
 
 ss::future<schema_definition> validate_protobuf_schema(
-  sharded_store& store,
+  schema_getter& store,
   subject_schema schema,
   normalize norm = normalize::no,
   output_format format = output_format::none);
 
 ss::future<subject_schema> make_canonical_protobuf_schema(
-  sharded_store& store,
+  schema_getter& store,
   subject_schema schema,
   normalize norm = normalize::no,
   output_format format = output_format::none);
 
 ss::future<schema_definition> format_protobuf_schema_definition(
-  sharded_store& store, schema_definition schema, output_format format);
+  schema_getter& store, schema_definition schema, output_format format);
 
 compatibility_result check_compatible(
   const protobuf_schema_definition& reader,

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -856,16 +856,28 @@ ss::future<> service::fetch_internal_topic() {
     auto max_offset = offset_res.data.topics[0].partitions[0].offset;
     vlog(srlog.debug, "Schema registry: _schemas max_offset: {}", max_offset);
 
+    using namespace std::chrono_literals;
     const auto defer = defer_processing{
       config::shard_local_cfg().schema_registry_deferred_recovery()};
+    auto replay_start = ss::lowres_clock::now();
     co_await kafka::client::make_client_fetch_batch_reader(
       _client.local(),
       model::schema_registry_internal_tp,
       model::offset{0},
       max_offset)
       .consume(consume_to_store{_store, writer(), defer}, model::no_timeout);
+    auto replay_done = ss::lowres_clock::now();
 
     co_await _store.process_marked_schemas();
+
+    vlog(
+      srlog.info,
+      "Schema registry recovery complete: replayed to offset {} in {}ms "
+      "(deferred={}), canonicalised marked schemas in {}ms",
+      max_offset,
+      (replay_done - replay_start) / 1ms,
+      defer == defer_processing::yes,
+      (ss::lowres_clock::now() - replay_done) / 1ms);
 }
 
 ss::future<> service::validate_topic_creation_authorization() {

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -13,6 +13,7 @@
 
 #include "base/vlog.h"
 #include "config/configuration.h"
+#include "container/chunked_hash_map.h"
 #include "container/chunked_vector.h"
 #include "hashing/jump_consistent_hash.h"
 #include "hashing/xx.h"
@@ -29,6 +30,7 @@
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/loop.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/exception.hh>
@@ -60,6 +62,92 @@ ss::shard_id shard_for(const context_schema_id& id) {
 ss::shard_id shard_for(const context& ctx) {
     auto hash = xxhash_64(ctx().data(), ctx().length());
     return jump_consistent_hash(hash, ss::smp::count);
+}
+
+/// Memoizes reference lookups for the duration of one
+/// process_marked_schemas() pass.
+///
+/// A (subject, version)'s definition is immutable once written, so
+/// serving repeats from a local cache is safe. Marked schemas commonly
+/// share their reference closure (layered proto packages), and without
+/// the cache every compile re-resolves the whole closure with chained
+/// cross-shard lookups.
+class caching_schema_getter final : public schema_getter {
+    // Cached entries share the store-owned definition buffers rather than
+    // copying them, so the cache pins memory (relevant if a definition is
+    // replaced mid-pass) rather than duplicating it, and schemas can be
+    // megabytes - so bound the pinned bytes rather than the entry count,
+    // generously. Reference closures are heavily shared; reset rather
+    // than evict if an unusual corpus overflows the cache.
+    static constexpr size_t max_bytes = 32 * 1024 * 1024;
+
+public:
+    explicit caching_schema_getter(sharded_store& store)
+      : _store{store} {}
+
+    ss::future<stored_schema> get_subject_schema(
+      context_subject sub,
+      std::optional<schema_version> version,
+      include_deleted inc_del) override {
+        if (!version.has_value()) {
+            // "latest" is not a stable key; don't cache it.
+            co_return co_await _store.get_subject_schema(
+              std::move(sub), version, inc_del);
+        }
+        auto key = subject_version{sub, *version};
+        if (auto it = _cache.find(key); it != _cache.end()) {
+            if (inc_del == include_deleted::no && it->second.deleted) {
+                // A cached soft-deleted entry can't answer an
+                // inc_del::no lookup; let the store produce its
+                // canonical error.
+                co_return co_await _store.get_subject_schema(
+                  std::move(sub), version, inc_del);
+            }
+            co_return it->second.share();
+        }
+        auto schema = co_await _store.get_subject_schema(
+          std::move(sub), version, inc_del);
+        auto size = schema.schema.def().raw()().size_bytes();
+        if (_cached_bytes + size >= max_bytes) {
+            _cache.clear();
+            _cached_bytes = 0;
+        }
+        if (_cache.emplace(std::move(key), schema.share()).second) {
+            _cached_bytes += size;
+        }
+        co_return schema;
+    }
+
+    ss::future<schema_definition>
+    get_schema_definition(context_schema_id id) override {
+        return _store.get_schema_definition(id);
+    }
+
+    ss::future<std::optional<schema_definition>>
+    maybe_get_schema_definition(context_schema_id id) override {
+        return _store.maybe_get_schema_definition(id);
+    }
+
+private:
+    sharded_store& _store;
+    chunked_hash_map<subject_version, stored_schema> _cache;
+    size_t _cached_bytes{0};
+};
+
+ss::future<subject_schema>
+make_canonical_with(schema_getter& getter, subject_schema schema) {
+    switch (schema.type()) {
+    case schema_type::avro:
+        co_return co_await make_canonical_avro_schema(
+          getter, std::move(schema));
+    case schema_type::protobuf:
+        co_return co_await make_canonical_protobuf_schema(
+          getter, std::move(schema));
+    case schema_type::json:
+        co_return co_await make_canonical_json_schema(
+          getter, std::move(schema));
+    }
+    __builtin_unreachable();
 }
 
 compatibility_result check_compatible(
@@ -232,38 +320,46 @@ ss::future<bool> sharded_store::upsert(
 }
 
 ss::future<> sharded_store::process_marked_schemas() {
+    // Bound the number of in-flight canonicalisations per shard: enough to
+    // hide the latency of cross-shard reference lookups without holding
+    // many partially-built descriptor sets in memory at once.
+    constexpr size_t max_concurrency = 8;
     return _store.invoke_on_all([this](store& store) {
         return ss::do_with(
-          store.extract_marked_schemas(), [this, &store](auto& marked) {
-              return ss::do_for_each(marked, [this, &store](auto id) {
-                  auto schema = store.get_schema_definition(id);
-                  if (schema.has_failure()) {
-                      // schema not found, ignore
-                      return ss::now();
-                  }
-                  return make_canonical_schema(
-                           {context_subject{id.ctx, subject{}},
-                            std::move(schema).assume_value()},
-                           normalize::no,
-                           false)
-                    .then([id, &store](auto canonical) {
-                        // Update the stored form of this schema to its
-                        // canonical form
-                        auto [sub, schema] = std::move(canonical).destructure();
-                        store.upsert_schema(id, std::move(schema), false);
-                    })
-                    .handle_exception([id](const std::exception_ptr& ep) {
-                        // processing attempt failed on marked schema. This is
-                        // not an issue of forward references. Ignore error and
-                        // keep schema in the store as-is
-                        vlog(
-                          srlog.debug,
-                          "process_marked_schemas failed for ctx={} id={}: {}",
-                          id.ctx,
-                          id.id,
-                          ep);
-                    });
-              });
+          store.extract_marked_schemas(),
+          caching_schema_getter{*this},
+          [&store](auto& marked, auto& getter) {
+              return ss::max_concurrent_for_each(
+                marked, max_concurrency, [&store, &getter](auto id) {
+                    auto schema = store.get_schema_definition(id);
+                    if (schema.has_failure()) {
+                        // schema not found, ignore
+                        return ss::now();
+                    }
+                    return make_canonical_with(
+                             getter,
+                             {context_subject{id.ctx, subject{}},
+                              std::move(schema).assume_value()})
+                      .then([id, &store](auto canonical) {
+                          // Update the stored form of this schema to its
+                          // canonical form
+                          auto [sub, schema]
+                            = std::move(canonical).destructure();
+                          store.upsert_schema(id, std::move(schema), false);
+                      })
+                      .handle_exception([id](const std::exception_ptr& ep) {
+                          // processing attempt failed on marked schema. This
+                          // is not an issue of forward references. Ignore
+                          // error and keep schema in the store as-is
+                          vlog(
+                            srlog.debug,
+                            "process_marked_schemas failed for ctx={} id={}: "
+                            "{}",
+                            id.ctx,
+                            id.id,
+                            ep);
+                      });
+                });
           });
     });
 }

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -590,6 +590,14 @@ struct subject_version {
       , version{v} {}
     context_subject sub;
     schema_version version;
+
+    friend bool
+    operator==(const subject_version&, const subject_version&) = default;
+
+    template<typename H>
+    friend H AbslHashValue(H h, const subject_version& sv) {
+        return H::combine(std::move(h), sv.sub, sv.version);
+    }
 };
 
 // Very similar to topic_key_type, separate to avoid intermingling storage code


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31141

- Command: git cherry-pick -x 033444fc8b 58e6714b72 7bb1446d8d
- Commits backported: 3
- Conflicts resolved: 2
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-31141-v26.1.x-1784571959

## Conflict details

- 033444fc8b (src/v/pandaproxy/schema_registry/test/BUILD): the commit added the `recovery_rpbench` bench; the surrounding context on dev included a `rpc_transport_test` gtest that does not exist on v26.1.x. Added only the `recovery_rpbench` target and dropped the unrelated `rpc_transport_test` block. Adapted its deps to the target branch's coarser BUILD layout: dev's `:seq_writer` and `:store` targets are consolidated into `:core` on v26.1.x, so both were replaced with a single `:core` dep (`:types` kept as-is).
- 58e6714b72 (src/v/pandaproxy/schema_registry/service.cc): the commit wraps the recovery replay with timing instrumentation. dev replays via `_transport->consume_range(...)` whereas v26.1.x still uses `make_client_fetch_batch_reader(...).consume(...)`. Kept the target branch's replay call and wrapped it with the `replay_start`/`replay_done` timers the added `vlog` consumes.
