### PR TITLE
`rptest`: add `TimeQueryParityTest`

### DIFF
--- a/src/v/cloud_storage/offset_index.cc
+++ b/src/v/cloud_storage/offset_index.cc
@@ -19,6 +19,8 @@
 
 #include <seastar/util/variant_utils.hh>
 
+#include <limits>
+
 namespace cloud_storage {
 
 offset_index::offset_index(
@@ -193,44 +195,100 @@ offset_index::find_timestamp(model::timestamp upper_bound) {
         return std::nullopt;
     }
 
-    auto search_result = maybe_find_offset(
-      upper_bound.value(), _time_index, _time_offsets);
+    // Entries written by current builders hold the running maximum data
+    // batch timestamp and are monotonic by construction, so the last entry
+    // below the target is a safe scan starting position: no batch at or
+    // before it holds a record with a timestamp at or after the target.
+    // Older indexes recorded each sampled batch's own max timestamp
+    // instead, which is not monotonic when producers use non-monotonic
+    // CreateTime timestamps; a batch above the target may then sit between
+    // entries that are below it (or in an unindexed sampling gap). The
+    // entries are therefore only trusted while they are non-decreasing:
+    // when a decrease is observed the index cannot bound the scan start
+    // and the caller has to scan the segment from the beginning.
+    std::optional<size_t> candidate;
+    size_t ix = 0;
+    int64_t running_max = std::numeric_limits<int64_t>::min();
+    bool monotonic = true;
+    bool stop = false;
+    auto consume = [&](int64_t value) {
+        if (value < running_max) {
+            monotonic = false;
+            return false;
+        }
+        running_max = value;
+        if (value >= upper_bound.value()) {
+            return false;
+        }
+        candidate = ix++;
+        return true;
+    };
 
-    return ss::visit(
-      search_result,
-      [](std::monostate) -> std::optional<find_result> { return std::nullopt; },
-      [](find_result result) -> std::optional<find_result> { return result; },
-      [this](index_value index_result) -> std::optional<find_result> {
-          size_t ix = index_result.ix;
+    decoder_t time_dec(
+      _time_index.get_initial_value(),
+      _time_index.get_row_count(),
+      _time_index.share());
+    std::array<int64_t, buffer_depth> buffer{};
+    while (!stop && time_dec.read(buffer)) {
+        for (auto value : buffer) {
+            if (!consume(value)) {
+                stop = true;
+                break;
+            }
+        }
+        buffer = {};
+    }
+    if (!stop) {
+        for (size_t i = 0; i < (_pos & index_mask); i++) {
+            if (!consume(_time_offsets.at(i))) {
+                break;
+            }
+        }
+    }
 
-          // Decode all offset indices to build up the result.
-          decoder_t rp_dec(
-            _rp_index.get_initial_value(),
-            _rp_index.get_row_count(),
-            _rp_index.copy());
-          auto rp_offset = _fetch_ix(std::move(rp_dec), ix);
-          vassert(rp_offset.has_value(), "Inconsistent index state");
+    if (!monotonic || !candidate.has_value()) {
+        return std::nullopt;
+    }
 
-          decoder_t kaf_dec(
-            _kaf_index.get_initial_value(),
-            _kaf_index.get_row_count(),
-            _kaf_index.copy());
-          auto kaf_offset = _fetch_ix(std::move(kaf_dec), ix);
-          vassert(kaf_offset.has_value(), "Inconsistent index state");
+    const size_t num_encoded = static_cast<size_t>(_time_index.get_row_count())
+                               * buffer_depth;
+    if (*candidate >= num_encoded) {
+        // The candidate is in the write buffer that has not been
+        // compressed yet.
+        auto i = *candidate - num_encoded;
+        return offset_index::find_result{
+          .rp_offset = model::offset(_rp_offsets.at(i)),
+          .kaf_offset = kafka::offset(_kaf_offsets.at(i)),
+          .file_pos = _file_offsets.at(i)};
+    }
 
-          foffset_decoder_t file_dec(
-            _file_index.get_initial_value(),
-            _file_index.get_row_count(),
-            _file_index.copy(),
-            delta_delta_t(_min_file_pos_step));
-          auto file_pos = _fetch_ix(std::move(file_dec), ix);
-          vassert(file_pos.has_value(), "Inconsistent index state");
+    // Decode all offset indices to build up the result.
+    decoder_t rp_dec(
+      _rp_index.get_initial_value(),
+      _rp_index.get_row_count(),
+      _rp_index.share());
+    auto rp_offset = _fetch_ix(std::move(rp_dec), *candidate);
+    vassert(rp_offset.has_value(), "Inconsistent index state");
 
-          return offset_index::find_result{
-            .rp_offset = model::offset(*rp_offset),
-            .kaf_offset = kafka::offset(*kaf_offset),
-            .file_pos = *file_pos};
-      });
+    decoder_t kaf_dec(
+      _kaf_index.get_initial_value(),
+      _kaf_index.get_row_count(),
+      _kaf_index.share());
+    auto kaf_offset = _fetch_ix(std::move(kaf_dec), *candidate);
+    vassert(kaf_offset.has_value(), "Inconsistent index state");
+
+    foffset_decoder_t file_dec(
+      _file_index.get_initial_value(),
+      _file_index.get_row_count(),
+      _file_index.share(),
+      delta_delta_t(_min_file_pos_step));
+    auto file_pos = _fetch_ix(std::move(file_dec), *candidate);
+    vassert(file_pos.has_value(), "Inconsistent index state");
+
+    return offset_index::find_result{
+      .rp_offset = model::offset(*rp_offset),
+      .kaf_offset = kafka::offset(*kaf_offset),
+      .file_pos = *file_pos};
 }
 
 offset_index::coarse_index_t offset_index::build_coarse_index(

--- a/src/v/cloud_storage/offset_index.h
+++ b/src/v/cloud_storage/offset_index.h
@@ -84,12 +84,16 @@ public:
     /// returned.
     std::optional<find_result> find_kaf_offset(kafka::offset upper_bound);
 
-    /// Find index entry which is strictly lower than the timestamp
+    /// Find a safe position to start a forward scan for the first record
+    /// with a timestamp at or after 'upper_bound'.
     ///
-    /// The returned value has timestamp less than upper_bound.
-    /// If all elements are larger than 'upper_bound' nullopt is returned.
-    /// If all elements are smaller than 'upper_bound' the last value is
-    /// returned.
+    /// Returns the last entry whose running max timestamp is strictly
+    /// lower than 'upper_bound': no batch at or before it can match, and
+    /// the first match (if any) is reachable by scanning forward from it.
+    /// Returns nullopt when no such entry exists or when the entries are
+    /// not monotonic (possible in older indexes built from non-monotonic
+    /// producer timestamps, where a matching batch may hide in a sampling
+    /// gap); the caller then has to scan the segment from the beginning.
     std::optional<find_result> find_timestamp(model::timestamp upper_bound);
 
     /// Builds a coarse index mapping kafka offsets to file positions. The step

--- a/src/v/cloud_storage/remote_segment_index.cc
+++ b/src/v/cloud_storage/remote_segment_index.cc
@@ -42,12 +42,14 @@ void remote_segment_index_builder::consume_batch_start(
     if (is_config) {
         _running_delta += delta;
     } else {
+        _running_max_timestamp = std::max(
+          _running_max_timestamp, hdr.max_timestamp);
         if (_window >= _sampling_step) {
             _ix.add(
               hdr.base_offset,
               hdr.base_offset - _running_delta,
               static_cast<int64_t>(physical_base_offset),
-              hdr.max_timestamp);
+              _running_max_timestamp);
             _window = 0;
         }
     }

--- a/src/v/cloud_storage/remote_segment_index.h
+++ b/src/v/cloud_storage/remote_segment_index.h
@@ -78,6 +78,12 @@ private:
     size_t _window{0};
     size_t _sampling_step;
     std::vector<model::record_batch_type> _filter;
+    /// Running max timestamp over all data batches seen so far. Written to
+    /// the index instead of the sampled batch's own max timestamp so that
+    /// the time index stays monotonic even when producers use
+    /// non-monotonic CreateTime timestamps, keeping timestamp seeks safe
+    /// (see offset_index::find_timestamp).
+    model::timestamp _running_max_timestamp{model::timestamp::missing()};
     /// Collected stats
     std::optional<std::reference_wrapper<segment_record_stats>> _stats;
 };

--- a/src/v/cloud_storage/tests/remote_segment_index_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_index_test.cc
@@ -171,6 +171,148 @@ SEASTAR_THREAD_TEST_CASE(test_remote_segment_index_builder) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(remote_segment_index_find_timestamp_test) {
+    // 100 entries: 6 full compressed rows plus a partial write buffer, so
+    // both storage tiers of the index are covered by the queries below.
+    const size_t num_entries = 100;
+    const int64_t base_ts = 1000;
+    const int64_t step = 10;
+    const model::offset base_rp{100};
+    const kafka::offset base_kaf{50};
+
+    offset_index index(base_rp, base_kaf, 0, 1000, model::timestamp{base_ts});
+    for (size_t i = 0; i < num_entries; i++) {
+        index.add(
+          base_rp + model::offset(i),
+          base_kaf + kafka::offset(i),
+          static_cast<int64_t>((i + 1) * 2000),
+          model::timestamp(base_ts + step * static_cast<int64_t>(i)));
+    }
+
+    // Nothing is provably below a timestamp at or before the first entry:
+    // the caller has to scan from the start of the segment.
+    BOOST_REQUIRE(!index.find_timestamp(model::timestamp{base_ts - 1}));
+    BOOST_REQUIRE(!index.find_timestamp(model::timestamp{base_ts}));
+
+    for (size_t i = 1; i < num_entries; i++) {
+        // A query matching entry i exactly must start scanning at entry
+        // i-1: entry values are running maxima including their own batch,
+        // so the first matching record may sit in the gap before entry i.
+        auto ts = model::timestamp(base_ts + step * static_cast<int64_t>(i));
+        auto res = index.find_timestamp(ts);
+        BOOST_REQUIRE(res.has_value());
+        BOOST_REQUIRE_EQUAL(res->rp_offset, base_rp + model::offset(i - 1));
+        BOOST_REQUIRE_EQUAL(res->kaf_offset, base_kaf + kafka::offset(i - 1));
+        BOOST_REQUIRE_EQUAL(res->file_pos, i * 2000);
+
+        // A query between entries i and i+1 starts at entry i.
+        auto mid = index.find_timestamp(model::timestamp(ts.value() + 1));
+        BOOST_REQUIRE(mid.has_value());
+        BOOST_REQUIRE_EQUAL(mid->rp_offset, base_rp + model::offset(i));
+    }
+
+    // A query above all entries starts at the last entry.
+    auto last = index.find_timestamp(
+      model::timestamp(base_ts + step * static_cast<int64_t>(num_entries)));
+    BOOST_REQUIRE(last.has_value());
+    BOOST_REQUIRE_EQUAL(
+      last->rp_offset, base_rp + model::offset(num_entries - 1));
+}
+
+BOOST_AUTO_TEST_CASE(remote_segment_index_find_timestamp_non_monotonic_test) {
+    // Indexes written before entries became running maxima may hold
+    // non-monotonic per-batch timestamps. Such entries cannot bound the
+    // scan start (a matching batch may hide in a sampling gap), so any
+    // query whose scan observes a decrease must return nullopt.
+    offset_index index(
+      model::offset{0}, kafka::offset{0}, 0, 1000, model::timestamp{1000});
+    const std::vector<int64_t> timestamps{1000, 1010, 990, 1020};
+    for (size_t i = 0; i < timestamps.size(); i++) {
+        index.add(
+          model::offset(i),
+          kafka::offset(i),
+          static_cast<int64_t>((i + 1) * 2000),
+          model::timestamp(timestamps[i]));
+    }
+
+    // Stops at entry 1 (1010 >= 1005) before observing the decrease:
+    // entries 0..1 are trustworthy and bound the scan.
+    auto res = index.find_timestamp(model::timestamp{1005});
+    BOOST_REQUIRE(res.has_value());
+    BOOST_REQUIRE_EQUAL(res->rp_offset, model::offset(0));
+
+    // These scans reach the 1010 -> 990 decrease: bail out.
+    BOOST_REQUIRE(!index.find_timestamp(model::timestamp{1015}));
+    BOOST_REQUIRE(!index.find_timestamp(model::timestamp{2000}));
+
+    // First entry is already at or above the query.
+    BOOST_REQUIRE(!index.find_timestamp(model::timestamp{995}));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_remote_segment_index_builder_running_max) {
+    // A single batch far in the future (the "spike") followed by batches
+    // that drop back below it, sized so that the sampling step skips the
+    // spike batch entirely. The builder must index running maxima: the
+    // first sampled batch after the spike then carries the spike's
+    // timestamp, so a query between the pre-spike max and the spike
+    // starts its scan before the spike batch. An index of raw per-batch
+    // timestamps would never cross such a query and the scan would start
+    // at the end of the segment, skipping the only matching record.
+    static const model::offset base_offset{0};
+    static const kafka::offset kbase_offset{0};
+    constexpr int records_per_batch = 10;
+    constexpr size_t spike_index = 10;
+    constexpr size_t num_batches = 21;
+    constexpr int64_t spike_ts = 50000;
+    constexpr size_t sampling_step = 4000;
+
+    std::vector<batch_t> batches;
+    for (size_t i = 0; i < num_batches; i++) {
+        // Batches 9-11 are far below the sampling step so the window
+        // reset caused by sampling batch 9 leaves batches 10 (the spike)
+        // and 11 unsampled; every other batch exceeds the step on its
+        // own.
+        const size_t record_size = (i >= 9 && i <= 11) ? 10 : 450;
+        batches.push_back(
+          batch_t{
+            .num_records = records_per_batch,
+            .type = model::record_batch_type::raft_data,
+            .record_sizes = std::vector<size_t>(records_per_batch, record_size),
+            .timestamp = i == spike_index
+                           ? model::timestamp(spike_ts)
+                           : model::timestamp(
+                               1000 + 100 * static_cast<int64_t>(i)),
+          });
+    }
+    auto [segment, co] = generate_segment(base_offset, batches);
+    auto is = make_iobuf_input_stream(std::move(segment));
+    offset_index ix(
+      base_offset, kbase_offset, 0, 0, model::timestamp{0xdeadbeef});
+    auto parser = make_remote_segment_index_builder(
+      test_ntp, std::move(is), ix, model::offset_delta(0), sampling_step);
+    auto pclose = ss::defer([&parser] { parser->close().get(); });
+    auto result = parser->consume().get();
+    BOOST_REQUIRE(result.has_value());
+
+    // Query above every non-spike batch but below the spike: the first
+    // matching record is in the (unsampled) spike batch, so the scan must
+    // start at or before the last batch preceding it.
+    auto res = ix.find_timestamp(model::timestamp{20000});
+    BOOST_REQUIRE(res.has_value());
+    BOOST_REQUIRE_LE(
+      res->rp_offset,
+      base_offset + model::offset((spike_index - 1) * records_per_batch));
+
+    // Query above the spike (= above everything): the running max keeps
+    // every entry below it, so the scan starts at the last entry and the
+    // caller finds no match.
+    auto above = ix.find_timestamp(model::timestamp{spike_ts + 100});
+    BOOST_REQUIRE(above.has_value());
+    BOOST_REQUIRE_GT(
+      above->rp_offset,
+      base_offset + model::offset(spike_index * records_per_batch));
+}
+
 SEASTAR_THREAD_TEST_CASE(test_remote_segment_build_coarse_index) {
     const model::offset base_offset{100};
     const kafka::offset kbase_offset{100};

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -713,48 +713,40 @@ ss::future<std::optional<storage::timequery_result>> partition::local_timequery(
             }
 
             if (
-              _raft->log()->start_timestamp() <= cfg.time
-              && result->time > cfg.time) {
-                // start_timestamp() points to the beginning of the oldest
-                // segment, but start_offset points to somewhere within a
-                // segment.  If our timequery hits the range between the start
-                // of segment and the start_offset, consensus::timequery may
-                // answer with the start offset rather than the
-                // pre-start-offset location where the timestamp is actually
-                // found. Ref
-                // https://github.com/redpanda-data/redpanda/issues/9669
+              start_cloud_offset()
+              < _raft->log()->from_log_offset(_raft->start_offset())) {
+                // Offsets below the local log start are retained in cloud
+                // storage and may contain a match earlier than the local
+                // result, so the local result cannot be proven to be the
+                // first record at or after the query time:
+                //
+                // - start_timestamp() points to the beginning of the oldest
+                //   segment, but start_offset points to somewhere within a
+                //   segment. If the query hits the range between the start
+                //   of segment and the start_offset, consensus::timequery
+                //   may answer with the start offset rather than the
+                //   pre-start-offset location where the timestamp is
+                //   actually found. Ref
+                //   https://github.com/redpanda-data/redpanda/issues/9669
+                // - even an exact-timestamp hit can be preceded by a
+                //   cloud-only record carrying the same timestamp, and with
+                //   non-monotonic producer timestamps by one carrying a
+                //   greater timestamp.
+                //
+                // Return null so that the caller falls back to cloud
+                // storage. Without such a cloud-only prefix the local
+                // answer is authoritative: result->time > cfg.time is the
+                // normal outcome whenever the query time falls between two
+                // record timestamps and must not be discarded.
                 vlog(
                   clusterlog.debug,
-                  "Timequery (raft) {} cfg(r)={} miss on local log "
-                  "(start_timestamp "
-                  "{}, result {})",
+                  "Timequery (raft) {} cfg(r)={} local result cannot be "
+                  "proven first, cloud retains offsets below local start "
+                  "(start_timestamp {}, result {})",
                   _raft->ntp(),
                   cfg,
                   _raft->log()->start_timestamp(),
                   result->time);
-                co_return std::nullopt;
-            }
-        }
-
-        if (result->offset == _raft->log()->offsets().start_offset) {
-            // If we hit at the start of the local log, this is ambiguous:
-            // there could be earlier batches prior to start_offset which
-            // have the same timestamp and are present in cloud storage.
-            vlog(
-              clusterlog.debug,
-              "Timequery (raft) {} cfg(r)={} hit start_offset in local log "
-              "(start_offset {} start_timestamp {}, result {})",
-              _raft->ntp(),
-              cfg,
-              _raft->log()->offsets().start_offset,
-              _raft->log()->start_timestamp(),
-              cfg.time);
-
-            if (allow_cloud_fallback) {
-                // Even though we hit data with the desired timestamp, we
-                // cannot be certain that this is the _first_ batch with
-                // the desired timestamp: return null so that the caller
-                // will fall back to cloud storage.
                 co_return std::nullopt;
             }
         }

--- a/tests/rptest/tests/timequery_parity_test.py
+++ b/tests/rptest/tests/timequery_parity_test.py
@@ -1,0 +1,474 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+"""
+5-way timequery parity test.
+
+Kafka's ListOffsets-by-timestamp contract is "the earliest offset whose
+record timestamp is >= the requested timestamp". Redpanda answers that
+query through a different index implementation per storage mode (raft-local
+time index, classic tiered-storage remote index, tiered_v2/cloud L1 object
+footer index), each of which has its own way of getting the "first record
+at-or-after" vs "running max timestamp" distinction wrong.
+
+This test produces a byte-identical workload - including non-monotonic
+timestamp phases where the correct answer is subtle and Apache Kafka's
+behavior is the spec - to one topic per Redpanda storage mode (local,
+tiered_v1, tiered_v2, cloud) and to an Apache Kafka cluster, then sweeps
+timequeries and asserts that all five topics agree, and that Kafka agrees
+with the analytically computed answer. Sweeps run at three lifecycle
+points: while all data is local, after data has moved to remote/L1
+storage, and after a full Redpanda restart.
+
+Retention is infinite everywhere (only *local* trimming is enabled on the
+tiered topics, which does not delete data) so answers cannot shift under
+the test's feet.
+"""
+
+import concurrent.futures
+import random
+import time
+from collections.abc import Callable
+from typing import cast
+
+from confluent_kafka import KafkaError, Message, Producer
+from ducktape.tests.test import Test, TestContext
+from kafkatest.services.kafka import KafkaService  # type: ignore[import-untyped]
+from kafkatest.services.zookeeper import (  # type: ignore[import-untyped]
+    ZookeeperService,
+)
+from kafkatest.version import V_3_0_0  # type: ignore[import-untyped]
+
+from rptest.clients.admin.v2 import Admin as AdminV2, metastore_pb, ntp_pb
+from rptest.clients.default import DefaultClient
+from rptest.clients.kafka_cat import KafkaCat
+from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.services.kafka import KafkaServiceAdapter
+from rptest.services.redpanda import SISettings, make_redpanda_service
+from rptest.services.redpanda_types import RedpandaServiceForClients
+from rptest.util import wait_for_local_storage_truncate, wait_until
+
+
+class TimeQueryParityTest(Test):
+    """
+    Differential timequery test: Apache Kafka as the spec oracle against
+    Redpanda's four storage modes, all fed the identical record/timestamp
+    sequence.
+    """
+
+    record_size = 1024
+    segment_size = 1024 * 1024
+    local_target_bytes = 4 * segment_size
+    ct_object_size = 1024 * 1024
+    # Small enough that L1 objects carry several index entries with
+    # multiple unindexed batches between consecutive entries; this is the
+    # regime in which running-max-vs-first-match seek bugs are visible.
+    ct_indexing_interval = 64 * 1024
+    # Producing in fixed-size flushed batches keeps batch composition (and
+    # therefore each batch's max_timestamp) identical across all topics.
+    records_per_flush = 16
+
+    kafka_topic = "tq-parity-kafka"
+    rp_topics = {
+        "tq-parity-local": TopicSpec.STORAGE_MODE_LOCAL,
+        "tq-parity-tiered-v1": TopicSpec.STORAGE_MODE_IMPL_TIERED_V1,
+        "tq-parity-tiered-v2": TopicSpec.STORAGE_MODE_IMPL_TIERED_V2,
+        "tq-parity-cloud": TopicSpec.STORAGE_MODE_CLOUD,
+    }
+    tiered_v1_topic = "tq-parity-tiered-v1"
+    tiered_v2_topic = "tq-parity-tiered-v2"
+    cloud_topic = "tq-parity-cloud"
+
+    def __init__(self, test_context: TestContext):
+        super().__init__(test_context=test_context)
+
+        self.zk = ZookeeperService(test_context, num_nodes=1, version=V_3_0_0)
+        self.kafka = KafkaServiceAdapter(
+            test_context,
+            KafkaService(test_context, num_nodes=1, zk=self.zk, version=V_3_0_0),
+        )
+
+        extra_rp_conf = {
+            "enable_cluster_metadata_upload_loop": False,
+            "enable_leader_balancer": False,
+            "disable_batch_cache": True,
+            "log_retention_ms": -1,
+            "log_segment_size": self.segment_size,
+            "log_segment_size_min": self.segment_size,
+            # Fast L0 -> L1 movement for the tiered_v2/cloud topics.
+            "cloud_topics_long_term_flush_interval": 1000,
+            "cloud_topics_reconciliation_min_interval": 1000,
+            "cloud_topics_reconciliation_max_interval": 2000,
+            "cloud_topics_reconciliation_max_object_size": self.ct_object_size,
+            "cloud_topics_indexing_interval": self.ct_indexing_interval,
+            # Engage strict local retention so the tiered_v2 topic actually
+            # trims its local log to retention.local.target.bytes and reads
+            # below the local start pivot to L1.
+            "retention_local_strict": True,
+            "retention_local_strict_override": True,
+            "retention_local_trim_interval": 2000,
+            "cloud_storage_housekeeping_interval_ms": 2000,
+            "log_compaction_interval_ms": 2000,
+        }
+        self.si_settings = SISettings(
+            test_context,
+            cloud_storage_max_connections=10,
+            cloud_storage_enable_remote_read=False,
+            cloud_storage_enable_remote_write=False,
+            fast_uploads=True,
+        )
+        self.si_settings.load_context(self.logger, test_context)
+        self.redpanda = make_redpanda_service(
+            context=test_context,
+            num_brokers=1,
+            si_settings=self.si_settings,
+            extra_rp_conf=extra_rp_conf,
+        )
+
+        self.base_ts = int(time.time() - 600) * 1000
+        self.timestamps, self.phases = self._generate_workload()
+        self.msg_count = len(self.timestamps)
+        self.queries = self._generate_queries()
+        self.expected = self._expected_offsets()
+
+    def setUp(self):
+        self.zk.start()
+        self.kafka.start()
+        self.redpanda.start()
+        self.redpanda.set_feature_active("tiered_cloud_topics", True, timeout_sec=30)
+
+    def tearDown(self):
+        # ducktape handles service teardown automatically, but stopping
+        # Kafka and zookeeper explicitly with logging makes hangs easier
+        # to attribute.
+        self.logger.info("Stopping Kafka...")
+        self.kafka.stop()
+        self.logger.info("Stopping zookeeper...")
+        self.zk.stop()
+
+    # ------------------------------------------------------------------
+    # Workload
+    # ------------------------------------------------------------------
+
+    def _generate_workload(self) -> tuple[list[int], dict[str, tuple[int, int]]]:
+        """
+        Build the deterministic timestamp sequence, one entry per record.
+        Returns the sequence plus a phase name -> [start, end) offset-range
+        map used to spread query sampling across every timestamp regime.
+        """
+        rng = random.Random(0x5EED)
+        timestamps: list[int] = []
+        phases: dict[str, tuple[int, int]] = {}
+
+        def phase(name: str, count: int, gen: Callable[[], int]) -> None:
+            start = len(timestamps)
+            for _ in range(count):
+                timestamps.append(gen())
+            phases[name] = (start, len(timestamps))
+
+        # Monotonic ramp: the baseline well-behaved regime.
+        cur = self.base_ts
+
+        def ramp() -> int:
+            nonlocal cur
+            cur += 1
+            return cur
+
+        phase("ramp", 4096, ramp)
+
+        # Duplicate run: thousands of records sharing one timestamp; the
+        # answer for that timestamp is the *first* of them.
+        plateau_ts = cur
+        phase("plateau", 512, lambda: plateau_ts)
+
+        # Local jitter: timestamps trend upward but are out of order
+        # within and across batches, so a batch's max_timestamp routinely
+        # exceeds timestamps of records that follow it.
+        def jitter() -> int:
+            nonlocal cur
+            cur += 3
+            return cur + rng.randint(-10, 10)
+
+        phase("jitter", 4096, jitter)
+
+        # Spike: a single record far in the future. Queries between the
+        # pre-spike max and the spike must answer with the spike's offset,
+        # not with a later backfill record that first re-crosses them.
+        spike_ts = max(timestamps) + 60_000
+        phase("spike", 1, lambda: spike_ts)
+
+        # Backfill: a long stretch entirely below the running max (the
+        # spike), rising back past the pre-spike level. This is the
+        # regime where seeking to "first index entry whose running max
+        # reaches the target" instead of its predecessor gives wrong
+        # answers.
+        back = max(t for t in timestamps if t != spike_ts) - 100
+
+        def backfill() -> int:
+            nonlocal back
+            back += 1
+            return back
+
+        phase("backfill", 2048, backfill)
+
+        # Recover: monotonic again from above everything, so the log ends
+        # with a clean global maximum and queries past it answer -1.
+        cur = spike_ts
+        phase("recover", 1536, ramp)
+
+        return timestamps, phases
+
+    def _generate_queries(self) -> list[int]:
+        rng = random.Random(0xFACE)
+        queries: set[int] = set()
+        for start, end in self.phases.values():
+            for _ in range(8):
+                t = self.timestamps[rng.randrange(start, end)]
+                queries.update((t - 1, t, t + 1))
+        lo, hi = min(self.timestamps), max(self.timestamps)
+        queries.update((lo - 1000, lo, hi, hi + 1, hi + 10_000))
+        return sorted(queries)
+
+    def _expected_offsets(self) -> dict[int, int]:
+        """
+        The ListOffsets contract: earliest offset with ts >= query, for
+        every query timestamp. The answer is non-decreasing in the query
+        timestamp, so walking the sorted queries alongside a single
+        forward scan of the log resolves all of them in one pass.
+        """
+        expected: dict[int, int] = {}
+        i = 0
+        for query_ts in self.queries:
+            while i < len(self.timestamps) and self.timestamps[i] < query_ts:
+                i += 1
+            expected[query_ts] = i if i < len(self.timestamps) else -1
+        return expected
+
+    # ------------------------------------------------------------------
+    # Setup helpers
+    # ------------------------------------------------------------------
+
+    def _create_topics(self):
+        rpk = RpkTool(self.redpanda)
+        common = {
+            "message.timestamp.type": "CreateTime",
+            "retention.ms": "-1",
+            "segment.bytes": str(self.segment_size),
+        }
+        # Local trimming starts effectively disabled (target far above the
+        # produced data) so the first sweep genuinely runs against local
+        # storage on every topic; _engage_local_trim() lowers the target
+        # before the remote sweep.
+        local_trim = {
+            "retention.local.target.bytes": str(1024 * self.segment_size),
+            "retention.local.target.ms": "-1",
+        }
+        for name, mode in self.rp_topics.items():
+            config = {**TopicSpec.storage_mode_config(mode), **common}
+            if mode in (
+                TopicSpec.STORAGE_MODE_IMPL_TIERED_V1,
+                TopicSpec.STORAGE_MODE_IMPL_TIERED_V2,
+            ):
+                config.update(local_trim)
+            rpk.create_topic(topic=name, partitions=1, replicas=1, config=config)
+
+        kafka_client = DefaultClient(self.kafka)
+        kafka_client.create_topic(
+            TopicSpec(name=self.kafka_topic, partition_count=1, replication_factor=1)
+        )
+        for k, v in common.items():
+            kafka_client.alter_topic_config(self.kafka_topic, k, v)
+
+    def _produce_all(self):
+        def make_producer(brokers: str) -> Producer:
+            return Producer(
+                {
+                    "bootstrap.servers": brokers,
+                    # Idempotence pins retries to in-order delivery, so
+                    # record i lands at offset i on every topic.
+                    "enable.idempotence": True,
+                    "linger.ms": 50,
+                }
+            )
+
+        rp_producer = make_producer(self.redpanda.brokers())
+        kafka_producer = make_producer(cast(str, self.kafka.brokers()))
+
+        errors: list[str] = []
+
+        def on_delivery(err: KafkaError | None, msg: Message) -> None:
+            if err is not None:
+                errors.append(f"{msg.topic()}: {err}")
+
+        for i, ts in enumerate(self.timestamps):
+            value = f"{i:016d}".encode().ljust(self.record_size, b"x")
+            for topic in self.rp_topics:
+                rp_producer.produce(
+                    topic,
+                    value=value,
+                    partition=0,
+                    timestamp=ts,
+                    on_delivery=on_delivery,
+                )
+            kafka_producer.produce(
+                self.kafka_topic,
+                value=value,
+                partition=0,
+                timestamp=ts,
+                on_delivery=on_delivery,
+            )
+            if (i + 1) % self.records_per_flush == 0:
+                rp_producer.flush()
+                kafka_producer.flush()
+        rp_producer.flush()
+        kafka_producer.flush()
+        assert not errors, f"produce failures: {errors[:10]}"
+
+    def _all_topics(self) -> list[tuple[str, KafkaCat]]:
+        rp_kcat = KafkaCat(self.redpanda)
+        kafka_kcat = KafkaCat(self.kafka)
+        topics: list[tuple[str, KafkaCat]] = [
+            (name, rp_kcat) for name in self.rp_topics
+        ]
+        topics.append((self.kafka_topic, kafka_kcat))
+        return topics
+
+    def _verify_hwm(self, retry_timeout_sec: int = 0):
+        def hwm_of(svc: RedpandaServiceForClients, topic: str) -> int:
+            partition = next(RpkTool(svc).describe_topic(topic))
+            return partition.high_watermark
+
+        def all_match() -> bool:
+            hwms = {t: hwm_of(self.redpanda, t) for t in self.rp_topics}
+            hwms[self.kafka_topic] = hwm_of(self.kafka, self.kafka_topic)
+            self.logger.info(f"high watermarks: {hwms} (want {self.msg_count})")
+            return all(h == self.msg_count for h in hwms.values())
+
+        if retry_timeout_sec > 0:
+            wait_until(
+                all_match,
+                timeout_sec=retry_timeout_sec,
+                backoff_sec=3,
+                err_msg="high watermarks did not converge",
+                retry_on_exc=True,
+            )
+        else:
+            assert all_match(), "unexpected high watermark on some topic"
+
+    # ------------------------------------------------------------------
+    # Lifecycle waits
+    # ------------------------------------------------------------------
+
+    def _wait_reconciled(self, topic: str):
+        """Wait until the L1 metastore covers the whole partition."""
+        metastore = AdminV2(self.redpanda).metastore()
+
+        def is_reconciled() -> bool:
+            req = metastore_pb.GetOffsetsRequest(
+                partition=ntp_pb.TopicPartition(topic=topic, partition=0)
+            )
+            next_offset = metastore.get_offsets(req=req).offsets.next_offset
+            self.logger.info(
+                f"{topic} metastore next_offset={next_offset}/{self.msg_count}"
+            )
+            return next_offset >= self.msg_count
+
+        wait_until(
+            is_reconciled,
+            timeout_sec=120,
+            backoff_sec=5,
+            err_msg=f"{topic} not reconciled to metastore",
+            retry_on_exc=True,
+        )
+
+    # ------------------------------------------------------------------
+    # The sweep
+    # ------------------------------------------------------------------
+
+    def _sweep(self, label: str):
+        """
+        Run every query timestamp against all five topics and require
+        (a) 5-way agreement and (b) Kafka matching the analytic answer.
+        """
+        topics = self._all_topics()
+        self.logger.info(
+            f"sweep '{label}': {len(self.queries)} query timestamps "
+            f"across {len(topics)} topics"
+        )
+
+        results: dict[int, dict[str, int]] = {q: {} for q in self.queries}
+        with concurrent.futures.ThreadPoolExecutor(max_workers=16) as pool:
+            futures = {
+                pool.submit(kcat.query_offset, topic, 0, q): (q, topic)
+                for q in self.queries
+                for topic, kcat in topics
+            }
+            for future in concurrent.futures.as_completed(futures):
+                q, topic = futures[future]
+                results[q][topic] = future.result()
+
+        mismatches: list[str] = []
+        for q in self.queries:
+            answers = results[q]
+            expected = self.expected[q]
+            if len(set(answers.values())) != 1 or answers[self.kafka_topic] != expected:
+                mismatches.append(
+                    f"ts={q} expected={expected} "
+                    + " ".join(f"{t}={o}" for t, o in sorted(answers.items()))
+                )
+
+        assert not mismatches, (
+            f"sweep '{label}': {len(mismatches)} timequery mismatches "
+            f"(expected = analytic first-offset-with-ts>=query):\n"
+            + "\n".join(mismatches[:20])
+        )
+        self.logger.info(f"sweep '{label}': all {len(self.queries)} queries agree")
+
+    # ------------------------------------------------------------------
+    # Test
+    # ------------------------------------------------------------------
+
+    @cluster(num_nodes=3)
+    def test_timequery_parity(self):
+        self._create_topics()
+        self._produce_all()
+        self._verify_hwm()
+
+        # Sweep 1: every topic still serves entirely from local storage.
+        self._sweep("all-local")
+
+        # Move data to remote: lower the tiered topics' local retention
+        # target so classic tiered storage trims its local log after
+        # upload; tiered_v2/cloud reconcile into L1 objects and the
+        # tiered_v2 topic additionally trims its local log so reads pivot
+        # to L1.
+        rpk = RpkTool(self.redpanda)
+        for topic in (self.tiered_v1_topic, self.tiered_v2_topic):
+            rpk.alter_topic_config(
+                topic, "retention.local.target.bytes", str(self.local_target_bytes)
+            )
+        self._wait_reconciled(self.tiered_v2_topic)
+        self._wait_reconciled(self.cloud_topic)
+        for topic in (self.tiered_v1_topic, self.tiered_v2_topic):
+            wait_for_local_storage_truncate(
+                redpanda=self.redpanda,
+                topic=topic,
+                target_bytes=self.local_target_bytes,
+                timeout_sec=180,
+            )
+
+        # Sweep 2: early timestamps now resolve via remote indexes.
+        self._sweep("remote")
+
+        # Sweep 3: cold caches and freshly recovered in-memory state.
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        self._verify_hwm(retry_timeout_sec=60)
+        self._sweep("post-restart")


### PR DESCRIPTION
Adds a 5-way parity test between `redpanda` topics and `Kafka` for timequeries.

This test produces a byte-identical workload (including non-monotonic timestamp phases - duplicates, jitter, a future spike followed by a long backfill below the running max) to four different `redpanda.storage.mode` backed topics (local, tiered_v1, tiered_v2, cloud) and to an Apache Kafka cluster. Then, timequeries are issued to each, and we assert all five topics agree.

Timequeries run at three lifecycle points. First, when all data is expected to be local, then, after data moves to remote/L1 storage and finally, after a full cluster restart. Retention is infinite everywhere so answers cannot shift during the test.

Also adds some fixes to TSv1 timequeries Claude found to be necessary to make this test pass.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none
