### PR TITLE
`config`: make `configuration` c-tor private w/ passkey

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -39,7 +39,7 @@
 namespace config {
 using namespace std::chrono_literals;
 
-configuration::configuration()
+configuration::configuration(ctor_key)
   : log_segment_size(
       *this,
       "log_segment_size",
@@ -5409,7 +5409,9 @@ std::unique_ptr<configuration> make_config() {
     // the case in all tests (BOOST_AUTO_TEST_CASE). Further, otherwise we are
     // running on a native posix thread with large stack anyway so this isn't an
     // issue.
-    auto make_cfg = []() { return std::make_unique<configuration>(); };
+    auto make_cfg = []() {
+        return std::make_unique<configuration>(configuration::ctor_key{});
+    };
     if (seastar::engine_is_ready() && ss::thread::running_in_thread()) {
         ss::thread_attributes attrs;
         attrs.stack_size = 512_KiB;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -39,6 +39,7 @@
 
 #include <cctype>
 #include <chrono>
+#include <memory>
 #include <vector>
 
 class monitor_unsafe;
@@ -807,7 +808,16 @@ struct configuration final : public config_store {
     bounded_property<uint32_t> shadow_link_failover_batch_size;
     property<std::chrono::milliseconds> internal_rpc_request_timeout_ms;
 
-    configuration();
+    class ctor_key {
+        ctor_key() = default;
+        friend std::unique_ptr<configuration> make_config();
+    };
+
+    explicit configuration(ctor_key);
+    configuration(const configuration&) = delete;
+    configuration& operator=(const configuration&) = delete;
+    configuration(configuration&&) = delete;
+    configuration& operator=(configuration&&) = delete;
 
     error_map_t load(const YAML::Node& root_node);
 

--- a/src/v/rp_util/main.cc
+++ b/src/v/rp_util/main.cc
@@ -44,7 +44,8 @@ int run_seastar(std::function<ss::future<int>()> main) {
 
 int print_cluster_config_schema() {
     return run_seastar([]() -> ss::future<int> {
-        auto schema = util::generate_json_schema(config::configuration());
+        auto cfg = config::make_config();
+        auto schema = util::generate_json_schema(*cfg);
         if (!schema._body_writer) {
             vassert(
               !schema._res.empty(),


### PR DESCRIPTION
To disallow people from creating this object through means other than calling `config::make_config()`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none
