### PR TITLE
[v26.1.x] rpk/connect: don't cap version segments at two digits in VersionFromString

### DIFF
--- a/src/go/rpk/pkg/redpanda/version.go
+++ b/src/go/rpk/pkg/redpanda/version.go
@@ -26,11 +26,21 @@ func VersionFromString(s string) (Version, error) {
 		return Version{}, fmt.Errorf("unable to get the redpanda version from %q", s)
 	}
 
-	// We can safely ignore the errors since we are making sure in the regexp
-	// that we match digits only.
-	y, _ := strconv.Atoi(vMatch[1])
-	f, _ := strconv.Atoi(vMatch[2])
-	p, _ := strconv.Atoi(vMatch[3])
+	// The regexp guarantees each group is digits-only, but no longer bounds
+	// how many: an implausibly long segment can still overflow int, so check
+	// the conversion instead of ignoring its error.
+	y, err := strconv.Atoi(vMatch[1])
+	if err != nil {
+		return Version{}, fmt.Errorf("unable to parse major version from %q: %v", s, err)
+	}
+	f, err := strconv.Atoi(vMatch[2])
+	if err != nil {
+		return Version{}, fmt.Errorf("unable to parse feature version from %q: %v", s, err)
+	}
+	p, err := strconv.Atoi(vMatch[3])
+	if err != nil {
+		return Version{}, fmt.Errorf("unable to parse patch version from %q: %v", s, err)
+	}
 	return Version{y, f, p}, nil
 }
 

--- a/src/go/rpk/pkg/redpanda/version.go
+++ b/src/go/rpk/pkg/redpanda/version.go
@@ -20,7 +20,7 @@ func VersionFromString(s string) (Version, error) {
 	//   - index 1: the Major
 	//   - index 2: the Feature
 	//   - index 3: the Patch
-	vMatch := regexp.MustCompile(`^v?(\d{1,2})\.(\d{1,2})\.(\d{1,2})(?:\s|-rc\d{1,2}|-dev|-nightly|$)`).FindStringSubmatch(s)
+	vMatch := regexp.MustCompile(`^v?(\d+)\.(\d+)\.(\d+)(?:\s|-rc\d+|-dev|-nightly|$)`).FindStringSubmatch(s)
 
 	if len(vMatch) == 0 {
 		return Version{}, fmt.Errorf("unable to get the redpanda version from %q", s)

--- a/src/go/rpk/pkg/redpanda/version_test.go
+++ b/src/go/rpk/pkg/redpanda/version_test.go
@@ -26,9 +26,12 @@ func TestVersionFromString(t *testing.T) {
 		{name: "nightly build", in: "v26.1.0-nightly", exp: Version{26, 1, 0}},
 		{name: "incomplete", in: "22.3", expErr: true},
 		{name: "random string", in: "random", expErr: true},
-		{name: "3 digits year", in: "v222.11.1", expErr: true},
-		{name: "3 digits feature", in: "v11.222.1", expErr: true},
-		{name: "3 digits patch", in: "v11.11.223", expErr: true},
+		{name: "3 digits year", in: "v222.11.1", exp: Version{222, 11, 1}},
+		{name: "3 digits feature", in: "v11.222.1", exp: Version{11, 222, 1}},
+		{name: "3 digits patch", in: "v11.11.223", exp: Version{11, 11, 223}},
+		{name: "3 digit feature, real Connect version", in: "4.103.1", exp: Version{4, 103, 1}},
+		{name: "3 digit feature with rc", in: "4.100.0-rc1", exp: Version{4, 100, 0}},
+		{name: "3 digit feature with text", in: "4.103.1 - 9eefb907c43bf1cfeb0783808c224385c857c0d4-dirty", exp: Version{4, 103, 1}},
 		{name: "non-digit version", in: "AB.C.D", expErr: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/src/go/rpk/pkg/redpanda/version_test.go
+++ b/src/go/rpk/pkg/redpanda/version_test.go
@@ -33,6 +33,7 @@ func TestVersionFromString(t *testing.T) {
 		{name: "3 digit feature with rc", in: "4.100.0-rc1", exp: Version{4, 100, 0}},
 		{name: "3 digit feature with text", in: "4.103.1 - 9eefb907c43bf1cfeb0783808c224385c857c0d4-dirty", exp: Version{4, 103, 1}},
 		{name: "non-digit version", in: "AB.C.D", expErr: true},
+		{name: "segment overflows int", in: "4.99999999999999999999.0", expErr: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := VersionFromString(test.in)


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31546
Fixes: https://github.com/redpanda-data/redpanda/issues/31550,