### PR TITLE
Add `ASSERT_THAT_CORO`

### DIFF
--- a/src/v/test_utils/test.h
+++ b/src/v/test_utils/test.h
@@ -158,6 +158,8 @@ private:
     co_return GTEST_MESSAGE_(message, ::testing::TestPartResult::kFatalFailure)
 #define GTEST_SKIP_CORO_(message)                                              \
     co_return GTEST_MESSAGE_(message, ::testing::TestPartResult::kSkip)
+#define ASSERT_PRED_FORMAT1_CORO(pred_format, v1)                              \
+    GTEST_PRED_FORMAT1_(pred_format, v1, GTEST_FATAL_FAILURE_CORO_)
 #define ASSERT_PRED_FORMAT2_CORO(pred_format, v1, v2)                          \
     GTEST_PRED_FORMAT2_(pred_format, v1, v2, GTEST_FATAL_FAILURE_CORO_)
 #define GTEST_ASSERT_EQ_CORO(val1, val2)                                       \
@@ -204,6 +206,10 @@ private:
 
 #define ASSERT_STREQ_CORO(val1, val2) GTEST_ASSERT_STREQ_CORO(val1, val2)
 #define ASSERT_STRNE_CORO(val1, val2) GTEST_ASSERT_NE_CORO(val1, val2)
+
+#define ASSERT_THAT_CORO(value, matcher)                                       \
+    ASSERT_PRED_FORMAT1_CORO(                                                  \
+      ::testing::internal::MakePredicateFormatterFromMatcher(matcher), value)
 
 #define ASSERT_RESULT_EQ_CORO(result_val, exp_naked_value)                     \
     /* NOLINTNEXTLINE(cppcoreguidelines-avoid-do-while) */                     \

--- a/src/v/test_utils/tests/gtest_test.cc
+++ b/src/v/test_utils/tests/gtest_test.cc
@@ -17,9 +17,11 @@
 #include <seastar/util/defer.hh>
 #include <seastar/util/file.hh>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <vector>
 
 using namespace std::chrono_literals;
 
@@ -59,6 +61,13 @@ TEST_CORO(SeastarTest, assert_eventually_coro) {
 TEST_CORO(SeastarTest, SkippingWorks) {
     GTEST_SKIP_CORO() << "Skipping should not trip the following assertion";
     ASSERT_FALSE_CORO(true);
+}
+
+TEST_CORO(SeastarTest, AssertThatCoro) {
+    co_await seastar::sleep(std::chrono::milliseconds(100));
+    auto values = std::vector<int>{1, 2, 3};
+    ASSERT_THAT_CORO(values, ::testing::ElementsAre(1, 2, 3));
+    ASSERT_THAT_CORO(values, ::testing::Contains(2));
 }
 
 /*


### PR DESCRIPTION
Adds `ASSERT_THAT_CORO`, the coroutine-safe equivalent of gmock's
`ASSERT_THAT`, so matcher-based assertions can be used inside
`TEST_CORO` / `TEST_F_CORO` bodies. The regular `ASSERT_THAT` expands to
a plain `return` on failure, which does not correctly terminate a
coroutine; the `_CORO` variant routes failures through
`GTEST_FATAL_FAILURE_CORO_` (a `co_return`), matching the other
`*_CORO` assertions in `test_utils/test.h`.

## Changes
- `ASSERT_PRED_FORMAT1_CORO` — the 1-arg predicate-format counterpart to
  the existing `ASSERT_PRED_FORMAT2_CORO`.
- `ASSERT_THAT_CORO` — built on it, mirroring upstream's `ASSERT_THAT`
  definition.
- A `SeastarTest.AssertThatCoro` test exercising `ElementsAre` and
  `Contains`.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
