### PR TITLE
`config`: note S3-compatible endpoints for `cloud_storage_api_endpoint`

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2183,7 +2183,11 @@ configuration::configuration()
       "Optional API endpoint. - AWS: When blank, this is automatically "
       "generated using <<cloud_storage_region,region>> and "
       "<<cloud_storage_bucket,bucket>>. Otherwise, this uses the value "
-      "assigned. - GCP: Uses `storage.googleapis.com`.",
+      "assigned. - GCP: Uses `storage.googleapis.com`. The endpoint can "
+      "also point to any S3-compatible object storage service, for "
+      "example Amazon S3, or a compatible provider such as Backblaze "
+      "B2, Cloudflare R2, or MinIO, using a placeholder endpoint such "
+      "as `https://<host>:<port>`.",
       {.visibility = visibility::user, .gets_restored = gets_restored::no},
       std::nullopt,
       &validate_api_endpoint)


### PR DESCRIPTION
The `cloud_storage_api_endpoint` description only documents the AWS and GCP cases today, so it is not obvious that the property also accepts an endpoint for any S3-compatible object storage service. This extends the description to say the endpoint can point at Amazon S3, or a compatible provider such as Backblaze B2, Cloudflare R2, or MinIO, and shows the expected `https://<host>:<port>` placeholder form.

Description string only, no behavior change.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none
