### PR TITLE
[CORE-16883] `kafka`: erase `group` before awaiting `shutdown()`

### DIFF
--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -357,8 +357,10 @@ ss::future<size_t> group_manager::delete_offsets(
     if (group->in_state(group_state::dead)) {
         auto it = _groups.find(group->id());
         if (it != _groups.end() && it->second == group) {
-            co_await it->second->shutdown();
+            // erase before shutdown()'s suspension point so concurrent
+            // deletion paths can't find the group and close its gate twice
             _groups.erase(it);
+            co_await group->shutdown();
             if (group->generation() > 0) {
                 vlog(
                   cg_klog.trace,
@@ -455,10 +457,17 @@ ss::future<> group_manager::stop() {
 
     return _gate.close().then([this]() {
         /**
-         * cancel all pending group opeartions
+         * cancel all pending group opeartions. remove the groups from the
+         * index before shutting them down so that, like every other
+         * shutdown path, only the fiber that erased a group closes its
+         * gate
          */
-        return ss::do_for_each(
-                 _groups, [](auto& p) { return p.second->shutdown(); })
+        return ss::do_with(
+                 std::exchange(_groups, {}),
+                 [](auto& groups) {
+                     return ss::do_for_each(
+                       groups, [](auto& p) { return p.second->shutdown(); });
+                 })
           .then([this] { _partitions.clear(); });
     });
 }
@@ -538,9 +547,11 @@ ss::future<> group_manager::cleanup_removed_topic_partitions(
             continue;
         }
         vlog(cg_klog.trace, "Removed group {}", group);
-        co_await group->shutdown();
+        // erase before shutdown()'s suspension point so concurrent
+        // deletion paths can't find the group and close its gate twice
         _groups.erase(it);
         _groups.rehash(0);
+        co_await group->shutdown();
     }
 }
 
@@ -2080,8 +2091,14 @@ ss::future<chunked_vector<deletable_group_result>> group_manager::delete_groups(
         // - batch tombstones same backing partition
         error = co_await group->remove();
         if (error == error_code::none) {
-            co_await group->shutdown();
-            _groups.erase(group_info.second);
+            auto it = _groups.find(group_info.second);
+            if (it != _groups.end() && it->second == group) {
+                // erase before shutdown()'s suspension point so concurrent
+                // deletion paths can't find the group and close its gate
+                // twice
+                _groups.erase(it);
+                co_await group->shutdown();
+            }
         }
         results.push_back(
           deletable_group_result{

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -339,6 +339,7 @@ redpanda_cc_btest(
         "//src/v/model:timeout_clock",
         "//src/v/redpanda/tests:fixture",
         "//src/v/security",
+        "//src/v/ssx:sformat",
         "//src/v/test_utils:scoped_config",
         "//src/v/test_utils:seastar_boost",
         "//src/v/utils:base64",

--- a/src/v/kafka/server/tests/consumer_groups_test.cc
+++ b/src/v/kafka/server/tests/consumer_groups_test.cc
@@ -28,6 +28,7 @@
 #include "model/timeout_clock.h"
 #include "redpanda/tests/fixture.h"
 #include "security/acl.h"
+#include "ssx/sformat.h"
 #include "test_utils/async.h"
 #include "test_utils/boost_fixture.h"
 #include "test_utils/scoped_config.h"
@@ -583,6 +584,85 @@ FIXTURE_TEST(conditional_retention_test, consumer_offsets_fixture) {
                 std::rethrow_exception(std::make_exception_ptr(e));
             }
         }
+    }
+}
+
+FIXTURE_TEST(group_delete_races_topic_cleanup, consumer_offsets_fixture) {
+    // regression test for a group gate double-close crash: deleting a topic
+    // triggers cleanup_removed_topic_partitions for every group holding
+    // offsets on it, while delete_groups can target the same groups
+    // concurrently (during data migration cut_over the migration worker does
+    // exactly this combination). both paths must agree on a single owner of
+    // group::shutdown() — a group must be erased from the group index before
+    // the erasing fiber suspends — or the loser trips the seastar gate
+    // double-close assertion and aborts the binary.
+    scoped_config cfg;
+    cfg.get("group_topic_partitions").set_value(1);
+
+    kafka::group_instance_id gi("group-instance");
+    wait_for_consumer_offsets_topic(gi);
+
+    auto client = make_kafka_client().get();
+    auto deferred = ss::defer([&client] {
+        client.stop().then([&client] { client.shutdown(); }).get();
+    });
+    client.connect().get();
+
+    model::ntp gntp(
+      model::kafka_namespace,
+      model::kafka_consumer_offsets_topic,
+      model::partition_id(0));
+    wait_for_leader(gntp).get();
+
+    constexpr int iterations = 10;
+    constexpr int groups_per_iteration = 8;
+
+    for (int iter = 0; iter < iterations; ++iter) {
+        model::topic t(ssx::sformat("gate-race-{}", iter));
+        add_topic(model::topic_namespace_view{model::kafka_namespace, t}).get();
+
+        std::vector<kafka::group_id> groups;
+        groups.reserve(groups_per_iteration);
+        for (int i = 0; i < groups_per_iteration; ++i) {
+            kafka::group_id g(ssx::sformat("gate-race-{}-{}", iter, i));
+            auto req = offset_commit_request{.data{
+              .group_id = g,
+              .topics = chunked_vector<offset_commit_request_topic>::single(
+                offset_commit_request_topic{
+                  .name = t,
+                  .partitions
+                  = chunked_vector<offset_commit_request_partition>::single(
+                    offset_commit_request_partition{
+                      .partition_index = model::partition_id{0},
+                      .committed_offset = model::offset{0}})})}};
+            auto resp
+              = client.dispatch(std::move(req), kafka::api_version(7)).get();
+            BOOST_REQUIRE(!resp.data.errored());
+            groups.push_back(std::move(g));
+        }
+
+        auto topic_deleted = delete_topic(
+          model::topic_namespace(model::kafka_namespace, t));
+
+        // hammer delete_groups while the topic deletion propagates and the
+        // background cleanup shuts the groups down, until every group is
+        // gone from the group index
+        auto deadline = model::timeout_clock::now() + 60s;
+        bool all_gone = false;
+        while (!all_gone) {
+            BOOST_REQUIRE(model::timeout_clock::now() < deadline);
+            chunked_vector<std::pair<model::ntp, kafka::group_id>> gs;
+            for (const auto& g : groups) {
+                gs.emplace_back(gntp, g);
+            }
+            auto results = app._group_manager.local()
+                             .delete_groups(std::move(gs), false)
+                             .get();
+            all_gone = std::ranges::all_of(results, [](const auto& r) {
+                return r.error_code == kafka::error_code::group_id_not_found;
+            });
+        }
+        std::move(topic_deleted).get();
     }
 }
 


### PR DESCRIPTION
Concurrent fibers could race and cause multiple callers into `group::shutdown()`, triggering an assertion failure:

```
seastar/include/seastar/core/gate.hh:160: future<> seastar::gate::close(): Assertion `!_stopped && "seastar::gate::close() cannot be called more than once"` failed.
```

To avoid this problem, always follow the idiom of finding and erasing synchronously from `_groups` _first_ (so that concurrent fibers will see a failure on `_groups.find()`) before awaiting `group::shutdown()`.  Do the same thing in `stop()`, with an `std::exchange()` on the entire`_groups` container.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.1.x
- [X] v25.3.x
- [X] v25.2.x

## Release Notes

* none
