### PR TITLE
`storage`: mark compaction index as incomplete when a batch's index update fails

### DIFF
--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -13,6 +13,7 @@
 #include "base/vlog.h"
 #include "compaction/utils.h"
 #include "config/configuration.h"
+#include "finjector/hbadger.h"
 #include "model/batch_compression.h"
 #include "ssx/future-util.h"
 #include "storage/batch_cache.h"
@@ -505,6 +506,13 @@ ss::future<> segment::compaction_index_batch(const model::record_batch& b) {
         co_return;
     }
 
+    if constexpr (finjector::honey_badger::is_enabled()) {
+        if (unlikely(std::exchange(_fail_next_compaction_index_batch, false))) {
+            co_await ss::coroutine::return_exception(
+              std::runtime_error("injected compaction index batch failure"));
+        }
+    }
+
     if (!b.compressed()) {
         co_return co_await do_compaction_index_batch(b);
     }
@@ -633,11 +641,42 @@ ss::future<append_result> segment::do_append(const model::record_batch& b) {
           auto index_err = std::move(index_fut).get_exception();
           vlog(
             stlog.error,
-            "segment::append index: {}. ignoring append: {}",
+            "segment::append: compaction index update failed: {}. batch {} "
+            "remains in the log; marking compaction index incomplete for "
+            "rebuild",
             index_err,
             ret);
-          return ss::make_exception_future<append_result>(index_err);
+          // The data write succeeded but the compaction index did not. Left as
+          // is, the compaction index can seal cleanly while permanently
+          // missing this batch, and self compaction would silently drop its
+          // records (since self compaction relies on the entries within the
+          // compaction index for deduplication). Mark the index incomplete so
+          // that compaction rebuilds it from the segment data instead.
+          return close_compaction_index_as_incomplete()
+            .handle_exception([](std::exception_ptr e) {
+                vlog(
+                  stlog.warn,
+                  "failed to close compaction index as incomplete: {}",
+                  e);
+            })
+            .then([index_err]() mutable {
+                return ss::make_exception_future<append_result>(index_err);
+            });
       });
+}
+
+ss::future<> segment::close_compaction_index_as_incomplete() {
+    if (!has_compaction_index()) {
+        co_return;
+    }
+    auto compacted_index
+      = std::exchange(_compaction_index, std::nullopt).value();
+    compacted_index->set_flag(compacted_index::footer_flags::incomplete);
+    vlog(
+      gclog.info,
+      "Marking compaction index {} as incomplete",
+      compacted_index->filename());
+    co_await compacted_index->close();
 }
 
 ss::future<append_result> segment::append(const model::record_batch& b) {
@@ -649,15 +688,7 @@ ss::future<append_result> segment::append(const model::record_batch& b) {
             // be aborted in the next segment. We mark this index as
             // `incomplete` and rebuild it later from scratch during compaction.
             try {
-                auto compacted_index
-                  = std::exchange(_compaction_index, std::nullopt).value();
-                compacted_index->set_flag(
-                  compacted_index::footer_flags::incomplete);
-                vlog(
-                  gclog.info,
-                  "Marking compaction index {} as incomplete",
-                  compacted_index->filename());
-                co_await compacted_index->close();
+                co_await close_compaction_index_as_incomplete();
             } catch (...) {
                 co_return ss::coroutine::exception(std::current_exception());
             }

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -224,6 +224,13 @@ public:
     segment_appender::stats_ptr get_appender_stats() const;
     compacted_index_writer& compaction_index();
     const compacted_index_writer& compaction_index() const;
+
+    /// Test hook: fail the next compaction index update, simulating a
+    /// failure (e.g. an allocation error) while indexing a batch whose data
+    /// write succeeded. Compiled out of release builds.
+    void fail_next_compaction_index_batch() {
+        _fail_next_compaction_index_batch = true;
+    }
     // We currently use `max_removable_local_log_offset` to control both
     // deletion/eviction, and compaction.
     bool is_compactible(const compaction::compaction_config& cfg) const;
@@ -320,6 +327,10 @@ private:
       std::optional<std::unique_ptr<compacted_index_writer>>);
     ss::future<> compaction_index_batch(const model::record_batch&);
     ss::future<> do_compaction_index_batch(const model::record_batch&);
+    /// Closes the compaction index with the `incomplete` footer flag set, so
+    /// that compaction rebuilds it from the segment data instead of trusting
+    /// it.
+    ss::future<> close_compaction_index_as_incomplete();
     void release_appender_in_background(readers_cache* readers_cache);
 
     ss::future<size_t> remove_persistent_state(std::filesystem::path);
@@ -353,6 +364,7 @@ private:
     // size of the compaction index is needed (e.g. estimating total seg size).
     std::optional<size_t> _compaction_index_size;
     std::optional<std::unique_ptr<compacted_index_writer>> _compaction_index;
+    bool _fail_next_compaction_index_batch{false};
 
     std::optional<batch_cache_index> _cache;
     ss::rwlock _destructive_ops;

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -3507,6 +3507,110 @@ TEST_F(storage_test_fixture, test_simple_compaction_rebuild_index) {
     linear_int_kv_batch_generator::validate_post_compaction(std::move(batches));
 };
 
+namespace {
+model::record_batch make_kv_batch(std::string_view key, std::string_view val) {
+    storage::record_batch_builder b(
+      model::record_batch_type::raft_data, model::offset(0));
+    b.add_raw_kv(iobuf::from(key), iobuf::from(val));
+    auto batch = std::move(b).build();
+    batch.set_term(model::term_id(1));
+    return batch;
+}
+} // namespace
+
+// Regression test for record loss on compacted topics when a compaction
+// index update fails for a batch whose data write succeeded.
+//
+// By the time segment::do_append observes the index failure, the batch is
+// already visible in the log, and raft will not re-append it (a retried
+// append entries request skip-matches batches that are already present). The
+// compaction index writer stays live, keeps indexing later batches and seals
+// with a valid footer. Unless the index is marked incomplete (forcing a
+// rebuild from segment data), compaction trusts it and silently drops the
+// unindexed batch's records - even when they hold the newest value of a key.
+TEST_F(storage_test_fixture, unindexed_visible_batch_is_not_compacted) {
+    if (!finjector::honey_badger::is_enabled()) {
+        GTEST_SKIP() << "Failure injection is only enabled in debug mode.";
+        return;
+    }
+    storage::log_manager mgr = make_log_manager();
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
+
+    auto ntp = model::ntp("kafka", "compacted", 0);
+    storage::ntp_config::default_overrides overrides;
+    overrides.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::compaction;
+    storage::ntp_config ntp_cfg(
+      ntp,
+      mgr.config().base_dir,
+      std::make_unique<storage::ntp_config::default_overrides>(overrides));
+    auto log = manage_log(mgr, std::move(ntp_cfg));
+    ss::abort_source as;
+    log->start(std::nullopt, as).get();
+
+    auto append = [&](std::string_view key, std::string_view val) {
+        auto appender = log->make_appender(
+          storage::log_append_config{storage::log_append_config::fsync::no});
+        auto b = make_kv_batch(key, val);
+        appender(b).get();
+        return appender.end_of_stream().get();
+    };
+
+    // offsets 0, 1: indexed normally
+    append("k1", "v1");
+    append("k2", "v2");
+
+    // offset 2: the newest value of k1; its data write succeeds but the
+    // compaction index update fails, and (like a raft retry, which
+    // skip-matches batches already present in the log) it is not re-appended
+    log->segments().back()->fail_next_compaction_index_batch();
+    EXPECT_THROW(append("k1", "v3"), std::runtime_error);
+    ASSERT_EQ(log->offsets().dirty_offset, model::offset(2));
+
+    // offset 3: the index writer is still live and keeps indexing
+    append("k3", "v4");
+
+    // seal the segment (closes the compaction index with a valid footer)
+    log->force_roll().get();
+
+    storage::housekeeping_config cfg(
+      model::timestamp::max(),
+      std::nullopt,
+      model::offset::max(),
+      model::offset::max(),
+      model::offset::max(),
+      std::nullopt,
+      std::nullopt,
+      std::chrono::milliseconds{0},
+      as);
+    log->housekeeping(cfg).get();
+    ASSERT_TRUE(
+      log->segments().front()->index().self_compact_timestamp().has_value());
+
+    // collect the surviving records
+    auto batches = read_and_validate_all_batches(log);
+    std::map<ss::sstring, ss::sstring> kvs;
+    for (auto& b : batches) {
+        b.for_each_record([&kvs](model::record r) {
+            auto to_string = [](iobuf buf) {
+                auto bytes = iobuf_to_bytes(buf);
+                return ss::sstring(
+                  reinterpret_cast<const char*>(bytes.data()), bytes.size());
+            };
+            kvs[to_string(r.key().copy())] = to_string(r.value().copy());
+        });
+    }
+
+    // k1's newest value lives in the unindexed batch at offset 2 and was
+    // never superseded: compaction must not remove it
+    ASSERT_TRUE(kvs.contains("k1"));
+    EXPECT_EQ(kvs["k1"], "v3")
+      << "compaction dropped the newest value of k1 (the unindexed batch) "
+         "and kept an older one";
+    EXPECT_EQ(kvs["k2"], "v2");
+    EXPECT_EQ(kvs["k3"], "v4");
+}
+
 struct compact_test_args {
     model::offset max_compact_offs;
     long num_compactable_msg;


### PR DESCRIPTION
`segment::do_append()` runs the data write and the compaction index update in parallel and fails the whole append when the index update fails. By then the batch is already visible in the log and the caller may never re-append it, since a retried raft append entries request skip-matches batches that are already present. The self-compaction copy pass keeps a record only if its offset is in the offset list generated from that index, so the unindexed batch's records can be silently dropped, even when they held the newest value of a key.

Mark the compaction index incomplete and close it when an index update fails after a successful write, so compaction must rebuild the index from segment data.

The new test drives this scenario through an injected index failure and verifies the newest value of the affected key survives compaction; without the fix compaction keeps the older value and drops the newest.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.2.x
- [X] v26.1.x
- [ ] v25.3.x

## Release Notes


### Bug Fixes

* Fixes a bug in which records could be silently dropped from compacted topics after a partly successful log append 