### PR TITLE
`json`: fix invalidated iterator use in `write_chunked_string()`

### DIFF
--- a/src/v/json/iobuf_writer.h
+++ b/src/v/json/iobuf_writer.h
@@ -92,15 +92,14 @@ private:
             this->os_->_impl.trim_back(1);
 
             // 2. Stash the final character, ...
-            auto last = last_frag();
-            stashed = *std::prev(last->get_current());
+            stashed = *std::prev(last_frag()->get_current());
             // 3. Drop the final character
             this->os_->_impl.trim_back(1);
 
-            // Ensure a stable address to restore the stashed character
-            if (last != last_frag()) {
-                this->os_->_impl.reserve_memory(1);
-            }
+            // Ensure a stable address to restore the stashed character: the
+            // trim may have dropped the last fragment along with its final
+            // byte.
+            this->os_->_impl.reserve_memory(1);
             // 2. ...and where it is to be written.
             stash_pos = last_frag()->get_current();
         }

--- a/src/v/json/tests/json_serialization_test.cc
+++ b/src/v/json/tests/json_serialization_test.cc
@@ -200,3 +200,38 @@ SEASTAR_THREAD_TEST_CASE(json_iobuf_writer_test) {
         BOOST_CHECK_EQUAL(to_string(out_buf), to_string(expected));
     }
 }
+
+// The quote fixup between input fragments trims the closing quote and the
+// final character of the just-written fragment; when that character is the
+// only byte in the output's last fragment, the trim drops the fragment with
+// it. Scan sizes across the allocator's fragment boundaries so that some
+// iteration lands the final character and quote alone in a fresh fragment,
+// and validate the round-trip either way.
+SEASTAR_THREAD_TEST_CASE(json_iobuf_writer_fragment_drop_test) {
+    constexpr auto to_string = [](const iobuf& buf) {
+        iobuf_const_parser p{buf};
+        auto b = p.read_bytes(p.bytes_left());
+        return std::string{b.begin(), b.end()};
+    };
+
+    for (size_t first_size = 1; first_size <= 1200; ++first_size) {
+        const auto first = std::string(first_size, 'a');
+        iobuf in;
+        in.append_fragments(iobuf::from(first));
+        in.append_fragments(iobuf::from("bc"));
+
+        json::chunked_buffer out;
+        json::iobuf_writer<json::chunked_buffer> os{out};
+        BOOST_REQUIRE(os.String(in));
+        auto out_buf = std::move(out).as_iobuf();
+
+        const auto encoded = to_string(out_buf);
+        json::Document doc;
+        doc.Parse(encoded.data(), encoded.size());
+        BOOST_REQUIRE(!doc.HasParseError());
+        BOOST_REQUIRE(doc.IsString());
+        BOOST_REQUIRE(
+          std::string_view(doc.GetString(), doc.GetStringLength())
+          == first + "bc");
+    }
+}


### PR DESCRIPTION
`write_chunked_string()` held a fragment iterator across a `trim_back()` that can pop the fragment (when the trimmed character is the only byte in the last fragment). The iterator generation check flags this in debug builds:

``` 
ERROR 2026-07-21 21:32:31,840 [shard 0:main] assert - Assert failure: (bazel-out/.../bytes/details/io_fragment.h:205) '_container->_generation == _my_generation' Attempting to use an invalidated iterator. The corresponding iobuf has been mutated since this iterator was constructed. 
```

In release mode, the behavior is undefined, but technically correct (as we may compare a freed node address against the new last fragment's).

Fix this by unconditionally calling `reserve_memory(1)`. This is a no-op for a fragment with memory already reserved, and correct for one without.


## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [X] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
