### PR TITLE
rptest: deflake DisableTieredStorageTest upload wait

### DIFF
--- a/tests/rptest/tests/node_pool_migration_test.py
+++ b/tests/rptest/tests/node_pool_migration_test.py
@@ -32,6 +32,7 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import expect_exception
 from rptest.utils.mode_checks import cleanup_on_early_exit
 from rptest.utils.node_operations import NodeDecommissionWaiter
+from rptest.utils.si_utils import quiesce_uploads
 
 TS_LOG_ALLOW_LIST = [
     re.compile("archival_metadata_stm.*Replication wait for archival STM timed out"),
@@ -475,6 +476,13 @@ class DisableTieredStorageTest(NodePoolMigrationTestBase):
         # defer starting redpanda to test body
         pass
 
+    @property
+    def msg_count(self):
+        # Enough segments that the two segment initial local retention target
+        # is a meaningful truncation point. The base class produces 10x more,
+        # which leaves the archiver too far behind for the upload wait below.
+        return int(100 if self.debug_mode else 100 * self.segment_size / self.msg_size)
+
     @cluster(num_nodes=4, log_allow_list=RESTART_LOG_ALLOW_LIST + TS_LOG_ALLOW_LIST)
     @matrix(
         disable_mode=[
@@ -535,20 +543,14 @@ class DisableTieredStorageTest(NodePoolMigrationTestBase):
         info = describe_topic()
 
         initial_start_offset = info.start_offset
-        initial_hwm = info.high_watermark
 
         def pm_last_offset():
             v = self.admin.get_partition_manifest(spec.name, 0)["last_offset"]
             return v
 
-        self.logger.debug("Wait until most of the topic is uploaded")
+        self.logger.debug("Wait until the topic is fully uploaded")
 
-        wait_until(
-            lambda: pm_last_offset() >= initial_hwm,
-            timeout_sec=30,
-            backoff_sec=2,
-            err_msg="Partition never uploaded",
-        )
+        quiesce_uploads(self.redpanda, [spec.name], timeout_sec=120)
 
         self.logger.debug(
             f"Now {disable_mode} and produce some more to put HWM well above the last uploaded offset"


### PR DESCRIPTION
The test inherited msg_count from NodePoolMigrationTestBase, producing 1 GiB into a topic with 1 MiB segments, so ~1000 segments had to reach cloud storage. The archiver uploads four segments per iteration and blocks until all four complete, which does not keep up with the 50 MiB/s producer: it was 57% behind when production stopped. Draining the remaining ~576 MiB took 28.4s against the wait's 30s budget, so the test was a coin flip on upload latency.

Produce 100 segments instead. That is still far above the two segment initial local retention target the test relies on, and it cuts the drain to a few seconds.

Wait via quiesce_uploads rather than a hand-rolled wait_until. The old condition compared the partition manifest's last_offset, which is a raft offset, against a Kafka high watermark; the helper converts to Kafka offsets and logs the offsets it is waiting on when it times out.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [x] v25.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
