### PR TITLE
bazel: Enable seastar fmt compile time checking

### DIFF
--- a/bazel/thirdparty/seastar.BUILD
+++ b/bazel/thirdparty/seastar.BUILD
@@ -28,7 +28,7 @@ bool_flag(
 # "fmt_VERSION VERSION_GREATER_EQUAL 8.0.0" OFF)
 bool_flag(
     name = "logger_compile_time_fmt",
-    build_setting_default = False,
+    build_setting_default = True,
 )
 
 bool_flag(

--- a/src/v/cloud_topics/read_replica/snapshot_metastore.cc
+++ b/src/v/cloud_topics/read_replica/snapshot_metastore.cc
@@ -308,8 +308,7 @@ snapshot_metastore::get_extent_metadata_forwards(
                   obj_result.error(), "Error getting object metadata: "));
             }
             if (!obj_result.value().has_value()) {
-                vlog(
-                  cd_log.error, "Object {} metadata is missing: {}", val.oid);
+                vlog(cd_log.error, "Object {} metadata is missing", val.oid);
                 co_return std::unexpected(errc::transport_error);
             }
             const auto& obj = *obj_result.value();

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -395,40 +395,63 @@ private:
           , _client_port(port) {}
 
         template<typename... Args>
-        void error(const char* format, Args&&... args) {
-            log(ss::log_level::error, format, std::forward<Args>(args)...);
+        void error(ss::logger::format_info_t<Args...> format, Args&&... args) {
+            log(
+              ss::log_level::error,
+              std::move(format),
+              std::forward<Args>(args)...);
         }
         template<typename... Args>
-        void warn(const char* format, Args&&... args) {
-            log(ss::log_level::warn, format, std::forward<Args>(args)...);
-        }
-
-        template<typename... Args>
-        void info(const char* format, Args&&... args) {
-            log(ss::log_level::info, format, std::forward<Args>(args)...);
-        }
-
-        template<typename... Args>
-        void debug(const char* format, Args&&... args) {
-            log(ss::log_level::debug, format, std::forward<Args>(args)...);
+        void warn(ss::logger::format_info_t<Args...> format, Args&&... args) {
+            log(
+              ss::log_level::warn,
+              std::move(format),
+              std::forward<Args>(args)...);
         }
 
         template<typename... Args>
-        void trace(const char* format, Args&&... args) {
-            log(ss::log_level::trace, format, std::forward<Args>(args)...);
+        void info(ss::logger::format_info_t<Args...> format, Args&&... args) {
+            log(
+              ss::log_level::info,
+              std::move(format),
+              std::forward<Args>(args)...);
         }
 
         template<typename... Args>
-        void log(ss::log_level lvl, const char* format, Args&&... args) {
+        void debug(ss::logger::format_info_t<Args...> format, Args&&... args) {
+            log(
+              ss::log_level::debug,
+              std::move(format),
+              std::forward<Args>(args)...);
+        }
+
+        template<typename... Args>
+        void trace(ss::logger::format_info_t<Args...> format, Args&&... args) {
+            log(
+              ss::log_level::trace,
+              std::move(format),
+              std::forward<Args>(args)...);
+        }
+
+        template<typename... Args>
+        void log(
+          ss::log_level lvl,
+          ss::logger::format_info_t<Args...> format,
+          Args&&... args) {
             if (kauthzlog.is_enabled(lvl)) {
-                auto line_fmt = ss::sstring("{}:{} failed authorization - ")
-                                + format;
-                kauthzlog.log(
-                  lvl,
-                  line_fmt.c_str(),
-                  _client_addr,
-                  _client_port,
-                  std::forward<Args>(args)...);
+                ss::logger::lambda_log_writer writer(
+                  [&](ss::internal::log_buf::inserter_iterator it) {
+                      it = fmt::format_to(
+                        it,
+                        "{}:{} failed authorization - ",
+                        _client_addr,
+                        _client_port);
+                      return fmt::format_to(
+                        it,
+                        fmt::runtime(format.format),
+                        std::forward<Args>(args)...);
+                  });
+                kauthzlog.log(lvl, writer);
             }
         }
 

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -759,41 +759,70 @@ private:
           , _group(group) {}
 
         template<typename... Args>
-        void info(const char* format, Args&&... args) const {
-            log(ss::log_level::info, format, std::forward<Args>(args)...);
+        void
+        info(ss::logger::format_info_t<Args...> format, Args&&... args) const {
+            log(
+              ss::log_level::info,
+              std::move(format),
+              std::forward<Args>(args)...);
         }
 
         template<typename... Args>
-        void error(const char* format, Args&&... args) const {
-            log(ss::log_level::error, format, std::forward<Args>(args)...);
+        void
+        error(ss::logger::format_info_t<Args...> format, Args&&... args) const {
+            log(
+              ss::log_level::error,
+              std::move(format),
+              std::forward<Args>(args)...);
         }
 
         template<typename... Args>
-        void warn(const char* format, Args&&... args) const {
-            log(ss::log_level::warn, format, std::forward<Args>(args)...);
+        void
+        warn(ss::logger::format_info_t<Args...> format, Args&&... args) const {
+            log(
+              ss::log_level::warn,
+              std::move(format),
+              std::forward<Args>(args)...);
         }
 
         template<typename... Args>
-        void debug(const char* format, Args&&... args) const {
-            log(ss::log_level::debug, format, std::forward<Args>(args)...);
+        void
+        debug(ss::logger::format_info_t<Args...> format, Args&&... args) const {
+            log(
+              ss::log_level::debug,
+              std::move(format),
+              std::forward<Args>(args)...);
         }
 
         template<typename... Args>
-        void trace(const char* format, Args&&... args) const {
-            log(ss::log_level::trace, format, std::forward<Args>(args)...);
+        void
+        trace(ss::logger::format_info_t<Args...> format, Args&&... args) const {
+            log(
+              ss::log_level::trace,
+              std::move(format),
+              std::forward<Args>(args)...);
         }
 
         template<typename... Args>
-        void log(ss::log_level lvl, const char* format, Args&&... args) const {
+        void log(
+          ss::log_level lvl,
+          ss::logger::format_info_t<Args...> format,
+          Args&&... args) const {
             if (unlikely(_logger.is_enabled(lvl))) {
-                auto line_fmt = ss::sstring("[N:{} S:{} G:{}] ") + format;
-                _logger.log(
-                  lvl,
-                  line_fmt.c_str(),
-                  _group.id()(),
-                  _group.state(),
-                  _group.generation(),
-                  std::forward<Args>(args)...);
+                ss::logger::lambda_log_writer writer(
+                  [&](ss::internal::log_buf::inserter_iterator it) {
+                      it = fmt::format_to(
+                        it,
+                        "[N:{} S:{} G:{}] ",
+                        _group.id()(),
+                        _group.state(),
+                        _group.generation());
+                      return fmt::format_to(
+                        it,
+                        fmt::runtime(format.format),
+                        std::forward<Args>(args)...);
+                  });
+                _logger.log(lvl, writer);
             }
         }
 

--- a/src/v/kafka/server/rm_group_frontend.cc
+++ b/src/v/kafka/server/rm_group_frontend.cc
@@ -77,6 +77,7 @@ ss::future<cluster::begin_group_tx_reply> rm_group_frontend::begin_group_tx(
             vlog(
               cluster::txlog.trace,
               "can't find meta info for {}/{}, retrying",
+              tp,
               *partition_opt);
             ec = cluster::tx::errc::partition_not_exists;
             co_await ss::sleep(delay_ms);

--- a/src/v/raft/logger.h
+++ b/src/v/raft/logger.h
@@ -28,39 +28,50 @@ public:
       , _ntp(std::move(ntp)) {}
 
     template<typename... Args>
-    void error(const char* format, Args&&... args) {
-        log(ss::log_level::error, format, std::forward<Args>(args)...);
+    void error(ss::logger::format_info_t<Args...> format, Args&&... args) {
+        log(
+          ss::log_level::error, std::move(format), std::forward<Args>(args)...);
     }
     template<typename... Args>
-    void warn(const char* format, Args&&... args) {
-        log(ss::log_level::warn, format, std::forward<Args>(args)...);
-    }
-
-    template<typename... Args>
-    void info(const char* format, Args&&... args) {
-        log(ss::log_level::info, format, std::forward<Args>(args)...);
+    void warn(ss::logger::format_info_t<Args...> format, Args&&... args) {
+        log(
+          ss::log_level::warn, std::move(format), std::forward<Args>(args)...);
     }
 
     template<typename... Args>
-    void debug(const char* format, Args&&... args) {
-        log(ss::log_level::debug, format, std::forward<Args>(args)...);
+    void info(ss::logger::format_info_t<Args...> format, Args&&... args) {
+        log(
+          ss::log_level::info, std::move(format), std::forward<Args>(args)...);
     }
 
     template<typename... Args>
-    void trace(const char* format, Args&&... args) {
-        log(ss::log_level::trace, format, std::forward<Args>(args)...);
+    void debug(ss::logger::format_info_t<Args...> format, Args&&... args) {
+        log(
+          ss::log_level::debug, std::move(format), std::forward<Args>(args)...);
     }
 
     template<typename... Args>
-    void log(ss::log_level lvl, const char* format, Args&&... args) {
+    void trace(ss::logger::format_info_t<Args...> format, Args&&... args) {
+        log(
+          ss::log_level::trace, std::move(format), std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    void log(
+      ss::log_level lvl,
+      ss::logger::format_info_t<Args...> format,
+      Args&&... args) {
         if (raftlog.is_enabled(lvl)) {
-            auto line_fmt = ss::sstring("[group_id:{}, {}] ") + format;
-            raftlog.log(
-              lvl,
-              line_fmt.c_str(),
-              _group_id,
-              _ntp,
-              std::forward<Args>(args)...);
+            ss::logger::lambda_log_writer writer(
+              [&](ss::internal::log_buf::inserter_iterator it) {
+                  it = fmt::format_to(
+                    it, "[group_id:{}, {}] ", _group_id, _ntp);
+                  return fmt::format_to(
+                    it,
+                    fmt::runtime(format.format),
+                    std::forward<Args>(args)...);
+              });
+            raftlog.log(lvl, writer);
         }
     }
 

--- a/src/v/syschecks/syschecks.cc
+++ b/src/v/syschecks/syschecks.cc
@@ -99,7 +99,7 @@ void memory(
           "Memory: '{}' below required: '{}'",
           human::bytes(shard_mem),
           human::bytes(required_per_shard));
-        checklog.error(line.c_str());
+        checklog.error("{}", line);
         throw std::runtime_error(line);
     }
     if (shard_mem < kRecommendedMemory) {
@@ -109,7 +109,7 @@ void memory(
           human::bytes(kRecommendedMemory));
         auto log_lvl = developer_mode_enabled ? ss::log_level::warn
                                               : ss::log_level::error;
-        checklog.log(log_lvl, line.c_str());
+        checklog.log(log_lvl, "{}", line);
     }
 }
 

--- a/src/v/test_utils/boost_fixture.h
+++ b/src/v/test_utils/boost_fixture.h
@@ -31,12 +31,14 @@
     public:                                                                    \
         void fixture_test();                                                   \
         template<typename... T>                                                \
-        static auto info(T&&... t) {                                           \
-            return g_seastar_test_log.info(std::forward<T>(t)...);             \
+        static auto info(ss::logger::format_info_t<T...> format, T&&... t) {   \
+            return g_seastar_test_log.info(                                    \
+              std::move(format), std::forward<T>(t)...);                       \
         }                                                                      \
         template<typename... T>                                                \
-        static auto debug(T&&... t) {                                          \
-            return g_seastar_test_log.debug(std::forward<T>(t)...);            \
+        static auto debug(ss::logger::format_info_t<T...> format, T&&... t) {  \
+            return g_seastar_test_log.debug(                                   \
+              std::move(format), std::forward<T>(t)...);                       \
         }                                                                      \
                                                                                \
     private:                                                                   \

--- a/src/v/utils/prefix_logger.h
+++ b/src/v/utils/prefix_logger.h
@@ -25,37 +25,54 @@ public:
       , _prefix(std::move(prefix)) {}
 
     template<typename... Args>
-    void log(ss::log_level lvl, const char* format, Args&&... args) const {
+    void log(
+      ss::log_level lvl,
+      ss::logger::format_info_t<Args...> format,
+      Args&&... args) const {
         if (_logger->is_enabled(lvl)) {
-            auto line_fmt = ss::sstring("{} - ") + format;
-            _logger->log(
-              lvl, line_fmt.c_str(), _prefix, std::forward<Args>(args)...);
+            ss::logger::lambda_log_writer writer(
+              [&](ss::internal::log_buf::inserter_iterator it) {
+                  it = fmt::format_to(it, "{} - ", _prefix);
+                  return fmt::format_to(
+                    it,
+                    fmt::runtime(format.format),
+                    std::forward<Args>(args)...);
+              });
+            _logger->log(lvl, writer);
         }
     }
 
     template<typename... Args>
-    void error(const char* format, Args&&... args) const {
-        log(ss::log_level::error, format, std::forward<Args>(args)...);
+    void
+    error(ss::logger::format_info_t<Args...> format, Args&&... args) const {
+        log(
+          ss::log_level::error, std::move(format), std::forward<Args>(args)...);
     }
 
     template<typename... Args>
-    void warn(const char* format, Args&&... args) const {
-        log(ss::log_level::warn, format, std::forward<Args>(args)...);
+    void warn(ss::logger::format_info_t<Args...> format, Args&&... args) const {
+        log(
+          ss::log_level::warn, std::move(format), std::forward<Args>(args)...);
     }
 
     template<typename... Args>
-    void info(const char* format, Args&&... args) const {
-        log(ss::log_level::info, format, std::forward<Args>(args)...);
+    void info(ss::logger::format_info_t<Args...> format, Args&&... args) const {
+        log(
+          ss::log_level::info, std::move(format), std::forward<Args>(args)...);
     }
 
     template<typename... Args>
-    void debug(const char* format, Args&&... args) const {
-        log(ss::log_level::debug, format, std::forward<Args>(args)...);
+    void
+    debug(ss::logger::format_info_t<Args...> format, Args&&... args) const {
+        log(
+          ss::log_level::debug, std::move(format), std::forward<Args>(args)...);
     }
 
     template<typename... Args>
-    void trace(const char* format, Args&&... args) const {
-        log(ss::log_level::trace, format, std::forward<Args>(args)...);
+    void
+    trace(ss::logger::format_info_t<Args...> format, Args&&... args) const {
+        log(
+          ss::log_level::trace, std::move(format), std::forward<Args>(args)...);
     }
 
     template<typename... Args>

--- a/src/v/utils/xml.cc
+++ b/src/v/utils/xml.cc
@@ -24,16 +24,12 @@ void log_buffer_with_rate_limiting(
     static constexpr int buffer_size = 0x100;
     static constexpr auto rate_limit = std::chrono::seconds(1);
     thread_local static ss::logger::rate_limit rate(rate_limit);
-    auto log_with_rate_limit = [&logger](
-                                 ss::logger::format_info fmt, auto... args) {
-        logger.log(ss::log_level::warn, rate, fmt, args...);
-    };
     iobuf_istreambuf strbuf(buf);
     std::istream stream(&strbuf);
     std::array<char, buffer_size> str{};
     auto sz = stream.readsome(str.data(), buffer_size);
     auto sview = std::string_view(str.data(), sz);
-    vlog(log_with_rate_limit, "{}: {}", msg, sview);
+    vloglr(logger, ss::log_level::warn, rate, "{}: {}", msg, sview);
 }
 
 } // namespace


### PR DESCRIPTION
Enable the seastar define to use compile time fmt argument checking.

Fix what didn't compile with the flag on.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none

