### PR TITLE
[CORE-1516] rpk shadow: replace the entire configuration on update

### DIFF
--- a/src/go/rpk/pkg/cli/shadow/BUILD
+++ b/src/go/rpk/pkg/cli/shadow/BUILD
@@ -33,7 +33,6 @@ go_library(
         "@build_buf_gen_go_redpandadata_core_protocolbuffers_go//redpanda/core/common/v1:common",
         "@build_buf_gen_go_redpandadata_dataplane_protocolbuffers_go//redpanda/api/dataplane/v1:dataplane",
         "@com_connectrpc_connect//:connect",
-        "@com_github_redpanda_data_common_go_rpadmin//:rpadmin",
         "@com_github_spf13_afero//:afero",
         "@com_github_spf13_cobra//:cobra",
         "@in_gopkg_yaml_v2//:yaml_v2",

--- a/src/go/rpk/pkg/cli/shadow/create.go
+++ b/src/go/rpk/pkg/cli/shadow/create.go
@@ -23,7 +23,6 @@ import (
 	"connectrpc.com/connect"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/oauth/providers/auth0"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
@@ -96,12 +95,7 @@ Create a Shadow Link without confirmation prompt:
 
 			successMsgTmpl := "Successfully created shadow link %q with ID %q. To query the status, run:\n  'rpk shadow status %[1]v'"
 			if prof.CheckFromCloud() {
-				cloudClient, err := publicapi.NewValidatedCloudClientSet(
-					cfg.DevOverrides().PublicAPIURL,
-					prof.CurrentAuth().AuthToken,
-					auth0.NewClient(cfg.DevOverrides()).Audience(),
-					[]string{prof.CurrentAuth().ClientID},
-				)
+				cloudClient, err := newCloudClientSet(cfg, prof)
 				out.MaybeDieErr(err)
 
 				err = validateCloudSecrets(cmd.Context(), prof, slCfg)

--- a/src/go/rpk/pkg/cli/shadow/delete.go
+++ b/src/go/rpk/pkg/cli/shadow/delete.go
@@ -20,9 +20,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/oauth/providers/auth0"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -82,12 +80,7 @@ Force delete a Shadow Link with active shadow topics:
 				}
 			}
 			if prof.CheckFromCloud() {
-				cloudClient, err := publicapi.NewValidatedCloudClientSet(
-					cfg.DevOverrides().PublicAPIURL,
-					prof.CurrentAuth().AuthToken,
-					auth0.NewClient(cfg.DevOverrides()).Audience(),
-					[]string{prof.CurrentAuth().ClientID},
-				)
+				cloudClient, err := newCloudClientSet(cfg, prof)
 				out.MaybeDieErr(err)
 
 				link, err := cloudClient.ShadowLinkByNameAndRPID(cmd.Context(), linkName, prof.CloudCluster.ClusterID)
@@ -109,7 +102,7 @@ Force delete a Shadow Link with active shadow topics:
 				}
 				if !isComplete {
 					spinner.Stop()
-					out.Exit("Shadow link deletion is taking longer than expected. Please check the status of the shadow link using 'rpk shadow status %q'", linkName)
+					out.Exit("Shadow link deletion is taking longer than expected. Please check the status of the shadow link using 'rpk shadow status %v'", linkName)
 				}
 				spinner.Success(fmt.Sprintf("Shadow Link %q deleted successfully", linkName))
 				os.Exit(0)

--- a/src/go/rpk/pkg/cli/shadow/describe.go
+++ b/src/go/rpk/pkg/cli/shadow/describe.go
@@ -20,9 +20,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/oauth/providers/auth0"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -184,12 +182,7 @@ Display output as JSON:
 			linkName := args[0]
 
 			if prof.CheckFromCloud() {
-				cloudClient, err := publicapi.NewValidatedCloudClientSet(
-					cfg.DevOverrides().PublicAPIURL,
-					prof.CurrentAuth().AuthToken,
-					auth0.NewClient(cfg.DevOverrides()).Audience(),
-					[]string{prof.CurrentAuth().ClientID},
-				)
+				cloudClient, err := newCloudClientSet(cfg, prof)
 				out.MaybeDieErr(err)
 
 				link, err := cloudClient.ShadowLinkByNameAndRPID(cmd.Context(), linkName, prof.CloudCluster.ClusterID)

--- a/src/go/rpk/pkg/cli/shadow/list.go
+++ b/src/go/rpk/pkg/cli/shadow/list.go
@@ -20,9 +20,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/oauth/providers/auth0"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -60,12 +58,7 @@ List all Shadow Links:
 
 			var resp []listShadowRowResponse
 			if prof.CheckFromCloud() {
-				cloudClient, err := publicapi.NewValidatedCloudClientSet(
-					cfg.DevOverrides().PublicAPIURL,
-					prof.CurrentAuth().AuthToken,
-					auth0.NewClient(cfg.DevOverrides()).Audience(),
-					[]string{prof.CurrentAuth().ClientID},
-				)
+				cloudClient, err := newCloudClientSet(cfg, prof)
 				out.MaybeDieErr(err)
 
 				link, err := cloudClient.ShadowLinkListItems(cmd.Context(), &controlplanev1.ListShadowLinksRequest_Filter{

--- a/src/go/rpk/pkg/cli/shadow/shadow.go
+++ b/src/go/rpk/pkg/cli/shadow/shadow.go
@@ -17,6 +17,7 @@ import (
 	controlplanev1 "buf.build/gen/go/redpandadata/cloud/protocolbuffers/go/redpanda/api/controlplane/v1"
 	"connectrpc.com/connect"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/oauth/providers/auth0"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -56,6 +57,17 @@ cluster metadata.
 	p.InstallAdminFlags(cmd)
 	p.InstallSASLFlags(cmd)
 	return cmd
+}
+
+// newCloudClientSet builds the validated control-plane client set for the
+// profile's current cloud auth.
+func newCloudClientSet(cfg *config.Config, prof *config.RpkProfile) (*publicapi.CloudClientSet, error) {
+	return publicapi.NewValidatedCloudClientSet(
+		cfg.DevOverrides().PublicAPIURL,
+		prof.CurrentAuth().AuthToken,
+		auth0.NewClient(cfg.DevOverrides()).Audience(),
+		[]string{prof.CurrentAuth().ClientID},
+	)
 }
 
 // waitForOperation is a shared function to poll for the completion of an async

--- a/src/go/rpk/pkg/cli/shadow/update.go
+++ b/src/go/rpk/pkg/cli/shadow/update.go
@@ -55,14 +55,20 @@ func newUpdateCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 
 By default, this command opens your default editor with the current Shadow
 Link configuration. Update the fields you want to change, save the file, and
-close the editor. The command applies only the changed fields to the Shadow
-Link.
+close the editor.
 
 Alternatively, use the '--config-file' flag to apply a configuration file
-directly without opening an editor, which is useful for scripted workflows. In
-this mode the file replaces the entire Shadow Link configuration: any field
-omitted from the file is reset to its default value. The name in the
-configuration file must match LINK_NAME.
+directly without opening an editor, which is useful for scripted workflows.
+
+In both modes the submitted configuration replaces the entire Shadow Link
+configuration: any field omitted is reset to its default value. The modes
+differ only in where the configuration comes from; the editor is seeded with
+the current configuration, while a configuration file is applied as-is. The
+name in the configuration file must match LINK_NAME.
+
+Set passwords appear in the editor as the placeholder '<redacted>'; leave the
+placeholder untouched to keep the existing password, or replace it to set a
+new one.
 
 You cannot change the Shadow Link name. If you need to rename a Shadow Link,
 delete it and create a new one with the desired name.
@@ -84,16 +90,15 @@ Replace the entire Shadow Link configuration from a file:
 			prof := cfg.VirtualProfile()
 			config.CheckExitServerlessAdmin(prof)
 
-			// The editor flow (default) diffs the current config and applies
-			// only the changed fields via a mask; --config-file replaces the
-			// entire configuration.
+			// Both modes replace the entire configuration; they differ only
+			// in where the config comes from: an editor seeded with the
+			// current config, or --config-file.
 			fromCloud := prof.CheckFromCloud()
 			fileMode := cfgLocation != ""
 			linkName := args[0]
 			var (
 				originalCfg *ShadowLinkConfig
 				updatedCfg  *ShadowLinkConfig
-				diff        []string
 				adminClient *rpadmin.AdminAPI
 				cloudClient *publicapi.CloudClientSet
 				cloudLinkID string
@@ -140,7 +145,8 @@ Replace the entire Shadow Link configuration from a file:
 				}
 			}
 
-			// Editor mode: open the editor and calculate the diff.
+			// Editor mode: open the editor and bail early when nothing
+			// changed.
 			if !fileMode {
 				updatedCfg, err = rpkos.EditTmpYAMLFile(cmd.Context(), fs, originalCfg)
 				out.MaybeDie(err, "unable to edit Shadow Link configuration: %v", err)
@@ -152,34 +158,26 @@ Replace the entire Shadow Link configuration from a file:
 					out.Die("shadow link name cannot be changed; if you need to rename, please delete and recreate the shadow link")
 				}
 
-				diff = diffConfigs(originalCfg, updatedCfg)
+				diff := diffConfigs(originalCfg, updatedCfg)
 				if diff == nil {
 					out.Exit("No changes detected")
 				}
+				zap.L().Sugar().Debugf("Detected changes in: %v", strings.Join(diff, ", "))
+
+				// An untouched password placeholder means "keep the existing
+				// password"; the server preserves the stored password when
+				// the submitted one is empty and the username is set.
+				stripRedactedPasswords(updatedCfg)
 			}
 
-			// Submit the update request.
 			if fromCloud {
+				err = validateCloudSecrets(cmd.Context(), prof, updatedCfg)
+				out.MaybeDie(err, "unable to validate cloud secrets: %v", err)
+
 				updatedSL := shadowLinkConfigToCloudUpdate(updatedCfg, cloudLinkID)
 
-				var cloudPaths []string
-				if fileMode {
-					err = validateCloudSecrets(cmd.Context(), prof, updatedCfg)
-					out.MaybeDie(err, "unable to validate cloud secrets: %v", err)
-
-					cloudPaths = cloudUpdateReplacePaths
-				} else {
-					// Cloud proto has no "configurations" wrapper; strip it.
-					cloudPaths = make([]string, len(diff))
-					for i, path := range diff {
-						cloudPaths[i] = strings.TrimPrefix(path, "configurations.")
-					}
-				}
-
-				fm, err := fieldmaskpb.New(updatedSL, cloudPaths...)
+				fm, err := fieldmaskpb.New(updatedSL, cloudUpdateReplacePaths...) // The cloud API rejects an empty mask.
 				out.MaybeDie(err, "unrecognized changed fields: %v; please report this with Redpanda Support", err)
-
-				zap.L().Sugar().Debugf("Requesting configuration update for: %v", strings.Join(cloudPaths, ", "))
 				op, err := cloudClient.ShadowLink.UpdateShadowLink(cmd.Context(), connect.NewRequest(&controlplanev1.UpdateShadowLinkRequest{
 					ShadowLink: updatedSL,
 					UpdateMask: fm,
@@ -198,21 +196,10 @@ Replace the entire Shadow Link configuration from a file:
 				spinner.Success(fmt.Sprintf("Successfully updated shadow link %q", linkName))
 				os.Exit(0)
 			}
-			// Self-hosted path. In file mode the mask stays unset, which the
-			// server treats as a full replace.
-			updatedSL := shadowLinkConfigToProto(updatedCfg)
-			var fm *fieldmaskpb.FieldMask
-			if fileMode {
-				zap.L().Sugar().Debug("Requesting full configuration replacement")
-			} else {
-				fm, err = fieldmaskpb.New(updatedSL, diff...)
-				out.MaybeDie(err, "unrecognized changed fields: %v; please report this with Redpanda Support", err)
 
-				zap.L().Sugar().Debugf("Requesting configuration update for: %v", strings.Join(diff, ", "))
-			}
+			zap.L().Sugar().Debug("Requesting full configuration replacement")
 			_, err = adminClient.ShadowLinkService().UpdateShadowLink(cmd.Context(), connect.NewRequest(&adminv2.UpdateShadowLinkRequest{
-				ShadowLink: updatedSL,
-				UpdateMask: fm,
+				ShadowLink: shadowLinkConfigToProto(updatedCfg),
 			}))
 			out.MaybeDie(err, "unable to update Shadow Link: %v", handleConnectError(err, "update", linkName))
 			fmt.Printf("Successfully updated shadow link %q.\n", linkName)
@@ -260,11 +247,40 @@ func addRedactedPasswordString(cfg *ShadowLinkConfig, link *adminv2.ShadowLink) 
 		}
 	}
 
+	if cfgs.GetClientOptions().GetAuthenticationConfiguration().GetPlainConfiguration().GetPasswordSet() {
+		if co := cfg.ClientOptions; co != nil {
+			if auth := co.AuthenticationConfiguration; auth != nil && auth.PlainConfiguration != nil {
+				auth.PlainConfiguration.Password = redacted
+			}
+		}
+	}
+
 	if cfgs.GetSchemaRegistrySyncOptions().GetShadowSchemaRegistryApi().GetAuthOptions().GetBasic().GetPasswordSet() {
 		if sr := cfg.SchemaRegistrySyncOptions; sr != nil && sr.ShadowSchemaRegistryAPI != nil {
 			if auth := sr.ShadowSchemaRegistryAPI.AuthOptions; auth != nil && auth.Basic != nil {
 				auth.Basic.Password = redacted
 			}
+		}
+	}
+}
+
+// stripRedactedPasswords clears passwords still holding the editor-seeded
+// placeholder. An empty password with a username set tells the server to keep
+// the existing password.
+func stripRedactedPasswords(cfg *ShadowLinkConfig) {
+	if co := cfg.ClientOptions; co != nil {
+		if auth := co.AuthenticationConfiguration; auth != nil {
+			if scram := auth.ScramConfiguration; scram != nil && scram.Password == redacted {
+				scram.Password = ""
+			}
+			if plain := auth.PlainConfiguration; plain != nil && plain.Password == redacted {
+				plain.Password = ""
+			}
+		}
+	}
+	if sr := cfg.SchemaRegistrySyncOptions; sr != nil && sr.ShadowSchemaRegistryAPI != nil {
+		if auth := sr.ShadowSchemaRegistryAPI.AuthOptions; auth != nil && auth.Basic != nil && auth.Basic.Password == redacted {
+			auth.Basic.Password = ""
 		}
 	}
 }

--- a/src/go/rpk/pkg/cli/shadow/update.go
+++ b/src/go/rpk/pkg/cli/shadow/update.go
@@ -10,6 +10,8 @@
 package shadow
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -18,26 +20,22 @@ import (
 	controlplanev1 "buf.build/gen/go/redpandadata/cloud/protocolbuffers/go/redpanda/api/controlplane/v1"
 	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
 	"connectrpc.com/connect"
-	"github.com/redpanda-data/common-go/rpadmin"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/oauth/providers/auth0"
 	rpkos "github.com/redpanda-data/redpanda/src/go/rpk/pkg/osutil"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
-// redacted is the placeholder shown in place of a set password; the server
-// only reports whether a password is set, never its value.
+// redacted is the placeholder for a set password; the server never reports
+// the value, only whether one is set.
 const redacted = "<redacted>"
 
-// cloudUpdateReplacePaths is the update mask covering every updatable field of
-// the cloud ShadowLinkUpdate message. The cloud API requires a mask, so
-// file-based updates use this to replace the entire configuration.
+// cloudUpdateReplacePaths lists every updatable ShadowLinkUpdate field; the
+// cloud API requires a mask, so updates always replace the entire config.
 var cloudUpdateReplacePaths = []string{
 	"client_options",
 	"topic_metadata_sync_options",
@@ -90,112 +88,54 @@ Replace the entire Shadow Link configuration from a file:
 			prof := cfg.VirtualProfile()
 			config.CheckExitServerlessAdmin(prof)
 
-			// Both modes replace the entire configuration; they differ only
-			// in where the config comes from: an editor seeded with the
-			// current config, or --config-file.
 			fromCloud := prof.CheckFromCloud()
-			fileMode := cfgLocation != ""
 			linkName := args[0]
-			var (
-				originalCfg *ShadowLinkConfig
-				updatedCfg  *ShadowLinkConfig
-				adminClient *rpadmin.AdminAPI
-				cloudClient *publicapi.CloudClientSet
-				cloudLinkID string
-			)
 
-			if fileMode {
-				updatedCfg, err = updatedConfigFromFile(fs, cfgLocation, linkName, fromCloud, prof.CloudCluster.ClusterID)
-				out.MaybeDieErr(err)
+			// Both modes replace the entire configuration; they differ only
+			// in where it comes from (--config-file or a pre-seeded editor).
+			updatedCfg, changed, err := resolveUpdatedConfig(cmd.Context(), fs, cfg, prof, fromCloud, cfgLocation, linkName)
+			out.MaybeDieErr(err)
+			if !changed {
+				out.Exit("No changes detected")
 			}
 
-			// Cloud always looks up the link to resolve its ID; editor mode
-			// also seeds the config from the current one.
 			if fromCloud {
-				cloudClient, err = publicapi.NewValidatedCloudClientSet(
-					cfg.DevOverrides().PublicAPIURL,
-					prof.CurrentAuth().AuthToken,
-					auth0.NewClient(cfg.DevOverrides()).Audience(),
-					[]string{prof.CurrentAuth().ClientID},
-				)
+				cloudClient, err := newCloudClientSet(cfg, prof)
 				out.MaybeDieErr(err)
 
+				// Cloud updates address the link by ID, resolved from its name.
 				link, err := cloudClient.ShadowLinkByNameAndRPID(cmd.Context(), linkName, prof.CloudCluster.ClusterID)
 				out.MaybeDie(err, "unable to find Shadow Link %q", linkName)
 
-				cloudLinkID = link.GetId()
-				if !fileMode {
-					// Cloud uses secrets for passwords, no redaction needed.
-					originalCfg = cloudShadowLinkToConfig(link)
-				}
-			} else {
-				adminClient, err = adminapi.NewClient(cmd.Context(), fs, prof)
-				out.MaybeDie(err, "unable to initialize admin client: %v", err)
-
-				if !fileMode {
-					link, err := adminClient.ShadowLinkService().GetShadowLink(cmd.Context(), connect.NewRequest(&adminv2.GetShadowLinkRequest{
-						Name: linkName,
-					}))
-					out.MaybeDie(err, "unable to get Redpanda Shadow Link information: %v", handleConnectError(err, "get", linkName))
-
-					shadowLink := link.Msg.GetShadowLink()
-					originalCfg = shadowLinkToConfig(shadowLink)
-
-					addRedactedPasswordString(originalCfg, shadowLink)
-				}
-			}
-
-			// Editor mode: open the editor and bail early when nothing
-			// changed.
-			if !fileMode {
-				updatedCfg, err = rpkos.EditTmpYAMLFile(cmd.Context(), fs, originalCfg)
-				out.MaybeDie(err, "unable to edit Shadow Link configuration: %v", err)
-
-				err = validateParsedShadowLinkConfig(updatedCfg)
-				out.MaybeDie(err, "invalid Shadow Link configuration: %v", err)
-
-				if updatedCfg.Name != originalCfg.Name {
-					out.Die("shadow link name cannot be changed; if you need to rename, please delete and recreate the shadow link")
-				}
-
-				diff := diffConfigs(originalCfg, updatedCfg)
-				if diff == nil {
-					out.Exit("No changes detected")
-				}
-				zap.L().Sugar().Debugf("Detected changes in: %v", strings.Join(diff, ", "))
-
-				// An untouched password placeholder means "keep the existing
-				// password"; the server preserves the stored password when
-				// the submitted one is empty and the username is set.
-				stripRedactedPasswords(updatedCfg)
-			}
-
-			if fromCloud {
 				err = validateCloudSecrets(cmd.Context(), prof, updatedCfg)
 				out.MaybeDie(err, "unable to validate cloud secrets: %v", err)
 
-				updatedSL := shadowLinkConfigToCloudUpdate(updatedCfg, cloudLinkID)
-
-				fm, err := fieldmaskpb.New(updatedSL, cloudUpdateReplacePaths...) // The cloud API rejects an empty mask.
-				out.MaybeDie(err, "unrecognized changed fields: %v; please report this with Redpanda Support", err)
 				op, err := cloudClient.ShadowLink.UpdateShadowLink(cmd.Context(), connect.NewRequest(&controlplanev1.UpdateShadowLinkRequest{
-					ShadowLink: updatedSL,
-					UpdateMask: fm,
+					ShadowLink: shadowLinkConfigToCloudUpdate(updatedCfg, link.GetId()),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: cloudUpdateReplacePaths}, // The cloud API rejects an empty mask.
 				}))
 				out.MaybeDie(err, "unable to update Shadow Link: %v", handleConnectError(err, "update", linkName))
-				spinner := out.NewSpinner(cmd.Context(), "Updating Shadow Link...")
+
+				spinner := out.NewSpinner(cmd.Context(), "Updating Shadow Link...", out.WithElapsedTime())
 				isComplete, err := waitForOperation(cmd.Context(), cloudClient, op.Msg.GetOperation().GetId())
 				if err != nil {
+					if oErr := new(OperationFailedError); errors.As(err, &oErr) {
+						spinner.Fail(tryShadowLinkErrReason(cmd.Context(), cloudClient.ShadowLink, oErr))
+						os.Exit(1)
+					}
 					spinner.Fail(fmt.Sprintf("unable to confirm Shadow Link update: %v", err))
 					os.Exit(1)
 				}
 				if !isComplete {
 					spinner.Stop()
-					out.Exit("Shadow link update is taking longer than expected. Please check the status of the shadow link using 'rpk shadow status %q'", linkName)
+					out.Exit("Shadow link update is taking longer than expected. Please check the status of the shadow link using 'rpk shadow status %v'", linkName)
 				}
 				spinner.Success(fmt.Sprintf("Successfully updated shadow link %q", linkName))
-				os.Exit(0)
+				return
 			}
+
+			adminClient, err := adminapi.NewClient(cmd.Context(), fs, prof)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			zap.L().Sugar().Debug("Requesting full configuration replacement")
 			_, err = adminClient.ShadowLinkService().UpdateShadowLink(cmd.Context(), connect.NewRequest(&adminv2.UpdateShadowLinkRequest{
@@ -209,10 +149,59 @@ Replace the entire Shadow Link configuration from a file:
 	return cmd
 }
 
-// updatedConfigFromFile parses and validates a Shadow Link configuration file
-// for use in update; the config's name must match linkName, and on a cloud
-// profile a cloud_options.shadow_redpanda_id, if present, must match the
-// selected cluster.
+// resolveUpdatedConfig returns the replacement config, parsed from cfgPath
+// or from an editor; changed is false when the editor left it untouched.
+func resolveUpdatedConfig(ctx context.Context, fs afero.Fs, cfg *config.Config, prof *config.RpkProfile, fromCloud bool, cfgPath, linkName string) (updated *ShadowLinkConfig, changed bool, err error) {
+	if cfgPath != "" {
+		updated, err := updatedConfigFromFile(fs, cfgPath, linkName, fromCloud, prof.CloudCluster.ClusterID)
+		if err != nil {
+			return nil, false, err
+		}
+		return updated, true, nil
+	}
+	original, err := currentShadowLinkConfig(ctx, fs, cfg, prof, fromCloud, linkName)
+	if err != nil {
+		return nil, false, err
+	}
+	updated, diff, err := editShadowLinkConfig(ctx, fs, original)
+	if err != nil {
+		return nil, false, err
+	}
+	return updated, diff != nil, nil
+}
+
+// currentShadowLinkConfig fetches the link's current configuration to seed
+// the editor; self-hosted set passwords are replaced with the placeholder.
+func currentShadowLinkConfig(ctx context.Context, fs afero.Fs, cfg *config.Config, prof *config.RpkProfile, fromCloud bool, linkName string) (*ShadowLinkConfig, error) {
+	if fromCloud {
+		cloudClient, err := newCloudClientSet(cfg, prof)
+		if err != nil {
+			return nil, err
+		}
+		link, err := cloudClient.ShadowLinkByNameAndRPID(ctx, linkName, prof.CloudCluster.ClusterID)
+		if err != nil {
+			return nil, fmt.Errorf("unable to find Shadow Link %q", linkName)
+		}
+		return cloudShadowLinkToConfig(link), nil
+	}
+	adminClient, err := adminapi.NewClient(ctx, fs, prof)
+	if err != nil {
+		return nil, fmt.Errorf("unable to initialize admin client: %v", err)
+	}
+	link, err := adminClient.ShadowLinkService().GetShadowLink(ctx, connect.NewRequest(&adminv2.GetShadowLinkRequest{
+		Name: linkName,
+	}))
+	if err != nil {
+		return nil, fmt.Errorf("unable to get Redpanda Shadow Link information: %v", handleConnectError(err, "get", linkName))
+	}
+	shadowLink := link.Msg.GetShadowLink()
+	original := shadowLinkToConfig(shadowLink)
+	addRedactedPasswordString(original, shadowLink)
+	return original, nil
+}
+
+// updatedConfigFromFile parses and validates a config file for update; the
+// name must match linkName, and any shadow_redpanda_id must match clusterID.
 func updatedConfigFromFile(fs afero.Fs, path, linkName string, fromCloud bool, clusterID string) (*ShadowLinkConfig, error) {
 	slCfg, err := parseShadowLinkConfig(fs, path)
 	if err != nil {
@@ -234,9 +223,33 @@ func updatedConfigFromFile(fs afero.Fs, path, linkName string, fromCloud bool, c
 	return slCfg, nil
 }
 
-// if a password is set, replace it with a redacted value so user can provide
-// a change easily instead of writing the full password field. The server only
-// reports whether a password is set, never its value.
+// editShadowLinkConfig opens an editor seeded with original; a nil diff means
+// no changes. Untouched password placeholders are cleared before returning.
+func editShadowLinkConfig(ctx context.Context, fs afero.Fs, original *ShadowLinkConfig) (*ShadowLinkConfig, []string, error) {
+	updated, err := rpkos.EditTmpYAMLFile(ctx, fs, original)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to edit Shadow Link configuration: %w", err)
+	}
+	if err := validateParsedShadowLinkConfig(updated); err != nil {
+		return nil, nil, fmt.Errorf("invalid Shadow Link configuration: %w", err)
+	}
+	if updated.Name != original.Name {
+		return nil, nil, errors.New("shadow link name cannot be changed; if you need to rename, please delete and recreate the shadow link")
+	}
+	diff := diffConfigs(original, updated)
+	if diff == nil {
+		return nil, nil, nil
+	}
+	zap.L().Sugar().Debugf("Detected changes in: %v", strings.Join(diff, ", "))
+
+	// An untouched placeholder means "keep the existing password"; the server
+	// keeps the stored password when it's empty and the username is set.
+	stripRedactedPasswords(updated)
+	return updated, diff, nil
+}
+
+// addRedactedPasswordString replaces set passwords with the placeholder; the
+// server only reports whether a password is set, never its value.
 func addRedactedPasswordString(cfg *ShadowLinkConfig, link *adminv2.ShadowLink) {
 	cfgs := link.GetConfigurations()
 	if cfgs.GetClientOptions().GetAuthenticationConfiguration().GetScramConfiguration().GetPasswordSet() {
@@ -264,9 +277,8 @@ func addRedactedPasswordString(cfg *ShadowLinkConfig, link *adminv2.ShadowLink) 
 	}
 }
 
-// stripRedactedPasswords clears passwords still holding the editor-seeded
-// placeholder. An empty password with a username set tells the server to keep
-// the existing password.
+// stripRedactedPasswords clears editor-seeded placeholders; an empty password
+// with a username set tells the server to keep the existing one.
 func stripRedactedPasswords(cfg *ShadowLinkConfig) {
 	if co := cfg.ClientOptions; co != nil {
 		if auth := co.AuthenticationConfiguration; auth != nil {
@@ -285,12 +297,8 @@ func stripRedactedPasswords(cfg *ShadowLinkConfig) {
 	}
 }
 
-// diffConfigs compares two ShadowLinkConfig objects and returns a list of
-// fields that changed. It uses Reflect to compare the fields and returns the
-// full JSON path of the changed fields, starting with "configurations".
-//
-// For example, if the 'bootstrap_servers' field changed, it returns
-// "configurations.client_options.bootstrap_servers".
+// diffConfigs returns the JSON paths of the fields that changed between the
+// two configs, e.g. "configurations.client_options.bootstrap_servers".
 func diffConfigs(original, updated *ShadowLinkConfig) []string {
 	if reflect.DeepEqual(original, updated) {
 		return nil // deeply equal, no changes.
@@ -305,20 +313,18 @@ func diffConfigs(original, updated *ShadowLinkConfig) []string {
 	return changedPaths
 }
 
-// getJSONTag extracts the JSON tag name from a struct field.
-// Returns empty string if the field should be skipped.
+// getJSONTag returns the field's json tag name; "" means skip the field.
 func getJSONTag(field reflect.StructField) string {
 	jsonTag := field.Tag.Get("json")
 	if jsonTag == "" || jsonTag == "-" {
 		return ""
 	}
-	// Extract the name before any options ("name,omitempty" -> "name")
-	parts := strings.Split(jsonTag, ",")
-	return parts[0]
+	// Take the name before any options ("name,omitempty" -> "name").
+	name, _, _ := strings.Cut(jsonTag, ",")
+	return name
 }
 
-// compareValues recursively compares two reflect.Value objects and records
-// changed paths.
+// compareValues recursively compares two values and records changed paths.
 func compareValues(original, updated reflect.Value, path string, changedPaths *[]string) {
 	if !original.IsValid() && !updated.IsValid() {
 		return
@@ -329,8 +335,8 @@ func compareValues(original, updated reflect.Value, path string, changedPaths *[
 		return
 	}
 
-	// Dereference pointers
-	if original.Kind() == reflect.Pointer {
+	switch original.Kind() {
+	case reflect.Pointer:
 		if original.IsNil() && updated.IsNil() {
 			return
 		}
@@ -339,10 +345,6 @@ func compareValues(original, updated reflect.Value, path string, changedPaths *[
 			return
 		}
 		compareValues(original.Elem(), updated.Elem(), path, changedPaths)
-		return
-	}
-
-	switch original.Kind() {
 	case reflect.Struct:
 		compareStructs(original, updated, path, changedPaths)
 	default:
@@ -356,14 +358,7 @@ func compareValues(original, updated reflect.Value, path string, changedPaths *[
 // compareStructs compares two struct values field by field.
 func compareStructs(original, updated reflect.Value, path string, changedPaths *[]string) {
 	typ := original.Type()
-
-	// Handle empty structs (markers like StartAtEarliest)
-	if typ.NumField() == 0 {
-		// Empty struct - just check existence (already handled by pointer nil check)
-		return
-	}
-
-	for i := 0; i < typ.NumField(); i++ {
+	for i := range typ.NumField() {
 		field := typ.Field(i)
 
 		if !field.IsExported() {

--- a/src/go/rpk/pkg/cli/shadow/update_test.go
+++ b/src/go/rpk/pkg/cli/shadow/update_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	controlplanev1 "buf.build/gen/go/redpandadata/cloud/protocolbuffers/go/redpanda/api/controlplane/v1"
+	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
@@ -332,6 +333,166 @@ func TestCloudUpdateReplacePaths(t *testing.T) {
 		}
 	}
 	require.ElementsMatch(t, want, cloudUpdateReplacePaths)
+}
+
+func TestAddRedactedPasswordString(t *testing.T) {
+	scramCfg := func(password string) *ShadowLinkConfig {
+		return &ShadowLinkConfig{
+			ClientOptions: &ShadowLinkClientOptions{
+				AuthenticationConfiguration: &AuthenticationConfiguration{
+					ScramConfiguration: &ScramConfiguration{Username: "user", Password: password},
+				},
+			},
+		}
+	}
+	plainCfg := func(password string) *ShadowLinkConfig {
+		return &ShadowLinkConfig{
+			ClientOptions: &ShadowLinkClientOptions{
+				AuthenticationConfiguration: &AuthenticationConfiguration{
+					PlainConfiguration: &PlainConfiguration{Username: "user", Password: password},
+				},
+			},
+		}
+	}
+	srBasicCfg := func(password string) *ShadowLinkConfig {
+		return &ShadowLinkConfig{
+			SchemaRegistrySyncOptions: &SchemaRegistrySyncOptions{
+				ShadowSchemaRegistryAPI: &ShadowSchemaRegistryAPI{
+					AuthOptions: &SchemaRegistryAuthOptions{
+						Basic: &HTTPBasicAuthOptions{Username: "user", Password: password},
+					},
+				},
+			},
+		}
+	}
+	tests := []struct {
+		name string
+		cfg  *ShadowLinkConfig
+		link *adminv2.ShadowLink
+		exp  *ShadowLinkConfig
+	}{
+		{
+			name: "scram password set",
+			cfg:  scramCfg(""),
+			link: &adminv2.ShadowLink{
+				Configurations: &adminv2.ShadowLinkConfigurations{
+					ClientOptions: &adminv2.ShadowLinkClientOptions{
+						AuthenticationConfiguration: &adminv2.AuthenticationConfiguration{
+							Authentication: &adminv2.AuthenticationConfiguration_ScramConfiguration{
+								ScramConfiguration: &adminv2.ScramConfig{Username: "user", PasswordSet: true},
+							},
+						},
+					},
+				},
+			},
+			exp: scramCfg(redacted),
+		},
+		{
+			name: "plain password set",
+			cfg:  plainCfg(""),
+			link: &adminv2.ShadowLink{
+				Configurations: &adminv2.ShadowLinkConfigurations{
+					ClientOptions: &adminv2.ShadowLinkClientOptions{
+						AuthenticationConfiguration: &adminv2.AuthenticationConfiguration{
+							Authentication: &adminv2.AuthenticationConfiguration_PlainConfiguration{
+								PlainConfiguration: &adminv2.PlainConfig{Username: "user", PasswordSet: true},
+							},
+						},
+					},
+				},
+			},
+			exp: plainCfg(redacted),
+		},
+		{
+			name: "schema registry basic password set",
+			cfg:  srBasicCfg(""),
+			link: &adminv2.ShadowLink{
+				Configurations: &adminv2.ShadowLinkConfigurations{
+					SchemaRegistrySyncOptions: &adminv2.SchemaRegistrySyncOptions{
+						SchemaRegistryShadowingMode: &adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryApi_{
+							ShadowSchemaRegistryApi: &adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryApi{
+								AuthOptions: &adminv2.SchemaRegistryAuthOptions{
+									AuthOptions: &adminv2.SchemaRegistryAuthOptions_Basic{
+										Basic: &adminv2.HTTPBasicAuthOptions{Username: "user", PasswordSet: true},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			exp: srBasicCfg(redacted),
+		},
+		{
+			name: "no password set leaves config untouched",
+			cfg:  scramCfg(""),
+			link: &adminv2.ShadowLink{
+				Configurations: &adminv2.ShadowLinkConfigurations{
+					ClientOptions: &adminv2.ShadowLinkClientOptions{
+						AuthenticationConfiguration: &adminv2.AuthenticationConfiguration{
+							Authentication: &adminv2.AuthenticationConfiguration_ScramConfiguration{
+								ScramConfiguration: &adminv2.ScramConfig{Username: "user"},
+							},
+						},
+					},
+				},
+			},
+			exp: scramCfg(""),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addRedactedPasswordString(tt.cfg, tt.link)
+			require.Equal(t, tt.exp, tt.cfg)
+		})
+	}
+}
+
+func TestStripRedactedPasswords(t *testing.T) {
+	full := func(scram, plain, srBasic string) *ShadowLinkConfig {
+		return &ShadowLinkConfig{
+			ClientOptions: &ShadowLinkClientOptions{
+				AuthenticationConfiguration: &AuthenticationConfiguration{
+					ScramConfiguration: &ScramConfiguration{Username: "user", Password: scram},
+					PlainConfiguration: &PlainConfiguration{Username: "user", Password: plain},
+				},
+			},
+			SchemaRegistrySyncOptions: &SchemaRegistrySyncOptions{
+				ShadowSchemaRegistryAPI: &ShadowSchemaRegistryAPI{
+					AuthOptions: &SchemaRegistryAuthOptions{
+						Basic: &HTTPBasicAuthOptions{Username: "user", Password: srBasic},
+					},
+				},
+			},
+		}
+	}
+	tests := []struct {
+		name string
+		cfg  *ShadowLinkConfig
+		exp  *ShadowLinkConfig
+	}{
+		{
+			name: "placeholders are cleared",
+			cfg:  full(redacted, redacted, redacted),
+			exp:  full("", "", ""),
+		},
+		{
+			name: "real passwords are kept",
+			cfg:  full("hunter2", "hunter3", "hunter4"),
+			exp:  full("hunter2", "hunter3", "hunter4"),
+		},
+		{
+			name: "nil sections are ignored",
+			cfg:  &ShadowLinkConfig{Name: "test"},
+			exp:  &ShadowLinkConfig{Name: "test"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stripRedactedPasswords(tt.cfg)
+			require.Equal(t, tt.exp, tt.cfg)
+		})
+	}
 }
 
 func TestUpdatedConfigFromFile(t *testing.T) {

--- a/src/v/redpanda/admin/services/shadow_link/converter.cc
+++ b/src/v/redpanda/admin/services/shadow_link/converter.cc
@@ -1678,6 +1678,30 @@ void merge_input_only_fields(
         }
     }
 
+    // Same for PLAIN, which is stored internally as scram_credentials with
+    // the "PLAIN" mechanism
+    if (
+      client_options.has_authentication_configuration()
+      && client_options.get_authentication_configuration()
+           .has_plain_configuration()) {
+        auto& to_plain = client_options.get_authentication_configuration()
+                           .get_plain_configuration();
+        if (
+          to_plain.get_password().empty() && !to_plain.get_username().empty()) {
+            if (
+              from.connection.authn_config.has_value()
+              && std::holds_alternative<cluster_link::model::scram_credentials>(
+                from.connection.authn_config.value())) {
+                const auto& from_creds
+                  = std::get<cluster_link::model::scram_credentials>(
+                    from.connection.authn_config.value());
+                if (from_creds.mechanism == "PLAIN") {
+                    to_plain.set_password(ss::sstring{from_creds.password});
+                }
+            }
+        }
+    }
+
     // Now check to see if the TLS settings are using values and if cert is set.
     // If so, then the key was not updated so we will use the curent key
     if (

--- a/src/v/redpanda/admin/services/shadow_link/tests/BUILD
+++ b/src/v/redpanda/admin/services/shadow_link/tests/BUILD
@@ -1,4 +1,30 @@
+load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("//bazel:test.bzl", "redpanda_cc_gtest")
+
+cc_proto_library(
+    name = "shadow_link_cc_proto",
+    deps = ["//proto/redpanda/core/admin/v2:shadow_link_proto"],
+)
+
+cc_proto_library(
+    name = "field_behavior_cc_proto",
+    deps = ["@googleapis//google/api:field_behavior_proto"],
+)
+
+redpanda_cc_gtest(
+    name = "input_only_fields_test",
+    timeout = "short",
+    srcs = [
+        "input_only_fields_test.cc",
+    ],
+    deps = [
+        ":field_behavior_cc_proto",
+        ":shadow_link_cc_proto",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@protobuf",
+    ],
+)
 
 redpanda_cc_gtest(
     name = "converter_test",

--- a/src/v/redpanda/admin/services/shadow_link/tests/converter_test.cc
+++ b/src/v/redpanda/admin/services/shadow_link/tests/converter_test.cc
@@ -1253,6 +1253,113 @@ TEST(converter_test, invalid_scram_update) {
       serde::pb::rpc::invalid_argument_exception);
 }
 
+TEST(converter_test, update_plain_creds_preserves_password) {
+    auto password_last_updated = model::to_timestamp(
+      std::chrono::system_clock::now() - 1h);
+    cluster_link::model::metadata current_md;
+    current_md.name = cluster_link::model::name_t{"test-link"};
+    current_md.uuid = cluster_link::model::uuid_t{uuid_t::create()};
+    current_md.connection.bootstrap_servers = {
+      net::unresolved_address("localhost", 9092)};
+    current_md.connection.authn_config = cluster_link::model::scram_credentials{
+      .username = "plain-user",
+      .password = "old-password",
+      .mechanism = "PLAIN",
+      .password_last_updated = password_last_updated};
+    admin::set_client_id(current_md);
+
+    // Mirror rpk's editor flow: an empty mask (full replace) carrying the
+    // complete configuration with the plain password left empty.
+    proto::admin::plain_config plain_config;
+    plain_config.set_username("plain-user");
+
+    proto::admin::authentication_configuration authn_config;
+    authn_config.set_plain_configuration(std::move(plain_config));
+
+    proto::admin::shadow_link_client_options client_options;
+    client_options.set_bootstrap_servers({"localhost:9092"});
+    client_options.set_authentication_configuration(std::move(authn_config));
+
+    proto::admin::update_shadow_link_request req;
+    req.get_shadow_link().set_name("test-link");
+    req.get_shadow_link().get_configurations().set_client_options(
+      std::move(client_options));
+
+    auto update_cmd = admin::create_update_cluster_link_config_cmd(
+      std::move(req),
+      ss::make_lw_shared<cluster_link::model::metadata>({
+        .name = current_md.name,
+        .uuid = current_md.uuid,
+        .connection = current_md.connection,
+        .configuration = current_md.configuration.copy(),
+      }));
+
+    ASSERT_TRUE(update_cmd.connection.authn_config.has_value());
+    const auto& creds = std::get<cluster_link::model::scram_credentials>(
+      update_cmd.connection.authn_config.value());
+    EXPECT_EQ(creds.username, "plain-user");
+    EXPECT_EQ(creds.password, "old-password");
+    EXPECT_EQ(creds.mechanism, "PLAIN");
+    EXPECT_EQ(creds.password_last_updated, password_last_updated);
+}
+
+TEST(converter_test, update_with_empty_mask_replaces_repeated_fields) {
+    cluster_link::model::metadata current_md;
+    current_md.name = cluster_link::model::name_t{"test-link"};
+    current_md.uuid = cluster_link::model::uuid_t{uuid_t::create()};
+    current_md.connection.bootstrap_servers = {
+      net::unresolved_address("localhost", 9092)};
+    current_md.configuration.topic_metadata_mirroring_cfg.topic_name_filters
+      .emplace_back(
+        cluster_link::model::resource_name_filter_pattern{
+          .pattern_type = cluster_link::model::filter_pattern_type::literal,
+          .filter = cluster_link::model::filter_type::include,
+          .pattern = "drop-me-1"});
+    current_md.configuration.topic_metadata_mirroring_cfg.topic_name_filters
+      .emplace_back(
+        cluster_link::model::resource_name_filter_pattern{
+          .pattern_type = cluster_link::model::filter_pattern_type::literal,
+          .filter = cluster_link::model::filter_type::include,
+          .pattern = "drop-me-2"});
+    admin::set_client_id(current_md);
+
+    // An empty mask replaces the whole configuration, so the repeated filter
+    // list must shrink to the single submitted entry rather than be appended
+    // to.
+    proto::admin::topic_metadata_sync_options topic_metadata_sync_options;
+    chunked_vector<proto::admin::name_filter> filters;
+    filters.emplace_back(create_name_filter(
+      proto::admin::pattern_type::literal,
+      proto::admin::filter_type::include,
+      "keep-me"));
+    topic_metadata_sync_options.set_auto_create_shadow_topic_filters(
+      std::move(filters));
+
+    proto::admin::shadow_link_client_options client_options;
+    client_options.set_bootstrap_servers({"localhost:9092"});
+
+    proto::admin::update_shadow_link_request req;
+    req.get_shadow_link().set_name("test-link");
+    req.get_shadow_link().get_configurations().set_client_options(
+      std::move(client_options));
+    req.get_shadow_link().get_configurations().set_topic_metadata_sync_options(
+      std::move(topic_metadata_sync_options));
+
+    auto update_cmd = admin::create_update_cluster_link_config_cmd(
+      std::move(req),
+      ss::make_lw_shared<cluster_link::model::metadata>({
+        .name = current_md.name,
+        .uuid = current_md.uuid,
+        .connection = current_md.connection,
+        .configuration = current_md.configuration.copy(),
+      }));
+
+    const auto& filters_after
+      = update_cmd.link_config.topic_metadata_mirroring_cfg.topic_name_filters;
+    ASSERT_EQ(filters_after.size(), 1);
+    EXPECT_EQ(filters_after[0].pattern, "keep-me");
+}
+
 TEST(converter_test, test_update_tls_value) {
     cluster_link::model::metadata current_md;
     current_md.name = cluster_link::model::name_t{"test-link"};

--- a/src/v/redpanda/admin/services/shadow_link/tests/input_only_fields_test.cc
+++ b/src/v/redpanda/admin/services/shadow_link/tests/input_only_fields_test.cc
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "proto/redpanda/core/admin/v2/shadow_link.pb.h"
+
+#include <gmock/gmock.h>
+#include <google/api/field_behavior.pb.h>
+#include <google/protobuf/descriptor.h>
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+namespace {
+
+bool is_input_only(const google::protobuf::FieldDescriptor& field) {
+    const auto& behaviors = field.options().GetRepeatedExtension(
+      google::api::field_behavior);
+    return std::ranges::any_of(behaviors, [](auto behavior) {
+        return behavior == google::api::INPUT_ONLY;
+    });
+}
+
+// Enumerates every path (dotted chain of field names) from `message` to a
+// field annotated (google.api.field_behavior) = INPUT_ONLY. Paths are
+// enumerated per reference, not per field descriptor, so reusing a message
+// containing INPUT_ONLY fields in a new place (e.g. another TLSSettings)
+// yields a new path.
+void collect_input_only_paths(
+  const google::protobuf::Descriptor& message,
+  const std::string& prefix,
+  std::vector<const google::protobuf::Descriptor*>& parents,
+  std::vector<std::string>& paths) {
+    if (std::ranges::contains(parents, &message)) {
+        return;
+    }
+    parents.push_back(&message);
+    for (int i = 0; i < message.field_count(); ++i) {
+        const auto* field = message.field(i);
+        auto path = prefix.empty() ? std::string{field->name()}
+                                   : prefix + "." + std::string{field->name()};
+        if (is_input_only(*field)) {
+            paths.push_back(path);
+        }
+        if (field->message_type() != nullptr) {
+            collect_input_only_paths(
+              *field->message_type(), path, parents, paths);
+        }
+    }
+    parents.pop_back();
+}
+
+} // namespace
+
+TEST(input_only_fields, merge_input_only_fields_covers_all) {
+    std::vector<std::string> paths;
+    std::vector<const google::protobuf::Descriptor*> parents;
+    collect_input_only_paths(
+      *redpanda::core::admin::v2::ShadowLink::descriptor(), "", parents, paths);
+
+    // Clients cannot read INPUT_ONLY values back, so an update request that
+    // omits one must keep the stored value instead of clearing it. Every
+    // INPUT_ONLY path reachable from ShadowLink therefore needs a matching
+    // branch in merge_input_only_fields() in converter.cc. If this
+    // expectation fails because a path appeared, add that branch first, then
+    // extend this list.
+    // clang-format off
+    EXPECT_THAT(
+      paths,
+      testing::UnorderedElementsAre(
+        "configurations.client_options.authentication_configuration.scram_configuration.password",
+        "configurations.client_options.authentication_configuration.plain_configuration.password",
+        "configurations.client_options.tls_settings.tls_pem_settings.key",
+        "configurations.schema_registry_sync_options.shadow_schema_registry_api.auth_options.basic.password",
+        "configurations.schema_registry_sync_options.shadow_schema_registry_api.tls_settings.tls_pem_settings.key"));
+    // clang-format on
+}

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1347,7 +1347,12 @@ class RpkTool:
         output = self._execute(cmd)
         return json.loads(output) if output_format == "json" else output
 
-    def _run_shadow(self, args: list[str], output_format: str | None = None) -> Any:
+    def _run_shadow(
+        self,
+        args: list[str],
+        output_format: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> Any:
         cmd = [
             self._rpk_binary(),
             "-X",
@@ -1356,7 +1361,7 @@ class RpkTool:
         ] + args
         if output_format is not None:
             cmd += ["--format", output_format]
-        output = self._execute(cmd)
+        output = self._execute(cmd, env=env)
         return json.loads(output) if output_format == "json" else output
 
     def shadow_create(self, config: dict[str, Any], no_confirm: bool = True) -> str:
@@ -1373,6 +1378,13 @@ class RpkTool:
             yaml.safe_dump(config, tf)
             tf.flush()
             return self._run_shadow(["update", name, "-c", tf.name])
+
+    def shadow_update_editor(self, name: str, editor: str) -> str:
+        """Run 'rpk shadow update' in editor mode. rpk seeds a temp file with
+        the current configuration and invokes `editor <tmpfile>` ($EDITOR is
+        not shell-parsed, so it must be a single executable); the edited file
+        is submitted when the editor exits."""
+        return self._run_shadow(["update", name], env={"EDITOR": editor})
 
     def shadow_status(self, name: str, output_format: str = "json") -> Any:
         return self._run_shadow(["status", name, "--print-all"], output_format)
@@ -1563,7 +1575,9 @@ class RpkTool:
             self._redpanda.logger.debug("Executing command: %s", cmd)
 
         if env is not None:
-            env.update(os.environ.copy())
+            # Caller-provided variables take precedence over the inherited
+            # environment.
+            env = os.environ | env
 
         p = subprocess.Popen(
             cmd,

--- a/tests/rptest/tests/rpk_shadow_link_test.py
+++ b/tests/rptest/tests/rpk_shadow_link_test.py
@@ -8,8 +8,12 @@
 # by the Apache License, Version 2.0
 
 import copy
+import os
+import sys
+import tempfile
 from typing import Any
 
+import yaml
 from ducktape.utils.util import wait_until
 
 from rptest.clients.rpk import RPKACLInput, RpkTool
@@ -140,13 +144,14 @@ class RpkShadowLinkTest(RpkShadowLinkTestBase):
             err_msg="role was not synced to the shadow cluster",
         )
 
-    @cluster(num_nodes=6)  # 3 target + 3 source brokers
+    @cluster(num_nodes=6)
     def test_shadow_update_config_file_topic_filters(self):
         """
         'rpk shadow update --config-file' replaces the entire configuration
         rather than diffing changed fields. Grow
         topic_metadata_sync_options.auto_create_shadow_topic_filters from one
-        filter to two and confirm the replacement lands.
+        filter to two, then shrink it back to one, and confirm each
+        replacement lands exactly.
         """
         rpk = self.target_cluster_rpk
 
@@ -169,6 +174,16 @@ class RpkShadowLinkTest(RpkShadowLinkTestBase):
             backoff_sec=1,
             retry_on_exc=True,
             err_msg="updated topic filters were not applied",
+        )
+
+        rpk.shadow_update(self.LINK_NAME, self._filters_link_config(one_filter))
+
+        wait_until(
+            lambda: self._topic_filters(rpk) == one_filter,
+            timeout_sec=30,
+            backoff_sec=1,
+            retry_on_exc=True,
+            err_msg="shrunk topic filter list was not applied",
         )
 
     def _filters_link_config(self, filters: list[dict[str, str]]) -> dict[str, Any]:
@@ -349,30 +364,50 @@ class RpkShadowLinkTest(RpkShadowLinkTestBase):
         return expected["member"] in members
 
 
+# Stand-in for $EDITOR in 'rpk shadow update' editor-mode tests. rpk is not
+# shell-parsing $EDITOR, so it must be a single executable; rpk invokes it as
+# `<script> <seeded yaml file>` and submits the file once it exits. The script
+# saves the seeded file aside for the test to assert on, then appends a topic
+# filter, leaving every other field (including the '<redacted>' password
+# placeholder) untouched. Formatted with python (the test venv interpreter,
+# which has yaml installed) and seeded_copy (where to save the seeded file).
+_FAKE_EDITOR_SCRIPT = """#!{python}
+import shutil
+import sys
+
+import yaml
+
+path = sys.argv[1]
+shutil.copy(path, {seeded_copy!r})
+
+with open(path) as f:
+    cfg = yaml.safe_load(f)
+
+cfg["topic_metadata_sync_options"]["auto_create_shadow_topic_filters"].append(
+    {{"pattern_type": "PREFIX", "filter_type": "INCLUDE", "name": "topic-b-"}}
+)
+
+with open(path, "w") as f:
+    yaml.safe_dump(cfg, f)
+"""
+
+
 class RpkShadowLinkAuthTest(RpkShadowLinkTestBase):
-    """Password-preservation on 'rpk shadow update --config-file'. This needs a
-    SASL-authenticated link: CreateShadowLink runs a source preflight check, so
-    the link must authenticate against the source with real credentials."""
+    """Password-preservation on 'rpk shadow update', both --config-file and
+    editor mode. This needs a SASL-authenticated link: CreateShadowLink runs a
+    source preflight check, so the link must authenticate against the source
+    with real credentials."""
 
     def __init__(self, test_context: TestContext, *args: Any, **kwargs: Any):
         security = SecurityConfig()
         security.enable_sasl = True
         super().__init__(test_context, security=security, *args, **kwargs)
 
-    @cluster(num_nodes=6)  # 3 target + 3 source brokers
-    def test_shadow_update_config_file_preserves_password(self):
-        """
-        A file-based update replaces the whole configuration, but an empty
-        SCRAM password with the username still set must preserve the existing
-        password rather than clear it. If it were cleared, the link's source
-        preflight would fail to re-authenticate on the update.
-        """
-        rpk = self.target_cluster_rpk
+    def _scram_link_config(self) -> dict[str, Any]:
         # Both clusters bootstrap the same superuser; using it as the link
         # principal lets the source preflight authenticate successfully.
         su = self.redpanda.SUPERUSER_CREDENTIALS
-
-        base: dict[str, Any] = {
+        return {
             "name": self.LINK_NAME,
             "client_options": {
                 "bootstrap_servers": self.source_cluster_service.brokers_list(),
@@ -394,6 +429,19 @@ class RpkShadowLinkAuthTest(RpkShadowLinkTestBase):
                 ],
             },
         }
+
+    @cluster(num_nodes=6)
+    def test_shadow_update_config_file_preserves_password(self):
+        """
+        A file-based update replaces the whole configuration, but an empty
+        SCRAM password with the username still set must preserve the existing
+        password rather than clear it. If it were cleared, the link's source
+        preflight would fail to re-authenticate on the update.
+        """
+        rpk = self.target_cluster_rpk
+        su = self.redpanda.SUPERUSER_CREDENTIALS
+
+        base = self._scram_link_config()
         rpk.shadow_create(base)
         self._wait_link_active(rpk)
 
@@ -428,3 +476,60 @@ class RpkShadowLinkAuthTest(RpkShadowLinkTestBase):
         # cleared and re-set (which would bump it).
         assert auth.get("password_set_at") == password_set_at, auth
         assert len(self._topic_filters(rpk)) == 2, self._topic_filters(rpk)
+
+    @cluster(num_nodes=6)
+    def test_shadow_update_editor_preserves_password(self):
+        """
+        Editor-mode updates seed a set SCRAM password as the '<redacted>'
+        placeholder and, like --config-file, submit a full replacement. rpk
+        must strip an untouched placeholder to an empty password so the server
+        preserves the stored one; submitting the placeholder verbatim would
+        silently change the password and break re-authentication to the
+        source.
+        """
+        rpk = self.target_cluster_rpk
+        su = self.redpanda.SUPERUSER_CREDENTIALS
+
+        rpk.shadow_create(self._scram_link_config())
+        self._wait_link_active(rpk)
+
+        auth = self._client_auth(rpk)
+        assert auth.get("password_set") is True, auth
+        password_set_at = auth.get("password_set_at")
+        assert password_set_at, auth
+
+        with tempfile.TemporaryDirectory() as td:
+            seeded_copy = os.path.join(td, "seeded.yaml")
+            editor = os.path.join(td, "editor")
+            with open(editor, "w") as f:
+                f.write(
+                    _FAKE_EDITOR_SCRIPT.format(
+                        python=sys.executable, seeded_copy=seeded_copy
+                    )
+                )
+            os.chmod(editor, 0o755)
+
+            rpk.shadow_update_editor(self.LINK_NAME, editor)
+
+            with open(seeded_copy) as f:
+                seeded = yaml.safe_load(f)
+
+        # check that rpk seeded the editor with the placeholder, never a real password.
+        seeded_scram = seeded["client_options"]["authentication_configuration"][
+            "scram_configuration"
+        ]
+        assert seeded_scram.get("password") == "<redacted>", seeded_scram
+
+        # The update landed (the filter appended in the editor is present),
+        # the placeholder was stripped rather than stored (set-at timestamp
+        # unchanged), and the link still authenticates to the source with the
+        # preserved password.
+        self._wait_link_active(rpk)
+        auth = self._client_auth(rpk)
+        assert auth.get("password_set") is True, auth
+        assert auth.get("username") == su.username, auth
+        assert auth.get("password_set_at") == password_set_at, auth
+        assert self._topic_filters(rpk) == [
+            {"pattern_type": "LITERAL", "filter_type": "INCLUDE", "name": "topic-a"},
+            {"pattern_type": "PREFIX", "filter_type": "INCLUDE", "name": "topic-b-"},
+        ], self._topic_filters(rpk)


### PR DESCRIPTION
The `rpk shadow update` editor flow sent a protobuf field mask of only the changed fields, but the server merges masked repeated fields by appending, so removing an entry from a filter list quietly unioned the old and new lists. Lists could never shrink or be cleared via an editor update.

This PR makes both update modes (editor and `--config-file`) submit the full configuration instead: an unset mask for the admin API, and a mask of every updatable path for the cloud API (which rejects empty masks). Editor-seeded `<redacted>` password placeholders are stripped before submitting, since an empty password with a username set tells the server to keep the stored one; PLAIN passwords are now redacted in the editor too.

That last part exposed a server-side gap: `merge_input_only_fields` only carried the stored password forward for SCRAM configs, so a full-replace update of a PLAIN-authenticated link was rejected with an invalid argument error. The second commit applies the same merge for PLAIN, reusing the stored password only when the existing credentials use the PLAIN mechanism.

**Covered by:**
* converter unit tests: empty update mask replaces repeated filter fields instead of appending, and PLAIN passwords survive a full-replace update.
* ducktape: filter lists now shrink on update, and a fake `$EDITOR` script drives the real editor flow end-to-end, asserting the seeded `<redacted>`  placeholder is stripped and `password_set_at` is untouched (i.e password didn't change when sending an empty one).

**Note for reviewers**: for cloud, replacing nested repeated fields through the five top-level mask paths depends on control-plane behavior we could not verify empirically; if the control plane also appends, that needs a fix on its side since maskless updates are rejected by validation.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.2.x
- [X] v26.1.x
- [ ] v25.3.x

## Release Notes

### Bug Fixes

* `rpk shadow update` in editor mode now replaces the entire Shadow Link configuration instead of merging changed fields, so list-valued fields (e.g. topic filters) can shrink or be cleared.
* Updating a Shadow Link that uses PLAIN authentication no longer fails when the password is omitted; the stored password is preserved.