### PR TITLE
pandaproxy: run REST proxy in a dedicated scheduling group

### DIFF
--- a/bazel/thirdparty/seastar.BUILD
+++ b/bazel/thirdparty/seastar.BUILD
@@ -74,7 +74,7 @@ int_flag(
 
 int_flag(
     name = "scheduling_groups",
-    build_setting_default = 21,
+    build_setting_default = 22,
     make_variable = "SCHEDULING_GROUPS",
 )
 

--- a/src/v/pandaproxy/rest/BUILD
+++ b/src/v/pandaproxy/rest/BUILD
@@ -61,6 +61,7 @@ redpanda_cc_library(
         "//src/v/pandaproxy:parsing",
         "//src/v/pandaproxy:rest_requests",
         "//src/v/pandaproxy:rest_swagger_definitions",
+        "//src/v/resource_mgmt:cpu_scheduling",
         "//src/v/security",
         "//src/v/security:request_auth",
         "//src/v/ssx:sformat",

--- a/src/v/pandaproxy/rest/proxy.cc
+++ b/src/v/pandaproxy/rest/proxy.cc
@@ -18,6 +18,7 @@
 #include "pandaproxy/rest/configuration.h"
 #include "pandaproxy/rest/handlers.h"
 #include "pandaproxy/rest/iceberg_handlers.h"
+#include "resource_mgmt/cpu_scheduling.h"
 #include "security/authorizer.h"
 
 #include <seastar/coroutine/parallel_for_each.hh> // NOLINT(misc-include-cleaner): required for co_await/co_return coroutine support
@@ -130,7 +131,7 @@ proxy::proxy(
   , _client_cache(client_cache)
   , _controller(controller)
   , _dl_frontend(dl_frontend)
-  , _ctx{{{{}, max_memory, _mem_sem, _inflight_config_binding(), _inflight_sem, {}, smp_sg}, *this},
+  , _ctx{{{{}, max_memory, _mem_sem, _inflight_config_binding(), _inflight_sem, {}, smp_sg, scheduling_groups::instance().pandaproxy_sg()}, *this},
   {config::always_true(), config::shard_local_cfg().superusers.bind(), controller},
   _config.pandaproxy_api.value()}
   , _topic_table(controller->get_topics_state())

--- a/src/v/pandaproxy/server.cc
+++ b/src/v/pandaproxy/server.cc
@@ -21,6 +21,7 @@
 #include "utils/truncating_logger.h"
 
 #include <seastar/core/coroutine.hh> // NOLINT(misc-include-cleaner): required for co_await/co_return coroutine support
+#include <seastar/coroutine/switch_to.hh>
 #include <seastar/http/function_handlers.hh> // NOLINT(misc-include-cleaner): provides ss::httpd::handler_base
 #include <seastar/http/reply.hh>
 #include <seastar/net/tls.hh>
@@ -256,6 +257,8 @@ ss::future<> server::start(
   const std::vector<config::rest_authn_endpoint>& endpoints,
   const std::vector<config::endpoint_tls_config>& endpoints_tls,
   const std::vector<model::broker_endpoint>& advertised) {
+    co_await ss::coroutine::switch_to(_ctx.sg);
+
     _server._routes.register_exeption_handler(
       exception_replier{ss::sstring{name(_exceptional_mime_type)}, _log});
 

--- a/src/v/pandaproxy/server.h
+++ b/src/v/pandaproxy/server.h
@@ -26,6 +26,7 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
+#include <seastar/core/scheduling.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/http/api_docs.hh>
@@ -79,6 +80,8 @@ public:
         adjustable_semaphore& inflight_sem;
         ss::abort_source as;
         ss::smp_service_group smp_sg;
+        // Scheduling group for request processing on accepted connections.
+        ss::scheduling_group sg = ss::default_scheduling_group();
     };
 
     struct request_t {

--- a/src/v/resource_mgmt/cpu_scheduling.h
+++ b/src/v/resource_mgmt/cpu_scheduling.h
@@ -137,6 +137,13 @@ public:
          */
         _cloud_topics_metastore = co_await ss::create_scheduling_group(
           "cloud_topics_metastore", 1000);
+        /**
+         * Group used to process REST proxy (pandaproxy) requests: HTTP
+         * parsing, authentication, and handler bodies. Keeps a proxy
+         * request flood from starving work in the default group, and makes
+         * proxy CPU visible in per-group scheduler metrics.
+         */
+        _pandaproxy = co_await ss::create_scheduling_group("pandaproxy", 1000);
     }
 
     ss::scheduling_group admin_sg() { return _admin; }
@@ -186,6 +193,7 @@ public:
     ss::scheduling_group cloud_topics_metastore_sg() {
         return _cloud_topics_metastore;
     }
+    ss::scheduling_group pandaproxy_sg() { return _pandaproxy; }
 
     std::vector<std::reference_wrapper<const ss::scheduling_group>>
     all_scheduling_groups() const {
@@ -209,7 +217,8 @@ public:
           std::cref(_cluster_linking),
           std::cref(_cloud_topics_compaction),
           std::cref(_cloud_topics_reconciler),
-          std::cref(_cloud_topics_metastore)};
+          std::cref(_cloud_topics_metastore),
+          std::cref(_pandaproxy)};
     }
 
 private:
@@ -236,4 +245,5 @@ private:
     ss::scheduling_group _cloud_topics_compaction;
     ss::scheduling_group _cloud_topics_reconciler;
     ss::scheduling_group _cloud_topics_metastore;
+    ss::scheduling_group _pandaproxy;
 };

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -32,6 +32,7 @@ from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import (
     LoggingConfig,
+    MetricsEndpoint,
     PandaproxyConfig,
     ResourceSettings,
     SecurityConfig,
@@ -476,6 +477,52 @@ class PandaProxyEndpoints(RedpandaTest):
 
         check_produce_output(
             self._produce_topic(topic_name, data, auth=auth_tuple), expected_offset=1
+        )
+
+
+class PandaProxySchedulingGroupTest(PandaProxyEndpoints):
+    """
+    Verify REST proxy request processing runs in the dedicated
+    "pandaproxy" scheduling group by asserting proxy traffic accrues
+    runtime in the group's public scheduler metric.
+    """
+
+    def _pandaproxy_scheduler_runtime_secs(self) -> float:
+        samples = self.redpanda.metrics_sample(
+            sample_pattern="scheduler_runtime_seconds",
+            metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS,
+        )
+        assert samples is not None, "scheduler runtime metric not found"
+        pandaproxy_samples = samples.label_filter(
+            {"redpanda_scheduling_group": "pandaproxy"}
+        )
+        return sum(s.value for s in pandaproxy_samples.samples)
+
+    @cluster(num_nodes=3)
+    def test_proxy_requests_run_in_pandaproxy_group(self):
+        name = create_topic_names(1)[0]
+        self._create_topics([name], partitions=1)
+
+        # Creating a scheduling group runs a tiny setup task inside the
+        # new group on every shard, so its runtime counter is nonzero
+        # from boot. Assert that proxy traffic grows the counter instead
+        # of asserting on the absolute value.
+        baseline = self._pandaproxy_scheduler_runtime_secs()
+
+        data = '{"records": [{"value": "cGFuZGFwcm94eQ==", "partition": 0}]}'
+        for _ in range(200):
+            result = self._produce_topic(name, data)
+            assert result.status_code == requests.codes.ok
+
+        runtime = self._pandaproxy_scheduler_runtime_secs()
+        growth = runtime - baseline
+        self.logger.info(
+            f"pandaproxy group runtime: baseline={baseline}s, "
+            f"after traffic={runtime}s, growth={growth}s"
+        )
+        assert growth > 0.01, (
+            "expected proxy traffic to accrue scheduler runtime in the "
+            f"pandaproxy group: baseline={baseline}s, growth={growth}s"
         )
 
 


### PR DESCRIPTION
The REST proxy currently runs its request processing in the `main` scheduling group. In a recent incident, high-rate HTTP produce traffic (with per-request SCRAM password hashing in Basic auth dominating the cost) saturated broker CPU, and the raft heartbeat send path, which also runs in `main`, queued behind the proxy work until the controller went leaderless. Per-group scheduler metrics could only attribute the burn to `main`; pinpointing the proxy required a CPU profile.

This PR moves REST proxy request processing into a dedicated `pandaproxy` scheduling group (1000 shares to match kafka processing): `server::start` switches into the group before it starts listening, so the accept loop and everything the accepted connections run (HTTP parse, authentication, handler bodies) inherit it. Listener setup in `start` (address resolution, TLS credentials and their cert-reload watchers) lands in the group too, which keeps the proxy's own work attributed in one place. Under CPU contention the proxy now competes as a single group while other groups keep their entitlements; under light load nothing changes (the scheduler is work-conserving). Per-group scheduler metrics, including the public `redpanda_scheduler_runtime_seconds_total`, now attribute proxy CPU out of the box.

Schema Registry shares the server implementation but stays in `main`.

The ducktape test asserts proxy produce traffic grows the group's public scheduler-runtime metric (growth rather than absolute value, because group creation itself accrues a few microseconds at boot). Verified red (growth exactly 0.0 without the wiring) and green (~0.2s growth for 200 requests).

Fixes [CORE-17022](https://redpandadata.atlassian.net/browse/CORE-17022)

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

### Improvements

* The HTTP Proxy (pandaproxy) now processes requests in a dedicated `pandaproxy` CPU scheduling group, isolating heavy proxy traffic from other broker work and making proxy CPU usage visible in per-scheduling-group metrics.


[CORE-17022]: https://redpandadata.atlassian.net/browse/CORE-17022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
