### PR TITLE
gha: backport - push branches directly instead of via a bot fork

### DIFF
--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   # assumptions:
   #   label "kind/backport" exists
-  #   the TARGET_REPO has been already forked into the bots account
+  #   the bot account can push branches directly to the TARGET_REPO (fork no longer required)
   #   outputs the source of the comment (PR or issue)
   backport-type:
     outputs:
@@ -85,7 +85,6 @@ jobs:
         run: |
           username=$(gh api user --jq .login)
           echo "username=$username" >> $GITHUB_OUTPUT
-          echo "repo=$TARGET_REPO" >> $GITHUB_OUTPUT
           echo "email=vbot@redpanda.com" >> $GITHUB_OUTPUT
       - name: Get assignees
         env:
@@ -122,9 +121,10 @@ jobs:
       - uses: actions/checkout@v6
         if: needs.backport-type.outputs.commented_on == 'pr'
         with:
-          repository: ${{ steps.user.outputs.username }}/${{ steps.user.outputs.repo }}
+          repository: ${{ env.TARGET_FULL_REPO }}
           token: ${{ env.ACTIONS_BOT_TOKEN }}
-          path: ./fork
+          path: ./target-repo
+          fetch-depth: 0
       - name: Backport commits and get details
         if: needs.backport-type.outputs.commented_on == 'pr'
         continue-on-error: true
@@ -180,7 +180,7 @@ jobs:
             ${{ github.workspace }}/.claude/skills/create-backport-branch/SKILL.md.
 
             Preflight (bash):
-              cd "${{ github.workspace }}/fork"
+              cd "${{ github.workspace }}/target-repo"
               git cherry-pick --abort || true
               export SKILL_REPORT_FILE="${{ github.workspace }}/.ai-backport-meta/report.md"
               mkdir -p "$(dirname "$SKILL_REPORT_FILE")"
@@ -204,7 +204,7 @@ jobs:
             echo "::error::Skill report file missing or empty at $report (skill probably aborted)"
             exit 1
           fi
-          branch=$(cd "${GITHUB_WORKSPACE}/fork" && git branch --list 'ai-backport-pr-*' --sort=-committerdate --format='%(refname:short)' | head -1)
+          branch=$(cd "${GITHUB_WORKSPACE}/target-repo" && git branch --list 'ai-backport-pr-*' --sort=-committerdate --format='%(refname:short)' | head -1)
           if [[ -z "$branch" ]]; then
             echo "::error::Report file written but no ai-backport-pr-* branch found"
             exit 1
@@ -219,7 +219,7 @@ jobs:
       - name: Diagnostic after AI
         if: always() && needs.backport-type.outputs.commented_on == 'pr'
         run: |
-          cd "${GITHUB_WORKSPACE}/fork" 2>/dev/null || exit 0
+          cd "${GITHUB_WORKSPACE}/target-repo" 2>/dev/null || exit 0
           echo "== git log =="
           git log --oneline -20 || true
           echo "== git status =="
@@ -242,7 +242,6 @@ jobs:
           FIXING_ISSUE_URLS: ${{ steps.pr_details.outputs.fixing_issue_urls }}
           ORIG_PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
           ORIG_PR_URL: ${{ github.event.client_payload.pull_request.html_url }}
-          GIT_USER: ${{ steps.user.outputs.username }}
         id: create_pr
         run: $SCRIPT_DIR/create_pr.sh
         shell: bash
@@ -251,13 +250,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
           PR_HEAD: ${{ env.AI_HEAD_BRANCH }}
-          GIT_USER: ${{ steps.user.outputs.username }}
         run: |
           pr_num=$(gh pr list --repo "$TARGET_FULL_REPO" \
-            --head "$GIT_USER:$PR_HEAD" --state open \
+            --head "$PR_HEAD" --state open \
             --json number --jq '.[0].number')
           if [[ -z "$pr_num" ]]; then
-            echo "::warning::Could not find backport PR with head=$GIT_USER:$PR_HEAD"
+            echo "::warning::Could not find backport PR with head=$PR_HEAD"
             exit 0
           fi
           gh pr edit "$pr_num" --repo "$TARGET_FULL_REPO" \

--- a/.github/workflows/scripts/backport-command/create_pr.sh
+++ b/.github/workflows/scripts/backport-command/create_pr.sh
@@ -8,7 +8,7 @@ set -e
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/gh_wrapper.sh"
 
-cd "$GITHUB_WORKSPACE/fork" || exit 1
+cd "$GITHUB_WORKSPACE/target-repo" || exit 1
 
 backport_issue_urls=""
 # shellcheck disable=SC2153
@@ -68,7 +68,7 @@ fi
 gh pr create --title "[$BACKPORT_BRANCH] $ORIG_TITLE" \
   --base "$BACKPORT_BRANCH" \
   --label "kind/backport" \
-  --head "$GIT_USER:$HEAD_BRANCH" \
+  --head "$HEAD_BRANCH" \
   --repo "$TARGET_ORG/$TARGET_REPO" \
   --reviewer "$AUTHOR" \
   --milestone "$TARGET_MILESTONE" \

--- a/.github/workflows/scripts/backport-command/pr_details.sh
+++ b/.github/workflows/scripts/backport-command/pr_details.sh
@@ -8,7 +8,7 @@ set -e
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/gh_wrapper.sh"
 
-cd "$GITHUB_WORKSPACE/fork"
+cd "$GITHUB_WORKSPACE/target-repo"
 
 if [[ $IS_MERGED != true ]]; then
   msg="The pull request is not merged yet. Cancelling backport..."
@@ -41,19 +41,16 @@ echo "fixing_issue_urls=$fixing_issue_urls" >>$GITHUB_OUTPUT
 suffix=$((RANDOM % 1000))
 git config --global user.email "$GIT_EMAIL"
 git config --global user.name "$GIT_USER"
-git remote add upstream "https://github.com/$TARGET_FULL_REPO.git"
 git fetch --all
-git remote set-url origin "https://$GIT_USER:$GITHUB_TOKEN@github.com/$GIT_USER/$TARGET_REPO.git"
 
 head_branch=$(echo "backport-pr-$PR_NUMBER-$BACKPORT_BRANCH-$suffix" | sed 's/ /-/g')
-git checkout -b "$head_branch" "remotes/upstream/$BACKPORT_BRANCH"
+git checkout -b "$head_branch" "remotes/origin/$BACKPORT_BRANCH"
 
 if ! git cherry-pick -x $BACKPORT_COMMITS; then
   msg="Failed to create a backport PR to $BACKPORT_BRANCH branch. I tried:\n
 \`\`\`\r
-git remote add upstream "https://github.com/$TARGET_FULL_REPO.git"
 git fetch --all
-git checkout -b "$head_branch" "remotes/upstream/$BACKPORT_BRANCH"
+git checkout -b "$head_branch" "remotes/origin/$BACKPORT_BRANCH"
 git cherry-pick -x $BACKPORT_COMMITS
 \`\`\`"
 
@@ -68,5 +65,4 @@ git cherry-pick -x $BACKPORT_COMMITS
 fi
 
 git push --set-upstream origin "$head_branch"
-git remote rm upstream
 echo "head_branch=$head_branch" >>$GITHUB_OUTPUT


### PR DESCRIPTION
The backport flow cherry-picked onto a clone of the bot fork and opened PRs from it, which requires maintaining a fork per target repo and hits the reduced CI/token behavior of PRs from forks. Check out the target repo itself and push the backport branches there, opening same-repo PRs.

fetch-depth: 0 is required: the commits being cherry-picked are ancestors of the default-branch tip, so a shallow checkout would not contain them (git fetch does not deepen an already-shallow branch).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none

