### PR TITLE
[CORE-16631] tests/rptest: wait for target HWM to settle after failover

### DIFF
--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -3825,6 +3825,38 @@ class ShadowLinkTopicFailoverTests(ShadowLinkPreAllocTestBase):
             except Exception:
                 return []
 
+        def target_partition_0_hwm() -> int | None:
+            try:
+                for part in self.target_cluster_rpk.describe_topic(
+                    topic.name, timeout=3
+                ):
+                    if part.id == 0:
+                        return part.high_watermark
+            except Exception as e:
+                self.logger.debug(f"Failed to describe target topic: {e}")
+            return None
+
+        last_hwm: int | None = None
+        consecutive_matches = 0
+
+        def target_hwm_settled() -> bool:
+            # Failover completion is a health-report heuristic (see
+            # link_status_reconciler.try_finish_failover), not a guarantee
+            # that every mirrored write has already landed on the target.
+            # Wait for the target's high watermark to stop moving across
+            # several of wait_until's own polling iterations before
+            # producing, so kgo-verifier's one-shot list-offsets(-1)
+            # snapshot doesn't race a trailing mirrored write and
+            # misreport it as an idempotency bug (CORE-16631).
+            nonlocal last_hwm, consecutive_matches
+            hwm = target_partition_0_hwm()
+            if hwm is None or hwm != last_hwm:
+                last_hwm = hwm
+                consecutive_matches = 0
+                return False
+            consecutive_matches += 1
+            return consecutive_matches >= 3
+
         produce(n=num_messages, redpanda=self.source_cluster.service)
 
         self.target_cluster_service.wait_until(
@@ -3843,6 +3875,13 @@ class ShadowLinkTopicFailoverTests(ShadowLinkPreAllocTestBase):
 
         self.failover_link(name="test-link")
         self.wait_for_link_failover(link="test-link")
+
+        wait_until(
+            target_hwm_settled,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Target high watermark never settled after failover",
+        )
 
         second_round = 2
 


### PR DESCRIPTION
## Summary
- `test_producer_ids_failover` occasionally hit kgo-verifier's "possible idempotency bug" check right after `failover_link()` — failover completion is a health-report heuristic (`link_status_reconciler::try_finish_failover`), not a guarantee that every previously-mirrored write has landed, so a fresh producer's one-shot `list-offsets(-1)` snapshot could race a trailing write and see a lower offset than what the broker later assigns the record.
- Waits for the target partition's high watermark to stop moving before the second round of production, so the producer's offset baseline is taken after the partition has actually settled.

## Test plan
- [x] `tools/type-checking/type-check.sh check rptest/tests/cluster_linking_e2e_test.py` — passes
- [x] `tools/ruff format --diff tests/rptest/tests/cluster_linking_e2e_test.py` — clean
- [x] Ran `test_producer_ids_failover[storage_mode=cloud]` 5x locally with the fix — 5/5 PASS, no added run-time overhead

## Caveats
- Could not reproduce the original flake locally. CORE-16631's CI bot comments show ~48 occurrences over 2 months, all with the identical signature `sent=4 acked=2 bad_offsets=2 restarts=1`, but 0/125 local repeated runs (with or without this fix) hit it. An experiment widening `health_monitor_max_metadata_age` to 60s (to see if amplifying health-report staleness would force the race) also didn't reproduce it locally — CI data shows ~3x the rate on arm64 vs amd64 and is concentrated on shared `ci-docker-aws` runners, so the trigger likely needs real network/CPU jitter this local docker-compose setup doesn't have.
- This fix closes a real, code-grounded race window, but is not proven to be the sole cause of every CORE-16631 occurrence — treat as a mitigation to validate against CI recurrence, not a confirmed root-cause fix.
- Separately: `try_finish_failover` already has access to finer-grained per-partition watermark data (`source_partition_high_watermark`/`shadow_partition_high_watermark`) but doesn't use it in its completion decision — using it directly would be a more robust product-level fix than this test-side workaround. Worth a follow-up ticket if this mitigation doesn't fully close CORE-16631.

Related to CORE-16631