### PR TITLE
DNM: CORE-16997 A/B arm D (minimal + tightened whitelist)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,5 @@ docker pull docker.redpanda.com/redpandadata/redpanda-unstable:v25.1.1-rc1
 - [Upcoming Redpanda Events](https://www.redpanda.com/events)
 - [Redpanda Support](https://support.redpanda.com/)
 - [Redpanda University](https://university.redpanda.com/)
+
+<!-- CORE-16997 A/B arm D (minimal + tightened whitelist). Do not merge. -->


### PR DESCRIPTION
**Do not merge.** Throwaway PR: arm D of the CORE-16997 remote-cache download-volume A/B experiment.

Measures a warm `bazel test //...` under `--remote_download_minimal` plus a *tightened* download whitelist, against:

- arm A control, Bazel default `--remote_download_outputs=toplevel` (#31477)
- arm B pure `--remote_download_minimal` (#31478)
- arm C minimal + the broad `.*bazel/packaging/.*` whitelist (#31479)

Arm C's first pattern is over-broad: the packaging tree holds a separate patched copy of the 2.2 GB redpanda binary per consumer and per patch stage, so `.*bazel/packaging/.*` pulls back ~24 GB that CI never reads. Arm D narrows it to the single tarball `copy-packaging-artifacts` installs, and so is the configuration we would actually consider shipping. Arm D is expected to end **green** (unlike arm B, which fails `copy-packaging-artifacts` by design).

The only change on this branch is a no-op `README.md` comment, so the action graph is identical to `dev` and the remote cache stays warm.
