### PR TITLE
zstd: bench and sync improvements

### DIFF
--- a/src/v/compaction/tests/filter_bench.cc
+++ b/src/v/compaction/tests/filter_bench.cc
@@ -64,10 +64,10 @@ public:
             builder.add_raw_kv(reflection::to_iobuf(i), gen_value(value_size));
         }
         auto batch = std::move(builder).build();
+        const auto uncompressed_bytes = batch.size_bytes();
         if (codec != model::compression::none) {
             batch = model::compress_batch_sync(codec, std::move(batch));
         }
-        const auto input_bytes = batch.size_bytes();
 
         // Index the keys of the records we want removed at an offset strictly
         // higher than any record in the batch, so the filter drops them. The
@@ -91,7 +91,7 @@ public:
         perf_tests::stop_measuring_time();
 
         perf_tests::do_not_optimize(output);
-        co_return input_bytes;
+        co_return uncompressed_bytes;
     }
 };
 

--- a/src/v/compression/stream_zstd.cc
+++ b/src/v/compression/stream_zstd.cc
@@ -123,7 +123,7 @@ iobuf stream_zstd::do_compress(const iobuf& x) {
         } else {
             in = {.src = nullptr, .size = 0, .pos = 0};
         }
-        auto mode = ZSTD_e_flush;
+        auto mode = ZSTD_e_continue;
         r = ZSTD_compressStream2(ctx, &out, &in, mode);
         throw_if_error(r);
         in_pos = in.pos;

--- a/src/v/compression/tests/zstd_tests.cc
+++ b/src/v/compression/tests/zstd_tests.cc
@@ -94,6 +94,30 @@ SEASTAR_THREAD_TEST_CASE(stream_zstd_test) {
     }
 }
 
+SEASTAR_THREAD_TEST_CASE(stream_zstd_fragmentation_independence_test) {
+    constexpr size_t fragment_size = 113;
+    const auto data = random_generators::gen_alphanum_string(10_KiB);
+
+    iobuf contiguous;
+    contiguous.append(data.data(), data.size());
+
+    iobuf fragmented;
+    auto remaining = std::string_view(data);
+    while (!remaining.empty()) {
+        const auto fragment = remaining.substr(0, fragment_size);
+        iobuf buf;
+        buf.append(fragment.data(), fragment.size());
+        fragmented.append_fragments(std::move(buf));
+        remaining.remove_prefix(fragment.size());
+    }
+    BOOST_REQUIRE_EQUAL(fragmented, contiguous);
+
+    compression::stream_zstd fn;
+    auto contiguous_compressed = fn.compress(contiguous);
+    auto fragmented_compressed = fn.compress(fragmented);
+    BOOST_REQUIRE_EQUAL(fragmented_compressed, contiguous_compressed);
+}
+
 SEASTAR_THREAD_TEST_CASE(async_stream_zstd_test) {
     compression::async_stream_zstd fn(default_decompression_size, 1);
     auto test_sizes = get_test_sizes();


### PR DESCRIPTION
 - Make sync zstd compression reuse the stream across iobuf fragments
 - Fix compaction zstd bench to be compression ratio independent

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes


* none
