### PR TITLE
raft/buffered_protocol: fix shutdown race in append entries queue

### DIFF
--- a/src/v/raft/buffered_protocol.cc
+++ b/src/v/raft/buffered_protocol.cc
@@ -30,27 +30,20 @@
 namespace raft {
 
 namespace {
-template<typename Func, typename Ret>
-ss::future<result<Ret>> try_with_gate(ss::gate& gate, Func&& f) {
-    if (gate.is_closed()) {
-        return ss::make_ready_future<result<Ret>>(raft::errc::shutting_down);
-    }
-    return ss::with_gate(gate, std::forward<Func>(f));
-}
-
 template<typename Req, typename Resp>
 using client_f = ss::future<result<Resp>> (consensus_client_protocol::*)(
   model::node_id, Req, rpc::client_opts);
 
 template<typename Req, typename Ret>
 ss::future<result<Ret>> apply_with_gate(
+  ss::abort_source& as,
   ss::gate& gate,
   consensus_client_protocol& proto,
   model::node_id target_node,
   Req req,
   rpc::client_opts opts,
   client_f<Req, Ret> f) {
-    if (gate.is_closed()) {
+    if (as.abort_requested()) {
         return ss::make_ready_future<result<Ret>>(raft::errc::shutting_down);
     }
 
@@ -95,6 +88,7 @@ ss::future<> buffered_protocol::reset_backoff(model::node_id node_id) {
 ss::future<result<vote_reply>> buffered_protocol::vote(
   model::node_id target_node, vote_request req, rpc::client_opts opts) {
     return apply_with_gate(
+      _as,
       _gate,
       _base_protocol,
       target_node,
@@ -107,7 +101,11 @@ ss::future<result<append_entries_reply>> buffered_protocol::append_entries(
   model::node_id target_node,
   append_entries_request req,
   rpc::client_opts opts) {
-    return try_with_gate(
+    if (_as.abort_requested()) {
+        return ss::make_ready_future<result<append_entries_reply>>(
+          raft::errc::shutting_down);
+    }
+    return ss::with_gate(
       _gate,
       [this,
        target_node,
@@ -136,6 +134,7 @@ ss::future<result<append_entries_reply>> buffered_protocol::append_entries(
 ss::future<result<heartbeat_reply_v2>> buffered_protocol::heartbeat_v2(
   model::node_id target_node, heartbeat_request_v2 req, rpc::client_opts opts) {
     return apply_with_gate(
+      _as,
       _gate,
       _base_protocol,
       target_node,
@@ -149,6 +148,7 @@ ss::future<result<install_snapshot_reply>> buffered_protocol::install_snapshot(
   install_snapshot_request req,
   rpc::client_opts opts) {
     return apply_with_gate(
+      _as,
       _gate,
       _base_protocol,
       target_node,
@@ -160,6 +160,7 @@ ss::future<result<install_snapshot_reply>> buffered_protocol::install_snapshot(
 ss::future<result<timeout_now_reply>> buffered_protocol::timeout_now(
   model::node_id target_node, timeout_now_request req, rpc::client_opts opts) {
     return apply_with_gate(
+      _as,
       _gate,
       _base_protocol,
       target_node,
@@ -174,6 +175,7 @@ buffered_protocol::get_compaction_mcco(
   get_compaction_mcco_request req,
   rpc::client_opts opts) {
     return apply_with_gate(
+      _as,
       _gate,
       _base_protocol,
       target_node,
@@ -188,6 +190,7 @@ buffered_protocol::distribute_compaction_mtro(
   distribute_compaction_mtro_request req,
   rpc::client_opts opts) {
     return apply_with_gate(
+      _as,
       _gate,
       _base_protocol,
       target_node,
@@ -199,6 +202,7 @@ buffered_protocol::distribute_compaction_mtro(
 ss::future<> buffered_protocol::stop() {
     vlog(raftlog.debug, "stopping buffered protocol");
     _gc_timer.cancel();
+    _as.request_abort();
     auto f = _gate.close();
     co_await ss::parallel_for_each(
       _append_entries_queues,

--- a/src/v/raft/buffered_protocol.cc
+++ b/src/v/raft/buffered_protocol.cc
@@ -333,6 +333,11 @@ ss::future<result<append_entries_reply>> append_entries_queue::append_entries(
     auto holder = _gate.hold();
     return _dispatched.wait([this, sz] { return can_buffer_next_request(sz); })
       .then([this, r = std::move(r), opts = std::move(opts)]() mutable {
+          if (_as.abort_requested()) {
+              // stop() could have occurred during the yield, recheck abort
+              return ss::make_ready_future<result<append_entries_reply>>(
+                raft::errc::shutting_down);
+          }
           /// consensus is no longer responsible for tracking memory usage and
           /// dispatch ordering after this point
           opts.resource_units.reset();
@@ -346,6 +351,7 @@ ss::future<result<append_entries_reply>> append_entries_queue::append_entries(
 }
 ss::future<> append_entries_queue::stop() {
     vlog(_logger.debug, "stopping append entries queue");
+    _as.request_abort();
     _new_requests.broken();
     _dispatched.broken();
     _inflight_requests_sem.broken();

--- a/src/v/raft/buffered_protocol.h
+++ b/src/v/raft/buffered_protocol.h
@@ -173,6 +173,7 @@ private:
     config::binding<size_t> _max_inflight_requests;
     config::binding<size_t> _max_buffered_bytes;
     ss::gate _gate;
+    ss::abort_source _as;
     ss::timer<> _gc_timer;
 };
 } // namespace raft

--- a/src/v/raft/buffered_protocol.h
+++ b/src/v/raft/buffered_protocol.h
@@ -20,6 +20,7 @@
 #include "ssx/semaphore.h"
 #include "utils/prefix_logger.h"
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
@@ -85,6 +86,7 @@ private:
 
     ss::chunked_fifo<request_entry> _requests;
     ss::gate _gate;
+    ss::abort_source _as;
     ss::condition_variable _new_requests;
     ss::condition_variable _dispatched;
 


### PR DESCRIPTION
TLDR buffered protocol can leak a gate holder

It typically checks 'is gate open' like a abort source to see if stop has been called or not

Theres one spot though, where it checks for stop, suspends, DOESNT check again, and tosses an entry on the requests queue.

Issue, the request entry holds a gate holder,
and the request queue is cancelled out in stop

So if you have

append entries gate check -> suspension point
stop -> cancels all the promises
stop -> suspend on wait for gate drained
resume append entries, add request to the queue
that entry will hold the gate... forever

This pr just adds an abort source and some checks on it s.t. we shouldn't be able to add a requests entry after cancellation now.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.1.x
- [x] v25.3.x
- [x] v25.2.x

## Release Notes

### Bug Fixes

* Fixed a rare race between buffering an append entries request and Raft shutdown that could hang a broker on shutdown.