### PR TITLE
[v26.1.x] `ct`: preserve `last_offset_delta` in placeholder header

### DIFF
--- a/src/v/cloud_topics/level_zero/stm/placeholder.cc
+++ b/src/v/cloud_topics/level_zero/stm/placeholder.cc
@@ -60,6 +60,7 @@ model::record_batch encode_placeholder_batch(
     ph.header().max_timestamp = header.max_timestamp;
     ph.header().attrs.set_timestamp_type(model::timestamp_type::append_time);
     ph.header().base_sequence = header.base_sequence;
+    ph.header().last_offset_delta = header.last_offset_delta;
     ph.header().reset_size_checksum_metadata(ph.data());
     return ph;
 }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31357
