### PR TITLE
test_utils: accept expressions in RPTEST_REQUIRE_EVENTUALLY

### DIFF
--- a/src/v/kafka/client/test/cluster_test.cc
+++ b/src/v/kafka/client/test/cluster_test.cc
@@ -74,7 +74,7 @@ public:
     // connections a test is about to open.
     void enable_sasl_and_wait() {
         enable_sasl();
-        RPTEST_REQUIRE_EVENTUALLY(5s, [] {
+        RPTEST_REQUIRE_EVENTUALLY(5s, [&] {
             auto shards = boost::irange(0u, ss::this_smp_shard_count());
             return ss::map_reduce(
               shards.begin(),

--- a/src/v/test_utils/async.h
+++ b/src/v/test_utils/async.h
@@ -27,6 +27,7 @@
 #include <seastar/core/timed_out_error.hh>
 
 #include <chrono>
+#include <type_traits>
 
 using namespace std::chrono_literals;
 
@@ -56,6 +57,25 @@ using namespace std::chrono_literals;
 
 namespace tests {
 
+namespace detail {
+
+/// The coroutine frame keeps \p p at a stable address: a suspended
+/// coroutine predicate holds a pointer to it.
+template<typename Predicate>
+ss::future<>
+spin_wait_loop(model::timeout_clock::time_point deadline, Predicate p) {
+    while (model::timeout_clock::now() <= deadline) {
+        bool stop = co_await ss::futurize_invoke(p);
+        if (stop) {
+            co_return;
+        }
+        co_await ss::sleep(std::chrono::milliseconds(10));
+    }
+    throw ss::timed_out_error();
+}
+
+} // namespace detail
+
 // clang-format off
 template<typename Rep, typename Period, typename Predicate>
 requires std::is_invocable_r_v<bool, Predicate> ||
@@ -64,25 +84,11 @@ requires std::is_invocable_r_v<bool, Predicate> ||
 /// Used to wait for Predicate to become true
 ss::future<> cooperative_spin_wait_with_timeout(
   std::chrono::duration<Rep, Period> timeout, Predicate p) {
-    using futurator = ss::futurize<std::invoke_result_t<Predicate>>;
-    auto tout = model::timeout_clock::now() + timeout;
+    auto deadline = model::timeout_clock::now() + timeout;
+    // with_timeout bounds a predicate call that never resolves; the loop's
+    // deadline check ends polling, including in the abandoned fiber.
     return ss::with_timeout(
-      tout, ss::repeat([tout, p = std::forward<Predicate>(p)]() mutable {
-          if (model::timeout_clock::now() > tout) {
-              return ss::make_exception_future<ss::stop_iteration>(
-                ss::timed_out_error());
-          }
-          auto f = futurator::invoke(p);
-          return f.then([](bool stop) {
-              if (stop) {
-                  return ss::make_ready_future<ss::stop_iteration>(
-                    ss::stop_iteration::yes);
-              }
-              return ss::sleep(std::chrono::milliseconds(10)).then([] {
-                  return ss::stop_iteration::no;
-              });
-          });
-      }));
+      deadline, detail::spin_wait_loop(deadline, std::move(p)));
 }
 
 // When a test expects that any background fibers should complete promptly,

--- a/src/v/test_utils/async.h
+++ b/src/v/test_utils/async.h
@@ -14,7 +14,6 @@
 #include "base/seastarx.h"
 #include "base/vassert.h" // IWYU pragma: keep; macro expansion
 #include "model/timeout_clock.h"
-#include "ssx/sformat.h" // IWYU pragma: keep; macro expansion
 #include "test_utils/test_macros.h"
 
 #include <seastar/core/future-util.hh>
@@ -26,38 +25,69 @@
 #include <seastar/core/thread.hh>
 #include <seastar/core/timed_out_error.hh>
 
+#include <fmt/format.h>
+
 #include <chrono>
+#include <string>
 #include <type_traits>
 
 using namespace std::chrono_literals;
 
+/// Waits until the given condition becomes true, failing the test on timeout.
+///
+/// The condition is either a boolean expression, re-evaluated every poll
+/// interval:
+///     RPTEST_REQUIRE_EVENTUALLY(5s, consumed_offset() == 100);
+/// or a nullary predicate returning bool or ss::future<bool>:
+///     RPTEST_REQUIRE_EVENTUALLY(5s, [&] { ... });
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define RPTEST_REQUIRE_EVENTUALLY_CORO(...)                                    \
+#define RPTEST_REQUIRE_EVENTUALLY(timeout, ...)                                \
     /* NOLINTNEXTLINE(*do-while*) */                                           \
     do {                                                                       \
         try {                                                                  \
-            co_await ::tests::cooperative_spin_wait_with_timeout(__VA_ARGS__); \
+            ::tests::cooperative_spin_wait_with_timeout(                       \
+              timeout, ::tests::detail::eventually_predicate([&] {             \
+                  return (__VA_ARGS__);                                        \
+              }))                                                              \
+              .get();                                                          \
         } catch (const ss::timed_out_error&) {                                 \
-            RPTEST_FAIL_CORO(                                                  \
-              ssx::sformat("Timed out at {}:{}", __FILE__, __LINE__));         \
+            RPTEST_FAIL(                                                       \
+              ::tests::detail::eventually_timeout_message(                     \
+                #__VA_ARGS__, __FILE__, __LINE__));                            \
         }                                                                      \
     } while (0);
 
+/// Coroutine variant of RPTEST_REQUIRE_EVENTUALLY.
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define RPTEST_REQUIRE_EVENTUALLY(...)                                         \
+#define RPTEST_REQUIRE_EVENTUALLY_CORO(timeout, ...)                           \
     /* NOLINTNEXTLINE(*do-while*) */                                           \
     do {                                                                       \
         try {                                                                  \
-            ::tests::cooperative_spin_wait_with_timeout(__VA_ARGS__).get();    \
+            co_await ::tests::cooperative_spin_wait_with_timeout(              \
+              timeout, ::tests::detail::eventually_predicate([&] {             \
+                  return (__VA_ARGS__);                                        \
+              }));                                                             \
         } catch (const ss::timed_out_error&) {                                 \
-            RPTEST_FAIL(                                                       \
-              ssx::sformat("Timed out at {}:{}", __FILE__, __LINE__));         \
+            RPTEST_FAIL_CORO(                                                  \
+              ::tests::detail::eventually_timeout_message(                     \
+                #__VA_ARGS__, __FILE__, __LINE__));                            \
         }                                                                      \
     } while (0);
 
 namespace tests {
 
 namespace detail {
+
+/// A nullary predicate returning bool or ss::future<bool>.
+template<typename R>
+inline constexpr bool is_eventually_predicate
+  = std::is_invocable_r_v<bool, R>
+    || std::is_invocable_r_v<ss::future<bool>, R>;
+
+/// A value testable for truthiness, or an ss::future<bool>.
+template<typename R>
+inline constexpr bool is_eventually_value
+  = std::is_constructible_v<bool, R> || std::is_same_v<R, ss::future<bool>>;
 
 /// The coroutine frame keeps \p p at a stable address: a suspended
 /// coroutine predicate holds a pointer to it.
@@ -76,11 +106,8 @@ spin_wait_loop(model::timeout_clock::time_point deadline, Predicate p) {
 
 } // namespace detail
 
-// clang-format off
 template<typename Rep, typename Period, typename Predicate>
-requires std::is_invocable_r_v<bool, Predicate> ||
-         std::is_invocable_r_v<ss::future<bool>, Predicate>
-// clang-format on
+requires detail::is_eventually_predicate<Predicate>
 /// Used to wait for Predicate to become true
 ss::future<> cooperative_spin_wait_with_timeout(
   std::chrono::duration<Rep, Period> timeout, Predicate p) {
@@ -90,6 +117,44 @@ ss::future<> cooperative_spin_wait_with_timeout(
     return ss::with_timeout(
       deadline, detail::spin_wait_loop(deadline, std::move(p)));
 }
+
+namespace detail {
+
+inline std::string
+eventually_timeout_message(const char* condition, const char* file, int line) {
+    return fmt::format(
+      "Timed out waiting for {} at {}:{}", condition, file, line);
+}
+
+/// \p f is the macro-wrapped condition. A predicate condition is unwrapped
+/// and polled directly; a value condition is re-evaluated on every poll by
+/// polling the wrapper itself.
+template<typename F>
+auto eventually_predicate(F f) {
+    using R = std::invoke_result_t<F&>;
+    static_assert(
+      !(is_eventually_predicate<R> && is_eventually_value<R>),
+      "RPTEST_REQUIRE_EVENTUALLY condition is ambiguous: its value is both "
+      "invocable and convertible to bool. Wrap it in a lambda ([&] { return "
+      "p(); }) to poll it, or write an explicit condition (p != nullptr) to "
+      "test its value. For captureless lambdas, use [&] instead of []");
+    if constexpr (is_eventually_predicate<R>) {
+        return f();
+    } else if constexpr (std::is_same_v<R, ss::future<bool>>) {
+        return f;
+    } else if constexpr (is_eventually_value<R>) {
+        return [f = std::move(f)]() mutable { return static_cast<bool>(f()); };
+    } else {
+        static_assert(
+          false,
+          "RPTEST_REQUIRE_EVENTUALLY condition must be a boolean expression "
+          "or a nullary predicate returning bool or ss::future<bool>");
+        // keeps the static_assert the only error
+        return [] { return false; };
+    }
+}
+
+} // namespace detail
 
 // When a test expects that any background fibers should complete promptly,
 // and wants to send a barrier through all the inter-CPU queues to ensure

--- a/src/v/test_utils/tests/BUILD
+++ b/src/v/test_utils/tests/BUILD
@@ -35,6 +35,7 @@ redpanda_cc_gtest(
     deps = [
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
+        "@seastar",
     ],
 )
 

--- a/src/v/test_utils/tests/gtest_test.cc
+++ b/src/v/test_utils/tests/gtest_test.cc
@@ -50,12 +50,10 @@ TEST_CORO(SeastarTest, SleepCoro) {
     ASSERT_EQ_CORO(100, 100);
 }
 
-TEST(SeastarTest, assert_eventually) {
-    RPTEST_REQUIRE_EVENTUALLY(100ms, [] { return true; });
-}
+TEST(SeastarTest, assert_eventually) { RPTEST_REQUIRE_EVENTUALLY(100ms, true); }
 
 TEST_CORO(SeastarTest, assert_eventually_coro) {
-    RPTEST_REQUIRE_EVENTUALLY_CORO(100ms, [] { return true; });
+    RPTEST_REQUIRE_EVENTUALLY_CORO(100ms, true);
 }
 
 TEST_CORO(SeastarTest, SkippingWorks) {

--- a/src/v/test_utils/tests/test_utils_test.cc
+++ b/src/v/test_utils/tests/test_utils_test.cc
@@ -16,9 +16,34 @@
 // unset this so we test the fallback macros
 #undef IS_GTEST
 
+#include "test_utils/async.h"
 #include "test_utils/test_macros.h"
 
+#include <seastar/core/sleep.hh>
+
 #include <gtest/gtest.h>
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+namespace {
+// A suspending predicate whose coroutine frame points into the predicate
+// object; the object must stay at a stable address while suspended.
+struct sleeping_predicate {
+    int& attempts;
+    ss::future<bool> operator()() {
+        co_await ss::sleep(1ms);
+        co_return ++attempts >= 3;
+    }
+};
+} // namespace
+
+TEST(TestUtilsTest, assert_eventually_async_predicate) {
+    int attempts = 0;
+    RPTEST_REQUIRE_EVENTUALLY(5s, sleeping_predicate{attempts});
+    ASSERT_GE(attempts, 3);
+}
 
 TEST(TestUtilsTest, test_macros_pass) {
     RPTEST_REQUIRE(true);

--- a/src/v/test_utils/tests/test_utils_test.cc
+++ b/src/v/test_utils/tests/test_utils_test.cc
@@ -16,6 +16,8 @@
 // unset this so we test the fallback macros
 #undef IS_GTEST
 
+#include "test_utils/test.h"
+
 #include "test_utils/async.h"
 #include "test_utils/test_macros.h"
 
@@ -24,8 +26,55 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <functional>
+#include <optional>
+#include <type_traits>
 
 using namespace std::chrono_literals;
+
+TEST(TestUtilsTest, assert_eventually_predicate) {
+    RPTEST_REQUIRE_EVENTUALLY(100ms, [&] { return true; });
+}
+
+TEST_CORO(TestUtilsTest, assert_eventually_predicate_coro) {
+    RPTEST_REQUIRE_EVENTUALLY_CORO(100ms, [&] { return true; });
+}
+
+TEST(TestUtilsTest, assert_eventually_expression) {
+    int attempts = 0;
+    RPTEST_REQUIRE_EVENTUALLY(5s, ++attempts >= 3);
+    ASSERT_GE(attempts, 3);
+}
+
+TEST_CORO(TestUtilsTest, assert_eventually_expression_coro) {
+    int attempts = 0;
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, ++attempts >= 3);
+    ASSERT_GE_CORO(attempts, 3);
+}
+
+TEST(TestUtilsTest, assert_eventually_expression_with_commas) {
+    // an angle-bracket comma splits the macro arguments; __VA_ARGS__
+    // rejoins them
+    RPTEST_REQUIRE_EVENTUALLY(5s, std::is_same_v<int, int>);
+}
+
+TEST(TestUtilsTest, assert_eventually_bool_convertible_expression) {
+    std::optional<int> opt;
+    auto setter = ss::sleep(10ms).then([&] { opt = 42; });
+    RPTEST_REQUIRE_EVENTUALLY(5s, opt);
+    ASSERT_EQ(*opt, 42);
+    setter.get();
+}
+
+TEST(TestUtilsTest, assert_eventually_future_expression) {
+    int attempts = 0;
+    RPTEST_REQUIRE_EVENTUALLY(5s, ss::make_ready_future<bool>(++attempts >= 3));
+    ASSERT_GE(attempts, 3);
+}
+
+TEST(TestUtilsTest, assert_eventually_stateful_predicate) {
+    RPTEST_REQUIRE_EVENTUALLY(5s, [n = 0]() mutable { return ++n >= 3; });
+}
 
 namespace {
 // A suspending predicate whose coroutine frame points into the predicate
@@ -44,6 +93,51 @@ TEST(TestUtilsTest, assert_eventually_async_predicate) {
     RPTEST_REQUIRE_EVENTUALLY(5s, sleeping_predicate{attempts});
     ASSERT_GE(attempts, 3);
 }
+
+// Compile-time classification of RPTEST_REQUIRE_EVENTUALLY conditions;
+// eventually_predicate rejects the ambiguous (both) and invalid (neither)
+// cases with a static_assert.
+namespace {
+
+using tests::detail::is_eventually_predicate;
+using tests::detail::is_eventually_value;
+
+using capturing_lambda = decltype([n = 0] { return n == 0; });
+using captureless_lambda = decltype([] { return true; });
+
+// polled as predicates
+static_assert(
+  is_eventually_predicate<capturing_lambda>
+  && !is_eventually_value<capturing_lambda>);
+
+// tested as values
+static_assert(!is_eventually_predicate<bool> && is_eventually_value<bool>);
+static_assert(!is_eventually_predicate<int*> && is_eventually_value<int*>);
+static_assert(
+  !is_eventually_predicate<std::optional<int>>
+  && is_eventually_value<std::optional<int>>);
+static_assert(
+  !is_eventually_predicate<ss::future<bool>>
+  && is_eventually_value<ss::future<bool>>);
+// a non-nullary callable can only be null-checked, not polled
+static_assert(
+  !is_eventually_predicate<std::function<void(int)>>
+  && is_eventually_value<std::function<void(int)>>);
+
+// ambiguous: both invocable and convertible to bool, rejected
+static_assert(
+  is_eventually_predicate<captureless_lambda>
+  && is_eventually_value<captureless_lambda>);
+static_assert(
+  is_eventually_predicate<std::function<bool()>>
+  && is_eventually_value<std::function<bool()>>);
+static_assert(
+  is_eventually_predicate<bool (*)()> && is_eventually_value<bool (*)()>);
+
+// neither predicate nor value, rejected
+static_assert(!is_eventually_predicate<void> && !is_eventually_value<void>);
+
+} // namespace
 
 TEST(TestUtilsTest, test_macros_pass) {
     RPTEST_REQUIRE(true);


### PR DESCRIPTION
RPTEST_REQUIRE_EVENTUALLY(_CORO) now also accepts a boolean expression, re-evaluated every poll interval, in addition to the usual nullary predicate:

```cpp
RPTEST_REQUIRE_EVENTUALLY(5s, consumed_offset() == 100);
```

The macro wraps the condition in a lambda and classifies its value at compile time: callables are polled, bool-testable values are re-evaluated, and values that are both (function pointers, `std::function<bool()>`, captureless lambdas) or neither are rejected with a descriptive static_assert. Timeout messages now include the stringified condition.

Writing tests for the async (`ss::future<bool>`) predicate path exposed a pre-existing crash: `cooperative_spin_wait_with_timeout` stored the predicate in an `ss::repeat` action, which seastar relocates while a suspended coroutine-lambda predicate still references it. The first commit fixes that by keeping the predicate in a coroutine frame with a stable address.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none