### PR TITLE
[v26.1.x] bazel: update seastar to a083b5b341 (CVE-2026-33630)

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -308,7 +308,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "5jE6ejfL2UCG2Mt6HfVupqd7XrryafHYrY7Gr1UG6uo=",
+        "bzlTransitiveDigest": "bigwKUfn/CT2/ANBEUuaC4yqP/Vj8DFJWbSSvpwWmWk=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -489,9 +489,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "f70e14b181db809d885d610b908162bebaa03a9083468fd1033a2a527a738e70",
-              "strip_prefix": "seastar-2417f85e750051932dd2161294516dca27640a87",
-              "url": "https://github.com/redpanda-data/seastar/archive/2417f85e750051932dd2161294516dca27640a87.tar.gz"
+              "sha256": "50117172aee5700e2ec46f873bff7f566295df5c45aca58f7d20066d95978aae",
+              "strip_prefix": "seastar-a083b5b341c28ffad81df5fec167187ed1a12942",
+              "url": "https://github.com/redpanda-data/seastar/archive/a083b5b341c28ffad81df5fec167187ed1a12942.tar.gz"
             }
           },
           "unordered_dense": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -174,9 +174,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "f70e14b181db809d885d610b908162bebaa03a9083468fd1033a2a527a738e70",
-        strip_prefix = "seastar-2417f85e750051932dd2161294516dca27640a87",
-        url = "https://github.com/redpanda-data/seastar/archive/2417f85e750051932dd2161294516dca27640a87.tar.gz",
+        sha256 = "50117172aee5700e2ec46f873bff7f566295df5c45aca58f7d20066d95978aae",
+        strip_prefix = "seastar-a083b5b341c28ffad81df5fec167187ed1a12942",
+        url = "https://github.com/redpanda-data/seastar/archive/a083b5b341c28ffad81df5fec167187ed1a12942.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Bumps the Seastar pin on this branch to pick up
redpanda-data/seastar#306 (cherry-pick of df311aa0acef00e896deeee6f209c64150d35427,
"dns: fix build with c-ares 1.34.7 constified host callback").

Needed as a prerequisite for the c-ares 1.34.7 CVE-2026-33630 backport
(#31486) — without it, `@seastar//:seastar` fails to compile against
c-ares 1.34.7 (`ares_gethostbyaddr`'s callback signature changed).

Verified locally: `bazel build @seastar//:seastar` succeeds with c-ares
1.34.7 + this pin.

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none