### PR TITLE
rpc/transport: retain memory semaphore units in queued request entry

### DIFF
--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -36,6 +36,22 @@
 
 using namespace std::chrono_literals; // NOLINT
 
+struct rpc_transport_test_accessor {
+    static size_t memory_available(const rpc::transport& t) {
+        return t._memory.available_units();
+    }
+    static size_t queue_size(const rpc::transport& t) {
+        return t._requests_queue.size();
+    }
+    static rpc::transport::sequence_t& next_seq(rpc::transport& t) {
+        return t._seq;
+    }
+    static rpc::transport::sequence_t& last_seq(rpc::transport& t) {
+        return t._last_seq;
+    }
+    static void dispatch(rpc::transport& t) { t.dispatch_send(); }
+};
+
 namespace rpc {
 
 template<typename Protocol>
@@ -63,6 +79,9 @@ public:
     const net::unresolved_address& server_address() const {
         return _transport->server_address();
     }
+
+    const rpc::transport& get_transport() const { return *_transport; }
+    rpc::transport& get_transport() { return *_transport; }
 
 private:
     ss::lw_shared_ptr<rpc::transport> _transport{nullptr};
@@ -668,6 +687,80 @@ FIXTURE_TEST(test_cleanup_on_timeout_before_sending, rpc_integration_fixture) {
     }
 
     ss::when_all_succeed(requests.begin(), requests.end()).get();
+}
+
+FIXTURE_TEST(
+  test_queued_timeout_retains_memory_units, rpc_integration_fixture) {
+    configure_server();
+    register_services();
+    start_server();
+
+    // Configure client with constrained max_queued_bytes memory budget.
+    constexpr size_t max_budget = 1024;
+    auto cfg = client_config();
+    cfg.max_queued_bytes = max_budget;
+    auto client = rpc::make_client<echo::echo_client_protocol>(cfg);
+    client.connect(model::no_timeout).get();
+    auto stop_client = ss::defer([&] { client.stop().get(); });
+
+    auto& tp = client.get_transport();
+    BOOST_REQUIRE_EQUAL(
+      rpc_transport_test_accessor::memory_available(tp), max_budget);
+    BOOST_REQUIRE_EQUAL(rpc_transport_test_accessor::queue_size(tp), 0);
+
+    // Force a sequence gap by setting _seq to 1 (while _last_seq is 0).
+    // When Request A is issued, it will receive sequence 2.
+    // transport::do_dispatch_send will observe 2 > (0 + 1) and
+    // deterministically hold Request A in _requests_queue without dispatching
+    // it to the socket.
+    rpc_transport_test_accessor::next_seq(tp) = rpc::transport::sequence_t(1);
+
+    const auto payload = random_generators::gen_alphanum_string(512);
+    auto f1 = client.echo(
+      echo::echo_req{.str = payload}, rpc::client_opts(rpc::clock_type::now()));
+
+    // Wait for Request A's response timeout to fire.
+    auto res1 = f1.get();
+    BOOST_REQUIRE(res1.has_error());
+    BOOST_REQUIRE_EQUAL(res1.error(), rpc::errc::client_request_timeout);
+
+    // CRITICAL INTERMEDIATE INVARIANT CHECK (before Request A is
+    // dispatched/drained):
+    // 1. Request A is still physically held in _requests_queue.
+    BOOST_REQUIRE_EQUAL(rpc_transport_test_accessor::queue_size(tp), 1);
+    // 2. Under the fixed implementation, memory units remain held in
+    // entry::memory_units. Under the pre-PR implementation, memory units were
+    // destroyed upon response timeout in f.finally(), prematurely restoring
+    // memory_available to max_budget.
+    auto available_mem = rpc_transport_test_accessor::memory_available(tp);
+    BOOST_REQUIRE_LT(available_mem, max_budget);
+
+    // While Request A remains queued, start Request B requiring more than
+    // available_mem. Request B must block waiting for memory units and cannot
+    // enter _requests_queue.
+    const auto payload2 = random_generators::gen_alphanum_string(600);
+    auto f2 = client.echo(
+      echo::echo_req{.str = payload2}, rpc::client_opts(rpc::no_timeout));
+
+    // Allow fibers to yield; Request B remains blocked on memory semaphore.
+    ss::sleep(20ms).get();
+    BOOST_REQUIRE_EQUAL(rpc_transport_test_accessor::queue_size(tp), 1);
+    BOOST_REQUIRE(!f2.available());
+
+    // Close the sequence gap by setting _last_seq to 1 and triggering dispatch.
+    // Request A (sequence 2) is dispatched and erased from _requests_queue,
+    // releasing its memory units and unblocking Request B.
+    rpc_transport_test_accessor::last_seq(tp) = rpc::transport::sequence_t(1);
+    rpc_transport_test_accessor::dispatch(tp);
+
+    auto res2 = f2.get();
+    BOOST_REQUIRE(res2.has_value());
+    BOOST_REQUIRE_EQUAL(res2.value().data.str, payload2);
+
+    // Final clean state: all entries drained, memory fully restored.
+    BOOST_REQUIRE_EQUAL(rpc_transport_test_accessor::queue_size(tp), 0);
+    BOOST_REQUIRE_EQUAL(
+      rpc_transport_test_accessor::memory_available(tp), max_budget);
 }
 
 FIXTURE_TEST(rpc_mixed_compression, rpc_integration_fixture) {

--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -249,7 +249,8 @@ transport::do_send(sequence_t seq, netbuf b, rpc::client_opts opts) {
             .then_unpack(
               [this, f = std::move(f), seq, corr](
                 ssx::semaphore_units units, scattered_buffer bufs) mutable {
-                  auto e = std::make_unique<entry>(std::move(bufs), corr);
+                  auto e = std::make_unique<entry>(
+                    std::move(bufs), corr, std::move(units));
                   _requests_queue.emplace(seq, std::move(e));
 
                   // By this point the request may already have timed out but
@@ -259,7 +260,7 @@ transport::do_send(sequence_t seq, netbuf b, rpc::client_opts opts) {
                   // - Draining of the request_queue which could otherwise be
                   //   stalled by missing sequence number.
                   dispatch_send();
-                  return std::move(f).finally([u = std::move(units)] {});
+                  return std::move(f);
               })
             .handle_exception([this, seq, corr](std::exception_ptr eptr) {
                 // This is unlikely but may potentially mean dispatch_send()
@@ -318,6 +319,7 @@ ss::future<> transport::do_dispatch_send() {
           _last_seq = it->first;
           auto v = std::move(it->second->bufs);
           auto corr = it->second->correlation_id;
+          auto mem_units = std::move(it->second->memory_units);
           _requests_queue.erase(it);
 
           auto resp_it = _correlations.find(corr);
@@ -356,7 +358,9 @@ ss::future<> transport::do_dispatch_send() {
                     maybe_timing->flushed = flushed;
                 }
             })
-            .finally([this, msg_size] { _probe->add_bytes_sent(msg_size); });
+            .finally([this, msg_size, u = std::move(mem_units)] {
+                _probe->add_bytes_sent(msg_size);
+            });
       });
 }
 

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -208,6 +208,7 @@ private:
     struct entry {
         scattered_buffer bufs;
         uint32_t correlation_id;
+        ssx::semaphore_units memory_units;
     };
     using requests_queue_t
       = absl::btree_map<sequence_t, std::unique_ptr<entry>>;
@@ -289,6 +290,7 @@ private:
 
     friend class ::rpc_integration_fixture_oc_ns_adl_serde_no_upgrade;
     friend class ::rpc_integration_fixture_oc_ns_adl_only_no_upgrade;
+    friend struct ::rpc_transport_test_accessor;
     void set_version(transport_version v) { _version = v; }
 
     std::unique_ptr<client_probe> _probe;


### PR DESCRIPTION
### Problem

Under high partition count or heavy load where inter-broker TCP writes experience backpressure, requests enqueued in `rpc::transport` can cause node OOM crashes.

When `transport::do_send` serializes an outgoing request, it acquires memory units from `_memory` (`max_queued_bytes`) and places an `entry` into `_requests_queue`. However, the acquired `ssx::semaphore_units` were previously moved into a `.finally([u = std::move(units)] {})` callback attached to the response promise future `f`.

When the higher-level caller's request timeout (e.g. Raft election or heartbeat timeout) expires:
1. `f` fails immediately with `rpc::errc::client_request_timeout`.
2. The `.finally` block runs, destructing `u` and releasing memory reservation back to `_memory`.
3. Meanwhile, `entry` (retaining `scattered_buffer bufs`) remains queued in `_requests_queue` while `do_dispatch_send()` is stalled on a blocked TCP socket write.
4. The caller retries, acquires newly-released units from `_memory`, and adds another `entry` to `_requests_queue`.
5. This cycle repeats during network write stalls, causing `_requests_queue` to accumulate thousands of un-backpressured buffer allocations until the node crashes with Out Of Memory (OOM).

### Root Cause

Memory semaphore units (`_memory`) were tied to the lifetime of the response future `f` rather than to the queued `entry` holding the serialized buffer payload. When `f` timed out, `_memory` units were returned prematurely before the buffer was dispatched or drained from `_requests_queue`.

### Solution

1. Store `ssx::semaphore_units memory_units` directly inside `struct entry` in `src/v/rpc/transport.h`.
2. In `transport::do_send`, transfer `units` to `std::make_unique<entry>(std::move(bufs), corr, std::move(units))` when emplacing into `_requests_queue`, and return `f` directly.
3. In `transport::do_dispatch_send`, extract `mem_units = std::move(it->second->memory_units)` when erasing from `_requests_queue`:
   - If the request already timed out, `mem_units` is released as soon as the entry is discarded.
   - If the request is dispatched, `mem_units` is held until `out().write(...)` finishes in `.finally([this, msg_size, u = std::move(mem_units)] { ... })`.

This ensures that `_memory` semaphore units accurately account for all buffer memory queued in `_requests_queue`. If `_requests_queue` reaches `max_queued_bytes`, incoming `send()` calls will wait on `_memory`, enforcing strict backpressure and preventing OOM.

### Test Plan

- Traced and verified Seastar semaphore unit ownership lifecycle across request enqueuing, caller timeout, queue draining, and socket write completion.
- Added regression test `test_queued_timeout_retains_memory_units` in `src/v/rpc/test/rpc_gen_cycling_test.cc` verifying that memory units remain held across timeouts until queue dispatch.
- Verified with red/green mutation: test fails without fix and passes deterministically with fix.

Fixes #12682

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [x] v25.3.x

## Release Notes

### Bug Fixes

* Fix potential memory exhaustion (OOM) during TCP write stalls by retaining RPC transport memory reservation units in queued request entries until dispatch or discard.
