### PR TITLE
[CORE-16806] - KIP-848: assignor interface and the homogeneous uniform assignor

### DIFF
--- a/src/v/kafka/server/BUILD
+++ b/src/v/kafka/server/BUILD
@@ -26,6 +26,23 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "consumer_group_assignor",
+    srcs = [
+        "consumer_group_assignor.cc",
+    ],
+    hdrs = [
+        "consumer_group_assignor.h",
+    ],
+    visibility = [":__subpackages__"],
+    deps = [
+        "//src/v/base",
+        "//src/v/container:chunked_vector",
+        "//src/v/kafka/protocol",
+        "//src/v/model",
+    ],
+)
+
+redpanda_cc_library(
     name = "topic_config_utils",
     srcs = [
         "handlers/configs/config_response_utils.cc",

--- a/src/v/kafka/server/BUILD
+++ b/src/v/kafka/server/BUILD
@@ -29,13 +29,16 @@ redpanda_cc_library(
     name = "consumer_group_assignor",
     srcs = [
         "consumer_group_assignor.cc",
+        "uniform_assignor.cc",
     ],
     hdrs = [
         "consumer_group_assignor.h",
+        "uniform_assignor.h",
     ],
     visibility = [":__subpackages__"],
     deps = [
         "//src/v/base",
+        "//src/v/container:chunked_hash_map",
         "//src/v/container:chunked_vector",
         "//src/v/kafka/protocol",
         "//src/v/model",

--- a/src/v/kafka/server/consumer_group_assignor.cc
+++ b/src/v/kafka/server/consumer_group_assignor.cc
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "kafka/server/consumer_group_assignor.h"
+
+#include "base/vassert.h"
+
+#include <algorithm>
+#include <utility>
+
+namespace kafka {
+
+void member_assignment::assign(
+  model::topic_id topic, model::partition_id partition) {
+    // An assignor assigns one topic's partitions in consecutive calls, so
+    // the entry to extend is almost always the last one.
+    if (!_topics.empty() && _topics.back().topic == topic) {
+        _topics.back().partitions.push_back(partition);
+        return;
+    }
+    auto found = std::ranges::find(_topics, topic, &topic_partitions::topic);
+    if (found == _topics.end()) {
+        _topics.push_back({.topic = topic});
+        found = std::prev(_topics.end());
+    }
+    found->partitions.push_back(partition);
+}
+
+void member_assignment::assign(
+  model::topic_id topic, partition_set partitions) {
+    vassert(
+      std::ranges::is_sorted(partitions),
+      "{} assigned out of partition id order",
+      topic);
+    vassert(
+      _topics.empty() || _topics.back().topic < topic,
+      "{} is assigned after {}",
+      topic,
+      _topics.back().topic);
+    _topics.push_back({.topic = topic, .partitions = std::move(partitions)});
+}
+
+const partition_set*
+member_assignment::partitions_of(model::topic_id topic) const {
+    auto found = std::ranges::find(_topics, topic, &topic_partitions::topic);
+    return found == _topics.end() ? nullptr : &found->partitions;
+}
+
+size_t member_assignment::num_partitions() const {
+    return std::ranges::fold_left(
+      _topics, size_t{0}, [](size_t total, const topic_partitions& entry) {
+          return total + entry.partitions.size();
+      });
+}
+
+void member_assignment::sort() {
+    std::ranges::sort(_topics, {}, &topic_partitions::topic);
+    for (auto& [topic, partitions] : _topics) {
+        std::ranges::sort(partitions);
+    }
+}
+
+member_assignment member_assignment::copy() const {
+    member_assignment out;
+    out._topics.reserve(_topics.size());
+    for (const auto& entry : _topics) {
+        out._topics.push_back(entry.copy());
+    }
+    return out;
+}
+
+group_assignment::group_assignment(size_t members) {
+    _members.reserve(members);
+    while (_members.size() < members) {
+        _members.push_back({});
+    }
+}
+
+void group_assignment::sort() {
+    std::ranges::for_each(_members, &member_assignment::sort);
+}
+
+group_spec::group_spec(chunked_vector<member_spec> members)
+  : _members(std::move(members)) {
+    _type = std::ranges::all_of(
+              _members,
+              [&](const member_spec& member) {
+                  return member.subscribed_topics
+                         == _members.front().subscribed_topics;
+              })
+              ? subscription_type::homogeneous
+              : subscription_type::heterogeneous;
+}
+
+fmt::iterator format_to(subscription_type type, fmt::iterator it) {
+    switch (type) {
+    case subscription_type::homogeneous:
+        return fmt::format_to(it, "homogeneous");
+    case subscription_type::heterogeneous:
+        return fmt::format_to(it, "heterogeneous");
+    }
+    std::unreachable();
+}
+
+fmt::iterator format_to(assignor_errc errc, fmt::iterator it) {
+    switch (errc) {
+    case assignor_errc::unknown_topic:
+        return fmt::format_to(it, "unknown_topic");
+    case assignor_errc::unknown_partition:
+        return fmt::format_to(it, "unknown_partition");
+    case assignor_errc::malformed_assignment:
+        return fmt::format_to(it, "malformed_assignment");
+    case assignor_errc::malformed_subscription:
+        return fmt::format_to(it, "malformed_subscription");
+    case assignor_errc::partitions_left_unassigned:
+        return fmt::format_to(it, "partitions_left_unassigned");
+    case assignor_errc::invalid_partition_count:
+        return fmt::format_to(it, "invalid_partition_count");
+    }
+    std::unreachable();
+}
+
+fmt::iterator assignor_error::format_to(fmt::iterator it) const {
+    it = fmt::format_to(it, "{{errc: {}, topic: {}", errc, topic);
+    if (partition.has_value()) {
+        it = fmt::format_to(it, ", partition: {}", *partition);
+    }
+    return fmt::format_to(it, "}}");
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/consumer_group_assignor.h
+++ b/src/v/kafka/server/consumer_group_assignor.h
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "base/format_to.h"
+#include "base/vassert.h"
+#include "container/chunked_vector.h"
+#include "kafka/protocol/types.h"
+#include "model/fundamental.h"
+
+#include <expected>
+#include <optional>
+#include <string_view>
+
+namespace kafka {
+
+/// The partitions of one topic assigned to one member, in order of increasing
+/// partition id.
+using partition_set = chunked_vector<model::partition_id>;
+
+/// What one member is assigned of one topic.
+struct topic_partitions {
+    model::topic_id topic;
+    partition_set partitions;
+
+    topic_partitions copy() const {
+        return {.topic = topic, .partitions = partitions.copy()};
+    }
+
+    friend bool
+    operator==(const topic_partitions&, const topic_partitions&) = default;
+};
+
+/// The partitions assigned to one member. `assign` appends, so the topics keep
+/// the order the assignor added them until `sort` puts them in order of
+/// increasing topic id. An assignment the assignor hands back is sorted.
+class member_assignment {
+public:
+    using const_iterator = chunked_vector<topic_partitions>::const_iterator;
+
+    member_assignment() = default;
+
+    /// Assigns one more partition of `topic`.
+    void assign(model::topic_id topic, model::partition_id);
+
+    /// Assigns some partitions of the specified topic to this group member.
+    /// This operation is sensitive to order:
+    /// - topics must be assigned in order of increasing topic_id
+    /// - each partition_set must be sorted by increasing partition_id
+    void assign(model::topic_id topic, partition_set partitions);
+
+    /// This member's partitions of `topic`, or nullptr if it has none.
+    const partition_set* partitions_of(model::topic_id topic) const;
+
+    /// How many partitions are assigned, across every topic.
+    size_t num_partitions() const;
+
+    bool empty() const { return _topics.empty(); }
+    const_iterator begin() const { return _topics.begin(); }
+    const_iterator end() const { return _topics.end(); }
+
+    /// Puts the topics and their partitions in increasing order.
+    void sort();
+
+    member_assignment copy() const;
+
+    friend bool
+    operator==(const member_assignment&, const member_assignment&) = default;
+
+private:
+    chunked_vector<topic_partitions> _topics;
+};
+
+/// An assignment for a whole group: one entry per member, in the same order as
+/// `group_spec::members()`, so entry `i` belongs to member `i`.
+class group_assignment {
+public:
+    group_assignment() = default;
+
+    /// An assignment of nothing to each of `members` members.
+    explicit group_assignment(size_t members);
+
+    member_assignment& operator[](size_t member) noexcept {
+        vassert(
+          member < _members.size(),
+          "member {} of a {} member assignment",
+          member,
+          _members.size());
+        return _members[member];
+    }
+    const member_assignment& operator[](size_t member) const noexcept {
+        vassert(
+          member < _members.size(),
+          "member {} of a {} member assignment",
+          member,
+          _members.size());
+        return _members[member];
+    }
+
+    size_t size() const { return _members.size(); }
+    auto begin() const { return _members.begin(); }
+    auto end() const { return _members.end(); }
+
+    /// Puts every member's assignment in increasing order.
+    void sort();
+
+    friend bool
+    operator==(const group_assignment&, const group_assignment&) = default;
+
+private:
+    chunked_vector<member_assignment> _members;
+};
+
+/// A member's subscribed topics, in order of increasing topic id.
+using subscribed_topic_ids = chunked_vector<model::topic_id>;
+
+/// One member's input to the assignor.
+struct member_spec {
+    member_id id;
+    /// The topics this member subscribes to. The caller resolves subscription
+    /// names to ids before assignment.
+    subscribed_topic_ids subscribed_topics;
+    /// The partitions assigned to this member in the group's *current target*
+    /// assignment. Stickiness measures against that target, not against the
+    /// assignment the member has reconciled to. The group assigns each
+    /// partition to at most one member.
+    member_assignment current_assignment;
+
+    friend bool operator==(const member_spec&, const member_spec&) = default;
+};
+
+enum class subscription_type {
+    /// All members subscribe to the same set of topics.
+    homogeneous,
+    /// One or more members subscribe to a different set of topics.
+    heterogeneous,
+};
+
+fmt::iterator format_to(subscription_type, fmt::iterator);
+
+/// Input to the assignor, describes a group's members, their subscriptions, and
+/// their current target assignment.
+class group_spec {
+public:
+    group_spec() = default;
+    explicit group_spec(chunked_vector<member_spec> members);
+
+    const chunked_vector<member_spec>& members() const { return _members; }
+
+    subscription_type type() const { return _type; }
+
+private:
+    chunked_vector<member_spec> _members;
+    subscription_type _type{subscription_type::homogeneous};
+};
+
+/// Supplies the partition counts an assignment needs.
+class topic_describer {
+public:
+    virtual ~topic_describer() = default;
+
+    /// Returns std::nullopt if topic metadata lookup fails.
+    virtual std::optional<int32_t>
+    num_partitions(model::topic_id topic) const = 0;
+};
+
+enum class assignor_errc {
+    /// Topic metadata lookup failed for one or more subscribed topics.
+    unknown_topic,
+    /// Metadata lookup failed for a partition in a current assignment. The
+    /// assignor fails rather than adjust to metadata that may be stale.
+    unknown_partition,
+    /// A current assignment is out of order, holds duplicates, or holds an
+    /// invalid partition_id.
+    malformed_assignment,
+    /// A member's subscribed topics are out of order, or hold duplicates.
+    malformed_subscription,
+    /// The assignor ran out of members before it placed every partition.
+    /// Well-formed input cannot produce this, so either the current assignment
+    /// is inconsistent or the assignor's own arithmetic is.
+    partitions_left_unassigned,
+    /// The metadata returned a negative partition count for a subscribed
+    /// topic.
+    invalid_partition_count,
+};
+
+fmt::iterator format_to(assignor_errc, fmt::iterator);
+
+struct assignor_error {
+    assignor_errc errc;
+    model::topic_id topic;
+    /// Unset for `unknown_topic`, which is about a whole topic.
+    std::optional<model::partition_id> partition;
+
+    fmt::iterator format_to(fmt::iterator) const;
+    friend bool
+    operator==(const assignor_error&, const assignor_error&) = default;
+};
+
+using assignment_result = std::expected<group_assignment, assignor_error>;
+
+/// Interface for a broker-side partition assignor.
+///
+/// A group picks its assignor by name, so a `range` assignor or a custom one
+/// uses this same interface. An implementation carries no state between calls.
+///
+/// This interface mirrors Kafka's PartitionAssignor:
+/// https://github.com/apache/kafka/blob/fce22525f74bbd7feeb4f8b34c79a215db9a74c3/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/assignor/PartitionAssignor.java#L22
+class assignor {
+public:
+    virtual ~assignor() = default;
+
+    /// The name a group selects this assignor by.
+    virtual std::string_view name() const = 0;
+
+    /// Assigns every partition of the group's subscribed topics to a member
+    /// that subscribes to that topic.
+    ///
+    /// Preconditions:
+    ///
+    /// - a member's subscribed topics are in order of increasing topic id,
+    ///   with no duplicate topic ids
+    /// - a member's current assignment is in order of increasing topic id,
+    ///   with one entry per topic
+    /// - each of those topics has its partitions sorted by increasing
+    ///   partition id, with no duplicate partition ids
+    /// - a partition id is at least zero, and below its topic's partition
+    ///   count
+    /// - one member at most holds each partition
+    ///
+    /// A subscription reaches a group from client requests, so an
+    /// implementation checks the preconditions it depends on and returns
+    /// `assignor_error`.
+    virtual assignment_result
+    assign(const group_spec&, const topic_describer&) const = 0;
+};
+
+} // namespace kafka

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -291,6 +291,25 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "consumer_group_assignor_test",
+    timeout = "short",
+    srcs = [
+        "consumer_group_assignor_test.cc",
+    ],
+    deps = [
+        "//src/v/container:chunked_vector",
+        "//src/v/kafka/protocol",
+        "//src/v/kafka/server:consumer_group_assignor",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "//src/v/utils:uuid",
+        "@abseil-cpp//absl/container:btree",
+        "@fmt",
+        "@googletest//:gtest",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "consumer_group_recovery_test",
     timeout = "short",
     srcs = [

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -309,6 +309,26 @@ redpanda_cc_gtest(
     ],
 )
 
+redpanda_cc_bench(
+    name = "consumer_group_assignor_rpbench",
+    srcs = [
+        "consumer_group_assignor_bench.cc",
+    ],
+    memory = "2GiB",
+    deps = [
+        "//src/v/base",
+        "//src/v/container:chunked_vector",
+        "//src/v/kafka/protocol",
+        "//src/v/kafka/server:consumer_group_assignor",
+        "//src/v/model",
+        "//src/v/utils:uuid",
+        "@abseil-cpp//absl/container:btree",
+        "@fmt",
+        "@seastar",
+        "@seastar//:benchmark",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "consumer_group_recovery_test",
     timeout = "short",

--- a/src/v/kafka/server/tests/consumer_group_assignor_bench.cc
+++ b/src/v/kafka/server/tests/consumer_group_assignor_bench.cc
@@ -1,0 +1,300 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "base/vassert.h"
+#include "container/chunked_vector.h"
+#include "kafka/protocol/types.h"
+#include "kafka/server/consumer_group_assignor.h"
+#include "kafka/server/uniform_assignor.h"
+#include "model/fundamental.h"
+#include "utils/uuid.h"
+
+#include <seastar/core/sstring.hh>
+#include <seastar/testing/perf_tests.hh>
+
+#include <absl/container/btree_map.h>
+#include <fmt/format.h>
+
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace kafka {
+
+namespace {
+
+/// The coordinator-shard CPU cost of computing a target assignment:
+///
+///   1. the group_spec constructor: subscription type detection
+///   2. uniform_assignor::assign() over the built spec
+///
+/// The assign_* cases measure step 2 alone, over a spec built up front. The
+/// spec_ctor_* cases measure step 1 alone, and name a size with no scenario,
+/// since the constructor reads only the subscriptions. The spec_and_assign_*
+/// cases measure both steps together.
+///
+/// Case names read <scenario>_<members>m_<topics>t_<partitions per topic>p:
+///   - fresh: no member holds an assignment, the group's first rebalance
+///   - stable: every member holds the assignment a previous run produced
+///   - join: one member with no assignment joins a stable group
+///   - leave: one member left a stable group, so its partitions have no
+///     owner
+
+/// Topic metadata for the topics the bench registered.
+class bench_describer final : public topic_describer {
+public:
+    void add(model::topic_id topic, int32_t partitions) {
+        _partitions[topic] = partitions;
+    }
+
+    std::optional<int32_t> num_partitions(model::topic_id topic) const final {
+        auto it = _partitions.find(topic);
+        if (it == _partitions.end()) {
+            return std::nullopt;
+        }
+        return it->second;
+    }
+
+private:
+    absl::btree_map<model::topic_id, int32_t> _partitions;
+};
+
+/// A topic id whose byte pattern orders by `n`, so the subscription
+/// builders can emit topic ids in increasing order.
+model::topic_id make_topic_id(uint16_t n) {
+    std::vector<uint8_t> bytes(uuid_t::length, 0);
+    bytes[uuid_t::length - 2] = static_cast<uint8_t>(n >> 8U);
+    bytes[uuid_t::length - 1] = static_cast<uint8_t>(n & 0xFFU);
+    return model::topic_id{uuid_t{bytes}};
+}
+
+struct shape {
+    size_t members;
+    uint16_t topics;
+    /// Partitions per topic.
+    int32_t partitions;
+    /// Operations per timed loop. Scaled down for the bigger shapes so a
+    /// single call stays well under the run duration.
+    size_t inner;
+};
+
+constexpr shape small_group{
+  .members = 10, .topics = 1, .partitions = 100, .inner = 100};
+constexpr shape medium_group{
+  .members = 100, .topics = 10, .partitions = 100, .inner = 20};
+constexpr shape large_group{
+  .members = 1000, .topics = 100, .partitions = 100, .inner = 5};
+
+enum class scenario { fresh, stable, join, leave };
+
+/// The topics member `m` subscribes to, in order of increasing topic id.
+using subscription_fn = subscribed_topic_ids (*)(size_t m, const shape&);
+
+/// Every member subscribes to every topic: the homogeneous pattern.
+subscribed_topic_ids subscribe_all(size_t, const shape& s) {
+    subscribed_topic_ids ids;
+    ids.reserve(s.topics);
+    for (uint16_t t = 0; t < s.topics; ++t) {
+        ids.push_back(make_topic_id(t));
+    }
+    return ids;
+}
+
+member_spec make_member(size_t m, const shape& s, subscription_fn subscribe) {
+    return member_spec{
+      .id = member_id{ss::sstring{fmt::format("member-{:05}", m)}},
+      .subscribed_topics = subscribe(m, s)};
+}
+
+chunked_vector<member_spec>
+make_members(size_t count, const shape& s, subscription_fn subscribe) {
+    chunked_vector<member_spec> members;
+    members.reserve(count);
+    for (size_t m = 0; m < count; ++m) {
+        members.push_back(make_member(m, s, subscribe));
+    }
+    return members;
+}
+
+chunked_vector<member_spec> copy(const chunked_vector<member_spec>& members) {
+    chunked_vector<member_spec> out;
+    out.reserve(members.size());
+    for (const auto& member : members) {
+        out.push_back(
+          member_spec{
+            .id = member.id,
+            .subscribed_topics = member.subscribed_topics.copy(),
+            .current_assignment = member.current_assignment.copy()});
+    }
+    return out;
+}
+
+struct assignor_bench {
+    uniform_assignor impl;
+    bench_describer metadata;
+    std::optional<group_spec> prebuilt;
+    std::optional<chunked_vector<member_spec>> proto;
+
+    void register_topics(const shape& s) {
+        for (uint16_t t = 0; t < s.topics; ++t) {
+            metadata.add(make_topic_id(t), s.partitions);
+        }
+    }
+
+    /// Assigns `members` once and hands each one the result back as its
+    /// current assignment.
+    chunked_vector<member_spec> seeded(chunked_vector<member_spec> members) {
+        auto spec = group_spec{copy(members)};
+        auto result = impl.assign(spec, metadata);
+        vassert(
+          result.has_value(),
+          "the bench seeds itself with a valid assignment: {}",
+          result.error());
+        for (size_t m = 0; m < members.size(); ++m) {
+            members[m].current_assignment = std::move((*result)[m]);
+        }
+        return members;
+    }
+
+    chunked_vector<member_spec>
+    make_input(const shape& s, scenario kind, subscription_fn subscribe) {
+        switch (kind) {
+        case scenario::fresh:
+            return make_members(s.members, s, subscribe);
+        case scenario::stable:
+            return seeded(make_members(s.members, s, subscribe));
+        case scenario::join: {
+            auto members = seeded(make_members(s.members - 1, s, subscribe));
+            members.push_back(make_member(s.members - 1, s, subscribe));
+            return members;
+        }
+        case scenario::leave: {
+            auto members = seeded(make_members(s.members + 1, s, subscribe));
+            members.pop_back();
+            return members;
+        }
+        }
+        __builtin_unreachable();
+    }
+
+    /// assign() alone, over a spec built once up front.
+    size_t
+    run_assign(const shape& s, scenario kind, subscription_fn subscribe) {
+        if (!prebuilt) {
+            register_topics(s);
+            prebuilt.emplace(make_input(s, kind, subscribe));
+        }
+        perf_tests::start_measuring_time();
+        for (size_t i = 0; i < s.inner; ++i) {
+            auto result = impl.assign(*prebuilt, metadata);
+            perf_tests::do_not_optimize(result);
+        }
+        perf_tests::stop_measuring_time();
+        return s.inner;
+    }
+
+    /// The group_spec constructor alone, which reads only the subscriptions.
+    /// The constructed specs outlive the timed loop, so it times the
+    /// constructor and not the teardown of the inputs.
+    size_t run_spec_ctor(const shape& s, subscription_fn subscribe) {
+        if (!proto) {
+            register_topics(s);
+            proto.emplace(make_members(s.members, s, subscribe));
+        }
+        std::vector<chunked_vector<member_spec>> inputs;
+        inputs.reserve(s.inner);
+        for (size_t i = 0; i < s.inner; ++i) {
+            inputs.push_back(copy(*proto));
+        }
+        std::vector<group_spec> specs;
+        specs.reserve(s.inner);
+        perf_tests::start_measuring_time();
+        for (auto& input : inputs) {
+            specs.emplace_back(std::move(input));
+        }
+        perf_tests::stop_measuring_time();
+        perf_tests::do_not_optimize(specs);
+        return s.inner;
+    }
+
+    /// Constructor plus assign(): the whole per-rebalance cost.
+    size_t run_spec_and_assign(
+      const shape& s, scenario kind, subscription_fn subscribe) {
+        if (!proto) {
+            register_topics(s);
+            proto.emplace(make_input(s, kind, subscribe));
+        }
+        std::vector<chunked_vector<member_spec>> inputs;
+        inputs.reserve(s.inner);
+        for (size_t i = 0; i < s.inner; ++i) {
+            inputs.push_back(copy(*proto));
+        }
+        perf_tests::start_measuring_time();
+        for (auto& input : inputs) {
+            auto spec = group_spec{std::move(input)};
+            auto result = impl.assign(spec, metadata);
+            perf_tests::do_not_optimize(result);
+        }
+        perf_tests::stop_measuring_time();
+        return s.inner;
+    }
+};
+
+} // namespace
+
+PERF_TEST_F(assignor_bench, assign_fresh_10m_1t_100p) {
+    return run_assign(small_group, scenario::fresh, subscribe_all);
+}
+PERF_TEST_F(assignor_bench, assign_fresh_100m_10t_100p) {
+    return run_assign(medium_group, scenario::fresh, subscribe_all);
+}
+PERF_TEST_F(assignor_bench, assign_fresh_1000m_100t_100p) {
+    return run_assign(large_group, scenario::fresh, subscribe_all);
+}
+
+PERF_TEST_F(assignor_bench, assign_stable_10m_1t_100p) {
+    return run_assign(small_group, scenario::stable, subscribe_all);
+}
+PERF_TEST_F(assignor_bench, assign_stable_100m_10t_100p) {
+    return run_assign(medium_group, scenario::stable, subscribe_all);
+}
+PERF_TEST_F(assignor_bench, assign_stable_1000m_100t_100p) {
+    return run_assign(large_group, scenario::stable, subscribe_all);
+}
+
+PERF_TEST_F(assignor_bench, assign_join_100m_10t_100p) {
+    return run_assign(medium_group, scenario::join, subscribe_all);
+}
+PERF_TEST_F(assignor_bench, assign_join_1000m_100t_100p) {
+    return run_assign(large_group, scenario::join, subscribe_all);
+}
+
+PERF_TEST_F(assignor_bench, assign_leave_100m_10t_100p) {
+    return run_assign(medium_group, scenario::leave, subscribe_all);
+}
+PERF_TEST_F(assignor_bench, assign_leave_1000m_100t_100p) {
+    return run_assign(large_group, scenario::leave, subscribe_all);
+}
+
+PERF_TEST_F(assignor_bench, spec_ctor_100m_10t_100p) {
+    return run_spec_ctor(medium_group, subscribe_all);
+}
+PERF_TEST_F(assignor_bench, spec_ctor_1000m_100t_100p) {
+    return run_spec_ctor(large_group, subscribe_all);
+}
+
+PERF_TEST_F(assignor_bench, spec_and_assign_stable_100m_10t_100p) {
+    return run_spec_and_assign(medium_group, scenario::stable, subscribe_all);
+}
+PERF_TEST_F(assignor_bench, spec_and_assign_stable_1000m_100t_100p) {
+    return run_spec_and_assign(large_group, scenario::stable, subscribe_all);
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/tests/consumer_group_assignor_test.cc
+++ b/src/v/kafka/server/tests/consumer_group_assignor_test.cc
@@ -1,0 +1,663 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "container/chunked_vector.h"
+#include "kafka/server/uniform_assignor.h"
+#include "model/fundamental.h"
+#include "utils/uuid.h"
+
+#include <absl/container/btree_map.h>
+#include <absl/container/btree_set.h>
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <ranges>
+#include <string>
+#include <vector>
+
+namespace kafka {
+namespace {
+
+/// Topic metadata for the topics a test registered.
+class test_describer final : public topic_describer {
+public:
+    void add(model::topic_id topic, int32_t partitions) {
+        _partitions[topic] = partitions;
+    }
+
+    std::optional<int32_t> num_partitions(model::topic_id topic) const final {
+        auto it = _partitions.find(topic);
+        if (it == _partitions.end()) {
+            return std::nullopt;
+        }
+        return it->second;
+    }
+
+private:
+    absl::btree_map<model::topic_id, int32_t> _partitions;
+};
+
+/// A topic id whose byte pattern orders by `n`, so a test can predict the order
+/// the assignor walks topics in.
+model::topic_id make_topic_id(uint16_t n) {
+    std::vector<uint8_t> bytes(uuid_t::length, 0);
+    bytes[uuid_t::length - 2] = static_cast<uint8_t>(n >> 8U);
+    bytes[uuid_t::length - 1] = static_cast<uint8_t>(n & 0xFFU);
+    return model::topic_id{uuid_t{bytes}};
+}
+
+/// An assignment of one topic, from partition ids given in any order.
+partition_set partitions(std::initializer_list<int32_t> ps) {
+    partition_set set;
+    set.reserve(ps.size());
+    for (auto p : ps) {
+        set.emplace_back(p);
+    }
+    std::ranges::sort(set);
+    return set;
+}
+
+/// An assignment written as `{{topic, {partition ids...}}, ...}`, in any order.
+using assignment_spec = std::initializer_list<
+  std::pair<model::topic_id, std::initializer_list<int32_t>>>;
+
+member_assignment assigned(assignment_spec entries) {
+    // `assign` expects the topics in increasing order, so we sort the spec up
+    // front.
+    chunked_vector<topic_partitions> sorted;
+    sorted.reserve(entries.size());
+    for (const auto& [topic, ps] : entries) {
+        sorted.push_back({.topic = topic, .partitions = partitions(ps)});
+    }
+    std::ranges::sort(sorted, {}, &topic_partitions::topic);
+
+    member_assignment assignment;
+    for (auto& [topic, ps] : sorted) {
+        assignment.assign(topic, std::move(ps));
+    }
+    return assignment;
+}
+
+/// A member built exactly as given, so a test can feed the assignor input
+/// that breaks the ordering rules.
+member_spec member_as_given(
+  std::string_view id,
+  subscribed_topic_ids subscribed,
+  member_assignment assigned_to_it = {}) {
+    return member_spec{
+      .id = member_id{ss::sstring{id}},
+      .subscribed_topics = std::move(subscribed),
+      .current_assignment = std::move(assigned_to_it)};
+}
+
+member_spec member(
+  std::string_view id,
+  subscribed_topic_ids subscribed,
+  assignment_spec assigned_to_it = {}) {
+    // This sorts the subscription, which the assignor requires of its caller,
+    // so that a test can list one in any order.
+    std::ranges::sort(subscribed);
+    return member_spec{
+      .id = member_id{ss::sstring{id}},
+      .subscribed_topics = std::move(subscribed),
+      .current_assignment = assigned(assigned_to_it)};
+}
+
+template<typename... Ms>
+group_spec spec(Ms&&... members) {
+    chunked_vector<member_spec> ms;
+    (ms.push_back(std::forward<Ms>(members)), ...);
+    return group_spec{std::move(ms)};
+}
+
+TEST(group_spec_test, group_sharing_one_subscription_is_homogeneous) {
+    auto t1 = make_topic_id(1);
+    auto t2 = make_topic_id(2);
+
+    auto group = spec(member("m1", {t1, t2}), member("m2", {t2, t1}));
+
+    EXPECT_EQ(group.type(), subscription_type::homogeneous);
+}
+
+TEST(group_spec_test, group_with_differing_subscriptions_is_heterogeneous) {
+    auto t1 = make_topic_id(1);
+    auto t2 = make_topic_id(2);
+
+    auto group = spec(member("m1", {t1, t2}), member("m2", {t1}));
+
+    EXPECT_EQ(group.type(), subscription_type::heterogeneous);
+}
+
+TEST(group_spec_test, empty_group_is_homogeneous) {
+    EXPECT_EQ(spec().type(), subscription_type::homogeneous);
+}
+
+class uniform_assignor_test : public ::testing::Test {
+protected:
+    /// Registers a topic and returns its id. Topics are named `t1`, `t2`, ...
+    /// in registration order, and their ids sort the same way.
+    model::topic_id add_topic(int32_t num_partitions) {
+        auto topic = make_topic_id(++_topic_count);
+        _describer.add(topic, num_partitions);
+        _names[topic] = fmt::format("t{}", _topic_count);
+        return topic;
+    }
+
+    /// An id for a topic that was never registered, so the metadata lookup for
+    /// it fails.
+    model::topic_id unknown_topic() { return make_topic_id(++_topic_count); }
+
+    assignment_result assign(const group_spec& group) {
+        // An assignment is positional, so `render` and `expect_assignment`
+        // both need the spec behind it.
+        chunked_vector<member_spec> members;
+        members.reserve(group.members().size());
+        for (const auto& member : group.members()) {
+            members.push_back(
+              member_spec{
+                .id = member.id,
+                .subscribed_topics = member.subscribed_topics.copy(),
+                .current_assignment = member.current_assignment.copy()});
+        }
+        _assigned_group.emplace(std::move(members));
+        return _assignor.assign(group, _describer);
+    }
+
+    /// Renders an assignment as `m1: t1[0,1] t2[0]; m2: t1[2]`, in the member
+    /// order of the spec it was assigned from, then topic order.
+    std::string render(const group_assignment& assignment) const {
+        std::string out;
+        for (size_t index = 0; index < assignment.size(); ++index) {
+            if (!out.empty()) {
+                out += "; ";
+            }
+            out += fmt::format("{}:", _assigned_group->members()[index].id());
+            for (const auto& [topic, ps] : assignment[index]) {
+                out += fmt::format(
+                  " {}[{}]", topic_name(topic), fmt::join(ps, ","));
+            }
+        }
+        return out;
+    }
+
+    /// The number of partitions assigned to each member, in spec order.
+    std::vector<size_t> sizes(const group_assignment& assignment) const {
+        std::vector<size_t> out;
+        out.reserve(assignment.size());
+        for (const auto& member : assignment) {
+            out.push_back(member.num_partitions());
+        }
+        return out;
+    }
+
+    /// Asserts the assignment, member by member in the spec's order, each
+    /// written like `assigned`. Holds both sides to `expect_valid`, so a test
+    /// that writes an invalid expectation fails on the expectation too. Prints
+    /// both rendered on failure.
+    void expect_assignment(
+      const group_assignment& actual,
+      std::initializer_list<assignment_spec> members) const {
+        group_assignment want{members.size()};
+        size_t index = 0;
+        for (const auto& member : members) {
+            want[index++] = assigned(member);
+        }
+        EXPECT_TRUE(actual == want)
+          << "assigned: " << render(actual) << "\n    want: " << render(want);
+        expect_valid(*_assigned_group, actual);
+        expect_valid(*_assigned_group, want);
+    }
+
+    /// Asserts the invariants of every assignment:
+    ///
+    /// - each partition of a subscribed topic has exactly one owner
+    /// - every owner subscribes to the topic it owns a partition of
+    /// - each member holds its topics in order of increasing topic id, and
+    ///   each topic's partitions in order of increasing partition id
+    /// - a homogeneous group must come out balanced to within one partition
+    void expect_valid(
+      const group_spec& group, const group_assignment& assignment) const {
+        ASSERT_EQ(assignment.size(), group.members().size())
+          << "an assignment has one entry per member";
+
+        absl::btree_map<model::topic_id_partition, member_id> owners;
+        absl::btree_set<model::topic_id> subscribed;
+        for (const auto& member : group.members()) {
+            subscribed.insert(
+              member.subscribed_topics.begin(), member.subscribed_topics.end());
+        }
+
+        for (size_t index = 0; index < assignment.size(); ++index) {
+            const auto& member = group.members()[index];
+            EXPECT_TRUE(
+              std::ranges::is_sorted(
+                assignment[index], {}, &topic_partitions::topic))
+              << member.id()
+              << " holds its topics out of order: " << render(assignment);
+            for (const auto& [topic, ps] : assignment[index]) {
+                EXPECT_TRUE(std::ranges::is_sorted(ps))
+                  << member.id() << " holds " << topic_name(topic)
+                  << " out of partition order: " << render(assignment);
+                EXPECT_TRUE(
+                  std::ranges::binary_search(member.subscribed_topics, topic))
+                  << member.id() << " does not subscribe to "
+                  << topic_name(topic);
+                for (auto partition : ps) {
+                    auto [owner, inserted] = owners.try_emplace(
+                      model::topic_id_partition{topic, partition}, member.id);
+                    EXPECT_TRUE(inserted)
+                      << topic_name(topic) << '/' << partition
+                      << " assigned to both " << owner->second() << " and "
+                      << member.id();
+                }
+            }
+        }
+
+        for (const auto& topic : subscribed) {
+            auto num_partitions = _describer.num_partitions(topic);
+            ASSERT_TRUE(num_partitions.has_value());
+            for (auto id : std::views::iota(0, *num_partitions)) {
+                EXPECT_TRUE(owners.contains(
+                  model::topic_id_partition{topic, model::partition_id{id}}))
+                  << topic_name(topic) << '/' << id << " was left unassigned";
+            }
+        }
+
+        if (
+          group.type() == subscription_type::homogeneous
+          && !group.members().empty()) {
+            auto [min, max] = std::ranges::minmax(sizes(assignment));
+            EXPECT_LE(max - min, 1) << "unbalanced: " << render(assignment);
+        }
+    }
+
+private:
+    std::string topic_name(model::topic_id topic) const {
+        auto it = _names.find(topic);
+        return it == _names.end() ? fmt::to_string(topic) : it->second;
+    }
+
+    test_describer _describer;
+    absl::btree_map<model::topic_id, std::string> _names;
+    uint16_t _topic_count{0};
+    uniform_assignor _assignor;
+    /// The spec of the last `assign` call, which an assignment is positional
+    /// against.
+    std::optional<group_spec> _assigned_group;
+};
+
+TEST_F(uniform_assignor_test, is_the_assignor_named_uniform) {
+    // The name a group selects this assignor by, and the one entry in
+    // `group_consumer_assignors`.
+    EXPECT_EQ(uniform_assignor{}.name(), "uniform");
+}
+
+TEST_F(uniform_assignor_test, empty_group_is_assigned_nothing) {
+    auto topic = add_topic(3);
+    std::ignore = topic;
+
+    auto assignment = assign(spec());
+
+    ASSERT_TRUE(assignment.has_value()) << "expected an assignment";
+    EXPECT_EQ(assignment->size(), 0) << render(*assignment);
+}
+
+TEST_F(uniform_assignor_test, sole_member_takes_every_partition) {
+    auto topic = add_topic(3);
+
+    auto assignment = assign(spec(member("m1", {topic})));
+
+    ASSERT_TRUE(assignment.has_value());
+    expect_assignment(
+      *assignment,
+      {
+        /* m1 */ {{topic, {0, 1, 2}}},
+      });
+}
+
+TEST_F(uniform_assignor_test, partitions_are_split_evenly) {
+    auto topic = add_topic(6);
+
+    auto assignment = assign(spec(
+      member("m1", {topic}), member("m2", {topic}), member("m3", {topic})));
+
+    ASSERT_TRUE(assignment.has_value());
+    expect_assignment(
+      *assignment,
+      {
+        /* m1 */ {{topic, {0, 1}}},
+        /* m2 */ {{topic, {2, 3}}},
+        /* m3 */ {{topic, {4, 5}}},
+      });
+}
+
+TEST_F(uniform_assignor_test, leftover_partitions_are_spread_one_each) {
+    auto topic = add_topic(7);
+
+    auto assignment = assign(spec(
+      member("m1", {topic}), member("m2", {topic}), member("m3", {topic})));
+
+    ASSERT_TRUE(assignment.has_value());
+    EXPECT_EQ(sizes(*assignment), (std::vector<size_t>{2, 2, 3}))
+      << render(*assignment);
+}
+
+TEST_F(
+  uniform_assignor_test, member_subscribed_to_nothing_is_assigned_nothing) {
+    add_topic(3);
+
+    auto assignment = assign(spec(member("m1", {})));
+
+    ASSERT_TRUE(assignment.has_value());
+    // The member still gets an entry, holding nothing.
+    EXPECT_EQ(sizes(*assignment), (std::vector<size_t>{0}))
+      << render(*assignment);
+}
+
+TEST_F(uniform_assignor_test, an_assignment_runs_parallel_to_the_members) {
+    auto topic = add_topic(4);
+
+    auto group = spec(member("m2", {topic}), member("m1", {topic}));
+    auto assignment = assign(group);
+
+    ASSERT_TRUE(assignment.has_value());
+    // One entry per member, in the spec's member order rather than by member
+    // id.
+    ASSERT_EQ(assignment->size(), 2);
+    expect_assignment(
+      *assignment,
+      {
+        /* m2 */ {{topic, {0, 1}}},
+        /* m1 */ {{topic, {2, 3}}},
+      });
+}
+
+TEST_F(uniform_assignor_test, assigned_partitions_within_target_size_are_kept) {
+    auto topic = add_topic(6);
+
+    auto assignment = assign(
+      spec(member("m1", {topic}, {{topic, {0, 1, 2}}}), member("m2", {topic})));
+
+    ASSERT_TRUE(assignment.has_value());
+    expect_assignment(
+      *assignment,
+      {
+        /* m1 */ {{topic, {0, 1, 2}}},
+        /* m2 */ {{topic, {3, 4, 5}}},
+      });
+}
+
+TEST_F(uniform_assignor_test, partitions_beyond_target_size_are_released) {
+    auto topic = add_topic(6);
+
+    auto assignment = assign(spec(
+      member("m1", {topic}, {{topic, {0, 1, 2, 3, 4, 5}}}),
+      member("m2", {topic})));
+
+    ASSERT_TRUE(assignment.has_value());
+    expect_assignment(
+      *assignment,
+      {
+        /* m1 */ {{topic, {0, 1, 2}}},
+        /* m2 */ {{topic, {3, 4, 5}}},
+      });
+}
+
+TEST_F(
+  uniform_assignor_test,
+  a_topic_is_released_whole_when_the_target_size_runs_out) {
+    auto t1 = add_topic(2);
+    auto t2 = add_topic(2);
+
+    // m1's target size is two, spent entirely on t1, so it gives up the one
+    // partition of t2 it holds.
+    auto group = spec(
+      member("m1", {t1, t2}, {{t1, {0, 1}}, {t2, {0}}}),
+      member("m2", {t1, t2}));
+
+    auto assignment = assign(group);
+
+    ASSERT_TRUE(assignment.has_value());
+    expect_assignment(
+      *assignment,
+      {
+        /* m1 */ {{t1, {0, 1}}},
+        /* m2 */ {{t2, {0, 1}}},
+      });
+}
+
+TEST_F(uniform_assignor_test, a_partition_past_the_end_of_a_topic_fails) {
+    auto topic = add_topic(2);
+
+    // The metadata has two partitions of t1 while m1 is assigned a third, so
+    // the metadata is behind the group's assignment. Assigning on the metadata
+    // alone would revoke that partition, so the assignor fails instead.
+    auto group = spec(
+      member("m1", {topic}, {{topic, {0, 5}}}), member("m2", {topic}));
+
+    auto assignment = assign(group);
+
+    ASSERT_FALSE(assignment.has_value()) << render(*assignment);
+    EXPECT_EQ(assignment.error().errc, assignor_errc::unknown_partition);
+    EXPECT_EQ(assignment.error().topic, topic);
+    EXPECT_EQ(assignment.error().partition, model::partition_id{5});
+}
+
+TEST_F(uniform_assignor_test, a_negative_partition_is_malformed) {
+    auto topic = add_topic(2);
+
+    // Corrupt input: no topic numbers its partitions from below zero, so this
+    // is not stale metadata. The check runs before the target-size arithmetic,
+    // which would otherwise keep it and hand it back in the assignment.
+    auto group = spec(
+      member("m1", {topic}, {{topic, {-1, 0}}}), member("m2", {topic}));
+
+    auto assignment = assign(group);
+
+    ASSERT_FALSE(assignment.has_value()) << render(*assignment);
+    EXPECT_EQ(assignment.error().errc, assignor_errc::malformed_assignment);
+    EXPECT_EQ(assignment.error().topic, topic);
+    EXPECT_EQ(assignment.error().partition, model::partition_id{-1});
+}
+
+TEST_F(
+  uniform_assignor_test, a_subscription_out_of_topic_id_order_is_malformed) {
+    auto t1 = add_topic(2);
+    auto t2 = add_topic(2);
+
+    // Both members share the backwards list, so the group is homogeneous.
+    auto group = spec(
+      member_as_given("m1", {t2, t1}), member_as_given("m2", {t2, t1}));
+
+    auto assignment = assign(group);
+
+    ASSERT_FALSE(assignment.has_value()) << render(*assignment);
+    EXPECT_EQ(assignment.error().errc, assignor_errc::malformed_subscription);
+    EXPECT_EQ(assignment.error().topic, t1);
+}
+
+TEST_F(
+  uniform_assignor_test, a_subscription_with_a_repeated_topic_is_malformed) {
+    auto topic = add_topic(4);
+
+    // Without the check the repeated topic counts its partitions twice, and
+    // the deal phase has exactly the room to assign every partition to two
+    // members.
+    auto group = spec(
+      member_as_given("m1", {topic, topic}),
+      member_as_given("m2", {topic, topic}));
+
+    auto assignment = assign(group);
+
+    ASSERT_FALSE(assignment.has_value()) << render(*assignment);
+    EXPECT_EQ(assignment.error().errc, assignor_errc::malformed_subscription);
+    EXPECT_EQ(assignment.error().topic, topic);
+}
+
+TEST_F(
+  uniform_assignor_test, an_assignment_out_of_topic_id_order_is_malformed) {
+    auto t1 = add_topic(2);
+    auto t2 = add_topic(2);
+
+    member_assignment holds;
+    holds.assign(t2, model::partition_id{0});
+    holds.assign(t1, model::partition_id{0});
+    auto group = spec(
+      member_as_given("m1", {t1, t2}, std::move(holds)),
+      member("m2", {t1, t2}));
+
+    auto assignment = assign(group);
+
+    ASSERT_FALSE(assignment.has_value()) << render(*assignment);
+    EXPECT_EQ(assignment.error().errc, assignor_errc::malformed_assignment);
+    EXPECT_EQ(assignment.error().topic, t1);
+}
+
+TEST_F(uniform_assignor_test, assigned_partitions_out_of_order_are_malformed) {
+    auto topic = add_topic(4);
+
+    member_assignment holds;
+    holds.assign(topic, model::partition_id{2});
+    holds.assign(topic, model::partition_id{0});
+    auto group = spec(
+      member_as_given("m1", {topic}, std::move(holds)), member("m2", {topic}));
+
+    auto assignment = assign(group);
+
+    ASSERT_FALSE(assignment.has_value()) << render(*assignment);
+    EXPECT_EQ(assignment.error().errc, assignor_errc::malformed_assignment);
+    EXPECT_EQ(assignment.error().topic, topic);
+    EXPECT_EQ(assignment.error().partition, model::partition_id{0});
+}
+
+TEST_F(uniform_assignor_test, a_repeated_assigned_partition_is_malformed) {
+    auto topic = add_topic(4);
+
+    member_assignment holds;
+    holds.assign(topic, model::partition_id{1});
+    holds.assign(topic, model::partition_id{1});
+    auto group = spec(
+      member_as_given("m1", {topic}, std::move(holds)), member("m2", {topic}));
+
+    auto assignment = assign(group);
+
+    ASSERT_FALSE(assignment.has_value()) << render(*assignment);
+    EXPECT_EQ(assignment.error().errc, assignor_errc::malformed_assignment);
+    EXPECT_EQ(assignment.error().topic, topic);
+    EXPECT_EQ(assignment.error().partition, model::partition_id{1});
+}
+
+TEST_F(uniform_assignor_test, partitions_of_unsubscribed_topics_are_dropped) {
+    auto subscribed = add_topic(2);
+    auto dropped = add_topic(2);
+
+    auto assignment = assign(
+      spec(member("m1", {subscribed}, {{subscribed, {0}}, {dropped, {0, 1}}})));
+
+    ASSERT_TRUE(assignment.has_value());
+    expect_assignment(
+      *assignment,
+      {
+        /* m1 */ {{subscribed, {0, 1}}},
+      });
+}
+
+TEST_F(uniform_assignor_test, partitions_of_a_departed_member_are_shared_out) {
+    auto topic = add_topic(6);
+
+    // The group holds four of the topic's six partitions, so 4 and 5 have no
+    // owner, which is the state a member's departure leaves behind.
+    auto assignment = assign(spec(
+      member("m1", {topic}, {{topic, {0, 1}}}),
+      member("m2", {topic}, {{topic, {2, 3}}})));
+
+    ASSERT_TRUE(assignment.has_value());
+    expect_assignment(
+      *assignment,
+      {
+        /* m1 */ {{topic, {0, 1, 4}}},
+        /* m2 */ {{topic, {2, 3, 5}}},
+      });
+}
+
+TEST_F(uniform_assignor_test, the_extra_partition_stays_with_a_full_member) {
+    auto topic = add_topic(7);
+
+    // A group of three splits 7 partitions 3/2/2. m1 already holds 3 of them,
+    // so it keeps all 3 and the other two members split the rest.
+    auto assignment = assign(spec(
+      member("m1", {topic}, {{topic, {0, 1, 2}}}),
+      member("m2", {topic}, {{topic, {3}}}),
+      member("m3", {topic})));
+
+    ASSERT_TRUE(assignment.has_value());
+    expect_assignment(
+      *assignment,
+      {
+        /* m1 */ {{topic, {0, 1, 2}}},
+        /* m2 */ {{topic, {3, 4}}},
+        /* m3 */ {{topic, {5, 6}}},
+      });
+}
+
+TEST_F(uniform_assignor_test, the_split_counts_every_subscribed_topic) {
+    auto t1 = add_topic(2);
+    auto t2 = add_topic(3);
+
+    // Five partitions across the two topics divide 2 and 3 between the
+    // members, so a member's share spans both topics.
+    auto assignment = assign(
+      spec(member("m1", {t1, t2}), member("m2", {t1, t2})));
+
+    ASSERT_TRUE(assignment.has_value());
+    EXPECT_EQ(sizes(*assignment), (std::vector<size_t>{2, 3}))
+      << render(*assignment);
+}
+
+TEST_F(uniform_assignor_test, subscription_to_a_topic_without_metadata_fails) {
+    auto missing = unknown_topic();
+
+    auto assignment = assign(spec(member("m1", {missing})));
+
+    ASSERT_FALSE(assignment.has_value()) << render(*assignment);
+    EXPECT_EQ(assignment.error().errc, assignor_errc::unknown_topic);
+    EXPECT_EQ(assignment.error().topic, missing);
+}
+
+TEST_F(uniform_assignor_test, a_negative_partition_count_fails) {
+    auto topic = add_topic(-1);
+
+    auto assignment = assign(spec(member("m1", {topic})));
+
+    ASSERT_FALSE(assignment.has_value()) << render(*assignment);
+    EXPECT_EQ(assignment.error().errc, assignor_errc::invalid_partition_count);
+    EXPECT_EQ(assignment.error().topic, topic);
+}
+
+TEST_F(uniform_assignor_test, a_partition_assigned_to_two_members_fails) {
+    // Malformed input: the caller must supply an assignment with one owner per
+    // partition. The homogeneous target-size arithmetic notices that it cannot
+    // place every partition, and fails rather than build a broken assignment.
+    auto topic = add_topic(4);
+
+    auto assignment = assign(spec(
+      member("m1", {topic}, {{topic, {0, 1}}}),
+      member("m2", {topic}, {{topic, {1, 2}}})));
+
+    ASSERT_FALSE(assignment.has_value()) << render(*assignment);
+    EXPECT_EQ(
+      assignment.error().errc, assignor_errc::partitions_left_unassigned);
+}
+} // namespace
+} // namespace kafka

--- a/src/v/kafka/server/uniform_assignor.cc
+++ b/src/v/kafka/server/uniform_assignor.cc
@@ -1,0 +1,561 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "kafka/server/uniform_assignor.h"
+
+#include "base/vassert.h"
+#include "container/chunked_hash_map.h"
+#include "container/chunked_vector.h"
+
+#include <algorithm>
+#include <bit>
+#include <functional>
+#include <limits>
+#include <optional>
+#include <ranges>
+#include <utility>
+
+namespace kafka {
+
+namespace {
+
+/// One topic's partition count from the metadata. Fails on a topic the
+/// metadata does not recognize, and on a negative count.
+std::expected<int32_t, assignor_error>
+partition_count(const topic_describer& metadata, model::topic_id topic) {
+    auto num_partitions = metadata.num_partitions(topic);
+    if (!num_partitions.has_value()) {
+        return std::unexpected(
+          assignor_error{.errc = assignor_errc::unknown_topic, .topic = topic});
+    }
+    if (*num_partitions < 0) {
+        return std::unexpected(
+          assignor_error{
+            .errc = assignor_errc::invalid_partition_count, .topic = topic});
+    }
+    return *num_partitions;
+}
+
+/// Checks one topic's assigned partitions, which must not be empty:
+///
+/// - they are sorted, with no duplicate partition ids
+/// - the lowest is at least zero
+/// - the highest is below `num_partitions`
+std::expected<void, assignor_error> check_assigned(
+  model::topic_id topic,
+  const partition_set& assigned,
+  int32_t num_partitions) {
+    if (
+      auto repeat = std::ranges::adjacent_find(
+        assigned, std::ranges::greater_equal{});
+      repeat != assigned.end()) {
+        return std::unexpected(
+          assignor_error{
+            .errc = assignor_errc::malformed_assignment,
+            .topic = topic,
+            .partition = *std::ranges::next(repeat)});
+    }
+    if (assigned.front()() < 0) {
+        return std::unexpected(
+          assignor_error{
+            .errc = assignor_errc::malformed_assignment,
+            .topic = topic,
+            .partition = assigned.front()});
+    }
+    if (assigned.back()() >= num_partitions) {
+        return std::unexpected(
+          assignor_error{
+            .errc = assignor_errc::unknown_partition,
+            .topic = topic,
+            .partition = assigned.back()});
+    }
+    return {};
+}
+
+/// Checks that a member's current assignment keeps its topics in order of
+/// increasing topic id, with no duplicates.
+std::expected<void, assignor_error>
+check_assignment_order(const member_assignment& assignment) {
+    if (
+      auto repeat = std::ranges::adjacent_find(
+        assignment, std::ranges::greater_equal{}, &topic_partitions::topic);
+      repeat != assignment.end()) {
+        return std::unexpected(
+          assignor_error{
+            .errc = assignor_errc::malformed_assignment,
+            .topic = std::ranges::next(repeat)->topic});
+    }
+    return {};
+}
+
+/// A forward-only position in a sequence ordered by increasing topic id, where
+/// `proj` gets the topic of an element. The position never moves backwards, so
+/// one pass over the sequence serves any number of lookups when they arrive in
+/// increasing topic order, and a lookup below the position misses.
+template<typename Range, typename Proj = std::identity>
+class topic_cursor {
+public:
+    using iterator = std::ranges::iterator_t<Range>;
+
+    /// The sequence must outlive the cursor, so we only accept an lvalue
+    /// reference here.
+    explicit topic_cursor(Range& sequence, Proj proj = {})
+      : _next(std::ranges::begin(sequence))
+      , _end(std::ranges::end(sequence))
+      , _proj(std::move(proj)) {}
+
+    /// Advances to `topic` if present in the tail of the sequence:
+    ///
+    /// - an iterator to its element when the sequence holds `topic`
+    /// - `std::nullopt` on a miss, where a later lookup can still hit
+    /// - `end()` once the sequence is exhausted
+    std::optional<iterator> advance_to(model::topic_id topic) {
+        while (_next != _end && std::invoke(_proj, *_next) < topic) {
+            ++_next;
+        }
+        if (_next == _end) {
+            return _end;
+        }
+        if (std::invoke(_proj, *_next) != topic) {
+            // A miss leaves the cursor as it was: `_next` already sits on the
+            // first element past `topic`, ready for the next, higher lookup.
+            return std::nullopt;
+        }
+        return _next++;
+    }
+
+    iterator end() const { return _end; }
+
+private:
+    iterator _next;
+    iterator _end;
+    Proj _proj;
+};
+
+/// Homogeneous assignment means every member subscribes to the same topics,
+/// so any member can take any partition. Three phases:
+///
+/// - count the partitions of every subscribed topic, and collect the ones that
+///   no member holds
+/// - every member keeps the partitions it already holds, lowest first, up to
+///   its target size, and releases the rest
+/// - the collected partitions go to the members below their target size
+///
+/// A member's target size is the total number of subscribed partitions divided
+/// by the member count, and the remainder goes to that many members, one extra
+/// partition each. So a member above its target size loses partitions it
+/// already holds: an even split takes priority over stickiness.
+///
+/// This class uses the same algorithm as Kafka's
+/// UniformHomogeneousAssignmentBuilder:
+/// https://github.com/apache/kafka/blob/fce22525f74bbd7feeb4f8b34c79a215db9a74c3/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/UniformHomogeneousAssignmentBuilder.java#L50
+class homogeneous_assignment {
+public:
+    /// The group must have at least one member, since they all share its
+    /// subscription.
+    homogeneous_assignment(
+      const group_spec& group, const topic_describer& metadata)
+      : _group(group)
+      , _metadata(metadata)
+      , _target(group.members().size()) {
+        vassert(
+          !group.members().empty(),
+          "tried to produce an assignment for a group with no members");
+    }
+
+    assignment_result build() && {
+        if (subscription().empty()) {
+            return std::move(_target);
+        }
+        auto counted = index_subscriptions();
+        if (!counted.has_value()) {
+            return std::unexpected(counted.error());
+        }
+        auto target_sizes = keep_within_target(*counted);
+        if (!target_sizes.has_value()) {
+            return std::unexpected(target_sizes.error());
+        }
+        auto dealt = deal_what_is_left(*target_sizes, counted->unassigned);
+        if (!dealt.has_value()) {
+            return std::unexpected(dealt.error());
+        }
+        _target.sort();
+        return std::move(_target);
+    }
+
+private:
+    /// The subscription, counted out for the phases that follow.
+    struct subscription_index {
+        /// How many partitions each subscribed topic has.
+        chunked_hash_map<model::topic_id, int32_t> partition_counts;
+        /// Across every subscribed topic.
+        size_t total_partitions{0};
+        /// The partitions no member holds, plus the ones members released to
+        /// stay within a target size, grouped by topic as they are collected.
+        /// A topic can appear more than once: once for the partitions nobody
+        /// held, and once per member that released some. The last phase hands
+        /// them out in this order.
+        chunked_vector<topic_partitions> unassigned;
+    };
+
+    /// A position in one member's current assignment.
+    using assignment_cursor = topic_cursor<
+      const member_assignment,
+      decltype(&topic_partitions::topic)>;
+
+    /// What every member of the group subscribes to.
+    const subscribed_topic_ids& subscription() const {
+        return _group.members().front().subscribed_topics;
+    }
+
+    /// A dynamically sized bitset for partition_ids. One bit per id.
+    class partition_bitmap {
+    public:
+        /// Empties the set and makes room for `capacity` ids.
+        void reset(size_t capacity) {
+            _capacity = capacity;
+            _count = 0;
+            auto in_use = words_for(capacity);
+            while (_words.size() < in_use) {
+                _words.push_back(0);
+            }
+            std::fill_n(_words.begin(), in_use, 0);
+        }
+
+        /// Ignores an id outside the capacity.
+        void insert(model::partition_id partition) {
+            if (!in_range(partition)) {
+                return;
+            }
+            auto& word = _words[word_of(partition)];
+            auto before = word;
+            word |= bit_of(partition);
+            if (word != before) {
+                ++_count;
+            }
+        }
+
+        bool contains(model::partition_id partition) const {
+            return in_range(partition)
+                   && (_words[word_of(partition)] & bit_of(partition)) != 0;
+        }
+
+        /// The ids inside the capacity that the set does not hold, in order
+        /// of increasing partition id. Walks words rather than ids, so a full
+        /// set costs one compare and a sparse one is linear in the words plus
+        /// the ids it returns.
+        partition_set missing() const {
+            partition_set out;
+            if (_count == _capacity) {
+                return out;
+            }
+            out.reserve(_capacity - _count);
+            for (size_t word = 0; word < words_for(_capacity); ++word) {
+                auto absent = ~_words[word];
+                while (absent != 0) {
+                    auto id = word * word_bits
+                              + static_cast<size_t>(std::countr_zero(absent));
+                    if (id >= _capacity) {
+                        break;
+                    }
+                    out.emplace_back(static_cast<int32_t>(id));
+                    absent &= absent - 1;
+                }
+            }
+            return out;
+        }
+
+    private:
+        static constexpr size_t word_bits
+          = std::numeric_limits<uint64_t>::digits;
+
+        bool in_range(model::partition_id partition) const {
+            return partition() >= 0
+                   && static_cast<size_t>(partition()) < _capacity;
+        }
+
+        static size_t words_for(size_t capacity) {
+            return (capacity + word_bits - 1) / word_bits;
+        }
+
+        static size_t word_of(model::partition_id partition) {
+            return static_cast<uint64_t>(partition()) / word_bits;
+        }
+
+        static uint64_t bit_of(model::partition_id partition) {
+            return uint64_t{1}
+                   << (static_cast<uint64_t>(partition()) % word_bits);
+        }
+
+        chunked_vector<uint64_t> _words;
+        size_t _capacity{0};
+        /// How many ids the set holds.
+        size_t _count{0};
+    };
+
+    /// Counts each subscribed topic's partitions and collects the ones that no
+    /// member holds. Fails if any subscribed topic is unrecognized by the
+    /// assignor shard.
+    std::expected<subscription_index, assignor_error> index_subscriptions() {
+        if (
+          auto repeat = std::ranges::adjacent_find(
+            subscription(), std::ranges::greater_equal{});
+          repeat != subscription().end()) {
+            return std::unexpected(
+              assignor_error{
+                .errc = assignor_errc::malformed_subscription,
+                .topic = *std::ranges::next(repeat)});
+        }
+
+        subscription_index result;
+        result.partition_counts.reserve(subscription().size());
+
+        // One position per member, moving forward with the subscription.
+        chunked_vector<assignment_cursor> cursors;
+        cursors.reserve(_group.members().size());
+        for (const auto& member : _group.members()) {
+            cursors.emplace_back(
+              member.current_assignment, &topic_partitions::topic);
+        }
+        // The partitions of the topic in hand that some member already holds.
+        partition_bitmap claimed;
+
+        // For each topic in the subscription, determine which partitions do
+        // not appear in any member's current target assignment.
+        for (const auto& topic : subscription()) {
+            auto num_partitions = partition_count(_metadata, topic);
+            if (!num_partitions.has_value()) {
+                return std::unexpected(num_partitions.error());
+            }
+            result.partition_counts.emplace(topic, *num_partitions);
+            result.total_partitions += static_cast<size_t>(*num_partitions);
+
+            claimed.reset(static_cast<size_t>(*num_partitions));
+
+            for (auto& member : cursors) {
+                auto assigned = member.advance_to(topic);
+                if (!assigned.has_value() || *assigned == member.end()) {
+                    continue;
+                }
+                for (auto partition : (*assigned)->partitions) {
+                    claimed.insert(partition);
+                }
+            }
+
+            auto unowned = claimed.missing();
+            if (!unowned.empty()) {
+                result.unassigned.push_back(
+                  {.topic = topic, .partitions = std::move(unowned)});
+            }
+        }
+
+        return result;
+    }
+
+    /// How much of one member's target size is still unspent, deducted as the
+    /// member keeps partitions topic by topic.
+    class keep_budget {
+    public:
+        explicit keep_budget(size_t target_size)
+          : _target_size(target_size)
+          , _room(target_size) {}
+
+        struct split {
+            size_t to_keep;
+            size_t to_release;
+        };
+
+        /// Splits `held` partitions into the ones the budget still covers,
+        /// which it deducts, and the rest.
+        split fit(size_t held) {
+            auto to_keep = std::min(_room, held);
+            _room -= to_keep;
+            return {.to_keep = to_keep, .to_release = held - to_keep};
+        }
+
+        /// How many partitions the budget has covered so far.
+        size_t kept() const { return _target_size - _room; }
+
+        /// Whether the whole target size was spent.
+        bool filled() const { return _room == 0; }
+
+    private:
+        size_t _target_size;
+        size_t _room;
+    };
+
+    /// Every member keeps the partitions it already holds, up to its target
+    /// size, and releases the rest. Fails on an assignment that is out of
+    /// order or that the topic metadata cannot account for. Returns each
+    /// member's target size, by member index.
+    std::expected<chunked_vector<size_t>, assignor_error>
+    keep_within_target(subscription_index& counted) {
+        // The constructor asserts at least one  member, so the two divisions
+        // below have a non-zero divisor.
+        const auto num_members = _group.members().size();
+        const auto min_size = counted.total_partitions / num_members;
+        // How many members still get one partition more than the minimum.
+        auto extras_left = counted.total_partitions % num_members;
+
+        chunked_vector<size_t> target_sizes;
+        target_sizes.reserve(num_members);
+
+        for (auto index : std::views::iota(size_t{0}, num_members)) {
+            const auto& member = _group.members()[index];
+            if (
+              auto checked = check_assignment_order(member.current_assignment);
+              !checked.has_value()) {
+                return std::unexpected(checked.error());
+            }
+
+            auto target_size = min_size;
+            bool takes_extra = extras_left > 0;
+            if (takes_extra) {
+                ++target_size;
+            }
+
+            auto& assignment = _target[index];
+            keep_budget budget{target_size};
+            for (const auto& [topic, curr_assigned] :
+                 member.current_assignment) {
+                auto counted_topic = counted.partition_counts.find(topic);
+                if (counted_topic == counted.partition_counts.end()) {
+                    // Nobody in the group subscribes to this topic any more,
+                    // so we don't carry its partitions forward into the new
+                    // assignment.
+                    continue;
+                }
+                if (curr_assigned.empty()) {
+                    continue;
+                }
+                if (
+                  auto checked = check_assigned(
+                    topic, curr_assigned, counted_topic->second);
+                  !checked.has_value()) {
+                    return std::unexpected(checked.error());
+                }
+
+                // Keep as much as the budget allows, lowest partitions
+                // first, and release the rest for a member with room to pick
+                // up.
+                auto [to_keep, to_release] = budget.fit(curr_assigned.size());
+                if (to_release > 0) {
+                    counted.unassigned.push_back(
+                      {.topic = topic,
+                       .partitions = partition_set(
+                         std::from_range,
+                         curr_assigned | std::views::drop(to_keep))});
+                }
+                if (to_keep > 0) {
+                    assignment.assign(
+                      topic,
+                      partition_set(
+                        std::from_range,
+                        curr_assigned | std::views::take(to_keep)));
+                }
+            }
+            vassert(
+              budget.kept() == assignment.num_partitions(),
+              "{} kept {} partitions but is assigned {}",
+              member.id,
+              budget.kept(),
+              assignment.num_partitions());
+
+            // Any `extras_left` members can take the odd partitions and the
+            // split stays even, so the extras are spent on stickiness: a
+            // member that did not fill its target would have its extra filled
+            // by a moved partition, while a later member may keep an extra
+            // partition it already holds. The extra passes on, as long as
+            // enough members remain to take every extra still unplaced.
+            bool enough_members_left = num_members - index > extras_left;
+            if (takes_extra && !budget.filled() && enough_members_left) {
+                --target_size;
+                takes_extra = false;
+            }
+            if (takes_extra) {
+                --extras_left;
+            }
+            target_sizes.push_back(target_size);
+        }
+        return target_sizes;
+    }
+
+    /// Hands the collected partitions to the members below their target size,
+    /// in collection order.
+    std::expected<void, assignor_error> deal_what_is_left(
+      const chunked_vector<size_t>& target_sizes,
+      const chunked_vector<topic_partitions>& unassigned) {
+        size_t member = 0;
+        size_t room = 0;
+        // Finds the next member below its target size and consumes one slot
+        // of its room, or reports that no member has room left.
+        auto take_room = [&] {
+            while (room == 0 && member < target_sizes.size()) {
+                auto assigned = _target[member].num_partitions();
+                vassert(
+                  assigned <= target_sizes[member],
+                  "member {} is assigned {} partitions of a target size of {}",
+                  member,
+                  assigned,
+                  target_sizes[member]);
+                room = target_sizes[member] - assigned;
+                if (room == 0) {
+                    ++member;
+                }
+            }
+            if (room == 0) {
+                return false;
+            }
+            --room;
+            return true;
+        };
+
+        for (const auto& [topic, partitions] : unassigned) {
+            for (auto partition : partitions) {
+                if (!take_room()) {
+                    // The target sizes add up to the partition count exactly,
+                    // so a partition left over means the current assignment
+                    // had a partition assigned to two members, or the
+                    // arithmetic above is wrong.
+                    return std::unexpected(
+                      assignor_error{
+                        .errc = assignor_errc::partitions_left_unassigned,
+                        .topic = topic,
+                        .partition = partition});
+                }
+                _target[member].assign(topic, partition);
+            }
+        }
+        return {};
+    }
+
+    const group_spec& _group;
+    const topic_describer& _metadata;
+    group_assignment _target;
+};
+
+} // namespace
+
+assignment_result uniform_assignor::assign(
+  const group_spec& group, const topic_describer& topics) const {
+    if (group.members().empty()) {
+        return group_assignment{};
+    }
+    switch (group.type()) {
+    case subscription_type::homogeneous:
+        return homogeneous_assignment{group, topics}.build();
+    case subscription_type::heterogeneous:
+        vassert(false, "not implemented");
+    }
+    std::unreachable();
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/uniform_assignor.h
+++ b/src/v/kafka/server/uniform_assignor.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "kafka/server/consumer_group_assignor.h"
+
+namespace kafka {
+
+/// The built-in `uniform` assignor: one owner per partition, and that owner
+/// subscribes to the partition's topic.
+///
+/// It spreads load as evenly as the group's subscriptions allow, then keeps as
+/// much of the current assignment as that evenness leaves room for. Evenness
+/// wins where the two conflict, so a member holding too many partitions gives
+/// some up. A group that is already balanced comes back unchanged.
+class uniform_assignor final : public assignor {
+public:
+    static constexpr std::string_view assignor_name = "uniform";
+
+    std::string_view name() const final { return assignor_name; }
+
+    assignment_result
+    assign(const group_spec&, const topic_describer&) const final;
+};
+
+} // namespace kafka


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation behind the change (bug fix, feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

KIP-848 moves partition assignment from the consumers into the group coordinator. This PR adds the assignor interface and the uniform assignor for homogeneous groups, where every member subscribes to the same topics.

  - `consumer_group_assignor`: the interface. A `group_spec` carries the members with their subscriptions and current assignments, and a `topic_describer` supplies partition counts. The assignor returns a `group_assignment` or an `assignor_error`.
  - `uniform_assignor`: the same algorithm as Kafka's `UniformHomogeneousAssignmentBuilder`. Partitions split evenly across the members, and every member keeps as much of its current assignment as the even split allows.
  - tests: 17 cases over the even split, stickiness across membership and subscription changes, and the failure paths.
  - consumer_group_assignor_rpbench measures the coordinator-shard cost of computing a target assignment, over four group scenarios at three sizes.

The assignor has no callers yet: the group coordinator wires it in with the ConsumerGroupHeartbeat path. A heterogeneous group asserts; that pass comes in a follow-up PR.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
