### PR TITLE
[CORE-15837] rpk: add --wait and aggregation to decommission

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/brokers/BUILD
+++ b/src/go/rpk/pkg/cli/cluster/brokers/BUILD
@@ -6,6 +6,7 @@ go_library(
         "brokers.go",
         "decommission.go",
         "decommission_status.go",
+        "decommission_watch.go",
         "recommission.go",
     ],
     importpath = "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster/brokers",
@@ -25,7 +26,10 @@ go_library(
 
 go_test(
     name = "brokers_test",
-    srcs = ["decommission_status_test.go"],
+    srcs = [
+        "decommission_status_test.go",
+        "decommission_watch_test.go",
+    ],
     embed = [":brokers"],
     deps = [
         "//src/go/rpk/pkg/config",

--- a/src/go/rpk/pkg/cli/cluster/brokers/decommission.go
+++ b/src/go/rpk/pkg/cli/cluster/brokers/decommission.go
@@ -25,7 +25,11 @@ import (
 
 // NewDecommissionBroker returns the cluster brokers decommission command.
 func NewDecommissionBroker(fs afero.Fs, p *config.Params) *cobra.Command {
-	var skipLivenessCheck bool
+	var (
+		skipLivenessCheck bool
+		wait              bool
+		watchOpts         watchDecommissionOptions
+	)
 	cmd := &cobra.Command{
 		Use:   "decommission [BROKER ID]",
 		Short: "Decommission the given broker",
@@ -41,6 +45,10 @@ broker is in maintenance mode. As of v23.x, Redpanda supports
 decommissioning a node that is currently in maintenance mode. If you are on
 a v22.x cluster and need to bypass the maintenance mode check (perhaps your
 cluster is unreachable), use the --skip-liveness-check flag.
+
+By default this command returns as soon as the decommission is requested. Use
+--wait to block until the decommission completes, printing progress as data
+moves off the broker.
 `,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -102,7 +110,14 @@ help text for more details on why`, broker)
 			err = cl.DecommissionBroker(cmd.Context(), broker)
 			out.MaybeDie(err, "unable to decommission broker: %v", err)
 
-			fmt.Printf("Success, broker %d decommission started.  Use 'rpk cluster brokers decommission-status %d' to monitor data movement.\n", broker, broker)
+			if !wait {
+				fmt.Fprintf(cmd.OutOrStdout(), "Success, broker %d decommission started.  Use 'rpk cluster brokers decommission-status %d' to monitor data movement.\n", broker, broker)
+				return
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Success, broker %d decommission started. Waiting for data to move off the broker...\n", broker)
+			err = watchDecommission(cmd.Context(), cl, broker, config.OutFormatter{Kind: "text"}, watchOpts, cmd.OutOrStdout())
+			out.MaybeDieErr(err)
 		},
 	}
 
@@ -115,6 +130,8 @@ help text for more details on why`, broker)
 	cmd.Flags().BoolVar(&skipLivenessCheck, "force", false, "If enabled, rpk will issue the decommission request without checking if the broker is in maintenance mode")
 	cmd.Flags().MarkHidden("force")
 	cmd.Flags().MarkDeprecated("force", "use --skip-liveness-check")
+
+	installWaitFlags(cmd, &watchOpts, &wait)
 
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/cluster/brokers/decommission_status.go
+++ b/src/go/rpk/pkg/cli/cluster/brokers/decommission_status.go
@@ -135,8 +135,10 @@ func printDecommissionStatus(f config.OutFormatter, resp decommissionStatusRespo
 // NewDecommissionBrokerStatus returns the cluster brokers decommission-status command.
 func NewDecommissionBrokerStatus(fs afero.Fs, p *config.Params) *cobra.Command {
 	var (
-		detailed bool
-		human    bool
+		detailed  bool
+		human     bool
+		wait      bool
+		watchOpts watchDecommissionOptions
 	)
 	cmd := &cobra.Command{
 		Use:   "decommission-status [BROKER ID]",
@@ -195,6 +197,14 @@ kafka/foo/7  Missing partition size information, all replicas may be offline
 			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
+			if wait {
+				watchOpts.detailed = detailed
+				watchOpts.human = human
+				err = watchDecommission(cmd.Context(), cl, broker, f, watchOpts, cmd.OutOrStdout())
+				out.MaybeDieErr(err)
+				return
+			}
+
 			dbs, err := cl.DecommissionBrokerStatus(cmd.Context(), broker)
 			if he := (*rpadmin.HTTPResponseError)(nil); errors.As(err, &he) {
 				// Special case 400 (validation) errors with friendly output
@@ -214,16 +224,8 @@ kafka/foo/7  Missing partition size information, all replicas may be offline
 			out.MaybeDie(err, "unable to request brokers: %v", err)
 
 			if dbs.Finished {
-				if isText, _, t, err := f.Format(buildDecommissionStatus(dbs, detailed)); !isText {
-					out.MaybeDie(err, "unable to print in the requested format %q: %v", f.Kind, err)
-					fmt.Fprintln(cmd.OutOrStdout(), t)
-					return
-				}
-				if dbs.ReplicasLeft == 0 {
-					out.Exit("Node %d is decommissioned successfully.", broker)
-				} else {
-					out.Exit("Node %d is decommissioned but there are %d replicas left, which may be an issue inside Redpanda. Please describe how you encountered this at https://github.com/redpanda-data/redpanda/issues/new?assignees=&labels=kind%2Fbug&template=01_bug_report.md", broker, dbs.ReplicasLeft)
-				}
+				out.MaybeDieErr(printDecommissionFinished(f, dbs, broker, detailed, cmd.OutOrStdout()))
+				return
 			}
 
 			types.Sort(dbs.Partitions)
@@ -235,6 +237,7 @@ kafka/foo/7  Missing partition size information, all replicas may be offline
 	}
 	cmd.Flags().BoolVarP(&detailed, "detailed", "d", false, "Print how much data moved and remaining in bytes")
 	cmd.Flags().BoolVarP(&human, "human-readable", "H", false, "Print the partition size in a human-readable form")
+	installWaitFlags(cmd, &watchOpts, &wait)
 	p.InstallFormatFlag(cmd)
 
 	return cmd

--- a/src/go/rpk/pkg/cli/cluster/brokers/decommission_watch.go
+++ b/src/go/rpk/pkg/cli/cluster/brokers/decommission_watch.go
@@ -1,0 +1,257 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package brokers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/docker/go-units"
+	"github.com/redpanda-data/common-go/rpadmin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/cobra"
+	"github.com/twmb/types"
+)
+
+const defaultDecommissionPollInterval = 5 * time.Second
+
+// watchDecommissionOptions configures a decommission watch loop.
+type watchDecommissionOptions struct {
+	detailed     bool
+	human        bool
+	waitTimeout  time.Duration // 0 means no limit.
+	pollInterval time.Duration
+}
+
+// decommissionProgress is the aggregate view of a decommission derived from a
+// single status response.
+type decommissionProgress struct {
+	partitionsMoving int
+	bytesMoved       int
+	bytesRemaining   int
+}
+
+func computeDecommissionProgress(dbs rpadmin.DecommissionStatusResponse) decommissionProgress {
+	p := decommissionProgress{partitionsMoving: len(dbs.Partitions)}
+	for _, part := range dbs.Partitions {
+		p.bytesMoved += part.BytesMoved
+		p.bytesRemaining += part.BytesLeftToMove
+	}
+	return p
+}
+
+// percent is the fraction of bytes already moved. An empty moving set yields
+// 0: during an in-progress decommission it means reallocation has not started
+// yet (or is stalled). Completion is signaled by the finished flag, which the
+// caller checks first.
+func (p decommissionProgress) percent() int {
+	total := p.bytesMoved + p.bytesRemaining
+	if total <= 0 {
+		return 0
+	}
+	return p.bytesMoved * 100 / total
+}
+
+// failureSuffix renders a compact note about standing allocation /
+// reallocation failures, which the cluster retries. It is meant to be appended
+// after a parenthesized progress clause, and is empty when there are none.
+func failureSuffix(dbs rpadmin.DecommissionStatusResponse) string {
+	if n := len(dbs.ReallocationFailureDetails); n > 0 {
+		return fmt.Sprintf(", %d reallocation %s (retrying)", n, pluralFailures(n))
+	}
+	if n := len(dbs.AllocationFailures); n > 0 {
+		return fmt.Sprintf(", %d allocation %s (retrying)", n, pluralFailures(n))
+	}
+	return ""
+}
+
+func pluralFailures(n int) string {
+	if n == 1 {
+		return "failure"
+	}
+	return "failures"
+}
+
+func decommissionProgressLine(broker int, dbs rpadmin.DecommissionStatusResponse, human bool) string {
+	p := computeDecommissionProgress(dbs)
+	// Until partitions enter the moving set there is no measurable progress
+	// yet, so report that the cluster has not scheduled the moves.
+	if p.partitionsMoving == 0 {
+		return fmt.Sprintf("broker %d: waiting for the cluster to schedule partition movement%s", broker, failureSuffix(dbs))
+	}
+	size := strconv.Itoa(p.bytesRemaining)
+	if human {
+		size = units.HumanSize(float64(p.bytesRemaining))
+	}
+	return fmt.Sprintf("broker %d: %d%% complete (%d partitions remaining, %s left to move)%s",
+		broker, p.percent(), p.partitionsMoving, size, failureSuffix(dbs))
+}
+
+// watchDecommission polls the decommission status of a broker until it
+// finishes, the wait timeout elapses, or the context is canceled. It streams
+// progress to w while waiting.
+//
+// It returns nil once the decommission has finished (including the
+// replicas-left warning case). It returns a non-nil error on timeout,
+// cancellation, or an unrecoverable status error, so the caller surfaces a
+// non-zero exit.
+func watchDecommission(
+	ctx context.Context,
+	cl *rpadmin.AdminAPI,
+	broker int,
+	f config.OutFormatter,
+	opts watchDecommissionOptions,
+	w io.Writer,
+) error {
+	interval := opts.pollInterval
+	if interval <= 0 {
+		interval = defaultDecommissionPollInterval
+	}
+	if opts.waitTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, opts.waitTimeout)
+		defer cancel()
+	}
+
+	// In-place line redraw only when writing to a terminal and not emitting a
+	// full table or machine-readable output, so we never corrupt logs, scripts,
+	// or JSON/YAML documents.
+	interactive := out.IsTerminal(w) && !opts.detailed && f.IsText()
+	printedInPlace := false
+
+	retries := 3
+	var lastStatus rpadmin.DecommissionStatusResponse
+	haveStatus := false
+	for {
+		dbs, err := cl.DecommissionBrokerStatus(ctx, broker)
+		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				breakInPlace(w, &printedInPlace)
+				return watchCtxError(ctxErr, broker, lastStatus, haveStatus, opts.waitTimeout)
+			}
+			if he := (*rpadmin.HTTPResponseError)(nil); errors.As(err, &he) && he.Response.StatusCode == 400 {
+				// A 400 means the broker is not decommissioning: it may have
+				// finished and been removed, been recommissioned, or never
+				// have started. The wait cannot complete, so stop with a clear
+				// reason. A 400 is not transient, so it is not retried.
+				breakInPlace(w, &printedInPlace)
+				return fmt.Errorf("broker %d is not decommissioning", broker)
+			}
+			if retries <= 0 {
+				breakInPlace(w, &printedInPlace)
+				return fmt.Errorf("unable to request decommission status: %v", err)
+			}
+			retries--
+			if sleepErr := sleepInterval(ctx, interval); sleepErr != nil {
+				breakInPlace(w, &printedInPlace)
+				return watchCtxError(sleepErr, broker, lastStatus, haveStatus, opts.waitTimeout)
+			}
+			continue
+		}
+		retries = 3
+		lastStatus = dbs
+		haveStatus = true
+
+		if dbs.Finished {
+			breakInPlace(w, &printedInPlace)
+			return printDecommissionFinished(f, dbs, broker, opts.detailed, w)
+		}
+
+		if f.IsText() {
+			if opts.detailed {
+				types.Sort(dbs.Partitions)
+				sort.Strings(dbs.AllocationFailures)
+				resp := buildDecommissionStatus(dbs, true)
+				printDecommissionStatus(f, resp, true, opts.human, w)
+				fmt.Fprintln(w)
+			} else if interactive {
+				fmt.Fprintf(w, "\r\033[K%s", decommissionProgressLine(broker, dbs, opts.human))
+				printedInPlace = true
+			} else {
+				fmt.Fprintln(w, decommissionProgressLine(broker, dbs, opts.human))
+			}
+		}
+
+		if sleepErr := sleepInterval(ctx, interval); sleepErr != nil {
+			breakInPlace(w, &printedInPlace)
+			return watchCtxError(sleepErr, broker, lastStatus, haveStatus, opts.waitTimeout)
+		}
+	}
+}
+
+// printDecommissionFinished renders the terminal state of a finished
+// decommission. It returns nil even when replicas are left: the node has
+// still been decommissioned, so that is a warning rather than an error.
+func printDecommissionFinished(f config.OutFormatter, dbs rpadmin.DecommissionStatusResponse, broker int, detailed bool, w io.Writer) error {
+	if isText, _, s, err := f.Format(buildDecommissionStatus(dbs, detailed)); !isText {
+		if err != nil {
+			return fmt.Errorf("unable to print in the requested format %q: %v", f.Kind, err)
+		}
+		fmt.Fprintln(w, s)
+		return nil
+	}
+	if dbs.ReplicasLeft == 0 {
+		fmt.Fprintf(w, "Node %d is decommissioned successfully.\n", broker)
+		return nil
+	}
+	fmt.Fprintf(w, "Node %d is decommissioned but there are %d replicas left, which may be an issue inside Redpanda. Please describe how you encountered this at https://github.com/redpanda-data/redpanda/issues/new?assignees=&labels=kind%%2Fbug&template=01_bug_report.md\n", broker, dbs.ReplicasLeft)
+	return nil
+}
+
+// watchCtxError turns a context error (timeout or cancellation) into a
+// user-facing error that reports last-known progress and where the
+// decommission continues.
+func watchCtxError(ctxErr error, broker int, last rpadmin.DecommissionStatusResponse, haveStatus bool, timeout time.Duration) error {
+	progress := ""
+	if haveStatus {
+		p := computeDecommissionProgress(last)
+		progress = fmt.Sprintf(" (%d%% complete, %d partitions remaining)%s", p.percent(), p.partitionsMoving, failureSuffix(last))
+	}
+	resume := fmt.Sprintf("; it continues on the cluster, check progress with 'rpk cluster brokers decommission-status %d'", broker)
+	if errors.Is(ctxErr, context.DeadlineExceeded) {
+		return fmt.Errorf("timed out after %s waiting for broker %d to decommission%s%s", timeout, broker, progress, resume)
+	}
+	return fmt.Errorf("stopped waiting for broker %d to decommission%s%s", broker, progress, resume)
+}
+
+// breakInPlace ends an in-place-updated status line with a newline so that a
+// following message starts cleanly. It is a no-op if nothing was drawn in
+// place.
+func breakInPlace(w io.Writer, printedInPlace *bool) {
+	if *printedInPlace {
+		fmt.Fprintln(w)
+		*printedInPlace = false
+	}
+}
+
+func sleepInterval(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// installWaitFlags registers the shared --wait/--wait-timeout/--poll-interval
+// flags on a decommission command.
+func installWaitFlags(cmd *cobra.Command, opts *watchDecommissionOptions, wait *bool) {
+	cmd.Flags().BoolVarP(wait, "wait", "w", false, "Wait until the decommission completes, printing progress as it goes")
+	cmd.Flags().DurationVar(&opts.waitTimeout, "wait-timeout", 0, "How long to wait for the decommission to complete (0 means no limit); only used with --wait. The decommission continues on the cluster regardless")
+	cmd.Flags().DurationVar(&opts.pollInterval, "poll-interval", defaultDecommissionPollInterval, "How often to poll the decommission status while waiting; only used with --wait")
+}

--- a/src/go/rpk/pkg/cli/cluster/brokers/decommission_watch_test.go
+++ b/src/go/rpk/pkg/cli/cluster/brokers/decommission_watch_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package brokers
+
+import (
+	"testing"
+
+	"github.com/redpanda-data/common-go/rpadmin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputeDecommissionProgress(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		dbs         rpadmin.DecommissionStatusResponse
+		wantRemain  int
+		wantMoved   int
+		wantLeft    int
+		wantPercent int
+	}{
+		{
+			name:        "nothing measurable reports zero, not done",
+			dbs:         rpadmin.DecommissionStatusResponse{},
+			wantPercent: 0,
+		},
+		{
+			name: "partitions listed but no sizes reported yet",
+			dbs: rpadmin.DecommissionStatusResponse{
+				Partitions: []rpadmin.DecommissionPartitions{{}, {}},
+			},
+			wantRemain:  2,
+			wantPercent: 0,
+		},
+		{
+			name: "partial progress",
+			dbs: rpadmin.DecommissionStatusResponse{
+				Partitions: []rpadmin.DecommissionPartitions{
+					{BytesMoved: 30, BytesLeftToMove: 70},
+					{BytesMoved: 10, BytesLeftToMove: 90},
+				},
+			},
+			wantRemain:  2,
+			wantMoved:   40,
+			wantLeft:    160,
+			wantPercent: 20,
+		},
+		{
+			name: "all bytes moved but partitions still listed",
+			dbs: rpadmin.DecommissionStatusResponse{
+				Partitions: []rpadmin.DecommissionPartitions{
+					{BytesMoved: 100, BytesLeftToMove: 0},
+				},
+			},
+			wantRemain:  1,
+			wantMoved:   100,
+			wantPercent: 100,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := computeDecommissionProgress(tc.dbs)
+			require.Equal(t, tc.wantRemain, p.partitionsMoving)
+			require.Equal(t, tc.wantMoved, p.bytesMoved)
+			require.Equal(t, tc.wantLeft, p.bytesRemaining)
+			require.Equal(t, tc.wantPercent, p.percent())
+		})
+	}
+}
+
+func TestDecommissionProgressLine(t *testing.T) {
+	dbs := rpadmin.DecommissionStatusResponse{
+		Partitions: []rpadmin.DecommissionPartitions{
+			{BytesMoved: 42, BytesLeftToMove: 58},
+		},
+	}
+	require.Equal(t,
+		"broker 3: 42% complete (1 partitions remaining, 58 left to move)",
+		decommissionProgressLine(3, dbs, false),
+	)
+
+	// Human-readable sizing uses units.HumanSize, which formats in SI units
+	// (MB, not MiB).
+	human := rpadmin.DecommissionStatusResponse{
+		Partitions: []rpadmin.DecommissionPartitions{
+			{BytesMoved: 0, BytesLeftToMove: 2000000},
+		},
+	}
+	require.Contains(t, decommissionProgressLine(4, human, true), "2MB left to move")
+
+	// With no partitions in the moving set yet, the line reports that we are
+	// waiting for the cluster to schedule movement.
+	require.Equal(t,
+		"broker 5: waiting for the cluster to schedule partition movement",
+		decommissionProgressLine(5, rpadmin.DecommissionStatusResponse{}, false),
+	)
+}
+
+func TestFailureSuffix(t *testing.T) {
+	require.Empty(t, failureSuffix(rpadmin.DecommissionStatusResponse{}))
+
+	// Reallocation failures take precedence and are pluralized.
+	realloc := rpadmin.DecommissionStatusResponse{
+		ReallocationFailureDetails: []rpadmin.ReallocationFailedPartition{{}, {}},
+		AllocationFailures:         []string{"kafka/foo/0"},
+	}
+	require.Equal(t, ", 2 reallocation failures (retrying)", failureSuffix(realloc))
+
+	alloc := rpadmin.DecommissionStatusResponse{
+		AllocationFailures: []string{"kafka/foo/0"},
+	}
+	require.Equal(t, ", 1 allocation failure (retrying)", failureSuffix(alloc))
+}

--- a/src/go/rpk/pkg/out/spinner.go
+++ b/src/go/rpk/pkg/out/spinner.go
@@ -62,8 +62,8 @@ func WithElapsedTime() SpinnerOption {
 	}
 }
 
-// isTerminal checks if the given writer is a terminal.
-func isTerminal(w io.Writer) bool {
+// IsTerminal reports whether the given writer is a terminal.
+func IsTerminal(w io.Writer) bool {
 	if f, ok := w.(*os.File); ok {
 		return isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
 	}
@@ -94,7 +94,7 @@ func NewSpinner(ctx context.Context, message string, opts ...SpinnerOption) *Spi
 
 	s := &Spinner{
 		output:      cfg.output,
-		isTTY:       isTerminal(cfg.output),
+		isTTY:       IsTerminal(cfg.output),
 		startTime:   time.Now(),
 		showElapsed: cfg.showElapsed,
 		message:     message,

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1599,6 +1599,37 @@ class RpkTool:
         )
         return f"{rp_install_path_root}/bin/rpk"
 
+    def _cluster_brokers(self, subcommand, node, wait, wait_timeout, timeout):
+        node_id = (
+            self._redpanda.node_id(node) if isinstance(node, ClusterNode) else node
+        )
+        cmd = [
+            self._rpk_binary(),
+            "--api-urls",
+            self._admin_host(),
+            "cluster",
+            "brokers",
+            subcommand,
+            str(node_id),
+        ]
+        if wait:
+            cmd.append("--wait")
+        if wait_timeout is not None:
+            cmd += ["--wait-timeout", wait_timeout]
+        return self._execute(cmd, timeout=timeout)
+
+    def cluster_decommission_broker(
+        self, node, wait=False, wait_timeout=None, timeout=None
+    ):
+        return self._cluster_brokers("decommission", node, wait, wait_timeout, timeout)
+
+    def cluster_decommission_status(
+        self, node, wait=False, wait_timeout=None, timeout=None
+    ):
+        return self._cluster_brokers(
+            "decommission-status", node, wait, wait_timeout, timeout
+        )
+
     def cluster_maintenance_enable(self, node, wait=False):
         node_id = (
             self._redpanda.node_id(node) if isinstance(node, ClusterNode) else node

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -18,7 +18,7 @@ from ducktape.utils.util import wait_until
 from ducktape.cluster.cluster import ClusterNode
 from rptest.clients.default import DefaultClient
 from rptest.clients.kafka_cat import KafkaCat
-from rptest.clients.rpk import RpkTool
+from rptest.clients.rpk import RpkException, RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
@@ -1383,6 +1383,137 @@ class NodeDecommissionFailureReportingTest(RedpandaTest):
             self.redpanda, to_decommission_id, self.logger, progress_timeout=60
         )
         waiter.wait_for_removal()
+
+
+class NodeDecommissionWaitTest(RedpandaTest):
+    """Covers 'rpk cluster brokers decommission --wait': blocking until a
+    decommission completes, and returning a reasonable error instead of
+    hanging when a decommission can never make progress."""
+
+    def __init__(self, *args, **kwargs):
+        # Three brokers. The stuck case uses a topic with RF equal to the broker
+        # count (RF must be odd, so 3), which cannot be re-replicated onto the
+        # two survivors. The success case uses an RF=1 topic, which can.
+        super().__init__(*args, num_brokers=3, **kwargs)
+
+    def _expect_wait_timeout(self, wait_call):
+        # rpk's own --wait-timeout must fire well before the subprocess timeout
+        # so we exercise rpk's timeout handling rather than a hard process kill.
+        try:
+            wait_call(wait=True, wait_timeout="10s", timeout=60)
+            assert False, "expected rpk to exit non-zero on a stuck decommission"
+        except RpkException as e:
+            assert e.returncode not in (
+                0,
+                None,
+            ), f"expected a non-zero rpk exit, got returncode {e.returncode}"
+            combined = f"{e.msg}\n{e.stdout}\n{e.stderr}"
+            assert "timed out" in combined or "decommission-status" in combined, (
+                f"rpk output did not explain the stuck decommission: {combined}"
+            )
+
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_wait_times_out_when_stuck(self):
+        # A topic whose replication factor equals the broker count cannot be
+        # re-replicated once a broker is removed: decommissioning any node
+        # leaves too few nodes to host a replica. The decommission therefore
+        # never completes, deterministically.
+        spec = TopicSpec(partition_count=1, replication_factor=3)
+        self.client().create_topic(spec)
+
+        admin = Admin(self.redpanda)
+        node = self.redpanda.node_id(self.redpanda.nodes[-1])
+        rpk = RpkTool(self.redpanda)
+
+        # 'decommission --wait' issues the decommission and waits; when it times
+        # out it leaves the decommission in progress on the cluster, so
+        # 'decommission-status --wait' then watches that same stuck decommission.
+        self._expect_wait_timeout(
+            lambda **kw: rpk.cluster_decommission_broker(node, **kw)
+        )
+        self._expect_wait_timeout(
+            lambda **kw: rpk.cluster_decommission_status(node, **kw)
+        )
+
+        # The one-shot status (no --wait) should still succeed and print a
+        # reasonable snapshot of the in-progress, stuck decommission.
+        status = rpk.cluster_decommission_status(node)
+        assert "DECOMMISSION PROGRESS" in status, status
+
+        # Recommission so the cluster tears down cleanly.
+        admin.recommission_broker(node)
+
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_wait_succeeds(self):
+        # An RF=1 topic can be re-replicated onto the survivors after a broker
+        # is removed, so the decommission completes and --wait blocks only until
+        # it is finished and then reports success.
+        spec = TopicSpec(partition_count=3, replication_factor=1)
+        self.client().create_topic(spec)
+
+        admin = Admin(self.redpanda)
+        node = self.redpanda.node_id(self.redpanda.nodes[-1])
+        rpk = RpkTool(self.redpanda)
+
+        out = rpk.cluster_decommission_broker(
+            node, wait=True, wait_timeout="120s", timeout=180
+        )
+        assert "decommissioned successfully" in out, out
+
+        # --wait returns once data movement reports finished; the broker's
+        # removal from cluster membership follows shortly after, so allow a
+        # brief window for it to disappear from the broker list.
+        def broker_removed():
+            return node not in [b["node_id"] for b in admin.get_brokers()]
+
+        wait_until(
+            broker_removed,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"broker {node} still present after a successful decommission --wait",
+        )
+
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_wait_returns_when_recommissioned(self):
+        # An RF == broker count topic keeps the decommission from ever
+        # completing, giving a stable in-progress state to abort. Once the
+        # broker is recommissioned mid-wait, --wait should observe that it is
+        # no longer decommissioning and return promptly.
+        spec = TopicSpec(partition_count=1, replication_factor=3)
+        self.client().create_topic(spec)
+
+        admin = Admin(self.redpanda)
+        node = self.redpanda.node_id(self.redpanda.nodes[-1])
+        rpk = RpkTool(self.redpanda)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            fut = executor.submit(
+                lambda: rpk.cluster_decommission_broker(node, wait=True, timeout=60)
+            )
+
+            def draining():
+                for b in admin.get_brokers():
+                    if b["node_id"] == node:
+                        return b["membership_status"] == "draining"
+                return False
+
+            wait_until(
+                draining,
+                timeout_sec=30,
+                backoff_sec=1,
+                err_msg=f"broker {node} never entered the draining state",
+            )
+            admin.recommission_broker(node)
+
+            # The wait cannot complete once aborted, so rpk exits non-zero with
+            # a reason. A hang would raise a TimeoutError from fut.result.
+            try:
+                out = fut.result(timeout=30)
+            except RpkException as e:
+                out = f"{e.msg}\n{e.stdout}\n{e.stderr}"
+
+        assert "decommissioned successfully" not in out, out
+        assert "not decommissioning" in out, out
 
 
 class NodeDecommissionSpaceManagementTest(RedpandaTest):


### PR DESCRIPTION
Add --wait/-w to 'decommission' and 'decommission-status' so the command blocks until the decommission completes instead of requiring the operator to poll decommission-status by hand.

While waiting, print an aggregate progress line (percent complete, partitions remaining, bytes left to move), redrawn in place on a terminal and on fresh lines when scripted; -d streams the full per-partition table instead. --wait-timeout bounds the wait (0 means no limit) and --poll-interval controls the poll cadence. Allocation and reallocation failures are surfaced inline but do not stop the wait, since the cluster retries them. On timeout or Ctrl-C the command exits non-zero and notes that the decommission continues on the cluster.

Sample output, a decommission that completes:

```
    $ rpk cluster brokers decommission 4 --wait
    Success, broker 4 decommission started. Waiting for data to move off the broker...
    broker 4: 0% complete (0 partitions remaining, 0 left to move)
    broker 4: 19% complete (9 partitions remaining, 124895323 left to move)
    broker 4: 40% complete (9 partitions remaining, 92303806 left to move)
    broker 4: 80% complete (8 partitions remaining, 18706975 left to move)
    broker 4: 90% complete (2 partitions remaining, 2777670 left to move)
    Node 4 is decommissioned successfully.
```

Sample output, a decommission that cannot make progress:

```
    $ rpk cluster brokers decommission 3 --wait --wait-timeout 10s
    Success, broker 3 decommission started. Waiting for data to move off the broker...
    broker 3: 0% complete (0 partitions remaining, 0 left to move)
    timed out after 10s waiting for broker 3 to decommission (0% complete, 0 partitions remaining); it continues on the cluster, check progress with 'rpk cluster brokers decommission-status 3'
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

### Improvements

* `rpk cluster brokers decommission` and `rpk cluster brokers decommission-status` now have `--wait` and `--wait-timeout` arguments that, when set, will wait for the decommissioning to complete and report summarized progress status while running.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
