### PR TITLE
[CORE-16998, CORE-17000, CORE-17001] - Consumer Groups (Classic): Fix some bugs where the offset map could diverge from the log

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -3489,6 +3489,25 @@ chunked_vector<model::topic_partition> offset_store::filter_expired_offsets(
         .count());
 
     const auto now = model::timestamp::now();
+
+    /*
+     * the partitions that open transactions stage a value for. the scan below
+     * runs in one reactor task, so it tests each offset with one lookup here.
+     * the keys are views over the transactions, which this function does not
+     * modify.
+     */
+    chunked_hash_set<model::topic_partition_view> staged;
+    for (const auto& producer : _producers) {
+        const auto& tx = producer.second.transaction;
+        if (tx == nullptr) {
+            continue;
+        }
+        for (const auto& o : tx->offsets) {
+            staged.insert(
+              model::topic_partition_view(o.first.topic, o.first.partition));
+        }
+    }
+
     chunked_vector<model::topic_partition> offsets;
     for (const auto& [topic, partitions] : _offsets) {
         const auto topic_subscribed = subscribed(topic);
@@ -3500,10 +3519,12 @@ chunked_vector<model::topic_partition> offset_store::filter_expired_offsets(
             model::topic_partition tp(topic, pid);
             /*
              * an offset won't be removed if its topic has an active
-             * subscription or there are pending offset commits for the
-             * offset's topic.
+             * subscription, if a plain commit for it is pending, or if an
+             * open transaction has a value staged for it.
              */
-            if (topic_subscribed || _pending_offset_commits.contains(tp)) {
+            if (
+              topic_subscribed || _pending_offset_commits.contains(tp)
+              || staged.contains(tp)) {
                 continue;
             }
 

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -2230,6 +2230,22 @@ offset_store::prepare_offset_commits(const offset_commit_request& r) {
     chunked_vector<std::pair<model::topic_partition, offset_metadata>>
       offset_commits;
 
+    /*
+     * kafka commits the last value for a partition that a request names more
+     * than once, so count each partition's entries and commit the last one.
+     * one record per partition also keeps the offsets map and the log in
+     * agreement: every record in this batch carries the same log offset, and
+     * try_upsert_offset only replaces a value on a higher one. the keys are
+     * views over the request, which outlives this function.
+     */
+    chunked_hash_map<model::topic_partition_view, size_t> remaining_entries;
+    for (const auto& t : r.data.topics) {
+        for (const auto& p : t.partitions) {
+            ++remaining_entries[model::topic_partition_view(
+              t.name, p.partition_index)];
+        }
+    }
+
     const auto expiry_timestamp = [&r]() -> std::optional<model::timestamp> {
         if (r.data.retention_time_ms == -1) {
             return std::nullopt;
@@ -2249,6 +2265,13 @@ offset_store::prepare_offset_commits(const offset_commit_request& r) {
     for (const auto& t : r.data.topics) {
         offset_commits.reserve(offset_commits.size() + t.partitions.size());
         for (const auto& p : t.partitions) {
+            if (
+              --remaining_entries.at(
+                model::topic_partition_view(t.name, p.partition_index))
+              > 0) {
+                continue;
+            }
+
             const auto commit_timestamp = get_commit_timestamp(p);
             update_store_offset_builder(
               builder,

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -3184,11 +3184,17 @@ offset_store::do_commit(model::producer_identity pid, model::tx_seq sequence) {
           cluster::tx::errc::unknown_server_error);
     }
 
+    /*
+     * try_upsert_offset keeps whichever value has the highest log offset, so
+     * stamp these with the commit batch's offset, which is above every commit
+     * that landed while the transaction was open. md.log_offset is the
+     * staging batch's, which is lower.
+     */
     for (const auto& [tp, md] : it->second.transaction->offsets) {
         try_upsert_offset(
           tp,
           offset_metadata{
-            .log_offset = md.log_offset,
+            .log_offset = result.value().last_offset,
             .offset = md.offset_metadata.offset,
             .metadata = md.offset_metadata.metadata.value_or(""),
             .committed_leader_epoch = kafka::leader_epoch(

--- a/src/v/kafka/server/tests/group_test.cc
+++ b/src/v/kafka/server/tests/group_test.cc
@@ -92,6 +92,21 @@ static join_group_response join_resp() {
       kafka::member_id("m"));
 }
 
+// group exposes the offsets map rather than a single offset
+static std::optional<group::offset_metadata>
+committed_offset(const group& g, const model::topic_partition& tp) {
+    const auto& offsets = g.offsets();
+    auto t_it = offsets.find(tp.topic);
+    if (t_it == offsets.end()) {
+        return std::nullopt;
+    }
+    auto p_it = t_it->second.find(tp.partition);
+    if (p_it == t_it->second.end()) {
+        return std::nullopt;
+    }
+    return p_it->second->metadata;
+}
+
 SEASTAR_THREAD_TEST_CASE(id) {
     auto g = get();
     BOOST_TEST(g.id() == "g");
@@ -566,6 +581,90 @@ SEASTAR_THREAD_TEST_CASE(add_new_static_member) {
     BOOST_TEST(m2->client_host() == m2_client_host);
     BOOST_TEST(m2->session_timeout() == m2_session_timeout);
     BOOST_TEST(m2->rebalance_timeout() == m2_rebalance_timeout);
+}
+
+// an offset that an open transaction stages survives expiry, and the
+// unstaged offset beside it is reclaimed
+SEASTAR_THREAD_TEST_CASE(expiry_retains_offset_staged_by_open_transaction) {
+    auto g = get();
+
+    const model::topic topic("t");
+    const model::topic_partition staged(topic, model::partition_id(0));
+    const model::topic_partition unstaged(topic, model::partition_id(1));
+
+    // committed an hour ago, past the retention period applied below
+    const auto committed_at = model::timestamp(
+      model::timestamp::now()() - std::chrono::milliseconds(1h).count());
+
+    for (const auto& tp : {staged, unstaged}) {
+        g.try_upsert_offset(
+          tp,
+          group::offset_metadata{
+            .log_offset = model::offset(0),
+            .offset = model::offset(10),
+            .committed_leader_epoch = kafka::leader_epoch(1),
+            .commit_timestamp = committed_at,
+          });
+    }
+
+    group::ongoing_transaction tx(
+      model::tx_seq(0), model::partition_id(0), 30s, model::offset(1));
+    tx.offsets[staged] = group::pending_tx_offset{
+      .offset_metadata = group_tx::partition_offset{
+        .tp = staged,
+        .offset = model::offset(20),
+        .leader_epoch = 1,
+      },
+      .log_offset = model::offset(1)};
+    g.insert_ongoing_tx(model::producer_identity(1, 0), std::move(tx));
+
+    const auto expired = g.delete_expired_offsets(60s);
+
+    BOOST_REQUIRE(expired.size() == 1);
+    BOOST_REQUIRE(expired.front() == unstaged);
+    BOOST_TEST(committed_offset(g, staged).has_value());
+    BOOST_TEST(!committed_offset(g, unstaged).has_value());
+}
+
+// the same guard with no transaction open: a plain commit in flight keeps
+// its offset, and the idle offset beside it is reclaimed
+SEASTAR_THREAD_TEST_CASE(expiry_retains_offset_with_pending_commit) {
+    auto g = get();
+
+    const model::topic topic("t");
+    const model::topic_partition pending(topic, model::partition_id(0));
+    const model::topic_partition idle(topic, model::partition_id(1));
+
+    const auto committed_at = model::timestamp(
+      model::timestamp::now()() - std::chrono::milliseconds(1h).count());
+
+    for (const auto& tp : {pending, idle}) {
+        g.try_upsert_offset(
+          tp,
+          group::offset_metadata{
+            .log_offset = model::offset(0),
+            .offset = model::offset(10),
+            .committed_leader_epoch = kafka::leader_epoch(1),
+            .commit_timestamp = committed_at,
+          });
+    }
+
+    // records a pending commit for `pending` without replicating it
+    offset_commit_request req;
+    req.data.group_id = g.id();
+    auto& req_topic = req.data.topics.emplace_back(
+      offset_commit_request_topic{.name = topic});
+    req_topic.partitions.push_back(
+      {.partition_index = pending.partition,
+       .committed_offset = model::offset(20)});
+    BOOST_REQUIRE(g.prepare_offset_commits(req).has_value());
+
+    const auto expired = g.delete_expired_offsets(60s);
+
+    BOOST_REQUIRE(expired.size() == 1);
+    BOOST_REQUIRE(expired.front() == idle);
+    BOOST_TEST(committed_offset(g, pending).has_value());
+    BOOST_TEST(!committed_offset(g, idle).has_value());
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/tests/group_tx_compaction_test.cc
+++ b/src/v/kafka/server/tests/group_tx_compaction_test.cc
@@ -81,6 +81,16 @@ struct group_manager_fixture
         return app._group_manager.local().txn_offset_commit(std::move(request));
     }
 
+    auto offset_commit(kafka::offset_commit_request request) {
+        return app._group_manager.local()
+          .offset_commit(std::move(request))
+          .result;
+    }
+
+    auto offset_fetch(kafka::offset_fetch_request request) {
+        return app._group_manager.local().offset_fetch(std::move(request));
+    }
+
     ss::shared_ptr<storage::log> consumer_offsets_log() {
         return app.storage.local().log_mgr().get(offsets_ntp);
     }
@@ -768,4 +778,70 @@ TEST_F_CORO(
       << " instead of committed_offset " << log->offsets().committed_offset
       << ". This indicates a stale open transaction from the snapshot was not "
          "resolved after compaction removed the commit batch.";
+}
+
+// a plain commit between a transaction's staging batch and its commit marker
+// is earlier in the log, so the transaction's value wins
+TEST_F_CORO(group_manager_fixture, test_tx_commit_beats_interleaved_plain) {
+    kafka::group_id gid{"tx-vs-plain-offset-commit"};
+    const auto pid = model::producer_identity{7, 0};
+    const auto seq = model::tx_seq{0};
+    const auto& topic = test_ntp.tp.topic;
+    const auto partition = model::partition_id{0};
+
+    const auto plain_offset = model::offset{10};
+    const auto tx_offset = model::offset{50};
+
+    // begin_tx creates the group, which stays empty, so the plain commit below
+    // takes the offsets-only path (generation_id defaults to -1)
+    auto bresult = co_await begin_tx(
+      cluster::begin_group_tx_request{
+        offsets_ntp, gid, pid, seq, no_timeout, model::partition_id{0}});
+    ASSERT_EQ_CORO(bresult.ec, cluster::tx::errc::none);
+
+    {
+        kafka::txn_offset_commit_request oreq;
+        oreq.ntp = offsets_ntp;
+        oreq.data.transactional_id = "tx.id";
+        oreq.data.group_id = gid;
+        oreq.data.producer_id = kafka::producer_id{pid.id};
+        oreq.data.producer_epoch = pid.epoch;
+        kafka::txn_offset_commit_request_topic tdata;
+        tdata.name = topic;
+        tdata.partitions.push_back(
+          {.partition_index = partition, .committed_offset = tx_offset});
+        oreq.data.topics.push_back(std::move(tdata));
+        auto oresult = co_await tx_offset_commit(std::move(oreq));
+        ASSERT_FALSE_CORO(oresult.data.errored());
+    }
+
+    {
+        kafka::offset_commit_request creq;
+        creq.ntp = offsets_ntp;
+        creq.data.group_id = gid;
+        kafka::offset_commit_request_topic tdata;
+        tdata.name = topic;
+        tdata.partitions.push_back(
+          {.partition_index = partition, .committed_offset = plain_offset});
+        creq.data.topics.push_back(std::move(tdata));
+        auto cresult = co_await offset_commit(std::move(creq));
+        ASSERT_FALSE_CORO(cresult.data.errored());
+    }
+
+    auto cresult = co_await commit_tx(
+      cluster::commit_group_tx_request{offsets_ntp, pid, seq, gid, no_timeout});
+    ASSERT_EQ_CORO(cresult.ec, cluster::tx::errc::none);
+
+    kafka::offset_fetch_request freq;
+    freq.ntp = offsets_ntp;
+    freq.data.groups.emplace_back().group_id = gid;
+    auto fresp = co_await offset_fetch(std::move(freq));
+
+    ASSERT_EQ_CORO(fresp.data.groups.size(), 1);
+    const auto& fetched = fresp.data.groups.front();
+    ASSERT_EQ_CORO(fetched.error_code, kafka::error_code::none);
+    ASSERT_EQ_CORO(fetched.topics.size(), 1);
+    ASSERT_EQ_CORO(fetched.topics.front().partitions.size(), 1);
+    ASSERT_EQ_CORO(
+      fetched.topics.front().partitions.front().committed_offset, tx_offset);
 }

--- a/src/v/kafka/server/tests/offset_store_test.cc
+++ b/src/v/kafka/server/tests/offset_store_test.cc
@@ -1452,3 +1452,33 @@ TEST_F(offset_store_test, expiry_skips_an_offset_a_transaction_staged) {
     ASSERT_EQ(expired.size(), 1);
     ASSERT_EQ(expired[0], idle);
 }
+
+// kafka commits the last value for a partition a request names twice, and one
+// record per partition keeps the offsets map and the log in agreement
+TEST_F(offset_store_test, a_duplicate_partition_commits_the_last_value) {
+    const auto partition = tp("t", 0);
+    auto req = commit_request(partition, model::offset(10));
+    req.data.topics.front().partitions.push_back(
+      offset_commit_request_partition{
+        .partition_index = partition.partition,
+        .committed_offset = model::offset(20),
+        .committed_leader_epoch = kafka::leader_epoch(1),
+        .commit_timestamp = -1,
+        .committed_metadata = "",
+      });
+
+    auto prepared = store.prepare_offset_commits(req);
+    ASSERT_TRUE(prepared.has_value());
+    ASSERT_EQ(prepared->batch.record_count(), 1);
+    ASSERT_EQ(prepared->commits.size(), 1);
+
+    // the replicate continuation stamps every commit with its batch's offset
+    for (auto& e : prepared->commits) {
+        e.second.log_offset = model::offset(100);
+        store.complete_offset_commit(e.first, e.second);
+    }
+
+    auto stored = store.offset(partition);
+    ASSERT_TRUE(stored.has_value());
+    ASSERT_EQ(stored->offset, model::offset(20));
+}

--- a/src/v/kafka/server/tests/offset_store_test.cc
+++ b/src/v/kafka/server/tests/offset_store_test.cc
@@ -1427,3 +1427,28 @@ TEST_F_CORO(offset_store_test, the_timer_leaves_live_transactions_alone) {
     ASSERT_TRUE_CORO(timed.store->has_transactions_in_progress());
     ASSERT_TRUE_CORO(timed.coordinator->asked_about.empty());
 }
+
+// an open transaction stages its offsets on the producer, so the guard reads
+// there as well as in the pending commit map
+TEST_F(offset_store_test, expiry_skips_an_offset_a_transaction_staged) {
+    constexpr auto retention = 24h;
+    const auto retention_secs
+      = std::chrono::duration_cast<std::chrono::seconds>(retention);
+    const auto long_ago = model::timestamp(
+      model::timestamp::now().value()
+      - std::chrono::milliseconds(retention * 2).count());
+
+    const auto staged = tp("t", 0);
+    const auto idle = tp("t", 1);
+    store.try_upsert_offset(staged, committed(10, 100, long_ago));
+    store.try_upsert_offset(idle, committed(10, 100, long_ago));
+
+    open_tx(
+      model::producer_identity{7, 1}, staged_tx(model::tx_seq(1), staged));
+
+    auto expired = store.filter_expired_offsets(
+      retention_secs, none_subscribed, expires_at_commit);
+
+    ASSERT_EQ(expired.size(), 1);
+    ASSERT_EQ(expired[0], idle);
+}


### PR DESCRIPTION

CORE-16998, CORE-17000, CORE-17001

  Three bugs in the classic group's offset accounting, all the same defect: live state and a replay of the log resolve the same key differently. The group's committed offset then changes on a leader change, a restart or compaction, and no client asked for it. None is a KIP-848 regression, and each commit carries its own unit test.

  - **CORE-16998 (High)** the retention sweep can tombstone an offset that an open transaction has staged, and when the tombstone lands last, recovery finds no offset for the partition. Fix: `filter_expired_offsets` consults the staged partitions.
    - [expiry vs. open transactions in Kafka](https://github.com/apache/kafka/blob/fce22525f74bbd7feeb4f8b34c79a215db9a74c3/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java#L1068-L1070)
  - **CORE-17000 (High)** a transactional commit ordered by its staging offset loses to a plain commit that raced it, so live state and the log disagree. Fix: stamp the staged offsets with the commit marker's offset.
    - [In Kafka, higher record offset wins on transaction commit](https://github.com/apache/kafka/blob/fce22525f74bbd7feeb4f8b34c79a215db9a74c3/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java#L1255-L1258)
    - We have the same rule, but Kafka writes the transactional offset records [while it handles TxnOffsetCommit](https://github.com/apache/kafka/blob/fce22525f74bbd7feeb4f8b34c79a215db9a74c3/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java#L681).
    - Redpanda, on the other hand, writes a control batch from the TxnOffsetCommit handler, only writing the final offset record when the transaction commits. As a result, the same sequence of transactional and plain offset commit requests can in some cases produce a different order or records in the log.
    - We still diverge from Kafka in this respect; the ordering difference appears inherent to how we handle consumer offset transactions. But now we are self consistent. Before the fix, we could get in a situation where the order of offset updates in memory could diverge from the order of offset records in the log. 
  - **CORE-17001 (Medium)** a request that names one partition twice commits the first value in memory and the last in the log. Fix: commit only the last entry for a partition.
    - a partition repeated in one OffsetCommit request: Kafka emits one record per entry, [duplicates included](https://github.com/apache/kafka/blob/fce22525f74bbd7feeb4f8b34c79a215db9a74c3/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java#L655-L660), and applies records to memory one map-put at a time, in order, [last entry wins](https://github.com/apache/kafka/blob/fce22525f74bbd7feeb4f8b34c79a215db9a74c3/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java#L1171-L1183)
    - This works because Kafka orders offset commits by record offset, whereas Redpanda uses a batch offset. So if you have two commits for the same partition in the same batch, only the _first_ of those would be applied to the live map. However, both records would appear on disk, so a recovery operation would produce the correct map state.
    - Adopting a record-offset based scheme looks pretty hairy, so the fix just prevents replicating multiple offset commit records for a given partition ID in a single batch. The rationale being that the older of the two (or more) would be immediately overwritten by the newer anyway and ultimately compacted away.

  **Backports.** The release branches predate the `offset_store` extraction, so all three land in `group.cc` as `group::` methods there. We adapt each cherry-pick by hand.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [x] v25.3.x

## Release Notes

### Bug Fixes

* Consumer groups: Fix a bug where retention could expire a committed offset while an open transaction holds a new value for it.
* Consumer groups: Fix a bug where a plain offset commit landing while a transaction is open would temporarily overrule the eventual transaction offset commit.
* Consumer groups: Fix a bug where an OffsetCommit naming the same partition twice would lead to the in-memory store and the log to disagree on the final value.
