### PR TITLE
kafka: create the schema registry topic as a tiered topic

### DIFF
--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -398,6 +398,12 @@ schema_registry_topic_configuration(int16_t replication_factor) {
     cfg.properties.cleanup_policy_bitflags
       = model::cleanup_policy_bitflags::compaction;
     cfg.properties.compression = model::compression::none;
+    // If cloud storage is available, use tiered storage, otherwise local.
+    // TODO: once we're comfortable, resolve the correct tiered storage impl.
+    cfg.properties.storage_mode
+      = config::shard_local_cfg().cloud_storage_enabled()
+          ? model::redpanda_storage_mode::tiered
+          : model::redpanda_storage_mode::local;
     cfg.properties.retention_bytes = tristate<size_t>{disable_tristate};
     cfg.properties.retention_duration = tristate<std::chrono::milliseconds>{
       disable_tristate};


### PR DESCRIPTION
_schemas previously inherited the cluster's default storage mode. This isn't inherently problematic: the schema registry goes through normal Kafka produce/consume paths (albeit with internal RPCs), so shouldn't care what kind of topic it's talking to.

An expected common case is that the cluster is configured with tiered storage (TSv1) as the default storage mode. With that in mind, we've put in a lot of effort to make sure _schemas as a TSv1 or local topic is safe.

This commit makes the autocreation of the schemas topic create it explicitly as a TSv1 topic, or local if cloud storage is unavailable. In the future we may use TSv2 instead, but without some testing TSv1 seems like a safer choice.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [x] v25.3.x

## Release Notes

### Improvements

* Autocreating the Schema Registry topic will now explicitly create as a tiered storage topic if available, and a local topic otherwise.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
