### PR TITLE
[v26.2.x] `config`: mark dev-features flag usable_before_ready

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -5304,9 +5304,11 @@ configuration::configuration()
       "or any cluster where stability, data loss, or the ability to upgrade "
       "are a concern. To enable experimental features, set the value of this "
       "configuration option to the current unix epoch expressed in seconds. "
-      "The value must be within one hour of the current time on the broker."
+      "The value must be within one hour of the current time on the broker. "
       "Once experimental features are enabled they cannot be disabled.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no,
+       .visibility = visibility::tunable,
+       .usable_before_ready = usable_before_ready::yes},
       "",
       [this](const ss::sstring& v) -> std::optional<ss::sstring> {
           if (development_features_enabled()) {


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31453
