### PR TITLE
bazel: Make PGO build use transitions

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -324,21 +324,10 @@ build:release --cxxopt=-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_NONE
 build:release --host_cxxopt=-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_NONE
 
 
-# Instrumentation/training step
-# /tmp is a dummy path as bazel expects an arg, we provide the actual path via
-# env var at run time
-build:pgo-instrument --config=lto --fdo_instrument=/tmp
-
-# Final/Optimization build step
-
-# We can't include this in here as bazel wants an absolute path (and we don't
-# really know that) as all the common dirs like /tmp are sandboxed so we can't
-# use them. We pass --fdo_optimize from task instead where the full path is known.
-# build:pgo-optimize --fdo_optimize=
-
 # bazel seems to pass -fprofile-correction unconditionally but that only exists
 # in gcc so need to make clang ignore it
-build:pgo-optimize --config=lto --copt -Wno-ignored-optimization-argument
+build:pgo --config=lto --copt -Wno-ignored-optimization-argument
+build:pgo --fdo_profile=//tools:redpanda_pgo_profile
 
 
 build:stamp --stamp --workspace_status_command=./bazel/stamp_vars.sh

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,7 +1,9 @@
 load("@buildifier_prebuilt//:rules.bzl", "buildifier")
+load("@rules_cc//cc:defs.bzl", "fdo_profile")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("//tools:pgo_bolt/pgo.bzl", "pgo_instrumented_target")
 
 exports_files(["run-cov"])
 
@@ -90,7 +92,6 @@ pkg_tar(
 # for dev_cluster.py such that we can run dev_cluster from within train_pgo
 py_binary(
     name = "train_pgo",
-    testonly = True,
     srcs = [
         "pgo_bolt/train_pgo.py",
     ],
@@ -103,7 +104,6 @@ py_binary(
 
 genrule(
     name = "pgo_profile",
-    testonly = True,
     srcs = [
         "//bazel/thirdparty:omb_minimal",
         "//bazel/thirdparty:minio",
@@ -128,6 +128,20 @@ genrule(
     tools = [
         ":train_pgo",
     ],
+    visibility = ["//visibility:public"],
+)
+
+pgo_instrumented_target(
+    name = "pgo_profile_for_optimization",
+    tags = ["manual"],
+    target = ":pgo_profile",
+    visibility = ["//visibility:public"],
+)
+
+fdo_profile(
+    name = "redpanda_pgo_profile",
+    profile = ":pgo_profile_for_optimization",
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 

--- a/tools/pgo_bolt/pgo.bzl
+++ b/tools/pgo_bolt/pgo.bzl
@@ -1,0 +1,38 @@
+"""Configuration transition for generating Redpanda's PGO profile."""
+
+def _pgo_instrument_transition_impl(_settings, _attr):
+    return {
+        "//command_line_option:fdo_instrument": "/tmp",
+        "//command_line_option:fdo_profile": None,
+    }
+
+_pgo_instrument_transition = transition(
+    implementation = _pgo_instrument_transition_impl,
+    inputs = [],
+    outputs = [
+        "//command_line_option:fdo_instrument",
+        "//command_line_option:fdo_profile",
+    ],
+)
+
+def _pgo_instrumented_target_impl(ctx):
+    target = ctx.attr.target[0]
+    info = target[DefaultInfo]
+    return [DefaultInfo(
+        files = info.files,
+        default_runfiles = info.default_runfiles,
+        data_runfiles = info.data_runfiles,
+    )]
+
+pgo_instrumented_target = rule(
+    implementation = _pgo_instrumented_target_impl,
+    attrs = {
+        "target": attr.label(
+            mandatory = True,
+            cfg = _pgo_instrument_transition,
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+)


### PR DESCRIPTION
Make the PGO build work via a single bazel invocation.

Add a transition file which handles the arg changes. It's relatively
small so I think it's worth it compared to the
two-invocations-via-external-script approach.

Should be a noop otherwise.

```
bazel build --config=release --config=pgo //src/v/redpanda
```

Depends on https://github.com/redpanda-data/vtools/pull/4385

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes


* none
