### PR TITLE
rptest/util: promote to strict type checking

### DIFF
--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -158,7 +158,7 @@ def wait_until_with_progress_check(
     timeout_sec: float,
     progress_sec: float,
     backoff_sec: float,
-    err_msg: str | None = None,
+    err_msg: str = "",
     logger: Logger | None = None,
 ):
     """

--- a/tools/type-checking/type-check-strictness.json
+++ b/tools/type-checking/type-check-strictness.json
@@ -267,6 +267,7 @@
         "rptest/tests/pkcs12_test.py",
         "rptest/tests/tls_version_test.py",
         "rptest/tests/topic_recovery_test.py",
+        "rptest/util.py",
         "rptest/utils/expect_rate.py",
         "rptest/utils/rpenv.py",
         "rptest/utils/si_utils.py"
@@ -449,7 +450,6 @@
         "rptest/transactions/verifiers/compacted_verifier.py",
         "rptest/transactions/verifiers/idempotency_load_generator.py",
         "rptest/transactions/verifiers/stream_verifier.py",
-        "rptest/util.py",
         "rptest/utils/cluster_topology.py"
     ],
     "skip": [


### PR DESCRIPTION
Tighten err_msg to a non-optional str and move rptest/util.py to the stricter type-checking level.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
