### PR TITLE
DNM: no-op build - remote downloader disabled (A/B control for #31454)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -540,3 +540,5 @@ filegroup(
     strip_prefix = "JSONTestSuite-1ef36fa01286573e846ac449e8683f8833c5b26a",
     urls = ["https://github.com/nst/JSONTestSuite/archive/1ef36fa01286573e846ac449e8683f8833c5b26a.tar.gz"],
 )
+
+# No-op change to trigger a CI build (CORE-16343 remote downloader timing).


### PR DESCRIPTION
**Do not merge.** Control arm for [#31454](https://github.com/redpanda-data/redpanda/pull/31454) - byte-identical no-op commit, run with the remote downloader **disabled**:

```
/rp-unit-test
bazel_args=--announce_rc --repository_cache=/tmp/rc-dl-off --experimental_remote_downloader=
```

An empty value trips `isNullOrEmpty` in bazel's `shouldEnableRemoteDownloader`, so the downloader is off while the gRPC action cache stays on - isolating the fetch path as the only variable. Both arms use a fresh `--repository_cache` so external archives are actually fetched over the wire rather than served from the agent-local cache.

Purpose: measure whether routing external dependency downloads through bazel-remote ([vtools#4334](https://github.com/redpanda-data/vtools/pull/4334), now merged) speeds up an otherwise fully-cached build - i.e. in-VPC gRPC fetches vs GitHub/S3 over the internet.

[CORE-16343](https://redpandadata.atlassian.net/browse/CORE-16343)

## Release Notes

- none

[CORE-16343]: https://redpandadata.atlassian.net/browse/CORE-16343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ