### PR TITLE
gha: link triggering workflow run in installpack bump BK message

### DIFF
--- a/.github/workflows/cloud-installpack-bk-trigger.yml
+++ b/.github/workflows/cloud-installpack-bk-trigger.yml
@@ -39,5 +39,5 @@ jobs:
           buildkite_pipeline: ${{ vars.CLOUD_PIPELINE }}
           commit: HEAD
           branch: ${{ vars.CLOUD_DEFAULT_BRANCH }}
-          message: Install Pack version bump trigger
+          message: 'Install pack version bump triggered for redpanda ${{ github.ref_name }} by ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
           env: '{"INSTALLPACK_BUMP": "1", "RELEASE_VERSION": "${{ github.ref_name }}"}'


### PR DESCRIPTION
## Summary

Jira: [DEVPROD-4540]

The Buildkite build that `cloud-installpack-bk-trigger.yml` triggers on release publish had the generic message `Install Pack version bump trigger` — nothing on the Buildkite build page said which release or GitHub workflow run triggered it.

This changes the build message to include the release tag and the triggering workflow run URL:

> Install pack version bump triggered for redpanda v26.1.15 by https://github.com/redpanda-data/redpanda/actions/runs/123456789

Companion to redpanda-data/cloudv2#28574, which makes the resulting `installpack: bump rp vX.Y.Z` PR link back to the Buildkite build that created it.

## Verification

- `actionlint` and `yamllint` pass on the modified workflow.
- The `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}` pattern is the same run-URL construction cloudv2's `set-upgrades-from.yml` already uses; `${{ github.ref_name }}` was already interpolated on the adjacent `env:` line of this step.
- End-to-end proof only occurs on the next release publish, since that's this workflow's only trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none

[DEVPROD-4540]: https://redpandadata.atlassian.net/browse/DEVPROD-4540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
