### PR TITLE
`rptest`: bump `LATEST_RELEASED_MAJOR`

### DIFF
--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -49,7 +49,7 @@ REDPANDA_INSTALLER_HEAD_TAG = "head"
 # The latest major version that has been released (binaries available on S3).
 # Update this when a new major version is published. No need to update it for
 # minors.
-LATEST_RELEASED_MAJOR: tuple[int, int, int] = (26, 1, 1)
+LATEST_RELEASED_MAJOR: tuple[int, int, int] = (26, 2, 1)
 
 RedpandaVersionTriple = tuple[int, int, int]
 RedpandaVersionLine = tuple[int, int]


### PR DESCRIPTION
`v26.2.1`

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none