### PR TITLE
Fix unbounded s3_fifo growth

### DIFF
--- a/src/v/lsm/db/BUILD
+++ b/src/v/lsm/db/BUILD
@@ -117,6 +117,7 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         "//src/v/container:chunked_hash_map",
+        "//src/v/container:intrusive",
         "//src/v/lsm/core:exceptions",
         "//src/v/lsm/core/internal:logger",
         "//src/v/lsm/sst:reader",

--- a/src/v/lsm/db/table_cache.cc
+++ b/src/v/lsm/db/table_cache.cc
@@ -11,6 +11,7 @@
 #include "base/vassert.h"
 #include "base/vlog.h"
 #include "container/chunked_hash_map.h"
+#include "container/intrusive_list_helpers.h"
 #include "lsm/core/exceptions.h"
 #include "lsm/core/internal/files.h"
 #include "lsm/core/internal/iterator.h"
@@ -157,22 +158,20 @@ public:
         co_await table->internal_get(key, fn);
         // It's possible (although unlikely), that while `internal_get` was
         // going on the table was evicted from the cache, if that's the case
-        // we need to enqueue the cleanup, as the ghost fifo gc would have not
-        // done it.
+        // we need to enqueue the cleanup, as the evicted-entry gc would have
+        // not done it.
         maybe_enqueue_cleanup(std::move(table));
     }
 
     ss::future<> evict(internal::file_handle h) {
-        gc_ghost_fifo();
+        gc_evicted_entries();
         auto guard = co_await reader_lock_guard::acquire(&_mu_map, h);
         auto it = _map.find(h);
         if (it == _map.end()) {
             co_return;
         }
         _cache.remove(*it->second);
-        if (it->second->ghost_hook.is_linked()) {
-            _ghost_fifo.erase(_ghost_fifo.iterator_to(*it->second));
-        }
+        it->second->fifo_hook.unlink();
         auto reader = std::exchange(it->second->value, {});
         _map.erase(it);
         vassert(
@@ -194,7 +193,7 @@ public:
               reader.use_count());
             co_await reader->close();
         }
-        _ghost_fifo.clear();
+        // _map.clear() destroys the entries, which auto-unlink from the fifos.
         _map.clear();
         ss::promise<void> p;
         _cleanup_queue.submit([&p] {
@@ -227,27 +226,28 @@ public:
     }
 
 private:
-    using ghost_hook_t = boost::intrusive::list_member_hook<
-      boost::intrusive::link_mode<boost::intrusive::safe_link>>;
-
     struct cached_value {
         internal::file_handle handle;
         ss::lw_shared_ptr<sst::reader> value;
         utils::s3_fifo::cache_hook hook;
-        ghost_hook_t ghost_hook;
+        intrusive_list_hook fifo_hook;
     };
 
     using entry_t = std::unique_ptr<cached_value>;
-    using ghost_fifo_t = boost::intrusive::list<
-      cached_value,
-      boost::intrusive::
-        member_hook<cached_value, ghost_hook_t, &cached_value::ghost_hook>>;
+    using fifo_t = intrusive_list<cached_value, &cached_value::fifo_hook>;
 
     struct eviction {
         table_cache::impl* impl;
         bool operator()(
-          cached_value& e, utils::s3_fifo::evict_source) noexcept {
-            impl->_ghost_fifo.push_back(e);
+          cached_value& e, utils::s3_fifo::evict_source source) noexcept {
+            switch (source) {
+            case utils::s3_fifo::evict_source::small_queue:
+                impl->_ghost_fifo.push_back(e);
+                break;
+            case utils::s3_fifo::evict_source::main_queue:
+                impl->_retired_fifo.push_back(e);
+                break;
+            }
             return true;
         }
     };
@@ -275,7 +275,7 @@ private:
 
     ss::future<ss::lw_shared_ptr<sst::reader>>
     find_reader(internal::file_handle handle, uint64_t file_size) {
-        gc_ghost_fifo();
+        gc_evicted_entries();
         auto it = _map.find(handle);
         if (it == _map.end()) {
             // Use fine grained locking to prevent opening unrelated tables from
@@ -300,9 +300,9 @@ private:
         _probe->table_cache_hit += 1;
         auto& entry = *it->second;
         if (entry.hook.evicted()) {
-            // If this was evicted, but on the ghost queue, then we can reinsert
+            // If this was evicted, but not yet reclaimed, then we can reinsert
             // it into the cache and keep the existing entry alive.
-            _ghost_fifo.erase(_ghost_fifo.iterator_to(entry));
+            entry.fifo_hook.unlink();
             _cache.insert(entry);
         }
         entry.hook.touch();
@@ -321,19 +321,33 @@ private:
         co_return ss::make_lw_shared(std::move(reader));
     }
 
-    void gc_ghost_fifo() {
+    // Free the evicted entry's reader and remove it from the index. The index
+    // erase happens before the cleanup submission so that a throwing
+    // submission can't leave a reclaimed entry behind in the index.
+    void reclaim(cached_value& entry) {
+        auto reader = std::exchange(entry.value, {});
+        ++_handles_pending_cleanup;
+        _map.erase(entry.handle);
+        maybe_enqueue_cleanup(std::move(reader));
+    }
+
+    void gc_evicted_entries() {
+        while (!_retired_fifo.empty()) {
+            auto& entry = _retired_fifo.front();
+            _retired_fifo.pop_front();
+            reclaim(entry);
+        }
+
         for (auto it = _ghost_fifo.begin(); it != _ghost_fifo.end();) {
             auto& entry = *it;
             if (_cache.ghost_queue_contains(entry)) {
                 // The ghost queue is in fifo-order so any entry that comes
-                // after an entry that hasn't been evicted will also not be
-                // evicted.
+                // after an entry that hasn't been removed will also be in
+                // the queue still.
                 return;
             }
-            ++_handles_pending_cleanup;
-            maybe_enqueue_cleanup(std::exchange(entry.value, {}));
             it = _ghost_fifo.erase(it);
-            _map.erase(entry.handle);
+            reclaim(entry);
         }
     }
 
@@ -343,9 +357,15 @@ private:
       _mu_map;
     chunked_hash_map<internal::file_handle, entry_t> _map;
     cache_t _cache;
-    // Entries that have been "soft evicted" from the cache. We keep them around
-    // just in case and GC them after some period of time.
-    ghost_fifo_t _ghost_fifo;
+    // Entries that have been "soft evicted" from the cache onto the ghost
+    // queue. We keep them around just in case and GC them after some period of
+    // time.
+    fifo_t _ghost_fifo;
+    // Entries evicted from the main queue. They have left the cache entirely
+    // and could be reclaimed during eviction, but enqueuing the reader cleanup
+    // allocates, which the noexcept evictor must not do, so they are parked
+    // here and reclaimed on the next gc.
+    fifo_t _retired_fifo;
     ss::lw_shared_ptr<sst::block_cache> _block_cache;
     // Once an item is evicted, we need to also check that outstanding iterators
     // are closed. If they are not, then we wait until they are, then we insert

--- a/src/v/lsm/db/table_cache.cc
+++ b/src/v/lsm/db/table_cache.cc
@@ -245,7 +245,8 @@ private:
 
     struct eviction {
         table_cache::impl* impl;
-        bool operator()(cached_value& e) noexcept {
+        bool operator()(
+          cached_value& e, utils::s3_fifo::evict_source) noexcept {
             impl->_ghost_fifo.push_back(e);
             return true;
         }

--- a/src/v/utils/chunked_kv_cache.h
+++ b/src/v/utils/chunked_kv_cache.h
@@ -122,7 +122,7 @@ template<typename Key, typename Value, typename Hash, typename EqualTo>
 struct chunked_kv_cache<Key, Value, Hash, EqualTo>::evict {
     chunked_kv_cache& kv_c;
 
-    bool operator()(cached_value& e) noexcept {
+    bool operator()(cached_value& e, s3_fifo::evict_source) noexcept {
         e.value = nullptr;
         kv_c._ghost_fifo.push_back(e);
         return true;

--- a/src/v/utils/chunked_kv_cache.h
+++ b/src/v/utils/chunked_kv_cache.h
@@ -122,9 +122,18 @@ template<typename Key, typename Value, typename Hash, typename EqualTo>
 struct chunked_kv_cache<Key, Value, Hash, EqualTo>::evict {
     chunked_kv_cache& kv_c;
 
-    bool operator()(cached_value& e, s3_fifo::evict_source) noexcept {
-        e.value = nullptr;
-        kv_c._ghost_fifo.push_back(e);
+    bool operator()(cached_value& e, s3_fifo::evict_source source) noexcept {
+        switch (source) {
+        case s3_fifo::evict_source::small_queue:
+            e.value = nullptr;
+            kv_c._ghost_fifo.push_back(e);
+            break;
+        case s3_fifo::evict_source::main_queue:
+            // The entry has left the cache entirely; erasing it from the index
+            // destroys it, which the cache allows for main-queue evictees.
+            kv_c._map.erase(e.key);
+            break;
+        }
         return true;
     }
 };
@@ -142,12 +151,16 @@ bool chunked_kv_cache<Key, Value, Hash, EqualTo>::try_insert(
             return false;
         }
 
+        // The evictor may erase other keys from _map re-entrantly; iterators
+        // must not be used across this call.
         _cache.insert(*e_it->second);
         return true;
     }
 
     auto& entry = *e_it->second;
     if (entry.hook.evicted()) {
+        // Main-queue evictees are removed from the index at eviction time, so
+        // an evicted entry that is still indexed must be on the ghost fifo.
         entry.value = std::move(val);
         _ghost_fifo.erase(_ghost_fifo.iterator_to(entry));
         _cache.insert(entry);
@@ -184,7 +197,7 @@ void chunked_kv_cache<Key, Value, Hash, EqualTo>::gc_ghost_fifo() {
         auto& entry = *it;
         if (_cache.ghost_queue_contains(entry)) {
             // The ghost queue is in fifo-order so any entry that comes after an
-            // entry that hasn't been evicted will also not be evicted.
+            // entry that hasn't been removed will also be in the queue still.
             return;
         }
 

--- a/src/v/utils/s3_fifo.h
+++ b/src/v/utils/s3_fifo.h
@@ -68,7 +68,7 @@
  * Next we'll define an instance of the cache to hold objects of type entry.
  *
  *     struct evict {
- *         bool operator()(entry& e) noexcept {
+ *         bool operator()(entry& e, evict_source) noexcept {
  *             e.address.clear();
  *             e.description.clear();
  *             free(e.image);
@@ -127,7 +127,11 @@
  *
  * Because the cache may evict random entries, the application should consider
  * periodically removing evicted items from the index. However, it is generally
- * desired to not remove items that remain on the ghost queue. The application
+ * desired to not remove items that remain on the ghost queue. The eviction
+ * function is told which queue an entry is evicted from, and only entries
+ * evicted from the small queue are placed on the ghost queue. An entry evicted
+ * from the main queue has left the cache entirely, so the eviction function
+ * may remove it from the index (destroying it) right away. The application
  * can query ghost queue membership using:
  *
  *     if (entry.hook.evicted()) {
@@ -180,6 +184,10 @@ namespace testing_details {
 class cache_hook_accessor;
 }; // namespace testing_details
 
+/// The queue an entry is being evicted from; see \ref cache_evictor for the
+/// lifetime implications.
+enum class evict_source : uint8_t { small_queue, main_queue };
+
 /**
  * Specifies that a callable type can be used as a cache eviction function.
  *
@@ -189,17 +197,27 @@ class cache_hook_accessor;
  * The function is passed a reference to a cache entry that is a candidate for
  * eviction from the cache. If the candidate entry should be evicted then the
  * function should return true, in which case the entry will be fully removed
- * from the cache. If the function returns false then the entry is not evicted
- * and the cache and entry's cache hook will not be modified.
+ * from the cache. If the function returns false then the entry is not evicted;
+ * a declined main-queue candidate is unlinked for the duration of the call and
+ * restored to its position afterwards, otherwise the cache and the entry's
+ * cache hook are not modified.
+ *
+ * The function is also passed the queue the entry is being evicted from. An
+ * entry evicted from the small queue is placed on the ghost queue after the
+ * function returns, so the function must leave the entry valid and should
+ * retain its index bookkeeping for rehydration. An entry evicted from the
+ * main queue leaves the cache entirely and is already unlinked when the
+ * function is invoked, so on approval the function may destroy the entry,
+ * e.g. by erasing it from the application's index.
  *
  * When an entry is selected for eviction the function may perform additional
  * operations specific to the application. For example, the function may release
  * memory or other resources associated with the entry.
  */
 template<typename F, typename E>
-concept cache_evictor = requires(F func, E& entry) {
-    requires noexcept(func(entry));
-    { func(entry) } -> std::same_as<bool>;
+concept cache_evictor = requires(F func, E& entry, evict_source source) {
+    requires noexcept(func(entry, source));
+    { func(entry, source) } -> std::same_as<bool>;
 };
 
 /**
@@ -283,7 +301,7 @@ public:
      *     struct entry { std::unique_ptr<int> ptr; }
      *
      *     struct evict {
-     *         bool operator()(entry& e) {
+     *         bool operator()(entry& e, evict_source) noexcept {
      *             e.ptr = nullptr;
      *             return true;
      *         }
@@ -330,7 +348,9 @@ private:
  */
 struct default_cache_evictor {
     /// Returns true.
-    bool operator()(auto&& /*entry*/) noexcept { return true; }
+    bool operator()(auto&& /*entry*/, evict_source /*source*/) noexcept {
+        return true;
+    }
 };
 
 /**
@@ -623,7 +643,7 @@ bool cache<T, Hook, Evictor, Cost>::evict_small() noexcept {
                 }
             }
 
-        } else if (evict_(entry)) {
+        } else if (evict_(entry, evict_source::small_queue)) {
             // evict from small queue
             it = small_fifo_.erase(it);
             const auto cost = cost_(entry);
@@ -659,14 +679,19 @@ bool cache<T, Hook, Evictor, Cost>::evict_main() noexcept {
             it = main_fifo_.erase(it);
             main_fifo_.push_back(entry);
 
-        } else if (evict_(entry)) {
-            // evict from main queue
-            it = main_fifo_.erase(it);
-            main_queue_size_ -= cost_(entry);
-            return true;
-
         } else {
-            ++it;
+            // The evictor may destroy the entry on approval, so read the
+            // cost and unlink before invoking it.
+            const auto cost = cost_(entry);
+            auto next = main_fifo_.erase(it);
+            if (evict_(entry, evict_source::main_queue)) {
+                // evict from main queue
+                main_queue_size_ -= cost;
+                return true;
+            }
+            // the entry declined eviction; restore its position
+            main_fifo_.insert(next, entry);
+            it = next;
         }
     }
     return false;

--- a/src/v/utils/tests/chunked_kv_cache_test.cc
+++ b/src/v/utils/tests/chunked_kv_cache_test.cc
@@ -103,6 +103,39 @@ TEST(ChunkedKVTest, EvictionTest) {
     }
 }
 
+TEST(ChunkedKVTest, IndexBoundedUnderChurnTest) {
+    using cache_type = utils::chunked_kv_cache<int, std::string>;
+
+    constexpr size_t cache_size = 8;
+    constexpr size_t small_size = 2;
+    cache_type cache(
+      cache_type::config{.cache_size = cache_size, .small_size = small_size});
+    auto str = "avaluestr";
+
+    // An untouched key that gets evicted from the small queue onto the ghost
+    // queue.
+    EXPECT_TRUE(cache.try_insert(0, ss::make_shared<std::string>(str)));
+
+    // Churn distinct keys that are always touched, so they are promoted to the
+    // main queue and evicted from there, never entering the ghost queue.
+    constexpr int churn = 100 * cache_size;
+    for (int i = 1; i <= churn; i++) {
+        EXPECT_TRUE(cache.try_insert(i, ss::make_shared<std::string>(str)));
+        // Touch twice so small-queue eviction promotes instead of ghosting.
+        EXPECT_TRUE(cache.get_value(i));
+        EXPECT_TRUE(cache.get_value(i));
+    }
+
+    auto stat = cache.stat();
+    // The queue accounting stays bounded regardless of the index size.
+    EXPECT_LE(stat.small_queue_size + stat.main_queue_size, cache_size + 1);
+    // At most the resident entries (capacity may be exceeded by one) plus a
+    // main queue's worth of ghost entries.
+    constexpr size_t max_index_size = (cache_size + 1)
+                                      + (cache_size - small_size);
+    EXPECT_LE(stat.index_size, max_index_size);
+}
+
 TEST(ChunkedKVTest, GhostToMainTest) {
     using cache_type = utils::chunked_kv_cache<int, std::string>;
 

--- a/src/v/utils/tests/s3_fifo_test.cc
+++ b/src/v/utils/tests/s3_fifo_test.cc
@@ -43,12 +43,15 @@ public:
         utils::s3_fifo::cache_hook hook;
         bool may_evict{true};
         bool evicted{false};
+        std::optional<utils::s3_fifo::evict_source> evicted_from{};
     };
 
     struct evict {
-        bool operator()(entry& e) noexcept {
+        bool
+        operator()(entry& e, utils::s3_fifo::evict_source source) noexcept {
             if (e.may_evict) {
                 e.evicted = true;
+                e.evicted_from = source;
                 return true;
             }
             return false;
@@ -245,6 +248,7 @@ TEST_F(CacheTest, EvictMain) {
     // e0 is first evicted
     cache->evict();
     EXPECT_TRUE(e0.evicted);
+    EXPECT_EQ(e0.evicted_from, utils::s3_fifo::evict_source::main_queue);
     EXPECT_FALSE(e1.evicted);
     EXPECT_EQ(cache->stat().main_queue_size, 1);
     EXPECT_EQ(cache->stat().small_queue_size, 0);
@@ -397,6 +401,7 @@ TEST_F(CacheTest, EvictSmall) {
     // e0 is first evicted
     cache->evict();
     EXPECT_TRUE(e0.evicted);
+    EXPECT_EQ(e0.evicted_from, utils::s3_fifo::evict_source::small_queue);
     EXPECT_TRUE(cache->ghost_queue_contains(e0));
     EXPECT_FALSE(e1.evicted);
     EXPECT_FALSE(e2.evicted);


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
`chunked_kv_cache` reclaims index entries by walking a fifo of evicted entries, stopping at the first one still on the ghost queue. Main-queue evictees never enter the ghost queue but shared that fifo, so one live ghost entry blocks reclamation of everything behind it and the index grows without bound under key churn. In production the fetch read coalescer's 1024-entry cache reached ~27M entries (~6.7 GB) on one shard and crashed the broker.

The s3_fifo cache now passes the eviction source to the evictor and unlinks main-queue evictees before invoking it, so `chunked_kv_cache` can erase them from the index immediately, leaving the fifo with only ghost-queue entries in expiry order. `table_cache` had a copy of the same bug and is fixed the same way, with reclamation deferred to a retired fifo because its cleanup can't run in the noexcept evictor.

  A new unit test reproduces the leak and asserts the index stays bounded.
  
Fixes CORE-17066
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes
### Bug Fixes
* Fixes potential unbounded growth of various s3_fifo users under specific workloads.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
