### PR TITLE
[CORE-4868] rptest: wait for retention progress in SI local retention test

### DIFF
--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -312,17 +312,34 @@ class ShadowIndexingLocalRetentionTest(RedpandaTest):
         )
 
         if expect_deletion:
-            # Wait up to just a bit longer than the 10s default config value
-            # for `cloud_storage_upload_loop_max_backoff_ms`.
             # the target segments limit is one higher than expected because
             # retention policy won't violate the target max size. that is: it
             # won't reclaim the last segment if it puts it over the edge.
-            wait_until(
-                lambda: self.segments_removed(self.default_retention_segments + 1),
-                timeout_sec=15,
-                backoff_sec=1,
-                err_msg="Segments were not removed",
-            )
+            target_segments = self.default_retention_segments + 1
+            num_segs = len(self.query_segments())
+
+            # Local retention on a remote write topic can only advance as fast
+            # as the segments are uploaded, and the first upload round also
+            # waits out the upload loop backoff
+            # (`cloud_storage_upload_loop_max_backoff_ms`, 10s by default) and
+            # the blocking topic manifest upload. A slow cloud storage backend
+            # pushes the first removal well past that, so we don't wait for the
+            # target with a single fixed timeout. Instead we reset the timeout
+            # every time a removal is observed: the test only fails if
+            # retention stops making progress.
+            timeout_sec = 60
+            while num_segs > target_segments:
+                wait_until(
+                    lambda: self.segments_removed(num_segs - 1),
+                    timeout_sec=timeout_sec,
+                    backoff_sec=2,
+                    err_msg=f"Segments were not removed, stuck at {num_segs} "
+                    f"segments, target is {target_segments}",
+                )
+                remaining = len(self.query_segments())
+                assert remaining < num_segs
+                num_segs = remaining
+                timeout_sec = 30
         else:
             with expect_exception(TimeoutError, lambda e: True):
                 wait_until(


### PR DESCRIPTION
`ShadowIndexingLocalRetentionTest.test_shadow_indexing_default_local_retention`
has been flaking on `cloud_storage_type=ABS` with
`TimeoutError: Segments were not removed`.

It is a test timeout problem, not a retention bug. On a remote write topic
local retention can only advance as fast as the segments are uploaded --
`archival_metadata_stm::max_removable_local_log_offset()` returns
`cloud_recoverable_offset()`, and `stm_hookset` mins across STMs, so local GC
runs at the speed of the archiver. That path has three serialization points,
all on the critical path of the first upload round:

* the upload loop is timer driven and backs off up to
  `cloud_storage_upload_loop_max_backoff_ms` (10s); ordinary produce does not
  signal `_wakeup_event`, only an explicit flush does
* `upload_topic_manifest()` is awaited inline before segment scheduling, so on
  partition 0 of a fresh topic it blocks the first round
* `ntp_archiver::_concurrency` is 4, and each round is a barrier (schedule 4,
  await all, replicate `add_segments`, upload manifest), so the 10 segments this
  test produces need 3 rounds

The docker CI environment runs a single shared, single threaded, MySQL backed
Azurite container, so ABS blob latency is far worse than MinIO's and varies a
lot under load. In the two failures I traced, 1MB segment PUTs took 5.4-14.0s
and one small topic manifest PUT took 9.3s. In both cases retention was working
and simply landed after the 15s deadline:

* build 87757: eviction reached the target 4.3s past the deadline (the test did
  observe the count drop from 10 to 6 before giving up)
* build 87451: a 9.3s topic manifest PUT delayed the first segment upload until
  after the deadline, so the count never moved

The test's own polling makes this worse: `segments_removed()` goes through
`node_storage()`, which shells out over ssh and runs `compute_storage.py`. One
such call took 10.3s, so the test burned two thirds of its budget on a single
observation and only sampled 3 times in 15s.

Rather than pick a bigger fixed timeout, wait for the segment count to keep
dropping and reset the timeout on every observed removal, so the test fails
only when retention stops making progress. This is the same approach 5858e7a782
took for `test_local_time_based_retention_is_overridden` in this class, which
carried the comment "we have seen long delays before the first removal occurs".

One deliberate difference from that commit: it opens with an unconditional
`assert num_segs > 1`, which is safe there because that test drives retention
down to a single segment. Here the target is 3, and on a fast backend enough
segments can be uploaded during `produce_total_bytes` that the target is
already met at the first sample, so an unconditional assert would introduce a
new flake. The `while num_segs > target_segments` condition covers that case.

Verified `ruff check`, `ruff format` and `type-check.sh check` pass, and
simulated the loop against both traced trajectories plus the edge cases
(already at target, single step to target, stall above target, nothing removed
at all): the two failing trajectories now pass and genuine stalls still fail.
The ducktape test itself was not run locally.

Note `test_shadow_indexing_non_default_local_retention` still has the same 15s
wait and the same root cause; it is left alone here.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none
