### PR TITLE
[v25.3.x] bazel: define an empty ci-remote-cache config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -217,4 +217,7 @@ test:lldb --strategy=TestRunner=local
 test --test_env=REDPANDA_RNG_SEEDING_MODE
 test --test_env=REDPANDA_DEBUG_TEST_HOOKS
 
+# Empty in this branch: CI passes --config=ci-remote-cache unconditionally.
+build:ci-remote-cache --build
+
 try-import %workspace%/user.bazelrc


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31537
