### PR TITLE
iceberg: Reduce coroutine yields and allocs in conversion hot path

### DIFF
--- a/src/v/iceberg/conversion/values_parquet.cc
+++ b/src/v/iceberg/conversion/values_parquet.cc
@@ -10,6 +10,7 @@
 #include "iceberg/conversion/values_parquet.h"
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 
 namespace iceberg {
 namespace {
@@ -78,9 +79,26 @@ struct value_converting_visitor {
     operator()(std::unique_ptr<iceberg::struct_value> value) {
         serde::parquet::group_value group;
         group.reserve(value->fields.size());
+        size_t fields_since_yield = 0;
         for (auto& field : value->fields) {
             if (!field.has_value()) {
                 group.emplace_back(serde::parquet::null_value{});
+                continue;
+            }
+            // Fast path: convert primitive values directly without
+            // allocating a coroutine frame for to_parquet_value().
+            if (
+              auto* prim = std::get_if<iceberg::primitive_value>(
+                &field.value())) {
+                auto result = std::visit(
+                  primitive_value_converting_visitor{}, std::move(*prim));
+                group.emplace_back(std::move(result).assume_value());
+                // Yield periodically on wide schemas to avoid reactor
+                // stalls. Each primitive conversion is ~20-50ns, so 64
+                // fields is ~1-3µs — well bounded.
+                if (++fields_since_yield % 64 == 0) {
+                    co_await ss::coroutine::maybe_yield();
+                }
                 continue;
             }
             auto result = co_await to_parquet_value(std::move(*field));
@@ -100,6 +118,12 @@ struct value_converting_visitor {
             serde::parquet::group_value element_wrapper;
             if (!element.has_value()) {
                 element_wrapper.emplace_back(serde::parquet::null_value{});
+            } else if (
+              auto* prim = std::get_if<iceberg::primitive_value>(
+                &element.value())) {
+                auto result = std::visit(
+                  primitive_value_converting_visitor{}, std::move(*prim));
+                element_wrapper.emplace_back(std::move(result).assume_value());
             } else {
                 auto result = co_await to_parquet_value(std::move(*element));
                 if (result.has_error()) {

--- a/src/v/serde/parquet/shredder.cc
+++ b/src/v/serde/parquet/shredder.cc
@@ -14,6 +14,7 @@
 #include "serde/parquet/schema.h"
 #include "serde/parquet/value.h"
 
+#include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/util/variant_utils.hh>
 
@@ -51,7 +52,16 @@ public:
     }
 
     ss::future<> shred() {
+        size_t entries_since_yield = 0;
         while (!_stack.empty()) {
+            // Yield periodically to avoid reactor stalls on wide schemas.
+            // Each entry involves a column write (~100-200ns), so 64
+            // entries is ~6-13µs of work — well under the preemption
+            // threshold, but enough to bound latency for schemas with
+            // hundreds of columns.
+            if (++entries_since_yield % 64 == 0) {
+                co_await ss::coroutine::maybe_yield();
+            }
             auto [element, levels, value] = std::move(_stack.back());
             _stack.pop_back();
             if (element->is_leaf()) {
@@ -165,7 +175,8 @@ private:
                     std::runtime_error(
                       "detected null value for required group node"));
               }
-              return process_optional_null_group(element, levels);
+              process_optional_null_group(element, levels);
+              return ss::now();
           },
           [element](repeated_value) -> ss::future<> {
               return ss::make_exception_future(
@@ -188,8 +199,9 @@ private:
       const schema_element* element, traversal_levels levels, value val) {
         return ss::visit(
           std::move(val),
-          [this, element, levels](null_value) {
-              return process_optional_null_group(element, levels);
+          [this, element, levels](null_value) -> ss::future<> {
+              process_optional_null_group(element, levels);
+              return ss::now();
           },
           [this, element, levels](repeated_value list) {
               return process_repeated_value(element, levels, std::move(list));
@@ -220,7 +232,8 @@ private:
                 element, levels, std::move(group));
           },
           [this, element, levels](null_value) -> ss::future<> {
-              return process_optional_null_group(element, levels);
+              process_optional_null_group(element, levels);
+              return ss::now();
           },
           [element](repeated_value) -> ss::future<> {
               return ss::make_exception_future(
@@ -245,7 +258,8 @@ private:
       repeated_value list) {
         // Empty lists are equivalent to a `null` value.
         if (list.empty()) {
-            co_return co_await process_optional_null_group(element, levels);
+            process_optional_null_group(element, levels);
+            co_return;
         }
         traversal_levels child_levels = levels;
         // Since these elements are repeated, we need to mark that they are
@@ -272,14 +286,13 @@ private:
         return process_required_group_value(element, levels, std::move(groups));
     }
 
-    ss::future<> process_optional_null_group(
+    void process_optional_null_group(
       const schema_element* element, traversal_levels levels) {
         // If the value is `null`, we use the parent definition_level so that
         // assembly can determine where the `null` started.
         for (size_t i : reverse_view(irange(element->children.size()))) {
             const schema_element* child = &element->children[i];
             _stack.emplace_back(child, levels, value(null_value()));
-            co_await ss::coroutine::maybe_yield();
         }
     }
 
@@ -288,15 +301,14 @@ private:
       traversal_levels levels,
       group_value group) {
         if (group.size() != element->children.size()) {
-            co_return co_await ss::make_exception_future(
-              std::runtime_error(
-                fmt::format(
-                  "schema/struct mismatch, schema had {} children, struct had "
-                  "{} "
-                  "fields. At column {}",
-                  element->children.size(),
-                  group.size(),
-                  element->position)));
+            return ss::make_exception_future<>(std::runtime_error(
+              fmt::format(
+                "schema/struct mismatch, schema had {} children, struct had "
+                "{} "
+                "fields. At column {}",
+                element->children.size(),
+                group.size(),
+                element->position)));
         }
         // Levels don't change for require elements because they always have
         // to be there so no additional bits need to be tracked (they'd be
@@ -305,8 +317,8 @@ private:
             group_member& member = group[i];
             const schema_element* child = &element->children[i];
             _stack.emplace_back(child, levels, std::move(member.field));
-            co_await ss::coroutine::maybe_yield();
         }
+        return ss::now();
     }
 
     struct entry {


### PR DESCRIPTION
Reduce the amount of coroutine yields and yield checks in conversion hot paths.
1. Handling of null groups in parquet shredding
2. Conversion of primitive values

This gives a speedup of ~10% in benchmarks.

Adds yields point amortized over many values/fields to prevent reactor stalls on wide schemas.

| test | iters | runtime | allocs | cycles |
|------|------:|--------:|-------:|-------:|
| **baseline** |
| protobuf_linear_1_field_small | 150000 | 2.61µs ± 0.03% | 62.6 | 14170.4 |
| protobuf_linear_40_fields_small | 20000 | 15.73µs ± 0.05% | 159.2 | 85918.7 |
| protobuf_linear_80_fields_small | 10000 | 28.87µs ± 0.10% | 243.8 | 157791.4 |
| protobuf_nested_10_levels_small | 30000 | 10.31µs ± 0.03% | 255.7 | 56233.5 |
| protobuf_nested_30_levels_small | 10000 | 25.59µs ± 0.36% | 677.2 | 139803.9 |
| avro_linear_1_field_small | 230000 | 2.55µs ± 0.04% | 57.6 | 13839.1 |
| avro_linear_40_fields_small | 30000 | 16.74µs ± 0.03% | 226.1 | 91442.0 |
| avro_linear_80_fields_small | 20000 | 31.25µs ± 0.13% | 389.8 | 170856.2 |
| avro_nested_10_levels_small | 30000 | 9.30µs ± 0.01% | 242.7 | 50751.8 |
| avro_nested_30_levels_small | 10000 | 22.35µs ± 0.12% | 623.2 | 122158.0 |
| json_linear_40_fields_small | 10000 | 21.06µs ± 0.07% | 673.2 | 115079.7 |
| json_linear_80_fields_small | 10000 | 39.12µs ± 0.04% | 1276.9 | 213780.0 |
| **with improvements** |
| protobuf_linear_1_field_small | 150000 | 2.37µs ± 0.08% | 57.6 | 12852.0 |
| protobuf_linear_40_fields_small | 20000 | 13.96µs ± 0.28% | 154.2 | 76158.6 |
| protobuf_linear_80_fields_small | 10000 | 25.45µs ± 0.18% | 238.8 | 139050.9 |
| protobuf_nested_10_levels_small | 30000 | 9.69µs ± 0.09% | 241.7 | 52904.5 |
| protobuf_nested_30_levels_small | 10000 | 23.87µs ± 0.09% | 643.2 | 130381.4 |
| avro_linear_1_field_small | 240000 | 2.32µs ± 0.28% | 52.6 | 12514.6 |
| avro_linear_40_fields_small | 30000 | 14.95µs ± 0.05% | 221.1 | 81640.1 |
| avro_linear_80_fields_small | 20000 | 27.74µs ± 0.07% | 384.7 | 151612.4 |
| avro_nested_10_levels_small | 30000 | 8.64µs ± 0.11% | 227.7 | 47089.3 |
| avro_nested_30_levels_small | 10000 | 20.64µs ± 0.10% | 588.2 | 112806.7 |
| json_linear_40_fields_small | 10000 | 19.50µs ± 0.28% | 668.2 | 106531.4 |
| json_linear_80_fields_small | 10000 | 36.06µs ± 0.28% | 1271.9 | 197109.7 |

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none

