### PR TITLE
rpk: fix grammar and wording defects in help text

### DIFF
--- a/src/go/rpk/pkg/cli/container/start.go
+++ b/src/go/rpk/pkg/cli/container/start.go
@@ -188,7 +188,7 @@ You can retry profile creation by running:
 	}
 
 	command.Flags().UintVarP(&nodes, "nodes", "n", 1, "The number of brokers (nodes) to start")
-	command.Flags().UintVar(&retries, "retries", 10, "The amount of times to check for the cluster before considering it unstable and exiting")
+	command.Flags().UintVar(&retries, "retries", 10, "The number of times to check for the cluster before considering it unstable and exiting")
 	command.Flags().StringVar(&image, "image", containerutil.DefaultRedpandaImage(), "An arbitrary Redpanda container image to use")
 	command.Flags().StringVar(&consoleImage, "console-image", containerutil.DefaultConsoleImage(), "An arbitrary Redpanda Console container image to use")
 	command.Flags().BoolVar(&pull, "pull", false, "Force pull the container image used")

--- a/src/go/rpk/pkg/cli/profile/clear.go
+++ b/src/go/rpk/pkg/cli/profile/clear.go
@@ -22,8 +22,8 @@ func newClearCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Short: "Clear the current profile",
 		Long: `Clear the current profile
 
-This small command clears the current profile, which can be useful to unset an
-prod cluster profile.
+This small command clears the current profile, which can be useful to unset a
+production cluster profile.
 `,
 		Args: cobra.ExactArgs(0),
 		Run: func(_ *cobra.Command, _ []string) {

--- a/src/go/rpk/pkg/cli/registry/compatibility_level.go
+++ b/src/go/rpk/pkg/cli/registry/compatibility_level.go
@@ -48,7 +48,7 @@ func compatGetCommand(fs afero.Fs, p *config.Params, schemaCtx *string) *cobra.C
 		Short: "Get the global or per-subject compatibility levels",
 		Long: `Get the global or per-subject compatibility levels.
 
-Running this command with no subject returns the global level, alternatively
+Running this command with no subject returns the global level. Alternatively,
 you can use the --global flag to get the global level at the same time as
 per-subject levels.
 `,

--- a/src/go/rpk/pkg/cli/registry/mode/get.go
+++ b/src/go/rpk/pkg/cli/registry/mode/get.go
@@ -27,7 +27,7 @@ func getCommand(fs afero.Fs, p *config.Params, schemaCtx *string) *cobra.Command
 		Short: "Get schema registry mode",
 		Long: `Get schema registry mode
 
-Running this command with no subject returns the global mode, alternatively
+Running this command with no subject returns the global mode. Alternatively,
 you can use the --global flag to get the global mode at the same time as
 per-subject modes.
 `,

--- a/src/go/rpk/pkg/cli/registry/mode/set.go
+++ b/src/go/rpk/pkg/cli/registry/mode/set.go
@@ -34,8 +34,8 @@ func setCommand(fs afero.Fs, p *config.Params, schemaCtx *string) *cobra.Command
 		Short: "Set schema registry mode",
 		Long: `Set schema registry mode
 
-Running this command with no subject sets the global schema registry mode, 
-alternatively you can use the --global flag to set the global schema registry 
+Running this command with no subject sets the global schema registry mode.
+Alternatively, you can use the --global flag to set the global schema registry
 mode at the same time as per-subject mode.
 
 Acceptable mode values: 

--- a/src/go/rpk/pkg/cli/security/acl/delete.go
+++ b/src/go/rpk/pkg/cli/security/acl/delete.go
@@ -122,7 +122,7 @@ func (a *acls) addDeleteFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringSliceVar(&a.topics, topicFlag, nil, "Topic to remove ACLs for (repeatable)")
 	cmd.Flags().StringSliceVar(&a.groups, groupFlag, nil, "Group to remove ACLs for (repeatable)")
-	cmd.Flags().BoolVar(&a.cluster, clusterFlag, false, "Whether to remove ACLs to the cluster")
+	cmd.Flags().BoolVar(&a.cluster, clusterFlag, false, "Whether to remove ACLs for the cluster")
 	cmd.Flags().StringSliceVar(&a.txnIDs, txnIDFlag, nil, "Transactional IDs to remove ACLs for (repeatable)")
 	cmd.Flags().BoolVar(&a.registry, registryFlag, false, "Whether to remove ACLs for the schema registry")
 	cmd.Flags().StringSliceVar(&a.subjects, subjectFlag, nil, "Schema Registry subjects to remove ACLs for (repeatable)")

--- a/src/go/rpk/pkg/cli/security/acl/list.go
+++ b/src/go/rpk/pkg/cli/security/acl/list.go
@@ -122,8 +122,8 @@ func (a *acls) addListFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&a.groups, groupFlag, nil, "Group to match ACLs for (repeatable)")
 	cmd.Flags().BoolVar(&a.cluster, clusterFlag, false, "Whether to match ACLs to the cluster")
 	cmd.Flags().StringSliceVar(&a.txnIDs, txnIDFlag, nil, "Transactional IDs to match ACLs for (repeatable)")
-	cmd.Flags().BoolVar(&a.registry, registryFlag, false, "Whether to grant ACLs for the schema registry")
-	cmd.Flags().StringSliceVar(&a.subjects, subjectFlag, nil, "Schema Registry subjects to grant ACLs for (repeatable)")
+	cmd.Flags().BoolVar(&a.registry, registryFlag, false, "Whether to match ACLs for the schema registry")
+	cmd.Flags().StringSliceVar(&a.subjects, subjectFlag, nil, "Schema Registry subjects to match ACLs for (repeatable)")
 
 	cmd.Flags().StringVar(&a.resourcePatternType, patternFlag, "any", "Pattern to use when matching resource names (any, match, literal, or prefixed)")
 	cmd.Flags().StringSliceVar(&a.operations, operationFlag, nil, "Operation to match (repeatable)")

--- a/src/go/rpk/pkg/cli/topic/consume.go
+++ b/src/go/rpk/pkg/cli/topic/consume.go
@@ -190,9 +190,9 @@ func newConsumeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd.Flags().StringVarP(&c.group, "group", "g", "", "Group to use for consuming (incompatible with -p)")
 	cmd.Flags().StringVarP(&c.balancer, "balancer", "b", "cooperative-sticky", "Group balancer to use if group consuming (range, roundrobin, sticky, cooperative-sticky)")
 
-	cmd.Flags().Int32Var(&c.fetchMaxBytes, "fetch-max-bytes", 1<<20, "Maximum amount of bytes per fetch request per broker")
+	cmd.Flags().Int32Var(&c.fetchMaxBytes, "fetch-max-bytes", 1<<20, "Maximum number of bytes per fetch request per broker")
 	cmd.Flags().DurationVar(&c.fetchMaxWait, "fetch-max-wait", 5*time.Second, "Maximum amount of time to wait when fetching from a broker before the broker replies")
-	cmd.Flags().Int32Var(&c.fetchMaxPartitionBytes, "fetch-max-partition-bytes", 1<<20, "Maximum amount of bytes that will be consumed for a single partition per fetch request")
+	cmd.Flags().Int32Var(&c.fetchMaxPartitionBytes, "fetch-max-partition-bytes", 1<<20, "Maximum number of bytes that will be consumed for a single partition per fetch request")
 	cmd.Flags().BoolVar(&c.readCommitted, "read-committed", false, "Opt in to reading only committed offsets")
 	cmd.Flags().BoolVar(&c.printControl, "print-control-records", false, "Opt in to printing control records")
 


### PR DESCRIPTION
## Summary

Copyedits surfaced by auditing the docs team's rpk description overrides (`docs-data/rpk-overrides.json` in redpanda-data/docs) against rpk's source text — these are cases where the docs override exists only to paper over a source defect, so fixing the source lets the docs drop the override:

- `profile clear`: "unset **an prod** cluster profile" → "a production"
- `registry mode get`/`set`, `registry compatibility-level`: fix the "global mode**, alternatively** you can…" comma splice (same pattern in all three)
- `security acl delete --cluster`: ACLs are removed *for*, not *to*, the cluster
- `security acl list --registry-global`/`--registry-subject`: the list command **matches** ACLs, it doesn't **grant** them (text was copied from `acl create`, where "grant" is correct and unchanged)
- `container start --retries`, `topic consume --fetch-max-bytes`/`--fetch-max-partition-bytes`: "amount of" → "number of" for countable nouns

Help-text strings only; no behavior changes. Affected package tests pass.

Related: #31520 (single-sources the `-X` flag docs from the same audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Release Notes

* none
