### PR TITLE
[CORE-9724] rptest: harden get_version against slow SSH version reads

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -4867,15 +4867,38 @@ class RedpandaService(Service, RedpandaServiceABC):
         env_preamble = self.redpanda_env_preamble()
         version_cmd = f"{env_preamble} {self.find_binary('redpanda')} --version"
         VERSION_LINE_RE = re.compile(".*(v\\d+\\.\\d+\\.\\d+).*")
+
+        def read_version_lines():
+            # `redpanda --version` is occasionally slow to respond over SSH on a
+            # loaded node, surfacing as a socket read timeout. The output is not
+            # latency-sensitive, so retry only that transient stall (CORE-9724);
+            # every other failure must surface immediately rather than spin until
+            # the wait_until_result timeout. Note socket.timeout is referenced
+            # explicitly because TimeoutError is shadowed by the ducktape import.
+            # ssh_capture yields lazily, so the read (and any timeout) happens
+            # while iterating -- keep the loop inside the try.
+            try:
+                version_lines = [
+                    l
+                    for l in node.account.ssh_capture(
+                        version_cmd, allow_fail=True, timeout_sec=30
+                    )
+                    if VERSION_LINE_RE.match(l)
+                ]
+            except socket.timeout:
+                return False, None
+
+            return True, version_lines
+
+        version_lines = wait_until_result(
+            read_version_lines,
+            timeout_sec=90,
+            backoff_sec=1,
+            err_msg="redpanda --version did not respond over SSH within 90s",
+        )
+
         # NOTE: not all versions of Redpanda support the --version field, even
         # though they print out the version.
-        version_lines = [
-            l
-            for l in node.account.ssh_capture(
-                version_cmd, allow_fail=True, timeout_sec=10
-            )
-            if VERSION_LINE_RE.match(l)
-        ]
         assert len(version_lines) == 1, version_lines
         return VERSION_LINE_RE.findall(version_lines[0])[0]
 


### PR DESCRIPTION
Deflakes upgrade tests such as
`ClusterConfigAliasTest.test_aliasing_with_upgrade`.

During `RedpandaInstaller.start()` the test runs `redpanda --version`
over SSH to verify the installed binary. On a loaded CI node this call
occasionally does not emit output within the 10s read timeout, so
paramiko raises a read timeout (`PipeTimeout` -> `socket.timeout` ->
`TimeoutError`) and the whole test fails during setup. This was the only
SSH call in the installer setup/download path with a finite read
timeout; the others (`mkdir`, `ln -s`, the tarball `curl`/`gunzip`, etc.)
pass `timeout_sec=None` and block indefinitely, which is why the failure
only ever surfaced in `get_version`.

Bump the per-attempt timeout to 30s and wrap the read in
`wait_until_result(retry_on_exc=True)` (the same retry idiom already used
elsewhere in the installer) so a transient stall is retried instead of
aborting the test.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
