### PR TITLE
cloud_topics: fast partition movement for tiered-storage v2

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -520,8 +520,7 @@ controller_backend::calculate_learner_initial_offset(
 
     const auto& ntp_cfg = p->log()->config();
     if (ntp_cfg.is_tiered_cloud()) {
-        // filled in by the cloud-topics learner offset implementation
-        return std::nullopt;
+        return calculate_learner_initial_offset_cloud_topics(policy, p);
     }
     if (ntp_cfg.cloud_topic_enabled()) {
         // storage.mode=cloud partitions keep only aggressively truncated
@@ -684,6 +683,43 @@ controller_backend::calculate_learner_initial_offset_archival(
       *retention_offset,
       archival_safe_removable,
       p->archival_meta_stm()->get_last_clean_at(),
+      max_removable_local_log_offset);
+
+    return model::next_offset(
+      std::min(max_removable_local_log_offset, *retention_offset));
+}
+
+std::optional<model::offset>
+controller_backend::calculate_learner_initial_offset_cloud_topics(
+  reconfiguration_policy policy, const ss::lw_shared_ptr<partition>& p) const {
+    /**
+     * For tiered_cloud partitions everything at or below the max removable
+     * local log offset (the last level-one reconciled offset) is durable in
+     * the cloud and readable through the L1 read path on any replica. It
+     * bounds the learner start offset the same way the cloud recoverable
+     * offset bounds it for archival tiered storage.
+     */
+    auto max_removable_local_log_offset = p->max_removable_local_log_offset();
+    if (max_removable_local_log_offset == model::offset::min()) {
+        vlog(
+          clusterlog.trace,
+          "[{}] nothing reconciled to level one yet, no learner start offset",
+          p->ntp());
+        return std::nullopt;
+    }
+
+    auto retention_offset = calculate_move_retention_offset(policy, p);
+
+    if (!retention_offset) {
+        return std::nullopt;
+    }
+
+    vlog(
+      clusterlog.info,
+      "[{}] calculated retention offset: {}, max_removable_local_log_offset "
+      "(level one reconciled): {}",
+      p->ntp(),
+      *retention_offset,
       max_removable_local_log_offset);
 
     return model::next_offset(

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -518,31 +518,26 @@ controller_backend::calculate_learner_initial_offset(
         return std::nullopt;
     }
 
-    if (!p->cloud_data_available()) {
-        vlog(clusterlog.trace, "no cloud data available for: {}", p->ntp());
+    const auto& ntp_cfg = p->log()->config();
+    if (ntp_cfg.is_tiered_cloud()) {
+        // filled in by the cloud-topics learner offset implementation
         return std::nullopt;
     }
-
-    if (p->get_cloud_storage_mode() != cluster::cloud_storage_mode::full) {
+    if (ntp_cfg.cloud_topic_enabled()) {
+        // storage.mode=cloud partitions keep only aggressively truncated
+        // placeholders locally, moves are metadata-sized already
         vlog(
           clusterlog.trace,
-          "cloud storage not fully enabled for: {}",
+          "no learner start offset for cloud-mode topic: {}",
           p->ntp());
         return std::nullopt;
     }
+    return calculate_learner_initial_offset_archival(policy, p);
+}
 
-    if (
-      config::shard_local_cfg().cloud_storage_enable_segment_uploads()
-      == false) {
-        vlog(clusterlog.trace, "segment uploads are paused");
-        return std::nullopt;
-    }
-
-    if (p->archival_meta_stm() == nullptr) {
-        vlog(clusterlog.trace, "no archival_meta_stm for {}", p->ntp());
-        return std::nullopt;
-    }
-
+std::optional<model::offset>
+controller_backend::calculate_move_retention_offset(
+  reconfiguration_policy policy, const ss::lw_shared_ptr<partition>& p) const {
     auto log = p->log();
 
     /**
@@ -617,9 +612,40 @@ controller_backend::calculate_learner_initial_offset(
           model::timestamp::now().value() - initial_retention_ms->count());
     }
 
-    auto retention_offset = log->retention_offset(
+    return log->retention_offset(
       storage::gc_config(
         retention_timestamp_threshold, initial_retention_bytes));
+}
+
+std::optional<model::offset>
+controller_backend::calculate_learner_initial_offset_archival(
+  reconfiguration_policy policy, const ss::lw_shared_ptr<partition>& p) const {
+    if (!p->cloud_data_available()) {
+        vlog(clusterlog.trace, "no cloud data available for: {}", p->ntp());
+        return std::nullopt;
+    }
+
+    if (p->get_cloud_storage_mode() != cluster::cloud_storage_mode::full) {
+        vlog(
+          clusterlog.trace,
+          "cloud storage not fully enabled for: {}",
+          p->ntp());
+        return std::nullopt;
+    }
+
+    if (
+      config::shard_local_cfg().cloud_storage_enable_segment_uploads()
+      == false) {
+        vlog(clusterlog.trace, "segment uploads are paused");
+        return std::nullopt;
+    }
+
+    if (p->archival_meta_stm() == nullptr) {
+        vlog(clusterlog.trace, "no archival_meta_stm for {}", p->ntp());
+        return std::nullopt;
+    }
+
+    auto retention_offset = calculate_move_retention_offset(policy, p);
 
     if (!retention_offset) {
         return std::nullopt;

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -391,6 +391,10 @@ private:
       reconfiguration_policy policy,
       const ss::lw_shared_ptr<partition>& partition) const;
 
+    std::optional<model::offset> calculate_learner_initial_offset_cloud_topics(
+      reconfiguration_policy policy,
+      const ss::lw_shared_ptr<partition>& partition) const;
+
     /// Resolves the retention target offset for a partition move, honoring
     /// the reconfiguration policy and the initial/local retention
     /// properties. std::nullopt means the move must deliver the full local

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -387,6 +387,18 @@ private:
       reconfiguration_policy policy,
       const ss::lw_shared_ptr<partition>& partition) const;
 
+    std::optional<model::offset> calculate_learner_initial_offset_archival(
+      reconfiguration_policy policy,
+      const ss::lw_shared_ptr<partition>& partition) const;
+
+    /// Resolves the retention target offset for a partition move, honoring
+    /// the reconfiguration policy and the initial/local retention
+    /// properties. std::nullopt means the move must deliver the full local
+    /// log.
+    std::optional<model::offset> calculate_move_retention_offset(
+      reconfiguration_policy policy,
+      const ss::lw_shared_ptr<partition>& partition) const;
+
     ss::sharded<topic_table>& _topics;
     shard_placement_table& _shard_placement;
     ss::sharded<shard_table>& _shard_table;

--- a/tests/rptest/tests/scaling_up_test.py
+++ b/tests/rptest/tests/scaling_up_test.py
@@ -440,7 +440,13 @@ class ScalingUpTest(PreallocNodesTest):
 
     @skip_debug_mode
     @cluster(num_nodes=7)
-    def test_fast_node_addition(self):
+    @matrix(
+        storage_mode=[
+            TopicSpec.STORAGE_MODE_TIERED,
+            TopicSpec.STORAGE_MODE_IMPL_TIERED_V2,
+        ]
+    )
+    def test_fast_node_addition(self, storage_mode: str):
         log_segment_size = 2 * 1024 * 1024
         total_segments_per_partition = 20
         partition_cnt = 40
@@ -455,6 +461,11 @@ class ScalingUpTest(PreallocNodesTest):
             # setup initial retention target to 1 segment
             "initial_retention_local_target_bytes_default": log_segment_size,
         }
+        if storage_mode == TopicSpec.STORAGE_MODE_IMPL_TIERED_V2:
+            # speed up L0 -> L1 reconciliation: the learner start offset is
+            # capped by the last reconciled offset, so reconciliation has to
+            # keep up with the producer for the move to be fast
+            extra_rp_conf["cloud_topics_reconciliation_interval"] = 2000
         # shadow indexing is required when we want to leverage fast partition movements
         si_settings = SISettings(
             test_context=self.test_context,
@@ -468,13 +479,24 @@ class ScalingUpTest(PreallocNodesTest):
         topic = TopicSpec(
             replication_factor=3,
             partition_count=partition_cnt,
-            redpanda_remote_write=True,
-            redpanda_remote_read=True,
+            redpanda_remote_write=(storage_mode == TopicSpec.STORAGE_MODE_TIERED),
+            redpanda_remote_read=(storage_mode == TopicSpec.STORAGE_MODE_TIERED),
         )
 
         total_replicas = 3 * partition_cnt
 
-        self.client().create_topic(topic)
+        if storage_mode == TopicSpec.STORAGE_MODE_IMPL_TIERED_V2:
+            self.redpanda.set_feature_active(
+                "tiered_cloud_topics", True, timeout_sec=30
+            )
+            RpkTool(self.redpanda).create_topic(
+                topic=topic.name,
+                partitions=topic.partition_count,
+                replicas=topic.replication_factor,
+                config=TopicSpec.storage_mode_config(storage_mode),
+            )
+        else:
+            self.client().create_topic(topic)
         self.logger.info(
             f"Producing {data_size} bytes of data in {msg_cnt} total messages"
         )

--- a/tests/rptest/tests/scaling_up_test.py
+++ b/tests/rptest/tests/scaling_up_test.py
@@ -465,7 +465,8 @@ class ScalingUpTest(PreallocNodesTest):
             # speed up L0 -> L1 reconciliation: the learner start offset is
             # capped by the last reconciled offset, so reconciliation has to
             # keep up with the producer for the move to be fast
-            extra_rp_conf["cloud_topics_reconciliation_interval"] = 2000
+            extra_rp_conf["cloud_topics_reconciliation_min_interval"] = 250
+            extra_rp_conf["cloud_topics_reconciliation_max_interval"] = 2000
         # shadow indexing is required when we want to leverage fast partition movements
         si_settings = SISettings(
             test_context=self.test_context,


### PR DESCRIPTION
Enables learner-initial-offset based fast partition movement for topics with `redpanda.storage.mode.impl=tiered_v2` (internally `tiered_cloud`).

Previously `controller_backend::calculate_learner_initial_offset` returned `nullopt` for all cloud-topic partitions because it is built on the legacy archival stack (`cloud_data_available()`, `cloud_storage_mode::full`, `archival_meta_stm`), none of which exists for cloud topics — so every replica move copied the full local log, which for `tiered_cloud` holds real data up to local retention.

The change is confined to `controller_backend` plus a ducktape test parametrization:

- `calculate_learner_initial_offset` is split into a dispatcher, the (unchanged) archival implementation, and a shared retention-target helper.
- A new cloud-topics path computes the learner offset with the same retention-target semantics as classic tiered storage (both reconfiguration policies, initial/local retention properties, strict-retention early-out), capped by `partition::max_removable_local_log_offset()` — for cloud topics the last L1-reconciled log offset. Everything below that cap is durable in L1 and served by the L1 read path on the new replica, so a learner can safely skip it.
- `storage.mode=cloud` partitions keep returning `nullopt`: their local log holds only aggressively truncated placeholders, so moves are metadata-sized already.

No `ctp_stm`, raft, or recovery changes. On-demand raft snapshots taken at the cutoff may carry `ctp_stm` state slightly ahead of the declared last-included offset; this is safe because the stm's apply path is idempotent for all correctness-relevant fields (epoch window, LRO/LRLO, and local-threshold updates are monotonic max-guarded; only the placeholder size estimator heuristic may briefly double-count on re-apply).

Coverage: `test_fast_node_addition` is parametrized by storage mode — the existing shadow-indexing flavor is unchanged, and a new `tiered_v2` flavor verifies the same property (a newly added node ends up with <35% of the average per-node footprint and all data stays readable, with the skipped prefix served from L1).

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none

🤖 Generated with [Claude Code](https://claude.com/claude-code)