### PR TITLE
cloud_topics/stm: reject epoch-window-violating batches at raft enqueue

### DIFF
--- a/src/v/cloud_topics/frontend/BUILD
+++ b/src/v/cloud_topics/frontend/BUILD
@@ -38,6 +38,7 @@ redpanda_cc_library(
         "//src/v/kafka/protocol",
         "//src/v/kafka/server:write_at_offset_stm",
         "//src/v/ssx:future_util",
+        "//src/v/ssx:mutex",
         "//src/v/storage:record_batch_builder",
     ],
     visibility = ["//visibility:public"],

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -39,6 +39,7 @@
 #include "raft/errc.h"
 #include "raft/replicate.h"
 #include "ssx/future-util.h"
+#include "ssx/mutex.h"
 #include "storage/log_reader.h"
 #include "storage/offset_translator_state.h"
 #include "storage/types.h"
@@ -817,6 +818,49 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
       placeholders.batches.size() == 1,
       "Expected single batch, got {}",
       placeholders.batches.size());
+
+    // Admit the epoch through the enqueue gate right before handing the
+    // batch to raft. The permit must be held until the request_enqueued
+    // stage resolves: that pins the batch's log position relative to later
+    // admissions, which is what makes the gate's ordering guarantee hold.
+    auto permit_fut = co_await ss::coroutine::as_future(
+      ctp_stm_api->admit_epoch_enqueue(fence->term, batch_epoch));
+    if (permit_fut.failed()) {
+        auto e = permit_fut.get_exception();
+        vlogl(
+          cd_log,
+          ssx::is_shutdown_exception(e) ? ss::log_level::debug
+                                        : ss::log_level::warn,
+          "Failed to admit epoch {} for enqueue for ntp {}, error: {}",
+          batch_epoch,
+          ntp,
+          e);
+        co_return default_errc;
+    }
+    auto permit = std::move(permit_fut.get());
+    if (!permit.has_value()) {
+        // The epoch is below the gate floor: batches carrying higher epochs
+        // are already ahead of this one in the log and landing it would
+        // violate the log epoch window. Invalidate the epoch on the upload
+        // shard so the batcher stops using it; the client retries against a
+        // fresh epoch.
+        auto upload_shard = upload_res.value().shard;
+        co_await ss::smp::submit_to(
+          upload_shard, [api, e = permit.error().window_min] {
+              return api->invalidate_epoch_below(e);
+          });
+        vlog(
+          cd_log.warn,
+          "Failed to admit epoch {} for enqueue for ntp {}, gate window is "
+          "[{}, {}]",
+          batch_epoch,
+          ntp,
+          permit.error().window_min,
+          permit.error().window_max);
+        co_return default_errc;
+    }
+    auto gate_units = std::move(permit.value());
+
     opts = update_replicate_options(opts, fence->term);
     auto replicate_stages = partition->replicate_in_stages(
       batch_id, std::move(placeholders.batches.front()), opts);
@@ -826,7 +870,8 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
     auto enqueued_fut = co_await ss::coroutine::as_future(
       std::move(replicate_stages.request_enqueued));
 
-    ticket.release(); // always release the ticket
+    ticket.release();        // always release the ticket
+    gate_units.return_all(); // the batch's log position is fixed
 
     if (enqueued_fut.failed()) {
         auto ex = enqueued_fut.get_exception();
@@ -1052,9 +1097,55 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
         placeholder_batches.push_back(std::move(batch));
     }
 
+    // Admit the epoch through the enqueue gate and hold the permit until
+    // the batches are enqueued in raft, pinning their log position relative
+    // to later admissions.
+    auto permit_fut = co_await ss::coroutine::as_future(
+      _ctp_stm_api->admit_epoch_enqueue(fence->term, batch_epoch));
+    if (permit_fut.failed()) {
+        auto e = permit_fut.get_exception();
+        vlogl(
+          cd_log,
+          ssx::is_shutdown_exception(e) ? ss::log_level::debug
+                                        : ss::log_level::warn,
+          "Failed to admit epoch {} for enqueue for ntp {}, error: {}",
+          batch_epoch,
+          ntp(),
+          e);
+        co_await ss::coroutine::return_exception_ptr(std::move(e));
+    }
+    auto permit = std::move(permit_fut.get());
+    if (!permit.has_value()) {
+        vlog(
+          cd_log.warn,
+          "Failed to admit epoch {} for enqueue for ntp {}, gate window is "
+          "[{}, {}]",
+          batch_epoch,
+          ntp(),
+          permit.error().window_min,
+          permit.error().window_max);
+        co_return std::unexpected(
+          kafka::make_error_code(kafka::error_code::request_timed_out));
+    }
+    auto gate_units = std::move(permit.value());
+
     opts = update_replicate_options(opts, fence->term);
-    auto result = co_await _partition->replicate(
+    auto stages = _partition->replicate_in_stages(
       std::move(placeholder_batches), opts);
+    auto enqueued_fut = co_await ss::coroutine::as_future(
+      std::move(stages.request_enqueued));
+    gate_units.return_all(); // the batches' log position is fixed
+    if (enqueued_fut.failed()) {
+        auto ex = enqueued_fut.get_exception();
+        vlog(
+          cd_log.trace,
+          "failed to enqueue replicate request into raft ({}): {}",
+          ntp(),
+          ex);
+        // fallthrough - we expect the finish command to throw if this one
+        // did and we don't want to abandon the replicate_finished future
+    }
+    auto result = co_await std::move(stages.replicate_finished);
 
     if (!result) {
         co_return std::unexpected(result.error());
@@ -1437,6 +1528,9 @@ ss::future<result<raft::replicate_result>> frontend::replicate_at_offset(
     batches.clear();
 
     chunked_vector<model::record_batch> placeholder_batches;
+    // Enqueue-gate permit for the placeholder epoch; held until the batches
+    // are enqueued in raft (control-only requests carry no epoch).
+    std::optional<ssx::mutex::units> gate_units;
 
     if (!data_batches.empty()) {
         auto min_epoch = cluster_epoch(_partition->get_topic_revision_id());
@@ -1525,6 +1619,34 @@ ss::future<result<raft::replicate_result>> frontend::replicate_at_offset(
             co_return raft::errc::not_leader;
         }
 
+        auto permit_fut = co_await ss::coroutine::as_future(
+          _ctp_stm_api->admit_epoch_enqueue(fence.value().term, batch_epoch));
+        if (permit_fut.failed()) {
+            auto e = permit_fut.get_exception();
+            vlogl(
+              cd_log,
+              ssx::is_shutdown_exception(e) ? ss::log_level::debug
+                                            : ss::log_level::warn,
+              "Failed to admit epoch {} for enqueue for ntp {}, error: {}",
+              batch_epoch,
+              ntp(),
+              e);
+            co_await ss::coroutine::return_exception_ptr(std::move(e));
+        }
+        auto permit = std::move(permit_fut.get());
+        if (!permit.has_value()) {
+            vlog(
+              cd_log.warn,
+              "Failed to admit epoch {} for enqueue for ntp {}, gate window "
+              "is [{}, {}]",
+              batch_epoch,
+              ntp(),
+              permit.error().window_min,
+              permit.error().window_max);
+            co_return raft::errc::not_leader;
+        }
+        gate_units = std::move(permit.value());
+
         auto placeholders = co_await convert_to_placeholders(
           res.value().extents, data_headers);
         placeholder_batches = chunked_vector<model::record_batch>(
@@ -1565,6 +1687,9 @@ ss::future<result<raft::replicate_result>> frontend::replicate_at_offset(
 
     auto enqueued_fut = co_await ss::coroutine::as_future(
       std::move(stages.request_enqueued));
+    if (gate_units.has_value()) {
+        gate_units->return_all(); // the batches' log position is fixed
+    }
     if (enqueued_fut.failed()) {
         auto ex = enqueued_fut.get_exception();
         vlogl(

--- a/src/v/cloud_topics/level_zero/stm/BUILD
+++ b/src/v/cloud_topics/level_zero/stm/BUILD
@@ -104,6 +104,7 @@ redpanda_cc_library(
     ],
     deps = [
         ":size_estimator",
+        ":types",
         "//src/v/base",
         "//src/v/cloud_topics:types",
         "//src/v/model",
@@ -164,6 +165,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics/level_zero/common:producer_queue",
         "//src/v/model",
         "//src/v/ssx:future_util",
+        "//src/v/ssx:mutex",
         "//src/v/utils:retry_chain_node",
         "@seastar",
     ],

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -531,6 +531,23 @@ ctp_stm::fence_epoch(cluster_epoch e, model::timeout_clock::duration timeout) {
     }
 }
 
+ss::future<std::expected<ssx::mutex::units, stale_cluster_epoch>>
+ctp_stm::admit_epoch_enqueue(model::term_id term, cluster_epoch epoch) {
+    auto units = co_await _enqueue_gate_lock.get_units(_as);
+    auto admitted = _state.admit_epoch_enqueue(term, epoch);
+    if (!admitted.has_value()) {
+        vlog(
+          _log.warn,
+          "epoch {} rejected by the enqueue gate, admission window is "
+          "[{}, {}]",
+          epoch,
+          admitted.error().window_min,
+          admitted.error().window_max);
+        co_return std::unexpected(admitted.error());
+    }
+    co_return std::move(units);
+}
+
 model::offset ctp_stm::max_removable_local_log_offset() {
     // If there is an active reader, it holds back prefix truncation.
     if (!_active_readers.empty()) {

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -87,6 +87,24 @@ public:
     fence_epoch(
       cluster_epoch e, model::timeout_clock::duration timeout = sync_timeout);
 
+    /// Admit an epoch-carrying batch for replication (the "enqueue gate").
+    ///
+    /// Raft preserves the submission order of appends within a term, so this
+    /// is the last point where a batch that would land below the log epoch
+    /// window can still be rejected. The admission window and its semantics
+    /// live in ctp_stm_state::admit_epoch_enqueue; this method contributes
+    /// the serialization that turns admission order into log order.
+    ///
+    /// \param term must come from a fence acquired in the current term (the
+    ///        fence's sync is what makes the applied window trustworthy).
+    /// \param epoch the epoch carried by the batch about to be replicated.
+    /// \return units that must be held until the raft request_enqueued stage
+    ///         of the batch resolves - this pins the batch's position in the
+    ///         log relative to later admissions - or the admission window if
+    ///         the epoch (or term) is stale.
+    ss::future<std::expected<ssx::mutex::units, stale_cluster_epoch>>
+    admit_epoch_enqueue(model::term_id term, cluster_epoch epoch);
+
     /// Return inactive epoch of the CTP
     ///
     /// The inactive epoch is any epoch which is no longer referenced
@@ -188,6 +206,10 @@ private:
     // is about the content of the log rather than the computed state. The state
     // is purely idempotent in terms of operations applied.
     epoch_window_checker _epoch_checker;
+
+    // Serializes epoch submissions to raft, see admit_epoch_enqueue(). The
+    // admission window itself lives in ctp_stm_state.
+    ssx::mutex _enqueue_gate_lock{"ctp_stm::enqueue_gate"};
 
     // An abort source to stop the prefix truncation loop on stop.
     ss::condition_variable _lro_advanced;

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
@@ -34,7 +34,8 @@ ctp_stm_api::replicated_apply(
   model::record_batch&& batch,
   std::optional<model::term_id> expected_term,
   model::timeout_clock::time_point deadline,
-  ss::abort_source& as) {
+  ss::abort_source& as,
+  ssx::mutex::units gate_units) {
     model::term_id term = expected_term.value_or(_stm->_raft->term());
 
     vlog(_log.debug, "Replicating batch {} in term {}", batch.header(), term);
@@ -45,7 +46,17 @@ ctp_stm_api::replicated_apply(
       /*timeout=*/std::nullopt,
       as);
     opts.set_force_flush();
-    auto res = co_await _stm->_raft->replicate(std::move(batch), opts);
+    auto stages = _stm->_raft->replicate_in_stages(std::move(batch), opts);
+    auto enqueued = co_await ss::coroutine::as_future(
+      std::move(stages.request_enqueued));
+    gate_units.return_all(); // the batch's log position is fixed
+    if (enqueued.failed()) {
+        auto e = enqueued.get_exception();
+        vlog(_log.debug, "Failed to enqueue batch: {}", e);
+        // fallthrough - replicate_finished carries the error and must not
+        // be abandoned
+    }
+    auto res = co_await std::move(stages.replicate_finished);
 
     if (!res.has_value()) {
         vlog(_log.debug, "Failed to replicate batch: {}", res.error());
@@ -276,6 +287,33 @@ ctp_stm_api::advance_epoch(
         co_return std::unexpected{ctp_stm_api_errc::failure};
     }
 
+    auto permit_fut = co_await ss::coroutine::as_future(
+      _stm->admit_epoch_enqueue(fence.value().term, new_epoch));
+    if (permit_fut.failed()) {
+        auto e = permit_fut.get_exception();
+        vlogl(
+          _log,
+          ssx::is_shutdown_exception(e) ? ss::log_level::debug
+                                        : ss::log_level::warn,
+          "Failed to admit epoch {} for enqueue for ntp {}, error: {}",
+          new_epoch,
+          _stm->ntp(),
+          e);
+        co_return std::unexpected{ctp_stm_api_errc::failure};
+    }
+    auto permit = std::move(permit_fut.get());
+    if (!permit.has_value()) {
+        vlog(
+          _log.warn,
+          "Failed to admit epoch {} for enqueue for ntp {}, gate window is "
+          "[{}, {}]",
+          new_epoch,
+          _stm->ntp(),
+          permit.error().window_min,
+          permit.error().window_max);
+        co_return std::unexpected{ctp_stm_api_errc::failure};
+    }
+
     vlog(_log.debug, "Replicating ctp_stm_cmd::advance_epoch{{{}}}", new_epoch);
 
     storage::record_batch_builder builder(
@@ -287,7 +325,11 @@ ctp_stm_api::advance_epoch(
 
     auto batch = std::move(builder).build();
     auto apply_result = co_await replicated_apply(
-      std::move(batch), fence.value().term, deadline, as);
+      std::move(batch),
+      fence.value().term,
+      deadline,
+      as,
+      std::move(permit.value()));
 
     if (!apply_result.has_value()) {
         co_return std::unexpected(apply_result.error());
@@ -354,6 +396,11 @@ ctp_stm_api::fence_epoch(
       e,
       res.has_value() ? res->term : model::term_id{-1});
     co_return std::move(res);
+}
+
+ss::future<std::expected<ssx::mutex::units, stale_cluster_epoch>>
+ctp_stm_api::admit_epoch_enqueue(model::term_id term, cluster_epoch epoch) {
+    return _stm->admit_epoch_enqueue(term, epoch);
 }
 
 std::optional<cluster_epoch> ctp_stm_api::get_max_epoch() const {

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.h
@@ -17,6 +17,7 @@
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "model/timeout_clock.h"
+#include "ssx/mutex.h"
 
 #include <seastar/core/gate.hh>
 
@@ -154,6 +155,13 @@ public:
     static constexpr auto default_fence_epoch_timeout = std::chrono::seconds(
       10);
 
+    /// Admit an epoch-carrying batch for replication through the enqueue
+    /// gate (see ctp_stm::admit_epoch_enqueue). `term` must come from a
+    /// fence acquired in the current term. The returned units must be held
+    /// until the raft request_enqueued stage of the batch resolves.
+    ss::future<std::expected<ssx::mutex::units, stale_cluster_epoch>>
+    admit_epoch_enqueue(model::term_id term, cluster_epoch epoch);
+
     std::optional<cluster_epoch> get_max_epoch() const;
 
     std::optional<cluster_epoch> get_max_seen_epoch(model::term_id) const;
@@ -171,12 +179,15 @@ public:
 
 private:
     /// Replicate a record batch and wait for it to be applied to the ctp_stm.
-    /// Returns the offset at which the batch was applied.
+    /// Returns the offset at which the batch was applied. If `gate_units`
+    /// carries an enqueue-gate permit it is released once raft fixed the
+    /// batch's position in the log.
     ss::future<std::expected<model::offset, ctp_stm_api_errc>> replicated_apply(
       model::record_batch&& batch,
       std::optional<model::term_id> expected_term,
       model::timeout_clock::time_point deadline,
-      ss::abort_source&);
+      ss::abort_source&,
+      ssx::mutex::units gate_units = {});
 
 private:
     ss::shared_ptr<ctp_stm> _stm;

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
@@ -29,6 +29,56 @@ void ctp_stm_state::advance_max_seen_epoch(
     }
 }
 
+std::expected<std::monostate, stale_cluster_epoch>
+ctp_stm_state::admit_epoch_enqueue(
+  model::term_id term, cluster_epoch epoch) noexcept {
+    auto make_stale = [this] {
+        return stale_cluster_epoch{
+          .window_min = _previous_seen_epoch
+                          .or_else([this] { return _previous_applied_epoch; })
+                          .value_or(cluster_epoch{-1}),
+          .window_max = _max_seen_epoch
+                          .or_else([this] { return _max_applied_epoch; })
+                          .value_or(cluster_epoch{-1}),
+        };
+    };
+    if (term < _seen_window_term) {
+        return std::unexpected(make_stale());
+    }
+    if (term > _seen_window_term) {
+        // First submission of the term: seed the window from the applied
+        // epochs. Everything that survived from earlier terms is applied
+        // before the caller's fence sync completed, and submissions that
+        // never landed must not constrain the new term.
+        _seen_window_term = term;
+        _previous_seen_epoch = _previous_applied_epoch;
+        _max_seen_epoch = _max_applied_epoch;
+    }
+    if (_previous_seen_epoch.has_value() && epoch < *_previous_seen_epoch) {
+        return std::unexpected(make_stale());
+    }
+    if (!_max_seen_epoch.has_value() || epoch > *_max_seen_epoch) {
+        // Normally the fence already bumped the seen window past the epoch;
+        // handle a direct submission the same way the bump would.
+        _previous_seen_epoch = _max_seen_epoch.value_or(epoch);
+        _max_seen_epoch = epoch;
+    } else if (
+      epoch < *_max_seen_epoch
+      && (!_previous_seen_epoch.has_value() || epoch > *_previous_seen_epoch)) {
+        // An admitted interior epoch becomes the floor: together with the
+        // max it forms the pair of distinct submitted epochs that could
+        // move the log window above anything below it.
+        _previous_seen_epoch = epoch;
+    }
+    if (!_max_applied_epoch.has_value()) {
+        // The log epoch window does not exist yet and whichever admitted
+        // epoch lands first collapses it to [e, e]: every admitted epoch
+        // becomes the floor until the window exists.
+        _previous_seen_epoch = epoch;
+    }
+    return std::monostate{};
+}
+
 std::optional<kafka::offset>
 ctp_stm_state::get_last_reconciled_offset() const noexcept {
     return _last_reconciled_offset;

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
@@ -125,39 +125,17 @@ bool ctp_stm_state::epoch_in_window(
     // the window should be [_previous_seen_epoch, _max_seen_epoch].
     // The window reflects in-flight requests. Write fence is required
     // to move it forward.
+    //
+    // The window is best-effort admission control: it filters out epochs
+    // that are definitely stale so writers refresh their epoch early. It is
+    // not the safety layer - a batch that would land below the log epoch
+    // window is rejected by the enqueue gate in ctp_stm right before it is
+    // handed to raft, where the landing order is known.
     auto end = _max_seen_epoch.value_or(
       _max_applied_epoch.value_or(cluster_epoch::min()));
     auto begin = _previous_seen_epoch.value_or(
       _previous_applied_epoch.value_or(end));
-    if (epoch < begin || epoch > end) {
-        return false;
-    }
-    if (epoch == end) {
-        return true;
-    }
-    // A below-max epoch is only admissible if some epoch batch is known to
-    // precede the max-seen epoch's first batch in the log. The seen window
-    // alone can't prove this: a fence-time bump whose batch never lands (a
-    // failed replicate) leaves a lower bound with no counterpart in the log.
-    // If nothing precedes the max epoch's first batch, the log epoch window
-    // collapses to [max, max] when that batch applies, and a below-max batch
-    // landing after it violates the log invariant enforced by
-    // epoch_window_checker and may reference L0 objects the GC already
-    // considers inactive.
-    //
-    // Applied state gives positional evidence, since apply follows log order:
-    // - _max_applied_epoch < end: an applied batch sits at a lower log
-    //   position than any batch at the max-seen epoch (applied or not).
-    // - _max_applied_epoch == end: the max epoch applied; a batch preceded it
-    //   iff the applied window did not collapse to [end, end].
-    if (!_max_applied_epoch.has_value()) {
-        return false;
-    }
-    if (*_max_applied_epoch < end) {
-        return true;
-    }
-    return *_max_applied_epoch == end
-           && _previous_applied_epoch.value_or(end) < end;
+    return epoch >= begin && epoch <= end;
 }
 
 bool ctp_stm_state::epoch_above_window(

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
@@ -12,9 +12,13 @@
 
 #include "base/format_to.h"
 #include "cloud_topics/level_zero/stm/size_estimator.h"
+#include "cloud_topics/level_zero/stm/types.h"
 #include "cloud_topics/types.h"
 #include "model/fundamental.h"
 #include "serde/envelope.h"
+
+#include <expected>
+#include <variant>
 
 namespace cloud_topics {
 
@@ -51,6 +55,28 @@ public:
     /// epoch value is even replicated.
     void
     advance_max_seen_epoch(model::term_id term, cluster_epoch epoch) noexcept;
+
+    /// Admit an epoch-carrying batch for submission to raft.
+    ///
+    /// The seen window doubles as the admission window: the floor
+    /// (_previous_seen_epoch) is raised by fence-time bumps, by interior
+    /// admissions and, until the first epoch batch applies, by every
+    /// admission (whichever admitted epoch lands first collapses the log
+    /// epoch window to [e, e]). Everything below the floor is rejected:
+    /// two distinct epochs above `e` may land ahead of it in rising order
+    /// and move the log epoch window past it, and applying `e` would then
+    /// fire the epoch_window_checker vassert on every replica. The floor is
+    /// the runner-up rather than the max because stragglers at the previous
+    /// epoch are routine when shards observe the cluster epoch at different
+    /// times, and a single epoch above `e` cannot move the log window past
+    /// it. On a term change the window reseeds from the applied epochs, so
+    /// a floor learned from submissions that never landed does not outlive
+    /// its term.
+    ///
+    /// The caller (ctp_stm) must serialize calls with the raft enqueue of
+    /// the admitted batch so that admission order equals log order.
+    std::expected<std::monostate, stale_cluster_epoch>
+    admit_epoch_enqueue(model::term_id term, cluster_epoch epoch) noexcept;
 
     // Set the new start offset for the partition.
     //
@@ -186,6 +212,10 @@ private:
     /// The previous epoch after the current in flight requests are applied.
     /// Requests with epochs below this value are fenced and not allowed to be
     /// applied to the STM.
+    ///
+    /// Doubles as the enqueue admission floor (see admit_epoch_enqueue):
+    /// besides fence-time bumps it is raised by admitted interior epochs and,
+    /// until the first epoch batch applies, by every admitted epoch.
     ///
     /// Not persisted with the snapshot because it reflects the state of
     /// in-flight requests.

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
@@ -295,12 +295,11 @@ TEST(ctp_stm_state_test, sliding_window_issue) {
     EXPECT_EQ(estimate_inactive_epoch(), 9_epoch);
 }
 
-TEST(ctp_stm_state_test, below_max_fence_requires_applied_evidence) {
-    // A fenced epoch bump whose batch never lands leaves a phantom lower
-    // bound in the seen window. Admitting a below-max epoch is only sound if
-    // some epoch batch is known to precede the max-seen epoch's first batch
-    // in the log; otherwise the log's epoch window collapses to [max, max]
-    // when the max applies and the below-max batch violates it.
+TEST(ctp_stm_state_test, below_max_fence_admitted_within_seen_window) {
+    // The seen window is a plain range check: it is best-effort admission
+    // control, not the safety layer. Landing-order safety (a batch landing
+    // below the log epoch window) is enforced by the enqueue gate in
+    // ctp_stm right before the batch is handed to raft.
     ct::ctp_stm_state state;
     model::term_id term(1);
 
@@ -308,22 +307,23 @@ TEST(ctp_stm_state_test, below_max_fence_requires_applied_evidence) {
     state.advance_max_seen_epoch(term, 132_epoch);
     state.advance_max_seen_epoch(term, 141_epoch);
 
-    // At-max admission is always sound.
+    // Everything inside [132, 141] is admitted.
     EXPECT_TRUE(state.epoch_in_window(term, 141_epoch));
-    // Below-max admission has no applied evidence: reject.
-    EXPECT_FALSE(state.epoch_in_window(term, 132_epoch));
+    EXPECT_TRUE(state.epoch_in_window(term, 132_epoch));
+    EXPECT_TRUE(state.epoch_in_window(term, 135_epoch));
+    // Outside the window is rejected.
+    EXPECT_FALSE(state.epoch_in_window(term, 131_epoch));
+    EXPECT_FALSE(state.epoch_in_window(term, 142_epoch));
 
-    // The max epoch lands as the first batch in the log: the log window is
-    // [141, 141], so 132 must still be rejected.
+    // Applied state does not change the seen-window answer.
     state.advance_epoch(141_epoch, model::offset{0});
-    EXPECT_FALSE(state.epoch_in_window(term, 132_epoch));
+    EXPECT_TRUE(state.epoch_in_window(term, 132_epoch));
     EXPECT_TRUE(state.epoch_in_window(term, 141_epoch));
 }
 
-TEST(ctp_stm_state_test, below_max_fence_allowed_with_applied_evidence) {
-    // The legitimate in-flight case: the previous epoch's batch landed and
-    // applied before the bump, so a straggler at that epoch stays admissible
-    // both before and after the max epoch's batch applies.
+TEST(ctp_stm_state_test, below_max_fence_allowed_within_window) {
+    // The legitimate in-flight case: a straggler at the previous epoch stays
+    // admissible both before and after the max epoch's batch applies.
     ct::ctp_stm_state state;
     model::term_id term(1);
 
@@ -331,11 +331,9 @@ TEST(ctp_stm_state_test, below_max_fence_allowed_with_applied_evidence) {
     state.advance_epoch(132_epoch, model::offset{0});
 
     state.advance_max_seen_epoch(term, 141_epoch);
-    // An applied 132 batch precedes any (future) 141 batch in the log.
     EXPECT_TRUE(state.epoch_in_window(term, 132_epoch));
 
     state.advance_epoch(141_epoch, model::offset{1});
-    // The log window is [132, 141]: 132 remains admissible.
     EXPECT_TRUE(state.epoch_in_window(term, 132_epoch));
     EXPECT_TRUE(state.epoch_in_window(term, 141_epoch));
     EXPECT_FALSE(state.epoch_in_window(term, 131_epoch));
@@ -574,10 +572,10 @@ TEST(ctp_stm_state_test, l0_simulation) {
                 universe.uploaded_batches.pop_front();
                 // Mirror the fence_epoch branches: bump the window for an
                 // above-window epoch, replicate an in-window epoch, reject
-                // everything else. A below-max epoch is rejected while no
-                // applied batch proves that something precedes the max
-                // epoch's first batch in the log (the producer would retry
-                // with a fresh epoch).
+                // everything else (the producer would retry with a fresh
+                // epoch). Placeholders apply in replication order below,
+                // which models the ordering the enqueue gate guarantees in
+                // production.
                 if (universe.stm.epoch_above_window(term, batch.epoch)) {
                     universe.stm.advance_max_seen_epoch(term, batch.epoch);
                     ASSERT_TRUE(

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
@@ -341,6 +341,117 @@ TEST(ctp_stm_state_test, below_max_fence_allowed_with_applied_evidence) {
     EXPECT_FALSE(state.epoch_in_window(term, 131_epoch));
 }
 
+TEST(ctp_stm_state_test, admit_is_strict_until_first_epoch_applies) {
+    // Until the first epoch batch applies, the log epoch window does not
+    // exist: whichever admitted epoch lands first collapses it to [e, e],
+    // and raft may drop any enqueued item, so every admitted epoch becomes
+    // the admission floor.
+    ct::ctp_stm_state state;
+    model::term_id term(1);
+
+    ASSERT_TRUE(state.admit_epoch_enqueue(term, 14_epoch).has_value());
+    auto rejected = state.admit_epoch_enqueue(term, 12_epoch);
+    ASSERT_FALSE(rejected.has_value());
+    EXPECT_EQ(rejected.error().window_min, 14_epoch);
+    EXPECT_EQ(rejected.error().window_max, 14_epoch);
+    // Repeats at the floor keep flowing.
+    EXPECT_TRUE(state.admit_epoch_enqueue(term, 14_epoch).has_value());
+
+    // The first epoch batch applies: the window exists and the regular
+    // two-highest tracking resumes.
+    state.advance_epoch(14_epoch, model::offset{0});
+    EXPECT_TRUE(state.admit_epoch_enqueue(term, 15_epoch).has_value());
+    EXPECT_TRUE(state.admit_epoch_enqueue(term, 14_epoch).has_value());
+    EXPECT_FALSE(state.admit_epoch_enqueue(term, 13_epoch).has_value());
+}
+
+TEST(ctp_stm_state_test, admit_tracks_two_highest_submitted_epochs) {
+    // The admission floor is the runner-up among the distinct epochs
+    // submitted for replication: a single higher epoch cannot move the log
+    // window past a straggler, two can.
+    ct::ctp_stm_state state;
+    model::term_id term(1);
+
+    state.advance_max_seen_epoch(term, 1_epoch);
+    ASSERT_TRUE(state.admit_epoch_enqueue(term, 1_epoch).has_value());
+    state.advance_epoch(1_epoch, model::offset{0});
+
+    state.advance_max_seen_epoch(term, 5_epoch);
+    EXPECT_TRUE(state.admit_epoch_enqueue(term, 5_epoch).has_value());
+    // Interior epoch admitted, becomes the floor.
+    EXPECT_TRUE(state.admit_epoch_enqueue(term, 3_epoch).has_value());
+    {
+        auto rejected = state.admit_epoch_enqueue(term, 2_epoch);
+        ASSERT_FALSE(rejected.has_value());
+        EXPECT_EQ(rejected.error().window_min, 3_epoch);
+        EXPECT_EQ(rejected.error().window_max, 5_epoch);
+    }
+    // A new max promotes the previous max to the floor.
+    EXPECT_TRUE(state.admit_epoch_enqueue(term, 7_epoch).has_value());
+    EXPECT_FALSE(state.admit_epoch_enqueue(term, 4_epoch).has_value());
+    // Stragglers at the floor and at the max keep flowing.
+    EXPECT_TRUE(state.admit_epoch_enqueue(term, 5_epoch).has_value());
+    EXPECT_TRUE(state.admit_epoch_enqueue(term, 7_epoch).has_value());
+    // An interior epoch raises the floor.
+    EXPECT_TRUE(state.admit_epoch_enqueue(term, 6_epoch).has_value());
+    EXPECT_FALSE(state.admit_epoch_enqueue(term, 5_epoch).has_value());
+}
+
+TEST(ctp_stm_state_test, admit_raises_the_fence_floor) {
+    // The fence and the enqueue admission share one window: an interior
+    // admission raises the floor that epoch_in_window checks, so later
+    // fences below it are rejected early.
+    ct::ctp_stm_state state;
+    model::term_id term(1);
+
+    state.advance_max_seen_epoch(term, 2_epoch);
+    ASSERT_TRUE(state.admit_epoch_enqueue(term, 2_epoch).has_value());
+    state.advance_epoch(2_epoch, model::offset{0});
+    state.advance_max_seen_epoch(term, 8_epoch);
+
+    EXPECT_TRUE(state.epoch_in_window(term, 3_epoch));
+    ASSERT_TRUE(state.admit_epoch_enqueue(term, 5_epoch).has_value());
+    EXPECT_FALSE(state.epoch_in_window(term, 3_epoch));
+    EXPECT_TRUE(state.epoch_in_window(term, 5_epoch));
+}
+
+TEST(ctp_stm_state_test, admit_reseeds_from_applied_window_on_new_term) {
+    // A floor learned from submissions that never landed must not outlive
+    // the term: the first admission of a new term reseeds the window from
+    // the applied epochs.
+    ct::ctp_stm_state state;
+    model::term_id term(1);
+
+    state.advance_max_seen_epoch(term, 3_epoch);
+    ASSERT_TRUE(state.admit_epoch_enqueue(term, 3_epoch).has_value());
+    state.advance_epoch(3_epoch, model::offset{0});
+    state.advance_max_seen_epoch(term, 5_epoch);
+    ASSERT_TRUE(state.admit_epoch_enqueue(term, 5_epoch).has_value());
+    state.advance_epoch(5_epoch, model::offset{1});
+
+    // Submissions with no counterpart in the log push the window to [8, 9].
+    ASSERT_TRUE(state.admit_epoch_enqueue(term, 8_epoch).has_value());
+    ASSERT_TRUE(state.admit_epoch_enqueue(term, 9_epoch).has_value());
+    EXPECT_FALSE(state.admit_epoch_enqueue(term, 6_epoch).has_value());
+
+    // New term: the window reseeds from the applied [3, 5].
+    model::term_id term2(2);
+    auto rejected = state.admit_epoch_enqueue(term2, 2_epoch);
+    ASSERT_FALSE(rejected.has_value());
+    EXPECT_EQ(rejected.error().window_min, 3_epoch);
+    EXPECT_EQ(rejected.error().window_max, 5_epoch);
+    EXPECT_TRUE(state.admit_epoch_enqueue(term2, 6_epoch).has_value());
+}
+
+TEST(ctp_stm_state_test, admit_rejects_stale_term) {
+    ct::ctp_stm_state state;
+    model::term_id term(2);
+
+    ASSERT_TRUE(state.admit_epoch_enqueue(term, 5_epoch).has_value());
+    EXPECT_FALSE(
+      state.admit_epoch_enqueue(model::term_id(1), 6_epoch).has_value());
+}
+
 TEST(ctp_stm_state_test, l0_simulation) {
     struct uploaded_l0_file_batch {
         ct::cluster_epoch epoch;
@@ -364,6 +475,11 @@ TEST(ctp_stm_state_test, l0_simulation) {
         ss::chunked_fifo<placeholder_batch> log_placeholders;
         // hwm for the partition
         kafka::offset hwm = 0_offset;
+        // Mirror of the epoch_window_checker in ctp_stm: the log epoch
+        // window derived from apply order. A batch applying below the
+        // window min would fire the checker vassert on every replica.
+        std::optional<ct::cluster_epoch> checker_min;
+        std::optional<ct::cluster_epoch> checker_max;
 
         testing::AssertionResult validate() {
             // The main thing we want to validate is that there are no batches
@@ -471,6 +587,17 @@ TEST(ctp_stm_state_test, l0_simulation) {
                       fmt::format("rejected batch with epoch {}", batch.epoch));
                     return;
                 }
+                // The enqueue admission runs right before the batch is
+                // handed to raft; batches below the admission floor are
+                // rejected (the producer would retry with a fresh epoch).
+                if (!universe.stm.admit_epoch_enqueue(term, batch.epoch)
+                       .has_value()) {
+                    oplog.push_back(
+                      fmt::format(
+                        "batch with epoch {} rejected at the enqueue gate",
+                        batch.epoch));
+                    return;
+                }
                 placeholder_batch placeholder{
                   .epoch = batch.epoch, .offset = universe.hwm++};
                 universe.unapplied_placeholders.push_back(placeholder);
@@ -487,6 +614,17 @@ TEST(ctp_stm_state_test, l0_simulation) {
             possible_operations.emplace_back([&universe, &oplog] {
                 auto batch = universe.unapplied_placeholders.front();
                 universe.unapplied_placeholders.pop_front();
+                // Mirror epoch_window_checker::check_epoch: the batch must
+                // not apply below the log epoch window.
+                if (!universe.checker_max.has_value()) {
+                    universe.checker_min = batch.epoch;
+                    universe.checker_max = batch.epoch;
+                } else if (batch.epoch > *universe.checker_max) {
+                    universe.checker_min = universe.checker_max;
+                    universe.checker_max = batch.epoch;
+                }
+                ASSERT_GE(batch.epoch, universe.checker_min.value())
+                  << fmt::format("operations:\n{}", fmt::join(oplog, "\n"));
                 // Apply to the STM
                 universe.stm.advance_epoch(
                   batch.epoch, kafka::offset_cast(batch.offset));

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -1069,27 +1069,24 @@ TEST_F_CORO(
       << "change, allowing an epoch that is below the applied window [7, 8].";
 }
 
-TEST_F_CORO(
-  ctp_stm_fixture, test_failed_epoch_bump_replicate_poisons_seen_window) {
-    // Bug reproduction (Antithesis ct_stress crash): a fence-time epoch bump
-    // whose batch never lands in the log leaves a phantom lower bound in the
-    // seen window, admitting a stale epoch that the log-content invariant
-    // forbids.
+TEST_F_CORO(ctp_stm_fixture, test_stale_epoch_after_failed_bump_cannot_land) {
+    // Layered admission for the original Antithesis ct_stress crash: a
+    // fence-time epoch bump whose batch never lands leaves a phantom lower
+    // bound in the seen window.
     //
     // Scenario, all within one term on one leader:
-    // 1. A writer fences epoch 132 (first fence in the term, seen window
-    //    becomes [132, 132]) but its replicate fails - nothing lands in the
-    //    log and the fence guard is dropped.
-    // 2. A writer fences epoch 141 (seen window [132, 141]) and replicates.
-    //    The log's first epoch-bearing batch carries 141, so the
-    //    epoch_window_checker window collapses to [141, 141] and the applied
-    //    state treats epochs <= 140 as inactive (their L0 objects become
-    //    eligible for GC).
-    // 3. A writer fences epoch 132 again. This must be rejected: admitting it
-    //    lands an epoch-132 placeholder after the 141 batch, and every
-    //    replica that applies the batch dies in
-    //    epoch_window_checker::check_epoch with "epoch 132 at N is outside of
-    //    sliding window [141, 141]".
+    // 1. A writer fences epoch 132 (seen window [132, 132]) but its
+    //    replicate fails - nothing lands and the guard is dropped.
+    // 2. A writer fences epoch 141 and replicates. The log's first
+    //    epoch-bearing batch carries 141, so the epoch_window_checker window
+    //    collapses to [141, 141]; the enqueue admission of 141 raises the
+    //    shared admission floor accordingly.
+    // 3. A writer fences epoch 132 again. It must not be able to reach the
+    //    log: landing an epoch-132 placeholder after the 141 batch would
+    //    fire the checker vassert "epoch 132 at N is outside of sliding
+    //    window [141, 141]" on every replica. The fence and the enqueue
+    //    admission share one window, so the fence already rejects it; if a
+    //    looser fence ever admits it, the enqueue admission must reject.
     co_await start();
     co_await wait_for_leader(raft::default_timeout());
 
@@ -1111,32 +1108,27 @@ TEST_F_CORO(
       leader, ct::cluster_epoch{141}, model::offset{0}, 0);
     ASSERT_TRUE_CORO(ok);
 
-    // Step 3: epoch 132 is now below the log window and must be rejected.
+    // Step 3: epoch 132 is rejected before it can reach the log.
     auto stale_fence = co_await leader_api.fence_epoch(ct::cluster_epoch{132});
-    EXPECT_FALSE(stale_fence.has_value())
-      << "fence_epoch admitted epoch 132 although the log's first epoch "
-         "entry is 141: the seen-window lower bound came from a bump whose "
-         "batch never landed in the log";
-
     if (stale_fence.has_value()) {
-        // Under the bug, replicating with the granted fence reproduces the
-        // crash: apply trips the epoch_window_checker vassert on every
-        // replica.
-        auto guard = std::move(stale_fence.value());
-        auto batch = make_record_batch(
-          ct::cluster_epoch{132}, model::offset{1}, 1);
-        auto res = co_await replicate_record_batch(leader, std::move(batch));
-        ASSERT_TRUE_CORO(res.has_value());
+        auto rejected = co_await leader_api.admit_epoch_enqueue(
+          stale_fence.value().term, ct::cluster_epoch{132});
+        ASSERT_FALSE_CORO(rejected.has_value())
+          << "epoch 132 admitted for enqueue although the log's first epoch "
+             "entry is 141: replicating it would fire the "
+             "epoch_window_checker vassert on every replica";
+        ASSERT_EQ_CORO(rejected.error().window_min, ct::cluster_epoch{141});
     }
 }
 
-TEST_F_CORO(ctp_stm_fixture, test_below_max_fence_rejected_without_batches) {
-    // Companion to test_failed_epoch_bump_replicate_poisons_seen_window
-    // covering the concurrent variant: the max-seen epoch's batch is not in
-    // the log yet (here it is never replicated at all - the same state the
-    // fence observes while that batch is still mid-replication). With no
-    // epoch batch applied there is no evidence that anything precedes the
-    // max epoch's first batch, so a below-max fence must be rejected.
+TEST_F_CORO(
+  ctp_stm_fixture, test_below_max_admitted_without_batches_lands_safely) {
+    // Companion to test_stale_epoch_after_failed_bump_rejected_at_gate: the
+    // max-seen epoch's batch is not in the log (here it is never replicated
+    // at all). A below-max writer is admitted by the fence (the seen window
+    // is a best-effort filter) and by the gate (no epoch above it has been
+    // submitted for replication), and its batch lands legally as the log's
+    // first epoch entry.
     co_await start();
     co_await wait_for_leader(raft::default_timeout());
 
@@ -1153,9 +1145,16 @@ TEST_F_CORO(ctp_stm_fixture, test_below_max_fence_rejected_without_batches) {
         ASSERT_TRUE_CORO(fence.has_value());
     }
 
-    auto stale_fence = co_await leader_api.fence_epoch(ct::cluster_epoch{132});
-    ASSERT_FALSE_CORO(stale_fence.has_value())
-      << "below-max epoch admitted while no epoch batch has been applied";
+    // The full write path (fence, gate, replicate, apply) succeeds: no
+    // epoch-141 batch exists or will ever exist, so an epoch-132 first
+    // entry collapses the checker window to [132, 132] legally.
+    ASSERT_TRUE_CORO(
+      co_await replicate_with_epoch(
+        leader, ct::cluster_epoch{132}, model::offset{0}, 0));
+
+    // Below the seen window is still rejected at the fence.
+    auto below_window = co_await leader_api.fence_epoch(ct::cluster_epoch{131});
+    ASSERT_FALSE_CORO(below_window.has_value());
 }
 
 TEST_F_CORO(ctp_stm_fixture, test_below_max_fence_allowed_after_epoch_landed) {

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -118,9 +118,11 @@ public:
         co_return co_await accessor.replicated_apply(std::move(rb), as);
     }
 
-    /// Helper method that follows the producer pattern: fence → replicate
-    /// Fences the given epoch, and if successful, replicates a batch with that
-    /// epoch. Returns true if both operations succeeded.
+    /// Helper method that follows the producer pattern:
+    /// fence → enqueue gate → replicate.
+    /// Fences the given epoch, admits it through the enqueue gate and, if
+    /// both succeed, replicates a batch with that epoch. Returns true if all
+    /// operations succeeded.
     ss::future<bool> replicate_with_epoch(
       raft::raft_node_instance& node,
       ct::cluster_epoch epoch,
@@ -135,11 +137,18 @@ public:
         // Keep the fence guard alive during replication
         auto fence_guard = std::move(fence_result.value());
 
+        // Pass the enqueue gate like the production write path does.
+        auto permit = co_await api(node).admit_epoch_enqueue(
+          fence_guard.term, epoch);
+        if (!permit.has_value()) {
+            co_return false;
+        }
+
         // Then replicate with that epoch
         auto batch = make_record_batch(epoch, base_offset, seq);
         auto res = co_await replicate_record_batch(node, std::move(batch));
 
-        // fence_guard released here when it goes out of scope
+        // fence_guard and permit released here when they go out of scope
         co_return res.has_value();
     }
 
@@ -1172,6 +1181,302 @@ TEST_F_CORO(ctp_stm_fixture, test_below_max_fence_allowed_after_epoch_landed) {
     ok = co_await replicate_with_epoch(
       leader, ct::cluster_epoch{132}, model::offset{2}, 2);
     ASSERT_TRUE_CORO(ok);
+}
+
+TEST_F_CORO(ctp_stm_fixture, test_enqueue_gate_admits_two_highest_epochs) {
+    // The enqueue gate keeps the two highest distinct epochs submitted for
+    // replication in the current term; the runner-up is the admission floor.
+    // Stragglers at the runner-up epoch keep flowing (cross-shard epoch skew
+    // is routine), while anything below the floor is rejected: two higher
+    // epochs could land ahead of it in rising order and move the log epoch
+    // window past it, so applying it would fire the epoch_window_checker
+    // vassert.
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+    auto& leader = node(*get_leader());
+    auto leader_api = api(leader);
+
+    // Land epoch 1 so the log epoch window exists (the gate stays strict
+    // before that, see test_enqueue_gate_strict_before_first_epoch_applies).
+    ASSERT_TRUE_CORO(
+      co_await replicate_with_epoch(
+        leader, ct::cluster_epoch{1}, model::offset{0}, 0));
+
+    auto fence = co_await leader_api.fence_epoch(ct::cluster_epoch{5});
+    ASSERT_TRUE_CORO(fence.has_value());
+    auto term = fence.value().term;
+
+    {
+        auto permit = co_await leader_api.admit_epoch_enqueue(
+          term, ct::cluster_epoch{5});
+        ASSERT_TRUE_CORO(permit.has_value());
+    }
+    // A lower epoch is admitted while 5 is the highest distinct epoch
+    // submitted and 1 is the only landed one; it becomes the floor.
+    {
+        auto permit = co_await leader_api.admit_epoch_enqueue(
+          term, ct::cluster_epoch{3});
+        ASSERT_TRUE_CORO(permit.has_value());
+    }
+    // Below the floor: rejected, the error carries the gate window.
+    {
+        auto rejected = co_await leader_api.admit_epoch_enqueue(
+          term, ct::cluster_epoch{2});
+        ASSERT_FALSE_CORO(rejected.has_value());
+        ASSERT_EQ_CORO(rejected.error().window_min, ct::cluster_epoch{3});
+        ASSERT_EQ_CORO(rejected.error().window_max, ct::cluster_epoch{5});
+    }
+    // A new max promotes the previous max to the floor.
+    {
+        auto permit = co_await leader_api.admit_epoch_enqueue(
+          term, ct::cluster_epoch{7});
+        ASSERT_TRUE_CORO(permit.has_value());
+    }
+    {
+        auto rejected = co_await leader_api.admit_epoch_enqueue(
+          term, ct::cluster_epoch{4});
+        ASSERT_FALSE_CORO(rejected.has_value());
+        ASSERT_EQ_CORO(rejected.error().window_min, ct::cluster_epoch{5});
+        ASSERT_EQ_CORO(rejected.error().window_max, ct::cluster_epoch{7});
+    }
+    // Stragglers at the floor and at the max are both admitted.
+    {
+        auto permit = co_await leader_api.admit_epoch_enqueue(
+          term, ct::cluster_epoch{5});
+        ASSERT_TRUE_CORO(permit.has_value());
+    }
+    {
+        auto permit = co_await leader_api.admit_epoch_enqueue(
+          term, ct::cluster_epoch{7});
+        ASSERT_TRUE_CORO(permit.has_value());
+    }
+    // An interior epoch raises the floor.
+    {
+        auto permit = co_await leader_api.admit_epoch_enqueue(
+          term, ct::cluster_epoch{6});
+        ASSERT_TRUE_CORO(permit.has_value());
+    }
+    {
+        auto rejected = co_await leader_api.admit_epoch_enqueue(
+          term, ct::cluster_epoch{5});
+        ASSERT_FALSE_CORO(rejected.has_value());
+        ASSERT_EQ_CORO(rejected.error().window_min, ct::cluster_epoch{6});
+        ASSERT_EQ_CORO(rejected.error().window_max, ct::cluster_epoch{7});
+    }
+}
+
+TEST_F_CORO(
+  ctp_stm_fixture, test_enqueue_gate_strict_before_first_epoch_applies) {
+    // Until the first epoch-carrying batch applies, the log epoch window
+    // does not exist: whichever admitted epoch lands first collapses the
+    // epoch_window_checker window to [e, e] (a default cluster_epoch is the
+    // min sentinel). Raft may drop any enqueued item mid-term, so any
+    // admitted epoch could be that first-landed one - the gate must keep
+    // the floor at the highest submitted epoch until an epoch batch applies.
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+    auto& leader = node(*get_leader());
+    auto leader_api = api(leader);
+
+    auto fence = co_await leader_api.fence_epoch(ct::cluster_epoch{14});
+    ASSERT_TRUE_CORO(fence.has_value());
+    auto term = fence.value().term;
+
+    {
+        auto permit = co_await leader_api.admit_epoch_enqueue(
+          term, ct::cluster_epoch{14});
+        ASSERT_TRUE_CORO(permit.has_value());
+    }
+    // Nothing applied yet: if the epoch-14 batch lands first the checker
+    // window collapses to [14, 14] and a later epoch-12 batch would fire
+    // the vassert. Rejected.
+    {
+        auto rejected = co_await leader_api.admit_epoch_enqueue(
+          term, ct::cluster_epoch{12});
+        ASSERT_FALSE_CORO(rejected.has_value());
+        ASSERT_EQ_CORO(rejected.error().window_min, ct::cluster_epoch{14});
+        ASSERT_EQ_CORO(rejected.error().window_max, ct::cluster_epoch{14});
+    }
+    // Stragglers at the max keep flowing.
+    {
+        auto permit = co_await leader_api.admit_epoch_enqueue(
+          term, ct::cluster_epoch{14});
+        ASSERT_TRUE_CORO(permit.has_value());
+    }
+    // Land epoch 14: the checker window becomes [14, 14] and the regular
+    // two-highest tracking resumes.
+    ASSERT_TRUE_CORO(
+      co_await replicate_with_epoch(
+        leader, ct::cluster_epoch{14}, model::offset{0}, 0));
+    {
+        auto permit = co_await leader_api.admit_epoch_enqueue(
+          term, ct::cluster_epoch{15});
+        ASSERT_TRUE_CORO(permit.has_value());
+    }
+    {
+        auto permit = co_await leader_api.admit_epoch_enqueue(
+          term, ct::cluster_epoch{14});
+        ASSERT_TRUE_CORO(permit.has_value());
+    }
+    {
+        auto rejected = co_await leader_api.admit_epoch_enqueue(
+          term, ct::cluster_epoch{13});
+        ASSERT_FALSE_CORO(rejected.has_value());
+        ASSERT_EQ_CORO(rejected.error().window_min, ct::cluster_epoch{14});
+        ASSERT_EQ_CORO(rejected.error().window_max, ct::cluster_epoch{15});
+    }
+}
+
+TEST_F_CORO(ctp_stm_fixture, test_enqueue_gate_rejects_stale_term) {
+    // An admission request carrying a term older than one the gate has
+    // already seen is rejected: the caller fenced in a term that is gone
+    // and its batch would be dropped by raft anyway.
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+    auto& leader = node(*get_leader());
+    auto leader_api = api(leader);
+
+    auto fence = co_await leader_api.fence_epoch(ct::cluster_epoch{5});
+    ASSERT_TRUE_CORO(fence.has_value());
+    auto term = fence.value().term;
+
+    {
+        auto permit = co_await leader_api.admit_epoch_enqueue(
+          term, ct::cluster_epoch{5});
+        ASSERT_TRUE_CORO(permit.has_value());
+    }
+    auto rejected = co_await leader_api.admit_epoch_enqueue(
+      model::term_id{term - 1}, ct::cluster_epoch{6});
+    ASSERT_FALSE_CORO(rejected.has_value());
+}
+
+TEST_F_CORO(ctp_stm_fixture, test_enqueue_gate_reseeds_from_log_on_new_term) {
+    // A floor learned from admissions whose batches never landed must not
+    // outlive the term: on a term change the gate reseeds from the applied
+    // epoch window, i.e. from what actually survived into the log.
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+    auto node0_id = *get_leader();
+    auto& node0 = node(node0_id);
+
+    // Land epochs 3 and 5: the applied epoch window becomes [3, 5].
+    ASSERT_TRUE_CORO(
+      co_await replicate_with_epoch(
+        node0, ct::cluster_epoch{3}, model::offset{0}, 0));
+    ASSERT_TRUE_CORO(
+      co_await replicate_with_epoch(
+        node0, ct::cluster_epoch{5}, model::offset{1}, 1));
+
+    // Admit epochs 8 and 9 without replicating anything: the gate window
+    // becomes [8, 9] with no counterpart in the log.
+    for (auto epoch : {ct::cluster_epoch{8}, ct::cluster_epoch{9}}) {
+        auto fence = co_await api(node0).fence_epoch(epoch);
+        ASSERT_TRUE_CORO(fence.has_value());
+        auto permit = co_await api(node0).admit_epoch_enqueue(
+          fence.value().term, epoch);
+        ASSERT_TRUE_CORO(permit.has_value());
+    }
+    // Epoch 6 is below the gate floor now.
+    {
+        auto rejected = co_await api(node0).admit_epoch_enqueue(
+          node0.raft()->term(), ct::cluster_epoch{6});
+        ASSERT_FALSE_CORO(rejected.has_value());
+    }
+
+    // Bounce leadership away and back so node0 starts a new term with its
+    // stale in-memory gate window.
+    node0.raft()->block_new_leadership();
+    co_await node0.raft()->step_down("test_induced_failover");
+    co_await wait_for_leader(10s);
+    auto interim_id = *get_leader();
+    ASSERT_NE_CORO(interim_id, node0_id);
+    auto& interim = node(interim_id);
+    node0.raft()->unblock_new_leadership();
+    co_await wait_for_committed_offset(interim.raft()->committed_offset(), 10s);
+    auto final_id = model::node_id{};
+    for (int attempt = 0; attempt < 5; ++attempt) {
+        co_await interim.raft()->transfer_leadership(
+          raft::transfer_leadership_request{
+            .group = interim.raft()->group(),
+            .target = node0_id,
+            .timeout = 10s});
+        co_await wait_for_leader(10s);
+        final_id = *get_leader();
+        if (final_id == node0_id) {
+            break;
+        }
+    }
+    ASSERT_EQ_CORO(final_id, node0_id);
+
+    auto deadline = model::timeout_clock::now() + 10s;
+    ASSERT_TRUE_CORO(co_await api(node0).sync_in_term(deadline, as));
+    auto new_term = node0.raft()->term();
+
+    // The [8, 9] window from the old term is gone: the gate reseeded from
+    // the applied window [3, 5], so epoch 2 is rejected with exactly that
+    // window...
+    {
+        auto rejected = co_await api(node0).admit_epoch_enqueue(
+          new_term, ct::cluster_epoch{2});
+        ASSERT_FALSE_CORO(rejected.has_value());
+        ASSERT_EQ_CORO(rejected.error().window_min, ct::cluster_epoch{3});
+        ASSERT_EQ_CORO(rejected.error().window_max, ct::cluster_epoch{5});
+    }
+    // ...while epoch 6, rejected in the previous term, is admitted again.
+    {
+        auto permit = co_await api(node0).admit_epoch_enqueue(
+          new_term, ct::cluster_epoch{6});
+        ASSERT_TRUE_CORO(permit.has_value());
+    }
+}
+
+TEST_F_CORO(
+  ctp_stm_fixture, test_enqueue_gate_blocks_epoch_below_landed_window) {
+    // Sequential counterexample for the seen-window fence hole that the
+    // fence alone cannot close
+    // (test_failed_epoch_bump_replicate_poisons_seen_window covers the
+    // fence-time variant):
+    // 1. epoch 10 lands
+    // 2. a fence-time bump to 14 widens the seen window to [10, 14] but its
+    //    batch never lands
+    // 3. in-window epochs 12 and 13 land; the log epoch window ratchets to
+    //    [12, 13]
+    // 4. epoch 11 sits inside the seen window [10, 14] and applied evidence
+    //    exists, so the fence may admit it - but landing it fires the
+    //    epoch_window_checker vassert (11 < 12) on every replica. The
+    //    enqueue gate must reject it.
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+    auto& leader = node(*get_leader());
+    auto leader_api = api(leader);
+
+    ASSERT_TRUE_CORO(
+      co_await replicate_with_epoch(
+        leader, ct::cluster_epoch{10}, model::offset{0}, 0));
+    {
+        auto fence = co_await leader_api.fence_epoch(ct::cluster_epoch{14});
+        ASSERT_TRUE_CORO(fence.has_value());
+        // Guard dropped here; the bump batch never lands.
+    }
+    ASSERT_TRUE_CORO(
+      co_await replicate_with_epoch(
+        leader, ct::cluster_epoch{12}, model::offset{1}, 1));
+    ASSERT_TRUE_CORO(
+      co_await replicate_with_epoch(
+        leader, ct::cluster_epoch{13}, model::offset{2}, 2));
+
+    auto fence = co_await leader_api.fence_epoch(ct::cluster_epoch{11});
+    if (!fence.has_value()) {
+        // If the fence ever learns to reject this on its own the gate has
+        // nothing left to do.
+        co_return;
+    }
+    auto rejected = co_await leader_api.admit_epoch_enqueue(
+      fence.value().term, ct::cluster_epoch{11});
+    ASSERT_FALSE_CORO(rejected.has_value())
+      << "epoch 11 admitted for enqueue although epochs 12 and 13 already "
+         "landed after the discarded bump to 14; replicating it would fire "
+         "the epoch_window_checker vassert on every replica";
 }
 
 // Test for the combined advance_epoch + sync_to_next_placeholder functionality.

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -449,6 +449,29 @@ kafka_stages partition::replicate_in_stages(
       });
 }
 
+kafka_stages partition::replicate_in_stages(
+  chunked_vector<model::record_batch> batches, raft::replicate_options opts) {
+    using ret_t = result<kafka_result>;
+    return stages_with_units(
+      hold_writes_enabled(),
+      [this, batches = std::move(batches), opts = std::move(opts)]() mutable {
+          auto res = _raft->replicate_in_stages(std::move(batches), opts);
+          auto replicate_finished = res.replicate_finished.then(
+            [this](result<raft::replicate_result> r) {
+                if (!r) {
+                    return ret_t(r.error());
+                }
+                auto old_offset = r.value().last_offset;
+                auto term = r.value().last_term;
+                auto new_offset = kafka::offset(
+                  log()->from_log_offset(old_offset)());
+                return ret_t(kafka_result{new_offset, term});
+            });
+          return kafka_stages(
+            std::move(res.request_enqueued), std::move(replicate_finished));
+      });
+}
+
 raft::group_id partition::group() const { return _raft->group(); }
 
 ss::future<> partition::start(

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -95,6 +95,12 @@ public:
       model::record_batch batch,
       raft::replicate_options);
 
+    /// Staged variant of the bulk replicate above: request_enqueued resolves
+    /// once raft fixed the batches' position in the log relative to later
+    /// replicate calls. Bypasses rm_stm, like the bulk replicate.
+    kafka_stages replicate_in_stages(
+      chunked_vector<model::record_batch> batches, raft::replicate_options);
+
     /**
      * The reader is modified such that the max offset is configured to be
      * the minimum of the max offset requested and the committed index of the


### PR DESCRIPTION
The `epoch_window_checker` vassert in `ctp_stm::do_apply` guards a log
invariant: a placeholder batch must never land below the current log epoch
window, otherwise `_min_epoch_lower_bound` (and therefore L0 GC) is computed
from a wrong window and live L0 objects become eligible for deletion. The
epoch fence tries to enforce this at admission time, but the invariant is
about *landing order*, which the fence cannot see:

* concurrent fence holders replicate under shared fence units, and raft
  enqueue order across them is arbitrary — once two distinct in-window epochs
  land in rising order, the log window ratchets past a lower in-window epoch
  that is still in flight, and applying it crashes every replica (and crashes
  again on replay);
* a fence-time bump whose batch never lands (failed replicate) leaves a seen
  window with no counterpart in the log, admitting epochs the log window has
  already moved past (partially addressed by #31110).

This PR closes the hole at the last point where a batch can still be
rejected: right before it is handed to raft. Within a term, raft preserves
the submission order of appends, so admission decisions made at the enqueue
point hold for the log. The new enqueue gate in `ctp_stm` serializes
epoch-carrying submissions and keeps the two highest distinct epochs
submitted in the current term; the runner-up is the admission floor and
everything below it is rejected with `stale_cluster_epoch` (handled by the
frontend like a fence rejection: the epoch is invalidated on the upload shard
and the client gets a retriable error). The floor is the runner-up rather
than the max because stragglers at the previous epoch are routine when shards
observe the cluster epoch at different times, and a single higher epoch can
never move the log window past a lower one — it takes two. The floor is also
deliberately not an exact mirror of the checker automaton: raft may silently
drop an enqueued item mid-term (replicate batcher item timeout/abort,
leadership-transfer flush), and the runner-up floor stays safe under
arbitrary drops while an exact mirror does not.

The gate window reseeds from the applied epoch window on a term change, so a
floor learned from a submission that never landed does not outlive its term.
Gate permits are held until raft's `request_enqueued` stage resolves, pinning
each batch's log position relative to later admissions; all four
epoch-carrying replication paths go through the gate (per-producer upload,
bulk replicate — which required a staged bulk `partition::replicate_in_stages`
— `replicate_at_offset`, and `advance_epoch`).

Complementary to #31149 (fence-side boundary locking): the gate makes the
vassert unreachable from these paths regardless of fence admission behavior,
converting would-be crashes into retriable rejections.

Integration tests cover the gate window transitions, stale-term rejection,
the term-change reseed across a leadership bounce, and the landing-order
counterexample the fence cannot reject (discarded bump to 14, epochs 12 and
13 land, epoch 11 still passes the fence but is rejected by the gate).

The change is structured as four commits:

* `cloud_topics/stm: add epoch enqueue admission window` — the admission
  window lives in `ctp_stm_state`, reusing the seen-window fields:
  `_previous_seen_epoch` doubles as the admission floor (raised by fence-time
  bumps, admitted interior epochs and, until the first epoch batch applies,
  every admitted epoch — whichever admitted epoch lands first collapses the
  checker window to `[e, e]`). Nothing is persisted, so the snapshot format
  is unchanged. `ctp_stm` contributes only the mutex held from admission
  until raft's `request_enqueued` stage resolves, which is what turns
  admission order into log order. The admission transitions are unit-tested
  without the raft fixture, and `l0_simulation` asserts an
  `epoch_window_checker` mirror on apply.
* `cluster: add staged bulk replicate_in_stages to partition` — needed so
  the bulk frontend path can release the admission permit at the enqueued
  stage instead of holding it across the quorum round trip.
* `cloud_topics/frontend: admit placeholder epochs via the enqueue gate` —
  all epoch-carrying replication paths go through the admission (per-producer
  upload, bulk replicate, `replicate_at_offset`, `advance_epoch`).
* `cloud_topics/stm: simplify fence admission to a plain window check` —
  with the enqueue admission enforcing safety, the fence-side
  applied-evidence logic from #31110 is retired; the fence becomes a
  best-effort early check of the same window.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [ ] v25.3.x

## Release Notes

### Bug Fixes

* Fixes a crash loop in cloud topics where placeholder batches carrying a
  stale cluster epoch could be written below the log epoch window during
  concurrent epoch changes; such writes are now rejected and retried with a
  fresh epoch.

