### PR TITLE
rpk/connect: don't cap version segments at two digits in VersionFromString

### DIFF
--- a/src/go/rpk/pkg/redpanda/version.go
+++ b/src/go/rpk/pkg/redpanda/version.go
@@ -26,11 +26,21 @@ func VersionFromString(s string) (Version, error) {
 		return Version{}, fmt.Errorf("unable to get the redpanda version from %q", s)
 	}
 
-	// We can safely ignore the errors since we are making sure in the regexp
-	// that we match digits only.
-	y, _ := strconv.Atoi(vMatch[1])
-	f, _ := strconv.Atoi(vMatch[2])
-	p, _ := strconv.Atoi(vMatch[3])
+	// The regexp guarantees each group is digits-only, but no longer bounds
+	// how many: an implausibly long segment can still overflow int, so check
+	// the conversion instead of ignoring its error.
+	y, err := strconv.Atoi(vMatch[1])
+	if err != nil {
+		return Version{}, fmt.Errorf("unable to parse major version from %q: %v", s, err)
+	}
+	f, err := strconv.Atoi(vMatch[2])
+	if err != nil {
+		return Version{}, fmt.Errorf("unable to parse feature version from %q: %v", s, err)
+	}
+	p, err := strconv.Atoi(vMatch[3])
+	if err != nil {
+		return Version{}, fmt.Errorf("unable to parse patch version from %q: %v", s, err)
+	}
 	return Version{y, f, p}, nil
 }
 

--- a/src/go/rpk/pkg/redpanda/version.go
+++ b/src/go/rpk/pkg/redpanda/version.go
@@ -20,7 +20,7 @@ func VersionFromString(s string) (Version, error) {
 	//   - index 1: the Major
 	//   - index 2: the Feature
 	//   - index 3: the Patch
-	vMatch := regexp.MustCompile(`^v?(\d{1,2})\.(\d{1,2})\.(\d{1,2})(?:\s|-rc\d{1,2}|-dev|-nightly|$)`).FindStringSubmatch(s)
+	vMatch := regexp.MustCompile(`^v?(\d+)\.(\d+)\.(\d+)(?:\s|-rc\d+|-dev|-nightly|$)`).FindStringSubmatch(s)
 
 	if len(vMatch) == 0 {
 		return Version{}, fmt.Errorf("unable to get the redpanda version from %q", s)

--- a/src/go/rpk/pkg/redpanda/version_test.go
+++ b/src/go/rpk/pkg/redpanda/version_test.go
@@ -26,9 +26,12 @@ func TestVersionFromString(t *testing.T) {
 		{name: "nightly build", in: "v26.1.0-nightly", exp: Version{26, 1, 0}},
 		{name: "incomplete", in: "22.3", expErr: true},
 		{name: "random string", in: "random", expErr: true},
-		{name: "3 digits year", in: "v222.11.1", expErr: true},
-		{name: "3 digits feature", in: "v11.222.1", expErr: true},
-		{name: "3 digits patch", in: "v11.11.223", expErr: true},
+		{name: "3 digits year", in: "v222.11.1", exp: Version{222, 11, 1}},
+		{name: "3 digits feature", in: "v11.222.1", exp: Version{11, 222, 1}},
+		{name: "3 digits patch", in: "v11.11.223", exp: Version{11, 11, 223}},
+		{name: "3 digit feature, real Connect version", in: "4.103.1", exp: Version{4, 103, 1}},
+		{name: "3 digit feature with rc", in: "4.100.0-rc1", exp: Version{4, 100, 0}},
+		{name: "3 digit feature with text", in: "4.103.1 - 9eefb907c43bf1cfeb0783808c224385c857c0d4-dirty", exp: Version{4, 103, 1}},
 		{name: "non-digit version", in: "AB.C.D", expErr: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/src/go/rpk/pkg/redpanda/version_test.go
+++ b/src/go/rpk/pkg/redpanda/version_test.go
@@ -33,6 +33,7 @@ func TestVersionFromString(t *testing.T) {
 		{name: "3 digit feature with rc", in: "4.100.0-rc1", exp: Version{4, 100, 0}},
 		{name: "3 digit feature with text", in: "4.103.1 - 9eefb907c43bf1cfeb0783808c224385c857c0d4-dirty", exp: Version{4, 103, 1}},
 		{name: "non-digit version", in: "AB.C.D", expErr: true},
+		{name: "segment overflows int", in: "4.99999999999999999999.0", expErr: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := VersionFromString(test.in)


### PR DESCRIPTION
Fixes #31545

## What this does

`VersionFromString` (`pkg/redpanda/version.go`) parsed a version string through a regex that capped every segment at two digits:

```go
regexp.MustCompile(`^v?(\d{1,2})\.(\d{1,2})\.(\d{1,2})(?:\s|-rc\d{1,2}|-dev|-nightly|$)`)
```

It's called by `connect/upgrade.go`'s `connectVersion` helper to parse the *currently installed* Connect version before comparing it to latest. Connect's minor version crossed 100 in 2026, so `rpk connect upgrade` fails outright for any installed version >= 4.100.0 — i.e. every currently shipping version:

```
$ rpk connect --version
Version: 4.103.1
Date: 2026-07-31T15:40:36Z

$ rpk connect upgrade
unable to determine current version of Redpanda Connect: unable to determine Redpanda version from "4.103.1": unable to get the redpanda version from "4.103.1"
```

This is the same bug class as #31432/CON-529 (fixed for `install.go`'s separate validator in #31438), in a sibling function that fix didn't touch. `VersionFromString` is exported from `pkg/redpanda`, so I widened `\d{1,2}` to `\d+` on all three segments plus the `-rc\d{1,2}` suffix, matching #31438's fix.

Filed as [CON-540](https://redpandadata.atlassian.net/browse/CON-540) / #31545.

## Test plan

- Flipped the three existing test cases that asserted 3-digit segments *error* (`3 digits year/feature/patch`) to assert they now parse correctly — those cases were pinning the exact bug.
- Added cases for the real-world trigger (`4.103.1`), a 3-digit segment with an `-rc` suffix, and a 3-digit segment with trailing build text.
- `go test ./pkg/redpanda/...` and `go test ./pkg/cli/connect/...`: all pass.
- Built `rpk` from this branch and reproduced the original failure end-to-end: `rpk connect upgrade` now correctly parses an installed `4.103.2` and upgrades to `4.104.0`, where it previously died before even fetching the manifest.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [x] v25.3.x

Same three branches #31438 was backported to — `VersionFromString` carries the defect on all of them, and this change touches only that one function, so it should cherry-pick cleanly.

## UX Changes

## Release Notes

### Bug Fixes

* `rpk connect upgrade` no longer fails to determine the currently-installed Redpanda Connect version when that version has a segment of three or more digits, which had blocked upgrading any Connect install since 4.100.0.


[CON-540]: https://redpandadata.atlassian.net/browse/CON-540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ