### PR TITLE
bazel: Apply Wno-backend-plugin to abseil crc_x86_arm_combined.cc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -139,6 +139,11 @@ build --host_per_file_copt=external/ragel.*@-Wno-return-type
 build --per_file_copt=external/.*@-Wno-attribute-alias
 build --host_per_file_copt=external/.*@-Wno-attribute-alias
 
+# Abseil marks every runtime-selected CRC variant hot, but a profile only
+# exercises the variant selected for the training CPU.
+build --per_file_copt=external/abseil-cpp.*/absl/crc/internal/crc_x86_arm_combined.cc@-Wno-backend-plugin
+build --host_per_file_copt=external/abseil-cpp.*/absl/crc/internal/crc_x86_arm_combined.cc@-Wno-backend-plugin
+
 # All C/C++ compiles build with -Werror, including external modules: the
 # suppressions above keep them warning-free, and this stops new warnings
 # (e.g. from toolchain bumps) from scrolling by unnoticed. per_file_copt


### PR DESCRIPTION
We were seeing:

```
error: external/abseil-cpp+/absl/crc/internal/crc_x86_arm_combined.cc: Function _ZNK4absl12lts_2025081412crc_internal12_GLOBAL__N_145CRC32AcceleratedX86ARMCombinedMultipleStreamsILm1ELm2ELNS2_14CutoffStrategyE1EE6ExtendEPjPKvm is annotated as a hot function but the profile is cold [-Werror,-Wbackend-plugin]
```

`CRC32AcceleratedX86ARMCombinedMultipleStreams::Extend` is marked
`__hot__`.

However, it's a template with non-type template parameters which are
chosen based on the host CPU type.

In training naturally only ever one of those instantiations gets trained
on. The others stay cold.

LLVM emits a warning when a function marked `__hot__` has cold profile
data.

With our new -Werror in external files this caused a build failure.
Silence the warning in that file to fix the build.
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none

