### PR TITLE
[CORE-13122] tests: allow for consumer startup in __consumer_offsets wait

### DIFF
--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -127,7 +127,7 @@ class ConsumerGroupTest(RedpandaTest):
 
         for c in consumers:
             c.start()
-        wait_until(self.co_topic_is_ready, 10, 1)
+        self.wait_for_co_topic()
 
         rpk = RpkTool(self.redpanda)
 
@@ -140,6 +140,18 @@ class ConsumerGroupTest(RedpandaTest):
 
     def co_topic_is_ready(self):
         return len(self.client().describe_topic("__consumer_offsets").partitions) > 0
+
+    def wait_for_co_topic(self):
+        # __consumer_offsets is created lazily, as a side effect of the first
+        # FindCoordinator request, which is only sent once a consumer has
+        # finished starting up. The budget therefore has to cover JVM startup
+        # of the CLI consumers on a busy machine, not just topic creation.
+        wait_until(
+            self.co_topic_is_ready,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="__consumer_offsets topic was not created",
+        )
 
     def consumed_at_least(consumers, count):
         return all([c._message_cnt > count for c in consumers])
@@ -300,7 +312,7 @@ class ConsumerGroupTest(RedpandaTest):
     def wait_for_members(self, group, members_count):
         rpk = RpkTool(self.redpanda)
 
-        wait_until(self.co_topic_is_ready, 10, 1)
+        self.wait_for_co_topic()
 
         def group_stable():
             rpk_group = rpk.group_describe(group)
@@ -658,7 +670,7 @@ class ConsumerGroupTest(RedpandaTest):
         )
 
         consumer1.start()
-        wait_until(self.co_topic_is_ready, 10, 1)
+        self.wait_for_co_topic()
 
         self.wait_for_members(group, 1)
 

--- a/tests/rptest/tests/rpk_group_test.py
+++ b/tests/rptest/tests/rpk_group_test.py
@@ -100,6 +100,17 @@ class RpkGroupCommandsTest(RedpandaTest):
     def co_topic_is_ready(self):
         return len(self.client().describe_topic("__consumer_offsets").partitions) > 0
 
+    def wait_for_co_topic(self):
+        # __consumer_offsets is created lazily, as a side effect of the first
+        # FindCoordinator request, which is only sent once the consumer has
+        # finished starting up.
+        wait_until(
+            self.co_topic_is_ready,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="__consumer_offsets topic was not created",
+        )
+
     @cluster(num_nodes=5)
     def test_group_describe(self):
         """
@@ -112,7 +123,7 @@ class RpkGroupCommandsTest(RedpandaTest):
         consumer = RpkConsumer(self._ctx, self.redpanda, topic, group=group_1)
         consumer.start()
 
-        wait_until(self.co_topic_is_ready, 10, 1)
+        self.wait_for_co_topic()
 
         rpk = RpkTool(self.redpanda)
 


### PR DESCRIPTION
## Problem

`ConsumerGroupTest.test_basic_group_join` is flaky in CI with a bare `TimeoutError('')` at `consumer_group_test.py:130`:

```
File "/home/ubuntu/redpanda/tests/rptest/tests/consumer_group_test.py", line 123, in create_consumers
    wait_until(self.co_topic_is_ready, 10, 1)
ducktape.errors.TimeoutError
```

The wait sits immediately after starting the `kafka-console-consumer` based consumers, and `__consumer_offsets` is created **lazily** by `kafka::group_initializer::assure_topic_exists`, reached from the **FindCoordinator** handler (`src/v/kafka/server/handlers/find_coordinator.cc:181`). `auto_create_topics_enabled` is `false` under ducktape, so the metadata auto-create path is gated off and the test's own `describe_topic("__consumer_offsets")` cannot create the topic.

So the 10s budget really had to cover *JVM startup of the CLI consumers* plus FindCoordinator plus creating 16 partitions at RF 3 — not just topic creation. On a loaded CI machine the JVM startup alone exceeds it. The wait also passed no `err_msg`, which is why the failure carries no diagnostic at all.

## Fix

Replace the four `wait_until(self.co_topic_is_ready, 10, 1)` call sites (3 in `consumer_group_test.py`, 1 in `rpk_group_test.py`) with a `wait_for_co_topic()` helper: 60s timeout — matching the group-stable wait that immediately follows — plus an error message and a comment recording the dependency on consumer startup.

The happy path is unaffected: the wait returns as soon as the topic is visible (~1s locally), so this only changes how long a stuck cluster is given before failing, and what it reports.

## Verification

Local docker ducktape (`tools/dt`, redpanda v26.2.1-rc4). Node allocation is deterministic — brokers land on `docker-rp-1..3`, the two CLI consumers on `docker-rp-4/rp-5` — so the CI condition can be reproduced by throttling just the consumer nodes:

```
docker update --cpus=0.10 docker-rp-4 docker-rp-5
```

- **Before the fix, throttled**: fails with the byte-identical CI traceback (line 130 → `wait_until` → `TimeoutError('')`), `__consumer_offsets` not ready after 10.9s.
- **After the fix, throttled**: PASS.
- **Unthrottled**: 5/5 pass — `test_basic_group_join` (both parametrizations), `test_consumer_rejoin` (both), `rpk_group_test::test_group_describe`.
- Instrumented measurement on an idle host: topic visible **1.2s** after consumer start, group `Stable` at 7.4s — i.e. the old budget had well under an order of magnitude of headroom.
- `tools/type-checking/type-check.sh` and `ruff format`/`check`: clean.

CORE-13122

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none
