### PR TITLE
sr: do not auto-create _schemas from authz pre-flight probe

### DIFF
--- a/src/v/pandaproxy/schema_registry/kafka_client_transport.cc
+++ b/src/v/pandaproxy/schema_registry/kafka_client_transport.cc
@@ -265,6 +265,11 @@ ss::future<> kafka_client_transport::validate_topic_creation_authorization(
     req.data.topics = {kafka::metadata_request_topic{
       .name = model::schema_registry_internal_tp.topic}};
     req.data.include_topic_authorized_operations = true;
+    // The protocol default is true; if the broker has
+    // auto_create_topics_enabled set, this probe would auto-create the
+    // topic with cluster-default properties (cleanup.policy=delete)
+    // instead of the compacted config create_topic sets below.
+    req.data.allow_auto_topic_creation = false;
     auto resp = co_await _client->fetch_metadata(std::move(req));
     vlog(srlog.trace, "Validating topic creation authorization");
     // If authz is not enabled on the cluster, then no need to validate

--- a/tests/rptest/tests/internal_topic_protection_test.py
+++ b/tests/rptest/tests/internal_topic_protection_test.py
@@ -286,3 +286,45 @@ class InternalTopicProtectionLargeClusterTest(RedpandaTest):
         assert num_found == 0, (
             f"Expected to find 0 messages about _schemas but found {num_found}"
         )
+
+
+class SchemaRegistryTopicAutoCreateTest(RedpandaTest):
+    """
+    Verify that the schema registry internal topic is created with its
+    intended configuration (compacted) even when `auto_create_topics_enabled`
+    is set: the authorization pre-flight metadata probe must not auto-create
+    `_schemas` with cluster-default properties (cleanup.policy=delete).
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs["schema_registry_config"] = SchemaRegistryConfig()
+        super().__init__(
+            *args,
+            extra_rp_conf={"auto_create_topics_enabled": True},
+            **kwargs,
+        )
+
+        self.rpk = RpkTool(self.redpanda)
+
+    @cluster(num_nodes=3)
+    def test_schemas_topic_cleanup_policy(self):
+        # The first schema registry request triggers creation of _schemas.
+        _ = get_subjects(self.redpanda.nodes, self.logger)
+
+        wait_until(
+            lambda: "_schemas" in self.rpk.list_topics(),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="_schemas topic was never created",
+        )
+
+        configs = self.rpk.describe_topic_configs("_schemas")
+        cleanup_policy, source = configs["cleanup.policy"]
+        assert cleanup_policy == "compact", (
+            f"Expected cleanup.policy=compact for _schemas but got "
+            f"{cleanup_policy} (source: {source})"
+        )
+        assert source == "DYNAMIC_TOPIC_CONFIG", (
+            f"Expected _schemas cleanup.policy to be explicitly set "
+            f"(DYNAMIC_TOPIC_CONFIG) but source is {source}"
+        )


### PR DESCRIPTION
Since v25.3.1 (#28083), the schema registry's `create_internal_topic` path calls `validate_topic_creation_authorization()` before creating `_schemas`. That method opens with a Metadata request naming `_schemas` that leaves `allow_auto_topic_creation` at its Kafka protocol default of `true`. On clusters with `auto_create_topics_enabled=true`, the broker auto-creates `_schemas` with cluster-default properties — `cleanup.policy=delete` and the default 7-day retention — in response to this probe, before the schema registry's own create (compact, compression=none, retention disabled) runs. The proper create then returns `topic_already_exists` and the incorrect configuration is silently kept, leaving all Schema Registry data on a delete-policy topic where retention will eventually remove it.

This is deterministic on every fresh cluster with auto-create enabled: the trigger is the first-ever schema registry REST request (a Console poll or health check suffices). Verified by repro on v26.1.6 (container and Kubernetes operator); details in #31213.

The first commit sets `allow_auto_topic_creation = false` on the probe request — matching the kafka client's own metadata refresh in `kafka/client/cluster.cc`, which already does this. The second commit adds a ducktape regression test asserting that with `auto_create_topics_enabled=true`, the first SR request still yields `_schemas` with `cleanup.policy=compact` set explicitly (`DYNAMIC_TOPIC_CONFIG`).

Fixes #31213

JIRA Link: [CORE-16880](https://redpandadata.atlassian.net/browse/CORE-16880)

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [ ] v25.2.x

## Release Notes

### Bug Fixes

* Fixed an issue where, on clusters with `auto_create_topics_enabled` set to `true`, the Schema Registry internal topic `_schemas` could be auto-created with cluster-default properties (`cleanup.policy=delete` and default retention) instead of the intended compacted configuration, putting schema data at risk of retention-based deletion. Clusters already affected can repair the topic with `rpk topic alter-config _schemas --set cleanup.policy=compact --set retention.ms=-1 --set compression.type=none`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CORE-16880]: https://redpandadata.atlassian.net/browse/CORE-16880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ