### PR TITLE
[CORE-9250] `kafka`: add broker side compression

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -887,6 +887,19 @@ configuration::configuration()
        model::compression::lz4,
        model::compression::zstd,
        model::compression::producer})
+  , kafka_produce_enable_batch_compression(
+      *this,
+      "kafka_produce_enable_batch_compression",
+      "Enables broker-side compression on the produce path. When enabled, "
+      "produced batches are recompressed to match the topic's effective "
+      "`compression.type` if their codec differs from it. An effective "
+      "compression type of `producer` retains the codec set by the producing "
+      "client. When disabled, batches are always stored with the codec set by "
+      "the producing client.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      true,
+      property<bool>::noop_validator,
+      legacy_default<bool>{false, legacy_version{18}})
   , fetch_max_bytes(
       *this,
       "fetch_max_bytes",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -220,6 +220,7 @@ struct configuration final : public config_store {
     enum_property<model::kafka_batch_validation_mode>
       kafka_produce_batch_validation;
     enum_property<model::compression> log_compression_type;
+    property<bool> kafka_produce_enable_batch_compression;
     property<size_t> fetch_max_bytes;
     property<bool> use_fetch_scheduler_group;
     property<bool> kafka_fetch_read_coalescing_enabled;

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -18,6 +18,8 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/kafka_batch_adapter.h"
 #include "kafka/server/handlers/produce_validation.h"
+#include "model/batch_compression.h"
+#include "model/compression.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/namespace.h"
@@ -212,7 +214,71 @@ struct ntp_produce_request {
     model::timestamp_type timestamp_type;
     std::chrono::milliseconds message_timestamp_before_max_ms;
     std::chrono::milliseconds message_timestamp_after_max_ms;
+    model::compression compression_type;
 };
+
+// Applies the topic's effective `compression.type` policy to a produced batch
+// (broker-side compression): a batch whose codec differs from the policy is
+// recompressed (or decompressed, for a policy of `none`) before being
+// replicated and stored. A policy of `producer` retains the codec chosen by
+// the producing client.
+//
+// `decompressed_payload` is the batch's records payload as decompressed on
+// the validation path, if that path had to decompress; it is reused here to
+// avoid decompressing the batch a second time.
+ss::future<std::optional<error_code_and_msg>> maybe_recompress_batch(
+  model::record_batch& batch,
+  std::optional<iobuf> decompressed_payload,
+  model::compression target) {
+    if (
+      target == model::compression::producer
+      || batch.header().attrs.compression() == target) {
+        co_return std::nullopt;
+    }
+
+    // The batch's header carries any updates made by validation (e.g.
+    // `max_timestamp`); its size and checksum metadata are recomputed by
+    // recompress_batch() over the final payload.
+    const auto header = batch.header();
+
+    if (!decompressed_payload.has_value()) {
+        if (batch.compressed()) {
+            try {
+                decompressed_payload = co_await model::decompress_payload(
+                  batch);
+            } catch (const std::exception& e) {
+                vlog(
+                  klog.warn,
+                  "Failed to decompress produced batch {}: {}",
+                  header,
+                  e.what());
+                co_return error_code_and_msg{
+                  .err = error_code::corrupt_message,
+                  .msg = "unable to decompress batch",
+                };
+            }
+        } else {
+            decompressed_payload = std::move(batch).release_data();
+        }
+    }
+
+    try {
+        batch = co_await model::recompress_batch(
+          target, header, std::move(*decompressed_payload));
+    } catch (const std::exception& e) {
+        vlog(
+          klog.error,
+          "Failed to recompress produced batch with topic compression type "
+          "{}: {}",
+          target,
+          e.what());
+        co_return error_code_and_msg{
+          .err = error_code::unknown_server_error,
+          .msg = "unable to compress batch",
+        };
+    }
+    co_return std::nullopt;
+}
 
 ss::future<produce_response::partition> do_produce_topic_partition(
   produce_ctx& octx,
@@ -228,13 +294,13 @@ ss::future<produce_response::partition> do_produce_topic_partition(
        .ntp = req.ntp,
        .client_id = octx.rctx.header().client_id});
 
-    if (validate_batch_res.has_value()) {
+    if (validate_batch_res.error.has_value()) {
         co_return finalize_request_with_error_code(
-          validate_batch_res->err,
+          validate_batch_res.error->err,
           std::move(dispatched),
           req.ntp,
           ss::this_shard_id(),
-          std::move(validate_batch_res->msg));
+          std::move(validate_batch_res.error->msg));
     }
 
     auto batch_size = req.batch->size_bytes();
@@ -289,6 +355,19 @@ ss::future<produce_response::partition> do_produce_topic_partition(
       batch_size, req.batch->header().attrs.compression());
     octx.rctx.connection()->attributes().produce_bytes.record(batch_size);
     octx.rctx.connection()->attributes().produce_batch_count.record(1);
+
+    auto recompress_res = co_await maybe_recompress_batch(
+      *req.batch,
+      std::move(validate_batch_res.decompressed_payload),
+      req.compression_type);
+    if (recompress_res.has_value()) {
+        co_return finalize_request_with_error_code(
+          recompress_res->err,
+          std::move(dispatched),
+          req.ntp,
+          ss::this_shard_id(),
+          std::move(recompress_res->msg));
+    }
 
     auto timeout = octx.request.data.timeout_ms;
     if (timeout < 0ms) {
@@ -366,8 +445,18 @@ struct topic_configuration_context {
     model::timestamp_type timestamp_type;
     std::chrono::milliseconds message_timestamp_before_max_ms;
     std::chrono::milliseconds message_timestamp_after_max_ms;
+    model::compression compression_type;
     const cluster::topic_properties* properties;
 };
+
+model::compression effective_compression_type(
+  const cluster::topic_properties& properties, const produce_ctx& octx) {
+    if (!config::shard_local_cfg().kafka_produce_enable_batch_compression()) {
+        return model::compression::producer;
+    }
+    return properties.compression.value_or(
+      octx.rctx.metadata_cache().get_default_compression());
+}
 
 /**
  * \brief handle writing to a single topic partition.
@@ -399,6 +488,7 @@ partition_produce_stages produce_topic_partition(
         = cfg_ctx.message_timestamp_before_max_ms,
         .message_timestamp_after_max_ms
         = cfg_ctx.message_timestamp_after_max_ms,
+        .compression_type = cfg_ctx.compression_type,
       },
       std::move(dispatch));
     return partition_produce_stages{
@@ -486,6 +576,8 @@ produce_topic(produce_ctx& octx, produce_request::topic& topic) {
       = topic_cfg.properties.message_timestamp_after_max_ms.value_or(
         octx.rctx.metadata_cache()
           .get_default_message_timestamp_after_max_ms()),
+      .compression_type = effective_compression_type(
+        topic_cfg.properties, octx),
       .properties = &topic_cfg.properties,
     };
 
@@ -629,6 +721,8 @@ partition_produce_stages produce_single_partition(
       = topic_cfg.properties.message_timestamp_after_max_ms.value_or(
         octx.rctx.metadata_cache()
           .get_default_message_timestamp_after_max_ms()),
+      .compression_type = effective_compression_type(
+        topic_cfg.properties, octx),
       .properties = &topic_cfg.properties,
     };
     return produce_topic_partition(octx, topic, part, cfg_ctx);

--- a/src/v/kafka/server/handlers/produce_validation.cc
+++ b/src/v/kafka/server/handlers/produce_validation.cc
@@ -456,8 +456,7 @@ std::optional<error_code_and_msg> validate_batch(
 
 } // namespace
 
-ss::future<std::optional<error_code_and_msg>>
-validate_batch(const validation_args& args) {
+ss::future<validation_result> validate_batch(const validation_args& args) {
     const auto& validation_mode
       = config::shard_local_cfg().kafka_produce_batch_validation();
 
@@ -473,10 +472,11 @@ validate_batch(const validation_args& args) {
                 maybe_decompressed_batch = co_await model::decompress_batch(
                   batch);
             } catch (...) {
-                co_return error_code_and_msg{
-                  .err = error_code::corrupt_message,
-                  .msg = "unable to decompress batch",
-                };
+                co_return validation_result{
+                  .error = error_code_and_msg{
+                    .err = error_code::corrupt_message,
+                    .msg = "unable to decompress batch",
+                  }};
             }
             maybe_decompressed_batch_ref = maybe_decompressed_batch.value();
         }
@@ -484,7 +484,7 @@ validate_batch(const validation_args& args) {
         maybe_decompressed_batch_ref = batch;
     }
 
-    co_return validate_batch(
+    auto error = validate_batch(
       batch,
       maybe_decompressed_batch_ref,
       validation_mode,
@@ -494,6 +494,17 @@ validate_batch(const validation_args& args) {
       args.probe,
       args.ntp,
       args.client_id);
+
+    std::optional<iobuf> decompressed_payload;
+    if (maybe_decompressed_batch.has_value()) {
+        decompressed_payload
+          = std::move(maybe_decompressed_batch).value().release_data();
+    }
+
+    co_return validation_result{
+      .error = std::move(error),
+      .decompressed_payload = std::move(decompressed_payload),
+    };
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/produce_validation.h
+++ b/src/v/kafka/server/handlers/produce_validation.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "bytes/iobuf.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/server/kafka_probe.h"
 #include "model/batch_compression.h"
@@ -44,8 +45,17 @@ struct validation_args {
     std::optional<std::string_view> client_id;
 };
 
+struct validation_result {
+    std::optional<error_code_and_msg> error;
+
+    // Set iff the batch had to be decompressed in order to validate it.
+    // Callers that need the batch's uncompressed records (e.g. for
+    // broker-side recompression) can reuse this payload to avoid a second
+    // decompression.
+    std::optional<iobuf> decompressed_payload;
+};
+
 // Entry point for batch validation.
-ss::future<std::optional<error_code_and_msg>>
-validate_batch(const validation_args&);
+ss::future<validation_result> validate_batch(const validation_args&);
 
 } // namespace kafka

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -882,6 +882,7 @@ redpanda_cc_btest(
     cpu = "1",
     deps = [
         ":kafka_test_utils",
+        "//src/v/bytes:iobuf_parser",
         "//src/v/cluster:cluster_link_table",
         "//src/v/cluster:cluster_link_types",
         "//src/v/cluster:controller_log_limiter",
@@ -899,6 +900,7 @@ redpanda_cc_btest(
         "//src/v/kafka/protocol:produce",
         "//src/v/kafka/server",
         "//src/v/model",
+        "//src/v/model:batch_compression",
         "//src/v/random:generators",
         "//src/v/redpanda/tests:fixture",
         "//src/v/storage:record_batch_builder",

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "bytes/iobuf_parser.h"
 #include "container/chunked_vector.h"
 #include "kafka/client/transport.h"
 #include "kafka/protocol/errors.h"
@@ -17,6 +18,7 @@
 #include "kafka/server/snc_quota_manager.h"
 #include "kafka/server/tests/delete_records_utils.h"
 #include "kafka/server/tests/produce_consume_utils.h"
+#include "model/batch_compression.h"
 #include "model/compression.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -1387,4 +1389,336 @@ FIXTURE_TEST(test_produce_unset_timestamps_relaxed, prod_consume_fixture) {
         BOOST_REQUIRE_EQUAL(
           batch.header().max_timestamp, model::timestamp::missing());
     }
+}
+
+namespace {
+
+// Fetch all record batches for the partition, starting at offset 0, until an
+// empty fetch response indicates the log has been drained. Fetch returns
+// stored batches verbatim, so the returned batch headers reflect the on-disk
+// batches.
+std::vector<model::record_batch> fetch_stored_batches(
+  kafka::client::transport& transport, const model::ntp& ntp) {
+    std::vector<model::record_batch> batches;
+    auto fetch_offset = model::offset{0};
+    while (true) {
+        kafka::fetch_request::topic topic;
+        topic.topic = ntp.tp.topic;
+        kafka::fetch_request::partition partition{
+          .partition = ntp.tp.partition,
+          .fetch_offset = fetch_offset,
+          .log_start_offset = model::offset{0},
+          .partition_max_bytes = 100_MiB};
+        topic.partitions.emplace_back(std::move(partition));
+        kafka::fetch_request req;
+        req.data.min_bytes = 1;
+        req.data.max_bytes = 100_MiB;
+        req.data.max_wait_ms = 100ms;
+        req.data.topics.push_back(std::move(topic));
+        auto fetch_resp
+          = transport.dispatch(std::move(req), kafka::api_version(4)).get();
+        BOOST_REQUIRE_EQUAL(
+          fetch_resp.data.error_code, kafka::error_code::none);
+
+        bool made_progress = false;
+        for (auto& topic_resp : fetch_resp.data.responses) {
+            for (auto& partition_resp : topic_resp.partitions) {
+                BOOST_REQUIRE_EQUAL(
+                  partition_resp.error_code, kafka::error_code::none);
+                BOOST_REQUIRE(partition_resp.records.has_value());
+                while (!partition_resp.records->is_end_of_stream()) {
+                    auto batch_adapter
+                      = partition_resp.records.value().consume_batch();
+                    if (!batch_adapter.batch.has_value()) {
+                        break;
+                    }
+                    made_progress = true;
+                    fetch_offset = model::next_offset(
+                      batch_adapter.batch->last_offset());
+                    batches.push_back(std::move(batch_adapter.batch).value());
+                }
+            }
+        }
+        if (!made_progress) {
+            break;
+        }
+    }
+    return batches;
+}
+
+std::vector<kv_t> kvs_from_batch(const model::record_batch& batch) {
+    auto iterable = batch.compressed() ? model::decompress_batch_sync(batch)
+                                       : batch.copy();
+    std::vector<kv_t> kvs;
+    for (const auto& r : iterable.copy_records()) {
+        iobuf_const_parser key_buf(r.key());
+        auto key = key_buf.read_string(key_buf.bytes_left());
+        iobuf_const_parser val_buf(r.value());
+        kvs.emplace_back(key, val_buf.read_string(val_buf.bytes_left()));
+    }
+    return kvs;
+}
+
+} // namespace
+
+// Batches produced to a topic whose `compression.type` names a codec (or
+// `none`) are recompressed by the broker to match it, while a value of
+// `producer` retains the codec set by the client.
+FIXTURE_TEST(test_broker_side_compression, prod_consume_fixture) {
+    scoped_config cfg;
+    cfg.get("kafka_produce_enable_batch_compression").set_value(true);
+    wait_for_controller_leadership().get();
+
+    const model::topic_namespace zstd_tp_ns{
+      model::ns("kafka"), model::topic("compress-zstd")};
+    const model::topic_namespace none_tp_ns{
+      model::ns("kafka"), model::topic("compress-none")};
+    const model::topic_namespace producer_tp_ns{
+      model::ns("kafka"), model::topic("compress-producer")};
+
+    auto make_topic = [this](
+                        const model::topic_namespace& tp_ns,
+                        model::compression compression_type) {
+        cluster::topic_properties props;
+        props.compression = compression_type;
+        add_topic(tp_ns, 1, props).get();
+        wait_for_leader(model::ntp(tp_ns.ns, tp_ns.tp, model::partition_id(0)))
+          .get();
+    };
+    make_topic(zstd_tp_ns, model::compression::zstd);
+    make_topic(none_tp_ns, model::compression::none);
+    make_topic(producer_tp_ns, model::compression::producer);
+
+    auto producer = tests::kafka_produce_transport(make_kafka_client().get());
+    producer.start().get();
+    auto deferred_p_close = ss::defer([&producer] { producer.stop().get(); });
+
+    // One batch per client-side codec, to each topic. Two rounds: one in
+    // `relaxed` validation mode, in which compressed batches are not
+    // decompressed for validation and recompression performs its own
+    // decompression, and one in `strict` mode, in which recompression reuses
+    // the batch decompressed on the validation path.
+    const auto records = kv_t::sequence(0, 3);
+    auto produce_all_codecs = [&](const model::topic& topic) {
+        for (auto c : model::all_batch_compression_types) {
+            producer
+              .produce_to_partition(
+                topic,
+                model::partition_id(0),
+                records,
+                model::timestamp::now(),
+                c)
+              .get();
+        }
+    };
+    for (auto mode :
+         {model::kafka_batch_validation_mode::relaxed,
+          model::kafka_batch_validation_mode::strict}) {
+        cfg.get("kafka_produce_batch_validation").set_value(mode);
+        produce_all_codecs(zstd_tp_ns.tp);
+        produce_all_codecs(none_tp_ns.tp);
+        produce_all_codecs(producer_tp_ns.tp);
+    }
+
+    auto transport = make_kafka_client().get();
+    transport.connect().get();
+    auto deferred_t_close = ss::defer([&transport] { transport.stop().get(); });
+
+    // `expected_codec` unset means the client's codec is expected to have
+    // been retained (the `producer` policy).
+    auto check_topic = [&](
+                         const model::topic_namespace& tp_ns,
+                         std::optional<model::compression> expected_codec) {
+        auto batches = fetch_stored_batches(
+          transport, model::ntp(tp_ns.ns, tp_ns.tp, model::partition_id(0)));
+        BOOST_REQUIRE_EQUAL(
+          batches.size(), 2 * model::all_batch_compression_types.size());
+        for (size_t i = 0; i < batches.size(); ++i) {
+            const auto& batch = batches[i];
+            const auto client_codec = model::all_batch_compression_types
+              [i % model::all_batch_compression_types.size()];
+            BOOST_TEST_INFO(
+              "topic " << tp_ns.tp << ", client codec " << client_codec);
+            BOOST_CHECK_EQUAL(
+              batch.header().attrs.compression(),
+              expected_codec.value_or(client_codec));
+            BOOST_CHECK_EQUAL(
+              batch.record_count(), static_cast<int32_t>(records.size()));
+            BOOST_CHECK(kvs_from_batch(batch) == records);
+        }
+    };
+    check_topic(zstd_tp_ns, model::compression::zstd);
+    check_topic(none_tp_ns, model::compression::none);
+    check_topic(producer_tp_ns, std::nullopt);
+}
+
+// With `kafka_produce_enable_batch_compression` disabled, the topic's
+// `compression.type` is ignored on the produce path and the client's codec is
+// retained.
+FIXTURE_TEST(test_broker_side_compression_disabled, prod_consume_fixture) {
+    scoped_config cfg;
+    cfg.get("kafka_produce_enable_batch_compression").set_value(false);
+    wait_for_controller_leadership().get();
+
+    cluster::topic_properties props;
+    props.compression = model::compression::zstd;
+    add_topic(test_tp_ns, 1, props).get();
+    auto ntp = model::ntp(test_tp_ns.ns, test_tp_ns.tp, model::partition_id(0));
+    wait_for_leader(ntp).get();
+
+    auto producer = tests::kafka_produce_transport(make_kafka_client().get());
+    producer.start().get();
+    auto deferred_p_close = ss::defer([&producer] { producer.stop().get(); });
+
+    const auto records = kv_t::sequence(0, 3);
+    producer
+      .produce_to_partition(
+        ntp.tp.topic,
+        ntp.tp.partition,
+        records,
+        model::timestamp::now(),
+        model::compression::gzip)
+      .get();
+
+    auto transport = make_kafka_client().get();
+    transport.connect().get();
+    auto deferred_t_close = ss::defer([&transport] { transport.stop().get(); });
+
+    auto batches = fetch_stored_batches(transport, ntp);
+    BOOST_REQUIRE_EQUAL(batches.size(), 1);
+    BOOST_CHECK_EQUAL(
+      batches.front().header().attrs.compression(), model::compression::gzip);
+    BOOST_CHECK(kvs_from_batch(batches.front()) == records);
+}
+
+// The broker-set `max_timestamp` and timestamp type of a `LogAppendTime`
+// topic must be carried into the recompressed batch.
+FIXTURE_TEST(test_broker_side_compression_append_time, prod_consume_fixture) {
+    scoped_config cfg;
+    cfg.get("kafka_produce_enable_batch_compression").set_value(true);
+    wait_for_controller_leadership().get();
+
+    cluster::topic_properties props;
+    props.compression = model::compression::zstd;
+    props.timestamp_type = model::timestamp_type::append_time;
+    add_topic(test_tp_ns, 1, props).get();
+    auto ntp = model::ntp(test_tp_ns.ns, test_tp_ns.tp, model::partition_id(0));
+    wait_for_leader(ntp).get();
+
+    auto producer = tests::kafka_produce_transport(make_kafka_client().get());
+    producer.start().get();
+    auto deferred_p_close = ss::defer([&producer] { producer.stop().get(); });
+
+    const auto records = kv_t::sequence(0, 3);
+    // A client timestamp in the past, distinguishable from broker time.
+    const auto client_ts = model::timestamp(42);
+    const auto broker_time_before = model::timestamp::now();
+    producer
+      .produce_to_partition(
+        ntp.tp.topic,
+        ntp.tp.partition,
+        records,
+        client_ts,
+        model::compression::gzip)
+      .get();
+
+    auto transport = make_kafka_client().get();
+    transport.connect().get();
+    auto deferred_t_close = ss::defer([&transport] { transport.stop().get(); });
+
+    auto batches = fetch_stored_batches(transport, ntp);
+    BOOST_REQUIRE_EQUAL(batches.size(), 1);
+    const auto& header = batches.front().header();
+    BOOST_CHECK_EQUAL(header.attrs.compression(), model::compression::zstd);
+    BOOST_CHECK(
+      header.attrs.timestamp_type() == model::timestamp_type::append_time);
+    BOOST_CHECK_GE(header.max_timestamp, broker_time_before);
+    BOOST_CHECK(kvs_from_batch(batches.front()) == records);
+}
+
+// A compressed batch produced with `max_timestamp` unset is decompressed on
+// the validation path, which then computes and sets the `max_timestamp` on
+// the batch header. Recompression reuses the decompressed payload and must
+// carry the updated header into the stored batch.
+FIXTURE_TEST(
+  test_broker_side_compression_unset_max_timestamp, prod_consume_fixture) {
+    scoped_config cfg;
+    cfg.get("kafka_produce_enable_batch_compression").set_value(true);
+    cfg.get("kafka_produce_batch_validation")
+      .set_value(model::kafka_batch_validation_mode::relaxed);
+    wait_for_controller_leadership().get();
+
+    cluster::topic_properties props;
+    props.compression = model::compression::zstd;
+    add_topic(test_tp_ns, 1, props).get();
+    auto ntp = model::ntp(test_tp_ns.ns, test_tp_ns.tp, model::partition_id(0));
+    wait_for_leader(ntp).get();
+
+    auto producer = tests::kafka_produce_transport(make_kafka_client().get());
+    producer.start().get();
+    auto deferred_p_close = ss::defer([&producer] { producer.stop().get(); });
+
+    const auto records = kv_t::sequence(0, 3);
+    const auto first_ts = model::timestamp::now();
+    auto batch = tests::batch_from_kvs(
+      records, model::offset(0), first_ts, model::compression::gzip);
+    // Unset the max timestamp, forcing validation to decompress the batch to
+    // compute it from the records (all carrying `first_ts`).
+    batch.set_max_timestamp(
+      model::timestamp_type::create_time, model::timestamp::missing());
+    producer
+      .produce_to_partition(ntp.tp.topic, ntp.tp.partition, std::move(batch))
+      .get();
+
+    auto transport = make_kafka_client().get();
+    transport.connect().get();
+    auto deferred_t_close = ss::defer([&transport] { transport.stop().get(); });
+
+    auto batches = fetch_stored_batches(transport, ntp);
+    BOOST_REQUIRE_EQUAL(batches.size(), 1);
+    const auto& header = batches.front().header();
+    BOOST_CHECK_EQUAL(header.attrs.compression(), model::compression::zstd);
+    BOOST_CHECK_EQUAL(header.max_timestamp, first_ts);
+    BOOST_CHECK(kvs_from_batch(batches.front()) == records);
+}
+
+// A batch that claims to be compressed but whose payload cannot be
+// decompressed is rejected with `corrupt_message` when the topic requires
+// recompression.
+FIXTURE_TEST(test_broker_side_compression_corrupt_batch, prod_consume_fixture) {
+    scoped_config cfg;
+    cfg.get("kafka_produce_enable_batch_compression").set_value(true);
+    wait_for_controller_leadership().get();
+
+    cluster::topic_properties props;
+    props.compression = model::compression::zstd;
+    add_topic(test_tp_ns, 1, props).get();
+    auto ntp = model::ntp(test_tp_ns.ns, test_tp_ns.tp, model::partition_id(0));
+    wait_for_leader(ntp).get();
+
+    auto producer = tests::kafka_produce_transport(make_kafka_client().get());
+    producer.start().get();
+    auto deferred_p_close = ss::defer([&producer] { producer.stop().get(); });
+
+    // Build an uncompressed batch and flip its gzip compression bits on
+    // without compressing the payload, keeping the checksums valid.
+    auto batch = tests::batch_from_kvs(
+      kv_t::sequence(0, 3),
+      model::offset(0),
+      model::timestamp::now(),
+      model::compression::none);
+    auto header = batch.header();
+    header.attrs |= model::compression::gzip;
+    auto payload = std::move(batch).release_data();
+    header.reset_size_checksum_metadata(payload);
+    auto corrupt_batch = model::record_batch(
+      header, std::move(payload), model::record_batch::tag_ctor_ng{});
+
+    auto produced = producer.produce_to_partition(
+      ntp.tp.topic, ntp.tp.partition, std::move(corrupt_batch));
+    BOOST_REQUIRE_EXCEPTION(
+      produced.get(), std::runtime_error, [](const std::runtime_error& e) {
+          return std::string_view(e.what()).find("corrupt_message")
+                 != std::string_view::npos;
+      });
 }

--- a/src/v/model/batch_compression.cc
+++ b/src/v/model/batch_compression.cc
@@ -39,7 +39,20 @@ namespace {
 }
 } // namespace
 
-ss::future<model::record_batch> decompress_batch(const model::record_batch& b) {
+namespace {
+model::record_batch make_uncompressed_batch(
+  model::record_batch_header header_of_compressed, iobuf uncompressed_payload) {
+    // must remove compression first!
+    header_of_compressed.attrs.remove_compression();
+    header_of_compressed.reset_size_checksum_metadata(uncompressed_payload);
+    return {
+      header_of_compressed,
+      std::move(uncompressed_payload),
+      model::record_batch::tag_ctor_ng{}};
+}
+} // namespace
+
+ss::future<iobuf> decompress_payload(const model::record_batch& b) {
     if (!b.compressed()) [[unlikely]] {
         throw std::runtime_error(fmt_with_ctx(
           fmt::format,
@@ -52,15 +65,13 @@ ss::future<model::record_batch> decompress_batch(const model::record_batch& b) {
     //
     // We should consider a version of async uncompress that takes a const
     // iobuf& where the caller owns the lifetime of the iobuf.
-    iobuf body_buf = ::compression::compressor::uncompress(
+    co_return ::compression::compressor::uncompress(
       b.data(), to_compression_type(b.header().attrs.compression()));
-    // must remove compression first!
-    auto h = b.header();
-    h.attrs.remove_compression();
-    h.reset_size_checksum_metadata(body_buf);
-    auto batch = model::record_batch(
-      h, std::move(body_buf), model::record_batch::tag_ctor_ng{});
-    co_return batch;
+}
+
+ss::future<model::record_batch> decompress_batch(const model::record_batch& b) {
+    auto body_buf = co_await decompress_payload(b);
+    co_return make_uncompressed_batch(b.header(), std::move(body_buf));
 }
 
 model::record_batch decompress_batch_sync(const model::record_batch& b) {
@@ -72,13 +83,25 @@ model::record_batch decompress_batch_sync(const model::record_batch& b) {
     }
     iobuf body_buf = ::compression::compressor::uncompress(
       b.data(), to_compression_type(b.header().attrs.compression()));
-    // must remove compression first!
-    auto h = b.header();
-    h.attrs.remove_compression();
-    h.reset_size_checksum_metadata(body_buf);
-    auto batch = model::record_batch(
-      h, std::move(body_buf), model::record_batch::tag_ctor_ng{});
-    return batch;
+    return make_uncompressed_batch(b.header(), std::move(body_buf));
+}
+
+ss::future<model::record_batch> recompress_batch(
+  model::compression target,
+  model::record_batch_header header,
+  iobuf uncompressed_payload) {
+    if (target == model::compression::none) {
+        co_return make_uncompressed_batch(
+          header, std::move(uncompressed_payload));
+    }
+    auto payload = co_await ::compression::stream_compressor::compress(
+      std::move(uncompressed_payload), to_compression_type(target));
+    header.attrs.remove_compression();
+    // compression bit must be set first!
+    header.attrs |= target;
+    header.reset_size_checksum_metadata(payload);
+    co_return model::record_batch(
+      header, std::move(payload), model::record_batch::tag_ctor_ng{});
 }
 
 ss::future<model::record_batch>

--- a/src/v/model/batch_compression.h
+++ b/src/v/model/batch_compression.h
@@ -21,6 +21,25 @@ namespace model {
 /// Throws if the batch is not compressed.
 ss::future<model::record_batch> decompress_batch(const model::record_batch&);
 
+/// \brief Decompress only the records payload of a compressed batch.
+///
+/// Cheaper than `decompress_batch()` when a well-formed uncompressed batch is
+/// not needed: no header is rebuilt and no checksum is computed. Throws if
+/// the batch is not compressed.
+ss::future<iobuf> decompress_payload(const model::record_batch&);
+
+/// \brief Build a batch compressed per `target` from an uncompressed records
+/// payload and the header of the batch the payload originated from.
+///
+/// The originating batch may have been compressed with any codec: `header`'s
+/// compression bits are cleared and re-set per `target` (`none` produces an
+/// uncompressed batch), and its size and checksum metadata are recomputed,
+/// exactly once, over the final payload.
+ss::future<model::record_batch> recompress_batch(
+  model::compression target,
+  model::record_batch_header header,
+  iobuf uncompressed_payload);
+
 /// \brief synchronous batch decompression
 model::record_batch decompress_batch_sync(const model::record_batch&);
 

--- a/tests/rptest/clients/offline_log_viewer.py
+++ b/tests/rptest/clients/offline_log_viewer.py
@@ -49,6 +49,16 @@ class OfflineLogViewer:
     def read_kafka_records(self, node: ClusterNode, topic: str) -> Any:
         return self._json_cmd(node, f"--type kafka_records --topic {topic}")
 
+    def read_kafka_batch_headers(self, node: ClusterNode, topic: str) -> Any:
+        """
+        Decode only the record batch headers of the given kafka topic's log.
+        Unlike read_kafka_records, this is safe for compressed batches, whose
+        records the viewer cannot decode. Batch checksums are validated as a
+        side effect of parsing. Returns one list of batch header dicts per
+        partition log found on the node.
+        """
+        return self._json_cmd(node, f"--type kafka --topic {topic}")
+
     def read_controller(self, node: ClusterNode) -> Any:
         return self._json_cmd(node, "--type controller")
 

--- a/tests/rptest/tests/broker_side_compression_test.py
+++ b/tests/rptest/tests/broker_side_compression_test.py
@@ -1,0 +1,202 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from typing import Any, cast
+
+from ducktape.mark import parametrize
+from ducktape.tests.test import TestContext
+from ducktape.utils.util import wait_until
+
+from rptest.clients.offline_log_viewer import OfflineLogViewer
+from rptest.clients.rpk import RpkTool
+from rptest.services.cluster import cluster
+from rptest.services.verifiable_producer import VerifiableProducer
+from rptest.tests.redpanda_test import RedpandaTest
+
+TOPIC_COMPRESSION_TYPES = ["producer", "none", "gzip", "snappy", "lz4", "zstd"]
+PRODUCER_COMPRESSION_TYPES = ["none", "gzip", "snappy", "lz4", "zstd"]
+
+
+class BrokerSideCompressionTest(RedpandaTest):
+    """
+    End-to-end tests for broker-side compression on the produce path: batches
+    produced to a topic are recompressed to match the topic's effective
+    `compression.type`, while a value of `producer` retains the codec chosen
+    by the producing client.
+    """
+
+    def __init__(self, test_context: TestContext):
+        super().__init__(
+            test_context=test_context,
+            num_brokers=1,
+            extra_rp_conf={"kafka_produce_enable_batch_compression": True},
+        )
+        self.rpk = RpkTool(self.redpanda)
+        self.viewer = OfflineLogViewer(self.redpanda)
+
+    def _stored_batch_codecs(self, topic: str) -> list[str]:
+        """
+        Codecs of the data batches stored on disk for the topic, as decoded
+        (and checksum-validated) by the offline log viewer.
+        """
+        node = self.redpanda.nodes[0]
+        partitions = cast(
+            list[list[dict[str, Any]]],
+            self.viewer.read_kafka_batch_headers(node, topic),
+        )
+        codecs: list[str] = []
+        for partition_headers in partitions:
+            for header in partition_headers:
+                if header["type_name"] != "raft_data":
+                    continue
+                codecs.append(header["expanded_attrs"]["compression"])
+        return codecs
+
+    def _assert_stored_codec(
+        self, topic: str, expected_codec: str, expected_batches: int
+    ):
+        codecs = self._stored_batch_codecs(topic)
+        assert len(codecs) == expected_batches, (
+            f"{topic}: expected {expected_batches} data batches, "
+            f"got {len(codecs)}: {codecs}"
+        )
+        assert all(c == expected_codec for c in codecs), (
+            f"{topic}: expected all batches stored with {expected_codec}, got {codecs}"
+        )
+
+    @staticmethod
+    def _message_value(i: int) -> str:
+        # Values must be large and compressible enough that clients actually
+        # compress the batch: producers (e.g. franz-go) fall back to sending
+        # batches uncompressed when compression does not shrink them.
+        return f"val{i}-" + "x" * 1024
+
+    def _produce_and_verify(
+        self, topic_codec: str, producer_codec: str, num_messages: int = 3
+    ):
+        topic = f"compress-{topic_codec}-{producer_codec}"
+        self.rpk.create_topic(
+            topic,
+            partitions=1,
+            replicas=1,
+            config={"compression.type": topic_codec},
+        )
+
+        for i in range(num_messages):
+            self.rpk.produce(
+                topic,
+                f"key{i}",
+                self._message_value(i),
+                compression_type=producer_codec,
+            )
+
+        expected_codec = producer_codec if topic_codec == "producer" else topic_codec
+        self._assert_stored_codec(topic, expected_codec, num_messages)
+
+        consumed = self.rpk.consume(
+            topic, n=num_messages, offset="start", format="%v\n"
+        )
+        values = consumed.splitlines()
+        expected_values = [self._message_value(i) for i in range(num_messages)]
+        assert values == expected_values, (
+            f"{topic}: expected {expected_values}, consumed {values}"
+        )
+
+    @cluster(num_nodes=1)
+    def test_compression_type_matrix(self):
+        """
+        Cover the full matrix of topic `compression.type` x producer codec:
+        the codec of the stored batches (and of batches served to consumers)
+        is the topic's compression type, unless it is `producer`, in which
+        case the producer's codec is retained. Consumers must be able to read
+        back the produced values in all combinations.
+        """
+        for topic_codec in TOPIC_COMPRESSION_TYPES:
+            for producer_codec in PRODUCER_COMPRESSION_TYPES:
+                self._produce_and_verify(topic_codec, producer_codec)
+
+    @cluster(num_nodes=1)
+    def test_batch_compression_disabled(self):
+        """
+        With kafka_produce_enable_batch_compression disabled, the topic's
+        `compression.type` is ignored on the produce path and the producer's
+        codec is retained.
+        """
+        self.redpanda.set_cluster_config(
+            {"kafka_produce_enable_batch_compression": False}
+        )
+
+        num_messages = 3
+        topic = "compress-disabled"
+        self.rpk.create_topic(
+            topic, partitions=1, replicas=1, config={"compression.type": "zstd"}
+        )
+        for i in range(num_messages):
+            self.rpk.produce(
+                topic, f"key{i}", self._message_value(i), compression_type="gzip"
+            )
+
+        self._assert_stored_codec(topic, "gzip", num_messages)
+
+    @cluster(num_nodes=2)
+    @parametrize(producer_codec="snappy", topic_codec="zstd")
+    @parametrize(producer_codec="zstd", topic_codec="snappy")
+    def test_java_producer_recompression(self, producer_codec: str, topic_codec: str):
+        """
+        Produce with an idempotent Java client (VerifiableProducer) using a
+        codec that differs from the topic's `compression.type`, and verify
+        that batches are stored with the topic's codec and remain consumable.
+        The snappy cases matter most: Java clients use xerial-framed snappy,
+        which the broker must both decode on the way in and encode
+        compatibly on the way out.
+        """
+        num_messages = 100
+        topic = f"compress-java-{producer_codec}-{topic_codec}"
+        self.rpk.create_topic(
+            topic,
+            partitions=1,
+            replicas=1,
+            config={"compression.type": topic_codec},
+        )
+
+        producer = VerifiableProducer(
+            self.test_context,
+            num_nodes=1,
+            redpanda=self.redpanda,
+            topic=topic,
+            max_messages=num_messages,
+            compression_types=[producer_codec],
+            enable_idempotence=True,
+        )
+        producer.start()
+        try:
+            wait_until(
+                lambda: producer.num_acked >= num_messages,
+                timeout_sec=60,
+                backoff_sec=1,
+                err_msg=f"Timed out waiting for {num_messages} acked messages.",
+            )
+        finally:
+            producer.stop()
+            producer.clean()
+            producer.free()
+
+        codecs = self._stored_batch_codecs(topic)
+        assert len(codecs) > 0, f"{topic}: no data batches found"
+        assert all(c == topic_codec for c in codecs), (
+            f"{topic}: expected all batches stored with {topic_codec}, got {codecs}"
+        )
+
+        consumed = self.rpk.consume(
+            topic, n=num_messages, offset="start", format="%v\n"
+        )
+        values = consumed.splitlines()
+        assert len(values) == num_messages and all(v.isdigit() for v in values), (
+            f"{topic}: unexpected consumed values {values}"
+        )


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/redpanda/issues/866.

Up until now, `redpanda` has relied on producers compressing batches with the codec they wish to persist their data with. While we have had the topic property `compression.type` in the codebase for a long time, this property has never actually controlled anything, and we have never before compressed batches broker side on behalf of this property.

Fix this product gap by supporting `compression.type` on the validation/produce path. When `compression.type` is set, we will ensure that the batch that is replicated and persisted matches the requested codec. The potential cases are enumerated below:

* `compression.type=producer`: batches are already compressed with the desired codec
* `compression.type={producer's compression type}`: same as above
* `compression.type=none`, batches will be decompressed and left uncompressed
* `compression.type={gzip, snappy, lz4, zstd}`, batches whose producer codec differs will be decompressed and recompressed according to the hardcoded codec

When validation already had to decompress the batch (`kafka_produce_batch_validation=strict` mode, or `kafka_produce_batch_validation=relaxed` with an unset `max_timestamp`), recompression reuses that decompressed payload rather than decompressing a second time, and size/checksum metadata is computed once over the final payload.

This compression behavior is gated by a new cluster config, `kafka_produce_enable_batch_compression`, with a new default of `true` and legacy default for clusters created before `v26.2` of `false`.



## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes


### Features

* Respect topic configured `compression.type` and cluster config `log_compression_type` for triggering broker side compression of batches produced to `redpanda`. Configured via `kafka_produce_enable_batch_compression` (new cluster default `true`, legacy default `false` for clusters created before `redpanda` major version `v26.1`. 
