### PR TITLE
[CORE-16804] - KIP-848: deterministic subscription-metadata hash

### DIFF
--- a/src/v/hashing/tests/xx_tests.cc
+++ b/src/v/hashing/tests/xx_tests.cc
@@ -19,48 +19,78 @@
 
 #include <array>
 
-BOOST_AUTO_TEST_CASE(incremental_same_as_array) {
-    incremental_xxhash64 inc;
+namespace {
+
+template<typename Hash>
+void check_incremental_matches(uint64_t expected) {
+    Hash inc;
     inc.update(1);
     inc.update(2);
     inc.update(42);
-    std::array<int, 3> arr = {1, 2, 42};
-    BOOST_CHECK_EQUAL(inc.digest(), xxhash_64(arr));
+    BOOST_CHECK_EQUAL(inc.digest(), expected);
 }
 
-BOOST_AUTO_TEST_CASE(digest_idempotency) {
-    incremental_xxhash64 inc;
+template<typename Hash>
+void check_digest_idempotency(uint64_t expected) {
+    Hash inc;
     inc.update(1);
     inc.digest();
     inc.update(2);
     inc.digest();
     inc.update(42);
     inc.digest();
-    std::array<int, 3> arr = {1, 2, 42};
 
-    const auto arr_hash = xxhash_64(arr);
-    BOOST_CHECK_EQUAL(inc.digest(), arr_hash);
+    BOOST_CHECK_EQUAL(inc.digest(), expected);
     for (auto i = 0; i < 10; ++i) {
-        BOOST_CHECK_EQUAL(inc.digest(), arr_hash);
+        BOOST_CHECK_EQUAL(inc.digest(), expected);
     }
 }
 
-template<typename T, typename V>
+template<typename Hash, typename T, typename V>
 void test_incremental_hash(T test, V expected) {
-    incremental_xxhash64 hash;
+    Hash hash;
     hash.update(test);
 
-    incremental_xxhash64 expected_hash;
+    Hash expected_hash;
     expected_hash.update(expected);
     BOOST_REQUIRE_EQUAL(hash.digest(), expected_hash.digest());
 }
 
-BOOST_AUTO_TEST_CASE(overload_resolution) {
+template<typename Hash>
+void check_overload_resolution() {
     using named_str = named_type<std::string, struct str_type>;
     using named_integral = named_type<size_t, struct int_type>;
 
-    test_incremental_hash(named_str{"named_str"}, "named_str");
-    test_incremental_hash(named_integral{10}, (size_t)10);
+    test_incremental_hash<Hash>(named_str{"named_str"}, "named_str");
+    test_incremental_hash<Hash>(named_integral{10}, (size_t)10);
     named_str s("test_str");
-    test_incremental_hash(s, s());
+    test_incremental_hash<Hash>(s, s());
+}
+
+constexpr std::array<int, 3> updates = {1, 2, 42};
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(incremental_same_as_array) {
+    check_incremental_matches<incremental_xxhash64>(xxhash_64(updates));
+    check_incremental_matches<incremental_xxh3_64>(xxh3_64(updates));
+}
+
+BOOST_AUTO_TEST_CASE(digest_idempotency) {
+    check_digest_idempotency<incremental_xxhash64>(xxhash_64(updates));
+    check_digest_idempotency<incremental_xxh3_64>(xxh3_64(updates));
+}
+
+BOOST_AUTO_TEST_CASE(overload_resolution) {
+    check_overload_resolution<incremental_xxhash64>();
+    check_overload_resolution<incremental_xxh3_64>();
+}
+
+/// The two hashes are distinct functions, so the same input gives two values.
+BOOST_AUTO_TEST_CASE(hashes_differ) {
+    incremental_xxhash64 xxhash64;
+    incremental_xxh3_64 xxh3;
+    xxhash64.update("the same input");
+    xxh3.update("the same input");
+    BOOST_CHECK_NE(xxhash64.digest(), xxh3.digest());
 }

--- a/src/v/hashing/xx.h
+++ b/src/v/hashing/xx.h
@@ -29,20 +29,54 @@ inline uint32_t xxhash_32(const unsigned char* data, size_t length) {
 inline uint64_t xxhash_64(const char* data, const size_t& length) {
     return XXH64(data, length, 0);
 }
+
+inline uint64_t xxh3_64(const unsigned char* data, size_t length) {
+    return XXH3_64bits(data, length);
+}
+inline uint64_t xxh3_64(const char* data, size_t length) {
+    return XXH3_64bits(data, length);
+}
 inline uint32_t xxhash_32(const char* data, const size_t& length) {
     return XXH32(data, length, 0);
 }
 
-class incremental_xxhash64 {
-public:
-    explicit incremental_xxhash64(uint64_t seed = 0) {
-        XXH64_reset(&_state, seed);
+namespace detail {
+
+/// xxhash.h is included with XXH_PRIVATE_API, so every XXH function has
+/// internal linkage. Naming them through a traits type keeps the
+/// specialization below identical in every translation unit, where template
+/// arguments of function-pointer type would name a different function in each.
+struct xxh64_traits {
+    using state = XXH64_state_t;
+    static void reset(state* s, uint64_t seed) { XXH64_reset(s, seed); }
+    static void update(state* s, const void* src, size_t sz) {
+        XXH64_update(s, src, sz);
     }
-    incremental_xxhash64(incremental_xxhash64&&) noexcept = default;
-    incremental_xxhash64& operator=(incremental_xxhash64&&) noexcept = default;
+    static uint64_t digest(const state* s) { return XXH64_digest(s); }
+};
+
+struct xxh3_64_traits {
+    using state = XXH3_state_t;
+    static void reset(state* s, uint64_t seed) {
+        XXH3_64bits_reset_withSeed(s, seed);
+    }
+    static void update(state* s, const void* src, size_t sz) {
+        XXH3_64bits_update(s, src, sz);
+    }
+    static uint64_t digest(const state* s) { return XXH3_64bits_digest(s); }
+};
+
+template<typename Traits>
+class incremental_xxhash {
+public:
+    explicit incremental_xxhash(uint64_t seed = 0) {
+        Traits::reset(&_state, seed);
+    }
+    incremental_xxhash(incremental_xxhash&&) noexcept = default;
+    incremental_xxhash& operator=(incremental_xxhash&&) noexcept = default;
 
     void update(const char* src, const std::size_t sz) {
-        XXH64_update(&_state, src, sz);
+        Traits::update(&_state, src, sz);
     }
 
     // string override
@@ -68,11 +102,16 @@ public:
         (update(t), ...);
     }
 
-    uint64_t digest() { return XXH64_digest(&_state); }
+    uint64_t digest() { return Traits::digest(&_state); }
 
 private:
-    XXH64_state_t _state{};
+    typename Traits::state _state{};
 };
+} // namespace detail
+
+using incremental_xxhash64 = detail::incremental_xxhash<detail::xxh64_traits>;
+
+using incremental_xxh3_64 = detail::incremental_xxhash<detail::xxh3_64_traits>;
 
 template<
   typename T,
@@ -87,6 +126,13 @@ template<
   typename = std::enable_if_t<std::is_integral<T>::value>>
 inline uint32_t xxhash_32(const std::array<T, N>& arr) {
     return xxhash_32(reinterpret_cast<const char*>(&arr[0]), sizeof(T) * N);
+}
+template<
+  typename T,
+  std::size_t N,
+  typename = std::enable_if_t<std::is_integral<T>::value>>
+inline uint64_t xxh3_64(const std::array<T, N>& arr) {
+    return xxh3_64(reinterpret_cast<const char*>(&arr[0]), sizeof(T) * N);
 }
 inline uint64_t xxhash_64_str(const char* s) {
     return xxhash_64(s, std::strlen(s));

--- a/src/v/hashing/xx.h
+++ b/src/v/hashing/xx.h
@@ -13,9 +13,11 @@
 
 #include "base/seastarx.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <functional>
+#include <span>
 #include <string_view>
 #include <xxhash.h>
 
@@ -77,6 +79,10 @@ public:
 
     void update(const char* src, const std::size_t sz) {
         Traits::update(&_state, src, sz);
+    }
+
+    void update(std::span<const std::byte> bytes) {
+        Traits::update(&_state, bytes.data(), bytes.size());
     }
 
     // string override

--- a/src/v/kafka/server/BUILD
+++ b/src/v/kafka/server/BUILD
@@ -117,6 +117,27 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "subscription_metadata_hash",
+    srcs = [
+        "subscription_metadata_hash.cc",
+    ],
+    hdrs = [
+        "subscription_metadata_hash.h",
+    ],
+    implementation_deps = [
+        "//src/v/base",
+        "//src/v/utils:uuid",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/hashing:xx",
+        "//src/v/model",
+        "@abseil-cpp//absl/container:btree",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "server",
     srcs = [
         "client_quota_translator.cc",

--- a/src/v/kafka/server/BUILD
+++ b/src/v/kafka/server/BUILD
@@ -138,6 +138,23 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "subscription_metadata_hash_cache",
+    srcs = [
+        "subscription_metadata_hash_cache.cc",
+    ],
+    hdrs = [
+        "subscription_metadata_hash_cache.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":subscription_metadata_hash",
+        "//src/v/container:chunked_hash_map",
+        "//src/v/model",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "server",
     srcs = [
         "client_quota_translator.cc",

--- a/src/v/kafka/server/subscription_metadata_hash.cc
+++ b/src/v/kafka/server/subscription_metadata_hash.cc
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "kafka/server/subscription_metadata_hash.h"
+
+#include "base/vassert.h"
+#include "hashing/xx.h"
+#include "utils/uuid.h"
+
+#include <seastar/core/byteorder.hh>
+
+#include <algorithm>
+#include <bit>
+#include <concepts>
+#include <span>
+#include <string_view>
+
+namespace kafka {
+
+namespace {
+
+/// This byte starts every topic hash. Bump it when the hash function or inputs
+/// change to force a rebalance on every group irrespective of subscriptions.
+constexpr uint8_t hash_version = 0;
+
+/// Write an integer as big-endian so that nodes of different architectures
+/// agree. Note that we always write sizeof(T) bytes irrespective of value.
+template<std::integral T>
+void update(incremental_xxh3_64& hash, T value) {
+    const auto big_endian = ss::cpu_to_be(value);
+    hash.update(std::as_bytes(std::span{&big_endian, 1}));
+}
+
+/// Writes the length before the bytes, so that the boundary between two strings
+/// is part of the hash: "a" then "bc" differs from "ab" then "c".
+void update(incremental_xxh3_64& hash, std::string_view value) {
+    update(hash, static_cast<int32_t>(value.size()));
+    hash.update(value);
+}
+
+void update(incremental_xxh3_64& hash, const uuid_t& value) {
+    hash.update(std::as_bytes(std::span{value.uuid().begin(), uuid_t::length}));
+}
+
+} // namespace
+
+topic_metadata_hasher::topic_metadata_hasher(
+  model::topic_id id, std::string_view name, int32_t partition_count)
+  : _partition_count(partition_count) {
+    update(_hash, hash_version);
+    update(_hash, id());
+    update(_hash, name);
+    update(_hash, partition_count);
+}
+
+void topic_metadata_hasher::partition(std::span<model::rack_id> racks) {
+    vassert(
+      _next_partition < _partition_count,
+      "partition {} is past the {} counted at construction",
+      _next_partition,
+      _partition_count);
+
+    update(_hash, _next_partition++);
+    std::ranges::sort(racks);
+    for (const auto& rack : racks) {
+        update(_hash, std::string_view{rack()});
+    }
+}
+
+int64_t topic_metadata_hasher::digest() {
+    vassert(
+      _next_partition == _partition_count,
+      "hashed {} of {} partitions",
+      _next_partition,
+      _partition_count);
+
+    return std::bit_cast<int64_t>(_hash.digest());
+}
+
+int64_t subscription_metadata_hash(const topic_metadata_hashes& topic_hashes) {
+    if (topic_hashes.empty()) {
+        return 0;
+    }
+
+    // topic hashes come sorted by topic_id, but all we care about is the value.
+    incremental_xxh3_64 hash;
+    for (const auto& [_, topic_hash] : topic_hashes) {
+        update(hash, topic_hash);
+    }
+    return std::bit_cast<int64_t>(hash.digest());
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/subscription_metadata_hash.h
+++ b/src/v/kafka/server/subscription_metadata_hash.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "hashing/xx.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+
+#include <absl/container/btree_map.h>
+
+#include <cstdint>
+#include <span>
+#include <string_view>
+
+namespace kafka {
+
+/// Input to subscription_metadata_hash.
+/// We use an ordered container so the hash remains stable across invocations.
+using topic_metadata_hashes = absl::btree_map<model::topic_id, int64_t>;
+
+namespace detail {
+template<typename T>
+concept OrdersByKey = requires { typename T::key_compare; };
+} // namespace detail
+
+static_assert(
+  detail::OrdersByKey<topic_metadata_hashes>,
+  "subscription_metadata_hash reads iteration order, so this map must order by "
+  "key");
+
+/// Hashes one topic's metadata over the same inputs as Kafka's
+/// Utils.computeTopicHash
+/// https://github.com/apache/kafka/blob/fce22525f7/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Utils.java#L491-L522
+///
+/// Hashes:
+/// - version byte (byte)
+/// - topic id (16 bytes)
+/// - topic name (string)
+/// - partition count (int32)
+/// - for each partition, in ascending order of partition id:
+///   - partition id (int32)
+///   - sorted rack ids (string)
+///
+/// The caller passes one partition at a time, so we don't have to materialize a
+/// topic's racks all at once and each can be discarded once hashed. The hasher
+/// iterates the partition ID space internally, so the caller must walk the
+/// partitions in ascending order of id.
+///
+/// Should be stable across nodes, processes, and architectures.
+class topic_metadata_hasher {
+public:
+    topic_metadata_hasher(
+      model::topic_id id, std::string_view name, int32_t partition_count);
+
+    /// Hashes `racks` as the next partition, sorting them in place. Pass one
+    /// entry per replica whose broker has a rack.
+    /// Precondition: Total `partition` calls <= partition_count
+    void partition(std::span<model::rack_id> racks);
+
+    /// Precondition: `partition` ran once for every partition counted at
+    /// construction.
+    int64_t digest();
+
+private:
+    incremental_xxh3_64 _hash;
+    int32_t _partition_count;
+    int32_t _next_partition{0};
+};
+
+/// Hashes a whole subscription from the per-topic hashes, in order of ascending
+/// topic id. See Kafka's Utils.computeGroupHash:
+/// https://github.com/apache/kafka/blob/fce22525f7/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Utils.java#L453-L468
+///
+/// Returns 0 for an empty map.
+int64_t subscription_metadata_hash(const topic_metadata_hashes& topic_hashes);
+
+} // namespace kafka

--- a/src/v/kafka/server/subscription_metadata_hash_cache.cc
+++ b/src/v/kafka/server/subscription_metadata_hash_cache.cc
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "kafka/server/subscription_metadata_hash_cache.h"
+
+namespace kafka {
+
+subscription_metadata_hash_cache::subscription_metadata_hash_cache(
+  topic_metadata_source& source)
+  : _source(&source)
+  , _notification(source.register_change_notification(
+      [this](const model::topic& topic) { _cache.erase(topic); })) {}
+
+subscription_metadata_hash_cache::~subscription_metadata_hash_cache() {
+    _source->unregister_change_notification(_notification);
+}
+
+std::optional<hashed_topic>
+subscription_metadata_hash_cache::topic_hash(const model::topic& topic) {
+    if (auto it = _cache.find(topic); it != _cache.end()) {
+        return it->second;
+    }
+    auto entry = _source->topic_hash(topic);
+    if (!entry.has_value()) {
+        return std::nullopt;
+    }
+    _cache.emplace(topic, *entry);
+    return entry;
+}
+
+void subscription_metadata_hash_cache::invalidate(const model::topic& topic) {
+    _cache.erase(topic);
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/subscription_metadata_hash_cache.h
+++ b/src/v/kafka/server/subscription_metadata_hash_cache.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "container/chunked_hash_map.h"
+#include "kafka/server/subscription_metadata_hash.h"
+#include "model/fundamental.h"
+
+#include <seastar/util/noncopyable_function.hh>
+
+#include <concepts>
+#include <cstdint>
+#include <optional>
+#include <ranges>
+
+namespace kafka {
+
+struct hashed_topic {
+    model::topic_id id;
+    int64_t hash;
+
+    friend bool operator==(const hashed_topic&, const hashed_topic&) = default;
+};
+
+/// Interface through which the cache requests a topic's hash and subscribes to
+/// metadata changes.
+class topic_metadata_source {
+public:
+    using notification_id = int32_t;
+
+    topic_metadata_source() = default;
+    topic_metadata_source(const topic_metadata_source&) = delete;
+    topic_metadata_source& operator=(const topic_metadata_source&) = delete;
+    topic_metadata_source(topic_metadata_source&&) = delete;
+    topic_metadata_source& operator=(topic_metadata_source&&) = delete;
+    virtual ~topic_metadata_source() = default;
+
+    /// Hashes the topic's metadata with `topic_metadata_hasher`. Returns
+    /// nullopt for a topic that does not exist.
+    virtual std::optional<hashed_topic> topic_hash(const model::topic&) = 0;
+
+    /// Calls `on_change` with every topic a metadata delta changes or deletes.
+    virtual notification_id register_change_notification(
+      ss::noncopyable_function<void(const model::topic&)> on_change) = 0;
+
+    virtual void unregister_change_notification(notification_id) = 0;
+};
+
+/// Holds one hash per topic. The cache drops a topic's entry when the source
+/// reports a change to it, so after a change the first group to ask for that
+/// topic pays for the hash, and every group after it reads the entry.
+class subscription_metadata_hash_cache {
+public:
+    explicit subscription_metadata_hash_cache(topic_metadata_source& source);
+    subscription_metadata_hash_cache(const subscription_metadata_hash_cache&)
+      = delete;
+    subscription_metadata_hash_cache&
+    operator=(const subscription_metadata_hash_cache&) = delete;
+    subscription_metadata_hash_cache(subscription_metadata_hash_cache&&)
+      = delete;
+    subscription_metadata_hash_cache&
+    operator=(subscription_metadata_hash_cache&&) = delete;
+    ~subscription_metadata_hash_cache();
+
+    /// Returns the topic's id and hash, and builds the entry on a miss.
+    /// Returns nullopt when the source has no metadata for the topic; the next
+    /// call asks the source again.
+    std::optional<hashed_topic> topic_hash(const model::topic& topic);
+
+    /// Returns the hash of a whole subscription: the per-topic hashes, hashed
+    /// in order of ascending topic id. Only the topics that have metadata
+    /// count.
+    template<std::ranges::input_range Range>
+    requires std::same_as<std::ranges::range_value_t<Range>, model::topic>
+    int64_t subscription_hash(const Range& subscription) {
+        topic_metadata_hashes hashes;
+        for (const model::topic& topic : subscription) {
+            if (auto entry = topic_hash(topic)) {
+                hashes.emplace(entry->id, entry->hash);
+            }
+        }
+        return subscription_metadata_hash(hashes);
+    }
+
+    /// Drops the topic's entry, for a topic that no group subscribes to any
+    /// more.
+    void invalidate(const model::topic& topic);
+
+    size_t size() const { return _cache.size(); }
+
+private:
+    topic_metadata_source* _source;
+    chunked_hash_map<model::topic, hashed_topic> _cache;
+    topic_metadata_source::notification_id _notification;
+};
+
+} // namespace kafka

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -244,6 +244,24 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "subscription_metadata_hash_cache_test",
+    timeout = "short",
+    srcs = [
+        "subscription_metadata_hash_cache_test.cc",
+    ],
+    deps = [
+        "//src/v/container:chunked_vector",
+        "//src/v/kafka/server:subscription_metadata_hash",
+        "//src/v/kafka/server:subscription_metadata_hash_cache",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "//src/v/utils:uuid",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "fetch_memory_units_test",
     timeout = "short",
     srcs = [

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -227,6 +227,23 @@ redpanda_cc_btest(
 )
 
 redpanda_cc_gtest(
+    name = "subscription_metadata_hash_test",
+    timeout = "short",
+    srcs = [
+        "subscription_metadata_hash_test.cc",
+    ],
+    deps = [
+        "//src/v/container:chunked_vector",
+        "//src/v/kafka/server:subscription_metadata_hash",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "//src/v/utils:uuid",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "fetch_memory_units_test",
     timeout = "short",
     srcs = [

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -1403,6 +1403,21 @@ redpanda_cc_btest(
 )
 
 redpanda_cc_bench(
+    name = "subscription_metadata_hash_rpbench",
+    srcs = [
+        "subscription_metadata_hash_bench.cc",
+    ],
+    memory = "2GiB",
+    deps = [
+        "//src/v/container:chunked_vector",
+        "//src/v/kafka/server:subscription_metadata_hash",
+        "//src/v/model",
+        "@seastar",
+        "@seastar//:benchmark",
+    ],
+)
+
+redpanda_cc_bench(
     name = "group_offset_commit_rpbench",
     srcs = [
         "group_offset_commit_bench.cc",

--- a/src/v/kafka/server/tests/subscription_metadata_hash_bench.cc
+++ b/src/v/kafka/server/tests/subscription_metadata_hash_bench.cc
@@ -1,0 +1,145 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/server/subscription_metadata_hash.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+
+#include <seastar/core/sstring.hh>
+#include <seastar/testing/perf_tests.hh>
+
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace kafka {
+
+namespace {
+
+/// The coordinator shard recomputes a group's hash to find out whether the
+/// metadata of its subscribed topics moved, and it holds the reactor while it
+/// does. These cases sweep the partition count of one topic and the topic count
+/// of one group.
+
+constexpr size_t replication_factor = 3;
+
+topic_metadata_hashes topic_hashes(size_t count) {
+    topic_metadata_hashes hashes;
+    for (size_t t = 0; t < count; ++t) {
+        hashes.emplace(model::topic_id::create(), static_cast<int64_t>(t));
+    }
+    return hashes;
+}
+
+std::vector<model::topic> topic_names(size_t count) {
+    std::vector<model::topic> names;
+    names.reserve(count);
+    for (size_t t = 0; t < count; ++t) {
+        names.emplace_back(ss::sstring{"topic-"} + std::to_string(t));
+    }
+    return names;
+}
+
+std::vector<model::topic_id> topic_ids(size_t count) {
+    std::vector<model::topic_id> ids;
+    ids.reserve(count);
+    for (size_t t = 0; t < count; ++t) {
+        ids.push_back(model::topic_id::create());
+    }
+    return ids;
+}
+
+std::vector<model::rack_id> rack_names() {
+    std::vector<model::rack_id> names;
+    names.reserve(replication_factor);
+    for (size_t r = 0; r < replication_factor; ++r) {
+        names.emplace_back(ss::sstring{"rack-"} + std::to_string(r));
+    }
+    return names;
+}
+
+/// The rack names a lookup hands back, and one buffer to derive a partition's
+/// racks into. A caller reuses the buffer across partitions and topics.
+struct hash_input {
+    model::topic_id id = model::topic_id::create();
+    std::vector<model::rack_id> names = rack_names();
+    std::vector<model::rack_id> racks{
+      std::vector<model::rack_id>(replication_factor)};
+};
+
+int64_t hash_topic(
+  model::topic_id id,
+  std::string_view name,
+  size_t partitions,
+  hash_input& input) {
+    topic_metadata_hasher hasher{id, name, static_cast<int32_t>(partitions)};
+    for (size_t p = 0; p < partitions; ++p) {
+        input.racks.clear();
+        for (size_t r = 0; r < replication_factor; ++r) {
+            input.racks.push_back(input.names[(p + r) % input.names.size()]);
+        }
+        hasher.partition(input.racks);
+    }
+    return hasher.digest();
+}
+
+struct group_topics {
+    topic_metadata_hashes hundred = topic_hashes(100);
+    topic_metadata_hashes ten_thousand = topic_hashes(10'000);
+};
+
+/// What a coordinator pays for one group when no topic hash is cached: hash
+/// every subscribed topic, then hash the group over those values.
+struct cold_subscription : hash_input {
+    static constexpr size_t topics = 1'000;
+    static constexpr size_t partitions = 100;
+
+    std::vector<model::topic_id> ids = topic_ids(topics);
+    std::vector<model::topic> names = topic_names(topics);
+};
+
+} // namespace
+
+PERF_TEST_F(hash_input, hash_topic_1k_partitions) {
+    auto hash = hash_topic(id, "benchmark-topic", 1'000, *this);
+    perf_tests::do_not_optimize(hash);
+}
+
+PERF_TEST_F(hash_input, hash_topic_10k_partitions) {
+    auto hash = hash_topic(id, "benchmark-topic", 10'000, *this);
+    perf_tests::do_not_optimize(hash);
+}
+
+PERF_TEST_F(hash_input, hash_topic_100k_partitions) {
+    auto hash = hash_topic(id, "benchmark-topic", 100'000, *this);
+    perf_tests::do_not_optimize(hash);
+}
+
+PERF_TEST_F(group_topics, hash_group_100_topics) {
+    auto hash = subscription_metadata_hash(hundred);
+    perf_tests::do_not_optimize(hash);
+}
+
+PERF_TEST_F(group_topics, hash_group_10k_topics) {
+    auto hash = subscription_metadata_hash(ten_thousand);
+    perf_tests::do_not_optimize(hash);
+}
+
+PERF_TEST_F(cold_subscription, hash_1k_topics_of_100_partitions) {
+    topic_metadata_hashes hashes;
+    for (size_t t = 0; t < topics; ++t) {
+        hashes.emplace(
+          ids[t], hash_topic(ids[t], names[t](), partitions, *this));
+    }
+    auto hash = subscription_metadata_hash(hashes);
+    perf_tests::do_not_optimize(hash);
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/tests/subscription_metadata_hash_cache_test.cc
+++ b/src/v/kafka/server/tests/subscription_metadata_hash_cache_test.cc
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "kafka/server/subscription_metadata_hash.h"
+#include "kafka/server/subscription_metadata_hash_cache.h"
+#include "model/fundamental.h"
+#include "test_utils/test.h"
+#include "utils/uuid.h"
+
+#include <seastar/util/noncopyable_function.hh>
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <optional>
+#include <vector>
+
+namespace {
+
+model::topic_id topic_id_of(uint8_t first_byte) {
+    std::vector<uint8_t> bytes(uuid_t::length, 0);
+    bytes.front() = first_byte;
+    return model::topic_id{uuid_t{bytes}};
+}
+
+/// Answers from `hashes` and counts every read, so a case can tell a cache hit
+/// from a rebuild. `change` fires the notification the cache registered.
+struct fake_source final : kafka::topic_metadata_source {
+    std::optional<kafka::hashed_topic>
+    topic_hash(const model::topic& topic) override {
+        ++reads;
+        auto it = hashes.find(topic);
+        if (it == hashes.end()) {
+            return std::nullopt;
+        }
+        return it->second;
+    }
+
+    notification_id register_change_notification(
+      ss::noncopyable_function<void(const model::topic&)> cb) override {
+        _on_change = std::move(cb);
+        ++registrations;
+        return 7;
+    }
+
+    void unregister_change_notification(notification_id id) override {
+        EXPECT_EQ(id, 7);
+        --registrations;
+    }
+
+    void change(const model::topic& topic) { _on_change(topic); }
+
+    std::map<model::topic, kafka::hashed_topic> hashes;
+    int reads = 0;
+    int registrations = 0;
+
+private:
+    ss::noncopyable_function<void(const model::topic&)> _on_change;
+};
+
+model::topic topic_1() { return model::topic{"topic-1"}; }
+model::topic topic_2() { return model::topic{"topic-2"}; }
+
+kafka::hashed_topic hashed(uint8_t id, int64_t hash) {
+    return kafka::hashed_topic{.id = topic_id_of(id), .hash = hash};
+}
+
+} // namespace
+
+TEST(subscription_metadata_hash_cache, reads_the_source_once_then_hits) {
+    fake_source source;
+    source.hashes.emplace(topic_1(), hashed(1, 111));
+    kafka::subscription_metadata_hash_cache cache{source};
+
+    EXPECT_EQ(cache.topic_hash(topic_1()), hashed(1, 111));
+    EXPECT_EQ(source.reads, 1);
+
+    EXPECT_EQ(cache.topic_hash(topic_1()), hashed(1, 111));
+    EXPECT_EQ(source.reads, 1);
+    EXPECT_EQ(cache.size(), 1);
+}
+
+TEST(subscription_metadata_hash_cache, reads_the_source_per_absent_topic) {
+    fake_source source;
+    kafka::subscription_metadata_hash_cache cache{source};
+
+    EXPECT_EQ(cache.topic_hash(topic_1()), std::nullopt);
+    EXPECT_EQ(cache.topic_hash(topic_1()), std::nullopt);
+    EXPECT_EQ(source.reads, 2);
+    EXPECT_EQ(cache.size(), 0);
+}
+
+/// A change notification drops the entry, and the next read takes the new
+/// value.
+TEST(subscription_metadata_hash_cache, a_change_rereads_the_source) {
+    fake_source source;
+    source.hashes.emplace(topic_1(), hashed(1, 111));
+    kafka::subscription_metadata_hash_cache cache{source};
+
+    EXPECT_EQ(cache.topic_hash(topic_1()), hashed(1, 111));
+    source.hashes.insert_or_assign(topic_1(), hashed(1, 222));
+    EXPECT_EQ(cache.topic_hash(topic_1()), hashed(1, 111));
+    EXPECT_EQ(source.reads, 1);
+
+    source.change(topic_1());
+    EXPECT_EQ(cache.size(), 0);
+    EXPECT_EQ(cache.topic_hash(topic_1()), hashed(1, 222));
+    EXPECT_EQ(source.reads, 2);
+}
+
+TEST(subscription_metadata_hash_cache, unregisters_on_destruction) {
+    fake_source source;
+    {
+        kafka::subscription_metadata_hash_cache cache{source};
+        EXPECT_EQ(source.registrations, 1);
+    }
+    EXPECT_EQ(source.registrations, 0);
+}
+
+/// `invalidate` drops the entry, and the next read takes the new value.
+TEST(subscription_metadata_hash_cache, invalidate_rereads_the_source) {
+    fake_source source;
+    source.hashes.emplace(topic_1(), hashed(1, 111));
+    kafka::subscription_metadata_hash_cache cache{source};
+
+    EXPECT_EQ(cache.topic_hash(topic_1()), hashed(1, 111));
+    source.hashes.insert_or_assign(topic_1(), hashed(1, 222));
+    EXPECT_EQ(cache.topic_hash(topic_1()), hashed(1, 111));
+    EXPECT_EQ(source.reads, 1);
+
+    cache.invalidate(topic_1());
+    EXPECT_EQ(cache.topic_hash(topic_1()), hashed(1, 222));
+    EXPECT_EQ(source.reads, 2);
+}
+
+TEST(
+  subscription_metadata_hash_cache,
+  subscription_hash_covers_topics_with_metadata) {
+    fake_source source;
+    source.hashes.emplace(topic_1(), hashed(1, 111));
+    source.hashes.emplace(topic_2(), hashed(2, 222));
+    kafka::subscription_metadata_hash_cache cache{source};
+
+    kafka::topic_metadata_hashes expected;
+    expected.emplace(topic_id_of(1), 111);
+    expected.emplace(topic_id_of(2), 222);
+
+    const std::vector<model::topic> subscription{
+      topic_1(), topic_2(), model::topic{"absent"}};
+    EXPECT_EQ(
+      cache.subscription_hash(subscription),
+      kafka::subscription_metadata_hash(expected));
+
+    const auto reads = source.reads;
+    cache.subscription_hash(subscription);
+    // the cache reads the source again for the absent topic
+    EXPECT_EQ(source.reads, reads + 1);
+}
+
+TEST(subscription_metadata_hash_cache, empty_subscription_hashes_to_zero) {
+    fake_source source;
+    kafka::subscription_metadata_hash_cache cache{source};
+    EXPECT_EQ(cache.subscription_hash(std::vector<model::topic>{}), 0);
+    EXPECT_EQ(source.reads, 0);
+}

--- a/src/v/kafka/server/tests/subscription_metadata_hash_test.cc
+++ b/src/v/kafka/server/tests/subscription_metadata_hash_test.cc
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "kafka/server/subscription_metadata_hash.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "test_utils/test.h"
+#include "utils/uuid.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <gtest/gtest.h>
+
+#include <string_view>
+#include <vector>
+
+namespace {
+
+using racks = std::vector<model::rack_id>;
+
+model::topic_id topic_id_of(uint8_t first_byte) {
+    std::vector<uint8_t> bytes(uuid_t::length, 0);
+    bytes.front() = first_byte;
+    return model::topic_id{uuid_t{bytes}};
+}
+
+racks racks_of(const std::vector<std::string_view>& names) {
+    racks result;
+    result.reserve(names.size());
+    for (const auto& name : names) {
+        result.emplace_back(ss::sstring{name});
+    }
+    return result;
+}
+
+/// Feeds the partitions to a hasher in the order given.
+/// Each rack list is sorted in place by the hasher, so we copy them at the call
+/// site verbatim.
+int64_t hash_of(
+  const std::vector<racks>& partitions,
+  model::topic_id id = topic_id_of(1),
+  std::string_view name = "topic-1") {
+    kafka::topic_metadata_hasher hasher{
+      id, name, static_cast<int32_t>(partitions.size())};
+    for (auto racks_here : partitions) {
+        hasher.partition(racks_here);
+    }
+    return hasher.digest();
+}
+
+std::vector<racks> a_topic() {
+    return {racks_of({"rack-a"}), racks_of({"rack-b"})};
+}
+
+} // namespace
+
+/// topic_metadata_hasher::partition sorts each racks vector, so the order the
+/// caller listed them in does not change the value.
+TEST(subscription_metadata_hash, ignores_rack_order) {
+    EXPECT_EQ(
+      hash_of({racks_of({"rack-y", "rack-x", "rack-x"}), racks_of({"rack-b"})}),
+      hash_of(
+        {racks_of({"rack-x", "rack-x", "rack-y"}), racks_of({"rack-b"})}));
+}
+
+/// The hash writes every rack entry, so a partition that lists a rack twice
+/// hashes differently from one that lists it once.
+TEST(subscription_metadata_hash, counts_every_rack_entry) {
+    EXPECT_NE(
+      hash_of({racks_of({"rack-x", "rack-x"})}),
+      hash_of({racks_of({"rack-x"})}));
+}
+
+TEST(subscription_metadata_hash, detects_every_input_change) {
+    const auto baseline = hash_of(a_topic());
+
+    EXPECT_NE(baseline, hash_of(a_topic(), topic_id_of(1), "topic-2"));
+
+    EXPECT_NE(baseline, hash_of(a_topic(), topic_id_of(2)));
+
+    EXPECT_NE(
+      baseline,
+      hash_of(
+        {racks_of({"rack-a"}), racks_of({"rack-b"}), racks_of({"rack-c"})}));
+
+    EXPECT_NE(baseline, hash_of({racks_of({"rack-z"}), racks_of({"rack-b"})}));
+
+    EXPECT_NE(
+      baseline,
+      hash_of({racks_of({"rack-a", "rack-b"}), racks_of({"rack-b"})}));
+
+    EXPECT_NE(baseline, hash_of({racks(), racks_of({"rack-b"})}));
+}
+
+TEST(subscription_metadata_hash, binds_racks_to_their_partition) {
+    EXPECT_NE(
+      hash_of({racks_of({"rack-a"}), racks_of({"rack-b"})}),
+      hash_of({racks_of({"rack-b"}), racks_of({"rack-a"})}));
+}
+
+/// A length precedes each variable-length field, so two field lists that
+/// concatenate to the same bytes give distinct hashes.
+TEST(subscription_metadata_hash, distinguishes_regrouped_strings) {
+    EXPECT_NE(
+      hash_of({racks_of({"a", "bc"})}), hash_of({racks_of({"ab", "c"})}));
+
+    EXPECT_NE(
+      hash_of({racks_of({"rack-a"})}, topic_id_of(1), "topic-11"),
+      hash_of({racks_of({"1rack-a"})}, topic_id_of(1), "topic-1"));
+}
+
+TEST(subscription_metadata_hash, empty_subscription_hashes_to_zero) {
+    EXPECT_EQ(kafka::subscription_metadata_hash({}), 0);
+}
+
+TEST(subscription_metadata_hash, group_hash_follows_its_topics) {
+    const auto topic_hash = hash_of(a_topic());
+
+    kafka::topic_metadata_hashes one_topic;
+    one_topic.emplace(topic_id_of(1), topic_hash);
+
+    kafka::topic_metadata_hashes two_topics = one_topic;
+    two_topics.emplace(topic_id_of(2), topic_hash);
+
+    kafka::topic_metadata_hashes changed_topic;
+    changed_topic.emplace(topic_id_of(1), topic_hash + 1);
+
+    EXPECT_NE(
+      kafka::subscription_metadata_hash(one_topic),
+      kafka::subscription_metadata_hash(two_topics));
+    EXPECT_NE(
+      kafka::subscription_metadata_hash(one_topic),
+      kafka::subscription_metadata_hash(changed_topic));
+}

--- a/src/v/kafka/server/tests/subscription_metadata_hash_test.cc
+++ b/src/v/kafka/server/tests/subscription_metadata_hash_test.cc
@@ -140,3 +140,18 @@ TEST(subscription_metadata_hash, group_hash_follows_its_topics) {
       kafka::subscription_metadata_hash(one_topic),
       kafka::subscription_metadata_hash(changed_topic));
 }
+
+/// Catches a change to the hash that the cases above still accept, such as a
+/// different hash function, byte order or length unit.
+TEST(subscription_metadata_hash, algorithm_is_frozen) {
+    EXPECT_EQ(hash_of(a_topic()), 3141736076706975280);
+
+    EXPECT_EQ(
+      hash_of({racks_of({"rack-a"})}, topic_id_of(3), "topic-\xc3\xa9"),
+      -7662982349425315869);
+
+    kafka::topic_metadata_hashes group;
+    group.emplace(topic_id_of(1), -2);
+    group.emplace(topic_id_of(2), 3);
+    EXPECT_EQ(kafka::subscription_metadata_hash(group), -2579233394402444332);
+}


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

A consumer group's assignment depends on the metadata of the topics it subscribes to. Nothing tells the group when that metadata changes, so the group stores a hash of it and recomputes the hash to decide whether to bump the group epoch and reassign. This adds that computation. See [KIP-1101](https://cwiki.apache.org/confluence/spaces/KAFKA/pages/327977750/KIP-1101+Trigger+rebalance+on+rack+topology+changes)
  

Two levels, as Kafka has them: a hash per topic, and a group hash over the collected topic hashes subscribed by the group. A simple cache shares a topic's hash between groups, dropping entries on metadata changes (either topic or group metadata).

A topic's hash covers:
  - a version byte, bumped when the function or inputs change to force a rebalance on every group
  - the topic id, name, and partition count
  - per partition, in ascending order of partition id: 
     - the partition id
     - the sorted racks of its replicas

The group hash covers the per-topic hashes in order of ascending topic id, and is 0 for an empty map. A topic absent from cluster metadata is left out rather than hashed, so creating it changes the group hash.

A hash that differs across nodes or restarts rebalances the group on every heartbeat, so:

To keep a consistent hash value across nodes or restarts, we 
  - use a stable hash function (xxh3_64)
  - sort racks and topics before hashing
  - ensure integers are hashed fixed-width big-endian
  - length-prefix variable length fields

Nothing compares a hash across a Kafka boundary: a client never sees it, cluster linking mirrors offsets, and an import from Kafka recomputes.

Kafka references, at apache/kafka fce22525f7:

  - [computeTopicHash, the per-topic inputs](https://github.com/apache/kafka/blob/fce22525f74bbd7feeb4f8b34c79a215db9a74c3/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Utils.java#L491-L522)
  - [computeGroupHash, the group hash](https://github.com/apache/kafka/blob/fce22525f74bbd7feeb4f8b34c79a215db9a74c3/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Utils.java#L453-L468)
  - [ModernGroup.computeMetadataHash, which leaves out absent topics](https://github.com/apache/kafka/blob/fce22525f74bbd7feeb4f8b34c79a215db9a74c3/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/ModernGroup.java#L375-L386)
  - [KRaftCoordinatorMetadataImage.partitionRacks, where racks come from](https://github.com/apache/kafka/blob/fce22525f74bbd7feeb4f8b34c79a215db9a74c3/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/KRaftCoordinatorMetadataImage.java#L140-L154)

Nothing calls this yet. It sits in its own library targets, so it and its tests build without the Kafka server.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
