### PR TITLE
raft: guarantee a configuration batch demarcates every data term

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -3026,65 +3026,55 @@ void consensus::maybe_schedule_flush() {
 ss::future<storage::append_result> consensus::disk_append(
   chunked_vector<model::record_batch> batches,
   update_last_quorum_index should_update_last_quorum_idx) {
-    using ret_t = storage::append_result;
     auto cfg = storage::log_append_config{
       // no fsync explicit on a per write, we verify at the end to
       // batch fsync
       storage::log_append_config::fsync::no};
 
-    return details::for_each_ref_extract_configuration(
-             _log->offsets().dirty_offset,
-             std::move(batches),
-             _log->make_appender(cfg))
-      .then([this, should_update_last_quorum_idx](
-              std::tuple<ret_t, chunked_vector<offset_configuration>> t) {
-          auto& [ret, configurations] = t;
-          _pending_flush_bytes += ret.byte_size;
-          if (should_update_last_quorum_idx) {
-              /**
-               * We have to update last quorum replicated index before we
-               * trigger read for followers recovery as recovery_stm will have
-               * to deceide if follower flush is required basing on last quorum
-               * replicated index.
-               */
-              _last_quorum_replicated_index_with_flush = ret.last_offset;
-          } else {
-              // Here are are appending entries without a flush, signal the
-              // flusher incase we hit the thresholds, particularly unflushed
-              // bytes.
-              maybe_schedule_flush();
-          }
-          // TODO
-          // if we rolled a log segment. write current configuration
-          // for speedy recovery in the background
+    auto [ret, configurations]
+      = co_await details::for_each_ref_extract_configuration(
+        _log->offsets().dirty_offset,
+        std::move(batches),
+        _log->make_appender(cfg));
 
-          // leader never flush just after write
-          // for quorum_ack it flush in parallel to dispatching RPCs
-          // to followers for other consistency flushes are done
-          // separately.
-          auto f = ss::now();
-          if (!configurations.empty()) {
-              // we can use latest configuration to update follower stats
-              f = _configuration_manager.add(std::move(configurations))
-                    .then([this] {
-                        update_follower_states(
-                          _configuration_manager.get_latest());
-                    });
-          }
+    _pending_flush_bytes += ret.byte_size;
+    if (should_update_last_quorum_idx) {
+        /**
+         * We have to update last quorum replicated index before we
+         * trigger read for followers recovery as recovery_stm will have
+         * to deceide if follower flush is required basing on last quorum
+         * replicated index.
+         */
+        _last_quorum_replicated_index_with_flush = ret.last_offset;
+    } else {
+        // Here are are appending entries without a flush, signal the
+        // flusher incase we hit the thresholds, particularly unflushed
+        // bytes.
+        maybe_schedule_flush();
+    }
+    // TODO
+    // if we rolled a log segment. write current configuration
+    // for speedy recovery in the background
 
-          return f.then([this, ret = ret] {
-              // if we are already shutting down, do nothing
-              if (_bg.is_closed()) {
-                  return ret;
-              }
+    // leader never flush just after write
+    // for quorum_ack it flush in parallel to dispatching RPCs
+    // to followers for other consistency flushes are done
+    // separately.
+    if (!configurations.empty()) {
+        // we can use latest configuration to update follower stats
+        co_await _configuration_manager.add(std::move(configurations));
+        update_follower_states(_configuration_manager.get_latest());
+    }
 
-              _configuration_manager
-                .maybe_store_highest_known_offset_in_background(
-                  ret.last_offset, ret.byte_size, _bg);
+    // if we are already shutting down, do nothing
+    if (_bg.is_closed()) {
+        co_return ret;
+    }
 
-              return ret;
-          });
-      });
+    _configuration_manager.maybe_store_highest_known_offset_in_background(
+      ret.last_offset, ret.byte_size, _bg);
+
+    co_return ret;
 }
 
 model::term_id consensus::get_term(model::offset o) const {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -897,7 +897,16 @@ replicate_stages consensus::do_replicate(
         return replicate_stages(errc::shutting_down);
     }
 
-    if (!is_elected_leader() || unlikely(_transferring_leadership)) {
+    /**
+     * Data replication requires a confirmed leadership term, not just a won
+     * election: a leader is only confirmed once an entry of its term - the
+     * configuration batch appended when it became leader - has been
+     * committed. Accepting data before that would allow a term to hold
+     * committed data batches without a configuration batch demarcating the
+     * term boundary in the log, e.g. when the initial configuration append
+     * failed and the first committed data batch confirmed the term instead.
+     */
+    if (!is_leader() || unlikely(_transferring_leadership)) {
         return replicate_stages(errc::not_leader);
     }
 

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -47,6 +47,7 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/metrics.hh>
 #include <seastar/core/semaphore.hh>
+#include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/exception.hh>
 #include <seastar/coroutine/switch_to.hh>
 #include <seastar/util/defer.hh>
@@ -3031,11 +3032,27 @@ ss::future<storage::append_result> consensus::disk_append(
       // batch fsync
       storage::log_append_config::fsync::no};
 
-    auto [ret, configurations]
-      = co_await details::for_each_ref_extract_configuration(
+    /**
+     * Configurations are owned by this coroutine frame so that they survive
+     * an append failure: an append may fail after some of its batches have
+     * already become visible in the log and the configurations from those
+     * batches must still reach the configuration manager. Nothing ever
+     * re-delivers them otherwise - a leader does not resend entries that are
+     * already present in a follower's log.
+     */
+    chunked_vector<offset_configuration> configurations;
+    auto append_fut = co_await ss::coroutine::as_future(
+      details::for_each_ref_extract_configuration(
         _log->offsets().dirty_offset,
         std::move(batches),
-        _log->make_appender(cfg));
+        _log->make_appender(cfg),
+        configurations));
+    if (append_fut.failed()) {
+        auto eptr = append_fut.get_exception();
+        co_await handle_disk_append_failure(std::move(configurations));
+        co_return ss::coroutine::exception(std::move(eptr));
+    }
+    auto ret = std::move(append_fut).get();
 
     _pending_flush_bytes += ret.byte_size;
     if (should_update_last_quorum_idx) {
@@ -3075,6 +3092,47 @@ ss::future<storage::append_result> consensus::disk_append(
       ret.last_offset, ret.byte_size, _bg);
 
     co_return ret;
+}
+
+ss::future<> consensus::handle_disk_append_failure(
+  chunked_vector<offset_configuration> configurations) {
+    /**
+     * The log appends batches one by one, so a failed append may still have
+     * made a prefix of its batches visible (and durable) in the log. Any
+     * configuration whose offset is covered by the log's dirty offset is in
+     * the log and the configuration manager must learn about it even though
+     * the append failed, otherwise its state silently diverges from the log.
+     */
+    const auto dirty_offset = _log->offsets().dirty_offset;
+    chunked_vector<offset_configuration> visible;
+    for (auto& oc : configurations) {
+        if (oc.offset <= dirty_offset) {
+            visible.push_back(std::move(oc));
+        }
+    }
+    if (visible.empty()) {
+        co_return;
+    }
+    vlog(
+      _ctxlog.warn,
+      "append failed with {} configuration(s) already visible in the log, "
+      "reconciling configuration manager",
+      visible.size());
+    auto add_fut = co_await ss::coroutine::as_future(
+      _configuration_manager.add(std::move(visible)));
+    if (add_fut.failed()) {
+        // the in-memory state of the configuration manager is updated before
+        // any persistence step, so on failure the live state still matches
+        // the log while the persisted highest known offset stays behind the
+        // configuration and a restart re-reads it from the log
+        auto add_eptr = add_fut.get_exception();
+        vlog(
+          _ctxlog.error,
+          "failed to reconcile configuration manager after append failure: {}",
+          add_eptr);
+    } else {
+        update_follower_states(_configuration_manager.get_latest());
+    }
 }
 
 model::term_id consensus::get_term(model::offset o) const {

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -663,6 +663,11 @@ private:
     ss::future<storage::append_result> disk_append(
       chunked_vector<model::record_batch>, update_last_quorum_index);
 
+    /// Adds configurations from batches that became visible in the log
+    /// before an append failure to the configuration manager.
+    ss::future<>
+      handle_disk_append_failure(chunked_vector<offset_configuration>);
+
     using success_reply = ss::bool_class<struct successfull_reply_tag>;
 
     success_reply update_follower_index(

--- a/src/v/raft/consensus_utils.h
+++ b/src/v/raft/consensus_utils.h
@@ -139,7 +139,7 @@ struct configuration_extracting_consumer {
         if (
           batch.header().type == model::record_batch_type::raft_configuration) {
             iobuf_parser parser(batch.copy_records().begin()->release_value());
-            configurations.emplace_back(
+            configurations->emplace_back(
               next_offset, deserialize_configuration(parser));
         }
 
@@ -152,20 +152,51 @@ struct configuration_extracting_consumer {
     }
 
     auto end_of_stream() {
-        return ss::futurize_invoke([this] { return wrapped.end_of_stream(); })
-          .then([confs = std::move(configurations)](auto ret) mutable {
-              return std::make_tuple(std::move(ret), std::move(confs));
-          });
+        return ss::futurize_invoke([this] { return wrapped.end_of_stream(); });
     }
 
     ReferenceConsumer wrapped;
     model::offset next_offset;
-    chunked_vector<offset_configuration> configurations;
+    chunked_vector<offset_configuration>* configurations;
 };
 
 template<typename ReferenceConsumer>
 using configuration_extracting_consumer_result_t = typename ss::futurize<
   decltype(std::declval<ReferenceConsumer&>().end_of_stream())>::value_type;
+
+/**
+ * Consumes all batches with the given consumer while lazily extracting
+ * raft::group_configuration batches into the caller provided vector.
+ *
+ * The vector is owned by the caller so that configurations extracted from
+ * batches consumed before a failure remain available to the caller even when
+ * the returned future resolves exceptionally: a batch may have become visible
+ * in the log before a later step of the same append failed and the caller
+ * must be able to reconcile derived state with the log in that case.
+ */
+template<typename ReferenceConsumer>
+requires model::ReferenceBatchReaderConsumer<ReferenceConsumer>
+ss::future<configuration_extracting_consumer_result_t<ReferenceConsumer>>
+for_each_ref_extract_configuration(
+  model::offset base_offset,
+  chunked_vector<model::record_batch> batches,
+  ReferenceConsumer c,
+  chunked_vector<offset_configuration>& configurations) {
+    auto consumer = configuration_extracting_consumer<ReferenceConsumer>{
+      .wrapped = std::move(c),
+      .next_offset = model::next_offset(base_offset),
+      .configurations = &configurations};
+    for (auto& batch : batches) {
+        // move the batch out so that its memory is released as soon as it has
+        // been consumed instead of holding all batches alive until the whole
+        // append completes
+        auto b = std::move(batch);
+        if (co_await consumer(b) == ss::stop_iteration::yes) {
+            break;
+        }
+    }
+    co_return co_await consumer.end_of_stream();
+}
 
 /**
  * Consumes all batches with the given consumer while lazily extracting
@@ -182,18 +213,10 @@ for_each_ref_extract_configuration(
   model::offset base_offset,
   chunked_vector<model::record_batch> batches,
   ReferenceConsumer c) {
-    auto consumer = configuration_extracting_consumer<ReferenceConsumer>{
-      .wrapped = std::move(c), .next_offset = model::next_offset(base_offset)};
-    for (auto& batch : batches) {
-        // move the batch out so that its memory is released as soon as it has
-        // been consumed instead of holding all batches alive until the whole
-        // append completes
-        auto b = std::move(batch);
-        if (co_await consumer(b) == ss::stop_iteration::yes) {
-            break;
-        }
-    }
-    co_return co_await consumer.end_of_stream();
+    chunked_vector<offset_configuration> configurations;
+    auto ret = co_await for_each_ref_extract_configuration(
+      base_offset, std::move(batches), std::move(c), configurations);
+    co_return std::make_tuple(std::move(ret), std::move(configurations));
 }
 
 bytes serialize_group_key(raft::group_id, metadata_key);

--- a/src/v/raft/replicate_batcher.cc
+++ b/src/v/raft/replicate_batcher.cc
@@ -231,13 +231,18 @@ ss::future<> replicate_batcher::flush(
 
         // release batcher replicate batcher lock
         batcher_units.return_all();
-        // we have to check if we are the leader
-        // it is critical as term could have been updated already by
-        // vote request and entries from current node could be accepted
-        // by the followers while it is no longer a leader
-        // this problem caused truncation failure.
-
-        if (!_ptr->is_elected_leader()) {
+        // We have to check leadership again while holding the op lock: the
+        // check in do_replicate() is only a fast path and the term could
+        // have been updated already by a vote request between enqueue and
+        // flush, in which case entries from the current node could be
+        // accepted by the followers while it is no longer a leader (this
+        // problem caused truncation failure). The check requires a confirmed
+        // term, not just a won election: batches are stamped with the
+        // current term below, and if the node lost and re-won leadership
+        // since enqueue, appending data of the new term before its
+        // configuration batch committed would let the data commit confirm
+        // the term with no configuration batch demarcating it in the log.
+        if (!_ptr->is_leader()) {
             for (auto& n : item_cache) {
                 n->set_value(errc::not_leader);
             }

--- a/src/v/raft/tests/BUILD
+++ b/src/v/raft/tests/BUILD
@@ -58,6 +58,7 @@ redpanda_test_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/base",
+        "//src/v/model",
         "//src/v/storage",
         "@seastar",
     ],
@@ -584,6 +585,28 @@ redpanda_test_cc_library(
         "//src/v/storage",
         "//src/v/test_utils:random",
         "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "configuration_divergence_test",
+    timeout = "moderate",
+    srcs = [
+        "configuration_divergence_test.cc",
+    ],
+    cpu = 4,
+    deps = [
+        "//src/v/bytes",
+        "//src/v/model",
+        "//src/v/raft",
+        "//src/v/raft/tests:raft_fixture",
+        "//src/v/raft/tests:raft_fixture_retry_policy",
+        "//src/v/serde",
+        "//src/v/storage",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+        "@seastar//:testing",
     ],
 )
 

--- a/src/v/raft/tests/basic_raft_fixture_test.cc
+++ b/src/v/raft/tests/basic_raft_fixture_test.cc
@@ -9,6 +9,7 @@
 
 #include "model/fundamental.h"
 #include "model/record.h"
+#include "model/record_batch_reader.h"
 #include "raft/tests/raft_fixture.h"
 #include "raft/tests/raft_fixture_retry_policy.h"
 #include "raft/types.h"
@@ -1210,4 +1211,96 @@ TEST_F_CORO(raft_fixture, test_leadership_blocked_replicas_can_elect_leader) {
 
     auto leader = co_await wait_for_leader(60s);
     ASSERT_NE_CORO(leader, blocked_follower);
+}
+
+/**
+ * Demonstrates that raft_configuration batches do not reliably demarcate
+ * term boundaries in the log: a candidate that wins an election but fails
+ * the local append of its initial configuration batch remains leader
+ * (vote_stm does not step down on configuration replication failure) and
+ * nothing retries the append, so data batches of the new term get
+ * committed with no configuration batch for that term anywhere in the
+ * log. Today the only durable record of such a term boundary is the
+ * segment roll on term change, which encodes the term in the segment file
+ * name.
+ */
+TEST_F_CORO(raft_fixture, test_term_span_without_configuration_batch) {
+    auto& n0 = add_node(model::node_id(0), model::revision_id(0));
+    co_await n0.init_and_start({n0.get_vnode()});
+    co_await wait_for_leader(10s);
+    auto raft = n0.raft();
+    const auto initial_term = raft->term();
+
+    auto res = co_await raft->replicate(
+      make_batches({{"k_0", "v_0"}}),
+      replicate_options(consistency_level::quorum_ack));
+    ASSERT_TRUE_CORO(res.has_value());
+
+    // fail only the next configuration batch append i.e. the one written by
+    // the new leader at the start of its term
+    bool config_append_failed = false;
+    n0.f_injectable_log()->set_append_hook(
+      [&config_append_failed](const model::record_batch& b) -> ss::future<> {
+          if (
+            !config_append_failed
+            && b.header().type
+                 == model::record_batch_type::raft_configuration) {
+              config_append_failed = true;
+              return ss::make_exception_future<>(
+                std::runtime_error("injected configuration append failure"));
+          }
+          return ss::now();
+      });
+
+    co_await raft->step_down("test-failed-configuration-append");
+
+    // the node is the only voter so it wins the next election, the initial
+    // configuration append fails, yet it stays an elected leader
+    RPTEST_REQUIRE_EVENTUALLY_CORO(10s, [&] {
+        return raft->is_elected_leader() && raft->term() > initial_term;
+    });
+    const auto new_term = raft->term();
+    ASSERT_TRUE_CORO(config_append_failed);
+
+    // leadership was never confirmed: the configuration batch of the new
+    // term was not appended and there is no retry, the leader is only
+    // confirmed once the first data batch of the new term commits
+    ASSERT_FALSE_CORO(raft->is_leader());
+
+    auto data_res = co_await raft->replicate(
+      make_batches({{"k_1", "v_1"}}),
+      replicate_options(consistency_level::quorum_ack));
+    ASSERT_TRUE_CORO(data_res.has_value());
+    RPTEST_REQUIRE_EVENTUALLY_CORO(10s, [&] { return raft->is_leader(); });
+
+    n0.f_injectable_log()->set_append_hook(std::nullopt);
+
+    // scan the raw log: the new term contains committed data batches but no
+    // raft_configuration batch
+    auto rdr = co_await raft->make_reader(
+      storage::local_log_reader_config(
+        raft->start_offset(), model::offset::max()));
+    auto batches = co_await model::consume_reader_to_memory(
+      std::move(rdr), default_timeout());
+
+    size_t data_in_new_term = 0;
+    size_t configs_in_new_term = 0;
+    for (const auto& b : batches) {
+        if (b.term() != new_term) {
+            continue;
+        }
+        if (b.header().type == model::record_batch_type::raft_data) {
+            data_in_new_term++;
+        } else if (
+          b.header().type == model::record_batch_type::raft_configuration) {
+            configs_in_new_term++;
+        }
+    }
+    ASSERT_GT_CORO(data_in_new_term, 0);
+    ASSERT_EQ_CORO(configs_in_new_term, 0);
+
+    // the term boundary is still recoverable, but only from the file name of
+    // the segment rolled on term change
+    ASSERT_EQ_CORO(
+      n0.f_injectable_log()->get_term(data_res.value().last_offset), new_term);
 }

--- a/src/v/raft/tests/basic_raft_fixture_test.cc
+++ b/src/v/raft/tests/basic_raft_fixture_test.cc
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <map>
 #include <ranges>
 
 using namespace raft;
@@ -1213,18 +1214,77 @@ TEST_F_CORO(raft_fixture, test_leadership_blocked_replicas_can_elect_leader) {
     ASSERT_NE_CORO(leader, blocked_follower);
 }
 
+namespace {
+
 /**
- * Demonstrates that raft_configuration batches do not reliably demarcate
- * term boundaries in the log: a candidate that wins an election but fails
- * the local append of its initial configuration batch remains leader
- * (vote_stm does not step down on configuration replication failure) and
- * nothing retries the append, so data batches of the new term get
- * committed with no configuration batch for that term anywhere in the
- * log. Today the only durable record of such a term boundary is the
- * segment roll on term change, which encodes the term in the segment file
- * name.
+ * Scans the raw log of a node and asserts that every term holding data
+ * batches also holds a configuration batch preceding them: the invariant
+ * that raft_configuration batches demarcate term boundaries in the log.
  */
-TEST_F_CORO(raft_fixture, test_term_span_without_configuration_batch) {
+ss::future<>
+assert_data_terms_have_configuration_batch(raft_node_instance& node) {
+    auto raft = node.raft();
+    auto rdr = co_await raft->make_reader(
+      storage::local_log_reader_config(
+        raft->start_offset(), model::offset::max()));
+    auto batches = co_await model::consume_reader_to_memory(
+      std::move(rdr), model::timeout_clock::now() + 10s);
+
+    struct term_batches {
+        std::optional<model::offset> first_config;
+        std::optional<model::offset> first_data;
+    };
+    std::map<model::term_id, term_batches> terms;
+    for (const auto& b : batches) {
+        auto& t = terms[b.term()];
+        if (b.header().type == model::record_batch_type::raft_configuration) {
+            t.first_config = std::min(
+              t.first_config.value_or(b.base_offset()), b.base_offset());
+        } else if (b.header().type == model::record_batch_type::raft_data) {
+            t.first_data = std::min(
+              t.first_data.value_or(b.base_offset()), b.base_offset());
+        }
+    }
+    for (const auto& [_, t] : terms) {
+        if (!t.first_data) {
+            continue;
+        }
+        ASSERT_TRUE_CORO(t.first_config.has_value());
+        ASSERT_LT_CORO(*t.first_config, *t.first_data);
+    }
+}
+
+// arms a one-shot failure of the next raft_configuration batch append,
+// returns a reference to the flag recording whether it fired
+bool& fail_next_configuration_append(raft_node_instance& node) {
+    auto failed = std::make_shared<bool>(false);
+    auto& failed_ref = *failed;
+    node.f_injectable_log()->set_append_hook(
+      [failed](const model::record_batch& b) -> ss::future<> {
+          if (
+            !*failed
+            && b.header().type
+                 == model::record_batch_type::raft_configuration) {
+              *failed = true;
+              return ss::make_exception_future<>(
+                std::runtime_error("injected configuration append failure"));
+          }
+          return ss::now();
+      });
+    return failed_ref;
+}
+
+} // namespace
+
+/**
+ * A candidate that wins an election but fails the local append of its
+ * initial configuration batch must not remain leader: nothing retries the
+ * append within the term, so staying leader would let data batches of the
+ * new term commit with no configuration batch demarcating the term boundary
+ * in the log. Instead the node steps down and the next election retries the
+ * append in a new term.
+ */
+TEST_F_CORO(raft_fixture, test_step_down_on_configuration_append_failure) {
     auto& n0 = add_node(model::node_id(0), model::revision_id(0));
     co_await n0.init_and_start({n0.get_vnode()});
     co_await wait_for_leader(10s);
@@ -1238,69 +1298,128 @@ TEST_F_CORO(raft_fixture, test_term_span_without_configuration_batch) {
 
     // fail only the next configuration batch append i.e. the one written by
     // the new leader at the start of its term
-    bool config_append_failed = false;
-    n0.f_injectable_log()->set_append_hook(
-      [&config_append_failed](const model::record_batch& b) -> ss::future<> {
-          if (
-            !config_append_failed
-            && b.header().type
-                 == model::record_batch_type::raft_configuration) {
-              config_append_failed = true;
-              return ss::make_exception_future<>(
-                std::runtime_error("injected configuration append failure"));
-          }
-          return ss::now();
-      });
+    auto& config_append_failed = fail_next_configuration_append(n0);
 
     co_await raft->step_down("test-failed-configuration-append");
 
-    // the node is the only voter so it wins the next election, the initial
-    // configuration append fails, yet it stays an elected leader
-    RPTEST_REQUIRE_EVENTUALLY_CORO(10s, [&] {
-        return raft->is_elected_leader() && raft->term() > initial_term;
-    });
-    const auto new_term = raft->term();
+    // the node is the only voter so it wins the next election. The failed
+    // configuration append forces another step down and the election after
+    // that retries the append, confirming leadership in a later term.
+    RPTEST_REQUIRE_EVENTUALLY_CORO(
+      10s, [&] { return raft->is_leader() && raft->term() > initial_term; });
     ASSERT_TRUE_CORO(config_append_failed);
-
-    // leadership was never confirmed: the configuration batch of the new
-    // term was not appended and there is no retry, the leader is only
-    // confirmed once the first data batch of the new term commits
-    ASSERT_FALSE_CORO(raft->is_leader());
+    n0.f_injectable_log()->set_append_hook(std::nullopt);
 
     auto data_res = co_await raft->replicate(
       make_batches({{"k_1", "v_1"}}),
       replicate_options(consistency_level::quorum_ack));
     ASSERT_TRUE_CORO(data_res.has_value());
+
+    co_await assert_data_terms_have_configuration_batch(n0);
+}
+
+/**
+ * An elected but not yet confirmed leader (one whose initial configuration
+ * batch has not committed) must not accept data writes: a data batch
+ * committed before the configuration batch would confirm the term while the
+ * configuration batch could still fail, leaving committed data in a term
+ * with no configuration batch demarcating it.
+ */
+TEST_F_CORO(raft_fixture, test_unconfirmed_leader_rejects_writes) {
+    auto& n0 = add_node(model::node_id(0), model::revision_id(0));
+    co_await n0.init_and_start({n0.get_vnode()});
+    co_await wait_for_leader(10s);
+    auto raft = n0.raft();
+    const auto initial_term = raft->term();
+
+    // delay the next configuration batch append long enough to observe the
+    // elected-but-unconfirmed window
+    bool config_append_delayed = false;
+    n0.f_injectable_log()->set_append_hook(
+      [&config_append_delayed](const model::record_batch& b) -> ss::future<> {
+          if (
+            !config_append_delayed
+            && b.header().type
+                 == model::record_batch_type::raft_configuration) {
+              config_append_delayed = true;
+              return ss::sleep(5s);
+          }
+          return ss::now();
+      });
+
+    co_await raft->step_down("test-delayed-configuration-append");
+
+    RPTEST_REQUIRE_EVENTUALLY_CORO(10s, [&] {
+        return raft->is_elected_leader() && raft->term() > initial_term;
+    });
+
+    // the election is won but the configuration batch has not committed yet
+    ASSERT_FALSE_CORO(raft->is_leader());
+    auto rejected = co_await raft->replicate(
+      make_batches({{"k_0", "v_0"}}),
+      replicate_options(consistency_level::quorum_ack));
+    ASSERT_TRUE_CORO(rejected.has_error());
+
+    // once the delayed configuration batch commits the leader is confirmed
+    // and accepts writes
     RPTEST_REQUIRE_EVENTUALLY_CORO(10s, [&] { return raft->is_leader(); });
-
     n0.f_injectable_log()->set_append_hook(std::nullopt);
+    auto accepted = co_await raft->replicate(
+      make_batches({{"k_1", "v_1"}}),
+      replicate_options(consistency_level::quorum_ack));
+    ASSERT_TRUE_CORO(accepted.has_value());
 
-    // scan the raw log: the new term contains committed data batches but no
-    // raft_configuration batch
-    auto rdr = co_await raft->make_reader(
-      storage::local_log_reader_config(
-        raft->start_offset(), model::offset::max()));
-    auto batches = co_await model::consume_reader_to_memory(
-      std::move(rdr), default_timeout());
+    co_await assert_data_terms_have_configuration_batch(n0);
+}
 
-    size_t data_in_new_term = 0;
-    size_t configs_in_new_term = 0;
-    for (const auto& b : batches) {
-        if (b.term() != new_term) {
-            continue;
-        }
-        if (b.header().type == model::record_batch_type::raft_data) {
-            data_in_new_term++;
-        } else if (
-          b.header().type == model::record_batch_type::raft_configuration) {
-            configs_in_new_term++;
+/**
+ * The configuration append failure scenario in a three node group: the node
+ * whose append failed steps down and the group converges on a confirmed
+ * leader with the term boundary invariant intact on every replica.
+ */
+TEST_F_CORO(raft_fixture, test_configuration_append_failure_multi_node) {
+    co_await create_simple_group(3);
+    auto leader_id = co_await wait_for_leader(10s);
+    auto leader_raft = node(leader_id).raft();
+
+    auto res = co_await leader_raft->replicate(
+      make_batches({{"k_0", "v_0"}}),
+      replicate_options(consistency_level::quorum_ack));
+    ASSERT_TRUE_CORO(res.has_value());
+    const auto initial_term = leader_raft->term();
+
+    // block the other nodes from becoming leader so that the next election
+    // is deterministically won by the node with the failing append
+    for (const auto& [id, n] : nodes()) {
+        if (id != leader_id) {
+            n->raft()->block_new_leadership();
         }
     }
-    ASSERT_GT_CORO(data_in_new_term, 0);
-    ASSERT_EQ_CORO(configs_in_new_term, 0);
+    auto& config_append_failed = fail_next_configuration_append(
+      node(leader_id));
 
-    // the term boundary is still recoverable, but only from the file name of
-    // the segment rolled on term change
-    ASSERT_EQ_CORO(
-      n0.f_injectable_log()->get_term(data_res.value().last_offset), new_term);
+    co_await leader_raft->step_down("test-failed-configuration-append");
+
+    // the node wins the election, fails the configuration append, steps down
+    // and wins again in a later term with the append succeeding
+    RPTEST_REQUIRE_EVENTUALLY_CORO(30s, [&] {
+        return leader_raft->is_leader() && leader_raft->term() > initial_term;
+    });
+    ASSERT_TRUE_CORO(config_append_failed);
+    node(leader_id).f_injectable_log()->set_append_hook(std::nullopt);
+    for (const auto& [id, n] : nodes()) {
+        if (id != leader_id) {
+            n->raft()->unblock_new_leadership();
+        }
+    }
+
+    auto data_res = co_await leader_raft->replicate(
+      make_batches({{"k_1", "v_1"}}),
+      replicate_options(consistency_level::quorum_ack));
+    ASSERT_TRUE_CORO(data_res.has_value());
+    co_await wait_for_committed_offset(data_res.value().last_offset, 30s);
+
+    for (const auto& [_, n] : nodes()) {
+        co_await assert_data_terms_have_configuration_batch(*n);
+    }
 }

--- a/src/v/raft/tests/configuration_divergence_test.cc
+++ b/src/v/raft/tests/configuration_divergence_test.cc
@@ -1,0 +1,347 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "raft/consensus.h"
+#include "raft/group_configuration.h"
+#include "raft/tests/raft_fixture.h"
+#include "raft/tests/raft_fixture_retry_policy.h"
+#include "raft/types.h"
+#include "storage/types.h"
+#include "test_utils/async.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/coroutine.hh>
+
+#include <algorithm>
+#include <chrono>
+
+using namespace raft;
+
+namespace {
+
+/**
+ * raft::configuration_manager is only ever told about a configuration from the
+ * continuation of consensus::disk_append. When an append fails after a
+ * raft_configuration batch already became visible in the log, that continuation
+ * never runs: the batch is in the log but the manager never learns about it.
+ *
+ * These tests demonstrate the consequences. They are all about a single
+ * replica's derived state diverging from its own log - the logs themselves stay
+ * identical across the group throughout.
+ */
+struct configuration_divergence_test : raft_fixture {
+    /**
+     * Fails the append of every raft_configuration batch on the given node,
+     * after the batch has become visible in its log. Returns a counter of the
+     * failures injected.
+     */
+    ss::shared_ptr<size_t> drop_configurations_on(model::node_id id) {
+        auto dropped = ss::make_shared<size_t>(0);
+        node(id).f_injectable_log()->set_post_append_hook(
+          [dropped](const model::record_batch& b) -> ss::future<> {
+              if (
+                b.header().type
+                != model::record_batch_type::raft_configuration) {
+                  return ss::now();
+              }
+              (*dropped)++;
+              return ss::make_exception_future<>(
+                std::runtime_error("injected post-visibility append failure"));
+          });
+        return dropped;
+    }
+
+    void stop_dropping_configurations_on(model::node_id id) {
+        node(id).f_injectable_log()->set_post_append_hook(std::nullopt);
+    }
+
+    /**
+     * Reads the raw log, including the raft_configuration batches that
+     * raft_node_instance::read_batches_in_range filters out.
+     */
+    ss::future<model::record_batch_reader::data_t>
+    read_raw_log(model::node_id id) {
+        auto raft = node(id).raft();
+        auto rdr = co_await raft->make_reader(
+          storage::local_log_reader_config(
+            raft->start_offset(), model::offset::max()));
+        co_return co_await model::consume_reader_to_memory(
+          std::move(rdr), default_timeout());
+    }
+
+    ss::future<std::vector<model::offset>>
+    configuration_offsets_in_log(model::node_id id) {
+        std::vector<model::offset> offsets;
+        for (const auto& b : co_await read_raw_log(id)) {
+            if (
+              b.header().type == model::record_batch_type::raft_configuration) {
+                offsets.push_back(b.base_offset());
+            }
+        }
+        co_return offsets;
+    }
+
+    ss::future<> transfer_leadership_to(model::node_id target) {
+        auto start = model::timeout_clock::now();
+        while (true) {
+            auto current_leader = co_await wait_for_leader(start + 30s);
+            if (current_leader == target) {
+                co_return;
+            }
+            auto raft = node(current_leader).raft();
+            std::ignore = co_await raft->transfer_leadership(
+              {.group = raft->group(), .target = target, .timeout = 10s});
+        }
+    }
+
+    ss::future<> restart(model::node_id id, std::vector<vnode> initial_nodes) {
+        auto dir = node(id).raft()->log()->config().base_directory();
+        co_await stop_node(id);
+        add_node(id, model::revision_id(0), dir);
+        co_await node(id).init_and_start(initial_nodes);
+    }
+
+    /**
+     * Brings the group to a state where `victim_id` missed a membership change:
+     * a fourth node is added to a three node group while every configuration
+     * batch append fails on the victim after becoming visible.
+     */
+    ss::future<> diverge_one_follower() {
+        co_await create_simple_group(3);
+        leader_id = co_await wait_for_leader(10s);
+
+        auto res = co_await node(leader_id).raft()->replicate(
+          make_batches({{"k_0", "v_0"}}),
+          replicate_options(consistency_level::quorum_ack));
+        ASSERT_TRUE_CORO(res.has_value());
+
+        for (const auto& [id, _] : nodes()) {
+            if (id != leader_id) {
+                victim_id = id;
+                break;
+            }
+        }
+        ASSERT_NE_CORO(victim_id, model::node_id{-1});
+
+        auto dropped = drop_configurations_on(victim_id);
+
+        auto& n3 = add_node(added_node, model::revision_id(0));
+        co_await n3.init_and_start({});
+
+        const auto target_voters = all_vnodes().size();
+        co_await node(leader_id).raft()->replace_configuration(
+          all_vnodes(), model::revision_id(1));
+
+        // the reconfiguration completes on every node but the victim, whose
+        // configuration manager never learns about any of the batches
+        RPTEST_REQUIRE_EVENTUALLY_CORO(30s, [this, target_voters] {
+            const auto& cfg = node(leader_id).raft()->config();
+            return cfg.get_state() == configuration_state::simple
+                   && cfg.current_config().voters.size() == target_voters;
+        });
+
+        // the failed appends leave the batches visible, so the victim's log
+        // still catches up with the leader's. Only once it has can the hook be
+        // removed without the victim picking a configuration up after the fact.
+        RPTEST_REQUIRE_EVENTUALLY_CORO(30s, [this] {
+            return node(victim_id).raft()->dirty_offset()
+                   == node(leader_id).raft()->dirty_offset();
+        });
+
+        // both the joint and the resulting simple configuration were dropped
+        ASSERT_GE_CORO(*dropped, 2);
+        stop_dropping_configurations_on(victim_id);
+
+        // a failed append never reaches end_of_stream, so the dropped batches
+        // are visible but not yet flushed. Appending data behind them makes
+        // them durable and readable without telling the victim's configuration
+        // manager anything.
+        auto tail = co_await node(leader_id).raft()->replicate(
+          make_batches({{"k_1", "v_1"}}),
+          replicate_options(consistency_level::quorum_ack));
+        ASSERT_TRUE_CORO(tail.has_value());
+        co_await wait_for_committed_offset(tail.value().last_offset, 30s);
+    }
+
+    static constexpr model::node_id added_node{3};
+
+    model::node_id victim_id{-1};
+    model::node_id leader_id{-1};
+};
+
+} // namespace
+
+/**
+ * The core defect: the victim's log holds configuration batches that its own
+ * configuration_manager has never seen, so it reports a stale group
+ * configuration while its log is byte for byte identical to the leader's.
+ */
+TEST_F_CORO(
+  configuration_divergence_test, configuration_lost_when_append_fails) {
+    co_await diverge_one_follower();
+
+    const auto n3 = node(added_node).get_vnode();
+
+    const auto& leader_cfg = node(leader_id).raft()->config();
+    ASSERT_EQ_CORO(leader_cfg.current_config().voters.size(), 4);
+    ASSERT_TRUE_CORO(leader_cfg.is_voter(n3));
+
+    const auto& victim_cfg = node(victim_id).raft()->config();
+    ASSERT_EQ_CORO(victim_cfg.current_config().voters.size(), 3);
+    ASSERT_FALSE_CORO(victim_cfg.contains(n3));
+
+    // the divergence is in derived state only - the logs agree
+    auto victim_batches = co_await read_raw_log(victim_id);
+    auto leader_batches = co_await read_raw_log(leader_id);
+    ASSERT_EQ_CORO(victim_batches.size(), leader_batches.size());
+    ASSERT_TRUE_CORO(
+      std::equal(
+        victim_batches.begin(), victim_batches.end(), leader_batches.begin()));
+
+    // and the victim's log contains configurations above the last one its
+    // manager knows about, which it will never read again
+    auto cfg_offsets = co_await configuration_offsets_in_log(victim_id);
+    auto latest_known = node(victim_id).raft()->get_latest_configuration_offset();
+    ASSERT_GT_CORO(
+      std::ranges::count_if(
+        cfg_offsets, [latest_known](auto o) { return o > latest_known; }),
+      0);
+}
+
+/**
+ * Boundary case: nothing persists a highest known offset above the dropped
+ * batches, so a plain restart rescans the log from a low offset and heals. The
+ * highest known offset - not log retention - is what makes the loss permanent.
+ */
+TEST_F_CORO(configuration_divergence_test, plain_restart_heals_the_divergence) {
+    co_await diverge_one_follower();
+
+    const auto n3 = node(added_node).get_vnode();
+    ASSERT_FALSE_CORO(node(victim_id).raft()->config().contains(n3));
+
+    auto vnodes = all_vnodes();
+    co_await restart(victim_id, vnodes);
+
+    ASSERT_TRUE_CORO(node(victim_id).raft()->config().contains(n3));
+    ASSERT_EQ_CORO(
+      node(victim_id).raft()->config().current_config().voters.size(), 4);
+}
+
+/**
+ * A snapshot raises the persisted highest known offset past the dropped batches
+ * and prefix truncates them out of the log. configuration_manager::prefix_
+ * truncate migrates the *stale* configuration forward to the truncation point,
+ * so after a restart the node has neither the correct configuration nor
+ * anything left to reconstruct it from.
+ */
+TEST_F_CORO(
+  configuration_divergence_test, snapshot_makes_the_divergence_permanent) {
+    co_await diverge_one_follower();
+
+    const auto n3 = node(added_node).get_vnode();
+    auto vnodes = all_vnodes();
+
+    // push the committed offset past the dropped configuration batches
+    auto res = co_await node(leader_id).raft()->replicate(
+      make_batches({{"k_1", "v_1"}}),
+      replicate_options(consistency_level::quorum_ack));
+    ASSERT_TRUE_CORO(res.has_value());
+    co_await wait_for_committed_offset(res.value().last_offset, 30s);
+
+    auto snapshot_offset = node(victim_id).raft()->committed_offset();
+    auto cfg_offsets = co_await configuration_offsets_in_log(victim_id);
+    ASSERT_TRUE_CORO(
+      std::ranges::all_of(
+        cfg_offsets, [snapshot_offset](auto o) { return o <= snapshot_offset; }));
+
+    // quiesce the rest of the group so nothing can push a new configuration to
+    // the victim while it snapshots and restarts
+    for (auto id : all_ids()) {
+        if (id != victim_id) {
+            co_await stop_node(id);
+        }
+    }
+
+    co_await node(victim_id).raft()->write_snapshot(
+      write_snapshot_cfg(snapshot_offset, iobuf{}));
+
+    // the configuration batches are gone from the log
+    ASSERT_TRUE_CORO(
+      (co_await configuration_offsets_in_log(victim_id)).empty());
+
+    co_await restart(victim_id, vnodes);
+
+    // permanently stale: the correct configuration is neither in the manager
+    // nor recoverable from the log
+    ASSERT_EQ_CORO(
+      node(victim_id).raft()->config().current_config().voters.size(), 3);
+    ASSERT_FALSE_CORO(node(victim_id).raft()->config().contains(n3));
+    ASSERT_TRUE_CORO(
+      (co_await configuration_offsets_in_log(victim_id)).empty());
+}
+
+/**
+ * The amplifier. vote_stm snapshots consensus::config() and, on winning,
+ * replicates it as the initial configuration batch of its term. A replica with
+ * a stale configuration therefore does not just misjudge quorum locally - it
+ * writes the stale membership back into the log as an authoritative
+ * configuration change, and every other replica accepts it.
+ *
+ * It also wins that election counting votes over the stale voter set, i.e. with
+ * fewer votes than the real configuration requires.
+ */
+TEST_F_CORO(
+  configuration_divergence_test, stale_replica_regresses_group_as_leader) {
+    co_await diverge_one_follower();
+
+    const auto n3 = node(added_node).get_vnode();
+    for (auto id : all_ids()) {
+        if (id != victim_id) {
+            ASSERT_TRUE_CORO(node(id).raft()->config().contains(n3));
+        }
+    }
+
+    co_await transfer_leadership_to(victim_id);
+
+    // every replica that is still part of the stale configuration accepts it as
+    // an authoritative configuration change: the group's membership has gone
+    // backwards, revision included
+    RPTEST_REQUIRE_EVENTUALLY_CORO(30s, [this, n3] {
+        return std::ranges::all_of(all_ids(), [this, n3](model::node_id id) {
+            if (id == added_node) {
+                return true;
+            }
+            const auto& cfg = node(id).raft()->config();
+            return cfg.get_state() == configuration_state::simple
+                   && cfg.current_config().voters.size() == 3
+                   && !cfg.contains(n3)
+                   && cfg.revision_id() < model::revision_id(1);
+        });
+    });
+
+    // the removed node is never told. It is absent from the configuration the
+    // new leader knows about, so it is dropped from the follower states and
+    // nothing is dispatched to it: it goes on believing it is a voter of a four
+    // node group, campaigning in a configuration that no longer exists.
+    const auto& orphan_cfg = node(added_node).raft()->config();
+    ASSERT_EQ_CORO(orphan_cfg.current_config().voters.size(), 4);
+    ASSERT_TRUE_CORO(orphan_cfg.is_voter(n3));
+    ASSERT_LT_CORO(
+      node(added_node).raft()->get_latest_configuration_offset(),
+      node(victim_id).raft()->get_latest_configuration_offset());
+
+    // the regression is durable: it is a real configuration batch in the log
+    auto cfg_offsets = co_await configuration_offsets_in_log(victim_id);
+    auto latest = node(victim_id).raft()->get_latest_configuration_offset();
+    ASSERT_TRUE_CORO(
+      std::ranges::find(cfg_offsets, latest) != cfg_offsets.end());
+}

--- a/src/v/raft/tests/configuration_divergence_test.cc
+++ b/src/v/raft/tests/configuration_divergence_test.cc
@@ -15,6 +15,7 @@
 #include "raft/tests/raft_fixture.h"
 #include "raft/tests/raft_fixture_retry_policy.h"
 #include "raft/types.h"
+#include "serde/rw/rw.h"
 #include "storage/types.h"
 #include "test_utils/async.h"
 #include "test_utils/test.h"
@@ -103,6 +104,46 @@ struct configuration_divergence_test : raft_fixture {
         }
     }
 
+    /**
+     * Splits the group in two, dropping every message crossing the boundary.
+     */
+    void partition_group(
+      std::vector<model::node_id> a, std::vector<model::node_id> b) {
+        auto block_towards = [this](
+                               const std::vector<model::node_id>& side,
+                               std::vector<model::node_id> unreachable) {
+            for (auto id : side) {
+                node(id).on_dispatch(
+                  [unreachable](model::node_id dest, raft::msg_type) {
+                      if (
+                        std::ranges::find(unreachable, dest)
+                        != unreachable.end()) {
+                          throw std::runtime_error("partitioned");
+                      }
+                      return ss::now();
+                  });
+            }
+        };
+        block_towards(a, b);
+        block_towards(b, a);
+    }
+
+    ss::future<bool>
+    log_contains_key(model::node_id id, const ss::sstring& key) {
+        const auto expected = serde::to_iobuf(key);
+        for (auto& b : co_await read_raw_log(id)) {
+            if (b.header().type != model::record_batch_type::raft_data) {
+                continue;
+            }
+            for (auto& r : b.copy_records()) {
+                if (r.key() == expected) {
+                    co_return true;
+                }
+            }
+        }
+        co_return false;
+    }
+
     ss::future<> restart(model::node_id id, std::vector<vnode> initial_nodes) {
         auto dir = node(id).raft()->log()->config().base_directory();
         co_await stop_node(id);
@@ -111,11 +152,11 @@ struct configuration_divergence_test : raft_fixture {
     }
 
     /**
-     * Brings the group to a state where `victim_id` missed a membership change:
-     * a fourth node is added to a three node group while every configuration
-     * batch append fails on the victim after becoming visible.
+     * Grows the initial three node group by `extra` nodes. When
+     * `drop_on_victim` is set every configuration batch append fails on the
+     * victim after becoming visible, so it never learns the new configuration.
      */
-    ss::future<> diverge_one_follower() {
+    ss::future<> grow_group(size_t extra, bool drop_on_victim) {
         co_await create_simple_group(3);
         leader_id = co_await wait_for_leader(10s);
 
@@ -125,17 +166,23 @@ struct configuration_divergence_test : raft_fixture {
         ASSERT_TRUE_CORO(res.has_value());
 
         for (const auto& [id, _] : nodes()) {
-            if (id != leader_id) {
+            original_nodes.push_back(id);
+            if (id != leader_id && victim_id == model::node_id{-1}) {
                 victim_id = id;
-                break;
             }
         }
         ASSERT_NE_CORO(victim_id, model::node_id{-1});
 
-        auto dropped = drop_configurations_on(victim_id);
+        auto dropped = ss::make_shared<size_t>(0);
+        if (drop_on_victim) {
+            dropped = drop_configurations_on(victim_id);
+        }
 
-        auto& n3 = add_node(added_node, model::revision_id(0));
-        co_await n3.init_and_start({});
+        for (size_t i = 0; i < extra; ++i) {
+            auto& n = add_node(
+              model::node_id(int(added_node() + i)), model::revision_id(0));
+            co_await n.init_and_start({});
+        }
 
         const auto target_voters = all_vnodes().size();
         co_await node(leader_id).raft()->replace_configuration(
@@ -157,9 +204,12 @@ struct configuration_divergence_test : raft_fixture {
                    == node(leader_id).raft()->dirty_offset();
         });
 
-        // both the joint and the resulting simple configuration were dropped
-        ASSERT_GE_CORO(*dropped, 2);
-        stop_dropping_configurations_on(victim_id);
+        if (drop_on_victim) {
+            // both the joint and the resulting simple configuration were
+            // dropped
+            ASSERT_GE_CORO(*dropped, 2);
+            stop_dropping_configurations_on(victim_id);
+        }
 
         // a failed append never reaches end_of_stream, so the dropped batches
         // are visible but not yet flushed. Appending data behind them makes
@@ -172,176 +222,129 @@ struct configuration_divergence_test : raft_fixture {
         co_await wait_for_committed_offset(tail.value().last_offset, 30s);
     }
 
+    ss::future<> diverge_one_follower() { return grow_group(1, true); }
+
+    // the original group member that is neither the leader nor the victim
+    model::node_id third_original() const {
+        for (auto id : original_nodes) {
+            if (id != leader_id && id != victim_id) {
+                return id;
+            }
+        }
+        return model::node_id{-1};
+    }
+
     static constexpr model::node_id added_node{3};
 
     model::node_id victim_id{-1};
     model::node_id leader_id{-1};
+    std::vector<model::node_id> original_nodes;
 };
 
 } // namespace
 
 /**
- * The core defect: the victim's log holds configuration batches that its own
- * configuration_manager has never seen, so it reports a stale group
- * configuration while its log is byte for byte identical to the leader's.
+ *
+ * The group really has five voters, so a commit needs three of them. The victim
+ * lost that configuration and still believes in the original three, so it needs
+ * only two. Partitioning the group so that the victim has a majority of the
+ * configuration it believes in, but not of the real one, lets it acknowledge a
+ * write to a client that no quorum of the real configuration ever saw. When the
+ * victim's side goes away that write is gone, while the surviving three nodes
+ * are a legitimate majority of the real configuration and carry on serving.
+ *
+ * Both sides can commit at the same time: the two acknowledging sets are
+ * disjoint, which is exactly what raft's configuration change rules exist to
+ * make impossible.
  */
-TEST_F_CORO(
-  configuration_divergence_test, configuration_lost_when_append_fails) {
-    co_await diverge_one_follower();
+TEST_F_CORO(configuration_divergence_test, acknowledged_write_is_lost) {
+    co_await grow_group(2, true);
 
-    const auto n3 = node(added_node).get_vnode();
-
-    const auto& leader_cfg = node(leader_id).raft()->config();
-    ASSERT_EQ_CORO(leader_cfg.current_config().voters.size(), 4);
-    ASSERT_TRUE_CORO(leader_cfg.is_voter(n3));
-
-    const auto& victim_cfg = node(victim_id).raft()->config();
-    ASSERT_EQ_CORO(victim_cfg.current_config().voters.size(), 3);
-    ASSERT_FALSE_CORO(victim_cfg.contains(n3));
-
-    // the divergence is in derived state only - the logs agree
-    auto victim_batches = co_await read_raw_log(victim_id);
-    auto leader_batches = co_await read_raw_log(leader_id);
-    ASSERT_EQ_CORO(victim_batches.size(), leader_batches.size());
-    ASSERT_TRUE_CORO(
-      std::equal(
-        victim_batches.begin(), victim_batches.end(), leader_batches.begin()));
-
-    // and the victim's log contains configurations above the last one its
-    // manager knows about, which it will never read again
-    auto cfg_offsets = co_await configuration_offsets_in_log(victim_id);
-    auto latest_known = node(victim_id).raft()->get_latest_configuration_offset();
-    ASSERT_GT_CORO(
-      std::ranges::count_if(
-        cfg_offsets, [latest_known](auto o) { return o > latest_known; }),
-      0);
-}
-
-/**
- * Boundary case: nothing persists a highest known offset above the dropped
- * batches, so a plain restart rescans the log from a low offset and heals. The
- * highest known offset - not log retention - is what makes the loss permanent.
- */
-TEST_F_CORO(configuration_divergence_test, plain_restart_heals_the_divergence) {
-    co_await diverge_one_follower();
-
-    const auto n3 = node(added_node).get_vnode();
-    ASSERT_FALSE_CORO(node(victim_id).raft()->config().contains(n3));
-
-    auto vnodes = all_vnodes();
-    co_await restart(victim_id, vnodes);
-
-    ASSERT_TRUE_CORO(node(victim_id).raft()->config().contains(n3));
-    ASSERT_EQ_CORO(
-      node(victim_id).raft()->config().current_config().voters.size(), 4);
-}
-
-/**
- * A snapshot raises the persisted highest known offset past the dropped batches
- * and prefix truncates them out of the log. configuration_manager::prefix_
- * truncate migrates the *stale* configuration forward to the truncation point,
- * so after a restart the node has neither the correct configuration nor
- * anything left to reconstruct it from.
- */
-TEST_F_CORO(
-  configuration_divergence_test, snapshot_makes_the_divergence_permanent) {
-    co_await diverge_one_follower();
-
-    const auto n3 = node(added_node).get_vnode();
-    auto vnodes = all_vnodes();
-
-    // push the committed offset past the dropped configuration batches
-    auto res = co_await node(leader_id).raft()->replicate(
-      make_batches({{"k_1", "v_1"}}),
-      replicate_options(consistency_level::quorum_ack));
-    ASSERT_TRUE_CORO(res.has_value());
-    co_await wait_for_committed_offset(res.value().last_offset, 30s);
-
-    auto snapshot_offset = node(victim_id).raft()->committed_offset();
-    auto cfg_offsets = co_await configuration_offsets_in_log(victim_id);
-    ASSERT_TRUE_CORO(
-      std::ranges::all_of(
-        cfg_offsets, [snapshot_offset](auto o) { return o <= snapshot_offset; }));
-
-    // quiesce the rest of the group so nothing can push a new configuration to
-    // the victim while it snapshots and restarts
-    for (auto id : all_ids()) {
-        if (id != victim_id) {
-            co_await stop_node(id);
-        }
-    }
-
-    co_await node(victim_id).raft()->write_snapshot(
-      write_snapshot_cfg(snapshot_offset, iobuf{}));
-
-    // the configuration batches are gone from the log
-    ASSERT_TRUE_CORO(
-      (co_await configuration_offsets_in_log(victim_id)).empty());
-
-    co_await restart(victim_id, vnodes);
-
-    // permanently stale: the correct configuration is neither in the manager
-    // nor recoverable from the log
+    // the victim still believes in the original three voters
     ASSERT_EQ_CORO(
       node(victim_id).raft()->config().current_config().voters.size(), 3);
-    ASSERT_FALSE_CORO(node(victim_id).raft()->config().contains(n3));
-    ASSERT_TRUE_CORO(
-      (co_await configuration_offsets_in_log(victim_id)).empty());
+    ASSERT_EQ_CORO(
+      node(leader_id).raft()->config().current_config().voters.size(), 5);
+
+    // the victim plus one other original node is a majority of the stale
+    // configuration and no majority at all of the real one
+    const std::vector<model::node_id> stale_side{victim_id, third_original()};
+    const std::vector<model::node_id> real_side{
+      leader_id, added_node, model::node_id(added_node() + 1)};
+
+    // make sure the victim, not its ally, wins on the stale side
+    node(third_original()).raft()->block_new_leadership();
+    partition_group(stale_side, real_side);
+
+    RPTEST_REQUIRE_EVENTUALLY_CORO(
+      30s, [this] { return node(victim_id).raft()->is_elected_leader(); });
+
+    // two of three acknowledge, so the write is committed and acknowledged to
+    // the caller with quorum_ack
+    auto lost = co_await node(victim_id).raft()->replicate(
+      make_batches({{"lost", "v"}}),
+      replicate_options(consistency_level::quorum_ack, 10s));
+    ASSERT_TRUE_CORO(lost.has_value());
+    RPTEST_REQUIRE_EVENTUALLY_CORO(30s, [this, lost] {
+        return node(victim_id).raft()->committed_offset()
+               >= lost.value().last_offset;
+    });
+
+    // the real side, holding a majority of the real configuration, never saw it
+    // and keeps committing on its own
+    for (auto id : real_side) {
+        ASSERT_FALSE_CORO(co_await log_contains_key(id, "lost"));
+    }
+
+    // the victim's side goes away, as the node that acknowledged the write
+    // would on any ordinary failure
+    for (auto id : stale_side) {
+        co_await stop_node(id);
+    }
+    for (auto id : real_side) {
+        node(id).reset_dispatch_handlers();
+    }
+
+    // three of five voters are alive: a legitimate majority of the real
+    // configuration, which elects and commits normally
+    co_await wait_for_leader(30s);
+    auto after = co_await retry_with_leader(
+      model::timeout_clock::now() + 30s, [this](raft_node_instance& leader) {
+          return leader.raft()->replicate(
+            make_batches({{"after", "v"}}),
+            replicate_options(consistency_level::quorum_ack, 10s));
+      });
+    ASSERT_TRUE_CORO(after.has_value());
+
+    // the acknowledged write is on no surviving replica
+    for (auto id : real_side) {
+        ASSERT_FALSE_CORO(co_await log_contains_key(id, "lost"));
+    }
 }
 
 /**
- * The amplifier. vote_stm snapshots consensus::config() and, on winning,
- * replicates it as the initial configuration batch of its term. A replica with
- * a stale configuration therefore does not just misjudge quorum locally - it
- * writes the stale membership back into the log as an authoritative
- * configuration change, and every other replica accepts it.
- *
- * It also wins that election counting votes over the stale voter set, i.e. with
- * fewer votes than the real configuration requires.
+ * Control: without the lost configuration the very same partition acknowledges
+ * nothing. The victim knows it needs three of five voters, cannot get them, and
+ * fails the write instead of losing it.
  */
 TEST_F_CORO(
-  configuration_divergence_test, stale_replica_regresses_group_as_leader) {
-    co_await diverge_one_follower();
+  configuration_divergence_test, no_write_is_acknowledged_when_intact) {
+    co_await grow_group(2, false);
 
-    const auto n3 = node(added_node).get_vnode();
-    for (auto id : all_ids()) {
-        if (id != victim_id) {
-            ASSERT_TRUE_CORO(node(id).raft()->config().contains(n3));
-        }
-    }
+    ASSERT_EQ_CORO(
+      node(victim_id).raft()->config().current_config().voters.size(), 5);
 
-    co_await transfer_leadership_to(victim_id);
+    const std::vector<model::node_id> stale_side{victim_id, third_original()};
+    const std::vector<model::node_id> real_side{
+      leader_id, added_node, model::node_id(added_node() + 1)};
 
-    // every replica that is still part of the stale configuration accepts it as
-    // an authoritative configuration change: the group's membership has gone
-    // backwards, revision included
-    RPTEST_REQUIRE_EVENTUALLY_CORO(30s, [this, n3] {
-        return std::ranges::all_of(all_ids(), [this, n3](model::node_id id) {
-            if (id == added_node) {
-                return true;
-            }
-            const auto& cfg = node(id).raft()->config();
-            return cfg.get_state() == configuration_state::simple
-                   && cfg.current_config().voters.size() == 3
-                   && !cfg.contains(n3)
-                   && cfg.revision_id() < model::revision_id(1);
-        });
-    });
+    node(third_original()).raft()->block_new_leadership();
+    partition_group(stale_side, real_side);
 
-    // the removed node is never told. It is absent from the configuration the
-    // new leader knows about, so it is dropped from the follower states and
-    // nothing is dispatched to it: it goes on believing it is a voter of a four
-    // node group, campaigning in a configuration that no longer exists.
-    const auto& orphan_cfg = node(added_node).raft()->config();
-    ASSERT_EQ_CORO(orphan_cfg.current_config().voters.size(), 4);
-    ASSERT_TRUE_CORO(orphan_cfg.is_voter(n3));
-    ASSERT_LT_CORO(
-      node(added_node).raft()->get_latest_configuration_offset(),
-      node(victim_id).raft()->get_latest_configuration_offset());
-
-    // the regression is durable: it is a real configuration batch in the log
-    auto cfg_offsets = co_await configuration_offsets_in_log(victim_id);
-    auto latest = node(victim_id).raft()->get_latest_configuration_offset();
-    ASSERT_TRUE_CORO(
-      std::ranges::find(cfg_offsets, latest) != cfg_offsets.end());
+    // two of five voters can neither elect nor commit
+    auto res = co_await node(victim_id).raft()->replicate(
+      make_batches({{"lost", "v"}}),
+      replicate_options(consistency_level::quorum_ack, 5s));
+    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_FALSE_CORO(node(victim_id).raft()->is_leader());
 }

--- a/src/v/raft/tests/configuration_divergence_test.cc
+++ b/src/v/raft/tests/configuration_divergence_test.cc
@@ -15,12 +15,12 @@
 #include "raft/tests/raft_fixture.h"
 #include "raft/tests/raft_fixture_retry_policy.h"
 #include "raft/types.h"
-#include "serde/rw/rw.h"
 #include "storage/types.h"
 #include "test_utils/async.h"
 #include "test_utils/test.h"
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/sleep.hh>
 
 #include <algorithm>
 #include <chrono>
@@ -30,14 +30,18 @@ using namespace raft;
 namespace {
 
 /**
- * raft::configuration_manager is only ever told about a configuration from the
- * continuation of consensus::disk_append. When an append fails after a
- * raft_configuration batch already became visible in the log, that continuation
- * never runs: the batch is in the log but the manager never learns about it.
+ * An append can fail after a raft_configuration batch already became visible
+ * in the log, e.g. when a later batch of the same append_entries request
+ * fails to be written. The configuration manager must still learn about the
+ * visible configuration: nothing ever re-delivers it otherwise (a leader
+ * does not resend entries that are already present in a follower's log) and
+ * the manager's state would silently diverge from the log, breaking the
+ * quorum arithmetic that raft's configuration change rules depend on.
  *
- * These tests demonstrate the consequences. They are all about a single
- * replica's derived state diverging from its own log - the logs themselves stay
- * identical across the group throughout.
+ * These tests inject such failures on a single replica (the victim) and
+ * verify that its configuration manager stays consistent with its log, in
+ * memory, across the partition scenario that would previously lose an
+ * acknowledged write, and across a restart.
  */
 struct configuration_divergence_test : raft_fixture {
     /**
@@ -66,13 +70,16 @@ struct configuration_divergence_test : raft_fixture {
     }
 
     /**
-     * Reads the raw log, including the raft_configuration batches that
-     * raft_node_instance::read_batches_in_range filters out.
+     * Reads the raw log directly from storage, including the
+     * raft_configuration batches that
+     * raft_node_instance::read_batches_in_range filters out and without
+     * capping at the raft visibility offset (which is unset on a freshly
+     * restarted node with no leader).
      */
     ss::future<model::record_batch_reader::data_t>
     read_raw_log(model::node_id id) {
         auto raft = node(id).raft();
-        auto rdr = co_await raft->make_reader(
+        auto rdr = co_await node(id).f_injectable_log()->make_reader(
           storage::local_log_reader_config(
             raft->start_offset(), model::offset::max()));
         co_return co_await model::consume_reader_to_memory(
@@ -89,19 +96,6 @@ struct configuration_divergence_test : raft_fixture {
             }
         }
         co_return offsets;
-    }
-
-    ss::future<> transfer_leadership_to(model::node_id target) {
-        auto start = model::timeout_clock::now();
-        while (true) {
-            auto current_leader = co_await wait_for_leader(start + 30s);
-            if (current_leader == target) {
-                co_return;
-            }
-            auto raft = node(current_leader).raft();
-            std::ignore = co_await raft->transfer_leadership(
-              {.group = raft->group(), .target = target, .timeout = 10s});
-        }
     }
 
     /**
@@ -128,22 +122,6 @@ struct configuration_divergence_test : raft_fixture {
         block_towards(b, a);
     }
 
-    ss::future<bool>
-    log_contains_key(model::node_id id, const ss::sstring& key) {
-        const auto expected = serde::to_iobuf(key);
-        for (auto& b : co_await read_raw_log(id)) {
-            if (b.header().type != model::record_batch_type::raft_data) {
-                continue;
-            }
-            for (auto& r : b.copy_records()) {
-                if (r.key() == expected) {
-                    co_return true;
-                }
-            }
-        }
-        co_return false;
-    }
-
     ss::future<> restart(model::node_id id, std::vector<vnode> initial_nodes) {
         auto dir = node(id).raft()->log()->config().base_directory();
         co_await stop_node(id);
@@ -154,7 +132,7 @@ struct configuration_divergence_test : raft_fixture {
     /**
      * Grows the initial three node group by `extra` nodes. When
      * `drop_on_victim` is set every configuration batch append fails on the
-     * victim after becoming visible, so it never learns the new configuration.
+     * victim after the batch became visible in its log.
      */
     ss::future<> grow_group(size_t extra, bool drop_on_victim) {
         co_await create_simple_group(3);
@@ -188,8 +166,6 @@ struct configuration_divergence_test : raft_fixture {
         co_await node(leader_id).raft()->replace_configuration(
           all_vnodes(), model::revision_id(1));
 
-        // the reconfiguration completes on every node but the victim, whose
-        // configuration manager never learns about any of the batches
         RPTEST_REQUIRE_EVENTUALLY_CORO(30s, [this, target_voters] {
             const auto& cfg = node(leader_id).raft()->config();
             return cfg.get_state() == configuration_state::simple
@@ -197,32 +173,30 @@ struct configuration_divergence_test : raft_fixture {
         });
 
         // the failed appends leave the batches visible, so the victim's log
-        // still catches up with the leader's. Only once it has can the hook be
-        // removed without the victim picking a configuration up after the fact.
+        // still catches up with the leader's. Waiting for that before
+        // removing the hook makes the number of injected failures
+        // deterministic.
         RPTEST_REQUIRE_EVENTUALLY_CORO(30s, [this] {
             return node(victim_id).raft()->dirty_offset()
                    == node(leader_id).raft()->dirty_offset();
         });
 
         if (drop_on_victim) {
-            // both the joint and the resulting simple configuration were
-            // dropped
+            // both the joint and the resulting simple configuration appends
+            // failed on the victim
             ASSERT_GE_CORO(*dropped, 2);
             stop_dropping_configurations_on(victim_id);
         }
 
-        // a failed append never reaches end_of_stream, so the dropped batches
-        // are visible but not yet flushed. Appending data behind them makes
-        // them durable and readable without telling the victim's configuration
-        // manager anything.
+        // a failed append never reaches end_of_stream, so the batches whose
+        // append failed are visible but not yet flushed. Appending data
+        // behind them makes them durable and readable.
         auto tail = co_await node(leader_id).raft()->replicate(
           make_batches({{"k_1", "v_1"}}),
           replicate_options(consistency_level::quorum_ack));
         ASSERT_TRUE_CORO(tail.has_value());
         co_await wait_for_committed_offset(tail.value().last_offset, 30s);
     }
-
-    ss::future<> diverge_one_follower() { return grow_group(1, true); }
 
     // the original group member that is neither the leader nor the victim
     model::node_id third_original() const {
@@ -244,88 +218,75 @@ struct configuration_divergence_test : raft_fixture {
 } // namespace
 
 /**
- *
- * The group really has five voters, so a commit needs three of them. The victim
- * lost that configuration and still believes in the original three, so it needs
- * only two. Partitioning the group so that the victim has a majority of the
- * configuration it believes in, but not of the real one, lets it acknowledge a
- * write to a client that no quorum of the real configuration ever saw. When the
- * victim's side goes away that write is gone, while the surviving three nodes
- * are a legitimate majority of the real configuration and carry on serving.
- *
- * Both sides can commit at the same time: the two acknowledging sets are
- * disjoint, which is exactly what raft's configuration change rules exist to
- * make impossible.
+ * The victim's configuration manager tracks its own log even though every
+ * configuration batch append on it failed after the batch became visible:
+ * the configurations of the visible batches are reconciled into the manager
+ * on the failure path, so the victim converges on the five voter
+ * configuration like every other replica.
  */
-TEST_F_CORO(configuration_divergence_test, acknowledged_write_is_lost) {
+TEST_F_CORO(configuration_divergence_test, configuration_manager_tracks_log) {
     co_await grow_group(2, true);
 
-    // the victim still believes in the original three voters
+    RPTEST_REQUIRE_EVENTUALLY_CORO(30s, [this] {
+        const auto& cfg = node(victim_id).raft()->config();
+        return cfg.get_state() == configuration_state::simple
+               && cfg.current_config().voters.size() == 5;
+    });
+
+    // the manager's latest configuration is the last configuration batch of
+    // the victim's log
+    auto log_offsets = co_await configuration_offsets_in_log(victim_id);
+    ASSERT_FALSE_CORO(log_offsets.empty());
     ASSERT_EQ_CORO(
-      node(victim_id).raft()->config().current_config().voters.size(), 3);
+      node(victim_id).raft()->get_latest_configuration_offset(),
+      log_offsets.back());
+}
+
+/**
+ * The partition that would previously lose an acknowledged write: the group
+ * really has five voters, and a victim that lost the configuration would
+ * believe in the original three, elect itself with two votes and acknowledge
+ * a write no quorum of the real configuration ever saw. With the
+ * configuration manager consistent with the log the victim knows it needs
+ * three of five voters, cannot get them, and no write is acknowledged.
+ */
+TEST_F_CORO(
+  configuration_divergence_test, no_split_brain_after_append_failures) {
+    co_await grow_group(2, true);
+
+    // the victim learned the five voter configuration despite the failures
+    ASSERT_EQ_CORO(
+      node(victim_id).raft()->config().current_config().voters.size(), 5);
     ASSERT_EQ_CORO(
       node(leader_id).raft()->config().current_config().voters.size(), 5);
 
-    // the victim plus one other original node is a majority of the stale
-    // configuration and no majority at all of the real one
+    // the victim plus one other original node is a majority of the original
+    // three node configuration and no majority at all of the real one
     const std::vector<model::node_id> stale_side{victim_id, third_original()};
     const std::vector<model::node_id> real_side{
       leader_id, added_node, model::node_id(added_node() + 1)};
 
-    // make sure the victim, not its ally, wins on the stale side
+    // if the victim were to campaign with a stale configuration, make sure
+    // it is the one to win on its side of the partition
     node(third_original()).raft()->block_new_leadership();
     partition_group(stale_side, real_side);
 
-    RPTEST_REQUIRE_EVENTUALLY_CORO(
-      30s, [this] { return node(victim_id).raft()->is_elected_leader(); });
+    // give the victim several election timeouts worth of opportunity to
+    // elect itself with a stale quorum
+    co_await ss::sleep(5s);
+    ASSERT_FALSE_CORO(node(victim_id).raft()->is_elected_leader());
 
-    // two of three acknowledge, so the write is committed and acknowledged to
-    // the caller with quorum_ack
-    auto lost = co_await node(victim_id).raft()->replicate(
+    // two of five voters can neither elect nor commit
+    auto res = co_await node(victim_id).raft()->replicate(
       make_batches({{"lost", "v"}}),
-      replicate_options(consistency_level::quorum_ack, 10s));
-    ASSERT_TRUE_CORO(lost.has_value());
-    RPTEST_REQUIRE_EVENTUALLY_CORO(30s, [this, lost] {
-        return node(victim_id).raft()->committed_offset()
-               >= lost.value().last_offset;
-    });
-
-    // the real side, holding a majority of the real configuration, never saw it
-    // and keeps committing on its own
-    for (auto id : real_side) {
-        ASSERT_FALSE_CORO(co_await log_contains_key(id, "lost"));
-    }
-
-    // the victim's side goes away, as the node that acknowledged the write
-    // would on any ordinary failure
-    for (auto id : stale_side) {
-        co_await stop_node(id);
-    }
-    for (auto id : real_side) {
-        node(id).reset_dispatch_handlers();
-    }
-
-    // three of five voters are alive: a legitimate majority of the real
-    // configuration, which elects and commits normally
-    co_await wait_for_leader(30s);
-    auto after = co_await retry_with_leader(
-      model::timeout_clock::now() + 30s, [this](raft_node_instance& leader) {
-          return leader.raft()->replicate(
-            make_batches({{"after", "v"}}),
-            replicate_options(consistency_level::quorum_ack, 10s));
-      });
-    ASSERT_TRUE_CORO(after.has_value());
-
-    // the acknowledged write is on no surviving replica
-    for (auto id : real_side) {
-        ASSERT_FALSE_CORO(co_await log_contains_key(id, "lost"));
-    }
+      replicate_options(consistency_level::quorum_ack, 5s));
+    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_FALSE_CORO(node(victim_id).raft()->is_leader());
 }
 
 /**
- * Control: without the lost configuration the very same partition acknowledges
- * nothing. The victim knows it needs three of five voters, cannot get them, and
- * fails the write instead of losing it.
+ * Control: the same partition with no failure injection behaves identically,
+ * demonstrating that the injected failures no longer make a difference.
  */
 TEST_F_CORO(
   configuration_divergence_test, no_write_is_acknowledged_when_intact) {
@@ -347,4 +308,32 @@ TEST_F_CORO(
       replicate_options(consistency_level::quorum_ack, 5s));
     ASSERT_TRUE_CORO(res.has_error());
     ASSERT_FALSE_CORO(node(victim_id).raft()->is_leader());
+}
+
+/**
+ * The reconciliation is durable: the configuration manager only persists a
+ * highest known offset covering offsets whose configurations it has
+ * processed, so a restart of the victim recovers a configuration consistent
+ * with its log even though later successful appends advanced the persisted
+ * state past the batches whose appends failed.
+ */
+TEST_F_CORO(
+  configuration_divergence_test, configuration_survives_victim_restart) {
+    co_await grow_group(2, true);
+
+    RPTEST_REQUIRE_EVENTUALLY_CORO(30s, [this] {
+        const auto& cfg = node(victim_id).raft()->config();
+        return cfg.get_state() == configuration_state::simple
+               && cfg.current_config().voters.size() == 5;
+    });
+
+    co_await restart(victim_id, all_vnodes());
+
+    const auto& cfg = node(victim_id).raft()->config();
+    ASSERT_EQ_CORO(cfg.current_config().voters.size(), 5);
+    auto log_offsets = co_await configuration_offsets_in_log(victim_id);
+    ASSERT_FALSE_CORO(log_offsets.empty());
+    ASSERT_EQ_CORO(
+      node(victim_id).raft()->get_latest_configuration_offset(),
+      log_offsets.back());
 }

--- a/src/v/raft/tests/failure_injectable_log.cc
+++ b/src/v/raft/tests/failure_injectable_log.cc
@@ -65,17 +65,40 @@ struct delay_introducing_appender : public storage::log_appender::impl {
     storage::log_appender _underlying;
     append_delay_generator _append_delay_generator;
 };
+
+struct hook_invoking_appender : public storage::log_appender::impl {
+    hook_invoking_appender(storage::log_appender underlying, append_hook hook)
+      : _underlying(std::move(underlying))
+      , _hook(std::move(hook)) {}
+
+    /// non-owning reference - do not steal the iobuf
+    ss::future<ss::stop_iteration> operator()(model::record_batch& b) final {
+        co_await _hook(b);
+        co_return co_await _underlying(b);
+    }
+
+    ss::future<storage::append_result> end_of_stream() final {
+        return _underlying.end_of_stream();
+    }
+    storage::log_appender _underlying;
+    append_hook _hook;
+};
 } // namespace
 
 storage::log_appender
 failure_injectable_log::make_appender(storage::log_append_config cfg) {
+    auto appender = _underlying_log->make_appender(cfg);
     if (_append_delay_generator) {
-        return storage::log_appender(
+        appender = storage::log_appender(
           std::make_unique<delay_introducing_appender>(
-            _underlying_log->make_appender(cfg), *_append_delay_generator));
+            std::move(appender), *_append_delay_generator));
     }
-
-    return _underlying_log->make_appender(cfg);
+    if (_append_hook) {
+        appender = storage::log_appender(
+          std::make_unique<hook_invoking_appender>(
+            std::move(appender), *_append_hook));
+    }
+    return appender;
 }
 
 ss::future<std::optional<ss::sstring>> failure_injectable_log::close() {

--- a/src/v/raft/tests/failure_injectable_log.cc
+++ b/src/v/raft/tests/failure_injectable_log.cc
@@ -83,6 +83,28 @@ struct hook_invoking_appender : public storage::log_appender::impl {
     storage::log_appender _underlying;
     append_hook _hook;
 };
+
+struct post_append_failing_appender : public storage::log_appender::impl {
+    post_append_failing_appender(
+      storage::log_appender underlying, post_append_hook hook)
+      : _underlying(std::move(underlying))
+      , _hook(std::move(hook)) {}
+
+    /// non-owning reference - do not steal the iobuf
+    ss::future<ss::stop_iteration> operator()(model::record_batch& b) final {
+        auto stop = co_await _underlying(b);
+        // the batch is durable and visible at this point, a failure here fails
+        // the append without removing it from the log
+        co_await _hook(b);
+        co_return stop;
+    }
+
+    ss::future<storage::append_result> end_of_stream() final {
+        return _underlying.end_of_stream();
+    }
+    storage::log_appender _underlying;
+    post_append_hook _hook;
+};
 } // namespace
 
 storage::log_appender
@@ -97,6 +119,11 @@ failure_injectable_log::make_appender(storage::log_append_config cfg) {
         appender = storage::log_appender(
           std::make_unique<hook_invoking_appender>(
             std::move(appender), *_append_hook));
+    }
+    if (_post_append_hook) {
+        appender = storage::log_appender(
+          std::make_unique<post_append_failing_appender>(
+            std::move(appender), *_post_append_hook));
     }
     return appender;
 }

--- a/src/v/raft/tests/failure_injectable_log.h
+++ b/src/v/raft/tests/failure_injectable_log.h
@@ -14,6 +14,7 @@
 namespace raft {
 
 using append_delay_generator = std::function<std::chrono::milliseconds()>;
+using append_hook = std::function<ss::future<>(const model::record_batch&)>;
 
 class failure_injectable_log final : public storage::log {
 public:
@@ -21,6 +22,12 @@ public:
     // batch to the log
     void set_append_delay(std::optional<append_delay_generator> generator) {
         _append_delay_generator = std::move(generator);
+    }
+
+    // sets a hook invoked before each record batch is appended to the log,
+    // returning a failed future from the hook fails the append
+    void set_append_hook(std::optional<append_hook> hook) {
+        _append_hook = std::move(hook);
     }
 
 public:
@@ -163,5 +170,6 @@ public:
 private:
     ss::shared_ptr<storage::log> _underlying_log;
     std::optional<append_delay_generator> _append_delay_generator;
+    std::optional<append_hook> _append_hook;
 };
 } // namespace raft

--- a/src/v/raft/tests/failure_injectable_log.h
+++ b/src/v/raft/tests/failure_injectable_log.h
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 #pragma once
+#include "model/record.h"
 #include "storage/log.h"
 #include "storage/offset_translator_state.h"
 #include "storage/types.h"
@@ -15,6 +16,8 @@ namespace raft {
 
 using append_delay_generator = std::function<std::chrono::milliseconds()>;
 using append_hook = std::function<ss::future<>(const model::record_batch&)>;
+using post_append_hook
+  = std::function<ss::future<>(const model::record_batch&)>;
 
 class failure_injectable_log final : public storage::log {
 public:
@@ -28,6 +31,22 @@ public:
     // returning a failed future from the hook fails the append
     void set_append_hook(std::optional<append_hook> hook) {
         _append_hook = std::move(hook);
+    }
+
+    /**
+     * Sets a hook invoked after each record batch has been appended to the
+     * underlying log, i.e. once the batch is visible to readers and the offset
+     * translator has been updated.
+     *
+     * Returning a failed future from the hook fails the append while leaving
+     * the batch in the log. This models a failure of a later step of the same
+     * append - most realistically a subsequent batch of the same
+     * append_entries request failing to be written - which leaves callers of
+     * log::make_appender() with an exception even though everything up to this
+     * batch is durable and readable.
+     */
+    void set_post_append_hook(std::optional<post_append_hook> hook) {
+        _post_append_hook = std::move(hook);
     }
 
 public:
@@ -171,5 +190,6 @@ private:
     ss::shared_ptr<storage::log> _underlying_log;
     std::optional<append_delay_generator> _append_delay_generator;
     std::optional<append_hook> _append_hook;
+    std::optional<post_append_hook> _post_append_hook;
 };
 } // namespace raft

--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -20,6 +20,7 @@
 
 #include <seastar/core/timed_out_error.hh>
 #include <seastar/core/with_timeout.hh>
+#include <seastar/coroutine/as_future.hh>
 #include <seastar/util/bool_class.hh>
 
 namespace raft {
@@ -430,14 +431,71 @@ ss::future<> vote_stm::update_vote_state(ssx::semaphore_units u) {
 
     auto ec = co_await replicate_config_as_new_leader(std::move(u));
 
-    // even if failed to replicate, don't step down: followers may be behind
     if (ec) {
-        vlog(
-          _ctxlog.info,
-          "unable to replicate configuration as a leader - error code: "
-          "{} - {} ",
-          ec.value(),
-          ec.message());
+        /**
+         * Re-acquire the op lock so that reading the log state, deciding and
+         * stepping down are atomic with respect to appends: every append
+         * path acquires the op lock, and on the timeout path this also
+         * serializes behind the still running configuration append (it holds
+         * the lock units until the local append completes), so the outcome
+         * of our own append is settled by the time the units are granted.
+         */
+        auto lock_fut = co_await ss::coroutine::as_future(
+          _ptr->_op_lock.get_units());
+        if (lock_fut.failed()) {
+            // the lock is only broken on shutdown
+            auto eptr = lock_fut.get_exception();
+            vlog(
+              _ctxlog.debug,
+              "failed to acquire op lock after configuration replication "
+              "failure: {}",
+              eptr);
+            co_return;
+        }
+        auto units = std::move(lock_fut).get();
+        if (
+          _ptr->_vstate != consensus::vote_state::leader
+          || _ptr->_term != term) {
+            // no longer the leader of this term, nothing to decide
+            co_return;
+        }
+        /**
+         * The failure modes differ in whether the configuration batch made
+         * it into the local log.
+         *
+         * If it did (its term is the term of the last batch in the log),
+         * quorum replication is what failed or timed out: followers may just
+         * be behind, recovery will deliver the batch to them and committing
+         * it confirms the term, so stay leader.
+         *
+         * If it did not, nothing will ever append a configuration batch for
+         * this term - there is no retry - and the leader could never be
+         * confirmed. Step down and let a new election retry the append in a
+         * new term.
+         */
+        const auto config_in_log = _ptr->_log->offsets().dirty_offset_term
+                                   == term;
+        if (config_in_log) {
+            vlog(
+              _ctxlog.info,
+              "unable to replicate configuration as a leader - error code: "
+              "{} - {}, configuration batch is in the local log, waiting for "
+              "the quorum to catch up",
+              ec.value(),
+              ec.message());
+        } else {
+            vlog(
+              _ctxlog.warn,
+              "failed to append configuration batch as a new leader - error "
+              "code: {} - {}, stepping down",
+              ec.value(),
+              ec.message());
+            _ptr->do_step_down("initial-configuration-append-failed");
+            if (_ptr->_leader_id) {
+                _ptr->_leader_id = std::nullopt;
+                _ptr->trigger_leadership_notification();
+            }
+        }
     } else {
         if (term == _ptr->_term) {
             vlog(_ctxlog.info, "became the leader term: {}", term);


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
