### PR TITLE
[v25.2.x] rpk: update console version to v3.9.0

### DIFF
--- a/src/go/rpk/pkg/cli/container/common/common.go
+++ b/src/go/rpk/pkg/cli/container/common/common.go
@@ -34,7 +34,7 @@ import (
 var (
 	tag               = "latest"
 	redpandaImageBase = "redpandadata/redpanda:" + tag
-	consoleImageBase  = "redpandadata/console:v3.1.2"
+	consoleImageBase  = "redpandadata/console:v3.9.0"
 )
 
 const (


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31263

- Command: git cherry-pick -x a957ecae89
- Commits backported: 1
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-31263-v25.2.x-1785262904

## Conflict details

- a957ecae89 (src/go/rpk/pkg/cli/container/common/common.go): the file lives at
  `container/containerutil/common.go` on dev but `container/common/common.go` on
  v25.2.x, and the branch pins a different console version, so `consoleImageBase`
  conflicted; resolved by taking the incoming value (`redpandadata/console:v3.9.0`)
  in the target branch's file location.

Note for the reviewer: v25.2.x was pinned at `redpandadata/console:v3.1.2`, not
the `v3.8.0` the upstream commit message mentions, so this backport is a larger
version jump than the original commit. Confirm console v3.9.0 is the intended
default for the v25.2.x line before merging.
