### PR TITLE
DNM: CAS upload probe arm B (remote_timeout=600)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -401,3 +401,12 @@ test --test_env=REDPANDA_RNG_SEEDING_MODE
 test --test_env=REDPANDA_DEBUG_TEST_HOOKS
 
 try-import %workspace%/user.bazelrc
+
+# DNM (CORE-16940 experiment, arm B = raised --remote_timeout).
+# Same forced recompile+relink as arm A but with a DIFFERENT probe symbol, so
+# arm B's action keys are distinct from arm A's and neither arm can serve the
+# other cache hits. --remote_timeout goes after the try-import so it wins
+# regardless of what the CI-generated user.bazelrc contains.
+build --copt=-DRP_CACHE_PROBE_B=1
+build --linkopt=-Wl,--defsym=rp_cache_probe_b=0
+build --remote_timeout=600


### PR DESCRIPTION
Do not merge. Half of an A/B pair for CORE-16940.

Same forced recompile+relink as arm A but with a distinct probe symbol (`RP_CACHE_PROBE_B`) so the two arms have independent action keys, plus `--remote_timeout=600` placed after the `try-import` so it wins over the CI-generated `user.bazelrc`.

Expected: the same 2-4 GB uploads that fail in arm A complete here, confirming the 60s deadline is the binding constraint rather than blob size or server capacity.

## Release Notes

- none