### PR TITLE
bazel: more efficient fuzz by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -261,19 +261,13 @@ build:debug --copt=-O1
 # This may also happen if the target rejected all inputs we tried so far
 #
 # https://llvm.org/docs/LibFuzzer.html
-build:fuzz --config=debug
+#
+# ASan and libFuzzer coverage on an -O1 build, like the default OSS-Fuzz
+# configuration. This is where long fuzzing runs spend their CPU.
+build:fuzz --config=san-asan-only
+build:fuzz --config=dbgsym-lines
+build:fuzz --copt=-O1
 build:fuzz --copt=-fsanitize=fuzzer-no-link
-
-# Uncomment to exempt seastar from coverage instrumentation: fewer
-# scheduling-dependent edges credited to whichever input happened to yield,
-# and fewer counters for libFuzzer to clear on every execution. Not a
-# complete cure, seastar calls into other instrumented libraries; the same
-# mechanism can exempt those too.
-#build:fuzz --per_file_copt=external/.*seastar.*@-fno-sanitize-coverage=inline-8bit-counters
-#build:fuzz --per_file_copt=external/.*seastar.*@-fno-sanitize-coverage=pc-table
-#build:fuzz --per_file_copt=external/.*seastar.*@-fno-sanitize-coverage=trace-cmp
-#build:fuzz --per_file_copt=external/.*seastar.*@-fno-sanitize-coverage=indirect-calls
-#build:fuzz --per_file_copt=external/.*seastar.*@-fno-sanitize-coverage=stack-depth
 
 # =================================
 # ODR Finder

--- a/src/v/test_utils/seastar_fuzz.h
+++ b/src/v/test_utils/seastar_fuzz.h
@@ -85,11 +85,6 @@ int checked_callback(const uint8_t* data, size_t size) {
 /// clock or timer when that is what you are testing; a slow target still finds
 /// bugs.
 ///
-/// Watch the exec/s libFuzzer prints. Every execution clears every coverage
-/// counter in the binary, so the more instrumented code the target links, the
-/// fewer executions it gets through. The fuzz section of .bazelrc shows how
-/// to exempt dependencies that are not under test.
-///
 /// Arguments before -- go to libFuzzer, those after to the reactor, which
 /// runs one shard (--smp/-c are rejected) and defaults to warn-level logging:
 ///


### PR DESCRIPTION
Move the fuzz configuration to an ASan-only -O1 build, like the default OSS-Fuzz configuration. UBSan cost about 2x in executions per second on a CPU-bound target and far more on a seastar-driven one.

CI is unaffected: it runs fuzz targets under the debug configuration, without coverage instrumentation; the fuzz configuration is for developers running longer searches.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none