### PR TITLE
rpk: build FIPS binary with native Go GOFIPS140

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -40,8 +40,14 @@ common --java_runtime_version=remotejdk_21
 # By default build without CGO
 build --@rules_go//go/config:pure
 
-build:gofips --//bazel:gofips=True --@rules_go//go/toolchain:sdk_name=go_sdk_with_systemcrypto
-build:gofips --@rules_go//go/config:pure=false
+# FIPS rpk: rules_go does not support GOFIPS140 yet
+# (https://github.com/bazel-contrib/rules_go/issues/4293), so a Bazel gofips
+# build would produce a binary that self-identifies as FIPS (`fips` build tag)
+# while running non-FIPS crypto. Fail with a self-describing unknown flag
+# until rules_go ships support; restore `--//bazel:gofips=True` then.
+# Release rpk-fips binaries are built by goreleaser with GOFIPS140
+# (see src/go/.goreleaser.yaml).
+build:gofips --gofips_is_unsupported_until_rules_go_issue_4293_is_resolved_see_bazelrc
 
 #################
 # Rust settings #

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -255,20 +255,6 @@ COMPILERS = {
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk", dev_dependency = True)
 go_sdk.download(version = "1.26.5")
 
-# The microsoft compiler versions can be listed at their github release under the `asset.json` file
-go_sdk.download(
-    name = "go_sdk_with_systemcrypto",
-    experiments = ["systemcrypto"],
-    sdks = {
-        "linux_amd64": ("96d1f4b28a670f8e9b3259194508ae2f/go1.26.5-20260709.6.linux-amd64.tar.gz", "df9f45167cf1cd825aa8555b76c5b24cb89dfbd771f48cc0007458236c414715"),
-        "linux_arm64": ("af17683a03acab86aec9ba37afbd5ff1/go1.26.5-20260709.6.linux-arm64.tar.gz", "9990f8fcfefcbd15fb888dd777c7a72f1745889c9e94836ffe26f7e46e43328d"),
-        "darwin_amd64": ("d45676061dfccb09b72f2579a6d8927f/go1.26.5-20260709.6.darwin-amd64.tar.gz", "7a4f0bd26ccf1ce912bc509fccb473ee39bdd149b804fa581e59a72b7708e78e"),
-        "darwin_arm64": ("f8da58db7007fa456d93c4f56bf6c337/go1.26.5-20260709.6.darwin-arm64.tar.gz", "a6d2124035c18602926af78d1e3ae523abc613e36b2086da9b451991ce4288c4"),
-    },
-    urls = ["https://download.visualstudio.microsoft.com/download/pr/a38f1e38-3cd4-48b2-b032-ca38793ec901/{}"],
-    version = "1.26.5",
-)
-
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.config(check_direct_dependencies = "error")
 go_deps.from_file(go_work = "//bazel/thirdparty:go.work")

--- a/src/go/.goreleaser.yaml
+++ b/src/go/.goreleaser.yaml
@@ -1,6 +1,6 @@
 project_name: rpk
 builds:
-  # rpk-windows-and-linux is deprecated; will be replaced by rpk-windows, rpk-linux, rpk-linux-microsoft-go
+  # rpk-windows-and-linux is deprecated; will be replaced by rpk-windows, rpk-linux, rpk-linux-fips
   - id: rpk-windows-and-linux
     dir: ./rpk/
     main: ./cmd/rpk
@@ -18,7 +18,10 @@ builds:
     goarch:
       - amd64
       - arm64
-  - id: rpk-linux-microsoft-go
+  # Native Go FIPS 140-3 build: GOFIPS140=certified compiles the newest
+  # CMVP-certified Go Cryptographic Module into a static binary with FIPS
+  # mode on by default. Resolved module version: `go version -m`.
+  - id: rpk-linux-fips
     dir: ./rpk/
     main: ./cmd/rpk
     binary: rpk
@@ -28,7 +31,8 @@ builds:
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.buildTime={{.Date}}
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/containerutil.tag={{.Tag}}
     env:
-      - 'CGO_ENABLED={{ if index .Env "CGO_ENABLED" }}{{ .Env.CGO_ENABLED }}{{ else }}0{{ end }}'
+      - CGO_ENABLED=0
+      - GOFIPS140=certified
     tags:
       - fips
     goos:


### PR DESCRIPTION
The rpk-linux-fips release build uses Go's native FIPS 140-3 support: GOFIPS140=certified compiles the newest CMVP-certified Go Cryptographic Module into a static, CGO-free binary with FIPS mode on by default. This replaces the Microsoft Go fork (systemcrypto) toolchain, which is no longer downloaded in MODULE.bazel.

rules_go cannot set GOFIPS140 yet, so a Bazel gofips build would produce a binary that self-identifies as FIPS while running non-FIPS crypto. The gofips config now fails with a self-describing error until rules_go gains GOFIPS140 support; the fips build tag wiring is kept so it can be re-enabled with one line.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

### Improvements
* `rpk-linux-fips` is now built with Go's native FIPS 140-3 support (`GOFIPS140=certified`), producing a static, CGO-free binary with FIPS mode enabled by default. This replaces the Microsoft Go fork toolchain.
