### PR TITLE
ct: track seen-window bumps as pending until observed in the log

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -822,10 +822,12 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
       batch_id, std::move(placeholders.batches.front()), opts);
     // Once the request is enqueued in raft and our order is guaranteed we can
     // release our ticket and further requests can be enqueued into the raft
-    // layer.
+    // layer. The fence units are released as well: the batch position in the
+    // raft queue is fixed so the batch can't be reordered anymore.
     auto enqueued_fut = co_await ss::coroutine::as_future(
       std::move(replicate_stages.request_enqueued));
 
+    fence->unit.return_all();
     ticket.release(); // always release the ticket
 
     if (enqueued_fut.failed()) {

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -458,6 +458,44 @@ ss::future<iobuf> ctp_stm::take_raft_snapshot(model::offset snapshot_at) {
       ctp_stm_snapshot{.state = _state, .checker = _epoch_checker});
 }
 
+ss::future<> ctp_stm::maybe_recover_stuck_bump(
+  model::term_id term,
+  model::timeout_clock::time_point wait_start,
+  cluster_epoch observed_bump) {
+    if (model::timeout_clock::now() - wait_start < _stuck_bump_min_wait) {
+        co_return;
+    }
+    if (_raft->term() != term || !_raft->is_leader()) {
+        co_return;
+    }
+    if (
+      !_state.has_pending_seen_bump(term)
+      || _state.get_max_seen_epoch(term) != observed_bump) {
+        // The bump resolved or a new one started: progress is being made.
+        co_return;
+    }
+    vlog(
+      _log.warn,
+      "The seen-window bump to epoch {} is unresolved and blocks admission, "
+      "giving up the leadership to restart the window from the applied state",
+      observed_bump);
+    try {
+        // Prefer a graceful transfer: it elects the new leader immediately
+        // instead of waiting out election timeouts.
+        auto reply = co_await _raft->transfer_leadership(
+          raft::transfer_leadership_request{.group = _raft->group()});
+        if (!reply.success) {
+            co_await _raft->step_down_in_term(
+              term, "ctp seen-window bump unresolved");
+        }
+    } catch (...) {
+        vlog(
+          _log.debug,
+          "Failed to give up leadership: {}",
+          std::current_exception());
+    }
+}
+
 ss::future<std::expected<cluster_epoch_fence, stale_cluster_epoch>>
 ctp_stm::fence_epoch(cluster_epoch e, model::timeout_clock::duration timeout) {
     auto holder = _gate.hold();
@@ -473,7 +511,10 @@ ctp_stm::fence_epoch(cluster_epoch e, model::timeout_clock::duration timeout) {
         throw ss::timed_out_error{};
     }
     auto term = _raft->confirmed_term();
-    auto deadline = model::timeout_clock::now() + timeout;
+    auto wait_start = model::timeout_clock::now();
+    auto deadline = wait_start + timeout;
+    // The pending bump this request first found itself blocked on, if any.
+    std::optional<cluster_epoch> observed_bump;
     while (true) {
         if (_state.epoch_in_window(term, e)) {
             // Case 1.1. Same epoch, need to acquire read-lock.
@@ -492,10 +533,25 @@ ctp_stm::fence_epoch(cluster_epoch e, model::timeout_clock::duration timeout) {
                 // Someone else is updating the epoch, or an earlier bump is
                 // not resolved yet (its batch has not been observed by the
                 // apply loop) - wait and re-check.
+                if (
+                  !observed_bump.has_value()
+                  && _state.has_pending_seen_bump(term)) {
+                    observed_bump = _state.get_max_seen_epoch(term);
+                }
                 epoch_update_lock.reset();
+                bool timed_out = false;
                 try {
                     co_await _epoch_updated_cv.wait(deadline);
                 } catch (const ss::condition_variable_timed_out&) {
+                    timed_out = true;
+                }
+                if (timed_out) {
+                    // We spent the whole deadline blocked; if it was on a
+                    // single unresolved bump the partition may be wedged.
+                    if (observed_bump.has_value()) {
+                        co_await maybe_recover_stuck_bump(
+                          term, wait_start, *observed_bump);
+                    }
                     // Translate to the timeout error the fence_epoch
                     // callers handle (mapped to a retryable produce error).
                     throw ss::timed_out_error{};

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -500,8 +500,9 @@ ctp_stm::fence_epoch(cluster_epoch e, model::timeout_clock::duration timeout) {
               || _state.epoch_above_window(term, e)) {
                 vlog(_log.debug, "Bumping max seen epoch to {}", e);
                 _state.advance_max_seen_epoch(term, e);
-                // Demote to reader lock after max_seen_epoch is updated.
-                unit.return_units(unit.count() - 1);
+                // The fence keeps the full write lock; the caller releases
+                // the units when the batch is enqueued into raft and its
+                // position in the queue is fixed.
                 epoch_fence_opt.emplace(std::move(unit), term);
             }
 

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -357,6 +357,8 @@ void ctp_stm::apply_advance_epoch(
     vlog(_log.debug, "Advancing epoch: {}", cmd.new_epoch);
     _epoch_checker.check_epoch(ntp(), cmd.new_epoch, base_offset);
     _state.advance_epoch(cmd.new_epoch, base_offset);
+    // A pending seen-window bump may have resolved.
+    _epoch_updated_cv.broadcast();
 }
 
 void ctp_stm::apply_reset_state(model::record record) {
@@ -385,6 +387,8 @@ void ctp_stm::apply_placeholder(const model::record_batch& batch) {
     auto id = placeholder.id;
     _epoch_checker.check_epoch(ntp(), id.epoch, batch.header().base_offset);
     _state.advance_epoch(id.epoch, batch.header().base_offset);
+    // A pending seen-window bump may have resolved.
+    _epoch_updated_cv.broadcast();
     _state.record_placeholder_size(
       batch.header().base_offset,
       static_cast<uint64_t>(placeholder.size_bytes));
@@ -469,6 +473,7 @@ ctp_stm::fence_epoch(cluster_epoch e, model::timeout_clock::duration timeout) {
         throw ss::timed_out_error{};
     }
     auto term = _raft->confirmed_term();
+    auto deadline = model::timeout_clock::now() + timeout;
     while (true) {
         if (_state.epoch_in_window(term, e)) {
             // Case 1.1. Same epoch, need to acquire read-lock.
@@ -483,10 +488,18 @@ ctp_stm::fence_epoch(cluster_epoch e, model::timeout_clock::duration timeout) {
         } else if (_state.epoch_above_window(term, e)) {
             // Case 2. New epoch, need to acquire write-lock.
             auto epoch_update_lock = _epoch_update_lock.try_get_units();
-            if (!epoch_update_lock) {
-                // Someone else is updating the epoch - wait for the update and
-                // then re-check.
-                co_await _epoch_updated_cv.wait();
+            if (!epoch_update_lock || _state.has_pending_seen_bump(term)) {
+                // Someone else is updating the epoch, or an earlier bump is
+                // not resolved yet (its batch has not been observed by the
+                // apply loop) - wait and re-check.
+                epoch_update_lock.reset();
+                try {
+                    co_await _epoch_updated_cv.wait(deadline);
+                } catch (const ss::condition_variable_timed_out&) {
+                    // Translate to the timeout error the fence_epoch
+                    // callers handle (mapped to a retryable produce error).
+                    throw ss::timed_out_error{};
+                }
                 continue;
             }
 
@@ -499,10 +512,10 @@ ctp_stm::fence_epoch(cluster_epoch e, model::timeout_clock::duration timeout) {
               _state.epoch_in_window(term, e)
               || _state.epoch_above_window(term, e)) {
                 vlog(_log.debug, "Bumping max seen epoch to {}", e);
+                // Records the bump as pending; the admission window only
+                // widens when the apply loop observes the bump batch (see
+                // ctp_stm_state).
                 _state.advance_max_seen_epoch(term, e);
-                // The fence keeps the full write lock; the caller releases
-                // the units when the batch is enqueued into raft and its
-                // position in the queue is fixed.
                 epoch_fence_opt.emplace(std::move(unit), term);
             }
 
@@ -519,11 +532,8 @@ ctp_stm::fence_epoch(cluster_epoch e, model::timeout_clock::duration timeout) {
         // If we reach here, it means that we need to discard the batch.
         co_return std::unexpected(
           stale_cluster_epoch{
-            .window_min = _state.get_previous_seen_epoch(term)
-                            .or_else([this] {
-                                return _state.get_previous_applied_epoch();
-                            })
-                            .value_or(cluster_epoch{-1}),
+            .window_min = _state.get_previous_applied_epoch().value_or(
+              cluster_epoch{-1}),
             .window_max = _state.get_max_seen_epoch(term)
                             .or_else(
                               [this] { return _state.get_max_applied_epoch(); })

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -127,6 +127,7 @@ public:
 
 private:
     ss::future<> do_apply(const model::record_batch&) override;
+
     void apply_placeholder(const model::record_batch&);
     void apply_advance_reconciled_offset(model::record);
     void apply_set_start_offset(model::record);

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -62,6 +62,14 @@ class ctp_stm final : public raft::persisted_stm<> {
 
     static constexpr auto sync_timeout = std::chrono::seconds(10);
 
+    /// Minimum time a fence attempt must be blocked on the same unresolved
+    /// seen-window bump before it gives up the leadership. Must not exceed
+    /// ctp_stm_api::default_fence_epoch_timeout: the housekeeper epoch
+    /// advance is the recovery trigger on partitions with no produce
+    /// traffic.
+    static constexpr auto default_stuck_bump_min_wait = std::chrono::seconds(
+      10);
+
 public:
     static constexpr const char* name = "ctp_stm";
 
@@ -128,6 +136,16 @@ public:
 private:
     ss::future<> do_apply(const model::record_batch&) override;
 
+    /// Give up the leadership if a fence attempt spent at least
+    /// _stuck_bump_min_wait blocked on the same unresolved seen-window
+    /// bump: nothing can resolve it anymore and only a new term (which
+    /// restarts the admission window from the applied state) can unblock
+    /// the partition.
+    ss::future<> maybe_recover_stuck_bump(
+      model::term_id term,
+      model::timeout_clock::time_point wait_start,
+      cluster_epoch observed_bump);
+
     void apply_placeholder(const model::record_batch&);
     void apply_advance_reconciled_offset(model::record);
     void apply_set_start_offset(model::record);
@@ -179,6 +197,10 @@ private:
     // updated by the holder of `_epoch_update_lock` (it is possible that the
     // lock holder may fail to update the epoch).
     ss::condition_variable _epoch_updated_cv;
+
+    /// Recovery floor for maybe_recover_stuck_bump, overridable in tests.
+    std::chrono::milliseconds _stuck_bump_min_wait
+      = default_stuck_bump_min_wait;
 
     /// Current in-memory state of the STM
     ctp_stm_state _state;

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
@@ -13,20 +13,45 @@
 #include "model/fundamental.h"
 #include "utils/to_string.h"
 
+#include <algorithm>
+
 namespace cloud_topics {
 
 void ctp_stm_state::advance_max_seen_epoch(
   model::term_id term, cluster_epoch epoch) noexcept {
-    if (term >= _seen_window_term && epoch > _max_seen_epoch) {
-        if (term > _seen_window_term) {
-            // If this is a new term, reset the window.
-            _previous_seen_epoch = epoch;
-            _seen_window_term = term;
-        } else {
-            _previous_seen_epoch = _max_seen_epoch.value_or(epoch);
-        }
-        _max_seen_epoch = epoch;
+    if (term < _seen_window_term) {
+        return;
     }
+    if (term > _seen_window_term) {
+        // New term: drop a bump left over from a previous term. The
+        // admission window is the applied window which is always current.
+        _seen_window_term = term;
+        _max_seen_epoch.reset();
+    }
+    if (has_pending_seen_bump(term)) {
+        // An unresolved bump can never be overwritten: that would allow two
+        // outstanding bump batches whose landing order is not constrained,
+        // and only one of them can be accounted for by the admission rules.
+        // The caller (fence_epoch) serializes bumps and waits for the
+        // pending one to resolve, so this is a defensive no-op.
+        return;
+    }
+    if (epoch <= _max_applied_epoch.value_or(cluster_epoch::min())) {
+        return;
+    }
+    // The admission window is not widened here: the bump stays pending
+    // until the apply loop observes a batch with this (or a higher) epoch
+    // and the applied window catches up.
+    _max_seen_epoch = epoch;
+}
+
+bool ctp_stm_state::has_pending_seen_bump(model::term_id term) const noexcept {
+    if (term > _seen_window_term) {
+        return false;
+    }
+    return _max_seen_epoch.has_value()
+           && *_max_seen_epoch
+                > _max_applied_epoch.value_or(cluster_epoch::min());
 }
 
 std::optional<kafka::offset>
@@ -54,71 +79,33 @@ ctp_stm_state::get_previous_applied_epoch() const noexcept {
     return _previous_applied_epoch;
 }
 
-std::optional<cluster_epoch>
-ctp_stm_state::get_previous_seen_epoch(model::term_id term) const noexcept {
-    if (term > _seen_window_term) {
-        return std::nullopt;
-    }
-    return _previous_seen_epoch;
-}
-
 bool ctp_stm_state::epoch_in_window(
   model::term_id term, cluster_epoch epoch) const noexcept {
-    // If the term is newer then treat the window as unset.
-    if (term > _seen_window_term) {
-        auto end = _max_applied_epoch.value_or(cluster_epoch::min());
-        auto begin = _previous_applied_epoch.value_or(end);
-        return epoch >= begin && epoch <= end;
+    if (has_pending_seen_bump(term)) {
+        // The bump outcome is ambiguous; admit only epochs that are safe
+        // whether the bump batch lands or not: the current max, and the
+        // pending epoch itself (its batch resolves the ambiguity when it
+        // lands, so a retry of a failed bump self-heals the window).
+        if (epoch == *_max_seen_epoch) {
+            return true;
+        }
+        return _max_applied_epoch.has_value() && epoch == *_max_applied_epoch;
     }
-    // NOTE: the window should move forward with _max_seen_epoch.
-    // If _max_seen_epoch is greater than _max_applied_epoch then
-    // the window should be [_previous_seen_epoch, _max_seen_epoch].
-    // The window reflects in-flight requests. Write fence is required
-    // to move it forward.
-    auto end = _max_seen_epoch.value_or(
-      _max_applied_epoch.value_or(cluster_epoch::min()));
-    auto begin = _previous_seen_epoch.value_or(
-      _previous_applied_epoch.value_or(end));
-    if (epoch < begin || epoch > end) {
-        return false;
-    }
-    if (epoch == end) {
-        return true;
-    }
-    // A below-max epoch is only admissible if some epoch batch is known to
-    // precede the max-seen epoch's first batch in the log. The seen window
-    // alone can't prove this: a fence-time bump whose batch never lands (a
-    // failed replicate) leaves a lower bound with no counterpart in the log.
-    // If nothing precedes the max epoch's first batch, the log epoch window
-    // collapses to [max, max] when that batch applies, and a below-max batch
-    // landing after it violates the log invariant enforced by
-    // epoch_window_checker and may reference L0 objects the GC already
-    // considers inactive.
-    //
-    // Applied state gives positional evidence, since apply follows log order:
-    // - _max_applied_epoch < end: an applied batch sits at a lower log
-    //   position than any batch at the max-seen epoch (applied or not).
-    // - _max_applied_epoch == end: the max epoch applied; a batch preceded it
-    //   iff the applied window did not collapse to [end, end].
-    if (!_max_applied_epoch.has_value()) {
-        return false;
-    }
-    if (*_max_applied_epoch < end) {
-        return true;
-    }
-    return *_max_applied_epoch == end
-           && _previous_applied_epoch.value_or(end) < end;
+    // No bump is pending: every epoch admitted so far has been observed by
+    // the apply loop, so the applied window is backed by positional
+    // evidence in the log and every epoch in it can be replicated safely
+    // in any order.
+    auto end = _max_applied_epoch.value_or(cluster_epoch::min());
+    auto begin = _previous_applied_epoch.value_or(end);
+    return epoch >= begin && epoch <= end;
 }
 
 bool ctp_stm_state::epoch_above_window(
   model::term_id term, cluster_epoch epoch) const noexcept {
-    // If the term changed, treat it as unset.
-    if (term > _seen_window_term) {
-        auto end = _max_applied_epoch.value_or(cluster_epoch::min());
-        return epoch > end;
+    auto end = _max_applied_epoch.value_or(cluster_epoch::min());
+    if (term <= _seen_window_term && _max_seen_epoch.has_value()) {
+        end = std::max(end, *_max_seen_epoch);
     }
-    auto end = _max_seen_epoch.value_or(
-      _max_applied_epoch.value_or(cluster_epoch::min()));
     return epoch > end;
 }
 
@@ -128,6 +115,9 @@ ctp_stm_state::estimate_inactive_epoch() const noexcept {
 }
 
 void ctp_stm_state::advance_epoch(cluster_epoch epoch, model::offset offset) {
+    // NOTE: a pending seen-window bump resolves implicitly here: once the
+    // applied window catches up with _max_seen_epoch the bump is backed by
+    // a batch in the log and the ambiguity is gone.
     // Register new epoch
     if (epoch > _max_applied_epoch.value_or(cluster_epoch::min())) {
         // A new max epoch requires the sliding window of epoch values in flight
@@ -172,7 +162,15 @@ ctp_stm_state::get_max_seen_epoch(model::term_id term) const noexcept {
     if (term > _seen_window_term) {
         return std::nullopt;
     }
-    return _max_seen_epoch;
+    // This value is used as the epoch floor for new L0 uploads. It includes
+    // a pending bump: uploads taken at the pending epoch are admissible
+    // while the bump is unresolved (uploads at an interior epoch would be
+    // rejected by the fence).
+    if (_max_seen_epoch.has_value()) {
+        return std::max(
+          *_max_seen_epoch, _max_applied_epoch.value_or(*_max_seen_epoch));
+    }
+    return _max_applied_epoch;
 }
 
 model::offset ctp_stm_state::get_max_collectible_offset() const noexcept {
@@ -224,10 +222,9 @@ kafka::offset ctp_stm_state::get_min_allowed_local_threshold() const noexcept {
 fmt::iterator ctp_stm_state::format_to(fmt::iterator it) const {
     return fmt::format_to(
       it,
-      "{{seen_window=[{}, {}], applied_window=[{}, {}], "
+      "{{max_seen_epoch={}, applied_window=[{}, {}], "
       "epoch_window_offset={}, min_epoch_lower_bound={}, lro={}, lrlo={}, "
       "start_offset={}}}",
-      _previous_seen_epoch,
       _max_seen_epoch,
       _previous_applied_epoch,
       _max_applied_epoch,

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
@@ -48,9 +48,16 @@ public:
     void advance_epoch(cluster_epoch epoch, model::offset offset);
 
     /// This is invoked in the write path before the batch with new
-    /// epoch value is even replicated.
+    /// epoch value is even replicated. Records the epoch as a pending
+    /// window bump (see _max_seen_epoch). Must not be called while another
+    /// bump is pending in the same term (the caller serializes bumps and
+    /// waits for resolution).
     void
     advance_max_seen_epoch(model::term_id term, cluster_epoch epoch) noexcept;
+
+    /// Return true if there is an unresolved seen-window bump in this term:
+    /// the max seen epoch is ahead of the max applied epoch.
+    bool has_pending_seen_bump(model::term_id term) const noexcept;
 
     // Set the new start offset for the partition.
     //
@@ -85,10 +92,6 @@ public:
     /// \return max_seen_epoch epoch.
     std::optional<cluster_epoch>
     get_max_seen_epoch(model::term_id term) const noexcept;
-
-    /// Return the previous_seen_epoch epoch.
-    std::optional<cluster_epoch>
-      get_previous_seen_epoch(model::term_id) const noexcept;
 
     /// Estimate the minimum epoch referenced by this ctp_stm.
     /// \note This value might be stale.
@@ -172,24 +175,24 @@ public:
     fmt::iterator format_to(fmt::iterator) const;
 
 private:
-    /// The term at which the *_seen_epochs are for, due to the sliding window
-    /// having the ability to diverge, we only track it within a single term,
-    /// then reset the window to avoid nasty edge cases when leadership changes.
+    /// The term _max_seen_epoch is valid for. A bump left over from a
+    /// previous term is ignored (and dropped by the next bump): the
+    /// admission window is the applied window, which is always current.
     model::term_id _seen_window_term;
+
     /// The max epoch after the current in flight requests are applied.
     ///
-    /// This is required because of the pipelining of requests in the STM.
-    /// If present, we don't allow any replicated requests to have an epoch
-    /// that is lower than this value.
-    std::optional<cluster_epoch> _max_seen_epoch;
-
-    /// The previous epoch after the current in flight requests are applied.
-    /// Requests with epochs below this value are fenced and not allowed to be
-    /// applied to the STM.
+    /// It is larger than _max_applied_epoch while the batch that carries it
+    /// is in flight: this is an unresolved (pending) window bump whose
+    /// outcome is ambiguous - the batch may land, fail, or land after its
+    /// replication is reported failed, and the bump can't be rolled back.
+    /// While the bump is pending only epochs that are safe under both
+    /// outcomes are admissible (see epoch_in_window). The bump resolves
+    /// implicitly when the applied window catches up.
     ///
     /// Not persisted with the snapshot because it reflects the state of
-    /// in-flight requests.
-    std::optional<cluster_epoch> _previous_seen_epoch;
+    /// in-flight requests (leader-side, term-scoped state).
+    std::optional<cluster_epoch> _max_seen_epoch;
 
     /// The maximum epoch of applied batches to the STM.
     ///

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
@@ -42,9 +42,19 @@ TEST(ctp_stm_state_test, advance_max_seen_epoch) {
 
     state.advance_max_seen_epoch(term, epoch1);
     EXPECT_EQ(state.get_max_seen_epoch(term).value(), epoch1);
+    EXPECT_TRUE(state.has_pending_seen_bump(term));
 
+    // An unresolved bump can't be overwritten by a higher epoch.
+    state.advance_max_seen_epoch(term, epoch2);
+    EXPECT_EQ(state.get_max_seen_epoch(term).value(), epoch1);
+
+    // The bump resolves when its batch is applied; then the next bump can
+    // start.
+    state.advance_epoch(epoch1, model::offset{0});
+    EXPECT_FALSE(state.has_pending_seen_bump(term));
     state.advance_max_seen_epoch(term, epoch2);
     EXPECT_EQ(state.get_max_seen_epoch(term).value(), epoch2);
+    state.advance_epoch(epoch2, model::offset{1});
 
     // Should not go backwards
     state.advance_max_seen_epoch(term, epoch3);
@@ -231,15 +241,16 @@ TEST(ctp_stm_state_test, sliding_window_issue) {
 
     EXPECT_FALSE(state.epoch_in_window(term, 5_epoch));
 
-    // Epoch is bumped, our window should now be [2, 5]
+    // Epoch is bumped; the bump is pending until its batch applies
     state.advance_max_seen_epoch(term, 5_epoch);
 
     // This is our new epoch
     EXPECT_TRUE(state.epoch_in_window(term, 5_epoch));
     // Our previous epoch is good still
     EXPECT_TRUE(state.epoch_in_window(term, 2_epoch));
-    // And so is something in between (unlikely in real life, but just to show)
-    EXPECT_TRUE(state.epoch_in_window(term, 3_epoch));
+    // An epoch in between is not admissible while the bump is pending: its
+    // safety depends on the fate of the epoch-5 batch
+    EXPECT_FALSE(state.epoch_in_window(term, 3_epoch));
     // Something below is still bad
     EXPECT_FALSE(state.epoch_in_window(term, 1_epoch));
 
@@ -260,7 +271,8 @@ TEST(ctp_stm_state_test, sliding_window_issue) {
     state.advance_max_seen_epoch(term, 10_epoch);
     EXPECT_TRUE(state.epoch_in_window(term, 10_epoch));
     EXPECT_TRUE(state.epoch_in_window(term, 5_epoch));
-    EXPECT_TRUE(state.epoch_in_window(term, 8_epoch));
+    // Interior epochs wait for the bump to resolve
+    EXPECT_FALSE(state.epoch_in_window(term, 8_epoch));
     EXPECT_FALSE(state.epoch_in_window(term, 0_epoch));
     EXPECT_FALSE(state.epoch_in_window(term, 4_epoch));
 
@@ -278,7 +290,8 @@ TEST(ctp_stm_state_test, sliding_window_issue) {
     state.advance_max_seen_epoch(term, 15_epoch);
     EXPECT_TRUE(state.epoch_in_window(term, 10_epoch));
     EXPECT_TRUE(state.epoch_in_window(term, 15_epoch));
-    EXPECT_TRUE(state.epoch_in_window(term, 12_epoch));
+    // Interior epochs wait for the bump to resolve
+    EXPECT_FALSE(state.epoch_in_window(term, 12_epoch));
     EXPECT_FALSE(state.epoch_in_window(term, 9_epoch));
 
     EXPECT_EQ(estimate_inactive_epoch(), 4_epoch);
@@ -295,29 +308,45 @@ TEST(ctp_stm_state_test, sliding_window_issue) {
     EXPECT_EQ(estimate_inactive_epoch(), 9_epoch);
 }
 
-TEST(ctp_stm_state_test, below_max_fence_requires_applied_evidence) {
-    // A fenced epoch bump whose batch never lands leaves a phantom lower
-    // bound in the seen window. Admitting a below-max epoch is only sound if
-    // some epoch batch is known to precede the max-seen epoch's first batch
-    // in the log; otherwise the log's epoch window collapses to [max, max]
-    // when the max applies and the below-max batch violates it.
+TEST(ctp_stm_state_test, pending_bump_restricts_admission) {
+    // A fenced epoch bump whose batch has not landed yet is ambiguous: the
+    // window may become [old-max, bump] or stay as it was. While the bump
+    // is pending only epochs that are safe under both outcomes (the old max
+    // and the bump epoch itself) are admissible.
     ct::ctp_stm_state state;
     model::term_id term(1);
 
-    // Two fence-time bumps, no batch lands for either.
+    // First bump on an empty state: the old window is empty so only the
+    // pending epoch itself is admissible.
     state.advance_max_seen_epoch(term, 132_epoch);
+    EXPECT_TRUE(state.has_pending_seen_bump(term));
+    EXPECT_TRUE(state.epoch_in_window(term, 132_epoch));
+    EXPECT_FALSE(state.epoch_in_window(term, 131_epoch));
+    EXPECT_FALSE(state.epoch_in_window(term, 133_epoch));
+
+    // A second bump can't start while the first one is unresolved.
     state.advance_max_seen_epoch(term, 141_epoch);
+    EXPECT_EQ(state.get_max_seen_epoch(term).value(), 132_epoch);
 
-    // At-max admission is always sound.
-    EXPECT_TRUE(state.epoch_in_window(term, 141_epoch));
-    // Below-max admission has no applied evidence: reject.
-    EXPECT_FALSE(state.epoch_in_window(term, 132_epoch));
+    // The bump batch lands as the first batch in the log: the window is
+    // [132, 132] now.
+    state.advance_epoch(132_epoch, model::offset{0});
+    EXPECT_FALSE(state.has_pending_seen_bump(term));
+    EXPECT_TRUE(state.epoch_in_window(term, 132_epoch));
+    EXPECT_FALSE(state.epoch_in_window(term, 131_epoch));
 
-    // The max epoch lands as the first batch in the log: the log window is
-    // [141, 141], so 132 must still be rejected.
-    state.advance_epoch(141_epoch, model::offset{0});
-    EXPECT_FALSE(state.epoch_in_window(term, 132_epoch));
+    // Bump to 141: pending again. The old max and the pending epoch are
+    // admissible, the interior is not (its safety depends on the fate of
+    // the 141 batch).
+    state.advance_max_seen_epoch(term, 141_epoch);
     EXPECT_TRUE(state.epoch_in_window(term, 141_epoch));
+    EXPECT_TRUE(state.epoch_in_window(term, 132_epoch));
+    EXPECT_FALSE(state.epoch_in_window(term, 135_epoch));
+
+    // The bump batch lands: the whole [132, 141] window is admissible.
+    state.advance_epoch(141_epoch, model::offset{1});
+    EXPECT_TRUE(state.epoch_in_window(term, 135_epoch));
+    EXPECT_FALSE(state.epoch_in_window(term, 131_epoch));
 }
 
 TEST(ctp_stm_state_test, below_max_fence_allowed_with_applied_evidence) {
@@ -458,11 +487,18 @@ TEST(ctp_stm_state_test, l0_simulation) {
                 universe.uploaded_batches.pop_front();
                 // Mirror the fence_epoch branches: bump the window for an
                 // above-window epoch, replicate an in-window epoch, reject
-                // everything else. A below-max epoch is rejected while no
-                // applied batch proves that something precedes the max
-                // epoch's first batch in the log (the producer would retry
-                // with a fresh epoch).
+                // everything else. While a bump is pending only the old max
+                // and the pending epoch are admissible; a new bump waits
+                // for the resolution and times out (modeled as a rejection,
+                // the producer would retry with a fresh upload).
                 if (universe.stm.epoch_above_window(term, batch.epoch)) {
+                    if (universe.stm.has_pending_seen_bump(term)) {
+                        oplog.push_back(
+                          fmt::format(
+                            "rejected bump to epoch {} (bump pending)",
+                            batch.epoch));
+                        return;
+                    }
                     universe.stm.advance_max_seen_epoch(term, batch.epoch);
                     ASSERT_TRUE(
                       universe.stm.epoch_in_window(term, batch.epoch));

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -723,20 +723,20 @@ TEST_F_CORO(ctp_stm_fixture, test_previous_epoch_fencing_with_lro) {
 
         // get_previous_epoch() returns the committed _previous_epoch, which
         // is still 2 because no batch with epoch 4 has been applied yet.
-        // The transient _previous_seen_epoch is 3 (used by epoch_in_window).
+        // The bump to 4 is pending (used by epoch_in_window).
         previous_epoch = stm->state().get_previous_applied_epoch();
         ASSERT_TRUE_CORO(previous_epoch.has_value());
         ASSERT_EQ_CORO(previous_epoch.value(), ct::cluster_epoch{2});
     }
 
-    // Try to fence an out-of-order epoch (epoch 2) that is <
-    // _previous_seen_epoch (3) and < max_seen_epoch (4) - should fail because
-    // epoch_in_window checks against the transient _previous_seen_epoch
+    // Try to fence an out-of-order epoch (epoch 2) while the bump to 4 is
+    // pending - should fail because only the current max (3) and the
+    // pending epoch (4) are admissible.
     {
         auto fence_prev = co_await leader_api.fence_epoch(ct::cluster_epoch{2});
         ASSERT_FALSE_CORO(fence_prev.has_value())
-          << "Should not be able to fence an out-of-order epoch < "
-             "_previous_seen_epoch";
+          << "Should not be able to fence an out-of-order epoch while a "
+             "bump is pending";
     }
 
     // Advance LRO to the middle of epoch 1 (kafka offset 5)
@@ -1085,25 +1085,11 @@ TEST_F_CORO(
 
 TEST_F_CORO(
   ctp_stm_fixture, test_failed_epoch_bump_replicate_poisons_seen_window) {
-    // Bug reproduction (Antithesis ct_stress crash): a fence-time epoch bump
-    // whose batch never lands in the log leaves a phantom lower bound in the
-    // seen window, admitting a stale epoch that the log-content invariant
-    // forbids.
-    //
-    // Scenario, all within one term on one leader:
-    // 1. A writer fences epoch 132 (first fence in the term, seen window
-    //    becomes [132, 132]) but its replicate fails - nothing lands in the
-    //    log and the fence guard is dropped.
-    // 2. A writer fences epoch 141 (seen window [132, 141]) and replicates.
-    //    The log's first epoch-bearing batch carries 141, so the
-    //    epoch_window_checker window collapses to [141, 141] and the applied
-    //    state treats epochs <= 140 as inactive (their L0 objects become
-    //    eligible for GC).
-    // 3. A writer fences epoch 132 again. This must be rejected: admitting it
-    //    lands an epoch-132 placeholder after the 141 batch, and every
-    //    replica that applies the batch dies in
-    //    epoch_window_checker::check_epoch with "epoch 132 at N is outside of
-    //    sliding window [141, 141]".
+    // A fence-time epoch bump whose batch never lands in the log leaves the
+    // bump unresolved (the seen window is not moved). The unresolved bump
+    // restricts admission to epochs that are safe under either outcome of
+    // the bump batch, and it self-heals when a batch with the bump epoch
+    // eventually lands.
     co_await start();
     co_await wait_for_leader(raft::default_timeout());
 
@@ -1112,64 +1098,75 @@ TEST_F_CORO(
 
     // Step 1: fence epoch 132 and drop the guard without replicating,
     // simulating a fenced write whose replicate failed (e.g. leadership
-    // churn between the fence and the raft append).
+    // churn between the fence and the raft append). The bump to 132 stays
+    // unresolved.
     {
         auto fence = co_await leader_api.fence_epoch(ct::cluster_epoch{132});
         ASSERT_TRUE_CORO(fence.has_value());
-        // Guard dropped here; the seen window keeps [132, 132].
+        // Guard dropped here; the bump to 132 remains pending.
     }
 
-    // Step 2: fence epoch 141 and replicate a placeholder under the fence.
-    // This is the first epoch-bearing batch in the log.
+    // A below-bump epoch is rejected while the bump is unresolved.
+    auto stale_fence = co_await leader_api.fence_epoch(ct::cluster_epoch{100});
+    ASSERT_FALSE_CORO(stale_fence.has_value())
+      << "below-bump epoch admitted while the bump batch never landed";
+
+    // Step 2: a retry with the bump epoch is admissible and its batch
+    // resolves the bump when it lands (self-heal, no step down needed).
     bool ok = co_await replicate_with_epoch(
-      leader, ct::cluster_epoch{141}, model::offset{0}, 0);
+      leader, ct::cluster_epoch{132}, model::offset{0}, 0);
     ASSERT_TRUE_CORO(ok);
 
-    // Step 3: epoch 132 is now below the log window and must be rejected.
-    auto stale_fence = co_await leader_api.fence_epoch(ct::cluster_epoch{132});
-    EXPECT_FALSE(stale_fence.has_value())
-      << "fence_epoch admitted epoch 132 although the log's first epoch "
-         "entry is 141: the seen-window lower bound came from a bump whose "
-         "batch never landed in the log";
+    // Step 3: the window is [132, 132] and backed by the log; the next bump
+    // can proceed.
+    ok = co_await replicate_with_epoch(
+      leader, ct::cluster_epoch{141}, model::offset{1}, 1);
+    ASSERT_TRUE_CORO(ok);
 
-    if (stale_fence.has_value()) {
-        // Under the bug, replicating with the granted fence reproduces the
-        // crash: apply trips the epoch_window_checker vassert on every
-        // replica.
-        auto guard = std::move(stale_fence.value());
-        auto batch = make_record_batch(
-          ct::cluster_epoch{132}, model::offset{1}, 1);
-        auto res = co_await replicate_record_batch(leader, std::move(batch));
-        ASSERT_TRUE_CORO(res.has_value());
-    }
+    // Epoch 131 is below the window and must be rejected.
+    stale_fence = co_await leader_api.fence_epoch(ct::cluster_epoch{131});
+    ASSERT_FALSE_CORO(stale_fence.has_value())
+      << "fence_epoch admitted epoch 131 below the [132, 141] window";
 }
 
 TEST_F_CORO(ctp_stm_fixture, test_below_max_fence_rejected_without_batches) {
-    // Companion to test_failed_epoch_bump_replicate_poisons_seen_window
-    // covering the concurrent variant: the max-seen epoch's batch is not in
-    // the log yet (here it is never replicated at all - the same state the
-    // fence observes while that batch is still mid-replication). With no
-    // epoch batch applied there is no evidence that anything precedes the
-    // max epoch's first batch, so a below-max fence must be rejected.
+    // Companion to test_failed_epoch_bump_replicate_poisons_seen_window:
+    // while a bump is unresolved a higher bump can't start (fence_epoch
+    // waits for the resolution and times out if it never comes) and interior
+    // epochs are rejected.
     co_await start();
     co_await wait_for_leader(raft::default_timeout());
 
     auto& leader = node(*get_leader());
     auto leader_api = api(leader);
 
-    // Two fence-time bumps, neither replicates a batch.
+    // A fence-time bump; no batch lands for it.
     {
         auto fence = co_await leader_api.fence_epoch(ct::cluster_epoch{132});
         ASSERT_TRUE_CORO(fence.has_value());
     }
-    {
-        auto fence = co_await leader_api.fence_epoch(ct::cluster_epoch{141});
-        ASSERT_TRUE_CORO(fence.has_value());
-    }
 
-    auto stale_fence = co_await leader_api.fence_epoch(ct::cluster_epoch{132});
+    // A higher bump waits for the unresolved bump and times out.
+    auto fence_fut = co_await ss::coroutine::as_future(leader_api.fence_epoch(
+      ct::cluster_epoch{141}, std::chrono::milliseconds(500)));
+    ASSERT_TRUE_CORO(fence_fut.failed());
+    bool timed_out = false;
+    try {
+        fence_fut.get();
+    } catch (const ss::timed_out_error&) {
+        timed_out = true;
+    } catch (...) {
+    }
+    ASSERT_TRUE_CORO(timed_out) << "expected timed_out_error";
+
+    // An interior epoch is rejected outright while the bump is unresolved.
+    auto stale_fence = co_await leader_api.fence_epoch(ct::cluster_epoch{120});
     ASSERT_FALSE_CORO(stale_fence.has_value())
-      << "below-max epoch admitted while no epoch batch has been applied";
+      << "below-bump epoch admitted while no epoch batch has been applied";
+
+    // A retry at the bump epoch is admissible (it would self-heal).
+    auto retry_fence = co_await leader_api.fence_epoch(ct::cluster_epoch{132});
+    ASSERT_TRUE_CORO(retry_fence.has_value());
 }
 
 TEST_F_CORO(ctp_stm_fixture, test_below_max_fence_allowed_after_epoch_landed) {

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -52,6 +52,10 @@ struct ctp_stm_accessor {
         return stm._epoch_updated_cv.has_waiters();
     }
 
+    void set_stuck_bump_min_wait(ctp_stm& stm, std::chrono::milliseconds d) {
+        stm._stuck_bump_min_wait = d;
+    }
+
     model::offset max_removable_local_log_offset(ctp_stm& stm) {
         return stm.max_removable_local_log_offset();
     }
@@ -1133,12 +1137,17 @@ TEST_F_CORO(ctp_stm_fixture, test_below_max_fence_rejected_without_batches) {
     // Companion to test_failed_epoch_bump_replicate_poisons_seen_window:
     // while a bump is unresolved a higher bump can't start (fence_epoch
     // waits for the resolution and times out if it never comes) and interior
-    // epochs are rejected.
+    // epochs are rejected. A waiter that spends the recovery floor blocked
+    // on the same unresolved bump gives up the leadership and the next term
+    // restarts the admission window from the applied state.
     co_await start();
     co_await wait_for_leader(raft::default_timeout());
 
     auto& leader = node(*get_leader());
     auto leader_api = api(leader);
+    auto stm = get_stm<0>(leader);
+    ct::ctp_stm_accessor accessor;
+    auto initial_term = leader.raft()->term();
 
     // A fence-time bump; no batch lands for it.
     {
@@ -1159,14 +1168,53 @@ TEST_F_CORO(ctp_stm_fixture, test_below_max_fence_rejected_without_batches) {
     }
     ASSERT_TRUE_CORO(timed_out) << "expected timed_out_error";
 
+    // The wait stayed below the recovery floor: no leadership change.
+    ASSERT_EQ_CORO(leader.raft()->term(), initial_term);
+
     // An interior epoch is rejected outright while the bump is unresolved.
     auto stale_fence = co_await leader_api.fence_epoch(ct::cluster_epoch{120});
     ASSERT_FALSE_CORO(stale_fence.has_value())
       << "below-bump epoch admitted while no epoch batch has been applied";
 
     // A retry at the bump epoch is admissible (it would self-heal).
-    auto retry_fence = co_await leader_api.fence_epoch(ct::cluster_epoch{132});
-    ASSERT_TRUE_CORO(retry_fence.has_value());
+    {
+        auto retry_fence = co_await leader_api.fence_epoch(
+          ct::cluster_epoch{132});
+        ASSERT_TRUE_CORO(retry_fence.has_value());
+    }
+
+    // A waiter that spends the whole recovery floor blocked on the
+    // unresolved bump gives up the leadership.
+    accessor.set_stuck_bump_min_wait(*stm, std::chrono::milliseconds(100));
+    fence_fut = co_await ss::coroutine::as_future(leader_api.fence_epoch(
+      ct::cluster_epoch{141}, std::chrono::milliseconds(500)));
+    ASSERT_TRUE_CORO(fence_fut.failed());
+    fence_fut.ignore_ready_future();
+    RPTEST_REQUIRE_EVENTUALLY_CORO(10s, [&] {
+        auto l = get_leader();
+        return l.has_value() && node(*l).raft()->term() > initial_term;
+    });
+
+    // The new term admits epochs against the applied state: a bump that
+    // would have been blocked by the unresolved bump goes through. Retry
+    // while the leadership settles after the transfer.
+    bool ok = false;
+    for (int i = 0; i < 50 && !ok; ++i) {
+        auto l = get_leader();
+        if (l.has_value()) {
+            auto fut = co_await ss::coroutine::as_future(replicate_with_epoch(
+              node(*l), ct::cluster_epoch{141}, model::offset{0}, 0));
+            if (fut.failed()) {
+                fut.ignore_ready_future();
+            } else {
+                ok = fut.get();
+            }
+        }
+        if (!ok) {
+            co_await ss::sleep(200ms);
+        }
+    }
+    ASSERT_TRUE_CORO(ok);
 }
 
 TEST_F_CORO(ctp_stm_fixture, test_below_max_fence_allowed_after_epoch_landed) {

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -565,11 +565,12 @@ TEST_F_CORO(ctp_stm_fixture, test_snapshot) {
 }
 
 TEST_F_CORO(ctp_stm_fixture, test_fence_epoch_concurrent_new_epoch) {
-    // This test verifies the optimization in fence_epoch() where multiple
-    // concurrent requests for a new epoch only require one write lock.
-    // The first request acquires the epoch_update_lock and write lock, updates
-    // the epoch, then signals waiters. The remaining requests wake up and take
-    // the read-lock path since the epoch has been updated.
+    // This test verifies that multiple concurrent requests for a new epoch
+    // only require one write lock. The first request acquires the
+    // epoch_update_lock and write lock, updates the epoch, then signals
+    // waiters. The remaining requests wake up and take the read-lock path
+    // since the epoch has been updated. The winner's fence keeps the write
+    // lock (no demotion) so the readers stay blocked until it's released.
     co_await start();
     co_await wait_for_leader(raft::default_timeout());
 
@@ -619,12 +620,34 @@ TEST_F_CORO(ctp_stm_fixture, test_fence_epoch_concurrent_new_epoch) {
         // Let `initial_fence` go out of scope.
     }
 
-    // Wait for all fences to be acquired - they should all be able to succeed
-    // without hanging because only one request (the first request) had to
-    // obtain a write lock, which then downgraded to a read lock, and the rest
-    // of the requests could obtain read locks for the current epoch.
+    // Exactly one request wins the epoch update and resolves with a fence
+    // that carries the full write lock; the rest stay blocked on the
+    // read-lock path until the winner releases it.
+    std::optional<size_t> winner;
+    RPTEST_REQUIRE_EVENTUALLY_CORO(10s, [&] {
+        for (size_t i = 0; i < futures.size(); ++i) {
+            if (futures[i].available()) {
+                winner = i;
+                return true;
+            }
+        }
+        return false;
+    });
+
+    auto winner_fence = co_await std::move(futures[*winner]);
+    ASSERT_TRUE_CORO(winner_fence.has_value());
+    ASSERT_GT_CORO(winner_fence->unit.count(), 1);
+    winner_fence->unit.return_all();
+
+    std::vector<ss::future<expected_t>> rest;
+    rest.reserve(futures.size() - 1);
+    for (size_t i = 0; i < futures.size(); ++i) {
+        if (i != *winner) {
+            rest.push_back(std::move(futures[i]));
+        }
+    }
     auto fences = co_await ssx::when_all_succeed<std::vector<expected_t>>(
-      std::move(futures));
+      std::move(rest));
     for (auto& fence : fences) {
         ASSERT_TRUE_CORO(fence.has_value())
           << "All fence requests should succeed";


### PR DESCRIPTION
Track cluster-epoch seen-window bumps explicitly instead of moving the window at fence time.

A fence-time epoch bump used to move the seen window before its batch was replicated. When the replication failed the window was left permanently ahead of the log (the move can't be rolled back because the batch may still land later), and the stale window floor could admit an epoch sequence that violates the log invariant enforced by `epoch_window_checker`: an interior epoch lands ahead of a retried max epoch, a straggler at the stale floor then applies below the checker window, and the vassert fires on every replica (and again on replay). One of the paths that can leave such a divergence behind is `ctp_stm_api::advance_epoch` (the housekeeper epoch advance), which returns an error on replication failure without any cleanup.

This PR removes the divergence by construction and replaces cleanup-by-callers with recovery owned by the STM:

- `fence_epoch` no longer demotes the write lock to a read lock; the frontend releases the fence units when the placeholder is enqueued into raft and its position in the queue is fixed. The units are only held for the duration of an in-memory enqueue.
- A bump is recorded as *pending* (`_max_seen_epoch` running ahead of the applied window) and the admission window - the applied window itself - only widens when the apply loop observes a batch with the bump (or a higher) epoch. While a bump is pending its outcome is ambiguous, and admission is restricted to epochs that are safe under both outcomes: the current window max (the intersection of the current window and the would-be window) and the pending epoch itself. A batch at the pending epoch is admissible in either outcome and resolves the ambiguity when it lands; new uploads use the pending epoch as their floor, so a produce retry after a failed bump self-heals the window without a leadership change. Epochs in between are rejected until the resolution and a new bump waits for the pending one to resolve (bounded by the fence timeout). The resolved seen window always coincides with the checker window, so no ordering of admissible batches can violate the log invariant.
- Recovery from a wedged bump (the bump batch never lands and the cluster epoch moves past the pending epoch, so no retry can resolve it) is demand-driven: the requests that suffer are exactly the ones that time out waiting for the fence, so a fence attempt that spent at least a minimum wait blocked on the same unresolved bump (the epoch floor did not move; bump epochs strictly increase within a term, so an unchanged floor means no progress) gives up the leadership (graceful transfer, falling back to a step down). The next term restarts the admission window from the applied state. An idle partition costs nothing until a request actually needs a higher epoch; the housekeeper epoch advance provides the trigger on partitions with no produce traffic.

State and fixture tests cover the unresolved-bump admission rules, the self-heal path, the blocked second bump, and the demand-driven recovery end to end through raft.

Supersedes the step-down approach in #31386: this branch is based directly on dev and includes the non-demoting fence from that PR as its first commit.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [ ] v25.3.x

## Release Notes

* none




