### PR TITLE
[v26.2.x] [CORE-16880] `kafka`: autocreate internal topics with correct properties

### DIFF
--- a/src/v/cluster/BUILD
+++ b/src/v/cluster/BUILD
@@ -1247,6 +1247,7 @@ redpanda_cc_library(
         ":errc",
         ":logger",
         "//src/v/base",
+        "//src/v/config",
         "@fmt",
     ],
     visibility = ["//visibility:public"],

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -1199,16 +1199,8 @@ ss::future<> controller::cluster_creation_hook(
  * how many replicas they should use.
  */
 int16_t controller::internal_topic_replication() const {
-    auto replication_factor
-      = (int16_t)config::shard_local_cfg().internal_topic_replication_factor();
-    if (replication_factor > (int16_t)_members_table.local().node_count()) {
-        // Fall back to r=1 if we do not have sufficient nodes
-        return 1;
-    } else {
-        // Respect `internal_topic_replication_factor` if enough
-        // nodes were available.
-        return replication_factor;
-    }
+    return cluster::internal_topic_replication(
+      _members_table.local().node_count());
 }
 
 ss::future<result<std::vector<partition_state>>>

--- a/src/v/cluster/members_table.cc
+++ b/src/v/cluster/members_table.cc
@@ -14,6 +14,7 @@
 #include "cluster/errc.h"
 #include "cluster/logger.h"
 #include "cluster/types.h"
+#include "config/configuration.h"
 #include "model/metadata.h"
 
 #include <fmt/format.h>
@@ -413,6 +414,18 @@ void members_table::notify_member_updated(
     for (const auto& [id, cb] : _members_updated_notifications) {
         cb(n, new_state);
     }
+}
+
+int16_t internal_topic_replication(size_t node_count) {
+    auto replication_factor = static_cast<int16_t>(
+      config::shard_local_cfg().internal_topic_replication_factor());
+    if (replication_factor > static_cast<int16_t>(node_count)) {
+        // Fall back to r=1 if we do not have sufficient nodes
+        return 1;
+    }
+    // Respect `internal_topic_replication_factor` if enough
+    // nodes were available.
+    return replication_factor;
 }
 
 } // namespace cluster

--- a/src/v/cluster/members_table.h
+++ b/src/v/cluster/members_table.h
@@ -115,4 +115,10 @@ private:
 
     void notify_member_updated(model::node_id, model::membership_state);
 };
+
+/// Helper for subsystems that create internal topics, to discover how many
+/// replicas they should use: respects `internal_topic_replication_factor`
+/// if enough nodes are available, otherwise falls back to r=1.
+int16_t internal_topic_replication(size_t node_count);
+
 } // namespace cluster

--- a/src/v/kafka/server/BUILD
+++ b/src/v/kafka/server/BUILD
@@ -70,6 +70,7 @@ redpanda_cc_library(
         "//src/v/pandaproxy/schema_registry:types",
         "//src/v/security",
         "//src/v/serde:chrono",
+        "//src/v/ssx:sformat",
         "//src/v/strings:string_switch",
         "//src/v/utils:absl_sstring_hash",
         "//src/v/utils:tristate",

--- a/src/v/kafka/server/BUILD
+++ b/src/v/kafka/server/BUILD
@@ -321,6 +321,7 @@ redpanda_cc_library(
         "//src/v/cluster:shard_table",
         "//src/v/cluster:state_machine_registry",
         "//src/v/cluster:tm_stm",
+        "//src/v/cluster:topic_configuration",
         "//src/v/cluster:topic_table",
         "//src/v/cluster:tx_protocol_types",
         "//src/v/cluster:types",

--- a/src/v/kafka/server/group_initializer.cc
+++ b/src/v/kafka/server/group_initializer.cc
@@ -12,6 +12,7 @@
 #include "kafka/server/group_initializer.h"
 
 #include "cluster/controller_api.h"
+#include "cluster/members_table.h"
 #include "cluster/topics_frontend.h"
 #include "kafka/protocol/logger.h"
 /*
@@ -60,13 +61,25 @@ ss::future<bool> group_initializer::assure_topic_exists(
     co_return true;
 }
 
+cluster::topic_configuration consumer_offsets_topic_configuration(
+  model::topic_namespace tp_ns, int16_t replication_factor) {
+    cluster::topic_configuration topic{
+      std::move(tp_ns.ns),
+      std::move(tp_ns.tp),
+      config::shard_local_cfg().group_topic_partitions(),
+      replication_factor};
+
+    topic.properties.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::compaction;
+    // allow creation even if a consumer group migration is in progress
+    topic.is_migrated = true;
+    return topic;
+}
+
 /*
  * create the internal metadata topic for group membership
  */
 ss::future<bool> group_initializer::try_create_consumer_group_topic() {
-    // Attempt to use internal topic replication factor, if enough nodes found.
-    auto replication_factor
-      = (int16_t)config::shard_local_cfg().internal_topic_replication_factor();
     if (!_members_table.local_is_initialized()) {
         vlog(
           klog.warn,
@@ -74,23 +87,14 @@ ss::future<bool> group_initializer::try_create_consumer_group_topic() {
           "initialized");
         return ssx::now(false);
     }
-    if (
-      static_cast<size_t>(replication_factor)
-      > _members_table.local().node_count()) {
-        replication_factor = 1;
-    }
+    // Attempt to use internal topic replication factor, if enough nodes found.
+    auto replication_factor = cluster::internal_topic_replication(
+      _members_table.local().node_count());
 
     // the new internal metadata topic for group membership
-    cluster::topic_configuration topic{
-      _coordinator_ntp_mapper.ns(),
-      _coordinator_ntp_mapper.topic(),
-      config::shard_local_cfg().group_topic_partitions(),
-      replication_factor};
-
-    topic.properties.cleanup_policy_bitflags
-      = model::cleanup_policy_bitflags::compaction;
-    // allow cretation even if a consumer group migration is in progress
-    topic.is_migrated = true;
+    auto topic = consumer_offsets_topic_configuration(
+      {_coordinator_ntp_mapper.ns(), _coordinator_ntp_mapper.topic()},
+      replication_factor);
 
     if (!_topics_frontend.local_is_initialized()) {
         vlog(

--- a/src/v/kafka/server/group_initializer.h
+++ b/src/v/kafka/server/group_initializer.h
@@ -10,11 +10,19 @@
  */
 #pragma once
 
+#include "cluster/topic_configuration.h"
 #include "kafka/server/coordinator_ntp_mapper.h"
 /*
  * This class creates consumer offsets topic
  */
 namespace kafka {
+
+/// \brief The intended configuration of the consumer group metadata topic:
+/// compacted, with group_topic_partitions partitions. Creation is permitted
+/// while a consumer group migration is in progress.
+cluster::topic_configuration consumer_offsets_topic_configuration(
+  model::topic_namespace tp_ns, int16_t replication_factor);
+
 class group_initializer {
 public:
     group_initializer(

--- a/src/v/kafka/server/handlers/configs/config_response_utils.cc
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.cc
@@ -136,18 +136,6 @@ bool config_property_requested(
                 != configuration_keys->end();
 }
 
-template<typename T>
-ss::sstring describe_as_string(const T& t) {
-    if constexpr (::detail::is_specialization_of_v<T, std::chrono::duration>) {
-        return ssx::sformat("{}", t.count());
-    } else {
-        return ssx::sformat("{}", t);
-    }
-}
-
-// Instantiate explicitly for unit testing
-template ss::sstring describe_as_string(const int&);
-
 // Kafka protocol defines integral types by sizes. See
 // https://kafka.apache.org/protocol.html
 // Therefore we should also use type sizes for integrals and use Java type sizes
@@ -464,15 +452,6 @@ template void add_topic_config_if_requested<int, describe_int_t>(
   std::optional<ss::sstring> documentation,
   describe_int_t&& describe_f,
   bool hide_default_override = false);
-
-template<typename T>
-static ss::sstring maybe_print_tristate(const tristate<T>& tri) {
-    if (tri.is_disabled() || !tri.has_optional_value()) {
-        return "-1";
-    }
-
-    return describe_as_string(tri.value());
-}
 
 template<typename T>
 static void add_topic_config(

--- a/src/v/kafka/server/handlers/configs/config_response_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "base/type_traits.h"
 #include "cluster/types.h"
 #include "container/chunked_vector.h"
 #include "kafka/protocol/describe_configs.h"
@@ -18,7 +19,10 @@
 #include "model/compression.h"
 #include "model/fundamental.h"
 #include "pandaproxy/schema_registry/subject_name_strategy.h"
+#include "ssx/sformat.h"
+#include "utils/tristate.h"
 
+#include <chrono>
 #include <iterator>
 #include <optional>
 
@@ -41,6 +45,28 @@ struct config_response {
 
 using config_response_container_t = chunked_vector<config_response>;
 using config_key_t = std::optional<chunked_vector<ss::sstring>>;
+
+/// Serialize a topic property value the way it appears in Kafka
+/// configuration responses (durations as their millisecond count).
+template<typename T>
+ss::sstring describe_as_string(const T& t) {
+    if constexpr (::detail::is_specialization_of_v<T, std::chrono::duration>) {
+        return ssx::sformat("{}", t.count());
+    } else {
+        return ssx::sformat("{}", t);
+    }
+}
+
+/// Serialize a tristate topic property value the way it appears in Kafka
+/// configuration responses: -1 when disabled or not set.
+template<typename T>
+ss::sstring maybe_print_tristate(const tristate<T>& tri) {
+    if (tri.is_disabled() || !tri.has_optional_value()) {
+        return "-1";
+    }
+
+    return describe_as_string(tri.value());
+}
 
 /// This abstract interface was added in order to decouple metadata_cache from
 /// the make_topic_configs method below.  This allows us to create our own

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -9,6 +9,7 @@
 
 #include "kafka/server/handlers/metadata.h"
 
+#include "cluster/members_table.h"
 #include "cluster/metadata_cache.h"
 #include "cluster/topics_frontend.h"
 #include "cluster/types.h"
@@ -20,10 +21,12 @@
 #include "kafka/protocol/types.h"
 #include "kafka/server/errors.h"
 #include "kafka/server/fwd.h"
+#include "kafka/server/group_initializer.h"
 #include "kafka/server/handlers/describe_cluster.h"
 #include "kafka/server/handlers/details/leader_epoch.h"
 #include "kafka/server/handlers/details/security.h"
 #include "kafka/server/handlers/topics/topic_utils.h"
+#include "kafka/server/handlers/topics/types.h"
 #include "kafka/server/response.h"
 #include "model/errc.h"
 #include "model/metadata.h"
@@ -31,6 +34,7 @@
 #include "model/timeout_clock.h"
 #include "random/generators.h"
 #include "security/acl.h"
+#include "security/audit/audit_log_topic.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future-util.hh>
@@ -206,6 +210,49 @@ metadata_response::topic make_topic_response_from_topic_metadata(
 }
 
 namespace {
+/// Internal topics requested by name are created with their owning
+/// subsystem's configuration rather than cluster defaults, mirroring Apache
+/// Kafka's special-casing of internal topics during metadata-driven topic
+/// auto-creation.
+cluster::topic_configuration
+autocreate_topic_configuration(request_context& ctx, model::topic topic) {
+    if (topic == model::kafka_consumer_offsets_topic) {
+        return consumer_offsets_topic_configuration(
+          model::kafka_consumer_offsets_nt,
+          cluster::internal_topic_replication(
+            ctx.metadata_cache().node_count()));
+    }
+    if (topic == model::schema_registry_internal_tp.topic) {
+        return schema_registry_topic_configuration(
+          cluster::internal_topic_replication(
+            ctx.metadata_cache().node_count()));
+    }
+    if (topic == model::kafka_audit_logging_topic) {
+        auto replication_factor
+          = config::shard_local_cfg().audit_log_replication_factor().value_or(
+            cluster::internal_topic_replication(
+              ctx.metadata_cache().node_count()));
+        cluster::topic_configuration cfg{
+          model::kafka_namespace,
+          std::move(topic),
+          config::shard_local_cfg().audit_log_num_partitions(),
+          replication_factor};
+        cfg.properties = security::audit::audit_log_topic_properties();
+        return cfg;
+    }
+    // default topic configuration
+    cluster::topic_configuration cfg{
+      model::kafka_namespace,
+      std::move(topic),
+      config::shard_local_cfg().default_topic_partitions(),
+      config::shard_local_cfg().default_topic_replication()};
+    // Need to respect the default_redpanda_storage_mode when autocreating a
+    // topic.
+    cfg.properties.storage_mode
+      = config::shard_local_cfg().default_redpanda_storage_mode();
+    return cfg;
+}
+
 ss::future<metadata_response::topic> create_topic(
   request_context& ctx,
   model::topic topic,
@@ -221,20 +268,10 @@ ss::future<metadata_response::topic> create_topic(
         t.error_code = error_code::broker_not_available;
         co_return t;
     }
-    // default topic configuration
-    cluster::topic_configuration cfg{
-      model::kafka_namespace,
-      topic,
-      config::shard_local_cfg().default_topic_partitions(),
-      config::shard_local_cfg().default_topic_replication()};
-    // Need to respect the default_redpanda_storage_mode when autocreating a
-    // topic.
-    cfg.properties.storage_mode
-      = config::shard_local_cfg().default_redpanda_storage_mode();
     auto tout = config::shard_local_cfg().internal_rpc_request_timeout_ms();
     try {
         auto res = co_await ctx.topics_frontend().autocreate_topics(
-          {std::move(cfg)}, tout);
+          {autocreate_topic_configuration(ctx, topic)}, tout);
         vassert(res.size() == 1, "expected single result");
         // error, neither success nor topic exists
         if (!(res[0].ec == cluster::errc::success
@@ -251,10 +288,11 @@ ss::future<metadata_response::topic> create_topic(
           ctx.controller_api(),
           tout + model::timeout_clock::now());
 
-        auto tp_md = ctx.metadata_cache().get_topic_metadata(res[0].tp_ns);
+        auto tp_md = ctx.metadata_cache().get_topic_metadata(
+          model::topic_namespace_view(model::kafka_namespace, topic));
         if (!tp_md) {
             metadata_response::topic t;
-            t.name = std::move(res[0].tp_ns.tp);
+            t.name = std::move(topic);
             t.error_code = error_code::invalid_topic_exception;
             co_return t;
         }

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -385,6 +385,33 @@ cluster::topic_configuration to_topic_config(
     return cfg;
 }
 
+cluster::topic_configuration
+schema_registry_topic_configuration(int16_t replication_factor) {
+    // Create the base topic configuration to get the cluster defaults
+    auto cfg = to_topic_config(
+      model::kafka_namespace,
+      model::schema_registry_internal_tp.topic,
+      /*partition_count=*/1,
+      replication_factor,
+      {});
+    // Now update the properties
+    cfg.properties.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::compaction;
+    cfg.properties.compression = model::compression::none;
+    cfg.properties.retention_bytes = tristate<size_t>{disable_tristate};
+    cfg.properties.retention_duration = tristate<std::chrono::milliseconds>{
+      disable_tristate};
+    cfg.properties.retention_local_target_bytes = tristate<size_t>{
+      disable_tristate};
+    cfg.properties.retention_local_target_ms
+      = tristate<std::chrono::milliseconds>{disable_tristate};
+    cfg.properties.initial_retention_local_target_bytes = tristate<size_t>{
+      disable_tristate};
+    cfg.properties.initial_retention_local_target_ms
+      = tristate<std::chrono::milliseconds>{disable_tristate};
+    return cfg;
+}
+
 static std::vector<kafka::creatable_topic_configs>
 convert_topic_configs(config_response_container_t&& topic_cfgs) {
     auto configs = std::vector<kafka::creatable_topic_configs>();

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -165,6 +165,11 @@ cluster::topic_configuration to_topic_config(
   int16_t replication_factor,
   const config_map_t& config_map);
 
+/// \brief The intended configuration of the schema registry's internal
+/// topic (_schemas): a single compacted partition with retention disabled.
+cluster::topic_configuration
+schema_registry_topic_configuration(int16_t replication_factor);
+
 std::vector<kafka::creatable_topic_configs> report_topic_configs(
   const cluster::metadata_cache& metadata_cache,
   const cluster::topic_properties& topic_properties);

--- a/src/v/kafka/server/tests/metadata_test.cc
+++ b/src/v/kafka/server/tests/metadata_test.cc
@@ -20,6 +20,7 @@
 #include "kafka/server/handlers/details/security.h"
 #include "kafka/server/handlers/metadata.h"
 #include "model/fundamental.h"
+#include "model/namespace.h"
 #include "model/timeout_clock.h"
 #include "redpanda/tests/fixture.h"
 #include "security/acl.h"
@@ -548,6 +549,73 @@ FIXTURE_TEST(metadata_autocreate, metadata_fixture) {
         BOOST_REQUIRE_EQUAL(topics.size(), 1);
         BOOST_REQUIRE_EQUAL(topics[0].error_code, kafka::error_code::none);
     }
+}
+
+FIXTURE_TEST(metadata_autocreate_internal_topics, metadata_fixture) {
+    // Internal topics auto-created in response to a metadata request must
+    // get their owning subsystem's configuration, not cluster defaults.
+    auto undo = set_auto_create_topics(true);
+    wait_for_controller_leadership().get();
+
+    auto client = make_kafka_client().get();
+    client.connect().get();
+    auto close = ss::defer([&client] { client.stop().get(); });
+
+    auto req = kafka::metadata_request{.data{
+      .topics = {{
+        {.name{model::kafka_consumer_offsets_topic}},
+        {.name{model::schema_registry_internal_tp.topic}},
+        {.name{model::kafka_audit_logging_topic}},
+      }},
+      .allow_auto_topic_creation = true,
+      .include_cluster_authorized_operations = false,
+      .include_topic_authorized_operations = false}};
+    auto resp = client.dispatch(std::move(req), kafka::api_version{9}).get();
+
+    // Only check topic-level errors: partitions may transiently report
+    // leader_not_available until leadership metadata catches up with the
+    // freshly created topics.
+    BOOST_REQUIRE_EQUAL(resp.data.topics.size(), 3);
+    for (const auto& topic : resp.data.topics) {
+        BOOST_REQUIRE_EQUAL(topic.error_code, kafka::error_code::none);
+    }
+
+    const auto& topics_state = app.controller->get_topics_state().local();
+
+    auto co_cfg = topics_state.get_topic_cfg(model::kafka_consumer_offsets_nt);
+    BOOST_REQUIRE(co_cfg.has_value());
+    BOOST_CHECK_EQUAL(
+      co_cfg->partition_count,
+      config::shard_local_cfg().group_topic_partitions());
+    BOOST_CHECK(
+      co_cfg->properties.cleanup_policy_bitflags
+      == model::cleanup_policy_bitflags::compaction);
+
+    auto schemas_cfg = topics_state.get_topic_cfg(
+      {model::kafka_namespace, model::schema_registry_internal_tp.topic});
+    BOOST_REQUIRE(schemas_cfg.has_value());
+    BOOST_CHECK_EQUAL(schemas_cfg->partition_count, 1);
+    BOOST_CHECK(
+      schemas_cfg->properties.cleanup_policy_bitflags
+      == model::cleanup_policy_bitflags::compaction);
+    BOOST_CHECK(
+      schemas_cfg->properties.compression == model::compression::none);
+    BOOST_CHECK(schemas_cfg->properties.retention_duration.is_disabled());
+    BOOST_CHECK(schemas_cfg->properties.retention_bytes.is_disabled());
+
+    auto audit_cfg = topics_state.get_topic_cfg(model::kafka_audit_logging_nt);
+    BOOST_REQUIRE(audit_cfg.has_value());
+    BOOST_CHECK_EQUAL(
+      audit_cfg->partition_count,
+      config::shard_local_cfg().audit_log_num_partitions());
+    BOOST_CHECK(
+      audit_cfg->properties.cleanup_policy_bitflags
+      == model::cleanup_policy_bitflags::deletion);
+    BOOST_REQUIRE(
+      audit_cfg->properties.retention_duration.has_optional_value());
+    BOOST_CHECK(
+      audit_cfg->properties.retention_duration.value()
+      == std::chrono::milliseconds(604800000));
 }
 
 FIXTURE_TEST(metadata_v12_unauthorized, metadata_fixture) {

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -37,7 +37,6 @@
 #include "security/authorizer.h"
 #include "security/request_auth.h"
 #include "ssx/semaphore.h"
-#include "utils/tristate.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future-util.hh>
@@ -693,29 +692,8 @@ ss::future<> service::create_internal_topic() {
       = _config.schema_registry_replication_factor().value_or(
         _controller->internal_topic_replication());
 
-    // Create the base topic configuration to get the cluster defaults
-    auto base_topic_config = kafka::to_topic_config(
-      model::kafka_namespace,
-      model::schema_registry_internal_tp.topic,
-      /*partition_count=*/1,
-      replication_factor,
-      {});
-    // Now update the properties
-    base_topic_config.properties.cleanup_policy_bitflags
-      = model::cleanup_policy_bitflags::compaction;
-    base_topic_config.properties.compression = model::compression::none;
-    base_topic_config.properties.retention_bytes = tristate<size_t>{
-      disable_tristate};
-    base_topic_config.properties.retention_duration
-      = tristate<std::chrono::milliseconds>{disable_tristate};
-    base_topic_config.properties.retention_local_target_bytes
-      = tristate<size_t>{disable_tristate};
-    base_topic_config.properties.retention_local_target_ms
-      = tristate<std::chrono::milliseconds>{disable_tristate};
-    base_topic_config.properties.initial_retention_local_target_bytes
-      = tristate<size_t>{disable_tristate};
-    base_topic_config.properties.initial_retention_local_target_ms
-      = tristate<std::chrono::milliseconds>{disable_tristate};
+    auto base_topic_config = kafka::schema_registry_topic_configuration(
+      replication_factor);
 
     vlog(
       srlog.debug,

--- a/src/v/security/audit/BUILD
+++ b/src/v/security/audit/BUILD
@@ -18,6 +18,7 @@ redpanda_cc_library(
     name = "audit",
     srcs = [
         "audit_log_manager.cc",
+        "audit_log_topic.cc",
         "client.cc",
         "client.h",  # Maybe split client into its own target
         "logger.cc",
@@ -27,6 +28,7 @@ redpanda_cc_library(
     ],
     hdrs = [
         "audit_log_manager.h",
+        "audit_log_topic.h",
         "client_probe.h",
         "fwd.h",
         "logger.h",
@@ -50,6 +52,7 @@ redpanda_cc_library(
         "//src/v/cluster:topic_metrics_watcher",
         "//src/v/features",
         "//src/v/kafka/data:record_batcher",
+        "//src/v/kafka/server:topic_config_utils",
         "@abseil-cpp//absl/algorithm:container",
     ],
     visibility = ["//visibility:public"],
@@ -64,6 +67,7 @@ redpanda_cc_library(
         "//src/v/cluster:fwd",
         "//src/v/cluster:logger",
         "//src/v/cluster:rpc_utils",
+        "//src/v/cluster:topic_configuration",
         "//src/v/config",
         "//src/v/container:chunked_vector",
         "//src/v/hashing:combine",

--- a/src/v/security/audit/audit_log_topic.cc
+++ b/src/v/security/audit/audit_log_topic.cc
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "security/audit/audit_log_topic.h"
+
+#include "kafka/protocol/topic_properties.h"
+#include "kafka/server/handlers/configs/config_response_utils.h"
+#include "model/fundamental.h"
+
+#include <chrono>
+
+namespace security::audit {
+
+cluster::topic_properties audit_log_topic_properties() {
+    using namespace std::chrono_literals;
+    constexpr std::chrono::milliseconds seven_days = 604800000ms;
+
+    cluster::topic_properties props;
+    props.retention_bytes = tristate<size_t>{};
+    props.retention_duration = tristate<std::chrono::milliseconds>{seven_days};
+    props.cleanup_policy_bitflags = model::cleanup_policy_bitflags::deletion;
+    return props;
+}
+
+std::vector<kafka::createable_topic_config> audit_log_topic_configs() {
+    auto props = audit_log_topic_properties();
+    return {
+      {.name = ss::sstring(kafka::topic_property_retention_bytes),
+       .value = kafka::maybe_print_tristate(props.retention_bytes)},
+      {.name = ss::sstring(kafka::topic_property_retention_duration),
+       .value = kafka::maybe_print_tristate(props.retention_duration)},
+      {.name = ss::sstring(kafka::topic_property_cleanup_policy),
+       .value = kafka::describe_as_string(
+         props.cleanup_policy_bitflags.value())}};
+}
+
+} // namespace security::audit

--- a/src/v/security/audit/audit_log_topic.h
+++ b/src/v/security/audit/audit_log_topic.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cluster/topic_properties.h"
+#include "kafka/protocol/schemata/create_topics_request.h"
+
+namespace security::audit {
+
+/// \brief The intended properties of the audit log topic
+/// (_redpanda.audit_log): delete cleanup policy with a fixed retention.
+cluster::topic_properties audit_log_topic_properties();
+
+/// \brief The same properties expressed as Kafka CreateTopics config
+/// entries, for the creation path that goes through the Kafka API.
+std::vector<kafka::createable_topic_config> audit_log_topic_configs();
+
+} // namespace security::audit

--- a/src/v/security/audit/client.cc
+++ b/src/v/security/audit/client.cc
@@ -18,8 +18,8 @@
 #include "kafka/client/client.h"
 #include "kafka/data/record_batcher.h"
 #include "kafka/data/rpc/client.h"
-#include "kafka/protocol/topic_properties.h"
 #include "security/audit/audit_log_manager.h"
+#include "security/audit/audit_log_topic.h"
 #include "security/audit/logger.h"
 #include "utils/retry.h"
 
@@ -100,9 +100,6 @@ public:
         return ss::now();
     }
     ss::future<> create_internal_topic() {
-        constexpr auto seven_days = 604800000ms;
-        using namespace std::chrono_literals;
-
         int16_t replication_factor
           = config::shard_local_cfg().audit_log_replication_factor().value_or(
             controller()->internal_topic_replication());
@@ -111,12 +108,7 @@ public:
           "Attempting to create internal topic (replication={})",
           replication_factor);
 
-        cluster::topic_properties audit_topic_props;
-        audit_topic_props.retention_bytes = tristate<size_t>{};
-        audit_topic_props.retention_duration
-          = tristate<std::chrono::milliseconds>{seven_days};
-        audit_topic_props.cleanup_policy_bitflags
-          = model::cleanup_policy_bitflags::deletion;
+        auto audit_topic_props = audit_log_topic_properties();
         vlog(
           adtlog.info,
           "Creating audit log topic with settings: {}",
@@ -377,8 +369,6 @@ private:
     }
 
     ss::future<> create_internal_topic() {
-        constexpr std::string_view retain_forever = "-1";
-        constexpr std::string_view seven_days = "604800000";
         int16_t replication_factor
           = config::shard_local_cfg().audit_log_replication_factor().value_or(
             controller()->internal_topic_replication());
@@ -392,16 +382,7 @@ private:
           = config::shard_local_cfg().audit_log_num_partitions(),
           .replication_factor = replication_factor,
           .assignments = {},
-          .configs = {
-            kafka::createable_topic_config{
-              .name = ss::sstring(kafka::topic_property_retention_bytes),
-              .value{retain_forever}},
-            kafka::createable_topic_config{
-              .name = ss::sstring(kafka::topic_property_retention_duration),
-              .value{seven_days}},
-            kafka::createable_topic_config{
-              .name = ss::sstring(kafka::topic_property_cleanup_policy),
-              .value = "delete"}}};
+          .configs = audit_log_topic_configs()};
         vlog(
           adtlog.info,
           "Creating audit log topic with settings: {}",

--- a/tests/rptest/tests/internal_topic_protection_test.py
+++ b/tests/rptest/tests/internal_topic_protection_test.py
@@ -13,6 +13,8 @@ from typing import Any, Callable
 
 from ducktape.mark import parametrize
 from ducktape.utils.util import wait_until
+from kafka import KafkaClient
+from kafka.protocol.metadata import MetadataRequest
 
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.clients.kafka_cli_tools import KafkaCliTools
@@ -206,6 +208,125 @@ class InternalTopicProtectionTest(RedpandaTest):
             lambda: test_topic not in client.list_topics(),
             timeout_sec=90,
             backoff_sec=3,
+        )
+
+
+class InternalTopicAutoCreateTest(RedpandaTest):
+    """
+    With `auto_create_topics_enabled=true`, a metadata request that names an
+    internal topic (with the request's allow_auto_topic_creation flag set)
+    must create the topic with its owning subsystem's configuration, not
+    cluster defaults. Otherwise e.g. `_schemas` would end up on the default
+    delete cleanup policy and schema data would be subject to retention.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            *args,
+            num_brokers=3,
+            extra_rp_conf={"auto_create_topics_enabled": True},
+            **kwargs,
+        )
+
+        self.rpk = RpkTool(self.redpanda)
+
+    def _metadata_auto_create(self, topic: str):
+        """Send a metadata request naming `topic` with
+        allow_auto_topic_creation=true, as e.g. Java clients do by default."""
+        client = KafkaClient(bootstrap_servers=self.redpanda.brokers())
+        try:
+            node_id = self.redpanda.node_id(self.redpanda.nodes[0])
+
+            def node_ready():
+                if not client.ready(node_id):
+                    client.poll()
+                    return False
+                return True
+
+            wait_until(
+                node_ready,
+                timeout_sec=30,
+                backoff_sec=1,
+                err_msg="Timeout waiting for broker connection to be ready",
+            )
+            request = MetadataRequest[4]([topic], True)
+            future = client.send(node_id, request)
+            client.poll(future=future)
+            assert future.succeeded(), f"metadata request failed: {future.exception}"
+        finally:
+            client.close()
+
+    def _partitions(self, topic: str):
+        def topic_ready():
+            partitions = list(self.rpk.describe_topic(topic))
+            return (len(partitions) > 0, partitions)
+
+        return wait_until_result(
+            topic_ready,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"{topic} never became ready",
+        )
+
+    @cluster(num_nodes=3)
+    def test_consumer_offsets_topic(self):
+        self._metadata_auto_create("__consumer_offsets")
+
+        partitions = self._partitions("__consumer_offsets")
+        assert len(partitions) == 16, (
+            f"Expected 16 partitions (group_topic_partitions) but got {len(partitions)}"
+        )
+        assert len(partitions[0].replicas) == 3, (
+            f"Expected RF of 3 but got {len(partitions[0].replicas)}"
+        )
+        cleanup_policy, _ = self.rpk.describe_topic_configs("__consumer_offsets")[
+            "cleanup.policy"
+        ]
+        assert cleanup_policy == "compact", (
+            f"Expected compact cleanup.policy but got {cleanup_policy}"
+        )
+
+    @cluster(num_nodes=3)
+    def test_schemas_topic(self):
+        self._metadata_auto_create("_schemas")
+
+        partitions = self._partitions("_schemas")
+        assert len(partitions) == 1, f"Expected 1 partition but got {len(partitions)}"
+        assert len(partitions[0].replicas) == 3, (
+            f"Expected RF of 3 but got {len(partitions[0].replicas)}"
+        )
+        configs = self.rpk.describe_topic_configs("_schemas")
+        cleanup_policy, source = configs["cleanup.policy"]
+        assert (cleanup_policy, source) == ("compact", "DYNAMIC_TOPIC_CONFIG"), (
+            f"Expected explicitly-set compact cleanup.policy but got "
+            f"{cleanup_policy} ({source})"
+        )
+        retention_ms, _ = configs["retention.ms"]
+        assert retention_ms == "-1", (
+            f"Expected disabled retention.ms but got {retention_ms}"
+        )
+
+    @cluster(num_nodes=3)
+    def test_audit_log_topic(self):
+        self._metadata_auto_create("_redpanda.audit_log")
+
+        partitions = self._partitions("_redpanda.audit_log")
+        assert len(partitions) == 12, (
+            f"Expected 12 partitions (audit_log_num_partitions) but got "
+            f"{len(partitions)}"
+        )
+        assert len(partitions[0].replicas) == 3, (
+            f"Expected RF of 3 but got {len(partitions[0].replicas)}"
+        )
+        configs = self.rpk.describe_topic_configs("_redpanda.audit_log")
+        cleanup_policy, _ = configs["cleanup.policy"]
+        assert cleanup_policy == "delete", (
+            f"Expected delete cleanup.policy but got {cleanup_policy}"
+        )
+        retention_ms, source = configs["retention.ms"]
+        assert (retention_ms, source) == ("604800000", "DYNAMIC_TOPIC_CONFIG"), (
+            f"Expected explicitly-set 7 day retention.ms but got "
+            f"{retention_ms} ({source})"
         )
 
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31234
Fixes: https://github.com/redpanda-data/redpanda/issues/31235,