### PR TITLE
`datalake`: pin record timestamps in multiplexer tests

### DIFF
--- a/src/v/datalake/tests/gtest_record_multiplexer_test.cc
+++ b/src/v/datalake/tests/gtest_record_multiplexer_test.cc
@@ -44,6 +44,11 @@ const model::ntp
 const model::revision_id rev{123};
 record_translator translator;
 ss::abort_source as;
+// Record timestamps are pinned to the middle of an hour: the default table
+// partition spec is hour(redpanda.timestamp), so wall-clock timestamps
+// produce an extra partition (and data file) whenever a test's records
+// straddle the top of an hour.
+constexpr model::timestamp mid_hour_timestamp{1000002600000};
 } // namespace
 
 TEST(DatalakeMultiplexerTest, TestMultiplexer) {
@@ -76,6 +81,7 @@ TEST(DatalakeMultiplexerTest, TestMultiplexer) {
     batch_spec.records = record_count;
     batch_spec.count = batch_count;
     batch_spec.offset = model::offset{start_offset};
+    batch_spec.timestamp = mid_hour_timestamp;
     chunked_circular_buffer<model::record_batch> batches
       = model::test::make_random_batches(batch_spec).get();
 
@@ -195,6 +201,7 @@ TEST(DatalakeMultiplexerTest, WritesDataFiles) {
     batch_spec.records = record_count;
     batch_spec.count = batch_count;
     batch_spec.offset = model::offset{start_offset};
+    batch_spec.timestamp = mid_hour_timestamp;
     chunked_circular_buffer<model::record_batch> batches
       = model::test::make_random_batches(batch_spec).get();
 
@@ -372,6 +379,7 @@ TEST_F(RecordMultiplexerParquetTest, TestKeySchemaMode) {
     for (int i = 0; i < num_records; ++i) {
         storage::record_batch_builder builder(
           model::record_batch_type::raft_data, model::offset{o});
+        builder.set_timestamp(mid_hour_timestamp);
         auto key_buf = gen.encode_avro_buf("key_schema").get();
         ASSERT_FALSE(key_buf.has_error()) << key_buf.error();
         auto add_res = gen


### PR DESCRIPTION
The default table partition spec is `hour(redpanda.timestamp)` and the tests stamp records starting at wall-clock `now()`, so a run starting within a second of the top of an hour splits records across two hourly partitions and fails the single-data-file assertions.

Therefore, this test fails 0.03% of the time, depending on the time of day, and on how (un)lucky you are :) 

Pin record timestamps to the middle of an hour to avoid the flake.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
