### PR TITLE
bytes: rewrite iobuf stream helpers as coroutines

### DIFF
--- a/src/v/bytes/iostream.cc
+++ b/src/v/bytes/iostream.cc
@@ -54,29 +54,21 @@ ss::output_stream<char> make_iobuf_ref_output_stream(iobuf& io) {
 }
 
 ss::future<iobuf> read_iobuf_exactly(ss::input_stream<char>& in, size_t n) {
-    return ss::do_with(iobuf{}, n, [&in](iobuf& b, size_t& n) {
-        return ss::do_until(
-                 [&n] { return n == 0; },
-                 [&n, &in, &b] {
-                     return in.read_up_to(n).then(
-                       [&n, &b](ss::temporary_buffer<char> buf) {
-                           if (buf.empty()) {
-                               n = 0;
-                               return;
-                           }
-                           n -= buf.size();
-                           b.append(std::move(buf));
-                       });
-                 })
-          .then([&b] { return std::move(b); });
-    });
+    iobuf result;
+    while (n > 0) {
+        auto buffer = co_await in.read_up_to(n);
+        if (buffer.empty()) {
+            break;
+        }
+        n -= buffer.size();
+        result.append(std::move(buffer));
+    }
+    co_return result;
 }
 
 ss::future<>
 write_iobuf_to_output_stream(iobuf buf, ss::output_stream<char>& output) {
-    return ss::do_with(std::move(buf), [&output](iobuf& buf) {
-        return ss::do_for_each(buf, [&output](iobuf::fragment& f) {
-            return output.write(f.get(), f.size());
-        });
-    });
+    for (const auto& fragment : buf) {
+        co_await output.write(fragment.get(), fragment.size());
+    }
 }


### PR DESCRIPTION
Improve readability and HALO synergies.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes


* none
