### PR TITLE
bazel: define an empty ci-remote-cache config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -416,4 +416,7 @@ build:io_uring --//bazel:io_uring=True
 test --test_env=REDPANDA_RNG_SEEDING_MODE
 test --test_env=REDPANDA_DEBUG_TEST_HOOKS
 
+# Empty in this branch: CI passes --config=ci-remote-cache unconditionally.
+build:ci-remote-cache --build
+
 try-import %workspace%/user.bazelrc


### PR DESCRIPTION
Defines `--config=ci-remote-cache` as a no-op, so that the config exists on every
branch CI builds.

The follow-up vtools change will pass `--config=ci-remote-cache` unconditionally,
and bazel treats an undefined config as a hard error.

The idea here is why want to put at least some of our caching config in the bazelrc
so we can modify it from redpanda repo, which lets us make branch specific changes
(in particular, some upcoming changes refer to file paths, which would change if
packaging things change in the redpanda repo).

The flags that make the config actually do something land on `dev` only, in
#31536.

jira: [CORE-16997](https://redpandadata.atlassian.net/browse/CORE-16997)

## Why at the end of the file

Not next to the other mixins, because the `MIXIN CONFIGS` and
`debug symbols mixins` sections do not exist on `v25.3.x`. The last three lines
of `.bazelrc` are byte-identical across `dev`, `v26.2.x`, `v26.1.x` and
`v25.3.x`, so appending there cherry-picks cleanly to every active branch.

`--build` as the no-op body follows the existing `build:fastbuild --build`
idiom in this file.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [x] v25.3.x

## Release Notes

* none


[CORE-16997]: https://redpandadata.atlassian.net/browse/CORE-16997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ