### PR TITLE
DNM: no-op build - remote downloader live in CI (default)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -540,3 +540,5 @@ filegroup(
     strip_prefix = "JSONTestSuite-1ef36fa01286573e846ac449e8683f8833c5b26a",
     urls = ["https://github.com/nst/JSONTestSuite/archive/1ef36fa01286573e846ac449e8683f8833c5b26a.tar.gz"],
 )
+
+# No-op change to trigger a CI build (CORE-16343 remote downloader timing).


### PR DESCRIPTION
**Do not merge.** No-op `MODULE.bazel` comment to trigger a CI build.

Smoke check now that [vtools#4334](https://github.com/redpanda-data/vtools/pull/4334) is merged, so every build gets `--experimental_remote_downloader` (with `local_fallback=true`) by default. Run with `--announce_rc` to confirm the merged flags actually reach `user.bazelrc`, and with a fresh `--repository_cache` so external fetches genuinely go over the wire.

Paired with [#31455](https://github.com/redpanda-data/redpanda/pull/31455), which is the byte-identical commit run with the downloader **disabled** (`bazel_args=--experimental_remote_downloader=`, which trips bazel's `isNullOrEmpty` check in `shouldEnableRemoteDownloader` while leaving the gRPC action cache intact). The two together measure whether funnelling downloads through the cache helps a fully-cached build.

[CORE-16343](https://redpandadata.atlassian.net/browse/CORE-16343)

## Release Notes

- none

[CORE-16343]: https://redpandadata.atlassian.net/browse/CORE-16343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ