### PR TITLE
rptest: install the expired cert after startup

### DIFF
--- a/tests/rptest/tests/tls_metrics_test.py
+++ b/tests/rptest/tests/tls_metrics_test.py
@@ -410,7 +410,7 @@ EXPIRED_CERT_ALLOW_LIST = [
 
 class TLSMetricsTestExpiring(TLSMetricsTestBase):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, broker_faketime="-23.995h", **kwargs)
+        super().__init__(*args, **kwargs)
         self.tls = tls.TLSCertManager(self.logger, cert_expiry_days=1)
 
     def setUp(self):
@@ -422,6 +422,17 @@ class TLSMetricsTestExpiring(TLSMetricsTestBase):
         Test that metrics detect an expired certificate
         """
         node = self.redpanda.nodes[0]
+
+        # The cluster starts with ordinary certs so that setUp can reach the
+        # Kafka API, then swaps in certs whose validity window already closed
+        # (signed 2 days ago, valid for 1). Expiring the cert *before* it is
+        # installed keeps the assertion below independent of how long startup
+        # took.
+        self.security.tls_provider = FaketimeTLSProvider(
+            self.tls, broker_faketime="-2d"
+        )
+        self.redpanda.set_security_settings(self.security)
+        self.redpanda.write_tls_certs()
 
         def certs_expired():
             metric_values = self._unpack_samples(


### PR DESCRIPTION
The broker cert was signed ~18s from expiry, so `setUp` had to start the cluster
and pass `wait_for_membership` (a Kafka TLS handshake) before it expired. The
arm64 debug runner needs ~24s and now always loses: 11/11 failures in build
88454, and again in each of 88466–88470.

The cluster now starts on ordinary certs and an already-expired one is installed
inside the test body, so the assertion no longer depends on startup latency.
Verified with `tools/dt`: a 20s delay before `wait_for_membership` reproduces the
old failure and passes on the new test; 8/8 for the file.

Fixes https://redpandadata.atlassian.net/browse/CORE-17008

Related: https://redpandadata.atlassian.net/browse/CORE-10158 — same scheme, and
its `EXPIRED_CERT_ALLOW_LIST` is still needed, so it stays.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [x] v25.3.x

## Release Notes

* none