### PR TITLE
`kgo-verifier`: truncate valid offsets when retries land at lower offsets

### DIFF
--- a/tests/go/kgo-verifier/pkg/worker/verifier/offset_ranges.go
+++ b/tests/go/kgo-verifier/pkg/worker/verifier/offset_ranges.go
@@ -69,19 +69,7 @@ func (ors *OffsetRanges) Insert(o int64) {
 		if o < last.Upper {
 			if ors.TolerateDataLoss {
 				// Truncate the ranges to the last offset.
-				for i, r := range ors.Ranges {
-					if o >= r.Lower && o < r.Upper {
-						// If the offset is within the range, truncate the range
-						// and remove all subsequent ranges.
-						ors.Ranges = ors.Ranges[:i+1]
-						ors.Ranges[i].Upper = o
-						break
-					} else if o < r.Lower {
-						// If the offset is before the range, truncate the range and all subsequent ranges.
-						ors.Ranges = ors.Ranges[:i]
-						break
-					}
-				}
+				ors.TruncateAt(o)
 			} else {
 				// TODO: more flexible structure for out of order inserts, at the moment
 				// we rely on franz-go callbacks being invoked in order.
@@ -97,6 +85,26 @@ func (ors *OffsetRanges) Insert(o int64) {
 	} else {
 		// Otherwise, create a new range.
 		ors.Ranges = append(ors.Ranges, OffsetRange{Lower: o, Upper: o + 1})
+	}
+}
+
+// TruncateAt invalidates all recorded offsets >= o, marking them as no
+// longer valid. Used when data loss is detected: the log was truncated
+// at o and offsets from there on may have been rewritten with different
+// records than the ones originally acked.
+func (ors *OffsetRanges) TruncateAt(o int64) {
+	for i, r := range ors.Ranges {
+		if o >= r.Lower && o < r.Upper {
+			// If the offset is within the range, truncate the range
+			// and remove all subsequent ranges.
+			ors.Ranges = ors.Ranges[:i+1]
+			ors.Ranges[i].Upper = o
+			break
+		} else if o < r.Lower {
+			// If the offset is before the range, truncate the range and all subsequent ranges.
+			ors.Ranges = ors.Ranges[:i]
+			break
+		}
 	}
 }
 
@@ -130,6 +138,10 @@ func (tors *TopicOffsetRanges) Insert(p int32, o int64) {
 
 func (tors *TopicOffsetRanges) Contains(p int32, o int64) bool {
 	return tors.PartitionRanges[p].Contains(o)
+}
+
+func (tors *TopicOffsetRanges) TruncateAt(p int32, o int64) {
+	tors.PartitionRanges[p].TruncateAt(o)
 }
 
 func (tors *TopicOffsetRanges) GetLastConsumableOffset(p int32) int64 {

--- a/tests/go/kgo-verifier/pkg/worker/verifier/producer_worker.go
+++ b/tests/go/kgo-verifier/pkg/worker/verifier/producer_worker.go
@@ -458,6 +458,16 @@ func (pw *ProducerWorker) produceInner(n int64) (int64, []BadOffset, error) {
 			} else if expectOffset != r.Offset {
 				log.Warnf("Produced at unexpected offset %d (expected %d) on partition %d", r.Offset, expectOffset, r.Partition)
 				pw.Status.OnBadOffset()
+				if pw.tolerateDataLoss && r.Offset < expectOffset {
+					// A retried record landing below its expected offset
+					// means the log was truncated and rewritten from
+					// r.Offset: previously acked offsets from there on no
+					// longer hold the records that were acked. Invalidate
+					// them so readers don't validate against stale data.
+					pw.Status.lock.Lock()
+					pw.validOffsets.TruncateAt(r.Partition, r.Offset)
+					pw.Status.lock.Unlock()
+				}
 				bad_offsets <- BadOffset{r.Partition, r.Offset}
 				errored = true
 				log.Debugf("errored = %t", errored)


### PR DESCRIPTION
With `tolerate-data-loss`, the `valid-offsets` map is only truncated when a successful ack lands below the current range upper bound. If enough in-flight records are retried after data loss, they re-fill the log past the old upper bound and the producer restarts producing above it, so the truncation never fires. Offsets between the log truncation point and the old upper bound then stay marked valid while physically holding retried records stamped for higher offsets, and readers panic with a bad read on data the producer already knew was rewritten.

Detect the loss on the produce ack path instead: a retried record acked below its expected offset is direct evidence the log was truncated and rewritten from that point, so invalidate all valid offsets from there on.

Seen in `RedpandaNodeOperationsSmokeTest` as a consumer panic on the write-caching topic after the failure injector killed the partition leader: https://ci-artifacts.dev.vectorized.cloud/production-devprod/redpanda/87770/019fa404-1e92-40f6-96fe-aa123c7b15af/vbuild/ducktape/results/2026-07-27--001/report.html

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none

