### PR TITLE
hashing: back crc32c with abseil instead of google/crc32c

### DIFF
--- a/src/v/hashing/BUILD
+++ b/src/v/hashing/BUILD
@@ -19,6 +19,7 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/bytes:iobuf",
+        "@abseil-cpp//absl/crc:crc32c",
         "@crc32c",
     ],
 )

--- a/src/v/hashing/crc32c.h
+++ b/src/v/hashing/crc32c.h
@@ -10,15 +10,46 @@
  */
 
 #pragma once
+#include "absl/crc/crc32c.h"
 #include "bytes/iobuf.h"
 
 #include <crc32c/crc32c.h>
 
+#include <string_view>
 #include <type_traits>
 
 namespace crc {
 
-class crc32c {
+/// Backends for basic_crc32c, each computing CRC32C (Castagnoli) as defined
+/// by RFC 3720 with a different library. Backends produce identical values
+/// -- hashing/tests/crc32c_tests.cc pins each against the RFC vectors -- so
+/// the choice between them is purely one of performance.
+
+struct crc32c_google_backend {
+    static uint32_t extend(uint32_t crc, const char* data, size_t size) {
+        return ::crc32c::Extend(
+          crc,
+          // NOLINTNEXTLINE
+          reinterpret_cast<const uint8_t*>(data),
+          size);
+    }
+};
+
+struct crc32c_abseil_backend {
+    static uint32_t extend(uint32_t crc, const char* data, size_t size) {
+        if (size == 0) {
+            // callers pass empty fragments; don't build a view over nullptr
+            return crc;
+        }
+        return static_cast<uint32_t>(absl::ExtendCrc32c(
+          absl::crc32c_t{crc}, std::string_view{data, size}));
+    }
+};
+
+/// Incremental CRC32C (Castagnoli), as defined by RFC 3720, computed by
+/// Backend.
+template<typename Backend>
+class basic_crc32c {
 public:
     using value_type = uint32_t;
 
@@ -27,16 +58,16 @@ public:
     requires(std::is_integral_v<T>)
     {
         // NOLINTNEXTLINE
-        extend(reinterpret_cast<const uint8_t*>(&num), sizeof(T));
+        extend(reinterpret_cast<const char*>(&num), sizeof(T));
     }
     void extend(const uint8_t* data, size_t size) {
-        _crc = ::crc32c::Extend(_crc, data, size);
-    }
-    void extend(const char* data, size_t size) {
         extend(
           // NOLINTNEXTLINE
-          reinterpret_cast<const uint8_t*>(data),
+          reinterpret_cast<const char*>(data),
           size);
+    }
+    void extend(const char* data, size_t size) {
+        _crc = Backend::extend(_crc, data, size);
     }
 
     value_type value() const { return _crc; }
@@ -45,9 +76,18 @@ private:
     value_type _crc = 0;
 };
 
+/// The instantiation production code uses. Backed by abseil, which inlines
+/// buffers of 64 bytes or less instead of dispatching through a call. That is
+/// what most callers do -- see model::internal_header_only_crc, which feeds a
+/// batch header through as twelve integers -- and it is worth roughly 15x
+/// over an out-of-line call on that path.
+using crc32c = basic_crc32c<crc32c_abseil_backend>;
+
 } // namespace crc
 
-inline void crc_extend_iobuf(crc::crc32c& crc, const iobuf& buf) {
+template<typename Backend>
+inline void
+crc_extend_iobuf(crc::basic_crc32c<Backend>& crc, const iobuf& buf) {
     auto in = iobuf::iterator_consumer(buf.cbegin(), buf.cend());
     (void)in.consume(buf.size_bytes(), [&crc](const char* src, size_t sz) {
         // NOLINTNEXTLINE

--- a/src/v/hashing/tests/BUILD
+++ b/src/v/hashing/tests/BUILD
@@ -59,6 +59,23 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_bench(
+    name = "crc_bench_rpbench",
+    srcs = [
+        "crc_bench.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes",
+        "//src/v/bytes:iobuf",
+        "//src/v/hashing:crc32c",
+        "//src/v/test_utils:random_bytes",
+        "@abseil-cpp//absl/crc:crc32c",
+        "@seastar",
+        "@seastar//:benchmark",
+    ],
+)
+
+redpanda_cc_bench(
     name = "hashing_bench_rpbench",
     srcs = [
         "hash_bench.cc",

--- a/src/v/hashing/tests/BUILD
+++ b/src/v/hashing/tests/BUILD
@@ -26,6 +26,23 @@ redpanda_cc_btest_no_seastar(
 )
 
 redpanda_cc_gtest(
+    name = "crc32c_test",
+    timeout = "short",
+    srcs = [
+        "crc32c_tests.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/hashing:crc32c",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "murmur_hash_test",
     timeout = "short",
     srcs = [

--- a/src/v/hashing/tests/crc32c_tests.cc
+++ b/src/v/hashing/tests/crc32c_tests.cc
@@ -1,0 +1,235 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// crc::crc32c values are persisted (storage indices, snapshots, sst footers)
+// and are part of the Kafka record batch wire format, so they can never
+// change. These tests pin the absolute values against external vectors rather
+// than against whatever a backing library computes, and they run over every
+// basic_crc32c backend, so no backend -- and no change of the production
+// backend -- can silently alter them.
+
+#include "bytes/iobuf.h"
+#include "hashing/crc32c.h"
+
+#include <seastar/core/temporary_buffer.hh>
+
+#include <base/seastarx.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+template<typename CrcT>
+uint32_t crc32c_of(std::string_view data) {
+    CrcT crc;
+    crc.extend(data.data(), data.size());
+    return crc.value();
+}
+
+std::string_view as_view(const std::vector<uint8_t>& v) {
+    // NOLINTNEXTLINE(*-reinterpret-cast)
+    return {reinterpret_cast<const char*>(v.data()), v.size()};
+}
+
+} // namespace
+
+template<typename CrcT>
+class crc32c_test : public ::testing::Test {};
+
+struct backend_names {
+    template<typename CrcT>
+    static std::string GetName(int) {
+        if constexpr (
+          std::is_same_v<CrcT, crc::basic_crc32c<crc::crc32c_google_backend>>) {
+            return "google";
+        } else {
+            return "abseil";
+        }
+    }
+};
+
+using implementations = ::testing::Types<
+  crc::basic_crc32c<crc::crc32c_google_backend>,
+  crc::basic_crc32c<crc::crc32c_abseil_backend>>;
+TYPED_TEST_SUITE(crc32c_test, implementations, backend_names);
+
+// The four 32-byte vectors from RFC 3720 appendix B.4 (iSCSI), which is where
+// the CRC32C polynomial, bit order and init/final xor are normatively defined.
+TYPED_TEST(crc32c_test, rfc3720_vectors) {
+    std::vector<uint8_t> zeros(32, 0x00);
+    EXPECT_EQ(crc32c_of<TypeParam>(as_view(zeros)), 0x8a9136aaU);
+
+    std::vector<uint8_t> ones(32, 0xff);
+    EXPECT_EQ(crc32c_of<TypeParam>(as_view(ones)), 0x62a8ab43U);
+
+    std::vector<uint8_t> incrementing(32);
+    std::iota(incrementing.begin(), incrementing.end(), uint8_t{0});
+    EXPECT_EQ(crc32c_of<TypeParam>(as_view(incrementing)), 0x46dd794eU);
+
+    std::vector<uint8_t> decrementing(32);
+    for (size_t i = 0; i < decrementing.size(); ++i) {
+        decrementing[i] = static_cast<uint8_t>(31 - i);
+    }
+    EXPECT_EQ(crc32c_of<TypeParam>(as_view(decrementing)), 0x113fdb5cU);
+}
+
+// The CRC-32/ISCSI "check" value: the catalogued output for the ASCII string
+// "123456789", used across implementations to identify the algorithm.
+TYPED_TEST(crc32c_test, check_value) {
+    EXPECT_EQ(crc32c_of<TypeParam>("123456789"), 0xe3069283U);
+}
+
+TYPED_TEST(crc32c_test, empty_is_zero) {
+    TypeParam crc;
+    EXPECT_EQ(crc.value(), 0U);
+    crc.extend(static_cast<const char*>(nullptr), 0);
+    EXPECT_EQ(crc.value(), 0U);
+}
+
+TYPED_TEST(crc32c_test, short_strings) {
+    EXPECT_EQ(crc32c_of<TypeParam>("a"), 0xc1d04330U);
+    EXPECT_EQ(crc32c_of<TypeParam>("foo"), 0xcfc4ae1dU);
+    EXPECT_EQ(crc32c_of<TypeParam>("hello world"), 0xc99465aaU);
+}
+
+// Extending in pieces must equal extending in one call, at every split point.
+// This is the property model::internal_header_only_crc and crc_extend_iobuf
+// rely on, and the one most at risk from an implementation that dispatches on
+// buffer length.
+TYPED_TEST(crc32c_test, incremental_matches_contiguous) {
+    std::vector<uint8_t> data(4096);
+    for (size_t i = 0; i < data.size(); ++i) {
+        data[i] = static_cast<uint8_t>(i * 31 + 7);
+    }
+    const auto whole = crc32c_of<TypeParam>(as_view(data));
+
+    // Split points chosen to straddle the internal size thresholds of both
+    // google/crc32c (1008, 4080) and abseil (64, 256, 2048).
+    for (size_t split :
+         {size_t{1},
+          size_t{7},
+          size_t{8},
+          size_t{63},
+          size_t{64},
+          size_t{65},
+          size_t{255},
+          size_t{256},
+          size_t{257},
+          size_t{1007},
+          size_t{1008},
+          size_t{2047},
+          size_t{2048},
+          size_t{4032},
+          size_t{4095}}) {
+        TypeParam crc;
+        // NOLINTNEXTLINE(*-reinterpret-cast)
+        const auto* p = reinterpret_cast<const char*>(data.data());
+        crc.extend(p, split);
+        crc.extend(p + split, data.size() - split);
+        EXPECT_EQ(crc.value(), whole) << "split at " << split;
+    }
+}
+
+TYPED_TEST(crc32c_test, byte_at_a_time_matches_contiguous) {
+    constexpr std::string_view data = "the quick brown fox jumps over the dog";
+    TypeParam crc;
+    for (char c : data) {
+        crc.extend(&c, 1);
+    }
+    EXPECT_EQ(crc.value(), crc32c_of<TypeParam>(data));
+}
+
+// The integral overload hashes the object representation, so its result must
+// match feeding the same bytes through the pointer overload.
+TYPED_TEST(crc32c_test, integral_overload_matches_bytes) {
+    constexpr uint64_t value = 0x0123456789abcdefULL;
+
+    TypeParam from_integral;
+    from_integral.extend(value);
+
+    TypeParam from_bytes;
+    // NOLINTNEXTLINE(*-reinterpret-cast)
+    from_bytes.extend(reinterpret_cast<const char*>(&value), sizeof(value));
+
+    EXPECT_EQ(from_integral.value(), from_bytes.value());
+}
+
+TYPED_TEST(crc32c_test, integral_overload_widths) {
+    TypeParam crc;
+    crc.extend(static_cast<int8_t>(-1));
+    crc.extend(static_cast<int16_t>(-2));
+    crc.extend(static_cast<int32_t>(-3));
+    crc.extend(static_cast<int64_t>(-4));
+
+    constexpr std::array<uint8_t, 15> expected{
+      0xff,
+      0xfe,
+      0xff,
+      0xfd,
+      0xff,
+      0xff,
+      0xff,
+      0xfc,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff};
+    TypeParam bytes;
+    // NOLINTNEXTLINE(*-reinterpret-cast)
+    bytes.extend(
+      reinterpret_cast<const char*>(expected.data()), expected.size());
+
+    EXPECT_EQ(crc.value(), bytes.value());
+}
+
+TYPED_TEST(crc32c_test, iobuf_matches_contiguous) {
+    std::vector<uint8_t> data(8192);
+    for (size_t i = 0; i < data.size(); ++i) {
+        data[i] = static_cast<uint8_t>(i % 251);
+    }
+    const auto expected = crc32c_of<TypeParam>(as_view(data));
+
+    for (size_t frag_size :
+         {size_t{1},
+          size_t{7},
+          size_t{64},
+          size_t{512},
+          size_t{4096},
+          size_t{8192}}) {
+        iobuf buf;
+        for (size_t off = 0; off < data.size(); off += frag_size) {
+            auto sz = std::min(frag_size, data.size() - off);
+            buf.append(
+              std::make_unique<iobuf::fragment>(
+                ss::temporary_buffer<char>(as_view(data).data() + off, sz)));
+        }
+
+        TypeParam crc;
+        crc_extend_iobuf(crc, buf);
+        EXPECT_EQ(crc.value(), expected) << "fragment size " << frag_size;
+    }
+}
+
+TYPED_TEST(crc32c_test, iobuf_empty) {
+    iobuf buf;
+    TypeParam crc;
+    crc_extend_iobuf(crc, buf);
+    EXPECT_EQ(crc.value(), 0U);
+}

--- a/src/v/hashing/tests/crc_bench.cc
+++ b/src/v/hashing/tests/crc_bench.cc
@@ -1,0 +1,399 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+// Compares the basic_crc32c backends: google/crc32c against the CRC32C abseil
+// ships as absl::ExtendCrc32c and absl::MemcpyCrc32c.
+//
+// Both sides go through crc::basic_crc32c, so each backend is measured exactly
+// as production would call it; crc::crc32c is the abseil instantiation. This
+// is kept as the evidence for that default and the way to re-evaluate it --
+// notably once abseil's CPU detection covers this host, which currently falls
+// back to no PCLMULQDQ streams.
+//
+// Every case reports the cost of *one whole checksum*, not one byte: perf_tests
+// never scales below nanoseconds, and per-byte figures round to two decimals
+// where they are all noise. The buffer size is in the group name, so throughput
+// is size/runtime.
+//
+// Successive iterations checksum independent copies of the same hot buffer, so
+// the out-of-order engine overlaps them. These are throughput numbers, not the
+// latency of a checksum in isolation.
+
+#include "absl/crc/crc32c.h"
+#include "base/units.h"
+#include "base/vassert.h"
+#include "bytes/bytes.h"
+#include "bytes/iobuf.h"
+#include "hashing/crc32c.h"
+#include "test_utils/random_bytes.h"
+
+#include <seastar/core/byteorder.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/testing/perf_tests.hh>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+using google_crc32c = crc::basic_crc32c<crc::crc32c_google_backend>;
+using abseil_crc32c = crc::basic_crc32c<crc::crc32c_abseil_backend>;
+
+// Bytes checksummed by a single test run. Only sets the granularity of the
+// timing loop; the framework repeats runs until the measurement duration is up.
+constexpr size_t bytes_per_run = 4_MiB;
+
+/// perf_tests::do_not_optimize keeps a result alive, but it leaves the compiler
+/// free to hoist the *pure* computation that produced it out of the loop. That
+/// would rig this comparison: the abseil backend inlines small buffers while
+/// the google backend always bottoms out in an opaque call, so only the abseil
+/// side could be hoisted. Claiming memory may have changed forces both to be
+/// recomputed.
+[[gnu::always_inline]] inline void clobber_memory() {
+    asm volatile("" : : : "memory");
+}
+
+template<size_t Iters, typename Fn>
+size_t measure(Fn checksum) {
+    for (auto i = Iters; i--;) {
+        clobber_memory();
+        perf_tests::do_not_optimize(checksum());
+    }
+    return Iters;
+}
+
+std::string_view as_view(const bytes& b) {
+    // NOLINTNEXTLINE(*-reinterpret-cast)
+    return {reinterpret_cast<const char*>(b.data()), b.size()};
+}
+
+template<typename CrcT>
+uint32_t checksum(std::string_view buf) {
+    CrcT crc;
+    crc.extend(buf.data(), buf.size());
+    return crc.value();
+}
+
+// ---------------------------------------------------------------------------
+// contiguous buffer
+// ---------------------------------------------------------------------------
+
+template<size_t Size>
+struct crc_bench {
+    static constexpr size_t inner_iters = std::max<size_t>(
+      1, bytes_per_run / Size);
+
+    crc_bench()
+      : _data(tests::random_bytes(Size)) {
+        auto google = checksum<google_crc32c>(data());
+        auto abseil = checksum<abseil_crc32c>(data());
+        vassert(
+          google == abseil,
+          "crc32c disagreement at {} bytes: google={:#010x} abseil={:#010x}",
+          Size,
+          google,
+          abseil);
+    }
+
+    std::string_view data() const { return as_view(_data); }
+
+    [[gnu::noinline]] size_t run_crc32c_google() {
+        return measure<inner_iters>(
+          [this] { return checksum<google_crc32c>(data()); });
+    }
+
+    [[gnu::noinline]] size_t run_crc32c_abseil() {
+        return measure<inner_iters>(
+          [this] { return checksum<abseil_crc32c>(data()); });
+    }
+
+private:
+    bytes _data;
+};
+
+// ---------------------------------------------------------------------------
+// incremental integer extends
+// ---------------------------------------------------------------------------
+
+/// Field widths, and their order, that model::internal_header_only_crc feeds
+/// into the checksum. Every replicated batch pays for this sequence, and unlike
+/// the bulk cases it is dominated by per-call overhead: 57 bytes over 12 calls.
+struct batch_header {
+    int32_t size_bytes;
+    int64_t base_offset;
+    int8_t type;
+    uint32_t crc;
+    int16_t attrs;
+    int32_t last_offset_delta;
+    int64_t first_timestamp;
+    int64_t max_timestamp;
+    int64_t producer_id;
+    int16_t producer_epoch;
+    int32_t base_sequence;
+    int32_t record_count;
+};
+
+template<typename Fn>
+constexpr void for_each_field(const batch_header& h, Fn fn) {
+    fn(h.size_bytes);
+    fn(h.base_offset);
+    fn(h.type);
+    fn(h.crc);
+    fn(h.attrs);
+    fn(h.last_offset_delta);
+    fn(h.first_timestamp);
+    fn(h.max_timestamp);
+    fn(h.producer_id);
+    fn(h.producer_epoch);
+    fn(h.base_sequence);
+    fn(h.record_count);
+}
+
+// sizeof(batch_header) counts padding the checksum never sees, so sum the
+// widths of the fields that are actually hashed.
+constexpr size_t batch_header_bytes = [] {
+    size_t n = 0;
+    for_each_field(batch_header{}, [&n](auto field) { n += sizeof(field); });
+    return n;
+}();
+static_assert(batch_header_bytes == 57);
+
+template<typename CrcT>
+uint32_t header_crc32c(const batch_header& h) {
+    CrcT crc;
+    for_each_field(h, [&crc](auto field) { crc.extend(ss::cpu_to_le(field)); });
+    return crc.value();
+}
+
+struct crc_batch_header {
+    static constexpr size_t inner_iters = std::max<size_t>(
+      1, bytes_per_run / batch_header_bytes);
+
+    crc_batch_header() {
+        auto google = header_crc32c<google_crc32c>(_header);
+        auto abseil = header_crc32c<abseil_crc32c>(_header);
+        vassert(
+          google == abseil,
+          "crc32c disagreement over batch header: google={:#010x} "
+          "abseil={:#010x}",
+          google,
+          abseil);
+    }
+
+    [[gnu::noinline]] size_t run_crc32c_google() {
+        return measure<inner_iters>(
+          [this] { return header_crc32c<google_crc32c>(_header); });
+    }
+
+    [[gnu::noinline]] size_t run_crc32c_abseil() {
+        return measure<inner_iters>(
+          [this] { return header_crc32c<abseil_crc32c>(_header); });
+    }
+
+private:
+    batch_header _header{
+      .size_bytes = 4096,
+      .base_offset = 1'234'567,
+      .type = 1,
+      .crc = 0xdeadbeef,
+      .attrs = 0,
+      .last_offset_delta = 99,
+      .first_timestamp = 1'700'000'000'000,
+      .max_timestamp = 1'700'000'000'999,
+      .producer_id = -1,
+      .producer_epoch = -1,
+      .base_sequence = -1,
+      .record_count = 100,
+    };
+};
+
+// ---------------------------------------------------------------------------
+// fragmented iobuf
+// ---------------------------------------------------------------------------
+
+template<typename CrcT>
+uint32_t iobuf_crc32c(const iobuf& buf) {
+    CrcT crc;
+    crc_extend_iobuf(crc, buf);
+    return crc.value();
+}
+
+/// iobuf::append(temporary_buffer) linearizes small buffers into the tail
+/// fragment, so append fragments explicitly to get an exact fragment size.
+iobuf make_fragmented(std::string_view data, size_t frag_size) {
+    iobuf buf;
+    for (size_t off = 0; off < data.size(); off += frag_size) {
+        auto sz = std::min(frag_size, data.size() - off);
+        buf.append(
+          std::make_unique<iobuf::fragment>(
+            ss::temporary_buffer<char>(data.data() + off, sz)));
+    }
+    return buf;
+}
+
+template<size_t Size, size_t FragSize>
+struct crc_iobuf_bench {
+    static constexpr size_t inner_iters = std::max<size_t>(
+      1, bytes_per_run / Size);
+
+    crc_iobuf_bench()
+      : _data(tests::random_bytes(Size))
+      , _buf(make_fragmented(as_view(_data), FragSize)) {
+        auto contiguous = checksum<google_crc32c>(as_view(_data));
+        auto google = iobuf_crc32c<google_crc32c>(_buf);
+        auto abseil = iobuf_crc32c<abseil_crc32c>(_buf);
+        vassert(
+          google == contiguous && abseil == contiguous,
+          "crc32c disagreement over {} bytes in {} byte fragments: "
+          "google={:#010x} abseil={:#010x} contiguous={:#010x}",
+          Size,
+          FragSize,
+          google,
+          abseil,
+          contiguous);
+    }
+
+    [[gnu::noinline]] size_t run_crc32c_google() {
+        return measure<inner_iters>(
+          [this] { return iobuf_crc32c<google_crc32c>(_buf); });
+    }
+
+    [[gnu::noinline]] size_t run_crc32c_abseil() {
+        return measure<inner_iters>(
+          [this] { return iobuf_crc32c<abseil_crc32c>(_buf); });
+    }
+
+private:
+    bytes _data;
+    iobuf _buf;
+};
+
+// ---------------------------------------------------------------------------
+// checksum fused with a copy
+// ---------------------------------------------------------------------------
+
+// absl::MemcpyCrc32c is the one place abseil offers something structurally
+// different: it interleaves the copy with the checksum instead of making two
+// passes. There is no basic_crc32c equivalent, so it is benchmarked raw. Note
+// that it switches to non-temporal stores for large buffers, which is a win
+// here but bypasses the cache the copy's consumer may want.
+
+uint32_t memcpy_crc32c_google(char* dst, std::string_view src) {
+    std::memcpy(dst, src.data(), src.size());
+    return checksum<google_crc32c>({dst, src.size()});
+}
+
+uint32_t memcpy_crc32c_abseil(char* dst, std::string_view src) {
+    return static_cast<uint32_t>(
+      absl::MemcpyCrc32c(dst, src.data(), src.size()));
+}
+
+template<size_t Size>
+struct crc_memcpy_bench {
+    static constexpr size_t inner_iters = std::max<size_t>(
+      1, bytes_per_run / Size);
+
+    crc_memcpy_bench()
+      : _src(tests::random_bytes(Size))
+      , _dst(Size) {
+        auto expected = checksum<google_crc32c>(as_view(_src));
+        auto google = memcpy_crc32c_google(_dst.data(), as_view(_src));
+        auto abseil = memcpy_crc32c_abseil(_dst.data(), as_view(_src));
+        vassert(
+          google == expected && abseil == expected,
+          "crc32c disagreement over a {} byte copy: google={:#010x} "
+          "abseil={:#010x} expected={:#010x}",
+          Size,
+          google,
+          abseil,
+          expected);
+    }
+
+    [[gnu::noinline]] size_t run_google() {
+        return measure<inner_iters>(
+          [this] { return memcpy_crc32c_google(_dst.data(), as_view(_src)); });
+    }
+
+    [[gnu::noinline]] size_t run_abseil() {
+        return measure<inner_iters>(
+          [this] { return memcpy_crc32c_abseil(_dst.data(), as_view(_src)); });
+    }
+
+private:
+    bytes _src;
+    std::vector<char> _dst;
+};
+
+} // namespace
+
+// NOLINTBEGIN(*-macro-*)
+
+#define CRC_BENCH(size)                                                        \
+    struct crc_##size##b : crc_bench<size> {};                                 \
+    PERF_TEST_F(crc_##size##b, crc32c_google) { return run_crc32c_google(); }  \
+    PERF_TEST_F(crc_##size##b, crc32c_abseil) { return run_crc32c_abseil(); }
+
+// 57 is the batch header and 128 is just past the 64 byte buffer below which
+// abseil takes an inlined fast path.
+//
+// The rest straddle google/crc32c's block tiers, which it enters only at
+// 3*336, 3*1360 and 3*5440 bytes (crc32c_sse42.cc). Whatever does not fill a
+// tier drops to a smaller one and finally to a serial 16-bytes-at-a-time loop,
+// so its throughput sawtooths: 4032 and 16256 land just under a tier and are
+// ~15% slower per byte than 4096 and 16384, which land just over one. Abseil
+// splits the whole buffer into equal streams and has no such cliffs, so a
+// single size can rank the two either way -- always measure both sides of a
+// tier boundary.
+CRC_BENCH(8)
+CRC_BENCH(57)
+CRC_BENCH(128)
+CRC_BENCH(512)
+CRC_BENCH(4032)
+CRC_BENCH(4096)
+CRC_BENCH(16256)
+CRC_BENCH(16384)
+CRC_BENCH(65536)
+
+PERF_TEST_F(crc_batch_header, crc32c_google) { return run_crc32c_google(); }
+PERF_TEST_F(crc_batch_header, crc32c_abseil) { return run_crc32c_abseil(); }
+
+#define CRC_IOBUF_BENCH(size, frag_size)                                       \
+    struct crc_iobuf_##size##b_##frag_size##b_frags                            \
+      : crc_iobuf_bench<size, frag_size> {};                                   \
+    PERF_TEST_F(crc_iobuf_##size##b_##frag_size##b_frags, crc32c_google) {     \
+        return run_crc32c_google();                                            \
+    }                                                                          \
+    PERF_TEST_F(crc_iobuf_##size##b_##frag_size##b_frags, crc32c_abseil) {     \
+        return run_crc32c_abseil();                                            \
+    }
+
+CRC_IOBUF_BENCH(65536, 512)
+CRC_IOBUF_BENCH(65536, 16384)
+
+#define CRC_MEMCPY_BENCH(size)                                                 \
+    struct crc_memcpy_##size##b : crc_memcpy_bench<size> {};                   \
+    PERF_TEST_F(crc_memcpy_##size##b, google_two_pass) {                       \
+        return run_google();                                                   \
+    }                                                                          \
+    PERF_TEST_F(crc_memcpy_##size##b, abseil_fused) { return run_abseil(); }
+
+// Paired around a tier boundary for the same reason: the two-pass side goes
+// through the google backend and inherits its sawtooth.
+CRC_MEMCPY_BENCH(512)
+CRC_MEMCPY_BENCH(4032)
+CRC_MEMCPY_BENCH(4096)
+CRC_MEMCPY_BENCH(65536)
+
+// NOLINTEND(*-macro-*)


### PR DESCRIPTION
Backs `crc::crc32c` with abseil's CRC32C instead of google/crc32c. The wrapper becomes `basic_crc32c<Backend>` with backends for both libraries, and `crc::crc32c` is an alias for the abseil instantiation, so production switches over with no call site changes.

CRC32C values are identical between the backends, which is what makes the switch safe: they are persisted in storage indices, snapshots and sst footers, and are part of the Kafka record batch wire format. The wrapper previously had no test coverage at all, so this adds a gtest suite typed over both backends that pins the absolute values to the RFC 3720 appendix B.4 vectors and the catalogued CRC-32/ISCSI check value — external references, not whatever the backing library computes — plus the properties callers rely on (incremental extends match one-shot at split points straddling both libraries' internal thresholds, the integral overload matches the equivalent bytes, `crc_extend_iobuf` is fragmentation independent).

The final commit adds a benchmark that measures both backends through the wrapper, exactly as production calls them. It is the record of this decision and the way to revisit it; each fixture cross-checks that the backends agree before measuring.

## Benchmark

`bazel run --config=release //src/v/hashing/tests:crc_bench_rpbench`. Times are the cost of one whole checksum, not one byte:

| case | google/crc32c | abseil | abseil speedup |
|---|--:|--:|--:|
| batch header, 12 integer extends | 36.8ns | 2.19ns | **16.8x** |
| 8B | 2.69ns | 1.34ns | 2.0x |
| 57B | 4.29ns | 2.72ns | 1.6x |
| 128B | 4.91ns | 5.13ns | 0.96x |
| 512B | 27.0ns | 15.0ns | 1.8x |
| 4032B | 113.6ns | 99.3ns | 1.14x |
| 4096B | 99.4ns | 102.4ns | 0.97x |
| 16256B | 447.0ns | 384.3ns | 1.16x |
| 16384B | 382.9ns | 384.7ns | 1.0x |
| 64KiB contiguous | 1.55µs | 1.52µs | 1.02x |
| 64KiB iobuf, 512B fragments | 4.55µs | 2.46µs | **1.85x** |
| 64KiB iobuf, 16KiB fragments | 1.56µs | 1.60µs | 0.98x |
| 512B memcpy+crc, two-pass vs fused | 30.1ns | 20.7ns | 1.45x |
| 64KiB memcpy+crc, two-pass vs fused | 2.36µs | 2.15µs | 1.10x |

## Why abseil is faster

**Small extends are inlined behind a compile-time CPU check.** `absl::ExtendCrc32c` is defined in the header, and for buffers of 64 bytes or less expands in place to a straight-line sequence of hardware `crc32b/w/l/q` instructions (`crc_internal::ExtendCrc32cInline`), enabled at compile time by the SSE4.2 target baseline. `crc32c::Extend` is always an out-of-line library call that branches on a function-local `static bool can_use_sse42` and then calls the SSE4.2 kernel — for an 8-byte extend that is two calls and a dispatch check to reach a single `crc32q`, so per-call overhead dominates the actual CRC work. This is redpanda's hottest checksum shape: `model::internal_header_only_crc` feeds twelve 1–8 byte integers through the checksum for every replicated batch and pays the overhead twelve times. With abseil the entire sequence compiles to inlined crc32 instructions: 36.8ns → 2.2ns. The 128B row shows the flip side of the cutoff — just past 64B both libraries go out of line and google is marginally ahead.

**Mid-size buffers get instruction-level parallelism sooner.** The `crc32` instruction has ~3-cycle latency but 1/cycle throughput, so a single dependency chain runs at a third of the hardware rate; full speed requires computing several independent streams and folding them together. google/crc32c engages its 3-way streams only in fixed block tiers — the smallest needs 3×336 = 1008 contiguous bytes, then 3×1360 and 3×5440 — and runs a serial 8-bytes-per-instruction loop below that and for whatever is left over. Abseil folds 3 streams starting at 256 bytes, and above 2KiB divides the whole buffer evenly across its streams. At 512 bytes google is fully serial while abseil is already 3-way: 27.0ns vs 15.0ns. Checksumming fragmented iobufs hits this shape repeatedly, hence 64KiB in 512B fragments going 4.55µs → 2.46µs.

**Bulk throughput is a wash, but google sawtooths across its tiers.** Above ~4KiB both libraries run multi-stream at similar speed. Because google's tiers are fixed-size blocks, a length that just misses a tier drops its remainder to smaller tiers and finally the serial loop: 4032B (just under the 3×1360 tier) is ~14% slower per byte than 4096B (just over), and likewise 16256 vs 16384. Abseil's even split has no cliffs. This is also why the benchmark pins sizes on both sides of each tier boundary — a single size can rank the two libraries either way.

Two footnotes recorded in the benchmark source: abseil's runtime CPU table does not recognize the benchmark host and falls back to its no-PCLMULQDQ streams for the out-of-line path, so abseil's mid/large numbers above are a floor rather than its best; and `absl::MemcpyCrc32c` (checksum fused with the copy in a single pass, non-temporal stores at large sizes) has no google/crc32c equivalent, so it is benchmarked raw against a memcpy-then-checksum two-pass.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

### Improvements

* Reduced the CPU cost of CRC32C checksumming (computed for every record batch header and for storage indices, snapshots and internal RPCs) by backing it with abseil's implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
