### PR TITLE
rpk: structured command status (experimental/beta) via annotations

### DIFF
--- a/src/go/rpk/pkg/cli/cmdstatus/cmdstatus.go
+++ b/src/go/rpk/pkg/cli/cmdstatus/cmdstatus.go
@@ -7,9 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-// Package cmdstatus marks commands with a maturity status (experimental or
-// beta) in a structured way, replacing ad-hoc help-text markers such as
-// "!!EXPERIMENTAL!!".
+// Package cmdstatus marks commands with a maturity status (experimental,
+// technical preview, beta, or limited availability) in a structured way,
+// replacing ad-hoc help-text markers such as "!!EXPERIMENTAL!!".
 //
 // Marking a command does three things, all from one call:
 //
@@ -24,14 +24,24 @@
 // GA commands are simply unmarked. Deprecation is not a status here: use
 // cobra's native Deprecated field, which already changes runtime behavior.
 //
-// The defined statuses:
+// The defined statuses mirror Redpanda's documented feature maturity
+// stages (see "Features in beta" and "Features in limited availability" in
+// the Redpanda Cloud overview), plus the engineering-level experimental
+// marker:
 //
-//   - Experimental: the interface and behavior may change or be removed in
-//     any release without notice, and the command is not covered by support
-//     SLAs. Use for commands whose shape is still being discovered.
-//   - Beta: the interface is stabilizing and incompatible changes are
-//     unlikely but still possible; support is best-effort and feedback is
-//     encouraged. Use for commands on a path to GA.
+//   - Experimental: an engineering statement about stability. The interface
+//     and behavior may change or be removed in any release without notice,
+//     and the command is not covered by Redpanda Support. Use for commands
+//     whose shape is still being discovered.
+//   - Technical preview: the earliest product lifecycle stage. Early access
+//     for evaluation and feedback; may change significantly, not for
+//     production, not covered by Redpanda Support.
+//   - Beta: available for testing and feedback. The interface is
+//     stabilizing but may still change; not for production and not covered
+//     by Redpanda Support.
+//   - Limited availability: production-ready and covered by Redpanda
+//     Support for early adopters; access may be restricted or require
+//     enablement.
 //
 // Managed plugins (rpk connect, rpk ai, ...) build their own command trees
 // in their own repositories; they can adopt the same annotation keys and
@@ -54,24 +64,56 @@ const (
 
 // The defined statuses. See the package documentation for their semantics.
 const (
-	StatusExperimental = "experimental"
-	StatusBeta         = "beta"
+	StatusExperimental        = "experimental"
+	StatusTechPreview         = "tech-preview"
+	StatusBeta                = "beta"
+	StatusLimitedAvailability = "limited-availability"
 )
+
+// notices holds the standard help notice for each defined status. Adding a
+// status means adding a constant, a row here, and a Mark helper.
+var notices = map[string]string{
+	StatusExperimental:        "This command is EXPERIMENTAL. Its interface and behavior may change or be removed in any release without notice, and it is not covered by Redpanda Support.",
+	StatusTechPreview:         "This command is in TECHNICAL PREVIEW. It is early access for evaluation and feedback: its interface and behavior may change significantly, it should not be used in production, and it is not covered by Redpanda Support.",
+	StatusBeta:                "This command is in BETA. It is available for testing and feedback: its interface is stabilizing but may still change, it should not be used in production, and it is not covered by Redpanda Support.",
+	StatusLimitedAvailability: "This command is in LIMITED AVAILABILITY. It is production-ready and covered by Redpanda Support for early adopters; access may be restricted or require enablement.",
+}
 
 // MarkExperimental marks cmd and its subtree as experimental. The optional
 // note adds command-specific detail to the standard notice (pass "" for
 // none).
 func MarkExperimental(cmd *cobra.Command, note string) {
-	mark(cmd, StatusExperimental, note)
+	Mark(cmd, StatusExperimental, note)
+}
+
+// MarkTechPreview marks cmd and its subtree as a technical preview. The
+// optional note adds command-specific detail to the standard notice (pass
+// "" for none).
+func MarkTechPreview(cmd *cobra.Command, note string) {
+	Mark(cmd, StatusTechPreview, note)
 }
 
 // MarkBeta marks cmd and its subtree as beta. The optional note adds
 // command-specific detail to the standard notice (pass "" for none).
 func MarkBeta(cmd *cobra.Command, note string) {
-	mark(cmd, StatusBeta, note)
+	Mark(cmd, StatusBeta, note)
 }
 
-func mark(cmd *cobra.Command, status, note string) {
+// MarkLimitedAvailability marks cmd and its subtree as limited
+// availability. The optional note adds command-specific detail to the
+// standard notice (pass "" for none).
+func MarkLimitedAvailability(cmd *cobra.Command, note string) {
+	Mark(cmd, StatusLimitedAvailability, note)
+}
+
+// Mark marks cmd and its subtree with one of the defined statuses. It
+// panics on an undefined status: marking happens at command registration,
+// so a typo fails the first test or invocation rather than silently
+// rendering a generic notice.
+func Mark(cmd *cobra.Command, status, note string) {
+	if _, ok := notices[status]; !ok {
+		panic(fmt.Sprintf("cmdstatus.Mark: undefined status %q on %q", status, cmd.Name()))
+	}
 	if cmd.Annotations == nil {
 		cmd.Annotations = map[string]string{}
 	}
@@ -100,13 +142,10 @@ func Banner(status, note string) string {
 	if status == "" {
 		return ""
 	}
-	var b string
-	switch status {
-	case StatusExperimental:
-		b = "This command is EXPERIMENTAL. Its interface and behavior may change or be removed in any release without notice, and it is not covered by support SLAs."
-	case StatusBeta:
-		b = "This command is in BETA. Its interface is stabilizing and incompatible changes are unlikely but still possible; support is best-effort and feedback is encouraged."
-	default:
+	b, ok := notices[status]
+	if !ok {
+		// Annotations can arrive from plugin command trees, so unknown
+		// values render visibly instead of being dropped or panicking.
 		b = fmt.Sprintf("This command has status %q.", status)
 	}
 	if note != "" {

--- a/src/go/rpk/pkg/cli/cmdstatus/cmdstatus.go
+++ b/src/go/rpk/pkg/cli/cmdstatus/cmdstatus.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// Package cmdstatus marks commands with a maturity status (experimental or
+// beta) in a structured way, replacing ad-hoc help-text markers such as
+// "!!EXPERIMENTAL!!".
+//
+// Marking a command does three things, all from one call:
+//
+//   - `--help` renders a consistent notice explaining what the status means,
+//     above the command's own description (see the help template in root.go).
+//   - `--print-tree` exposes status and status_note fields on the command,
+//     so documentation and other tooling can surface the status (for
+//     example, as a page badge) without parsing help text.
+//   - Subcommands inherit the status of their nearest marked ancestor, so
+//     marking a command marks its whole subtree.
+//
+// GA commands are simply unmarked. Deprecation is not a status here: use
+// cobra's native Deprecated field, which already changes runtime behavior.
+//
+// The defined statuses:
+//
+//   - Experimental: the interface and behavior may change or be removed in
+//     any release without notice, and the command is not covered by support
+//     SLAs. Use for commands whose shape is still being discovered.
+//   - Beta: the interface is stabilizing and incompatible changes are
+//     unlikely but still possible; support is best-effort and feedback is
+//     encouraged. Use for commands on a path to GA.
+//
+// Managed plugins (rpk connect, rpk ai, ...) build their own command trees
+// in their own repositories; they can adopt the same annotation keys and
+// their statuses flow through the merged tree unchanged.
+package cmdstatus
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Annotation keys, on cobra.Command.Annotations. The values are stable
+// public API for tooling that reads --print-tree or the annotations
+// directly; change them only with a migration plan.
+const (
+	AnnotationStatus     = "redpanda.com/status"
+	AnnotationStatusNote = "redpanda.com/status-note"
+)
+
+// The defined statuses. See the package documentation for their semantics.
+const (
+	StatusExperimental = "experimental"
+	StatusBeta         = "beta"
+)
+
+// MarkExperimental marks cmd and its subtree as experimental. The optional
+// note adds command-specific detail to the standard notice (pass "" for
+// none).
+func MarkExperimental(cmd *cobra.Command, note string) {
+	mark(cmd, StatusExperimental, note)
+}
+
+// MarkBeta marks cmd and its subtree as beta. The optional note adds
+// command-specific detail to the standard notice (pass "" for none).
+func MarkBeta(cmd *cobra.Command, note string) {
+	mark(cmd, StatusBeta, note)
+}
+
+func mark(cmd *cobra.Command, status, note string) {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations[AnnotationStatus] = status
+	if note != "" {
+		cmd.Annotations[AnnotationStatusNote] = note
+	}
+}
+
+// Get returns the status and note for cmd, inheriting from the nearest
+// marked ancestor. Both are empty for GA (unmarked) commands.
+func Get(cmd *cobra.Command) (status, note string) {
+	for c := cmd; c != nil; c = c.Parent() {
+		if s, ok := c.Annotations[AnnotationStatus]; ok {
+			return s, c.Annotations[AnnotationStatusNote]
+		}
+	}
+	return "", ""
+}
+
+// Banner returns the standard help notice for a status, with the optional
+// note appended, or "" for an empty status. Unknown statuses render a
+// generic notice rather than being dropped, so a typo'd status is visible
+// instead of silently unmarked.
+func Banner(status, note string) string {
+	if status == "" {
+		return ""
+	}
+	var b string
+	switch status {
+	case StatusExperimental:
+		b = "This command is EXPERIMENTAL. Its interface and behavior may change or be removed in any release without notice, and it is not covered by support SLAs."
+	case StatusBeta:
+		b = "This command is in BETA. Its interface is stabilizing and incompatible changes are unlikely but still possible; support is best-effort and feedback is encouraged."
+	default:
+		b = fmt.Sprintf("This command has status %q.", status)
+	}
+	if note != "" {
+		b += " " + note
+	}
+	return b
+}
+
+// HelpBanner is the cobra template function backing the help template: it
+// returns the rendered banner for a command, or "" when unmarked.
+func HelpBanner(cmd *cobra.Command) string {
+	return Banner(Get(cmd))
+}

--- a/src/go/rpk/pkg/cli/cmdstatus/cmdstatus_test.go
+++ b/src/go/rpk/pkg/cli/cmdstatus/cmdstatus_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package cmdstatus
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarkAndGet(t *testing.T) {
+	cmd := &cobra.Command{Use: "thing"}
+	s, n := Get(cmd)
+	require.Empty(t, s, "unmarked commands must have no status")
+	require.Empty(t, n)
+
+	MarkExperimental(cmd, "The output format is still in flux.")
+	s, n = Get(cmd)
+	require.Equal(t, StatusExperimental, s)
+	require.Equal(t, "The output format is still in flux.", n)
+}
+
+func TestSubtreeInheritance(t *testing.T) {
+	parent := &cobra.Command{Use: "parent"}
+	child := &cobra.Command{Use: "child"}
+	grandchild := &cobra.Command{Use: "grandchild"}
+	child.AddCommand(grandchild)
+	parent.AddCommand(child)
+
+	MarkBeta(parent, "")
+	s, _ := Get(grandchild)
+	require.Equal(t, StatusBeta, s, "status must inherit through the subtree")
+
+	// A more specific mark on a descendant wins.
+	MarkExperimental(grandchild, "")
+	s, _ = Get(grandchild)
+	require.Equal(t, StatusExperimental, s)
+	s, _ = Get(child)
+	require.Equal(t, StatusBeta, s)
+}
+
+func TestBanner(t *testing.T) {
+	require.Empty(t, Banner("", ""), "GA renders no banner")
+	require.Contains(t, Banner(StatusExperimental, ""), "EXPERIMENTAL")
+	require.Contains(t, Banner(StatusBeta, ""), "BETA")
+	require.Contains(t, Banner(StatusExperimental, "Extra detail."), "Extra detail.")
+	require.Contains(t, Banner("preview", ""), `"preview"`, "unknown statuses must be visible, not dropped")
+}
+
+func TestHelpRendersBanner(t *testing.T) {
+	// Mirrors the help template installed in root.go.
+	const helpTemplate = `{{with statusBanner .}}{{.}}
+
+{{end}}{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
+
+{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
+
+	cobra.AddTemplateFunc("statusBanner", HelpBanner)
+
+	root := &cobra.Command{Use: "rpk"}
+	sub := &cobra.Command{
+		Use:   "thing",
+		Short: "Do a thing",
+		Long:  "Do a thing with detail.",
+		Run:   func(*cobra.Command, []string) {},
+	}
+	root.AddCommand(sub)
+	root.SetHelpTemplate(helpTemplate)
+
+	var out strings.Builder
+	root.SetOut(&out)
+	root.SetArgs([]string{"thing", "--help"})
+	require.NoError(t, root.Execute())
+	require.Contains(t, out.String(), "Do a thing with detail.")
+	require.NotContains(t, out.String(), "EXPERIMENTAL", "unmarked commands must render no banner")
+
+	MarkExperimental(sub, "")
+	out.Reset()
+	root.SetArgs([]string{"thing", "--help"})
+	require.NoError(t, root.Execute())
+	require.Contains(t, out.String(), "This command is EXPERIMENTAL.")
+	require.Contains(t, out.String(), "Do a thing with detail.", "the banner must not replace the description")
+	require.Less(t,
+		strings.Index(out.String(), "EXPERIMENTAL"),
+		strings.Index(out.String(), "Do a thing with detail."),
+		"the banner renders above the description")
+}

--- a/src/go/rpk/pkg/cli/cmdstatus/cmdstatus_test.go
+++ b/src/go/rpk/pkg/cli/cmdstatus/cmdstatus_test.go
@@ -51,9 +51,30 @@ func TestSubtreeInheritance(t *testing.T) {
 func TestBanner(t *testing.T) {
 	require.Empty(t, Banner("", ""), "GA renders no banner")
 	require.Contains(t, Banner(StatusExperimental, ""), "EXPERIMENTAL")
+	require.Contains(t, Banner(StatusTechPreview, ""), "TECHNICAL PREVIEW")
 	require.Contains(t, Banner(StatusBeta, ""), "BETA")
+	require.Contains(t, Banner(StatusLimitedAvailability, ""), "LIMITED AVAILABILITY")
 	require.Contains(t, Banner(StatusExperimental, "Extra detail."), "Extra detail.")
-	require.Contains(t, Banner("preview", ""), `"preview"`, "unknown statuses must be visible, not dropped")
+	require.Contains(t, Banner("previeww", ""), `"previeww"`, "unknown statuses must be visible, not dropped")
+}
+
+func TestEveryDefinedStatusHasANotice(t *testing.T) {
+	for _, status := range []string{StatusExperimental, StatusTechPreview, StatusBeta, StatusLimitedAvailability} {
+		require.Contains(t, notices, status)
+		require.Contains(t, notices[status], "This command", "notices follow the standard shape (%s)", status)
+	}
+}
+
+func TestMarkPanicsOnUndefinedStatus(t *testing.T) {
+	cmd := &cobra.Command{Use: "thing"}
+	require.Panics(t, func() { Mark(cmd, "previeww", "") },
+		"a typo'd status must fail at registration, not render generically")
+	MarkTechPreview(cmd, "")
+	s, _ := Get(cmd)
+	require.Equal(t, StatusTechPreview, s)
+	MarkLimitedAvailability(cmd, "")
+	s, _ = Get(cmd)
+	require.Equal(t, StatusLimitedAvailability, s)
 }
 
 func TestHelpRendersBanner(t *testing.T) {

--- a/src/go/rpk/pkg/cli/printtree.go
+++ b/src/go/rpk/pkg/cli/printtree.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmdstatus"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/spf13/cobra"
@@ -41,6 +42,8 @@ type commandPrint struct {
 	Aliases     []string       `json:"aliases"`
 	Examples    string         `json:"examples,omitempty"`
 	Deprecated  string         `json:"deprecated,omitempty"`
+	Status      string         `json:"status,omitempty"`
+	StatusNote  string         `json:"status_note,omitempty"`
 	Flags       []flagPrint    `json:"flags"`
 	Commands    []commandPrint `json:"commands"`
 }
@@ -95,6 +98,7 @@ func printCommand(c *cobra.Command) commandPrint {
 	if aliases == nil {
 		aliases = []string{}
 	}
+	status, statusNote := cmdstatus.Get(c)
 	return commandPrint{
 		Name:        c.Name(),
 		Description: desc,
@@ -102,6 +106,8 @@ func printCommand(c *cobra.Command) commandPrint {
 		Aliases:     aliases,
 		Examples:    c.Example,
 		Deprecated:  c.Deprecated,
+		Status:      status,
+		StatusNote:  statusNote,
 		Flags:       printFlagSet(c.LocalFlags()),
 		Commands:    printChildren(c),
 	}

--- a/src/go/rpk/pkg/cli/printtree_test.go
+++ b/src/go/rpk/pkg/cli/printtree_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmdstatus"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
@@ -34,6 +35,10 @@ func newPrintTreeTestRoot() *cobra.Command {
 	topic.Flags().MarkHidden("internal")
 	topic.Flags().String("legacy", "old", "legacy flag")
 	topic.Flags().Lookup("legacy").Deprecated = "use --new-flag"
+
+	create := &cobra.Command{Use: "create", Short: "create a topic"}
+	topic.AddCommand(create)
+	cmdstatus.MarkBeta(topic, "Feedback welcome.")
 
 	short := &cobra.Command{Use: "short-only", Short: "short fallback"}
 	old := &cobra.Command{Use: "old", Short: "old", Deprecated: "use new"}
@@ -77,6 +82,11 @@ func TestPrintTree(t *testing.T) {
 	require.Equal(t, "manage topics in detail", tc.Description, "Long is preferred over Short")
 	require.Equal(t, []string{"t"}, tc.Aliases)
 	require.Equal(t, "rpk topic create foo", tc.Examples)
+	require.Equal(t, "beta", tc.Status)
+	require.Equal(t, "Feedback welcome.", tc.StatusNote)
+	require.Len(t, tc.Commands, 1)
+	require.Equal(t, "beta", tc.Commands[0].Status, "status must inherit into subtrees in the tree output")
+	require.Empty(t, cmds["short-only"].Status, "unmarked commands must omit status")
 
 	flags := flagsByName(tc.Flags)
 	require.Len(t, tc.Flags, 5, "hidden flag must be excluded")

--- a/src/go/rpk/pkg/cli/root.go
+++ b/src/go/rpk/pkg/cli/root.go
@@ -26,6 +26,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/check"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cloud"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmdstatus"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/connect"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/debug"
@@ -214,7 +215,9 @@ Use --print-tree to emit the full command tree as JSON.`,
 
 	cobra.AddTemplateFunc("wrappedLocalFlagUsages", wrappedLocalFlagUsages)
 	cobra.AddTemplateFunc("wrappedGlobalFlagUsages", wrappedGlobalFlagUsages)
+	cobra.AddTemplateFunc("statusBanner", cmdstatus.HelpBanner)
 	root.SetUsageTemplate(usageTemplate)
+	root.SetHelpTemplate(helpTemplate)
 
 	err := root.Execute()
 	if err != nil {
@@ -267,6 +270,14 @@ func newOxlaCommand() *cobra.Command {
 	}
 	return cmd
 }
+
+// This is the default Cobra help template with a status notice (see the
+// cmdstatus package) rendered above the command's description.
+var helpTemplate = `{{with statusBanner .}}{{.}}
+
+{{end}}{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
+
+{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
 
 // This is the same Cobra usage template but using the wrapped flag usages.
 var usageTemplate = `Usage:{{if .Runnable}}


### PR DESCRIPTION
## Summary

Implements the proposal in #31522: a formal command maturity status replacing ad-hoc help-text markers such as `!!EXPERIMENTAL!!`, with the semantics defined once instead of implied by punctuation.

**New package `pkg/cli/cmdstatus`:**
- `Mark(cmd, status, note)` with helpers (`MarkExperimental`, `MarkTechPreview`, `MarkBeta`, `MarkLimitedAvailability`) sets `redpanda.com/status` (and optional `redpanda.com/status-note`) annotations. Subcommands inherit from the nearest marked ancestor, so marking a command marks its subtree; a more specific mark on a descendant wins.
- **The vocabulary mirrors Redpanda's documented feature maturity stages** (the "Features in beta" / "Features in limited availability" definitions in the Cloud overview), plus the engineering-level experimental marker:
  - *experimental* — interface and behavior may change or be removed in any release without notice; not covered by Redpanda Support.
  - *tech-preview* — earliest lifecycle stage: early access for evaluation and feedback; may change significantly; not for production; not covered by Redpanda Support.
  - *beta* — available for testing and feedback; interface stabilizing but may change; not for production; not covered by Redpanda Support (wording matches the documented definition).
  - *limited-availability* — production-ready and covered by Redpanda Support for early adopters; access may be restricted or require enablement.
  - GA is simply unmarked; deprecation stays on cobra's native `Deprecated` field.
- `Mark` panics on an undefined status at registration time (a typo fails the first test run), while unknown values arriving via annotations from plugin trees still render a visible generic notice rather than being silently dropped.

**Rendering and exposure:**
- A help template renders the standard notice above the command's own description — every marked command explains its status in the same words, and `Long` text stays clean (no more markers embedded in prose).
- `--print-tree` exposes `status`/`status_note` per command, inherited into subtrees, so docs tooling can render page badges (the docs site already has `badge::[beta]`-style macros) without parsing help text. Complements #31520's `x_options`.

**Deliberately not in this PR:**
- **No commands are marked.** Adopting a status is a product decision for the owning team, and takes one line: `cmdstatus.MarkExperimental(cmd, "")`.
- Managed plugins (`rpk connect`, `rpk ai`, …) build their command trees in their own repositories; they can adopt the same annotation keys and their statuses flow through the merged tree unchanged. (The `!!EXPERIMENTAL!!` that motivated #31522 lives in the connect repo — migrating it is a follow-up there.)
- Flag-level status/env metadata (also floated in #31522) — separable follow-up.

## Testing

- Unit tests: mark/get, subtree inheritance with override, banner rendering (including the unknown-status case), and help-template rendering (banner above description, absent when unmarked).
- Extended `TestPrintTree`: status + note in the JSON, inheritance into child commands, omitted when unmarked.
- Built rpk and verified live: unmarked `--help` output is byte-for-byte unchanged, and `--print-tree` contains zero `status` keys (nothing marked), parsing cleanly across all 22 top-level commands.

Closes #31522

🤖 Generated with [Claude Code](https://claude.com/claude-code)
