### PR TITLE
[CORE-16898] rpk shadow: add --config-file to update

### DIFF
--- a/src/go/rpk/pkg/cli/shadow/BUILD
+++ b/src/go/rpk/pkg/cli/shadow/BUILD
@@ -68,10 +68,12 @@ go_test(
         "@build_buf_gen_go_redpandadata_cloud_protocolbuffers_go//redpanda/api/controlplane/v1:controlplane",
         "@build_buf_gen_go_redpandadata_core_protocolbuffers_go//redpanda/core/admin/v2:admin",
         "@build_buf_gen_go_redpandadata_core_protocolbuffers_go//redpanda/core/common/v1:common",
+        "@com_github_spf13_afero//:afero",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",
         "@org_golang_google_protobuf//reflect/protoreflect",
         "@org_golang_google_protobuf//types/known/durationpb",
+        "@org_golang_google_protobuf//types/known/fieldmaskpb",
         "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )

--- a/src/go/rpk/pkg/cli/shadow/update.go
+++ b/src/go/rpk/pkg/cli/shadow/update.go
@@ -31,15 +31,38 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
+// redacted is the placeholder shown in place of a set password; the server
+// only reports whether a password is set, never its value.
+const redacted = "<redacted>"
+
+// cloudUpdateReplacePaths is the update mask covering every updatable field of
+// the cloud ShadowLinkUpdate message. The cloud API requires a mask, so
+// file-based updates use this to replace the entire configuration.
+var cloudUpdateReplacePaths = []string{
+	"client_options",
+	"topic_metadata_sync_options",
+	"consumer_offset_sync_options",
+	"security_sync_options",
+	"schema_registry_sync_options",
+}
+
 func newUpdateCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var cfgLocation string
 	cmd := &cobra.Command{
 		Use:   "update [LINK_NAME]",
 		Short: "Update a Shadow Link",
-		Long: `Update a Shadow Link.
+		Long: `Updates a Shadow Link.
 
-This command opens your default editor with the current Shadow Link
-configuration. Update the fields you want to change, save the file, and close
-the editor. The command applies only the changed fields to the Shadow Link.
+By default, this command opens your default editor with the current Shadow
+Link configuration. Update the fields you want to change, save the file, and
+close the editor. The command applies only the changed fields to the Shadow
+Link.
+
+Alternatively, use the '--config-file' flag to apply a configuration file
+directly without opening an editor, which is useful for scripted workflows. In
+this mode the file replaces the entire Shadow Link configuration: any field
+omitted from the file is reset to its default value. The name in the
+configuration file must match LINK_NAME.
 
 You cannot change the Shadow Link name. If you need to rename a Shadow Link,
 delete it and create a new one with the desired name.
@@ -48,8 +71,11 @@ The editor respects your EDITOR environment variable. If EDITOR is not set, the
 command uses 'vi' on Unix-like systems.
 `,
 		Example: `
-Update a Shadow Link configuration:
+Update a Shadow Link in your editor:
   rpk shadow update my-shadow-link
+
+Replace the entire Shadow Link configuration from a file:
+  rpk shadow update my-shadow-link --config-file shadow-link.yaml
 `,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -58,21 +84,28 @@ Update a Shadow Link configuration:
 			prof := cfg.VirtualProfile()
 			config.CheckExitServerlessAdmin(prof)
 
-			// This commands retrieves the current ShadowLink configuration from
-			// 2 different sources depending on whether it's for Cloud or SH.
-			// The user will be prompted for changes in their editor of choice,
-			// and we calculate the diff from it. At the end, we need to call
-			// the appropriate API to submit the update.
+			// The editor flow (default) diffs the current config and applies
+			// only the changed fields via a mask; --config-file replaces the
+			// entire configuration.
 			fromCloud := prof.CheckFromCloud()
+			fileMode := cfgLocation != ""
 			linkName := args[0]
 			var (
 				originalCfg *ShadowLinkConfig
+				updatedCfg  *ShadowLinkConfig
+				diff        []string
 				adminClient *rpadmin.AdminAPI
 				cloudClient *publicapi.CloudClientSet
 				cloudLinkID string
 			)
 
-			// First part: retrieve current configuration.
+			if fileMode {
+				updatedCfg, err = updatedConfigFromFile(fs, cfgLocation, linkName, fromCloud, prof.CloudCluster.ClusterID)
+				out.MaybeDieErr(err)
+			}
+
+			// Cloud always looks up the link to resolve its ID; editor mode
+			// also seeds the config from the current one.
 			if fromCloud {
 				cloudClient, err = publicapi.NewValidatedCloudClientSet(
 					cfg.DevOverrides().PublicAPIURL,
@@ -86,58 +119,67 @@ Update a Shadow Link configuration:
 				out.MaybeDie(err, "unable to find Shadow Link %q", linkName)
 
 				cloudLinkID = link.GetId()
-				originalCfg = cloudShadowLinkToConfig(link)
-
-				// Cloud uses secrets for passwords so we don't need to add the
-				// redacted string here.
+				if !fileMode {
+					// Cloud uses secrets for passwords, no redaction needed.
+					originalCfg = cloudShadowLinkToConfig(link)
+				}
 			} else {
 				adminClient, err = adminapi.NewClient(cmd.Context(), fs, prof)
 				out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-				link, err := adminClient.ShadowLinkService().GetShadowLink(cmd.Context(), connect.NewRequest(&adminv2.GetShadowLinkRequest{
-					Name: linkName,
-				}))
-				out.MaybeDie(err, "unable to get Redpanda Shadow Link information: %v", handleConnectError(err, "get", linkName))
+				if !fileMode {
+					link, err := adminClient.ShadowLinkService().GetShadowLink(cmd.Context(), connect.NewRequest(&adminv2.GetShadowLinkRequest{
+						Name: linkName,
+					}))
+					out.MaybeDie(err, "unable to get Redpanda Shadow Link information: %v", handleConnectError(err, "get", linkName))
 
-				shadowLink := link.Msg.GetShadowLink()
-				originalCfg = shadowLinkToConfig(shadowLink)
+					shadowLink := link.Msg.GetShadowLink()
+					originalCfg = shadowLinkToConfig(shadowLink)
 
-				addRedactedPasswordString(originalCfg, shadowLink)
+					addRedactedPasswordString(originalCfg, shadowLink)
+				}
 			}
 
-			// Second part: open editor and get updated configuration.
-			updatedCfg, err := rpkos.EditTmpYAMLFile(cmd.Context(), fs, originalCfg)
-			out.MaybeDie(err, "unable to edit Shadow Link configuration: %v", err)
+			// Editor mode: open the editor and calculate the diff.
+			if !fileMode {
+				updatedCfg, err = rpkos.EditTmpYAMLFile(cmd.Context(), fs, originalCfg)
+				out.MaybeDie(err, "unable to edit Shadow Link configuration: %v", err)
 
-			err = validateParsedShadowLinkConfig(updatedCfg)
-			out.MaybeDie(err, "invalid Shadow Link configuration: %v", err)
+				err = validateParsedShadowLinkConfig(updatedCfg)
+				out.MaybeDie(err, "invalid Shadow Link configuration: %v", err)
 
-			if updatedCfg.Name != originalCfg.Name {
-				out.Die("shadow link name cannot be changed; if you need to rename, please delete and recreate the shadow link")
+				if updatedCfg.Name != originalCfg.Name {
+					out.Die("shadow link name cannot be changed; if you need to rename, please delete and recreate the shadow link")
+				}
+
+				diff = diffConfigs(originalCfg, updatedCfg)
+				if diff == nil {
+					out.Exit("No changes detected")
+				}
 			}
 
-			// Third part: calculate diff.
-			diff := diffConfigs(originalCfg, updatedCfg)
-			if diff == nil {
-				out.Exit("No changes detected")
-			}
-
-			// Finally: submit the update request, for that we calculate the
-			// field mask from the diff.
+			// Submit the update request.
 			if fromCloud {
 				updatedSL := shadowLinkConfigToCloudUpdate(updatedCfg, cloudLinkID)
 
-				// Cloud proto doesn't have the "configurations" wrapper, so we
-				// need to strip it from the paths.
-				cloudDiff := make([]string, len(diff))
-				for i, path := range diff {
-					cloudDiff[i] = strings.TrimPrefix(path, "configurations.")
+				var cloudPaths []string
+				if fileMode {
+					err = validateCloudSecrets(cmd.Context(), prof, updatedCfg)
+					out.MaybeDie(err, "unable to validate cloud secrets: %v", err)
+
+					cloudPaths = cloudUpdateReplacePaths
+				} else {
+					// Cloud proto has no "configurations" wrapper; strip it.
+					cloudPaths = make([]string, len(diff))
+					for i, path := range diff {
+						cloudPaths[i] = strings.TrimPrefix(path, "configurations.")
+					}
 				}
 
-				fm, err := fieldmaskpb.New(updatedSL, cloudDiff...)
+				fm, err := fieldmaskpb.New(updatedSL, cloudPaths...)
 				out.MaybeDie(err, "unrecognized changed fields: %v; please report this with Redpanda Support", err)
 
-				zap.L().Sugar().Debugf("Requesting configuration update for: %v", strings.Join(cloudDiff, ", "))
+				zap.L().Sugar().Debugf("Requesting configuration update for: %v", strings.Join(cloudPaths, ", "))
 				op, err := cloudClient.ShadowLink.UpdateShadowLink(cmd.Context(), connect.NewRequest(&controlplanev1.UpdateShadowLinkRequest{
 					ShadowLink: updatedSL,
 					UpdateMask: fm,
@@ -156,12 +198,18 @@ Update a Shadow Link configuration:
 				spinner.Success(fmt.Sprintf("Successfully updated shadow link %q", linkName))
 				os.Exit(0)
 			}
-			// Self-hosted path
+			// Self-hosted path. In file mode the mask stays unset, which the
+			// server treats as a full replace.
 			updatedSL := shadowLinkConfigToProto(updatedCfg)
-			fm, err := fieldmaskpb.New(updatedSL, diff...)
-			out.MaybeDie(err, "unrecognized changed fields: %v; please report this with Redpanda Support", err)
+			var fm *fieldmaskpb.FieldMask
+			if fileMode {
+				zap.L().Sugar().Debug("Requesting full configuration replacement")
+			} else {
+				fm, err = fieldmaskpb.New(updatedSL, diff...)
+				out.MaybeDie(err, "unrecognized changed fields: %v; please report this with Redpanda Support", err)
 
-			zap.L().Sugar().Debugf("Requesting configuration update for: %v", strings.Join(diff, ", "))
+				zap.L().Sugar().Debugf("Requesting configuration update for: %v", strings.Join(diff, ", "))
+			}
 			_, err = adminClient.ShadowLinkService().UpdateShadowLink(cmd.Context(), connect.NewRequest(&adminv2.UpdateShadowLinkRequest{
 				ShadowLink: updatedSL,
 				UpdateMask: fm,
@@ -170,15 +218,39 @@ Update a Shadow Link configuration:
 			fmt.Printf("Successfully updated shadow link %q.\n", linkName)
 		},
 	}
+	cmd.Flags().StringVarP(&cfgLocation, "config-file", "c", "", "Path to a configuration file that replaces the entire Shadow Link configuration; use --help for details")
 	return cmd
+}
+
+// updatedConfigFromFile parses and validates a Shadow Link configuration file
+// for use in update; the config's name must match linkName, and on a cloud
+// profile a cloud_options.shadow_redpanda_id, if present, must match the
+// selected cluster.
+func updatedConfigFromFile(fs afero.Fs, path, linkName string, fromCloud bool, clusterID string) (*ShadowLinkConfig, error) {
+	slCfg, err := parseShadowLinkConfig(fs, path)
+	if err != nil {
+		return nil, err
+	}
+	// A placeholder copied from the editor flow would be stored verbatim.
+	if authPassword(slCfg.ClientOptions) == redacted || srAPIAuthPassword(slCfg.SchemaRegistrySyncOptions) == redacted {
+		return nil, fmt.Errorf("the configuration file contains the placeholder password %q; set the real password, or leave it empty to keep the existing one", redacted)
+	}
+	if err := validateParsedShadowLinkConfig(slCfg); err != nil {
+		return nil, fmt.Errorf("invalid Shadow Link configuration: %w", err)
+	}
+	if slCfg.Name != linkName {
+		return nil, fmt.Errorf("shadow link name %q in the configuration file does not match %q; the link name cannot be changed", slCfg.Name, linkName)
+	}
+	if co := slCfg.CloudOptions; fromCloud && co != nil && co.ShadowRedpandaID != clusterID {
+		return nil, fmt.Errorf("shadow_redpanda_id %q in the configuration file does not match the selected cluster %q", co.ShadowRedpandaID, clusterID)
+	}
+	return slCfg, nil
 }
 
 // if a password is set, replace it with a redacted value so user can provide
 // a change easily instead of writing the full password field. The server only
 // reports whether a password is set, never its value.
 func addRedactedPasswordString(cfg *ShadowLinkConfig, link *adminv2.ShadowLink) {
-	const redacted = "<redacted>"
-
 	cfgs := link.GetConfigurations()
 	if cfgs.GetClientOptions().GetAuthenticationConfiguration().GetScramConfiguration().GetPasswordSet() {
 		if co := cfg.ClientOptions; co != nil {

--- a/src/go/rpk/pkg/cli/shadow/update_test.go
+++ b/src/go/rpk/pkg/cli/shadow/update_test.go
@@ -13,7 +13,10 @@ import (
 	"testing"
 	"time"
 
+	controlplanev1 "buf.build/gen/go/redpandadata/cloud/protocolbuffers/go/redpanda/api/controlplane/v1"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 func TestDiffConfigs(t *testing.T) {
@@ -311,6 +314,173 @@ func TestDiffConfigs(t *testing.T) {
 			got := diffConfigs(tt.original, tt.updated)
 
 			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCloudUpdateReplacePaths(t *testing.T) {
+	_, err := fieldmaskpb.New(&controlplanev1.ShadowLinkUpdate{}, cloudUpdateReplacePaths...)
+	require.NoError(t, err)
+
+	// The replace mask must cover every updatable field of ShadowLinkUpdate;
+	// if the cloud API grows a new option group it must be added to the mask.
+	fields := (&controlplanev1.ShadowLinkUpdate{}).ProtoReflect().Descriptor().Fields()
+	var want []string
+	for i := 0; i < fields.Len(); i++ {
+		if name := string(fields.Get(i).Name()); name != "id" {
+			want = append(want, name)
+		}
+	}
+	require.ElementsMatch(t, want, cloudUpdateReplacePaths)
+}
+
+func TestUpdatedConfigFromFile(t *testing.T) {
+	tests := []struct {
+		name      string
+		contents  string // written to the config file path, unless noFile is set
+		noFile    bool
+		linkName  string
+		fromCloud bool
+		clusterID string
+		expErr    string
+		exp       *ShadowLinkConfig
+	}{
+		{
+			name: "valid config with matching name",
+			contents: `name: my-link
+client_options:
+  bootstrap_servers:
+    - localhost:9092
+`,
+			linkName: "my-link",
+			exp: &ShadowLinkConfig{
+				Name: "my-link",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"localhost:9092"},
+				},
+			},
+		},
+		{
+			name: "non-placeholder password is accepted",
+			contents: `name: my-link
+client_options:
+  bootstrap_servers:
+    - localhost:9092
+  authentication_configuration:
+    scram_configuration:
+      username: user
+      password: hunter2
+`,
+			linkName: "my-link",
+			exp: &ShadowLinkConfig{
+				Name: "my-link",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"localhost:9092"},
+					AuthenticationConfiguration: &AuthenticationConfiguration{
+						ScramConfiguration: &ScramConfiguration{
+							Username: "user",
+							Password: "hunter2",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "name mismatch",
+			contents: `name: other-link
+client_options:
+  bootstrap_servers:
+    - localhost:9092
+`,
+			linkName: "my-link",
+			expErr:   "does not match",
+		},
+		{
+			name:     "empty file",
+			contents: "",
+			linkName: "my-link",
+			expErr:   "the Shadow Link name is required",
+		},
+		{
+			name:     "missing file",
+			noFile:   true,
+			linkName: "my-link",
+			expErr:   "unable to read",
+		},
+		{
+			name: "redacted scram password",
+			contents: `name: my-link
+client_options:
+  bootstrap_servers:
+    - localhost:9092
+  authentication_configuration:
+    scram_configuration:
+      username: user
+      password: <redacted>
+`,
+			linkName: "my-link",
+			expErr:   "placeholder password",
+		},
+		{
+			name: "redacted schema registry password",
+			contents: `name: my-link
+client_options:
+  bootstrap_servers:
+    - localhost:9092
+schema_registry_sync_options:
+  shadow_schema_registry_api:
+    source_url: https://source-sr:8081
+    auth_options:
+      basic:
+        username: user
+        password: <redacted>
+`,
+			linkName: "my-link",
+			expErr:   "placeholder password",
+		},
+		{
+			name: "cloud shadow_redpanda_id mismatch",
+			contents: `name: my-link
+cloud_options:
+  shadow_redpanda_id: other-cluster
+`,
+			linkName:  "my-link",
+			fromCloud: true,
+			clusterID: "my-cluster",
+			expErr:    "does not match the selected cluster",
+		},
+		{
+			name: "cloud shadow_redpanda_id match",
+			contents: `name: my-link
+cloud_options:
+  shadow_redpanda_id: my-cluster
+`,
+			linkName:  "my-link",
+			fromCloud: true,
+			clusterID: "my-cluster",
+			exp: &ShadowLinkConfig{
+				Name: "my-link",
+				CloudOptions: &CloudShadowLinkOptions{
+					ShadowRedpandaID: "my-cluster",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			const path = "/shadow-link.yaml"
+			if !tt.noFile {
+				require.NoError(t, afero.WriteFile(fs, path, []byte(tt.contents), 0o644))
+			}
+
+			cfg, err := updatedConfigFromFile(fs, path, tt.linkName, tt.fromCloud, tt.clusterID)
+			if tt.expErr != "" {
+				require.ErrorContains(t, err, tt.expErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.exp, cfg)
 		})
 	}
 }

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1368,6 +1368,12 @@ class RpkTool:
                 args.append("--no-confirm")
             return self._run_shadow(args)
 
+    def shadow_update(self, name: str, config: dict[str, Any]) -> str:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as tf:
+            yaml.safe_dump(config, tf)
+            tf.flush()
+            return self._run_shadow(["update", name, "-c", tf.name])
+
     def shadow_status(self, name: str, output_format: str = "json") -> Any:
         return self._run_shadow(["status", name, "--print-all"], output_format)
 

--- a/tests/rptest/tests/rpk_shadow_link_test.py
+++ b/tests/rptest/tests/rpk_shadow_link_test.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import copy
 from typing import Any
 
 from ducktape.utils.util import wait_until
@@ -15,26 +16,68 @@ from rptest.clients.rpk import RPKACLInput, RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import TestContext, cluster
 from rptest.services.multi_cluster_services import SecondaryClusterArgs
-from rptest.services.redpanda import SchemaRegistryConfig
+from rptest.services.redpanda import SchemaRegistryConfig, SecurityConfig
 from rptest.tests.cluster_linking_test_base import ShadowLinkTestBase
 
 
-class RpkShadowLinkTest(ShadowLinkTestBase):
+class RpkShadowLinkTestBase(ShadowLinkTestBase):
+    """Shared config and helpers for rpk shadow-link tests. Holds no test
+    methods so subclasses with different security topologies do not re-run
+    each other's tests."""
+
     LINK_NAME = "rpk-test-link"
     CONSUMER_GROUP = "shadow-group"
 
-    def __init__(self, test_context: TestContext, *args: Any, **kwargs: Any):
+    def __init__(
+        self,
+        test_context: TestContext,
+        *args: Any,
+        security: SecurityConfig | None = None,
+        **kwargs: Any,
+    ):
+        # Only pass security through when set; RedpandaService distinguishes
+        # an unset security config from an explicit None.
+        secondary_kwargs: dict[str, Any] = {
+            "schema_registry_config": SchemaRegistryConfig(),
+        }
+        if security is not None:
+            secondary_kwargs["security"] = security
+            kwargs["security"] = security
         super().__init__(
             test_context=test_context,
             num_brokers=3,
-            secondary_cluster_args=SecondaryClusterArgs(
-                schema_registry_config=SchemaRegistryConfig()
-            ),
+            secondary_cluster_args=SecondaryClusterArgs(**secondary_kwargs),
             schema_registry_config=SchemaRegistryConfig(),
             *args,
             **kwargs,
         )
 
+    def _topic_filters(self, rpk: RpkTool) -> list[dict[str, str]]:
+        describe = rpk.shadow_describe(self.LINK_NAME)
+        opts = describe.get("topic_metadata_sync_options") or {}
+        return opts.get("auto_create_shadow_topic_filters") or []
+
+    def _client_auth(self, rpk: RpkTool) -> dict[str, Any]:
+        describe = rpk.shadow_describe(self.LINK_NAME)
+        opts = describe.get("client_options") or {}
+        return opts.get("authentication_configuration") or {}
+
+    def _wait_link_active(self, rpk: RpkTool) -> None:
+        def link_active() -> bool:
+            status = rpk.shadow_status(self.LINK_NAME)
+            self.logger.debug(f"rpk shadow status: {status}")
+            return status["overview"]["state"] == "ACTIVE"
+
+        wait_until(
+            link_active,
+            timeout_sec=60,
+            backoff_sec=2,
+            retry_on_exc=True,
+            err_msg="shadow link did not reach ACTIVE state",
+        )
+
+
+class RpkShadowLinkTest(RpkShadowLinkTestBase):
     @cluster(num_nodes=6)  # 3 target + 3 source brokers
     def test_shadow_link_full_sync(self):
         """
@@ -96,6 +139,48 @@ class RpkShadowLinkTest(ShadowLinkTestBase):
             retry_on_exc=True,
             err_msg="role was not synced to the shadow cluster",
         )
+
+    @cluster(num_nodes=6)  # 3 target + 3 source brokers
+    def test_shadow_update_config_file_topic_filters(self):
+        """
+        'rpk shadow update --config-file' replaces the entire configuration
+        rather than diffing changed fields. Grow
+        topic_metadata_sync_options.auto_create_shadow_topic_filters from one
+        filter to two and confirm the replacement lands.
+        """
+        rpk = self.target_cluster_rpk
+
+        one_filter = [
+            {"pattern_type": "LITERAL", "filter_type": "INCLUDE", "name": "topic-a"},
+        ]
+        two_filters = one_filter + [
+            {"pattern_type": "PREFIX", "filter_type": "INCLUDE", "name": "topic-b-"},
+        ]
+
+        rpk.shadow_create(self._filters_link_config(one_filter))
+        self._wait_link_active(rpk)
+        assert self._topic_filters(rpk) == one_filter, self._topic_filters(rpk)
+
+        rpk.shadow_update(self.LINK_NAME, self._filters_link_config(two_filters))
+
+        wait_until(
+            lambda: self._topic_filters(rpk) == two_filters,
+            timeout_sec=30,
+            backoff_sec=1,
+            retry_on_exc=True,
+            err_msg="updated topic filters were not applied",
+        )
+
+    def _filters_link_config(self, filters: list[dict[str, str]]) -> dict[str, Any]:
+        return {
+            "name": self.LINK_NAME,
+            "client_options": {
+                "bootstrap_servers": self.source_cluster_service.brokers_list(),
+            },
+            "topic_metadata_sync_options": {
+                "auto_create_shadow_topic_filters": filters,
+            },
+        }
 
     def _full_link_config(self) -> dict[str, Any]:
         """
@@ -263,16 +348,83 @@ class RpkShadowLinkTest(ShadowLinkTestBase):
         self.logger.debug(f"target role {expected['role']} members: {members}")
         return expected["member"] in members
 
-    def _wait_link_active(self, rpk: RpkTool) -> None:
-        def link_active() -> bool:
-            status = rpk.shadow_status(self.LINK_NAME)
-            self.logger.debug(f"rpk shadow status: {status}")
-            return status["overview"]["state"] == "ACTIVE"
 
-        wait_until(
-            link_active,
-            timeout_sec=60,
-            backoff_sec=2,
-            retry_on_exc=True,
-            err_msg="shadow link did not reach ACTIVE state",
+class RpkShadowLinkAuthTest(RpkShadowLinkTestBase):
+    """Password-preservation on 'rpk shadow update --config-file'. This needs a
+    SASL-authenticated link: CreateShadowLink runs a source preflight check, so
+    the link must authenticate against the source with real credentials."""
+
+    def __init__(self, test_context: TestContext, *args: Any, **kwargs: Any):
+        security = SecurityConfig()
+        security.enable_sasl = True
+        super().__init__(test_context, security=security, *args, **kwargs)
+
+    @cluster(num_nodes=6)  # 3 target + 3 source brokers
+    def test_shadow_update_config_file_preserves_password(self):
+        """
+        A file-based update replaces the whole configuration, but an empty
+        SCRAM password with the username still set must preserve the existing
+        password rather than clear it. If it were cleared, the link's source
+        preflight would fail to re-authenticate on the update.
+        """
+        rpk = self.target_cluster_rpk
+        # Both clusters bootstrap the same superuser; using it as the link
+        # principal lets the source preflight authenticate successfully.
+        su = self.redpanda.SUPERUSER_CREDENTIALS
+
+        base: dict[str, Any] = {
+            "name": self.LINK_NAME,
+            "client_options": {
+                "bootstrap_servers": self.source_cluster_service.brokers_list(),
+                "authentication_configuration": {
+                    "scram_configuration": {
+                        "username": su.username,
+                        "password": su.password,
+                        "scram_mechanism": su.algorithm,
+                    },
+                },
+            },
+            "topic_metadata_sync_options": {
+                "auto_create_shadow_topic_filters": [
+                    {
+                        "pattern_type": "LITERAL",
+                        "filter_type": "INCLUDE",
+                        "name": "topic-a",
+                    },
+                ],
+            },
+        }
+        rpk.shadow_create(base)
+        self._wait_link_active(rpk)
+
+        auth = self._client_auth(rpk)
+        assert auth.get("password_set") is True, auth
+        assert auth.get("username") == su.username, auth
+        # Record when the password was set so we can prove it is not rewritten
+        # by the update below.
+        password_set_at = auth.get("password_set_at")
+        assert password_set_at, auth
+
+        # Full-replace update with an empty password: the server keeps the
+        # existing password because the username is still set. The extra filter
+        # proves the replace took effect, and reaching ACTIVE again proves the
+        # preserved password still authenticates to the source.
+        updated: dict[str, Any] = copy.deepcopy(base)
+        updated["client_options"]["authentication_configuration"][
+            "scram_configuration"
+        ]["password"] = ""
+        updated["topic_metadata_sync_options"][
+            "auto_create_shadow_topic_filters"
+        ].append(
+            {"pattern_type": "PREFIX", "filter_type": "INCLUDE", "name": "topic-b-"}
         )
+        rpk.shadow_update(self.LINK_NAME, updated)
+        self._wait_link_active(rpk)
+
+        auth = self._client_auth(rpk)
+        assert auth.get("password_set") is True, auth
+        assert auth.get("username") == su.username, auth
+        # The set-at timestamp is unchanged: the password was preserved, not
+        # cleared and re-set (which would bump it).
+        assert auth.get("password_set_at") == password_set_at, auth
+        assert len(self._topic_filters(rpk)) == 2, self._topic_filters(rpk)


### PR DESCRIPTION
rpk shadow update now accepts --config-file to
apply a configuration file directly, without
opening an editor, mirroring create. This enables
scripted workflows such as credential rotation.

Unlike the editor flow, which diffs and sends only the changed fields, the file replaces the entire
configuration: omitted fields reset to defaults.
On self-hosted the update mask is left unset so
the server performs a full replace; cloud requires a mask, so a replace-all mask over the top-level
option groups is sent instead.

The file name must match the target link, and a
literal <redacted> placeholder password is
rejected so it is not stored verbatim. Leaving a
password or TLS key empty while its username or
cert is set preserves the existing value.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes


### Features

* rpk shadow update now accepts a --config-file flag to apply a configuration file directly.