### PR TITLE
metrics: remove one-shot IMDS connect probe

### DIFF
--- a/src/v/metrics/instance_type_detector.cc
+++ b/src/v/metrics/instance_type_detector.cc
@@ -123,33 +123,6 @@ detect_instance(ss::abort_source& as) {
       .disable_metrics = net::metrics_disabled::yes,
       .disable_public_metrics = net::public_metrics_disabled::yes};
 
-    // Probe the metadata endpoint with a single bounded connect before issuing
-    // any request. The http client's request path retries the connection in a
-    // tight no-backoff loop (client::get_connected) that spins hot whenever the
-    // link-local address is unreachable, i.e. whenever we are not on EC2. A
-    // one-shot connect (base_transport makes exactly one attempt) lets us bail
-    // cleanly in that case instead of spinning, and avoids leaving a failed
-    // in-flight request to be reported as an abandoned failed future at
-    // shutdown.
-    {
-        net::base_transport probe{config, &ii_log};
-        // Cancel the probe promptly on shutdown: shutdown() fails any in-flight
-        // connect attempt so we don't wait out the timeout.
-        auto abort_sub = as.subscribe(
-          [&probe]() noexcept { probe.shutdown(); });
-        auto connected = co_await ss::coroutine::as_future(
-          probe.connect(ss::lowres_clock::now() + imds_timeout));
-        co_await probe.stop();
-        if (connected.failed()) {
-            auto ex = connected.get_exception();
-            vlog(
-              ii_log.debug,
-              "EC2 IMDS endpoint not reachable, assuming not on EC2: {}",
-              ex);
-            co_return std::nullopt;
-        }
-    }
-
     http::client client{config, as};
     auto fut = co_await ss::coroutine::as_future(
       query_ec2_instance_type(client, imds_timeout));


### PR DESCRIPTION
## What

Removes the one-shot IMDS connect probe from the cloud instance-type detector (`instance_type_detector.cc`).

## Why

The detector probed the EC2 IMDS endpoint with a single bounded `base_transport` connect before issuing any request. That was a workaround (added alongside the capacity-metrics feature in #30742) for `http::client::get_connected` retrying `connect()` in a tight **no-backoff loop** that spun hot whenever the link-local `169.254.169.254` address was unreachable, i.e. whenever we're not on EC2. The spin flooded the log and burned a shard's CPU for the whole timeout window (this was CORE-16451, and it caused the CI blowup in build #85550).

#30796 ("http: dial all resolved addresses in a single bounded attempt") replaced that retry loop with a single bounded dial pass, so the request path no longer spins on an unreachable endpoint. The probe is now redundant: off EC2, issuing the request directly fails fast via `query_ec2_instance_type`'s normal failure path, which already returns `std::nullopt` on failure.

JIRA: [CORE-16451](https://redpandadata.atlassian.net/browse/CORE-16451)

## Backports Required

- [x] none - not a bug fix (removes a now-unnecessary workaround)

## Release Notes

* none

[CORE-16451]: https://redpandadata.atlassian.net/browse/CORE-16451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ