### PR TITLE
kafka/client: fix node crash on concurrent pandaproxy consumer fetches

### DIFF
--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -264,6 +264,8 @@ ss::future<> consumer::stop() {
     _inactive_timer.set_callback([]() {});
 
     _on_stopped(name());
+
+    _fetch_mutex.broken();
     if (_as.abort_requested()) {
         return ss::now();
     }
@@ -543,11 +545,19 @@ consumer::dispatch_fetch(broker_reqs_t::value_type br) {
 
     // Session state is deliberately not applied here: whether the tracked
     // offsets may advance depends on the responses of ALL brokers, which
-    // only consumer::fetch() has in hand.
+    // only consumer::fetch() has in hand. This coupling is also why fetch()
+    // serializes whole polls rather than taking per-broker locks: one
+    // broker's apply-or-discard decision depends on the others' outcomes.
     co_return res;
 }
 
 ss::future<> consumer::seed_positions_from_committed() {
+    // Runs under _fetch_mutex, necessarily: has_offset() is read before the
+    // OffsetFetch suspension and reseed() written after it, so an
+    // unserialized peer could advance a position in between, and the stale
+    // write would rewind it past records already delivered -- re-delivering
+    // them and regressing the group's committed offset at the next commit.
+    //
     // Collect the assigned partitions that have no fetch position yet --
     // freshly (re)assigned ones. A partition that already carries an in-RAM
     // position (e.g. a same-instance rebalance) is left untouched: that
@@ -733,6 +743,29 @@ ss::future<fetch_response> consumer::fetch(
   std::chrono::milliseconds timeout, std::optional<int32_t> max_bytes) {
     refresh_inactivity_timer();
 
+    // The deadline is computed before acquiring the mutex so that time spent
+    // waiting behind an in-flight fetch counts against this caller's budget;
+    // the round loop below always runs at least one round, which is then
+    // non-blocking (max_wait_ms=0).
+    const auto deadline = ss::lowres_clock::now() + timeout;
+
+    // Overlapping fetches wait their turn: a round snapshots each session's
+    // id, epoch and offsets (build_fetch_requests), suspends dispatching to
+    // the brokers, and writes the state back (fetch_session::apply). Two
+    // overlapping first fetches would both snapshot epoch 0 and make the
+    // broker mint two sessions; the second response then flips the session
+    // id mid-stream (see fetch_session::update_session_state). Overlap needs
+    // no adversarial caller: a pandaproxy HTTP client (or load balancer)
+    // whose request timeout is shorter than the fetch long-poll retries
+    // while the original fetch is still in flight.
+    //
+    // The scope is the whole poll rather than anything smaller: seeding
+    // rewinds live fetch positions if it races a fetch (see
+    // seed_positions_from_committed), and a round's responses are applied
+    // all-or-nothing across brokers (see dispatch_fetch), so no per-broker
+    // critical section could complete independently anyway.
+    auto units = co_await _fetch_mutex.get_units(_as);
+
     // Before fetching, seed any freshly (re)assigned partition from the group's
     // committed offset so a fresh consumer instance resumes where the group
     // left off, mirroring the Java consumer's updateFetchPositions at the start
@@ -754,7 +787,6 @@ ss::future<fetch_response> consumer::fetch(
     // must still issue one (non-blocking, max_wait_ms=0) fetch rather than give
     // up with an empty response. The deadline is therefore checked after the
     // round, not before.
-    const auto deadline = ss::lowres_clock::now() + timeout;
     for (;;) {
         const auto remaining = std::max(
           deadline - ss::lowres_clock::now(),

--- a/src/v/kafka/client/consumer.h
+++ b/src/v/kafka/client/consumer.h
@@ -26,6 +26,7 @@
 #include "kafka/protocol/fetch.h"
 #include "kafka/protocol/offset_commit.h"
 #include "kafka/protocol/offset_fetch.h"
+#include "ssx/mutex.h"
 
 #include <seastar/core/shared_ptr.hh>
 
@@ -210,6 +211,14 @@ private:
     std::unique_ptr<assignment_plan> _plan{};
     assignment_t _assignment{};
     absl::node_hash_map<shared_broker_t, fetch_session> _fetch_sessions;
+    /// \brief Serializes fetch() calls: one poll at a time per consumer.
+    /// All mutation of _fetch_sessions happens inside fetch(), under this
+    /// mutex; every other access may only read it synchronously (as
+    /// offset_commit() does), which is safe without the mutex. Even a
+    /// synchronous mutation elsewhere would interleave with a fetch
+    /// suspended mid-round. See fetch() for why the critical section
+    /// spans the whole poll.
+    ssx::mutex _fetch_mutex{"consumer::fetch"};
     ss::noncopyable_function<void(const kafka::member_id&)> _on_stopped;
     ss::noncopyable_function<ss::future<>(std::exception_ptr)>
       _external_mitigate;

--- a/src/v/kafka/client/fetch_session.cc
+++ b/src/v/kafka/client/fetch_session.cc
@@ -40,10 +40,12 @@ void fetch_session::reseed(
 }
 
 void fetch_session::update_session_state(const fetch_response& res) {
-    if (_id == invalid_fetch_session_id) {
-        _id = fetch_session_id{res.data.session_id};
+    const auto res_id = fetch_session_id{res.data.session_id};
+
+    if (!has_session()) {
+        _id = res_id;
     }
-    vassert(res.data.session_id == _id, "session mismatch: {}", *this);
+    vassert(res_id == _id, "session mismatch: {}", *this);
     ++_epoch;
 }
 

--- a/src/v/kafka/client/fetch_session.cc
+++ b/src/v/kafka/client/fetch_session.cc
@@ -9,6 +9,7 @@
 
 #include "kafka/client/fetch_session.h"
 
+#include "kafka/client/logger.h"
 #include "kafka/protocol/fetch.h"
 #include "kafka/protocol/schemata/offset_commit_request.h"
 
@@ -39,13 +40,30 @@ void fetch_session::reseed(
     _offsets[model::topic{tpv.topic}][tpv.partition] = new_offset;
 }
 
+void fetch_session::reset_session() {
+    _id = invalid_fetch_session_id;
+    _epoch = initial_fetch_session_epoch;
+}
+
 void fetch_session::update_session_state(const fetch_response& res) {
     const auto res_id = fetch_session_id{res.data.session_id};
 
     if (!has_session()) {
         _id = res_id;
+    } else if (res_id != _id) {
+        // This side and the broker no longer agree on the session, e.g. the
+        // broker dropped a session that went empty. The session is a
+        // disposable optimization and the consumed positions live in
+        // _offsets, so forget it and let the next fetch re-establish one.
+        vlog(
+          kclog.warn,
+          "fetch response session_id {} does not match session {}; resetting "
+          "session",
+          res_id,
+          *this);
+        reset_session();
+        return;
     }
-    vassert(res_id == _id, "session mismatch: {}", *this);
     ++_epoch;
 }
 

--- a/src/v/kafka/client/fetch_session.cc
+++ b/src/v/kafka/client/fetch_session.cc
@@ -64,7 +64,10 @@ void fetch_session::update_session_state(const fetch_response& res) {
         reset_session();
         return;
     }
-    ++_epoch;
+
+    if (has_session()) {
+        ++_epoch;
+    }
 }
 
 void fetch_session::rehash_offsets() {

--- a/src/v/kafka/client/fetch_session.h
+++ b/src/v/kafka/client/fetch_session.h
@@ -85,6 +85,10 @@ private:
     /// happens to the response on our side.
     void update_session_state(const fetch_response& res);
 
+    /// \brief Forget the session, so the next fetch re-establishes one with a
+    /// full (epoch 0) fetch. The consumed positions in _offsets survive.
+    void reset_session();
+
     bool has_session() const { return _id != kafka::invalid_fetch_session_id; }
 
     /// \brief Compact each partition-offset map to its current size, e.g.

--- a/src/v/kafka/client/fetch_session.h
+++ b/src/v/kafka/client/fetch_session.h
@@ -79,10 +79,15 @@ public:
     fmt::iterator format_to(fmt::iterator it) const;
 
 private:
-    /// \brief Common session bookkeeping shared by apply() and
-    /// discard(): seed/validate the session id and advance the
-    /// epoch, since the broker has processed the request regardless of what
-    /// happens to the response on our side.
+    /// \brief Reconcile the tracked session with a response; shared by
+    /// apply() and discard(). The response is authoritative about the id:
+    /// adopt it when we hold no session, forget ours when it names a
+    /// different one. Then advance the epoch only while a session is held:
+    /// the broker advanced its side by processing the request (so discard()
+    /// advances too), but a broker may decline a session and answer
+    /// sessionless, and advancing without one would make the next request
+    /// an incremental fetch against a session that never existed, which the
+    /// broker rejects with fetch_session_id_not_found.
     void update_session_state(const fetch_response& res);
 
     /// \brief Forget the session, so the next fetch re-establishes one with a

--- a/src/v/kafka/client/fetch_session.h
+++ b/src/v/kafka/client/fetch_session.h
@@ -85,6 +85,8 @@ private:
     /// happens to the response on our side.
     void update_session_state(const fetch_response& res);
 
+    bool has_session() const { return _id != kafka::invalid_fetch_session_id; }
+
     /// \brief Compact each partition-offset map to its current size, e.g.
     /// after reseed() or apply() may have grown it.
     void rehash_offsets();

--- a/src/v/kafka/client/test/BUILD
+++ b/src/v/kafka/client/test/BUILD
@@ -231,6 +231,34 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "fetch_session_broker_test",
+    timeout = "short",
+    srcs = [
+        "fetch_session_broker.cc",
+    ],
+    deps = [
+        "//src/v/cluster:client_quota_backend",
+        "//src/v/cluster:cluster_utils",
+        "//src/v/cluster:controller_log_limiter",
+        "//src/v/cluster:data_migration_table",
+        "//src/v/cluster:feature_backend",
+        "//src/v/cluster:leader_balancer_strategy",
+        "//src/v/cluster:node_status_backend",
+        "//src/v/cluster:self_test",
+        "//src/v/cluster:topic_metrics_watcher",
+        "//src/v/kafka/client",
+        "//src/v/kafka/client/test:fixture",
+        "//src/v/kafka/protocol",
+        "//src/v/kafka/protocol:fetch",
+        "//src/v/model",
+        "//src/v/redpanda/tests:fixture",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
 redpanda_cc_btest(
     name = "produce",
     timeout = "short",

--- a/src/v/kafka/client/test/consumer_group.cc
+++ b/src/v/kafka/client/test/consumer_group.cc
@@ -386,3 +386,121 @@ FIXTURE_TEST(consumer_group, kafka_client_fixture) {
         }
     }
 }
+
+namespace {
+
+// Collect every record offset carried by a consumer fetch response. A
+// no-data response may either omit the partition or include it with an empty
+// record set, so both shapes yield no offsets.
+//
+// The response is drained: reading a batch moves the buffer out of the record
+// set, so a second call on the same response yields nothing.
+std::vector<model::offset> consume_record_offsets(kafka::fetch_response& res) {
+    std::vector<model::offset> offsets;
+    for (const auto& part : res) {
+        auto& p = *part.partition_response;
+        BOOST_REQUIRE_EQUAL(p.error_code, kafka::error_code::none);
+        if (!p.records) {
+            continue;
+        }
+        while (!p.records->empty()) {
+            auto adapter = p.records->consume_batch();
+            BOOST_REQUIRE(adapter.batch.has_value());
+            adapter.batch->for_each_record([&](const model::record& r) {
+                offsets.push_back(
+                  adapter.batch->base_offset()
+                  + model::offset_delta{r.offset_delta()});
+            });
+        }
+    }
+    return offsets;
+}
+
+} // namespace
+
+// A consumer is not safe for concurrent fetches, but pandaproxy can deliver
+// them: an HTTP client (or load balancer) whose request timeout is shorter
+// than the fetch long-poll retries while the original fetch is still in
+// flight, and both requests land on the same consumer. Unserialized, two
+// overlapping fetches on a fresh consumer would both dispatch
+// session-creating (epoch 0) requests, making the broker mint two fetch
+// sessions for a consumer that tracks only one per broker (see
+// fetch_session::update_session_state).
+//
+// consumer::fetch() serializes concurrent callers instead: both fetches
+// succeed, and each record is delivered to exactly one of them -- the
+// serialized second fetch resumes from the first fetch's end position rather
+// than re-reading the same records.
+FIXTURE_TEST(consumer_group_concurrent_fetch, kafka_client_fixture) {
+    using namespace std::chrono_literals;
+
+    info("Waiting for leadership");
+    wait_for_controller_leadership().get();
+
+    info("Connecting client");
+    auto client = make_connected_client();
+    client.set_retry_base_backoff(10ms);
+    client.set_max_retries(size_t(10));
+    client.connect().get();
+    auto stop_client = ss::defer([&client]() { client.stop().get(); });
+
+    info("Adding known topic");
+    auto tp_ns = create_topic(1);
+    wait_for_lso(
+      model::ntp(tp_ns.ns, tp_ns.tp, model::partition_id{0}), model::offset{0})
+      .get();
+
+    info("Producing to topic");
+    const auto tp = model::topic_partition(tp_ns.tp, model::partition_id{0});
+    for (auto b = 0; b < 2; ++b) {
+        auto res = client
+                     .produce_record_batch(tp, make_batch(model::offset{0}, 2))
+                     .get();
+        BOOST_REQUIRE_EQUAL(res.error_code, kafka::error_code::none);
+    }
+
+    kafka::group_id group_id{"test_group_concurrent_fetch"};
+
+    info("Joining consumer");
+    auto member = client.create_consumer(group_id).get();
+    auto remove_consumer = ss::defer([&]() {
+        client.remove_consumer(group_id, member)
+          .handle_exception([](std::exception_ptr) {})
+          .get();
+    });
+
+    info("Subscribing consumer");
+    client.subscribe_consumer(group_id, member, {tp_ns.tp}).get();
+    tests::cooperative_spin_wait_with_timeout(10s, [&] {
+        return client.consumer_assignment(group_id, member)
+          .then([](kc::assignment a) { return a.size() == 1; });
+    }).get();
+
+    info("Issuing two concurrent fetches");
+    auto [res_a, res_b]
+      = ss::when_all_succeed(
+          client.consumer_fetch(group_id, member, 200ms, 1_MiB),
+          client.consumer_fetch(group_id, member, 200ms, 1_MiB))
+          .get();
+    BOOST_REQUIRE_EQUAL(res_a.data.error_code, kafka::error_code::none);
+    BOOST_REQUIRE_EQUAL(res_b.data.error_code, kafka::error_code::none);
+
+    // Each record is delivered to exactly one of the two fetches: were they
+    // not serialized, both would read from the same start position and
+    // deliver the same records twice. Either fetch may deliver any part of
+    // the log (a round need not drain everything), so assert the invariant
+    // itself: together the fetches cover every produced record, and no
+    // record appears in both.
+    auto all_offsets = consume_record_offsets(res_a);
+    all_offsets.append_range(consume_record_offsets(res_b));
+    std::ranges::sort(all_offsets);
+    const std::vector<model::offset> expected{
+      model::offset{0}, model::offset{1}, model::offset{2}, model::offset{3}};
+    BOOST_REQUIRE_EQUAL_COLLECTIONS(
+      all_offsets.begin(), all_offsets.end(), expected.begin(), expected.end());
+
+    // The consumer must remain usable afterwards.
+    auto res_c = client.consumer_fetch(group_id, member, 200ms, 1_MiB).get();
+    BOOST_REQUIRE_EQUAL(res_c.data.error_code, kafka::error_code::none);
+    BOOST_REQUIRE(consume_record_offsets(res_c).empty());
+}

--- a/src/v/kafka/client/test/fetch_session_broker.cc
+++ b/src/v/kafka/client/test/fetch_session_broker.cc
@@ -93,6 +93,40 @@ private:
     std::optional<kafka::client::transport> _client;
 };
 
+// Epoch -1 asks for a full fetch that opens no session, so the broker serves
+// records and answers with session id 0. A broker whose session cache is at its
+// memory cap answers the same way, having declined to open one.
+TEST_F(FetchSessionBrokerTest, SessionlessResponseStillDeliversRecords) {
+    connect_to_topic_with_data();
+
+    kc::fetch_session s;
+    auto res = fetch(
+      kafka::invalid_fetch_session_id,
+      kafka::final_fetch_session_epoch,
+      model::offset{0});
+    ASSERT_EQ(res.data.error_code, kafka::error_code::none);
+    EXPECT_EQ(res.data.session_id, kafka::invalid_fetch_session_id);
+    ASSERT_EQ(res.data.responses.size(), 1);
+    ASSERT_EQ(res.data.responses[0].partitions.size(), 1);
+    auto& part = res.data.responses[0].partitions[0];
+    ASSERT_EQ(part.error_code, kafka::error_code::none);
+    ASSERT_TRUE(part.records && !part.records->empty());
+    const auto delivered_through = part.records->last_offset();
+
+    s.apply(res);
+
+    // The records were delivered, so the position advances past them.
+    EXPECT_EQ(s.offset(tp()), delivered_through + model::offset{1});
+    // No session was opened though, so the epoch has to stay initial: the next
+    // request must still read as a full fetch, or the broker rejects it with
+    // fetch_session_id_not_found.
+    EXPECT_EQ(s.id(), kafka::invalid_fetch_session_id);
+    EXPECT_EQ(s.epoch(), kafka::initial_fetch_session_epoch);
+    const kafka::fetch_request next{
+      .data = {.session_id = s.id(), .session_epoch = s.epoch()}};
+    EXPECT_TRUE(next.is_full_fetch_request());
+}
+
 // Two full fetches each open their own session, which is what two overlapping
 // fetches on one consumer do: both snapshot epoch 0, so the second response
 // names a session this side never adopted.

--- a/src/v/kafka/client/test/fetch_session_broker.cc
+++ b/src/v/kafka/client/test/fetch_session_broker.cc
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "kafka/client/fetch_session.h"
+#include "kafka/client/test/fixture.h"
+#include "kafka/protocol/errors.h"
+#include "kafka/protocol/fetch.h"
+#include "kafka/protocol/types.h"
+#include "model/fundamental.h"
+#include "test_utils/test.h"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+using namespace std::chrono_literals;
+
+// fetch_session's handling of a session the client and broker disagree about
+// rests on claims about what the broker sends back. Assert those against a real
+// broker rather than a hand-built fetch_response: every response here comes off
+// the wire and is handed to fetch_session the way consumer::fetch_round does,
+// so a change in broker behaviour surfaces here instead of quietly leaving the
+// client tested against a fiction.
+class FetchSessionBrokerTest
+  : public kafka_client_fixture
+  , public seastar_test {
+public:
+    FetchSessionBrokerTest()
+      : kafka_client_fixture() {}
+
+protected:
+    /// \brief A topic with data, plus a connected raw kafka client, so a test
+    /// can send fetch requests whose session fields it controls.
+    void connect_to_topic_with_data() {
+        wait_for_controller_leadership().get();
+        auto tp_ns = make_data(get_next_partition_revision_id().get(), 1);
+        auto ntp = model::ntp(tp_ns.ns, tp_ns.tp, model::partition_id{0});
+        wait_for_lso(ntp, model::offset{1}).get();
+        _tp = model::topic_partition(tp_ns.tp, model::partition_id{0});
+
+        _client.emplace(make_kafka_client().get());
+        _client->connect().get();
+    }
+
+    seastar::future<> TearDownAsync() override {
+        if (_client) {
+            co_await _client->stop();
+            _client->shutdown();
+        }
+    }
+
+    kafka::fetch_response fetch(
+      kafka::fetch_session_id id,
+      kafka::fetch_session_epoch epoch,
+      model::offset fetch_offset) {
+        kafka::fetch_request req;
+        req.data.max_bytes = std::numeric_limits<int32_t>::max();
+        req.data.min_bytes = 1;
+        req.data.max_wait_ms = 100ms;
+        req.data.session_id = id;
+        req.data.session_epoch = epoch;
+        req.data.topics.emplace_back(
+          kafka::fetch_topic{
+            .topic = _tp.topic,
+            .partitions = {{
+              .partition = _tp.partition,
+              .fetch_offset = fetch_offset,
+            }},
+          });
+        return _client->dispatch(std::move(req), kafka::api_version(12)).get();
+    }
+
+    /// \brief A full fetch, which opens a session.
+    kafka::fetch_response open_session(model::offset fetch_offset) {
+        return fetch(
+          kafka::invalid_fetch_session_id,
+          kafka::initial_fetch_session_epoch,
+          fetch_offset);
+    }
+
+    const model::topic_partition& tp() const { return _tp; }
+
+private:
+    model::topic_partition _tp{model::topic{}, model::partition_id{0}};
+    std::optional<kafka::client::transport> _client;
+};
+
+// Two full fetches each open their own session, which is what two overlapping
+// fetches on one consumer do: both snapshot epoch 0, so the second response
+// names a session this side never adopted.
+TEST_F(FetchSessionBrokerTest, ResponseNamingAnotherSessionResets) {
+    connect_to_topic_with_data();
+
+    kc::fetch_session s;
+    auto first = open_session(model::offset{0});
+    s.apply(first);
+    const auto first_session_id = s.id();
+    ASSERT_NE(first_session_id, kafka::invalid_fetch_session_id);
+    const auto position = s.offset(tp());
+
+    auto second = open_session(position);
+    ASSERT_NE(
+      kafka::fetch_session_id(second.data.session_id), first_session_id);
+
+    s.apply(second);
+
+    EXPECT_EQ(s.id(), kafka::invalid_fetch_session_id);
+    EXPECT_EQ(s.epoch(), kafka::initial_fetch_session_epoch);
+    // Positions live client-side and survive the reset.
+    EXPECT_GE(s.offset(tp()), position);
+
+    // So the next full fetch re-establishes a session and resumes from the
+    // surviving position.
+    auto reestablished = open_session(s.offset(tp()));
+    s.apply(reestablished);
+    EXPECT_NE(s.id(), kafka::invalid_fetch_session_id);
+    EXPECT_EQ(s.epoch(), kafka::fetch_session_epoch{1});
+}
+
+// The broker rejects a request carrying an epoch it has already left behind.
+TEST_F(FetchSessionBrokerTest, RejectedRequestResets) {
+    connect_to_topic_with_data();
+
+    kc::fetch_session s;
+    auto opened = open_session(model::offset{0});
+    s.apply(opened);
+    ASSERT_NE(s.id(), kafka::invalid_fetch_session_id);
+    ASSERT_EQ(s.epoch(), kafka::fetch_session_epoch{1});
+    const auto session_id = s.id();
+    const auto position = s.offset(tp());
+
+    // Spend the epoch this side holds without applying the response, which is
+    // the state a consumer is in while its first fetch is still in flight: the
+    // broker has moved on, the client has not.
+    auto accepted = fetch(session_id, s.epoch(), position);
+    ASSERT_EQ(accepted.data.error_code, kafka::error_code::none);
+
+    // So the next request carries a stale epoch, exactly what the second of two
+    // overlapping fetches sends.
+    auto rejected = fetch(session_id, s.epoch(), position);
+    EXPECT_EQ(
+      rejected.data.error_code, kafka::error_code::invalid_fetch_session_epoch);
+    EXPECT_EQ(rejected.data.session_id, kafka::invalid_fetch_session_id);
+    // The rejection is not an empty response: the requested partition is echoed
+    // back as a placeholder with a none error_code and no records, so applying
+    // it must not move the position.
+    ASSERT_EQ(rejected.data.responses.size(), 1);
+    ASSERT_EQ(rejected.data.responses[0].partitions.size(), 1);
+    const auto& rejected_part = rejected.data.responses[0].partitions[0];
+    EXPECT_EQ(rejected_part.error_code, kafka::error_code::none);
+    EXPECT_TRUE(!rejected_part.records || rejected_part.records->empty());
+
+    s.apply(rejected);
+
+    EXPECT_EQ(s.id(), kafka::invalid_fetch_session_id);
+    EXPECT_EQ(s.epoch(), kafka::initial_fetch_session_epoch);
+    EXPECT_EQ(s.offset(tp()), position);
+}

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -2317,6 +2317,59 @@ class PandaProxyConsumerGroupTest(PandaProxyEndpoints):
         do_consumer_offset_commit(new_offset=1)
 
     @cluster(num_nodes=3)
+    def test_concurrent_fetches_on_one_consumer(self):
+        """
+        Two concurrent fetches on the same consumer instance must not corrupt
+        the consumer's fetch session or crash the node hosting the proxy.
+
+        The kafka client tracks one incremental fetch session per broker. A
+        fresh consumer's first fetch is built with session epoch 0, which asks
+        the broker to create a new session. Two overlapping first fetches both
+        go out with epoch 0, the broker creates two sessions, and the second
+        response to arrive used to trip the client's session-mismatch
+        assertion, taking down the whole node. Overlapping fetches need no
+        adversarial client: an HTTP client (or load balancer) whose request
+        timeout is shorter than the fetch long-poll retries while the original
+        fetch is still in flight.
+        """
+        group_id = f"pandaproxy-group-{uuid.uuid4()}"
+
+        self.logger.info("Create a consumer group")
+        cc_res = self._create_consumer(group_id)
+        assert cc_res.status_code == requests.codes.ok
+        c0 = Consumer(cc_res.json(), self.logger)
+
+        self.logger.info(f"Subscribe consumer to topic: {self.topic}")
+        sc_res = c0.subscribe([self.topic])
+        assert sc_res.status_code == requests.codes.no_content
+
+        # Long-poll fetches on an empty topic: both requests stay in flight
+        # for the full timeout, so both are dispatched with fetch session
+        # epoch 0.
+        self.logger.info("Issue two concurrent fetches")
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [
+                executor.submit(
+                    c0.fetch,
+                    headers=HTTP_CONSUMER_FETCH_JSON_V2_HEADERS,
+                    params={"timeout": 5000},
+                )
+                for _ in range(2)
+            ]
+            results = [f.result() for f in futures]
+
+        for res in results:
+            assert res.status_code == requests.codes.ok, (
+                f"Expected 200, got {res.status_code}: {res.text}"
+            )
+
+        # The consumer must remain usable afterwards.
+        cf_res = c0.fetch(headers=HTTP_CONSUMER_FETCH_JSON_V2_HEADERS)
+        assert cf_res.status_code == requests.codes.ok, (
+            f"Expected 200, got {cf_res.status_code}: {cf_res.text}"
+        )
+
+    @cluster(num_nodes=3)
     def test_consumer_group_fetch_after_prefix_trim(self):
         """
         CORE-16844: a fresh consumer group must recover once retention


### PR DESCRIPTION
Two concurrent HTTP fetches for the same pandaproxy consumer instance crash the node: `consumer::fetch()` reads and updates the per-broker fetch sessions across suspension points without any serialization, so two overlapping first fetches both dispatch session-creating (epoch 0) requests. The broker creates two sessions, as the protocol allows, and the second response to arrive trips the client's session-mismatch `vassert`, aborting the whole redpanda process. No adversarial client is needed: an HTTP client or load balancer whose request timeout is shorter than the fetch long-poll retries while the original fetch is still in flight.

The fix serializes the poll and makes the client tolerant of session answers it didn't expect:

* **kafka/client: serialize concurrent fetches on a consumer** — a per-consumer mutex serializes `fetch()` end to end (position seeding plus the fetch round), with the deadline computed before acquisition so a queued fetch's wait counts against its own budget. A fixture test asserts two concurrent fetches deliver every record exactly once and leave the consumer usable.
* **kafka/client: reset fetch session on response session id mismatch** (plus a small prep refactor) — the `vassert` on broker-supplied data becomes a warn plus session reset; the next fetch re-establishes the session with a full (epoch 0) fetch, and consumed positions survive client-side, so recovery costs one full fetch, never data. Defense in depth now that fetches serialize; mirrors how `direct_consumer` handles session errors.
* **kafka/client: keep fetch session epoch initial when broker declines one** — an adjacent bug found while testing against a real broker, called out for backport reviewers: a broker at its session-cache cap answers sessionless, the epoch advanced anyway, and the consumer could never fetch from that broker again. Four-line fix.
* **tests/pandaproxy: cover concurrent fetches on one consumer instance** — end-to-end repro (previously: `NodeCrash`; now passes).

Fixes [CORE-16973](https://redpandadata.atlassian.net/browse/CORE-16973).

## Backports Required
- [x] v26.2.x
- [x] v26.1.x
- [x] v25.3.x

## Release Notes
### Bug Fixes
* Fixed a node crash when two HTTP Proxy fetch requests for the same consumer instance ran concurrently. Concurrent fetches on one consumer instance are now serialized.
* Fixed an HTTP Proxy consumer becoming permanently unable to fetch from a broker whose fetch-session cache was at capacity.

[CORE-16973]: https://redpandadata.atlassian.net/browse/CORE-16973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ