### PR TITLE
storage/tests: fix 1-byte no-flush appender bench

### DIFF
--- a/src/v/storage/tests/segment_appender_bench.cc
+++ b/src/v/storage/tests/segment_appender_bench.cc
@@ -66,7 +66,7 @@ struct appender_fixture {
 
 // 1 byte writes
 PERF_TEST_CN(appender_fixture, 1_byte_writes_no_flush) {
-    co_return co_await run_write_bench<1>(2_MiB, true);
+    co_return co_await run_write_bench<1>(2_MiB, false);
 }
 
 PERF_TEST_CN(appender_fixture, 1_byte_writes_flush) {


### PR DESCRIPTION
`1_byte_writes_no_flush` passed `do_flush = true`, making it identical to
`1_byte_writes_flush`. There was no 1-byte no-flush measurement at all; the
other three no_flush variants pass `false` correctly.

With the fix the two variants are clearly distinguishable:

```
test                                         iters            runtime     allocs      tasks       inst     cycles
appender_fixture.1_byte_writes_no_flush   50331648    19.87ns ± 0.11%      1.005      0.000     467.12       95.2
appender_fixture.1_byte_writes_flush       4194304   445.21ns ± 1.75%      8.004      0.001    3615.02     1079.3
```

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none