### PR TITLE
[v26.1.x] rpk/connect: don't cap version segments at two digits

### DIFF
--- a/src/go/rpk/pkg/cli/connect/BUILD
+++ b/src/go/rpk/pkg/cli/connect/BUILD
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "connect",
@@ -23,4 +23,11 @@ go_library(
         "@com_github_spf13_cobra//:cobra",
         "@org_uber_go_zap//:zap",
     ],
+)
+
+go_test(
+    name = "connect_test",
+    srcs = ["install_test.go"],
+    embed = [":connect"],
+    deps = ["@com_github_stretchr_testify//require"],
 )

--- a/src/go/rpk/pkg/cli/connect/install.go
+++ b/src/go/rpk/pkg/cli/connect/install.go
@@ -132,12 +132,15 @@ func downloadAndInstallConnect(ctx context.Context, fs afero.Fs, installPath, do
 // validateVersion validates that the provided version in the flag is either
 // 'latest' or it's a full semantic version.
 func validateVersion(version string) error {
-	// This simple regexp just matches that a semver is in the string, it may
-	// be prefixed with 'v' and contain anything after. Nothing to capture.
+	// The version may be prefixed with 'v' and carry a prerelease or build
+	// suffix (e.g. '4.102.0-rc1'), which is forwarded to the manifest for
+	// lookup; the manifest is the source of truth for what is published.
+	// Segments are unbounded in width: Connect minor versions passed 99 in
+	// 4.100.0.
 	if version == "latest" {
 		return nil
 	}
-	vMatch := regexp.MustCompile(`^v?\d{1,2}\.\d{1,2}\.\d{1,2}`).MatchString(version)
+	vMatch := regexp.MustCompile(`^v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$`).MatchString(version)
 	if !vMatch {
 		return fmt.Errorf("provided version %q is not valid. Ensure is either 'latest' or it follows the format MAJOR.MINOR.PATCH (e.g., 2.1.3)", version)
 	}

--- a/src/go/rpk/pkg/cli/connect/install_test.go
+++ b/src/go/rpk/pkg/cli/connect/install_test.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package connect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateVersion(t *testing.T) {
+	// Connect minor versions passed 99 in 4.100.0, so segments must not be
+	// capped in width.
+	for _, ok := range []string{"latest", "4.99.0", "4.102.0", "v4.102.0", "4.102.0-rc1", "4.102.100"} {
+		require.NoError(t, validateVersion(ok), ok)
+	}
+	for _, bad := range []string{"", "abc", "4", "4.102", "garbage", "4.102.0garbage", "4.102.0 "} {
+		require.Error(t, validateVersion(bad), bad)
+	}
+}


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31438

- Command: git cherry-pick -x 4f03977837
- Commits backported: 1
- Conflicts resolved: 0
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-31438-v26.1.x-1785959552

## Note on the PR's second commit

The PR lists two commits. `7d6f0758de` is a `Merge remote-tracking branch
'origin/dev'` sync merge, not PR content, and it is intentionally not
cherry-picked:

- Its combined diff (`git show 7d6f0758de`) is empty, so it is not an evil
  merge — it carries no conflict-resolution changes of its own.
- `git diff 4f03977837 7d6f0758de -- src/go/rpk/pkg/cli/connect/` is empty,
  so it contributes nothing to the files this PR touches.

All of the PR's content is in `4f03977837`, and the three files it changes
match the PR's file list exactly (`src/go/rpk/pkg/cli/connect/BUILD` +8/-1,
`install.go` +6/-3, `install_test.go` +27/-0).

## Conflict details

None — `4f03977837` applied cleanly onto `v26.1.x`.

`@com_github_stretchr_testify//require` (the new `go_test` target's only dep)
is already available on `v26.1.x`: `github.com/stretchr/testify v1.11.1` is in
`src/go/rpk/go.mod` and the label is used by existing rpk BUILD files.

The new `TestValidateVersion` was not executed locally; CI covers it.


Fixes: https://github.com/redpanda-data/redpanda/issues/31448,
