### PR TITLE
[v26.2.x] build/deps: upgrade c-ares to 1.34.7 (CVE-2026-33630)

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -355,7 +355,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "FiOjSQzJYv0eX0CT1OccUyAtMTAQxAX+KGU+yNIBxBI=",
+        "bzlTransitiveDigest": "/YslpTNYXO6USyyobv/1GqS7ounlpyts711QBMyC5jA=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedInputs": [
           "REPO_MAPPING:,bazel_tools bazel_tools",
@@ -401,9 +401,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:c-ares.BUILD",
-              "sha256": "912dd7cc3b3e8a79c52fd7fb9c0f4ecf0aaa73e45efda880266a2d6e26b84ef5",
-              "strip_prefix": "c-ares-1.34.6",
-              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.6.tar.gz"
+              "sha256": "556f781dd188ad932dc8263fee0ad3aaba675b4cd8e54d86908681b43ce3e327",
+              "strip_prefix": "c-ares-1.34.7",
+              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.7.tar.gz"
             }
           },
           "hdrhistogram": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -44,9 +44,9 @@ def data_dependency():
     http_archive(
         name = "c-ares",
         build_file = "//bazel/thirdparty:c-ares.BUILD",
-        sha256 = "912dd7cc3b3e8a79c52fd7fb9c0f4ecf0aaa73e45efda880266a2d6e26b84ef5",
-        strip_prefix = "c-ares-1.34.6",
-        url = "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.6.tar.gz",
+        sha256 = "556f781dd188ad932dc8263fee0ad3aaba675b4cd8e54d86908681b43ce3e327",
+        strip_prefix = "c-ares-1.34.7",
+        url = "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.7.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Backport of PR #31465

c-ares 1.34.6 (our pinned version) had a double-free / use-after-free in
query-completion handling (CVE-2026-33630 / GHSA-6wfj-rwm7-3542), fixed
upstream in 1.34.7. v26.2.x carries the same vulnerable pin as dev,
v26.1.x and v25.3.x. No Snyk ticket exists for this branch yet, but
fixing it here too avoids leaving a known gap.

c-ares 1.34.7 is now mirrored on our S3 dependency bucket
(redpanda-data/vtools#4401), so this upgrades the pin directly instead
of carrying a temporary source patch on top of 1.34.6.

Verified `bazel build @c-ares//:c-ares` succeeds against the new pin.

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport

## Release Notes

### Bug Fixes

* Fixed a double-free / use-after-free in c-ares query-completion handling (CVE-2026-33630).