### PR TITLE
[v25.3.x] raft: refresh election timer on recovery-path append_entries (pre-vote livelock)

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2112,6 +2112,8 @@ consensus::do_append_entries(append_entries_request&& r) {
     // follower (§5.2)
     maybe_update_leader(r.source_node());
 
+    auto refresh_hbeat = ss::defer([this] { _hbeat = clock_type::now(); });
+
     // raft.pdf: Reply false if log doesn’t contain an entry at
     // prevLogIndex whose term matches prevLogTerm (§5.3)
     // broken into 3 sections
@@ -2356,11 +2358,6 @@ consensus::do_append_entries(append_entries_request&& r) {
     // success. copy entries for each subsystem
 
     try {
-        auto deferred = ss::defer([this] {
-            // we do not want to include our disk flush latency into
-            // the leader vote timeout
-            _hbeat = clock_type::now();
-        });
         validate_offset_translator_delta(request_metadata, lstats);
 
         // simulate disk error


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30817

- Command: git cherry-pick -x 81f445b69b eb137bfae2
- Commits backported: 2
- Conflicts resolved: 0
- Commits skipped (already on target): 1
- Backport branch: ai-backport-pr-30817-v25.3.x-1784821079

## Conflict details

- eb137bfae2 (merge commit): skipped. This is a routine "Merge branch 'dev' into fix/raft-prevote-livelock-recovery-hbeat" sync commit whose first parent is the PR's fix commit (81f445b69b, already applied) and whose second parent is a dev tip. Its only non-parent hunks are conflict resolutions of unrelated dev changes (src/v/cloud_storage_clients/multipart_upload.cc and tests/rptest/scale_tests/many_partitions_test.py), which belong to dev rather than to this PR. The PR's actual fix is entirely contained in 81f445b69b (src/v/raft/consensus.cc), so the merge carries no PR-specific change to backport.


Fixes: https://github.com/redpanda-data/redpanda/issues/31254,
