### PR TITLE
kafka: relicense fetch read coalescing files under RCL

### DIFF
--- a/src/v/kafka/server/fetch_memory_units.h
+++ b/src/v/kafka/server/fetch_memory_units.h
@@ -1,12 +1,11 @@
 /*
  * Copyright 2025 Redpanda Data, Inc.
  *
- * Use of this software is governed by the Business Source License
- * included in the file licenses/BSL.md
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
- * As of the Change Date specified in that file, in accordance with
- * the Business Source License, use of this software will be governed
- * by the Apache License, Version 2.0
+ * https://github.com/redpanda-data/redpanda/blob/dev/licenses/rcl.md
  */
 #pragma once
 #include "base/seastarx.h"

--- a/src/v/kafka/server/fetch_read_coalescer.cc
+++ b/src/v/kafka/server/fetch_read_coalescer.cc
@@ -1,12 +1,11 @@
 /*
  * Copyright 2026 Redpanda Data, Inc.
  *
- * Use of this software is governed by the Business Source License
- * included in the file licenses/BSL.md
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
- * As of the Change Date specified in that file, in accordance with
- * the Business Source License, use of this software will be governed
- * by the Apache License, Version 2.0
+ * https://github.com/redpanda-data/redpanda/blob/dev/licenses/rcl.md
  */
 #include "kafka/server/fetch_read_coalescer.h"
 

--- a/src/v/kafka/server/fetch_read_coalescer.h
+++ b/src/v/kafka/server/fetch_read_coalescer.h
@@ -1,12 +1,11 @@
 /*
  * Copyright 2026 Redpanda Data, Inc.
  *
- * Use of this software is governed by the Business Source License
- * included in the file licenses/BSL.md
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
- * As of the Change Date specified in that file, in accordance with
- * the Business Source License, use of this software will be governed
- * by the Apache License, Version 2.0
+ * https://github.com/redpanda-data/redpanda/blob/dev/licenses/rcl.md
  */
 #pragma once
 


### PR DESCRIPTION
Updating the license to RCL for the fetch read coalescing files.

Backport of PR #31257

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none