### PR TITLE
[v25.3.x] k/s/tests: fix group_test segfault by using shard_local_cfg

### DIFF
--- a/src/v/kafka/server/tests/group_test.cc
+++ b/src/v/kafka/server/tests/group_test.cc
@@ -51,7 +51,7 @@ static bool is_uuid(const ss::sstring& uuid) {
  *  good covering set of scenarios.
  */
 static group get() {
-    static config::configuration conf;
+    auto& conf = config::shard_local_cfg();
     conf.enable_consumer_group_metrics.set_value(std::vector<ss::sstring>{});
     ss::sharded<cluster::tx_gateway_frontend> fr;
     ss::sharded<features::feature_table> feature_table;

--- a/src/v/kafka/server/tests/group_test.cc
+++ b/src/v/kafka/server/tests/group_test.cc
@@ -53,8 +53,8 @@ static bool is_uuid(const ss::sstring& uuid) {
 static group get() {
     auto& conf = config::shard_local_cfg();
     conf.enable_consumer_group_metrics.set_value(std::vector<ss::sstring>{});
-    ss::sharded<cluster::tx_gateway_frontend> fr;
-    ss::sharded<features::feature_table> feature_table;
+    static ss::sharded<cluster::tx_gateway_frontend> fr;
+    static ss::sharded<features::feature_table> feature_table;
     return group(
       kafka::group_id("g"),
       group_state::empty,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31371
