### PR TITLE
[v25.3.x] `json`: reduce per-character costs in chunked buffer and input stream

### DIFF
--- a/src/v/json/chunked_buffer.h
+++ b/src/v/json/chunked_buffer.h
@@ -12,6 +12,10 @@
 #include "bytes/iobuf.h"
 #include "json/encodings.h"
 
+#include <array>
+#include <optional>
+#include <string_view>
+
 namespace json {
 
 template<
@@ -25,6 +29,10 @@ namespace impl {
 
 /**
  * \brief An in-memory output stream with non-contiguous memory allocation.
+ *
+ * Single characters are staged in a small inline buffer and flushed to the
+ * underlying iobuf in blocks, so that per-character Put() calls don't pay
+ * for an iobuf::append() each.
  */
 template<typename Encoding>
 struct generic_chunked_buffer {
@@ -35,18 +43,26 @@ struct generic_chunked_buffer {
      */
     /**@{*/
 
-    void Put(Ch c) { _impl.append(&c, sizeof(Ch)); }
-    void Flush() {}
+    void Put(Ch c) {
+        if (_staged == stage_capacity) [[unlikely]] {
+            flush_stage();
+        }
+        _stage[_staged++] = c;
+    }
+    void Flush() { flush_stage(); }
 
     //! Get the size of string in bytes in the string buffer.
-    size_t GetSize() const { return _impl.size_bytes(); }
+    size_t GetSize() const { return _impl.size_bytes() + _staged * sizeof(Ch); }
 
     //! Get the length of string in Ch in the string buffer.
-    size_t GetLength() const { return _impl.size_bytes() / sizeof(Ch); }
+    size_t GetLength() const { return GetSize() / sizeof(Ch); }
 
     void Reserve(size_t s) { _impl.reserve_memory(s); }
 
-    void Clear() { _impl.clear(); }
+    void Clear() {
+        _impl.clear();
+        _staged = 0;
+    }
 
     /**@}*/
 
@@ -55,15 +71,42 @@ struct generic_chunked_buffer {
      * fragment and is a zero-copy operation.
      */
     void append(std::unique_ptr<iobuf::fragment> frag) {
+        flush_stage();
         _impl.append(std::move(frag));
+    }
+
+    /**
+     * If the buffered data is entirely contiguous in memory (i.e. it never
+     * spilled out of the stage buffer), return a view over it. The view is
+     * invalidated by any subsequent modification of this buffer.
+     */
+    std::optional<std::basic_string_view<Ch>> contiguous_view() const {
+        if (!_impl.empty()) {
+            return std::nullopt;
+        }
+        return std::basic_string_view<Ch>{_stage.data(), _staged};
     }
 
     /**
      * Return the underlying iobuf, this is destructive and zero-copy.
      */
-    iobuf as_iobuf() && { return std::move(_impl); }
+    iobuf as_iobuf() && {
+        flush_stage();
+        return std::move(_impl);
+    }
 
 private:
+    void flush_stage() {
+        if (_staged > 0) {
+            _impl.append(
+              reinterpret_cast<const char*>(_stage.data()),
+              _staged * sizeof(Ch));
+            _staged = 0;
+        }
+    }
+
+    static constexpr size_t stage_capacity = 1024;
+
     template<
       typename OutputStream,
       typename SourceEncoding,
@@ -71,6 +114,8 @@ private:
       unsigned writeFlags>
     friend class json::generic_iobuf_writer;
     iobuf _impl;
+    std::array<Ch, stage_capacity> _stage;
+    size_t _staged{0};
 };
 
 } // namespace impl

--- a/src/v/json/chunked_input_stream.h
+++ b/src/v/json/chunked_input_stream.h
@@ -9,9 +9,10 @@
 
 #pragma once
 
-#include "bytes/streambuf.h"
+#include "bytes/iobuf.h"
 #include "json/encodings.h"
-#include "json/istreamwrapper.h"
+
+#include <utility>
 
 namespace json {
 
@@ -19,39 +20,72 @@ namespace impl {
 
 /**
  * \brief An in-memory input stream with non-contiguous memory allocation.
+ *
+ * Reads directly from the iobuf's fragments via iobuf::byte_iterator:
+ * Peek()/Take() are pointer operations over the current fragment, hopping
+ * to the next fragment at its boundary.
  */
 template<typename Encoding = ::json::UTF8<>>
 class chunked_input_stream {
 public:
     using Ch = Encoding::Ch;
+    static_assert(
+      sizeof(Ch) == sizeof(char), "only single-byte encodings are supported");
+
+    /// rapidjson streams have no explicit end-of-input signal; the reader
+    /// detects termination by seeing a NUL (StringStream parses C strings
+    /// and runs into the terminator, other streams synthesize it). A raw
+    /// NUL is never legitimate JSON, so no payload byte is masked.
+    static constexpr Ch eof_sentinel = '\0';
 
     explicit chunked_input_stream(iobuf&& buf)
       : _buf(std::move(buf))
-      , _is(_buf)
-      , _sis{&_is}
-      , _isw(_sis) {}
+      , _it(std::as_const(_buf).begin(), std::as_const(_buf).end())
+      , _end(std::as_const(_buf).end(), std::as_const(_buf).end()) {}
+
+    chunked_input_stream(const chunked_input_stream&) = delete;
+    chunked_input_stream& operator=(const chunked_input_stream&) = delete;
+    chunked_input_stream(chunked_input_stream&&) = delete;
+    chunked_input_stream& operator=(chunked_input_stream&&) = delete;
+    ~chunked_input_stream() = default;
 
     /**
      * \defgroup Implement rapidjson::Stream
      */
     /**@{*/
 
-    Ch Peek() const { return _isw.Peek(); }
-    Ch Peek4() const { return _isw.Peek4(); }
-    Ch Take() { return _isw.Take(); }
-    size_t Tell() const { return _isw.Tell(); }
-    void Put(Ch ch) { return _isw.Put(ch); }
-    Ch* PutBegin() { return _isw.PutBegin(); }
-    size_t PutEnd(Ch* ch) { return _isw.PutEnd(ch); }
-    void Flush() { return _isw.Flush(); }
+    Ch Peek() const { return _it != _end ? *_it : eof_sentinel; }
+    Ch Take() {
+        if (_it == _end) [[unlikely]] {
+            return eof_sentinel;
+        }
+        Ch c = *_it;
+        ++_it;
+        ++_consumed;
+        return c;
+    }
+    size_t Tell() const { return _consumed; }
+
+    // Not implemented, present to satisfy in-situ parsing codepaths that are
+    // instantiated but never taken.
+    void Put(Ch) { RAPIDJSON_ASSERT(false); }
+    Ch* PutBegin() {
+        RAPIDJSON_ASSERT(false);
+        return nullptr;
+    }
+    size_t PutEnd(Ch*) {
+        RAPIDJSON_ASSERT(false);
+        return 0;
+    }
+    void Flush() { RAPIDJSON_ASSERT(false); }
 
     /**@}*/
 
 private:
     iobuf _buf;
-    iobuf_istreambuf _is;
-    std::istream _sis;
-    ::json::IStreamWrapper _isw;
+    iobuf::byte_iterator _it;
+    iobuf::byte_iterator _end;
+    size_t _consumed{0};
 };
 
 } // namespace impl

--- a/src/v/json/iobuf_writer.h
+++ b/src/v/json/iobuf_writer.h
@@ -80,6 +80,9 @@ private:
             if (!Base::WriteString(i->get(), i->size())) {
                 return false;
             }
+            // The fixup below reads and writes fragment memory directly, so
+            // any bytes still staged in the buffer must be flushed to it.
+            this->os_->Flush();
             if (i != beg) {
                 // 4. Restore the stashed character over the prefix-quote
                 *stash_pos = stashed;

--- a/src/v/pandaproxy/json/requests/produce.h
+++ b/src/v/pandaproxy/json/requests/produce.h
@@ -167,11 +167,21 @@ public:
         return _sink;
     }
 
-    bool ChunkedString(::json::SizeType) {
-        auto encoded = std::move(_sink).as_iobuf();
-        // drop the '\0' terminator appended by the reader
-        encoded.trim_back(sizeof(Ch));
-        auto [res, buf] = rjson_parse_impl<iobuf>(_fmt)(std::move(encoded));
+    bool ChunkedString(::json::SizeType len) {
+        auto decode = [this, len] {
+            // Small strings that never spilled out of the sink's inline
+            // stage are decoded from contiguous memory, skipping the iobuf
+            // round-trip.
+            if (auto v = _sink.contiguous_view(); v.has_value()) {
+                // drop the '\0' terminator appended by the reader
+                return rjson_parse_impl<iobuf>(_fmt)(v->substr(0, len));
+            }
+            auto encoded = std::move(_sink).as_iobuf();
+            // drop the '\0' terminator appended by the reader
+            encoded.trim_back(sizeof(Ch));
+            return rjson_parse_impl<iobuf>(_fmt)(std::move(encoded));
+        };
+        auto [res, buf] = decode();
         if (res) {
             if (state == state::key) {
                 result.back().key = std::move(buf);

--- a/src/v/pandaproxy/json/test/parse.cc
+++ b/src/v/pandaproxy/json/test/parse.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "bytes/iobuf.h"
 #include "pandaproxy/json/requests/produce.h"
 #include "pandaproxy/json/rjson_util.h"
 
@@ -48,4 +49,17 @@ inline void parse_test(size_t data_size) {
     perf_tests::stop_measuring_time();
 }
 
+// Parse from an iobuf via chunked_input_stream, the path production HTTP
+// bodies take (pandaproxy streams request content into an iobuf).
+inline void parse_test_iobuf(size_t data_size) {
+    auto input = gen(data_size);
+    iobuf buf;
+    buf.append(input.data(), input.size());
+
+    perf_tests::start_measuring_time();
+    auto records = ppj::rjson_parse(std::move(buf), make_binary_v2_handler());
+    perf_tests::stop_measuring_time();
+}
+
 PERF_TEST(json_parse_test, binary) { parse_test(record_count); }
+PERF_TEST(json_parse_test, binary_iobuf) { parse_test_iobuf(record_count); }

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -12,6 +12,7 @@
 #include "pandaproxy/schema_registry/json.h"
 
 #include "base/format_to.h"
+#include "bytes/streambuf.h"
 #include "container/chunked_hash_map.h"
 #include "json/chunked_buffer.h"
 #include "json/chunked_input_stream.h"


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31215

- Command: git cherry-pick -x 7c2e22ca5b 73c39b1741 bd0b146a57 8dc62ae826
- Commits backported: 4
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-31215-v25.3.x-1784736536

## Conflict details

- 8dc62ae826 (src/v/pandaproxy/schema_registry/BUILD): dev has a standalone `json_schema` library that the commit adds `//src/v/bytes:streambuf` to, but v25.3.x compiles `json.cc` inside the `core` library, which already lists `//src/v/bytes:streambuf` in its `implementation_deps`. Kept the target branch's `core` structure and discarded the incoming `json_schema` block; the commit's dependency intent is already satisfied on the target.
