### PR TITLE
[v25.3.x] rptest: install the expired cert after startup

### DIFF
--- a/tests/rptest/tests/tls_metrics_test.py
+++ b/tests/rptest/tests/tls_metrics_test.py
@@ -408,7 +408,7 @@ EXPIRED_CERT_ALLOW_LIST = [
 
 class TLSMetricsTestExpiring(TLSMetricsTestBase):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, broker_faketime="-23.995h", **kwargs)
+        super().__init__(*args, **kwargs)
         self.tls = tls.TLSCertManager(self.logger, cert_expiry_days=1)
 
     def setUp(self):
@@ -420,6 +420,17 @@ class TLSMetricsTestExpiring(TLSMetricsTestBase):
         Test that metrics detect an expired certificate
         """
         node = self.redpanda.nodes[0]
+
+        # The cluster starts with ordinary certs so that setUp can reach the
+        # Kafka API, then swaps in certs whose validity window already closed
+        # (signed 2 days ago, valid for 1). Expiring the cert *before* it is
+        # installed keeps the assertion below independent of how long startup
+        # took.
+        self.security.tls_provider = FaketimeTLSProvider(
+            self.tls, broker_faketime="-2d"
+        )
+        self.redpanda.set_security_settings(self.security)
+        self.redpanda.write_tls_certs()
 
         def certs_expired():
             metric_values = self._unpack_samples(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31501
