### PR TITLE
`cloud_topics`: bump test timeout to `moderate`

### DIFF
--- a/src/v/cloud_topics/tests/BUILD
+++ b/src/v/cloud_topics/tests/BUILD
@@ -18,7 +18,7 @@ redpanda_test_cc_library(
 
 redpanda_cc_gtest(
     name = "end_to_end_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "end_to_end_test.cc",
     ],


### PR DESCRIPTION
This was timing out in CI. Bump the timeout.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none
