### PR TITLE
[v26.1.x] kafka: quiet and stop auditing broker-internal authz probes

### DIFF
--- a/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
+++ b/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
@@ -216,9 +216,14 @@ ss::future<response_ptr> offset_for_leader_epoch_handler::handle(
     std::vector<offset_for_leader_topic_result> unauthorized;
 
     // authorize
+    //
+    // cluster_action here is a fast path for brokers/superusers; a regular
+    // consumer is expected to fail it and fall through to the per-topic
+    // describe checks below. quiet the authz log for the expected failure.
     if (!ctx.authorized(
           security::acl_operation::cluster_action,
-          security::default_cluster_name)) {
+          security::default_cluster_name,
+          authz_quiet{true})) {
         auto it = std::stable_partition(
           request.data.topics.begin(),
           request.data.topics.end(),

--- a/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
+++ b/src/v/kafka/server/handlers/offset_for_leader_epoch.cc
@@ -219,11 +219,14 @@ ss::future<response_ptr> offset_for_leader_epoch_handler::handle(
     //
     // cluster_action here is a fast path for brokers/superusers; a regular
     // consumer is expected to fail it and fall through to the per-topic
-    // describe checks below. quiet the authz log for the expected failure.
+    // describe checks below. quiet the authz log and skip auditing for
+    // this broker-internal probe on both allow and deny. the user-meaningful
+    // access decisions happen at the per-topic describe checks below.
     if (!ctx.authorized(
           security::acl_operation::cluster_action,
           security::default_cluster_name,
-          authz_quiet{true})) {
+          authz_quiet{true},
+          audit_authz_check::no)) {
         auto it = std::stable_partition(
           request.data.topics.begin(),
           request.data.topics.end(),

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -1913,11 +1913,20 @@ ss::future<response_ptr> init_producer_id_handler::handle(
               });
         }
 
+        // probe whether the client has write on any topic, as a fall back
+        // to the idempotent_write cluster ACL check below. quiet the authz
+        // log and skip auditing for this broker-internal probe on both
+        // allow and deny. the client asked for an idempotent producer ID,
+        // not to write to any specific topic, so neither outcome is a
+        // user-initiated access decision.
         bool permitted = false;
         auto topics = ctx.metadata_cache().all_topics();
         for (auto& tp_ns : topics) {
             permitted = ctx.authorized(
-              security::acl_operation::write, tp_ns.tp, authz_quiet{true});
+              security::acl_operation::write,
+              tp_ns.tp,
+              authz_quiet{true},
+              audit_authz_check::no);
             if (permitted) {
                 break;
             }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/30956
Fixes: https://github.com/redpanda-data/redpanda/issues/31320,