### PR TITLE
`admin`: use `stream_range_as_array` in usage response

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -355,7 +355,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "VL/dlqfvsoFLdJ/1iyEHTFvCMM66KTA/hVvGT1WOPNA=",
+        "bzlTransitiveDigest": "FiOjSQzJYv0eX0CT1OccUyAtMTAQxAX+KGU+yNIBxBI=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedInputs": [
           "REPO_MAPPING:,bazel_tools bazel_tools",
@@ -528,9 +528,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "120bb1711ea5c56124b83556fec3dc85d8edd9b3c0990419b7c8900659a46e5f",
-              "strip_prefix": "seastar-cde680a9c6c3ff290a46f93a7ccea570ee8ccd87",
-              "url": "https://github.com/redpanda-data/seastar/archive/cde680a9c6c3ff290a46f93a7ccea570ee8ccd87.tar.gz"
+              "sha256": "0b8f08bb0fc971dfee675707b0119653a18fe5e42274b069bdb1f36b2d18dabd",
+              "strip_prefix": "seastar-39dfd216bac408133110edf83c087be322d0256f",
+              "url": "https://github.com/redpanda-data/seastar/archive/39dfd216bac408133110edf83c087be322d0256f.tar.gz"
             }
           },
           "unordered_dense": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -164,9 +164,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "120bb1711ea5c56124b83556fec3dc85d8edd9b3c0990419b7c8900659a46e5f",
-        strip_prefix = "seastar-cde680a9c6c3ff290a46f93a7ccea570ee8ccd87",
-        url = "https://github.com/redpanda-data/seastar/archive/cde680a9c6c3ff290a46f93a7ccea570ee8ccd87.tar.gz",
+        sha256 = "0b8f08bb0fc971dfee675707b0119653a18fe5e42274b069bdb1f36b2d18dabd",
+        strip_prefix = "seastar-39dfd216bac408133110edf83c087be322d0256f",
+        url = "https://github.com/redpanda-data/seastar/archive/39dfd216bac408133110edf83c087be322d0256f.tar.gz",
     )
 
     http_archive(

--- a/src/v/redpanda/admin/usage.cc
+++ b/src/v/redpanda/admin/usage.cc
@@ -12,6 +12,8 @@
 #include "redpanda/admin/api-doc/usage.json.hh"
 #include "redpanda/admin/server.h"
 
+#include <seastar/json/json_elements.hh>
+
 namespace {
 ss::json::json_return_type raw_data_to_usage_response(
   const std::vector<kafka::usage_window>& total_usage, bool include_open) {
@@ -55,7 +57,7 @@ ss::json::json_return_type raw_data_to_usage_response(
                             ss::lowres_system_clock::now().time_since_epoch())
                             .count();
     }
-    return resp;
+    return ss::json::stream_object(std::move(resp));
 }
 } // namespace
 


### PR DESCRIPTION
We were hitting oversized allocations and OOMs due to the size of string allocated here on a cluster with a large number of iceberg topics.

Use `ss::json::stream_range_as_array()` (as other endpoints do) to chunk the response and avoid allocating a large contiguous string.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.2.x
- [x] v26.1.x
- [ ] v25.3.x

## Release Notes

### Improvements

* Fixes an issue where `/v1/usage` responses could cause oversized allocations for clusters with a large number of Iceberg-enabled topics.
