### PR TITLE
rpk: single-source -X flag docs; expose x_options in --print-tree

### DIFF
--- a/src/go/rpk/pkg/cli/printtree.go
+++ b/src/go/rpk/pkg/cli/printtree.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -46,12 +47,13 @@ type commandPrint struct {
 }
 
 type rootPrint struct {
-	Name        string         `json:"name"`
-	Version     string         `json:"version"`
-	Description string         `json:"description"`
-	Usage       string         `json:"usage"`
-	GlobalFlags []flagPrint    `json:"global_flags"`
-	Commands    []commandPrint `json:"commands"`
+	Name        string            `json:"name"`
+	Version     string            `json:"version"`
+	Description string            `json:"description"`
+	Usage       string            `json:"usage"`
+	GlobalFlags []flagPrint       `json:"global_flags"`
+	XOptions    []config.XFlagDoc `json:"x_options"`
+	Commands    []commandPrint    `json:"commands"`
 }
 
 func printTreeJSON(root *cobra.Command) ([]byte, error) {
@@ -61,6 +63,7 @@ func printTreeJSON(root *cobra.Command) ([]byte, error) {
 		Description: root.Short,
 		Usage:       root.UseLine(),
 		GlobalFlags: printFlagSet(root.PersistentFlags()),
+		XOptions:    config.XFlagDocs(),
 		Commands:    printChildren(root),
 	}
 	return json.Marshal(rp)

--- a/src/go/rpk/pkg/cli/printtree_test.go
+++ b/src/go/rpk/pkg/cli/printtree_test.go
@@ -62,6 +62,13 @@ func TestPrintTree(t *testing.T) {
 	require.Equal(t, "bool", globals["verbose"].Type)
 	require.Equal(t, false, globals["verbose"].Default)
 
+	require.NotEmpty(t, got.XOptions, "x_options must expose the documented -X flags")
+	require.Equal(t, "brokers", got.XOptions[0].Name, "x_options must be in display order")
+	for _, x := range got.XOptions {
+		require.NotEmpty(t, x.Description, "every x_option must carry a description (%s)", x.Name)
+		require.NotEqual(t, "cloud_environment", x.Name, "deliberately undocumented flags must not be exposed")
+	}
+
 	names := make([]string, len(got.Commands))
 	for i, c := range got.Commands {
 		names[i] = c.Name

--- a/src/go/rpk/pkg/cli/printtree_test.go
+++ b/src/go/rpk/pkg/cli/printtree_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
@@ -64,8 +65,10 @@ func TestPrintTree(t *testing.T) {
 
 	require.NotEmpty(t, got.XOptions, "x_options must expose the documented -X flags")
 	require.Equal(t, "brokers", got.XOptions[0].Name, "x_options must be in display order")
+	require.Equal(t, "RPK_BROKERS", got.XOptions[0].Env)
 	for _, x := range got.XOptions {
 		require.NotEmpty(t, x.Description, "every x_option must carry a description (%s)", x.Name)
+		require.Equal(t, config.XEnvVar(x.Name), x.Env, "env must come from the same derivation rpk reads (%s)", x.Name)
 		require.NotEqual(t, "cloud_environment", x.Name, "deliberately undocumented flags must not be exposed")
 	}
 

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -307,6 +307,7 @@ var xflagDocs = []xflagDoc{
 // --print-tree to expose the flags to automation tooling.
 type XFlagDoc struct {
 	Name        string `json:"name"`
+	Env         string `json:"env"`
 	Format      string `json:"format"`
 	Example     string `json:"example"`
 	Description string `json:"description"`
@@ -319,6 +320,7 @@ func XFlagDocs() []XFlagDoc {
 	for _, d := range xflagDocs {
 		docs = append(docs, XFlagDoc{
 			Name:        d.name,
+			Env:         XEnvVar(d.name),
 			Format:      d.listHint,
 			Example:     d.helpExample,
 			Description: d.help,
@@ -1684,14 +1686,18 @@ func envOverrides() []string {
 		}
 	}
 	for _, k := range XFlags() {
-		targetKey := k
-		k = strings.ReplaceAll(k, ".", "_")
-		k = strings.ToUpper(k)
-		if v, exists := os.LookupEnv("RPK_" + k); exists {
-			envOverrides = append(envOverrides, targetKey+"="+v)
+		if v, exists := os.LookupEnv(XEnvVar(k)); exists {
+			envOverrides = append(envOverrides, k+"="+v)
 		}
 	}
 	return envOverrides
+}
+
+// XEnvVar returns the environment variable that overrides the given -X flag:
+// the flag name uppercased, with dots replaced by underscores, prefixed with
+// RPK_. For example, tls.enabled becomes RPK_TLS_ENABLED.
+func XEnvVar(name string) string {
+	return "RPK_" + strings.ToUpper(strings.ReplaceAll(name, ".", "_"))
 }
 
 // processes first env and then flag overrides into our virtual rpk yaml.

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -100,6 +100,233 @@ type xflag struct {
 	parse       func(string, *RpkYaml) error
 }
 
+// xflagDoc is the documentation for one -X flag: the short value hint shown
+// by -X list, and the example value and description shown by -X help. This
+// table is the single source of -X flag documentation; ParamsHelp, ParamsList,
+// and the --print-tree x_options output all render from it. Flags that are
+// deliberately undocumented (for example cloud_environment) are simply not
+// listed here; TestXFlagDocsComplete pins the table to the xflags map in both
+// directions.
+type xflagDoc struct {
+	name        string
+	listHint    string
+	helpExample string
+	help        string
+}
+
+var xflagDocs = []xflagDoc{
+	{
+		name:        xKafkaBrokers,
+		listHint:    `comma,delimited,host:ports`,
+		helpExample: `127.0.0.1:9092,localhost:9094`,
+		help:        "A comma separated list of host:ports that rpk talks to for the Kafka API.\nBy default, this is 127.0.0.1:9092.",
+	},
+	{
+		name:        xKafkaTLSEnabled,
+		listHint:    `boolean`,
+		helpExample: `true`,
+		help:        "A boolean that enables rpk to speak TLS to your broker's Kafka API listeners.\nYou can use this if you have well known certificates setup on your Kafka API.\nIf you use mTLS, specifying mTLS certificate filepaths automatically opts\ninto TLS enabled.",
+	},
+	{
+		name:        xKafkaTLSInsecure,
+		listHint:    `boolean`,
+		helpExample: `false`,
+		help:        "A boolean that disables rpk from verifying the broker's certificate chain.",
+	},
+	{
+		name:        xKafkaCACert,
+		listHint:    `/path/to/ca.pem`,
+		helpExample: `/path/to/ca.pem`,
+		help:        "A filepath to a PEM encoded CA certificate file to talk to your broker's\nKafka API listeners with mTLS. You may also need this if your listeners are\nusing a certificate by a well known authority that is not yet bundled on your\noperating system.",
+	},
+	{
+		name:        xKafkaClientCert,
+		listHint:    `/path/to/cert.pem`,
+		helpExample: `/path/to/cert.pem`,
+		help:        "A filepath to a PEM encoded client certificate file to talk to your broker's\nKafka API listeners with mTLS.",
+	},
+	{
+		name:        xKafkaClientKey,
+		listHint:    `/path/to/key.pem`,
+		helpExample: `/path/to/key.pem`,
+		help:        "A filepath to a PEM encoded client key file to talk to your broker's Kafka\nAPI listeners with mTLS.",
+	},
+	{
+		name:        xKafkaSASLMechanism,
+		listHint:    `SCRAM-SHA-256, SCRAM-SHA-512, PLAIN, or OAUTHBEARER`,
+		helpExample: `SCRAM-SHA-256`,
+		help:        "The SASL mechanism to use for authentication. This can be SCRAM-SHA-256,\nSCRAM-SHA-512, PLAIN, or OAUTHBEARER. For OAUTHBEARER, pass the token via\nthe pass field (optionally prefixed with \"token:\"). Note that with Redpanda,\nthe Admin API can be configured to require basic authentication with your\nKafka API SASL credentials. This defaults to SCRAM-SHA-256 if no mechanism\nis specified.",
+	},
+	{
+		name:        xKafkaSASLUser,
+		listHint:    `username`,
+		helpExample: `username`,
+		help:        "The SASL username to use for authentication. This is also used for the admin\nAPI if you have configured it to require basic authentication.",
+	},
+	{
+		name:        xKafkaSASLPass,
+		listHint:    `password`,
+		helpExample: `password`,
+		help:        "The SASL password to use for authentication. This is also used for the admin\nAPI if you have configured it to require basic authentication.",
+	},
+	{
+		name:        xAdminHosts,
+		listHint:    `comma,delimited,host:ports`,
+		helpExample: `localhost:9644,rp.example.com:9644`,
+		help:        "A comma separated list of host:ports that rpk talks to for the Admin API.\nBy default, this is 127.0.0.1:9644.",
+	},
+	{
+		name:        xAdminTLSEnabled,
+		listHint:    `boolean`,
+		helpExample: `false`,
+		help:        "A boolean that enables rpk to speak TLS to your broker's Admin API listeners.\nYou can use this if you have well known certificates setup on your admin API.\nIf you use mTLS, specifying mTLS certificate filepaths automatically opts\ninto TLS enabled.",
+	},
+	{
+		name:        xAdminTLSInsecure,
+		listHint:    `boolean`,
+		helpExample: `false`,
+		help:        "A boolean that disables rpk from verifying the broker's certificate chain.",
+	},
+	{
+		name:        xAdminCACert,
+		listHint:    `/path/to/ca.pem`,
+		helpExample: `/path/to/ca.pem`,
+		help:        "A filepath to a PEM encoded CA certificate file to talk to your broker's\nAdmin API listeners with mTLS. You may also need this if your listeners are\nusing a certificate by a well known authority that is not yet bundled on your\noperating system.",
+	},
+	{
+		name:        xAdminClientCert,
+		listHint:    `/path/to/cert.pem`,
+		helpExample: `/path/to/cert.pem`,
+		help:        "A filepath to a PEM encoded client certificate file to talk to your broker's\nAdmin API listeners with mTLS.",
+	},
+	{
+		name:        xAdminClientKey,
+		listHint:    `/path/to/key.pem`,
+		helpExample: `/path/to/key.pem`,
+		help:        "A filepath to a PEM encoded client key file to talk to your broker's Admin\nAPI listeners with mTLS.",
+	},
+	{
+		name:        xSchemaRegistryHosts,
+		listHint:    `comma,delimited,host:ports`,
+		helpExample: `localhost:8081,rp.example.com:8081`,
+		help:        "A comma separated list of host:ports that rpk talks to for the schema registry\nAPI. By default, this is 127.0.0.1:8081.",
+	},
+	{
+		name:        xSchemaRegistryTLSEnabled,
+		listHint:    `boolean`,
+		helpExample: `false`,
+		help:        "A boolean that enables rpk to speak TLS to your broker's schema registry API\nlisteners. You can use this if you have well known certificates setup on your\nschema registry API. If you use mTLS, specifying mTLS certificate filepaths\nautomatically opts into TLS enabled.",
+	},
+	{
+		name:        xSchemaRegistryTLSInsecure,
+		listHint:    `boolean`,
+		helpExample: `false`,
+		help:        "A boolean that disables rpk from verifying the broker's certificate chain.",
+	},
+	{
+		name:        xSchemaRegistryCACert,
+		listHint:    `/path/to/ca.pem`,
+		helpExample: `/path/to/ca.pem`,
+		help:        "A filepath to a PEM encoded CA certificate file to talk to your broker's\nschema registry API listeners with mTLS. You may also need this if your\nlisteners are using a certificate by a well known authority that is not yet\nbundled on your operating system.",
+	},
+	{
+		name:        xSchemaRegistryClientCert,
+		listHint:    `/path/to/cert.pem`,
+		helpExample: `/path/to/cert.pem`,
+		help:        "A filepath to a PEM encoded client certificate file to talk to your broker's\nschema registry API listeners with mTLS.",
+	},
+	{
+		name:        xSchemaRegistryClientKey,
+		listHint:    `/path/to/key.pem`,
+		helpExample: `/path/to/key.pem`,
+		help:        "A filepath to a PEM encoded client key file to talk to your broker's schema\nregistry API listeners with mTLS.",
+	},
+	{
+		name:        xCloudClientID,
+		listHint:    `somestring`,
+		helpExample: `somestring`,
+		help:        "An oauth client ID to use for authenticating with the Redpanda Cloud API.\nOverrides the client ID in the current profile if it is for a cloud cluster,\notherwise overrides the default cloud auth client ID.",
+	},
+	{
+		name:        xCloudClientSecret,
+		listHint:    `somelongerstring`,
+		helpExample: `somelongerstring`,
+		help:        "An oauth client secret to use for authenticating with the Redpanda Cloud API.\nOverrides the client secret in the current profile if it is for a cloud\ncluster, otherwise overrides the default cloud auth client secret.",
+	},
+	{
+		name:        "globals.prompt",
+		listHint:    `"%n"`,
+		helpExample: `"%n"`,
+		help:        "A format string to use for the default prompt; see 'rpk profile prompt' for\nmore information.",
+	},
+	{
+		name:        "globals.no_default_cluster",
+		listHint:    `boolean`,
+		helpExample: `false`,
+		help:        "A boolean that disables rpk from talking to localhost:9092 if no other\ncluster is specified.",
+	},
+	{
+		name:        "globals.command_timeout",
+		listHint:    `(30s,1m)`,
+		helpExample: `30s`,
+		help:        "A duration that rpk will wait for a command to complete before timing out,\nfor certain commands.",
+	},
+	{
+		name:        "globals.dial_timeout",
+		listHint:    `duration(3s,1m,2h)`,
+		helpExample: `3s`,
+		help:        "A duration that rpk will wait for a connection to be established before\ntiming out.",
+	},
+	{
+		name:        "globals.request_timeout_overhead",
+		listHint:    `duration(10s,1m,2h)`,
+		helpExample: `5s`,
+		help:        "A duration that limits how long rpk waits for responses, *on top* of any\nrequest-internal timeout. For example, ListOffsets has no Timeout field so\nif request_timeout_overhead is 10s, rpk will wait for 10s for a response.\nHowever, JoinGroup has a RebalanceTimeoutMillis field, so the 10s is applied\non top of the rebalance timeout.",
+	},
+	{
+		name:        "globals.retry_timeout",
+		listHint:    `duration(30s,1m,2h)`,
+		helpExample: `11s`,
+		help:        "This timeout specifies how long rpk will retry Kafka API requests. This\ntimeout is evaluated before any backoff -- if a request fails, we first check\nif the retry timeout has elapsed and if so, we stop retrying. If not, we wait\nfor the backoff and then retry.",
+	},
+	{
+		name:        "globals.fetch_max_wait",
+		listHint:    `duration(5s,1m,2h)`,
+		helpExample: `5s`,
+		help:        "This timeout specifies the maximum time that brokers will wait before\nreplying to a fetch request with whatever data is available.",
+	},
+	{
+		name:        "globals.kafka_protocol_request_client_id",
+		listHint:    `rpk`,
+		helpExample: `rpk`,
+		help:        "This string value is the client ID that rpk uses when issuing Kafka protocol\nrequests to Redpanda. This client ID shows up in Redpanda logs and metrics,\nchanging it can be useful if you want to have your own rpk client stand out\nfrom others that may be hitting the cluster.",
+	},
+}
+
+// XFlagDoc is the exported form of one -X flag's documentation, used by
+// --print-tree to expose the flags to automation tooling.
+type XFlagDoc struct {
+	Name        string `json:"name"`
+	Format      string `json:"format"`
+	Example     string `json:"example"`
+	Description string `json:"description"`
+}
+
+// XFlagDocs returns the documentation for every documented -X flag, in
+// display order.
+func XFlagDocs() []XFlagDoc {
+	docs := make([]XFlagDoc, 0, len(xflagDocs))
+	for _, d := range xflagDocs {
+		docs = append(docs, XFlagDoc{
+			Name:        d.name,
+			Format:      d.listHint,
+			Example:     d.helpExample,
+			Description: d.help,
+		})
+	}
+	return docs
+}
+
 func splitCommaIntoStrings(in string, dst *[]string) error {
 	*dst = nil
 	split := strings.SplitSeq(in, ",")
@@ -651,7 +878,24 @@ type Params struct {
 
 // ParamsHelp returns the long help text for -X help.
 func ParamsHelp() string {
-	return `The -X flag can be used to override any rpk specific configuration option.
+	var sb strings.Builder
+	sb.WriteString(xflagHelpIntro)
+	for _, d := range xflagDocs {
+		sb.WriteString("\n")
+		sb.WriteString(d.name)
+		sb.WriteString("=")
+		sb.WriteString(d.helpExample)
+		sb.WriteString("\n")
+		for line := range strings.SplitSeq(d.help, "\n") {
+			sb.WriteString("  ")
+			sb.WriteString(line)
+			sb.WriteString("\n")
+		}
+	}
+	return sb.String()
+}
+
+const xflagHelpIntro = `The -X flag can be used to override any rpk specific configuration option.
 As an example, -X brokers.tls.enabled=true enables TLS for the Kafka API.
 
 All -X flags can also be set via environment variables. The corresponding
@@ -660,189 +904,18 @@ underscores, and prefixed with RPK_. For example, -X brokers becomes
 RPK_BROKERS, and -X tls.enabled becomes RPK_TLS_ENABLED.
 
 The following options are available, with an example value for each option:
-
-brokers=127.0.0.1:9092,localhost:9094
-  A comma separated list of host:ports that rpk talks to for the Kafka API.
-  By default, this is 127.0.0.1:9092.
-
-tls.enabled=true
-  A boolean that enables rpk to speak TLS to your broker's Kafka API listeners.
-  You can use this if you have well known certificates setup on your Kafka API.
-  If you use mTLS, specifying mTLS certificate filepaths automatically opts
-  into TLS enabled.
-
-tls.insecure_skip_verify=false
-  A boolean that disables rpk from verifying the broker's certificate chain.
-
-tls.ca=/path/to/ca.pem
-  A filepath to a PEM encoded CA certificate file to talk to your broker's
-  Kafka API listeners with mTLS. You may also need this if your listeners are
-  using a certificate by a well known authority that is not yet bundled on your
-  operating system.
-
-tls.cert=/path/to/cert.pem
-  A filepath to a PEM encoded client certificate file to talk to your broker's
-  Kafka API listeners with mTLS.
-
-tls.key=/path/to/key.pem
-  A filepath to a PEM encoded client key file to talk to your broker's Kafka
-  API listeners with mTLS.
-
-sasl.mechanism=SCRAM-SHA-256
-  The SASL mechanism to use for authentication. This can be SCRAM-SHA-256,
-  SCRAM-SHA-512, PLAIN, or OAUTHBEARER. For OAUTHBEARER, pass the token via
-  the pass field (optionally prefixed with "token:"). Note that with Redpanda,
-  the Admin API can be configured to require basic authentication with your
-  Kafka API SASL credentials. This defaults to SCRAM-SHA-256 if no mechanism
-  is specified.
-
-user=username
-  The SASL username to use for authentication. This is also used for the admin
-  API if you have configured it to require basic authentication.
-
-pass=password
-  The SASL password to use for authentication. This is also used for the admin
-  API if you have configured it to require basic authentication.
-
-admin.hosts=localhost:9644,rp.example.com:9644
-  A comma separated list of host:ports that rpk talks to for the Admin API.
-  By default, this is 127.0.0.1:9644.
-
-admin.tls.enabled=false
-  A boolean that enables rpk to speak TLS to your broker's Admin API listeners.
-  You can use this if you have well known certificates setup on your admin API.
-  If you use mTLS, specifying mTLS certificate filepaths automatically opts
-  into TLS enabled.
-
-admin.tls.insecure_skip_verify=false
-  A boolean that disables rpk from verifying the broker's certificate chain.
-
-admin.tls.ca=/path/to/ca.pem
-  A filepath to a PEM encoded CA certificate file to talk to your broker's
-  Admin API listeners with mTLS. You may also need this if your listeners are
-  using a certificate by a well known authority that is not yet bundled on your
-  operating system.
-
-admin.tls.cert=/path/to/cert.pem
-  A filepath to a PEM encoded client certificate file to talk to your broker's
-  Admin API listeners with mTLS.
-
-admin.tls.key=/path/to/key.pem
-  A filepath to a PEM encoded client key file to talk to your broker's Admin
-  API listeners with mTLS.
-
-registry.hosts=localhost:8081,rp.example.com:8081
-  A comma separated list of host:ports that rpk talks to for the schema registry
-  API. By default, this is 127.0.0.1:8081.
-
-registry.tls.enabled=false
-  A boolean that enables rpk to speak TLS to your broker's schema registry API
-  listeners. You can use this if you have well known certificates setup on your
-  schema registry API. If you use mTLS, specifying mTLS certificate filepaths
-  automatically opts into TLS enabled.
-
-registry.tls.insecure_skip_verify=false
-  A boolean that disables rpk from verifying the broker's certificate chain.
-
-registry.tls.ca=/path/to/ca.pem
-  A filepath to a PEM encoded CA certificate file to talk to your broker's
-  schema registry API listeners with mTLS. You may also need this if your
-  listeners are using a certificate by a well known authority that is not yet
-  bundled on your operating system.
-
-registry.tls.cert=/path/to/cert.pem
-  A filepath to a PEM encoded client certificate file to talk to your broker's
-  schema registry API listeners with mTLS.
-
-registry.tls.key=/path/to/key.pem
-  A filepath to a PEM encoded client key file to talk to your broker's schema
-  registry API listeners with mTLS.
-
-cloud.client_id=somestring
-  An oauth client ID to use for authenticating with the Redpanda Cloud API.
-  Overrides the client ID in the current profile if it is for a cloud cluster,
-  otherwise overrides the default cloud auth client ID.
-
-cloud.client_secret=somelongerstring
-  An oauth client secret to use for authenticating with the Redpanda Cloud API.
-  Overrides the client secret in the current profile if it is for a cloud
-  cluster, otherwise overrides the default cloud auth client secret.
-
-globals.prompt="%n"
-  A format string to use for the default prompt; see 'rpk profile prompt' for
-  more information.
-
-globals.no_default_cluster=false
-  A boolean that disables rpk from talking to localhost:9092 if no other
-  cluster is specified.
-
-globals.command_timeout=30s
-  A duration that rpk will wait for a command to complete before timing out,
-  for certain commands.
-
-globals.dial_timeout=3s
-  A duration that rpk will wait for a connection to be established before
-  timing out.
-
-globals.request_timeout_overhead=5s
-  A duration that limits how long rpk waits for responses, *on top* of any
-  request-internal timeout. For example, ListOffsets has no Timeout field so
-  if request_timeout_overhead is 10s, rpk will wait for 10s for a response.
-  However, JoinGroup has a RebalanceTimeoutMillis field, so the 10s is applied
-  on top of the rebalance timeout.
-
-globals.retry_timeout=11s
-  This timeout specifies how long rpk will retry Kafka API requests. This
-  timeout is evaluated before any backoff -- if a request fails, we first check
-  if the retry timeout has elapsed and if so, we stop retrying. If not, we wait
-  for the backoff and then retry.
-
-globals.fetch_max_wait=5s
-  This timeout specifies the maximum time that brokers will wait before
-  replying to a fetch request with whatever data is available.
-
-globals.kafka_protocol_request_client_id=rpk
-  This string value is the client ID that rpk uses when issuing Kafka protocol
-  requests to Redpanda. This client ID shows up in Redpanda logs and metrics,
-  changing it can be useful if you want to have your own rpk client stand out
-  from others that may be hitting the cluster.
 `
-}
 
 // ParamsList returns the short help text for -X list.
 func ParamsList() string {
-	return `brokers=comma,delimited,host:ports
-tls.enabled=boolean
-tls.insecure_skip_verify=boolean
-tls.ca=/path/to/ca.pem
-tls.cert=/path/to/cert.pem
-tls.key=/path/to/key.pem
-sasl.mechanism=SCRAM-SHA-256, SCRAM-SHA-512, PLAIN, or OAUTHBEARER
-user=username
-pass=password
-admin.hosts=comma,delimited,host:ports
-admin.tls.enabled=boolean
-admin.tls.insecure_skip_verify=boolean
-admin.tls.ca=/path/to/ca.pem
-admin.tls.cert=/path/to/cert.pem
-admin.tls.key=/path/to/key.pem
-registry.hosts=comma,delimited,host:ports
-registry.tls.enabled=boolean
-registry.tls.insecure_skip_verify=boolean
-registry.tls.ca=/path/to/ca.pem
-registry.tls.cert=/path/to/cert.pem
-registry.tls.key=/path/to/key.pem
-cloud.client_id=somestring
-cloud.client_secret=somelongerstring
-globals.prompt="%n"
-globals.no_default_cluster=boolean
-globals.command_timeout=(30s,1m)
-globals.dial_timeout=duration(3s,1m,2h)
-globals.request_timeout_overhead=duration(10s,1m,2h)
-globals.retry_timeout=duration(30s,1m,2h)
-globals.fetch_max_wait=duration(5s,1m,2h)
-globals.kafka_protocol_request_client_id=rpk
-`
+	var sb strings.Builder
+	for _, d := range xflagDocs {
+		sb.WriteString(d.name)
+		sb.WriteString("=")
+		sb.WriteString(d.listHint)
+		sb.WriteString("\n")
+	}
+	return sb.String()
 }
 
 //////////////////////

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -896,7 +896,7 @@ func ParamsHelp() string {
 }
 
 const xflagHelpIntro = `The -X flag can be used to override any rpk specific configuration option.
-As an example, -X brokers.tls.enabled=true enables TLS for the Kafka API.
+As an example, -X tls.enabled=true enables TLS for the Kafka API.
 
 All -X flags can also be set via environment variables. The corresponding
 environment variable is the flag name uppercased, with dots replaced by

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -1356,6 +1356,28 @@ func TestParamsListComplete(t *testing.T) {
 	}
 }
 
+func TestXFlagDocsComplete(t *testing.T) {
+	m := maps.Clone(xflags)
+	delete(m, xCloudEnvironment) // We leave this out of the list and docs on purpose.
+	seen := make(map[string]bool)
+	for _, d := range xflagDocs {
+		if seen[d.name] {
+			t.Errorf("xflagDocs contains duplicate entry %q", d.name)
+		}
+		seen[d.name] = true
+		if _, ok := xflags[d.name]; !ok {
+			t.Errorf("xflagDocs documents %q, which is not an -X flag in xflags", d.name)
+		}
+		if d.listHint == "" || d.helpExample == "" || d.help == "" {
+			t.Errorf("xflagDocs entry %q must set listHint, helpExample, and help", d.name)
+		}
+		delete(m, d.name)
+	}
+	if len(m) > 0 {
+		t.Errorf("xflagDocs is missing entries for -X flags: %v (add them, or exclude deliberately undocumented flags here and in the ParamsHelp/ParamsList tests)", maps.Keys(m))
+	}
+}
+
 func TestXSetExamples(t *testing.T) {
 	m := maps.Clone(xflags)
 	for _, fn := range []func() (xs, yamlPaths []string){


### PR DESCRIPTION
## Summary

The `-X` flag documentation lived in three hand-synced places: the `xflags` map (behavior), and two hardcoded string literals in `ParamsHelp()` and `ParamsList()` (docs). The completeness tests only checked one direction (every flag has a line), so the doc strings could drift — and had: the `-X help` intro referenced `brokers.tls.enabled`, which is not an `-X` flag (fixed in the second commit).

- Moves the per-flag documentation (list hint, help example, description) into one ordered `xflagDocs` table in `params.go` and renders `ParamsHelp()`/`ParamsList()` from it. **Rendered output is byte-identical to the previous literals** (verified by diff), so this changes no user-visible behavior.
- `TestXFlagDocsComplete` pins the table to the `xflags` map in both directions (no missing docs, no docs for nonexistent flags, no empty fields). `cloud_environment` stays undocumented by omission, as before.
- `--print-tree` now includes an `x_options` array — `{name, format, example, description}`, hidden flags excluded — so automation can consume the `-X` flags from the same JSON it already uses for the command tree.

## Why

The docs team's rpk reference pipeline builds on `--print-tree` (added for exactly this kind of tooling). The `-X` → `RPK_*` environment-variable table in the docs is moving from hand-maintained to generated ([docs-extensions-and-macros#256](https://github.com/redpanda-data/docs-extensions-and-macros/pull/256), [DOC-130](https://redpandadata.atlassian.net/browse/DOC-130)), and currently has to parse `-X list` text because the tree JSON doesn't carry the `-X` options. With `x_options` in the tree, the docs pipeline needs no extra rpk invocation and no text parsing — and future `-X` flags are documented in one place, once.

## Testing

- `go test ./pkg/config/ ./pkg/cli/` passes.
- Generated `ParamsHelp()`/`ParamsList()` output byte-diffed against the previous hardcoded strings: identical (before the intro typo fix).
- `go run cmd/rpk/main.go --print-tree`: 31 `x_options`, display order preserved, descriptions present, `cloud_environment` excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-130]: https://redpandadata.atlassian.net/browse/DOC-130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ