### PR TITLE
build/deps: namespace lz4's bundled xxhash

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -47,6 +47,14 @@ single_version_override(
 
 bazel_dep(name = "libxml2", version = "2.15.3")
 bazel_dep(name = "lz4", version = "1.9.4")
+single_version_override(
+    module_name = "lz4",
+    patch_strip = 1,
+    patches = [
+        "//bazel/thirdparty:lz4-namespace-xxhash.patch",
+    ],
+)
+
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "protobuf", version = "33.5")
 single_version_override(

--- a/bazel/thirdparty/lz4-namespace-xxhash.patch
+++ b/bazel/thirdparty/lz4-namespace-xxhash.patch
@@ -1,0 +1,19 @@
+Namespace LZ4's bundled xxHash symbols as its upstream build does. This avoids
+collisions with applications that link a separate xxHash version.
+
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -6,5 +6,6 @@
+ cc_library(
+     name = "lz4",
++    local_defines = ["XXH_NAMESPACE=LZ4_"],
+     srcs = [
+         "lib/lz4.c",
+         "lib/xxhash.c",
+@@ -44,5 +45,6 @@
+ cc_library(
+     name = "lz4_frame",
++    local_defines = ["XXH_NAMESPACE=LZ4_"],
+     srcs = [
+         "lib/lz4frame.c",
+         "lib/lz4frame_static.h",


### PR DESCRIPTION
lz4 bundles some (different) xxhash version to ours so we have duplicate
symbols in our build. These usually get removed by linking but PGO CFG
hash checks fail because of these mismatches.

This is a knwon lz4 issue: https://github.com/lz4/lz4/issues/125 which
has a workaround of adding a define that prefixes these symbols such
that there is no collision.

Apply a patch to the BCR lz4 rule to do that.

I'll upstream this fix shortly.

PGO build now succeeds with this.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes


* none
