### PR TITLE
[CORE-16799] KIP-848: Add ConsumerGroup* record schemas and serde

### DIFF
--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -1662,7 +1662,7 @@ writer.write_tags(tagged_fields(std::move(tags_to_encode)));
 {%- if obj != "" %}
 {%- set tf = obj + '.unknown_tags' %}
 {%- endif %}
-{{ writer }}.write_tags(std::move({{ tf }}));
+{{ writer }}.write_tags({{ tf }});
 {%- else %}
 {
 {{- tag_encoder_impl(tag_definitions, obj) | indent }}
@@ -1862,7 +1862,7 @@ void {{ struct.name }}::decode(iobuf buf, [[maybe_unused]] api_version version) 
 {%- if first_flex > 0 %}
 void {{ struct.name }}::encode(protocol::encoder& writer, api_version version) {
     if (version >= api_version({{ first_flex }})) {
-        writer.write_tags(std::move(unknown_tags));
+        writer.write_tags(unknown_tags);
     }
 }
 void {{ struct.name }}::decode(protocol::decoder& reader, api_version version) {
@@ -1878,7 +1878,7 @@ void {{ struct.name }}::decode(protocol::decoder&, api_version) {}
 {%- if first_flex > 0 %}
 void {{ struct.name }}::encode(protocol::encoder& writer, api_version version) {
     if (version >= api_version({{ first_flex }})) {
-        write.write_tags(std::move(unknown_tags));
+        writer.write_tags(unknown_tags);
     }
 }
 void {{ struct.name }}::decode(iobuf buf, api_version version) {

--- a/src/v/kafka/protocol/tests/field_parser_test.cc
+++ b/src/v/kafka/protocol/tests/field_parser_test.cc
@@ -59,7 +59,7 @@ SEASTAR_THREAD_TEST_CASE(serde_tags) {
     /// Re-serialize these tags to compare against the previous
     iobuf result;
     kafka::protocol::encoder end_writer(result);
-    end_writer.write_tags(std::move(deser_tags));
+    end_writer.write_tags(deser_tags);
 
     /// Perform checks against serialized copies
     BOOST_REQUIRE_EQUAL(result.size_bytes(), copy.size_bytes());

--- a/src/v/kafka/protocol/tests/wire_validation_test.cc
+++ b/src/v/kafka/protocol/tests/wire_validation_test.cc
@@ -134,6 +134,20 @@ SEASTAR_THREAD_TEST_CASE(read_flex_bytes_length_exceeds_buffer) {
     BOOST_CHECK_THROW(reader.read_flex_bytes(), std::out_of_range);
 }
 
+/// Test that read_flex_bytes rejects a huge length before allocating. The case
+/// above throws either way: read_bytes sizes its buffer, then finds the bytes
+/// missing.
+SEASTAR_THREAD_TEST_CASE(read_flex_bytes_huge_length) {
+    iobuf buf;
+    kafka::protocol::encoder writer(buf);
+    writer.write_unsigned_varint(1U << 30); // ~1 GiB
+    buf.append("abc", 3);                   // Only 3 bytes
+
+    kafka::protocol::decoder reader(std::move(buf));
+
+    BOOST_CHECK_THROW(reader.read_flex_bytes(), std::out_of_range);
+}
+
 /// Test that read_string throws when length exceeds remaining bytes
 SEASTAR_THREAD_TEST_CASE(read_string_length_exceeds_buffer) {
     iobuf buf;

--- a/src/v/kafka/protocol/wire.h
+++ b/src/v/kafka/protocol/wire.h
@@ -477,6 +477,21 @@ public:
         return write_flex(std::string_view(*v));
     }
 
+    /// Writes an optional named_type as a nullable compact string: an unsigned
+    /// varint of length + 1 followed by the characters, or a single zero varint
+    /// when absent.
+    ///
+    /// Exists so the string is passed by reference. Without it the argument
+    /// converts to optional<ss::sstring>, which builds a second optional and
+    /// copies the string into it.
+    template<typename Tag>
+    uint32_t write_flex(const std::optional<named_type<ss::sstring, Tag>>& v) {
+        if (!v) {
+            return write_unsigned_varint(0);
+        }
+        return write_flex((*v)());
+    }
+
     uint32_t write(std::optional<std::string_view> v) {
         if (!v) {
             return serialize_int<int16_t>(-1);
@@ -489,6 +504,20 @@ public:
             return serialize_int<int16_t>(-1);
         }
         return write(std::string_view(*v));
+    }
+
+    /// Writes an optional named_type as a nullable string: an int16 length
+    /// followed by the characters, or an int16 of -1 when absent.
+    ///
+    /// Exists so the string is passed by reference. Without it the argument
+    /// converts to optional<ss::sstring>, which builds a second optional and
+    /// copies the string into it.
+    template<typename Tag>
+    uint32_t write(const std::optional<named_type<ss::sstring, Tag>>& v) {
+        if (!v) {
+            return serialize_int<int16_t>(-1);
+        }
+        return write((*v)());
     }
 
     uint32_t write(uuid_t id) {

--- a/src/v/kafka/protocol/wire.h
+++ b/src/v/kafka/protocol/wire.h
@@ -750,7 +750,7 @@ public:
     }
 
     // Only relevent when writing flex responses
-    uint32_t write_tags(tagged_fields&& tags) {
+    uint32_t write_tags(const tagged_fields& tags) {
         auto start_size = uint32_t(_out->size_bytes());
         const auto n = tags().size();
         write_unsigned_varint(n); // write total number of tags

--- a/src/v/kafka/protocol/wire.h
+++ b/src/v/kafka/protocol/wire.h
@@ -150,6 +150,15 @@ public:
         if (unlikely(n == 0)) {
             throw std::out_of_range("Asked to read a negative byte string");
         }
+        // Checked before read_bytes, which allocates the length it is given
+        // before discovering the bytes are not there.
+        if (unlikely(static_cast<size_t>(n - 1) > _parser.bytes_left())) {
+            throw std::out_of_range(
+              fmt::format(
+                "Flex bytes length {} exceeds remaining bytes {}",
+                n - 1,
+                _parser.bytes_left()));
+        }
         return _parser.read_bytes(n - 1);
     }
 

--- a/src/v/kafka/protocol/wire.h
+++ b/src/v/kafka/protocol/wire.h
@@ -644,6 +644,21 @@ public:
 
     template<typename C, typename ElementWriter>
     requires requires(
+      ElementWriter writer, encoder& rw, const typename C::value_type& elem) {
+        requires SizedContainer<C>;
+        { writer(elem, rw) } -> std::same_as<void>;
+    }
+    uint32_t write_flex_array(const C& v, ElementWriter&& writer) {
+        auto start_size = uint32_t(_out->size_bytes());
+        write_unsigned_varint(v.size() + 1);
+        for (const auto& elem : v) {
+            writer(elem, *this);
+        }
+        return _out->size_bytes() - start_size;
+    }
+
+    template<typename C, typename ElementWriter>
+    requires requires(
       ElementWriter writer, encoder& rw, typename C::value_type& elem) {
         { writer(elem, rw) } -> std::same_as<void>;
     }

--- a/src/v/kafka/server/group_metadata.cc
+++ b/src/v/kafka/server/group_metadata.cc
@@ -324,6 +324,30 @@ iobuf maybe_unwrap_from_iobuf(iobuf buffer) {
     }
     return buffer;
 }
+
+template<typename KV>
+group_metadata_serializer::key_value to_kv_impl(KV md) {
+    group_metadata_serializer::key_value ret;
+    ret.key = metadata_to_iobuf(md.key);
+    if (md.value) {
+        ret.value = metadata_to_iobuf(*md.value);
+    }
+    return ret;
+}
+
+template<typename KV>
+KV decode_kv(model::record record) {
+    KV ret;
+    using key_type = decltype(ret.key);
+    using value_type = typename decltype(ret.value)::value_type;
+    protocol::decoder k_reader(maybe_unwrap_from_iobuf(record.release_key()));
+    ret.key = key_type::decode(k_reader);
+    if (record.has_value()) {
+        protocol::decoder v_reader(record.release_value());
+        ret.value = value_type::decode(v_reader);
+    }
+    return ret;
+}
 } // namespace
 
 fmt::iterator group_block_info::format_to(fmt::iterator it) const {
@@ -362,48 +386,16 @@ group_metadata_type get_metadata_type(iobuf buffer) {
     return decode_metadata_type(reader);
 };
 
-key_value to_kv(group_metadata_kv md) {
-    key_value ret;
-    ret.key = metadata_to_iobuf(md.key);
-    if (md.value) {
-        ret.value = metadata_to_iobuf(*md.value);
-    }
+key_value to_kv(group_metadata_kv md) { return to_kv_impl(std::move(md)); }
 
-    return ret;
-}
-
-key_value to_kv(offset_metadata_kv md) {
-    group_metadata_serializer::key_value ret;
-    ret.key = metadata_to_iobuf(md.key);
-    if (md.value) {
-        ret.value = metadata_to_iobuf(*md.value);
-    }
-
-    return ret;
-}
+key_value to_kv(offset_metadata_kv md) { return to_kv_impl(std::move(md)); }
 
 group_metadata_kv decode_group_metadata(model::record record) {
-    group_metadata_kv ret;
-    protocol::decoder k_reader(maybe_unwrap_from_iobuf(record.release_key()));
-    ret.key = group_metadata_key::decode(k_reader);
-    if (record.has_value()) {
-        protocol::decoder v_reader(record.release_value());
-        ret.value = group_metadata_value::decode(v_reader);
-    }
-
-    return ret;
+    return decode_kv<group_metadata_kv>(std::move(record));
 }
 
 offset_metadata_kv decode_offset_metadata(model::record record) {
-    offset_metadata_kv ret;
-    protocol::decoder k_reader(maybe_unwrap_from_iobuf(record.release_key()));
-    ret.key = offset_metadata_key::decode(k_reader);
-    if (record.has_value()) {
-        protocol::decoder v_reader(record.release_value());
-        ret.value = offset_metadata_value::decode(v_reader);
-    }
-
-    return ret;
+    return decode_kv<offset_metadata_kv>(std::move(record));
 }
 } // namespace group_metadata_serializer
 

--- a/src/v/kafka/server/group_metadata.cc
+++ b/src/v/kafka/server/group_metadata.cc
@@ -39,6 +39,33 @@ group_metadata_kv group_metadata_kv::copy() const {
     return cp;
 }
 
+consumer_group_member_metadata_kv
+consumer_group_member_metadata_kv::copy() const {
+    consumer_group_member_metadata_kv cp{.key = key};
+    if (value) {
+        cp.value = value->copy();
+    }
+    return cp;
+}
+
+consumer_group_target_assignment_member_kv
+consumer_group_target_assignment_member_kv::copy() const {
+    consumer_group_target_assignment_member_kv cp{.key = key};
+    if (value) {
+        cp.value = value->copy();
+    }
+    return cp;
+}
+
+consumer_group_current_member_assignment_kv
+consumer_group_current_member_assignment_kv::copy() const {
+    consumer_group_current_member_assignment_kv cp{.key = key};
+    if (value) {
+        cp.value = value->copy();
+    }
+    return cp;
+}
+
 /**
  * /Kafka
  * Messages stored for the group topic has versions for both the key and value
@@ -57,18 +84,45 @@ group_metadata_kv group_metadata_kv::copy() const {
  * key version 2:       group metadata
  *    -> value version 0:       [protocol_type, generation, protocol, leader,
  * members]
+ *
+ * KIP-848 adds the consumer-protocol records below. Their key version is
+ * Kafka's record apiKey; the value carries its own version. Key version 4
+ * (ConsumerGroupPartitionMetadata) is absent because Kafka deprecated it in
+ * favour of ConsumerGroupMetadata's MetadataHash and Redpanda never writes it.
+ *
+ * key version 3:       consumer group metadata
+ *    -> value version 0:       [epoch, (metadata_hash)]
+ * key version 5:       consumer group member metadata
+ * key version 6:       consumer group target assignment metadata
+ * key version 7:       consumer group target assignment member
+ * key version 8:       consumer group current member assignment
  */
 group_metadata_type decode_metadata_type(protocol::decoder& key_reader) {
     auto version = read_metadata_version(key_reader);
 
+    // The pre-KIP-98 offset commit has no struct of its own.
     if (
       version == group_metadata_version{0}
-      || version == group_metadata_version{1}) {
+      || version == offset_metadata_key::version) {
         return group_metadata_type::offset_commit;
     }
-
-    if (version == group_metadata_version{2}) {
+    if (version == group_metadata_key::version) {
         return group_metadata_type::group_metadata;
+    }
+    if (version == consumer_group_metadata_key::version) {
+        return group_metadata_type::consumer_group_metadata;
+    }
+    if (version == consumer_group_member_metadata_key::version) {
+        return group_metadata_type::consumer_group_member_metadata;
+    }
+    if (version == consumer_group_target_assignment_metadata_key::version) {
+        return group_metadata_type::consumer_group_target_assignment_metadata;
+    }
+    if (version == consumer_group_target_assignment_member_key::version) {
+        return group_metadata_type::consumer_group_target_assignment_member;
+    }
+    if (version == consumer_group_current_member_assignment_key::version) {
+        return group_metadata_type::consumer_group_current_member_assignment;
     }
     throw std::invalid_argument(
       fmt::format(
@@ -92,6 +146,91 @@ void validate_version_range(
       type_name,
       max,
       read_version);
+}
+
+/// A record key's version is its type discriminator, so only one value is ever
+/// valid for a given key type.
+void validate_key_version(
+  group_metadata_version read_version,
+  std::string_view type_name,
+  group_metadata_version expected) {
+    vassert(
+      read_version == expected,
+      "Only valid version for {} is {}. Read version: {}",
+      type_name,
+      expected,
+      read_version);
+}
+
+/// Encodes one known tagged field into `tags`, ready for `write_tags`.
+template<typename PayloadWriter>
+void add_tag(tagged_fields::type& tags, uint32_t id, PayloadWriter&& write) {
+    iobuf payload;
+    protocol::encoder writer(payload);
+    write(writer);
+    tags.emplace(tag_id(id), iobuf_to_bytes(payload));
+}
+
+/// Reads a flexible value's trailing tagged-fields section. `handler` is given
+/// each tag id and returns whether it consumed the payload; whatever it
+/// declines is retained in `unknown`.
+///
+/// Both the tag count and each payload size are rejected if they need more than
+/// the bytes remaining. The size check matters beyond reporting a corrupt
+/// record early: `consume_unknown_tag` reads the payload with `read_bytes`,
+/// which allocates the length taken off the wire before anything bounds-checks
+/// it.
+template<typename Handler>
+void read_tagged_fields(
+  protocol::decoder& reader, tagged_fields& unknown, Handler&& handler) {
+    auto fits = [&reader](size_t needed, std::string_view what) {
+        if (unlikely(needed > reader.bytes_left())) {
+            throw std::out_of_range(
+              fmt::format(
+                "tagged fields: {} needs {} bytes, {} remain",
+                what,
+                needed,
+                reader.bytes_left()));
+        }
+    };
+
+    auto num_tags = reader.read_unsigned_varint();
+    // An entry costs at least an id varint and a size varint before any
+    // payload, so two bytes per tag is the floor.
+    fits(size_t{2} * num_tags, "count");
+
+    int64_t prev_tag = -1;
+    while (num_tags-- > 0) {
+        auto tag = reader.read_unsigned_varint();
+        if (unlikely(tag <= prev_tag)) {
+            throw std::out_of_range(
+              fmt::format(
+                "tagged fields must be serialized in ascending order with no "
+                "duplicates, tag: {}",
+                tag));
+        }
+        prev_tag = tag;
+
+        auto size = reader.read_unsigned_varint();
+        fits(size, "payload");
+
+        auto before = reader.bytes_left();
+        if (!handler(tag)) {
+            reader.consume_unknown_tag(unknown, tag, size);
+        }
+        // A handler that reads the wrong amount would otherwise leave the loop
+        // mid-payload, where the next bytes decode as a plausible tag id and
+        // size and land in `unknown` to be re-emitted on the next encode.
+        auto consumed = before - reader.bytes_left();
+        if (unlikely(consumed != size)) {
+            throw std::out_of_range(
+              fmt::format(
+                "tagged fields: tag {} declared {} bytes, consumed {}",
+                tag,
+                size,
+                consumed));
+        }
+    }
 }
 } // namespace
 
@@ -241,6 +380,483 @@ offset_metadata_value offset_metadata_value::decode(protocol::decoder& reader) {
         ret.expiry_timestamp = model::timestamp(reader.read_int64());
     }
 
+    return ret;
+}
+
+void consumer_group_metadata_key::encode(
+  protocol::encoder& writer, const consumer_group_metadata_key& v) {
+    writer.write(v.version);
+    writer.write(v.group_id);
+}
+
+consumer_group_metadata_key
+consumer_group_metadata_key::decode(protocol::decoder& reader) {
+    consumer_group_metadata_key ret;
+    validate_key_version(
+      read_metadata_version(reader),
+      "consumer_group_metadata_key",
+      consumer_group_metadata_key::version);
+    ret.group_id = kafka::group_id(reader.read_string());
+    return ret;
+}
+
+void consumer_group_metadata_value::encode(
+  protocol::encoder& writer, const consumer_group_metadata_value& v) {
+    writer.write(v.version);
+    writer.write(v.epoch);
+    tagged_fields::type tags{v.unknown_tags()};
+    if (v.metadata_hash != 0) {
+        add_tag(
+          tags, 0, [&](protocol::encoder& w) { w.write(v.metadata_hash); });
+    }
+    writer.write_tags(tagged_fields(std::move(tags)));
+}
+
+consumer_group_metadata_value
+consumer_group_metadata_value::decode(protocol::decoder& reader) {
+    consumer_group_metadata_value ret;
+    validate_version_range(
+      read_metadata_version(reader),
+      "consumer_group_metadata_value",
+      consumer_group_metadata_value::version);
+    ret.epoch = reader.read_int32();
+    read_tagged_fields(reader, ret.unknown_tags, [&](uint32_t tag) {
+        if (tag != 0) {
+            return false;
+        }
+        ret.metadata_hash = reader.read_int64();
+        return true;
+    });
+    return ret;
+}
+
+void classic_protocol::encode(
+  protocol::encoder& writer, const classic_protocol& v) {
+    writer.write_flex(v.name);
+    writer.write_flex(v.metadata);
+    writer.write_tags(v.unknown_tags);
+}
+
+classic_protocol classic_protocol::decode(protocol::decoder& reader) {
+    classic_protocol ret;
+    ret.name = kafka::protocol_name(reader.read_flex_string());
+    ret.metadata = reader.read_flex_bytes();
+    ret.unknown_tags = reader.read_tags();
+    return ret;
+}
+
+classic_member_metadata classic_member_metadata::copy() const {
+    return classic_member_metadata{
+      .session_timeout = session_timeout,
+      .supported_protocols = supported_protocols.copy(),
+      .unknown_tags = unknown_tags,
+    };
+}
+
+void classic_member_metadata::encode(
+  protocol::encoder& writer, const classic_member_metadata& v) {
+    writer.write(v.session_timeout);
+    writer.write_flex_array(
+      v.supported_protocols,
+      [](const classic_protocol& p, protocol::encoder& w) {
+          classic_protocol::encode(w, p);
+      });
+    writer.write_tags(v.unknown_tags);
+}
+
+classic_member_metadata
+classic_member_metadata::decode(protocol::decoder& reader) {
+    classic_member_metadata ret;
+    ret.session_timeout = std::chrono::milliseconds(reader.read_int32());
+    ret.supported_protocols = reader.read_flex_array<chunked_vector>(
+      [](protocol::decoder& reader) {
+          return classic_protocol::decode(reader);
+      });
+    ret.unknown_tags = reader.read_tags();
+    return ret;
+}
+
+void consumer_group_member_metadata_key::encode(
+  protocol::encoder& writer, const consumer_group_member_metadata_key& v) {
+    writer.write(v.version);
+    writer.write(v.group_id);
+    writer.write(v.member_id);
+}
+
+consumer_group_member_metadata_key
+consumer_group_member_metadata_key::decode(protocol::decoder& reader) {
+    consumer_group_member_metadata_key ret;
+    validate_key_version(
+      read_metadata_version(reader),
+      "consumer_group_member_metadata_key",
+      consumer_group_member_metadata_key::version);
+    ret.group_id = kafka::group_id(reader.read_string());
+    ret.member_id = kafka::member_id(reader.read_string());
+    return ret;
+}
+
+consumer_group_member_metadata_value
+consumer_group_member_metadata_value::copy() const {
+    consumer_group_member_metadata_value ret{
+      .instance_id = instance_id,
+      .rack_id = rack_id,
+      .client_id = client_id,
+      .client_host = client_host,
+      .subscribed_topic_names = subscribed_topic_names.copy(),
+      .subscribed_topic_regex = subscribed_topic_regex,
+      .rebalance_timeout = rebalance_timeout,
+      .server_assignor = server_assignor,
+      .unknown_tags = unknown_tags,
+    };
+    if (classic_metadata) {
+        ret.classic_metadata = classic_metadata->copy();
+    }
+    return ret;
+}
+
+void consumer_group_member_metadata_value::encode(
+  protocol::encoder& writer, const consumer_group_member_metadata_value& v) {
+    writer.write(v.version);
+    writer.write_flex(v.instance_id);
+    writer.write_flex(v.rack_id);
+    writer.write_flex(v.client_id);
+    writer.write_flex(v.client_host);
+    writer.write_flex_array(
+      v.subscribed_topic_names,
+      [](const model::topic& t, protocol::encoder& w) { w.write_flex(t); });
+    writer.write_flex(v.subscribed_topic_regex);
+    writer.write(v.rebalance_timeout);
+    writer.write_flex(v.server_assignor);
+    tagged_fields::type tags{v.unknown_tags()};
+    // Tag 0, following ConsumerGroupMemberMetadataValue's generated write.
+    if (!v.classic_metadata) {
+        add_tag(tags, 0, [](protocol::encoder& w) {
+            w.write_unsigned_varint(0); // null
+        });
+    } else if (*v.classic_metadata != classic_member_metadata{}) {
+        add_tag(tags, 0, [&](protocol::encoder& w) {
+            w.write_unsigned_varint(1); // present
+            classic_member_metadata::encode(w, *v.classic_metadata);
+        });
+    } // else omit the tag, indicating "present and default"
+    writer.write_tags(tagged_fields(std::move(tags)));
+}
+
+consumer_group_member_metadata_value
+consumer_group_member_metadata_value::decode(protocol::decoder& reader) {
+    consumer_group_member_metadata_value ret;
+    validate_version_range(
+      read_metadata_version(reader),
+      "consumer_group_member_metadata_value",
+      consumer_group_member_metadata_value::version);
+    if (auto instance_id = reader.read_nullable_flex_string(); instance_id) {
+        ret.instance_id = kafka::group_instance_id(std::move(*instance_id));
+    }
+    if (auto rack_id = reader.read_nullable_flex_string(); rack_id) {
+        ret.rack_id = model::rack_id(std::move(*rack_id));
+    }
+    ret.client_id = kafka::client_id(reader.read_flex_string());
+    ret.client_host = kafka::client_host(reader.read_flex_string());
+    ret.subscribed_topic_names = reader.read_flex_array<chunked_vector>(
+      [](protocol::decoder& reader) {
+          return model::topic(reader.read_flex_string());
+      });
+    ret.subscribed_topic_regex = reader.read_nullable_flex_string();
+    ret.rebalance_timeout = std::chrono::milliseconds(reader.read_int32());
+    ret.server_assignor = reader.read_nullable_flex_string();
+    read_tagged_fields(reader, ret.unknown_tags, [&](uint32_t tag) {
+        if (tag != 0) {
+            return false;
+        }
+        // A leading zero varint marks the struct absent.
+        if (reader.read_unsigned_varint() == 0) {
+            ret.classic_metadata = std::nullopt;
+        } else {
+            ret.classic_metadata = classic_member_metadata::decode(reader);
+        }
+        return true;
+    });
+    return ret;
+}
+
+void consumer_group_target_assignment_metadata_key::encode(
+  protocol::encoder& writer,
+  const consumer_group_target_assignment_metadata_key& v) {
+    writer.write(v.version);
+    writer.write(v.group_id);
+}
+
+consumer_group_target_assignment_metadata_key
+consumer_group_target_assignment_metadata_key::decode(
+  protocol::decoder& reader) {
+    consumer_group_target_assignment_metadata_key ret;
+    validate_key_version(
+      read_metadata_version(reader),
+      "consumer_group_target_assignment_metadata_key",
+      consumer_group_target_assignment_metadata_key::version);
+    ret.group_id = kafka::group_id(reader.read_string());
+    return ret;
+}
+
+void consumer_group_target_assignment_metadata_value::encode(
+  protocol::encoder& writer,
+  const consumer_group_target_assignment_metadata_value& v) {
+    writer.write(v.version);
+    writer.write(v.assignment_epoch);
+    tagged_fields::type tags{v.unknown_tags()};
+    if (v.assignment_timestamp != 0) {
+        add_tag(tags, 0, [&](protocol::encoder& w) {
+            w.write(v.assignment_timestamp);
+        });
+    }
+    writer.write_tags(tagged_fields(std::move(tags)));
+}
+
+consumer_group_target_assignment_metadata_value
+consumer_group_target_assignment_metadata_value::decode(
+  protocol::decoder& reader) {
+    consumer_group_target_assignment_metadata_value ret;
+    validate_version_range(
+      read_metadata_version(reader),
+      "consumer_group_target_assignment_metadata_value",
+      consumer_group_target_assignment_metadata_value::version);
+    ret.assignment_epoch = reader.read_int32();
+    read_tagged_fields(reader, ret.unknown_tags, [&](uint32_t tag) {
+        if (tag != 0) {
+            return false;
+        }
+        ret.assignment_timestamp = reader.read_int64();
+        return true;
+    });
+    return ret;
+}
+
+target_assignment_topic_partitions
+target_assignment_topic_partitions::copy() const {
+    return target_assignment_topic_partitions{
+      .topic_id = topic_id,
+      .partitions = partitions.copy(),
+      .unknown_tags = unknown_tags,
+    };
+}
+
+void target_assignment_topic_partitions::encode(
+  protocol::encoder& writer, const target_assignment_topic_partitions& v) {
+    writer.write(v.topic_id);
+    writer.write_flex_array(
+      v.partitions,
+      [](model::partition_id p, protocol::encoder& w) { w.write(p); });
+    writer.write_tags(v.unknown_tags);
+}
+
+target_assignment_topic_partitions
+target_assignment_topic_partitions::decode(protocol::decoder& reader) {
+    target_assignment_topic_partitions ret;
+    ret.topic_id = model::topic_id(reader.read_uuid());
+    ret.partitions = reader.read_flex_array<chunked_vector>(
+      [](protocol::decoder& reader) {
+          return model::partition_id(reader.read_int32());
+      });
+    ret.unknown_tags = reader.read_tags();
+    return ret;
+}
+
+void consumer_group_target_assignment_member_key::encode(
+  protocol::encoder& writer,
+  const consumer_group_target_assignment_member_key& v) {
+    writer.write(v.version);
+    writer.write(v.group_id);
+    writer.write(v.member_id);
+}
+
+consumer_group_target_assignment_member_key
+consumer_group_target_assignment_member_key::decode(protocol::decoder& reader) {
+    consumer_group_target_assignment_member_key ret;
+    validate_key_version(
+      read_metadata_version(reader),
+      "consumer_group_target_assignment_member_key",
+      consumer_group_target_assignment_member_key::version);
+    ret.group_id = kafka::group_id(reader.read_string());
+    ret.member_id = kafka::member_id(reader.read_string());
+    return ret;
+}
+
+consumer_group_target_assignment_member_value
+consumer_group_target_assignment_member_value::copy() const {
+    consumer_group_target_assignment_member_value ret{
+      .unknown_tags = unknown_tags};
+    ret.topic_partitions.reserve(topic_partitions.size());
+    for (const auto& tp : topic_partitions) {
+        ret.topic_partitions.push_back(tp.copy());
+    }
+    return ret;
+}
+
+void consumer_group_target_assignment_member_value::encode(
+  protocol::encoder& writer,
+  const consumer_group_target_assignment_member_value& v) {
+    writer.write(v.version);
+    writer.write_flex_array(
+      v.topic_partitions,
+      [](const target_assignment_topic_partitions& tp, protocol::encoder& w) {
+          target_assignment_topic_partitions::encode(w, tp);
+      });
+    writer.write_tags(v.unknown_tags);
+}
+
+consumer_group_target_assignment_member_value
+consumer_group_target_assignment_member_value::decode(
+  protocol::decoder& reader) {
+    consumer_group_target_assignment_member_value ret;
+    validate_version_range(
+      read_metadata_version(reader),
+      "consumer_group_target_assignment_member_value",
+      consumer_group_target_assignment_member_value::version);
+    ret.topic_partitions = reader.read_flex_array<chunked_vector>(
+      [](protocol::decoder& reader) {
+          return target_assignment_topic_partitions::decode(reader);
+      });
+    ret.unknown_tags = reader.read_tags();
+    return ret;
+}
+
+current_assignment_topic_partitions
+current_assignment_topic_partitions::copy() const {
+    current_assignment_topic_partitions ret{
+      .topic_id = topic_id,
+      .partitions = partitions.copy(),
+      .unknown_tags = unknown_tags,
+    };
+    if (assignment_epochs) {
+        ret.assignment_epochs = assignment_epochs->copy();
+    }
+    return ret;
+}
+
+void current_assignment_topic_partitions::encode(
+  protocol::encoder& writer, const current_assignment_topic_partitions& v) {
+    writer.write(v.topic_id);
+    writer.write_flex_array(
+      v.partitions,
+      [](model::partition_id p, protocol::encoder& w) { w.write(p); });
+    tagged_fields::type tags{v.unknown_tags()};
+    // Tag 0, following ConsumerGroupCurrentMemberAssignmentValue's generated
+    // TopicPartitions::write.
+    if (!v.assignment_epochs) {
+        add_tag(tags, 0, [](protocol::encoder& enc) {
+            enc.write_unsigned_varint(0); // null
+        });
+    } else if (!v.assignment_epochs->empty()) {
+        add_tag(tags, 0, [&](protocol::encoder& enc) {
+            enc.write_flex_array(
+              *v.assignment_epochs,
+              [](int32_t epoch, protocol::encoder& w) { w.write(epoch); });
+        });
+    } // else omit the tag, indicating "present and default"
+    writer.write_tags(tagged_fields(std::move(tags)));
+}
+
+current_assignment_topic_partitions
+current_assignment_topic_partitions::decode(protocol::decoder& reader) {
+    current_assignment_topic_partitions ret;
+    ret.topic_id = model::topic_id(reader.read_uuid());
+    ret.partitions = reader.read_flex_array<chunked_vector>(
+      [](protocol::decoder& reader) {
+          return model::partition_id(reader.read_int32());
+      });
+    read_tagged_fields(reader, ret.unknown_tags, [&](uint32_t tag) {
+        if (tag != 0) {
+            return false;
+        }
+        ret.assignment_epochs = reader.read_nullable_flex_array<chunked_vector>(
+          [](protocol::decoder& reader) { return reader.read_int32(); });
+        return true;
+    });
+    return ret;
+}
+
+void consumer_group_current_member_assignment_key::encode(
+  protocol::encoder& writer,
+  const consumer_group_current_member_assignment_key& v) {
+    writer.write(v.version);
+    writer.write(v.group_id);
+    writer.write(v.member_id);
+}
+
+consumer_group_current_member_assignment_key
+consumer_group_current_member_assignment_key::decode(
+  protocol::decoder& reader) {
+    consumer_group_current_member_assignment_key ret;
+    validate_key_version(
+      read_metadata_version(reader),
+      "consumer_group_current_member_assignment_key",
+      consumer_group_current_member_assignment_key::version);
+    ret.group_id = kafka::group_id(reader.read_string());
+    ret.member_id = kafka::member_id(reader.read_string());
+    return ret;
+}
+
+namespace {
+chunked_vector<current_assignment_topic_partitions> copy_topic_partitions(
+  const chunked_vector<current_assignment_topic_partitions>& partitions) {
+    chunked_vector<current_assignment_topic_partitions> ret;
+    ret.reserve(partitions.size());
+    for (const auto& tp : partitions) {
+        ret.push_back(tp.copy());
+    }
+    return ret;
+}
+} // namespace
+
+consumer_group_current_member_assignment_value
+consumer_group_current_member_assignment_value::copy() const {
+    return consumer_group_current_member_assignment_value{
+      .member_epoch = member_epoch,
+      .previous_member_epoch = previous_member_epoch,
+      .state = state,
+      .assigned_partitions = copy_topic_partitions(assigned_partitions),
+      .partitions_pending_revocation = copy_topic_partitions(
+        partitions_pending_revocation),
+      .unknown_tags = unknown_tags,
+    };
+}
+
+void consumer_group_current_member_assignment_value::encode(
+  protocol::encoder& writer,
+  const consumer_group_current_member_assignment_value& v) {
+    auto write_partitions =
+      [](const current_assignment_topic_partitions& tp, protocol::encoder& w) {
+          current_assignment_topic_partitions::encode(w, tp);
+      };
+    writer.write(v.version);
+    writer.write(v.member_epoch);
+    writer.write(v.previous_member_epoch);
+    writer.write(v.state);
+    writer.write_flex_array(v.assigned_partitions, write_partitions);
+    writer.write_flex_array(v.partitions_pending_revocation, write_partitions);
+    writer.write_tags(v.unknown_tags);
+}
+
+consumer_group_current_member_assignment_value
+consumer_group_current_member_assignment_value::decode(
+  protocol::decoder& reader) {
+    auto read_partitions = [](protocol::decoder& reader) {
+        return reader.read_flex_array<chunked_vector>(
+          [](protocol::decoder& reader) {
+              return current_assignment_topic_partitions::decode(reader);
+          });
+    };
+    consumer_group_current_member_assignment_value ret;
+    validate_version_range(
+      read_metadata_version(reader),
+      "consumer_group_current_member_assignment_value",
+      consumer_group_current_member_assignment_value::version);
+    ret.member_epoch = reader.read_int32();
+    ret.previous_member_epoch = reader.read_int32();
+    ret.state = static_cast<consumer_group_member_state>(reader.read_int8());
+    ret.assigned_partitions = read_partitions(reader);
+    ret.partitions_pending_revocation = read_partitions(reader);
+    ret.unknown_tags = reader.read_tags();
     return ret;
 }
 
@@ -397,6 +1013,51 @@ group_metadata_kv decode_group_metadata(model::record record) {
 offset_metadata_kv decode_offset_metadata(model::record record) {
     return decode_kv<offset_metadata_kv>(std::move(record));
 }
+
+key_value to_kv(consumer_group_metadata_kv md) {
+    return to_kv_impl(std::move(md));
+}
+
+key_value to_kv(consumer_group_member_metadata_kv md) {
+    return to_kv_impl(std::move(md));
+}
+
+key_value to_kv(consumer_group_target_assignment_metadata_kv md) {
+    return to_kv_impl(std::move(md));
+}
+
+key_value to_kv(consumer_group_target_assignment_member_kv md) {
+    return to_kv_impl(std::move(md));
+}
+
+key_value to_kv(consumer_group_current_member_assignment_kv md) {
+    return to_kv_impl(std::move(md));
+}
+
+consumer_group_metadata_kv decode_consumer_group_metadata(model::record r) {
+    return decode_kv<consumer_group_metadata_kv>(std::move(r));
+}
+
+consumer_group_member_metadata_kv
+decode_consumer_group_member_metadata(model::record r) {
+    return decode_kv<consumer_group_member_metadata_kv>(std::move(r));
+}
+
+consumer_group_target_assignment_metadata_kv
+decode_consumer_group_target_assignment_metadata(model::record r) {
+    return decode_kv<consumer_group_target_assignment_metadata_kv>(
+      std::move(r));
+}
+
+consumer_group_target_assignment_member_kv
+decode_consumer_group_target_assignment_member(model::record r) {
+    return decode_kv<consumer_group_target_assignment_member_kv>(std::move(r));
+}
+
+consumer_group_current_member_assignment_kv
+decode_consumer_group_current_member_assignment(model::record r) {
+    return decode_kv<consumer_group_current_member_assignment_kv>(std::move(r));
+}
 } // namespace group_metadata_serializer
 
 fmt::iterator member_state::format_to(fmt::iterator it) const {
@@ -451,6 +1112,129 @@ fmt::iterator offset_metadata_value::format_to(fmt::iterator it) const {
       commit_timestamp,
       expiry_timestamp);
 }
+
+fmt::iterator
+format_to(const consumer_group_member_state& state, fmt::iterator it) {
+    switch (state) {
+    case consumer_group_member_state::stable:
+        return fmt::format_to(it, "stable");
+    case consumer_group_member_state::unrevoked_partitions:
+        return fmt::format_to(it, "unrevoked_partitions");
+    case consumer_group_member_state::unreleased_partitions:
+        return fmt::format_to(it, "unreleased_partitions");
+    case consumer_group_member_state::unknown:
+        return fmt::format_to(it, "unknown");
+    }
+    return fmt::format_to(it, "unrecognized({})", static_cast<int>(state));
+}
+
+fmt::iterator consumer_group_metadata_key::format_to(fmt::iterator it) const {
+    return fmt::format_to(it, "{{group_id: {}}}", group_id);
+}
+
+fmt::iterator consumer_group_metadata_value::format_to(fmt::iterator it) const {
+    return fmt::format_to(
+      it, "{{epoch: {}, metadata_hash: {}}}", epoch, metadata_hash);
+}
+
+fmt::iterator classic_protocol::format_to(fmt::iterator it) const {
+    return fmt::format_to(
+      it, "{{name: {}, metadata_size: {}}}", name, metadata.size());
+}
+
+fmt::iterator classic_member_metadata::format_to(fmt::iterator it) const {
+    return fmt::format_to(
+      it,
+      "{{session_timeout: {}, supported_protocols: {}}}",
+      session_timeout,
+      fmt::join(supported_protocols, ", "));
+}
+
+fmt::iterator
+consumer_group_member_metadata_key::format_to(fmt::iterator it) const {
+    return fmt::format_to(
+      it, "{{group_id: {}, member_id: {}}}", group_id, member_id);
+}
+
+fmt::iterator
+consumer_group_member_metadata_value::format_to(fmt::iterator it) const {
+    return fmt::format_to(
+      it,
+      "{{instance_id: {}, rack_id: {}, client_id: {}, client_host: {}, "
+      "subscribed_topic_names: {}, subscribed_topic_regex: {}, "
+      "rebalance_timeout: {}, server_assignor: {}, classic_metadata: {}}}",
+      instance_id,
+      rack_id,
+      client_id,
+      client_host,
+      fmt::join(subscribed_topic_names, ", "),
+      subscribed_topic_regex,
+      rebalance_timeout,
+      server_assignor,
+      classic_metadata);
+}
+
+fmt::iterator consumer_group_target_assignment_metadata_key::format_to(
+  fmt::iterator it) const {
+    return fmt::format_to(it, "{{group_id: {}}}", group_id);
+}
+
+fmt::iterator consumer_group_target_assignment_metadata_value::format_to(
+  fmt::iterator it) const {
+    return fmt::format_to(
+      it,
+      "{{assignment_epoch: {}, assignment_timestamp: {}}}",
+      assignment_epoch,
+      assignment_timestamp);
+}
+
+fmt::iterator
+target_assignment_topic_partitions::format_to(fmt::iterator it) const {
+    return fmt::format_to(
+      it, "{{topic_id: {}, partition_count: {}}}", topic_id, partitions.size());
+}
+
+fmt::iterator
+consumer_group_target_assignment_member_key::format_to(fmt::iterator it) const {
+    return fmt::format_to(
+      it, "{{group_id: {}, member_id: {}}}", group_id, member_id);
+}
+
+fmt::iterator consumer_group_target_assignment_member_value::format_to(
+  fmt::iterator it) const {
+    return fmt::format_to(
+      it, "{{topic_partitions: {}}}", fmt::join(topic_partitions, ", "));
+}
+
+fmt::iterator
+current_assignment_topic_partitions::format_to(fmt::iterator it) const {
+    return fmt::format_to(
+      it,
+      "{{topic_id: {}, partition_count: {}, has_assignment_epochs: {}}}",
+      topic_id,
+      partitions.size(),
+      assignment_epochs.has_value());
+}
+
+fmt::iterator consumer_group_current_member_assignment_key::format_to(
+  fmt::iterator it) const {
+    return fmt::format_to(
+      it, "{{group_id: {}, member_id: {}}}", group_id, member_id);
+}
+
+fmt::iterator consumer_group_current_member_assignment_value::format_to(
+  fmt::iterator it) const {
+    return fmt::format_to(
+      it,
+      "{{member_epoch: {}, previous_member_epoch: {}, state: {}, "
+      "assigned_partitions: {}, partitions_pending_revocation: {}}}",
+      member_epoch,
+      previous_member_epoch,
+      state,
+      fmt::join(assigned_partitions, ", "),
+      fmt::join(partitions_pending_revocation, ", "));
+}
+
 namespace group_tx {
 fmt::iterator offsets_metadata::format_to(fmt::iterator it) const {
     return fmt::format_to(

--- a/src/v/kafka/server/group_metadata.h
+++ b/src/v/kafka/server/group_metadata.h
@@ -14,9 +14,11 @@
 #include "base/seastarx.h"
 #include "bytes/iobuf.h"
 #include "container/chunked_vector.h"
+#include "kafka/protocol/types.h"
 #include "kafka/protocol/wire.h"
 #include "model/adl_serde.h"
 #include "model/fundamental.h"
+#include "model/metadata.h"
 #include "model/record.h"
 #include "model/timestamp.h"
 #include "serde/rw/rw.h"
@@ -26,10 +28,16 @@
 
 namespace kafka {
 
+/// `consumer_group_*` are the KIP-848 protocol's records; the rest predate it.
 enum group_metadata_type {
     offset_commit,
     group_metadata,
     noop,
+    consumer_group_metadata,
+    consumer_group_member_metadata,
+    consumer_group_target_assignment_metadata,
+    consumer_group_target_assignment_member,
+    consumer_group_current_member_assignment,
 };
 
 group_metadata_type decode_metadata_type(protocol::decoder& key_reader);
@@ -175,6 +183,306 @@ inline group_metadata_version read_metadata_version(protocol::decoder& reader) {
     return group_metadata_version{reader.read_int16()};
 }
 
+/*
+ * The ConsumerGroup* records, lifted from Kafka's coordinator record schemas.
+ * They share __consumer_offsets with the classic records above and use the same
+ * key-version discriminator, but are framed differently. A key is prefixed with
+ * its record type and is not flexible. A value is prefixed with its own version
+ * and is flexible, so it carries compact strings and arrays plus a trailing
+ * tagged-fields section. Each value keeps `unknown_tags` so tags written by a
+ * newer version survive a round-trip.
+ */
+
+/// A member's state in the reconciliation FSM, as persisted in
+/// `consumer_group_current_member_assignment_value::state`. Byte values are
+/// Kafka's (org.apache.kafka.coordinator.group.modern.MemberState). An
+/// unrecognized byte decodes to itself rather than being rejected.
+enum class consumer_group_member_state : int8_t {
+    stable = 0,
+    unrevoked_partitions = 1,
+    unreleased_partitions = 2,
+    unknown = 127,
+};
+
+fmt::iterator format_to(const consumer_group_member_state&, fmt::iterator);
+
+struct consumer_group_metadata_key {
+    static constexpr group_metadata_version version{3};
+    kafka::group_id group_id;
+
+    fmt::iterator format_to(fmt::iterator it) const;
+    friend bool operator==(
+      const consumer_group_metadata_key&,
+      const consumer_group_metadata_key&) = default;
+    static consumer_group_metadata_key decode(protocol::decoder&);
+    static void encode(protocol::encoder&, const consumer_group_metadata_key&);
+};
+
+/// The group epoch, and the hash that detects subscription-metadata changes.
+struct consumer_group_metadata_value {
+    static constexpr group_metadata_version version{0};
+    int32_t epoch{0};
+    /// Hash over the subscribed topics' metadata, which detects subscription
+    /// changes. Tagged field 0; not written when 0.
+    int64_t metadata_hash{0};
+    tagged_fields unknown_tags;
+
+    fmt::iterator format_to(fmt::iterator it) const;
+    friend bool operator==(
+      const consumer_group_metadata_value&,
+      const consumer_group_metadata_value&) = default;
+    static consumer_group_metadata_value decode(protocol::decoder&);
+    static void
+    encode(protocol::encoder&, const consumer_group_metadata_value&);
+};
+
+/// One protocol a classic-protocol member supports. Not written until
+/// classic-to-consumer migration exists.
+struct classic_protocol {
+    kafka::protocol_name name;
+    bytes metadata;
+    tagged_fields unknown_tags;
+
+    fmt::iterator format_to(fmt::iterator it) const;
+    friend bool
+    operator==(const classic_protocol&, const classic_protocol&) = default;
+    static classic_protocol decode(protocol::decoder&);
+    static void encode(protocol::encoder&, const classic_protocol&);
+};
+
+/// A classic-protocol member's session timeout and supported protocols. Absent
+/// for a consumer-protocol member.
+struct classic_member_metadata {
+    std::chrono::milliseconds session_timeout{};
+    chunked_vector<classic_protocol> supported_protocols;
+    tagged_fields unknown_tags;
+
+    classic_member_metadata copy() const;
+    fmt::iterator format_to(fmt::iterator it) const;
+    friend bool operator==(
+      const classic_member_metadata&, const classic_member_metadata&) = default;
+    static classic_member_metadata decode(protocol::decoder&);
+    static void encode(protocol::encoder&, const classic_member_metadata&);
+};
+
+struct consumer_group_member_metadata_key {
+    static constexpr group_metadata_version version{5};
+    kafka::group_id group_id;
+    kafka::member_id member_id;
+
+    fmt::iterator format_to(fmt::iterator it) const;
+    friend bool operator==(
+      const consumer_group_member_metadata_key&,
+      const consumer_group_member_metadata_key&) = default;
+    static consumer_group_member_metadata_key decode(protocol::decoder&);
+    static void
+    encode(protocol::encoder&, const consumer_group_member_metadata_key&);
+};
+
+/// A member's subscription, rack, and chosen assignor.
+struct consumer_group_member_metadata_value {
+    static constexpr group_metadata_version version{0};
+    std::optional<kafka::group_instance_id> instance_id;
+    std::optional<model::rack_id> rack_id;
+    kafka::client_id client_id;
+    kafka::client_host client_host;
+    chunked_vector<model::topic> subscribed_topic_names;
+    std::optional<ss::sstring> subscribed_topic_regex;
+    std::chrono::milliseconds rebalance_timeout{-1};
+    std::optional<ss::sstring> server_assignor;
+    /// Tagged field 0. Null is written explicitly and the default is omitted,
+    /// so the default here must be present for an omitted tag to round-trip.
+    std::optional<classic_member_metadata> classic_metadata{std::in_place};
+    tagged_fields unknown_tags;
+
+    consumer_group_member_metadata_value copy() const;
+    fmt::iterator format_to(fmt::iterator it) const;
+    friend bool operator==(
+      const consumer_group_member_metadata_value&,
+      const consumer_group_member_metadata_value&) = default;
+    static consumer_group_member_metadata_value decode(protocol::decoder&);
+    static void
+    encode(protocol::encoder&, const consumer_group_member_metadata_value&);
+};
+
+struct consumer_group_target_assignment_metadata_key {
+    static constexpr group_metadata_version version{6};
+    kafka::group_id group_id;
+
+    fmt::iterator format_to(fmt::iterator it) const;
+    friend bool operator==(
+      const consumer_group_target_assignment_metadata_key&,
+      const consumer_group_target_assignment_metadata_key&) = default;
+    static consumer_group_target_assignment_metadata_key
+    decode(protocol::decoder&);
+    static void encode(
+      protocol::encoder&, const consumer_group_target_assignment_metadata_key&);
+};
+
+/// The group epoch the current target assignment was computed at.
+struct consumer_group_target_assignment_metadata_value {
+    static constexpr group_metadata_version version{0};
+    int32_t assignment_epoch{0};
+    /// Tagged field 0; not written when 0.
+    int64_t assignment_timestamp{0};
+    tagged_fields unknown_tags;
+
+    fmt::iterator format_to(fmt::iterator it) const;
+    friend bool operator==(
+      const consumer_group_target_assignment_metadata_value&,
+      const consumer_group_target_assignment_metadata_value&) = default;
+    static consumer_group_target_assignment_metadata_value
+    decode(protocol::decoder&);
+    static void encode(
+      protocol::encoder&,
+      const consumer_group_target_assignment_metadata_value&);
+};
+
+/// One topic's share of a member's target assignment.
+struct target_assignment_topic_partitions {
+    model::topic_id topic_id;
+    chunked_vector<model::partition_id> partitions;
+    tagged_fields unknown_tags;
+
+    target_assignment_topic_partitions copy() const;
+    fmt::iterator format_to(fmt::iterator it) const;
+    friend bool operator==(
+      const target_assignment_topic_partitions&,
+      const target_assignment_topic_partitions&) = default;
+    static target_assignment_topic_partitions decode(protocol::decoder&);
+    static void
+    encode(protocol::encoder&, const target_assignment_topic_partitions&);
+};
+
+struct consumer_group_target_assignment_member_key {
+    static constexpr group_metadata_version version{7};
+    kafka::group_id group_id;
+    kafka::member_id member_id;
+
+    fmt::iterator format_to(fmt::iterator it) const;
+    friend bool operator==(
+      const consumer_group_target_assignment_member_key&,
+      const consumer_group_target_assignment_member_key&) = default;
+    static consumer_group_target_assignment_member_key
+    decode(protocol::decoder&);
+    static void encode(
+      protocol::encoder&, const consumer_group_target_assignment_member_key&);
+};
+
+/// The partitions the assignor wants a member to own.
+struct consumer_group_target_assignment_member_value {
+    static constexpr group_metadata_version version{0};
+    chunked_vector<target_assignment_topic_partitions> topic_partitions;
+    tagged_fields unknown_tags;
+
+    consumer_group_target_assignment_member_value copy() const;
+    fmt::iterator format_to(fmt::iterator it) const;
+    friend bool operator==(
+      const consumer_group_target_assignment_member_value&,
+      const consumer_group_target_assignment_member_value&) = default;
+    static consumer_group_target_assignment_member_value
+    decode(protocol::decoder&);
+    static void encode(
+      protocol::encoder&, const consumer_group_target_assignment_member_value&);
+};
+
+/// One topic's share of a member's current assignment. `assignment_epochs` is
+/// parallel to `partitions`, holding the epoch each was assigned at, which
+/// fences a stale offset commit.
+struct current_assignment_topic_partitions {
+    model::topic_id topic_id;
+    chunked_vector<model::partition_id> partitions;
+    /// Tagged field 0. Null is written explicitly and empty is omitted, so the
+    /// default here must be present for an omitted tag to round-trip.
+    std::optional<chunked_vector<int32_t>> assignment_epochs{std::in_place};
+    tagged_fields unknown_tags;
+
+    current_assignment_topic_partitions copy() const;
+    fmt::iterator format_to(fmt::iterator it) const;
+    friend bool operator==(
+      const current_assignment_topic_partitions&,
+      const current_assignment_topic_partitions&) = default;
+    static current_assignment_topic_partitions decode(protocol::decoder&);
+    static void
+    encode(protocol::encoder&, const current_assignment_topic_partitions&);
+};
+
+struct consumer_group_current_member_assignment_key {
+    static constexpr group_metadata_version version{8};
+    kafka::group_id group_id;
+    kafka::member_id member_id;
+
+    fmt::iterator format_to(fmt::iterator it) const;
+    friend bool operator==(
+      const consumer_group_current_member_assignment_key&,
+      const consumer_group_current_member_assignment_key&) = default;
+    static consumer_group_current_member_assignment_key
+    decode(protocol::decoder&);
+    static void encode(
+      protocol::encoder&, const consumer_group_current_member_assignment_key&);
+};
+
+/// How far a member has converged on its target, and what it still owes. Its
+/// epoch reaches the assignment epoch only once it owes nothing.
+struct consumer_group_current_member_assignment_value {
+    static constexpr group_metadata_version version{0};
+    int32_t member_epoch{0};
+    /// The epoch to accept if the member never saw the last bump.
+    int32_t previous_member_epoch{0};
+    consumer_group_member_state state{consumer_group_member_state::unknown};
+    chunked_vector<current_assignment_topic_partitions> assigned_partitions;
+    chunked_vector<current_assignment_topic_partitions>
+      partitions_pending_revocation;
+    tagged_fields unknown_tags;
+
+    consumer_group_current_member_assignment_value copy() const;
+    fmt::iterator format_to(fmt::iterator it) const;
+    friend bool operator==(
+      const consumer_group_current_member_assignment_value&,
+      const consumer_group_current_member_assignment_value&) = default;
+    static consumer_group_current_member_assignment_value
+    decode(protocol::decoder&);
+    static void encode(
+      protocol::encoder&,
+      const consumer_group_current_member_assignment_value&);
+};
+
+/*
+ * A record as it sits on the log, for each of the types above. No value means a
+ * tombstone. `group_metadata_serializer` converts between these and
+ * `model::record`.
+ */
+struct consumer_group_metadata_kv {
+    consumer_group_metadata_key key;
+    std::optional<consumer_group_metadata_value> value;
+};
+
+struct consumer_group_member_metadata_kv {
+    consumer_group_member_metadata_key key;
+    std::optional<consumer_group_member_metadata_value> value;
+
+    consumer_group_member_metadata_kv copy() const;
+};
+
+struct consumer_group_target_assignment_metadata_kv {
+    consumer_group_target_assignment_metadata_key key;
+    std::optional<consumer_group_target_assignment_metadata_value> value;
+};
+
+struct consumer_group_target_assignment_member_kv {
+    consumer_group_target_assignment_member_key key;
+    std::optional<consumer_group_target_assignment_member_value> value;
+
+    consumer_group_target_assignment_member_kv copy() const;
+};
+
+struct consumer_group_current_member_assignment_kv {
+    consumer_group_current_member_assignment_key key;
+    std::optional<consumer_group_current_member_assignment_value> value;
+
+    consumer_group_current_member_assignment_kv copy() const;
+};
+
 struct group_block_info
   : serde::
       envelope<group_block_info, serde::version<0>, serde::compat_version<0>> {
@@ -209,6 +517,22 @@ key_value to_kv(group_metadata_kv md);
 key_value to_kv(offset_metadata_kv md);
 group_metadata_kv decode_group_metadata(model::record record);
 offset_metadata_kv decode_offset_metadata(model::record record);
+
+key_value to_kv(consumer_group_metadata_kv md);
+key_value to_kv(consumer_group_member_metadata_kv md);
+key_value to_kv(consumer_group_target_assignment_metadata_kv md);
+key_value to_kv(consumer_group_target_assignment_member_kv md);
+key_value to_kv(consumer_group_current_member_assignment_kv md);
+
+consumer_group_metadata_kv decode_consumer_group_metadata(model::record);
+consumer_group_member_metadata_kv
+  decode_consumer_group_member_metadata(model::record);
+consumer_group_target_assignment_metadata_kv
+  decode_consumer_group_target_assignment_metadata(model::record);
+consumer_group_target_assignment_member_kv
+  decode_consumer_group_target_assignment_member(model::record);
+consumer_group_current_member_assignment_kv
+  decode_consumer_group_current_member_assignment(model::record);
 }; // namespace group_metadata_serializer
 
 namespace group_tx {

--- a/src/v/kafka/server/group_recovery_consumer.cc
+++ b/src/v/kafka/server/group_recovery_consumer.cc
@@ -203,6 +203,14 @@ void group_recovery_consumer::handle_record(model::record r) {
         case noop:
             // ignore noops, they are handled for backward compatibility
             return;
+        // Recovery here rebuilds classic groups only; consumer-protocol groups
+        // recover by log replay through consumer_group_stm::do_apply.
+        case consumer_group_metadata:
+        case consumer_group_member_metadata:
+        case consumer_group_target_assignment_metadata:
+        case consumer_group_target_assignment_member:
+        case consumer_group_current_member_assignment:
+            return;
         }
         __builtin_unreachable();
     } catch (...) {

--- a/src/v/kafka/server/group_tx_tracker_stm.cc
+++ b/src/v/kafka/server/group_tx_tracker_stm.cc
@@ -219,6 +219,15 @@ ss::future<> group_tx_tracker_stm::handle_raft_data(model::record_batch batch) {
         switch (record_type) {
         case offset_commit:
         case noop:
+        // Consumer-protocol group state belongs to consumer_group_stm, which
+        // bounds those groups' open transactions itself. This STM registers a
+        // group only from a classic group_metadata record, so it never matches
+        // a fence against one.
+        case consumer_group_metadata:
+        case consumer_group_member_metadata:
+        case consumer_group_target_assignment_metadata:
+        case consumer_group_target_assignment_member:
+        case consumer_group_current_member_assignment:
             return;
         case group_metadata:
             handle_group_metadata(

--- a/src/v/kafka/server/protocol_utils.cc
+++ b/src/v/kafka/server/protocol_utils.cc
@@ -127,7 +127,7 @@ scattered_buffer response_as_scattered(response_ptr response) {
     if (response->is_flexible()) {
         protocol::encoder writer(tags_header);
         vassert(response->tags(), "If flexible, tags should be filled");
-        writer.write_tags(std::move(*response->tags()));
+        writer.write_tags(*response->tags());
     }
     const auto size = static_cast<int32_t>(
       sizeof(response->correlation()) + tags_header.size_bytes()

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -680,6 +680,7 @@ redpanda_cc_btest(
     deps = [
         "//src/v/bytes",
         "//src/v/cluster:fwd",
+        "//src/v/container:chunked_vector",
         "//src/v/kafka/protocol",
         "//src/v/kafka/server",
         "//src/v/model",
@@ -688,6 +689,7 @@ redpanda_cc_btest(
         "//src/v/storage:record_batch_builder",
         "//src/v/test_utils:random_bytes",
         "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:uuid",
         "@boost//:range",
         "@boost//:test",
         "@seastar",

--- a/src/v/kafka/server/tests/group_metadata_serialization_test.cc
+++ b/src/v/kafka/server/tests/group_metadata_serialization_test.cc
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0
 
 #include "bytes/bytes.h"
+#include "container/chunked_vector.h"
 #include "kafka/protocol/wire.h"
 #include "kafka/server/group_metadata.h"
 #include "kafka/server/server.h"
@@ -21,6 +22,7 @@
 #include "storage/record_batch_builder.h"
 #include "test_utils/boost_fixture.h"
 #include "test_utils/random_bytes.h"
+#include "utils/uuid.h"
 
 #include <seastar/core/sstring.hh>
 #include <seastar/util/log.hh>
@@ -262,4 +264,620 @@ FIXTURE_TEST(test_unwrapping_tombstones_from_iobuf, fixture) {
 
     BOOST_REQUIRE_EQUAL(offset_key, offset_md_kv.key);
     BOOST_REQUIRE_EQUAL(offset_key, iobuf_offset_md_kv.key);
+}
+
+/*
+ * ConsumerGroup* records (KIP-848).
+ */
+
+template<typename T>
+chunked_vector<T> random_vector(size_t min, size_t max, auto&& generator) {
+    chunked_vector<T> ret;
+    for ([[maybe_unused]] auto i :
+         boost::irange(size_t{0}, random_generators::get_int(min, max))) {
+        ret.push_back(generator());
+    }
+    return ret;
+}
+
+kafka::classic_protocol random_classic_protocol() {
+    return kafka::classic_protocol{
+      .name = random_named_string<kafka::protocol_name>(),
+      .metadata = tests::random_bytes(),
+    };
+}
+
+kafka::classic_member_metadata random_classic_member_metadata() {
+    return kafka::classic_member_metadata{
+      .session_timeout = random_named_int<std::chrono::milliseconds>(),
+      .supported_protocols = random_vector<kafka::classic_protocol>(
+        1, 3, random_classic_protocol),
+    };
+}
+
+kafka::consumer_group_member_metadata_value
+random_consumer_group_member_metadata_value() {
+    kafka::consumer_group_member_metadata_value value{
+      .instance_id = random_optional<kafka::group_instance_id>(),
+      .rack_id = random_optional<model::rack_id>(),
+      .client_id = random_named_string<kafka::client_id>(),
+      .client_host = random_named_string<kafka::client_host>(),
+      .subscribed_topic_names = random_vector<model::topic>(
+        0, 4, random_named_string<model::topic>),
+      .subscribed_topic_regex = random_optional<ss::sstring>(),
+      .rebalance_timeout = random_named_int<std::chrono::milliseconds>(),
+      .server_assignor = random_optional<ss::sstring>(),
+    };
+    if (random_generators::get_int(10) < 5) {
+        value.classic_metadata = random_classic_member_metadata();
+    }
+    return value;
+}
+
+chunked_vector<model::partition_id> random_partitions() {
+    return random_vector<model::partition_id>(
+      1, 5, random_named_int<model::partition_id>);
+}
+
+kafka::target_assignment_topic_partitions
+random_target_assignment_topic_partitions() {
+    return kafka::target_assignment_topic_partitions{
+      .topic_id = model::topic_id::create(),
+      .partitions = random_partitions(),
+    };
+}
+
+/// Kafka keeps the epochs parallel to the partitions they fence.
+chunked_vector<int32_t> random_epochs(size_t count) {
+    return random_vector<int32_t>(
+      count, count, [] { return random_generators::get_int(1000); });
+}
+
+kafka::current_assignment_topic_partitions
+random_current_assignment_topic_partitions() {
+    kafka::current_assignment_topic_partitions ret{
+      .topic_id = model::topic_id::create(),
+      .partitions = random_partitions(),
+    };
+    if (random_generators::get_int(10) < 5) {
+        ret.assignment_epochs = random_epochs(ret.partitions.size());
+    }
+    return ret;
+}
+
+kafka::consumer_group_current_member_assignment_value
+random_current_member_assignment_value() {
+    return kafka::consumer_group_current_member_assignment_value{
+      .member_epoch = random_generators::get_int(1000),
+      .previous_member_epoch = random_generators::get_int(1000),
+      .state = random_generators::random_choice(
+        {kafka::consumer_group_member_state::stable,
+         kafka::consumer_group_member_state::unrevoked_partitions,
+         kafka::consumer_group_member_state::unreleased_partitions}),
+      .assigned_partitions
+      = random_vector<kafka::current_assignment_topic_partitions>(
+        0, 3, random_current_assignment_topic_partitions),
+      .partitions_pending_revocation
+      = random_vector<kafka::current_assignment_topic_partitions>(
+        0, 3, random_current_assignment_topic_partitions),
+    };
+}
+
+FIXTURE_TEST(consumer_group_metadata_rt_test, fixture) {
+    roundtrip_test(
+      kafka::consumer_group_metadata_key{
+        .group_id = random_named_string<kafka::group_id>()});
+    // metadata_hash is a tagged field, so exercise both present and absent.
+    roundtrip_test(
+      kafka::consumer_group_metadata_value{
+        .epoch = random_generators::get_int(1000), .metadata_hash = 0});
+    roundtrip_test(
+      kafka::consumer_group_metadata_value{
+        .epoch = random_generators::get_int(1000),
+        .metadata_hash = random_generators::get_int<int64_t>(1, 1000000)});
+
+    roundtrip_test(random_classic_protocol());
+    roundtrip_test(random_classic_member_metadata());
+    roundtrip_test(
+      kafka::consumer_group_member_metadata_key{
+        .group_id = random_named_string<kafka::group_id>(),
+        .member_id = random_named_string<kafka::member_id>()});
+    // null, default and populated classic_metadata take three different wire
+    // forms: a tag holding a null marker, an omitted tag, and a tag holding the
+    // struct.
+    auto member_metadata = random_consumer_group_member_metadata_value();
+    member_metadata.classic_metadata = std::nullopt;
+    roundtrip_test(member_metadata);
+    member_metadata.classic_metadata = kafka::classic_member_metadata{};
+    roundtrip_test(member_metadata);
+    member_metadata.classic_metadata = random_classic_member_metadata();
+    roundtrip_test(member_metadata);
+
+    roundtrip_test(
+      kafka::consumer_group_target_assignment_metadata_key{
+        .group_id = random_named_string<kafka::group_id>()});
+    roundtrip_test(
+      kafka::consumer_group_target_assignment_metadata_value{
+        .assignment_epoch = random_generators::get_int(1000),
+        .assignment_timestamp = 0});
+    roundtrip_test(
+      kafka::consumer_group_target_assignment_metadata_value{
+        .assignment_epoch = random_generators::get_int(1000),
+        .assignment_timestamp = model::timestamp::now().value()});
+
+    roundtrip_test(random_target_assignment_topic_partitions());
+    roundtrip_test(
+      kafka::consumer_group_target_assignment_member_key{
+        .group_id = random_named_string<kafka::group_id>(),
+        .member_id = random_named_string<kafka::member_id>()});
+    roundtrip_test(
+      kafka::consumer_group_target_assignment_member_value{
+        .topic_partitions
+        = random_vector<kafka::target_assignment_topic_partitions>(
+          0, 3, random_target_assignment_topic_partitions)});
+
+    // Likewise for null, empty and populated assignment_epochs: a tag holding a
+    // null marker, an omitted tag, and a tag holding the array.
+    auto assigned = random_current_assignment_topic_partitions();
+    assigned.assignment_epochs = std::nullopt;
+    roundtrip_test(assigned);
+    assigned.assignment_epochs = chunked_vector<int32_t>{};
+    roundtrip_test(assigned);
+    assigned.assignment_epochs = random_epochs(assigned.partitions.size());
+    roundtrip_test(assigned);
+
+    roundtrip_test(
+      kafka::consumer_group_current_member_assignment_key{
+        .group_id = random_named_string<kafka::group_id>(),
+        .member_id = random_named_string<kafka::member_id>()});
+    roundtrip_test(random_current_member_assignment_value());
+}
+
+FIXTURE_TEST(test_consumer_group_key_versions, fixture) {
+    auto type_of = [](auto kv) {
+        return kafka::group_metadata_serializer::get_metadata_type(
+          kafka::group_metadata_serializer::to_kv(std::move(kv)).key);
+    };
+    auto group_id = random_named_string<kafka::group_id>();
+    auto member_id = random_named_string<kafka::member_id>();
+
+    BOOST_REQUIRE_EQUAL(
+      type_of(kafka::consumer_group_metadata_kv{.key = {.group_id = group_id}}),
+      kafka::group_metadata_type::consumer_group_metadata);
+    BOOST_REQUIRE_EQUAL(
+      type_of(
+        kafka::consumer_group_member_metadata_kv{
+          .key = {.group_id = group_id, .member_id = member_id}}),
+      kafka::group_metadata_type::consumer_group_member_metadata);
+    BOOST_REQUIRE_EQUAL(
+      type_of(
+        kafka::consumer_group_target_assignment_metadata_kv{
+          .key = {.group_id = group_id}}),
+      kafka::group_metadata_type::consumer_group_target_assignment_metadata);
+    BOOST_REQUIRE_EQUAL(
+      type_of(
+        kafka::consumer_group_target_assignment_member_kv{
+          .key = {.group_id = group_id, .member_id = member_id}}),
+      kafka::group_metadata_type::consumer_group_target_assignment_member);
+    BOOST_REQUIRE_EQUAL(
+      type_of(
+        kafka::consumer_group_current_member_assignment_kv{
+          .key = {.group_id = group_id, .member_id = member_id}}),
+      kafka::group_metadata_type::consumer_group_current_member_assignment);
+
+    // The classic records must keep their own versions.
+    BOOST_REQUIRE_EQUAL(
+      type_of(kafka::group_metadata_kv{.key = {.group_id = group_id}}),
+      kafka::group_metadata_type::group_metadata);
+    BOOST_REQUIRE_EQUAL(
+      type_of(
+        kafka::offset_metadata_kv{
+          .key
+          = {.group_id = group_id, .topic = random_named_string<model::topic>(), .partition = random_named_int<model::partition_id>()}}),
+      kafka::group_metadata_type::offset_commit);
+
+    // Kafka's ConsumerGroupPartitionMetadata (key version 4) is deprecated and
+    // never written by us, so it stays undecodable.
+    iobuf key_v4;
+    kafka::protocol::encoder writer(key_v4);
+    writer.write(int16_t{4});
+    writer.write(group_id);
+    BOOST_REQUIRE_THROW(
+      kafka::group_metadata_serializer::get_metadata_type(key_v4.copy()),
+      std::invalid_argument);
+}
+
+namespace {
+
+/// A consumer_group_metadata_value up to its tagged-fields section, then
+/// whatever varints the caller wants in place of a well-formed one.
+iobuf truncated_value(std::initializer_list<uint32_t> varints) {
+    iobuf buffer;
+    kafka::protocol::encoder writer(buffer);
+    writer.write(int16_t{0});
+    writer.write(int32_t{7});
+    for (auto v : varints) {
+        writer.write_unsigned_varint(v);
+    }
+    return buffer;
+}
+
+} // namespace
+
+FIXTURE_TEST(test_consumer_group_tag_section_bounds, fixture) {
+    // A count with nothing behind it. Any non-zero count fails the same way,
+    // since the buffer ends where the count does.
+    kafka::protocol::decoder too_many_tags(truncated_value({
+      127, /* count=127 */
+           /* no more bytes! ERROR */
+    }));
+    BOOST_REQUIRE_THROW(
+      kafka::consumer_group_metadata_value::decode(too_many_tags),
+      std::out_of_range);
+
+    // Three bytes behind a count of two: enough for one entry's id and size,
+    // one short of a second. A naive count-against-bytes check would let this
+    // through, since 2 <= 3; the floor of two bytes per entry catches it.
+    kafka::protocol::decoder count_exceeds_two_bytes_each(truncated_value({
+      2, /* count=2, so at least four bytes must follow! ERROR */
+      5, /* tag=5 */
+      0, /* size=0, entry one is complete */
+      6, /* entry two's tag, with no size byte left for it */
+    }));
+    BOOST_REQUIRE_THROW(
+      kafka::consumer_group_metadata_value::decode(
+        count_exceeds_two_bytes_each),
+      std::out_of_range);
+
+    // One unknown tag claiming a 127 byte payload, with none present. Unknown
+    // because that is the path where the size reaches read_bytes.
+    kafka::protocol::decoder oversized_payload(truncated_value({
+      1,   /* count=1  */
+      9,   /* tag=9 */
+      127, /*size=127*/
+           /* no more bytes! ERROR */
+    }));
+    BOOST_REQUIRE_THROW(
+      kafka::consumer_group_metadata_value::decode(oversized_payload),
+      std::out_of_range);
+
+    // Tag 5 twice with *different* payloads: the encoding the ascending-order
+    // rule exists to reject, since accepting it would leave which of the two
+    // values wins up to the reader. Every length here is honest, so this passes
+    // all the size checks and is malformed only in its ordering. Tag 5 rather
+    // than 0 so the payloads reach consume_unknown_tag instead of a known
+    // handler expecting an int64.
+    kafka::protocol::decoder duplicate_tag(truncated_value({
+      2, /* count=2 */
+      5, /* tag=5 */
+      2, /* size=2 */
+      1, /* payload[0] */
+      2, /* payload[1] */
+      5, /* tag=5 again! ERROR */
+      2, /* size=2 */
+      3, /* payload[0], a different value under the same tag */
+      4, /* payload[1] */
+    }));
+    BOOST_REQUIRE_THROW(
+      kafka::consumer_group_metadata_value::decode(duplicate_tag),
+      std::out_of_range);
+
+    // Descending ids, rejected by the same comparison. Worth having alongside
+    // the duplicate: these ids are distinct, so consume_unknown_tag would store
+    // both without complaint and the record would decode, where a repeated id
+    // trips its duplicate-key check regardless of the ordering.
+    kafka::protocol::decoder descending_tags(truncated_value({
+      2, /* count=2 */
+      5, /* tag=5 */
+      2, /* size=2 */
+      1, /* payload[0] */
+      2, /* payload[1] */
+      3, /* tag=3, lower than 5! ERROR */
+      2, /* size=2 */
+      3, /* payload[0] */
+      4, /* payload[1] */
+    }));
+    BOOST_REQUIRE_THROW(
+      kafka::consumer_group_metadata_value::decode(descending_tags),
+      std::out_of_range);
+}
+
+FIXTURE_TEST(test_consumer_group_tag_size_mismatch, fixture) {
+    // Tag 0 is consumer_group_metadata_value's metadata_hash, so the handler
+    // reads exactly the eight bytes of an int64 whatever the size says.
+
+    // Nine bytes declared and present, eight of them read. All the sizes here
+    // are within bounds, so nothing else objects: the loop simply ends with a
+    // byte of the payload unread.
+    kafka::protocol::decoder over_declared(truncated_value({
+      1, /* count=1 */
+      0, /* tag=0, metadata_hash */
+      9, /* size=9, one more byte than an int64! ERROR */
+      1, /* payload[0] */
+      2, /* payload[1] */
+      3, /* payload[2] */
+      4, /* payload[3] */
+      5, /* payload[4] */
+      6, /* payload[5] */
+      7, /* payload[6] */
+      8, /* payload[7] */
+      9, /* payload[8], past where the handler stops */
+    }));
+    BOOST_REQUIRE_THROW(
+      kafka::consumer_group_metadata_value::decode(over_declared),
+      std::out_of_range);
+
+    // Four bytes declared, eight read. The handler runs off the end of its own
+    // payload and into whatever follows, which for a real record is the next
+    // entry's tag id.
+    kafka::protocol::decoder under_declared(truncated_value({
+      1, /* count=1 */
+      0, /* tag=0, metadata_hash */
+      4, /* size=4, half an int64! ERROR */
+      1, /* payload[0] */
+      2, /* payload[1] */
+      3, /* payload[2] */
+      4, /* payload[3] */
+      5, /* the handler reads these four as well */
+      6,
+      7,
+      8,
+    }));
+    BOOST_REQUIRE_THROW(
+      kafka::consumer_group_metadata_value::decode(under_declared),
+      std::out_of_range);
+}
+
+FIXTURE_TEST(test_consumer_group_serializer, fixture) {
+    auto member_value = random_consumer_group_member_metadata_value();
+    auto member_kv = kafka::consumer_group_member_metadata_kv{
+      .key
+      = {.group_id = random_named_string<kafka::group_id>(), .member_id = random_named_string<kafka::member_id>()},
+      .value = member_value.copy()};
+
+    auto decoded
+      = kafka::group_metadata_serializer::decode_consumer_group_member_metadata(
+        to_record(kafka::group_metadata_serializer::to_kv(member_kv.copy())));
+
+    BOOST_REQUIRE_EQUAL(member_kv.key, decoded.key);
+    BOOST_REQUIRE_EQUAL(member_value, decoded.value);
+
+    // A tombstone carries the key only.
+    auto tombstone_kv = kafka::group_metadata_serializer::to_kv(
+      kafka::consumer_group_current_member_assignment_kv{
+        .key = {
+          .group_id = random_named_string<kafka::group_id>(),
+          .member_id = random_named_string<kafka::member_id>()}});
+    auto tombstone = kafka::group_metadata_serializer::
+      decode_consumer_group_current_member_assignment(
+        build_tombstone_record(tombstone_kv.key.copy()));
+    BOOST_REQUIRE(!tombstone.value.has_value());
+}
+
+template<typename T>
+ss::sstring encode_to_hex(const T& value) {
+    iobuf buffer;
+    kafka::protocol::encoder writer(buffer);
+    T::encode(writer, value);
+    return to_hex(iobuf_to_bytes(buffer));
+}
+
+/*
+ * Byte-shape checks against Kafka's encoding of the same records: a key is
+ * prefixed with its record type and written non-flex (int16-length strings), a
+ * value is prefixed with its own version and written flex (compact
+ * strings/arrays, unsigned-varint lengths of size+1) with a trailing
+ * tagged-fields section.
+ *
+ * Each expectation is the output of Kafka's generated serializer for the same
+ * logical record: the classes in org.apache.kafka.coordinator.group.generated
+ * run through MessageUtil.toVersionPrefixedBytes(), which is what
+ * GroupCoordinatorRecordSerde writes to __consumer_offsets.
+ *
+ * Regenerate with kafka_oracle/GroupRecordVectors.java when Kafka's
+ * ConsumerGroup*.json schemas move. Nothing does that automatically. The table
+ * below is in the order the harness prints, and each entry names the harness
+ * label that produced it, so its output can be diffed against this table.
+ */
+namespace vectors {
+
+/// consumer_group_metadata_key{g1}
+/// 0003 type | 0002 "g1"
+constexpr auto metadata_key = "000300026731";
+
+/// consumer_group_metadata_value{epoch=7,hash=0}
+/// 0000 version | 00000007 epoch | 00 no tags
+constexpr auto metadata_value = "00000000000700";
+
+/// consumer_group_metadata_value{epoch=7,hash=0x1122334455667788}
+/// ... | 01 one tag | 00 tag id | 08 size | hash
+constexpr auto metadata_value_with_hash = "0000000000070100081122334455667788";
+
+/// consumer_group_member_metadata_key{g1,m1}
+/// 0005 type | 0002 "g1" | 0002 "m1"
+constexpr auto member_metadata_key = "00050002673100026d31";
+
+/// consumer_group_member_metadata_value{c,h,[t],1000}
+/// 0000 version | 00 null instance_id | 00 null rack_id | 0263 "c" | 0268 "h" |
+/// 02 one topic | 0274 "t" | 00 null regex | 000003e8 timeout | 00 null
+/// assignor | 01 one tag | 00 tag id | 01 size | 00 absent struct
+constexpr auto member_metadata_value
+  = "000000000263026802027400000003e80001000100";
+
+/// consumer_group_member_metadata_value{+classic}
+/// The same with classic_metadata present: the tag payload becomes 01
+/// (present) followed by 00007530 timeout, 02 one protocol, 06 "range", 03 two
+/// metadata bytes, then the protocol's and the struct's own tags.
+constexpr auto member_metadata_value_with_classic
+  = "000000000263026802027400000003e8000100"
+    "110100007530020672616e67650301020000";
+
+/// target_assignment_metadata_key{g1}
+/// 0006 type | 0002 "g1"
+constexpr auto target_assignment_metadata_key = "000600026731";
+
+/// target_assignment_metadata_value{epoch=3,ts=0}
+/// 0000 version | 00000003 epoch | 00 no tags
+constexpr auto target_assignment_metadata_value = "00000000000300";
+
+/// target_assignment_member_key{g1,m1}
+/// 0007 type | 0002 "g1" | 0002 "m1"
+constexpr auto target_assignment_member_key = "00070002673100026d31";
+
+/// target_assignment_member_value{topic,[0]}
+/// 0000 version | 02 one topic (id | 02 one partition | 00000000 | 00 no tags)
+/// | 00 no tags
+constexpr auto target_assignment_member_value
+  = "0000020102030405060708090a0b0c0d0e0f1002000000000000";
+
+/// current_member_assignment_key{g1,m1}
+/// 0008 type | 0002 "g1" | 0002 "m1"
+constexpr auto current_member_assignment_key = "00080002673100026d31";
+
+/// current_member_assignment_value{epochs=[],[0]}
+/// Epochs present but empty: the tag is omitted entirely.
+constexpr auto current_member_assignment_empty_epochs
+  = "0000000000010000000000020102030405060708090a0b0c0d0e0f10"
+    "0200000000000100";
+
+/// current_member_assignment_value{1,0,stable,[0]}
+/// Epochs absent: tag 0 is written, carrying a one-byte null marker.
+constexpr auto current_member_assignment_absent_epochs
+  = "0000000000010000000000020102030405060708090a0b0c0d0e0f10"
+    "0200000000010001000100";
+
+/// current_member_assignment_value{epochs=[9],[5]}
+/// Epochs present and non-empty: the compact array rides in the tag payload.
+constexpr auto current_member_assignment_with_epochs
+  = "0000000000010000000000020102030405060708090a0b0c0d0e0f10"
+    "020000000501000502000000090100";
+
+} // namespace vectors
+
+FIXTURE_TEST(test_consumer_group_byte_shape, fixture) {
+    BOOST_REQUIRE_EQUAL(
+      encode_to_hex(
+        kafka::consumer_group_metadata_key{.group_id = kafka::group_id("g1")}),
+      vectors::metadata_key);
+
+    BOOST_REQUIRE_EQUAL(
+      encode_to_hex(
+        kafka::consumer_group_metadata_value{.epoch = 7, .metadata_hash = 0}),
+      vectors::metadata_value);
+
+    BOOST_REQUIRE_EQUAL(
+      encode_to_hex(
+        kafka::consumer_group_metadata_value{
+          .epoch = 7, .metadata_hash = 0x1122334455667788}),
+      vectors::metadata_value_with_hash);
+
+    BOOST_REQUIRE_EQUAL(
+      encode_to_hex(
+        kafka::consumer_group_member_metadata_key{
+          .group_id = kafka::group_id("g1"),
+          .member_id = kafka::member_id("m1")}),
+      vectors::member_metadata_key);
+
+    BOOST_REQUIRE_EQUAL(
+      encode_to_hex(
+        kafka::consumer_group_member_metadata_value{
+          .client_id = kafka::client_id("c"),
+          .client_host = kafka::client_host("h"),
+          .subscribed_topic_names = {model::topic("t")},
+          .rebalance_timeout = std::chrono::milliseconds(1000),
+          // Explicit, because the field defaults to present-and-default, which
+          // is the omitted form rather than this null marker.
+          .classic_metadata = std::nullopt}),
+      vectors::member_metadata_value);
+
+    chunked_vector<kafka::classic_protocol> protocols;
+    protocols.push_back(
+      kafka::classic_protocol{
+        .name = kafka::protocol_name("range"), .metadata = bytes{1, 2}});
+
+    auto with_classic_metadata = kafka::consumer_group_member_metadata_value{
+      .client_id = kafka::client_id("c"),
+      .client_host = kafka::client_host("h"),
+      .subscribed_topic_names = {model::topic("t")},
+      .rebalance_timeout = std::chrono::milliseconds(1000),
+      .classic_metadata = kafka::classic_member_metadata{
+        .session_timeout = std::chrono::milliseconds(30000),
+        .supported_protocols = std::move(protocols)}};
+
+    BOOST_REQUIRE_EQUAL(
+      encode_to_hex(with_classic_metadata),
+      vectors::member_metadata_value_with_classic);
+
+    BOOST_REQUIRE_EQUAL(
+      encode_to_hex(
+        kafka::consumer_group_target_assignment_metadata_key{
+          .group_id = kafka::group_id("g1")}),
+      vectors::target_assignment_metadata_key);
+
+    BOOST_REQUIRE_EQUAL(
+      encode_to_hex(
+        kafka::consumer_group_target_assignment_metadata_value{
+          .assignment_epoch = 3, .assignment_timestamp = 0}),
+      vectors::target_assignment_metadata_value);
+
+    auto topic_id = model::topic_id(uuid_t(
+      std::vector<uint8_t>{
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}));
+
+    BOOST_REQUIRE_EQUAL(
+      encode_to_hex(
+        kafka::consumer_group_target_assignment_member_key{
+          .group_id = kafka::group_id("g1"),
+          .member_id = kafka::member_id("m1")}),
+      vectors::target_assignment_member_key);
+
+    chunked_vector<kafka::target_assignment_topic_partitions> target;
+    target.push_back(
+      kafka::target_assignment_topic_partitions{
+        .topic_id = topic_id, .partitions = {model::partition_id(0)}});
+
+    auto target_value = kafka::consumer_group_target_assignment_member_value{
+      .topic_partitions = std::move(target)};
+
+    BOOST_REQUIRE_EQUAL(
+      encode_to_hex(target_value), vectors::target_assignment_member_value);
+
+    BOOST_REQUIRE_EQUAL(
+      encode_to_hex(
+        kafka::consumer_group_current_member_assignment_key{
+          .group_id = kafka::group_id("g1"),
+          .member_id = kafka::member_id("m1")}),
+      vectors::current_member_assignment_key);
+
+    // One assigned topic holding a single partition, with assignment_epochs in
+    // a given state.
+    auto assignment_of = [&topic_id](
+                           model::partition_id partition,
+                           std::optional<chunked_vector<int32_t>> epochs) {
+        chunked_vector<kafka::current_assignment_topic_partitions> assigned;
+        assigned.push_back(
+          kafka::current_assignment_topic_partitions{
+            .topic_id = topic_id,
+            .partitions = {partition},
+            .assignment_epochs = std::move(epochs)});
+        return kafka::consumer_group_current_member_assignment_value{
+          .member_epoch = 1,
+          .previous_member_epoch = 0,
+          .state = kafka::consumer_group_member_state::stable,
+          .assigned_partitions = std::move(assigned)};
+    };
+
+    BOOST_REQUIRE_EQUAL(
+      encode_to_hex(
+        assignment_of(model::partition_id(0), chunked_vector<int32_t>{})),
+      vectors::current_member_assignment_empty_epochs);
+
+    BOOST_REQUIRE_EQUAL(
+      encode_to_hex(assignment_of(model::partition_id(0), std::nullopt)),
+      vectors::current_member_assignment_absent_epochs);
+
+    BOOST_REQUIRE_EQUAL(
+      encode_to_hex(
+        assignment_of(model::partition_id(5), chunked_vector<int32_t>{9})),
+      vectors::current_member_assignment_with_epochs);
 }

--- a/src/v/kafka/server/tests/kafka_oracle/GroupRecordVectors.java
+++ b/src/v/kafka/server/tests/kafka_oracle/GroupRecordVectors.java
@@ -1,0 +1,204 @@
+// Prints the bytes Kafka's generated serializer produces for each consumer
+// group coordinator record, as hex. These are the expected values in
+// ../group_metadata_serialization_test.cc.
+//
+// Framing, per Kafka's GroupCoordinatorRecordSerde:
+//   key   = int16 apiKey       + key message at version 0
+//   value = int16 valueVersion + value message at that version
+//
+// Every field is set explicitly. The two sides disagree on defaults: Kafka's
+// generator defaults a nullable string with no declared default to "", while
+// the C++ defaults the corresponding optional to nullopt, and those encode
+// differently (0x01 against 0x00).
+//
+// Building Kafka needs a JDK, not just a JRE, or :generator:compileJava fails
+// with "does not provide the required capabilities: [JAVA_COMPILER]".
+//
+// clang-format off
+//   cd "$KAFKA" && ./gradlew :group-coordinator:jar :clients:jar :server-common:jar
+//   CP=$(find "$KAFKA" -path '*build/libs*' -name '*.jar' | tr '\n' ':')
+//   javac -cp "$CP" -d /tmp/vectors GroupRecordVectors.java
+//   java  -cp "$CP:/tmp/vectors" GroupRecordVectors
+// clang-format on
+//
+// Each line of output is `<label> <hex>`, and the hex drops straight into the
+// matching BOOST_REQUIRE_EQUAL in the test. Nothing re-runs this
+// automatically, so re-run it when Kafka's ConsumerGroup*.json schemas change.
+//
+// The committed vectors, and therefore the encoding our codec is pinned to,
+// were produced from Kafka at fce22525f7 (trunk, 4.4.0-SNAPSHOT). That commit
+// is the baseline for "have the schemas changed": without it the instruction
+// above has nothing to diff against.
+//
+// clang-format off
+//   git -C "$KAFKA" diff fce22525f7..trunk -- \
+//     group-coordinator/src/main/resources/common/message/'ConsumerGroup*.json'
+// clang-format on
+
+import java.util.List;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.protocol.Message;
+import org.apache.kafka.common.protocol.MessageUtil;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMetadataValue;
+
+public final class GroupRecordVectors {
+
+  // The 16 bytes 01..10, matching the C++ test's topic_id.
+  private static final Uuid TOPIC_ID
+      = new Uuid(0x0102030405060708L, 0x090a0b0c0d0e0f10L);
+
+  private static String hex(byte[] b) {
+    StringBuilder sb = new StringBuilder(b.length * 2);
+    for (byte x : b) {
+      sb.append(String.format("%02x", x));
+    }
+    return sb.toString();
+  }
+
+  private static void emit(String label, short prefix, Message m) {
+    System.out.printf(
+        "%-56s %s%n", label,
+        hex(MessageUtil.toVersionPrefixedBytes(prefix, m)));
+  }
+
+  public static void main(String[] args) {
+    // --- apiKey 3: ConsumerGroupMetadata ---
+    emit(
+        "consumer_group_metadata_key{g1}", (short)3,
+        new ConsumerGroupMetadataKey().setGroupId("g1"));
+
+    emit(
+        "consumer_group_metadata_value{epoch=7,hash=0}", (short)0,
+        new ConsumerGroupMetadataValue().setEpoch(7).setMetadataHash(0L));
+
+    emit(
+        "consumer_group_metadata_value{epoch=7,hash=0x1122334455667788}",
+        (short)0,
+        new ConsumerGroupMetadataValue().setEpoch(7).setMetadataHash(
+            0x1122334455667788L));
+
+    // --- apiKey 5: ConsumerGroupMemberMetadata ---
+    emit(
+        "consumer_group_member_metadata_key{g1,m1}", (short)5,
+        new ConsumerGroupMemberMetadataKey().setGroupId("g1").setMemberId(
+            "m1"));
+
+    emit(
+        "consumer_group_member_metadata_value{c,h,[t],1000}", (short)0,
+        new ConsumerGroupMemberMetadataValue()
+            .setInstanceId(null)
+            .setRackId(null)
+            .setClientId("c")
+            .setClientHost("h")
+            .setSubscribedTopicNames(List.of("t"))
+            .setSubscribedTopicRegex(null)
+            .setRebalanceTimeoutMs(1000)
+            .setServerAssignor(null)
+            .setClassicMemberMetadata(null));
+
+    // classic_metadata present: pins the presence-marker byte that precedes
+    // the struct inside the tag payload.
+    emit(
+        "consumer_group_member_metadata_value{+classic}", (short)0,
+        new ConsumerGroupMemberMetadataValue()
+            .setInstanceId(null)
+            .setRackId(null)
+            .setClientId("c")
+            .setClientHost("h")
+            .setSubscribedTopicNames(List.of("t"))
+            .setSubscribedTopicRegex(null)
+            .setRebalanceTimeoutMs(1000)
+            .setServerAssignor(null)
+            .setClassicMemberMetadata(
+                new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                    .setSessionTimeoutMs(30000)
+                    .setSupportedProtocols(List.of(
+                        new ConsumerGroupMemberMetadataValue.ClassicProtocol()
+                            .setName("range")
+                            .setMetadata(new byte[] {1, 2})))));
+
+    // --- apiKey 6: ConsumerGroupTargetAssignmentMetadata ---
+    emit(
+        "target_assignment_metadata_key{g1}", (short)6,
+        new ConsumerGroupTargetAssignmentMetadataKey().setGroupId("g1"));
+
+    emit(
+        "target_assignment_metadata_value{epoch=3,ts=0}", (short)0,
+        new ConsumerGroupTargetAssignmentMetadataValue()
+            .setAssignmentEpoch(3)
+            .setAssignmentTimestamp(0L));
+
+    // --- apiKey 7: ConsumerGroupTargetAssignmentMember ---
+    emit(
+        "target_assignment_member_key{g1,m1}", (short)7,
+        new ConsumerGroupTargetAssignmentMemberKey()
+            .setGroupId("g1")
+            .setMemberId("m1"));
+
+    emit(
+        "target_assignment_member_value{topic,[0]}", (short)0,
+        new ConsumerGroupTargetAssignmentMemberValue().setTopicPartitions(
+            List.of(
+                new ConsumerGroupTargetAssignmentMemberValue.TopicPartition()
+                    .setTopicId(TOPIC_ID)
+                    .setPartitions(List.of(0)))));
+
+    // --- apiKey 8: ConsumerGroupCurrentMemberAssignment ---
+    emit(
+        "current_member_assignment_key{g1,m1}", (short)8,
+        new ConsumerGroupCurrentMemberAssignmentKey()
+            .setGroupId("g1")
+            .setMemberId("m1"));
+
+    // Empty assignment_epochs: Kafka omits the tag.
+    emit(
+        "current_member_assignment_value{epochs=[],[0]}", (short)0,
+        new ConsumerGroupCurrentMemberAssignmentValue()
+            .setMemberEpoch(1)
+            .setPreviousMemberEpoch(0)
+            .setState((byte)0)
+            .setAssignedPartitions(List.of(
+                new ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions()
+                    .setTopicId(TOPIC_ID)
+                    .setPartitions(List.of(0))
+                    .setAssignmentEpochs(List.of())))
+            .setPartitionsPendingRevocation(List.of()));
+
+    // No assignment_epochs: the tagged field is absent.
+    emit(
+        "current_member_assignment_value{1,0,stable,[0]}", (short)0,
+        new ConsumerGroupCurrentMemberAssignmentValue()
+            .setMemberEpoch(1)
+            .setPreviousMemberEpoch(0)
+            .setState((byte)0)
+            .setAssignedPartitions(List.of(
+                new ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions()
+                    .setTopicId(TOPIC_ID)
+                    .setPartitions(List.of(0))
+                    .setAssignmentEpochs(null)))
+            .setPartitionsPendingRevocation(List.of()));
+
+    // Populated assignment_epochs, covering the nested struct's tagged field.
+    emit(
+        "current_member_assignment_value{epochs=[9],[5]}", (short)0,
+        new ConsumerGroupCurrentMemberAssignmentValue()
+            .setMemberEpoch(1)
+            .setPreviousMemberEpoch(0)
+            .setState((byte)0)
+            .setAssignedPartitions(List.of(
+                new ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions()
+                    .setTopicId(TOPIC_ID)
+                    .setPartitions(List.of(5))
+                    .setAssignmentEpochs(List.of(9))))
+            .setPartitionsPendingRevocation(List.of()));
+  }
+}


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Adds the five persisted record types for consumer-protocol groups on
__consumer_offsets, lifted from Kafka's coordinator schemas (apiKeys 3, 5, 6, 7,
8): group epoch plus the KIP-1101 metadata hash, member subscription,
target-assignment epoch and per-member target, and per-member current assignment.
Key version 4 is skipped because Kafka deprecated it in favour of the metadata hash.

The new key versions are added to the shared decoder, which requires teaching 
`group_tx_tracker` and `group_recovery_consumer` to skip them.

Byte compatibility with Kafka is enforced by vectors generated from Kafka's own
serializer rather than derived by hand; the generator is included. Nothing writes
these records yet, so there is no behavior change.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
