### PR TITLE
kafka/produce: enable produce v9 (flexible versions)

### DIFF
--- a/src/v/kafka/protocol/schemata/produce_request.json
+++ b/src/v/kafka/protocol/schemata/produce_request.json
@@ -29,7 +29,7 @@
   //
   // Starting in version 7, records can be produced using ZStandard compression.  See KIP-110.
   //
-  // Starting in Version 8, response has RecordErrors and ErrorMEssage. See KIP-467.
+  // Starting in Version 8, response has RecordErrors and ErrorMessage. See KIP-467.
   //
   // Version 9 enables flexible versions. See KIP-482.
   "validVersions": "0-9",

--- a/src/v/kafka/protocol/schemata/produce_request.json
+++ b/src/v/kafka/protocol/schemata/produce_request.json
@@ -30,8 +30,10 @@
   // Starting in version 7, records can be produced using ZStandard compression.  See KIP-110.
   //
   // Starting in Version 8, response has RecordErrors and ErrorMEssage. See KIP-467.
-  "validVersions": "0-8",
-  "flexibleVersions": "none",
+  //
+  // Version 9 enables flexible versions. See KIP-482.
+  "validVersions": "0-9",
+  "flexibleVersions": "9+",
   "fields": [
     { "name": "TransactionalId", "type": "string", "versions": "3+", "nullableVersions": "0+", "entityType": "transactionalId",
       "about": "The transactional ID, or null if the producer is not transactional." },

--- a/src/v/kafka/protocol/schemata/produce_response.json
+++ b/src/v/kafka/protocol/schemata/produce_response.json
@@ -30,8 +30,10 @@
   //
   // Version 8 added RecordErrors and ErrorMessage to include information about
   // records that cause the whole batch to be dropped.  See KIP-467 for details.
-  "validVersions": "0-8",
-  "flexibleVersions": "none",
+  //
+  // Version 9 enables flexible versions. See KIP-482.
+  "validVersions": "0-9",
+  "flexibleVersions": "9+",
   "fields": [
     { "name": "Responses", "type": "[]TopicProduceResponse", "versions": "0+",
       "about": "Each produce response", "fields": [

--- a/src/v/kafka/protocol/tests/protocol_test.cc
+++ b/src/v/kafka/protocol/tests/protocol_test.cc
@@ -195,15 +195,19 @@ void check_kafka_binary_format(
     bytes b;
     {
         if constexpr (std::is_same_v<T, produce_request>) {
-            /// Redpanda currently does not support encoding legacy batches,
-            /// it is not possible to re-convert back to bytes and compare
-            BOOST_TEST(
-              !legacy_batch_failures(r, version),
-              fmt::format(
-                "produce_request encountered when decoding legacy batches, "
-                "version: {}",
-                version));
-            return;
+            /// Versions below 3 carry legacy (message-set) batches which are
+            /// decoded by conversion into v2 batches. Redpanda does not
+            /// support re-encoding legacy batches, so byte comparison is only
+            /// possible for v3+ where clients send v2 batches verbatim.
+            if (version < api_version(3)) {
+                BOOST_TEST(
+                  !legacy_batch_failures(r, version),
+                  fmt::format(
+                    "produce_request encountered when decoding legacy "
+                    "batches, version: {}",
+                    version));
+                return;
+            }
         }
         iobuf iob;
         kafka::protocol::encoder rw(iob);

--- a/src/v/kafka/server/handlers/handler.h
+++ b/src/v/kafka/server/handlers/handler.h
@@ -61,6 +61,15 @@ struct handler_template {
     static constexpr bool has_latency_histogram = LatencyHistogram
                                                   == latency_hist::yes;
 
+    // A handler may support a subset of the versions its schemata define, but
+    // never a version outside them: there would be no encoder or decoder for
+    // it, and api_versions would advertise it to clients regardless.
+    static_assert(
+      min_supported >= api::min_valid && max_supported <= api::max_valid,
+      "Handler supports an API version its schemata do not define. Bump "
+      "validVersions in the corresponding <api>_{request,response}.json "
+      "first.");
+
     static HandleRetType handle(request_context, ss::smp_service_group);
 
     /**

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -42,6 +42,10 @@ namespace kafka {
 namespace {
 static constexpr auto despam_interval = std::chrono::minutes(5);
 
+/// Errors raised here apply to whole topics (request-level failures such as
+/// authorization or a full disk), so they carry no RecordErrors: no single
+/// record is to blame. Per-record diagnostics come from batch validation, see
+/// finalize_request_with_error_code.
 void fill_response_with_errors(
   produce_request::topic_cit topics_begin,
   produce_request::topic_cit topics_end,
@@ -186,22 +190,32 @@ partition_produce_stages partition_append(
     };
 }
 
+/// `batch_index` identifies the record within the batch that caused the
+/// rejection, when validation could attribute the failure to one. It is
+/// reported alongside the error message as a KIP-467 RecordErrors entry, which
+/// the encoder drops below produce v8.
 produce_response::partition finalize_request_with_error_code(
   error_code ec,
   std::unique_ptr<ss::promise<>> dispatch,
   const model::ntp& ntp,
   ss::shard_id source_shard,
-  std::optional<ss::sstring> err_msg = std::nullopt) {
+  std::optional<ss::sstring> err_msg = std::nullopt,
+  std::optional<int32_t> batch_index = std::nullopt) {
     // submit back to promise source shard
     ssx::background = ss::smp::submit_to(
       source_shard, [dispatch = std::move(dispatch)]() mutable {
           dispatch->set_value();
           dispatch.reset();
       });
-    return produce_response::partition{
-      .partition_index = ntp.tp.partition,
-      .error_code = ec,
-      .error_message = std::move(err_msg)};
+    produce_response::partition p{
+      .partition_index = ntp.tp.partition, .error_code = ec};
+    if (batch_index.has_value()) {
+        p.record_errors.push_back(
+          batch_index_and_error_message{
+            .batch_index = *batch_index, .batch_index_error_message = err_msg});
+    }
+    p.error_message = std::move(err_msg);
+    return p;
 }
 
 struct ntp_produce_request {
@@ -300,7 +314,8 @@ ss::future<produce_response::partition> do_produce_topic_partition(
           std::move(dispatched),
           req.ntp,
           ss::this_shard_id(),
-          std::move(validate_batch_res.error->msg));
+          std::move(validate_batch_res.error->msg),
+          validate_batch_res.error->batch_index);
     }
 
     auto batch_size = req.batch->size_bytes();

--- a/src/v/kafka/server/handlers/produce.h
+++ b/src/v/kafka/server/handlers/produce.h
@@ -20,7 +20,7 @@ produce_scheduling_group_provider(const connection_context&);
 using produce_handler = two_phase_handler<
   produce_api,
   0,
-  7,
+  9,
   default_estimate_adaptor,
   produce_scheduling_group_provider,
   latency_hist::yes>;

--- a/src/v/kafka/server/handlers/produce_validation.cc
+++ b/src/v/kafka/server/handlers/produce_validation.cc
@@ -143,10 +143,11 @@ void maybe_set_max_timestamp(
     }
 }
 
-// Iterate over all records in the batch, invoking `f()` on each.
-// Invoking this function shows that iteration over the records within the batch
-// is possible (i.e format validation). For corrupted batches, an
-// `INVALID_RECORD` error code and message are returned.
+// Iterate over all records in the batch, invoking `f(batch_index, metadata)`
+// on each. Invoking this function shows that iteration over the records within
+// the batch is possible (i.e format validation). For corrupted batches, an
+// `INVALID_RECORD` error code and message are returned, along with the index
+// of the record that failed to parse.
 template<typename Func>
 std::optional<error_code_and_msg> iterate_over_records(
   const model::record_batch& b, Func&& f, bool is_strict_validation = false) {
@@ -154,8 +155,15 @@ std::optional<error_code_and_msg> iterate_over_records(
       !b.compressed(),
       "Cannot iterate over records within a compressed batch.");
 
+    int32_t batch_index = 0;
     try {
-        b.for_each_record_metadata(std::forward<Func>(f), is_strict_validation);
+        b.for_each_record_metadata(
+          [&](model::record_metadata r) {
+              auto stop = f(batch_index, std::move(r));
+              ++batch_index;
+              return stop;
+          },
+          is_strict_validation);
     } catch (const std::exception& e) {
         vlog(
           klog.error,
@@ -163,8 +171,21 @@ std::optional<error_code_and_msg> iterate_over_records(
           "{}",
           b.header(),
           e.what());
+        // The throw comes from parsing the record at `batch_index`, unless
+        // every record parsed and the batch has trailing bytes, in which case
+        // no single record is to blame.
+        const auto blamed_record = batch_index < b.record_count();
+        // Deliberately not `e.what()`: from produce v8 on this message goes
+        // back to the client as a protocol string, and these exceptions carry
+        // broker-internal detail, including a multi-line seastar backtrace.
         return error_code_and_msg{
-          .err = error_code::invalid_record, .msg = e.what()};
+          .err = error_code::invalid_record,
+          .msg = blamed_record
+                   ? ssx::sformat(
+                       "Record at index {} could not be parsed", batch_index)
+                   : ss::sstring("Batch records could not be parsed"),
+          .batch_index = blamed_record ? std::make_optional(batch_index)
+                                       : std::nullopt};
     }
 
     return std::nullopt;
@@ -177,11 +198,12 @@ std::expected<model::timestamp, error_code_and_msg>
 compute_max_timestamp(const model::record_batch& b) {
     int64_t max_timestamp_delta = 0;
 
-    auto res = iterate_over_records(b, [&](model::record_metadata r) mutable {
-        max_timestamp_delta = std::max(
-          r.timestamp_delta(), max_timestamp_delta);
-        return ss::stop_iteration::no;
-    });
+    auto res = iterate_over_records(
+      b, [&](int32_t, model::record_metadata r) mutable {
+          max_timestamp_delta = std::max(
+            r.timestamp_delta(), max_timestamp_delta);
+          return ss::stop_iteration::no;
+      });
 
     if (res.has_value()) {
         return std::unexpected(res.value());
@@ -211,7 +233,7 @@ validate_records_and_compute_max_timestamp(
     int64_t max_timestamp = -1;
     auto iterable_res = iterate_over_records(
       iterable_batch_ref,
-      [&](model::record_metadata r) mutable {
+      [&](int32_t batch_index, model::record_metadata r) mutable {
           auto timestamp = model::timestamp{
             b.header().first_timestamp() + r.timestamp_delta()};
           auto offset = b.base_offset() + model::offset_delta(r.offset_delta());
@@ -226,8 +248,13 @@ validate_records_and_compute_max_timestamp(
             ntp);
           max_timestamp = std::max(timestamp(), max_timestamp);
 
-          return res.has_value() ? ss::stop_iteration::yes
-                                 : ss::stop_iteration::no;
+          if (!res.has_value()) {
+              return ss::stop_iteration::no;
+          }
+          // Validation stops at the first offending record, so this is the
+          // only index reported to the client (KIP-467).
+          res->batch_index = batch_index;
+          return ss::stop_iteration::yes;
       },
       is_strict_validation);
 

--- a/src/v/kafka/server/handlers/produce_validation.h
+++ b/src/v/kafka/server/handlers/produce_validation.h
@@ -33,6 +33,10 @@ namespace kafka {
 struct error_code_and_msg {
     error_code err;
     ss::sstring msg;
+    /// Index within the batch of the record that caused the rejection, when
+    /// the failure can be attributed to a single record. Reported to clients
+    /// as RecordErrors[].BatchIndex in produce responses at v8+ (KIP-467).
+    std::optional<int32_t> batch_index;
 };
 
 struct validation_args {

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -902,6 +902,7 @@ redpanda_cc_btest(
         "//src/v/kafka/server",
         "//src/v/model",
         "//src/v/model:batch_compression",
+        "//src/v/model/tests:raw_record_batch_factory",
         "//src/v/random:generators",
         "//src/v/redpanda/tests:fixture",
         "//src/v/storage:record_batch_builder",

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -22,6 +22,7 @@
 #include "model/compression.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "model/tests/raw_record_batch_factory.h"
 #include "model/timeout_clock.h"
 #include "model/timestamp.h"
 #include "random/generators.h"
@@ -315,8 +316,8 @@ single_batch(model::partition_id p_id, const size_t volume) {
 /// below v8; from v8 they reach the client. v9 re-encodes the same field as a
 /// compact nullable string, so it is worth covering separately.
 ///
-/// The companion RecordErrors array stays empty: Redpanda rejects batches
-/// whole rather than per-record. See fill_response_with_errors in produce.cc.
+/// This rejection is a property of the whole batch, so RecordErrors stays
+/// empty. See test_produce_record_errors_kip467 for the per-record case.
 FIXTURE_TEST(test_produce_error_message_kip467, prod_consume_fixture) {
     wait_for_controller_leadership().get();
     start();
@@ -346,6 +347,86 @@ FIXTURE_TEST(test_produce_error_message_kip467, prod_consume_fixture) {
                   std::string_view{*p.error_message}.contains("exceeds max"));
             }
             BOOST_REQUIRE(p.record_errors.empty());
+        }
+    }
+}
+
+namespace {
+
+/// A batch that claims one more record than it carries. Parsing it stops at
+/// index `record_count`, which is the record the broker blames.
+model::record_batch batch_with_missing_last_record(int32_t record_count) {
+    storage::record_batch_builder builder(
+      model::record_batch_type::raft_data, model::offset(0));
+    for (int32_t i = 0; i < record_count; ++i) {
+        iobuf v{};
+        v.append("v", 1);
+        builder.add_raw_kv(iobuf{}, std::move(v));
+    }
+    auto batch = std::move(builder).build();
+
+    auto header = batch.header();
+    header.record_count = record_count + 1;
+    header.last_offset_delta = record_count;
+    auto data = batch.data().copy();
+    // the batch is otherwise well formed: the CRC covers the record count, so
+    // it has to be recomputed or the broker rejects it as corrupt instead
+    header.reset_size_checksum_metadata(data);
+
+    return model::test::raw_record_batch_factory::create_record_batch(
+      header, std::move(data), false);
+}
+
+} // namespace
+
+/// KIP-467 also added RecordErrors, which pinpoints the records that caused a
+/// batch to be rejected. Redpanda stops validating at the first offending
+/// record, so it reports that one index, with the same detail as the summary
+/// ErrorMessage. Like ErrorMessage, the encoder drops it below v8.
+FIXTURE_TEST(test_produce_record_errors_kip467, prod_consume_fixture) {
+    wait_for_controller_leadership().get();
+    start();
+
+    static constexpr int32_t record_count = 4;
+    const auto invalid = [] {
+        kafka::produce_request::partition partition;
+        partition.partition_index = model::partition_id(0);
+        partition.records.emplace(batch_with_missing_last_record(record_count));
+        chunked_vector<kafka::produce_request::partition> res;
+        res.push_back(std::move(partition));
+        return res;
+    };
+
+    for (auto v = kafka::api_version(3);
+         v <= kafka::produce_handler::max_supported;
+         ++v) {
+        auto resp = produce_raw(producers.front(), invalid(), v).get();
+        BOOST_TEST_CONTEXT("produce version " << v) {
+            BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
+            const auto& p = *resp.data.responses.begin()->partitions.begin();
+            BOOST_REQUIRE_EQUAL(
+              p.error_code, kafka::error_code::invalid_record);
+
+            if (v < kafka::api_version(8)) {
+                // neither field exists on the wire yet
+                BOOST_REQUIRE(!p.error_message.has_value());
+                BOOST_REQUIRE(p.record_errors.empty());
+            } else {
+                BOOST_REQUIRE(p.error_message.has_value());
+                // the message is a protocol string, so it has to survive the
+                // client's control character check, i.e. carry no exception
+                // text or backtrace
+                BOOST_REQUIRE(
+                  std::string_view{*p.error_message}.contains(
+                    "index " + std::to_string(record_count)));
+                BOOST_REQUIRE_EQUAL(p.record_errors.size(), 1);
+                const auto& record_error = *p.record_errors.begin();
+                BOOST_REQUIRE_EQUAL(record_error.batch_index, record_count);
+                BOOST_REQUIRE(
+                  record_error.batch_index_error_message.has_value());
+                BOOST_REQUIRE_EQUAL(
+                  *record_error.batch_index_error_message, *p.error_message);
+            }
         }
     }
 }

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -310,6 +310,46 @@ single_batch(model::partition_id p_id, const size_t volume) {
     return res;
 }
 
+/// KIP-467 added a per-partition ErrorMessage to the produce response at v8.
+/// Redpanda has always built these strings, but the encoder dropped them
+/// below v8; from v8 they reach the client. v9 re-encodes the same field as a
+/// compact nullable string, so it is worth covering separately.
+///
+/// The companion RecordErrors array stays empty: Redpanda rejects batches
+/// whole rather than per-record. See fill_response_with_errors in produce.cc.
+FIXTURE_TEST(test_produce_error_message_kip467, prod_consume_fixture) {
+    wait_for_controller_leadership().get();
+    start();
+
+    // comfortably over the 1 MiB kafka_batch_max_bytes default, so the
+    // handler rejects it with message_too_large and an explanatory string
+    const auto oversized = [] {
+        return single_batch(model::partition_id(0), 2_MiB);
+    };
+
+    for (auto v = kafka::api_version(3);
+         v <= kafka::produce_handler::max_supported;
+         ++v) {
+        auto resp = produce_raw(producers.front(), oversized(), v).get();
+        BOOST_TEST_CONTEXT("produce version " << v) {
+            BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
+            const auto& p = *resp.data.responses.begin()->partitions.begin();
+            BOOST_REQUIRE_EQUAL(
+              p.error_code, kafka::error_code::message_too_large);
+
+            if (v < kafka::api_version(8)) {
+                // the field does not exist on the wire yet
+                BOOST_REQUIRE(!p.error_message.has_value());
+            } else {
+                BOOST_REQUIRE(p.error_message.has_value());
+                BOOST_REQUIRE(
+                  std::string_view{*p.error_message}.contains("exceeds max"));
+            }
+            BOOST_REQUIRE(p.record_errors.empty());
+        }
+    }
+}
+
 namespace ch = std::chrono;
 
 namespace {

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -103,7 +103,8 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
 
     ss::future<kafka::produce_response> produce_raw(
       kafka::client::transport& producer,
-      chunked_vector<kafka::produce_request::partition>&& partitions) {
+      chunked_vector<kafka::produce_request::partition>&& partitions,
+      kafka::api_version version = kafka::api_version(7)) {
         kafka::produce_request::topic tp;
         tp.partitions = std::move(partitions);
         tp.name = test_topic;
@@ -113,7 +114,7 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
         req.data.timeout_ms = std::chrono::seconds(2);
         req.has_idempotent = false;
         req.has_transactional = false;
-        return producer.dispatch(std::move(req), kafka::api_version(7));
+        return producer.dispatch(std::move(req), version);
     }
 
     ss::future<kafka::produce_response> produce_raw(
@@ -236,6 +237,38 @@ FIXTURE_TEST(test_produce_consume_small_batches, prod_consume_fixture) {
       resp_2.data.responses.begin()->partitions.begin()->records->last_offset(),
       offset_2);
 };
+
+/// Produce works at every supported version that accepts v2 record batches
+/// (v3 was the first). Notably covers v8 (KIP-467 error fields) and v9, the
+/// first flexible version (KIP-482: compact strings/arrays, varint-prefixed
+/// records and tagged fields).
+FIXTURE_TEST(test_produce_all_supported_versions, prod_consume_fixture) {
+    wait_for_controller_leadership().get();
+    start();
+    static constexpr size_t records_per_batch = 10;
+    auto expected_offset = model::offset(0);
+    for (auto v = kafka::api_version(3);
+         v <= kafka::produce_handler::max_supported;
+         ++v) {
+        auto resp = produce_raw(
+                      producers.front(), small_batches(records_per_batch), v)
+                      .get();
+        BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
+        BOOST_REQUIRE_EQUAL(resp.data.responses.begin()->partitions.size(), 1);
+        const auto& p = *resp.data.responses.begin()->partitions.begin();
+        BOOST_REQUIRE_EQUAL(p.error_code, kafka::error_code::none);
+        BOOST_REQUIRE_EQUAL(p.base_offset, expected_offset);
+        expected_offset += model::offset(records_per_batch);
+    }
+    // all batches produced above are readable
+    auto resp = fetch_next().get();
+    BOOST_REQUIRE_EQUAL(resp.data.responses.empty(), false);
+    BOOST_REQUIRE_EQUAL(resp.data.responses.begin()->partitions.empty(), false);
+    const auto& part = *resp.data.responses.begin()->partitions.begin();
+    BOOST_REQUIRE_EQUAL(part.error_code, kafka::error_code::none);
+    BOOST_REQUIRE_EQUAL(
+      part.records->last_offset(), expected_offset - model::offset(1));
+}
 
 FIXTURE_TEST(test_version_handler, prod_consume_fixture) {
     wait_for_controller_leadership().get();


### PR DESCRIPTION
Enables version 8 and 9 of the Kafka produce request/response.

Version 9 introduces flexible versions (KIP-482: compact strings/arrays, varint-prefixed records and tagged fields). This is purely a wire-format change — the flexible framing is handled generically by the existing schema generator and `flex_versions` machinery, so no hand-written encode/decode was needed. The produce schemas are bumped to `0-9` with `flexibleVersions: 9+`.

Raising the produce handler's max supported version from 7 to 9 also enables version 8, whose `RecordErrors`/`ErrorMessage` fields (KIP-467) were already declared in the schema. Note: Redpanda reports batch-level produce errors only — the top-level per-partition `ErrorMessage` is populated, but the per-record `RecordErrors` array introduced by KIP-467 is left empty. So the broker is wire-compatible with v8 rather than implementing KIP-467's per-record error reporting.

A new smoke test produces at every supported version from v3 through max and verifies all batches are readable back, plus a byte-compare roundtrip test for the produce request across v3+.

## Backports Required

- [x] none - not a bug fix

## Release Notes

### Features

* Added support for versions 8 and 9 of the Kafka produce API (flexible versions, KIP-482).
