### PR TITLE
DNM: no-op build to check gRPC remote cache after asset API enablement

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -540,3 +540,7 @@ filegroup(
     strip_prefix = "JSONTestSuite-1ef36fa01286573e846ac449e8683f8833c5b26a",
     urls = ["https://github.com/nst/JSONTestSuite/archive/1ef36fa01286573e846ac449e8683f8833c5b26a.tar.gz"],
 )
+
+# No-op change to trigger a CI build: verifying the Bazel gRPC remote cache
+# still works after redpanda-data/devprod-infra#722 (Remote Asset API enabled
+# on the prod bazel-remote service).


### PR DESCRIPTION
**Do not merge.** No-op comment in `MODULE.bazel` to trigger a CI build.

Purpose: confirm the Bazel gRPCS remote cache still behaves normally now that
[devprod-infra#722](https://github.com/redpanda-data/devprod-infra/pull/722)
enabled `--experimental_remote_asset_api` on the prod `bazel-remote` ECS service
([TFC apply](https://app.terraform.io/app/redpanda-data/aws-bazel-remote-prod/runs/run-oS7qEDTWPSpTEGj5) succeeded 2026-08-04). This build does **not** exercise the
asset API itself - `--experimental_remote_downloader` is still off in CI (vtools
[#4334](https://github.com/redpanda-data/vtools/pull/4334)) - it is the control
run: normal action-cache hit behaviour, unchanged.

[CORE-16911](https://redpandadata.atlassian.net/browse/CORE-16911) /
[CORE-16343](https://redpandadata.atlassian.net/browse/CORE-16343). Supersedes the
older no-op PR #31340 (which was for devprod-infra#702).

## Release Notes

- none

[CORE-16911]: https://redpandadata.atlassian.net/browse/CORE-16911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-16343]: https://redpandadata.atlassian.net/browse/CORE-16343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ