### PR TITLE
`storage`: batch cache microbenchmark and reclamiation optimizations

### DIFF
--- a/src/v/storage/batch_cache.cc
+++ b/src/v/storage/batch_cache.cc
@@ -14,12 +14,12 @@
 #include "model/adl_serde.h"
 #include "model/fundamental.h"
 #include "resource_mgmt/available_memory.h"
-#include "ssx/async_algorithm.h"
 #include "ssx/future-util.h"
 #include "utils/to_string.h" // NOLINT(misc-include-cleaner) fmt::formatter for optionals
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/gate.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/util/defer.hh>
 
 namespace storage {
@@ -530,21 +530,23 @@ void batch_cache_index::mark_clean(model::offset up_to_inclusive) {
 
     _dirty_tracker.mark_clean(up_to_inclusive);
 }
-ss::future<> batch_cache_index::clear_async_unlocked() {
+ss::future<> batch_cache_index::clear_async() {
     vassert(
       _dirty_tracker.clean(),
       "Destroying batch_cache_index ({}) tracking dirty batches.",
       *this);
-    co_await ssx::async_for_each(
-      _index.begin(), _index.end(), [this](index_type::value_type& value) {
-          _cache->evict(std::move(value.second.range()));
-      });
-    _index.clear();
-}
-
-ss::future<> batch_cache_index::clear_async() {
-    lock_guard lk(*this);
-    co_await clear_async_unlocked();
+    /*
+     * clear in bounded chunks, restarting from the beginning of the index at
+     * each scheduling point, so that no btree iterator lives across a yield.
+     */
+    while (!_index.empty()) {
+        auto it = _index.begin();
+        do {
+            _cache->evict(std::move(it->second.range()));
+            it = _index.erase(it);
+        } while (it != _index.end() && !ss::need_preempt());
+        co_await ss::coroutine::maybe_yield();
+    }
 }
 
 void batch_cache::background_reclaimer::start() {

--- a/src/v/storage/batch_cache.cc
+++ b/src/v/storage/batch_cache.cc
@@ -10,8 +10,6 @@
 #include "batch_cache.h"
 
 #include "base/vassert.h"
-#include "bytes/iobuf_parser.h"
-#include "model/adl_serde.h"
 #include "model/fundamental.h"
 #include "resource_mgmt/available_memory.h"
 #include "ssx/future-util.h"
@@ -38,26 +36,14 @@ batch_cache::range::range(
     add(batch, dirty);
 }
 
-model::record_batch batch_cache::range::batch(size_t o) {
-    return batch(o, header(o));
-}
-
-model::record_batch
-batch_cache::range::batch(size_t o, const model::record_batch_header& hdr) {
+model::record_batch batch_cache::range::batch(
+  size_t data_offset, const model::record_batch_header& hdr) {
     vassert(_valid, "cannot access invalided batch");
     auto buffer = _arena.share(
-      o + serialized_header_size,
-      hdr.size_bytes - model::packed_record_batch_header_size);
+      data_offset, hdr.size_bytes - model::packed_record_batch_header_size);
 
     return model::record_batch(
-      hdr, std::move(buffer), model::record_batch::tag_ctor_ng{});
-}
-
-model::record_batch_header batch_cache::range::header(size_t o) {
-    vassert(_valid, "cannot access invalided batch");
-    iobuf_const_parser parser(_arena);
-    parser.skip(o);
-    return reflection::adl<model::record_batch_header>{}.from(parser);
+      hdr.copy(), std::move(buffer), model::record_batch::tag_ctor_ng{});
 }
 
 size_t batch_cache::range::memory_size() const {
@@ -76,10 +62,10 @@ double batch_cache::range::waste() const {
     return (1.0 - ((double)_size / memory_size())) * 100.0;
 }
 
-bool batch_cache::range::empty() const { return _size == 0; }
+bool batch_cache::range::empty() const { return _offsets.empty(); }
 
 bool batch_cache::range::fits(const model::record_batch& b) const {
-    const size_t to_add = serialized_header_size + b.data().size_bytes();
+    const size_t to_add = b.data().size_bytes();
     // if there are not enough bytes in current range return true even
     // though batch doesn't fit into arena. This way we can control maximum
     // waste
@@ -98,13 +84,14 @@ bool batch_cache::range::fits(const model::record_batch& b) const {
 
 uint32_t
 batch_cache::range::add(const model::record_batch& b, is_dirty_entry dirty) {
-    auto offset = _arena.size_bytes();
-    reflection::adl<model::record_batch_header>{}.to(_arena, b.header().copy());
-    _size += serialized_header_size;
+    auto data_offset = _arena.size_bytes();
     // if there is not enough space left in last arena fragment we
     // trim it and append existing fragments directly to the arena
-    // iobuf
-    if (_arena.rbegin()->available_bytes() < b.data().size_bytes()) {
+    // iobuf. the arena is empty when the range was constructed for a
+    // single large batch.
+    if (
+      _arena.begin() == _arena.end()
+      || _arena.rbegin()->available_bytes() < b.data().size_bytes()) {
         _size += b.data().size_bytes();
         _arena.append_fragments(b.data().copy());
     } else {
@@ -127,7 +114,7 @@ batch_cache::range::add(const model::record_batch& b, is_dirty_entry dirty) {
         _max_dirty_offset = b.last_offset();
     }
 
-    return offset;
+    return data_offset;
 }
 
 static resources::available_memory::deregister_holder
@@ -173,7 +160,7 @@ batch_cache::entry batch_cache::put(
         auto r = new range(index, input, dirty);
         _lru.push_back(*r);
         _size_bytes += r->memory_size();
-        return entry(0, r->weak_from_this());
+        return entry(0, r->weak_from_this(), input.header());
     }
 
     if (
@@ -191,7 +178,8 @@ batch_cache::entry batch_cache::put(
     int64_t diff = (int64_t)index._small_batches_range->memory_size()
                    - initial_sz;
     _size_bytes += diff;
-    return entry(offset, index._small_batches_range->weak_from_this());
+    return entry(
+      offset, index._small_batches_range->weak_from_this(), input.header());
 }
 
 batch_cache::~batch_cache() noexcept {
@@ -382,18 +370,18 @@ batch_cache_index::read_result batch_cache_index::read(
         return ret;
     }
     for (auto it = find_first_contains(offset); it != _index.end();) {
-        auto batch_header = it->second.header();
+        auto& e = it->second;
 
-        auto take = !type_filter || type_filter == batch_header.type;
-        take &= !first_ts || batch_header.max_timestamp >= *first_ts;
-        offset = batch_header.last_offset() + model::offset(1);
+        auto take = !type_filter || type_filter == e.type();
+        take &= !first_ts || e.max_timestamp() >= *first_ts;
+        offset = e.last_offset() + model::offset(1);
         if (take) {
-            auto batch = it->second.batch(batch_header);
-            batch_cache::range::lock_guard g(*it->second.range());
+            batch_cache::range::lock_guard g(*e.range());
+            auto batch = e.batch();
             ret.memory_usage += batch.memory_usage();
             ret.batches.emplace_back(std::move(batch));
             if (!skip_lru_promote) {
-                _cache->touch(it->second.range());
+                _cache->touch(e.range());
             }
         }
 
@@ -419,7 +407,7 @@ batch_cache_index::read_result batch_cache_index::read(
                   return e.second.range() && e.second.range()->valid();
               });
             if (next_batch != _index.end()) {
-                ret.next_cached_batch = next_batch->second.header().base_offset;
+                ret.next_cached_batch = next_batch->first;
             }
             break;
         }
@@ -452,11 +440,10 @@ bool batch_cache_index::has_contiguous_coverage(
         if (!range || !range->valid()) {
             return false;
         }
-        auto hdr = it->second.header();
-        if (hdr.base_offset > expected) {
+        if (it->first > expected) {
             return false;
         }
-        auto next = model::next_offset(hdr.last_offset());
+        auto next = model::next_offset(it->second.last_offset());
         if (next <= expected) {
             ++it;
             continue;
@@ -478,11 +465,10 @@ model::offset batch_cache_index::contiguous_end(model::offset from) const {
         if (!range || !range->valid()) {
             break;
         }
-        auto hdr = it->second.header();
-        if (hdr.base_offset > expected) {
+        if (it->first > expected) {
             break;
         }
-        auto next = model::next_offset(hdr.last_offset());
+        auto next = model::next_offset(it->second.last_offset());
         if (next <= expected) {
             ++it;
             continue;
@@ -505,7 +491,7 @@ void batch_cache_index::truncate(model::offset offset) {
         // rule out if possible, otherwise always be pessimistic
         if (
           it->second.range() && it->second.valid()
-          && !it->second.header().contains(offset)) {
+          && !(it->first <= offset && offset <= it->second.last_offset())) {
             ++it;
         }
         std::for_each(it, _index.end(), [this](index_type::value_type& e) {

--- a/src/v/storage/batch_cache.cc
+++ b/src/v/storage/batch_cache.cc
@@ -20,6 +20,8 @@
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/util/defer.hh>
 
+#include <algorithm>
+
 namespace storage {
 
 batch_cache::range::range(batch_cache_index& index)
@@ -295,9 +297,7 @@ void batch_cache::dispose_pending(range* r) {
      * generally safe since all batch cache users are prepared to handle a
      * miss.
      */
-    for (auto& o : offsets) {
-        index->remove(o);
-    }
+    index->remove(std::move(offsets));
 }
 
 ss::future<> batch_cache::do_pending_index_removals() {
@@ -316,6 +316,28 @@ ss::future<> batch_cache::do_pending_index_removals() {
 
 void batch_cache::drain_pending_index_removals() {
     _pending_index_removal.clear_and_dispose(dispose_pending);
+}
+
+void batch_cache_index::remove(std::vector<model::offset> offsets) {
+    vassert(!locked(), "attempt to erase from locked index");
+    /*
+     * a range's batches are typically adjacent in the index, so erasing in
+     * offset order and resuming from the iterator returned by the previous
+     * erase avoids a full-tree descent per entry. offsets are appended in
+     * put() order and may be unsorted when reads populated the range out of
+     * order.
+     */
+    std::sort(offsets.begin(), offsets.end());
+    auto it = _index.end();
+    for (auto o : offsets) {
+        if (it == _index.end() || it->first != o) {
+            it = _index.find(o);
+            if (it == _index.end()) {
+                continue;
+            }
+        }
+        it = _index.erase(it);
+    }
 }
 
 void batch_cache_index::dirty_tracker::mark_dirty(

--- a/src/v/storage/batch_cache.cc
+++ b/src/v/storage/batch_cache.cc
@@ -197,7 +197,7 @@ batch_cache::entry batch_cache::put(
 batch_cache::~batch_cache() noexcept {
     clear();
     vassert(
-      _size_bytes == 0 && _lru.empty(),
+      _size_bytes == 0 && _lru.empty() && _pending_index_removal.empty(),
       "Detected incorrect batch_cache accounting. {}",
       *this);
 }
@@ -214,8 +214,10 @@ void batch_cache::evict(range_ptr&& e) {
         // r-value reference `e` wouldn't do that.
         auto p = std::exchange(e, {});
         _size_bytes -= p->memory_size();
-        _lru.erase_and_dispose(
-          _lru.iterator_to(*p), [](range* e) { delete e; });
+        // the range is linked on either the lru list or, if its memory was
+        // already reclaimed, the pending index removal list. the auto-unlink
+        // hook removes it from whichever list holds it on destruction.
+        delete p.get(); // NOLINT
     }
 }
 
@@ -249,16 +251,16 @@ size_t batch_cache::reclaim(size_t size) {
     _reclaim_size = std::max(size, _reclaim_size);
 
     /*
-     * reclaiming is a two pass process. given that the range isn't pinned (in
-     * which case it is skipped), the first step is to reclaim the batch's
-     * record data. at this point, if the range's owning index is not locked the
-     * range is added to a temporary list of entries which will be removed.
-     * otherwise if the index is locked, removal is deferred but the range is
-     * invalidated. invalidation is important because the batch reference in the
-     * index still exists even though the batch data was removed.
+     * given that the range isn't pinned (in which case it is skipped), the
+     * batch's record data is reclaimed and the range is invalidated and moved
+     * to the pending index removal list. invalidation is important because the
+     * batch reference in the index still exists even though the batch data was
+     * removed. removal of the index entries is completed by the background
+     * reclaimer so that the potentially large number of index erases stays off
+     * the memory allocation path (this reclaimer runs synchronously within
+     * allocation).
      */
     size_t reclaimed = 0;
-    intrusive_list<range, &range::_hook> reclaimed_ranges;
 
     for (auto it = _lru.begin(); it != _lru.end();) {
         if (reclaimed >= _reclaim_size) {
@@ -277,51 +279,55 @@ size_t batch_cache::reclaim(size_t size) {
         // reclaim the batch's record data
         reclaimed += it->memory_size();
         it->_arena.clear();
+        it->invalidate();
 
-        /*
-         * if the owning index is locked invalidate the range but leave it on
-         * the lru list for deferred deletion so as to not invalidate any open
-         * iterators on the index.
-         */
-        if (unlikely(it->_index.locked())) {
-            it->invalidate();
-            ++it;
-            continue;
-        }
-
-        // collect the entries that will be fully removed
-        it = _lru.erase_and_dispose(it, [&reclaimed_ranges](range* e) {
-            reclaimed_ranges.push_back(*e);
-        });
+        it = _lru.erase_and_dispose(
+          it, [this](range* e) { _pending_index_removal.push_back(*e); });
     }
 
-    /*
-     * final removal from the index is deferred because there is some chance
-     * that removal allocates, so waiting until the bulk of the reclaims have
-     * occurred reduces the probability of an allocation failure.
-     */
-
-    reclaimed_ranges.clear_and_dispose([](range* e) {
-        auto* index = &e->_index;
-        auto offsets = std::move(e->_offsets);
-        delete e; // NOLINT
-
-        /*
-         * since reclaim may be invoked at any moment and removals may be
-         * deferred if an index is locked, one can imagine races in which a
-         * batch is removed by offset here which is not the same batch that was
-         * reclaimed in a prior pass. at worst this would raise the miss ratio,
-         * but is still generally safe since all batch cache users are prepared
-         * to handle a miss.
-         */
-        for (auto& o : offsets) {
-            index->remove(o);
-        }
-    });
+    if (reclaimed != 0) {
+        _background_reclaimer.notify();
+    }
 
     _last_reclaim = ss::lowres_clock::now();
     _size_bytes -= reclaimed;
     return reclaimed;
+}
+
+void batch_cache::dispose_pending(range* r) {
+    auto* index = &r->_index;
+    auto offsets = std::move(r->_offsets);
+    delete r; // NOLINT
+
+    /*
+     * since reclaim may be invoked at any moment and removals are
+     * deferred, one can imagine races in which a batch is removed by
+     * offset here which is not the same batch that was reclaimed in a
+     * prior pass. at worst this would raise the miss ratio, but is still
+     * generally safe since all batch cache users are prepared to handle a
+     * miss.
+     */
+    for (auto& o : offsets) {
+        index->remove(o);
+    }
+}
+
+ss::future<> batch_cache::do_pending_index_removals() {
+    /*
+     * detach the current pending set so that list mutations during scheduling
+     * points (new arrivals from reclaim, ranges evicted by their index) don't
+     * interfere with iteration.
+     */
+    intrusive_range_list work;
+    work.splice(work.begin(), _pending_index_removal);
+    while (!work.empty()) {
+        dispose_pending(&work.front());
+        co_await ss::coroutine::maybe_yield();
+    }
+}
+
+void batch_cache::drain_pending_index_removals() {
+    _pending_index_removal.clear_and_dispose(dispose_pending);
 }
 
 void batch_cache_index::dirty_tracker::mark_dirty(
@@ -568,6 +574,8 @@ ss::future<> batch_cache::background_reclaimer::reclaim_loop() {
         if (unlikely(_stopped)) {
             co_return;
         }
+
+        co_await _cache.do_pending_index_removals();
 
         if (!have_to_reclaim()) {
             continue;

--- a/src/v/storage/batch_cache.h
+++ b/src/v/storage/batch_cache.h
@@ -332,7 +332,10 @@ public:
     bool empty() const { return _lru.empty(); }
 
     /// Removes all entries from the cache.
-    void clear() { reclaim(std::numeric_limits<size_t>::max()); }
+    void clear() {
+        reclaim(std::numeric_limits<size_t>::max());
+        drain_pending_index_removals();
+    }
 
     /**
      * Copies a batch into the LRU cache.
@@ -457,7 +460,31 @@ private:
                               : reclaim_result::reclaimed_nothing;
     }
 
-    intrusive_list<range, &range::_hook> _lru;
+    /*
+     * Remove the index entries of ranges whose memory was reclaimed. The
+     * asynchronous form runs in the background reclaimer fiber and yields
+     * between ranges; the synchronous form is used by clear() where the
+     * deferred work must complete before returning.
+     */
+    ss::future<> do_pending_index_removals();
+    void drain_pending_index_removals();
+
+    /*
+     * Complete a reclaimed range's deferred index entry removal and dispose
+     * of it.
+     */
+    static void dispose_pending(range* r);
+
+    using intrusive_range_list = intrusive_list<range, &range::_hook>;
+
+    intrusive_range_list _lru;
+    /*
+     * ranges whose arena memory has been reclaimed but whose entries have
+     * not yet been removed from their owning index. drained by the
+     * background reclaimer so that the removals stay off the memory
+     * allocation path.
+     */
+    intrusive_range_list _pending_index_removal;
     reclaimer _reclaimer;
     bool _is_reclaiming{false};
     size_t _size_bytes{0};
@@ -472,10 +499,12 @@ public:
     fmt::iterator format_to(fmt::iterator it) const {
         return fmt::format_to(
           it,
-          "{{is_reclaiming:{}, size_bytes: {}, lru_empty:{}}}",
+          "{{is_reclaiming:{}, size_bytes: {}, lru_empty:{}, "
+          "pending_index_removal_empty:{}}}",
           is_memory_reclaiming(),
           _size_bytes,
-          _lru.empty());
+          _lru.empty(),
+          _pending_index_removal.empty());
     }
 };
 
@@ -556,6 +585,12 @@ public:
           _dirty_tracker);
         std::for_each(
           _index.begin(), _index.end(), [this](index_type::value_type& e) {
+              /*
+               * this also disposes any ranges awaiting deferred index entry
+               * removal: every range is reachable from its index entries,
+               * and evict() unlinks it from the cache's pending removal
+               * list.
+               */
               _cache->evict(std::move(e.second.range()));
           });
     }

--- a/src/v/storage/batch_cache.h
+++ b/src/v/storage/batch_cache.h
@@ -749,12 +749,11 @@ private:
     }
 
     /*
+     * Remove the entries of a reclaimed range from the index.
+     *
      * XXX: only safe when invoked by the batch cache reclaimer.
      */
-    bool remove(model::offset offset) {
-        vassert(!locked(), "attempt to erase from locked index");
-        return _index.erase(offset) == 1;
-    }
+    void remove(std::vector<model::offset> offsets);
 
     /*
      * Return an iterator to the first batch that _may_ contain the specified

--- a/src/v/storage/batch_cache.h
+++ b/src/v/storage/batch_cache.h
@@ -29,6 +29,7 @@
 #include <seastar/core/weak_ptr.hh>
 
 #include <limits>
+#include <memory>
 #include <type_traits>
 
 class batch_cache_test_fixture;
@@ -174,15 +175,8 @@ public:
         // into an invalid state where the batch data cannot be accessed.
         bool valid() const { return _valid; }
         void invalidate() { _valid = false; }
-        static constexpr size_t serialized_header_size
-          = model::packed_record_batch_header_size + sizeof(size_t);
-
-        model::record_batch batch(size_t o);
-        /// Builds the batch from an already-parsed header, avoiding a second
-        /// header decode when the caller has already read it.
         model::record_batch
-        batch(size_t o, const model::record_batch_header& hdr);
-        model::record_batch_header header(size_t o);
+        batch(size_t data_offset, const model::record_batch_header&);
 
         void pin() { _pinned = true; }
         void unpin() { _pinned = false; }
@@ -282,8 +276,9 @@ public:
      */
     class entry {
     public:
-        entry(uint32_t o, range_ptr&& ptr)
-          : _range_offset(o)
+        entry(uint32_t o, range_ptr&& ptr, const model::record_batch_header& h)
+          : _data_offset(o)
+          , _header(std::make_unique<model::record_batch_header>(h.copy()))
           , _range(std::move(ptr)) {}
 
         ~entry() noexcept = default;
@@ -292,12 +287,19 @@ public:
         entry(const entry&) = delete;
         entry& operator=(const entry&) = delete;
 
-        model::record_batch batch() { return _range->batch(_range_offset); }
-        model::record_batch batch(const model::record_batch_header& hdr) {
-            return _range->batch(_range_offset, hdr);
+        model::record_batch batch() {
+            return _range->batch(_data_offset, *_header);
         }
-        model::record_batch_header header() const {
-            return _range->header(_range_offset);
+
+        /*
+         * the batch header is captured at insertion time so that lookups,
+         * filtering and materialization never deserialize it from the
+         * range's arena.
+         */
+        model::record_batch_type type() const { return _header->type; }
+        model::offset last_offset() const { return _header->last_offset(); }
+        model::timestamp max_timestamp() const {
+            return _header->max_timestamp;
         }
 
         range_ptr& range() { return _range; }
@@ -305,7 +307,8 @@ public:
         bool valid() const { return _range->valid(); }
 
     private:
-        uint32_t _range_offset;
+        uint32_t _data_offset;
+        std::unique_ptr<model::record_batch_header> _header;
         range_ptr _range;
     };
 
@@ -755,8 +758,8 @@ private:
 
     /*
      * Return an iterator to the first batch that _may_ contain the specified
-     * offset. Since the batch may have been evicted, and we only store the base
-     * offset in the index, the caller deals with the missing upper bound.
+     * offset. The caller verifies containment against the entry's cached
+     * offset bounds and liveness.
      */
     index_type::iterator find_first(model::offset offset) {
         if (_index.empty()) {
@@ -771,16 +774,15 @@ private:
 
     /*
      * Return an iterator to the first batch known to contain the specified
-     * offset, otherwise return the end iterator. Since a batch must be present
-     * in memory to verify that it contains the offset, a non-end returned
-     * iterator is guaranteed to point to a live batch.
+     * offset, otherwise return the end iterator. A non-end returned iterator
+     * is guaranteed to point to a live batch.
      */
     index_type::iterator find_first_contains(model::offset offset) {
         if (
-          auto it = find_first(offset);
-          it != _index.end() && it->second.range()
-          && it->second.range()->valid()
-          && it->second.header().contains(offset)) {
+          auto it = find_first(offset); it != _index.end() && it->second.range()
+                                        && it->second.range()->valid()
+                                        && it->first <= offset
+                                        && offset <= it->second.last_offset()) {
             return it;
         }
         return _index.end();

--- a/src/v/storage/batch_cache.h
+++ b/src/v/storage/batch_cache.h
@@ -565,8 +565,6 @@ public:
     batch_cache_index& operator=(const batch_cache_index&) = delete;
 
     ss::future<> clear_async();
-    // Requires that a `lock_guard` for `this` is held elsewhere.
-    ss::future<> clear_async_unlocked();
     bool empty() const { return _index.empty(); }
 
     void
@@ -676,8 +674,7 @@ public:
 
     // Leaves the batch_cache_index in a fully clean, re-usable state.
     ss::future<> reset() {
-        lock_guard lk(*this);
-        co_await clear_async_unlocked();
+        co_await clear_async();
         _small_batches_range = nullptr;
     }
 

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -286,6 +286,7 @@ redpanda_cc_gtest(
         "//src/v/model",
         "//src/v/storage:batch_cache",
         "//src/v/storage:record_batch_builder",
+        "//src/v/test_utils:async",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
         "@seastar",

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -1075,6 +1075,19 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_bench(
+    name = "batch_cache_rpbench",
+    srcs = ["batch_cache_bench.cc"],
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/model",
+        "//src/v/storage:batch_cache",
+        "//src/v/storage:record_batch_builder",
+        "@seastar",
+        "@seastar//:benchmark",
+    ],
+)
+
+redpanda_cc_bench(
     name = "storage_rpbench",
     srcs = ["compaction_idx_bench.cc"],
     deps = [

--- a/src/v/storage/tests/batch_cache_bench.cc
+++ b/src/v/storage/tests/batch_cache_bench.cc
@@ -1,0 +1,264 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "bytes/iobuf.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "model/record_batch_types.h"
+#include "storage/batch_cache.h"
+#include "storage/record_batch_builder.h"
+
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/testing/perf_tests.hh>
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <random>
+
+namespace {
+
+storage::batch_cache::reclaim_options make_opts() {
+    return {
+      .growth_window = std::chrono::milliseconds(3000),
+      .stable_window = std::chrono::milliseconds(10000),
+      .min_size = 128 << 10,
+      .max_size = 4 << 20,
+    };
+}
+
+model::record_batch make_batch(model::offset base, size_t value_size) {
+    storage::record_batch_builder builder(
+      model::record_batch_type::raft_data, base);
+    iobuf value;
+    value.append(ss::temporary_buffer<char>(value_size));
+    builder.add_raw_kv(iobuf{}, std::move(value));
+    return std::move(builder).build();
+}
+
+} // namespace
+
+/*
+ * measures the cost of evicting ranges under memory pressure. small batches
+ * pack ~190 to a 32KiB range, so a 4MiB reclaim (the default reclaim_max_size,
+ * i.e. the quantum of a single reclaim upcall under sustained pressure)
+ * covers ~128 ranges and ~24k index entries.
+ */
+struct batch_cache_reclaim_bench {
+    static constexpr size_t reclaim_bytes = 4 << 20;
+    static constexpr size_t batch_value_size = 100;
+
+    storage::batch_cache cache;
+    storage::batch_cache_index index;
+
+    batch_cache_reclaim_bench()
+      : cache(make_opts())
+      , index(cache) {}
+
+    ~batch_cache_reclaim_bench() { cache.stop().get(); }
+
+    void fill() {
+        for (int64_t o = 0; cache.size_bytes() < reclaim_bytes; ++o) {
+            index.put(
+              make_batch(model::offset(o), batch_value_size),
+              storage::batch_cache::is_dirty_entry::no);
+        }
+    }
+};
+
+/*
+ * the synchronous reclaim call: this is what runs inside the seastar memory
+ * allocator's reclaim upcall, on the allocating fiber's critical path.
+ */
+PERF_TEST_F(batch_cache_reclaim_bench, reclaim_sync) {
+    fill();
+    perf_tests::start_measuring_time();
+    auto reclaimed = cache.reclaim(reclaim_bytes);
+    perf_tests::stop_measuring_time();
+    perf_tests::do_not_optimize(reclaimed);
+    // release any deferred state outside the measured region so iterations
+    // are independent
+    cache.clear();
+}
+
+/*
+ * total reclamation work including any index cleanup deferred by reclaim():
+ * quantifies whether deferring changed the overall cost or just moved it.
+ */
+PERF_TEST_F(batch_cache_reclaim_bench, reclaim_total) {
+    fill();
+    perf_tests::start_measuring_time();
+    auto reclaimed = cache.reclaim(reclaim_bytes);
+    cache.clear();
+    perf_tests::stop_measuring_time();
+    perf_tests::do_not_optimize(reclaimed);
+}
+
+/*
+ * lookup path costs. single-record batches are placed at even offsets so that
+ * even lookups hit and odd lookups miss after the containment check.
+ */
+struct batch_cache_lookup_bench {
+    static constexpr int64_t num_batches = 100'000;
+    static constexpr size_t batch_value_size = 100;
+    static constexpr size_t lookups_per_iteration = 1000;
+
+    storage::batch_cache cache;
+    storage::batch_cache_index index;
+
+    batch_cache_lookup_bench()
+      : cache(make_opts())
+      , index(cache) {
+        for (int64_t i = 0; i < num_batches; ++i) {
+            index.put(
+              make_batch(model::offset(2 * i), batch_value_size),
+              storage::batch_cache::is_dirty_entry::no);
+        }
+    }
+
+    ~batch_cache_lookup_bench() { cache.stop().get(); }
+};
+
+PERF_TEST_F(batch_cache_lookup_bench, get_hit) {
+    model::offset o{0};
+    for (size_t i = 0; i < lookups_per_iteration; ++i) {
+        auto batch = index.get(o);
+        perf_tests::do_not_optimize(batch);
+        o = model::offset((o() + 2) % (2 * num_batches));
+    }
+    return lookups_per_iteration;
+}
+
+PERF_TEST_F(batch_cache_lookup_bench, get_miss) {
+    model::offset o{1};
+    for (size_t i = 0; i < lookups_per_iteration; ++i) {
+        auto batch = index.get(o);
+        perf_tests::do_not_optimize(batch);
+        o = model::offset((o() + 2) % (2 * num_batches));
+    }
+    return lookups_per_iteration;
+}
+
+/*
+ * span reads need gapless offsets: read() stops at the first hole in offset
+ * coverage.
+ */
+struct batch_cache_span_bench {
+    static constexpr int64_t num_batches = 100'000;
+    static constexpr size_t batch_value_size = 100;
+    static constexpr int64_t batches_per_read = 1000;
+
+    storage::batch_cache cache;
+    storage::batch_cache_index index;
+
+    batch_cache_span_bench()
+      : cache(make_opts())
+      , index(cache) {
+        for (int64_t i = 0; i < num_batches; ++i) {
+            index.put(
+              make_batch(model::offset(i), batch_value_size),
+              storage::batch_cache::is_dirty_entry::no);
+        }
+    }
+
+    ~batch_cache_span_bench() { cache.stop().get(); }
+};
+
+/*
+ * a contiguous scan taking every batch: the fetch path shape.
+ */
+PERF_TEST_F(batch_cache_span_bench, read_span) {
+    auto result = index.read(
+      model::offset(0),
+      model::offset(batches_per_read - 1),
+      std::nullopt,
+      std::nullopt,
+      std::numeric_limits<size_t>::max(),
+      true);
+    perf_tests::do_not_optimize(result);
+    return result.batches.size();
+}
+
+/*
+ * a scan whose type filter rejects every batch: isolates the per-entry
+ * metadata inspection cost from batch materialization.
+ */
+PERF_TEST_F(batch_cache_span_bench, read_span_filtered) {
+    auto result = index.read(
+      model::offset(0),
+      model::offset(batches_per_read - 1),
+      model::record_batch_type::raft_configuration,
+      std::nullopt,
+      std::numeric_limits<size_t>::max(),
+      true);
+    perf_tests::do_not_optimize(result);
+    return batches_per_read;
+}
+
+/*
+ * production-scale reclaim: a large, cold set of indexes whose ranges hold
+ * scattered (non-adjacent) offsets, as happens when reads populate the cache
+ * out of order. every reclaimed range touches a different deep btree with
+ * cold caches, which is the regime behind reactor stalls observed on
+ * memory-pressured fetch-heavy clusters.
+ */
+struct batch_cache_large_bench {
+    static constexpr size_t reclaim_bytes = 4 << 20;
+    static constexpr size_t batch_value_size = 100;
+    static constexpr int64_t num_indexes = 8;
+    static constexpr int64_t entries_per_index = 96'000;
+
+    storage::batch_cache cache;
+    std::vector<std::unique_ptr<storage::batch_cache_index>> indexes;
+    std::vector<std::vector<int64_t>> shuffled_offsets;
+
+    batch_cache_large_bench()
+      : cache(make_opts()) {
+        std::mt19937 rng(42);
+        for (int64_t i = 0; i < num_indexes; ++i) {
+            indexes.push_back(
+              std::make_unique<storage::batch_cache_index>(cache));
+            auto& offsets = shuffled_offsets.emplace_back(entries_per_index);
+            std::iota(offsets.begin(), offsets.end(), 0);
+            std::shuffle(offsets.begin(), offsets.end(), rng);
+        }
+        fill();
+    }
+
+    ~batch_cache_large_bench() {
+        cache.clear();
+        cache.stop().get();
+    }
+
+    void fill() {
+        for (int64_t i = 0; i < entries_per_index; ++i) {
+            for (int64_t j = 0; j < num_indexes; ++j) {
+                indexes[j]->put(
+                  make_batch(
+                    model::offset(shuffled_offsets[j][i]), batch_value_size),
+                  storage::batch_cache::is_dirty_entry::no);
+            }
+        }
+    }
+};
+
+PERF_TEST_F(batch_cache_large_bench, reclaim_sync_cold) {
+    if (cache.size_bytes() < reclaim_bytes) {
+        // release deferred state so offsets can be re-inserted, then refill
+        cache.clear();
+        fill();
+    }
+    perf_tests::start_measuring_time();
+    auto reclaimed = cache.reclaim(reclaim_bytes);
+    perf_tests::stop_measuring_time();
+    perf_tests::do_not_optimize(reclaimed);
+}

--- a/src/v/storage/tests/batch_cache_reclaim_test.cc
+++ b/src/v/storage/tests/batch_cache_reclaim_test.cc
@@ -10,6 +10,7 @@
 #include "model/record.h"
 #include "storage/batch_cache.h"
 #include "storage/record_batch_builder.h"
+#include "test_utils/async.h"
 
 #include <seastar/core/memory.hh>
 #include <seastar/core/thread.hh>
@@ -95,8 +96,9 @@ TEST(BatchCacheReclaimTest, reclaim) {
         cache_entries.emplace_back(std::move(e));
     }
 
-    // cache uses an async reclaimer. give it a chance to run
-    ss::thread::yield();
+    // reclaim frees batch data synchronously but defers the invalidation of
+    // entry weak pointers to the background reclaimer. wait for it to run
+    tests::drain_task_queue().get();
 
     // now some of the cache entries should have been reclaimed
     EXPECT_TRUE(
@@ -112,5 +114,11 @@ TEST(BatchCacheReclaimTest, reclaim) {
               << " free " << stats.free_memory() / 1024 << " min_free "
               << ss::memory::min_free_memory() / 1024 << " until_reclaim "
               << bytes_until_reclaim / 1024 << " reclaims " << stats.reclaims();
+
+    // this test bypasses the batch_cache_index::put interface, so the ranges
+    // in the cache are not reachable from the index and would dangle past the
+    // index's destruction (the index is declared after the cache, so it is
+    // destroyed first). release them while the index is still alive.
+    cache.clear();
     cache.stop().get();
 }

--- a/src/v/storage/tests/batch_cache_test.cc
+++ b/src/v/storage/tests/batch_cache_test.cc
@@ -49,6 +49,9 @@ public:
       : cache(opts) {}
 
     auto& get_lru() { return cache._lru; };
+    // complete the index removals that reclaim defers to the background
+    // reclaimer, so tests can make synchronous assertions
+    void drain_pending() { cache.drain_pending_index_removals(); }
     ~batch_cache_test_fixture() { cache.stop().get(); }
 
     storage::batch_cache cache;
@@ -81,6 +84,10 @@ TEST_F(batch_cache_test_fixture, reclaim_rounds_up) {
     // reclaims rounds up to the range size for small batches
     EXPECT_EQ(size, storage::batch_cache::range::range_size);
     EXPECT_TRUE(cache.empty());
+
+    // this test bypasses batch_cache_index::put, so the reclaimed range has
+    // no index entries and must be drained before the index is destroyed
+    drain_pending();
 }
 
 TEST_F(batch_cache_test_fixture, reclaim_removes_multiple) {
@@ -100,6 +107,11 @@ TEST_F(batch_cache_test_fixture, reclaim_removes_multiple) {
     auto size = cache.reclaim(b_size + 1);
     EXPECT_GT(size, (2 * b_size));
     EXPECT_TRUE(cache.empty());
+
+    // this test bypasses batch_cache_index::put, so the reclaimed ranges
+    // have no index entries and must be drained before the index is
+    // destroyed
+    drain_pending();
 }
 
 TEST_F(batch_cache_test_fixture, weakness) {
@@ -116,6 +128,7 @@ TEST_F(batch_cache_test_fixture, weakness) {
     EXPECT_TRUE(b2.range());
 
     cache.reclaim(1);
+    drain_pending();
     EXPECT_FALSE(b0.range());
     EXPECT_FALSE(b1.range());
     EXPECT_FALSE(b2.range());
@@ -141,8 +154,8 @@ TEST(batch_cache_test, touch) {
 
         // first one is invalid, second one still valid
         cache.reclaim(1);
-        EXPECT_FALSE(b0.range());
-        EXPECT_TRUE(b1.range());
+        EXPECT_FALSE(b0.range() && b0.range()->valid());
+        EXPECT_TRUE(b1.range() && b1.range()->valid());
         cache.stop().get();
     }
 
@@ -161,8 +174,8 @@ TEST(batch_cache_test, touch) {
         cache.touch(b0.range());
         // so reclaiming now frees the second
         cache.reclaim(1);
-        EXPECT_TRUE(b0.range());
-        EXPECT_FALSE(b1.range());
+        EXPECT_TRUE(b0.range() && b0.range()->valid());
+        EXPECT_FALSE(b1.range() && b1.range()->valid());
         cache.stop().get();
     }
 }


### PR DESCRIPTION
Under high memory pressure, `batch_cache` reclamation can cause significant reactor stalls, [as seen in the decoded backtraces here](https://gist.github.com/WillemKauf/9fd109190d4ceb9dbef15f28f1dbc478). 

Most of these backtraces trace back to the same root in `storage::batch_cache::reclaim()`. For context, the `batch_cache` registers a synchronous memory reclaimer, so `reclaim()` runs inside the seastar allocator _on the allocation hot path_.

As we thrash the `batch_cache` in high memory pressure situations, this reclamation begins to dominate and slow everything down. This PR attempts to optimize this path by:

* Defering `batch_cache` index removal to the background reclaimer. The synchronous allocation path still frees batch data and invalidates ranges, but we push `_index` erases to the background instead (where most of the reactor stalls trace to, within the `btree_map`).
* Caching batch metadata in `batch_cache` index entries. Every index lookup deserialized a `record_batch_header` out of the range's arena in order to access the batch's last offset, type, and max timestamp for answering specific containment, filtering, and coverage checks. It is much cheaper to just cache these values in the entries themselves instead of parsing them repeatedly.
* Erasing reclaimed index entries with iterator reuse. Deferred index removal erased each reclaimed batch's entry with an independent erase-by-key, paying a full root-to-leaf descent per entry. A range's batches are typically adjacent in its index, so erasing in sorted offset order and resuming from the iterator returned by the previous erase reduces most erases to a sequential leaf operation.

A microbenchmark is added, and each change carries the relevant benchmark diffs in their commit message. To paste them again here:

```
Defering `batch_cache` index removal to the background reclaimer.
    test                    dev            this commit
    reclaim_sync            1.04ms         3.83us    (-99.6%)
    reclaim_total           1.05ms         1.06ms    (unchanged)
    reclaim_sync_cold       6.43ms         8.37us    (-99.9%)
    get_hit                 164.39ns       167.66ns  (unchanged)
    get_miss                91.60ns        92.61ns   (unchanged)

```

```
Caching batch metadata in `batch_cache` index entries
    test                    previous commit   this commit
    get_hit                 167.66ns          116.62ns  (-30%)
    get_miss                92.61ns           41.81ns   (-55%)
    read_span               83.09ns           83.04ns   (unchanged)
    read_span_filtered      70.95ns           1.98ns    (-97%)
    reclaim_sync            3.83us            3.93us    (unchanged)
    reclaim_total           1.06ms            1.14ms    (+8%)
```

```
Erasing reclaimed index entries with iterator reuse
    test                    previous commit   this commit
    reclaim_sync            3.93us            3.97us    (unchanged)
    reclaim_total           1.14ms            770.08us  (-32%)
```

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

### Improvements

* Optimize the `batch_cache` reclamation path and avoid reactor stalls in this area
