### PR TITLE
[v26.1.x] build/deps: upgrade c-ares to 1.34.7 (CVE-2026-33630)

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -308,7 +308,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "bigwKUfn/CT2/ANBEUuaC4yqP/Vj8DFJWbSSvpwWmWk=",
+        "bzlTransitiveDigest": "s8tuS4I8QI+HLkRamy+fBze/D3qUhC5bE3ilUzQANEQ=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -350,9 +350,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:c-ares.BUILD",
-              "sha256": "912dd7cc3b3e8a79c52fd7fb9c0f4ecf0aaa73e45efda880266a2d6e26b84ef5",
-              "strip_prefix": "c-ares-1.34.6",
-              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.6.tar.gz"
+              "sha256": "556f781dd188ad932dc8263fee0ad3aaba675b4cd8e54d86908681b43ce3e327",
+              "strip_prefix": "c-ares-1.34.7",
+              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.7.tar.gz"
             }
           },
           "hdrhistogram": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -40,9 +40,9 @@ def data_dependency():
     http_archive(
         name = "c-ares",
         build_file = "//bazel/thirdparty:c-ares.BUILD",
-        sha256 = "912dd7cc3b3e8a79c52fd7fb9c0f4ecf0aaa73e45efda880266a2d6e26b84ef5",
-        strip_prefix = "c-ares-1.34.6",
-        url = "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.6.tar.gz",
+        sha256 = "556f781dd188ad932dc8263fee0ad3aaba675b4cd8e54d86908681b43ce3e327",
+        strip_prefix = "c-ares-1.34.7",
+        url = "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.7.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31465

- Command: git cherry-pick -x 6106f9b6ff
- Commits backported: 1
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-31465-v26.1.x-1786090013

## Conflict details

- 6106f9b6ff (MODULE.bazel.lock): the lockfile diverges heavily between `dev` and
  `v26.1.x` (different pinned versions of abseil-cpp, fmt, liburing, rules_cc,
  rules_foreign_cc, bazel_skylib, plus `single_version_override` patches that only
  exist on `dev`), so taking the incoming file wholesale would have replaced the
  release branch's dependency graph with `dev`'s (~4400 lines changed). Resolved by
  keeping the `v26.1.x` lockfile and applying only the commit's intent: the `c-ares`
  `sha256`, `strip_prefix` and `url` attributes bumped 1.34.6 -> 1.34.7. The
  commit's `bzlTransitiveDigest` change was deliberately not carried over, since
  that digest is computed from this branch's own extension inputs.
- `bazel/repositories.bzl` merged cleanly and carries the same 1.34.6 -> 1.34.7 pin.

The resulting backport is a minimal 6-insertion / 6-deletion change across the two
files, matching the upstream commit's intent.

## ⚠️ Generated files

The following files were cherry-picked and may need regeneration:

- MODULE.bazel.lock

These files were accepted as-is from the source branch. Before merging,
regenerate them on the target branch to ensure they're correct. For example:
- MODULE.bazel.lock: run `bazel mod deps --lockfile_mode=update`
- *.pb.go / *.pb.cc / *.pb.h: rebuild protobuf targets
- go.sum: run `go mod tidy`

Note: `MODULE.bazel.lock` was hand-edited rather than taken from the source branch
(see conflict details above). The `//bazel:extensions.bzl%non_module_dependencies`
`bzlTransitiveDigest` entry is now stale on this branch and must be refreshed by
running `bazel mod deps --lockfile_mode=update` on `v26.1.x` and committing the
result before merge.
