### PR TITLE
[v26.1.x] `ct`: clamp timequeries to the kafka start offset

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -428,13 +428,19 @@ frontend::timequery(storage::timequery_config cfg) {
       "metadata timequery for L1: {}, for L0: {}",
       l1_result,
       l0_result);
+    auto min_offset = model::offset_cast(cfg.min_offset);
     if (l1_result) {
-        co_return co_await refine_timequery_result(
-          *l1_result, cfg.abort_source);
+        auto refined = co_await refine_timequery_result(
+          *l1_result, min_offset, cfg.abort_source);
+        // The L1 candidate can be clamped away entirely (its whole range is
+        // below the kafka start offset); the L0 candidate may still answer.
+        if (refined.has_value()) {
+            co_return refined;
+        }
     }
     if (l0_result) {
         co_return co_await refine_timequery_result(
-          *l0_result, cfg.abort_source);
+          *l0_result, min_offset, cfg.abort_source);
     }
     co_return std::nullopt;
 }
@@ -475,12 +481,23 @@ frontend::l1_timequery(storage::timequery_config cfg) {
 
 ss::future<std::optional<frontend::coarse_grained_timequery_result>>
 frontend::l0_timequery(storage::timequery_config cfg) {
+    // The query bounds are kafka offsets while the local reader operates on
+    // log offsets. Clamp the lower bound to the local log start first, then
+    // translate into log offset space. Data below the local log start has been
+    // reconciled and is answered by the L1 query.
+    auto ot_state = _partition->get_offset_translator_state();
+    auto local_start_offset = ot_state->from_log_offset(
+      _partition->raft_start_offset());
+    auto min_offset = std::max(cfg.min_offset, local_start_offset);
+    if (min_offset > cfg.max_offset) {
+        co_return std::nullopt;
+    }
     // Read L0 metadata to find the right batch. We can't use
     // _partition->timequery because it will filter for only data batches, not
     // placeholder batches.
     auto reader = co_await _partition->make_local_reader({
-      /*start_offset=*/cfg.min_offset,
-      /*max_offset=*/cfg.max_offset,
+      /*start_offset=*/ot_state->to_log_offset(min_offset),
+      /*max_offset=*/ot_state->to_log_offset(cfg.max_offset),
       /*max_bytes=*/std::numeric_limits<size_t>::max(),
       /*type_filter=*/std::nullopt,
       /*time=*/cfg.time,
@@ -533,14 +550,21 @@ frontend::l0_timequery(storage::timequery_config cfg) {
 ss::future<std::optional<storage::timequery_result>>
 frontend::refine_timequery_result(
   coarse_grained_timequery_result input,
+  kafka::offset min_offset,
   model::opt_abort_source_t abort_source) {
+    // Clamp the scan in offset space so records below the start offset can
+    // never answer the query
+    auto clamped_start = std::max(input.start_offset, min_offset);
+    if (clamped_start > input.last_offset) {
+        co_return std::nullopt;
+    }
     // Pass the timestamp so the L1 reader can use the footer's timestamp
     // index to seek directly to the relevant position, avoiding unnecessary
     // cloud IO. In the case of L0, we should only need to materialize a
     // single batch here, because the local log is correct to the granularity of
     // a batch (but not within a batch due to placeholders).
     cloud_topic_log_reader_config reader_cfg(
-      /*start_offset=*/input.start_offset,
+      /*start_offset=*/clamped_start,
       /*max_offset=*/input.last_offset,
       /*first_timestamp=*/input.time,
       /*as=*/abort_source,
@@ -576,7 +600,7 @@ frontend::refine_timequery_result(
         }
     };
 
-    auto start_offset = kafka::offset_cast(input.start_offset);
+    auto start_offset = kafka::offset_cast(clamped_start);
     auto last_offset = kafka::offset_cast(input.last_offset);
     co_return co_await std::move(reader.reader)
       .consume(

--- a/src/v/cloud_topics/frontend/frontend.h
+++ b/src/v/cloud_topics/frontend/frontend.h
@@ -200,10 +200,14 @@ private:
     ss::future<std::optional<coarse_grained_timequery_result>>
     l1_timequery(storage::timequery_config cfg);
 
-    // Create a reader to find the exact offset for a timequery.
+    // Create a reader to find the exact offset for a timequery. The result
+    // is clamped to `min_offset` (the kafka start offset). Returns nullopt if
+    // the whole candidate lies below `min_offset`.
     ss::future<std::optional<storage::timequery_result>>
-      refine_timequery_result(
-        coarse_grained_timequery_result, model::opt_abort_source_t);
+    refine_timequery_result(
+      coarse_grained_timequery_result,
+      kafka::offset min_offset,
+      model::opt_abort_source_t);
 
     raft::replicate_stages upload_and_replicate(
       model::batch_identity batch_id,

--- a/src/v/cloud_topics/tests/BUILD
+++ b/src/v/cloud_topics/tests/BUILD
@@ -32,6 +32,7 @@ redpanda_cc_gtest(
         "//src/v/cloud_topics/level_zero/stm:ctp_stm",
         "//src/v/config",
         "//src/v/container:chunked_vector",
+        "//src/v/kafka/data:partition_proxy",
         "//src/v/kafka/server/tests:kafka_test_utils",
         "//src/v/model",
         "//src/v/model:batch_builder",

--- a/src/v/cloud_topics/tests/end_to_end_test.cc
+++ b/src/v/cloud_topics/tests/end_to_end_test.cc
@@ -11,6 +11,8 @@
 #include "cloud_io/tests/s3_imposter.h"
 #include "cloud_topics/level_zero/stm/ctp_stm.h"
 #include "container/chunked_vector.h"
+#include "kafka/data/partition_proxy.h"
+#include "kafka/server/tests/delete_records_utils.h"
 #include "kafka/server/tests/list_offsets_utils.h"
 #include "kafka/server/tests/produce_consume_utils.h"
 #include "model/batch_builder.h"
@@ -82,6 +84,16 @@ public:
     tests::kafka_list_offsets_transport* make_list_offsets_client() {
         auto transport = std::make_unique<tests::kafka_list_offsets_transport>(
           make_kafka_client().get());
+        transport->start().get();
+        auto* t = transport.get();
+        cleanup.emplace_back([t = std::move(transport)] { t->stop().get(); });
+        return t;
+    }
+
+    tests::kafka_delete_records_transport* make_delete_records_client() {
+        auto transport
+          = std::make_unique<tests::kafka_delete_records_transport>(
+            make_kafka_client().get());
         transport->start().get();
         auto* t = transport.get();
         cleanup.emplace_back([t = std::move(transport)] { t->stop().get(); });
@@ -391,4 +403,154 @@ TEST_F(e2e_fixture, test_tailing_consumer_no_l0_downloads) {
       << " unexpected S3 GetObject request(s) during tailing consume. "
          "This indicates a race between replicate() and cache_put() "
          "in the cloud topics write path.";
+}
+
+// A ListOffsets-by-timestamp answer must never be below the partition's
+// Kafka start offset. Kafka guarantees the offset returned by
+// offsetsForTimes is fetchable; if it is below the start offset the client's
+// own fetch is rejected with OFFSET_OUT_OF_RANGE and auto.offset.reset fires.
+//
+// Setup: 20 single-record batches reconciled into a single L1 extent
+// [0, 20), then DeleteRecords(10). The surviving log is [10, 20). A query
+// for a timestamp older than every record must answer 10, not 0.
+TEST_F(e2e_fixture, timequery_after_delete_records_respects_start_offset_l1) {
+    // Hold reconciliation off while producing so that all of the records land
+    // in a single L1 extent -- DeleteRecords must fall strictly inside an
+    // extent, otherwise the metastore prunes the whole extent and the
+    // straddling case is never exercised.
+    test_local_cfg.get("cloud_topics_disable_reconciliation_loop")
+      .set_value(true);
+
+    constexpr int num_records = 20;
+    constexpr int delete_up_to = 10;
+
+    auto now = model::timestamp::now();
+    // Every record is in the past, oldest first: record i has
+    // ts = now - (num_records - i) seconds.
+    auto ts_for = [now](int i) {
+        return model::timestamp{now() - (num_records - i) * 1000};
+    };
+
+    auto* producer = make_producer();
+    for (int i = 0; i < num_records; ++i) {
+        producer
+          ->produce_to_partition(
+            topic_name,
+            model::partition_id(0),
+            std::vector<kv_t>{{ssx::sformat("k{}", i), ssx::sformat("v{}", i)}},
+            ts_for(i))
+          .get();
+    }
+
+    // Let a single reconciliation round move everything into L1.
+    test_local_cfg.get("cloud_topics_disable_reconciliation_loop")
+      .set_value(false);
+
+    auto partition = app.partition_manager.local().get(ntp);
+    ASSERT_NE(partition, nullptr);
+    auto stm = partition->raft()->stm_manager()->get<cloud_topics::ctp_stm>();
+    ASSERT_TRUE(stm != nullptr);
+    RPTEST_REQUIRE_EVENTUALLY(30s, [stm]() {
+        auto lro = stm->state().get_last_reconciled_offset();
+        return lro.has_value() && *lro == kafka::offset(num_records - 1);
+    });
+
+    auto* deleter = make_delete_records_client();
+    deleter
+      ->delete_records_from_partition(
+        topic_name,
+        model::partition_id(0),
+        model::offset(delete_up_to),
+        std::chrono::seconds(10))
+      .get();
+
+    // A timestamp older than every record. The oldest *surviving* record is
+    // at offset 10, so that is the only Kafka-correct answer.
+    auto* client = make_list_offsets_client();
+    auto query_ts = model::timestamp{now() - (num_records + 10) * 1000};
+    auto answer = client->timequery(ntp.tp, query_ts).get();
+    vlog(
+      e2e_test_log.info,
+      "timequery({}) answered {} (kafka start offset {})",
+      query_ts,
+      answer,
+      delete_up_to);
+    EXPECT_EQ(answer, kafka::offset(delete_up_to))
+      << "timequery answered " << answer << " rather than the Kafka start "
+      << "offset " << delete_up_to << "; a client seeking below the start "
+      << "offset gets OFFSET_OUT_OF_RANGE";
+
+    // Kafka's contract for offsetsForTimes: the returned offset is fetchable.
+    auto proxy = kafka::make_partition_proxy(partition);
+    auto fetch_ec = proxy
+                      .validate_fetch_offset(
+                        model::offset(answer()),
+                        false,
+                        model::timeout_clock::now() + 30s)
+                      .get();
+    EXPECT_EQ(fetch_ec, kafka::error_code::none)
+      << "a fetch at the offset timequery answered (" << answer
+      << ") was rejected with " << fetch_ec;
+}
+
+// Same invariant, but the coarse candidate comes from the local log:
+// DeleteRecords lands in the middle of a placeholder batch, so the local
+// reader hands refine_timequery_result a batch whose base offset is below
+// the Kafka start offset.
+TEST_F(e2e_fixture, timequery_after_delete_records_respects_start_offset_l0) {
+    // Keep everything in L0 so l1_timequery finds nothing and the L0
+    // candidate is the one that gets refined.
+    test_local_cfg.get("cloud_topics_disable_reconciliation_loop")
+      .set_value(true);
+
+    constexpr int records_per_batch = 5;
+    constexpr int num_batches = 4;
+    constexpr int num_records = records_per_batch * num_batches;
+    // Strictly inside the first batch [0, 4].
+    constexpr int delete_up_to = 3;
+
+    auto now = model::timestamp::now();
+    auto* producer = make_producer();
+    for (int b = 0; b < num_batches; ++b) {
+        std::vector<kv_t> records;
+        for (int i = 0; i < records_per_batch; ++i) {
+            int n = b * records_per_batch + i;
+            records.emplace_back(
+              ssx::sformat("k{}", n), ssx::sformat("v{}", n));
+        }
+        producer
+          ->produce_to_partition(
+            topic_name,
+            model::partition_id(0),
+            std::move(records),
+            model::timestamp{now() - (num_batches - b) * 1000})
+          .get();
+    }
+
+    auto* deleter = make_delete_records_client();
+    deleter
+      ->delete_records_from_partition(
+        topic_name,
+        model::partition_id(0),
+        model::offset(delete_up_to),
+        std::chrono::seconds(10))
+      .get();
+
+    auto* client = make_list_offsets_client();
+    auto hwm
+      = client->high_watermark_for_partition(topic_name, model::partition_id(0))
+          .get();
+    ASSERT_EQ(hwm, model::offset(num_records));
+
+    auto query_ts = model::timestamp{now() - (num_batches + 10) * 1000};
+    auto answer = client->timequery(ntp.tp, query_ts).get();
+    vlog(
+      e2e_test_log.info,
+      "L0 timequery({}) answered {} (kafka start offset {})",
+      query_ts,
+      answer,
+      delete_up_to);
+    EXPECT_EQ(answer, kafka::offset(delete_up_to))
+      << "timequery answered " << answer << " rather than the Kafka start "
+      << "offset " << delete_up_to;
 }

--- a/tests/rptest/tests/cloud_topics/e2e_test.py
+++ b/tests/rptest/tests/cloud_topics/e2e_test.py
@@ -7,12 +7,15 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import time
+
 from ducktape.tests.test import TestContext
 from typing import Any
 from ducktape.utils.util import wait_until
 from ducktape.mark import matrix
 from collections.abc import Iterable
 
+from rptest.clients.kafka_cat import KafkaCat
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.rpk import RpkTool
 from rptest.clients.admin.v2 import Admin, metastore_pb, ntp_pb
@@ -201,6 +204,49 @@ class EndToEndCloudTopicsTest(EndToEndCloudTopicsBase):
             expected_missing_records=35 * self.topics[0].partition_count
         )
         self.wait_until_all_reconciled()
+
+    @cluster(num_nodes=4)
+    def test_timequery_below_start_offset(self):
+        """A timestamp query below the start offset must not fail or answer
+        below it.
+
+        ListOffsets-by-timestamp must return a fetchable offset. Reconciliation
+        allows the local log to be prefix truncated, so after a DeleteRecords
+        the Kafka start offset can be far below the local log start and the
+        query must be served from L1 rather than a local reader positioned
+        below the log start.
+
+        This mirrors BaseTimeQuery._test_timequery_below_start_offset, which
+        pins the same invariant for a non-cloud topic.
+        """
+        base_ts = int(time.time() * 1000) - 3600_000
+
+        self.start_producer()
+        self.await_num_produced(min_records=50000)
+        self.producer.stop()
+        self.wait_until_all_reconciled()
+
+        trim_to = 1000
+        self.rpk.trim_prefix(self.s3_topic_name, trim_to)
+
+        def start_offset() -> int:
+            for part in self.rpk.describe_topic(self.s3_topic_name):
+                if part.id == 0:
+                    return part.start_offset
+            raise AssertionError("partition 0 not found")
+
+        lwm = start_offset()
+        assert lwm >= trim_to, f"trim did not take effect, start offset is {lwm}"
+
+        assert self.redpanda
+        kcat = KafkaCat(self.redpanda)
+        offset = kcat.query_offset(self.s3_topic_name, 0, base_ts)
+        self.logger.info(f"timequery({base_ts}) -> {offset}, start_offset={lwm}")
+
+        assert offset >= lwm, (
+            f"timequery answered offset {offset}, below the start offset {lwm}; "
+            "the client cannot fetch this offset"
+        )
 
     @cluster(num_nodes=4)
     def test_get_size(self):


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31353

- Command: git cherry-pick -x 4d839eaa8b
- Commits backported: 1
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-31353-v26.1.x-1785900997

## Conflict details

- 4d839eaa8b (src/v/cloud_topics/frontend/frontend.cc): the incoming hunk changed the `cloud_topic_log_reader_config` construction in `refine_timequery_result()` to use the new `clamped_start`, but it also carried a `/*group=*/cloud_io::group_id::consumer_fetch` argument that only exists on `dev`. `v26.1.x` has no `group` parameter on that constructor (`src/v/cloud_topics/log_reader_config.h`) and no `cloud_io::group_id` usage anywhere under `src/v/cloud_topics`, so the target's argument list was kept and only the substantive change (`input.start_offset` → `clamped_start`) was applied.
- 4d839eaa8b (tests/rptest/tests/cloud_topics/e2e_test.py): the new `test_timequery_below_start_offset` was inserted just above `test_get_size`, and the incoming side carried `dev`'s `@matrix(storage_mode=[...])` parameterization for both tests. `v26.1.x` does not parameterize any test in this file by `storage_mode`, and `TopicSpec.STORAGE_MODE_IMPL_TIERED_V2` does not exist on the target (only `LOCAL`/`TIERED`/`CLOUD`/`UNSET`). The new test was therefore added unparameterized as `def test_timequery_below_start_offset(self)` under the existing `@cluster(num_nodes=4)`, and `test_get_size` was left with the target's original `def test_get_size(self)` signature. `import time` was added to the target file: the new test calls `time.time()`, and `dev` already had that import from an earlier commit so the cherry-picked diff did not carry it.

## Notes

The C++ test additions in `src/v/cloud_topics/tests/end_to_end_test.cc` merged cleanly; the helper APIs they depend on were confirmed to exist on `v26.1.x`: `tests::kafka_delete_records_transport::delete_records_from_partition`, `list_offsets_utils`' `timequery` and `high_watermark_for_partition`, the `produce_to_partition(topic, pid, records, ts)` overload, `kafka::make_partition_proxy` / `validate_fetch_offset`, the `cloud_topics_disable_reconciliation_loop` config, and `ctp_stm_state::get_last_reconciled_offset()` (which returns `std::optional<kafka::offset>` on the target, as the test's `has_value()` check requires). The added Bazel dep `//src/v/kafka/data:partition_proxy` also exists on the target.

No generated files were touched by this backport.
