### PR TITLE
cluster: restore fast path in sync_kafka_start_offset_override 

### DIFF
--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -160,8 +160,30 @@ kafka::offset log_eviction_stm::kafka_start_offset_override() {
     return _cached_kafka_start_offset_override;
 }
 
+std::optional<kafka::offset>
+log_eviction_stm::try_sync_kafka_start_offset_override() {
+    // Sync ensures that the stm has applied all batches from any previous term.
+    // If we're already sync'd up to the current term then there is no need to
+    // sync.
+    if (_raft->is_leader() && _insync_term == _raft->term()) {
+        return kafka_start_offset_override();
+    }
+    return std::nullopt;
+}
+
 ss::future<result<kafka::offset, std::error_code>>
 log_eviction_stm::sync_kafka_start_offset_override(
+  model::timeout_clock::duration timeout) {
+    // Fast path for when we're already in-sync.
+    if (auto override = try_sync_kafka_start_offset_override()) {
+        return ss::make_ready_future<result<kafka::offset, std::error_code>>(
+          *override);
+    }
+    return do_sync_kafka_start_offset_override(timeout);
+}
+
+ss::future<result<kafka::offset, std::error_code>>
+log_eviction_stm::do_sync_kafka_start_offset_override(
   model::timeout_clock::duration timeout) {
     /// Call this method to ensure followers have processed up until the
     /// most recent known version of the special batch. This is particularly

--- a/src/v/cluster/log_eviction_stm.h
+++ b/src/v/cluster/log_eviction_stm.h
@@ -23,6 +23,8 @@
 #include <seastar/core/queue.hh>
 #include <seastar/util/log.hh>
 
+#include <optional>
+
 namespace cluster {
 
 class consensus;
@@ -107,6 +109,13 @@ public:
     ss::future<result<kafka::offset, std::error_code>>
     sync_kafka_start_offset_override(model::timeout_clock::duration timeout);
 
+    /// Non-suspending fast path of `sync_kafka_start_offset_override`:
+    /// returns the override iff the stm has already synced within the
+    /// current term, in which case the locally applied override reflects
+    /// every previous term's writes; the same guarantee the syncing
+    /// variant provides. Returns std::nullopt when a sync is required.
+    std::optional<kafka::offset> try_sync_kafka_start_offset_override();
+
     /// If `kafka::offset{}` is returned and archival storage is enabled for the
     /// given ntp then the caller should fall back on the archival stm to check
     /// if a start offset override exists and if so what its value is.
@@ -144,6 +153,9 @@ private:
       model::record_batch batch,
       ss::lowres_clock::time_point deadline,
       std::optional<std::reference_wrapper<ss::abort_source>> as);
+
+    ss::future<result<kafka::offset, std::error_code>>
+      do_sync_kafka_start_offset_override(model::timeout_clock::duration);
 
 private:
     ss::abort_source _as;

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -1457,6 +1457,34 @@ partition::get_cloud_storage_manifest_view() {
 ss::future<result<model::offset, std::error_code>>
 partition::sync_kafka_start_offset_override(
   model::timeout_clock::duration timeout) {
+    // Non-suspending fast path for the steady state where the eviction stm has
+    // already synced within the current term and the archival fallback has been
+    // synced once.
+    if (!is_read_replica_mode_enabled() && _log_eviction_stm) {
+        if (
+          auto override
+          = _log_eviction_stm->try_sync_kafka_start_offset_override()) {
+            using ret_t = result<model::offset, std::error_code>;
+            if (*override != kafka::offset{}) {
+                return ss::make_ready_future<ret_t>(
+                  kafka::offset_cast(*override));
+            }
+            if (!_archival_meta_stm) {
+                return ss::make_ready_future<ret_t>(model::offset{});
+            }
+            if (_has_synced_archival_for_start_override) {
+                return ss::make_ready_future<ret_t>(
+                  kafka::offset_cast(_archival_meta_stm->manifest()
+                                       .get_start_kafka_offset_override()));
+            }
+        }
+    }
+    return do_sync_kafka_start_offset_override(timeout);
+}
+
+ss::future<result<model::offset, std::error_code>>
+partition::do_sync_kafka_start_offset_override(
+  model::timeout_clock::duration timeout) {
     try {
         if (is_read_replica_mode_enabled()) {
             auto term = _raft->term();

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -425,6 +425,9 @@ private:
     // dirty so that it gets reuploaded
     ss::future<> restart_archiver(bool should_notify_topic_config);
 
+    ss::future<result<model::offset, std::error_code>>
+      do_sync_kafka_start_offset_override(model::timeout_clock::duration);
+
     consensus_ptr _raft; // never null
     ss::shared_ptr<cluster::log_eviction_stm> _log_eviction_stm;
     ss::shared_ptr<cluster::rm_stm> _rm_stm;

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -1063,6 +1063,29 @@ redpanda_cc_bench(
 )
 
 redpanda_cc_bench(
+    name = "validate_fetch_offset_rpbench",
+    srcs = [
+        "validate_fetch_offset_bench.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/cluster",
+        "//src/v/cluster:leader_balancer_strategy",
+        "//src/v/cluster:node_status_backend",
+        "//src/v/cluster:self_test",
+        "//src/v/cluster:topic_metrics_watcher",
+        "//src/v/kafka/data:partition_proxy",
+        "//src/v/model",
+        "//src/v/random:generators",
+        "//src/v/redpanda/tests:fixture",
+        "//src/v/test_utils:async",
+        "//src/v/test_utils:scoped_config",
+        "@seastar",
+        "@seastar//:benchmark",
+    ],
+)
+
+redpanda_cc_bench(
     name = "kafka_fetch_plan_rpbench",
     srcs = [
         "fetch_plan_bench.cc",

--- a/src/v/kafka/server/tests/validate_fetch_offset_bench.cc
+++ b/src/v/kafka/server/tests/validate_fetch_offset_bench.cc
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "base/vassert.h"
+#include "cluster/partition.h"
+#include "kafka/data/partition_proxy.h"
+#include "model/fundamental.h"
+#include "model/namespace.h"
+#include "random/generators.h"
+#include "redpanda/tests/fixture.h"
+#include "test_utils/async.h"
+#include "test_utils/scoped_config.h"
+
+#include <seastar/testing/perf_tests.hh>
+
+using namespace std::chrono_literals; // NOLINT
+
+// Microbenchmarks for the offset validation step of the fetch path. Every
+// fetched partition runs partition_proxy::validate_fetch_offset before any
+// data is read, so its steady-state cost (leader, eviction stm already synced
+// within the current term) is pure per-fetch overhead. It is measured
+// directly here to catch regressions that whole-fetch benchmarks would hide
+// in the noise.
+
+struct validate_fetch_offset_fixture : redpanda_thread_fixture {
+    static constexpr size_t topic_name_length = 30;
+
+    validate_fetch_offset_fixture() {
+        wait_for_controller_leadership().get();
+
+        // Disable as many background processes as possible to reduce noise.
+        test_local_cfg.get("log_disable_housekeeping_for_tests")
+          .set_value(true);
+        test_local_cfg.get("disable_cluster_recovery_loop_for_tests")
+          .set_value(true);
+        test_local_cfg.get("enable_metrics_reporter").set_value(false);
+    }
+
+    ss::future<model::ntp> initialize_single_partition_topic() {
+        auto t = model::topic(
+          random_generators::gen_alphanum_string(topic_name_length));
+        co_await add_topic(
+          model::topic_namespace_view(model::kafka_namespace, t), 1);
+        auto ntp = make_default_ntp(t, model::partition_id(0));
+        co_await wait_for_leader(ntp);
+        co_return ntp;
+    }
+
+    scoped_config test_local_cfg;
+};
+
+namespace {
+constexpr size_t num_calls_per_run = 1000;
+} // namespace
+
+PERF_TEST_CN(validate_fetch_offset_fixture, leader_steady_state) {
+    static model::ntp ntp = co_await initialize_single_partition_topic();
+
+    auto partition = app.partition_manager.local().get(ntp);
+    vassert(partition, "partition {} must exist", ntp);
+    auto proxy = kafka::make_partition_proxy(partition);
+
+    auto deadline = model::timeout_clock::now() + 10min;
+
+    // The first call after a leadership change takes the suspending slow path
+    // (it syncs the log eviction stm and, with archival enabled, the archival
+    // stm). Do it outside the measured region so the measurement covers the
+    // steady state that every subsequent fetch hits.
+    auto warmup_ec = co_await proxy.validate_fetch_offset(
+      model::offset(0), false, deadline);
+    vassert(
+      warmup_ec == kafka::error_code::none, "unexpected error: {}", warmup_ec);
+
+    // Drain task queue before running the measured region in order to
+    // reduce noise from unrelated tasks.
+    co_await tests::drain_task_queue();
+
+    perf_tests::start_measuring_time();
+    for (size_t i = 0; i < num_calls_per_run; i++) {
+        auto ec = co_await proxy.validate_fetch_offset(
+          model::offset(0), false, deadline);
+        perf_tests::do_not_optimize(ec);
+    }
+    perf_tests::stop_measuring_time();
+
+    co_return num_calls_per_run;
+}
+
+// The dominant historical cost inside validate_fetch_offset:
+// partition::sync_kafka_start_offset_override. Measured on its own to
+// pinpoint regressions in this specific call.
+PERF_TEST_CN(validate_fetch_offset_fixture, sync_start_offset_override) {
+    static model::ntp ntp = co_await initialize_single_partition_topic();
+
+    auto partition = app.partition_manager.local().get(ntp);
+    vassert(partition, "partition {} must exist", ntp);
+
+    auto warmup_res = co_await partition->sync_kafka_start_offset_override(5s);
+    vassert(!warmup_res.has_failure(), "sync must succeed on the leader");
+
+    // Drain task queue before running the measured region in order to
+    // reduce noise from unrelated tasks.
+    co_await tests::drain_task_queue();
+
+    perf_tests::start_measuring_time();
+    for (size_t i = 0; i < num_calls_per_run; i++) {
+        auto res = co_await partition->sync_kafka_start_offset_override(5s);
+        perf_tests::do_not_optimize(res);
+    }
+    perf_tests::stop_measuring_time();
+
+    co_return num_calls_per_run;
+}


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Commit https://github.com/redpanda-data/redpanda/commit/395a8f493f4ecfbb54cc368c4e8c098de64fbc1e re-coroutinized `log_eviction_stm::
sync_kafka_start_offset_override` to hold the stm gate, reversing https://github.com/redpanda-data/redpanda/commit/e96451ad86d860097a7f1928ac3445f411459318 and putting two coroutine frame allocations plus a gate enter/leave back on every fetch's offset validation. On a high-fanout fetch workload (~30k partition reads/s) this showed up as ~4.6% of reactor util, up from the ~0.9% before the regression

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
