### PR TITLE
[v26.2.x] build/deps: upgrade c-ares to 1.34.7 (CVE-2026-33630)

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -355,7 +355,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "Vd5fleZJE/7J3DfoAyhqn6jEuL4ysbCxoJiDfu5Amcg=",
+        "bzlTransitiveDigest": "G6xiSAh5Rh3tpLdV0zGaF5o5aVrbuUY+p/jbGTTkPhU=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedInputs": [
           "REPO_MAPPING:,bazel_tools bazel_tools",
@@ -401,9 +401,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:c-ares.BUILD",
-              "sha256": "912dd7cc3b3e8a79c52fd7fb9c0f4ecf0aaa73e45efda880266a2d6e26b84ef5",
-              "strip_prefix": "c-ares-1.34.6",
-              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.6.tar.gz"
+              "sha256": "556f781dd188ad932dc8263fee0ad3aaba675b4cd8e54d86908681b43ce3e327",
+              "strip_prefix": "c-ares-1.34.7",
+              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.7.tar.gz"
             }
           },
           "hdrhistogram": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -44,9 +44,9 @@ def data_dependency():
     http_archive(
         name = "c-ares",
         build_file = "//bazel/thirdparty:c-ares.BUILD",
-        sha256 = "912dd7cc3b3e8a79c52fd7fb9c0f4ecf0aaa73e45efda880266a2d6e26b84ef5",
-        strip_prefix = "c-ares-1.34.6",
-        url = "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.6.tar.gz",
+        sha256 = "556f781dd188ad932dc8263fee0ad3aaba675b4cd8e54d86908681b43ce3e327",
+        strip_prefix = "c-ares-1.34.7",
+        url = "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.7.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31465

- Command: git cherry-pick -x 6106f9b6ff
- Commits backported: 1
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-31465-v26.2.x-1786090038

## Conflict details

- 6106f9b6ff (MODULE.bazel.lock): the `bzlTransitiveDigest` for the `non_module_dependencies` extension differs between `v26.2.x` and `dev`, so that line conflicted; took the incoming (`dev`) value per the generated-file rule. The actual c-ares 1.34.6 → 1.34.7 sha256/strip_prefix/url changes merged cleanly, as did `bazel/repositories.bzl`.

## ⚠️ Generated files

The following files were cherry-picked and may need regeneration:

- MODULE.bazel.lock

These files were accepted as-is from the source branch. Before merging,
regenerate them on the target branch to ensure they're correct. For example:
- MODULE.bazel.lock: run `bazel mod deps --lockfile_mode=update`
- *.pb.go / *.pb.cc / *.pb.h: rebuild protobuf targets
- go.sum: run `go mod tidy`
