### PR TITLE
ct/l0: deflake read_merge_test

### DIFF
--- a/src/v/cloud_topics/level_zero/common/level_zero_probe.h
+++ b/src/v/cloud_topics/level_zero/common/level_zero_probe.h
@@ -153,6 +153,9 @@ public:
         _bytes_out += bytes;
     }
 
+    uint64_t requests_in() const { return _requests_in; }
+    uint64_t requests_out() const { return _requests_out; }
+
 private:
     void setup_internal_metrics(bool disable);
 

--- a/src/v/cloud_topics/level_zero/read_merge/read_merge.h
+++ b/src/v/cloud_topics/level_zero/read_merge/read_merge.h
@@ -35,6 +35,10 @@ public:
     ss::future<> start();
     ss::future<> stop();
 
+    /// Request counters, exposed so tests can synchronize with the
+    /// background request processing.
+    const read_merge_probe& probe() const { return _probe; }
+
 private:
     using semaphore_units
       = seastar::semaphore_units<ss::named_semaphore_exception_factory, Clock>;

--- a/src/v/cloud_topics/level_zero/read_merge/tests/BUILD
+++ b/src/v/cloud_topics/level_zero/read_merge/tests/BUILD
@@ -18,6 +18,7 @@ redpanda_cc_gtest(
         "//src/v/config",
         "//src/v/model",
         "//src/v/model/tests:random",
+        "//src/v/test_utils:async",
         "//src/v/test_utils:gtest",
         "//src/v/utils:uuid",
         "@googletest//:gtest",

--- a/src/v/cloud_topics/level_zero/read_merge/tests/read_merge_test.cc
+++ b/src/v/cloud_topics/level_zero/read_merge/tests/read_merge_test.cc
@@ -15,6 +15,7 @@
 #include "model/namespace.h"
 #include "model/record.h"
 #include "model/tests/random_batch.h"
+#include "test_utils/async.h"
 #include "test_utils/test.h"
 #include "utils/uuid.h"
 
@@ -72,13 +73,31 @@ public:
 
         co_await sink.start(
           ss::sharded_parameter([this] { return std::ref(pipeline.local()); }));
+
+        _started = true;
     }
 
-    ss::future<> stop() {
+    // Runs even when a test body bails out on a failed assertion:
+    // sharded services must be stopped or their destructors abort
+    // the whole test binary.
+    ss::future<> TearDownAsync() override {
+        if (!_started) {
+            co_return;
+        }
         co_await pipeline.invoke_on_all([](auto& s) { return s.shutdown(); });
         co_await sink.stop();
         co_await merge.stop();
         co_await pipeline.stop();
+    }
+
+    /// read_merge processes pulled requests in concurrently spawned
+    /// background tasks, so tests must wait for it to catch up before
+    /// making assumptions about what reached the next stage.
+    ss::future<> merge_processed(uint64_t requests_in) {
+        co_await tests::cooperative_spin_wait_with_timeout(
+          10s, [this, requests_in] {
+              return merge.local().probe().requests_in() >= requests_in;
+          });
     }
 
     /// Helper: make a query targeting a specific object_id.
@@ -104,6 +123,9 @@ public:
     ss::sharded<l0::read_pipeline<ss::manual_clock>> pipeline;
     ss::sharded<l0::read_merge<ss::manual_clock>> merge;
     ss::sharded<fetch_handler> sink;
+
+private:
+    bool _started{false};
 };
 
 static const model::topic_namespace
@@ -131,8 +153,6 @@ TEST_F_CORO(read_merge_fixture, test_happy_path) {
     ASSERT_EQ_CORO(result.value().results.size(), 1);
     ASSERT_EQ_CORO(
       result.value().results.front().header().base_offset, model::offset{0});
-
-    co_await stop();
 }
 
 TEST_F_CORO(read_merge_fixture, test_error_propagation) {
@@ -152,8 +172,6 @@ TEST_F_CORO(read_merge_fixture, test_error_propagation) {
     auto result = co_await std::move(result_fut);
     ASSERT_FALSE_CORO(result.has_value());
     ASSERT_EQ_CORO(result.error(), errc::timeout);
-
-    co_await stop();
 }
 
 TEST_F_CORO(read_merge_fixture, test_merge_same_object) {
@@ -172,7 +190,13 @@ TEST_F_CORO(read_merge_fixture, test_merge_same_object) {
     auto fut2 = pipeline.local().make_reader(
       test_ntp, make_query(id), ss::manual_clock::now() + 10s);
 
+    // Wait until read_merge has processed both requests. Once it has,
+    // the second request is subscribed to the in-flight download and
+    // fulfilling the proxy below deterministically wakes it.
+    co_await merge_processed(2);
+
     // The fetch handler should only receive ONE proxy request (the first).
+    ASSERT_EQ_CORO(merge.local().probe().requests_out(), 1);
     auto request = co_await sink.local().get_next_requests();
     ASSERT_TRUE_CORO(request.has_value());
     ASSERT_EQ_CORO(request.value().requests.size(), 1);
@@ -198,8 +222,6 @@ TEST_F_CORO(read_merge_fixture, test_merge_same_object) {
     auto result2 = co_await std::move(fut2);
     ASSERT_TRUE_CORO(result2.has_value());
     ASSERT_EQ_CORO(result2.value().results.size(), 1);
-
-    co_await stop();
 }
 
 TEST_F_CORO(read_merge_fixture, test_merge_error_propagated_to_waiters) {
@@ -215,7 +237,14 @@ TEST_F_CORO(read_merge_fixture, test_merge_error_propagated_to_waiters) {
     auto fut2 = pipeline.local().make_reader(
       test_ntp, make_query(id), ss::manual_clock::now() + 10s);
 
+    // Wait until the second request is merged onto the in-flight
+    // download, otherwise failing the proxy below erases the in-flight
+    // entry before the merge happens and the second request gets its
+    // own proxy instead of the propagated error.
+    co_await merge_processed(2);
+
     // Only one proxy reaches the fetch handler.
+    ASSERT_EQ_CORO(merge.local().probe().requests_out(), 1);
     auto request = co_await sink.local().get_next_requests();
     ASSERT_TRUE_CORO(request.has_value());
     ASSERT_EQ_CORO(request.value().requests.size(), 1);
@@ -233,8 +262,6 @@ TEST_F_CORO(read_merge_fixture, test_merge_error_propagated_to_waiters) {
     auto result2 = co_await std::move(fut2);
     ASSERT_FALSE_CORO(result2.has_value());
     ASSERT_EQ_CORO(result2.error(), errc::timeout);
-
-    co_await stop();
 }
 
 TEST_F_CORO(read_merge_fixture, test_unique_objects_not_merged) {
@@ -251,7 +278,12 @@ TEST_F_CORO(read_merge_fixture, test_unique_objects_not_merged) {
     auto fut2 = pipeline.local().make_reader(
       test_ntp, make_query(id2), ss::manual_clock::now() + 10s);
 
+    // Wait until read_merge has processed both requests so that a
+    // single pull below observes both proxies.
+    co_await merge_processed(2);
+
     // The fetch handler should receive TWO proxy requests (one per object).
+    ASSERT_EQ_CORO(merge.local().probe().requests_out(), 2);
     auto request = co_await sink.local().get_next_requests();
     ASSERT_TRUE_CORO(request.has_value());
     ASSERT_EQ_CORO(request.value().requests.size(), 2);
@@ -268,8 +300,6 @@ TEST_F_CORO(read_merge_fixture, test_unique_objects_not_merged) {
     auto result2 = co_await std::move(fut2);
     ASSERT_TRUE_CORO(result2.has_value());
     ASSERT_EQ_CORO(result2.value().results.size(), 1);
-
-    co_await stop();
 }
 
 TEST_F_CORO(read_merge_fixture, test_second_request_after_first_completes) {
@@ -306,6 +336,4 @@ TEST_F_CORO(read_merge_fixture, test_second_request_after_first_completes) {
 
     auto result2 = co_await std::move(fut2);
     ASSERT_TRUE_CORO(result2.has_value());
-
-    co_await stop();
 }


### PR DESCRIPTION
Flaky under `--@seastar//:shuffle_task_queue=true` (12/30 local runs failed).
`read_merge` processes pulled requests in independently spawned tasks, but the
tests assumed the batch reaches the next stage atomically: one test observed a
partial pull, another hung when a request missed the merge window. The tests
now synchronize on the probe's request counters. Fixture shutdown moved to
`TearDownAsync` so a failed assertion no longer aborts the test binary.
100/100 shuffled runs pass after the fix.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none