### PR TITLE
[v25.3.x] bazel: update seastar to 085388fb07 (CVE-2026-33630)

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -303,7 +303,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "RTdD4rZEtPyLu37STAMANRmaS7AHLH+ZCOiJrZib6gY=",
+        "bzlTransitiveDigest": "7H4VLTieQdBj4Au+UM/Rbh8F7/sdshXLpJ8qypbpmPE=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -484,9 +484,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "deca5a8ff31cc35e8e2e5e832bfbc5bc7587cbdf0d79f7485709fd2ccf38a7b2",
-              "strip_prefix": "seastar-3e8c2be009921b9ceda058d5eb959c9a923656fa",
-              "url": "https://github.com/redpanda-data/seastar/archive/3e8c2be009921b9ceda058d5eb959c9a923656fa.tar.gz"
+              "sha256": "a7b336577124edd8e4cededa4bc58dedb349ed4748e87708a87e0cc3849120e9",
+              "strip_prefix": "seastar-085388fb07a83a6b5cc768f66e416c7331e3c0b0",
+              "url": "https://github.com/redpanda-data/seastar/archive/085388fb07a83a6b5cc768f66e416c7331e3c0b0.tar.gz"
             }
           },
           "unordered_dense": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -173,9 +173,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "deca5a8ff31cc35e8e2e5e832bfbc5bc7587cbdf0d79f7485709fd2ccf38a7b2",
-        strip_prefix = "seastar-3e8c2be009921b9ceda058d5eb959c9a923656fa",
-        url = "https://github.com/redpanda-data/seastar/archive/3e8c2be009921b9ceda058d5eb959c9a923656fa.tar.gz",
+        sha256 = "a7b336577124edd8e4cededa4bc58dedb349ed4748e87708a87e0cc3849120e9",
+        strip_prefix = "seastar-085388fb07a83a6b5cc768f66e416c7331e3c0b0",
+        url = "https://github.com/redpanda-data/seastar/archive/085388fb07a83a6b5cc768f66e416c7331e3c0b0.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Bumps the Seastar pin on this branch to pick up
redpanda-data/seastar#305 (cherry-pick of df311aa0acef00e896deeee6f209c64150d35427,
"dns: fix build with c-ares 1.34.7 constified host callback").

Needed as a prerequisite for the c-ares 1.34.7 CVE-2026-33630 backport
(#31485) — without it, `@seastar//:seastar` fails to compile against
c-ares 1.34.7 (`ares_gethostbyaddr`'s callback signature changed).

Verified locally: `bazel build @seastar//:seastar` succeeds with c-ares
1.34.7 + this pin.

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none