### PR TITLE
kvstore: fail fast on flush fiber exceptions

### DIFF
--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -101,22 +101,29 @@ ss::future<> kvstore::start() {
     _started = true;
 
     // Flushing background fiber
-    ssx::spawn_with_gate(_gate, [this] {
-        return ss::do_until(
-          [this] { return _gate.is_closed(); },
-          [this] {
-              // semaphore used here instead of condition variable so that
-              // we don't lose wake-ups if they occur while flushing.
-              // consume at least one unit to avoid spinning on wait(0).
-              auto units = std::max(_sem.current(), size_t(1));
-              return _sem.wait(units).then([this] {
-                  if (_gate.is_closed()) {
-                      return ss::now();
-                  }
-                  return roll().then([this] { return flush_and_apply_ops(); });
-              });
+    ssx::repeat_until_gate_closed(
+      _gate,
+      [this] {
+          // semaphore used here instead of condition variable so that
+          // we don't lose wake-ups if they occur while flushing.
+          // consume at least one unit to avoid spinning on wait(0).
+          auto units = std::max(_sem.current(), size_t(1));
+          return _sem.wait(units).then([this] {
+              if (_gate.is_closed()) {
+                  return ss::now();
+              }
+              return roll().then([this] { return flush_and_apply_ops(); });
           });
-    });
+      },
+      [](const std::exception_ptr& e) {
+          // an error mid roll/flush leaves the segment, pending ops and
+          // _next_offset in an unknown state, so neither retrying nor
+          // exiting the fiber is safe (the latter would hang all future
+          // puts). on-disk state is crash-safe, so terminate and recover.
+          if (!ssx::is_shutdown_exception(e)) {
+              vunreachable("kvstore flush fiber failed: {}", e);
+          }
+      });
 }
 
 ss::future<> kvstore::stop() {


### PR DESCRIPTION
The kvstore flushing background fiber had no exception handling: any non-shutdown exception escaping `roll()` or `flush_and_apply_ops()` — e.g. disk I/O errors (EIO, ENOSPC, EROFS) from segment creation, snapshot writes, or old-segment removal — was discarded along with the backgrounded future. The fiber terminated silently while the kvstore kept accepting `put()`s whose futures never resolve, wedging all kvstore writers on the shard (raft vote persistence, log start offsets, ...) with only a single seastar "Exceptional future ignored" warning as evidence.

Switch the fiber to `ssx::repeat_until_gate_closed` and terminate the process on any non-shutdown exception. Mid-flush state (segment, pending ops, next offset) cannot be safely retried in-process, while the on-disk state is crash-safe by design (snapshot + replay + partial-snapshot cleanup), and fail-stop matches the segment appender's existing policy for write/flush/fallocate errors.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

### Improvements

* The key-value store now terminates the process on unrecoverable I/O errors in its flush path instead of silently stalling writes.