### PR TITLE
admin/usage: clarify that datalake kafka_bytes_processed is cumulative

### DIFF
--- a/src/v/redpanda/admin/api-doc/usage.json
+++ b/src/v/redpanda/admin/api-doc/usage.json
@@ -38,7 +38,7 @@
                 },
                 "kafka_bytes_processed": {
                     "type": "long",
-                    "description": "Total number of topic bytes successfully converted to Iceberg format. This is a counter that persists across restarts."
+                    "description": "Cumulative all-time total of topic bytes successfully converted to Iceberg format for this topic revision, measured at the bucket's close time."
                 }
             }
         },


### PR DESCRIPTION
Fix the description of the datalake total bytes processed usage number.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.2.x
- [X] v26.1.x
- [X] v25.3.x

## Release Notes

* none
