### PR TITLE
`ct/l1`: hold back undersized tail ranges from leveling

### DIFF
--- a/src/v/cloud_topics/level_one/maintenance/leveling/tests/leveling_reducer_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/leveling/tests/leveling_reducer_test.cc
@@ -135,13 +135,12 @@ protected:
         return count;
     }
 
-    // Returns leveling info for `tidp`, treating all objects as undersized.
-    l1::metastore::leveling_info_response
-    get_all_leveling_info(const model::topic_id_partition& tidp) {
+    // Returns leveling info for `tidp`.
+    l1::metastore::leveling_info_response get_all_leveling_info(
+      const model::topic_id_partition& tidp, size_t min_acceptable_bytes) {
         chunked_vector<l1::metastore::leveling_info_spec> specs;
         specs.push_back(
-          {.tidp = tidp,
-           .min_acceptable_extent_bytes = std::numeric_limits<size_t>::max()});
+          {.tidp = tidp, .min_acceptable_extent_bytes = min_acceptable_bytes});
         auto result = _metastore.get_leveling_infos(specs).get();
         EXPECT_TRUE(result.has_value()) << "get_leveling_infos failed";
         auto it = result->find(tidp);
@@ -150,21 +149,26 @@ protected:
         return std::move(it->second.value());
     }
 
-    // Produces `num_batches` random batches and uploads them as a single L1
-    // object for `tidp`, starting at `base_offset`.
+    // Produces `num_batches` batches of `records_per_batch` fixed-size
+    // (1 KiB) records and uploads them as a single L1 object for `tidp`,
+    // starting at `base_offset`.
     void upload_batches(
       const model::topic_id_partition& tidp,
       model::offset base_offset,
       int num_batches,
-      int records_per_batch = 10,
-      bool allow_compression = false) {
-        auto batches = model::test::make_random_batches(
-                         base_offset,
-                         num_batches,
-                         allow_compression,
-                         std::nullopt,
-                         records_per_batch)
-                         .get();
+      int records_per_batch = 10) {
+        chunked_circular_buffer<model::record_batch> batches;
+        auto offset = base_offset;
+        for (int i = 0; i < num_batches; ++i) {
+            model::test::record_batch_spec spec;
+            spec.offset = offset;
+            spec.allow_compression = false;
+            spec.count = records_per_batch;
+            spec.record_sizes = std::vector<size_t>(records_per_batch, 1024);
+            auto b = model::test::make_random_batch(spec);
+            offset = model::next_offset(b.last_offset());
+            batches.push_back(std::move(b));
+        }
         std::vector<tidp_batches_t> tidp_batches;
         tidp_batches.emplace_back(tidp, std::move(batches));
         make_l1_objects(std::move(tidp_batches)).get();
@@ -195,7 +199,9 @@ TEST_F(LevelingReducerTest, RewritesLevelableRange) {
     auto extents_before = count_extents(tidp);
     ASSERT_EQ(extents_before, static_cast<size_t>(num_extents));
 
-    auto leveling_info = get_all_leveling_info(tidp);
+    // Each extent is ~55 KiB (50 framed 1 KiB records), ~220 KiB in total:
+    // all four are undersized and the run's total clears the threshold.
+    auto leveling_info = get_all_leveling_info(tidp, 100_KiB);
     ASSERT_FALSE(leveling_info.ranges.empty());
 
     do_level(
@@ -236,7 +242,9 @@ TEST_F(LevelingReducerTest, PreservesBatchData) {
     auto orig_batches = read_all(std::move(orig_reader));
     ASSERT_GT(orig_batches.size(), 0);
 
-    auto leveling_info = get_all_leveling_info(tidp);
+    // Each extent is ~56 KiB (50 framed 1 KiB records), ~170 KiB in total:
+    // all three are undersized and the run's total clears the threshold.
+    auto leveling_info = get_all_leveling_info(tidp, 100_KiB);
     ASSERT_FALSE(leveling_info.ranges.empty());
 
     do_level(
@@ -280,7 +288,9 @@ TEST_F(LevelingReducerTest, HardStopPreempts) {
     auto extents_before = count_extents(tidp);
     ASSERT_EQ(extents_before, 2);
 
-    auto leveling_info = get_all_leveling_info(tidp);
+    // Each extent is ~55 KiB (50 framed 1 KiB records), ~110 KiB in total:
+    // both are undersized and the run's total clears the threshold.
+    auto leveling_info = get_all_leveling_info(tidp, 80_KiB);
     ASSERT_FALSE(leveling_info.ranges.empty());
 
     // Run leveling with state set to hard_stop from the start.
@@ -562,13 +572,23 @@ INSTANTIATE_TEST_SUITE_P(
       .target_bytes = 100_KiB,
       .expected_shape_bytes = {100_KiB, 100_KiB, 100_KiB},
     },
-    // All small: consolidated into one tiny object.
+    // All small, but the run is the partition's tail and its total (~6 KiB)
+    // can't fill a healthy output object yet: held back, layout unchanged.
     test_case{
-      .name = "AllSmall",
+      .name = "AllSmallTailHeldBack",
       .object_sizes_bytes = {2_KiB, 2_KiB, 2_KiB},
       .min_acceptable_bytes = 50_KiB,
       .target_bytes = 100_KiB,
-      .expected_shape_bytes = {6_KiB},
+      .expected_shape_bytes = {2_KiB, 2_KiB, 2_KiB},
+    },
+    // All small and the tail run's total (~60 KiB) reaches min_acceptable:
+    // consolidated into one healthy object.
+    test_case{
+      .name = "AllSmallTailCommits",
+      .object_sizes_bytes = {20_KiB, 20_KiB, 20_KiB},
+      .min_acceptable_bytes = 50_KiB,
+      .target_bytes = 100_KiB,
+      .expected_shape_bytes = {60_KiB},
     },
     // Isolated small with no rewrite savings: range discarded, partition
     // unchanged.
@@ -635,17 +655,18 @@ INSTANTIATE_TEST_SUITE_P(
       .target_bytes = 100_KiB,
       .expected_shape_bytes = {100_KiB, 100_KiB, 2_KiB},
     },
-    // Long run of small extents (30 of them, 1 KiB each). Each upload
+    // Long run of small extents (60 of them, 1 KiB each). Each upload
     // becomes one 1-batch L1 object. After consolidation, the new object
-    // holds 30 batches — per-batch framing overhead accumulates to about
-    // 250 B * 30 ~= 7 KiB on top of the ~30 KiB of record data. Verifies
-    // the sink correctly consolidates a high batch-count range.
+    // holds 60 batches — per-batch framing overhead accumulates to about
+    // 250 B * 60 ~= 15 KiB on top of the ~60 KiB of record data (also
+    // pushing the tail run's total past min_acceptable so it commits).
+    // Verifies the sink correctly consolidates a high batch-count range.
     test_case{
       .name = "LongRunOfSmalls",
-      .object_sizes_bytes = std::vector<size_t>(30, 1_KiB),
+      .object_sizes_bytes = std::vector<size_t>(60, 1_KiB),
       .min_acceptable_bytes = 50_KiB,
       .target_bytes = 100_KiB,
-      .expected_shape_bytes = {37_KiB},
+      .expected_shape_bytes = {75_KiB},
     },
     // Three consecutive smalls of varying sizes (2K, 15K, 30K — all under
     // 50K min_acceptable) form a K=3 run, closed by the trailing healthy

--- a/src/v/cloud_topics/level_one/maintenance/tests/BUILD
+++ b/src/v/cloud_topics/level_one/maintenance/tests/BUILD
@@ -65,6 +65,7 @@ redpanda_cc_gtest(
         "//src/v/model",
         "//src/v/model/tests:random",
         "//src/v/test_utils:gtest",
+        "//src/v/test_utils:scoped_config",
         "@googletest//:gtest",
         "@seastar",
     ],

--- a/src/v/cloud_topics/level_one/maintenance/tests/log_info_collector_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/tests/log_info_collector_test.cc
@@ -18,6 +18,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/tests/random_batch.h"
+#include "test_utils/scoped_config.h"
 
 #include <gtest/gtest.h>
 
@@ -54,19 +55,42 @@ void drain_and_mark_inflight(l1::leveling_queue& queue) {
 
 class LogInfoCollectorTestFixture : public l1::l1_reader_fixture {
 protected:
+    LogInfoCollectorTestFixture() {
+        // Pin the leveling threshold: min_acceptable = 40 KiB * 0.5 (the
+        // default min-extent-size ratio) = 20 KiB, so each ~13 KiB object
+        // seeded below is undersized, while a run of two or more totals past
+        // the threshold a tail run must reach to be committed as a range.
+        _cfg.get("cloud_topics_reconciliation_max_object_size")
+          .set_value(size_t{40_KiB});
+    }
+
     // Builds `n` separate small (undersized) L1 objects for `tidp`, each from
     // its own batch run, so they form a run of consecutive undersized extents
-    // that the leveling range builder will coalesce into a range.
+    // that the leveling range builder will coalesce into a range. Each object
+    // holds ten single-record ~1 KiB batches; the fixed record size keeps
+    // extent sizes deterministic (~13 KiB) relative to the threshold pinned
+    // in the constructor.
     void seed_undersized_objects(const model::topic_id_partition& tidp, int n) {
         model::offset o{0};
         for (int i = 0; i < n; ++i) {
-            auto batches = model::test::make_random_batches(o, 10).get();
-            o = model::next_offset(batches.back().last_offset());
+            chunked_circular_buffer<model::record_batch> batches;
+            for (int b = 0; b < 10; ++b) {
+                model::test::record_batch_spec spec;
+                spec.offset = o;
+                spec.allow_compression = false;
+                spec.count = 1;
+                spec.record_sizes = std::vector<size_t>{1024};
+                auto batch = model::test::make_random_batch(spec);
+                o = model::next_offset(batch.last_offset());
+                batches.push_back(std::move(batch));
+            }
             std::vector<tidp_batches_t> bs;
             bs.emplace_back(tidp, std::move(batches));
             make_l1_objects(std::move(bs)).get();
         }
     }
+
+    scoped_config _cfg;
 };
 
 // A fake topic config provider which always returns a value. The config is
@@ -146,27 +170,13 @@ TEST_F(LogInfoCollectorTestFixture, TestSampleLevelingInfo) {
     auto [ntp, tidp] = make_ntidp("leveling_topic");
     auto log_ptr = ss::make_lw_shared<l1::log_compaction_meta>(tidp, ntp);
 
-    // Seed the metastore with two small objects for this partition. With the
-    // default config (max_object_size=80MiB, threshold=0.5 =>
-    // min_acceptable=40MiB), each object is undersized. The leveling range
-    // builder only emits a range when it sees a run of *two or more*
-    // consecutive undersized extents (singletons can't reduce extent count),
-    // so we need at least two objects to produce a non-empty range.
-    model::offset o{0};
-    {
-        auto batches = model::test::make_random_batches(o, 10).get();
-        o = model::next_offset(batches.back().last_offset());
-        std::vector<tidp_batches_t> bs;
-        bs.emplace_back(tidp, std::move(batches));
-        make_l1_objects(std::move(bs)).get();
-    }
-
-    {
-        auto batches = model::test::make_random_batches(o, 10).get();
-        std::vector<tidp_batches_t> bs;
-        bs.emplace_back(tidp, std::move(batches));
-        make_l1_objects(std::move(bs)).get();
-    }
+    // Seed the metastore with two small objects for this partition; each is
+    // undersized relative to the threshold pinned in the fixture. The
+    // leveling range builder only emits a range when it sees a run of *two
+    // or more* consecutive undersized extents (singletons can't reduce
+    // extent count) whose total clears the tail-run threshold, so we need at
+    // least two objects to produce a non-empty range.
+    seed_undersized_objects(tidp, 2);
 
     l1::log_set_t logs_set;
     auto [it, inserted] = logs_set.insert(log_ptr);

--- a/src/v/cloud_topics/level_one/metastore/leveling_range_builder.h
+++ b/src/v/cloud_topics/level_one/metastore/leveling_range_builder.h
@@ -15,6 +15,8 @@
 #include "serde/envelope.h"
 #include "serde/rw/envelope.h"
 
+#include <seastar/util/bool_class.hh>
+
 #include <fmt/core.h>
 
 #include <optional>
@@ -55,8 +57,8 @@ struct levelable_range
 // is considered undersized when its length is strictly less than
 // `min_acceptable_extent_bytes`.
 //
-// We only consider rewriting a *run* of consecutive undersized extents.
-// Healthy extents close the active run. We never include a healthy extent in
+// We only consider rewriting a *range* of consecutive undersized extents.
+// Healthy extents close the active range. We never include a healthy extent in
 // a leveling range, as those have per-byte rewrite cost without corresponding
 // extent-count savings.
 //
@@ -69,7 +71,14 @@ struct levelable_range
 //     minutes, and can be soft-stopped at coarse-grained boundaries without
 //     wasting hours of upload work.
 //   - On close: commit the range only if it contains more than one
-//     extent (K > 1), as singleton runs can't reduce extent count.
+//     extent (K > 1), as singleton ranges can't reduce extent count.
+//   - The range still open when the extents run out is the partition's tail;
+//     unlike a range closed by a healthy extent, it keeps growing as new data
+//     is reconciled. It is only committed once its total reaches
+//     `min_acceptable_extent_bytes`, so that its output is itself a healthy
+//     extent. Rewriting it earlier would produce yet another undersized
+//     extent that gets re-leveled on every pass as new small extents land
+//     behind it — quadratic write amplification at low produce rates.
 class leveling_range_builder {
 public:
     explicit leveling_range_builder(size_t min_acceptable_extent_bytes)
@@ -80,8 +89,8 @@ public:
     // Processes a single extent.
     void process_extent(kafka::offset base, kafka::offset last, size_t len) {
         if (len >= _min_acceptable_extent_bytes) {
-            // A healthy extent closes any active run.
-            maybe_commit_range();
+            // A healthy extent closes any active range.
+            maybe_commit_range(is_tail_range::no);
             return;
         }
         if (!_range.has_value()) {
@@ -94,14 +103,14 @@ public:
 
         // Cap per-range bytes so each leveling job stays bounded.
         if (_range->bytes >= _max_acceptable_range_bytes) {
-            maybe_commit_range();
+            maybe_commit_range(is_tail_range::no);
         }
     }
 
     // Commit any pending range and return the accumulated ranges. Must
     // be called after all extents have been processed.
     chunked_vector<levelable_range> finalize() && {
-        maybe_commit_range();
+        maybe_commit_range(is_tail_range::yes);
         return std::move(_ranges);
     }
 
@@ -113,11 +122,19 @@ private:
         size_t extent_count;
     };
 
-    void maybe_commit_range() {
+    using is_tail_range = ss::bool_class<struct is_tail_range_tag>;
+
+    void maybe_commit_range(is_tail_range tail) {
         if (!_range.has_value()) {
             return;
         }
-        if (_range->extent_count > 1) {
+        // The tail range keeps growing as new data is reconciled; hold it
+        // back until leveling it can produce a healthy output extent (see
+        // class comment).
+        const bool undersized_tail = tail == is_tail_range::yes
+                                     && _range->bytes
+                                          < _min_acceptable_extent_bytes;
+        if (_range->extent_count > 1 && !undersized_tail) {
             _ranges.push_back(
               levelable_range{
                 .base_offset = _range->base,

--- a/src/v/cloud_topics/level_one/metastore/tests/leveling_range_builder_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/leveling_range_builder_test.cc
@@ -140,15 +140,55 @@ INSTANTIATE_TEST_SUITE_P(
       .min_acceptable = 50,
       .expected_ranges = {},
     },
-    // All extents undersized: one range covers everything, rewritten as
-    // one tiny object.
+    // All extents undersized, but the run is the partition's tail and its
+    // total (6) can't fill a healthy output extent yet. Held back: leveling
+    // it now would produce another undersized extent that snowballs.
     test_case{
-      .name = "AllSmall",
+      .name = "AllSmallTailHeldBack",
       .extents = {{0_o, 9_o, 2},
                   {10_o, 19_o, 2},
                   {20_o, 29_o, 2}},
       .min_acceptable = 50,
-      .expected_ranges = {{.base_offset = 0_o, .last_offset = 29_o, .size_bytes = 6, .extent_count = 3}},
+      .expected_ranges = {},
+    },
+    // All extents undersized and the tail run's total (60) reaches
+    // min_acceptable: leveling can produce a healthy output extent, so the
+    // range commits.
+    test_case{
+      .name = "AllSmallTailCommits",
+      .extents = {{0_o, 9_o, 20},
+                  {10_o, 19_o, 20},
+                  {20_o, 29_o, 20}},
+      .min_acceptable = 50,
+      .expected_ranges = {{.base_offset = 0_o, .last_offset = 29_o, .size_bytes = 60, .extent_count = 3}},
+    },
+    // Boundary: tail run total exactly at min_acceptable commits (the
+    // check is `>=`).
+    test_case{
+      .name = "TailExactlyAtMinAcceptableCommits",
+      .extents = {{0_o, 9_o, 25},
+                  {10_o, 19_o, 25}},
+      .min_acceptable = 50,
+      .expected_ranges = {{.base_offset = 0_o, .last_offset = 19_o, .size_bytes = 50, .extent_count = 2}},
+    },
+    // Boundary: tail run total one byte below min_acceptable is held back.
+    test_case{
+      .name = "TailJustBelowMinAcceptableHeldBack",
+      .extents = {{0_o, 9_o, 25},
+                  {10_o, 19_o, 24}},
+      .min_acceptable = 50,
+      .expected_ranges = {},
+    },
+    // An enclosed run (closed by a healthy extent) commits regardless of
+    // its total: it can never grow, so holding it back would strand it
+    // fragmented forever, while one rewrite collapses it for good.
+    test_case{
+      .name = "EnclosedRunBelowMinAcceptableCommits",
+      .extents = {{0_o, 9_o, 2},
+                  {10_o, 19_o, 2},
+                  {20_o, 29_o, 100}},
+      .min_acceptable = 50,
+      .expected_ranges = {{.base_offset = 0_o, .last_offset = 19_o, .size_bytes = 4, .extent_count = 2}},
     },
     // Leading healthies are no-ops (no active range to close). Range
     // opens at obj 2, extends to obj 3, and closes on the trailing

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -1310,11 +1310,18 @@ TEST_P(ReplicatedMetastoreTest, TestGetLevelingInfo) {
        .object_sizes = {100, 2, 100, 100, 2, 100},
        .min_acceptable = 50,
        .expected_ranges = {}},
-      {.name = "AllSmall",
+      {// The all-undersized run is the partition's tail and its total (6)
+       // can't fill a healthy output extent yet, so it is held back.
+       .name = "AllSmallTailHeldBack",
        .object_sizes = {2, 2, 2},
        .min_acceptable = 50,
+       .expected_ranges = {}},
+      {// The tail run's total (60) reaches min_acceptable, so it commits.
+       .name = "AllSmallTailCommits",
+       .object_sizes = {20, 20, 20},
+       .min_acceptable = 50,
        .expected_ranges
-       = {{.base_offset = o{0}, .last_offset = o{29}, .size_bytes = 6, .extent_count = 3}}},
+       = {{.base_offset = o{0}, .last_offset = o{29}, .size_bytes = 60, .extent_count = 3}}},
       {.name = "LeadingHealthyExtentsUntouched",
        .object_sizes = {100, 100, 2, 2, 100},
        .min_acceptable = 50,

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -2902,14 +2902,23 @@ INSTANTIATE_TEST_SUITE_P(
       .min_acceptable = 50,
       .expected_ranges = {},
     },
-    // All extents undersized. Rewrites cleanly into a single 6-byte
-    // object, 3 extents become 1, saving 2.
+    // All extents undersized, but the run is the partition's tail and its
+    // total (6) can't fill a healthy output extent yet. Held back so its
+    // rewrite doesn't just produce another undersized extent.
     leveling_case{
-      .name = "AllSmall",
+      .name = "AllSmallTailHeldBack",
       .object_sizes = {2, 2, 2},
       .min_acceptable = 50,
+      .expected_ranges = {},
+    },
+    // All extents undersized and the tail run's total (60) reaches
+    // min_acceptable, so the range commits.
+    leveling_case{
+      .name = "AllSmallTailCommits",
+      .object_sizes = {20, 20, 20},
+      .min_acceptable = 50,
       .expected_ranges
-      = {{.base_offset = 0_o, .last_offset = 29_o, .size_bytes = 6, .extent_count = 3}},
+      = {{.base_offset = 0_o, .last_offset = 29_o, .size_bytes = 60, .extent_count = 3}},
     },
     // Leading healthies are no-ops (no active range to close). Range
     // opens at obj 2, extends to obj 3, and closes on the trailing

--- a/tests/rptest/tests/cloud_topics/e2e_test.py
+++ b/tests/rptest/tests/cloud_topics/e2e_test.py
@@ -359,6 +359,13 @@ class EndToEndCloudTopicsBase(EndToEndTest):
         extents that have no foldable neighbour — a lone small extent between
         two ~`max_target_size` extents cannot be merged without exceeding the
         cap. Those are an expected, irreducible outcome, not a leveling defect.
+
+        The partition's tail run — the trailing consecutive undersized
+        extents — is likewise exempt while its combined size is below the
+        undersized threshold: leveling deliberately holds it back until its
+        rewrite can produce a healthy extent, since folding it earlier would
+        just emit another undersized extent that snowballs as new data lands
+        behind it.
         """
         by_partition = ct_utils.get_l1_extent_lengths_by_partition(
             self.admin, topic=topic
@@ -383,7 +390,19 @@ class EndToEndCloudTopicsBase(EndToEndTest):
                 f"{max_target_size}B soft cap): {oversized}"
             )
 
+            # Locate the tail run (trailing consecutive undersized extents).
+            # If its combined size cannot yet fill a healthy extent, leveling
+            # holds it back on purpose; exempt pairs within it.
+            tail_start = len(lengths)
+            while tail_start > 0 and lengths[tail_start - 1] < min_healthy:
+                tail_start -= 1
+            if sum(lengths[tail_start:]) >= min_healthy:
+                # The tail run is big enough to level; no exemption.
+                tail_start = len(lengths)
+
             for i in range(len(lengths) - 1):
+                if i >= tail_start:
+                    continue
                 a, b = lengths[i], lengths[i + 1]
                 foldable = (
                     a < min_healthy and b < min_healthy and a + b <= max_target_size


### PR DESCRIPTION
A leveled output smaller than `min_acceptable_extent_bytes` is itself still undersized, so as soon as reconciliation appends the next small extent behind it the pair forms a new levelable range and the whole suffix is rewritten again. At low per-partition produce rates, this leads to write amplification.

Hold the undersized tail range back until its total reaches `min_acceptable_extent_bytes`, so that its rewrite always produces a healthy extent.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
