### PR TITLE
rptest: add OOM crash self-test; allow-list memory diagnostics

### DIFF
--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -833,7 +833,8 @@
                                 "abort",
                                 "assert",
                                 "asan_crash",
-                                "ubsan_crash"
+                                "ubsan_crash",
+                                "oom"
                             ]
                         }
                     ]

--- a/src/v/redpanda/admin/debug.cc
+++ b/src/v/redpanda/admin/debug.cc
@@ -41,6 +41,9 @@
 #include <seastar/http/httpd.hh>
 #include <seastar/json/json_elements.hh>
 
+#include <memory>
+#include <vector>
+
 namespace {
 ss::future<result<std::vector<cluster::partition_state>>>
 get_partition_state(model::ntp ntp, cluster::controller& controller) {
@@ -153,6 +156,25 @@ void trigger_crash(std::unique_ptr<ss::http::request> req) {
         // triggers integer overflow
         volatile int max_int = std::numeric_limits<int>::max(), one = 1, sink{};
         sink = max_int + one + sink;
+    } else if (crash_type == "oom") {
+#ifdef SEASTAR_DEFAULT_ALLOCATOR
+        // With the system allocator (e.g. debug builds) there is no
+        // per-process seastar memory limit: allocating without bound would
+        // exhaust host memory and invite the kernel OOM killer, so refuse.
+        throw ss::httpd::bad_request_exception(
+          "oom crash type requires the seastar allocator");
+#else
+        vlog(adminlog.info, "Triggering out-of-memory from /trigger_crash API");
+        // Allocate until the seastar allocator runs out of memory: tests
+        // always run with --abort-on-seastar-bad-alloc, so the failing
+        // allocation dumps the memory diagnostics and aborts the process.
+        // Chunks are small enough to avoid oversized allocation warnings.
+        std::vector<std::unique_ptr<char[]>> sink;
+        while (true) {
+            constexpr size_t chunk_size = 32 * 1024;
+            sink.push_back(std::make_unique<char[]>(chunk_size));
+        }
+#endif
     } else {
         throw ss::httpd::bad_request_exception(
           fmt::format("invalid crash type: {}", crash_type));

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -482,6 +482,7 @@ class CrashType(Enum):
     ASSERT = "assert"
     ASAN_CRASH = "asan_crash"
     UBSAN_CRASH = "ubsan_crash"
+    OOM = "oom"
 
 
 class Admin:

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2536,7 +2536,9 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
     ) -> None:
         """
         Raise a BadLogLines exception if any nodes' logs contain errors
-        not permitted by `allow_list`
+        not permitted by `allow_list`. The `allow_list` is a list of
+        unanchored regexes (i.e., they match if they occur anywhere in the
+        line even without leading and trailing wildcards).
 
         :param allow_list: list of compiled regexes, or None for default
         :return: None
@@ -3144,7 +3146,9 @@ class RedpandaService(Service, RedpandaServiceABC):
     ):
         """
         Raise a BadLogLines exception if any nodes' logs contain errors not
-        permitted by `allow_list`
+        permitted by `allow_list`. The `allow_list` is a list of unanchored
+        regexes (i.e., they match if they occur anywhere in the line even
+        without leading and trailing wildcards).
 
         :param allow_list: LogAllowList of additional lines to ignore (default
             ignores are always included)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -236,6 +236,10 @@ DEFAULT_LOG_ALLOW_LIST: list[CompiledLogAllowElem] = [
         r"Accessing .*, unexpected REST API error \"http status: Bad Request, error body: 400 Bad Request\" detected, code: _unknown_error_code_, request_id: , resource:"
     ),
     re.compile(r"Configuring topic .* with id .*SEGV.*"),
+    # With our current settings (--abort-on-seastar-bad-alloc) this will immediately
+    # be followed by a crash, and we'd rather the "redpanda crashed" diagnostic instead
+    # of the bad log lines diagnostic as the failure reason for the test.
+    re.compile(r"Dumping seastar memory diagnostics"),
 ]
 
 # Log errors that are expected in tests that restart nodes mid-test

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -14,6 +14,8 @@ from subprocess import CalledProcessError
 from typing import Any, Callable, Iterator, cast
 import time
 
+from requests.exceptions import HTTPError
+
 from ducktape.cluster.cluster import ClusterNode
 from ducktape.cluster.remoteaccount import RemoteCommandError
 from ducktape.mark import matrix, ignore
@@ -60,6 +62,7 @@ from rptest.utils.mode_checks import (
     ignore_if_not_asan,
     ignore_if_not_debug,
     ignore_if_not_ubsan,
+    is_debug_mode,
     skip_debug_mode,
 )
 from rptest.utils.si_utils import BucketView
@@ -992,3 +995,50 @@ class RedpandaServiceSelfRawTest(Test):
                 raise RuntimeError("inner test passed when it shouldn't")
             except NodeCrash as e:
                 assert "SIGSEGV" in str(e)
+
+    @dt_cluster(num_nodes=1)
+    @ignore_if_not_debug
+    def test_raise_on_oom(self) -> None:
+        """Check the harness behavior when redpanda runs out of memory via
+        the oom type of the trigger_crash API.
+
+        With the seastar allocator, the failing allocation dumps the seastar
+        memory diagnostics and aborts the process, and we check that the test
+        fails with NodeCrash (the crash diagnostic) rather than something
+        less useful like BadLogLines triggered by the diagnostics dump, which
+        is emitted at ERROR level on the way down (that dump is on the
+        default allow list).
+
+        Debug builds use the system allocator, where allocating without
+        bound would exhaust host memory instead of hitting the seastar
+        memory limit, so there we check that the API refuses the request
+        and the node survives. Since this test currently runs only in debug
+        mode, the seastar-allocator branch below is exercised only if that
+        ever changes."""
+
+        def func(rptest: RedpandaTest) -> None:
+            node = rptest.redpanda.nodes[0]
+            rptest.redpanda._admin.trigger_crash(node, CrashType.OOM)
+            raise RuntimeError("test is failing")  # to trigger raise_on_crash
+
+        with self._with_inner(func) as test:
+            node = test.redpanda.nodes[0]
+
+            if is_debug_mode():
+                with expect_exception(
+                    HTTPError, lambda e: e.response.status_code == 400
+                ):
+                    test.redpanda._admin.trigger_crash(node, CrashType.OOM)
+                assert test.redpanda.redpanda_pid(node), (
+                    "node should survive a refused oom request"
+                )
+                return
+
+            try:
+                test.run(func=func)  # type: ignore
+                raise RuntimeError("inner test passed when it shouldn't")
+            except NodeCrash as e:
+                assert "Aborting on shard" in str(e)
+            # verify that the crash really was an out-of-memory abort: the
+            # allocator dumps its memory diagnostics before aborting
+            _assert_log_content(test, node, "Dumping seastar memory diagnostics")


### PR DESCRIPTION
Revives #8570 (rebased onto dev, see #8565 for the original motivation): put the seastar memory diagnostics dump, which is emitted at ERROR level when a node runs out of memory, on the default log allow list so an OOM surfaces as the "redpanda crashed" diagnostic rather than a BadLogLines about the dump. Also clarifies in the raise_on_bad_logs docstrings that allow-list regexes are unanchored.

The main value over the old PR is the meta-test: a new debug-only `oom` type for the `/v1/debug/trigger_crash` admin API that allocates until the seastar allocator gives out, plus a ducktape self-test (alongside the existing segfault/assert ones) that runs a node out of memory and checks the harness reports it as a NodeCrash. With the system allocator (sanitized builds) there is no seastar memory limit and unbounded allocation would exhaust host memory instead, so there the API refuses the request, and the self-test verifies the refusal and that the node survives.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none