### PR TITLE
`storage`: stop using SUCCEED() as a log line in `issue_8091`

### DIFF
--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -2839,10 +2839,11 @@ TEST_F(storage_test_fixture, read_write_truncate) {
             })
             .then([](chunked_circular_buffer<model::record_batch> batches) {
                 if (batches.empty()) {
-                    SUCCEED() << "read empty range";
+                    vlog(e2e_test_log.trace, "read empty range");
                     return;
                 }
-                SUCCEED() << fmt::format(
+                vlog(
+                  e2e_test_log.trace,
                   "read range: {}, {}",
                   batches.front().base_offset(),
                   batches.back().last_offset());
@@ -3908,7 +3909,7 @@ TEST_F(storage_test_fixture, issue_8091) {
     auto log = manage_log(mgr, storage::ntp_config(ntp, mgr.config().base_dir));
 
     int cnt = 0;
-    int max = 50; // NB: Reduced for GTest due to OOM; hopefully temporary.
+    int max = 500;
     ssx::mutex log_mutex{"e2e_test::log_mutex"};
     model::offset last_truncate;
 
@@ -3939,15 +3940,17 @@ TEST_F(storage_test_fixture, issue_8091) {
           storage::log_append_config cfg{
             .should_fsync = storage::log_append_config::fsync::no,
           };
-          SUCCEED() << "append";
+          vlog(e2e_test_log.trace, "append");
           return log_mutex
             .with([reader = std::move(reader), cfg, &log]() mutable {
-                SUCCEED() << "append_lock";
+                vlog(e2e_test_log.trace, "append_lock");
                 return std::move(reader)
                   .for_each_ref(log->make_appender(cfg), model::no_timeout)
                   .then([](storage::append_result res) {
-                      SUCCEED()
-                        << fmt::format("append_result: {}", res.last_offset);
+                      vlog(
+                        e2e_test_log.trace,
+                        "append_result: {}",
+                        res.last_offset);
                   })
                   .then([&log] { return log->flush(); });
             })
@@ -3975,10 +3978,11 @@ TEST_F(storage_test_fixture, issue_8091) {
             })
             .then([](chunked_circular_buffer<model::record_batch> batches) {
                 if (batches.empty()) {
-                    SUCCEED() << "read empty range";
+                    vlog(e2e_test_log.trace, "read empty range");
                     return;
                 }
-                SUCCEED() << fmt::format(
+                vlog(
+                  e2e_test_log.trace,
                   "read range: {}, {}",
                   batches.front().base_offset(),
                   batches.back().last_offset());
@@ -3995,7 +3999,7 @@ TEST_F(storage_test_fixture, issue_8091) {
           return log_mutex
             .with([&log, &last_truncate] {
                 auto offset = log->offsets();
-                SUCCEED() << fmt::format("truncate offsets: {}", offset);
+                vlog(e2e_test_log.trace, "truncate offsets: {}", offset);
                 auto start = ss::steady_clock_type::now();
                 last_truncate = offset.dirty_offset;
                 return log
@@ -4004,7 +4008,7 @@ TEST_F(storage_test_fixture, issue_8091) {
                       // assert that truncation took less than 5 seconds
                       ASSERT_LT(
                         (ss::steady_clock_type::now() - start) / 1ms, 5000);
-                      SUCCEED() << "truncate_done";
+                      vlog(e2e_test_log.trace, "truncate_done");
                   });
             })
             .then([] { return ss::sleep(10ms); });


### PR DESCRIPTION
`SUCCEED()` records a `TestPartResult`, which gtest retains for the lifetime of the test, exactly like a failed assertion does. The gtest migration converted this test's info() log calls into `SUCCEED()`, and over the course of this test, can easily OOM a machine due to the size of backing `std::vector<>` required to store all the result messages.

Log through the test logger instead, and restore the original iteration count.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none
