### PR TITLE
dt/rbac: lengthen bogus passwords in list_user_roles tests

### DIFF
--- a/tests/rptest/tests/rbac_test.py
+++ b/tests/rptest/tests/rbac_test.py
@@ -628,7 +628,10 @@ class RBACTest(RBACTestBase):
             f"Unexpected roles list {roles_list}"
         )
 
-        bogus_admin = Admin(self.redpanda, auth=("bob", "1234"))
+        # The password must be at least 14 bytes long. In FIPS mode the broker
+        # rejects a shorter password before it ever looks the user up, which
+        # answers 400 instead of the 401 this test is checking for.
+        bogus_admin = Admin(self.redpanda, auth=("bob", "bogus_password0"))
 
         with expect_http_error(401):
             bogus_admin.list_user_roles()

--- a/tests/rptest/tests/rbac_test_v2.py
+++ b/tests/rptest/tests/rbac_test_v2.py
@@ -553,7 +553,12 @@ class RBACTest(RBACTestBase):
         # TODO: Add testing for filtering once v2 list_current_user_roles supports it
         # self.logger.debug("Test '?filter' parameter")
 
-        bogus_admin = AdminV2RoleWrapper(AdminV2(self.redpanda, auth=("bob", "1234")))
+        # The password must be at least 14 bytes long. In FIPS mode the broker
+        # rejects a shorter password before it ever looks the user up, and admin
+        # v2 reports that as an internal error rather than unauthenticated.
+        bogus_admin = AdminV2RoleWrapper(
+            AdminV2(self.redpanda, auth=("bob", "bogus_password0"))
+        )
         with expect_role_error(ConnectErrorCode.UNAUTHENTICATED):
             bogus_admin.list_current_user_roles()
 


### PR DESCRIPTION
`RBACTest.test_list_user_roles` has failed on nearly every CI day since
2026-03-18 in CDT runs with FIPS enabled, and its admin v2 twin in
`rbac_test_v2.py` fails the same way for the same reason.

Both tests build an admin client for a user that does not exist and assert
the request comes back unauthorized. Both used a 4-byte password. In FIPS
the broker rejects a basic-auth password shorter than 14 bytes before it
ever looks the user up (`src/v/security/request_auth.cc:117`), since the
SCRAM HMAC key needs at least 112 bits. So rather than the unauthorized
they assert, v1 saw `400 Bad Request` and v2 saw a ConnectRPC `internal`.

Lengthening both passwords restores what these tests mean to exercise,
unknown user rejected as unauthorized, and makes them behave identically
in FIPS and non-FIPS. This closes the gap left by 3ebcb0f5fc ("dt: Longify
all scram passwords"), which raised the other passwords in these files but
missed the two bogus-admin ones.

Jira: https://redpandadata.atlassian.net/browse/CORE-15847

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [ ] v25.3.x

## Release Notes

* none
