### PR TITLE
`kafka`: `group` optimizations

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -2198,7 +2198,8 @@ bool group::try_upsert_offset(
     }
 }
 
-group::offset_commit_stages group::store_offsets(offset_commit_request&& r) {
+std::optional<group::prepared_offset_commits>
+group::prepare_offset_commits(const offset_commit_request& r) {
     cluster::simple_batch_builder builder(
       model::record_batch_type::raft_data, model::offset(0));
 
@@ -2261,13 +2262,25 @@ group::offset_commit_stages group::store_offsets(offset_commit_request&& r) {
         }
     }
     if (builder.empty()) {
+        return std::nullopt;
+    }
+    return prepared_offset_commits{
+      .batch = std::move(builder).build(),
+      .commits = std::move(offset_commits),
+    };
+}
+
+group::offset_commit_stages group::store_offsets(offset_commit_request&& r) {
+    auto prepared = prepare_offset_commits(r);
+    if (!prepared) {
         vlog(_ctxlog.debug, "Empty offsets committed request");
         return offset_commit_stages(
           offset_commit_response(r, error_code::none));
     }
+    auto offset_commits = std::move(prepared->commits);
 
     auto replicate_stages = _partition->raft()->replicate_in_stages(
-      chunked_vector<model::record_batch>::single(std::move(builder).build()),
+      chunked_vector<model::record_batch>::single(std::move(prepared->batch)),
       raft::replicate_options(raft::consistency_level::quorum_ack, _term));
 
     auto f = replicate_stages.replicate_finished.then(

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1375,8 +1375,10 @@ void group::remove_pending_member(kafka::member_id member_id) {
 
 void group::pre_shutdown() {
     _probe.reset();
-    for (auto& p : _offsets) {
-        p.second->probe.reset();
+    for (auto& t : _offsets) {
+        for (auto& p : t.second) {
+            p.second->probe.reset();
+        }
     }
 }
 
@@ -2170,7 +2172,8 @@ void group::update_store_offset_builder(
 }
 bool group::try_upsert_offset(
   const model::topic_partition& tp, offset_metadata md) {
-    if (auto o_it = _offsets.find(tp); o_it != _offsets.end()) {
+    auto& partitions = _offsets[tp.topic];
+    if (auto o_it = partitions.find(tp.partition); o_it != partitions.end()) {
         if (o_it->second->metadata.log_offset < md.log_offset) {
             if (o_it->second->metadata.offset > md.offset) [[unlikely]] {
                 vlog(
@@ -2186,8 +2189,8 @@ bool group::try_upsert_offset(
         }
         return false;
     } else {
-        _offsets.emplace(
-          tp,
+        partitions.emplace(
+          tp.partition,
           std::make_unique<offset_metadata_with_probe>(
             std::move(md),
             _id,
@@ -2505,32 +2508,33 @@ group::handle_offset_fetch(offset_fetch_request_group r, bool require_stable) {
 
     // retrieve all topics available
     if (!r.topics) {
-        chunked_hash_map<
-          model::topic,
-          chunked_vector<offset_fetch_response_partitions>>
-          tmp;
-        for (const auto& e : _offsets) {
-            offset_fetch_response_partitions p = {
-              .partition_index = e.first.partition,
-              .committed_offset = model::offset(-1),
-              .metadata = "",
-              .error_code = error_code::none,
-            };
+        resp.topics.reserve(_offsets.size());
+        for (const auto& [topic, partitions] : _offsets) {
+            offset_fetch_response_topics t;
+            t.name = topic;
+            t.partitions.reserve(partitions.size());
+            for (const auto& [id, md] : partitions) {
+                offset_fetch_response_partitions p = {
+                  .partition_index = id,
+                  .committed_offset = model::offset(-1),
+                  .metadata = "",
+                  .error_code = error_code::none,
+                };
 
-            if (check_unstable && has_pending_transaction(e.first)) {
-                p.error_code = error_code::unstable_offset_commit;
-            } else {
-                p.committed_offset = e.second->metadata.offset;
-                p.committed_leader_epoch
-                  = e.second->metadata.committed_leader_epoch;
-                p.metadata = e.second->metadata.metadata;
+                if (
+                  check_unstable
+                  && has_pending_transaction(
+                    model::topic_partition(topic, id))) {
+                    p.error_code = error_code::unstable_offset_commit;
+                } else {
+                    p.committed_offset = md->metadata.offset;
+                    p.committed_leader_epoch
+                      = md->metadata.committed_leader_epoch;
+                    p.metadata = md->metadata.metadata;
+                }
+                t.partitions.push_back(std::move(p));
             }
-            tmp[e.first.topic].push_back(std::move(p));
-        }
-
-        for (auto& e : tmp) {
-            resp.topics.push_back(
-              {.name = e.first, .partitions = std::move(e.second)});
+            resp.topics.push_back(std::move(t));
         }
 
         return resp;
@@ -2540,9 +2544,9 @@ group::handle_offset_fetch(offset_fetch_request_group r, bool require_stable) {
     for (const auto& topic : *r.topics) {
         offset_fetch_response_topics t;
         t.name = topic.name;
+        t.partitions.reserve(topic.partition_indexes.size());
+        const auto t_it = _offsets.find(topic.name);
         for (auto id : topic.partition_indexes) {
-            model::topic_partition tp(topic.name, id);
-
             offset_fetch_response_partitions p = {
               .partition_index = id,
               .committed_offset = model::offset(-1),
@@ -2550,16 +2554,19 @@ group::handle_offset_fetch(offset_fetch_request_group r, bool require_stable) {
               .error_code = error_code::none,
             };
 
-            if (check_unstable && has_pending_transaction(tp)) {
+            if (
+              check_unstable
+              && has_pending_transaction(
+                model::topic_partition(topic.name, id))) {
                 p.error_code = error_code::unstable_offset_commit;
-            } else {
-                auto res = offset(tp);
-                if (res) {
-                    p.partition_index = id;
-                    p.committed_offset = res->offset;
-                    p.committed_leader_epoch = res->committed_leader_epoch;
-                    p.metadata = res->metadata;
-                    p.error_code = error_code::none;
+            } else if (t_it != _offsets.end()) {
+                if (
+                  auto p_it = t_it->second.find(id);
+                  p_it != t_it->second.end()) {
+                    p.committed_offset = p_it->second->metadata.offset;
+                    p.committed_leader_epoch
+                      = p_it->second->metadata.committed_leader_epoch;
+                    p.metadata = p_it->second->metadata.metadata;
                 }
             }
             t.partitions.push_back(std::move(p));
@@ -2652,8 +2659,11 @@ ss::future<error_code> group::remove() {
     storage::record_batch_builder builder(
       model::record_batch_type::raft_data, model::offset(0));
 
-    for (auto& offset : _offsets) {
-        add_offset_tombstone_record(_id, offset.first, builder);
+    for (const auto& [topic, partitions] : _offsets) {
+        for (const auto& [pid, md] : partitions) {
+            add_offset_tombstone_record(
+              _id, model::topic_partition(topic, pid), builder);
+        }
     }
 
     // build group tombstone
@@ -2702,9 +2712,13 @@ ss::future<> group::remove_topic_partitions(
     chunked_vector<std::pair<model::topic_partition, offset_metadata>> removed;
     for (const auto& tp : tps) {
         _pending_offset_commits.erase(tp);
-        if (auto offset = _offsets.extract(tp); offset) {
-            removed.emplace_back(
-              std::move(offset->first), std::move(offset->second->metadata));
+        if (auto t_it = _offsets.find(tp.topic); t_it != _offsets.end()) {
+            if (auto offset = t_it->second.extract(tp.partition); offset) {
+                if (t_it->second.empty()) {
+                    _offsets.erase(t_it);
+                }
+                removed.emplace_back(tp, std::move(offset->second->metadata));
+            }
         }
     }
 
@@ -3506,41 +3520,43 @@ chunked_vector<model::topic_partition> group::filter_expired_offsets(
 
     const auto now = model::timestamp::now();
     chunked_vector<model::topic_partition> offsets;
-    for (const auto& offset : _offsets) {
-        if (offset.second->metadata.non_reclaimable) {
-            continue;
-        }
-
-        /*
-         * an offset won't be removed if its topic has an active subscription or
-         * there are pending offset commits for the offset's topic.
-         */
-        if (
-          subscribed(offset.first.topic)
-          || _pending_offset_commits.contains(offset.first)) {
-            continue;
-        }
-
-        if (offset.second->metadata.expiry_timestamp.has_value()) {
-            /*
-             * the old way is explicit expiration time point per offset
-             */
-            const auto& expires
-              = offset.second->metadata.expiry_timestamp.value();
-            if (expires > now) {
+    for (const auto& [topic, partitions] : _offsets) {
+        const auto topic_subscribed = subscribed(topic);
+        for (const auto& [pid, offset] : partitions) {
+            if (offset->metadata.non_reclaimable) {
                 continue;
             }
-        } else {
+
+            model::topic_partition tp(topic, pid);
             /*
-             * the new way is a configurable global retention duration
+             * an offset won't be removed if its topic has an active
+             * subscription or there are pending offset commits for the
+             * offset's topic.
              */
-            const auto expires = effective_expires(offset.second->metadata);
-            if (model::timestamp(now() - expires()) < retain_for) {
+            if (topic_subscribed || _pending_offset_commits.contains(tp)) {
                 continue;
             }
-        }
 
-        offsets.push_back(offset.first);
+            if (offset->metadata.expiry_timestamp.has_value()) {
+                /*
+                 * the old way is explicit expiration time point per offset
+                 */
+                const auto& expires = offset->metadata.expiry_timestamp.value();
+                if (expires > now) {
+                    continue;
+                }
+            } else {
+                /*
+                 * the new way is a configurable global retention duration
+                 */
+                const auto expires = effective_expires(offset->metadata);
+                if (model::timestamp(now() - expires()) < retain_for) {
+                    continue;
+                }
+            }
+
+            offsets.push_back(std::move(tp));
+        }
     }
 
     return offsets;
@@ -3642,7 +3658,7 @@ group::delete_expired_offsets(std::chrono::seconds retention_period) {
     auto offsets = get_expired_offsets(retention_period);
     for (const auto& offset : offsets) {
         vlog(_ctxlog.debug, "Expiring group offset {}", offset);
-        _offsets.erase(offset);
+        erase_offset(offset);
     }
 
     /*
@@ -3665,7 +3681,7 @@ group::delete_offsets(const chunked_vector<model::topic_partition>& offsets) {
     for (const auto& offset : offsets) {
         if (!subscribed(offset.topic)) {
             vlog(_ctxlog.debug, "Deleting group offset {}", offset);
-            _offsets.erase(offset);
+            erase_offset(offset);
             _pending_offset_commits.erase(offset);
             deleted_offsets.push_back(offset);
         }

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -2495,6 +2495,14 @@ group::handle_offset_fetch(offset_fetch_request_group r, bool require_stable) {
     offset_fetch_response_group resp{
       .group_id = r.group_id, .error_code = error_code::none};
 
+    /*
+     * a partition's offset can only be unstable when there is a pending
+     * commit or an open transaction.
+     */
+    const bool check_unstable
+      = require_stable
+        && (!_pending_offset_commits.empty() || has_transactions_in_progress());
+
     // retrieve all topics available
     if (!r.topics) {
         chunked_hash_map<
@@ -2509,7 +2517,7 @@ group::handle_offset_fetch(offset_fetch_request_group r, bool require_stable) {
               .error_code = error_code::none,
             };
 
-            if (require_stable && has_pending_transaction(e.first)) {
+            if (check_unstable && has_pending_transaction(e.first)) {
                 p.error_code = error_code::unstable_offset_commit;
             } else {
                 p.committed_offset = e.second->metadata.offset;
@@ -2542,7 +2550,7 @@ group::handle_offset_fetch(offset_fetch_request_group r, bool require_stable) {
               .error_code = error_code::none,
             };
 
-            if (require_stable && has_pending_transaction(tp)) {
+            if (check_unstable && has_pending_transaction(tp)) {
                 p.error_code = error_code::unstable_offset_commit;
             } else {
                 auto res = offset(tp);

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -2486,10 +2486,10 @@ group::handle_offset_commit(offset_commit_request&& r) {
     }
 }
 
-ss::future<offset_fetch_response_group>
+offset_fetch_response_group
 group::handle_offset_fetch(offset_fetch_request_group r, bool require_stable) {
     if (in_state(group_state::dead)) {
-        co_return offset_fetch_response::make_group(std::move(r));
+        return offset_fetch_response::make_group(std::move(r));
     }
 
     offset_fetch_response_group resp{
@@ -2533,7 +2533,7 @@ group::handle_offset_fetch(offset_fetch_request_group r, bool require_stable) {
               {.name = e.first, .partitions = std::move(e.second)});
         }
 
-        co_return resp;
+        return resp;
     }
 
     // retrieve for the topics specified in the request
@@ -2567,7 +2567,7 @@ group::handle_offset_fetch(offset_fetch_request_group r, bool require_stable) {
         resp.topics.push_back(std::move(t));
     }
 
-    co_return resp;
+    return resp;
 }
 
 kafka::member_id group::generate_member_id(const join_group_request& r) {

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -634,6 +634,18 @@ public:
     ss::future<txn_offset_commit_response>
     store_txn_offsets(txn_offset_commit_request r);
 
+    struct prepared_offset_commits {
+        model::record_batch batch;
+        chunked_vector<std::pair<model::topic_partition, offset_metadata>>
+          commits;
+    };
+
+    /// Builds the record batch for an offset commit request and registers the
+    /// offsets as pending commits. Returns std::nullopt if the request
+    /// contains no offsets.
+    std::optional<prepared_offset_commits>
+    prepare_offset_commits(const offset_commit_request& r);
+
     offset_commit_stages store_offsets(offset_commit_request&& r);
 
     ss::future<txn_offset_commit_response>

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -276,6 +276,11 @@ public:
         absl::node_hash_map<model::topic_partition, offset_metadata> offsets;
     };
 
+    using partition_offsets_map = chunked_hash_map<
+      model::partition_id,
+      std::unique_ptr<offset_metadata_with_probe>>;
+    using offsets_map = chunked_hash_map<model::topic, partition_offsets_map>;
+
     group(
       kafka::group_id id,
       group_state s,
@@ -605,8 +610,12 @@ public:
 
     std::optional<offset_metadata>
     offset(const model::topic_partition& tp) const {
-        if (auto it = _offsets.find(tp); it != _offsets.end()) {
-            return it->second->metadata;
+        if (auto t_it = _offsets.find(tp.topic); t_it != _offsets.end()) {
+            if (
+              auto p_it = t_it->second.find(tp.partition);
+              p_it != t_it->second.end()) {
+                return p_it->second->metadata;
+            }
         }
         return std::nullopt;
     }
@@ -666,11 +675,13 @@ public:
     handle_offset_fetch(offset_fetch_request_group r, bool require_stable);
 
     void insert_offset(const model::topic_partition& tp, offset_metadata md) {
-        if (auto o_it = _offsets.find(tp); o_it != _offsets.end()) {
-            o_it->second->metadata = std::move(md);
+        auto& partitions = _offsets[tp.topic];
+        if (
+          auto p_it = partitions.find(tp.partition); p_it != partitions.end()) {
+            p_it->second->metadata = std::move(md);
         } else {
-            _offsets.emplace(
-              tp,
+            partitions.emplace(
+              tp.partition,
               std::make_unique<offset_metadata_with_probe>(
                 std::move(md),
                 _id,
@@ -678,6 +689,21 @@ public:
                 _conf.enable_consumer_group_metrics.bind(
                   std::function{enabled_metrics::from_vector})));
         }
+    }
+
+    /// removes a tracked offset; empty per-topic maps are erased so that
+    /// _offsets.empty() means "no offsets" and iteration never visits
+    /// offset-less topics
+    bool erase_offset(const model::topic_partition& tp) {
+        auto t_it = _offsets.find(tp.topic);
+        if (t_it == _offsets.end()) {
+            return false;
+        }
+        const auto erased = t_it->second.erase(tp.partition) > 0;
+        if (t_it->second.empty()) {
+            _offsets.erase(t_it);
+        }
+        return erased;
     }
 
     bool
@@ -981,15 +1007,9 @@ private:
     config::configuration& _conf;
     ss::lw_shared_ptr<ss::rwlock> _catchup_lock;
     ss::lw_shared_ptr<cluster::partition> _partition;
-    chunked_hash_map<
-      model::topic_partition,
-      std::unique_ptr<offset_metadata_with_probe>>
-      _offsets;
+    offsets_map _offsets;
     consumer_lag_metrics _lag_metrics;
-    group_probe<
-      model::topic_partition,
-      std::unique_ptr<offset_metadata_with_probe>>
-      _probe;
+    group_probe<model::topic, partition_offsets_map> _probe;
     ctx_log _ctxlog;
     ctx_log _ctx_txlog;
     /**

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -889,11 +889,7 @@ private:
     bool has_transactions_in_progress() const;
 
     bool has_pending_transaction(const model::topic_partition& tp) {
-        if (
-          std::any_of(
-            _pending_offset_commits.begin(),
-            _pending_offset_commits.end(),
-            [&tp](const auto& tp_info) { return tp_info.first == tp; })) {
+        if (_pending_offset_commits.contains(tp)) {
             return true;
         }
 

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -662,7 +662,7 @@ public:
     ss::future<cluster::commit_group_tx_reply>
     handle_commit_tx(cluster::commit_group_tx_request r);
 
-    ss::future<offset_fetch_response_group>
+    offset_fetch_response_group
     handle_offset_fetch(offset_fetch_request_group r, bool require_stable);
 
     void insert_offset(const model::topic_partition& tp, offset_metadata md) {

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -1790,6 +1790,7 @@ group_manager::offset_fetch(offset_fetch_request r) {
     offset_fetch_response response;
 
     for (auto& g_req : r.data.groups) {
+        co_await ss::coroutine::maybe_yield();
         auto& g_res = response.data.groups.emplace_back();
         auto error = validate_group_status(
           r.ntp, g_req.group_id, offset_fetch_api::key, true);
@@ -1803,7 +1804,7 @@ group_manager::offset_fetch(offset_fetch_request r) {
         if (!group) {
             g_res = offset_fetch_response::make_group(std::move(g_req));
         } else {
-            g_res = co_await group->handle_offset_fetch(
+            g_res = group->handle_offset_fetch(
               std::move(g_req), require_stable);
         }
     }

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -934,9 +934,12 @@ group_manager::do_snapshot_groups(
           model::topic,
           chunked_vector<group_offsets::partition_offset>>
           offsets;
-        for (const auto& [tp, o] : group->offsets()) {
-            offsets[tp.topic].emplace_back(
-              tp.partition, model::offset_cast(o->metadata.offset));
+        for (const auto& [topic, partitions] : group->offsets()) {
+            auto& topic_offsets = offsets[topic];
+            for (const auto& [pid, o] : partitions) {
+                topic_offsets.emplace_back(
+                  pid, model::offset_cast(o->metadata.offset));
+            }
         }
         for (auto& [t, ps] : offsets) {
             go.offsets.emplace_back(t, std::move(ps));
@@ -2332,8 +2335,11 @@ ss::future<> group_manager::collect_consumer_lag_metrics() {
     constexpr auto collect_ntps = [](const auto& gm) {
         topic_map_t topic_map;
         for (const auto& group : gm._groups | std::views::values) {
-            for (const auto& tp : group->offsets() | std::views::keys) {
-                topic_map[tp.topic].insert(tp.partition);
+            for (const auto& [topic, partitions] : group->offsets()) {
+                auto& parts = topic_map[topic];
+                for (const auto& pid : partitions | std::views::keys) {
+                    parts.insert(pid);
+                }
             }
         }
         return topic_map;
@@ -2402,23 +2408,28 @@ ss::future<> group_manager::collect_consumer_lag_metrics() {
     const auto set_metrics = [&report_r](const group_manager& gm) {
         for (const auto& group : gm._groups | std::views::values) {
             consumer_lag_metrics lag_metrics{};
-            for (const auto& [tp, group_topic_offsets] : group->offsets()) {
-                auto [hwm, lso] = find_lag_bounds(report_r.value(), tp);
-                if (hwm) {
-                    auto committed_offset = offset_cast(
-                      group_topic_offsets->metadata.offset);
-                    // Clamp committed_offset up to log_start_offset when
-                    // known: a stale commit below log_start_offset means no
-                    // consumable backlog exists and should not inflate lag.
-                    // log_start_offset is nullopt for reports from older nodes
-                    // — fall back to the pre-fix behaviour in that case.
-                    auto effective_committed = lso ? std::max(
-                                                       committed_offset, *lso)
-                                                   : committed_offset;
-                    lag part_lag{static_cast<lag>(
-                      std::max(*hwm - effective_committed, offset{0}))};
-                    lag_metrics.sum += part_lag;
-                    lag_metrics.max = std::max(lag_metrics.max, part_lag);
+            for (const auto& [topic, partitions] : group->offsets()) {
+                for (const auto& [pid, group_topic_offsets] : partitions) {
+                    model::topic_partition tp(topic, pid);
+                    auto [hwm, lso] = find_lag_bounds(report_r.value(), tp);
+                    if (hwm) {
+                        auto committed_offset = offset_cast(
+                          group_topic_offsets->metadata.offset);
+                        // Clamp committed_offset up to log_start_offset when
+                        // known: a stale commit below log_start_offset means no
+                        // consumable backlog exists and should not inflate lag.
+                        // log_start_offset is nullopt for reports from older
+                        // nodes — fall back to the pre-fix behaviour in that
+                        // case.
+                        auto effective_committed = lso
+                                                     ? std::max(
+                                                         committed_offset, *lso)
+                                                     : committed_offset;
+                        lag part_lag{static_cast<lag>(
+                          std::max(*hwm - effective_committed, offset{0}))};
+                        lag_metrics.sum += part_lag;
+                        lag_metrics.max = std::max(lag_metrics.max, part_lag);
+                    }
                 }
             }
             group->set_lag_metrics(lag_metrics);

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -1352,3 +1352,23 @@ redpanda_cc_btest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_bench(
+    name = "group_offset_commit_rpbench",
+    srcs = [
+        "group_offset_commit_bench.cc",
+    ],
+    memory = "2GiB",
+    deps = [
+        "//src/v/cluster",
+        "//src/v/config",
+        "//src/v/container:chunked_vector",
+        "//src/v/kafka/protocol",
+        "//src/v/kafka/protocol:offset_commit",
+        "//src/v/kafka/server",
+        "//src/v/model",
+        "@fmt",
+        "@seastar",
+        "@seastar//:benchmark",
+    ],
+)

--- a/src/v/kafka/server/tests/group_offset_commit_bench.cc
+++ b/src/v/kafka/server/tests/group_offset_commit_bench.cc
@@ -170,8 +170,7 @@ struct group_bench {
         }
         perf_tests::start_measuring_time();
         for (auto& req : reqs) {
-            auto resp = co_await g.handle_offset_fetch(
-              std::move(req), require_stable);
+            auto resp = g.handle_offset_fetch(std::move(req), require_stable);
             perf_tests::do_not_optimize(resp);
         }
         perf_tests::stop_measuring_time();
@@ -220,8 +219,7 @@ struct group_bench {
         }
         perf_tests::start_measuring_time();
         for (auto& req : reqs) {
-            auto resp = co_await g.handle_offset_fetch(
-              std::move(req), false);
+            auto resp = g.handle_offset_fetch(std::move(req), false);
             perf_tests::do_not_optimize(resp);
         }
         perf_tests::stop_measuring_time();

--- a/src/v/kafka/server/tests/group_offset_commit_bench.cc
+++ b/src/v/kafka/server/tests/group_offset_commit_bench.cc
@@ -1,0 +1,271 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/partition.h"
+#include "config/configuration.h"
+#include "container/chunked_vector.h"
+#include "kafka/protocol/offset_commit.h"
+#include "kafka/server/group.h"
+#include "model/fundamental.h"
+#include "model/timestamp.h"
+
+#include <seastar/testing/perf_tests.hh>
+
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace kafka {
+
+namespace {
+
+/// The coordinator-shard CPU cost of an offset commit, minus raft replication
+/// and cross-shard hops:
+///
+///   1. group::prepare_offset_commits() - record batch serialization plus
+///      pending-commit registration
+///   2. group::complete_offset_commit() per partition - committed offset
+///      upsert and pending-commit cleanup
+///   3. offset_commit_response echo construction
+///
+/// Request shapes mirror production traffic: single-partition commits from
+/// per-message committers and wide commits from checkpointing consumers
+/// (e.g. Flink jobs committing hundreds of partitions at once).
+
+group make_group() {
+    auto& conf = config::shard_local_cfg();
+    conf.enable_consumer_group_metrics.set_value(std::vector<ss::sstring>{});
+    static ss::sharded<cluster::tx_gateway_frontend> tx_frontend;
+    static ss::sharded<features::feature_table> feature_table;
+    return group(
+      kafka::group_id("bench-group"),
+      group_state::empty,
+      conf,
+      nullptr,
+      nullptr,
+      model::term_id(),
+      tx_frontend,
+      feature_table);
+}
+
+offset_commit_request
+make_request(size_t topics, size_t partitions_per_topic, int64_t offset) {
+    offset_commit_request req;
+    req.data.group_id = kafka::group_id("bench-group");
+    req.data.generation_id = kafka::generation_id(1);
+    req.data.topics.reserve(topics);
+    for (size_t t = 0; t < topics; ++t) {
+        offset_commit_request_topic topic;
+        // realistic production-style topic name length
+        topic.name = model::topic(
+          fmt::format("bench.topic.with.a.realistic.name.length-{}", t));
+        topic.partitions.reserve(partitions_per_topic);
+        for (size_t p = 0; p < partitions_per_topic; ++p) {
+            topic.partitions.push_back(
+              offset_commit_request_partition{
+                .partition_index = model::partition_id(static_cast<int32_t>(p)),
+                .committed_offset = model::offset(offset),
+                .committed_leader_epoch = kafka::leader_epoch(5),
+              });
+        }
+        req.data.topics.push_back(std::move(topic));
+    }
+    return req;
+}
+
+constexpr size_t inner_iters = 100;
+
+struct group_bench {
+    group g = make_group();
+    int64_t committed_offset = 0;
+    int64_t log_offset = 0;
+
+    std::vector<offset_commit_request> make_requests(size_t t, size_t p) {
+        std::vector<offset_commit_request> reqs;
+        reqs.reserve(inner_iters);
+        for (size_t i = 0; i < inner_iters; ++i) {
+            reqs.push_back(make_request(t, p, ++committed_offset));
+        }
+        return reqs;
+    }
+
+    /// prepare_offset_commits() only: batch serialization + pending map
+    /// registration. drains pending afterwards (untimed) to keep state
+    /// steady across iterations.
+    size_t run_prepare(size_t topics, size_t partitions) {
+        auto reqs = make_requests(topics, partitions);
+        perf_tests::start_measuring_time();
+        for (auto& req : reqs) {
+            auto prepared = g.prepare_offset_commits(req);
+            perf_tests::do_not_optimize(prepared);
+        }
+        perf_tests::stop_measuring_time();
+        return inner_iters;
+    }
+
+    /// the full coordinator-shard cycle: prepare, assign log offsets,
+    /// complete each partition, build the response echo. this is
+    /// store_offsets() minus the raft replicate.
+    size_t run_cycle(size_t topics, size_t partitions) {
+        auto reqs = make_requests(topics, partitions);
+        perf_tests::start_measuring_time();
+        for (auto& req : reqs) {
+            auto prepared = g.prepare_offset_commits(req);
+            for (auto& e : prepared->commits) {
+                e.second.log_offset = model::offset(++log_offset);
+                g.complete_offset_commit(e.first, e.second);
+            }
+            auto resp = offset_commit_response(req, error_code::none);
+            perf_tests::do_not_optimize(resp);
+        }
+        perf_tests::stop_measuring_time();
+        return inner_iters;
+    }
+
+    /// all-topics offset fetch (topics == null) over a group with tracked
+    /// offsets. the require_stable variant seeds pending offset commits
+    /// (never completed), the state a backlogged coordinator is in, where
+    /// every fetched partition consults the pending set.
+    ss::future<size_t> run_fetch_all(
+      size_t topics, size_t partitions, bool require_stable, size_t pending) {
+        if (!fetch_populated) {
+            for (size_t t = 0; t < topics; ++t) {
+                model::topic topic(fmt::format("fetch-topic-{}", t));
+                for (size_t p = 0; p < partitions; ++p) {
+                    g.insert_offset(
+                      model::topic_partition(
+                        topic, model::partition_id(static_cast<int32_t>(p))),
+                      group::offset_metadata{
+                        .log_offset = model::offset(++log_offset),
+                        .offset = model::offset(++committed_offset),
+                        .committed_leader_epoch = kafka::leader_epoch(5),
+                      });
+                }
+            }
+            if (pending > 0) {
+                // the pending commits are deliberately seeded under a
+                // different topic than the fetched offsets, so that every
+                // per-partition stability check is a miss: a miss must
+                // consider the entire pending set, making it the worst case
+                // for the stability probe, while a hit could return after
+                // examining only part of it.
+                auto prepared = g.prepare_offset_commits(
+                  make_request(1, pending, ++committed_offset));
+                perf_tests::do_not_optimize(prepared);
+            }
+            fetch_populated = true;
+        }
+        std::vector<offset_fetch_request_group> reqs;
+        reqs.reserve(inner_iters);
+        for (size_t i = 0; i < inner_iters; ++i) {
+            reqs.push_back(
+              offset_fetch_request_group{
+                .group_id = kafka::group_id("bench-group")});
+        }
+        perf_tests::start_measuring_time();
+        for (auto& req : reqs) {
+            auto resp = co_await g.handle_offset_fetch(
+              std::move(req), require_stable);
+            perf_tests::do_not_optimize(resp);
+        }
+        perf_tests::stop_measuring_time();
+        co_return inner_iters;
+    }
+
+    bool fetch_populated{false};
+
+    void populate_fetch_offsets(size_t topics, size_t partitions) {
+        for (size_t t = 0; t < topics; ++t) {
+            model::topic topic(fmt::format("fetch-topic-{}", t));
+            for (size_t p = 0; p < partitions; ++p) {
+                g.insert_offset(
+                  model::topic_partition(
+                    topic, model::partition_id(static_cast<int32_t>(p))),
+                  group::offset_metadata{
+                    .log_offset = model::offset(++log_offset),
+                    .offset = model::offset(++committed_offset),
+                    .committed_leader_epoch = kafka::leader_epoch(5),
+                  });
+            }
+        }
+    }
+
+    /// specific-topics fetch: the shape consumers issue on partition
+    /// assignment ("committed offsets for these partitions of this topic")
+    ss::future<size_t> run_fetch_specific(size_t partitions) {
+        if (!fetch_populated) {
+            populate_fetch_offsets(1, partitions);
+            fetch_populated = true;
+        }
+        std::vector<offset_fetch_request_group> reqs;
+        reqs.reserve(inner_iters);
+        for (size_t i = 0; i < inner_iters; ++i) {
+            offset_fetch_request_topics t;
+            t.name = model::topic("fetch-topic-0");
+            t.partition_indexes.reserve(partitions);
+            for (size_t p = 0; p < partitions; ++p) {
+                t.partition_indexes.emplace_back(static_cast<int32_t>(p));
+            }
+            offset_fetch_request_group req{
+              .group_id = kafka::group_id("bench-group")};
+            req.topics.emplace();
+            req.topics->push_back(std::move(t));
+            reqs.push_back(std::move(req));
+        }
+        perf_tests::start_measuring_time();
+        for (auto& req : reqs) {
+            auto resp = co_await g.handle_offset_fetch(
+              std::move(req), false);
+            perf_tests::do_not_optimize(resp);
+        }
+        perf_tests::stop_measuring_time();
+        co_return inner_iters;
+    }
+
+    /// response echo construction alone (copies the request's topic
+    /// partition structure into the response)
+    size_t run_response(size_t topics, size_t partitions) {
+        auto req = make_request(topics, partitions, ++committed_offset);
+        perf_tests::start_measuring_time();
+        for (size_t i = 0; i < inner_iters; ++i) {
+            auto resp = offset_commit_response(req, error_code::none);
+            perf_tests::do_not_optimize(resp);
+        }
+        perf_tests::stop_measuring_time();
+        return inner_iters;
+    }
+};
+
+} // namespace
+
+PERF_TEST_F(group_bench, prepare_1t_1p) { return run_prepare(1, 1); }
+PERF_TEST_F(group_bench, prepare_1t_50p) { return run_prepare(1, 50); }
+PERF_TEST_F(group_bench, prepare_4t_64p) { return run_prepare(4, 64); }
+
+PERF_TEST_F(group_bench, cycle_1t_1p) { return run_cycle(1, 1); }
+PERF_TEST_F(group_bench, cycle_1t_50p) { return run_cycle(1, 50); }
+PERF_TEST_F(group_bench, cycle_4t_64p) { return run_cycle(4, 64); }
+
+PERF_TEST_CN(group_bench, fetch_all_1t_256p) {
+    co_return co_await this->run_fetch_all(1, 256, false, 0);
+}
+PERF_TEST_CN(group_bench, fetch_all_32t_8p) {
+    co_return co_await this->run_fetch_all(32, 8, false, 0);
+}
+PERF_TEST_CN(group_bench, fetch_specific_1t_256p) {
+    co_return co_await this->run_fetch_specific(256);
+}
+PERF_TEST_CN(group_bench, fetch_all_stable_1t_256p) {
+    co_return co_await this->run_fetch_all(1, 256, true, 512);
+}
+
+PERF_TEST_F(group_bench, response_1t_1p) { return run_response(1, 1); }
+PERF_TEST_F(group_bench, response_4t_64p) { return run_response(4, 64); }
+
+} // namespace kafka


### PR DESCRIPTION
Some low hanging fruit optimizations I've had Claude dig for while investigating a cluster with very high `offset_commit` p99 latency.  While these fixes in isolation don't fully address other underlying suboptimalities in consumer group related code, these optimizations are valuable and generally small enough in scope to check in on their own here.

Commits:

* Add a benchmark for `group_offset_commit()` related functions
* Some optimizations for `group::handle_offset_fetch()`, including a fix for an accidentally quadratic section of code (see commit two for explanation)
* De-coroutinize `group::handle_offset_fetch()` (it doesn't need to be one)
* Adding an extra layer of hashing for `_offsets` in `group` (outer map by `topic`, inner map by `partition`)

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

### Improvements

* Optimize `offset_fetch` and `offset_commit` Kafka RPCs
