### PR TITLE
[v26.2.x] dt/rbac: lengthen bogus passwords in list_user_roles tests

### DIFF
--- a/tests/rptest/tests/rbac_test.py
+++ b/tests/rptest/tests/rbac_test.py
@@ -628,7 +628,10 @@ class RBACTest(RBACTestBase):
             f"Unexpected roles list {roles_list}"
         )
 
-        bogus_admin = Admin(self.redpanda, auth=("bob", "1234"))
+        # The password must be at least 14 bytes long. In FIPS mode the broker
+        # rejects a shorter password before it ever looks the user up, which
+        # answers 400 instead of the 401 this test is checking for.
+        bogus_admin = Admin(self.redpanda, auth=("bob", "bogus_password0"))
 
         with expect_http_error(401):
             bogus_admin.list_user_roles()

--- a/tests/rptest/tests/rbac_test_v2.py
+++ b/tests/rptest/tests/rbac_test_v2.py
@@ -553,7 +553,12 @@ class RBACTest(RBACTestBase):
         # TODO: Add testing for filtering once v2 list_current_user_roles supports it
         # self.logger.debug("Test '?filter' parameter")
 
-        bogus_admin = AdminV2RoleWrapper(AdminV2(self.redpanda, auth=("bob", "1234")))
+        # The password must be at least 14 bytes long. In FIPS mode the broker
+        # rejects a shorter password before it ever looks the user up, and admin
+        # v2 reports that as an internal error rather than unauthenticated.
+        bogus_admin = AdminV2RoleWrapper(
+            AdminV2(self.redpanda, auth=("bob", "bogus_password0"))
+        )
         with expect_role_error(ConnectErrorCode.UNAUTHENTICATED):
             bogus_admin.list_current_user_roles()
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31331
