### PR TITLE
rptest/consumer_group_test: widen api-version probe timeout in large group test

### DIFF
--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -599,6 +599,10 @@ class ConsumerGroupTest(RedpandaTest):
                         bootstrap_servers=self.redpanda.brokers(),
                         enable_auto_commit=True,
                         client_id=f"python-consumer-client-{i}",
+                        # kafka-python default 2s api-version probe budget is too tight under
+                        # concurrent connection setup on a loaded CI VM, producing spurious
+                        # NoBrokersAvailable during check_version() even though brokers are up.
+                        api_version_auto_timeout_ms=30000,
                     )
                     try:
                         consumer.subscribe([self.topic_spec.name])


### PR DESCRIPTION
## Summary

- Fixes the recurring flaky `NoBrokersAvailable` in `ConsumerGroupTest.test_large_group_count` (DEVPROD-2990).
- The exception is raised inside `KafkaConsumer.__init__` → `check_version()`, before the consumer joins a group. kafka-python (2.3.1) auto-detects the broker version on construction with a bootstrap probe bounded by `api_version_auto_timeout_ms`, default **2000ms**. Under concurrent connection setup on a loaded `ci-vm-gcp` runner, that probe exceeds 2s and raises `NoBrokersAvailable` even though the brokers are up and healthy (topic creation via CLI succeeds seconds earlier).
- PR #30088 throttled concurrency to 10 via a semaphore, which reduced but did not remove the failure — throttling doesn't help because the failure is per-consumer probe timeout, not aggregate load.
- This widens the probe budget to 30s (matching the existing join-loop deadline). It's a ceiling consumed only on failure, so it has no effect on happy-path runtime and does not change the negotiated protocol.


## Backports Required

- [x ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none

