### PR TITLE
cloud_topics: read manifest config from topic table

### DIFF
--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -319,10 +319,12 @@ redpanda_cc_library(
         "topic_manifest_upload_manager.h",
     ],
     implementation_deps = [
+        ":state_accessors",
         ":topic_manifest_uploader",
         "//src/v/cloud_io:remote",
         "//src/v/cloud_storage:topic_path_provider",
         "//src/v/cluster",
+        "//src/v/cluster:topic_configuration",
         "//src/v/utils:retry_chain_node",
     ],
     deps = [

--- a/src/v/cloud_topics/manager/manager.cc
+++ b/src/v/cloud_topics/manager/manager.cc
@@ -82,6 +82,8 @@ ss::future<> cloud_topics_manager::start() {
               model::topic_id_partition tidp{it->second, ntp.tp.partition};
               topic_id_mapping_.erase(it);
               on_leadership_change(ntp, tidp, /*is_leader=*/false);
+              on_leadership_or_properties_change(
+                ntp, tidp, /*is_leader=*/false);
               return;
           }
           if (

--- a/src/v/cloud_topics/topic_manifest_upload_manager.cc
+++ b/src/v/cloud_topics/topic_manifest_upload_manager.cc
@@ -13,8 +13,11 @@
 #include "cloud_io/remote.h"
 #include "cloud_storage/topic_path_provider.h"
 #include "cloud_topics/logger.h"
+#include "cloud_topics/state_accessors.h"
 #include "cloud_topics/topic_manifest_uploader.h"
+#include "cluster/metadata_cache.h"
 #include "cluster/partition.h"
+#include "cluster/topic_configuration.h"
 #include "ssx/actor.h"
 #include "utils/retry_chain_node.h"
 
@@ -70,25 +73,35 @@ protected:
 private:
     ss::future<std::expected<void, topic_manifest_uploader::error>>
     upload_once() {
-        auto topic_cfg_opt = _partition->get_topic_config();
-        if (!topic_cfg_opt.has_value()) {
-            // Topic config may not yet be set if we raced with partition
-            // creation. Retry after backoff.
+        // Read the config from the topic table (metadata_cache reads through
+        // to the shard-local topic table): the partition's cached copy is
+        // updated asynchronously by controller backend reconciliation and
+        // may not yet reflect the update that signalled us.
+        auto* metadata_cache
+          = _partition->get_cloud_topics_state()->local().get_metadata_cache();
+        std::optional<cluster::topic_configuration> topic_cfg_opt
+          = metadata_cache->get_topic_cfg(
+            model::topic_namespace_view(_partition->ntp()));
+        if (
+          !topic_cfg_opt.has_value()
+          || topic_cfg_opt->tp_id != _tidp.topic_id) {
+            // Topic was deleted, or recreated under the same name; the loop
+            // will be stopped by the deletion notification. Retry until then.
             co_return std::unexpected(
               topic_manifest_uploader::error{
                 topic_manifest_uploader::errc::io_error,
                 fmt::format(
-                  "topic config not yet set on partition 0: {}", _tidp)});
+                  "no topic with matching id in topic table: {} ({})",
+                  _partition->ntp(),
+                  _tidp)});
         }
+        auto& topic_cfg = *topic_cfg_opt;
 
         // Tweak the replication factor based on the current number of
         // replicas, matching the behavior in tiered storage.
         // TODO: probably not needed?
-        auto& topic_cfg = topic_cfg_opt->get();
-        auto replication_factor = cluster::replication_factor(
+        topic_cfg.replication_factor = cluster::replication_factor(
           _partition->raft()->config().current_config().voters.size());
-        auto cfg_copy = topic_cfg;
-        cfg_copy.replication_factor = replication_factor;
 
         cloud_storage::topic_path_provider path_provider(
           topic_cfg.properties.remote_label,
@@ -99,7 +112,7 @@ private:
 
         vlog(cd_log.info, "Uploading topic manifest for {}", _tidp);
         co_return co_await _uploader.upload_manifest(
-          path_provider, cfg_copy, rev, fib);
+          path_provider, topic_cfg, rev, fib);
     }
 
     // Retries uploading until it succeeds or until we're shutting down.


### PR DESCRIPTION
The topic manifest upload loop is signaled from the topic table
properties delta but read the config from the partition's cached copy,
which controller backend updates asynchronously during reconciliation.
When the read won the race, the manifest was uploaded with stale
properties, reported success and was never re-signaled, so a property
update could be missing from the manifest until the next leadership
change. Found via `TopicManifestUploaderTest.TestManifestUpdatedOnPropertyChange`
flaking in CI; reproduces 7/10 with `--@seastar//:shuffle_task_queue=True`,
0/10 after the fix.

The first commit fixes an adjacent lifecycle gap: on topic deletion the
manager never notified the upload manager, so loops (each pinning a
`cluster::partition`) leaked for the node's lifetime.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [ ] v25.3.x

## Release Notes

* none