### PR TITLE
serde: write fixed envelopes contiguously

### DIFF
--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -394,9 +394,6 @@ inline void iobuf::create_new_fragment(size_t sz) {
 /// as an empty details::io_fragment
 inline void iobuf::reserve_memory(size_t reservation) {
     if (auto b = available_bytes(); b < reservation) {
-        if (b > 0) {
-            _frags.back().trim();
-        }
         create_new_fragment(reservation); // make space if not enough
     }
 }

--- a/src/v/bytes/tests/iobuf_tests.cc
+++ b/src/v/bytes/tests/iobuf_tests.cc
@@ -199,6 +199,20 @@ SEASTAR_THREAD_TEST_CASE(test_writing_placeholders_at_end) {
     BOOST_REQUIRE_EQUAL(buf.size_bytes(), 15);
 }
 
+SEASTAR_THREAD_TEST_CASE(test_repeated_reservations_grow_fragments) {
+    constexpr size_t reservation_size = 513;
+    constexpr size_t reservation_count = 1000;
+
+    iobuf buf;
+    for (size_t i = 0; i < reservation_count; ++i) {
+        [[maybe_unused]] auto placeholder = buf.reserve(reservation_size);
+    }
+
+    BOOST_REQUIRE_EQUAL(buf.size_bytes(), reservation_size * reservation_count);
+    BOOST_REQUIRE_LT(
+      std::distance(buf.cbegin(), buf.cend()), reservation_count / 10);
+}
+
 SEASTAR_THREAD_TEST_CASE(test_temporary_buffs) {
     iobuf buf;
     ss::temporary_buffer<char> x(55);

--- a/src/v/serde/BUILD
+++ b/src/v/serde/BUILD
@@ -11,6 +11,7 @@ redpanda_cc_library(
         "peek.h",
         "read_header.h",
         "rw/envelope.h",
+        "rw/fixed.h",
         "rw/reservable.h",
         "rw/rw.h",
         "rw/scalar.h",

--- a/src/v/serde/rw/bool_class.h
+++ b/src/v/serde/rw/bool_class.h
@@ -9,14 +9,29 @@
 
 #pragma once
 
+#include "serde/rw/fixed.h"
 #include "serde/rw/rw.h"
 
 #include <cinttypes>
 
 namespace serde {
 
+namespace detail {
+
 template<typename Tag>
-void tag_invoke(tag_t<write_tag>, iobuf& out, ss::bool_class<Tag> t) {
+requires(
+  !has_nonmember_write_nested<ss::bool_class<Tag>>
+  && !disable_fixed_serde_v<ss::bool_class<Tag>>)
+struct fixed_serde_traits<ss::bool_class<Tag>> {
+    static constexpr bool supported = true;
+    static constexpr size_t size = sizeof(int8_t);
+    static constexpr bool requires_validation = false;
+};
+
+} // namespace detail
+
+template<SerdeWriteOutput Output, typename Tag>
+void tag_invoke(tag_t<write_tag>, Output& out, ss::bool_class<Tag> t) {
     write(out, static_cast<int8_t>(bool(t)));
 }
 

--- a/src/v/serde/rw/enum.h
+++ b/src/v/serde/rw/enum.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "base/vlog.h"
+#include "serde/rw/fixed.h"
 #include "serde/rw/rw.h"
 #include "serde/serde_exception.h"
 #include "serde/serde_is_enum.h"
@@ -21,22 +22,13 @@
 
 namespace serde {
 
-template<typename T>
+template<SerdeWriteOutput Output, typename T>
 requires(serde_is_enum_v<std::decay_t<T>>)
-void tag_invoke(tag_t<write_tag>, iobuf& out, T t) {
-#if defined(__cpp_lib_is_scoped_enum) && __cpp_lib_is_scoped_enum >= 202011L
+void tag_invoke(tag_t<write_tag>, Output& out, T t) {
     static_assert(std::is_scoped_enum_v<std::decay_t<T>>);
-#endif
     using Type = std::decay_t<T>;
+    detail::validate_serde_enum(t);
     const auto val = static_cast<std::underlying_type_t<Type>>(t);
-    if (unlikely(!std::in_range<serde_enum_serialized_t>(val))) {
-        throw serde_exception{fmt_with_ctx(
-          ssx::sformat,
-          "serde: enum of type {} has value {} which is out of bounds for "
-          "serde_enum_serialized_t",
-          type_str<T>(),
-          val)};
-    }
     write(out, static_cast<serde_enum_serialized_t>(val));
 }
 

--- a/src/v/serde/rw/envelope.h
+++ b/src/v/serde/rw/envelope.h
@@ -15,6 +15,7 @@
 #include "serde/envelope.h"
 #include "serde/envelope_for_each_field.h"
 #include "serde/read_header.h"
+#include "serde/rw/fixed.h"
 #include "serde/rw/rw.h"
 #include "serde/serde_size_t.h"
 
@@ -92,53 +93,125 @@ void tag_invoke(
     }
 }
 
-template<typename T>
-requires is_envelope<std::decay_t<T>>
-void tag_invoke(tag_t<write_tag>, iobuf& out, T&& t) {
-    using Type = std::decay_t<T>;
+namespace detail {
 
-    write(out, Type::redpanda_serde_version);
-    write(out, Type::redpanda_serde_compat_version);
+[[gnu::always_inline]] inline crc::crc32c
+envelope_body_crc(iobuf& out, size_t body_offset) {
+    auto crc = crc::crc32c{};
+    auto in = iobuf_const_parser{out};
+    in.skip(body_offset);
+    in.consume(in.bytes_left(), [&crc](const char* src, const std::size_t n) {
+        crc.extend(src, n);
+        return ss::stop_iteration::no;
+    });
+    return crc;
+}
 
-    auto size_placeholder = out.reserve(sizeof(serde_size_t));
+[[gnu::always_inline]] inline crc::crc32c
+envelope_body_crc(contiguous_output& out, size_t body_offset) {
+    const auto body = out.written_from(body_offset);
+    auto crc = crc::crc32c{};
+    crc.extend(body.data(), body.size());
+    return crc;
+}
 
-    auto checksum_placeholder = iobuf::placeholder{};
+template<typename Type, SerdeWriteOutput Output, typename Func>
+[[gnu::always_inline]] inline void
+write_sized_envelope(Output& out, Func&& write_body) {
+    auto size_placeholder = [&out] {
+        if constexpr (fixed_serde_v<Type>) {
+            write(
+              out,
+              static_cast<serde_size_t>(fixed_serde_traits<Type>::body_size));
+            return typename Output::placeholder{};
+        } else {
+            static_assert(std::same_as<Output, iobuf>);
+            return out.reserve(sizeof(serde_size_t));
+        }
+    }();
+
+    auto checksum_placeholder = [&] {
+        if constexpr (is_checksum_envelope<Type>) {
+            return out.reserve(sizeof(checksum_t));
+        } else {
+            return typename Output::placeholder{};
+        }
+    }();
+
+    const auto body_offset = out.size_bytes();
+    std::forward<Func>(write_body)();
+
+    if constexpr (!fixed_serde_v<Type>) {
+        const auto written_size = out.size_bytes() - body_offset;
+        if (unlikely(written_size > std::numeric_limits<serde_size_t>::max())) {
+            throw serde_exception("envelope too big");
+        }
+        const auto size = ss::cpu_to_le(
+          static_cast<serde_size_t>(written_size));
+        size_placeholder.write(
+          reinterpret_cast<const char*>(&size), sizeof(serde_size_t));
+    }
+
     if constexpr (is_checksum_envelope<Type>) {
-        checksum_placeholder = out.reserve(sizeof(checksum_t));
-    }
-
-    const auto size_before = out.size_bytes();
-    if constexpr (has_serde_write<Type>) {
-        static_assert(!has_serde_fields<Type>);
-        t.serde_write(out);
-    } else {
-        envelope_for_each_field(
-          t, [&out](auto& f) { write(out, std::forward_like<T>(f)); });
-    }
-
-    const auto written_size = out.size_bytes() - size_before;
-    if (unlikely(written_size > std::numeric_limits<serde_size_t>::max())) {
-        throw serde_exception("envelope too big");
-    }
-    const auto size = ss::cpu_to_le(static_cast<serde_size_t>(written_size));
-    size_placeholder.write(
-      reinterpret_cast<const char*>(&size), sizeof(serde_size_t));
-
-    if constexpr (is_checksum_envelope<Type>) {
-        auto crc = crc::crc32c{};
-        auto in = iobuf_const_parser{out};
-        in.skip(size_before);
-        in.consume(
-          in.bytes_left(), [&crc](const char* src, const std::size_t n) {
-              crc.extend(src, n);
-              return ss::stop_iteration::no;
-          });
+        const auto crc = envelope_body_crc(out, body_offset);
         const auto checksum = ss::cpu_to_le(crc.value());
         static_assert(
           std::is_same_v<std::decay_t<decltype(checksum)>, checksum_t>);
         checksum_placeholder.write(
           reinterpret_cast<const char*>(&checksum), sizeof(checksum_t));
     }
+}
+
+template<typename Type, SerdeWriteOutput Output, typename T>
+[[gnu::always_inline]] inline void write_envelope(Output& out, T&& value) {
+    write(out, Type::redpanda_serde_version);
+    write(out, Type::redpanda_serde_compat_version);
+    write_sized_envelope<Type>(out, [&out, &value] {
+        if constexpr (has_serde_write<Type>) {
+            static_assert(!has_serde_fields<Type>);
+            value.serde_write(out);
+        } else {
+            envelope_for_each_field(value, [&out](auto& field) {
+                write(out, std::forward_like<T>(field));
+            });
+        }
+    });
+}
+
+template<typename Type, typename T>
+[[gnu::always_inline]] inline void
+with_serialization_output(iobuf& out, T&& value) {
+    // Reserve fixed envelopes once at the iobuf boundary. Nested serialization
+    // then uses the contiguous cursor and avoids per-field fragment checks.
+    if constexpr (fixed_serde_v<Type>) {
+        if constexpr (fixed_serde_traits<Type>::requires_validation) {
+            fixed_serde_traits<Type>::validate(value);
+        }
+        auto storage = out.reserve(fixed_serde_size_v<Type>);
+        contiguous_output writer(storage.mutable_index());
+        write_envelope<Type>(writer, std::forward<T>(value));
+    } else {
+        write_envelope<Type>(out, std::forward<T>(value));
+    }
+}
+
+template<typename Type, typename T>
+[[gnu::always_inline]] inline void
+with_serialization_output(contiguous_output& out, T&& value) {
+    write_envelope<Type>(out, std::forward<T>(value));
+}
+
+} // namespace detail
+
+template<SerdeWriteOutput Output, typename T>
+requires(
+  is_envelope<std::decay_t<T>>
+  && (std::same_as<Output, iobuf> || detail::fixed_serde_v<std::decay_t<T>>))
+[[gnu::always_inline]] inline void
+tag_invoke(tag_t<write_tag>, Output& out, T&& t) {
+    using Type = std::decay_t<T>;
+
+    detail::with_serialization_output<Type>(out, std::forward<T>(t));
 }
 
 } // namespace serde

--- a/src/v/serde/rw/fixed.h
+++ b/src/v/serde/rw/fixed.h
@@ -1,0 +1,232 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "bytes/details/io_allocation_size.h"
+#include "bytes/iobuf.h"
+#include "serde/checksum_t.h"
+#include "serde/envelope.h"
+#include "serde/envelope_for_each_field.h"
+#include "serde/rw/rw.h"
+#include "serde/serde_exception.h"
+#include "serde/serde_is_enum.h"
+#include "serde/serde_size_t.h"
+#include "serde/type_str.h"
+#include "ssx/sformat.h"
+
+#include <concepts>
+#include <cstring>
+#include <limits>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+
+namespace serde {
+
+/// Set to true when a custom writer changes the canonical encoding of a type
+/// that would otherwise be eligible for fixed-width serialization.
+template<typename T>
+inline constexpr bool disable_fixed_serde_v = false;
+
+namespace detail {
+
+template<typename T>
+requires(serde_is_enum_v<std::decay_t<T>>)
+void validate_serde_enum(T value) {
+    using Type = std::decay_t<T>;
+    const auto raw = static_cast<std::underlying_type_t<Type>>(value);
+    if (unlikely(!std::in_range<serde_enum_serialized_t>(raw))) {
+        throw serde_exception{fmt_with_ctx(
+          ssx::sformat,
+          "serde: enum of type {} has value {} which is out of bounds for "
+          "serde_enum_serialized_t",
+          type_str<T>(),
+          raw)};
+    }
+}
+
+class contiguous_output {
+public:
+    class placeholder {
+    public:
+        placeholder() noexcept = default;
+
+        explicit placeholder(char* cursor)
+          : _cursor(cursor) {}
+
+        void write(const char* src, size_t size) {
+            std::memcpy(_cursor, src, size);
+        }
+
+    private:
+        char* _cursor{nullptr};
+    };
+
+    explicit contiguous_output(char* cursor)
+      : _begin(cursor)
+      , _cursor(cursor) {}
+
+    void append(const char* src, size_t size) {
+        std::memcpy(_cursor, src, size);
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        _cursor += size;
+    }
+
+    placeholder reserve(size_t size) {
+        auto* cursor = _cursor;
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        _cursor += size;
+        return placeholder{cursor};
+    }
+
+    size_t size_bytes() const { return static_cast<size_t>(_cursor - _begin); }
+
+    std::string_view written_from(size_t offset) const {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        return {_begin + offset, size_bytes() - offset};
+    }
+
+private:
+    char* _begin;
+    char* _cursor;
+};
+
+template<typename T>
+struct fixed_serde_traits {
+    static constexpr bool supported = false;
+    static constexpr size_t size = 0;
+    static constexpr bool requires_validation = false;
+};
+
+template<typename T>
+inline constexpr bool fixed_serde_v
+  = fixed_serde_traits<std::remove_cvref_t<T>>::supported;
+
+template<typename T>
+inline constexpr size_t fixed_serde_size_v
+  = fixed_serde_traits<std::remove_cvref_t<T>>::size;
+
+template<typename T>
+requires(
+  std::is_arithmetic_v<T> && !std::same_as<T, bool>
+  && !has_nonmember_write_nested<T> && !disable_fixed_serde_v<T>)
+struct fixed_serde_traits<T> {
+    static constexpr bool supported = true;
+    static constexpr size_t size = sizeof(T);
+    static constexpr bool requires_validation = false;
+};
+
+template<>
+struct fixed_serde_traits<bool> {
+    static constexpr bool supported = true;
+    static constexpr size_t size = sizeof(int8_t);
+    static constexpr bool requires_validation = false;
+};
+
+template<typename T>
+requires(
+  serde_is_enum_v<T> && std::is_scoped_enum_v<T>
+  && !has_nonmember_write_nested<T> && !disable_fixed_serde_v<T>)
+struct fixed_serde_traits<T> {
+    using underlying_type = std::underlying_type_t<T>;
+
+    static constexpr bool supported = true;
+    static constexpr size_t size = sizeof(serde_enum_serialized_t);
+    static constexpr bool requires_validation
+      = !std::in_range<serde_enum_serialized_t>(
+          std::numeric_limits<underlying_type>::lowest())
+        || !std::in_range<serde_enum_serialized_t>(
+          std::numeric_limits<underlying_type>::max());
+
+    static void validate(T value)
+    requires requires_validation
+    {
+        validate_serde_enum(value);
+    }
+};
+
+template<typename Tuple, size_t... Index>
+consteval bool fixed_tuple_supported(std::index_sequence<Index...>) {
+    return (fixed_serde_v<std::tuple_element_t<Index, Tuple>> && ...);
+}
+
+template<typename Tuple>
+inline constexpr bool fixed_tuple_supported_v = fixed_tuple_supported<Tuple>(
+  std::make_index_sequence<std::tuple_size_v<Tuple>>{});
+
+template<typename Tuple, size_t... Index>
+consteval size_t fixed_tuple_size(std::index_sequence<Index...>) {
+    return (fixed_serde_size_v<std::tuple_element_t<Index, Tuple>> + ... + 0);
+}
+
+template<typename Tuple>
+inline constexpr size_t fixed_tuple_size_v = fixed_tuple_size<Tuple>(
+  std::make_index_sequence<std::tuple_size_v<Tuple>>{});
+
+template<typename Tuple, size_t... Index>
+consteval bool fixed_tuple_requires_validation(std::index_sequence<Index...>) {
+    return (
+      fixed_serde_traits<std::remove_cvref_t<
+        std::tuple_element_t<Index, Tuple>>>::requires_validation
+      || ...);
+}
+
+template<typename Tuple>
+inline constexpr bool fixed_tuple_requires_validation_v
+  = fixed_tuple_requires_validation<Tuple>(
+    std::make_index_sequence<std::tuple_size_v<Tuple>>{});
+
+template<typename T>
+concept has_fixed_serde_fields = requires(T value) { value.serde_fields(); };
+
+template<typename T>
+concept has_custom_serde_write = requires(T value, iobuf& out) {
+    value.serde_write(out);
+};
+
+template<typename T>
+requires(
+  is_envelope<T> && has_fixed_serde_fields<T> && !has_custom_serde_write<T>
+  && !has_nonmember_write_nested<T> && !disable_fixed_serde_v<T>)
+struct fixed_serde_traits<T> {
+    using fields_type = decltype(envelope_to_tuple(std::declval<const T&>()));
+
+    static constexpr size_t body_size = fixed_tuple_size_v<fields_type>;
+    static constexpr size_t size
+      = 2 * sizeof(version_t) + sizeof(serde_size_t)
+        + (is_checksum_envelope<T> ? sizeof(checksum_t) : 0) + body_size;
+    static constexpr bool supported
+      = fixed_tuple_supported_v<fields_type>
+        && body_size <= std::numeric_limits<serde_size_t>::max()
+        && size <= ::details::io_allocation_size::ss_max_small_allocation;
+    static constexpr bool requires_validation
+      = fixed_tuple_requires_validation_v<fields_type>;
+
+    static void validate(const T& value)
+    requires(supported && requires_validation)
+    {
+        std::apply(
+          [](const auto&... field) {
+              (
+                []<typename Field>(const Field& field) {
+                    if constexpr (
+                      fixed_serde_traits<Field>::requires_validation) {
+                        fixed_serde_traits<Field>::validate(field);
+                    }
+                }(field),
+                ...);
+          },
+          envelope_to_tuple(value));
+    }
+};
+
+} // namespace detail
+
+} // namespace serde

--- a/src/v/serde/rw/named_type.h
+++ b/src/v/serde/rw/named_type.h
@@ -9,10 +9,36 @@
 
 #pragma once
 
+#include "serde/rw/fixed.h"
 #include "serde/rw/rw.h"
 #include "utils/named_type.h"
 
 namespace serde {
+
+namespace detail {
+
+template<typename T, typename Tag, typename IsConstexpr>
+requires(
+  fixed_serde_v<T>
+  && !disable_fixed_serde_v<::detail::base_named_type<T, Tag, IsConstexpr>>
+  && !has_nonmember_write_nested<
+     ::detail::base_named_type<T, Tag, IsConstexpr>>)
+struct fixed_serde_traits<::detail::base_named_type<T, Tag, IsConstexpr>> {
+    using type = ::detail::base_named_type<T, Tag, IsConstexpr>;
+
+    static constexpr bool supported = true;
+    static constexpr size_t size = fixed_serde_size_v<T>;
+    static constexpr bool requires_validation
+      = fixed_serde_traits<T>::requires_validation;
+
+    static void validate(const type& value)
+    requires requires_validation
+    {
+        fixed_serde_traits<T>::validate(value());
+    }
+};
+
+} // namespace detail
 
 template<typename T, typename Tag, typename IsConstexpr>
 void tag_invoke(
@@ -24,10 +50,14 @@ void tag_invoke(
     t = Type{read_nested<typename Type::type>(in, bytes_left_limit)};
 }
 
-template<typename T, typename Tag, typename IsConstexpr>
+template<
+  SerdeWriteOutput Output,
+  typename T,
+  typename Tag,
+  typename IsConstexpr>
 void tag_invoke(
   tag_t<write_tag>,
-  iobuf& out,
+  Output& out,
   ::detail::base_named_type<T, Tag, IsConstexpr> t) {
     return write(out, static_cast<T>(t));
 }

--- a/src/v/serde/rw/rw.h
+++ b/src/v/serde/rw/rw.h
@@ -60,30 +60,34 @@ std::decay_t<T> read(iobuf_parser& in) {
     return ret;
 }
 
-template<typename T>
-concept has_nonmember_write_nested_lv = requires(const T& t, iobuf& out) {
+template<typename Output, typename T>
+concept has_nonmember_write_nested_lv_for = requires(const T& t, Output& out) {
     { write_nested(out, t) } -> std::same_as<void>;
 };
 
-template<typename T>
-concept has_nonmember_write_nested_rv = requires(T&& t, iobuf& out) {
+template<typename Output, typename T>
+concept has_nonmember_write_nested_rv_for = requires(T&& t, Output& out) {
     { write_nested(out, std::move(t)) } -> std::same_as<void>;
 };
 
-template<typename T>
-concept has_nonmember_write_nested = []() consteval {
+template<typename Output, typename T>
+concept has_nonmember_write_nested_for = []() consteval {
     // `write_nested` must be defined either for both lvalue and rvalue T or for
     // neither.
     static_assert(
-      has_nonmember_write_nested_lv<T> == has_nonmember_write_nested_rv<T>);
-    return has_nonmember_write_nested_lv<T>;
+      has_nonmember_write_nested_lv_for<Output, T>
+      == has_nonmember_write_nested_rv_for<Output, T>);
+    return has_nonmember_write_nested_lv_for<Output, T>;
 }();
 
+template<typename T>
+concept has_nonmember_write_nested = has_nonmember_write_nested_for<iobuf, T>;
+
 // Two functions just to be able to specify T explicitly when calling.
-template<typename T, bool IsRvalue = true>
+template<typename T, bool IsRvalue = true, typename Output>
 requires(!std::is_reference_v<T>)
-void write(iobuf& b, T&& x) {
-    if constexpr (has_nonmember_write_nested<T>) {
+void write(Output& b, T&& x) {
+    if constexpr (has_nonmember_write_nested_for<Output, T>) {
         // NOLINTNEXTLINE(bugprone-move-forwarding-reference)
         write_nested(b, std::move(x));
     } else {
@@ -92,10 +96,10 @@ void write(iobuf& b, T&& x) {
     }
 }
 
-template<typename T, bool IsRvalue = false>
+template<typename T, bool IsRvalue = false, typename Output>
 requires(!std::is_reference_v<T>)
-void write(iobuf& b, const T& x) {
-    if constexpr (has_nonmember_write_nested<T>) {
+void write(Output& b, const T& x) {
+    if constexpr (has_nonmember_write_nested_for<Output, T>) {
         write_nested(b, x);
     } else {
         write_tag(b, x);

--- a/src/v/serde/rw/scalar.h
+++ b/src/v/serde/rw/scalar.h
@@ -50,9 +50,9 @@ void tag_invoke(
     }
 }
 
-template<typename T>
+template<SerdeWriteOutput Output, typename T>
 requires(std::is_scalar_v<std::decay_t<T>> && !serde_is_enum_v<std::decay_t<T>>)
-void tag_invoke(tag_t<write_tag>, iobuf& out, T t) {
+void tag_invoke(tag_t<write_tag>, Output& out, T t) {
     using Type = std::decay_t<T>;
     if constexpr (sizeof(Type) == 1) {
         out.append(reinterpret_cast<const char*>(&t), sizeof(t));
@@ -71,7 +71,8 @@ void tag_invoke(tag_t<write_tag>, iobuf& out, T t) {
     }
 }
 
-inline void tag_invoke(tag_t<write_tag>, iobuf& out, bool t) {
+template<SerdeWriteOutput Output>
+inline void tag_invoke(tag_t<write_tag>, Output& out, bool t) {
     write_tag(out, static_cast<int8_t>(t));
 }
 

--- a/src/v/serde/rw/tags.h
+++ b/src/v/serde/rw/tags.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <concepts>
+#include <cstddef>
 #include <type_traits>
 
 class iobuf;
@@ -16,10 +18,18 @@ class iobuf_parser;
 
 namespace serde {
 
+template<typename Output>
+concept SerdeWriteOutput = requires(
+  Output& out, const char* src, std::size_t size) {
+    out.append(src, size);
+    out.reserve(size);
+    { out.size_bytes() } -> std::convertible_to<std::size_t>;
+};
+
 // How to use:
 //
 // template<typename T>
-// void tag_invoke(tag_t<write_tag>, iobuf& out, my_type<T> t) {
+// void tag_invoke(tag_t<write_tag>, SerdeWriteOutput auto& out, my_type<T> t) {
 //     // write `t` to `out`
 // }
 //
@@ -31,13 +41,16 @@ namespace serde {
 //   std::size_t const bytes_left_limit) {
 //     t = ...; // read from `in` to `t`
 // }
+//
+// Writers that change the canonical encoding of an otherwise fixed-width type
+// must specialize `disable_fixed_serde_v<T>` to true.
 
 template<auto& CPO>
 using tag_t = std::remove_cvref_t<decltype(CPO)>;
 
 inline constexpr struct write_fn {
-    template<typename T>
-    void operator()(iobuf& b, T&& x) const {
+    template<typename Output, typename T>
+    void operator()(Output& b, T&& x) const {
         return tag_invoke(*this, b, std::forward<T>(x));
     }
 } write_tag{};

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -84,6 +84,159 @@ struct test_msg0
     auto serde_fields() { return std::tie(_i, _j); }
 };
 
+using fixed_write_flag = ss::bool_class<struct fixed_write_flag_tag>;
+enum class fixed_write_wide_enum : uint32_t { value = 7 };
+
+using custom_write_flag = ss::bool_class<struct custom_write_flag_tag>;
+void write_nested(iobuf&, custom_write_flag) {}
+
+enum class custom_write_enum : int8_t { value };
+void tag_invoke(serde::tag_t<serde::write_tag>, iobuf&, custom_write_enum) {}
+template<>
+inline constexpr bool serde::disable_fixed_serde_v<custom_write_enum> = true;
+
+struct fixed_write_msg
+  : serde::
+      envelope<fixed_write_msg, serde::version<3>, serde::compat_version<2>> {
+    int8_t i8;
+    int16_t i16;
+    int32_t i32;
+    int64_t i64;
+    float f32;
+    double f64;
+    model::offset offset;
+    my_enum value;
+    fixed_write_wide_enum wide_value;
+    bool flag;
+    fixed_write_flag bool_class;
+    test_msg0 nested;
+
+    auto serde_fields() {
+        return std::tie(
+          i8,
+          i16,
+          i32,
+          i64,
+          f32,
+          f64,
+          offset,
+          value,
+          wide_value,
+          flag,
+          bool_class,
+          nested);
+    }
+};
+
+struct fieldwise_test_msg0
+  : serde::envelope<
+      fieldwise_test_msg0,
+      serde::version<1>,
+      serde::compat_version<0>> {
+    char i;
+    char j;
+
+    void serde_write(iobuf& out) const {
+        serde::write(out, i);
+        serde::write(out, j);
+    }
+};
+
+struct fieldwise_write_msg
+  : serde::envelope<
+      fieldwise_write_msg,
+      serde::version<3>,
+      serde::compat_version<2>> {
+    int8_t i8;
+    int16_t i16;
+    int32_t i32;
+    int64_t i64;
+    float f32;
+    double f64;
+    model::offset offset;
+    my_enum value;
+    fixed_write_wide_enum wide_value;
+    bool flag;
+    fixed_write_flag bool_class;
+    fieldwise_test_msg0 nested;
+
+    void serde_write(iobuf& out) const {
+        serde::write(out, i8);
+        serde::write(out, i16);
+        serde::write(out, i32);
+        serde::write(out, i64);
+        serde::write(out, f32);
+        serde::write(out, f64);
+        serde::write(out, offset);
+        serde::write(out, value);
+        serde::write(out, wide_value);
+        serde::write(out, flag);
+        serde::write(out, bool_class);
+        serde::write(out, nested);
+    }
+};
+
+struct fixed_checksummed_msg
+  : serde::checksum_envelope<
+      fixed_checksummed_msg,
+      serde::version<3>,
+      serde::compat_version<2>> {
+    int32_t value;
+    test_msg0 nested;
+
+    auto serde_fields() { return std::tie(value, nested); }
+    bool operator==(const fixed_checksummed_msg&) const = default;
+};
+
+struct fieldwise_checksummed_msg
+  : serde::checksum_envelope<
+      fieldwise_checksummed_msg,
+      serde::version<3>,
+      serde::compat_version<2>> {
+    int32_t value;
+    test_msg0 nested;
+
+    void serde_write(iobuf& out) const {
+        serde::write(out, value);
+        serde::write(out, nested);
+    }
+};
+
+template<size_t Depth>
+struct fixed_write_tree
+  : serde::envelope<
+      fixed_write_tree<Depth>,
+      serde::version<1>,
+      serde::compat_version<0>> {
+    fixed_write_tree<Depth - 1> left;
+    fixed_write_tree<Depth - 1> right;
+
+    auto serde_fields() { return std::tie(left, right); }
+};
+
+template<>
+struct fixed_write_tree<0>
+  : serde::envelope<
+      fixed_write_tree<0>,
+      serde::version<1>,
+      serde::compat_version<0>> {
+    int64_t value;
+
+    auto serde_fields() { return std::tie(value); }
+};
+
+static_assert(serde::detail::fixed_serde_v<float>);
+static_assert(serde::detail::fixed_serde_v<double>);
+static_assert(serde::detail::fixed_serde_v<fixed_write_wide_enum>);
+static_assert(!serde::detail::fixed_serde_v<custom_write_flag>);
+static_assert(!serde::detail::fixed_serde_v<custom_write_enum>);
+static_assert(serde::detail::fixed_serde_v<fixed_write_msg>);
+static_assert(serde::detail::fixed_serde_v<fixed_checksummed_msg>);
+static_assert(!serde::detail::fixed_serde_v<fieldwise_checksummed_msg>);
+static_assert(serde::detail::fixed_serde_v<fixed_write_tree<10>>);
+static_assert(!serde::detail::fixed_serde_v<fixed_write_tree<11>>);
+static_assert(!serde::detail::fixed_serde_v<fieldwise_write_msg>);
+
 struct test_msg1
   : serde::envelope<test_msg1, serde::version<4>, serde::compat_version<0>> {
     bool operator==(const test_msg1&) const = default;
@@ -200,6 +353,76 @@ SEASTAR_THREAD_TEST_CASE(envelope_test) {
     BOOST_CHECK(m._c == 44);
     BOOST_CHECK(m._m._i == 'i');
     BOOST_CHECK(m._m._j == 'j');
+}
+
+SEASTAR_THREAD_TEST_CASE(fixed_envelope_matches_fieldwise_encoding) {
+    const auto fixed = serde::to_iobuf(
+      fixed_write_msg{
+        .i8 = 1,
+        .i16 = -2,
+        .i32 = -3,
+        .i64 = -4,
+        .f32 = 1.25F,
+        .f64 = -2.5,
+        .offset = model::offset{-5},
+        .value = my_enum::z,
+        .wide_value = fixed_write_wide_enum::value,
+        .flag = false,
+        .bool_class = fixed_write_flag::no,
+        .nested = test_msg0{._i = 'i', ._j = 'j'},
+      });
+    const auto fieldwise = serde::to_iobuf(
+      fieldwise_write_msg{
+        .i8 = 1,
+        .i16 = -2,
+        .i32 = -3,
+        .i64 = -4,
+        .f32 = 1.25F,
+        .f64 = -2.5,
+        .offset = model::offset{-5},
+        .value = my_enum::z,
+        .wide_value = fixed_write_wide_enum::value,
+        .flag = false,
+        .bool_class = fixed_write_flag::no,
+        .nested = fieldwise_test_msg0{.i = 'i', .j = 'j'},
+      });
+
+    BOOST_REQUIRE(fixed == fieldwise);
+}
+
+SEASTAR_THREAD_TEST_CASE(fixed_checksum_matches_fieldwise_encoding) {
+    const auto value = fixed_checksummed_msg{
+      .value = 42,
+      .nested = test_msg0{._i = 'i', ._j = 'j'},
+    };
+    const auto fixed = serde::to_iobuf(value);
+    const auto fieldwise = serde::to_iobuf(
+      fieldwise_checksummed_msg{
+        .value = value.value,
+        .nested = value.nested,
+      });
+
+    BOOST_REQUIRE(fixed == fieldwise);
+    BOOST_REQUIRE(
+      serde::from_iobuf<fixed_checksummed_msg>(fixed.copy()) == value);
+
+    auto corrupted = fixed.copy();
+    auto& last_fragment = *corrupted.rbegin();
+    last_fragment.get_write()[last_fragment.size() - 1] += 1;
+    BOOST_REQUIRE_THROW(
+      serde::from_iobuf<fixed_checksummed_msg>(corrupted.copy()),
+      serde::serde_exception);
+}
+
+SEASTAR_THREAD_TEST_CASE(fixed_envelope_validates_before_reserving) {
+    auto out = iobuf::from("prefix");
+    const auto invalid = fixed_write_msg{
+      .wide_value = static_cast<fixed_write_wide_enum>(
+        std::numeric_limits<uint32_t>::max()),
+    };
+
+    BOOST_REQUIRE_THROW(serde::write(out, invalid), serde::serde_exception);
+    BOOST_REQUIRE(out == "prefix");
 }
 
 SEASTAR_THREAD_TEST_CASE(envelope_test_version_older_than_compat_version) {


### PR DESCRIPTION
Serde is known to be notriously slow and full of boilerplate.

Fieldwise envelope serialization mutates the iobuf for each header and
field, then backfills the body size. Those separate mutations retain their
capacity checks and slow paths in optimized code.

Detect canonical fixed-width layouts at compile time, reserve the complete
wire size once, and encode directly into that reservation. Fall back for
variable fields, checksums, custom writers, and oversized envelopes.

For this we introduce a new trait which envelopes can use to enable this
faster mode of serialization. We enable it for the important built-in
types which allows most of the basic types that use `serde_fields` to
benefit from this.

While this introduces quite a bit of code the huge benefits we see from
this justify that.

Note that this doesn't rely on pod-ness or byte blasting structs or
anything like that. The advantage comes from less iobuf logic and basic
sequential memcpy of the various fields.

Repeated exact reservations also exposed reserve_memory trimming the old
fragment before selecting the next allocation size. Select the
replacement size first so these writes preserve geometric fragment
growth (iobuf::last_allocation_size actually looks at capacity which
trim shrinks). Keep both changes atomic because the fixed writer depends
on that growth behavior.

A few select benchmarks, parent to this commit:

serde_rpbench instructions:
- small.serialize: 466.05 -> 279.05 (-40.1%)
- big_1mb.serialize: 2125.27 -> 1945.27 (-8.5%)
- big_10mb.serialize: 6976.40 -> 6796.40 (-2.6%)

heartbeat_bench_rpbench instructions:
- request_full: 4314311.48 -> 1062637.85 (-75.4%)
- request_mixed: 866459.13 -> 216129.98 (-75.1%)
- reply_full: 4956346.17 -> 1463519.23 (-70.5%)
- reply_mixed: 995977.09 -> 297587.46 (-70.1%)

heartbeat_bench_rpbench tasks:
- request_full: 1.906 -> 0.682 (-64.2%)
- request_mixed: 0.379 -> 0.136 (-64.0%)
- reply_full: 2.360 -> 0.850 (-64.0%)
- reply_mixed: 0.466 -> 0.173 (-63.0%)

heartbeat_bench_rpbench allocations:
- request_full: 34.477 -> 34.170 (-0.9%)
- request_mixed: 17.095 -> 17.034 (-0.4%)
- reply_full: 36.590 -> 32.212 (-12.0%)
- reply_mixed: 17.117 -> 17.043 (-0.4%)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes


* none


