### PR TITLE
`admin`: usage fast follow up

### DIFF
--- a/bazel/clang_tidy/plugins/BUILD
+++ b/bazel/clang_tidy/plugins/BUILD
@@ -25,6 +25,8 @@ cc_library(
 cc_binary(
     name = "plugins.so",
     srcs = [
+        "redpanda_eager_json_serialization_check.cc",
+        "redpanda_eager_json_serialization_check.h",
         "redpanda_lambda_coroutine_deduces_this_check.cc",
         "redpanda_lambda_coroutine_deduces_this_check.h",
         "redpanda_noop_check.h",

--- a/bazel/clang_tidy/plugins/redpanda_eager_json_serialization_check.cc
+++ b/bazel/clang_tidy/plugins/redpanda_eager_json_serialization_check.cc
@@ -1,0 +1,79 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "redpanda_eager_json_serialization_check.h"
+
+#include <clang-tidy/ClangTidyCheck.h>
+#include <clang/AST/ASTContext.h>
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+
+namespace clang::tidy::redpanda {
+
+using namespace clang::ast_matchers;
+
+namespace {
+
+// Mirrors the dispatch in seastar's json formatter: a type is serialized via
+// the eager range overload iff it is an input_range that is not string-like.
+// We approximate input_range as "has both begin() and end() members", which
+// matches every container that reaches formatter::to_json's range overload.
+AST_MATCHER(CXXRecordDecl, hasBeginAndEnd) {
+    if (!Node.hasDefinition()) {
+        return false;
+    }
+    bool has_begin = false;
+    bool has_end = false;
+    for (const auto* method : Node.methods()) {
+        if (const auto* ident = method->getIdentifier()) {
+            if (ident->isStr("begin")) {
+                has_begin = true;
+            } else if (ident->isStr("end")) {
+                has_end = true;
+            }
+        }
+    }
+    return has_begin && has_end;
+}
+
+} // namespace
+
+void EagerJsonSerialization::registerMatchers(MatchFinder* Finder) {
+    // string-like types have begin()/end() too, but seastar serializes them
+    // via the scalar path (internal::is_string_like), so they are exempt.
+    auto string_like = cxxRecordDecl(hasAnyName(
+      "::seastar::basic_sstring",
+      "::std::basic_string",
+      "::std::basic_string_view"));
+
+    auto container_arg = hasType(hasUnqualifiedDesugaredType(recordType(
+      hasDeclaration(cxxRecordDecl(hasBeginAndEnd(), unless(string_like))))));
+
+    Finder->addMatcher(
+      cxxConstructExpr(
+        hasDeclaration(cxxConstructorDecl(
+          isTemplateInstantiation(),
+          ofClass(
+            cxxRecordDecl(hasName("::seastar::json::json_return_type"))))),
+        argumentCountIs(1),
+        hasArgument(0, container_arg))
+        .bind("ctor"),
+      this);
+}
+
+void EagerJsonSerialization::check(const MatchFinder::MatchResult& Result) {
+    const auto* Ctor = Result.Nodes.getNodeAs<CXXConstructExpr>("ctor");
+    diag(
+      Ctor->getBeginLoc(),
+      "constructing json_return_type from a container serializes the whole "
+      "range into one contiguous string, risking an oversized allocation; "
+      "return ss::json::stream_range_as_array() instead to stream elements "
+      "with bounded allocations");
+}
+
+} // namespace clang::tidy::redpanda

--- a/bazel/clang_tidy/plugins/redpanda_eager_json_serialization_check.h
+++ b/bazel/clang_tidy/plugins/redpanda_eager_json_serialization_check.h
@@ -1,0 +1,39 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include <clang-tidy/ClangTidyCheck.h>
+
+namespace clang::tidy::redpanda {
+
+/**
+ * A clang-tidy check that flags construction of
+ * `seastar::json::json_return_type` from a container (any range that is not
+ * string-like). The converting constructor eagerly serializes the whole range
+ * into a single contiguous string via `formatter::to_json`, which for large
+ * responses requires an oversized contiguous allocation and can crash the
+ * process when memory is fragmented (allocation failure aborts by default).
+ *
+ * Instead, return `ss::json::stream_range_as_array(...)`, which streams
+ * elements to the HTTP output stream with bounded allocations. See
+ * src/v/redpanda/admin/usage.cc for an example.
+ *
+ * Scalars, strings and fixed-size json objects are not flagged: they take the
+ * scalar serialization path and their size does not grow with cluster state.
+ */
+class EagerJsonSerialization : public ClangTidyCheck {
+public:
+    EagerJsonSerialization(StringRef Name, ClangTidyContext* Context)
+      : ClangTidyCheck(Name, Context) {}
+    void registerMatchers(ast_matchers::MatchFinder* Finder) override;
+    void check(const ast_matchers::MatchFinder::MatchResult& Result) override;
+};
+
+} // namespace clang::tidy::redpanda

--- a/bazel/clang_tidy/plugins/redpanda_tidy_module.cc
+++ b/bazel/clang_tidy/plugins/redpanda_tidy_module.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "redpanda_eager_json_serialization_check.h"
 #include "redpanda_lambda_coroutine_deduces_this_check.h"
 #include "redpanda_noop_check.h"
 
@@ -31,6 +32,8 @@ public:
         check_factories.registerCheck<NoopCheck>("redpanda-noop");
         check_factories.registerCheck<LambdaCoroutineDeducesThis>(
           "redpanda-lambda-coroutine-deduces-this");
+        check_factories.registerCheck<EagerJsonSerialization>(
+          "redpanda-eager-json-serialization");
     }
 
     // this is where you might set default options for any configurable checks

--- a/bazel/clang_tidy/plugins/tests/redpanda_eager_json_serialization_check_test.cc.in
+++ b/bazel/clang_tidy/plugins/tests/redpanda_eager_json_serialization_check_test.cc.in
@@ -1,0 +1,140 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// clang-format off
+// Test file for `redpanda-eager-json-serialization`.
+// Run with `./tools/clang-tidy --checks=-*,redpanda-eager-json-serialization bazel/clang_tidy/plugins/tests/redpanda_eager_json_serialization_check_test.cc.in`
+// clang-format on
+
+// Minimal mocks of the seastar types involved. The check matches by
+// qualified name, so namespaces and class names must match the real ones.
+namespace seastar {
+
+template<typename CharT>
+class basic_sstring {
+public:
+    basic_sstring() = default;
+    basic_sstring(const char*) {}
+    const CharT* begin() const { return nullptr; }
+    const CharT* end() const { return nullptr; }
+};
+
+using sstring = basic_sstring<char>;
+
+namespace json {
+
+struct formatter {
+    template<typename T>
+    static sstring to_json(const T&) {
+        return {};
+    }
+};
+
+struct json_return_type {
+    sstring _res;
+    using body_writer_type = void (*)();
+    body_writer_type _body_writer = nullptr;
+    json_return_type(body_writer_type body_writer)
+      : _body_writer(body_writer) {}
+    template<class T>
+    json_return_type(const T& res) {
+        _res = formatter::to_json(res);
+    }
+};
+
+struct json_void {
+    sstring to_json() const { return {}; }
+};
+
+} // namespace json
+} // namespace seastar
+
+namespace std {
+inline namespace __1 {
+template<typename T>
+class vector {
+public:
+    T* begin() { return nullptr; }
+    T* end() { return nullptr; }
+    const T* begin() const { return nullptr; }
+    const T* end() const { return nullptr; }
+};
+template<typename CharT>
+class basic_string {
+public:
+    basic_string(const char*) {}
+    const CharT* begin() const { return nullptr; }
+    const CharT* end() const { return nullptr; }
+};
+using string = basic_string<char>;
+} // namespace __1
+} // namespace std
+
+template<typename T>
+class chunked_vector {
+public:
+    T* begin() { return nullptr; }
+    T* end() { return nullptr; }
+};
+
+struct usage_response {
+    int begin_timestamp;
+};
+
+namespace {
+
+void body_writer_fn() {}
+
+struct Test {
+    // 1. Constructing from std::vector eagerly serializes: should fail.
+    seastar::json::json_return_type CaughtVector() {
+        std::vector<usage_response> resp;
+        return resp;
+    }
+
+    // 2. Explicit construction from a container: should fail.
+    seastar::json::json_return_type CaughtExplicit() {
+        std::vector<usage_response> resp;
+        return seastar::json::json_return_type(resp);
+    }
+
+    // 3. Custom containers with begin/end are ranges too: should fail.
+    seastar::json::json_return_type CaughtChunkedVector() {
+        chunked_vector<usage_response> resp;
+        return resp;
+    }
+
+    // 4. Strings are serialized via the scalar path: should pass.
+    seastar::json::json_return_type UncaughtSstring() {
+        seastar::sstring msg = "ok";
+        return msg;
+    }
+
+    // 5. std::string is string-like: should pass.
+    seastar::json::json_return_type UncaughtStdString() {
+        std::string msg = "ok";
+        return msg;
+    }
+
+    // 6. Fixed-size json objects (e.g. json_void) are not ranges: should
+    // pass.
+    seastar::json::json_return_type UncaughtJsonVoid() {
+        return seastar::json::json_void();
+    }
+
+    // 7. Scalars: should pass.
+    seastar::json::json_return_type UncaughtScalar() { return 42; }
+
+    // 8. The body-writer constructor is the streaming path: should pass.
+    seastar::json::json_return_type UncaughtBodyWriter() {
+        return seastar::json::json_return_type(&body_writer_fn);
+    }
+};
+
+} // namespace

--- a/src/v/kafka/server/tests/usage_manager_test.cc
+++ b/src/v/kafka/server/tests/usage_manager_test.cc
@@ -82,7 +82,7 @@ private:
 
 namespace {
 std::vector<kafka::usage>
-strip_window_data(const std::vector<kafka::usage_window>& v) {
+strip_window_data(const chunked_vector<kafka::usage_window>& v) {
     std::vector<kafka::usage> vv;
     std::transform(
       v.begin(),
@@ -92,7 +92,7 @@ strip_window_data(const std::vector<kafka::usage_window>& v) {
     return vv;
 }
 
-ss::sstring print_window_data(const std::vector<kafka::usage_window>& v) {
+ss::sstring print_window_data(const chunked_vector<kafka::usage_window>& v) {
     std::stringstream ss;
     ss << "\n[\n";
     for (const auto& vs : v) {

--- a/src/v/kafka/server/usage_aggregator.cc
+++ b/src/v/kafka/server/usage_aggregator.cc
@@ -247,12 +247,12 @@ ss::future<> usage_aggregator<clock_type>::start() {
 }
 
 template<typename clock_type>
-ss::future<std::vector<usage_window>>
+ss::future<chunked_vector<usage_window>>
 usage_aggregator<clock_type>::get_usage_stats() {
     /// Get the freshest data for the open bucket
     co_await grab_data(_current_window);
 
-    std::vector<usage_window> stats;
+    chunked_vector<usage_window> stats;
     for (size_t i = 1; i < _buckets.size(); ++i) {
         const auto idx = (_current_window + i) % _usage_num_windows;
         if (!_buckets[idx].is_uninitialized()) {

--- a/src/v/kafka/server/usage_aggregator.h
+++ b/src/v/kafka/server/usage_aggregator.h
@@ -121,7 +121,7 @@ public:
     virtual ss::future<> start();
     virtual ss::future<> stop();
 
-    ss::future<std::vector<usage_window>> get_usage_stats();
+    ss::future<chunked_vector<usage_window>> get_usage_stats();
 
     std::chrono::seconds max_history() const {
         return _usage_window_width_interval * _usage_num_windows;

--- a/src/v/kafka/server/usage_manager.cc
+++ b/src/v/kafka/server/usage_manager.cc
@@ -152,14 +152,15 @@ ss::future<> usage_manager::stop() {
     co_await _accounting_fiber->stop();
 }
 
-ss::future<std::vector<usage_window>> usage_manager::get_usage_stats() const {
+ss::future<chunked_vector<usage_window>>
+usage_manager::get_usage_stats() const {
     if (ss::this_shard_id() != usage_manager_main_shard) {
         throw std::runtime_error(
           "Attempt to query results of "
           "kafka::usage_manager off the main accounting shard");
     }
     if (!_accounting_fiber) {
-        co_return std::vector<usage_window>{}; // no stats
+        co_return chunked_vector<usage_window>{}; // no stats
     }
     co_return co_await _accounting_fiber->get_usage_stats();
 }

--- a/src/v/kafka/server/usage_manager.h
+++ b/src/v/kafka/server/usage_manager.h
@@ -93,7 +93,7 @@ public:
 
     /// Obtain all current stats - for all shards
     ///
-    ss::future<std::vector<usage_window>> get_usage_stats() const;
+    ss::future<chunked_vector<usage_window>> get_usage_stats() const;
 
     /// Obtain all current stats - for 'this' shard, resets window
     ///

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1513,7 +1513,7 @@ admin_server::cancel_node_partition_moves(
           req, res.error(), model::controller_ntp, node_id);
     }
 
-    co_return ss::json::json_return_type(
+    co_return ss::json::stream_object(
       co_await map_partition_results(std::move(res.value())));
 }
 
@@ -2103,42 +2103,43 @@ void admin_server::register_cluster_config_routes() {
               [](cluster::config_manager& manager) {
                   return manager.get_projected_status();
               })
-            .then([local_node,
-                   local_pending = std::move(local_pending)](auto statuses) {
-                std::vector<
-                  ss::httpd::cluster_config_json::cluster_config_status>
-                  res;
+            .then(
+              [local_node, local_pending = std::move(local_pending)](
+                auto statuses) -> ss::json::json_return_type {
+                  std::vector<
+                    ss::httpd::cluster_config_json::cluster_config_status>
+                    res;
 
-                for (const auto& s : statuses) {
-                    vlog(adminlog.trace, "status: {}", s.second);
-                    auto& rs = res.emplace_back();
-                    rs.node_id = s.first;
-                    rs.restart = s.second.restart;
-                    rs.config_version = s.second.version;
+                  for (const auto& s : statuses) {
+                      vlog(adminlog.trace, "status: {}", s.second);
+                      auto& rs = res.emplace_back();
+                      rs.node_id = s.first;
+                      rs.restart = s.second.restart;
+                      rs.config_version = s.second.version;
 
-                    // Workaround: seastar json_list hides empty lists by
-                    // default.  This complicates API clients, so always push
-                    // in a dummy element to get _set=true on json_list (this
-                    // is then cleared in the subsequent operator=).
-                    rs.invalid.push(ss::sstring("hack"));
-                    rs.unknown.push(ss::sstring("hack"));
-                    rs.pending.push(ss::sstring("hack"));
+                      // Workaround: seastar json_list hides empty lists by
+                      // default.  This complicates API clients, so always push
+                      // in a dummy element to get _set=true on json_list (this
+                      // is then cleared in the subsequent operator=).
+                      rs.invalid.push(ss::sstring("hack"));
+                      rs.unknown.push(ss::sstring("hack"));
+                      rs.pending.push(ss::sstring("hack"));
 
-                    rs.invalid = s.second.invalid;
-                    rs.unknown = s.second.unknown;
+                      rs.invalid = s.second.invalid;
+                      rs.unknown = s.second.unknown;
 
-                    if (s.first == local_node) {
-                        rs.pending = local_pending;
-                    } else {
-                        // TODO: Pending state is local-only: extending
-                        // config_status (on-wire type) is needed to
-                        // propagate pending info from remote nodes.
-                        rs.pending = std::vector<ss::sstring>{};
-                    }
-                }
+                      if (s.first == local_node) {
+                          rs.pending = local_pending;
+                      } else {
+                          // TODO: Pending state is local-only: extending
+                          // config_status (on-wire type) is needed to
+                          // propagate pending info from remote nodes.
+                          rs.pending = std::vector<ss::sstring>{};
+                      }
+                  }
 
-                return ss::json::json_return_type(res);
-            });
+                  return ss::json::stream_object(std::move(res));
+              });
       });
 
     register_route<publik>(
@@ -2898,7 +2899,8 @@ admin_server::get_broker_uuids_handler() {
           }
           return ret;
       });
-    co_return ss::json::json_return_type(mappings);
+
+    co_return ss::json::stream_object(std::move(mappings));
 }
 
 ss::future<ss::json::json_return_type> admin_server::decomission_broker_handler(
@@ -3125,9 +3127,11 @@ void admin_server::register_broker_routes() {
       ss::httpd::broker_json::get_brokers,
       [this](std::unique_ptr<ss::http::request>) {
           return get_brokers(_controller)
-            .then([](std::vector<ss::httpd::broker_json::broker> brokers) {
-                return ss::json::json_return_type(brokers);
-            });
+            .then(
+              [](std::vector<ss::httpd::broker_json::broker> brokers)
+                -> ss::json::json_return_type {
+                  return ss::json::stream_object(std::move(brokers));
+              });
       });
     register_route<user>(
       ss::httpd::broker_json::get_broker_uuids,
@@ -3510,7 +3514,7 @@ admin_server::self_test_get_results_handler(
         }
         reports.push_back(nr);
     }
-    co_return ss::json::json_return_type(reports);
+    co_return ss::json::stream_object(std::move(reports));
 }
 
 void admin_server::register_self_test_routes() {
@@ -3732,7 +3736,7 @@ admin_server::cancel_all_partitions_reconfigs_handler(
         co_await throw_on_error(*req, res.error(), model::controller_ntp);
     }
 
-    co_return ss::json::json_return_type(
+    co_return ss::json::stream_object(
       co_await map_partition_results(std::move(res.value())));
 }
 
@@ -4397,7 +4401,7 @@ ss::json::json_return_type serialize_topic_recovery_status(
         status_log.push_back(map_status_to_json(entry));
     }
 
-    return status_log;
+    return ss::json::stream_object(std::move(status_log));
 }
 } // namespace
 

--- a/src/v/redpanda/admin/usage.cc
+++ b/src/v/redpanda/admin/usage.cc
@@ -16,8 +16,8 @@
 
 namespace {
 ss::json::json_return_type raw_data_to_usage_response(
-  const std::vector<kafka::usage_window>& total_usage, bool include_open) {
-    std::vector<ss::httpd::usage_json::usage_response> resp;
+  const chunked_vector<kafka::usage_window>& total_usage, bool include_open) {
+    chunked_vector<ss::httpd::usage_json::usage_response> resp;
     resp.reserve(total_usage.size());
     for (size_t i = (include_open ? 0 : 1); i < total_usage.size(); ++i) {
         resp.emplace_back();
@@ -51,7 +51,7 @@ ss::json::json_return_type raw_data_to_usage_response(
     if (include_open && !resp.empty()) {
         /// Handle case where client does not want to observe
         /// value of 0 for open buckets end timestamp
-        auto& e = resp.at(0);
+        auto& e = resp[0];
         vassert(e.open(), "Bucket not open when expecting to be");
         e.end_timestamp = std::chrono::duration_cast<std::chrono::seconds>(
                             ss::lowres_system_clock::now().time_since_epoch())
@@ -82,7 +82,7 @@ void admin_server::register_usage_routes() {
             .invoke_on(
               kafka::usage_manager::usage_manager_main_shard,
               [](kafka::usage_manager& um) { return um.get_usage_stats(); })
-            .then([include_open](auto total_usage) {
+            .then([include_open](const auto& total_usage) {
                 return raw_data_to_usage_response(total_usage, include_open);
             });
       });


### PR DESCRIPTION
* Prefer `chunked_vector<>` for usage stats
* Use `stream_object()` in more places
* Add a `clang-tidy` check to ensure we don't ever fall back to formatting containers into a contiguous string for `ss::json_return_type`s

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none
