### PR TITLE
[v26.2.x] [CORE-14223] kafka/client: full fetch when broker withholds an unknown partition

### DIFF
--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -392,6 +392,16 @@ ss::future<> fetcher::do_fetch() {
 
         auto fetch_result_value = std::move(fetch_result.value());
         _session_state.update_fetch_session(fetch_result_value.session_id);
+        if (fetch_result_value.needs_full_fetch) {
+            // Reset after update_fetch_session, otherwise the response we just
+            // processed transitions the session straight back to incremental.
+            vlog(
+              logger().debug,
+              "[broker: {}] resetting fetch session to re-report partitions "
+              "with unknown source offsets",
+              _id);
+            _session_state.reset();
+        }
         if (fetch_result_value.needs_metadata_update) {
             // if we need to update metadata, we should do it
             // so that we can retry fetching the partitions later
@@ -531,6 +541,7 @@ fetcher::process_fetch_response(
 
     // Clear incremental fetch state, skipping partitions that errored
     // or just returned new data.
+    size_t unreported_partitions = 0;
     for (const auto& to_process : partitions) {
         const auto& included = to_process.to_include_in_fetch;
         const auto& forgotten = to_process.to_forget;
@@ -567,6 +578,17 @@ fetcher::process_fetch_response(
                 auto& fetcher_state
                   = find_fetcher_state(topic, p.partition_id)->get();
 
+                if (!fetcher_state.source_reported) {
+                    // We asked for this partition and the broker reported
+                    // nothing about it, so we still do not know where the
+                    // source is. Per KIP-227 an unchanged partition is omitted
+                    // from incremental fetch responses, so re-including it in
+                    // an incremental request will not help; a full fetch is
+                    // returned unfiltered, so it will.
+                    ++unreported_partitions;
+                    result.needs_full_fetch = true;
+                }
+
                 fetcher_state.incremental_include = false;
             }
         }
@@ -592,6 +614,15 @@ fetcher::process_fetch_response(
                 _partitions_to_forget.erase(fgt_it);
             }
         }
+    }
+
+    if (unreported_partitions > 0) {
+        vlog(
+          logger().debug,
+          "[broker: {}] {} partition(s) unreported with unknown source "
+          "offsets, requesting a full fetch",
+          _id,
+          unreported_partitions);
     }
 
     co_return result;
@@ -686,6 +717,20 @@ fetcher::process_partition_response(
     }
     if (actions.maybe_fetched_partition_data.has_value()) {
         auto& fetched_partition_data = *actions.maybe_fetched_partition_data;
+
+        if (fetched_partition_data.error == kafka::error_code::none) {
+            // The broker reported this partition's offsets, records or not.
+            // Recording that is what lets us tell "the source is idle" apart
+            // from "the broker has never told us where the source is".
+            auto state = find_fetcher_state(topic, part_data.partition_id);
+            vassert(
+              state.has_value(),
+              "responses are filtered to consistent tps before processing, "
+              "which demands that {}/{} is still assigned",
+              topic,
+              part_data.partition_id);
+            state->get().source_reported = true;
+        }
 
         // if the fetched data is empty, its probably an offset update
         // notification, log it

--- a/src/v/kafka/client/direct_consumer/fetcher.h
+++ b/src/v/kafka/client/direct_consumer/fetcher.h
@@ -197,9 +197,12 @@ private:
      * Fields required s.t. they are harder to forget.
      * Defaults:
      *  - high_watermark: nullopt, not known at instantiation
-     *  - current_leader_epoch: nullopt, not known at instantiation
+     *  - current_leader_epoch: invalid_leader_epoch, not known at
+     *    instantiation
      *  - incremental_include: true, new assignments should always be included
      *    in the next fetch
+     *  - source_reported: false, the broker has told us nothing about this
+     *    partition yet
      */
     struct partition_fetch_state {
         partition_fetch_state(
@@ -213,6 +216,7 @@ private:
           , current_leader_epoch{kafka::invalid_leader_epoch}
           , fetcher_epoch{fetcher_epoch}
           , incremental_include{true}
+          , source_reported{false}
           , subscription_epoch{subscription_epoch} {}
 
         model::partition_id partition_id;
@@ -221,6 +225,7 @@ private:
         leader_epoch current_leader_epoch;
         fetcher_epoch fetcher_epoch;
         bool incremental_include;
+        bool source_reported;
         subscription_epoch subscription_epoch;
 
         bool include_in_fetch_request() const {
@@ -262,6 +267,9 @@ private:
         chunked_vector<fetched_topic_data> topics;
         size_t total_bytes{0};
         bool needs_metadata_update{false};
+        // Set when the broker withheld a partition whose source offsets we have
+        // never learned. Only a full fetch makes the broker re-report it.
+        bool needs_full_fetch{false};
         kafka::fetch_session_id session_id{0};
     };
 

--- a/src/v/kafka/client/direct_consumer/tests/direct_consumer_fixture_test.cc
+++ b/src/v/kafka/client/direct_consumer/tests/direct_consumer_fixture_test.cc
@@ -14,6 +14,7 @@
 #include "redpanda/tests/fixture.h"
 
 #include <fmt/format.h>
+#include <gmock/gmock.h>
 
 #include <unordered_map>
 
@@ -356,6 +357,52 @@ TEST_P(BasicConsumerFixture, TestBogusPartitionIds) {
               model::offset(2 * n - 1));
         }
     }
+}
+
+// A subscription that is torn down and recreated while the source partition is
+// idle must still learn the source partition's offsets. The shadow-link status
+// API derives source_high_watermark from these, and a replicator restart
+// (leadership change / partition move) recreates the subscription with
+// default-initialized offsets.
+TEST_P(BasicConsumerFixture, TestSourceOffsetsAfterIdleReassign) {
+    constexpr auto n = size_t{100};
+    const auto tp = model::topic_partition{topic, model::partition_id{0}};
+    const auto tp_view = model::topic_partition_view{tp.topic, tp.partition};
+
+    assign_partitions(make_assignment(topic, {0}));
+    produce_to_partition(topic, 0, n).get();
+
+    // Drain, so the fetch offset sits at the source high watermark and the
+    // broker's fetch session has cached that state.
+    fetch_until_empty(*consumer);
+
+    ASSERT_THAT(
+      consumer->get_source_offsets(tp_view),
+      testing::Optional(
+        testing::Field(
+          &source_partition_offsets::high_watermark, kafka::offset(n))));
+
+    // Simulate the replicator restart: resubscribe at the offset already
+    // reached, and produce nothing afterwards.
+    unassign_partition(tp);
+    assign_partitions(make_assignment(topic, {0}, kafka::offset(n)));
+
+    fetch_until_empty(*consumer);
+
+    EXPECT_THAT(
+      consumer->get_source_offsets(tp_view),
+      testing::Optional(
+        testing::AllOf(
+          testing::Field(
+            &source_partition_offsets::log_start_offset, kafka::offset(0)),
+          testing::Field(
+            &source_partition_offsets::high_watermark, kafka::offset(n)),
+          testing::Field(
+            &source_partition_offsets::last_stable_offset,
+            testing::Ne(model::offset_cast(model::invalid_lso))),
+          testing::Field(
+            &source_partition_offsets::last_offset_update_timestamp,
+            testing::Ne(ss::lowres_clock::time_point{})))));
 }
 
 using session_config = kafka::client::tests::session_config;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31300
