### PR TITLE
[CORE-16980] iceberg/avro: handle UUID logical type for fixed(16) columns

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -359,7 +359,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "fkMdLvKMU8vr/ZS2EUt5B8zDz0vrA6K1Af/aKVC6XoQ=",
+        "bzlTransitiveDigest": "cBSy9ouu+7ojOWTee6nbj+eEhqJ4Pj4xbVantOgXLEc=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedInputs": [
           "REPO_MAPPING:,bazel_tools bazel_tools",
@@ -382,7 +382,13 @@
               "build_file": "@@//bazel/thirdparty:avro.BUILD",
               "sha256": "d605e8c139f50ca9892e4e682591a977916b222770aab710d014dd7bf1975324",
               "strip_prefix": "avro-3f2a1426d443df12ea45daf049dfb6eeef99ec39",
-              "url": "https://github.com/redpanda-data/avro/archive/3f2a1426d443df12ea45daf049dfb6eeef99ec39.tar.gz"
+              "url": "https://github.com/redpanda-data/avro/archive/3f2a1426d443df12ea45daf049dfb6eeef99ec39.tar.gz",
+              "patches": [
+                "@@//bazel/thirdparty:avro-uuid-fixed.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
             }
           },
           "base64": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -26,6 +26,10 @@ def data_dependency():
         sha256 = "d605e8c139f50ca9892e4e682591a977916b222770aab710d014dd7bf1975324",
         strip_prefix = "avro-3f2a1426d443df12ea45daf049dfb6eeef99ec39",
         url = "https://github.com/redpanda-data/avro/archive/3f2a1426d443df12ea45daf049dfb6eeef99ec39.tar.gz",
+        patches = [
+            "//bazel/thirdparty:avro-uuid-fixed.patch",
+        ],
+        patch_args = ["-p1"],
     )
 
     http_archive(

--- a/bazel/thirdparty/avro-uuid-fixed.patch
+++ b/bazel/thirdparty/avro-uuid-fixed.patch
@@ -1,0 +1,16 @@
+diff --git a/lang/c++/impl/Node.cc b/lang/c++/impl/Node.cc
+index b310ca26e..f8a1c2d3e 100644
+--- a/lang/c++/impl/Node.cc
++++ b/lang/c++/impl/Node.cc
+@@ -200,9 +200,9 @@ void Node::setLogicalType(LogicalType logicalType) {
+             }
+             break;
+         case LogicalType::UUID:
+-            if (type_ != AVRO_STRING) {
++            if (type_ != AVRO_STRING && (type_ != AVRO_FIXED || fixedSize() != 16)) {
+                 throw Exception("UUID logical type can only annotate "
+-                                "STRING type");
++                                "STRING type or FIXED type of length 16");
+             }
+             break;
+         case LogicalType::MAP:

--- a/src/v/iceberg/conversion/schema_avro.cc
+++ b/src/v/iceberg/conversion/schema_avro.cc
@@ -237,6 +237,9 @@ inner_field_type_from_avro(const avro::NodePtr& node, state& state) {
         if (node->logicalType().type() == avro::LogicalType::DECIMAL) {
             return create_decimal(node);
         }
+        if (node->logicalType().type() == avro::LogicalType::UUID) {
+            return iceberg::uuid_type{};
+        }
         return iceberg::fixed_type{node->fixedSize()};
     case avro::AVRO_SYMBOLIC:
         /**

--- a/src/v/iceberg/conversion/tests/iceberg_avro_tests.cc
+++ b/src/v/iceberg/conversion/tests/iceberg_avro_tests.cc
@@ -386,6 +386,15 @@ constexpr auto logical_types = R"J(
             }
         },
         {
+            "name": "uuid_fixed",
+            "type": {
+                "name": "fixed_uuid_16",
+                "type": "fixed",
+                "size": 16,
+                "logicalType": "uuid"
+            }
+        },
+        {
             "name": "date_int",
             "type": {
                 "type": "int",
@@ -459,30 +468,32 @@ TEST(AvroSchema, TestLogicalTypes) {
 
     ASSERT_FALSE(iceberg_struct_res.has_error());
     auto struct_t = std::move(iceberg_struct_res.value());
-    ASSERT_EQ(struct_t.fields.size(), 9);
+    ASSERT_EQ(struct_t.fields.size(), 10);
     EXPECT_TRUE(
       field_matches(struct_t.fields[0], "uuid_string", iceberg::uuid_type{}));
     EXPECT_TRUE(
-      field_matches(struct_t.fields[1], "date_int", iceberg::date_type{}));
+      field_matches(struct_t.fields[1], "uuid_fixed", iceberg::uuid_type{}));
+    EXPECT_TRUE(
+      field_matches(struct_t.fields[2], "date_int", iceberg::date_type{}));
     EXPECT_TRUE(field_matches(
-      struct_t.fields[2],
+      struct_t.fields[3],
       "bytes_decimal",
       iceberg::decimal_type{.precision = 38, .scale = 9}));
     EXPECT_TRUE(field_matches(
-      struct_t.fields[3],
+      struct_t.fields[4],
       "fixed_decimal",
       iceberg::decimal_type{.precision = 20, .scale = 9}));
     EXPECT_TRUE(
-      field_matches(struct_t.fields[4], "int_time_ms", iceberg::time_type{}));
+      field_matches(struct_t.fields[5], "int_time_ms", iceberg::time_type{}));
     EXPECT_TRUE(field_matches(
-      struct_t.fields[5], "long_time_micro", iceberg::time_type{}));
+      struct_t.fields[6], "long_time_micro", iceberg::time_type{}));
     EXPECT_TRUE(field_matches(
-      struct_t.fields[6], "long_ts_ms", iceberg::timestamptz_type{}));
+      struct_t.fields[7], "long_ts_ms", iceberg::timestamptz_type{}));
     EXPECT_TRUE(field_matches(
-      struct_t.fields[7], "long_ts_micro", iceberg::timestamptz_type{}));
+      struct_t.fields[8], "long_ts_micro", iceberg::timestamptz_type{}));
     // Duration logical type is not intrepreted in as a separate iceberg type
     EXPECT_TRUE(field_matches(
-      struct_t.fields[8], "duration_fixed", iceberg::fixed_type{12}));
+      struct_t.fields[9], "duration_fixed", iceberg::fixed_type{12}));
 }
 
 iobuf serialize_with_avro(
@@ -1132,6 +1143,18 @@ AssertionResult value_matches(
                   ASSERT_VALUES_EQUAL(
                     decimal_bytes,
                     expected.value<::avro::GenericFixed>().value())
+              });
+        }
+        if (datum.logicalType().type() == avro::LogicalType::UUID) {
+            return primitive_equal<iceberg::uuid_value>(
+              datum,
+              value,
+              [](
+                const iceberg::uuid_value& current,
+                const avro::GenericDatum& expected) {
+                  auto uuid_bytes = current.val.to_vector();
+                  ASSERT_VALUES_EQUAL(
+                    uuid_bytes, expected.value<::avro::GenericFixed>().value())
               });
         }
         return primitive_equal<iceberg::fixed_value>(

--- a/src/v/iceberg/conversion/values_avro.cc
+++ b/src/v/iceberg/conversion/values_avro.cc
@@ -102,6 +102,13 @@ struct primitive_visitor {
         }
 
         if (node->type() == avro::AVRO_FIXED) {
+            if (node->logicalType().type() == avro::LogicalType::UUID) {
+                iobuf_parser p(std::move(buffer));
+                std::vector<uint8_t> v(uuid_t::length);
+                p.consume_to(uuid_t::length, v.data());
+                return convert_primitive<uuid_t, iceberg::uuid_value>(
+                  uuid_t(v), avro::AVRO_FIXED, node);
+            }
             return convert_primitive<iobuf, iceberg::fixed_value>(
               std::move(buffer), avro::AVRO_FIXED, node);
         }

--- a/src/v/serde/avro/tests/data_generator.cc
+++ b/src/v/serde/avro/tests/data_generator.cc
@@ -167,6 +167,13 @@ avro_generator::generate_datum_impl(int level, const avro::NodePtr& node) {
             datum.value<::avro::GenericFixed>() = fixed;
             return datum;
         }
+        if (node->logicalType().type() == avro::LogicalType::UUID) {
+            auto uuid = uuid_t::create();
+            auto v = uuid.to_vector();
+            fixed.value().assign(v.begin(), v.end());
+            datum.value<::avro::GenericFixed>() = fixed;
+            return datum;
+        }
         fixed.value().reserve(node->fixedSize());
         for (size_t i = 0; i < node->fixedSize(); ++i) {
             fixed.value()[i] = random_generators::get_int<uint8_t>();


### PR DESCRIPTION
Avro allows the UUID logical type to be backed by string and fixed(16), but we only handled the string case. This adds support for backing with fixed(16). This required a minimal patch to our Avro fork (first commit) and updates to translation (second commit).

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.2.x
- [X] v26.1.x
- [X] v25.3.x

## Release Notes

### Bug Fixes

* Iceberg translation now supports Avro schemas with UUID logical types backed by fixed(16).
