### PR TITLE
bazel: link binaries dynamically outside release builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -24,6 +24,11 @@ common --@toolchains_llvm//toolchain/config:compiler-rt=False
 build --linkopt --unwindlib=libgcc
 build --linkopt -stdlib=libc++
 
+# Statically linked binaries (mostly benches) are very large (up to ~4 GB in
+# debug), which isn't necessary in dev and debug modes: link dynamically by
+# default. Release overrides this back to static linking below.
+build --dynamic_mode=fully
+
 # Use Bash instead of system python for finding the hermetic interpreter
 # within Bazel due to the `python3` binary not being present on CI
 # (it has `python` version 3 but Bazel uses the `python3` executable).
@@ -313,6 +318,7 @@ build:secure --config=relro
 # --config=release doesn't create a _true_ release binary, that needs at
 # least --stamp=full and PGO-specific compile steps (outside of bazel).
 build:release --compilation_mode opt
+build:release --dynamic_mode=default
 build:release --config=secure
 build:release --@seastar//:stack_guards=False --@seastar//:debug=False
 build:release --copt -g --strip=never


### PR DESCRIPTION
Statically linked debug binaries are enormous: the largest bench binaries and the `redpanda` binary itself reach ~4 GB in debug mode. These blobs are too large for the remote cache to store (the gRPC upload exceeds its call deadline and is cancelled), so their link actions can never get cache hits and CI relinks them from scratch on every build - and each of those relinks also forces the full multi-GB `.o` input closure to be downloaded (see CORE-16938 for the detailed evidence).

(Note we need to fix the caching anyway, but this is a useful improvement regardless).

This sets `--dynamic_mode=fully` as the default so binaries link against shared libraries, and pins release builds back to `--dynamic_mode=default` (bazel's built-in default, so the release configuration checksum is unchanged) to keep static linking where the binaries ship or performance is measured.

Measured effects (full `bazel build //src/v/...`):

| debug | before | after |
| --- | --- | --- |
| worst bench binary | 4.03 GB | 0.24 GB |
| `redpanda` binary | 4.00 GB | 0.23 GB |
| all 59 bench binaries | 27.7 GB | 2.2 GB |
| whole `bazel-out` tree | 123 GB | 80 GB |
| largest link output | 4.03 GB (bench) | 0.77 GB (`libcluster.so`) |

All `*_rpbench_test` smoke tests pass in debug (asan/ubsan) and fastbuild, the seastar allocator interposition and rpbench perf hooks still work (verified via a live bench run), and a release bench binary is confirmed unchanged (still statically linked, byte-comparable configuration).

@ballard26 note this also effectively switches `--config=antithesis` (an opt build that previously inherited the static default) to `--dynamic_mode=fully`, i.e. dynamically linked binaries. As far as I know that's actually desirable for antithesis (see [this Slack thread](https://redpandadata.slack.com/archives/C0AHZUF5L81/p1778877907381009?thread_ts=1778877138.542819&cid=C0AHZUF5L81)); the config already passes `-Wl,--allow-shlib-undefined`. If that's wrong it's a one-line pin back to `--dynamic_mode=default` in the antithesis stanza.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none