### PR TITLE
github: update PR template for v26.2.x release branch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,9 +21,9 @@ If this PR is a backport, link to the original with `Backport of PR`, e.g.
 - [ ] none - this is a backport
 - [ ] none - issue does not exist in previous branches
 - [ ] none - papercut/not impactful enough to backport
+- [ ] v26.2.x
 - [ ] v26.1.x
 - [ ] v25.3.x
-- [ ] v25.2.x
 
 ## Release Notes
 


### PR DESCRIPTION
Add \`v26.2.x\` as a backport option and remove \`v25.2.x\`, which has reached end of support.

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none