### PR TITLE
kafka/server: reject client-produced control batches

### DIFF
--- a/src/v/cloud_topics/level_zero/stm/placeholder.cc
+++ b/src/v/cloud_topics/level_zero/stm/placeholder.cc
@@ -29,9 +29,12 @@ model::record_batch encode_placeholder_batch(
       model::record_batch_type::ctp_placeholder, header.base_offset);
 
     builder.set_producer_identity(header.producer_id, header.producer_epoch);
-    if (header.attrs.is_control()) {
-        builder.set_control_type();
-    }
+    // Control batches should not be encoded as placeholders, as this
+    // replication path is specifically for user-provided data.
+    vassert(
+      !header.attrs.is_control(),
+      "Cannot encode control batch as a placeholder: {}",
+      header);
     if (header.attrs.is_transactional()) {
         builder.set_transactional_type();
     }

--- a/src/v/kafka/server/handlers/produce_validation.cc
+++ b/src/v/kafka/server/handlers/produce_validation.cc
@@ -23,6 +23,28 @@ namespace kafka {
 
 namespace {
 
+// Validates the batch attributes a client is permitted to set.
+//
+// Client-generated control batches in Kafka are disallowed[1], and in Redpanda
+// they would be mishandled by various subsystems (e.g. rm_stm expects control
+// batches to be Redpanda-generated).
+//
+// [1]
+// https://github.com/apache/kafka/blob/07e1f099acad26200b2681411e05616bd3fe7879/storage/src/main/java/org/apache/kafka/storage/internals/log/LogValidator.java#L474-L477
+std::optional<error_code_and_msg> validate_batch_attributes(
+  const model::record_batch_header& header, const model::ntp& ntp) {
+    if (header.attrs.is_control()) {
+        return error_code_and_msg{
+          .err = error_code::invalid_record,
+          .msg = ssx::sformat(
+            "Clients are not allowed to write control records in topic "
+            "partition {}",
+            ntp)};
+    }
+
+    return std::nullopt;
+}
+
 // Validates the input timestamp using the broker time and the allowable
 // `log.message.timestamp.{before/after}.max.ms` drift.
 //
@@ -418,7 +440,7 @@ std::optional<error_code_and_msg> validate_batch(
         // 1. Iterate over records and set max_timestamp. It is guaranteed that
         // a batch will have a `max_timestamp` set in `strict` mode.
         // 2. Check record timestamps.
-        // TODO: validate offsets, control batches, versioning, etc.
+        // TODO: validate offsets, versioning, etc.
         // See checks present here:
         // github.com/apache/kafka/blob/trunk/storage/src/main/java/org/apache/kafka/storage/internals/log/LogValidator.java#L438
 
@@ -457,6 +479,14 @@ std::optional<error_code_and_msg> validate_batch(
 } // namespace
 
 ss::future<validation_result> validate_batch(const validation_args& args) {
+    // Attributes bound what the protocol accepts at all, so they are checked
+    // ahead of the mode-specific record validation rather than as part of it.
+    if (
+      auto err = validate_batch_attributes(args.batch.header(), args.ntp);
+      err) {
+        co_return validation_result{.error = std::move(err)};
+    }
+
     const auto& validation_mode
       = config::shard_local_cfg().kafka_produce_batch_validation();
 

--- a/src/v/kafka/server/tests/produce_invalid_batch_test.cc
+++ b/src/v/kafka/server/tests/produce_invalid_batch_test.cc
@@ -121,3 +121,32 @@ FIXTURE_TEST(test_handling_message_with_truncated_batch, test_fixture) {
     BOOST_REQUIRE_THROW(
       resp_f.get(), kafka::client::kafka_request_disconnected_exception);
 };
+
+// A client may not author a control batch, matching Kafka's validation.
+FIXTURE_TEST(test_handling_client_produced_control_batch, test_fixture) {
+    wait_for_controller_leadership().get();
+    start();
+    auto deferred_close = ss::defer([this] { producer->stop().get(); });
+
+    auto hw_before = high_watermark();
+
+    storage::record_batch_builder builder(
+      model::record_batch_type::raft_data, model::offset(0));
+    builder.set_control_type();
+    builder.add_raw_kv(iobuf{}, iobuf{});
+
+    chunked_vector<kafka::produce_request::partition> batches;
+    batches.push_back(
+      kafka::produce_request::partition{
+        .partition_index = model::partition_id(0),
+        .records = kafka::produce_request_record_data{
+          std::move(builder).build()}});
+
+    auto resp = produce_batch(std::move(batches)).get();
+    BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
+    BOOST_REQUIRE_EQUAL(resp.data.responses[0].partitions.size(), 1);
+    BOOST_REQUIRE_EQUAL(
+      resp.data.responses[0].partitions[0].error_code,
+      kafka::error_code::invalid_record);
+    BOOST_REQUIRE_EQUAL(high_watermark(), hw_before);
+};


### PR DESCRIPTION
In cloud topics a bug was flagged where client-produced control batches end up in an awkward state: we stamp out their keys and replicate them as placeholders like we do regular client-produced batches.

This is particularly awkward in rm_stm, where we try to parse the control placeholder's key[1] and fail, since cloud_topics get their keys stamped out[2] in placeholders. Typically we expect that Redpanda is the one generating control batches, so control batches aren't expected to be encoded as placeholders.

Mainline Kafka rejects control batches from clients[3]. This adds this same behavior to follow suit.

[1] https://github.com/redpanda-data/redpanda/blob/7b3c35380fb4387a668397bb7e858f6f7b57604d/src/v/cluster/rm_stm_types.cc#L225-L245
[2] https://github.com/redpanda-data/redpanda/blob/7b3c35380fb4387a668397bb7e858f6f7b57604d/src/v/cloud_topics/level_zero/stm/placeholder.cc#L45
[3] https://github.com/apache/kafka/blob/07e1f099acad26200b2681411e05616bd3fe7879/storage/src/main/java/org/apache/kafka/storage/internals/log/LogValidator.java#L474-L477

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [x] v25.3.x

## Release Notes

### Bug Fixes

* Redpanda will no longer incorrectly accept client-produced control batches.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
