### PR TITLE
[CORE-15500] `storage`: respect abort sources in `segment::{read}/{write}_lock()`

### DIFF
--- a/src/v/cluster/archival/async_data_uploader.cc
+++ b/src/v/cluster/archival/async_data_uploader.cc
@@ -322,7 +322,8 @@ segment_upload::compute_upload_parameters(
               storage::log::offset_range_size_requirements_t{
                 .target_size = range.max_size,
                 .min_size = range.min_size,
-              });
+              },
+              deadline);
         }
         if (!sz.has_value()) {
             // This means that there is not enough data in the log

--- a/src/v/raft/state_machine_manager.cc
+++ b/src/v/raft/state_machine_manager.cc
@@ -535,7 +535,7 @@ ss::future<> state_machine_manager::try_apply_in_foreground() {
          * scheduling group soon
          */
         auto config = storage::local_log_reader_config(
-          _next, _raft->committed_offset());
+          _next, _raft->committed_offset(), _as);
 
         model::record_batch_reader reader = co_await _raft->make_reader(config);
 
@@ -664,7 +664,7 @@ ss::future<> state_machine_manager::background_apply_fiber(
             continue;
         }
         auto config = storage::local_log_reader_config(
-          entry->stm->next(), model::prev_offset(_next));
+          entry->stm->next(), model::prev_offset(_next), _as);
 
         vlog(
           _log.debug,

--- a/src/v/raft/tests/failure_injectable_log.cc
+++ b/src/v/raft/tests/failure_injectable_log.cc
@@ -184,8 +184,10 @@ failure_injectable_log::offset_range_size(
 
 ss::future<std::optional<failure_injectable_log::offset_range_size_result_t>>
 failure_injectable_log::offset_range_size(
-  model::offset first, offset_range_size_requirements_t target) {
-    return _underlying_log->offset_range_size(first, target);
+  model::offset first,
+  offset_range_size_requirements_t target,
+  ss::semaphore::time_point deadline) {
+    return _underlying_log->offset_range_size(first, target, deadline);
 }
 
 bool failure_injectable_log::is_compacted(

--- a/src/v/raft/tests/failure_injectable_log.h
+++ b/src/v/raft/tests/failure_injectable_log.h
@@ -104,7 +104,9 @@ public:
       ss::semaphore::time_point timeout) final;
 
     ss::future<std::optional<offset_range_size_result_t>> offset_range_size(
-      model::offset first, offset_range_size_requirements_t target) final;
+      model::offset first,
+      offset_range_size_requirements_t target,
+      ss::semaphore::time_point deadline) final;
 
     bool is_compacted(model::offset first, model::offset last) const final;
 

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1718,7 +1718,7 @@ ss::future<> disk_log_impl::rewrite_segment_with_offset_map(
       tmpname);
 
     auto rdr_holder = co_await _readers_cache->evict_segment_readers(seg);
-    auto write_lock = co_await seg->write_lock();
+    auto write_lock = co_await seg->write_lock(*cfg.asrc);
     if (initial_generation_id != seg->get_generation_id()) {
         throw std::runtime_error(
           fmt::format(

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2796,7 +2796,9 @@ disk_log_impl::offset_range_size(
 
 ss::future<std::optional<log::offset_range_size_result_t>>
 disk_log_impl::offset_range_size(
-  model::offset first, offset_range_size_requirements_t target) {
+  model::offset first,
+  offset_range_size_requirements_t target,
+  ss::semaphore::time_point deadline) {
     vlog(
       stlog.debug,
       "Offset range size, first: {}, target size: {}/{}, lstat: {}",
@@ -2848,7 +2850,7 @@ disk_log_impl::offset_range_size(
         model::offset last_locked_offset;
         for (auto& s : _segs) {
             locked_range_size += s->size_bytes();
-            f_locks.emplace_back(s->read_lock());
+            f_locks.emplace_back(s->read_lock(deadline));
             segments.emplace_back(s);
             last_locked_offset = s->offsets().get_committed_offset();
             if (locked_range_size > (target.target_size + first_segment_size)) {

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -108,7 +108,10 @@ public:
     /// contains size requirements. The desired target size and smallest
     /// acceptable size.
     ss::future<std::optional<offset_range_size_result_t>> offset_range_size(
-      model::offset first, offset_range_size_requirements_t target) override;
+      model::offset first,
+      offset_range_size_requirements_t target,
+      ss::semaphore::time_point deadline
+      = ss::semaphore::time_point::max()) override;
 
     /// Return true if the offset range contains compacted data
     bool is_compacted(model::offset first, model::offset last) const override;

--- a/src/v/storage/lock_manager.cc
+++ b/src/v/storage/lock_manager.cc
@@ -11,9 +11,12 @@
 
 #include "container/chunked_vector.h"
 #include "model/offset_interval.h"
+#include "ssx/abort_source.h"
 #include "ssx/when_all.h"
 #include "storage/segment.h"
 
+#include <seastar/core/abort_on_expiry.hh>
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/rwlock.hh>
 #include <seastar/core/shared_ptr.hh>
 
@@ -21,24 +24,28 @@ namespace storage {
 
 static ss::future<std::unique_ptr<lock_manager::lease>> range(
   segment_set::underlying_t segs,
-  ss::semaphore::clock::time_point read_lock_deadline
-  = ss::semaphore::clock::time_point::max()) {
+  model::opt_abort_source_t as = std::nullopt,
+  std::optional<ss::semaphore::clock::time_point> read_lock_deadline
+  = std::nullopt) {
     auto ctx = std::make_unique<lock_manager::lease>(
       segment_set(std::move(segs)));
+
+    ss::abort_source never_abort;
+    ss::abort_on_expiry<ss::semaphore::clock> expiry(
+      read_lock_deadline.value_or(ss::semaphore::clock::time_point::max()));
+    ssx::composite_abort_source combined(
+      as.has_value() ? as->get() : never_abort, expiry.abort_source());
 
     chunked_vector<ss::future<ss::rwlock::holder>> dispatch;
     dispatch.reserve(ctx->range.size());
     for (auto& s : ctx->range) {
-        dispatch.push_back(s->read_lock(read_lock_deadline));
+        dispatch.push_back(s->read_lock(combined.as()));
     }
 
-    return ssx::when_all_succeed<chunked_vector<ss::rwlock::holder>>(
-             std::move(dispatch))
-      .then(
-        [ctx = std::move(ctx)](chunked_vector<ss::rwlock::holder> lks) mutable {
-            ctx->locks = std::move(lks);
-            return std::move(ctx);
-        });
+    ctx->locks
+      = co_await ssx::when_all_succeed<chunked_vector<ss::rwlock::holder>>(
+        std::move(dispatch));
+    co_return ctx;
 }
 
 ss::future<std::unique_ptr<lock_manager::lease>>
@@ -79,7 +86,7 @@ lock_manager::range_lock(const timequery_config& cfg) {
         tmp.push_back(*it);
     }
 
-    return range(std::move(tmp));
+    return range(std::move(tmp), cfg.abort_source);
 }
 
 ss::future<std::unique_ptr<lock_manager::lease>>
@@ -93,9 +100,7 @@ lock_manager::range_lock(const local_log_reader_config& cfg) {
           // must be base offset
           return s->offsets().get_base_offset() <= cfg.max_offset;
       });
-    return range(
-      std::move(tmp),
-      cfg.read_lock_deadline.value_or(ss::semaphore::clock::time_point::max()));
+    return range(std::move(tmp), cfg.abort_source, cfg.read_lock_deadline);
 }
 
 std::ostream& operator<<(std::ostream& o, const lock_manager::lease& l) {

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -193,7 +193,10 @@ public:
     /// acceptable size.
     virtual ss::future<std::optional<offset_range_size_result_t>>
     offset_range_size(
-      model::offset first, offset_range_size_requirements_t target) = 0;
+      model::offset first,
+      offset_range_size_requirements_t target,
+      ss::semaphore::time_point deadline = ss::semaphore::time_point::max())
+      = 0;
 
     virtual bool
     is_compacted(model::offset first, model::offset last) const = 0;

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -259,6 +259,8 @@ public:
     ss::future<ss::rwlock::holder> write_lock(
       ss::semaphore::time_point timeout = ss::semaphore::time_point::max());
 
+    ss::future<ss::rwlock::holder> write_lock(ss::abort_source& as);
+
     /*
      * return an estimate of how much data on disk is associated with this
      * segment (e.g. the data file, indices, etc...).
@@ -556,6 +558,10 @@ inline ss::future<ss::rwlock::holder> segment::read_lock(ss::abort_source& as) {
 inline ss::future<ss::rwlock::holder>
 segment::write_lock(ss::semaphore::time_point timeout) {
     return _destructive_ops.hold_write_lock(timeout);
+}
+inline ss::future<ss::rwlock::holder>
+segment::write_lock(ss::abort_source& as) {
+    return _destructive_ops.hold_write_lock(as);
 }
 inline void segment::tombstone() { _flags |= bitflags::mark_tombstone; }
 inline bool segment::has_outstanding_locks() const {

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -23,6 +23,7 @@
 #include "storage/version.h"
 #include "utils/functional.h"
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/file.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/rwlock.hh>
@@ -252,6 +253,8 @@ public:
 
     ss::future<ss::rwlock::holder> read_lock(
       ss::semaphore::time_point timeout = ss::semaphore::time_point::max());
+
+    ss::future<ss::rwlock::holder> read_lock(ss::abort_source& as);
 
     ss::future<ss::rwlock::holder> write_lock(
       ss::semaphore::time_point timeout = ss::semaphore::time_point::max());
@@ -546,6 +549,9 @@ inline std::optional<ss::rwlock::holder> segment::try_hold_write_lock() {
 inline ss::future<ss::rwlock::holder>
 segment::read_lock(ss::semaphore::time_point timeout) {
     return _destructive_ops.hold_read_lock(timeout);
+}
+inline ss::future<ss::rwlock::holder> segment::read_lock(ss::abort_source& as) {
+    return _destructive_ops.hold_read_lock(as);
 }
 inline ss::future<ss::rwlock::holder>
 segment::write_lock(ss::semaphore::time_point timeout) {

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -146,7 +146,7 @@ ss::future<model::offset> build_offset_map(
         vlog(gclog.trace, "Adding segment to offset map: {}", seg->filename());
 
         try {
-            auto read_lock = co_await seg->read_lock();
+            auto read_lock = co_await seg->read_lock(*cfg.asrc);
             co_await internal::maybe_rebuild_compaction_index(
               seg,
               stm_hookset,
@@ -197,7 +197,7 @@ ss::future<index_state> deduplicate_segment(
   offset_delta_time should_offset_delta_times,
   ss::sharded<features::feature_table>& feature_table,
   bool inject_reader_failure) {
-    auto read_holder = co_await seg->read_lock();
+    auto read_holder = co_await seg->read_lock(*cfg.asrc);
     if (seg->is_closed()) {
         throw segment_closed_exception();
     }
@@ -326,7 +326,7 @@ ss::future<bool> index_chunk_of_segment_for_map(
         throw segment_closed_exception();
     }
     co_await map.reset();
-    auto read_holder = co_await seg->read_lock();
+    auto read_holder = co_await seg->read_lock(*compact_cfg.asrc);
     auto start_offset_inclusive = model::next_offset(last_indexed_offset);
     auto rdr = internal::create_segment_full_reader(
       seg, compact_cfg, pb, std::move(read_holder), start_offset_inclusive);

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -621,7 +621,7 @@ ss::future<compaction_result> do_self_compact_segment(
 
     auto rdr_holder = co_await readers_cache.evict_segment_readers(s);
 
-    auto write_lock_holder = co_await s->write_lock();
+    auto write_lock_holder = co_await s->write_lock(*cfg.asrc);
     if (segment_generation != s->get_generation_id()) {
         vlog(
           gclog.debug,
@@ -726,7 +726,7 @@ ss::future<> rebuild_compaction_index(
     segment_full_path idx_path = s->path().to_compacted_index();
     vlog(gclog.info, "Rebuilding index file... ({})", idx_path);
     pb.corrupted_compaction_index();
-    auto h = co_await s->read_lock();
+    auto h = co_await s->read_lock(*cfg.asrc);
     if (s->is_closed()) {
         co_await ss::coroutine::return_exception(segment_closed_exception());
     }
@@ -790,7 +790,7 @@ ss::future<compacted_index::recovery_state> maybe_rebuild_compaction_index(
           s, stm_hookset, cfg, pb, resources, tx_batch_compaction_enabled);
 
         // Take the lock again before proceeding.
-        read_holder = co_await s->read_lock();
+        read_holder = co_await s->read_lock(*cfg.asrc);
     }
 
     // Compaction index was successfully built, remove it from files to clean.
@@ -833,7 +833,7 @@ ss::future<compaction_result> self_compact_segment(
         co_return compaction_result{s->size_bytes()};
     }
 
-    auto read_holder = co_await s->read_lock();
+    auto read_holder = co_await s->read_lock(*cfg.asrc);
     compacted_index::recovery_state state
       = co_await maybe_rebuild_compaction_index(
         s,
@@ -885,7 +885,7 @@ make_concatenated_segment(
     chunked_vector<segment::generation_id> generations;
     generations.reserve(segments.size());
     for (auto& segment : segments) {
-        locks.push_back(co_await segment->read_lock());
+        locks.push_back(co_await segment->read_lock(*cfg.asrc));
         generations.push_back(segment->get_generation_id());
     }
 

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -6618,6 +6618,91 @@ TEST_F(storage_test_fixture, test_offset_range_size_lock_timeout) {
     }
 }
 
+TEST_F(storage_test_fixture, test_make_reader_range_lock_abort) {
+    // - Generate a few segments
+    // - Acquire read locks from each
+    // - Queue up a write lock behind one of them, in the background
+    // - make_reader now blocks on segment range lock acquisition behind the
+    //   pending write lock
+    // - firing the reader config's abort source (or reaching its deadline)
+    //   must promptly fail the acquisition instead of waiting indefinitely
+
+    constexpr size_t num_segments = 5;
+    ss::gate gate{};
+
+    auto cfg = default_log_config(test_dir);
+    storage::log_manager mgr = make_log_manager(cfg);
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
+    auto ntp = model::ntp("redpanda", "test-topic", 0);
+
+    storage::ntp_config ntp_cfg(ntp, mgr.config().base_dir);
+
+    auto log = manage_log(mgr, std::move(ntp_cfg));
+
+    for (size_t i = 0; i < num_segments; i++) {
+        append_random_batches(
+          log,
+          10,
+          model::term_id(0),
+          std::nullopt,
+          custom_ts_batch_generator(model::timestamp::now()));
+        log->force_roll().get();
+    }
+
+    auto& segments = log->segments();
+
+    {
+        std::vector<ss::future<ss::rwlock::holder>> f_locks;
+        f_locks.reserve(segments.size());
+        for (auto& s : segments) {
+            f_locks.emplace_back(s->read_lock());
+        }
+
+        auto seg = *std::next(segments.begin(), num_segments / 2);
+
+        ssx::spawn_with_gate(gate, [seg] {
+            return seg->write_lock().then([](auto) { return ss::now(); });
+        });
+
+        auto make_blocked_reader_cfg = [&](ss::abort_source& as) {
+            auto reader_cfg = storage::local_log_reader_config(
+              log->offsets().start_offset, log->offsets().dirty_offset, as);
+            reader_cfg.skip_readers_cache = true;
+            return reader_cfg;
+        };
+
+        {
+            // abort source only
+            ss::abort_source as;
+            auto fut = log->make_reader(make_blocked_reader_cfg(as));
+            EXPECT_FALSE(fut.available());
+            as.request_abort();
+            EXPECT_THROW(std::move(fut).get(), ss::abort_requested_exception);
+        }
+
+        {
+            // abort source and deadline: deadline fires first
+            ss::abort_source as;
+            auto reader_cfg = make_blocked_reader_cfg(as);
+            reader_cfg.read_lock_deadline = ss::semaphore::clock::now() + 20ms;
+            EXPECT_THROW(
+              log->make_reader(reader_cfg).get(), ss::timed_out_error);
+        }
+
+        {
+            // abort source and deadline: abort fires first
+            ss::abort_source as;
+            auto reader_cfg = make_blocked_reader_cfg(as);
+            reader_cfg.read_lock_deadline = ss::semaphore::clock::now() + 1h;
+            auto fut = log->make_reader(reader_cfg);
+            EXPECT_FALSE(fut.available());
+            as.request_abort();
+            EXPECT_THROW(std::move(fut).get(), ss::abort_requested_exception);
+        }
+    }
+    gate.close().get();
+}
+
 TEST_F(storage_test_fixture, test_max_eligible_for_compacted_reupload_offset) {
     constexpr size_t num_segments = 2;
     auto cfg = default_log_config(test_dir);

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -461,7 +461,8 @@ struct local_log_reader_config {
     /// `timestamp > batch.header().max_timestamp`.
     std::optional<model::timestamp> timestamp;
 
-    /// abort source for read operations
+    /// abort source for read operations. aborts the segment range lock
+    /// acquisition in make_reader and ends the stream of an existing reader.
     model::opt_abort_source_t abort_source;
 
     model::opt_client_address_t client_address;


### PR DESCRIPTION
Waiters parked on segment read/write locks can stall shutdown, since these previously didn't respect abort sources, just timeouts, leading to potential `ERROR` level log lines like:

```
rptest.services.utils.BadLogLines: <BadLogLines nodes=docker-rp-18(2) example="ERROR 2026-07-29 14:20:12,369 [shard 0:main] cluster - partition_manager.cc:533 - partition {kafka/tp-workload-writecaching-compact/1} shutdown takes longer than expected, current shutdown stage: stopping_raft time since last update: 20 seconds">
```

Fix the issue by adding overloads for `segment::{read}/{write}_lock(ss::abort_source&)` and use these where necessary.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none
