### PR TITLE
kafka/client: assert produce dispatch is serial per partition

### DIFF
--- a/src/v/kafka/client/producer.cc
+++ b/src/v/kafka/client/producer.cc
@@ -164,6 +164,11 @@ producer::do_send(model::topic_partition tp, model::record_batch batch) {
 
 ss::future<>
 producer::send(model::topic_partition tp, model::record_batch&& batch) {
+    // produce_partition invokes send() serially per partition; serial
+    // dispatch is what orders produce requests on the wire. A concurrent
+    // send() means the accounting is already corrupt.
+    auto inserted = _in_flight_sends.insert(tp).second;
+    vassert(inserted, "concurrent produce dispatch for {}", tp);
     auto record_count = batch.record_count();
     vlog(
       _logger->debug,
@@ -194,10 +199,12 @@ producer::send(model::topic_partition tp, model::record_batch&& batch) {
                        _as);
                  });
              })
-      .handle_exception([this, p_id](std::exception_ptr ex) {
-          return make_produce_response(p_id, ex, *_logger);
-      })
-      .then([this, tp, record_count](produce_response::partition res) mutable {
+      .then_wrapped([this, tp, p_id, record_count](
+                      ss::future<produce_response::partition> fut) mutable {
+          _in_flight_sends.erase(tp);
+          auto res = fut.failed() ? make_produce_response(
+                                      p_id, fut.get_exception(), *_logger)
+                                  : fut.get();
           vlog(
             _logger->debug,
             "sent record_batch: {}, {{record_count: {}}}, {}",

--- a/src/v/kafka/client/producer.h
+++ b/src/v/kafka/client/producer.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 #include "kafka/client/logger.h"
 #include "kafka/client/produce_batcher.h"
 #include "kafka/client/produce_partition.h"
@@ -63,6 +64,8 @@ public:
     }
 
 private:
+    friend struct producer_test_access;
+
     ss::future<> send(model::topic_partition tp, model::record_batch&& batch);
 
     ss::future<produce_response::partition>
@@ -89,6 +92,9 @@ private:
     retries_configuration& _retries_config;
     absl::flat_hash_map<model::topic_partition, shared_produce_partition>
       _partitions;
+    /// Partitions with a produce dispatch outstanding; send() rejects a
+    /// second dispatch for a partition already present.
+    absl::flat_hash_set<model::topic_partition> _in_flight_sends;
     prefix_logger* _logger;
     error_handler _error_handler;
     topic_cache& _topic_cache;

--- a/src/v/kafka/client/test/BUILD
+++ b/src/v/kafka/client/test/BUILD
@@ -128,7 +128,29 @@ redpanda_cc_btest(
         "//src/v/model",
         "//src/v/test_utils:seastar_boost",
         "@boost//:test",
+        "@seastar",
         "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "producer_test",
+    timeout = "short",
+    srcs = [
+        "producer_test.cc",
+    ],
+    deps = [
+        ":utils",
+        "//src/v/kafka/client",
+        "//src/v/kafka/client:brokers",
+        "//src/v/kafka/client:configuration",
+        "//src/v/kafka/client:logger",
+        "//src/v/kafka/client:topic_cache",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "//src/v/utils:prefix_logger",
+        "@googletest//:gtest",
+        "@seastar",
     ],
 )
 

--- a/src/v/kafka/client/test/cluster_test.cc
+++ b/src/v/kafka/client/test/cluster_test.cc
@@ -293,7 +293,11 @@ TEST_F(ClusterFixture, TestDispatchingMultipleRequests) {
     ss::when_all_succeed(std::ranges::to<std::vector<ss::future<>>>(range))
       .get();
     /**
-     * check that order is preserved
+     * Every request must land exactly once. Order is not asserted:
+     * dispatch() suspends between the call and the write to the
+     * connection, so concurrent dispatches can reach the wire in any
+     * order (shuffle_task_queue reorders them in practice). Callers that
+     * need order must not overlap requests; see produce_partition.
      */
     auto batches = app.partition_manager
                      .invoke_on(
@@ -305,11 +309,14 @@ TEST_F(ClusterFixture, TestDispatchingMultipleRequests) {
                      .get();
 
     ASSERT_EQ(batches.size(), 10);
+    std::vector<int> values;
+    values.reserve(batches.size());
     for (auto& b : batches) {
         auto records = b.copy_records();
-        auto r_number = serde::from_iobuf<int>(records[0].value().copy());
-        ASSERT_EQ(static_cast<int64_t>(r_number), b.base_offset()());
+        values.push_back(serde::from_iobuf<int>(records[0].value().copy()));
     }
+    std::ranges::sort(values);
+    ASSERT_TRUE(std::ranges::equal(values, std::ranges::iota_view(0, 10)));
 }
 
 TEST_F(ClusterFixture, TestTopicTimeout) {

--- a/src/v/kafka/client/test/produce_partition.cc
+++ b/src/v/kafka/client/test/produce_partition.cc
@@ -17,6 +17,7 @@
 #include "model/record.h"
 #include "test_utils/async.h"
 
+#include <seastar/core/sleep.hh>
 #include <seastar/testing/thread_test_case.hh>
 
 #include <boost/test/tools/old/interface.hpp>
@@ -72,5 +73,62 @@ SEASTAR_THREAD_TEST_CASE(test_produce_partition_record_count) {
     BOOST_REQUIRE_EQUAL(consumed_batches[1].record_count(), 3);
     auto c_res2 = c_res2_fut.get();
     BOOST_REQUIRE_EQUAL(c_res2.base_offset, model::offset{3});
+    producer.stop().get();
+}
+
+// produce_partition dispatches at most one request at a time. The test puts
+// one batch in flight, then produces five records that each exceed the
+// flush thresholds: none may dispatch while the first is outstanding. After
+// handle_response() they go out as one batch. Per-partition ordering rests
+// on this: dispatches that never overlap cannot reorder.
+SEASTAR_THREAD_TEST_CASE(test_produce_partition_serializes_dispatch) {
+    int outstanding = 0;
+    int consumed = 0;
+    auto consumer = [&](model::record_batch&&) {
+        BOOST_REQUIRE_EQUAL(outstanding, 0);
+        ++outstanding;
+        ++consumed;
+    };
+
+    auto cfg = kc::configuration{};
+    // force a flush attempt on every produce
+    cfg.produce_batch_size_bytes.set_value(1);
+    cfg.produce_batch_record_count.set_value(1);
+
+    kc::produce_partition producer(
+      kc::producer_configuration::from_config_store(cfg), consumer);
+
+    auto c_res0_fut = producer.produce(make_batch(model::offset(0), 1));
+    RPTEST_REQUIRE_EVENTUALLY(5s, [&consumed]() { return consumed == 1; });
+
+    std::vector<ss::future<kc::produce_partition::response>> futs;
+    futs.reserve(5);
+    for (int i = 1; i <= 5; ++i) {
+        futs.push_back(producer.produce(make_batch(model::offset(i), 1)));
+    }
+    // give the flush timers every chance to (wrongly) fire
+    ss::sleep(100ms).get();
+    BOOST_REQUIRE_EQUAL(consumed, 1);
+
+    --outstanding;
+    producer.handle_response(
+      kafka::produce_response::partition{
+        .partition_index{model::partition_id{42}},
+        .error_code = kafka::error_code::none,
+        .base_offset{model::offset{0}}});
+    BOOST_REQUIRE_EQUAL(c_res0_fut.get().base_offset, model::offset{0});
+
+    // the buffered records go out as one request
+    RPTEST_REQUIRE_EVENTUALLY(5s, [&consumed]() { return consumed == 2; });
+
+    --outstanding;
+    producer.handle_response(
+      kafka::produce_response::partition{
+        .partition_index{model::partition_id{42}},
+        .error_code = kafka::error_code::none,
+        .base_offset{model::offset{1}}});
+    for (auto& fut : futs) {
+        fut.get();
+    }
     producer.stop().get();
 }

--- a/src/v/kafka/client/test/producer_test.cc
+++ b/src/v/kafka/client/test/producer_test.cc
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "kafka/client/broker.h"
+#include "kafka/client/brokers.h"
+#include "kafka/client/configuration.h"
+#include "kafka/client/logger.h"
+#include "kafka/client/producer.h"
+#include "kafka/client/test/utils.h"
+#include "kafka/client/topic_cache.h"
+#include "test_utils/async.h"
+#include "test_utils/test.h"
+#include "utils/prefix_logger.h"
+
+#include <gtest/gtest.h>
+
+using namespace std::chrono_literals;
+
+namespace kafka::client {
+struct producer_test_access {
+    static ss::future<>
+    send(producer& p, model::topic_partition tp, model::record_batch batch) {
+        return p.send(std::move(tp), std::move(batch));
+    }
+    static bool send_in_flight(producer& p, const model::topic_partition& tp) {
+        return p._in_flight_sends.contains(tp);
+    }
+};
+} // namespace kafka::client
+
+namespace {
+namespace kc = kafka::client;
+
+struct null_broker_factory final : kc::broker_factory {
+    ss::future<kc::shared_broker_t>
+    create_broker(model::node_id, net::unresolved_address) final {
+        throw std::runtime_error("unexpected broker creation");
+    }
+};
+} // namespace
+
+// producer::send() asserts against a concurrent dispatch to the same
+// partition. The public API cannot trigger it (produce_partition serializes
+// dispatch; see test_produce_partition_serializes_dispatch), so the second
+// dispatch goes through test access.
+TEST(ProducerDeathTest, ConcurrentDispatchHitsGuard) {
+    kc::configuration cfg;
+    // dispatch a produce request on the first record
+    cfg.produce_batch_record_count.set_value(1);
+    cfg.produce_batch_size_bytes.set_value(1);
+    kc::retries_configuration retries{
+      .max_retries = 3,
+      // parks the first dispatch in retry backoff while the second is issued
+      .retry_base_backoff = 10s,
+    };
+    kc::topic_cache topic_cache;
+    prefix_logger logger(kc::kclog, "producer_test");
+    kc::brokers brokers(logger, std::make_unique<null_broker_factory>());
+    kc::producer p(
+      kc::producer_configuration::from_config_store(cfg),
+      retries,
+      topic_cache,
+      brokers,
+      logger,
+      [](std::exception_ptr) { return ss::now(); });
+
+    model::topic_partition tp(model::topic("t"), model::partition_id(0));
+
+    // The batch is dispatched through produce_partition's consumer; with no
+    // leader known it fails into retry backoff, holding the in-flight guard.
+    auto produce_fut = p.produce(tp, make_batch(model::offset(0), 1));
+    RPTEST_REQUIRE_EVENTUALLY(
+      5s, [&] { return kc::producer_test_access::send_in_flight(p, tp); });
+
+    ASSERT_DEATH(
+      {
+          (void)kc::producer_test_access::send(
+            p, tp, make_batch(model::offset(1), 1));
+      },
+      "concurrent produce dispatch");
+
+    // stop() aborts the parked dispatch; the record resolves with an error
+    p.stop().get();
+    auto res = produce_fut.get();
+    EXPECT_NE(res.error_code, kafka::error_code::none);
+}


### PR DESCRIPTION
`ClusterFixture.TestDispatchingMultipleRequests` fails under seastar's `shuffle_task_queue` mode: it asserts that concurrent `dispatch()` calls reach the wire in submission order, which was never guaranteed — a fiber can be rescheduled between `dispatch()` and the write to the connection. Drop the ordering assertion; the test keeps its multi-request coverage (every request lands exactly once).

Ordered concurrent produce would need more than the client provides (in-order retries, ideally idempotent produce). Nobody pipelines today: the producer dispatches at most one request per partition, and per-partition ordering rests on that. Encode the contract: track partitions with a dispatch in flight and assert on a concurrent send. An assert, because error handling there is complex — a violation means the dispatch accounting is already corrupt.

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none