### PR TITLE
[CORE-14911] Fix `_schemas` replay for a truncated log

### DIFF
--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -104,6 +104,7 @@ enum class errc : int16_t {
     invalid_target_node_id,
     topic_id_already_exists,
     feature_sanctioned,
+    offset_out_of_range,
 };
 
 fmt::iterator format_to(errc err, fmt::iterator);
@@ -298,6 +299,9 @@ struct errc_category final : public std::error_category {
             return "A topic with the given id already exists";
         case errc::feature_sanctioned:
             return "Unable to use requested feature - license is invalid";
+        case errc::offset_out_of_range:
+            return "Requested offset is outside of the available range of the "
+                   "partition";
             REDPANDA_BEGIN_IGNORE_DEPRECATIONS
             // unused in the codebase but still in the enum, include it here
             // since clang wants switches to be exhaustive

--- a/src/v/cluster/errors.cc
+++ b/src/v/cluster/errors.cc
@@ -213,6 +213,8 @@ fmt::iterator format_to(errc err, fmt::iterator out) {
         return fmt::format_to(out, "cluster::errc::topic_id_already_exists");
     case errc::feature_sanctioned:
         return fmt::format_to(out, "cluster::errc::feature_sanctioned");
+    case errc::offset_out_of_range:
+        return fmt::format_to(out, "cluster::errc::offset_out_of_range");
         REDPANDA_BEGIN_IGNORE_DEPRECATIONS
     case errc::inconsistent_stm_update:
         return fmt::format_to(

--- a/src/v/kafka/data/rpc/serde.cc
+++ b/src/v/kafka/data/rpc/serde.cc
@@ -81,9 +81,10 @@ fmt::iterator topic_partitions::format_to(fmt::iterator it) const {
 fmt::iterator partition_offsets::format_to(fmt::iterator it) const {
     return fmt::format_to(
       it,
-      "{{ high_watermark: {}, last_stable_offset: {} }}",
+      "{{ high_watermark: {}, last_stable_offset: {}, start_offset: {} }}",
       high_watermark,
-      last_stable_offset);
+      last_stable_offset,
+      start_offset);
 }
 
 fmt::iterator partition_offset_result::format_to(fmt::iterator it) const {

--- a/src/v/kafka/data/rpc/serde.h
+++ b/src/v/kafka/data/rpc/serde.h
@@ -121,11 +121,14 @@ struct topic_partitions
 
 struct partition_offsets
   : serde::
-      envelope<partition_offsets, serde::version<0>, serde::compat_version<0>> {
-    auto serde_fields() { return std::tie(high_watermark, last_stable_offset); }
+      envelope<partition_offsets, serde::version<1>, serde::compat_version<0>> {
+    auto serde_fields() {
+        return std::tie(high_watermark, last_stable_offset, start_offset);
+    }
 
     kafka::offset high_watermark;
     kafka::offset last_stable_offset;
+    std::optional<kafka::offset> start_offset;
 
     fmt::iterator format_to(fmt::iterator it) const;
 };

--- a/src/v/kafka/data/rpc/service.cc
+++ b/src/v/kafka/data/rpc/service.cc
@@ -20,6 +20,7 @@
 #include "model/record_batch_reader.h"
 #include "model/timeout_clock.h"
 #include "raft/errc.h"
+#include "storage/exceptions.h"
 
 #include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/future.hh>
@@ -159,6 +160,7 @@ local_service::get_partition_offsets(
           return ssx::now<ret_t>(partition_offsets{
             .high_watermark = model::offset_cast(partition->high_watermark()),
             .last_stable_offset = model::offset_cast(lso_r.value()),
+            .start_offset = model::offset_cast(partition->start_offset()),
           });
       });
 }
@@ -212,6 +214,25 @@ local_service::consume(
               co_return cluster::errc::not_leader;
           }
 
+          auto deadline = model::timeout_clock::now() + timeout;
+
+          auto offset_ec = co_await partition->validate_fetch_offset(
+            kafka::offset_cast(start_offset),
+            /*is_follower=*/false,
+            deadline);
+          if (offset_ec == kafka::error_code::offset_out_of_range) {
+              co_return cluster::errc::offset_out_of_range;
+          }
+          if (offset_ec != kafka::error_code::none) {
+              vlog(
+                log.warn,
+                "Error validating fetch offset {} on partition {}: {}",
+                start_offset,
+                partition->ntp(),
+                offset_ec);
+              co_return cluster::errc::partition_operation_failed;
+          }
+
           // Create log reader config
           kafka::log_reader_config reader_cfg(
             start_offset,
@@ -223,23 +244,30 @@ local_service::consume(
             std::nullopt,  // client_address
             false);        // strict_max_bytes
 
-          auto deadline = model::timeout_clock::now() + timeout;
-
-          // Create reader
-          auto translating_reader = co_await partition->make_reader(reader_cfg);
-
-          // Consume batches from reader
+          // Create reader and consume batches from it
           try {
+              auto translating_reader = co_await partition->make_reader(
+                reader_cfg);
               co_return co_await model::consume_reader_to_chunked_vector(
                 std::move(translating_reader.reader), deadline);
           } catch (const ss::timed_out_error&) {
               co_return cluster::errc::timeout;
+          } catch (const translation_offset_out_of_range& e) {
+              vlog(
+                log.warn,
+                "Offset {} is outside the translation range of partition {}: "
+                "{}",
+                start_offset,
+                partition->ntp(),
+                e.what());
+              co_return cluster::errc::offset_out_of_range;
           } catch (...) {
+              auto eptr = std::current_exception();
               vlog(
                 log.warn,
                 "Error consuming from partition {}: {}",
                 partition->ntp(),
-                std::current_exception());
+                eptr);
               co_return cluster::errc::partition_operation_failed;
           }
       });

--- a/src/v/kafka/data/rpc/test/deps.h
+++ b/src/v/kafka/data/rpc/test/deps.h
@@ -78,13 +78,19 @@ struct produced_batch {
 class in_memory_proxy : public kafka::partition_proxy::impl {
 public:
     in_memory_proxy(
-      const model::ktp& ktp, ss::chunked_fifo<produced_batch>* produced_batches)
+      const model::ktp& ktp,
+      ss::chunked_fifo<produced_batch>* produced_batches,
+      model::offset start_offset = model::offset{0})
       : _ntp(ktp.to_ntp())
-      , _produced_batches(produced_batches) {}
+      , _produced_batches(produced_batches)
+      , _start_offset(start_offset) {}
     in_memory_proxy(
-      model::ntp ntp, ss::chunked_fifo<produced_batch>* produced_batches)
+      model::ntp ntp,
+      ss::chunked_fifo<produced_batch>* produced_batches,
+      model::offset start_offset = model::offset{0})
       : _ntp(std::move(ntp))
-      , _produced_batches(produced_batches) {}
+      , _produced_batches(produced_batches)
+      , _start_offset(start_offset) {}
 
     const model::ntp& ntp() const final { return _ntp; }
     ss::future<result<model::offset, kafka::error_code>>
@@ -94,9 +100,7 @@ public:
     model::offset local_start_offset() const final {
         throw std::runtime_error("unimplemented");
     }
-    model::offset start_offset() const final {
-        throw std::runtime_error("unimplemented");
-    }
+    model::offset start_offset() const final { return _start_offset; }
     model::offset high_watermark() const final {
         return model::next_offset(latest_offset());
     }
@@ -151,8 +155,12 @@ public:
         throw std::runtime_error("unimplemented");
     }
     ss::future<kafka::error_code> validate_fetch_offset(
-      model::offset, bool, model::timeout_clock::time_point) final {
-        throw std::runtime_error("unimplemented");
+      model::offset fetch_offset,
+      bool,
+      model::timeout_clock::time_point) final {
+        co_return fetch_offset < _start_offset
+          ? kafka::error_code::offset_out_of_range
+          : kafka::error_code::none;
     }
 
     ss::future<result<model::offset>> replicate(
@@ -215,6 +223,7 @@ private:
 
     model::ntp _ntp;
     ss::chunked_fifo<produced_batch>* _produced_batches;
+    model::offset _start_offset;
 };
 
 class fake_partition_leader_cache : public partition_leader_cache {
@@ -428,6 +437,10 @@ public:
 
     void set_errors(int n) { _errors_to_inject = n; }
 
+    void set_start_offset(const model::ntp& ntp, model::offset o) {
+        _start_offsets.insert_or_assign(ntp, o);
+    }
+
     void set_shard_owner(const model::ntp& ntp, ss::shard_id shard_id) {
         _shard_locations.insert_or_assign(ntp, shard_id);
     }
@@ -464,7 +477,8 @@ public:
             co_await _stall_cv.wait([this] { return !_stalled; });
         }
         auto pp = kafka::partition_proxy(
-          std::make_unique<in_memory_proxy>(ntp, &_produced_batches));
+          std::make_unique<in_memory_proxy>(
+            ntp, &_produced_batches, start_offset(ntp)));
         co_return co_await fn(&pp);
     }
 
@@ -473,11 +487,18 @@ public:
     }
 
 private:
+    template<typename N>
+    model::offset start_offset(const N& ntp) const {
+        auto it = _start_offsets.find(ntp);
+        return it == _start_offsets.end() ? model::offset{0} : it->second;
+    }
+
     int _errors_to_inject = 0;
     bool _stalled{false};
     ss::condition_variable _stall_cv;
     ss::chunked_fifo<produced_batch> _produced_batches;
     model::ntp_map_type<ss::shard_id> _shard_locations;
+    model::ntp_map_type<model::offset> _start_offsets;
 };
 
 class fake_partition_manager : public partition_manager {
@@ -492,6 +513,10 @@ public:
     }
 
     void set_errors(int n) { _fake_proxy->set_errors(n); }
+
+    void set_start_offset(const model::ntp& ntp, model::offset o) {
+        _fake_proxy->set_start_offset(ntp, o);
+    }
 
     void set_shard_owner(const model::ntp& ntp, ss::shard_id shard_id) {
         _fake_proxy->set_shard_owner(ntp, shard_id);

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -52,6 +52,8 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
         return error_code::not_coordinator;
     case cluster::errc::invalid_request:
         return error_code::invalid_request;
+    case cluster::errc::offset_out_of_range:
+        return error_code::offset_out_of_range;
     case cluster::errc::throttling_quota_exceeded:
         return error_code::throttling_quota_exceeded;
     case cluster::errc::update_in_progress:

--- a/src/v/pandaproxy/schema_registry/BUILD
+++ b/src/v/pandaproxy/schema_registry/BUILD
@@ -105,6 +105,7 @@ redpanda_cc_library(
         "//src/v/kafka/client:exceptions",
         "//src/v/kafka/data/rpc",
         "//src/v/kafka/protocol:create_topics",
+        "//src/v/kafka/protocol:list_offset",
         "//src/v/kafka/server:topic_config_utils",
         "//src/v/model",
         "//src/v/pandaproxy:logger",
@@ -299,6 +300,7 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         "//src/v/base",
+        "//src/v/kafka/protocol",
         "//src/v/pandaproxy:logger",
         "//src/v/storage:record_batch_builder",
     ],

--- a/src/v/pandaproxy/schema_registry/kafka_client_transport.cc
+++ b/src/v/pandaproxy/schema_registry/kafka_client_transport.cc
@@ -25,6 +25,7 @@
 #include "kafka/client/exceptions.h"
 #include "kafka/data/rpc/deps.h"
 #include "kafka/protocol/create_topics.h"
+#include "kafka/protocol/list_offset.h"
 #include "kafka/server/handlers/topics/types.h"
 #include "model/namespace.h"
 #include "pandaproxy/logger.h"
@@ -132,8 +133,26 @@ kafka_client_transport::produce(model::record_batch batch) {
 }
 
 ss::future<model::offset> kafka_client_transport::get_high_watermark() {
+    return list_offset(kafka::list_offsets_request::latest_timestamp);
+}
+
+ss::future<model::offset> kafka_client_transport::get_log_start() {
+    return list_offset(kafka::list_offsets_request::earliest_timestamp);
+}
+
+ss::future<model::offset>
+kafka_client_transport::list_offset(model::timestamp timestamp) {
+    kafka::list_offsets_request req;
+    req.data.topics.emplace_back(
+      kafka::list_offset_topic{
+        .name = model::schema_registry_internal_tp.topic,
+        .partitions = {kafka::list_offset_partition{
+          .partition_index = model::schema_registry_internal_tp.partition,
+          .timestamp = timestamp,
+          .max_num_offsets = 1,
+        }}});
     auto offsets_f = co_await ss::coroutine::as_future(
-      _client->list_offsets(model::schema_registry_internal_tp));
+      _client->list_offsets(std::move(req)));
     if (offsets_f.failed()) {
         rethrow_partition_error(offsets_f.get_exception());
     }

--- a/src/v/pandaproxy/schema_registry/kafka_client_transport.h
+++ b/src/v/pandaproxy/schema_registry/kafka_client_transport.h
@@ -41,6 +41,7 @@ public:
 
     ss::future<produce_result> produce(model::record_batch batch) override;
     ss::future<model::offset> get_high_watermark() override;
+    ss::future<model::offset> get_log_start() override;
     ss::future<> consume_range(
       model::offset start,
       model::offset end,
@@ -56,6 +57,7 @@ public:
     bool has_ephemeral_credentials() const;
 
 private:
+    ss::future<model::offset> list_offset(model::timestamp timestamp);
     ss::future<> mitigate_error(std::exception_ptr eptr);
     ss::future<> inform(model::node_id);
     ss::future<> do_inform(model::node_id);

--- a/src/v/pandaproxy/schema_registry/rpc_transport.cc
+++ b/src/v/pandaproxy/schema_registry/rpc_transport.cc
@@ -47,6 +47,10 @@ throw_as_kafka_error(std::string_view context, cluster::errc ec) {
         throw kafka::exception(
           kafka::error_code::request_timed_out,
           fmt::format("{}: {}", context, ec));
+    case cluster::errc::offset_out_of_range:
+        throw kafka::exception(
+          kafka::error_code::offset_out_of_range,
+          fmt::format("{}: {}", context, ec));
     default:
         throw kafka::exception(
           kafka::error_code::unknown_server_error,
@@ -79,6 +83,19 @@ ss::future<model::offset> rpc_transport::get_high_watermark() {
           "RPC get_partition_offsets failed", result.error());
     }
     co_return kafka::offset_cast(result.value().high_watermark);
+}
+
+ss::future<model::offset> rpc_transport::get_log_start() {
+    auto result = co_await _client.get_single_partition_offsets(
+      model::schema_registry_internal_tp);
+    if (result.has_error()) {
+        throw_as_kafka_error(
+          "RPC get_partition_offsets failed", result.error());
+    }
+    // A broker that predates the start_offset field can't tell us where the
+    // log begins. Assume the whole log is available.
+    co_return kafka::offset_cast(
+      result.value().start_offset.value_or(kafka::offset{0}));
 }
 
 ss::future<> rpc_transport::consume_range(

--- a/src/v/pandaproxy/schema_registry/rpc_transport.h
+++ b/src/v/pandaproxy/schema_registry/rpc_transport.h
@@ -33,6 +33,7 @@ public:
 
     ss::future<produce_result> produce(model::record_batch batch) override;
     ss::future<model::offset> get_high_watermark() override;
+    ss::future<model::offset> get_log_start() override;
     ss::future<> consume_range(
       model::offset start,
       model::offset end,

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -11,6 +11,7 @@
 
 #include "base/vassert.h"
 #include "base/vlog.h"
+#include "kafka/protocol/exceptions.h"
 #include "model/namespace.h"
 #include "pandaproxy/logger.h"
 #include "pandaproxy/schema_registry/error.h"
@@ -102,6 +103,16 @@ struct batch_builder : public storage::record_batch_builder {
     }
 };
 
+bool is_offset_out_of_range(const std::exception_ptr& eptr) {
+    try {
+        std::rethrow_exception(eptr);
+    } catch (const kafka::exception_base& e) {
+        return e.error == kafka::error_code::offset_out_of_range;
+    } catch (...) {
+        return false;
+    }
+}
+
 } // namespace
 
 /// Call this before reading from the store, if servicing
@@ -134,22 +145,57 @@ ss::future<> seq_writer::wait_for(model::offset offset) {
               vlog(srlog.trace, "wait_for waiting for {} waiters", waiters);
           }
           return ss::with_semaphore(seq._wait_for_sem, 1, [&seq, offset]() {
-              if (offset > seq._loaded_offset) {
-                  vlog(
-                    srlog.debug,
-                    "wait_for dirty!  Reading {}..{}",
-                    seq._loaded_offset,
-                    offset);
-                  return seq._transport->consume_range(
-                    seq._loaded_offset + model::offset{1},
-                    offset + model::offset{1},
-                    consume_to_store{seq._store, seq});
-              } else {
-                  vlog(srlog.trace, "wait_for clean (offset  {})", offset);
-                  return ss::make_ready_future<>();
-              }
+              return seq.do_wait_for(offset);
           });
       });
+}
+
+ss::future<> seq_writer::do_wait_for(model::offset offset) {
+    if (offset <= _loaded_offset) {
+        vlog(srlog.trace, "wait_for clean (offset  {})", offset);
+        co_return;
+    }
+    vlog(
+      srlog.debug, "wait_for dirty!  Reading {}..{}", _loaded_offset, offset);
+
+    auto read_from = model::next_offset(_loaded_offset);
+    auto read_to = model::next_offset(offset);
+    auto fut = co_await ss::coroutine::as_future(_transport->consume_range(
+      read_from, read_to, consume_to_store{_store, *this}));
+    if (!fut.failed()) {
+        co_return;
+    }
+
+    // The topic may have been prefix truncated past what we've already read,
+    // in which case the records between are gone for good. Resume from
+    // whatever survives rather than failing every subsequent request.
+    auto eptr = fut.get_exception();
+    if (!is_offset_out_of_range(eptr)) {
+        std::rethrow_exception(eptr);
+    }
+    auto log_start = co_await _transport->get_log_start();
+    if (log_start <= read_from) {
+        std::rethrow_exception(eptr);
+    }
+    vlog(
+      srlog.error,
+      "The {} topic has been truncated to offset {}, past the last offset we "
+      "read ({}): the records between are lost, along with the schemas, "
+      "subject configs and modes they held. Resuming from offset {} with "
+      "whatever survives. Restore {} from a backup, and do not enable "
+      "deletion (a cleanup policy including 'delete', or any retention limit) "
+      "on it.",
+      model::schema_registry_internal_tp.topic,
+      log_start,
+      _loaded_offset,
+      log_start,
+      model::schema_registry_internal_tp.topic);
+    advance_offset_inner(model::prev_offset(log_start));
+    if (read_to <= log_start) {
+        co_return;
+    }
+    co_await _transport->consume_range(
+      log_start, read_to, consume_to_store{_store, *this});
 }
 
 /// Helper for write methods that need to check + retry if their

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -251,6 +251,7 @@ private:
 
     /// Block until this offset is available, fetching if necessary
     ss::future<> wait_for(model::offset offset);
+    ss::future<> do_wait_for(model::offset offset);
 
     std::unique_ptr<sequence_state_checker> _state_checker;
 

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -743,12 +743,39 @@ ss::future<> service::fetch_internal_topic() {
     auto max_offset = co_await _transport->get_high_watermark();
     vlog(srlog.debug, "Schema registry: _schemas max_offset: {}", max_offset);
 
+    // The topic is created with compaction and no retention, so the log
+    // normally starts at offset 0 even after compaction. A later start offset
+    // means records were deleted outright (retention or DeleteRecords), and
+    // whatever they held is unrecoverable.
+    auto log_start = co_await _transport->get_log_start();
+    auto start_offset = std::max(model::offset{0}, log_start);
+    if (start_offset > model::offset{0}) {
+        vlog(
+          srlog.error,
+          "The {} topic has been truncated to offset {}: records [0, {}) have "
+          "been deleted and the schemas, subject configs and modes they held "
+          "are lost. Recovering from offset {} with whatever survives. The "
+          "registry may be missing schemas that produced data still refers to, "
+          "and may reissue a schema id that was assigned in the deleted range. "
+          "Restore {} from a backup, and do not enable deletion (a cleanup "
+          "policy including 'delete', or any retention limit) on it.",
+          model::schema_registry_internal_tp.topic,
+          start_offset,
+          start_offset,
+          start_offset,
+          model::schema_registry_internal_tp.topic);
+        // Nothing below the start offset can ever be read, so record it as
+        // replayed. Otherwise an empty surviving range would leave the
+        // sequencer asking for offset 0 on the next incremental read.
+        co_await writer().advance_offset(model::prev_offset(start_offset));
+    }
+
     using namespace std::chrono_literals;
     const auto defer = defer_processing{
       config::shard_local_cfg().schema_registry_deferred_recovery()};
     auto replay_start = ss::lowres_clock::now();
     co_await _transport->consume_range(
-      model::offset{0}, max_offset, consume_to_store{_store, writer(), defer});
+      start_offset, max_offset, consume_to_store{_store, writer(), defer});
     auto replay_done = ss::lowres_clock::now();
 
     co_await _store.process_marked_schemas();

--- a/src/v/pandaproxy/schema_registry/test/BUILD
+++ b/src/v/pandaproxy/schema_registry/test/BUILD
@@ -517,6 +517,39 @@ redpanda_cc_gtest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "truncated_replay_test",
+    timeout = "short",
+    srcs = [
+        "truncated_replay.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/cluster",
+        "//src/v/cluster:cluster_utils",
+        "//src/v/cluster:controller_log_limiter",
+        "//src/v/cluster:data_migration_table",
+        "//src/v/cluster:feature_backend",
+        "//src/v/cluster:fwd",
+        "//src/v/cluster:leader_balancer_strategy",
+        "//src/v/cluster:node_status_backend",
+        "//src/v/cluster:self_test",
+        "//src/v/cluster:topic_metrics_watcher",
+        "//src/v/config",
+        "//src/v/kafka/data:partition_proxy",
+        "//src/v/model",
+        "//src/v/pandaproxy/schema_registry:api",
+        "//src/v/pandaproxy/schema_registry:exceptions",
+        "//src/v/pandaproxy/schema_registry:types",
+        "//src/v/redpanda/tests:fixture",
+        "//src/v/schema:registry",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
 redpanda_cc_btest(
     name = "delete_subject_endpoints",
     timeout = "short",

--- a/src/v/pandaproxy/schema_registry/test/rpc_transport_test.cc
+++ b/src/v/pandaproxy/schema_registry/test/rpc_transport_test.cc
@@ -112,6 +112,16 @@ public:
         _kd->remote_partition_manager()->set_errors(n);
     }
 
+    /// Simulate prefix truncation of the internal topic.
+    void set_start_offset(model::offset o) {
+        auto ntp = model::ntp(
+          model::kafka_namespace,
+          model::schema_registry_internal_tp.topic,
+          model::schema_registry_internal_tp.partition);
+        _kd->local_partition_manager()->set_start_offset(ntp, o);
+        _kd->remote_partition_manager()->set_start_offset(ntp, o);
+    }
+
     model::record_batch make_batch(std::string_view key, std::string_view val) {
         storage::record_batch_builder rb{
           model::record_batch_type::raft_data, model::offset{0}};
@@ -262,6 +272,53 @@ TEST_P(SchemaRegistryRpcTransportTest, ConsumeRangePastHwmThrows) {
           })
         .get(),
       kafka::exception);
+}
+
+TEST_P(SchemaRegistryRpcTransportTest, GetLogStart) {
+    // An untruncated log starts at 0.
+    EXPECT_EQ(transport().get_log_start().get(), model::offset(0));
+    transport().produce(make_batch("k1", "v1")).get();
+    transport().produce(make_batch("k2", "v2")).get();
+    EXPECT_EQ(transport().get_log_start().get(), model::offset(0));
+
+    set_start_offset(model::offset(1));
+    EXPECT_EQ(transport().get_log_start().get(), model::offset(1));
+}
+
+TEST_P(SchemaRegistryRpcTransportTest, ConsumeRangeBelowLogStart) {
+    transport().produce(make_batch("k1", "v1")).get();
+    transport().produce(make_batch("k2", "v2")).get();
+    set_start_offset(model::offset(1));
+
+    // Reading from before the start offset must report offset_out_of_range,
+    // rather than letting the offset translator throw through the RPC layer.
+    try {
+        transport()
+          .consume_range(
+            model::offset(0),
+            hwm(),
+            [](model::record_batch) -> ss::future<ss::stop_iteration> {
+                co_return ss::stop_iteration::no;
+            })
+          .get();
+        FAIL() << "consume_range below the log start unexpectedly succeeded";
+    } catch (const kafka::exception_base& e) {
+        EXPECT_EQ(e.error, kafka::error_code::offset_out_of_range);
+    }
+
+    // Reading from the start offset works.
+    int consumed_count = 0;
+    transport()
+      .consume_range(
+        model::offset(1),
+        hwm(),
+        [&consumed_count](
+          this auto, model::record_batch) -> ss::future<ss::stop_iteration> {
+            ++consumed_count;
+            co_return ss::stop_iteration::no;
+        })
+      .get();
+    EXPECT_EQ(consumed_count, 1);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/v/pandaproxy/schema_registry/test/truncated_replay.cc
+++ b/src/v/pandaproxy/schema_registry/test/truncated_replay.cc
@@ -1,0 +1,165 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/partition_manager.h"
+#include "config/configuration.h"
+#include "kafka/data/partition_proxy.h"
+#include "model/ktp.h"
+#include "model/namespace.h"
+#include "pandaproxy/schema_registry/api.h"
+#include "pandaproxy/schema_registry/exceptions.h"
+#include "pandaproxy/schema_registry/types.h"
+#include "redpanda/tests/fixture.h"
+#include "schema/registry.h"
+
+#include <gtest/gtest.h>
+
+namespace pps = pandaproxy::schema_registry;
+
+namespace {
+
+const model::ktp schemas_ktp{
+  model::schema_registry_internal_tp.topic,
+  model::schema_registry_internal_tp.partition};
+
+pps::subject_schema make_schema(pps::context_subject sub) {
+    return pps::subject_schema{
+      std::move(sub),
+      pps::schema_definition{
+        R"({"type":"record","name":"r","fields":[{"name":"f","type":"string"}]})",
+        pps::schema_type::avro}};
+}
+
+} // namespace
+
+/// Covers what happens when the `_schemas` topic has been prefix truncated.
+/// Replay then starts at the earliest surviving offset instead of 0, keeping
+/// the registry available, at the cost of whatever the deleted records held.
+class truncated_replay_fixture
+  : public redpanda_thread_fixture
+  , public ::testing::TestWithParam<bool> {
+public:
+    truncated_replay_fixture() {
+        wait_for_controller_leadership().get();
+        make_registry();
+    }
+
+    void make_registry() {
+        registry = schema::registry::make_default(app.schema_registry().get());
+    }
+
+    /// Highest kafka offset written to `_schemas` so far, exclusive.
+    model::offset kafka_high_watermark() {
+        return on_schemas_partition(
+          [](kafka::partition_proxy& p) { return p.high_watermark(); });
+    }
+
+    /// Earliest kafka offset still available on `_schemas`.
+    model::offset kafka_start_offset() {
+        return on_schemas_partition(
+          [](kafka::partition_proxy& p) { return p.start_offset(); });
+    }
+
+    /// Restart the broker with `_schemas` no longer exempt from log eviction,
+    /// and with the schema store loaded lazily so that a test can truncate
+    /// before the first replay.
+    void restart_with_eviction_enabled(bool use_rpc) {
+        ss::smp::invoke_on_all([use_rpc] {
+            auto& cfg = config::shard_local_cfg();
+            cfg.log_eviction_exempt_topics.set_value(
+              std::vector<ss::sstring>{});
+            cfg.schema_registry_replay_on_startup.set_value(false);
+            cfg.schema_registry_use_rpc.set_value(use_rpc);
+        }).get();
+        restart(should_wipe::no);
+        wait_for_controller_leadership().get();
+        wait_for_leader(schemas_ktp.to_ntp()).get();
+        make_registry();
+    }
+
+    /// What an operator who enables deletion on `_schemas` and then calls
+    /// DeleteRecords ends up with: the topic becomes collectable, and the log
+    /// is prefix truncated.
+    void enable_deletion_and_prefix_truncate(model::offset kafka_offset) {
+        auto shard = app.shard_table.local().shard_for(schemas_ktp.to_ntp());
+        ASSERT_TRUE(shard.has_value());
+        auto ec = app.partition_manager
+                    .invoke_on(
+                      *shard,
+                      [kafka_offset](this auto, cluster::partition_manager& mgr)
+                        -> ss::future<std::error_code> {
+                          auto partition = mgr.get(schemas_ktp.to_ntp());
+                          auto props
+                            = partition->get_topic_config()->get().properties;
+                          props.cleanup_policy_bitflags
+                            = model::cleanup_policy_bitflags::compaction
+                              | model::cleanup_policy_bitflags::deletion;
+                          co_await partition->update_configuration(
+                            std::move(props));
+                          co_return co_await partition->prefix_truncate(
+                            partition->log()->to_log_offset(kafka_offset),
+                            model::offset_cast(kafka_offset),
+                            ss::lowres_clock::time_point::max());
+                      })
+                    .get();
+        ASSERT_FALSE(ec) << ec.message();
+    }
+
+    std::unique_ptr<schema::registry> registry;
+
+private:
+    template<typename Fn>
+    model::offset on_schemas_partition(Fn fn) {
+        auto shard = app.shard_table.local().shard_for(schemas_ktp.to_ntp());
+        vassert(shard.has_value(), "_schemas partition not found");
+        return app.partition_manager
+          .invoke_on(
+            *shard,
+            [fn](cluster::partition_manager& mgr) {
+                auto proxy = kafka::make_partition_proxy(schemas_ktp, mgr);
+                vassert(proxy.has_value(), "_schemas partition proxy");
+                return fn(*proxy);
+            })
+          .get();
+    }
+};
+
+TEST_P(truncated_replay_fixture, replays_from_the_earliest_surviving_offset) {
+    auto lost = pps::context_subject::unqualified("lost-subject");
+    auto kept = pps::context_subject::unqualified("kept-subject");
+
+    registry->create_schema(make_schema(lost)).get();
+    // Everything written for `lost` is below this offset, and everything
+    // written for `kept` is at or above it.
+    auto truncate_at = kafka_high_watermark();
+    registry->create_schema(make_schema(kept)).get();
+    ASSERT_GT(truncate_at, model::offset{0});
+
+    restart_with_eviction_enabled(GetParam());
+    enable_deletion_and_prefix_truncate(truncate_at);
+    ASSERT_EQ(kafka_start_offset(), truncate_at);
+
+    // This is the first read since the restart, so it drives the replay. A
+    // replay from offset 0 would fail with offset_out_of_range: the registry
+    // must come up and serve what survived.
+    auto stored = registry->get_subject_schema(kept, std::nullopt).get();
+    EXPECT_EQ(stored.schema.sub(), kept);
+
+    // The truncated record is unrecoverable, so its subject is gone.
+    EXPECT_THROW(
+      registry->get_subject_schema(lost, std::nullopt).get(), pps::exception);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  Transport,
+  truncated_replay_fixture,
+  ::testing::Values(true, false),
+  [](const ::testing::TestParamInfo<bool>& info) {
+      return info.param ? "rpc" : "kafka_client";
+  });

--- a/src/v/pandaproxy/schema_registry/test/utils.h
+++ b/src/v/pandaproxy/schema_registry/test/utils.h
@@ -51,6 +51,10 @@ public:
         throw std::runtime_error(
           "noop_transport::get_high_watermark not implemented");
     }
+    ss::future<model::offset> get_log_start() override {
+        throw std::runtime_error(
+          "noop_transport::get_log_start not implemented");
+    }
     ss::future<> consume_range(
       model::offset,
       model::offset,
@@ -82,6 +86,10 @@ public:
     }
 
     ss::future<model::offset> get_high_watermark() override {
+        return ss::make_ready_future<model::offset>(model::offset{0});
+    }
+
+    ss::future<model::offset> get_log_start() override {
         return ss::make_ready_future<model::offset>(model::offset{0});
     }
 

--- a/src/v/pandaproxy/schema_registry/transport.h
+++ b/src/v/pandaproxy/schema_registry/transport.h
@@ -49,6 +49,11 @@ public:
     /// Get the high watermark (next offset) for the _schemas topic.
     virtual ss::future<model::offset> get_high_watermark() = 0;
 
+    /// Get the earliest available offset on the _schemas topic. Anything
+    /// other than 0 means the topic has been prefix truncated and part of
+    /// the schema history is gone.
+    virtual ss::future<model::offset> get_log_start() = 0;
+
     /// Consume batches from [start, end) on the _schemas topic.
     /// Calls consumer(batch) for each batch. Handles pagination internally.
     /// Returning stop_iteration::yes halts consumption early.


### PR DESCRIPTION
If we are unfortunate enough to be in a bad situation where `_schemas` has been prefix truncated and the start offset is no longer 0, either `_schemas` replay upon restart OR log read requests through the RPC client are all doomed to fail.

Since a working schema registry with truncated data is preferable to one that refuses to start or fails to serve requests, the changes here enable users to inspect the start offset of a log through the Kafka RPC client, and the `schema_registry` now uses this tool to replay from the start offset of the log and to allow re-syncing of the log start offset during normal read operations which would otherwise be stuck.

We will be loud about these cases with `ERROR` log lines, since we really shouldn't have a truncated `_schemas` topic in the first place.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

### Improvements

* Tolerate and log on replay/reads for a truncated `_schemas` topic instead of failing to start the schema registry or serving requests from it.