### PR TITLE
[CORE-7771] tests: tolerate approximate __consumer_offsets balance

### DIFF
--- a/tests/rptest/tests/consumer_group_balancing_test.py
+++ b/tests/rptest/tests/consumer_group_balancing_test.py
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0
 
 from collections import defaultdict
-from math import floor
+from math import ceil
 
 from ducktape.utils.util import wait_until
 
@@ -75,16 +75,41 @@ class ConsumerGroupBalancingTest(RedpandaTest):
         partitions = admin.get_partitions("__consumer_offsets")
         replicas_per_node = defaultdict(lambda: 0)
 
-        expected_number_of_replicas = floor((consumer_group_topic_partitions * 3) / 5)
-
         for p in partitions:
             for node in p["replicas"]:
                 replicas_per_node[node["node_id"]] += 1
 
-        for node, replicas in replicas_per_node.items():
+        # Derive the target from the cluster size and the observed total replica
+        # count rather than hard-coding, so the assertion tracks the test config
+        # (and the topic's actual replication factor) if either changes.
+        num_brokers = len(self.redpanda.nodes)
+        total_replicas = sum(len(p["replicas"]) for p in partitions)
+        expected = total_replicas / num_brokers
+
+        for node, replicas in sorted(replicas_per_node.items()):
             self.logger.info(
-                f"__consumer_offsets partition has: {replicas} replicas on node: {node}"
+                f"__consumer_offsets has {replicas} replicas on node {node} "
+                f"(expected ~{expected:.0f})"
             )
-            assert replicas in range(
-                expected_number_of_replicas - 1, expected_number_of_replicas + 2
+
+        # Coordinators must be spread across every broker.
+        assert len(replicas_per_node) == num_brokers, (
+            f"__consumer_offsets replicas are not spread across all {num_brokers} "
+            f"brokers: {dict(sorted(replicas_per_node.items()))}"
+        )
+
+        # The allocator only balances approximately (it balances total partitions
+        # per node and breaks ties randomly), so a single topic drifts from the
+        # ideal -- the seed node especially, which carries baseline partitions.
+        # Allow each node within 15% of the mean (for the default config, mean 38.4
+        # -> band [33, 44]): clears the ~2-3 skew seen under load (CORE-7771:
+        # {36,39,39,39,39}) while still failing gross imbalance like replicas packed
+        # onto a subset of nodes.
+        tolerance = ceil(expected * 0.15)
+        for node, replicas in replicas_per_node.items():
+            assert abs(replicas - expected) <= tolerance, (
+                f"node {node} holds {replicas} __consumer_offsets replicas, outside "
+                f"the tolerated band [{expected - tolerance:.0f}, "
+                f"{expected + tolerance:.0f}]; distribution: "
+                f"{dict(sorted(replicas_per_node.items()))}"
             )


### PR DESCRIPTION
## Problem

`ConsumerGroupBalancingTest.test_coordinator_nodes_balance` asserted that every broker holds `37..39` replicas of `__consumer_offsets` (64 partitions × RF 3 / 5 nodes = 38.4, i.e. a near-perfect ±1 band).

The partition allocator only guarantees **approximate** balance: it balances the *total* partition count per node (across all internal topics) and breaks ties randomly, so the per-node count of a single topic legitimately drifts from the ideal — most notably the seed/controller node, which carries extra baseline partitions and tends to get a few fewer.

The real CI failure (build 87451, 2026-07-21) was `{1:36, 2:39, 3:39, 4:39, 5:39}` on a fully healthy 5-broker cluster — a valid, roughly-even placement that the ±1 assertion rejected. Hence the flake.

## Fix

Replace the exact-band check with intent-matching assertions:
- **Every broker participates** (`len(replicas_per_node) == num_brokers`) — the actual point of the test (coordinators spread across the whole cluster).
- **Each node within 15% of the mean** — clears the ~2–3 skew observed under load with margin, while still failing gross imbalance (replicas packed onto a subset of nodes, or a broker fully excluded → also caught by the `len` check).

The target is **derived, not hard-coded**: broker count comes from the cluster (`len(self.redpanda.nodes)`) and the mean from the observed total replica count (`sum(len(p["replicas"]) …) / num_brokers`), so it tracks the test configuration and the topic's actual replication factor if either changes.

## Verification

- `pyright` type-check: clean.
- Ran the fixed test 15× locally via `tools/dt`: 15/15 pass, distributions 37–39 (well within the band).
- Confirmed the historical failure `{36,39,39,39,39}` now passes and catastrophic cases (a node at 0, or ~48 packed onto four nodes) still fail.

CORE-7771

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none
