### PR TITLE
`security`: apply snapshots and replace ACL store contents atomically 

### DIFF
--- a/src/v/cluster/security_manager.cc
+++ b/src/v/cluster/security_manager.cc
@@ -12,11 +12,13 @@
 
 #include "cluster/commands.h"
 #include "cluster/controller_snapshot.h"
+#include "security/acl_store.h"
 #include "security/authorizer.h"
 #include "security/credential_store.h"
 #include "security/role_store.h"
 
 #include <seastar/core/loop.hh>
+#include <seastar/core/smp.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
 #include <system_error>
@@ -220,30 +222,38 @@ security_manager::fill_snapshot(controller_snapshot& controller_snap) const {
     co_return;
 }
 
+ss::future<> apply_security_snapshot_to_shard(
+  security::credential_store& credentials,
+  security::authorizer& authorizer,
+  security::role_store& roles,
+  const controller_snapshot_parts::security_t& snapshot) {
+    security::credential_store staged_credentials;
+    co_await ss::do_for_each(
+      snapshot.user_credentials, [&staged_credentials](const auto& user) {
+          staged_credentials.put(user.username, user.credential);
+      });
+
+    auto staged_acls = co_await authorizer.store().stage_bindings(
+      snapshot.acls);
+
+    security::role_store staged_roles;
+    co_await ss::do_for_each(snapshot.roles, [&staged_roles](const auto& r) {
+        staged_roles.put(r.name, security::role{r.role});
+    });
+
+    credentials = std::move(staged_credentials);
+    authorizer.store().commit_bindings(std::move(staged_acls));
+    roles = std::move(staged_roles);
+}
+
 ss::future<> security_manager::apply_snapshot(
   model::offset, const controller_snapshot& controller_snap) {
     const auto& snapshot = controller_snap.security;
 
-    co_await _credentials.invoke_on_all(
-      [&snapshot](security::credential_store& credentials) {
-          credentials.clear();
-          return ss::do_for_each(
-            snapshot.user_credentials, [&credentials](const auto& user) {
-                credentials.put(user.username, user.credential);
-            });
-      });
-
-    co_await _authorizer.invoke_on_all(
-      [&snapshot](security::authorizer& authorizer) {
-          return authorizer.reset_bindings(snapshot.acls);
-      });
-
-    co_await _roles.invoke_on_all(
-      [&snapshot](security::role_store& role_store) {
-          return ss::do_for_each(snapshot.roles, [&role_store](const auto& r) {
-              role_store.put(r.name, security::role{r.role});
-          });
-      });
+    return ss::smp::invoke_on_all([this, &snapshot] {
+        return apply_security_snapshot_to_shard(
+          _credentials.local(), _authorizer.local(), _roles.local(), snapshot);
+    });
 }
 
 } // namespace cluster

--- a/src/v/cluster/security_manager.h
+++ b/src/v/cluster/security_manager.h
@@ -22,6 +22,27 @@
 
 namespace cluster {
 
+namespace controller_snapshot_parts {
+struct security_t;
+}
+
+/**
+ * Replace this shard's security state with the snapshot's, atomically with
+ * respect to authentication and authorization running on the same shard.
+ *
+ * All three stores are staged off to the side (which yields freely, leaving the
+ * live stores untouched) and only then published, back to back with no
+ * intervening yield.
+ *
+ * Exposed for testing, production callers go through
+ * security_manager::apply_snapshot().
+ */
+ss::future<> apply_security_snapshot_to_shard(
+  security::credential_store&,
+  security::authorizer&,
+  security::role_store&,
+  const controller_snapshot_parts::security_t&);
+
 class security_manager final {
 public:
     explicit security_manager(

--- a/src/v/cluster/tests/BUILD
+++ b/src/v/cluster/tests/BUILD
@@ -1693,3 +1693,23 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "security_snapshot_apply_test",
+    timeout = "short",
+    srcs = [
+        "security_snapshot_apply_test.cc",
+    ],
+    deps = [
+        "//src/v/cluster",
+        "//src/v/cluster:controller_snapshot",
+        "//src/v/config",
+        "//src/v/container:chunked_vector",
+        "//src/v/model",
+        "//src/v/security",
+        "//src/v/test_utils:gtest",
+        "@fmt",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/cluster/tests/security_snapshot_apply_test.cc
+++ b/src/v/cluster/tests/security_snapshot_apply_test.cc
@@ -1,0 +1,156 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/controller_snapshot.h"
+#include "cluster/security_manager.h"
+#include "config/mock_property.h"
+#include "container/chunked_vector.h"
+#include "model/fundamental.h"
+#include "security/acl.h"
+#include "security/authorizer.h"
+#include "security/credential_store.h"
+#include "security/role.h"
+#include "security/role_store.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+
+#include <fmt/format.h>
+
+#include <vector>
+
+namespace cluster {
+
+namespace {
+
+const security::acl_host any_host = security::acl_host::wildcard_host();
+
+security::acl_binding literal_read_allow(
+  std::string_view topic, const security::acl_principal& principal) {
+    return security::acl_binding(
+      security::resource_pattern(
+        security::resource_type::topic,
+        ss::sstring{topic},
+        security::pattern_type::literal),
+      security::acl_entry(
+        principal,
+        any_host,
+        security::acl_operation::read,
+        security::acl_permission::allow));
+}
+
+} // namespace
+
+// Applying a controller snapshot must publish this shard's ACL store and role
+// store together.
+//
+// The authorizer resolves role-granted ACLs by consulting the role store inline
+// on every check, so the two stores are jointly load-bearing. Staging them
+// yields, and authorization runs on this shard in those gaps -- if either store
+// becomes visible before the other, a principal whose grant comes via a role is
+// transiently denied even though both the role and the ACL are present before
+// and after.
+//
+// The role_store half also has to be a replacement rather than a merge: a role
+// deleted in a log range that the snapshot subsumes is never removed otherwise,
+// so it keeps granting access on any node that installs that snapshot.
+TEST_CORO(security_snapshot_apply, publishes_acls_and_roles_together) {
+    // The snapshot rotates the grant from one role to another: both the ACL and
+    // the role membership change. That is what makes the ordering observable --
+    // publishing the ACLs first leaves a state where the new ACL names a role
+    // the live role store does not have yet, and publishing the roles first
+    // leaves the old ACL naming a role that is already gone. Either way alice
+    // is denied, even though she is authorized both before and after.
+    const security::role_name old_role{"old-role"};
+    const security::role_name new_role{"new-role"};
+    const security::role_name stale_role{"stale-role"};
+    const security::acl_principal alice(
+      security::principal_type::user, "alice");
+    const security::acl_principal old_role_principal(
+      security::principal_type::role, old_role());
+    const security::acl_principal new_role_principal(
+      security::principal_type::role, new_role());
+    const model::topic granted_topic{"granted-topic"};
+
+    security::role_store roles;
+    security::credential_store credentials;
+    config::mock_property<std::vector<ss::sstring>> superusers(
+      std::vector<ss::sstring>{});
+    security::authorizer auth(superusers.bind(), &roles);
+
+    const security::role alice_role{
+      {security::role_member::from_principal(alice)}};
+
+    // alice can read granted-topic only by virtue of her role membership.
+    // stale-role is granted nothing; it exists to show that a role the snapshot
+    // omits is actually removed rather than merged through.
+    ASSERT_TRUE_CORO(roles.put(old_role, alice_role));
+    ASSERT_TRUE_CORO(roles.put(stale_role, alice_role));
+    chunked_vector<security::acl_binding> initial;
+    initial.push_back(literal_read_allow(granted_topic(), old_role_principal));
+    auth.add_bindings(initial);
+
+    auto allowed = [&] {
+        return bool(auth.authorized(
+          granted_topic,
+          security::acl_operation::read,
+          alice,
+          any_host,
+          security::superuser_required::no,
+          {}));
+    };
+    ASSERT_TRUE_CORO(allowed());
+
+    // The snapshot carries the same grant, plus enough filler that staging is
+    // certain to exceed the task quota and yield. The grant under test is last
+    // so a partially staged store cannot happen to contain it.
+    constexpr size_t filler = 50'000;
+    controller_snapshot_parts::security_t snapshot;
+    snapshot.acls.reserve(filler + 1);
+    for (size_t i = 0; i < filler; ++i) {
+        snapshot.acls.push_back(literal_read_allow(
+          fmt::format("filler-{:06}", i), new_role_principal));
+    }
+    snapshot.acls.push_back(
+      literal_read_allow(granted_topic(), new_role_principal));
+    snapshot.roles.emplace_back(new_role, alice_role);
+
+    bool apply_complete = false;
+    auto apply = apply_security_snapshot_to_shard(
+                   credentials, auth, roles, snapshot)
+                   .then([&apply_complete] { apply_complete = true; });
+
+    // Interleave authorization checks with the staging.
+    size_t checks = 0;
+    size_t denials = 0;
+    while (!apply_complete) {
+        if (!allowed()) {
+            ++denials;
+        }
+        ++checks;
+        co_await ss::yield();
+    }
+    co_await std::move(apply);
+
+    // Guards against the test passing trivially: if staging never yielded,
+    // nothing interleaved and neither race was exercised.
+    ASSERT_GT_CORO(checks, 1);
+    ASSERT_EQ_CORO(denials, 0);
+
+    ASSERT_TRUE_CORO(allowed());
+
+    // The snapshot is authoritative for roles: the ones it omits are gone,
+    // rather than merged through and left granting access indefinitely.
+    ASSERT_TRUE_CORO(roles.contains(new_role));
+    ASSERT_FALSE_CORO(roles.contains(old_role));
+    ASSERT_FALSE_CORO(roles.contains(stale_role));
+}
+
+} // namespace cluster

--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -19,6 +19,7 @@
 #include "serde/rw/rw.h"
 #include "utils/to_string.h"
 
+#include <seastar/core/loop.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
 #include <container/chunked_vector.h>
@@ -27,6 +28,7 @@
 #include <algorithm>
 #include <iterator>
 #include <ranges>
+#include <utility>
 
 namespace security {
 
@@ -353,17 +355,27 @@ ss::future<chunked_vector<acl_binding>> acl_store::all_bindings() const {
     co_return result;
 }
 
+ss::future<acl_store::staged_bindings>
+acl_store::stage_bindings(const chunked_vector<acl_binding>& bindings) const {
+    staged_bindings staged;
+
+    co_await ss::do_for_each(bindings, [&staged](const acl_binding& binding) {
+        insert_binding(staged.acls, staged.prefix_index, binding);
+    });
+    co_await ss::do_for_each(
+      staged.acls, [](const auto& node) { node->entries.rehash(); });
+
+    co_return staged;
+}
+
+void acl_store::commit_bindings(staged_bindings staged) {
+    _acls = std::move(staged.acls);
+    _prefix_index = std::move(staged.prefix_index);
+}
+
 ss::future<>
 acl_store::reset_bindings(const chunked_vector<acl_binding>& bindings) {
-    // NOTE: not coroutinized because otherwise clang-14 crashes.
-    _acls.clear();
-    _prefix_index.clear();
-    return ss::do_for_each(
-             bindings, [this](const auto& binding) { insert_binding(binding); })
-      .then([this] {
-          return ss::do_for_each(
-            _acls, [](const auto& node) { node->entries.rehash(); });
-      });
+    commit_bindings(co_await stage_bindings(bindings));
 }
 
 acl_principal acl_principal::from_string(std::string_view principal) {

--- a/src/v/security/acl_store.h
+++ b/src/v/security/acl_store.h
@@ -74,9 +74,18 @@ public:
      */
     acl_matches find(resource_type, const ss::sstring&) const;
 
-    // NOTE: the following functions assume that acl_store doesn't change across
-    // yield points.
+    // NOTE: assumes that acl_store doesn't change across yield points.
     ss::future<chunked_vector<acl_binding>> all_bindings() const;
+
+    /**
+     * Replace the entire contents of the store with `bindings`.
+     *
+     * Atomic with respect to readers: the replacement is built off to the side
+     * and swapped in without an intervening yield, so a find() interleaved with
+     * the rebuild sees either the whole old set or the whole new one, never a
+     * partial one. Callers rely on this, since Kafka authorization checks may
+     * be in flight on the same shard.
+     */
     ss::future<> reset_bindings(const chunked_vector<acl_binding>& bindings);
 
 private:
@@ -152,7 +161,7 @@ private:
      * erasure of an `_acls` key MUST drop the corresponding `_prefix_index`
      * entry in the same step. remove_bindings() (the only element-erasing path)
      * does exactly this when it prunes an emptied pattern; reset_bindings()
-     * clears both.
+     * replaces both together.
      */
     container_type _acls;
 
@@ -170,28 +179,70 @@ private:
      * prunes the emptied pattern from `_acls`, and reset rebuilds alongside
      * `_acls`. There are few resource types, so this map stays tiny.
      */
-    absl::flat_hash_map<resource_type, radix_tree<acl_entry_set_match>>
-      _prefix_index;
+    using prefix_index_type
+      = absl::flat_hash_map<resource_type, radix_tree<acl_entry_set_match>>;
 
-    /// Insert one binding into `_acls`, and when it creates a new prefixed
-    /// pattern, record a reference to it in the prefix index. Returns the entry
+    prefix_index_type _prefix_index;
+
+    /// Insert one binding into `acls`, and when it creates a new prefixed
+    /// pattern, record a reference to it in `prefix_index`. Returns the entry
     /// set it was added to so callers may rehash(); does not rehash itself.
-    acl_entry_set& insert_binding(const acl_binding& binding) {
+    ///
+    /// Takes the containers explicitly so reset_bindings() can build a
+    /// replacement pair without publishing it as it goes.
+    static acl_entry_set& insert_binding(
+      container_type& acls,
+      prefix_index_type& prefix_index,
+      const acl_binding& binding) {
         const auto& pattern = binding.pattern();
-        if (auto it = _acls.find(pattern); it != _acls.end()) {
+        if (auto it = acls.find(pattern); it != acls.end()) {
             (*it)->entries.insert(binding.entry());
             return (*it)->entries;
         }
-        auto [it, _] = _acls.insert(std::make_unique<acls_node>(pattern));
+        auto [it, _] = acls.insert(std::make_unique<acls_node>(pattern));
         auto& node = **it;
         node.entries.insert(binding.entry());
         if (pattern.pattern() == pattern_type::prefixed) {
-            _prefix_index[pattern.resource()].insert(
+            prefix_index[pattern.resource()].insert(
               node.pattern.name(),
               acl_entry_set_match{node.pattern, node.entries});
         }
         return node.entries;
     }
+
+    acl_entry_set& insert_binding(const acl_binding& binding) {
+        return insert_binding(_acls, _prefix_index, binding);
+    }
+
+public:
+    class staged_bindings {
+    public:
+        staged_bindings() = default;
+        staged_bindings(staged_bindings&&) noexcept = default;
+        staged_bindings& operator=(staged_bindings&&) noexcept = default;
+        staged_bindings(const staged_bindings&) = delete;
+        staged_bindings& operator=(const staged_bindings&) = delete;
+        ~staged_bindings() noexcept = default;
+
+    private:
+        friend class acl_store;
+        container_type acls;
+        prefix_index_type prefix_index;
+    };
+
+    /**
+     * Build a replacement for the store's entire contents without publishing
+     * it. Yields while building; the store is untouched throughout, so readers
+     * continue to see the current contents.
+     */
+    ss::future<staged_bindings>
+    stage_bindings(const chunked_vector<acl_binding>& bindings) const;
+
+    /**
+     * Install a replacement built by stage_bindings(). Synchronous and
+     * yield-free, so readers see either the whole old set or the whole new one.
+     */
+    void commit_bindings(staged_bindings staged);
 };
 
 /*

--- a/src/v/security/tests/authorizer_test.cc
+++ b/src/v/security/tests/authorizer_test.cc
@@ -17,7 +17,10 @@
 #include "security/authorizer.h"
 #include "security/role.h"
 #include "security/role_store.h"
+#include "test_utils/test.h"
 
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/loop.hh>
 #include <seastar/util/defer.hh>
 
 #include <fmt/format.h>
@@ -3697,6 +3700,78 @@ TEST(AUTHORIZER_TEST, prefix_index_remove_then_readd) {
 
     grant();
     EXPECT_TRUE(idx_allows(store, "tz-events", alice));
+}
+
+namespace {
+
+acl_binding literal_read_allow(std::string_view name, const acl_principal& p) {
+    return acl_binding(
+      resource_pattern(
+        resource_type::topic, ss::sstring{name}, pattern_type::literal),
+      acl_entry(p, idx_any_host, acl_operation::read, acl_permission::allow));
+}
+
+} // namespace
+
+// reset_bindings() must never be observable in a partial state.
+//
+// The refill is not a single reactor task: ss::do_for_each defers the remainder
+// once the task quota expires, and on the controller snapshot apply path
+// authorization checks run on this shard in exactly those gaps. An in-place
+// clear-then-refill therefore hands an empty (or half-built) store to those
+// checks and denies principals that do hold the ACL -- observed in production
+// as transient TOPIC_AUTHORIZATION_FAILED on a correctly-ACLed consumer while a
+// controller snapshot was installed, which the client saw as a fatal error.
+//
+// The grant under test is placed LAST in the replacement set so that a partial
+// store cannot happen to contain it: under the old implementation the very
+// first interleaved check fails.
+TEST_CORO(AUTHORIZER_TEST, reset_bindings_not_observable_as_partial) {
+    const acl_principal alice(principal_type::user, "alice");
+    constexpr std::string_view granted_topic = "stable-topic";
+
+    acl_store store;
+    chunked_vector<acl_binding> initial;
+    initial.push_back(literal_read_allow(granted_topic, alice));
+    store.add_bindings(initial);
+    ASSERT_TRUE_CORO(idx_allows(store, granted_topic, alice));
+
+    // Large enough that the refill is certain to exceed the task quota and
+    // yield at least once, with the grant under test rebuilt only at the end.
+    constexpr size_t bulk = 50'000;
+    chunked_vector<acl_binding> replacement;
+    replacement.reserve(bulk + 1);
+    for (size_t i = 0; i < bulk; ++i) {
+        replacement.push_back(
+          literal_read_allow(fmt::format("filler-{:06}", i), alice));
+    }
+    replacement.push_back(literal_read_allow(granted_topic, alice));
+
+    bool reset_complete = false;
+    auto reset = store.reset_bindings(replacement).then([&reset_complete] {
+        reset_complete = true;
+    });
+
+    // Interleave authorization checks with the rebuild.
+    size_t checks = 0;
+    size_t denials = 0;
+    while (!reset_complete) {
+        if (!idx_allows(store, granted_topic, alice)) {
+            ++denials;
+        }
+        ++checks;
+        co_await ss::yield();
+    }
+    co_await std::move(reset);
+
+    // Guards against the test passing trivially: if the rebuild never yielded,
+    // nothing interleaved and the race was not exercised at all.
+    ASSERT_GT_CORO(checks, 1);
+    ASSERT_EQ_CORO(denials, 0);
+
+    // The replacement is fully visible once the future resolves.
+    ASSERT_TRUE_CORO(idx_allows(store, granted_topic, alice));
+    ASSERT_TRUE_CORO(idx_allows(store, "filler-000000", alice));
 }
 
 } // namespace security


### PR DESCRIPTION
See commit messages.

Relevant slack thread: https://redpandadata.slack.com/archives/C01ND4SVB6Z/p1785875309326759

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.2.x
- [X] v26.1.x
- [ ] v25.3.x

## Release Notes

### Bug Fixes

* Fixes a bug in which transient `TOPIC_AUTHORIZATION_FAILED` errors and SASL authentication failures were possible during application of a controller snapshot.