### PR TITLE
bazel: suppress Wattribute-alias, apply -Werror to all C/C++ compiles

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -133,6 +133,12 @@ build --host_per_file_copt=external/.*@-Wno-unused-template
 build --per_file_copt=external/ragel.*@-Wno-return-type
 build --host_per_file_copt=external/ragel.*@-Wno-return-type
 
+# New default-on warning in clang-23: lksctp intentionally aliases the
+# sctp_connectx compat symbols to __sctp_connectx with a different signature
+# as part of its symbol-versioning scheme (src/lib/connectx.c)
+build --per_file_copt=external/.*@-Wno-attribute-alias
+build --host_per_file_copt=external/.*@-Wno-attribute-alias
+
 # -base configs generally aren't meant to be used directly but are
 # helpers to DRY later user-facing configs
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -139,6 +139,15 @@ build --host_per_file_copt=external/ragel.*@-Wno-return-type
 build --per_file_copt=external/.*@-Wno-attribute-alias
 build --host_per_file_copt=external/.*@-Wno-attribute-alias
 
+# All C/C++ compiles build with -Werror, including external modules: the
+# suppressions above keep them warning-free, and this stops new warnings
+# (e.g. from toolchain bumps) from scrolling by unnoticed. per_file_copt
+# rather than --copt because --copt leaks into the CFLAGS/CXXFLAGS of
+# rules_foreign_cc builds (openssl, krb5, hwloc), which are not
+# warning-clean and where -Werror can also break configure feature checks.
+build --per_file_copt=.*@-Werror
+build --host_per_file_copt=.*@-Werror
+
 # -base configs generally aren't meant to be used directly but are
 # helpers to DRY later user-facing configs
 

--- a/bazel/internal.bzl
+++ b/bazel/internal.bzl
@@ -12,7 +12,6 @@ def redpanda_copts():
     """
 
     copts = []
-    copts.append("-Werror")
     copts.append("-Wall")
     copts.append("-Wextra")
     copts.append("-Wno-missing-field-initializers")


### PR DESCRIPTION
The clang-23 toolchain introduced a new default-on warning, -Wattribute-alias, which fires when compiling lksctp: it intentionally aliases the sctp_connectx compat symbols to `__sctp_connectx` with a different signature as part of its symbol-versioning scheme (`src/lib/connectx.c`). This slipped past our third-party warning suppression because that operates via `-isystem` include paths (which only silence warnings from external *headers* included by our code) plus an enumerated list of `--per_file_copt=external/.*@-Wno-...` entries which didn't include this warning.

The first commit suppresses the warning for external sources, following the existing pattern.

The second commit makes sure we stay warning-free: `-Werror` moves from the `redpanda_cc_*` macros to a global `--per_file_copt=.*@-Werror`, so every bazel-native C/C++ compile (first-party, plain `cc_library`, and all external modules) now fails on any warning instead of letting it scroll by. `per_file_copt` is used rather than `--copt` because `--copt` leaks into the CFLAGS/CXXFLAGS that rules_foreign_cc passes to the openssl/krb5/hwloc builds, which are not warning-clean and where `-Werror` can also break configure feature checks.

Verified with a full recompile of `//src/v/...` (the flag change invalidates every C/C++ action key): all targets build with zero warnings.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none