### PR TITLE
[v26.2.x] dt/tests: declare Kafka 4.2 in sarama compatibility tests

### DIFF
--- a/tests/go/sarama/produce_test/main.go
+++ b/tests/go/sarama/produce_test/main.go
@@ -14,7 +14,7 @@ import (
 var (
 	brokers = flag.String("brokers", "127.0.0.1:9092", "Th Redpanda brokers to connect to, as a comma separated list")
 	count   = flag.Int64("count", 100, "Optional count to run")
-	version = flag.String("version", "2.1.0", "Kafka version to use, e.g. 2.1.0")
+	version = flag.String("version", "4.2.0", "Kafka version to use, e.g. 2.1.0")
 )
 
 func main() {

--- a/tests/rptest/tests/compatibility/sarama_produce_test.py
+++ b/tests/rptest/tests/compatibility/sarama_produce_test.py
@@ -46,7 +46,7 @@ class SaramaProduceTest(RedpandaTest):
         )
 
     @cluster(num_nodes=3, log_allow_list=TX_ERROR_LOGS)
-    @matrix(version=["2.1.0", "2.6.0"])
+    @matrix(version=["2.1.0", "2.6.0", "3.6.0", "4.2.0"])
     def test_produce(self, version):
         verifier_bin = "/opt/redpanda-tests/go/sarama/produce_test/produce_test"
 

--- a/tests/rptest/tests/compatibility/sarama_test.py
+++ b/tests/rptest/tests/compatibility/sarama_test.py
@@ -43,7 +43,7 @@ class SaramaTest(RedpandaTest):
         self._timeout = 30 if self.scale.local else 1200
 
     @cluster(num_nodes=4)
-    @matrix(version=["2.1.0", "2.6.0"])
+    @matrix(version=["2.1.0", "2.6.0", "3.6.0", "4.2.0"])
     def test_sarama_interceptors(self, version):
         sarama_example = SaramaExamples.SaramaInterceptors(
             self.redpanda, version, self.topic
@@ -56,7 +56,7 @@ class SaramaTest(RedpandaTest):
         wait_until(example.condition_met, timeout_sec=self._timeout, backoff_sec=1)
 
     @cluster(num_nodes=4)
-    @matrix(version=["2.1.0", "2.6.0"])
+    @matrix(version=["2.1.0", "2.6.0", "3.6.0", "4.2.0"])
     def test_sarama_http_server(self, version):
         sarama_example = SaramaExamples.SaramaHttpServer(self.redpanda, version)
         example = ExampleRunner(self._ctx, sarama_example, timeout_sec=self._timeout)
@@ -91,7 +91,7 @@ class SaramaTest(RedpandaTest):
         )
 
     @cluster(num_nodes=5)
-    @matrix(version=["2.1.0", "2.6.0"])
+    @matrix(version=["2.1.0", "2.6.0", "3.6.0", "4.2.0"])
     def test_sarama_consumergroup(self, version):
         count = 10 if self.scale.local else 5000
 
@@ -144,7 +144,7 @@ class SaramaScramTest(RedpandaTest):
         super(SaramaScramTest, self).__init__(test_context, security=security)
 
     @cluster(num_nodes=3)
-    @matrix(version=["2.1.0", "2.6.0"])
+    @matrix(version=["2.1.0", "2.6.0", "3.6.0", "4.2.0"])
     def test_sarama_sasl_scram(self, version):
         # Get the SASL SCRAM command and a ducktape node
         cmd = SaramaExamples.sarama_sasl_scram(self.redpanda, version, self.topic)


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31073
