### PR TITLE
[v25.3.x] deps: bump go to 1.26.5 in rpk and tools

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -218,20 +218,20 @@ COMPILERS = {
 # Go Toolchain
 # ====================================
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk", dev_dependency = True)
-go_sdk.download(version = "1.25.7")
+go_sdk.download(version = "1.26.5")
 
 # The microsoft compiler versions can be listed at their github release under the `asset.json` file
 go_sdk.download(
     name = "go_sdk_with_systemcrypto",
     experiments = ["systemcrypto"],
     sdks = {
-        "linux_amd64": ("b6ae036e2c246d52bd15d5300994c8ee/go1.25.7-20260204.4.linux-amd64.tar.gz", "328b235ebd36ddc92c852b6d25b01d8e9478c2779bbbac3c8964890118a8aa6f"),
-        "linux_arm64": ("218094e73bfc123b8065805487bd52fa/go1.25.7-20260204.4.linux-arm64.tar.gz", "73c5ffdedf6cf5ec57eb2478a64ab50a363e17cb1f53e37049d4a42b2886f939"),
-        "darwin_amd64": ("16503ff2f5ff30261b0602f647300571/go1.25.7-20260204.4.darwin-amd64.tar.gz", "3cca680b5619449e436a15e4d799d6ae3c4e79616637b4c6fadc0b186df8e61a"),
-        "darwin_arm64": ("cda77c95a10a9e64d75094d1cdc79d03/go1.25.7-20260204.4.darwin-arm64.tar.gz", "e8ebdd66099a1e216adb643355f040416cd27077c2215681f9e7419d98266679"),
+        "linux_amd64": ("96d1f4b28a670f8e9b3259194508ae2f/go1.26.5-20260709.6.linux-amd64.tar.gz", "df9f45167cf1cd825aa8555b76c5b24cb89dfbd771f48cc0007458236c414715"),
+        "linux_arm64": ("af17683a03acab86aec9ba37afbd5ff1/go1.26.5-20260709.6.linux-arm64.tar.gz", "9990f8fcfefcbd15fb888dd777c7a72f1745889c9e94836ffe26f7e46e43328d"),
+        "darwin_amd64": ("d45676061dfccb09b72f2579a6d8927f/go1.26.5-20260709.6.darwin-amd64.tar.gz", "7a4f0bd26ccf1ce912bc509fccb473ee39bdd149b804fa581e59a72b7708e78e"),
+        "darwin_arm64": ("f8da58db7007fa456d93c4f56bf6c337/go1.26.5-20260709.6.darwin-arm64.tar.gz", "a6d2124035c18602926af78d1e3ae523abc613e36b2086da9b451991ce4288c4"),
     },
-    urls = ["https://download.visualstudio.microsoft.com/download/pr/39e12277-1463-47e4-9f91-f71f8c450c61/{}"],
-    version = "1.25.7",
+    urls = ["https://download.visualstudio.microsoft.com/download/pr/a38f1e38-3cd4-48b2-b032-ca38793ec901/{}"],
+    version = "1.26.5",
 )
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")

--- a/bazel/thirdparty/go.work
+++ b/bazel/thirdparty/go.work
@@ -1,5 +1,5 @@
 // This should match what is listed in MODULE.bazel
-go 1.25.7
+go 1.26.5
 
 // Everything we build with Bazel goes here.
 use (

--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda/src/go/rpk
 
-go 1.25.7
+go 1.26.5
 
 // add the git commit hash as the target version and `go mod tidy` will transform it into pseudo-version
 replace github.com/hamba/avro/v2 => github.com/redpanda-data/go-avro/v2 v2.0.0-20240405204525-77b1144dc525

--- a/src/v/test_utils/go/go.mod
+++ b/src/v/test_utils/go/go.mod
@@ -1,6 +1,6 @@
 module redpanda-test-utils
 
-go 1.25.7
+go 1.26.5
 
 require (
 	github.com/kr/pretty v0.3.1

--- a/tools/go-comment-pbgen/go.mod
+++ b/tools/go-comment-pbgen/go.mod
@@ -1,5 +1,5 @@
 module github.com/redpanda-data/redpanda/tools/go-comment-pbgen
 
-go 1.21
+go 1.26.5
 
 require google.golang.org/protobuf v1.36.3


### PR DESCRIPTION
Backport of PR #31102

v25.3.x was on Go 1.25.7, below the patched release for CVE-2026-39822
(os.Root symlink escape via trailing slash on Unix; fixed upstream in
1.25.12 / 1.26.5 / 1.27.0-rc.2). This bumps to 1.26.5 to match
dev/v26.1.x/v26.2.x rather than the minimal 1.25.12, since dev has
already moved to 1.26.5 and there's no reason to diverge.

Verified: `bazel build //:rpk` and `//src/v/test_utils/go/...` succeed;
built rpk binary reports `go1.26.5`; `bazel test //src/go/rpk/...`
(45 tests) all pass.

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport

## Release Notes

### Bug Fixes

* Upgraded Go toolchain to 1.26.5 to address CVE-2026-39822 (os.Root symlink escape).