### PR TITLE
[CORE-12930] - Storage: Some observability improvements for unrecoverable segments

### DIFF
--- a/src/v/storage/BUILD
+++ b/src/v/storage/BUILD
@@ -320,6 +320,7 @@ redpanda_cc_library(
         ":log_manager_probe",
         "//src/v/ssx:abort_source",
         "//src/v/syschecks",
+        "//src/v/utils:human",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/v/storage/BUILD
+++ b/src/v/storage/BUILD
@@ -333,6 +333,7 @@ redpanda_cc_library(
         ":parser_utils",
         ":record_batch_builder",
         ":record_batch_utils",
+        ":recovery_report",
         ":resources",
         ":scoped_file_tracker",
         ":segment_appender",
@@ -447,6 +448,14 @@ redpanda_cc_library(
     deps = [
         "@abseil-cpp//absl/container:btree",
     ],
+)
+
+redpanda_cc_library(
+    name = "recovery_report",
+    hdrs = [
+        "recovery_report.h",
+    ],
+    visibility = ["//visibility:public"],
 )
 
 redpanda_cc_library(

--- a/src/v/storage/BUILD
+++ b/src/v/storage/BUILD
@@ -472,8 +472,11 @@ redpanda_cc_library(
         "@seastar",
     ],
     deps = [
+        ":recovery_report",
         ":segment_appender",
+        "//src/v/container:chunked_hash_map",
         "//src/v/metrics",
+        "//src/v/model",
     ],
 )
 

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -1036,10 +1036,18 @@ ss::future<> log_manager::remove(model::ntp ntp) {
           // If this has happened, clean up all staging files so we can fully
           // remove the NTP directory.
           //
+          // Recovery renames the segment file to .cannotrecover and leaves
+          // its indices under the original name, so .base_index and
+          // .compaction_index are here for the same reason.
+          //
           // TODO: we should more consistently clean up the staging operations
           // to clean up after themselves on failure.
           static constexpr auto suffixes_to_remove = std::to_array(
-            {".staging", ".cannotrecover", ".ignore_have_newer"});
+            {".staging",
+             ".cannotrecover",
+             ".ignore_have_newer",
+             ".base_index",
+             ".compaction_index"});
           const auto should_remove = std::ranges::any_of(
             suffixes_to_remove,
             [&](const auto& v) { return de.name.ends_with(v); });
@@ -1051,7 +1059,17 @@ ss::future<> log_manager::remove(model::ntp ntp) {
               // Log verbosely to make it easier to catch.
               auto file_path = fmt::format("{}/{}", ntp_dir, de.name);
               vlog(stlog.warn, "Leftover file found, removing: {}", file_path);
-              return ss::remove_file(file_path);
+              // directory_walker lets an exception from the callback escape
+              // the walk, which would skip both directory removals below with
+              // the log already out of _logs.
+              return ss::remove_file(file_path).handle_exception(
+                [file_path](const std::exception_ptr& e) {
+                    vlog(
+                      stlog.warn,
+                      "Failed to remove leftover file {}: {}",
+                      file_path,
+                      e);
+                });
           }
           return ss::make_ready_future<>();
       });

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -52,6 +52,7 @@
 #include <seastar/core/with_scheduling_group.hh>
 #include <seastar/coroutine/exception.hh>
 #include <seastar/coroutine/maybe_yield.hh>
+#include <seastar/util/defer.hh>
 #include <seastar/util/file.hh>
 #include <seastar/util/later.hh>
 
@@ -935,6 +936,15 @@ ss::future<ss::shared_ptr<log>> log_manager::do_manage(
     with_cache cache_enabled = cfg.cache_enabled();
     auto ntp_sanitizer_cfg = _config.maybe_get_ntp_sanitizer_config(cfg.ntp());
 
+    recovery_report recovery;
+    // Recovery can throw after it counts a dropped segment, so the counts
+    // reach the probe on the failure path too. A log that fails to open never
+    // enters _logs, so its report stays until a later manage() replaces it.
+    // The files it counted stay on disk as well, since remove() also returns
+    // early without a handle, so the gauge keeps reporting what is there.
+    auto record_recovery = ss::defer([this, ntp = cfg.ntp(), &recovery] {
+        _probe->record_recovery(ntp, recovery);
+    });
     auto segments = co_await recover_segments(
       partition_path(cfg),
       cfg.is_locally_compacted(),
@@ -945,7 +955,8 @@ ss::future<ss::shared_ptr<log>> log_manager::do_manage(
       last_clean_segment,
       _resources,
       _feature_table,
-      std::move(ntp_sanitizer_cfg));
+      std::move(ntp_sanitizer_cfg),
+      &recovery);
 
     auto l = storage::make_disk_backed_log(
       std::move(cfg),
@@ -981,6 +992,8 @@ ss::future<> log_manager::shutdown(model::ntp ntp) {
     if (!handle) {
         co_return;
     }
+    // clean_close() can throw and nothing retries once the log leaves _logs
+    auto forget = ss::defer([this, &ntp] { _probe->forget_recovery(ntp); });
 
     auto close_fut = handle->second->housekeeping_gate.close();
 
@@ -998,6 +1011,9 @@ ss::future<> log_manager::remove(model::ntp ntp) {
     if (!handle) {
         co_return;
     }
+    // the removals below can throw and nothing retries once the log leaves
+    // _logs
+    auto forget = ss::defer([this, &ntp] { _probe->forget_recovery(ntp); });
 
     auto close_fut = handle->second->housekeeping_gate.close();
 

--- a/src/v/storage/log_manager_probe.cc
+++ b/src/v/storage/log_manager_probe.cc
@@ -15,12 +15,59 @@
 
 namespace storage {
 
+void log_manager_probe::record_recovery(
+  const model::ntp& ntp, const recovery_report& r) {
+    if (r.empty()) {
+        forget_recovery(ntp);
+        return;
+    }
+    auto it = _recovery.find(ntp);
+    if (it == _recovery.end()) {
+        _recovery.emplace(ntp, r);
+    } else {
+        subtract_from_recovery_totals(it->second);
+        it->second = r;
+    }
+    add_to_recovery_totals(r);
+}
+
+void log_manager_probe::forget_recovery(const model::ntp& ntp) {
+    auto it = _recovery.find(ntp);
+    if (it == _recovery.end()) {
+        return;
+    }
+    subtract_from_recovery_totals(it->second);
+    _recovery.erase(it);
+}
+
+void log_manager_probe::add_to_recovery_totals(const recovery_report& r) {
+    _recovery_totals.dropped_at_tail += r.dropped_at_tail;
+    _recovery_totals.dropped_mid_log += r.dropped_mid_log;
+    _recovery_totals.dropped_position_unknown += r.dropped_position_unknown;
+}
+
+void log_manager_probe::subtract_from_recovery_totals(
+  const recovery_report& r) {
+    _recovery_totals.dropped_at_tail -= r.dropped_at_tail;
+    _recovery_totals.dropped_mid_log -= r.dropped_mid_log;
+    _recovery_totals.dropped_position_unknown -= r.dropped_position_unknown;
+}
+
 void log_manager_probe::setup_metrics() {
     if (config::shard_local_cfg().disable_metrics()) {
         return;
     }
 
     namespace sm = ss::metrics;
+
+    const auto position_label = sm::label("position");
+    auto at = [&position_label](segment_position p) {
+        return position_label(ss::sstring(to_string_view(p)));
+    };
+    const auto quarantined = sm::description(
+      "Number of segment files on disk that recovery renamed to "
+      ".cannotrecover and dropped from their logs, by where the segment sat "
+      "in its log.");
 
     _metrics.add_group(
       "storage_manager",
@@ -37,6 +84,21 @@ void log_manager_probe::setup_metrics() {
           "housekeeping_log_processed",
           [this] { return _housekeeping_log_processed; },
           sm::description("Number of logs processed by housekeeping")),
+        sm::make_gauge(
+          "recovery_segments_quarantined",
+          [this] { return _recovery_totals.dropped_at_tail; },
+          quarantined,
+          {at(segment_position::tail)}),
+        sm::make_gauge(
+          "recovery_segments_quarantined",
+          [this] { return _recovery_totals.dropped_mid_log; },
+          quarantined,
+          {at(segment_position::mid_log)}),
+        sm::make_gauge(
+          "recovery_segments_quarantined",
+          [this] { return _recovery_totals.dropped_position_unknown; },
+          quarantined,
+          {at(segment_position::unknown)}),
       },
       {},
       {});

--- a/src/v/storage/log_manager_probe.h
+++ b/src/v/storage/log_manager_probe.h
@@ -9,7 +9,10 @@
 
 #pragma once
 
+#include "container/chunked_hash_map.h"
 #include "metrics/metrics.h"
+#include "model/fundamental.h"
+#include "storage/recovery_report.h"
 #include "storage/segment_appender.h"
 
 #include <cstdint>
@@ -35,14 +38,31 @@ public:
     void housekeeping_log_processed() { ++_housekeeping_log_processed; }
     void urgent_gc_run() { ++_urgent_gc_runs; }
 
+    /// Keeps what recovery found for one log, and replaces an earlier report
+    /// for the same log.
+    void record_recovery(const model::ntp&, const recovery_report&);
+
+    /// Drops the report for a log that the shard no longer holds. A log that
+    /// moves to another shard keeps its files on disk, so the shard that
+    /// receives it counts them.
+    void forget_recovery(const model::ntp&);
+
     // Returns shared pointer to segment appender stats for this shard.
     // Segment appenders increment these stats directly.
     segment_appender::stats_ptr get_appender_stats() { return _appender_stats; }
 
 private:
+    void add_to_recovery_totals(const recovery_report&);
+    void subtract_from_recovery_totals(const recovery_report&);
+
     uint32_t _log_count = 0;
     uint64_t _urgent_gc_runs = 0;
     uint64_t _housekeeping_log_processed = 0;
+
+    /// Only the logs that hold at least one `.cannotrecover` file, which is
+    /// usually none of them.
+    chunked_hash_map<model::ntp, recovery_report> _recovery;
+    recovery_report _recovery_totals;
 
     // Segment appender stats (accumulated across all segment appenders on this
     // shard)

--- a/src/v/storage/log_replayer.cc
+++ b/src/v/storage/log_replayer.cc
@@ -69,6 +69,9 @@ public:
             _header = {};
             co_return stop_parser::no;
         }
+        // stop_parser::yes and a clean parse to end of file both leave
+        // parser_errc::none, so record the reason here.
+        _cfg.stop_reason = replay_stop_reason::record_crc_mismatch;
         co_return stop_parser::yes;
     }
 
@@ -91,6 +94,42 @@ private:
     size_t _file_pos_to_end_of_batch{0};
 };
 
+std::string_view to_string_view(replay_stop_reason r) {
+    switch (r) {
+    case replay_stop_reason::end_of_file:
+        return "end_of_file";
+    case replay_stop_reason::zeroed_batch_header:
+        return "zeroed_batch_header";
+    case replay_stop_reason::header_crc_mismatch:
+        return "header_crc_mismatch";
+    case replay_stop_reason::record_crc_mismatch:
+        return "record_crc_mismatch";
+    case replay_stop_reason::truncated_batch:
+        return "truncated_batch";
+    case replay_stop_reason::threw:
+        return "threw";
+    }
+    std::unreachable();
+}
+
+/// Maps the parser's terminal error onto a reason. Only called when no reason
+/// is set yet, so parser_errc::none here means a clean parse to end of file.
+static replay_stop_reason from_parser_errc(parser_errc e) {
+    switch (e) {
+    case parser_errc::fallocated_file_read_zero_bytes_for_header:
+        return replay_stop_reason::zeroed_batch_header;
+    case parser_errc::header_only_crc_missmatch:
+        return replay_stop_reason::header_crc_mismatch;
+    case parser_errc::input_stream_not_enough_bytes:
+    case parser_errc::not_enough_bytes_in_parser_for_one_record:
+        return replay_stop_reason::truncated_batch;
+    case parser_errc::end_of_stream:
+    case parser_errc::none:
+        return replay_stop_reason::end_of_file;
+    }
+    std::unreachable();
+}
+
 // Called in the context of a ss::thread
 log_replayer::checkpoint log_replayer::recover_in_thread() {
     vlog(stlog.debug, "Recovering segment {}", *_seg);
@@ -99,15 +138,22 @@ log_replayer::checkpoint log_replayer::recover_in_thread() {
     auto consumer = std::make_unique<checksumming_consumer>(_seg, _ckpt);
     auto parser = continuous_batch_parser(
       std::move(consumer), std::move(data_stream), true);
+    std::exception_ptr exc;
     try {
         parser.consume().get();
     } catch (...) {
+        exc = std::current_exception();
+    }
+    if (exc) {
         vlog(
           stlog.warn,
           "{} partial recovery to {}, with: {}",
           _seg->reader().filename(),
           _ckpt,
-          std::current_exception());
+          exc);
+        _ckpt.stop_reason = replay_stop_reason::threw;
+    } else if (!_ckpt.stop_reason.has_value()) {
+        _ckpt.stop_reason = from_parser_errc(parser.error());
     }
     parser.close().get();
     return _ckpt;
@@ -116,9 +162,10 @@ log_replayer::checkpoint log_replayer::recover_in_thread() {
 fmt::iterator log_replayer::checkpoint::format_to(fmt::iterator it) const {
     return fmt::format_to(
       it,
-      "{{last_offset: {}, truncate_file_pos: {}}}",
+      "{{last_offset: {}, truncate_file_pos: {}, stop_reason: {}}}",
       last_offset,
-      truncate_file_pos);
+      truncate_file_pos,
+      stop_reason.has_value() ? to_string_view(*stop_reason) : "unset");
 }
 
 } // namespace storage

--- a/src/v/storage/log_replayer.h
+++ b/src/v/storage/log_replayer.h
@@ -20,7 +20,32 @@
 #include <seastar/core/io_queue.hh>
 #include <seastar/util/bool_class.hh>
 
+#include <string_view>
+
 namespace storage {
+
+/// Where replay stopped reading a segment. `checkpoint::operator bool` says
+/// whether the segment held any data, and a full description of an
+/// unrecoverable segment needs both.
+enum class replay_stop_reason {
+    /// Replay read to the end of the file and validated every batch.
+    end_of_file,
+    /// The bytes where a batch header belongs read back as zeros. Two causes
+    /// produce this: a preallocated region that nobody wrote, or corruption
+    /// that zeroed the bytes.
+    zeroed_batch_header,
+    /// A batch header failed the CRC it carries over its own fields.
+    header_crc_mismatch,
+    /// A batch header was intact but the records it covers failed the batch
+    /// CRC.
+    record_crc_mismatch,
+    /// The file ended before the batch did.
+    truncated_batch,
+    /// Replay threw, for example on an input or output error.
+    threw,
+};
+
+std::string_view to_string_view(replay_stop_reason);
 
 class log_replayer {
 public:
@@ -31,6 +56,11 @@ public:
         std::optional<model::offset> last_offset;
         std::optional<size_t> truncate_file_pos;
         std::optional<model::timestamp> last_max_timestamp;
+
+        /// Why replay stopped. `recover_in_thread` sets this before it
+        /// returns.
+        std::optional<replay_stop_reason> stop_reason;
+
         explicit operator bool() const {
             return last_offset && truncate_file_pos && last_max_timestamp;
         }

--- a/src/v/storage/log_replayer.h
+++ b/src/v/storage/log_replayer.h
@@ -45,6 +45,8 @@ enum class replay_stop_reason {
     threw,
 };
 
+/// The name recovery gives an unrecoverable segment file carries this, so a
+/// change here changes a name on disk.
 std::string_view to_string_view(replay_stop_reason);
 
 class log_replayer {

--- a/src/v/storage/recovery_report.h
+++ b/src/v/storage/recovery_report.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <string_view>
+#include <utility>
+
+namespace storage {
+
+/// Where a segment sat in its log when recovery dropped it. Recovery renames
+/// the segment out of the log, so nothing can work this out afterward.
+enum class segment_position {
+    /// No segment that recovery kept or dropped had a higher base offset.
+    tail,
+    /// One of them did, so the offsets this segment claimed sit inside the log.
+    mid_log,
+    /// Nothing recorded the position.
+    unknown,
+};
+
+constexpr std::string_view to_string_view(segment_position p) {
+    switch (p) {
+    case segment_position::tail:
+        return "tail";
+    case segment_position::mid_log:
+        return "mid_log";
+    case segment_position::unknown:
+        return "unknown";
+    }
+    std::unreachable();
+}
+
+/// Counts that recovery collects while it opens one log.
+struct recovery_report {
+    /// Recovery renamed these segments to `.cannotrecover` and dropped them
+    /// from the log, because replay could not validate the first batch. Each
+    /// one had the highest base offset among the segments recovery kept or
+    /// dropped.
+    size_t dropped_at_tail{0};
+
+    // The same for segments whose base offset was not the highest among the
+    // segments recovery kept or dropped. Dropping a segment here can leave the
+    // log with offsets not covered by any segment.
+    size_t dropped_mid_log{0};
+
+    /// The same, where nothing recorded the position.
+    size_t dropped_position_unknown{0};
+
+    size_t& count_at(segment_position p) {
+        switch (p) {
+        case segment_position::tail:
+            return dropped_at_tail;
+        case segment_position::mid_log:
+            return dropped_mid_log;
+        case segment_position::unknown:
+            return dropped_position_unknown;
+        }
+        std::unreachable();
+    }
+
+    bool empty() const {
+        return dropped_at_tail == 0 && dropped_mid_log == 0
+               && dropped_position_unknown == 0;
+    }
+};
+
+} // namespace storage

--- a/src/v/storage/recovery_report.h
+++ b/src/v/storage/recovery_report.h
@@ -28,6 +28,8 @@ enum class segment_position {
     unknown,
 };
 
+/// The name recovery gives an unrecoverable segment file carries this, so a
+/// change here changes a name on disk.
 constexpr std::string_view to_string_view(segment_position p) {
     switch (p) {
     case segment_position::tail:

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -18,6 +18,7 @@
 #include "storage/logger.h"
 #include "storage/segment.h"
 #include "utils/directory_walker.h"
+#include "utils/human.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/loop.hh>
@@ -436,7 +437,16 @@ static ss::future<segment_set> unsafe_do_recover(
                     : std::string_view{"unset"},
                   to_string_view(position),
                   cannotrecover_suffix);
-                vlog(stlog.info, "Unable to recover segment: {}", s);
+                // A drop away from the tail may leave a hole in the log.
+                vlogl(
+                  stlog,
+                  position == segment_position::tail ? ss::log_level::info
+                                                     : ss::log_level::warn,
+                  "Unable to recover {} [{}]. checkpoint: {}. position: {}",
+                  s->reader().filename(),
+                  human::bytes(s->reader().file_size()),
+                  recovered,
+                  to_string_view(position));
                 s->close().get();
                 ss::rename_file(s->reader().filename(), cannotrecover_name)
                   .get();

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -518,6 +518,27 @@ static ss::future<segment_set> do_recover(
         });
 }
 
+/// Reads the position back out of a name that recovery wrote. Names that an
+/// earlier version of redpanda wrote carry no position.
+static segment_position position_from_name(std::string_view name) {
+    if (!name.ends_with(cannotrecover_suffix)) {
+        return segment_position::unknown;
+    }
+    name.remove_suffix(cannotrecover_suffix.size());
+    const auto dot = name.rfind('.');
+    if (dot == std::string_view::npos) {
+        return segment_position::unknown;
+    }
+    const auto token = name.substr(dot + 1);
+    if (token == to_string_view(segment_position::tail)) {
+        return segment_position::tail;
+    }
+    if (token == to_string_view(segment_position::mid_log)) {
+        return segment_position::mid_log;
+    }
+    return segment_position::unknown;
+}
+
 /**
  * \brief Open all segments in a directory.
  *
@@ -532,7 +553,8 @@ static ss::future<segment_set::underlying_t> open_segments(
   unsigned read_ahead,
   storage_resources& resources,
   ss::sharded<features::feature_table>& feature_table,
-  const std::optional<ntp_sanitizer_config>& ntp_sanitizer_config) {
+  const std::optional<ntp_sanitizer_config>& ntp_sanitizer_config,
+  recovery_report* report) {
     using segs_type = segment_set::underlying_t;
     return ss::do_with(
       segs_type{},
@@ -542,6 +564,7 @@ static ss::future<segment_set::underlying_t> open_segments(
        ntp_sanitizer_config,
        buf_size,
        read_ahead,
+       report,
        &resources,
        &feature_table](segs_type& segs) {
           auto f = directory_walker::walk(
@@ -553,6 +576,7 @@ static ss::future<segment_set::underlying_t> open_segments(
              &segs,
              buf_size,
              read_ahead,
+             report,
              &resources,
              &feature_table](ss::directory_entry seg) {
                 // abort if requested
@@ -570,6 +594,13 @@ static ss::future<segment_set::underlying_t> open_segments(
                 auto path = segment_full_path::parse(ppath, seg.name);
                 if (!path) {
                     // This is normal, we skip non-log files like indices
+                    if (
+                      report != nullptr
+                      && seg.name.ends_with(cannotrecover_suffix)) {
+                        // A segment that an earlier recovery dropped. It stays
+                        // on disk until the partition goes away.
+                        ++report->count_at(position_from_name(seg.name));
+                    }
                     return ss::make_ready_future<>();
                 }
 
@@ -615,6 +646,7 @@ ss::future<segment_set> recover_segments(
              ntp_sanitizer_config,
              read_buf_size,
              read_readahead_count,
+             report,
              &resources,
              &feature_table] {
           return open_segments(
@@ -625,7 +657,8 @@ ss::future<segment_set> recover_segments(
             read_readahead_count,
             resources,
             feature_table,
-            ntp_sanitizer_config);
+            ntp_sanitizer_config,
+            report);
       })
       .then([&as,
              report,

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -31,6 +31,11 @@
 #include <exception>
 
 namespace storage {
+
+/// Recovery appends this to the name of a segment it drops, and the name keeps
+/// it last so that a match on it still finds the file.
+static constexpr std::string_view cannotrecover_suffix = ".cannotrecover";
+
 struct segment_ordering {
     using type = ss::lw_shared_ptr<segment>;
     bool operator()(const type& seg1, const type& seg2) const {
@@ -423,11 +428,17 @@ static ss::future<segment_set> unsafe_do_recover(
                 if (report != nullptr) {
                     ++report->count_at(position);
                 }
+                const auto cannotrecover_name = fmt::format(
+                  "{}.{}.{}{}",
+                  s->reader().filename(),
+                  recovered.stop_reason.has_value()
+                    ? to_string_view(*recovered.stop_reason)
+                    : std::string_view{"unset"},
+                  to_string_view(position),
+                  cannotrecover_suffix);
                 vlog(stlog.info, "Unable to recover segment: {}", s);
                 s->close().get();
-                ss::rename_file(
-                  s->reader().filename(),
-                  s->reader().filename() + ".cannotrecover")
+                ss::rename_file(s->reader().filename(), cannotrecover_name)
                   .get();
                 continue;
             }

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -268,10 +268,12 @@ maybe_create_contiguous_segment_set(segment_set::underlying_t segs) {
 static ss::future<segment_set> unsafe_do_recover(
   segment_set&& segments,
   std::optional<ss::sstring> last_clean_segment,
-  ss::abort_source& as) {
+  ss::abort_source& as,
+  recovery_report* report) {
     return ss::async([segments = std::move(segments),
                       last_clean_segment = std::move(last_clean_segment),
-                      &as]() mutable {
+                      &as,
+                      report]() mutable {
         if (segments.empty() || as.abort_requested()) {
             return std::move(segments);
         }
@@ -383,6 +385,18 @@ static ss::future<segment_set> unsafe_do_recover(
             good.pop_back();
         }
 
+        // A segment's filename carries its base offset, so recovery knows its
+        // position even when replay reads nothing out of the file. Both sets
+        // are sorted by ascending base offset, so the maximum is at the back.
+        auto max_base_offset = model::offset::min();
+        if (!good.empty()) {
+            max_base_offset = good.back()->offsets().get_base_offset();
+        }
+        if (!to_recover.empty()) {
+            max_base_offset = std::max(
+              max_base_offset, to_recover.back()->offsets().get_base_offset());
+        }
+
         for (auto& s : to_recover) {
             // check for abort
             if (unlikely(as.abort_requested())) {
@@ -402,6 +416,13 @@ static ss::future<segment_set> unsafe_do_recover(
             auto replayer = log_replayer(*s);
             auto recovered = replayer.recover_in_thread();
             if (!recovered) {
+                const auto position = s->offsets().get_base_offset()
+                                          == max_base_offset
+                                        ? segment_position::tail
+                                        : segment_position::mid_log;
+                if (report != nullptr) {
+                    ++report->count_at(position);
+                }
                 vlog(stlog.info, "Unable to recover segment: {}", s);
                 s->close().get();
                 ss::rename_file(
@@ -442,7 +463,8 @@ static ss::future<segment_set> unsafe_do_recover(
 static ss::future<segment_set> do_recover(
   segment_set&& segments,
   std::optional<ss::sstring> last_clean_segment,
-  ss::abort_source& as) {
+  ss::abort_source& as,
+  recovery_report* report) {
     // light-weight copy used for clean-up if recovery fails
     segment_set::underlying_t copy;
     std::copy(segments.cbegin(), segments.cend(), std::back_inserter(copy));
@@ -453,7 +475,8 @@ static ss::future<segment_set> do_recover(
     // are any pending io operations on a file associated with the segment
     // at the time of destruction seastar will complain about the file handle
     // being destroyed with pending ops.
-    return unsafe_do_recover(std::move(segments), last_clean_segment, as)
+    return unsafe_do_recover(
+             std::move(segments), last_clean_segment, as, report)
       .handle_exception(
         [copy = std::move(copy)](const std::exception_ptr& ex) mutable {
             return ss::do_with(
@@ -562,7 +585,8 @@ ss::future<segment_set> recover_segments(
   std::optional<ss::sstring> last_clean_segment,
   storage_resources& resources,
   ss::sharded<features::feature_table>& feature_table,
-  std::optional<ntp_sanitizer_config> ntp_sanitizer_config) {
+  std::optional<ntp_sanitizer_config> ntp_sanitizer_config,
+  recovery_report* report) {
     return ss::recursive_touch_directory(ss::sstring(path))
       .then([&as,
              path,
@@ -583,6 +607,7 @@ ss::future<segment_set> recover_segments(
             ntp_sanitizer_config);
       })
       .then([&as,
+             report,
              is_compaction_enabled,
              last_clean_segment = std::move(last_clean_segment)](
               segment_set::underlying_t segs) {
@@ -594,7 +619,8 @@ ss::future<segment_set> recover_segments(
                   s->mark_as_compacted_segment();
               }
           }
-          return do_recover(std::move(segments), last_clean_segment, as);
+          return do_recover(
+            std::move(segments), last_clean_segment, as, report);
       });
 }
 

--- a/src/v/storage/segment_set.h
+++ b/src/v/storage/segment_set.h
@@ -17,6 +17,7 @@
 #include "storage/file_sanitizer_types.h"
 #include "storage/fs_utils.h"
 #include "storage/fwd.h"
+#include "storage/recovery_report.h"
 #include "storage/segment.h"
 
 #include <seastar/core/sharded.hh>
@@ -112,7 +113,8 @@ ss::future<segment_set> recover_segments(
   std::optional<ss::sstring> last_clean_segment,
   storage_resources&,
   ss::sharded<features::feature_table>& feature_table,
-  std::optional<ntp_sanitizer_config> ntp_sanitizer_config);
+  std::optional<ntp_sanitizer_config> ntp_sanitizer_config,
+  recovery_report* report = nullptr);
 
 // Attempts to create a contiguous & non-overlapping `segment_set` from those
 // provided after recovery is performed. `segs` are first sorted in ascending

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -228,6 +228,7 @@ redpanda_cc_gtest(
         "//src/v/storage:record_batch_utils",
         "//src/v/storage:segment_appender",
         "//src/v/test_utils:gtest",
+        "//src/v/test_utils:metrics",
         "//src/v/test_utils:random_bytes",
         "//src/v/test_utils:test_env",
         "@googletest//:gtest",

--- a/src/v/storage/tests/log_manager_test.cc
+++ b/src/v/storage/tests/log_manager_test.cc
@@ -167,7 +167,49 @@ TEST_F(LogManagerTest, test_can_load_logs) {
     EXPECT_TRUE(file_exists(seg3->reader().filename()).get());
     EXPECT_FALSE(file_exists(seg4->reader().filename()).get());
     EXPECT_TRUE(
-      file_exists(seg4->reader().filename() + ".cannotrecover").get());
+      file_exists(
+        seg4->reader().filename() + ".header_crc_mismatch.tail.cannotrecover")
+        .get());
+}
+
+TEST_F(
+  LogManagerTest, test_unrecoverable_segment_name_carries_reason_and_position) {
+    auto& m = log_mgr();
+
+    auto ntp = config_from_ntp(model::ntp("ns-zeroed", "topic-1", 0));
+    directories::initialize(ntp.work_directory()).get();
+
+    auto seg = m.make_log_segment(
+                  ntp,
+                  model::offset(2),
+                  model::term_id(1),
+                  default_segment_readahead_size,
+                  default_segment_readahead_count,
+                  0)
+                 .get();
+    const ss::sstring log_path = seg->reader().filename();
+    seg->close().get();
+
+    // Simulate a situation where a segment was fallocated but never written
+    // to before a crash. That is, a segment with non-zero file size that is
+    // all zeros. A clean segment close would have trimmed the preallocated
+    // tail.
+    {
+        auto f = ss::open_file_dma(log_path, ss::open_flags::rw).get();
+        f.truncate(4096).get();
+        f.close().get();
+    }
+
+    auto log = m.manage(config_from_ntp(ntp.ntp())).get();
+    log->stm_hookset()->start();
+    auto stop_stm = ss::defer([&log] { log->stm_hookset()->stop(); });
+
+    // Replay stops at the first batch header, and the only segment in the log
+    // is also the highest, so the name reports both.
+    EXPECT_EQ(log->segment_count(), 0);
+    EXPECT_FALSE(file_exists(log_path).get());
+    EXPECT_TRUE(
+      file_exists(log_path + ".zeroed_batch_header.tail.cannotrecover").get());
 }
 
 TEST_F(

--- a/src/v/storage/tests/log_manager_test.cc
+++ b/src/v/storage/tests/log_manager_test.cc
@@ -17,6 +17,7 @@
 #include "storage/segment_appender.h"
 #include "storage/segment_reader.h"
 #include "storage/segment_set.h"
+#include "test_utils/metrics.h"
 #include "test_utils/random_bytes.h"
 
 #include <seastar/core/abort_source.hh>
@@ -45,6 +46,18 @@ void write_batches(ss::lw_shared_ptr<segment> seg) {
         (void)seg->append(std::move(b)).get();
     }
     seg->flush().get();
+}
+
+/// Writes an empty file with the name a previous recovery would have given a
+/// segment it dropped.
+ss::sstring
+stage_quarantined_file(const ntp_config& ntp, const ss::sstring& name) {
+    auto path = ssx::sformat("{}/{}", ntp.work_directory(), name);
+    ss::open_file_dma(path, ss::open_flags::create | ss::open_flags::rw)
+      .get()
+      .close()
+      .get();
+    return path;
 }
 
 inline ss::sstring test_directory() {
@@ -97,6 +110,15 @@ public:
     log_manager& log_mgr() { return _store->log_mgr(); }
     ss::sharded<features::feature_table>& feature_table() {
         return _feature_table;
+    }
+
+    /// Reads the gauge back out, so the assertions cover the label as well as
+    /// the count.
+    static std::optional<uint64_t> quarantined(segment_position p) {
+        return test_utils::find_metric_value<uint64_t>(
+          "storage_manager_recovery_segments_quarantined",
+          ss::metrics::default_handle(),
+          {{"position", ss::sstring(to_string_view(p))}});
     }
 
 private:
@@ -274,4 +296,92 @@ TEST_F(
         EXPECT_EQ(report.dropped_mid_log, 0);
         EXPECT_EQ(report.dropped_at_tail, 1);
     }
+}
+
+TEST_F(LogManagerTest, test_recovery_counts_the_files_an_earlier_run_dropped) {
+    auto& m = log_mgr();
+
+    auto ntp = config_from_ntp(model::ntp("ns-quarantined", "topic-1", 0));
+    directories::initialize(ntp.work_directory()).get();
+
+    // Three names that recovery writes, and one from a version that recorded
+    // no position.
+    for (const auto* name :
+         {"0-1-v1.log.zeroed_batch_header.tail.cannotrecover",
+          "100-1-v1.log.header_crc_mismatch.mid_log.cannotrecover",
+          "200-1-v1.log.record_crc_mismatch.mid_log.cannotrecover",
+          "300-1-v1.log.cannotrecover"}) {
+        stage_quarantined_file(ntp, name);
+    }
+
+    ss::abort_source as;
+    recovery_report report;
+    auto segments = recover_segments(
+                      partition_path(ntp),
+                      /*is_compaction_enabled=*/false,
+                      [] { return std::nullopt; },
+                      as,
+                      default_segment_readahead_size,
+                      default_segment_readahead_count,
+                      std::nullopt,
+                      m.resources(),
+                      feature_table(),
+                      std::nullopt,
+                      &report)
+                      .get();
+
+    // None of them is a segment of the log any more, and the position comes
+    // back out of the name.
+    EXPECT_EQ(segments.size(), 0);
+    EXPECT_EQ(report.dropped_at_tail, 1);
+    EXPECT_EQ(report.dropped_mid_log, 2);
+    EXPECT_EQ(report.dropped_position_unknown, 1);
+}
+
+TEST_F(LogManagerTest, test_removing_a_log_stops_reporting_its_files) {
+    auto& m = log_mgr();
+
+    auto ntp = config_from_ntp(model::ntp("ns-forget-remove", "topic-1", 0));
+    directories::initialize(ntp.work_directory()).get();
+    const auto path = stage_quarantined_file(
+      ntp, "0-1-v1.log.header_crc_mismatch.mid_log.cannotrecover");
+
+    // Other tests in this binary leave files of their own behind, so read the
+    // gauge as a delta.
+    const auto before = quarantined(segment_position::mid_log);
+    ASSERT_TRUE(before.has_value());
+
+    auto log = m.manage(config_from_ntp(ntp.ntp())).get();
+    log->stm_hookset()->start();
+    log->stm_hookset()->stop();
+    ASSERT_EQ(quarantined(segment_position::mid_log), *before + 1);
+
+    // remove() deletes the directory, so the file goes with it.
+    m.remove(ntp.ntp()).get();
+    EXPECT_EQ(quarantined(segment_position::mid_log), before);
+    EXPECT_FALSE(ss::file_exists(path).get());
+}
+
+TEST_F(LogManagerTest, test_shutting_down_a_log_stops_reporting_its_files) {
+    auto& m = log_mgr();
+
+    auto ntp = config_from_ntp(model::ntp("ns-forget-shutdown", "topic-1", 0));
+    directories::initialize(ntp.work_directory()).get();
+    const auto path = stage_quarantined_file(
+      ntp, "0-1-v1.log.header_crc_mismatch.mid_log.cannotrecover");
+
+    const auto before = quarantined(segment_position::mid_log);
+    ASSERT_TRUE(before.has_value());
+
+    auto log = m.manage(config_from_ntp(ntp.ntp())).get();
+    log->stm_hookset()->start();
+    log->stm_hookset()->stop();
+    ASSERT_EQ(quarantined(segment_position::mid_log), *before + 1);
+
+    // shutdown() hands the log off to another shard and leaves the file where
+    // it is, so this shard stops reporting a file that is still on disk. The
+    // shard that takes the log walks the directory and reports it instead.
+    m.shutdown(ntp.ntp()).get();
+    EXPECT_EQ(quarantined(segment_position::mid_log), before);
+    EXPECT_TRUE(ss::file_exists(path).get());
 }

--- a/src/v/storage/tests/log_manager_test.cc
+++ b/src/v/storage/tests/log_manager_test.cc
@@ -12,13 +12,18 @@
 #include "model/tests/random_batch.h"
 #include "storage/api.h"
 #include "storage/directories.h"
+#include "storage/fs_utils.h"
 #include "storage/segment.h"
 #include "storage/segment_appender.h"
 #include "storage/segment_reader.h"
+#include "storage/segment_set.h"
 #include "test_utils/random_bytes.h"
 
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/seastar.hh>
 #include <seastar/util/defer.hh>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 using namespace std::chrono_literals; // NOLINT
@@ -62,33 +67,45 @@ ntp_config config_from_ntp(const model::ntp& ntp) {
 constexpr size_t default_segment_readahead_size = 128 * 1024;
 constexpr unsigned default_segment_readahead_count = 10;
 
-TEST(LogManagerTest, test_can_load_logs) {
-    auto conf = make_config();
+class LogManagerTest : public ::testing::Test {
+public:
+    LogManagerTest() {
+        _feature_table.start().get();
+        _feature_table
+          .invoke_on_all(
+            [](features::feature_table& f) { f.testing_activate_all(); })
+          .get();
+        auto conf = make_config();
+        _store = std::make_unique<storage::api>(
+          [conf]() {
+              return storage::kvstore_config(
+                1_MiB,
+                config::mock_binding(10ms),
+                conf.base_dir,
+                storage::make_sanitized_file_config());
+          },
+          [conf]() { return conf; },
+          _feature_table);
+        _store->start().get();
+    }
 
-    ss::logger test_logger("test-logger");
-    ss::sharded<features::feature_table> feature_table;
-    feature_table.start().get();
-    feature_table
-      .invoke_on_all(
-        [](features::feature_table& f) { f.testing_activate_all(); })
-      .get();
+    ~LogManagerTest() override {
+        _store->stop().get();
+        _feature_table.stop().get();
+    }
 
-    storage::api store(
-      [conf]() {
-          return storage::kvstore_config(
-            1_MiB,
-            config::mock_binding(10ms),
-            conf.base_dir,
-            storage::make_sanitized_file_config());
-      },
-      [conf]() { return conf; },
-      feature_table);
-    store.start().get();
-    auto stop_kvstore = ss::defer([&store, &feature_table] {
-        store.stop().get();
-        feature_table.stop().get();
-    });
-    auto& m = store.log_mgr();
+    log_manager& log_mgr() { return _store->log_mgr(); }
+    ss::sharded<features::feature_table>& feature_table() {
+        return _feature_table;
+    }
+
+private:
+    ss::sharded<features::feature_table> _feature_table;
+    std::unique_ptr<storage::api> _store;
+};
+
+TEST_F(LogManagerTest, test_can_load_logs) {
+    auto& m = log_mgr();
     std::vector<storage::ntp_config> ntps;
     ntps.reserve(4);
     for (size_t i = 0; i < 4; ++i) {

--- a/src/v/storage/tests/log_manager_test.cc
+++ b/src/v/storage/tests/log_manager_test.cc
@@ -338,6 +338,54 @@ TEST_F(LogManagerTest, test_recovery_counts_the_files_an_earlier_run_dropped) {
     EXPECT_EQ(report.dropped_position_unknown, 1);
 }
 
+TEST_F(LogManagerTest, test_removal_sweeps_past_an_entry_it_cannot_remove) {
+    auto& m = log_mgr();
+
+    auto ntp = config_from_ntp(model::ntp("ns-sweep-error", "topic-1", 0));
+    directories::initialize(ntp.work_directory()).get();
+
+    auto seg = m.make_log_segment(
+                  ntp,
+                  model::offset(2),
+                  model::term_id(1),
+                  default_segment_readahead_size,
+                  default_segment_readahead_count,
+                  1_MiB)
+                 .get();
+    write_garbage(seg->appender());
+    seg->close().get();
+    const ss::sstring log_path = seg->reader().filename();
+    const ss::sstring index_path = seg->index().path().string();
+
+    auto log = m.manage(config_from_ntp(ntp.ntp())).get();
+    log->stm_hookset()->start();
+    log->stm_hookset()->stop();
+    ASSERT_TRUE(
+      ss::file_exists(log_path + ".header_crc_mismatch.tail.cannotrecover")
+        .get());
+    ASSERT_TRUE(ss::file_exists(index_path).get());
+
+    // The sweep tries to remove this, because the name ends in .base_index,
+    // and ::remove() is rmdir for a directory, so a non-empty one fails.
+    const auto blocker = std::filesystem::path(ntp.work_directory())
+                         / "0-1-v1.base_index";
+    ss::recursive_touch_directory((blocker / "occupant").string()).get();
+
+    // The subdirectory keeps the partition directory itself, so the removal
+    // still fails. The path it fails on is what this asserts: the sweep reaches
+    // the end and the directory removal reports, so the error names the
+    // partition directory and not the subdirectory.
+    EXPECT_THAT(
+      [&] { m.remove(ntp.ntp()).get(); },
+      testing::Throws<std::filesystem::filesystem_error>(testing::Property(
+        &std::filesystem::filesystem_error::path1,
+        std::filesystem::path(ntp.work_directory()))));
+    EXPECT_FALSE(
+      ss::file_exists(log_path + ".header_crc_mismatch.tail.cannotrecover")
+        .get());
+    EXPECT_FALSE(ss::file_exists(index_path).get());
+}
+
 TEST_F(LogManagerTest, test_removing_a_log_stops_reporting_its_files) {
     auto& m = log_mgr();
 
@@ -384,4 +432,53 @@ TEST_F(LogManagerTest, test_shutting_down_a_log_stops_reporting_its_files) {
     m.shutdown(ntp.ntp()).get();
     EXPECT_EQ(quarantined(segment_position::mid_log), before);
     EXPECT_TRUE(ss::file_exists(path).get());
+}
+
+TEST_F(LogManagerTest, test_removal_sweeps_a_stranded_index) {
+    auto& m = log_mgr();
+
+    auto ntp = config_from_ntp(model::ntp("ns-orphan-index", "topic-1", 0));
+    directories::initialize(ntp.work_directory()).get();
+
+    auto seg = m.make_log_segment(
+                  ntp,
+                  model::offset(2),
+                  model::term_id(1),
+                  default_segment_readahead_size,
+                  default_segment_readahead_count,
+                  1_MiB)
+                 .get();
+    write_garbage(seg->appender());
+    seg->close().get();
+    const ss::sstring log_path = seg->reader().filename();
+    const ss::sstring index_path = seg->index().path().string();
+    const ss::sstring compaction_index_path
+      = seg->reader().path().to_compacted_index().string();
+
+    // A segment on a compacted topic carries a compaction index alongside its
+    // offset index, and recovery strands both.
+    ss::open_file_dma(
+      compaction_index_path, ss::open_flags::create | ss::open_flags::rw)
+      .get()
+      .close()
+      .get();
+
+    auto log = m.manage(config_from_ntp(ntp.ntp())).get();
+    log->stm_hookset()->start();
+    log->stm_hookset()->stop();
+
+    // Recovery renamed the log file to .cannotrecover and left its indices
+    // under the original name. materialize_index() opens with create, so every
+    // segment that recovery reads has an offset index on disk by this point.
+    EXPECT_TRUE(
+      ss::file_exists(log_path + ".header_crc_mismatch.tail.cannotrecover")
+        .get());
+    EXPECT_TRUE(ss::file_exists(index_path).get());
+    EXPECT_TRUE(ss::file_exists(compaction_index_path).get());
+
+    // Removing the partition has to sweep both indices. Otherwise the
+    // directory removal fails with ENOTEMPTY, and the retry returns early and
+    // leaves the directory on disk.
+    m.remove(ntp.ntp()).get();
+    EXPECT_FALSE(ss::file_exists(ntp.work_directory()).get());
 }

--- a/src/v/storage/tests/log_manager_test.cc
+++ b/src/v/storage/tests/log_manager_test.cc
@@ -169,3 +169,67 @@ TEST_F(LogManagerTest, test_can_load_logs) {
     EXPECT_TRUE(
       file_exists(seg4->reader().filename() + ".cannotrecover").get());
 }
+
+TEST_F(
+  LogManagerTest, test_recovery_counts_a_mid_log_drop_apart_from_the_last) {
+    auto& m = log_mgr();
+
+    // Builds a two-segment log with garbage in one of them and recovers it.
+    // manage() keeps the recovery_report to itself, so this calls
+    // recover_segments directly.
+    auto recover = [&](const ss::sstring& ns, model::offset garbage_at) {
+        auto ntp = config_from_ntp(model::ntp(ns, "topic-1", 0));
+        directories::initialize(ntp.work_directory()).get();
+        for (auto base : {model::offset(0), model::offset(100)}) {
+            auto seg = m.make_log_segment(
+                          ntp,
+                          base,
+                          model::term_id(1),
+                          default_segment_readahead_size,
+                          default_segment_readahead_count,
+                          1_MiB)
+                         .get();
+            if (base == garbage_at) {
+                write_garbage(seg->appender());
+            } else {
+                write_batches(seg);
+            }
+            seg->close().get();
+        }
+        ss::abort_source as;
+        recovery_report report;
+        auto segments = recover_segments(
+                          partition_path(ntp),
+                          /*is_compaction_enabled=*/false,
+                          [] { return std::nullopt; },
+                          as,
+                          default_segment_readahead_size,
+                          default_segment_readahead_count,
+                          std::nullopt,
+                          m.resources(),
+                          feature_table(),
+                          std::nullopt,
+                          &report)
+                          .get();
+        for (auto& s : segments) {
+            s->close().get();
+        }
+        return report;
+    };
+
+    {
+        // Garbage in the older segment. The newer segment has a higher base
+        // offset, so the offsets the dropped segment claimed sit inside the
+        // log.
+        auto report = recover("ns-mid-log", model::offset(0));
+        EXPECT_EQ(report.dropped_mid_log, 1);
+        EXPECT_EQ(report.dropped_at_tail, 0);
+    }
+    {
+        // Garbage in the newer segment, which is the shape an unclean stop
+        // leaves on the segment that was open at the time.
+        auto report = recover("ns-last", model::offset(100));
+        EXPECT_EQ(report.dropped_mid_log, 0);
+        EXPECT_EQ(report.dropped_at_tail, 1);
+    }
+}

--- a/src/v/storage/tests/log_replayer_test.cc
+++ b/src/v/storage/tests/log_replayer_test.cc
@@ -97,6 +97,24 @@ public:
 
     void write_garbage_index() { do_write_garbage(base_name + ".index"); }
 
+    /// Builds the on-disk shape of a preallocated region that nobody wrote:
+    /// the file has a non-zero size and reads back as zeros from position 0.
+    void write_zeros(size_t n) {
+        auto fd = ss::open_file_dma(
+                    base_name, ss::open_flags::create | ss::open_flags::rw)
+                    .get();
+        fd = ss::file(
+          ss::make_shared(file_io_sanitizer(
+            std::move(fd),
+            std::filesystem::path{base_name},
+            ntp_sanitizer_config{.sanitize_only = true})));
+        auto out = ss::make_file_output_stream(std::move(fd)).get();
+        const std::vector<char> zeros(n, 0);
+        out.write(zeros.data(), zeros.size()).get();
+        out.flush().get();
+        out.close().get();
+    }
+
     void do_write_garbage(ss::sstring name) {
         auto fd = ss::open_file_dma(
                     name, ss::open_flags::create | ss::open_flags::rw)
@@ -145,9 +163,12 @@ TEST(log_replayer_test, test_can_recover_single_batch) {
       = ctx.replayer().recover_in_thread();
     ASSERT_TRUE(bool(recovered));
     EXPECT_EQ(recovered.last_offset.value(), last_offset);
+    EXPECT_EQ(recovered.stop_reason, storage::replay_stop_reason::end_of_file);
 }
 
 TEST(log_replayer_test, test_unrecovered_single_batch) {
+    // write() recomputes the header's own CRC, so both mutations leave it
+    // valid. The header parses and the batch's record CRC fails.
     {
         log_replayer_fixture ctx;
         auto batches
@@ -156,6 +177,9 @@ TEST(log_replayer_test, test_unrecovered_single_batch) {
         ctx.write(batches);
         auto recovered = ctx.replayer().recover_in_thread();
         EXPECT_FALSE(bool(recovered));
+        EXPECT_EQ(
+          recovered.stop_reason,
+          storage::replay_stop_reason::record_crc_mismatch);
     }
     {
         log_replayer_fixture ctx;
@@ -165,6 +189,9 @@ TEST(log_replayer_test, test_unrecovered_single_batch) {
         ctx.write(batches);
         auto recovered = ctx.replayer().recover_in_thread();
         EXPECT_FALSE(bool(recovered));
+        EXPECT_EQ(
+          recovered.stop_reason,
+          storage::replay_stop_reason::record_crc_mismatch);
     }
 }
 
@@ -174,6 +201,42 @@ TEST(log_replayer_test, test_malformed_segment) {
     ctx.initialize(model::offset(0));
     auto recovered = ctx.replayer().recover_in_thread();
     EXPECT_FALSE(bool(recovered));
+    EXPECT_EQ(
+      recovered.stop_reason, storage::replay_stop_reason::header_crc_mismatch);
+}
+
+TEST(log_replayer_test, test_zeroed_batch_header_is_not_a_verdict) {
+    // Both cases report the same reason, so a caller cannot read the reason
+    // as a verdict on the contents.
+    {
+        // A preallocated region that nobody wrote.
+        log_replayer_fixture ctx;
+        ctx.write_zeros(4096);
+        ctx.initialize(model::offset(0));
+        auto recovered = ctx.replayer().recover_in_thread();
+        EXPECT_FALSE(bool(recovered));
+        EXPECT_EQ(
+          recovered.stop_reason,
+          storage::replay_stop_reason::zeroed_batch_header);
+    }
+    {
+        // Batches, then preallocated space: the shape of the segment that
+        // was open when the process died. Replay recovers it and reports the
+        // same stopping point.
+        log_replayer_fixture ctx;
+        auto batches
+          = model::test::make_random_batches(model::offset(1), 2).get();
+        auto last_offset = batches.back().last_offset();
+        ctx.write(batches);
+        ctx._seg->reader().set_file_size(
+          ctx._seg->appender().file_byte_offset() + 4096);
+        auto recovered = ctx.replayer().recover_in_thread();
+        ASSERT_TRUE(bool(recovered));
+        EXPECT_EQ(recovered.last_offset.value(), last_offset);
+        EXPECT_EQ(
+          recovered.stop_reason,
+          storage::replay_stop_reason::zeroed_batch_header);
+    }
 }
 
 TEST(log_replayer_test, test_can_recover_multiple_batches) {


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

A .cannotrecover file is a segment that failed startup recovery. The presence of these is a consistent source of confusion for support engineers. 

This PR adds some new metrics, naming, and logging around unrecoverable segments.

  - gauge for unrecoverable segments on disk, labelled by whether the segment was the tail of its log at recovery time (tail, mid_log, or unknown for files an older version left behind)
    - counted during the open_segments directory walk during recovery
  - try to surface a reason we couldn't recover the segment (not enough bytes, zero header, crc error, etc.)
  - put the reason and the position in the filename: `<segment>.<stop_reason>.<tail|mid_log>.cannotrecover`, so both are still there after the log line that reported them rotates away
  - in addition to the filename, log the size on disk, `log_replayer` checkpoint (incl the stop reason), and where the segment sat in the log
    - for non-tail segments, log at warn, otherwise keep logging at info as before.

  The idea here is to give a bit more signal to support or oncallers trying to determine whether 
  cannotrecover files might indicate data loss, where to look, etc.

  Also adds some code to clean up previously orphaned index files from unrecoverable segments that 
  could otherwise prevent partition removal from fully removing partition directories. Covers .base_index 
  and .compaction_index, plus the compaction staging variant of each.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [ ] v25.3.x

## Release Notes

### Improvements

* Improves observability and logging around unrecoverable segments.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
