### PR TITLE
storage: remove unneeded vassert in batch_header_from_disk_buf

### DIFF
--- a/src/v/storage/record_batch_utils.cc
+++ b/src/v/storage/record_batch_utils.cc
@@ -124,11 +124,6 @@ model::record_batch_header batch_header_from_disk_iobuf(iobuf b) {
 
 model::record_batch_header
 batch_header_from_disk_buf(std::span<const char> data) {
-    vassert(
-      data.size() == model::packed_record_batch_header_size,
-      "disk headers must be of static size {}, but got {}",
-      model::packed_record_batch_header_size,
-      data.size());
     buffer_parser parser(data);
     return parse_header(parser);
 }


### PR DESCRIPTION
`parse_header` largely asserts on the same requirements rendering the removed vassert redundant.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
