### PR TITLE
kafka/server: fix quota_manager gc use-after-free at shutdown

### DIFF
--- a/src/v/kafka/server/quota_manager.cc
+++ b/src/v/kafka/server/quota_manager.cc
@@ -717,16 +717,13 @@ void quota_manager::gc() {
       "gc should only be performed on the owner shard");
     auto full_window = _default_num_windows() * _default_window_width();
     auto expire_threshold = clock::now() - 10 * full_window;
-    ssx::background
-      = ssx::spawn_with_gate_then(
-          _gate,
-          [this, expire_threshold]() {
-              return container()
-                .invoke_on_all([expire_threshold](quota_manager& qm) {
-                    return qm.do_local_gc(expire_threshold);
-                })
-                .then([this]() { return do_global_gc(); });
-          })
+    ssx::spawn_with_gate(_gate, [this, expire_threshold]() {
+        return ssx::ignore_shutdown_exceptions(
+                 container()
+                   .invoke_on_all([expire_threshold](quota_manager& qm) {
+                       return qm.do_local_gc(expire_threshold);
+                   })
+                   .then([this]() { return do_global_gc(); }))
           .handle_exception([](const std::exception_ptr& e) {
               vlog(klog.warn, "Error garbage collecting quotas - {}", e);
           })
@@ -735,6 +732,7 @@ void quota_manager::gc() {
                   _gc_timer.arm(_gc_freq());
               }
           });
+    });
 }
 
 ss::future<> quota_manager::do_global_gc() {


### PR DESCRIPTION
`quota_manager::gc()` chained its exception handler and timer re-arm onto the future
returned by `ssx::spawn_with_gate_then`, which holds the gate only for its own
continuation. `stop()` could therefore complete and `sharded<>::stop()` free the
instance while those continuations were still queued, so the re-arm read a destroyed
`_gate`. Worse than the stray read: if that read happens to see an open gate, it arms a
destroyed `ss::timer` into the reactor's timer list, which later fires `gc()` on a freed
`quota_manager`.

Found by enabling seastar's task queue shuffling (`SEASTAR_SHUFFLE_TASK_QUEUE`) in debug
builds, which is a separate unmerged change. Under FIFO the bug is effectively invisible:
`forward_to` resolves the `spawn_with_gate_then` future via `set_urgent_state`, putting
the trailing `.finally` at the front of the task queue while `close()`'s waiter goes to
the back, so the `.finally` almost always wins. Shuffling lets it be deferred past the
whole stop-and-destroy chain.

Measured with `--runs_per_test` at `--local_test_jobs=24` on 24 cores (load is the
deciding variable — at 8 jobs it is 0/50 either way):

| tree | shuffling | heap-use-after-free |
| --- | --- | --- |
| pre-fix | on | 86 / 900 (9.6%) |
| pre-fix | off | 0 / 600 |
| post-fix | on | 0 / 2100 |

Plus a back-to-back A/B on one harness: restoring the pre-fix body gave 18/300, the fix
gave 0/300. All 86 failures had the same stack (`gate::is_closed()` from
`quota_manager::gc()` via `finally_body`, freed by `sharded<quota_manager>::stop()`).

Note for reviewers: `quota_manager_test` is independently ~5% flaky under this much load,
unrelated to this fix and to shuffling. A companion PR fixes that separately, so a red run
here is not necessarily this change.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [x] v25.3.x

## Release Notes

### Bug Fixes

* Fixed a use-after-free in the Kafka client quota manager during shutdown.
