### PR TITLE
[v25.3.x] admin/controller: expose raft0 cancel_reconfiguration

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -1257,6 +1257,34 @@ ss::future<std::error_code> controller::cancel_raft0_reconfiguration() {
           _raft0->config().revision_id());
     });
 }
+
+ss::future<std::error_code>
+controller::force_raft0_reconfiguration(std::vector<model::node_id> replicas) {
+    return ss::smp::submit_to(
+      controller_stm_shard, [this, replicas = std::move(replicas)]() mutable {
+          if (!_raft0->is_elected_leader()) {
+              return ss::make_ready_future<std::error_code>(
+                make_error_code(errc::not_leader));
+          }
+          std::vector<raft::vnode> voters;
+          voters.reserve(replicas.size());
+          for (auto id : replicas) {
+              // raft0 vnodes always carry revision 0.
+              voters.emplace_back(id, model::revision_id{0});
+          }
+          vlog(
+            clusterlog.warn,
+            "Forcing controller (raft0) reconfiguration to {}",
+            replicas);
+          // Bump the revision past the current log tail so the members backend
+          // treats any raft0 update enqueued behind the wedge as stale and
+          // drops it.
+          return _raft0->force_replace_configuration_replicated(
+            std::move(voters),
+            {},
+            model::revision_id(model::next_offset(_raft0->dirty_offset())));
+      });
+}
 /**
  * Validate that:
  * - node_id never changes

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -1241,6 +1241,22 @@ controller::do_get_controller_partition_state(model::node_id target_node) {
             .then(&rpc::get_ctx_data<partition_state_reply>);
       });
 }
+
+ss::future<std::error_code> controller::cancel_raft0_reconfiguration() {
+    return ss::smp::submit_to(controller_stm_shard, [this] {
+        if (!_raft0->is_elected_leader()) {
+            return ss::make_ready_future<std::error_code>(
+              make_error_code(errc::not_leader));
+        }
+        vlog(
+          clusterlog.info,
+          "Requesting cancellation of controller (raft0) reconfiguration");
+        // Cancel with the revision of the config being cancelled; if it gets
+        // bumped, another completely unrelated config change can get skipped.
+        return _raft0->cancel_configuration_change(
+          _raft0->config().revision_id());
+    });
+}
 /**
  * Validate that:
  * - node_id never changes

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -283,6 +283,12 @@ public:
 
     ss::future<std::error_code> cancel_raft0_reconfiguration();
 
+    /// Force the controller (raft0) configuration to the given replica set,
+    /// superseding any in-flight or enqueued reconfiguration. An operator
+    /// escape hatch for a wedged controller; unclean by design.
+    ss::future<std::error_code>
+    force_raft0_reconfiguration(std::vector<model::node_id> replicas);
+
     static bytes invariants_key();
 
     ss::future<cluster::error_info>

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -281,6 +281,8 @@ public:
     ss::future<result<partition_state_reply>>
     do_get_controller_partition_state(model::node_id id);
 
+    ss::future<std::error_code> cancel_raft0_reconfiguration();
+
     static bytes invariants_key();
 
     ss::future<cluster::error_info>

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1324,6 +1324,7 @@ consensus::interrupt_configuration_change(model::revision_id revision, Func f) {
 
 ss::future<std::error_code>
 consensus::cancel_configuration_change(model::revision_id revision) {
+    auto holder = _bg.hold();
     vlog(
       _ctxlog.info,
       "requested cancellation of current configuration change - {}",
@@ -1371,7 +1372,8 @@ consensus::cancel_configuration_change(model::revision_id revision) {
               }
           }
           return ss::make_ready_future<std::error_code>(ec);
-      });
+      })
+      .finally([holder = std::move(holder)] {});
 }
 
 ss::future<std::error_code>
@@ -1451,6 +1453,7 @@ ss::future<std::error_code> consensus::force_replace_configuration_replicated(
   std::vector<vnode> voters,
   std::vector<vnode> learners,
   model::revision_id new_revision) {
+    auto holder = _bg.hold();
     auto u = co_await acquire_op_lock_units();
     if (!u) {
         co_return u.error();

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -58,6 +58,7 @@
 #include <algorithm>
 #include <chrono>
 #include <exception>
+#include <expected>
 #include <iterator>
 #include <optional>
 #include <ranges>
@@ -1431,6 +1432,60 @@ ss::future<std::error_code> consensus::force_replace_configuration_locally(
         co_return errc::shutting_down;
     }
     co_return errc::success;
+}
+
+ss::future<std::expected<ssx::semaphore_units, std::error_code>>
+consensus::acquire_op_lock_units() {
+    return _op_lock.get_units()
+      .then([](ssx::semaphore_units u) {
+          return std::expected<ssx::semaphore_units, std::error_code>(
+            std::move(u));
+      })
+      .handle_exception_type([](const ss::broken_semaphore&) {
+          return std::expected<ssx::semaphore_units, std::error_code>(
+            std::unexpected(make_error_code(errc::shutting_down)));
+      });
+}
+
+ss::future<std::error_code> consensus::force_replace_configuration_replicated(
+  std::vector<vnode> voters,
+  std::vector<vnode> learners,
+  model::revision_id new_revision) {
+    auto u = co_await acquire_op_lock_units();
+    if (!u) {
+        co_return u.error();
+    }
+    if (!is_elected_leader()) {
+        co_return errc::not_leader;
+    }
+    // Deliberately skip the configuration_change_in_progress guard used by
+    // change_configuration: this replaces whatever configuration is current,
+    // including an in-flight one, by replicating a fresh configuration.
+    auto new_cfg = group_configuration(
+      std::move(voters), std::move(learners), new_revision);
+    vlog(
+      _ctxlog.info,
+      "Force replacing configuration (replicated) with: {}",
+      new_cfg);
+    // If this node is replicating a configuration that removes itself from the
+    // voter set, it must step down once the configuration is replicated so a
+    // remaining voter can take over leadership.
+    const bool self_removed = !new_cfg.is_voter(_self);
+    auto ec = co_await replicate_configuration(
+      std::move(u.value()), std::move(new_cfg));
+    if (ec || !self_removed) {
+        co_return ec;
+    }
+    auto units = co_await acquire_op_lock_units();
+    if (!units) {
+        co_return units.error();
+    }
+    vlog(
+      _ctxlog.info,
+      "Stepping down: forced reconfiguration removed this node from the voter "
+      "set");
+    do_step_down("forced-reconfiguration-self-removed");
+    co_return ec;
 }
 
 void consensus::try_updating_configuration_version(group_configuration& cfg) {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -3175,6 +3175,7 @@ consensus::next_followers_request_seq() {
 }
 
 ss::future<> consensus::refresh_commit_index() {
+    auto holder = _bg.hold();
     return _op_lock.get_units()
       .then([this](ssx::semaphore_units u) mutable {
           auto f = ss::now();
@@ -3191,7 +3192,8 @@ ss::future<> consensus::refresh_commit_index() {
       })
       .handle_exception_type([](const ss::broken_semaphore&) {
           // ignore exception, shutting down
-      });
+      })
+      .finally([holder = std::move(holder)] {});
 }
 
 void consensus::maybe_update_leader_commit_idx() {

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -51,6 +51,7 @@
 #include <seastar/core/sharded.hh>
 #include <seastar/util/bool_class.hh>
 
+#include <expected>
 #include <optional>
 #include <string_view>
 
@@ -172,6 +173,20 @@ public:
      * majority.
      */
     ss::future<std::error_code> force_replace_configuration_locally(
+      std::vector<vnode> voters,
+      std::vector<vnode> learners,
+      model::revision_id);
+
+    /**
+     * Forcibly replaces the group configuration by replicating a brand new
+     * configuration through the group, bypassing the usual "configuration
+     * change in progress" guard so it supersedes any in-flight reconfiguration.
+     * Unlike force_replace_configuration_locally this requires leadership and a
+     * functioning quorum, but the change is durable and propagates
+     * deterministically to all replicas via normal replication. Unclean by
+     * design; intended for breaking a wedged but quorate group.
+     */
+    ss::future<std::error_code> force_replace_configuration_replicated(
       std::vector<vnode> voters,
       std::vector<vnode> learners,
       model::revision_id);
@@ -599,6 +614,10 @@ private:
       = ss::bool_class<struct update_last_quorum_index>;
     using flush_delay_t
       = std::variant<std::chrono::milliseconds, std::chrono::years>;
+    // Acquire the op lock, translating the broken-semaphore shutdown case into
+    // an errc rather than an exception.
+    ss::future<std::expected<ssx::semaphore_units, std::error_code>>
+    acquire_op_lock_units();
     // all these private functions assume that we are under exclusive operations
     // via the _op_sem
     void do_step_down(std::string_view);

--- a/src/v/redpanda/admin/partition.cc
+++ b/src/v/redpanda/admin/partition.cc
@@ -318,8 +318,15 @@ admin_server::cancel_partition_reconfig_handler(
     const auto ntp = parse_ntp_from_request(req->param);
 
     if (ntp == model::controller_ntp) {
-        throw ss::httpd::bad_request_exception(
-          fmt::format("Can't cancel controller reconfiguration"));
+        if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
+            throw co_await redirect_to_leader(*req, model::controller_ntp);
+        }
+        vlog(
+          adminlog.info,
+          "Requesting cancelling of controller partition reconfiguration");
+        auto err = co_await _controller->cancel_raft0_reconfiguration();
+        co_await throw_on_error(*req, err, model::controller_ntp);
+        co_return ss::json::json_void();
     }
     vlog(
       adminlog.debug,

--- a/src/v/redpanda/admin/partition.cc
+++ b/src/v/redpanda/admin/partition.cc
@@ -480,14 +480,34 @@ admin_server::force_set_partition_replicas_handler(
     }
 
     auto ntp = parse_ntp_from_request(req->param);
-    if (ntp == model::controller_ntp) {
-        throw ss::httpd::bad_request_exception(
-          fmt::format("Can't reconfigure a controller"));
-    }
 
     auto doc = co_await parse_json_body(req.get());
     auto replicas = co_await validate_set_replicas(
       doc, _controller->get_topics_frontend().local());
+
+    if (ntp == model::controller_ntp) {
+        // Reconfiguring the controller group is dangerous and gated behind an
+        // explicit evil_mode flag. It forcibly replaces raft0's configuration,
+        // blowing away any in-flight or enqueued raft0 reconfiguration.
+        if (!admin::get_boolean_query_param(*req, "evil_mode")) {
+            throw ss::httpd::bad_request_exception(
+              "Refusing to reconfigure the controller; pass evil_mode=true to "
+              "force a raft0 reconfiguration");
+        }
+        std::vector<model::node_id> nodes;
+        nodes.reserve(replicas.size());
+        for (const auto& bs : replicas) {
+            nodes.push_back(bs.node_id);
+        }
+        vlog(
+          adminlog.warn,
+          "evil_mode: forcing controller (raft0) reconfiguration to {}",
+          nodes);
+        auto err = co_await _controller->force_raft0_reconfiguration(
+          std::move(nodes));
+        co_await throw_on_error(*req, err, model::controller_ntp);
+        co_return ss::json::json_void();
+    }
 
     const auto& topics = _controller->get_topics_state().local();
     const auto& in_progress = topics.updates_in_progress();

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1406,6 +1406,9 @@ ss::future<> admin_server::throw_on_error(
             // rather than a node ID appearing in a URL path.
             throw ss::httpd::bad_request_exception(
               fmt::format("Invalid request: {}", ec.message()));
+        case raft::errc::invalid_configuration_update:
+            throw ss::httpd::bad_request_exception(
+              fmt::format("Invalid request: {}", ec.message()));
         default:
             throw ss::httpd::server_error_exception(
               fmt::format("Unexpected raft error: {}", ec.message()));

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -1209,13 +1209,24 @@ class Admin:
         return self._request("post", path, node=node, json=replicas)
 
     def force_set_partition_replicas(
-        self, topic, partition, replicas, *, namespace="kafka", node=None
-    ):
+        self,
+        topic: str,
+        partition: int,
+        replicas: list[dict[str, Any]],
+        *,
+        namespace: str = "kafka",
+        node: ClusterNode | None = None,
+        evil_mode: bool = False,
+    ) -> Response:
         """
         [ {"node_id": 0, "core": 1}, ... ]
+
+        evil_mode opts in to forcing a reconfiguration of the controller
+        (redpanda/controller/0) group, which is otherwise rejected.
         """
         path = f"debug/partitions/{namespace}/{topic}/{partition}/force_replicas"
-        return self._request("post", path, node=node, json=replicas)
+        params = {"evil_mode": "true"} if evil_mode else None
+        return self._request("post", path, node=node, json=replicas, params=params)
 
     def toggle_failure_injection(
         self,

--- a/tests/rptest/tests/throttled_raft0_test.py
+++ b/tests/rptest/tests/throttled_raft0_test.py
@@ -13,6 +13,7 @@ Regression tests which require a throttled raft0 recovery.
 
 import re
 import signal
+import time
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
@@ -79,18 +80,31 @@ MEDIUM_TIMEOUT = TimeoutConfig(timeout_s=60, backoff_s=2)
 LONG_TIMEOUT = TimeoutConfig(timeout_s=120, backoff_s=2)
 
 
-class StuckRaft0LearnerTest(RedpandaTest):
-    """Decommissioning a dead learner cancels the in-flight raft0 add."""
+class _StuckRaft0LearnerBase(RedpandaTest):
+    """
+    Shared machinery for tests that need a throttled raft0 with a node wedged
+    as an in-flight learner. Subclasses set ``INITIAL_CLUSTER_SIZE`` (the number
+    of seed voters) and ``JOINER_NODE_ID`` (the node id the joiner registers as).
+    Not a test itself: it has no ``test_`` methods so ducktape collects nothing
+    here.
+    """
 
     INITIAL_CLUSTER_SIZE = 3
-    # Seeds are [1,2,3] joiner is then 4
+    # Seeds are [1..INITIAL_CLUSTER_SIZE]; joiner is then INITIAL_CLUSTER_SIZE+1.
     JOINER_NODE_ID = 4
+    # Replication factor for internal topics. Kept <= the number of live nodes
+    # so a decommissioned voter's replicas always have somewhere to drain to.
+    INTERNAL_TOPIC_RF = 3
+    # Nodes held in reserve beyond the seed voters (joiners / enqueued adds).
+    RESERVE_NODES = 1
 
     def __init__(self, test_context: TestContext, *args: Any, **kwargs: Any):
-        # 4 nodes: 3 initial seeds + 1 joiner held in reserve.
+        # One ducktape node per seed voter plus RESERVE_NODES held back as
+        # joiners. Joiner nodes are later reused (wiped + restarted) by some
+        # tests, so no extra node is needed for a rejoin under a fresh node id.
         super().__init__(
             test_context,
-            num_brokers=4,
+            num_brokers=self.INITIAL_CLUSTER_SIZE + self.RESERVE_NODES,
             *args,
             **kwargs,
         )
@@ -140,92 +154,114 @@ class StuckRaft0LearnerTest(RedpandaTest):
                 return f"id: {node_id}" in cfg
         return False
 
-    # ── test ────────────────────────────────────────────────────────────
+    def _node_in_brokers(self, node_id: int) -> bool:
+        """True if ``node_id`` is in the controller leader's broker list.
 
-    @cluster(num_nodes=4)
-    def test_decommission_cancels_in_flight_raft0_add(self):
+        Consults the controller leader (the authoritative membership view)
+        rather than the first node that answers: nodes removed from the cluster
+        keep running with a stale broker list, and joining nodes may not have an
+        admin endpoint up yet, so polling an arbitrary node is unreliable.
         """
-        Decommissioning a raft0 learner should cancel the underlying raft0 reconfiguration rather than waiting for it to complete and then decommissioning.
-        Without this, a lost learner can lock membership changes.
+        leader = self.redpanda.controller()
+        if leader is None:
+            return False
+        try:
+            brokers = self.redpanda._admin.get_brokers(node=leader)
+        except Exception:
+            return False
+        return any(b.get("node_id") == node_id for b in brokers)
 
-        Steps:
-        1. start a 3 node cluster with throttled raft0 learner rate
-        2. push controller commands to fill the log past snapshot
-        3. join node 4
-        4. wait for / assert we see node 4 as a learner
-        5. kill node 4
-        6. decommission node 4
-        7. wait for / assert raft0 returns to simple
-        8. assert clean removal of 4
+    def _joiner_in_brokers(self) -> bool:
+        """True if the joiner appears in any started node's broker list"""
+        return self._node_in_brokers(self.JOINER_NODE_ID)
+
+    def _voter_ids(self) -> list[int]:
+        """Sequential node ids of the seed voters (RedpandaService assigns by
+        index, so 1..INITIAL_CLUSTER_SIZE)."""
+        return list(range(1, self.INITIAL_CLUSTER_SIZE + 1))
+
+    def _assert_only_voters_remain(self, gone_ids: list[int]) -> None:
+        """Wait until raft0 is `simple` with exactly the seed voters present and
+        none of ``gone_ids``, then confirm it *stays* that way.
+
+        A single point-in-time check could land in the brief `simple` window
+        between a drained reconfiguration and the next queued add being
+        ingested, so we require the settled state to hold over a window to prove
+        the force actually nuked the whole queue.
         """
-        # 1. Start the first 3 of 4 allocated nodes; the 4th is the joiner.
+
+        def settled() -> bool:
+            return (
+                self._controller_state() == GroupConfigurationState.SIMPLE
+                and all(self._node_in_raft0(v) for v in self._voter_ids())
+                and not any(self._node_in_raft0(g) for g in gone_ids)
+            )
+
+        wait_until(
+            settled,
+            timeout_sec=LONG_TIMEOUT.timeout_s,
+            backoff_sec=LONG_TIMEOUT.backoff_s,
+            err_msg="raft0 did not settle to exactly the voters after force reconfig",
+        )
+        for _ in range(5):
+            time.sleep(1)
+            assert settled(), (
+                "raft0 left the settled state after force reconfig; the queue "
+                "was not fully nuked"
+            )
+
+    def _start_cluster(self, throttle: bool = True) -> None:
+        """
+        Bring up the seed voters and a test topic (so the controller log has
+        non-bootstrap state to ship). With ``throttle`` set, learner recovery is
+        pinned to 0 so a joining node stays stuck mid-reconfiguration.
+        """
         seed_nodes = self.redpanda.nodes[: self.INITIAL_CLUSTER_SIZE]
-        joiner = self.redpanda.nodes[self.INITIAL_CLUSTER_SIZE]
-
         self.logger.info(
-            f"[raft0-cancel] step 1: starting {len(seed_nodes)}-node "
-            f"cluster (seeds: {[n.name for n in seed_nodes]}); "
-            f"holding {joiner.name} in reserve"
+            f"[raft0] starting {len(seed_nodes)}-node cluster "
+            f"(seeds: {[n.name for n in seed_nodes]})"
         )
         self.redpanda.set_seed_servers(seed_nodes)
-
-        self.redpanda.add_extra_rp_conf(
-            {
-                "internal_topic_replication_factor": self.INITIAL_CLUSTER_SIZE,
-                "raft_learner_recovery_rate": 0,
-                "controller_log_learner_recovery_rate_enabled": True,
-            }
-        )
+        conf: dict[str, Any] = {
+            "internal_topic_replication_factor": self.INTERNAL_TOPIC_RF,
+        }
+        if throttle:
+            # throttle learner recovery to 0 so a joiner is stuck as a learner
+            # and raft0 stays mid-reconfiguration.
+            conf["raft_learner_recovery_rate"] = 0
+            conf["controller_log_learner_recovery_rate_enabled"] = True
+        self.redpanda.add_extra_rp_conf(conf)
         self.redpanda.start(nodes=seed_nodes, omit_seeds_on_idx_one=False)
-        self.logger.info("[raft0-cancel] cluster up")
 
-        # 2. Add some non-bootstrap state to the controller log so that
-        #    catch-up actually has data to ship
-        self.logger.info("[raft0-cancel] step 2: creating test topic")
-        topic = TopicSpec(replication_factor=3, partition_count=10)
-        self.client().create_topic(topic)
+        self.client().create_topic(TopicSpec(replication_factor=3, partition_count=10))
 
-        # Sanity: raft0 is `simple` on a healthy 3-node cluster.
         wait_until(
             lambda: self._controller_state() == GroupConfigurationState.SIMPLE,
             timeout_sec=SHORT_TIMEOUT.timeout_s,
             backoff_sec=SHORT_TIMEOUT.backoff_s,
             err_msg="raft0 did not start in simple state",
         )
-        self.logger.info("[raft0-cancel] raft0 confirmed `simple`")
 
-        # 3. Start the joiner
-        self.logger.info(
-            f"[raft0-cancel] step 3: starting joiner {joiner.name} "
-            f"with skip_readiness_check=True"
-        )
+    def _start_stuck_raft0_learner(self) -> int:
+        """
+        Bring up a throttled cluster and join a node so it becomes an
+        in-flight raft0 learner that can never finish catching up, then
+        SIGKILL it. Leaves raft0 in `transitional` with a dead learner.
+        Returns the joiner node id.
+        """
+        self._start_cluster(throttle=True)
+        joiner = self.redpanda.nodes[self.INITIAL_CLUSTER_SIZE]
         self.redpanda.start_node(joiner, skip_readiness_check=True)
-
-        def joiner_in_brokers() -> bool:
-            for survivor in seed_nodes:
-                try:
-                    brokers = self.redpanda._admin.get_brokers(node=survivor)
-                except Exception:
-                    continue
-                return any(b.get("node_id") == self.JOINER_NODE_ID for b in brokers)
-            return False
-
         wait_until(
-            joiner_in_brokers,
+            self._joiner_in_brokers,
             timeout_sec=LONG_TIMEOUT.timeout_s,
             backoff_sec=LONG_TIMEOUT.backoff_s,
             err_msg="joiner never appeared in the leader's broker list",
         )
         joiner_id = self.JOINER_NODE_ID
-        self.logger.info(
-            f"[raft0-cancel] joiner appeared in cluster as node_id={joiner_id}"
-        )
 
-        # 4. Wait for raft0 to enter `transitional` with the joiner as
-        #    the in-flight learner addition.
-        self.logger.info(
-            "[raft0-cancel] step 4: waiting for raft0 to enter `transitional`"
-        )
+        # Wait for raft0 to enter `transitional` with the joiner as the
+        # in-flight learner addition.
         wait_until(
             lambda: (
                 self._controller_state() == GroupConfigurationState.TRANSITIONAL
@@ -235,30 +271,152 @@ class StuckRaft0LearnerTest(RedpandaTest):
             backoff_sec=MEDIUM_TIMEOUT.backoff_s,
             err_msg="raft0 never entered transitional state with joiner present",
         )
-        self.logger.info(
-            "[raft0-cancel] raft0 is `transitional` (learner pending promotion)"
-        )
 
-        # 5. kill the joiner while it is still a learner.
-        self.logger.info(
-            f"[raft0-cancel] step 5: SIGKILLing joiner node_id={joiner_id} "
-            f"mid-promotion"
-        )
+        # Kill the joiner while it is still a learner (intentionally killed
+        # mid-promotion).
         self.redpanda.remove_from_started_nodes(joiner)
         self.redpanda.signal_redpanda(joiner, signal=signal.SIGKILL, idempotent=True)
+        return joiner_id
 
-        # 6. Decommission the dead joiner, should un-add from learners
-        self.logger.info(f"[raft0-cancel] step 6: decommissioning node_id={joiner_id}")
+    def _start_joining_node(self, node_idx: int) -> int:
+        """
+        Start the reserve node at ``node_idx`` so it registers with the cluster.
+        Its raft0 add may be blocked (the cluster is wedged), so readiness is
+        skipped and its own admin endpoint may never come up; registration is
+        confirmed via the controller leader's broker list. RedpandaService
+        assigns node ids sequentially by node index, so the id is node_idx + 1.
+        Returns the node id.
+        """
+        node = self.redpanda.nodes[node_idx]
+        node_id = node_idx + 1
+        self.redpanda.start_node(node, skip_readiness_check=True)
+        wait_until(
+            lambda: self._node_in_brokers(node_id),
+            timeout_sec=LONG_TIMEOUT.timeout_s,
+            backoff_sec=LONG_TIMEOUT.backoff_s,
+            err_msg=f"joining node {node_id} never registered with the cluster",
+        )
+        return node_id
+
+    def _join_and_kill_dead_learner(self, node_idx: int) -> int:
+        """
+        Start a reserve node so its raft0 add is enqueued, then SIGKILL it,
+        leaving a dead in-flight/enqueued learner addition. Returns its id.
+        """
+        node = self.redpanda.nodes[node_idx]
+        node_id = self._start_joining_node(node_idx)
+        self.redpanda.remove_from_started_nodes(node)  # dead learner
+        self.redpanda.signal_redpanda(node, signal=signal.SIGKILL, idempotent=True)
+        return node_id
+
+    def _cancel_controller_reconfiguration(self) -> bool:
+        """
+        Issue one admin cancel_reconfiguration against the controller partition,
+        routed to the raft0 leader. Returns True if it was accepted.
+        """
+        leader = self.redpanda.controller()
+        if leader is None:
+            return False
+        try:
+            self.redpanda._admin.cancel_partition_move(
+                namespace="redpanda",
+                topic="controller",
+                partition=0,
+                node=leader,
+            )
+            return True
+        except Exception as e:
+            self.logger.debug(f"cancel reconfiguration not yet accepted: {e}")
+            return False
+
+    def _force_reconfigure_controller(self, replica_ids: list[int]) -> None:
+        """
+        Force the controller (raft0) configuration to ``replica_ids`` via the
+        evil_mode admin endpoint, routed to the raft0 leader.
+        """
+        replicas = [{"node_id": nid, "core": 0} for nid in replica_ids]
+
+        def _accepted() -> bool:
+            leader = self.redpanda.controller()
+            if leader is None:
+                return False
+            try:
+                self.redpanda._admin.force_set_partition_replicas(
+                    namespace="redpanda",
+                    topic="controller",
+                    partition=0,
+                    replicas=replicas,
+                    node=leader,
+                    evil_mode=True,
+                )
+                return True
+            except Exception as e:
+                self.logger.debug(f"force reconfiguration not yet accepted: {e}")
+                return False
+
+        self.logger.info(f"[raft0] force-reconfiguring controller to {replica_ids}")
+        wait_until(
+            _accepted,
+            timeout_sec=MEDIUM_TIMEOUT.timeout_s,
+            backoff_sec=MEDIUM_TIMEOUT.backoff_s,
+            err_msg="controller force reconfiguration was never accepted",
+        )
+
+    def _join_live_add(self, node_idx: int) -> int:
+        """
+        Start a live node so its raft0 add is enqueued behind the wedge; assert
+        it has registered but is not yet in raft0. Returns the node id.
+        """
+        add_id = self._start_joining_node(node_idx)
+        assert not self._node_in_raft0(add_id), (
+            f"add of node {add_id} should be enqueued behind the wedge, not yet "
+            f"applied to raft0"
+        )
+        return add_id
+
+    def _raise_recovery_rate(self) -> None:
+        """
+        Lift the learner recovery throttle so live nodes can catch up. Uses a
+        raw config upsert rather than set_cluster_config: the latter blocks
+        until every node acks the new config version, which a not-yet-ready
+        joining node never will.
+        """
+        self.redpanda._admin.patch_cluster_config(
+            upsert={"raft_learner_recovery_rate": 100 * 1024 * 1024}
+        )
+
+
+class StuckRaft0LearnerTest(_StuckRaft0LearnerBase):
+    """Decommissioning a dead learner cancels the in-flight raft0 add."""
+
+    INITIAL_CLUSTER_SIZE = 3
+    # Seeds are [1,2,3] joiner is then 4
+    JOINER_NODE_ID = 4
+
+    # ── tests ───────────────────────────────────────────────────────────
+
+    @cluster(num_nodes=4)
+    def test_decommission_cancels_in_flight_raft0_add(self):
+        """
+        Decommissioning a raft0 learner should cancel the underlying raft0 reconfiguration rather than waiting for it to complete and then decommissioning.
+        Without this, a lost learner can lock membership changes.
+
+        Steps:
+        1-5. start a throttled cluster, join node 4 as a stuck learner, kill it
+        6. decommission node 4
+        7. wait for / assert raft0 returns to simple
+        8. assert clean removal of 4
+        """
+        joiner_id = self._start_stuck_raft0_learner()
+
+        # Decommission the dead joiner, should un-add from learners.
+        self.logger.info(f"[raft0-cancel] decommissioning node_id={joiner_id}")
         survivor = self.redpanda.controller()
         assert survivor is not None, "no controller leader to send decommission to"
         self.redpanda._admin.decommission_broker(joiner_id, node=survivor)
 
-        # 7. Wait for raft0 to return to `simple` with the joiner removed
-        #    from raft0's group_configuration.
-        self.logger.info(
-            "[raft0-cancel] step 7: waiting for raft0 to return to `simple` "
-            "with joiner removed"
-        )
+        # Wait for raft0 to return to `simple` with the joiner removed from
+        # raft0's group_configuration.
         wait_until(
             lambda: (
                 self._controller_state() == GroupConfigurationState.SIMPLE
@@ -271,15 +429,8 @@ class StuckRaft0LearnerTest(RedpandaTest):
                 "decommission appears stalled on configuration_change_in_progress"
             ),
         )
-        self.logger.info(
-            "[raft0-cancel] raft0 returned to `simple`; joiner removed from raft0"
-        )
 
-        # 8. And the broker should be fully removed from cluster
-        #    membership.
-        self.logger.info(
-            "[raft0-cancel] step 8: waiting for broker removal from membership"
-        )
+        # And the broker should be fully removed from cluster membership.
         recovery_waiter = NodeDecommissionWaiter(
             self.redpanda,
             joiner_id,
@@ -287,14 +438,345 @@ class StuckRaft0LearnerTest(RedpandaTest):
             progress_timeout=MEDIUM_TIMEOUT.timeout_s,
         )
         recovery_waiter.wait_for_removal()
-        self.logger.info("[raft0-cancel] joiner removed from cluster membership")
 
         # Final sanity.
         assert self._controller_state() == GroupConfigurationState.SIMPLE
         assert not self._node_in_raft0(joiner_id), (
             f"joiner {joiner_id} still in raft0 after decommission completed"
         )
-        assert not joiner_in_brokers(), (
+        assert not self._joiner_in_brokers(), (
             f"joiner {joiner_id} still in broker list after decommission completed"
         )
-        self.logger.info("[raft0-cancel] all assertions passed — test PASSED")
+
+    @cluster(num_nodes=4)
+    def test_admin_cancel_in_flight_raft0_add(self):
+        """
+        The admin cancel_reconfiguration endpoint, when targeted at the
+        controller partition (redpanda/controller/0), should delegate to the
+        raft0 leader and cancel the in-flight controller reconfiguration
+        instead of rejecting the request.
+
+        Steps:
+        1-5. start a throttled cluster, join node 4 as a stuck learner, kill it
+        6. POST cancel_reconfiguration for redpanda/controller/0
+        7. wait for / assert raft0 returns to simple with node 4 removed
+        """
+        joiner_id = self._start_stuck_raft0_learner()
+
+        # Cancel the in-flight controller reconfiguration via the admin API.
+        # The request is routed to the raft0 leader rather than rejected.
+        def cancel_controller_reconfiguration() -> bool:
+            controller = self.redpanda.controller()
+            if controller is None:
+                return False
+            try:
+                self.redpanda._admin.cancel_partition_move(
+                    namespace="redpanda",
+                    topic="controller",
+                    partition=0,
+                    node=controller,
+                )
+                return True
+            except Exception as e:
+                self.logger.debug(f"cancel reconfiguration not yet accepted: {e}")
+                return False
+
+        wait_until(
+            cancel_controller_reconfiguration,
+            timeout_sec=MEDIUM_TIMEOUT.timeout_s,
+            backoff_sec=MEDIUM_TIMEOUT.backoff_s,
+            err_msg="controller reconfiguration cancel was never accepted",
+        )
+
+        # raft0 should return to `simple` with the joiner removed and, because
+        # the cancel bumps the configuration revision, the dead learner is not
+        # re-added.
+        wait_until(
+            lambda: (
+                self._controller_state() == GroupConfigurationState.SIMPLE
+                and not self._node_in_raft0(joiner_id)
+            ),
+            timeout_sec=LONG_TIMEOUT.timeout_s,
+            backoff_sec=LONG_TIMEOUT.backoff_s,
+            err_msg="raft0 did not return to simple after admin cancel",
+        )
+
+
+class Raft0CancelDrainsQueuedAddsTest(_StuckRaft0LearnerBase):
+    """
+    Cancelling a stuck learner drains the adds queued behind it.
+
+    A dead learner wedges raft0; several live nodes then join, queuing their
+    adds behind the stuck reconfiguration. One admin cancel reverts the stuck
+    add, after which the queued adds apply and the nodes join. Guards against
+    the cancel dropping queued entries, which would happen if it bumped the
+    configuration revision past their offsets (see
+    controller::cancel_raft0_reconfiguration).
+    """
+
+    INITIAL_CLUSTER_SIZE = 3
+    JOINER_NODE_ID = 4
+    # 1 stuck learner (id 4) + 2 live adds (ids 5, 6).
+    RESERVE_NODES = 3
+
+    @cluster(num_nodes=6)
+    def test_cancel_drains_queued_adds(self):
+        stuck_id = self._start_stuck_raft0_learner()
+        add_ids = [
+            self._join_live_add(self.INITIAL_CLUSTER_SIZE + 1 + i) for i in range(2)
+        ]
+        # Lift the throttle so the live adds can catch up once unblocked (the
+        # dead learner stays stuck regardless, being dead).
+        self._raise_recovery_rate()
+
+        self.logger.info("[raft0] cancelling the stuck learner")
+        wait_until(
+            self._cancel_controller_reconfiguration,
+            timeout_sec=MEDIUM_TIMEOUT.timeout_s,
+            backoff_sec=MEDIUM_TIMEOUT.backoff_s,
+            err_msg="controller reconfiguration cancel was never accepted",
+        )
+
+        wait_until(
+            lambda: (
+                self._controller_state() == GroupConfigurationState.SIMPLE
+                and not self._node_in_raft0(stuck_id)
+                and all(self._node_in_raft0(a) for a in add_ids)
+            ),
+            timeout_sec=LONG_TIMEOUT.timeout_s,
+            backoff_sec=LONG_TIMEOUT.backoff_s,
+            err_msg=(
+                "raft0 did not settle to simple with the stuck learner gone and "
+                "the queued adds applied after the cancel"
+            ),
+        )
+
+
+class Raft0ForceReconfigNukesQueueTest(_StuckRaft0LearnerBase):
+    """
+    A force reconfiguration of the controller nukes whatever is wedged or queued
+    behind it in one shot, returning raft0 to exactly the requested replica set.
+    """
+
+    INITIAL_CLUSTER_SIZE = 3
+    JOINER_NODE_ID = 4
+    # 1 stuck learner (id 4) + 2 live adds (ids 5, 6).
+    RESERVE_NODES = 3
+
+    @cluster(num_nodes=6)
+    def test_force_nukes_stuck_learner_and_queued_adds(self):
+        """stuck, add, add -> force nukes all of them."""
+        stuck_id = self._start_stuck_raft0_learner()
+        add_ids = [
+            self._join_live_add(self.INITIAL_CLUSTER_SIZE + 1 + i) for i in range(2)
+        ]
+        self._force_reconfigure_controller(self._voter_ids())
+        self._assert_only_voters_remain([stuck_id, *add_ids])
+
+
+class Raft0ForceNukesStuckLearnersTest(_StuckRaft0LearnerBase):
+    """stuck, stuck -> a single force reconfiguration nukes both dead learners."""
+
+    INITIAL_CLUSTER_SIZE = 3
+    JOINER_NODE_ID = 4
+    # Two dead learners (ids 4, 5).
+    RESERVE_NODES = 2
+
+    @cluster(num_nodes=5)
+    def test_force_nukes_multiple_stuck_learners(self):
+        stuck_ids = [self._start_stuck_raft0_learner()]
+        stuck_ids.append(
+            self._join_and_kill_dead_learner(self.INITIAL_CLUSTER_SIZE + 1)
+        )
+        self._force_reconfigure_controller(self._voter_ids())
+        self._assert_only_voters_remain(stuck_ids)
+
+
+class Raft0ForceRemoveVoterTest(_StuckRaft0LearnerBase):
+    """
+    A force reconfiguration can drop a healthy voter from the controller group.
+    The dropped voter is ejected from raft0 but lingers in the members table; a
+    decommission then cleanly removes it.
+    """
+
+    INITIAL_CLUSTER_SIZE = 4
+    # No reserve nodes: the scenario only force-removes one of the four voters.
+    RESERVE_NODES = 0
+
+    @cluster(num_nodes=4)
+    def test_force_remove_voter_repaired_by_decommission(self):
+        # Healthy cluster, no throttle: the ejected voter's replicas must drain
+        # when it is decommissioned below.
+        self._start_cluster(throttle=False)
+
+        controller = self.redpanda.controller()
+        assert controller is not None, "no controller leader"
+        controller_id = self.redpanda.node_id(controller)
+        # Force-remove a voter other than the leader.
+        victim_id = next(v for v in self._voter_ids() if v != controller_id)
+        survivors = [v for v in self._voter_ids() if v != victim_id]
+
+        self._force_reconfigure_controller(survivors)
+        wait_until(
+            lambda: (
+                self._controller_state() == GroupConfigurationState.SIMPLE
+                and all(self._node_in_raft0(s) for s in survivors)
+                and not self._node_in_raft0(victim_id)
+            ),
+            timeout_sec=LONG_TIMEOUT.timeout_s,
+            backoff_sec=LONG_TIMEOUT.backoff_s,
+            err_msg="raft0 did not drop the force-removed voter",
+        )
+
+        # The force-removed voter is now ejected from the controller group, so
+        # it no longer receives the controller log and can't shed its own data
+        # partitions; stop it (it is no longer a functioning member) so the
+        # decommission below reconfigures those partitions via the live
+        # majorities — the dead-node pattern the force-reconfiguration tests use.
+        victim_node = self.redpanda.nodes[victim_id - 1]
+        self.redpanda.stop_node(victim_node)
+
+        # Decommissioning the ejected voter cleans it out of the members table.
+        self.logger.info(f"[raft0] decommissioning force-removed voter {victim_id}")
+        leader = self.redpanda.controller()
+        assert leader is not None, "no controller leader"
+        self.redpanda._admin.decommission_broker(victim_id, node=leader)
+        NodeDecommissionWaiter(
+            self.redpanda,
+            victim_id,
+            self.logger,
+            progress_timeout=MEDIUM_TIMEOUT.timeout_s,
+            decommissioned_node_ids=[victim_id],
+        ).wait_for_removal()
+        assert not self._node_in_brokers(victim_id), (
+            f"force-removed voter {victim_id} still in the members table after "
+            f"decommission"
+        )
+
+    @cluster(num_nodes=4)
+    def test_force_remove_leader_transfers_leadership(self):
+        """
+        Force-reconfiguring the controller to a replica set that excludes the
+        current raft0 leader must make that leader step down so a survivor takes
+        over (consensus::force_replace_configuration_replicated steps down when
+        the replicated configuration removes the local node from the voters).
+        """
+        self._start_cluster(throttle=False)
+
+        old_leader = self.redpanda.controller()
+        assert old_leader is not None, "no controller leader"
+        old_leader_id = self.redpanda.node_id(old_leader)
+        survivors = [v for v in self._voter_ids() if v != old_leader_id]
+
+        self.logger.info(
+            f"[raft0] force-removing controller leader {old_leader_id}, "
+            f"survivors={survivors}"
+        )
+        self._force_reconfigure_controller(survivors)
+
+        def _leadership_transferred() -> bool:
+            leader = self.redpanda.controller()
+            if leader is None:
+                return False
+            return self.redpanda.node_id(leader) in survivors
+
+        wait_until(
+            _leadership_transferred,
+            timeout_sec=LONG_TIMEOUT.timeout_s,
+            backoff_sec=LONG_TIMEOUT.backoff_s,
+            err_msg="controller leadership did not transfer to a survivor after "
+            "force-removing the leader",
+        )
+        wait_until(
+            lambda: (
+                self._controller_state() == GroupConfigurationState.SIMPLE
+                and all(self._node_in_raft0(s) for s in survivors)
+                and not self._node_in_raft0(old_leader_id)
+            ),
+            timeout_sec=LONG_TIMEOUT.timeout_s,
+            backoff_sec=LONG_TIMEOUT.backoff_s,
+            err_msg="raft0 did not settle to the survivors after force-removing "
+            "the leader",
+        )
+
+
+class SuccessiveCancelsClearDeadAddsTest(_StuckRaft0LearnerBase):
+    """
+    A backlog of stuck raft0 learner adds can be cleared by running the admin
+    cancel_reconfiguration repeatedly.
+
+    Several dead nodes join a throttled cluster: the first add is in-flight and
+    wedges raft0 (`transitional`), and the rest queue behind it. raft0 only
+    reconfigures one at a time, so each admin cancel reverts the current
+    in-flight add and lets the next dead add take its place. Running the cancel
+    successively drains the whole backlog, leaving raft0 `simple` with none of
+    the dead learners present.
+    """
+
+    INITIAL_CLUSTER_SIZE = 3
+    JOINER_NODE_ID = 4
+    # Three dead learners (ids 4,5,6), each held on its own reserve node.
+    NUM_DEAD = 3
+    RESERVE_NODES = 3
+
+    def _dead_in_raft0(self, dead_ids: list[int]) -> set[int]:
+        return {d for d in dead_ids if self._node_in_raft0(d)}
+
+    @cluster(num_nodes=6)
+    def test_successive_cancels_clear_dead_adds(self):
+        """
+        1.  start a throttled cluster and join the first dead learner, wedging
+            raft0 with its in-flight add.
+        2.  join and kill the remaining dead learners; their adds queue behind.
+        3.  run the admin cancel repeatedly: each cancel clears the current
+            in-flight dead add and the next one takes its place.
+        4.  assert raft0 is `simple` with none of the dead learners present.
+        """
+        dead_ids = [self._start_stuck_raft0_learner()]
+        for node_idx in range(
+            self.INITIAL_CLUSTER_SIZE + 1, self.INITIAL_CLUSTER_SIZE + self.NUM_DEAD
+        ):
+            dead_ids.append(self._join_and_kill_dead_learner(node_idx))
+        self.logger.info(f"[raft0-cancels] dead learners enqueued: {dead_ids}")
+
+        # One dead add is in-flight (raft0 transitional); the rest are queued.
+        assert len(self._dead_in_raft0(dead_ids)) == 1, (
+            "expected exactly one in-flight dead add to start"
+        )
+
+        # Each cancel clears the current in-flight dead add; the next dead add
+        # then becomes in-flight. Run one cancel per dead learner.
+        for n in range(1, len(dead_ids) + 1):
+            wait_until(
+                lambda: len(self._dead_in_raft0(dead_ids)) >= 1,
+                timeout_sec=MEDIUM_TIMEOUT.timeout_s,
+                backoff_sec=MEDIUM_TIMEOUT.backoff_s,
+                err_msg="no in-flight dead add to cancel",
+            )
+            in_flight = self._dead_in_raft0(dead_ids)
+            self.logger.info(
+                f"[raft0-cancels] cancel {n}/{len(dead_ids)}: clearing {in_flight}"
+            )
+            wait_until(
+                self._cancel_controller_reconfiguration,
+                timeout_sec=MEDIUM_TIMEOUT.timeout_s,
+                backoff_sec=MEDIUM_TIMEOUT.backoff_s,
+                err_msg="controller reconfiguration cancel was never accepted",
+            )
+            wait_until(
+                lambda: not (in_flight & self._dead_in_raft0(dead_ids)),
+                timeout_sec=MEDIUM_TIMEOUT.timeout_s,
+                backoff_sec=MEDIUM_TIMEOUT.backoff_s,
+                err_msg=f"cancel did not clear in-flight dead add(s) {in_flight}",
+            )
+
+        # The backlog is drained: raft0 is simple with no dead learners left.
+        wait_until(
+            lambda: (
+                self._controller_state() == GroupConfigurationState.SIMPLE
+                and not self._dead_in_raft0(dead_ids)
+            ),
+            timeout_sec=LONG_TIMEOUT.timeout_s,
+            backoff_sec=LONG_TIMEOUT.backoff_s,
+            err_msg="raft0 did not settle to simple with all dead adds cleared",
+        )


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30918
Also includes both raft gate-correctness fixes from https://github.com/redpanda-data/redpanda/pull/31022 (`raft: hold gate across cancel/force`, `raft: hold gate in refresh_commit_index`) — same root issue; the v26.1.x backport (#30945) carried the first of these as well.

## Release Notes
### Improvements
* adds stuck raft0 escape hatches

---

Backport adaptations:
- `tests/rptest/tests/throttled_raft0_test.py`: `RedpandaService.remove_from_started_nodes` has no `reason` parameter on this branch — dropped the reason arguments (kept as comments).
- `tests/rptest/services/admin.py`: dev's `MaybeNode` alias doesn't exist here — used `ClusterNode | None` (this branch's existing convention) in the `force_set_partition_replicas` signature; rest of the typed signature kept verbatim.

Verified locally: bazel build of `//src/v/redpanda/admin:admin`, `//src/v/raft`, `//src/v/cluster` succeeds on this branch; branch-pinned `bazel run //tools:clang_format` produces no changes; `ruff format --check` (CI-pinned 0.12.10) passes on the touched python files.