### PR TITLE
bazel: link only benches dynamically, and only outside opt

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,11 +27,6 @@ common --@toolchains_llvm//toolchain/config:compiler-rt=False
 build --linkopt --unwindlib=libgcc
 build --linkopt -stdlib=libc++
 
-# Statically linked binaries (mostly benches) are very large (up to ~4 GB in
-# debug), which isn't necessary in dev and debug modes: link dynamically by
-# default. Release overrides this back to static linking below.
-build --dynamic_mode=fully
-
 # Use Bash instead of system python for finding the hermetic interpreter
 # within Bazel due to the `python3` binary not being present on CI
 # (it has `python` version 3 but Bazel uses the `python3` executable).
@@ -345,7 +340,6 @@ build:secure --config=relro
 # --config=release doesn't create a _true_ release binary, that needs at
 # least --stamp=full and PGO-specific compile steps (outside of bazel).
 build:release --compilation_mode opt
-build:release --dynamic_mode=default
 build:release --config=secure
 build:release --@seastar//:stack_guards=False --@seastar//:debug=False
 build:release --copt -g --strip=never

--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -475,6 +475,15 @@ def redpanda_cc_bench(
         deps = deps + test_deps,
         testonly = True,
         copts = redpanda_copts(),
+        # Statically linked bench binaries are huge - the biggest reach ~4 GB in
+        # debug, too large for the remote cache to store, so the gRPC upload
+        # exceeds its deadline and their link actions never get a cache hit.
+        # Link them dynamically, except in optimized builds, which is where the
+        # numbers actually get measured.
+        linkstatic = select({
+            "//bazel:optimized_build": True,
+            "//conditions:default": False,
+        }),
         features = [
             "layering_check",
         ],


### PR DESCRIPTION
`--dynamic_mode=fully` make rp (and all other binaries) link dynamically in non-release. A dynamically linked debug `redpanda` spends ~4s in the dynamic loader on every exec (in CI, at least).

That broke `TLSMetricsTestExpiring.test_detect_expired_cert` (CORE-17008), whose broker certificate is valid for only ~18s by construction, and it added ~10% to ducktape shard wall time. Measured across matched ducktape shards either side of the change (209 tests, 519 broker starts per side): exec to first log line went from 1.79s to 5.72s median, while in-process init stayed flat at 0.75s. Upgrade tests that launch the *released* binary over the same ssh path moved only 0.16s, which rules out agent variance.

That flake is being fixed regardless but the latter is still very bad. So go back to static for all binaries except benches. In practice, that's just 2 binaries: redpanda and rp_util (I think).

So this scopes the flag down to what motivated it: `linkstatic = False` on the bench `cc_binary`, except in optimized builds, where the numbers are measured. This cannot be written as a per-target opt-out of the global flag, because Bazel's linking mode decision returns DYNAMIC as soon as it sees `DynamicMode.FULLY`, before it ever consults the `linkstatic` attribute.

Verified with a debug build: `redpanda` links no `libsrc_Sv_*.so` (only the krb5 prebuilts, same as before #31354), and `ioarray_rpbench_binary` links 155 bazel-built `.so`s in debug and 4 under `-c opt`.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none