### PR TITLE
[CORE-13122] tests: allow for consumer startup in __consumer_offsets wait

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1112,7 +1112,7 @@ class RpkTool:
                 )
                 wait_until(
                     lambda: "__consumer_offsets" in self.list_topics(internal=True),
-                    timeout_sec=10,
+                    timeout_sec=30,
                     backoff_sec=1,
                     err_msg="__consumer_offsets topic not created",
                 )

--- a/tests/rptest/services/kafka_cli_consumer.py
+++ b/tests/rptest/services/kafka_cli_consumer.py
@@ -108,7 +108,10 @@ class KafkaCliConsumer(BackgroundThreadService):
     def wait_for_messages(self, messages, timeout=30):
         wait_until(lambda: self.message_cnt() >= messages, timeout, backoff_sec=2)
 
-    def wait_for_started(self, timeout=10):
+    def wait_for_started(self, timeout=60):
+        # The budget covers ssh plus JVM startup of the console consumer, which
+        # on a busy machine takes considerably longer than the process itself
+        # suggests.
         def all_started():
             return all(
                 [
@@ -117,7 +120,12 @@ class KafkaCliConsumer(BackgroundThreadService):
                 ]
             )
 
-        wait_until(all_started, timeout, backoff_sec=1)
+        wait_until(
+            all_started,
+            timeout,
+            backoff_sec=1,
+            err_msg="console consumer did not start",
+        )
 
     def stop_node(self, node):
         self._stopping.set()

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -127,7 +127,7 @@ class ConsumerGroupTest(RedpandaTest):
 
         for c in consumers:
             c.start()
-        wait_until(self.co_topic_is_ready, 10, 1)
+        self.wait_for_co_topic()
 
         rpk = RpkTool(self.redpanda)
 
@@ -140,6 +140,18 @@ class ConsumerGroupTest(RedpandaTest):
 
     def co_topic_is_ready(self):
         return len(self.client().describe_topic("__consumer_offsets").partitions) > 0
+
+    def wait_for_co_topic(self):
+        # __consumer_offsets is created lazily, as a side effect of the first
+        # FindCoordinator request, which is only sent once a consumer has
+        # finished starting up. The budget therefore has to cover JVM startup
+        # of the CLI consumers on a busy machine, not just topic creation.
+        wait_until(
+            self.co_topic_is_ready,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="__consumer_offsets topic was not created",
+        )
 
     def consumed_at_least(consumers, count):
         return all([c._message_cnt > count for c in consumers])
@@ -300,7 +312,7 @@ class ConsumerGroupTest(RedpandaTest):
     def wait_for_members(self, group, members_count):
         rpk = RpkTool(self.redpanda)
 
-        wait_until(self.co_topic_is_ready, 10, 1)
+        self.wait_for_co_topic()
 
         def group_stable():
             rpk_group = rpk.group_describe(group)
@@ -658,7 +670,7 @@ class ConsumerGroupTest(RedpandaTest):
         )
 
         consumer1.start()
-        wait_until(self.co_topic_is_ready, 10, 1)
+        self.wait_for_co_topic()
 
         self.wait_for_members(group, 1)
 

--- a/tests/rptest/tests/rpk_group_test.py
+++ b/tests/rptest/tests/rpk_group_test.py
@@ -100,6 +100,17 @@ class RpkGroupCommandsTest(RedpandaTest):
     def co_topic_is_ready(self):
         return len(self.client().describe_topic("__consumer_offsets").partitions) > 0
 
+    def wait_for_co_topic(self):
+        # __consumer_offsets is created lazily, as a side effect of the first
+        # FindCoordinator request, which is only sent once the consumer has
+        # finished starting up.
+        wait_until(
+            self.co_topic_is_ready,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="__consumer_offsets topic was not created",
+        )
+
     @cluster(num_nodes=5)
     def test_group_describe(self):
         """
@@ -112,7 +123,7 @@ class RpkGroupCommandsTest(RedpandaTest):
         consumer = RpkConsumer(self._ctx, self.redpanda, topic, group=group_1)
         consumer.start()
 
-        wait_until(self.co_topic_is_ready, 10, 1)
+        self.wait_for_co_topic()
 
         rpk = RpkTool(self.redpanda)
 


### PR DESCRIPTION
## Problem

`ConsumerGroupTest.test_basic_group_join` is flaky in CI with a bare `TimeoutError('')` at `consumer_group_test.py:130`:

```
File "/home/ubuntu/redpanda/tests/rptest/tests/consumer_group_test.py", line 123, in create_consumers
    wait_until(self.co_topic_is_ready, 10, 1)
ducktape.errors.TimeoutError
```

The wait sits immediately after starting the `kafka-console-consumer` based consumers, and `__consumer_offsets` is created **lazily** by `kafka::group_initializer::assure_topic_exists`, reached from the **FindCoordinator** handler (`src/v/kafka/server/handlers/find_coordinator.cc:181`). `auto_create_topics_enabled` is `false` under ducktape, so the metadata auto-create path is gated off and the test's own `describe_topic("__consumer_offsets")` cannot create the topic.

So the 10s budget really had to cover *JVM startup of the CLI consumers* plus FindCoordinator plus creating 16 partitions at RF 3 — not just topic creation. On a loaded CI machine the JVM startup alone exceeds it. The wait also passed no `err_msg`, which is why the failure carries no diagnostic at all.

## Scope: this is not a single-test flake

The same wait exists at four call sites, and CI has already hit all four. Searching Jira for `co_topic_is_ready` turns up three sibling tickets with an identical traceback, each pointing at a different one of those sites:

| Ticket | Test | Call site |
| --- | --- | --- |
| CORE-13122 | `ConsumerGroupTest.test_basic_group_join` | `create_consumers` |
| CORE-15510 | `ConsumerGroupTest.test_last_member_expiry_with_pending_member` | `wait_for_members` |
| CORE-15775 | `ConsumerGroupTest.test_consumer_static_member_update` | `test_consumer_static_member_update` |
| CORE-13194 | `RpkGroupCommandsTest.test_group_describe` | `rpk_group_test.py` |

This PR fixes all four sites, so it should close the three sibling tickets as well (CORE-15510 is backlogged; CORE-15775 and CORE-13194 were auto-closed as "will not implement" and would come back on the next hit).

## Fix

**Commit 1** replaces the four `wait_until(self.co_topic_is_ready, 10, 1)` call sites (3 in `consumer_group_test.py`, 1 in `rpk_group_test.py`) with a `wait_for_co_topic()` helper: 60s timeout — matching the group-stable wait that immediately follows — plus an error message and a comment recording the dependency on consumer startup.

**Commit 2** covers the two remaining timeouts in the same family:

- `KafkaCliConsumer.wait_for_started()` allowed 10s for the console consumer to appear — the same JVM startup budget — and reported nothing on failure. Now 60s, with a message.
- The `__consumer_offsets` wait inside `RpkTool.group_describe` (its fallback for the not-yet-created topic) goes from 10s to 30s. There the creation has already been triggered by rpk's own FindCoordinator, so it only has to cover reconciliation and metadata propagation.

The happy path is unaffected: each wait returns as soon as its condition holds (~1s locally), so this only changes how long a stuck cluster is given before failing, and what it reports.

## Verification

Local docker ducktape (`tools/dt`, redpanda v26.2.1-rc4). Node allocation is deterministic — brokers land on `docker-rp-1..3`, the two CLI consumers on `docker-rp-4/rp-5` — so the CI condition can be reproduced by throttling just the consumer nodes:

```
docker update --cpus=0.10 docker-rp-4 docker-rp-5
```

- **Before the fix, throttled**: fails with the byte-identical CI traceback (line 130 → `wait_until` → `TimeoutError('')`), `__consumer_offsets` not ready after 10.9s. Repeated 15× in one session: **7/15 FAIL (47%)**, every failure at that wait.
- **After the fix, throttled**: the same test repeated 15×: **15/15 PASS**, per-run times 33–47s, so the 60s budget is never approached.
- **Sibling tests, throttled**: `test_consumer_static_member_update` (CORE-15775) fails pre-fix at its own `co_topic_is_ready` frame and passes post-fix; same for `test_last_member_expiry_with_pending_member` (CORE-15510) via `wait_for_members`. `rpk_group_test::test_group_describe` (CORE-13194) could **not** be made to fail this way — 15/15 pass pre-fix even at `--cpus=0.03`, because `RpkConsumer` is the Go `rpk` binary and reaches FindCoordinator ~2s after start. Its call site is fixed regardless, and the wait now reports `__consumer_offsets topic was not created` instead of an empty `TimeoutError('')`.
- **Unthrottled, after both commits**: 5/5 pass — `test_consumer_rejoin` (both parametrizations), `test_consumer_static_member_update`, `test_last_member_expiry_with_pending_member`, `rpk_group_test::test_group_describe`, i.e. the tests from the sibling tickets. An earlier 5/5 run covered `test_basic_group_join` (both parametrizations) as well.
- Instrumented measurement on an idle host: topic visible **1.2s** after consumer start, group `Stable` at 7.4s — the old budget had well under an order of magnitude of headroom.
- `tools/type-checking/type-check.sh` and `ruff format`/`check`: clean.

CORE-13122

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none

