### PR TITLE
[v26.1.x] admin: use stream_range_as_array in usage response (manual backport)

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -308,7 +308,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "+y1p2Pl1UPETIow5cbHJYaoM2/tuB1gtdqj0gwMDbLk=",
+        "bzlTransitiveDigest": "5jE6ejfL2UCG2Mt6HfVupqd7XrryafHYrY7Gr1UG6uo=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -489,9 +489,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "539f98c1b1d34f2e5f9948eb81d1cb8e3cb61a5ed6ded54b246e070bf81808de",
-              "strip_prefix": "seastar-7e67971d789c6642de7ec6225d37fabaa197b184",
-              "url": "https://github.com/redpanda-data/seastar/archive/7e67971d789c6642de7ec6225d37fabaa197b184.tar.gz"
+              "sha256": "f70e14b181db809d885d610b908162bebaa03a9083468fd1033a2a527a738e70",
+              "strip_prefix": "seastar-2417f85e750051932dd2161294516dca27640a87",
+              "url": "https://github.com/redpanda-data/seastar/archive/2417f85e750051932dd2161294516dca27640a87.tar.gz"
             }
           },
           "unordered_dense": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -174,9 +174,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "539f98c1b1d34f2e5f9948eb81d1cb8e3cb61a5ed6ded54b246e070bf81808de",
-        strip_prefix = "seastar-7e67971d789c6642de7ec6225d37fabaa197b184",
-        url = "https://github.com/redpanda-data/seastar/archive/7e67971d789c6642de7ec6225d37fabaa197b184.tar.gz",
+        sha256 = "f70e14b181db809d885d610b908162bebaa03a9083468fd1033a2a527a738e70",
+        strip_prefix = "seastar-2417f85e750051932dd2161294516dca27640a87",
+        url = "https://github.com/redpanda-data/seastar/archive/2417f85e750051932dd2161294516dca27640a87.tar.gz",
     )
 
     http_archive(

--- a/src/v/redpanda/admin/usage.cc
+++ b/src/v/redpanda/admin/usage.cc
@@ -12,6 +12,8 @@
 #include "redpanda/admin/api-doc/usage.json.hh"
 #include "redpanda/admin/server.h"
 
+#include <seastar/json/json_elements.hh>
+
 namespace {
 ss::json::json_return_type raw_data_to_usage_response(
   const std::vector<kafka::usage_window>& total_usage, bool include_open) {
@@ -55,7 +57,7 @@ ss::json::json_return_type raw_data_to_usage_response(
                             ss::lowres_system_clock::now().time_since_epoch())
                             .count();
     }
-    return resp;
+    return ss::json::stream_object(std::move(resp));
 }
 } // namespace
 


### PR DESCRIPTION
`cherry-pick` conflict due to bazel seastar version stuff.

Fixes https://github.com/redpanda-data/redpanda/issues/31335

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

### Improvements

* Fixes an issue where `/v1/usage` responses could cause oversized allocations for clusters with a large number of Iceberg-enabled topics.