### PR TITLE
kafka/client/test: deflake data_queue blocking push test

### DIFF
--- a/src/v/kafka/client/direct_consumer/tests/data_queue_test.cc
+++ b/src/v/kafka/client/direct_consumer/tests/data_queue_test.cc
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0
 
 #include "kafka/client/direct_consumer/data_queue.h"
+#include "test_utils/async.h"
 
 #include <gtest/gtest.h>
 
@@ -164,13 +165,13 @@ TEST(DataQueueTest, TestBlockingPushWhenFull) {
     ASSERT_FALSE(queue.can_insert(50));
 
     auto push_future = queue.push(make_data(1, 50), 50);
+    tests::drain_task_queue().get();
     ASSERT_FALSE(push_future.available());
     ASSERT_EQ(queue.size(), max_count);
     ASSERT_EQ(queue.current_bytes(), max_count * 50);
 
-    queue.pop(std::chrono::milliseconds(100)).get();
-    ASSERT_EQ(queue.size(), max_count - 1);
-    ASSERT_EQ(queue.current_bytes(), (max_count - 1) * 50);
+    auto fetches = queue.pop(std::chrono::milliseconds(100)).get();
+    ASSERT_EQ(fetches.value().size(), 1);
 
     push_future.get();
     ASSERT_EQ(queue.size(), max_count);


### PR DESCRIPTION
`TestBlockingPushWhenFull` asserted the queue size between a `pop()` and the
resumption of a push blocked on a full queue. `pop()` signals the condition
variable the push waits on, so the push can resume first, which
`--@seastar//:shuffle_task_queue=true` exposes about a quarter of the time. The
queue itself is fine.

Assert on the popped value instead, and drain the task queue before checking
that the push has not completed.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none
