### PR TITLE
[CORE-16845] `rptest`: mark permanently killed nodes as stopped

### DIFF
--- a/tests/rptest/services/failure_injector.py
+++ b/tests/rptest/services/failure_injector.py
@@ -88,6 +88,11 @@ class FailureInjectorBase:
         self.redpanda.logger.info(f"injecting failure: {spec}")
         try:
             self._start_func(spec.type)(spec.node)
+            if spec.length is None and spec.type in (
+                FailureSpec.FAILURE_KILL,
+                FailureSpec.FAILURE_TERMINATE,
+            ):
+                self._mark_permanently_stopped(spec.node)
         except Exception as e:
             self.redpanda.logger.info(f"injecting failure error: {e}")
             if spec.type == FailureSpec.FAILURE_TERMINATE and isinstance(
@@ -175,6 +180,9 @@ class FailureInjectorBase:
     def _kill(self, node):
         pass
 
+    def _mark_permanently_stopped(self, node):
+        pass
+
     def _isolate(self, node):
         pass
 
@@ -237,6 +245,9 @@ class FailureInjector(FailureInjectorBase):
             timeout_sec=timeout_sec,
             err_msg="Redpanda failed to kill in %d seconds" % timeout_sec,
         )
+
+    def _mark_permanently_stopped(self, node):
+        self.redpanda.remove_from_started_nodes(node, "permanent failure injected")
 
     def _isolate(self, node):
         self.redpanda.logger.info(f"isolating node {node.account.hostname}")


### PR DESCRIPTION
A permanent kill/terminate failure is never undone, so the node stays down for the rest of the test by design. The service however still tracked it in _started, so when the test later failed for an unrelated reason, `raise_on_crash`'s pid check reported the node as "Redpanda process unexpectedly stopped" and the resulting NodeCrash masked the original failure.

Remove the node from started nodes at injection time, mirroring what `paused_node()` does for SIGSTOP.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none
