### PR TITLE
[v26.2.x] storage: bump segment_concatenation_test timeout

### DIFF
--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -544,7 +544,7 @@ redpanda_cc_gtest(
 
 redpanda_cc_gtest(
     name = "segment_concatenation_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "segment_concatenation_test.cc",
     ],


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31568
