### PR TITLE
storage: skip redundant chunk remainder copy for page-aligned appends

### DIFF
--- a/src/v/storage/segment_appender.cc
+++ b/src/v/storage/segment_appender.cc
@@ -164,12 +164,21 @@ ss::future<> segment_appender::do_append(const char* buf, size_t n) {
             co_await do_next_adaptive_fallocation();
             continue;
         }
-        // we need to copy the reminder of the chunk into the new one not write
-        // to the one currently being written
-        if (is_chunk_write_dispatched(_head)) {
-            // if head write is dispatched it means there is at least one
-            // inflight write. Always copy the remainder to a new chunk
-            // to simplify the logic (aligned case is very rare ~0.02%)
+        // If the head has an already-dispatched in-flight write, appending into
+        // it risks corrupting a page the DMA is still reading -- but only when
+        // that write ended mid-page. Writes are rounded up to a full page
+        // (pending_aligned_end), so a write ending at an unaligned offset
+        // leaves a trailing partial page that new appends would share; in that
+        // case copy the unflushed remainder into a fresh chunk and append
+        // there.
+        //
+        // When the dispatched write ended on a page boundary (flushed_pos is
+        // aligned) no page is shared: pending and new data live on later,
+        // disjoint pages, so we keep appending to the same chunk and skip the
+        // copy. This is always the case for page-aligned appends.
+        if (
+          is_chunk_write_dispatched(_head)
+          && _head->flushed_pos() != _head->pending_aligned_begin()) {
             auto last_inflight_write = _inflight.back();
             auto old_head = std::exchange(_head, nullptr);
             /**

--- a/src/v/storage/tests/segment_appender_test.cc
+++ b/src/v/storage/tests/segment_appender_test.cc
@@ -57,6 +57,17 @@ public:
           tst_log.debug,
           "Total appended size: {} bytes",
           reference.size_bytes());
+        // Drain background flush_op(false) flushes before close().
+        co_await gate.close();
+        // Close here so no test body has to, and a failed assertion doesn't
+        // trip ~segment_appender's unclosed-appender abort. Skip the content
+        // check on failure: the file state is expected to be off.
+        if (appender) {
+            co_await appender->close();
+            if (!HasFailure()) {
+                EXPECT_TRUE(co_await file_content_equal_to_reference());
+            }
+        }
         co_await ss::remove_file(file_name);
     }
 
@@ -210,8 +221,6 @@ TEST_F(SegmentAppenderFixture, AppendMixedData) {
     ops.emplace_back(write_op(256));
     ops.emplace_back(flush_op(true));
     execute_operations(std::move(ops)).get();
-    appender->close().get();
-    ASSERT_TRUE(file_content_equal_to_reference().get());
 }
 
 TEST_F(SegmentAppenderFixture, AppendAllSizesUpTo1MiB) {
@@ -219,9 +228,6 @@ TEST_F(SegmentAppenderFixture, AppendAllSizesUpTo1MiB) {
     for (auto i = 1; i <= 4096; i += 1) {
         execute_operation(write_op(i)).get();
     }
-
-    appender->close().get();
-    ASSERT_TRUE(file_content_equal_to_reference().get());
 }
 
 TEST_F(SegmentAppenderFixture, TestLargeAppends) {
@@ -229,9 +235,6 @@ TEST_F(SegmentAppenderFixture, TestLargeAppends) {
     for (size_t i = 1; i <= 128 * 16_KiB; i += 16_KiB) {
         execute_operation(write_op(i)).get();
     }
-
-    appender->close().get();
-    ASSERT_TRUE(file_content_equal_to_reference().get());
 }
 
 TEST_F(SegmentAppenderFixture, TestTruncation) {
@@ -250,8 +253,6 @@ TEST_F(SegmentAppenderFixture, TestTruncation) {
     }
 
     execute_operations(std::move(ops)).get();
-    appender->close().get();
-    ASSERT_TRUE(file_content_equal_to_reference().get());
 }
 
 TEST_F(SegmentAppenderFixture, TestFlushesAreMerged) {
@@ -268,23 +269,17 @@ TEST_F(SegmentAppenderFixture, TestFlushesAreMerged) {
     EXPECT_GE(stats->fsyncs, 1);
     // TODO: fix possible redundant flushes in segment appender
     // EXPECT_LE(appender->get_stats().fsyncs, 2);
-    appender->close().get();
-    ASSERT_TRUE(file_content_equal_to_reference().get());
 }
 
 TEST_F(SegmentAppenderFixture, TestConcurrentFlushes) {
     execute_concurrent_flush_and_writes(1, 16_KiB).get();
     ASSERT_GT(stats->bytes_copied_in_chunk_remainder, 0);
-    appender->close().get();
-    ASSERT_TRUE(file_content_equal_to_reference().get());
     ASSERT_EQ(reference.size_bytes(), 16_KiB);
 }
 
 TEST_F(SegmentAppenderFixture, TestConcurrentFlushesPageBoundaryWrites) {
     execute_concurrent_flush_and_writes(4_KiB, 1_MiB).get();
     ASSERT_EQ(stats->bytes_copied_in_chunk_remainder, 0);
-    appender->close().get();
-    ASSERT_TRUE(file_content_equal_to_reference().get());
     ASSERT_GE(reference.size_bytes(), 1_MiB);
 }
 
@@ -294,8 +289,6 @@ TEST_F(SegmentAppenderFixture, TestConcurrentFlushesSmallWritesShifted) {
     // now execute concurrent flushes with 1 byte writes
     execute_concurrent_flush_and_writes(1, 16_KiB).get();
     ASSERT_GT(stats->bytes_copied_in_chunk_remainder, 0);
-    appender->close().get();
-    ASSERT_TRUE(file_content_equal_to_reference().get());
     ASSERT_GE(reference.size_bytes(), 24_KiB);
 }
 

--- a/src/v/storage/tests/segment_appender_test.cc
+++ b/src/v/storage/tests/segment_appender_test.cc
@@ -72,14 +72,14 @@ public:
     }
 
     ss::future<> append_data(const char* data, size_t size) {
-        co_await appender->append(data, size);
         reference.append(data, size);
+        co_await appender->append(data, size);
     }
 
     ss::future<> append_data(const iobuf& data) {
         vlog(tst_log.debug, "Appending iobuf of size {}", data.size_bytes());
-        co_await appender->append(data.copy());
         reference.append(data.copy());
+        co_await appender->append(data.copy());
     }
 
     ss::future<bool> file_content_equal_to_reference() {


### PR DESCRIPTION
`do_append()` always copied the head chunk's unflushed remainder into a
fresh chunk when the head had a dispatched in-flight write. The original
code took this "always copy" path deliberately, to keep the logic simple
(its comment notes the page-aligned case is rare, ~0.02%). But
`TestConcurrentFlushesPageBoundaryWrites` assumed the opposite —
`bytes_copied_in_chunk_remainder == 0` for aligned writes — and under
task-queue shuffle the aligned case is common, so the copy fired and the
test aborted.

The copy is only actually needed when the dispatched write ended mid-page,
sharing a trailing partial page with later appends. Gate it on a
non-page-aligned flushed position so aligned writes stay in the same chunk,
skipping a redundant chunk allocation and page copy — which reconciles the
code with the test's (correct) assumption.

Also moves `close()` + content verification into the test fixture teardown,
so an assertion failing before a test's explicit `close()` surfaces cleanly
instead of aborting in `~segment_appender`.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
