### PR TITLE
`rptest`: various test fixes with faulty version/upgrade expectations

### DIFF
--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -907,6 +907,28 @@ class Admin:
     def get_features(self, node: MaybeNode = None):
         return self._request("GET", "features", node=node).json()
 
+    def await_active_version_settled(
+        self,
+        node: MaybeNode = None,
+        timeout_sec: int = 60,
+        backoff_sec: int = 1,
+    ) -> None:
+        """
+        Wait until the cluster's active version has caught up to the
+        queried node's binary (cluster_version == node_latest_version).
+        """
+
+        def settled():
+            features = self.get_features(node=node)
+            return features["cluster_version"] == features["node_latest_version"]
+
+        wait_until(
+            settled,
+            timeout_sec=timeout_sec,
+            backoff_sec=backoff_sec,
+            err_msg="active version did not settle after upgrade",
+        )
+
     def get_cloud_storage_lifecycle_markers(self, node: MaybeNode = None):
         return self._request("GET", "cloud_storage/lifecycle", node=node).json()
 

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -1308,16 +1308,27 @@ class ManualFinalizationUpgradeTest(UnfinalizedUpgradeMixin, FeaturesTestBase):
         """Perturb the cluster while it sits in `phase` (e.g.
         "...-upgraded-unfinalized" on the new binary, or "...-downgraded" after a
         rollback). Structured as 1 + N parts: shared baseline work, then one
-        function per supported unfinalized-upgrade step. Today N=1 -- the
-        v26.1 -> v26.2 step. See the note above the per-step functions for how
-        this grows for v26.3 and beyond."""
+        function per supported unfinalized-upgrade step, dispatched on the old
+        release's feature line so only the step matching the upgrade window
+        under test runs. See the note above the per-step functions for how
+        this grows for new majors."""
         self.logger.info(f"perturb: phase={phase}")
         self._perturb_common(phase)
         if "upgraded" in phase:
             # Generic across majors: every feature gated by the upgrade under
             # test must be exercised or acknowledged.
             self._assert_feature_coverage()
-        self._perturb_v26_1_to_v26_2(phase)
+        # A missing entry (e.g. right after a version cut, before any gated
+        # feature lands in the new major) leaves only the shared baseline and
+        # the coverage guard -- exactly what an upgrade that gates nothing
+        # needs. The guard fails loudly once a gated feature appears, forcing
+        # a new per-step function to be written and registered here.
+        per_step = {
+            (26, 1): self._perturb_v26_1_to_v26_2,
+        }
+        step = per_step.get(self.old_release[:2])
+        if step is not None:
+            step(phase)
 
     def _perturb_common(self, phase):
         """Baseline data-plane perturbation, run in every state. On the first
@@ -1367,20 +1378,24 @@ class ManualFinalizationUpgradeTest(UnfinalizedUpgradeMixin, FeaturesTestBase):
 
     # NOTE: growing this beyond the v26.1 -> v26.2 step.
     #
-    # When v26.2 is released and v26.3 development begins, two things change:
-    #   1. Add a new per-step function, e.g. _perturb_v26_2_to_v26_3, exercising
-    #      the features gated by the unfinalized v26.2 -> v26.3 upgrade, and call
-    #      it from _perturb alongside the existing one.
-    #   2. Extend the harness to perform CHAINED unfinalized upgrades: an
-    #      unfinalized upgrade v26.1 -> v26.2, then a further unfinalized upgrade
-    #      v26.2 -> v26.3, perturbing (and exercising downgrade) at each step
-    #      instead of a single old -> HEAD hop.
-    # Keep older step functions and their harness coverage for as long as the
-    # support window allows upgrading from those releases; drop a step once its
-    # source release leaves the supported upgrade matrix.
+    # Once the first feature gated on the new major lands, the coverage guard
+    # (_assert_feature_coverage) fails: add a new per-step function, e.g.
+    # _perturb_v26_2_to_v26_3, exercising the features gated by the unfinalized
+    # v26.2 -> v26.3 upgrade, and register it in _perturb's per-step dispatch.
+    # A step only runs when the installed old release matches its source line,
+    # so older steps go dormant (rather than fail) as the prior feature line
+    # moves forward; they stay live on release branches where the prior line
+    # still matches. Drop a step once its source release leaves the supported
+    # upgrade matrix everywhere.
+    #
+    # A possible further extension: perform CHAINED unfinalized upgrades (an
+    # unfinalized upgrade v26.1 -> v26.2, then a further unfinalized upgrade
+    # v26.2 -> v26.3, perturbing and exercising downgrade at each step) instead
+    # of a single old -> HEAD hop.
     def _perturb_v26_1_to_v26_2(self, phase):
-        """Per-step perturbation for the v26.1 -> v26.2 unfinalized upgrade (the
-        N=1 part of the 1 + N structure).
+        """Per-step perturbation for the v26.1 -> v26.2 unfinalized upgrade;
+        dispatched from _perturb only when the installed old release is on the
+        v26.1 line.
 
         Exercises the code paths gated by the v26.2 feature flags. While the
         upgrade is unfinalized the active version is held at v26.1, so these

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -1813,86 +1813,109 @@ class ManualFinalizationUpgradeTest(UnfinalizedUpgradeMixin, FeaturesTestBase):
     def test_config_passes_through_multi_hop_upgrade(self):
         """
         Lock in that `features_auto_finalization`, set once on the oldest
-        release, survives a multi-hop upgrade (v25.3.x -> v26.1.x -> HEAD) and
-        is still honored by the final binary's gating logic.
+        release, survives a multi-hop upgrade from v25.3.x all the way to HEAD
+        and is still honored by the gating logic of every binary that ships it.
 
-        The knob was backported to both v25.3.15 and v26.1.9, so every
-        intermediate binary recognizes the property and carries it through the
-        controller log unchanged. Only HEAD consumes the knob, so the
-        deferred-advance behavior appears only after the final hop -- the
-        intermediate v26.1 hop advances the active version normally.
+        The knob was backported to v25.3.15 and v26.1.9 and ships natively from
+        v26.2.1 onward, so every binary in the chain recognizes the property
+        and carries it through the controller log unchanged. The gating logic
+        first shipped in v26.2.1: a hop onto an older binary auto-advances the
+        active version, while every hop onto a v26.2.1+ binary defers its
+        advance until an explicit finalize.
+
+        The hop chain is recomputed from the released-versions list each run,
+        so a new feature release extends the chain with one more gated
+        intermediate hop instead of breaking the test: an intermediate gated
+        hop must be finalized anyway, because the next binary only supports
+        upgrading from the immediately preceding logical version.
         """
-        oldest, _ = self.installer.latest_for_line((25, 3))
-        assert oldest >= MANUAL_FINALIZE_MIN_OLDEST_RELEASE, (
-            f"latest v25.3 patch {oldest} predates the features_auto_finalization "
-            f"backport {MANUAL_FINALIZE_MIN_OLDEST_RELEASE}"
-        )
-        mid, _ = self.installer.latest_for_line((26, 1))
-        assert mid >= self.MIN_OLD_RELEASE, (
-            f"latest v26.1 patch {mid} predates the backport {self.MIN_OLD_RELEASE}"
-        )
+        # Feature lines whose binaries only carry the knob via backport; a hop
+        # landing in one of these lines must be at least the backport patch.
+        # Lines >= v26.2 ship the knob natively.
+        knob_backports = {
+            (25, 3): MANUAL_FINALIZE_MIN_OLDEST_RELEASE,
+            (26, 1): self.MIN_OLD_RELEASE,
+        }
+        # The first release that consumes the knob: hops onto this binary or
+        # newer defer their version advance when auto-finalization is off.
+        gating_min_release = (26, 2, 1)
+
+        chain = self.load_version_range((25, 3))
+        self.logger.info(f"Upgrade chain: {chain}")
+        for hop in chain:
+            backport_min = knob_backports.get(hop[:2])
+            assert backport_min is None or hop >= backport_min, (
+                f"hop {hop} predates the features_auto_finalization "
+                f"backport {backport_min}"
+            )
 
         # Hop 0: boot the oldest release and opt out of auto-finalization once.
         # Setting the flag here is a convenience (set-it-once-early), NOT a
         # guarantee of multi-hop downgradability: a multi-hop upgrade does not
-        # preserve the ability to downgrade across every hop. Only the gated hop
-        # (to HEAD) keeps its downgrade open -- see the assertions below.
+        # preserve the ability to downgrade across every hop. Only a gated hop
+        # keeps its downgrade open, and only until it is finalized -- see the
+        # assertions below.
+        oldest, hops = chain[0], chain[1:]
         self.logger.info(f"Booting oldest release {oldest}")
         self.installer.install(self.redpanda.nodes, oldest)
         self.redpanda.start()
         self._disable_auto_finalization()
+        held_version = self.admin.get_features()["cluster_version"]
 
-        # Hop 1: upgrade to the latest v26.1 patch. v26.1 has the knob but not
-        # the gating logic, so it auto-advances the active version to its own
-        # latest; the flag rides along in the controller log untouched.
-        self.logger.info(f"Upgrading to intermediate release {mid}")
-        mid_logical = self._upgrade_all_to(mid)
-        self._wait_for_version_everywhere(mid_logical, timeout_sec=60)
-        held_version = mid_logical
+        for hop in hops:
+            final_hop = hop == hops[-1]
+            gated = hop >= gating_min_release
+            self.logger.info(
+                f"Upgrading to {'gated' if gated else 'ungated'} release {hop}"
+            )
+            hop_logical = self._upgrade_all_to(hop)
+            assert hop_logical > held_version, (
+                f"hop {hop} logical {hop_logical} should exceed the held "
+                f"version {held_version}"
+            )
+            if not gated:
+                # Ungated binary: it has the knob but not the gating logic, so
+                # it auto-advances the active version -- which doubles as the
+                # downgrade floor -- to its own latest; the flag rides along in
+                # the controller log untouched. Downgrade back past this hop is
+                # no longer possible: the flag set on the oldest release did
+                # not (and cannot) protect an ungated hop.
+                self._wait_for_version_everywhere(hop_logical, timeout_sec=60)
+            else:
+                # Gated binary: because the flag survived every hop so far, the
+                # advance must be deferred. READY_TO_FINALIZE proves the new
+                # binary observed the completed upgrade and deferred (stronger
+                # than a fixed sleep that could pass before the gating loop
+                # runs). The downgrade floor is held at the previous version,
+                # so downgrade back across this hop IS preserved until it is
+                # finalized.
+                status = self._wait_for_status_state(
+                    features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE
+                )
+                assert self.admin.get_features()["cluster_version"] == held_version
+                assert status.active_version == held_version
+                assert status.version_after_finalization == hop_logical
+                # The decisive passthrough check: this binary sees
+                # auto-finalization as disabled even though the flag was set
+                # only once, on the oldest release.
+                assert not status.auto_finalization_enabled
 
-        # The v26.1 hop was NOT gated, so the active version -- which doubles as
-        # the downgrade floor -- has advanced to the v26.1 logical version.
-        # Downgrade back to v25.3 is no longer possible from here: the flag set
-        # on v25.3 did not (and cannot) protect this ungated hop.
-        assert self.admin.get_features()["cluster_version"] == held_version
+                if final_hop:
+                    # Dwell and re-check: the version must stay held across
+                    # subsequent gating-loop ticks, not advance late.
+                    time.sleep(MANUAL_FINALIZE_HOLD_DWELL_SEC)
+                    assert self.admin.get_features()["cluster_version"] == held_version
 
-        # Hop 2: upgrade to HEAD, which DOES consume the knob. Because the flag
-        # survived both hops, the final advance must be deferred.
-        self.logger.info("Upgrading to HEAD")
-        head_logical = self._upgrade_all_to(RedpandaInstaller.HEAD)
-        assert head_logical > held_version, (
-            f"HEAD logical {head_logical} should exceed the held version {held_version}"
-        )
-
-        # READY_TO_FINALIZE proves HEAD observed the completed upgrade and
-        # deferred the advance (stronger than a fixed sleep that could pass
-        # before the gating loop runs).
-        status = self._wait_for_status_state(
-            features_pb2.FINALIZATION_STATE_READY_TO_FINALIZE
-        )
-        # The active version (downgrade floor) is held at the v26.1 version, so
-        # downgrade from v26.2 back to v26.1 IS preserved: this gated hop is the
-        # only one whose downgrade the flag keeps open.
-        assert self.admin.get_features()["cluster_version"] == held_version
-        assert status.active_version == held_version
-        assert status.version_after_finalization == head_logical
-        # The decisive passthrough check: HEAD sees auto-finalization as
-        # disabled even though the flag was set only once, on the oldest release.
-        assert not status.auto_finalization_enabled
-
-        # Dwell and re-check: the version must stay held across subsequent
-        # gating-loop ticks, not advance late.
-        time.sleep(MANUAL_FINALIZE_HOLD_DWELL_SEC)
-        assert self.admin.get_features()["cluster_version"] == held_version
-
-        # The explicit finalize still drives the advance to the head version.
-        self._finalize()
-        self._wait_for_version_everywhere(head_logical)
-        finalized = self._wait_for_status_state(
-            features_pb2.FINALIZATION_STATE_FINALIZED
-        )
-        assert finalized.active_version == head_logical
-        assert finalized.version_after_finalization == head_logical
+                # The explicit finalize drives the advance to this hop's
+                # version.
+                self._finalize()
+                self._wait_for_version_everywhere(hop_logical)
+                finalized = self._wait_for_status_state(
+                    features_pb2.FINALIZATION_STATE_FINALIZED
+                )
+                assert finalized.active_version == hop_logical
+                assert finalized.version_after_finalization == hop_logical
+            held_version = hop_logical
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_downgrade_before_finalize(self):

--- a/tests/rptest/tests/cluster_linking_unfinalized_upgrade_test.py
+++ b/tests/rptest/tests/cluster_linking_unfinalized_upgrade_test.py
@@ -67,9 +67,12 @@ class ShadowLinkUnfinalizedUpgradeTest(ShadowLinkTestBase, UnfinalizedUpgradeMix
     (features active) providing topics, roles, and schemas to mirror.
 
     The lifecycle exercised end to end:
-      1. While unfinalized, the link's data plane works (topic mirroring) but the
-         v26.2 sync features are gated: configuring role sync or Schema Registry
-         API-mode sync is refused with FAILED_PRECONDITION.
+      1. While unfinalized, the link's data plane works (topic mirroring). If
+         the prior release predates the v26.2 sync features, they are gated:
+         configuring role sync or Schema Registry API-mode sync is refused with
+         FAILED_PRECONDITION. From a v26.2.1+ prior release the features are
+         active before the upgrade begins, so there is no gate to observe and
+         step 1 instead pins down that they stay active.
       2. The link's `link_configuration` -- written to the controller log by the
          HEAD binary -- survives a rollback to the prior release: the cluster
          comes back healthy and mirroring resumes, proving the record is
@@ -79,6 +82,10 @@ class ShadowLinkUnfinalizedUpgradeTest(ShadowLinkTestBase, UnfinalizedUpgradeMix
          actually sync real data: roles matching the filter appear on the target,
          and the source's schema appears in the target's Schema Registry.
     """
+
+    # The release that introduced the role-sync and SR API-mode sync features
+    # (shadow_link_role_sync, shadow_link_sr_api_sync) and their gates.
+    SYNC_FEATURES_MIN_RELEASE = (26, 2, 1)
 
     def __init__(self, test_context, *args, **kwargs):
         # Schema Registry on both clusters so SR API-mode sync can be exercised:
@@ -108,6 +115,11 @@ class ShadowLinkUnfinalizedUpgradeTest(ShadowLinkTestBase, UnfinalizedUpgradeMix
             f"features_auto_finalization backport {self.MIN_OLD_RELEASE}; cannot "
             "opt out before upgrade"
         )
+        # The sync features shipped in v26.2.1. When the old release predates
+        # them, an unfinalized upgrade holds them unavailable and their
+        # surfaces must refuse; from any newer old release they are active
+        # before the upgrade begins and there is no gate to observe.
+        self.sync_features_gated = self.old_release < self.SYNC_FEATURES_MIN_RELEASE
         self.logger.info(f"Target starts on old release {self.old_release}")
         self.installer.install(self.redpanda.nodes, self.old_release)
 
@@ -315,12 +327,29 @@ class ShadowLinkUnfinalizedUpgradeTest(ShadowLinkTestBase, UnfinalizedUpgradeMix
         else:
             raise AssertionError(f"{what} should be gated while unfinalized")
 
-    def _assert_v26_2_sync_gated(self):
-        """While unfinalized, both v26.2 sync surfaces must be refused on the
-        target with FAILED_PRECONDITION and the feature-specific message -- this
-        is what keeps a downgrade safe (no role/SR-API state can be written)."""
-        self._assert_gated(self._update_link_role_sync, ROLE_SYNC_GATE, "role sync")
-        self._assert_gated(self._update_link_sr_api, SR_API_GATE, "SR API-mode sync")
+    def _check_sync_gates_unfinalized(self):
+        """Pin down the state of the v26.2 sync surfaces while unfinalized.
+
+        When the old release predates the sync features, both surfaces must be
+        refused on the target with FAILED_PRECONDITION and the feature-specific
+        message -- this is what keeps a downgrade safe (no role/SR-API state
+        the old binary cannot read can be written). When the old release
+        already ships the features, they activated before the upgrade began
+        and any sync state is legible to the old binary; there is no gate to
+        observe, so instead assert the unfinalized upgrade did not regress them
+        to unavailable."""
+        if self.sync_features_gated:
+            self._assert_gated(self._update_link_role_sync, ROLE_SYNC_GATE, "role sync")
+            self._assert_gated(
+                self._update_link_sr_api, SR_API_GATE, "SR API-mode sync"
+            )
+        else:
+            for feature in ("shadow_link_role_sync", "shadow_link_sr_api_sync"):
+                state = self.redpanda.get_feature_state(feature)
+                assert state == "active", (
+                    f"{feature} was active on the old release and must stay "
+                    f"active while unfinalized, got {state}"
+                )
 
     def _verify_role_sync_works(self):
         """Post-finalize: configuring role sync is accepted and the migrator
@@ -406,8 +435,9 @@ class ShadowLinkUnfinalizedUpgradeTest(ShadowLinkTestBase, UnfinalizedUpgradeMix
         self._produce_source(MIRROR_TOPIC, MIRROR_RECORDS_PRE)
         self._wait_mirrored(MIRROR_TOPIC, MIRROR_RECORDS_PRE, "unfinalized")
 
-        # ...but the v26.2 sync features are gated off.
-        self._assert_v26_2_sync_gated()
+        # ...and the v26.2 sync surfaces are refused or active depending on
+        # whether the old release predates them.
+        self._check_sync_gates_unfinalized()
 
         # Roll the target back to the old release WITHOUT finalizing. The v1
         # link_configuration written by HEAD must replay on the old binary: the
@@ -453,9 +483,10 @@ class ShadowLinkUnfinalizedUpgradeTest(ShadowLinkTestBase, UnfinalizedUpgradeMix
         record the upgraded binary wrote.
 
         Lifecycle:
-          1. Unfinalized on HEAD: API-mode is refused (gated) while topic-mode is
-             accepted (ungated) -- the gate distinguishes the two modes. The
-             accepted config is read back through the controller.
+          1. Unfinalized on HEAD: topic-mode is accepted and read back through
+             the controller. When the prior release predates the v26.2 sync
+             features, API-mode is additionally refused (gated) -- the gate
+             distinguishes the two modes.
           2. Roll back to the prior release without finalizing: the cluster
              returns healthy (the populated v1 record replayed on the old binary)
              and the link's data plane keeps mirroring.
@@ -483,10 +514,17 @@ class ShadowLinkUnfinalizedUpgradeTest(ShadowLinkTestBase, UnfinalizedUpgradeMix
         self._produce_source(MIRROR_TOPIC, MIRROR_RECORDS_PRE)
         self._wait_mirrored(MIRROR_TOPIC, MIRROR_RECORDS_PRE, "unfinalized")
 
-        # The gate distinguishes the SR sync modes: API-mode is refused...
-        self._assert_gated(self._update_link_sr_api, SR_API_GATE, "SR API-mode sync")
-        # ...but topic-mode (pre-v26.2, ungated) is accepted and persisted as a
-        # populated schema_registry_sync_config in the controller log.
+        # When the old release predates the sync features, the gate
+        # distinguishes the SR sync modes: API-mode is refused while topic-mode
+        # (pre-v26.2, ungated) is accepted. From a v26.2.1+ old release there
+        # is no gate to observe on API-mode; the persistence round trip below
+        # is regime-independent.
+        if self.sync_features_gated:
+            self._assert_gated(
+                self._update_link_sr_api, SR_API_GATE, "SR API-mode sync"
+            )
+        # Topic-mode is accepted and persisted as a populated
+        # schema_registry_sync_config in the controller log.
         self._update_link_sr_topic()
         self._assert_sr_sync_mode("shadow_schema_registry_topic", "unfinalized")
 

--- a/tests/rptest/tests/compatibility/java_compression_test.py
+++ b/tests/rptest/tests/compatibility/java_compression_test.py
@@ -186,6 +186,7 @@ class JavaCompressionTest(EndToEndTest):
             self.redpanda._installer.install(self.redpanda.nodes, version)
             self.redpanda.stop_node(self.redpanda.nodes[0])
             self.redpanda.start_node(self.redpanda.nodes[0])
+            self.redpanda._admin.await_active_version_settled()
         self.redpanda.stop_node(self.redpanda.nodes[0])
 
         # Delete all the compaction indices to force self compaction of segments.

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -990,6 +990,7 @@ class BogusTimestampTest(EndToEndTest):
             self.redpanda._installer.install(self.redpanda.nodes, version)
             self.redpanda.stop_node(self.redpanda.nodes[0])
             self.redpanda.start_node(self.redpanda.nodes[0])
+            self.redpanda._admin.await_active_version_settled()
 
         # broker_time_based_retention fixes this test case for new segments. (disable it to simulate a legacy condition)
         self.redpanda.set_feature_active(

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -55,7 +55,6 @@ from rptest.services.redpanda import (
     SecurityConfig,
 )
 from rptest.services.redpanda_installer import (
-    RedpandaInstaller,
     wait_for_num_versions,
 )
 from rptest.services.redpanda_types import SaslCredentials
@@ -11882,14 +11881,14 @@ class SchemaRegistryTransportCompatTest(RedpandaTest):
             for i in range(num_subjects)
         ]
 
-        self.installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
-        self.redpanda.rolling_restart_nodes(self.redpanda.nodes)
-        wait_for_num_versions(self.redpanda, 1)
-
         # api::start picks the transport once at process start; rolling-
-        # restart re-runs it now that the active version is past the
+        # restart re-runs it once the active version is past the
         # v26.2.1 gate.
-        self.redpanda.rolling_restart_nodes(self.redpanda.nodes)
+        for version in self.installer.upgrade_path_to_head(self.initial_version):
+            self.installer.install(self.redpanda.nodes, version)
+            self.redpanda.rolling_restart_nodes(self.redpanda.nodes)
+            wait_for_num_versions(self.redpanda, 1)
+            self.redpanda._admin.await_active_version_settled()
 
         for node in self.redpanda.nodes:
             wait_until(

--- a/tests/rptest/tests/storage_mode_test.py
+++ b/tests/rptest/tests/storage_mode_test.py
@@ -711,13 +711,19 @@ class TieredCloudUpgradeTest(StorageModeTestBase):
         )
         self.installer = self.redpanda._installer
 
+    # The release that introduced the tiered_v2 variant and its
+    # tiered_cloud_topics feature flag.
+    TIERED_CLOUD_MIN_RELEASE = (26, 2, 1)
+
     def setUp(self):
         # Start the whole cluster on the latest release of the prior feature
-        # line (26.1.x), which supports the cloud storage mode but predates
-        # the tiered_v2 variant and its feature flag.
+        # line, which supports the cloud storage mode (v26.1+) but, before
+        # TIERED_CLOUD_MIN_RELEASE, predates the tiered_v2 variant and its
+        # feature flag.
         old_version = self.installer.highest_from_prior_feature_version(
             RedpandaInstaller.HEAD
         )
+        self.old_has_tiered_cloud = old_version >= self.TIERED_CLOUD_MIN_RELEASE
         self.installer.install(self.redpanda.nodes, old_version)
         super(TieredCloudUpgradeTest, self).setUp()
 
@@ -758,19 +764,25 @@ class TieredCloudUpgradeTest(StorageModeTestBase):
         _ = wait_for_num_versions(self.redpanda, 2)
 
         # The upgraded node knows the feature but must not report it active
-        # while old nodes are still in the cluster.
+        # while old nodes are still in the cluster, unless the prior release
+        # already ships it, in which case it activated before the upgrade
+        # began and must stay active.
         state = self.redpanda.get_feature_state("tiered_cloud_topics", node=first)
-        assert state == "unavailable", (
-            f"tiered_cloud_topics should be unavailable in a mixed cluster, got {state}"
+        expected_state = "active" if self.old_has_tiered_cloud else "unavailable"
+        assert state == expected_state, (
+            f"tiered_cloud_topics should be {expected_state} in this mixed "
+            f"cluster, got {state}"
         )
 
-        # CreateTopics is routed to the controller broker. A HEAD controller
-        # rejects the request via the feature gate. A v26.1 controller does
-        # not know the redpanda.storage.mode.impl property: unsupported
-        # topic configs are ignored on create, so the request silently
-        # degrades to a classic tiered topic. Either way the gating
-        # invariant holds: no tiered_v2 topic can exist in a partially
-        # upgraded cluster.
+        # CreateTopics is routed to the controller broker. While the feature
+        # is unavailable, a HEAD controller rejects the request via the
+        # feature gate, and a pre-feature controller does not know the
+        # redpanda.storage.mode.impl property: unsupported topic configs
+        # are ignored on create, so the request silently degrades to a
+        # classic tiered topic. Either way the gating invariant holds: no
+        # tiered_v2 topic can exist in a partially upgraded cluster. Once the
+        # feature is active, the create must instead succeed as a genuine
+        # tiered_v2 topic no matter which broker is the controller.
         created_in_mixed = True
         try:
             self._create_topic(
@@ -783,16 +795,25 @@ class TieredCloudUpgradeTest(StorageModeTestBase):
         except RpkException as e:
             created_in_mixed = False
             self.logger.info(f"tiered_v2 creation rejected in mixed cluster: {e}")
+            assert not self.old_has_tiered_cloud, (
+                "tiered_v2 creation must succeed once the feature is active"
+            )
         if created_in_mixed:
             version = self._get_topic_storage_mode_impl(rpk, "topic-tiered-v2-mixed")
-            assert version != TopicSpec.STORAGE_MODE_IMPL_TIERED_V2, (
-                "a tiered_v2 topic must not be creatable in a partially "
-                "upgraded cluster"
-            )
+            if self.old_has_tiered_cloud:
+                assert version == TopicSpec.STORAGE_MODE_IMPL_TIERED_V2, (
+                    f"expected a genuine tiered_v2 topic, got {version}"
+                )
+            else:
+                assert version != TopicSpec.STORAGE_MODE_IMPL_TIERED_V2, (
+                    "a tiered_v2 topic must not be creatable in a partially "
+                    "upgraded cluster"
+                )
 
-        # Conversion is expressed as an alter to 'tiered'; both binaries
-        # resolve it to a variant the cloud -> X transition rules forbid
-        # (classic tiered) while the cluster is not fully upgraded.
+        # Conversion is expressed as an alter to 'tiered'; with the default
+        # tiered impl (tiered_v1) both binaries resolve it to classic tiered,
+        # which the cloud -> X transition rules forbid regardless of upgrade
+        # state.
         self._expect_rejected(
             "cloud to tiered_v2 conversion",
             lambda: rpk.alter_topic_config(
@@ -822,15 +843,21 @@ class TieredCloudUpgradeTest(StorageModeTestBase):
             f"clusters should default to tiered_v1, got {default_impl}"
         )
 
-        # If the mixed-cluster create went through a v26.1 controller, the
-        # resulting topic must have degraded to classic tiered - never the
-        # v2 variant. Now that every broker runs HEAD, the version property
+        # If the mixed-cluster create went through a pre-feature controller,
+        # the resulting topic must have degraded to classic tiered - never the
+        # v2 variant (with the feature active it was genuine tiered_v2 all
+        # along). Now that every broker runs HEAD, the version property
         # is authoritative.
         if created_in_mixed:
+            expected_impl = (
+                TopicSpec.STORAGE_MODE_IMPL_TIERED_V2
+                if self.old_has_tiered_cloud
+                else TopicSpec.STORAGE_MODE_IMPL_TIERED_V1
+            )
             assert (
                 self._get_topic_storage_mode_impl(rpk, "topic-tiered-v2-mixed")
-                == TopicSpec.STORAGE_MODE_IMPL_TIERED_V1
-            ), "the mixed-cluster create must not have produced a tiered_v2 topic"
+                == expected_impl
+            ), f"the mixed-cluster create must have produced {expected_impl}"
 
         # Creation with an explicit version works under any default.
         self._create_topic(

--- a/tests/rptest/transactions/tx_upgrade_test.py
+++ b/tests/rptest/transactions/tx_upgrade_test.py
@@ -260,6 +260,7 @@ class TxUpgradeCompactionTest(TxUpgradeTestBase, LogCompactionTxRemovalMixin):
             assert self._get_tx_id_mapping() == initial_mapping, (
                 "Mapping changed after full upgrade"
             )
+            self.redpanda._admin.await_active_version_settled()
             prev_version_str = ver_string(new_version)
 
         # Once we have upgraded to the newest version, enable tx batch removal.


### PR DESCRIPTION
See individual commits. Mostly Claude'ified. If test authors want to weigh in please do.


Fixes:
* https://redpandadata.atlassian.net/browse/CORE-16929
* https://redpandadata.atlassian.net/browse/CORE-16928
* https://redpandadata.atlassian.net/browse/CORE-16925
* https://redpandadata.atlassian.net/browse/CORE-16924
* https://redpandadata.atlassian.net/browse/CORE-16923

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none
