### PR TITLE
[CORE-15822] security/audit: apply failure policy when the sink cannot initialize

### DIFF
--- a/src/v/kafka/data/rpc/client.cc
+++ b/src/v/kafka/data/rpc/client.cc
@@ -319,8 +319,9 @@ ss::future<cluster::errc> client::try_create_topic(
     if (
       ec != cluster::errc::success
       && ec != cluster::errc::topic_already_exists) {
-        throw std::runtime_error(
-          fmt::format("Failed to create topic '{}'", nt));
+        throw topic_create_exception(
+          ec,
+          fmt::format("Failed to create topic '{}' - error_code: {}", nt, ec));
     }
     co_return ec;
 }

--- a/src/v/kafka/data/rpc/client.h
+++ b/src/v/kafka/data/rpc/client.h
@@ -20,6 +20,8 @@
 #include "kafka/data/rpc/serde.h"
 #include "kafka/data/rpc/service.h"
 
+#include <stdexcept>
+
 namespace kafka::data::rpc {
 
 /// Result of a produce operation that includes both base and last offset.
@@ -30,6 +32,21 @@ struct produce_result {
     cluster::errc ec{cluster::errc::success};
     std::optional<model::offset> base_offset;
     std::optional<model::offset> last_offset;
+};
+
+/// Raised when topic creation fails with an unexpected error code; carries
+/// the code so that callers can distinguish permanent configuration errors
+/// (e.g. an invalid replication factor) from transient ones.
+class topic_create_exception final : public std::runtime_error {
+public:
+    topic_create_exception(cluster::errc ec, const std::string& msg)
+      : std::runtime_error(msg)
+      , _errc(ec) {}
+
+    cluster::errc errc() const { return _errc; }
+
+private:
+    cluster::errc _errc;
 };
 
 /**

--- a/src/v/security/audit/audit_log_manager.cc
+++ b/src/v/security/audit/audit_log_manager.cc
@@ -78,10 +78,12 @@ audit_log_manager::audit_log_manager(
   , _config(&cfg)
   , _metadata_cache(metadata_cache)
   , _rpc_client(rpc_client) {
-    _probe.setup_metrics([this] {
-        return 1.0
-               - (static_cast<double>(_queue_bytes_sem.available_units()) / static_cast<double>(_max_queue_size_bytes));
-    });
+    _probe.setup_metrics(
+      [this] {
+          return 1.0
+                 - (static_cast<double>(_queue_bytes_sem.available_units()) / static_cast<double>(_max_queue_size_bytes));
+      },
+      [this] { return _sink_unavailable ? 0.0 : 1.0; });
     set_enabled_events();
     _audit_event_types.watch([this] { set_enabled_events(); });
     _audit_excluded_topics_binding.watch([this] {
@@ -357,6 +359,25 @@ audit_sink& audit_log_manager::sink() {
     return *_sink;
 }
 
+void audit_log_manager::set_sink_availability(
+  bool available, const ss::sstring& reason) {
+    const bool was_unavailable = _sink_unavailable;
+    _sink_unavailable = !available;
+    _sink_unavailable_reason = reason;
+    if (ss::this_shard_id() == client_shard_id) {
+        if (!available) {
+            vlog(
+              adtlog.error,
+              "Audit sink unavailable: {}. audit_failure_policy ({}) will be "
+              "applied to auditable requests",
+              reason,
+              _audit_log_reject_policy());
+        } else if (was_unavailable) {
+            vlog(adtlog.info, "Audit sink available again");
+        }
+    }
+}
+
 std::optional<audit_log_manager::audit_event_passthrough>
 audit_log_manager::should_enqueue_audit_event() const {
     if (recovery_mode_enabled() || !_audit_enabled()) {
@@ -387,6 +408,25 @@ audit_log_manager::should_enqueue_audit_event() const {
         vlog(
           adtlog.warn,
           "Audit message rejected due to misconfigured authorization");
+        return std::make_optional(
+          _audit_log_reject_policy() == config::audit_failure_policy::reject
+            ? audit_event_passthrough::no
+            : audit_event_passthrough::yes);
+    }
+    if (_sink_unavailable) {
+        /// The sink reported it cannot become operational. Apply the failure
+        /// policy immediately instead of queueing into a buffer that nothing
+        /// drains: the queues would fill up and reject with a misleading
+        /// "queue full" verdict, pinning memory until a restart.
+        static constexpr auto rate_limit = std::chrono::seconds(5);
+        static thread_local ss::logger::rate_limit rate(rate_limit);
+        vloglr(
+          adtlog,
+          ss::log_level::warn,
+          rate,
+          "Audit sink unavailable ({}), applying audit_failure_policy",
+          _sink_unavailable_reason);
+        _probe.audit_error();
         return std::make_optional(
           _audit_log_reject_policy() == config::audit_failure_policy::reject
             ? audit_event_passthrough::no

--- a/src/v/security/audit/audit_log_manager.h
+++ b/src/v/security/audit/audit_log_manager.h
@@ -319,6 +319,7 @@ private:
 
     audit_sink& sink();
     void set_auth_misconfigured(bool v) { _auth_misconfigured = v; }
+    void set_sink_availability(bool available, const ss::sstring& reason);
 
     bool is_audit_event_enabled(event_type) const;
     void set_enabled_events();
@@ -469,6 +470,13 @@ private:
     /// special permission to the audit client to do things like produce to the
     /// audit topic.
     bool _auth_misconfigured{false};
+
+    /// Set when the sink reports that it cannot become operational
+    /// (initialization persistently failing). Gates the enqueue path so the
+    /// audit_failure_policy is applied immediately instead of accumulating
+    /// events in a queue that nothing drains until initialization succeeds.
+    bool _sink_unavailable{false};
+    ss::sstring _sink_unavailable_reason;
 
     /// Represents whether the feature is actually active, not the
     /// representation of the config variable

--- a/src/v/security/audit/client.cc
+++ b/src/v/security/audit/client.cc
@@ -113,29 +113,31 @@ public:
           adtlog.info,
           "Creating audit log topic with settings: {}",
           audit_topic_props);
-        const auto ec = co_await _rpc_client->create_topic(
-          model::kafka_audit_logging_nt,
-          std::move(audit_topic_props),
-          config::shard_local_cfg().audit_log_num_partitions(),
-          replication_factor);
-        if (ec == cluster::errc::success) {
-            vlog(
-              adtlog.debug,
-              "Auditing: created audit log topic: {}",
-              model::kafka_audit_logging_topic);
-        } else if (ec == cluster::errc::topic_already_exists) {
-            vlog(adtlog.debug, "Auditing: topic already exists");
-        } else {
-            if (ec == cluster::errc::topic_invalid_replication_factor) {
+        cluster::errc ec{};
+        try {
+            ec = co_await _rpc_client->create_topic(
+              model::kafka_audit_logging_nt,
+              std::move(audit_topic_props),
+              config::shard_local_cfg().audit_log_num_partitions(),
+              replication_factor);
+        } catch (const kafka::data::rpc::topic_create_exception& e) {
+            if (e.errc() == cluster::errc::topic_invalid_replication_factor) {
                 vlog(
                   adtlog.warn,
                   "Auditing: invalid replication factor on audit topic, "
                   "check/modify settings, then disable and re-enable "
                   "'audit_enabled'");
+                throw permanent_config_error(e.what());
             }
-            throw std::runtime_error(
-              fmt::format(
-                "Error creating audit log topic - error_code: {}", ec));
+            throw;
+        }
+        if (ec == cluster::errc::success) {
+            vlog(
+              adtlog.debug,
+              "Auditing: created audit log topic: {}",
+              model::kafka_audit_logging_topic);
+        } else {
+            vlog(adtlog.debug, "Auditing: topic already exists");
         }
     }
 
@@ -401,6 +403,10 @@ private:
             vlog(adtlog.debug, "Auditing: topic already exists");
             co_await _client.update_metadata();
         } else {
+            const auto msg = fmt::format(
+              "{} - error_code: {}",
+              topic.error_message.value_or("<no_err_msg>"),
+              topic.error_code);
             if (
               topic.error_code
               == kafka::error_code::invalid_replication_factor) {
@@ -409,12 +415,9 @@ private:
                   "Auditing: invalid replication factor on audit topic, "
                   "check/modify settings, then disable and re-enable "
                   "'audit_enabled'");
+                throw permanent_config_error(msg);
             }
-            const auto msg = topic.error_message.has_value()
-                               ? *topic.error_message
-                               : "<no_err_msg>";
-            throw std::runtime_error(
-              fmt::format("{} - error_code: {}", msg, topic.error_code));
+            throw std::runtime_error(msg);
         }
     }
 };
@@ -479,20 +482,49 @@ audit_client::audit_client(audit_sink* sink, cluster::controller* controller)
 
 ss::future<> audit_client::initialize() {
     static const auto base_backoff = 250ms;
+    /// Grace window during which initialization failures are presumed
+    /// transient and events keep accumulating in the per-shard queues. Past
+    /// it, the sink is marked unavailable so the audit_failure_policy is
+    /// applied at enqueue time instead of silently filling queues that
+    /// nothing drains until initialization succeeds.
+    static constexpr auto mark_unavailable_after = 60s;
     exp_backoff_policy backoff_policy;
+    const auto started = ss::lowres_clock::now();
+    bool marked_unavailable = false;
     while (!_as.abort_requested()) {
+        std::optional<ss::sstring> unavailable_reason;
         try {
             co_await configure();
             _is_initialized = true;
             break;
+        } catch (const permanent_config_error& e) {
+            /// Deterministic misconfiguration: retrying cannot succeed until
+            /// the configuration changes, so surface it immediately.
+            if (!marked_unavailable) {
+                unavailable_reason = e.what();
+            }
         } catch (...) {
             /// Sleep, then try again
+            if (
+              !marked_unavailable
+              && ss::lowres_clock::now() - started > mark_unavailable_after) {
+                unavailable_reason = fmt::format(
+                  "{}", std::current_exception());
+            }
+        }
+        if (unavailable_reason.has_value()) {
+            marked_unavailable = true;
+            co_await sink()->update_sink_availability(
+              false, std::move(*unavailable_reason));
         }
         auto next = backoff_policy.next_backoff();
         co_await ss::sleep_abortable(base_backoff * next, _as)
           .handle_exception_type([](const ss::sleep_aborted&) {});
     }
     if (_is_initialized) {
+        if (marked_unavailable) {
+            co_await sink()->update_sink_availability(true, {});
+        }
         _probe = std::make_unique<client_probe>();
         _probe->setup_metrics([this]() {
             auto avail = static_cast<double>(_send_sem.available_units());
@@ -655,6 +687,14 @@ ss::future<> audit_sink::stop() {
     co_await _gate.close();
 }
 
+ss::future<>
+audit_sink::update_sink_availability(bool available, ss::sstring reason) {
+    return _audit_mgr->container().invoke_on_all(
+      [available, reason = std::move(reason)](audit_log_manager& mgr) {
+          mgr.set_sink_availability(available, reason);
+      });
+}
+
 ss::future<> audit_sink::produce(
   chunked_vector<partition_batch> records,
   std::optional<ss::timer<>::duration> timeout) {
@@ -757,6 +797,9 @@ ss::future<> audit_sink::do_toggle(bool enabled) {
         vlog(adtlog.info, "Auditing fibers stopped");
         co_await client()->shutdown();
         reset_client();
+        /// A fresh client starts with a clean slate; do not carry a stale
+        /// unavailability verdict across disable/enable cycles.
+        co_await update_sink_availability(true, {});
     } else {
         vlog(
           adtlog.info,

--- a/src/v/security/audit/client.h
+++ b/src/v/security/audit/client.h
@@ -25,7 +25,17 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
 
+#include <stdexcept>
+
 namespace security::audit {
+
+/// Raised by the configuration phase for errors that are a deterministic
+/// function of configuration (e.g. invalid replication factor): retrying
+/// cannot succeed until the configuration changes.
+class permanent_config_error final : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
 
 struct partition_batch {
     model::partition_id pid;
@@ -68,6 +78,12 @@ public:
     /// Allocates and connects, or deallocates and shuts down the audit client
     void toggle(bool);
     bool active() { return _active; }
+
+    /// Propagates the sink availability state to the audit managers on all
+    /// shards, where it gates the enqueue path: while unavailable, the
+    /// audit_failure_policy is applied at enqueue time instead of letting
+    /// events accumulate in queues that nothing drains.
+    ss::future<> update_sink_availability(bool available, ss::sstring reason);
 
     using update_auth_fn = ss::noncopyable_function<ss::future<>(bool)>;
     static std::unique_ptr<audit_sink> make_kafka_sink(

--- a/src/v/security/audit/probe.h
+++ b/src/v/security/audit/probe.h
@@ -29,7 +29,9 @@ public:
     audit_probe& operator=(audit_probe&&) = delete;
     ~audit_probe() = default;
 
-    void setup_metrics(std::function<double()> get_usage_ratio);
+    void setup_metrics(
+      std::function<double()> get_usage_ratio,
+      std::function<double()> get_sink_available);
 
     void audit_event() { _last_event = clock_type::now(); }
     void audit_error() { ++_audit_error_count; }

--- a/src/v/security/audit/probes.cc
+++ b/src/v/security/audit/probes.cc
@@ -19,10 +19,12 @@
 
 namespace security::audit {
 
-void audit_probe::setup_metrics(std::function<double()> get_usage_ratio) {
+void audit_probe::setup_metrics(
+  std::function<double()> get_usage_ratio,
+  std::function<double()> get_sink_available) {
     namespace sm = ss::metrics;
 
-    auto setup_common = [this]<typename MetricDef>(
+    auto setup_common = [this, &get_sink_available]<typename MetricDef>(
                           const std::vector<sm::label>& aggregate_labels) {
         std::vector<MetricDef> defs;
         if (ss::this_shard_id() == audit_log_manager::client_shard_id) {
@@ -33,6 +35,14 @@ void audit_probe::setup_metrics(std::function<double()> get_usage_ratio) {
                 sm::description(
                   "Timestamp of last successful publish on the "
                   "audit log (seconds since epoch)"))
+                .aggregate(aggregate_labels));
+            defs.emplace_back(
+              sm::make_gauge(
+                "sink_available",
+                [fn = get_sink_available] { return fn(); },
+                sm::description(
+                  "Whether the audit subsystem can deliver events to the "
+                  "audit log topic (1 = available, 0 = unavailable)"))
                 .aggregate(aggregate_labels));
         }
         defs.emplace_back(

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -4405,3 +4405,167 @@ class AuditLogUpgradeTest(AuditLogTestBase):
         )
 
         self._test_audit_on_all_nodes("post_upgrade_restart")
+
+
+class AuditLogInitFailureTest(AuditLogTestBase):
+    """
+    Covers the failure mode where the audit client cannot initialize
+    (here: audit_log_replication_factor larger than the cluster while the
+    audit topic does not exist yet).
+
+    The audit sink arms the per-shard drain timer only after
+    audit_client::initialize() succeeds, so a persistently failing
+    initialization used to leave the per-shard queues undrained: they would
+    fill up and every request that must be audited -- including
+    authentication -- would be rejected on an otherwise healthy cluster,
+    recoverable only by a restart.
+
+    Now a persistently failing initialization marks the sink unavailable,
+    which applies audit_failure_policy at enqueue time: queues do not fill,
+    reject refuses auditable requests explicitly, permit lets them through,
+    and the sink recovers automatically once initialization succeeds.
+    """
+
+    ARG_FAILURE_POLICY = "audit_failure_policy"
+
+    def __init__(self, test_context):
+        policy = AuditFailurePolicy.REJECT
+        if test_context.injected_args:
+            policy = test_context.injected_args.get(
+                self.ARG_FAILURE_POLICY, AuditFailurePolicy.REJECT
+            )
+        super(AuditLogInitFailureTest, self).__init__(
+            test_context=test_context,
+            audit_log_config=AuditLogConfig(
+                enabled=False,
+                event_types=["management", "authenticate", "admin"],
+                failure_policy=policy,
+            ),
+            # Small per-shard queue (needs_restart=yes, so it must be set at
+            # bootstrap): if the sink-unavailable gate regressed, undrained
+            # queues would visibly fill up ("Unable to enqueue audit event")
+            # within a single spray below.
+            extra_rp_conf={"audit_queue_max_buffer_size_per_shard": 16384},
+        )
+        self.policy = policy
+
+    NUM_LATE_USERS = 4
+
+    def _spray_admin_events(self, count: int, node):
+        """Generate `count` distinct api_activity audit events on `node`.
+
+        api_activity events are deduplicated by a hash that includes the
+        request URL, so vary a query parameter to make each event unique. The
+        endpoint itself is on the audit escape-hatch allow list, so these
+        requests succeed regardless of audit state.
+        """
+        for _ in range(count):
+            self._fill_seq += 1
+            self.admin._request(
+                "GET", f"cluster_config/status?fill={self._fill_seq}", node=node
+            )
+
+    @skip_fips_mode
+    @cluster(
+        num_nodes=4,
+        log_allow_list=AUDIT_LOG_ALLOW_LIST
+        + [
+            r".*Audit sink unavailable.*",
+            r".*Audit log client failed to initialize.*",
+            r".*Error creating audit log topic.*",
+            r".*invalid replication factor on audit topic.*",
+            r".*Failed to audit authentication request for endpoint.*",
+            r".*was not audited due to audit queues being full.*",
+        ],
+    )
+    @matrix(
+        audit_transport_mode=get_audit_modes(),
+        audit_failure_policy=[AuditFailurePolicy.REJECT, AuditFailurePolicy.PERMIT],
+    )
+    def test_init_failure_applies_policy(
+        self, audit_transport_mode, audit_failure_policy
+    ):
+        self._fill_seq = 0
+        mech = self.security.user_creds[2]
+        # Fresh users, created up front and never authenticated: identical
+        # authn events deduplicate into a counter without consuming queue
+        # budget, so only a previously-unseen user exercises the enqueue
+        # decision under test.
+        for i in range(self.NUM_LATE_USERS):
+            self.super_rpk.sasl_create_user(f"late-user-{i}", "pass123", mech)
+
+        # Impossible replication factor: create_internal_topic() fails with
+        # invalid_replication_factor on every initialize() attempt. This is
+        # classified as a permanent config error, so the sink is marked
+        # unavailable immediately, with no grace window.
+        self._modify_cluster_config({"audit_log_replication_factor": 5})
+        self.modify_audit_enabled(True)
+
+        wait_until(
+            lambda: self.redpanda.search_log_any("Audit sink unavailable"),
+            timeout_sec=60,
+            backoff_sec=2,
+            err_msg="expected the audit sink to be marked unavailable",
+        )
+        assert not self.redpanda.search_log_any("Auditing fibers started"), (
+            "drain fibers must not start while initialization fails"
+        )
+
+        # The sink-unavailable gate applies the failure policy at enqueue
+        # time: events must not accumulate in queues that nothing drains.
+        for node in self.redpanda.nodes:
+            self._spray_admin_events(60, node)
+        assert not self.redpanda.search_log_any("Unable to enqueue audit event"), (
+            "audit queues must not fill up while the sink is unavailable"
+        )
+
+        def _fresh_user_authn(i: int) -> bool:
+            rpk = self.get_rpk_credentials(f"late-user-{i}", "pass123", mech)
+            try:
+                rpk.list_topics()
+                return True
+            except RpkException:
+                return False
+
+        if self.policy == AuditFailurePolicy.REJECT:
+            # The incident symptom, now explicit and immediate: a client with
+            # valid credentials is refused because its authentication cannot
+            # be audited.
+            def _authn_rejected():
+                _fresh_user_authn(0)
+                return self.redpanda.search_log_any(
+                    "Failed to append authentication event to audit log"
+                )
+
+            wait_until(
+                _authn_rejected,
+                timeout_sec=60,
+                backoff_sec=1,
+                err_msg="expected authentication to be refused under reject",
+            )
+        else:
+            assert _fresh_user_authn(0), (
+                "authentication must succeed under permit while the sink is unavailable"
+            )
+
+        # Fixing the configuration must recover the sink automatically:
+        # initialization succeeds, the drain fibers start and auditable
+        # requests are served again, with audit logging still enabled.
+        self._modify_cluster_config({"audit_log_replication_factor": 3})
+        wait_until(
+            lambda: self.redpanda.search_log_any("Auditing fibers started"),
+            # initialize() retries with exponential backoff capped at
+            # 300 * 250ms, so the next attempt may be over a minute out.
+            timeout_sec=180,
+            backoff_sec=5,
+            err_msg="expected the audit sink to recover after the config fix",
+        )
+        wait_until(
+            lambda: _fresh_user_authn(1),
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="expected authentication to work after sink recovery",
+        )
+        assert self.audit_log in self.super_rpk.list_topics(), (
+            "audit topic should exist after recovery"
+        )


### PR DESCRIPTION
## Problem

The audit sink arms the per-shard drain timer only after `audit_client::initialize()` succeeds. A persistently failing initialization leaves the per-shard queues undrained: they fill within ~90s and stay full, and with `audit_failure_policy=reject` every auditable request — including **authentication** and the **admin API** — is rejected on an otherwise healthy cluster. Recovery requires the underlying cause to clear (or a restart) — and until then nothing in the system names the cause: the only visible verdict is a misleading "queue full".

This is the root cause of a recurring incident class (INC-2362 / fiveonefour, CORE-12785 / StoneX, ~6 prior cases). Full RCA with log evidence: [CORE-15822](https://redpandadata.atlassian.net/browse/CORE-15822). The failure mode reproduces on HEAD in **both** transport modes (see the ducktape test in this PR — its pre-fix variant passed against clean dev).

Note: this closes the failure *class*; the most common concrete trigger (CreateTopics requiring a reachable controller although the audit topic already exists) is removed separately in #31411 (RPC sink only; a v25.1.x/v25.2.x backport would additionally need the Kafka-client-sink variant described there).

## Changes

1. **`k/d/rpc/client`**: topic-creation failures now throw `topic_create_exception` carrying the `cluster::errc`, so callers can tell permanent configuration errors from transient ones (previously flattened into a plain `runtime_error`).

2. **`security/audit`**: `initialize()` marks the sink unavailable — immediately for permanent config errors (`invalid_replication_factor`), after a 60s grace window otherwise. `should_enqueue_audit_event()` surfaces this the same way as the existing `_auth_misconfigured` state: the failure policy is applied at enqueue time, with **no queue growth**, a rate-limited log naming the cause, and **automatic recovery** once initialization succeeds. New public gauge `security_audit_sink_available` (1/0, shard 0) exposes the state for alerting.

This does not change what `reject` promises — it changes how the system behaves while unable to keep that promise: explicitly, without memory growth, and with automatic recovery.

Known limitations / review questions:
- `invalid_replication_factor` is classified as permanent, but it can also be transient (a broker temporarily down at enable time); the only consequence of that misclassification is skipping the 60s grace window, and the state still self-heals on the first successful init. Happy to gate it behind the grace window instead.
- The 60s threshold is an internal constant; can be promoted to a cluster property if preferred.
- The RPC sink initializes per shard, so the flag can briefly flap during convergence (cosmetic, extra log lines only).

## Testing

- New ducktape `AuditLogInitFailureTest.test_init_failure_applies_policy`: enables auditing with an impossible replication factor; asserts queues do not fill, reject refuses a fresh user's authn explicitly, permit lets it through, cluster config remains operable throughout (escape hatch), and fixing the config recovers the sink automatically. Matrix over both transport modes × both failure policies — 4/4 PASS.
- `//src/v/security/audit/tests:audit_test`, `//src/v/kafka/data/rpc/test:kafka_data_rpc_test` — PASS.
- Full `tests/rptest/tests/audit_log_test.py` suite against this branch: **131/134 PASS** (3 known-unrelated: 2× sanctioning-mode requiring `REDPANDA_SAMPLE_LICENSE`, 1× `AuditLogUpgradeTest` known-flaky family).

## Backports Required

- [ ] v25.3.x
- [ ] v25.2.x / v25.1.x — to be decided; the trigger-removal counterpart lives in #31411 (needs a Kafka-client-sink variant there first)

## Release Notes

### Improvements

* Audit logging: a persistently failing audit client initialization no longer fills the audit queues and rejects authentication with a misleading "queue full" error. The configured `audit_failure_policy` is applied immediately and visibly, the sink recovers automatically once initialization succeeds, and a new `security_audit_sink_available` metric exposes the state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CORE-15822]: https://redpandadata.atlassian.net/browse/CORE-15822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
