### PR TITLE
serde: Some read perf improvements

### DIFF
--- a/src/v/bytes/details/io_iterator_consumer.h
+++ b/src/v/bytes/details/io_iterator_consumer.h
@@ -84,7 +84,7 @@ public:
     template<
       typename T,
       typename = std::enable_if_t<std::is_trivially_copyable_v<T>, T>>
-    T consume_type() {
+    [[gnu::always_inline]] T consume_type() {
         constexpr size_t sz = sizeof(T);
         T obj;
         char* dst = reinterpret_cast<char*>(&obj); // NOLINT
@@ -116,30 +116,40 @@ public:
     /// takes a Consumer object and iteraters over the chunks in oder, from
     /// the given buffer index position. Use a stop_iteration::yes for early
     /// exit;
-    size_t consume(const size_t n, Consumer&& f) {
-        size_t i = 0;
-        while (i < n) {
-            if (_frag == _frag_end) {
-                return i;
-            }
-            const size_t bytes_left = segment_bytes_left();
-            if (bytes_left == 0) {
-                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-                if (++_frag != _frag_end) {
-                    _frag_index = _frag->get();
-                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-                    _frag_index_end = _frag->get() + _frag->size();
-                }
-                continue;
-            }
-            const size_t step = std::min(n - i, bytes_left);
-            const ss::stop_iteration stop = f(_frag_index, step);
-            i += step;
+    [[gnu::always_inline]] size_t consume(const size_t n, Consumer&& f) {
+        size_t consumed = 0;
+        // (otherwise identical) fast path: clang fails to optimize for this
+        // through various layers of APIs and the below so we hand unroll it.
+        if (likely(n > 0 && _frag != _frag_end && segment_bytes_left() >= n)) {
+            f(_frag_index, n);
+            consumed = n;
             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-            _frag_index += step;
-            _bytes_consumed += step;
-            if (stop == ss::stop_iteration::yes) {
-                break;
+            _frag_index += n;
+            _bytes_consumed += n;
+        } else {
+            while (consumed < n) {
+                if (_frag == _frag_end) {
+                    return consumed;
+                }
+                const size_t bytes_left = segment_bytes_left();
+                if (bytes_left == 0) {
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+                    if (++_frag != _frag_end) {
+                        _frag_index = _frag->get();
+                        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+                        _frag_index_end = _frag->get() + _frag->size();
+                    }
+                    continue;
+                }
+                const size_t step = std::min(n - consumed, bytes_left);
+                const ss::stop_iteration stop = f(_frag_index, step);
+                consumed += step;
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+                _frag_index += step;
+                _bytes_consumed += step;
+                if (stop == ss::stop_iteration::yes) {
+                    break;
+                }
             }
         }
 
@@ -155,7 +165,7 @@ public:
             }
         }
 
-        return i;
+        return consumed;
     }
     size_t bytes_consumed() const { return _bytes_consumed; }
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)

--- a/src/v/bytes/iobuf_parser.h
+++ b/src/v/bytes/iobuf_parser.h
@@ -107,7 +107,7 @@ public:
     bool read_bool() { return bool(consume_type<int8_t>()); }
 
     template<typename T>
-    T consume_type() {
+    [[gnu::always_inline]] T consume_type() {
         return _in.consume_type<T>();
     }
 

--- a/src/v/bytes/tests/iobuf_tests.cc
+++ b/src/v/bytes/tests/iobuf_tests.cc
@@ -236,6 +236,42 @@ SEASTAR_THREAD_TEST_CASE(test_read_pod) {
     BOOST_CHECK_THROW(in.consume_type<pod>(), std::out_of_range);
 }
 
+SEASTAR_THREAD_TEST_CASE(test_read_pod_across_fragments) {
+    constexpr uint64_t expected = 0x0123456789abcdef;
+    const auto encoded = std::string_view(
+      reinterpret_cast<const char*>(&expected), sizeof(expected));
+
+    for (size_t split = 1; split < encoded.size(); ++split) {
+        iobuf b;
+        b.append_fragments(iobuf::from(encoded.substr(0, split)));
+        b.append_fragments(iobuf::from(encoded.substr(split)));
+
+        auto in = iobuf::iterator_consumer(b.cbegin(), b.cend());
+        BOOST_CHECK_EQUAL(in.consume_type<uint64_t>(), expected);
+        BOOST_CHECK_EQUAL(in.bytes_consumed(), sizeof(expected));
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_read_pod_advances_to_next_fragment) {
+    constexpr uint64_t first = 0x0123456789abcdef;
+    constexpr uint64_t second = 0xfedcba9876543210;
+
+    iobuf b;
+    b.append_fragments(
+      iobuf::from(
+        std::string_view(
+          reinterpret_cast<const char*>(&first), sizeof(first))));
+    b.append_fragments(
+      iobuf::from(
+        std::string_view(
+          reinterpret_cast<const char*>(&second), sizeof(second))));
+
+    auto in = iobuf::iterator_consumer(b.cbegin(), b.cend());
+    BOOST_CHECK_EQUAL(in.consume_type<uint64_t>(), first);
+    BOOST_CHECK_EQUAL(in.consume_type<uint64_t>(), second);
+    BOOST_CHECK_EQUAL(in.bytes_consumed(), sizeof(first) + sizeof(second));
+}
+
 SEASTAR_THREAD_TEST_CASE(test_consume_to) {
     // read 75 bytes * i number of times
     // cumulative

--- a/src/v/serde/rw/rw.h
+++ b/src/v/serde/rw/rw.h
@@ -28,12 +28,14 @@ concept DirectReadable = requires(iobuf_parser& in, const header& h) {
 };
 
 template<typename T>
-void read_nested(iobuf_parser& in, T& t, const std::size_t bytes_left_limit) {
+[[gnu::always_inline]] void
+read_nested(iobuf_parser& in, T& t, const std::size_t bytes_left_limit) {
     read_tag(in, t, bytes_left_limit);
 }
 
 template<typename T>
-T read_nested(iobuf_parser& in, const std::size_t bytes_left_limit) {
+[[gnu::always_inline]] T
+read_nested(iobuf_parser& in, const std::size_t bytes_left_limit) {
     using Type = std::decay_t<T>;
     static_assert(std::is_default_constructible_v<T> || DirectReadable<T>);
     if constexpr (DirectReadable<T>) {

--- a/src/v/serde/rw/scalar.h
+++ b/src/v/serde/rw/scalar.h
@@ -26,7 +26,7 @@ namespace serde {
 
 template<typename T>
 requires(std::is_scalar_v<std::decay_t<T>> && !serde_is_enum_v<std::decay_t<T>>)
-void tag_invoke(
+[[gnu::always_inline]] void tag_invoke(
   tag_t<read_tag>, iobuf_parser& in, T& t, const std::size_t bytes_left_limit) {
     using Type = std::decay_t<T>;
 

--- a/src/v/serde/rw/tags.h
+++ b/src/v/serde/rw/tags.h
@@ -44,7 +44,7 @@ inline constexpr struct write_fn {
 
 inline constexpr struct read_fn {
     template<typename T>
-    void operator()(
+    [[gnu::always_inline]] void operator()(
       iobuf_parser& in, T& t, const std::size_t bytes_left_limit) const {
         return tag_invoke(*this, in, t, bytes_left_limit);
     }


### PR DESCRIPTION
Handle the contiguous fast path in consume so callers use one traversal
implementation. Requests spanning fragments or running past the end
retain the existing loop and truncation behavior.

Force consume and the scalar parser forwarding methods inline so scalar
sizes remain visible. Inlining the generic loop alone left
small.deserialize at 1011.81 instructions; the contiguous branch inside
consume reduces it to 881.82 instructions.

Release benchmark results (five-run aggregate, unchanged cases and
metrics omitted):

serde_rpbench instructions:
- small.deserialize: 1124.820 -> 881.820 (-21.603%)
- big_1mb.deserialize: 4591.621 -> 4227.625 (-7.927%)
- big_10mb.deserialize: 24858.648 -> 24498.474 (-1.449%)

health_monitor_rpbench instructions:
- deserialize_many_partitions: 137160956 -> 100155383 (-26.980%)
- deserialize_many_topics: 229850352 -> 175001022 (-23.863%)
- deserialize_many_topics_replicated_partitions:
  450981754 -> 335933930 (-25.511%)

raft_replicate_rpbench instructions:
- quorum_ack_replicate_16B: 159532.177 -> 155123.143 (-2.764%)
- quorum_ack_replicate_16KiB: 228417.619 -> 222659.153 (-2.521%)
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none


