### PR TITLE
k/s/tests: fix group_test segfault by using shard_local_cfg

### DIFF
--- a/src/v/kafka/server/tests/group_test.cc
+++ b/src/v/kafka/server/tests/group_test.cc
@@ -49,7 +49,7 @@ static bool is_uuid(const ss::sstring& uuid) {
  *  good covering set of scenarios.
  */
 static group get() {
-    static config::configuration conf;
+    auto& conf = config::shard_local_cfg();
     conf.enable_consumer_group_metrics.set_value(std::vector<ss::sstring>{});
     ss::sharded<cluster::tx_gateway_frontend> fr;
     ss::sharded<features::feature_table> feature_table;

--- a/src/v/kafka/server/tests/group_test.cc
+++ b/src/v/kafka/server/tests/group_test.cc
@@ -51,8 +51,8 @@ static bool is_uuid(const ss::sstring& uuid) {
 static group get() {
     auto& conf = config::shard_local_cfg();
     conf.enable_consumer_group_metrics.set_value(std::vector<ss::sstring>{});
-    ss::sharded<cluster::tx_gateway_frontend> fr;
-    ss::sharded<features::feature_table> feature_table;
+    static ss::sharded<cluster::tx_gateway_frontend> fr;
+    static ss::sharded<features::feature_table> feature_table;
     return group(
       kafka::group_id("g"),
       group_state::empty,


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

group_test built its own config::configuration on the stack of the
ss::thread that SEASTAR_THREAD_TEST_CASE runs the test body in. That
constructor initializes every property in a single function body, so
its frame is ~143KiB unoptimized, while an ss::thread only gets a
128KiB stack. It ran off the end of the stack and died on the guard
page in the very first test case.

Only fastbuild is affected. release optimizes the frame down to
~107KiB, which fits, and debug enables asan, which raises the
ss::thread stack to 256KiB.

config::shard_local_cfg() already constructs its instance on a
dedicated 512KiB thread for this exact reason, and is also the config
group_manager hands to group in production.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [x] v25.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
