### PR TITLE
[v26.2.x] bazel: define an empty ci-remote-cache config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -400,4 +400,7 @@ build:io_uring --//bazel:io_uring=True
 test --test_env=REDPANDA_RNG_SEEDING_MODE
 test --test_env=REDPANDA_DEBUG_TEST_HOOKS
 
+# Empty in this branch: CI passes --config=ci-remote-cache unconditionally.
+build:ci-remote-cache --build
+
 try-import %workspace%/user.bazelrc


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31537
