### PR TITLE
docs: treat user-facing doc strings as documentation

### DIFF
--- a/.claude/skills/doc-strings/SKILL.md
+++ b/.claude/skills/doc-strings/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: doc-strings
+description: Writing standards for user-facing doc strings in this repo — config property descriptions in src/v/config/, sm::description(...) metric help, and rpk cobra Short/Long/flag usage strings in src/go/rpk/pkg/cli/. Apply when adding or editing any of those strings, or reviewing a diff that touches them. These strings are published documentation, generated verbatim onto docs.redpanda.com.
+user-invocable: true
+---
+
+# Doc strings
+
+Config property descriptions, metric help text, and rpk help strings in this
+repo are not code comments. Doc generators publish them verbatim: property
+descriptions become the property reference pages and the docs-site hover
+tooltips, `sm::description` strings become the Prometheus `# HELP` text and
+the metrics reference, and rpk `Short`/`Long`/flag usage strings become the
+rpk command reference and `--help` output. Write them as documentation for
+an operator, not as notes for a maintainer.
+
+The authoritative standard is `resources/writing-style/embedded-reference-strings.md`
+in redpanda-data/docs-team-standards (private; fetch it, never vendor a copy —
+it carries the per-surface contracts and the full quality bar). The rules
+below are the local summary.
+
+## What this skill looks for
+
+- Every new user-facing property, metric, command, or flag carries a
+  description. An empty or missing string ships an empty docs page.
+- The description is a complete thought that states the effect and when an
+  operator would change the setting — never a restatement of the name
+  ("Cluster identifier." for `cluster_id` documents nothing).
+- Defaults, units, and valid ranges are stated in prose. Spell out units.
+- A changed default or unit updates the description string in the same diff,
+  or the published docs state the old behavior the moment this merges.
+- No internal jargon in user-facing text: users set `null`, not `nullopt`;
+  expand or avoid NTP, shard, seastar, stm.
+
+## Per-surface rules
+
+| Surface | Rules |
+|---|---|
+| Properties (`src/v/config/`) | Verbatim AsciiDoc: keep backticks balanced; no raw `\|` or `{attr}`. Sentence case, terminal period. The 4th ctor arg's `.example` field is where example values go. |
+| Metrics (`sm::description`) | Zero escaping downstream — no `\|` or `{attr}` at all. Capitalized, NO terminal period. Never echo the metric name. |
+| rpk (`src/go/rpk/pkg/cli/`) | The docs formatter rewrites these: `Short` = one line, capitalized, no period; flag usage = capitalized, no period, never an echo of the flag name; in `Long`, an ALLCAPS line becomes a section heading, so never use ALLCAPS for emphasis. Tie CLI defaults to their server property ("-1 defaults to the cluster's `default_topic_partitions`"). |
+
+## Tools
+
+When the redpanda-doc-tools-assistant MCP server is available, use
+`lint_doc_strings` (deterministic rule check over a repo or diff) and
+`preview_doc_string` (renders one declaration exactly as it will ship,
+including whether a docs-side override currently masks it). Without MCP:
+`npx doc-tools lint-strings --repo . --diff origin/dev`.
+
+## Check published content
+
+Changing a default, unit, or behavior, removing or renaming a surface, or
+adding a new one can make published docs wrong or leave a gap. Search
+docs.redpanda.com for the surface name before finalizing the change (the
+public docs MCP at https://docs.redpanda.com/mcp exposes search and Q&A
+tools; plain web search works too). If a published page states the old
+behavior, say so in the PR description and update the doc string in the
+same diff; the PR review automation routes high-impact cases to the docs
+team's Jira intake (comments on the existing DOC ticket or files one).
+
+## What NOT to flag
+
+- Subjective wording or polish on a string that already states effect,
+  default, and units. Never bikeshed phrasing.
+- Internal comments, log messages, or test strings — this skill covers only
+  strings the doc generators consume.
+- Style of the surrounding C++/Go code (other reviews own that).
+
+## Severity (for reviews)
+
+- **high**: changed default/unit/behavior with the string left stating the
+  old one (published docs become wrong on merge).
+- **medium** (default): new user-facing surface with an empty, missing, or
+  name-echo description.
+- **low**: present and accurate but incomplete (no default, no units).
+
+Zero findings on a diff that adds user-facing surfaces is a claim: state
+which surfaces you checked.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,6 +25,17 @@ If this PR is a backport, link to the original with `Backport of PR`, e.g.
 - [ ] v26.1.x
 - [ ] v25.3.x
 
+## UX Changes
+
+<!--
+REQUIRED if this PR adds or changes anything a user sees, types, or configures:
+config properties, rpk commands/flags, metrics, defaults, API endpoints,
+error messages. Describe the change in plain language (see CONTRIBUTING.md,
+"UX Changes"), and make sure the user-facing doc strings in the source are
+written as documentation: docs.redpanda.com generates the property, metrics,
+and rpk references verbatim from the strings in this diff. Otherwise, `none`.
+-->
+
 ## Release Notes
 
 <!--

--- a/.github/workflows/doc-strings-review.yml
+++ b/.github/workflows/doc-strings-review.yml
@@ -1,0 +1,34 @@
+---
+# Suggest-only review of user-facing doc strings (config property
+# descriptions, sm::description metric help, rpk cobra help strings) —
+# these are published verbatim to docs.redpanda.com by the doc generators.
+#
+# All review logic lives in the shared reusable workflow in
+# redpanda-data/docs-extensions-and-macros so it cannot drift between
+# repos; this shim owns only the trigger paths and the secrets. Pin the
+# ref to a release tag once one exists.
+name: doc-strings-review
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    paths:
+      - "src/v/config/**"
+      - "src/go/rpk/pkg/cli/**"
+      - "src/v/**/*probe.cc"
+      - "src/v/metrics/**"
+concurrency:
+  group: doc-strings-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+jobs:
+  review:
+    if: "!github.event.pull_request.draft"
+    uses: redpanda-data/docs-extensions-and-macros/.github/workflows/doc-strings-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    with:
+      surfaces: properties,rpk,metrics
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+      actions_bot_token: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,11 @@ for memory safety in coroutines, not self-reference.
   - Links to external resources (specs, docs, issues)
   - Mapping internal types/concepts to external formats (e.g., wire protocols, APIs)
   - ASCII diagrams for complex state machines or data flows
+- **User-facing doc strings are not comments** - config property descriptions
+  (`configuration.cc`/`node_config.cc`), `sm::description(...)` metric help, and
+  rpk cobra `Short`/`Long`/flag usage strings are published documentation
+  (docs.redpanda.com and `--help` output are generated from them verbatim).
+  The no-comments default does not apply; the `doc-strings` skill governs them.
 - **Avoid obvious branching comments** - `if (x)` rarely needs `// when x is true`
 
 ### Benchmarking


### PR DESCRIPTION
Property descriptions in `configuration.cc`, `sm::description` metric help, and rpk cobra help strings ship **verbatim** to docs.redpanda.com — the docs team currently hand-patches ~445 property descriptions downstream because nothing here treats those strings as documentation (2 properties ship empty descriptions today; `node_config.cc` ships a typo'd "recomended").

Suggest-only, zero new required checks:

- **CLAUDE.md**: one bullet carving user-facing doc strings out of the no-comments default
- **PR template**: adds the `UX Changes` section CONTRIBUTING.md already documents
- **`.claude/skills/doc-strings`**: writing standards for the three surfaces (per-surface rules, published-content check via the public docs MCP)
- **`doc-strings-review.yml`**: a 33-line shim calling the shared reusable workflow in docs-extensions-and-macros — deterministic lint on the diff, then (only when it finds something) one Claude review with suggestion blocks engineers can one-click apply, citing the docs-team standard; high-impact changes (published page contradicted) are routed to the docs team's Jira intake automatically. Hardened against config tampering; every step fails open; the job always succeeds.

**Draft until**: docs-extensions-and-macros#264 merges and releases (provides `doc-tools lint-strings` and the reusable workflow), and this repo has `ACTIONS_BOT_TOKEN` available to the workflow (fails open to lint-only without it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)