### PR TITLE
k/s/tests: deflake the offset_store producer lock test

### DIFF
--- a/src/v/kafka/server/tests/offset_store_test.cc
+++ b/src/v/kafka/server/tests/offset_store_test.cc
@@ -687,6 +687,7 @@ TEST_F(offset_store_test, a_transaction_expires_at_its_deadline) {
 TEST_F_CORO(offset_store_test, the_producer_lock_serializes_by_producer) {
     int running = 0;
     int most_concurrent = 0;
+    ss::promise<> first_running;
     ss::promise<> release_first;
 
     const auto operation = [&running, &most_concurrent](auto f) {
@@ -701,8 +702,15 @@ TEST_F_CORO(offset_store_test, the_producer_lock_serializes_by_producer) {
     };
 
     auto held = store.with_pid_lock(
-      model::producer_id(7),
-      operation([&release_first] { return release_first.get_future(); }));
+      model::producer_id(7), operation([&first_running, &release_first] {
+          first_running.set_value();
+          return release_first.get_future();
+      }));
+
+    // the reactor gives no ordering guarantee between this operation and the
+    // ones started below, so wait for it to hold the lock rather than assume
+    // it ran first
+    co_await first_running.get_future();
 
     // a second operation for the same producer waits for the first
     auto queued = store.with_pid_lock(
@@ -712,10 +720,12 @@ TEST_F_CORO(offset_store_test, the_producer_lock_serializes_by_producer) {
     co_await store.with_pid_lock(
       model::producer_id(8), operation([] { return ss::now(); }));
 
-    ASSERT_EQ_CORO(most_concurrent, 2);
+    // non-fatal: the operations above hold references into this coroutine's
+    // frame, so it must reach the awaits below even when a check fails
+    EXPECT_EQ(most_concurrent, 2);
 
     // producer 7 still holds the lock, so the operation behind it has not run
-    ASSERT_FALSE_CORO(queued.available());
+    EXPECT_FALSE(queued.available());
 
     release_first.set_value();
     co_await std::move(held);


### PR DESCRIPTION
`the_producer_lock_serializes_by_producer` asserted that two operations ran concurrently, which requires the first producer's operation to start before the second producer's runs. Both are scheduled as tasks in debug builds, and nothing ordered them: under `--@seastar//:shuffle_task_queue=true` the second can run to completion first (reproduced in 10/30 runs, 0/100 after the fix). Wait for the first operation to hold the lock instead.

The mid-test checks also become non-fatal. `ASSERT_*_CORO` expands to `co_return`, which freed a coroutine frame the pending operations still referenced, so the assertion failure surfaced as a heap-use-after-free that masked it. Test-only change.

## Backports Required

- [ ] none - papercut/not impactful enough to backport
- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none