### PR TITLE
tests: compare with v26.2.x branch for pass criteria

### DIFF
--- a/tests/ducktape-common-retry.yml
+++ b/tests/ducktape-common-retry.yml
@@ -8,7 +8,7 @@ common_pc_definitions: &common_pc_definitions
   statistical-default:
     mode:
       statistical:
-        compare_with_branch: dev
+        compare_with_branch: v26.2.x
         time_window: 2w
         reject_threshold: 0.01
         trust_threshold: 0.5
@@ -16,14 +16,14 @@ common_pc_definitions: &common_pc_definitions
   zero-drift:
     mode:
       dynamic_reliability:
-        compare_with_branch: dev
+        compare_with_branch: v26.2.x
         time_window: 2w
         allowed_drift: 0 # upstream_reliability - current_ci_reliability <= allowed_drift
         fallback_reliability: 90.0 # when reliability cannot be fetched from branch (e.g. new test)
   fifty-drift:
     mode:
       dynamic_reliability:
-        compare_with_branch: dev
+        compare_with_branch: v26.2.x
         time_window: 2w
         allowed_drift: 50 # upstream_reliability - current_ci_reliability <= allowed_drift
         fallback_reliability: 90.0 # when reliability cannot be fetched from branch (e.g. new test)


### PR DESCRIPTION
Now that `v26.2.x` is cut and test results are available, the pass criteria auto-retry config should compare with the `v26.2.x` branch rather than `dev`.

Left pointing at `dev`, the statistical and dynamic-reliability pass criteria on this release branch measure themselves against a branch that has already moved on to v26.3 development, so the reliability baselines drift away from what this branch actually ships.

This updates all three sections in `tests/ducktape-common-retry.yml` (`statistical-default`, `zero-drift`, `fifty-drift`) to `compare_with_branch: v26.2.x`, matching what was done for `v26.1.x` and `v25.2.x` (#26921) after those branches were cut. This is a post-branch task from [Branching for release](https://redpandadata.atlassian.net/wiki/spaces/CORE/pages/1313243197/Branching+for+release).

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none