### PR TITLE
bazel/packaging: bake rpath at link time instead of patching

### DIFF
--- a/bazel/packaging/BUILD
+++ b/bazel/packaging/BUILD
@@ -24,7 +24,6 @@ redpanda_package(
     default_yaml_config = "//conf:redpanda.yaml",
     include_sysroot_libs = True,
     redpanda_binary = "//:redpanda",
-    rpath_override = "$ORIGIN/../lib",
     rpk_binary = ":rpk",
     sysroot_runtime = ":sysroot_runtime",
 )
@@ -54,7 +53,6 @@ redpanda_package(
     include_sysroot_libs = True,
     install_path = "/opt/redpanda_installs/redpanda",
     redpanda_binary = "//:redpanda",
-    rpath_override = "$ORIGIN/../lib",
     rpk_binary = ":rpk",
     sysroot_runtime = ":sysroot_runtime",
 )
@@ -68,7 +66,6 @@ redpanda_package(
     default_yaml_config = "//conf:redpanda.yaml",
     owner = NONROOT_USER,
     redpanda_binary = "//:redpanda",
-    rpath_override = "$ORIGIN/../lib",
     rpk_binary = ":rpk",
 )
 

--- a/bazel/packaging/BUILD
+++ b/bazel/packaging/BUILD
@@ -39,7 +39,6 @@ redpanda_package(
     iotune = "@seastar//:iotune",
     openssl = "@openssl//:openssl_binary",
     redpanda_binary = "//:redpanda",
-    rpath_override = "$ORIGIN/../lib",
     rpk_binary = ":rpk",
     sysroot_runtime = ":sysroot_runtime",
 )

--- a/bazel/packaging/packaging.bzl
+++ b/bazel/packaging/packaging.bzl
@@ -13,19 +13,6 @@ def _patched_file(ctx, original, suffix):
     name = "patched/{}/{}_{}".format(ctx.label.name, original.basename, suffix)
     return ctx.actions.declare_file(name)
 
-def _override_binary_rpath(ctx, path_override, original_binary):
-    patched_binary = _patched_file(ctx, original_binary, "patched")
-
-    ctx.actions.run(
-        inputs = [original_binary],
-        outputs = [patched_binary],
-        executable = ctx.executable._patchelf,
-        arguments = ["--set-rpath", path_override, original_binary.path, "--output", patched_binary.path],
-        tools = [],
-        mnemonic = "OverrideBinaryRPath",
-    )
-    return patched_binary
-
 def _set_dynamic_loader(ctx, binary, loader, interpreter_path):
     """Uses provided dynamic loader as the interpreter for the binary"""
     patched_binary = _patched_file(ctx, binary, "ld")
@@ -72,12 +59,6 @@ def _prepare_package_binaries(ctx, binaries, dynamic_loader_path):
                 continue
             shared_libraries.append(solib)
         file = binary.file
-        if ctx.attr.rpath_override != "" and binary.patch_rpath:
-            file = _override_binary_rpath(
-                ctx,
-                ctx.attr.rpath_override,
-                file,
-            )
         if ctx.attr.include_sysroot_libs:
             file = _set_dynamic_loader(
                 ctx,
@@ -93,17 +74,16 @@ def _prepare_redpanda_package_content(ctx, dynamic_loader_path):
     # Collect all the shared libraries that we built as part of each binary.
     # NOTE: We don't need to do this for `rpk` because it's a static binary,
     # this is only needed for binaries with shared libraries.
-    # Bazel-built binaries (redpanda, rp_util, iotune) link with
-    # -Wl,-rpath,$ORIGIN/../lib (see their BUILD files), so their rpath is
-    # never patched here; only the foreign_cc binaries (hwloc, openssl),
-    # whose link flags we do not control, get the rpath_override patch.
+    # All packaged binaries link with an $ORIGIN/../lib rpath baked in at
+    # link time (see their BUILD files; the foreign_cc ones get it via
+    # LDFLAGS/Configure flags), so packaging never patches rpaths.
     binaries = [
-        struct(attr = ctx.attr.redpanda_binary, file = ctx.file.redpanda_binary, patch_rpath = False),
-        struct(attr = ctx.attr.rp_util, file = ctx.file.rp_util, patch_rpath = False),
-        struct(attr = ctx.attr.iotune, file = ctx.file.iotune, patch_rpath = False),
-        struct(attr = ctx.attr.hwloc_calc, file = ctx.file.hwloc_calc, patch_rpath = True),
-        struct(attr = ctx.attr.hwloc_distrib, file = ctx.file.hwloc_distrib, patch_rpath = True),
-        struct(attr = ctx.attr.openssl, file = ctx.file.openssl, patch_rpath = True),
+        struct(attr = ctx.attr.redpanda_binary, file = ctx.file.redpanda_binary),
+        struct(attr = ctx.attr.rp_util, file = ctx.file.rp_util),
+        struct(attr = ctx.attr.iotune, file = ctx.file.iotune),
+        struct(attr = ctx.attr.hwloc_calc, file = ctx.file.hwloc_calc),
+        struct(attr = ctx.attr.hwloc_distrib, file = ctx.file.hwloc_distrib),
+        struct(attr = ctx.attr.openssl, file = ctx.file.openssl),
     ]
 
     package_binaries = _prepare_package_binaries(
@@ -329,10 +309,6 @@ redpanda_package = rule(
             allow_files = True,
             doc = "Sysroot shared libraries plus the glibc dynamic loader. Shipped to install_path/lib; the loader (basename ld-linux-*) is also set as the binaries' interpreter.",
         ),
-        "rpath_override": attr.string(
-            mandatory = False,
-            doc = "rpath to patch into foreign_cc binaries (hwloc, openssl). Bazel-built binaries bake $ORIGIN/../lib at link time and are never patched.",
-        ),
         "install_path": attr.string(
             default = "/opt/redpanda",
             doc = "The path where the package will be installed, used to set the interpreter path.",
@@ -356,7 +332,7 @@ def _prepapare_package_conent(ctx):
     cc_binaries = [
     ]
     for b in ctx.attr.cc_binaries:
-        cc_binaries += [struct(attr = b, file = file, patch_rpath = True) for file in b.files.to_list()]
+        cc_binaries += [struct(attr = b, file = file) for file in b.files.to_list()]
 
     package_cc_binaries = _prepare_package_binaries(
         ctx,
@@ -437,9 +413,6 @@ native_package = rule(
             allow_files = True,
             doc = "Sysroot shared libraries plus the glibc dynamic loader. Shipped to install_path/lib; the loader (basename ld-linux-*) is also set as the binaries' interpreter.",
         ),
-        "rpath_override": attr.string(
-            default = "$ORIGIN/../lib",
-        ),
         "owner": attr.int(),
         "install_path": attr.string(
             mandatory = True,
@@ -513,26 +486,26 @@ def _prepare_deb_package_content(ctx, dynamic_loader_path):
     binaries = []
     binary_map = {}
 
-    # See _prepare_redpanda_package_content for the patch_rpath split between
-    # bazel-built binaries (rpath baked at link time) and foreign_cc ones.
+    # See _prepare_redpanda_package_content: all packaged binaries bake their
+    # rpath at link time, so packaging never patches rpaths.
     if ctx.file.redpanda_binary != None:
         binary_map["redpanda_binary"] = len(binaries)
-        binaries.append(struct(attr = ctx.attr.redpanda_binary, file = ctx.file.redpanda_binary, patch_rpath = False))
+        binaries.append(struct(attr = ctx.attr.redpanda_binary, file = ctx.file.redpanda_binary))
     if ctx.file.rp_util != None:
         binary_map["rp_util"] = len(binaries)
-        binaries.append(struct(attr = ctx.attr.rp_util, file = ctx.file.rp_util, patch_rpath = False))
+        binaries.append(struct(attr = ctx.attr.rp_util, file = ctx.file.rp_util))
     if ctx.file.iotune != None:
         binary_map["iotune"] = len(binaries)
-        binaries.append(struct(attr = ctx.attr.iotune, file = ctx.file.iotune, patch_rpath = False))
+        binaries.append(struct(attr = ctx.attr.iotune, file = ctx.file.iotune))
     if ctx.file.hwloc_calc != None:
         binary_map["hwloc_calc"] = len(binaries)
-        binaries.append(struct(attr = ctx.attr.hwloc_calc, file = ctx.file.hwloc_calc, patch_rpath = True))
+        binaries.append(struct(attr = ctx.attr.hwloc_calc, file = ctx.file.hwloc_calc))
     if ctx.file.hwloc_distrib != None:
         binary_map["hwloc_distrib"] = len(binaries)
-        binaries.append(struct(attr = ctx.attr.hwloc_distrib, file = ctx.file.hwloc_distrib, patch_rpath = True))
+        binaries.append(struct(attr = ctx.attr.hwloc_distrib, file = ctx.file.hwloc_distrib))
     if ctx.file.openssl != None:
         binary_map["openssl"] = len(binaries)
-        binaries.append(struct(attr = ctx.attr.openssl, file = ctx.file.openssl, patch_rpath = True))
+        binaries.append(struct(attr = ctx.attr.openssl, file = ctx.file.openssl))
 
     package_binaries = _prepare_package_binaries(
         ctx,
@@ -727,9 +700,6 @@ redpanda_deb_package = rule(
         "sysroot_runtime": attr.label(
             allow_files = True,
             doc = "Sysroot shared libraries plus the glibc dynamic loader. Shipped to install_path/lib; the loader (basename ld-linux-*) is also set as the binaries' interpreter.",
-        ),
-        "rpath_override": attr.string(
-            default = "$ORIGIN/../lib",
         ),
         "owner": attr.int(
             default = 0,

--- a/bazel/packaging/packaging.bzl
+++ b/bazel/packaging/packaging.bzl
@@ -72,7 +72,7 @@ def _prepare_package_binaries(ctx, binaries, dynamic_loader_path):
                 continue
             shared_libraries.append(solib)
         file = binary.file
-        if ctx.attr.rpath_override != "":
+        if ctx.attr.rpath_override != "" and binary.patch_rpath:
             file = _override_binary_rpath(
                 ctx,
                 ctx.attr.rpath_override,
@@ -93,13 +93,17 @@ def _prepare_redpanda_package_content(ctx, dynamic_loader_path):
     # Collect all the shared libraries that we built as part of each binary.
     # NOTE: We don't need to do this for `rpk` because it's a static binary,
     # this is only needed for binaries with shared libraries.
+    # Bazel-built binaries (redpanda, rp_util, iotune) link with
+    # -Wl,-rpath,$ORIGIN/../lib (see their BUILD files), so their rpath is
+    # never patched here; only the foreign_cc binaries (hwloc, openssl),
+    # whose link flags we do not control, get the rpath_override patch.
     binaries = [
-        struct(attr = ctx.attr.redpanda_binary, file = ctx.file.redpanda_binary),
-        struct(attr = ctx.attr.rp_util, file = ctx.file.rp_util),
-        struct(attr = ctx.attr.iotune, file = ctx.file.iotune),
-        struct(attr = ctx.attr.hwloc_calc, file = ctx.file.hwloc_calc),
-        struct(attr = ctx.attr.hwloc_distrib, file = ctx.file.hwloc_distrib),
-        struct(attr = ctx.attr.openssl, file = ctx.file.openssl),
+        struct(attr = ctx.attr.redpanda_binary, file = ctx.file.redpanda_binary, patch_rpath = False),
+        struct(attr = ctx.attr.rp_util, file = ctx.file.rp_util, patch_rpath = False),
+        struct(attr = ctx.attr.iotune, file = ctx.file.iotune, patch_rpath = False),
+        struct(attr = ctx.attr.hwloc_calc, file = ctx.file.hwloc_calc, patch_rpath = True),
+        struct(attr = ctx.attr.hwloc_distrib, file = ctx.file.hwloc_distrib, patch_rpath = True),
+        struct(attr = ctx.attr.openssl, file = ctx.file.openssl, patch_rpath = True),
     ]
 
     package_binaries = _prepare_package_binaries(
@@ -325,7 +329,10 @@ redpanda_package = rule(
             allow_files = True,
             doc = "Sysroot shared libraries plus the glibc dynamic loader. Shipped to install_path/lib; the loader (basename ld-linux-*) is also set as the binaries' interpreter.",
         ),
-        "rpath_override": attr.string(mandatory = False),
+        "rpath_override": attr.string(
+            mandatory = False,
+            doc = "rpath to patch into foreign_cc binaries (hwloc, openssl). Bazel-built binaries bake $ORIGIN/../lib at link time and are never patched.",
+        ),
         "install_path": attr.string(
             default = "/opt/redpanda",
             doc = "The path where the package will be installed, used to set the interpreter path.",
@@ -349,7 +356,7 @@ def _prepapare_package_conent(ctx):
     cc_binaries = [
     ]
     for b in ctx.attr.cc_binaries:
-        cc_binaries += [struct(attr = b, file = file) for file in b.files.to_list()]
+        cc_binaries += [struct(attr = b, file = file, patch_rpath = True) for file in b.files.to_list()]
 
     package_cc_binaries = _prepare_package_binaries(
         ctx,
@@ -506,24 +513,26 @@ def _prepare_deb_package_content(ctx, dynamic_loader_path):
     binaries = []
     binary_map = {}
 
+    # See _prepare_redpanda_package_content for the patch_rpath split between
+    # bazel-built binaries (rpath baked at link time) and foreign_cc ones.
     if ctx.file.redpanda_binary != None:
         binary_map["redpanda_binary"] = len(binaries)
-        binaries.append(struct(attr = ctx.attr.redpanda_binary, file = ctx.file.redpanda_binary))
+        binaries.append(struct(attr = ctx.attr.redpanda_binary, file = ctx.file.redpanda_binary, patch_rpath = False))
     if ctx.file.rp_util != None:
         binary_map["rp_util"] = len(binaries)
-        binaries.append(struct(attr = ctx.attr.rp_util, file = ctx.file.rp_util))
+        binaries.append(struct(attr = ctx.attr.rp_util, file = ctx.file.rp_util, patch_rpath = False))
     if ctx.file.iotune != None:
         binary_map["iotune"] = len(binaries)
-        binaries.append(struct(attr = ctx.attr.iotune, file = ctx.file.iotune))
+        binaries.append(struct(attr = ctx.attr.iotune, file = ctx.file.iotune, patch_rpath = False))
     if ctx.file.hwloc_calc != None:
         binary_map["hwloc_calc"] = len(binaries)
-        binaries.append(struct(attr = ctx.attr.hwloc_calc, file = ctx.file.hwloc_calc))
+        binaries.append(struct(attr = ctx.attr.hwloc_calc, file = ctx.file.hwloc_calc, patch_rpath = True))
     if ctx.file.hwloc_distrib != None:
         binary_map["hwloc_distrib"] = len(binaries)
-        binaries.append(struct(attr = ctx.attr.hwloc_distrib, file = ctx.file.hwloc_distrib))
+        binaries.append(struct(attr = ctx.attr.hwloc_distrib, file = ctx.file.hwloc_distrib, patch_rpath = True))
     if ctx.file.openssl != None:
         binary_map["openssl"] = len(binaries)
-        binaries.append(struct(attr = ctx.attr.openssl, file = ctx.file.openssl))
+        binaries.append(struct(attr = ctx.attr.openssl, file = ctx.file.openssl, patch_rpath = True))
 
     package_binaries = _prepare_package_binaries(
         ctx,

--- a/bazel/thirdparty/hwloc.BUILD
+++ b/bazel/thirdparty/hwloc.BUILD
@@ -44,6 +44,12 @@ configure_make(
         # headers (helper.h, plugins.h) produce deterministic assert strings.
         "CFLAGS": "-ffile-prefix-map=$$EXT_BUILD_ROOT=.",
         "CXXFLAGS": "-ffile-prefix-map=$$EXT_BUILD_ROOT=.",
+        # Bake an $ORIGIN-relative rpath so packaging does not need to patch
+        # it (see //bazel/packaging). The escaping survives four evaluations:
+        # the foreign_cc bash export, configure's conftest links, Makefile
+        # variable expansion, and the recipe shell, so the linker sees a
+        # literal $ORIGIN.
+        "LDFLAGS": "-Wl,-rpath,\\\\$$\\$$ORIGIN/../lib",
     },
     lib_source = ":srcs",
     out_binaries = [

--- a/bazel/thirdparty/openssl.BUILD
+++ b/bazel/thirdparty/openssl.BUILD
@@ -60,6 +60,12 @@ configure_make(
         "--libdir=lib",
         "no-tests",
         "no-docs",
+        # Bake an $ORIGIN-relative rpath so packaging does not need to patch
+        # it (see //bazel/packaging). The escaping survives four evaluations:
+        # the unquoted foreign_cc script word, the generated Makefile,
+        # Makefile variable expansion, and the recipe shell, so the linker
+        # sees a literal $ORIGIN.
+        "-Wl,-rpath,\\\\\\$$\\$$ORIGIN/../lib",
     ] + select({
         ":debug_mode": ["--debug"],
         ":release_mode": ["--release"],

--- a/bazel/thirdparty/seastar.BUILD
+++ b/bazel/thirdparty/seastar.BUILD
@@ -775,6 +775,11 @@ cc_binary(
     srcs = [
         "apps/iotune/iotune.cc",
     ],
+    # Resolve bundled shared libraries from lib/ next to the install's bin/,
+    # so packaging does not need to patch the rpath (see //bazel/packaging).
+    linkopts = [
+        "-Wl,-rpath,$$ORIGIN/../lib",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         ":seastar",

--- a/src/v/redpanda/BUILD
+++ b/src/v/redpanda/BUILD
@@ -187,6 +187,10 @@ redpanda_cc_binary(
         # than packing segments into a single mapping.
         "-Wl,-z,max-page-size=2097152",
         "-Wl,-z,separate-loadable-segments",
+        # Resolve bundled shared libraries from lib/ next to the install's
+        # bin/, so packaging does not need to patch the rpath. Inert in the
+        # build tree, where $ORIGIN/../lib does not exist.
+        "-Wl,-rpath,$$ORIGIN/../lib",
     ] + select({
         ":use_emit_relocs": [
             "-Wl,--emit-relocs",

--- a/src/v/rp_util/BUILD
+++ b/src/v/rp_util/BUILD
@@ -12,6 +12,11 @@ redpanda_cc_binary(
     copts = [
         "-Wno-backend-plugin",
     ],
+    # Resolve bundled shared libraries from lib/ next to the install's bin/,
+    # so packaging does not need to patch the rpath (see //bazel/packaging).
+    linkopts = [
+        "-Wl,-rpath,$$ORIGIN/../lib",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/base",


### PR DESCRIPTION
The packaging rules run two patchelf stages over every packaged binary, per consuming target: an rpath rewrite to `$ORIGIN/../lib` (OverrideBinaryRPath) and an interpreter rewrite (SetDynamicLoader). Because outputs are namespaced by the consuming target, a warm build of the packaging targets materializes nine patched copies of the 2.2 GB redpanda binary, each a distinct CAS blob that gets produced, uploaded to the remote cache, stored, and re-downloaded by consumers.

This PR eliminates the rpath stage entirely by baking the rpath at link time instead:

* `redpanda`, `rp_util` and `iotune` link with `-Wl,-rpath,$ORIGIN/../lib` via their `linkopts`.
* The foreign_cc binaries get the same flag through their build systems: `hwloc` via an `LDFLAGS` env entry, `openssl` via a `Configure` command-line flag. The escaping in those two BUILD files is chosen so a literal `$ORIGIN` survives every evaluation layer (the foreign_cc script, configure, Makefile expansion, and the recipe shell); the resulting `DT_RUNPATH` is byte-identical to what patchelf used to write.

The baked entry is inert in the build tree (`bin/../lib` does not exist next to the build output, so `bazel test` and dev workflows see no change), and the preexisting bazel `_solib` RUNPATH entries are inert in an install tree, so runtime behavior is identical in both contexts. With no binaries left to patch, the rpath patching machinery (`OverrideBinaryRPath`, the `rpath_override` attribute) is removed from the packaging rules; each packaged binary now produces exactly one patched output (the interpreter stage) instead of two chained ones.

Savings, per warm build per configuration (sizes from the CI opt build; see the measurements in CORE-16997):

* Patched redpanda copies drop from 9 (19.8 GB) to 4 (8.8 GB): the five rpath-only copies are no longer produced at all, about **11.0 GB less unique output** per build that is no longer written to disk, uploaded to and stored in the remote cache, or fetched by any cache consumer whose `--remote_download_regex` matches `bazel/packaging`. `iotune`, `hwloc-calc`, `hwloc-distrib` and `openssl` similarly lose their rpath copies (a further ~66 MB).
* Five fewer patchelf passes over the 2.2 GB binary per build: roughly 11 GB fewer executor disk writes (about 22 GB less I/O counting the reads back), plus their wall clock off the packaging critical path.
* On dev machines, the redpanda copies under `bazel-out` after a warm `bazel test //...` drop from 23.7 GB to about 12.7 GB.

`oci_image_contents` only needed the rpath stage, so the container image now ships the binary byte-identical to the build output. The vtools release pipeline is unaffected: it takes the binaries from `bazel_out.tar.gz`, re-sets the interpreter itself, and relies on the `$ORIGIN/../lib` rpath, which is now baked in rather than patched in. Two behavioral notes: the shipped `libssl.so.3`/`libcrypto.so.3` gain a benign self-referential `$ORIGIN/../lib` runpath (their build flags changed, so expect a one-time openssl rebuild + relink), and redpanda/iotune keep their inert bazel `_solib` RUNPATH entries ahead of `$ORIGIN/../lib` where patchelf used to replace the whole list (verified those entries resolve nowhere in any install layout).

The interpreter stage (SetDynamicLoader) is unchanged; deduplicating or eliminating the remaining four `redpanda_ld` copies is a follow-up.

Verified locally: built all packaging targets and confirmed the rpath stage is gone from the action graph with only `_ld` outputs remaining; `readelf` shows the expected `DT_RUNPATH` and interpreter on every packaged binary (including the tuner deb's unpatched hwloc binaries); the in-tree binary runs normally; `redpanda --version` and `openssl version` run from the extracted vtools tarball tree via the shipped loader, with openssl resolving the bundled `libssl`/`libcrypto` purely via the baked rpath; an install-shaped tree without sysroot libs (the OCI configuration) resolves the bundled solibs via the baked rpath under the host loader.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none