### PR TITLE
[CORE-7759] tests: retry initial produce in test_coordinator_nodes_balance

### DIFF
--- a/tests/rptest/tests/consumer_group_balancing_test.py
+++ b/tests/rptest/tests/consumer_group_balancing_test.py
@@ -10,8 +10,9 @@
 from collections import defaultdict
 from math import floor
 
+from ducktape.utils.util import wait_until
 
-from rptest.clients.rpk import RpkTool
+from rptest.clients.rpk import RpkException, RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
@@ -41,13 +42,36 @@ class ConsumerGroupBalancingTest(RedpandaTest):
         topic = TopicSpec(partition_count=1)
         self.client().create_topic(topic)
 
-        # execute a single produce/consume to initialize __consumer_group topic
         rpk = RpkTool(self.redpanda)
-        rpk.produce(topic=topic.name, key="test_key", msg="test_msg", partition=0)
+        admin = Admin(self.redpanda)
+
+        # Wait for the freshly-started cluster to settle before producing.
+        admin.await_stable_leader(topic.name, partition=0, timeout_s=30, backoff_s=1)
+
+        # Initialize __consumer_offsets via a produce/consume. The first produce
+        # lazily creates the id_allocator (via InitProducerID), whose leader
+        # election can outlast the 5s delivery timeout on a just-started cluster.
+        # Retry only that transient timeout; re-raise any other error.
+        def initial_produce_succeeds() -> bool:
+            try:
+                rpk.produce(
+                    topic=topic.name, key="test_key", msg="test_msg", partition=0
+                )
+                return True
+            except RpkException as e:
+                if "timed out" in e.msg + e.stderr:
+                    return False
+                raise
+
+        wait_until(
+            initial_produce_succeeds,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="initial produce did not succeed while the cluster warmed up",
+        )
 
         rpk.consume(topic=topic.name, n=1, group="test-group")
 
-        admin = Admin(self.redpanda)
         partitions = admin.get_partitions("__consumer_offsets")
         replicas_per_node = defaultdict(lambda: 0)
 


### PR DESCRIPTION
## Why this is needed

`ConsumerGroupBalancingTest.test_coordinator_nodes_balance` has been a
long-standing flaky test (CORE-7759): it failed intermittently in CI across
`amd64`/`arm64` and `ci-docker-aws` over a long period, each time in the test's
bootstrap step rather than in the behavior it actually asserts (even
distribution of `__consumer_offsets` replicas across nodes).

## Where it failed and why

The failure is not in the assertion — it is in the single "bootstrap" produce
used to initialize `__consumer_offsets`:

```python
rpk.produce(topic=topic.name, key="test_key", msg="test_msg", partition=0)
```

`rpk.produce` runs with the default `DEFAULT_PRODUCE_TIMEOUT = 5s`
(`--delivery-timeout 5s`). On a freshly-started cluster the very first produce
must first obtain a producer id via **InitProducerID**, which **lazily creates
the `id_allocator` partition and elects its leader**. On a slow/contended
startup that election can outlast the 5s delivery deadline, so the record's
whole delivery budget is consumed before it is ever sent:

```
wrote InitProducerID v3   {"broker": "2"}
read  InitProducerID v3   "time_to_read": "5.154685802s"   <- InitProducerID > 5s
producer id initialization success {"id": 1}               <- succeeded, but too late
unable to produce record: records have timed out before they were able to be produced
```

The delivery timeout is a budget for the *whole* delivery, including the
InitProducerID handshake, so when the first handshake on a cold cluster is slow
the record times out and the test fails spuriously. This has nothing to do with
what the test verifies.

## The fix

1. Wait for the cluster to settle before producing, via
   `admin.await_stable_leader(topic.name, partition=0)` — confirms the
   controller is up and Raft elections are succeeding.
2. Retry the bootstrap produce with `wait_until`, so a slow first InitProducerID
   no longer fails the run. The retry is deliberately **narrow**: it only
   swallows the transient timeout (`"timed out" in e.msg + e.stderr`) and
   re-raises any other `RpkException` immediately, so genuine failures still
   surface with their real message (matching the existing idiom in
   `shadow_indexing_firewall_test.py`). Matching `"timed out"` covers both ways
   `rpk._execute` reports a timeout: rpk exiting non-zero with
   "records have timed out" in stderr, and Python's `subprocess.TimeoutExpired`
   whose message is "command ... timed out".

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none
