### PR TITLE
bazel: add a remote_download_minimal config to cut CI download volume

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -173,6 +173,19 @@ build:dev-base --copt=-Og
 # we try to note the restrictions below.
 ####################################################
 
+##########################
+## remote cache mixins   #
+##########################
+
+# Don't materialize anything that isn't needed: we only need these 3 output
+# files, which are used by downstream packaging steps. This saves ~73% of
+# downloaded bytes on a full cache hit. Keep in sync with vtools'
+# copy-packaging-artifacts task.
+build:ci-remote-cache --remote_download_minimal
+build:ci-remote-cache --remote_download_regex=.*/bazel/packaging/bazel_out\\.tar\\.gz$
+build:ci-remote-cache --remote_download_regex=.*/redpanda/redpanda$
+build:ci-remote-cache --remote_download_regex=.*/rp_util/rp_util$
+
 #########################
 ## debug symbols mixins #
 #########################
@@ -415,8 +428,5 @@ build:io_uring --//bazel:io_uring=True
 # always pass through the following variables if they are set in the environment
 test --test_env=REDPANDA_RNG_SEEDING_MODE
 test --test_env=REDPANDA_DEBUG_TEST_HOOKS
-
-# Empty in this branch: CI passes --config=ci-remote-cache unconditionally.
-build:ci-remote-cache --build
 
 try-import %workspace%/user.bazelrc


### PR DESCRIPTION
Adds `--remote_download_minimal` in bazelrc that stops CI materialising outputs
no CI step reads. This reduces downloaded and materialized-on-disk bytes by
about 70% and shaves maybe ~1 minute off of a cached build.

jira: [CORE-16997](https://redpandadata.atlassian.net/browse/CORE-16997)

## Activated later
It is inert until something passes `--config=ci-remote-cache`; the
vtools change to do that in CI is a separate PR. Keeping the flags here means
the whitelist lives next to the rest of the repo's build config rather than in
CI config (a pattern we should follow for other cache related flags when it
makes sense).

## Why

Bazel's default is `--remote_download_outputs=toplevel`, which materialises
every top-level artifact of `//...`. On a warm-cache `bazel test //...` that is
~56 GB, and ~53 (ish) GB of it is never opened by any CI step:

| what | files | size |
|---|---|---|
| rpbench `_binary` targets | 63 | 15.86 GB |
| intermediate `.a` / `.so` | 2,411 | 12.96 GB |
| duplicate copies under `bazel/packaging` | 40 | 5.27 GB |
| parquet test-case JSONs | 64 | 4.42 GB |
| other | 1,636 | 3.40 GB |

The rpbench `_binary` targets are the largest single category at ~16 GB, some
individually 2.3 GB. They are `cc_binary`, not test rules, so Bazel's
TEST-mode exclusion for test rules does not cover them, and the unit-test job
never runs them.

## Measured before / after

Two same-commit warm-cache CI runs. Spawn count, cache-hit count and total
output bytes were **identical across both** (13,864 spawns / 13,860 cache
hits / 95,855,439,177 output bytes), so the deltas are attributable to the
flags alone.

| config | materialised | files | result |
|---|---|---|---|
| default (`toplevel`) | **56.05 GB** | 15,475 | green |
| **`--config=ci-remote-cache`** | **17.15 GB** (**-69%**) | 11,274 | green |

Bytes actually on the wire are ~75% below the materialised figures because
`--remote_cache_compression` is on: **17.37 GB -> 4.66 GB, -73%**.

### Timing

| config | bazel wall time | critical path | CI job |
|---|---|---|---|
| default | 65.70 s | 25.86 s | 4.43 min |
| **`--config=ci-remote-cache`** | **38.96 s (-41%)** | 13.17 s | 3.52 min (-21%) |

Single sample per arm and the arms ran on different agents of the same type, so
treat the timing as indicative; the byte figures are the solid part.

## What is still materialised under the new config

Of the remaining 17.15 GB:

| what | files | size | share |
|---|---|---|---|
| test logs / xml | 2,007 | 13.97 GB | 81.5% |
| the 3 whitelisted packaging outputs | 25 | 3.00 GB | 17.5% |
| everything else | 9,242 | 0.18 GB | 0.9% |

So after this change the residue is essentially just test logs plus the three
artifacts the packaging step needs.

**Test logs cannot be removed by any download flag.** `test.log` is the test
runner's stdout, and Bazel downloads stdout/stderr unconditionally for every
cache-hit action regardless of `--remote_download_outputs`. They are the floor.

Some are enormous:

```
3586.7 MB  src/v/storage/tests/storage_e2e_single_thread/test.log
1474.6 MB  src/v/cluster/tests/partition_balancer_simulator_test/test.log
 855.0 MB  src/v/cloud_topics/tests/end_to_end_test/test.log
 687.2 MB  src/v/raft/tests/raft_reconfiguration_test/test.log
 588.6 MB  src/v/kafka/client/direct_consumer/tests/direct_consumer_test/test.log
```

We should try to address this as well, it would result in another similar
relative improvement in downloaded bytes.


## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none


[CORE-16997]: https://redpandadata.atlassian.net/browse/CORE-16997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ