### PR TITLE
`kafka`: enforce `batch_max_bytes` after broker-side recompression

### DIFF
--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -217,6 +217,28 @@ struct ntp_produce_request {
     model::compression compression_type;
 };
 
+std::optional<ss::sstring> batch_exceeds_max_bytes(
+  const ntp_produce_request& req, bool after_recompression) {
+    const auto batch_size = req.batch->size_bytes();
+    if (static_cast<uint32_t>(batch_size) <= req.batch_max_bytes) {
+        return std::nullopt;
+    }
+    auto msg = after_recompression
+                 ? ssx::sformat(
+                     "batch size {} after applying topic compression type {} "
+                     "exceeds max {}",
+                     batch_size,
+                     req.compression_type,
+                     req.batch_max_bytes)
+                 : ssx::sformat(
+                     "batch size {} exceeds max {}",
+                     batch_size,
+                     req.batch_max_bytes);
+    thread_local static ss::logger::rate_limit rate(1s);
+    vloglr(klog, ss::log_level::warn, rate, "{}", msg);
+    return msg;
+}
+
 // Applies the topic's effective `compression.type` policy to a produced batch
 // (broker-side compression): a batch whose codec differs from the policy is
 // recompressed (or decompressed, for a policy of `none`) before being
@@ -285,6 +307,17 @@ ss::future<produce_response::partition> do_produce_topic_partition(
   ntp_produce_request req,
   std::unique_ptr<ss::promise<>> dispatched) {
     auto start = std::chrono::steady_clock::now();
+    if (
+      auto msg = batch_exceeds_max_bytes(req, /*after_recompression=*/false);
+      msg.has_value()) {
+        co_return finalize_request_with_error_code(
+          error_code::message_too_large,
+          std::move(dispatched),
+          req.ntp,
+          ss::this_shard_id(),
+          std::move(msg));
+    }
+
     auto validate_batch_res = co_await validate_batch(
       {.batch = *req.batch,
        .timestamp_type = req.timestamp_type,
@@ -301,20 +334,6 @@ ss::future<produce_response::partition> do_produce_topic_partition(
           req.ntp,
           ss::this_shard_id(),
           std::move(validate_batch_res.error->msg));
-    }
-
-    auto batch_size = req.batch->size_bytes();
-    if (static_cast<uint32_t>(batch_size) > req.batch_max_bytes) {
-        auto msg = ssx::sformat(
-          "batch size {} exceeds max {}", batch_size, req.batch_max_bytes);
-        thread_local static ss::logger::rate_limit rate(1s);
-        vloglr(klog, ss::log_level::warn, rate, "{}", msg);
-        co_return finalize_request_with_error_code(
-          error_code::message_too_large,
-          std::move(dispatched),
-          req.ntp,
-          ss::this_shard_id(),
-          std::move(msg));
     }
 
     if (auto& validator = req.schema_id_validator) {
@@ -351,6 +370,7 @@ ss::future<produce_response::partition> do_produce_topic_partition(
     }
 
     auto m = octx.rctx.probe().auto_produce_measurement();
+    const auto batch_size = req.batch->size_bytes();
     octx.rctx.probe().record_batch(
       batch_size, req.batch->header().attrs.compression());
     octx.rctx.connection()->attributes().produce_bytes.record(batch_size);
@@ -367,6 +387,20 @@ ss::future<produce_response::partition> do_produce_topic_partition(
           req.ntp,
           ss::this_shard_id(),
           std::move(recompress_res->msg));
+    }
+
+    // Recompression can grow the batch beyond the size accepted above, so the
+    // limit is enforced again on the batch that is actually replicated and
+    // stored.
+    if (
+      auto msg = batch_exceeds_max_bytes(req, /*after_recompression=*/true);
+      msg.has_value()) {
+        co_return finalize_request_with_error_code(
+          error_code::message_too_large,
+          std::move(dispatched),
+          req.ntp,
+          ss::this_shard_id(),
+          std::move(msg));
     }
 
     auto timeout = octx.request.data.timeout_ms;

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -1591,6 +1591,78 @@ FIXTURE_TEST(test_broker_side_compression_disabled, prod_consume_fixture) {
     BOOST_CHECK(kvs_from_batch(batches.front()) == records);
 }
 
+// `batch_max_bytes` applies to the batch as stored: a batch whose
+// client-compressed size is within the limit but whose recompressed size is
+// not (here: decompressed by a `compression.type` of `none`) must be
+// rejected.
+FIXTURE_TEST(test_broker_side_compression_max_bytes, prod_consume_fixture) {
+    scoped_config cfg;
+    cfg.get("kafka_produce_enable_batch_compression").set_value(true);
+    wait_for_controller_leadership().get();
+
+    constexpr uint32_t batch_max_bytes = 4_KiB;
+    const model::topic_namespace none_tp_ns{
+      model::ns("kafka"), model::topic("compress-none")};
+    const model::topic_namespace producer_tp_ns{
+      model::ns("kafka"), model::topic("compress-producer")};
+    auto make_topic = [&](
+                        const model::topic_namespace& tp_ns,
+                        model::compression compression_type) {
+        cluster::topic_properties props;
+        props.compression = compression_type;
+        props.batch_max_bytes = batch_max_bytes;
+        add_topic(tp_ns, 1, props).get();
+        wait_for_leader(model::ntp(tp_ns.ns, tp_ns.tp, model::partition_id(0)))
+          .get();
+    };
+    make_topic(none_tp_ns, model::compression::none);
+    make_topic(producer_tp_ns, model::compression::producer);
+
+    auto transport = make_kafka_client().get();
+    transport.connect().get();
+    auto deferred_t_close = ss::defer([&transport] { transport.stop().get(); });
+
+    // A highly compressible payload much larger than the batch size limit:
+    // compressed it fits within the limit, decompressed it does not.
+    const std::vector<kv_t> records{kv_t("key", ss::sstring(16_KiB, 'a'))};
+    auto produce_batch = [&](const model::topic& topic) {
+        auto batch = tests::batch_from_kvs(
+          records,
+          model::offset(0),
+          model::timestamp::now(),
+          model::compression::zstd);
+        BOOST_REQUIRE_LT(batch.size_bytes(), batch_max_bytes);
+
+        kafka::produce_request::partition partition;
+        partition.partition_index = model::partition_id(0);
+        partition.records.emplace(std::move(batch));
+        chunked_vector<kafka::produce_request::partition> partitions;
+        partitions.push_back(std::move(partition));
+        kafka::produce_request::topic tp;
+        tp.name = topic;
+        tp.partitions = std::move(partitions);
+        chunked_vector<kafka::produce_request::topic> topics;
+        topics.push_back(std::move(tp));
+        kafka::produce_request req(std::nullopt, 1, std::move(topics));
+        req.data.timeout_ms = std::chrono::seconds(2);
+        req.has_idempotent = false;
+        req.has_transactional = false;
+        auto resp
+          = transport.dispatch(std::move(req), kafka::api_version(7)).get();
+        BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
+        BOOST_REQUIRE_EQUAL(resp.data.responses[0].partitions.size(), 1);
+        return resp.data.responses[0].partitions[0].error_code;
+    };
+
+    // Under `producer` the batch is stored with the client's codec, within
+    // the limit.
+    BOOST_CHECK_EQUAL(
+      produce_batch(producer_tp_ns.tp), kafka::error_code::none);
+    // Under `none` the stored (decompressed) batch exceeds the limit.
+    BOOST_CHECK_EQUAL(
+      produce_batch(none_tp_ns.tp), kafka::error_code::message_too_large);
+}
+
 // The broker-set `max_timestamp` and timestamp type of a `LogAppendTime`
 // topic must be carried into the recompressed batch.
 FIXTURE_TEST(test_broker_side_compression_append_time, prod_consume_fixture) {


### PR DESCRIPTION
Recompression per a topic's `compression.type` can grow a batch beyond the size accepted on ingest, most notably a policy of `none` storing a client-compressed batch uncompressed. Re-check the limit after recompression so the batch that is actually replicated and stored obeys `batch_max_bytes`.

The pre-existing check is factored into a helper shared by both call sites and moved ahead of batch validation, therefore rejecting oversized batches before validation potentially decompresses them.


## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none
