### PR TITLE
[v26.2.x] ssx/actor: document blocked tell() ordering as unspecified

### DIFF
--- a/src/v/ssx/actor.h
+++ b/src/v/ssx/actor.h
@@ -134,7 +134,9 @@ public:
         co_await _gate.close();
     }
 
-    // Send a message. It waits until space is available.
+    // Send a message. It waits until space is available. If multiple senders
+    // are blocked waiting for space, the order in which their messages are
+    // enqueued is unspecified.
     ss::future<> tell(T msg)
     requires(OverflowPolicy == overflow_policy::block)
     {

--- a/src/v/ssx/tests/actor_test.cc
+++ b/src/v/ssx/tests/actor_test.cc
@@ -159,8 +159,11 @@ TEST(Actor, ConcurrentTellsWithFullMailbox) {
     tell_fut2.get();
     tell_fut3.get();
 
-    // All messages should be processed
-    EXPECT_THAT(actor.processed, ElementsAre(1, 2, 3, 4, 5));
+    // All messages should be processed. Senders blocked on a full mailbox
+    // race for freed space when woken, so their relative order is
+    // unspecified.
+    EXPECT_THAT(
+      actor.processed, ::testing::UnorderedElementsAre(1, 2, 3, 4, 5));
     actor.stop().get();
 }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31146
