### PR TITLE
rpk: bump twmb/avro to v1.8.0

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/sjson v1.2.5
 	github.com/tklauser/go-sysconf v0.3.16
-	github.com/twmb/avro v1.7.2
+	github.com/twmb/avro v1.8.0
 	github.com/twmb/franz-go v1.21.6
 	github.com/twmb/franz-go/pkg/kadm v1.18.0
 	github.com/twmb/franz-go/pkg/kfake v0.0.0-20260804154521-adb3a18abe14

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -364,8 +364,8 @@ github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYI
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
-github.com/twmb/avro v1.7.2 h1:cmrEBRSbELRqsg/dRkQvVWuOaR2EfGifHIt/2iJ9lfI=
-github.com/twmb/avro v1.7.2/go.mod h1:X0fT1dY2xcbV4YuCE4mYro+qljHl4kUF5uA/2z1rgSk=
+github.com/twmb/avro v1.8.0 h1:UMWLg+nH4P3yad5Om7yFSohYLy2RG1s7BcFFiOvmK9Q=
+github.com/twmb/avro v1.8.0/go.mod h1:X0fT1dY2xcbV4YuCE4mYro+qljHl4kUF5uA/2z1rgSk=
 github.com/twmb/franz-go v1.21.6 h1:+v0dQJVIIuw9uPmPWmPrkoUHs1pPeV8MSwA4eU/Y2kY=
 github.com/twmb/franz-go v1.21.6/go.mod h1:wMepkgCatAdV9vCsuwM+wr+C1fl7KV/41+uHGAjt/wc=
 github.com/twmb/franz-go/pkg/kadm v1.18.0 h1:WRf/LZmDdcDXwX7WMbtDU++v+b3NzYh2bCGoPMmzirw=


### PR DESCRIPTION
Bumps `github.com/twmb/avro` from v1.7.2 to v1.8.0. No code changes are required; rpk only uses `Parse`, `SchemaCache.Parse`, `Decode`, `Encode`, `DecodeJSON` and `EncodeJSON`.

v1.8.0 changes how decimal logical types are encoded to JSON, which shows up in `rpk topic consume` output:

```
v1.7.2:  {"d":1094795.586}
v1.8.0:  {"d":"AAAB"}
```

The new form is what the Avro spec requires: a decimal is `bytes`, and Avro encodes bytes in JSON as a string of the raw byte values -- here the unscaled value 1094795586 is 0x41414142, which is ASCII "AAAB". fastavro emits byte-identical output; the old numeric form was a divergence. rpk has no decimal test coverage, so nothing in the test suite catches this.

Verified with `go build ./pkg/serde/` and `go test -count=1 ./pkg/serde/` in `src/go/rpk`; both pass.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

### Improvements

* `rpk topic consume` now encodes Avro decimal logical types to JSON as the Avro spec requires, as a byte string rather than a number.
