### PR TITLE
DNM: verify bazel external fetches via the remote downloader (asset API)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -540,3 +540,7 @@ filegroup(
     strip_prefix = "JSONTestSuite-1ef36fa01286573e846ac449e8683f8833c5b26a",
     urls = ["https://github.com/nst/JSONTestSuite/archive/1ef36fa01286573e846ac449e8683f8833c5b26a.tar.gz"],
 )
+
+# No-op change to trigger a CI build: verifying Bazel external dependency
+# fetches are served through the bazel-remote Remote Asset API when
+# --experimental_remote_downloader is enabled (CORE-16343).

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -355,7 +355,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "Sge1thaTIUepifUmXA80WBhVeqj8Bxh7+30mbdnbv3o=",
+        "bzlTransitiveDigest": "o54xXzkCGHDhVnwhfrYvt9ob2g3/y6fPd0mOYGhaOkA=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedInputs": [
           "REPO_MAPPING:,bazel_tools bazel_tools",
@@ -431,7 +431,7 @@
               "build_file": "@@//bazel/thirdparty:jsoncons.BUILD",
               "sha256": "078ba32cd1198cbeb1903fbf4881d4960b226bdf8083d9f5a927b96f0aa8d6dd",
               "strip_prefix": "jsoncons-ffd2540bc9cfb54c16ef4d29d80622605d8dfbe8",
-              "url": "https://github.com/danielaparker/jsoncons/archive/ffd2540bc9cfb54c16ef4d29d80622605d8dfbe8.tar.gz",
+              "url": "https://github.com/danielaparker/jsoncons/archive/DELIBERATELY-BROKEN-FOR-CORE-16343-DO-NOT-MERGE.tar.gz",
               "patches": [
                 "@@//bazel/thirdparty:jsoncons-pr-603.patch"
               ],

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -71,7 +71,7 @@ def data_dependency():
         build_file = "//bazel/thirdparty:jsoncons.BUILD",
         sha256 = "078ba32cd1198cbeb1903fbf4881d4960b226bdf8083d9f5a927b96f0aa8d6dd",
         strip_prefix = "jsoncons-ffd2540bc9cfb54c16ef4d29d80622605d8dfbe8",
-        url = "https://github.com/danielaparker/jsoncons/archive/ffd2540bc9cfb54c16ef4d29d80622605d8dfbe8.tar.gz",
+        url = "https://github.com/danielaparker/jsoncons/archive/DELIBERATELY-BROKEN-FOR-CORE-16343-DO-NOT-MERGE.tar.gz",
         patches = ["//bazel/thirdparty:jsoncons-pr-603.patch"],
         patch_args = ["-p1"],
     )


### PR DESCRIPTION
**Do not merge.** Verification vehicle for
[CORE-16343](https://redpandadata.atlassian.net/browse/CORE-16343) /
[CORE-16911](https://redpandadata.atlassian.net/browse/CORE-16911).

Bazel's external dependency fetches (`http_archive`, `bazel_dep`, toolchain
downloads) are done directly against upstream today, so a transient GitHub
404/502 aborts the whole build - Bazel never retries 4xx and is sparing on 5xx.
`--experimental_remote_downloader` routes those fetches through our own
`bazel-remote` over the Remote Asset API instead, which caches them and removes
GitHub from the critical path without any manual mirroring.

The server side landed today:
[devprod-infra#722](https://github.com/redpanda-data/devprod-infra/pull/722)
enabled `--experimental_remote_asset_api` on the prod service. The client-side
flag is a one-line vtools change (the CI-generated `user.bazelrc`), so there is
no permanent redpanda-repo change in this effort - this PR is just a no-op
commit used to drive CI runs against the vtools branch that sets the flag:

```
/rp-unit-test
vtools_gitref=td-remote-downloader-test
```

That branch is the approved
[vtools#4334](https://github.com/redpanda-data/vtools/pull/4334) one-liner
rebased onto vtools `main`, plus an explicit
`--experimental_remote_downloader_local_fallback=false` so a broken downloader
fails the build loudly instead of silently falling back to a direct upstream
fetch (a green build with fallback enabled would prove nothing).

Planned verification, in order:

1. **Positive run** (this commit): fetches go through the asset API with local
   fallback disabled. Green = every external fetch was served by bazel-remote.
2. **Negative run** (follow-up commit): point one dependency at a deliberately
   bad upstream URL while keeping its `sha256`. bazel-remote resolves the
   `checksum.sri` qualifier against its CAS, so a green build proves the bytes
   came from our cache and not from upstream.

## Release Notes

- none

[CORE-16343]: https://redpandadata.atlassian.net/browse/CORE-16343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-16911]: https://redpandadata.atlassian.net/browse/CORE-16911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ