### PR TITLE
`ct`: preserve `last_offset_delta` in placeholder header

### DIFF
--- a/src/v/cloud_topics/level_zero/stm/placeholder.cc
+++ b/src/v/cloud_topics/level_zero/stm/placeholder.cc
@@ -61,6 +61,7 @@ model::record_batch encode_placeholder_batch(
     ph.header().max_timestamp = header.max_timestamp;
     ph.header().attrs.set_timestamp_type(model::timestamp_type::append_time);
     ph.header().base_sequence = header.base_sequence;
+    ph.header().last_offset_delta = header.last_offset_delta;
     ph.header().reset_size_checksum_metadata(ph.data());
     return ph;
 }


### PR DESCRIPTION
We weren't preserving `last_offset_delta` in the header of placeholder batches written for L0. This is dangerous for cluster linking (since the `last_offset_delta` is used in the `write_at_offset_stm`: https://github.com/redpanda-data/redpanda/blob/9c958f19fd286a66bec0eb72ee25df9a1fe37966/src/v/kafka/server/write_at_offset_stm.cc#L275-L277) and is also misleading for consumers which may use this value when consuming.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.2.x
- [X] v26.1.x
- [ ] v25.3.x

## Release Notes

### Bug Fixes

* Fixes a bug in which L0 batches in a cloud topic forgot to preserve `last_offset_delta` in their header, leading to an under-declared last offset which can stall consumers, skip records, or halt exact-offset replication.