### PR TITLE
`config`: mark dev-features flag usable_before_ready

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -5349,9 +5349,11 @@ configuration::configuration(ctor_key)
       "or any cluster where stability, data loss, or the ability to upgrade "
       "are a concern. To enable experimental features, set the value of this "
       "configuration option to the current unix epoch expressed in seconds. "
-      "The value must be within one hour of the current time on the broker."
+      "The value must be within one hour of the current time on the broker. "
       "Once experimental features are enabled they cannot be disabled.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no,
+       .visibility = visibility::tunable,
+       .usable_before_ready = usable_before_ready::yes},
       "",
       [this](const ss::sstring& v) -> std::optional<ss::sstring> {
           if (development_features_enabled()) {


### PR DESCRIPTION
## Motivation

Debug/fastbuild `dev_cluster` (and any debug build whose bootstrap yaml enables a development feature) has aborted on startup since #30396 merged (2026-06-30, ~36 days), with:

```
Assert failure: (src/v/config/base_property.cc:97)
Read property 'enable_developmental_unrecoverable_data_corrupting_features'
before its config_store was marked as ready by the startup process.
```

`enable_developmental_unrecoverable_data_corrupting_features` gates every `development_feature_property` via `development_features_enabled()`. That gate is read during `config_manager::load_bootstrap()` while `read_yaml()` loads the bootstrap file, which happens *before* the config store is marked ready. Since the `usable_before_ready` audit was added, that read trips the debug-only `debug_assert_readable()` assert and aborts startup. `tools/dev_cluster.py` always writes this flag into each node's `.bootstrap.yaml`, so debug/fastbuild dev clusters fail every time; release builds are unaffected (the assert is a `dassert`).

## Change

Mark the flag `usable_before_ready::yes`. Reading the default/stale value during bootstrap is safe here: the gate is only consulted to validate the dev-gated properties as the bootstrap file is loaded, matching the many other properties already marked usable-before-ready.

Verified locally: `bazel run //tools:dev_cluster -- --delete-data-dir --nodes 1 ... -- --smp=1 --memory 4G` now reaches "Successfully started Redpanda!".

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none