### PR TITLE
[v26.1.x] `compaction`: fix `min.compaction.lag.ms` comparision for future timestamps

### DIFF
--- a/src/v/cloud_topics/level_one/compaction/source.cc
+++ b/src/v/cloud_topics/level_one/compaction/source.cc
@@ -116,12 +116,14 @@ void align_extent_to_dirty_range(
 bool should_compact_extent(
   const metastore::extent_metadata& extent,
   std::chrono::milliseconds min_compaction_lag_ms) {
+    // As in Kafka's LogCleanerManager::cleanableOffsets, the timestamp check is
+    // skipped entirely when the lag is unset.
+    if (min_compaction_lag_ms <= std::chrono::milliseconds{0}) {
+        return true;
+    }
     const auto now = to_time_point(model::timestamp::now());
     const auto max_extent_ts = to_time_point(extent.max_timestamp);
-    if (now - max_extent_ts < min_compaction_lag_ms) {
-        return false;
-    }
-    return true;
+    return now - max_extent_ts >= min_compaction_lag_ms;
 }
 
 } // namespace

--- a/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
@@ -945,6 +945,86 @@ TEST_F(ReducerTestFixture, MinCompactionLagMsReducerInterleavedTimestamps) {
       std::move(output_batches));
 }
 
+// An extent's max timestamp may be ahead of the local clock: producers may set
+// create-time up to log_message_timestamp_after_max_ms (1h by default) in the
+// future, and the system clock may step backwards. With min.compaction.lag.ms
+// set, such an extent is held back until the clock catches up (as in Kafka's
+// `largestTimestamp > now - minCompactionLagMs`), but with the lag unset the
+// timestamp must not be consulted at all and the extent must still compact.
+TEST_F(ReducerTestFixture, MinCompactionLagMsUnsetTimestampsInFuture) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+    int num_produce_rounds = 4;
+    int num_batches = 10;
+    int num_records = 10;
+    kafka::offset start_offset{0};
+    kafka::offset last_offset{
+      (num_produce_rounds * num_batches * num_records) - 1};
+    auto gen = linear_int_kv_batch_generator();
+
+    const auto future_ts = model::timestamp(
+      model::timestamp::now().value() + std::chrono::milliseconds{1h}.count());
+
+    for (int i = 0; i < num_produce_rounds; ++i) {
+        model::test::record_batch_spec spec{
+          .allow_compression = true,
+          .count = num_records,
+          .timestamp = future_ts,
+          .all_records_have_same_timestamp = true};
+        auto batches = gen(spec, num_batches);
+        std::vector<tidp_batches_t> tidp_batches;
+        tidp_batches.emplace_back(tidp, std::move(batches));
+        make_l1_objects(std::move(tidp_batches)).get();
+    }
+
+    auto info_spec = l1::metastore::compaction_info_spec{
+      .tidp = tidp,
+      .tombstone_removal_upper_bound_ts = model::timestamp::max()};
+
+    // With a lag configured, the future timestamps hold every extent back.
+    auto compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    ASSERT_TRUE(compaction_info->offsets_response.dirty_ranges.covers(
+      start_offset, last_offset));
+    do_compact(
+      tidp,
+      ntp,
+      std::move(compaction_info->offsets_response),
+      compaction_info->compaction_epoch,
+      compaction_info->start_offset,
+      &_metastore,
+      &_io,
+      /*min_compaction_lag_ms=*/1h)
+      .get();
+
+    compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    ASSERT_TRUE(compaction_info->offsets_response.dirty_ranges.covers(
+      start_offset, last_offset));
+
+    // With the lag unset, the same extents compact despite the future
+    // timestamps.
+    do_compact(
+      tidp,
+      ntp,
+      std::move(compaction_info->offsets_response),
+      compaction_info->compaction_epoch,
+      compaction_info->start_offset,
+      &_metastore,
+      &_io,
+      /*min_compaction_lag_ms=*/0ms)
+      .get();
+
+    compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    ASSERT_FLOAT_EQ(compaction_info->dirty_ratio, 0.0);
+    ASSERT_TRUE(compaction_info->offsets_response.dirty_ranges.empty());
+
+    auto reader = make_reader(ntp, tidp);
+    auto output_batches = read_all(std::move(reader));
+    linear_int_kv_batch_generator::validate_post_compaction(
+      std::move(output_batches));
+}
+
 TEST_F(ReducerTestFixture, MaxCompactibleOffsetReducer) {
     // This test verifies that compaction respects the max_compactible_offset
     // boundary. We create multiple extents and set max_compactible_offset to

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -455,10 +455,15 @@ segment::is_compactible(const compaction::compaction_config& cfg) const {
     // compaction a segment must both
     // 1. have latest batch timestamp longer ago than min.compaction.lag.ms, and
     // 2. end before the max compactible offset.
-    const auto now = to_time_point(model::timestamp::now());
-    const auto max_batch_ts = to_time_point(index().retention_timestamp());
-    if (now - max_batch_ts < cfg.min_lag_ms) {
-        return false;
+    //
+    // As in Kafka's LogCleanerManager::cleanableOffsets, the timestamp check is
+    // skipped entirely when the lag is unset.
+    if (cfg.min_lag_ms > std::chrono::milliseconds{0}) {
+        const auto now = to_time_point(model::timestamp::now());
+        const auto max_batch_ts = to_time_point(index().retention_timestamp());
+        if (now - max_batch_ts < cfg.min_lag_ms) {
+            return false;
+        }
     }
     return _tracker.get_stable_offset() <= cfg.max_removable_local_log_offset;
 }

--- a/src/v/storage/tests/segment_deduplication_test.cc
+++ b/src/v/storage/tests/segment_deduplication_test.cc
@@ -51,7 +51,8 @@ void add_segments(
   int start_offset = 0,
   bool mark_compacted = true,
   bool may_have_tombstones = true,
-  std::optional<model::timestamp> clean_compacted_ts = std::nullopt) {
+  std::optional<model::timestamp> clean_compacted_ts = std::nullopt,
+  model::timestamp batch_ts = model::timestamp::min()) {
     auto& disk_log = b.get_disk_log_impl();
     for (int i = 0; i < num_segs; i++) {
         auto offset = start_offset + i * records_per_seg;
@@ -63,7 +64,7 @@ void add_segments(
             model::record_batch_type::raft_data,
             append_config(),
             disk_log_builder::should_flush_after::yes,
-            model::timestamp::min());
+            batch_ts);
     }
     for (auto& seg : disk_log.segments()) {
         if (mark_compacted) {
@@ -98,7 +99,8 @@ void build_segments(
   int start_offset = 0,
   bool mark_compacted = true,
   bool may_have_tombstones = true,
-  std::optional<model::timestamp> clean_compacted_ts = std::nullopt) {
+  std::optional<model::timestamp> clean_compacted_ts = std::nullopt,
+  model::timestamp batch_ts = model::timestamp::min()) {
     b | start();
     add_segments(
       b,
@@ -107,7 +109,8 @@ void build_segments(
       start_offset,
       mark_compacted,
       may_have_tombstones,
-      clean_compacted_ts);
+      clean_compacted_ts,
+      batch_ts);
 }
 
 TEST(FindSlidingRangeTest, TestCollectSegments) {
@@ -137,6 +140,81 @@ TEST(FindSlidingRangeTest, TestCollectSegments) {
               << ssx::sformat("{} to {}: {}", start, end, segs.size());
         }
     }
+}
+
+// A segment's retention timestamp may be ahead of the local clock: producers
+// may set create-time up to log_message_timestamp_after_max_ms (1h by default)
+// in the future, and the system clock may step backwards. With
+// min.compaction.lag.ms unset, such a segment must still be compactible, as in
+// Kafka's LogCleanerManager::cleanableOffsets.
+TEST(FindSlidingRangeTest, TestSegmentTimestampInFuture) {
+    storage::disk_log_builder b;
+    const auto num_segs = 3;
+    const auto future_ts = model::timestamp{
+      model::timestamp::now().value() + std::chrono::milliseconds{1h}.count()};
+    build_segments(
+      b,
+      num_segs,
+      /*records_per_seg=*/10,
+      /*start_offset=*/0,
+      /*mark_compacted=*/false,
+      /*may_have_tombstones=*/true,
+      /*clean_compacted_ts=*/std::nullopt,
+      future_ts);
+    auto cleanup = ss::defer([&] { b.stop().get(); });
+    auto& disk_log = b.get_disk_log_impl();
+    ASSERT_GE(
+      disk_log.segments().front()->index().retention_timestamp(), future_ts);
+
+    compaction::compaction_config cfg(
+      model::offset{30},
+      model::offset{30},
+      model::offset{30},
+      std::nullopt,
+      std::nullopt,
+      never_abort);
+
+    auto segs = disk_log.find_sliding_range(cfg);
+    ASSERT_EQ(segs.size(), num_segs);
+    ASSERT_TRUE(disk_log.sliding_window_compact(cfg).get());
+}
+
+// Conversely, when min.compaction.lag.ms is set, a retention timestamp in the
+// future holds the segment back until the clock catches up. Kafka does the same
+// (the lag is a guarantee about recent data, and a future timestamp trivially
+// satisfies `largestTimestamp > now - minCompactionLagMs`), so this is not
+// something to "correct" by clamping the timestamp.
+TEST(FindSlidingRangeTest, TestSegmentTimestampInFutureRespectsMinLag) {
+    storage::disk_log_builder b;
+    const auto num_segs = 3;
+    const auto future_ts = model::timestamp{
+      model::timestamp::now().value() + std::chrono::milliseconds{1h}.count()};
+    build_segments(
+      b,
+      num_segs,
+      /*records_per_seg=*/10,
+      /*start_offset=*/0,
+      /*mark_compacted=*/false,
+      /*may_have_tombstones=*/true,
+      /*clean_compacted_ts=*/std::nullopt,
+      future_ts);
+    auto cleanup = ss::defer([&] { b.stop().get(); });
+    auto& disk_log = b.get_disk_log_impl();
+
+    compaction::compaction_config cfg(
+      model::offset{30},
+      model::offset{30},
+      model::offset{30},
+      std::nullopt,
+      std::nullopt,
+      never_abort,
+      std::nullopt,
+      std::nullopt,
+      /*min_lag_ms=*/1h);
+
+    auto segs = disk_log.find_sliding_range(cfg);
+    ASSERT_EQ(segs.size(), 0);
+    ASSERT_FALSE(disk_log.sliding_window_compact(cfg).get());
 }
 
 TEST(FindSlidingRangeTest, TestCollectExcludesPrevious) {


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31442
