### PR TITLE
rpk: consolidate plugin version validation on pkg

### DIFF
--- a/src/go/rpk/pkg/cli/ai/client_test.go
+++ b/src/go/rpk/pkg/cli/ai/client_test.go
@@ -23,7 +23,9 @@ func TestValidateVersion(t *testing.T) {
 		{"latest", false},
 		{"0.1.2", false},
 		{"v0.1.2", false},
-		{"1.2.3-rc1", false}, // suffix after patch is allowed by the regex
+		{"1.2.3-rc1", false},   // suffix after patch is allowed by the regex
+		{"4.100.0", false},     // segments are not capped at two digits
+		{"0.1.2garbage", true}, // trailing garbage is rejected
 		{"0.1", true},
 		{"foo", true},
 		{"", true},

--- a/src/go/rpk/pkg/cli/ai/install.go
+++ b/src/go/rpk/pkg/cli/ai/install.go
@@ -12,13 +12,13 @@ package ai
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/fips"
 	rpkos "github.com/redpanda-data/redpanda/src/go/rpk/pkg/osutil"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/redpanda"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -122,19 +122,14 @@ func downloadAndInstallAIPlugin(ctx context.Context, fs afero.Fs, installPath, d
 }
 
 // validateVersion validates that the provided version flag is either
-// 'latest' or starts with a MAJOR.MINOR.PATCH prefix (optionally v-prefixed).
-// The regex is intentionally loose on the suffix so prereleases like
-// "0.1.2-rc1" are accepted and forwarded to the manifest for lookup; the
-// manifest is then the source of truth for what's actually published.
+// 'latest' or a full semantic version (optionally v-prefixed, optionally with
+// a prerelease/build suffix such as -rc1, which is forwarded to the manifest
+// for lookup; the manifest is the source of truth for what is published).
 func validateVersion(version string) error {
-	if version == "latest" {
+	if version == "latest" || redpanda.ValidVersion(version) {
 		return nil
 	}
-	vMatch := regexp.MustCompile(`^v?\d{1,2}\.\d{1,2}\.\d{1,2}`).MatchString(version)
-	if !vMatch {
-		return fmt.Errorf("provided version %q is not valid. Ensure it is either 'latest' or it follows the format MAJOR.MINOR.PATCH (e.g., 0.1.2)", version)
-	}
-	return nil
+	return fmt.Errorf("provided version %q is not valid. Ensure it is either 'latest' or it follows the format MAJOR.MINOR.PATCH (e.g., 0.1.2)", version)
 }
 
 // maybeExitFIPS exits with a clear error if fips is enabled. The rpk ai

--- a/src/go/rpk/pkg/cli/check/BUILD
+++ b/src/go/rpk/pkg/cli/check/BUILD
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "check",
@@ -22,4 +22,11 @@ go_library(
         "@com_github_spf13_cobra//:cobra",
         "@org_uber_go_zap//:zap",
     ],
+)
+
+go_test(
+    name = "check_test",
+    srcs = ["install_test.go"],
+    embed = [":check"],
+    deps = ["@com_github_stretchr_testify//require"],
 )

--- a/src/go/rpk/pkg/cli/check/install.go
+++ b/src/go/rpk/pkg/cli/check/install.go
@@ -12,12 +12,12 @@ package check
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 
 	rpkos "github.com/redpanda-data/redpanda/src/go/rpk/pkg/osutil"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/redpanda"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -117,13 +117,13 @@ func downloadAndInstallCheck(ctx context.Context, fs afero.Fs, installPath, down
 	return path, nil
 }
 
+// validateVersion validates that the provided version flag is either
+// 'latest' or a full semantic version (optionally v-prefixed, optionally with
+// a prerelease/build suffix such as -rc1, which is forwarded to the manifest
+// for lookup; the manifest is the source of truth for what is published).
 func validateVersion(version string) error {
-	if version == "latest" {
+	if version == "latest" || redpanda.ValidVersion(version) {
 		return nil
 	}
-	vMatch := regexp.MustCompile(`^v?\d{1,2}\.\d{1,2}\.\d{1,2}`).MatchString(version)
-	if !vMatch {
-		return fmt.Errorf("provided version %q is not valid. Ensure it is either 'latest' or follows the format MAJOR.MINOR.PATCH (e.g., 0.1.0)", version)
-	}
-	return nil
+	return fmt.Errorf("provided version %q is not valid. Ensure it is either 'latest' or follows the format MAJOR.MINOR.PATCH (e.g., 0.1.0)", version)
 }

--- a/src/go/rpk/pkg/cli/check/install_test.go
+++ b/src/go/rpk/pkg/cli/check/install_test.go
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-package connect
+package check
 
 import (
 	"testing"
@@ -16,13 +16,10 @@ import (
 )
 
 func TestValidateVersion(t *testing.T) {
-	// Slim regression test for the 'latest' special case and the wiring to
-	// redpanda.ValidVersion; exhaustive pattern coverage lives in
-	// pkg/redpanda/version_test.go.
-	for _, ok := range []string{"latest", "4.99.0", "4.102.0", "v4.102.0", "4.102.0-rc1", "4.102.0-beta1", "4.102.100"} {
+	for _, ok := range []string{"latest", "0.1.0", "v0.1.0", "0.1.0-rc1", "0.100.0"} {
 		require.NoError(t, validateVersion(ok), ok)
 	}
-	for _, bad := range []string{"", "abc", "4", "4.102", "garbage", "4.102.0garbage", "4.102.0 "} {
+	for _, bad := range []string{"", "abc", "0", "garbage", "0.1.0garbage"} {
 		require.Error(t, validateVersion(bad), bad)
 	}
 }

--- a/src/go/rpk/pkg/cli/connect/install.go
+++ b/src/go/rpk/pkg/cli/connect/install.go
@@ -13,12 +13,12 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 
 	rpkos "github.com/redpanda-data/redpanda/src/go/rpk/pkg/osutil"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/redpanda"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -130,19 +130,12 @@ func downloadAndInstallConnect(ctx context.Context, fs afero.Fs, installPath, do
 }
 
 // validateVersion validates that the provided version in the flag is either
-// 'latest' or it's a full semantic version.
+// 'latest' or a full semantic version (optionally v-prefixed, optionally with
+// a prerelease/build suffix such as -rc1, which is forwarded to the manifest
+// for lookup; the manifest is the source of truth for what is published).
 func validateVersion(version string) error {
-	// The version may be prefixed with 'v' and carry a prerelease or build
-	// suffix (e.g. '4.102.0-rc1'), which is forwarded to the manifest for
-	// lookup; the manifest is the source of truth for what is published.
-	// Segments are unbounded in width: Connect minor versions passed 99 in
-	// 4.100.0.
-	if version == "latest" {
+	if version == "latest" || redpanda.ValidVersion(version) {
 		return nil
 	}
-	vMatch := regexp.MustCompile(`^v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$`).MatchString(version)
-	if !vMatch {
-		return fmt.Errorf("provided version %q is not valid. Ensure is either 'latest' or it follows the format MAJOR.MINOR.PATCH (e.g., 2.1.3)", version)
-	}
-	return nil
+	return fmt.Errorf("provided version %q is not valid. Ensure it is either 'latest' or it follows the format MAJOR.MINOR.PATCH (e.g., 2.1.3)", version)
 }

--- a/src/go/rpk/pkg/cli/k8s/install.go
+++ b/src/go/rpk/pkg/cli/k8s/install.go
@@ -12,13 +12,13 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/fips"
 	rpkos "github.com/redpanda-data/redpanda/src/go/rpk/pkg/osutil"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/redpanda"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -125,16 +125,14 @@ func downloadAndInstallK8sPlugin(ctx context.Context, fs afero.Fs, installPath, 
 	return path, nil
 }
 
-// validateVersion accepts 'latest' or a MAJOR.MINOR.PATCH prefix (optionally
-// v-prefixed); the manifest is the source of truth for what is published.
+// validateVersion accepts 'latest' or a full semantic version (optionally
+// v-prefixed, optionally with a prerelease/build suffix such as -rc1);
+// the manifest is the source of truth for what is published.
 func validateVersion(version string) error {
-	if version == "latest" {
+	if version == "latest" || redpanda.ValidVersion(version) {
 		return nil
 	}
-	if !regexp.MustCompile(`^v?\d{1,2}\.\d{1,2}\.\d{1,2}`).MatchString(version) {
-		return fmt.Errorf("provided version %q is not valid. Ensure it is either 'latest' or it follows the format MAJOR.MINOR.PATCH (e.g., 25.3.5)", version)
-	}
-	return nil
+	return fmt.Errorf("provided version %q is not valid. Ensure it is either 'latest' or it follows the format MAJOR.MINOR.PATCH (e.g., 25.3.5)", version)
 }
 
 // shadowingSelfManaged reports the path of a self-managed k8s plugin that

--- a/src/go/rpk/pkg/cli/k8s/install_test.go
+++ b/src/go/rpk/pkg/cli/k8s/install_test.go
@@ -103,10 +103,10 @@ func TestInstallK8s_SHAMismatch(t *testing.T) {
 }
 
 func TestValidateVersion(t *testing.T) {
-	for _, ok := range []string{"latest", "25.3.5", "v25.3.5", "25.3.5-rc1"} {
+	for _, ok := range []string{"latest", "25.3.5", "v25.3.5", "25.3.5-rc1", "25.100.0"} {
 		require.NoError(t, validateVersion(ok), ok)
 	}
-	for _, bad := range []string{"", "abc", "25", "garbage"} {
+	for _, bad := range []string{"", "abc", "25", "garbage", "25.3.5garbage"} {
 		require.Error(t, validateVersion(bad), bad)
 	}
 }

--- a/src/go/rpk/pkg/redpanda/version.go
+++ b/src/go/rpk/pkg/redpanda/version.go
@@ -12,6 +12,21 @@ type Version struct {
 	Patch   int
 }
 
+// versionPattern matches an optionally v-prefixed MAJOR.FEATURE.PATCH semver
+// core with an optional prerelease/build suffix (e.g. -rc1, -dev, -nightly,
+// -beta.1, +build5, -rc.1+build.5). Segments are unbounded in width. Capture
+// groups are Major, Feature, and Patch.
+const versionPattern = `v?(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.+-]+)?`
+
+var (
+	// versionRe matches a version (including any optional prerelease/build
+	// suffix, e.g. "22.3.4-dirty") at the start of a string, tolerating
+	// trailing text after whitespace, e.g. "v22.3.4 - 9eefb90... - dirty".
+	versionRe = regexp.MustCompile(`^` + versionPattern + `(?:\s|$)`)
+	// strictVersionRe requires the entire string to be a version.
+	strictVersionRe = regexp.MustCompile(`^` + versionPattern + `$`)
+)
+
 // VersionFromString creates a Version struct based on a passed string that
 // contains the semver version string.
 func VersionFromString(s string) (Version, error) {
@@ -20,7 +35,7 @@ func VersionFromString(s string) (Version, error) {
 	//   - index 1: the Major
 	//   - index 2: the Feature
 	//   - index 3: the Patch
-	vMatch := regexp.MustCompile(`^v?(\d+)\.(\d+)\.(\d+)(?:\s|-rc\d+|-dev|-nightly|$)`).FindStringSubmatch(s)
+	vMatch := versionRe.FindStringSubmatch(s)
 
 	if len(vMatch) == 0 {
 		return Version{}, fmt.Errorf("unable to get the redpanda version from %q", s)
@@ -42,6 +57,13 @@ func VersionFromString(s string) (Version, error) {
 		return Version{}, fmt.Errorf("unable to parse patch version from %q: %v", s, err)
 	}
 	return Version{y, f, p}, nil
+}
+
+// ValidVersion reports whether s is exactly a semantic version, optionally
+// v-prefixed, with an optional prerelease/build suffix (e.g. 4.102.0,
+// v25.3.5, 4.102.0-rc1) and no surrounding text.
+func ValidVersion(s string) bool {
+	return strictVersionRe.MatchString(s)
 }
 
 // Less returns true if the version is lower than the passed 'b' version.

--- a/src/go/rpk/pkg/redpanda/version_test.go
+++ b/src/go/rpk/pkg/redpanda/version_test.go
@@ -34,6 +34,12 @@ func TestVersionFromString(t *testing.T) {
 		{name: "3 digit feature with text", in: "4.103.1 - 9eefb907c43bf1cfeb0783808c224385c857c0d4-dirty", exp: Version{4, 103, 1}},
 		{name: "non-digit version", in: "AB.C.D", expErr: true},
 		{name: "segment overflows int", in: "4.99999999999999999999.0", expErr: true},
+		{name: "beta prerelease", in: "4.102.0-beta1", exp: Version{4, 102, 0}},
+		{name: "build metadata", in: "4.102.0+build5", exp: Version{4, 102, 0}},
+		{name: "dirty suffix without space", in: "22.3.4-dirty", exp: Version{22, 3, 4}},
+		{name: "suffix then text", in: "4.102.0-beta.1 - 9eefb907c43bf1cfeb0783808c224385c857c0d4", exp: Version{4, 102, 0}},
+		{name: "trailing dash", in: "22.3.4-", expErr: true},
+		{name: "four segments", in: "1.2.3.4", expErr: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := VersionFromString(test.in)
@@ -44,6 +50,23 @@ func TestVersionFromString(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, test.exp, got)
 		})
+	}
+}
+
+func TestValidVersion(t *testing.T) {
+	for _, ok := range []string{
+		"4.99.0", "4.102.0", "v4.102.0", "4.102.0-rc1", "4.102.100",
+		"0.1.2", "v0.1.2", "1.2.3-rc1", "25.3.5", "v25.3.5",
+		"4.102.0-beta1", "4.102.0+build5", "1.2.3-rc.1+build.5", "26.1.0-nightly",
+	} {
+		require.True(t, ValidVersion(ok), ok)
+	}
+	for _, bad := range []string{
+		"", "latest", "abc", "4", "4.102", "garbage",
+		"4.102.0garbage", "4.102.0 ", " 4.102.0", "4.102.0-", "1.2.3.4",
+		"v22.3.4 - 9eefb907-dirty",
+	} {
+		require.False(t, ValidVersion(bad), bad)
 	}
 }
 


### PR DESCRIPTION
Define the semver pattern once in pkg/redpanda:
VersionFromString parses versions from command
output, and a new ValidVersion strictly validates
user-supplied flags. The connect, ai, check, and
k8s install commands drop their private regexes
and delegate to ValidVersion.

The parser now accepts any prerelease or build
suffix, so upgrade can parse any version that
install accepts. The ai, check, and k8s
validators previously capped segments at two
digits and accepted trailing garbage; both bugs
are gone with the shared pattern.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none
