### PR TITLE
rptest: propagate log_config to the shadow link source cluster

### DIFF
--- a/tests/rptest/scale_tests/cluster_linking_many_partitions_test.py
+++ b/tests/rptest/scale_tests/cluster_linking_many_partitions_test.py
@@ -7,12 +7,50 @@ from rptest.tests.cluster_linking_test_base import (
 )
 from rptest.clients.default import TopicSpec
 from rptest.services.cluster import TestContext, cluster
+from rptest.services.multi_cluster_services import SecondaryClusterArgs
 from rptest.utils.scale_parameters import ScaleParameters
+
+# A cloud-topic partition read is latency-bound: a per-object metastore lookup,
+# a footer read, and an object-store GET. At the default
+# fetch_max_read_concurrency=1 a fetch reads its partitions serially, so at
+# topic_count=1, where the whole partition budget lands on one topic, reads miss
+# the consumer's fetch deadline and it stops making progress entirely. A little
+# concurrency pipelines the reads and hides the per-read round trip.
+#
+# Both clusters need it. Each serves a consumer over the full partition count:
+# the target additionally mirrors every partition, and the source is marginal on
+# its own (it finished 172 messages short of the workload in one run and stalled
+# 771 short in the next).
+#
+# Raising it is not free, so only the modes that read through the object store
+# get it. The max_bytes short-circuit in the fetch path races across concurrent
+# reads, and up to fetch_max_read_concurrency reads count as the obligatory
+# batch read, so a fetch can buffer more than it was asked for. local and
+# tiered_v1 would pay that for nothing: their reads were never latency-bound,
+# and both pass at the default.
+FETCH_CONCURRENCY_CONF = {"fetch_max_read_concurrency": 4}
+CLOUD_TOPIC_STORAGE_MODES = (
+    TopicSpec.STORAGE_MODE_CLOUD,
+    TopicSpec.STORAGE_MODE_IMPL_TIERED_V2,
+)
 
 
 class ClusterLinkingScaleTest(ShadowLinkPreAllocTestBase):
     def __init__(self, test_context: TestContext):
-        super().__init__(test_context=test_context)
+        storage_mode = (test_context.injected_args or {}).get("storage_mode")
+        reads_via_object_store = storage_mode in CLOUD_TOPIC_STORAGE_MODES
+        if reads_via_object_store:
+            secondary_args = SecondaryClusterArgs(
+                extra_rp_conf=dict(FETCH_CONCURRENCY_CONF)
+            )
+        else:
+            secondary_args = SecondaryClusterArgs()
+        super().__init__(
+            test_context=test_context,
+            secondary_cluster_args=secondary_args,
+        )
+        if reads_via_object_store:
+            self.redpanda.add_extra_rp_conf(dict(FETCH_CONCURRENCY_CONF))
         self.scale = ScaleParameters(
             self.redpanda,
             replication_factor=3,

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -674,11 +674,40 @@ class ShadowLinkTestBase(PreallocNodesTest):
                 }
             )
 
-        # Propagate SI / cloud-topics config to the secondary (source)
-        # cluster, creating a fresh SecondaryClusterArgs to avoid
+        kwargs.setdefault(
+            "log_config",
+            LoggingConfig(
+                "info",
+                logger_levels={
+                    "cluster": "trace",
+                    "shadow_link": "trace",
+                    "kafka/client": "trace",
+                    "kafka": "trace",
+                    "archival": "trace",
+                    "tx": "trace",
+                    "shadow_link_service": "trace",
+                },
+            ),
+        )
+
+        # Propagate logging and SI / cloud-topics config to the secondary
+        # (source) cluster, creating a fresh SecondaryClusterArgs to avoid
         # mutating the shared default instance.
+        sec_kwargs = dict(secondary_cluster_args.kwargs)
+        # A secondary left without a log_config takes its default level from
+        # the redpanda_log_level ducktape global, which is trace in CDT. At
+        # scale that is tens of GB of log per node, enough that the
+        # end-of-test log scan and trim overrun the test timeout. Copy rather
+        # than share: set_up_failure_injection mutates logger_levels in place.
+        primary_log_config: LoggingConfig = kwargs["log_config"]
+        sec_kwargs.setdefault(
+            "log_config",
+            LoggingConfig(
+                primary_log_config.default_level,
+                logger_levels=dict(primary_log_config.logger_levels),
+            ),
+        )
         if needs_si:
-            sec_kwargs = dict(secondary_cluster_args.kwargs)
             if "si_settings" not in sec_kwargs:
                 sec_kwargs["si_settings"] = kwargs.get("si_settings")
             if needs_cloud_topics:
@@ -701,26 +730,10 @@ class ShadowLinkTestBase(PreallocNodesTest):
                     }
                 )
                 sec_kwargs["extra_rp_conf"] = sec_extra
-            secondary_cluster_args = SecondaryClusterArgs(
-                secondary_cluster_args.num_brokers,
-                *secondary_cluster_args.args,
-                **sec_kwargs,
-            )
-
-        kwargs.setdefault(
-            "log_config",
-            LoggingConfig(
-                "info",
-                logger_levels={
-                    "cluster": "trace",
-                    "shadow_link": "trace",
-                    "kafka/client": "trace",
-                    "kafka": "trace",
-                    "archival": "trace",
-                    "tx": "trace",
-                    "shadow_link_service": "trace",
-                },
-            ),
+        secondary_cluster_args = SecondaryClusterArgs(
+            secondary_cluster_args.num_brokers,
+            *secondary_cluster_args.args,
+            **sec_kwargs,
         )
 
         super().__init__(


### PR DESCRIPTION
The source cluster was built without a log_config, so its default level came from the redpanda_log_level ducktape global rather than the test. In CDT that is trace, which put the source at ~64GB of log per node against ~0.13GB on the target in ClusterLinkingScaleTest. The end-of-test log scan, object storage scrub and log trim then ran past the 2700s test timeout even though the test body itself passed in 1059s.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [ ] v25.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
