### PR TITLE
storage: bump segment_concatenation_test timeout

### DIFF
--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -561,7 +561,7 @@ redpanda_cc_gtest(
 
 redpanda_cc_gtest(
     name = "segment_concatenation_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "segment_concatenation_test.cc",
     ],


### PR DESCRIPTION
`segment_concatenation_test` is declared `timeout = "short"` (60s), but the
two 100-segment params take ~11s each locally, putting the whole target at
36s — 61% of its budget. The test is fsync-bound (`fsync::yes` appends plus
sanitized file config), so on a CI host with slower syncs it runs past 60s
and bazel kills it mid-test, which reads as a flake.

Bumping to `moderate` (300s) gives ~3x headroom over the slowest observed
run. `shuffle_task_queue` was incidental: measured locally it costs ~3%.

The test carries the same `short` timeout and 100-segment params on all
three release branches, so the flake applies there too.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [x] v25.3.x

## Release Notes

* none