### PR TITLE
[CORE-14565] `storage`: make offset translator truncation checkpoint crash-safe and ensure offset translator processes visible raft batches

### DIFF
--- a/src/v/raft/tests/BUILD
+++ b/src/v/raft/tests/BUILD
@@ -502,6 +502,26 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "ot_consistency_test",
+    timeout = "moderate",
+    srcs = [
+        "ot_consistency_test.cc",
+    ],
+    deps = [
+        "//src/v/model",
+        "//src/v/raft",
+        "//src/v/raft/tests:raft_fixture",
+        "//src/v/random:generators",
+        "//src/v/storage:record_batch_builder",
+        "//src/v/test_utils:gtest",
+        "@fmt",
+        "@googletest//:gtest",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "compaction_recovery_test",
     timeout = "short",
     srcs = [

--- a/src/v/raft/tests/BUILD
+++ b/src/v/raft/tests/BUILD
@@ -512,6 +512,7 @@ redpanda_cc_gtest(
         "//src/v/raft",
         "//src/v/raft/tests:raft_fixture",
         "//src/v/random:generators",
+        "//src/v/storage",
         "//src/v/storage:record_batch_builder",
         "//src/v/test_utils:gtest",
         "@fmt",

--- a/src/v/raft/tests/ot_consistency_test.cc
+++ b/src/v/raft/tests/ot_consistency_test.cc
@@ -24,6 +24,8 @@
 #include "raft/tests/raft_fixture.h"
 #include "raft/types.h"
 #include "random/generators.h"
+#include "storage/disk_log_impl.h"
+#include "test_utils/async.h"
 #include "test_utils/test.h"
 
 #include <seastar/core/coroutine.hh>
@@ -276,5 +278,126 @@ TEST_F_CORO(raft_fixture, offset_translator_consistency_under_churn) {
           counted,
           lstats.start_offset,
           lstats.dirty_offset);
+    }
+}
+
+// End-to-end reproduction of translator divergence from an append that
+// fails on a follower after the batch became visible in its log.
+//
+// A leadership change makes the new leader replicate a raft_configuration
+// batch. With the append failure injected on one follower, that batch lands
+// in the follower's log but the append reports failure; the leader's retry
+// skip-matches the already-present batch without re-appending it. Without
+// the storage-side fix the follower's offset translator permanently misses
+// the gap and its deltas diverge from its peers' (the production symptom:
+// "Offset translator state inconsistency detected").
+TEST_F_CORO(raft_fixture, follower_append_failure_keeps_translation) {
+    static constexpr auto node_count = 3;
+    enable_offset_translation();
+    co_await create_simple_group(node_count);
+    auto leader = co_await wait_for_leader(10s);
+
+    auto res = co_await node(leader).raft()->replicate(
+      make_batches({{"k0", "v0"}, {"k1", "v1"}}),
+      replicate_options(consistency_level::quorum_ack));
+    ASSERT_TRUE_CORO(res.has_value());
+    co_await wait_for_committed_offset(res.value().last_offset, 10s);
+
+    // inject append failures on one follower; batches keep becoming visible
+    // in its log, but every append reports failure
+    auto follower = model::node_id((leader() + 1) % node_count);
+    auto& follower_log = dynamic_cast<storage::disk_log_impl&>(
+      *node(follower).underlying_log());
+    follower_log.get_failure_probes().set_exception("append");
+
+    // force a leadership change to the healthy follower (if the armed
+    // follower won the election instead, its own failed config append would
+    // later be conflict-truncated and re-appended, healing the translator
+    // as a side effect and masking the hazard): the new leader replicates
+    // its configuration batch (a filtered batch) to the armed follower,
+    // where the append fails after the batch became visible
+    auto dirty_before = node(follower).raft()->dirty_offset();
+    auto target = model::node_id((leader() + 2) % node_count);
+    auto transfer_reply = co_await node(leader).raft()->transfer_leadership(
+      transfer_leadership_request{
+        .group = node(leader).raft()->group(),
+        .target = target,
+      });
+    ASSERT_TRUE_CORO(transfer_reply.success);
+    co_await wait_for_leader(10s);
+
+    // wait until the new leader's configuration batch became visible in the
+    // follower's log through a failed append, then stop injecting so the
+    // group can converge
+    RPTEST_REQUIRE_EVENTUALLY_CORO(10s, [&] {
+        return node(follower).raft()->dirty_offset() > dirty_before;
+    });
+    follower_log.get_failure_probes().unset("append");
+
+    // the leadership may still be settling; retry until a functional leader
+    // accepts writes (a plain loop: a capturing coroutine lambda passed to a
+    // retry helper is a use-after-free hazard)
+    model::offset committed{};
+    for (int attempt = 0; attempt < 100 && committed == model::offset{};
+         ++attempt) {
+        if (auto l = get_leader(); l.has_value()) {
+            auto r = co_await node(*l).raft()->replicate(
+              make_batches({{"k2", "v2"}}),
+              replicate_options(consistency_level::quorum_ack));
+            if (r.has_value()) {
+                committed = r.value().last_offset;
+                break;
+            }
+        }
+        co_await ss::sleep(100ms);
+    }
+    ASSERT_GT_CORO(committed, model::offset{});
+    // wait until every replica has the full log (wait_for_committed_offset
+    // is satisfied by a quorum, which may exclude the injected follower)
+    RPTEST_REQUIRE_EVENTUALLY_CORO(30s, [&] {
+        for (auto i = 0; i < node_count; ++i) {
+            if (
+              node(model::node_id(i)).raft()->committed_offset() < committed) {
+                return false;
+            }
+        }
+        return true;
+    });
+
+    // one more append past the injected batch: this is what makes raft's
+    // validate_offset_translator_delta compare deltas at the divergent
+    // offset on the follower (and emit "Offset translator state
+    // inconsistency detected" when the translator state was corrupted)
+    if (auto l = get_leader(); l.has_value()) {
+        auto r = co_await node(*l).raft()->replicate(
+          make_batches({{"k3", "v3"}}),
+          replicate_options(consistency_level::quorum_ack));
+        if (r.has_value()) {
+            committed = r.value().last_offset;
+            RPTEST_REQUIRE_EVENTUALLY_CORO(30s, [&] {
+                for (auto i = 0; i < node_count; ++i) {
+                    if (
+                      node(model::node_id(i)).raft()->committed_offset()
+                      < committed) {
+                        return false;
+                    }
+                }
+                return true;
+            });
+        }
+    }
+
+    // every replica must agree on the offset translator delta at every
+    // committed offset
+    for (auto o = model::offset(0); o <= committed; o = model::next_offset(o)) {
+        std::optional<model::offset_delta> expected;
+        for (auto i = 0; i < node_count; ++i) {
+            auto d = node(model::node_id(i)).raft()->log()->offset_delta(o);
+            if (expected) {
+                ASSERT_EQ_CORO(d, *expected) << fmt::format(
+                  "delta divergence at offset {} on node {}", o, i);
+            }
+            expected = d;
+        }
     }
 }

--- a/src/v/raft/tests/ot_consistency_test.cc
+++ b/src/v/raft/tests/ot_consistency_test.cc
@@ -1,0 +1,280 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// Raft-level stress for offset translator delta consistency.
+//
+// Runs a 3-node group under simultaneous election churn (step-downs), produce
+// traffic, per-replica prefix eviction via snapshot_and_truncate_log (the
+// log_eviction_stm / ctp_stm entry point), and rolling node restarts, while
+// continuously checking that all replicas agree on the offset translator delta
+// at committed offsets, and that each replica's delta is self-consistent with
+// its own log content.
+
+#include "model/fundamental.h"
+#include "model/record_batch_reader.h"
+#include "model/record_batch_types.h"
+#include "raft/consensus.h"
+#include "raft/state_machine_manager.h"
+#include "raft/tests/raft_fixture.h"
+#include "raft/types.h"
+#include "random/generators.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/rwlock.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/coroutine/parallel_for_each.hh>
+
+#include <fmt/format.h>
+
+using namespace raft;
+
+namespace {
+ss::future<> ignore_exceptions(ss::future<> f) {
+    try {
+        co_await std::move(f);
+    } catch (...) {
+    }
+}
+} // namespace
+
+TEST_F_CORO(raft_fixture, offset_translator_consistency_under_churn) {
+    static constexpr auto node_count = 3;
+    enable_offset_translation();
+    for (auto i = 0; i < node_count; ++i) {
+        add_node(model::node_id(i), model::revision_id(0));
+    }
+    co_await ss::coroutine::parallel_for_each(nodes(), [this](auto& pair) {
+        // an (empty) stm manager is required for snapshot_and_truncate_log
+        return pair.second->init_and_start(
+          all_vnodes(), raft::state_machine_manager_builder{});
+    });
+    co_await wait_for_leader(10s);
+
+    bool stop = false;
+    std::optional<model::node_id> restarting;
+    std::optional<ss::sstring> divergence;
+    // fibers take read locks per iteration; the restarter takes the write
+    // lock so that no fiber is mid-operation while a node stops
+    ss::rwlock quiesce;
+
+    auto now_plus = [](auto d) { return model::timeout_clock::now() + d; };
+
+    // continuous produce traffic; leader_ack leaves uncommitted tails on
+    // abrupt leadership changes -> conflict truncations on followers
+    auto producer = [&](this auto) -> ss::future<> {
+        size_t i = 0;
+        while (!stop) {
+            auto held = co_await quiesce.hold_read_lock();
+            auto l = get_leader();
+            if (!l || l == restarting) {
+                held.return_all();
+                co_await ss::sleep(5ms);
+                continue;
+            }
+            auto batches = make_batches(
+              {{fmt::format("k{}", i), fmt::format("v{}", i)}});
+            ++i;
+            auto lvl = random_generators::get_int(0, 1) == 0
+                         ? consistency_level::quorum_ack
+                         : consistency_level::leader_ack;
+            co_await ignore_exceptions(
+              node(*l)
+                .raft()
+                ->replicate(std::move(batches), replicate_options(lvl))
+                .discard_result());
+        }
+    };
+
+    // election churn: repeatedly force the leader to step down; every new
+    // term replicates a raft_configuration batch (a filtered batch) and can
+    // truncate uncommitted config/data batches on other replicas
+    auto churner = [&](this auto) -> ss::future<> {
+        while (!stop) {
+            co_await ss::sleep(
+              std::chrono::milliseconds(random_generators::get_int(30, 120)));
+            auto held = co_await quiesce.hold_read_lock();
+            auto l = get_leader();
+            if (!l || l == restarting) {
+                continue;
+            }
+            co_await ignore_exceptions(node(*l).raft()->step_down("churn"));
+        }
+    };
+
+    // per-replica prefix eviction, like log_eviction_stm / ctp_stm
+    auto evictor = [&](this auto) -> ss::future<> {
+        while (!stop) {
+            co_await ss::sleep(
+              std::chrono::milliseconds(random_generators::get_int(20, 80)));
+            auto held = co_await quiesce.hold_read_lock();
+            for (auto i = 0; i < node_count; ++i) {
+                auto id = model::node_id(i);
+                if (id == restarting || stop) {
+                    continue;
+                }
+                auto raft = node(id).raft();
+                auto committed = raft->committed_offset();
+                if (committed < model::offset(0)) {
+                    continue;
+                }
+                auto target = model::offset(
+                  committed() - random_generators::get_int(0, 3));
+                if (
+                  target <= raft->last_snapshot_index()
+                  || target < raft->start_offset()) {
+                    continue;
+                }
+                co_await ignore_exceptions(
+                  raft->snapshot_and_truncate_log(target).discard_result());
+            }
+        }
+    };
+
+    // rolling graceful restarts (mimics the scale tests' restart phases)
+    auto restarter = [&](this auto) -> ss::future<> {
+        while (!stop) {
+            co_await ss::sleep(
+              std::chrono::milliseconds(
+                random_generators::get_int(1500, 2500)));
+            if (stop) {
+                break;
+            }
+            auto id = model::node_id(
+              random_generators::get_int(node_count - 1));
+            restarting = id;
+            {
+                auto held = co_await quiesce.hold_write_lock();
+                co_await stop_node(id);
+            }
+            auto& n = add_node(id, model::revision_id(0));
+            co_await n.init_and_start(
+              all_vnodes(), raft::state_machine_manager_builder{});
+            restarting = std::nullopt;
+        }
+    };
+
+    // continuous cross-replica delta comparison at committed offsets: all
+    // replicas that contain offset o must agree on delta(o)
+    auto checker = [&](this auto) -> ss::future<> {
+        while (!stop && !divergence) {
+            co_await ss::sleep(10ms);
+            auto held = co_await quiesce.hold_read_lock();
+            model::offset lo{0};
+            model::offset hi = model::offset::max();
+            for (auto i = 0; i < node_count; ++i) {
+                auto id = model::node_id(i);
+                if (id == restarting) {
+                    hi = model::offset::min();
+                    break;
+                }
+                auto raft = node(id).raft();
+                lo = std::max(lo, raft->start_offset());
+                hi = std::min(hi, raft->committed_offset());
+            }
+            if (hi < lo) {
+                continue;
+            }
+            // sample a few offsets in [lo, hi]
+            for (int s = 0; s < 4 && !divergence; ++s) {
+                auto o = s == 0 ? hi
+                                : model::offset(
+                                    random_generators::get_int(lo(), hi()));
+                std::optional<model::offset_delta> expected;
+                for (auto i = 0; i < node_count; ++i) {
+                    auto id = model::node_id(i);
+                    if (id == restarting) {
+                        expected.reset();
+                        break;
+                    }
+                    auto raft = node(id).raft();
+                    if (
+                      o < raft->start_offset()
+                      || o > raft->committed_offset()) {
+                        continue;
+                    }
+                    model::offset_delta d;
+                    try {
+                        d = raft->log()->offset_delta(o);
+                    } catch (...) {
+                        continue;
+                    }
+                    if (expected && d != *expected) {
+                        divergence = fmt::format(
+                          "delta divergence at offset {}: node {} has {}, "
+                          "another node has {}",
+                          o,
+                          id,
+                          d,
+                          *expected);
+                    }
+                    expected = d;
+                }
+            }
+        }
+    };
+
+    auto producer_f = producer();
+    auto churner_f = churner();
+    auto evictor_f = evictor();
+    auto restarter_f = restarter();
+    auto checker_f = checker();
+
+    static constexpr auto test_duration = 25s;
+    auto deadline = now_plus(test_duration);
+    while (model::timeout_clock::now() < deadline && !divergence) {
+        co_await ss::sleep(100ms);
+    }
+    stop = true;
+    co_await ss::when_all_succeed(
+      std::move(producer_f),
+      std::move(churner_f),
+      std::move(evictor_f),
+      std::move(restarter_f),
+      std::move(checker_f));
+
+    ASSERT_FALSE_CORO(divergence.has_value()) << *divergence;
+
+    // final absolute self-check: each replica's delta span across its log
+    // must equal the number of filtered batch records it stores
+    co_await wait_for_leader(10s);
+    for (auto i = 0; i < node_count; ++i) {
+        auto raft = node(model::node_id(i)).raft();
+        auto log = raft->log();
+        auto lstats = log->offsets();
+        if (lstats.dirty_offset < lstats.start_offset) {
+            continue;
+        }
+        auto reader = co_await log->make_reader(
+          storage::local_log_reader_config(
+            lstats.start_offset, lstats.dirty_offset, std::nullopt));
+        struct gap_counter {
+            int64_t filtered_records = 0;
+            ss::future<ss::stop_iteration> operator()(model::record_batch b) {
+                if (b.header().type != model::record_batch_type::raft_data) {
+                    filtered_records += b.record_count();
+                }
+                co_return ss::stop_iteration::no;
+            }
+            int64_t end_of_stream() const { return filtered_records; }
+        };
+        int64_t counted = co_await std::move(reader).consume(
+          gap_counter{}, model::no_timeout);
+        auto span = log->offset_delta(model::next_offset(lstats.dirty_offset))
+                    - log->offset_delta(lstats.start_offset);
+        ASSERT_EQ_CORO(span(), counted) << fmt::format(
+          "node {} self-inconsistent: delta span {} vs {} filtered records "
+          "in log [{}, {}]",
+          i,
+          span(),
+          counted,
+          lstats.start_offset,
+          lstats.dirty_offset);
+    }
+}

--- a/src/v/storage/disk_log_appender.cc
+++ b/src/v/storage/disk_log_appender.cc
@@ -111,10 +111,25 @@ disk_log_appender::operator()(model::record_batch& batch) {
             co_await initialize();
         }
         auto stop = co_await append_batch_to_segment(batch);
+        if constexpr (finjector::honey_badger::is_enabled()) {
+            // simulates a failure after the batch became visible in the log
+            // but before the offset translator processes it
+            co_await _log._failure_probes.append();
+        }
         _log.offset_translator().process(batch);
         co_return stop;
     } catch (...) {
         release_lock();
+        // The batch may have become visible in the log before the failure:
+        // the segment's offset tracker advances before the index and batch
+        // cache updates, any of which can throw. A visible batch that the
+        // offset translator never processes would corrupts offset
+        // translation on this replica (a retried append will skip batches
+        // that are already present in the log without re-processing them),
+        // so account for it before propagating the error.
+        if (_log.offsets().dirty_offset >= batch.last_offset()) {
+            _log.offset_translator().process(batch);
+        }
         auto e = std::current_exception();
         vlogl(
           stlog,

--- a/src/v/storage/disk_log_appender.cc
+++ b/src/v/storage/disk_log_appender.cc
@@ -133,7 +133,7 @@ disk_log_appender::operator()(model::record_batch& batch) {
         auto e = std::current_exception();
         vlogl(
           stlog,
-          ssx::is_shutdown_exception(e) ? ss::log_level::debug
+          ssx::is_shutdown_exception(e) ? ss::log_level::warn
                                         : ss::log_level::error,
           "Could not append batch: {} - {}",
           e,

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -3556,12 +3556,19 @@ ss::future<> disk_log_impl::do_truncate_prefix(truncate_prefix_config cfg) {
 
 ss::future<> disk_log_impl::truncate(truncate_config cfg) {
     throw_if_closed();
-    // Truncate the log before the offset translator. This ordering ensures
-    // that if the OT update fails (I/O error on checkpoint), the in-memory
-    // OT state is already correct (the map erase happens before the
-    // checkpoint) so runtime offset translations remain accurate. On
-    // restart, sync_with_log will reconcile the on-disk OT state with the
-    // actual log.
+    // Durably lower the offset translator's persisted coverage below the
+    // truncation point before the log is modified. If this preparation step
+    // fails, the truncation is aborted while the log and translator are still
+    // fully consistent, and raft will retry. Once it succeeds, a failure in
+    // either `do_truncate()` or `complete_truncate()` below can no longer leave
+    // the persisted state diverged.
+    //
+    // The log itself is truncated before the in-memory offset translator
+    // state so that if the truncation fails midway, runtime offset
+    // translations remain accurate. On restart, startup reconciliation trims
+    // the loaded map to the coverage persisted above and sync_with_log re-reads
+    // the rest from the log.
+    co_await _offset_translator.prepare_truncate(cfg.base_offset);
     co_await _failure_probes.truncate().then([this, cfg]() mutable {
         // Before truncation, erase any claim about a particular segment being
         // clean: this may refer to a segment we are about to delete, or it
@@ -3578,7 +3585,7 @@ ss::future<> disk_log_impl::truncate(truncate_config cfg) {
               return do_truncate(cfg, std::nullopt);
           });
     });
-    co_await _offset_translator.truncate(cfg.base_offset);
+    co_await _offset_translator.complete_truncate(cfg.base_offset);
 }
 
 ss::future<> disk_log_impl::do_truncate(

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -160,6 +160,7 @@ public:
     ss::future<> force_roll() override;
 
     probe& get_probe() override { return *_probe; }
+    failure_probes& get_failure_probes() { return _failure_probes; }
     model::term_id term() const;
     segment_set& segments() override { return _segs; }
     const segment_set& segments() const override { return _segs; }

--- a/src/v/storage/offset_translator.cc
+++ b/src/v/storage/offset_translator.cc
@@ -137,11 +137,20 @@ ss::future<> offset_translator::start(must_reset reset) {
               _state->ntp(), std::move(*map_buf));
             _highest_known_offset = reflection::from_iobuf<model::offset>(
               std::move(*highest_known_offset_buf));
+            _persisted_highest_known_offset = _highest_known_offset;
 
-            // highest known offset could be more stale than the map, in
-            // this case we take it from the map
-            _highest_known_offset = std::max(
-              _highest_known_offset, _state->last_gap_offset());
+            // The map and the highest known offset are persisted separately,
+            // so they can be mutually stale. Trust only the checkpoint both
+            // agree on by dropping map entries above the persisted highest
+            // known offset (since they may describe log content that has since
+            // been truncated and rewritten) and re-derive that range from the
+            // log in sync_with_log.
+            auto [checkpoint, changed] = _state->reconcile_with_checkpoint(
+              _highest_known_offset);
+            _highest_known_offset = checkpoint;
+            if (changed) {
+                ++_map_version;
+            }
         } else {
             vlog(
               _logger.info,
@@ -238,7 +247,36 @@ ss::future<> offset_translator::sync_with_log(
     co_await maybe_checkpoint();
 }
 
-ss::future<> offset_translator::truncate(model::offset offset) {
+ss::future<> offset_translator::prepare_truncate(model::offset offset) {
+    if (_filtered_types.empty()) {
+        co_return;
+    }
+
+    auto units = co_await _checkpoint_lock.get_units();
+    const auto cap = model::prev_offset(offset);
+    // Cap concurrent checkpoints (e.g. from a prefix truncation running on
+    // the eviction fiber) until `complete_truncate()` finishes. If the
+    // truncation is aborted after this point the cap lingers, which is safe (it
+    // only makes the next startup re-read more of the log).
+    _max_checkpoint_offset = _max_checkpoint_offset
+                               ? std::min(*_max_checkpoint_offset, cap)
+                               : cap;
+    if (cap < _persisted_highest_known_offset) {
+        co_await _kvs.put(
+          storage::kvstore::key_space::offset_translator,
+          highest_known_offset_key(),
+          reflection::to_iobuf(cap));
+        _persisted_highest_known_offset = cap;
+        vlog(
+          _logger.debug,
+          "prepare_truncate at offset {}: lowered persisted "
+          "highest_known_offset to {}",
+          offset,
+          cap);
+    }
+}
+
+ss::future<> offset_translator::complete_truncate(model::offset offset) {
     if (_filtered_types.empty()) {
         co_return;
     }
@@ -249,6 +287,7 @@ ss::future<> offset_translator::truncate(model::offset offset) {
 
     model::offset prev = model::prev_offset(offset);
     _highest_known_offset = std::min(prev, _highest_known_offset);
+    _max_checkpoint_offset.reset();
 
     vlog(_logger.info, "truncate at offset: {}, new state: {}", offset, _state);
 
@@ -353,7 +392,14 @@ ss::future<> offset_translator::do_checkpoint() {
         map_buf.emplace(_state->serialize_map());
     }
 
-    iobuf hko_buf = reflection::to_iobuf(_highest_known_offset);
+    // While a two-phase truncation is in flight, never persist coverage of
+    // an offset range that is being truncated (it is about to be
+    // rewritten).
+    auto hko = _highest_known_offset;
+    if (_max_checkpoint_offset) {
+        hko = std::min(hko, *_max_checkpoint_offset);
+    }
+    iobuf hko_buf = reflection::to_iobuf(hko);
 
     // Persisting offsets map before highest offset so that if the latter
     // fails, we are still left with a consistent state (map can be
@@ -371,6 +417,7 @@ ss::future<> offset_translator::do_checkpoint() {
       storage::kvstore::key_space::offset_translator,
       highest_known_offset_key(),
       std::move(hko_buf));
+    _persisted_highest_known_offset = hko;
     _bytes_processed_at_checkpoint = bytes_processed;
     _bytes_processed_units.return_all();
 

--- a/src/v/storage/offset_translator.h
+++ b/src/v/storage/offset_translator.h
@@ -87,9 +87,26 @@ public:
     ss::future<> maybe_checkpoint(
       size_t checkpoint_threshold = default_checkpoint_threshold);
 
-    /// Removes the offset translation state starting from the offset
-    /// (inclusive).
-    ss::future<> truncate(model::offset);
+    /// First phase of a log suffix truncation at `offset`. Durably lowers the
+    /// persisted highest known offset below `offset` BEFORE the log is
+    /// truncated, and caps any checkpoint that runs before
+    /// `complete_truncate()` so it cannot raise the persisted coverage back
+    /// into the range being truncated. In-memory translation state is not
+    /// modified, so a failure (which must abort the enclosing log truncation
+    /// before the log is modified) leaves the translator fully consistent.
+    ///
+    /// This ordering guarantees that the persisted state never claims
+    /// coverage of offsets the log has rewritten. If the post-truncation
+    /// checkpoint in `complete_truncate()` is lost (I/O error, shutdown), the
+    /// persisted highest known offset is already below the truncation point,
+    /// so a restart re-reads the rewritten range from the log instead of
+    /// silently skipping it.
+    ss::future<> prepare_truncate(model::offset);
+
+    /// Second phase of a log suffix truncation at `offset`: removes the
+    /// translation state starting from `offset` (inclusive), clears the
+    /// coverage cap set by `prepare_truncate()`, and finally checkpoints.
+    ss::future<> complete_truncate(model::offset);
 
     /// Removes the offset translation state up to and including the offset. The
     /// offset delta for the next offsets is preserved.
@@ -135,6 +152,28 @@ private:
 
     // The last offset for which we have offset translation state (inclusive).
     model::offset _highest_known_offset;
+
+    // The highest known offset value most recently persisted to the kvstore.
+    // Used by `prepare_truncate()` to only ever lower (never raise) the
+    // persisted coverage.
+    model::offset _persisted_highest_known_offset = model::offset::min();
+
+    // While a two-phase truncation is in flight, checkpoints must not persist a
+    // highest known offset above this cap: the log range above it is about to
+    // be (or may have been) rewritten.
+    //
+    // This exists instead of holding `_checkpoint_lock` from
+    // `prepare_truncate()` through `complete_truncate()` because log truncation
+    // may try to acquire segment write locks while a concurrent eviction
+    // through the prefix truncation path is holding them, and
+    // `offset_translator::prefix_truncate()` also takes `_checkpoint_lock`,
+    // potentially leading to a deadlock.
+    //
+    // The cap deliberately lingers if the truncation aborts between the
+    // phases: that only under-claims persisted coverage, which costs extra
+    // log re-reading at the next startup and is cleared by the truncation
+    // retry (or the next successful complete_truncate).
+    std::optional<model::offset> _max_checkpoint_offset;
 
     size_t _bytes_processed = 0;
 

--- a/src/v/storage/offset_translator_state.cc
+++ b/src/v/storage/offset_translator_state.cc
@@ -338,6 +338,30 @@ bool offset_translator_state::prefix_truncate(model::offset offset) {
     return true;
 }
 
+std::pair<model::offset, bool>
+offset_translator_state::reconcile_with_checkpoint(
+  model::offset persisted_hko) {
+    vassert(
+      !_last_offset2batch.empty(),
+      "ntp {}: offsets map shouldn't be empty",
+      _ntp);
+
+    // The state is always trustworthy up to (and including) the first entry.
+    auto checkpoint = std::max(
+      persisted_hko, _last_offset2batch.begin()->first);
+    auto it = _last_offset2batch.upper_bound(checkpoint);
+    if (it == _last_offset2batch.end()) {
+        return {checkpoint, false};
+    }
+    if (it->second.base_offset <= checkpoint) {
+        // The checkpoint offset falls inside the first dropped gap; its prefix
+        // must be re-read together with the rest of the gap.
+        checkpoint = model::prev_offset(it->second.base_offset);
+    }
+    _last_offset2batch.erase(it, _last_offset2batch.end());
+    return {checkpoint, true};
+}
+
 namespace {
 
 struct persisted_batch {

--- a/src/v/storage/offset_translator_state.h
+++ b/src/v/storage/offset_translator_state.h
@@ -91,6 +91,16 @@ public:
     /// changed.
     bool prefix_truncate(model::offset);
 
+    /// Reconciles the loaded map against the separately persisted highest known
+    /// offset. Drops all entries above `max(persisted hko, translation range
+    /// start)`, since they may describe log content that was truncated and
+    /// rewritten after the highest known offset was written.
+    ///
+    /// Returns the offset up to which the remaining state is trustworthy (from
+    /// which the caller must re-read the log), along with whether the map
+    /// changed.
+    std::pair<model::offset, bool> reconcile_with_checkpoint(model::offset);
+
     iobuf serialize_map() const;
     static offset_translator_state
     from_serialized_map(model::ntp ntp, iobuf buf);

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -522,6 +522,27 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "offset_translator_race_test",
+    timeout = "moderate",
+    srcs = [
+        "offset_translator_race_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/model",
+        "//src/v/raft",
+        "//src/v/random:generators",
+        "//src/v/storage",
+        "//src/v/storage:record_batch_builder",
+        "//src/v/storage/tests:storage_test_fixture",
+        "//src/v/test_utils:gtest",
+        "@fmt",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "scoped_file_tracker_test",
     timeout = "short",
     srcs = [

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -529,6 +529,7 @@ redpanda_cc_gtest(
     ],
     cpu = 1,
     deps = [
+        "//src/v/finjector",
         "//src/v/model",
         "//src/v/raft",
         "//src/v/random:generators",

--- a/src/v/storage/tests/offset_translator_race_test.cc
+++ b/src/v/storage/tests/offset_translator_race_test.cc
@@ -23,6 +23,7 @@
 // restart reconstruction: a fresh offset_translator over the same kvstore
 // state + sync_with_log must agree with ground truth.
 
+#include "finjector/hbadger.h"
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "model/record_batch_types.h"
@@ -93,6 +94,91 @@ struct ground_truth {
 } // namespace
 
 class ot_race_fixture : public storage_test_fixture {};
+
+// Regression test for translator state loss on an append that fails after
+// the batch became visible in the log.
+//
+// segment::do_append advances the segment offset tracker (making the batch
+// visible to readers and to raft) before the index and batch cache updates;
+// an exception from those escapes disk_log_appender::operator() before the
+// offset translator processed the batch. Raft replies failure and the leader
+// retries, but the retry skip-matches the already-present batch without
+// re-appending it, so the translator would permanently miss the gap: this
+// replica's deltas diverge from its peers' with nothing but a (possibly
+// debug-level) log line ever emitted.
+//
+// The appender must therefore account for any batch that became visible even
+// when failing the append. Uses the storage::log::failure_probes append
+// injection point, which fires exactly between batch visibility and the
+// translator update.
+TEST_F(ot_race_fixture, append_failure_after_visibility_keeps_translation) {
+    if (!finjector::honey_badger::is_enabled()) {
+        GTEST_SKIP() << "Failure injection is only enabled in debug mode.";
+        return;
+    }
+    auto cfg = default_log_config(test_dir);
+    storage::log_manager mgr(std::move(cfg), kvstore, resources, feature_table);
+    auto ntp = model::ntp("redpanda", "ot-append-failure", 0);
+    auto group = raft::group_id(44);
+    std::optional<log_holder> log_h;
+    log_h.emplace(manage_log(
+      mgr,
+      {ntp, mgr.config().base_dir},
+      group,
+      {model::record_batch_type::raft_configuration}));
+    ss::abort_source as;
+    (*log_h)->start(std::nullopt, as).get();
+    storage::log* logp = log_h->get();
+    auto deferred = ss::defer([&]() mutable {
+        log_h.reset();
+        mgr.stop().get();
+    });
+
+    auto append = [&](std::vector<model::record_batch_type> types) {
+        auto appender = logp->make_appender(
+          storage::log_append_config{storage::log_append_config::fsync::no});
+        for (auto t : types) {
+            auto b = make_batch(t, 1, model::term_id(1));
+            appender(b).get();
+        }
+        return appender.end_of_stream().get();
+    };
+
+    constexpr auto data = model::record_batch_type::raft_data;
+    constexpr auto conf = model::record_batch_type::raft_configuration;
+
+    // offsets 0..2: config at 2
+    append({data, data, conf});
+    ASSERT_EQ(logp->offset_delta(model::offset(3))(), 1);
+
+    // fail the append of the next config batch after it becomes visible
+    auto& dl = *dynamic_cast<storage::disk_log_impl*>(logp);
+    dl.get_failure_probes().set_exception("append");
+    EXPECT_THROW(append({conf}), std::runtime_error);
+    dl.get_failure_probes().unset("append");
+
+    // the batch is in the log regardless of the failed append...
+    auto lstats = logp->offsets();
+    ASSERT_EQ(lstats.dirty_offset, model::offset(3));
+    // ...so the translator must account for it
+    EXPECT_EQ(logp->offset_delta(model::offset(4))(), 2);
+
+    // a raft-style retry skip-matches the visible batch and continues with
+    // subsequent entries; translation must stay consistent...
+    append({data});
+    EXPECT_EQ(logp->offset_delta(model::offset(5))(), 2);
+
+    // ...including across a restart
+    storage::offset_translator fresh(
+      {model::record_batch_type::raft_configuration},
+      group,
+      ntp,
+      kvstore,
+      resources);
+    fresh.start(storage::offset_translator::must_reset::no).get();
+    fresh.sync_with_log(*logp, std::nullopt).get();
+    EXPECT_EQ(fresh.state()->delta(model::offset(5)), 2);
+}
 
 // Regression test for the stale-HKO reconstruction hazard.
 //

--- a/src/v/storage/tests/offset_translator_race_test.cc
+++ b/src/v/storage/tests/offset_translator_race_test.cc
@@ -1,0 +1,464 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// Stress reproducer for offset translator delta divergence.
+//
+// Drives a translator-enabled disk_log_impl the way raft does:
+//  - fiber M: serialized appends + conflict (suffix) truncations followed by
+//    re-appends at the same offsets (mimics do_append_entries under op_lock)
+//  - fiber E: prefix truncations without force delta (mimics
+//    consensus::write_snapshot -> logp->truncate_prefix, which runs on the
+//    log_eviction_stm/ctp_stm background fiber, NOT under the raft op_lock)
+//
+// Invariant checked between rounds: for every offset o in
+// [start_offset, dirty+1], logp->offset_delta(o) must equal the number of
+// filtered (raft_configuration) records at offsets < o according to an
+// independently maintained ground-truth history. Also periodically simulates
+// restart reconstruction: a fresh offset_translator over the same kvstore
+// state + sync_with_log must agree with ground truth.
+
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "model/record_batch_types.h"
+#include "random/generators.h"
+#include "storage/disk_log_impl.h"
+#include "storage/log.h"
+#include "storage/log_manager.h"
+#include "storage/offset_translator.h"
+#include "storage/record_batch_builder.h"
+#include "storage/tests/storage_test_fixture.h"
+#include "storage/types.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/util/defer.hh>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+using namespace storage; // NOLINT
+
+namespace {
+
+struct batch_spec {
+    model::offset base;
+    model::offset last;
+    bool filtered;
+};
+
+model::record_batch
+make_batch(model::record_batch_type type, size_t records, model::term_id term) {
+    storage::record_batch_builder b(type, model::offset(0));
+    for (size_t i = 0; i < records; ++i) {
+        iobuf value;
+        value.append("payload-data-payload", 20);
+        b.add_raw_kv(iobuf{}, std::move(value));
+    }
+    auto batch = std::move(b).build();
+    batch.set_term(term);
+    return batch;
+}
+
+struct ground_truth {
+    // one entry per offset in [0, dirty]; true = offset belongs to a filtered
+    // batch. Never prefix-truncated (delta is cumulative from offset 0).
+    std::vector<bool> offsets;
+    // batches currently in the log (suffix truncations shrink this, prefix
+    // truncations do not affect correctness of delta computations).
+    std::vector<batch_spec> batches;
+
+    int64_t expected_delta(model::offset o) const {
+        int64_t d = 0;
+        for (int64_t i = 0; i < o() && i < int64_t(offsets.size()); ++i) {
+            d += offsets[i] ? 1 : 0;
+        }
+        return d;
+    }
+
+    void suffix_truncate(model::offset at) {
+        offsets.resize(size_t(at()));
+        while (!batches.empty() && batches.back().base >= at) {
+            batches.pop_back();
+        }
+    }
+};
+
+} // namespace
+
+class ot_race_fixture : public storage_test_fixture {};
+
+// Regression test for the stale-HKO reconstruction hazard.
+//
+// Before the two-phase truncation fix, a suffix truncation whose translator
+// checkpoint was lost (I/O error / shutdown abort, swallowed by raft with a
+// WARN) left the kvstore claiming coverage (highest_known_offset) of an
+// offset range the log had since rewritten. On restart, sync_with_log
+// trusted that coverage and silently skipped the re-appended config batches
+// below it, permanently losing their gaps.
+//
+// With the fix, prepare_truncate durably lowers the persisted coverage
+// before the log is touched, so losing every subsequent checkpoint leaves
+// the kvstore under-claiming (old superset map + low hko), which restart
+// reconciliation heals by trimming the map to the persisted coverage and
+// re-reading the rest from the log. This test manufactures exactly that
+// worst-case surviving kvstore state and asserts reconstruction is correct.
+TEST_F(ot_race_fixture, truncation_checkpoint_loss_is_recoverable) {
+    auto cfg = default_log_config(test_dir);
+    storage::log_manager mgr(std::move(cfg), kvstore, resources, feature_table);
+    auto ntp = model::ntp("redpanda", "ot-stale-hko", 0);
+    auto group = raft::group_id(43);
+    std::optional<log_holder> log_h;
+    log_h.emplace(manage_log(
+      mgr,
+      {ntp, mgr.config().base_dir},
+      group,
+      {model::record_batch_type::raft_configuration}));
+    ss::abort_source as;
+    (*log_h)->start(std::nullopt, as).get();
+    storage::log* logp = log_h->get();
+    auto deferred = ss::defer([&]() mutable {
+        log_h.reset();
+        mgr.stop().get();
+    });
+
+    auto append = [&](std::vector<model::record_batch_type> types) {
+        auto appender = logp->make_appender(
+          storage::log_append_config{storage::log_append_config::fsync::no});
+        for (auto t : types) {
+            auto b = make_batch(t, 1, model::term_id(1));
+            appender(b).get();
+        }
+        return appender.end_of_stream().get();
+    };
+
+    constexpr auto data = model::record_batch_type::raft_data;
+    constexpr auto conf = model::record_batch_type::raft_configuration;
+    constexpr auto ks = storage::kvstore::key_space::offset_translator;
+    auto hko_key = storage::offset_translator::kvstore_highest_known_offset_key(
+      group);
+    auto map_key = storage::offset_translator::kvstore_offsetmap_key(group);
+
+    // offsets 0..7: configs at 2 and 5
+    append({data, data, conf, data, data, conf, data, data});
+    ASSERT_EQ(logp->offset_delta(model::offset(8))(), 2);
+
+    // checkpoint so the kvstore covers the whole log (map {2,5}, hko = 7)
+    auto& dl = *dynamic_cast<storage::disk_log_impl*>(logp);
+    dl.offset_translator().maybe_checkpoint(0).get();
+    auto pre_truncation_map = kvstore.get(ks, map_key)->copy();
+
+    // raft conflict truncation at T=4, then the leader re-replicates offsets
+    // 4..8 with different content: configs at 4 and 6
+    logp->truncate(storage::truncate_config(model::offset(4))).get();
+    append({conf, data, conf, data, data});
+    // live state is correct: configs at 2, 4, 6
+    ASSERT_EQ(logp->offset_delta(model::offset(9))(), 3);
+
+    // simulate losing every checkpoint from complete_truncate onwards: the
+    // kvstore retains the pre-truncation map, and the coverage that
+    // prepare_truncate persisted before the log was touched (hko = T-1 = 3).
+    // This is the worst surviving state the two-phase truncation permits;
+    // before the fix the surviving state could instead pair a high hko with
+    // a map that no longer covers it, which was unrecoverable.
+    kvstore.put(ks, map_key, std::move(pre_truncation_map)).get();
+    kvstore.put(ks, hko_key, reflection::to_iobuf(model::offset(3))).get();
+
+    // restart reconstruction must trim the stale map entries above the
+    // persisted coverage (the pre-truncation config at 5) and re-derive
+    // offsets 4..8 from the log
+    storage::offset_translator fresh(
+      {model::record_batch_type::raft_configuration},
+      group,
+      ntp,
+      kvstore,
+      resources);
+    fresh.start(storage::offset_translator::must_reset::no).get();
+    fresh.sync_with_log(*logp, std::nullopt).get();
+    // compare the full delta profile (a stale gap from the truncated-away
+    // content could numerically compensate for a missed re-appended gap at
+    // the tail, so checking a single offset is not sufficient)
+    for (auto o = model::offset(0); o <= model::offset(9);
+         o = model::next_offset(o)) {
+        EXPECT_EQ(fresh.state()->delta(o), logp->offset_delta(o)())
+          << "reconstructed delta diverges from live state at offset " << o;
+    }
+}
+
+TEST_F(ot_race_fixture, offset_translator_delta_stress) {
+    auto seed = random_generators::get_int<uint64_t>(0, 1UL << 40);
+    if (auto* env = std::getenv("OT_STRESS_SEED"); env != nullptr) {
+        seed = std::stoull(env);
+    }
+    fmt::print("offset_translator_delta_stress seed: {}\n", seed);
+    std::mt19937_64 rng(seed);
+    auto rand_int = [&rng](int lo, int hi) {
+        return int(rng() % uint64_t(hi - lo + 1)) + lo;
+    };
+
+    auto make_cfg = [&] {
+        auto cfg = default_log_config(test_dir);
+        cfg.max_segment_size = config::mock_binding<size_t>(16_KiB);
+        return cfg;
+    };
+    auto ntp = model::ntp("redpanda", "ot-race", 0);
+    auto group = raft::group_id(42);
+
+    std::optional<storage::log_manager> mgr;
+    mgr.emplace(
+      make_cfg(),
+      std::ref(kvstore),
+      std::ref(resources),
+      std::ref(feature_table));
+    std::optional<log_holder> log_h;
+    log_h.emplace(manage_log(
+      *mgr,
+      {ntp, mgr->config().base_dir},
+      group,
+      {model::record_batch_type::raft_configuration}));
+    ss::abort_source as;
+    (*log_h)->start(std::nullopt, as).get();
+    storage::log* logp = log_h->get();
+    auto deferred = ss::defer([&]() mutable {
+        log_h.reset();
+        mgr->stop().get();
+    });
+
+    ground_truth truth;
+    model::term_id term{1};
+    model::offset committed{-1};
+
+    auto append_round = [&](this auto, int nbatches) -> ss::future<> {
+        auto appender = logp->make_appender(
+          storage::log_append_config{storage::log_append_config::fsync::no});
+        std::vector<bool> pending_flags;
+        std::vector<size_t> pending_sizes;
+        for (int i = 0; i < nbatches; ++i) {
+            bool filtered = rand_int(0, 99) < 40;
+            size_t records = filtered ? 1 : size_t(rand_int(1, 3));
+            auto b = make_batch(
+              filtered ? model::record_batch_type::raft_configuration
+                       : model::record_batch_type::raft_data,
+              records,
+              term);
+            pending_flags.push_back(filtered);
+            pending_sizes.push_back(records);
+            co_await appender(b);
+        }
+        auto res = co_await appender.end_of_stream();
+        // reconcile ground truth with the offsets the appender assigned
+        ASSERT_EQ_CORO(res.base_offset(), int64_t(truth.offsets.size()));
+        for (size_t i = 0; i < pending_flags.size(); ++i) {
+            auto base = model::offset(int64_t(truth.offsets.size()));
+            for (size_t r = 0; r < pending_sizes[i]; ++r) {
+                truth.offsets.push_back(pending_flags[i]);
+            }
+            truth.batches.push_back(
+              batch_spec{
+                .base = base,
+                .last = model::offset(int64_t(truth.offsets.size()) - 1),
+                .filtered = pending_flags[i]});
+        }
+        ASSERT_EQ_CORO(res.last_offset(), int64_t(truth.offsets.size()) - 1);
+    };
+
+    auto conflict_round = [&](this auto) -> ss::future<> {
+        // pick a batch-aligned truncation point above committed
+        std::vector<model::offset> candidates;
+        for (const auto& b : truth.batches) {
+            if (b.base > committed && b.base > logp->offsets().start_offset) {
+                candidates.push_back(b.base);
+            }
+        }
+        if (candidates.empty()) {
+            co_return;
+        }
+        auto at = candidates[size_t(rand_int(0, int(candidates.size()) - 1))];
+        co_await logp->truncate(storage::truncate_config(at));
+        truth.suffix_truncate(at);
+        term = model::term_id(term() + 1);
+        // raft always follows a conflict truncation with replacement appends
+        co_await append_round(rand_int(1, 3));
+    };
+
+    auto evict = [&](this auto) -> ss::future<> {
+        // batch-aligned prefix truncation: start offset = some batch's
+        // last + 1, bounded by committed (like snapshot_and_truncate_log)
+        std::vector<model::offset> candidates;
+        auto cur_start = logp->offsets().start_offset;
+        for (const auto& b : truth.batches) {
+            if (b.last <= committed && model::next_offset(b.last) > cur_start) {
+                candidates.push_back(model::next_offset(b.last));
+            }
+        }
+        if (candidates.empty()) {
+            co_return;
+        }
+        auto start
+          = candidates[size_t(rand_int(0, int(candidates.size()) - 1))];
+        co_await logp->truncate_prefix(storage::truncate_prefix_config(start));
+    };
+
+    auto verify = [&](std::string_view when) {
+        auto lstats = logp->offsets();
+        if (lstats.dirty_offset < lstats.start_offset) {
+            return;
+        }
+        auto from = std::max(lstats.start_offset, model::offset(0));
+        for (auto o = from; o <= model::next_offset(lstats.dirty_offset);
+             o = model::next_offset(o)) {
+            auto expected = truth.expected_delta(o);
+            auto actual = logp->offset_delta(o)();
+            ASSERT_EQ(actual, expected) << fmt::format(
+              "[{}] delta mismatch at offset {} (start {}, dirty {}, "
+              "committed {}, seed {})",
+              when,
+              o,
+              lstats.start_offset,
+              lstats.dirty_offset,
+              committed,
+              seed);
+        }
+    };
+
+    auto verify_reconstruction = [&](this auto) -> ss::future<> {
+        // simulate restart: fresh translator over the same kvstore state
+        storage::offset_translator fresh(
+          {model::record_batch_type::raft_configuration},
+          group,
+          ntp,
+          kvstore,
+          resources);
+        co_await fresh.start(storage::offset_translator::must_reset::no);
+        co_await fresh.sync_with_log(*logp, std::nullopt);
+        auto lstats = logp->offsets();
+        if (lstats.dirty_offset < lstats.start_offset) {
+            co_return;
+        }
+        auto from = std::max(lstats.start_offset, model::offset(0));
+        for (auto o = from; o <= model::next_offset(lstats.dirty_offset);
+             o = model::next_offset(o)) {
+            auto expected = truth.expected_delta(o);
+            auto actual = fresh.state()->delta(o);
+            ASSERT_EQ_CORO(actual, expected) << fmt::format(
+              "[reconstruction] delta mismatch at offset {} (start {}, dirty "
+              "{}, seed {})",
+              o,
+              lstats.start_offset,
+              lstats.dirty_offset,
+              seed);
+        }
+    };
+
+    // reader fiber: readers hold segment read locks, which gates the
+    // front-segment write-lock window inside truncate_prefix (like fetches)
+    auto read_some = [&](this auto) -> ss::future<> {
+        auto lstats = logp->offsets();
+        if (lstats.dirty_offset < lstats.start_offset) {
+            co_return;
+        }
+        auto reader = co_await logp->make_reader(
+          storage::local_log_reader_config(
+            lstats.start_offset, lstats.dirty_offset, std::nullopt));
+        struct counter {
+            ss::future<ss::stop_iteration> operator()(model::record_batch&) {
+                co_return ss::stop_iteration::no;
+            }
+            void end_of_stream() {}
+        };
+        co_await std::move(reader).for_each_ref(counter{}, model::no_timeout);
+    };
+
+    // checkpoint churn: memory-pressure hints make production checkpoint
+    // far more often than the 64MiB threshold
+    auto checkpoint_churn = [&](this auto) -> ss::future<> {
+        auto& dl = *dynamic_cast<storage::disk_log_impl*>(logp);
+        co_await dl.offset_translator().maybe_checkpoint(0);
+    };
+
+    // full restart: stop the log manager, recreate it (segment recovery +
+    // translator kvstore load), and start the log with the raft-startup
+    // truncate cfg (snapshot start offset + force delta), like
+    // consensus::start -> truncation_cfg_for_snapshot -> log->start
+    auto restart = [&]() {
+        log_h.reset();
+        mgr->stop().get();
+        mgr.emplace(
+          make_cfg(),
+          std::ref(kvstore),
+          std::ref(resources),
+          std::ref(feature_table));
+        log_h.emplace(manage_log(
+          *mgr,
+          {ntp, mgr->config().base_dir},
+          group,
+          {model::record_batch_type::raft_configuration}));
+        logp = log_h->get();
+        std::optional<storage::truncate_prefix_config> tcfg;
+        auto start = logp->offsets().start_offset;
+        if (start > model::offset(0)) {
+            // raft always passes the snapshot-derived cfg at startup; the
+            // snapshot stores delta(next(last_included)) == delta(start)
+            tcfg.emplace(
+              start, model::offset_delta(truth.expected_delta(start)));
+        }
+        logp->start(tcfg, as).get();
+    };
+
+    const int rounds = 3000;
+    for (int round = 0; round < rounds; ++round) {
+        // work fiber: appends + occasional conflict truncation (serialized,
+        // like raft under op_lock)
+        auto work = [&](this auto) -> ss::future<> {
+            co_await append_round(rand_int(1, 4));
+            if (rand_int(0, 99) < 25) {
+                co_await conflict_round();
+            }
+            if (rand_int(0, 99) < 30) {
+                co_await logp->flush();
+            }
+        };
+        // concurrent fibers mirroring production concurrency: eviction
+        // (log_eviction_stm), readers (fetch), checkpoint hints
+        std::vector<ss::future<>> fibers;
+        fibers.push_back(work());
+        if (rand_int(0, 99) < 35) {
+            fibers.push_back(evict());
+        }
+        if (rand_int(0, 99) < 40) {
+            fibers.push_back(read_some());
+        }
+        if (rand_int(0, 99) < 30) {
+            fibers.push_back(checkpoint_churn());
+        }
+        ss::when_all_succeed(fibers.begin(), fibers.end()).get();
+        // advance commit index sometimes (enables future evictions and
+        // bounds conflict truncations)
+        if (rand_int(0, 99) < 50) {
+            committed = logp->offsets().dirty_offset;
+        }
+        verify(fmt::format("round {}", round));
+        if (HasFatalFailure()) {
+            break;
+        }
+        if (round % 200 == 199) {
+            verify_reconstruction().get();
+            if (HasFatalFailure()) {
+                break;
+            }
+        }
+        if (round % 250 == 249) {
+            restart();
+            verify(fmt::format("post-restart round {}", round));
+            if (HasFatalFailure()) {
+                break;
+            }
+        }
+    }
+}

--- a/src/v/storage/tests/offset_translator_tests.cc
+++ b/src/v/storage/tests/offset_translator_tests.cc
@@ -406,9 +406,11 @@ struct fuzz_checker {
           = batch_base_offsets[random_generators::get_int(
             batch_base_offsets.size() - 1)];
 
-        co_await _tr->truncate(truncate_at);
+        co_await _tr->prepare_truncate(truncate_at);
 
         co_await _log->truncate(storage::truncate_config(truncate_at));
+
+        co_await _tr->complete_truncate(truncate_at);
 
         if (_log->offsets().dirty_offset() < 0) {
             _kafka_offsets.clear();


### PR DESCRIPTION
Two fixes related to offset inconsistency errors seen in CORE-14565:

## Fix One (Commits 1->3)

A log suffix truncation updates the offset translator (map erase + kvstore checkpoint) only after the log itself is truncated. If that checkpoint was lost (`kvstore` I/O error, shutdown abort, errors which raft swallows with a WARN and retries, etc.), the kvstore kept a highest known offset covering an offset range that was truncated. On the next startup, `sync_with_log()` trusted that coverage and skipped re-reading the rewritten range, so gaps for re-replicated non-data batches were silently lost, and the replica's offset delta ended up permanently lower than its peers', surfacing as "Offset translator state inconsistency detected" errors in raft.

To ensure atomicity of this operation, split the translator truncation in two phases around the log truncation. `prepare_truncate()` durably lowers the persisted highest known offset below the truncation point in the `kvstore` before the log is modified and caps concurrent checkpoints so they cannot re-raise it.  `complete_truncate()` erases the in-memory state and checkpoints as before. Any lost checkpoint now leaves the persisted state under-claiming coverage instead of over-claiming it.

On startup, the loaded map is reconciled against the separately persisted highest known offset instead of taking max(hko, last gap) as before. Entries above the persisted checkpoint may describe truncated-and-rewritten log content, so they must be dropped, and ranges must be re-read from the log.

## Fix Two (Commit 4)

`segment::do_append(b)` appends the batch `b` to the segment and then advances the segment offset tracker, making the batch visible to readers and raft, before the index and batch cache updates. If an exception is thrown from either of those operations, the offset translator never gets to processed the batch. A raft retry skip-matches the already-present batch without re-appending it, so the translator permanently misses the gap.

Account for a batch that became visible before propagating the append error by checking if the dirty offset of the log reflects the batch's last offset.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.2.x
- [X] v26.1.x
- [ ] v25.3.x

## Release Notes

### Bug Fixes

* Fixes a bug in which offset translator state could be lost after a log truncation.
* Fixes a bug in which offset translator state could be lost during a partly successful log append.
