### PR TITLE
cloud_storage_clients: fix stale pool utilization gauge

### DIFF
--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -428,7 +428,6 @@ ss::future<client_pool::client_lease> client_pool::acquire(
     }
     vassert(client.has_value(), "'acquire' invariant is broken");
 
-    update_usage_stats();
     vlog(
       pool_log.debug,
       "client lease is acquired, own usage stat: {}, is-borrowed: {}",
@@ -586,12 +585,6 @@ auto client_pool::acquire_with_timeout(
       bucket, cloud_io::group_id::default_group, as, timeout, std::move(ctx));
 }
 
-void client_pool::update_usage_stats() {
-    if (_probe) {
-        _probe->register_utilization(normalized_num_clients_in_use());
-    }
-}
-
 size_t client_pool::normalized_num_clients_in_use() const {
     // Here we won't be showing that some clients are available if previously
     // the pool was depleted. This is needed to prevent borrowing from
@@ -616,7 +609,6 @@ bool client_pool::borrow_one(unsigned other) noexcept {
     // TODO: do not use the bottommost (oldest) element. Find the one
     // with expired connection.
     auto c = pop_least_recently_used();
-    update_usage_stats();
     c->shutdown();
     ssx::spawn_with_gate(_bg_gate, [c] { return c->stop().finally([c] {}); });
     return true;
@@ -629,7 +621,6 @@ void client_pool::return_one(
       _idle_clients.size() < _capacity,
       "tried to return a borrowed client but the pool is full");
     emplace_idle(up);
-    update_usage_stats();
     vlog(
       pool_log.debug,
       "creating new client, current usage is {}/{}",
@@ -740,6 +731,16 @@ void client_pool::populate_client_pool(upstream_registry::handle& up) {
     _idle_clients.reserve(_capacity);
     for (size_t i = 0; i < _capacity; i++) {
         emplace_idle(up);
+    }
+
+    if (_probe) {
+        // Sample utilization live at scrape time. Capture a weak reference so
+        // the gauge stays safe once the pool is gone: the probe is owned by
+        // the upstream registry and outlives us. Mirrors the lease deleter.
+        _probe->set_pool_utilization_source(
+          [w = weak_from_this()]() -> uint64_t {
+              return w ? w->normalized_num_clients_in_use() : 0;
+          });
     }
 
     // Be defensive in checking that we properly synchronized access to

--- a/src/v/cloud_storage_clients/client_pool.h
+++ b/src/v/cloud_storage_clients/client_pool.h
@@ -256,8 +256,6 @@ private:
     [[nodiscard]] client_ptr
     replace_least_recently_used(client_ptr leased) noexcept;
 
-    void update_usage_stats();
-
     upstream_registry& _upstreams;
     std::optional<upstream_registry::handle> _default_upstream;
 

--- a/src/v/cloud_storage_clients/client_probe.cc
+++ b/src/v/cloud_storage_clients/client_probe.cc
@@ -97,8 +97,8 @@ client_probe::register_lease_duration() {
     return _lease_duration.auto_measure();
 }
 
-void client_probe::register_utilization(unsigned clients_in_use) {
-    _pool_utilization = clients_in_use;
+void client_probe::set_pool_utilization_source(std::function<uint64_t()> src) {
+    _pool_utilization_source = std::move(src);
 }
 
 void client_probe::register_timeout() { _total_timeouts += 1; }
@@ -218,7 +218,10 @@ void client_probe::setup_internal_metrics(
           labels),
         sm::make_gauge(
           "client_pool_utilization",
-          [this] { return _pool_utilization; },
+          [this] {
+              return _pool_utilization_source ? _pool_utilization_source()
+                                              : uint64_t{0};
+          },
           sm::description(
             "Utilization of the cloud storage pool(0 - unused, "
             "100 - fully utilized)"),
@@ -330,7 +333,10 @@ void client_probe::setup_public_metrics(
           labels),
         sm::make_gauge(
           "client_pool_utilization",
-          [this] { return _pool_utilization; },
+          [this] {
+              return _pool_utilization_source ? _pool_utilization_source()
+                                              : uint64_t{0};
+          },
           sm::description(
             "Utilization of the cloud storage pool(0 - unused, "
             "100 - fully utilized)"),

--- a/src/v/cloud_storage_clients/client_probe.h
+++ b/src/v/cloud_storage_clients/client_probe.h
@@ -25,6 +25,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <functional>
 #include <span>
 
 namespace cloud_storage_clients {
@@ -84,8 +85,11 @@ public:
     void register_borrow();
     /// Register total lease duration
     std::unique_ptr<hist_t::measurement> register_lease_duration();
-    /// Utilization metric which is used to decide if borrowing is possible
-    void register_utilization(unsigned clients_in_use);
+    /// Set the callback sampled at scrape time to produce the pool
+    /// utilization gauge value, or clear it by passing {}. Sampled on the
+    /// metrics shard, so the callback must be safe to call there while
+    /// installed (the pool installs one holding a weak self-reference).
+    void set_pool_utilization_source(std::function<uint64_t()> src);
     /// Register client timeout
     void register_timeout();
 
@@ -123,8 +127,9 @@ private:
     uint64_t _total_borrows{0};
     /// Total time the lease is held by the ntp_archiver (or another user)
     hist_t _lease_duration;
-    /// Current utilization of the client pool
-    uint64_t _pool_utilization;
+    /// Live source for the client pool utilization gauge, sampled at scrape
+    /// time. Empty until a pool installs it via set_pool_utilization_source.
+    std::function<uint64_t()> _pool_utilization_source;
     /// Total client timeouts;
     uint64_t _total_timeouts{0};
     /// Total multipart upload creates

--- a/src/v/cloud_storage_clients/tests/BUILD
+++ b/src/v/cloud_storage_clients/tests/BUILD
@@ -26,6 +26,7 @@ redpanda_cc_btest(
         "//src/v/base",
         "//src/v/cloud_io/tests:s3_imposter",
         "//src/v/cloud_storage_clients",
+        "//src/v/test_utils:metrics",
         "//src/v/test_utils:seastar_boost",
         "@boost//:test",
         "@seastar",

--- a/src/v/cloud_storage_clients/tests/client_pool_test.cc
+++ b/src/v/cloud_storage_clients/tests/client_pool_test.cc
@@ -12,6 +12,7 @@
 #include "cloud_io/tests/s3_imposter.h"
 #include "cloud_storage_clients/client_pool.h"
 #include "cloud_storage_clients/tests/client_pool_builder.h"
+#include "test_utils/metrics.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
@@ -26,6 +27,8 @@
 #include <seastar/util/later.hh>
 
 #include <boost/test/tools/interface.hpp>
+
+#include <vector>
 
 using namespace std::chrono_literals;
 using namespace cloud_storage_clients::tests;
@@ -289,4 +292,55 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_max_upstreams_limit) {
           return std::string_view(e.what()).find("registry entry limit")
                  != std::string_view::npos;
       });
+}
+
+// The client_pool_utilization gauge must reflect the live idle state of the
+// pool. It is refreshed only when a client is taken (acquire / lend to a
+// peer) and when a peer returns a borrow, but never on the normal local
+// release. So after leasing and then returning every client, the pool is
+// genuinely fully idle while the gauge stays pinned at its acquire-time
+// value.
+SEASTAR_THREAD_TEST_CASE(test_client_pool_utilization_reflects_release) {
+    constexpr size_t num_connections_per_shard = 4;
+
+    ss::sharded<cloud_storage_clients::client_pool> pool;
+    auto stop_guard = test_pool_builder
+                        .connections_per_shard(num_connections_per_shard)
+                        .build(pool)
+                        .get();
+
+    ss::abort_source as;
+
+    // Reads the same gauge value that Prometheus scrapes, on this shard. The
+    // value-map key has no "vectorized_" prefix; that is added at scrape time.
+    auto reported_utilization = [] {
+        return test_utils::find_metric_value<uint64_t>(
+          "cloud_client_client_pool_utilization",
+          ss::metrics::default_handle(),
+          {{"endpoint", "localhost"}, {"region", "us-east-1"}});
+    };
+
+    // Fully idle at rest reads 0%. Also guards the gauge against being read
+    // before it is ever written (it was previously an uninitialized field).
+    BOOST_REQUIRE(reported_utilization().has_value());
+    BOOST_REQUIRE_EQUAL(reported_utilization().value(), 0);
+
+    // Lease every client: the pool is fully in use and the gauge tracks it.
+    std::vector<cloud_storage_clients::client_pool::client_lease> leases;
+    for (size_t i = 0; i < num_connections_per_shard; ++i) {
+        leases.push_back(pool.local().acquire(test_bucket, as).get());
+    }
+    BOOST_REQUIRE_EQUAL(pool.local().idle_count(), 0);
+    BOOST_REQUIRE_EQUAL(reported_utilization().value(), 100);
+
+    // Return the clients one at a time. The gauge must track the live idle
+    // count on every release, with no intervening acquire to refresh it --
+    // the shape of the bug, which stuck at 100 until the next acquire.
+    const uint64_t expected_after_release[] = {75, 50, 25, 0};
+    for (size_t i = 0; i < num_connections_per_shard; ++i) {
+        leases.pop_back();
+        BOOST_REQUIRE_EQUAL(pool.local().idle_count(), i + 1);
+        BOOST_REQUIRE_EQUAL(
+          reported_utilization().value(), expected_after_release[i]);
+    }
 }


### PR DESCRIPTION
The client_pool_utilization gauge was refreshed only when a client was taken from the pool on acquire, when one was lent to a peer, and when a peer returned a borrow, but never on the normal local release. This meant that sometimes we could not see the utilization go down even if there was 0 active clients.

I noticed this in a test cluster, where after a period of heavy cloud activity, the utilization dropped, but only down to 75% instead of 0%.

This commit makes the gauge pull-based: the probe samples normalized_num_clients_in_use() at scrape time through a source that the pool installs, rather than trying to catch every transition of the pool.

I'd considered just adding the missing update_usage_stats() to the local release path, but opted to read live instead. Pushing requires every path that moves the idle count (release, borrow/return, the invalid-client replacement) to remember to refresh, which seems fragile (particularly given the bug here).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
