### PR TITLE
[v26.1.x] ct: Fix seen/apply window divergence

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -46,6 +46,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
 #include <seastar/util/defer.hh>
 
 #include <chrono>
@@ -779,7 +780,9 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
     auto enqueued_fut = co_await ss::coroutine::as_future(
       std::move(replicate_stages.request_enqueued));
 
-    ticket.release(); // always release the ticket
+    const bool moves_seen_window = fence->moves_seen_window();
+    fence->unit.return_all(); // the operation can't be reordered
+    ticket.release();         // always release the ticket
 
     if (enqueued_fut.failed()) {
         auto ex = enqueued_fut.get_exception();
@@ -792,8 +795,56 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
         // and we don't want to abandon the replicate_finished future
     }
 
-    auto res = co_await std::move(replicate_stages.replicate_finished);
+    auto res_fut = co_await ss::coroutine::as_future(
+      std::move(replicate_stages.replicate_finished));
+    if (res_fut.failed()) {
+        // Replication failed with an exception. This is the expected
+        // outcome when the enqueue stage failed above: the seen window
+        // was already advanced but the placeholder never reached the
+        // raft queue, so the divergence has to be resolved by stepping
+        // down, same as the error case below.
+        auto ex = res_fut.get_exception();
+        if (moves_seen_window && !ssx::is_shutdown_exception(ex)) {
+            vlog(
+              cd_log.warn,
+              "{} The epoch advancing replication failed {}, stepping down "
+              "the leadership",
+              ntp,
+              ex);
+            co_await partition->raft()->step_down_in_term(
+              fence->term, "seen-window diverged due to replication failure");
+        }
+        co_await ss::coroutine::return_exception_ptr(std::move(ex));
+    }
+    auto res = res_fut.get();
     if (res.has_error()) {
+        // We can't universally guarantee the correct epoch order if replication
+        // failed.
+        // - The batch that advances the epoch is replicated with exclusive
+        //   lock;
+        // - It waits for all requests that carry smaller epoch values will
+        //   finish first;
+        // - After that the lock is taken. The lock is only held until the batch
+        //   is enqueued into Raft and can't be reordered anymore.
+        // - Now if the replication operation fails the 'seen' window stays
+        //   unchanged but the 'applied' window may or may not be moved
+        //   accordingly.
+        // - The divergence between the 'applied' and 'seen' windows may cause
+        //   ordering violations.
+        //
+        // To avoid this problem we need to step down the leadership.
+        // This is only required if the seen-window was moved. The new term
+        // will invalidate the seen window.
+        if (moves_seen_window && res.error() != raft::errc::shutting_down) {
+            vlog(
+              cd_log.warn,
+              "{} The epoch advancing replication failed {}, stepping down the "
+              "leadership",
+              ntp,
+              res.error());
+            co_await partition->raft()->step_down_in_term(
+              fence->term, "seen-window diverged due to replication failure");
+        }
         co_return res.error();
     }
     if (!cache_batches.empty()) {
@@ -917,10 +968,39 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
     }
 
     opts = update_replicate_options(opts, fence->term);
-    auto result = co_await _partition->replicate(
-      std::move(placeholder_batches), opts);
-
+    auto result_fut = co_await ss::coroutine::as_future(
+      _partition->replicate(std::move(placeholder_batches), opts));
+    if (result_fut.failed()) {
+        // Same divergence handling as the error path below: the seen
+        // window was already advanced by the fence and can't be rolled
+        // back, so a failed replication requires a step down.
+        auto ex = result_fut.get_exception();
+        if (fence->moves_seen_window() && !ssx::is_shutdown_exception(ex)) {
+            vlog(
+              cd_log.warn,
+              "{} The epoch advancing replication failed {}, stepping down "
+              "the leadership",
+              ntp(),
+              ex);
+            co_await _partition->raft()->step_down_in_term(
+              fence->term, "seen-window diverged due to replication failure");
+        }
+        co_await ss::coroutine::return_exception_ptr(std::move(ex));
+    }
+    auto result = result_fut.get();
     if (!result) {
+        if (
+          fence->moves_seen_window()
+          && result.error() != raft::errc::shutting_down) {
+            vlog(
+              cd_log.warn,
+              "{} The epoch advancing replication failed {}, stepping down the "
+              "leadership",
+              ntp(),
+              result.error());
+            co_await _partition->raft()->step_down_in_term(
+              fence->term, "seen-window diverged due to replication failure");
+        }
         co_return std::unexpected(result.error());
     }
     auto ret_offset = model::offset(result.value().last_offset());

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -472,8 +472,8 @@ ctp_stm::fence_epoch(cluster_epoch e) {
               || _state.epoch_above_window(term, e)) {
                 vlog(_log.debug, "Bumping max seen epoch to {}", e);
                 _state.advance_max_seen_epoch(term, e);
-                // Demote to reader lock after max_seen_epoch is updated.
-                unit.return_units(unit.count() - 1);
+                // Demote to reader lock when the command is queued
+                // in Raft. Keep all the units for now.
                 epoch_fence_opt.emplace(std::move(unit), term);
             }
 

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -495,11 +495,12 @@ TEST_F_CORO(ctp_stm_fixture, test_snapshot) {
 }
 
 TEST_F_CORO(ctp_stm_fixture, test_fence_epoch_concurrent_new_epoch) {
-    // This test verifies the optimization in fence_epoch() where multiple
-    // concurrent requests for a new epoch only require one write lock.
-    // The first request acquires the epoch_update_lock and write lock, updates
-    // the epoch, then signals waiters. The remaining requests wake up and take
-    // the read-lock path since the epoch has been updated.
+    // This test verifies that multiple concurrent requests for a new epoch
+    // only require one write lock. The first request acquires the
+    // epoch_update_lock and write lock, updates the epoch, then signals
+    // waiters. The remaining requests wake up and take the read-lock path
+    // since the epoch has been updated. The winner's fence keeps the write
+    // lock (no demotion) so the readers stay blocked until it's released.
     co_await start();
     co_await wait_for_leader(raft::default_timeout());
 
@@ -549,12 +550,41 @@ TEST_F_CORO(ctp_stm_fixture, test_fence_epoch_concurrent_new_epoch) {
         // Let `initial_fence` go out of scope.
     }
 
-    // Wait for all fences to be acquired - they should all be able to succeed
-    // without hanging because only one request (the first request) had to
-    // obtain a write lock, which then downgraded to a read lock, and the rest
-    // of the requests could obtain read locks for the current epoch.
+    // Exactly one request wins the epoch update and resolves with a fence
+    // that carries the full write lock. The remaining requests take the
+    // read-lock path and stay blocked until the winner releases the fence.
+    std::optional<size_t> winner;
+    RPTEST_REQUIRE_EVENTUALLY_CORO(10s, [&] {
+        for (size_t i = 0; i < futures.size(); ++i) {
+            if (futures[i].available()) {
+                winner = i;
+                return true;
+            }
+        }
+        return false;
+    });
+
+    auto winner_fence = co_await std::move(futures[*winner]);
+    ASSERT_TRUE_CORO(winner_fence.has_value());
+    ASSERT_GT_CORO(winner_fence->unit.count(), 1);
+    for (size_t i = 0; i < futures.size(); ++i) {
+        if (i != *winner) {
+            ASSERT_FALSE_CORO(futures[i].available());
+        }
+    }
+
+    // Release the write lock, unblocking the readers.
+    winner_fence->unit.return_all();
+
+    std::vector<ss::future<expected_t>> rest;
+    rest.reserve(futures.size() - 1);
+    for (size_t i = 0; i < futures.size(); ++i) {
+        if (i != *winner) {
+            rest.push_back(std::move(futures[i]));
+        }
+    }
     auto fences = co_await ssx::when_all_succeed<std::vector<expected_t>>(
-      std::move(futures));
+      std::move(rest));
     for (auto& fence : fences) {
         ASSERT_TRUE_CORO(fence.has_value())
           << "All fence requests should succeed";

--- a/src/v/cloud_topics/level_zero/stm/types.h
+++ b/src/v/cloud_topics/level_zero/stm/types.h
@@ -30,6 +30,10 @@ struct [[nodiscard]] cluster_epoch_fence {
     ss::rwlock::holder unit;
     // Term in which the batch is replicated.
     model::term_id term;
+
+    // The fence holds the full write lock (more than one unit) iff the
+    // fenced request advanced the "seen" window.
+    bool moves_seen_window() const { return unit.count() > 1; }
 };
 
 // The error returned when the CTP STM has seen a newer epoch than the one


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31386

- Command: git cherry-pick -x 1969fe95b4
- Commits backported: 1
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-31386-v26.1.x-1786442124

## Conflict details

- 1969fe95b4 (src/v/cloud_topics/frontend/frontend.cc): `frontend::replicate_at_offset` does not exist on `v26.1.x` (it is a dev-only cluster-link path, absent from both `frontend.cc` and `frontend.h`), so git reported the whole function as an incoming addition against an empty HEAD side. The commit's only change inside that function was a 3-line explanatory comment about discarding the fence, so the HEAD (empty) side was taken and no functional code was dropped. The commit's two substantive hunks — early `fence->unit.return_all()` plus `moves_seen_window` capture in `do_upload_and_replicate`, and the `as_future` + `step_down_in_term` divergence handling in both `do_upload_and_replicate` and `frontend::replicate` — were re-applied verbatim.
- 1969fe95b4 (src/v/cloud_topics/frontend/frontend.cc): added `#include <seastar/coroutine/exception.hh>`, which `dev` already had before this commit but `v26.1.x` did not. It is required by the newly introduced `ss::coroutine::return_exception_ptr` calls.

`src/v/cloud_topics/level_zero/stm/ctp_stm.cc`, `src/v/cloud_topics/level_zero/stm/types.h` and
`src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc` merged cleanly.
