### PR TITLE
[v25.3.x] kafka/server: reject client-produced control batches

### DIFF
--- a/src/v/cloud_topics/level_zero/stm/placeholder.cc
+++ b/src/v/cloud_topics/level_zero/stm/placeholder.cc
@@ -29,9 +29,12 @@ model::record_batch encode_placeholder_batch(
       model::record_batch_type::ctp_placeholder, header.base_offset);
 
     builder.set_producer_identity(header.producer_id, header.producer_epoch);
-    if (header.attrs.is_control()) {
-        builder.set_control_type();
-    }
+    // Control batches should not be encoded as placeholders, as this
+    // replication path is specifically for user-provided data.
+    vassert(
+      !header.attrs.is_control(),
+      "Cannot encode control batch as a placeholder: {}",
+      header);
     if (header.attrs.is_transactional()) {
         builder.set_transactional_type();
     }

--- a/src/v/kafka/server/handlers/produce_validation.cc
+++ b/src/v/kafka/server/handlers/produce_validation.cc
@@ -22,6 +22,28 @@ namespace kafka {
 
 namespace {
 
+// Validates the batch attributes a client is permitted to set.
+//
+// Client-generated control batches in Kafka are disallowed[1], and in Redpanda
+// they would be mishandled by various subsystems (e.g. rm_stm expects control
+// batches to be Redpanda-generated).
+//
+// [1]
+// https://github.com/apache/kafka/blob/07e1f099acad26200b2681411e05616bd3fe7879/storage/src/main/java/org/apache/kafka/storage/internals/log/LogValidator.java#L474-L477
+std::optional<error_code_and_msg> validate_batch_attributes(
+  const model::record_batch_header& header, const model::ntp& ntp) {
+    if (header.attrs.is_control()) {
+        return error_code_and_msg{
+          .err = error_code::invalid_record,
+          .msg = ssx::sformat(
+            "Clients are not allowed to write control records in topic "
+            "partition {}",
+            ntp)};
+    }
+
+    return std::nullopt;
+}
+
 // Validates the input timestamp using the broker time and the allowable
 // `log.message.timestamp.{before/after}.max.ms` drift.
 //
@@ -413,7 +435,7 @@ std::optional<error_code_and_msg> validate_batch(
         // 1. Iterate over records and set max_timestamp. It is guaranteed that
         // a batch will have a `max_timestamp` set in `strict` mode.
         // 2. Check record timestamps.
-        // TODO: validate offsets, control batches, versioning, etc.
+        // TODO: validate offsets, versioning, etc.
         // See checks present here:
         // github.com/apache/kafka/blob/trunk/storage/src/main/java/org/apache/kafka/storage/internals/log/LogValidator.java#L438
 
@@ -451,6 +473,14 @@ std::optional<error_code_and_msg> validate_batch(
 } // namespace
 
 std::optional<error_code_and_msg> validate_batch(const validation_args& args) {
+    // Attributes bound what the protocol accepts at all, so they are checked
+    // ahead of the mode-specific record validation rather than as part of it.
+    if (
+      auto err = validate_batch_attributes(args.batch.header(), args.ntp);
+      err) {
+        return err;
+    }
+
     const auto& validation_mode
       = config::shard_local_cfg().kafka_produce_batch_validation();
 

--- a/src/v/kafka/server/tests/produce_invalid_batch_test.cc
+++ b/src/v/kafka/server/tests/produce_invalid_batch_test.cc
@@ -126,3 +126,32 @@ FIXTURE_TEST(test_handling_message_with_truncated_batch, test_fixture) {
     BOOST_REQUIRE_THROW(
       resp_f.get(), kafka::client::kafka_request_disconnected_exception);
 };
+
+// A client may not author a control batch, matching Kafka's validation.
+FIXTURE_TEST(test_handling_client_produced_control_batch, test_fixture) {
+    wait_for_controller_leadership().get();
+    start();
+    auto deferred_close = ss::defer([this] { producer->stop().get(); });
+
+    auto hw_before = high_watermark();
+
+    storage::record_batch_builder builder(
+      model::record_batch_type::raft_data, model::offset(0));
+    builder.set_control_type();
+    builder.add_raw_kv(iobuf{}, iobuf{});
+
+    chunked_vector<kafka::produce_request::partition> batches;
+    batches.push_back(
+      kafka::produce_request::partition{
+        .partition_index = model::partition_id(0),
+        .records = kafka::produce_request_record_data{
+          std::move(builder).build()}});
+
+    auto resp = produce_batch(std::move(batches)).get();
+    BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
+    BOOST_REQUIRE_EQUAL(resp.data.responses[0].partitions.size(), 1);
+    BOOST_REQUIRE_EQUAL(
+      resp.data.responses[0].partitions[0].error_code,
+      kafka::error_code::invalid_record);
+    BOOST_REQUIRE_EQUAL(high_watermark(), hw_before);
+};


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31369

- Command: git cherry-pick -x 11ff98aa1b
- Commits backported: 1
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-31369-v25.3.x-1787004991

## Conflict details

- 11ff98aa1b (src/v/kafka/server/handlers/produce_validation.cc): the public `validate_batch(const validation_args&)` entry point conflicted because v25.3.x still has the synchronous signature `std::optional<error_code_and_msg>` while dev returns `ss::future<validation_result>`; the new `validate_batch_attributes()` pre-check was kept in the same position (ahead of the mode-specific record validation) and adapted to return the `std::optional<error_code_and_msg>` directly instead of `co_return`ing a `validation_result`.
