### PR TITLE
`storage`: flush pending kvstore ops on stop instead of cancelling them

### DIFF
--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -100,30 +100,57 @@ ss::future<> kvstore::start() {
 
     _started = true;
 
-    // Flushing background fiber
-    ssx::repeat_until_gate_closed(
-      _gate,
-      [this] {
-          // semaphore used here instead of condition variable so that
-          // we don't lose wake-ups if they occur while flushing.
-          // consume at least one unit to avoid spinning on wait(0).
-          auto units = std::max(_sem.current(), size_t(1));
-          return _sem.wait(units).then([this] {
-              if (_gate.is_closed()) {
-                  return ss::now();
-              }
-              return roll().then([this] { return flush_and_apply_ops(); });
-          });
-      },
-      [](const std::exception_ptr& e) {
-          // an error mid roll/flush leaves the segment, pending ops and
-          // _next_offset in an unknown state, so neither retrying nor
-          // exiting the fiber is safe (the latter would hang all future
-          // puts). on-disk state is crash-safe, so terminate and recover.
-          if (!ssx::is_shutdown_exception(e)) {
-              vunreachable("kvstore flush fiber failed: {}", e);
-          }
-      });
+    ssx::spawn_with_gate(_gate, [this] { return flush_loop(); });
+}
+
+ss::future<> kvstore::flush_loop() {
+    while (true) {
+        try {
+            // don't wait once shutting down: stop() signals the semaphore only
+            // once, but ops may have been queued after the flush that consumed
+            // that signal, and those still need to be written.
+            if (!_as.abort_requested()) {
+                // semaphore used here instead of condition variable so that
+                // we don't lose wake-ups if they occur while flushing.
+                // consume at least one unit to avoid spinning on wait(0).
+                auto units = std::max(_sem.current(), size_t(1));
+                co_await _sem.wait(units);
+            }
+            co_await roll();
+            co_await flush_and_apply_ops();
+        } catch (...) {
+            // an error mid roll/flush leaves the segment, pending ops and
+            // _next_offset in an unknown state, so neither retrying nor
+            // exiting the fiber is safe (the latter would hang all future
+            // puts). on-disk state is crash-safe, so terminate and recover.
+            auto e = std::current_exception();
+            if (!ssx::is_shutdown_exception(e)) {
+                vunreachable("kvstore flush fiber failed: {}", e);
+            }
+
+            vlog(
+              lg.warn,
+              "kvstore flush fiber exiting with {} unresolved op(s): {} - dir "
+              "{}",
+              _ops.size(),
+              e,
+              _ntpc.work_directory());
+
+            for (auto& op : _ops) {
+                op.done.set_exception(ss::gate_closed_exception());
+            }
+            _ops.clear();
+
+            co_return;
+        }
+
+        // checked after flushing so that ops which were queued before the abort
+        // are persisted instead of cancelled. at most one more drain pass is
+        // needed.
+        if (_as.abort_requested() && _ops.empty()) {
+            co_return;
+        }
+    }
 }
 
 ss::future<> kvstore::stop() {
@@ -131,28 +158,22 @@ ss::future<> kvstore::stop() {
 
     _probe.metrics.clear();
 
-    _as.request_abort();
-
-    // prevent new ops, signal flusher to exit
+    // prevent new ops, signal the flusher to drain _ops and exit
     auto f = _gate.close();
+    _as.request_abort();
     _sem.signal();
+    co_await std::move(f);
 
-    // it's ok for the flusher to run concurrently with stop() because the
-    // flusher only operates on a snapshot of the pending ops that it takes when
-    // it starts these ops begin cancelled would be ops that arrived between the
-    // start of a flush and this service being stopped.
-    for (auto& op : _ops) {
-        op.done.set_exception(ss::gate_closed_exception());
+    vassert(
+      _ops.empty(),
+      "Stopped kvstore with {} inflight ops still queued but not flushed",
+      _ops.size());
+
+    // the flusher might have created _segment
+    if (_segment) {
+        co_await _segment->flush();
+        co_await _segment->close();
     }
-    _ops.clear();
-
-    return f.then([this] {
-        // wait until the flusher exists--it might create _segment
-        if (_segment) {
-            return _segment->flush().then([this] { return _segment->close(); });
-        }
-        return ss::now();
-    });
 }
 
 /*

--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -208,6 +208,13 @@ private:
     ss::future<> roll();
     ss::future<> save_snapshot();
 
+    /**
+     * Background fiber which periodically rolls and flushes queued ops. Exits
+     * once an abort has been requested and no ops remain queued, so that ops
+     * queued concurrently with the abort are persisted rather than cancelled.
+     */
+    ss::future<> flush_loop();
+
     /*
      * Recovery (recover() itself is a public entry point declared above)
      *

--- a/src/v/storage/tests/kvstore_fixture.h
+++ b/src/v/storage/tests/kvstore_fixture.h
@@ -39,6 +39,14 @@ public:
           _kv_config, ss::this_shard_id(), resources, _feature_table);
     }
 
+    std::unique_ptr<storage::kvstore>
+    make_kvstore(std::chrono::milliseconds commit_interval) {
+        auto cfg = _kv_config;
+        cfg.commit_interval = config::mock_binding(std::move(commit_interval));
+        return std::make_unique<storage::kvstore>(
+          cfg, ss::this_shard_id(), resources, _feature_table);
+    }
+
     ~kvstore_test_fixture() {
         _feature_table.stop().get();
         resources.stop().get();

--- a/src/v/storage/tests/kvstore_test.cc
+++ b/src/v/storage/tests/kvstore_test.cc
@@ -195,6 +195,41 @@ TEST_F(kvstore_test_fixture, kvstore) {
     kvs->stop().get();
 }
 
+TEST_F(kvstore_test_fixture, stop_flushes_pending_ops) {
+    set_configuration("disable_metrics", true);
+
+    // a commit interval far beyond the test duration, so that the flush timer
+    // never fires and every put stays queued until stop()
+    auto kvs = make_kvstore(std::chrono::hours(1));
+    kvs->start().get();
+
+    std::unordered_map<bytes, iobuf> truth;
+    std::vector<ss::future<>> puts;
+    for (int i = 0; i < 10; i++) {
+        auto key = tests::random_bytes(8);
+        auto value = bytes_to_iobuf(tests::random_bytes(100));
+        truth[key] = value.copy();
+        puts.push_back(kvs->put(
+          storage::kvstore::key_space::testing, key, std::move(value)));
+    }
+
+    kvs->stop().get();
+    // Expect that the puts were flushed by stop()
+    for (auto& f : puts) {
+        EXPECT_NO_THROW(f.get());
+    }
+    kvs.reset(nullptr);
+
+    kvs = make_kvstore();
+    kvs->start().get();
+    for (auto& e : truth) {
+        EXPECT_EQ(
+          kvs->get(storage::kvstore::key_space::testing, e.first).value(),
+          e.second);
+    }
+    kvs->stop().get();
+}
+
 // persist_pre_start() durably writes a key on a fresh (empty) kvstore, before
 // start(), and the value survives a restart.
 TEST_F(kvstore_test_fixture, persist_pre_start_empty) {


### PR DESCRIPTION
`kvstore::stop()` cancelled every op still queued for the background flusher, discarding up to a commit interval's worth of writes on every clean shutdown. An unresolved put carries no durability promise, so this was not incorrect, but it needlessly widens the loss window for callers that were still awaiting those writes when shutdown began, and it does so silently.

Change the flushing fiber so that `_ops` is always guaranteed to be empty by the time it is resolved. Exception handling remains unchanged.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none
