### PR TITLE
bazel/seastar: silence PGO CFG hash mismatch warnings in iotune

### DIFF
--- a/bazel/thirdparty/seastar.BUILD
+++ b/bazel/thirdparty/seastar.BUILD
@@ -775,6 +775,12 @@ cc_binary(
     srcs = [
         "apps/iotune/iotune.cc",
     ],
+    # Silences "CFG hash mismatch" warnings which stem from the fact that we
+    # compile multiple binaries with only the RP profile data.
+    # Similar to: https://issues.chromium.org/issues/40272404
+    copts = [
+        "-Wno-backend-plugin",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         ":seastar",


### PR DESCRIPTION
PGO builds compile seastar's `iotune` binary using the profile data gathered
from the `redpanda` binary, so the profile reader reports control flow hash
mismatches for it:

```
error: external/+non_module_dependencies+seastar/apps/iotune/iotune.cc: function control flow change detected (hash mismatch) main Hash = 590097511905153941 up to 3 count discarded [-Werror,-Wbackend-plugin]
```

These warnings are benign (similar to https://issues.chromium.org/issues/40272404),
but became build failures once #31452 applied `-Werror` to all compiles, including
external modules. PR builds don't use PGO, which is why this only showed up on dev.

This disables `-Wbackend-plugin` for the `iotune` binary, which is a separate
target from the main redpanda binary, so the suppression stays narrowly scoped.

Verified with `bazel aquery 'mnemonic("CppCompile", @seastar//:iotune)'` that the
flag reaches iotune's compile action.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none