### PR TITLE
[CORE-8759] storage: kill broker process if log_reader detects a corrupt segment

### DIFF
--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -217,6 +217,16 @@ node_config::node_config() noexcept
       "not loaded and only administrative operations are allowed.",
       {.visibility = visibility::user},
       false)
+  , storage_abort_on_corrupt_segment(
+      *this,
+      "storage_abort_on_corrupt_segment",
+      "If `true`, abort the process upon failure to read committed log segment "
+      "data. Continuing to operate with missing or corrupted committed data "
+      "could result in propagating invalid state to clients or other brokers. "
+      "Can be set to `false` in order to salvage data from a broker with some "
+      "damaged segments.",
+      {.visibility = visibility::user},
+      true)
   , storage_failure_injection_config_path(
       *this,
       "storage_failure_injection_config_path",

--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -85,6 +85,10 @@ public:
     // user partitions and allowing only metadata operations.
     property<bool> recovery_mode_enabled;
 
+    // If true, abort the process when a log read detects a corrupt segment.
+    // Defaults to true. See the property description.
+    property<bool> storage_abort_on_corrupt_segment;
+
     // Path to the configuration file for low level storage failure injection.
     property<std::optional<std::filesystem::path>>
       storage_failure_injection_config_path;

--- a/src/v/storage/exceptions.h
+++ b/src/v/storage/exceptions.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "base/seastarx.h"
+#include "model/fundamental.h"
 
 #include <seastar/core/sstring.hh>
 
@@ -21,13 +22,20 @@
 
 class malformed_batch_stream_exception : public std::exception {
 public:
-    explicit malformed_batch_stream_exception(ss::sstring s)
-      : _msg(std::move(s)) {}
+    /// \param failed_at the first offset the read was unable to supply.
+    malformed_batch_stream_exception(ss::sstring s, model::offset failed_at)
+      : _msg(std::move(s))
+      , _failed_at(failed_at) {}
 
     const char* what() const noexcept override { return _msg.c_str(); }
 
+    /// The first offset the read was unable to supply. Carried separately from
+    /// the message so callers can assert on it without parsing prose.
+    model::offset failed_at() const { return _failed_at; }
+
 private:
     ss::sstring _msg;
+    model::offset _failed_at;
 };
 
 class zero_segments_indexed_exception : public std::exception {

--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -12,11 +12,13 @@
 #include "base/vassert.h"
 #include "base/vlog.h"
 #include "bytes/iobuf.h"
+#include "config/node_config.h"
 #include "model/batch_compression.h"
 #include "model/batch_utils.h"
 #include "model/fundamental.h"
 #include "model/offset_interval.h"
 #include "model/record.h"
+#include "storage/exceptions.h"
 #include "storage/logger.h"
 #include "storage/offset_translator_state.h"
 #include "storage/parser_errc.h"
@@ -44,6 +46,57 @@ struct fmt::formatter<storage::log_reader> : fmt::formatter<std::string_view> {
 
 namespace storage {
 using records_t = chunked_circular_buffer<model::record_batch>;
+
+void internal::handle_corrupt_segment(
+  parser_errc err,
+  std::string_view segment_desc,
+  model::offset next_offset,
+  model::offset stable_offset_at_stream_start,
+  corrupt_segment_action action) {
+    // - `none` is a consumer-requested stop.
+    // - `end_of_stream` means the parser reached the end of *its own* stream,
+    //   whose length segment_reader::data_stream() fixed at creation. It has to
+    //   clear the stable offset captured then, not the segment's current one,
+    //   which it may have grown past since.
+    // - Anything else is a malformed batch, and needs no bound. The stream
+    //   cannot extend past filepos(stable_offset_at_stream_start), so all
+    //   included batches must be valid.
+    if (err == parser_errc::none) {
+        return;
+    }
+    if (
+      err == parser_errc::end_of_stream
+      && next_offset > stable_offset_at_stream_start) {
+        return;
+    }
+    auto msg = fmt::format(
+      "Read on segment {} stopped at offset {} with error {}, before stable "
+      "offset {} (at the time the read began)",
+      segment_desc,
+      next_offset,
+      to_string_view(err),
+      stable_offset_at_stream_start);
+    if (action == corrupt_segment_action::throw_exception) {
+        throw malformed_batch_stream_exception(msg, next_offset);
+    }
+    if (!config::node().storage_abort_on_corrupt_segment()) {
+        vlog(
+          stlog.error,
+          "{} - continuing with a truncated read because "
+          "storage_abort_on_corrupt_segment is false",
+          msg);
+        return;
+    }
+    vassert(
+      false,
+      "{}. Aborting process due to invalid disk state. If possible, introduce "
+      "a replacement broker, allow the cluster to recover, and then "
+      "decommission this damaged broker once the cluster is healthy. If this "
+      "broker is absolutely necessary to recover data, the "
+      "storage_abort_on_corrupt_segment node property can be set to false to "
+      "override this abort.",
+      msg);
+}
 
 /**
  * makes multiple ghost batches required to fill the gap in a way that max batch
@@ -179,6 +232,11 @@ ss::future<std::unique_ptr<continuous_batch_parser>>
 log_segment_batch_reader::initialize(
   model::timeout_clock::time_point timeout,
   std::optional<model::offset> next_cached_batch) {
+    // Stream will be constructed with the current size and must read up to
+    // the current stable offset (if requested).  Capture here so that
+    // handle_corrupt_segment can distinguish a correct end_of_stream
+    // from a premature one.
+    _stable_at_stream_start = _seg.offsets().get_stable_offset();
     auto input = co_await _seg.offset_data_stream(_config.start_offset);
     co_return std::make_unique<continuous_batch_parser>(
       std::make_unique<skipping_consumer>(*this, timeout, next_cached_batch),
@@ -248,7 +306,16 @@ log_segment_batch_reader::read_some(model::timeout_clock::time_point timeout) {
     }
     auto ptr = _iterator.get();
     co_return co_await ptr->consume()
-      .then([this](result<size_t> bytes_consumed) -> result<records_t> {
+      .then([this, ptr](result<size_t> bytes_consumed) -> result<records_t> {
+          // bytes_consumed will indicate success if any bytes were read and
+          // may (depending on the error) even with no bytes read.  Validate
+          // via ptr->error() and next_offset (_config.start_offset).
+          internal::handle_corrupt_segment(
+            ptr->error(),
+            _seg.filename(),
+            _config.start_offset,
+            _stable_at_stream_start,
+            _config.on_corrupt_segment);
           if (!bytes_consumed) {
               return bytes_consumed.error();
           }

--- a/src/v/storage/log_reader.h
+++ b/src/v/storage/log_reader.h
@@ -50,6 +50,25 @@ after every invocation of `record_batch_reader::load_batches()`
 */
 namespace storage {
 
+namespace internal {
+
+/// \brief Aborts the process if `err` shows that a read stopped inside the
+/// offset range a segment reports as written.  A corrupt segment indicates
+/// a storage problem (or redpanda bug), and we don't want to propagate invalid
+/// state to clients or other brokers.
+///
+/// `storage_abort_on_corrupt_segment` downgrades the abort to a log line.
+/// Passing `throw_exception` raises `malformed_batch_stream_exception` instead,
+/// which is how the tests validate detection.
+void handle_corrupt_segment(
+  parser_errc err,
+  std::string_view segment_desc,
+  model::offset next_offset,
+  model::offset stable_offset_at_stream_start,
+  corrupt_segment_action action);
+
+} // namespace internal
+
 class log_segment_batch_reader;
 class skipping_consumer final : public batch_consumer {
 public:
@@ -125,6 +144,11 @@ private:
     probe& _probe;
 
     std::unique_ptr<continuous_batch_parser> _iterator;
+
+    // The segment's stable offset when `_iterator`'s stream was created.
+    // Reads up through this offset must succeed, see handle_corrupt_segment.
+    model::offset _stable_at_stream_start;
+
     tmp_state _state;
     friend class skipping_consumer;
 };

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -526,6 +526,8 @@ model::record_batch_reader create_segment_full_reader(
     auto lease = std::make_unique<lock_manager::lease>(
       segment_set(std::move(set)));
     lease->locks.push_back(std::move(h));
+    // Note, `log_reader` aborts the process upon detecting a corrupt segment
+    // rather than returning an error to the caller. See handle_corrupt_segment.
     return model::make_record_batch_reader<log_reader>(
       std::move(lease), reader_cfg, pb, nullptr);
 }

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -814,6 +814,26 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "log_reader_gap_test",
+    timeout = "short",
+    srcs = [
+        "log_reader_gap_test.cc",
+    ],
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/model",
+        "//src/v/storage",
+        "//src/v/storage:record_batch_builder",
+        "//src/v/storage:record_batch_utils",
+        "//src/v/storage:segment_appender",
+        "//src/v/storage/tests:disk_log_builder",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "file_sanitizer_test",
     timeout = "short",
     srcs = [

--- a/src/v/storage/tests/log_reader_gap_test.cc
+++ b/src/v/storage/tests/log_reader_gap_test.cc
@@ -1,0 +1,520 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// CORE-8759: a read that cannot supply the offset range a segment says it wrote
+// must fail, not report a clean end-of-stream.
+//
+// The parser in log_segment_batch_reader::initialize() is given a stream
+// bounded by the filesize at the time of construction, which must match
+// get_stable_offset(). All reads up to get_stable_offset() at construction time
+// must succeed, or handle_corrupt_segment must detect the segment as corrupt.
+//
+// A note on why writing zeros straight through the appender is a faithful
+// reproduction rather than a contrivance: for an active segment the readable
+// extent (segment_reader::_file_size) is advanced only by
+// segment::advance_stable_offset, from _inflight entries that are recorded at
+// complete-batch boundaries. Appending raw bytes bypasses _inflight, so the
+// zeros only become *readable* once a subsequent real batch extends the extent
+// past them -- which is exactly the production shape: a gap with committed data
+// behind it.
+
+#include "bytes/iobuf.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "model/record_batch_types.h"
+#include "model/record_utils.h"
+#include "storage/exceptions.h"
+#include "storage/log_reader.h"
+#include "storage/parser_errc.h"
+#include "storage/record_batch_builder.h"
+#include "storage/record_batch_utils.h"
+#include "storage/segment.h"
+#include "storage/segment_appender.h"
+#include "storage/tests/utils/disk_log_builder.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <fcntl.h>
+#include <filesystem>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+namespace {
+
+// Comfortably larger than segment_index's 32KiB indexing step, so every batch
+// gets its own index entry and a read can seek to an offset *past* an injected
+// gap.
+constexpr size_t big_payload = 64 * 1024;
+
+// Comfortably smaller than the indexing step, so only the segment's first batch
+// is indexed and a seek to any later offset lands back at file position 0.
+constexpr size_t small_payload = 512;
+
+model::record_batch make_batch(model::offset o, size_t payload_size) {
+    storage::record_batch_builder builder(
+      model::record_batch_type::raft_data, o);
+    iobuf value;
+    // Deliberately non-zero: a zero-filled *body* is fine, but keeping bodies
+    // distinguishable from the injected gap makes failures easier to read.
+    const std::string payload(payload_size, 'x');
+    value.append(payload.data(), payload.size());
+    builder.add_raw_kv(std::nullopt, std::move(value));
+    return std::move(builder).build();
+}
+
+// Push raw bytes through the segment's appender, bypassing segment::append and
+// therefore bypassing _inflight / the segment index. Mimics a lost write or an
+// unwritten fallocated region sitting in the middle of a segment.
+void inject_raw(storage::segment& seg, iobuf buf) {
+    for (const auto& frag : buf) {
+        seg.appender().append(frag.get(), frag.size()).get();
+    }
+}
+
+void inject_zero_gap(storage::segment& seg, size_t n) {
+    iobuf zeros;
+    const std::vector<char> buf(n, 0);
+    zeros.append(buf.data(), buf.size());
+    inject_raw(seg, std::move(zeros));
+}
+
+// Overwrite bytes already on disk, in place. Used to corrupt a batch the
+// segment index points *at*, which appending cannot do. Plain POSIX rather than
+// seastar so the write needs no dma alignment.
+[[nodiscard]] bool overwrite_in_place(
+  const std::filesystem::path& path, size_t pos, size_t n, char fill) {
+    const int fd = ::open(path.c_str(), O_WRONLY); // NOLINT
+    if (fd < 0) {
+        return false;
+    }
+    const std::vector<char> buf(n, fill);
+    const bool ok = ::pwrite(
+                      fd, buf.data(), buf.size(), static_cast<off_t>(pos))
+                      == static_cast<ssize_t>(buf.size())
+                    && ::fsync(fd) == 0;
+    ::close(fd);
+    return ok;
+}
+
+// A well-formed, correctly-CRC'd batch header that lies about how long its body
+// is. The parser accepts the header, then short-reads trying to consume
+// `size_bytes - packed_record_batch_header_size` body bytes.
+void inject_overlong_header(
+  storage::segment& seg, model::offset base, int32_t claimed_size_bytes) {
+    model::record_batch_header header{
+      .size_bytes = claimed_size_bytes,
+      .base_offset = base,
+      .type = model::record_batch_type::raft_data,
+      .crc = 0,
+      .attrs = model::record_batch_attributes{},
+      .last_offset_delta = 0,
+      .first_timestamp = model::timestamp{1},
+      .max_timestamp = model::timestamp{1},
+      .producer_id = -1,
+      .producer_epoch = -1,
+      .base_sequence = -1,
+      .record_count = 1,
+    };
+    // Make the header pass read_header_impl's CRC check, so the parser gets far
+    // enough to try to read the (nonexistent) body.
+    header.header_crc = model::internal_header_only_crc(header);
+    inject_raw(seg, storage::batch_header_to_disk_iobuf(header));
+}
+
+struct log_reader_gap_fixture : public testing::Test {
+    storage::disk_log_builder b;
+    ~log_reader_gap_fixture() override { b.stop().get(); }
+
+    // Reads must come off disk. skip_batch_cache only skips LRU promotion --
+    // cached batches are still returned -- so the index has to be reset.
+    void drop_batch_cache() {
+        auto& segs = b.get_log_segments();
+        for (size_t i = 0; i < segs.size(); ++i) {
+            b.get_segment(i).reset_batch_cache_index().get();
+        }
+    }
+
+    static storage::local_log_reader_config throwing_reader_config(
+      model::offset start = model::offset(0),
+      model::offset max = model::model_limits<model::offset>::max()) {
+        storage::local_log_reader_config cfg{start, max};
+        cfg.on_corrupt_segment
+          = storage::corrupt_segment_action::throw_exception;
+        return cfg;
+    }
+
+    // Assert detection fired, and that it named the first offset the read could
+    // not supply.
+    void expect_detected_at(
+      storage::local_log_reader_config cfg, model::offset expected) {
+        try {
+            b.consume(cfg).get();
+            FAIL() << "expected malformed_batch_stream_exception";
+        } catch (const malformed_batch_stream_exception& e) {
+            EXPECT_EQ(e.failed_at(), expected) << e.what();
+        }
+    }
+};
+
+constexpr auto stable_offset = model::offset(42);
+
+} // namespace
+
+// Test basic handle_corrupt_segment errc handling
+TEST(corrupt_segment, classifies_every_parser_errc) {
+    constexpr std::array all_errcs{
+      storage::parser_errc::none,
+      storage::parser_errc::end_of_stream,
+      storage::parser_errc::header_only_crc_missmatch,
+      storage::parser_errc::input_stream_not_enough_bytes,
+      storage::parser_errc::fallocated_file_read_zero_bytes_for_header,
+      storage::parser_errc::not_enough_bytes_in_parser_for_one_record,
+    };
+    for (const auto err : all_errcs) {
+        const auto describe = fmt::format("errc: {}", to_string_view(err));
+        auto detect = [err](model::offset next_offset) {
+            storage::internal::handle_corrupt_segment(
+              err,
+              "0-0-v1.log",
+              next_offset,
+              stable_offset,
+              storage::corrupt_segment_action::throw_exception);
+        };
+        auto fatal_at = [&](model::offset next_offset) {
+            EXPECT_THROW(detect(next_offset), malformed_batch_stream_exception)
+              << describe << " at next_offset " << next_offset;
+        };
+        auto benign_at = [&](model::offset next_offset) {
+            EXPECT_NO_THROW(detect(next_offset))
+              << describe << " at next_offset " << next_offset;
+        };
+
+        // next_offset == stable means the read terminated before successfully
+        // reading stable_offset.
+        const auto at_bound = stable_offset;
+        const auto past_bound = model::next_offset(stable_offset);
+
+        // Ensures any added errcs will fail the build unless also added here
+        switch (err) {
+        // The consumer asked to stop, valid anywhere
+        case storage::parser_errc::none:
+            benign_at(at_bound);
+            benign_at(past_bound);
+            break;
+        // Parser reached end of stream.  Valid iff next_offset > stable_offset.
+        case storage::parser_errc::end_of_stream:
+            fatal_at(at_bound);
+            benign_at(past_bound);
+            break;
+        // Always invalid
+        case storage::parser_errc::header_only_crc_missmatch:
+        case storage::parser_errc::input_stream_not_enough_bytes:
+        case storage::parser_errc::fallocated_file_read_zero_bytes_for_header:
+        case storage::parser_errc::not_enough_bytes_in_parser_for_one_record:
+            fatal_at(at_bound);
+            fatal_at(past_bound);
+            break;
+        }
+    }
+}
+
+// Test that exception (and therefore abort message) contain segment name,
+// offset at which reading stopped, stable_offset from read start, and error
+TEST(corrupt_segment, message_identifies_the_damage) {
+    try {
+        storage::internal::handle_corrupt_segment(
+          storage::parser_errc::fallocated_file_read_zero_bytes_for_header,
+          "kafka/topic/0_11/1234-7-v1.log",
+          model::offset(97),
+          model::offset(512),
+          storage::corrupt_segment_action::throw_exception);
+        FAIL() << "expected malformed_batch_stream_exception";
+    } catch (const malformed_batch_stream_exception& e) {
+        const std::string msg{e.what()};
+        EXPECT_NE(msg.find("kafka/topic/0_11/1234-7-v1.log"), std::string::npos)
+          << msg;
+        EXPECT_NE(msg.find("97"), std::string::npos) << msg;
+        EXPECT_NE(msg.find("512"), std::string::npos) << msg;
+        EXPECT_NE(
+          msg.find("fallocated_file_read_zero_bytes_for_header"),
+          std::string::npos)
+          << msg;
+    }
+}
+
+// A zeroed batch header in the middle of segment 0, with a durable batch behind
+// it and a whole further segment behind that.
+TEST_F(log_reader_gap_fixture, zeroed_header_mid_segment_fails_the_read) {
+    using namespace storage; // NOLINT
+
+    b | start() | add_segment(0);
+
+    // Offset 0: complete, flushed, before the gap.
+    b.add_batch(make_batch(model::offset(0), big_payload)).get();
+
+    inject_zero_gap(b.get_segment(0), model::packed_record_batch_header_size);
+
+    // Offset 1: complete and durable, but sitting behind the gap. Appending it
+    // is what pushes the readable extent past the zeros.
+    b.add_batch(make_batch(model::offset(1), big_payload)).get();
+
+    // Offset 2: an entire second segment behind the gap.
+    b.add_segment(model::offset(2)).get();
+    b.add_batch(make_batch(model::offset(2), big_payload)).get();
+    b.get_log()->flush().get();
+
+    ASSERT_EQ(b.get_log_segments().size(), 2u);
+
+    const auto log_dirty = b.get_log()->offsets().dirty_offset;
+    const auto seg0_stable = b.get_segment(0).offsets().get_stable_offset();
+    ASSERT_EQ(log_dirty, model::offset(2));
+    ASSERT_GE(seg0_stable, model::offset(1))
+      << "segment 0 must report offset 1 as written, otherwise the read below "
+         "stops for a legitimate reason and the test proves nothing";
+
+    drop_batch_cache();
+
+    expect_detected_at(throwing_reader_config(), model::offset(1));
+}
+
+// Test behavior of read after damaged segment region.
+// Depending on indexing, the actual read may or may not precede the damage.
+// In this case, the read starts after the damaged region and should succeed.
+//
+// The distinction between this and the next test is where the index entry is
+// relative to the target and damaged region -- we just want coverage of both
+// behaviors.
+TEST_F(log_reader_gap_fixture, data_behind_a_zeroed_header_is_still_readable) {
+    using namespace storage; // NOLINT
+
+    b | start() | add_segment(0);
+    b.add_batch(make_batch(model::offset(0), big_payload)).get();
+    inject_zero_gap(b.get_segment(0), model::packed_record_batch_header_size);
+    b.add_batch(make_batch(model::offset(1), big_payload)).get();
+    b.add_segment(model::offset(2)).get();
+    b.add_batch(make_batch(model::offset(2), big_payload)).get();
+    b.get_log()->flush().get();
+
+    drop_batch_cache();
+
+    // Start at offset 1: the segment index has an entry for it (batches are
+    // larger than the 32KiB index step), so the read starts *after* the zeros.
+    auto batches = b.consume(throwing_reader_config(model::offset(1))).get();
+
+    EXPECT_EQ(batches.size(), 2u);
+    ASSERT_FALSE(batches.empty());
+    EXPECT_EQ(batches.front().base_offset(), model::offset(1));
+    EXPECT_EQ(batches.back().base_offset(), model::offset(2));
+}
+
+// Similar to above, but index causes read to start *before* the damaged
+// region.
+TEST_F(log_reader_gap_fixture, data_behind_a_zeroed_header_is_not_readable) {
+    using namespace storage; // NOLINT
+
+    b | start() | add_segment(0);
+    b.add_batch(make_batch(model::offset(0), small_payload)).get();
+    inject_zero_gap(b.get_segment(0), model::packed_record_batch_header_size);
+    b.add_batch(make_batch(model::offset(1), small_payload)).get();
+    b.add_segment(model::offset(2)).get();
+    b.add_batch(make_batch(model::offset(2), big_payload)).get();
+    b.get_log()->flush().get();
+
+    drop_batch_cache();
+
+    // Start at offset 1: the segment index does not have an entry for it,
+    // so the read will start at the beginning and fail
+    expect_detected_at(
+      throwing_reader_config(model::offset(1)), model::offset(1));
+}
+
+// Similar to above, but with gap at the start of the segment
+TEST_F(log_reader_gap_fixture, data_behind_zeroed_header_at_start_readable) {
+    using namespace storage; // NOLINT
+
+    b | start() | add_segment(0);
+    b.add_batch(make_batch(model::offset(0), big_payload)).get();
+
+    // Segment 1 opens directly onto the gap, ahead of its first real batch.
+    b.add_segment(model::offset(1)).get();
+    inject_overlong_header(b.get_segment(1), model::offset(1), 8 * 1024 * 1024);
+    b.add_batch(make_batch(model::offset(1), big_payload)).get();
+
+    b.add_segment(model::offset(2)).get();
+    b.add_batch(make_batch(model::offset(2), big_payload)).get();
+    b.get_log()->flush().get();
+
+    ASSERT_EQ(b.get_log_segments().size(), 3u);
+    ASSERT_EQ(b.get_log()->offsets().dirty_offset, model::offset(2));
+
+    drop_batch_cache();
+
+    auto batches = b.consume(throwing_reader_config()).get();
+
+    // Everything is returned: the index entry for offset 1 points past the gap,
+    // so segment 1's parser never sees it.
+    EXPECT_EQ(batches.size(), 3u);
+    ASSERT_FALSE(batches.empty());
+    EXPECT_EQ(batches.front().base_offset(), model::offset(0));
+    EXPECT_EQ(batches.back().base_offset(), model::offset(2));
+}
+
+// Similar, but the parser stops with input_stream_not_enough_bytes rather
+// than on a zeroed header. This is the variant logged in CORE-8759.
+TEST_F(log_reader_gap_fixture, short_read_mid_segment_fails_the_read) {
+    using namespace storage; // NOLINT
+
+    b | start() | add_segment(0);
+
+    b.add_batch(make_batch(model::offset(0), big_payload)).get();
+
+    // Claim a body far longer than anything left in the segment, so
+    // consume_records() is guaranteed to short-read.
+    inject_overlong_header(b.get_segment(0), model::offset(1), 8 * 1024 * 1024);
+
+    b.add_batch(make_batch(model::offset(1), big_payload)).get();
+    b.add_segment(model::offset(2)).get();
+    b.add_batch(make_batch(model::offset(2), big_payload)).get();
+    b.get_log()->flush().get();
+
+    const auto log_dirty = b.get_log()->offsets().dirty_offset;
+    ASSERT_EQ(log_dirty, model::offset(2));
+
+    drop_batch_cache();
+
+    expect_detected_at(throwing_reader_config(), model::offset(1));
+}
+
+// Test read against a segment with an unflushed append, should not fail
+TEST_F(log_reader_gap_fixture, read_with_unflushed_tail_should_succeed) {
+    using namespace storage; // NOLINT
+
+    b | start() | add_segment(0);
+    b.add_batch(make_batch(model::offset(0), big_payload)).get();
+
+    // Drop the cache while it is still clean, so the read below has to come off
+    // disk. Appending after this leaves offset 1 cached and dirty.
+    drop_batch_cache();
+
+    b.add_batch(
+       make_batch(model::offset(1), big_payload),
+       log_append_config{log_append_config::fsync::no},
+       disk_log_builder::should_flush_after::no)
+      .get();
+
+    // Offset 1 sits above the readable extent, so it can only be served from
+    // the cache -- which is how production serves dirty batches. Asserted so
+    // that the test fails rather than degrading into an ordinary read if the
+    // extent ever stops lagging.
+    ASSERT_LT(
+      b.get_segment(0).offsets().get_stable_offset(),
+      b.get_segment(0).offsets().get_dirty_offset());
+
+    auto batches = decltype(b.consume().get()){};
+    ASSERT_NO_THROW(batches = b.consume(throwing_reader_config()).get());
+    ASSERT_EQ(batches.size(), 2u);
+    EXPECT_EQ(batches.front().base_offset(), model::offset(0));
+    EXPECT_EQ(batches.back().base_offset(), model::offset(1));
+
+    // batch_cache_index asserts if it is destroyed still tracking dirty
+    // batches.
+    b.get_log()->flush().get();
+}
+
+// Log segment truncated before stable_offset.
+//
+// Truncating on an exact batch boundary means nothing is malformed; the bytes
+// simply stop, so the parser reports end_of_stream. That is only
+// distinguishable from a reader whose stream snapshot ended because it compares
+// against the stable offset captured when the stream was created.
+TEST_F(
+  log_reader_gap_fixture, data_file_shorter_than_the_index_fails_the_read) {
+    using namespace storage; // NOLINT
+
+    b | start() | add_segment(0);
+    b.add_batch(make_batch(model::offset(0), big_payload)).get();
+    b.add_batch(make_batch(model::offset(1), big_payload)).get();
+    b.get_log()->flush().get();
+
+    // Boundary after offset 1, captured before offset 2 exists. Two batches
+    // survive the truncation below, so detection has to name 2 rather than the
+    // first offset in the log.
+    const auto batch_1_end = b.get_segment(0).reader().file_size();
+
+    b.add_batch(make_batch(model::offset(2), big_payload)).get();
+    b.get_log()->flush().get();
+
+    ASSERT_EQ(b.get_segment(0).offsets().get_stable_offset(), model::offset(2));
+    ASSERT_GT(b.get_segment(0).reader().file_size(), batch_1_end);
+
+    // Shorten the data file only. The index and the offset tracker keep
+    // advertising offset 2, so the segment now claims more than it can supply.
+    b.get_segment(0).reader().truncate(batch_1_end).get();
+    ASSERT_EQ(b.get_segment(0).index().max_offset(), model::offset(2));
+
+    drop_batch_cache();
+
+    expect_detected_at(throwing_reader_config(), model::offset(2));
+}
+
+// Damage at the *first* position the parser reads. consume() reports failure
+// rather than partial success when it consumed nothing, so check that
+// handle_corrupt_segment still runs.
+TEST_F(
+  log_reader_gap_fixture, damage_at_the_first_parsed_position_is_detected) {
+    using namespace storage; // NOLINT
+
+    b | start() | add_segment(0);
+    b.add_batch(make_batch(model::offset(0), big_payload)).get();
+    b.add_batch(make_batch(model::offset(1), big_payload)).get();
+    b.get_log()->flush().get();
+
+    // Batches exceed the 32KiB index step, so offset 1 has its own entry and a
+    // seek to it starts the parser exactly at the header corrupted below.
+    auto entry = b.get_segment(0).index().find_nearest(model::offset(1));
+    ASSERT_TRUE(entry.has_value());
+    ASSERT_EQ(entry->offset, model::offset(1));
+
+    ASSERT_TRUE(overwrite_in_place(
+      b.get_segment(0).reader().path(),
+      entry->filepos,
+      model::packed_record_batch_header_size,
+      '\x5a'))
+      << "could not corrupt the segment file";
+
+    drop_batch_cache();
+
+    // Nothing precedes the damage, so bytes_consumed is zero and the parser's
+    // header CRC check is the only thing that fired.
+    expect_detected_at(
+      throwing_reader_config(model::offset(1)), model::offset(1));
+}
+
+TEST_F(log_reader_gap_fixture, intact_log_reads_completely) {
+    using namespace storage; // NOLINT
+
+    b | start() | add_segment(0);
+    b.add_batch(make_batch(model::offset(0), big_payload)).get();
+    b.add_batch(make_batch(model::offset(1), big_payload)).get();
+    b.add_segment(model::offset(2)).get();
+    b.add_batch(make_batch(model::offset(2), big_payload)).get();
+    b.get_log()->flush().get();
+
+    ASSERT_EQ(b.get_log_segments().size(), 2u);
+    drop_batch_cache();
+
+    auto batches = b.consume(throwing_reader_config()).get();
+
+    EXPECT_EQ(batches.size(), 3u);
+    ASSERT_FALSE(batches.empty());
+    EXPECT_EQ(batches.front().base_offset(), model::offset(0));
+    EXPECT_EQ(batches.back().base_offset(), model::offset(2));
+}

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -385,6 +385,14 @@ struct truncate_prefix_config {
     fmt::iterator format_to(fmt::iterator it) const;
 };
 
+/// What a reader does upon detecting a corrupt segment.
+/// Normal behavior is to abort the broker to avoid propagating invalid state.
+/// Tests set throw_exception to test the detection pathway.
+enum class corrupt_segment_action {
+    abort_process,
+    throw_exception,
+};
+
 /**
  * Log reader configuration. Operates on Raft offsets.
  *
@@ -506,6 +514,10 @@ struct local_log_reader_config {
 
     // Timeout for segment range lock acquisition
     std::optional<ss::semaphore::clock::time_point> read_lock_deadline{};
+
+    // Test seam. Leave at the default outside tests.
+    corrupt_segment_action on_corrupt_segment{
+      corrupt_segment_action::abort_process};
 
     fmt::iterator format_to(fmt::iterator it) const;
 


### PR DESCRIPTION
In cases where a segment file had a zeroed batch header mid-file, the log reader
would return the batches before it and then report a clean end of stream at the
broken header. The offset translator, seeing a successful read that stopped
short of the log tip, would then throw out of `consensus::start()`, causing the
raft group to never register on that shard.

`log_reader` should fail there instead of passing the fault up as a success. The
stream passed to the `continuous_batch_parser` in
`log_segment_batch_reader::initialize` is limited by the filesize at
construction, which will match `get_stable_offset()`. `recover_segments` sets
stable_offset for each segment from the index (written only after flushing the
appender) or from recovering the segment. Thus, reads up through the segment's
stable offset must succeed -- invalid or missing batches indicate either a
redpanda bug or a fault in the underlying storage. In either case, we don't want
to propagate that state to clients or other brokers.

`consume()`'s `result<size_t>` will report success if any data is read (and for
some errors if no data is read). We need to use `error()` to see the actual
error result. We also need a bit of additional information to distinguish a
correct `end_of_stream` from a premature one -- capture
`_stable_at_stream_start` at `continuous_batch_parser` construction time in
`initialize()` and use it to check whether an `end_of_stream` from `consume()`
occurred prematurely. The other errors are automatically fatal as they indicate
invalid batches in a range that must be valid.

By default, detecting a fault in a segment kills the broker process as
continuing to operate with a corrupt storage layer is dangerous. Setting
`storage_abort_on_corrupt_segment` to false will disable this abort and allow
the broker to tolerate the problem. It is a node property because it must be
settable on a broker that will not start.

The following read paths may hit this case:

- kafka fetch, including fetch from a follower
- raft recovery, feeding a lagging follower from the leader's log
- offset translator startup sync
- tiered storage upload
- suffix truncation's offset-to-filepos scan
- compaction, via `create_segment_full_reader`

The second commit tests detection. Every `parser_errc` is classified through a
`switch`, so adding an enumerator without updating the test fails the build.
The fixture tests corrupt real segments -- a zeroed batch header mid-segment, a
header whose declared size runs past the readable extent, a data file that ends
early while the index still advertises the range, damage at the very first
position the parser reads -- and cover the cases that must keep succeeding: a
read whose physical start lies past the damage, a gap at a segment's head
stepped over via the index, and reads against a normal intact log with and
without unflushed batches.

## Backports Required

- [x] none - seems risky to backport quickly

## Release Notes

### Improvements

* A read which detects a corrupt on disk segment will now abort the broker rather than risk propagating invalid state to clients or other brokers. This behavior can be overridden by `storage_abort_on_corrupt_segment` if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
