### PR TITLE
[v26.1.x] sr: fix broker abort when a request fails before its deferred authz check

### DIFF
--- a/src/v/pandaproxy/schema_registry/auth.cc
+++ b/src/v/pandaproxy/schema_registry/auth.cc
@@ -19,6 +19,9 @@
 #include "security/audit/types.h"
 #include "security/request_auth.h"
 
+#include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
+
 #include <boost/algorithm/string/predicate.hpp>
 
 namespace pandaproxy::schema_registry {
@@ -183,7 +186,7 @@ void handle_authz(
 
 } // namespace
 
-std::optional<request_auth_result> auth::handle_auth(
+ss::lw_shared_ptr<request_auth_result> auth::handle_auth(
   server::request_t& rq, std::string_view operation_name) const {
     rq.authn_method = config::get_authn_method(
       rq.service().config().schema_registry_api.value(),
@@ -214,7 +217,8 @@ std::optional<request_auth_result> auth::handle_auth(
         if (config::shard_local_cfg().schema_registry_enable_authorization) {
             if (is_deferred()) {
                 // Defer the authorization handling to the method handler
-                return auth_result;
+                return ss::make_lw_shared<request_auth_result>(
+                  std::move(auth_result));
             } else {
                 enterprise::handle_authz(
                   rq, operation_name, *this, auth_result);
@@ -227,7 +231,34 @@ std::optional<request_auth_result> auth::handle_auth(
         audit_authn_success(rq);
         audit_authz_success(rq);
     }
-    return std::nullopt;
+    return nullptr;
+}
+
+ss::future<server::reply_t> enforce_deferred_authz(
+  ss::future<server::reply_t> handler_result,
+  ss::lw_shared_ptr<request_auth_result> auth_result,
+  std::string_view operation_name) {
+    auto rp = co_await ss::coroutine::as_future(std::move(handler_result));
+    if (auth_result) {
+        if (rp.failed()) {
+            // The request failed before returning any data, so it is
+            // acceptable that its authorization check may not have run.
+            auth_result->pass();
+        } else if (!auth_result->is_checked()) {
+            vlog(
+              srlog.error,
+              "'{}' handler replied without performing its deferred "
+              "authorization check",
+              operation_name);
+            auth_result->pass();
+            // It is essential that the reply is not sent: the client gets a
+            // 500 instead. Since this is security code, do not tell them why.
+            co_await ss::coroutine::return_exception(
+              ss::httpd::server_error_exception("Internal Error"));
+        }
+    }
+    // Yields the handler's reply, or rethrows its original exception.
+    co_return co_await std::move(rp);
 }
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/auth.h
+++ b/src/v/pandaproxy/schema_registry/auth.h
@@ -63,7 +63,7 @@ public:
       = ss::noncopyable_function<ss::future<server::reply_t>(
         server::request_t,
         server::reply_t,
-        std::optional<request_auth_result>,
+        ss::lw_shared_ptr<request_auth_result>,
         std::string_view operation_name)>;
     using function_handler
       = std::variant<regular_function_handler, deferred_function_handler>;
@@ -83,8 +83,9 @@ public:
     // Handle authentication and authorization.
     // The presence of a returned authentication result indicates that the
     // authorization check was deferred and has to be done inside the method
-    // handler
-    std::optional<request_auth_result>
+    // handler. The result is shared with the handler so the caller can
+    // verify, once the handler completes, that the check was performed.
+    ss::lw_shared_ptr<request_auth_result>
     handle_auth(server::request_t& rq, std::string_view operation_name) const;
 
 private:
@@ -92,5 +93,21 @@ private:
     std::optional<op> _op;
     route_resource _res;
 };
+
+/// Await a deferred-authorization handler's reply and enforce that the
+/// handler performed its check.
+///
+/// A handler that fails before reaching its check is acceptable: the client
+/// receives the original error, and no data is returned. A handler that
+/// produces a reply without having checked indicates a handler bug that may
+/// be allowing unchecked access, so the reply is discarded and replaced with
+/// a 500.
+///
+/// A null auth_result means authorization was not deferred for this request
+/// (e.g. it is disabled) and there is nothing to enforce.
+ss::future<server::reply_t> enforce_deferred_authz(
+  ss::future<server::reply_t> handler_result,
+  ss::lw_shared_ptr<request_auth_result> auth_result,
+  std::string_view operation_name);
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/authorization.cc
+++ b/src/v/pandaproxy/schema_registry/authorization.cc
@@ -10,8 +10,10 @@
 
 #include "pandaproxy/schema_registry/authorization.h"
 
+#include "base/vlog.h"
 #include "container/chunked_hash_map.h"
 #include "pandaproxy/api/api-doc/schema_registry.json.hh"
+#include "pandaproxy/logger.h"
 #include "pandaproxy/parsing/httpd.h"
 #include "pandaproxy/schema_registry/context_router.h"
 #include "pandaproxy/schema_registry/service.h"
@@ -184,6 +186,13 @@ void handle_get_schemas_ids_id_authz(
         // schema id exists or not.
         audit_authz(
           rq, operation_name, *auth_result, false, op, audit_resources{});
+        vlog(
+          srlog.info,
+          "{}: schema id {} not found; returning 403 rather than 404 to avoid "
+          "revealing whether schema ids exist (principal: {})",
+          operation_name,
+          parse::request_param<schema_id>(*rq.req, "id"),
+          params.principal);
         throw_unauthorized();
     }
 
@@ -212,6 +221,14 @@ void handle_get_schemas_ids_id_authz(
     } else {
         audit_authz(
           rq, operation_name, *auth_result, false, op, std::move(all_results));
+        vlog(
+          srlog.info,
+          "{}: principal {} has no read permission on any of the {} subjects "
+          "associated with schema id {}",
+          operation_name,
+          params.principal,
+          subjects.size(),
+          parse::request_param<schema_id>(*rq.req, "id"));
         throw_unauthorized();
     }
 }
@@ -235,6 +252,7 @@ void handle_get_subjects_authz(
     auto passing_results = audit_resources{};
     auto failing_results = audit_resources{};
 
+    const auto total_subjects = subjects.size();
     auto new_end = std::ranges::remove_if(subjects, [&](const auto& ctx_sub) {
         auto res = rq.service().authorizor().authorized(
           ctx_sub,
@@ -254,6 +272,17 @@ void handle_get_subjects_authz(
         }
     });
     subjects.erase_to_end(new_end.begin());
+
+    if (!failing_results.empty()) {
+        vlog(
+          srlog.debug,
+          "{}: filtered out {} of {} subjects for principal {} (no describe "
+          "permission)",
+          operation_name,
+          failing_results.size(),
+          total_subjects,
+          params.principal);
+    }
 
     // This endpoint always returns a successful response.
     // Generate a successful audit event with the (possibly empty) list of

--- a/src/v/pandaproxy/schema_registry/authorization.cc
+++ b/src/v/pandaproxy/schema_registry/authorization.cc
@@ -165,10 +165,10 @@ void handle_authz(
 void handle_get_schemas_ids_id_authz(
   const server::request_t& rq,
   std::string_view operation_name,
-  std::optional<request_auth_result>& auth_result,
+  const ss::lw_shared_ptr<request_auth_result>& auth_result,
   const chunked_vector<context_subject>& subjects) {
     constexpr auto op = security::acl_operation::read;
-    if (!auth_result.has_value()) {
+    if (!auth_result) {
         // ACLs or authentication is disabled
         return;
     }
@@ -183,12 +183,7 @@ void handle_get_schemas_ids_id_authz(
         // Throw unauthorized here to avoid leaking information about whether a
         // schema id exists or not.
         audit_authz(
-          rq,
-          operation_name,
-          auth_result.value(),
-          false,
-          op,
-          audit_resources{});
+          rq, operation_name, *auth_result, false, op, audit_resources{});
         throw_unauthorized();
     }
 
@@ -201,7 +196,7 @@ void handle_get_schemas_ids_id_authz(
           params.principal,
           params.host,
           security::superuser_required::no,
-          auth_result.value().get_groups());
+          auth_result->get_groups());
 
         if (res.is_authorized()) {
             authorizing_result = std::move(res);
@@ -216,12 +211,7 @@ void handle_get_schemas_ids_id_authz(
         audit_authz(rq, operation_name, std::move(*authorizing_result));
     } else {
         audit_authz(
-          rq,
-          operation_name,
-          auth_result.value(),
-          false,
-          op,
-          std::move(all_results));
+          rq, operation_name, *auth_result, false, op, std::move(all_results));
         throw_unauthorized();
     }
 }
@@ -229,11 +219,11 @@ void handle_get_schemas_ids_id_authz(
 void handle_get_subjects_authz(
   const server::request_t& rq,
   std::string_view operation_name,
-  std::optional<request_auth_result>& auth_result,
+  const ss::lw_shared_ptr<request_auth_result>& auth_result,
   chunked_vector<context_subject>& subjects) {
     constexpr auto op = security::acl_operation::describe;
 
-    if (!auth_result.has_value()) {
+    if (!auth_result) {
         // ACLs or authentication is disabled
         return;
     }
@@ -252,7 +242,7 @@ void handle_get_subjects_authz(
           params.principal,
           params.host,
           security::superuser_required::no,
-          auth_result.value().get_groups());
+          auth_result->get_groups());
         if (res.is_authorized()) {
             passing_results.emplace_back(
               ctx_sub.to_string(), subject_resource_type);
@@ -271,18 +261,13 @@ void handle_get_subjects_authz(
     // If there are any unauthorized subjects, generate failed audit event with
     // them.
     audit_authz(
-      rq,
-      operation_name,
-      auth_result.value(),
-      true,
-      op,
-      std::move(passing_results));
+      rq, operation_name, *auth_result, true, op, std::move(passing_results));
 
     if (!failing_results.empty()) {
         audit_authz(
           rq,
           operation_name,
-          auth_result.value(),
+          *auth_result,
           false,
           op,
           std::move(failing_results));
@@ -293,11 +278,11 @@ ss::future<> handle_get_contexts_authz(
   const server::request_t& rq,
   std::string_view operation_name,
   sharded_store& store,
-  std::optional<request_auth_result>& auth_result,
+  const ss::lw_shared_ptr<request_auth_result>& auth_result,
   chunked_vector<context>& contexts) {
     constexpr auto op = security::acl_operation::describe;
 
-    if (!auth_result.has_value()) {
+    if (!auth_result) {
         co_return;
     }
 
@@ -311,7 +296,7 @@ ss::future<> handle_get_contexts_authz(
       params.principal,
       params.host,
       security::superuser_required::no,
-      auth_result.value().get_groups());
+      auth_result->get_groups());
 
     auto all_subjects = co_await store.get_subjects(include_deleted::yes);
 
@@ -340,7 +325,7 @@ ss::future<> handle_get_contexts_authz(
           params.principal,
           params.host,
           security::superuser_required::no,
-          auth_result.value().get_groups());
+          auth_result->get_groups());
 
         if (res.is_authorized()) {
             passing_results.emplace_back(
@@ -384,18 +369,13 @@ ss::future<> handle_get_contexts_authz(
     contexts = std::move(result_contexts);
 
     audit_authz(
-      rq,
-      operation_name,
-      auth_result.value(),
-      true,
-      op,
-      std::move(passing_results));
+      rq, operation_name, *auth_result, true, op, std::move(passing_results));
 
     if (!failing_results.empty()) {
         audit_authz(
           rq,
           operation_name,
-          auth_result.value(),
+          *auth_result,
           false,
           op,
           std::move(failing_results));
@@ -405,10 +385,10 @@ ss::future<> handle_get_contexts_authz(
 void handle_config_mode_authz(
   const server::request_t& rq,
   std::string_view operation_name,
-  std::optional<request_auth_result>& auth_result,
+  const ss::lw_shared_ptr<request_auth_result>& auth_result,
   const context_subject& ctx_sub,
   security::acl_operation op) {
-    if (!auth_result.has_value()) {
+    if (!auth_result) {
         // ACLs or authentication is disabled
         return;
     }
@@ -426,14 +406,14 @@ void handle_config_mode_authz(
                               params.principal,
                               params.host,
                               security::superuser_required::no,
-                              auth_result.value().get_groups())
+                              auth_result->get_groups())
                           : rq.service().authorizor().authorized(
                               ctx_sub,
                               op,
                               params.principal,
                               params.host,
                               security::superuser_required::no,
-                              auth_result.value().get_groups());
+                              auth_result->get_groups());
 
     const bool is_authorized = authz_result.is_authorized();
 

--- a/src/v/pandaproxy/schema_registry/authorization.h
+++ b/src/v/pandaproxy/schema_registry/authorization.h
@@ -34,13 +34,13 @@ void handle_authz(
 void handle_get_schemas_ids_id_authz(
   const server::request_t& rq,
   std::string_view operation_name,
-  std::optional<request_auth_result>& auth_result,
+  const ss::lw_shared_ptr<request_auth_result>& auth_result,
   const chunked_vector<context_subject>& subjects);
 
 void handle_get_subjects_authz(
   const server::request_t& rq,
   std::string_view operation_name,
-  std::optional<request_auth_result>& auth_result,
+  const ss::lw_shared_ptr<request_auth_result>& auth_result,
   chunked_vector<context_subject>& subjects);
 
 /// Handles authorization for GET /contexts by filtering the contexts vector
@@ -51,7 +51,7 @@ ss::future<> handle_get_contexts_authz(
   const server::request_t& rq,
   std::string_view operation_name,
   sharded_store& store,
-  std::optional<request_auth_result>& auth_result,
+  const ss::lw_shared_ptr<request_auth_result>& auth_result,
   chunked_vector<context>& contexts);
 
 /// Handles authorization for config/mode endpoints that operate on either
@@ -62,7 +62,7 @@ ss::future<> handle_get_contexts_authz(
 void handle_config_mode_authz(
   const server::request_t& rq,
   std::string_view operation_name,
-  std::optional<request_auth_result>& auth_result,
+  const ss::lw_shared_ptr<request_auth_result>& auth_result,
   const context_subject& ctx_sub,
   security::acl_operation op);
 

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -350,7 +350,7 @@ put_config(server::request_t rq, server::reply_t rp) {
 ss::future<server::reply_t> get_config_subject(
   server::request_t rq,
   server::reply_t rp,
-  std::optional<request_auth_result> auth_result,
+  ss::lw_shared_ptr<request_auth_result> auth_result,
   std::string_view operation_name) {
     parse_accept_header(rq, rp);
     auto ctx_sub = context_subject::from_string(
@@ -418,7 +418,7 @@ std::invoke_result_t<F> get_or_load(server::request_t& rq, F f) {
 ss::future<server::reply_t> put_config_subject(
   server::request_t rq,
   server::reply_t rp,
-  std::optional<request_auth_result> auth_result,
+  ss::lw_shared_ptr<request_auth_result> auth_result,
   std::string_view operation_name) {
     parse_content_type_header(rq);
     parse_accept_header(rq, rp);
@@ -448,7 +448,7 @@ ss::future<server::reply_t> put_config_subject(
 ss::future<server::reply_t> delete_config_subject(
   server::request_t rq,
   server::reply_t rp,
-  std::optional<request_auth_result> auth_result,
+  ss::lw_shared_ptr<request_auth_result> auth_result,
   std::string_view operation_name) {
     parse_accept_header(rq, rp);
     auto ctx_sub = context_subject::from_string(
@@ -534,7 +534,7 @@ ss::future<server::reply_t> put_mode(server::request_t rq, server::reply_t rp) {
 ss::future<server::reply_t> get_mode_subject(
   server::request_t rq,
   server::reply_t rp,
-  std::optional<request_auth_result> auth_result,
+  ss::lw_shared_ptr<request_auth_result> auth_result,
   std::string_view operation_name) {
     parse_accept_header(rq, rp);
     auto ctx_sub = context_subject::from_string(
@@ -570,7 +570,7 @@ ss::future<server::reply_t> get_mode_subject(
 ss::future<server::reply_t> put_mode_subject(
   server::request_t rq,
   server::reply_t rp,
-  std::optional<request_auth_result> auth_result,
+  ss::lw_shared_ptr<request_auth_result> auth_result,
   std::string_view operation_name) {
     parse_content_type_header(rq);
     parse_accept_header(rq, rp);
@@ -602,7 +602,7 @@ ss::future<server::reply_t> put_mode_subject(
 ss::future<server::reply_t> delete_mode_subject(
   server::request_t rq,
   server::reply_t rp,
-  std::optional<request_auth_result> auth_result,
+  ss::lw_shared_ptr<request_auth_result> auth_result,
   std::string_view operation_name) {
     parse_accept_header(rq, rp);
     auto ctx_sub = context_subject::from_string(
@@ -660,7 +660,7 @@ get_schemas_types(server::request_t rq, server::reply_t rp) {
 ss::future<server::reply_t> get_schemas_ids_id(
   server::request_t rq,
   server::reply_t rp,
-  std::optional<request_auth_result> auth_result,
+  ss::lw_shared_ptr<request_auth_result> auth_result,
   std::string_view operation_name) {
     parse_accept_header(rq, rp);
     auto id = parse::request_param<schema_id>(*rq.req, "id");
@@ -698,7 +698,7 @@ ss::future<server::reply_t> get_schemas_ids_id(
 ss::future<server::reply_t> get_schemas_ids_id_schema(
   server::request_t rq,
   server::reply_t rp,
-  std::optional<request_auth_result> auth_result,
+  ss::lw_shared_ptr<request_auth_result> auth_result,
   std::string_view operation_name) {
     parse_accept_header(rq, rp);
     auto id = parse::request_param<schema_id>(*rq.req, "id");
@@ -811,7 +811,7 @@ ss::future<ctx_server<service>::reply_t> get_schemas_ids_id_subjects(
 ss::future<server::reply_t> get_subjects(
   server::request_t rq,
   server::reply_t rp,
-  std::optional<request_auth_result> auth_result,
+  ss::lw_shared_ptr<request_auth_result> auth_result,
   std::string_view operation_name) {
     parse_accept_header(rq, rp);
     auto inc_del{
@@ -1496,7 +1496,7 @@ delete_security_acls(server::request_t rq, server::reply_t rp) {
 ss::future<server::reply_t> get_contexts(
   server::request_t rq,
   server::reply_t rp,
-  std::optional<request_auth_result> auth_result,
+  ss::lw_shared_ptr<request_auth_result> auth_result,
   std::string_view operation_name) {
     parse_accept_header(rq, rp);
 

--- a/src/v/pandaproxy/schema_registry/handlers.h
+++ b/src/v/pandaproxy/schema_registry/handlers.h
@@ -29,19 +29,19 @@ put_config(ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 ss::future<ctx_server<service>::reply_t> get_config_subject(
   ctx_server<service>::request_t rq,
   ctx_server<service>::reply_t rp,
-  std::optional<request_auth_result> auth_result,
+  ss::lw_shared_ptr<request_auth_result> auth_result,
   std::string_view operation_name);
 
 ss::future<ctx_server<service>::reply_t> put_config_subject(
   ctx_server<service>::request_t rq,
   ctx_server<service>::reply_t rp,
-  std::optional<request_auth_result> auth_result,
+  ss::lw_shared_ptr<request_auth_result> auth_result,
   std::string_view operation_name);
 
 ss::future<ctx_server<service>::reply_t> delete_config_subject(
   ctx_server<service>::request_t rq,
   ctx_server<service>::reply_t rp,
-  std::optional<request_auth_result> auth_result,
+  ss::lw_shared_ptr<request_auth_result> auth_result,
   std::string_view operation_name);
 
 ss::future<ctx_server<service>::reply_t>
@@ -53,19 +53,19 @@ put_mode(ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 ss::future<ctx_server<service>::reply_t> get_mode_subject(
   ctx_server<service>::request_t rq,
   ctx_server<service>::reply_t rp,
-  std::optional<request_auth_result> auth_result,
+  ss::lw_shared_ptr<request_auth_result> auth_result,
   std::string_view operation_name);
 
 ss::future<ctx_server<service>::reply_t> put_mode_subject(
   ctx_server<service>::request_t rq,
   ctx_server<service>::reply_t rp,
-  std::optional<request_auth_result> auth_result,
+  ss::lw_shared_ptr<request_auth_result> auth_result,
   std::string_view operation_name);
 
 ss::future<ctx_server<service>::reply_t> delete_mode_subject(
   ctx_server<service>::request_t rq,
   ctx_server<service>::reply_t rp,
-  std::optional<request_auth_result> auth_result,
+  ss::lw_shared_ptr<request_auth_result> auth_result,
   std::string_view operation_name);
 
 ss::future<ctx_server<service>::reply_t> get_schemas_types(
@@ -74,13 +74,13 @@ ss::future<ctx_server<service>::reply_t> get_schemas_types(
 ss::future<ctx_server<service>::reply_t> get_schemas_ids_id(
   ctx_server<service>::request_t rq,
   ctx_server<service>::reply_t rp,
-  std::optional<request_auth_result> auth_result,
+  ss::lw_shared_ptr<request_auth_result> auth_result,
   std::string_view operation_name);
 
 ss::future<ctx_server<service>::reply_t> get_schemas_ids_id_schema(
   ctx_server<service>::request_t rq,
   ctx_server<service>::reply_t rp,
-  std::optional<request_auth_result> auth_result,
+  ss::lw_shared_ptr<request_auth_result> auth_result,
   std::string_view operation_name);
 
 ss::future<ctx_server<service>::reply_t> get_schemas_ids_id_versions(
@@ -92,7 +92,7 @@ ss::future<ctx_server<service>::reply_t> get_schemas_ids_id_subjects(
 ss::future<ctx_server<service>::reply_t> get_subjects(
   ctx_server<service>::request_t rq,
   ctx_server<service>::reply_t rp,
-  std::optional<request_auth_result> auth_result,
+  ss::lw_shared_ptr<request_auth_result> auth_result,
   std::string_view operation_name);
 
 ss::future<ctx_server<service>::reply_t> get_subject_versions(
@@ -138,7 +138,7 @@ ss::future<ctx_server<service>::reply_t> delete_security_acls(
 ss::future<ctx_server<service>::reply_t> get_contexts(
   ctx_server<service>::request_t rq,
   ctx_server<service>::reply_t rp,
-  std::optional<request_auth_result> auth_result,
+  ss::lw_shared_ptr<request_auth_result> auth_result,
   std::string_view operation_name);
 
 ss::future<ctx_server<service>::reply_t> delete_context(

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -92,16 +92,18 @@ public:
               _h,
               [&](const auth::regular_function_handler& h) {
                   vassert(
-                    !auth_result.has_value(),
+                    !auth_result,
                     "Authorization must not be deferred for non-deferred "
                     "endpoints");
                   return h(std::move(rq), std::move(rp));
               },
               [&](const auth::deferred_function_handler& h) {
-                  return h(
-                    std::move(rq),
-                    std::move(rp),
-                    std::move(auth_result),
+                  return enforce_deferred_authz(
+                    h(std::move(rq),
+                      std::move(rp),
+                      auth_result,
+                      _operation_name),
+                    auth_result,
                     _operation_name);
               });
         } catch (const kafka::client::partition_error& ex) {
@@ -390,7 +392,7 @@ server::routes_t get_schema_registry_routes(ss::gate& gate, one_shot& es) {
           [=](
             server::request_t rq,
             server::reply_t rp,
-            std::optional<request_auth_result> auth_result,
+            ss::lw_shared_ptr<request_auth_result> auth_result,
             std::string_view operation_name) -> ss::future<server::reply_t> {
               auto ctx = parse_normalized_context(*rq.req);
               scope_fn(*rq.req, ctx);

--- a/src/v/pandaproxy/schema_registry/test/BUILD
+++ b/src/v/pandaproxy/schema_registry/test/BUILD
@@ -177,6 +177,26 @@ redpanda_cc_btest(
 )
 
 redpanda_cc_btest(
+    name = "deferred_auth",
+    timeout = "short",
+    srcs = [
+        "deferred_auth.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/container:chunked_vector",
+        "//src/v/pandaproxy:core",
+        "//src/v/pandaproxy/schema_registry:server",
+        "//src/v/security",
+        "//src/v/security:request_auth",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
     name = "sharded_store",
     timeout = "short",
     srcs = [

--- a/src/v/pandaproxy/schema_registry/test/deferred_auth.cc
+++ b/src/v/pandaproxy/schema_registry/test/deferred_auth.cc
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "pandaproxy/schema_registry/auth.h"
+#include "security/request_auth.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/http/exception.hh>
+#include <seastar/http/reply.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/unit_test.hpp>
+
+#include <memory>
+#include <stdexcept>
+
+namespace ppsr = pandaproxy::schema_registry;
+
+namespace {
+
+ss::lw_shared_ptr<request_auth_result> make_deferred_auth_result() {
+    return ss::make_lw_shared<request_auth_result>(
+      security::credential_user{"user"},
+      security::credential_password{"password"},
+      "SCRAM-SHA-256",
+      request_auth_result::superuser::no,
+      chunked_vector<security::acl_principal>{});
+}
+
+ppsr::server::reply_t make_reply() {
+    ppsr::server::reply_t rp;
+    rp.rep = std::make_unique<ss::http::reply>();
+    return rp;
+}
+
+ss::future<ppsr::server::reply_t> ready_reply(ppsr::server::reply_t rp) {
+    return ss::make_ready_future<ppsr::server::reply_t>(std::move(rp));
+}
+
+ss::future<ppsr::server::reply_t> failed_reply() {
+    return ss::make_exception_future<ppsr::server::reply_t>(
+      std::runtime_error{"handler failed"});
+}
+
+} // namespace
+
+SEASTAR_THREAD_TEST_CASE(checked_reply_passes_through) {
+    auto auth_result = make_deferred_auth_result();
+    auth_result->pass();
+    auto rp = make_reply();
+    const auto* marker = rp.rep.get();
+
+    auto result = ppsr::enforce_deferred_authz(
+                    ready_reply(std::move(rp)), auth_result, "get_config")
+                    .get();
+
+    BOOST_CHECK_EQUAL(result.rep.get(), marker);
+}
+
+// A handler that produces a reply without having performed its deferred
+// authorization check must not have that reply returned to the client.
+SEASTAR_THREAD_TEST_CASE(unchecked_reply_is_replaced_with_a_500) {
+    auto auth_result = make_deferred_auth_result();
+
+    auto fut = ppsr::enforce_deferred_authz(
+      ready_reply(make_reply()), auth_result, "get_config");
+
+    BOOST_CHECK_THROW(fut.get(), ss::httpd::server_error_exception);
+    BOOST_CHECK(auth_result->is_checked());
+}
+
+// A handler that fails before its deferred authorization check is an
+// acceptable outcome: the client receives the original error, which must
+// not be masked by enforcement.
+SEASTAR_THREAD_TEST_CASE(failed_handler_keeps_its_original_exception) {
+    auto auth_result = make_deferred_auth_result();
+
+    auto fut = ppsr::enforce_deferred_authz(
+      failed_reply(), auth_result, "get_config");
+
+    BOOST_CHECK_THROW(fut.get(), std::runtime_error);
+    BOOST_CHECK(auth_result->is_checked());
+}
+
+// No authentication result means authorization is not deferred for this
+// request (e.g. it is disabled); there is nothing to enforce.
+SEASTAR_THREAD_TEST_CASE(without_auth_result_reply_passes_through) {
+    auto rp = make_reply();
+    const auto* marker = rp.rep.get();
+
+    auto result = ppsr::enforce_deferred_authz(
+                    ready_reply(std::move(rp)), nullptr, "get_config")
+                    .get();
+
+    BOOST_CHECK_EQUAL(result.rep.get(), marker);
+}
+
+SEASTAR_THREAD_TEST_CASE(without_auth_result_failure_propagates) {
+    auto fut = ppsr::enforce_deferred_authz(
+      failed_reply(), nullptr, "get_config");
+
+    BOOST_CHECK_THROW(fut.get(), std::runtime_error);
+}

--- a/src/v/security/request_auth.cc
+++ b/src/v/security/request_auth.cc
@@ -38,8 +38,8 @@ request_authenticator::request_authenticator(
  * Attempt to authenticate the request.
  *
  * The returned object **must be used** via one of its authorization
- * helpers (e.g. require_superuser) or it will throw an exception
- * on destruction.
+ * helpers (e.g. require_superuser) or it will log an error on
+ * destruction.
  *
  * @param req
  * @return
@@ -248,11 +248,14 @@ request_auth_result::request_auth_result(request_auth_result&& other) noexcept
  * a request handler that might be unintentionally allowing unchecked
  * access.
  *
- * This is a rare case of a throwing destructor.  It is made safe by
- * checking if there is already an exception in flight first, and by
- * knowing that all our member objects have nothrow destructors.
+ * The destructor can only log about it: throwing here used to be how the
+ * request was failed, but a coroutine that takes this object by value
+ * destroys it during frame teardown, inside the reactor's noexcept task
+ * entry point, where a throw aborts the broker.  Callers that hand an
+ * unchecked result to a handler are responsible for failing the request,
+ * by inspecting is_checked() once the handler completes.
  */
-request_auth_result::~request_auth_result() noexcept(false) {
+request_auth_result::~request_auth_result() {
     // If another exception is already in flight (e.g., thrown during request
     // handling between authenticate() and the check), it's acceptable that we
     // didn't perform the check. We only log the error if there is no active
@@ -263,10 +266,5 @@ request_auth_result::~request_auth_result() noexcept(false) {
     if (!_checked && !another_exception_in_flight) {
         vlog(
           logger.error, "request_auth_result destroyed without being checked!");
-
-        // In this case, it is essential that we do not send any data
-        // in a response: they get a 500 instead.  Since this is security
-        // code, we do not tell them why.
-        throw ss::httpd::server_error_exception("Internal Error");
     }
 }

--- a/src/v/security/request_auth.h
+++ b/src/v/security/request_auth.h
@@ -125,6 +125,10 @@ public:
     bool is_superuser() const { return _superuser; }
     bool is_auth_required() const { return _auth_required; }
 
+    /// Whether one of the authorization helpers (require_superuser,
+    /// require_authenticated, pass) has been called.
+    bool is_checked() const { return _checked; }
+
 private:
     security::credential_user _username;
     security::credential_password _password;

--- a/src/v/security/request_auth.h
+++ b/src/v/security/request_auth.h
@@ -97,7 +97,7 @@ public:
       , _checked(rhs._checked) {}
 
     request_auth_result(request_auth_result&&) noexcept;
-    ~request_auth_result() noexcept(false);
+    ~request_auth_result();
 
     /**
      * Raise 403 if not a superuser

--- a/src/v/security/tests/BUILD
+++ b/src/v/security/tests/BUILD
@@ -67,6 +67,22 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_btest(
+    name = "request_auth_test",
+    timeout = "short",
+    srcs = [
+        "request_auth_test.cc",
+    ],
+    deps = [
+        "//src/v/security",
+        "//src/v/security:request_auth",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "authorizer_test",
     timeout = "short",

--- a/src/v/security/tests/request_auth_test.cc
+++ b/src/v/security/tests/request_auth_test.cc
@@ -1,0 +1,93 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "security/request_auth.h"
+
+#include <seastar/http/exception.hh>
+
+#include <boost/test/unit_test.hpp>
+
+namespace {
+
+request_auth_result make_authenticated_user(
+  request_auth_result::superuser is_superuser
+  = request_auth_result::superuser::no) {
+    return request_auth_result{
+      security::credential_user{"user"},
+      security::credential_password{"password"},
+      "SCRAM-SHA-256",
+      is_superuser,
+      {}};
+}
+
+request_auth_result
+make_anonymous(request_auth_result::authenticated is_authenticated) {
+    return request_auth_result{
+      is_authenticated,
+      request_auth_result::superuser::no,
+      request_auth_result::auth_required::yes};
+}
+
+} // namespace
+
+// A handler can fail before reaching its authorization check, in which case
+// the result is destroyed unchecked. In a coroutine frame teardown that
+// happens inside a noexcept task entry point, so the destructor must never
+// throw; enforcement of "the check must run" lives with the caller instead.
+BOOST_AUTO_TEST_CASE(unchecked_destroy_does_not_throw) {
+    BOOST_CHECK_NO_THROW({ auto result = make_authenticated_user(); });
+}
+
+BOOST_AUTO_TEST_CASE(is_checked_reflects_authorization_checks) {
+    {
+        auto result = make_authenticated_user();
+        BOOST_CHECK(!result.is_checked());
+        result.pass();
+        BOOST_CHECK(result.is_checked());
+    }
+    {
+        auto result = make_authenticated_user();
+        BOOST_CHECK_NO_THROW(result.require_authenticated());
+        BOOST_CHECK(result.is_checked());
+    }
+    {
+        auto result = make_authenticated_user(
+          request_auth_result::superuser::yes);
+        BOOST_CHECK_NO_THROW(result.require_superuser());
+        BOOST_CHECK(result.is_checked());
+    }
+}
+
+// A denied check throws, but still counts as performed: callers that treat
+// "handler failed" as an acceptable outcome rely on denial being an
+// exception, never an unchecked success.
+BOOST_AUTO_TEST_CASE(denied_checks_throw_and_still_mark_checked) {
+    {
+        auto result = make_anonymous(request_auth_result::authenticated::no);
+        BOOST_CHECK_THROW(
+          result.require_authenticated(), ss::httpd::base_exception);
+        BOOST_CHECK(result.is_checked());
+    }
+    {
+        auto result = make_authenticated_user();
+        BOOST_CHECK_THROW(
+          result.require_superuser(), ss::httpd::base_exception);
+        BOOST_CHECK(result.is_checked());
+    }
+}
+
+// The moved-from husk counts as checked so it neither logs nor enforces,
+// while the moved-to object carries the real state.
+BOOST_AUTO_TEST_CASE(move_transfers_checked_state_to_destination) {
+    auto source = make_authenticated_user();
+    auto destination = std::move(source);
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    BOOST_CHECK(source.is_checked());
+    BOOST_CHECK(!destination.is_checked());
+    destination.pass();
+}

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -10285,7 +10285,13 @@ class SchemaRegistryAclAuthzTestBase(SchemaRegistryEndpoints):
     Base class providing shared ACL test infrastructure (setup, helpers) without test methods.
     """
 
-    def __init__(self, context, extra_rp_conf: dict | None = None, **kwargs):
+    def __init__(
+        self,
+        context,
+        extra_rp_conf: dict | None = None,
+        num_brokers: int = 1,
+        **kwargs,
+    ):
         security = SecurityConfig()
         security.enable_sasl = True
         security.endpoint_authn_method = "sasl"
@@ -10297,7 +10303,7 @@ class SchemaRegistryAclAuthzTestBase(SchemaRegistryEndpoints):
         super().__init__(
             context,
             security=security,
-            num_brokers=1,
+            num_brokers=num_brokers,
             schema_registry_config=schema_registry_config,
             extra_rp_conf=extra_rp_conf,
             **kwargs,

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -10672,6 +10672,33 @@ class SchemaRegistryAclAuthzTest(SchemaRegistryAclAuthzTestBase):
         self.assert_equal(result.status_code, 403)
 
     @cluster(num_nodes=1)
+    def test_get_schemas_ids_id_unacceptable_accept_header(self):
+        """
+        A request that fails before the deferred authz check must produce an
+        error reply, not abort the broker.
+
+        GET /schemas/ids/{id} defers its authorization check until after the
+        schema id is resolved. parse_accept_header() runs first and throws 406
+        for an unsupported Accept header, so the check never runs. The
+        request_auth_result carrying the authentication result must not fault
+        the broker in that case.
+        """
+        subject = "test-subject-1"
+        schema_id = self._create_schema(subject)
+        self._post_acl(self._create_acl(subject, "SUBJECT", "LITERAL", "READ"))
+
+        result = self.sr_client.get_schemas_ids_id(
+            schema_id,
+            headers={"Accept": "application/vnd.not-a-real-format"},
+            auth=self.user_auth,
+        )
+        self.assert_equal(result.status_code, 406)
+
+        # The broker must still be serving.
+        result = self.sr_client.get_schemas_ids_id(schema_id, auth=self.user_auth)
+        self.assert_equal(result.status_code, 200)
+
+    @cluster(num_nodes=1)
     def test_get_schemas_ids_no_match(self):
         """
         Test that access is denied when no subject referencing the schema allows access.
@@ -10871,6 +10898,91 @@ class SchemaRegistryAclAuthzTest(SchemaRegistryAclAuthzTestBase):
             self.redpanda.set_cluster_config(
                 {"schema_registry_enable_authorization": True}
             )
+
+
+class SchemaRegistryAclAuthzUnavailableTest(SchemaRegistryAclAuthzTestBase):
+    """
+    Deferred-authz endpoints must survive an unreachable _schemas partition.
+    """
+
+    def __init__(self, context, **kwargs):
+        # This branch predates schema_registry_use_rpc: read_sync() always
+        # goes through the internal kafka client, which likewise throws after
+        # its suspension point once the _schemas partition has no leader.
+        super().__init__(
+            context,
+            num_brokers=3,
+            **kwargs,
+        )
+
+    @cluster(num_nodes=3)
+    def test_get_schemas_ids_id_unavailable_schemas_partition(self):
+        """
+        GET /schemas/ids/{id} calls read_sync() before its deferred authz
+        check, and that call suspends. When _schemas has no leader, read_sync()
+        throws after the suspension and the check never runs. The request must
+        produce an error reply rather than aborting the broker.
+
+        The suspension matters: an exception raised before the first co_await
+        unwinds on the caller's stack and is caught, but one raised after a
+        suspension tears the coroutine frame down inside the reactor's
+        noexcept task entry point, where a throw cannot be delivered.
+        """
+        subject = "test-subject-1"
+        schema_id = self._create_schema(subject)
+        self._post_acl(self._create_acl(subject, "SUBJECT", "LITERAL", "READ"))
+
+        # Serve the request from a node that does not lead _schemas. A leader
+        # answers the offset lookup out of its own log without needing a
+        # quorum, so read_sync() would keep succeeding there.
+        admin = Admin(self.redpanda)
+        leader_id = admin.await_stable_leader("_schemas", partition=0, timeout_s=30)
+        target = next(
+            n for n in self.redpanda.nodes if self.redpanda.node_id(n) != leader_id
+        )
+
+        # Warm up the target: its schema registry one_shot init must already
+        # have completed. Otherwise _os() throws from inside wrap::operator(),
+        # where the auth result is a local and safe, and the test would pass
+        # for the wrong reason.
+        result = self.sr_client.get_schemas_ids_id(
+            schema_id, hostname=target.account.hostname, auth=self.user_auth
+        )
+        self.assert_equal(result.status_code, 200)
+
+        # The target must not be able to take over _schemas leadership once
+        # the other brokers stop: a leader answers the offset lookup out of
+        # its own log, so read_sync() on it would keep succeeding. Stopping
+        # the brokers one by one leaves the two remaining ones as a live
+        # quorum long enough to elect the target. Maintenance mode blocks the
+        # node from acquiring any leadership while it keeps serving requests.
+        admin.maintenance_start(target)
+        wait_until(
+            lambda: admin.maintenance_status(target).get("finished", False),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="the target never finished draining its leaderships",
+        )
+
+        # Stop the other two brokers. The target is then left below quorum,
+        # so it cannot reach the old leader, and maintenance mode prevents it
+        # from becoming the leader itself: read_sync() has no leader to query.
+        for node in self.redpanda.nodes:
+            if node != target:
+                self.redpanda.stop_node(node)
+
+        def read_sync_fails():
+            result = self.sr_client.get_schemas_ids_id(
+                schema_id, hostname=target.account.hostname, auth=self.user_auth
+            )
+            return result.status_code >= 500
+
+        wait_until(
+            read_sync_fails,
+            timeout_sec=90,
+            backoff_sec=2,
+            err_msg="read_sync() never failed on the surviving broker",
+        )
 
 
 class SchemaRegistryContextAuthzTest(SchemaRegistryAclAuthzTestBase):


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31559

- Command: git cherry-pick -x c81e3b5e5f 2c7d8d57b7 fb07594874 f007f87a2d c8d8b3dc66 c267225967
- Commits backported: 6
- Conflicts resolved: 2
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-31559-v26.1.x-1786739977

## Conflict details

- 2c7d8d57b7 (src/v/pandaproxy/schema_registry/service.cc): `wrap::operator()` on v26.1.x wraps the `ss::visit` in a `try`/`catch` that maps a `_schemas` `partition_error` to an `unknown_server_error` exception, which dev does not have; kept that handler and applied the incoming body inside it (`!auth_result` for the `lw_shared_ptr`, and the deferred branch routed through `enforce_deferred_authz`).
- c8d8b3dc66 (tests/rptest/tests/schema_registry_test.py): the new `SchemaRegistryAclAuthzUnavailableTest` class is inserted directly above a class that dev renamed to `SchemaRegistryContextAuthzTestBase` but is still `SchemaRegistryContextAuthzTest` on v26.1.x; inserted the new class and kept the target branch's class name.

## Branch adaptations

- 2c7d8d57b7 (src/v/pandaproxy/schema_registry/test/BUILD): the new deferred_auth target additionally depends on `//src/v/pandaproxy:core`. On v26.1.x pandaproxy:core is only an implementation_dep of schema_registry:server, so auth.h's include of pandaproxy/server.h does not propagate to dependents the way it does on dev, where it is a public dep.
- c8d8b3dc66 (tests/rptest/tests/schema_registry_test.py): dropped `extra_rp_conf={"schema_registry_use_rpc": True}` from `SchemaRegistryAclAuthzUnavailableTest`; that property does not exist on v26.1.x (the SR RPC transport is 26.2+). read_sync() on this branch always goes through the internal kafka client, which likewise throws after its suspension point once `_schemas` has no leader, so the covered failure mode is unchanged.
