### PR TITLE
[CORE-12597] consumer_group_test: fix flaky test_large_group_count

### DIFF
--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -590,10 +590,16 @@ class ConsumerGroupTest(RedpandaTest):
                     )
                     try:
                         consumer.subscribe([self.topic_spec.name])
-                        # poll() must run long enough for JoinGroup to
-                        # complete so the group is registered; kafka-python
-                        # 2.3.1's coordinator poll honors this timeout.
-                        consumer.poll(timeout_ms=5000)
+                        # Poll until the consumer is actually assigned
+                        # partitions, which proves JoinGroup/SyncGroup
+                        # completed and the group is registered on the
+                        # coordinator.
+                        deadline = time.monotonic() + 30
+                        while not consumer.assignment() and time.monotonic() < deadline:
+                            consumer.poll(timeout_ms=500)
+                        assert consumer.assignment(), (
+                            f"consumer g-{i} failed to join group in time"
+                        )
                     finally:
                         consumer.close(autocommit=True)
                 except Exception as e:


### PR DESCRIPTION

Fixes a flake in `ConsumerGroupTest.test_large_group_count` where the
first `assert len(list) == groups_in_round * rounds` (expected 1000)
intermittently failed with the count short of 1000.

The test creates 1000 short-lived consumer groups; each group is only
registered on the coordinator once its consumer completes
`JoinGroup`/`SyncGroup`. The kafka-python 2.3.1 upgrade made `poll()`
honor its timeout in the coordinator step, so a single fixed-budget
`poll(timeout_ms=5000)` can return before the join finishes under load —
leaving that group unregistered and the count short. The earlier 5s bump
only shrank the race window.

Instead, poll in short slices until `consumer.assignment()` is non-empty
(which proves the join completed and the group is registered), bounded by
a 30s deadline, and assert per-consumer so a genuine join failure surfaces
a clear message instead of a bare count mismatch.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
