### PR TITLE
`config`: update `cloud_storage_enabled` description

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2074,8 +2074,8 @@ configuration::configuration()
       *this,
       true,
       "cloud_storage_enabled",
-      "Enable object storage. Must be set to `true` to use Tiered Storage or "
-      "Remote Read Replicas.",
+      "Enable object storage. Must be set to `true` to use Tiered Storage, "
+      "Remote Read Replicas, or Cloud Topics.",
       meta{.needs_restart = needs_restart::yes, .visibility = visibility::user},
       false)
   , cloud_storage_enable_remote_read(


### PR DESCRIPTION
To reflect this configurations control over cloud topics enablement as well.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
