### PR TITLE
[v26.2.x] `ct/l1`: add `cloud_topics_leveling_max_ranges_per_partition` and some incremental base work

### DIFF
--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -1455,6 +1455,9 @@ db_domain_manager::do_get_leveling_info(
             }
             builder.process_extent(
               base, extent.val.last_offset, extent.val.len);
+            if (builder.is_full()) {
+                break;
+            }
         }
     }
     co_return rpc::get_leveling_info_reply{

--- a/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
+++ b/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
@@ -1157,6 +1157,382 @@ TEST_F(DbDomainManagerTest, TestGarbageCollectionDeletionDelay) {
       30s, [&] { return all_objects_missing(object_ids); });
 }
 
+namespace {
+// A "partial" compaction commit: a batch of the job's output objects with
+// an empty compaction update. This is the existing compact_objects shape
+// the sink's no-metadata fallback has always used: the epoch is validated
+// and bumped, the extents are replaced span-exact, and no compaction state
+// is recorded. Bumping the epoch on every batch is what fences stale
+// rewriters (straggler compactions, leveling jobs with old read snapshots)
+// out of the job's data for the remainder of the run.
+l1_rpc::compact_objects_request make_partial_compact(
+  const model::topic_id_partition& tp,
+  chunked_vector<new_object> objects,
+  partition_state::compaction_epoch_t expected_epoch) {
+    l1_rpc::compact_objects_request req;
+    req.metastore_partition = model::partition_id(0);
+    req.new_objects = std::move(objects);
+    compaction_state_update csu;
+    csu.cleaned_at = model::timestamp::missing();
+    csu.expected_compaction_epoch = expected_epoch;
+    req.compaction_updates.emplace(tp, std::move(csu));
+    return req;
+}
+} // namespace
+
+// Models a long-running compaction job under the incremental-commit
+// pattern: the job lands each batch of output objects via a partial
+// compaction commit as it is produced (validated span-exact and bumping
+// the compaction epoch every time), then finishes with a metadata-only
+// compact_objects() carrying no objects — just the cleaned ranges,
+// recorded against the epoch its own partials advanced. The job may run
+// arbitrarily longer than the preregistration TTL: by the time the GC
+// could expire anything, the objects are already committed. Together with
+// TestReplaceObjectsAfterPreregistrationExpiry (where a single-shot commit
+// of a job outliving the TTL is rejected), this shows the incremental
+// pattern is what makes long jobs commit safely.
+TEST_F(DbDomainManagerTest, TestPartialCompactsSurvivePreregistrationExpiry) {
+    cfg.get("cloud_topics_long_term_garbage_collection_interval")
+      .set_value(100ms);
+    cfg.get("cloud_topics_preregistered_object_ttl").set_value(1ms);
+
+    auto tp = make_tp();
+    // Seed [0, 30) as three extents.
+    add_preregistered_objects(tp, kafka::offset(0), 3, 10, model::term_id(1));
+
+    auto partial_commit =
+      [&](kafka::offset base, uint32_t count, int expected_epoch) {
+          auto prereg = initial_manager
+                          ->preregister_objects({
+                            .metastore_partition = model::partition_id(0),
+                            .count = count,
+                          })
+                          .get();
+          ASSERT_EQ(prereg.ec, l1_rpc::errc::ok);
+          auto reply = initial_manager
+                         ->compact_objects(make_partial_compact(
+                           tp,
+                           make_new_objects_with_ids(
+                             tp, base, 10, prereg.object_ids),
+                           partition_state::compaction_epoch_t{expected_epoch}))
+                         .get();
+          ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+      };
+
+    // Incremental phase: partial-commit [0, 20) as the job produces its
+    // first two output objects, bumping the epoch to 1.
+    ASSERT_NO_FATAL_FAILURE(partial_commit(kafka::offset(0), 2, 0));
+
+    // The job outlives the preregistration TTL while the GC cycles; the
+    // committed objects are no longer preregistrations, so there is
+    // nothing for the GC to expire from under the job.
+    ASSERT_EQ(initial_manager->flush_domain({}).get().ec, l1_rpc::errc::ok);
+    initial_manager->start();
+    ss::sleep(1s).get();
+
+    // Tail of the job: the last output object lands the same way.
+    ASSERT_NO_FATAL_FAILURE(partial_commit(kafka::offset(20), 1, 1));
+
+    // Final commit: metadata only. Atomically records the job's cleaned
+    // ranges against the epoch its partials advanced.
+    {
+        l1_rpc::compact_objects_request req;
+        req.metastore_partition = model::partition_id(0);
+        compaction_state_update csu;
+        csu.new_cleaned_ranges.push_back({
+          .base_offset = kafka::offset(0),
+          .last_offset = kafka::offset(29),
+          .has_tombstones = false,
+        });
+        csu.cleaned_at = model::timestamp::now();
+        csu.expected_compaction_epoch = partition_state::compaction_epoch_t{2};
+        req.compaction_updates.emplace(tp, std::move(csu));
+        auto reply = initial_manager->compact_objects(std::move(req)).get();
+        ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+    }
+
+    // The log is [0, 30) across the job's three output extents, the epoch
+    // advanced once per partial plus once for the metadata commit, and the
+    // log is fully clean.
+    validate_metadata(
+      tp, kafka::offset(0), kafka::offset(30), exact_next::yes, 3);
+    {
+        l1_rpc::get_compaction_info_request req;
+        req.tp = tp;
+        req.tombstone_removal_upper_bound_ts = model::timestamp::max();
+        auto reply = initial_manager->get_compaction_info(std::move(req)).get();
+        ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+        EXPECT_EQ(
+          reply.compaction_epoch, partition_state::compaction_epoch_t{3});
+        EXPECT_TRUE(reply.dirty_ranges.empty());
+    }
+}
+
+// A truncation advancing the start offset between a job's partial commits
+// and its final commit deletes the extent rows of output objects that
+// fall wholly below the new start offset. The metadata-only final commit
+// references no extents, so it is unaffected and must succeed.
+TEST_F(DbDomainManagerTest, TestMetadataOnlyCompactAfterTruncation) {
+    auto tp = make_tp();
+    // Seed [0, 30) as three extents.
+    add_preregistered_objects(tp, kafka::offset(0), 3, 10, model::term_id(1));
+
+    auto partial_commit =
+      [&](kafka::offset base, uint32_t count, int expected_epoch) {
+          auto prereg = initial_manager
+                          ->preregister_objects({
+                            .metastore_partition = model::partition_id(0),
+                            .count = count,
+                          })
+                          .get();
+          ASSERT_EQ(prereg.ec, l1_rpc::errc::ok);
+          auto reply = initial_manager
+                         ->compact_objects(make_partial_compact(
+                           tp,
+                           make_new_objects_with_ids(
+                             tp, base, 10, prereg.object_ids),
+                           partition_state::compaction_epoch_t{expected_epoch}))
+                         .get();
+          ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+      };
+
+    ASSERT_NO_FATAL_FAILURE(partial_commit(kafka::offset(0), 2, 0));
+
+    // Retention truncates to offset 15 mid-job: the first output object's
+    // extent [0, 9] is deleted; [10, 19] straddles the start offset and
+    // survives.
+    {
+        l1_rpc::set_start_offset_request req;
+        req.tp = tp;
+        req.start_offset = kafka::offset(15);
+        auto reply = initial_manager->set_start_offset(std::move(req)).get();
+        ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+    }
+
+    ASSERT_NO_FATAL_FAILURE(partial_commit(kafka::offset(20), 1, 1));
+
+    {
+        l1_rpc::compact_objects_request req;
+        req.metastore_partition = model::partition_id(0);
+        compaction_state_update csu;
+        csu.new_cleaned_ranges.push_back({
+          .base_offset = kafka::offset(0),
+          .last_offset = kafka::offset(29),
+          .has_tombstones = false,
+        });
+        csu.cleaned_at = model::timestamp::now();
+        csu.expected_compaction_epoch = partition_state::compaction_epoch_t{2};
+        req.compaction_updates.emplace(tp, std::move(csu));
+        auto reply = initial_manager->compact_objects(std::move(req)).get();
+        ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+    }
+
+    // The surviving log has start offset 15, next offset 30, and extents
+    // [10, 19] and [20, 29]; the epoch advanced once per partial plus once
+    // for the metadata commit, and the live region is fully clean.
+    {
+        auto offsets_reply = initial_manager->get_offsets({.tp = tp}).get();
+        ASSERT_EQ(offsets_reply.ec, l1_rpc::errc::ok);
+        EXPECT_EQ(offsets_reply.start_offset, kafka::offset(15));
+        EXPECT_EQ(offsets_reply.next_offset, kafka::offset(30));
+    }
+    {
+        l1_rpc::get_compaction_info_request req;
+        req.tp = tp;
+        req.tombstone_removal_upper_bound_ts = model::timestamp::max();
+        auto reply = initial_manager->get_compaction_info(std::move(req)).get();
+        ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+        EXPECT_EQ(
+          reply.compaction_epoch, partition_state::compaction_epoch_t{3});
+        EXPECT_TRUE(reply.dirty_ranges.empty());
+    }
+}
+
+// The metadata-only commit is still fenced by the compaction epoch: a job
+// whose epoch is stale (another compaction committed since it began) must
+// be rejected.
+TEST_F(DbDomainManagerTest, TestMetadataOnlyCompactRejectsStaleEpoch) {
+    auto tp = make_tp();
+    add_preregistered_objects(tp, kafka::offset(0), 1, 10, model::term_id(1));
+
+    l1_rpc::compact_objects_request req;
+    req.metastore_partition = model::partition_id(0);
+    compaction_state_update csu;
+    csu.new_cleaned_ranges.push_back({
+      .base_offset = kafka::offset(0),
+      .last_offset = kafka::offset(9),
+      .has_tombstones = false,
+    });
+    csu.cleaned_at = model::timestamp::now();
+    csu.expected_compaction_epoch = partition_state::compaction_epoch_t{1};
+    req.compaction_updates.emplace(tp, std::move(csu));
+    auto reply = initial_manager->compact_objects(std::move(req)).get();
+    EXPECT_EQ(reply.ec, l1_rpc::errc::concurrent_requests);
+}
+
+// A metadata-only commit may only mark offsets the log has seen as
+// cleaned.
+TEST_F(DbDomainManagerTest, TestMetadataOnlyCompactRejectsRangeBeyondNext) {
+    auto tp = make_tp();
+    add_preregistered_objects(tp, kafka::offset(0), 3, 10, model::term_id(1));
+
+    l1_rpc::compact_objects_request req;
+    req.metastore_partition = model::partition_id(0);
+    compaction_state_update csu;
+    csu.new_cleaned_ranges.push_back({
+      .base_offset = kafka::offset(0),
+      .last_offset = kafka::offset(49),
+      .has_tombstones = false,
+    });
+    csu.cleaned_at = model::timestamp::now();
+    csu.expected_compaction_epoch = partition_state::compaction_epoch_t{0};
+    req.compaction_updates.emplace(tp, std::move(csu));
+    auto reply = initial_manager->compact_objects(std::move(req)).get();
+    EXPECT_EQ(reply.ec, l1_rpc::errc::concurrent_requests);
+}
+
+// The job commits each batch of output objects via a partial compaction commit
+// (bumping the epoch every time), then finishes with a metadata-only
+// compact_objects recording the cleaned ranges against the epoch its partials
+// advanced.
+TEST_F(DbDomainManagerTest, TestPartialCompactsThenMetadataOnlyCompact) {
+    auto tp = make_tp();
+    // Seed [0, 30) as three extents.
+    add_preregistered_objects(tp, kafka::offset(0), 3, 10, model::term_id(1));
+
+    // Three partial commits, one per output object; each bumps the epoch.
+    for (int i = 0; i < 3; ++i) {
+        auto prereg = initial_manager
+                        ->preregister_objects({
+                          .metastore_partition = model::partition_id(0),
+                          .count = 1,
+                        })
+                        .get();
+        ASSERT_EQ(prereg.ec, l1_rpc::errc::ok);
+        auto reply = initial_manager
+                       ->compact_objects(make_partial_compact(
+                         tp,
+                         make_new_objects_with_ids(
+                           tp, kafka::offset(i * 10), 10, prereg.object_ids),
+                         partition_state::compaction_epoch_t{i}))
+                       .get();
+        ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+    }
+
+    // Final commit: metadata only, against the epoch the partials advanced.
+    {
+        l1_rpc::compact_objects_request req;
+        req.metastore_partition = model::partition_id(0);
+        compaction_state_update csu;
+        csu.new_cleaned_ranges.push_back({
+          .base_offset = kafka::offset(0),
+          .last_offset = kafka::offset(29),
+          .has_tombstones = false,
+        });
+        csu.cleaned_at = model::timestamp::now();
+        csu.expected_compaction_epoch = partition_state::compaction_epoch_t{3};
+        req.compaction_updates.emplace(tp, std::move(csu));
+        auto reply = initial_manager->compact_objects(std::move(req)).get();
+        ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+    }
+
+    validate_metadata(
+      tp, kafka::offset(0), kafka::offset(30), exact_next::yes, 3);
+    {
+        l1_rpc::get_compaction_info_request req;
+        req.tp = tp;
+        req.tombstone_removal_upper_bound_ts = model::timestamp::max();
+        auto reply = initial_manager->get_compaction_info(std::move(req)).get();
+        ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+        EXPECT_EQ(
+          reply.compaction_epoch, partition_state::compaction_epoch_t{4});
+        EXPECT_TRUE(reply.dirty_ranges.empty());
+    }
+}
+
+// A partial commit fences straggler compaction jobs: once one job's
+// partial bumps the epoch, another job still pinned at the old epoch is
+// rejected on its very first partial rather than wasting a full run.
+TEST_F(DbDomainManagerTest, TestPartialCompactFencesStragglerCompaction) {
+    auto tp = make_tp();
+    add_preregistered_objects(tp, kafka::offset(0), 2, 10, model::term_id(1));
+
+    auto partial = [&](kafka::offset base, int expected_epoch) {
+        auto prereg = initial_manager
+                        ->preregister_objects({
+                          .metastore_partition = model::partition_id(0),
+                          .count = 1,
+                        })
+                        .get();
+        EXPECT_EQ(prereg.ec, l1_rpc::errc::ok);
+        return initial_manager
+          ->compact_objects(make_partial_compact(
+            tp,
+            make_new_objects_with_ids(tp, base, 10, prereg.object_ids),
+            partition_state::compaction_epoch_t{expected_epoch}))
+          .get();
+    };
+
+    // Job A's first partial bumps the epoch to 1.
+    ASSERT_EQ(partial(kafka::offset(0), 0).ec, l1_rpc::errc::ok);
+    // Straggler job B, still pinned at epoch 0, is fenced immediately —
+    // even on a range job A never touched.
+    EXPECT_EQ(
+      partial(kafka::offset(10), 0).ec, l1_rpc::errc::concurrent_requests);
+    // Job A continues at the epoch its own partial advanced.
+    EXPECT_EQ(partial(kafka::offset(10), 1).ec, l1_rpc::errc::ok);
+}
+
+// A partial commit fences leveling jobs with stale read snapshots: a
+// leveling replace_objects carries the epoch it read at, so once a
+// compaction partial bumps the epoch, the stale repackaging can no longer
+// land on top of the job's deduplicated output (or anywhere else in the
+// partition).
+TEST_F(DbDomainManagerTest, TestPartialCompactFencesStaleLeveling) {
+    auto tp = make_tp();
+    add_preregistered_objects(tp, kafka::offset(0), 2, 10, model::term_id(1));
+
+    // A leveling job "reads" at epoch 0 here (its replace below carries
+    // expected epoch 0). Compaction's partial then bumps the epoch.
+    {
+        auto prereg = initial_manager
+                        ->preregister_objects({
+                          .metastore_partition = model::partition_id(0),
+                          .count = 1,
+                        })
+                        .get();
+        ASSERT_EQ(prereg.ec, l1_rpc::errc::ok);
+        auto reply = initial_manager
+                       ->compact_objects(make_partial_compact(
+                         tp,
+                         make_new_objects_with_ids(
+                           tp, kafka::offset(0), 10, prereg.object_ids),
+                         partition_state::compaction_epoch_t{0}))
+                       .get();
+        ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+    }
+
+    // The stale leveling commit — same boundaries as what it read, so
+    // span-exact alone would let it through — is rejected by the epoch.
+    {
+        auto prereg = initial_manager
+                        ->preregister_objects({
+                          .metastore_partition = model::partition_id(0),
+                          .count = 1,
+                        })
+                        .get();
+        ASSERT_EQ(prereg.ec, l1_rpc::errc::ok);
+        l1_rpc::replace_objects_request req{
+          .metastore_partition = model::partition_id(0),
+          .new_objects = make_new_objects_with_ids(
+            tp, kafka::offset(10), 10, prereg.object_ids),
+          .expected_epochs = {{tp, partition_state::compaction_epoch_t{0}}},
+        };
+        auto reply = initial_manager->replace_objects(std::move(req)).get();
+        EXPECT_EQ(reply.ec, l1_rpc::errc::concurrent_requests);
+    }
+}
+
 TEST_F(DbDomainManagerTest, TestGetSizeBasic) {
     auto tp = make_tp();
     // Add 3 objects, each with an extent of size 512 bytes.

--- a/src/v/cloud_topics/level_one/maintenance/leveling/BUILD
+++ b/src/v/cloud_topics/level_one/maintenance/leveling/BUILD
@@ -36,6 +36,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics/level_one/frontend_reader:reader",
         "//src/v/cloud_topics/level_one/maintenance:meta",
         "//src/v/cloud_topics/level_one/metastore",
+        "//src/v/cloud_topics/level_one/metastore:extent_metadata_reader",
         "//src/v/cloud_topics/level_one/metastore:leveling_range_builder",
         "//src/v/compaction:reducer",
         "//src/v/container:chunked_vector",

--- a/src/v/cloud_topics/level_one/maintenance/leveling/leveling_source.cc
+++ b/src/v/cloud_topics/level_one/maintenance/leveling/leveling_source.cc
@@ -12,6 +12,7 @@
 
 #include "cloud_io/admission_control_types.h"
 #include "cloud_topics/level_one/frontend_reader/level_one_reader.h"
+#include "cloud_topics/level_one/metastore/extent_metadata_reader.h"
 #include "cloud_topics/log_reader_config.h"
 #include "model/record_batch_reader.h"
 #include "model/timeout_clock.h"
@@ -72,31 +73,50 @@ ss::future<ss::stop_iteration> leveling_source::deduplication_iteration(
         co_return ss::stop_iteration::yes;
     }
 
-    const auto& range = *_range_it;
-
-    kafka::offset start_offset{range.base_offset};
-    kafka::offset last_offset{range.last_offset};
-    cloud_topic_log_reader_config config(
-      cloud_io::group_id::default_group,
-      start_offset,
-      last_offset,
-      std::nullopt,
+    auto reader = extent_metadata_reader(
+      _metastore,
+      _tp,
+      kafka::offset{_range_it->base_offset},
+      kafka::offset{_range_it->last_offset},
+      extent_metadata_reader::iteration_direction::forwards,
       _as);
-    config.skip_cache = true;
-    auto rdr = model::record_batch_reader(
-      std::make_unique<level_one_log_reader_impl>(
-        config, _ntp, _tp, _metastore, _io));
+    auto gen = reader.generator();
+    while (auto extent_res_opt = co_await gen()) {
+        auto& extent_res = extent_res_opt->get();
+        if (!extent_res.has_value()) {
+            vlog(
+              _ctxlog.warn,
+              "Error fetching extent metadata during leveling iteration: {}",
+              extent_res.error());
+            co_return ss::stop_iteration::yes;
+        }
 
-    co_await sink.prepare_iteration(start_offset);
-    co_await std::move(rdr).consume(
-      passthrough_consumer{sink}, model::no_timeout);
-    co_await sink.finish_iteration(start_offset, last_offset);
+        auto extent = std::move(extent_res).value();
 
-    vlog(
-      _ctxlog.debug,
-      "L1 leveling rewriting offset range ({}~{})",
-      start_offset,
-      last_offset);
+        kafka::offset start_offset{extent.base_offset};
+        kafka::offset last_offset{extent.last_offset};
+        cloud_topic_log_reader_config config(
+          cloud_io::group_id::default_group,
+          start_offset,
+          last_offset,
+          std::nullopt,
+          _as);
+        config.skip_cache = true;
+        auto rdr = model::record_batch_reader(
+          std::make_unique<level_one_log_reader_impl>(
+            config, _ntp, _tp, _metastore, _io));
+
+        co_await sink.prepare_iteration(start_offset);
+        co_await std::move(rdr).consume(
+          passthrough_consumer{sink}, model::no_timeout);
+        co_await sink.finish_iteration(start_offset, last_offset);
+
+        vlog(
+          _ctxlog.debug,
+          "L1 leveling rewriting offset range ({}~{})",
+          start_offset,
+          last_offset);
+    }
 
     ++_range_it;
     co_return ss::stop_iteration::no;

--- a/src/v/cloud_topics/level_one/maintenance/leveling/leveling_source.h
+++ b/src/v/cloud_topics/level_one/maintenance/leveling/leveling_source.h
@@ -59,7 +59,9 @@ private:
     // undersized/fragmented L1 objects).
     chunked_vector<levelable_range> _leveling_ranges;
 
-    // Iterator over _leveling_ranges for the current range being processed.
+    // Cursor into `_leveling_ranges`. deduplication_iteration() processes the
+    // range it points at — iterating that range's extents one at a time — then
+    // advances it, one range per call, until the ranges are exhausted.
     chunked_vector<levelable_range>::iterator _range_it;
 
     metastore* _metastore;

--- a/src/v/cloud_topics/level_one/metastore/leveling_range_builder.h
+++ b/src/v/cloud_topics/level_one/metastore/leveling_range_builder.h
@@ -84,7 +84,15 @@ public:
     explicit leveling_range_builder(size_t min_acceptable_extent_bytes)
       : _min_acceptable_extent_bytes(min_acceptable_extent_bytes)
       , _max_acceptable_range_bytes(
-          config::shard_local_cfg().cloud_topics_leveling_max_range_bytes()) {}
+          config::shard_local_cfg().cloud_topics_leveling_max_range_bytes())
+      , _max_ranges(
+          config::shard_local_cfg()
+            .cloud_topics_leveling_max_ranges_per_partition()) {}
+
+    // Whether the cap on ranges per partition has been reached. Callers should
+    // stop feeding extents once this is true; the scan reply is bounded and
+    // the remaining ranges are picked up by a later scan.
+    bool is_full() const { return _ranges.size() >= _max_ranges; }
 
     // Processes a single extent.
     void process_extent(kafka::offset base, kafka::offset last, size_t len) {
@@ -134,7 +142,9 @@ private:
         const bool undersized_tail = tail == is_tail_range::yes
                                      && _range->bytes
                                           < _min_acceptable_extent_bytes;
-        if (_range->extent_count > 1 && !undersized_tail) {
+        if (
+          _range->extent_count > 1 && !undersized_tail
+          && _ranges.size() < _max_ranges) {
             _ranges.push_back(
               levelable_range{
                 .base_offset = _range->base,
@@ -148,6 +158,7 @@ private:
 
     size_t _min_acceptable_extent_bytes;
     size_t _max_acceptable_range_bytes;
+    size_t _max_ranges;
     std::optional<in_progress_range> _range;
     chunked_vector<levelable_range> _ranges;
 };

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
@@ -922,6 +922,68 @@ compact_objects_db_update::build_rows(
     chunked_hash_map<model::topic_id_partition, metadata_row_value>
       updated_metadata;
 
+    if (new_objects.empty()) {
+        // Metadata-only commit.
+        chunked_hash_map<model::topic_id_partition, compaction_state>
+          merged_compaction_states;
+        for (const auto& [t, p_updates] : compaction_updates) {
+            for (const auto& [p, comp_update] : p_updates) {
+                model::topic_id_partition tidp{t, p};
+                auto meta = co_await get_metadata_for_update(
+                  state, updated_metadata, tidp, "compaction");
+                if (!meta.has_value()) {
+                    co_return std::unexpected(std::move(meta.error()));
+                }
+                // Cleaned ranges must refer to offsets the log has seen.
+                for (const auto& r : comp_update.new_cleaned_ranges) {
+                    if (r.last_offset >= meta.value()->next_offset) {
+                        co_return std::unexpected(db_update_error(
+                          invalid_update,
+                          fmt::format(
+                            "Cleaned range [{}, {}] for {} extends past the "
+                            "next offset {}",
+                            r.base_offset,
+                            r.last_offset,
+                            tidp,
+                            meta.value()->next_offset)));
+                    }
+                }
+                compaction_state merged;
+                auto merge_res = co_await merge_compaction_state(
+                  tidp, comp_update, state, *meta.value(), merged);
+                if (!merge_res.has_value()) {
+                    co_return std::unexpected(std::move(merge_res.error()));
+                }
+                // An update with no cleaned ranges and no tombstone
+                // removals validates and bumps the epoch but leaves the
+                // compaction state definitionally unchanged; skip
+                // rewriting the row. The epoch bump still lands via the
+                // metadata row.
+                if (
+                  !comp_update.new_cleaned_ranges.empty()
+                  || !comp_update.removed_tombstones_ranges.empty()) {
+                    merged_compaction_states[tidp] = std::move(merged);
+                }
+            }
+        }
+        for (const auto& [tidp, comp_state] : merged_compaction_states) {
+            out.emplace_back(
+              write_batch_row{
+                .key = compaction_row_key::encode(tidp),
+                .value = serde::to_iobuf(
+                  compaction_row_value{.state = comp_state}),
+              });
+        }
+        for (auto& [tidp, meta] : updated_metadata) {
+            out.emplace_back(
+              write_batch_row{
+                .key = metadata_row_key::encode(tidp),
+                .value = serde::to_iobuf(meta),
+              });
+        }
+        co_return std::expected<void, db_update_error>{};
+    }
+
     auto replacements_res = co_await validate_replacement(
       state, new_objects, updated_metadata);
     if (!replacements_res.has_value()) {
@@ -941,14 +1003,21 @@ compact_objects_db_update::build_rows(
             if (!meta.has_value()) {
                 co_return std::unexpected(std::move(meta.error()));
             }
+            compaction_state merged;
             auto merge_res = co_await merge_compaction_state(
-              tidp,
-              comp_update,
-              state,
-              *meta.value(),
-              merged_compaction_states[tidp]);
+              tidp, comp_update, state, *meta.value(), merged);
             if (!merge_res.has_value()) {
                 co_return std::unexpected(std::move(merge_res.error()));
+            }
+            // An update with no cleaned ranges and no tombstone removals —
+            // the shape a job uses to commit a batch of output objects
+            // mid-run — validates and bumps the epoch but leaves the
+            // compaction state definitionally unchanged; skip rewriting
+            // the row. The epoch bump still lands via the metadata row.
+            if (
+              !comp_update.new_cleaned_ranges.empty()
+              || !comp_update.removed_tombstones_ranges.empty()) {
+                merged_compaction_states[tidp] = std::move(merged);
             }
 
             // If there are new cleaned ranges, check that the extents replace
@@ -1001,6 +1070,17 @@ compact_objects_db_update::discover_replaced_object_ids(
 
 std::expected<void, db_update_error>
 compact_objects_db_update::validate_inputs() const {
+    if (new_objects.empty()) {
+        // Metadata-only commit (see build_rows). All request-level checks
+        // relate new objects to the compaction updates, so there is nothing
+        // further to validate here beyond the request not being a no-op.
+        if (compaction_updates.empty()) {
+            return std::unexpected(db_update_error(
+              invalid_input,
+              "Metadata-only compaction request carries no updates"));
+        }
+        return std::expected<void, db_update_error>{};
+    }
     auto layout_res = validate_new_objects_extent_layout(new_objects);
     if (!layout_res.has_value()) {
         return std::unexpected(layout_res.error());

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -368,6 +368,15 @@ public:
     virtual ss::future<std::expected<void, errc>> compact_objects(
       const object_metadata_builder&, const compaction_map_t&) = 0;
 
+    // Commits compaction metadata without any object replacements: the
+    // cleaned ranges, tombstone-removal ranges, and one epoch bump. Used by
+    // jobs that installed their output objects incrementally via partial
+    // compact_objects() commits (objects with an empty compaction update,
+    // each of which bumped the epoch), so the expected epoch here is the one
+    // the job's own partial commits advanced.
+    virtual ss::future<std::expected<void, errc>>
+    commit_compaction_metadata(const compaction_map_t&) = 0;
+
     // All the information required to query a `compaction_info_response` from
     // the metastore. Parameters are used for call to `get_compaction_info()`.
     struct compaction_info_spec {

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -719,6 +719,45 @@ replicated_metastore::get_end_offset_for_term(
 }
 
 ss::future<std::expected<void, metastore::errc>>
+replicated_metastore::commit_compaction_metadata(
+  const metastore::compaction_map_t& compaction_updates) {
+    chunked_hash_map<
+      model::partition_id,
+      chunked_hash_map<model::topic_id_partition, compaction_state_update>>
+      compaction_updates_by_partition;
+    for (auto& [tp, update] : compaction_updates) {
+        auto metastore_partition = fe_.metastore_partition(tp);
+        if (!metastore_partition) {
+            vlog(cd_log.warn, "Unable to get metastore partition for {}", tp);
+            co_return std::unexpected(errc::transport_error);
+        }
+        compaction_updates_by_partition[*metastore_partition].emplace(
+          tp, meta_to_rpc_compact_update(update));
+    }
+    for (auto& [partition_id, updates] : compaction_updates_by_partition) {
+        rpc::compact_objects_request req;
+        req.metastore_partition = partition_id;
+        req.compaction_updates = std::move(updates);
+        auto reply_fut = co_await ss::coroutine::as_future(
+          fe_.compact_objects(std::move(req)));
+        if (reply_fut.failed()) {
+            auto ex = reply_fut.get_exception();
+            vlog(cd_log.warn, "Error while sending request: {}", ex);
+            co_return std::unexpected(metastore::errc::transport_error);
+        }
+        auto reply = reply_fut.get();
+        if (reply.ec != rpc::errc::ok) {
+            vlog(
+              cd_log.debug,
+              "Error code received for request {}",
+              int(reply.ec));
+            co_return std::unexpected(rpc_to_meta_errc(reply.ec));
+        }
+    }
+    co_return std::expected<void, errc>{};
+}
+
+ss::future<std::expected<void, metastore::errc>>
 replicated_metastore::compact_objects(
   const metastore::object_metadata_builder& builder,
   const metastore::compaction_map_t& compaction_updates) {

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
@@ -74,6 +74,8 @@ public:
       const object_metadata_builder&, const compaction_map_t&) override;
     ss::future<std::expected<void, errc>> compact_objects(
       const chunked_vector<object_metadata>&, const compaction_map_t&);
+    ss::future<std::expected<void, errc>>
+    commit_compaction_metadata(const compaction_map_t&) override;
 
     ss::future<std::expected<compaction_offsets_response, errc>>
     get_compaction_offsets(const model::topic_id_partition&, model::timestamp);

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -829,6 +829,9 @@ simple_metastore::get_leveling_info(
         }
         const auto base = std::max(ext.base_offset, prt.start_offset);
         builder.process_extent(base, ext.last_offset, ext.len);
+        if (builder.is_full()) {
+            break;
+        }
     }
     resp.ranges = std::move(builder).finalize();
     return resp;

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -529,6 +529,13 @@ simple_metastore::get_term_for_offset(
 }
 
 ss::future<std::expected<void, metastore::errc>>
+simple_metastore::commit_compaction_metadata(
+  const compaction_map_t& compaction_metas) {
+    co_return co_await compact_objects(
+      chunked_vector<object_metadata>{}, compaction_metas);
+}
+
+ss::future<std::expected<void, metastore::errc>>
 simple_metastore::compact_objects(
   const chunked_vector<object_metadata>& objects,
   const compaction_map_t& compaction_metas) {

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -102,6 +102,8 @@ public:
       const object_metadata_builder&, const compaction_map_t&) override;
     ss::future<std::expected<void, errc>> compact_objects(
       const chunked_vector<object_metadata>&, const compaction_map_t&);
+    ss::future<std::expected<void, errc>>
+    commit_compaction_metadata(const compaction_map_t&) override;
 
     void preregister_objects(const chunked_vector<object_id>&);
 

--- a/src/v/cloud_topics/level_one/metastore/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update.cc
@@ -628,6 +628,49 @@ replace_objects_update::build(
 
 std::expected<std::monostate, stm_update_error>
 compact_objects_update::can_apply(const state& state) {
+    if (new_objects.empty()) {
+        // Metadata-only commit.
+        if (compaction_updates.empty()) {
+            return std::unexpected(stm_update_error(
+              "Metadata-only compaction request carries no updates"));
+        }
+        for (const auto& [t, t_req] : compaction_updates) {
+            for (const auto& [p, compaction_update] : t_req) {
+                model::topic_id_partition tidp{t, p};
+                auto p_ref = state.partition_state(tidp);
+                if (!p_ref.has_value()) {
+                    return std::unexpected(stm_update_error(
+                      fmt::format("Partition {} not tracked by state", tidp)));
+                }
+                const auto& p_state = p_ref->get();
+                if (
+                  compaction_update.expected_compaction_epoch
+                  != p_state.compaction_epoch) {
+                    return std::unexpected(stm_update_error(
+                      fmt::format(
+                        "Expected compaction epoch {} does not match the "
+                        "current compaction epoch {} for {}",
+                        compaction_update.expected_compaction_epoch,
+                        p_state.compaction_epoch,
+                        tidp)));
+                }
+                // Cleaned ranges must refer to offsets the log has seen.
+                for (const auto& r : compaction_update.new_cleaned_ranges) {
+                    if (r.last_offset >= p_state.next_offset) {
+                        return std::unexpected(stm_update_error(
+                          fmt::format(
+                            "Cleaned range [{}, {}] for {} extends past "
+                            "the next offset {}",
+                            r.base_offset,
+                            r.last_offset,
+                            tidp,
+                            p_state.next_offset)));
+                    }
+                }
+            }
+        }
+        return std::monostate{};
+    }
     auto layout_res = validate_new_objects_layout(state, new_objects);
     if (!layout_res.has_value()) {
         return std::unexpected(layout_res.error());
@@ -784,6 +827,17 @@ compact_objects_update::apply(state& state) {
             model::topic_id_partition tidp{t, p};
             auto& p_state = state.topic_to_state[tidp.topic_id]
                               .pid_to_state[tidp.partition];
+            // An update with no cleaned ranges and no tombstone removals —
+            // the shape a job uses to commit a batch of output objects
+            // mid-run — bumps the epoch but leaves the compaction state
+            // untouched, mirroring the LSM path which skips rewriting the
+            // compaction row.
+            if (
+              compaction_update.new_cleaned_ranges.empty()
+              && compaction_update.removed_tombstones_ranges.empty()) {
+                ++p_state.compaction_epoch;
+                continue;
+            }
             if (!p_state.compaction_state.has_value()) {
                 p_state.compaction_state.emplace();
             }

--- a/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
@@ -1341,8 +1341,8 @@ TEST_P(StateUpdateParamTest, TestCompactWithEpochOnlyUpdate) {
 
     // A compact_objects request whose compaction_update has only the
     // expected_compaction_epoch set — no cleaned ranges, no tombstone
-    // removals — is valid. Extents are replaced, the epoch is bumped, and
-    // an empty compaction_state is visible.
+    // removals — is valid. Extents are replaced and the epoch is bumped,
+    // but the compaction state is left untouched (absent here).
     auto replace = compact_objects_builder()
                      .add(new_obj_builder(oid2, 100, 1100)
                             .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
@@ -1359,7 +1359,7 @@ TEST_P(StateUpdateParamTest, TestCompactWithEpochOnlyUpdate) {
       = s.partition_state(model::topic_id_partition::from(tidp_a))->get();
     EXPECT_THAT(prt_a.extents, ElementsAre(MatchesRange(oid2, 0_o, 10_o)));
     EXPECT_EQ(prt_a.compaction_epoch, partition_state::compaction_epoch_t{1});
-    EXPECT_TRUE(prt_a.compaction_state.has_value());
+    EXPECT_FALSE(prt_a.compaction_state.has_value());
 }
 
 TEST_P(StateUpdateParamTest, TestRejectsNotPreregistered) {

--- a/src/v/cloud_topics/read_replica/snapshot_metastore.cc
+++ b/src/v/cloud_topics/read_replica/snapshot_metastore.cc
@@ -230,6 +230,11 @@ snapshot_metastore::compact_objects(
     co_return std::unexpected(errc::invalid_request);
 }
 
+ss::future<std::expected<void, l1::metastore::errc>>
+snapshot_metastore::commit_compaction_metadata(const compaction_map_t&) {
+    co_return std::unexpected(errc::invalid_request);
+}
+
 ss::future<
   std::expected<l1::metastore::compaction_info_response, l1::metastore::errc>>
 snapshot_metastore::get_compaction_info(const compaction_info_spec&) {

--- a/src/v/cloud_topics/read_replica/snapshot_metastore.h
+++ b/src/v/cloud_topics/read_replica/snapshot_metastore.h
@@ -72,6 +72,8 @@ public:
 
     ss::future<std::expected<void, errc>> compact_objects(
       const object_metadata_builder&, const compaction_map_t&) override;
+    ss::future<std::expected<void, errc>>
+    commit_compaction_metadata(const compaction_map_t&) override;
 
     ss::future<std::expected<compaction_info_response, errc>>
     get_compaction_info(const compaction_info_spec&) override;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -5035,6 +5035,15 @@ configuration::configuration()
       "in time and blast radius. Lower values mean more, smaller jobs.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1_GiB)
+  , cloud_topics_leveling_max_ranges_per_partition(
+      *this,
+      "cloud_topics_leveling_max_ranges_per_partition",
+      "Maximum number of levelable ranges returned per partition by a single "
+      "leveling scan. Bounds the scan reply's size as well as the rate at "
+      "which leveling work is produced along with "
+      "`cloud_topics_leveling_interval_ms`.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      5)
   , cloud_topics_compaction_disabled(
       *this,
       "cloud_topics_compaction_disabled",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -835,6 +835,7 @@ public:
     bounded_property<double, numeric_bounds>
       cloud_topics_leveling_min_extent_size_ratio;
     property<size_t> cloud_topics_leveling_max_range_bytes;
+    property<size_t> cloud_topics_leveling_max_ranges_per_partition;
     property<bool> cloud_topics_compaction_disabled;
     property<bool> cloud_topics_leveling_disabled;
     bounded_property<uint64_t> cloud_topics_compaction_key_map_memory;


### PR DESCRIPTION
Manual backport of some of the commits from https://github.com/redpanda-data/redpanda/pull/31176, minus the commit which wires incremental commits into the cloud topics `sink` implementations for leveling and compaction (this will likely land in a future minor, once we get more CI marination time with the new approach).

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none
