### PR TITLE
[CORE-16884] cloud_topics: fix shadow-link replication stall after transient S3 outage

### DIFF
--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -1247,6 +1247,24 @@ remote::upload_object(upload_request upload_request, group_id gid) {
         }
         auto lease = std::move(fut).get();
 
+        // The lease already subscribes this abort source and shuts the
+        // client down on abort for the in-flight window, but its
+        // constructor silently skips that subscription if abort was
+        // already requested, and the pool's fast path never checks it.
+        // The `!abort_sub` branch below closes that already-aborted
+        // window; the subscription itself is a second line of defense
+        // so upload_object's promptness on abort doesn't depend on pool
+        // internals. The callback owns a reference to the client so a
+        // late abort (after the lease is dropped on the error path)
+        // stays safe; shutdown is idempotent.
+        auto abort_sub = fib.root_abort_source().subscribe(
+          [client = lease.client]() noexcept { client->shutdown(); });
+        if (!abort_sub) {
+            // Abort was requested while acquiring the client.
+            transfer_details.on_failure();
+            co_return upload_result::cancelled;
+        }
+
         vlog(
           ctxlog.debug,
           "Uploading {} to path {}, length {}",

--- a/src/v/cloud_io/tests/BUILD
+++ b/src/v/cloud_io/tests/BUILD
@@ -148,6 +148,24 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "remote_abort_test",
+    timeout = "short",
+    srcs = [
+        "remote_abort_test.cc",
+    ],
+    deps = [
+        ":scoped_remote",
+        "//src/v/bytes:iobuf",
+        "//src/v/cloud_io:remote",
+        "//src/v/cloud_storage_clients",
+        "//src/v/test_utils:gtest",
+        "//src/v/utils:retry_chain_node",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "io_resources_test",
     timeout = "short",
     srcs = [

--- a/src/v/cloud_io/tests/remote_abort_test.cc
+++ b/src/v/cloud_io/tests/remote_abort_test.cc
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "bytes/iobuf.h"
+#include "cloud_io/remote.h"
+#include "cloud_io/tests/scoped_remote.h"
+#include "cloud_storage_clients/configuration.h"
+#include "cloud_storage_clients/types.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/core/timed_out_error.hh>
+#include <seastar/core/with_timeout.hh>
+#include <seastar/net/api.hh>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+/// TCP server that accepts connections and discards everything it reads,
+/// never sending a response. Emulates a blackholed S3 endpoint: the
+/// client's request lands in an established socket and then no forward
+/// progress ever happens.
+class blackhole_server {
+public:
+    void start() {
+        ss::listen_options lo;
+        lo.reuse_address = true;
+        _sock = ss::listen(
+          ss::socket_address(ss::net::inet_address("127.0.0.1"), 0), lo);
+        _port = _sock.local_address().port();
+        _accept_loop = accept_loop();
+    }
+
+    uint16_t port() const { return _port; }
+
+    ss::future<> stop() {
+        _stopped = true;
+        _sock.abort_accept();
+        for (auto& s : _connections) {
+            s.shutdown_input();
+            s.shutdown_output();
+        }
+        co_await std::move(_accept_loop);
+    }
+
+private:
+    ss::future<> accept_loop() {
+        while (!_stopped) {
+            try {
+                auto ar = co_await _sock.accept();
+                _connections.push_back(std::move(ar.connection));
+                // Drain the request in the background; never respond.
+                std::ignore = drain(_connections.back().input());
+            } catch (...) {
+                // abort_accept() lands here on stop.
+                co_return;
+            }
+        }
+    }
+
+    static ss::future<> drain(ss::input_stream<char> in) {
+        try {
+            while (true) {
+                auto buf = co_await in.read();
+                if (buf.empty()) {
+                    co_return;
+                }
+            }
+        } catch (...) {
+        }
+    }
+
+    ss::server_socket _sock;
+    ss::future<> _accept_loop = ss::make_ready_future<>();
+    std::vector<ss::connected_socket> _connections;
+    uint16_t _port{0};
+    bool _stopped{false};
+};
+
+cloud_storage_clients::s3_configuration blackhole_configuration(uint16_t port) {
+    cloud_storage_clients::s3_configuration conf;
+    conf.uri = cloud_storage_clients::access_point_uri("127.0.0.1");
+    conf.access_key = cloud_roles::public_key_str("access-key");
+    conf.secret_key = cloud_roles::private_key_str("secret-key");
+    conf.region = cloud_roles::aws_region_name("us-east-1");
+    conf.service = cloud_roles::aws_service_name("s3");
+    conf.url_style = cloud_storage_clients::s3_url_style::path;
+    conf.server_addr = net::unresolved_address("127.0.0.1", port);
+    return conf;
+}
+
+enum class upload_outcome { finished_error, finished_success };
+
+} // namespace
+
+class RemoteAbortTest : public seastar_test {
+public:
+    void SetUp() override {
+        _server.start();
+        _scoped = cloud_io::scoped_remote::create(
+          1, blackhole_configuration(_server.port()));
+    }
+
+    void TearDown() override {
+        _scoped->request_stop();
+        _scoped.reset();
+        _server.stop().get();
+    }
+
+    cloud_io::remote& remote() { return _scoped->remote.local(); }
+
+    blackhole_server _server;
+    std::unique_ptr<cloud_io::scoped_remote> _scoped;
+};
+
+TEST_F(RemoteAbortTest, AbortShutsDownInflightUpload) {
+    ss::abort_source as;
+    // Deadline far in the future: promptness must come from the abort,
+    // not from the retry-chain deadline.
+    retry_chain_node rtc(as, 300s, 100ms);
+    cloud_storage_clients::bucket_name bucket("test-bucket");
+    cloud_storage_clients::object_key key("test-key");
+
+    auto fut = remote().upload_object(
+      {.transfer_details = {.bucket = bucket, .key = key, .parent_rtc = rtc},
+       .display_str = "blackhole-upload",
+       .payload = bytes_to_iobuf(bytes(bytes::initialized_zero{}, 1024))});
+
+    // Let the PUT get in flight on the established, silent connection.
+    ss::sleep(500ms).get();
+    ASSERT_FALSE(fut.available()) << "upload finished against a blackhole "
+                                     "server; test precondition broken";
+
+    as.request_abort_ex(ss::timed_out_error{});
+
+    // Map any completion (value or exception) to a value, so a timeout of
+    // the bounded wait below unambiguously means "still parked".
+    auto outcome_fut = std::move(fut).then_wrapped(
+      [](ss::future<cloud_io::upload_result> f) {
+          try {
+              auto r = f.get();
+              return r == cloud_io::upload_result::success
+                       ? upload_outcome::finished_success
+                       : upload_outcome::finished_error;
+          } catch (...) {
+              return upload_outcome::finished_error;
+          }
+      });
+    try {
+        auto outcome = ss::with_timeout(
+                         ss::lowres_clock::now() + 10s, std::move(outcome_fut))
+                         .get();
+        ASSERT_EQ(outcome, upload_outcome::finished_error);
+    } catch (const ss::timed_out_error&) {
+        FAIL() << "upload_object still parked 10s after abort — abort did "
+                  "not reach the in-flight attempt";
+    }
+}

--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -407,8 +407,15 @@ ss::future<> app::cleanup_tmp_files() {
 }
 
 ss::future<> app::stop() {
-    ssx::sharded_service_container::shutdown();
+    // Stop the data plane first: pipeline shutdown aborts the pipelines'
+    // abort sources, waking any request-resolver fibers parked in retry
+    // backoff. Container services (e.g. the reconciler) block their own
+    // stop() on those requests resolving; stopping the container first
+    // deadlocks until the backoff expires. Services that call into the
+    // stopped data plane during their shutdown receive benign
+    // shutting_down errors.
     co_await data_plane->stop();
+    co_await ss::async([this] { ssx::sharded_service_container::shutdown(); });
 }
 
 ss::sharded<l1::leader_router>* app::get_sharded_l1_metastore_router() {

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -43,7 +43,6 @@
 #include "storage/offset_translator_state.h"
 #include "storage/types.h"
 
-#include <seastar/core/circular_buffer.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/coroutine/as_future.hh>
@@ -60,7 +59,7 @@ namespace cloud_topics {
 namespace {
 
 struct placeholder_batches_with_size {
-    ss::circular_buffer<model::record_batch> batches;
+    chunked_vector<model::record_batch> batches;
     // Total size of all referenced data
     size_t extent_size{0};
 };
@@ -1047,10 +1046,7 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
     auto placeholders = co_await convert_to_placeholders(
       res.value().extents, headers);
 
-    chunked_vector<model::record_batch> placeholder_batches;
-    for (auto&& batch : placeholders.batches) {
-        placeholder_batches.push_back(std::move(batch));
-    }
+    auto placeholder_batches = std::move(placeholders.batches);
 
     opts = update_replicate_options(opts, fence->term);
     auto result = co_await _partition->replicate(
@@ -1527,9 +1523,7 @@ ss::future<result<raft::replicate_result>> frontend::replicate_at_offset(
 
         auto placeholders = co_await convert_to_placeholders(
           res.value().extents, data_headers);
-        placeholder_batches = chunked_vector<model::record_batch>(
-          std::make_move_iterator(placeholders.batches.begin()),
-          std::make_move_iterator(placeholders.batches.end()));
+        placeholder_batches = std::move(placeholders.batches);
     }
 
     // Restore the original input order by 2-way merging placeholders and

--- a/src/v/cloud_topics/level_zero/batcher/batcher.cc
+++ b/src/v/cloud_topics/level_zero/batcher/batcher.cc
@@ -20,7 +20,9 @@
 #include "config/configuration.h"
 #include "utils/human.h"
 
+#include <seastar/core/timer.hh>
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/util/defer.hh>
 
 #include <exception>
 #include <limits>
@@ -78,12 +80,32 @@ batcher<Clock>::upload_object(object_id id, iobuf payload) {
 
     auto err = errc::success;
     try {
+        ss::abort_source per_request_as;
+        // Propagate batcher shutdown into the per-request abort source so
+        // the main abort path still reaches the remote mid-upload.
+        auto main_abort_sub = _as.subscribe(
+          [&per_request_as]() noexcept { per_request_as.request_abort(); });
+        if (!main_abort_sub) {
+            co_return std::unexpected{errc::shutting_down};
+        }
+        // Bound the whole upload, including an attempt wedged on a dead
+        // socket that no lower-level deadline can reach. On expiry the
+        // abort tears down the leased client connection in
+        // cloud_io::remote.
+        auto deadline = Clock::now() + _upload_timeout();
+        ss::timer<Clock> upload_timer([&per_request_as] {
+            per_request_as.request_abort_ex(upload_timeout_exception{});
+        });
+        upload_timer.arm(deadline);
+        auto timer_guard = ss::defer(
+          [&upload_timer]() noexcept { upload_timer.cancel(); });
+
         // Clock type is not parametrized further down the call chain.
         basic_retry_chain_node<Clock> local_rtc(
-          Clock::now() + _upload_timeout(),
+          per_request_as,
+          deadline,
           _upload_backoff_interval(),
-          retry_strategy::backoff,
-          &_rtc);
+          retry_strategy::backoff);
 
         auto path = object_path_factory::level_zero_path(id);
 
@@ -114,7 +136,7 @@ batcher<Clock>::upload_object(object_id id, iobuf payload) {
         case cloud_io::upload_result::success:
             break;
         case cloud_io::upload_result::cancelled:
-            err = errc::shutting_down;
+            err = _as.abort_requested() ? errc::shutting_down : errc::timeout;
             break;
         case cloud_io::upload_result::timedout:
             err = errc::timeout;
@@ -122,6 +144,11 @@ batcher<Clock>::upload_object(object_id id, iobuf payload) {
         case cloud_io::upload_result::failed:
             err = errc::upload_failure;
         }
+    } catch (const upload_timeout_exception&) {
+        // The upload timer fired and the abort exception propagated out
+        // of the remote (e.g. via the retry chain's abort check) instead
+        // of being classified into a result code.
+        co_return std::unexpected{errc::timeout};
     } catch (...) {
         auto e = std::current_exception();
         if (ssx::is_shutdown_exception(e)) {

--- a/src/v/cloud_topics/level_zero/batcher/batcher.h
+++ b/src/v/cloud_topics/level_zero/batcher/batcher.h
@@ -33,6 +33,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/lowres_clock.hh>
+#include <seastar/core/timed_out_error.hh>
 
 #include <chrono>
 
@@ -43,6 +44,13 @@ class remote;
 } // namespace cloud_io
 
 namespace cloud_topics::l0 {
+
+/// Raised through the per-upload abort source when the batcher's upload
+/// timer expires. Derives from ss::timed_out_error so cloud_io's existing
+/// exception classification maps it to upload_result::timedout.
+struct upload_timeout_exception final : ss::timed_out_error {
+    const char* what() const noexcept override { return "L0 upload timed out"; }
+};
 
 struct batcher_result {
     uuid_t uuid;

--- a/src/v/cloud_topics/level_zero/batcher/tests/BUILD
+++ b/src/v/cloud_topics/level_zero/batcher/tests/BUILD
@@ -44,6 +44,7 @@ redpanda_cc_gtest(
         "//src/v/cloud_topics/level_zero/pipeline:serializer",
         "//src/v/cloud_topics/level_zero/pipeline:write_pipeline",
         "//src/v/cloud_topics/level_zero/pipeline:write_request",
+        "//src/v/config",
         "//src/v/model",
         "//src/v/model/tests:random",
         "//src/v/random:generators",

--- a/src/v/cloud_topics/level_zero/batcher/tests/batcher_test.cc
+++ b/src/v/cloud_topics/level_zero/batcher/tests/batcher_test.cc
@@ -12,6 +12,7 @@
 #include "cloud_topics/level_zero/batcher/batcher.h"
 #include "cloud_topics/level_zero/common/extent_meta.h"
 #include "cloud_topics/object_utils.h"
+#include "config/configuration.h"
 #include "model/fundamental.h"
 #include "model/namespace.h"
 #include "model/record.h"
@@ -27,6 +28,7 @@
 #include <seastar/core/when_all.hh>
 #include <seastar/util/later.hh>
 #include <seastar/util/log.hh>
+#include <seastar/util/optimized_optional.hh>
 
 #include <chrono>
 #include <iterator>
@@ -420,4 +422,239 @@ TEST_CORO(batcher_test, chunk_splitting_balances_upload_sizes) {
           << "Upload " << i << " size " << mock.payloads[i].size()
           << " is too small relative to average " << avg_size;
     }
+}
+
+namespace {
+
+/// State for a mocked upload that completes only when the caller aborts
+/// it through the retry chain's root abort source — the behavior the
+/// real remote has after the cloud_io abort-subscription fix.
+struct parked_upload {
+    ss::promise<cloud_io::upload_result> promise;
+    ss::optimized_optional<ss::abort_source::subscription> sub;
+    bool abort_seen{false};
+
+    /// Resolve with `res` when the abort fires.
+    void park_until_abort(remote_mock& mock, cloud_io::upload_result res) {
+        EXPECT_CALL(mock, upload_object(::testing::_, ::testing::_))
+          .WillOnce(
+            [this, res](
+              const cloud_io::basic_upload_request<ss::manual_clock>& req,
+              cloud_io::group_id) {
+                auto& as = req.transfer_details.parent_rtc.root_abort_source();
+                sub = as.subscribe([this, res]() noexcept {
+                    abort_seen = true;
+                    promise.set_value(res);
+                });
+                return promise.get_future();
+            });
+    }
+
+    /// Resolve by throwing when the abort fires (models the real remote
+    /// path where fib.retry() -> as.check() rethrows the abort exception).
+    void park_until_abort_then_throw(remote_mock& mock) {
+        EXPECT_CALL(mock, upload_object(::testing::_, ::testing::_))
+          .WillOnce(
+            [this](
+              const cloud_io::basic_upload_request<ss::manual_clock>& req,
+              cloud_io::group_id) {
+                auto& as = req.transfer_details.parent_rtc.root_abort_source();
+                sub = as.subscribe([this]() noexcept {
+                    abort_seen = true;
+                    promise.set_exception(
+                      std::make_exception_ptr(
+                        cloud_topics::l0::upload_timeout_exception{}));
+                });
+                return promise.get_future();
+            });
+    }
+};
+
+} // namespace
+
+TEST_CORO(batcher_test, upload_timer_aborts_wedged_upload) {
+    scoped_config cfg;
+    cfg.get("cloud_storage_segment_upload_timeout_ms")
+      .set_value(std::chrono::milliseconds(10s));
+
+    remote_mock mock;
+    cloud_storage_clients::bucket_name bucket("foo");
+    cloud_topics::l0::write_pipeline<ss::manual_clock> pipeline;
+    static_cluster_services cluster_services;
+    cloud_topics::l0::batcher<ss::manual_clock> batcher(
+      pipeline.register_write_pipeline_stage(),
+      bucket,
+      mock,
+      &cluster_services);
+    cloud_topics::l0::batcher_accessor batcher_accessor{
+      .batcher = &batcher,
+    };
+    cloud_topics::l0::write_pipeline_accessor pipeline_accessor{
+      .pipeline = &pipeline,
+    };
+
+    parked_upload parked;
+    parked.park_until_abort(mock, cloud_io::upload_result::timedout);
+
+    auto [_, records, reader] = get_random_batches(10, 10);
+    // Generous request deadline: the upload timer, not request expiry,
+    // must end this upload.
+    auto deadline = ss::manual_clock::now() + 200s;
+    auto write_fut = pipeline.write_and_debounce(
+      model::controller_ntp, min_epoch, std::move(reader), deadline);
+    co_await sleep_until(
+      10ms, [&] { return pipeline_accessor.write_requests_pending(1); });
+
+    auto run_fut = batcher_accessor.run_once();
+    // The upload parks; nothing resolves before the timer deadline.
+    co_await sleep(1s);
+    ASSERT_FALSE_CORO(run_fut.available());
+    ASSERT_FALSE_CORO(parked.abort_seen);
+
+    // Cross the upload timeout: the timer must fire the per-request
+    // abort, which the (mocked) remote observes.
+    co_await sleep_until(10s, [&] { return run_fut.available(); });
+    ASSERT_TRUE_CORO(parked.abort_seen);
+
+    auto run_res = co_await std::move(run_fut);
+    ASSERT_FALSE_CORO(run_res.has_value());
+    ASSERT_EQ_CORO(run_res.error(), cloud_topics::errc::timeout);
+
+    auto write_res = co_await std::move(write_fut);
+    ASSERT_FALSE_CORO(write_res.has_value());
+    ASSERT_EQ_CORO(write_res.error(), cloud_topics::errc::timeout);
+}
+
+TEST_CORO(batcher_test, upload_timeout_exception_maps_to_timeout) {
+    scoped_config cfg;
+    cfg.get("cloud_storage_segment_upload_timeout_ms")
+      .set_value(std::chrono::milliseconds(10s));
+
+    remote_mock mock;
+    cloud_storage_clients::bucket_name bucket("foo");
+    cloud_topics::l0::write_pipeline<ss::manual_clock> pipeline;
+    static_cluster_services cluster_services;
+    cloud_topics::l0::batcher<ss::manual_clock> batcher(
+      pipeline.register_write_pipeline_stage(),
+      bucket,
+      mock,
+      &cluster_services);
+    cloud_topics::l0::batcher_accessor batcher_accessor{
+      .batcher = &batcher,
+    };
+    cloud_topics::l0::write_pipeline_accessor pipeline_accessor{
+      .pipeline = &pipeline,
+    };
+
+    parked_upload parked;
+    parked.park_until_abort_then_throw(mock);
+
+    auto [_, records, reader] = get_random_batches(10, 10);
+    auto deadline = ss::manual_clock::now() + 200s;
+    auto write_fut = pipeline.write_and_debounce(
+      model::controller_ntp, min_epoch, std::move(reader), deadline);
+    co_await sleep_until(
+      10ms, [&] { return pipeline_accessor.write_requests_pending(1); });
+
+    auto run_fut = batcher_accessor.run_once();
+    // Let the upload timer actually get armed (run_once() suspends at
+    // least once before reaching upload_object's timer-arm statement,
+    // e.g. on the already-ready current_epoch() future) before crossing
+    // the timeout below, otherwise the clock advance below could race
+    // ahead of the timer's arm point.
+    co_await sleep_until(1ms, [&] { return bool(parked.sub); });
+    co_await sleep_until(10s, [&] { return run_fut.available(); });
+    ASSERT_TRUE_CORO(parked.abort_seen);
+
+    // The custom exception classifies as timeout, not shutdown and not
+    // an unexpected failure.
+    auto run_res = co_await std::move(run_fut);
+    ASSERT_FALSE_CORO(run_res.has_value());
+    ASSERT_EQ_CORO(run_res.error(), cloud_topics::errc::timeout);
+
+    auto write_res = co_await std::move(write_fut);
+    ASSERT_FALSE_CORO(write_res.has_value());
+}
+
+TEST_CORO(batcher_test, batcher_abort_propagates_to_upload) {
+    remote_mock mock;
+    cloud_storage_clients::bucket_name bucket("foo");
+    cloud_topics::l0::write_pipeline<ss::manual_clock> pipeline;
+    static_cluster_services cluster_services;
+    cloud_topics::l0::batcher<ss::manual_clock> batcher(
+      pipeline.register_write_pipeline_stage(),
+      bucket,
+      mock,
+      &cluster_services);
+    cloud_topics::l0::batcher_accessor batcher_accessor{
+      .batcher = &batcher,
+    };
+    cloud_topics::l0::write_pipeline_accessor pipeline_accessor{
+      .pipeline = &pipeline,
+    };
+
+    parked_upload parked;
+    parked.park_until_abort(mock, cloud_io::upload_result::cancelled);
+
+    auto [_, records, reader] = get_random_batches(10, 10);
+    auto deadline = ss::manual_clock::now() + 200s;
+    auto write_fut = pipeline.write_and_debounce(
+      model::controller_ntp, min_epoch, std::move(reader), deadline);
+    co_await sleep_until(
+      10ms, [&] { return pipeline_accessor.write_requests_pending(1); });
+
+    auto run_fut = batcher_accessor.run_once();
+    co_await sleep(100ms);
+    ASSERT_FALSE_CORO(run_fut.available());
+
+    // Main abort (batcher shutdown) must reach the in-flight upload
+    // through the per-request abort source — no clock advance needed.
+    auto stop_fut = batcher.stop();
+    co_await sleep_until(10ms, [&] { return run_fut.available(); });
+    ASSERT_TRUE_CORO(parked.abort_seen);
+
+    auto run_res = co_await std::move(run_fut);
+    ASSERT_FALSE_CORO(run_res.has_value());
+    ASSERT_EQ_CORO(run_res.error(), cloud_topics::errc::shutting_down);
+
+    auto write_res = co_await std::move(write_fut);
+    ASSERT_FALSE_CORO(write_res.has_value());
+    co_await std::move(stop_fut);
+}
+
+TEST_CORO(batcher_test, upload_timer_disarmed_on_completion) {
+    remote_mock mock;
+    cloud_storage_clients::bucket_name bucket("foo");
+    cloud_topics::l0::write_pipeline<ss::manual_clock> pipeline;
+    static_cluster_services cluster_services;
+    cloud_topics::l0::batcher<ss::manual_clock> batcher(
+      pipeline.register_write_pipeline_stage(),
+      bucket,
+      mock,
+      &cluster_services);
+    cloud_topics::l0::batcher_accessor batcher_accessor{
+      .batcher = &batcher,
+    };
+    cloud_topics::l0::write_pipeline_accessor pipeline_accessor{
+      .pipeline = &pipeline,
+    };
+
+    auto [_, records, reader] = get_random_batches(10, 10);
+    mock.expect_upload_object(records);
+
+    auto deadline = ss::manual_clock::now() + 200s;
+    auto write_fut = pipeline.write_and_debounce(
+      model::controller_ntp, min_epoch, std::move(reader), deadline);
+    co_await sleep_until(
+      10ms, [&] { return pipeline_accessor.write_requests_pending(1); });
+
+    auto res = co_await batcher_accessor.run_once();
+    ASSERT_TRUE_CORO(res.has_value());
+    auto write_res = co_await std::move(write_fut);
+    ASSERT_TRUE_CORO(write_res.has_value());
+
+    // The timer must be disarmed after completion: crossing the timeout
+    // now must not fire a callback into the destroyed per-request abort
+    // source (ASAN would catch a use-after-free here).
+    co_await sleep(200'000ms);
 }

--- a/tests/rptest/tests/cluster_linking_s3_fault_test.py
+++ b/tests/rptest/tests/cluster_linking_s3_fault_test.py
@@ -1,0 +1,188 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import re
+import time
+
+from ducktape.mark import matrix
+from ducktape.utils.util import wait_until
+
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
+from rptest.tests.cluster_linking_test_base import (
+    CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST,
+    ShadowLinkPreAllocTestBase,
+)
+from rptest.util import firewall_blocked
+
+# While the target's S3 endpoint is blackholed, the cloud-topics write
+# path and the shadow-link replicators emit error-level logs that are
+# expected for this scenario.
+S3_FAULT_LOG_ALLOW_LIST = CLOUD_TOPICS_SHADOW_LINK_LOG_ALLOW_LIST + [
+    # batcher.cc: exception path of the L0 upload
+    re.compile(r".*Unexpected L0 upload error.*"),
+    re.compile(r".*Unexpected batcher error.*"),
+    # partition_replicator.cc: exception path of replicate_finished
+    re.compile(r".*Exception during replication.*"),
+    re.compile(r".*Error in fetch_and_replicate.*"),
+    # cloud_io remote: upload/download retries exhausted
+    re.compile(r".*backoff quota exceded.*"),
+]
+
+
+class ClusterLinkS3FaultTest(ShadowLinkPreAllocTestBase):
+    """Reproducer for CORE-16884: a transient, silent S3 outage on the
+    TARGET cluster of a shadow link wedges every partition replicator.
+    In-flight L0 upload PUTs hang on established-but-dead sockets
+    (http::client only bounds connection establishment with a timeout),
+    upload slots and partition-data-queue units leak, and replication
+    stays stalled until the kernel TCP retransmit limit (~15 min)
+    fires -- regardless of when S3 connectivity returns.
+
+    The test blackholes the target's S3 port (iptables DROP, sockets
+    left alive), verifies replication actually stalled (precondition,
+    so the run cannot pass vacuously), lifts the block, and requires
+    replication to resume within RESUME_TIMEOUT_SEC and fully catch up
+    within CATCH_UP_TIMEOUT_SEC.
+
+    Expected on current dev: FAILS at the resume assertion with the
+    "CORE-16884 stall" message. Passes once uploads observe deadlines.
+
+    Not covered here (follow-up fix areas of the same ticket): lag
+    mis-reporting during the stall (SRC-HWM=-1 / negative lag in
+    rpk shadow status) and retry-liveness during the block.
+    """
+
+    LINK_NAME = "test-link"
+    PARTITION_COUNT = 8
+    MSG_SIZE = 1024
+    # Effectively unbounded; the test stops the producer explicitly.
+    MSG_COUNT = 2_000_000
+    PRODUCE_RATE_BPS = 512 * 1024
+
+    BLOCK_SEC = 120
+    STALL_CHECK_DELAY_SEC = 30
+    STALL_CHECK_INTERVAL_SEC = 20
+    RESUME_TIMEOUT_SEC = 90
+    CATCH_UP_TIMEOUT_SEC = 240
+
+    def _hwms(self, rpk, topic: str) -> dict[int, int]:
+        return {p.id: p.high_watermark for p in rpk.describe_topic(topic)}
+
+    def _target_hwm_sum(self, topic: str) -> int:
+        return sum(self._hwms(self.target_cluster_rpk, topic).values())
+
+    @cluster(num_nodes=7, log_allow_list=S3_FAULT_LOG_ALLOW_LIST)
+    @matrix(storage_mode=[TopicSpec.STORAGE_MODE_CLOUD])
+    def test_replication_resumes_after_s3_blackhole(self, storage_mode: str):
+        topic = TopicSpec(
+            name="source-topic",
+            partition_count=self.PARTITION_COUNT,
+            replication_factor=3,
+        )
+        self.create_source_topic(topic, storage_mode)
+        self.create_link(self.LINK_NAME)
+
+        self.target_cluster.service.wait_until(
+            lambda: self.topic_partitions_exists_in_target(topic),
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg=f"Topic {topic.name} not found in target cluster",
+        )
+
+        producer = KgoVerifierProducer(
+            context=self.test_context,
+            redpanda=self.source_cluster.service,
+            topic=topic.name,
+            msg_size=self.MSG_SIZE,
+            msg_count=self.MSG_COUNT,
+            rate_limit_bps=self.PRODUCE_RATE_BPS,
+            custom_node=self.preallocated_nodes,
+        )
+        producer.start(clean=True)
+        try:
+            producer.wait_for_acks(1000, timeout_sec=60, backoff_sec=1)
+
+            # Steady state: the shadow topic's HWM is advancing.
+            base_hwm = self._target_hwm_sum(topic.name)
+            wait_until(
+                lambda: self._target_hwm_sum(topic.name) > base_hwm,
+                timeout_sec=60,
+                backoff_sec=2,
+                err_msg="replication did not reach steady state",
+            )
+
+            s3_port = self.redpanda.si_settings.cloud_storage_api_endpoint_port
+            self.logger.info(
+                f"Blackholing S3 port {s3_port} on target nodes for "
+                f"{self.BLOCK_SEC}s (sockets left alive)"
+            )
+            block_started = time.monotonic()
+            stalled_hwm = None
+            with firewall_blocked(self.redpanda.nodes, s3_port, kill_sockets=False):
+                # Precondition: the wedge must actually trigger. If
+                # replication keeps advancing the run must not proceed
+                # to a vacuous pass. Compare per-partition HWMs (not
+                # just the sum) so a partition dropped from one of the
+                # two snapshots -- e.g. a transient NOT_LEADER during
+                # `rpk describe topic` -- is self-diagnosing instead of
+                # silently mimicking "HWM advanced".
+                time.sleep(self.STALL_CHECK_DELAY_SEC)
+                hwms_a = self._hwms(self.target_cluster_rpk, topic.name)
+                time.sleep(self.STALL_CHECK_INTERVAL_SEC)
+                hwms_b = self._hwms(self.target_cluster_rpk, topic.name)
+                assert hwms_b == hwms_a, (
+                    "reproducer precondition not met: target HWM advanced "
+                    f"during the S3 block ({hwms_a} -> {hwms_b}); the "
+                    "upload wedge did not trigger"
+                )
+                # Capture the frozen HWM here, inside the block window.
+                # Sampling after unblock risks the backlog fully
+                # draining before the sample lands, which would
+                # plateau the resume check below and flake it red with
+                # a misleading "CORE-16884 stall" message.
+                stalled_hwm = sum(hwms_b.values())
+                remaining = self.BLOCK_SEC - (time.monotonic() - block_started)
+                if remaining > 0:
+                    time.sleep(remaining)
+        finally:
+            producer.stop()
+
+        self.logger.info("S3 unblocked; waiting for replication to resume")
+
+        # (a) Replication resumes shortly after S3 recovery. On current
+        # dev this fails: the stall persists until the kernel TCP
+        # retransmit limit (~15 min from block start).
+        wait_until(
+            lambda: self._target_hwm_sum(topic.name) > stalled_hwm,
+            timeout_sec=self.RESUME_TIMEOUT_SEC,
+            backoff_sec=5,
+            err_msg=(
+                f"CORE-16884 stall: target HWM did not advance within "
+                f"{self.RESUME_TIMEOUT_SEC}s of S3 recovery"
+            ),
+        )
+
+        # (b) Full catch-up to the (now fixed) source HWMs.
+        def caught_up() -> bool:
+            src = self._hwms(self.source_cluster_rpk, topic.name)
+            dst = self._hwms(self.target_cluster_rpk, topic.name)
+            self.logger.debug(f"catch-up check: source={src} target={dst}")
+            return src == dst
+
+        wait_until(
+            caught_up,
+            timeout_sec=self.CATCH_UP_TIMEOUT_SEC,
+            backoff_sec=5,
+            err_msg=(
+                f"target did not catch up to source within "
+                f"{self.CATCH_UP_TIMEOUT_SEC}s of S3 recovery"
+            ),
+        )

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -562,9 +562,15 @@ class firewall_blocked:
     """Temporary firewall barrier that isolates set of redpanda
     nodes from the ip-address"""
 
-    def __init__(self, nodes, blocked_port, full_block=False):
+    def __init__(self, nodes, blocked_port, full_block=False, kill_sockets=True):
         self._nodes = nodes
         self._port = blocked_port
+        # When False, established connections to the port are left alive
+        # and silently blackholed (packets dropped, no RST/FIN), so they
+        # wedge in kernel retransmit -- use to reproduce hung-socket
+        # behavior. When True (default), existing sockets are destroyed
+        # on entry, forcing prompt errors on in-flight operations.
+        self._kill_sockets = kill_sockets
 
         self.mode_for_input = "sport"
         if full_block:
@@ -575,8 +581,9 @@ class firewall_blocked:
         cmd = [
             f"iptables -A INPUT -p tcp --{self.mode_for_input} {self._port} -j DROP",
             f"iptables -A OUTPUT -p tcp --dport {self._port} -j DROP",
-            f"ss -K dport {self._port}",
         ]
+        if self._kill_sockets:
+            cmd.append(f"ss -K dport {self._port}")
         cmd = " && ".join(cmd)
         for node in self._nodes:
             node.account.ssh_output(cmd, allow_fail=False)

--- a/tools/type-checking/type-check-strictness.json
+++ b/tools/type-checking/type-check-strictness.json
@@ -86,6 +86,7 @@
         "rptest/tests/cluster_bootstrap_test.py",
         "rptest/tests/cluster_health_overview_test.py",
         "rptest/tests/cluster_linking_e2e_test.py",
+        "rptest/tests/cluster_linking_s3_fault_test.py",
         "rptest/tests/cluster_linking_schema_registry_sync_test.py",
         "rptest/tests/cluster_linking_topic_syncing_test.py",
         "rptest/tests/cluster_linking_unfinalized_upgrade_test.py",


### PR DESCRIPTION
A transient S3 outage on the target cluster of a shadow link wedged every
partition replicator for ~15 minutes past S3 recovery (CORE-16884). In-flight
L0 upload PUTs hang on established-but-dead sockets until the kernel abandons
retransmission: the http layer bounds only connection establishment, and the
upload retry chain re-checks its deadline only between attempts, so no
upper-layer deadline could interrupt a wedged attempt. The stuck uploads held
the batcher's upload slots and the replicators' data-queue units, so
replication stalled silently until the kernel timeout finally fired.

The fix makes the L0 batcher own an enforceable upload timeout: each upload
arms a timer (RAII-cancelled) that fires a typed abort through a per-request
abort source; the upload's retry chain is rooted in that source, so the
client-pool lease tears the connection down and the attempt fails within the
existing 90s budget. The batcher's main abort source forwards into the
per-request source, preserving prompt shutdown. cloud_io additionally covers
the abort-before-subscribe window where the pool lease silently skips its
shutdown subscription.

The series is reproducer-first: a ducktape test blackholes the target's S3
port (iptables DROP with sockets left alive) and asserts replication resumes
within 90s of unblock — red before the fix (stall until kernel timeout),
green after. Getting the test fully green also surfaced and fixed two
adjacent bugs: a ~0.5-1MiB contiguous allocation in the placeholder
conversion path (now chunked_vector), and a pre-existing shutdown deadlock
where the service container stop blocked on a reconciler round whose resolver
fiber only the (later) data plane stop could wake.

Verification: reproducer passes end-to-end 2/2 (recovery ~10-12s after
unblock, clean log scan, same-millisecond reconciler stop); real two-cluster
bench runs with the original 5-minute fault show recovery ≤48s vs ~10.4min,
catch-up at ~280-650k msg/s, including a 10k-partition run (3/3 pass). Known
follow-up (tracked on the ticket, not fixed here): `rpk shadow status`
reports SRC-HWM=-1 / negative lag while partitions are unassigned during the
outage window.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
