### PR TITLE
[v25.3.x] sr: fix broker abort when a request fails before its deferred authz check

### DIFF
--- a/src/v/pandaproxy/schema_registry/auth.cc
+++ b/src/v/pandaproxy/schema_registry/auth.cc
@@ -19,6 +19,9 @@
 #include "security/audit/types.h"
 #include "security/request_auth.h"
 
+#include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
+
 #include <boost/algorithm/string/predicate.hpp>
 
 namespace pandaproxy::schema_registry {
@@ -158,7 +161,7 @@ void handle_authz(
 
 } // namespace
 
-std::optional<request_auth_result> auth::handle_auth(
+ss::lw_shared_ptr<request_auth_result> auth::handle_auth(
   server::request_t& rq, std::string_view operation_name) const {
     rq.authn_method = config::get_authn_method(
       rq.service().config().schema_registry_api.value(),
@@ -189,7 +192,8 @@ std::optional<request_auth_result> auth::handle_auth(
         if (config::shard_local_cfg().schema_registry_enable_authorization) {
             if (is_deferred()) {
                 // Defer the authorization handling to the method handler
-                return auth_result;
+                return ss::make_lw_shared<request_auth_result>(
+                  std::move(auth_result));
             } else {
                 enterprise::handle_authz(
                   rq, operation_name, *this, auth_result);
@@ -202,7 +206,34 @@ std::optional<request_auth_result> auth::handle_auth(
         audit_authn_success(rq);
         audit_authz_success(rq);
     }
-    return std::nullopt;
+    return nullptr;
+}
+
+ss::future<server::reply_t> enforce_deferred_authz(
+  ss::future<server::reply_t> handler_result,
+  ss::lw_shared_ptr<request_auth_result> auth_result,
+  std::string_view operation_name) {
+    auto rp = co_await ss::coroutine::as_future(std::move(handler_result));
+    if (auth_result) {
+        if (rp.failed()) {
+            // The request failed before returning any data, so it is
+            // acceptable that its authorization check may not have run.
+            auth_result->pass();
+        } else if (!auth_result->is_checked()) {
+            vlog(
+              srlog.error,
+              "'{}' handler replied without performing its deferred "
+              "authorization check",
+              operation_name);
+            auth_result->pass();
+            // It is essential that the reply is not sent: the client gets a
+            // 500 instead. Since this is security code, do not tell them why.
+            co_await ss::coroutine::return_exception(
+              ss::httpd::server_error_exception("Internal Error"));
+        }
+    }
+    // Yields the handler's reply, or rethrows its original exception.
+    co_return co_await std::move(rp);
 }
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/auth.h
+++ b/src/v/pandaproxy/schema_registry/auth.h
@@ -49,9 +49,11 @@ public:
 
     using regular_function_handler = ss::noncopyable_function<
       ss::future<server::reply_t>(server::request_t, server::reply_t)>;
-    using deferred_function_handler = ss::noncopyable_function<ss::future<
-      server::reply_t>(
-      server::request_t, server::reply_t, std::optional<request_auth_result>)>;
+    using deferred_function_handler
+      = ss::noncopyable_function<ss::future<server::reply_t>(
+        server::request_t,
+        server::reply_t,
+        ss::lw_shared_ptr<request_auth_result>)>;
     using function_handler
       = std::variant<regular_function_handler, deferred_function_handler>;
 
@@ -70,8 +72,9 @@ public:
     // Handle authentication and authorization.
     // The presence of a returned authentication result indicates that the
     // authorization check was deferred and has to be done inside the method
-    // handler
-    std::optional<request_auth_result>
+    // handler. The result is shared with the handler so the caller can
+    // verify, once the handler completes, that the check was performed.
+    ss::lw_shared_ptr<request_auth_result>
     handle_auth(server::request_t& rq, std::string_view operation_name) const;
 
 private:
@@ -79,5 +82,21 @@ private:
     std::optional<op> _op;
     resource _res;
 };
+
+/// Await a deferred-authorization handler's reply and enforce that the
+/// handler performed its check.
+///
+/// A handler that fails before reaching its check is acceptable: the client
+/// receives the original error, and no data is returned. A handler that
+/// produces a reply without having checked indicates a handler bug that may
+/// be allowing unchecked access, so the reply is discarded and replaced with
+/// a 500.
+///
+/// A null auth_result means authorization was not deferred for this request
+/// (e.g. it is disabled) and there is nothing to enforce.
+ss::future<server::reply_t> enforce_deferred_authz(
+  ss::future<server::reply_t> handler_result,
+  ss::lw_shared_ptr<request_auth_result> auth_result,
+  std::string_view operation_name);
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/authorization.cc
+++ b/src/v/pandaproxy/schema_registry/authorization.cc
@@ -150,12 +150,12 @@ void handle_authz(
 
 void handle_get_schemas_ids_id_authz(
   const server::request_t& rq,
-  std::optional<request_auth_result>& auth_result,
+  const ss::lw_shared_ptr<request_auth_result>& auth_result,
   const chunked_vector<subject>& subjects) {
     const auto& operation_name
       = ss::httpd::schema_registry_json::get_schemas_ids_id.operations.nickname;
     constexpr auto op = security::acl_operation::read;
-    if (!auth_result.has_value()) {
+    if (!auth_result) {
         // ACLs or authentication is disabled
         return;
     }
@@ -170,12 +170,7 @@ void handle_get_schemas_ids_id_authz(
         // Throw unauthorized here to avoid leaking information about whether a
         // schema id exists or not.
         audit_authz(
-          rq,
-          operation_name,
-          auth_result.value(),
-          false,
-          op,
-          audit_resources{});
+          rq, operation_name, *auth_result, false, op, audit_resources{});
         throw_unauthorized();
     }
 
@@ -201,25 +196,20 @@ void handle_get_schemas_ids_id_authz(
         audit_authz(rq, operation_name, std::move(*authorizing_result));
     } else {
         audit_authz(
-          rq,
-          operation_name,
-          auth_result.value(),
-          false,
-          op,
-          std::move(all_results));
+          rq, operation_name, *auth_result, false, op, std::move(all_results));
         throw_unauthorized();
     }
 }
 
 void handle_get_subjects_authz(
   const server::request_t& rq,
-  std::optional<request_auth_result>& auth_result,
+  const ss::lw_shared_ptr<request_auth_result>& auth_result,
   chunked_vector<subject>& subjects) {
     const auto& operation_name
       = ss::httpd::schema_registry_json::get_subjects.operations.nickname;
     constexpr auto op = security::acl_operation::describe;
 
-    if (!auth_result.has_value()) {
+    if (!auth_result) {
         // ACLs or authentication is disabled
         return;
     }
@@ -254,18 +244,13 @@ void handle_get_subjects_authz(
     // If there are any unauthorized subjects, generate failed audit event with
     // them.
     audit_authz(
-      rq,
-      operation_name,
-      auth_result.value(),
-      true,
-      op,
-      std::move(passing_results));
+      rq, operation_name, *auth_result, true, op, std::move(passing_results));
 
     if (!failing_results.empty()) {
         audit_authz(
           rq,
           operation_name,
-          auth_result.value(),
+          *auth_result,
           false,
           op,
           std::move(failing_results));

--- a/src/v/pandaproxy/schema_registry/authorization.cc
+++ b/src/v/pandaproxy/schema_registry/authorization.cc
@@ -10,7 +10,9 @@
 
 #include "pandaproxy/schema_registry/authorization.h"
 
+#include "base/vlog.h"
 #include "pandaproxy/api/api-doc/schema_registry.json.hh"
+#include "pandaproxy/logger.h"
 #include "pandaproxy/parsing/httpd.h"
 #include "pandaproxy/schema_registry/service.h"
 #include "pandaproxy/schema_registry/types.h"
@@ -171,6 +173,13 @@ void handle_get_schemas_ids_id_authz(
         // schema id exists or not.
         audit_authz(
           rq, operation_name, *auth_result, false, op, audit_resources{});
+        vlog(
+          srlog.info,
+          "{}: schema id {} not found; returning 403 rather than 404 to avoid "
+          "revealing whether schema ids exist (principal: {})",
+          operation_name,
+          parse::request_param<schema_id>(*rq.req, "id"),
+          params.principal);
         throw_unauthorized();
     }
 
@@ -197,6 +206,14 @@ void handle_get_schemas_ids_id_authz(
     } else {
         audit_authz(
           rq, operation_name, *auth_result, false, op, std::move(all_results));
+        vlog(
+          srlog.info,
+          "{}: principal {} has no read permission on any of the {} subjects "
+          "associated with schema id {}",
+          operation_name,
+          params.principal,
+          subjects.size(),
+          parse::request_param<schema_id>(*rq.req, "id"));
         throw_unauthorized();
     }
 }
@@ -221,6 +238,7 @@ void handle_get_subjects_authz(
     auto passing_results = audit_resources{};
     auto failing_results = audit_resources{};
 
+    const auto total_subjects = subjects.size();
     auto new_end = std::ranges::remove_if(subjects, [&](const auto& subject) {
         auto res = rq.service().authorizor().authorized(
           subject,
@@ -237,6 +255,17 @@ void handle_get_subjects_authz(
         }
     });
     subjects.erase_to_end(new_end.begin());
+
+    if (!failing_results.empty()) {
+        vlog(
+          srlog.debug,
+          "{}: filtered out {} of {} subjects for principal {} (no describe "
+          "permission)",
+          operation_name,
+          failing_results.size(),
+          total_subjects,
+          params.principal);
+    }
 
     // This endpoint always returns a successful response.
     // Generate a successful audit event with the (possibly empty) list of

--- a/src/v/pandaproxy/schema_registry/authorization.h
+++ b/src/v/pandaproxy/schema_registry/authorization.h
@@ -30,12 +30,12 @@ void handle_authz(
 
 void handle_get_schemas_ids_id_authz(
   const server::request_t& rq,
-  std::optional<request_auth_result>& auth_result,
+  const ss::lw_shared_ptr<request_auth_result>& auth_result,
   const chunked_vector<subject>& subjects);
 
 void handle_get_subjects_authz(
   const server::request_t& rq,
-  std::optional<request_auth_result>& auth_result,
+  const ss::lw_shared_ptr<request_auth_result>& auth_result,
   chunked_vector<subject>& subjects);
 
 } // namespace pandaproxy::schema_registry::enterprise

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -349,7 +349,7 @@ get_schemas_types(server::request_t rq, server::reply_t rp) {
 ss::future<server::reply_t> get_schemas_ids_id(
   server::request_t rq,
   server::reply_t rp,
-  std::optional<request_auth_result> auth_result) {
+  ss::lw_shared_ptr<request_auth_result> auth_result) {
     parse_accept_header(rq, rp);
     auto id = parse::request_param<schema_id>(*rq.req, "id");
     const auto format = parse_output_format(*rq.req);
@@ -421,7 +421,7 @@ ss::future<ctx_server<service>::reply_t> get_schemas_ids_id_subjects(
 ss::future<server::reply_t> get_subjects(
   server::request_t rq,
   server::reply_t rp,
-  std::optional<request_auth_result> auth_result) {
+  ss::lw_shared_ptr<request_auth_result> auth_result) {
     parse_accept_header(rq, rp);
     auto inc_del{
       parse::query_param<std::optional<include_deleted>>(*rq.req, "deleted")

--- a/src/v/pandaproxy/schema_registry/handlers.h
+++ b/src/v/pandaproxy/schema_registry/handlers.h
@@ -56,7 +56,7 @@ ss::future<ctx_server<service>::reply_t> get_schemas_types(
 ss::future<ctx_server<service>::reply_t> get_schemas_ids_id(
   ctx_server<service>::request_t rq,
   ctx_server<service>::reply_t rp,
-  std::optional<request_auth_result> auth_result);
+  ss::lw_shared_ptr<request_auth_result> auth_result);
 
 ss::future<ctx_server<service>::reply_t> get_schemas_ids_id_versions(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
@@ -67,7 +67,7 @@ ss::future<ctx_server<service>::reply_t> get_schemas_ids_id_subjects(
 ss::future<ctx_server<service>::reply_t> get_subjects(
   ctx_server<service>::request_t rq,
   ctx_server<service>::reply_t rp,
-  std::optional<request_auth_result> auth_result);
+  ss::lw_shared_ptr<request_auth_result> auth_result);
 
 ss::future<ctx_server<service>::reply_t> get_subject_versions(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -88,14 +88,16 @@ public:
               _h,
               [&](const auth::regular_function_handler& h) {
                   vassert(
-                    !auth_result.has_value(),
+                    !auth_result,
                     "Authorization must not be deferred for non-deferred "
                     "endpoints");
                   return h(std::move(rq), std::move(rp));
               },
               [&](const auth::deferred_function_handler& h) {
-                  return h(
-                    std::move(rq), std::move(rp), std::move(auth_result));
+                  return enforce_deferred_authz(
+                    h(std::move(rq), std::move(rp), auth_result),
+                    auth_result,
+                    _operation_name);
               });
         } catch (const kafka::client::partition_error& ex) {
             if (

--- a/src/v/pandaproxy/schema_registry/test/BUILD
+++ b/src/v/pandaproxy/schema_registry/test/BUILD
@@ -178,6 +178,26 @@ redpanda_cc_btest(
 )
 
 redpanda_cc_btest(
+    name = "deferred_auth",
+    timeout = "short",
+    srcs = [
+        "deferred_auth.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/container:chunked_vector",
+        "//src/v/pandaproxy:core",
+        "//src/v/pandaproxy/schema_registry:server",
+        "//src/v/security",
+        "//src/v/security:request_auth",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
     name = "sharded_store",
     timeout = "short",
     srcs = [

--- a/src/v/pandaproxy/schema_registry/test/deferred_auth.cc
+++ b/src/v/pandaproxy/schema_registry/test/deferred_auth.cc
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "pandaproxy/schema_registry/auth.h"
+#include "security/request_auth.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/http/exception.hh>
+#include <seastar/http/reply.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/unit_test.hpp>
+
+#include <memory>
+#include <stdexcept>
+
+namespace ppsr = pandaproxy::schema_registry;
+
+namespace {
+
+ss::lw_shared_ptr<request_auth_result> make_deferred_auth_result() {
+    return ss::make_lw_shared<request_auth_result>(
+      security::credential_user{"user"},
+      security::credential_password{"password"},
+      "SCRAM-SHA-256",
+      request_auth_result::superuser::no);
+}
+
+ppsr::server::reply_t make_reply() {
+    ppsr::server::reply_t rp;
+    rp.rep = std::make_unique<ss::http::reply>();
+    return rp;
+}
+
+ss::future<ppsr::server::reply_t> ready_reply(ppsr::server::reply_t rp) {
+    return ss::make_ready_future<ppsr::server::reply_t>(std::move(rp));
+}
+
+ss::future<ppsr::server::reply_t> failed_reply() {
+    return ss::make_exception_future<ppsr::server::reply_t>(
+      std::runtime_error{"handler failed"});
+}
+
+} // namespace
+
+SEASTAR_THREAD_TEST_CASE(checked_reply_passes_through) {
+    auto auth_result = make_deferred_auth_result();
+    auth_result->pass();
+    auto rp = make_reply();
+    const auto* marker = rp.rep.get();
+
+    auto result = ppsr::enforce_deferred_authz(
+                    ready_reply(std::move(rp)), auth_result, "get_config")
+                    .get();
+
+    BOOST_CHECK_EQUAL(result.rep.get(), marker);
+}
+
+// A handler that produces a reply without having performed its deferred
+// authorization check must not have that reply returned to the client.
+SEASTAR_THREAD_TEST_CASE(unchecked_reply_is_replaced_with_a_500) {
+    auto auth_result = make_deferred_auth_result();
+
+    auto fut = ppsr::enforce_deferred_authz(
+      ready_reply(make_reply()), auth_result, "get_config");
+
+    BOOST_CHECK_THROW(fut.get(), ss::httpd::server_error_exception);
+    BOOST_CHECK(auth_result->is_checked());
+}
+
+// A handler that fails before its deferred authorization check is an
+// acceptable outcome: the client receives the original error, which must
+// not be masked by enforcement.
+SEASTAR_THREAD_TEST_CASE(failed_handler_keeps_its_original_exception) {
+    auto auth_result = make_deferred_auth_result();
+
+    auto fut = ppsr::enforce_deferred_authz(
+      failed_reply(), auth_result, "get_config");
+
+    BOOST_CHECK_THROW(fut.get(), std::runtime_error);
+    BOOST_CHECK(auth_result->is_checked());
+}
+
+// No authentication result means authorization is not deferred for this
+// request (e.g. it is disabled); there is nothing to enforce.
+SEASTAR_THREAD_TEST_CASE(without_auth_result_reply_passes_through) {
+    auto rp = make_reply();
+    const auto* marker = rp.rep.get();
+
+    auto result = ppsr::enforce_deferred_authz(
+                    ready_reply(std::move(rp)), nullptr, "get_config")
+                    .get();
+
+    BOOST_CHECK_EQUAL(result.rep.get(), marker);
+}
+
+SEASTAR_THREAD_TEST_CASE(without_auth_result_failure_propagates) {
+    auto fut = ppsr::enforce_deferred_authz(
+      failed_reply(), nullptr, "get_config");
+
+    BOOST_CHECK_THROW(fut.get(), std::runtime_error);
+}

--- a/src/v/security/request_auth.cc
+++ b/src/v/security/request_auth.cc
@@ -38,8 +38,8 @@ request_authenticator::request_authenticator(
  * Attempt to authenticate the request.
  *
  * The returned object **must be used** via one of its authorization
- * helpers (e.g. require_superuser) or it will throw an exception
- * on destruction.
+ * helpers (e.g. require_superuser) or it will log an error on
+ * destruction.
  *
  * @param req
  * @return
@@ -235,11 +235,14 @@ request_auth_result::request_auth_result(request_auth_result&& other) noexcept
  * a request handler that might be unintentionally allowing unchecked
  * access.
  *
- * This is a rare case of a throwing destructor.  It is made safe by
- * checking if there is already an exception in flight first, and by
- * knowing that all our member objects have nothrow destructors.
+ * The destructor can only log about it: throwing here used to be how the
+ * request was failed, but a coroutine that takes this object by value
+ * destroys it during frame teardown, inside the reactor's noexcept task
+ * entry point, where a throw aborts the broker.  Callers that hand an
+ * unchecked result to a handler are responsible for failing the request,
+ * by inspecting is_checked() once the handler completes.
  */
-request_auth_result::~request_auth_result() noexcept(false) {
+request_auth_result::~request_auth_result() {
     // If another exception is already in flight (e.g., thrown during request
     // handling between authenticate() and the check), it's acceptable that we
     // didn't perform the check. We only log the error if there is no active
@@ -250,10 +253,5 @@ request_auth_result::~request_auth_result() noexcept(false) {
     if (!_checked && !another_exception_in_flight) {
         vlog(
           logger.error, "request_auth_result destroyed without being checked!");
-
-        // In this case, it is essential that we do not send any data
-        // in a response: they get a 500 instead.  Since this is security
-        // code, we do not tell them why.
-        throw ss::httpd::server_error_exception("Internal Error");
     }
 }

--- a/src/v/security/request_auth.h
+++ b/src/v/security/request_auth.h
@@ -85,7 +85,7 @@ public:
 
     request_auth_result(const request_auth_result&) = default;
     request_auth_result(request_auth_result&&) noexcept;
-    ~request_auth_result() noexcept(false);
+    ~request_auth_result();
 
     /**
      * Raise 403 if not a superuser

--- a/src/v/security/request_auth.h
+++ b/src/v/security/request_auth.h
@@ -110,6 +110,10 @@ public:
     bool is_superuser() const { return _superuser; }
     bool is_auth_required() const { return _auth_required; }
 
+    /// Whether one of the authorization helpers (require_superuser,
+    /// require_authenticated, pass) has been called.
+    bool is_checked() const { return _checked; }
+
 private:
     security::credential_user _username;
     security::credential_password _password;

--- a/src/v/security/tests/BUILD
+++ b/src/v/security/tests/BUILD
@@ -66,6 +66,22 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_btest(
+    name = "request_auth_test",
+    timeout = "short",
+    srcs = [
+        "request_auth_test.cc",
+    ],
+    deps = [
+        "//src/v/security",
+        "//src/v/security:request_auth",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "authorizer_test",
     timeout = "short",

--- a/src/v/security/tests/request_auth_test.cc
+++ b/src/v/security/tests/request_auth_test.cc
@@ -1,0 +1,92 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "security/request_auth.h"
+
+#include <seastar/http/exception.hh>
+
+#include <boost/test/unit_test.hpp>
+
+namespace {
+
+request_auth_result make_authenticated_user(
+  request_auth_result::superuser is_superuser
+  = request_auth_result::superuser::no) {
+    return request_auth_result{
+      security::credential_user{"user"},
+      security::credential_password{"password"},
+      "SCRAM-SHA-256",
+      is_superuser};
+}
+
+request_auth_result
+make_anonymous(request_auth_result::authenticated is_authenticated) {
+    return request_auth_result{
+      is_authenticated,
+      request_auth_result::superuser::no,
+      request_auth_result::auth_required::yes};
+}
+
+} // namespace
+
+// A handler can fail before reaching its authorization check, in which case
+// the result is destroyed unchecked. In a coroutine frame teardown that
+// happens inside a noexcept task entry point, so the destructor must never
+// throw; enforcement of "the check must run" lives with the caller instead.
+BOOST_AUTO_TEST_CASE(unchecked_destroy_does_not_throw) {
+    BOOST_CHECK_NO_THROW({ auto result = make_authenticated_user(); });
+}
+
+BOOST_AUTO_TEST_CASE(is_checked_reflects_authorization_checks) {
+    {
+        auto result = make_authenticated_user();
+        BOOST_CHECK(!result.is_checked());
+        result.pass();
+        BOOST_CHECK(result.is_checked());
+    }
+    {
+        auto result = make_authenticated_user();
+        BOOST_CHECK_NO_THROW(result.require_authenticated());
+        BOOST_CHECK(result.is_checked());
+    }
+    {
+        auto result = make_authenticated_user(
+          request_auth_result::superuser::yes);
+        BOOST_CHECK_NO_THROW(result.require_superuser());
+        BOOST_CHECK(result.is_checked());
+    }
+}
+
+// A denied check throws, but still counts as performed: callers that treat
+// "handler failed" as an acceptable outcome rely on denial being an
+// exception, never an unchecked success.
+BOOST_AUTO_TEST_CASE(denied_checks_throw_and_still_mark_checked) {
+    {
+        auto result = make_anonymous(request_auth_result::authenticated::no);
+        BOOST_CHECK_THROW(
+          result.require_authenticated(), ss::httpd::base_exception);
+        BOOST_CHECK(result.is_checked());
+    }
+    {
+        auto result = make_authenticated_user();
+        BOOST_CHECK_THROW(
+          result.require_superuser(), ss::httpd::base_exception);
+        BOOST_CHECK(result.is_checked());
+    }
+}
+
+// The moved-from husk counts as checked so it neither logs nor enforces,
+// while the moved-to object carries the real state.
+BOOST_AUTO_TEST_CASE(move_transfers_checked_state_to_destination) {
+    auto source = make_authenticated_user();
+    auto destination = std::move(source);
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    BOOST_CHECK(source.is_checked());
+    BOOST_CHECK(!destination.is_checked());
+    destination.pass();
+}

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -7516,7 +7516,12 @@ class SchemaRegistryAclAuthzTest(SchemaRegistryEndpoints):
         # DELETE_SECURITY_ACLS          - kafka cluster ACL required
     ]
 
-    def __init__(self, context):
+    def __init__(
+        self,
+        context,
+        num_brokers: int = 1,
+        **kwargs,
+    ):
         security = SecurityConfig()
         security.enable_sasl = True
         security.endpoint_authn_method = "sasl"
@@ -7528,8 +7533,9 @@ class SchemaRegistryAclAuthzTest(SchemaRegistryEndpoints):
         super(SchemaRegistryAclAuthzTest, self).__init__(
             context,
             security=security,
-            num_brokers=1,
+            num_brokers=num_brokers,
             schema_registry_config=schema_registry_config,
+            **kwargs,
         )
 
         superuser = self.redpanda.SUPERUSER_CREDENTIALS

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -7479,42 +7479,10 @@ class GetStatusReady(ACLTestEndpoint):
         return {"name": "", "type": "registry"}
 
 
-class SchemaRegistryAclAuthzTest(SchemaRegistryEndpoints):
+class SchemaRegistryAclAuthzTestBase(SchemaRegistryEndpoints):
     """
-    Verify that schema registry endpoints are protected by the correct ACL resource and operation.
+    Base class providing shared ACL test infrastructure (setup, helpers) without test methods.
     """
-
-    ENDPOINTS = [
-        GetConfigEndpoint,
-        PutConfigEndpoint,
-        GetConfigSubjectEndpoint,
-        PutConfigSubjectEndpoint,
-        DeleteConfigSubject,
-        GetMode,
-        PutMode,
-        GetModeSubject,
-        PutModeSubject,
-        DeleteModeSubject,
-        PostSubjectVersions,
-        GetSchemasIdsIdVersions,
-        GetSchemasIdsIdSubjects,
-        GetSubjectVersions,
-        PostSubject,
-        GetSubjectVersionsVersion,
-        GetSubjectVersionsVersionSchema,
-        GetSubjectVersionsVersionReferencedBy,
-        DeleteSubject,
-        DeleteSubjectVersion,
-        CompatibilitySubjectVersion,
-        # Tested separately:
-        # GET_SCHEMAS_TYPES             - no ACLs required
-        # SCHEMA_REGISTRY_STATUS_READY  - no ACLs required
-        # GET_SCHEMAS_IDS_ID            - custom ACL handling
-        # GET_SUBJECTS                  - custom ACL handling
-        # GET_SECURITY_ACLS             - kafka cluster ACL required
-        # POST_SECURITY_ACLS            - kafka cluster ACL required
-        # DELETE_SECURITY_ACLS          - kafka cluster ACL required
-    ]
 
     def __init__(
         self,
@@ -7530,7 +7498,7 @@ class SchemaRegistryAclAuthzTest(SchemaRegistryEndpoints):
         schema_registry_config.authn_method = "http_basic"
         schema_registry_config.mode_mutability = True
 
-        super(SchemaRegistryAclAuthzTest, self).__init__(
+        super().__init__(
             context,
             security=security,
             num_brokers=num_brokers,
@@ -7622,6 +7590,44 @@ class SchemaRegistryAclAuthzTest(SchemaRegistryEndpoints):
         self.redpanda.set_cluster_config(
             {"schema_registry_enable_authorization": "True"}
         )
+
+
+class SchemaRegistryAclAuthzTest(SchemaRegistryAclAuthzTestBase):
+    """
+    Verify that schema registry endpoints are protected by the correct ACL resource and operation.
+    """
+
+    ENDPOINTS = [
+        GetConfigEndpoint,
+        PutConfigEndpoint,
+        GetConfigSubjectEndpoint,
+        PutConfigSubjectEndpoint,
+        DeleteConfigSubject,
+        GetMode,
+        PutMode,
+        GetModeSubject,
+        PutModeSubject,
+        DeleteModeSubject,
+        PostSubjectVersions,
+        GetSchemasIdsIdVersions,
+        GetSchemasIdsIdSubjects,
+        GetSubjectVersions,
+        PostSubject,
+        GetSubjectVersionsVersion,
+        GetSubjectVersionsVersionSchema,
+        GetSubjectVersionsVersionReferencedBy,
+        DeleteSubject,
+        DeleteSubjectVersion,
+        CompatibilitySubjectVersion,
+        # Tested separately:
+        # GET_SCHEMAS_TYPES             - no ACLs required
+        # SCHEMA_REGISTRY_STATUS_READY  - no ACLs required
+        # GET_SCHEMAS_IDS_ID            - custom ACL handling
+        # GET_SUBJECTS                  - custom ACL handling
+        # GET_SECURITY_ACLS             - kafka cluster ACL required
+        # POST_SECURITY_ACLS            - kafka cluster ACL required
+        # DELETE_SECURITY_ACLS          - kafka cluster ACL required
+    ]
 
     def _get_endpoint_by_name(self, name: str) -> ACLTestEndpoint:
         for endpoint in self.ENDPOINTS:
@@ -7863,6 +7869,33 @@ class SchemaRegistryAclAuthzTest(SchemaRegistryEndpoints):
         self.assert_equal(result.status_code, 403)
 
     @cluster(num_nodes=1)
+    def test_get_schemas_ids_id_unacceptable_accept_header(self):
+        """
+        A request that fails before the deferred authz check must produce an
+        error reply, not abort the broker.
+
+        GET /schemas/ids/{id} defers its authorization check until after the
+        schema id is resolved. parse_accept_header() runs first and throws 406
+        for an unsupported Accept header, so the check never runs. The
+        request_auth_result carrying the authentication result must not fault
+        the broker in that case.
+        """
+        subject = "test-subject-1"
+        schema_id = self._create_schema(subject)
+        self._post_acl(self._create_acl(subject, "SUBJECT", "LITERAL", "READ"))
+
+        result = self.sr_client.get_schemas_ids_id(
+            schema_id,
+            headers={"Accept": "application/vnd.not-a-real-format"},
+            auth=self.user_auth,
+        )
+        self.assert_equal(result.status_code, 406)
+
+        # The broker must still be serving.
+        result = self.sr_client.get_schemas_ids_id(schema_id, auth=self.user_auth)
+        self.assert_equal(result.status_code, 200)
+
+    @cluster(num_nodes=1)
     def test_get_schemas_ids_no_match(self):
         """
         Test that access is denied when no subject referencing the schema allows access.
@@ -7991,3 +8024,88 @@ class SchemaRegistryAclAuthzTest(SchemaRegistryEndpoints):
             self.redpanda.set_cluster_config(
                 {"schema_registry_enable_authorization": True}
             )
+
+
+class SchemaRegistryAclAuthzUnavailableTest(SchemaRegistryAclAuthzTestBase):
+    """
+    Deferred-authz endpoints must survive an unreachable _schemas partition.
+    """
+
+    def __init__(self, context, **kwargs):
+        # This branch predates schema_registry_use_rpc: read_sync() always
+        # goes through the internal kafka client, which likewise throws after
+        # its suspension point once the _schemas partition has no leader.
+        super().__init__(
+            context,
+            num_brokers=3,
+            **kwargs,
+        )
+
+    @cluster(num_nodes=3)
+    def test_get_schemas_ids_id_unavailable_schemas_partition(self):
+        """
+        GET /schemas/ids/{id} calls read_sync() before its deferred authz
+        check, and that call suspends. When _schemas has no leader, read_sync()
+        throws after the suspension and the check never runs. The request must
+        produce an error reply rather than aborting the broker.
+
+        The suspension matters: an exception raised before the first co_await
+        unwinds on the caller's stack and is caught, but one raised after a
+        suspension tears the coroutine frame down inside the reactor's
+        noexcept task entry point, where a throw cannot be delivered.
+        """
+        subject = "test-subject-1"
+        schema_id = self._create_schema(subject)
+        self._post_acl(self._create_acl(subject, "SUBJECT", "LITERAL", "READ"))
+
+        # Serve the request from a node that does not lead _schemas. A leader
+        # answers the offset lookup out of its own log without needing a
+        # quorum, so read_sync() would keep succeeding there.
+        admin = Admin(self.redpanda)
+        leader_id = admin.await_stable_leader("_schemas", partition=0, timeout_s=30)
+        target = next(
+            n for n in self.redpanda.nodes if self.redpanda.node_id(n) != leader_id
+        )
+
+        # Warm up the target: its schema registry one_shot init must already
+        # have completed. Otherwise _os() throws from inside wrap::operator(),
+        # where the auth result is a local and safe, and the test would pass
+        # for the wrong reason.
+        result = self.sr_client.get_schemas_ids_id(
+            schema_id, hostname=target.account.hostname, auth=self.user_auth
+        )
+        self.assert_equal(result.status_code, 200)
+
+        # The target must not be able to take over _schemas leadership once
+        # the other brokers stop: a leader answers the offset lookup out of
+        # its own log, so read_sync() on it would keep succeeding. Stopping
+        # the brokers one by one leaves the two remaining ones as a live
+        # quorum long enough to elect the target. Maintenance mode blocks the
+        # node from acquiring any leadership while it keeps serving requests.
+        admin.maintenance_start(target)
+        wait_until(
+            lambda: admin.maintenance_status(target).get("finished", False),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="the target never finished draining its leaderships",
+        )
+
+        # Stop the other two brokers. The target is then left below quorum,
+        # so it cannot reach the old leader, and maintenance mode prevents it
+        # from becoming the leader itself: read_sync() has no leader to query.
+        for node in self.redpanda.nodes:
+            if node != target:
+                self.redpanda.stop_node(node)
+
+        def read_sync_fails():
+            result = self.sr_client.get_schemas_ids_id(
+                schema_id, hostname=target.account.hostname, auth=self.user_auth
+            )
+            return result.status_code >= 500
+
+        wait_until(
+            read_sync_fails,
+            timeout_sec=90,
+            backoff_sec=2,
+            err_msg="read_sync() never failed on the surviving broker",
+        )


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31559

Fixes #31592

- Command: git cherry-pick -x c81e3b5e5f 2c7d8d57b7 fb07594874 f007f87a2d c8d8b3dc66 c267225967
- Commits backported: 6
- Conflicts resolved: 5
- Commits skipped (already on target): 0
- Backport branch: manual-backport-31559-v25.3.x-382

## Conflict details

- 2c7d8d57b7 (schema_registry auth.*, service.cc, handlers.*, authorization.*): v25.3.x predates the context_subject refactor, so the lw_shared_ptr<request_auth_result> plumbing and the enforce_deferred_authz routing were re-anchored onto this branch's handler and wrap shapes (the pre-existing try/catch in wrap::operator() that maps a `_schemas` partition_error to unknown_server_error is kept, with the deferred branch routed through enforce_deferred_authz inside it).
- 2c7d8d57b7 (schema_registry/test/BUILD): the new deferred_auth target additionally depends on `//src/v/pandaproxy:core`. On this branch pandaproxy:core is only an implementation_dep of schema_registry:server, so auth.h's include of pandaproxy/server.h does not propagate to dependents the way it does on dev, where it is a public dep.
- fb07594874 (security/request_auth.*): re-anchored onto this branch's request_auth_result constructor shapes (the copy constructor is defaulted here instead of gaining a _checked member initializer).
- f007f87a2d, c8d8b3dc66 (tests/rptest/tests/schema_registry_test.py): this branch still had the monolithic SchemaRegistryAclAuthzTest, so the coverage commit performs the SchemaRegistryAclAuthzTestBase split itself and re-parents the existing test class. The new SchemaRegistryAclAuthzUnavailableTest drops `extra_rp_conf={"schema_registry_use_rpc": True}`; that property does not exist on v25.3.x. read_sync() on this branch always goes through the internal kafka client, which likewise throws after its suspension point once `_schemas` has no leader, so the covered failure mode is unchanged.
- c267225967 (schema_registry/authorization.cc): re-anchored the new vlogs; kept this branch's `subject` naming in the GET /subjects filter and added only the base/vlog.h include.

## Local verification

- bazel test //src/v/pandaproxy/schema_registry/test:deferred_auth //src/v/security/tests:request_auth_test: both pass
- bazel run //tools:clang_format and //tools:buildifier.check: no diff
