### PR TITLE
ct: Fix seen/apply window divergence

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -826,7 +826,9 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
     auto enqueued_fut = co_await ss::coroutine::as_future(
       std::move(replicate_stages.request_enqueued));
 
-    ticket.release(); // always release the ticket
+    const bool moves_seen_window = fence->moves_seen_window();
+    fence->unit.return_all(); // the operation can't be reordered
+    ticket.release();         // always release the ticket
 
     if (enqueued_fut.failed()) {
         auto ex = enqueued_fut.get_exception();
@@ -839,8 +841,56 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
         // and we don't want to abandon the replicate_finished future
     }
 
-    auto res = co_await std::move(replicate_stages.replicate_finished);
+    auto res_fut = co_await ss::coroutine::as_future(
+      std::move(replicate_stages.replicate_finished));
+    if (res_fut.failed()) {
+        // Replication failed with an exception. This is the expected
+        // outcome when the enqueue stage failed above: the seen window
+        // was already advanced but the placeholder never reached the
+        // raft queue, so the divergence has to be resolved by stepping
+        // down, same as the error case below.
+        auto ex = res_fut.get_exception();
+        if (moves_seen_window && !ssx::is_shutdown_exception(ex)) {
+            vlog(
+              cd_log.warn,
+              "{} The epoch advancing replication failed {}, stepping down "
+              "the leadership",
+              ntp,
+              ex);
+            co_await partition->raft()->step_down_in_term(
+              fence->term, "seen-window diverged due to replication failure");
+        }
+        co_await ss::coroutine::return_exception_ptr(std::move(ex));
+    }
+    auto res = res_fut.get();
     if (res.has_error()) {
+        // We can't universally guarantee the correct epoch order if replication
+        // failed.
+        // - The batch that advances the epoch is replicated with exclusive
+        //   lock;
+        // - It waits for all requests that carry smaller epoch values will
+        //   finish first;
+        // - After that the lock is taken. The lock is only held until the batch
+        //   is enqueued into Raft and can't be reordered anymore.
+        // - Now if the replication operation fails the 'seen' window stays
+        //   unchanged but the 'applied' window may or may not be moved
+        //   accordingly.
+        // - The divergence between the 'applied' and 'seen' windows may cause
+        //   ordering violations.
+        //
+        // To avoid this problem we need to step down the leadership.
+        // This is only required if the seen-window was moved. The new term
+        // will invalidate the seen window.
+        if (moves_seen_window && res.error() != raft::errc::shutting_down) {
+            vlog(
+              cd_log.warn,
+              "{} The epoch advancing replication failed {}, stepping down the "
+              "leadership",
+              ntp,
+              res.error());
+            co_await partition->raft()->step_down_in_term(
+              fence->term, "seen-window diverged due to replication failure");
+        }
         co_return res.error();
     }
     if (!cache_batches.empty()) {
@@ -1053,10 +1103,39 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
     }
 
     opts = update_replicate_options(opts, fence->term);
-    auto result = co_await _partition->replicate(
-      std::move(placeholder_batches), opts);
-
+    auto result_fut = co_await ss::coroutine::as_future(
+      _partition->replicate(std::move(placeholder_batches), opts));
+    if (result_fut.failed()) {
+        // Same divergence handling as the error path below: the seen
+        // window was already advanced by the fence and can't be rolled
+        // back, so a failed replication requires a step down.
+        auto ex = result_fut.get_exception();
+        if (fence->moves_seen_window() && !ssx::is_shutdown_exception(ex)) {
+            vlog(
+              cd_log.warn,
+              "{} The epoch advancing replication failed {}, stepping down "
+              "the leadership",
+              ntp(),
+              ex);
+            co_await _partition->raft()->step_down_in_term(
+              fence->term, "seen-window diverged due to replication failure");
+        }
+        co_await ss::coroutine::return_exception_ptr(std::move(ex));
+    }
+    auto result = result_fut.get();
     if (!result) {
+        if (
+          fence->moves_seen_window()
+          && result.error() != raft::errc::shutting_down) {
+            vlog(
+              cd_log.warn,
+              "{} The epoch advancing replication failed {}, stepping down the "
+              "leadership",
+              ntp(),
+              result.error());
+            co_await _partition->raft()->step_down_in_term(
+              fence->term, "seen-window diverged due to replication failure");
+        }
         co_return std::unexpected(result.error());
     }
     auto ret_offset = result.value().last_offset;
@@ -1530,6 +1609,9 @@ ss::future<result<raft::replicate_result>> frontend::replicate_at_offset(
         placeholder_batches = chunked_vector<model::record_batch>(
           std::make_move_iterator(placeholders.batches.begin()),
           std::make_move_iterator(placeholders.batches.end()));
+
+        // There is no concurrency here (one link is active at a time)
+        // so the fence can be discarded safely.
     }
 
     // Restore the original input order by 2-way merging placeholders and

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -500,8 +500,8 @@ ctp_stm::fence_epoch(cluster_epoch e, model::timeout_clock::duration timeout) {
               || _state.epoch_above_window(term, e)) {
                 vlog(_log.debug, "Bumping max seen epoch to {}", e);
                 _state.advance_max_seen_epoch(term, e);
-                // Demote to reader lock after max_seen_epoch is updated.
-                unit.return_units(unit.count() - 1);
+                // Demote to reader lock when the command is queued
+                // in Raft. Keep all the units for now.
                 epoch_fence_opt.emplace(std::move(unit), term);
             }
 

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -565,11 +565,12 @@ TEST_F_CORO(ctp_stm_fixture, test_snapshot) {
 }
 
 TEST_F_CORO(ctp_stm_fixture, test_fence_epoch_concurrent_new_epoch) {
-    // This test verifies the optimization in fence_epoch() where multiple
-    // concurrent requests for a new epoch only require one write lock.
-    // The first request acquires the epoch_update_lock and write lock, updates
-    // the epoch, then signals waiters. The remaining requests wake up and take
-    // the read-lock path since the epoch has been updated.
+    // This test verifies that multiple concurrent requests for a new epoch
+    // only require one write lock. The first request acquires the
+    // epoch_update_lock and write lock, updates the epoch, then signals
+    // waiters. The remaining requests wake up and take the read-lock path
+    // since the epoch has been updated. The winner's fence keeps the write
+    // lock (no demotion) so the readers stay blocked until it's released.
     co_await start();
     co_await wait_for_leader(raft::default_timeout());
 
@@ -619,12 +620,41 @@ TEST_F_CORO(ctp_stm_fixture, test_fence_epoch_concurrent_new_epoch) {
         // Let `initial_fence` go out of scope.
     }
 
-    // Wait for all fences to be acquired - they should all be able to succeed
-    // without hanging because only one request (the first request) had to
-    // obtain a write lock, which then downgraded to a read lock, and the rest
-    // of the requests could obtain read locks for the current epoch.
+    // Exactly one request wins the epoch update and resolves with a fence
+    // that carries the full write lock. The remaining requests take the
+    // read-lock path and stay blocked until the winner releases the fence.
+    std::optional<size_t> winner;
+    RPTEST_REQUIRE_EVENTUALLY_CORO(10s, [&] {
+        for (size_t i = 0; i < futures.size(); ++i) {
+            if (futures[i].available()) {
+                winner = i;
+                return true;
+            }
+        }
+        return false;
+    });
+
+    auto winner_fence = co_await std::move(futures[*winner]);
+    ASSERT_TRUE_CORO(winner_fence.has_value());
+    ASSERT_GT_CORO(winner_fence->unit.count(), 1);
+    for (size_t i = 0; i < futures.size(); ++i) {
+        if (i != *winner) {
+            ASSERT_FALSE_CORO(futures[i].available());
+        }
+    }
+
+    // Release the write lock, unblocking the readers.
+    winner_fence->unit.return_all();
+
+    std::vector<ss::future<expected_t>> rest;
+    rest.reserve(futures.size() - 1);
+    for (size_t i = 0; i < futures.size(); ++i) {
+        if (i != *winner) {
+            rest.push_back(std::move(futures[i]));
+        }
+    }
     auto fences = co_await ssx::when_all_succeed<std::vector<expected_t>>(
-      std::move(futures));
+      std::move(rest));
     for (auto& fence : fences) {
         ASSERT_TRUE_CORO(fence.has_value())
           << "All fence requests should succeed";

--- a/src/v/cloud_topics/level_zero/stm/types.h
+++ b/src/v/cloud_topics/level_zero/stm/types.h
@@ -31,6 +31,10 @@ struct [[nodiscard]] cluster_epoch_fence {
     ss::rwlock::holder unit;
     // Term in which the batch is replicated.
     model::term_id term;
+
+    // The fence holds the full write lock (more than one unit) iff the
+    // fenced request advanced the "seen" window.
+    bool moves_seen_window() const { return unit.count() > 1; }
 };
 
 // The error returned when the CTP STM has seen a newer epoch than the one


### PR DESCRIPTION
In the ctp_stm::fence_epoch do not demote write lock to read lock. Old behavior: if the epoch advances the seen window the write lock is acquired first. This means that all in-flight requests are committed. The problem is that after demotion the produce request that advances the seen window may still be scheduled concurrently with a request that carries previous epoch. There is a very slight room for them to be reordered and it was never observed but it is still possible.

The fix is to avoid demoting the lock from write to read. The fence_epoch now returns a fence that carries a write lock if the request advances the "seen" window.

This may potentially create a performance regression. To avoid this the second part of this commit (frontend.cc) releases units early. The units are released when the placeholder is enqueued into Raft. At this point the reordering of placeholders becomes impossible and it is safe to release the fence. This allows us to use full write lock in the fence if needed. The units are only being held up until the placeholder is queued which is a low latency in-memory operation that doesn't require any I/O.

The final bit of this PR addresses the failed replication problem. Currently, if the placeholder replication fails the seen and apply windows diverge. When the fence is acquired the seen window is advanced before the placeholder is replicated and applied to the in-memory state of the STM. After that the background fiber of the ctp_stm applies the placehodler to the in-memory state and advances the applied window. When the replication of the placholder fails we can't roll-back the changes to the seen window because the placeholder could still be replicated and applied. The replication failure doesn't invalidate all queued placeholders after the failed one. So, because of that we may or may not end up in the incorrect state.

To avoid this problem the frontend.cc triggers leadership step down after a failed replication. This only happens if the placeholder that moved seen window failed to replicate.

Example:

```
Setup, term `T`: log `e4@10, e5@20`; applied/checker `[4,5]`; seen `[4,5]`.

1. Epoch **7** fenced (write path): seen → `[5,7]` (jumps over 6).
   Its placeholder **fails to replicate** — never lands. Checker stays `[4,5]`.
2. Epoch **6** admitted (`6 ∈ [5,7)`), lands `e6@30`.
   Apply: checker `[4,5] → [5,6]`.
3. Epoch **7** retries (`7 == max_seen`), lands `e7@40`.
   Apply: checker `[5,6] → [6,7]`.
   Log slid twice (5→6→7); seen window recorded one jump, floor still 5.
4. Epoch **5** straggler admitted (`5 ≥ prev_seen = 5`), lands `e5@50`.
   Apply: `5 < min = 6` →
   `vassert: epoch 5 at 50 is outside of sliding window [6, 7]`
```


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [ ] v25.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none