### PR TITLE
DNM: CAS upload probe arm A (default 60s remote_timeout)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -401,3 +401,12 @@ test --test_env=REDPANDA_RNG_SEEDING_MODE
 test --test_env=REDPANDA_DEBUG_TEST_HOOKS
 
 try-import %workspace%/user.bazelrc
+
+# DNM (CORE-16940 experiment, arm A = default 60s --remote_timeout).
+# No-op compiler + linker flags whose only purpose is to change the action key
+# so every C++ compile and link re-executes and must upload its outputs to the
+# remote cache. This exercises the multi-GB CAS upload path that silently fails
+# under the 60s deadline. Unused define / unused absolute symbol: no codegen
+# effect beyond the command line hash.
+build --copt=-DRP_CACHE_PROBE_A=1
+build --linkopt=-Wl,--defsym=rp_cache_probe_a=0


### PR DESCRIPTION
Do not merge. Half of an A/B pair for CORE-16940.

Adds two no-op flags to `.bazelrc` (`--copt=-DRP_CACHE_PROBE_A=1`, `--linkopt=-Wl,--defsym=rp_cache_probe_a=0`) purely to change every C++ compile and link action key, so the whole tree re-executes and must **upload** its outputs. That is the only way to exercise the multi-GB CAS upload path, since on an unchanged tree those actions are cache hits and never upload.

This arm runs on bazel's default `--remote_timeout=60s`. Paired with arm B (`--remote_timeout=600`) on a distinct probe symbol so neither arm can serve the other cache hits.

Expected: the 2-4 GB debug `*_rpbench_binary` and `redpanda_patched` uploads fail with `DEADLINE_EXCEEDED` after 60s.

## Release Notes

- none