### PR TITLE
rpk/registry: document print flag exclusivity in help text

### DIFF
--- a/src/go/rpk/pkg/cli/registry/schema/get.go
+++ b/src/go/rpk/pkg/cli/registry/schema/get.go
@@ -49,6 +49,8 @@ potential (mutually exclusive) ways:
 To print the schema, use the '--print-schema' flag.
 
 To print schema metadata properties, use the '--print-metadata' flag.
+
+The '--print-schema' and '--print-metadata' flags are mutually exclusive.
 `,
 		Args: cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -162,8 +164,8 @@ To print schema metadata properties, use the '--print-metadata' flag.
 	cmd.Flags().StringVar(&schemaFile, "schema", "", "Schema file to check existence of, must be .avro, .json or .proto; subject required")
 	cmd.Flags().StringVar(&schemaType, "type", "", fmt.Sprintf("Schema type of the file used to lookup (%v); overrides schema file extension", strings.Join(supportedTypes, ",")))
 	cmd.Flags().BoolVar(&deleted, "deleted", false, "If true, also return deleted schemas")
-	cmd.Flags().BoolVar(&printSchema, "print-schema", false, "Prints the schema in JSON format")
-	cmd.Flags().BoolVar(&printMetadata, "print-metadata", false, "Print the schema metadata properties")
+	cmd.Flags().BoolVar(&printSchema, "print-schema", false, "Prints the schema in JSON format; cannot be combined with --print-metadata")
+	cmd.Flags().BoolVar(&printMetadata, "print-metadata", false, "Print the schema metadata properties; cannot be combined with --print-schema")
 
 	cmd.MarkFlagsMutuallyExclusive("print-schema", "print-metadata")
 	cmd.RegisterFlagCompletionFunc("type", validTypes())


### PR DESCRIPTION
`rpk registry schema get` marks `--print-schema` and `--print-metadata` as mutually exclusive (`MarkFlagsMutuallyExclusive`, added in #29431), but the help text doesn't say so — users only discover the constraint by hitting the cobra runtime error, and the docs team's generated CLI reference (built from `rpk --print-tree` output) can't state it either.

This adds the constraint to both flag descriptions (matching the existing semicolon-qualifier style, for example "subject required") and as a line in the long help.

Help-text only; no behavior change.

## Backports Required

- [x] none - papercut/not impactful enough to backport

## Release Notes

* none

🤖 Generated with [Claude Code](https://claude.com/claude-code)