### PR TITLE
datalake: Configure parquet writing using Iceberg table properties

### DIFF
--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -104,10 +104,13 @@ redpanda_cc_library(
         ":logger",
         "//src/v/base",
         "//src/v/strings:string_switch",
+        "@abseil-cpp//absl/container:flat_hash_map",
     ],
     visibility = [":__subpackages__"],
     deps = [
+        "//src/v/container:chunked_vector",
         "//src/v/iceberg:table_metadata",
+        "@seastar",
     ],
 )
 
@@ -510,7 +513,9 @@ redpanda_cc_library(
         "//src/v/iceberg/conversion:schema_parquet",
         "//src/v/iceberg/conversion:values_parquet",
         "//src/v/serde/parquet:metadata",
+        "//src/v/serde/parquet:schema",
         "//src/v/version",
+        "@fmt",
     ],
     visibility = [":__subpackages__"],
     deps = [
@@ -518,6 +523,7 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/iceberg:datatypes",
         "//src/v/serde/parquet:writer",
+        "@abseil-cpp//absl/container:flat_hash_map",
         "@seastar",
     ],
 )

--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -100,6 +100,11 @@ redpanda_cc_library(
     hdrs = [
         "parquet_write_config.h",
     ],
+    implementation_deps = [
+        ":logger",
+        "//src/v/base",
+        "//src/v/strings:string_switch",
+    ],
     visibility = [":__subpackages__"],
     deps = [
         "//src/v/iceberg:table_metadata",
@@ -381,6 +386,7 @@ redpanda_cc_library(
     visibility = [":__subpackages__"],
     deps = [
         ":location",
+        ":parquet_write_config",
         ":partitioning_writer",
         ":schema_identifier",
         ":types",

--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -67,6 +67,7 @@ redpanda_cc_library(
     ],
     visibility = [":__subpackages__"],
     deps = [
+        ":parquet_write_config",
         ":partition_key_path",
         ":writer",
         "//src/v/base",
@@ -92,6 +93,20 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "parquet_write_config",
+    srcs = [
+        "parquet_write_config.cc",
+    ],
+    hdrs = [
+        "parquet_write_config.h",
+    ],
+    visibility = [":__subpackages__"],
+    deps = [
+        "//src/v/iceberg:table_metadata",
+    ],
+)
+
+redpanda_cc_library(
     name = "writer",
     srcs = [
         "data_writer_interface.cc",
@@ -105,6 +120,7 @@ redpanda_cc_library(
     visibility = [":__subpackages__"],
     deps = [
         ":base_types",
+        ":parquet_write_config",
         "//src/v/base",
         "//src/v/iceberg:datatypes",
         "//src/v/iceberg:values",
@@ -461,6 +477,7 @@ redpanda_cc_library(
     visibility = [":__subpackages__"],
     deps = [
         ":logger",
+        ":parquet_write_config",
         ":writer",
         "//src/v/base",
         "//src/v/container:chunked_vector",

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -12,6 +12,7 @@
 #include "base/format_to.h"
 #include "base/outcome.h"
 #include "datalake/base_types.h"
+#include "datalake/parquet_write_config.h"
 #include "iceberg/datatypes.h"
 #include "iceberg/values.h"
 
@@ -233,6 +234,7 @@ public:
 
     virtual ss::future<std::unique_ptr<parquet_ostream>> create_writer(
       const iceberg::struct_type&,
+      const parquet_write_config&,
       ss::output_stream<char>,
       writer_mem_tracker&) = 0;
 };
@@ -285,8 +287,10 @@ public:
 
     virtual ss::future<
       result<std::unique_ptr<parquet_file_writer>, writer_error>>
-    create_writer(const iceberg::struct_type& /* schema */, ss::abort_source&)
-      = 0;
+    create_writer(
+      const iceberg::struct_type& /* schema */,
+      const parquet_write_config&,
+      ss::abort_source&) = 0;
 };
 
 } // namespace datalake

--- a/src/v/datalake/local_parquet_file_writer.cc
+++ b/src/v/datalake/local_parquet_file_writer.cc
@@ -74,7 +74,9 @@ local_parquet_file_writer::local_parquet_file_writer(
   , _mem_tracker(mem_tracker) {}
 
 ss::future<checked<std::nullopt_t, writer_error>>
-local_parquet_file_writer::initialize(const iceberg::struct_type& schema) {
+local_parquet_file_writer::initialize(
+  const iceberg::struct_type& schema,
+  const parquet_write_config& write_config) {
     vlog(datalake_log.info, "Writing Parquet file to {}", _output_file_path);
     ss::file output_file;
     try {
@@ -106,7 +108,7 @@ local_parquet_file_writer::initialize(const iceberg::struct_type& schema) {
     }
 
     _writer = co_await _writer_factory->create_writer(
-      schema, std::move(fut.get()), _mem_tracker);
+      schema, write_config, std::move(fut.get()), _mem_tracker);
     _initialized = true;
     co_return std::nullopt;
 }
@@ -227,7 +229,9 @@ local_parquet_file_writer_factory::local_parquet_file_writer_factory(
 
 ss::future<result<std::unique_ptr<parquet_file_writer>, writer_error>>
 local_parquet_file_writer_factory::create_writer(
-  const iceberg::struct_type& schema, ss::abort_source& as) {
+  const iceberg::struct_type& schema,
+  const parquet_write_config& write_config,
+  ss::abort_source& as) {
     // Buffered row data is reserved separately as it is written.
     const size_t reservation_bytes = output_stream_buffer_size
                                      + serde::parquet::writer::estimated_memory(
@@ -240,7 +244,7 @@ local_parquet_file_writer_factory::create_writer(
     auto writer = std::make_unique<local_parquet_file_writer>(
       create_filename(), _writer_factory, _mem_tracker);
 
-    auto res = co_await writer->initialize(schema);
+    auto res = co_await writer->initialize(schema, write_config);
     if (res.has_error()) {
         co_return res.error();
     }

--- a/src/v/datalake/local_parquet_file_writer.h
+++ b/src/v/datalake/local_parquet_file_writer.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "datalake/data_writer_interface.h"
+#include "datalake/parquet_write_config.h"
 
 #include <seastar/core/file.hh>
 
@@ -27,7 +28,7 @@ public:
       local_path, ss::shared_ptr<parquet_ostream_factory>, writer_mem_tracker&);
 
     ss::future<checked<std::nullopt_t, writer_error>>
-    initialize(const iceberg::struct_type&);
+    initialize(const iceberg::struct_type&, const parquet_write_config&);
 
     ss::future<writer_error> add_data_struct(
       iceberg::struct_value /* data */,
@@ -68,7 +69,10 @@ public:
       writer_mem_tracker&);
 
     ss::future<result<std::unique_ptr<parquet_file_writer>, writer_error>>
-    create_writer(const iceberg::struct_type& schema, ss::abort_source&) final;
+    create_writer(
+      const iceberg::struct_type& schema,
+      const parquet_write_config&,
+      ss::abort_source&) final;
 
 private:
     local_path create_filename() const;

--- a/src/v/datalake/parquet_write_config.cc
+++ b/src/v/datalake/parquet_write_config.cc
@@ -9,11 +9,48 @@
  */
 #include "datalake/parquet_write_config.h"
 
+#include "base/vlog.h"
+#include "datalake/logger.h"
+#include "strings/string_switch.h"
+
+#include <algorithm>
+#include <cctype>
+
 namespace datalake {
 
+namespace {
+constexpr std::string_view codec_key = "write.parquet.compression-codec";
+} // namespace
+
 parquet_write_config parquet_write_config::from_properties(
-  const std::optional<iceberg::table_properties_t>&) {
-    return {};
+  const std::optional<iceberg::table_properties_t>& props) {
+    parquet_write_config config;
+    if (!props) {
+        return config;
+    }
+    auto it = props->find(codec_key);
+    if (it == props->end()) {
+        return config;
+    }
+    // Iceberg convention: codec values are case-insensitive.
+    auto codec = it->second;
+    std::ranges::transform(
+      codec, codec.begin(), [](unsigned char c) { return std::tolower(c); });
+    auto compress = string_switch<std::optional<bool>>(codec)
+                      .match("zstd", true)
+                      .match("uncompressed", false)
+                      .match("none", false)
+                      .default_match(std::nullopt);
+    if (compress.has_value()) {
+        config.compress = *compress;
+    } else {
+        vlog(
+          datalake_log.warn,
+          "unsupported write.parquet.compression-codec '{}', falling back to "
+          "zstd",
+          it->second);
+    }
+    return config;
 }
 
 } // namespace datalake

--- a/src/v/datalake/parquet_write_config.cc
+++ b/src/v/datalake/parquet_write_config.cc
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/parquet_write_config.h"
+
+namespace datalake {
+
+parquet_write_config parquet_write_config::from_properties(
+  const std::optional<iceberg::table_properties_t>&) {
+    return {};
+}
+
+} // namespace datalake

--- a/src/v/datalake/parquet_write_config.cc
+++ b/src/v/datalake/parquet_write_config.cc
@@ -13,26 +13,28 @@
 #include "datalake/logger.h"
 #include "strings/string_switch.h"
 
+#include <absl/container/flat_hash_map.h>
+
 #include <algorithm>
 #include <cctype>
+#include <charconv>
 
 namespace datalake {
 
 namespace {
-constexpr std::string_view codec_key = "write.parquet.compression-codec";
-} // namespace
 
-parquet_write_config parquet_write_config::from_properties(
-  const std::optional<iceberg::table_properties_t>& props) {
-    parquet_write_config config;
-    if (!props) {
-        return config;
+constexpr std::string_view codec_key = "write.parquet.compression-codec";
+constexpr std::string_view bf_enabled_prefix
+  = "write.parquet.bloom-filter-enabled.column.";
+constexpr std::string_view bf_ndv_prefix
+  = "write.parquet.bloom-filter-ndv.column.";
+
+void parse_compression_codec(
+  parquet_write_config& config, const iceberg::table_properties_t& props) {
+    auto it = props.find(codec_key);
+    if (it == props.end()) {
+        return;
     }
-    auto it = props->find(codec_key);
-    if (it == props->end()) {
-        return config;
-    }
-    // Iceberg convention: codec values are case-insensitive.
     auto codec = it->second;
     std::ranges::transform(
       codec, codec.begin(), [](unsigned char c) { return std::tolower(c); });
@@ -50,6 +52,108 @@ parquet_write_config parquet_write_config::from_properties(
           "zstd",
           it->second);
     }
+}
+
+std::optional<bool> parse_bool_value(std::string_view value) {
+    ss::sstring lower(value);
+    std::ranges::transform(
+      lower, lower.begin(), [](unsigned char c) { return std::tolower(c); });
+    return string_switch<std::optional<bool>>(lower)
+      .match("true", true)
+      .match("false", false)
+      .default_match(std::nullopt);
+}
+
+std::optional<size_t> parse_size_value(std::string_view value) {
+    size_t result = 0;
+    auto [ptr, ec] = std::from_chars(value.begin(), value.end(), result);
+    if (ec != std::errc{} || ptr != value.end()) {
+        return std::nullopt;
+    }
+    return result;
+}
+
+void parse_bloom_filter_columns(
+  parquet_write_config& config, const iceberg::table_properties_t& props) {
+    // Two-pass: first collect enabled flags, then apply NDV overrides.
+    // Properties iterate in arbitrary order, so we can't assume enabled
+    // comes before ndv.
+    struct column_state {
+        bool enabled = false;
+        std::optional<size_t> ndv;
+    };
+    absl::flat_hash_map<ss::sstring, column_state> columns;
+
+    for (const auto& [key, value] : props) {
+        if (key.starts_with(bf_enabled_prefix)) {
+            auto col_name = key.substr(bf_enabled_prefix.size());
+            auto parsed = parse_bool_value(value);
+            if (!parsed) {
+                vlog(
+                  datalake_log.warn,
+                  "malformed bloom-filter-enabled value '{}' for column '{}', "
+                  "ignoring",
+                  value,
+                  col_name);
+                continue;
+            }
+            columns[col_name].enabled = *parsed;
+        } else if (key.starts_with(bf_ndv_prefix)) {
+            auto col_name = key.substr(bf_ndv_prefix.size());
+            auto parsed = parse_size_value(value);
+            if (!parsed) {
+                vlog(
+                  datalake_log.warn,
+                  "malformed bloom-filter-ndv value '{}' for column '{}', "
+                  "ignoring",
+                  value,
+                  col_name);
+                continue;
+            }
+            if (*parsed == 0) {
+                vlog(
+                  datalake_log.warn,
+                  "bloom-filter-ndv of 0 for column '{}' disables the filter, "
+                  "ignoring",
+                  col_name);
+                continue;
+            }
+            if (*parsed > parquet_write_config::max_bloom_filter_ndv) {
+                vlog(
+                  datalake_log.warn,
+                  "bloom-filter-ndv {} for column '{}' exceeds maximum {}, "
+                  "clamping",
+                  *parsed,
+                  col_name,
+                  parquet_write_config::max_bloom_filter_ndv);
+                *parsed = parquet_write_config::max_bloom_filter_ndv;
+            }
+            columns[col_name].ndv = *parsed;
+        }
+    }
+
+    for (auto& [name, state] : columns) {
+        if (!state.enabled) {
+            continue;
+        }
+        config.bloom_filter_columns.push_back({
+          .name = name,
+          .ndv = state.ndv.value_or(
+            parquet_write_config::default_bloom_filter_ndv),
+        });
+    }
+}
+
+} // namespace
+
+parquet_write_config parquet_write_config::from_properties(
+  const std::optional<iceberg::table_properties_t>& props) {
+    parquet_write_config config;
+    if (!props) {
+        return config;
+    }
+    parse_compression_codec(config, *props);
+    parse_bloom_filter_columns(config, *props);
     return config;
 }
 

--- a/src/v/datalake/parquet_write_config.h
+++ b/src/v/datalake/parquet_write_config.h
@@ -9,7 +9,10 @@
  */
 #pragma once
 
+#include "container/chunked_vector.h"
 #include "iceberg/table_metadata.h"
+
+#include <seastar/core/sstring.hh>
 
 #include <optional>
 
@@ -21,6 +24,20 @@ struct parquet_write_config {
     /// Compress column data with zstd. Set to false by
     /// write.parquet.compression-codec = "uncompressed".
     bool compress = true;
+
+    static constexpr size_t default_bloom_filter_ndv = 10'000;
+    // ~12 MiB per bloom filter at 9.6 bits/NDV.
+    static constexpr size_t max_bloom_filter_ndv = 10'000'000;
+
+    /// Per-column bloom filter configuration. Only columns explicitly
+    /// enabled via write.parquet.bloom-filter-enabled.column.<col>=true
+    /// appear here. The NDV comes from bloom-filter-ndv.column.<col> or
+    /// default_bloom_filter_ndv if unset.
+    struct bloom_column {
+        ss::sstring name;
+        size_t ndv;
+    };
+    chunked_vector<bloom_column> bloom_filter_columns;
 
     static parquet_write_config
     from_properties(const std::optional<iceberg::table_properties_t>&);

--- a/src/v/datalake/parquet_write_config.h
+++ b/src/v/datalake/parquet_write_config.h
@@ -18,6 +18,10 @@ namespace datalake {
 /// Parquet writer configuration parsed from Iceberg write.parquet.* table
 /// properties.
 struct parquet_write_config {
+    /// Compress column data with zstd. Set to false by
+    /// write.parquet.compression-codec = "uncompressed".
+    bool compress = true;
+
     static parquet_write_config
     from_properties(const std::optional<iceberg::table_properties_t>&);
 };

--- a/src/v/datalake/parquet_write_config.h
+++ b/src/v/datalake/parquet_write_config.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "iceberg/table_metadata.h"
+
+#include <optional>
+
+namespace datalake {
+
+/// Parquet writer configuration parsed from Iceberg write.parquet.* table
+/// properties.
+struct parquet_write_config {
+    static parquet_write_config
+    from_properties(const std::optional<iceberg::table_properties_t>&);
+};
+
+} // namespace datalake

--- a/src/v/datalake/partitioning_writer.cc
+++ b/src/v/datalake/partitioning_writer.cc
@@ -57,7 +57,8 @@ ss::future<writer_error> partitioning_writer::add_data(
     }
     auto writer_iter = writers_.find(pk);
     if (writer_iter == writers_.end()) {
-        auto writer_res = co_await writer_factory_.create_writer(type_, as);
+        auto writer_res = co_await writer_factory_.create_writer(
+          type_, write_config_, as);
         if (writer_res.has_error()) {
             vlog(
               datalake_log.error,

--- a/src/v/datalake/partitioning_writer.h
+++ b/src/v/datalake/partitioning_writer.h
@@ -12,6 +12,7 @@
 #include "base/format_to.h"
 #include "container/chunked_hash_map.h"
 #include "datalake/data_writer_interface.h"
+#include "datalake/parquet_write_config.h"
 #include "iceberg/datatypes.h"
 #include "iceberg/partition_key.h"
 #include "iceberg/schema.h"
@@ -36,13 +37,15 @@ public:
       iceberg::schema::id_t schema_id,
       iceberg::struct_type type,
       iceberg::partition_spec spec,
-      remote_path remote_prefix)
+      remote_path remote_prefix,
+      parquet_write_config write_config)
       : writer_factory_(factory)
       , schema_id_(schema_id)
       , type_(std::move(type))
       , accessors_(iceberg::struct_accessor::from_struct_type(type_))
       , spec_(std::move(spec))
-      , remote_prefix_(std::move(remote_prefix)) {}
+      , remote_prefix_(std::move(remote_prefix))
+      , write_config_(std::move(write_config)) {}
 
     // Adds the given value to the writer corresponding to the value's
     // partition key.
@@ -84,6 +87,8 @@ private:
     iceberg::struct_accessor::ids_accessor_map_t accessors_;
     iceberg::partition_spec spec_;
     remote_path remote_prefix_;
+
+    parquet_write_config write_config_;
 
     // Map of partition keys to their corresponding data file writers.
     chunked_hash_map<

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -14,6 +14,7 @@
 #include "datalake/data_writer_interface.h"
 #include "datalake/location.h"
 #include "datalake/logger.h"
+#include "datalake/parquet_write_config.h"
 #include "datalake/record_schema_resolver.h"
 #include "datalake/record_translator.h"
 #include "datalake/table_creator.h"
@@ -371,6 +372,8 @@ ss::future<ss::stop_iteration> record_multiplexer::do_multiplex(
                 co_return ss::stop_iteration::yes;
             }
 
+            auto write_config = parquet_write_config::from_properties(
+              load_res.value().properties);
             auto [iter, _] = _writers.emplace(
               record_type.comps,
               std::make_unique<partitioning_writer>(
@@ -378,7 +381,8 @@ ss::future<ss::stop_iteration> record_multiplexer::do_multiplex(
                 load_res.value().schema.schema_id,
                 std::move(record_type.type),
                 std::move(load_res.value().partition_spec),
-                std::move(data_remote_path.value())));
+                std::move(data_remote_path.value()),
+                std::move(write_config)));
             writer_iter = iter;
         }
 
@@ -623,12 +627,15 @@ record_multiplexer::handle_invalid_record(
                 co_return writer_error::unknown_error;
             }
 
+            auto write_config = parquet_write_config::from_properties(
+              load_res.value().properties);
             _invalid_record_writer = std::make_unique<partitioning_writer>(
               *_writer_factory,
               load_res.value().schema.schema_id,
               std::move(record_type.type),
               std::move(load_res.value().partition_spec),
-              std::move(data_remote_path.value()));
+              std::move(data_remote_path.value()),
+              std::move(write_config));
         }
 
         int64_t estimated_size = (key ? key->size_bytes() : 0)

--- a/src/v/datalake/serde_parquet_writer.cc
+++ b/src/v/datalake/serde_parquet_writer.cc
@@ -6,13 +6,68 @@
 #include "iceberg/conversion/schema_parquet.h"
 #include "iceberg/conversion/values_parquet.h"
 #include "serde/parquet/metadata.h"
+#include "serde/parquet/schema.h"
 #include "version/version.h"
 
 #include <seastar/util/defer.hh>
 
+#include <fmt/ranges.h>
+
 #include <variant>
 
 namespace datalake {
+
+absl::flat_hash_map<ss::sstring, size_t> resolve_bloom_filter_columns(
+  const parquet_write_config& config,
+  const iceberg::struct_type& iceberg_schema) {
+    absl::flat_hash_map<ss::sstring, size_t> result;
+    if (config.bloom_filter_columns.empty()) {
+        return result;
+    }
+
+    auto schema_copy = schema_to_parquet(iceberg_schema);
+    serde::parquet::index_schema(schema_copy);
+
+    // Build dot-paths for all leaves.
+    chunked_vector<ss::sstring> leaf_dot_paths;
+    schema_copy.for_each([&](const serde::parquet::schema_element& element) {
+        if (!element.is_leaf()) {
+            return;
+        }
+        // Drop the root name from the path.
+        chunked_vector<ss::sstring> segments;
+        auto it = element.path.begin();
+        for (++it; it != element.path.end(); ++it) {
+            segments.push_back(*it);
+        }
+        leaf_dot_paths.push_back(fmt::format("{}", fmt::join(segments, ".")));
+    });
+
+    for (const auto& col : config.bloom_filter_columns) {
+        size_t match_count = 0;
+        for (const auto& dot_path : leaf_dot_paths) {
+            if (dot_path == col.name) {
+                result[dot_path] = col.ndv;
+                ++match_count;
+            }
+        }
+        if (match_count == 0) {
+            vlog(
+              datalake_log.warn,
+              "bloom filter property references unknown column '{}', ignoring",
+              col.name);
+        } else if (match_count > 1) {
+            vlog(
+              datalake_log.warn,
+              "bloom filter column name '{}' matches {} schema paths "
+              "(ambiguous dot-separated name), applying to all",
+              col.name,
+              match_count);
+        }
+    }
+
+    return result;
+}
 
 writer_error serde_parquet_writer::set_error(writer_error e) {
     _error = e;
@@ -148,11 +203,13 @@ serde_parquet_writer_factory::create_writer(
   const parquet_write_config& write_config,
   ss::output_stream<char> out,
   writer_mem_tracker& mem_tracker) {
+    auto bloom_columns = resolve_bloom_filter_columns(write_config, schema);
     serde::parquet::writer::options opts{
       .schema = schema_to_parquet(schema),
       .version = ss::sstring(redpanda_git_version()),
       .build = ss::sstring(redpanda_git_revision()),
       .compress = write_config.compress,
+      .bloom_filter_columns = std::move(bloom_columns),
     };
     serde::parquet::writer writer(std::move(opts), std::move(out));
     co_await writer.init();

--- a/src/v/datalake/serde_parquet_writer.cc
+++ b/src/v/datalake/serde_parquet_writer.cc
@@ -145,14 +145,14 @@ chunked_vector<per_column_stats> serde_parquet_writer::column_stats() const {
 ss::future<std::unique_ptr<parquet_ostream>>
 serde_parquet_writer_factory::create_writer(
   const iceberg::struct_type& schema,
-  const parquet_write_config& /*write_config*/,
+  const parquet_write_config& write_config,
   ss::output_stream<char> out,
   writer_mem_tracker& mem_tracker) {
     serde::parquet::writer::options opts{
       .schema = schema_to_parquet(schema),
       .version = ss::sstring(redpanda_git_version()),
       .build = ss::sstring(redpanda_git_revision()),
-      .compress = true,
+      .compress = write_config.compress,
     };
     serde::parquet::writer writer(std::move(opts), std::move(out));
     co_await writer.init();

--- a/src/v/datalake/serde_parquet_writer.cc
+++ b/src/v/datalake/serde_parquet_writer.cc
@@ -145,6 +145,7 @@ chunked_vector<per_column_stats> serde_parquet_writer::column_stats() const {
 ss::future<std::unique_ptr<parquet_ostream>>
 serde_parquet_writer_factory::create_writer(
   const iceberg::struct_type& schema,
+  const parquet_write_config& /*write_config*/,
   ss::output_stream<char> out,
   writer_mem_tracker& mem_tracker) {
     serde::parquet::writer::options opts{

--- a/src/v/datalake/serde_parquet_writer.h
+++ b/src/v/datalake/serde_parquet_writer.h
@@ -38,6 +38,7 @@ class serde_parquet_writer_factory : public parquet_ostream_factory {
 public:
     ss::future<std::unique_ptr<parquet_ostream>> create_writer(
       const iceberg::struct_type&,
+      const parquet_write_config&,
       ss::output_stream<char>,
       writer_mem_tracker&) final;
 };

--- a/src/v/datalake/serde_parquet_writer.h
+++ b/src/v/datalake/serde_parquet_writer.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include "absl/container/flat_hash_map.h"
 #include "datalake/data_writer_interface.h"
 #include "iceberg/datatypes.h"
 #include "serde/parquet/writer.h"
+
+#include <seastar/core/sstring.hh>
 
 namespace datalake {
 class serde_parquet_writer : public parquet_ostream {
@@ -42,5 +45,12 @@ public:
       ss::output_stream<char>,
       writer_mem_tracker&) final;
 };
+
+/// Resolve per-column bloom filter config against the given Iceberg schema.
+/// Returns a map from dot-joined parquet column path (without root) to NDV.
+/// Warns on unknown columns (0 matches) and ambiguous dot-separated names
+/// (>1 match), applying config to all matches in the latter case.
+absl::flat_hash_map<ss::sstring, size_t> resolve_bloom_filter_columns(
+  const parquet_write_config& config, const iceberg::struct_type& schema);
 
 } // namespace datalake

--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -144,6 +144,7 @@ redpanda_cc_gtest(
         ":test_data_writer",
         ":test_utils",
         "//src/v/bytes",
+        "//src/v/datalake:parquet_write_config",
         "//src/v/datalake:partitioning_writer",
         "//src/v/datalake:table_definition",
         "//src/v/iceberg/tests:test_schemas",
@@ -241,6 +242,7 @@ redpanda_cc_gtest(
     deps = [
         ":test_data_writer",
         "//src/v/datalake:local_parquet_file_writer",
+        "//src/v/datalake:parquet_write_config",
         "//src/v/datalake/tests:test_data",
         "//src/v/iceberg:datatypes",
         "//src/v/iceberg/tests:value_generator",
@@ -263,6 +265,7 @@ redpanda_cc_gtest(
         "//src/v/bytes",
         "//src/v/bytes:iobuf",
         "//src/v/bytes:iostream",
+        "//src/v/datalake:parquet_write_config",
         "//src/v/datalake:serde_parquet_writer",
         "//src/v/datalake/tests:test_data",
         "//src/v/iceberg:datatypes",
@@ -270,6 +273,20 @@ redpanda_cc_gtest(
         "//src/v/iceberg/tests:value_generator",
         "//src/v/test_utils:gtest",
         "@fmt",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "parquet_write_config_test",
+    timeout = "short",
+    srcs = [
+        "parquet_write_config_test.cc",
+    ],
+    deps = [
+        "//src/v/datalake:parquet_write_config",
+        "//src/v/test_utils:gtest",
         "@googletest//:gtest",
         "@seastar",
     ],

--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -292,6 +292,22 @@ redpanda_cc_gtest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "resolve_bloom_filter_columns_test",
+    timeout = "short",
+    srcs = [
+        "resolve_bloom_filter_columns_test.cc",
+    ],
+    deps = [
+        "//src/v/datalake:parquet_write_config",
+        "//src/v/datalake:serde_parquet_writer",
+        "//src/v/iceberg:datatypes",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
 redpanda_cc_bench(
     name = "record_multiplexer_rpbench",
     timeout = "long",

--- a/src/v/datalake/tests/local_parquet_file_writer_test.cc
+++ b/src/v/datalake/tests/local_parquet_file_writer_test.cc
@@ -9,6 +9,7 @@
  */
 
 #include "datalake/local_parquet_file_writer.h"
+#include "datalake/parquet_write_config.h"
 #include "datalake/tests/test_data.h"
 #include "datalake/tests/test_data_writer.h"
 #include "iceberg/datatypes.h"
@@ -71,6 +72,7 @@ struct test_writer_factory : datalake::parquet_ostream_factory {
 
     ss::future<std::unique_ptr<datalake::parquet_ostream>> create_writer(
       const iceberg::struct_type&,
+      const datalake::parquet_write_config&,
       ss::output_stream<char> os,
       datalake::writer_mem_tracker&) final {
         co_return std::make_unique<test_writer>(
@@ -169,7 +171,7 @@ TEST_F(LocalFileWriterTest, TestHappyPath) {
       mem_tracker);
 
     auto schema = test_schema(iceberg::field_required::no);
-    file_writer.initialize(schema).get();
+    file_writer.initialize(schema, datalake::parquet_write_config{}).get();
 
     size_t rows = 1000;
     for (size_t i = 0; i < rows; i++) {
@@ -197,7 +199,7 @@ TEST_F(LocalFileWriterTest, TestErrorOnWrite) {
       ss::make_shared<test_writer_factory>(100),
       mem_tracker);
     auto schema = test_schema(iceberg::field_required::no);
-    file_writer.initialize(schema).get();
+    file_writer.initialize(schema, datalake::parquet_write_config{}).get();
 
     size_t rows = 1000;
     for (size_t i = 0; i < rows; i++) {
@@ -222,7 +224,7 @@ TEST_F(LocalFileWriterTest, TestErrorOnFinish) {
       ss::make_shared<test_writer_factory>(5000, true),
       mem_tracker);
     auto schema = test_schema(iceberg::field_required::no);
-    file_writer.initialize(schema).get();
+    file_writer.initialize(schema, datalake::parquet_write_config{}).get();
 
     size_t rows = 1000;
     for (size_t i = 0; i < rows; i++) {
@@ -251,8 +253,12 @@ TEST_F(LocalFileWriterTest, ReservationScalesWithLeafColumns) {
 
     auto reserved_for = [&](size_t n_leaves) -> size_t {
         tracker.last_reserved = 0;
-        auto res
-          = factory.create_writer(make_flat_int_schema(n_leaves), as).get();
+        auto res = factory
+                     .create_writer(
+                       make_flat_int_schema(n_leaves),
+                       datalake::parquet_write_config{},
+                       as)
+                     .get();
         EXPECT_FALSE(res.has_error());
         // Close the writer's stream so its test_writer doesn't assert on drop.
         std::move(res.value())->finish().get();
@@ -273,7 +279,12 @@ TEST_F(LocalFileWriterTest, ReservationScalesWithLeafColumns) {
     EXPECT_GT(r4, r2);
 
     tracker.last_reserved = 0;
-    auto nested_res = factory.create_writer(make_nested_schema(), as).get();
+    auto nested_res = factory
+                        .create_writer(
+                          make_nested_schema(),
+                          datalake::parquet_write_config{},
+                          as)
+                        .get();
     EXPECT_FALSE(nested_res.has_error());
     std::move(nested_res.value())->finish().get();
     EXPECT_EQ(tracker.last_reserved, reserved_for(5));

--- a/src/v/datalake/tests/parquet_write_config_test.cc
+++ b/src/v/datalake/tests/parquet_write_config_test.cc
@@ -27,6 +27,25 @@ std::optional<table_properties_t> make_codec_prop(std::string_view codec) {
     return make_props("write.parquet.compression-codec", codec);
 }
 
+std::optional<table_properties_t> make_props_multi(
+  std::initializer_list<std::pair<std::string_view, std::string_view>> kvs) {
+    table_properties_t props;
+    for (const auto& [k, v] : kvs) {
+        props.emplace(ss::sstring(k), ss::sstring(v));
+    }
+    return std::make_optional(std::move(props));
+}
+
+const parquet_write_config::bloom_column*
+find_bloom_column(const parquet_write_config& config, std::string_view name) {
+    for (const auto& col : config.bloom_filter_columns) {
+        if (col.name == name) {
+            return &col;
+        }
+    }
+    return nullptr;
+}
+
 } // namespace
 
 TEST(ParquetWriteConfigTest, DefaultsToCompressed) {
@@ -76,4 +95,118 @@ TEST(ParquetWriteConfigTest, UnrelatedPropertiesIgnored) {
     auto props = make_props("write.parquet.page-size-bytes", "1048576");
     auto config = parquet_write_config::from_properties(props);
     EXPECT_TRUE(config.compress);
+}
+
+TEST(ParquetWriteConfigTest, BloomFilterEnabledDefaultNdv) {
+    auto props = make_props(
+      "write.parquet.bloom-filter-enabled.column.redpanda.offset", "true");
+    auto config = parquet_write_config::from_properties(props);
+    ASSERT_EQ(config.bloom_filter_columns.size(), 1);
+    EXPECT_EQ(config.bloom_filter_columns[0].name, "redpanda.offset");
+    EXPECT_EQ(
+      config.bloom_filter_columns[0].ndv,
+      parquet_write_config::default_bloom_filter_ndv);
+}
+
+TEST(ParquetWriteConfigTest, BloomFilterEnabledWithNdv) {
+    auto props = make_props_multi({
+      {"write.parquet.bloom-filter-enabled.column.my_col", "true"},
+      {"write.parquet.bloom-filter-ndv.column.my_col", "50000"},
+    });
+    auto config = parquet_write_config::from_properties(props);
+    ASSERT_EQ(config.bloom_filter_columns.size(), 1);
+    EXPECT_EQ(config.bloom_filter_columns[0].name, "my_col");
+    EXPECT_EQ(config.bloom_filter_columns[0].ndv, 50000);
+}
+
+TEST(ParquetWriteConfigTest, BloomFilterNdvWithoutEnabledIsIgnored) {
+    auto props = make_props(
+      "write.parquet.bloom-filter-ndv.column.my_col", "50000");
+    auto config = parquet_write_config::from_properties(props);
+    EXPECT_TRUE(config.bloom_filter_columns.empty());
+}
+
+TEST(ParquetWriteConfigTest, BloomFilterDisabled) {
+    auto props = make_props(
+      "write.parquet.bloom-filter-enabled.column.my_col", "false");
+    auto config = parquet_write_config::from_properties(props);
+    EXPECT_TRUE(config.bloom_filter_columns.empty());
+}
+
+TEST(ParquetWriteConfigTest, BloomFilterCaseInsensitive) {
+    for (auto val : {"true", "TRUE", "True"}) {
+        auto props = make_props(
+          "write.parquet.bloom-filter-enabled.column.col", val);
+        auto config = parquet_write_config::from_properties(props);
+        EXPECT_EQ(config.bloom_filter_columns.size(), 1) << "val: " << val;
+    }
+    for (auto val : {"false", "FALSE", "False"}) {
+        auto props = make_props(
+          "write.parquet.bloom-filter-enabled.column.col", val);
+        auto config = parquet_write_config::from_properties(props);
+        EXPECT_TRUE(config.bloom_filter_columns.empty()) << "val: " << val;
+    }
+}
+
+TEST(ParquetWriteConfigTest, BloomFilterMultipleColumns) {
+    auto props = make_props_multi({
+      {"write.parquet.bloom-filter-enabled.column.a", "true"},
+      {"write.parquet.bloom-filter-enabled.column.b", "false"},
+      {"write.parquet.bloom-filter-enabled.column.c", "true"},
+      {"write.parquet.bloom-filter-ndv.column.c", "99999"},
+    });
+    auto config = parquet_write_config::from_properties(props);
+    EXPECT_EQ(config.bloom_filter_columns.size(), 2);
+    auto* a = find_bloom_column(config, "a");
+    auto* c = find_bloom_column(config, "c");
+    ASSERT_NE(a, nullptr);
+    ASSERT_NE(c, nullptr);
+    EXPECT_EQ(a->ndv, parquet_write_config::default_bloom_filter_ndv);
+    EXPECT_EQ(c->ndv, 99999);
+    EXPECT_EQ(find_bloom_column(config, "b"), nullptr);
+}
+
+TEST(ParquetWriteConfigTest, BloomFilterMalformedEnabled) {
+    auto props = make_props(
+      "write.parquet.bloom-filter-enabled.column.col", "yes");
+    auto config = parquet_write_config::from_properties(props);
+    EXPECT_TRUE(config.bloom_filter_columns.empty());
+}
+
+TEST(ParquetWriteConfigTest, BloomFilterMalformedNdv) {
+    auto props = make_props_multi({
+      {"write.parquet.bloom-filter-enabled.column.col", "true"},
+      {"write.parquet.bloom-filter-ndv.column.col", "not_a_number"},
+    });
+    auto config = parquet_write_config::from_properties(props);
+    ASSERT_EQ(config.bloom_filter_columns.size(), 1);
+    // Malformed NDV is ignored, falls back to default.
+    EXPECT_EQ(
+      config.bloom_filter_columns[0].ndv,
+      parquet_write_config::default_bloom_filter_ndv);
+}
+
+TEST(ParquetWriteConfigTest, BloomFilterNdvZeroIgnored) {
+    auto props = make_props_multi({
+      {"write.parquet.bloom-filter-enabled.column.col", "true"},
+      {"write.parquet.bloom-filter-ndv.column.col", "0"},
+    });
+    auto config = parquet_write_config::from_properties(props);
+    ASSERT_EQ(config.bloom_filter_columns.size(), 1);
+    // NDV=0 is ignored, falls back to default.
+    EXPECT_EQ(
+      config.bloom_filter_columns[0].ndv,
+      parquet_write_config::default_bloom_filter_ndv);
+}
+
+TEST(ParquetWriteConfigTest, BloomFilterNdvClampedToMax) {
+    auto props = make_props_multi({
+      {"write.parquet.bloom-filter-enabled.column.col", "true"},
+      {"write.parquet.bloom-filter-ndv.column.col", "999999999"},
+    });
+    auto config = parquet_write_config::from_properties(props);
+    ASSERT_EQ(config.bloom_filter_columns.size(), 1);
+    EXPECT_EQ(
+      config.bloom_filter_columns[0].ndv,
+      parquet_write_config::max_bloom_filter_ndv);
 }

--- a/src/v/datalake/tests/parquet_write_config_test.cc
+++ b/src/v/datalake/tests/parquet_write_config_test.cc
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/parquet_write_config.h"
+
+#include <gtest/gtest.h>
+
+using namespace datalake;
+using namespace iceberg;
+
+namespace {
+
+std::optional<table_properties_t>
+make_props(std::string_view key, std::string_view value) {
+    table_properties_t props;
+    props.emplace(ss::sstring(key), ss::sstring(value));
+    return std::make_optional(std::move(props));
+}
+
+std::optional<table_properties_t> make_codec_prop(std::string_view codec) {
+    return make_props("write.parquet.compression-codec", codec);
+}
+
+} // namespace
+
+TEST(ParquetWriteConfigTest, DefaultsToCompressed) {
+    // No properties at all.
+    auto config = parquet_write_config::from_properties(std::nullopt);
+    EXPECT_TRUE(config.compress);
+
+    // Empty properties map.
+    auto empty = std::make_optional<table_properties_t>();
+    config = parquet_write_config::from_properties(empty);
+    EXPECT_TRUE(config.compress);
+}
+
+TEST(ParquetWriteConfigTest, Zstd) {
+    for (auto codec : {"zstd", "ZSTD", "Zstd"}) {
+        auto props = make_codec_prop(codec);
+        auto config = parquet_write_config::from_properties(props);
+        EXPECT_TRUE(config.compress) << "codec: " << codec;
+    }
+}
+
+TEST(ParquetWriteConfigTest, Uncompressed) {
+    for (auto codec : {"uncompressed", "UNCOMPRESSED", "Uncompressed"}) {
+        auto props = make_codec_prop(codec);
+        auto config = parquet_write_config::from_properties(props);
+        EXPECT_FALSE(config.compress) << "codec: " << codec;
+    }
+}
+
+TEST(ParquetWriteConfigTest, None) {
+    for (auto codec : {"none", "NONE", "None"}) {
+        auto props = make_codec_prop(codec);
+        auto config = parquet_write_config::from_properties(props);
+        EXPECT_FALSE(config.compress) << "codec: " << codec;
+    }
+}
+
+TEST(ParquetWriteConfigTest, UnsupportedCodecFallsBackToZstd) {
+    for (auto codec : {"gzip", "snappy", "lz4_raw", "brotli", "garbage"}) {
+        auto props = make_codec_prop(codec);
+        auto config = parquet_write_config::from_properties(props);
+        EXPECT_TRUE(config.compress) << "codec: " << codec;
+    }
+}
+
+TEST(ParquetWriteConfigTest, UnrelatedPropertiesIgnored) {
+    auto props = make_props("write.parquet.page-size-bytes", "1048576");
+    auto config = parquet_write_config::from_properties(props);
+    EXPECT_TRUE(config.compress);
+}

--- a/src/v/datalake/tests/partitioning_writer_test.cc
+++ b/src/v/datalake/tests/partitioning_writer_test.cc
@@ -8,6 +8,7 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 #include "bytes/bytes.h"
+#include "datalake/parquet_write_config.h"
 #include "datalake/partitioning_writer.h"
 #include "datalake/table_definition.h"
 #include "datalake/tests/test_data_writer.h"
@@ -100,7 +101,8 @@ TEST_P(PartitioningWriterExtraColumnsTest, TestSchemaHappyPath) {
       schema_id,
       default_type.copy(),
       pspec.value().copy(),
-      {});
+      {},
+      datalake::parquet_write_config{});
 
     static constexpr int num_hrs = 5;
     static constexpr int records_per_hr = 5;
@@ -147,7 +149,8 @@ TEST(PartitioningWriterTest, TestWriterError) {
       schema_id,
       default_type.copy(),
       pspec.value().copy(),
-      {});
+      {},
+      datalake::parquet_write_config{});
     auto err = writer
                  .add_data(
                    val_with_timestamp(field, model::timestamp::now()),
@@ -164,7 +167,12 @@ TEST(PartitioningWriterTest, TestUnexpectedSchema) {
     auto pspec = partition_spec::resolve(hour_partition_spec(), schema_type);
     ASSERT_TRUE(pspec.has_value());
     partitioning_writer writer(
-      *writer_factory, schema_id, schema_type.copy(), pspec.value().copy(), {});
+      *writer_factory,
+      schema_id,
+      schema_type.copy(),
+      pspec.value().copy(),
+      {},
+      datalake::parquet_write_config{});
     auto unexpected_field_type = test_nested_schema_type();
     auto err = writer
                  .add_data(
@@ -184,7 +192,12 @@ TEST(PartitioningWriterTest, TestEmptyKey) {
     auto spec_id = partition_spec::id_t{123};
     partition_spec empty_spec{.spec_id = spec_id};
     partitioning_writer writer(
-      *writer_factory, schema_id, default_type.copy(), empty_spec.copy(), {});
+      *writer_factory,
+      schema_id,
+      default_type.copy(),
+      empty_spec.copy(),
+      {},
+      datalake::parquet_write_config{});
 
     static constexpr auto num_hrs = 10;
     static constexpr auto records_per_hr = 5;
@@ -219,7 +232,8 @@ TEST(PartitioningWriterTest, TestDayTransform) {
       schema_id,
       default_type.copy(),
       pspec.value().copy(),
-      {});
+      {},
+      datalake::parquet_write_config{});
 
     static constexpr int num_days = 4;
     static constexpr int records_per_day = 5;
@@ -281,7 +295,12 @@ TEST(PartitioningWriterTest, TestCompositeKey) {
     ASSERT_TRUE(spec.has_value());
 
     partitioning_writer writer(
-      *writer_factory, schema_id, schema_type.copy(), spec.value().copy(), {});
+      *writer_factory,
+      schema_id,
+      schema_type.copy(),
+      spec.value().copy(),
+      {},
+      datalake::parquet_write_config{});
 
     static constexpr auto num_hrs = 10;
     static constexpr auto records_per_hr = 5;

--- a/src/v/datalake/tests/resolve_bloom_filter_columns_test.cc
+++ b/src/v/datalake/tests/resolve_bloom_filter_columns_test.cc
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/parquet_write_config.h"
+#include "datalake/serde_parquet_writer.h"
+#include "iceberg/datatypes.h"
+
+#include <gtest/gtest.h>
+
+using namespace datalake;
+using namespace iceberg;
+
+namespace {
+
+// Flat schema: {str_col: string, int_col: int, bool_col: boolean}
+struct_type flat_schema() {
+    struct_type schema;
+    schema.fields.push_back(
+      nested_field::create(1, "str_col", field_required::yes, string_type{}));
+    schema.fields.push_back(
+      nested_field::create(2, "int_col", field_required::yes, int_type{}));
+    schema.fields.push_back(
+      nested_field::create(3, "bool_col", field_required::yes, boolean_type{}));
+    return schema;
+}
+
+// Nested schema: {outer: {inner: string}}
+struct_type nested_schema() {
+    struct_type inner;
+    inner.fields.push_back(
+      nested_field::create(2, "inner", field_required::yes, string_type{}));
+    struct_type schema;
+    schema.fields.push_back(
+      nested_field::create(1, "outer", field_required::yes, std::move(inner)));
+    return schema;
+}
+
+parquet_write_config
+make_config(std::initializer_list<parquet_write_config::bloom_column> columns) {
+    parquet_write_config config;
+    for (auto& col : columns) {
+        config.bloom_filter_columns.push_back(col);
+    }
+    return config;
+}
+
+} // namespace
+
+TEST(ResolveBloomFilterColumnsTest, EmptyConfig) {
+    auto config = make_config({});
+    auto result = resolve_bloom_filter_columns(config, flat_schema());
+    EXPECT_TRUE(result.empty());
+}
+
+TEST(ResolveBloomFilterColumnsTest, MatchesFlatColumn) {
+    auto config = make_config({{"str_col", 5000}});
+    auto result = resolve_bloom_filter_columns(config, flat_schema());
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result.at("str_col"), 5000);
+}
+
+TEST(ResolveBloomFilterColumnsTest, MatchesMultipleColumns) {
+    auto config = make_config({{"str_col", 5000}, {"int_col", 8000}});
+    auto result = resolve_bloom_filter_columns(config, flat_schema());
+    ASSERT_EQ(result.size(), 2);
+    EXPECT_EQ(result.at("str_col"), 5000);
+    EXPECT_EQ(result.at("int_col"), 8000);
+}
+
+TEST(ResolveBloomFilterColumnsTest, UnknownColumnIgnored) {
+    auto config = make_config({{"nonexistent", 5000}});
+    auto result = resolve_bloom_filter_columns(config, flat_schema());
+    EXPECT_TRUE(result.empty());
+}
+
+TEST(ResolveBloomFilterColumnsTest, MatchesNestedColumn) {
+    auto config = make_config({{"outer.inner", 7000}});
+    auto result = resolve_bloom_filter_columns(config, nested_schema());
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result.at("outer.inner"), 7000);
+}
+
+TEST(ResolveBloomFilterColumnsTest, NestedColumnParentNameDoesNotMatch) {
+    // "outer" is a struct, not a leaf — should not match.
+    auto config = make_config({{"outer", 7000}});
+    auto result = resolve_bloom_filter_columns(config, nested_schema());
+    EXPECT_TRUE(result.empty());
+}
+
+TEST(ResolveBloomFilterColumnsTest, MixOfMatchedAndUnknown) {
+    auto config = make_config({{"str_col", 5000}, {"no_such_col", 1000}});
+    auto result = resolve_bloom_filter_columns(config, flat_schema());
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result.at("str_col"), 5000);
+}

--- a/src/v/datalake/tests/serde_parquet_writer_test.cc
+++ b/src/v/datalake/tests/serde_parquet_writer_test.cc
@@ -1,5 +1,6 @@
 #include "bytes/bytes.h"
 #include "bytes/iostream.h"
+#include "datalake/parquet_write_config.h"
 #include "datalake/serde_parquet_writer.h"
 #include "datalake/tests/test_data.h"
 #include "datalake/tests/test_data_writer.h"
@@ -22,7 +23,10 @@ TEST(SerdeParquetWriterTest, CheckIfTheWriterWritesData) {
     datalake::noop_mem_tracker mem_tracker;
     auto writer = datalake::serde_parquet_writer_factory{}
                     .create_writer(
-                      schema, make_iobuf_ref_output_stream(target), mem_tracker)
+                      schema,
+                      datalake::parquet_write_config{},
+                      make_iobuf_ref_output_stream(target),
+                      mem_tracker)
                     .get();
 
     auto v = iceberg::tests::make_value(
@@ -47,7 +51,10 @@ TEST(SerdeParquetWriterTest, ValidateWriterBehaviorOnOOM) {
     datalake::noop_mem_tracker mem_tracker;
     auto writer = datalake::serde_parquet_writer_factory{}
                     .create_writer(
-                      schema, make_iobuf_ref_output_stream(target), mem_tracker)
+                      schema,
+                      datalake::parquet_write_config{},
+                      make_iobuf_ref_output_stream(target),
+                      mem_tracker)
                     .get();
 
     auto v = iceberg::tests::make_value(
@@ -98,7 +105,10 @@ TEST(SerdeParquetWriterTest, ColumnStats) {
 
     auto writer = datalake::serde_parquet_writer_factory{}
                     .create_writer(
-                      schema, make_iobuf_ref_output_stream(target), mem_tracker)
+                      schema,
+                      datalake::parquet_write_config{},
+                      make_iobuf_ref_output_stream(target),
+                      mem_tracker)
                     .get();
 
     const float nan_f = std::numeric_limits<float>::quiet_NaN();
@@ -222,7 +232,10 @@ TEST(SerdeParquetWriterTest, ColumnStatsMultipleRowGroups) {
 
     auto writer = datalake::serde_parquet_writer_factory{}
                     .create_writer(
-                      schema, make_iobuf_ref_output_stream(target), mem_tracker)
+                      schema,
+                      datalake::parquet_write_config{},
+                      make_iobuf_ref_output_stream(target),
+                      mem_tracker)
                     .get();
 
     auto add = [&](std::optional<int64_t> v) {

--- a/src/v/datalake/tests/test_data_writer.h
+++ b/src/v/datalake/tests/test_data_writer.h
@@ -102,7 +102,9 @@ public:
 
     ss::future<result<std::unique_ptr<parquet_file_writer>, writer_error>>
     create_writer(
-      const iceberg::struct_type& schema, ss::abort_source&) override {
+      const iceberg::struct_type& schema,
+      const parquet_write_config&,
+      ss::abort_source&) override {
         co_return std::make_unique<test_data_writer>(
           std::move(schema), _return_error);
     }
@@ -152,9 +154,11 @@ class test_serde_parquet_writer_factory : public parquet_file_writer_factory {
 public:
     ss::future<result<std::unique_ptr<parquet_file_writer>, writer_error>>
     create_writer(
-      const iceberg::struct_type& schema, ss::abort_source&) override {
+      const iceberg::struct_type& schema,
+      const parquet_write_config& write_config,
+      ss::abort_source&) override {
         auto ostream_writer = co_await _serde_parquet_factory.create_writer(
-          schema, utils::make_null_output_stream(), _mem_tracker);
+          schema, write_config, utils::make_null_output_stream(), _mem_tracker);
 
         co_return std::make_unique<test_serde_parquet_data_writer>(
           std::move(ostream_writer));

--- a/src/v/serde/parquet/BUILD
+++ b/src/v/serde/parquet/BUILD
@@ -156,6 +156,7 @@ redpanda_cc_library(
         "//src/v/bytes:iostream",
         "//src/v/container:contiguous_range_map",
         "@abseil-cpp//absl/container:flat_hash_set",
+        "@fmt",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -164,6 +165,7 @@ redpanda_cc_library(
         ":value",
         "//src/v/base",
         "//src/v/container:chunked_vector",
+        "@abseil-cpp//absl/container:flat_hash_map",
         "@seastar",
     ],
 )

--- a/src/v/serde/parquet/tests/BUILD
+++ b/src/v/serde/parquet/tests/BUILD
@@ -226,6 +226,8 @@ redpanda_cc_gtest(
         "//src/v/serde/parquet:value",
         "//src/v/serde/parquet:writer",
         "//src/v/test_utils:gtest",
+        "@abseil-cpp//absl/container:flat_hash_map",
+        "@fmt",
         "@googletest//:gtest",
         "@seastar",
     ],

--- a/src/v/serde/parquet/tests/writer_test.cc
+++ b/src/v/serde/parquet/tests/writer_test.cc
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
+#include "absl/container/flat_hash_map.h"
 #include "base/vlog.h"
 #include "bytes/iostream.h"
 #include "serde/parquet/column_stats_collector.h"
@@ -21,6 +22,7 @@
 #include <seastar/core/memory.hh>
 #include <seastar/util/log.hh>
 
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 
 #include <cmath>
@@ -716,6 +718,58 @@ TEST(ParquetWriter, StatsTruncationUtf8InvalidInput) {
     ASSERT_TRUE(stats->max.has_value());
     EXPECT_GT(stats->max->value.linearize_to_string(), ss::sstring("abc"));
     EXPECT_FALSE(stats->max->is_exact);
+}
+
+TEST(ParquetWriter, BloomFilterPerColumnOverride) {
+    // Two-column schema: str_col gets a bloom filter, int_col does not.
+    iobuf file;
+    absl::flat_hash_map<ss::sstring, size_t> bloom_cols;
+    bloom_cols["str_col"] = 1000;
+    writer w(
+      {
+        .schema = two_column_schema(),
+        .bloom_filter_columns = std::move(bloom_cols),
+      },
+      make_iobuf_ref_output_stream(file));
+    w.init().get();
+
+    for (int i = 0; i < 10; ++i) {
+        w.write_row(make_two_col_row(fmt::format("val_{}", i), i)).get();
+    }
+    auto metadata = w.close().get();
+
+    ASSERT_EQ(metadata.row_groups.size(), 1);
+    auto& rg = metadata.row_groups[0];
+    ASSERT_GE(rg.columns.size(), 2);
+
+    // str_col (column 0): bloom filter enabled.
+    auto& str_meta = rg.columns[0].meta_data;
+    EXPECT_TRUE(str_meta.bloom_filter_offset.has_value());
+    EXPECT_TRUE(str_meta.bloom_filter_length.has_value());
+    EXPECT_GT(*str_meta.bloom_filter_length, 0);
+
+    // int_col (column 1): bloom filter NOT enabled (ndv=0 default).
+    auto& int_meta = rg.columns[1].meta_data;
+    EXPECT_FALSE(int_meta.bloom_filter_offset.has_value());
+}
+
+TEST(ParquetWriter, BloomFilterGlobalDefault) {
+    // With no bloom_filter_columns map, the global bloom_filter_ndv=0 means
+    // no bloom filters on any column.
+    iobuf file;
+    writer w(
+      {.schema = two_column_schema()}, make_iobuf_ref_output_stream(file));
+    w.init().get();
+
+    for (int i = 0; i < 10; ++i) {
+        w.write_row(make_two_col_row(fmt::format("val_{}", i), i)).get();
+    }
+    auto metadata = w.close().get();
+
+    ASSERT_EQ(metadata.row_groups.size(), 1);
+    for (const auto& col : metadata.row_groups[0].columns) {
+        EXPECT_FALSE(col.meta_data.bloom_filter_offset.has_value());
+    }
 }
 
 // NOLINTEND(*magic-number*)

--- a/src/v/serde/parquet/writer.cc
+++ b/src/v/serde/parquet/writer.cc
@@ -21,6 +21,8 @@
 
 #include <seastar/coroutine/exception.hh>
 
+#include <fmt/ranges.h>
+
 #include <algorithm>
 #include <limits>
 #include <stdexcept>
@@ -55,6 +57,19 @@ public:
                 return;
             }
             bool is_bool = std::holds_alternative<bool_type>(element.type);
+            size_t ndv = _opts.bloom_filter_ndv;
+            if (!_opts.bloom_filter_columns.empty()) {
+                auto segments = path_in_schema(element);
+                auto dot_path = fmt::format("{}", fmt::join(segments, "."));
+                if (
+                  auto it = _opts.bloom_filter_columns.find(dot_path);
+                  it != _opts.bloom_filter_columns.end()) {
+                    ndv = it->second;
+                }
+            }
+            if (is_bool) {
+                ndv = 0;
+            }
             _columns.emplace(
               element.position,
               column{
@@ -65,7 +80,7 @@ public:
                     .compress = _opts.compress,
                     .max_stats_truncate_length
                     = _opts.max_stats_truncate_length,
-                    .bloom_filter_ndv = is_bool ? 0 : _opts.bloom_filter_ndv,
+                    .bloom_filter_ndv = ndv,
                   }),
               });
         });

--- a/src/v/serde/parquet/writer.h
+++ b/src/v/serde/parquet/writer.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "absl/container/flat_hash_map.h"
 #include "base/units.h"
 #include "container/chunked_vector.h"
 #include "serde/parquet/metadata.h"
@@ -73,6 +74,11 @@ public:
         // occurs at roughly 1.5× the configured NDV (~15K for the default).
         static constexpr size_t default_bloom_filter_ndv = 10'000;
         size_t bloom_filter_ndv = 0;
+
+        // Per-column bloom filter NDV overrides. Key is the dot-joined
+        // column path without the schema root (e.g., "redpanda.offset").
+        // Overrides bloom_filter_ndv for matched columns.
+        absl::flat_hash_map<ss::sstring, size_t> bloom_filter_columns;
     };
 
     // Create a new parquet file writer using the given options that


### PR DESCRIPTION
This change introduces support for a limited set of Iceberg table properties. They configure how translation writes Parquet files. The supported keys are based on conventional keys supported by the Java reference implementation.

- `write.parquet.compression-codec`: zstd, uncompressed, or none (=uncompressed). Other codecs are not supported by our Parquet writer. We will warn and ignore unsupported options, defaulting to zstd.
- `write.parquet.bloom-filter-enabled.column.<col>` : true/false, enables/disables bloom filters for a column (no effect on bool columns). Default is false.
- `write.parquet.bloom-filter-ndv.column.<col>` : expected distinct values, default is 10000

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

### Improvements

* Iceberg translation now honors several table properties that configure how Parquet is written, including compression and Bloom filters.

