### PR TITLE
ts-ct-migration: chunked data source [PR 1b]

### DIFF
--- a/src/v/cloud_topics/level_one/common/BUILD
+++ b/src/v/cloud_topics/level_one/common/BUILD
@@ -148,3 +148,13 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "chunk_data_source",
+    hdrs = ["chunk_data_source.h"],
+    deps = [
+        "//src/v/base",
+        "@fmt",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_one/common/chunk_data_source.h
+++ b/src/v/cloud_topics/level_one/common/chunk_data_source.h
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "base/vassert.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/iostream.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/util/bool_class.hh>
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <utility>
+
+namespace cloud_topics::l1 {
+
+/// Controls where the first chunk starts. When yes, chunk boundaries are
+/// chunk_size aligned, so overlapping reads request identical
+/// (position, length) chunks that a downstream cache can dedup. When no, the
+/// first chunk starts exactly at start_pos -- for a caller with no cache to
+/// dedup against, which would otherwise fetch and discard the bytes between the
+/// chunk boundary and start_pos.
+using use_chunk_aligned_reads
+  = ss::bool_class<struct use_chunk_aligned_reads_tag>;
+
+/// A data source that fetches the byte range [start_pos, start_pos+total_len)
+/// one fixed-size chunk at a time, lazily, and presents the result as a single
+/// contiguous stream.
+///
+/// Only the chunks actually consumed are fetched: a reader that stops early
+/// simply stops pulling, so the un-read tail is never fetched. Chunks are fixed
+/// byte ranges and need not be aligned to any structure in the data -- the
+/// source concatenates one chunk's tail with the next chunk's head, so a record
+/// spanning a boundary is read seamlessly. EOF is signalled only at the true
+/// end (start_pos+total_len), so a consumer never mistakes a chunk boundary for
+/// the end of the data.
+///
+/// `Fetch` is any callable
+///   (size_t file_position, size_t length, ss::abort_source*)
+///     -> ss::future<std::expected<ss::input_stream<char>, E>>
+/// for any formattable error `E`. A chunk-fetch failure (an unexpected result)
+/// surfaces as an exception from get(); a record-batch reader propagates it
+/// (its read API has no error variant), matching how such readers already
+/// report stream errors.
+template<typename Fetch>
+class chunk_data_source final : public ss::data_source_impl {
+public:
+    /// See use_chunk_aligned_reads. When yes the first fetch is aligned
+    /// at or before start_pos and the leading `start_pos % chunk_size` bytes
+    /// are skipped; when no the first chunk starts exactly at start_pos with no
+    /// skipped head.
+    chunk_data_source(
+      Fetch fetch,
+      size_t start_pos,
+      size_t total_len,
+      size_t chunk_size,
+      ss::abort_source* as,
+      use_chunk_aligned_reads aligned)
+      : _fetch(std::move(fetch))
+      , _end(start_pos + total_len)
+      , _chunk_size(chunk_size)
+      , _next_chunk_start(
+          aligned ? start_pos - (start_pos % chunk_size) : start_pos)
+      , _skip_head(aligned ? start_pos % chunk_size : 0)
+      , _as(as) {
+        vassert(
+          chunk_size > 0, "chunk_data_source requires a non-zero chunk size");
+    }
+
+    ss::future<ss::temporary_buffer<char>> get() override {
+        while (true) {
+            // Surface an abort as an exception on every read -- including while
+            // draining a buffered chunk or between chunks -- so a cancelled
+            // read fails loudly rather than terminating as a (truncated) clean
+            // end-of-stream.
+            if (_as != nullptr) {
+                _as->check();
+            }
+            if (!_cur.has_value()) {
+                if (_next_chunk_start >= _end) {
+                    // Past the requested range: true EOF.
+                    co_return ss::temporary_buffer<char>{};
+                }
+                auto chunk_end = std::min(
+                  _next_chunk_start + _chunk_size, _end);
+                auto len = chunk_end - _next_chunk_start;
+                auto stream = co_await _fetch(_next_chunk_start, len, _as);
+                if (!stream.has_value()) {
+                    throw std::runtime_error(
+                      fmt::format(
+                        "failed to fetch chunk at byte {} (len {}): {}",
+                        _next_chunk_start,
+                        len,
+                        stream.error()));
+                }
+                _cur = std::move(*stream);
+                if (_skip_head > 0) {
+                    co_await _cur->skip(_skip_head);
+                    _skip_head = 0;
+                }
+                _next_chunk_start += _chunk_size;
+            }
+            auto buf = co_await _cur->read();
+            if (buf.empty()) {
+                // Current chunk exhausted; advance to the next.
+                co_await _cur->close();
+                _cur.reset();
+                continue;
+            }
+            co_return buf;
+        }
+    }
+
+    ss::future<> close() override {
+        if (_cur.has_value()) {
+            co_await _cur->close();
+            _cur.reset();
+        }
+    }
+
+private:
+    Fetch _fetch;
+    size_t _end;
+    size_t _chunk_size;
+    // Start of the next chunk to fetch. When chunk-aligned this is the chunk
+    // boundary at or before start_pos; otherwise it is start_pos itself.
+    size_t _next_chunk_start;
+    // Bytes to discard from the first chunk so the stream starts at start_pos
+    // (non-zero only when chunk-aligned and start_pos sits mid-chunk). Zeroed
+    // after the first chunk.
+    size_t _skip_head;
+    std::optional<ss::input_stream<char>> _cur;
+    ss::abort_source* _as;
+};
+
+/// Deduce `Fetch` and wrap a chunk_data_source in an ss::data_source.
+template<typename Fetch>
+ss::data_source make_chunk_data_source(
+  Fetch fetch,
+  size_t start_pos,
+  size_t total_len,
+  size_t chunk_size,
+  ss::abort_source* as,
+  use_chunk_aligned_reads aligned) {
+    return ss::data_source{std::make_unique<chunk_data_source<Fetch>>(
+      std::move(fetch), start_pos, total_len, chunk_size, as, aligned)};
+}
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/tests/BUILD
+++ b/src/v/cloud_topics/level_one/common/tests/BUILD
@@ -77,3 +77,20 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "chunk_data_source_test",
+    timeout = "short",
+    srcs = [
+        "chunk_data_source_test.cc",
+    ],
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:iostream",
+        "//src/v/cloud_topics/level_one/common:abstract_io",
+        "//src/v/cloud_topics/level_one/common:chunk_data_source",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_one/common/tests/chunk_data_source_test.cc
+++ b/src/v/cloud_topics/level_one/common/tests/chunk_data_source_test.cc
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "bytes/iobuf.h"
+#include "bytes/iostream.h"
+#include "cloud_topics/level_one/common/abstract_io.h"
+#include "cloud_topics/level_one/common/chunk_data_source.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/iostream.hh>
+
+#include <gtest/gtest.h>
+
+#include <expected>
+#include <string>
+#include <vector>
+
+using namespace cloud_topics::l1;
+
+namespace {
+
+// A deterministic byte sequence so reads can be checked positionally.
+std::string make_bytes(size_t n) {
+    std::string s(n, '\0');
+    for (size_t i = 0; i < n; ++i) {
+        s[i] = static_cast<char>(i % 251);
+    }
+    return s;
+}
+
+iobuf to_iobuf(const std::string& s) {
+    iobuf b;
+    b.append(s.data(), s.size());
+    return b;
+}
+
+// A fetch over an in-memory buffer that records every requested (pos, len) so
+// tests can assert which chunks were fetched and in what granularity. The fetch
+// is returned as a plain lambda -- chunk_data_source is generic over the fetch
+// type (io::errc here is just this test's error type).
+struct recording_fetcher {
+    iobuf data;
+    std::vector<std::pair<size_t, size_t>> calls;
+
+    explicit recording_fetcher(const std::string& s)
+      : data(to_iobuf(s)) {}
+
+    auto fn() {
+        return
+          [this](this auto, size_t pos, size_t len, ss::abort_source*)
+            -> ss::future<std::expected<ss::input_stream<char>, io::errc>> {
+              calls.emplace_back(pos, len);
+              co_return make_iobuf_input_stream(data.share(pos, len));
+          };
+    }
+
+    static auto failing_fn() {
+        return
+          [](size_t, size_t, ss::abort_source*)
+            -> ss::future<std::expected<ss::input_stream<char>, io::errc>> {
+              co_return std::unexpected(io::errc::cloud_op_error);
+          };
+    }
+};
+
+template<typename Fetch>
+ss::input_stream<char> make_stream(
+  Fetch fetch,
+  size_t start,
+  size_t total,
+  size_t chunk_size,
+  ss::abort_source& as,
+  use_chunk_aligned_reads aligned) {
+    return ss::input_stream<char>{make_chunk_data_source(
+      std::move(fetch), start, total, chunk_size, &as, aligned)};
+}
+
+std::string read_all(ss::input_stream<char>& in) {
+    std::string out;
+    while (true) {
+        auto buf = in.read().get();
+        if (buf.empty()) {
+            break;
+        }
+        out.append(buf.get(), buf.size());
+    }
+    return out;
+}
+
+} // namespace
+
+// A full read across many chunks yields exactly the requested byte range, i.e.
+// chunking is transparent: the stream is byte-identical to a single download.
+TEST(ChunkDataSourceTest, FullReadConcatenatesChunks) {
+    auto bytes = make_bytes(1000);
+    recording_fetcher f(bytes);
+    ss::abort_source as;
+    auto in = make_stream(
+      f.fn(), 0, 1000, 256, as, use_chunk_aligned_reads::yes);
+    auto out = read_all(in);
+    in.close().get();
+
+    EXPECT_EQ(out, bytes);
+    // ceil(1000/256) = 4 chunks: (0,256)(256,256)(512,256)(768,232).
+    ASSERT_EQ(f.calls.size(), 4u);
+    EXPECT_EQ(f.calls[0], (std::pair<size_t, size_t>{0, 256}));
+    EXPECT_EQ(f.calls[1], (std::pair<size_t, size_t>{256, 256}));
+    EXPECT_EQ(f.calls[2], (std::pair<size_t, size_t>{512, 256}));
+    EXPECT_EQ(f.calls[3], (std::pair<size_t, size_t>{768, 232}));
+}
+
+// A seek into the middle of a chunk: the first fetch is chunk-aligned and the
+// leading bytes before the seek point are skipped.
+TEST(ChunkDataSourceTest, MidChunkSeekSkipsHead) {
+    auto bytes = make_bytes(1000);
+    recording_fetcher f(bytes);
+    ss::abort_source as;
+    // start at 300 (mid second chunk), read to end.
+    auto in = make_stream(
+      f.fn(), 300, 700, 256, as, use_chunk_aligned_reads::yes);
+    auto out = read_all(in);
+    in.close().get();
+
+    EXPECT_EQ(out, bytes.substr(300));
+    // First fetch is the chunk containing 300: [256, 512).
+    ASSERT_FALSE(f.calls.empty());
+    EXPECT_EQ(f.calls[0], (std::pair<size_t, size_t>{256, 256}));
+}
+
+// use_chunk_aligned_reads=false: a mid-chunk start reads exactly from start_pos
+// -- no chunk alignment and no skipped head, so no bytes before the start are
+// fetched (contrast MidChunkSeekSkipsHead, which fetches the [256, 512) chunk
+// and discards the leading 44 bytes). Chunks then advance by chunk_size
+// from the start.
+TEST(ChunkDataSourceTest, UnalignedStartReadsFromStartPos) {
+    auto bytes = make_bytes(1000);
+    recording_fetcher f(bytes);
+    ss::abort_source as;
+    auto in = make_stream(
+      f.fn(), 300, 700, 256, as, use_chunk_aligned_reads::no);
+    auto out = read_all(in);
+    in.close().get();
+
+    EXPECT_EQ(out, bytes.substr(300));
+    // First fetch starts at 300 itself; subsequent chunks advance by 256.
+    ASSERT_EQ(f.calls.size(), 3u);
+    EXPECT_EQ(f.calls[0], (std::pair<size_t, size_t>{300, 256}));
+    EXPECT_EQ(f.calls[1], (std::pair<size_t, size_t>{556, 256}));
+    EXPECT_EQ(f.calls[2], (std::pair<size_t, size_t>{812, 188}));
+}
+
+// When start_pos already sits on a chunk boundary the flag makes no difference:
+// use_chunk_aligned_reads::no fetches the same chunks as ::yes.
+TEST(ChunkDataSourceTest, UnalignedStartOnBoundaryMatchesAligned) {
+    auto bytes = make_bytes(1000);
+    recording_fetcher f(bytes);
+    ss::abort_source as;
+    auto in = make_stream(
+      f.fn(), 0, 1000, 256, as, use_chunk_aligned_reads::no);
+    auto out = read_all(in);
+    in.close().get();
+
+    EXPECT_EQ(out, bytes);
+    ASSERT_EQ(f.calls.size(), 4u);
+    EXPECT_EQ(f.calls[0], (std::pair<size_t, size_t>{0, 256}));
+    EXPECT_EQ(f.calls[1], (std::pair<size_t, size_t>{256, 256}));
+    EXPECT_EQ(f.calls[2], (std::pair<size_t, size_t>{512, 256}));
+    EXPECT_EQ(f.calls[3], (std::pair<size_t, size_t>{768, 232}));
+}
+
+// A read that stops early only fetches the chunks it touches; the tail is never
+// downloaded. This is the win that a whole-suffix download cannot give, and the
+// reason a naive length cap (which would EOF early) is unnecessary.
+TEST(ChunkDataSourceTest, EarlyTerminationFetchesOnlyTouchedChunks) {
+    auto bytes = make_bytes(10000);
+    recording_fetcher f(bytes);
+    ss::abort_source as;
+    auto in = make_stream(
+      f.fn(), 0, 10000, 256, as, use_chunk_aligned_reads::yes);
+
+    auto head = in.read_exactly(50).get();
+    in.close().get();
+
+    EXPECT_EQ(std::string(head.get(), head.size()), bytes.substr(0, 50));
+    // Only the first chunk was needed; a whole-suffix download would have
+    // pulled all ceil(10000/256)=40 chunks.
+    EXPECT_EQ(f.calls.size(), 1u);
+}
+
+// A segment smaller than one chunk is a single fetch.
+TEST(ChunkDataSourceTest, SingleChunkSegment) {
+    auto bytes = make_bytes(100);
+    recording_fetcher f(bytes);
+    ss::abort_source as;
+    auto in = make_stream(
+      f.fn(), 0, 100, 256, as, use_chunk_aligned_reads::yes);
+    auto out = read_all(in);
+    in.close().get();
+
+    EXPECT_EQ(out, bytes);
+    ASSERT_EQ(f.calls.size(), 1u);
+    EXPECT_EQ(f.calls[0], (std::pair<size_t, size_t>{0, 100}));
+}
+
+// When the length is an exact multiple of the chunk size, EOF lands exactly at
+// the end -- it is not mistaken for a chunk boundary.
+TEST(ChunkDataSourceTest, ExactMultipleEndsAtTotal) {
+    auto bytes = make_bytes(512);
+    recording_fetcher f(bytes);
+    ss::abort_source as;
+    auto in = make_stream(
+      f.fn(), 0, 512, 256, as, use_chunk_aligned_reads::yes);
+    auto out = read_all(in);
+    in.close().get();
+
+    EXPECT_EQ(out.size(), 512u);
+    EXPECT_EQ(out, bytes);
+    ASSERT_EQ(f.calls.size(), 2u);
+    EXPECT_EQ(f.calls[1], (std::pair<size_t, size_t>{256, 256}));
+}
+
+// A fetch failure surfaces as an exception from the stream read.
+TEST(ChunkDataSourceTest, FetchFailurePropagates) {
+    ss::abort_source as;
+    auto in = make_stream(
+      recording_fetcher::failing_fn(),
+      0,
+      1000,
+      256,
+      as,
+      use_chunk_aligned_reads::yes);
+    EXPECT_THROW(in.read().get(), std::runtime_error);
+    in.close().get();
+}
+
+// A mid-stream abort surfaces as an exception rather than a clean EOF: the
+// source checks the abort source on every get(), so a cancelled read fails
+// loudly instead of looking like a (truncated) end-of-stream -- otherwise a
+// cancelled caller could commit a partial read as if it had read everything.
+TEST(ChunkDataSourceTest, AbortSurfacesAsError) {
+    auto bytes = make_bytes(1000);
+    recording_fetcher f(bytes);
+    ss::abort_source as;
+    auto in = make_stream(
+      f.fn(), 0, 1000, 256, as, use_chunk_aligned_reads::yes);
+
+    // First read succeeds, then abort with bytes still unread.
+    auto first = in.read().get();
+    EXPECT_FALSE(first.empty());
+    as.request_abort();
+
+    EXPECT_THROW(
+      {
+          while (!in.read().get().empty()) {
+          }
+      },
+      ss::abort_requested_exception);
+    in.close().get();
+}
+
+// An abort before the first read fails the very first get(), before any chunk
+// is fetched -- the abort check sits at the top of get(), ahead of the fetch.
+TEST(ChunkDataSourceTest, AbortBeforeFirstReadFetchesNothing) {
+    auto bytes = make_bytes(1000);
+    recording_fetcher f(bytes);
+    ss::abort_source as;
+    auto in = make_stream(
+      f.fn(), 0, 1000, 256, as, use_chunk_aligned_reads::yes);
+
+    as.request_abort();
+    EXPECT_THROW(in.read().get(), ss::abort_requested_exception);
+    in.close().get();
+
+    EXPECT_TRUE(f.calls.empty());
+}


### PR DESCRIPTION
## Backports Required

- [x] none - not a bug fix

## Release Notes

* none

## Summary

A lazily-fetched, fixed-size **chunked data source** (`ts_chunk_data_source`)
for reading a tiered-storage-backed segment: only the chunks a read touches are
downloaded (`chunk_size == 0` falls back to a whole-suffix fetch).

Independent leaf on `dev`, split out of the old "metastore and L1 reader" PR
(#30800); consumed by the TS reader in **PR 1d**.

## Changes by area

- `cloud_topics/level_one/common/chunk_data_source.h` — the chunk data source
  and its unit test.

## Testing

`bazel test //src/v/cloud_topics/level_one/common/...` — green standalone
(incl. `chunk_data_source_test`).

[Design Doc](https://docs.google.com/document/d/1HmzBsabpu28Oh8d2PW_HoEQA4rB3Jo1jcj1D3Rsh5mo/edit?usp=sharing)

[PR 0](https://github.com/redpanda-data/redpanda/pull/30977) · [PR 1a](https://github.com/redpanda-data/redpanda/pull/31288) · **PR 1b** · [PR 1c](https://github.com/redpanda-data/redpanda/pull/31290) · [PR 1d](https://github.com/redpanda-data/redpanda/pull/31291) · [PR 2](https://github.com/redpanda-data/redpanda/pull/30887) · [PR 3](https://github.com/redpanda-data/redpanda/pull/30891) · [PR 4](https://github.com/redpanda-data/redpanda/pull/30892) · [PR 5](https://github.com/redpanda-data/redpanda/pull/30893) · [PR 6](https://github.com/redpanda-data/redpanda/pull/30894) · [PR 7](https://github.com/redpanda-data/redpanda/pull/30895) · [PR 8](https://github.com/redpanda-data/redpanda/pull/30896)
