### PR TITLE
raft: fix election timer starvation and busy reply term loss

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -377,12 +377,6 @@ consensus::success_reply consensus::update_follower_index(
         return success_reply::yes;
     }
 
-    if (unlikely(r.value().result == reply_result::follower_busy)) {
-        // ignore this response, timed out on the receiver node
-        vlog(_ctxlog.trace, "Follower busy on node {}", node.id());
-        return success_reply::no;
-    }
-
     const auto& config = _configuration_manager.get_latest();
     if (!config.contains(node)) {
         // We might have sent an append_entries just before removing
@@ -437,6 +431,21 @@ consensus::success_reply consensus::update_follower_index(
     // check preconditions for processing the reply
     if (unlikely(!is_elected_leader())) {
         vlog(_ctxlog.debug, "ignoring append entries reply, not leader");
+        return success_reply::no;
+    }
+
+    if (unlikely(reply.result == reply_result::follower_busy)) {
+        // The reply carries no replication state, but its term is still
+        // valid evidence of a term we may be lagging behind (Raft paper:
+        // §5.1).
+        if (reply.term > _term) {
+            ssx::spawn_with_gate(_bg, [this, term = reply.term] {
+                return step_down(
+                  model::term_id(term), "busy response with greater term");
+            });
+        }
+        // ignore this response, timed out on the receiver node
+        vlog(_ctxlog.trace, "Follower busy on node {}", node.id());
         return success_reply::no;
     }
 

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -4188,6 +4188,10 @@ reply_result consensus::lightweight_heartbeat(
         return reply_result::failure;
     }
 
+    // Any lightweight heartbeat from the current leader is leader contact
+    // and resets the election timer, even when rejected below.
+    _hbeat = clock_type::now();
+
     if (
       unlikely(
         _follower_recovery_state && _follower_recovery_state->is_active())) {
@@ -4196,7 +4200,6 @@ reply_result consensus::lightweight_heartbeat(
         return reply_result::failure;
     }
 
-    _hbeat = clock_type::now();
     return reply_result::success;
 }
 ss::future<full_heartbeat_reply> consensus::full_heartbeat(
@@ -4253,6 +4256,13 @@ ss::future<full_heartbeat_reply> consensus::full_heartbeat(
 void consensus::reset_last_sent_protocol_meta(const vnode& node) {
     if (auto it = _fstates.find(node); it != _fstates.end()) {
         it->second.last_sent_protocol_meta.reset();
+    }
+}
+
+void consensus::on_lw_heartbeat_failure(const vnode& node) {
+    if (auto it = _fstates.find(node); it != _fstates.end()) {
+        it->second.last_sent_protocol_meta.reset();
+        it->second.lw_heartbeat_failed = true;
     }
 }
 

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -563,6 +563,12 @@ public:
 
     void reset_last_sent_protocol_meta(const vnode&);
 
+    /// Records a lightweight heartbeat the node rejected: clears the last
+    /// sent protocol metadata and requests a full heartbeat. Not used for
+    /// transport failures, escalating those would send full heartbeats to
+    /// unreachable nodes.
+    void on_lw_heartbeat_failure(const vnode&);
+
     const std::optional<follower_recovery_state>&
     get_follower_recovery_state() const {
         return _follower_recovery_state;

--- a/src/v/raft/follower_states.cc
+++ b/src/v/raft/follower_states.cc
@@ -67,6 +67,7 @@ void follower_index_metadata::reset() {
     last_successful_received_seq = follower_req_seq{0};
     inflight_append_request_count = 0;
     last_sent_protocol_meta.reset();
+    lw_heartbeat_failed = false;
     follower_state_change.broadcast();
     max_cleanly_compacted_offset = {};
     coordinated_compaction_offsets_getter = std::make_unique<void_executor>();

--- a/src/v/raft/follower_states.h
+++ b/src/v/raft/follower_states.h
@@ -115,6 +115,13 @@ struct follower_index_metadata {
     follower_req_seq last_successful_received_seq{0};
     bool is_learner = true;
     bool is_recovering = false;
+    /**
+     * Set when this follower rejected a lightweight heartbeat. Forces the
+     * next heartbeat to be a full one even when append requests are in
+     * flight, as those may be stalled for longer than an election timeout.
+     * Cleared when a full heartbeat request is built.
+     */
+    bool lw_heartbeat_failed = false;
 
     /*
      * When is_recovering is true a fiber may wait for recovery to be signaled

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -121,6 +121,7 @@ void heartbeat_manager::fetch_heartbeats_for_raft_group(
         const auto seq_id = follower_metadata.next_follower_sequence();
 
         follower_metadata.last_sent_protocol_meta = raft_metadata;
+        follower_metadata.lw_heartbeat_failed = false;
         group_beat.data = heartbeat_request_data{
           .source_revision = raft_group->_self.revision(),
           .target_revision = id.revision(),
@@ -201,6 +202,16 @@ bool heartbeat_manager::needs_full_heartbeat(
   const follower_index_metadata& f_meta,
   const protocol_metadata& p_meta,
   model::offset leader_flushed_offset) const {
+    if (f_meta.lw_heartbeat_failed) {
+        // The follower rejected a lightweight heartbeat so it requires a
+        // full heartbeat, ahead of the in flight append suppression below.
+        // A full heartbeat refreshes the follower election timer and is
+        // the only request that lets a caught up follower leave recovery
+        // state. The remaining full heartbeat triggers stay behind the
+        // suppression, in flight append replies already carry the flushed
+        // offset.
+        return true;
+    }
     if (f_meta.has_inflight_appends()) {
         // in flight append will result in a full blown response
         // until then a full heartbeat is not needed.
@@ -446,8 +457,7 @@ void heartbeat_manager::process_reply(
          * Failed lightweight heartbeat, fallback to full heartbeat
          */
         if (unlikely(result == reply_result::failure)) {
-            consensus->reset_last_sent_protocol_meta(
-              meta_it->second.follower_vnode);
+            consensus->on_lw_heartbeat_failure(meta_it->second.follower_vnode);
             return;
         }
 

--- a/src/v/raft/service.h
+++ b/src/v/raft/service.h
@@ -444,14 +444,31 @@ private:
         futures.reserve(reqs.full_heartbeats.size());
 
         for (auto& full_hb : reqs.full_heartbeats) {
+            auto c = m.consensus_for(full_hb.group);
             auto f = dispatch_full_heartbeat(
               source_node, target_node, m, full_hb);
             f = ss::with_timeout(timeout, std::move(f))
-                  .handle_exception_type([group = full_hb.group](
-                                           const ss::timed_out_error&) {
-                      return full_heartbeat_reply{
-                        .group = group, .result = reply_result::follower_busy};
-                  });
+                  .handle_exception_type(
+                    [group = full_hb.group,
+                     local_revision = c ? c->self().revision()
+                                        : model::revision_id{},
+                     sender_revision = full_hb.data.source_revision,
+                     term = c ? c->term()
+                              : model::term_id{}](const ss::timed_out_error&) {
+                        // The busy reply carries no replication state, but
+                        // the group term is known without dispatching and
+                        // lets the sender discover a term it is lagging
+                        // behind. Revisions are filled as in a genuine
+                        // reply so it maps back to a vnode the sender's
+                        // membership check accepts.
+                        return full_heartbeat_reply{
+                          .group = group,
+                          .result = reply_result::follower_busy,
+                          .data = heartbeat_reply_data{
+                            .source_revision = local_revision,
+                            .target_revision = sender_revision,
+                            .term = term}};
+                    });
             futures.push_back(std::move(f));
         }
 

--- a/src/v/raft/tests/basic_raft_fixture_test.cc
+++ b/src/v/raft/tests/basic_raft_fixture_test.cc
@@ -1321,3 +1321,142 @@ TEST_F_CORO(raft_fixture, test_rejected_append_entries_refresh_hbeat) {
     ASSERT_EQ_CORO(follower_vote_requests, 0);
     ASSERT_EQ_CORO(follower->term(), term);
 }
+
+/**
+ * Livelock reproducer: a follower in active recovery only refreshes its
+ * election timer on full append entries requests, lightweight heartbeats
+ * are rejected without a refresh to make the leader fall back to a full
+ * heartbeat. That fallback is suppressed while any append request to the
+ * follower is in flight. With replication or recovery requests stalled in
+ * flight (slow network or overloaded follower), every heartbeat round
+ * observes an in-flight append and picks a lightweight heartbeat again,
+ * starving the follower of election timer refreshes while it stays in
+ * continuous contact with a live leader.
+ *
+ * Liveness property asserted: such a follower must not start elections.
+ */
+TEST_F_CORO(raft_fixture, test_no_election_storm_with_stalled_appends) {
+    set_election_timeout(1s);
+    co_await create_simple_group(3);
+    auto leader_id = co_await wait_for_leader(10s);
+    auto& leader_node = node(leader_id);
+
+    auto res = co_await leader_node.raft()->replicate(
+      make_batches(10, 1, 128),
+      replicate_options(consistency_level::quorum_ack, 10s));
+    ASSERT_FALSE_CORO(res.has_error());
+    co_await wait_for_committed_offset(res.value().last_offset, 10s);
+
+    auto follower_id = random_follower_id().value();
+    auto& follower_node = node(follower_id);
+    auto follower = follower_node.raft();
+    const auto term = follower->term();
+
+    ss::abort_source stall_as;
+    auto cleanup = ss::defer([&] {
+        stall_as.request_abort();
+        leader_node.reset_reply_interceptor();
+        leader_node.reset_dispatch_handlers();
+        follower_node.reset_dispatch_handlers();
+    });
+
+    // Stall replication and recovery traffic to the follower: requests
+    // stay in flight for the whole observation window, keeping an
+    // in-flight append guard alive at every heartbeat round.
+    leader_node.on_dispatch(
+      [follower_id, &stall_as](model::node_id target, msg_type t) {
+          if (target == follower_id && t == msg_type::append_entries) {
+              return ss::sleep_abortable(8s, stall_as);
+          }
+          return ss::now();
+      });
+
+    res = co_await leader_node.raft()->replicate(
+      make_batches(10, 1, 128),
+      replicate_options(consistency_level::leader_ack, 10s));
+    ASSERT_FALSE_CORO(res.has_error());
+
+    // Put the follower into an active recovery state with a crafted
+    // recovery-shaped request (dirty offset ahead of the previous offset
+    // means the leader considers this follower already recovering).
+    auto gap_prev = model::offset(follower->dirty_offset()() + 1000);
+    auto reply = co_await follower->append_entries(append_entries_request(
+      leader_node.get_vnode(),
+      follower_node.get_vnode(),
+      protocol_metadata{
+        .group = follower->group(),
+        .commit_index = follower->committed_offset(),
+        .term = term,
+        .prev_log_index = gap_prev,
+        .prev_log_term = term,
+        .last_visible_index = follower->last_visible_index(),
+        .dirty_offset = model::offset(gap_prev() + 100),
+      },
+      chunked_vector<model::record_batch>{},
+      0,
+      flush_after_append::no));
+    ASSERT_EQ_CORO(reply.result, reply_result::failure);
+    ASSERT_TRUE_CORO(reply.may_recover);
+
+    // A lightweight heartbeat rejected because recovery is active must
+    // still count as leader contact. Pause heartbeats so the last contact
+    // timestamp ages, then deliver one directly. Dispatch handlers
+    // accumulate, the append stall above stays active.
+    leader_node.on_dispatch([follower_id](model::node_id target, msg_type t) {
+        if (target == follower_id && t == msg_type::heartbeat_v2) {
+            throw std::runtime_error("paused by test");
+        }
+        return ss::now();
+    });
+    co_await ss::sleep(200ms);
+    auto hbeat_before = follower->last_heartbeat();
+    ASSERT_EQ_CORO(
+      follower->lightweight_heartbeat(leader_id, follower_id),
+      reply_result::failure);
+    ASSERT_GT_CORO(follower->last_heartbeat(), hbeat_before);
+
+    leader_node.reset_dispatch_handlers();
+    leader_node.on_dispatch(
+      [follower_id, &stall_as](model::node_id target, msg_type t) {
+          if (target == follower_id && t == msg_type::append_entries) {
+              return ss::sleep_abortable(8s, stall_as);
+          }
+          return ss::now();
+      });
+
+    size_t follower_vote_requests = 0;
+    follower_node.on_dispatch(
+      [&follower_vote_requests](model::node_id, msg_type type) {
+          if (type == msg_type::vote) {
+              ++follower_vote_requests;
+          }
+          return ss::now();
+      });
+
+    // The full heartbeat fallback after a lightweight heartbeat failure
+    // must not be suppressed by the stalled in-flight appends.
+    size_t follower_full_heartbeat_replies = 0;
+    leader_node.set_reply_interceptor(
+      [&follower_full_heartbeat_replies,
+       follower_id](reply_variant reply, model::node_id from) {
+          return ss::visit(
+            std::move(reply),
+            [&follower_full_heartbeat_replies, follower_id, from](
+              heartbeat_reply_v2 hb) {
+                if (from == follower_id && !hb.full_replies().empty()) {
+                    ++follower_full_heartbeat_replies;
+                }
+                return ss::make_ready_future<reply_variant>(std::move(hb));
+            },
+            [](auto r) {
+                return ss::make_ready_future<reply_variant>(std::move(r));
+            });
+      });
+
+    co_await ss::sleep(6s);
+
+    ASSERT_TRUE_CORO(node(leader_id).raft()->is_leader());
+    ASSERT_EQ_CORO(follower->term(), term);
+    ASSERT_EQ_CORO(follower_vote_requests, 0);
+    ASSERT_GT_CORO(follower_full_heartbeat_replies, 0);
+}

--- a/src/v/raft/tests/basic_raft_fixture_test.cc
+++ b/src/v/raft/tests/basic_raft_fixture_test.cc
@@ -18,6 +18,7 @@
 #include "test_utils/test.h"
 
 #include <seastar/core/circular_buffer.hh>
+#include <seastar/util/defer.hh>
 
 #include <algorithm>
 #include <chrono>
@@ -1210,4 +1211,113 @@ TEST_F_CORO(raft_fixture, test_leadership_blocked_replicas_can_elect_leader) {
 
     auto leader = co_await wait_for_leader(60s);
     ASSERT_NE_CORO(leader, blocked_follower);
+}
+
+/**
+ * An append entries request from the current term leader must refresh the
+ * follower election timer even when the request is rejected because the
+ * follower log is behind (gap) or the previous log entry term does not
+ * match. Without the refresh a follower that stays in contact with a live
+ * leader, but can not append because it is still being recovered, keeps
+ * starting elections that deterministically fail the longest log check.
+ * The resulting (pre-)vote storm starves recovery, a livelock.
+ *
+ * Note that during active follower recovery lightweight heartbeats are
+ * rejected to force full heartbeats, so rejected full append entries
+ * requests can be the dominant form of leader contact.
+ */
+TEST_F_CORO(raft_fixture, test_rejected_append_entries_refresh_hbeat) {
+    set_election_timeout(1s);
+    co_await create_simple_group(3);
+    auto leader_id = co_await wait_for_leader(10s);
+    auto& leader_node = node(leader_id);
+
+    auto res = co_await leader_node.raft()->replicate(
+      make_batches(10, 1, 128),
+      replicate_options(consistency_level::quorum_ack, 10s));
+    ASSERT_FALSE_CORO(res.has_error());
+    co_await wait_for_committed_offset(res.value().last_offset, 10s);
+
+    auto follower_id = random_follower_id().value();
+    auto& follower_node = node(follower_id);
+    auto follower = follower_node.raft();
+    const auto term = follower->term();
+
+    auto cleanup = ss::defer([&] {
+        leader_node.reset_dispatch_handlers();
+        follower_node.reset_dispatch_handlers();
+    });
+
+    // Cut the follower off from real leader traffic. The requests crafted
+    // below are its only contact with the leader.
+    leader_node.on_dispatch([follower_id](model::node_id target, msg_type) {
+        if (target == follower_id) {
+            throw std::runtime_error("blocked by test");
+        }
+        return ss::now();
+    });
+
+    size_t follower_vote_requests = 0;
+    follower_node.on_dispatch(
+      [&follower_vote_requests](model::node_id, msg_type type) {
+          if (type == msg_type::vote) {
+              ++follower_vote_requests;
+          }
+          return ss::now();
+      });
+
+    auto make_request =
+      [&](model::offset prev_log_index, model::term_id prev_log_term) {
+          return append_entries_request(
+            leader_node.get_vnode(),
+            follower_node.get_vnode(),
+            protocol_metadata{
+              .group = follower->group(),
+              .commit_index = follower->committed_offset(),
+              .term = term,
+              .prev_log_index = prev_log_index,
+              .prev_log_term = prev_log_term,
+              .last_visible_index = follower->last_visible_index(),
+              .dirty_offset = prev_log_index,
+            },
+            chunked_vector<model::record_batch>{},
+            0,
+            flush_after_append::no);
+      };
+
+    // let the timestamp of the last real leader contact age
+    co_await ss::sleep(200ms);
+
+    // rejected because it would leave a gap in the follower log
+    auto hbeat_before = follower->last_heartbeat();
+    auto reply = co_await follower->append_entries(
+      make_request(model::offset(follower->dirty_offset()() + 1000), term));
+    ASSERT_EQ_CORO(reply.result, reply_result::failure);
+    ASSERT_GT_CORO(follower->last_heartbeat(), hbeat_before);
+
+    co_await ss::sleep(200ms);
+
+    // rejected because the previous log entry term does not match
+    hbeat_before = follower->last_heartbeat();
+    auto lstats = follower->log()->offsets();
+    reply = co_await follower->append_entries(make_request(
+      lstats.dirty_offset, model::term_id(lstats.dirty_offset_term() - 1)));
+    ASSERT_EQ_CORO(reply.result, reply_result::failure);
+    ASSERT_GT_CORO(follower->last_heartbeat(), hbeat_before);
+
+    /**
+     * Keep the follower in contact with the leader through rejected append
+     * entries only, for several election timeouts (with margin for the
+     * voter priority decay rounds preceding the first vote dispatch). The
+     * follower must not attempt an election.
+     */
+    auto deadline = model::timeout_clock::now() + 8s;
+    while (model::timeout_clock::now() < deadline) {
+        reply = co_await follower->append_entries(
+          make_request(model::offset(follower->dirty_offset()() + 1000), term));
+        ASSERT_EQ_CORO(reply.result, reply_result::failure);
+        co_await ss::sleep(100ms);
+    }
+    ASSERT_EQ_CORO(follower_vote_requests, 0);
+    ASSERT_EQ_CORO(follower->term(), term);
 }

--- a/src/v/raft/tests/basic_raft_fixture_test.cc
+++ b/src/v/raft/tests/basic_raft_fixture_test.cc
@@ -1460,3 +1460,150 @@ TEST_F_CORO(raft_fixture, test_no_election_storm_with_stalled_appends) {
     ASSERT_EQ_CORO(follower_vote_requests, 0);
     ASSERT_GT_CORO(follower_full_heartbeat_replies, 0);
 }
+
+/**
+ * Wedge reproducer: a follower one term above a live leader rejects all
+ * append entries and full heartbeats without refreshing its election
+ * timer, so it keeps starting elections that peers with a healthy leader
+ * reject without ever reading the higher term (leader stickiness). The
+ * only remaining path for the cluster to learn the follower term is the
+ * heartbeat reply. When the follower is overloaded the service degrades
+ * full heartbeat replies to follower_busy and the leader drops busy
+ * replies before its reply-term check, so the wedge never resolves.
+ *
+ * The follower is seeded one term ahead the same way it happens in
+ * production: a leadership transfer (timeout_now) whose vote round is
+ * lost to the network. The reply interceptor simulates a persistently
+ * overloaded follower, preserving the reply term the service includes
+ * when fabricating busy replies.
+ *
+ * Liveness property asserted: the group must converge to a term at least
+ * as high as the wedged follower's.
+ */
+TEST_F_CORO(raft_fixture, test_leader_learns_higher_term_from_busy_follower) {
+    set_election_timeout(1s);
+    co_await create_simple_group(3);
+    auto leader_id = co_await wait_for_leader(10s);
+    auto& leader_node = node(leader_id);
+
+    auto res = co_await leader_node.raft()->replicate(
+      make_batches(10, 1, 128),
+      replicate_options(consistency_level::quorum_ack, 10s));
+    ASSERT_FALSE_CORO(res.has_error());
+    co_await wait_for_committed_offset(res.value().last_offset, 10s);
+
+    auto follower_id = random_follower_id().value();
+    auto& follower_node = node(follower_id);
+    auto follower = follower_node.raft();
+    const auto term = follower->term();
+
+    auto cleanup = ss::defer([&] {
+        leader_node.reset_reply_interceptor();
+        follower_node.reset_dispatch_handlers();
+    });
+
+    // All full heartbeat replies from the follower degrade to
+    // follower_busy, keeping the rest of the reply intact.
+    leader_node.set_reply_interceptor(
+      [follower_id](reply_variant reply, model::node_id from) {
+          return ss::visit(
+            std::move(reply),
+            [follower_id, from](heartbeat_reply_v2 hb) {
+                if (from != follower_id) {
+                    return ss::make_ready_future<reply_variant>(std::move(hb));
+                }
+                heartbeat_reply_v2 busy(hb.source(), hb.target());
+                hb.for_each_lw_reply([&busy](raft::group_id g, reply_result r) {
+                    busy.add(g, r);
+                });
+                for (const auto& full : hb.full_replies()) {
+                    busy.add(
+                      full.group, reply_result::follower_busy, full.data);
+                }
+                return ss::make_ready_future<reply_variant>(std::move(busy));
+            },
+            [](auto r) {
+                return ss::make_ready_future<reply_variant>(std::move(r));
+            });
+      });
+
+    // Seed the follower one term above the leader: deliver a leadership
+    // transfer request but lose its vote rounds. Peers with a live leader
+    // would reject the follower's (pre-)votes without adopting the higher
+    // term anyway, so the block stays on for the whole test.
+    follower_node.on_dispatch([](model::node_id, msg_type t) {
+        if (t == msg_type::vote) {
+            throw std::runtime_error("vote round lost by test");
+        }
+        return ss::now();
+    });
+    auto tn_reply = co_await follower->timeout_now(
+      timeout_now_request{
+        .target_node_id = follower_node.get_vnode(),
+        .node_id = leader_node.get_vnode(),
+        .group = follower->group(),
+        .term = term,
+      });
+    ASSERT_EQ_CORO(tn_reply.result, timeout_now_reply::status::success);
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [&] { return follower->term() > term; });
+
+    // The group must learn the follower's term from its heartbeat replies
+    // and converge, instead of leaving it electioneering forever.
+    RPTEST_REQUIRE_EVENTUALLY_CORO(8s, [&] {
+        auto leader = get_leader();
+        return leader.has_value() && node(*leader).raft()->term() > term;
+    });
+}
+
+/**
+ * The busy replies fabricated by the raft service when a full heartbeat
+ * dispatch exceeds its deadline must carry the group term. A zero service
+ * deadline degrades every full heartbeat reply to follower_busy, making
+ * those replies the only channel through which the leader can learn about
+ * a follower wedged at a higher term.
+ */
+TEST_F_CORO(raft_fixture, test_fabricated_busy_reply_carries_term) {
+    set_election_timeout(1s);
+    set_service_heartbeat_timeout(0ms);
+    co_await create_simple_group(3);
+    auto leader_id = co_await wait_for_leader(10s);
+    auto& leader_node = node(leader_id);
+
+    auto res = co_await leader_node.raft()->replicate(
+      make_batches(10, 1, 128),
+      replicate_options(consistency_level::quorum_ack, 10s));
+    ASSERT_FALSE_CORO(res.has_error());
+    co_await wait_for_committed_offset(res.value().last_offset, 10s);
+
+    auto follower_id = random_follower_id().value();
+    auto& follower_node = node(follower_id);
+    auto follower = follower_node.raft();
+    const auto term = follower->term();
+
+    auto cleanup = ss::defer([&] { follower_node.reset_dispatch_handlers(); });
+
+    // Seed the follower one term above the leader: deliver a leadership
+    // transfer request but lose its vote rounds.
+    follower_node.on_dispatch([](model::node_id, msg_type t) {
+        if (t == msg_type::vote) {
+            throw std::runtime_error("vote round lost by test");
+        }
+        return ss::now();
+    });
+    auto tn_reply = co_await follower->timeout_now(
+      timeout_now_request{
+        .target_node_id = follower_node.get_vnode(),
+        .node_id = leader_node.get_vnode(),
+        .group = follower->group(),
+        .term = term,
+      });
+    ASSERT_EQ_CORO(tn_reply.result, timeout_now_reply::status::success);
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [&] { return follower->term() > term; });
+
+    // The group must learn the follower's term from the fabricated busy
+    // replies and converge.
+    RPTEST_REQUIRE_EVENTUALLY_CORO(8s, [&] {
+        auto leader = get_leader();
+        return leader.has_value() && node(*leader).raft()->term() > term;
+    });
+}

--- a/src/v/raft/tests/raft_fixture_base.cc
+++ b/src/v/raft/tests/raft_fixture_base.cc
@@ -372,6 +372,7 @@ raft_node_instance::raft_node_instance(
   bool enable_longest_log_detection,
   config::binding<std::chrono::milliseconds> election_timeout,
   config::binding<std::chrono::milliseconds> heartbeat_interval,
+  std::chrono::milliseconds service_heartbeat_timeout,
   bool with_offset_translation)
   : _id(id)
   , _revision(revision)
@@ -401,7 +402,7 @@ raft_node_instance::raft_node_instance(
       ss::default_scheduling_group(),
       std::ref(_group_manager),
       _shard_manager,
-      _heartbeat_interval(),
+      service_heartbeat_timeout,
       _id) {
     config::shard_local_cfg().disable_metrics.set_value(true);
 }
@@ -633,6 +634,7 @@ raft_node_instance& raft_fixture_base::add_node(
       _enable_longest_log_detection,
       _election_timeout.bind(),
       _heartbeat_interval.bind(),
+      _service_heartbeat_timeout.value_or(_heartbeat_interval()),
       _with_offset_translation);
 
     auto [it, success] = _nodes.emplace(id, std::move(instance));

--- a/src/v/raft/tests/raft_fixture_base.h
+++ b/src/v/raft/tests/raft_fixture_base.h
@@ -204,6 +204,7 @@ public:
       bool enable_longest_log_detection,
       config::binding<std::chrono::milliseconds> election_timeout,
       config::binding<std::chrono::milliseconds> heartbeat_interval,
+      std::chrono::milliseconds service_heartbeat_timeout,
       bool with_offset_translation = false);
 
     raft_node_instance(const raft_node_instance&) = delete;
@@ -589,6 +590,15 @@ public:
         _heartbeat_interval.update(std::move(timeout));
     }
 
+    /**
+     * Deadline after which a node's raft service degrades a full heartbeat
+     * reply to follower_busy. Defaults to the heartbeat interval, as in
+     * production. Only affects nodes added after the call.
+     */
+    void set_service_heartbeat_timeout(std::chrono::milliseconds timeout) {
+        _service_heartbeat_timeout = timeout;
+    }
+
     void enable_offset_translation() { _with_offset_translation = true; }
 
     std::chrono::milliseconds get_election_timeout() const {
@@ -626,6 +636,7 @@ private:
     std::optional<leader_update_clb_t> _leader_clb;
     config::mock_property<std::chrono::milliseconds> _election_timeout{500ms};
     config::mock_property<std::chrono::milliseconds> _heartbeat_interval{50ms};
+    std::optional<std::chrono::milliseconds> _service_heartbeat_timeout;
     bool _with_offset_translation = false;
     std::filesystem::path _test_dir;
 };


### PR DESCRIPTION
Two raft liveness gaps let a follower storm elections against a live
leader, the family of symptoms previously reported in #30815:

* A follower in active recovery rejects lightweight heartbeats without
  refreshing its election timer, and the full heartbeat fallback after a
  lightweight heartbeat failure can be suppressed indefinitely by stalled
  in-flight appends. The follower's timer expires and it keeps starting
  elections that are doomed while the leader is healthy.
* Full heartbeat replies fabricated as `follower_busy` carried no term
  and the leader dropped busy replies before its reply-term check, so a
  follower wedged one term above a live leader (a leadership transfer
  whose vote round was lost) could never depose it.

Both livelocks are reproduced by new `raft_fixture` tests that fail
without the fixes. A companion test pins the pre-existing invariant that
rejected append entries from the current term leader still refresh the
election timer.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

### Bug Fixes

* Fixed raft livelocks where a follower could repeatedly start elections
  against a live leader: a recovering follower starved of election timer
  refreshes, and a follower wedged at a higher term whose busy heartbeat
  replies carried no term.