### PR TITLE
[v25.3.x] rpk/connect: don't cap version segments at two digits

### DIFF
--- a/src/go/rpk/pkg/cli/connect/BUILD
+++ b/src/go/rpk/pkg/cli/connect/BUILD
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "connect",
@@ -24,4 +24,11 @@ go_library(
         "@com_github_spf13_cobra//:cobra",
         "@org_uber_go_zap//:zap",
     ],
+)
+
+go_test(
+    name = "connect_test",
+    srcs = ["install_test.go"],
+    embed = [":connect"],
+    deps = ["@com_github_stretchr_testify//require"],
 )

--- a/src/go/rpk/pkg/cli/connect/install.go
+++ b/src/go/rpk/pkg/cli/connect/install.go
@@ -141,12 +141,15 @@ func downloadAndInstallConnect(ctx context.Context, fs afero.Fs, installPath, do
 // validateVersion validates that the provided version in the flag is either
 // 'latest' or it's a full semantic version.
 func validateVersion(version string) error {
-	// This simple regexp just matches that a semver is in the string, it may
-	// be prefixed with 'v' and contain anything after. Nothing to capture.
+	// The version may be prefixed with 'v' and carry a prerelease or build
+	// suffix (e.g. '4.102.0-rc1'), which is forwarded to the manifest for
+	// lookup; the manifest is the source of truth for what is published.
+	// Segments are unbounded in width: Connect minor versions passed 99 in
+	// 4.100.0.
 	if version == "latest" {
 		return nil
 	}
-	vMatch := regexp.MustCompile(`^v?\d{1,2}\.\d{1,2}\.\d{1,2}`).MatchString(version)
+	vMatch := regexp.MustCompile(`^v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$`).MatchString(version)
 	if !vMatch {
 		return fmt.Errorf("provided version %q is not valid. Ensure is either 'latest' or it follows the format MAJOR.MINOR.PATCH (e.g., 2.1.3)", version)
 	}

--- a/src/go/rpk/pkg/cli/connect/install_test.go
+++ b/src/go/rpk/pkg/cli/connect/install_test.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package connect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateVersion(t *testing.T) {
+	// Connect minor versions passed 99 in 4.100.0, so segments must not be
+	// capped in width.
+	for _, ok := range []string{"latest", "4.99.0", "4.102.0", "v4.102.0", "4.102.0-rc1", "4.102.100"} {
+		require.NoError(t, validateVersion(ok), ok)
+	}
+	for _, bad := range []string{"", "abc", "4", "4.102", "garbage", "4.102.0garbage", "4.102.0 "} {
+		require.Error(t, validateVersion(bad), bad)
+	}
+}


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31438

- Command: git cherry-pick -x 4f03977837 7d6f0758de
- Commits backported: 2
- Conflicts resolved: 0
- Commits skipped (already on target): 1
- Backport branch: ai-backport-pr-31438-v25.3.x-1785959698

## Conflict details

No content conflicts. `4f03977837` auto-merged onto `v25.3.x` with only
context shifts in `src/go/rpk/pkg/cli/connect/install.go` and
`src/go/rpk/pkg/cli/connect/BUILD`.

## Skipped commit

- `7d6f0758de` ("Merge remote-tracking branch 'origin/dev' into
  rpk-uncap-plugin-version-segments"): a merge of `dev` into the PR branch, not
  authored PR content. Its diff against second parent (`dev`) is exactly the
  three files already delivered by `4f03977837`; its diff against first parent
  (the PR commit) is unrelated `src/v/cloud_topics/` work picked up from `dev`.
  Cherry-picking it with `-m 1` would have imported that unrelated cloud_topics
  change onto the release branch, so it was skipped. No PR code is dropped: the
  backported tree contains the full change (regex fix, doc comment, new
  `install_test.go`, and the `go_test` target in `BUILD`).

## Note on divergence from `dev`

`v25.3.x` still has the older `connectRepoClient`/`getPluginURL` implementation
in this package, whereas `dev` has refactored it to `plugin.RepoClient`. That
refactor is out of scope for this backport and was intentionally not carried
over; the version-validation fix is self-contained in `validateVersion` and
applies to both shapes unchanged.

## Verification not performed

`go test ./pkg/cli/connect/ -run TestValidateVersion` could not be executed in
the backport sandbox (command not permitted). The new test is carried over
verbatim from the source commit and is expected to pass; CI on the backport PR
will confirm.


Fixes: https://github.com/redpanda-data/redpanda/issues/31450,
