### PR TITLE
kafka/raft: absorb offset_not_available races on follower fetches

### DIFF
--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -156,6 +156,20 @@ void replicated_partition_probe::setup_internal_metrics(const model::ntp& ntp) {
             "Total number of bytes fetched from follower (not all might be "
             "returned to the client)"),
           labels),
+        sm::make_counter(
+          "follower_fetch_waits_total",
+          [this] { return _follower_fetch_waits; },
+          sm::description(
+            "Total number of follower fetches that waited for the follower's "
+            "available-to-read offset to catch up to the fetch offset"),
+          labels),
+        sm::make_counter(
+          "follower_fetch_wait_timeouts_total",
+          [this] { return _follower_fetch_wait_timeouts; },
+          sm::description(
+            "Total number of follower fetch catch-up waits that timed out "
+            "and returned offset_not_available"),
+          labels),
         sm::make_total_bytes(
           "cloud_storage_segments_metadata_bytes",
           [this] {

--- a/src/v/cluster/partition_probe.h
+++ b/src/v/cluster/partition_probe.h
@@ -32,6 +32,7 @@ public:
         virtual void add_batches_produced(uint64_t) = 0;
         virtual void add_bytes_fetched(uint64_t) = 0;
         virtual void add_bytes_fetched_from_follower(uint64_t) = 0;
+        virtual void add_follower_fetch_wait(bool timed_out) = 0;
         virtual void add_schema_id_validation_failed() = 0;
         virtual void setup_metrics(const model::ntp&) = 0;
         virtual void clear_metrics() = 0;
@@ -68,6 +69,10 @@ public:
         return _impl->add_bytes_fetched_from_follower(bytes);
     }
 
+    void add_follower_fetch_wait(bool timed_out) {
+        return _impl->add_follower_fetch_wait(timed_out);
+    }
+
     void add_schema_id_validation_failed() {
         _impl->add_schema_id_validation_failed();
     }
@@ -88,6 +93,12 @@ public:
     void add_bytes_fetched(uint64_t cnt) final { _bytes_fetched += cnt; }
     void add_bytes_fetched_from_follower(uint64_t cnt) final {
         _bytes_fetched_from_follower += cnt;
+    }
+    void add_follower_fetch_wait(bool timed_out) final {
+        ++_follower_fetch_waits;
+        if (timed_out) {
+            ++_follower_fetch_wait_timeouts;
+        }
     }
     void add_bytes_produced(uint64_t cnt) final { _bytes_produced += cnt; }
     void add_batches_produced(uint64_t cnt) final { _batches_produced += cnt; }
@@ -114,6 +125,8 @@ private:
     uint64_t _batches_produced{0};
     uint64_t _bytes_fetched{0};
     uint64_t _bytes_fetched_from_follower{0};
+    uint64_t _follower_fetch_waits{0};
+    uint64_t _follower_fetch_wait_timeouts{0};
     uint64_t _schema_id_validation_records_failed{0};
     config::binding<bool> _enable_scrubbing_bind;
     metrics::internal_metric_groups _metrics;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -711,6 +711,16 @@ configuration::configuration(ctor_key)
       "minimum bytes was not reached.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1ms)
+  , kafka_fetch_follower_catchup_wait_ms(
+      *this,
+      "kafka_fetch_follower_catchup_wait_ms",
+      "Maximum time a follower fetch waits for the follower to catch up to "
+      "the requested offset before returning offset_not_available. Also "
+      "capped by the raft heartbeat interval and the fetch's max wait time. "
+      "Set to 0 to disable the wait.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      300ms,
+      {.min = std::chrono::milliseconds(0)})
   , kafka_fetch_request_timeout_ms(
       *this,
       "kafka_fetch_request_timeout_ms",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -422,6 +422,16 @@ configuration::configuration(ctor_key)
       "0.",
       {.visibility = visibility::tunable},
       3)
+  , raft_follower_nudge_debounce_ms(
+      *this,
+      "raft_follower_nudge_debounce_ms",
+      "Minimum time between out of band metadata pushes to a single follower "
+      "that expedite its view of the leader's committed and visible offsets, "
+      "e.g. when the leader refers a fetch-from-follower consumer to it. Set "
+      "to null to disable the pushes altogether.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      10ms,
+      {.min = 1ms})
 
   , raft_max_recovery_memory(
       *this,

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -201,6 +201,8 @@ struct configuration final : public config_store {
     property<int16_t> metadata_dissemination_retries;
     property<std::chrono::milliseconds> tx_timeout_delay_ms;
     property<std::chrono::milliseconds> fetch_reads_debounce_timeout;
+    bounded_property<std::chrono::milliseconds>
+      kafka_fetch_follower_catchup_wait_ms;
     property<std::chrono::milliseconds> kafka_fetch_request_timeout_ms;
     development_feature_property<bool>
       enable_listoffsets_historical_leader_epoch;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -163,6 +163,8 @@ struct configuration final : public config_store {
     bounded_property<std::chrono::milliseconds> raft_heartbeat_interval_ms;
     bounded_property<std::chrono::milliseconds> raft_heartbeat_timeout_ms;
     property<size_t> raft_heartbeat_disconnect_failures;
+    bounded_property<std::optional<std::chrono::milliseconds>>
+      raft_follower_nudge_debounce_ms;
     bounded_property<std::optional<size_t>> raft_max_recovery_memory;
     property<bool> raft_enable_lw_heartbeat;
     bounded_property<size_t> raft_recovery_concurrency_per_shard;

--- a/src/v/kafka/data/BUILD
+++ b/src/v/kafka/data/BUILD
@@ -65,6 +65,7 @@ redpanda_cc_library(
         "//src/v/cluster",
         "//src/v/cluster:types",
         "//src/v/kafka/server:write_at_offset_stm",
+        "//src/v/ssx:sformat",
         "@boost//:numeric_conversion",
     ],
     visibility = ["//visibility:public"],

--- a/src/v/kafka/data/replicated_partition.cc
+++ b/src/v/kafka/data/replicated_partition.cc
@@ -10,6 +10,7 @@
  */
 #include "kafka/data/replicated_partition.h"
 
+#include "base/vlog.h"
 #include "cloud_storage/types.h"
 #include "cluster/partition.h"
 #include "cluster/partition_kafka_offsets.h"
@@ -22,6 +23,7 @@
 #include "model/fundamental.h"
 #include "model/timeout_clock.h"
 #include "raft/errc.h"
+#include "ssx/sformat.h"
 #include "storage/types.h"
 
 #include <seastar/core/future.hh>
@@ -625,37 +627,50 @@ ss::future<error_code> replicated_partition::validate_fetch_offset(
 
     // offset validation logic on follower
     if (reading_from_follower && !_partition->is_leader()) {
-        auto ec = error_code::none;
-
-        const auto available_to_read = std::min(
-          leader_high_watermark(), log_end_offset());
-
-        if (fetch_offset < start_offset()) {
-            ec = error_code::offset_out_of_range;
-        } else if (fetch_offset > available_to_read) {
-            /**
-             * Offset know to be committed but not yet available on the
-             * follower.
-             */
-            ec = error_code::offset_not_available;
-        }
-
-        if (ec != error_code::none) {
-            vlog(
-              kdlog.warn,
-              "ntp {}: fetch offset out of range on follower, requested: {}, "
-              "partition start offset: {}, high watermark: {}, leader high "
-              "watermark: {}, log end offset: {}, ec: {}",
+        // only the expected, retried-on debug message is rate limited
+        auto log_rejected = [&](ss::log_level level, std::string_view reason) {
+            if (!kdlog.is_enabled(level)) {
+                return;
+            }
+            auto msg = ssx::sformat(
+              "ntp {}: fetch offset {} on follower, requested: {}, partition "
+              "start offset: {}, high watermark: {}, leader high watermark: "
+              "{}, log end offset: {}",
               ntp(),
+              reason,
               fetch_offset,
               start_offset(),
               high_watermark(),
               leader_high_watermark(),
-              log_end_offset(),
-              ec);
+              log_end_offset());
+            if (level == ss::log_level::debug) {
+                thread_local static ss::logger::rate_limit rate(
+                  std::chrono::seconds(1));
+                vloglr(kdlog, level, rate, "{}", msg);
+            } else {
+                vlogl(kdlog, level, "{}", msg);
+            }
+        };
+
+        if (fetch_offset < start_offset()) {
+            log_rejected(ss::log_level::warn, "out of range");
+            return ss::make_ready_future<error_code>(
+              error_code::offset_out_of_range);
         }
 
-        return ss::make_ready_future<error_code>(ec);
+        const auto available_to_read = std::min(
+          leader_high_watermark(), log_end_offset());
+        if (fetch_offset > available_to_read) {
+            /**
+             * Offset known to be committed but not yet available on the
+             * follower.
+             */
+            log_rejected(ss::log_level::debug, "not yet available");
+            return ss::make_ready_future<error_code>(
+              error_code::offset_not_available);
+        }
+
+        return ss::make_ready_future<error_code>(error_code::none);
     }
 
     // Grab the up to date start offset

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -47,6 +47,7 @@
 #include <seastar/core/scheduling.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/timer.hh>
+#include <seastar/coroutine/as_future.hh>
 #include <seastar/util/log.hh>
 
 #include <boost/range/irange.hpp>
@@ -262,6 +263,65 @@ static ss::future<read_result> read_with_units(
 }
 
 /**
+ * A follower fetch (KIP-392) at the leader high watermark routinely races
+ * the follower's view of that watermark, which the next heartbeat or append
+ * from the leader refreshes. Instead of failing with offset_not_available
+ * right away, which makes clients retry in a tight loop, wait for the
+ * follower's available-to-read offset to catch up and re-validate.
+ */
+static ss::future<error_code> wait_for_follower_catchup(
+  cluster::partition_manager& cluster_pm,
+  ntp_fetch_config& ntp_config,
+  kafka::partition_proxy& kafka_partition,
+  std::optional<model::timeout_clock::time_point> max_wait_deadline) {
+    const auto catchup_wait = std::min(
+      config::shard_local_cfg().kafka_fetch_follower_catchup_wait_ms(),
+      config::shard_local_cfg().raft_heartbeat_interval_ms());
+    if (
+      catchup_wait <= std::chrono::milliseconds::zero()
+      || !max_wait_deadline.has_value()) {
+        co_return error_code::offset_not_available;
+    }
+    auto partition = cluster_pm.get(ntp_config.ktp_with_hash());
+    if (!partition || partition->is_read_replica_mode_enabled()) {
+        co_return error_code::offset_not_available;
+    }
+    auto raft = partition->raft();
+
+    const auto wait_deadline = std::min(
+      *max_wait_deadline, model::timeout_clock::now() + catchup_wait);
+    const auto as = ntp_config.cfg.abort_source.has_value()
+                      ? model::opt_abort_source_t(
+                          ntp_config.cfg.abort_source.value().get().local())
+                      : model::opt_abort_source_t{};
+
+    auto ec = error_code::offset_not_available;
+    while (ec == error_code::offset_not_available
+           && model::timeout_clock::now() < wait_deadline) {
+        const auto wait_for = model::next_offset(
+          std::max(
+            raft->last_visible_index(),
+            raft->visible_offset_monitor().last_applied()));
+        auto f = co_await ss::coroutine::as_future(
+          raft->visible_offset_monitor().wait(wait_for, wait_deadline, as));
+        // timed out, fetch aborted or raft is stopping; one final
+        // re-validation picks up a last-instant catch-up
+        const auto interrupted = f.failed();
+        if (interrupted) {
+            f.ignore_ready_future();
+        }
+        ec = co_await kafka_partition.validate_fetch_offset(
+          ntp_config.cfg.start_offset,
+          ntp_config.cfg.read_from_follower,
+          default_fetch_timeout + model::timeout_clock::now());
+        if (interrupted) {
+            break;
+        }
+    }
+    co_return ec;
+}
+
+/**
  * Entry point for reading from an ntp. This is executed on NTP home core and
  * build error responses if anything goes wrong.
  */
@@ -271,6 +331,7 @@ static ss::future<read_result> do_read_from_ntp(
   const replica_selector& replica_selector,
   ntp_fetch_config& ntp_config,
   std::optional<model::timeout_clock::time_point> deadline,
+  std::optional<model::timeout_clock::time_point> max_wait_deadline,
   const bool obligatory_batch_read,
   fetch_memory_units_manager& units_mgr,
   fetch_read_coalescer& coalescer) {
@@ -300,6 +361,12 @@ static ss::future<read_result> do_read_from_ntp(
       ntp_config.cfg.start_offset,
       ntp_config.cfg.read_from_follower,
       default_fetch_timeout + model::timeout_clock::now());
+    if (
+      offset_ec == error_code::offset_not_available
+      && ntp_config.cfg.read_from_follower && !kafka_partition->is_leader()) {
+        offset_ec = co_await wait_for_follower_catchup(
+          cluster_pm, ntp_config, *kafka_partition, max_wait_deadline);
+    }
 
     auto maybe_lso = kafka_partition->last_stable_offset();
     if (unlikely(!maybe_lso)) {
@@ -414,6 +481,7 @@ ss::future<read_result> read_from_ntp(
       md_cache,
       replica_selector,
       ntp_config,
+      deadline,
       deadline,
       obligatory_batch_read,
       units_mgr,
@@ -602,6 +670,7 @@ static ss::future<chunked_vector<read_result>> fetch_ntps(
                    replica_selector,
                    ntp_cfg,
                    fetch_deadline,
+                   deadline,
                    obligatory_batch_read,
                    units_mgr,
                    coalescer)

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -318,6 +318,8 @@ static ss::future<error_code> wait_for_follower_catchup(
             break;
         }
     }
+    kafka_partition.probe().add_follower_fetch_wait(
+      ec == error_code::offset_not_available);
     co_return ec;
 }
 

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -412,6 +412,15 @@ static ss::future<read_result> do_read_from_ntp(
               "Consumer in rack: {}, preferred replica id: {}",
               *ntp_config.cfg.consumer_rack_id,
               preferred_replica.value());
+            /**
+             * The HWM follower we are referring the consumer to may be lagging.
+             * Nudge the follower so it can advance its HWM as soon as possible.
+             */
+            if (
+              auto partition = cluster_pm.get(ntp_config.ktp_with_hash());
+              partition) {
+                partition->raft()->nudge_follower(preferred_replica.value());
+            }
             co_return read_result(
               kafka_partition->start_offset(),
               kafka_partition->high_watermark(),

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -820,6 +820,83 @@ consensus::linearizable_barrier(model::timeout_clock::time_point deadline) {
     co_return ret_t(_commit_index);
 }
 
+void consensus::nudge_follower(model::node_id target) {
+    const auto debounce
+      = config::shard_local_cfg().raft_follower_nudge_debounce_ms();
+    if (!debounce.has_value()) {
+        return;
+    }
+    if (!is_elected_leader() || _bg.is_closed()) {
+        return;
+    }
+    const auto target_vnode = config().find_by_node_id(target);
+    if (!target_vnode) {
+        return;
+    }
+    auto it = _fstates.find(*target_vnode);
+    if (it == _fstates.end()) {
+        return;
+    }
+    auto& f_meta = it->second;
+    /**
+     * A recovering follower is not up to date with the leader's log, so a
+     * bare metadata push does not help it; a follower with inflight appends
+     * is receiving the current metadata via the replicate path already.
+     */
+    if (f_meta.is_recovering || f_meta.has_inflight_appends()) {
+        return;
+    }
+    const auto now = clock_type::now();
+    if (now < f_meta.next_follower_nudge) {
+        return;
+    }
+    const auto m = meta();
+    if (f_meta.last_sent_protocol_meta == m) {
+        return;
+    }
+    f_meta.next_follower_nudge = now + debounce.value();
+    f_meta.last_sent_protocol_meta = m;
+    const auto seq = next_follower_sequence(*target_vnode);
+    update_node_append_timestamp(*target_vnode);
+    _probe->follower_nudge();
+    vlog(_ctxlog.trace, "Sending follower nudge to {}", *target_vnode);
+
+    /**
+     * Track the request as an inflight append for its whole flight, like
+     * heartbeats and replicate rounds do: the heartbeat manager and
+     * subsequent nudges then treat this follower as already contacted (at
+     * most one nudge is pending per follower), and the reply participates in
+     * the same accounting as any other append.
+     */
+    ssx::spawn_with_gate(
+      _bg,
+      [this,
+       target = *target_vnode,
+       m,
+       seq,
+       guard = track_append_inflight(*target_vnode)]() mutable {
+          append_entries_request req(
+            _self, target, m, {}, 0, flush_after_append::no);
+          return _client_protocol
+            .append_entries(
+              target.id(),
+              std::move(req),
+              rpc::client_opts(_replicate_append_timeout))
+            .then(
+              [this,
+               id = target.id(),
+               seq,
+               dirty_offset = m.dirty_offset,
+               guard = std::move(guard)](result<append_entries_reply> reply) {
+                  process_append_entries_reply(id, reply, seq, dirty_offset);
+              })
+            .handle_exception([this, target](const std::exception_ptr& e) {
+                vlog(
+                  _ctxlog.debug, "follower nudge to {} failed: {}", target, e);
+            });
+      });
+}
+
 ss::future<result<replicate_result>>
 consensus::chain_stages(replicate_stages stages) {
     return stages.request_enqueued.then_wrapped(

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -221,6 +221,12 @@ public:
     ss::future<result<model::offset>> linearizable_barrier(
       model::timeout_clock::time_point deadline = model::no_timeout);
 
+    /// Best-effort, debounced push of the current protocol metadata (commit
+    /// index and last visible index) to a single follower via an empty
+    /// append entries request, so its view of the leader's offsets catches
+    /// up without waiting for the next heartbeat.
+    void nudge_follower(model::node_id target);
+
     vnode self() const { return _self; }
     protocol_metadata meta() const;
     raft::group_id group() const { return _group; }

--- a/src/v/raft/follower_states.cc
+++ b/src/v/raft/follower_states.cc
@@ -67,6 +67,7 @@ void follower_index_metadata::reset() {
     last_successful_received_seq = follower_req_seq{0};
     inflight_append_request_count = 0;
     last_sent_protocol_meta.reset();
+    next_follower_nudge = clock_type::time_point{};
     follower_state_change.broadcast();
     max_cleanly_compacted_offset = {};
     coordinated_compaction_offsets_getter = std::make_unique<void_executor>();

--- a/src/v/raft/follower_states.h
+++ b/src/v/raft/follower_states.h
@@ -60,6 +60,9 @@ struct follower_index_metadata {
     // timestamp of last append_entries_rpc call
     clock_type::time_point last_sent_append_entries_req_timestamp;
     clock_type::time_point last_received_reply_timestamp;
+    // earliest time the next out of band metadata push (nudge) may be sent
+    // to this follower.
+    clock_type::time_point next_follower_nudge;
     /// Heartbeat failures observed on the current cached transport.
     /// Reset on a successful reply or when we force a reconnect.
     uint32_t heartbeats_failed{0};

--- a/src/v/raft/probe.cc
+++ b/src/v/raft/probe.cc
@@ -162,6 +162,14 @@ void probe::setup_metrics(const model::ntp& ntp) {
           sm::description("Number of full heartbeats sent by the leader"),
           labels),
         sm::make_counter(
+          "follower_nudge_requests",
+          [this] { return _follower_nudge_requests; },
+          sm::description(
+            "Number of out of band metadata pushes sent by the "
+            "leader to expedite a follower's view of the "
+            "leader's committed and visible offsets"),
+          labels),
+        sm::make_counter(
           "offset_translator_inconsistency_errors",
           [this] { return _offset_translator_inconsistency_error; },
           sm::description(

--- a/src/v/raft/probe.h
+++ b/src/v/raft/probe.h
@@ -63,6 +63,10 @@ public:
 
     void full_heartbeat() { ++_full_heartbeat_requests; }
     void lw_heartbeat() { ++_lw_heartbeat_requests; }
+    void follower_nudge() { ++_follower_nudge_requests; }
+    uint64_t follower_nudge_requests() const {
+        return _follower_nudge_requests;
+    }
     void offset_translator_inconsistency_error() {
         ++_offset_translator_inconsistency_error;
     }
@@ -92,6 +96,7 @@ private:
     uint64_t _recovery_request_error = 0;
     uint64_t _full_heartbeat_requests = 0;
     uint64_t _lw_heartbeat_requests = 0;
+    uint64_t _follower_nudge_requests = 0;
     uint64_t _offset_translator_inconsistency_error = 0;
     uint64_t _append_entries_buffer_flush = 0;
     metrics::internal_metric_groups _metrics;

--- a/src/v/raft/tests/basic_raft_fixture_test.cc
+++ b/src/v/raft/tests/basic_raft_fixture_test.cc
@@ -1211,3 +1211,155 @@ TEST_F_CORO(raft_fixture, test_leadership_blocked_replicas_can_elect_leader) {
     auto leader = co_await wait_for_leader(60s);
     ASSERT_NE_CORO(leader, blocked_follower);
 }
+
+namespace {
+// a follower with inflight appends is not nudged, wait for any pending
+// replication round to settle
+ss::future<> wait_for_no_inflight_appends(
+  ss::lw_shared_ptr<consensus> leader_raft, vnode follower) {
+    return tests::cooperative_spin_wait_with_timeout(
+      10s, [leader_raft, follower] {
+          return !leader_raft->get_follower_states()
+                    .get(follower)
+                    .has_inflight_appends();
+      });
+}
+} // namespace
+
+/**
+ * Nudging a follower pushes the leader's protocol metadata (commit index and
+ * last visible index) to it outside the heartbeat schedule, so its view of
+ * the leader offsets catches up promptly.
+ */
+TEST_F_CORO(raft_fixture, test_follower_nudge_advances_visible_offsets) {
+    co_await create_simple_group(3);
+    auto leader_id = co_await wait_for_leader(10s);
+    auto leader_raft = node(leader_id).raft();
+
+    /**
+     * Push scheduled heartbeats out of the assertion window so that any
+     * catch-up observed below must come from the nudge.
+     */
+    set_election_timeout(60s);
+    set_heartbeat_interval(5s);
+
+    auto result = co_await leader_raft->replicate(
+      make_batches(10, 10, 128),
+      replicate_options(consistency_level::quorum_ack));
+    ASSERT_FALSE_CORO(result.has_error());
+    const auto leader_visible = leader_raft->last_visible_index();
+
+    auto follower_id = random_follower_id().value();
+    auto follower_raft = node(follower_id).raft();
+
+    co_await wait_for_no_inflight_appends(
+      leader_raft, node(follower_id).get_vnode());
+
+    /**
+     * The leader advanced its visible index after the append round was
+     * acked and nothing has carried it to the followers yet - the next
+     * heartbeat is seconds away.
+     */
+    ASSERT_LT_CORO(follower_raft->last_leader_visible_index(), leader_visible);
+    const auto nudges_before
+      = leader_raft->get_probe().follower_nudge_requests();
+
+    leader_raft->nudge_follower(follower_id);
+
+    ASSERT_EQ_CORO(
+      leader_raft->get_probe().follower_nudge_requests(), nudges_before + 1);
+    // the next scheduled heartbeat is seconds away, catching up within a
+    // second demonstrates the nudge carried the offsets
+    co_await tests::cooperative_spin_wait_with_timeout(1s, [&] {
+        return follower_raft->last_leader_visible_index() >= leader_visible;
+    });
+}
+
+/**
+ * Repeated nudges for unchanged leader state collapse into a single request:
+ * once the current protocol metadata was sent to the follower, subsequent
+ * nudges are no-ops until the leader state changes.
+ */
+TEST_F_CORO(raft_fixture, test_follower_nudge_debounce) {
+    co_await create_simple_group(3);
+    auto leader_id = co_await wait_for_leader(10s);
+    auto leader_raft = node(leader_id).raft();
+
+    set_election_timeout(60s);
+    set_heartbeat_interval(5s);
+
+    auto result = co_await leader_raft->replicate(
+      make_batches(1, 1, 128),
+      replicate_options(consistency_level::quorum_ack));
+    ASSERT_FALSE_CORO(result.has_error());
+
+    auto follower_id = random_follower_id().value();
+    co_await wait_for_no_inflight_appends(
+      leader_raft, node(follower_id).get_vnode());
+
+    const auto nudges_before
+      = leader_raft->get_probe().follower_nudge_requests();
+    for (int i = 0; i < 100; ++i) {
+        leader_raft->nudge_follower(follower_id);
+    }
+    ASSERT_LE_CORO(
+      leader_raft->get_probe().follower_nudge_requests(), nudges_before + 1);
+}
+
+/**
+ * Nudges are safe no-ops when called on a non-leader, for an unknown target
+ * node and for a stopped follower.
+ */
+TEST_F_CORO(raft_fixture, test_follower_nudge_no_ops) {
+    co_await create_simple_group(3);
+    auto leader_id = co_await wait_for_leader(10s);
+    auto leader_raft = node(leader_id).raft();
+
+    auto follower_id = random_follower_id().value();
+    auto follower_raft = node(follower_id).raft();
+
+    // non-leader
+    follower_raft->nudge_follower(leader_id);
+    ASSERT_EQ_CORO(follower_raft->get_probe().follower_nudge_requests(), 0);
+
+    // unknown target
+    const auto nudges_before
+      = leader_raft->get_probe().follower_nudge_requests();
+    leader_raft->nudge_follower(model::node_id(123));
+    ASSERT_EQ_CORO(
+      leader_raft->get_probe().follower_nudge_requests(), nudges_before);
+
+    // stopped follower, the dispatched request fails in the background
+    // without surfacing an error
+    co_await stop_node(follower_id);
+    auto result = co_await leader_raft->replicate(
+      make_batches(1, 1, 128),
+      replicate_options(consistency_level::quorum_ack));
+    ASSERT_FALSE_CORO(result.has_error());
+    leader_raft->nudge_follower(follower_id);
+    co_await ss::sleep(100ms);
+}
+
+/**
+ * A waiter on a follower's visible offset monitor is woken by a heartbeat
+ * that only carries the leader's advanced visible index, without any new
+ * appends. The fetch-from-follower catch-up wait relies on this.
+ */
+TEST_F_CORO(
+  raft_fixture, test_follower_visible_offset_monitor_woken_by_heartbeat) {
+    co_await create_simple_group(3);
+    auto leader_id = co_await wait_for_leader(10s);
+    auto leader_raft = node(leader_id).raft();
+
+    auto result = co_await leader_raft->replicate(
+      make_batches(10, 10, 128),
+      replicate_options(consistency_level::quorum_ack));
+    ASSERT_FALSE_CORO(result.has_error());
+    const auto leader_visible = leader_raft->last_visible_index();
+
+    auto follower_id = random_follower_id().value();
+    co_await node(follower_id)
+      .raft()
+      ->visible_offset_monitor()
+      .wait(leader_visible, model::timeout_clock::now() + 10s, std::nullopt);
+}

--- a/tests/rptest/tests/follower_fetching_test.py
+++ b/tests/rptest/tests/follower_fetching_test.py
@@ -439,19 +439,20 @@ class IncrementalFollowerFetchingTest(PreallocNodesTest):
             },
         )
 
-    @skip_debug_mode
-    @cluster(num_nodes=5)
-    @matrix(follower_offline=[True, False])
-    def test_incremental_fetch_from_follower(self, follower_offline):
-        rack_layout_str = "ABC"
-        rack_layout = [str(i) for i in rack_layout_str]
-
+    def _configure_rack_layout(self, rack_layout):
         for ix, node in enumerate(self.redpanda.nodes):
             extra_node_conf = {
                 "rack": rack_layout[ix],
                 "enable_rack_awareness": True,
             }
             self.redpanda.set_extra_node_conf(node, extra_node_conf)
+
+    @skip_debug_mode
+    @cluster(num_nodes=5)
+    @matrix(follower_offline=[True, False])
+    def test_incremental_fetch_from_follower(self, follower_offline):
+        rack_layout_str = "ABC"
+        self._configure_rack_layout([str(i) for i in rack_layout_str])
 
         self.redpanda.start()
         topic = TopicSpec(partition_count=12, replication_factor=3)
@@ -509,3 +510,105 @@ class IncrementalFollowerFetchingTest(PreallocNodesTest):
         )
 
         cli_consumer.stop()
+
+    @skip_debug_mode
+    @cluster(num_nodes=5)
+    @matrix(mode=["catchup_wait_only", "nudge_only", "default"])
+    def test_follower_fetch_at_leader_hwm(self, mode):
+        """
+        A consumer pinned to a follower rack chases the leader high watermark
+        of a steadily produced topic. Its fetches routinely target offsets the
+        follower does not yet know are available; the broker absorbs the race
+        with the follower-side catch-up wait and the leader-side nudge of the
+        preferred replica, and the consumer makes continuous progress with
+        either mechanism (or both) active.
+        """
+        self._configure_rack_layout([str(i) for i in "ABC"])
+
+        self.redpanda.start()
+        if mode == "catchup_wait_only":
+            self.redpanda.set_cluster_config_to_null("raft_follower_nudge_debounce_ms")
+        elif mode == "nudge_only":
+            self.redpanda.set_cluster_config({"kafka_fetch_follower_catchup_wait_ms": 0})
+
+        topic = TopicSpec(partition_count=12, replication_factor=3)
+        self.client().create_topic(topic)
+
+        producer = KgoVerifierProducer(
+            self.test_context,
+            self.redpanda,
+            topic,
+            msg_size=512,
+            # some large number to keep produce load until the end of the test
+            msg_count=1000000,
+            custom_node=self.preallocated_nodes,
+            rate_limit_bps=256 * 1024,
+        )
+        producer.start()
+
+        consumer_group = "follower-hwm-group"
+        # A short metadata max age keeps the consumer re-resolving its
+        # preferred replica, so fetches repeatedly race the follower's view
+        # of the leader high watermark.
+        cli_consumer = KafkaCliConsumer(
+            self.test_context,
+            self.redpanda,
+            topic.name,
+            group=consumer_group,
+            consumer_properties={"client.rack": "A", "metadata.max.age.ms": 10000},
+        )
+        cli_consumer.start()
+        cli_consumer.wait_for_messages(100)
+
+        def sum_nudges():
+            return self.redpanda.metric_sum(
+                "vectorized_raft_follower_nudge_requests_total"
+            )
+
+        def sum_waits():
+            return self.redpanda.metric_sum(
+                "vectorized_cluster_partition_follower_fetch_waits_total",
+                namespace="kafka",
+                topic=topic.name,
+            )
+
+        # chase the head of the log until the mechanism under test has
+        # demonstrably fired
+        fired = sum_waits if mode == "catchup_wait_only" else sum_nudges
+        wait_until(
+            lambda: fired() > 0,
+            timeout_sec=60,
+            backoff_sec=2,
+            err_msg=f"mechanism under test did not fire in mode {mode}",
+        )
+        producer.stop()
+
+        rpk = RpkTool(self.redpanda)
+
+        def no_lag():
+            gr = rpk.group_describe(consumer_group)
+            if gr.state != "Stable":
+                return False
+
+            return all([p.lag == 0 for p in gr.partitions])
+
+        wait_until(
+            no_lag,
+            60,
+            backoff_sec=3,
+            err_msg="Consumer did not catch up with the produced data",
+        )
+        cli_consumer.stop()
+
+        nudges = sum_nudges()
+        waits = sum_waits()
+        self.logger.info(f"follower nudges: {nudges}, catch-up waits: {waits}")
+
+        if mode == "catchup_wait_only":
+            assert nudges == 0, f"nudges are disabled, saw {nudges}"
+            assert waits > 0, "expected follower fetches to hit the catch-up wait"
+        elif mode == "nudge_only":
+            assert nudges > 0, "expected referrals to nudge the preferred replica"
+            assert waits == 0, f"the catch-up wait is disabled, saw {waits}"
+        else:
+            assert nudges > 0, "expected referrals to nudge the preferred replica"


### PR DESCRIPTION
With follower fetching, a consumer learns the high watermark from the leader and immediately fetches from a rack-local follower at that offset. The follower's view of the leader HWM only advances when an append entries request or heartbeat arrives, so it lags by up to a raft heartbeat interval and the fetch routinely fails with the retriable `offset_not_available`. Clients react by retrying in a tight loop until the follower catches up: franzgo and kafka-python re-fetch immediately, while the Java client and librdkafka re-request metadata and usually get referred straight back to the same follower. On busy clusters this produces thousands of warning log lines per second plus the wasted reactor and network work of the retry storm itself.

The commits address this from three angles:

- `kafka: rate limit follower fetch offset validation logs` splits the shared warning: `offset_out_of_range` stays an unconditional warning while the expected, transient `offset_not_available` drops to a rate-limited debug message.
- `kafka: wait for follower catch-up before returning offset_not_available` (plus its config and metric commits): instead of failing immediately, the fetch parks on the raft visible offset monitor and re-validates as appends and heartbeats arrive. The wait ends when the offset becomes available, after one heartbeat interval or `kafka_fetch_follower_catchup_wait_ms` (whichever is smaller), at the client's requested max wait time, or when the fetch is aborted. It is skipped for read replicas. New per-partition counters (`follower_fetch_waits_total`, `follower_fetch_wait_timeouts_total`) expose how often the wait fires and expires.
- `raft: add consensus::nudge_follower` (plus its config and referral commits): when the leader refers a consumer to a follower, it proactively pushes its current protocol metadata to that follower via a one-off empty append entries request (the same shape a full heartbeat synthesizes), so the follower's view usually catches up before the consumer's first fetch even lands. Nudges are debounced per follower (`raft_follower_nudge_debounce_ms`, null disables), suppressed when the follower already saw the current metadata or has inflight appends, tracked as inflight appends themselves, and counted via `raft_follower_nudge_requests_total`.

Covered by raft fixture tests (nudge advances a lagging follower promptly, debounce and meta-equality collapse repeats, no-op safety, and the monitor-wakeup property the wait relies on) and a ducktape test that exercises each mechanism in isolation via the new metrics while a consumer chases the leader HWM from a follower rack.

Note: cloud-topics partitions have their own `validate_fetch_offset` path (`cloud_topics/frontend`) which still returns `offset_not_available` immediately and logs a warning on every occurrence; bringing it to parity is left as a follow-up.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

### Improvements

* Follower fetching: fetches at offsets not yet visible on a follower now briefly wait for the follower to catch up instead of immediately returning a retriable `offset_not_available` error, eliminating client retry storms and the associated log flooding when consumers fetch at the head of the log from a follower. The wait is bounded by the new `kafka_fetch_follower_catchup_wait_ms` property, the raft heartbeat interval, and the fetch's max wait time.
* Follower fetching: the leader now proactively pushes its high watermark to a follower when referring a consumer to it, so the follower is usually caught up before the consumer's first fetch arrives. The pushes are debounced per follower via the new `raft_follower_nudge_debounce_ms` property.
