### PR TITLE
cluster_link: harden shadow link create against transient unavailable

### DIFF
--- a/src/v/redpanda/admin/proxy/BUILD
+++ b/src/v/redpanda/admin/proxy/BUILD
@@ -48,6 +48,7 @@ redpanda_cc_library(
     implementation_deps = [
         ":context",
         ":proxy_rpc",
+        "//src/v/ssx:sformat",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/v/redpanda/admin/proxy/client.cc
+++ b/src/v/redpanda/admin/proxy/client.cc
@@ -18,6 +18,7 @@
 #include "redpanda/admin/proxy/types.h"
 #include "rpc/connection_cache.h"
 #include "serde/protobuf/rpc.h"
+#include "ssx/sformat.h"
 #include "strings/utf8.h"
 
 #include <exception>
@@ -90,7 +91,11 @@ ss::future<iobuf> client::send(
               target,
               result.error());
             proxy_resp.error_code = errc::unavailable;
-            // Leave it as a generic error message
+            proxy_resp.payload = iobuf::from(
+              ssx::sformat(
+                "failed to proxy admin request to node {}: {}",
+                target,
+                result.error().message()));
         } else {
             proxy_resp = std::move(result.value().data);
         }
@@ -101,7 +106,9 @@ ss::future<iobuf> client::send(
           target,
           std::current_exception());
         proxy_resp.error_code = errc::internal_error;
-        // Leave it as a generic error message
+        proxy_resp.payload = iobuf::from(
+          ssx::sformat(
+            "exception while proxying admin request to node {}", target));
     }
     switch (proxy_resp.error_code) {
     case errc::ok:

--- a/tests/rptest/tests/cloud_topics/l0_gc_test.py
+++ b/tests/rptest/tests/cloud_topics/l0_gc_test.py
@@ -508,7 +508,7 @@ class CloudTopicsL0GCAdminTest(CloudTopicsL0GCAdminBase):
         self.check_statuses(
             statuses,
             nodes=[kill_node_id],
-            error="(Service unavailable)",
+            error=f"failed to proxy admin request to node {kill_node_id}",
             strict=False,
         )
 

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -528,7 +528,7 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
 
         # Attempting to create a second one with the same name should fail
         with self._expect_connect_error(ConnectErrorCode.ALREADY_EXISTS):
-            self.create_link("test-link")
+            self.create_link("test-link", fetch_on_already_exists=False)
 
         # Attempting to create a second link should fail.
         # Only one link is supported per cluster

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, Optional
 
 import google.protobuf.duration_pb2
 import google.protobuf.field_mask_pb2
+from connectrpc.errors import ConnectError, ConnectErrorCode
 from ducktape.cluster.cluster import ClusterNode
 from ducktape.services.service import Service
 from ducktape.utils.util import wait_until
@@ -994,16 +995,67 @@ class ShadowLinkTestBase(PreallocNodesTest):
         return req
 
     def create_link(
-        self, link_name: str, *args: Any, **kwargs: Any
+        self,
+        link_name: str,
+        *args: Any,
+        fetch_on_already_exists: bool = True,
+        **kwargs: Any,
     ) -> shadow_link_pb2.ShadowLink:
         req = self.create_default_link_request(link_name=link_name, *args, **kwargs)
-        return self.create_link_with_request(req=req)
+        return self.create_link_with_request(
+            req=req, fetch_on_already_exists=fetch_on_already_exists
+        )
 
     @retry_request
-    def create_link_with_request(
+    def _create_link_rpc(
         self, req: shadow_link_pb2.CreateShadowLinkRequest
     ) -> shadow_link_pb2.ShadowLink:
         return self.service_client.create_shadow_link(req=req).shadow_link
+
+    def create_link_with_request(
+        self,
+        req: shadow_link_pb2.CreateShadowLinkRequest,
+        fetch_on_already_exists: bool = True,
+    ) -> shadow_link_pb2.ShadowLink:
+        # "Unavailable" is usually transient: leadership may still be
+        # settling, and the broker may have applied the create even though
+        # the RPC failed (e.g. the internal proxy hop to the controller
+        # leader timed out while the create kept running). Retry with
+        # backoff, treating "already exists" on a retry as an earlier
+        # attempt having landed.
+        #
+        # A validate_only request never creates anything, so "already exists"
+        # from one is always a real duplicate rather than our own earlier
+        # attempt. Tests that assert on a duplicate create pass
+        # fetch_on_already_exists=False for the same reason.
+        fetch_existing = fetch_on_already_exists and not req.validate_only
+        max_attempts = 5
+        for attempt in range(max_attempts):
+            try:
+                return self._create_link_rpc(req=req)
+            except ConnectError as e:
+                if (
+                    e.code == ConnectErrorCode.ALREADY_EXISTS
+                    and attempt > 0
+                    and fetch_existing
+                ):
+                    name = req.shadow_link.name
+                    self.logger.debug(
+                        f"Shadow link {name} was created by an earlier attempt"
+                    )
+                    return self.get_link(name)
+                if (
+                    e.code != ConnectErrorCode.UNAVAILABLE
+                    or attempt == max_attempts - 1
+                ):
+                    raise
+                backoff = 2**attempt
+                self.logger.debug(
+                    f"Received {e} while creating shadow link. "
+                    f"Retrying in {backoff}s..."
+                )
+                time.sleep(backoff)
+        raise RuntimeError("unreachable")
 
     def delete_link(
         self, link_name: str, force: bool = False, *args: Any, **kwargs: Any


### PR DESCRIPTION
A nightly `ShadowLinkCustomStartOffsetSelectionTests.test_starting_offset`
run (failures=True) failed to create its shadow link, with the create call
returning `ConnectError [unavailable] Service unavailable`.

The run's logs show the sequence. The create request landed on a broker
that was not the controller leader, so it was forwarded to the leader over
the internal admin proxy. That forwarding hop has a fixed 10s timeout.
Meanwhile, the test's failure injector had suspended one of the source
cluster's brokers, and the create's preflight check on the leader stalled
waiting for that broker. The stall outlasted the hop's 10s budget, so the
proxying node gave up and the client saw a failure — while the leader,
unaware, went on to complete the create successfully moments later. The
client was told the create failed when it had actually succeeded, via an
error that names no component.

Two commits, one per half of that:

- `admin/proxy: attach an error message to failed proxy hops` — the
  forwarded-request failure path returned a message-less "Service
  unavailable"; every other path through the proxy already carries a
  descriptive message. It now names the node the request was forwarded to
  and the transport error, e.g. "failed to proxy admin request to node 1:
  rpc::errc::client_request_timeout".

- `cl/test: retry shadow link create on unavailable` — the ducktape helper
  treated `unavailable` as fatal. It now retries with backoff, up to 5
  attempts, matching the v1 admin client's policy for 503s. Because the
  broker can finish applying a create after the hop has already reported
  failure, "already exists" on a retry means an earlier attempt landed,
  and is resolved by fetching the link. Two cases keep raising instead: a
  `validate_only` create never writes anything, so "already exists" from
  one is always a real duplicate, and a test that asserts on a duplicate
  create opts out with `fetch_on_already_exists=False`. Without those
  guards a first-attempt `unavailable` would push a duplicate's "already
  exists" onto a retry, where the fetch would swallow it.

Fixes [CORE-16856](https://redpandadata.atlassian.net/browse/CORE-16856).

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none


[CORE-16856]: https://redpandadata.atlassian.net/browse/CORE-16856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
