### PR TITLE
bazel: raise --remote_timeout to 600s

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,6 +5,9 @@ common --extra_toolchains=@current_llvm_toolchain//:all
 common --experimental_repository_downloader_retries=15
 common --http_connector_attempts=24
 
+# Multi-GB CAS uploads don't fit in the 60s default deadline: CORE-16940.
+build --remote_timeout=600
+
 # Bazel 9 removes native C++ rule symbols. Autoload them for external rulesets
 # that have not migrated all generated BUILD/Starlark files to explicit loads.
 common --incompatible_autoload_externally=+@rules_cc


### PR DESCRIPTION
Bazel's default `--remote_timeout=60s` is an **absolute deadline per gRPC call**, so a multi-GB CAS upload that can't finish inside 60s is cancelled and retried from scratch. Our 1.4-2.2 GB `*_rpbench_binary` targets and packaging artifacts (`redpanda_patched_ld`, `bazel_out.tar.gz`, `redpanda_nonroot.tar.gz`) routinely exceed it.

The HTTP cache path has no equivalent limit - its upload timeout is Netty's `IdleStateHandler`, which resets while bytes flow ([bazel#7211](https://github.com/bazelbuild/bazel/issues/7211)) - so this only shows up on the gRPC cache.

### Measurement

A/B on a forced full recompile+relink (no-op `-D`/`--defsym` to invalidate every compile and link, distinct probe symbol per arm so neither serves the other cache hits). Workloads matched at 7960 vs 7962 sandboxed release actions.

| | 60s (default) | 600s |
| --- | --- | --- |
| `WARNING: Remote Cache` | 4 | **0** |
| `DEADLINE_EXCEEDED` | 3, all at `59.9999s` | **0** |
| >1GB uploads failed | **8** | **0** |

Failure volume scales with how cold the cache is: right after a cache-wiping redeploy, when every concurrent build is cold and pushing its largest outputs at once, one ~4.5h window contained 172 distinct failing digests retried 7-20x each.

### Notes

- 600s is a ceiling, not a delay; calls that finish quickly are unaffected. The tradeoff is that a wedged remote call takes 10min to fail instead of 1, which is acceptable for a cache whose failures are already non-fatal warnings.
- Placed before the `user.bazelrc` try-import so a local override still wins.

Full analysis, including the pre/post gRPC-flip comparison and the `--remote_max_connections=1` interaction, is on CORE-16940.

## Backports Required

- [x] none

## Release Notes

- none