### PR TITLE
DNM: CORE-16997 A/B arm C (minimal + regex whitelist)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,5 @@ docker pull docker.redpanda.com/redpandadata/redpanda-unstable:v25.1.1-rc1
 - [Upcoming Redpanda Events](https://www.redpanda.com/events)
 - [Redpanda Support](https://support.redpanda.com/)
 - [Redpanda University](https://university.redpanda.com/)
+
+<!-- CORE-16997 A/B arm C (minimal + regex whitelist). Do not merge. -->


### PR DESCRIPTION
DNM / do not merge. Scratch PR for [CORE-16997](https://redpandadata.atlassian.net/browse/CORE-16997).

One of three arms in an A/B(/C) measuring how many bytes a warm `bazel test //...` CI build pulls from the remote cache, and whether `--remote_download_minimal` reduces it. The commit is a no-op README edit purely to give this PR a distinct head SHA; the action graph is identical to `dev`.

**This arm:** `--remote_download_minimal` plus the `--remote_download_regex` whitelist for the packaging artifacts. The deployable variant; should stay green. Difference vs arm B is how much the whitelist gives back.

All three arms run with the same `vtools_gitref=td-core-16997-bazel-out-du`, which adds a post-build `du` of the resolved `bazel-out` as a CI artifact. The only difference between arms is the `--remote_download_*` flags.

Will be closed once the measurement is recorded.

[CORE-16997]: https://redpandadata.atlassian.net/browse/CORE-16997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ