### PR TITLE
DNM: no-op build to test gRPC remote cache

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -528,3 +528,5 @@ filegroup(
     strip_prefix = "JSONTestSuite-1ef36fa01286573e846ac449e8683f8833c5b26a",
     urls = ["https://github.com/nst/JSONTestSuite/archive/1ef36fa01286573e846ac449e8683f8833c5b26a.tar.gz"],
 )
+
+# No-op change to trigger a CI build for testing the gRPC remote cache path.


### PR DESCRIPTION
Do not merge. No-op comment in `MODULE.bazel` to trigger a CI build and confirm the Bazel gRPC remote cache still works after redpanda-data/devprod-infra#702 (aws-bazel-remote now reads its gRPC TLS material and `X-Bazel-Auth` token from the canonical `bazel_cacher_aws` secret).

Rebased replacement for #30809 (GitHub refused to reopen it after the force-push).

## Release Notes

- none