### PR TITLE
rpk/connect: don't cap version segments at two digits

### DIFF
--- a/src/go/rpk/pkg/cli/connect/BUILD
+++ b/src/go/rpk/pkg/cli/connect/BUILD
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "connect",
@@ -23,4 +23,11 @@ go_library(
         "@com_github_spf13_cobra//:cobra",
         "@org_uber_go_zap//:zap",
     ],
+)
+
+go_test(
+    name = "connect_test",
+    srcs = ["install_test.go"],
+    embed = [":connect"],
+    deps = ["@com_github_stretchr_testify//require"],
 )

--- a/src/go/rpk/pkg/cli/connect/install.go
+++ b/src/go/rpk/pkg/cli/connect/install.go
@@ -132,12 +132,15 @@ func downloadAndInstallConnect(ctx context.Context, fs afero.Fs, installPath, do
 // validateVersion validates that the provided version in the flag is either
 // 'latest' or it's a full semantic version.
 func validateVersion(version string) error {
-	// This simple regexp just matches that a semver is in the string, it may
-	// be prefixed with 'v' and contain anything after. Nothing to capture.
+	// The version may be prefixed with 'v' and carry a prerelease or build
+	// suffix (e.g. '4.102.0-rc1'), which is forwarded to the manifest for
+	// lookup; the manifest is the source of truth for what is published.
+	// Segments are unbounded in width: Connect minor versions passed 99 in
+	// 4.100.0.
 	if version == "latest" {
 		return nil
 	}
-	vMatch := regexp.MustCompile(`^v?\d{1,2}\.\d{1,2}\.\d{1,2}`).MatchString(version)
+	vMatch := regexp.MustCompile(`^v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$`).MatchString(version)
 	if !vMatch {
 		return fmt.Errorf("provided version %q is not valid. Ensure is either 'latest' or it follows the format MAJOR.MINOR.PATCH (e.g., 2.1.3)", version)
 	}

--- a/src/go/rpk/pkg/cli/connect/install_test.go
+++ b/src/go/rpk/pkg/cli/connect/install_test.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package connect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateVersion(t *testing.T) {
+	// Connect minor versions passed 99 in 4.100.0, so segments must not be
+	// capped in width.
+	for _, ok := range []string{"latest", "4.99.0", "4.102.0", "v4.102.0", "4.102.0-rc1", "4.102.100"} {
+		require.NoError(t, validateVersion(ok), ok)
+	}
+	for _, bad := range []string{"", "abc", "4", "4.102", "garbage", "4.102.0garbage", "4.102.0 "} {
+		require.Error(t, validateVersion(bad), bad)
+	}
+}


### PR DESCRIPTION
`rpk connect install` validated `--connect-version` against
``^v?\d{1,2}\.\d{1,2}\.\d{1,2}``. The two-digit cap on each segment means every
Redpanda Connect release since 4.100.0 is rejected before the plugin manifest is
ever consulted:

```
$ rpk connect install --connect-version 4.102.0
provided version "4.102.0" is not valid. Ensure is either 'latest' or it follows the format MAJOR.MINOR.PATCH (e.g., 2.1.3)

$ rpk connect install --connect-version 4.99.0
Redpanda Connect 4.99.0 successfully installed.
```

This blocks downgrading after a bad Connect release, version-locked CI, and
installing a known version in air-gapped environments.

The validator now uses ``^v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$``: segments are
unbounded in width, and the pattern is anchored at both ends so trailing garbage
fails validation up front instead of surfacing later as a download error.

Note the fix is *not* the plain `^v?\d+\.\d+\.\d+$` suggested in the issue. The
previous pattern was unanchored and therefore accepted prerelease suffixes,
forwarding them to the manifest — the sibling plugin validators document that
behavior as deliberate. A bare `$` would drop it, so the optional `[-+]` group
keeps prerelease and build suffixes valid while still anchoring the match.

Fixes #31432

Verified end to end against a real install in an isolated `HOME`/`PATH`:

```
$ rpk connect install --connect-version 4.102.0
Redpanda Connect 4.102.0 successfully installed.
$ rpk connect --version
Version: 4.102.0
$ rpk connect install --connect-version 4.102.0garbage
provided version "4.102.0garbage" is not valid. ...
```

Covered by a new `TestValidateVersion` — the package had no test file at all.
The test was confirmed failing against the unmodified validator before the regex
change.

### Scope

This PR deliberately changes only `rpk connect`. The identical regex is copied
into the `ai`, `check` and `k8s` managed-plugin validators, so `rpk ai` (0.2.x)
and `rpk check` (0.1.x) will hit the same wall once any segment reaches three
digits. Those are left for separate changes.

**Reviewer note on the BUILD file:** the new `go_test` target was written by hand
to match the Gazelle-generated `k8s`/`ai` siblings. `make bazel` does not run on
darwin/arm64 here — bazel fails fetching the LLVM toolchain with
`invalid base-10 literal: "0-rc2"` — and the standalone Gazelle CLI rewrites
external labels to legacy `//:go_default_library` naming because it cannot see
the bzlmod `go_deps` extension. Worth a confirming `make bazel` on Linux;
`gazelle_test` in CI should also catch any drift.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [x] v25.3.x

The `connect` validator carries the defect on all three release branches, and
this change touches only that package, so it should cherry-pick cleanly.

## Release Notes

### Bug Fixes

* `rpk connect install --connect-version` no longer rejects versions with a
  segment of three or more digits, which had blocked pinning any Redpanda Connect
  release since 4.100.0. Malformed versions with trailing characters are now
  rejected during validation rather than failing at download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
