### PR TITLE
[v26.1.x] [CORE-16939] `config`: fix `leader_balancer_node_mute_timeout` name

### DIFF
--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -1266,7 +1266,7 @@ ss::future<> service::maybe_start_manager() {
       kafka_rpc_client_service::make_default(_kafka_data_rpc_client),
       members_table_provider::make_default(&_controller->get_members_table()),
       30s, // Temporary until we have a proper configuration for this
-      config::shard_local_cfg().default_topic_replication.bind(),
+      config::shard_local_cfg().default_topic_replications.bind(),
       _scheduling_group);
     co_await _manager->register_task_factory<source_topic_syncer_factory>();
     co_await _manager->register_task_factory<group_mirroring_task_factory>();

--- a/src/v/config/base_property.cc
+++ b/src/v/config/base_property.cc
@@ -23,11 +23,14 @@ base_property::base_property(
   : _name(name)
   , _desc(desc)
   , _meta(std::move(meta)) {
-    conf._properties.emplace(name, this);
+    auto inserted = conf._properties.emplace(name, this).second;
+    vassert(
+      inserted, "Two properties tried to register the same name {}", name);
     for (const auto& alias : _meta.aliases) {
-        auto [_, inserted] = conf._aliases.emplace(alias, this);
+        auto alias_inserted = conf._aliases.emplace(alias, this).second;
 
-        vassert(inserted, "Two properties tried to register the same alias");
+        vassert(
+          alias_inserted, "Two properties tried to register the same alias");
     }
 }
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3433,7 +3433,7 @@ configuration::configuration()
       5min)
   , leader_balancer_node_mute_timeout(
       *this,
-      "leader_balancer_mute_timeout",
+      "leader_balancer_node_mute_timeout",
       "Leadership rebalancing node mute timeout.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       20s)

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1145,7 +1145,7 @@ configuration::configuration()
       "Number of partitions in the internal group membership topic.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       16)
-  , default_topic_replication(
+  , default_topic_replications(
       *this,
       "default_topic_replications",
       "Default replication factor for new topics.",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -253,7 +253,7 @@ struct configuration final : public config_store {
     // same as retention.size in kafka - TODO: size not implemented
     property<std::optional<size_t>> retention_bytes;
     property<int32_t> group_topic_partitions;
-    bounded_property<int16_t> default_topic_replication;
+    bounded_property<int16_t> default_topic_replications;
     bounded_property<int16_t> minimum_topic_replication;
     property<int32_t> transaction_coordinator_partitions;
     property<model::cleanup_policy_bitflags>

--- a/src/v/config/tests/bounded_property_test.cc
+++ b/src/v/config/tests/bounded_property_test.cc
@@ -79,7 +79,7 @@ struct test_config : public config::config_store {
           {.min = 5ms})
       , minmax_bounded_opt_ms(
           *this,
-          "bounded_opt_ms",
+          "minmax_bounded_opt_ms",
           "An optional duration",
           {},
           std::nullopt,

--- a/src/v/config/tests/enterprise_property_test.cc
+++ b/src/v/config/tests/enterprise_property_test.cc
@@ -62,7 +62,7 @@ struct test_config : public config_store {
       , enterprise_enum(
           *this,
           std::vector<tls_version>{tls_version::v1_3},
-          "enterprise_str_enum",
+          "enterprise_enum",
           "An enterprise-only enum property",
           meta{.needs_restart = needs_restart::no},
           tls_version::v1_1,

--- a/src/v/features/tests/enterprise_features_test.cc
+++ b/src/v/features/tests/enterprise_features_test.cc
@@ -62,7 +62,7 @@ struct test_config : public config_store {
       , enterprise_enum(
           *this,
           std::vector<tls_version>{tls_version::v1_3},
-          "enterprise_str_enum",
+          "enterprise_enum",
           "An enterprise-only enum property",
           meta{.needs_restart = needs_restart::no},
           tls_version::v1_1,

--- a/src/v/kafka/server/handlers/configs/config_response_utils.cc
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.cc
@@ -1264,11 +1264,11 @@ config_response_container_t make_broker_configs(
       config_keys,
       result,
       "default.replication.factor",
-      config::shard_local_cfg().default_topic_replication,
+      config::shard_local_cfg().default_topic_replications,
       include_synonyms,
       maybe_make_documentation(
         include_documentation,
-        config::shard_local_cfg().default_topic_replication.desc()),
+        config::shard_local_cfg().default_topic_replications.desc()),
       &describe_as_string<int16_t>);
 
     add_broker_config_if_requested(

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -310,7 +310,7 @@ ss::future<response_ptr> create_topics_handler::handle(
         }
         if (r.replication_factor == -1) {
             r.replication_factor
-              = config::shard_local_cfg().default_topic_replication();
+              = config::shard_local_cfg().default_topic_replications();
         }
     }
 

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -252,7 +252,7 @@ autocreate_topic_configuration(request_context& ctx, model::topic topic) {
       model::kafka_namespace,
       std::move(topic),
       config::shard_local_cfg().default_topic_partitions(),
-      config::shard_local_cfg().default_topic_replication()};
+      config::shard_local_cfg().default_topic_replications()};
     // Need to respect the default_redpanda_storage_mode when autocreating a
     // topic.
     cfg.properties.storage_mode

--- a/src/v/pandaproxy/schema_registry/configuration.cc
+++ b/src/v/pandaproxy/schema_registry/configuration.cc
@@ -46,7 +46,7 @@ configuration::configuration()
       *this,
       "schema_registry_replication_factor",
       "Replication factor for internal `_schemas` topic.  If unset, defaults "
-      "to `default_topic_replication`.",
+      "to `default_topic_replications`.",
       {},
       std::nullopt)
   , api_doc_dir(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31347

- Command: git cherry-pick -x 18aa82f18a 9c71f3bcf4 1d9ef9c3e5
- Commits backported: 3
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-31347-v26.1.x-1785362482

## Conflict details

- 1d9ef9c3e5 (src/v/config/base_property.cc): the constructor body diverged because `v26.1.x` predates the metadata-interning refactor (`_name`/`_desc`/`_meta` are stored by value instead of `_meta` being an interned pointer with a `_conf` back-reference). Applied the commit's intent onto the target's structure: kept the target's member initializers and added the `vassert` on the `conf._properties.emplace` result, using the `name` parameter in place of `_meta->name`, plus the `alias_inserted` rename for the existing alias assert.
