### PR TITLE
dt/scram: fix flaky PLAIN mechanism check in test_plain_authn

### DIFF
--- a/tests/rptest/tests/scram_test.py
+++ b/tests/rptest/tests/scram_test.py
@@ -858,8 +858,13 @@ class SaslPlainTest(BaseScramTest):
             assert not expect_success, (
                 f"Should not have failed with SASL/PLAIN enabled: {e}"
             )
-            assert "UnsupportedSaslMechanismException" in str(e), (
-                f"Expected to see UnsupportedSaslMechanismException, got {e}"
+            # str(e) only quotes the last "ERROR" line of the command output. The
+            # AdminClient network thread keeps logging authentication failures for
+            # the other bootstrap brokers after the tool has already reported the
+            # exception, so whether that last line is the one naming the exception
+            # is a race. Match against the whole output instead.
+            assert "UnsupportedSaslMechanismException" in e.output, (
+                f"Expected to see UnsupportedSaslMechanismException, got {e.output}"
             )
 
     @cluster(num_nodes=3)


### PR DESCRIPTION
Fixes the flaky `SaslPlainTest.test_plain_authn` failure tracked in CORE-13236,
seen a handful of times a year on the nightly CDT runs with
`client_type=ClientType.KCLI` and SASL/PLAIN disabled:

```
AssertionError: Expected to see UnsupportedSaslMechanismException, got
KafkaCliTools create_topic failed (...). Last error: ERROR [AdminClient
clientId=adminclient-1] Connection to node -1 (...) failed authentication due
to: Client SASL mechanism 'PLAIN' not enabled in the server, enabled mechanisms
are [SCRAM-SHA-256, SCRAM-SHA-512]
```

Redpanda behaves correctly here — the quoted line *is* the broker refusing PLAIN.
The test was looking in the wrong place for the proof.

`str(KafkaCliToolsError)` is a human-facing summary that quotes only the last
line of the command output matching `ERROR `; the full output lives on
`e.output`. `kafka-topics.sh` emits such lines from two threads:

| line | thread | names the exception class? |
|---|---|---|
| `ERROR [AdminClient …] Connection to node -N … failed authentication due to: …` | AdminClient network thread | no — `getMessage()` only |
| `ERROR org.apache.kafka.common.errors.UnsupportedSaslMechanismException: …` | main thread, `TopicCommand.printException` | yes |

`TopicCommand.printException` runs *before* `topicService.close()`, so the
AdminClient thread is still polling the remaining bootstrap brokers when the tool
has already reported its error. Each of those brokers refuses PLAIN too and logs
another `ERROR` line, which can land after the one naming the exception and win
the tail. Asserting on `e.output` removes the dependency on thread interleaving —
the class name appears there regardless (3x in the captured failure, 0x in the
last `ERROR` line).

Reproduced 8/50 locally by pointing `kafka-topics.sh` at three SCRAM-only brokers
with the JVM and three CPU hogs pinned to a single core, which makes the two
threads contend:

```
1 ERROR [AdminClient] Connection to node -2 … failed authentication … PLAIN not enabled
5 ERROR org.apache.kafka.common.errors.UnsupportedSaslMechanismException: …   <- main thread
7 ERROR [AdminClient] Connection to node -3 … failed authentication … PLAIN not enabled   <- 7ms later, wins the tail
```

Verified with ducktape locally: all four `KCLI` x `SCRAM-SHA-512` x
`{OFF, ON}` x `{v1, v2 API}` cases pass.

Backports are requested because the same assert exists verbatim on v26.2.x,
v26.1.x and v25.3.x, so the flake can fire on those nightlies too. Happy to drop
them if we would rather not carry test-only changes back.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [x] v25.3.x

## Release Notes

* none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
