### PR TITLE
[v26.2.x] ct/l1: keep flushing metastore partitions past a failure

### DIFF
--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -258,6 +258,8 @@ db_domain_manager::db_domain_manager(
   , gc_interval_(
       config::shard_local_cfg()
         .cloud_topics_long_term_garbage_collection_interval)
+  , flush_interval_(
+      config::shard_local_cfg().cloud_topics_long_term_flush_interval)
   , probe_(probe) {
     gc_interval_.watch([this]() { sem_.signal(); });
 }
@@ -1996,11 +1998,30 @@ db_domain_manager::restore_domain(rpc::restore_domain_request req) {
     };
 }
 
+bool db_domain_manager::flushed_recently() const {
+    if (!last_flush_.has_value()) {
+        return false;
+    }
+    // Half the flush interval, so a domain still persists on roughly the
+    // configured cadence while retries in between don't each force a new SST.
+    return ss::lowres_clock::now() - *last_flush_ < flush_interval_() / 2;
+}
+
 ss::future<rpc::flush_domain_reply>
 db_domain_manager::flush_domain(rpc::flush_domain_request req) {
     auto gl_res = co_await gate_and_open_reads();
     if (!gl_res.has_value()) {
         co_return rpc::flush_domain_reply{.ec = gl_res.error()};
+    }
+    if (req.skip_if_recent && flushed_recently()) {
+        vlog(
+          cd_log.debug,
+          "Skipping flush of domain {}, last flushed recently",
+          db_->get_domain_uuid());
+        co_return rpc::flush_domain_reply{
+          .ec = rpc::errc::ok,
+          .uuid = db_->get_domain_uuid(),
+        };
     }
     auto flush_res = co_await db_->flush(30s);
     if (!flush_res.has_value()) {
@@ -2008,6 +2029,7 @@ db_domain_manager::flush_domain(rpc::flush_domain_request req) {
           .ec = log_and_convert(flush_res.error(), "Failed to flush domain: "),
         };
     }
+    last_flush_ = ss::lowres_clock::now();
     co_return rpc::flush_domain_reply{
       .ec = rpc::errc::ok,
       .uuid = db_->get_domain_uuid(),

--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.h
@@ -140,6 +140,10 @@ private:
     ss::future<> gc_loop();
     ss::lowres_clock::duration gc_interval() const;
 
+    // Whether this domain flushed recently enough in this term that a
+    // skippable flush can decline to persist again.
+    bool flushed_recently() const;
+
     struct gate_read_lock {
         ss::gate::holder gate;
         ss::rwlock::holder db_lock;
@@ -264,6 +268,14 @@ private:
     entity_lock_map<object_id> object_locks_{"l1/domain/object"};
 
     config::binding<std::chrono::milliseconds> gc_interval_;
+    config::binding<std::chrono::milliseconds> flush_interval_;
+
+    // When this domain last successful call to flush_domain, used to let
+    // periodic flushes skip a if we flushed recently. Empty until the first
+    // flush of this term.
+    // NOTE: doesn't account for flushes outside of flush_domain, e.g. those
+    // triggered by memtable limits.
+    std::optional<ss::lowres_clock::time_point> last_flush_;
     // This semaphore is used as a way to signal a change to
     // `cloud_topics_long_term_garbage_collection_interval` during the `wait()`
     // operation in the main garbage collection loop.

--- a/src/v/cloud_topics/level_one/metastore/flush_loop.cc
+++ b/src/v/cloud_topics/level_one/metastore/flush_loop.cc
@@ -46,7 +46,11 @@ private:
         const auto retry_interval = ssx::duration::seconds(10);
         while (!as_.abort_requested()) {
             auto start = ssx::instant::from_chrono(ss::lowres_clock::now());
-            auto res = co_await metastore_->flush();
+            // Periodic flushes let a domain that flushed recently decline, so
+            // that retries after a failed partition don't force every healthy
+            // domain to persist a small SST every retry interval.
+            auto res = co_await metastore_->flush(
+              metastore::flush_type::skip_if_recent);
             auto finish = ssx::instant::from_chrono(ss::lowres_clock::now());
 
             ssx::duration sleep_duration;

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -569,8 +569,25 @@ public:
       const model::topic_id_partition&, kafka::offset, kafka::offset, size_t)
       = 0;
 
-    // Flushes all metastore partitions to cloud storage.
-    virtual ss::future<std::expected<std::nullopt_t, errc>> flush() = 0;
+    enum class flush_type {
+        // Persists every metastore partition, regardless of when it last
+        // flushed. On success, all metadata is durable as of the call.
+        force,
+
+        // Lets partitions that flushed within half of
+        // cloud_topics_long_term_flush_interval decline to persist again. On
+        // success, all metadata is durable as of some point within that
+        // window, rather than as of the call.
+        skip_if_recent,
+    };
+
+    // Flushes all metastore partitions to cloud storage. Flushes every
+    // partition even if some fail, returning the first error encountered.
+    //
+    // Defaults to `force` so that callers needing a barrier get one without
+    // having to ask; `skip_if_recent` must be requested explicitly.
+    virtual ss::future<std::expected<std::nullopt_t, errc>>
+      flush(flush_type = flush_type::force) = 0;
 
     // Restores metastore state from a previously flushed manifest in the given
     // cluster's cloud storage. This downloads the metastore topic manifest,

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -1113,6 +1113,7 @@ replicated_metastore::flush(flush_type type) {
 
     chunked_vector<domain_uuid> domains;
     domains.reserve(*num_partitions);
+    std::optional<errc> flush_error;
     for (int pid = 0; pid < *num_partitions; ++pid) {
         rpc::flush_domain_request req{
           .metastore_partition = model::partition_id{pid},
@@ -1123,13 +1124,23 @@ replicated_metastore::flush(flush_type type) {
         if (reply_fut.failed()) {
             auto ex = reply_fut.get_exception();
             vlog(cd_log.warn, "Error flushing partition {}: {}", pid, ex);
-            co_return std::unexpected(errc::transport_error);
+            flush_error = flush_error.value_or(errc::transport_error);
+            continue;
         }
         auto reply = reply_fut.get();
         if (reply.ec != rpc::errc::ok) {
-            co_return std::unexpected(rpc_to_meta_errc(reply.ec));
+            vlog(cd_log.warn, "Error flushing partition {}: {}", pid, reply.ec);
+            flush_error = flush_error.value_or(rpc_to_meta_errc(reply.ec));
+            continue;
         }
         domains.push_back(reply.uuid);
+    }
+
+    // The manifest must list every domain to be usable for restore, so only
+    // upload it if all partitions flushed. Otherwise report the error and let
+    // the caller retry.
+    if (flush_error.has_value()) {
+        co_return std::unexpected(*flush_error);
     }
 
     metastore_manifest manifest{

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -1098,7 +1098,7 @@ replicated_metastore::get_extent_metadata_backwards(
 }
 
 ss::future<std::expected<std::nullopt_t, metastore::errc>>
-replicated_metastore::flush() {
+replicated_metastore::flush(flush_type type) {
     auto num_partitions = fe_.num_metastore_partitions();
     if (!num_partitions.has_value()) {
         vlog(cd_log.warn, "Unable to get num metastore partitions for flush");
@@ -1115,7 +1115,8 @@ replicated_metastore::flush() {
     domains.reserve(*num_partitions);
     for (int pid = 0; pid < *num_partitions; ++pid) {
         rpc::flush_domain_request req{
-          .metastore_partition = model::partition_id{pid}};
+          .metastore_partition = model::partition_id{pid},
+          .skip_if_recent = type == flush_type::skip_if_recent};
 
         auto reply_fut = co_await ss::coroutine::as_future(
           fe_.flush_domain(std::move(req)));

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
@@ -104,7 +104,8 @@ public:
       kafka::offset,
       size_t) override;
 
-    ss::future<std::expected<std::nullopt_t, errc>> flush() override;
+    ss::future<std::expected<std::nullopt_t, errc>>
+      flush(flush_type = flush_type::force) override;
 
     ss::future<std::expected<std::nullopt_t, errc>>
     restore(const cloud_storage::remote_label&) override;

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -537,11 +537,17 @@ struct flush_domain_reply
 struct flush_domain_request
   : serde::envelope<
       flush_domain_request,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
     using resp_t = flush_domain_reply;
-    auto serde_fields() { return std::tie(metastore_partition); }
+    auto serde_fields() {
+        return std::tie(metastore_partition, skip_if_recent);
+    }
     model::partition_id metastore_partition;
+
+    // When set, the domain may no-op if it flushed within half of
+    // cloud_topics_long_term_flush_interval.
+    bool skip_if_recent{false};
 };
 
 struct preregister_objects_reply

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -134,7 +134,8 @@ public:
       kafka::offset,
       size_t) override;
 
-    ss::future<std::expected<std::nullopt_t, errc>> flush() override {
+    ss::future<std::expected<std::nullopt_t, errc>>
+    flush(flush_type = flush_type::force) override {
         co_return std::unexpected(errc::transport_error);
     }
 

--- a/src/v/cloud_topics/level_one/metastore/tests/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/tests/BUILD
@@ -97,6 +97,7 @@ redpanda_cc_gtest(
     deps = [
         "//src/v/cloud_storage:remote_label",
         "//src/v/cloud_topics:app",
+        "//src/v/cloud_topics/level_one/domain:domain_supervisor",
         "//src/v/cloud_topics/level_one/metastore:domain_uuid",
         "//src/v/cloud_topics/level_one/metastore:leader_router",
         "//src/v/cloud_topics/level_one/metastore:manifest_io",
@@ -120,6 +121,7 @@ redpanda_cc_gtest(
         "//src/v/lsm/io:memory_persistence",
         "//src/v/model",
         "//src/v/serde",
+        "//src/v/test_utils:async",
         "//src/v/test_utils:gtest",
         "//src/v/test_utils:scoped_config",
         "@googletest//:gtest",

--- a/src/v/cloud_topics/level_one/metastore/tests/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/tests/BUILD
@@ -98,6 +98,7 @@ redpanda_cc_gtest(
         "//src/v/cloud_storage:remote_label",
         "//src/v/cloud_topics:app",
         "//src/v/cloud_topics/level_one/metastore:domain_uuid",
+        "//src/v/cloud_topics/level_one/metastore:leader_router",
         "//src/v/cloud_topics/level_one/metastore:manifest_io",
         "//src/v/cloud_topics/level_one/metastore:metastore_manifest",
         "//src/v/cloud_topics/level_one/metastore:replicated_metastore",
@@ -120,6 +121,7 @@ redpanda_cc_gtest(
         "//src/v/model",
         "//src/v/serde",
         "//src/v/test_utils:gtest",
+        "//src/v/test_utils:scoped_config",
         "@googletest//:gtest",
     ],
 )

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -10,6 +10,7 @@
 
 #include "cloud_storage/remote_label.h"
 #include "cloud_topics/level_one/metastore/domain_uuid.h"
+#include "cloud_topics/level_one/metastore/leader_router.h"
 #include "cloud_topics/level_one/metastore/manifest_io.h"
 #include "cloud_topics/level_one/metastore/metastore_manifest.h"
 #include "cloud_topics/level_one/metastore/replicated_metastore.h"
@@ -22,6 +23,7 @@
 #include "lsm/lsm.h"
 #include "model/fundamental.h"
 #include "model/namespace.h"
+#include "test_utils/scoped_config.h"
 
 using namespace cloud_topics::l1;
 
@@ -57,6 +59,21 @@ public:
             add_node(fixture_cfg());
         }
         wait_for_all_members(5s).get();
+    }
+
+    // The seqno of the given partition's last flushed manifest, or nullopt if
+    // it hasn't flushed.
+    std::optional<lsm::sequence_number>
+    persisted_seqno(model::partition_id pid) {
+        auto stm = get_l1_lsm_stm(pid);
+        if (!stm) {
+            return std::nullopt;
+        }
+        const auto& manifest = stm->state().persisted_manifest;
+        if (!manifest.has_value()) {
+            return std::nullopt;
+        }
+        return manifest->get_last_seqno();
     }
 
     // For simple_stm, this returns the state directly.
@@ -1392,6 +1409,58 @@ TEST_P(ReplicatedMetastoreTest, TestGetLevelingInfo) {
 
         EXPECT_THAT(res.ranges, ::testing::ElementsAreArray(c.expected_ranges))
           << c.name;
+    }
+}
+
+TEST_P(ReplicatedMetastoreTest, TestPeriodicFlushSkipsRecentlyFlushedDomains) {
+    if (GetParam() == metastore_backend::simple) {
+        GTEST_SKIP() << "Flush not supported with simple backend";
+    }
+    // Make "flushed recently" (half the flush interval) cover the whole test.
+    scoped_config cfg;
+    cfg.get("cloud_topics_long_term_flush_interval")
+      .set_value(std::chrono::milliseconds(2h));
+
+    auto& app = get_ct_app(model::node_id{0});
+    auto& meta = app.get_sharded_replicated_metastore()->local();
+    auto num_partitions = app.get_sharded_l1_metastore_router()
+                            ->local()
+                            .num_metastore_partitions();
+    ASSERT_TRUE(num_partitions.has_value());
+
+    ASSERT_NO_FATAL_FAILURE(add_initial_objects(meta, 100, 99).get());
+
+    // A forced flush always persists.
+    auto forced = meta.flush().get();
+    ASSERT_TRUE(forced.has_value()) << fmt::to_string(forced.error());
+    std::vector<lsm::sequence_number> before;
+    for (int pid = 0; pid < *num_partitions; ++pid) {
+        auto seqno = persisted_seqno(model::partition_id(pid));
+        ASSERT_TRUE(seqno.has_value())
+          << "partition " << pid << " never persisted a manifest";
+        before.push_back(*seqno);
+    }
+
+    // More writes, so every partition has something new it could persist.
+    ASSERT_NO_FATAL_FAILURE(add_objects_for_topics(meta, 60, 99).get());
+
+    // A periodic flush should decline on every partition, since they all
+    // flushed moments ago. It still reports success: the metadata is durable as
+    // of that flush, just not as of this call.
+    auto skipped = meta.flush(metastore::flush_type::skip_if_recent).get();
+    ASSERT_TRUE(skipped.has_value()) << fmt::to_string(skipped.error());
+    for (int pid = 0; pid < *num_partitions; ++pid) {
+        EXPECT_EQ(persisted_seqno(model::partition_id(pid)), before[pid])
+          << "partition " << pid << " persisted despite flushing recently";
+    }
+
+    // A forced flush ignores the guard.
+    auto forced_again = meta.flush().get();
+    ASSERT_TRUE(forced_again.has_value())
+      << fmt::to_string(forced_again.error());
+    for (int pid = 0; pid < *num_partitions; ++pid) {
+        EXPECT_GT(persisted_seqno(model::partition_id(pid)), before[pid])
+          << "partition " << pid << " did not persist on a forced flush";
     }
 }
 

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -23,6 +23,7 @@
 #include "lsm/lsm.h"
 #include "model/fundamental.h"
 #include "model/namespace.h"
+#include "test_utils/async.h"
 #include "test_utils/scoped_config.h"
 
 using namespace cloud_topics::l1;
@@ -1409,6 +1410,54 @@ TEST_P(ReplicatedMetastoreTest, TestGetLevelingInfo) {
 
         EXPECT_THAT(res.ranges, ::testing::ElementsAreArray(c.expected_ranges))
           << c.name;
+    }
+}
+
+TEST_P(ReplicatedMetastoreTest, TestFlushWithUnhealthyPartition) {
+    if (GetParam() == metastore_backend::simple) {
+        GTEST_SKIP() << "Flush not supported with simple backend";
+    }
+    auto& app = get_ct_app(model::node_id{0});
+    auto& meta = app.get_sharded_replicated_metastore()->local();
+    auto num_partitions = app.get_sharded_l1_metastore_router()
+                            ->local()
+                            .num_metastore_partitions();
+    ASSERT_TRUE(num_partitions.has_value());
+    ASSERT_GE(*num_partitions, 2);
+
+    // Enough topic partitions that every metastore partition has rows to
+    // persist. Nothing has flushed yet, so no domain has a manifest.
+    ASSERT_NO_FATAL_FAILURE(add_initial_objects(meta, 100, 99).get());
+
+    // Take the domain manager away from metastore partition 0, so its flush
+    // fails with not_leader.
+    auto unhealthy_ntp = model::ntp{
+      model::kafka_internal_namespace,
+      model::l1_metastore_topic,
+      model::partition_id{0}};
+    auto [leader_fx, leader_p] = get_leader(unhealthy_ntp);
+    ASSERT_NE(leader_fx, nullptr);
+    auto* sup
+      = leader_fx->app.cloud_topics_app->get_sharded_l1_domain_supervisor();
+    sup
+      ->invoke_on_all([&unhealthy_ntp](domain_supervisor& s) {
+          s.on_domain_leadership_change(unhealthy_ntp, {});
+      })
+      .get();
+    RPTEST_REQUIRE_EVENTUALLY(
+      10s, [&] { return sup->local().get(unhealthy_ntp) == nullptr; });
+
+    auto res = meta.flush().get();
+    EXPECT_FALSE(res.has_value()) << "flush should report partition 0";
+
+    EXPECT_FALSE(persisted_seqno(model::partition_id{0}).has_value())
+      << "partition 0 was expected to be unhealthy, but it flushed";
+
+    // The healthy partitions should have flushed anyway: each one persists its
+    // own manifest, which is what gates its L1 GC.
+    for (int pid = 1; pid < *num_partitions; ++pid) {
+        EXPECT_TRUE(persisted_seqno(model::partition_id(pid)).has_value())
+          << "partition " << pid << " was skipped";
     }
 }
 

--- a/src/v/cloud_topics/read_replica/snapshot_metastore.cc
+++ b/src/v/cloud_topics/read_replica/snapshot_metastore.cc
@@ -331,7 +331,7 @@ snapshot_metastore::get_extent_metadata_backwards(
 }
 
 ss::future<std::expected<std::nullopt_t, l1::metastore::errc>>
-snapshot_metastore::flush() {
+snapshot_metastore::flush(flush_type) {
     co_return std::unexpected(errc::invalid_request);
 }
 

--- a/src/v/cloud_topics/read_replica/snapshot_metastore.h
+++ b/src/v/cloud_topics/read_replica/snapshot_metastore.h
@@ -99,7 +99,8 @@ public:
       kafka::offset,
       size_t) override;
 
-    ss::future<std::expected<std::nullopt_t, errc>> flush() override;
+    ss::future<std::expected<std::nullopt_t, errc>>
+      flush(flush_type = flush_type::force) override;
 
     ss::future<std::expected<std::nullopt_t, errc>>
     restore(const cloud_storage::remote_label&) override;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31422
