### PR TITLE
`rptest`: exercise incremental compaction/leveling in RNOT

### DIFF
--- a/src/v/cloud_topics/level_one/maintenance/compaction/tests/reducer_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/compaction/tests/reducer_test.cc
@@ -1262,6 +1262,80 @@ TEST_F(ReducerTestFixture, CommitIntervalGovernsCommitCadence) {
       num_extents * batches_per_extent);
 }
 
+// A commit interval below the target object size is raised to it, for
+// compaction as well as leveling: a commit cuts the inflight object, so
+// honouring a sub-target interval literally would publish an undersized L1
+// extent at every boundary, which is what leveling then churns on. The
+// tradeoff is deliberate — it bounds how much preregistration-TTL headroom a
+// short interval can buy back, since a commit can no longer happen more often
+// than once per full object.
+TEST_F(ReducerTestFixture, CommitIntervalIsClampedToObjectSize) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+    constexpr int num_extents = 3;
+    constexpr int batches_per_extent = 8;
+    constexpr int records_per_batch = 5;
+    constexpr int total_records = num_extents * batches_per_extent
+                                  * records_per_batch;
+
+    latest_kv_map_t latest_kv_map;
+    auto batches = generate_batches(
+      num_extents * batches_per_extent,
+      /*cardinality=*/total_records,
+      records_per_batch,
+      /*starting_value=*/0,
+      /*produce_tombstones=*/false,
+      &latest_kv_map);
+    for (int i = 0; i < num_extents; ++i) {
+        chunked_circular_buffer<model::record_batch> extent_batches;
+        for (int j = 0; j < batches_per_extent; ++j) {
+            extent_batches.push_back(std::move(batches.front()));
+            batches.pop_front();
+        }
+        std::vector<tidp_batches_t> tidp_batches;
+        tidp_batches.emplace_back(tidp, std::move(extent_batches));
+        make_l1_objects(std::move(tidp_batches)).get();
+    }
+
+    auto info_spec = l1::metastore::compaction_info_spec{
+      .tidp = tidp,
+      .tombstone_removal_upper_bound_ts = model::timestamp::max()};
+    auto compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    auto initial_epoch = compaction_info->compaction_epoch;
+
+    // The job's whole output exceeds the 512 byte interval, so honouring it
+    // literally would cut and commit at every one of the three extent
+    // boundaries: three partial commits plus the metadata-only commit, four
+    // epoch bumps. Clamped to the 1 MiB object size — which the output never
+    // reaches — no boundary commit fires, leaving the finalize commit and the
+    // metadata-only commit: exactly two.
+    do_compact(
+      tidp,
+      ntp,
+      std::move(compaction_info->offsets_response),
+      initial_epoch,
+      compaction_info->start_offset,
+      &_metastore,
+      &_io,
+      0ms,
+      kafka::offset::max(),
+      /*max_object_size=*/1_MiB,
+      /*commit_interval_bytes=*/512)
+      .get();
+
+    compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    EXPECT_EQ(compaction_info->compaction_epoch(), initial_epoch() + 2);
+    EXPECT_TRUE(compaction_info->offsets_response.dirty_ranges.empty());
+
+    verify_compacted_log(
+      ntp,
+      tidp,
+      latest_kv_map,
+      total_records,
+      num_extents * batches_per_extent);
+}
+
 // After a partial commit cuts at an extent boundary, the next extent's
 // leading batches may be deduplicated away entirely (all their records
 // superseded later in the log), so the first batch reaching the sink sits

--- a/src/v/cloud_topics/level_one/maintenance/l1_object_sink.cc
+++ b/src/v/cloud_topics/level_one/maintenance/l1_object_sink.cc
@@ -248,6 +248,25 @@ ss::future<> l1_object_sink::prepare_iteration(kafka::offset next_extent_base) {
     co_await initialize_builder(next_extent_base);
 }
 
+size_t l1_object_sink::effective_commit_interval_bytes() const {
+    auto configured = _commit_interval_bytes();
+    auto max_object_size = _max_object_size();
+    if (configured >= max_object_size) {
+        return configured;
+    }
+    static thread_local ss::logger::rate_limit rate(std::chrono::minutes{5});
+    vloglr(
+      _ctxlog,
+      ss::log_level::warn,
+      rate,
+      "Commit interval of {} bytes is below the target object size of {} "
+      "bytes; clamping commit interval to {} bytes instead.",
+      configured,
+      max_object_size,
+      max_object_size);
+    return max_object_size;
+}
+
 ss::future<> l1_object_sink::finish_iteration(
   kafka::offset prev_extent_base, kafka::offset prev_extent_last) {
     _processed_extents.insert(prev_extent_base, prev_extent_last);
@@ -258,7 +277,7 @@ ss::future<> l1_object_sink::finish_iteration(
     auto uncommitted_bytes
       = _pending_bytes
         + (_inflight_object ? _inflight_object->builder->file_size() : 0);
-    if (uncommitted_bytes < _commit_interval_bytes()) {
+    if (uncommitted_bytes < effective_commit_interval_bytes()) {
         co_return;
     }
     co_await flush(prev_extent_last);

--- a/src/v/cloud_topics/level_one/maintenance/l1_object_sink.h
+++ b/src/v/cloud_topics/level_one/maintenance/l1_object_sink.h
@@ -101,6 +101,9 @@ protected:
     // not been committed yet.
     ss::future<> finalize_inflight(bool success);
 
+    // Returns the commit interval, never below `max_object_size`.
+    size_t effective_commit_interval_bytes() const;
+
 protected:
     model::topic_id_partition _tp;
     io* _io;

--- a/src/v/cloud_topics/level_one/maintenance/leveling/tests/leveling_reducer_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/leveling/tests/leveling_reducer_test.cc
@@ -223,6 +223,52 @@ TEST_F(LevelingReducerTest, RewritesLevelableRange) {
     ASSERT_LT(extents_after, extents_before);
 }
 
+// A commit interval below the target object size must not be honoured
+// literally: cutting the inflight object at every extent boundary would make
+// each output extent undersized, so leveling would rewrite the same run into
+// an equally undersized run on every pass. The interval is raised to the
+// target object size, so the run still consolidates.
+TEST_F(LevelingReducerTest, ClampsCommitIntervalToObjectSize) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+    const int records_per_batch = 10;
+    const int batches_per_extent = 5;
+    const int num_extents = 4;
+    const int records_per_extent = batches_per_extent * records_per_batch;
+
+    for (int i = 0; i < num_extents; ++i) {
+        upload_batches(
+          tidp,
+          model::offset{i * records_per_extent},
+          batches_per_extent,
+          records_per_batch);
+    }
+
+    auto before = count_batches_and_records(ntp, tidp);
+    auto extents_before = count_extents(tidp);
+    ASSERT_EQ(extents_before, static_cast<size_t>(num_extents));
+
+    auto leveling_info = get_all_leveling_info(tidp, 100_KiB);
+    ASSERT_FALSE(leveling_info.ranges.empty());
+
+    // The whole ~220 KiB run fits in one 128 MiB output object, so with the
+    // interval clamped up there is a single commit and a single output extent.
+    // Honouring the 512 byte interval literally would instead cut at every
+    // extent boundary, leaving as many extents as it started with.
+    do_level(
+      ntp,
+      tidp,
+      std::move(leveling_info.ranges),
+      leveling_info.epoch,
+      &_metastore,
+      &_io,
+      /*max_object_size=*/128_MiB,
+      /*commit_interval_bytes=*/512)
+      .get();
+
+    ASSERT_EQ(count_batches_and_records(ntp, tidp), before);
+    ASSERT_LT(count_extents(tidp), extents_before);
+}
+
 // Every input record must be byte-for-byte present in the output after
 // leveling.
 TEST_F(LevelingReducerTest, PreservesBatchData) {

--- a/src/v/cloud_topics/level_one/maintenance/log_info_collector.cc
+++ b/src/v/cloud_topics/level_one/maintenance/log_info_collector.cc
@@ -25,10 +25,39 @@ namespace cloud_topics::l1 {
 
 namespace {
 
+// Checks the provided compaction offsets response against the currently
+// reported max compactible offset to see if any of the compaction work reported
+// is actionable.
+inline bool has_compactible_work(
+  const metastore::compaction_offsets_response& offsets,
+  kafka::offset max_compactible_offset) {
+    auto lowest_base_offset =
+      [](const offset_interval_set& s) -> std::optional<kafka::offset> {
+        auto stream = s.make_stream();
+        if (!stream.has_next()) {
+            return std::nullopt;
+        }
+        return stream.next().base_offset;
+    };
+    for (const auto* ranges :
+         {&offsets.dirty_ranges, &offsets.removable_tombstone_ranges}) {
+        auto base = lowest_base_offset(*ranges);
+        if (base.has_value() && base.value() <= max_compactible_offset) {
+            return true;
+        }
+    }
+    return false;
+}
+
 inline bool needs_compaction(
-  const metastore::compaction_info_response& info,
+  const compaction_info_and_timestamp& info_and_ts,
   const cluster::topic_configuration& topic_cfg) {
+    const auto& info = info_and_ts.info;
     if (!topic_cfg.is_compacted()) {
+        return false;
+    }
+    if (!has_compactible_work(
+          info.offsets_response, info_and_ts.max_compactible_offset)) {
         return false;
     }
     auto& topic_mcdr = topic_cfg.properties.min_cleanable_dirty_ratio;
@@ -315,7 +344,7 @@ void log_info_collector::populate_logs_with_compaction_info(
 
         const auto& topic_cfg = topic_cfg_opt.value().get();
 
-        if (!needs_compaction(info_and_ts.info, topic_cfg)) {
+        if (!needs_compaction(info_and_ts, topic_cfg)) {
             continue;
         }
 

--- a/src/v/cloud_topics/level_one/maintenance/tests/log_info_collector_test.cc
+++ b/src/v/cloud_topics/level_one/maintenance/tests/log_info_collector_test.cc
@@ -112,11 +112,27 @@ private:
     cluster::topic_configuration _cfg{};
 };
 
-// A fake offset provider which always returns kafka::offset::max().
+// A fake offset provider which reports every NTP as fully compactible.
 class fake_offset_provider : public l1::max_compactible_offset_provider {
 public:
     ss::future<> fill_max_compactible_offsets(
-      chunked_hash_map<model::ntp, kafka::offset>&) const final {
+      chunked_hash_map<model::ntp, kafka::offset>& offsets) const final {
+        for (auto& [_, offset] : offsets) {
+            offset = kafka::offset::max();
+        }
+        co_return;
+    }
+};
+
+// A fake offset provider which reports every NTP as having nothing compactible,
+// as an STM pinning from offset 0 does.
+class fake_pinned_offset_provider : public l1::max_compactible_offset_provider {
+public:
+    ss::future<> fill_max_compactible_offsets(
+      chunked_hash_map<model::ntp, kafka::offset>& offsets) const final {
+        for (auto& [_, offset] : offsets) {
+            offset = kafka::offset::min();
+        }
         co_return;
     }
 };
@@ -159,6 +175,40 @@ TEST_F(LogInfoCollectorTestFixture, TestInfoCollector) {
         ASSERT_FLOAT_EQ(sample->info_and_ts.info.dirty_ratio, 1.0);
         ASSERT_TRUE(sample->info_and_ts.info.earliest_dirty_ts.has_value());
     }
+}
+
+// A log whose data is entirely pinned (nothing at or below
+// `max_compactible_offset`) must not be queued: the job could only build its
+// compaction map and find every extent filtered out.
+TEST_F(LogInfoCollectorTestFixture, TestInfoCollectorSkipsFullyPinnedLog) {
+    auto cfg_provider = std::make_unique<fake_cfg_provider>();
+    auto offset_provider = std::make_unique<fake_pinned_offset_provider>();
+    l1::log_info_collector log_info_collector(
+      &_metastore, std::move(cfg_provider), std::move(offset_provider));
+
+    auto [ntp, tidp] = make_ntidp("topic_a");
+
+    l1::log_set_t logs;
+    l1::log_list_t logs_list;
+    auto [it, success] = logs.emplace(
+      ss::make_lw_shared<l1::log_compaction_meta>(tidp, ntp));
+    ASSERT_TRUE(success);
+    logs_list.push_back(*it->get());
+
+    l1::compaction_queue cached_metadata(
+      [](const l1::compaction_job_ptr& a, const l1::compaction_job_ptr& b) {
+          return a->meta->ntp < b->meta->ntp;
+      });
+
+    std::vector<tidp_batches_t> tidp_batches;
+    tidp_batches.emplace_back(
+      tidp, model::test::make_random_batches(model::offset{0}, 10).get());
+    make_l1_objects(std::move(tidp_batches)).get();
+
+    log_info_collector.collect_compaction_info(logs, logs_list, cached_metadata)
+      .get();
+
+    ASSERT_TRUE(cached_metadata.empty());
 }
 
 TEST_F(LogInfoCollectorTestFixture, TestSampleLevelingInfo) {

--- a/src/v/utils/prefix_logger.h
+++ b/src/v/utils/prefix_logger.h
@@ -42,6 +42,26 @@ public:
         }
     }
 
+    /// Rate-limited variant.
+    template<typename... Args>
+    void log(
+      ss::log_level lvl,
+      ss::logger::rate_limit& rate,
+      ss::logger::format_info_t<Args...> format,
+      Args&&... args) const {
+        if (_logger->is_enabled(lvl)) {
+            ss::logger::lambda_log_writer writer(
+              [&](ss::internal::log_buf::inserter_iterator it) {
+                  it = fmt::format_to(it, "{} - ", _prefix);
+                  return fmt::format_to(
+                    it,
+                    fmt::runtime(format.format),
+                    std::forward<Args>(args)...);
+              });
+            _logger->log(lvl, rate, writer);
+        }
+    }
+
     template<typename... Args>
     void
     error(ss::logger::format_info_t<Args...> format, Args&&... args) const {

--- a/tests/rptest/tests/cloud_topics/compaction_stress_test.py
+++ b/tests/rptest/tests/cloud_topics/compaction_stress_test.py
@@ -429,7 +429,6 @@ class CompactionPreregistrationTTLTest(CompactionStressBase):
                 "cloud_topics_compaction_max_object_size": 1024 * 1024,
                 "cloud_topics_reconciliation_max_object_size": 8 * 1024 * 1024,
                 "cloud_topics_compaction_commit_interval_bytes": 1024 * 1024,
-                "cloud_topics_leveling_commit_interval_bytes": 1024 * 1024,
             },
         )
 

--- a/tests/rptest/tests/random_node_operations_smoke_test.py
+++ b/tests/rptest/tests/random_node_operations_smoke_test.py
@@ -244,6 +244,22 @@ class RandomNodeOperationsBase(PreallocNodesTest):
                     # Tune down the leveling interval so leveling actually runs
                     # (and is exercised by node operations) within the test.
                     "cloud_topics_leveling_interval_ms": 5000,
+                    # Exercise incremental commits of compaction and leveling
+                    # output. Commits only happen at source extent boundaries
+                    # once a commit interval's worth of output is pending, so
+                    # the reconciler's objects must also be small enough for a
+                    # job to see several extents at this test's data volume.
+                    #
+                    # Each commit interval matches its sink's output object
+                    # size, so a commit cuts an object that is already full.
+                    # An interval below the object size would cut every
+                    # object short of `min_extent_size_ratio` of the
+                    # reconciler's size, leaving leveling's own output
+                    # undersized and its ranges eligible forever.
+                    "cloud_topics_reconciliation_max_object_size": 8 * 1024 * 1024,
+                    "cloud_topics_compaction_max_object_size": 4 * 1024 * 1024,
+                    "cloud_topics_compaction_commit_interval_bytes": 4 * 1024 * 1024,
+                    "cloud_topics_leveling_commit_interval_bytes": 8 * 1024 * 1024,
                 },
             )
 


### PR DESCRIPTION
* Adds configuration to RNOT that will trigger incremental compaction/leveling
* Some minor QOL fixes to incremental compaction/leveling
  * Ensuring that we don't enqueue compaction jobs that are completely pinned by `max_compactible_offset` (which would lead to us building a compaction offset map just to throw it away)
  * Clamping commit interval to target object size. Users can configure the commit interval for leveling or compaction to be less than the target object size, leading to undersized objects and a perpetual leveling queue (since the objects leveling produces are themselves eligible for leveling in this configuration). By clamping the commit interval we avoid this problem.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none
